### PR TITLE
feat: add escapeHtmlTags function to handle HTML-like content in call…

### DIFF
--- a/src/obsidian/formatter.ts
+++ b/src/obsidian/formatter.ts
@@ -18,8 +18,17 @@ export function observationCalloutType(observationType: string): string {
   return CALLOUT_MAP[observationType] ?? 'note';
 }
 
+/**
+ * Escape angle brackets that Obsidian would interpret as HTML tags.
+ * Matches `<` followed by a letter, `/`, or `!` (opening/closing tags, comments).
+ */
+export function escapeHtmlTags(text: string): string {
+  return text.replace(/<(?=[a-zA-Z/!])/g, '\\<');
+}
+
 export function callout(type: string, title: string, content: string): string {
-  const indented = content.split('\n').map((line) => `> ${line}`).join('\n');
+  const safe = escapeHtmlTags(content);
+  const indented = safe.split('\n').map((line) => `> ${line}`).join('\n');
   return `> [!${type}] ${title}\n${indented}`;
 }
 

--- a/tests/obsidian/formatter.test.ts
+++ b/tests/obsidian/formatter.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   callout,
+  escapeHtmlTags,
   inlineField,
   wikilink,
   observationCalloutType,
@@ -13,6 +14,31 @@ import {
   formatArtifactBody,
 } from '../../src/obsidian/formatter.js';
 
+describe('escapeHtmlTags', () => {
+  it('escapes opening HTML tags', () => {
+    expect(escapeHtmlTags('in <module>')).toBe('in \\<module>');
+  });
+
+  it('escapes closing HTML tags', () => {
+    expect(escapeHtmlTags('</div>')).toBe('\\</div>');
+  });
+
+  it('escapes HTML comments', () => {
+    expect(escapeHtmlTags('<!-- comment -->')).toBe('\\<!-- comment -->');
+  });
+
+  it('leaves comparison operators alone', () => {
+    expect(escapeHtmlTags('x < 5 and x <= 10')).toBe('x < 5 and x <= 10');
+  });
+
+  it('handles Python tracebacks', () => {
+    const traceback = 'File "dev_console.py", line 387, in <module>\n    main()';
+    expect(escapeHtmlTags(traceback)).toBe(
+      'File "dev_console.py", line 387, in \\<module>\n    main()',
+    );
+  });
+});
+
 describe('callout', () => {
   it('wraps content in Obsidian callout syntax', () => {
     const result = callout('warning', 'Watch Out', 'This is tricky.');
@@ -22,6 +48,11 @@ describe('callout', () => {
   it('handles multiline content', () => {
     const result = callout('info', 'Note', 'Line 1\nLine 2');
     expect(result).toBe('> [!info] Note\n> Line 1\n> Line 2');
+  });
+
+  it('escapes HTML-like tags in content', () => {
+    const result = callout('user', 'Prompt', 'in <module>\n    main()');
+    expect(result).toBe('> [!user] Prompt\n> in \\<module>\n>     main()');
   });
 });
 


### PR DESCRIPTION
…outs

Introduced a new function, escapeHtmlTags, to escape angle brackets in text that could be interpreted as HTML tags. Updated the callout function to utilize this new feature, ensuring that content is safely formatted. Added comprehensive tests for escapeHtmlTags to verify its functionality across various scenarios.

## Summary

This pull request adds improved handling for HTML-like tags in Obsidian callout content to prevent unintended interpretation as HTML. It introduces a new escaping function and updates both the implementation and tests to ensure correctness.

Enhancements to HTML tag handling in Obsidian formatting:

* Added `escapeHtmlTags` function in `formatter.ts` to escape angle brackets that Obsidian would interpret as HTML tags, preventing accidental rendering of HTML in callout content.
* Updated the `callout` function in `formatter.ts` to use `escapeHtmlTags` for its content, ensuring all callout bodies are safely escaped before formatting.

Testing improvements:

* Added comprehensive tests for `escapeHtmlTags` in `formatter.test.ts`, covering opening/closing tags, HTML comments, Python tracebacks, and ensuring comparison operators are not affected.
* Added a test for `callout` to verify that HTML-like tags in content are correctly escaped in the output.
* Imported `escapeHtmlTags` in `formatter.test.ts` to enable testing of the new function.

## Related Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [ ] Enhancement / new feature
- [x] Refactor / code quality
- [ ] Documentation
- [ ] CI / workflow

## Validation

```bash
make check    # lint + 266 tests
```

## Checklist

- [x] `make check` passes locally
- [ ] Tests added or updated where behavior changed
- [ ] Docs updated for user-visible changes
- [ ] No magic literals introduced (named constants in `src/constants.ts`)
