### PR TITLE
feat: implement session resolution from buffer files

### DIFF
--- a/src/capture/buffer.ts
+++ b/src/capture/buffer.ts
@@ -66,3 +66,26 @@ export class EventBuffer {
     return this.filePath;
   }
 }
+
+/**
+ * Find the most recently active session by buffer file mtime.
+ * The UserPromptSubmit hook appends to the session's buffer on every prompt,
+ * so the most recently modified buffer is the calling session.
+ */
+export function resolveSessionFromBuffer(bufferDir: string): string | undefined {
+  try {
+    let bestSession: string | undefined;
+    let bestMtime = 0;
+    for (const file of fs.readdirSync(bufferDir)) {
+      if (!file.endsWith('.jsonl')) continue;
+      const mtime = fs.statSync(path.join(bufferDir, file)).mtimeMs;
+      if (mtime > bestMtime) {
+        bestMtime = mtime;
+        bestSession = file.replace('.jsonl', '');
+      }
+    }
+    return bestSession;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/hooks/client.ts
+++ b/src/hooks/client.ts
@@ -143,17 +143,41 @@ export class DaemonClient {
   }
 
   spawnDaemon(): void {
-    const pluginRoot = new AgentRegistry().resolvePluginRoot();
-    const daemonScript = pluginRoot
-      ? path.join(pluginRoot, 'dist', 'src', 'daemon', 'main.js')
-      : path.resolve(import.meta.dirname, '..', 'daemon', 'main.js');
-    if (!fs.existsSync(daemonScript)) return;
+    const daemonScript = this.resolveDaemonScript();
+    if (!daemonScript || !fs.existsSync(daemonScript)) return;
 
     const child = spawn('node', [daemonScript, '--vault', this.vaultDir], {
       detached: true,
       stdio: 'ignore',
     });
     child.unref();
+  }
+
+  /**
+   * Resolve the daemon entry script path.
+   * Priority:
+   * 1. Plugin root env var (set by the agent host) → dist/src/daemon/main.js
+   * 2. Walk up from the current file to find the dist/ directory containing
+   *    the daemon entry. This handles both chunk files (dist/chunk-*.js) and
+   *    thin entry points (dist/src/hooks/*.js) after bundling.
+   */
+  private resolveDaemonScript(): string | undefined {
+    const pluginRoot = new AgentRegistry().resolvePluginRoot();
+    if (pluginRoot) {
+      return path.join(pluginRoot, 'dist', 'src', 'daemon', 'main.js');
+    }
+
+    // Walk up from import.meta.dirname looking for the daemon entry
+    let dir = import.meta.dirname;
+    for (let i = 0; i < 5; i++) {
+      const candidate = path.join(dir, 'dist', 'src', 'daemon', 'main.js');
+      if (fs.existsSync(candidate)) return candidate;
+      // Also check if we're already inside dist/
+      const inDist = path.join(dir, 'src', 'daemon', 'main.js');
+      if (fs.existsSync(inDist)) return inDist;
+      dir = path.dirname(dir);
+    }
+    return undefined;
   }
 
   private readDaemonJson(): DaemonInfo | null {

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -55,14 +55,14 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: TOOL_REMEMBER,
-    description: 'Save a decision, gotcha, bug fix, discovery, or trade-off as a permanent memory. Use after making a key decision, fixing a tricky bug, discovering something non-obvious, or encountering a gotcha. Always include the session ID from your context.',
+    description: 'Save a decision, gotcha, bug fix, discovery, or trade-off as a permanent memory. Use after making a key decision, fixing a tricky bug, discovering something non-obvious, or encountering a gotcha.',
     inputSchema: {
       type: 'object' as const,
       properties: {
         content: { type: 'string', description: 'The observation — include context, reasoning, and what someone encountering this in the future needs to know' },
         type: { type: 'string', enum: OBSERVATION_TYPES, description: `Observation type: ${OBSERVATION_TYPES.join(', ')}` },
         tags: { type: 'array', items: { type: 'string' }, description: PROP_TAGS },
-        session: { type: 'string', description: 'Your session ID (from "Session::" in your context) — links this memory to the current session' },
+        session: { type: 'string', description: 'Your current session ID — auto-detected if omitted' },
         related_plan: { type: 'string', description: 'Plan ID if this observation relates to an active plan' },
       },
       required: ['content', 'type'],

--- a/src/mcp/tools/remember.ts
+++ b/src/mcp/tools/remember.ts
@@ -2,7 +2,9 @@ import { VaultWriter } from '../../vault/writer.js';
 import { indexNote } from '../../index/rebuild.js';
 import type { MycoIndex } from '../../index/sqlite.js';
 import type { ObservationType } from '../../vault/types.js';
+import { resolveSessionFromBuffer } from '../../capture/buffer.js';
 import { randomBytes } from 'node:crypto';
+import path from 'node:path';
 
 interface RememberInput {
   content: string;
@@ -15,6 +17,7 @@ interface RememberInput {
 interface RememberResult {
   note_path: string;
   id: string;
+  session?: string;
 }
 
 export async function handleMycoRemember(
@@ -24,11 +27,12 @@ export async function handleMycoRemember(
 ): Promise<RememberResult> {
   const writer = new VaultWriter(vaultDir);
   const id = `${input.type}-${randomBytes(4).toString('hex')}`;
+  const session = input.session ?? resolveSessionFromBuffer(path.join(vaultDir, 'buffer'));
 
   const notePath = writer.writeMemory({
     id,
     observation_type: input.type,
-    session: input.session,
+    session,
     plan: input.related_plan ?? undefined,
     tags: input.tags,
     content: input.content,
@@ -37,5 +41,5 @@ export async function handleMycoRemember(
   // Update index so the new memory is immediately searchable
   indexNote(index, vaultDir, notePath);
 
-  return { note_path: notePath, id };
+  return { note_path: notePath, id, session };
 }

--- a/tests/capture/buffer.test.ts
+++ b/tests/capture/buffer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { EventBuffer } from '@myco/capture/buffer';
+import { EventBuffer, resolveSessionFromBuffer } from '@myco/capture/buffer';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -62,5 +62,43 @@ describe('EventBuffer', () => {
       buffer.append({ type: 'tool_use', tool: `tool-${i}` });
     }
     expect(buffer.isOverflow()).toBe(true);
+  });
+});
+
+describe('resolveSessionFromBuffer', () => {
+  let tmpDir: string;
+  let bufferDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-resolve-'));
+    bufferDir = path.join(tmpDir, 'buffer');
+    fs.mkdirSync(bufferDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns most recently modified buffer session', () => {
+    fs.writeFileSync(path.join(bufferDir, 'older.jsonl'), '{}');
+    const past = new Date(Date.now() - 60000);
+    fs.utimesSync(path.join(bufferDir, 'older.jsonl'), past, past);
+
+    fs.writeFileSync(path.join(bufferDir, 'newer.jsonl'), '{}');
+
+    expect(resolveSessionFromBuffer(bufferDir)).toBe('newer');
+  });
+
+  it('returns undefined for empty buffer directory', () => {
+    expect(resolveSessionFromBuffer(bufferDir)).toBeUndefined();
+  });
+
+  it('returns undefined for missing buffer directory', () => {
+    expect(resolveSessionFromBuffer('/nonexistent/path')).toBeUndefined();
+  });
+
+  it('ignores non-jsonl files', () => {
+    fs.writeFileSync(path.join(bufferDir, 'notes.txt'), 'not a buffer');
+    expect(resolveSessionFromBuffer(bufferDir)).toBeUndefined();
   });
 });

--- a/tests/mcp/tools/remember.test.ts
+++ b/tests/mcp/tools/remember.test.ts
@@ -47,4 +47,62 @@ describe('myco_remember', () => {
     const note = index.getNoteByPath(result.note_path);
     expect((note!.frontmatter as any).plan).toBe('auth-redesign');
   });
+
+  it('uses explicit session when provided', async () => {
+    const result = await handleMycoRemember(tmpDir, index, {
+      content: 'Explicit session test',
+      type: 'discovery',
+      session: 'sess-explicit',
+    });
+
+    expect(result.session).toBe('sess-explicit');
+    const note = index.getNoteByPath(result.note_path);
+    expect((note!.frontmatter as any).session).toContain('sess-explicit');
+  });
+
+  it('auto-resolves session from most recent buffer file', async () => {
+    const bufferDir = path.join(tmpDir, 'buffer');
+    fs.mkdirSync(bufferDir);
+
+    // Older buffer
+    fs.writeFileSync(path.join(bufferDir, 'old-session.jsonl'), '{}');
+    const past = new Date(Date.now() - 60000);
+    fs.utimesSync(path.join(bufferDir, 'old-session.jsonl'), past, past);
+
+    // Most recent buffer — the calling session
+    fs.writeFileSync(path.join(bufferDir, 'active-session.jsonl'), '{}');
+
+    const result = await handleMycoRemember(tmpDir, index, {
+      content: 'Auto-resolved session',
+      type: 'gotcha',
+    });
+
+    expect(result.session).toBe('active-session');
+    const note = index.getNoteByPath(result.note_path);
+    expect((note!.frontmatter as any).session).toContain('active-session');
+  });
+
+  it('prefers explicit session over buffer heuristic', async () => {
+    const bufferDir = path.join(tmpDir, 'buffer');
+    fs.mkdirSync(bufferDir);
+    fs.writeFileSync(path.join(bufferDir, 'buffer-session.jsonl'), '{}');
+
+    const result = await handleMycoRemember(tmpDir, index, {
+      content: 'Explicit wins',
+      type: 'decision',
+      session: 'explicit-session',
+    });
+
+    expect(result.session).toBe('explicit-session');
+  });
+
+  it('handles missing buffer directory gracefully', async () => {
+    const result = await handleMycoRemember(tmpDir, index, {
+      content: 'No buffer dir',
+      type: 'gotcha',
+    });
+
+    expect(result.session).toBeUndefined();
+    expect(result.note_path).toContain('memories/');
+  });
 });


### PR DESCRIPTION
Added a new function, resolveSessionFromBuffer, to determine the most recently active session based on buffer file modification times. This function is integrated into the handleMycoRemember process, allowing for automatic session resolution when a session ID is not explicitly provided. Updated tests to cover various scenarios for session resolution, including handling of non-existent directories and preference for explicit session IDs. This enhancement improves session management and user experience.

## Summary

This pull request introduces improvements to session handling for the "remember" tool, enabling automatic session detection and more robust behavior when explicit session information is missing. The main changes include a new heuristic for resolving the current session from buffer files, updates to the tool's schema and implementation to support auto-detection, and comprehensive tests to verify the new functionality.

Session resolution improvements:

* Added a new `resolveSessionFromBuffer` function in `src/capture/buffer.ts` to determine the most recently active session by inspecting buffer file modification times.
* Updated the "remember" tool's schema in `src/mcp/tool-definitions.ts` so that the session ID is auto-detected if omitted, clarifying the description for the `session` input parameter.
* Modified `handleMycoRemember` in `src/mcp/tools/remember.ts` to use the new session resolution heuristic when an explicit session is not provided, and to return the resolved session in the result. [[1]](diffhunk://#diff-48e15303ca174695f8f406a35f0210d269c1c90473c0b67add3b4e181f16c320R5-R7) [[2]](diffhunk://#diff-48e15303ca174695f8f406a35f0210d269c1c90473c0b67add3b4e181f16c320R20) [[3]](diffhunk://#diff-48e15303ca174695f8f406a35f0210d269c1c90473c0b67add3b4e181f16c320R30-R35) [[4]](diffhunk://#diff-48e15303ca174695f8f406a35f0210d269c1c90473c0b67add3b4e181f16c320L40-R44)

Testing enhancements:

* Added unit tests for `resolveSessionFromBuffer` in `tests/capture/buffer.test.ts`, covering scenarios such as empty directories, missing directories, file types, and mtime ordering. [[1]](diffhunk://#diff-51d4fdb5e2230f99dd265bd300f77add435d90f9801381e3c400ccd6e6c40df1L2-R2) [[2]](diffhunk://#diff-51d4fdb5e2230f99dd265bd300f77add435d90f9801381e3c400ccd6e6c40df1R67-R104)
* Expanded tests for the "remember" tool in `tests/mcp/tools/remember.test.ts` to verify explicit session handling, auto-resolution from buffer files, preference for explicit session, and graceful handling of missing buffer directories.

Daemon script resolution refactor:

* Refactored `DaemonClient` in `src/hooks/client.ts` to encapsulate daemon entry script resolution logic in a new private method, improving robustness and maintainability. [[1]](diffhunk://#diff-8c32f86c76cc96f6741482bc7abdd807449f8f58ac52ebc872166dcb82bbe80fL146-R147) [[2]](diffhunk://#diff-8c32f86c76cc96f6741482bc7abdd807449f8f58ac52ebc872166dcb82bbe80fR156-R182)

## Related Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [x] Enhancement / new feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] CI / workflow

## Validation

```bash
make check    # lint + 266 tests
```

## Checklist

- [x] `make check` passes locally
- [x] Tests added or updated where behavior changed
- [ ] Docs updated for user-visible changes
- [ ] No magic literals introduced (named constants in `src/constants.ts`)
