### PR TITLE
fix: write vault path to settings.user.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,2 @@
 {
-  "env": {
-    "MYCO_VAULT_DIR": "~/.myco/vaults/myco"
-  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ dist/
 .myco/logs/
 .myco/.obsidian/
 
+# User-local settings (vault paths contain home directory)
+.claude/settings.user.json
+
 # Dev tooling
 .worktrees/
 

--- a/commands/status.md
+++ b/commands/status.md
@@ -11,7 +11,7 @@ Check and report the health of the Myco vault and daemon. Use the CLI (`node dis
 
 Find the vault directory:
 - Check `MYCO_VAULT_DIR` in the environment
-- Check `.claude/settings.json` under the `env` key for `MYCO_VAULT_DIR`
+- Check `.claude/settings.user.json` (or `.claude/settings.json`) under the `env` key for `MYCO_VAULT_DIR`
 - Fall back to `~/.myco/vaults/<project-name>/`
 
 If no vault is found, report: "No Myco vault configured. Run `/myco-init` to set up."

--- a/src/agents/claude-code.ts
+++ b/src/agents/claude-code.ts
@@ -29,7 +29,9 @@ export const claudeCodeAdapter: AgentAdapter = {
     const settingsDir = path.join(projectRoot, '.claude');
     if (!fs.existsSync(settingsDir)) return false;
 
-    const settingsPath = path.join(settingsDir, 'settings.json');
+    // Write to settings.user.json (gitignored) — vault paths contain the
+    // user's home directory and should not be committed to the repository.
+    const settingsPath = path.join(settingsDir, 'settings.user.json');
     let settings: Record<string, unknown> = {};
     if (fs.existsSync(settingsPath)) {
       try { settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')); } catch { /* fresh */ }

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -79,7 +79,7 @@ logs/
 `;
 
 /** Collapse an absolute home-dir path to its `~/` form for portable config storage. */
-function collapseHomePath(absPath: string): string {
+export function collapseHomePath(absPath: string): string {
   const home = os.homedir();
   if (absPath.startsWith(home + path.sep) || absPath === home) {
     return '~' + absPath.slice(home.length);

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import os from 'node:os';
 import { AgentRegistry } from '../agents/registry.js';
 import { OllamaBackend } from '../intelligence/ollama.js';
 import { LmStudioBackend } from '../intelligence/lm-studio.js';
@@ -77,25 +78,36 @@ logs/
 .obsidian/
 `;
 
+/** Collapse an absolute home-dir path to its `~/` form for portable config storage. */
+function collapseHomePath(absPath: string): string {
+  const home = os.homedir();
+  if (absPath.startsWith(home + path.sep) || absPath === home) {
+    return '~' + absPath.slice(home.length);
+  }
+  return absPath;
+}
+
 /** Set MYCO_VAULT_DIR in the active agent's config, falling back to all known agents. */
 export function configureVaultEnv(projectRoot: string, vaultDir: string): void {
   const registry = new AgentRegistry();
   const active = registry.detectActiveAgent();
+  // Store the portable ~/... form so config files don't leak the username
+  const portableDir = collapseHomePath(vaultDir);
 
   if (active) {
-    if (active.configureVaultEnv(projectRoot, vaultDir)) {
+    if (active.configureVaultEnv(projectRoot, portableDir)) {
       console.log(`Set MYCO_VAULT_DIR for ${active.displayName}`);
     }
   } else {
     // No active agent detected — try all adapters
     for (const name of registry.adapterNames) {
       const adapter = registry.getAdapter(name);
-      if (adapter?.configureVaultEnv(projectRoot, vaultDir)) {
+      if (adapter?.configureVaultEnv(projectRoot, portableDir)) {
         console.log(`Set MYCO_VAULT_DIR for ${adapter.displayName}`);
       }
     }
   }
 
   console.log(`\nFor other agents, add to your shell profile:`);
-  console.log(`  export MYCO_VAULT_DIR="${vaultDir}"\n`);
+  console.log(`  export MYCO_VAULT_DIR="${portableDir}"\n`);
 }

--- a/tests/cli/shared.test.ts
+++ b/tests/cli/shared.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import { collapseHomePath } from '@myco/cli/shared';
+
+describe('collapseHomePath', () => {
+  const home = os.homedir();
+
+  it('collapses absolute home path to ~/', () => {
+    expect(collapseHomePath(path.join(home, '.myco', 'vaults', 'myco')))
+      .toBe('~/.myco/vaults/myco');
+  });
+
+  it('collapses bare home directory', () => {
+    expect(collapseHomePath(home)).toBe('~');
+  });
+
+  it('leaves non-home paths unchanged', () => {
+    expect(collapseHomePath('/tmp/vault')).toBe('/tmp/vault');
+  });
+
+  it('leaves relative paths unchanged', () => {
+    expect(collapseHomePath('.myco/vault')).toBe('.myco/vault');
+  });
+
+  it('does not collapse partial prefix match', () => {
+    // e.g., /Users/chris2 should NOT match /Users/chris
+    expect(collapseHomePath(home + '2/vault')).toBe(home + '2/vault');
+  });
+});


### PR DESCRIPTION
## Summary
- Write `MYCO_VAULT_DIR` to `.claude/settings.user.json` (gitignored) instead of `.claude/settings.json` to avoid committing the user's home directory path
- Collapse absolute home paths to `~/` form before persisting to any agent config (Claude Code and Cursor)
- Add `.claude/settings.user.json` to `.gitignore`

## Test plan
- [ ] Run `myco init` in a fresh project and verify `MYCO_VAULT_DIR` is written to `.claude/settings.user.json`, not `.claude/settings.json`
- [x] Verify the stored path uses `~/` form, not expanded absolute path
- [x] Verify `make check` passes (333 tests)
- [ ] Verify Cursor adapter stores portable `~/` path in `.cursor/mcp.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)