### PR TITLE
feat: digest continuous reasoning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ This is Myco's core contract. Violations:
 - Session notes are rebuilt from the agent's authoritative transcript on each stop event. The transcript file (e.g., Claude's `.jsonl`) is the source of truth — all turns are re-parsed and the `## Conversation` section is regenerated in full. Data preservation is guaranteed by the transcript being append-only, not by the session note's write logic.
 - The degraded stop path (`src/hooks/stop.ts`) MUST NOT write a session file if one already exists. It returns early; the daemon handles it when it's back.
 - Buffer files (`buffer/<session-id>.jsonl`) MUST NOT be deleted on session unregister. Session reload (SessionEnd → SessionStart) reuses the same session ID. Buffers are cleaned up by age (>24h) on daemon startup only.
-- `observation_type` in memory frontmatter accepts any string (`z.string()`). The LLM prompt guides types; the schema MUST NOT reject unexpected values.
+- `observation_type` in spore frontmatter accepts any string (`z.string()`). The LLM prompt guides types; the schema MUST NOT reject unexpected values.
 
 ## Session ID Is the Source of Truth
 
@@ -89,7 +89,7 @@ Every write operation MUST be safe to run twice with the same input. No "first-t
 
 Concrete requirements:
 
-- `writeMemory`, `writeArtifact`, `writeSession`, `writePlan`, `writeTeamMember` MUST produce the same file content given the same input, whether or not the file already exists.
+- `writeSpore`, `writeArtifact`, `writeSession`, `writePlan`, `writeTeamMember` MUST produce the same file content given the same input, whether or not the file already exists.
 - Startup tasks (migration, buffer cleanup, index rebuild) MUST be idempotent. Running the daemon startup sequence twice in a row MUST NOT move, duplicate, or corrupt data.
 - `indexNote` and `indexAndEmbed` MUST upsert, not insert. Re-indexing an already-indexed note MUST NOT create duplicates.
 
@@ -110,7 +110,7 @@ Exceptions: array indices (`[0]`), string operations (`.slice(0, 10)` for ISO da
 
 ## Naming Conventions
 
-- **Memory files:** `memories/{normalized_type}/{observation_type}-{session_id_last_6}-{timestamp}.md` (e.g., `memories/gotcha/gotcha-ac5220-1773416089650.md`). The subdirectory name normalizes underscores to hyphens (`bug_fix` → `bug-fix/`).
+- **Spore files:** `spores/{normalized_type}/{observation_type}-{session_id_last_6}-{timestamp}.md` (e.g., `spores/gotcha/gotcha-ac5220-1773416089650.md`). The subdirectory name normalizes underscores to hyphens (`bug_fix` → `bug-fix/`).
 - **Session files:** `sessions/{YYYY-MM-DD}/session-{session_id}.md`
 - **Imports:** Use `@myco/*` path aliases mapping to `src/*`
 - **Tests:** `tests/<module>.test.ts` mirroring `src/<module>.ts`
@@ -125,7 +125,7 @@ Exceptions: array indices (`[0]`), string operations (`.slice(0, 10)` for ISO da
   vectors.db         # sqlite-vec vector embeddings
   buffer/            # Per-session JSONL event buffers (ephemeral)
   sessions/          # Session notes by date
-  memories/          # Observation notes (subdirectories by type: gotcha/, decision/, etc.)
+  spores/            # Observation notes (subdirectories by type: gotcha/, decision/, etc.)
   plans/             # Plan notes
   artifacts/         # Artifact references
   attachments/       # Images extracted from session transcripts (Obsidian embeds)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ src/
   capture/       # Event buffering (EventBuffer) and buffer-based turn fallback
   config/        # Vault config loading and Zod schema
   context/       # Context injection for UserPromptSubmit hook
-  daemon/        # Long-lived HTTP daemon: batch processing, session lifecycle, plan watching
+  daemon/        # Long-lived HTTP daemon: batch processing, session lifecycle, plan watching, digest
   hooks/         # Claude Code hook entry points (thin — delegate to daemon)
   index/         # SQLite FTS5 + sqlite-vec vector search
   intelligence/  # LLM backend abstraction (Ollama, LM Studio, Anthropic)
@@ -65,6 +65,7 @@ skills/          # Skill markdown files (subdirectory per skill)
 - **Hooks MUST be thin.** Hook entry points in `src/hooks/` MUST delegate to the daemon via `DaemonClient`. Hooks MUST NOT contain business logic, LLM calls, or complex processing. If the daemon is unreachable, hooks spawn it via `client.ensureRunning()` and buffer events to disk for later processing.
 - **The daemon is the authority.** All event processing, session note writing, observation extraction, and embedding happen in the daemon (`src/daemon/main.ts`). Hooks send events; the daemon decides what to do with them.
 - **MCP server config MUST be in `plugin.json`.** The `mcpServers` field in `.claude-plugin/plugin.json` is the only way to register MCP servers for plugins loaded via `--plugin-dir`. Do NOT use standalone `.mcp.json` for plugin MCP servers.
+- **Digest is a daemon task.** The digest engine runs inside the daemon process alongside batch processing and plan watching. It is NOT a hook or MCP server — it produces vault files that are read by hooks and MCP tools at serve time.
 
 ## Data Preservation
 
@@ -115,6 +116,19 @@ Exceptions: array indices (`[0]`), string operations (`.slice(0, 10)` for ISO da
 - **Imports:** Use `@myco/*` path aliases mapping to `src/*`
 - **Tests:** `tests/<module>.test.ts` mirroring `src/<module>.ts`
 
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| **Digest** | Continuous reasoning process that synthesizes vault knowledge into pre-computed context extracts. Runs as a daemon task on an adaptive timer. |
+| **Extract** | Tiered context representation at a specific token budget (1500/3000/5000/10000). Stored in `vault/digest/`. |
+| **Substrate** | New or updated vault notes not yet digested. Input to a digest cycle. |
+| **Trace** | Append-only audit chain of digest cycles. Stored as JSONL in `vault/digest/trace.jsonl`. |
+| **Metabolism** | Adaptive processing rate of the digest system. Active → cooling → dormant. |
+| **Dormancy** | Digest timer suspended when no new substrate arrives for an extended period. |
+| **Activation** | Return from dormancy to active metabolism, triggered by new session events. |
+| **Spore** | Discrete observation extracted from session activity (gotcha, decision, discovery, trade-off, bug fix). Stored in `vault/spores/`. |
+
 ## Vault Structure
 
 ```
@@ -130,6 +144,7 @@ Exceptions: array indices (`[0]`), string operations (`.slice(0, 10)` for ISO da
   artifacts/         # Artifact references
   attachments/       # Images extracted from session transcripts (Obsidian embeds)
   team/              # Team member notes
+  digest/            # Pre-computed context extracts and digest trace
   logs/              # Daemon logs
 ```
 
@@ -194,6 +209,13 @@ Use the CLI: `node dist/src/cli.js <command>`
 - `vectors <query>` — raw similarity scores for threshold tuning
 - `rebuild` — reindex all vault notes (FTS + vectors)
 - `restart` — kill and respawn the daemon with current code
+
+### Modify digest behavior
+
+1. Prompt templates in `src/prompts/digest-*.md` — change what the LLM focuses on per tier
+2. Substrate formatting in `src/daemon/digest.ts` `formatSubstrate()` — change how notes are presented to the LLM
+3. Metabolism timing in `src/daemon/digest.ts` `Metabolism` class — change active/cooldown/dormancy intervals
+4. Config in `src/config/schema.ts` `DigestSchema` — change defaults or add new options
 
 ### Restart daemon after code changes
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Myco captures everything your AI agents do — sessions, decisions, plans, disco
 myco_search("how did we handle auth?")  → semantically matched sessions, decisions, and linked context
 myco_recall("migration plan")           → full decision history with session lineage
 myco_remember(observation)              → persist a discovery for the team
+myco_context(tier: 3000)                → pre-computed project understanding, instantly available
 ```
 
 **For humans** — open the vault in Obsidian and browse the intelligence graph visually. Sessions link to plans, plans link to decisions, decisions link to spores. It's all Markdown with backlinks — your team's connected knowledge, navigable and searchable.
@@ -47,7 +48,11 @@ myco_remember(observation)              → persist a discovery for the team
 
 ### Capture
 
-A background daemon reads your agent's conversation transcript after each turn — the full dialogue including prompts, AI responses, tool calls, and screenshots. Observations (decisions, gotchas, discoveries) are extracted automatically via a local LLM and written as linked vault notes.
+A background daemon reads your agent's conversation transcript after each turn — the full dialogue including prompts, AI responses, tool calls, and screenshots. Observations called **spores** (decisions, gotchas, discoveries, trade-offs, bug fixes) are extracted automatically via a local LLM and written as linked vault notes.
+
+### Digest
+
+A **continuous reasoning engine** runs inside the daemon, periodically synthesizing all accumulated knowledge into tiered context extracts. These pre-computed summaries give agents an instant, rich understanding of the project at session start — no searching required. Four tiers serve different needs: executive briefing (1.5K tokens), team standup (3K), deep onboarding (5K), and institutional knowledge (10K).
 
 ### Index
 
@@ -55,7 +60,7 @@ Every note is indexed for both keyword search (SQLite FTS5) and semantic search 
 
 ### Serve
 
-An MCP server exposes the vault to any agent runtime. Relevant spores are injected into every prompt automatically — no manual lookup needed. Agents build on your team's accumulated knowledge without being told to.
+An MCP server exposes the vault to any agent runtime. The digest extract is injected at session start for immediate context, and relevant spores are injected per-prompt for targeted intelligence. Agents build on your team's accumulated knowledge without being told to.
 
 ### Connect
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ myco_recall("migration plan")           → full decision history with session l
 myco_remember(observation)              → persist a discovery for the team
 ```
 
-**For humans** — open the vault in Obsidian and browse the intelligence graph visually. Sessions link to plans, plans link to decisions, decisions link to memories. It's all Markdown with backlinks — your team's connected knowledge, navigable and searchable.
+**For humans** — open the vault in Obsidian and browse the intelligence graph visually. Sessions link to plans, plans link to decisions, decisions link to spores. It's all Markdown with backlinks — your team's connected knowledge, navigable and searchable.
 
 **For teams** — the vault is a Git-friendly directory of Markdown files. Share it through your existing Git workflow.
 
@@ -55,11 +55,11 @@ Every note is indexed for both keyword search (SQLite FTS5) and semantic search 
 
 ### Serve
 
-An MCP server exposes the vault to any agent runtime. Relevant memories are injected into every prompt automatically — no manual lookup needed. Agents build on your team's accumulated knowledge without being told to.
+An MCP server exposes the vault to any agent runtime. Relevant spores are injected into every prompt automatically — no manual lookup needed. Agents build on your team's accumulated knowledge without being told to.
 
 ### Connect
 
-Sessions link to plans. Plans link to decisions. Decisions link to memories. Obsidian backlinks and metadata create a navigable graph of your team's institutional knowledge. Open the vault in [Obsidian](https://obsidian.md) to browse it visually, or let agents traverse it via MCP tools.
+Sessions link to plans. Plans link to decisions. Decisions link to spores. Obsidian backlinks and metadata create a navigable graph of your team's institutional knowledge. Open the vault in [Obsidian](https://obsidian.md) to browse it visually, or let agents traverse it via MCP tools.
 
 ### Multi-agent
 

--- a/commands/init.md
+++ b/commands/init.md
@@ -38,9 +38,9 @@ Using the detected providers from Step 1, ask the user:
 
 **Question:** "Which LLM provider for summarization?"
 
-**Options:** List only providers where `available` is `true`, with recommended models. Example:
-- "Ollama — gpt-oss (recommended)"
-- "LM Studio — openai/gpt-oss-20b"
+**Options:** List only providers where `available` is `true`, with recommended models. Prefer Qwen 3.5 for its strong instruction-following and synthesis quality. Example:
+- "Ollama — qwen3.5 (recommended)"
+- "LM Studio — qwen/qwen3.5-35b-a3b"
 - "Anthropic"
 
 After the user picks a provider, ask them to choose a specific model from that provider's model list (from the detect-providers output).

--- a/commands/init.md
+++ b/commands/init.md
@@ -60,7 +60,33 @@ After the user picks a provider, ask them to choose a specific embedding model.
 If the recommended embedding model isn't available, offer to pull it:
 - **Ollama**: `ollama pull bge-m3`
 
-## Step 5: Run init with all gathered inputs
+## Step 5: Configure digest
+
+Myco's digest engine continuously synthesizes vault knowledge into pre-computed context extracts, giving agents rich project understanding at session start.
+
+**Detect system RAM** to recommend settings:
+- **macOS**: `sysctl -n hw.memsize` (bytes → GB)
+- **Linux**: parse `/proc/meminfo` for `MemTotal`
+
+| Available Memory | Recommended Tiers | Context Window |
+|-----------------|-------------------|----------------|
+| < 16GB | `[1500]` | 8192 |
+| 16–32GB | `[1500, 3000]` | 16384 |
+| 32–64GB | `[1500, 3000, 5000]` | 24576 |
+| 64GB+ | `[1500, 3000, 5000, 10000]` | 32768 |
+
+Present the recommendation and ask:
+
+**Question:** "Digest will continuously synthesize your vault into context extracts. Accept recommended settings?"
+
+**Options:**
+- "Yes — use recommended settings" (default)
+- "Customize tiers and model"
+- "Disable digest"
+
+Store the user's choice to include in the init command. Digest is enabled by default — the user must explicitly disable it.
+
+## Step 6: Run init with all gathered inputs
 
 Pass everything to the init command in a single call:
 
@@ -77,7 +103,9 @@ node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js init \
 
 The CLI creates the vault structure, writes myco.yaml, .gitignore, _dashboard.md, initializes the FTS index, and configures MYCO_VAULT_DIR if the vault is external.
 
-## Step 6: Verify connectivity
+After init completes, if the user chose custom digest settings, update the `digest` section in the newly created `myco.yaml` with their choices. If they accepted defaults, Zod handles it automatically — no YAML mutation needed.
+
+## Step 7: Verify connectivity
 
 Run the verify command to confirm providers are reachable:
 
@@ -87,7 +115,7 @@ node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js verify
 
 If verification fails, help the user troubleshoot (check if the provider is running, model is loaded, etc.).
 
-## Step 7: Display summary
+## Step 8: Display summary
 
 Show the user a setup summary table:
 
@@ -96,3 +124,6 @@ Show the user a setup summary table:
 | Vault path | `<resolved path>` |
 | LLM provider | `<provider>` / `<model>` |
 | Embedding provider | `<provider>` / `<model>` |
+| Digest | enabled / disabled |
+| Digest tiers | `[1500, 3000, ...]` |
+| Digest inject tier | `3000` (or "MCP tool only") |

--- a/commands/init.md
+++ b/commands/init.md
@@ -9,19 +9,23 @@ Guide the user through setup using the composable CLI commands. **Do NOT create 
 
 **Ask each question one at a time using AskUserQuestion with selectable options.** Wait for the user's answer before proceeding to the next question. Do NOT combine multiple questions into one message.
 
-## Step 1: Detect available providers
+The streamlined setup asks just four questions: vault location, provider, model, and embedding model. One model handles everything — hooks, extraction, summaries, and digest — sized for the most demanding task (digestion). Advanced configuration is available via CLI commands after init.
 
-Run the provider detection command to see what's available:
+## Step 1: Detect available providers and system capabilities
+
+Run the provider detection command and detect system RAM:
 
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js detect-providers
 ```
 
+Detect RAM:
+- **macOS**: `sysctl -n hw.memsize` (bytes → GB)
+- **Linux**: parse `/proc/meminfo` for `MemTotal`
+
 Parse the JSON output. This tells you which providers are running and what models are available.
 
 ## Step 2: Choose vault location
-
-Ask the user:
 
 **Question:** "Where would you like to store the Myco vault?"
 
@@ -30,118 +34,89 @@ Ask the user:
 - "Centralized (~/.myco/vaults/<project-name>/)" — vault stays outside the repo, good for public repos or personal use
 - "Custom path" — specify your own location
 
-If the user picks "Custom path", ask them to type the path.
+## Step 3: Choose provider and model
 
-## Step 3: Choose LLM provider
+**Question:** "Which LLM provider and model?"
 
-Using the detected providers from Step 1, ask the user:
+List only providers where `available` is `true`. Recommend a model sized for digest based on detected RAM:
 
-**Question:** "Which LLM provider for summarization?"
+| RAM | Recommended Model | Digest Context |
+|-----|-------------------|----------------|
+| **64GB+** | `qwen3.5:35b` (MoE, recommended) | 65536 |
+| **32–64GB** | `qwen3.5:27b` | 32768 |
+| **16–32GB** | `qwen3.5:latest` (~10B) | 16384 |
+| **8–16GB** | `qwen3.5:4b` | 8192 |
 
-**Options:** List only providers where `available` is `true`, with recommended models. Prefer Qwen 3.5 for its strong instruction-following and synthesis quality. Example:
-- "Ollama — qwen3.5 (recommended)"
-- "LM Studio — qwen/qwen3.5-35b-a3b"
-- "Anthropic"
+The same model handles hooks (at 8K context), extraction, summaries, and digest (at the larger context from the table). No separate model configuration needed.
 
-After the user picks a provider, ask them to choose a specific model from that provider's model list (from the detect-providers output).
+If the model isn't installed, offer to pull it:
+- **Ollama**: `ollama pull qwen3.5`
+- **LM Studio**: search for `qwen3.5` in the model browser
 
-## Step 4: Choose embedding provider
+## Step 4: Choose embedding model
 
-Ask the user:
+**Question:** "Which embedding model?"
 
-**Question:** "Which embedding provider?"
-
-**Options:** List only providers where `available` is `true` and that support embeddings (Anthropic does not). Example:
+**Options:** List only providers that support embeddings (Anthropic does not):
 - "Ollama — bge-m3 (recommended)"
 - "LM Studio — text-embedding-bge-m3"
 
-After the user picks a provider, ask them to choose a specific embedding model.
+If not installed: `ollama pull bge-m3`
 
-If the recommended embedding model isn't available, offer to pull it:
-- **Ollama**: `ollama pull bge-m3`
+## Step 5: Choose digest inject tier
 
-## Step 5: Configure digest
+**Question:** "How much context should the agent receive at session start?"
 
-Myco's digest engine continuously synthesizes vault knowledge into pre-computed context extracts, giving agents rich project understanding at session start.
+Based on RAM, present the recommended tiers:
 
-**Detect system RAM** to recommend settings:
-- **macOS**: `sysctl -n hw.memsize` (bytes → GB)
-- **Linux**: parse `/proc/meminfo` for `MemTotal`
-
-| Available Memory | Recommended Tiers | Context Window |
-|-----------------|-------------------|----------------|
-| < 16GB | `[1500]` | 8192 |
-| 16–32GB | `[1500, 3000]` | 16384 |
-| 32–64GB | `[1500, 3000, 5000]` | 24576 |
-| 64GB+ | `[1500, 3000, 5000, 10000]` | 32768 |
-
-Present the recommendation and ask:
-
-**Question:** "Digest will continuously synthesize your vault into context extracts. Accept recommended settings?"
+| RAM | Options | Default |
+|-----|---------|---------|
+| **64GB+** | 1500, 3000, 5000, 10000 | 3000 |
+| **32–64GB** | 1500, 3000, 5000 | 3000 |
+| **16–32GB** | 1500, 3000 | 1500 |
+| **8–16GB** | 1500 | 1500 |
 
 **Options:**
-- "Yes — use recommended settings" (default)
-- "Customize"
-- "Disable digest"
+- "1500 — executive briefing (fastest, lightest)"
+- "3000 — team standup (recommended)"
+- "5000 — deep onboarding"
+- "10000 — institutional knowledge (richest)"
 
-Digest is enabled by default — the user must explicitly disable it.
+This controls what gets auto-injected at the start of every session. Agents can always request a different tier on-demand via the `myco_context` tool.
 
-If the user chooses **"Customize"**, ask these one at a time:
+## Step 6: Run init and configure
 
-1. **Tiers:** "Which tiers to generate?" — options: [1500], [1500, 3000], [1500, 3000, 5000], [1500, 3000, 5000, 10000]
-2. **Inject tier:** "Which tier to auto-inject at session start?" — options: 1500, 3000, 5000, 10000, or "None (MCP tool only)"
-3. **Separate model:** "Use a different model for digestion?" — For Ollama users, recommend "No" (same model) since Ollama handles different context windows per-request and a separate model would exceed the default 2-model concurrent limit, causing slow model swapping. For LM Studio users, a separate model is fine since LM Studio manages instances independently.
-4. **Context window:** "Context window for digest?" — suggest based on RAM tier from the table above
-
-Use the CLI command to write digest settings deterministically:
+Create the vault and apply settings:
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js setup-digest \
-  --tiers 1500,3000,5000,10000 \
-  --inject-tier 3000 \
-  --context-window 32768
-```
-
-Only pass flags the user explicitly changed — Zod defaults handle the rest.
-
-## Step 6: Run init with all gathered inputs
-
-Pass everything to the init command in a single call:
-
-```bash
+# Create vault structure and base config
 node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js init \
   --vault <chosen-path> \
   --llm-provider <provider> \
   --llm-model <model> \
-  --llm-url <base-url> \
-  --embedding-provider <provider> \
-  --embedding-model <model> \
-  --embedding-url <base-url>
+  --embedding-provider <embedding-provider> \
+  --embedding-model <embedding-model>
+
+# Set digest context window and inject tier based on user choices
+node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js setup-digest \
+  --context-window <from-ram-table> \
+  --inject-tier <chosen-tier>
 ```
 
-The CLI creates the vault structure, writes myco.yaml, .gitignore, _dashboard.md, initializes the FTS index, and configures MYCO_VAULT_DIR if the vault is external.
-
-After init completes, if the user chose custom digest settings, update the `digest` section in the newly created `myco.yaml` with their choices. If they accepted defaults, Zod handles it automatically — no YAML mutation needed.
-
 ## Step 7: Verify connectivity
-
-Run the verify command to confirm providers are reachable:
 
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js verify
 ```
 
-If verification fails, help the user troubleshoot (check if the provider is running, model is loaded, etc.).
+If verification fails, help the user troubleshoot.
 
 ## Step 8: Display summary
-
-Show the user a setup summary table:
 
 | Setting | Value |
 |---------|-------|
 | Vault path | `<resolved path>` |
-| LLM provider | `<provider>` / `<model>` |
-| Embedding provider | `<provider>` / `<model>` |
-| Digest | enabled / disabled |
-| Digest tiers | `[1500, 3000, ...]` |
-| Digest inject tier | `3000` (or "MCP tool only") |
+| Provider | `<provider>` / `<model>` |
+| Embedding | `<embedding-provider>` / `<embedding-model>` |
+| Digest | enabled (context: `<context-window>`) |
+| RAM detected | `<X>` GB |

--- a/commands/init.md
+++ b/commands/init.md
@@ -81,10 +81,19 @@ Present the recommendation and ask:
 
 **Options:**
 - "Yes — use recommended settings" (default)
-- "Customize tiers and model"
+- "Customize"
 - "Disable digest"
 
-Store the user's choice to include in the init command. Digest is enabled by default — the user must explicitly disable it.
+Digest is enabled by default — the user must explicitly disable it.
+
+If the user chooses **"Customize"**, ask these one at a time:
+
+1. **Tiers:** "Which tiers to generate?" — options: [1500], [1500, 3000], [1500, 3000, 5000], [1500, 3000, 5000, 10000]
+2. **Inject tier:** "Which tier to auto-inject at session start?" — options: 1500, 3000, 5000, 10000, or "None (MCP tool only)"
+3. **Separate model:** "Use a different model for digestion?" — if yes, show available models from detected providers. This allows a larger/better model for digest while keeping a fast model for hooks.
+4. **Context window:** "Context window for digest?" — suggest based on RAM tier from the table above
+
+Store the user's choices to write into the `digest` section of `myco.yaml`.
 
 ## Step 6: Run init with all gathered inputs
 

--- a/commands/init.md
+++ b/commands/init.md
@@ -93,7 +93,16 @@ If the user chooses **"Customize"**, ask these one at a time:
 3. **Separate model:** "Use a different model for digestion?" — if yes, show available models from detected providers. This allows a larger/better model for digest while keeping a fast model for hooks.
 4. **Context window:** "Context window for digest?" — suggest based on RAM tier from the table above
 
-Store the user's choices to write into the `digest` section of `myco.yaml`.
+Use the CLI command to write digest settings deterministically:
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js setup-digest \
+  --tiers 1500,3000,5000,10000 \
+  --inject-tier 3000 \
+  --context-window 32768
+```
+
+Only pass flags the user explicitly changed — Zod defaults handle the rest.
 
 ## Step 6: Run init with all gathered inputs
 

--- a/commands/init.md
+++ b/commands/init.md
@@ -58,8 +58,10 @@ If the model isn't installed, offer to pull it:
 **Question:** "Which embedding model?"
 
 **Options:** List only providers that support embeddings (Anthropic does not):
-- **Ollama** — recommend `bge-m3` or `nomic-embed-text`. If not installed: `ollama pull bge-m3`
-- **LM Studio** — list models with `text-embedding` in the name from the detect-providers output (e.g., `text-embedding-nomic-embed-text-v1.5`, `text-embedding-qwen3-embedding-8b`). These load on demand.
+- **Ollama** — list available embedding models. If none are available, offer to pull one (e.g., `bge-m3` or `nomic-embed-text`).
+- **LM Studio** — filter the model list for names containing `text-embedding`. If none are available, guide the user to search for and download an embedding model through LM Studio's model browser.
+
+If no embedding models are available on the chosen provider, help the user get one before proceeding.
 
 ## Step 5: Choose digest inject tier
 

--- a/commands/init.md
+++ b/commands/init.md
@@ -58,10 +58,8 @@ If the model isn't installed, offer to pull it:
 **Question:** "Which embedding model?"
 
 **Options:** List only providers that support embeddings (Anthropic does not):
-- "Ollama — bge-m3 (recommended)"
-- "LM Studio — text-embedding-bge-m3"
-
-If not installed: `ollama pull bge-m3`
+- **Ollama** — recommend `bge-m3` or `nomic-embed-text`. If not installed: `ollama pull bge-m3`
+- **LM Studio** — list models with `text-embedding` in the name from the detect-providers output (e.g., `text-embedding-nomic-embed-text-v1.5`, `text-embedding-qwen3-embedding-8b`). These load on demand.
 
 ## Step 5: Choose digest inject tier
 

--- a/commands/init.md
+++ b/commands/init.md
@@ -90,7 +90,7 @@ If the user chooses **"Customize"**, ask these one at a time:
 
 1. **Tiers:** "Which tiers to generate?" — options: [1500], [1500, 3000], [1500, 3000, 5000], [1500, 3000, 5000, 10000]
 2. **Inject tier:** "Which tier to auto-inject at session start?" — options: 1500, 3000, 5000, 10000, or "None (MCP tool only)"
-3. **Separate model:** "Use a different model for digestion?" — if yes, show available models from detected providers. This allows a larger/better model for digest while keeping a fast model for hooks.
+3. **Separate model:** "Use a different model for digestion?" — For Ollama users, recommend "No" (same model) since Ollama handles different context windows per-request and a separate model would exceed the default 2-model concurrent limit, causing slow model swapping. For LM Studio users, a separate model is fine since LM Studio manages instances independently.
 4. **Context window:** "Context window for digest?" — suggest based on RAM tier from the table above
 
 Use the CLI command to write digest settings deterministically:

--- a/commands/setup-llm.md
+++ b/commands/setup-llm.md
@@ -50,10 +50,8 @@ If the chosen model isn't installed, offer to pull it:
 
 Ask the user to select an embedding model — **Anthropic is not an option** (it doesn't support embeddings):
 
-- **Ollama** (recommended) — recommend **`bge-m3`** or `nomic-embed-text`
-- **LM Studio** — possible but not recommended for embeddings
-
-If the embedding model isn't installed: `ollama pull bge-m3`
+- **Ollama** — recommend `bge-m3` or `nomic-embed-text`. If not installed: `ollama pull bge-m3`
+- **LM Studio** — list models with `text-embedding` in the name from the detected providers (e.g., `text-embedding-nomic-embed-text-v1.5`, `text-embedding-qwen3-embedding-8b`). These load on demand.
 
 **Important:** If the user changes the embedding model, warn them:
 > "Changing the embedding model will require a full rebuild of the vector index. Run `node dist/src/cli.js rebuild` after this change."

--- a/commands/setup-llm.md
+++ b/commands/setup-llm.md
@@ -101,9 +101,11 @@ Ask the user:
 **Question:** "Configure digest (continuous reasoning)?"
 
 **Options:**
-- "Accept recommended settings" — use the RAM-based recommendation above
-- "Customize" — let the user pick tiers, context window, and optionally a separate model
+- "Accept recommended settings" — use the RAM-based recommendation above, same model as main LLM
+- "Customize" — pick tiers, context window, and optionally a separate model/provider
 - "Disable" — set `digest.enabled: false`
+
+**Important guidance for Ollama users:** When using Ollama, recommend the **same model** for both main LLM and digest. Ollama defaults to 2 concurrent models, and the embedding model takes one slot. Using a separate digest model would require 3 slots, causing constant model swapping (~22GB+ per swap). Ollama handles different context windows per-request on the same model natively, so the same model works at 8K for hooks and 32K+ for digest without any issues.
 
 If customizing, ask these one at a time:
 

--- a/commands/setup-llm.md
+++ b/commands/setup-llm.md
@@ -7,11 +7,13 @@ description: Configure or change the intelligence backend (Ollama, LM Studio, or
 
 Guide the user through configuring their intelligence backend. This command can be run at any time to change providers or models.
 
+The streamlined setup asks just three questions: provider, model, and embedding model. One model handles everything — hooks, extraction, summaries, and digest — at different context windows per request. Advanced configuration is available via the CLI for power users.
+
 ## Prerequisites
 
 Read the existing `myco.yaml` from the vault directory to show current settings before making changes.
 
-## Step 1: Detect available providers
+## Step 1: Detect available providers and system capabilities
 
 Check which providers are reachable:
 
@@ -19,156 +21,94 @@ Check which providers are reachable:
 - **LM Studio** — fetch `http://localhost:1234/v1/models`, list model names
 - **Anthropic** — check if `ANTHROPIC_API_KEY` is set in the environment
 
-Report which are available and which are not.
+Detect system RAM for recommendations:
+- **macOS**: `sysctl -n hw.memsize` (bytes → GB)
+- **Linux**: parse `/proc/meminfo` for `MemTotal`
 
-## Step 2: Choose LLM provider
+Report which providers are available and the detected RAM.
 
-Ask the user to select from available providers:
+## Step 2: Choose provider and model
 
-- **Ollama** — list available models
-- **LM Studio** — list available models
-- **Anthropic** — verify API key works, default model `claude-haiku-4-5-20251001`
+Ask the user to select from available providers. After picking a provider, recommend a model sized for digest (the most demanding task). The same model handles hooks and extraction at smaller context windows automatically.
 
-Recommended models by hardware tier. Qwen 3.5 is preferred for its strong instruction-following and synthesis quality — extraction data feeds into the digest, so higher quality here means better project understanding:
+Recommended models by hardware tier — Qwen 3.5 is preferred for its strong instruction-following and synthesis quality:
 
-| Tier | Models | RAM |
-|------|--------|-----|
-| **High** | `qwen3.5:35b` (MoE, recommended), `qwen3.5:27b`, `gpt-oss` (~20B) | 32GB+ |
-| **Mid** | `qwen3.5:latest` (~10B), `gemma3:12b`, `qwen3:30b` | 16GB+ |
-| **Light** | `qwen3.5:4b`, `gemma3:4b` | 8GB+ |
+| RAM | Model | Context for Digest |
+|-----|-------|--------------------|
+| **64GB+** | `qwen3.5:35b` (MoE, recommended) | 65536 |
+| **32–64GB** | `qwen3.5:27b` | 32768 |
+| **16–32GB** | `qwen3.5:latest` (~10B) | 16384 |
+| **8–16GB** | `qwen3.5:4b` | 8192 |
 
 Any instruction-tuned model that handles JSON output works. Prefer what the user already has loaded, but recommend Qwen 3.5 if they're starting fresh.
-
-For local providers (Ollama, LM Studio), also configure:
-- `context_window` — ask or accept default of 8192 for hooks. Digest uses its own `context_window` (default 32768, configurable in Step 5)
-- `max_tokens` — ask or accept default of 1024
 
 If the chosen model isn't installed, offer to pull it:
 - **Ollama**: `ollama pull qwen3.5` (pulls latest tag automatically)
 - **LM Studio**: search for `qwen3.5` in the model browser
 
-These settings do not apply to Anthropic (API-managed).
+## Step 3: Choose embedding model
 
-## Step 3: Choose embedding provider
+Ask the user to select an embedding model — **Anthropic is not an option** (it doesn't support embeddings):
 
-Ask the user to select from available providers — **Anthropic is not an option** (it doesn't support embeddings):
-
-- **Ollama** (recommended for embeddings) — list available models, recommend **`bge-m3`** or `nomic-embed-text`
-- **LM Studio** — possible but not recommended for embeddings; better suited for LLM work
+- **Ollama** (recommended) — recommend **`bge-m3`** or `nomic-embed-text`
+- **LM Studio** — possible but not recommended for embeddings
 
 If the embedding model isn't installed: `ollama pull bge-m3`
 
-**Important:** If the user changes the embedding model, the vector index must be rebuilt. Warn them:
+**Important:** If the user changes the embedding model, warn them:
 > "Changing the embedding model will require a full rebuild of the vector index. Run `node dist/src/cli.js rebuild` after this change."
 
-## Step 4: Update `myco.yaml`
+## Step 4: Apply settings
 
-Use the CLI command to write settings deterministically:
+Use the CLI commands to write settings deterministically. The context window for the main LLM stays at 8192 (hooks don't need more). The digest context window is set based on the RAM tier recommendation.
 
 ```bash
+# Set provider and model
 node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js setup-llm \
-  --llm-provider ollama \
-  --llm-model qwen3.5 \
-  --llm-url http://localhost:11434 \
-  --llm-context-window 8192 \
-  --llm-max-tokens 1024 \
-  --embedding-provider ollama \
-  --embedding-model bge-m3 \
-  --embedding-url http://localhost:11434
+  --llm-provider <provider> \
+  --llm-model <model> \
+  --embedding-provider <embedding-provider> \
+  --embedding-model <embedding-model>
+
+# Set digest context window based on RAM tier (model inherits from main LLM)
+node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js setup-digest \
+  --context-window <from-ram-table>
 ```
 
-Only pass flags the user explicitly changed — existing values are preserved. Use `--show` to display current settings.
+Only pass flags the user explicitly changed — Zod defaults handle the rest.
 
 If migrating from a v1 config (has `backend: local/cloud` structure), bump `version` to `2` and rewrite the entire intelligence section. The loader auto-maps `provider: haiku` to `anthropic`.
 
-## Step 5: Configure digest (continuous reasoning)
-
-Myco's digest engine continuously synthesizes vault knowledge into pre-computed context extracts. It runs in the daemon on an adaptive timer.
-
-**Detect system capabilities** to recommend appropriate settings:
-- **macOS**: `sysctl -n hw.memsize` (bytes → GB)
-- **Linux**: parse `/proc/meminfo` for `MemTotal`
-
-| Available Memory | Recommended Tiers | Context Window |
-|-----------------|-------------------|----------------|
-| < 16GB | `[1500]` | 8192 |
-| 16–32GB | `[1500, 3000]` | 16384 |
-| 32–64GB | `[1500, 3000, 5000]` | 24576 |
-| 64GB+ | `[1500, 3000, 5000, 10000]` | 32768 |
-
-Ask the user:
-
-**Question:** "Configure digest (continuous reasoning)?"
-
-**Options:**
-- "Accept recommended settings" — use the RAM-based recommendation above, same model as main LLM
-- "Customize" — pick tiers, context window, and optionally a separate model/provider
-- "Disable" — set `digest.enabled: false`
-
-**Important guidance for Ollama users:** When using Ollama, recommend the **same model** for both main LLM and digest. Ollama defaults to 2 concurrent models, and the embedding model takes one slot. Using a separate digest model would require 3 slots, causing constant model swapping (~22GB+ per swap). Ollama handles different context windows per-request on the same model natively, so the same model works at 8K for hooks and 32K+ for digest without any issues.
-
-If customizing, ask these one at a time:
-
-1. **Tiers**: "Which tiers to generate?" — options: [1500], [1500, 3000], [1500, 3000, 5000], [1500, 3000, 5000, 10000]
-2. **Inject tier**: "Which tier to auto-inject at session start?" — options: 1500, 3000, 5000, 10000, or "None (MCP tool only)"
-3. **Separate model**: "Use a different model for digestion?" — if yes, ask provider and model from the detected providers. This allows a larger/better model for digest while keeping a fast model for hooks.
-4. **Context window**: "Context window for digest?" — suggest based on RAM tier from the table above. If using LM Studio, note that the model will be pre-loaded with this context size.
-5. **KV cache**: "Offload KV cache to GPU?" — default No (safer for large contexts). Only relevant for LM Studio.
-6. **Keep alive**: "How long to keep model loaded between cycles?" — default "30m". Only relevant for Ollama.
-
-Also ask about capture token budgets:
-
-7. **Extraction tokens**: "Max tokens for spore extraction?" — default 2048
-8. **Summary tokens**: "Max tokens for session summaries?" — default 1024
-
-Write all settings to `myco.yaml`. Example with all fields explicit:
-
-```yaml
-capture:
-  extraction_max_tokens: 2048
-  summary_max_tokens: 1024
-  title_max_tokens: 32
-  classification_max_tokens: 1024
-
-digest:
-  enabled: true
-  tiers: [1500, 3000, 5000, 10000]
-  inject_tier: 3000
-  intelligence:
-    provider: null          # null = inherit from main LLM
-    model: null             # null = inherit from main LLM
-    base_url: null          # null = inherit from main LLM
-    context_window: 32768
-    keep_alive: 30m         # Ollama: keep model loaded between cycles
-    gpu_kv_cache: false     # LM Studio: KV cache in system RAM
-  metabolism:
-    active_interval: 300
-    cooldown_intervals: [900, 1800, 3600]
-    dormancy_threshold: 7200
-  substrate:
-    max_notes_per_cycle: 50
-```
-
-Use the CLI command to write settings deterministically:
-
-```bash
-node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js setup-digest \
-  --tiers 1500,3000,5000,10000 \
-  --inject-tier 3000 \
-  --provider lm-studio \
-  --model "qwen/qwen3.5-35b-a3b" \
-  --context-window 65536 \
-  --gpu-kv-cache false \
-  --keep-alive 30m \
-  --summary-tokens 1024 \
-  --extraction-tokens 2048
-```
-
-Only pass flags the user explicitly changed — Zod defaults handle the rest. Use `--show` to display current settings.
-
-## Step 6: Verify and restart
+## Step 5: Verify and restart
 
 1. Test the LLM provider with a simple prompt
 2. Test the embedding provider with a test embedding
 3. Restart the daemon to pick up the new config: `node dist/src/cli.js restart`
 4. Report success or issues found
+
+## Advanced Configuration
+
+For power users who want fine-grained control, all settings are available via CLI:
+
+```bash
+# Separate digest model (e.g., larger model on LM Studio)
+node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js setup-digest \
+  --provider lm-studio \
+  --model "qwen/qwen3.5-35b-a3b" \
+  --context-window 65536 \
+  --gpu-kv-cache false
+
+# Custom tiers and injection
+node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js setup-digest \
+  --tiers 1500,3000,5000,10000 \
+  --inject-tier 3000
+
+# Capture token budgets
+node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js setup-digest \
+  --extraction-tokens 2048 \
+  --summary-tokens 1024
+
+# View current settings
+node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js setup-llm --show
+node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js setup-digest --show
+```

--- a/commands/setup-llm.md
+++ b/commands/setup-llm.md
@@ -63,21 +63,21 @@ If the embedding model isn't installed: `ollama pull bge-m3`
 
 ## Step 4: Update `myco.yaml`
 
-Write both `intelligence.llm` and `intelligence.embedding` sections with all values explicit:
+Use the CLI command to write settings deterministically:
 
-```yaml
-intelligence:
-  llm:
-    provider: ollama
-    model: qwen3.5
-    base_url: http://localhost:11434
-    context_window: 8192
-    max_tokens: 1024
-  embedding:
-    provider: ollama
-    model: bge-m3
-    base_url: http://localhost:11434
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js setup-llm \
+  --llm-provider ollama \
+  --llm-model qwen3.5 \
+  --llm-url http://localhost:11434 \
+  --llm-context-window 8192 \
+  --llm-max-tokens 1024 \
+  --embedding-provider ollama \
+  --embedding-model bge-m3 \
+  --embedding-url http://localhost:11434
 ```
+
+Only pass flags the user explicitly changed — existing values are preserved. Use `--show` to display current settings.
 
 If migrating from a v1 config (has `backend: local/cloud` structure), bump `version` to `2` and rewrite the entire intelligence section. The loader auto-maps `provider: haiku` to `anthropic`.
 

--- a/commands/setup-llm.md
+++ b/commands/setup-llm.md
@@ -69,7 +69,7 @@ Write both `intelligence.llm` and `intelligence.embedding` sections with all val
 intelligence:
   llm:
     provider: ollama
-    model: gpt-oss
+    model: qwen3.5
     base_url: http://localhost:11434
     context_window: 8192
     max_tokens: 1024
@@ -105,24 +105,40 @@ Ask the user:
 - "Customize" — let the user pick tiers, context window, and optionally a separate model
 - "Disable" — set `digest.enabled: false`
 
-If customizing:
-- **Tiers**: which token budgets to generate (1500, 3000, 5000, 10000)
-- **Context window**: how much context the digest model can handle
-- **Separate model**: optionally use a different (larger/reasoning) model for digest than for hook-based extraction. Show available models from the detected providers.
-- **Inject tier**: which tier to auto-inject at session start (or null for MCP-tool-only)
+If customizing, ask these one at a time:
 
-Write the `digest` section to `myco.yaml`:
+1. **Tiers**: "Which tiers to generate?" — options: [1500], [1500, 3000], [1500, 3000, 5000], [1500, 3000, 5000, 10000]
+2. **Inject tier**: "Which tier to auto-inject at session start?" — options: 1500, 3000, 5000, 10000, or "None (MCP tool only)"
+3. **Separate model**: "Use a different model for digestion?" — if yes, ask provider and model from the detected providers. This allows a larger/better model for digest while keeping a fast model for hooks.
+4. **Context window**: "Context window for digest?" — suggest based on RAM tier from the table above. If using LM Studio, note that the model will be pre-loaded with this context size.
+5. **KV cache**: "Offload KV cache to GPU?" — default No (safer for large contexts). Only relevant for LM Studio.
+6. **Keep alive**: "How long to keep model loaded between cycles?" — default "30m". Only relevant for Ollama.
+
+Also ask about capture token budgets:
+
+7. **Extraction tokens**: "Max tokens for spore extraction?" — default 2048
+8. **Summary tokens**: "Max tokens for session summaries?" — default 1024
+
+Write all settings to `myco.yaml`. Example with all fields explicit:
 
 ```yaml
+capture:
+  extraction_max_tokens: 2048
+  summary_max_tokens: 1024
+  title_max_tokens: 32
+  classification_max_tokens: 1024
+
 digest:
   enabled: true
   tiers: [1500, 3000, 5000, 10000]
   inject_tier: 3000
   intelligence:
-    provider: null     # null = inherit from main LLM
-    model: null        # null = inherit from main LLM
-    base_url: null     # null = inherit from main LLM
+    provider: null          # null = inherit from main LLM
+    model: null             # null = inherit from main LLM
+    base_url: null          # null = inherit from main LLM
     context_window: 32768
+    keep_alive: 30m         # Ollama: keep model loaded between cycles
+    gpu_kv_cache: false     # LM Studio: KV cache in system RAM
   metabolism:
     active_interval: 300
     cooldown_intervals: [900, 1800, 3600]

--- a/commands/setup-llm.md
+++ b/commands/setup-llm.md
@@ -81,7 +81,59 @@ intelligence:
 
 If migrating from a v1 config (has `backend: local/cloud` structure), bump `version` to `2` and rewrite the entire intelligence section. The loader auto-maps `provider: haiku` to `anthropic`.
 
-## Step 5: Verify and restart
+## Step 5: Configure digest (continuous reasoning)
+
+Myco's digest engine continuously synthesizes vault knowledge into pre-computed context extracts. It runs in the daemon on an adaptive timer.
+
+**Detect system capabilities** to recommend appropriate settings:
+- **macOS**: `sysctl -n hw.memsize` (bytes → GB)
+- **Linux**: parse `/proc/meminfo` for `MemTotal`
+
+| Available Memory | Recommended Tiers | Context Window |
+|-----------------|-------------------|----------------|
+| < 16GB | `[1500]` | 8192 |
+| 16–32GB | `[1500, 3000]` | 16384 |
+| 32–64GB | `[1500, 3000, 5000]` | 24576 |
+| 64GB+ | `[1500, 3000, 5000, 10000]` | 32768 |
+
+Ask the user:
+
+**Question:** "Configure digest (continuous reasoning)?"
+
+**Options:**
+- "Accept recommended settings" — use the RAM-based recommendation above
+- "Customize" — let the user pick tiers, context window, and optionally a separate model
+- "Disable" — set `digest.enabled: false`
+
+If customizing:
+- **Tiers**: which token budgets to generate (1500, 3000, 5000, 10000)
+- **Context window**: how much context the digest model can handle
+- **Separate model**: optionally use a different (larger/reasoning) model for digest than for hook-based extraction. Show available models from the detected providers.
+- **Inject tier**: which tier to auto-inject at session start (or null for MCP-tool-only)
+
+Write the `digest` section to `myco.yaml`:
+
+```yaml
+digest:
+  enabled: true
+  tiers: [1500, 3000, 5000, 10000]
+  inject_tier: 3000
+  intelligence:
+    provider: null     # null = inherit from main LLM
+    model: null        # null = inherit from main LLM
+    base_url: null     # null = inherit from main LLM
+    context_window: 32768
+  metabolism:
+    active_interval: 300
+    cooldown_intervals: [900, 1800, 3600]
+    dormancy_threshold: 7200
+  substrate:
+    max_notes_per_cycle: 50
+```
+
+Only write fields the user explicitly changed — Zod defaults handle the rest.
+
+## Step 6: Verify and restart
 
 1. Test the LLM provider with a simple prompt
 2. Test the embedding provider with a test embedding

--- a/commands/setup-llm.md
+++ b/commands/setup-llm.md
@@ -29,23 +29,23 @@ Ask the user to select from available providers:
 - **LM Studio** — list available models
 - **Anthropic** — verify API key works, default model `claude-haiku-4-5-20251001`
 
-Recommended summarization models by hardware tier:
+Recommended models by hardware tier. Qwen 3.5 is preferred for its strong instruction-following and synthesis quality — extraction data feeds into the digest, so higher quality here means better project understanding:
 
 | Tier | Models | RAM |
 |------|--------|-----|
-| **High** | `gpt-oss` (~20B), `gemma3:27b`, `qwen3.5:14b` | 16GB+ |
-| **Mid** | `qwen3.5:8b`, `gemma3:12b` | 8GB+ |
-| **Light** | `gemma3:4b`, `qwen3.5:4b` | 4GB+ |
+| **High** | `qwen3.5:35b` (MoE, recommended), `qwen3.5:27b`, `gpt-oss` (~20B) | 32GB+ |
+| **Mid** | `qwen3.5:latest` (~10B), `gemma3:12b`, `qwen3:30b` | 16GB+ |
+| **Light** | `qwen3.5:4b`, `gemma3:4b` | 8GB+ |
 
-Any instruction-tuned model that handles JSON output works. Prefer what the user already has loaded.
+Any instruction-tuned model that handles JSON output works. Prefer what the user already has loaded, but recommend Qwen 3.5 if they're starting fresh.
 
 For local providers (Ollama, LM Studio), also configure:
-- `context_window` — ask or accept default of 8192
+- `context_window` — ask or accept default of 8192 for hooks. Digest uses its own `context_window` (default 32768, configurable in Step 5)
 - `max_tokens` — ask or accept default of 1024
 
 If the chosen model isn't installed, offer to pull it:
-- **Ollama**: `ollama pull gpt-oss` (pulls latest tag automatically)
-- **LM Studio**: `lms get openai/gpt-oss-20b` (uses `owner/model` format)
+- **Ollama**: `ollama pull qwen3.5` (pulls latest tag automatically)
+- **LM Studio**: search for `qwen3.5` in the model browser
 
 These settings do not apply to Anthropic (API-managed).
 

--- a/commands/setup-llm.md
+++ b/commands/setup-llm.md
@@ -50,8 +50,10 @@ If the chosen model isn't installed, offer to pull it:
 
 Ask the user to select an embedding model — **Anthropic is not an option** (it doesn't support embeddings):
 
-- **Ollama** — recommend `bge-m3` or `nomic-embed-text`. If not installed: `ollama pull bge-m3`
-- **LM Studio** — list models with `text-embedding` in the name from the detected providers (e.g., `text-embedding-nomic-embed-text-v1.5`, `text-embedding-qwen3-embedding-8b`). These load on demand.
+- **Ollama** — list available embedding models. If none are available, offer to pull one (e.g., `bge-m3` or `nomic-embed-text`).
+- **LM Studio** — filter the model list for names containing `text-embedding`. If none are available, guide the user to search for and download an embedding model through LM Studio's model browser.
+
+If no embedding models are available on the chosen provider, help the user get one before proceeding.
 
 **Important:** If the user changes the embedding model, warn them:
 > "Changing the embedding model will require a full rebuild of the vector index. Run `node dist/src/cli.js rebuild` after this change."

--- a/commands/setup-llm.md
+++ b/commands/setup-llm.md
@@ -147,7 +147,22 @@ digest:
     max_notes_per_cycle: 50
 ```
 
-Only write fields the user explicitly changed — Zod defaults handle the rest.
+Use the CLI command to write settings deterministically:
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/dist/src/cli.js setup-digest \
+  --tiers 1500,3000,5000,10000 \
+  --inject-tier 3000 \
+  --provider lm-studio \
+  --model "qwen/qwen3.5-35b-a3b" \
+  --context-window 65536 \
+  --gpu-kv-cache false \
+  --keep-alive 30m \
+  --summary-tokens 1024 \
+  --extraction-tokens 2048
+```
+
+Only pass flags the user explicitly changed — Zod defaults handle the rest. Use `--show` to display current settings.
 
 ## Step 6: Verify and restart
 

--- a/commands/status.md
+++ b/commands/status.md
@@ -39,14 +39,24 @@ Query the FTS index for counts:
 | Metric | How to check |
 |--------|-------------|
 | Sessions | `index.query({ type: 'session' }).length` |
-| Memories | `index.query({ type: 'memory' }).length` |
+| Spores | `index.query({ type: 'spore' }).length` |
 | Plans | `index.query({ type: 'plan' }).length` |
 | Artifacts | `index.query({ type: 'artifact' }).length` |
 | Embeddings | Vector index count |
 
-Also report memory breakdown by observation type (decision, gotcha, trade_off, etc.).
+Also report spore breakdown by observation type (decision, gotcha, trade_off, etc.).
 
-## Step 5: Intelligence backend health
+## Step 5: Digest status
+
+Check the digest system state:
+
+- **Enabled/disabled**: read `digest.enabled` from `myco.yaml`
+- **Extracts**: list which tier files exist in `vault/digest/` (extract-1500.md, etc.) with file sizes and generated timestamps
+- **Last cycle**: read last line of `vault/digest/trace.jsonl` — report cycle ID, timestamp, tiers generated, substrate count, duration
+- **Metabolism**: report configured tiers, inject tier, and context window
+- **Digest model**: if `digest.intelligence.model` is set, show it; otherwise note "inherits from main LLM"
+
+## Step 6: Intelligence backend health
 
 Test connectivity to the configured providers:
 
@@ -54,7 +64,7 @@ Test connectivity to the configured providers:
 - **Embedding provider**: call `isAvailable()` — report reachable or not
 - If either is unreachable, suggest running `/myco-setup-llm`
 
-## Step 6: Pending issues
+## Step 7: Pending issues
 
 Check for problems:
 
@@ -63,13 +73,13 @@ Check for problems:
 - **Missing vectors**: does `vectors.db` exist? If not, embeddings are disabled
 - **Lineage**: does `lineage.json` exist? Report link count if so
 
-## Step 7: Recent activity
+## Step 8: Recent activity
 
 Show the 3 most recent sessions with:
 - Session ID (short form)
 - Title
 - Started/ended timestamps
-- Number of memories extracted
+- Number of spores extracted
 - Parent session (if lineage detected)
 
 ## Output format
@@ -92,18 +102,26 @@ Sessions: 1 active
 
 --- Vault ---
 Sessions:  12
-Memories:  183 (67 decision, 34 gotcha, 32 trade_off, 20 discovery, 19 bug_fix, 1 cross-cutting)
+Spores:    183 (67 decision, 34 gotcha, 32 trade_off, 20 discovery, 19 bug_fix, 1 cross-cutting)
 Plans:     0
 Artifacts: 8
 Vectors:   224
+
+--- Digest ---
+Enabled:    yes
+Tiers:      [1500, 3000, 5000, 10000]
+Inject:     3000 (auto-inject at session start)
+Model:      gpt-oss (inherited from main LLM)
+Last cycle: dc-a1b2c3 (2 min ago, 4 tiers, 12 notes, 45s)
+Extracts:   1500 (1.1KB), 3000 (4.5KB), 5000 (6.9KB), 10000 (9.6KB)
 
 --- Lineage ---
 Links: 5 (3 clear, 1 inferred, 1 semantic_similarity)
 
 --- Recent Sessions ---
-1. [abc123] "Auth redesign session" (2h 15m, 5 memories)
-2. [def456] "Bug fix for CORS" (45m, 2 memories, parent: abc123)
-3. [ghi789] "Config cleanup" (20m, 1 memory)
+1. [abc123] "Auth redesign session" (2h 15m, 5 spores)
+2. [def456] "Bug fix for CORS" (45m, 2 spores, parent: abc123)
+3. [ghi789] "Config cleanup" (20m, 1 spore)
 
 --- Issues ---
 None found.

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -24,8 +24,8 @@ sequenceDiagram
     User->>Hook: Prompt submitted
     Hook->>Daemon: POST /events {user_prompt}
     Hook->>Daemon: POST /context/prompt {prompt}
-    Daemon-->>Hook: Relevant memories (vector search)
-    Hook-->>User: Memories injected
+    Daemon-->>Hook: Relevant spores (vector search)
+    Hook-->>User: Spores injected
 
     User->>Hook: Tool used
     Hook->>Daemon: POST /events {tool_use}
@@ -40,7 +40,7 @@ sequenceDiagram
     Daemon->>LLM: Summarize full conversation
     Daemon->>LLM: Classify artifacts
     Daemon->>Vault: Write session note (full rebuild from transcript)
-    Daemon->>Vault: Write memory notes
+    Daemon->>Vault: Write spore notes
     Daemon->>Vault: Write artifact notes
     Daemon->>LLM: Detect lineage (semantic similarity)
     Hook->>Daemon: POST /sessions/unregister
@@ -73,7 +73,7 @@ flowchart LR
 | Artifacts | Stop handler | ✅ `indexAndEmbed` | ✅ fire-and-forget | `{slugified-path}` |
 | Plans (file watcher) | Real-time | ✅ `indexAndEmbed` | ✅ fire-and-forget | `plan-{filename}` |
 | Wisdom notes (`myco_consolidate`) | On tool call | ✅ `indexNote` | ✅ `embedNote` | `{type}-wisdom-{hex}` |
-| Superseded memories | On supersede | ✅ (updated) | ❌ (embedding deleted) | — |
+| Superseded spores | On supersede | ✅ (updated) | ❌ (embedding deleted) | — |
 
 ### Embedding is Fire-and-Forget
 
@@ -100,7 +100,7 @@ Two injection points, each with a different purpose:
 ```mermaid
 flowchart TD
     SS[SessionStart] --> Struct[Structural Context<br/>Active plans + parent session<br/>Branch name + IDs as breadcrumbs]
-    UP[UserPromptSubmit] --> Sem[Semantic Context<br/>Vector search against prompt<br/>Top 3 relevant memories + IDs]
+    UP[UserPromptSubmit] --> Sem[Semantic Context<br/>Vector search against prompt<br/>Top 3 relevant spores + IDs]
 
     Struct --> Agent[Agent Context Window]
     Sem --> Agent
@@ -119,8 +119,8 @@ flowchart TD
 
 **Per-prompt** — injected on every prompt, targeted intelligence:
 - Vector similarity search against the prompt text (~20ms, no LLM)
-- Top 3 memories, filtered for superseded/archived
-- Each result includes the memory ID for follow-up
+- Top 3 spores, filtered for superseded/archived
+- Each result includes the spore ID for follow-up
 - Short prompts (<10 chars) skip the search
 
 ## Daemon Startup
@@ -146,7 +146,7 @@ The daemon initializes in this order:
 4. Initialize vector index (test embedding for dimensions)
 5. Initialize FTS index
 6. Initialize lineage graph
-7. Migrate flat memory files to type subdirectories (if needed)
+7. Migrate flat spore files to type subdirectories (if needed)
 8. Start plan file watcher
 9. Start HTTP server
 10. Write `daemon.json` with PID and port
@@ -175,7 +175,7 @@ If the daemon is unreachable, hooks fall back gracefully:
 | `SessionStart` | Context injection via local FTS query (no semantic search) |
 | `UserPromptSubmit` | Events buffered to disk (JSONL files), no context injection |
 | `PostToolUse` | Events buffered to disk |
-| `Stop` | Local LLM processing: session/memory writes (no embeddings, no lineage) |
+| `Stop` | Local LLM processing: session/spore writes (no embeddings, no lineage) |
 | `SessionEnd` | No-op |
 
 Buffered events are processed by the daemon when it next starts. Buffer files are cleaned up after 24 hours.

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,6 +1,6 @@
 # Daemon Lifecycle
 
-Myco runs a long-lived background daemon that processes session events, extracts observations, and maintains the vault index. The daemon is fully automatic — users never start, stop, or restart it manually.
+Myco runs a long-lived background daemon that processes session events, extracts observations (spores), maintains the vault index, and continuously synthesizes knowledge into digest extracts. The daemon is fully automatic — users never start, stop, or restart it manually.
 
 ## Session Flow
 
@@ -17,7 +17,7 @@ sequenceDiagram
     Hook->>Daemon: POST /sessions/register {session_id, branch}
     Daemon-->>Hook: Heuristic lineage detection
     Hook->>Daemon: POST /context {branch}
-    Daemon-->>Hook: Active plans + parent session
+    Daemon-->>Hook: Digest extract (or layer-based fallback)
     Hook-->>User: Context injected
 
     Note over Hook,Daemon: During Session
@@ -33,7 +33,7 @@ sequenceDiagram
     Note over Hook,Daemon: Session End (async — hook returns immediately)
     Hook->>Daemon: POST /events/stop
     Daemon-->>Hook: {ok: true}
-    Daemon->>LLM: Extract observations from last batch
+    Daemon->>LLM: Extract spores from last batch
     Daemon->>Transcript: Read agent transcript (Claude Code, Cursor)
     Note right of Transcript: Tiered: transcript → buffer fallback
     Daemon->>Vault: Write images to attachments/
@@ -45,6 +45,74 @@ sequenceDiagram
     Daemon->>LLM: Detect lineage (semantic similarity)
     Hook->>Daemon: POST /sessions/unregister
 ```
+
+## Digest System
+
+The digest engine runs continuously inside the daemon, synthesizing accumulated vault knowledge into tiered context extracts. These pre-computed summaries are served instantly at session start — no LLM call needed at read time.
+
+```mermaid
+flowchart TD
+    Timer[Metabolism Timer] --> Check{New<br/>Substrate?}
+    Check -->|Yes| Discover[Discover Substrate<br/>updatedSince filter]
+    Check -->|No| Backoff[Metabolic Slowdown<br/>15m → 30m → 1h → dormancy]
+    Discover --> Load[Load Model<br/>ensureLoaded with context_window]
+    Load --> Tiers[Generate Extracts<br/>Sequential: 1500 → 3000 → 5000 → 10000]
+    Tiers --> Write[Write Extracts<br/>vault/digest/extract-tier.md]
+    Write --> Trace[Append Trace<br/>vault/digest/trace.jsonl]
+    Trace --> Reset[Reset to Active Metabolism]
+
+    Session[New Session Registered] --> Activate[Activate Metabolism]
+    Activate --> Timer
+
+    style Timer fill:#e8f5e9
+    style Backoff fill:#fff3e0
+    style Tiers fill:#e1f5fe
+```
+
+### Metabolism States
+
+The digest engine adapts its processing rate based on activity:
+
+| State | Interval | Trigger |
+|-------|----------|---------|
+| **Active** | 5 minutes | Substrate found, or session registered |
+| **Cooling** | 15m → 30m → 1h | Empty cycles (no new substrate) |
+| **Dormant** | Suspended | No substrate for 2+ hours |
+
+New session registrations activate the metabolism from any state.
+
+### Tiered Extracts
+
+Each tier serves a different use case and gets its own purpose-built prompt:
+
+| Tier | Character | Use Case |
+|------|-----------|----------|
+| **1,500** | Executive briefing | Quick orientation — what is this, what's active, what to avoid |
+| **3,000** | Team standup | Enough to start contributing — decisions, plans, conventions |
+| **5,000** | Deep onboarding | Full context — trade-offs, patterns, team dynamics |
+| **10,000** | Institutional knowledge | Everything — thread history, design tensions, lessons learned |
+
+### Context Injection with Digest
+
+When digest is enabled, the session-start hook serves the pre-computed extract instead of the layer-based system:
+
+```mermaid
+flowchart TD
+    Start[Session Start] --> DigestEnabled{Digest<br/>Enabled?}
+    DigestEnabled -->|Yes| ExtractExists{Extract<br/>File Exists?}
+    ExtractExists -->|Yes| Inject[Inject Digest Extract<br/>at configured tier]
+    ExtractExists -->|No| Fallback[Layer-Based Injection<br/>plans + sessions + spores + team]
+    DigestEnabled -->|No| Fallback
+
+    Prompt[User Prompt] --> VectorSearch[Vector Search<br/>Top 3 relevant spores]
+    VectorSearch --> InjectSpores[Inject Spores<br/>per-prompt context]
+
+    style Inject fill:#e8f5e9
+    style Fallback fill:#fff3e0
+    style InjectSpores fill:#fff3e0
+```
+
+Per-prompt spore injection continues unchanged alongside digest — the extract provides the big picture, spore injection provides targeted relevance for each specific prompt.
 
 ## Indexing & Embedding Pipeline
 
@@ -67,13 +135,13 @@ flowchart LR
 
 | Content | When | FTS Indexed | Embedded | Vector ID |
 |---------|------|-------------|----------|-----------|
-| Session notes | Stop handler | ✅ `indexAndEmbed` | ✅ fire-and-forget | `session-{id}` |
-| Observations (daemon) | Stop handler | ✅ `indexAndEmbed` | ✅ fire-and-forget | `{type}-{session}-{ts}` |
-| Observations (MCP `myco_remember`) | On tool call | ✅ `indexNote` | ✅ `embedNote` | `{type}-{hex}` |
-| Artifacts | Stop handler | ✅ `indexAndEmbed` | ✅ fire-and-forget | `{slugified-path}` |
-| Plans (file watcher) | Real-time | ✅ `indexAndEmbed` | ✅ fire-and-forget | `plan-{filename}` |
-| Wisdom notes (`myco_consolidate`) | On tool call | ✅ `indexNote` | ✅ `embedNote` | `{type}-wisdom-{hex}` |
-| Superseded spores | On supersede | ✅ (updated) | ❌ (embedding deleted) | — |
+| Session notes | Stop handler | indexAndEmbed | fire-and-forget | `session-{id}` |
+| Spores (daemon) | Stop handler | indexAndEmbed | fire-and-forget | `{type}-{session}-{ts}` |
+| Spores (MCP `myco_remember`) | On tool call | indexNote | embedNote | `{type}-{hex}` |
+| Artifacts | Stop handler | indexAndEmbed | fire-and-forget | `{slugified-path}` |
+| Plans (file watcher) | Real-time | indexAndEmbed | fire-and-forget | `plan-{filename}` |
+| Wisdom notes (`myco_consolidate`) | On tool call | indexNote | embedNote | `{type}-wisdom-{hex}` |
+| Superseded spores | On supersede | updated | embedding deleted | — |
 
 ### Embedding is Fire-and-Forget
 
@@ -99,7 +167,7 @@ Two injection points, each with a different purpose:
 
 ```mermaid
 flowchart TD
-    SS[SessionStart] --> Struct[Structural Context<br/>Active plans + parent session<br/>Branch name + IDs as breadcrumbs]
+    SS[SessionStart] --> Struct[Digest Extract<br/>Pre-computed project understanding<br/>or layer-based fallback]
     UP[UserPromptSubmit] --> Sem[Semantic Context<br/>Vector search against prompt<br/>Top 3 relevant spores + IDs]
 
     Struct --> Agent[Agent Context Window]
@@ -111,11 +179,10 @@ flowchart TD
     style Sem fill:#fff3e0
 ```
 
-**Session start** — injected once, structural framing:
-- Active plans (what's in flight)
-- Parent session summary (lineage continuity)
-- Git branch name
-- IDs as breadcrumbs for MCP tool follow-up
+**Session start** — injected once, project understanding:
+- Digest extract at the configured tier (when digest is enabled and extracts exist)
+- Fallback: active plans, parent session summary, git branch, IDs as breadcrumbs
+- Session ID and branch name always appended
 
 **Per-prompt** — injected on every prompt, targeted intelligence:
 - Vector similarity search against the prompt text (~20ms, no LLM)
@@ -136,6 +203,7 @@ flowchart TD
     Ready -->|No| Degraded[Degraded Mode<br/>Local FTS only]
     Register --> Lineage[Heuristic Lineage Detection]
     Register --> Context[Inject Session Context]
+    Register --> Activate[Activate Digest Metabolism]
 ```
 
 The daemon initializes in this order:
@@ -147,9 +215,11 @@ The daemon initializes in this order:
 5. Initialize FTS index
 6. Initialize lineage graph
 7. Migrate flat spore files to type subdirectories (if needed)
-8. Start plan file watcher
-9. Start HTTP server
-10. Write `daemon.json` with PID and port
+8. Migrate `memories/` → `spores/` (if upgrading from older version)
+9. Start plan file watcher
+10. Initialize digest engine + metabolism (if enabled)
+11. Start HTTP server
+12. Write `daemon.json` with PID and port
 
 ## Shutdown
 
@@ -161,7 +231,7 @@ flowchart LR
     Grace --> Check{New Session<br/>Registered?}
     Check -->|Yes| Cancel[Cancel Timer]
     Check -->|No| Shutdown[Clean Shutdown]
-    Shutdown --> Close[Close Indexes<br/>Stop Watchers<br/>Flush Logs]
+    Shutdown --> Close[Close Indexes<br/>Stop Watchers<br/>Stop Metabolism<br/>Flush Logs]
 ```
 
 The grace period prevents the daemon from cycling on/off during rapid session reloads (e.g., clearing context → new session within seconds).
@@ -172,7 +242,7 @@ If the daemon is unreachable, hooks fall back gracefully:
 
 | Hook | Degraded behavior |
 |------|-------------------|
-| `SessionStart` | Context injection via local FTS query (no semantic search) |
+| `SessionStart` | Context injection via local FTS query (no digest, no semantic search) |
 | `UserPromptSubmit` | Events buffered to disk (JSONL files), no context injection |
 | `PostToolUse` | Events buffered to disk |
 | `Stop` | Local LLM processing: session/spore writes (no embeddings, no lineage) |
@@ -195,18 +265,41 @@ daemon:
   log_level: info          # debug | info | warn | error
   grace_period: 30         # seconds before shutdown after last session ends
   max_log_size: 5242880    # log rotation threshold (bytes)
+
+capture:
+  extraction_max_tokens: 2048    # spore extraction budget per batch
+  summary_max_tokens: 1024       # session summary budget
+  title_max_tokens: 32           # session title budget
+  classification_max_tokens: 1024 # artifact classification budget
+
+digest:
+  enabled: true                          # opt-out (enabled by default)
+  tiers: [1500, 3000, 5000, 10000]       # which tiers to generate
+  inject_tier: 3000                      # auto-inject at session start
+  intelligence:
+    provider: null                       # null = inherit from main LLM
+    model: null                          # null = inherit from main LLM
+    context_window: 32768                # override for digest operations
+    keep_alive: 30m                      # keep model loaded (Ollama)
+    gpu_kv_cache: false                  # KV cache in RAM (LM Studio)
+  metabolism:
+    active_interval: 300                 # seconds between active cycles
+    cooldown_intervals: [900, 1800, 3600] # backoff schedule (seconds)
+    dormancy_threshold: 7200             # seconds before dormancy
+  substrate:
+    max_notes_per_cycle: 50              # cap substrate per cycle
 ```
 
 ## Monitoring
 
 ```bash
-node dist/src/cli.js stats    # PID, port, active sessions, vault stats
+node dist/src/cli.js stats    # PID, port, active sessions, vault stats, digest status
 node dist/src/cli.js logs     # Tail daemon + MCP activity logs
 ```
 
 Or via MCP:
 ```json
-{ "tool": "myco_logs", "level": "info", "component": "lifecycle" }
+{ "tool": "myco_logs", "level": "info", "component": "digest" }
 ```
 
 ## Files
@@ -221,6 +314,8 @@ Or via MCP:
 | `logs/mcp.jsonl` | MCP tool activity log |
 | `buffer/*.jsonl` | Per-session event buffers (ephemeral) |
 | `attachments/*.png` | Images extracted from session transcripts (Obsidian embeds) |
+| `digest/extract-*.md` | Pre-computed context extracts per tier |
+| `digest/trace.jsonl` | Digest cycle audit trail |
 
 ## Transcript Sourcing
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -104,13 +104,13 @@ Open your vault directory in Obsidian (e.g., `~/.myco/vaults/myco/`). You'll see
 
 ```
 sessions/          → Session notes organized by date
-memories/          → Observations organized by type (decisions, gotchas, etc.)
+spores/            → Observations organized by type (decisions, gotchas, etc.)
 plans/             → Plan documents
 artifacts/         → Captured design docs and specs
 _dashboard.md      → Dataview-powered overview (requires Dataview plugin)
 ```
 
-Use the graph view to see how sessions, memories, and plans connect through backlinks.
+Use the graph view to see how sessions, spores, and plans connect through backlinks.
 
 ### From the CLI
 
@@ -126,7 +126,7 @@ Myco exposes these tools to your coding agent via MCP:
 
 | Tool | What it does |
 |------|-------------|
-| `myco_recall` | Retrieve relevant memories for the current context |
+| `myco_recall` | Retrieve relevant spores for the current context |
 | `myco_remember` | Capture a new observation or decision |
 | `myco_search` | Search the vault by keyword or semantic similarity |
 | `myco_sessions` | List recent sessions with summaries |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ Myco is a collective agent intelligence plugin that captures session knowledge â
 ## Requirements
 
 - **Node.js 22+**
-- **Local LLM** (recommended): [Ollama](https://ollama.com) with `gpt-oss` and `bge-m3` models, or [LM Studio](https://lmstudio.ai)
+- **Local LLM** (recommended): [Ollama](https://ollama.com) with `qwen3.5` and `bge-m3` models, or [LM Studio](https://lmstudio.ai)
 - **Cloud LLM** (alternative): Anthropic API key for Claude Haiku
 - **Obsidian** (optional): For browsing your vault with backlinks, Dataview, and graph view
 
@@ -82,7 +82,7 @@ This guides you through:
 ### Pull Ollama Models (if using local LLM)
 
 ```bash
-ollama pull gpt-oss
+ollama pull qwen3.5
 ollama pull bge-m3
 ```
 

--- a/docs/superpowers/plans/2026-03-19-digest-continuous-reasoning.md
+++ b/docs/superpowers/plans/2026-03-19-digest-continuous-reasoning.md
@@ -1,0 +1,1673 @@
+# Digest: Continuous Reasoning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add continuous reasoning (Digest) to the Myco daemon that synthesizes vault knowledge into tiered context extracts, and rename memories → spores across the codebase.
+
+**Architecture:** Two phases — (1) rename memory/memories to spore/spores throughout types, vault, tools, and tests, with a runtime vault migration; (2) build the Digest engine as a daemon task with adaptive timer, tiered prompt pipeline, MCP tool, and session-start injection.
+
+**Tech Stack:** TypeScript, Zod schemas, SQLite FTS5/sqlite-vec, Vitest, Ollama/LM Studio/Anthropic LLM backends.
+
+**Spec:** `docs/superpowers/specs/2026-03-19-digest-continuous-reasoning-design.md`
+
+---
+
+## Phase 1: Spore Migration (memories → spores)
+
+### Task 1: Rename Core Types
+
+**Files:**
+- Modify: `src/vault/types.ts`
+- Test: `tests/vault/types.test.ts`
+
+- [ ] **Step 1: Update the schema and type exports in types.ts**
+
+Rename in `src/vault/types.ts`:
+- `MemoryFrontmatterSchema` → `SporeFrontmatterSchema`
+- `type: z.literal('memory')` → `type: z.literal('spore')`
+- `MemoryFrontmatter` → `SporeFrontmatter`
+- `MEMORY_STATUSES` → `SPORE_STATUSES`
+- `MemoryStatus` → `SporeStatus`
+
+Keep `OBSERVATION_TYPES` unchanged (those describe the observation, not the container).
+
+Also update `schemasByType` map (line ~92):
+- `memory: MemoryFrontmatterSchema` → `spore: SporeFrontmatterSchema`
+
+This map is used by `parseNoteFrontmatter()` — if not updated, all spore note parsing will fail with `Unknown note type: spore`.
+
+- [ ] **Step 2: Update tests in types.test.ts**
+
+Find all references to `Memory`/`memory` in test descriptions and assertions. Update schema names and `type: 'memory'` → `type: 'spore'` in test fixtures.
+
+- [ ] **Step 3: Run tests to verify**
+
+Run: `npx vitest run tests/vault/types.test.ts`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/vault/types.ts tests/vault/types.test.ts
+git commit -m "refactor: rename MemoryFrontmatterSchema to SporeFrontmatterSchema"
+```
+
+---
+
+### Task 2: Rename Writer and Frontmatter Helpers
+
+**Files:**
+- Modify: `src/vault/writer.ts`
+- Modify: `src/vault/frontmatter.ts`
+- Test: `tests/vault/writer.test.ts`
+
+- [ ] **Step 1: Update writer.ts**
+
+Rename in `src/vault/writer.ts`:
+- `WriteMemoryInput` → `WriteSporeInput`
+- `writeMemory(input: WriteMemoryInput)` → `writeSpore(input: WriteSporeInput)`
+- Path: `memories/${normalizedType}` → `spores/${normalizedType}`
+- `buildTags('memory', ...)` → `buildTags('spore', ...)`
+- Update import from types.ts to use new names
+
+- [ ] **Step 2: Update frontmatter.ts**
+
+Rename in `src/vault/frontmatter.ts`:
+- `memoryFm()` → `sporeFm()`
+- Import `SporeFrontmatter` instead of `MemoryFrontmatter`
+- Return type: `SporeFrontmatter`
+
+- [ ] **Step 3: Update writer tests**
+
+In `tests/vault/writer.test.ts`:
+- Rename `writeMemory` → `writeSpore` in all calls and descriptions
+- Update expected paths from `memories/` → `spores/`
+- Update expected frontmatter `type: 'memory'` → `type: 'spore'`
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run tests/vault/writer.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vault/writer.ts src/vault/frontmatter.ts tests/vault/writer.test.ts
+git commit -m "refactor: rename writeMemory to writeSpore, memoryFm to sporeFm"
+```
+
+---
+
+### Task 3: Rename Formatter and Observations
+
+**Files:**
+- Modify: `src/obsidian/formatter.ts`
+- Modify: `src/vault/observations.ts`
+- Test: `tests/obsidian/formatter.test.ts` (if exists)
+- Test: `tests/vault/observations.test.ts` (if exists)
+
+- [ ] **Step 1: Update formatter.ts**
+
+Rename in `src/obsidian/formatter.ts`:
+- `MemoryBodyInput` → `SporeBodyInput`
+- `formatMemoryBody()` → `formatSporeBody()`
+- `buildTags()`: update `'memory'` references to `'spore'` if present in tag generation
+
+- [ ] **Step 2: Update observations.ts**
+
+Rename in `src/vault/observations.ts`:
+- `formatMemoryBody()` → `formatSporeBody()` calls
+- `writer.writeMemory()` → `writer.writeSpore()` calls
+- Update imports
+
+- [ ] **Step 3: Update tests for formatter and observations**
+
+Update any test files that reference `MemoryBodyInput`, `formatMemoryBody`, or `writeMemory` in observation context.
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run`
+Expected: PASS (catch any remaining import breakage across all tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/obsidian/formatter.ts src/vault/observations.ts
+git add -A tests/
+git commit -m "refactor: rename formatMemoryBody to formatSporeBody, update observations"
+```
+
+---
+
+### Task 4: Rename Constants and Config Schema
+
+**Files:**
+- Modify: `src/constants.ts`
+- Modify: `src/config/schema.ts`
+
+- [ ] **Step 1: Update constants.ts**
+
+Rename in `src/constants.ts`:
+- `CONTEXT_MEMORY_PREVIEW_CHARS` → `CONTEXT_SPORE_PREVIEW_CHARS`
+- `RELATED_MEMORIES_LIMIT` → `RELATED_SPORES_LIMIT`
+- `PROMPT_CONTEXT_MAX_MEMORIES` → `PROMPT_CONTEXT_MAX_SPORES`
+- Grep for any other `MEMORY`/`MEMORIES` constants and rename
+
+- [ ] **Step 2: Update config schema**
+
+In `src/config/schema.ts`, rename the `ContextLayersSchema` key:
+```typescript
+const ContextLayersSchema = z.object({
+  plans: z.number().int().nonnegative().default(200),
+  sessions: z.number().int().nonnegative().default(500),
+  spores: z.number().int().nonnegative().default(300),  // was: memories
+  team: z.number().int().nonnegative().default(200),
+});
+```
+
+Update the `ContextSchema` default to match:
+```typescript
+layers: ContextLayersSchema.default({ plans: 200, sessions: 500, spores: 300, team: 200 }),
+```
+
+- [ ] **Step 3: Fix all importers of renamed constants**
+
+Grep for old constant names across the codebase and update imports. Key files: `src/context/injector.ts`, `src/hooks/user-prompt-submit.ts`, `src/daemon/main.ts`.
+
+- [ ] **Step 4: Run type check**
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors (catches all broken references)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/constants.ts src/config/schema.ts
+git add -A src/
+git commit -m "refactor: rename memory constants and config keys to spore"
+```
+
+---
+
+### Task 5: Update Context Injector
+
+**Files:**
+- Modify: `src/context/injector.ts`
+- Test: `tests/context/injector.test.ts`
+
+- [ ] **Step 1: Update injector.ts**
+
+In `src/context/injector.ts`:
+- `InjectedContext.layers.memories` → `InjectedContext.layers.spores`
+- Query filter: `type: 'memory'` → `type: 'spore'`
+- Layer heading: `memories` → `spores` (or `Relevant Spores` etc.)
+- Import renamed constants (`CONTEXT_SPORE_PREVIEW_CHARS`, etc.)
+- Update `sporeFm()` import (was `memoryFm()`)
+- Status filter for `superseded`/`archived` stays the same
+
+- [ ] **Step 2: Update injector tests**
+
+In `tests/context/injector.test.ts`:
+- Update fixtures: `type: 'memory'` → `type: 'spore'`
+- Update assertions: `.layers.memories` → `.layers.spores`
+- Update descriptions
+
+- [ ] **Step 3: Run tests**
+
+Run: `npx vitest run tests/context/injector.test.ts`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/context/injector.ts tests/context/injector.test.ts
+git commit -m "refactor: update context injector for spore terminology"
+```
+
+---
+
+### Task 6: Update MCP Tools
+
+**Files:**
+- Modify: `src/mcp/tool-definitions.ts`
+- Modify: `src/mcp/server.ts`
+- Modify: `src/mcp/tools/remember.ts`
+- Modify: `src/mcp/tools/supersede.ts`
+- Modify: `src/mcp/tools/consolidate.ts`
+- Modify: `src/mcp/tools/recall.ts`
+- Modify: `src/mcp/tools/search.ts`
+- Test: `tests/mcp/tools/remember.test.ts`
+- Test: other MCP tool tests
+
+- [ ] **Step 1: Update tool-definitions.ts**
+
+Tool names stay the same (`myco_remember`, `myco_recall`, etc.). Update descriptions and parameter names:
+- `old_memory_id` → `old_spore_id` in supersede schema
+- `new_memory_id` → `new_spore_id` in supersede schema
+- `source_memory_ids` → `source_spore_ids` in consolidate schema
+- Update description text: "memory" → "spore" where it appears in user-facing descriptions
+
+- [ ] **Step 2: Update remember.ts**
+
+- `writer.writeMemory()` → `writer.writeSpore()`
+- `RememberInput` type stays (it's the tool's input, not tied to the type name)
+- Update imports
+
+- [ ] **Step 3: Update supersede.ts**
+
+- `input.old_memory_id` → `input.old_spore_id`
+- `input.new_memory_id` → `input.new_spore_id`
+- `status: 'superseded'` stays (it's a status, not a type name)
+- Update callout text
+
+- [ ] **Step 4: Update consolidate.ts**
+
+- `input.source_memory_ids` → `input.source_spore_ids`
+- `wisdomId` naming stays
+- `writer.writeMemory()` → `writer.writeSpore()`
+- Update callout text
+
+- [ ] **Step 5: Update server.ts**
+
+- Vector metadata: `{ type: 'memory' }` → `{ type: 'spore' }` in `embedNote()` calls
+- Update any log messages
+
+- [ ] **Step 6: Update recall.ts and search.ts**
+
+- Query filters: `type: 'memory'` → `type: 'spore'`
+- Response formatting: update labels
+
+- [ ] **Step 7: Update MCP tool tests**
+
+Update all test fixtures and assertions: `writeMemory` → `writeSpore`, `type: 'memory'` → `type: 'spore'`, parameter names.
+
+- [ ] **Step 8: Run tests**
+
+Run: `npx vitest run tests/mcp/`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/mcp/ tests/mcp/
+git commit -m "refactor: update MCP tools for spore terminology"
+```
+
+---
+
+### Task 7: Update CLI and Daemon
+
+**Files:**
+- Modify: `src/cli/stats.ts`
+- Modify: `src/cli/rebuild.ts`
+- Modify: `src/cli/reprocess.ts`
+- Modify: `src/cli/init.ts`
+- Modify: `src/daemon/main.ts`
+- Modify: `src/vault/reader.ts`
+
+- [ ] **Step 1: Update vault reader**
+
+In `src/vault/reader.ts`:
+- `readAllNotes()` subdirectories: `'memories'` → `'spores'`
+
+- [ ] **Step 2: Update CLI files**
+
+In `src/cli/stats.ts`:
+- `index.query({ type: 'memory' })` → `index.query({ type: 'spore' })`
+- Update display labels
+
+In `src/cli/rebuild.ts`:
+- Vector metadata `type: 'memory'` → `type: 'spore'`
+- Status filter comments
+
+In `src/cli/reprocess.ts`:
+- `writeObservationNotes()` already updated via observations.ts
+- Any direct `type: 'memory'` references
+
+In `src/cli/init.ts`:
+- Any `memories` directory creation → `spores`
+
+- [ ] **Step 3: Update daemon main.ts**
+
+In `src/daemon/main.ts`:
+- `migrateMemoryFiles()` → `migrateSporeFiles()` (rename function)
+- Update path references: `memories/` → `spores/`
+- `writeObservations()` metadata: `{ type: 'memory' }` → `{ type: 'spore' }`
+- Update log messages
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `npx vitest run`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/ src/daemon/main.ts src/vault/reader.ts
+git commit -m "refactor: update CLI, daemon, and reader for spore terminology"
+```
+
+---
+
+### Task 8: Update Prompts and Vault Migration
+
+**Files:**
+- Modify: `src/prompts/extraction.md`
+- Modify: `src/daemon/main.ts` (add vault migration)
+
+- [ ] **Step 1: Update extraction prompt**
+
+In `src/prompts/extraction.md`:
+- Update any references to "memory" or "memories" to "spore" or "spores" in the prompt text
+- The JSON output schema (observation types) stays the same — those are observation types, not container types
+
+- [ ] **Step 2: Add vault migration to daemon startup**
+
+In `src/daemon/main.ts`, add a `migrateMemoriesToSpores()` function called during startup (after existing `migrateSporeFiles()`):
+
+```typescript
+async function migrateMemoriesToSpores(vaultDir: string, index: MycoIndex): Promise<number> {
+  const memoriesDir = path.join(vaultDir, 'memories');
+  const sporesDir = path.join(vaultDir, 'spores');
+
+  // Skip if already migrated (spores exists, memories doesn't)
+  if (!fs.existsSync(memoriesDir)) return 0;
+
+  if (fs.existsSync(sporesDir)) {
+    // Both exist (interrupted migration) — merge remaining files
+    // Walk memories/, move any files not already in spores/
+    const moveRemaining = (srcDir: string, destDir: string) => {
+      for (const entry of fs.readdirSync(srcDir, { withFileTypes: true })) {
+        const srcPath = path.join(srcDir, entry.name);
+        const destPath = path.join(destDir, entry.name);
+        if (entry.isDirectory()) {
+          if (!fs.existsSync(destPath)) fs.mkdirSync(destPath, { recursive: true });
+          moveRemaining(srcPath, destPath);
+        } else if (!fs.existsSync(destPath)) {
+          fs.renameSync(srcPath, destPath);
+        }
+        // Skip files that already exist in destination (deduplicate by path)
+      }
+    };
+    moveRemaining(memoriesDir, sporesDir);
+    // Clean up empty memories/ directory
+    fs.rmSync(memoriesDir, { recursive: true, force: true });
+  } else {
+    // Clean migration — rename directory
+    fs.renameSync(memoriesDir, sporesDir);
+  }
+
+  // Walk all .md files, update frontmatter type: 'memory' → type: 'spore'
+  let count = 0;
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) { walk(fullPath); continue; }
+      if (!entry.name.endsWith('.md')) continue;
+      const content = fs.readFileSync(fullPath, 'utf-8');
+      if (content.includes('type: memory')) {
+        fs.writeFileSync(fullPath, content.replace(/type: memory/g, 'type: spore'));
+        count++;
+      }
+    }
+  };
+  walk(sporesDir);
+
+  // Trigger full reindex — type field changed in all migrated notes.
+  // Read all spore files and re-index them so the SQLite index
+  // reflects type: 'spore' instead of stale type: 'memory'.
+  const reader = new VaultReader(vaultDir);
+  const sporeNotes = reader.listNotes('spores');
+  for (const note of sporeNotes) {
+    indexNote(index, vaultDir, note.path);
+  }
+
+  return count;
+}
+```
+
+- [ ] **Step 3: Call migration on daemon startup**
+
+Add the call in the startup sequence, before index rebuild:
+```typescript
+const migrated = await migrateMemoriesToSpores(vaultDir, index);
+if (migrated > 0) log.info(`Migrated ${migrated} memories → spores`);
+```
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `make check`
+Expected: PASS (lint + tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/prompts/extraction.md src/daemon/main.ts
+git commit -m "refactor: add vault migration memories→spores, update extraction prompt"
+```
+
+---
+
+### Task 9: Update CLAUDE.md and Remaining References
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Any remaining files found by grep
+
+- [ ] **Step 1: Grep for remaining references**
+
+Run: `grep -rn "memory\|Memory\|memories" src/ --include="*.ts" | grep -v node_modules | grep -v dist`
+
+Fix any remaining references not yet addressed.
+
+- [ ] **Step 2: Update CLAUDE.md**
+
+In `CLAUDE.md`, update:
+- Vault Structure section: `memories/` → `spores/`
+- Naming Conventions: `memories/{normalized_type}/` → `spores/{normalized_type}/`
+- Data Preservation: `writeMemory` → `writeSpore`
+- Idempotence: `writeMemory` → `writeSpore`
+- Any other `memory`/`memories` references
+
+- [ ] **Step 3: Run full quality gate**
+
+Run: `make check`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git add -A src/ tests/
+git commit -m "refactor: complete spore rename — update CLAUDE.md and remaining references"
+```
+
+---
+
+## Phase 2: Digest System
+
+### Task 10: Add Digest Config Schema
+
+**Files:**
+- Modify: `src/config/schema.ts`
+- Test: `tests/config/schema.test.ts` (if exists)
+
+- [ ] **Step 1: Write failing test for digest config parsing**
+
+```typescript
+describe('DigestSchema', () => {
+  it('should parse digest config with defaults', () => {
+    const config = MycoConfigSchema.parse({ version: 2 });
+    expect(config.digest.enabled).toBe(true);
+    expect(config.digest.tiers).toEqual([1500, 3000, 5000, 10000]);
+    expect(config.digest.inject_tier).toBe(3000);
+    expect(config.digest.metabolism.active_interval).toBe(300);
+    expect(config.digest.metabolism.dormancy_threshold).toBe(7200);
+    expect(config.digest.substrate.max_notes_per_cycle).toBe(50);
+  });
+
+  it('should allow intelligence override with nullable fields', () => {
+    const config = MycoConfigSchema.parse({
+      version: 2,
+      digest: {
+        intelligence: {
+          model: 'qwen3.5-30b',
+          context_window: 32768,
+        },
+      },
+    });
+    expect(config.digest.intelligence.model).toBe('qwen3.5-30b');
+    expect(config.digest.intelligence.provider).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/config/`
+Expected: FAIL — `digest` not in schema
+
+- [ ] **Step 3: Add DigestSchema to config/schema.ts**
+
+```typescript
+const DigestIntelligenceSchema = z.object({
+  provider: z.enum(['ollama', 'lm-studio', 'anthropic']).nullable().default(null),
+  model: z.string().nullable().default(null),
+  base_url: z.string().nullable().default(null),
+  context_window: z.number().int().positive().default(32768),
+});
+
+const DigestMetabolismSchema = z.object({
+  active_interval: z.number().int().positive().default(300),
+  cooldown_intervals: z.array(z.number().int().positive()).default([900, 1800, 3600]),
+  dormancy_threshold: z.number().int().positive().default(7200),
+});
+
+const DigestSubstrateSchema = z.object({
+  max_notes_per_cycle: z.number().int().positive().default(50),
+});
+
+const DigestSchema = z.object({
+  enabled: z.boolean().default(true),
+  tiers: z.array(z.number().int().positive()).default([1500, 3000, 5000, 10000]),
+  inject_tier: z.number().int().positive().nullable().default(3000),
+  intelligence: DigestIntelligenceSchema.default({}),
+  metabolism: DigestMetabolismSchema.default({}),
+  substrate: DigestSubstrateSchema.default({}),
+});
+```
+
+Add `digest: DigestSchema.default({})` to `MycoConfigSchema`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/config/`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/schema.ts tests/config/
+git commit -m "feat: add digest config schema with metabolism, intelligence, substrate sections"
+```
+
+---
+
+### Task 11: Extend QueryOptions with updatedSince
+
+**Files:**
+- Modify: `src/index/sqlite.ts`
+- Test: `tests/index/sqlite.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+describe('query with updatedSince', () => {
+  it('should filter notes by updated_at', async () => {
+    // Insert two notes with different updated_at timestamps
+    index.upsertNote({ path: 'old.md', type: 'spore', id: 'old', title: 'Old', content: '', frontmatter: {}, created: '2026-03-01' });
+    // Wait a tick so updated_at differs
+    index.upsertNote({ path: 'new.md', type: 'spore', id: 'new', title: 'New', content: '', frontmatter: {}, created: '2026-03-02' });
+
+    const oldTimestamp = '2026-03-01T12:00:00Z';
+    const results = index.query({ updatedSince: oldTimestamp });
+    // Should return notes updated after the timestamp
+    expect(results.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/index/sqlite.test.ts`
+Expected: FAIL — `updatedSince` not recognized
+
+- [ ] **Step 3: Add updatedSince to QueryOptions and query()**
+
+In `src/index/sqlite.ts`:
+
+```typescript
+export interface QueryOptions {
+  type?: string;
+  id?: string;
+  limit?: number;
+  since?: string;        // existing: filters on created
+  updatedSince?: string; // new: filters on updated_at
+  frontmatter?: Record<string, string>;
+}
+```
+
+In the `query()` method, add after the `since` filter:
+```typescript
+if (options.updatedSince) {
+  conditions.push('updated_at >= ?');
+  params.push(options.updatedSince);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/index/sqlite.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index/sqlite.ts tests/index/sqlite.test.ts
+git commit -m "feat: add updatedSince filter to QueryOptions for substrate discovery"
+```
+
+---
+
+### Task 12: Add Digest Constants
+
+**Files:**
+- Modify: `src/constants.ts`
+
+- [ ] **Step 1: Add digest-related named constants**
+
+```typescript
+// Digest — Metabolism
+export const DIGEST_ACTIVE_INTERVAL_MS = 300_000;           // 5 min
+export const DIGEST_COOLDOWN_INTERVALS_MS = [900_000, 1_800_000, 3_600_000]; // 15m, 30m, 1h
+export const DIGEST_DORMANCY_THRESHOLD_MS = 7_200_000;      // 2 hours
+export const DIGEST_ACTIVE_SESSION_WINDOW_MS = 1_800_000;   // 30 min — sessions within this are "active"
+
+// Digest — Tiers
+export const DIGEST_TIERS = [1500, 3000, 5000, 10000] as const;
+export type DigestTier = (typeof DIGEST_TIERS)[number];
+
+// Digest — Context window minimums per tier (from spec table)
+export const DIGEST_TIER_MIN_CONTEXT: Record<number, number> = {
+  1500: 6500,
+  3000: 11500,
+  5000: 18500,
+  10000: 30500,
+};
+
+// Digest — Substrate
+export const DIGEST_MAX_NOTES_PER_CYCLE = 50;
+export const DIGEST_SUBSTRATE_TYPE_WEIGHTS: Record<string, number> = {
+  session: 3,
+  spore: 3,
+  plan: 2,
+  artifact: 1,
+  team: 1,
+};
+
+// Digest — System prompt overhead estimate
+export const DIGEST_SYSTEM_PROMPT_TOKENS = 500;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/constants.ts
+git commit -m "feat: add digest constants — metabolism, tiers, substrate weights"
+```
+
+---
+
+### Task 13: Create Digest Prompt Templates
+
+**Files:**
+- Create: `src/prompts/digest-system.md`
+- Create: `src/prompts/digest-1500.md`
+- Create: `src/prompts/digest-3000.md`
+- Create: `src/prompts/digest-5000.md`
+- Create: `src/prompts/digest-10000.md`
+
+- [ ] **Step 1: Create shared system prompt**
+
+Create `src/prompts/digest-system.md`:
+```markdown
+You are Myco's digest engine. Your role is to maintain a living understanding
+of a software project by synthesizing observations, session histories, plans,
+and team activity into a coherent context representation.
+
+You will receive:
+1. Your previous synthesis (if one exists)
+2. New substrate — recently captured knowledge that needs to be incorporated
+
+Produce an updated synthesis that:
+- Integrates the new substrate into your existing understanding
+- Stays within the specified token budget
+- Is written for an AI agent that will use this as its primary project context
+- Uses present tense for active state, past tense for completed work
+- Never fabricates — only synthesize from provided data
+- Uses markdown formatting for structure and readability
+```
+
+- [ ] **Step 2: Create tier-specific prompts**
+
+Create `src/prompts/digest-1500.md`:
+```markdown
+Budget: ~1,500 tokens. This is the smallest representation.
+Prioritize ruthlessly:
+- What is this project? (1-2 sentences)
+- What is actively being worked on right now?
+- What are the critical gotchas or blockers?
+- Who is working on it? (if known)
+
+Drop: historical decisions, completed work, trade-off reasoning, conventions.
+An agent reading this should immediately know what it's walking into.
+```
+
+Create `src/prompts/digest-3000.md`:
+```markdown
+Budget: ~3,000 tokens.
+Include everything from the briefing tier, plus:
+- Recent activity narrative (what happened in the last few sessions)
+- Key decisions made and why
+- Active plans and their status
+- Important conventions or patterns the agent should follow
+
+Drop: deep trade-off reasoning, exhaustive history, edge case wisdom.
+An agent reading this should be able to start contributing meaningfully.
+```
+
+Create `src/prompts/digest-5000.md`:
+```markdown
+Budget: ~5,000 tokens.
+Include everything from the standup tier, plus:
+- Accumulated wisdom: recurring gotchas, established patterns
+- Trade-off reasoning behind key architectural decisions
+- Cross-cutting concerns that affect multiple areas
+- Team member specialties and working patterns
+
+Drop: exhaustive historical detail, completed-and-closed threads.
+An agent reading this should understand not just what to do, but why things are the way they are.
+```
+
+Create `src/prompts/digest-10000.md`:
+```markdown
+Budget: ~10,000 tokens.
+The full picture. Include everything from the onboarding tier, plus:
+- Complete thread histories for active and recently completed work
+- Detailed trade-off analysis and alternatives that were rejected
+- Plan evolution — what changed and why
+- Artifact summaries and their significance
+- Lessons learned from past incidents
+
+An agent reading this should have the equivalent of months of project context.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/prompts/digest-system.md src/prompts/digest-1500.md src/prompts/digest-3000.md src/prompts/digest-5000.md src/prompts/digest-10000.md
+git commit -m "feat: add digest prompt templates — system + 4 tier-specific prompts"
+```
+
+---
+
+### Task 14: Build Digest Engine Core
+
+**Files:**
+- Create: `src/daemon/digest.ts`
+- Test: `tests/daemon/digest.test.ts`
+
+This is the largest task. It builds the `DigestEngine` class with substrate discovery, prompt assembly, cycle pipeline, and extract writing.
+
+- [ ] **Step 1: Write failing tests for substrate discovery**
+
+Create `tests/daemon/digest.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DigestEngine } from '@myco/daemon/digest';
+
+describe('DigestEngine', () => {
+  describe('discoverSubstrate', () => {
+    it('should return notes updated since last cycle', () => {
+      // Setup: mock index with notes at different updated_at timestamps
+      // Call discoverSubstrate with a lastCycleTimestamp
+      // Assert: only notes after that timestamp are returned
+    });
+
+    it('should return empty array when no new substrate exists', () => {
+      // Setup: all notes updated before lastCycleTimestamp
+      // Assert: empty array
+    });
+
+    it('should respect max_notes_per_cycle limit', () => {
+      // Setup: more notes than limit
+      // Assert: array length <= max_notes_per_cycle
+    });
+
+    it('should prioritize by type weight then recency', () => {
+      // Setup: mix of sessions, spores, artifacts
+      // Assert: sessions and spores come before artifacts
+    });
+  });
+
+  describe('getEligibleTiers', () => {
+    it('should filter tiers by context window', () => {
+      const engine = new DigestEngine({ contextWindow: 8192, tiers: [1500, 3000, 5000, 10000] });
+      const eligible = engine.getEligibleTiers();
+      expect(eligible).toEqual([1500]); // Only 1500 fits in 8K
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/daemon/digest.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement DigestEngine class**
+
+Create `src/daemon/digest.ts`:
+
+```typescript
+import fs from 'node:fs';
+import path from 'node:path';
+import type { MycoIndex, IndexedNote } from '@myco/index/sqlite';
+import type { LlmProvider } from '@myco/intelligence/types';
+import type { MycoConfig } from '@myco/config/schema';
+// loadPrompt() is currently private in src/prompts/index.ts.
+// It must be exported as part of this task. Add: export function loadPrompt(...)
+import { loadPrompt } from '@myco/prompts/index';
+import {
+  CHARS_PER_TOKEN,
+  DIGEST_TIER_MIN_CONTEXT,
+  DIGEST_SUBSTRATE_TYPE_WEIGHTS,
+  DIGEST_SYSTEM_PROMPT_TOKENS,
+} from '@myco/constants';
+
+export interface DigestCycleResult {
+  cycleId: string;
+  timestamp: string;
+  substrate: {
+    sessions: string[];
+    spores: string[];
+    plans: string[];
+    artifacts: string[];
+    team: string[];
+  };
+  tiersGenerated: number[];
+  model: string;
+  durationMs: number;
+  tokensUsed: number;
+}
+
+export interface DigestEngineConfig {
+  vaultDir: string;
+  index: MycoIndex;
+  llmProvider: LlmProvider;
+  config: MycoConfig;
+}
+
+export class DigestEngine {
+  private vaultDir: string;
+  private index: MycoIndex;
+  private llm: LlmProvider;
+  private config: MycoConfig;
+  private digestDir: string;
+
+  constructor(opts: DigestEngineConfig) {
+    this.vaultDir = opts.vaultDir;
+    this.index = opts.index;
+    this.llm = opts.llmProvider;
+    this.config = opts.config;
+    this.digestDir = path.join(opts.vaultDir, 'digest');
+  }
+
+  /** Find notes updated since the last cycle */
+  discoverSubstrate(lastCycleTimestamp: string | null): IndexedNote[] {
+    const maxNotes = this.config.digest.substrate.max_notes_per_cycle;
+    const notes = lastCycleTimestamp
+      ? this.index.query({ updatedSince: lastCycleTimestamp })
+      : this.index.query({ limit: maxNotes });
+
+    // Filter out extract notes (don't digest our own output)
+    const filtered = notes.filter((n) => n.type !== 'extract');
+
+    // Sort by type weight (desc) then recency (desc)
+    filtered.sort((a, b) => {
+      const wa = DIGEST_SUBSTRATE_TYPE_WEIGHTS[a.type] ?? 0;
+      const wb = DIGEST_SUBSTRATE_TYPE_WEIGHTS[b.type] ?? 0;
+      if (wb !== wa) return wb - wa;
+      return b.created.localeCompare(a.created);
+    });
+
+    return filtered.slice(0, maxNotes);
+  }
+
+  /** Determine which tiers can run given the context window */
+  getEligibleTiers(): number[] {
+    const contextWindow = this.config.digest.intelligence.context_window;
+    return this.config.digest.tiers.filter(
+      (tier) => (DIGEST_TIER_MIN_CONTEXT[tier] ?? Infinity) <= contextWindow,
+    );
+  }
+
+  /** Format substrate notes for prompt injection */
+  formatSubstrate(notes: IndexedNote[], tokenBudget: number): string {
+    const charBudget = tokenBudget * CHARS_PER_TOKEN;
+    const lines: string[] = [];
+    let chars = 0;
+
+    for (const note of notes) {
+      const fm = note.frontmatter as Record<string, unknown>;
+      let header: string;
+      const noteType = fm.observation_type
+        ? `${note.type}:${fm.observation_type}`
+        : note.type;
+
+      header = `### [${noteType}] ${note.id}`;
+      if (note.title) header += ` — "${note.title}"`;
+
+      const preview = note.content.slice(0, charBudget - chars);
+      const block = `${header}\n${preview}\n`;
+
+      if (chars + block.length > charBudget) break;
+      lines.push(block);
+      chars += block.length;
+    }
+
+    return lines.join('\n');
+  }
+
+  /** Read the previous extract for a tier */
+  readPreviousExtract(tier: number): string | null {
+    const extractPath = path.join(this.digestDir, `extract-${tier}.md`);
+    if (!fs.existsSync(extractPath)) return null;
+    const content = fs.readFileSync(extractPath, 'utf-8');
+    // Strip YAML frontmatter, return body only
+    const fmEnd = content.indexOf('---', 3);
+    return fmEnd > 0 ? content.slice(fmEnd + 3).trim() : content;
+  }
+
+  /** Write an extract file with frontmatter */
+  writeExtract(tier: number, body: string, cycleId: string, model: string, substrateCount: number): void {
+    if (!fs.existsSync(this.digestDir)) {
+      fs.mkdirSync(this.digestDir, { recursive: true });
+    }
+    const frontmatter = [
+      '---',
+      'type: extract',
+      `tier: ${tier}`,
+      `generated: ${new Date().toISOString()}`,
+      `cycle_id: ${cycleId}`,
+      `substrate_count: ${substrateCount}`,
+      `model: ${model}`,
+      '---',
+    ].join('\n');
+
+    const extractPath = path.join(this.digestDir, `extract-${tier}.md`);
+    const tmpPath = `${extractPath}.tmp`;
+    fs.writeFileSync(tmpPath, `${frontmatter}\n\n${body}`);
+    fs.renameSync(tmpPath, extractPath);
+  }
+
+  /** Append a cycle record to the trace */
+  appendTrace(record: DigestCycleResult): void {
+    if (!fs.existsSync(this.digestDir)) {
+      fs.mkdirSync(this.digestDir, { recursive: true });
+    }
+    const tracePath = path.join(this.digestDir, 'trace.jsonl');
+    fs.appendFileSync(tracePath, JSON.stringify(record) + '\n');
+  }
+
+  /** Get the timestamp of the last cycle from the trace */
+  getLastCycleTimestamp(): string | null {
+    const tracePath = path.join(this.digestDir, 'trace.jsonl');
+    if (!fs.existsSync(tracePath)) return null;
+    const lines = fs.readFileSync(tracePath, 'utf-8').trim().split('\n');
+    if (lines.length === 0 || lines[0] === '') return null;
+    const last = JSON.parse(lines[lines.length - 1]) as DigestCycleResult;
+    return last.timestamp;
+  }
+
+  /** Run a full digest cycle */
+  async runCycle(): Promise<DigestCycleResult | null> {
+    const lastTimestamp = this.getLastCycleTimestamp();
+    const substrate = this.discoverSubstrate(lastTimestamp);
+
+    if (substrate.length === 0) return null;
+
+    const cycleId = `dc-${Date.now().toString(36)}`;
+    const startTime = Date.now();
+    const eligibleTiers = this.getEligibleTiers();
+    const tiersGenerated: number[] = [];
+    let totalTokens = 0;
+
+    const systemPrompt = loadPrompt('digest-system');
+
+    // Group substrate by type for the trace
+    const substrateByType: DigestCycleResult['substrate'] = {
+      sessions: [], spores: [], plans: [], artifacts: [], team: [],
+    };
+    for (const note of substrate) {
+      const key = note.type as keyof typeof substrateByType;
+      if (key in substrateByType) {
+        substrateByType[key].push(note.id);
+      }
+    }
+
+    for (const tier of eligibleTiers) {
+      const tierPrompt = loadPrompt(`digest-${tier}`);
+      const previousExtract = this.readPreviousExtract(tier);
+
+      // Calculate substrate token budget
+      const previousTokens = previousExtract
+        ? Math.ceil(previousExtract.length / CHARS_PER_TOKEN)
+        : 0;
+      const substrateBudget = this.config.digest.intelligence.context_window
+        - tier                       // output tokens
+        - previousTokens             // previous extract
+        - DIGEST_SYSTEM_PROMPT_TOKENS; // system + tier prompt
+
+      const formattedSubstrate = this.formatSubstrate(substrate, substrateBudget);
+
+      const prompt = [
+        tierPrompt,
+        '',
+        '## Previous Synthesis',
+        previousExtract ?? 'No previous synthesis exists.',
+        '',
+        '## New Substrate',
+        formattedSubstrate,
+        '',
+        '## Instructions',
+        `Produce your updated synthesis now. Stay within ${tier} tokens.`,
+      ].join('\n');
+
+      // LlmProvider.summarize() takes a single prompt string (no separate system prompt).
+      // Concatenate system + tier prompt + content into one prompt.
+      const fullPrompt = `${systemPrompt}\n\n${prompt}`;
+      const response = await this.llm.summarize(fullPrompt, {
+        maxTokens: tier,
+      });
+
+      this.writeExtract(tier, response.text, cycleId, response.model, substrate.length);
+      tiersGenerated.push(tier);
+      totalTokens += Math.ceil(prompt.length / CHARS_PER_TOKEN) + Math.ceil(response.text.length / CHARS_PER_TOKEN);
+    }
+
+    const result: DigestCycleResult = {
+      cycleId,
+      timestamp: new Date().toISOString(),
+      substrate: substrateByType,
+      tiersGenerated,
+      model: this.config.digest.intelligence.model ?? this.config.intelligence.llm.model,
+      durationMs: Date.now() - startTime,
+      tokensUsed: totalTokens,
+    };
+
+    this.appendTrace(result);
+    return result;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/daemon/digest.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/daemon/digest.ts tests/daemon/digest.test.ts
+git commit -m "feat: implement DigestEngine — substrate discovery, cycle pipeline, extract writing"
+```
+
+---
+
+### Task 15: Add Metabolism (Adaptive Timer)
+
+**Files:**
+- Modify: `src/daemon/digest.ts`
+- Test: `tests/daemon/digest.test.ts`
+
+- [ ] **Step 1: Write failing tests for metabolism**
+
+```typescript
+describe('Metabolism', () => {
+  it('should start in active state', () => {
+    const metabolism = new Metabolism(config.digest.metabolism);
+    expect(metabolism.state).toBe('active');
+  });
+
+  it('should advance through cooldown on empty cycles', () => {
+    const metabolism = new Metabolism(config.digest.metabolism);
+    metabolism.onEmptyCycle();
+    expect(metabolism.currentIntervalMs).toBe(900_000); // first cooldown
+    metabolism.onEmptyCycle();
+    expect(metabolism.currentIntervalMs).toBe(1_800_000); // second cooldown
+  });
+
+  it('should enter dormancy after threshold', () => {
+    const metabolism = new Metabolism(config.digest.metabolism);
+    metabolism.markLastSubstrate(Date.now() - 7_200_001);
+    metabolism.checkDormancy();
+    expect(metabolism.state).toBe('dormant');
+  });
+
+  it('should activate from dormancy', () => {
+    const metabolism = new Metabolism(config.digest.metabolism);
+    metabolism.state = 'dormant';
+    metabolism.activate();
+    expect(metabolism.state).toBe('active');
+    expect(metabolism.currentIntervalMs).toBe(300_000);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/daemon/digest.test.ts`
+Expected: FAIL — Metabolism not exported
+
+- [ ] **Step 3: Implement Metabolism class**
+
+Add to `src/daemon/digest.ts`:
+
+```typescript
+export type MetabolismState = 'active' | 'cooling' | 'dormant';
+
+export class Metabolism {
+  state: MetabolismState = 'active';
+  currentIntervalMs: number;
+  private cooldownStep = 0;
+  private lastSubstrateTime: number = Date.now();
+  private activeIntervalMs: number;
+  private cooldownIntervalsMs: number[];
+  private dormancyThresholdMs: number;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(config: { active_interval: number; cooldown_intervals: number[]; dormancy_threshold: number }) {
+    this.activeIntervalMs = config.active_interval * 1000;
+    this.cooldownIntervalsMs = config.cooldown_intervals.map((s) => s * 1000);
+    this.dormancyThresholdMs = config.dormancy_threshold * 1000;
+    this.currentIntervalMs = this.activeIntervalMs;
+  }
+
+  onSubstrateFound(): void {
+    this.lastSubstrateTime = Date.now();
+    this.state = 'active';
+    this.cooldownStep = 0;
+    this.currentIntervalMs = this.activeIntervalMs;
+  }
+
+  onEmptyCycle(): void {
+    if (this.state === 'dormant') return;
+    this.state = 'cooling';
+    if (this.cooldownStep < this.cooldownIntervalsMs.length) {
+      this.currentIntervalMs = this.cooldownIntervalsMs[this.cooldownStep];
+      this.cooldownStep++;
+    }
+    this.checkDormancy();
+  }
+
+  checkDormancy(): void {
+    const elapsed = Date.now() - this.lastSubstrateTime;
+    if (elapsed >= this.dormancyThresholdMs) {
+      this.state = 'dormant';
+      this.currentIntervalMs = 0; // timer suspended
+    }
+  }
+
+  activate(): void {
+    this.state = 'active';
+    this.cooldownStep = 0;
+    this.currentIntervalMs = this.activeIntervalMs;
+    this.lastSubstrateTime = Date.now();
+  }
+
+  markLastSubstrate(time: number): void {
+    this.lastSubstrateTime = time;
+  }
+
+  start(callback: () => Promise<void>): void {
+    this.scheduleNext(callback);
+  }
+
+  stop(): void {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = null;
+  }
+
+  private scheduleNext(callback: () => Promise<void>): void {
+    if (this.state === 'dormant' || this.currentIntervalMs <= 0) return;
+    this.timer = setTimeout(async () => {
+      await callback();
+      this.scheduleNext(callback);
+    }, this.currentIntervalMs);
+    // Don't block process exit
+    if (this.timer.unref) this.timer.unref();
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run tests/daemon/digest.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/daemon/digest.ts tests/daemon/digest.test.ts
+git commit -m "feat: add Metabolism — adaptive timer with active/cooling/dormant states"
+```
+
+---
+
+### Task 16: Integrate Digest into Daemon
+
+**Files:**
+- Modify: `src/daemon/main.ts`
+
+- [ ] **Step 1: Import and initialize DigestEngine in daemon startup**
+
+In `src/daemon/main.ts`, after existing initialization (index, plan watcher, batch manager):
+
+```typescript
+import { DigestEngine, Metabolism } from '@myco/daemon/digest';
+
+// In startup, after index and providers are initialized:
+if (config.digest.enabled) {
+  // Build digest LLM provider: use digest overrides where non-null, fall back to main config
+  const digestLlmConfig = {
+    provider: config.digest.intelligence.provider ?? config.intelligence.llm.provider,
+    model: config.digest.intelligence.model ?? config.intelligence.llm.model,
+    base_url: config.digest.intelligence.base_url ?? config.intelligence.llm.base_url,
+    context_window: config.digest.intelligence.context_window,
+  };
+  const digestLlm = (config.digest.intelligence.model || config.digest.intelligence.provider)
+    ? createLlmProvider(digestLlmConfig)
+    : llmProvider; // no overrides — reuse main provider
+
+  const digestEngine = new DigestEngine({
+    vaultDir,
+    index,
+    llmProvider: digestLlm,
+    config,
+  });
+
+  const metabolism = new Metabolism(config.digest.metabolism);
+
+  // Run initial cycle if substrate exists
+  const result = await digestEngine.runCycle();
+  if (result) {
+    metabolism.onSubstrateFound();
+    log.info(`Initial digest cycle: ${result.tiersGenerated.length} tiers, ${result.durationMs}ms`);
+  }
+
+  // Start metabolism timer
+  metabolism.start(async () => {
+    const cycleResult = await digestEngine.runCycle();
+    if (cycleResult) {
+      metabolism.onSubstrateFound();
+      log.info(`Digest cycle ${cycleResult.cycleId}: ${cycleResult.tiersGenerated.length} tiers`);
+    } else {
+      metabolism.onEmptyCycle();
+      log.debug('Digest: no substrate, backing off');
+    }
+  });
+
+  // Activate on session registration
+  // In the /sessions/register route handler, add:
+  metabolism.activate();
+}
+```
+
+- [ ] **Step 2: Verify config auto-migration for upgrades**
+
+No YAML file mutation needed. The `DigestSchema` uses `.default({})` at every level, so when an existing `myco.yaml` has no `digest` section, Zod parsing fills in all defaults automatically:
+- `enabled: true`
+- `tiers: [1500, 3000, 5000, 10000]`
+- `inject_tier: 3000`
+- All metabolism and substrate defaults
+
+Verify this works by adding a test: parse a config YAML with no `digest` key, assert defaults are populated. The daemon logs should note when digest is running for the first time:
+
+```typescript
+if (config.digest.enabled) {
+  log.info('Digest enabled — starting metabolism');
+}
+```
+
+- [ ] **Step 3: Run type check**
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/daemon/main.ts
+git commit -m "feat: integrate DigestEngine into daemon startup with metabolism and activation"
+```
+
+---
+
+### Task 17: Create myco_context MCP Tool
+
+**Files:**
+- Create: `src/mcp/tools/context.ts`
+- Modify: `src/mcp/tool-definitions.ts`
+- Modify: `src/mcp/server.ts`
+- Test: `tests/mcp/tools/context.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/mcp/tools/context.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import { handleMycoContext } from '@myco/mcp/tools/context';
+
+describe('myco_context', () => {
+  it('should return extract content for requested tier', () => {
+    // Setup: write a mock extract-3000.md to tmpDir/digest/
+    const result = handleMycoContext(tmpDir, { tier: 3000 });
+    expect(result.content).toContain('synthesized content');
+    expect(result.tier).toBe(3000);
+  });
+
+  it('should fall back to nearest tier when requested tier unavailable', () => {
+    // Setup: only extract-1500.md exists
+    const result = handleMycoContext(tmpDir, { tier: 5000 });
+    expect(result.tier).toBe(1500);
+    expect(result.fallback).toBe(true);
+  });
+
+  it('should return not-ready message when no extracts exist', () => {
+    const result = handleMycoContext(tmpDir, { tier: 3000 });
+    expect(result.content).toContain('not yet available');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/mcp/tools/context.test.ts`
+Expected: FAIL
+
+- [ ] **Step 3: Implement context tool handler**
+
+Create `src/mcp/tools/context.ts`:
+
+```typescript
+import fs from 'node:fs';
+import path from 'node:path';
+import { DIGEST_TIERS } from '@myco/constants';
+
+interface ContextInput {
+  tier?: number;
+}
+
+interface ContextResult {
+  content: string;
+  tier: number;
+  fallback: boolean;
+  generated?: string;
+}
+
+export function handleMycoContext(vaultDir: string, input: ContextInput): ContextResult {
+  const requestedTier = input.tier ?? 3000;
+  const digestDir = path.join(vaultDir, 'digest');
+
+  // Try exact tier first
+  const exactPath = path.join(digestDir, `extract-${requestedTier}.md`);
+  if (fs.existsSync(exactPath)) {
+    return readExtract(exactPath, requestedTier, false);
+  }
+
+  // Fall back to nearest available tier
+  const available = DIGEST_TIERS
+    .filter((t) => fs.existsSync(path.join(digestDir, `extract-${t}.md`)))
+    .sort((a, b) => Math.abs(a - requestedTier) - Math.abs(b - requestedTier));
+
+  if (available.length > 0) {
+    const fallbackTier = available[0];
+    const fallbackPath = path.join(digestDir, `extract-${fallbackTier}.md`);
+    return readExtract(fallbackPath, fallbackTier, true);
+  }
+
+  return {
+    content: 'Digest context is not yet available. The first digest cycle has not completed. Context will be available after the daemon processes vault data.',
+    tier: requestedTier,
+    fallback: false,
+  };
+}
+
+function readExtract(filePath: string, tier: number, fallback: boolean): ContextResult {
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  // Strip YAML frontmatter
+  const fmEnd = raw.indexOf('---', 3);
+  const body = fmEnd > 0 ? raw.slice(fmEnd + 3).trim() : raw;
+
+  // Extract generated timestamp from frontmatter
+  const generatedMatch = raw.match(/generated:\s*(.+)/);
+  const generated = generatedMatch?.[1]?.trim();
+
+  let content = body;
+  if (fallback) {
+    content = `[Note: Requested tier ${tier} unavailable, serving nearest available tier]\n\n${body}`;
+  }
+
+  return { content, tier, fallback, generated };
+}
+```
+
+- [ ] **Step 4: Register tool in tool-definitions.ts**
+
+Add to `src/mcp/tool-definitions.ts`:
+
+```typescript
+export const TOOL_CONTEXT = 'myco_context';
+
+// Add to TOOL_DEFINITIONS array:
+{
+  name: TOOL_CONTEXT,
+  description: 'Retrieve Myco\'s synthesized understanding of this project. Returns a pre-computed context extract at the requested token tier. Available tiers: 1500 (executive briefing), 3000 (team standup), 5000 (deep onboarding), 10000 (institutional knowledge). This is a rich, always-current synthesis of project history, decisions, patterns, and active work — not a search result.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      tier: {
+        type: 'number',
+        enum: [1500, 3000, 5000, 10000],
+        description: 'Token budget tier. Larger tiers include more detail. Default: 3000.',
+      },
+    },
+  },
+}
+```
+
+- [ ] **Step 5: Add case to server.ts switch**
+
+In `src/mcp/server.ts`, add to the `CallToolRequestSchema` switch:
+
+```typescript
+case TOOL_CONTEXT: {
+  const result = handleMycoContext(config.vaultDir, args as { tier?: number });
+  return { content: [{ type: 'text', text: result.content }] };
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `npx vitest run tests/mcp/tools/context.test.ts`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/mcp/tools/context.ts src/mcp/tool-definitions.ts src/mcp/server.ts tests/mcp/tools/context.test.ts
+git commit -m "feat: add myco_context MCP tool — serves tiered digest extracts"
+```
+
+---
+
+### Task 18: Update Session-Start Injection
+
+**Files:**
+- Modify: `src/hooks/session-start.ts`
+- Modify: `src/daemon/main.ts` (the `/context` route handler)
+
+- [ ] **Step 1: Update the /context route to serve digest extract when enabled**
+
+In `src/daemon/main.ts`, modify the `/context` route handler:
+
+```typescript
+server.registerRoute('POST', '/context', async (body: unknown) => {
+  const { session_id, branch } = body;
+
+  // If digest is enabled and inject_tier is set, serve the extract
+  if (config.digest.enabled && config.digest.inject_tier) {
+    const { handleMycoContext } = await import('@myco/mcp/tools/context');
+    const result = handleMycoContext(vaultDir, { tier: config.digest.inject_tier });
+
+    if (result.content && !result.content.includes('not yet available')) {
+      return {
+        context: result.content,
+        source: 'digest',
+        tier: result.tier,
+      };
+    }
+    // Fall through to layer-based injection if no extract exists yet
+  }
+
+  // Existing layer-based injection (fallback)
+  const context = buildInjectedContext(index, config, { sessionId: session_id, branch });
+  return { context: context.text, source: 'layers' };
+});
+```
+
+- [ ] **Step 2: Update session-start.ts to handle the new response format**
+
+In `src/hooks/session-start.ts`, the hook already outputs the context text from the daemon response. If the response includes `source: 'digest'`, no change needed — it outputs the text either way. But add logging:
+
+```typescript
+if (response.source === 'digest') {
+  log.debug(`Injecting digest extract (tier ${response.tier})`);
+}
+```
+
+- [ ] **Step 3: Run type check**
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/daemon/main.ts src/hooks/session-start.ts
+git commit -m "feat: serve digest extract at session start, fallback to layer-based injection"
+```
+
+---
+
+### Task 19: Full Integration Test
+
+**Files:**
+- Test: `tests/daemon/digest.test.ts` (extend)
+
+- [ ] **Step 1: Add integration test for full digest cycle**
+
+```typescript
+describe('DigestEngine integration', () => {
+  it('should run a full cycle: discover → synthesize → write extracts → trace', async () => {
+    // Setup:
+    // 1. Create tmpDir with vault structure
+    // 2. Write mock session and spore notes to vault
+    // 3. Index them
+    // 4. Create DigestEngine with mock LLM provider
+    // 5. Run cycle
+
+    const mockLlm = {
+      name: 'test',
+      summarize: async (prompt: string) => ({
+        text: 'Synthesized project understanding...',
+        model: 'test-model',
+      }),
+      isAvailable: async () => true,
+    };
+
+    const engine = new DigestEngine({
+      vaultDir: tmpDir,
+      index,
+      llmProvider: mockLlm as LlmProvider,
+      config: testConfig,
+    });
+
+    const result = await engine.runCycle();
+
+    // Verify extracts written
+    expect(fs.existsSync(path.join(tmpDir, 'digest', 'extract-1500.md'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, 'digest', 'extract-3000.md'))).toBe(true);
+
+    // Verify trace appended
+    const trace = fs.readFileSync(path.join(tmpDir, 'digest', 'trace.jsonl'), 'utf-8');
+    const record = JSON.parse(trace.trim());
+    expect(record.cycleId).toBeDefined();
+    expect(record.tiersGenerated).toContain(1500);
+    expect(record.substrate.sessions.length).toBeGreaterThan(0);
+
+    // Verify result
+    expect(result).not.toBeNull();
+    expect(result!.durationMs).toBeGreaterThan(0);
+  });
+
+  it('should return null when no substrate exists', async () => {
+    // Setup: empty index, no notes
+    const result = await engine.runCycle();
+    expect(result).toBeNull();
+  });
+
+  it('should skip tiers that exceed context window', async () => {
+    // Setup: config with context_window: 8192
+    // Only 1500 tier should be generated
+    const result = await engine.runCycle();
+    expect(result!.tiersGenerated).toEqual([1500]);
+  });
+});
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `make check`
+Expected: PASS (lint + all tests)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/daemon/digest.test.ts
+git commit -m "test: add digest integration tests — full cycle, empty substrate, tier gating"
+```
+
+---
+
+### Task 20: Update CLAUDE.md with Digest Documentation
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add digest to CLAUDE.md**
+
+Update the following sections:
+
+**Architecture section** — add `digest/` to the vault structure diagram.
+
+**Vault Structure section** — add `digest/` directory with description.
+
+**Glossary** — add the full glossary from the spec (Digest, Extract, Substrate, Trace, Metabolism, Dormancy, Activation, Spore).
+
+**Golden Paths** — add "Restart daemon after code changes" note about digest.
+
+**Module Boundaries** — note that the Digest module is a daemon task, not a hook.
+
+- [ ] **Step 2: Run quality gate**
+
+Run: `make check`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update CLAUDE.md with digest system and spore terminology"
+```
+
+---
+
+## Verification Checklist
+
+After completing all tasks:
+
+- [ ] `make check` passes (lint + tests)
+- [ ] `make build` succeeds
+- [ ] Daemon starts cleanly with `node dist/src/cli.js restart`
+- [ ] Vault migration runs (memories/ → spores/) on first startup
+- [ ] Digest cycle runs within 5 minutes of daemon start
+- [ ] Extract files appear in `vault/digest/`
+- [ ] `myco_context` MCP tool returns extract content
+- [ ] Session-start hook injects extract when configured
+- [ ] Metabolism backs off when no new data arrives
+- [ ] All existing MCP tools still work with spore terminology

--- a/docs/superpowers/specs/2026-03-19-digest-continuous-reasoning-design.md
+++ b/docs/superpowers/specs/2026-03-19-digest-continuous-reasoning-design.md
@@ -1,0 +1,502 @@
+# Digest: Continuous Reasoning for Myco
+
+**Date:** 2026-03-19
+**Status:** Approved
+**Author:** Chris + Claude
+
+## Summary
+
+Digest is a continuous reasoning system that runs inside the Myco daemon, periodically synthesizing all accumulated vault knowledge into tiered, pre-computed context representations called **extracts**. It replaces the current session-start context injection (layer-based: plans, sessions, memories, team) with a rich, always-ready project understanding that an agent receives automatically or pulls on demand.
+
+The feature is **opt-out by default** — upgrading users get conservative settings that just work; new users get system-aware recommendations during onboarding.
+
+## Motivation
+
+Today, Myco captures rich data — session summaries, observations (spores), plans, artifacts, team activity — but serves it back as search results and raw snippets. Each session is analyzed in isolation. No process reasons across the accumulated corpus to produce a unified understanding.
+
+The result: agents start each session with a shallow view — recent session titles, a few relevant spore snippets. They can search for more, but they don't know what they don't know.
+
+Digest closes this gap. A background process continuously maintains a synthesized understanding of the project: what it is, what's been happening, where it's going, who's building it, and what the team has learned. This understanding is pre-computed and instantly available — no LLM call at serve time.
+
+Inspired by [Honcho's continuous reasoning architecture](https://docs.honcho.dev/v3/documentation/core-concepts/architecture), adapted for Myco's local-first, file-based design.
+
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| **Digest** | The continuous reasoning process that synthesizes accumulated vault knowledge into pre-computed context representations. Runs as a daemon task on an adaptive timer. |
+| **Digest cycle** | A single execution of the digest process — discovers substrate, reasons over it, produces updated extracts. |
+| **Extract** | A tiered, pre-computed context representation at a specific token budget (1500/3000/5000/10000). Stored as markdown in `vault/digest/`. The output of a digest cycle. |
+| **Substrate** | New or updated vault notes (sessions, spores, plans, artifacts, team) that haven't been digested yet. The input to a digest cycle. |
+| **Trace** | The append-only audit chain recording what each digest cycle processed — which notes, which tiers, duration, model used. Stored as JSONL in `vault/digest/trace.jsonl`. |
+| **Metabolism** | The adaptive processing rate of the digest system. High metabolism = frequent cycles. Low metabolism = infrequent cycles. |
+| **Active metabolism** | Digest cycles running at maximum frequency (~5 min). Triggered by active sessions. |
+| **Metabolic slowdown** | Progressive backoff of cycle frequency when no new sessions are active but substrate exists. |
+| **Dormancy** | Digest timer fully suspended. No substrate has arrived for an extended period. No processing occurs. |
+| **Activation** | Transition from dormancy back to active metabolism, triggered by a new session registration or fresh substrate. |
+| **Spore** | A discrete observation extracted from session activity — a gotcha, decision, discovery, trade-off, or bug fix. Formerly called "memory." Stored in `vault/spores/{type}/`. |
+
+## Architecture
+
+### Module Placement
+
+The Digest module lives in `src/daemon/digest.ts` and runs inside the existing daemon process — not a separate process. It's a peer to batch processing and plan watching: another background task managed by the daemon lifecycle.
+
+### Lifecycle
+
+```
+Daemon starts
+  → Digest initializes
+  → Reads trace (last cycle state)
+  → Checks for substrate (new data since last cycle)
+  → If substrate exists: runs digest cycle
+  → Sets timer based on metabolic rate
+  → Listens for activation signals (new session events)
+```
+
+The daemon already knows about session registrations. The Digest module subscribes to these events for activation — no new infrastructure needed.
+
+### Adaptive Metabolism (Timer)
+
+```
+Active metabolism:    5 min cycles   (sessions active in last 30 min)
+Slowing metabolism:  15 min → 30 min → 1 hour   (backoff steps, no active sessions)
+Dormancy:            timer suspended   (no new substrate for 2+ hours)
+Activation:          session-start event → resume active metabolism
+```
+
+Power-aware design inspired by Open Agent Kit's power state management: burst when active, decay when idle, full sleep when stale. Prevents keeping laptops awake when there's nothing to process.
+
+## The Digest Cycle
+
+### Trigger
+
+The timer fires. The digest module checks: is there new substrate since the last cycle? If not, skip and advance toward dormancy. If yes, run.
+
+### Substrate Discovery
+
+Query the existing SQLite index for notes with `updated_at > last_cycle_timestamp`:
+
+- Session summaries (new or resumed sessions — resumed sessions generate new spores, which update `updated_at`)
+- Spores (new observations from any session)
+- Plans (status changes, new plans)
+- Artifacts (new or updated)
+- Team members (new or updated)
+
+This is a single index query, not a vault scan. The index already tracks `updated_at` for every note. **Note:** The current `MycoIndex.query()` API filters on `created`, not `updated_at`. The index schema has the `updated_at` column, but `QueryOptions` must be extended to support filtering by it. This is a small addition to `src/index/sqlite.ts`.
+
+### Pipeline
+
+```
+1. Query index for substrate (notes with updated_at > last_cycle_timestamp)
+2. If no substrate → skip, increase backoff toward dormancy, return
+3. Load substrate content (read the actual note files)
+4. For each configured tier (1500, 3000, 5000, 10000):
+   a. Read the previous extract for this tier (if exists)
+   b. Build prompt: system prompt + tier prompt + previous extract + substrate
+   c. LLM call with tier-specific prompt and token budget
+   d. Write new extract to vault/digest/extract-{tier}.md
+5. Append cycle record to trace.jsonl
+6. Reset timer to active metabolism rate
+```
+
+### Delta-Based Processing
+
+Each cycle takes the previous extract as input alongside new substrate. The LLM integrates new information into its existing understanding and produces an updated extract. The previous extract is the LLM's "memory" of all prior cycles.
+
+This means:
+- Context window stays bounded regardless of vault size
+- Older knowledge is preserved through the extract, not re-read from source
+- Resumed sessions naturally surface as fresh substrate (their `updated_at` changes when new spores are extracted)
+
+### Substrate Truncation
+
+When substrate exceeds the context budget, prioritize by:
+1. **Recency** — most recent notes first
+2. **Type weight** — sessions and spores over artifacts and team notes
+3. **Truncation** — individual note content trimmed using `CHARS_PER_TOKEN` heuristic
+
+Unprocessed substrate remains for the next cycle — the delta approach naturally catches up over subsequent cycles.
+
+## Tiered Extracts
+
+Each tier gets an independent LLM call with a purpose-built prompt. Tiers are not compressed versions of each other — each reasons about what matters within its specific budget.
+
+| Tier | Focus | Character |
+|------|-------|-----------|
+| **1,500 tokens** | Project identity, current focus, critical gotchas/blockers, who's working | Executive briefing — what is this and what's happening right now |
+| **3,000 tokens** | Above + recent activity narrative, key decisions, active plans, conventions | Team standup — enough to orient and start contributing |
+| **5,000 tokens** | Above + accumulated wisdom, patterns, trade-off reasoning, cross-cutting concerns | Deep onboarding — a new contributor could hit the ground running |
+| **10,000 tokens** | Above + full thread histories, plan evolution, artifact summaries, lessons learned | Institutional knowledge — the full picture with context behind decisions |
+
+### Context Window Requirements
+
+| Tier | Output | Previous Extract | Substrate Budget | System Prompt | Total Needed |
+|------|--------|-----------------|------------------|---------------|-------------|
+| 1,500 | ~1,500 | ~1,500 | ~3,000 | ~500 | ~6,500 |
+| 3,000 | ~3,000 | ~3,000 | ~5,000 | ~500 | ~11,500 |
+| 5,000 | ~5,000 | ~5,000 | ~8,000 | ~500 | ~18,500 |
+| 10,000 | ~10,000 | ~10,000 | ~10,000 | ~500 | ~30,500 |
+
+### Extract Format
+
+Each extract is a markdown file with YAML frontmatter, readable in Obsidian:
+
+```markdown
+---
+type: extract
+tier: 3000
+generated: 2026-03-18T14:30:00Z
+cycle_id: dc-a1b2c3
+substrate_count: 12
+model: llama3.2
+---
+
+[synthesized context as markdown prose, structured by the LLM
+ to fit within the token budget]
+```
+
+### Trace Record
+
+Each cycle appends one JSON line to `trace.jsonl`:
+
+```json
+{
+  "cycle_id": "dc-a1b2c3",
+  "timestamp": "2026-03-18T14:30:00Z",
+  "substrate": {
+    "sessions": ["session-abc123", "session-def456"],
+    "spores": ["gotcha-ac5220-1773416089650"],
+    "plans": [],
+    "artifacts": ["artifact-readme"]
+  },
+  "tiers_generated": [1500, 3000, 5000, 10000],
+  "model": "llama3.2",
+  "duration_ms": 45200,
+  "tokens_used": 18400
+}
+```
+
+## Prompt Design
+
+### Shared System Prompt
+
+```
+You are Myco's digest engine. Your role is to maintain a living understanding
+of a software project by synthesizing observations, session histories, plans,
+and team activity into a coherent context representation.
+
+You will receive:
+1. Your previous synthesis (if one exists)
+2. New substrate — recently captured knowledge that needs to be incorporated
+
+Produce an updated synthesis that:
+- Integrates the new substrate into your existing understanding
+- Stays within the specified token budget
+- Is written for an AI agent that will use this as its primary project context
+- Uses present tense for active state, past tense for completed work
+- Never fabricates — only synthesize from provided data
+```
+
+### Tier-Specific Prompts
+
+**1,500 tokens — Executive Briefing:**
+```
+Budget: ~1,500 tokens. This is the smallest representation.
+Prioritize ruthlessly:
+- What is this project? (1-2 sentences)
+- What is actively being worked on right now?
+- What are the critical gotchas or blockers?
+- Who is working on it? (if known)
+
+Drop: historical decisions, completed work, trade-off reasoning, conventions.
+An agent reading this should immediately know what it's walking into.
+```
+
+**3,000 tokens — Team Standup:**
+```
+Budget: ~3,000 tokens.
+Include everything from the briefing tier, plus:
+- Recent activity narrative (what happened in the last few sessions)
+- Key decisions made and why
+- Active plans and their status
+- Important conventions or patterns the agent should follow
+
+Drop: deep trade-off reasoning, exhaustive history, edge case wisdom.
+An agent reading this should be able to start contributing meaningfully.
+```
+
+**5,000 tokens — Deep Onboarding:**
+```
+Budget: ~5,000 tokens.
+Include everything from the standup tier, plus:
+- Accumulated wisdom: recurring gotchas, established patterns
+- Trade-off reasoning behind key architectural decisions
+- Cross-cutting concerns that affect multiple areas
+- Team member specialties and working patterns
+
+Drop: exhaustive historical detail, completed-and-closed threads.
+An agent reading this should understand not just what to do, but why things are the way they are.
+```
+
+**10,000 tokens — Institutional Knowledge:**
+```
+Budget: ~10,000 tokens.
+The full picture. Include everything from the onboarding tier, plus:
+- Complete thread histories for active and recently completed work
+- Detailed trade-off analysis and alternatives that were rejected
+- Plan evolution — what changed and why
+- Artifact summaries and their significance
+- Lessons learned from past incidents
+
+An agent reading this should have the equivalent of months of project context.
+```
+
+### Prompt Assembly
+
+```
+[System prompt]
+[Tier-specific prompt]
+
+## Previous Synthesis
+{previous extract content, or "No previous synthesis exists."}
+
+## New Substrate
+{formatted substrate notes — type, title, key content for each}
+
+## Instructions
+Produce your updated synthesis now. Stay within {budget} tokens.
+```
+
+### Substrate Formatting
+
+Each substrate note is formatted compactly:
+
+```
+### [session] session-abc123 — "Refactored auth middleware"
+Ended: 2026-03-18. Branch: fix/auth. Files changed: 4.
+Summary: Replaced legacy session token storage with encrypted JWT...
+
+### [spore:gotcha] gotcha-ac5220-1773416089650
+Session: session-abc123
+Root cause: The old middleware cached tokens in localStorage...
+
+### [plan] plan-digest-feature
+Status: active. Author: chris.
+Implement continuous reasoning for the Myco daemon...
+```
+
+## Serving
+
+### Session-Start Injection
+
+When `digest.enabled: true` and `digest.inject_tier` is set, the session-start hook reads the extract file directly from disk — no LLM call, no index query:
+
+```
+vault/digest/extract-{inject_tier}.md → parse frontmatter → inject body as context
+```
+
+This replaces the current `buildInjectedContext()` layer system. The extract already contains a synthesized version of plans, sessions, spores, and team activity.
+
+**Fallback:** If digest is enabled but no extract file exists yet (first run, vault just initialized), fall back to the existing layer-based injection until the first digest cycle completes.
+
+### MCP Tool: `myco_context`
+
+New tool exposed via the MCP server:
+
+```typescript
+{
+  name: "myco_context",
+  description: "Retrieve Myco's synthesized understanding of this project. " +
+    "Returns a pre-computed context extract at the requested token tier. " +
+    "Available tiers: 1500 (executive briefing), 3000 (team standup), " +
+    "5000 (deep onboarding), 10000 (institutional knowledge). " +
+    "This is a rich, always-current synthesis of project history, " +
+    "decisions, patterns, and active work — not a search result.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      tier: {
+        type: "number",
+        enum: [1500, 3000, 5000, 10000],
+        description: "Token budget tier. Larger tiers include more detail."
+      }
+    }
+  }
+}
+```
+
+Reads the extract file, returns its content. If the requested tier doesn't exist, returns the nearest available tier with a note about what was served. No LLM call at serve time.
+
+### Skill Update
+
+The Myco skill is updated to know about `myco_context`. When digest is enabled but injection tier is low (or disabled), the skill instructs the agent to use the MCP tool for deeper context. This enables the layered approach: auto-inject 1.5K, agent pulls 5K+ when it needs deeper understanding.
+
+### Per-Prompt Spore Injection
+
+**Unchanged.** The existing vector-search-based per-prompt injection continues. When the user types a prompt, the hook searches for relevant spores and injects the top matches. This complements the extract — the extract provides the big picture, spore injection provides targeted relevance for the specific prompt.
+
+## Configuration
+
+New `digest` section in `myco.yaml`:
+
+```yaml
+digest:
+  enabled: true                     # Opt-out (enabled by default)
+  tiers: [1500, 3000, 5000, 10000]  # Which tiers to generate
+  inject_tier: 3000                 # Which tier to auto-inject at session start (null = disabled)
+
+  intelligence:
+    provider: null       # null = inherit from intelligence.llm.provider
+    model: null          # null = inherit from intelligence.llm.model
+    base_url: null       # null = inherit from intelligence.llm.base_url
+    context_window: 32768  # Override for digest operations
+
+  metabolism:
+    active_interval: 300         # 5 min when sessions active
+    cooldown_intervals: [900, 1800, 3600]  # 15m → 30m → 1h backoff steps
+    dormancy_threshold: 7200     # 2 hours no substrate → dormancy
+
+  substrate:
+    max_notes_per_cycle: 50      # Cap substrate size per cycle
+```
+
+### Interaction with Existing Config
+
+When `digest.enabled: true` and `digest.inject_tier` is set:
+- Session-start injection uses the extract file instead of the layer-based system
+- The current `context.layers` config is bypassed (not removed)
+- Per-prompt spore injection continues unchanged
+
+When `digest.enabled: false`:
+- Everything works exactly as it does today
+- No digest cycles run, no extracts generated
+
+### Intelligence Override
+
+The `digest.intelligence` block allows a full LLM provider override. Users can run:
+- **Hooks/extraction:** Ollama, `gpt-oss-20b`, 8K context — fast, lightweight
+- **Digest:** Ollama, `qwen3.5-30b`, 32K context — slower, deeper reasoning
+
+Or point digest at a different provider entirely. The separation exists because digest has fundamentally different resource needs than real-time hook processing.
+
+**Tier gating by context window:** If the configured `context_window` is too small for a tier (per the Context Window Requirements table), that tier is automatically skipped during digest cycles. For example, `context_window: 8192` only generates the 1,500-token tier. This prevents failed LLM calls and lets users safely configure all four tiers knowing only the ones their hardware can handle will run.
+
+## Upgrade & Onboarding
+
+### Existing Users (Upgrade Path)
+
+On daemon startup, if `digest` config section is missing from `myco.yaml`:
+- Add it with `enabled: true`
+- No intelligence overrides — inherits the existing LLM config
+- Default tiers: `[1500, 3000]` (safe for any machine already running local LLMs)
+- Default `inject_tier: 1500` (conservative, immediately useful)
+
+No re-setup required. The daemon starts the digest metabolism, and the next session gets a synthesized extract.
+
+### New Users (Onboarding)
+
+The `/init` and `/setup-llm` commands are enhanced with system capability detection:
+
+```
+Detecting system capabilities...
+  RAM: 32GB | GPU: Apple M2 Pro 16GB unified
+  Recommended digest config: tiers [1500, 3000, 5000], context 16K
+
+? Accept recommended digest configuration? [Y/n]
+```
+
+Heuristics:
+
+| Available Memory | Recommended Tiers | Context Window |
+|-----------------|-------------------|----------------|
+| < 16GB | `[1500]` | 8K |
+| 16–32GB | `[1500, 3000]` | 16K |
+| 32–64GB | `[1500, 3000, 5000]` | 24K |
+| 64GB+ | `[1500, 3000, 5000, 10000]` | 32K |
+
+System detection: `sysctl hw.memsize` (macOS), `/proc/meminfo` (Linux), Ollama model list for available models.
+
+### Power Users
+
+Run `/setup-llm` to reconfigure with full control: separate provider/model for digest, custom tiers, context window tuning.
+
+## Spore Migration
+
+Rename `memories` → `spores` across the codebase and vault.
+
+### Vault Migration
+
+One-time, on daemon startup:
+
+1. **Detect:** `vault/memories/` exists and `vault/spores/` does not
+2. **Rename:** `vault/memories/` → `vault/spores/`
+3. **Update frontmatter:** Walk all `.md` files — `type: 'memory'` → `type: 'spore'`
+4. **Reindex:** All affected notes (type field changed)
+5. **Re-embed:** Affected notes (metadata updated)
+
+**Idempotent:** If `vault/spores/` already exists, skip. If both exist (interrupted migration), merge and deduplicate by note ID.
+
+### Code Changes
+
+The rename touches every file that references `memory`/`Memory`/`memories`. The table below lists the primary areas; the implementation must also grep for and update all remaining references across the codebase.
+
+| Area | Change |
+|------|--------|
+| `src/vault/writer.ts` | `writeMemory()` → `writeSpore()`, paths `memories/` → `spores/` |
+| `src/vault/types.ts` | `MemorySchema` → `SporeSchema`, `MemoryFrontmatter` → `SporeFrontmatter`, `type: 'memory'` → `type: 'spore'` |
+| `src/vault/frontmatter.ts` | `memoryFm()` → `sporeFm()`, imports updated |
+| `src/vault/observations.ts` | `writeMemory()` → `writeSpore()`, `formatMemoryBody()` → `formatSporeBody()` |
+| `src/vault/reader.ts` | Query paths updated |
+| `src/obsidian/formatter.ts` | `formatMemoryBody()` → `formatSporeBody()`, `MemoryBodyInput` → `SporeBodyInput`, `'memory'` tag → `'spore'` |
+| `src/constants.ts` | `CONTEXT_MEMORY_PREVIEW_CHARS` → `CONTEXT_SPORE_PREVIEW_CHARS` and similar |
+| `src/config/schema.ts` | `context.layers.memories` → `context.layers.spores`, new `digest` config section with Zod schema (all-optional fields inheriting from parent LLM config) |
+| `src/prompts/extraction.md` | Terminology update |
+| `src/mcp/tools/` | `myco_remember`, `myco_recall`, `myco_search`, `consolidate`, `supersede` — descriptions updated, tool names unchanged (the verbs "remember" and "recall" are user-facing actions, not tied to the internal type name) |
+| `src/context/injector.ts` | Layer references updated |
+| `src/cli/` | `stats.ts`, `rebuild.ts`, `reprocess.ts`, `init.ts` — memory paths/types updated |
+| `src/index/sqlite.ts` | Extend `QueryOptions` to support `updatedSince` filter on `updated_at` column (existing `since` filter on `created` remains unchanged) |
+| `CLAUDE.md` | Update vault structure, naming conventions (`memories/` → `spores/`), `writeMemory` → `writeSpore` references, glossary |
+| `tests/` | All test files mirroring the above changes |
+
+## New Components
+
+| File | Purpose |
+|------|---------|
+| `src/daemon/digest.ts` | The digest engine — timer, substrate discovery, cycle pipeline, metabolism management |
+| `src/mcp/tools/context.ts` | `myco_context` MCP tool handler |
+| `src/prompts/digest-system.md` | Shared system prompt template |
+| `src/prompts/digest-1500.md` | 1,500-token tier prompt |
+| `src/prompts/digest-3000.md` | 3,000-token tier prompt |
+| `src/prompts/digest-5000.md` | 5,000-token tier prompt |
+| `src/prompts/digest-10000.md` | 10,000-token tier prompt |
+| `vault/digest/` | Extract files and trace (created on first cycle) |
+
+## Updated Vault Structure
+
+```
+~/.myco/vaults/<vault-name>/
+  myco.yaml           # Vault configuration
+  daemon.json          # Running daemon PID/port
+  index.db             # SQLite FTS5 index
+  vectors.db           # sqlite-vec vector embeddings
+  buffer/              # Per-session JSONL event buffers (ephemeral)
+  sessions/            # Session notes by date
+  spores/              # Observation notes (renamed from memories/)
+  plans/               # Plan notes
+  artifacts/           # Artifact references
+  attachments/         # Images from session transcripts
+  team/                # Team member notes
+  digest/              # Extracts and trace (new)
+  logs/                # Daemon logs
+```
+
+## Design Principles
+
+All existing Myco principles apply to the digest system:
+
+- **Data preservation:** Extracts are overwritten (they're derived, not primary data). The trace is append-only. Source data (sessions, spores) is never modified by the digest process.
+- **Idempotence:** Running the same digest cycle twice with the same substrate produces the same result. The LLM may vary output, but the process is structurally idempotent.
+- **Session ID as source of truth:** Digest doesn't track sessions by lifecycle events. It discovers substrate via `updated_at` timestamps in the index.
+- **No magic literals:** All timer intervals, thresholds, token budgets, and limits are named constants.
+- **Graceful degradation:** If the LLM is unreachable, the cycle skips and retries on the next timer tick. If no extract exists, session-start falls back to the existing layer-based injection.

--- a/skills/myco/SKILL.md
+++ b/skills/myco/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: myco
-description: Use when making design decisions, debugging non-obvious issues, encountering gotchas, wondering why code is structured a certain way, or when you need context about prior work on the same feature or component. Myco captures the reasoning, trade-offs, and lessons behind the codebase — things the code itself doesn't show. Also use when the user mentions vault, memories, sessions, team knowledge, institutional memory, or prior decisions.
+description: Use when making design decisions, debugging non-obvious issues, encountering gotchas, wondering why code is structured a certain way, or when you need context about prior work on the same feature or component. Myco captures the reasoning, trade-offs, and lessons behind the codebase — things the code itself doesn't show. Also use when the user mentions vault, spores, sessions, team knowledge, institutional memory, or prior decisions.
 ---
 
 # Myco — Collective Agent Intelligence
@@ -13,7 +13,7 @@ Use Myco tools proactively in these situations — don't wait to be asked:
 
 - **Before making a design decision** — search for prior reasoning on the same component. Someone may have already evaluated the approach you're considering, or documented why an alternative was rejected.
 - **When debugging a non-obvious issue** — search for the error message, component name, or symptom. A prior session may have hit the same problem and documented the root cause.
-- **When wondering why code is structured a certain way** — decisions and trade-offs behind the architecture are captured as memories.
+- **When wondering why code is structured a certain way** — decisions and trade-offs behind the architecture are captured as spores.
 - **When continuing work on a feature** — check session history and plan progress for context on what's been done and what's pending.
 - **After discovering a gotcha, making a key decision, or fixing a tricky bug** — save it so future sessions benefit from the knowledge.
 - **When starting work on a branch** — context is injected automatically at session start, but you can call `myco_recall` for deeper context on specific files.
@@ -37,17 +37,17 @@ If the vault isn't configured, run `/myco-init` to set up. To change LLM provide
 
 ### myco_search — Find knowledge across the vault
 
-Combined semantic + full-text search across sessions, plans, and memories.
+Combined semantic + full-text search across sessions, plans, and spores.
 
 ```json
-{ "query": "why did we choose JWT over session cookies", "type": "memory", "limit": 5 }
+{ "query": "why did we choose JWT over session cookies", "type": "spore", "limit": 5 }
 ```
 
-**When to use**: searching for prior decisions, debugging context, or understanding rationale. The `type` filter narrows results — use `"memory"` for decisions/gotchas, `"session"` for session history, `"plan"` for plans, or omit for all.
+**When to use**: searching for prior decisions, debugging context, or understanding rationale. The `type` filter narrows results — use `"spore"` for decisions/gotchas, `"session"` for session history, `"plan"` for plans, or omit for all.
 
 **Example**: before choosing an authentication approach, search for prior decisions:
 ```json
-{ "query": "authentication approach JWT session", "type": "memory" }
+{ "query": "authentication approach JWT session", "type": "spore" }
 ```
 
 ### myco_recall — Get context for current work
@@ -106,13 +106,13 @@ Filter by `plan`, `branch`, `user`, or `since` (ISO timestamp). Useful for under
 
 ### myco_graph — Traverse vault connections
 
-Follow wikilink connections between notes — find related sessions, memories, and plans.
+Follow wikilink connections between notes — find related sessions, spores, and plans.
 
 ```json
 { "note_id": "session-abc123", "direction": "both", "depth": 2 }
 ```
 
-**When to use**: exploring how a decision connects to sessions and other memories, or understanding the lineage of a feature's development across multiple sessions.
+**When to use**: exploring how a decision connects to sessions and other spores, or understanding the lineage of a feature's development across multiple sessions.
 
 ### myco_orphans — Find disconnected notes
 
@@ -140,47 +140,47 @@ View daemon logs for debugging when sessions aren't being captured, observations
 
 Components: `daemon`, `processor`, `hooks`, `lifecycle`, `embeddings`, `lineage`, `watcher`.
 
-### myco_supersede — Mark a memory as replaced
+### myco_supersede — Mark a spore as replaced
 
-When a newer observation makes an older one obsolete, supersede it. The old memory stays in the vault (data is never deleted) but is marked `status: superseded`.
+When a newer observation makes an older one obsolete, supersede it. The old spore stays in the vault (data is never deleted) but is marked `status: superseded`.
 
 ```json
-{ "old_memory_id": "decision-abc123", "new_memory_id": "decision-def456", "reason": "Migrated from bcrypt to argon2" }
+{ "old_spore_id": "decision-abc123", "new_spore_id": "decision-def456", "reason": "Migrated from bcrypt to argon2" }
 ```
 
 **When to use**: a decision was reversed, a gotcha was fixed, a discovery turned out to be wrong, or the codebase changed and an observation no longer applies.
 
-### myco_consolidate — Merge memories into wisdom
+### myco_consolidate — Merge spores into wisdom
 
-When multiple memories describe aspects of the same insight, consolidate them into a single comprehensive note. Source memories are marked superseded with links to the new wisdom note.
+When multiple spores describe aspects of the same insight, consolidate them into a single comprehensive note. Source spores are marked superseded with links to the new wisdom note.
 
 ```json
 {
-  "source_memory_ids": ["gotcha-aaa111", "gotcha-bbb222", "gotcha-ccc333"],
+  "source_spore_ids": ["gotcha-aaa111", "gotcha-bbb222", "gotcha-ccc333"],
   "consolidated_content": "# SQLite Operational Gotchas\n\n1. WAL mode requires shared memory...\n2. Single writer lock...\n3. FTS5 tokenization...",
   "observation_type": "gotcha",
   "tags": ["sqlite", "infrastructure"]
 }
 ```
 
-**When to use**: 3+ memories share a root cause, describe the same pattern from different angles, or would be more useful as a single comprehensive reference.
+**When to use**: 3+ spores share a root cause, describe the same pattern from different angles, or would be more useful as a single comprehensive reference.
 
 For detailed patterns on when and how to consolidate, read `references/wisdom.md`.
 
 ## Wisdom — Keeping the Vault Clean
 
-Memories are injected into every prompt via the `UserPromptSubmit` hook. Each injected memory includes its ID (e.g., `[decision-abc123]`). When you see an injected memory that contradicts what you just did or know to be outdated, **supersede it immediately** — don't wait to be asked. This is how the vault stays accurate.
+Spores are injected into every prompt via the `UserPromptSubmit` hook. Each injected spore includes its ID (e.g., `[decision-abc123]`). When you see an injected spore that contradicts what you just did or know to be outdated, **supersede it immediately** — don't wait to be asked. This is how the vault stays accurate.
 
 **Proactive superseding during normal work:**
 
-- You just changed how the stop hook works → an injected memory says it works the old way → `myco_supersede` with the old ID and a new `myco_remember` capturing the current behavior
-- You see two injected memories that say conflicting things → supersede the older one
+- You just changed how the stop hook works → an injected spore says it works the old way → `myco_supersede` with the old ID and a new `myco_remember` capturing the current behavior
+- You see two injected spores that say conflicting things → supersede the older one
 - An injected gotcha references code that was refactored → supersede it
 
 **Other signals to act on:**
 
 - **Recurring gotchas**: the same problem keeps being recorded → `myco_consolidate` into one definitive note
-- **Overlapping content**: a `myco_remember` would duplicate an existing memory → `myco_supersede` with updated content instead
+- **Overlapping content**: a `myco_remember` would duplicate an existing spore → `myco_supersede` with updated content instead
 - **Stale decisions**: a decision references a deleted component or reversed approach → supersede it
 
 The vault should get sharper over time, not just bigger. Every session should leave the vault more accurate than it found it.
@@ -223,7 +223,7 @@ If observations were lost due to a bug, or if you want to re-extract observation
 node <plugin-root>/dist/src/cli.js reprocess
 ```
 
-This re-reads all session transcripts, re-extracts observations, and re-indexes everything. Existing memories are preserved — new observations are additive.
+This re-reads all session transcripts, re-extracts observations, and re-indexes everything. Existing spores are preserved — new observations are additive.
 
 Options:
 - `--session <id>` — reprocess a single session (partial ID match)

--- a/skills/myco/references/wisdom.md
+++ b/skills/myco/references/wisdom.md
@@ -1,10 +1,10 @@
 # Wisdom Consolidation Patterns
 
-When you notice patterns in vault memories — recurring themes, conflicting advice, outdated observations — use these tools to keep the vault clean and its knowledge sharp.
+When you notice patterns in vault spores — recurring themes, conflicting advice, outdated observations — use these tools to keep the vault clean and its knowledge sharp.
 
 ## Supersede
 
-Use `myco_supersede` when a newer memory replaces an older one.
+Use `myco_supersede` when a newer spore replaces an older one.
 
 **Signals:**
 - A decision was reversed in a later session
@@ -13,28 +13,28 @@ Use `myco_supersede` when a newer memory replaces an older one.
 - The codebase changed and an observation no longer applies
 
 **Example flow:**
-1. You find memory `decision-abc123` saying "we chose bcrypt for password hashing"
-2. A newer memory `decision-def456` says "migrated from bcrypt to argon2 for better side-channel resistance"
+1. You find spore `decision-abc123` saying "we chose bcrypt for password hashing"
+2. A newer spore `decision-def456` says "migrated from bcrypt to argon2 for better side-channel resistance"
 3. Supersede the old one:
 ```json
 {
-  "old_memory_id": "decision-abc123",
-  "new_memory_id": "decision-def456",
+  "old_spore_id": "decision-abc123",
+  "new_spore_id": "decision-def456",
   "reason": "Auth migrated from bcrypt to argon2"
 }
 ```
 
-The old memory stays in the vault (data is never deleted) but its frontmatter is marked `status: superseded` with a link to the replacement. Search results deprioritize superseded memories.
+The old spore stays in the vault (data is never deleted) but its frontmatter is marked `status: superseded` with a link to the replacement. Search results deprioritize superseded spores.
 
 ## Consolidate
 
-Use `myco_consolidate` when multiple memories describe aspects of the same insight and would be more useful as a single comprehensive note.
+Use `myco_consolidate` when multiple spores describe aspects of the same insight and would be more useful as a single comprehensive note.
 
 **Signals:**
 - Three gotchas about the same subsystem that share a root cause
 - Multiple discoveries about the same library that, together, form a complete picture
 - A bug fix and a gotcha that describe the same issue from different angles
-- Several trade-off memories about the same architectural decision
+- Several trade-off spores about the same architectural decision
 
 **Example flow:**
 1. You find three related gotchas:
@@ -44,18 +44,18 @@ Use `myco_consolidate` when multiple memories describe aspects of the same insig
 2. Consolidate them into a wisdom note:
 ```json
 {
-  "source_memory_ids": ["gotcha-aaa111", "gotcha-bbb222", "gotcha-ccc333"],
+  "source_spore_ids": ["gotcha-aaa111", "gotcha-bbb222", "gotcha-ccc333"],
   "consolidated_content": "# SQLite Operational Gotchas\n\nThree key constraints when using SQLite in production:\n\n1. **WAL mode + Docker**: WAL requires shared memory (mmap). Containers with `--tmpfs` or read-only root filesystems break this. Mount the database directory as a named volume.\n\n2. **Concurrent write access**: SQLite serializes all writes through a single writer lock. Multiple processes writing concurrently will get SQLITE_BUSY. Use a single long-lived process (the daemon) for all writes.\n\n3. **FTS5 tokenization**: The default tokenizer splits on non-alphanumeric characters, so CamelCase identifiers like `getUserById` are indexed as one token. Use the `unicode61` tokenizer with `tokenchars` to handle this.",
   "observation_type": "gotcha",
   "tags": ["sqlite", "infrastructure"]
 }
 ```
 
-The source memories are marked `status: superseded` with links to the wisdom note. The wisdom note has `consolidated_from` in its frontmatter linking back to its sources.
+The source spores are marked `status: superseded` with links to the wisdom note. The wisdom note has `consolidated_from` in its frontmatter linking back to its sources.
 
 ## When NOT to act
 
-- **Don't consolidate unrelated memories** that happen to share tags — they should remain separate observations
-- **Don't supersede a memory just because it's old** — age alone isn't a reason; the content must be outdated or replaced
-- **Don't force consolidation for fewer than 3 sources** — two related memories are fine as separate notes; consolidation adds value when there's a pattern across 3+
+- **Don't consolidate unrelated spores** that happen to share tags — they should remain separate observations
+- **Don't supersede a spore just because it's old** — age alone isn't a reason; the content must be outdated or replaced
+- **Don't force consolidation for fewer than 3 sources** — two related spores are fine as separate notes; consolidation adds value when there's a pattern across 3+
 - **Don't consolidate across observation types** unless they truly describe the same insight from different angles (e.g., a bug_fix and a gotcha about the same issue is fine)

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -27,7 +27,7 @@ Rules files contain **project invariants** — things every agent must follow ev
 | Belongs in Rules File | Does NOT Belong |
 |----------------------|-----------------|
 | Hard constraints: "All API routes go through `src/routes/`" | Situational context (use Myco context injection) |
-| Golden paths: step-by-step standard procedures | Decision rationale (use Myco memory) |
+| Golden paths: step-by-step standard procedures | Decision rationale (use Myco spore) |
 | Quality gates: specific commands that must pass | Code documentation (that's the codebase) |
 | Non-goals: what the project is NOT | Anything starting with "try to" or "when possible" |
 
@@ -166,15 +166,15 @@ Good rule: "better-sqlite3 MUST be installed with native bindings, not WASM. The
 1. Myco surfaces a pattern: "Your team has hit 3 gotchas about X. Should this become a rule?"
 2. If the developer approves:
    - Craft the rule from the observation
-   - The rule states the **what** — the observation (in Myco memory) stores the **why**
+   - The rule states the **what** — the observation (in Myco spore) stores the **why**
    - Place it in the correct file and section
 3. If the developer dismisses: the observation stays as context, not a rule
 
-### What stays as memory, NOT a rule
+### What stays as a spore, NOT a rule
 
 Reject promotion for:
 - One-off gotchas unlikely to recur (< 3 occurrences)
-- Decision rationale (the rule states what; memory stores why)
+- Decision rationale (the rule states what; spore stores why)
 - Branch-specific or time-limited knowledge
 - Anything that would only matter during a specific initiative
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ Commands:
   vectors <query>          Raw vector search with similarity scores
   session [id|latest]      Show a session note
   logs [options]           View daemon logs
+  setup-digest [options]   Configure digest and capture settings
   restart                  Restart the daemon
   rebuild                  Reindex the entire vault
   reprocess [options]      Re-extract observations and re-index sessions
@@ -52,6 +53,7 @@ async function main(): Promise<void> {
     case 'search': return (await import('./cli/search.js')).run(args, vaultDir);
     case 'vectors': return (await import('./cli/search.js')).runVectors(args, vaultDir);
     case 'session': return (await import('./cli/session.js')).run(args, vaultDir);
+    case 'setup-digest': return (await import('./cli/setup-digest.js')).run(args, vaultDir);
     case 'restart': return (await import('./cli/restart.js')).run(args, vaultDir);
     case 'rebuild': return (await import('./cli/rebuild.js')).run(args, vaultDir);
     case 'reprocess': return (await import('./cli/reprocess.js')).run(args, vaultDir);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ Commands:
   vectors <query>          Raw vector search with similarity scores
   session [id|latest]      Show a session note
   logs [options]           View daemon logs
+  setup-llm [options]      Configure LLM and embedding providers
   setup-digest [options]   Configure digest and capture settings
   restart                  Restart the daemon
   rebuild                  Reindex the entire vault
@@ -53,6 +54,7 @@ async function main(): Promise<void> {
     case 'search': return (await import('./cli/search.js')).run(args, vaultDir);
     case 'vectors': return (await import('./cli/search.js')).runVectors(args, vaultDir);
     case 'session': return (await import('./cli/session.js')).run(args, vaultDir);
+    case 'setup-llm': return (await import('./cli/setup-llm.js')).run(args, vaultDir);
     case 'setup-digest': return (await import('./cli/setup-digest.js')).run(args, vaultDir);
     case 'restart': return (await import('./cli/restart.js')).run(args, vaultDir);
     case 'rebuild': return (await import('./cli/rebuild.js')).run(args, vaultDir);

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -39,18 +39,11 @@ export async function run(args: string[]): Promise<void> {
     fs.mkdirSync(path.join(vaultDir, dir), { recursive: true });
   }
 
-  // Write myco.yaml — pass only required fields, let Zod schema populate defaults.
-  // intelligence.llm and intelligence.embedding are required (no defaults),
-  // everything else has Zod defaults.
-  const minimal = {
-    version: 2 as const,
-    intelligence: {
-      llm: { provider: 'ollama' as const, model: 'qwen3.5' },
-      embedding: { provider: 'ollama' as const, model: 'bge-m3' },
-    },
+  // Write myco.yaml — only version is truly required, everything else has Zod defaults
+  const config = MycoConfigSchema.parse({
+    version: 2,
     team: { user, enabled: teamEnabled },
-  };
-  const config = MycoConfigSchema.parse(minimal);
+  });
 
   fs.writeFileSync(
     path.join(vaultDir, 'myco.yaml'),

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -38,7 +38,7 @@ export async function run(args: string[]): Promise<void> {
   console.log(`Initializing Myco vault at ${vaultDir}`);
 
   // Create directory structure
-  const dirs = ['sessions', 'plans', 'memories', 'artifacts', 'team', 'buffer', 'logs'];
+  const dirs = ['sessions', 'plans', 'spores', 'artifacts', 'team', 'buffer', 'logs'];
   for (const dir of dirs) {
     fs.mkdirSync(path.join(vaultDir, dir), { recursive: true });
   }
@@ -73,7 +73,7 @@ export async function run(args: string[]): Promise<void> {
     },
     context: {
       max_tokens: 1200,
-      layers: { plans: 200, sessions: 500, memories: 300, team: 200 },
+      layers: { plans: 200, sessions: 500, spores: 300, team: 200 },
     },
     team: {
       enabled: teamEnabled,

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -3,11 +3,12 @@ import { initFts } from '../index/fts.js';
 import { resolveVaultDir } from '../vault/resolve.js';
 import {
   parseStringFlag,
-  PROVIDER_DEFAULTS,
   DASHBOARD_CONTENT,
   VAULT_GITIGNORE,
   configureVaultEnv,
 } from './shared.js';
+import { run as setupLlm } from './setup-llm.js';
+import { run as setupDigest } from './setup-digest.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -15,12 +16,6 @@ import YAML from 'yaml';
 
 export async function run(args: string[]): Promise<void> {
   const vaultPath = parseStringFlag(args, '--vault');
-  const llmProvider = parseStringFlag(args, '--llm-provider') ?? 'ollama';
-  const llmModel = parseStringFlag(args, '--llm-model') ?? 'gpt-oss';
-  const llmUrl = parseStringFlag(args, '--llm-url') ?? PROVIDER_DEFAULTS[llmProvider]?.base_url;
-  const embeddingProvider = parseStringFlag(args, '--embedding-provider') ?? 'ollama';
-  const embeddingModel = parseStringFlag(args, '--embedding-model') ?? 'bge-m3';
-  const embeddingUrl = parseStringFlag(args, '--embedding-url') ?? PROVIDER_DEFAULTS[embeddingProvider]?.base_url;
   const user = parseStringFlag(args, '--user') ?? '';
   const teamEnabled = args.includes('--team');
 
@@ -43,21 +38,19 @@ export async function run(args: string[]): Promise<void> {
     fs.mkdirSync(path.join(vaultDir, dir), { recursive: true });
   }
 
-  // Write myco.yaml — all values explicit, no hidden defaults
+  // Write minimal myco.yaml — provider settings are written by setup-llm/setup-digest
   const config: Record<string, unknown> = {
     version: 2,
     intelligence: {
       llm: {
-        provider: llmProvider,
-        model: llmModel,
-        ...(llmUrl ? { base_url: llmUrl } : {}),
+        provider: 'ollama',
+        model: 'qwen3.5',
         context_window: 8192,
         max_tokens: 1024,
       },
       embedding: {
-        provider: embeddingProvider,
-        model: embeddingModel,
-        ...(embeddingUrl ? { base_url: embeddingUrl } : {}),
+        provider: 'ollama',
+        model: 'bge-m3',
       },
     },
     daemon: {
@@ -99,12 +92,42 @@ export async function run(args: string[]): Promise<void> {
   initFts(index);
   index.close();
 
+  // Apply LLM provider settings from flags (if any were passed)
+  const llmFlags: string[] = [];
+  const llmProvider = parseStringFlag(args, '--llm-provider');
+  const llmModel = parseStringFlag(args, '--llm-model');
+  const llmUrl = parseStringFlag(args, '--llm-url');
+  if (llmProvider) llmFlags.push('--llm-provider', llmProvider);
+  if (llmModel) llmFlags.push('--llm-model', llmModel);
+  if (llmUrl) llmFlags.push('--llm-url', llmUrl);
+  const embeddingProvider = parseStringFlag(args, '--embedding-provider');
+  const embeddingModel = parseStringFlag(args, '--embedding-model');
+  const embeddingUrl = parseStringFlag(args, '--embedding-url');
+  if (embeddingProvider) llmFlags.push('--embedding-provider', embeddingProvider);
+  if (embeddingModel) llmFlags.push('--embedding-model', embeddingModel);
+  if (embeddingUrl) llmFlags.push('--embedding-url', embeddingUrl);
+
+  if (llmFlags.length > 0) {
+    await setupLlm(llmFlags, vaultDir);
+  }
+
+  // Apply digest settings from flags (if any were passed)
+  const digestFlags: string[] = [];
+  const tiers = parseStringFlag(args, '--tiers');
+  const injectTier = parseStringFlag(args, '--inject-tier');
+  const contextWindow = parseStringFlag(args, '--context-window');
+  if (tiers) digestFlags.push('--tiers', tiers);
+  if (injectTier) digestFlags.push('--inject-tier', injectTier);
+  if (contextWindow) digestFlags.push('--context-window', contextWindow);
+
+  if (digestFlags.length > 0) {
+    await setupDigest(digestFlags, vaultDir);
+  }
+
   // Summary
   console.log('');
   console.log('=== Myco Vault Initialized ===');
   console.log(`Path:               ${vaultDir}`);
-  console.log(`LLM provider:       ${llmProvider} / ${llmModel}`);
-  console.log(`Embedding provider: ${embeddingProvider} / ${embeddingModel}`);
   console.log(`Team mode:          ${teamEnabled ? 'enabled' : 'disabled'}`);
   if (user) console.log(`User:               ${user}`);
   console.log('');

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -7,6 +7,7 @@ import {
   VAULT_GITIGNORE,
   configureVaultEnv,
 } from './shared.js';
+import { MycoConfigSchema } from '../config/schema.js';
 import { run as setupLlm } from './setup-llm.js';
 import { run as setupDigest } from './setup-digest.js';
 import fs from 'node:fs';
@@ -38,42 +39,18 @@ export async function run(args: string[]): Promise<void> {
     fs.mkdirSync(path.join(vaultDir, dir), { recursive: true });
   }
 
-  // Write minimal myco.yaml — provider settings are written by setup-llm/setup-digest
-  const config: Record<string, unknown> = {
-    version: 2,
+  // Write myco.yaml — pass only required fields, let Zod schema populate defaults.
+  // intelligence.llm and intelligence.embedding are required (no defaults),
+  // everything else has Zod defaults.
+  const minimal = {
+    version: 2 as const,
     intelligence: {
-      llm: {
-        provider: 'ollama',
-        model: 'qwen3.5',
-        context_window: 8192,
-        max_tokens: 1024,
-      },
-      embedding: {
-        provider: 'ollama',
-        model: 'bge-m3',
-      },
+      llm: { provider: 'ollama' as const, model: 'qwen3.5' },
+      embedding: { provider: 'ollama' as const, model: 'bge-m3' },
     },
-    daemon: {
-      log_level: 'info',
-      grace_period: 30,
-      max_log_size: 5242880,
-    },
-    capture: {
-      transcript_paths: [],
-      artifact_watch: ['.claude/plans/', '.cursor/plans/'],
-      artifact_extensions: ['.md'],
-      buffer_max_events: 500,
-    },
-    context: {
-      max_tokens: 1200,
-      layers: { plans: 200, sessions: 500, spores: 300, team: 200 },
-    },
-    team: {
-      enabled: teamEnabled,
-      user,
-      sync: 'git',
-    },
+    team: { user, enabled: teamEnabled },
   };
+  const config = MycoConfigSchema.parse(minimal);
 
   fs.writeFileSync(
     path.join(vaultDir, 'myco.yaml'),

--- a/src/cli/rebuild.ts
+++ b/src/cli/rebuild.ts
@@ -26,7 +26,7 @@ export async function run(_args: string[], vaultDir: string): Promise<void> {
     const vec = new VectorIndex(vecDb, testEmbed.dimensions);
 
     const allNotes = index.query({});
-    // Skip superseded/archived memories — they shouldn't appear in vector search
+    // Skip superseded/archived spores — they shouldn't appear in vector search
     const activeNotes = allNotes.filter((n) => {
       const status = (n.frontmatter as Record<string, unknown>)?.status as string | undefined;
       return status !== 'superseded' && status !== 'archived';

--- a/src/cli/reprocess.ts
+++ b/src/cli/reprocess.ts
@@ -145,7 +145,7 @@ export async function run(args: string[], vaultDir: string): Promise<void> {
             embedJobs.push({
               id: `${o.type}-${task.bare.slice(-6)}-${Date.now()}`,
               text: `${o.title}\n${o.content}`.slice(0, EMBEDDING_INPUT_LIMIT),
-              metadata: { type: 'memory', session_id: task.bare },
+              metadata: { type: 'spore', session_id: task.bare },
             });
           }
         }

--- a/src/cli/reprocess.ts
+++ b/src/cli/reprocess.ts
@@ -3,7 +3,7 @@
  * for existing sessions. Useful after bugs or when the LLM backend changes.
  *
  * Reads transcripts (the source of truth), re-extracts observations, regenerates
- * summaries, and re-indexes everything. Existing memory files from those sessions
+ * summaries, and re-indexes everything. Existing spore files from those sessions
  * are preserved — new observations are additive.
  */
 import fs from 'node:fs';

--- a/src/cli/setup-digest.ts
+++ b/src/cli/setup-digest.ts
@@ -1,0 +1,167 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import YAML from 'yaml';
+import { MycoConfigSchema } from '../config/schema.js';
+import { parseStringFlag } from './shared.js';
+
+const CONFIG_FILENAME = 'myco.yaml';
+const DAEMON_STATE_FILENAME = 'daemon.json';
+
+const USAGE = `Usage: myco setup-digest [options]
+
+Configure digest (continuous reasoning) settings.
+
+Options:
+  --enabled <true|false>        Enable/disable digest (default: true)
+  --tiers <1500,3000,...>       Comma-separated tier list
+  --inject-tier <number|null>   Tier to auto-inject at session start
+  --provider <name>             LLM provider for digest (null = inherit)
+  --model <name>                Model for digest (null = inherit)
+  --base-url <url>              Provider base URL (null = inherit)
+  --context-window <number>     Context window for digest operations
+  --keep-alive <duration>       Keep model loaded (Ollama, e.g. "30m")
+  --gpu-kv-cache <true|false>   Offload KV cache to GPU (LM Studio)
+  --active-interval <seconds>   Metabolism active interval
+  --dormancy-threshold <seconds> Time before dormancy
+  --max-notes <number>          Max substrate notes per cycle
+  --extraction-tokens <number>  Max tokens for spore extraction
+  --summary-tokens <number>     Max tokens for session summaries
+  --title-tokens <number>       Max tokens for session titles
+  --classification-tokens <number> Max tokens for artifact classification
+  --show                        Show current settings and exit
+`;
+
+export async function run(args: string[], vaultDir: string): Promise<void> {
+  const configPath = path.join(vaultDir, CONFIG_FILENAME);
+  const raw = fs.readFileSync(configPath, 'utf-8');
+  const doc = YAML.parse(raw) as Record<string, unknown>;
+
+  // Show current settings
+  if (args.includes('--show')) {
+    const config = MycoConfigSchema.parse(doc);
+    console.log(JSON.stringify({
+      digest: config.digest,
+      capture: {
+        extraction_max_tokens: config.capture.extraction_max_tokens,
+        summary_max_tokens: config.capture.summary_max_tokens,
+        title_max_tokens: config.capture.title_max_tokens,
+        classification_max_tokens: config.capture.classification_max_tokens,
+      },
+    }, null, 2));
+    return;
+  }
+
+  // No flags = show usage
+  if (args.length === 0) {
+    console.log(USAGE);
+    return;
+  }
+
+  // Ensure digest section exists
+  if (!doc.digest || typeof doc.digest !== 'object') {
+    doc.digest = {};
+  }
+  const digest = doc.digest as Record<string, unknown>;
+
+  // Ensure nested sections exist
+  if (!digest.intelligence || typeof digest.intelligence !== 'object') {
+    digest.intelligence = {};
+  }
+  if (!digest.metabolism || typeof digest.metabolism !== 'object') {
+    digest.metabolism = {};
+  }
+  if (!digest.substrate || typeof digest.substrate !== 'object') {
+    digest.substrate = {};
+  }
+  if (!doc.capture || typeof doc.capture !== 'object') {
+    doc.capture = {};
+  }
+
+  const intelligence = digest.intelligence as Record<string, unknown>;
+  const metabolism = digest.metabolism as Record<string, unknown>;
+  const substrate = digest.substrate as Record<string, unknown>;
+  const capture = doc.capture as Record<string, unknown>;
+
+  // Parse and apply flags
+  const enabled = parseStringFlag(args, '--enabled');
+  if (enabled !== undefined) digest.enabled = enabled === 'true';
+
+  const tiers = parseStringFlag(args, '--tiers');
+  if (tiers !== undefined) {
+    digest.tiers = tiers.split(',').map((t) => parseInt(t.trim(), 10));
+  }
+
+  const injectTier = parseStringFlag(args, '--inject-tier');
+  if (injectTier !== undefined) {
+    digest.inject_tier = injectTier === 'null' ? null : parseInt(injectTier, 10);
+  }
+
+  const provider = parseStringFlag(args, '--provider');
+  if (provider !== undefined) intelligence.provider = provider === 'null' ? null : provider;
+
+  const model = parseStringFlag(args, '--model');
+  if (model !== undefined) intelligence.model = model === 'null' ? null : model;
+
+  const baseUrl = parseStringFlag(args, '--base-url');
+  if (baseUrl !== undefined) intelligence.base_url = baseUrl === 'null' ? null : baseUrl;
+
+  const contextWindow = parseStringFlag(args, '--context-window');
+  if (contextWindow !== undefined) intelligence.context_window = parseInt(contextWindow, 10);
+
+  const keepAlive = parseStringFlag(args, '--keep-alive');
+  if (keepAlive !== undefined) intelligence.keep_alive = keepAlive === 'null' ? null : keepAlive;
+
+  const gpuKvCache = parseStringFlag(args, '--gpu-kv-cache');
+  if (gpuKvCache !== undefined) intelligence.gpu_kv_cache = gpuKvCache === 'true';
+
+  const activeInterval = parseStringFlag(args, '--active-interval');
+  if (activeInterval !== undefined) metabolism.active_interval = parseInt(activeInterval, 10);
+
+  const dormancyThreshold = parseStringFlag(args, '--dormancy-threshold');
+  if (dormancyThreshold !== undefined) metabolism.dormancy_threshold = parseInt(dormancyThreshold, 10);
+
+  const maxNotes = parseStringFlag(args, '--max-notes');
+  if (maxNotes !== undefined) substrate.max_notes_per_cycle = parseInt(maxNotes, 10);
+
+  const extractionTokens = parseStringFlag(args, '--extraction-tokens');
+  if (extractionTokens !== undefined) capture.extraction_max_tokens = parseInt(extractionTokens, 10);
+
+  const summaryTokens = parseStringFlag(args, '--summary-tokens');
+  if (summaryTokens !== undefined) capture.summary_max_tokens = parseInt(summaryTokens, 10);
+
+  const titleTokens = parseStringFlag(args, '--title-tokens');
+  if (titleTokens !== undefined) capture.title_max_tokens = parseInt(titleTokens, 10);
+
+  const classificationTokens = parseStringFlag(args, '--classification-tokens');
+  if (classificationTokens !== undefined) capture.classification_max_tokens = parseInt(classificationTokens, 10);
+
+  // Validate the full config
+  const result = MycoConfigSchema.safeParse(doc);
+  if (!result.success) {
+    console.error('Validation error:');
+    for (const issue of result.error.issues) {
+      console.error(`  ${issue.path.join('.')}: ${issue.message}`);
+    }
+    process.exit(1);
+  }
+
+  // Write back
+  fs.writeFileSync(configPath, YAML.stringify(doc), 'utf-8');
+  console.log('Digest configuration updated.');
+
+  // Show what was set
+  const updated = MycoConfigSchema.parse(doc);
+  console.log(JSON.stringify({
+    digest: updated.digest,
+    capture: {
+      extraction_max_tokens: updated.capture.extraction_max_tokens,
+      summary_max_tokens: updated.capture.summary_max_tokens,
+      title_max_tokens: updated.capture.title_max_tokens,
+      classification_max_tokens: updated.capture.classification_max_tokens,
+    },
+  }, null, 2));
+
+  if (fs.existsSync(path.join(vaultDir, DAEMON_STATE_FILENAME))) {
+    console.log('\nNote: restart the daemon for changes to take effect (myco restart)');
+  }
+}

--- a/src/cli/setup-llm.ts
+++ b/src/cli/setup-llm.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import YAML from 'yaml';
+import { MycoConfigSchema } from '../config/schema.js';
+import { parseStringFlag } from './shared.js';
+
+const CONFIG_FILENAME = 'myco.yaml';
+const DAEMON_STATE_FILENAME = 'daemon.json';
+
+const USAGE = `Usage: myco setup-llm [options]
+
+Configure LLM and embedding provider settings.
+
+Options:
+  --llm-provider <name>         LLM provider (ollama, lm-studio, anthropic)
+  --llm-model <name>            LLM model name
+  --llm-url <url>               LLM provider base URL
+  --llm-context-window <number> LLM context window (tokens)
+  --llm-max-tokens <number>     LLM max output tokens
+  --embedding-provider <name>   Embedding provider (ollama, lm-studio)
+  --embedding-model <name>      Embedding model name
+  --embedding-url <url>         Embedding provider base URL
+  --show                        Show current settings and exit
+`;
+
+export async function run(args: string[], vaultDir: string): Promise<void> {
+  const configPath = path.join(vaultDir, CONFIG_FILENAME);
+  const raw = fs.readFileSync(configPath, 'utf-8');
+  const doc = YAML.parse(raw) as Record<string, unknown>;
+
+  // Show current settings
+  if (args.includes('--show')) {
+    const config = MycoConfigSchema.parse(doc);
+    console.log(JSON.stringify(config.intelligence, null, 2));
+    return;
+  }
+
+  // No flags = show usage
+  if (args.length === 0) {
+    console.log(USAGE);
+    return;
+  }
+
+  // Ensure intelligence section exists
+  if (!doc.intelligence || typeof doc.intelligence !== 'object') {
+    doc.intelligence = {};
+  }
+  const intelligence = doc.intelligence as Record<string, unknown>;
+
+  if (!intelligence.llm || typeof intelligence.llm !== 'object') {
+    intelligence.llm = {};
+  }
+  if (!intelligence.embedding || typeof intelligence.embedding !== 'object') {
+    intelligence.embedding = {};
+  }
+
+  const llm = intelligence.llm as Record<string, unknown>;
+  const embedding = intelligence.embedding as Record<string, unknown>;
+
+  // Parse and apply flags
+  const llmProvider = parseStringFlag(args, '--llm-provider');
+  if (llmProvider !== undefined) llm.provider = llmProvider;
+
+  const llmModel = parseStringFlag(args, '--llm-model');
+  if (llmModel !== undefined) llm.model = llmModel;
+
+  const llmUrl = parseStringFlag(args, '--llm-url');
+  if (llmUrl !== undefined) llm.base_url = llmUrl;
+
+  const llmContextWindow = parseStringFlag(args, '--llm-context-window');
+  if (llmContextWindow !== undefined) llm.context_window = parseInt(llmContextWindow, 10);
+
+  const llmMaxTokens = parseStringFlag(args, '--llm-max-tokens');
+  if (llmMaxTokens !== undefined) llm.max_tokens = parseInt(llmMaxTokens, 10);
+
+  const embeddingProvider = parseStringFlag(args, '--embedding-provider');
+  if (embeddingProvider !== undefined) embedding.provider = embeddingProvider;
+
+  const embeddingModel = parseStringFlag(args, '--embedding-model');
+  if (embeddingModel !== undefined) embedding.model = embeddingModel;
+
+  const embeddingUrl = parseStringFlag(args, '--embedding-url');
+  if (embeddingUrl !== undefined) embedding.base_url = embeddingUrl;
+
+  // Validate the full config
+  const result = MycoConfigSchema.safeParse(doc);
+  if (!result.success) {
+    console.error('Validation error:');
+    for (const issue of result.error.issues) {
+      console.error(`  ${issue.path.join('.')}: ${issue.message}`);
+    }
+    process.exit(1);
+  }
+
+  // Write back
+  fs.writeFileSync(configPath, YAML.stringify(doc), 'utf-8');
+  console.log('Intelligence configuration updated.');
+
+  // Show what was set
+  const updated = MycoConfigSchema.parse(doc);
+  console.log(JSON.stringify(updated.intelligence, null, 2));
+
+  // Warn about embedding model changes
+  if (embeddingModel !== undefined) {
+    console.log('\nWarning: changing the embedding model requires a full vector index rebuild.');
+    console.log('Run: node dist/src/cli.js rebuild');
+  }
+
+  if (fs.existsSync(path.join(vaultDir, DAEMON_STATE_FILENAME))) {
+    console.log('\nNote: restart the daemon for changes to take effect (myco restart)');
+  }
+}

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -44,22 +44,22 @@ TABLE user, started, tools_used FROM #type/session
 SORT started DESC LIMIT 10
 \`\`\`
 
-## Recent Memories
+## Recent Spores
 \`\`\`dataview
-TABLE observation_type AS "Type", created FROM #type/memory
+TABLE observation_type AS "Type", created FROM #type/spore
 SORT created DESC LIMIT 15
 \`\`\`
 
-## Memories by Type
+## Spores by Type
 \`\`\`dataview
 TABLE WITHOUT ID observation_type AS "Type", length(rows) AS "Count"
-FROM #type/memory GROUP BY observation_type
+FROM #type/spore GROUP BY observation_type
 SORT length(rows) DESC
 \`\`\`
 
 ## Gotchas
 \`\`\`dataview
-LIST FROM #memory/gotcha SORT created DESC LIMIT 10
+LIST FROM #spore/gotcha SORT created DESC LIMIT 10
 \`\`\`
 `;
 

--- a/src/cli/stats.ts
+++ b/src/cli/stats.ts
@@ -8,7 +8,7 @@ export function run(_args: string[], vaultDir: string): void {
   const index = new MycoIndex(path.join(vaultDir, 'index.db'));
 
   const sessions = index.query({ type: 'session' });
-  const memories = index.query({ type: 'memory' });
+  const spores = index.query({ type: 'spore' });
   const plans = index.query({ type: 'plan' });
 
   console.log('=== Myco Vault ===');
@@ -16,17 +16,17 @@ export function run(_args: string[], vaultDir: string): void {
   console.log();
   console.log('--- Index ---');
   console.log(`Sessions:  ${sessions.length}`);
-  console.log(`Memories:  ${memories.length}`);
+  console.log(`Spores:    ${spores.length}`);
   console.log(`Plans:     ${plans.length}`);
 
-  // Memory breakdown by type
+  // Spore breakdown by type
   const types: Record<string, number> = {};
-  for (const m of memories) {
+  for (const m of spores) {
     const t = (m.frontmatter as Record<string, unknown>)?.observation_type as string || 'unknown';
     types[t] = (types[t] || 0) + 1;
   }
   if (Object.keys(types).length > 0) {
-    console.log('\n--- Memories by Type ---');
+    console.log('\n--- Spores by Type ---');
     for (const [t, c] of Object.entries(types).sort((a, b) => b[1] - a[1])) {
       console.log(`  ${t}: ${c}`);
     }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,22 +1,22 @@
 import { z } from 'zod';
 
 const LlmProviderSchema = z.object({
-  provider: z.enum(['ollama', 'lm-studio', 'anthropic']),
-  model: z.string(),
+  provider: z.enum(['ollama', 'lm-studio', 'anthropic']).default('ollama'),
+  model: z.string().default('qwen3.5'),
   base_url: z.string().url().optional(),
   context_window: z.number().int().positive().default(8192),
   max_tokens: z.number().int().positive().default(1024),
 });
 
 const EmbeddingProviderSchema = z.object({
-  provider: z.enum(['ollama', 'lm-studio']),
-  model: z.string(),
+  provider: z.enum(['ollama', 'lm-studio']).default('ollama'),
+  model: z.string().default('bge-m3'),
   base_url: z.string().url().optional(),
 });
 
 const IntelligenceSchema = z.object({
-  llm: LlmProviderSchema,
-  embedding: EmbeddingProviderSchema,
+  llm: LlmProviderSchema.default(() => LlmProviderSchema.parse({})),
+  embedding: EmbeddingProviderSchema.default(() => EmbeddingProviderSchema.parse({})),
 });
 
 const DaemonSchema = z.object({

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -93,11 +93,11 @@ const DigestSchema = z.object({
 
 export const MycoConfigSchema = z.object({
   version: z.literal(2),
-  intelligence: IntelligenceSchema,
-  daemon: DaemonSchema.default({ log_level: 'info', grace_period: 30, max_log_size: 5_242_880 }),
+  intelligence: IntelligenceSchema.default(() => IntelligenceSchema.parse({})),
+  daemon: DaemonSchema.default(() => DaemonSchema.parse({})),
   capture: CaptureSchema.default(() => CaptureSchema.parse({})),
-  context: ContextSchema.default({ max_tokens: 1200, layers: { plans: 200, sessions: 500, spores: 300, team: 200 } }),
-  team: TeamSchema.default({ enabled: false, user: '', sync: 'git' }),
+  context: ContextSchema.default(() => ContextSchema.parse({})),
+  team: TeamSchema.default(() => TeamSchema.parse({})),
   digest: DigestSchema.default(() => DigestSchema.parse({})),
 });
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -53,6 +53,32 @@ const TeamSchema = z.object({
   sync: z.enum(['git', 'obsidian-sync', 'manual']).default('git'),
 });
 
+const DigestIntelligenceSchema = z.object({
+  provider: z.enum(['ollama', 'lm-studio', 'anthropic']).nullable().default(null),
+  model: z.string().nullable().default(null),
+  base_url: z.string().nullable().default(null),
+  context_window: z.number().int().positive().default(32768),
+});
+
+const DigestMetabolismSchema = z.object({
+  active_interval: z.number().int().positive().default(300),
+  cooldown_intervals: z.array(z.number().int().positive()).default([900, 1800, 3600]),
+  dormancy_threshold: z.number().int().positive().default(7200),
+});
+
+const DigestSubstrateSchema = z.object({
+  max_notes_per_cycle: z.number().int().positive().default(50),
+});
+
+const DigestSchema = z.object({
+  enabled: z.boolean().default(true),
+  tiers: z.array(z.number().int().positive()).default([1500, 3000, 5000, 10000]),
+  inject_tier: z.number().int().positive().nullable().default(3000),
+  intelligence: DigestIntelligenceSchema.default(() => DigestIntelligenceSchema.parse({})),
+  metabolism: DigestMetabolismSchema.default(() => DigestMetabolismSchema.parse({})),
+  substrate: DigestSubstrateSchema.default(() => DigestSubstrateSchema.parse({})),
+});
+
 export const MycoConfigSchema = z.object({
   version: z.literal(2),
   intelligence: IntelligenceSchema,
@@ -60,8 +86,11 @@ export const MycoConfigSchema = z.object({
   capture: CaptureSchema.default({ transcript_paths: [], artifact_watch: ['.claude/plans/', '.cursor/plans/'], artifact_extensions: ['.md'], buffer_max_events: 500 }),
   context: ContextSchema.default({ max_tokens: 1200, layers: { plans: 200, sessions: 500, spores: 300, team: 200 } }),
   team: TeamSchema.default({ enabled: false, user: '', sync: 'git' }),
+  digest: DigestSchema.default(() => DigestSchema.parse({})),
 });
 
 export type MycoConfig = z.infer<typeof MycoConfigSchema>;
 export type LlmProviderConfig = z.infer<typeof LlmProviderSchema>;
 export type EmbeddingProviderConfig = z.infer<typeof EmbeddingProviderSchema>;
+export type DigestConfig = z.infer<typeof DigestSchema>;
+export type DigestIntelligenceConfig = z.infer<typeof DigestIntelligenceSchema>;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -38,13 +38,13 @@ const CaptureSchema = z.object({
 const ContextLayersSchema = z.object({
   plans: z.number().int().nonnegative().default(200),
   sessions: z.number().int().nonnegative().default(500),
-  memories: z.number().int().nonnegative().default(300),
+  spores: z.number().int().nonnegative().default(300),
   team: z.number().int().nonnegative().default(200),
 });
 
 const ContextSchema = z.object({
   max_tokens: z.number().int().positive().default(1200),
-  layers: ContextLayersSchema.default({ plans: 200, sessions: 500, memories: 300, team: 200 }),
+  layers: ContextLayersSchema.default({ plans: 200, sessions: 500, spores: 300, team: 200 }),
 });
 
 const TeamSchema = z.object({
@@ -58,7 +58,7 @@ export const MycoConfigSchema = z.object({
   intelligence: IntelligenceSchema,
   daemon: DaemonSchema.default({ log_level: 'info', grace_period: 30, max_log_size: 5_242_880 }),
   capture: CaptureSchema.default({ transcript_paths: [], artifact_watch: ['.claude/plans/', '.cursor/plans/'], artifact_extensions: ['.md'], buffer_max_events: 500 }),
-  context: ContextSchema.default({ max_tokens: 1200, layers: { plans: 200, sessions: 500, memories: 300, team: 200 } }),
+  context: ContextSchema.default({ max_tokens: 1200, layers: { plans: 200, sessions: 500, spores: 300, team: 200 } }),
   team: TeamSchema.default({ enabled: false, user: '', sync: 'git' }),
 });
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -58,6 +58,10 @@ const DigestIntelligenceSchema = z.object({
   model: z.string().nullable().default(null),
   base_url: z.string().nullable().default(null),
   context_window: z.number().int().positive().default(32768),
+  /** Keep model loaded between digest cycles. Ollama duration string (e.g., "30m") or null for provider default. */
+  keep_alive: z.string().nullable().default('30m'),
+  /** Whether to offload KV cache to GPU. false = use system RAM (safer for large contexts). */
+  gpu_kv_cache: z.boolean().default(false),
 });
 
 const DigestMetabolismSchema = z.object({

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -35,8 +35,8 @@ const CaptureSchema = z.object({
   buffer_max_events: z.number().int().positive().default(500),
   /** Max output tokens for spore/observation extraction per batch. */
   extraction_max_tokens: z.number().int().positive().default(2048),
-  /** Max output tokens for session summary generation. */
-  summary_max_tokens: z.number().int().positive().default(512),
+  /** Max output tokens for session summary generation. Higher = richer summaries for digest. */
+  summary_max_tokens: z.number().int().positive().default(1024),
   /** Max output tokens for session title generation. */
   title_max_tokens: z.number().int().positive().default(32),
   /** Max output tokens for artifact classification. */

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -33,6 +33,14 @@ const CaptureSchema = z.object({
   ]),
   artifact_extensions: z.array(z.string()).default(['.md']),
   buffer_max_events: z.number().int().positive().default(500),
+  /** Max output tokens for spore/observation extraction per batch. */
+  extraction_max_tokens: z.number().int().positive().default(2048),
+  /** Max output tokens for session summary generation. */
+  summary_max_tokens: z.number().int().positive().default(512),
+  /** Max output tokens for session title generation. */
+  title_max_tokens: z.number().int().positive().default(32),
+  /** Max output tokens for artifact classification. */
+  classification_max_tokens: z.number().int().positive().default(1024),
 });
 
 const ContextLayersSchema = z.object({
@@ -87,7 +95,7 @@ export const MycoConfigSchema = z.object({
   version: z.literal(2),
   intelligence: IntelligenceSchema,
   daemon: DaemonSchema.default({ log_level: 'info', grace_period: 30, max_log_size: 5_242_880 }),
-  capture: CaptureSchema.default({ transcript_paths: [], artifact_watch: ['.claude/plans/', '.cursor/plans/'], artifact_extensions: ['.md'], buffer_max_events: 500 }),
+  capture: CaptureSchema.default(() => CaptureSchema.parse({})),
   context: ContextSchema.default({ max_tokens: 1200, layers: { plans: 200, sessions: 500, spores: 300, team: 200 } }),
   team: TeamSchema.default({ enabled: false, user: '', sync: 'git' }),
   digest: DigestSchema.default(() => DigestSchema.parse({})),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,11 @@
 /** Approximate characters per token for the chars/4 heuristic. */
 export const CHARS_PER_TOKEN = 4;
 
+/** Estimate token count from character length using the CHARS_PER_TOKEN heuristic. */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
 // --- Embedding ---
 /** Max characters of text sent to the embedding model. */
 export const EMBEDDING_INPUT_LIMIT = 8000;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -52,6 +52,8 @@ export const DAEMON_HEALTH_CHECK_TIMEOUT_MS = 500;
 export const LLM_REQUEST_TIMEOUT_MS = 180_000;
 /** Embedding request timeout (ms). Embeddings run in background batch processing — generous timeout. */
 export const EMBEDDING_REQUEST_TIMEOUT_MS = 60_000;
+/** Digest LLM request timeout (ms). Digest cycles use large context windows and may need model loading time. */
+export const DIGEST_LLM_REQUEST_TIMEOUT_MS = 600_000;
 /** Stdin read timeout for hooks (ms). */
 export const STDIN_TIMEOUT_MS = 100;
 /** Chokidar write stability threshold (ms). */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,7 +31,7 @@ export const RECALL_SUMMARY_PREVIEW_CHARS = 200;
 // --- Context injection layer budgets (chars, not tokens — used with .slice()) ---
 export const CONTEXT_PLAN_PREVIEW_CHARS = 100;
 export const CONTEXT_SESSION_PREVIEW_CHARS = 80;
-export const CONTEXT_MEMORY_PREVIEW_CHARS = 80;
+export const CONTEXT_SPORE_PREVIEW_CHARS = 80;
 
 // --- Processor maxTokens budgets ---
 /** Response token budget for observation extraction. */
@@ -82,14 +82,14 @@ export const MIN_TRANSCRIPT_CONTENT_LENGTH = 10;
 // --- Query limits ---
 /** Max recent sessions to check for lineage heuristics. */
 export const LINEAGE_RECENT_SESSIONS_LIMIT = 5;
-/** Max related memories to query for session notes. */
-export const RELATED_MEMORIES_LIMIT = 50;
+/** Max related spores to query for session notes. */
+export const RELATED_SPORES_LIMIT = 50;
 
 // --- Context injection ---
 /** Max active plans to inject at session start. */
 export const SESSION_CONTEXT_MAX_PLANS = 3;
-/** Max memories to inject per prompt. */
-export const PROMPT_CONTEXT_MAX_MEMORIES = 3;
+/** Max spores to inject per prompt. */
+export const PROMPT_CONTEXT_MAX_SPORES = 3;
 /** Minimum similarity score for prompt context injection (0-1). */
 export const PROMPT_CONTEXT_MIN_SIMILARITY = 0.3;
 /** Max token budget for session-start context injection. */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -134,5 +134,3 @@ export const DIGEST_SUBSTRATE_TYPE_WEIGHTS: Record<string, number> = {
 };
 
 // --- Digest — System prompt overhead estimate ---
-/** Estimated token overhead for the digest system prompt. */
-export const DIGEST_SYSTEM_PROMPT_TOKENS = 500;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -106,3 +106,43 @@ export const MCP_SEARCH_DEFAULT_LIMIT = 10;
 export const MCP_SESSIONS_DEFAULT_LIMIT = 20;
 /** Default result limit for myco_logs. */
 export const MCP_LOGS_DEFAULT_LIMIT = 50;
+
+// --- Digest — Metabolism ---
+/** How often the digest engine runs while the session is active (ms). */
+export const DIGEST_ACTIVE_INTERVAL_MS = 300_000;
+/** Cooldown schedule — intervals grow as session goes idle (ms). */
+export const DIGEST_COOLDOWN_INTERVALS_MS = [900_000, 1_800_000, 3_600_000];
+/** Time since last activity before the engine enters dormancy (ms). */
+export const DIGEST_DORMANCY_THRESHOLD_MS = 7_200_000;
+/** Activity window used to determine whether a session is "active" (ms). */
+export const DIGEST_ACTIVE_SESSION_WINDOW_MS = 1_800_000;
+
+// --- Digest — Tiers ---
+/** Available token-budget tiers for digest synthesis. */
+export const DIGEST_TIERS = [1500, 3000, 5000, 10000] as const;
+export type DigestTier = (typeof DIGEST_TIERS)[number];
+
+// --- Digest — Context window minimums per tier ---
+/** Minimum context window (tokens) required to run a digest at a given tier. */
+export const DIGEST_TIER_MIN_CONTEXT: Record<number, number> = {
+  1500: 6500,
+  3000: 11500,
+  5000: 18500,
+  10000: 30500,
+};
+
+// --- Digest — Substrate ---
+/** Max notes fetched from the index per digest cycle. */
+export const DIGEST_MAX_NOTES_PER_CYCLE = 50;
+/** Scoring weights by note type when selecting substrate for synthesis. */
+export const DIGEST_SUBSTRATE_TYPE_WEIGHTS: Record<string, number> = {
+  session: 3,
+  spore: 3,
+  plan: 2,
+  artifact: 1,
+  team: 1,
+};
+
+// --- Digest — System prompt overhead estimate ---
+/** Estimated token overhead for the digest system prompt. */
+export const DIGEST_SYSTEM_PROMPT_TOKENS = 500;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -107,16 +107,6 @@ export const MCP_SESSIONS_DEFAULT_LIMIT = 20;
 /** Default result limit for myco_logs. */
 export const MCP_LOGS_DEFAULT_LIMIT = 50;
 
-// --- Digest — Metabolism ---
-/** How often the digest engine runs while the session is active (ms). */
-export const DIGEST_ACTIVE_INTERVAL_MS = 300_000;
-/** Cooldown schedule — intervals grow as session goes idle (ms). */
-export const DIGEST_COOLDOWN_INTERVALS_MS = [900_000, 1_800_000, 3_600_000];
-/** Time since last activity before the engine enters dormancy (ms). */
-export const DIGEST_DORMANCY_THRESHOLD_MS = 7_200_000;
-/** Activity window used to determine whether a session is "active" (ms). */
-export const DIGEST_ACTIVE_SESSION_WINDOW_MS = 1_800_000;
-
 // --- Digest — Tiers ---
 /** Available token-budget tiers for digest synthesis. */
 export const DIGEST_TIERS = [1500, 3000, 5000, 10000] as const;
@@ -132,8 +122,6 @@ export const DIGEST_TIER_MIN_CONTEXT: Record<number, number> = {
 };
 
 // --- Digest — Substrate ---
-/** Max notes fetched from the index per digest cycle. */
-export const DIGEST_MAX_NOTES_PER_CYCLE = 50;
 /** Scoring weights by note type when selecting substrate for synthesis. */
 export const DIGEST_SUBSTRATE_TYPE_WEIGHTS: Record<string, number> = {
   session: 3,

--- a/src/context/injector.ts
+++ b/src/context/injector.ts
@@ -1,8 +1,8 @@
 import type { MycoIndex } from '../index/sqlite.js';
 import type { MycoConfig } from '../config/schema.js';
-import { planFm, memoryFm } from '../vault/frontmatter.js';
+import { planFm, sporeFm } from '../vault/frontmatter.js';
 import { scoreRelevance } from './relevance.js';
-import { CHARS_PER_TOKEN, CONTEXT_PLAN_PREVIEW_CHARS, CONTEXT_SESSION_PREVIEW_CHARS, CONTEXT_MEMORY_PREVIEW_CHARS } from '../constants.js';
+import { CHARS_PER_TOKEN, CONTEXT_PLAN_PREVIEW_CHARS, CONTEXT_SESSION_PREVIEW_CHARS, CONTEXT_SPORE_PREVIEW_CHARS } from '../constants.js';
 
 interface InjectionContext {
   branch?: string;
@@ -14,7 +14,7 @@ interface InjectedContext {
   layers: {
     plans: string;
     sessions: string;
-    memories: string;
+    spores: string;
     team: string;
   };
 }
@@ -52,29 +52,29 @@ export function buildInjectedContext(
     budgets.sessions,
   );
 
-  // Layer 3: Relevant memories (exclude superseded/archived)
-  const memories = index.query({ type: 'memory', limit: 20 })
+  // Layer 3: Relevant spores (exclude superseded/archived)
+  const spores = index.query({ type: 'spore', limit: 20 })
     .filter((m) => {
-      const status = memoryFm(m).status;
+      const status = sporeFm(m).status;
       return status !== 'superseded' && status !== 'archived';
     });
-  const scoredMemories = scoreRelevance(memories, {
+  const scoredSpores = scoreRelevance(spores, {
     branch: context.branch,
     activePlanIds,
   });
-  const memoriesText = formatLayer(
-    'Relevant Memories',
-    scoredMemories.slice(0, 5).map((m) =>
-      `- **${m.note.title}** (${memoryFm(m.note).observation_type}): ${m.note.content.slice(0, CONTEXT_MEMORY_PREVIEW_CHARS)}`,
+  const sporesText = formatLayer(
+    'Relevant Spores',
+    scoredSpores.slice(0, 5).map((m) =>
+      `- **${m.note.title}** (${sporeFm(m.note).observation_type}): ${m.note.content.slice(0, CONTEXT_SPORE_PREVIEW_CHARS)}`,
     ),
-    budgets.memories,
+    budgets.spores,
   );
 
   // Layer 4: Team activity
   const teamText = formatLayer('Team Activity', [], budgets.team);
 
   // Enforce total max_tokens budget
-  const allLayers = [plansText, sessionsText, memoriesText, teamText].filter(Boolean);
+  const allLayers = [plansText, sessionsText, sporesText, teamText].filter(Boolean);
   const parts: string[] = [];
   let totalTokens = 0;
 
@@ -93,7 +93,7 @@ export function buildInjectedContext(
     layers: {
       plans: plansText,
       sessions: sessionsText,
-      memories: memoriesText,
+      spores: sporesText,
       team: teamText,
     },
   };

--- a/src/context/injector.ts
+++ b/src/context/injector.ts
@@ -2,7 +2,7 @@ import type { MycoIndex } from '../index/sqlite.js';
 import type { MycoConfig } from '../config/schema.js';
 import { planFm, sporeFm } from '../vault/frontmatter.js';
 import { scoreRelevance } from './relevance.js';
-import { CHARS_PER_TOKEN, CONTEXT_PLAN_PREVIEW_CHARS, CONTEXT_SESSION_PREVIEW_CHARS, CONTEXT_SPORE_PREVIEW_CHARS } from '../constants.js';
+import { estimateTokens, CONTEXT_PLAN_PREVIEW_CHARS, CONTEXT_SESSION_PREVIEW_CHARS, CONTEXT_SPORE_PREVIEW_CHARS } from '../constants.js';
 
 interface InjectionContext {
   branch?: string;
@@ -115,6 +115,3 @@ function formatLayer(heading: string, items: string[], budget: number): string {
   return text.trim();
 }
 
-function estimateTokens(text: string): number {
-  return Math.ceil(text.length / CHARS_PER_TOKEN);
-}

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -17,7 +17,6 @@ import {
   CHARS_PER_TOKEN,
   DIGEST_TIER_MIN_CONTEXT,
   DIGEST_SUBSTRATE_TYPE_WEIGHTS,
-  DIGEST_SYSTEM_PROMPT_TOKENS,
   DIGEST_LLM_REQUEST_TIMEOUT_MS,
 } from '@myco/constants.js';
 
@@ -287,15 +286,15 @@ export class DigestEngine {
       const previousExtract = this.readPreviousExtract(tier);
 
       // Calculate token budget for substrate:
-      // context_window - output_tokens - system_prompt - tier_prompt - previous_extract
+      // (context_window * safety_margin) - output - system_prompt - tier_prompt - previous_extract
       const contextWindow = this.config.digest.intelligence.context_window;
-      const systemTokens = DIGEST_SYSTEM_PROMPT_TOKENS;
+      const systemPromptTokens = Math.ceil(systemPrompt.length / CHARS_PER_TOKEN);
       const tierPromptTokens = Math.ceil(tierPrompt.length / CHARS_PER_TOKEN);
       const previousExtractTokens = previousExtract
         ? Math.ceil(previousExtract.length / CHARS_PER_TOKEN) + PREVIOUS_EXTRACT_OVERHEAD_TOKENS
         : 0;
       const availableTokens = Math.floor(contextWindow * CONTEXT_SAFETY_MARGIN);
-      const substrateBudget = availableTokens - tier - systemTokens - tierPromptTokens - previousExtractTokens;
+      const substrateBudget = availableTokens - tier - systemPromptTokens - tierPromptTokens - previousExtractTokens;
 
       if (substrateBudget <= 0) continue;
 

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -246,6 +246,14 @@ export class DigestEngine {
     const substrate = this.discoverSubstrate(lastTimestamp);
 
     this.log('debug', 'Discovering substrate', { lastTimestamp: lastTimestamp ?? 'cold start', substrateCount: substrate.length });
+
+    // Ensure the LLM model is loaded with the configured context window before processing.
+    // This is critical for LM Studio where auto-loaded models may use smaller context defaults.
+    if ('ensureLoaded' in this.llm && typeof (this.llm as { ensureLoaded: unknown }).ensureLoaded === 'function') {
+      const contextWindow = this.config.digest.intelligence.context_window;
+      this.log('debug', 'Ensuring model is loaded', { contextWindow });
+      await (this.llm as { ensureLoaded: (ctx?: number) => Promise<void> }).ensureLoaded(contextWindow);
+    }
     if (substrate.length === 0) {
       this.log('debug', 'No substrate found — skipping cycle');
       return null;

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -247,13 +247,9 @@ export class DigestEngine {
 
     this.log('debug', 'Discovering substrate', { lastTimestamp: lastTimestamp ?? 'cold start', substrateCount: substrate.length });
 
-    // Ensure the LLM model is loaded with the configured context window before processing.
-    // This is critical for LM Studio where auto-loaded models may use smaller context defaults.
-    if ('ensureLoaded' in this.llm && typeof (this.llm as { ensureLoaded: unknown }).ensureLoaded === 'function') {
-      const contextWindow = this.config.digest.intelligence.context_window;
-      this.log('debug', 'Ensuring model is loaded', { contextWindow });
-      await (this.llm as { ensureLoaded: (ctx?: number) => Promise<void> }).ensureLoaded(contextWindow);
-    }
+    // Note: For LM Studio, the model should be pre-loaded with the correct context window
+    // using `lms load <model> --context-length <size> --identifier <name>`.
+    // The API's /api/v1/models/load doesn't reliably set context_length.
     if (substrate.length === 0) {
       this.log('debug', 'No substrate found — skipping cycle');
       return null;

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -259,7 +259,7 @@ export class DigestEngine {
     // Ensure model is loaded with correct settings — one-time on first cycle
     if (!this.modelReady && this.llm.ensureLoaded) {
       const { context_window: contextWindow, gpu_kv_cache: gpuKvCache } = this.config.digest.intelligence;
-      this.log('debug', 'Ensuring model is loaded', { contextWindow, gpuKvCache });
+      this.log('info', 'Loading digest model', { contextWindow, gpuKvCache });
       await this.llm.ensureLoaded(contextWindow, gpuKvCache);
       this.modelReady = true;
     }

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -13,7 +13,9 @@ import type { LlmProvider, LlmRequestOptions } from '@myco/intelligence/llm.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import { loadPrompt } from '@myco/prompts/index.js';
 import { stripReasoningTokens } from '@myco/intelligence/response.js';
+import { stripFrontmatter } from '@myco/vault/frontmatter.js';
 import {
+  estimateTokens,
   CHARS_PER_TOKEN,
   DIGEST_TIER_MIN_CONTEXT,
   DIGEST_SUBSTRATE_TYPE_WEIGHTS,
@@ -153,12 +155,7 @@ export class DigestEngine {
       return null;
     }
 
-    // Strip YAML frontmatter
-    const fmMatch = content.match(/^---\n[\s\S]*?\n---\n*/);
-    if (fmMatch) {
-      return content.slice(fmMatch[0].length).trim();
-    }
-    return content.trim();
+    return stripFrontmatter(content).body;
   }
 
   /**
@@ -260,10 +257,10 @@ export class DigestEngine {
 
   private async runCycleInternal(): Promise<DigestCycleResult | null> {
     // Ensure model is loaded with correct settings — one-time on first cycle
-    if (!this.modelReady && 'ensureLoaded' in this.llm && typeof (this.llm as { ensureLoaded: unknown }).ensureLoaded === 'function') {
+    if (!this.modelReady && this.llm.ensureLoaded) {
       const { context_window: contextWindow, gpu_kv_cache: gpuKvCache } = this.config.digest.intelligence;
       this.log('debug', 'Ensuring model is loaded', { contextWindow, gpuKvCache });
-      await (this.llm as { ensureLoaded: (ctx?: number, gpuKv?: boolean) => Promise<void> }).ensureLoaded(contextWindow, gpuKvCache);
+      await this.llm.ensureLoaded(contextWindow, gpuKvCache);
       this.modelReady = true;
     }
 
@@ -316,10 +313,10 @@ export class DigestEngine {
       // Calculate token budget for substrate:
       // (context_window * safety_margin) - output - system_prompt - tier_prompt - previous_extract
       const contextWindow = this.config.digest.intelligence.context_window;
-      const systemPromptTokens = Math.ceil(systemPrompt.length / CHARS_PER_TOKEN);
-      const tierPromptTokens = Math.ceil(tierPrompt.length / CHARS_PER_TOKEN);
+      const systemPromptTokens = estimateTokens(systemPrompt);
+      const tierPromptTokens = estimateTokens(tierPrompt);
       const previousExtractTokens = previousExtract
-        ? Math.ceil(previousExtract.length / CHARS_PER_TOKEN) + PREVIOUS_EXTRACT_OVERHEAD_TOKENS
+        ? estimateTokens(previousExtract) + PREVIOUS_EXTRACT_OVERHEAD_TOKENS
         : 0;
       const availableTokens = Math.floor(contextWindow * CONTEXT_SAFETY_MARGIN);
       const substrateBudget = availableTokens - tier - systemPromptTokens - tierPromptTokens - previousExtractTokens;
@@ -343,7 +340,7 @@ export class DigestEngine {
       );
 
       const userPrompt = promptParts.join('\n');
-      const promptTokens = Math.ceil((systemPrompt.length + userPrompt.length) / CHARS_PER_TOKEN);
+      const promptTokens = estimateTokens(systemPrompt + userPrompt);
       this.log('debug', `Tier ${tier}: sending LLM request`, { promptTokens, maxTokens: tier, substrateBudget });
 
       const tierStart = Date.now();
@@ -362,7 +359,7 @@ export class DigestEngine {
       // Strip reasoning tokens if present (some models output chain-of-thought)
       const extractText = stripReasoningTokens(response.text);
       model = response.model;
-      const responseTokens = Math.ceil(extractText.length / CHARS_PER_TOKEN);
+      const responseTokens = estimateTokens(extractText);
       totalTokensUsed += promptTokens + responseTokens;
 
       this.log('info', `Tier ${tier}: completed`, { durationMs: tierDuration, responseTokens, model: response.model });

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -265,9 +265,9 @@ export class DigestEngine {
     // Ensure the LLM model is loaded with the configured context window.
     // For LM Studio, this calls /api/v1/models/load with context_length.
     if ('ensureLoaded' in this.llm && typeof (this.llm as { ensureLoaded: unknown }).ensureLoaded === 'function') {
-      const contextWindow = this.config.digest.intelligence.context_window;
-      this.log('debug', 'Ensuring model is loaded', { contextWindow });
-      await (this.llm as { ensureLoaded: (ctx?: number) => Promise<void> }).ensureLoaded(contextWindow);
+      const { context_window: contextWindow, gpu_kv_cache: gpuKvCache } = this.config.digest.intelligence;
+      this.log('debug', 'Ensuring model is loaded', { contextWindow, gpuKvCache });
+      await (this.llm as { ensureLoaded: (ctx?: number, gpuKv?: boolean) => Promise<void> }).ensureLoaded(contextWindow, gpuKvCache);
     }
     if (substrate.length === 0) {
       this.log('debug', 'No substrate found — skipping cycle');
@@ -344,12 +344,14 @@ export class DigestEngine {
       this.log('debug', `Tier ${tier}: sending LLM request`, { promptTokens, maxTokens: tier, substrateBudget });
 
       const tierStart = Date.now();
+      const digestConfig = this.config.digest.intelligence;
       const opts: LlmRequestOptions = {
         maxTokens: tier,
         timeoutMs: DIGEST_LLM_REQUEST_TIMEOUT_MS,
         contextLength: contextWindow,
         reasoning: 'off',
         systemPrompt,
+        keepAlive: digestConfig.keep_alive ?? undefined,
       };
       const response = await this.llm.summarize(userPrompt, opts);
       const tierDuration = Date.now() - tierStart;

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -54,8 +54,10 @@ export interface DigestEngineConfig {
 /** Token overhead estimate for previous extract section wrapper. */
 const PREVIOUS_EXTRACT_OVERHEAD_TOKENS = 50;
 
-/** Safety margin for context window — our chars-per-token heuristic underestimates by ~10-15%. */
-const CONTEXT_SAFETY_MARGIN = 0.85;
+/** Safety margin for context window — our CHARS_PER_TOKEN=4 heuristic significantly
+ *  underestimates real token counts (observed ~3.2 chars/token for mixed content).
+ *  0.70 provides a safe buffer: 32K * 0.70 = 22.4K usable tokens. */
+const CONTEXT_SAFETY_MARGIN = 0.70;
 
 /** Types that are digest output — excluded from substrate to avoid self-digestion. */
 const EXTRACT_TYPE = 'extract';

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -17,6 +17,7 @@ import {
   DIGEST_TIER_MIN_CONTEXT,
   DIGEST_SUBSTRATE_TYPE_WEIGHTS,
   DIGEST_SYSTEM_PROMPT_TOKENS,
+  DIGEST_LLM_REQUEST_TIMEOUT_MS,
 } from '@myco/constants.js';
 
 // --- Interfaces ---
@@ -298,7 +299,7 @@ export class DigestEngine {
       );
 
       const fullPrompt = promptParts.join('\n');
-      const opts: LlmRequestOptions = { maxTokens: tier };
+      const opts: LlmRequestOptions = { maxTokens: tier, timeoutMs: DIGEST_LLM_REQUEST_TIMEOUT_MS };
       const response = await this.llm.summarize(fullPrompt, opts);
 
       model = response.model;

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -1,0 +1,398 @@
+/**
+ * DigestEngine — synthesizes vault knowledge into tiered context extracts.
+ * Metabolism — adaptive timer that throttles digest cycles based on activity.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import YAML from 'yaml';
+
+import type { MycoIndex, IndexedNote } from '@myco/index/sqlite.js';
+import type { LlmProvider, LlmRequestOptions } from '@myco/intelligence/llm.js';
+import type { MycoConfig } from '@myco/config/schema.js';
+import { loadPrompt } from '@myco/prompts/index.js';
+import {
+  CHARS_PER_TOKEN,
+  DIGEST_TIER_MIN_CONTEXT,
+  DIGEST_SUBSTRATE_TYPE_WEIGHTS,
+  DIGEST_SYSTEM_PROMPT_TOKENS,
+  DIGEST_MAX_NOTES_PER_CYCLE,
+} from '@myco/constants.js';
+
+// --- Interfaces ---
+
+export interface DigestCycleResult {
+  cycleId: string;
+  timestamp: string;
+  substrate: {
+    sessions: string[];
+    spores: string[];
+    plans: string[];
+    artifacts: string[];
+    team: string[];
+  };
+  tiersGenerated: number[];
+  model: string;
+  durationMs: number;
+  tokensUsed: number;
+}
+
+export interface DigestEngineConfig {
+  vaultDir: string;
+  index: MycoIndex;
+  llmProvider: LlmProvider;
+  config: MycoConfig;
+}
+
+// --- Constants ---
+
+/** Token overhead estimate for previous extract section wrapper. */
+const PREVIOUS_EXTRACT_OVERHEAD_TOKENS = 50;
+
+/** Types that are digest output — excluded from substrate to avoid self-digestion. */
+const EXTRACT_TYPE = 'extract';
+
+// --- DigestEngine ---
+
+export class DigestEngine {
+  private vaultDir: string;
+  private index: MycoIndex;
+  private llm: LlmProvider;
+  private config: MycoConfig;
+
+  constructor(engineConfig: DigestEngineConfig) {
+    this.vaultDir = engineConfig.vaultDir;
+    this.index = engineConfig.index;
+    this.llm = engineConfig.llmProvider;
+    this.config = engineConfig.config;
+  }
+
+  /**
+   * Query index for recent vault notes to feed into the digest.
+   * Filters out extract notes (our own output) and caps at max_notes_per_cycle.
+   */
+  discoverSubstrate(lastCycleTimestamp: string | null): IndexedNote[] {
+    const maxNotes = this.config.digest.substrate.max_notes_per_cycle;
+
+    const notes = lastCycleTimestamp
+      ? this.index.query({ updatedSince: lastCycleTimestamp, limit: maxNotes })
+      : this.index.query({ limit: maxNotes });
+
+    const filtered = notes.filter((n) => n.type !== EXTRACT_TYPE);
+
+    // Sort by type weight (descending) then by recency (descending)
+    filtered.sort((a, b) => {
+      const weightA = DIGEST_SUBSTRATE_TYPE_WEIGHTS[a.type] ?? 0;
+      const weightB = DIGEST_SUBSTRATE_TYPE_WEIGHTS[b.type] ?? 0;
+      if (weightB !== weightA) return weightB - weightA;
+      // More recent first — created is ISO string, lexicographic sort works
+      return b.created.localeCompare(a.created);
+    });
+
+    return filtered.slice(0, maxNotes);
+  }
+
+  /**
+   * Filter configured tiers by the context window available.
+   * Only tiers whose minimum context requirement is met are eligible.
+   */
+  getEligibleTiers(): number[] {
+    const contextWindow = this.config.digest.intelligence.context_window;
+    return this.config.digest.tiers.filter((tier) => {
+      const minContext = DIGEST_TIER_MIN_CONTEXT[tier];
+      return minContext !== undefined && minContext <= contextWindow;
+    });
+  }
+
+  /**
+   * Format notes compactly for inclusion in the digest prompt.
+   * Stops adding notes once the token budget is exceeded.
+   */
+  formatSubstrate(notes: IndexedNote[], tokenBudget: number): string {
+    const charBudget = tokenBudget * CHARS_PER_TOKEN;
+    const parts: string[] = [];
+    let usedChars = 0;
+
+    for (const note of notes) {
+      const entry = `### [${note.type}] ${note.id} — "${note.title}"\n${note.content}`;
+      if (usedChars + entry.length > charBudget && parts.length > 0) break;
+      parts.push(entry);
+      usedChars += entry.length;
+    }
+
+    return parts.join('\n\n');
+  }
+
+  /**
+   * Read a previously generated extract for a given tier.
+   * Returns the body (stripped of YAML frontmatter), or null if not found.
+   */
+  readPreviousExtract(tier: number): string | null {
+    const extractPath = path.join(this.vaultDir, 'digest', `extract-${tier}.md`);
+    let content: string;
+    try {
+      content = fs.readFileSync(extractPath, 'utf-8');
+    } catch {
+      return null;
+    }
+
+    // Strip YAML frontmatter
+    const fmMatch = content.match(/^---\n[\s\S]*?\n---\n*/);
+    if (fmMatch) {
+      return content.slice(fmMatch[0].length).trim();
+    }
+    return content.trim();
+  }
+
+  /**
+   * Write a digest extract to the vault with YAML frontmatter.
+   * Uses atomic write pattern (temp file + rename).
+   */
+  writeExtract(
+    tier: number,
+    body: string,
+    cycleId: string,
+    model: string,
+    substrateCount: number,
+  ): void {
+    const digestDir = path.join(this.vaultDir, 'digest');
+    fs.mkdirSync(digestDir, { recursive: true });
+
+    const frontmatter: Record<string, unknown> = {
+      type: EXTRACT_TYPE,
+      tier,
+      generated: new Date().toISOString(),
+      cycle_id: cycleId,
+      substrate_count: substrateCount,
+      model,
+    };
+
+    const fmYaml = YAML.stringify(frontmatter, {
+      defaultStringType: 'QUOTE_DOUBLE',
+      defaultKeyType: 'PLAIN',
+    }).trim();
+    const file = `---\n${fmYaml}\n---\n\n${body}\n`;
+
+    const fullPath = path.join(digestDir, `extract-${tier}.md`);
+    const tmpPath = `${fullPath}.tmp`;
+    fs.writeFileSync(tmpPath, file, 'utf-8');
+    fs.renameSync(tmpPath, fullPath);
+  }
+
+  /**
+   * Append a digest cycle result as a JSON line to trace.jsonl.
+   */
+  appendTrace(record: DigestCycleResult): void {
+    const digestDir = path.join(this.vaultDir, 'digest');
+    fs.mkdirSync(digestDir, { recursive: true });
+    const tracePath = path.join(digestDir, 'trace.jsonl');
+    fs.appendFileSync(tracePath, JSON.stringify(record) + '\n', 'utf-8');
+  }
+
+  /**
+   * Read the last cycle timestamp from trace.jsonl.
+   * Returns null if no trace file or it's empty.
+   */
+  getLastCycleTimestamp(): string | null {
+    const tracePath = path.join(this.vaultDir, 'digest', 'trace.jsonl');
+    let content: string;
+    try {
+      content = fs.readFileSync(tracePath, 'utf-8').trim();
+    } catch {
+      return null;
+    }
+
+    if (!content) return null;
+
+    const lines = content.split('\n');
+    const lastLine = lines[lines.length - 1];
+    try {
+      const record = JSON.parse(lastLine) as DigestCycleResult;
+      return record.timestamp;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Run a full digest cycle: discover substrate, generate extracts for each tier.
+   * Returns the cycle result, or null if no substrate was found.
+   */
+  async runCycle(): Promise<DigestCycleResult | null> {
+    const startTime = Date.now();
+    const lastTimestamp = this.getLastCycleTimestamp();
+    const substrate = this.discoverSubstrate(lastTimestamp);
+
+    if (substrate.length === 0) return null;
+
+    const cycleId = crypto.randomUUID();
+    const eligibleTiers = this.getEligibleTiers();
+    const tiersGenerated: number[] = [];
+    let totalTokensUsed = 0;
+    let model = '';
+
+    // Categorize substrate by type for the result
+    const substrateIndex: DigestCycleResult['substrate'] = {
+      sessions: [],
+      spores: [],
+      plans: [],
+      artifacts: [],
+      team: [],
+    };
+    for (const note of substrate) {
+      const key = `${note.type}s` as keyof typeof substrateIndex;
+      if (key in substrateIndex) {
+        substrateIndex[key].push(note.id);
+      }
+    }
+
+    const systemPrompt = loadPrompt('digest-system');
+
+    for (const tier of eligibleTiers) {
+      const tierPrompt = loadPrompt(`digest-${tier}`);
+      const previousExtract = this.readPreviousExtract(tier);
+
+      // Calculate token budget for substrate:
+      // tier budget - system prompt - tier prompt - previous extract - overhead
+      const systemTokens = DIGEST_SYSTEM_PROMPT_TOKENS;
+      const tierPromptTokens = Math.ceil(tierPrompt.length / CHARS_PER_TOKEN);
+      const previousExtractTokens = previousExtract
+        ? Math.ceil(previousExtract.length / CHARS_PER_TOKEN) + PREVIOUS_EXTRACT_OVERHEAD_TOKENS
+        : 0;
+      const substrateBudget = tier - systemTokens - tierPromptTokens - previousExtractTokens;
+
+      if (substrateBudget <= 0) continue;
+
+      const formattedSubstrate = this.formatSubstrate(substrate, substrateBudget);
+
+      // Build full prompt as a single string
+      const promptParts = [systemPrompt, '', tierPrompt];
+
+      if (previousExtract) {
+        promptParts.push('', '## Previous Synthesis', '', previousExtract);
+      }
+
+      promptParts.push('', '## New Substrate', '', formattedSubstrate);
+      promptParts.push(
+        '',
+        '---',
+        'Produce your updated synthesis now. Stay within the token budget specified above.',
+      );
+
+      const fullPrompt = promptParts.join('\n');
+      const opts: LlmRequestOptions = { maxTokens: tier };
+      const response = await this.llm.summarize(fullPrompt, opts);
+
+      model = response.model;
+      totalTokensUsed += Math.ceil(fullPrompt.length / CHARS_PER_TOKEN) + Math.ceil(response.text.length / CHARS_PER_TOKEN);
+
+      this.writeExtract(tier, response.text, cycleId, response.model, substrate.length);
+      tiersGenerated.push(tier);
+    }
+
+    const result: DigestCycleResult = {
+      cycleId,
+      timestamp: new Date().toISOString(),
+      substrate: substrateIndex,
+      tiersGenerated,
+      model,
+      durationMs: Date.now() - startTime,
+      tokensUsed: totalTokensUsed,
+    };
+
+    this.appendTrace(result);
+    return result;
+  }
+}
+
+// --- Metabolism (Adaptive Timer) ---
+
+export type MetabolismState = 'active' | 'cooling' | 'dormant';
+
+/** Milliseconds per second for config conversion. */
+const MS_PER_SECOND = 1000;
+
+export class Metabolism {
+  state: MetabolismState = 'active';
+  currentIntervalMs: number;
+
+  private cooldownStep = 0;
+  private lastSubstrateTime: number;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private activeIntervalMs: number;
+  private cooldownIntervalsMs: number[];
+  private dormancyThresholdMs: number;
+
+  constructor(config: MycoConfig['digest']['metabolism']) {
+    this.activeIntervalMs = config.active_interval * MS_PER_SECOND;
+    this.cooldownIntervalsMs = config.cooldown_intervals.map((s) => s * MS_PER_SECOND);
+    this.dormancyThresholdMs = config.dormancy_threshold * MS_PER_SECOND;
+    this.currentIntervalMs = this.activeIntervalMs;
+    this.lastSubstrateTime = Date.now();
+  }
+
+  /** Reset to active state when new substrate is found. */
+  onSubstrateFound(): void {
+    this.state = 'active';
+    this.cooldownStep = 0;
+    this.currentIntervalMs = this.activeIntervalMs;
+    this.lastSubstrateTime = Date.now();
+  }
+
+  /** Advance cooldown when a cycle finds no new substrate. */
+  onEmptyCycle(): void {
+    if (this.state === 'dormant') return;
+
+    this.state = 'cooling';
+    if (this.cooldownStep < this.cooldownIntervalsMs.length) {
+      this.currentIntervalMs = this.cooldownIntervalsMs[this.cooldownStep];
+      this.cooldownStep++;
+    }
+
+    this.checkDormancy();
+  }
+
+  /** Enter dormant state if enough time has elapsed since last substrate. */
+  checkDormancy(): void {
+    const elapsed = Date.now() - this.lastSubstrateTime;
+    if (elapsed >= this.dormancyThresholdMs) {
+      this.state = 'dormant';
+      // Keep the last cooldown interval as the dormant polling rate
+    }
+  }
+
+  /** Return to active from any state, resetting timers. */
+  activate(): void {
+    this.state = 'active';
+    this.cooldownStep = 0;
+    this.currentIntervalMs = this.activeIntervalMs;
+    this.lastSubstrateTime = Date.now();
+  }
+
+  /** Set lastSubstrateTime explicitly (for testing). */
+  markLastSubstrate(time: number): void {
+    this.lastSubstrateTime = time;
+  }
+
+  /** Begin scheduling digest cycles with adaptive intervals. */
+  start(callback: () => Promise<void>): void {
+    this.stop();
+    const schedule = (): void => {
+      this.timer = setTimeout(async () => {
+        await callback();
+        schedule();
+      }, this.currentIntervalMs);
+      this.timer.unref();
+    };
+    schedule();
+  }
+
+  /** Stop the timer. */
+  stop(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -71,6 +71,7 @@ export class DigestEngine {
   private config: MycoConfig;
   private log: DigestLogFn;
   private lastCycleTimestampCache: string | null | undefined = undefined;
+  private cycleInProgress = false;
 
   constructor(engineConfig: DigestEngineConfig) {
     this.vaultDir = engineConfig.vaultDir;
@@ -241,6 +242,20 @@ export class DigestEngine {
    * Returns the cycle result, or null if no substrate was found.
    */
   async runCycle(): Promise<DigestCycleResult | null> {
+    if (this.cycleInProgress) {
+      this.log('debug', 'Cycle already in progress — skipping');
+      return null;
+    }
+    this.cycleInProgress = true;
+
+    try {
+      return await this.runCycleInternal();
+    } finally {
+      this.cycleInProgress = false;
+    }
+  }
+
+  private async runCycleInternal(): Promise<DigestCycleResult | null> {
     const startTime = Date.now();
     const lastTimestamp = this.getLastCycleTimestamp();
     const substrate = this.discoverSubstrate(lastTimestamp);

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -17,7 +17,6 @@ import {
   DIGEST_TIER_MIN_CONTEXT,
   DIGEST_SUBSTRATE_TYPE_WEIGHTS,
   DIGEST_SYSTEM_PROMPT_TOKENS,
-  DIGEST_MAX_NOTES_PER_CYCLE,
 } from '@myco/constants.js';
 
 // --- Interfaces ---
@@ -60,6 +59,7 @@ export class DigestEngine {
   private index: MycoIndex;
   private llm: LlmProvider;
   private config: MycoConfig;
+  private lastCycleTimestampCache: string | null | undefined = undefined;
 
   constructor(engineConfig: DigestEngineConfig) {
     this.vaultDir = engineConfig.vaultDir;
@@ -188,29 +188,38 @@ export class DigestEngine {
     fs.mkdirSync(digestDir, { recursive: true });
     const tracePath = path.join(digestDir, 'trace.jsonl');
     fs.appendFileSync(tracePath, JSON.stringify(record) + '\n', 'utf-8');
+    this.lastCycleTimestampCache = record.timestamp;
   }
 
   /**
    * Read the last cycle timestamp from trace.jsonl.
-   * Returns null if no trace file or it's empty.
+   * Cached in memory after first read — subsequent calls are O(1).
    */
   getLastCycleTimestamp(): string | null {
+    if (this.lastCycleTimestampCache !== undefined) return this.lastCycleTimestampCache;
+
     const tracePath = path.join(this.vaultDir, 'digest', 'trace.jsonl');
     let content: string;
     try {
       content = fs.readFileSync(tracePath, 'utf-8').trim();
     } catch {
+      this.lastCycleTimestampCache = null;
       return null;
     }
 
-    if (!content) return null;
+    if (!content) {
+      this.lastCycleTimestampCache = null;
+      return null;
+    }
 
     const lines = content.split('\n');
     const lastLine = lines[lines.length - 1];
     try {
       const record = JSON.parse(lastLine) as DigestCycleResult;
+      this.lastCycleTimestampCache = record.timestamp;
       return record.timestamp;
     } catch {
+      this.lastCycleTimestampCache = null;
       return null;
     }
   }
@@ -233,6 +242,13 @@ export class DigestEngine {
     let model = '';
 
     // Categorize substrate by type for the result
+    const typeToKey: Record<string, keyof DigestCycleResult['substrate']> = {
+      session: 'sessions',
+      spore: 'spores',
+      plan: 'plans',
+      artifact: 'artifacts',
+      'team-member': 'team',
+    };
     const substrateIndex: DigestCycleResult['substrate'] = {
       sessions: [],
       spores: [],
@@ -241,8 +257,8 @@ export class DigestEngine {
       team: [],
     };
     for (const note of substrate) {
-      const key = `${note.type}s` as keyof typeof substrateIndex;
-      if (key in substrateIndex) {
+      const key = typeToKey[note.type];
+      if (key) {
         substrateIndex[key].push(note.id);
       }
     }
@@ -364,10 +380,7 @@ export class Metabolism {
 
   /** Return to active from any state, resetting timers. */
   activate(): void {
-    this.state = 'active';
-    this.cooldownStep = 0;
-    this.currentIntervalMs = this.activeIntervalMs;
-    this.lastSubstrateTime = Date.now();
+    this.onSubstrateFound();
   }
 
   /** Set lastSubstrateTime explicitly (for testing). */

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -93,6 +93,8 @@ export class DigestEngine {
       ? this.index.query({ updatedSince: lastCycleTimestamp, limit: maxNotes })
       : this.index.query({ limit: maxNotes });
 
+    // Guard against self-digestion: extract files are not currently indexed,
+    // but this filter prevents feedback loops if they ever are (e.g., via rebuild)
     const filtered = notes.filter((n) => n.type !== EXTRACT_TYPE);
 
     // Sort by type weight (descending) then by recency (descending)
@@ -361,7 +363,7 @@ export class DigestEngine {
       const extractText = stripReasoningTokens(response.text);
       model = response.model;
       const responseTokens = Math.ceil(extractText.length / CHARS_PER_TOKEN);
-      totalTokensUsed += promptTokens + Math.ceil(extractText.length / CHARS_PER_TOKEN);
+      totalTokensUsed += promptTokens + responseTokens;
 
       this.log('info', `Tier ${tier}: completed`, { durationMs: tierDuration, responseTokens, model: response.model });
       this.writeExtract(tier, extractText, cycleId, response.model, substrate.length);
@@ -439,9 +441,14 @@ export class Metabolism {
     }
   }
 
-  /** Return to active from any state, resetting timers. */
+  /** Return to active from any state, resetting timers and rescheduling immediately. */
   activate(): void {
     this.onSubstrateFound();
+    // Reschedule with the new active interval — without this, the old
+    // (possibly dormant) timer continues ticking at the wrong rate
+    if (this.callback) {
+      this.reschedule();
+    }
   }
 
   /** Set lastSubstrateTime explicitly (for testing). */
@@ -451,15 +458,8 @@ export class Metabolism {
 
   /** Begin scheduling digest cycles with adaptive intervals. */
   start(callback: () => Promise<void>): void {
-    this.stop();
-    const schedule = (): void => {
-      this.timer = setTimeout(async () => {
-        await callback();
-        schedule();
-      }, this.currentIntervalMs);
-      this.timer.unref();
-    };
-    schedule();
+    this.callback = callback;
+    this.reschedule();
   }
 
   /** Stop the timer. */
@@ -468,5 +468,21 @@ export class Metabolism {
       clearTimeout(this.timer);
       this.timer = null;
     }
+  }
+
+  private callback: (() => Promise<void>) | null = null;
+
+  private reschedule(): void {
+    this.stop();
+    if (!this.callback) return;
+    const cb = this.callback;
+    const schedule = (): void => {
+      this.timer = setTimeout(async () => {
+        await cb();
+        schedule();
+      }, this.currentIntervalMs);
+      this.timer.unref();
+    };
+    schedule();
   }
 }

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -262,9 +262,13 @@ export class DigestEngine {
 
     this.log('debug', 'Discovering substrate', { lastTimestamp: lastTimestamp ?? 'cold start', substrateCount: substrate.length });
 
-    // Note: For LM Studio, the model should be pre-loaded with the correct context window
-    // using `lms load <model> --context-length <size> --identifier <name>`.
-    // The API's /api/v1/models/load doesn't reliably set context_length.
+    // Ensure the LLM model is loaded with the configured context window.
+    // For LM Studio, this calls /api/v1/models/load with context_length.
+    if ('ensureLoaded' in this.llm && typeof (this.llm as { ensureLoaded: unknown }).ensureLoaded === 'function') {
+      const contextWindow = this.config.digest.intelligence.context_window;
+      this.log('debug', 'Ensuring model is loaded', { contextWindow });
+      await (this.llm as { ensureLoaded: (ctx?: number) => Promise<void> }).ensureLoaded(contextWindow);
+    }
     if (substrate.length === 0) {
       this.log('debug', 'No substrate found — skipping cycle');
       return null;

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -297,8 +297,8 @@ export class DigestEngine {
 
       const formattedSubstrate = this.formatSubstrate(substrate, substrateBudget);
 
-      // Build full prompt as a single string
-      const promptParts = [systemPrompt, '', tierPrompt];
+      // Build user prompt (system prompt sent separately via LlmRequestOptions)
+      const promptParts = [tierPrompt];
 
       if (previousExtract) {
         promptParts.push('', '## Previous Synthesis', '', previousExtract);
@@ -309,27 +309,28 @@ export class DigestEngine {
         '',
         '---',
         'Produce your updated synthesis now. Stay within the token budget specified above.',
-        'Output ONLY the synthesis — no thinking process, no analysis, no planning. Start directly with the content.',
-        '/no_think',
       );
 
-      const fullPrompt = promptParts.join('\n');
-      const promptTokens = Math.ceil(fullPrompt.length / CHARS_PER_TOKEN);
+      const userPrompt = promptParts.join('\n');
+      const promptTokens = Math.ceil((systemPrompt.length + userPrompt.length) / CHARS_PER_TOKEN);
       this.log('debug', `Tier ${tier}: sending LLM request`, { promptTokens, maxTokens: tier, substrateBudget });
 
       const tierStart = Date.now();
-      // Request 3x the tier budget to accommodate reasoning model thinking overhead.
-      // The thinking tokens will be stripped from the response; only the synthesis is kept.
-      const REASONING_OVERHEAD_MULTIPLIER = 3;
-      const opts: LlmRequestOptions = { maxTokens: tier * REASONING_OVERHEAD_MULTIPLIER, timeoutMs: DIGEST_LLM_REQUEST_TIMEOUT_MS };
-      const response = await this.llm.summarize(fullPrompt, opts);
+      const opts: LlmRequestOptions = {
+        maxTokens: tier,
+        timeoutMs: DIGEST_LLM_REQUEST_TIMEOUT_MS,
+        contextLength: contextWindow,
+        reasoning: 'off',
+        systemPrompt,
+      };
+      const response = await this.llm.summarize(userPrompt, opts);
       const tierDuration = Date.now() - tierStart;
 
       // Strip reasoning tokens if present (some models output chain-of-thought)
       const extractText = stripReasoningTokens(response.text);
       model = response.model;
       const responseTokens = Math.ceil(extractText.length / CHARS_PER_TOKEN);
-      totalTokensUsed += promptTokens + responseTokens;
+      totalTokensUsed += promptTokens + Math.ceil(extractText.length / CHARS_PER_TOKEN);
 
       this.log('info', `Tier ${tier}: completed`, { durationMs: tierDuration, responseTokens, model: response.model });
       this.writeExtract(tier, extractText, cycleId, response.model, substrate.length);

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -318,7 +318,10 @@ export class DigestEngine {
       this.log('debug', `Tier ${tier}: sending LLM request`, { promptTokens, maxTokens: tier, substrateBudget });
 
       const tierStart = Date.now();
-      const opts: LlmRequestOptions = { maxTokens: tier, timeoutMs: DIGEST_LLM_REQUEST_TIMEOUT_MS };
+      // Request 3x the tier budget to accommodate reasoning model thinking overhead.
+      // The thinking tokens will be stripped from the response; only the synthesis is kept.
+      const REASONING_OVERHEAD_MULTIPLIER = 3;
+      const opts: LlmRequestOptions = { maxTokens: tier * REASONING_OVERHEAD_MULTIPLIER, timeoutMs: DIGEST_LLM_REQUEST_TIMEOUT_MS };
       const response = await this.llm.summarize(fullPrompt, opts);
       const tierDuration = Date.now() - tierStart;
 

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -38,11 +38,15 @@ export interface DigestCycleResult {
   tokensUsed: number;
 }
 
+/** Simple log function signature for digest progress reporting. */
+export type DigestLogFn = (level: 'debug' | 'info' | 'warn', message: string, data?: Record<string, unknown>) => void;
+
 export interface DigestEngineConfig {
   vaultDir: string;
   index: MycoIndex;
   llmProvider: LlmProvider;
   config: MycoConfig;
+  log?: DigestLogFn;
 }
 
 // --- Constants ---
@@ -60,6 +64,7 @@ export class DigestEngine {
   private index: MycoIndex;
   private llm: LlmProvider;
   private config: MycoConfig;
+  private log: DigestLogFn;
   private lastCycleTimestampCache: string | null | undefined = undefined;
 
   constructor(engineConfig: DigestEngineConfig) {
@@ -67,6 +72,7 @@ export class DigestEngine {
     this.index = engineConfig.index;
     this.llm = engineConfig.llmProvider;
     this.config = engineConfig.config;
+    this.log = engineConfig.log ?? (() => {});
   }
 
   /**
@@ -234,10 +240,16 @@ export class DigestEngine {
     const lastTimestamp = this.getLastCycleTimestamp();
     const substrate = this.discoverSubstrate(lastTimestamp);
 
-    if (substrate.length === 0) return null;
+    this.log('debug', 'Discovering substrate', { lastTimestamp: lastTimestamp ?? 'cold start', substrateCount: substrate.length });
+    if (substrate.length === 0) {
+      this.log('debug', 'No substrate found — skipping cycle');
+      return null;
+    }
 
+    this.log('info', `Starting digest cycle`, { substrateCount: substrate.length });
     const cycleId = crypto.randomUUID();
     const eligibleTiers = this.getEligibleTiers();
+    this.log('debug', `Eligible tiers: [${eligibleTiers.join(', ')}]`);
     const tiersGenerated: number[] = [];
     let totalTokensUsed = 0;
     let model = '';
@@ -299,12 +311,19 @@ export class DigestEngine {
       );
 
       const fullPrompt = promptParts.join('\n');
+      const promptTokens = Math.ceil(fullPrompt.length / CHARS_PER_TOKEN);
+      this.log('debug', `Tier ${tier}: sending LLM request`, { promptTokens, maxTokens: tier, substrateBudget });
+
+      const tierStart = Date.now();
       const opts: LlmRequestOptions = { maxTokens: tier, timeoutMs: DIGEST_LLM_REQUEST_TIMEOUT_MS };
       const response = await this.llm.summarize(fullPrompt, opts);
+      const tierDuration = Date.now() - tierStart;
 
       model = response.model;
-      totalTokensUsed += Math.ceil(fullPrompt.length / CHARS_PER_TOKEN) + Math.ceil(response.text.length / CHARS_PER_TOKEN);
+      const responseTokens = Math.ceil(response.text.length / CHARS_PER_TOKEN);
+      totalTokensUsed += promptTokens + responseTokens;
 
+      this.log('info', `Tier ${tier}: completed`, { durationMs: tierDuration, responseTokens, model: response.model });
       this.writeExtract(tier, response.text, cycleId, response.model, substrate.length);
       tiersGenerated.push(tier);
     }

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -12,6 +12,7 @@ import type { MycoIndex, IndexedNote } from '@myco/index/sqlite.js';
 import type { LlmProvider, LlmRequestOptions } from '@myco/intelligence/llm.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import { loadPrompt } from '@myco/prompts/index.js';
+import { stripReasoningTokens } from '@myco/intelligence/response.js';
 import {
   CHARS_PER_TOKEN,
   DIGEST_TIER_MIN_CONTEXT,
@@ -308,6 +309,8 @@ export class DigestEngine {
         '',
         '---',
         'Produce your updated synthesis now. Stay within the token budget specified above.',
+        'Output ONLY the synthesis — no thinking process, no analysis, no planning. Start directly with the content.',
+        '/no_think',
       );
 
       const fullPrompt = promptParts.join('\n');
@@ -319,12 +322,14 @@ export class DigestEngine {
       const response = await this.llm.summarize(fullPrompt, opts);
       const tierDuration = Date.now() - tierStart;
 
+      // Strip reasoning tokens if present (some models output chain-of-thought)
+      const extractText = stripReasoningTokens(response.text);
       model = response.model;
-      const responseTokens = Math.ceil(response.text.length / CHARS_PER_TOKEN);
+      const responseTokens = Math.ceil(extractText.length / CHARS_PER_TOKEN);
       totalTokensUsed += promptTokens + responseTokens;
 
       this.log('info', `Tier ${tier}: completed`, { durationMs: tierDuration, responseTokens, model: response.model });
-      this.writeExtract(tier, response.text, cycleId, response.model, substrate.length);
+      this.writeExtract(tier, extractText, cycleId, response.model, substrate.length);
       tiersGenerated.push(tier);
     }
 

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -270,13 +270,14 @@ export class DigestEngine {
       const previousExtract = this.readPreviousExtract(tier);
 
       // Calculate token budget for substrate:
-      // tier budget - system prompt - tier prompt - previous extract - overhead
+      // context_window - output_tokens - system_prompt - tier_prompt - previous_extract
+      const contextWindow = this.config.digest.intelligence.context_window;
       const systemTokens = DIGEST_SYSTEM_PROMPT_TOKENS;
       const tierPromptTokens = Math.ceil(tierPrompt.length / CHARS_PER_TOKEN);
       const previousExtractTokens = previousExtract
         ? Math.ceil(previousExtract.length / CHARS_PER_TOKEN) + PREVIOUS_EXTRACT_OVERHEAD_TOKENS
         : 0;
-      const substrateBudget = tier - systemTokens - tierPromptTokens - previousExtractTokens;
+      const substrateBudget = contextWindow - tier - systemTokens - tierPromptTokens - previousExtractTokens;
 
       if (substrateBudget <= 0) continue;
 

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -55,6 +55,9 @@ export interface DigestEngineConfig {
 /** Token overhead estimate for previous extract section wrapper. */
 const PREVIOUS_EXTRACT_OVERHEAD_TOKENS = 50;
 
+/** Safety margin for context window — our chars-per-token heuristic underestimates by ~10-15%. */
+const CONTEXT_SAFETY_MARGIN = 0.85;
+
 /** Types that are digest output — excluded from substrate to avoid self-digestion. */
 const EXTRACT_TYPE = 'extract';
 
@@ -291,7 +294,8 @@ export class DigestEngine {
       const previousExtractTokens = previousExtract
         ? Math.ceil(previousExtract.length / CHARS_PER_TOKEN) + PREVIOUS_EXTRACT_OVERHEAD_TOKENS
         : 0;
-      const substrateBudget = contextWindow - tier - systemTokens - tierPromptTokens - previousExtractTokens;
+      const availableTokens = Math.floor(contextWindow * CONTEXT_SAFETY_MARGIN);
+      const substrateBudget = availableTokens - tier - systemTokens - tierPromptTokens - previousExtractTokens;
 
       if (substrateBudget <= 0) continue;
 

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -72,6 +72,7 @@ export class DigestEngine {
   private log: DigestLogFn;
   private lastCycleTimestampCache: string | null | undefined = undefined;
   private cycleInProgress = false;
+  private modelReady = false;
 
   constructor(engineConfig: DigestEngineConfig) {
     this.vaultDir = engineConfig.vaultDir;
@@ -256,19 +257,19 @@ export class DigestEngine {
   }
 
   private async runCycleInternal(): Promise<DigestCycleResult | null> {
+    // Ensure model is loaded with correct settings — one-time on first cycle
+    if (!this.modelReady && 'ensureLoaded' in this.llm && typeof (this.llm as { ensureLoaded: unknown }).ensureLoaded === 'function') {
+      const { context_window: contextWindow, gpu_kv_cache: gpuKvCache } = this.config.digest.intelligence;
+      this.log('debug', 'Ensuring model is loaded', { contextWindow, gpuKvCache });
+      await (this.llm as { ensureLoaded: (ctx?: number, gpuKv?: boolean) => Promise<void> }).ensureLoaded(contextWindow, gpuKvCache);
+      this.modelReady = true;
+    }
+
     const startTime = Date.now();
     const lastTimestamp = this.getLastCycleTimestamp();
     const substrate = this.discoverSubstrate(lastTimestamp);
 
     this.log('debug', 'Discovering substrate', { lastTimestamp: lastTimestamp ?? 'cold start', substrateCount: substrate.length });
-
-    // Ensure the LLM model is loaded with the configured context window.
-    // For LM Studio, this calls /api/v1/models/load with context_length.
-    if ('ensureLoaded' in this.llm && typeof (this.llm as { ensureLoaded: unknown }).ensureLoaded === 'function') {
-      const { context_window: contextWindow, gpu_kv_cache: gpuKvCache } = this.config.digest.intelligence;
-      this.log('debug', 'Ensuring model is loaded', { contextWindow, gpuKvCache });
-      await (this.llm as { ensureLoaded: (ctx?: number, gpuKv?: boolean) => Promise<void> }).ensureLoaded(contextWindow, gpuKvCache);
-    }
     if (substrate.length === 0) {
       this.log('debug', 'No substrate found — skipping cycle');
       return null;

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -190,7 +190,7 @@ export async function main(): Promise<void> {
     logger.warn('embeddings', 'Vector index unavailable', { error: (error as Error).message });
   }
 
-  const processor = new BufferProcessor(llmProvider, config.intelligence.llm.context_window);
+  const processor = new BufferProcessor(llmProvider, config.intelligence.llm.context_window, config.capture);
   const vault = new VaultWriter(vaultDir);
   const index = new MycoIndex(path.join(vaultDir, 'index.db'));
   const lineageGraph = new LineageGraph(vaultDir);

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -15,6 +15,8 @@ import { generateEmbedding } from '../intelligence/embeddings.js';
 import { LineageGraph, LINEAGE_SIMILARITY_THRESHOLD, LINEAGE_SIMILARITY_HIGH_CONFIDENCE, LINEAGE_SIMILARITY_CANDIDATES, LINEAGE_SIMILARITY_MAX_TOKENS, type LineageLink } from './lineage.js';
 import type { RegisteredSession } from './lifecycle.js';
 import { PlanWatcher } from './watcher.js';
+import { DigestEngine, Metabolism } from './digest.js';
+import { handleMycoContext } from '../mcp/tools/context.js';
 import { buildSimilarityPrompt } from '../prompts/index.js';
 import { extractNumber } from '../intelligence/response.js';
 import { EMBEDDING_INPUT_LIMIT, CONTENT_SNIPPET_CHARS, CHARS_PER_TOKEN, STALE_BUFFER_MAX_AGE_MS, LINEAGE_RECENT_SESSIONS_LIMIT, RELATED_SPORES_LIMIT, CANDIDATE_CONTENT_PREVIEW, SESSION_CONTEXT_MAX_PLANS, PROMPT_CONTEXT_MAX_SPORES, PROMPT_CONTEXT_MIN_SIMILARITY, PROMPT_CONTEXT_MIN_LENGTH, CONTEXT_SESSION_PREVIEW_CHARS } from '../constants.js';
@@ -165,6 +167,7 @@ export async function main(): Promise<void> {
     gracePeriod: config.daemon.grace_period,
     onEmpty: async () => {
       logger.info('daemon', 'Grace period expired, shutting down');
+      metabolism?.stop();
       planWatcher.stopFileWatcher();
       await server.stop();
       vectorIndex?.close();
@@ -279,6 +282,60 @@ export async function main(): Promise<void> {
   });
   planWatcher.startFileWatcher();
 
+  // Digest engine: synthesizes vault knowledge into tiered context extracts
+  let metabolism: Metabolism | null = null;
+
+  if (config.digest.enabled) {
+    const digestLlmConfig = {
+      provider: config.digest.intelligence.provider ?? config.intelligence.llm.provider,
+      model: config.digest.intelligence.model ?? config.intelligence.llm.model,
+      base_url: config.digest.intelligence.base_url ?? config.intelligence.llm.base_url,
+      context_window: config.digest.intelligence.context_window,
+    };
+    const digestLlm = (config.digest.intelligence.model || config.digest.intelligence.provider)
+      ? createLlmProvider(digestLlmConfig)
+      : llmProvider;
+
+    const digestEngine = new DigestEngine({
+      vaultDir,
+      index,
+      llmProvider: digestLlm,
+      config,
+    });
+
+    metabolism = new Metabolism(config.digest.metabolism);
+
+    // Run initial cycle
+    try {
+      const result = await digestEngine.runCycle();
+      if (result) {
+        metabolism.onSubstrateFound();
+        logger.info('digest', `Initial digest cycle: ${result.tiersGenerated.length} tiers, ${result.durationMs}ms`);
+      }
+    } catch (err) {
+      logger.warn('digest', 'Initial digest cycle failed', { error: (err as Error).message });
+    }
+
+    // Start metabolism timer
+    metabolism.start(async () => {
+      try {
+        const cycleResult = await digestEngine.runCycle();
+        if (cycleResult) {
+          metabolism!.onSubstrateFound();
+          logger.info('digest', `Digest cycle ${cycleResult.cycleId}: ${cycleResult.tiersGenerated.length} tiers`);
+        } else {
+          metabolism!.onEmptyCycle();
+          logger.debug('digest', 'No substrate, backing off');
+        }
+      } catch (err) {
+        logger.warn('digest', 'Digest cycle failed', { error: (err as Error).message });
+        metabolism!.onEmptyCycle();
+      }
+    });
+
+    logger.info('digest', 'Digest enabled — starting metabolism');
+  }
+
   const batchManager = new BatchManager(async (closedBatch: BatchEvent[]) => {
     if (closedBatch.length === 0) return;
 
@@ -360,6 +417,9 @@ export async function main(): Promise<void> {
     } catch (err) {
       logger.debug('lineage', 'Heuristic detection failed', { error: (err as Error).message });
     }
+
+    // Wake digest metabolism when a new session starts
+    metabolism?.activate();
 
     logger.info('lifecycle', 'Session registered', { session_id, branch });
     return { ok: true, sessions: registry.sessions };
@@ -751,12 +811,28 @@ export async function main(): Promise<void> {
     logger.info('processor', 'Session note written', { session_id: sessionId, path: relativePath });
   }
 
-  // Session-start context: structural facts only — active plans + parent session.
+  // Session-start context: digest extract (if available) or structural facts.
   // Memories are injected per-prompt (more targeted, less noise).
   server.registerRoute('POST', '/context', async (body: unknown) => {
     const { session_id, branch } = ContextBody.parse(body);
     logger.debug('hooks', 'Session context query', { session_id });
     try {
+      // Digest-first: serve pre-computed extract if available
+      if (config.digest.enabled && config.digest.inject_tier) {
+        const result = handleMycoContext(vaultDir, { tier: config.digest.inject_tier });
+
+        if (!result.content.includes('not yet available')) {
+          // Append session metadata that the agent needs regardless of context source
+          const meta: string[] = [result.content];
+          if (branch) meta.push(`\nBranch:: \`${branch}\``);
+          meta.push(`Session:: \`${session_id}\``);
+
+          logger.debug('context', `Injecting digest extract (tier ${result.tier})`, { session_id, fallback: result.fallback });
+          return { text: meta.join('\n\n'), source: 'digest', tier: result.tier };
+        }
+        // Fall through to layer-based injection if no extract exists yet
+      }
+
       const parts: string[] = [];
 
       // Active plans — the agent needs to know what's in flight
@@ -866,6 +942,7 @@ export async function main(): Promise<void> {
       logger.info('daemon', 'Waiting for active stop processing to complete...');
       await activeStopProcessing;
     }
+    metabolism?.stop();
     planWatcher.stopFileWatcher();
     registry.destroy();
     await server.stop();

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -880,7 +880,7 @@ export async function main(): Promise<void> {
     }
   });
 
-  // Per-prompt context: semantic search for memories relevant to THIS specific prompt.
+  // Per-prompt context: semantic search for spores relevant to THIS specific prompt.
   // This is the primary intelligence delivery — targeted, high-confidence, token-efficient.
   const PromptContextBody = z.object({
     prompt: z.string(),

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -292,20 +292,24 @@ export async function main(): Promise<void> {
       base_url: config.digest.intelligence.base_url ?? config.intelligence.llm.base_url,
       context_window: config.digest.intelligence.context_window,
     };
+    logger.debug('digest', 'Digest LLM config', digestLlmConfig);
     const digestLlm = (config.digest.intelligence.model || config.digest.intelligence.provider)
       ? createLlmProvider(digestLlmConfig)
       : llmProvider;
+    logger.debug('digest', `Using ${digestLlm.name} provider for digest`);
 
     const digestEngine = new DigestEngine({
       vaultDir,
       index,
       llmProvider: digestLlm,
       config,
+      log: (level, message, data) => logger[level]('digest', message, data),
     });
 
     metabolism = new Metabolism(config.digest.metabolism);
 
     // Fire initial cycle in the background — don't block server readiness
+    logger.debug('digest', 'Firing initial digest cycle (background)');
     digestEngine.runCycle()
       .then((result) => {
         if (result) {

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -305,16 +305,17 @@ export async function main(): Promise<void> {
 
     metabolism = new Metabolism(config.digest.metabolism);
 
-    // Run initial cycle
-    try {
-      const result = await digestEngine.runCycle();
-      if (result) {
-        metabolism.onSubstrateFound();
-        logger.info('digest', `Initial digest cycle: ${result.tiersGenerated.length} tiers, ${result.durationMs}ms`);
-      }
-    } catch (err) {
-      logger.warn('digest', 'Initial digest cycle failed', { error: (err as Error).message });
-    }
+    // Fire initial cycle in the background — don't block server readiness
+    digestEngine.runCycle()
+      .then((result) => {
+        if (result) {
+          metabolism!.onSubstrateFound();
+          logger.info('digest', `Initial digest cycle: ${result.tiersGenerated.length} tiers, ${result.durationMs}ms`);
+        }
+      })
+      .catch((err) => {
+        logger.warn('digest', 'Initial digest cycle failed', { error: (err as Error).message });
+      });
 
     // Start metabolism timer
     metabolism.start(async () => {
@@ -821,7 +822,7 @@ export async function main(): Promise<void> {
       if (config.digest.enabled && config.digest.inject_tier) {
         const result = handleMycoContext(vaultDir, { tier: config.digest.inject_tier });
 
-        if (!result.content.includes('not yet available')) {
+        if (result.generated !== undefined) {
           // Append session metadata that the agent needs regardless of context source
           const meta: string[] = [result.content];
           if (branch) meta.push(`\nBranch:: \`${branch}\``);

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -17,7 +17,7 @@ import type { RegisteredSession } from './lifecycle.js';
 import { PlanWatcher } from './watcher.js';
 import { buildSimilarityPrompt } from '../prompts/index.js';
 import { extractNumber } from '../intelligence/response.js';
-import { EMBEDDING_INPUT_LIMIT, CONTENT_SNIPPET_CHARS, CHARS_PER_TOKEN, STALE_BUFFER_MAX_AGE_MS, LINEAGE_RECENT_SESSIONS_LIMIT, RELATED_MEMORIES_LIMIT, CANDIDATE_CONTENT_PREVIEW, SESSION_CONTEXT_MAX_PLANS, PROMPT_CONTEXT_MAX_MEMORIES, PROMPT_CONTEXT_MIN_SIMILARITY, PROMPT_CONTEXT_MIN_LENGTH, CONTEXT_SESSION_PREVIEW_CHARS } from '../constants.js';
+import { EMBEDDING_INPUT_LIMIT, CONTENT_SNIPPET_CHARS, CHARS_PER_TOKEN, STALE_BUFFER_MAX_AGE_MS, LINEAGE_RECENT_SESSIONS_LIMIT, RELATED_SPORES_LIMIT, CANDIDATE_CONTENT_PREVIEW, SESSION_CONTEXT_MAX_PLANS, PROMPT_CONTEXT_MAX_SPORES, PROMPT_CONTEXT_MIN_SIMILARITY, PROMPT_CONTEXT_MIN_LENGTH, CONTEXT_SESSION_PREVIEW_CHARS } from '../constants.js';
 import { TranscriptMiner, extractTurnsFromBuffer } from '../capture/transcript-miner.js';
 import { createPerProjectAdapter, extensionForMimeType } from '../agents/adapter.js';
 import { claudeCodeAdapter } from '../agents/claude-code.js';
@@ -64,7 +64,7 @@ function writeObservations(
   const written = writeObservationNotes(observations, sessionId, deps.vault, deps.index, deps.vaultDir);
   for (const note of written) {
     indexAndEmbed(note.path, note.id, `${note.observation.title}\n${note.observation.content}`,
-      { type: 'memory', importance: 'high', session_id: sessionId }, deps);
+      { type: 'spore', importance: 'high', session_id: sessionId }, deps);
     deps.logger.info('processor', 'Observation written', { type: note.observation.type, title: note.observation.title, session_id: sessionId });
   }
 }
@@ -106,15 +106,15 @@ async function captureArtifacts(
   }
 }
 
-export function migrateMemoryFiles(vaultDir: string): number {
-  const memoriesDir = path.join(vaultDir, 'memories');
-  if (!fs.existsSync(memoriesDir)) return 0;
+export function migrateSporeFiles(vaultDir: string): number {
+  const sporesDir = path.join(vaultDir, 'spores');
+  if (!fs.existsSync(sporesDir)) return 0;
 
   let moved = 0;
-  const entries = fs.readdirSync(memoriesDir);
+  const entries = fs.readdirSync(sporesDir);
 
   for (const entry of entries) {
-    const fullPath = path.join(memoriesDir, entry);
+    const fullPath = path.join(sporesDir, entry);
     if (!entry.endsWith('.md')) continue;
     if (fs.statSync(fullPath).isDirectory()) continue;
 
@@ -128,7 +128,7 @@ export function migrateMemoryFiles(vaultDir: string): number {
       if (!obsType) continue;
 
       const normalizedType = obsType.replace(/_/g, '-');
-      const targetDir = path.join(memoriesDir, normalizedType);
+      const targetDir = path.join(sporesDir, normalizedType);
       fs.mkdirSync(targetDir, { recursive: true });
       const targetPath = path.join(targetDir, entry);
       fs.renameSync(fullPath, targetPath);
@@ -218,10 +218,10 @@ export async function main(): Promise<void> {
     }
   }
 
-  // Migrate flat memory files into type subdirectories
-  const migrated = migrateMemoryFiles(vaultDir);
+  // Migrate flat spore files into type subdirectories
+  const migrated = migrateSporeFiles(vaultDir);
   if (migrated > 0) {
-    logger.info('daemon', 'Migrated memory files to type subdirectories', { count: migrated });
+    logger.info('daemon', 'Migrated spore files to type subdirectories', { count: migrated });
     // Rebuild FTS index to update stored paths (vectors are keyed by ID, unaffected)
     initFts(index);
     rebuildIndex(index, vaultDir);
@@ -649,8 +649,8 @@ export async function main(): Promise<void> {
       narrative = summaryResult.summary;
     }
 
-    // Query related memories for this session
-    const relatedMemories = index.query({ type: 'memory', limit: RELATED_MEMORIES_LIMIT })
+    // Query related spores for this session
+    const relatedMemories = index.query({ type: 'spore', limit: RELATED_SPORES_LIMIT })
       .filter((n) => {
         const fm = n.frontmatter as Record<string, unknown>;
         return fm.session === sessionNoteId(sessionId) || fm.session === sessionId;
@@ -819,8 +819,8 @@ export async function main(): Promise<void> {
     try {
       const emb = await generateEmbedding(embeddingProvider, prompt.slice(0, EMBEDDING_INPUT_LIMIT));
       const results = vectorIndex.search(emb.embedding, {
-        limit: PROMPT_CONTEXT_MAX_MEMORIES,
-        type: 'memory',
+        limit: PROMPT_CONTEXT_MAX_SPORES,
+        type: 'spore',
         relativeThreshold: PROMPT_CONTEXT_MIN_SIMILARITY,
       });
 
@@ -842,10 +842,10 @@ export async function main(): Promise<void> {
 
       if (lines.length === 0) return { text: '' };
 
-      const injected = `**Relevant memories for this task:**\n${lines.join('\n')}`;
+      const injected = `**Relevant spores for this task:**\n${lines.join('\n')}`;
       logger.debug('context', 'Prompt context injected', {
         session_id,
-        memories: lines.length,
+        spores: lines.length,
         prompt_preview: prompt.slice(0, 50),
       });
 

--- a/src/daemon/processor.ts
+++ b/src/daemon/processor.ts
@@ -96,7 +96,7 @@ export class BufferProcessor {
     sessionId: string,
   ): string {
     const toolSummary = this.summarizeEvents(events);
-    return buildExtractionPrompt(sessionId, events.length, toolSummary);
+    return buildExtractionPrompt(sessionId, events.length, toolSummary, this.extractionMaxTokens);
   }
 
   async summarizeSession(
@@ -105,7 +105,7 @@ export class BufferProcessor {
     user?: string,
   ): Promise<{ summary: string; title: string }> {
     const truncatedContent = this.truncateForContext(conversationMarkdown, this.summaryMaxTokens);
-    const summaryPrompt = buildSummaryPrompt(sessionId, user ?? 'unknown', truncatedContent);
+    const summaryPrompt = buildSummaryPrompt(sessionId, user ?? 'unknown', truncatedContent, this.summaryMaxTokens);
 
     let summaryText: string;
     try {
@@ -144,7 +144,7 @@ export class BufferProcessor {
     candidates: Array<{ path: string; content: string }>,
     sessionId: string,
   ): string {
-    return buildClassificationPrompt(sessionId, candidates);
+    return buildClassificationPrompt(sessionId, candidates, this.classificationMaxTokens);
   }
 
   private summarizeEvents(events: Array<Record<string, unknown>>): string {

--- a/src/daemon/processor.ts
+++ b/src/daemon/processor.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { LlmProvider } from '../intelligence/llm.js';
 import { ARTIFACT_TYPES } from '../vault/types.js';
-import { CHARS_PER_TOKEN, PROMPT_PREVIEW_CHARS, AI_RESPONSE_PREVIEW_CHARS, COMMAND_PREVIEW_CHARS } from '../constants.js';
+import { estimateTokens, CHARS_PER_TOKEN, PROMPT_PREVIEW_CHARS, AI_RESPONSE_PREVIEW_CHARS, COMMAND_PREVIEW_CHARS } from '../constants.js';
 import type { MycoConfig } from '../config/schema.js';
 import type { ObservationType, ArtifactType } from '../vault/types.js';
 import { buildExtractionPrompt, buildSummaryPrompt, buildTitlePrompt, buildClassificationPrompt } from '../prompts/index.js';
@@ -57,7 +57,7 @@ export class BufferProcessor {
 
   private truncateForContext(data: string, maxTokens: number): string {
     const available = this.contextWindow - maxTokens;
-    const dataTokens = Math.ceil(data.length / CHARS_PER_TOKEN);
+    const dataTokens = estimateTokens(data);
     if (dataTokens <= available) return data;
     const charBudget = available * CHARS_PER_TOKEN;
     return data.slice(0, charBudget);

--- a/src/daemon/processor.ts
+++ b/src/daemon/processor.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
 import type { LlmProvider } from '../intelligence/llm.js';
 import { ARTIFACT_TYPES } from '../vault/types.js';
-import { CHARS_PER_TOKEN, EXTRACTION_MAX_TOKENS, SUMMARY_MAX_TOKENS, TITLE_MAX_TOKENS, CLASSIFICATION_MAX_TOKENS, PROMPT_PREVIEW_CHARS, AI_RESPONSE_PREVIEW_CHARS, COMMAND_PREVIEW_CHARS } from '../constants.js';
+import { CHARS_PER_TOKEN, PROMPT_PREVIEW_CHARS, AI_RESPONSE_PREVIEW_CHARS, COMMAND_PREVIEW_CHARS } from '../constants.js';
+import type { MycoConfig } from '../config/schema.js';
 import type { ObservationType, ArtifactType } from '../vault/types.js';
 import { buildExtractionPrompt, buildSummaryPrompt, buildTitlePrompt, buildClassificationPrompt } from '../prompts/index.js';
 import { extractJson, stripReasoningTokens } from '../intelligence/response.js';
@@ -42,7 +43,17 @@ const ClassificationResponseSchema = z.object({
 });
 
 export class BufferProcessor {
-  constructor(private backend: LlmProvider, private contextWindow: number = 8192) {}
+  private extractionMaxTokens: number;
+  private summaryMaxTokens: number;
+  private titleMaxTokens: number;
+  private classificationMaxTokens: number;
+
+  constructor(private backend: LlmProvider, private contextWindow: number = 8192, captureConfig?: MycoConfig['capture']) {
+    this.extractionMaxTokens = captureConfig?.extraction_max_tokens ?? 2048;
+    this.summaryMaxTokens = captureConfig?.summary_max_tokens ?? 512;
+    this.titleMaxTokens = captureConfig?.title_max_tokens ?? 32;
+    this.classificationMaxTokens = captureConfig?.classification_max_tokens ?? 1024;
+  }
 
   private truncateForContext(data: string, maxTokens: number): string {
     const available = this.contextWindow - maxTokens;
@@ -57,10 +68,10 @@ export class BufferProcessor {
     sessionId: string,
   ): Promise<ProcessorResult> {
     const rawPrompt = this.buildPromptForExtraction(events, sessionId);
-    const prompt = this.truncateForContext(rawPrompt, EXTRACTION_MAX_TOKENS);
+    const prompt = this.truncateForContext(rawPrompt, this.extractionMaxTokens);
 
     try {
-      const response = await this.backend.summarize(prompt, { maxTokens: EXTRACTION_MAX_TOKENS });
+      const response = await this.backend.summarize(prompt, { maxTokens: this.extractionMaxTokens });
       const parsed = extractJson(response.text) as {
         summary: string;
         observations: Observation[];
@@ -93,12 +104,12 @@ export class BufferProcessor {
     sessionId: string,
     user?: string,
   ): Promise<{ summary: string; title: string }> {
-    const truncatedContent = this.truncateForContext(conversationMarkdown, SUMMARY_MAX_TOKENS);
+    const truncatedContent = this.truncateForContext(conversationMarkdown, this.summaryMaxTokens);
     const summaryPrompt = buildSummaryPrompt(sessionId, user ?? 'unknown', truncatedContent);
 
     let summaryText: string;
     try {
-      const response = await this.backend.summarize(summaryPrompt, { maxTokens: SUMMARY_MAX_TOKENS });
+      const response = await this.backend.summarize(summaryPrompt, { maxTokens: this.summaryMaxTokens });
       summaryText = stripReasoningTokens(response.text);
     } catch (error) {
       summaryText = `Session ${sessionId} — summarization failed: ${(error as Error).message}`;
@@ -107,7 +118,7 @@ export class BufferProcessor {
     const titlePrompt = buildTitlePrompt(summaryText, sessionId);
     let title: string;
     try {
-      const response = await this.backend.summarize(titlePrompt, { maxTokens: TITLE_MAX_TOKENS });
+      const response = await this.backend.summarize(titlePrompt, { maxTokens: this.titleMaxTokens });
       title = stripReasoningTokens(response.text).trim();
     } catch {
       title = `Session ${sessionId}`;
@@ -123,7 +134,7 @@ export class BufferProcessor {
     if (candidates.length === 0) return [];
 
     const prompt = this.buildPromptForClassification(candidates, sessionId);
-    const response = await this.backend.summarize(prompt, { maxTokens: CLASSIFICATION_MAX_TOKENS });
+    const response = await this.backend.summarize(prompt, { maxTokens: this.classificationMaxTokens });
     const raw = extractJson(response.text);
     const parsed = ClassificationResponseSchema.parse(raw);
     return parsed.artifacts;

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -35,6 +35,9 @@ async function main() {
       const contextResult = await client.post('/context', { session_id: sessionId, branch });
 
       if (contextResult.ok && contextResult.data?.text) {
+        if (contextResult.data.source === 'digest') {
+          process.stderr.write(`[myco] Injecting digest extract (tier ${contextResult.data.tier})\n`);
+        }
         process.stdout.write(contextResult.data.text);
         return;
       }

--- a/src/hooks/user-prompt-submit.ts
+++ b/src/hooks/user-prompt-submit.ts
@@ -32,9 +32,9 @@ async function main() {
       buffer.append({ type: 'user_prompt', prompt });
     }
 
-    // Search for relevant memories to inject as context for this prompt.
+    // Search for relevant spores to inject as context for this prompt.
     // The daemon does a vector search against the prompt text and returns
-    // any high-relevance memories. This is fast (~20ms) — no LLM call.
+    // any high-relevance spores. This is fast (~20ms) — no LLM call.
     const contextResult = await client.post('/context/prompt', {
       prompt,
       session_id: sessionId,

--- a/src/index/sqlite.ts
+++ b/src/index/sqlite.ts
@@ -110,8 +110,11 @@ export class MycoIndex {
       params.push(options.since);
     }
     if (options.updatedSince) {
+      // Normalize ISO 8601 (e.g., "2026-03-19T16:40:08.582Z") to SQLite datetime format
+      // ("2026-03-19 16:40:08") for correct string comparison
+      const normalized = options.updatedSince.replace('T', ' ').replace(/\.\d+Z$/, '').replace(/Z$/, '');
       conditions.push('updated_at >= ?');
-      params.push(options.updatedSince);
+      params.push(normalized);
     }
     if (options.frontmatter) {
       for (const [key, value] of Object.entries(options.frontmatter)) {

--- a/src/index/sqlite.ts
+++ b/src/index/sqlite.ts
@@ -48,6 +48,7 @@ export class MycoIndex {
       CREATE INDEX IF NOT EXISTS idx_notes_type ON notes(type);
       CREATE INDEX IF NOT EXISTS idx_notes_id ON notes(id);
       CREATE INDEX IF NOT EXISTS idx_notes_created ON notes(created);
+      CREATE INDEX IF NOT EXISTS idx_notes_updated_at ON notes(updated_at);
     `);
   }
 
@@ -110,11 +111,9 @@ export class MycoIndex {
       params.push(options.since);
     }
     if (options.updatedSince) {
-      // Normalize ISO 8601 (e.g., "2026-03-19T16:40:08.582Z") to SQLite datetime format
-      // ("2026-03-19 16:40:08") for correct string comparison
-      const normalized = options.updatedSince.replace('T', ' ').replace(/\.\d+Z$/, '').replace(/Z$/, '');
-      conditions.push('updated_at >= ?');
-      params.push(normalized);
+      // Use SQLite datetime() to handle ISO 8601 formats (Z-suffix, offsets, milliseconds)
+      conditions.push('updated_at >= datetime(?)');
+      params.push(options.updatedSince);
     }
     if (options.frontmatter) {
       for (const [key, value] of Object.entries(options.frontmatter)) {

--- a/src/index/sqlite.ts
+++ b/src/index/sqlite.ts
@@ -16,6 +16,8 @@ export interface QueryOptions {
   id?: string;
   limit?: number;
   since?: string;
+  /** Filter by updated_at — returns notes with updated_at >= this ISO string. */
+  updatedSince?: string;
   /** Filter by frontmatter fields using json_extract. Applied before LIMIT. */
   frontmatter?: Record<string, string>;
 }
@@ -106,6 +108,10 @@ export class MycoIndex {
     if (options.since) {
       conditions.push('created >= ?');
       params.push(options.since);
+    }
+    if (options.updatedSince) {
+      conditions.push('updated_at >= ?');
+      params.push(options.updatedSince);
     }
     if (options.frontmatter) {
       for (const [key, value] of Object.entries(options.frontmatter)) {

--- a/src/intelligence/llm.ts
+++ b/src/intelligence/llm.ts
@@ -4,6 +4,7 @@ import { AnthropicBackend } from './anthropic.js';
 
 export interface LlmRequestOptions {
   maxTokens?: number;
+  timeoutMs?: number;
 }
 
 export interface LlmResponse {

--- a/src/intelligence/llm.ts
+++ b/src/intelligence/llm.ts
@@ -5,6 +5,12 @@ import { AnthropicBackend } from './anthropic.js';
 export interface LlmRequestOptions {
   maxTokens?: number;
   timeoutMs?: number;
+  /** Per-request context length (tokens). Supported by LM Studio and Ollama. */
+  contextLength?: number;
+  /** Control reasoning/thinking output. 'off' suppresses chain-of-thought. LM Studio native API only. */
+  reasoning?: 'off' | 'low' | 'medium' | 'high' | 'on';
+  /** System prompt, sent separately from user content. LM Studio native API only. */
+  systemPrompt?: string;
 }
 
 export interface LlmResponse {

--- a/src/intelligence/llm.ts
+++ b/src/intelligence/llm.ts
@@ -30,6 +30,8 @@ export interface LlmProvider {
   name: string;
   summarize(prompt: string, opts?: LlmRequestOptions): Promise<LlmResponse>;
   isAvailable(): Promise<boolean>;
+  /** Pre-load the model with specific settings. Optional — only LM Studio implements this. */
+  ensureLoaded?(contextLength?: number, gpuKvCache?: boolean): Promise<void>;
 }
 
 export interface EmbeddingProvider {

--- a/src/intelligence/llm.ts
+++ b/src/intelligence/llm.ts
@@ -9,8 +9,10 @@ export interface LlmRequestOptions {
   contextLength?: number;
   /** Control reasoning/thinking output. 'off' suppresses chain-of-thought. LM Studio native API only. */
   reasoning?: 'off' | 'low' | 'medium' | 'high' | 'on';
-  /** System prompt, sent separately from user content. LM Studio native API only. */
+  /** System prompt, sent separately from user content. Supported by LM Studio and Ollama native APIs. */
   systemPrompt?: string;
+  /** Keep model loaded for this duration after request (e.g., "10m"). Ollama only. */
+  keepAlive?: string;
 }
 
 export interface LlmResponse {

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -116,25 +116,13 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
   }
 
   /**
-   * Load the model with the correct settings for digest operations.
-   * If we previously loaded an instance, unloads it first to prevent stacking
-   * across daemon restarts. Only unloads OUR instance — leaves other instances
-   * (user-loaded or hook-loaded) untouched.
-   * Captures the instance_id so subsequent chat requests target this exact instance.
+   * Load the model with specific settings for digest operations.
+   * Creates a dedicated instance and captures the instance_id so subsequent
+   * chat requests target it directly (avoiding auto-load side effects).
+   * Does not unload other instances — hooks and other providers may be
+   * using the same model with different settings.
    */
   async ensureLoaded(contextLength?: number, gpuKvCache?: boolean): Promise<void> {
-    // Unload only our previously loaded instance, not all instances of this model
-    if (this.loadedInstanceId) {
-      try {
-        await fetch(`${this.baseUrl}${ENDPOINT_MODELS_UNLOAD}`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ instance_id: this.loadedInstanceId }),
-          signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
-        });
-      } catch { /* already unloaded — fine */ }
-      this.loadedInstanceId = null;
-    }
 
     const ctx = contextLength ?? this.contextWindow;
     const body: Record<string, unknown> = {

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -33,6 +33,8 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
         model: this.model,
         messages: [{ role: 'user', content: prompt }],
         max_tokens: maxTokens,
+        // Suppress visible chain-of-thought for reasoning models (Qwen 3.5, etc.)
+        chat_template_kwargs: { enable_thinking: false },
       }),
       signal: AbortSignal.timeout(opts?.timeoutMs ?? LLM_REQUEST_TIMEOUT_MS),
     });

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -110,9 +110,21 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
 
   /**
    * Ensure the model is loaded with the correct settings.
+   * Unloads existing instances first (LM Studio auto-loads with defaults when
+   * it sees context_length in chat requests, creating duplicates).
    * Captures the instance_id so subsequent chat requests target this exact instance.
    */
   async ensureLoaded(contextLength?: number, gpuKvCache?: boolean): Promise<void> {
+    // Unload any auto-loaded instances with wrong settings
+    try {
+      await fetch(`${this.baseUrl}/api/v1/models/unload`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: this.model }),
+        signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
+      });
+    } catch { /* not loaded — fine */ }
+
     const ctx = contextLength ?? this.contextWindow;
     const body: Record<string, unknown> = {
       model: this.model,

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -122,13 +122,24 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
    * Captures the instance_id so subsequent chat requests target this exact instance.
    */
   async ensureLoaded(contextLength?: number, gpuKvCache?: boolean): Promise<void> {
+    // Unload all existing instances of this model to prevent stacking
     try {
-      await fetch(`${this.baseUrl}${ENDPOINT_MODELS_UNLOAD}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model: this.model }),
+      const listResp = await fetch(`${this.baseUrl}${ENDPOINT_MODELS_LIST}`, {
         signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
       });
+      if (listResp.ok) {
+        const listData = await listResp.json() as { data: Array<{ id: string }> };
+        for (const m of listData.data) {
+          if (m.id === this.model || m.id.startsWith(`${this.model}:`)) {
+            await fetch(`${this.baseUrl}${ENDPOINT_MODELS_UNLOAD}`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ instance_id: m.id }),
+              signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
+            }).catch(() => {});
+          }
+        }
+      }
     } catch { /* not loaded — fine */ }
 
     const ctx = contextLength ?? this.contextWindow;

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -64,8 +64,8 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
     });
 
     if (!response.ok) {
-      const text = await response.text().catch(() => '');
-      throw new Error(`LM Studio summarize failed: ${response.status} ${text}`);
+      const errorBody = await response.text().catch(() => '');
+      throw new Error(`LM Studio summarize failed: ${response.status} ${errorBody.slice(0, 500)}`);
     }
 
     const data = await response.json() as {

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -109,22 +109,11 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
   }
 
   /**
-   * Ensure the model is loaded with the correct settings.
-   * Unloads existing instances first (LM Studio auto-loads with defaults when
-   * it sees context_length in chat requests, creating duplicates).
-   * Captures the instance_id so subsequent chat requests target this exact instance.
+   * Load the model with the correct settings for digest operations.
+   * Captures the instance_id so subsequent chat requests target this exact instance
+   * without passing context_length (which would trigger LM Studio auto-loading).
    */
   async ensureLoaded(contextLength?: number, gpuKvCache?: boolean): Promise<void> {
-    // Unload any auto-loaded instances with wrong settings
-    try {
-      await fetch(`${this.baseUrl}/api/v1/models/unload`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model: this.model }),
-        signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
-      });
-    } catch { /* not loaded — fine */ }
-
     const ctx = contextLength ?? this.contextWindow;
     const body: Record<string, unknown> = {
       model: this.model,

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -60,15 +60,11 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
       body.reasoning = opts.reasoning;
     }
 
-    // keepalive: true prevents Node.js from closing the connection at its
-    // default 5-minute idle timeout. Digest requests can take 5+ minutes
-    // for large context windows on local models.
     const response = await fetch(`${this.baseUrl}/api/v1/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(opts?.timeoutMs ?? LLM_REQUEST_TIMEOUT_MS),
-      keepalive: true,
     });
 
     if (!response.ok) {
@@ -114,23 +110,9 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
 
   /**
    * Ensure the model is loaded with the correct settings.
-   * Unloads any existing instances first to prevent duplicates with wrong settings,
-   * then loads with the specified context length and KV cache config.
+   * Captures the instance_id so subsequent chat requests target this exact instance.
    */
   async ensureLoaded(contextLength?: number, gpuKvCache?: boolean): Promise<void> {
-    // Unload any existing instances of this model to prevent duplicates
-    // with default settings (wrong context size, KV cache on GPU)
-    try {
-      await fetch(`${this.baseUrl}/api/v1/models/unload`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model: this.model }),
-        signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
-      });
-    } catch {
-      // Model may not be loaded — that's fine
-    }
-
     const ctx = contextLength ?? this.contextWindow;
     const body: Record<string, unknown> = {
       model: this.model,

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -16,6 +16,7 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
   readonly name = 'lm-studio';
   private baseUrl: string;
   private model: string;
+  private loadedInstanceId: string | null = null;
   private contextWindow: number | undefined;
   private defaultMaxTokens: number;
 
@@ -34,16 +35,19 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
     const maxTokens = opts?.maxTokens ?? this.defaultMaxTokens;
 
     const body: Record<string, unknown> = {
-      model: this.model,
+      model: this.loadedInstanceId ?? this.model,
       input: prompt,
       max_output_tokens: maxTokens,
       store: false,
     };
 
-    // Per-request context length (from opts or constructor config)
-    const contextLength = opts?.contextLength ?? this.contextWindow;
-    if (contextLength) {
-      body.context_length = contextLength;
+    // Only set context_length if we haven't pre-loaded the model
+    // (pre-loaded models already have the correct context via ensureLoaded)
+    if (!this.loadedInstanceId) {
+      const contextLength = opts?.contextLength ?? this.contextWindow;
+      if (contextLength) {
+        body.context_length = contextLength;
+      }
     }
 
     // System prompt — sent separately from user content
@@ -147,6 +151,12 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
     if (!response.ok) {
       const errorBody = await response.text().catch(() => '');
       throw new Error(`LM Studio model load failed: ${response.status} ${errorBody.slice(0, 200)}`);
+    }
+
+    // Capture the instance ID so chat requests target this specific loaded instance
+    const loadResult = await response.json() as { instance_id?: string };
+    if (loadResult.instance_id) {
+      this.loadedInstanceId = loadResult.instance_id;
     }
   }
 

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -113,14 +113,12 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
    * Uses LM Studio's native /api/v1/models/load endpoint.
    * If the model is already loaded, this is a no-op on LM Studio's side.
    */
-  async ensureLoaded(contextLength?: number): Promise<void> {
+  async ensureLoaded(contextLength?: number, gpuKvCache?: boolean): Promise<void> {
     const ctx = contextLength ?? this.contextWindow;
     const body: Record<string, unknown> = {
       model: this.model,
       flash_attention: true,
-      // Keep KV cache in system RAM — GPU VRAM is often too small for large contexts
-      // and LM Studio silently downsizes the effective context to fit VRAM
-      offload_kv_cache_to_gpu: false,
+      offload_kv_cache_to_gpu: gpuKvCache ?? false,
     };
     if (ctx) {
       body.context_length = ctx;

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -104,6 +104,33 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
     return { embedding, model: data.model, dimensions: embedding.length };
   }
 
+  /**
+   * Ensure the model is loaded with the specified context length.
+   * Uses LM Studio's native /api/v1/models/load endpoint.
+   * If the model is already loaded, this is a no-op on LM Studio's side.
+   */
+  async ensureLoaded(contextLength?: number): Promise<void> {
+    const body: Record<string, unknown> = {
+      model: this.model,
+      flash_attention: true,
+    };
+    if (contextLength ?? this.contextWindow) {
+      body.context_length = contextLength ?? this.contextWindow;
+    }
+
+    const response = await fetch(`${this.baseUrl}/api/v1/models/load`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(LLM_REQUEST_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => '');
+      throw new Error(`LM Studio model load failed: ${response.status} ${errorBody.slice(0, 200)}`);
+    }
+  }
+
   async isAvailable(): Promise<boolean> {
     try {
       const response = await fetch(`${this.baseUrl}/v1/models`, {

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -117,30 +117,24 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
 
   /**
    * Load the model with the correct settings for digest operations.
-   * Unloads first because LM Studio persists models across daemon restarts —
-   * without this, each daemon start would stack a new instance alongside the old one.
+   * If we previously loaded an instance, unloads it first to prevent stacking
+   * across daemon restarts. Only unloads OUR instance — leaves other instances
+   * (user-loaded or hook-loaded) untouched.
    * Captures the instance_id so subsequent chat requests target this exact instance.
    */
   async ensureLoaded(contextLength?: number, gpuKvCache?: boolean): Promise<void> {
-    // Unload all existing instances of this model to prevent stacking
-    try {
-      const listResp = await fetch(`${this.baseUrl}${ENDPOINT_MODELS_LIST}`, {
-        signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
-      });
-      if (listResp.ok) {
-        const listData = await listResp.json() as { data: Array<{ id: string }> };
-        for (const m of listData.data) {
-          if (m.id === this.model || m.id.startsWith(`${this.model}:`)) {
-            await fetch(`${this.baseUrl}${ENDPOINT_MODELS_UNLOAD}`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ instance_id: m.id }),
-              signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
-            }).catch(() => {});
-          }
-        }
-      }
-    } catch { /* not loaded — fine */ }
+    // Unload only our previously loaded instance, not all instances of this model
+    if (this.loadedInstanceId) {
+      try {
+        await fetch(`${this.baseUrl}${ENDPOINT_MODELS_UNLOAD}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ instance_id: this.loadedInstanceId }),
+          signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
+        });
+      } catch { /* already unloaded — fine */ }
+      this.loadedInstanceId = null;
+    }
 
     const ctx = contextLength ?? this.contextWindow;
     const body: Record<string, unknown> = {

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -110,10 +110,20 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
 
   /**
    * Load the model with the correct settings for digest operations.
-   * Captures the instance_id so subsequent chat requests target this exact instance
-   * without passing context_length (which would trigger LM Studio auto-loading).
+   * Unloads first because LM Studio persists models across daemon restarts —
+   * without this, each daemon start would stack a new instance alongside the old one.
+   * Captures the instance_id so subsequent chat requests target this exact instance.
    */
   async ensureLoaded(contextLength?: number, gpuKvCache?: boolean): Promise<void> {
+    try {
+      await fetch(`${this.baseUrl}/api/v1/models/unload`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: this.model }),
+        signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
+      });
+    } catch { /* not loaded — fine */ }
+
     const ctx = contextLength ?? this.contextWindow;
     const body: Record<string, unknown> = {
       model: this.model,

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -56,11 +56,15 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
       body.reasoning = opts.reasoning;
     }
 
+    // keepalive: true prevents Node.js from closing the connection at its
+    // default 5-minute idle timeout. Digest requests can take 5+ minutes
+    // for large context windows on local models.
     const response = await fetch(`${this.baseUrl}/api/v1/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(opts?.timeoutMs ?? LLM_REQUEST_TIMEOUT_MS),
+      keepalive: true,
     });
 
     if (!response.ok) {

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -11,6 +11,13 @@ interface LmStudioConfig {
   summary_model?: string;
 }
 
+// LM Studio API endpoints
+const ENDPOINT_CHAT = '/api/v1/chat';
+const ENDPOINT_MODELS_LOAD = '/api/v1/models/load';
+const ENDPOINT_MODELS_UNLOAD = '/api/v1/models/unload';
+const ENDPOINT_MODELS_LIST = '/v1/models';
+const ENDPOINT_EMBEDDINGS = '/v1/embeddings';
+
 export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
   static readonly DEFAULT_BASE_URL = 'http://localhost:1234';
   readonly name = 'lm-studio';
@@ -60,7 +67,7 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
       body.reasoning = opts.reasoning;
     }
 
-    const response = await fetch(`${this.baseUrl}/api/v1/chat`, {
+    const response = await fetch(`${this.baseUrl}${ENDPOINT_CHAT}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -86,7 +93,7 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
    * (The native API doesn't have an embedding endpoint — OpenAI-compat is fine here.)
    */
   async embed(text: string): Promise<EmbeddingResponse> {
-    const response = await fetch(`${this.baseUrl}/v1/embeddings`, {
+    const response = await fetch(`${this.baseUrl}${ENDPOINT_EMBEDDINGS}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -116,7 +123,7 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
    */
   async ensureLoaded(contextLength?: number, gpuKvCache?: boolean): Promise<void> {
     try {
-      await fetch(`${this.baseUrl}/api/v1/models/unload`, {
+      await fetch(`${this.baseUrl}${ENDPOINT_MODELS_UNLOAD}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ model: this.model }),
@@ -134,7 +141,7 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
       body.context_length = ctx;
     }
 
-    const response = await fetch(`${this.baseUrl}/api/v1/models/load`, {
+    const response = await fetch(`${this.baseUrl}${ENDPOINT_MODELS_LOAD}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -155,7 +162,7 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
 
   async isAvailable(): Promise<boolean> {
     try {
-      const response = await fetch(`${this.baseUrl}/v1/models`, {
+      const response = await fetch(`${this.baseUrl}${ENDPOINT_MODELS_LIST}`, {
         signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
       });
       return response.ok;
@@ -167,7 +174,7 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
   /** List available models on this LM Studio instance. */
   async listModels(timeoutMs?: number): Promise<string[]> {
     try {
-      const response = await fetch(`${this.baseUrl}/v1/models`, {
+      const response = await fetch(`${this.baseUrl}${ENDPOINT_MODELS_LIST}`, {
         signal: AbortSignal.timeout(timeoutMs ?? DAEMON_CLIENT_TIMEOUT_MS),
       });
       const data = await response.json() as { data: Array<{ id: string }> };

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -69,10 +69,12 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
     }
 
     const data = await response.json() as {
-      message: string;
-      model: string;
+      model_instance_id: string;
+      output: Array<{ type: string; content: string }>;
     };
-    return { text: data.message, model: data.model };
+    const messageOutput = data.output.find((o) => o.type === 'message');
+    const text = messageOutput?.content ?? '';
+    return { text, model: data.model_instance_id };
   }
 
   /**

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -109,11 +109,24 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
   }
 
   /**
-   * Ensure the model is loaded with the specified context length.
-   * Uses LM Studio's native /api/v1/models/load endpoint.
-   * If the model is already loaded, this is a no-op on LM Studio's side.
+   * Ensure the model is loaded with the correct settings.
+   * Unloads any existing instances first to prevent duplicates with wrong settings,
+   * then loads with the specified context length and KV cache config.
    */
   async ensureLoaded(contextLength?: number, gpuKvCache?: boolean): Promise<void> {
+    // Unload any existing instances of this model to prevent duplicates
+    // with default settings (wrong context size, KV cache on GPU)
+    try {
+      await fetch(`${this.baseUrl}/api/v1/models/unload`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: this.model }),
+        signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
+      });
+    } catch {
+      // Model may not be loaded — that's fine
+    }
+
     const ctx = contextLength ?? this.contextWindow;
     const body: Record<string, unknown> = {
       model: this.model,

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -4,6 +4,7 @@ import { LLM_REQUEST_TIMEOUT_MS, EMBEDDING_REQUEST_TIMEOUT_MS, DAEMON_CLIENT_TIM
 interface LmStudioConfig {
   model?: string;
   base_url?: string;
+  context_window?: number;
   max_tokens?: number;
   // Legacy fields
   embedding_model?: string;
@@ -15,41 +16,69 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
   readonly name = 'lm-studio';
   private baseUrl: string;
   private model: string;
+  private contextWindow: number | undefined;
   private defaultMaxTokens: number;
 
   constructor(config?: LmStudioConfig) {
     this.baseUrl = config?.base_url ?? LmStudioBackend.DEFAULT_BASE_URL;
     this.model = config?.model ?? config?.summary_model ?? 'llama3.2';
+    this.contextWindow = config?.context_window;
     this.defaultMaxTokens = config?.max_tokens ?? 1024;
   }
 
+  /**
+   * Generate text using LM Studio's native REST API (/api/v1/chat).
+   * Supports per-request context_length, reasoning control, and system_prompt.
+   */
   async summarize(prompt: string, opts?: LlmRequestOptions): Promise<LlmResponse> {
     const maxTokens = opts?.maxTokens ?? this.defaultMaxTokens;
 
-    const response = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+    const body: Record<string, unknown> = {
+      model: this.model,
+      input: prompt,
+      max_output_tokens: maxTokens,
+      store: false,
+    };
+
+    // Per-request context length (from opts or constructor config)
+    const contextLength = opts?.contextLength ?? this.contextWindow;
+    if (contextLength) {
+      body.context_length = contextLength;
+    }
+
+    // System prompt — sent separately from user content
+    if (opts?.systemPrompt) {
+      body.system_prompt = opts.systemPrompt;
+    }
+
+    // Reasoning control — 'off' suppresses chain-of-thought for reasoning models
+    if (opts?.reasoning) {
+      body.reasoning = opts.reasoning;
+    }
+
+    const response = await fetch(`${this.baseUrl}/api/v1/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        model: this.model,
-        messages: [{ role: 'user', content: prompt }],
-        max_tokens: maxTokens,
-        // Suppress visible chain-of-thought for reasoning models (Qwen 3.5, etc.)
-        chat_template_kwargs: { enable_thinking: false },
-      }),
+      body: JSON.stringify(body),
       signal: AbortSignal.timeout(opts?.timeoutMs ?? LLM_REQUEST_TIMEOUT_MS),
     });
 
     if (!response.ok) {
-      throw new Error(`LM Studio summarize failed: ${response.status}`);
+      const text = await response.text().catch(() => '');
+      throw new Error(`LM Studio summarize failed: ${response.status} ${text}`);
     }
 
     const data = await response.json() as {
-      choices: Array<{ message: { content: string } }>;
+      message: string;
       model: string;
     };
-    return { text: data.choices[0].message.content, model: data.model };
+    return { text: data.message, model: data.model };
   }
 
+  /**
+   * Generate embeddings using LM Studio's OpenAI-compatible endpoint.
+   * (The native API doesn't have an embedding endpoint — OpenAI-compat is fine here.)
+   */
   async embed(text: string): Promise<EmbeddingResponse> {
     const response = await fetch(`${this.baseUrl}/v1/embeddings`, {
       method: 'POST',

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -110,12 +110,16 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
    * If the model is already loaded, this is a no-op on LM Studio's side.
    */
   async ensureLoaded(contextLength?: number): Promise<void> {
+    const ctx = contextLength ?? this.contextWindow;
     const body: Record<string, unknown> = {
       model: this.model,
       flash_attention: true,
+      // Keep KV cache in system RAM — GPU VRAM is often too small for large contexts
+      // and LM Studio silently downsizes the effective context to fit VRAM
+      offload_kv_cache_to_gpu: false,
     };
-    if (contextLength ?? this.contextWindow) {
-      body.context_length = contextLength ?? this.contextWindow;
+    if (ctx) {
+      body.context_length = ctx;
     }
 
     const response = await fetch(`${this.baseUrl}/api/v1/models/load`, {

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -34,7 +34,7 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
         messages: [{ role: 'user', content: prompt }],
         max_tokens: maxTokens,
       }),
-      signal: AbortSignal.timeout(LLM_REQUEST_TIMEOUT_MS),
+      signal: AbortSignal.timeout(opts?.timeoutMs ?? LLM_REQUEST_TIMEOUT_MS),
     });
 
     if (!response.ok) {

--- a/src/intelligence/ollama.ts
+++ b/src/intelligence/ollama.ts
@@ -62,7 +62,6 @@ export class OllamaBackend implements LlmProvider, EmbeddingProvider {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(opts?.timeoutMs ?? LLM_REQUEST_TIMEOUT_MS),
-      keepalive: true,
     });
 
     if (!response.ok) {

--- a/src/intelligence/ollama.ts
+++ b/src/intelligence/ollama.ts
@@ -28,23 +28,46 @@ export class OllamaBackend implements LlmProvider, EmbeddingProvider {
 
   async summarize(prompt: string, opts?: LlmRequestOptions): Promise<LlmResponse> {
     const maxTokens = opts?.maxTokens ?? this.defaultMaxTokens;
+    const contextLength = opts?.contextLength ?? this.contextWindow;
     const promptTokens = Math.ceil(prompt.length / CHARS_PER_TOKEN);
-    const numCtx = Math.max(promptTokens + maxTokens, this.contextWindow);
+    const numCtx = Math.max(promptTokens + maxTokens, contextLength);
+
+    const body: Record<string, unknown> = {
+      model: this.model,
+      prompt,
+      stream: false,
+      options: {
+        num_ctx: numCtx,
+        num_predict: maxTokens,
+      },
+    };
+
+    // System prompt — sent as a separate field instead of concatenated into prompt
+    if (opts?.systemPrompt) {
+      body.system = opts.systemPrompt;
+    }
+
+    // Thinking control — false suppresses chain-of-thought for reasoning models
+    if (opts?.reasoning) {
+      body.think = opts.reasoning === 'off' ? false : opts.reasoning;
+    }
+
+    // Keep model loaded between requests (useful for digest cycles)
+    if (opts?.keepAlive) {
+      body.keep_alive = opts.keepAlive;
+    }
 
     const response = await fetch(`${this.baseUrl}/api/generate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        model: this.model,
-        prompt,
-        stream: false,
-        options: { num_ctx: numCtx },
-      }),
+      body: JSON.stringify(body),
       signal: AbortSignal.timeout(opts?.timeoutMs ?? LLM_REQUEST_TIMEOUT_MS),
+      keepalive: true,
     });
 
     if (!response.ok) {
-      throw new Error(`Ollama summarize failed: ${response.status} ${response.statusText}`);
+      const errorBody = await response.text().catch(() => '');
+      throw new Error(`Ollama summarize failed: ${response.status} ${errorBody.slice(0, 500)}`);
     }
 
     const data = await response.json() as { response: string; model: string };

--- a/src/intelligence/ollama.ts
+++ b/src/intelligence/ollama.ts
@@ -11,6 +11,11 @@ interface OllamaConfig {
   summary_model?: string;
 }
 
+// Ollama API endpoints
+const ENDPOINT_GENERATE = '/api/generate';
+const ENDPOINT_EMBED = '/api/embed';
+const ENDPOINT_TAGS = '/api/tags';
+
 export class OllamaBackend implements LlmProvider, EmbeddingProvider {
   static readonly DEFAULT_BASE_URL = 'http://localhost:11434';
   readonly name = 'ollama';
@@ -57,7 +62,7 @@ export class OllamaBackend implements LlmProvider, EmbeddingProvider {
       body.keep_alive = opts.keepAlive;
     }
 
-    const response = await fetch(`${this.baseUrl}/api/generate`, {
+    const response = await fetch(`${this.baseUrl}${ENDPOINT_GENERATE}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -74,7 +79,7 @@ export class OllamaBackend implements LlmProvider, EmbeddingProvider {
   }
 
   async embed(text: string): Promise<EmbeddingResponse> {
-    const response = await fetch(`${this.baseUrl}/api/embed`, {
+    const response = await fetch(`${this.baseUrl}${ENDPOINT_EMBED}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -95,7 +100,7 @@ export class OllamaBackend implements LlmProvider, EmbeddingProvider {
 
   async isAvailable(): Promise<boolean> {
     try {
-      const response = await fetch(`${this.baseUrl}/api/tags`, {
+      const response = await fetch(`${this.baseUrl}${ENDPOINT_TAGS}`, {
         signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
       });
       return response.ok;
@@ -107,7 +112,7 @@ export class OllamaBackend implements LlmProvider, EmbeddingProvider {
   /** List available models on this Ollama instance. */
   async listModels(timeoutMs?: number): Promise<string[]> {
     try {
-      const response = await fetch(`${this.baseUrl}/api/tags`, {
+      const response = await fetch(`${this.baseUrl}${ENDPOINT_TAGS}`, {
         signal: AbortSignal.timeout(timeoutMs ?? DAEMON_CLIENT_TIMEOUT_MS),
       });
       const data = await response.json() as { models: Array<{ name: string }> };

--- a/src/intelligence/ollama.ts
+++ b/src/intelligence/ollama.ts
@@ -40,7 +40,7 @@ export class OllamaBackend implements LlmProvider, EmbeddingProvider {
         stream: false,
         options: { num_ctx: numCtx },
       }),
-      signal: AbortSignal.timeout(LLM_REQUEST_TIMEOUT_MS),
+      signal: AbortSignal.timeout(opts?.timeoutMs ?? LLM_REQUEST_TIMEOUT_MS),
     });
 
     if (!response.ok) {

--- a/src/intelligence/ollama.ts
+++ b/src/intelligence/ollama.ts
@@ -1,5 +1,5 @@
 import type { LlmProvider, EmbeddingProvider, LlmResponse, EmbeddingResponse, LlmRequestOptions } from './llm.js';
-import { CHARS_PER_TOKEN, LLM_REQUEST_TIMEOUT_MS, EMBEDDING_REQUEST_TIMEOUT_MS, DAEMON_CLIENT_TIMEOUT_MS } from '../constants.js';
+import { estimateTokens, LLM_REQUEST_TIMEOUT_MS, EMBEDDING_REQUEST_TIMEOUT_MS, DAEMON_CLIENT_TIMEOUT_MS } from '../constants.js';
 
 interface OllamaConfig {
   model?: string;
@@ -29,7 +29,7 @@ export class OllamaBackend implements LlmProvider, EmbeddingProvider {
   async summarize(prompt: string, opts?: LlmRequestOptions): Promise<LlmResponse> {
     const maxTokens = opts?.maxTokens ?? this.defaultMaxTokens;
     const contextLength = opts?.contextLength ?? this.contextWindow;
-    const promptTokens = Math.ceil(prompt.length / CHARS_PER_TOKEN);
+    const promptTokens = estimateTokens(prompt);
     const numCtx = Math.max(promptTokens + maxTokens, contextLength);
 
     const body: Record<string, unknown> = {

--- a/src/intelligence/response.ts
+++ b/src/intelligence/response.ts
@@ -17,6 +17,10 @@ const REASONING_PATTERNS = [
   /<reasoning>[\s\S]*?<\/reasoning>\s*/gi,
   // <|thinking|>...<|/thinking|>answer
   /<\|thinking\|>[\s\S]*?<\|\/thinking\|>\s*/gi,
+  // Plain-text "Thinking Process:" block followed by actual content
+  // (Qwen 3.5 via LM Studio without native thinking mode)
+  // Matches numbered thinking steps until content starts with a markdown heading
+  /^Thinking Process:[\s\S]*?(?=\n## )/i,
 ];
 
 /**

--- a/src/intelligence/response.ts
+++ b/src/intelligence/response.ts
@@ -19,8 +19,8 @@ const REASONING_PATTERNS = [
   /<\|thinking\|>[\s\S]*?<\|\/thinking\|>\s*/gi,
   // Plain-text "Thinking Process:" block followed by actual content
   // (Qwen 3.5 via LM Studio without native thinking mode)
-  // Matches numbered thinking steps until content starts with a markdown heading
-  /^Thinking Process:[\s\S]*?(?=\n## )/i,
+  // Matches from "Thinking Process:" up to the last numbered step, then the synthesis follows
+  /^Thinking Process:[\s\S]*?(?=\n(?:## |# |\*\*[A-Z]))/i,
 ];
 
 /**

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -99,7 +99,7 @@ export function createMycoServer(config: ServerConfig): MycoServer {
         return { content: [{ type: 'text', text: JSON.stringify(await handleMycoRecall(idx, input as any)) }] };
       case TOOL_REMEMBER: {
         const result = await handleMycoRemember(config.vaultDir, idx, input as any);
-        embedNote(result.id, String(input.content), { type: 'memory', observation_type: String(input.type ?? ''), importance: 'high' });
+        embedNote(result.id, String(input.content), { type: 'spore', observation_type: String(input.type ?? ''), importance: 'high' });
         logActivity(TOOL_REMEMBER, { id: result.id, observation_type: input.type, path: result.note_path });
         return { content: [{ type: 'text', text: JSON.stringify(result) }] };
       }
@@ -118,20 +118,20 @@ export function createMycoServer(config: ServerConfig): MycoServer {
       case TOOL_SUPERSEDE: {
         const result = await handleMycoSupersede(config.vaultDir, idx, input as any);
         if (result.status === 'superseded' && config.vectorIndex) {
-          config.vectorIndex.delete(result.old_memory);
+          config.vectorIndex.delete(result.old_spore);
         }
-        logActivity(TOOL_SUPERSEDE, { old: result.old_memory, new: result.new_memory, status: result.status });
+        logActivity(TOOL_SUPERSEDE, { old: result.old_spore, new: result.new_spore, status: result.status });
         return { content: [{ type: 'text', text: JSON.stringify(result) }] };
       }
       case TOOL_CONSOLIDATE: {
         const result = await handleMycoConsolidate(config.vaultDir, idx, input as any);
-        embedNote(result.wisdom_id, String(input.consolidated_content), { type: 'memory', observation_type: String(input.observation_type ?? ''), importance: 'high' });
-        if (config.vectorIndex && Array.isArray(input.source_memory_ids)) {
-          for (const id of input.source_memory_ids as string[]) {
+        embedNote(result.wisdom_id, String(input.consolidated_content), { type: 'spore', observation_type: String(input.observation_type ?? ''), importance: 'high' });
+        if (config.vectorIndex && Array.isArray(input.source_spore_ids)) {
+          for (const id of input.source_spore_ids as string[]) {
             config.vectorIndex.delete(id);
           }
         }
-        logActivity(TOOL_CONSOLIDATE, { wisdom_id: result.wisdom_id, sources: input.source_memory_ids, archived: result.sources_archived });
+        logActivity(TOOL_CONSOLIDATE, { wisdom_id: result.wisdom_id, sources: input.source_spore_ids, archived: result.sources_archived });
         return { content: [{ type: 'text', text: JSON.stringify(result) }] };
       }
       default:

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -19,6 +19,7 @@ import { handleMycoGraph, handleMycoOrphans } from './tools/graph.js';
 import { handleMycoLogs } from './tools/logs.js';
 import { handleMycoSupersede } from './tools/supersede.js';
 import { handleMycoConsolidate } from './tools/consolidate.js';
+import { handleMycoContext } from './tools/context.js';
 import { resolveVaultDir } from '../vault/resolve.js';
 import { loadConfig } from '../config/loader.js';
 import { createEmbeddingProvider } from '../intelligence/llm.js';
@@ -40,6 +41,7 @@ import {
   TOOL_DEFINITIONS,
   TOOL_SEARCH, TOOL_RECALL, TOOL_REMEMBER, TOOL_PLANS, TOOL_SESSIONS,
   TOOL_TEAM, TOOL_GRAPH, TOOL_ORPHANS, TOOL_LOGS, TOOL_SUPERSEDE, TOOL_CONSOLIDATE,
+  TOOL_CONTEXT,
 } from './tool-definitions.js';
 
 export interface MycoServer {
@@ -133,6 +135,10 @@ export function createMycoServer(config: ServerConfig): MycoServer {
         }
         logActivity(TOOL_CONSOLIDATE, { wisdom_id: result.wisdom_id, sources: input.source_spore_ids, archived: result.sources_archived });
         return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+      }
+      case TOOL_CONTEXT: {
+        const result = handleMycoContext(config.vaultDir, args as { tier?: number });
+        return { content: [{ type: 'text', text: result.content }] };
       }
       default:
         throw new Error(`Unknown tool: ${name}`);

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -36,7 +36,7 @@ export const TOOL_DEFINITIONS = [
       type: 'object' as const,
       properties: {
         query: { type: 'string', description: 'Natural language search query — describe what you are looking for' },
-        type: { type: 'string', enum: ['session', 'plan', 'memory', 'all'], description: 'Filter by note type (default: all)' },
+        type: { type: 'string', enum: ['session', 'plan', 'spore', 'all'], description: 'Filter by note type (default: all)' },
         limit: { type: 'number', description: `Max results (default: ${MCP_SEARCH_DEFAULT_LIMIT})` },
       },
       required: ['query'],
@@ -44,7 +44,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: TOOL_RECALL,
-    description: 'Get context relevant to your current work — memories, sessions, and plans related to the branch and files you are working on. Use at the start of a task or when you need background on a component.',
+    description: 'Get context relevant to your current work — spores, sessions, and plans related to the branch and files you are working on. Use at the start of a task or when you need background on a component.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -55,7 +55,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: TOOL_REMEMBER,
-    description: 'Save a decision, gotcha, bug fix, discovery, or trade-off as a permanent memory. Use after making a key decision, fixing a tricky bug, discovering something non-obvious, or encountering a gotcha.',
+    description: 'Save a decision, gotcha, bug fix, discovery, or trade-off as a permanent spore. Use after making a key decision, fixing a tricky bug, discovering something non-obvious, or encountering a gotcha.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -81,7 +81,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: TOOL_SESSIONS,
-    description: 'Browse past coding sessions with summaries, tools used, and linked memories. Use to understand what work has been done on a feature or branch.',
+    description: 'Browse past coding sessions with summaries, tools used, and linked spores. Use to understand what work has been done on a feature or branch.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -107,7 +107,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: TOOL_GRAPH,
-    description: 'Traverse connections between vault notes via wikilinks — explore how sessions, memories, and plans relate to each other.',
+    description: 'Traverse connections between vault notes via wikilinks — explore how sessions, spores, and plans relate to each other.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -142,29 +142,29 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: TOOL_SUPERSEDE,
-    description: 'Mark a memory as outdated and replaced by a newer one. Use when a decision was reversed, a gotcha was fixed, a discovery was wrong, or the codebase changed and an observation no longer applies. The old memory is preserved but marked superseded.',
+    description: 'Mark a spore as outdated and replaced by a newer one. Use when a decision was reversed, a gotcha was fixed, a discovery was wrong, or the codebase changed and an observation no longer applies. The old spore is preserved but marked superseded.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        old_memory_id: { type: 'string', description: 'ID of the outdated memory (e.g., "decision-abc123")' },
-        new_memory_id: { type: 'string', description: 'ID of the replacement memory' },
-        reason: { type: 'string', description: 'Why the old memory is being superseded' },
+        old_spore_id: { type: 'string', description: 'ID of the outdated spore (e.g., "decision-abc123")' },
+        new_spore_id: { type: 'string', description: 'ID of the replacement spore' },
+        reason: { type: 'string', description: 'Why the old spore is being superseded' },
       },
-      required: ['old_memory_id', 'new_memory_id'],
+      required: ['old_spore_id', 'new_spore_id'],
     },
   },
   {
     name: TOOL_CONSOLIDATE,
-    description: 'Merge 3+ related memories into a single comprehensive wisdom note. Use when multiple observations describe aspects of the same insight, share a root cause, or would be more useful as one reference. Source memories are marked superseded.',
+    description: 'Merge 3+ related spores into a single comprehensive wisdom note. Use when multiple observations describe aspects of the same insight, share a root cause, or would be more useful as one reference. Source spores are marked superseded.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        source_memory_ids: { type: 'array', items: { type: 'string' }, description: 'IDs of the memories to merge (minimum 2)' },
+        source_spore_ids: { type: 'array', items: { type: 'string' }, description: 'IDs of the spores to merge (minimum 2)' },
         consolidated_content: { type: 'string', description: 'The merged, comprehensive content — synthesize, do not just concatenate' },
         observation_type: { type: 'string', enum: OBSERVATION_TYPES, description: `Type for the consolidated wisdom note: ${OBSERVATION_TYPES.join(', ')}` },
         tags: { type: 'array', items: { type: 'string' }, description: PROP_TAGS },
       },
-      required: ['source_memory_ids', 'consolidated_content', 'observation_type'],
+      required: ['source_spore_ids', 'consolidated_content', 'observation_type'],
     },
   },
 ];

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -50,7 +50,7 @@ export const TOOL_DEFINITIONS = [
       type: 'object' as const,
       properties: {
         branch: { type: 'string', description: PROP_BRANCH },
-        files: { type: 'array', items: { type: 'string' }, description: 'File paths you are working on — finds memories tagged with these files' },
+        files: { type: 'array', items: { type: 'string' }, description: 'File paths you are working on — finds spores tagged with these files' },
       },
     },
   },

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -21,6 +21,7 @@ export const TOOL_ORPHANS = 'myco_orphans';
 export const TOOL_LOGS = 'myco_logs';
 export const TOOL_SUPERSEDE = 'myco_supersede';
 export const TOOL_CONSOLIDATE = 'myco_consolidate';
+export const TOOL_CONTEXT = 'myco_context';
 
 // --- Shared property descriptions (used by multiple tools) ---
 const PROP_BRANCH = 'Git branch name to find related sessions and plans';
@@ -165,6 +166,20 @@ export const TOOL_DEFINITIONS = [
         tags: { type: 'array', items: { type: 'string' }, description: PROP_TAGS },
       },
       required: ['source_spore_ids', 'consolidated_content', 'observation_type'],
+    },
+  },
+  {
+    name: TOOL_CONTEXT,
+    description: "Retrieve Myco's synthesized understanding of this project. Returns a pre-computed context extract at the requested token tier. Available tiers: 1500 (executive briefing), 3000 (team standup), 5000 (deep onboarding), 10000 (institutional knowledge). This is a rich, always-current synthesis of project history, decisions, patterns, and active work — not a search result.",
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        tier: {
+          type: 'number',
+          enum: [1500, 3000, 5000, 10000],
+          description: 'Token budget tier. Larger tiers include more detail. Default: 3000.',
+        },
+      },
     },
   },
 ];

--- a/src/mcp/tools/consolidate.ts
+++ b/src/mcp/tools/consolidate.ts
@@ -6,7 +6,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 interface ConsolidateInput {
-  source_memory_ids: string[];
+  source_spore_ids: string[];
   consolidated_content: string;
   observation_type: string;
   tags?: string[];
@@ -27,11 +27,11 @@ export async function handleMycoConsolidate(
   const wisdomId = `${input.observation_type}-wisdom-${randomBytes(4).toString('hex')}`;
 
   // Build the wisdom note content with source links for Obsidian graph
-  const sourceLinks = input.source_memory_ids.map((id) => `- [[${id}]]`).join('\n');
+  const sourceLinks = input.source_spore_ids.map((id) => `- [[${id}]]`).join('\n');
   const fullContent = `${input.consolidated_content}\n\n## Sources\n\nConsolidated from:\n${sourceLinks}`;
 
   // Create the consolidated wisdom note
-  const wisdomPath = writer.writeMemory({
+  const wisdomPath = writer.writeSpore({
     id: wisdomId,
     observation_type: input.observation_type,
     tags: [...(input.tags ?? []), 'wisdom', 'consolidated'],
@@ -40,12 +40,12 @@ export async function handleMycoConsolidate(
 
   // Add consolidated_from to the new note's frontmatter
   writer.updateNoteFrontmatter(wisdomPath, {
-    consolidated_from: input.source_memory_ids,
+    consolidated_from: input.source_spore_ids,
   }, true);
 
-  // Mark each source memory as superseded by the wisdom note
+  // Mark each source spore as superseded by the wisdom note
   let archived = 0;
-  for (const sourceId of input.source_memory_ids) {
+  for (const sourceId of input.source_spore_ids) {
     const notes = index.queryByIds([sourceId]);
     if (notes.length > 0) {
       const notePath = notes[0].path;

--- a/src/mcp/tools/context.ts
+++ b/src/mcp/tools/context.ts
@@ -3,11 +3,14 @@ import path from 'node:path';
 import YAML from 'yaml';
 import { DIGEST_TIERS } from '../../constants.js';
 
+/** Default tier when none is requested. */
+const DEFAULT_CONTEXT_TIER = 3000;
+
 interface ContextInput {
   tier?: number;
 }
 
-interface ContextResult {
+export interface ContextResult {
   content: string;
   tier: number;
   fallback: boolean;
@@ -15,10 +18,16 @@ interface ContextResult {
 }
 
 /**
- * Read a digest extract file, strip YAML frontmatter, and extract metadata.
+ * Try to read a digest extract file. Returns null if the file doesn't exist.
+ * Strips YAML frontmatter and extracts the generated timestamp.
  */
-function readExtract(filePath: string, tier: number, fallback: boolean): ContextResult {
-  const raw = fs.readFileSync(filePath, 'utf-8');
+function tryReadExtract(filePath: string, tier: number, fallback: boolean): ContextResult | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
 
   let generated: string | undefined;
   let body = raw;
@@ -41,23 +50,20 @@ function readExtract(filePath: string, tier: number, fallback: boolean): Context
 }
 
 export function handleMycoContext(vaultDir: string, input: ContextInput): ContextResult {
-  const requestedTier = input.tier ?? 3000;
+  const requestedTier = input.tier ?? DEFAULT_CONTEXT_TIER;
   const digestDir = path.join(vaultDir, 'digest');
 
   // Try exact tier first
-  const exactPath = path.join(digestDir, `extract-${requestedTier}.md`);
-  if (fs.existsSync(exactPath)) {
-    return readExtract(exactPath, requestedTier, false);
-  }
+  const exact = tryReadExtract(path.join(digestDir, `extract-${requestedTier}.md`), requestedTier, false);
+  if (exact) return exact;
 
   // Fall back to nearest available tier
-  const available = DIGEST_TIERS
-    .filter((t) => fs.existsSync(path.join(digestDir, `extract-${t}.md`)))
+  const candidates = [...DIGEST_TIERS]
     .sort((a, b) => Math.abs(a - requestedTier) - Math.abs(b - requestedTier));
 
-  if (available.length > 0) {
-    const fallbackTier = available[0];
-    return readExtract(path.join(digestDir, `extract-${fallbackTier}.md`), fallbackTier, true);
+  for (const tier of candidates) {
+    const result = tryReadExtract(path.join(digestDir, `extract-${tier}.md`), tier, true);
+    if (result) return result;
   }
 
   return {

--- a/src/mcp/tools/context.ts
+++ b/src/mcp/tools/context.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import YAML from 'yaml';
+import { DIGEST_TIERS } from '../../constants.js';
+
+interface ContextInput {
+  tier?: number;
+}
+
+interface ContextResult {
+  content: string;
+  tier: number;
+  fallback: boolean;
+  generated?: string;
+}
+
+/**
+ * Read a digest extract file, strip YAML frontmatter, and extract metadata.
+ */
+function readExtract(filePath: string, tier: number, fallback: boolean): ContextResult {
+  const raw = fs.readFileSync(filePath, 'utf-8');
+
+  let generated: string | undefined;
+  let body = raw;
+
+  const fmMatch = raw.match(/^---\n([\s\S]*?)\n---\n*/);
+  if (fmMatch) {
+    try {
+      const parsed = YAML.parse(fmMatch[1]) as Record<string, unknown>;
+      generated = parsed.generated as string | undefined;
+    } catch { /* ignore malformed frontmatter */ }
+    body = raw.slice(fmMatch[0].length).trim();
+  }
+
+  return {
+    content: body,
+    tier,
+    fallback,
+    generated,
+  };
+}
+
+export function handleMycoContext(vaultDir: string, input: ContextInput): ContextResult {
+  const requestedTier = input.tier ?? 3000;
+  const digestDir = path.join(vaultDir, 'digest');
+
+  // Try exact tier first
+  const exactPath = path.join(digestDir, `extract-${requestedTier}.md`);
+  if (fs.existsSync(exactPath)) {
+    return readExtract(exactPath, requestedTier, false);
+  }
+
+  // Fall back to nearest available tier
+  const available = DIGEST_TIERS
+    .filter((t) => fs.existsSync(path.join(digestDir, `extract-${t}.md`)))
+    .sort((a, b) => Math.abs(a - requestedTier) - Math.abs(b - requestedTier));
+
+  if (available.length > 0) {
+    const fallbackTier = available[0];
+    return readExtract(path.join(digestDir, `extract-${fallbackTier}.md`), fallbackTier, true);
+  }
+
+  return {
+    content: 'Digest context is not yet available. The first digest cycle has not completed.',
+    tier: requestedTier,
+    fallback: false,
+  };
+}

--- a/src/mcp/tools/context.ts
+++ b/src/mcp/tools/context.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import YAML from 'yaml';
+import { stripFrontmatter } from '../../vault/frontmatter.js';
 import { DIGEST_TIERS } from '../../constants.js';
 
 /** Default tier when none is requested. */
@@ -29,17 +29,8 @@ function tryReadExtract(filePath: string, tier: number, fallback: boolean): Cont
     return null;
   }
 
-  let generated: string | undefined;
-  let body = raw;
-
-  const fmMatch = raw.match(/^---\n([\s\S]*?)\n---\n*/);
-  if (fmMatch) {
-    try {
-      const parsed = YAML.parse(fmMatch[1]) as Record<string, unknown>;
-      generated = parsed.generated as string | undefined;
-    } catch { /* ignore malformed frontmatter */ }
-    body = raw.slice(fmMatch[0].length).trim();
-  }
+  const { body, frontmatter } = stripFrontmatter(raw);
+  const generated = frontmatter.generated as string | undefined;
 
   return {
     content: body,

--- a/src/mcp/tools/recall.ts
+++ b/src/mcp/tools/recall.ts
@@ -1,5 +1,5 @@
 import type { MycoIndex } from '../../index/sqlite.js';
-import { planFm, sessionFm, memoryFm } from '../../vault/frontmatter.js';
+import { planFm, sessionFm, sporeFm } from '../../vault/frontmatter.js';
 import { RECALL_SUMMARY_PREVIEW_CHARS } from '../../constants.js';
 
 interface RecallInput {
@@ -10,7 +10,7 @@ interface RecallInput {
 interface RecallResult {
   active_plans: Array<{ id: string; title: string; status: string }>;
   recent_sessions: Array<{ id: string; title: string; summary: string }>;
-  relevant_memories: Array<{ id: string; title: string; type: string }>;
+  relevant_spores: Array<{ id: string; title: string; type: string }>;
   team_activity: Array<{ user: string; session_id: string; summary: string }>;
 }
 
@@ -29,8 +29,8 @@ export async function handleMycoRecall(
     sessions = sessions.filter((s) => sessionFm(s).branch === input.branch);
   }
 
-  const memories = index.query({ type: 'memory', limit: 5 })
-    .filter((m) => memoryFm(m).status !== 'superseded' && memoryFm(m).status !== 'archived');
+  const spores = index.query({ type: 'spore', limit: 5 })
+    .filter((m) => sporeFm(m).status !== 'superseded' && sporeFm(m).status !== 'archived');
 
   return {
     active_plans: activePlans.map((p) => ({
@@ -43,10 +43,10 @@ export async function handleMycoRecall(
       title: s.title,
       summary: s.content.slice(0, RECALL_SUMMARY_PREVIEW_CHARS),
     })),
-    relevant_memories: memories.map((m) => ({
+    relevant_spores: spores.map((m) => ({
       id: m.id,
       title: m.title,
-      type: memoryFm(m).observation_type ?? 'discovery',
+      type: sporeFm(m).observation_type ?? 'discovery',
     })),
     team_activity: [],
   };

--- a/src/mcp/tools/remember.ts
+++ b/src/mcp/tools/remember.ts
@@ -29,7 +29,7 @@ export async function handleMycoRemember(
   const id = `${input.type}-${randomBytes(4).toString('hex')}`;
   const session = input.session ?? resolveSessionFromBuffer(path.join(vaultDir, 'buffer'));
 
-  const notePath = writer.writeMemory({
+  const notePath = writer.writeSpore({
     id,
     observation_type: input.type,
     session,
@@ -38,7 +38,7 @@ export async function handleMycoRemember(
     content: input.content,
   });
 
-  // Update index so the new memory is immediately searchable
+  // Update index so the new spore is immediately searchable
   indexNote(index, vaultDir, notePath);
 
   return { note_path: notePath, id, session };

--- a/src/mcp/tools/search.ts
+++ b/src/mcp/tools/search.ts
@@ -7,7 +7,7 @@ import { CONTENT_SNIPPET_CHARS } from '../../constants.js';
 
 interface SearchInput {
   query: string;
-  type?: 'session' | 'plan' | 'memory' | 'all';
+  type?: 'session' | 'plan' | 'spore' | 'all';
   limit?: number;
 }
 

--- a/src/mcp/tools/supersede.ts
+++ b/src/mcp/tools/supersede.ts
@@ -5,14 +5,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 interface SupersedeInput {
-  old_memory_id: string;
-  new_memory_id: string;
+  old_spore_id: string;
+  new_spore_id: string;
   reason?: string;
 }
 
 interface SupersedeResult {
-  old_memory: string;
-  new_memory: string;
+  old_spore: string;
+  new_spore: string;
   status: 'superseded' | 'not_found';
 }
 
@@ -23,25 +23,25 @@ export async function handleMycoSupersede(
 ): Promise<SupersedeResult> {
   const writer = new VaultWriter(vaultDir);
 
-  // Find the old memory note in the index
-  const oldNotes = index.queryByIds([input.old_memory_id]);
+  // Find the old spore note in the index
+  const oldNotes = index.queryByIds([input.old_spore_id]);
   if (oldNotes.length === 0) {
-    return { old_memory: input.old_memory_id, new_memory: input.new_memory_id, status: 'not_found' };
+    return { old_spore: input.old_spore_id, new_spore: input.new_spore_id, status: 'not_found' };
   }
 
   const oldNote = oldNotes[0];
 
-  // Mark the old memory as superseded in frontmatter
+  // Mark the old spore as superseded in frontmatter
   writer.updateNoteFrontmatter(oldNote.path, {
     status: 'superseded',
-    superseded_by: input.new_memory_id,
+    superseded_by: input.new_spore_id,
   }, true);
 
   // Append a supersession notice to the body with wikilink for Obsidian graph
   const fullPath = path.join(vaultDir, oldNote.path);
   const content = fs.readFileSync(fullPath, 'utf-8');
   if (!content.includes('Superseded by::')) {
-    const notice = `\n\n> [!warning] Superseded\n> This observation has been superseded.\n\nSuperseded by:: [[${input.new_memory_id}]]`;
+    const notice = `\n\n> [!warning] Superseded\n> This observation has been superseded.\n\nSuperseded by:: [[${input.new_spore_id}]]`;
     const reasonLine = input.reason ? `\nReason:: ${input.reason}` : '';
     fs.writeFileSync(fullPath, content.trimEnd() + notice + reasonLine + '\n', 'utf-8');
   }
@@ -49,5 +49,5 @@ export async function handleMycoSupersede(
   // Re-index the updated note
   indexNote(index, vaultDir, oldNote.path);
 
-  return { old_memory: input.old_memory_id, new_memory: input.new_memory_id, status: 'superseded' };
+  return { old_spore: input.old_spore_id, new_spore: input.new_spore_id, status: 'superseded' };
 }

--- a/src/obsidian/formatter.ts
+++ b/src/obsidian/formatter.ts
@@ -120,10 +120,10 @@ export function formatSessionBody(input: SessionBodyInput): string {
   if (input.branch) fields.push(inlineField('Branch', `\`${input.branch}\``));
   sections.push(fields.join('\n'));
 
-  // Related memories
+  // Related spores
   if (input.relatedMemories?.length) {
     const links = input.relatedMemories.map((m) => `- ${wikilink(m.id, m.title)}`);
-    sections.push(`## Related Memories\n${links.join('\n')}`);
+    sections.push(`## Related Spores\n${links.join('\n')}`);
   }
 
   // Conversation turns — always rebuilt from the full transcript.
@@ -163,9 +163,9 @@ export function formatSessionBody(input: SessionBodyInput): string {
   return sections.join('\n\n');
 }
 
-// --- Memory formatting ---
+// --- Spore formatting ---
 
-export interface MemoryBodyInput {
+export interface SporeBodyInput {
   title: string;
   observationType: string;
   content: string;
@@ -179,7 +179,7 @@ export interface MemoryBodyInput {
   tags?: string[];
 }
 
-export function formatMemoryBody(input: MemoryBodyInput): string {
+export function formatSporeBody(input: SporeBodyInput): string {
   const sections: string[] = [];
   const calloutType = observationCalloutType(input.observationType);
   const calloutTitle = capitalize(tagNormalize(input.observationType));
@@ -204,7 +204,7 @@ export function formatMemoryBody(input: MemoryBodyInput): string {
   if (input.sacrificed) sections.push(`## Sacrificed\n${input.sacrificed}`);
 
   // Footer tags
-  const allTags = buildTags('memory', input.observationType, input.tags ?? []);
+  const allTags = buildTags('spore', input.observationType, input.tags ?? []);
   sections.push(footerTags(allTags));
 
   return sections.join('\n\n');

--- a/src/prompts/classification.md
+++ b/src/prompts/classification.md
@@ -1,4 +1,5 @@
 You are classifying files from coding session "{{sessionId}}" to determine which are substantive **project** artifacts worth preserving in a knowledge vault.
+You have a budget of ~{{maxTokens}} tokens for your response.
 
 ## Candidate Files
 

--- a/src/prompts/digest-10000.md
+++ b/src/prompts/digest-10000.md
@@ -1,9 +1,74 @@
-Budget: ~10,000 tokens.
-The full picture. Include everything from the onboarding tier, plus:
-- Complete thread histories for active and recently completed work
-- Detailed trade-off analysis and alternatives that were rejected
-- Plan evolution — what changed and why
-- Artifact summaries and their significance
-- Lessons learned from past incidents
+Budget: ~10,000 tokens. Use the FULL budget — this is the institutional knowledge tier.
 
-An agent reading this should have the equivalent of months of project context.
+This is the complete project context — an agent reading this should have the equivalent of MONTHS of project history and team knowledge. It should be able to make architectural decisions, understand why any part of the system exists, trace the evolution of features, and anticipate risks that aren't obvious from the current code.
+
+This tier exists for complex work: major refactors, architectural reviews, onboarding new team members, or debugging systemic issues where understanding history matters.
+
+## Required Sections
+
+### Project Identity & Vision (~500 tokens)
+What is this project? What problem does it solve? Who uses it and how? What's the long-term vision? What makes it unique? Ground the agent in purpose so it can evaluate whether proposed changes serve the project's goals.
+
+### Architecture Deep Dive (~1,000 tokens)
+How the system fits together — subsystems, data flows, integration points, deployment model. Include the conceptual architecture (not just file paths) and explain WHY it's structured this way. What are the boundaries? What are the invariants? Where does complexity live and why?
+
+### Active Work & Recent History (~1,200 tokens)
+Detailed narrative of the last 5-10 sessions. What was built, what problems were solved, what changed and why. Include the story arc — how did the project get from where it was to where it is now? This gives the agent a sense of trajectory, not just current state.
+
+For each major piece of recent work: what triggered it, what was the approach, what was the outcome, and what's still pending.
+
+### Decision Archive (~1,500 tokens)
+A comprehensive log of the decisions that shaped the project. Each decision should include:
+- What was decided
+- What alternatives were considered and rejected
+- The rationale — why THIS choice over the alternatives
+- Whether the decision is still active or has been superseded
+
+Recent decisions (last 2-4 weeks) get full treatment. Older decisions that are still load-bearing get compressed but preserved. Superseded decisions are mentioned briefly with what replaced them.
+
+This section should grow and compress over time — early decisions get shorter as they become settled, but never disappear entirely if they still affect how the system works.
+
+### Accumulated Wisdom & Patterns (~1,200 tokens)
+Everything the team has learned that isn't obvious from reading the code. Organize by domain:
+
+- **Architecture & Design**: Patterns that emerged, abstractions that work, boundaries that matter
+- **Operational**: Deployment gotchas, configuration pitfalls, monitoring insights
+- **Development**: Testing strategies that work, debugging approaches, tooling quirks
+- **Agent Behavior**: How AI agents interact with this codebase — what they get wrong, what helps them succeed
+
+Each item should be specific and actionable, not generic advice. "SQLite WAL mode requires shared memory" is useful; "be careful with databases" is not.
+
+### Trade-offs & Design Tensions (~800 tokens)
+The active tensions in the system where there isn't a clean answer. For each:
+- What's the tension (e.g., "local inference quality vs. speed")
+- What's the current balance point
+- What would shift it (e.g., "if we move to cloud inference, we'd revisit X")
+
+These help the agent make judgment calls that align with the team's values and constraints. They also signal where the system is most likely to need rethinking as conditions change.
+
+### Team Knowledge (~600 tokens)
+Who has been working on what? What are their areas of expertise? What's the collaboration model? How does code get reviewed and merged? What are the testing expectations?
+
+Include working patterns that affect how the agent should behave — e.g., "Chris prefers bundled PRs for refactors" or "the team uses subagent-driven development for plan execution."
+
+### Thread History (~1,200 tokens)
+The evolution of major features and initiatives. Not just "what shipped" but "how it evolved" — what was the original idea, how did it change during implementation, what surprised the team, what would they do differently?
+
+This is the institutional memory that prevents the team from repeating mistakes or losing context on why something that looks simple was actually hard.
+
+When the vault is small, this section covers all threads in detail. As the vault grows, older threads compress into lessons learned and only active/recent threads get full treatment.
+
+### Risks & Open Questions (~500 tokens)
+What could go wrong? What's unresolved? What assumptions might break? What technical debt is accumulating? These help the agent be appropriately cautious and flag risks early.
+
+### Glossary & Reference (~500 tokens)
+Project-specific terminology, acronyms, and concepts. Include terms that have specific meanings in this project that differ from general usage. Also include key file paths and components that are frequently referenced.
+
+## Priority Rules
+- USE THE FULL 10,000 TOKENS — this tier should be DENSE with useful information
+- This is the one tier where historical depth matters — don't compress away the story
+- Recent activity (last 5-10 sessions) gets narrative detail with context
+- Older activity becomes patterns, lessons, and compressed summaries — but key moments are preserved
+- Trade-offs, wisdom, and thread history should be the RICHEST sections — they grow over time
+- When the vault is small and you can't fill 10K: go DEEP on what exists — explain reasoning, include examples, explore implications, document the "why" behind every decision thoroughly
+- When the vault is large and 10K feels tight: ruthlessly prioritize by relevance to current work, but preserve foundational decisions and hard-won lessons even if they're old

--- a/src/prompts/digest-10000.md
+++ b/src/prompts/digest-10000.md
@@ -1,0 +1,9 @@
+Budget: ~10,000 tokens.
+The full picture. Include everything from the onboarding tier, plus:
+- Complete thread histories for active and recently completed work
+- Detailed trade-off analysis and alternatives that were rejected
+- Plan evolution — what changed and why
+- Artifact summaries and their significance
+- Lessons learned from past incidents
+
+An agent reading this should have the equivalent of months of project context.

--- a/src/prompts/digest-1500.md
+++ b/src/prompts/digest-1500.md
@@ -1,9 +1,25 @@
-Budget: ~1,500 tokens. This is the smallest representation.
-Prioritize ruthlessly:
-- What is this project? (1-2 sentences)
-- What is actively being worked on right now?
-- What are the critical gotchas or blockers?
-- Who is working on it? (if known)
+Budget: ~1,500 tokens. Use the full budget.
 
-Drop: historical decisions, completed work, trade-off reasoning, conventions.
-An agent reading this should immediately know what it's walking into.
+This is the executive briefing — an agent reading this should immediately know what project it's in, what's happening right now, and what not to step on.
+
+## Required Sections
+
+### Project Identity (~200 tokens)
+What is this project? What does it do? What's the tech stack? 2-3 sentences that orient a newcomer.
+
+### Current Focus (~400 tokens)
+What is actively being worked on RIGHT NOW? What branches are active? What's the immediate goal? Be specific — name the features, not just "ongoing development."
+
+### Critical Warnings (~400 tokens)
+What will bite the agent if it doesn't know? Active gotchas, known bugs, things that look like they should work but don't. These are the "stop and read before you touch anything" items.
+
+### Who & How (~200 tokens)
+Who is working on this? What's their focus? Any active collaboration patterns the agent should know about?
+
+### Recent Momentum (~300 tokens)
+What just shipped or changed in the last few sessions? This gives the agent a sense of velocity and direction.
+
+## Priority Rules
+- When the vault is small: fill every section generously with available detail
+- When the vault is large: compress historical context, emphasize last 3-5 sessions
+- NEVER leave sections empty — if there's no data for a section, say so explicitly ("No active blockers")

--- a/src/prompts/digest-1500.md
+++ b/src/prompts/digest-1500.md
@@ -1,0 +1,9 @@
+Budget: ~1,500 tokens. This is the smallest representation.
+Prioritize ruthlessly:
+- What is this project? (1-2 sentences)
+- What is actively being worked on right now?
+- What are the critical gotchas or blockers?
+- Who is working on it? (if known)
+
+Drop: historical decisions, completed work, trade-off reasoning, conventions.
+An agent reading this should immediately know what it's walking into.

--- a/src/prompts/digest-3000.md
+++ b/src/prompts/digest-3000.md
@@ -1,0 +1,9 @@
+Budget: ~3,000 tokens.
+Include everything from the briefing tier, plus:
+- Recent activity narrative (what happened in the last few sessions)
+- Key decisions made and why
+- Active plans and their status
+- Important conventions or patterns the agent should follow
+
+Drop: deep trade-off reasoning, exhaustive history, edge case wisdom.
+An agent reading this should be able to start contributing meaningfully.

--- a/src/prompts/digest-3000.md
+++ b/src/prompts/digest-3000.md
@@ -1,9 +1,32 @@
-Budget: ~3,000 tokens.
-Include everything from the briefing tier, plus:
-- Recent activity narrative (what happened in the last few sessions)
-- Key decisions made and why
-- Active plans and their status
-- Important conventions or patterns the agent should follow
+Budget: ~3,000 tokens. Use the full budget.
 
-Drop: deep trade-off reasoning, exhaustive history, edge case wisdom.
-An agent reading this should be able to start contributing meaningfully.
+This is the team standup — an agent reading this should be able to start contributing meaningfully within minutes. It needs to understand not just what's happening, but why things are the way they are.
+
+## Required Sections
+
+### Project Identity & Architecture (~400 tokens)
+What is this project? What are the major components and how do they fit together? What's the tech stack? Don't describe code structure — describe the system's purpose and shape.
+
+### Current Sprint (~600 tokens)
+What's actively being worked on? What branches are in flight? What's the immediate priority? Include enough detail that the agent knows where to focus without asking.
+
+### Recent Activity (~500 tokens)
+Narrative of what happened in the last few sessions. What was accomplished? What problems were solved? What changed? This gives the agent momentum context.
+
+### Key Decisions & Rationale (~500 tokens)
+The most important decisions that are currently shaping the project. WHY things are done a certain way, not just what was decided. Include the reasoning — this prevents agents from second-guessing established choices.
+
+### Active Gotchas & Conventions (~500 tokens)
+Patterns to follow, pitfalls to avoid, things that aren't obvious from reading the code. Include both "do this" and "don't do that" guidance.
+
+### Team & Workflow (~300 tokens)
+Who's working on what? What's the collaboration model? Any active plans or milestones?
+
+### Open Questions (~200 tokens)
+Things that are unresolved, under discussion, or need attention. Helps the agent know where to be careful.
+
+## Priority Rules
+- When the vault is small: go deep on decisions and reasoning — explain the "why" thoroughly
+- When the vault is large: compress older decisions into brief mentions, expand recent activity
+- Decisions that are still actively shaping work get full treatment; settled decisions get one-liners
+- Recent sessions (last 3-5) get narrative detail; older sessions become trend summaries

--- a/src/prompts/digest-5000.md
+++ b/src/prompts/digest-5000.md
@@ -1,0 +1,9 @@
+Budget: ~5,000 tokens.
+Include everything from the standup tier, plus:
+- Accumulated wisdom: recurring gotchas, established patterns
+- Trade-off reasoning behind key architectural decisions
+- Cross-cutting concerns that affect multiple areas
+- Team member specialties and working patterns
+
+Drop: exhaustive historical detail, completed-and-closed threads.
+An agent reading this should understand not just what to do, but why things are the way they are.

--- a/src/prompts/digest-5000.md
+++ b/src/prompts/digest-5000.md
@@ -1,9 +1,43 @@
-Budget: ~5,000 tokens.
-Include everything from the standup tier, plus:
-- Accumulated wisdom: recurring gotchas, established patterns
-- Trade-off reasoning behind key architectural decisions
-- Cross-cutting concerns that affect multiple areas
-- Team member specialties and working patterns
+Budget: ~5,000 tokens. Use the FULL budget — this is a rich context tier.
 
-Drop: exhaustive historical detail, completed-and-closed threads.
-An agent reading this should understand not just what to do, but why things are the way they are.
+This is deep onboarding — an agent reading this should understand the project as well as a team member who's been on the project for weeks. It needs to know not just what and why, but the patterns, trade-offs, accumulated wisdom, and team dynamics that shape daily work.
+
+## Required Sections
+
+### Project Identity & Purpose (~400 tokens)
+What is this project? What problem does it solve? Who uses it? What's the vision? Ground the agent in the project's reason for existing.
+
+### Architecture & Key Components (~600 tokens)
+How the system fits together at a high level. Major subsystems, data flow, integration points. Focus on the concepts and boundaries, not file paths — the agent can read code for implementation details.
+
+### Current State & Active Work (~700 tokens)
+What's in progress right now? What branches are active? What's the immediate priority? What shipped recently? Give enough detail that the agent could pick up a task without asking for orientation.
+
+### Decision Log (~800 tokens)
+The important decisions that shaped the project and are still relevant. For each: what was decided, what alternatives were considered, and WHY this path was chosen. These prevent agents from relitigating settled questions or unknowingly violating established direction.
+
+When the vault is large, compress older decisions but preserve their conclusions. Recent decisions get full treatment with rationale and alternatives rejected.
+
+### Accumulated Wisdom (~700 tokens)
+Cross-cutting lessons the team has learned. Recurring gotchas, established patterns, things that aren't obvious from the code. These are the "we learned this the hard way" items that save time.
+
+Organize by theme (e.g., "Configuration & Settings", "Testing Patterns", "Agent Behavior") rather than chronologically.
+
+### Trade-offs & Tensions (~500 tokens)
+Active tensions in the system — things where there isn't a clean answer and the agent needs to understand the balance. Performance vs. quality, simplicity vs. flexibility, local vs. remote, etc. These help the agent make judgment calls that align with the team's values.
+
+### Team Dynamics & Workflow (~400 tokens)
+Who is working on what, and how? Communication patterns, review processes, branch strategies, testing expectations. How does work get done here?
+
+### Open Threads & Risks (~400 tokens)
+Unfinished work, known risks, things that need attention soon. Helps the agent understand where the edges are and what to be careful about.
+
+### Glossary (~500 tokens)
+Project-specific terminology that an agent needs to know. Include terms that have specific meanings in this codebase that differ from general usage.
+
+## Priority Rules
+- USE THE FULL 5,000 TOKENS — sparse output at this tier is a failure
+- When the vault is small: go deep on every section, explain reasoning thoroughly, include examples
+- When the vault is large: recent activity (last 5-10 sessions) gets detailed treatment; older context compresses into patterns and conclusions
+- Trade-offs and wisdom should GROW over time as the team learns more — these sections should get richer, not shorter
+- Decisions from early in the project that are still load-bearing get preserved; decisions that were superseded get dropped or mentioned briefly

--- a/src/prompts/digest-system.md
+++ b/src/prompts/digest-system.md
@@ -1,21 +1,32 @@
-You are Myco's digest engine. Your role is to maintain a living understanding
-of a software project by synthesizing observations, session histories, plans,
-and team activity into a coherent context representation.
+You are Myco's digest engine. Your role is to maintain a living understanding of a software project by synthesizing observations, session histories, plans, and team activity into a coherent context representation.
 
 You will receive:
-1. Your previous synthesis (if one exists)
+1. Your previous synthesis (if one exists) — this is your accumulated understanding from prior cycles
 2. New substrate — recently captured knowledge that needs to be incorporated
 
-Produce an updated synthesis that:
-- Integrates the new substrate into your existing understanding
-- Stays within the specified token budget
-- Is written for an AI agent that will use this as its primary project context
-- Uses present tense for active state, past tense for completed work
-- Uses markdown formatting for structure and readability
+Your output will be injected directly into an AI agent's context window at the start of every session. The agent will rely on this as its primary understanding of the project. Write for that audience.
 
 CRITICAL RULES:
-- NEVER fabricate file paths, function names, commands, or architecture that isn't explicitly stated in the substrate
-- NEVER invent plans, issues, or next steps that aren't mentioned in the substrate
-- If the substrate doesn't mention something, don't include it — omission is better than fabrication
-- When referencing code or files, use ONLY paths and names that appear verbatim in the substrate
-- Focus on WHAT the project does and WHY decisions were made, not HOW the code is structured (the agent can read the code itself)
+- NEVER fabricate file paths, function names, commands, or architecture not explicitly in the substrate
+- NEVER invent plans, issues, or next steps not mentioned in the substrate
+- Omission is better than fabrication — if the substrate doesn't mention it, leave it out
+- Reference code or files ONLY using paths and names that appear verbatim in the substrate
+- Focus on WHAT the project does, WHY decisions were made, and WHAT to watch out for — not HOW the code is structured (the agent can read code itself)
+
+BUDGET DISCIPLINE:
+- You MUST use the full token budget generously — a 5,000-token tier should produce close to 5,000 tokens of content
+- Sparse output wastes the budget the user is paying for — fill the space with genuinely useful detail
+- When the knowledge base is small, go deeper on what exists rather than being brief
+- When the knowledge base is large, prioritize recent activity and compress older context — but never drop foundational knowledge entirely
+
+KNOWLEDGE LIFECYCLE:
+- Recent sessions and observations carry more weight than older ones — they reflect current state
+- Foundational knowledge (project identity, architecture decisions, team conventions) persists across cycles even when old
+- Completed work transitions from "active focus" to "historical context" — compress it, don't drop it
+- Contradictions between old and new substrate should be resolved in favor of the new — note what changed
+- As the vault grows, your role shifts from "capture everything" to "curate what matters most right now"
+
+FORMATTING:
+- Use markdown with clear section headings
+- Present tense for active state, past tense for completed work
+- Use tables, bullet lists, and structured formats to maximize information density

--- a/src/prompts/digest-system.md
+++ b/src/prompts/digest-system.md
@@ -11,5 +11,11 @@ Produce an updated synthesis that:
 - Stays within the specified token budget
 - Is written for an AI agent that will use this as its primary project context
 - Uses present tense for active state, past tense for completed work
-- Never fabricates — only synthesize from provided data
 - Uses markdown formatting for structure and readability
+
+CRITICAL RULES:
+- NEVER fabricate file paths, function names, commands, or architecture that isn't explicitly stated in the substrate
+- NEVER invent plans, issues, or next steps that aren't mentioned in the substrate
+- If the substrate doesn't mention something, don't include it — omission is better than fabrication
+- When referencing code or files, use ONLY paths and names that appear verbatim in the substrate
+- Focus on WHAT the project does and WHY decisions were made, not HOW the code is structured (the agent can read the code itself)

--- a/src/prompts/digest-system.md
+++ b/src/prompts/digest-system.md
@@ -1,0 +1,15 @@
+You are Myco's digest engine. Your role is to maintain a living understanding
+of a software project by synthesizing observations, session histories, plans,
+and team activity into a coherent context representation.
+
+You will receive:
+1. Your previous synthesis (if one exists)
+2. New substrate — recently captured knowledge that needs to be incorporated
+
+Produce an updated synthesis that:
+- Integrates the new substrate into your existing understanding
+- Stays within the specified token budget
+- Is written for an AI agent that will use this as its primary project context
+- Uses present tense for active state, past tense for completed work
+- Never fabricates — only synthesize from provided data
+- Uses markdown formatting for structure and readability

--- a/src/prompts/extraction.md
+++ b/src/prompts/extraction.md
@@ -1,4 +1,5 @@
 You are analyzing a coding session buffer for session "{{sessionId}}".
+You have a budget of ~{{maxTokens}} tokens for your response. Use it generously — richer, more detailed observations are more valuable than brief ones.
 
 ## Events ({{eventCount}} total)
 {{toolSummary}}
@@ -11,7 +12,7 @@ Analyze these events and produce a JSON response with exactly this structure:
     {
       "type": "gotcha|bug_fix|decision|discovery|trade_off",
       "title": "Short descriptive title",
-      "content": "Detailed explanation of the observation.",
+      "content": "Detailed explanation of the observation. Be thorough — include the context, the specifics, and why this matters. A teammate reading this should fully understand the issue without needing to look at the code.",
       "tags": ["relevant", "tags"]
     }
   ]
@@ -20,9 +21,9 @@ Analyze these events and produce a JSON response with exactly this structure:
 ## Type-Specific Fields
 Include these additional fields when appropriate for the observation type:
 
-- **bug_fix**: add "root_cause" (what caused the bug) and "fix" (what resolved it)
-- **decision**: add "rationale" (why this choice) and "alternatives_rejected" (what was considered and why not)
-- **trade_off**: add "gained" (what was achieved) and "sacrificed" (what was given up)
+- **bug_fix**: add "root_cause" (what caused the bug — be specific) and "fix" (what resolved it — include the approach, not just the file name)
+- **decision**: add "rationale" (why this choice was made — include constraints and context) and "alternatives_rejected" (what was considered and why it was ruled out)
+- **trade_off**: add "gained" (what was achieved) and "sacrificed" (what was given up, and why the tradeoff was acceptable)
 
 These fields are optional — only include them when the session provides clear evidence.
 
@@ -33,13 +34,13 @@ Only include observations that meet ALL criteria:
 - Not specific to this session's transient state
 
 Types:
-- "gotcha": A non-obvious problem, pitfall, or workaround
-- "bug_fix": Root cause of a bug and what fixed it
-- "decision": An architectural or technical choice, with rationale and rejected alternatives
-- "discovery": A significant learning about the codebase, tooling, or domain
-- "trade_off": What was sacrificed and why
+- "gotcha": A non-obvious problem, pitfall, or workaround — include the symptom, the root cause, and the fix or workaround
+- "bug_fix": Root cause of a bug and what fixed it — include enough detail that someone could recognize the same bug
+- "decision": An architectural or technical choice — explain the reasoning, constraints, and what was rejected
+- "discovery": A significant learning about the codebase, tooling, or domain — explain what was surprising or non-obvious
+- "trade_off": What was sacrificed and why — include both sides of the tradeoff and what tipped the balance
 
 Routine activity (file reads, searches, test runs, navigation) goes in the summary only.
-Target 0-5 observations. Err on fewer, higher-quality observations.
+Target 0-5 observations. Err on fewer, higher-quality observations with rich detail over many thin ones.
 
 Respond with valid JSON only, no markdown fences.

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -34,7 +34,7 @@ const PROMPTS_DIR = resolvePromptsDir();
 
 const promptCache = new Map<string, string>();
 
-function loadPrompt(name: string): string {
+export function loadPrompt(name: string): string {
   let cached = promptCache.get(name);
   if (!cached) {
     cached = fs.readFileSync(path.join(PROMPTS_DIR, `${name}.md`), 'utf-8').trim();

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -57,11 +57,13 @@ export function buildExtractionPrompt(
   sessionId: string,
   eventCount: number,
   toolSummary: string,
+  maxTokens?: number,
 ): string {
   return interpolate(loadPrompt('extraction'), {
     sessionId,
     eventCount: String(eventCount),
     toolSummary,
+    maxTokens: String(maxTokens ?? 2048),
   });
 }
 
@@ -69,11 +71,13 @@ export function buildSummaryPrompt(
   sessionId: string,
   user: string,
   content: string,
+  maxTokens?: number,
 ): string {
   return interpolate(loadPrompt('summary'), {
     sessionId,
     user,
     content,
+    maxTokens: String(maxTokens ?? 1024),
   });
 }
 
@@ -108,6 +112,7 @@ export function buildSimilarityPrompt(
 export function buildClassificationPrompt(
   sessionId: string,
   candidates: Array<{ path: string; content: string }>,
+  maxTokens?: number,
 ): string {
   const fileList = candidates
     .map((c) => {
@@ -121,5 +126,6 @@ export function buildClassificationPrompt(
     fileList,
     artifactTypes: ARTIFACT_TYPE_DESCRIPTIONS.map((d) => `- ${d}`).join('\n'),
     validTypes: ARTIFACT_TYPES.join('|'),
+    maxTokens: String(maxTokens ?? 1024),
   });
 }

--- a/src/prompts/summary.md
+++ b/src/prompts/summary.md
@@ -1,9 +1,19 @@
 You are summarizing a coding session for user "{{user}}" (session "{{sessionId}}").
+You have a budget of ~{{maxTokens}} tokens. Use the full budget to produce a rich, detailed narrative.
 
 ## Session Content
 {{content}}
 
 ## Task
-Write a concise narrative summary of this session (3-6 sentences). Describe what was accomplished, key decisions made, and any problems encountered. Focus on outcomes rather than individual tool calls.
+Write a detailed narrative summary of this session. This summary will be used by the digest engine to synthesize project understanding, so richness and accuracy matter more than brevity.
+
+Cover:
+- **What was accomplished** — features built, bugs fixed, refactors completed
+- **Key decisions made** — what was chosen and why, including alternatives that were rejected
+- **Problems encountered** — what went wrong, how it was debugged, what the root cause was
+- **Discoveries and learnings** — anything surprising or non-obvious that was learned
+- **Current state** — where things stand at the end of the session, what's next
+
+Focus on outcomes and reasoning rather than individual tool calls. Include enough context that someone reading this summary months later would understand what happened and why.
 
 Respond with plain text only, no JSON or markdown fences.

--- a/src/prompts/title.md
+++ b/src/prompts/title.md
@@ -1,4 +1,4 @@
-Given this session summary, produce a short, descriptive title (5-10 words) suitable for a vault note heading.
+Given this session summary, produce a short, descriptive title (5-10 words) that captures the primary accomplishment or focus of the session.
 
 Summary:
 {{summary}}

--- a/src/vault/frontmatter.ts
+++ b/src/vault/frontmatter.ts
@@ -1,5 +1,19 @@
+import YAML from 'yaml';
 import type { IndexedNote } from '../index/sqlite.js';
 import type { PlanFrontmatter, SessionFrontmatter, SporeFrontmatter } from './types.js';
+
+/** Strip YAML frontmatter from a markdown string, returning the body and parsed frontmatter. */
+export function stripFrontmatter(raw: string): { body: string; frontmatter: Record<string, unknown> } {
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n*/);
+  if (!match) return { body: raw.trim(), frontmatter: {} };
+
+  let frontmatter: Record<string, unknown> = {};
+  try {
+    frontmatter = YAML.parse(match[1]) as Record<string, unknown>;
+  } catch { /* malformed frontmatter */ }
+
+  return { body: raw.slice(match[0].length).trim(), frontmatter };
+}
 
 export function planFm(note: IndexedNote): PlanFrontmatter {
   return note.frontmatter as unknown as PlanFrontmatter;

--- a/src/vault/frontmatter.ts
+++ b/src/vault/frontmatter.ts
@@ -1,5 +1,5 @@
 import type { IndexedNote } from '../index/sqlite.js';
-import type { PlanFrontmatter, SessionFrontmatter, MemoryFrontmatter } from './types.js';
+import type { PlanFrontmatter, SessionFrontmatter, SporeFrontmatter } from './types.js';
 
 export function planFm(note: IndexedNote): PlanFrontmatter {
   return note.frontmatter as unknown as PlanFrontmatter;
@@ -9,6 +9,6 @@ export function sessionFm(note: IndexedNote): SessionFrontmatter {
   return note.frontmatter as unknown as SessionFrontmatter;
 }
 
-export function memoryFm(note: IndexedNote): MemoryFrontmatter {
-  return note.frontmatter as unknown as MemoryFrontmatter;
+export function sporeFm(note: IndexedNote): SporeFrontmatter {
+  return note.frontmatter as unknown as SporeFrontmatter;
 }

--- a/src/vault/observations.ts
+++ b/src/vault/observations.ts
@@ -1,4 +1,4 @@
-import { formatMemoryBody } from '../obsidian/formatter.js';
+import { formatSporeBody } from '../obsidian/formatter.js';
 import { sessionNoteId } from './session-id.js';
 import { indexNote } from '../index/rebuild.js';
 import type { Observation } from '../daemon/processor.js';
@@ -22,7 +22,7 @@ export function writeObservationNotes(
 
   for (const obs of observations) {
     const obsId = `${obs.type}-${sessionId.slice(-6)}-${Date.now()}`;
-    const body = formatMemoryBody({
+    const body = formatSporeBody({
       title: obs.title,
       observationType: obs.type,
       content: obs.content,
@@ -35,7 +35,7 @@ export function writeObservationNotes(
       sacrificed: obs.sacrificed,
       tags: obs.tags,
     });
-    const relativePath = writer.writeMemory({
+    const relativePath = writer.writeSpore({
       id: obsId,
       observation_type: obs.type,
       session: sessionNoteId(sessionId),

--- a/src/vault/reader.ts
+++ b/src/vault/reader.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import matter from 'gray-matter';
 import { parseNoteFrontmatter, type VaultNote } from './types.js';
 
-const VAULT_SUBDIRS = ['sessions', 'plans', 'memories', 'artifacts', 'team'];
+const VAULT_SUBDIRS = ['sessions', 'plans', 'spores', 'artifacts', 'team'];
 
 export class VaultReader {
   constructor(private vaultDir: string) {}

--- a/src/vault/types.ts
+++ b/src/vault/types.ts
@@ -30,14 +30,14 @@ export const PlanFrontmatterSchema = z.object({
 
 export const OBSERVATION_TYPES = ['gotcha', 'bug_fix', 'decision', 'discovery', 'trade_off', 'cross-cutting'] as const;
 
-export const MEMORY_STATUSES = ['active', 'superseded', 'archived'] as const;
-export type MemoryStatus = (typeof MEMORY_STATUSES)[number];
+export const SPORE_STATUSES = ['active', 'superseded', 'archived'] as const;
+export type SporeStatus = (typeof SPORE_STATUSES)[number];
 
-export const MemoryFrontmatterSchema = z.object({
-  type: z.literal('memory'),
+export const SporeFrontmatterSchema = z.object({
+  type: z.literal('spore'),
   id: z.string(),
   observation_type: z.string(),
-  status: z.enum(MEMORY_STATUSES).default('active'),
+  status: z.enum(SPORE_STATUSES).default('active'),
   session: z.string().optional(),
   plan: z.string().optional(),
   superseded_by: z.string().optional(),
@@ -71,15 +71,15 @@ export const TeamMemberFrontmatterSchema = z.object({
 
 export type SessionFrontmatter = z.infer<typeof SessionFrontmatterSchema>;
 export type PlanFrontmatter = z.infer<typeof PlanFrontmatterSchema>;
-export type MemoryFrontmatter = z.infer<typeof MemoryFrontmatterSchema>;
-export type ObservationType = MemoryFrontmatter['observation_type'];
+export type SporeFrontmatter = z.infer<typeof SporeFrontmatterSchema>;
+export type ObservationType = SporeFrontmatter['observation_type'];
 export type ArtifactFrontmatter = z.infer<typeof ArtifactFrontmatterSchema>;
 export type TeamMemberFrontmatter = z.infer<typeof TeamMemberFrontmatterSchema>;
 
 export type NoteFrontmatter =
   | SessionFrontmatter
   | PlanFrontmatter
-  | MemoryFrontmatter
+  | SporeFrontmatter
   | ArtifactFrontmatter
   | TeamMemberFrontmatter;
 
@@ -92,7 +92,7 @@ export interface VaultNote<T extends NoteFrontmatter = NoteFrontmatter> {
 const schemasByType: Record<string, z.ZodSchema> = {
   session: SessionFrontmatterSchema,
   plan: PlanFrontmatterSchema,
-  memory: MemoryFrontmatterSchema,
+  spore: SporeFrontmatterSchema,
   artifact: ArtifactFrontmatterSchema,
   'team-member': TeamMemberFrontmatterSchema,
 };

--- a/src/vault/writer.ts
+++ b/src/vault/writer.ts
@@ -29,7 +29,7 @@ interface WritePlanInput {
   content: string;
 }
 
-interface WriteMemoryInput {
+interface WriteSporeInput {
   id: string;
   observation_type: string;
   session?: string;
@@ -123,9 +123,9 @@ export class VaultWriter {
     return relativePath;
   }
 
-  writeMemory(input: WriteMemoryInput): string {
+  writeSpore(input: WriteSporeInput): string {
     const normalizedType = input.observation_type.replace(/_/g, '-');
-    const relativePath = `memories/${normalizedType}/${input.id}.md`;
+    const relativePath = `spores/${normalizedType}/${input.id}.md`;
     const fullPath = path.join(this.vaultDir, relativePath);
     const now = new Date().toISOString();
 
@@ -143,14 +143,14 @@ export class VaultWriter {
     }
 
     const frontmatter: Record<string, unknown> = {
-      type: 'memory',
+      type: 'spore',
       id: input.id,
       observation_type: input.observation_type,
       created,
     };
     if (input.session) frontmatter.session = input.session;
     if (input.plan) frontmatter.plan = input.plan;
-    frontmatter.tags = buildTags('memory', input.observation_type, input.tags ?? []);
+    frontmatter.tags = buildTags('spore', input.observation_type, input.tags ?? []);
 
     this.writeMarkdown(relativePath, frontmatter, input.content);
     return relativePath;

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -18,7 +18,7 @@ const VALID_CONFIG = {
     artifact_extensions: ['.md'],
     buffer_max_events: 500,
   },
-  context: { max_tokens: 1200, layers: { plans: 200, sessions: 500, memories: 300, team: 200 } },
+  context: { max_tokens: 1200, layers: { plans: 200, sessions: 500, spores: 300, team: 200 } },
   team: { enabled: false, user: '', sync: 'git' },
 };
 

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -80,8 +80,8 @@ describe('myco init', () => {
     expect(config.team.user).toBe('chris');
   });
 
-  it('uses correct base_url defaults per provider', () => {
-    runInit(testDir, ['--llm-provider', 'lm-studio', '--llm-model', 'gpt-oss', '--embedding-provider', 'ollama', '--embedding-model', 'bge-m3']);
+  it('uses correct base_url when explicitly passed', () => {
+    runInit(testDir, ['--llm-provider', 'lm-studio', '--llm-model', 'test', '--llm-url', 'http://localhost:1234', '--embedding-model', 'bge-m3', '--embedding-url', 'http://localhost:11434']);
 
     const config = YAML.parse(fs.readFileSync(path.join(testDir, '.myco', 'myco.yaml'), 'utf-8'));
     expect(config.intelligence.llm.base_url).toBe('http://localhost:1234');

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -40,7 +40,7 @@ describe('myco init', () => {
   it('creates all required subdirectories', () => {
     runInit(testDir, ['--llm-provider', 'ollama', '--llm-model', 'gpt-oss', '--embedding-model', 'bge-m3']);
 
-    const dirs = ['sessions', 'plans', 'memories', 'artifacts', 'team', 'buffer', 'logs'];
+    const dirs = ['sessions', 'plans', 'spores', 'artifacts', 'team', 'buffer', 'logs'];
     for (const dir of dirs) {
       expect(fs.existsSync(path.join(testDir, '.myco', dir))).toBe(true);
     }
@@ -116,7 +116,7 @@ describe('myco init', () => {
     expect(dashboard).toContain('dataview');
     expect(dashboard).toContain('#type/plan');
     expect(dashboard).toContain('#type/session');
-    expect(dashboard).toContain('#memory/gotcha');
+    expect(dashboard).toContain('#spore/gotcha');
   });
 
   it('is idempotent — does not overwrite existing vault', () => {

--- a/tests/cli/setup-digest.test.ts
+++ b/tests/cli/setup-digest.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import YAML from 'yaml';
+import { MycoConfigSchema } from '@myco/config/schema';
+import { run } from '@myco/cli/setup-digest';
+
+function writeConfig(dir: string, config: Record<string, unknown>): void {
+  fs.writeFileSync(path.join(dir, 'myco.yaml'), YAML.stringify(config), 'utf-8');
+}
+
+function readConfig(dir: string): Record<string, unknown> {
+  return YAML.parse(fs.readFileSync(path.join(dir, 'myco.yaml'), 'utf-8')) as Record<string, unknown>;
+}
+
+describe('myco setup-digest', () => {
+  let tmpDir: string;
+  let originalLog: typeof console.log;
+  let originalError: typeof console.error;
+  let logged: string[];
+  let errors: string[];
+  let exitCode: number | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-setup-digest-test-'));
+    // Write a minimal valid config using MycoConfigSchema defaults
+    const config = MycoConfigSchema.parse({ version: 2, intelligence: { llm: { provider: 'ollama', model: 'qwen3.5' }, embedding: { provider: 'ollama', model: 'bge-m3' } } });
+    writeConfig(tmpDir, config as unknown as Record<string, unknown>);
+
+    logged = [];
+    errors = [];
+    exitCode = undefined;
+    originalLog = console.log;
+    originalError = console.error;
+    console.log = (...args: unknown[]) => logged.push(args.join(' '));
+    console.error = (...args: unknown[]) => errors.push(args.join(' '));
+
+    const originalExit = process.exit;
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as never;
+    (globalThis as Record<string, unknown>).__originalExit = originalExit;
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+    console.error = originalError;
+    process.exit = (globalThis as Record<string, unknown>).__originalExit as typeof process.exit;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('--show outputs current digest config as JSON containing inject_tier', async () => {
+    await run(['--show'], tmpDir);
+    const output = logged.join('\n');
+    const parsed = JSON.parse(output);
+    expect(parsed).toHaveProperty('digest');
+    expect(parsed.digest).toHaveProperty('inject_tier');
+  });
+
+  it('--tiers updates the tiers array in the YAML file', async () => {
+    await run(['--tiers', '1500,3000'], tmpDir);
+    const config = readConfig(tmpDir);
+    const digest = config.digest as Record<string, unknown>;
+    expect(digest.tiers).toEqual([1500, 3000]);
+  });
+
+  it('--inject-tier updates inject_tier to the given number', async () => {
+    await run(['--inject-tier', '5000'], tmpDir);
+    const config = readConfig(tmpDir);
+    const digest = config.digest as Record<string, unknown>;
+    expect(digest.inject_tier).toBe(5000);
+  });
+
+  it('--inject-tier null sets inject_tier to null', async () => {
+    await run(['--inject-tier', 'null'], tmpDir);
+    const config = readConfig(tmpDir);
+    const digest = config.digest as Record<string, unknown>;
+    expect(digest.inject_tier).toBeNull();
+  });
+
+  it('--provider and --model update digest intelligence provider and model', async () => {
+    await run(['--provider', 'lm-studio', '--model', 'test-model'], tmpDir);
+    const config = readConfig(tmpDir);
+    const digest = config.digest as Record<string, unknown>;
+    const intelligence = digest.intelligence as Record<string, unknown>;
+    expect(intelligence.provider).toBe('lm-studio');
+    expect(intelligence.model).toBe('test-model');
+  });
+
+  it('--context-window updates intelligence context_window', async () => {
+    await run(['--context-window', '65536'], tmpDir);
+    const config = readConfig(tmpDir);
+    const digest = config.digest as Record<string, unknown>;
+    const intelligence = digest.intelligence as Record<string, unknown>;
+    expect(intelligence.context_window).toBe(65536);
+  });
+
+  it('--gpu-kv-cache true sets gpu_kv_cache to true', async () => {
+    await run(['--gpu-kv-cache', 'true'], tmpDir);
+    const config = readConfig(tmpDir);
+    const digest = config.digest as Record<string, unknown>;
+    const intelligence = digest.intelligence as Record<string, unknown>;
+    expect(intelligence.gpu_kv_cache).toBe(true);
+  });
+
+  it('--summary-tokens updates capture.summary_max_tokens', async () => {
+    await run(['--summary-tokens', '2048'], tmpDir);
+    const config = readConfig(tmpDir);
+    const capture = config.capture as Record<string, unknown>;
+    expect(capture.summary_max_tokens).toBe(2048);
+  });
+
+  it('--enabled false disables digest', async () => {
+    await run(['--enabled', 'false'], tmpDir);
+    const config = readConfig(tmpDir);
+    const digest = config.digest as Record<string, unknown>;
+    expect(digest.enabled).toBe(false);
+  });
+
+  it('invalid value causes validation error and exits with code 1', async () => {
+    // Corrupt the tiers value to cause a schema validation error by passing a
+    // non-positive integer via a direct YAML manipulation before the run call.
+    // We trigger validation failure by writing a bad inject_tier after parsing:
+    // write an invalid config with version missing, then call with valid args
+    // to ensure the safeParse step fails.
+    const badConfig = {
+      version: 2,
+      intelligence: { llm: { provider: 'ollama', model: 'qwen3.5' }, embedding: { provider: 'ollama', model: 'bge-m3' } },
+      digest: { tiers: [-1] }, // negative number fails z.number().int().positive()
+    };
+    writeConfig(tmpDir, badConfig);
+
+    await expect(run(['--enabled', 'true'], tmpDir)).rejects.toThrow('process.exit(1)');
+    expect(exitCode).toBe(1);
+    expect(errors.some((e) => e.includes('Validation error') || e.includes('validation'))).toBe(true);
+  });
+
+  it('shows daemon restart notice when daemon.json exists', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'daemon.json'), '{}', 'utf-8');
+    await run(['--enabled', 'true'], tmpDir);
+    expect(logged.some((l) => l.includes('restart'))).toBe(true);
+  });
+
+  it('does not show daemon restart notice when daemon.json is absent', async () => {
+    await run(['--enabled', 'true'], tmpDir);
+    expect(logged.every((l) => !l.includes('restart'))).toBe(true);
+  });
+});

--- a/tests/cli/setup-llm.test.ts
+++ b/tests/cli/setup-llm.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import YAML from 'yaml';
+import { MycoConfigSchema } from '@myco/config/schema';
+import { run } from '@myco/cli/setup-llm';
+
+function writeConfig(dir: string, config: Record<string, unknown>): void {
+  fs.writeFileSync(path.join(dir, 'myco.yaml'), YAML.stringify(config), 'utf-8');
+}
+
+function readConfig(dir: string): Record<string, unknown> {
+  return YAML.parse(fs.readFileSync(path.join(dir, 'myco.yaml'), 'utf-8')) as Record<string, unknown>;
+}
+
+describe('myco setup-llm', () => {
+  let tmpDir: string;
+  let originalLog: typeof console.log;
+  let originalError: typeof console.error;
+  let logged: string[];
+  let errors: string[];
+  let exitCode: number | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-setup-llm-test-'));
+    const config = MycoConfigSchema.parse({ version: 2, intelligence: { llm: { provider: 'ollama', model: 'qwen3.5' }, embedding: { provider: 'ollama', model: 'bge-m3' } } });
+    writeConfig(tmpDir, config as unknown as Record<string, unknown>);
+
+    logged = [];
+    errors = [];
+    exitCode = undefined;
+    originalLog = console.log;
+    originalError = console.error;
+    console.log = (...args: unknown[]) => logged.push(args.join(' '));
+    console.error = (...args: unknown[]) => errors.push(args.join(' '));
+
+    const originalExit = process.exit;
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    }) as never;
+    (globalThis as Record<string, unknown>).__originalExit = originalExit;
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+    console.error = originalError;
+    process.exit = (globalThis as Record<string, unknown>).__originalExit as typeof process.exit;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('--show outputs current intelligence config as JSON', async () => {
+    await run(['--show'], tmpDir);
+    const output = logged.join('\n');
+    const parsed = JSON.parse(output);
+    expect(parsed).toHaveProperty('llm');
+    expect(parsed).toHaveProperty('embedding');
+  });
+
+  it('--llm-model updates the llm model', async () => {
+    await run(['--llm-model', 'qwen3.5:35b'], tmpDir);
+    const config = readConfig(tmpDir);
+    const intelligence = config.intelligence as Record<string, Record<string, unknown>>;
+    expect(intelligence.llm.model).toBe('qwen3.5:35b');
+  });
+
+  it('--llm-provider and --llm-url updates provider and base_url', async () => {
+    await run(['--llm-provider', 'lm-studio', '--llm-url', 'http://localhost:1234'], tmpDir);
+    const config = readConfig(tmpDir);
+    const intelligence = config.intelligence as Record<string, Record<string, unknown>>;
+    expect(intelligence.llm.provider).toBe('lm-studio');
+    expect(intelligence.llm.base_url).toBe('http://localhost:1234');
+  });
+
+  it('--embedding-model updates the embedding model', async () => {
+    await run(['--embedding-model', 'nomic-embed-text'], tmpDir);
+    const config = readConfig(tmpDir);
+    const intelligence = config.intelligence as Record<string, Record<string, unknown>>;
+    expect(intelligence.embedding.model).toBe('nomic-embed-text');
+  });
+
+  it('--llm-context-window updates context_window', async () => {
+    await run(['--llm-context-window', '32768'], tmpDir);
+    const config = readConfig(tmpDir);
+    const intelligence = config.intelligence as Record<string, Record<string, unknown>>;
+    expect(intelligence.llm.context_window).toBe(32768);
+  });
+
+  it('partial update preserves other fields unchanged', async () => {
+    // Change only the model; provider should remain 'ollama'
+    await run(['--llm-model', 'llama3'], tmpDir);
+    const config = readConfig(tmpDir);
+    const intelligence = config.intelligence as Record<string, Record<string, unknown>>;
+    expect(intelligence.llm.model).toBe('llama3');
+    expect(intelligence.llm.provider).toBe('ollama');
+  });
+
+  it('prints updated intelligence config after a change', async () => {
+    await run(['--llm-model', 'deepseek-r1'], tmpDir);
+    const allOutput = logged.join('\n');
+    // The updated config JSON should appear in output
+    expect(allOutput).toContain('deepseek-r1');
+  });
+
+  it('warns about vector rebuild when embedding model changes', async () => {
+    await run(['--embedding-model', 'nomic-embed-text'], tmpDir);
+    expect(logged.some((l) => l.includes('rebuild'))).toBe(true);
+  });
+
+  it('shows daemon restart notice when daemon.json exists', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'daemon.json'), '{}', 'utf-8');
+    await run(['--llm-model', 'llama3'], tmpDir);
+    expect(logged.some((l) => l.includes('restart'))).toBe(true);
+  });
+
+  it('does not show daemon restart notice when daemon.json is absent', async () => {
+    await run(['--llm-model', 'llama3'], tmpDir);
+    expect(logged.every((l) => !l.includes('restart'))).toBe(true);
+  });
+});

--- a/tests/cli/verify.test.ts
+++ b/tests/cli/verify.test.ts
@@ -17,7 +17,7 @@ const VALID_CONFIG = {
     artifact_extensions: ['.md'],
     buffer_max_events: 500,
   },
-  context: { max_tokens: 1200, layers: { plans: 200, sessions: 500, memories: 300, team: 200 } },
+  context: { max_tokens: 1200, layers: { plans: 200, sessions: 500, spores: 300, team: 200 } },
   team: { enabled: false, user: '', sync: 'git' },
 };
 

--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -70,7 +70,7 @@ intelligence:
         embedding: { provider: 'ollama' as const, model: 'bge-m3' },
       },
       capture: { transcript_paths: [], artifact_watch: [], artifact_extensions: ['.md'], buffer_max_events: 500 },
-      context: { max_tokens: 1200, layers: { plans: 200, sessions: 500, memories: 300, team: 200 } },
+      context: { max_tokens: 1200, layers: { plans: 200, sessions: 500, spores: 300, team: 200 } },
       daemon: { log_level: 'info' as const, grace_period: 30, max_log_size: 5242880 },
       team: { enabled: false, user: '', sync: 'git' as const },
     };

--- a/tests/config/schema.test.ts
+++ b/tests/config/schema.test.ts
@@ -81,4 +81,49 @@ describe('MycoConfigSchema v2', () => {
     expect(config.daemon.log_level).toBe('info');
     expect(config.team.enabled).toBe(false);
   });
+
+  describe('digest section', () => {
+    it('populates default digest values when digest section is absent', () => {
+      const config = MycoConfigSchema.parse(minimal);
+      expect(config.digest.enabled).toBe(true);
+      expect(config.digest.tiers).toEqual([1500, 3000, 5000, 10000]);
+      expect(config.digest.inject_tier).toBe(3000);
+      expect(config.digest.intelligence.provider).toBeNull();
+      expect(config.digest.intelligence.model).toBeNull();
+      expect(config.digest.intelligence.base_url).toBeNull();
+      expect(config.digest.intelligence.context_window).toBe(32768);
+      expect(config.digest.metabolism.active_interval).toBe(300);
+      expect(config.digest.metabolism.cooldown_intervals).toEqual([900, 1800, 3600]);
+      expect(config.digest.metabolism.dormancy_threshold).toBe(7200);
+      expect(config.digest.substrate.max_notes_per_cycle).toBe(50);
+    });
+
+    it('accepts intelligence override with nullable fields', () => {
+      const config = MycoConfigSchema.parse({
+        ...minimal,
+        digest: {
+          intelligence: {
+            provider: 'anthropic',
+            model: 'claude-haiku-4-5-20251001',
+            base_url: null,
+            context_window: 16384,
+          },
+        },
+      });
+      expect(config.digest.intelligence.provider).toBe('anthropic');
+      expect(config.digest.intelligence.model).toBe('claude-haiku-4-5-20251001');
+      expect(config.digest.intelligence.base_url).toBeNull();
+      expect(config.digest.intelligence.context_window).toBe(16384);
+    });
+
+    it('accepts custom tiers array', () => {
+      const config = MycoConfigSchema.parse({
+        ...minimal,
+        digest: {
+          tiers: [500, 1000, 2000],
+        },
+      });
+      expect(config.digest.tiers).toEqual([500, 1000, 2000]);
+    });
+  });
 });

--- a/tests/daemon/digest.test.ts
+++ b/tests/daemon/digest.test.ts
@@ -566,11 +566,13 @@ describe('DigestEngine', () => {
       const tracePath = path.join(vaultDir, 'digest', 'trace.jsonl');
       expect(fs.existsSync(tracePath)).toBe(true);
 
-      // Verify LLM was called with a prompt containing system + tier + substrate
+      // Verify LLM was called with user prompt + opts containing system prompt
       expect(llm.summarize).toHaveBeenCalledTimes(1);
       const promptArg = (llm.summarize as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
-      expect(promptArg).toContain('digest engine');
+      const optsArg = (llm.summarize as ReturnType<typeof vi.fn>).mock.calls[0][1] as Record<string, unknown>;
       expect(promptArg).toContain('New Substrate');
+      expect(optsArg.systemPrompt).toContain('digest engine');
+      expect(optsArg.reasoning).toBe('off');
     });
 
     it('includes previous extract in prompt when available', async () => {

--- a/tests/daemon/digest.test.ts
+++ b/tests/daemon/digest.test.ts
@@ -628,6 +628,33 @@ describe('DigestEngine', () => {
       expect(fs.existsSync(path.join(vaultDir, 'digest', 'extract-1500.md'))).toBe(true);
       expect(fs.existsSync(path.join(vaultDir, 'digest', 'extract-3000.md'))).toBe(true);
     });
+
+    it('tier gating: context_window 8192 produces only tier 1500', async () => {
+      // 1500 needs 6500 (fits), 3000 needs 11500 (does not fit in 8192)
+      const notes = [makeNote({ id: 's1', type: 'session', title: 'Auth work', content: 'Fixed auth.' })];
+      const index = makeMockIndex(notes);
+      const llm = makeMockLlm();
+
+      const engine = new DigestEngine({
+        vaultDir,
+        index,
+        llmProvider: llm,
+        config: makeConfig({
+          tiers: [1500, 3000, 5000, 10000],
+          intelligence: { provider: null, model: null, base_url: null, context_window: 8192 },
+        }),
+      });
+
+      const result = await engine.runCycle();
+
+      expect(result).not.toBeNull();
+      expect(result!.tiersGenerated).toEqual([1500]);
+      expect(llm.summarize).toHaveBeenCalledTimes(1);
+
+      // Only tier 1500 file should exist
+      expect(fs.existsSync(path.join(vaultDir, 'digest', 'extract-1500.md'))).toBe(true);
+      expect(fs.existsSync(path.join(vaultDir, 'digest', 'extract-3000.md'))).toBe(false);
+    });
   });
 });
 

--- a/tests/daemon/digest.test.ts
+++ b/tests/daemon/digest.test.ts
@@ -1,0 +1,747 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DigestEngine, Metabolism } from '@myco/daemon/digest';
+import type { DigestEngineConfig, DigestCycleResult } from '@myco/daemon/digest';
+import type { MycoIndex, IndexedNote } from '@myco/index/sqlite';
+import type { LlmProvider } from '@myco/intelligence/llm';
+import type { MycoConfig } from '@myco/config/schema';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// --- Helpers ---
+
+function makeConfig(overrides: Partial<MycoConfig['digest']> = {}): MycoConfig {
+  return {
+    version: 2,
+    intelligence: {
+      llm: { provider: 'ollama', model: 'test', context_window: 8192, max_tokens: 1024 },
+      embedding: { provider: 'ollama', model: 'test-embed' },
+    },
+    daemon: { log_level: 'info', grace_period: 30, max_log_size: 5_242_880 },
+    capture: { transcript_paths: [], artifact_watch: [], artifact_extensions: ['.md'], buffer_max_events: 500 },
+    context: { max_tokens: 1200, layers: { plans: 200, sessions: 500, spores: 300, team: 200 } },
+    team: { enabled: false, user: '', sync: 'git' },
+    digest: {
+      enabled: true,
+      tiers: [1500, 3000, 5000, 10000],
+      inject_tier: 3000,
+      intelligence: {
+        provider: null,
+        model: null,
+        base_url: null,
+        context_window: 32768,
+      },
+      metabolism: {
+        active_interval: 300,
+        cooldown_intervals: [900, 1800, 3600],
+        dormancy_threshold: 7200,
+      },
+      substrate: {
+        max_notes_per_cycle: 50,
+      },
+      ...overrides,
+    },
+  } as MycoConfig;
+}
+
+function makeNote(overrides: Partial<IndexedNote> = {}): IndexedNote {
+  return {
+    path: 'sessions/2026-03-15/session-abc123.md',
+    type: 'session',
+    id: 'abc123',
+    title: 'Test Session',
+    content: 'Did some work on the auth layer.',
+    frontmatter: { type: 'session' },
+    created: '2026-03-15T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeMockIndex(notes: IndexedNote[] = []): MycoIndex {
+  return {
+    query: vi.fn().mockReturnValue(notes),
+    getNoteByPath: vi.fn(),
+    upsertNote: vi.fn(),
+    deleteNote: vi.fn(),
+    queryByIds: vi.fn(),
+    close: vi.fn(),
+    getPragma: vi.fn(),
+    getDb: vi.fn(),
+  } as unknown as MycoIndex;
+}
+
+function makeMockLlm(): LlmProvider {
+  return {
+    name: 'test',
+    summarize: vi.fn().mockResolvedValue({ text: 'Synthesized context.', model: 'test-model' }),
+    isAvailable: vi.fn().mockResolvedValue(true),
+  };
+}
+
+// --- DigestEngine Tests ---
+
+describe('DigestEngine', () => {
+  let vaultDir: string;
+
+  beforeEach(() => {
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-digest-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(vaultDir, { recursive: true, force: true });
+  });
+
+  describe('discoverSubstrate', () => {
+    it('returns notes when no timestamp provided (first run)', () => {
+      const notes = [
+        makeNote({ id: 's1', type: 'session' }),
+        makeNote({ id: 's2', type: 'spore' }),
+      ];
+      const index = makeMockIndex(notes);
+      const engine = new DigestEngine({
+        vaultDir,
+        index,
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      const result = engine.discoverSubstrate(null);
+
+      expect(index.query).toHaveBeenCalledWith({ limit: 50 });
+      expect(result).toHaveLength(2);
+    });
+
+    it('passes updatedSince when timestamp provided', () => {
+      const index = makeMockIndex([]);
+      const engine = new DigestEngine({
+        vaultDir,
+        index,
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      engine.discoverSubstrate('2026-03-15T10:00:00Z');
+
+      expect(index.query).toHaveBeenCalledWith({
+        updatedSince: '2026-03-15T10:00:00Z',
+        limit: 50,
+      });
+    });
+
+    it('returns empty when no notes found', () => {
+      const index = makeMockIndex([]);
+      const engine = new DigestEngine({
+        vaultDir,
+        index,
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      const result = engine.discoverSubstrate(null);
+      expect(result).toHaveLength(0);
+    });
+
+    it('filters out extract notes', () => {
+      const notes = [
+        makeNote({ id: 's1', type: 'session' }),
+        makeNote({ id: 'e1', type: 'extract' }),
+        makeNote({ id: 's2', type: 'spore' }),
+      ];
+      const index = makeMockIndex(notes);
+      const engine = new DigestEngine({
+        vaultDir,
+        index,
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      const result = engine.discoverSubstrate(null);
+      expect(result).toHaveLength(2);
+      expect(result.find((n) => n.type === 'extract')).toBeUndefined();
+    });
+
+    it('respects max_notes_per_cycle limit', () => {
+      const notes = Array.from({ length: 10 }, (_, i) =>
+        makeNote({ id: `s${i}`, type: 'session' }),
+      );
+      const index = makeMockIndex(notes);
+      const engine = new DigestEngine({
+        vaultDir,
+        index,
+        llmProvider: makeMockLlm(),
+        config: makeConfig({ substrate: { max_notes_per_cycle: 3 } }),
+      });
+
+      const result = engine.discoverSubstrate(null);
+      expect(result).toHaveLength(3);
+    });
+
+    it('sorts by type weight then recency', () => {
+      const notes = [
+        makeNote({ id: 'a1', type: 'artifact', created: '2026-03-15T12:00:00Z' }),
+        makeNote({ id: 's1', type: 'session', created: '2026-03-15T10:00:00Z' }),
+        makeNote({ id: 's2', type: 'session', created: '2026-03-15T11:00:00Z' }),
+        makeNote({ id: 'p1', type: 'plan', created: '2026-03-15T09:00:00Z' }),
+      ];
+      const index = makeMockIndex(notes);
+      const engine = new DigestEngine({
+        vaultDir,
+        index,
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      const result = engine.discoverSubstrate(null);
+
+      // Sessions (weight 3) should come before plans (weight 2) before artifacts (weight 1)
+      expect(result[0].type).toBe('session');
+      expect(result[1].type).toBe('session');
+      // Within sessions, more recent first
+      expect(result[0].id).toBe('s2');
+      expect(result[1].id).toBe('s1');
+      expect(result[2].type).toBe('plan');
+      expect(result[3].type).toBe('artifact');
+    });
+  });
+
+  describe('getEligibleTiers', () => {
+    it('returns all tiers when context window is large', () => {
+      const engine = new DigestEngine({
+        vaultDir,
+        index: makeMockIndex(),
+        llmProvider: makeMockLlm(),
+        config: makeConfig({ intelligence: { provider: null, model: null, base_url: null, context_window: 100000 } }),
+      });
+
+      const tiers = engine.getEligibleTiers();
+      expect(tiers).toEqual([1500, 3000, 5000, 10000]);
+    });
+
+    it('filters tiers by context window', () => {
+      const engine = new DigestEngine({
+        vaultDir,
+        index: makeMockIndex(),
+        llmProvider: makeMockLlm(),
+        config: makeConfig({ intelligence: { provider: null, model: null, base_url: null, context_window: 12000 } }),
+      });
+
+      const tiers = engine.getEligibleTiers();
+      // 1500 needs 6500, 3000 needs 11500 — both fit in 12000
+      // 5000 needs 18500 — too large
+      expect(tiers).toEqual([1500, 3000]);
+    });
+
+    it('returns empty when context window is too small', () => {
+      const engine = new DigestEngine({
+        vaultDir,
+        index: makeMockIndex(),
+        llmProvider: makeMockLlm(),
+        config: makeConfig({ intelligence: { provider: null, model: null, base_url: null, context_window: 5000 } }),
+      });
+
+      const tiers = engine.getEligibleTiers();
+      expect(tiers).toEqual([]);
+    });
+  });
+
+  describe('formatSubstrate', () => {
+    it('formats notes within token budget', () => {
+      const notes = [
+        makeNote({ id: 's1', type: 'session', title: 'Auth work', content: 'Fixed auth bugs.' }),
+        makeNote({ id: 's2', type: 'spore', title: 'CORS gotcha', content: 'Proxy strips headers.' }),
+      ];
+
+      const engine = new DigestEngine({
+        vaultDir,
+        index: makeMockIndex(),
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      const result = engine.formatSubstrate(notes, 1000);
+      expect(result).toContain('[session] s1');
+      expect(result).toContain('"Auth work"');
+      expect(result).toContain('Fixed auth bugs.');
+      expect(result).toContain('[spore] s2');
+    });
+
+    it('stops adding notes when budget exceeded', () => {
+      const longContent = 'x'.repeat(500);
+      const notes = [
+        makeNote({ id: 's1', content: longContent }),
+        makeNote({ id: 's2', content: longContent }),
+        makeNote({ id: 's3', content: longContent }),
+      ];
+
+      const engine = new DigestEngine({
+        vaultDir,
+        index: makeMockIndex(),
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      // Budget for ~200 tokens = ~800 chars — should fit first note but not all three
+      const result = engine.formatSubstrate(notes, 200);
+      expect(result).toContain('s1');
+      expect(result).not.toContain('s3');
+    });
+
+    it('always includes at least one note', () => {
+      const longContent = 'y'.repeat(2000);
+      const notes = [makeNote({ id: 's1', content: longContent })];
+
+      const engine = new DigestEngine({
+        vaultDir,
+        index: makeMockIndex(),
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      const result = engine.formatSubstrate(notes, 10);
+      expect(result).toContain('s1');
+    });
+  });
+
+  describe('readPreviousExtract', () => {
+    it('returns null when file does not exist', () => {
+      const engine = new DigestEngine({
+        vaultDir,
+        index: makeMockIndex(),
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      expect(engine.readPreviousExtract(1500)).toBeNull();
+    });
+
+    it('reads file and strips YAML frontmatter', () => {
+      const digestDir = path.join(vaultDir, 'digest');
+      fs.mkdirSync(digestDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(digestDir, 'extract-1500.md'),
+        '---\ntype: extract\ntier: 1500\n---\n\nThis is the synthesis body.\n',
+        'utf-8',
+      );
+
+      const engine = new DigestEngine({
+        vaultDir,
+        index: makeMockIndex(),
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      const body = engine.readPreviousExtract(1500);
+      expect(body).toBe('This is the synthesis body.');
+    });
+
+    it('returns full content if no frontmatter', () => {
+      const digestDir = path.join(vaultDir, 'digest');
+      fs.mkdirSync(digestDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(digestDir, 'extract-3000.md'),
+        'Plain content without frontmatter.\n',
+        'utf-8',
+      );
+
+      const engine = new DigestEngine({
+        vaultDir,
+        index: makeMockIndex(),
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      const body = engine.readPreviousExtract(3000);
+      expect(body).toBe('Plain content without frontmatter.');
+    });
+  });
+
+  describe('writeExtract', () => {
+    it('creates file with correct YAML frontmatter', () => {
+      const engine = new DigestEngine({
+        vaultDir,
+        index: makeMockIndex(),
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      engine.writeExtract(1500, 'Synthesized body.', 'cycle-123', 'test-model', 5);
+
+      const filePath = path.join(vaultDir, 'digest', 'extract-1500.md');
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('type: "extract"');
+      expect(content).toContain('tier: 1500');
+      expect(content).toContain('cycle_id: "cycle-123"');
+      expect(content).toContain('substrate_count: 5');
+      expect(content).toContain('model: "test-model"');
+      expect(content).toContain('Synthesized body.');
+    });
+
+    it('creates digest directory if it does not exist', () => {
+      const engine = new DigestEngine({
+        vaultDir,
+        index: makeMockIndex(),
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      expect(fs.existsSync(path.join(vaultDir, 'digest'))).toBe(false);
+      engine.writeExtract(3000, 'Body.', 'c1', 'model', 1);
+      expect(fs.existsSync(path.join(vaultDir, 'digest'))).toBe(true);
+    });
+
+    it('uses atomic write (no .tmp file left behind)', () => {
+      const engine = new DigestEngine({
+        vaultDir,
+        index: makeMockIndex(),
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      engine.writeExtract(1500, 'Body.', 'c1', 'model', 1);
+
+      const tmpPath = path.join(vaultDir, 'digest', 'extract-1500.md.tmp');
+      expect(fs.existsSync(tmpPath)).toBe(false);
+    });
+  });
+
+  describe('appendTrace', () => {
+    it('appends JSON line to trace.jsonl', () => {
+      const engine = new DigestEngine({
+        vaultDir,
+        index: makeMockIndex(),
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      const record: DigestCycleResult = {
+        cycleId: 'c1',
+        timestamp: '2026-03-15T12:00:00Z',
+        substrate: { sessions: ['s1'], spores: [], plans: [], artifacts: [], team: [] },
+        tiersGenerated: [1500],
+        model: 'test-model',
+        durationMs: 1234,
+        tokensUsed: 500,
+      };
+
+      engine.appendTrace(record);
+
+      const tracePath = path.join(vaultDir, 'digest', 'trace.jsonl');
+      expect(fs.existsSync(tracePath)).toBe(true);
+      const content = fs.readFileSync(tracePath, 'utf-8').trim();
+      const parsed = JSON.parse(content);
+      expect(parsed.cycleId).toBe('c1');
+    });
+
+    it('appends multiple records', () => {
+      const engine = new DigestEngine({
+        vaultDir,
+        index: makeMockIndex(),
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      const base: DigestCycleResult = {
+        cycleId: 'c1',
+        timestamp: '2026-03-15T12:00:00Z',
+        substrate: { sessions: [], spores: [], plans: [], artifacts: [], team: [] },
+        tiersGenerated: [1500],
+        model: 'test-model',
+        durationMs: 100,
+        tokensUsed: 100,
+      };
+
+      engine.appendTrace({ ...base, cycleId: 'c1' });
+      engine.appendTrace({ ...base, cycleId: 'c2' });
+
+      const tracePath = path.join(vaultDir, 'digest', 'trace.jsonl');
+      const lines = fs.readFileSync(tracePath, 'utf-8').trim().split('\n');
+      expect(lines).toHaveLength(2);
+    });
+  });
+
+  describe('getLastCycleTimestamp', () => {
+    it('returns null when no trace file exists', () => {
+      const engine = new DigestEngine({
+        vaultDir,
+        index: makeMockIndex(),
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      expect(engine.getLastCycleTimestamp()).toBeNull();
+    });
+
+    it('returns null for empty trace file', () => {
+      const digestDir = path.join(vaultDir, 'digest');
+      fs.mkdirSync(digestDir, { recursive: true });
+      fs.writeFileSync(path.join(digestDir, 'trace.jsonl'), '', 'utf-8');
+
+      const engine = new DigestEngine({
+        vaultDir,
+        index: makeMockIndex(),
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      expect(engine.getLastCycleTimestamp()).toBeNull();
+    });
+
+    it('reads timestamp from last record', () => {
+      const digestDir = path.join(vaultDir, 'digest');
+      fs.mkdirSync(digestDir, { recursive: true });
+      const records = [
+        { cycleId: 'c1', timestamp: '2026-03-15T10:00:00Z' },
+        { cycleId: 'c2', timestamp: '2026-03-15T12:00:00Z' },
+      ];
+      fs.writeFileSync(
+        path.join(digestDir, 'trace.jsonl'),
+        records.map((r) => JSON.stringify(r)).join('\n') + '\n',
+        'utf-8',
+      );
+
+      const engine = new DigestEngine({
+        vaultDir,
+        index: makeMockIndex(),
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      expect(engine.getLastCycleTimestamp()).toBe('2026-03-15T12:00:00Z');
+    });
+  });
+
+  describe('runCycle', () => {
+    it('returns null when no substrate found', async () => {
+      const index = makeMockIndex([]);
+      const engine = new DigestEngine({
+        vaultDir,
+        index,
+        llmProvider: makeMockLlm(),
+        config: makeConfig(),
+      });
+
+      const result = await engine.runCycle();
+      expect(result).toBeNull();
+    });
+
+    it('runs full cycle and writes extracts and trace', async () => {
+      const notes = [
+        makeNote({ id: 's1', type: 'session', title: 'Auth work', content: 'Fixed auth.' }),
+        makeNote({ id: 'm1', type: 'spore', title: 'CORS issue', content: 'Proxy problem.' }),
+      ];
+      const index = makeMockIndex(notes);
+      const llm = makeMockLlm();
+
+      // Use only 1500 tier for speed
+      const config = makeConfig({
+        tiers: [1500],
+        intelligence: { provider: null, model: null, base_url: null, context_window: 32768 },
+      });
+
+      const engine = new DigestEngine({
+        vaultDir,
+        index,
+        llmProvider: llm,
+        config,
+      });
+
+      const result = await engine.runCycle();
+
+      expect(result).not.toBeNull();
+      expect(result!.tiersGenerated).toContain(1500);
+      expect(result!.model).toBe('test-model');
+      expect(result!.substrate.sessions).toContain('s1');
+      expect(result!.substrate.spores).toContain('m1');
+      expect(result!.durationMs).toBeGreaterThanOrEqual(0);
+
+      // Verify extract was written
+      const extractPath = path.join(vaultDir, 'digest', 'extract-1500.md');
+      expect(fs.existsSync(extractPath)).toBe(true);
+      const extractContent = fs.readFileSync(extractPath, 'utf-8');
+      expect(extractContent).toContain('Synthesized context.');
+
+      // Verify trace was written
+      const tracePath = path.join(vaultDir, 'digest', 'trace.jsonl');
+      expect(fs.existsSync(tracePath)).toBe(true);
+
+      // Verify LLM was called with a prompt containing system + tier + substrate
+      expect(llm.summarize).toHaveBeenCalledTimes(1);
+      const promptArg = (llm.summarize as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(promptArg).toContain('digest engine');
+      expect(promptArg).toContain('New Substrate');
+    });
+
+    it('includes previous extract in prompt when available', async () => {
+      // Write a previous extract
+      const digestDir = path.join(vaultDir, 'digest');
+      fs.mkdirSync(digestDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(digestDir, 'extract-1500.md'),
+        '---\ntype: extract\ntier: 1500\n---\n\nPrevious synthesis content.\n',
+        'utf-8',
+      );
+
+      const notes = [makeNote({ id: 's1', type: 'session' })];
+      const index = makeMockIndex(notes);
+      const llm = makeMockLlm();
+
+      const engine = new DigestEngine({
+        vaultDir,
+        index,
+        llmProvider: llm,
+        config: makeConfig({
+          tiers: [1500],
+          intelligence: { provider: null, model: null, base_url: null, context_window: 32768 },
+        }),
+      });
+
+      await engine.runCycle();
+
+      const promptArg = (llm.summarize as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(promptArg).toContain('Previous Synthesis');
+      expect(promptArg).toContain('Previous synthesis content.');
+    });
+
+    it('generates multiple tiers when eligible', async () => {
+      const notes = [makeNote({ id: 's1', type: 'session' })];
+      const index = makeMockIndex(notes);
+      const llm = makeMockLlm();
+
+      const engine = new DigestEngine({
+        vaultDir,
+        index,
+        llmProvider: llm,
+        config: makeConfig({
+          tiers: [1500, 3000],
+          intelligence: { provider: null, model: null, base_url: null, context_window: 32768 },
+        }),
+      });
+
+      const result = await engine.runCycle();
+
+      expect(result!.tiersGenerated).toEqual([1500, 3000]);
+      expect(llm.summarize).toHaveBeenCalledTimes(2);
+
+      // Both extract files should exist
+      expect(fs.existsSync(path.join(vaultDir, 'digest', 'extract-1500.md'))).toBe(true);
+      expect(fs.existsSync(path.join(vaultDir, 'digest', 'extract-3000.md'))).toBe(true);
+    });
+  });
+});
+
+// --- Metabolism Tests ---
+
+describe('Metabolism', () => {
+  const defaultConfig = {
+    active_interval: 300,
+    cooldown_intervals: [900, 1800, 3600],
+    dormancy_threshold: 7200,
+  };
+
+  it('starts in active state with correct interval', () => {
+    const metabolism = new Metabolism(defaultConfig);
+
+    expect(metabolism.state).toBe('active');
+    expect(metabolism.currentIntervalMs).toBe(300_000);
+  });
+
+  it('resets to active on substrate found', () => {
+    const metabolism = new Metabolism(defaultConfig);
+    metabolism.onEmptyCycle(); // cooling
+    expect(metabolism.state).toBe('cooling');
+
+    metabolism.onSubstrateFound();
+    expect(metabolism.state).toBe('active');
+    expect(metabolism.currentIntervalMs).toBe(300_000);
+  });
+
+  it('advances through cooldown steps on empty cycles', () => {
+    const metabolism = new Metabolism(defaultConfig);
+
+    metabolism.onEmptyCycle();
+    expect(metabolism.state).toBe('cooling');
+    expect(metabolism.currentIntervalMs).toBe(900_000);
+
+    metabolism.onEmptyCycle();
+    expect(metabolism.currentIntervalMs).toBe(1_800_000);
+
+    metabolism.onEmptyCycle();
+    expect(metabolism.currentIntervalMs).toBe(3_600_000);
+
+    // Beyond last step — stays at last interval
+    metabolism.onEmptyCycle();
+    expect(metabolism.currentIntervalMs).toBe(3_600_000);
+  });
+
+  it('enters dormancy after threshold elapsed', () => {
+    const metabolism = new Metabolism(defaultConfig);
+
+    // Set last substrate to well in the past
+    metabolism.markLastSubstrate(Date.now() - 7_200_001);
+    metabolism.onEmptyCycle();
+
+    expect(metabolism.state).toBe('dormant');
+  });
+
+  it('does not enter dormancy if threshold not reached', () => {
+    const metabolism = new Metabolism(defaultConfig);
+
+    metabolism.markLastSubstrate(Date.now() - 1000);
+    metabolism.onEmptyCycle();
+
+    expect(metabolism.state).toBe('cooling');
+  });
+
+  it('activates from dormancy', () => {
+    const metabolism = new Metabolism(defaultConfig);
+
+    // Force dormancy
+    metabolism.markLastSubstrate(Date.now() - 7_200_001);
+    metabolism.onEmptyCycle();
+    expect(metabolism.state).toBe('dormant');
+
+    metabolism.activate();
+    expect(metabolism.state).toBe('active');
+    expect(metabolism.currentIntervalMs).toBe(300_000);
+  });
+
+  it('ignores onEmptyCycle when already dormant', () => {
+    const metabolism = new Metabolism(defaultConfig);
+
+    metabolism.markLastSubstrate(Date.now() - 7_200_001);
+    metabolism.onEmptyCycle();
+    expect(metabolism.state).toBe('dormant');
+    const intervalBefore = metabolism.currentIntervalMs;
+
+    metabolism.onEmptyCycle();
+    expect(metabolism.state).toBe('dormant');
+    expect(metabolism.currentIntervalMs).toBe(intervalBefore);
+  });
+
+  it('stop() clears timer', () => {
+    const metabolism = new Metabolism(defaultConfig);
+
+    let callCount = 0;
+    metabolism.start(async () => { callCount++; });
+    metabolism.stop();
+
+    // Timer was cleared — callback should not fire
+    // We can't easily test timing, but verify stop doesn't throw
+    expect(metabolism.state).toBe('active');
+  });
+
+  it('start() cancels previous timer', () => {
+    const metabolism = new Metabolism(defaultConfig);
+
+    let callCount = 0;
+    metabolism.start(async () => { callCount++; });
+    // Starting again should cancel the first timer
+    metabolism.start(async () => { callCount += 10; });
+    metabolism.stop();
+
+    // No assertions on timing — just verify no exceptions
+    expect(metabolism.state).toBe('active');
+  });
+});

--- a/tests/daemon/migration.test.ts
+++ b/tests/daemon/migration.test.ts
@@ -3,75 +3,75 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import YAML from 'yaml';
-import { migrateMemoryFiles } from '@myco/daemon/main';
+import { migrateSporeFiles } from '@myco/daemon/main';
 
-describe('migrateMemoryFiles', () => {
+describe('migrateSporeFiles', () => {
   let vaultDir: string;
 
   beforeEach(() => {
     vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-migrate-'));
-    fs.mkdirSync(path.join(vaultDir, 'memories'), { recursive: true });
+    fs.mkdirSync(path.join(vaultDir, 'spores'), { recursive: true });
   });
 
   afterEach(() => {
     fs.rmSync(vaultDir, { recursive: true, force: true });
   });
 
-  function writeMemoryFile(filename: string, observationType: string): void {
-    const fm = { type: 'memory', id: filename.replace('.md', ''), observation_type: observationType, created: new Date().toISOString() };
+  function writeSporeFile(filename: string, observationType: string): void {
+    const fm = { type: 'spore', id: filename.replace('.md', ''), observation_type: observationType, created: new Date().toISOString() };
     const content = `---\n${YAML.stringify(fm)}---\n\n# Test`;
-    fs.writeFileSync(path.join(vaultDir, 'memories', filename), content);
+    fs.writeFileSync(path.join(vaultDir, 'spores', filename), content);
   }
 
-  it('moves flat memory files into type subdirectories', () => {
-    writeMemoryFile('gotcha-abc123-123.md', 'gotcha');
-    writeMemoryFile('decision-abc123-456.md', 'decision');
+  it('moves flat spore files into type subdirectories', () => {
+    writeSporeFile('gotcha-abc123-123.md', 'gotcha');
+    writeSporeFile('decision-abc123-456.md', 'decision');
 
-    const moved = migrateMemoryFiles(vaultDir);
+    const moved = migrateSporeFiles(vaultDir);
 
     expect(moved).toBe(2);
-    expect(fs.existsSync(path.join(vaultDir, 'memories/gotcha/gotcha-abc123-123.md'))).toBe(true);
-    expect(fs.existsSync(path.join(vaultDir, 'memories/decision/decision-abc123-456.md'))).toBe(true);
-    expect(fs.existsSync(path.join(vaultDir, 'memories/gotcha-abc123-123.md'))).toBe(false);
+    expect(fs.existsSync(path.join(vaultDir, 'spores/gotcha/gotcha-abc123-123.md'))).toBe(true);
+    expect(fs.existsSync(path.join(vaultDir, 'spores/decision/decision-abc123-456.md'))).toBe(true);
+    expect(fs.existsSync(path.join(vaultDir, 'spores/gotcha-abc123-123.md'))).toBe(false);
   });
 
   it('normalizes underscores to hyphens in directory name', () => {
-    writeMemoryFile('bug_fix-abc123-789.md', 'bug_fix');
+    writeSporeFile('bug_fix-abc123-789.md', 'bug_fix');
 
-    migrateMemoryFiles(vaultDir);
+    migrateSporeFiles(vaultDir);
 
-    expect(fs.existsSync(path.join(vaultDir, 'memories/bug-fix/bug_fix-abc123-789.md'))).toBe(true);
+    expect(fs.existsSync(path.join(vaultDir, 'spores/bug-fix/bug_fix-abc123-789.md'))).toBe(true);
   });
 
   it('skips files already in subdirectories', () => {
-    fs.mkdirSync(path.join(vaultDir, 'memories/gotcha'), { recursive: true });
-    const subFile = path.join(vaultDir, 'memories/gotcha/gotcha-abc123-123.md');
-    fs.writeFileSync(subFile, '---\ntype: memory\n---\n\n# Test');
+    fs.mkdirSync(path.join(vaultDir, 'spores/gotcha'), { recursive: true });
+    const subFile = path.join(vaultDir, 'spores/gotcha/gotcha-abc123-123.md');
+    fs.writeFileSync(subFile, '---\ntype: spore\n---\n\n# Test');
 
-    const moved = migrateMemoryFiles(vaultDir);
+    const moved = migrateSporeFiles(vaultDir);
 
     expect(moved).toBe(0);
     expect(fs.existsSync(subFile)).toBe(true);
   });
 
   it('skips files with missing observation_type', () => {
-    const fm = { type: 'memory', id: 'broken' };
+    const fm = { type: 'spore', id: 'broken' };
     fs.writeFileSync(
-      path.join(vaultDir, 'memories/broken.md'),
+      path.join(vaultDir, 'spores/broken.md'),
       `---\n${YAML.stringify(fm)}---\n\n# Broken`,
     );
 
-    const moved = migrateMemoryFiles(vaultDir);
+    const moved = migrateSporeFiles(vaultDir);
 
     expect(moved).toBe(0);
-    expect(fs.existsSync(path.join(vaultDir, 'memories/broken.md'))).toBe(true);
+    expect(fs.existsSync(path.join(vaultDir, 'spores/broken.md'))).toBe(true);
   });
 
   it('is idempotent — running twice moves nothing on second run', () => {
-    writeMemoryFile('gotcha-abc123-123.md', 'gotcha');
+    writeSporeFile('gotcha-abc123-123.md', 'gotcha');
 
-    migrateMemoryFiles(vaultDir);
-    const secondRun = migrateMemoryFiles(vaultDir);
+    migrateSporeFiles(vaultDir);
+    const secondRun = migrateSporeFiles(vaultDir);
 
     expect(secondRun).toBe(0);
   });

--- a/tests/index/fts.test.ts
+++ b/tests/index/fts.test.ts
@@ -20,9 +20,9 @@ describe('FTS5 Search', () => {
       frontmatter: { type: 'session' }, created: '2026-03-12T09:00:00Z',
     });
     index.upsertNote({
-      path: 'memories/m1.md', type: 'memory', id: 'm1', title: 'CORS Proxy Gotcha',
+      path: 'spores/m1.md', type: 'spore', id: 'm1', title: 'CORS Proxy Gotcha',
       content: 'The CORS proxy strips auth headers. Must add X-Forwarded-Auth.',
-      frontmatter: { type: 'memory' }, created: '2026-03-12T10:00:00Z',
+      frontmatter: { type: 'spore' }, created: '2026-03-12T10:00:00Z',
     });
     index.upsertNote({
       path: 'plans/p1.md', type: 'plan', id: 'p1', title: 'Auth Redesign',

--- a/tests/index/rebuild.test.ts
+++ b/tests/index/rebuild.test.ts
@@ -49,7 +49,7 @@ describe('Index Rebuild', () => {
       started: '2026-03-12T10:00:00Z', summary: '# S2',
     });
     writer.writePlan({ id: 'p1', content: '# Plan' });
-    writer.writeMemory({
+    writer.writeSpore({
       id: 'm1', observation_type: 'gotcha',
       content: '# Gotcha',
     });

--- a/tests/index/sqlite.test.ts
+++ b/tests/index/sqlite.test.ts
@@ -61,11 +61,11 @@ describe('MycoIndex', () => {
 
   it('deletes a note', () => {
     index.upsertNote({
-      path: 'memories/m.md', type: 'memory', id: 'm', title: 'Memory',
+      path: 'spores/m.md', type: 'spore', id: 'm', title: 'Spore',
       content: 'test', frontmatter: {}, created: '2026-03-12T00:00:00Z',
     });
-    index.deleteNote('memories/m.md');
-    expect(index.getNoteByPath('memories/m.md')).toBeNull();
+    index.deleteNote('spores/m.md');
+    expect(index.getNoteByPath('spores/m.md')).toBeNull();
   });
 
   it('queries notes by type', () => {

--- a/tests/index/sqlite.test.ts
+++ b/tests/index/sqlite.test.ts
@@ -88,4 +88,37 @@ describe('MycoIndex', () => {
     expect(results).toEqual([]);
     expect(index.getNoteByPath('nonexistent.md')).toBeNull();
   });
+
+  it('filters notes by updatedSince', () => {
+    // Insert two notes, then manually backdate the first one so we can
+    // query with a known boundary between their updated_at values.
+    index.upsertNote({
+      path: 'sessions/early.md', type: 'session', id: 'early', title: 'Early',
+      content: 'first', frontmatter: {}, created: '2026-01-01T00:00:00Z',
+    });
+    index.upsertNote({
+      path: 'sessions/late.md', type: 'session', id: 'late', title: 'Late',
+      content: 'second', frontmatter: {}, created: '2026-02-01T00:00:00Z',
+    });
+
+    // Backdate the early note so there is a known gap between the two updated_at values
+    const EARLY_TS = '2026-01-01 00:00:00';
+    const LATE_TS = '2026-02-01 00:00:00';
+    const BOUNDARY_TS = '2026-01-15 00:00:00';
+    index.getDb().prepare("UPDATE notes SET updated_at = ? WHERE id = 'early'").run(EARLY_TS);
+    index.getDb().prepare("UPDATE notes SET updated_at = ? WHERE id = 'late'").run(LATE_TS);
+
+    // Query with updatedSince = boundary: should return only the late note
+    const results = index.query({ updatedSince: BOUNDARY_TS });
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe('late');
+
+    // Query with updatedSince before both: should return both
+    const all = index.query({ updatedSince: '2025-01-01 00:00:00' });
+    expect(all).toHaveLength(2);
+
+    // Query with a far-future timestamp — should return nothing
+    const none = index.query({ updatedSince: '2099-01-01 00:00:00' });
+    expect(none).toHaveLength(0);
+  });
 });

--- a/tests/index/vectors.test.ts
+++ b/tests/index/vectors.test.ts
@@ -17,7 +17,7 @@ describe('VectorIndex', () => {
 
   it('stores and retrieves embeddings', () => {
     const idx = new VectorIndex(dbPath, 3);
-    idx.upsert('mem-1', [0.1, 0.2, 0.3], { type: 'memory', importance: 'high' });
+    idx.upsert('mem-1', [0.1, 0.2, 0.3], { type: 'spore', importance: 'high' });
 
     const results = idx.search([0.1, 0.2, 0.3], { limit: 5 });
     expect(results).toHaveLength(1);
@@ -28,10 +28,10 @@ describe('VectorIndex', () => {
 
   it('filters by metadata type', () => {
     const idx = new VectorIndex(dbPath, 3);
-    idx.upsert('mem-1', [0.1, 0.2, 0.3], { type: 'memory' });
+    idx.upsert('mem-1', [0.1, 0.2, 0.3], { type: 'spore' });
     idx.upsert('sess-1', [0.1, 0.2, 0.3], { type: 'session' });
 
-    const results = idx.search([0.1, 0.2, 0.3], { limit: 5, type: 'memory' });
+    const results = idx.search([0.1, 0.2, 0.3], { limit: 5, type: 'spore' });
     expect(results).toHaveLength(1);
     expect(results[0].id).toBe('mem-1');
     idx.close();
@@ -39,8 +39,8 @@ describe('VectorIndex', () => {
 
   it('applies relative threshold', () => {
     const idx = new VectorIndex(dbPath, 3);
-    idx.upsert('close', [0.9, 0.1, 0.0], { type: 'memory' });
-    idx.upsert('far', [0.0, 0.0, 1.0], { type: 'memory' });
+    idx.upsert('close', [0.9, 0.1, 0.0], { type: 'spore' });
+    idx.upsert('far', [0.0, 0.0, 1.0], { type: 'spore' });
 
     // With a high relative threshold, only results near the top score survive
     const results = idx.search([1.0, 0.0, 0.0], { limit: 5, relativeThreshold: 0.8 });
@@ -52,8 +52,8 @@ describe('VectorIndex', () => {
 
   it('upserts existing id', () => {
     const idx = new VectorIndex(dbPath, 3);
-    idx.upsert('mem-1', [0.1, 0.2, 0.3], { type: 'memory' });
-    idx.upsert('mem-1', [0.4, 0.5, 0.6], { type: 'memory' });
+    idx.upsert('mem-1', [0.1, 0.2, 0.3], { type: 'spore' });
+    idx.upsert('mem-1', [0.4, 0.5, 0.6], { type: 'spore' });
 
     expect(idx.count()).toBe(1);
     idx.close();

--- a/tests/intelligence/response.test.ts
+++ b/tests/intelligence/response.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { stripReasoningTokens, extractJson } from '@myco/intelligence/response';
+
+describe('stripReasoningTokens', () => {
+  it('strips <think>...</think> tags (DeepSeek pattern)', () => {
+    const input = '<think>\nLet me think about this carefully.\n</think>\nThe answer is 42.';
+    expect(stripReasoningTokens(input)).toBe('The answer is 42.');
+  });
+
+  it('strips implicit </think> (GLM pattern: text starts mid-thinking, ends with </think>)', () => {
+    const input = 'I am reasoning through this...\n</think>\nFinal answer here.';
+    expect(stripReasoningTokens(input)).toBe('Final answer here.');
+  });
+
+  it('strips <reasoning>...</reasoning> tags', () => {
+    const input = '<reasoning>\nThis is my chain of thought.\n</reasoning>\nConclusion reached.';
+    expect(stripReasoningTokens(input)).toBe('Conclusion reached.');
+  });
+
+  it('strips <|thinking|>...<|/thinking|> tags', () => {
+    const input = '<|thinking|>\nStep 1: consider options.\nStep 2: decide.\n<|/thinking|>\nResult: option A.';
+    expect(stripReasoningTokens(input)).toBe('Result: option A.');
+  });
+
+  it('strips "Thinking Process:" plain text block followed by ## heading (Qwen 3.5 pattern)', () => {
+    const input = 'Thinking Process:\n1. Consider the request.\n2. Formulate a response.\n\n## Answer\nHere is the answer.';
+    const result = stripReasoningTokens(input);
+    expect(result).toContain('## Answer');
+    expect(result).not.toContain('Thinking Process:');
+  });
+
+  it('returns original text when no reasoning tokens present', () => {
+    const input = 'This is a plain response with no reasoning tags.';
+    expect(stripReasoningTokens(input)).toBe(input);
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(stripReasoningTokens('')).toBe('');
+  });
+
+  it('handles multiline think blocks with nested content', () => {
+    const input = '<think>\nLet me consider:\n- point A\n- point B\n\nFinal thought.\n</think>\nDone.';
+    expect(stripReasoningTokens(input)).toBe('Done.');
+  });
+});
+
+describe('extractJson', () => {
+  it('extracts JSON from ```json fences', () => {
+    const input = 'Here is the result:\n```json\n{"key": "value", "count": 3}\n```\nDone.';
+    const result = extractJson(input) as Record<string, unknown>;
+    expect(result.key).toBe('value');
+    expect(result.count).toBe(3);
+  });
+
+  it('extracts JSON from plain ``` fences without language tag', () => {
+    const input = '```\n{"type": "spore"}\n```';
+    const result = extractJson(input) as Record<string, unknown>;
+    expect(result.type).toBe('spore');
+  });
+
+  it('extracts bare JSON object without fences', () => {
+    const input = 'Some preamble text.\n{"observation": "found bug", "severity": 2}\nSome trailing text.';
+    const result = extractJson(input) as Record<string, unknown>;
+    expect(result.observation).toBe('found bug');
+    expect(result.severity).toBe(2);
+  });
+
+  it('strips reasoning tokens before extracting JSON', () => {
+    const input = '<think>\nLet me format the output.\n</think>\n```json\n{"type": "decision"}\n```';
+    const result = extractJson(input) as Record<string, unknown>;
+    expect(result.type).toBe('decision');
+  });
+
+  it('handles malformed JSON gracefully by throwing a SyntaxError', () => {
+    const input = '{"broken": json here}';
+    expect(() => extractJson(input)).toThrow(SyntaxError);
+  });
+
+  it('extracts JSON with nested objects', () => {
+    const input = '```json\n{"outer": {"inner": true, "count": 5}}\n```';
+    const result = extractJson(input) as Record<string, Record<string, unknown>>;
+    expect(result.outer.inner).toBe(true);
+    expect(result.outer.count).toBe(5);
+  });
+
+  it('extracts JSON array from fences', () => {
+    const input = '```json\n[1, 2, 3]\n```';
+    const result = extractJson(input) as number[];
+    expect(result).toEqual([1, 2, 3]);
+  });
+});

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -15,7 +15,7 @@ describe('MCP Server', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('creates server with all 11 tools registered', () => {
+  it('creates server with all 12 tools registered', () => {
     const server = createMycoServer({ vaultDir: tmpDir });
     const tools = server.getRegisteredTools();
     expect(tools).toContain('myco_search');
@@ -29,7 +29,8 @@ describe('MCP Server', () => {
     expect(tools).toContain('myco_logs');
     expect(tools).toContain('myco_supersede');
     expect(tools).toContain('myco_consolidate');
-    expect(tools).toHaveLength(11);
+    expect(tools).toContain('myco_context');
+    expect(tools).toHaveLength(12);
   });
 
   it('exports server name and version', () => {

--- a/tests/mcp/tools/context.test.ts
+++ b/tests/mcp/tools/context.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { handleMycoContext } from '@myco/mcp/tools/context';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+function writeExtract(digestDir: string, tier: number, body: string): void {
+  fs.mkdirSync(digestDir, { recursive: true });
+  const content = `---
+type: "extract"
+tier: ${tier}
+generated: "2026-03-19T10:00:00.000Z"
+cycle_id: "test-cycle"
+substrate_count: 5
+model: "test-model"
+---
+
+${body}
+`;
+  fs.writeFileSync(path.join(digestDir, `extract-${tier}.md`), content);
+}
+
+describe('myco_context', () => {
+  let tmpDir: string;
+  let digestDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-context-'));
+    digestDir = path.join(tmpDir, 'digest');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns extract for requested tier', () => {
+    writeExtract(digestDir, 3000, 'Project synthesis at 3000 tokens.');
+
+    const result = handleMycoContext(tmpDir, { tier: 3000 });
+
+    expect(result.tier).toBe(3000);
+    expect(result.fallback).toBe(false);
+    expect(result.content).toBe('Project synthesis at 3000 tokens.');
+    expect(result.generated).toBe('2026-03-19T10:00:00.000Z');
+  });
+
+  it('falls back to nearest tier when requested unavailable', () => {
+    writeExtract(digestDir, 1500, 'Executive briefing.');
+    writeExtract(digestDir, 5000, 'Deep onboarding.');
+
+    const result = handleMycoContext(tmpDir, { tier: 3000 });
+
+    // 1500 is distance 1500, 5000 is distance 2000 — should pick 1500
+    expect(result.tier).toBe(1500);
+    expect(result.fallback).toBe(true);
+    expect(result.content).toBe('Executive briefing.');
+  });
+
+  it('returns not-ready message when no extracts exist', () => {
+    const result = handleMycoContext(tmpDir, { tier: 3000 });
+
+    expect(result.tier).toBe(3000);
+    expect(result.fallback).toBe(false);
+    expect(result.content).toContain('not yet available');
+    expect(result.generated).toBeUndefined();
+  });
+
+  it('defaults to tier 3000 when no tier specified', () => {
+    writeExtract(digestDir, 3000, 'Default tier content.');
+
+    const result = handleMycoContext(tmpDir, {});
+
+    expect(result.tier).toBe(3000);
+    expect(result.content).toBe('Default tier content.');
+  });
+
+  it('returns exact tier over nearest when both exist', () => {
+    writeExtract(digestDir, 3000, 'Exact match.');
+    writeExtract(digestDir, 5000, 'Larger tier.');
+
+    const result = handleMycoContext(tmpDir, { tier: 3000 });
+
+    expect(result.tier).toBe(3000);
+    expect(result.fallback).toBe(false);
+    expect(result.content).toBe('Exact match.');
+  });
+});

--- a/tests/mcp/tools/graph.test.ts
+++ b/tests/mcp/tools/graph.test.ts
@@ -19,28 +19,28 @@ describe('myco_graph', () => {
       type: 'session',
       id: 'session-abc',
       title: 'Auth Refactor',
-      content: '# Auth Refactor\n\nSession:: [[session-abc]]\n\n## Related Memories\n- [[gotcha-abc-123|CORS issue]]',
+      content: '# Auth Refactor\n\nSession:: [[session-abc]]\n\n## Related Spores\n- [[gotcha-abc-123|CORS issue]]',
       frontmatter: { type: 'session', id: 'session-abc' },
       created: '2026-03-13T10:00:00Z',
     });
 
     index.upsertNote({
-      path: 'memories/gotcha-abc-123.md',
-      type: 'memory',
+      path: 'spores/gotcha-abc-123.md',
+      type: 'spore',
       id: 'gotcha-abc-123',
       title: 'CORS issue',
       content: '# CORS issue\n\nSession:: [[session-abc]]',
-      frontmatter: { type: 'memory', id: 'gotcha-abc-123', session: 'session-abc' },
+      frontmatter: { type: 'spore', id: 'gotcha-abc-123', session: 'session-abc' },
       created: '2026-03-13T10:05:00Z',
     });
 
     index.upsertNote({
-      path: 'memories/decision-xyz-456.md',
-      type: 'memory',
+      path: 'spores/decision-xyz-456.md',
+      type: 'spore',
       id: 'decision-xyz-456',
       title: 'Chose RS256',
       content: '# Chose RS256\n\nNo wikilinks here.',
-      frontmatter: { type: 'memory', id: 'decision-xyz-456' },
+      frontmatter: { type: 'spore', id: 'decision-xyz-456' },
       created: '2026-03-13T10:10:00Z',
     });
   });
@@ -98,22 +98,22 @@ describe('myco_orphans', () => {
     });
 
     index.upsertNote({
-      path: 'memories/gotcha-abc.md',
-      type: 'memory',
+      path: 'spores/gotcha-abc.md',
+      type: 'spore',
       id: 'gotcha-abc',
       title: 'CORS',
       content: '# CORS\n\nSession:: [[session-abc]]',
-      frontmatter: { type: 'memory', id: 'gotcha-abc', session: 'session-abc' },
+      frontmatter: { type: 'spore', id: 'gotcha-abc', session: 'session-abc' },
       created: '2026-03-13T10:05:00Z',
     });
 
     index.upsertNote({
-      path: 'memories/orphan-note.md',
-      type: 'memory',
+      path: 'spores/orphan-note.md',
+      type: 'spore',
       id: 'orphan-note',
       title: 'Orphan',
       content: '# Orphan\n\nNo links at all.',
-      frontmatter: { type: 'memory', id: 'orphan-note' },
+      frontmatter: { type: 'spore', id: 'orphan-note' },
       created: '2026-03-13T10:10:00Z',
     });
   });

--- a/tests/mcp/tools/remember.test.ts
+++ b/tests/mcp/tools/remember.test.ts
@@ -21,20 +21,20 @@ describe('myco_remember', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('creates a memory note and indexes it', async () => {
+  it('creates a spore note and indexes it', async () => {
     const result = await handleMycoRemember(tmpDir, index, {
       content: 'CORS proxy strips auth headers',
       type: 'gotcha',
       tags: ['cors', 'auth'],
     });
 
-    expect(result.note_path).toContain('memories/');
+    expect(result.note_path).toContain('spores/');
     expect(result.id).toContain('gotcha-');
 
     // Verify it was indexed
     const note = index.getNoteByPath(result.note_path);
     expect(note).toBeTruthy();
-    expect(note!.type).toBe('memory');
+    expect(note!.type).toBe('spore');
   });
 
   it('links to a related plan', async () => {
@@ -103,6 +103,6 @@ describe('myco_remember', () => {
     });
 
     expect(result.session).toBeUndefined();
-    expect(result.note_path).toContain('memories/');
+    expect(result.note_path).toContain('spores/');
   });
 });

--- a/tests/mcp/tools/search.test.ts
+++ b/tests/mcp/tools/search.test.ts
@@ -23,10 +23,10 @@ describe('myco_search', () => {
       created: '2026-03-12T09:00:00Z',
     });
     index.upsertNote({
-      path: 'memories/m1.md', type: 'memory', id: 'm1',
+      path: 'spores/m1.md', type: 'spore', id: 'm1',
       title: 'CORS Proxy Gotcha',
       content: 'The CORS proxy strips auth headers silently.',
-      frontmatter: { type: 'memory', id: 'm1', observation_type: 'gotcha' },
+      frontmatter: { type: 'spore', id: 'm1', observation_type: 'gotcha' },
       created: '2026-03-12T10:00:00Z',
     });
   });
@@ -42,8 +42,8 @@ describe('myco_search', () => {
   });
 
   it('filters by type', async () => {
-    const results = await handleMycoSearch(index, { query: 'auth', type: 'memory' });
-    expect(results.every((r) => r.type === 'memory')).toBe(true);
+    const results = await handleMycoSearch(index, { query: 'auth', type: 'spore' });
+    expect(results.every((r) => r.type === 'spore')).toBe(true);
   });
 
   it('respects limit', async () => {

--- a/tests/obsidian/formatter.test.ts
+++ b/tests/obsidian/formatter.test.ts
@@ -8,7 +8,7 @@ import {
   buildTags,
   footerTags,
   formatSessionBody,
-  formatMemoryBody,
+  formatSporeBody,
   formatPlanBody,
   formatTeamBody,
   formatArtifactBody,
@@ -89,13 +89,13 @@ describe('observationCalloutType', () => {
 
 describe('buildTags', () => {
   it('produces hierarchical tags', () => {
-    const tags = buildTags('memory', 'bug_fix', ['auth', 'jwt']);
-    expect(tags).toEqual(['type/memory', 'memory/bug-fix', 'auth', 'jwt']);
+    const tags = buildTags('spore', 'bug_fix', ['auth', 'jwt']);
+    expect(tags).toEqual(['type/spore', 'spore/bug-fix', 'auth', 'jwt']);
   });
 
   it('normalizes underscores to hyphens in subtype', () => {
-    const tags = buildTags('memory', 'trade_off');
-    expect(tags).toEqual(['type/memory', 'memory/trade-off']);
+    const tags = buildTags('spore', 'trade_off');
+    expect(tags).toEqual(['type/spore', 'spore/trade-off']);
   });
 
   it('deduplicates extra tags', () => {
@@ -104,8 +104,8 @@ describe('buildTags', () => {
   });
 
   it('strips # prefix from extra tags', () => {
-    const tags = buildTags('memory', 'gotcha', ['#auth']);
-    expect(tags).toEqual(['type/memory', 'memory/gotcha', 'auth']);
+    const tags = buildTags('spore', 'gotcha', ['#auth']);
+    expect(tags).toEqual(['type/spore', 'spore/gotcha', 'auth']);
   });
 
   it('skips empty subtype', () => {
@@ -157,7 +157,7 @@ describe('formatSessionBody', () => {
     expect(body).toContain('User:: chris');
     expect(body).toContain('Duration:: 1h 22m');
     expect(body).toContain('Branch:: `feat/auth`');
-    expect(body).toContain('## Related Memories');
+    expect(body).toContain('## Related Spores');
     expect(body).toContain('[[gotcha-c5220-123|Stop Hook Throws]]');
     expect(body).toContain('### Turn 1');
     expect(body).toContain('> [!user] Prompt');
@@ -199,14 +199,14 @@ describe('formatSessionBody', () => {
     expect(body).toContain('Session:: [[session-xyz]]');
     expect(body).not.toContain('Duration');
     expect(body).not.toContain('Branch');
-    expect(body).not.toContain('## Related Memories');
+    expect(body).not.toContain('## Related Spores');
     expect(body).not.toContain('## Conversation');
   });
 });
 
-describe('formatMemoryBody', () => {
-  it('produces memory body with typed callout', () => {
-    const body = formatMemoryBody({
+describe('formatSporeBody', () => {
+  it('produces spore body with typed callout', () => {
+    const body = formatSporeBody({
       title: 'RS256 over HS256',
       observationType: 'decision',
       content: 'Chose RS256 for key rotation.',
@@ -222,12 +222,12 @@ describe('formatMemoryBody', () => {
     expect(body).toContain('Observation:: decision');
     expect(body).toContain('## Rationale');
     expect(body).toContain('## Alternatives Rejected');
-    expect(body).toContain('#type/memory');
-    expect(body).toContain('#memory/decision');
+    expect(body).toContain('#type/spore');
+    expect(body).toContain('#spore/decision');
   });
 
   it('produces bug_fix body with root cause and fix sections', () => {
-    const body = formatMemoryBody({
+    const body = formatSporeBody({
       title: 'NPE in stop hook',
       observationType: 'bug_fix',
       content: 'Null check missing.',
@@ -241,7 +241,7 @@ describe('formatMemoryBody', () => {
   });
 
   it('produces trade_off body with gained/sacrificed', () => {
-    const body = formatMemoryBody({
+    const body = formatSporeBody({
       title: 'Dropped SQLite for FTS',
       observationType: 'trade_off',
       content: 'Simplified index.',
@@ -255,7 +255,7 @@ describe('formatMemoryBody', () => {
   });
 
   it('handles missing optional fields', () => {
-    const body = formatMemoryBody({
+    const body = formatSporeBody({
       title: 'Simple note',
       observationType: 'discovery',
       content: 'Found a thing.',
@@ -264,8 +264,8 @@ describe('formatMemoryBody', () => {
     expect(body).toContain('> [!tip] Discovery');
     expect(body).not.toContain('Session::');
     expect(body).not.toContain('## Root Cause');
-    expect(body).toContain('#type/memory');
-    expect(body).toContain('#memory/discovery');
+    expect(body).toContain('#type/spore');
+    expect(body).toContain('#spore/discovery');
   });
 });
 

--- a/tests/vault/frontmatter.test.ts
+++ b/tests/vault/frontmatter.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { stripFrontmatter } from '@myco/vault/frontmatter';
+
+describe('stripFrontmatter', () => {
+  it('strips YAML frontmatter and returns body and parsed frontmatter', () => {
+    const raw = '---\ntype: session\nid: abc123\n---\n\n# Session Title\n\nBody content here.';
+    const { body, frontmatter } = stripFrontmatter(raw);
+    expect(frontmatter.type).toBe('session');
+    expect(frontmatter.id).toBe('abc123');
+    expect(body).toContain('# Session Title');
+    expect(body).toContain('Body content here.');
+    expect(body).not.toContain('---');
+  });
+
+  it('returns raw text as body (trimmed) when no frontmatter is present', () => {
+    const raw = '# Just a heading\n\nSome content without frontmatter.';
+    const { body, frontmatter } = stripFrontmatter(raw);
+    expect(body).toBe(raw.trim());
+    expect(frontmatter).toEqual({});
+  });
+
+  it('handles malformed YAML gracefully by returning an empty frontmatter object', () => {
+    // YAML with a tab character causes a parse error
+    const raw = '---\nkey: : bad yaml ::\n\tanother: [unclosed\n---\n\nBody after bad frontmatter.';
+    const { body, frontmatter } = stripFrontmatter(raw);
+    expect(frontmatter).toEqual({});
+    expect(body).toContain('Body after bad frontmatter.');
+  });
+
+  it('handles empty content', () => {
+    const { body, frontmatter } = stripFrontmatter('');
+    expect(body).toBe('');
+    expect(frontmatter).toEqual({});
+  });
+
+  it('preserves body content exactly after frontmatter without extra trimming of internal whitespace', () => {
+    const bodyContent = '# Heading\n\nParagraph one.\n\nParagraph two.\n\n    indented block';
+    const raw = `---\ntype: spore\n---\n\n${bodyContent}`;
+    const { body } = stripFrontmatter(raw);
+    // The body should preserve all internal whitespace
+    expect(body).toContain('    indented block');
+    expect(body).toContain('Paragraph one.');
+    expect(body).toContain('Paragraph two.');
+  });
+
+  it('handles frontmatter with multiple field types', () => {
+    const raw = '---\ntitle: My Note\ncount: 42\nenabled: true\ntags:\n  - foo\n  - bar\n---\n\nContent.';
+    const { body, frontmatter } = stripFrontmatter(raw);
+    expect(frontmatter.title).toBe('My Note');
+    expect(frontmatter.count).toBe(42);
+    expect(frontmatter.enabled).toBe(true);
+    expect(frontmatter.tags).toEqual(['foo', 'bar']);
+    expect(body).toBe('Content.');
+  });
+
+  it('handles frontmatter with no body after it', () => {
+    const raw = '---\ntype: artifact\n---\n';
+    const { body, frontmatter } = stripFrontmatter(raw);
+    expect(frontmatter.type).toBe('artifact');
+    expect(body).toBe('');
+  });
+
+  it('does not treat a line starting with --- mid-document as frontmatter delimiter', () => {
+    // No opening --- at position 0, so the whole thing is treated as body
+    const raw = 'Some text\n---\ntype: not frontmatter\n---\nMore text.';
+    const { body, frontmatter } = stripFrontmatter(raw);
+    expect(frontmatter).toEqual({});
+    expect(body).toBe(raw.trim());
+  });
+});

--- a/tests/vault/observations.test.ts
+++ b/tests/vault/observations.test.ts
@@ -36,11 +36,11 @@ describe('writeObservationNotes', () => {
     const results = writeObservationNotes(observations, 'test-session', writer, index, vaultDir);
 
     expect(results).toHaveLength(1);
-    expect(results[0].path).toContain('memories/gotcha/');
+    expect(results[0].path).toContain('spores/gotcha/');
     expect(results[0].path).toContain('.md');
 
     const note = reader.readNote(results[0].path);
-    expect(note.frontmatter.type).toBe('memory');
+    expect(note.frontmatter.type).toBe('spore');
     expect(note.content).toContain('CORS Issue');
   });
 

--- a/tests/vault/reader.test.ts
+++ b/tests/vault/reader.test.ts
@@ -69,8 +69,8 @@ describe('VaultReader', () => {
     writeNote(vaultDir, 'sessions/2026-03-12/s.md', {
       type: 'session', id: 's', agent: 'claude-code', user: 'chris', started: '2026-03-12T09:00:00Z',
     }, '');
-    writeNote(vaultDir, 'memories/m.md', {
-      type: 'memory', id: 'm', observation_type: 'gotcha', created: '2026-03-12T10:00:00Z',
+    writeNote(vaultDir, 'spores/m.md', {
+      type: 'spore', id: 'm', observation_type: 'gotcha', created: '2026-03-12T10:00:00Z',
     }, '');
 
     const all = reader.readAllNotes();

--- a/tests/vault/types.test.ts
+++ b/tests/vault/types.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   SessionFrontmatterSchema,
   PlanFrontmatterSchema,
-  MemoryFrontmatterSchema,
+  SporeFrontmatterSchema,
   ArtifactFrontmatterSchema,
   TeamMemberFrontmatterSchema,
   parseNoteFrontmatter,
@@ -35,16 +35,16 @@ describe('Vault Note Types', () => {
     expect(result.success).toBe(true);
   });
 
-  it('validates memory frontmatter', () => {
+  it('validates spore frontmatter', () => {
     const fm = {
-      type: 'memory',
+      type: 'spore',
       id: 'gotcha-cors',
       observation_type: 'gotcha',
       session: '[[session-a1b2c3]]',
       created: '2026-03-12T10:00:00Z',
       tags: ['cors'],
     };
-    const result = MemoryFrontmatterSchema.safeParse(fm);
+    const result = SporeFrontmatterSchema.safeParse(fm);
     expect(result.success).toBe(true);
   });
 
@@ -86,16 +86,16 @@ describe('Vault Note Types', () => {
 
   it('accepts new observation types', () => {
     for (const type of ['gotcha', 'bug_fix', 'decision', 'discovery', 'trade_off']) {
-      const result = MemoryFrontmatterSchema.safeParse({
-        type: 'memory', id: 'test', observation_type: type, created: '2026-01-01',
+      const result = SporeFrontmatterSchema.safeParse({
+        type: 'spore', id: 'test', observation_type: type, created: '2026-01-01',
       });
       expect(result.success, `${type} should be valid`).toBe(true);
     }
   });
 
   it('accepts arbitrary observation types like cross-cutting', () => {
-    const result = MemoryFrontmatterSchema.safeParse({
-      type: 'memory', id: 'test', observation_type: 'cross-cutting', created: '2026-01-01',
+    const result = SporeFrontmatterSchema.safeParse({
+      type: 'spore', id: 'test', observation_type: 'cross-cutting', created: '2026-01-01',
     });
     expect(result.success).toBe(true);
   });

--- a/tests/vault/writer.test.ts
+++ b/tests/vault/writer.test.ts
@@ -64,8 +64,8 @@ describe('VaultWriter', () => {
     expect(tags).toContain('security');
   });
 
-  it('writes a memory note with hierarchical tags', () => {
-    const notePath = writer.writeMemory({
+  it('writes a spore note with hierarchical tags', () => {
+    const notePath = writer.writeSpore({
       id: 'gotcha-cors',
       observation_type: 'gotcha',
       session: 'session-abc123',
@@ -73,14 +73,14 @@ describe('VaultWriter', () => {
       content: '# CORS Gotcha\n\nProxy strips headers.',
     });
 
-    expect(notePath).toBe('memories/gotcha/gotcha-cors.md');
+    expect(notePath).toBe('spores/gotcha/gotcha-cors.md');
     const note = reader.readNote(notePath);
-    expect(note.frontmatter.type).toBe('memory');
+    expect(note.frontmatter.type).toBe('spore');
     expect((note.frontmatter as any).observation_type).toBe('gotcha');
     expect((note.frontmatter as any).session).toBe('session-abc123');
     const tags = (note.frontmatter as any).tags as string[];
-    expect(tags).toContain('type/memory');
-    expect(tags).toContain('memory/gotcha');
+    expect(tags).toContain('type/spore');
+    expect(tags).toContain('spore/gotcha');
     expect(tags).toContain('cors');
   });
 


### PR DESCRIPTION
## Summary

This pull request introduces a major update to Myco's documentation and onboarding flow, focusing on the new "digest" engine for continuous reasoning and context synthesis. It also standardizes terminology, replacing "memory" with "spore" throughout, and updates recommended LLM models to prioritize Qwen 3.5 for improved extraction and digest quality. The onboarding and status commands are expanded to guide users through digest configuration and to report digest health. These changes clarify system architecture, improve user guidance, and ensure documentation reflects the latest features.

**Digest engine integration and documentation:**

* Added detailed explanation of the digest engine, its purpose, tiers, and integration as a daemon task. Provided a glossary for new terminology and updated vault structure to include `digest/` and `spores/` directories. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L46-R46) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R68) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L113-R131) [[4]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L128-R147)
* Expanded CLI onboarding (`init.md`, `setup-llm.md`) to include digest configuration, RAM-based tier recommendations, and user options for enabling, customizing, or disabling digest. Digest settings are now shown in the setup summary table. [[1]](diffhunk://#diff-7528de41e7db58db3e60d449ef4ddea402a6de7c8f31facf87e47e46cfba33e3L63-R89) [[2]](diffhunk://#diff-7528de41e7db58db3e60d449ef4ddea402a6de7c8f31facf87e47e46cfba33e3L80-R108) [[3]](diffhunk://#diff-7528de41e7db58db3e60d449ef4ddea402a6de7c8f31facf87e47e46cfba33e3R127-R129) [[4]](diffhunk://#diff-34952ae7789968ea9db145ee880485be476e7f63f0d707a2858a8d353fecd363L84-R136)

**Terminology updates ("memory" → "spore"):**

* Replaced all references to "memory" with "spore" in documentation, vault structure, and status reporting. Updated file naming, breakdowns, and session linkage descriptions. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L78-R79) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L92-R93) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L113-R131) [[4]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L128-R147) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R40-R67) [[6]](diffhunk://#diff-f6e51484a884cf7f809905c482611fc8ae02a288bdc12dce98b2f68bab584db7L42-R67) [[7]](diffhunk://#diff-f6e51484a884cf7f809905c482611fc8ae02a288bdc12dce98b2f68bab584db7L66-R82)

**LLM model recommendations and onboarding improvements:**

* Updated recommended summarization and extraction models in onboarding flow to prioritize Qwen 3.5 for its superior instruction-following and synthesis quality, with RAM-based tier guidance. [[1]](diffhunk://#diff-7528de41e7db58db3e60d449ef4ddea402a6de7c8f31facf87e47e46cfba33e3L41-R43) [[2]](diffhunk://#diff-34952ae7789968ea9db145ee880485be476e7f63f0d707a2858a8d353fecd363L32-R48)

**Status command enhancements:**

* Expanded `status.md` to report digest system health, including enabled state, tier extracts, last cycle details, metabolism, and digest model inheritance. Updated session activity reporting to use "spores" instead of "memories". [[1]](diffhunk://#diff-f6e51484a884cf7f809905c482611fc8ae02a288bdc12dce98b2f68bab584db7L42-R67) [[2]](diffhunk://#diff-f6e51484a884cf7f809905c482611fc8ae02a288bdc12dce98b2f68bab584db7L66-R82)

**Architecture and onboarding clarifications:**

* Clarified daemon authority and task separation, emphasizing that digest is a daemon task (not a hook or MCP server), and updated onboarding flow to reflect new digest options and summary reporting. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R68) [[2]](diffhunk://#diff-7528de41e7db58db3e60d449ef4ddea402a6de7c8f31facf87e47e46cfba33e3L63-R89) [[3]](diffhunk://#diff-7528de41e7db58db3e60d449ef4ddea402a6de7c8f31facf87e47e46cfba33e3L80-R108) [[4]](diffhunk://#diff-7528de41e7db58db3e60d449ef4ddea402a6de7c8f31facf87e47e46cfba33e3R127-R129) [[5]](diffhunk://#diff-34952ae7789968ea9db145ee880485be476e7f63f0d707a2858a8d353fecd363L84-R136)

## Related Issues

- Closes #
- Related #

## Change Type

- [x] Bug fix
- [x] Enhancement / new feature
- [x] Refactor / code quality
- [x] Documentation
- [ ] CI / workflow

## Validation

```bash
make check    # lint + 266 tests
```

## Checklist

- [x] `make check` passes locally
- [x] Tests added or updated where behavior changed
- [x] Docs updated for user-visible changes
- [x] No magic literals introduced (named constants in `src/constants.ts`)
