### PR TITLE
feat: add vault migration system and memories→spores runtime migration

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import YAML from 'yaml';
 import { MycoConfigSchema, type MycoConfig } from './schema.js';
+import { runMigrations, CURRENT_MIGRATION_VERSION } from './migrations.js';
 
 const CONFIG_FILENAME = 'myco.yaml';
 
@@ -29,25 +30,22 @@ export function loadConfig(vaultDir: string): MycoConfig {
     llm.provider = 'anthropic';
   }
 
-  // Auto-migrate context.layers.memories → context.layers.spores
-  const context = parsed.context as Record<string, unknown> | undefined;
-  const layers = context?.layers as Record<string, unknown> | undefined;
-  if (layers && 'memories' in layers && !('spores' in layers)) {
-    layers.spores = layers.memories;
-    delete layers.memories;
-    // Write the migrated config back so the user sees the updated key
-    fs.writeFileSync(configPath, YAML.stringify(parsed), 'utf-8');
-  }
+  // Run numbered migrations
+  const migrationsRan = runMigrations(parsed, vaultDir, (msg) => {
+    // Log to stderr since this runs during config loading (before logger is available)
+    process.stderr.write(`[myco migration] ${msg}\n`);
+  });
 
-  // Parse with Zod to fill in any missing defaults (new config sections like digest, capture tokens)
+  // Parse with Zod to fill in defaults for new config sections
   const config = MycoConfigSchema.parse(parsed);
 
-  // Write back if Zod added defaults that weren't in the original file
-  // This ensures new config sections (digest, capture token limits) are visible to the user
-  const fullConfig = JSON.parse(JSON.stringify(config)) as Record<string, unknown>;
-  const originalKeys = Object.keys(parsed);
-  const fullKeys = Object.keys(fullConfig);
-  if (fullKeys.length > originalKeys.length || !originalKeys.includes('digest')) {
+  // Write back if migrations ran or new defaults were added
+  const needsWrite = migrationsRan
+    || (parsed.config_version as number ?? 0) < CURRENT_MIGRATION_VERSION
+    || !('digest' in parsed);
+
+  if (needsWrite) {
+    const fullConfig = JSON.parse(JSON.stringify(config)) as Record<string, unknown>;
     fs.writeFileSync(configPath, YAML.stringify(fullConfig), 'utf-8');
   }
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -29,7 +29,29 @@ export function loadConfig(vaultDir: string): MycoConfig {
     llm.provider = 'anthropic';
   }
 
-  return MycoConfigSchema.parse(parsed);
+  // Auto-migrate context.layers.memories → context.layers.spores
+  const context = parsed.context as Record<string, unknown> | undefined;
+  const layers = context?.layers as Record<string, unknown> | undefined;
+  if (layers && 'memories' in layers && !('spores' in layers)) {
+    layers.spores = layers.memories;
+    delete layers.memories;
+    // Write the migrated config back so the user sees the updated key
+    fs.writeFileSync(configPath, YAML.stringify(parsed), 'utf-8');
+  }
+
+  // Parse with Zod to fill in any missing defaults (new config sections like digest, capture tokens)
+  const config = MycoConfigSchema.parse(parsed);
+
+  // Write back if Zod added defaults that weren't in the original file
+  // This ensures new config sections (digest, capture token limits) are visible to the user
+  const fullConfig = JSON.parse(JSON.stringify(config)) as Record<string, unknown>;
+  const originalKeys = Object.keys(parsed);
+  const fullKeys = Object.keys(fullConfig);
+  if (fullKeys.length > originalKeys.length || !originalKeys.includes('digest')) {
+    fs.writeFileSync(configPath, YAML.stringify(fullConfig), 'utf-8');
+  }
+
+  return config;
 }
 
 export function saveConfig(vaultDir: string, config: MycoConfig): void {

--- a/src/config/migrations.ts
+++ b/src/config/migrations.ts
@@ -64,11 +64,11 @@ export const MIGRATIONS: Migration[] = [
         fs.renameSync(memoriesDir, sporesDir);
       }
 
-      // Update frontmatter type: memory → type: spore
-      const walk = (dir: string): void => {
+      // Update frontmatter type: memory → type: spore in migrated files
+      const walkUpdate = (dir: string): void => {
         for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
           const fullPath = path.join(dir, entry.name);
-          if (entry.isDirectory()) { walk(fullPath); continue; }
+          if (entry.isDirectory()) { walkUpdate(fullPath); continue; }
           if (!entry.name.endsWith('.md')) continue;
           const content = fs.readFileSync(fullPath, 'utf-8');
           if (content.includes('type: memory')) {
@@ -76,7 +76,22 @@ export const MIGRATIONS: Migration[] = [
           }
         }
       };
-      walk(sporesDir);
+      walkUpdate(sporesDir);
+
+      // Update wikilinks in ALL vault files: [[memories/...]] → [[spores/...]]
+      const walkLinks = (dir: string): void => {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          const fullPath = path.join(dir, entry.name);
+          if (entry.isDirectory()) { walkLinks(fullPath); continue; }
+          if (!entry.name.endsWith('.md')) continue;
+          const content = fs.readFileSync(fullPath, 'utf-8');
+          if (content.includes('memories/')) {
+            fs.writeFileSync(fullPath, content.replace(/memories\//g, 'spores/'));
+          }
+        }
+      };
+      // Walk the entire vault, not just spores/ — session notes reference memories/
+      walkLinks(vaultDir);
     },
   },
 ];

--- a/src/config/migrations.ts
+++ b/src/config/migrations.ts
@@ -1,0 +1,109 @@
+/**
+ * Config and vault migrations — run once per version, tracked by config_version.
+ *
+ * Each migration has a version number, a name, and a function that receives
+ * the raw parsed YAML doc and the vault directory. Migrations run in order
+ * and are skipped if config_version is already past them.
+ *
+ * To add a new migration:
+ * 1. Add an entry to MIGRATIONS with the next version number
+ * 2. Write the migrate function — it receives the mutable doc and vaultDir
+ * 3. The framework handles version tracking and writing the config back
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface Migration {
+  version: number;
+  name: string;
+  migrate: (doc: Record<string, unknown>, vaultDir: string) => void;
+}
+
+export const MIGRATIONS: Migration[] = [
+  {
+    version: 1,
+    name: 'rename-memories-to-spores-config',
+    migrate: (doc) => {
+      // Rename context.layers.memories → context.layers.spores
+      const context = doc.context as Record<string, unknown> | undefined;
+      const layers = context?.layers as Record<string, unknown> | undefined;
+      if (layers && 'memories' in layers && !('spores' in layers)) {
+        layers.spores = layers.memories;
+        delete layers.memories;
+      }
+    },
+  },
+  {
+    version: 2,
+    name: 'rename-memories-to-spores-vault',
+    migrate: (_, vaultDir) => {
+      // Rename memories/ directory to spores/, update frontmatter
+      const memoriesDir = path.join(vaultDir, 'memories');
+      const sporesDir = path.join(vaultDir, 'spores');
+
+      if (!fs.existsSync(memoriesDir)) return;
+
+      if (fs.existsSync(sporesDir)) {
+        // Both exist (interrupted migration) — merge remaining files
+        const moveRemaining = (srcDir: string, destDir: string): void => {
+          for (const entry of fs.readdirSync(srcDir, { withFileTypes: true })) {
+            const srcPath = path.join(srcDir, entry.name);
+            const destPath = path.join(destDir, entry.name);
+            if (entry.isDirectory()) {
+              if (!fs.existsSync(destPath)) fs.mkdirSync(destPath, { recursive: true });
+              moveRemaining(srcPath, destPath);
+            } else if (!fs.existsSync(destPath)) {
+              fs.renameSync(srcPath, destPath);
+            }
+          }
+        };
+        moveRemaining(memoriesDir, sporesDir);
+        fs.rmSync(memoriesDir, { recursive: true, force: true });
+      } else {
+        fs.renameSync(memoriesDir, sporesDir);
+      }
+
+      // Update frontmatter type: memory → type: spore
+      const walk = (dir: string): void => {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          const fullPath = path.join(dir, entry.name);
+          if (entry.isDirectory()) { walk(fullPath); continue; }
+          if (!entry.name.endsWith('.md')) continue;
+          const content = fs.readFileSync(fullPath, 'utf-8');
+          if (content.includes('type: memory')) {
+            fs.writeFileSync(fullPath, content.replace(/type: memory/g, 'type: spore'));
+          }
+        }
+      };
+      walk(sporesDir);
+    },
+  },
+];
+
+/** Current migration version — the highest version in MIGRATIONS. */
+export const CURRENT_MIGRATION_VERSION = MIGRATIONS[MIGRATIONS.length - 1]?.version ?? 0;
+
+/**
+ * Run all pending migrations on the raw config doc.
+ * Returns true if any migrations ran (caller should reindex).
+ */
+export function runMigrations(
+  doc: Record<string, unknown>,
+  vaultDir: string,
+  log?: (message: string) => void,
+): boolean {
+  const currentVersion = (doc.config_version as number) ?? 0;
+  let ran = false;
+
+  for (const migration of MIGRATIONS) {
+    if (migration.version <= currentVersion) continue;
+
+    log?.(`Running migration ${migration.version}: ${migration.name}`);
+    migration.migrate(doc, vaultDir);
+    doc.config_version = migration.version;
+    ran = true;
+  }
+
+  return ran;
+}

--- a/src/config/migrations.ts
+++ b/src/config/migrations.ts
@@ -20,25 +20,23 @@ export interface Migration {
   migrate: (doc: Record<string, unknown>, vaultDir: string) => void;
 }
 
+/** Regex matching both quoted and unquoted YAML: type: memory, type: "memory", type: 'memory' */
+const MEMORY_TYPE_PATTERN = /type:\s*["']?memory["']?/g;
+
 export const MIGRATIONS: Migration[] = [
   {
     version: 1,
-    name: 'rename-memories-to-spores-config',
-    migrate: (doc) => {
-      // Rename context.layers.memories → context.layers.spores
+    name: 'rename-memories-to-spores',
+    migrate: (doc, vaultDir) => {
+      // Config: rename context.layers.memories → context.layers.spores
       const context = doc.context as Record<string, unknown> | undefined;
       const layers = context?.layers as Record<string, unknown> | undefined;
       if (layers && 'memories' in layers && !('spores' in layers)) {
         layers.spores = layers.memories;
         delete layers.memories;
       }
-    },
-  },
-  {
-    version: 2,
-    name: 'rename-memories-to-spores-vault',
-    migrate: (_, vaultDir) => {
-      // Rename memories/ directory to spores/, update frontmatter
+
+      // Vault: rename memories/ directory → spores/
       const memoriesDir = path.join(vaultDir, 'memories');
       const sporesDir = path.join(vaultDir, 'spores');
 
@@ -64,18 +62,17 @@ export const MIGRATIONS: Migration[] = [
         fs.renameSync(memoriesDir, sporesDir);
       }
 
-      // Update frontmatter type: memory → type: spore in migrated files
-      // Handles both unquoted (type: memory) and quoted (type: "memory") YAML
-      const memoryPattern = /type:\s*["']?memory["']?/g;
+      // Update frontmatter type: memory → type: spore (handles quoted and unquoted)
       const walkUpdate = (dir: string): void => {
         for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
           const fullPath = path.join(dir, entry.name);
           if (entry.isDirectory()) { walkUpdate(fullPath); continue; }
           if (!entry.name.endsWith('.md')) continue;
           const content = fs.readFileSync(fullPath, 'utf-8');
-          if (memoryPattern.test(content)) {
-            memoryPattern.lastIndex = 0; // reset regex state
-            fs.writeFileSync(fullPath, content.replace(memoryPattern, 'type: spore'));
+          MEMORY_TYPE_PATTERN.lastIndex = 0;
+          if (MEMORY_TYPE_PATTERN.test(content)) {
+            MEMORY_TYPE_PATTERN.lastIndex = 0;
+            fs.writeFileSync(fullPath, content.replace(MEMORY_TYPE_PATTERN, 'type: spore'));
           }
         }
       };
@@ -93,33 +90,7 @@ export const MIGRATIONS: Migration[] = [
           }
         }
       };
-      // Walk the entire vault, not just spores/ — session notes reference memories/
       walkLinks(vaultDir);
-    },
-  },
-  {
-    version: 3,
-    name: 'fix-quoted-memory-type-in-spores',
-    migrate: (_, vaultDir) => {
-      // Migration 2 only matched unquoted type: memory but YAML files often
-      // have type: "memory" (quoted). Fix any remaining quoted references.
-      const sporesDir = path.join(vaultDir, 'spores');
-      if (!fs.existsSync(sporesDir)) return;
-
-      const memoryPattern = /type:\s*["']?memory["']?/g;
-      const walk = (dir: string): void => {
-        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-          const fullPath = path.join(dir, entry.name);
-          if (entry.isDirectory()) { walk(fullPath); continue; }
-          if (!entry.name.endsWith('.md')) continue;
-          const content = fs.readFileSync(fullPath, 'utf-8');
-          if (memoryPattern.test(content)) {
-            memoryPattern.lastIndex = 0;
-            fs.writeFileSync(fullPath, content.replace(memoryPattern, 'type: spore'));
-          }
-        }
-      };
-      walk(sporesDir);
     },
   },
 ];

--- a/src/config/migrations.ts
+++ b/src/config/migrations.ts
@@ -65,14 +65,17 @@ export const MIGRATIONS: Migration[] = [
       }
 
       // Update frontmatter type: memory → type: spore in migrated files
+      // Handles both unquoted (type: memory) and quoted (type: "memory") YAML
+      const memoryPattern = /type:\s*["']?memory["']?/g;
       const walkUpdate = (dir: string): void => {
         for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
           const fullPath = path.join(dir, entry.name);
           if (entry.isDirectory()) { walkUpdate(fullPath); continue; }
           if (!entry.name.endsWith('.md')) continue;
           const content = fs.readFileSync(fullPath, 'utf-8');
-          if (content.includes('type: memory')) {
-            fs.writeFileSync(fullPath, content.replace(/type: memory/g, 'type: spore'));
+          if (memoryPattern.test(content)) {
+            memoryPattern.lastIndex = 0; // reset regex state
+            fs.writeFileSync(fullPath, content.replace(memoryPattern, 'type: spore'));
           }
         }
       };
@@ -92,6 +95,31 @@ export const MIGRATIONS: Migration[] = [
       };
       // Walk the entire vault, not just spores/ — session notes reference memories/
       walkLinks(vaultDir);
+    },
+  },
+  {
+    version: 3,
+    name: 'fix-quoted-memory-type-in-spores',
+    migrate: (_, vaultDir) => {
+      // Migration 2 only matched unquoted type: memory but YAML files often
+      // have type: "memory" (quoted). Fix any remaining quoted references.
+      const sporesDir = path.join(vaultDir, 'spores');
+      if (!fs.existsSync(sporesDir)) return;
+
+      const memoryPattern = /type:\s*["']?memory["']?/g;
+      const walk = (dir: string): void => {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          const fullPath = path.join(dir, entry.name);
+          if (entry.isDirectory()) { walk(fullPath); continue; }
+          if (!entry.name.endsWith('.md')) continue;
+          const content = fs.readFileSync(fullPath, 'utf-8');
+          if (memoryPattern.test(content)) {
+            memoryPattern.lastIndex = 0;
+            fs.writeFileSync(fullPath, content.replace(memoryPattern, 'type: spore'));
+          }
+        }
+      };
+      walk(sporesDir);
     },
   },
 ];

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -93,6 +93,8 @@ const DigestSchema = z.object({
 
 export const MycoConfigSchema = z.object({
   version: z.literal(2),
+  /** Tracks which migrations have been applied. Managed automatically. */
+  config_version: z.number().int().nonnegative().default(0),
   intelligence: IntelligenceSchema.default(() => IntelligenceSchema.parse({})),
   daemon: DaemonSchema.default(() => DaemonSchema.parse({})),
   capture: CaptureSchema.default(() => CaptureSchema.parse({})),

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -274,6 +274,10 @@ export async function main(): Promise<void> {
   const memoriesMigrated = migrateMemoriesToSpores(vaultDir);
   if (memoriesMigrated > 0) {
     logger.info('daemon', 'Migrated memories to spores', { count: memoriesMigrated });
+    // Rebuild FTS index — type field changed from 'memory' to 'spore', paths changed
+    initFts(index);
+    rebuildIndex(index, vaultDir);
+    logger.info('daemon', 'Rebuilt index after memories→spores migration');
   }
 
   // Migrate flat spore files into type subdirectories

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -221,14 +221,9 @@ export async function main(): Promise<void> {
     }
   }
 
-  // If the index has stale 'memory' type entries, the vault was migrated
-  // to spores but the index wasn't rebuilt yet. Rebuild now.
-  const staleMemoryEntries = index.query({ type: 'memory' });
-  if (staleMemoryEntries.length > 0) {
-    logger.info('daemon', 'Rebuilding index after memories→spores migration', { staleEntries: staleMemoryEntries.length });
-    initFts(index);
-    rebuildIndex(index, vaultDir);
-  }
+  // Check for stale 'memory' type entries — migration happened but index wasn't rebuilt.
+  // Deferred to after server starts so it doesn't block the health check.
+  const needsMigrationReindex = index.query({ type: 'memory' }).length > 0;
 
   // Migrate flat spore files into type subdirectories
   const migrated = migrateSporeFiles(vaultDir);
@@ -948,6 +943,16 @@ export async function main(): Promise<void> {
 
   await server.start();
   logger.info('daemon', 'Daemon ready', { vault: vaultDir, port: server.port });
+
+  // Background reindex after migration — runs after server is healthy
+  if (needsMigrationReindex) {
+    setImmediate(() => {
+      logger.info('daemon', 'Rebuilding index after memories→spores migration (background)');
+      initFts(index);
+      rebuildIndex(index, vaultDir);
+      logger.info('daemon', 'Migration reindex complete');
+    });
+  }
 
   const shutdown = async (signal: string) => {
     logger.info('daemon', `${signal} received`);

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -108,6 +108,55 @@ async function captureArtifacts(
   }
 }
 
+/**
+ * Migrate memories/ directory to spores/ for vaults created before the rename.
+ * Renames directory, updates frontmatter type: memory → type: spore, reindexes.
+ */
+export function migrateMemoriesToSpores(vaultDir: string): number {
+  const memoriesDir = path.join(vaultDir, 'memories');
+  const sporesDir = path.join(vaultDir, 'spores');
+
+  if (!fs.existsSync(memoriesDir)) return 0;
+
+  if (fs.existsSync(sporesDir)) {
+    // Both exist (interrupted migration) — move remaining files from memories/ to spores/
+    const moveRemaining = (srcDir: string, destDir: string): void => {
+      for (const entry of fs.readdirSync(srcDir, { withFileTypes: true })) {
+        const srcPath = path.join(srcDir, entry.name);
+        const destPath = path.join(destDir, entry.name);
+        if (entry.isDirectory()) {
+          if (!fs.existsSync(destPath)) fs.mkdirSync(destPath, { recursive: true });
+          moveRemaining(srcPath, destPath);
+        } else if (!fs.existsSync(destPath)) {
+          fs.renameSync(srcPath, destPath);
+        }
+      }
+    };
+    moveRemaining(memoriesDir, sporesDir);
+    fs.rmSync(memoriesDir, { recursive: true, force: true });
+  } else {
+    fs.renameSync(memoriesDir, sporesDir);
+  }
+
+  // Update frontmatter type: memory → type: spore in all .md files
+  let count = 0;
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) { walk(fullPath); continue; }
+      if (!entry.name.endsWith('.md')) continue;
+      const content = fs.readFileSync(fullPath, 'utf-8');
+      if (content.includes('type: memory')) {
+        fs.writeFileSync(fullPath, content.replace(/type: memory/g, 'type: spore'));
+        count++;
+      }
+    }
+  };
+  walk(sporesDir);
+
+  return count;
+}
+
 export function migrateSporeFiles(vaultDir: string): number {
   const sporesDir = path.join(vaultDir, 'spores');
   if (!fs.existsSync(sporesDir)) return 0;
@@ -219,6 +268,12 @@ export async function main(): Promise<void> {
         logger.debug('daemon', 'Cleaned stale buffer', { file });
       }
     }
+  }
+
+  // Migrate memories/ → spores/ for vaults created before the rename
+  const memoriesMigrated = migrateMemoriesToSpores(vaultDir);
+  if (memoriesMigrated > 0) {
+    logger.info('daemon', 'Migrated memories to spores', { count: memoriesMigrated });
   }
 
   // Migrate flat spore files into type subdirectories

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -108,55 +108,6 @@ async function captureArtifacts(
   }
 }
 
-/**
- * Migrate memories/ directory to spores/ for vaults created before the rename.
- * Renames directory, updates frontmatter type: memory → type: spore, reindexes.
- */
-export function migrateMemoriesToSpores(vaultDir: string): number {
-  const memoriesDir = path.join(vaultDir, 'memories');
-  const sporesDir = path.join(vaultDir, 'spores');
-
-  if (!fs.existsSync(memoriesDir)) return 0;
-
-  if (fs.existsSync(sporesDir)) {
-    // Both exist (interrupted migration) — move remaining files from memories/ to spores/
-    const moveRemaining = (srcDir: string, destDir: string): void => {
-      for (const entry of fs.readdirSync(srcDir, { withFileTypes: true })) {
-        const srcPath = path.join(srcDir, entry.name);
-        const destPath = path.join(destDir, entry.name);
-        if (entry.isDirectory()) {
-          if (!fs.existsSync(destPath)) fs.mkdirSync(destPath, { recursive: true });
-          moveRemaining(srcPath, destPath);
-        } else if (!fs.existsSync(destPath)) {
-          fs.renameSync(srcPath, destPath);
-        }
-      }
-    };
-    moveRemaining(memoriesDir, sporesDir);
-    fs.rmSync(memoriesDir, { recursive: true, force: true });
-  } else {
-    fs.renameSync(memoriesDir, sporesDir);
-  }
-
-  // Update frontmatter type: memory → type: spore in all .md files
-  let count = 0;
-  const walk = (dir: string): void => {
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-      const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) { walk(fullPath); continue; }
-      if (!entry.name.endsWith('.md')) continue;
-      const content = fs.readFileSync(fullPath, 'utf-8');
-      if (content.includes('type: memory')) {
-        fs.writeFileSync(fullPath, content.replace(/type: memory/g, 'type: spore'));
-        count++;
-      }
-    }
-  };
-  walk(sporesDir);
-
-  return count;
-}
-
 export function migrateSporeFiles(vaultDir: string): number {
   const sporesDir = path.join(vaultDir, 'spores');
   if (!fs.existsSync(sporesDir)) return 0;
@@ -270,14 +221,13 @@ export async function main(): Promise<void> {
     }
   }
 
-  // Migrate memories/ → spores/ for vaults created before the rename
-  const memoriesMigrated = migrateMemoriesToSpores(vaultDir);
-  if (memoriesMigrated > 0) {
-    logger.info('daemon', 'Migrated memories to spores', { count: memoriesMigrated });
-    // Rebuild FTS index — type field changed from 'memory' to 'spore', paths changed
+  // If the index has stale 'memory' type entries, the vault was migrated
+  // to spores but the index wasn't rebuilt yet. Rebuild now.
+  const staleMemoryEntries = index.query({ type: 'memory' });
+  if (staleMemoryEntries.length > 0) {
+    logger.info('daemon', 'Rebuilding index after memories→spores migration', { staleEntries: staleMemoryEntries.length });
     initFts(index);
     rebuildIndex(index, vaultDir);
-    logger.info('daemon', 'Rebuilt index after memories→spores migration');
   }
 
   // Migrate flat spore files into type subdirectories

--- a/src/vault/types.ts
+++ b/src/vault/types.ts
@@ -101,7 +101,7 @@ export function parseNoteFrontmatter(data: Record<string, unknown>): NoteFrontma
   const type = data.type as string;
   const schema = schemasByType[type];
   if (!schema) {
-    throw new Error(`Unknown note type: ${type}`);
+    throw new Error(`Unknown note type: ${type}. Known types: ${Object.keys(schemasByType).join(', ')}`);
   }
   // gray-matter and YAML.parse return Date objects for ISO date strings.
   // Coerce them to strings before Zod validation.


### PR DESCRIPTION
## Summary

- Adds a numbered migration framework (`src/config/migrations.ts`) tracked by `config_version` in `myco.yaml`
- Implements the memories→spores vault migration: directory rename, frontmatter update (handles quoted YAML), wikilink update, config key rename
- Migration reindex runs in background after server starts (doesn't block health check)
- Improved `parseNoteFrontmatter` error message to list known types

## Test plan

- [x] `make check` passes (424 tests)
- [x] Migration runs correctly on dogfooding vault (488 spores migrated)
- [x] Idempotent — running on already-migrated vault is a no-op
- [x] `config_version` tracked correctly
- [x] Background reindex doesn't block daemon startup
- [ ] Test on unifi-mcp vault (publish + install required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)