### PR TITLE
fix: digest infinite loop, LM Studio instance management, daemon rest…

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ Commands:
   logs [options]           View daemon logs
   setup-llm [options]      Configure LLM and embedding providers
   setup-digest [options]   Configure digest and capture settings
+  digest [options]         Run a digest cycle (--tier N, --full)
   restart                  Restart the daemon
   rebuild                  Reindex the entire vault
   reprocess [options]      Re-extract observations and re-index sessions
@@ -56,6 +57,7 @@ async function main(): Promise<void> {
     case 'session': return (await import('./cli/session.js')).run(args, vaultDir);
     case 'setup-llm': return (await import('./cli/setup-llm.js')).run(args, vaultDir);
     case 'setup-digest': return (await import('./cli/setup-digest.js')).run(args, vaultDir);
+    case 'digest': return (await import('./cli/digest.js')).run(args, vaultDir);
     case 'restart': return (await import('./cli/restart.js')).run(args, vaultDir);
     case 'rebuild': return (await import('./cli/rebuild.js')).run(args, vaultDir);
     case 'reprocess': return (await import('./cli/reprocess.js')).run(args, vaultDir);

--- a/src/cli/digest.ts
+++ b/src/cli/digest.ts
@@ -1,0 +1,93 @@
+/**
+ * myco digest — run a digest cycle from the CLI.
+ *
+ * Usage:
+ *   myco digest              Incremental cycle (only new substrate)
+ *   myco digest --full       Full reprocess of all tiers from clean slate
+ *   myco digest --tier 3000  Reprocess a specific tier from clean slate
+ *
+ * When --tier or --full is used, the cycle processes ALL vault notes (not just
+ * new ones) and ignores previous extracts, producing a clean synthesis.
+ */
+import { loadConfig } from '../config/loader.js';
+import { MycoIndex } from '../index/sqlite.js';
+import { createLlmProvider } from '../intelligence/llm.js';
+import { DigestEngine } from '../daemon/digest.js';
+import type { DigestCycleOptions } from '../daemon/digest.js';
+import { parseIntFlag } from './shared.js';
+import path from 'node:path';
+
+export async function run(args: string[], vaultDir: string): Promise<void> {
+  const config = loadConfig(vaultDir);
+
+  if (!config.digest.enabled) {
+    console.error('Digest is not enabled. Set digest.enabled: true in myco.yaml.');
+    process.exit(1);
+  }
+
+  const tierArg = parseIntFlag(args, '--tier');
+  const isFull = args.includes('--full');
+  const isReprocess = isFull || tierArg !== undefined;
+
+  // Resolve the digest LLM provider
+  const digestLlmConfig = {
+    provider: config.digest.intelligence.provider ?? config.intelligence.llm.provider,
+    model: config.digest.intelligence.model ?? config.intelligence.llm.model,
+    base_url: config.digest.intelligence.base_url ?? config.intelligence.llm.base_url,
+    context_window: config.digest.intelligence.context_window,
+  };
+  const llmProvider = createLlmProvider(digestLlmConfig);
+
+  const index = new MycoIndex(path.join(vaultDir, 'index.db'));
+
+  const engine = new DigestEngine({
+    vaultDir,
+    index,
+    llmProvider,
+    config,
+    log: (level, message, data) => {
+      const prefix = level === 'warn' ? '⚠' : level === 'info' ? '→' : '  ';
+      const suffix = data ? ` ${JSON.stringify(data)}` : '';
+      console.log(`${prefix} ${message}${suffix}`);
+    },
+  });
+
+  const opts: DigestCycleOptions = {};
+  if (isReprocess) {
+    opts.fullReprocess = true;
+    opts.cleanSlate = true;
+  }
+  if (tierArg !== undefined) {
+    const eligible = engine.getEligibleTiers();
+    if (!eligible.includes(tierArg)) {
+      console.error(`Tier ${tierArg} is not eligible. Eligible tiers: [${eligible.join(', ')}]`);
+      index.close();
+      process.exit(1);
+    }
+    opts.tiers = [tierArg];
+  }
+
+  if (isReprocess) {
+    const tierLabel = tierArg ? `tier ${tierArg}` : 'all tiers';
+    console.log(`Full reprocess of ${tierLabel} — clean slate, all substrate`);
+  } else {
+    console.log('Running incremental digest cycle');
+  }
+
+  try {
+    const result = await engine.runCycle(opts);
+
+    if (!result) {
+      console.log('No substrate found — nothing to digest.');
+      return;
+    }
+
+    console.log(`\nDigest cycle complete:`);
+    console.log(`  Tiers generated: [${result.tiersGenerated.join(', ')}]`);
+    console.log(`  Substrate: ${Object.values(result.substrate).flat().length} notes`);
+    console.log(`  Duration: ${(result.durationMs / 1000).toFixed(1)}s`);
+    console.log(`  Model: ${result.model}`);
+  } finally {
+    index.close();
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -74,6 +74,10 @@ export const STALE_BUFFER_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 /** Retry delays for daemon health check (ms). */
 export const DAEMON_HEALTH_RETRY_DELAYS = [100, 200, 400, 800, 1500];
 
+/** Grace period after daemon.json is written before stale checks can trigger a restart (ms).
+ *  Prevents rapid restart loops from concurrent hooks or session reloads. */
+export const DAEMON_STALE_GRACE_PERIOD_MS = 60_000;
+
 // --- Slug limits ---
 /** Max length for slugified artifact IDs. */
 export const MAX_SLUG_LENGTH = 100;

--- a/src/daemon/digest.ts
+++ b/src/daemon/digest.ts
@@ -43,6 +43,15 @@ export interface DigestCycleResult {
 /** Simple log function signature for digest progress reporting. */
 export type DigestLogFn = (level: 'debug' | 'info' | 'warn', message: string, data?: Record<string, unknown>) => void;
 
+export interface DigestCycleOptions {
+  /** Process all substrate regardless of last cycle timestamp. */
+  fullReprocess?: boolean;
+  /** Only generate these tiers (default: all eligible). */
+  tiers?: number[];
+  /** Skip previous extract — start from clean slate. */
+  cleanSlate?: boolean;
+}
+
 export interface DigestEngineConfig {
   vaultDir: string;
   index: MycoIndex;
@@ -74,7 +83,6 @@ export class DigestEngine {
   private log: DigestLogFn;
   private lastCycleTimestampCache: string | null | undefined = undefined;
   private cycleInProgress = false;
-  private modelReady = false;
 
   constructor(engineConfig: DigestEngineConfig) {
     this.vaultDir = engineConfig.vaultDir;
@@ -241,7 +249,7 @@ export class DigestEngine {
    * Run a full digest cycle: discover substrate, generate extracts for each tier.
    * Returns the cycle result, or null if no substrate was found.
    */
-  async runCycle(): Promise<DigestCycleResult | null> {
+  async runCycle(opts?: DigestCycleOptions): Promise<DigestCycleResult | null> {
     if (this.cycleInProgress) {
       this.log('debug', 'Cycle already in progress — skipping');
       return null;
@@ -249,34 +257,41 @@ export class DigestEngine {
     this.cycleInProgress = true;
 
     try {
-      return await this.runCycleInternal();
+      return await this.runCycleInternal(opts);
     } finally {
       this.cycleInProgress = false;
     }
   }
 
-  private async runCycleInternal(): Promise<DigestCycleResult | null> {
-    // Ensure model is loaded with correct settings — one-time on first cycle
-    if (!this.modelReady && this.llm.ensureLoaded) {
+  private async runCycleInternal(opts?: DigestCycleOptions): Promise<DigestCycleResult | null> {
+    // Ensure model is loaded with correct settings every cycle.
+    // LM Studio's idle TTL can evict our instance between cycles — without
+    // re-running ensureLoaded, the auto-reloaded instance would use LM Studio's
+    // UI defaults (wrong KV cache setting). This is fast (~26ms) when the
+    // instance is still alive (just a getLoadedInstances check).
+    if (this.llm.ensureLoaded) {
       const { context_window: contextWindow, gpu_kv_cache: gpuKvCache } = this.config.digest.intelligence;
-      this.log('info', 'Loading digest model', { contextWindow, gpuKvCache });
+      this.log('debug', 'Verifying digest model', { contextWindow, gpuKvCache });
       await this.llm.ensureLoaded(contextWindow, gpuKvCache);
-      this.modelReady = true;
     }
 
     const startTime = Date.now();
-    const lastTimestamp = this.getLastCycleTimestamp();
+    const fullReprocess = opts?.fullReprocess ?? false;
+    const lastTimestamp = fullReprocess ? null : this.getLastCycleTimestamp();
     const substrate = this.discoverSubstrate(lastTimestamp);
 
-    this.log('debug', 'Discovering substrate', { lastTimestamp: lastTimestamp ?? 'cold start', substrateCount: substrate.length });
+    this.log('debug', 'Discovering substrate', { lastTimestamp: lastTimestamp ?? 'full reprocess', substrateCount: substrate.length });
     if (substrate.length === 0) {
       this.log('debug', 'No substrate found — skipping cycle');
       return null;
     }
 
-    this.log('info', `Starting digest cycle`, { substrateCount: substrate.length });
+    this.log('info', `Starting digest cycle`, { substrateCount: substrate.length, fullReprocess });
     const cycleId = crypto.randomUUID();
-    const eligibleTiers = this.getEligibleTiers();
+    const allEligible = this.getEligibleTiers();
+    const eligibleTiers = opts?.tiers
+      ? allEligible.filter((t) => opts.tiers!.includes(t))
+      : allEligible;
     this.log('debug', `Eligible tiers: [${eligibleTiers.join(', ')}]`);
     const tiersGenerated: number[] = [];
     let totalTokensUsed = 0;
@@ -304,11 +319,16 @@ export class DigestEngine {
       }
     }
 
+    // Record the cycle timestamp NOW, before tier processing. This ensures the
+    // timestamp advances even if LLM calls fail, preventing the same substrate
+    // from being rediscovered on every subsequent timer fire.
+    const cycleTimestamp = new Date().toISOString();
+
     const systemPrompt = loadPrompt('digest-system');
 
     for (const tier of eligibleTiers) {
       const tierPrompt = loadPrompt(`digest-${tier}`);
-      const previousExtract = this.readPreviousExtract(tier);
+      const previousExtract = opts?.cleanSlate ? null : this.readPreviousExtract(tier);
 
       // Calculate token budget for substrate:
       // (context_window * safety_margin) - output - system_prompt - tier_prompt - previous_extract
@@ -343,33 +363,37 @@ export class DigestEngine {
       const promptTokens = estimateTokens(systemPrompt + userPrompt);
       this.log('debug', `Tier ${tier}: sending LLM request`, { promptTokens, maxTokens: tier, substrateBudget });
 
-      const tierStart = Date.now();
-      const digestConfig = this.config.digest.intelligence;
-      const opts: LlmRequestOptions = {
-        maxTokens: tier,
-        timeoutMs: DIGEST_LLM_REQUEST_TIMEOUT_MS,
-        contextLength: contextWindow,
-        reasoning: 'off',
-        systemPrompt,
-        keepAlive: digestConfig.keep_alive ?? undefined,
-      };
-      const response = await this.llm.summarize(userPrompt, opts);
-      const tierDuration = Date.now() - tierStart;
+      try {
+        const tierStart = Date.now();
+        const digestConfig = this.config.digest.intelligence;
+        const opts: LlmRequestOptions = {
+          maxTokens: tier,
+          timeoutMs: DIGEST_LLM_REQUEST_TIMEOUT_MS,
+          contextLength: contextWindow,
+          reasoning: 'off',
+          systemPrompt,
+          keepAlive: digestConfig.keep_alive ?? undefined,
+        };
+        const response = await this.llm.summarize(userPrompt, opts);
+        const tierDuration = Date.now() - tierStart;
 
-      // Strip reasoning tokens if present (some models output chain-of-thought)
-      const extractText = stripReasoningTokens(response.text);
-      model = response.model;
-      const responseTokens = estimateTokens(extractText);
-      totalTokensUsed += promptTokens + responseTokens;
+        // Strip reasoning tokens if present (some models output chain-of-thought)
+        const extractText = stripReasoningTokens(response.text);
+        model = response.model;
+        const responseTokens = estimateTokens(extractText);
+        totalTokensUsed += promptTokens + responseTokens;
 
-      this.log('info', `Tier ${tier}: completed`, { durationMs: tierDuration, responseTokens, model: response.model });
-      this.writeExtract(tier, extractText, cycleId, response.model, substrate.length);
-      tiersGenerated.push(tier);
+        this.log('info', `Tier ${tier}: completed`, { durationMs: tierDuration, responseTokens, model: response.model });
+        this.writeExtract(tier, extractText, cycleId, response.model, substrate.length);
+        tiersGenerated.push(tier);
+      } catch (err) {
+        this.log('warn', `Tier ${tier}: failed`, { error: (err as Error).message });
+      }
     }
 
     const result: DigestCycleResult = {
       cycleId,
-      timestamp: new Date().toISOString(),
+      timestamp: cycleTimestamp,
       substrate: substrateIndex,
       tiersGenerated,
       model,

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -323,6 +323,7 @@ export async function main(): Promise<void> {
       })
       .catch((err) => {
         logger.warn('digest', 'Initial digest cycle failed', { error: (err as Error).message });
+        metabolism!.onEmptyCycle();
       });
 
     // Start metabolism timer

--- a/src/hooks/client.ts
+++ b/src/hooks/client.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
-import { DAEMON_CLIENT_TIMEOUT_MS, DAEMON_HEALTH_CHECK_TIMEOUT_MS, DAEMON_HEALTH_RETRY_DELAYS } from '../constants.js';
+import { DAEMON_CLIENT_TIMEOUT_MS, DAEMON_HEALTH_CHECK_TIMEOUT_MS, DAEMON_HEALTH_RETRY_DELAYS, DAEMON_STALE_GRACE_PERIOD_MS } from '../constants.js';
 import { AgentRegistry } from '../agents/registry.js';
 import { getPluginVersion } from '../version.js';
 
@@ -83,9 +83,17 @@ export class DaemonClient {
   /**
    * Check if the daemon is running a stale version.
    * Returns true if the daemon's version doesn't match the current plugin version.
+   * Skips the check if daemon.json was written recently (grace period) to prevent
+   * rapid restart loops from concurrent hooks or session reloads.
    */
   private async isStale(): Promise<boolean> {
     try {
+      const jsonPath = path.join(this.vaultDir, 'daemon.json');
+      const stat = fs.statSync(jsonPath);
+      if (Date.now() - stat.mtimeMs < DAEMON_STALE_GRACE_PERIOD_MS) {
+        return false;
+      }
+
       const info = this.readDaemonJson();
       if (!info) return false;
 
@@ -120,12 +128,16 @@ export class DaemonClient {
   }
 
   /**
-   * Ensure the daemon is running the current version. Spawns it if unhealthy
-   * or restarts it if the version is stale. Returns true if healthy after this call.
+   * Ensure the daemon is running. Spawns it if unhealthy.
+   * When checkStale is true (default), also restarts a healthy daemon if its
+   * version doesn't match the current plugin version. Use checkStale: false
+   * for hooks that just need the daemon alive (e.g., stop) without triggering
+   * version-driven restarts.
    */
-  async ensureRunning(): Promise<boolean> {
-    // Check if daemon is running but stale (version mismatch)
-    if (await this.isStale()) {
+  async ensureRunning(opts?: { checkStale?: boolean }): Promise<boolean> {
+    const checkStale = opts?.checkStale ?? true;
+
+    if (checkStale && await this.isStale()) {
       this.killDaemon();
       // Brief pause for port release
       await new Promise((r) => setTimeout(r, 200));

--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -17,7 +17,7 @@ async function main() {
     const config = loadConfig(VAULT_DIR);
     const client = new DaemonClient(VAULT_DIR);
 
-    await client.ensureRunning();
+    await client.ensureRunning({ checkStale: false });
 
     // Pass transcript_path and last_assistant_message from Claude Code.
     // These are provided by the hook system and eliminate the need to

--- a/src/intelligence/lm-studio.ts
+++ b/src/intelligence/lm-studio.ts
@@ -14,7 +14,6 @@ interface LmStudioConfig {
 // LM Studio API endpoints
 const ENDPOINT_CHAT = '/api/v1/chat';
 const ENDPOINT_MODELS_LOAD = '/api/v1/models/load';
-const ENDPOINT_MODELS_UNLOAD = '/api/v1/models/unload';
 const ENDPOINT_MODELS_LIST = '/v1/models';
 const ENDPOINT_MODELS_NATIVE = '/api/v1/models';
 const ENDPOINT_EMBEDDINGS = '/v1/embeddings';
@@ -41,7 +40,7 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
   readonly name = 'lm-studio';
   private baseUrl: string;
   private model: string;
-  private loadedInstanceId: string | null = null;
+  private instanceId: string | null = null;
   private contextWindow: number | undefined;
   private defaultMaxTokens: number;
 
@@ -54,25 +53,27 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
 
   /**
    * Generate text using LM Studio's native REST API (/api/v1/chat).
-   * Supports per-request context_length, reasoning control, and system_prompt.
+   * Routes to our specific instance by ID when available, with model name +
+   * context_length as fallback. This ensures correct routing when multiple
+   * daemons share the same LM Studio, and graceful degradation when our
+   * instance is evicted by idle TTL.
    */
   async summarize(prompt: string, opts?: LlmRequestOptions): Promise<LlmResponse> {
     const maxTokens = opts?.maxTokens ?? this.defaultMaxTokens;
+    const contextLength = opts?.contextLength ?? this.contextWindow;
 
     const body: Record<string, unknown> = {
-      model: this.loadedInstanceId ?? this.model,
+      model: this.instanceId ?? this.model,
       input: prompt,
       max_output_tokens: maxTokens,
       store: false,
     };
 
-    // Only set context_length if we haven't pre-loaded the model
-    // (pre-loaded models already have the correct context via ensureLoaded)
-    if (!this.loadedInstanceId) {
-      const contextLength = opts?.contextLength ?? this.contextWindow;
-      if (contextLength) {
-        body.context_length = contextLength;
-      }
+    // Always send context_length — even when routing by instance ID.
+    // If our instance was evicted and LM Studio auto-loads, this ensures
+    // the replacement gets the correct context window.
+    if (contextLength) {
+      body.context_length = contextLength;
     }
 
     // System prompt — sent separately from user content
@@ -94,6 +95,11 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
 
     if (!response.ok) {
       const errorBody = await response.text().catch(() => '');
+      // If our instance was evicted, clear the ID so ensureLoaded
+      // reloads on the next cycle instead of hitting a stale ID repeatedly
+      if (response.status === 404 && this.instanceId) {
+        this.instanceId = null;
+      }
       throw new Error(`LM Studio summarize failed: ${response.status} ${errorBody.slice(0, 500)}`);
     }
 
@@ -135,9 +141,13 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
 
   /**
    * Ensure a model instance is loaded with the desired settings.
-   * First checks for an existing compatible instance to reuse (prevents
-   * accumulation across daemon restarts), then loads a new one only if needed.
-   * Unloads incompatible instances of the same model to prevent resource exhaustion.
+   * Called every digest cycle (not cached) so it recovers from idle TTL eviction.
+   *
+   * The load API is necessary to control offload_kv_cache_to_gpu — a load-time
+   * setting that cannot be set per-request via the chat API.
+   *
+   * Multi-daemon safe: finds or loads our own compatible instance without
+   * touching instances from other daemons/projects. Routes by instance ID.
    */
   async ensureLoaded(contextLength?: number, gpuKvCache?: boolean): Promise<void> {
     const ctx = contextLength ?? this.contextWindow;
@@ -146,22 +156,17 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
     // Query native API for existing loaded instances of this model
     const instances = await this.getLoadedInstances();
 
-    // Check for a compatible instance we can reuse
+    // Look for a compatible instance we can reuse (ours or anyone's)
     for (const instance of instances) {
       const matchesContext = !ctx || instance.config.context_length === ctx;
       const matchesKvCache = instance.config.offload_kv_cache_to_gpu === kvCache;
       if (matchesContext && matchesKvCache) {
-        this.loadedInstanceId = instance.id;
-        // Unload any incompatible instances (best effort, don't block on failure)
-        await this.unloadIncompatibleInstances(instances, ctx, kvCache);
+        this.instanceId = instance.id;
         return;
       }
     }
 
-    // Unload incompatible instances before loading to free resources
-    await this.unloadIncompatibleInstances(instances, ctx, kvCache);
-
-    // No compatible instance found — load a new one
+    // No compatible instance — load our own (don't touch others)
     const body: Record<string, unknown> = {
       model: this.model,
       flash_attention: true,
@@ -183,11 +188,10 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
       throw new Error(`LM Studio model load failed: ${response.status} ${errorBody.slice(0, 200)}`);
     }
 
-    // Capture instance ID — LM Studio may return it under different field names
     const loadResult = await response.json() as Record<string, unknown>;
-    const instanceId = (loadResult.id ?? loadResult.instance_id ?? loadResult.model_instance_id) as string | undefined;
-    if (instanceId) {
-      this.loadedInstanceId = instanceId;
+    const id = (loadResult.instance_id ?? loadResult.id ?? loadResult.model_instance_id) as string | undefined;
+    if (id) {
+      this.instanceId = id;
     }
   }
 
@@ -207,33 +211,6 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
       return entry?.loaded_instances ?? [];
     } catch {
       return [];
-    }
-  }
-
-  /**
-   * Unload instances of this model that don't match the desired settings.
-   * Best-effort — failures are silently ignored to avoid blocking the load path.
-   */
-  private async unloadIncompatibleInstances(
-    instances: NativeLoadedInstance[],
-    contextLength: number | undefined,
-    gpuKvCache: boolean,
-  ): Promise<void> {
-    for (const instance of instances) {
-      const matchesContext = !contextLength || instance.config.context_length === contextLength;
-      const matchesKvCache = instance.config.offload_kv_cache_to_gpu === gpuKvCache;
-      if (!matchesContext || !matchesKvCache) {
-        try {
-          await fetch(`${this.baseUrl}${ENDPOINT_MODELS_UNLOAD}`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ model: instance.id }),
-            signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
-          });
-        } catch {
-          // Best effort — don't fail the load if cleanup fails
-        }
-      }
     }
   }
 

--- a/tests/daemon/digest.test.ts
+++ b/tests/daemon/digest.test.ts
@@ -631,6 +631,69 @@ describe('DigestEngine', () => {
       expect(fs.existsSync(path.join(vaultDir, 'digest', 'extract-3000.md'))).toBe(true);
     });
 
+    it('advances timestamp and records trace even when LLM fails', async () => {
+      const notes = [makeNote({ id: 's1', type: 'session' })];
+      const index = makeMockIndex(notes);
+      const llm = makeMockLlm();
+      (llm.summarize as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('model not found'));
+
+      const engine = new DigestEngine({
+        vaultDir,
+        index,
+        llmProvider: llm,
+        config: makeConfig({
+          tiers: [1500],
+          intelligence: { provider: null, model: null, base_url: null, context_window: 32768 },
+        }),
+      });
+
+      const result = await engine.runCycle();
+
+      // Cycle should still return a result (with no tiers generated)
+      expect(result).not.toBeNull();
+      expect(result!.tiersGenerated).toEqual([]);
+
+      // Trace should be written so the timestamp advances
+      const tracePath = path.join(vaultDir, 'digest', 'trace.jsonl');
+      expect(fs.existsSync(tracePath)).toBe(true);
+      const traceContent = fs.readFileSync(tracePath, 'utf-8').trim();
+      const traced = JSON.parse(traceContent);
+      expect(traced.cycleId).toBe(result!.cycleId);
+
+      // Subsequent getLastCycleTimestamp should return the new timestamp
+      expect(engine.getLastCycleTimestamp()).toBe(result!.timestamp);
+    });
+
+    it('completes successful tiers even when later tiers fail', async () => {
+      const notes = [makeNote({ id: 's1', type: 'session' })];
+      const index = makeMockIndex(notes);
+      const llm = makeMockLlm();
+      // First call succeeds, second fails
+      (llm.summarize as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ text: 'Good synthesis.', model: 'test-model' })
+        .mockRejectedValueOnce(new Error('context exceeded'));
+
+      const engine = new DigestEngine({
+        vaultDir,
+        index,
+        llmProvider: llm,
+        config: makeConfig({
+          tiers: [1500, 3000],
+          intelligence: { provider: null, model: null, base_url: null, context_window: 32768 },
+        }),
+      });
+
+      const result = await engine.runCycle();
+
+      expect(result).not.toBeNull();
+      expect(result!.tiersGenerated).toEqual([1500]);
+      // Tier 1500 extract should exist, tier 3000 should not
+      expect(fs.existsSync(path.join(vaultDir, 'digest', 'extract-1500.md'))).toBe(true);
+      expect(fs.existsSync(path.join(vaultDir, 'digest', 'extract-3000.md'))).toBe(false);
+      // Trace should still be written
+      expect(fs.existsSync(path.join(vaultDir, 'digest', 'trace.jsonl'))).toBe(true);
+    });
+
     it('tier gating: context_window 8192 produces only tier 1500', async () => {
       // 1500 needs 6500 (fits), 3000 needs 11500 (does not fit in 8192)
       const notes = [makeNote({ id: 's1', type: 'session', title: 'Auth work', content: 'Fixed auth.' })];

--- a/tests/intelligence/lm-studio.test.ts
+++ b/tests/intelligence/lm-studio.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { LmStudioBackend } from '@myco/intelligence/lm-studio';
+
+// --- Helpers ---
+
+/** Capture fetch calls and return canned responses. */
+function mockFetch(handlers: Record<string, (body: any) => unknown>) {
+  const calls: Array<{ url: string; method: string; body: any }> = [];
+
+  const mock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const urlStr = typeof url === 'string' ? url : url.toString();
+    const method = init?.method ?? 'GET';
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    calls.push({ url: urlStr, method, body });
+
+    for (const [pattern, handler] of Object.entries(handlers)) {
+      if (urlStr.includes(pattern)) {
+        const data = handler(body);
+        return new Response(JSON.stringify(data), { status: 200 });
+      }
+    }
+    return new Response('Not found', { status: 404 });
+  }) as unknown as typeof globalThis.fetch;
+
+  vi.stubGlobal('fetch', mock);
+  return { calls, mock };
+}
+
+function makeBackend(overrides: Record<string, unknown> = {}) {
+  return new LmStudioBackend({
+    model: 'test-model',
+    base_url: 'http://localhost:9999',
+    context_window: 65536,
+    max_tokens: 1024,
+    ...overrides,
+  });
+}
+
+// --- Tests ---
+
+describe('LmStudioBackend', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('summarize', () => {
+    it('always includes context_length in request body', async () => {
+      const { calls } = mockFetch({
+        '/api/v1/chat': () => ({
+          model_instance_id: 'test-model',
+          output: [{ type: 'message', content: 'response' }],
+        }),
+      });
+
+      const backend = makeBackend();
+      await backend.summarize('test prompt');
+
+      const chatCall = calls.find((c) => c.url.includes('/api/v1/chat'));
+      expect(chatCall).toBeDefined();
+      expect(chatCall!.body.context_length).toBe(65536);
+    });
+
+    it('uses per-request contextLength when provided', async () => {
+      const { calls } = mockFetch({
+        '/api/v1/chat': () => ({
+          model_instance_id: 'test-model',
+          output: [{ type: 'message', content: 'response' }],
+        }),
+      });
+
+      const backend = makeBackend();
+      await backend.summarize('test prompt', { contextLength: 32768 });
+
+      const chatCall = calls.find((c) => c.url.includes('/api/v1/chat'));
+      expect(chatCall!.body.context_length).toBe(32768);
+    });
+
+    it('routes by instance ID after ensureLoaded', async () => {
+      const { calls } = mockFetch({
+        '/api/v1/models/load': () => ({ instance_id: 'test-model:3', status: 'loaded' }),
+        '/api/v1/models': () => ({ models: [{ key: 'test-model', loaded_instances: [] }] }),
+        '/api/v1/chat': () => ({
+          model_instance_id: 'test-model:3',
+          output: [{ type: 'message', content: 'response' }],
+        }),
+      });
+
+      const backend = makeBackend();
+      await backend.ensureLoaded(65536, false);
+      await backend.summarize('test prompt');
+
+      const chatCall = calls.find((c) => c.url.includes('/api/v1/chat'));
+      expect(chatCall!.body.model).toBe('test-model:3');
+      // context_length still sent alongside instance ID
+      expect(chatCall!.body.context_length).toBe(65536);
+    });
+
+    it('falls back to model name when no instance ID', async () => {
+      const { calls } = mockFetch({
+        '/api/v1/chat': () => ({
+          model_instance_id: 'test-model',
+          output: [{ type: 'message', content: 'response' }],
+        }),
+      });
+
+      const backend = makeBackend();
+      // No ensureLoaded — instanceId is null
+      await backend.summarize('test prompt');
+
+      const chatCall = calls.find((c) => c.url.includes('/api/v1/chat'));
+      expect(chatCall!.body.model).toBe('test-model');
+    });
+
+    it('clears instance ID on 404 for self-healing', async () => {
+      mockFetch({
+        '/api/v1/models/load': () => ({ instance_id: 'test-model:3', status: 'loaded' }),
+        '/api/v1/models': () => ({ models: [{ key: 'test-model', loaded_instances: [] }] }),
+      });
+
+      const backend = makeBackend();
+      await backend.ensureLoaded(65536, false);
+
+      // Now mock a 404 on chat
+      vi.restoreAllMocks();
+      const { calls } = mockFetch({});
+      // No chat handler → returns 404
+
+      await expect(backend.summarize('test')).rejects.toThrow(/404/);
+
+      // Next summarize should use model name (instance ID was cleared)
+      vi.restoreAllMocks();
+      const round2 = mockFetch({
+        '/api/v1/chat': () => ({
+          model_instance_id: 'test-model',
+          output: [{ type: 'message', content: 'ok' }],
+        }),
+      });
+
+      await backend.summarize('test');
+      const chatCall = round2.calls.find((c) => c.url.includes('/api/v1/chat'));
+      expect(chatCall!.body.model).toBe('test-model');
+    });
+  });
+
+  describe('ensureLoaded', () => {
+    it('reuses compatible instance without loading', async () => {
+      const { calls } = mockFetch({
+        '/api/v1/models': () => ({
+          models: [{
+            key: 'test-model',
+            loaded_instances: [{
+              id: 'test-model:1',
+              config: { context_length: 65536, offload_kv_cache_to_gpu: false },
+            }],
+          }],
+        }),
+      });
+
+      const backend = makeBackend();
+      await backend.ensureLoaded(65536, false);
+
+      const loadCalls = calls.filter((c) => c.url.includes('/models/load'));
+      expect(loadCalls).toHaveLength(0);
+    });
+
+    it('loads new instance when none exist', async () => {
+      const { calls } = mockFetch({
+        '/api/v1/models/load': () => ({ instance_id: 'test-model:1', status: 'loaded' }),
+        '/api/v1/models': () => ({
+          models: [{ key: 'test-model', loaded_instances: [] }],
+        }),
+      });
+
+      const backend = makeBackend();
+      await backend.ensureLoaded(65536, false);
+
+      const loadCall = calls.find((c) => c.url.includes('/models/load'));
+      expect(loadCall).toBeDefined();
+      expect(loadCall!.body.model).toBe('test-model');
+      expect(loadCall!.body.context_length).toBe(65536);
+      expect(loadCall!.body.offload_kv_cache_to_gpu).toBe(false);
+    });
+
+    it('loads own instance without unloading incompatible ones', async () => {
+      const { calls } = mockFetch({
+        '/api/v1/models/load': () => ({ instance_id: 'test-model:3', status: 'loaded' }),
+        '/api/v1/models': () => ({
+          models: [{
+            key: 'test-model',
+            loaded_instances: [{
+              id: 'test-model:1',
+              config: { context_length: 32768, offload_kv_cache_to_gpu: true },
+            }],
+          }],
+        }),
+      });
+
+      const backend = makeBackend();
+      await backend.ensureLoaded(65536, false);
+
+      // Should NOT unload the other instance
+      const unloadCalls = calls.filter((c) => c.url.includes('/models/unload'));
+      expect(unloadCalls).toHaveLength(0);
+
+      // Should load our own
+      const loadCall = calls.find((c) => c.url.includes('/models/load'));
+      expect(loadCall).toBeDefined();
+      expect(loadCall!.body.offload_kv_cache_to_gpu).toBe(false);
+    });
+
+    it('captures instance ID from load response', async () => {
+      const { calls } = mockFetch({
+        '/api/v1/models/load': () => ({ instance_id: 'test-model:5', status: 'loaded' }),
+        '/api/v1/models': () => ({
+          models: [{ key: 'test-model', loaded_instances: [] }],
+        }),
+        '/api/v1/chat': () => ({
+          model_instance_id: 'test-model:5',
+          output: [{ type: 'message', content: 'ok' }],
+        }),
+      });
+
+      const backend = makeBackend();
+      await backend.ensureLoaded(65536, false);
+      await backend.summarize('test');
+
+      const chatCall = calls.find((c) => c.url.includes('/api/v1/chat'));
+      expect(chatCall!.body.model).toBe('test-model:5');
+    });
+
+    it('reuses compatible instance from another daemon', async () => {
+      const { calls } = mockFetch({
+        '/api/v1/models': () => ({
+          models: [{
+            key: 'test-model',
+            loaded_instances: [
+              {
+                id: 'test-model:1',
+                config: { context_length: 32768, offload_kv_cache_to_gpu: true },
+              },
+              {
+                id: 'test-model:2',
+                config: { context_length: 65536, offload_kv_cache_to_gpu: false },
+              },
+            ],
+          }],
+        }),
+      });
+
+      const backend = makeBackend();
+      await backend.ensureLoaded(65536, false);
+
+      // Should reuse :2 without loading or unloading
+      const loadCalls = calls.filter((c) => c.url.includes('/models/load'));
+      expect(loadCalls).toHaveLength(0);
+      const unloadCalls = calls.filter((c) => c.url.includes('/models/unload'));
+      expect(unloadCalls).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
Digest engine:
- Failed cycles now advance timestamp via per-tier try/catch, preventing infinite rediscovery of the same substrate
- ensureLoaded runs every cycle (removed modelReady gate) to recover from LM Studio idle TTL eviction
- Added DigestCycleOptions for full reprocess and per-tier clean-slate runs

LM Studio provider:
- Route by instance ID for multi-daemon coexistence, fall back to model name
- Always send context_length in chat requests (prevents wrong context after eviction)
- Clear instance ID on 404 for self-healing
- Fixed unload API field: instance_id not model (was silently failing)
- Removed destructive unloadAllInstances — never touch other daemons' instances

Daemon lifecycle:
- Initial cycle .catch() now calls onEmptyCycle() to back off properly
- Stop hook skips stale version checks (checkStale: false)
- 60-second grace period on stale checks prevents rapid restart loops

CLI:
- Added digest command: myco digest [--tier N] [--full] for on-demand digest cycles and clean-slate tier reprocessing

## Summary

This pull request introduces a new CLI command for running digest cycles, adds more flexible digest processing options, and improves the robustness and safety of daemon lifecycle management. The changes also enhance the LM Studio integration to better handle model instance eviction and multi-daemon scenarios.

**Digest CLI and Engine Enhancements:**

* Added a new `digest` command to the CLI, allowing users to run digest cycles with options for incremental, full, or tier-specific processing. (`src/cli.ts`, `src/cli/digest.ts`) [[1]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR23) [[2]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR60) [[3]](diffhunk://#diff-be2ac0272ed0b6323dffd179b503fb1e30d86dddf28625dacf8ccaa85de8a818R1-R93)
* Updated the `DigestEngine` to accept options for full reprocessing, tier selection, and clean slate operation, enabling more granular control over digest cycles. (`src/daemon/digest.ts`) [[1]](diffhunk://#diff-3e6571bd9d566feaf97da6af5c20cb20cc19febf29d75e3cf4360f2fb33003ceR46-R54) [[2]](diffhunk://#diff-3e6571bd9d566feaf97da6af5c20cb20cc19febf29d75e3cf4360f2fb33003ceL244-R294)
* Improved digest cycle logic: now records the cycle timestamp before tier processing to avoid rediscovering the same substrate on repeated cycles, and handles tier failures gracefully by logging warnings instead of aborting the cycle. (`src/daemon/digest.ts`) [[1]](diffhunk://#diff-3e6571bd9d566feaf97da6af5c20cb20cc19febf29d75e3cf4360f2fb33003ceR322-R331) [[2]](diffhunk://#diff-3e6571bd9d566feaf97da6af5c20cb20cc19febf29d75e3cf4360f2fb33003ceR366) [[3]](diffhunk://#diff-3e6571bd9d566feaf97da6af5c20cb20cc19febf29d75e3cf4360f2fb33003ceR389-R396)

**Daemon Lifecycle and Safety Improvements:**

* Introduced a grace period after writing `daemon.json` to prevent rapid restart loops from concurrent hooks or session reloads. This is enforced in stale version checks and daemon startup logic. (`src/constants.ts`, `src/hooks/client.ts`) [[1]](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199R77-R80) [[2]](diffhunk://#diff-8c32f86c76cc96f6741482bc7abdd807449f8f58ac52ebc872166dcb82bbe80fL4-R4) [[3]](diffhunk://#diff-8c32f86c76cc96f6741482bc7abdd807449f8f58ac52ebc872166dcb82bbe80fR86-R96)
* Refactored the daemon client to allow hooks to skip version-driven restarts when only daemon liveness is required, improving reliability for stop hooks and other operations. (`src/hooks/client.ts`, `src/hooks/stop.ts`) [[1]](diffhunk://#diff-8c32f86c76cc96f6741482bc7abdd807449f8f58ac52ebc872166dcb82bbe80fL123-R140) [[2]](diffhunk://#diff-e5ff86b9431ea379f8962a375cfdcca69195639dc2e34511f8a802aa27c3e0a1L20-R20)

**LM Studio Integration Robustness:**

* Enhanced LM Studio backend to always route requests by instance ID when available, send context window on every request, and recover gracefully from instance eviction by clearing the ID and reloading as needed. (`src/intelligence/lm-studio.ts`) [[1]](diffhunk://#diff-cb69c669d011bac2707322f7c4a3d06370222785ae614f40f1fbba0c9337fd65L44-R43) [[2]](diffhunk://#diff-cb69c669d011bac2707322f7c4a3d06370222785ae614f40f1fbba0c9337fd65L57-L76) [[3]](diffhunk://#diff-cb69c669d011bac2707322f7c4a3d06370222785ae614f40f1fbba0c9337fd65R98-R102)
* Refined model loading logic to ensure compatibility and multi-daemon safety, avoiding unnecessary unloading of other instances and supporting recovery from idle TTL eviction. (`src/intelligence/lm-studio.ts`) [[1]](diffhunk://#diff-cb69c669d011bac2707322f7c4a3d06370222785ae614f40f1fbba0c9337fd65L138-R150) [[2]](diffhunk://#diff-cb69c669d011bac2707322f7c4a3d06370222785ae614f40f1fbba0c9337fd65L149-R169)

**Digest Cycle Result Handling:**

* Ensured that digest cycle results use the correct timestamp and substrate, and that tier failures do not block the reporting of successful tiers. (`src/daemon/digest.ts`)

**Daemon Metabolism Handling:**

* Added a call to `metabolism.onEmptyCycle()` after an initial digest cycle failure to ensure proper metabolism state management. (`src/daemon/main.ts`)

## Related Issues

- Closes #
- Related #

## Change Type

- [x] Bug fix
- [x] Enhancement / new feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] CI / workflow

## Validation

```bash
make check    # lint + 266 tests
```

## Checklist

- [x] `make check` passes locally
- [x] Tests added or updated where behavior changed
- [ ] Docs updated for user-visible changes
- [ ] No magic literals introduced (named constants in `src/constants.ts`)
