### PR TITLE
feat(agent): add phased executor for guaranteed phase completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/superpowers/
 docs/plans/
 docs/specs/
 .superpowers/
+.myco/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,3 +265,32 @@ myco restart     # or myco-dev restart in dogfooding mode
 ```
 
 Or manually: kill the PID in `~/.myco/vaults/myco/daemon.json`, then let the next session-start hook spawn a fresh one.
+
+## Agent Teams
+
+Use Claude Code agent teams for parallelizable work where teammates need to communicate with each other. See [docs/agent-teams.md](docs/agent-teams.md) for the full reference.
+
+### When to use agent teams
+
+- **User explicitly requests it** — always honor a direct request to create an agent team.
+- **Cross-layer implementation** — changes spanning frontend, backend, and tests where each layer can be owned independently.
+- **Competing hypothesis debugging** — multiple theories to investigate in parallel, especially when adversarial debate would surface the root cause faster.
+- **Parallel review** — reviewing a PR or codebase from multiple lenses (security, performance, coverage) simultaneously.
+- **Independent module development** — building 3+ modules with no shared files, where parallel execution saves significant time.
+
+### When NOT to use agent teams
+
+- **Sequential or dependent work** — tasks that must happen in order. Use a single session.
+- **Same-file edits** — two teammates editing the same file causes overwrites. Use a single session or subagents.
+- **Simple focused tasks** — when only the result matters and no inter-worker discussion is needed. Use subagents.
+- **Token-constrained work** — each teammate is a separate Claude instance. Use subagents for lower cost.
+
+### Rules for agent team usage
+
+- **3-5 teammates** is the default. Scale up only when the work genuinely benefits.
+- **5-6 tasks per teammate** keeps everyone productive without excessive context switching.
+- **File ownership must be exclusive** — break work so each teammate owns a different set of files. Never assign two teammates to the same file.
+- **Spawn prompts must include full context** — teammates do NOT inherit the lead's conversation history. Include all task-specific details in the spawn prompt.
+- **Require plan approval for risky changes** — use plan mode for teammates touching critical paths (auth, data, config).
+- **The lead delegates, not implements** — if the lead starts doing work itself, tell it to wait for teammates.
+- **Only the lead cleans up** — teammates must not run cleanup. Shut down all teammates before the lead cleans up the team.

--- a/docs/agent-teams.md
+++ b/docs/agent-teams.md
@@ -1,0 +1,378 @@
+# Agent Teams Reference Guide
+
+Master reference for orchestrating teams of Claude Code sessions. Use this when designing multi-agent workflows, deciding between subagents and teams, or troubleshooting team coordination.
+
+> **Status:** Agent teams are experimental (Claude Code v2.1.32+). Enable via `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in settings.json or environment.
+
+---
+
+## When to Use Agent Teams vs Subagents
+
+The core question: **do the workers need to talk to each other?**
+
+| Dimension | Subagents | Agent Teams |
+|-----------|-----------|-------------|
+| **Context** | Own window; results return to caller | Own window; fully independent |
+| **Communication** | Report back to main agent only | Teammates message each other directly |
+| **Coordination** | Main agent manages all work | Shared task list with self-coordination |
+| **Best for** | Focused tasks where only the result matters | Complex work requiring discussion and collaboration |
+| **Token cost** | Lower: results summarized back | Higher: each teammate is a separate Claude instance |
+| **Lifecycle** | Scoped to the calling session | Independent sessions, persist until shutdown |
+
+### Use agent teams when:
+
+- **Research and review** — multiple reviewers investigate different aspects simultaneously, share and challenge findings
+- **New modules or features** — each teammate owns a separate piece without stepping on each other
+- **Debugging with competing hypotheses** — teammates test different theories in parallel, actively disprove each other
+- **Cross-layer coordination** — frontend, backend, and tests each owned by a different teammate
+
+### Use subagents (or a single session) when:
+
+- Tasks are sequential or have many dependencies
+- Work involves same-file edits (conflict risk)
+- Only the result matters, not inter-worker discussion
+- Token budget is a concern
+
+---
+
+## Setup
+
+### Enable agent teams
+
+```json
+// settings.json
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
+}
+```
+
+### Display modes
+
+| Mode | Description | Requirement |
+|------|-------------|-------------|
+| `"auto"` (default) | Split panes if inside tmux, in-process otherwise | — |
+| `"in-process"` | All teammates in one terminal. `Shift+Down` to cycle. | Any terminal |
+| `"tmux"` | Each teammate gets its own pane. Auto-detects tmux vs iTerm2. | tmux or iTerm2 + `it2` CLI |
+
+Configure in settings.json:
+
+```json
+{
+  "teammateMode": "in-process"
+}
+```
+
+Or per-session:
+
+```bash
+claude --teammate-mode in-process
+```
+
+**Split pane dependencies:**
+- **tmux**: install via package manager. `tmux -CC` in iTerm2 is the recommended entrypoint.
+- **iTerm2**: install the `it2` CLI, enable Python API in iTerm2 > Settings > General > Magic.
+- **Not supported**: VS Code integrated terminal, Windows Terminal, Ghostty.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────┐
+│  Team Lead (main Claude Code session)   │
+│  - Creates team, spawns teammates       │
+│  - Coordinates work, synthesizes results│
+│  - Approves/rejects teammate plans      │
+├─────────────────────────────────────────┤
+│  Shared Task List                       │
+│  ~/.claude/tasks/{team-name}/           │
+│  - pending → in_progress → completed   │
+│  - Dependency tracking (auto-unblock)   │
+│  - File-lock based claiming (no races)  │
+├─────────────────────────────────────────┤
+│  Mailbox (inter-agent messaging)        │
+│  - Direct: message one teammate         │
+│  - Broadcast: message all (use sparingly│
+│  - Automatic delivery (no polling)      │
+├───────────┬───────────┬─────────────────┤
+│ Teammate A│ Teammate B│ Teammate C  ... │
+│ Own context│Own context│ Own context     │
+│ Own tools  │Own tools  │ Own tools       │
+└───────────┴───────────┴─────────────────┘
+```
+
+**Storage locations:**
+- Team config: `~/.claude/teams/{team-name}/config.json`
+- Task list: `~/.claude/tasks/{team-name}/`
+
+The team config contains a `members` array with each teammate's name, agent ID, and agent type. Teammates can read this file to discover other team members.
+
+---
+
+## Team Lifecycle
+
+### 1. Creation
+
+Tell Claude to create a team with a task description and team structure:
+
+```
+Create an agent team to refactor the auth module. Spawn three teammates:
+- One for the token service
+- One for the session middleware
+- One for the test suite
+```
+
+Claude can also propose a team if it determines the task benefits from parallel work. You confirm before it proceeds.
+
+### 2. Coordination
+
+The lead handles task creation, assignment, and synthesis. Teammates self-claim tasks after completing their current work.
+
+**Task states:** `pending` → `in_progress` → `completed`
+
+**Task dependencies:** when a teammate completes a task that others depend on, blocked tasks unblock automatically.
+
+### 3. Communication
+
+- **Automatic message delivery** — no polling needed
+- **Idle notifications** — teammates auto-notify the lead when they stop
+- **Shared task list** — all agents see task status and claim available work
+- **message** — send to one specific teammate
+- **broadcast** — send to all teammates (costs scale with team size)
+
+### 4. Shutdown
+
+```
+Ask the researcher teammate to shut down
+```
+
+The teammate can approve (exits gracefully) or reject with an explanation. Always shut down all teammates before cleanup.
+
+### 5. Cleanup
+
+```
+Clean up the team
+```
+
+**Only the lead should run cleanup.** Teammates should not run cleanup — their team context may not resolve correctly, leaving resources in an inconsistent state. The lead checks for active teammates and fails if any are still running.
+
+---
+
+## Controlling Teammates
+
+### Specify teammates and models
+
+```
+Create a team with 4 teammates to refactor these modules in parallel.
+Use Sonnet for each teammate.
+```
+
+### Require plan approval
+
+For risky tasks, teammates can be put in read-only plan mode until the lead approves:
+
+```
+Spawn an architect teammate to refactor the authentication module.
+Require plan approval before they make any changes.
+```
+
+**Flow:** teammate plans → sends plan approval request to lead → lead approves or rejects with feedback → if rejected, teammate revises and resubmits → if approved, teammate exits plan mode and implements.
+
+Influence approval criteria via the prompt:
+- "Only approve plans that include test coverage"
+- "Reject plans that modify the database schema"
+
+### Direct interaction
+
+**In-process mode:**
+- `Shift+Down` — cycle through teammates
+- `Enter` — view a teammate's session
+- `Escape` — interrupt their current turn
+- `Ctrl+T` — toggle the task list
+- Type to send messages directly
+
+**Split-pane mode:**
+- Click into a teammate's pane to interact directly
+- Each teammate has full terminal access
+
+### Permissions
+
+Teammates start with the lead's permission settings. If the lead uses `--dangerously-skip-permissions`, all teammates do too. Individual teammate modes can be changed after spawning, but not at spawn time.
+
+Pre-approve common operations in permission settings before spawning to reduce prompt interruptions.
+
+---
+
+## Quality Gates with Hooks
+
+Two hooks enforce rules when teammates finish work:
+
+### `TeammateIdle`
+
+Runs when a teammate is about to go idle. Exit with code 2 to send feedback and keep the teammate working.
+
+**Use case:** validate the teammate's output before letting them stop — check that tests pass, linting is clean, or deliverables match requirements.
+
+### `TaskCompleted`
+
+Runs when a task is being marked complete. Exit with code 2 to prevent completion and send feedback.
+
+**Use case:** enforce that tasks meet acceptance criteria — test coverage thresholds, documentation requirements, code review checks.
+
+---
+
+## Best Practices
+
+### 1. Give teammates enough context
+
+Teammates load project context (CLAUDE.md, MCP servers, skills) but do NOT inherit the lead's conversation history. Include task-specific details in the spawn prompt:
+
+```
+Spawn a security reviewer teammate with the prompt: "Review the authentication
+module at src/auth/ for security vulnerabilities. Focus on token handling, session
+management, and input validation. The app uses JWT tokens stored in httpOnly
+cookies. Report any issues with severity ratings."
+```
+
+### 2. Right-size the team
+
+**Start with 3-5 teammates.** This balances parallel work with manageable coordination.
+
+**Target 5-6 tasks per teammate.** If you have 15 independent tasks, 3 teammates is a good starting point.
+
+Three focused teammates often outperform five scattered ones. Scale up only when the work genuinely benefits from simultaneous execution.
+
+### 3. Size tasks appropriately
+
+| Size | Problem |
+|------|---------|
+| Too small | Coordination overhead exceeds the benefit |
+| Too large | Teammates work too long without check-ins, increasing wasted effort risk |
+| Just right | Self-contained units producing a clear deliverable (a function, test file, review) |
+
+If the lead isn't creating enough tasks, ask it to split the work into smaller pieces.
+
+### 4. Prevent file conflicts
+
+Two teammates editing the same file leads to overwrites. Break work so each teammate owns a different set of files. Design task boundaries around file ownership.
+
+### 5. Keep the lead delegating, not implementing
+
+The lead sometimes starts implementing instead of waiting for teammates:
+
+```
+Wait for your teammates to complete their tasks before proceeding
+```
+
+### 6. Monitor and steer
+
+Check in on progress, redirect approaches that aren't working, synthesize findings as they arrive. Letting a team run unattended too long increases wasted effort risk.
+
+### 7. Start with read-only tasks
+
+If you're new to agent teams, start with tasks that don't require writing code: reviewing a PR, researching a library, investigating a bug. These show the value of parallel exploration without coordination challenges of parallel implementation.
+
+---
+
+## Prompt Patterns
+
+### Parallel code review
+
+```
+Create an agent team to review PR #142. Spawn three reviewers:
+- One focused on security implications
+- One checking performance impact
+- One validating test coverage
+Have them each review and report findings.
+```
+
+Each reviewer applies a different filter to the same PR. The lead synthesizes findings.
+
+### Competing hypothesis investigation
+
+```
+Users report the app exits after one message instead of staying connected.
+Spawn 5 agent teammates to investigate different hypotheses. Have them talk to
+each other to try to disprove each other's theories, like a scientific debate.
+Update the findings doc with whatever consensus emerges.
+```
+
+The adversarial debate structure fights anchoring bias — the theory that survives active disproof attempts is more likely to be the root cause.
+
+### Feature implementation with plan gates
+
+```
+Create an agent team to build the notification system:
+- Teammate 1: Backend API (src/api/notifications/)
+- Teammate 2: Frontend components (src/components/notifications/)
+- Teammate 3: Integration tests (tests/notifications/)
+Require plan approval for all teammates before they write code.
+Only approve plans that include error handling and test coverage.
+```
+
+### Research with synthesis
+
+```
+Create an agent team to evaluate state management options for our React app.
+Spawn teammates for:
+- Redux Toolkit evaluation
+- Zustand evaluation
+- Jotai evaluation
+Each should build a small proof-of-concept with our data model.
+Have them compare findings and produce a recommendation doc.
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Teammates not appearing | May be running but not visible in in-process mode | `Shift+Down` to cycle through teammates |
+| Teammates not appearing | Task too simple for Claude to warrant a team | Explicitly request team creation |
+| Teammates not appearing (split) | tmux not installed | `which tmux` to verify, install if missing |
+| Too many permission prompts | Teammate permissions bubble up to lead | Pre-approve common operations in permission settings |
+| Teammates stopping on errors | Teammate gave up after encountering error | Message them directly with instructions, or spawn replacement |
+| Lead shuts down early | Lead decided team is finished prematurely | Tell lead to wait for teammates to finish |
+| Task appears stuck | Teammate didn't mark task as completed | Check if work is done, update status manually or nudge via lead |
+| Orphaned tmux sessions | Team cleanup didn't fully remove sessions | `tmux ls` then `tmux kill-session -t <name>` |
+| `/resume` doesn't restore teammates | Known limitation: in-process teammates don't survive resume | Tell lead to spawn new teammates after resuming |
+
+---
+
+## Known Limitations
+
+- **No session resumption** — `/resume` and `/rewind` don't restore in-process teammates
+- **Task status lag** — teammates sometimes fail to mark tasks complete, blocking dependents
+- **Slow shutdown** — teammates finish current request/tool call before stopping
+- **One team per session** — clean up current team before starting a new one
+- **No nested teams** — teammates cannot spawn their own teams
+- **Fixed lead** — the creating session is lead for the team's lifetime, no transfer
+- **Permissions set at spawn** — all teammates inherit lead's mode, changeable individually after spawn only
+- **Split panes limited** — requires tmux or iTerm2, not supported in VS Code terminal, Windows Terminal, or Ghostty
+- **CLAUDE.md works normally** — teammates read CLAUDE.md from their working directory (this is a feature, not a limitation)
+
+---
+
+## Quick Decision Matrix
+
+```
+Need parallel work?
+├── No → Single session
+├── Yes
+│   ├── Workers need to talk to each other?
+│   │   ├── No → Subagents
+│   │   └── Yes → Agent team
+│   ├── Same-file edits?
+│   │   ├── Yes → Single session or careful file ownership
+│   │   └── No → Agent team candidate
+│   └── Token budget tight?
+│       ├── Yes → Subagents (lower cost)
+│       └── No → Agent team
+```
+
+---
+
+*Source: [Claude Code Agent Teams Documentation](https://code.claude.com/docs/en/agent-teams)*

--- a/docs/superpowers/plans/2026-03-24-agent-task-system.md
+++ b/docs/superpowers/plans/2026-03-24-agent-task-system.md
@@ -1,0 +1,863 @@
+# Agent Task System — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Transform Myco's static agent pipeline into a full task system where users can create, configure, and run custom intelligence tasks with phased execution, per-phase model selection, and context-aware orchestration.
+
+**Architecture:** Adopts OAK's template/task separation pattern. Built-in agent definition (`agent.yaml`) defines capabilities (tools, permissions). Tasks define what to do — with phases, tool scoping, model overrides, and context queries. A registry discovers both built-in tasks (from YAML) and user tasks (from vault directory). The executor resolves effective config by merging definition + DB overrides + task phases. API routes and CLI commands provide full CRUD.
+
+**Tech Stack:** TypeScript, Zod validation, PGlite (SQLite dialect), Claude Agent SDK, YAML task definitions
+
+**Prior work:** The phased executor is already built on branch `feat/phased-executor` — it supports `PhaseDefinition[]` in task YAML with per-phase tools, turn limits, and model overrides. This plan extends that foundation.
+
+**Reference:** OAK's agent runtime at `~/Repos/open-agent-kit/src/open_agent_kit/features/agent_runtime/` — especially `models.py` (task schema), `registry.py` (discovery), `executor.py` (prompt composition), and `routes/agents.py` (API).
+
+---
+
+## Design Decisions
+
+### DB storage: use existing `config` column
+
+The `agent_tasks` table already has a `config TEXT` column (schema.ts:327) intended for extension data. Rather than adding new columns via a migration, we store `phases`, `execution`, and `contextQueries` as a JSON object in `config`. No schema migration needed.
+
+```typescript
+// config column stores:
+interface TaskConfig {
+  phases?: PhaseDefinition[];
+  execution?: ExecutionConfig;
+  contextQueries?: Record<string, ContextQuery[]>;
+  schemaVersion?: number;
+}
+```
+
+### `isDefault` vs `isBuiltin` are separate concepts
+
+- `isDefault: boolean` — "this is the default task for the agent" (exactly one per agent)
+- `isBuiltin: boolean` — "this task ships with the package" (many can be built-in)
+
+Both coexist. A built-in task can be the default. A user task cannot be isDefault (the default is always the built-in full-intelligence task).
+
+### Config override precedence
+
+When multiple levels define the same field, highest priority wins:
+
+```
+execution.model > task.model > agentRow.model > agentDefinition.model
+execution.maxTurns > task.maxTurns > agentRow.max_turns > agentDefinition.maxTurns
+execution.timeoutSeconds > task.timeoutSeconds > agentRow.timeout_seconds > agentDefinition.timeoutSeconds
+```
+
+The `execution` block is for task-level overrides that are independent of the YAML top-level fields. This matches OAK's pattern where `AgentTask.execution` overrides `AgentDefinition.execution`.
+
+### Registry: no cache, always load from disk
+
+For simplicity and correctness, the registry loads all tasks from disk on every call to `loadAllTasks()`. With single-digit task file counts, this is fast enough. No module-level mutable cache. Mutations (create/copy/delete) write to disk; the next read picks up changes automatically. This satisfies CLAUDE.md's idempotence requirement.
+
+### Context query execution deferred to Plan 2
+
+This plan adds `contextQueries` to the schema and types but does NOT wire them into the executor. Context queries run before phases and require orchestrator intelligence to decide which queries are relevant. Plan 2 (Orchestrator Intelligence) implements the execution.
+
+### Provider configuration deferred to Plan 2
+
+This plan adds `ProviderConfig` to types and schemas. Actual environment variable injection (the OAK pattern: `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`) is deferred to Plan 2 where the orchestrator handles model routing.
+
+---
+
+## Subsystem Scope
+
+This plan covers **Task Schema + User Task Registry + API** — the foundation layer. Two follow-up plans build on this:
+
+- **Plan 2: Orchestrator Intelligence** — dynamic phase planning, vault-state-aware dispatch, context query execution, provider routing
+- **Plan 3: Dashboard Task Management** — UI for creating, editing, and running tasks
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|------|---------------|
+| `src/agent/registry.ts` | Discover and load built-in + user tasks, validate, write/delete user tasks |
+| `src/agent/schemas.ts` | Zod schemas for task YAML validation (extracted from loader.ts) |
+| `src/daemon/api/agent-tasks.ts` | API route handlers for task CRUD |
+| `src/cli/agent-tasks.ts` | CLI commands: `myco task list`, `myco task create`, `myco task copy` |
+| `tests/agent/registry.test.ts` | Registry tests |
+| `tests/agent/schemas.test.ts` | Schema validation tests |
+| `tests/daemon/api/agent-tasks.test.ts` | API route tests |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `src/agent/types.ts` | Add ContextQuery, ExecutionConfig, ProviderConfig, TaskConfig; extend AgentTask |
+| `src/agent/loader.ts` | Import schemas from `schemas.ts` instead of inline; persist config JSON on upsert |
+| `src/agent/executor.ts` | Use registry instead of direct loader calls; apply execution overrides |
+| `src/db/queries/tasks.ts` | Parse/serialize config column; add `deleteTask` |
+| `src/daemon/main.ts` | Register new API routes; replace existing GET /api/agent/tasks (line 933) |
+| `src/cli.ts` | Add `task` to subcommand dispatch |
+| `src/constants.ts` | Add USER_TASKS_DIR, USER_TASK_SOURCE, TASK_NAME_PATTERN, MAX_TASK_NAME_LENGTH |
+
+---
+
+## Task 1: Extract Schemas and Extend Task Types
+
+**Files:**
+- Create: `src/agent/schemas.ts`
+- Modify: `src/agent/types.ts`
+- Modify: `src/agent/loader.ts`
+- Create: `tests/agent/schemas.test.ts`
+
+- [ ] **Step 1: Define extended types in `src/agent/types.ts`**
+
+Add new interfaces after the existing `PhaseResult` interface:
+
+```typescript
+/** Context query that runs before task execution to gather vault state. */
+export interface ContextQuery {
+  tool: string;
+  queryTemplate: string;
+  limit: number;
+  purpose: string;
+  required: boolean;
+}
+
+/** API provider configuration for task execution. */
+export interface ProviderConfig {
+  type: 'cloud' | 'ollama' | 'lmstudio';
+  baseUrl?: string;
+  apiKey?: string;
+  model?: string;
+}
+
+/** Execution configuration overrides for a task. */
+export interface ExecutionConfig {
+  model?: string;
+  maxTurns?: number;
+  timeoutSeconds?: number;
+  provider?: ProviderConfig;
+}
+
+/**
+ * Extended config stored as JSON in the agent_tasks.config column.
+ * Structural data that doesn't fit in flat columns.
+ */
+export interface TaskConfig {
+  phases?: PhaseDefinition[];
+  execution?: ExecutionConfig;
+  contextQueries?: Record<string, ContextQuery[]>;
+  schemaVersion?: number;
+}
+```
+
+Add `source` and `isBuiltin` to `AgentTask`:
+
+```typescript
+export interface AgentTask {
+  // ... existing fields (name, displayName, description, agent, prompt,
+  //     isDefault, toolOverrides?, model?, maxTurns?, timeoutSeconds?, phases?) ...
+  execution?: ExecutionConfig;
+  contextQueries?: Record<string, ContextQuery[]>;
+  isBuiltin: boolean;
+  source?: 'built-in' | 'user';
+  schemaVersion?: number;
+}
+```
+
+- [ ] **Step 2: Create `src/agent/schemas.ts`**
+
+Move Zod schemas from `loader.ts` (lines 42-76) into this new file:
+
+```typescript
+import { z } from 'zod/v4';
+
+export const CURRENT_TASK_SCHEMA_VERSION = 1;
+
+export const ProviderConfigSchema = z.object({
+  type: z.enum(['cloud', 'ollama', 'lmstudio']),
+  baseUrl: z.string().optional(),
+  apiKey: z.string().optional(),
+  model: z.string().optional(),
+});
+
+export const ExecutionConfigSchema = z.object({
+  model: z.string().optional(),
+  maxTurns: z.number().optional(),
+  timeoutSeconds: z.number().optional(),
+  provider: ProviderConfigSchema.optional(),
+});
+
+export const ContextQuerySchema = z.object({
+  tool: z.string(),
+  queryTemplate: z.string(),
+  limit: z.number().default(10),
+  purpose: z.string(),
+  required: z.boolean().default(false),
+});
+
+export const PhaseDefinitionSchema = z.object({
+  name: z.string(),
+  prompt: z.string(),
+  tools: z.array(z.string()),
+  maxTurns: z.number(),
+  model: z.string().optional(),
+  required: z.boolean(),
+});
+
+export const AgentDefinitionSchema = z.object({
+  name: z.string(),
+  displayName: z.string(),
+  description: z.string(),
+  model: z.string(),
+  maxTurns: z.number(),
+  timeoutSeconds: z.number(),
+  systemPromptPath: z.string(),
+  tools: z.array(z.string()),
+});
+
+export const AgentTaskSchema = z.object({
+  name: z.string(),
+  displayName: z.string(),
+  description: z.string(),
+  agent: z.string(),
+  prompt: z.string(),
+  isDefault: z.boolean(),
+  toolOverrides: z.array(z.string()).optional(),
+  model: z.string().optional(),
+  maxTurns: z.number().optional(),
+  timeoutSeconds: z.number().optional(),
+  phases: z.array(PhaseDefinitionSchema).optional(),
+  execution: ExecutionConfigSchema.optional(),
+  contextQueries: z.record(z.string(), z.array(ContextQuerySchema)).optional(),
+  schemaVersion: z.number().optional(),
+});
+```
+
+- [ ] **Step 3: Update `loader.ts` — replace inline schemas with imports**
+
+In `src/agent/loader.ts`, replace lines 42-76 (the inline Zod schemas) with:
+
+```typescript
+import {
+  AgentDefinitionSchema,
+  AgentTaskSchema,
+  PhaseDefinitionSchema,
+} from './schemas.js';
+```
+
+Delete the `PhaseDefinitionSchema`, `AgentDefinitionSchema`, and `AgentTaskSchema` definitions from `loader.ts`. Keep all other code unchanged.
+
+- [ ] **Step 4: Run existing tests to verify no regressions**
+
+Run: `npx vitest run tests/agent/loader.test.ts tests/agent/executor.test.ts`
+Expected: All existing tests pass (schema extraction is a pure refactor).
+
+- [ ] **Step 5: Write schema validation tests**
+
+Create `tests/agent/schemas.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { AgentTaskSchema, AgentDefinitionSchema } from '@myco/agent/schemas.js';
+
+describe('AgentTaskSchema', () => {
+  it('validates minimal task (no optional fields)', () => { /* ... */ });
+  it('validates task with phases array', () => { /* ... */ });
+  it('validates task with execution overrides', () => { /* ... */ });
+  it('validates task with contextQueries', () => { /* ... */ });
+  it('rejects task missing required fields', () => { /* ... */ });
+  it('rejects task with invalid phase (missing tools)', () => { /* ... */ });
+  it('rejects invalid provider type', () => { /* ... */ });
+});
+```
+
+- [ ] **Step 6: Run schema tests**
+
+Run: `npx vitest run tests/agent/schemas.test.ts`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/agent/schemas.ts src/agent/types.ts src/agent/loader.ts tests/agent/schemas.test.ts
+git commit -m "refactor(agent): extract Zod schemas, extend task types with execution/provider/contextQueries"
+```
+
+---
+
+## Task 2: Persist Task Config in DB
+
+**Files:**
+- Modify: `src/db/queries/tasks.ts`
+- Modify: `src/agent/loader.ts`
+- Test: `tests/db/queries/tasks.test.ts` (extend)
+
+No schema migration — we use the existing `config TEXT` column on `agent_tasks`.
+
+- [ ] **Step 1: Add config serialization helpers to `tasks.ts`**
+
+In `src/db/queries/tasks.ts`, add helpers to serialize/deserialize the `config` column:
+
+```typescript
+import type { TaskConfig, PhaseDefinition, ExecutionConfig, ContextQuery } from '@myco/agent/types.js';
+
+/** Serialize TaskConfig to JSON for the config column. */
+function serializeConfig(config: TaskConfig | null): string | null {
+  if (!config) return null;
+  return JSON.stringify(config);
+}
+
+/** Deserialize config column JSON to TaskConfig. */
+function deserializeConfig(raw: string | null): TaskConfig | null {
+  if (!raw) return null;
+  try { return JSON.parse(raw) as TaskConfig; } catch { return null; }
+}
+```
+
+- [ ] **Step 2: Update `upsertTask` to accept and persist config**
+
+Update `TaskInsert` to include a `config` field (it already exists as a column). When upserting, serialize the `TaskConfig` into the `config` column.
+
+- [ ] **Step 3: Update `getTask` and `listTasks` to return parsed config**
+
+After fetching a `TaskRow`, parse the `config` column and attach `phases`, `execution`, `contextQueries` to the returned object for API consumers.
+
+- [ ] **Step 4: Add `deleteTask` query**
+
+```typescript
+export async function deleteTask(id: string): Promise<boolean> {
+  const db = getDatabase();
+  const result = await db.query(
+    `DELETE FROM agent_tasks WHERE id = $1 AND source != $2 RETURNING id`,
+    [id, BUILT_IN_SOURCE],
+  );
+  return result.rows.length > 0;
+}
+```
+
+Import `BUILT_IN_SOURCE` from `loader.ts` or define in constants. Built-in tasks (where `source = 'built-in'`, set by `registerBuiltInAgentsAndTasks`) cannot be deleted.
+
+- [ ] **Step 5: Update `registerBuiltInAgentsAndTasks` in `loader.ts`**
+
+When upserting built-in tasks, serialize `phases` and `execution` into the `config` column:
+
+```typescript
+await upsertTask({
+  // ... existing fields ...
+  config: JSON.stringify({
+    phases: task.phases ?? null,
+    execution: task.execution ?? null,
+    contextQueries: task.contextQueries ?? null,
+    schemaVersion: task.schemaVersion ?? 1,
+  }),
+});
+```
+
+- [ ] **Step 6: Extend existing task tests**
+
+Add tests to `tests/db/queries/tasks.test.ts`:
+- Upsert task with config containing phases, read back and verify phases parsed
+- Upsert task with config containing execution overrides, read back and verify
+- Config column null when no extended config provided
+- Delete user task (source='user') succeeds
+- Delete built-in task (source='built-in') returns false
+
+- [ ] **Step 7: Run tests**
+
+Run: `npx vitest run tests/db/queries/tasks.test.ts`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/db/queries/tasks.ts src/agent/loader.ts tests/db/queries/tasks.test.ts
+git commit -m "feat(db): persist phases/execution in agent_tasks.config column, add deleteTask"
+```
+
+---
+
+## Task 3: User Task Registry
+
+**Files:**
+- Create: `src/agent/registry.ts`
+- Modify: `src/constants.ts`
+- Create: `tests/agent/registry.test.ts`
+
+- [ ] **Step 1: Add constants**
+
+In `src/constants.ts`:
+
+```typescript
+/** Subdirectory within the vault for user-created task YAML files. */
+export const USER_TASKS_DIR = 'tasks';
+
+/** Source label for user-created tasks. */
+export const USER_TASK_SOURCE = 'user';
+
+/** Task name validation pattern (lowercase, hyphens, digits). */
+export const TASK_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
+
+/** Maximum length for task names. */
+export const MAX_TASK_NAME_LENGTH = 50;
+```
+
+- [ ] **Step 2: Create `src/agent/registry.ts`**
+
+No module-level cache — always load from disk. Simple and correct.
+
+```typescript
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import { AgentTaskSchema } from './schemas.js';
+import { loadAgentTasks } from './loader.js';
+import {
+  USER_TASKS_DIR,
+  USER_TASK_SOURCE,
+  TASK_NAME_PATTERN,
+  MAX_TASK_NAME_LENGTH,
+} from '@myco/constants.js';
+import type { AgentTask } from './types.js';
+
+// -------------------------------------------------------------------------
+// Constants
+// -------------------------------------------------------------------------
+
+/** Source label for built-in tasks (matches loader.ts BUILT_IN_SOURCE). */
+const BUILT_IN_SOURCE = 'built-in';
+
+// -------------------------------------------------------------------------
+// Discovery
+// -------------------------------------------------------------------------
+
+/**
+ * Load all tasks from built-in definitions and user vault directory.
+ * User tasks with the same name as built-in tasks override them.
+ * Always reads from disk — no caching.
+ */
+export function loadAllTasks(
+  definitionsDir: string,
+  vaultDir?: string,
+): Map<string, AgentTask> {
+  const tasks = new Map<string, AgentTask>();
+
+  // 1. Built-in tasks from definitions/tasks/
+  for (const task of loadAgentTasks(definitionsDir)) {
+    tasks.set(task.name, { ...task, source: BUILT_IN_SOURCE, isBuiltin: true });
+  }
+
+  // 2. User tasks from vault/tasks/
+  if (vaultDir) {
+    const userTasksDir = path.join(vaultDir, USER_TASKS_DIR);
+    if (fs.existsSync(userTasksDir)) {
+      for (const file of fs.readdirSync(userTasksDir).filter(f => f.endsWith('.yaml'))) {
+        try {
+          const raw = fs.readFileSync(path.join(userTasksDir, file), 'utf-8');
+          const parsed = AgentTaskSchema.parse(parseYaml(raw));
+          tasks.set(parsed.name, {
+            ...parsed,
+            source: USER_TASK_SOURCE,
+            isBuiltin: false,
+          });
+        } catch {
+          // Skip malformed user task files — log but don't crash
+          console.warn(`[registry] Failed to parse user task: ${file}`);
+        }
+      }
+    }
+  }
+
+  return tasks;
+}
+
+// -------------------------------------------------------------------------
+// Validation
+// -------------------------------------------------------------------------
+
+/** Validate a task name (lowercase, hyphens, digits, max length). */
+export function validateTaskName(name: string): boolean {
+  return name.length <= MAX_TASK_NAME_LENGTH && TASK_NAME_PATTERN.test(name);
+}
+
+// -------------------------------------------------------------------------
+// Write operations
+// -------------------------------------------------------------------------
+
+/**
+ * Write a user task YAML file to the vault tasks directory.
+ * Validates the task through AgentTaskSchema before writing.
+ */
+export function writeUserTask(vaultDir: string, task: AgentTask): string {
+  const tasksDir = path.join(vaultDir, USER_TASKS_DIR);
+  fs.mkdirSync(tasksDir, { recursive: true });
+
+  // Strip internal fields before serializing to YAML
+  const { source: _source, isBuiltin: _isBuiltin, ...yamlFields } = task;
+
+  // Validate before writing — prevents malformed files on disk
+  AgentTaskSchema.parse(yamlFields);
+
+  const filePath = path.join(tasksDir, `${task.name}.yaml`);
+  fs.writeFileSync(filePath, stringifyYaml(yamlFields), 'utf-8');
+  return filePath;
+}
+
+/** Delete a user task YAML file. Returns true if deleted. */
+export function deleteUserTask(vaultDir: string, taskName: string): boolean {
+  const filePath = path.join(vaultDir, USER_TASKS_DIR, `${taskName}.yaml`);
+  if (fs.existsSync(filePath)) {
+    fs.unlinkSync(filePath);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Copy a task to the user tasks directory for customization.
+ * Returns the new user task.
+ */
+export function copyTaskToUser(
+  definitionsDir: string,
+  vaultDir: string,
+  sourceName: string,
+  newName?: string,
+): AgentTask {
+  const allTasks = loadAllTasks(definitionsDir, vaultDir);
+  const sourceTask = allTasks.get(sourceName);
+  if (!sourceTask) throw new Error(`Task "${sourceName}" not found`);
+
+  const name = newName ?? `${sourceName}-custom`;
+  if (!validateTaskName(name)) {
+    throw new Error(`Invalid task name "${name}" — use lowercase, hyphens, digits, max ${MAX_TASK_NAME_LENGTH} chars`);
+  }
+
+  const userTask: AgentTask = {
+    ...sourceTask,
+    name,
+    displayName: `${sourceTask.displayName} (Custom)`,
+    isDefault: false,
+    isBuiltin: false,
+    source: USER_TASK_SOURCE,
+  };
+
+  writeUserTask(vaultDir, userTask);
+  return userTask;
+}
+```
+
+- [ ] **Step 3: Write registry tests**
+
+Create `tests/agent/registry.test.ts` using `fs.mkdtempSync` for test isolation:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadAllTasks, validateTaskName, writeUserTask, deleteUserTask, copyTaskToUser } from '@myco/agent/registry.js';
+
+describe('loadAllTasks', () => {
+  it('discovers built-in tasks from definitions dir');
+  it('discovers user tasks from vault tasks dir');
+  it('user task with same name overrides built-in');
+  it('skips malformed user task YAML without crashing');
+});
+
+describe('validateTaskName', () => {
+  it('accepts valid names: my-task, a, task-123');
+  it('rejects invalid names: My-Task, task_name, -leading, trailing-');
+  it('rejects names longer than MAX_TASK_NAME_LENGTH');
+});
+
+describe('writeUserTask', () => {
+  it('creates YAML file in vault tasks dir');
+  it('validates task before writing (rejects malformed)');
+  it('creates tasks dir if it does not exist');
+});
+
+describe('deleteUserTask', () => {
+  it('removes file from disk and returns true');
+  it('returns false for non-existent file');
+});
+
+describe('copyTaskToUser', () => {
+  it('creates user copy with -custom suffix');
+  it('uses custom name when provided');
+  it('throws on invalid task name');
+  it('throws on non-existent source task');
+});
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run tests/agent/registry.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/registry.ts src/constants.ts tests/agent/registry.test.ts
+git commit -m "feat(agent): add user task registry with built-in + user task discovery"
+```
+
+---
+
+## Task 4: Task CRUD API Routes
+
+**Files:**
+- Create: `src/daemon/api/agent-tasks.ts`
+- Modify: `src/daemon/main.ts`
+- Create: `tests/daemon/api/agent-tasks.test.ts`
+
+- [ ] **Step 1: Create `src/daemon/api/agent-tasks.ts`**
+
+Import types from `../router.js` (not `../types.js` — that file doesn't exist):
+
+```typescript
+import type { RouteRequest, RouteResponse } from '../router.js';
+import { loadAllTasks, writeUserTask, deleteUserTask, copyTaskToUser, validateTaskName } from '@myco/agent/registry.js';
+import { resolveDefinitionsDir } from '@myco/agent/loader.js';
+import { AgentTaskSchema } from '@myco/agent/schemas.js';
+
+export async function handleListTasks(req: RouteRequest, vaultDir: string): Promise<RouteResponse> {
+  const definitionsDir = resolveDefinitionsDir();
+  const tasks = loadAllTasks(definitionsDir, vaultDir);
+  const source = req.query?.source as 'built-in' | 'user' | undefined;
+  const all = Array.from(tasks.values());
+  const filtered = source ? all.filter(t => t.source === source) : all;
+  return { status: 200, body: { tasks: filtered } };
+}
+
+export async function handleGetTask(req: RouteRequest, vaultDir: string): Promise<RouteResponse> {
+  const taskId = req.params?.id;
+  if (!taskId) return { status: 400, body: { error: 'Missing task ID' } };
+  const definitionsDir = resolveDefinitionsDir();
+  const tasks = loadAllTasks(definitionsDir, vaultDir);
+  const task = tasks.get(taskId);
+  if (!task) return { status: 404, body: { error: `Task "${taskId}" not found` } };
+  return { status: 200, body: { task } };
+}
+
+export async function handleCreateTask(req: RouteRequest, vaultDir: string): Promise<RouteResponse> {
+  const body = AgentTaskSchema.parse(req.body);
+  if (!validateTaskName(body.name)) {
+    return { status: 400, body: { error: 'Invalid task name — use lowercase, hyphens, digits' } };
+  }
+  const definitionsDir = resolveDefinitionsDir();
+  const existing = loadAllTasks(definitionsDir, vaultDir).get(body.name);
+  if (existing?.source === 'user') {
+    return { status: 409, body: { error: `User task "${body.name}" already exists` } };
+  }
+  const task = { ...body, source: 'user' as const, isBuiltin: false };
+  writeUserTask(vaultDir, task);
+  return { status: 201, body: { task } };
+}
+
+export async function handleCopyTask(req: RouteRequest, vaultDir: string): Promise<RouteResponse> {
+  const taskId = req.params?.id;
+  if (!taskId) return { status: 400, body: { error: 'Missing task ID' } };
+  const newName = typeof req.body?.name === 'string' ? req.body.name : undefined;
+  const definitionsDir = resolveDefinitionsDir();
+  const task = copyTaskToUser(definitionsDir, vaultDir, taskId, newName);
+  return { status: 201, body: { task } };
+}
+
+export async function handleDeleteTask(req: RouteRequest, vaultDir: string): Promise<RouteResponse> {
+  const taskId = req.params?.id;
+  if (!taskId) return { status: 400, body: { error: 'Missing task ID' } };
+  const definitionsDir = resolveDefinitionsDir();
+  const tasks = loadAllTasks(definitionsDir, vaultDir);
+  const task = tasks.get(taskId);
+  if (!task) return { status: 404, body: { error: `Task "${taskId}" not found` } };
+  if (task.source === 'built-in') {
+    return { status: 403, body: { error: 'Cannot delete built-in tasks' } };
+  }
+  deleteUserTask(vaultDir, taskId);
+  return { status: 200, body: { ok: true } };
+}
+```
+
+- [ ] **Step 2: Register routes in `src/daemon/main.ts`**
+
+Replace the existing `GET /api/agent/tasks` route (line 933 of main.ts) with the new handler. Add the remaining CRUD routes:
+
+```typescript
+// Replace existing GET /api/agent/tasks (line 933)
+server.registerRoute('GET', '/api/agent/tasks', async (req) => handleListTasks(req, vaultDir));
+server.registerRoute('GET', '/api/agent/tasks/:id', async (req) => handleGetTask(req, vaultDir));
+server.registerRoute('POST', '/api/agent/tasks', async (req) => handleCreateTask(req, vaultDir));
+server.registerRoute('POST', '/api/agent/tasks/:id/copy', async (req) => handleCopyTask(req, vaultDir));
+server.registerRoute('DELETE', '/api/agent/tasks/:id', async (req) => handleDeleteTask(req, vaultDir));
+```
+
+Import the handlers at the top of main.ts.
+
+- [ ] **Step 3: Write API route tests**
+
+Create `tests/daemon/api/agent-tasks.test.ts`:
+- GET /api/agent/tasks returns both built-in and user tasks
+- GET /api/agent/tasks?source=user returns only user tasks
+- GET /api/agent/tasks/:id returns task with phases in response
+- POST /api/agent/tasks creates user task YAML file in vault
+- POST /api/agent/tasks rejects invalid task name (400)
+- POST /api/agent/tasks/:id/copy creates user copy of built-in (201)
+- DELETE /api/agent/tasks/:id deletes user task (200)
+- DELETE /api/agent/tasks/:id rejects built-in task deletion (403)
+- GET /api/agent/tasks/:id returns 404 for unknown task
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run tests/daemon/api/agent-tasks.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/daemon/api/agent-tasks.ts src/daemon/main.ts tests/daemon/api/agent-tasks.test.ts
+git commit -m "feat(api): add task CRUD routes — list, get, create, copy, delete"
+```
+
+---
+
+## Task 5: CLI Task Commands
+
+**Files:**
+- Create: `src/cli/agent-tasks.ts`
+- Modify: `src/cli.ts`
+
+Note: CLI commands delegate to daemon API (same pattern as `src/cli/agent-run.ts`). The API tests in Task 4 cover the backend logic. CLI testing is manual — this matches the existing pattern where no CLI modules have automated tests.
+
+- [ ] **Step 1: Create `src/cli/agent-tasks.ts`**
+
+Commands delegate to daemon API via `connectToDaemon()`:
+- `myco task list [--source built-in|user]` — GET /api/agent/tasks
+- `myco task show <name>` — GET /api/agent/tasks/:name
+- `myco task create <name> --from <template>` — POST /api/agent/tasks/:template/copy
+- `myco task delete <name>` — DELETE /api/agent/tasks/:name
+- `myco task run <name> [--instruction TEXT]` — POST /api/agent/run with task param
+
+Follow the pattern in `src/cli/agent-run.ts` for daemon connection.
+
+- [ ] **Step 2: Add `task` to CLI dispatch in `src/cli.ts`**
+
+Add `task` to the `SUBCOMMAND_DISPATCH` map, delegating to the new module.
+
+- [ ] **Step 3: Verify CLI manually**
+
+```bash
+myco-dev task list
+myco-dev task show full-intelligence
+myco-dev task create my-extract --from extract-only
+myco-dev task list --source user
+myco-dev task delete my-extract
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/cli/agent-tasks.ts src/cli.ts
+git commit -m "feat(cli): add task list/show/create/delete/run commands"
+```
+
+---
+
+## Task 6: Update Executor to Use Registry
+
+**Files:**
+- Modify: `src/agent/executor.ts`
+- Test: `tests/agent/executor.test.ts` (extend)
+
+- [ ] **Step 1: Replace direct YAML loading with registry call**
+
+In `src/agent/executor.ts`, replace the current YAML task loading (lines ~351-366):
+
+```typescript
+// Before:
+const yamlTasks = loadAgentTasks(definitionsDir);
+const yamlTask = taskName ? yamlTasks.find((t) => t.name === taskName) : undefined;
+
+// After:
+import { loadAllTasks } from './registry.js';
+const allTasks = loadAllTasks(definitionsDir, vaultDir);
+const yamlTask = taskName ? allTasks.get(taskName) : undefined;
+```
+
+This means `runAgent` now needs `vaultDir` passed through (it already receives it as the first argument).
+
+- [ ] **Step 2: Apply execution config overrides in `resolveEffectiveConfig`**
+
+Update `resolveEffectiveConfig` in `loader.ts` to handle the `execution` field from task config. Add after the existing task override block:
+
+```typescript
+// Apply execution config overrides (highest priority)
+if (taskOverrides?.execution) {
+  if (taskOverrides.execution.model) model = taskOverrides.execution.model;
+  if (taskOverrides.execution.maxTurns) maxTurns = taskOverrides.execution.maxTurns;
+  if (taskOverrides.execution.timeoutSeconds) timeoutSeconds = taskOverrides.execution.timeoutSeconds;
+}
+```
+
+This implements the documented precedence: `execution.model > task.model > agent.model`.
+
+- [ ] **Step 3: Update executor tests**
+
+Add tests to `tests/agent/executor.test.ts`:
+- "user task with custom phases executes all phases" — set `mockYamlPhases` via registry mock and verify phased execution
+- "execution.model overrides task.model" — verify the SDK receives the execution model, not the task model
+- "execution.maxTurns overrides task.maxTurns" — verify turn limits
+
+- [ ] **Step 4: Run all tests**
+
+Run: `make check`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/executor.ts src/agent/loader.ts tests/agent/executor.test.ts
+git commit -m "feat(agent): executor uses registry for task resolution, supports execution config overrides"
+```
+
+---
+
+## Task 7: Full Quality Gate + Integration Verification
+
+- [ ] **Step 1: Run `make check`**
+
+Run: `make check`
+Expected: lint + all tests pass
+
+- [ ] **Step 2: Build**
+
+Run: `make build`
+Expected: tsup bundle succeeds
+
+- [ ] **Step 3: Integration test with daemon**
+
+```bash
+myco-dev restart
+myco-dev task list
+myco-dev task show full-intelligence
+myco-dev task create test-task --from extract-only
+myco-dev task list --source user
+myco-dev task delete test-task
+```
+
+- [ ] **Step 4: Commit any fixes**
+
+---
+
+## Summary
+
+| Task | What it delivers | Depends on |
+|------|-----------------|------------|
+| 1. Schema + Types | Rich task type system, Zod validation extracted | — |
+| 2. DB Config Persistence | Phases/execution stored in config column | Task 1 |
+| 3. Registry | Built-in + user task discovery, write/delete | Task 1 |
+| 4. API Routes | Task CRUD over HTTP | Tasks 2, 3 |
+| 5. CLI Commands | `myco task` subcommands | Task 4 |
+| 6. Executor Update | Registry-backed execution, execution overrides | Tasks 2, 3 |
+| 7. Quality Gate | Verification | All |
+
+**After this plan:** Users can create custom intelligence tasks via YAML, configure phases/models/tools, and run them via CLI or API. The dashboard (Plan 3) and orchestrator intelligence (Plan 2) build on this foundation.
+
+**Deferred to Plan 2:**
+- Context query execution (queries run before phases to gather vault state)
+- Provider environment injection (ANTHROPIC_BASE_URL, etc.)
+- Orchestrator planning model (dynamic phase selection/reordering)
+- Per-phase model routing with fallback detection

--- a/docs/superpowers/plans/2026-03-24-dashboard-task-management.md
+++ b/docs/superpowers/plans/2026-03-24-dashboard-task-management.md
@@ -1,0 +1,531 @@
+# Dashboard Task Management — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a task management interface to the Myco dashboard where users can view, create, edit, copy, and run intelligence tasks with full phase visualization.
+
+**Architecture:** Extends the existing Agent page with a task-centric view. Tasks are fetched from the Plan 1 API routes (`GET/POST/DELETE /api/agent/tasks`). The UI shows built-in tasks as read-only references and user tasks as editable. Run detail view shows per-phase execution results from the phased executor.
+
+**Tech Stack:** React 19, Tailwind CSS, TanStack Query, Radix UI, Vite
+
+**Depends on:** Plan 1 (Agent Task System) — requires task CRUD API routes
+
+**Reference:** Existing dashboard at `ui/src/` — Agent page (`pages/Agent.tsx`), agent hooks (`hooks/use-agent.ts`), agent components (`components/agent/`)
+
+---
+
+## Design Decisions
+
+### Task management extends the Agent page, not a separate page
+
+The Agent page already shows runs. We add a "Tasks" tab alongside the existing "Runs" view. This keeps agent configuration and execution in one place.
+
+### Built-in tasks are read-only with a "Customize" action
+
+Users can view built-in task definitions (phases, tools, prompts) but cannot edit them. A "Customize" button copies the built-in task to user tasks for editing. This matches OAK's copy-to-customize pattern.
+
+### Phase visualization on run detail
+
+When a run has `phases` in its result, the RunDetail component shows a phase timeline: each phase as a card with status badge, turn count, token usage, and summary. This replaces the flat turn list for phased runs.
+
+### YAML editor for task prompts
+
+Task editing uses a monospace textarea for prompt content and a structured form for metadata (name, model, turns, timeout). Phase editing is YAML-based — a code editor for the phases array. This avoids building a complex phase form builder.
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|------|---------------|
+| `ui/src/components/agent/TaskList.tsx` | Table of all tasks (built-in + user) with actions |
+| `ui/src/components/agent/TaskDetail.tsx` | Task detail view — config, phases, prompts |
+| `ui/src/components/agent/TaskEditor.tsx` | Form for creating/editing user tasks |
+| `ui/src/components/agent/PhaseTimeline.tsx` | Per-phase run visualization |
+| `ui/src/components/agent/TaskActions.tsx` | Run, Copy, Delete action buttons |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `ui/src/pages/Agent.tsx` | Add tabs: "Runs" / "Tasks", route to TaskList |
+| `ui/src/hooks/use-agent.ts` | Add `useTask`, `useCreateTask`, `useCopyTask`, `useDeleteTask` hooks |
+| `ui/src/components/agent/RunDetail.tsx` | Add PhaseTimeline when run has phases |
+| `ui/src/components/agent/helpers.ts` | Add phase status colors, task source badge |
+
+---
+
+## Task 1: Agent Hook Extensions
+
+**Files:**
+- Modify: `ui/src/hooks/use-agent.ts`
+
+- [ ] **Step 1: Add task detail hook**
+
+```typescript
+/** Fetch a single task definition by ID. */
+export function useTask(taskId: string | undefined) {
+  return useQuery({
+    queryKey: ['agent-task', taskId],
+    queryFn: () => api.get<{ task: TaskRow }>(`/agent/tasks/${taskId}`).then(r => r.task),
+    enabled: !!taskId,
+    staleTime: TASK_STALE_TIME,
+  });
+}
+```
+
+Add `TASK_STALE_TIME = 60_000` constant.
+
+- [ ] **Step 2: Add task mutation hooks**
+
+```typescript
+/** Create a new user task. */
+export function useCreateTask() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (task: CreateTaskPayload) => api.post('/agent/tasks', task),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['agent-tasks'] }),
+  });
+}
+
+/** Copy a task to user tasks. */
+export function useCopyTask() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ taskId, name }: { taskId: string; name?: string }) =>
+      api.post(`/agent/tasks/${taskId}/copy`, { name }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['agent-tasks'] }),
+  });
+}
+
+/** Delete a user task. */
+export function useDeleteTask() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (taskId: string) => api.delete(`/agent/tasks/${taskId}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['agent-tasks'] }),
+  });
+}
+```
+
+- [ ] **Step 3: Add TypeScript types for new API shapes**
+
+```typescript
+export interface CreateTaskPayload {
+  name: string;
+  displayName: string;
+  description: string;
+  agent: string;
+  prompt: string;
+  isDefault: boolean;
+  phases?: PhaseDefinition[];
+  model?: string;
+  maxTurns?: number;
+  timeoutSeconds?: number;
+}
+
+export interface PhaseDefinition {
+  name: string;
+  prompt: string;
+  tools: string[];
+  maxTurns: number;
+  model?: string;
+  required: boolean;
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ui/src/hooks/use-agent.ts
+git commit -m "feat(ui): add task CRUD hooks — useTask, useCreateTask, useCopyTask, useDeleteTask"
+```
+
+---
+
+## Task 2: TaskList Component
+
+**Files:**
+- Create: `ui/src/components/agent/TaskList.tsx`
+- Modify: `ui/src/components/agent/helpers.ts`
+
+- [ ] **Step 1: Add task helper functions**
+
+In `helpers.ts`:
+
+```typescript
+/** Badge classes for task source. */
+export function taskSourceClass(source: string): string {
+  return source === 'user'
+    ? 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200'
+    : 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200';
+}
+
+/** Format phase count for display. */
+export function formatPhaseCount(phases: unknown[] | null | undefined): string {
+  if (!phases || phases.length === 0) return 'Single query';
+  return `${phases.length} phases`;
+}
+```
+
+- [ ] **Step 2: Create TaskList component**
+
+```tsx
+// ui/src/components/agent/TaskList.tsx
+import { useAgentTasks } from '@/hooks/use-agent';
+import { taskSourceClass, formatPhaseCount } from './helpers';
+
+export function TaskList({ onSelect }: { onSelect: (taskId: string) => void }) {
+  const { data: tasks, isLoading } = useAgentTasks();
+
+  if (isLoading) return <TaskListSkeleton />;
+
+  return (
+    <div className="space-y-2">
+      {tasks?.map(task => (
+        <button
+          key={task.id}
+          onClick={() => onSelect(task.id)}
+          className="w-full text-left p-4 rounded-lg border hover:bg-accent/50 transition-colors"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <span className="font-medium">{task.display_name}</span>
+              <span className={`ml-2 text-xs px-2 py-0.5 rounded-full ${taskSourceClass(task.source)}`}>
+                {task.source}
+              </span>
+            </div>
+            <span className="text-sm text-muted-foreground">
+              {formatPhaseCount(task.config?.phases)}
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground mt-1">{task.description}</p>
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ui/src/components/agent/TaskList.tsx ui/src/components/agent/helpers.ts
+git commit -m "feat(ui): add TaskList component with source badges and phase counts"
+```
+
+---
+
+## Task 3: TaskDetail Component
+
+**Files:**
+- Create: `ui/src/components/agent/TaskDetail.tsx`
+- Create: `ui/src/components/agent/TaskActions.tsx`
+
+- [ ] **Step 1: Create TaskActions component**
+
+Action buttons: Run Now, Customize (copy), Delete (user tasks only).
+
+```tsx
+export function TaskActions({ task, onRun, onCopy, onDelete }: TaskActionsProps) {
+  return (
+    <div className="flex gap-2">
+      <Button onClick={onRun} size="sm">Run Now</Button>
+      {task.source === 'built-in' && (
+        <Button onClick={onCopy} variant="outline" size="sm">Customize</Button>
+      )}
+      {task.source === 'user' && (
+        <Button onClick={onDelete} variant="destructive" size="sm">Delete</Button>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create TaskDetail component**
+
+Shows task metadata, execution config, and phase definitions:
+
+```tsx
+export function TaskDetail({ taskId, onBack }: { taskId: string; onBack: () => void }) {
+  const { data: task, isLoading } = useTask(taskId);
+  const triggerRun = useTriggerRun();
+  const copyTask = useCopyTask();
+  const deleteTask = useDeleteTask();
+
+  if (isLoading || !task) return <Skeleton />;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <button onClick={onBack} className="text-sm text-muted-foreground">Back to tasks</button>
+        <TaskActions
+          task={task}
+          onRun={() => triggerRun.mutate({ task: task.id })}
+          onCopy={() => copyTask.mutate({ taskId: task.id })}
+          onDelete={() => deleteTask.mutate(task.id)}
+        />
+      </div>
+
+      <div>
+        <h2 className="text-xl font-semibold">{task.display_name}</h2>
+        <p className="text-muted-foreground">{task.description}</p>
+      </div>
+
+      {/* Execution Config */}
+      <section>
+        <h3 className="font-medium mb-2">Execution</h3>
+        <dl className="grid grid-cols-3 gap-4 text-sm">
+          <div><dt className="text-muted-foreground">Model</dt><dd>{task.model ?? 'default'}</dd></div>
+          <div><dt className="text-muted-foreground">Max Turns</dt><dd>{task.max_turns ?? 'default'}</dd></div>
+          <div><dt className="text-muted-foreground">Timeout</dt><dd>{task.timeout_seconds ?? 'default'}s</dd></div>
+        </dl>
+      </section>
+
+      {/* Phases */}
+      {task.config?.phases && (
+        <section>
+          <h3 className="font-medium mb-2">Phases ({task.config.phases.length})</h3>
+          <div className="space-y-2">
+            {task.config.phases.map((phase, i) => (
+              <div key={phase.name} className="p-3 rounded border text-sm">
+                <div className="flex justify-between">
+                  <span className="font-medium">{i + 1}. {phase.name}</span>
+                  <span className="text-muted-foreground">
+                    {phase.maxTurns} turns
+                    {phase.required && ' (required)'}
+                  </span>
+                </div>
+                <div className="text-muted-foreground mt-1">
+                  Tools: {phase.tools.join(', ')}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Prompt */}
+      <section>
+        <h3 className="font-medium mb-2">Prompt</h3>
+        <pre className="p-3 rounded border bg-muted text-sm whitespace-pre-wrap font-mono">
+          {task.prompt}
+        </pre>
+      </section>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ui/src/components/agent/TaskDetail.tsx ui/src/components/agent/TaskActions.tsx
+git commit -m "feat(ui): add TaskDetail and TaskActions components"
+```
+
+---
+
+## Task 4: PhaseTimeline Component
+
+**Files:**
+- Create: `ui/src/components/agent/PhaseTimeline.tsx`
+- Modify: `ui/src/components/agent/RunDetail.tsx`
+
+- [ ] **Step 1: Create PhaseTimeline component**
+
+Visual timeline of phase execution results:
+
+```tsx
+export function PhaseTimeline({ phases }: { phases: PhaseResult[] }) {
+  return (
+    <div className="space-y-3">
+      <h3 className="font-medium">Phase Execution</h3>
+      {phases.map((phase, i) => (
+        <div key={phase.name} className="flex items-start gap-3">
+          {/* Step indicator */}
+          <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium
+            ${phase.status === 'completed' ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' :
+              phase.status === 'failed' ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' :
+              'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200'}`}>
+            {i + 1}
+          </div>
+
+          {/* Phase details */}
+          <div className="flex-1 p-3 rounded border">
+            <div className="flex justify-between items-center">
+              <span className="font-medium">{phase.name}</span>
+              <div className="flex gap-3 text-sm text-muted-foreground">
+                <span>{phase.turnsUsed} turns</span>
+                <span>{formatTokens(phase.tokensUsed)} tokens</span>
+                <span>{formatCost(phase.costUsd)}</span>
+              </div>
+            </div>
+            {phase.summary && (
+              <p className="text-sm text-muted-foreground mt-1 line-clamp-2">{phase.summary}</p>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Integrate PhaseTimeline into RunDetail**
+
+In `RunDetail.tsx`, check if the run result has phases and render the timeline:
+
+```tsx
+// After the existing run metadata section:
+{run.phases && run.phases.length > 0 && (
+  <PhaseTimeline phases={run.phases} />
+)}
+```
+
+Note: The `phases` data needs to be available on the run response. This requires the executor to store phase results. Currently `AgentRunResult.phases` exists in the type but isn't persisted to DB. Two options:
+- Store `phases` JSON in `agent_runs.actions_taken` column (already exists, currently unused)
+- Return phases from a new API endpoint
+
+Use `actions_taken` column — it's the right place for structured run output.
+
+- [ ] **Step 3: Update run API to persist and return phases**
+
+In `executor.ts`, when a phased run completes, serialize `phaseResults` into `actions_taken`:
+
+```typescript
+await updateRunStatus(runId, STATUS_COMPLETED, {
+  completed_at: completedAt,
+  tokens_used: tokensUsed,
+  cost_usd: costUsd,
+  actions_taken: JSON.stringify({ phases: phaseResults }),
+});
+```
+
+In `use-agent.ts`, parse `actions_taken` when available:
+
+```typescript
+export interface RunRow {
+  // ... existing fields ...
+  actions_taken: string | null;  // JSON with { phases: PhaseResult[] }
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ui/src/components/agent/PhaseTimeline.tsx ui/src/components/agent/RunDetail.tsx \
+  ui/src/hooks/use-agent.ts src/agent/executor.ts
+git commit -m "feat(ui): add PhaseTimeline component, persist phase results in run record"
+```
+
+---
+
+## Task 5: Agent Page Tabs (Runs / Tasks)
+
+**Files:**
+- Modify: `ui/src/pages/Agent.tsx`
+
+- [ ] **Step 1: Add tab navigation to Agent page**
+
+Replace the current flat layout with a tabbed interface:
+
+```tsx
+export default function AgentPage() {
+  const [tab, setTab] = useState<'runs' | 'tasks'>('runs');
+  const [selectedRunId, setSelectedRunId] = useState<string | undefined>();
+  const [selectedTaskId, setSelectedTaskId] = useState<string | undefined>();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex gap-1 p-1 rounded-lg bg-muted">
+          <button
+            onClick={() => { setTab('runs'); setSelectedTaskId(undefined); }}
+            className={`px-4 py-2 rounded-md text-sm font-medium transition-colors
+              ${tab === 'runs' ? 'bg-background shadow-sm' : 'text-muted-foreground hover:text-foreground'}`}
+          >
+            Runs
+          </button>
+          <button
+            onClick={() => { setTab('tasks'); setSelectedRunId(undefined); }}
+            className={`px-4 py-2 rounded-md text-sm font-medium transition-colors
+              ${tab === 'tasks' ? 'bg-background shadow-sm' : 'text-muted-foreground hover:text-foreground'}`}
+          >
+            Tasks
+          </button>
+        </div>
+
+        {tab === 'runs' && <TriggerRunButton />}
+      </div>
+
+      {tab === 'runs' && (
+        selectedRunId
+          ? <RunDetail runId={selectedRunId} onBack={() => setSelectedRunId(undefined)} />
+          : <RunList onSelect={setSelectedRunId} />
+      )}
+
+      {tab === 'tasks' && (
+        selectedTaskId
+          ? <TaskDetail taskId={selectedTaskId} onBack={() => setSelectedTaskId(undefined)} />
+          : <TaskList onSelect={setSelectedTaskId} />
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify in dev mode**
+
+```bash
+cd ui && MYCO_DAEMON_PORT=<port> npx vite dev
+```
+
+Navigate to the Agent page, verify tabs switch between Runs and Tasks views.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ui/src/pages/Agent.tsx
+git commit -m "feat(ui): add Runs/Tasks tabs to Agent page"
+```
+
+---
+
+## Task 6: Build and Quality Gate
+
+- [ ] **Step 1: Run `make check`**
+
+Expected: All backend tests pass
+
+- [ ] **Step 2: Run `make build`**
+
+Expected: Both tsup (backend) and vite build (frontend) succeed
+
+- [ ] **Step 3: Visual verification**
+
+Start daemon, open dashboard, verify:
+- Tasks tab shows all 7 built-in tasks
+- Task detail shows phases, tools, prompt
+- Run detail shows PhaseTimeline for phased runs
+- "Customize" on built-in creates user copy
+- "Delete" on user task removes it
+
+- [ ] **Step 4: Commit any fixes**
+
+---
+
+## Summary
+
+| Task | What it delivers | Depends on |
+|------|-----------------|------------|
+| 1. Agent Hooks | Task CRUD mutations + queries | Plan 1 API |
+| 2. TaskList | Browseable task list with source badges | Task 1 |
+| 3. TaskDetail + Actions | Task inspection, Run/Copy/Delete | Task 1 |
+| 4. PhaseTimeline | Per-phase run visualization | — |
+| 5. Agent Page Tabs | Runs/Tasks tab navigation | Tasks 2, 3, 4 |
+| 6. Quality Gate | Build + visual verification | All |
+
+**After this plan:** The dashboard provides full task management — users can browse built-in tasks, customize them, create new ones, and see per-phase execution results. Combined with Plans 1 and 2, this completes the agent orchestrator system.

--- a/docs/superpowers/plans/2026-03-24-orchestrator-intelligence.md
+++ b/docs/superpowers/plans/2026-03-24-orchestrator-intelligence.md
@@ -1,0 +1,800 @@
+# Orchestrator Intelligence — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an intelligent orchestration layer that plans phase execution based on vault state, executes context queries before phases, routes models per-phase/per-provider, and adapts the pipeline dynamically.
+
+**Architecture:** Before running phases, the executor calls a planning model (orchestrator) that reviews vault state and produces a phase execution plan. Each phase can use a different model via provider configuration. Context queries gather data before the orchestrator decides. The orchestrator pattern is opt-in — tasks without an orchestrator config use the existing static phase loop.
+
+**Tech Stack:** TypeScript, Claude Agent SDK, YAML task definitions, PGlite
+
+**Depends on:** Plan 1 (Agent Task System) — requires registry, extended task schema, execution config
+
+**Reference:** OAK executor at `~/Repos/open-agent-kit/src/open_agent_kit/features/agent_runtime/executor.py` — provider env var injection pattern. Phased executor spec at `docs/superpowers/specs/2026-03-24-phased-executor.md` — orchestrator section.
+
+---
+
+## Design Decisions
+
+### Orchestrator is a planning call, not a persistent agent
+
+The orchestrator is a single `query()` call that receives vault state + task definition and returns a structured phase plan. It does NOT run tools — it only plans. This keeps it cheap (few turns, small context) and separable from execution.
+
+### Orchestrator output is a JSON phase plan
+
+The orchestrator returns structured JSON, not free text. The executor parses this to determine:
+- Which phases to run (skip phases with nothing to do)
+- Phase order (may reorder if dependencies allow)
+- Turn budget adjustments (more turns for extraction if many batches)
+- Context notes for each phase (what to focus on)
+
+```typescript
+interface OrchestratorPlan {
+  phases: OrchestratorPhaseDirective[];
+  reasoning: string;
+}
+
+interface OrchestratorPhaseDirective {
+  name: string;
+  skip: boolean;
+  skipReason?: string;
+  maxTurns?: number;        // override from task definition
+  contextNotes?: string;    // additional guidance for this phase
+}
+```
+
+### Provider env vars follow OAK's pattern
+
+Provider configuration sets environment variables before each `query()` call:
+- **Cloud** (default): no env changes needed
+- **Ollama**: `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN=ollama`, `ANTHROPIC_API_KEY=""`
+- **LM Studio**: `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN=lmstudio`, `ANTHROPIC_API_KEY=""`
+
+Env vars are set before and restored after each phase's `query()` call.
+
+### Context queries run before the orchestrator
+
+Context queries are defined per-task (from Plan 1's `contextQueries` field). They run before the orchestrator planning call using the vault's existing tool infrastructure. Results are injected into the orchestrator's prompt as structured data.
+
+### Fallback: code-only orchestration when no planning model available
+
+If the orchestrator model is unavailable (local-only setup, no API key), fall back to code-only orchestration:
+- Run all phases sequentially (current behavior)
+- Skip phases with `required: false` if the prior phase reported nothing to do
+- No turn budget adjustments
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|------|---------------|
+| `src/agent/orchestrator.ts` | Planning call, phase plan parsing, directive application |
+| `src/agent/context-queries.ts` | Execute context queries using vault tool handlers |
+| `src/agent/provider.ts` | Provider env var management (set/restore) |
+| `src/agent/prompts/orchestrator.md` | Orchestrator system prompt template |
+| `tests/agent/orchestrator.test.ts` | Orchestrator planning tests |
+| `tests/agent/context-queries.test.ts` | Context query execution tests |
+| `tests/agent/provider.test.ts` | Provider env var tests |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `src/agent/executor.ts` | Integrate orchestrator planning, provider routing, context queries |
+| `src/agent/types.ts` | Add OrchestratorPlan, OrchestratorPhaseDirective types |
+| `src/agent/definitions/tasks/full-intelligence.yaml` | Add orchestrator config and context queries |
+
+---
+
+## Task 1: Orchestrator Types and Prompt
+
+**Files:**
+- Modify: `src/agent/types.ts`
+- Create: `src/agent/prompts/orchestrator.md`
+
+- [ ] **Step 1: Add orchestrator types to `types.ts`**
+
+```typescript
+/** Directive for a single phase from the orchestrator's plan. */
+export interface OrchestratorPhaseDirective {
+  name: string;
+  skip: boolean;
+  skipReason?: string;
+  maxTurns?: number;
+  contextNotes?: string;
+}
+
+/** The orchestrator's output — a plan for phase execution. */
+export interface OrchestratorPlan {
+  phases: OrchestratorPhaseDirective[];
+  reasoning: string;
+}
+
+/** Orchestrator configuration on a task definition. */
+export interface OrchestratorConfig {
+  enabled: boolean;
+  model?: string;           // orchestrator model (defaults to task model)
+  maxTurns?: number;        // turn budget for planning call (default: 3)
+}
+```
+
+Add `orchestrator` to `AgentTask`:
+
+```typescript
+export interface AgentTask {
+  // ... existing fields ...
+  orchestrator?: OrchestratorConfig;
+}
+```
+
+And to `EffectiveConfig`:
+
+```typescript
+export interface EffectiveConfig {
+  // ... existing fields ...
+  orchestrator?: OrchestratorConfig;
+}
+```
+
+- [ ] **Step 2: Create orchestrator prompt template**
+
+Create `src/agent/prompts/orchestrator.md`:
+
+```markdown
+You are a vault intelligence orchestrator. Your job is to plan which phases
+of the intelligence pipeline should run, based on the current vault state.
+
+## Vault State
+{{vault_state}}
+
+## Available Phases
+{{phase_definitions}}
+
+## Context Query Results
+{{context_results}}
+
+## Instructions
+
+Analyze the vault state and decide:
+1. Which phases should run (skip phases with nothing to do)
+2. Whether any phases need adjusted turn budgets
+3. What each phase should focus on
+
+Return a JSON object with this exact structure:
+```json
+{
+  "phases": [
+    {
+      "name": "phase-name",
+      "skip": false,
+      "maxTurns": 15,
+      "contextNotes": "Focus on the 5 unprocessed batches from session X"
+    }
+  ],
+  "reasoning": "Brief explanation of planning decisions"
+}
+```
+
+Rules:
+- Include ALL phases from Available Phases, marking skipped ones with `skip: true`
+- Required phases (`required: true`) should almost never be skipped
+- If there are no unprocessed batches, skip extract but still run consolidate/graph/digest
+- Adjust maxTurns based on workload (more batches = more extract turns)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/agent/types.ts src/agent/prompts/orchestrator.md
+git commit -m "feat(agent): add orchestrator types and prompt template"
+```
+
+---
+
+## Task 2: Context Query Execution
+
+**Files:**
+- Create: `src/agent/context-queries.ts`
+- Create: `tests/agent/context-queries.test.ts`
+
+- [ ] **Step 1: Create context query executor**
+
+Context queries use the same vault tool handlers from `tools.ts` but run them directly (no Agent SDK). This is a lightweight pre-flight data gather.
+
+```typescript
+import type { ContextQuery } from './types.js';
+import { getUnprocessedBatches } from '@myco/db/queries/batches.js';
+import { listSpores } from '@myco/db/queries/spores.js';
+import { listSessions } from '@myco/db/queries/sessions.js';
+import { getStatesForAgent } from '@myco/db/queries/agent-state.js';
+
+/** Result of a single context query execution. */
+export interface ContextQueryResult {
+  tool: string;
+  purpose: string;
+  data: unknown;
+  error?: string;
+}
+
+/** Default limit for context query results. */
+const DEFAULT_CONTEXT_QUERY_LIMIT = 10;
+
+/**
+ * Execute a set of context queries and return structured results.
+ * Queries that fail are included with an error field — never throws.
+ */
+export async function executeContextQueries(
+  agentId: string,
+  queries: ContextQuery[],
+): Promise<ContextQueryResult[]> {
+  const results: ContextQueryResult[] = [];
+
+  for (const query of queries) {
+    try {
+      const data = await executeQuery(agentId, query);
+      results.push({ tool: query.tool, purpose: query.purpose, data });
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      results.push({ tool: query.tool, purpose: query.purpose, data: null, error });
+      if (query.required) {
+        throw new Error(`Required context query failed: ${query.tool} — ${error}`);
+      }
+    }
+  }
+
+  return results;
+}
+
+/** Route a single query to the appropriate DB function. */
+async function executeQuery(agentId: string, query: ContextQuery): Promise<unknown> {
+  const limit = query.limit ?? DEFAULT_CONTEXT_QUERY_LIMIT;
+
+  switch (query.tool) {
+    case 'vault_unprocessed':
+      return getUnprocessedBatches({ limit });
+    case 'vault_spores':
+      return listSpores({ agent_id: agentId, limit });
+    case 'vault_sessions':
+      return listSessions({ limit });
+    case 'vault_state':
+      return getStatesForAgent(agentId);
+    default:
+      throw new Error(`Unknown context query tool: ${query.tool}`);
+  }
+}
+```
+
+- [ ] **Step 2: Write context query tests**
+
+```typescript
+describe('executeContextQueries', () => {
+  it('executes vault_unprocessed query and returns results');
+  it('executes vault_spores query with agent_id filter');
+  it('executes vault_state query');
+  it('returns error field for failed non-required query');
+  it('throws on failed required query');
+  it('rejects unknown tool name');
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `npx vitest run tests/agent/context-queries.test.ts`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/agent/context-queries.ts tests/agent/context-queries.test.ts
+git commit -m "feat(agent): add context query executor for pre-phase data gathering"
+```
+
+---
+
+## Task 3: Provider Environment Management
+
+**Files:**
+- Create: `src/agent/provider.ts`
+- Create: `tests/agent/provider.test.ts`
+
+- [ ] **Step 1: Create provider env manager**
+
+Following OAK's pattern from `executor.py:_apply_provider_env`:
+
+```typescript
+import type { ProviderConfig } from './types.js';
+
+// -------------------------------------------------------------------------
+// Constants
+// -------------------------------------------------------------------------
+
+/** Environment variable for Anthropic API base URL. */
+const ENV_ANTHROPIC_BASE_URL = 'ANTHROPIC_BASE_URL';
+
+/** Environment variable for Anthropic auth token. */
+const ENV_ANTHROPIC_AUTH_TOKEN = 'ANTHROPIC_AUTH_TOKEN';
+
+/** Environment variable for Anthropic API key. */
+const ENV_ANTHROPIC_API_KEY = 'ANTHROPIC_API_KEY';
+
+/** Default Ollama base URL. */
+const DEFAULT_OLLAMA_URL = 'http://localhost:11434';
+
+/** Default LM Studio base URL. */
+const DEFAULT_LMSTUDIO_URL = 'http://localhost:1234';
+
+/** Auth token value for Ollama provider. */
+const OLLAMA_AUTH_TOKEN = 'ollama';
+
+/** Auth token value for LM Studio provider. */
+const LMSTUDIO_AUTH_TOKEN = 'lmstudio';
+
+// -------------------------------------------------------------------------
+// Types
+// -------------------------------------------------------------------------
+
+/** Saved environment state for restoration after a query. */
+export interface SavedEnv {
+  vars: Record<string, string | undefined>;
+}
+
+// -------------------------------------------------------------------------
+// Public API
+// -------------------------------------------------------------------------
+
+/**
+ * Apply provider environment variables for a query() call.
+ * Returns saved state for restoration via restoreProviderEnv().
+ */
+export function applyProviderEnv(provider: ProviderConfig): SavedEnv {
+  const saved: Record<string, string | undefined> = {};
+
+  const envVars = getProviderEnvVars(provider);
+  for (const [key, value] of Object.entries(envVars)) {
+    saved[key] = process.env[key];
+    process.env[key] = value;
+  }
+
+  return { vars: saved };
+}
+
+/**
+ * Restore environment variables after a query() call.
+ */
+export function restoreProviderEnv(saved: SavedEnv): void {
+  for (const [key, value] of Object.entries(saved.vars)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+/**
+ * Get the environment variables for a provider configuration.
+ */
+export function getProviderEnvVars(provider: ProviderConfig): Record<string, string> {
+  switch (provider.type) {
+    case 'cloud':
+      return {};
+    case 'ollama':
+      return {
+        [ENV_ANTHROPIC_BASE_URL]: provider.baseUrl ?? DEFAULT_OLLAMA_URL,
+        [ENV_ANTHROPIC_AUTH_TOKEN]: OLLAMA_AUTH_TOKEN,
+        [ENV_ANTHROPIC_API_KEY]: '',
+      };
+    case 'lmstudio':
+      return {
+        [ENV_ANTHROPIC_BASE_URL]: provider.baseUrl ?? DEFAULT_LMSTUDIO_URL,
+        [ENV_ANTHROPIC_AUTH_TOKEN]: provider.apiKey ?? LMSTUDIO_AUTH_TOKEN,
+        [ENV_ANTHROPIC_API_KEY]: '',
+      };
+    default:
+      return {};
+  }
+}
+```
+
+- [ ] **Step 2: Write provider tests**
+
+```typescript
+describe('applyProviderEnv / restoreProviderEnv', () => {
+  it('sets Ollama env vars and restores originals');
+  it('sets LM Studio env vars and restores originals');
+  it('cloud provider sets no env vars');
+  it('restores undefined vars by deleting them');
+});
+
+describe('getProviderEnvVars', () => {
+  it('returns correct vars for ollama with default URL');
+  it('returns correct vars for ollama with custom URL');
+  it('returns correct vars for lmstudio');
+  it('returns empty for cloud');
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `npx vitest run tests/agent/provider.test.ts`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/agent/provider.ts tests/agent/provider.test.ts
+git commit -m "feat(agent): add provider env management for Ollama/LM Studio/cloud"
+```
+
+---
+
+## Task 4: Orchestrator Planning Call
+
+**Files:**
+- Create: `src/agent/orchestrator.ts`
+- Create: `tests/agent/orchestrator.test.ts`
+
+- [ ] **Step 1: Create orchestrator module**
+
+```typescript
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type {
+  OrchestratorPlan,
+  OrchestratorPhaseDirective,
+  OrchestratorConfig,
+  PhaseDefinition,
+  ContextQueryResult,
+} from './types.js';
+
+// -------------------------------------------------------------------------
+// Constants
+// -------------------------------------------------------------------------
+
+/** Default max turns for the orchestrator planning call. */
+const DEFAULT_ORCHESTRATOR_MAX_TURNS = 3;
+
+/** Orchestrator prompt template filename. */
+const ORCHESTRATOR_PROMPT_FILE = 'orchestrator.md';
+
+// -------------------------------------------------------------------------
+// Prompt Composition
+// -------------------------------------------------------------------------
+
+/**
+ * Load the orchestrator prompt template and substitute variables.
+ */
+export function composeOrchestratorPrompt(
+  vaultState: string,
+  phases: PhaseDefinition[],
+  contextResults: ContextQueryResult[],
+): string {
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  const templatePath = path.join(dir, 'prompts', ORCHESTRATOR_PROMPT_FILE);
+  let template = fs.readFileSync(templatePath, 'utf-8');
+
+  const phaseList = phases.map(p =>
+    `- **${p.name}** (maxTurns: ${p.maxTurns}, required: ${p.required}): ${p.prompt.slice(0, 100)}...`
+  ).join('\n');
+
+  const contextStr = contextResults.length > 0
+    ? contextResults.map(r =>
+        `### ${r.tool} — ${r.purpose}\n${r.error ? `Error: ${r.error}` : JSON.stringify(r.data, null, 2)}`
+      ).join('\n\n')
+    : 'No context queries configured.';
+
+  template = template.replace('{{vault_state}}', vaultState);
+  template = template.replace('{{phase_definitions}}', phaseList);
+  template = template.replace('{{context_results}}', contextStr);
+
+  return template;
+}
+
+// -------------------------------------------------------------------------
+// Plan Parsing
+// -------------------------------------------------------------------------
+
+/**
+ * Parse the orchestrator's response into a structured plan.
+ * Falls back to "run all phases" if parsing fails.
+ */
+export function parseOrchestratorPlan(
+  response: string,
+  phases: PhaseDefinition[],
+): OrchestratorPlan {
+  try {
+    // Extract JSON from response (may be wrapped in markdown code block)
+    const jsonMatch = response.match(/```json\s*([\s\S]*?)```/) ?? response.match(/(\{[\s\S]*\})/);
+    if (!jsonMatch) throw new Error('No JSON found in orchestrator response');
+
+    const parsed = JSON.parse(jsonMatch[1]) as OrchestratorPlan;
+    if (!Array.isArray(parsed.phases)) throw new Error('phases must be an array');
+
+    return parsed;
+  } catch {
+    // Fallback: run all phases with default config
+    return {
+      phases: phases.map(p => ({ name: p.name, skip: false })),
+      reasoning: 'Orchestrator response could not be parsed — running all phases.',
+    };
+  }
+}
+
+// -------------------------------------------------------------------------
+// Directive Application
+// -------------------------------------------------------------------------
+
+/**
+ * Apply orchestrator directives to phase definitions.
+ * Returns the modified phases list (filtered, reordered, turn-adjusted).
+ */
+export function applyDirectives(
+  phases: PhaseDefinition[],
+  directives: OrchestratorPhaseDirective[],
+): PhaseDefinition[] {
+  const directiveMap = new Map(directives.map(d => [d.name, d]));
+  const result: PhaseDefinition[] = [];
+
+  for (const phase of phases) {
+    const directive = directiveMap.get(phase.name);
+
+    if (directive?.skip) {
+      // Skip this phase — but never skip required phases
+      if (phase.required) {
+        console.warn(`[orchestrator] Cannot skip required phase "${phase.name}"`);
+      } else {
+        continue;
+      }
+    }
+
+    result.push({
+      ...phase,
+      // Apply turn budget override
+      maxTurns: directive?.maxTurns ?? phase.maxTurns,
+      // Append context notes to phase prompt
+      prompt: directive?.contextNotes
+        ? `${phase.prompt}\n\n## Orchestrator Guidance\n${directive.contextNotes}`
+        : phase.prompt,
+    });
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 2: Write orchestrator tests**
+
+```typescript
+describe('composeOrchestratorPrompt', () => {
+  it('substitutes vault state, phase definitions, and context results');
+  it('handles empty context results');
+});
+
+describe('parseOrchestratorPlan', () => {
+  it('parses valid JSON response');
+  it('extracts JSON from markdown code block');
+  it('falls back to run-all on malformed response');
+  it('falls back to run-all on missing phases array');
+});
+
+describe('applyDirectives', () => {
+  it('skips non-required phases marked skip: true');
+  it('refuses to skip required phases (logs warning)');
+  it('applies maxTurns override from directive');
+  it('appends contextNotes to phase prompt');
+  it('preserves phase order when no reordering');
+  it('runs all phases when no directives match');
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `npx vitest run tests/agent/orchestrator.test.ts`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/agent/orchestrator.ts tests/agent/orchestrator.test.ts
+git commit -m "feat(agent): add orchestrator planning, parsing, and directive application"
+```
+
+---
+
+## Task 5: Integrate Orchestrator into Executor
+
+**Files:**
+- Modify: `src/agent/executor.ts`
+- Test: `tests/agent/executor.test.ts` (extend)
+
+- [ ] **Step 1: Add orchestrator call before phased execution**
+
+In `executePhasedQuery`, add an orchestrator step before the phase loop:
+
+```typescript
+import { composeOrchestratorPrompt, parseOrchestratorPlan, applyDirectives } from './orchestrator.js';
+import { executeContextQueries } from './context-queries.js';
+import { applyProviderEnv, restoreProviderEnv } from './provider.js';
+
+// Inside executePhasedQuery, before the phase loop:
+let effectivePhases = phases;
+
+if (config.orchestrator?.enabled) {
+  // 1. Run context queries
+  const contextResults = config.contextQueries
+    ? await executeContextQueries(agentId, Object.values(config.contextQueries).flat())
+    : [];
+
+  // 2. Call orchestrator
+  const orchestratorPrompt = composeOrchestratorPrompt(vaultContext, phases, contextResults);
+  const orchestratorModel = config.orchestrator.model ?? config.model;
+  const orchestratorTurns = config.orchestrator.maxTurns ?? DEFAULT_ORCHESTRATOR_MAX_TURNS;
+
+  let planResponse = '';
+  for await (const message of query({
+    prompt: orchestratorPrompt,
+    options: {
+      model: orchestratorModel,
+      maxTurns: orchestratorTurns,
+      permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
+      persistSession: false,
+      tools: [],
+    },
+  })) {
+    if (message.type === 'result' && 'result' in message) {
+      planResponse = message.result as string;
+    }
+  }
+
+  // 3. Parse and apply plan
+  const plan = parseOrchestratorPlan(planResponse, phases);
+  effectivePhases = applyDirectives(phases, plan.phases);
+}
+
+// Then iterate effectivePhases instead of phases
+```
+
+- [ ] **Step 2: Add provider routing per phase**
+
+In the phase loop, apply/restore provider env for each phase:
+
+```typescript
+for (const phase of effectivePhases) {
+  const phaseProvider = phase.model
+    ? config.execution?.provider  // use task-level provider for non-default models
+    : undefined;
+
+  const savedEnv = phaseProvider ? applyProviderEnv(phaseProvider) : null;
+  try {
+    // ... existing phase query() call ...
+  } finally {
+    if (savedEnv) restoreProviderEnv(savedEnv);
+  }
+}
+```
+
+- [ ] **Step 3: Update executor tests**
+
+Add tests:
+- "orchestrator enabled: runs planning call before phases"
+- "orchestrator skips non-required phase when directed"
+- "orchestrator cannot skip required phase"
+- "orchestrator adjusts turn budget per directive"
+- "orchestrator disabled (default): runs all phases statically"
+- "orchestrator fallback on parse failure: runs all phases"
+
+- [ ] **Step 4: Run all tests**
+
+Run: `make check`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/executor.ts tests/agent/executor.test.ts
+git commit -m "feat(agent): integrate orchestrator planning and provider routing into executor"
+```
+
+---
+
+## Task 6: Update full-intelligence Task with Orchestrator Config
+
+**Files:**
+- Modify: `src/agent/definitions/tasks/full-intelligence.yaml`
+- Modify: `src/agent/schemas.ts` (add orchestrator to schema)
+
+- [ ] **Step 1: Add orchestrator schema**
+
+In `src/agent/schemas.ts`:
+
+```typescript
+export const OrchestratorConfigSchema = z.object({
+  enabled: z.boolean(),
+  model: z.string().optional(),
+  maxTurns: z.number().optional(),
+});
+```
+
+Add to `AgentTaskSchema`:
+```typescript
+orchestrator: OrchestratorConfigSchema.optional(),
+```
+
+- [ ] **Step 2: Add orchestrator config and context queries to full-intelligence.yaml**
+
+```yaml
+orchestrator:
+  enabled: true
+  model: claude-sonnet-4-6
+  maxTurns: 3
+
+contextQueries:
+  pre-planning:
+    - tool: vault_unprocessed
+      queryTemplate: ""
+      limit: 5
+      purpose: "Check if there are unprocessed batches"
+      required: false
+    - tool: vault_state
+      queryTemplate: ""
+      limit: 10
+      purpose: "Get agent cursor state"
+      required: false
+    - tool: vault_spores
+      queryTemplate: ""
+      limit: 20
+      purpose: "Review recent spores for consolidation candidates"
+      required: false
+```
+
+- [ ] **Step 3: Run loader tests to verify YAML still parses**
+
+Run: `npx vitest run tests/agent/loader.test.ts`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/agent/schemas.ts src/agent/definitions/tasks/full-intelligence.yaml
+git commit -m "feat(agent): enable orchestrator on full-intelligence task with context queries"
+```
+
+---
+
+## Task 7: Full Quality Gate
+
+- [ ] **Step 1: Run `make check`**
+
+Expected: All tests pass
+
+- [ ] **Step 2: Run `make build`**
+
+Expected: Bundle succeeds
+
+- [ ] **Step 3: Integration test**
+
+```bash
+myco-dev restart
+myco-dev agent run                     # verify orchestrator planning runs
+myco-dev agent run --task extract-only  # verify non-orchestrated task still works
+```
+
+Check daemon logs for orchestrator planning output.
+
+- [ ] **Step 4: Commit any fixes**
+
+---
+
+## Summary
+
+| Task | What it delivers | Depends on |
+|------|-----------------|------------|
+| 1. Types + Prompt | OrchestratorPlan types, prompt template | Plan 1 |
+| 2. Context Queries | Pre-phase data gathering from vault | Plan 1 |
+| 3. Provider Env | Ollama/LM Studio/cloud env var management | — |
+| 4. Orchestrator | Planning call, parsing, directive application | Tasks 1, 2 |
+| 5. Executor Integration | Wire orchestrator + provider into phase loop | Tasks 2, 3, 4 |
+| 6. Task Config | Enable orchestrator on full-intelligence | Task 5 |
+| 7. Quality Gate | Verification | All |
+
+**After this plan:** The agent intelligently plans its execution — skipping phases with nothing to do, adjusting turn budgets based on workload, and routing models per provider. Combined with Plan 1's user tasks, users can create custom tasks with custom orchestrator behavior.

--- a/src/agent/context-queries.ts
+++ b/src/agent/context-queries.ts
@@ -1,0 +1,136 @@
+/**
+ * Context query execution for pre-phase vault lookups.
+ *
+ * Executes lightweight vault queries before the orchestrator makes planning
+ * decisions. Uses the same DB query functions as the vault tools but bypasses
+ * the MCP layer entirely.
+ */
+
+import type { ContextQuery } from './types.js';
+import { getUnprocessedBatches } from '@myco/db/queries/batches.js';
+import { listSpores } from '@myco/db/queries/spores.js';
+import { listSessions } from '@myco/db/queries/sessions.js';
+import { getStatesForAgent } from '@myco/db/queries/agent-state.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default limit for context query results when none specified. */
+const DEFAULT_CONTEXT_QUERY_LIMIT = 10;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Result of a single context query execution. */
+export interface ContextQueryResult {
+  tool: string;
+  purpose: string;
+  data: unknown;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a list of context queries against the vault database.
+ *
+ * Each query is routed to the appropriate DB function based on `query.tool`.
+ * On failure:
+ * - Required queries throw — the caller should abort.
+ * - Optional queries return a result with `error` set and `data: null`.
+ *
+ * Unknown tool names always throw, regardless of `required`.
+ *
+ * @param agentId - The agent ID to scope agent-specific queries.
+ * @param queries - The list of context queries to execute.
+ * @returns Resolved results in the same order as the input queries.
+ */
+export async function executeContextQueries(
+  agentId: string,
+  queries: ContextQuery[],
+): Promise<ContextQueryResult[]> {
+  const results: ContextQueryResult[] = [];
+
+  for (const query of queries) {
+    const limit = query.limit ?? DEFAULT_CONTEXT_QUERY_LIMIT;
+
+    // Unknown tools are a programming error — always throw regardless of required flag.
+    validateTool(query.tool);
+
+    try {
+      const data = await executeQuery(agentId, query.tool, limit);
+      results.push({ tool: query.tool, purpose: query.purpose, data });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+
+      if (query.required) {
+        throw new Error(
+          `Required context query "${query.tool}" failed: ${message}`,
+        );
+      }
+
+      results.push({
+        tool: query.tool,
+        purpose: query.purpose,
+        data: null,
+        error: message,
+      });
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/** Set of recognized context query tool names. */
+const KNOWN_CONTEXT_QUERY_TOOLS = new Set([
+  'vault_unprocessed',
+  'vault_spores',
+  'vault_sessions',
+  'vault_state',
+]);
+
+/**
+ * Guard against unknown tool names.
+ *
+ * Unknown tools are a programming error (misconfigured task YAML), so they
+ * always throw — even if the query is not marked required.
+ */
+function validateTool(tool: string): void {
+  if (!KNOWN_CONTEXT_QUERY_TOOLS.has(tool)) {
+    throw new Error(`Unknown context query tool: "${tool}"`);
+  }
+}
+
+/**
+ * Route a single query to the appropriate DB function.
+ */
+async function executeQuery(
+  agentId: string,
+  tool: string,
+  limit: number,
+): Promise<unknown> {
+  switch (tool) {
+    case 'vault_unprocessed':
+      return getUnprocessedBatches({ limit });
+
+    case 'vault_spores':
+      return listSpores({ agent_id: agentId, limit });
+
+    case 'vault_sessions':
+      return listSessions({ limit });
+
+    case 'vault_state':
+      return getStatesForAgent(agentId);
+
+    default:
+      throw new Error(`Unknown context query tool: "${tool}"`);
+  }
+}

--- a/src/agent/context-queries.ts
+++ b/src/agent/context-queries.ts
@@ -53,19 +53,32 @@ export async function executeContextQueries(
   agentId: string,
   queries: ContextQuery[],
 ): Promise<ContextQueryResult[]> {
-  const results: ContextQueryResult[] = [];
-
+  // Validate all tool names upfront — unknown tools are a programming error.
   for (const query of queries) {
-    const limit = query.limit ?? DEFAULT_CONTEXT_QUERY_LIMIT;
-
-    // Unknown tools are a programming error — always throw regardless of required flag.
     validateTool(query.tool);
+  }
 
-    try {
+  // Execute all queries in parallel — they hit independent DB tables.
+  const settled = await Promise.allSettled(
+    queries.map(async (query) => {
+      const limit = query.limit ?? DEFAULT_CONTEXT_QUERY_LIMIT;
       const data = await executeQuery(agentId, query.tool, limit);
-      results.push({ tool: query.tool, purpose: query.purpose, data });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      return { tool: query.tool, purpose: query.purpose, data } satisfies ContextQueryResult;
+    }),
+  );
+
+  // Map settled results, throwing for required failures.
+  const results: ContextQueryResult[] = [];
+  for (let i = 0; i < settled.length; i++) {
+    const outcome = settled[i];
+    const query = queries[i];
+
+    if (outcome.status === 'fulfilled') {
+      results.push(outcome.value);
+    } else {
+      const message = outcome.reason instanceof Error
+        ? outcome.reason.message
+        : String(outcome.reason);
 
       if (query.required) {
         throw new Error(

--- a/src/agent/context-queries.ts
+++ b/src/agent/context-queries.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ContextQuery } from './types.js';
+import { errorMessage as toErrorMessage } from '@myco/utils/error-message.js';
 import { getUnprocessedBatches } from '@myco/db/queries/batches.js';
 import { listSpores } from '@myco/db/queries/spores.js';
 import { listSessions } from '@myco/db/queries/sessions.js';
@@ -76,9 +77,7 @@ export async function executeContextQueries(
     if (outcome.status === 'fulfilled') {
       results.push(outcome.value);
     } else {
-      const message = outcome.reason instanceof Error
-        ? outcome.reason.message
-        : String(outcome.reason);
+      const message = toErrorMessage(outcome.reason);
 
       if (query.required) {
         throw new Error(

--- a/src/agent/definitions/agent.yaml
+++ b/src/agent/definitions/agent.yaml
@@ -26,6 +26,7 @@ tools:
   - vault_resolve_spore
   - vault_update_session
   - vault_mark_processed
+  - vault_read_digest
   - vault_write_digest
   - vault_set_state
   - vault_report

--- a/src/agent/definitions/tasks/digest-only.yaml
+++ b/src/agent/definitions/tasks/digest-only.yaml
@@ -19,45 +19,62 @@ timeoutSeconds: 300
 prompt: |
   Regenerate digest extracts from current vault state. Budget: ~15 turns.
 
-  ## Phase 1 — Survey Current Knowledge (budget: 5 turns)
+  ## Phase 1 — Assess Current State (budget: 4 turns)
 
   1. Call `vault_state` for context
-  2. Call `vault_spores` with status "active" to see current observations
-  3. Call `vault_sessions` to understand recent activity
-  4. Call `vault_search` with broad queries to sample vault breadth:
-     - "architecture decisions"
-     - "bugs and gotchas"
-     - "key components"
+  2. Call `vault_read_digest` (no tier param) to see current digest metadata
+     and assess whether any tiers exist and how fresh they are
+  3. Call `vault_spores` with status "active" to see current observations
+  4. Call `vault_sessions` to understand recent activity
 
-  ## Phase 2 — Generate Extracts (budget: 8 turns)
+  If the current digest is very recent and no meaningful vault changes have
+  occurred since it was written (check spore counts and session dates), call
+  `vault_report` with action "skip" and reason "digest is already current",
+  then stop. Only proceed if there is genuine new material to incorporate.
 
-  Write digest extracts at all five tiers. Each tier is a self-contained
-  summary at that token budget — NOT an incremental expansion.
+  ## Phase 2 — Survey New Material (budget: 3 turns)
 
-  For each tier, call `vault_write_digest`:
-  1. Tier 1500 — Executive briefing: what is this project, what's active,
-     what to avoid. Most critical knowledge only.
-  2. Tier 3000 — Team standup: decisions, plans, conventions. Enough to
-     start contributing.
-  3. Tier 5000 — Deep onboarding: trade-offs, patterns, team dynamics.
-  4. Tier 7500 — Comprehensive: thread history, design tensions.
-  5. Tier 10000 — Full institutional knowledge: everything worth knowing.
+  Call `vault_search` with broad queries to sample vault breadth and identify
+  themes that have changed since the last digest:
+  - "architecture decisions"
+  - "bugs and gotchas"
+  - "key components"
+
+  The existing digest is your baseline — your goal is to integrate new
+  material into it, not start from scratch.
+
+  ## Phase 3 — Update Extracts (budget: 7 turns)
+
+  For each tier, call `vault_read_digest` with the tier number to get the
+  current content, then call `vault_write_digest` with the updated version.
+
+  Preserve well-crafted existing content — only update sections affected by
+  new material. Tiers that need the most frequent updating:
+  1. Tier 10000 — Full institutional knowledge: update if any new content
+  2. Tier 7500 — Comprehensive: update if significant new content
+  3. Tier 5000 — Deep onboarding: update if new trade-offs or patterns
+  4. Tier 3000 — Team standup: update if new conventions or plans
+  5. Tier 1500 — Executive briefing: only if something critical changed
+
+  You do NOT need to update all 5 tiers — only those affected by new material.
 
   Prioritize: recent insights > active decisions > unresolved gotchas >
   architectural patterns > historical context.
 
-  ## Phase 3 — Report (budget: 1 turn)
+  ## Phase 4 — Report (budget: 1 turn)
 
   Call `vault_report` with action "digest":
-  - Tiers regenerated: [1500, 3000, 5000, 7500, 10000]
+  - Tiers updated: [list]
+  - Tiers skipped (already current): [list]
   - Active spores used as substrate: N
-  - Key themes captured
+  - Key themes incorporated
 
 toolOverrides:
   - vault_spores
   - vault_sessions
   - vault_search
   - vault_state
+  - vault_read_digest
   - vault_write_digest
   - vault_set_state
   - vault_report

--- a/src/agent/definitions/tasks/extract-only.yaml
+++ b/src/agent/definitions/tasks/extract-only.yaml
@@ -31,9 +31,20 @@ prompt: |
 
   For each batch:
   1. Read `user_prompt` — understand what the developer asked
-  2. Extract observations as spores (genuine insights only)
-  3. Call `vault_create_spore` with session_id, prompt_batch_id,
-     importance, tags
+  2. Identify candidate observations — genuine insights only, not activity logs
+  3. **Group candidates by topic across all batches** before searching.
+     One search call per topic is cheaper than one per batch.
+
+  For each TOPIC group:
+  1. Call `vault_search` with the topic to check existing spore coverage
+  2. If a similar spore exists:
+     - If the new observation adds meaningful new detail: call
+       `vault_create_spore` then supersede the old via `vault_resolve_spore`
+       action "supersede" with new_spore_id
+     - If the new observation adds nothing new: skip it entirely
+  3. If no similar spore exists: call `vault_create_spore`
+
+  After processing each batch:
   4. Call `vault_mark_processed`
   5. Update cursor via `vault_set_state`
 
@@ -56,6 +67,7 @@ toolOverrides:
   - vault_search
   - vault_state
   - vault_create_spore
+  - vault_resolve_spore
   - vault_update_session
   - vault_mark_processed
   - vault_set_state

--- a/src/agent/definitions/tasks/full-intelligence.yaml
+++ b/src/agent/definitions/tasks/full-intelligence.yaml
@@ -62,6 +62,7 @@ phases:
     tools:
       - vault_state
       - vault_unprocessed
+      - vault_spores
       - vault_report
     maxTurns: 6
     required: true
@@ -69,32 +70,42 @@ phases:
   - name: extract
     prompt: |
       Extract observations from unprocessed batches as spores.
-      CRITICAL: search before creating — the vault must stay sharp, not bloated.
+      CRITICAL: the vault must stay sharp, not bloated. Supersede, don't duplicate.
 
       If the prior phase reported no unprocessed batches, call `vault_report`
       with action "skip" and reason "no unprocessed batches" and finish.
 
-      For each unprocessed batch:
-      1. Read the batch content to understand what happened
-      2. Identify genuine insights (not activity — "added file X" is not a spore)
-      3. For EACH potential observation, BEFORE creating:
-         a. Call `vault_search` with the key phrase of the observation
-         b. If a similar spore exists and yours adds meaningful new detail:
-            - Create the new spore via `vault_create_spore`
-            - Supersede the old one via `vault_resolve_spore` action "supersede"
-              with new_spore_id pointing to the replacement
-         c. If a similar spore exists and yours adds nothing new: skip it
-         d. If no similar spore exists: create it as new
-      4. Call `vault_mark_processed` for the batch
-      5. Update cursor via `vault_set_state` periodically
+      ## Step 1: Read batches and identify observations (budget: ~10 turns)
+
+      Process batches from `vault_unprocessed`. For each batch:
+      1. Read the content — identify genuine insights, not activity logs
+      2. Group related observations across batches by topic before creating
+
+      ## Step 2: Search and create/supersede (budget: ~20 turns)
+
+      For each TOPIC you identified (not each batch — group first):
+      1. Call `vault_search` with the topic to check existing coverage
+      2. If a similar spore exists:
+         - If your observation adds meaningful new detail: create the new
+           spore, then supersede the old via `vault_resolve_spore`
+           action "supersede" with new_spore_id
+         - If your observation adds nothing new: skip it entirely
+      3. If no similar spore exists: create it as new
+      4. Mark the source batches as processed via `vault_mark_processed`
+
+      ## Step 3: Update cursor (budget: 1 turn)
+
+      Call `vault_set_state` to update `last_processed_batch_id`.
 
       ## Quality rules
       - One observation per spore — specific, not vague
       - Include session_id, prompt_batch_id, importance 1-10, tags
       - Supersede rather than duplicate — the vault gets sharper, not bigger
+      - Group batches by topic to minimize search calls
       - If approaching the turn budget, stop and move on
     tools:
       - vault_unprocessed
+      - vault_spores
       - vault_search
       - vault_create_spore
       - vault_resolve_spore
@@ -216,6 +227,7 @@ phases:
       - Entity→entity structural edges: N
     tools:
       - vault_spores
+      - vault_sessions
       - vault_search
       - vault_create_entity
       - vault_create_edge

--- a/src/agent/definitions/tasks/full-intelligence.yaml
+++ b/src/agent/definitions/tasks/full-intelligence.yaml
@@ -17,8 +17,8 @@ description: >
   regenerates digest extracts.
 agent: myco-agent
 isDefault: true
-maxTurns: 50
-timeoutSeconds: 600
+maxTurns: 103
+timeoutSeconds: 900
 model: claude-sonnet-4-6
 
 orchestrator:
@@ -63,7 +63,7 @@ phases:
       - vault_state
       - vault_unprocessed
       - vault_report
-    maxTurns: 3
+    maxTurns: 6
     required: true
 
   - name: extract
@@ -89,7 +89,7 @@ phases:
       - vault_mark_processed
       - vault_set_state
       - vault_report
-    maxTurns: 20
+    maxTurns: 30
     required: true
 
   - name: summarize
@@ -133,7 +133,7 @@ phases:
       - vault_create_spore
       - vault_resolve_spore
       - vault_report
-    maxTurns: 12
+    maxTurns: 18
     required: true
 
   - name: graph
@@ -158,7 +158,7 @@ phases:
       - vault_create_entity
       - vault_create_edge
       - vault_report
-    maxTurns: 12
+    maxTurns: 20
     required: true
 
   - name: digest
@@ -184,7 +184,7 @@ phases:
       - vault_sessions
       - vault_write_digest
       - vault_report
-    maxTurns: 10
+    maxTurns: 18
     required: true
 
   - name: report
@@ -202,5 +202,5 @@ phases:
       This report MUST be the last tool call of the run.
     tools:
       - vault_report
-    maxTurns: 2
+    maxTurns: 3
     required: true

--- a/src/agent/definitions/tasks/full-intelligence.yaml
+++ b/src/agent/definitions/tasks/full-intelligence.yaml
@@ -225,20 +225,27 @@ phases:
 
   - name: digest
     prompt: |
-      Regenerate digest extracts at all five tiers. The vault context
-      injected into every session depends on these — they must be
-      comprehensive and accurate.
+      Regenerate digest extracts — but ONLY if the vault changed.
 
-      ## Gather knowledge (budget: 5 turns)
+      ## Step 1: Check if digest needs updating (budget: 1 turn)
 
-      Use `vault_search` to query specific themes. Suggested queries:
+      Review the prior phase results (provided in your context). If:
+      - Extract created 0 new spores AND
+      - Consolidate resolved 0 spores AND
+      - Graph created 0 new entities/edges
+      Then call `vault_report` with action "skip" and reason
+      "no vault changes since last digest" and STOP. Do not regenerate.
+
+      ## Step 2: Gather knowledge (budget: 5 turns)
+
+      If the vault DID change, use `vault_search` to query themes:
       - "architecture decisions and trade-offs"
       - "bugs gotchas and workarounds"
       - "key components and how they interact"
       - "active work and plans"
-      Also call `vault_spores` and `vault_sessions` for a broad overview.
+      Also call `vault_spores` and `vault_sessions` for a broad view.
 
-      ## Write extracts (budget: 10 turns)
+      ## Step 3: Write extracts (budget: 10 turns)
 
       Call `vault_write_digest` for EACH of these five tiers:
       1. Tier 1500 — Executive briefing: what is this project, what's
@@ -253,7 +260,7 @@ phases:
       recent insights > active decisions > unresolved gotchas >
       architectural patterns > historical context.
 
-      You MUST call `vault_write_digest` exactly 5 times.
+      When regenerating, call `vault_write_digest` exactly 5 times.
     tools:
       - vault_spores
       - vault_sessions

--- a/src/agent/definitions/tasks/full-intelligence.yaml
+++ b/src/agent/definitions/tasks/full-intelligence.yaml
@@ -225,46 +225,52 @@ phases:
 
   - name: digest
     prompt: |
-      Regenerate digest extracts — but ONLY if the vault changed.
+      Update digest extracts incrementally based on new vault substrate.
 
-      ## Step 1: Check if digest needs updating (budget: 1 turn)
+      ## Step 1: Assess whether update is warranted (budget: 2 turns)
 
-      Review the prior phase results (provided in your context). If:
-      - Extract created 0 new spores AND
-      - Consolidate resolved 0 spores AND
-      - Graph created 0 new entities/edges
-      Then call `vault_report` with action "skip" and reason
-      "no vault changes since last digest" and STOP. Do not regenerate.
+      Call `vault_read_digest` (no tier param) to see current digest state.
+      Review the prior phase results (in your context):
+      - How many spores were created/superseded?
+      - How many entities/edges were added?
 
-      ## Step 2: Gather knowledge (budget: 5 turns)
+      If changes are minor (< 3 new spores, 0 entity changes), call
+      `vault_report` with action "skip" and reason explaining why the
+      current digest is still sufficient. STOP.
 
-      If the vault DID change, use `vault_search` to query themes:
-      - "architecture decisions and trade-offs"
-      - "bugs gotchas and workarounds"
-      - "key components and how they interact"
-      - "active work and plans"
-      Also call `vault_spores` and `vault_sessions` for a broad view.
+      ## Step 2: Read current digest + gather new material (budget: 6 turns)
 
-      ## Step 3: Write extracts (budget: 10 turns)
+      For each tier you plan to update:
+      1. Call `vault_read_digest` with the tier number to get current content
+      2. Call `vault_search` with themes relevant to what changed:
+         - Topics from newly created/superseded spores
+         - New entity names
+      3. The existing digest is your baseline — integrate new material
+         into it, don't start from scratch
 
-      Call `vault_write_digest` for EACH of these five tiers:
-      1. Tier 1500 — Executive briefing: what is this project, what's
-         active, what to avoid. Most critical knowledge only.
-      2. Tier 3000 — Team standup: decisions, plans, conventions.
-         Enough to start contributing.
-      3. Tier 5000 — Deep onboarding: trade-offs, patterns, team dynamics.
-      4. Tier 7500 — Comprehensive: thread history, design tensions.
-      5. Tier 10000 — Full institutional knowledge: everything worth knowing.
+      ## Step 3: Write updated extracts (budget: 8 turns)
 
-      Each tier is self-contained (not incremental). Prioritize:
+      Call `vault_write_digest` for tiers that need updating:
+      1. Tier 1500 — Executive briefing (most compressed, most sensitive
+         to changes — update if important new decisions or gotchas)
+      2. Tier 3000 — Team standup (update if new conventions or plans)
+      3. Tier 5000 — Deep onboarding (update if new trade-offs or patterns)
+      4. Tier 7500 — Comprehensive (update if significant new content)
+      5. Tier 10000 — Full institutional knowledge (update if any new content)
+
+      Each tier is self-contained. Preserve well-crafted existing content —
+      integrate new material, don't rewrite from scratch. Prioritize:
       recent insights > active decisions > unresolved gotchas >
       architectural patterns > historical context.
 
-      When regenerating, call `vault_write_digest` exactly 5 times.
+      You do NOT need to update all 5 tiers. Only update tiers affected
+      by the new material. Tier 10000 (largest) is most likely to need
+      updating; tier 1500 (smallest) only if something critical changed.
     tools:
       - vault_spores
       - vault_sessions
       - vault_search
+      - vault_read_digest
       - vault_write_digest
       - vault_report
     maxTurns: 20

--- a/src/agent/definitions/tasks/full-intelligence.yaml
+++ b/src/agent/definitions/tasks/full-intelligence.yaml
@@ -138,27 +138,54 @@ phases:
 
   - name: graph
     prompt: |
-      Create entities and semantic edges for the knowledge graph.
+      Build the knowledge graph: create entities, then link spores to them.
 
-      1. Call `vault_spores` with status "active" — review the full set
-      2. For components/concepts/people mentioned in 3+ spores from 2+ sessions:
-         Call `vault_create_entity` with type: component | concept | person
-      3. For each entity, create semantic edges via `vault_create_edge`:
-         - REFERENCES (spore→entity): link spores that discuss this entity
-         - DEPENDS_ON (entity→entity): architectural dependencies
-         - AFFECTS (spore→entity): observations that impact components
-         - Always include source_type and target_type
-      4. Do NOT create lineage edges (FROM_SESSION, EXTRACTED_FROM, etc.)
+      The graph has two layers:
+      - Lineage (automatic): spore→session, spore→batch — already done
+      - Semantic (your job): spore→entity, entity→entity — you create these
 
-      Call `vault_report` with action "graph" reporting what you created.
-      If truly no entities qualify, report action "graph" with details
-      explaining why.
+      ## Step 1: Review spores and existing entities (2 turns)
+
+      1. Call `vault_spores` with status "active" to see current spores
+      2. Call `vault_search` with "architecture components" to understand
+         the landscape of topics
+
+      ## Step 2: Create entities (budget: 6 turns)
+
+      For components/concepts/people that appear across multiple spores:
+      - Call `vault_create_entity` with type: component | concept | person
+      - Focus on entities that help understand the system architecture
+      - Prefer fewer well-defined entities over many vague ones
+
+      ## Step 3: Link spores to entities (budget: 12 turns) — CRITICAL
+
+      For EACH entity (newly created AND existing unlinked ones):
+      1. Call `vault_search` with the entity name to find related spores
+      2. For each relevant search result, call `vault_create_edge`:
+         - type: REFERENCES
+         - source_id: the spore ID, source_type: spore
+         - target_id: the entity ID, target_type: entity
+      3. Entities without edges are invisible — always link after creating
+
+      ## Step 4: Structural edges between entities (remaining turns)
+
+      For architectural dependencies between entities:
+      - DEPENDS_ON (entity→entity): "daemon" depends on "PGlite"
+      - AFFECTS (spore→entity): a gotcha that impacts a component
+
+      Do NOT create lineage edges (FROM_SESSION, EXTRACTED_FROM, etc.)
+
+      Call `vault_report` with action "graph" reporting:
+      - Entities created: N
+      - Spore→entity REFERENCES edges: N
+      - Entity→entity structural edges: N
     tools:
       - vault_spores
+      - vault_search
       - vault_create_entity
       - vault_create_edge
       - vault_report
-    maxTurns: 20
+    maxTurns: 25
     required: true
 
   - name: digest

--- a/src/agent/definitions/tasks/full-intelligence.yaml
+++ b/src/agent/definitions/tasks/full-intelligence.yaml
@@ -97,18 +97,21 @@ phases:
       Update session titles and summaries for sessions touched during extraction.
 
       1. Call `vault_sessions` to check current title/summary
-      2. If missing or outdated, call `vault_update_session` with BOTH title
-         and summary
-      3. Title: under 80 chars, reflects full session scope
-      4. Summary: 2-4 sentences, key work done + outcomes
+      2. For sessions needing updates, call `vault_search` with the session_id
+         filter to find spores from that session — use them to understand
+         the full scope of work done
+      3. Call `vault_update_session` with BOTH title and summary
+      4. Title: under 80 chars, reflects full session scope
+      5. Summary: 2-4 sentences, key work done + outcomes
 
       Report via `vault_report` with action "summary" for each update.
       If no updates needed, report action "skip" with reason.
     tools:
       - vault_sessions
+      - vault_search
       - vault_update_session
       - vault_report
-    maxTurns: 8
+    maxTurns: 10
     required: false
 
   - name: consolidate
@@ -191,27 +194,41 @@ phases:
   - name: digest
     prompt: |
       Regenerate digest extracts at all five tiers. The vault context
-      depends on these.
+      injected into every session depends on these — they must be
+      comprehensive and accurate.
 
-      Call `vault_write_digest` for EACH of these tiers:
-      1. Tier 1500 — Executive briefing (most critical knowledge)
-      2. Tier 3000 — Team standup (decisions, plans, conventions)
-      3. Tier 5000 — Deep onboarding (trade-offs, patterns)
-      4. Tier 7500 — Comprehensive coverage
-      5. Tier 10000 — Full institutional knowledge
+      ## Gather knowledge (budget: 5 turns)
 
-      Read vault_spores and vault_sessions first to understand the full
-      corpus, then write each tier as a self-contained extract.
-      Prioritize: recent insights > active decisions > unresolved gotchas
-      > architectural patterns.
+      Use `vault_search` to query specific themes. Suggested queries:
+      - "architecture decisions and trade-offs"
+      - "bugs gotchas and workarounds"
+      - "key components and how they interact"
+      - "active work and plans"
+      Also call `vault_spores` and `vault_sessions` for a broad overview.
 
-      You must call `vault_write_digest` at least 5 times.
+      ## Write extracts (budget: 10 turns)
+
+      Call `vault_write_digest` for EACH of these five tiers:
+      1. Tier 1500 — Executive briefing: what is this project, what's
+         active, what to avoid. Most critical knowledge only.
+      2. Tier 3000 — Team standup: decisions, plans, conventions.
+         Enough to start contributing.
+      3. Tier 5000 — Deep onboarding: trade-offs, patterns, team dynamics.
+      4. Tier 7500 — Comprehensive: thread history, design tensions.
+      5. Tier 10000 — Full institutional knowledge: everything worth knowing.
+
+      Each tier is self-contained (not incremental). Prioritize:
+      recent insights > active decisions > unresolved gotchas >
+      architectural patterns > historical context.
+
+      You MUST call `vault_write_digest` exactly 5 times.
     tools:
       - vault_spores
       - vault_sessions
+      - vault_search
       - vault_write_digest
       - vault_report
-    maxTurns: 18
+    maxTurns: 20
     required: true
 
   - name: report

--- a/src/agent/definitions/tasks/full-intelligence.yaml
+++ b/src/agent/definitions/tasks/full-intelligence.yaml
@@ -21,6 +21,29 @@ maxTurns: 50
 timeoutSeconds: 600
 model: claude-sonnet-4-6
 
+orchestrator:
+  enabled: true
+  model: claude-sonnet-4-6
+  maxTurns: 3
+
+contextQueries:
+  pre-planning:
+    - tool: vault_unprocessed
+      queryTemplate: ""
+      limit: 5
+      purpose: "Check if there are unprocessed batches"
+      required: false
+    - tool: vault_state
+      queryTemplate: ""
+      limit: 10
+      purpose: "Get agent cursor state"
+      required: false
+    - tool: vault_spores
+      queryTemplate: ""
+      limit: 20
+      purpose: "Review recent spores for consolidation candidates"
+      required: false
+
 prompt: >
   Complete intelligence pipeline. Each phase runs as a separate pass with
   scoped tools. Focus on quality over quantity — one precise observation

--- a/src/agent/definitions/tasks/full-intelligence.yaml
+++ b/src/agent/definitions/tasks/full-intelligence.yaml
@@ -69,27 +69,39 @@ phases:
   - name: extract
     prompt: |
       Extract observations from unprocessed batches as spores.
-
-      For each unprocessed batch:
-      1. Read `user_prompt` to understand what the developer asked
-      2. Extract observations as spores — only genuine insights, not activity
-      3. Call `vault_create_spore` for each observation (include session_id,
-         prompt_batch_id, importance 1-10, tags)
-      4. Call `vault_mark_processed` for the batch
-      5. Update cursor via `vault_set_state`
-
-      Batch multiple mark_processed calls. One observation per spore.
-      If approaching the turn budget, stop extraction and move on.
+      CRITICAL: search before creating — the vault must stay sharp, not bloated.
 
       If the prior phase reported no unprocessed batches, call `vault_report`
       with action "skip" and reason "no unprocessed batches" and finish.
+
+      For each unprocessed batch:
+      1. Read the batch content to understand what happened
+      2. Identify genuine insights (not activity — "added file X" is not a spore)
+      3. For EACH potential observation, BEFORE creating:
+         a. Call `vault_search` with the key phrase of the observation
+         b. If a similar spore exists and yours adds meaningful new detail:
+            - Create the new spore via `vault_create_spore`
+            - Supersede the old one via `vault_resolve_spore` action "supersede"
+              with new_spore_id pointing to the replacement
+         c. If a similar spore exists and yours adds nothing new: skip it
+         d. If no similar spore exists: create it as new
+      4. Call `vault_mark_processed` for the batch
+      5. Update cursor via `vault_set_state` periodically
+
+      ## Quality rules
+      - One observation per spore — specific, not vague
+      - Include session_id, prompt_batch_id, importance 1-10, tags
+      - Supersede rather than duplicate — the vault gets sharper, not bigger
+      - If approaching the turn budget, stop and move on
     tools:
       - vault_unprocessed
+      - vault_search
       - vault_create_spore
+      - vault_resolve_spore
       - vault_mark_processed
       - vault_set_state
       - vault_report
-    maxTurns: 30
+    maxTurns: 35
     required: true
 
   - name: summarize
@@ -116,17 +128,37 @@ phases:
 
   - name: consolidate
     prompt: |
-      Search for clusters of related spores that can become wisdom.
+      Consolidate related spores into wisdom and clean up redundancy.
+      The vault must get SHARPER over time, not just bigger.
 
-      1. Call `vault_search` with content from newly created spores
-      2. Also call `vault_spores` filtered by observation_type as fallback
-      3. When you find 3+ related active spores on the same topic:
-         a. Create a wisdom spore via `vault_create_spore` with:
-            - observation_type: "wisdom"
-            - properties: '{"consolidated_from": ["id-1", "id-2", "id-3"]}'
-            - Content preserving ALL specific details from sources
-         b. Resolve each source via `vault_resolve_spore` action "consolidate"
-      4. Skip spores with status "consolidated" to prevent cycles
+      ## Step 1: Find clusters (budget: 5 turns)
+
+      Use `vault_search` with themes from recent spores to find clusters:
+      - Search for each observation_type: "gotcha", "decision", "discovery"
+      - Call `vault_spores` with status "active" to see the full set
+      - Look for 2+ spores covering the same topic or component
+
+      ## Step 2: Create wisdom (budget: 8 turns)
+
+      When you find 3+ related active spores on the same topic:
+      1. Create a wisdom spore via `vault_create_spore`:
+         - observation_type: "wisdom"
+         - properties: '{"consolidated_from": ["id-1", "id-2", "id-3"]}'
+         - Content MUST preserve ALL specific details from sources —
+           file paths, error messages, concrete values. Wisdom is a
+           comprehensive reference, not a vague summary.
+      2. Resolve EACH source via `vault_resolve_spore` action "consolidate"
+         — this removes them from search results and context injection
+
+      ## Step 3: Supersede stale spores (budget: 5 turns)
+
+      Also look for spores that are outdated or contradicted by newer ones:
+      - If two spores describe the same thing but one is more recent/detailed,
+        supersede the older one via `vault_resolve_spore` action "supersede"
+      - Superseded spores stay in the DB but are removed from search and
+        context injection — this keeps the vault relevant
+
+      Skip spores with status "consolidated" or "superseded" to prevent cycles.
 
       If `vault_search` returns no results (embedding unavailable), report
       action "skip" and move on.
@@ -136,7 +168,7 @@ phases:
       - vault_create_spore
       - vault_resolve_spore
       - vault_report
-    maxTurns: 18
+    maxTurns: 22
     required: true
 
   - name: graph

--- a/src/agent/definitions/tasks/full-intelligence.yaml
+++ b/src/agent/definitions/tasks/full-intelligence.yaml
@@ -1,10 +1,11 @@
 # =============================================================================
-# Built-in Task: Full Intelligence
+# Built-in Task: Full Intelligence (Phased)
 # =============================================================================
 # Default task for: myco-agent
 #
-# Complete intelligence pipeline: extraction → summaries → consolidation →
-# entity building → digest. Each phase has a turn budget. Total: ~45 turns.
+# Complete intelligence pipeline using phased execution. Each phase is a
+# separate query() call with scoped tools and turn limits. The executor
+# controls the loop — the LLM cannot skip phases.
 # =============================================================================
 
 name: full-intelligence
@@ -20,103 +21,163 @@ maxTurns: 50
 timeoutSeconds: 600
 model: claude-sonnet-4-6
 
-prompt: |
-  Run a complete intelligence pass. This task has 7 phases — you MUST
-  complete all of them. Each phase has a turn budget (1 turn = 1 tool call).
+prompt: >
+  Complete intelligence pipeline. Each phase runs as a separate pass with
+  scoped tools. Focus on quality over quantity — one precise observation
+  is worth more than ten vague ones.
 
-  ## Phase 1 — Read State (budget: 2 turns)
+phases:
+  - name: read-state
+    prompt: |
+      Read the current vault state to determine what needs processing.
 
-  1. Call `vault_state` to get your cursor (`last_processed_batch_id`)
-  2. Call `vault_unprocessed` with `after_id` set to your cursor
+      1. Call `vault_state` to get your cursor (`last_processed_batch_id`)
+      2. Call `vault_unprocessed` with `after_id` set to your cursor
 
-  If no unprocessed batches exist, skip to Phase 4 (consolidation may
-  still be needed on existing spores). Report via `vault_report` with
-  action "skip" and reason "no unprocessed batches".
+      If no unprocessed batches exist, report via `vault_report` with
+      action "skip" and reason "no unprocessed batches".
+    tools:
+      - vault_state
+      - vault_unprocessed
+      - vault_report
+    maxTurns: 3
+    required: true
 
-  ## Phase 2 — Extract Spores (budget: 15 turns)
+  - name: extract
+    prompt: |
+      Extract observations from unprocessed batches as spores.
 
-  For each unprocessed batch:
-  1. Read `user_prompt` to understand what the developer asked
-  2. Extract observations as spores — only genuine insights, not activity
-  3. Call `vault_create_spore` for each observation (include session_id,
-     prompt_batch_id, importance 1-10, tags)
-  4. Call `vault_mark_processed` for the batch
-  5. Update cursor via `vault_set_state`
+      For each unprocessed batch:
+      1. Read `user_prompt` to understand what the developer asked
+      2. Extract observations as spores — only genuine insights, not activity
+      3. Call `vault_create_spore` for each observation (include session_id,
+         prompt_batch_id, importance 1-10, tags)
+      4. Call `vault_mark_processed` for the batch
+      5. Update cursor via `vault_set_state`
 
-  Batch multiple mark_processed calls. One observation per spore.
-  If approaching the turn budget, stop extraction and continue to Phase 3.
+      Batch multiple mark_processed calls. One observation per spore.
+      If approaching the turn budget, stop extraction and move on.
 
-  ## Phase 3 — Session Summaries (budget: 5 turns)
+      If the prior phase reported no unprocessed batches, call `vault_report`
+      with action "skip" and reason "no unprocessed batches" and finish.
+    tools:
+      - vault_unprocessed
+      - vault_create_spore
+      - vault_mark_processed
+      - vault_set_state
+      - vault_report
+    maxTurns: 20
+    required: true
 
-  For each session touched during extraction:
-  1. Call `vault_sessions` to check current title/summary
-  2. If missing or outdated, call `vault_update_session` with BOTH title
-     and summary
-  3. Title: under 80 chars, reflects full session scope
-  4. Summary: 2-4 sentences, key work done + outcomes
+  - name: summarize
+    prompt: |
+      Update session titles and summaries for sessions touched during extraction.
 
-  Report via `vault_report` with action "summary" for each update.
-  If no updates needed, report action "skip" with reason.
+      1. Call `vault_sessions` to check current title/summary
+      2. If missing or outdated, call `vault_update_session` with BOTH title
+         and summary
+      3. Title: under 80 chars, reflects full session scope
+      4. Summary: 2-4 sentences, key work done + outcomes
 
-  ## Phase 4 — Consolidation (budget: 10 turns)
+      Report via `vault_report` with action "summary" for each update.
+      If no updates needed, report action "skip" with reason.
+    tools:
+      - vault_sessions
+      - vault_update_session
+      - vault_report
+    maxTurns: 8
+    required: false
 
-  Search for clusters of related spores that can become wisdom:
-  1. Call `vault_search` with content from your newly created spores
-  2. Also call `vault_spores` filtered by observation_type as fallback
-  3. When you find 3+ related active spores on the same topic:
-     a. Create a wisdom spore via `vault_create_spore` with:
-        - observation_type: "wisdom"
-        - properties: '{"consolidated_from": ["id-1", "id-2", "id-3"]}'
-        - Content preserving ALL specific details from sources
-     b. Resolve each source via `vault_resolve_spore` action "consolidate"
-  4. Skip spores with status "consolidated" to prevent cycles
+  - name: consolidate
+    prompt: |
+      Search for clusters of related spores that can become wisdom.
 
-  If `vault_search` returns no results (embedding unavailable), report
-  action "skip" and move on. Do NOT skip this phase entirely.
+      1. Call `vault_search` with content from newly created spores
+      2. Also call `vault_spores` filtered by observation_type as fallback
+      3. When you find 3+ related active spores on the same topic:
+         a. Create a wisdom spore via `vault_create_spore` with:
+            - observation_type: "wisdom"
+            - properties: '{"consolidated_from": ["id-1", "id-2", "id-3"]}'
+            - Content preserving ALL specific details from sources
+         b. Resolve each source via `vault_resolve_spore` action "consolidate"
+      4. Skip spores with status "consolidated" to prevent cycles
 
-  ## Phase 5 — Entity Hub Building (budget: 5 turns) — MANDATORY
+      If `vault_search` returns no results (embedding unavailable), report
+      action "skip" and move on.
+    tools:
+      - vault_spores
+      - vault_search
+      - vault_create_spore
+      - vault_resolve_spore
+      - vault_report
+    maxTurns: 12
+    required: true
 
-  You MUST attempt entity creation. Call `vault_spores` to review all
-  active spores, then identify entities that appear across multiple spores.
+  - name: graph
+    prompt: |
+      Create entities and semantic edges for the knowledge graph.
 
-  1. Call `vault_spores` with status "active" — review the full set
-  2. For components/concepts/people mentioned in 3+ spores from 2+ sessions:
-     Call `vault_create_entity` with type: component | concept | person
-  3. For each entity, create semantic edges via `vault_create_edge`:
-     - REFERENCES (spore→entity): link spores that discuss this entity
-     - DEPENDS_ON (entity→entity): architectural dependencies
-     - AFFECTS (spore→entity): observations that impact components
-     - Always include source_type and target_type
-  4. Do NOT create lineage edges (FROM_SESSION, EXTRACTED_FROM, etc.)
+      1. Call `vault_spores` with status "active" — review the full set
+      2. For components/concepts/people mentioned in 3+ spores from 2+ sessions:
+         Call `vault_create_entity` with type: component | concept | person
+      3. For each entity, create semantic edges via `vault_create_edge`:
+         - REFERENCES (spore→entity): link spores that discuss this entity
+         - DEPENDS_ON (entity→entity): architectural dependencies
+         - AFFECTS (spore→entity): observations that impact components
+         - Always include source_type and target_type
+      4. Do NOT create lineage edges (FROM_SESSION, EXTRACTED_FROM, etc.)
 
-  REQUIRED: Call `vault_report` with action "graph" reporting what you
-  created. If truly no entities qualify, report action "graph" with
-  details explaining why (e.g., "only 2 sessions worth of data").
+      Call `vault_report` with action "graph" reporting what you created.
+      If truly no entities qualify, report action "graph" with details
+      explaining why.
+    tools:
+      - vault_spores
+      - vault_create_entity
+      - vault_create_edge
+      - vault_report
+    maxTurns: 12
+    required: true
 
-  ## Phase 6 — Digest (budget: 5 turns) — MANDATORY
+  - name: digest
+    prompt: |
+      Regenerate digest extracts at all five tiers. The vault context
+      depends on these.
 
-  You MUST regenerate digest extracts. The vault context depends on these.
+      Call `vault_write_digest` for EACH of these tiers:
+      1. Tier 1500 — Executive briefing (most critical knowledge)
+      2. Tier 3000 — Team standup (decisions, plans, conventions)
+      3. Tier 5000 — Deep onboarding (trade-offs, patterns)
+      4. Tier 7500 — Comprehensive coverage
+      5. Tier 10000 — Full institutional knowledge
 
-  Call `vault_write_digest` for EACH of these five tiers:
-  1. Tier 1500 — Executive briefing (most critical knowledge)
-  2. Tier 3000 — Team standup (decisions, plans, conventions)
-  3. Tier 5000 — Deep onboarding (trade-offs, patterns)
-  4. Tier 7500 — Comprehensive coverage
-  5. Tier 10000 — Full institutional knowledge
+      Read vault_spores and vault_sessions first to understand the full
+      corpus, then write each tier as a self-contained extract.
+      Prioritize: recent insights > active decisions > unresolved gotchas
+      > architectural patterns.
 
-  Each tier is self-contained. Prioritize: recent insights > active
-  decisions > unresolved gotchas > architectural patterns.
+      You must call `vault_write_digest` at least 5 times.
+    tools:
+      - vault_spores
+      - vault_sessions
+      - vault_write_digest
+      - vault_report
+    maxTurns: 10
+    required: true
 
-  REQUIRED: You must call `vault_write_digest` at least 5 times.
+  - name: report
+    prompt: |
+      Summarize what was done across all phases.
 
-  ## Phase 7 — Report (budget: 2 turns) — MANDATORY
+      Call `vault_report` with action "complete" and these details:
+      - Batches processed: N
+      - Spores created: N (by type)
+      - Sessions updated: N
+      - Wisdom created: N
+      - Entities created: N, edges created: N
+      - Digest tiers written: N
 
-  REQUIRED: Call `vault_report` with action "complete" and these details:
-  - Batches processed: N
-  - Spores created: N (by type)
-  - Sessions updated: N
-  - Wisdom created: N
-  - Entities created: N, edges created: N
-  - Digest tiers written: N
-
-  This report MUST be the last tool call of the run.
+      This report MUST be the last tool call of the run.
+    tools:
+      - vault_report
+    maxTurns: 2
+    required: true

--- a/src/agent/definitions/tasks/graph-maintenance.yaml
+++ b/src/agent/definitions/tasks/graph-maintenance.yaml
@@ -38,15 +38,25 @@ prompt: |
 
   ## Phase 3 — Semantic Edges (budget: 10 turns)
 
-  Create edges between related nodes:
-  1. REFERENCES (spore→entity): when a spore discusses a specific entity
-  2. DEPENDS_ON (entity→entity): architectural dependencies
-  3. AFFECTS (spore→entity): when an observation impacts a component
-  4. RELATES_TO: general semantic connections
-  5. SUPERSEDED_BY: when a newer observation replaces an older one
+  Link spores and entities with semantic edges. For each entity:
+  1. Call `vault_search` with the entity name to find spores that discuss it
+  2. For each relevant spore found, call `vault_create_edge`:
+     - type: REFERENCES
+     - source_id: the spore ID, source_type: spore
+     - target_id: the entity ID, target_type: entity
+  3. Before creating any edge, verify it does not already exist — use
+     `vault_sessions` to review existing session context if needed, and
+     avoid creating duplicate edges for the same (source, type, target) triple
+
+  Also create structural edges between entities:
+  - DEPENDS_ON (entity→entity): architectural dependencies
+  - AFFECTS (spore→entity): when an observation directly impacts a component
+  - RELATES_TO: general semantic connections
 
   Always include source_type and target_type on every edge.
   Do NOT create lineage edges (FROM_SESSION, EXTRACTED_FROM, etc.).
+  Entities without any edges are invisible in the graph — always link after
+  creating.
 
   ## Phase 4 — Deduplication (budget: 5 turns)
 

--- a/src/agent/definitions/tasks/review-session.yaml
+++ b/src/agent/definitions/tasks/review-session.yaml
@@ -1,4 +1,9 @@
-# Review a specific session — targeted extraction and summarization.
+# =============================================================================
+# Built-in Task: Review Session
+# =============================================================================
+# Targeted end-to-end pass over a single session: extract spores, build
+# graph entities and edges, run supersession checks, update title/summary.
+# =============================================================================
 
 name: review-session
 displayName: Review Session
@@ -7,10 +12,105 @@ description: >
   batches in the session, builds graph entities and edges, runs supersession
   checks, and generates the session title and summary.
 agent: myco-agent
-prompt: >
-  Review the specified session. Process all prompt batches within it:
-  extract observations as spores, identify entities and relationships,
-  and check for supersession. Evaluate and update the session title and
-  summary per the summary update criteria in your instructions. Mark all
-  batches and the session as processed when complete.
 isDefault: false
+maxTurns: 40
+timeoutSeconds: 480
+
+prompt: |
+  Review the specified session end-to-end. Budget: ~35 turns.
+
+  Target session: {{session_id}}
+
+  ## Phase 1 — Read State (budget: 3 turns)
+
+  1. Call `vault_state` to get current cursor and context
+  2. Call `vault_sessions` to find the target session and its current
+     title/summary/processed status
+  3. Call `vault_unprocessed` filtered to the target session to see what
+     batches need processing
+
+  If no batches are found for this session, call `vault_report` with
+  action "skip" and reason "no unprocessed batches for session", then stop.
+
+  ## Phase 2 — Extract Spores (budget: 15 turns)
+
+  Extract observations from all unprocessed batches in this session.
+  CRITICAL: the vault must stay sharp, not bloated — supersede, don't duplicate.
+
+  1. Read all batch content first — understand the full scope of the session
+  2. Group candidate observations by TOPIC across all batches
+  3. Call `vault_spores` to see existing spores for context
+
+  For each TOPIC group:
+  1. Call `vault_search` with the topic to check existing spore coverage
+  2. If a similar spore exists:
+     - If your observation adds meaningful new detail: call `vault_create_spore`
+       then supersede the old via `vault_resolve_spore` action "supersede"
+       with new_spore_id
+     - If your observation adds nothing new: skip it entirely
+  3. If no similar spore exists: call `vault_create_spore` with session_id,
+     prompt_batch_id, importance 1-10, and relevant tags
+
+  After processing all batches: call `vault_mark_processed` for each batch,
+  then call `vault_set_state` to update the cursor.
+
+  ## Phase 3 — Graph (budget: 10 turns)
+
+  Build entities and semantic edges for knowledge discovered in this session.
+
+  1. Call `vault_spores` to review the spores just created plus existing ones
+  2. For components, concepts, or people that appear in multiple spores:
+     - Call `vault_create_entity` with type: component | concept | person
+     - Good: "DaemonClient", "cursor-based pagination" — specific named things
+     - Bad: "testing phase", "code quality" — abstract categories
+  3. For each entity (new and existing relevant ones):
+     - Call `vault_search` with the entity name to find related spores
+     - Call `vault_create_edge` with type REFERENCES, source_type spore,
+       target_type entity for each relevant spore
+  4. Create structural edges: DEPENDS_ON (entity→entity), AFFECTS (spore→entity)
+
+  Always include source_type and target_type on every edge.
+  Do NOT create lineage edges (FROM_SESSION, EXTRACTED_FROM, etc.).
+
+  ## Phase 4 — Supersession Check (budget: 3 turns)
+
+  Scan active spores for newly introduced redundancy:
+  1. Call `vault_spores` with status "active" to see the current set
+  2. For any spores that are now outdated or contradicted by the newly created
+     ones, call `vault_resolve_spore` with action "supersede" or "archive"
+  3. Only supersede when the new information genuinely replaces the old;
+     when in doubt, keep both
+
+  ## Phase 5 — Title & Summary (budget: 3 turns)
+
+  1. Call `vault_sessions` to check the current title and summary
+  2. Call `vault_search` filtered by session_id to see all spores from
+     this session — use them to understand the full scope of work done
+  3. Call `vault_update_session` with BOTH title and summary:
+     - Title: under 80 characters, reflects the full session scope
+     - Summary: 2-4 sentences capturing key work, tools used, outcomes
+
+  ## Phase 6 — Report (budget: 1 turn)
+
+  Call `vault_report` with action "complete":
+  - Session reviewed: {{session_id}}
+  - Batches processed: N
+  - Spores created: N (by type)
+  - Spores superseded: N
+  - Entities created: N, edges created: N
+  - Title/summary updated: yes/no
+
+toolOverrides:
+  - vault_unprocessed
+  - vault_spores
+  - vault_sessions
+  - vault_search
+  - vault_create_spore
+  - vault_resolve_spore
+  - vault_create_entity
+  - vault_create_edge
+  - vault_update_session
+  - vault_mark_processed
+  - vault_set_state
+  - vault_state
+  - vault_report

--- a/src/agent/definitions/tasks/review-session.yaml
+++ b/src/agent/definitions/tasks/review-session.yaml
@@ -26,11 +26,12 @@ prompt: |
   1. Call `vault_state` to get current cursor and context
   2. Call `vault_sessions` to find the target session and its current
      title/summary/processed status
-  3. Call `vault_unprocessed` filtered to the target session to see what
-     batches need processing
+  3. Call `vault_unprocessed` to get all unprocessed batches — note which
+     ones belong to the target session (by matching session_id in the batch data)
 
-  If no batches are found for this session, call `vault_report` with
+  If no unprocessed batches belong to this session, call `vault_report` with
   action "skip" and reason "no unprocessed batches for session", then stop.
+  Only process batches from the target session — ignore batches from other sessions.
 
   ## Phase 2 — Extract Spores (budget: 15 turns)
 

--- a/src/agent/definitions/tasks/supersession-sweep.yaml
+++ b/src/agent/definitions/tasks/supersession-sweep.yaml
@@ -34,19 +34,32 @@ prompt: |
   If `vault_search` is unavailable (no embeddings), use `vault_spores`
   filtered by observation_type and compare manually. Report the limitation.
 
-  ## Phase 3 — Resolution (budget: 10 turns)
+  ## Phase 3 — Resolution and Wisdom Creation (budget: 10 turns)
 
-  For each cluster of duplicates:
+  For each cluster:
+
+  **If 3 or more related active spores cover the same topic:**
+  1. Create a wisdom spore via `vault_create_spore`:
+     - observation_type: "wisdom"
+     - properties: '{"consolidated_from": ["id-1", "id-2", "id-3"]}'
+     - Content MUST preserve ALL specific details from the sources —
+       file paths, error messages, concrete values. Wisdom is a
+       comprehensive reference, not a vague summary.
+  2. Resolve EACH source via `vault_resolve_spore` action "consolidate"
+     so they are removed from search results and context injection.
+
+  **If 2 related spores cover the same topic (pair):**
   1. Determine which spore has the best content (most complete, most accurate)
-  2. Call `vault_resolve_spore` with action "supersede" on the inferior spores:
+  2. Call `vault_resolve_spore` with action "supersede" on the inferior spore:
      - new_spore_id: the kept spore's ID
      - reason: specific explanation (not just "duplicate")
-  3. For truly outdated spores (no longer accurate):
-     - Call `vault_resolve_spore` with action "archive"
-     - reason: explain what changed
 
-  Only supersede when the new information genuinely replaces the old.
-  When in doubt, keep both.
+  **For truly outdated spores (no longer accurate):**
+  - Call `vault_resolve_spore` with action "archive"
+  - reason: explain what changed
+
+  Only supersede or consolidate when the new information genuinely replaces
+  the old. When in doubt, keep both.
 
   ## Phase 4 — Report (budget: 2 turns)
 
@@ -60,6 +73,7 @@ toolOverrides:
   - vault_spores
   - vault_search
   - vault_state
+  - vault_create_spore
   - vault_resolve_spore
   - vault_set_state
   - vault_report

--- a/src/agent/definitions/tasks/title-summary.yaml
+++ b/src/agent/definitions/tasks/title-summary.yaml
@@ -34,7 +34,10 @@ prompt: |
   For each session needing updates:
   1. Call `vault_unprocessed` or review existing batches to understand
      what happened in the session
-  2. Call `vault_update_session` with BOTH title and summary:
+  2. Call `vault_search` with the session_id to find spores extracted from
+     this session — use them to understand the full scope of work done and
+     the outcomes that matter most
+  3. Call `vault_update_session` with BOTH title and summary:
      - Title: under 80 characters, reflects the full session scope
      - Summary: 2-4 sentences capturing key work, tools used, outcomes
 
@@ -47,6 +50,7 @@ prompt: |
 toolOverrides:
   - vault_unprocessed
   - vault_sessions
+  - vault_search
   - vault_state
   - vault_update_session
   - vault_set_state

--- a/src/agent/executor.ts
+++ b/src/agent/executor.ts
@@ -14,6 +14,7 @@
 
 import crypto from 'node:crypto';
 import { epochSeconds, DEFAULT_AGENT_ID } from '@myco/constants.js';
+import { errorMessage as toErrorMessage } from '@myco/utils/error-message.js';
 import { initDatabaseForVault } from '@myco/db/client.js';
 import { getAgent } from '@myco/db/queries/agents.js';
 import { getTask, getDefaultTask } from '@myco/db/queries/tasks.js';
@@ -342,7 +343,7 @@ async function executePhasedQuery(
         summary: phaseSummary,
       });
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : String(err);
+      const phaseError = toErrorMessage(err);
 
       phaseResults.push({
         name: phase.name,
@@ -350,7 +351,7 @@ async function executePhasedQuery(
         turnsUsed: phaseTurns,
         tokensUsed: phaseTokens,
         costUsd: phaseCost,
-        summary: `Error: ${errorMessage}`,
+        summary: `Error: ${phaseError}`,
       });
 
       // If a required phase fails, stop the pipeline.

--- a/src/agent/executor.ts
+++ b/src/agent/executor.ts
@@ -517,15 +517,20 @@ export async function runAgent(
     };
   } catch (err) {
     // 7. Error handling — mark run as failed, preserve phase results
-    const errorMessage = err instanceof Error
-      ? err.message || err.constructor.name
-      : String(err) || 'Unknown error';
+    // Aggressively extract error info — the SDK may throw non-Error objects
+    let errorMessage: string;
+    if (err instanceof Error) {
+      errorMessage = err.message || err.constructor.name || 'Error (no message)';
+      if (err.stack) errorMessage += `\n${err.stack.split('\n').slice(0, 3).join('\n')}`;
+    } else if (typeof err === 'string') {
+      errorMessage = err || 'Empty string error';
+    } else {
+      try { errorMessage = JSON.stringify(err); } catch { errorMessage = 'Unserializable error'; }
+    }
     const failedAt = epochSeconds();
 
-    console.error(`[agent] Run ${runId} failed:`, errorMessage);
-    if (err instanceof Error && err.stack) {
-      console.error(`[agent] Stack:`, err.stack);
-    }
+    // Log to stderr (daemon may capture) and to structured log
+    console.error(`[agent] Run ${runId} failed: ${errorMessage}`);
 
     try {
       await updateRunStatus(runId, STATUS_FAILED, {
@@ -534,8 +539,9 @@ export async function runAgent(
         // Preserve phase results collected before the failure
         actions_taken: phaseResults ? JSON.stringify({ phases: phaseResults }) : undefined,
       });
-    } catch {
-      // DB failure in error path — do not mask the original error
+    } catch (dbErr) {
+      // DB failure in error path — log it but don't mask the original error
+      console.error(`[agent] Failed to save error to DB:`, dbErr);
     }
 
     return {

--- a/src/agent/executor.ts
+++ b/src/agent/executor.ts
@@ -463,10 +463,10 @@ export async function runAgent(
   const vaultContext = await buildVaultContext(agentId);
 
   // 6. Execute — phased or single query
+  let phaseResults: PhaseResult[] | undefined;
   try {
     let tokensUsed: number;
     let costUsd: number;
-    let phaseResults: PhaseResult[] | undefined;
 
     if (config.phases && config.phases.length > 0) {
       // Phased execution: sequential query() per phase with scoped tools
@@ -516,14 +516,23 @@ export async function runAgent(
       ...(phaseResults ? { phases: phaseResults } : {}),
     };
   } catch (err) {
-    // 7. Error handling — mark run as failed
-    const errorMessage = err instanceof Error ? err.message : String(err);
+    // 7. Error handling — mark run as failed, preserve phase results
+    const errorMessage = err instanceof Error
+      ? err.message || err.constructor.name
+      : String(err) || 'Unknown error';
     const failedAt = epochSeconds();
+
+    console.error(`[agent] Run ${runId} failed:`, errorMessage);
+    if (err instanceof Error && err.stack) {
+      console.error(`[agent] Stack:`, err.stack);
+    }
 
     try {
       await updateRunStatus(runId, STATUS_FAILED, {
         completed_at: failedAt,
         error: errorMessage,
+        // Preserve phase results collected before the failure
+        actions_taken: phaseResults ? JSON.stringify({ phases: phaseResults }) : undefined,
       });
     } catch {
       // DB failure in error path — do not mask the original error
@@ -533,6 +542,7 @@ export async function runAgent(
       runId,
       status: STATUS_FAILED,
       error: errorMessage,
+      ...(phaseResults ? { phases: phaseResults } : {}),
     };
   }
 }

--- a/src/agent/executor.ts
+++ b/src/agent/executor.ts
@@ -28,10 +28,10 @@ import {
 import {
   resolveDefinitionsDir,
   loadAgentDefinition,
-  loadAgentTasks,
   loadSystemPrompt,
   resolveEffectiveConfig,
 } from './loader.js';
+import { loadAllTasks } from './registry.js';
 import { createVaultToolServer, createScopedVaultToolServer } from './tools.js';
 import { buildVaultContext } from './context.js';
 import type {
@@ -349,13 +349,11 @@ export async function runAgent(
   ]);
 
   // Convert TaskRow to AgentTask shape for resolveEffectiveConfig.
-  // Phases are structural (define how the executor runs) and come from YAML,
-  // not from DB. Load YAML tasks to get phase definitions.
-  const yamlTasks = loadAgentTasks(definitionsDir);
+  // Structural fields (phases, execution, contextQueries) come from the registry
+  // (built-in YAML merged with user vault tasks) rather than the DB flat columns.
+  const allTasks = loadAllTasks(definitionsDir, vaultDir);
   const taskName = taskRow?.id ?? options?.task;
-  const yamlTask = taskName
-    ? yamlTasks.find((t) => t.name === taskName)
-    : undefined;
+  const yamlTask = taskName ? allTasks.get(taskName) : undefined;
 
   const taskOverrides = taskRow
     ? {
@@ -368,8 +366,10 @@ export async function runAgent(
         ...(taskRow.tool_overrides
           ? { toolOverrides: JSON.parse(taskRow.tool_overrides) as string[] }
           : {}),
-        // Phases come from YAML — DB doesn't store them
+        // Structural fields come from the registry (not DB flat columns)
         ...(yamlTask?.phases ? { phases: yamlTask.phases } : {}),
+        ...(yamlTask?.execution ? { execution: yamlTask.execution } : {}),
+        ...(yamlTask?.contextQueries ? { contextQueries: yamlTask.contextQueries } : {}),
       }
     : undefined;
 

--- a/src/agent/executor.ts
+++ b/src/agent/executor.ts
@@ -233,6 +233,7 @@ async function executePhasedQuery(
   const phaseResults: PhaseResult[] = [];
   let totalTokens = 0;
   let totalCost = 0;
+  let runningTurnCount = 0;
 
   // ---------------------------------------------------------------------------
   // Orchestrator planning (opt-in via config.orchestrator.enabled)
@@ -292,7 +293,7 @@ async function executePhasedQuery(
     );
 
     const phaseModel = phase.model ?? config.model;
-    const toolServer = createScopedVaultToolServer(agentId, runId, phase.tools);
+    const toolServer = createScopedVaultToolServer(agentId, runId, phase.tools, runningTurnCount);
 
     let phaseCost = 0;
     let phaseTokens = 0;
@@ -355,17 +356,16 @@ async function executePhasedQuery(
       // If a required phase fails, stop the pipeline.
       // finally runs before break, so provider env is always restored.
       if (phase.required) {
-        totalTokens += phaseTokens;
-        totalCost += phaseCost;
         break;
       }
     } finally {
       // Always restore provider env after each phase query (including on break).
       if (savedEnv) restoreProviderEnv(savedEnv);
+      // Accumulate totals and advance turn count (runs even on break).
+      totalTokens += phaseTokens;
+      totalCost += phaseCost;
+      runningTurnCount += phaseTurns;
     }
-
-    totalTokens += phaseTokens;
-    totalCost += phaseCost;
   }
 
   return { tokensUsed: totalTokens, costUsd: totalCost, phases: phaseResults };

--- a/src/agent/executor.ts
+++ b/src/agent/executor.ts
@@ -7,7 +7,8 @@
  *   3. Guards against concurrent runs for the same agent.
  *   4. Creates a run record in the database.
  *   5. Builds the task prompt (vault context + task + optional instruction).
- *   6. Executes the Claude Agent SDK query with an in-process MCP tool server.
+ *   6. Executes the Claude Agent SDK query — single call for flat tasks,
+ *      sequential phase loop for phased tasks.
  *   7. Records cost/token data and marks the run completed or failed.
  */
 
@@ -27,12 +28,19 @@ import {
 import {
   resolveDefinitionsDir,
   loadAgentDefinition,
+  loadAgentTasks,
   loadSystemPrompt,
   resolveEffectiveConfig,
 } from './loader.js';
-import { createVaultToolServer } from './tools.js';
+import { createVaultToolServer, createScopedVaultToolServer } from './tools.js';
 import { buildVaultContext } from './context.js';
-import type { RunOptions, AgentRunResult } from './types.js';
+import type {
+  RunOptions,
+  AgentRunResult,
+  EffectiveConfig,
+  PhaseDefinition,
+  PhaseResult,
+} from './types.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -58,6 +66,15 @@ const MCP_SERVER_NAME = 'myco-vault';
 
 /** Whether to persist the agent session to disk. */
 const PERSIST_SESSION = false;
+
+/** Header for prior phase context in phased prompts. */
+const PROMPT_SECTION_PRIOR_PHASES = '## Prior Phase Results';
+
+/** Header for the current phase in phased prompts. */
+const PROMPT_SECTION_CURRENT_PHASE = '## Current Phase: ';
+
+/** Truncation limit for phase summary text passed to subsequent phases. */
+const PHASE_SUMMARY_MAX_CHARS = 2000;
 
 // ---------------------------------------------------------------------------
 // Prompt composition
@@ -98,12 +115,211 @@ export function composeTaskPrompt(
   return parts.join(PROMPT_SECTION_SEPARATOR);
 }
 
+/**
+ * Build the prompt for a single phase in a phased execution.
+ *
+ * Includes vault context, the task overview, prior phase summaries,
+ * and the current phase instructions.
+ */
+export function composePhasePrompt(
+  vaultContext: string,
+  taskDisplayName: string,
+  taskOverview: string,
+  phase: PhaseDefinition,
+  priorPhaseResults: PhaseResult[],
+  instruction?: string,
+): string {
+  const parts = [
+    vaultContext,
+    `${PROMPT_SECTION_TASK}${taskDisplayName}\n${taskOverview}`,
+  ];
+
+  if (instruction) {
+    parts.push(`${PROMPT_SECTION_INSTRUCTION}\n${instruction}`);
+  }
+
+  // Include prior phase results as context
+  if (priorPhaseResults.length > 0) {
+    const summaries = priorPhaseResults.map((pr) => {
+      const truncated = pr.summary.length > PHASE_SUMMARY_MAX_CHARS
+        ? pr.summary.slice(0, PHASE_SUMMARY_MAX_CHARS) + '...'
+        : pr.summary;
+      return `### ${pr.name} (${pr.status})\n${truncated}`;
+    });
+    parts.push(`${PROMPT_SECTION_PRIOR_PHASES}\n${summaries.join('\n\n')}`);
+  }
+
+  // Current phase instructions
+  parts.push(`${PROMPT_SECTION_CURRENT_PHASE}${phase.name}\n${phase.prompt}`);
+
+  return parts.join(PROMPT_SECTION_SEPARATOR);
+}
+
+// ---------------------------------------------------------------------------
+// Single-query execution (non-phased tasks)
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a single query() call for non-phased tasks.
+ *
+ * @returns tokens used, cost, and status.
+ */
+async function executeSingleQuery(
+  config: EffectiveConfig,
+  systemPrompt: string,
+  taskPrompt: string,
+  agentId: string,
+  runId: string,
+): Promise<{ tokensUsed: number; costUsd: number }> {
+  const { query } = await import('@anthropic-ai/claude-agent-sdk');
+  const toolServer = createVaultToolServer(agentId, runId);
+
+  let resultCostUsd = 0;
+  let resultTokens = 0;
+
+  for await (const message of query({
+    prompt: taskPrompt,
+    options: {
+      model: config.model,
+      systemPrompt,
+      mcpServers: { [MCP_SERVER_NAME]: toolServer },
+      maxTurns: config.maxTurns,
+      permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
+      persistSession: PERSIST_SESSION,
+      tools: [],
+    },
+  })) {
+    if (message.type === 'result') {
+      resultCostUsd = message.total_cost_usd ?? 0;
+      resultTokens =
+        (message.usage.input_tokens ?? 0) + (message.usage.output_tokens ?? 0);
+    }
+  }
+
+  return { tokensUsed: resultTokens, costUsd: resultCostUsd };
+}
+
+// ---------------------------------------------------------------------------
+// Phased execution
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a phased task — sequential query() calls, one per phase.
+ *
+ * Each phase gets:
+ * - Scoped tools (only the tools listed in the phase definition)
+ * - Its own turn budget (maxTurns)
+ * - Optional model override (falls back to task/agent model)
+ * - Context from prior phase results
+ *
+ * The executor controls the loop — the LLM cannot skip phases.
+ */
+async function executePhasedQuery(
+  config: EffectiveConfig,
+  systemPrompt: string,
+  vaultContext: string,
+  agentId: string,
+  runId: string,
+  instruction?: string,
+): Promise<{ tokensUsed: number; costUsd: number; phases: PhaseResult[] }> {
+  const { query } = await import('@anthropic-ai/claude-agent-sdk');
+
+  const phases = config.phases!;
+  const phaseResults: PhaseResult[] = [];
+  let totalTokens = 0;
+  let totalCost = 0;
+
+  for (const phase of phases) {
+    const phasePrompt = composePhasePrompt(
+      vaultContext,
+      config.taskDisplayName,
+      config.taskPrompt,
+      phase,
+      phaseResults,
+      instruction,
+    );
+
+    const phaseModel = phase.model ?? config.model;
+    const toolServer = createScopedVaultToolServer(agentId, runId, phase.tools);
+
+    let phaseCost = 0;
+    let phaseTokens = 0;
+    let phaseTurns = 0;
+    let phaseSummary = '';
+
+    try {
+      for await (const message of query({
+        prompt: phasePrompt,
+        options: {
+          model: phaseModel,
+          systemPrompt,
+          mcpServers: { [MCP_SERVER_NAME]: toolServer },
+          maxTurns: phase.maxTurns,
+          permissionMode: 'bypassPermissions',
+          allowDangerouslySkipPermissions: true,
+          persistSession: PERSIST_SESSION,
+          tools: [],
+        },
+      })) {
+        if (message.type === 'result') {
+          phaseCost = message.total_cost_usd ?? 0;
+          phaseTokens =
+            (message.usage.input_tokens ?? 0) + (message.usage.output_tokens ?? 0);
+          phaseTurns = message.num_turns ?? 0;
+          if ('result' in message && typeof message.result === 'string') {
+            phaseSummary = message.result;
+          }
+        }
+      }
+
+      if (phase.required && phaseTurns === 0) {
+        console.warn(`[agent] Required phase "${phase.name}" produced 0 turns`);
+      }
+
+      phaseResults.push({
+        name: phase.name,
+        status: 'completed',
+        turnsUsed: phaseTurns,
+        tokensUsed: phaseTokens,
+        costUsd: phaseCost,
+        summary: phaseSummary,
+      });
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+
+      phaseResults.push({
+        name: phase.name,
+        status: 'failed',
+        turnsUsed: phaseTurns,
+        tokensUsed: phaseTokens,
+        costUsd: phaseCost,
+        summary: `Error: ${errorMessage}`,
+      });
+
+      // If a required phase fails, stop the pipeline
+      if (phase.required) {
+        break;
+      }
+    }
+
+    totalTokens += phaseTokens;
+    totalCost += phaseCost;
+  }
+
+  return { tokensUsed: totalTokens, costUsd: totalCost, phases: phaseResults };
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 /**
  * Run an agent against a vault.
+ *
+ * For tasks with a `phases` array, uses phased execution (sequential query()
+ * calls per phase with scoped tools). For tasks without phases, uses a single
+ * query() call as before.
  *
  * @param vaultDir — absolute path to the vault directory.
  * @param options — optional overrides for agent, task, and instruction.
@@ -132,7 +348,15 @@ export async function runAgent(
     taskPromise,
   ]);
 
-  // Convert TaskRow to AgentTask shape for resolveEffectiveConfig
+  // Convert TaskRow to AgentTask shape for resolveEffectiveConfig.
+  // Phases are structural (define how the executor runs) and come from YAML,
+  // not from DB. Load YAML tasks to get phase definitions.
+  const yamlTasks = loadAgentTasks(definitionsDir);
+  const taskName = taskRow?.id ?? options?.task;
+  const yamlTask = taskName
+    ? yamlTasks.find((t) => t.name === taskName)
+    : undefined;
+
   const taskOverrides = taskRow
     ? {
         name: taskRow.id,
@@ -144,6 +368,8 @@ export async function runAgent(
         ...(taskRow.tool_overrides
           ? { toolOverrides: JSON.parse(taskRow.tool_overrides) as string[] }
           : {}),
+        // Phases come from YAML — DB doesn't store them
+        ...(yamlTask?.phases ? { phases: yamlTask.phases } : {}),
       }
     : undefined;
 
@@ -172,61 +398,64 @@ export async function runAgent(
     started_at: now,
   });
 
-  // 5. Build prompt
+  // 5. Build prompt components
   const systemPrompt = loadSystemPrompt(definitionsDir, config.systemPromptPath);
   const vaultContext = await buildVaultContext(agentId);
-  const taskPrompt = composeTaskPrompt(
-    vaultContext,
-    config.taskDisplayName,
-    config.taskPrompt,
-    options?.instruction,
-  );
 
-  // 6. Create tool server
-  const toolServer = createVaultToolServer(agentId, runId);
-
-  // 7. Execute Agent SDK
+  // 6. Execute — phased or single query
   try {
-    const { query } = await import('@anthropic-ai/claude-agent-sdk');
+    let tokensUsed: number;
+    let costUsd: number;
+    let phaseResults: PhaseResult[] | undefined;
 
-    let resultCostUsd = 0;
-    let resultTokens = 0;
-
-    for await (const message of query({
-      prompt: taskPrompt,
-      options: {
-        model: config.model,
+    if (config.phases && config.phases.length > 0) {
+      // Phased execution: sequential query() per phase with scoped tools
+      const result = await executePhasedQuery(
+        config,
         systemPrompt,
-        mcpServers: { [MCP_SERVER_NAME]: toolServer },
-        maxTurns: config.maxTurns,
-        permissionMode: 'bypassPermissions',
-        allowDangerouslySkipPermissions: true,
-        persistSession: PERSIST_SESSION,
-        tools: [],
-      },
-    })) {
-      if (message.type === 'result') {
-        resultCostUsd = message.total_cost_usd ?? 0;
-        resultTokens =
-          (message.usage.input_tokens ?? 0) + (message.usage.output_tokens ?? 0);
-      }
+        vaultContext,
+        agentId,
+        runId,
+        options?.instruction,
+      );
+      tokensUsed = result.tokensUsed;
+      costUsd = result.costUsd;
+      phaseResults = result.phases;
+    } else {
+      // Single-query execution (backward compatible)
+      const taskPrompt = composeTaskPrompt(
+        vaultContext,
+        config.taskDisplayName,
+        config.taskPrompt,
+        options?.instruction,
+      );
+      const result = await executeSingleQuery(
+        config,
+        systemPrompt,
+        taskPrompt,
+        agentId,
+        runId,
+      );
+      tokensUsed = result.tokensUsed;
+      costUsd = result.costUsd;
     }
 
     const completedAt = epochSeconds();
     await updateRunStatus(runId, STATUS_COMPLETED, {
       completed_at: completedAt,
-      tokens_used: resultTokens,
-      cost_usd: resultCostUsd,
+      tokens_used: tokensUsed,
+      cost_usd: costUsd,
     });
 
     return {
       runId,
       status: STATUS_COMPLETED,
-      tokensUsed: resultTokens,
-      costUsd: resultCostUsd,
+      tokensUsed,
+      costUsd,
+      ...(phaseResults ? { phases: phaseResults } : {}),
     };
   } catch (err) {
-    // 8. Error handling — mark run as failed
+    // 7. Error handling — mark run as failed
     const errorMessage = err instanceof Error ? err.message : String(err);
     const failedAt = epochSeconds();
 

--- a/src/agent/executor.ts
+++ b/src/agent/executor.ts
@@ -393,11 +393,21 @@ export async function runAgent(
   // 1. Init DB
   await initDatabaseForVault(vaultDir);
 
-  // 2. Resolve config
+  const agentId = options?.agentId ?? DEFAULT_AGENT_ID;
+
+  // 2. Concurrency guard — check before expensive config loading
+  const running = await getRunningRun(agentId);
+  if (running) {
+    return {
+      runId: running.id,
+      status: STATUS_SKIPPED,
+      reason: SKIP_REASON_ALREADY_RUNNING,
+    };
+  }
+
+  // 3. Resolve config
   const definitionsDir = resolveDefinitionsDir();
   const definition = loadAgentDefinition(definitionsDir);
-
-  const agentId = options?.agentId ?? DEFAULT_AGENT_ID;
 
   // Load agent and task in parallel — both are independent DB lookups
   const taskPromise = options?.task
@@ -409,7 +419,6 @@ export async function runAgent(
     taskPromise,
   ]);
 
-  // Convert TaskRow to AgentTask shape for resolveEffectiveConfig.
   // Structural fields (phases, execution, contextQueries) come from the registry
   // (built-in YAML merged with user vault tasks) rather than the DB flat columns.
   const allTasks = loadAllTasks(definitionsDir, vaultDir);
@@ -427,7 +436,6 @@ export async function runAgent(
         ...(taskRow.tool_overrides
           ? { toolOverrides: JSON.parse(taskRow.tool_overrides) as string[] }
           : {}),
-        // Structural fields come from the registry (not DB flat columns)
         ...(yamlTask?.phases ? { phases: yamlTask.phases } : {}),
         ...(yamlTask?.execution ? { execution: yamlTask.execution } : {}),
         ...(yamlTask?.contextQueries ? { contextQueries: yamlTask.contextQueries } : {}),
@@ -436,16 +444,6 @@ export async function runAgent(
     : undefined;
 
   const config = resolveEffectiveConfig(definition, agentRow, taskOverrides);
-
-  // 3. Concurrency guard
-  const running = await getRunningRun(agentId);
-  if (running) {
-    return {
-      runId: running.id,
-      status: STATUS_SKIPPED,
-      reason: SKIP_REASON_ALREADY_RUNNING,
-    };
-  }
 
   // 4. Create run record
   const runId = crypto.randomUUID();

--- a/src/agent/executor.ts
+++ b/src/agent/executor.ts
@@ -34,6 +34,10 @@ import {
 import { loadAllTasks } from './registry.js';
 import { createVaultToolServer, createScopedVaultToolServer } from './tools.js';
 import { buildVaultContext } from './context.js';
+import { composeOrchestratorPrompt, parseOrchestratorPlan, applyDirectives, DEFAULT_ORCHESTRATOR_MAX_TURNS } from './orchestrator.js';
+import { executeContextQueries } from './context-queries.js';
+import { applyProviderEnv, restoreProviderEnv } from './provider.js';
+import type { ContextQueryResult } from './context-queries.js';
 import type {
   RunOptions,
   AgentRunResult,
@@ -230,7 +234,54 @@ async function executePhasedQuery(
   let totalTokens = 0;
   let totalCost = 0;
 
-  for (const phase of phases) {
+  // ---------------------------------------------------------------------------
+  // Orchestrator planning (opt-in via config.orchestrator.enabled)
+  // ---------------------------------------------------------------------------
+
+  let effectivePhases = [...phases];
+
+  if (config.orchestrator?.enabled) {
+    // 1. Run context queries (if any)
+    const contextQueries = config.contextQueries
+      ? Object.values(config.contextQueries).flat()
+      : [];
+    const contextResults: ContextQueryResult[] = contextQueries.length > 0
+      ? await executeContextQueries(agentId, contextQueries)
+      : [];
+
+    // 2. Compose orchestrator prompt
+    const orchestratorPrompt = composeOrchestratorPrompt(vaultContext, phases, contextResults);
+    const orchestratorModel = config.orchestrator.model ?? config.model;
+    const orchestratorMaxTurns = config.orchestrator.maxTurns ?? DEFAULT_ORCHESTRATOR_MAX_TURNS;
+
+    // 3. Call orchestrator (no tools — planning only)
+    let planResponse = '';
+    for await (const message of query({
+      prompt: orchestratorPrompt,
+      options: {
+        model: orchestratorModel,
+        maxTurns: orchestratorMaxTurns,
+        permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
+        persistSession: PERSIST_SESSION,
+        tools: [],
+      },
+    })) {
+      if (message.type === 'result' && 'result' in message && typeof message.result === 'string') {
+        planResponse = message.result;
+      }
+    }
+
+    // 4. Parse plan and apply directives
+    const plan = parseOrchestratorPlan(planResponse, phases);
+    effectivePhases = applyDirectives(phases, plan.phases);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Phase loop
+  // ---------------------------------------------------------------------------
+
+  for (const phase of effectivePhases) {
     const phasePrompt = composePhasePrompt(
       vaultContext,
       config.taskDisplayName,
@@ -247,6 +298,10 @@ async function executePhasedQuery(
     let phaseTokens = 0;
     let phaseTurns = 0;
     let phaseSummary = '';
+
+    // Apply provider env for this phase (if execution.provider is configured)
+    const phaseProvider = config.execution?.provider;
+    const savedEnv = phaseProvider ? applyProviderEnv(phaseProvider) : null;
 
     try {
       for await (const message of query({
@@ -297,10 +352,16 @@ async function executePhasedQuery(
         summary: `Error: ${errorMessage}`,
       });
 
-      // If a required phase fails, stop the pipeline
+      // If a required phase fails, stop the pipeline.
+      // finally runs before break, so provider env is always restored.
       if (phase.required) {
+        totalTokens += phaseTokens;
+        totalCost += phaseCost;
         break;
       }
+    } finally {
+      // Always restore provider env after each phase query (including on break).
+      if (savedEnv) restoreProviderEnv(savedEnv);
     }
 
     totalTokens += phaseTokens;
@@ -370,6 +431,7 @@ export async function runAgent(
         ...(yamlTask?.phases ? { phases: yamlTask.phases } : {}),
         ...(yamlTask?.execution ? { execution: yamlTask.execution } : {}),
         ...(yamlTask?.contextQueries ? { contextQueries: yamlTask.contextQueries } : {}),
+        ...(yamlTask?.orchestrator ? { orchestrator: yamlTask.orchestrator } : {}),
       }
     : undefined;
 

--- a/src/agent/executor.ts
+++ b/src/agent/executor.ts
@@ -507,6 +507,7 @@ export async function runAgent(
       completed_at: completedAt,
       tokens_used: tokensUsed,
       cost_usd: costUsd,
+      actions_taken: phaseResults ? JSON.stringify({ phases: phaseResults }) : undefined,
     });
 
     return {

--- a/src/agent/loader.ts
+++ b/src/agent/loader.ts
@@ -117,23 +117,35 @@ export function loadAgentTasks(definitionsDir: string): AgentTask[] {
     const raw = fs.readFileSync(path.join(tasksDir, file), 'utf-8');
     const parsed = AgentTaskSchema.parse(parseYaml(raw));
 
-    return {
-      name: parsed.name,
-      displayName: parsed.displayName,
-      description: parsed.description.trim(),
-      agent: parsed.agent,
-      prompt: parsed.prompt.trim(),
-      isDefault: parsed.isDefault,
-      ...(parsed.toolOverrides ? { toolOverrides: parsed.toolOverrides } : {}),
-      ...(parsed.model ? { model: parsed.model } : {}),
-      ...(parsed.maxTurns ? { maxTurns: parsed.maxTurns } : {}),
-      ...(parsed.timeoutSeconds ? { timeoutSeconds: parsed.timeoutSeconds } : {}),
-      ...(parsed.phases ? { phases: parsed.phases } : {}),
-      ...(parsed.orchestrator ? { orchestrator: parsed.orchestrator } : {}),
-      ...(parsed.contextQueries ? { contextQueries: parsed.contextQueries } : {}),
-      ...(parsed.execution ? { execution: parsed.execution } : {}),
-    };
+    return taskFromParsed(parsed);
   });
+}
+
+/**
+ * Convert a Zod-parsed task schema result to an AgentTask object.
+ *
+ * Shared by loadAgentTasks (built-in) and registry (user tasks) to ensure
+ * all optional fields are consistently spread. Adding a new optional field
+ * to AgentTaskSchema only requires updating this one function.
+ */
+export function taskFromParsed(parsed: AgentTask): AgentTask {
+  return {
+    name: parsed.name,
+    displayName: parsed.displayName,
+    description: parsed.description.trim(),
+    agent: parsed.agent,
+    prompt: parsed.prompt.trim(),
+    isDefault: parsed.isDefault,
+    ...(parsed.toolOverrides ? { toolOverrides: parsed.toolOverrides } : {}),
+    ...(parsed.model ? { model: parsed.model } : {}),
+    ...(parsed.maxTurns ? { maxTurns: parsed.maxTurns } : {}),
+    ...(parsed.timeoutSeconds ? { timeoutSeconds: parsed.timeoutSeconds } : {}),
+    ...(parsed.phases ? { phases: parsed.phases } : {}),
+    ...(parsed.orchestrator ? { orchestrator: parsed.orchestrator } : {}),
+    ...(parsed.contextQueries ? { contextQueries: parsed.contextQueries } : {}),
+    ...(parsed.execution ? { execution: parsed.execution } : {}),
+    ...(parsed.schemaVersion ? { schemaVersion: parsed.schemaVersion } : {}),
+  };
 }
 
 /**

--- a/src/agent/loader.ts
+++ b/src/agent/loader.ts
@@ -9,7 +9,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { z } from 'zod/v4';
 import { parse as parseYaml } from 'yaml';
 import { epochSeconds, DEFAULT_AGENT_ID } from '@myco/constants.js';
 import { getDatabase } from '@myco/db/client.js';
@@ -17,6 +16,7 @@ import { registerAgent } from '@myco/db/queries/agents.js';
 import { upsertTask } from '@myco/db/queries/tasks.js';
 import type { AgentRow } from '@myco/db/queries/agents.js';
 import type { AgentDefinition, AgentTask, EffectiveConfig } from './types.js';
+import { AgentDefinitionSchema, AgentTaskSchema } from './schemas.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -33,47 +33,6 @@ const MAX_PARENT_WALK_DEPTH = 10;
 
 /** Source label for built-in agents and tasks in the database. */
 const BUILT_IN_SOURCE = 'built-in';
-
-// ---------------------------------------------------------------------------
-// Zod schemas for YAML validation
-// ---------------------------------------------------------------------------
-
-/** Schema for agent.yaml agent definition files. */
-const AgentDefinitionSchema = z.object({
-  name: z.string(),
-  displayName: z.string(),
-  description: z.string(),
-  model: z.string(),
-  maxTurns: z.number(),
-  timeoutSeconds: z.number(),
-  systemPromptPath: z.string(),
-  tools: z.array(z.string()),
-});
-
-/** Schema for a single phase within a phased task pipeline. */
-const PhaseDefinitionSchema = z.object({
-  name: z.string(),
-  prompt: z.string(),
-  tools: z.array(z.string()),
-  maxTurns: z.number(),
-  model: z.string().optional(),
-  required: z.boolean(),
-});
-
-/** Schema for task YAML files in tasks/. */
-const AgentTaskSchema = z.object({
-  name: z.string(),
-  displayName: z.string(),
-  description: z.string(),
-  agent: z.string(),
-  prompt: z.string(),
-  isDefault: z.boolean(),
-  toolOverrides: z.array(z.string()).optional(),
-  model: z.string().optional(),
-  maxTurns: z.number().optional(),
-  timeoutSeconds: z.number().optional(),
-  phases: z.array(PhaseDefinitionSchema).optional(),
-});
 
 // ---------------------------------------------------------------------------
 // Definitions directory resolution

--- a/src/agent/loader.ts
+++ b/src/agent/loader.ts
@@ -201,6 +201,14 @@ export function resolveEffectiveConfig(
     tools = [...taskOverrides.toolOverrides];
   }
 
+  // Apply execution config overrides (highest priority)
+  // Precedence: execution.model > task.model > agent.model
+  if (taskOverrides?.execution) {
+    if (taskOverrides.execution.model) model = taskOverrides.execution.model;
+    if (taskOverrides.execution.maxTurns) maxTurns = taskOverrides.execution.maxTurns;
+    if (taskOverrides.execution.timeoutSeconds) timeoutSeconds = taskOverrides.execution.timeoutSeconds;
+  }
+
   // Task prompt and display info (fall back to a generic prompt)
   const taskName = taskOverrides?.name ?? 'full-intelligence';
   const taskDisplayName = taskOverrides?.displayName ?? 'Full Intelligence';

--- a/src/agent/loader.ts
+++ b/src/agent/loader.ts
@@ -225,6 +225,9 @@ export function resolveEffectiveConfig(
     taskDisplayName,
     taskPrompt,
     ...(taskOverrides?.phases ? { phases: taskOverrides.phases } : {}),
+    ...(taskOverrides?.orchestrator ? { orchestrator: taskOverrides.orchestrator } : {}),
+    ...(taskOverrides?.contextQueries ? { contextQueries: taskOverrides.contextQueries } : {}),
+    ...(taskOverrides?.execution ? { execution: taskOverrides.execution } : {}),
   };
 }
 

--- a/src/agent/loader.ts
+++ b/src/agent/loader.ts
@@ -10,7 +10,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parse as parseYaml } from 'yaml';
-import { epochSeconds, DEFAULT_AGENT_ID } from '@myco/constants.js';
+import { epochSeconds, DEFAULT_AGENT_ID, BUILT_IN_SOURCE } from '@myco/constants.js';
 import { getDatabase } from '@myco/db/client.js';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import { upsertTask } from '@myco/db/queries/tasks.js';
@@ -31,8 +31,7 @@ const TASKS_SUBDIRECTORY = 'tasks';
 /** Max parent directories to walk when resolving the package root. */
 const MAX_PARENT_WALK_DEPTH = 10;
 
-/** Source label for built-in agents and tasks in the database. */
-const BUILT_IN_SOURCE = 'built-in';
+// BUILT_IN_SOURCE imported from @myco/constants.js
 
 // ---------------------------------------------------------------------------
 // Definitions directory resolution
@@ -132,6 +131,9 @@ export function loadAgentTasks(definitionsDir: string): AgentTask[] {
       ...(parsed.maxTurns ? { maxTurns: parsed.maxTurns } : {}),
       ...(parsed.timeoutSeconds ? { timeoutSeconds: parsed.timeoutSeconds } : {}),
       ...(parsed.phases ? { phases: parsed.phases } : {}),
+      ...(parsed.orchestrator ? { orchestrator: parsed.orchestrator } : {}),
+      ...(parsed.contextQueries ? { contextQueries: parsed.contextQueries } : {}),
+      ...(parsed.execution ? { execution: parsed.execution } : {}),
     };
   });
 }

--- a/src/agent/loader.ts
+++ b/src/agent/loader.ts
@@ -9,6 +9,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { findPackageRoot } from '@myco/utils/find-package-root.js';
 import { parse as parseYaml } from 'yaml';
 import { epochSeconds, DEFAULT_AGENT_ID, BUILT_IN_SOURCE } from '@myco/constants.js';
 import { getDatabase } from '@myco/db/client.js';
@@ -28,8 +29,7 @@ const AGENT_DEFINITION_FILE = 'agent.yaml';
 /** Subdirectory containing task YAML files. */
 const TASKS_SUBDIRECTORY = 'tasks';
 
-/** Max parent directories to walk when resolving the package root. */
-const MAX_PARENT_WALK_DEPTH = 10;
+// Package root resolution uses shared findPackageRoot from @myco/utils
 
 // BUILT_IN_SOURCE imported from @myco/constants.js
 
@@ -47,33 +47,31 @@ const MAX_PARENT_WALK_DEPTH = 10;
  * 4. Also check if the current file's directory already contains agent.yaml.
  */
 export function resolveDefinitionsDir(): string {
-  let dir = path.dirname(fileURLToPath(import.meta.url));
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 
-  // Check if we're already adjacent to the definitions
-  const adjacentDefs = path.join(dir, 'definitions');
+  // Check if we're already adjacent to the definitions (tsc output or dev mode)
+  const adjacentDefs = path.join(scriptDir, 'definitions');
   if (fs.existsSync(path.join(adjacentDefs, AGENT_DEFINITION_FILE))) {
     return adjacentDefs;
   }
 
-  // Walk up to find package.json
-  for (let i = 0; i < MAX_PARENT_WALK_DEPTH; i++) {
-    if (fs.existsSync(path.join(dir, 'package.json'))) {
-      // Try dist path first (tsup bundled output)
-      const distPath = path.join(dir, 'dist', 'src', 'agent', 'definitions');
-      if (fs.existsSync(path.join(distPath, AGENT_DEFINITION_FILE))) {
-        return distPath;
-      }
-      // Fall back to src path (dev mode)
-      const srcPath = path.join(dir, 'src', 'agent', 'definitions');
-      if (fs.existsSync(path.join(srcPath, AGENT_DEFINITION_FILE))) {
-        return srcPath;
-      }
+  // Walk up to package root using shared utility
+  const root = findPackageRoot(scriptDir);
+  if (root) {
+    // Try dist path first (tsup bundled output)
+    const distPath = path.join(root, 'dist', 'src', 'agent', 'definitions');
+    if (fs.existsSync(path.join(distPath, AGENT_DEFINITION_FILE))) {
+      return distPath;
     }
-    dir = path.dirname(dir);
+    // Fall back to src path (dev mode)
+    const srcPath = path.join(root, 'src', 'agent', 'definitions');
+    if (fs.existsSync(path.join(srcPath, AGENT_DEFINITION_FILE))) {
+      return srcPath;
+    }
   }
 
   // Final fallback: adjacent to current file
-  return path.join(path.dirname(fileURLToPath(import.meta.url)), 'definitions');
+  return adjacentDefs;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/agent/loader.ts
+++ b/src/agent/loader.ts
@@ -261,6 +261,12 @@ export async function registerBuiltInAgentsAndTasks(definitionsDir: string): Pro
       prompt: task.prompt,
       is_default: task.isDefault ? 1 : 0,
       tool_overrides: task.toolOverrides ? JSON.stringify(task.toolOverrides) : null,
+      config: JSON.stringify({
+        phases: task.phases ?? null,
+        execution: task.execution ?? null,
+        contextQueries: task.contextQueries ?? null,
+        schemaVersion: task.schemaVersion ?? 1,
+      }),
       created_at: now,
       updated_at: now,
     });

--- a/src/agent/loader.ts
+++ b/src/agent/loader.ts
@@ -50,6 +50,16 @@ const AgentDefinitionSchema = z.object({
   tools: z.array(z.string()),
 });
 
+/** Schema for a single phase within a phased task pipeline. */
+const PhaseDefinitionSchema = z.object({
+  name: z.string(),
+  prompt: z.string(),
+  tools: z.array(z.string()),
+  maxTurns: z.number(),
+  model: z.string().optional(),
+  required: z.boolean(),
+});
+
 /** Schema for task YAML files in tasks/. */
 const AgentTaskSchema = z.object({
   name: z.string(),
@@ -62,6 +72,7 @@ const AgentTaskSchema = z.object({
   model: z.string().optional(),
   maxTurns: z.number().optional(),
   timeoutSeconds: z.number().optional(),
+  phases: z.array(PhaseDefinitionSchema).optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -161,6 +172,7 @@ export function loadAgentTasks(definitionsDir: string): AgentTask[] {
       ...(parsed.model ? { model: parsed.model } : {}),
       ...(parsed.maxTurns ? { maxTurns: parsed.maxTurns } : {}),
       ...(parsed.timeoutSeconds ? { timeoutSeconds: parsed.timeoutSeconds } : {}),
+      ...(parsed.phases ? { phases: parsed.phases } : {}),
     };
   });
 }
@@ -245,6 +257,7 @@ export function resolveEffectiveConfig(
     taskName,
     taskDisplayName,
     taskPrompt,
+    ...(taskOverrides?.phases ? { phases: taskOverrides.phases } : {}),
   };
 }
 

--- a/src/agent/orchestrator.ts
+++ b/src/agent/orchestrator.ts
@@ -11,6 +11,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { findPackageRoot } from '@myco/utils/find-package-root.js';
 import { extractJson } from '@myco/intelligence/response.js';
 import type { PhaseDefinition, OrchestratorPlan, OrchestratorPhaseDirective } from './types.js';
 import type { ContextQueryResult } from './context-queries.js';
@@ -63,9 +64,30 @@ let cachedPromptTemplate: string | undefined;
 
 function loadPromptTemplate(): string {
   if (!cachedPromptTemplate) {
-    const dir = path.dirname(fileURLToPath(import.meta.url));
-    const filePath = path.join(dir, 'prompts', ORCHESTRATOR_PROMPT_FILE);
-    cachedPromptTemplate = fs.readFileSync(filePath, 'utf-8');
+    const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+
+    // Check sibling prompts/ directory first (tsc output or dev mode)
+    const adjacentPath = path.join(scriptDir, 'prompts', ORCHESTRATOR_PROMPT_FILE);
+    if (fs.existsSync(adjacentPath)) {
+      cachedPromptTemplate = fs.readFileSync(adjacentPath, 'utf-8');
+      return cachedPromptTemplate;
+    }
+
+    // tsup bundles into dist/chunk-XXXX.js — walk up to package root
+    const root = findPackageRoot(scriptDir);
+    if (root) {
+      const distPath = path.join(root, 'dist', 'src', 'agent', 'prompts', ORCHESTRATOR_PROMPT_FILE);
+      if (fs.existsSync(distPath)) {
+        cachedPromptTemplate = fs.readFileSync(distPath, 'utf-8');
+        return cachedPromptTemplate;
+      }
+      const srcPath = path.join(root, 'src', 'agent', 'prompts', ORCHESTRATOR_PROMPT_FILE);
+      cachedPromptTemplate = fs.readFileSync(srcPath, 'utf-8');
+      return cachedPromptTemplate;
+    }
+
+    // Final fallback
+    cachedPromptTemplate = fs.readFileSync(adjacentPath, 'utf-8');
   }
   return cachedPromptTemplate;
 }

--- a/src/agent/orchestrator.ts
+++ b/src/agent/orchestrator.ts
@@ -1,0 +1,278 @@
+/**
+ * Orchestrator planning call.
+ *
+ * Composes the orchestrator prompt, parses the LLM response into a structured
+ * plan, and applies phase directives to PhaseDefinition objects.
+ *
+ * This module is pure logic — no SDK calls. SDK invocation happens in the
+ * executor integration (Task 5).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { PhaseDefinition, OrchestratorPlan, OrchestratorPhaseDirective } from './types.js';
+import type { ContextQueryResult } from './context-queries.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default max turns for the orchestrator's own LLM call. */
+export const DEFAULT_ORCHESTRATOR_MAX_TURNS = 3;
+
+/** Filename of the orchestrator prompt template. */
+const ORCHESTRATOR_PROMPT_FILE = 'orchestrator.md';
+
+/** Number of characters to show from a phase's prompt as a preview. */
+const PHASE_PROMPT_PREVIEW_CHARS = 100;
+
+/** Section header injected into a phase prompt when contextNotes are present. */
+const ORCHESTRATOR_GUIDANCE_HEADER = '## Orchestrator Guidance';
+
+/** Placeholder substituted when no context query results are available. */
+const NO_CONTEXT_QUERIES_TEXT = 'No context queries configured.';
+
+/** Fallback reasoning string used when JSON parsing fails. */
+const FALLBACK_REASONING_PARSE_ERROR = 'Orchestrator response could not be parsed — running all phases with defaults.';
+
+/** Fallback reasoning string used when the parsed plan has no phases array. */
+const FALLBACK_REASONING_MISSING_PHASES = 'Orchestrator plan missing phases array — running all phases with defaults.';
+
+// ---------------------------------------------------------------------------
+// Template placeholder names
+// ---------------------------------------------------------------------------
+
+const PLACEHOLDER_VAULT_STATE = '{{vault_state}}';
+const PLACEHOLDER_PHASE_DEFINITIONS = '{{phase_definitions}}';
+const PLACEHOLDER_CONTEXT_RESULTS = '{{context_results}}';
+
+// ---------------------------------------------------------------------------
+// Prompt template loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the orchestrator prompt template from disk.
+ *
+ * Resolves the path relative to this file so it works in both dev and built
+ * (tsup) environments. The `prompts/` directory is a sibling of this file.
+ */
+function loadPromptTemplate(): string {
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  const filePath = path.join(dir, 'prompts', ORCHESTRATOR_PROMPT_FILE);
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compose the orchestrator prompt by substituting runtime data into the
+ * template.
+ *
+ * @param vaultState     - Free-form summary of current vault state.
+ * @param phases         - Phase definitions available for this task.
+ * @param contextResults - Results from pre-execution context queries.
+ * @returns The fully composed prompt string.
+ */
+export function composeOrchestratorPrompt(
+  vaultState: string,
+  phases: PhaseDefinition[],
+  contextResults: ContextQueryResult[],
+): string {
+  const template = loadPromptTemplate();
+
+  const phaseList = formatPhaseList(phases);
+  const contextSection = formatContextResults(contextResults);
+
+  return template
+    .replace(PLACEHOLDER_VAULT_STATE, vaultState)
+    .replace(PLACEHOLDER_PHASE_DEFINITIONS, phaseList)
+    .replace(PLACEHOLDER_CONTEXT_RESULTS, contextSection);
+}
+
+/**
+ * Parse the orchestrator's LLM response into a structured plan.
+ *
+ * Accepts JSON that is either raw or wrapped in a ```json code block.
+ * Validates that the parsed value has a `phases` array.
+ *
+ * On any failure — malformed JSON, missing array, empty input — returns a
+ * safe fallback plan that runs all phases with no modifications.
+ *
+ * Never throws.
+ *
+ * @param response - Raw LLM response text.
+ * @param phases   - Phase definitions; used to construct the fallback plan.
+ * @returns A valid OrchestratorPlan.
+ */
+export function parseOrchestratorPlan(
+  response: string,
+  phases: PhaseDefinition[],
+): OrchestratorPlan {
+  const trimmed = response.trim();
+
+  if (!trimmed) {
+    return buildRunAllPlan(phases, FALLBACK_REASONING_PARSE_ERROR);
+  }
+
+  try {
+    const json = extractJson(trimmed);
+    const parsed = JSON.parse(json) as unknown;
+
+    if (!isOrchestratorPlanShape(parsed)) {
+      return buildRunAllPlan(phases, FALLBACK_REASONING_MISSING_PHASES);
+    }
+
+    return parsed;
+  } catch {
+    return buildRunAllPlan(phases, FALLBACK_REASONING_PARSE_ERROR);
+  }
+}
+
+/**
+ * Apply orchestrator directives to a set of phase definitions.
+ *
+ * For each phase:
+ * - If the directive says `skip: true` and the phase is not required, it is
+ *   excluded from the result.
+ * - If the directive says `skip: true` but the phase IS required, it is kept
+ *   and a warning is logged.
+ * - If the directive provides `maxTurns`, the phase's turn limit is overridden.
+ * - If the directive provides `contextNotes`, they are appended to the phase
+ *   prompt under `## Orchestrator Guidance`.
+ *
+ * Phase order is preserved. Phases with no matching directive pass through
+ * unchanged.
+ *
+ * @param phases     - Original phase definitions.
+ * @param directives - Directives from the orchestrator's plan.
+ * @returns Modified phase definitions.
+ */
+export function applyDirectives(
+  phases: PhaseDefinition[],
+  directives: OrchestratorPhaseDirective[],
+): PhaseDefinition[] {
+  const directiveMap = new Map<string, OrchestratorPhaseDirective>(
+    directives.map((d) => [d.name, d]),
+  );
+
+  const result: PhaseDefinition[] = [];
+
+  for (const phase of phases) {
+    const directive = directiveMap.get(phase.name);
+
+    if (!directive) {
+      result.push(phase);
+      continue;
+    }
+
+    if (directive.skip) {
+      if (phase.required) {
+        console.warn(
+          `[orchestrator] Cannot skip required phase "${phase.name}" — keeping it. Reason: ${directive.skipReason ?? 'none given'}`,
+        );
+        result.push(applyNonSkipDirective(phase, directive));
+      }
+      // Non-required phases with skip: true are simply excluded.
+      continue;
+    }
+
+    result.push(applyNonSkipDirective(phase, directive));
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply non-skip directive fields (maxTurns, contextNotes) to a phase.
+ */
+function applyNonSkipDirective(
+  phase: PhaseDefinition,
+  directive: OrchestratorPhaseDirective,
+): PhaseDefinition {
+  let updated = { ...phase };
+
+  if (directive.maxTurns !== undefined) {
+    updated = { ...updated, maxTurns: directive.maxTurns };
+  }
+
+  if (directive.contextNotes) {
+    updated = {
+      ...updated,
+      prompt: `${updated.prompt}\n\n${ORCHESTRATOR_GUIDANCE_HEADER}\n\n${directive.contextNotes}`,
+    };
+  }
+
+  return updated;
+}
+
+/**
+ * Format phases as a bulleted list for the prompt template.
+ */
+function formatPhaseList(phases: PhaseDefinition[]): string {
+  if (phases.length === 0) {
+    return '(no phases defined)';
+  }
+
+  return phases
+    .map((p) => {
+      const preview = p.prompt.slice(0, PHASE_PROMPT_PREVIEW_CHARS);
+      const ellipsis = p.prompt.length > PHASE_PROMPT_PREVIEW_CHARS ? '...' : '';
+      return `- **${p.name}** (maxTurns: ${p.maxTurns}, required: ${p.required}): ${preview}${ellipsis}`;
+    })
+    .join('\n');
+}
+
+/**
+ * Format context query results as sections for the prompt template.
+ */
+function formatContextResults(results: ContextQueryResult[]): string {
+  if (results.length === 0) {
+    return NO_CONTEXT_QUERIES_TEXT;
+  }
+
+  return results
+    .map((r) => {
+      const dataSection = r.error
+        ? `Error: ${r.error}`
+        : JSON.stringify(r.data, null, 2);
+      return `### ${r.tool}\nPurpose: ${r.purpose}\n\n${dataSection}`;
+    })
+    .join('\n\n');
+}
+
+/**
+ * Extract JSON from a string that may be wrapped in a ```json code block.
+ */
+function extractJson(text: string): string {
+  const codeBlockMatch = text.match(/```json\s*([\s\S]*?)```/);
+  if (codeBlockMatch) {
+    return codeBlockMatch[1].trim();
+  }
+  return text;
+}
+
+/**
+ * Type guard: check that a parsed value has the OrchestratorPlan shape.
+ */
+function isOrchestratorPlanShape(value: unknown): value is OrchestratorPlan {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return Array.isArray(obj['phases']);
+}
+
+/**
+ * Build a fallback "run everything" plan from the available phases.
+ */
+function buildRunAllPlan(phases: PhaseDefinition[], reasoning: string): OrchestratorPlan {
+  return {
+    phases: phases.map((p) => ({ name: p.name, skip: false })),
+    reasoning,
+  };
+}

--- a/src/agent/orchestrator.ts
+++ b/src/agent/orchestrator.ts
@@ -11,6 +11,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractJson } from '@myco/intelligence/response.js';
 import type { PhaseDefinition, OrchestratorPlan, OrchestratorPhaseDirective } from './types.js';
 import type { ContextQueryResult } from './context-queries.js';
 
@@ -57,10 +58,16 @@ const PLACEHOLDER_CONTEXT_RESULTS = '{{context_results}}';
  * Resolves the path relative to this file so it works in both dev and built
  * (tsup) environments. The `prompts/` directory is a sibling of this file.
  */
+/** Cached prompt template — loaded once, reused across calls. */
+let cachedPromptTemplate: string | undefined;
+
 function loadPromptTemplate(): string {
-  const dir = path.dirname(fileURLToPath(import.meta.url));
-  const filePath = path.join(dir, 'prompts', ORCHESTRATOR_PROMPT_FILE);
-  return fs.readFileSync(filePath, 'utf-8');
+  if (!cachedPromptTemplate) {
+    const dir = path.dirname(fileURLToPath(import.meta.url));
+    const filePath = path.join(dir, 'prompts', ORCHESTRATOR_PROMPT_FILE);
+    cachedPromptTemplate = fs.readFileSync(filePath, 'utf-8');
+  }
+  return cachedPromptTemplate;
 }
 
 // ---------------------------------------------------------------------------
@@ -118,8 +125,7 @@ export function parseOrchestratorPlan(
   }
 
   try {
-    const json = extractJson(trimmed);
-    const parsed = JSON.parse(json) as unknown;
+    const parsed = extractJson(trimmed);
 
     if (!isOrchestratorPlanShape(parsed)) {
       return buildRunAllPlan(phases, FALLBACK_REASONING_MISSING_PHASES);
@@ -245,17 +251,6 @@ function formatContextResults(results: ContextQueryResult[]): string {
       return `### ${r.tool}\nPurpose: ${r.purpose}\n\n${dataSection}`;
     })
     .join('\n\n');
-}
-
-/**
- * Extract JSON from a string that may be wrapped in a ```json code block.
- */
-function extractJson(text: string): string {
-  const codeBlockMatch = text.match(/```json\s*([\s\S]*?)```/);
-  if (codeBlockMatch) {
-    return codeBlockMatch[1].trim();
-  }
-  return text;
 }
 
 /**

--- a/src/agent/prompts/orchestrator.md
+++ b/src/agent/prompts/orchestrator.md
@@ -1,0 +1,84 @@
+# Orchestrator
+
+You are the Myco orchestrator. Your job is to analyze the current vault state and produce a precise execution plan for the intelligence pipeline phases.
+
+You do not execute any phases yourself. You reason about what needs to happen and output a structured JSON plan. Worker agents will execute each phase using your directives.
+
+## Vault State
+
+{{vault_state}}
+
+## Phase Definitions
+
+The following phases are available for this task:
+
+{{phase_definitions}}
+
+## Context Query Results
+
+Pre-execution vault queries returned the following:
+
+{{context_results}}
+
+## Your Task
+
+Analyze the vault state and context results, then produce a JSON plan that directs phase execution.
+
+For each phase, decide:
+- **skip**: Should this phase be skipped? (e.g., skip `extract` if there are no unprocessed batches)
+- **skipReason**: If skipping, why? (e.g., "No unprocessed batches found")
+- **maxTurns**: Override the default turn limit if needed (e.g., increase for large batch sets)
+- **contextNotes**: What context should the worker know going into this phase? (e.g., "12 unprocessed batches since batch_id 847", "3 active spores from last session need consolidation review")
+
+## Output Format
+
+Respond with a single JSON object — no prose, no markdown fences, no explanation outside the JSON:
+
+```json
+{
+  "phases": [
+    {
+      "name": "extract",
+      "skip": false,
+      "maxTurns": 20,
+      "contextNotes": "14 unprocessed batches since batch_id 831. Focus on spore extraction; do not run consolidation."
+    },
+    {
+      "name": "consolidate",
+      "skip": false,
+      "contextNotes": "After extraction, search for clusters among newly created spores and existing active spores."
+    },
+    {
+      "name": "graph",
+      "skip": false,
+      "contextNotes": "Focus on components referenced across multiple spores. Current entity count: 8."
+    },
+    {
+      "name": "digest",
+      "skip": false,
+      "contextNotes": "Regenerate all tiers. Last digest was 3 days ago; significant new spores added."
+    }
+  ],
+  "reasoning": "14 unprocessed batches warrant a full pipeline run. Extraction turn limit increased to 20 to handle batch volume. All phases enabled."
+}
+```
+
+## Skipping Rules
+
+- Skip `extract` only when there are zero unprocessed batches.
+- Skip `consolidate` only when fewer than 3 active spores exist across all sessions.
+- Skip `graph` only when no new spores were created in the extract phase AND entity count has not changed since last run.
+- Skip `digest` only when no new spores or entities were created and the existing digest is recent (within 24 hours).
+- Never skip required phases unless you have explicit evidence the work is unnecessary.
+
+## Context Notes Guidelines
+
+Context notes are injected into the worker's prompt. Be specific and actionable:
+- Include counts: "12 unprocessed batches", "5 active spores of type gotcha"
+- Include IDs when relevant: "start from batch_id 831"
+- Include scope constraints: "focus on sessions from the last 48 hours"
+- Avoid vague instructions — the worker follows your notes literally
+
+## Reasoning Field
+
+The `reasoning` field is a single sentence summarizing your overall plan decision. It appears in the run audit trail.

--- a/src/agent/provider.ts
+++ b/src/agent/provider.ts
@@ -1,0 +1,76 @@
+import type { ProviderConfig } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Named constants — env var names and default values
+// ---------------------------------------------------------------------------
+
+const ENV_ANTHROPIC_BASE_URL = 'ANTHROPIC_BASE_URL';
+const ENV_ANTHROPIC_AUTH_TOKEN = 'ANTHROPIC_AUTH_TOKEN';
+const ENV_ANTHROPIC_API_KEY = 'ANTHROPIC_API_KEY';
+const DEFAULT_OLLAMA_URL = 'http://localhost:11434';
+const DEFAULT_LMSTUDIO_URL = 'http://localhost:1234';
+const OLLAMA_AUTH_TOKEN = 'ollama';
+const LMSTUDIO_AUTH_TOKEN = 'lmstudio';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SavedEnv {
+  vars: Record<string, string | undefined>;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply provider env vars for a query() call.
+ * Returns saved state for restoration.
+ */
+export function applyProviderEnv(provider: ProviderConfig): SavedEnv {
+  const saved: Record<string, string | undefined> = {};
+  const envVars = getProviderEnvVars(provider);
+  for (const [key, value] of Object.entries(envVars)) {
+    saved[key] = process.env[key];
+    process.env[key] = value;
+  }
+  return { vars: saved };
+}
+
+/**
+ * Restore env vars after a query() call.
+ */
+export function restoreProviderEnv(saved: SavedEnv): void {
+  for (const [key, value] of Object.entries(saved.vars)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+/**
+ * Get env vars for a provider config.
+ */
+export function getProviderEnvVars(provider: ProviderConfig): Record<string, string> {
+  switch (provider.type) {
+    case 'cloud':
+      return {};
+    case 'ollama':
+      return {
+        [ENV_ANTHROPIC_BASE_URL]: provider.baseUrl ?? DEFAULT_OLLAMA_URL,
+        [ENV_ANTHROPIC_AUTH_TOKEN]: OLLAMA_AUTH_TOKEN,
+        [ENV_ANTHROPIC_API_KEY]: '',
+      };
+    case 'lmstudio':
+      return {
+        [ENV_ANTHROPIC_BASE_URL]: provider.baseUrl ?? DEFAULT_LMSTUDIO_URL,
+        [ENV_ANTHROPIC_AUTH_TOKEN]: provider.apiKey ?? LMSTUDIO_AUTH_TOKEN,
+        [ENV_ANTHROPIC_API_KEY]: '',
+      };
+    default:
+      return {};
+  }
+}

--- a/src/agent/registry.ts
+++ b/src/agent/registry.ts
@@ -12,7 +12,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { USER_TASKS_DIR, USER_TASK_SOURCE, BUILT_IN_SOURCE, TASK_NAME_PATTERN, MAX_TASK_NAME_LENGTH } from '@myco/constants.js';
-import { loadAgentTasks } from './loader.js';
+import { loadAgentTasks, taskFromParsed } from './loader.js';
 import { AgentTaskSchema } from './schemas.js';
 import type { AgentTask } from './types.js';
 
@@ -62,20 +62,7 @@ export function loadAllTasks(definitionsDir: string, vaultDir?: string): Map<str
           const raw = fs.readFileSync(filePath, 'utf-8');
           const parsed = AgentTaskSchema.parse(parseYaml(raw));
           const task: AgentTask = {
-            name: parsed.name,
-            displayName: parsed.displayName,
-            description: parsed.description.trim(),
-            agent: parsed.agent,
-            prompt: parsed.prompt.trim(),
-            isDefault: parsed.isDefault,
-            ...(parsed.toolOverrides ? { toolOverrides: parsed.toolOverrides } : {}),
-            ...(parsed.model ? { model: parsed.model } : {}),
-            ...(parsed.maxTurns ? { maxTurns: parsed.maxTurns } : {}),
-            ...(parsed.timeoutSeconds ? { timeoutSeconds: parsed.timeoutSeconds } : {}),
-            ...(parsed.phases ? { phases: parsed.phases } : {}),
-            ...(parsed.execution ? { execution: parsed.execution } : {}),
-            ...(parsed.contextQueries ? { contextQueries: parsed.contextQueries } : {}),
-            ...(parsed.schemaVersion ? { schemaVersion: parsed.schemaVersion } : {}),
+            ...taskFromParsed(parsed),
             isBuiltin: false,
             source: USER_TASK_SOURCE,
           };

--- a/src/agent/registry.ts
+++ b/src/agent/registry.ts
@@ -1,0 +1,193 @@
+/**
+ * User task registry.
+ *
+ * Loads built-in tasks from the definitions directory and user-created tasks
+ * from the vault's tasks/ subdirectory. User tasks with the same name as a
+ * built-in task override the built-in.
+ *
+ * No module-level cache — always reads from disk.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import { USER_TASKS_DIR, USER_TASK_SOURCE, TASK_NAME_PATTERN, MAX_TASK_NAME_LENGTH } from '@myco/constants.js';
+import { loadAgentTasks } from './loader.js';
+import { AgentTaskSchema } from './schemas.js';
+import type { AgentTask } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Source label applied to tasks loaded from the definitions directory. */
+const BUILT_IN_SOURCE = 'built-in';
+
+/** Suffix appended to the task name when copying a built-in task for the user. */
+const COPY_SUFFIX = '-custom';
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Load all tasks: built-in definitions merged with user-created overrides.
+ *
+ * Built-in tasks are loaded from `definitionsDir/tasks/*.yaml`.
+ * User tasks are loaded from `vaultDir/tasks/*.yaml`.
+ * A user task with the same name as a built-in task replaces it entirely.
+ *
+ * Always reads from disk — no caching.
+ *
+ * @param definitionsDir — path to `src/agent/definitions/` (or dist equivalent).
+ * @param vaultDir — optional vault directory; user tasks skipped if not provided.
+ * @returns map from task name → AgentTask.
+ */
+export function loadAllTasks(definitionsDir: string, vaultDir?: string): Map<string, AgentTask> {
+  const result = new Map<string, AgentTask>();
+
+  // Load built-in tasks first
+  const builtIn = loadAgentTasks(definitionsDir);
+  for (const task of builtIn) {
+    result.set(task.name, { ...task, isBuiltin: true, source: BUILT_IN_SOURCE });
+  }
+
+  // Overlay user tasks (override built-in if same name)
+  if (vaultDir) {
+    const userTasksDir = path.join(vaultDir, USER_TASKS_DIR);
+    if (fs.existsSync(userTasksDir)) {
+      const files = fs.readdirSync(userTasksDir).filter((f) => f.endsWith('.yaml'));
+      for (const file of files) {
+        const filePath = path.join(userTasksDir, file);
+        try {
+          const raw = fs.readFileSync(filePath, 'utf-8');
+          const parsed = AgentTaskSchema.parse(parseYaml(raw));
+          const task: AgentTask = {
+            name: parsed.name,
+            displayName: parsed.displayName,
+            description: parsed.description.trim(),
+            agent: parsed.agent,
+            prompt: parsed.prompt.trim(),
+            isDefault: parsed.isDefault,
+            ...(parsed.toolOverrides ? { toolOverrides: parsed.toolOverrides } : {}),
+            ...(parsed.model ? { model: parsed.model } : {}),
+            ...(parsed.maxTurns ? { maxTurns: parsed.maxTurns } : {}),
+            ...(parsed.timeoutSeconds ? { timeoutSeconds: parsed.timeoutSeconds } : {}),
+            ...(parsed.phases ? { phases: parsed.phases } : {}),
+            ...(parsed.execution ? { execution: parsed.execution } : {}),
+            ...(parsed.contextQueries ? { contextQueries: parsed.contextQueries } : {}),
+            ...(parsed.schemaVersion ? { schemaVersion: parsed.schemaVersion } : {}),
+            isBuiltin: false,
+            source: USER_TASK_SOURCE,
+          };
+          result.set(task.name, task);
+        } catch (err) {
+          console.warn(`[registry] Skipping malformed user task file: ${filePath}`, err);
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Validate a task name against the allowed pattern and length limit.
+ *
+ * Valid names: lowercase letters, digits, and hyphens. Must start and end
+ * with a letter or digit. Single character names (a–z, 0–9) are allowed.
+ *
+ * @param name — candidate task name.
+ * @returns true if valid.
+ */
+export function validateTaskName(name: string): boolean {
+  if (name.length > MAX_TASK_NAME_LENGTH) return false;
+  return TASK_NAME_PATTERN.test(name);
+}
+
+/**
+ * Serialize an AgentTask to YAML and write it to `vaultDir/tasks/<name>.yaml`.
+ *
+ * Validates the task through AgentTaskSchema before writing.
+ * Creates the tasks directory if it does not exist (idempotent).
+ * Strips the internal `source` and `isBuiltin` fields from the serialized output.
+ *
+ * @param vaultDir — path to the vault root directory.
+ * @param task — task to write.
+ * @returns absolute path to the written file.
+ * @throws if schema validation fails.
+ */
+export function writeUserTask(vaultDir: string, task: AgentTask): string {
+  // Validate before touching the filesystem
+  AgentTaskSchema.parse(task);
+
+  const tasksDir = path.join(vaultDir, USER_TASKS_DIR);
+  fs.mkdirSync(tasksDir, { recursive: true });
+
+  // Strip internal-only fields before serializing
+  const { isBuiltin: _isBuiltin, source: _source, ...serializable } = task;
+  const yaml = stringifyYaml(serializable);
+
+  const filePath = path.join(tasksDir, `${task.name}.yaml`);
+  fs.writeFileSync(filePath, yaml, 'utf-8');
+  return filePath;
+}
+
+/**
+ * Delete a user task YAML file from `vaultDir/tasks/<taskName>.yaml`.
+ *
+ * @param vaultDir — path to the vault root directory.
+ * @param taskName — name of the task to delete.
+ * @returns true if the file existed and was removed, false if it did not exist.
+ */
+export function deleteUserTask(vaultDir: string, taskName: string): boolean {
+  const filePath = path.join(vaultDir, USER_TASKS_DIR, `${taskName}.yaml`);
+  if (!fs.existsSync(filePath)) return false;
+  fs.rmSync(filePath);
+  return true;
+}
+
+/**
+ * Create a user copy of an existing task.
+ *
+ * Loads all tasks (built-in + user), locates `sourceName`, then writes a new
+ * user task with the given name (or `sourceName + COPY_SUFFIX` if omitted),
+ * `isDefault: false`, `isBuiltin: false`, and `source: 'user'`.
+ *
+ * @param definitionsDir — path to built-in definitions directory.
+ * @param vaultDir — path to vault root directory.
+ * @param sourceName — name of the task to copy.
+ * @param newName — optional name for the copy; defaults to `sourceName + '-custom'`.
+ * @returns the newly written AgentTask.
+ * @throws if the source task is not found.
+ * @throws if the new name is invalid.
+ */
+export function copyTaskToUser(
+  definitionsDir: string,
+  vaultDir: string,
+  sourceName: string,
+  newName?: string,
+): AgentTask {
+  const allTasks = loadAllTasks(definitionsDir, vaultDir);
+
+  const source = allTasks.get(sourceName);
+  if (!source) {
+    throw new Error(`Task not found: ${sourceName}`);
+  }
+
+  const targetName = newName ?? `${sourceName}${COPY_SUFFIX}`;
+  if (!validateTaskName(targetName)) {
+    throw new Error(`Invalid task name: ${targetName}`);
+  }
+
+  const copy: AgentTask = {
+    ...source,
+    name: targetName,
+    isDefault: false,
+    isBuiltin: false,
+    source: USER_TASK_SOURCE,
+  };
+
+  writeUserTask(vaultDir, copy);
+  return copy;
+}

--- a/src/agent/registry.ts
+++ b/src/agent/registry.ts
@@ -11,7 +11,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
-import { USER_TASKS_DIR, USER_TASK_SOURCE, TASK_NAME_PATTERN, MAX_TASK_NAME_LENGTH } from '@myco/constants.js';
+import { USER_TASKS_DIR, USER_TASK_SOURCE, BUILT_IN_SOURCE, TASK_NAME_PATTERN, MAX_TASK_NAME_LENGTH } from '@myco/constants.js';
 import { loadAgentTasks } from './loader.js';
 import { AgentTaskSchema } from './schemas.js';
 import type { AgentTask } from './types.js';
@@ -20,8 +20,7 @@ import type { AgentTask } from './types.js';
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Source label applied to tasks loaded from the definitions directory. */
-const BUILT_IN_SOURCE = 'built-in';
+// BUILT_IN_SOURCE imported from @myco/constants.js
 
 /** Suffix appended to the task name when copying a built-in task for the user. */
 const COPY_SUFFIX = '-custom';

--- a/src/agent/schemas.ts
+++ b/src/agent/schemas.ts
@@ -1,0 +1,92 @@
+/**
+ * Zod schemas for agent definition and task YAML validation.
+ *
+ * These schemas are shared between the loader (which validates YAML files)
+ * and any other code that needs to parse or validate task/agent config.
+ */
+
+import { z } from 'zod/v4';
+
+// ---------------------------------------------------------------------------
+// Schema version
+// ---------------------------------------------------------------------------
+
+/** Current schema version for task config structures. */
+export const CURRENT_TASK_SCHEMA_VERSION = 1;
+
+// ---------------------------------------------------------------------------
+// Shared sub-schemas
+// ---------------------------------------------------------------------------
+
+/** Schema for API provider configuration. */
+export const ProviderConfigSchema = z.object({
+  type: z.enum(['cloud', 'ollama', 'lmstudio']),
+  baseUrl: z.string().optional(),
+  apiKey: z.string().optional(),
+  model: z.string().optional(),
+});
+
+/** Schema for execution configuration overrides. */
+export const ExecutionConfigSchema = z.object({
+  model: z.string().optional(),
+  maxTurns: z.number().optional(),
+  timeoutSeconds: z.number().optional(),
+  provider: ProviderConfigSchema.optional(),
+});
+
+/** Schema for a single context query entry. */
+export const ContextQuerySchema = z.object({
+  tool: z.string(),
+  queryTemplate: z.string(),
+  limit: z.number(),
+  purpose: z.string(),
+  required: z.boolean(),
+});
+
+// ---------------------------------------------------------------------------
+// Agent definition schema
+// ---------------------------------------------------------------------------
+
+/** Schema for agent.yaml agent definition files. */
+export const AgentDefinitionSchema = z.object({
+  name: z.string(),
+  displayName: z.string(),
+  description: z.string(),
+  model: z.string(),
+  maxTurns: z.number(),
+  timeoutSeconds: z.number(),
+  systemPromptPath: z.string(),
+  tools: z.array(z.string()),
+});
+
+// ---------------------------------------------------------------------------
+// Task schemas
+// ---------------------------------------------------------------------------
+
+/** Schema for a single phase within a phased task pipeline. */
+export const PhaseDefinitionSchema = z.object({
+  name: z.string(),
+  prompt: z.string(),
+  tools: z.array(z.string()),
+  maxTurns: z.number(),
+  model: z.string().optional(),
+  required: z.boolean(),
+});
+
+/** Schema for task YAML files in tasks/. */
+export const AgentTaskSchema = z.object({
+  name: z.string(),
+  displayName: z.string(),
+  description: z.string(),
+  agent: z.string(),
+  prompt: z.string(),
+  isDefault: z.boolean(),
+  toolOverrides: z.array(z.string()).optional(),
+  model: z.string().optional(),
+  maxTurns: z.number().optional(),
+  timeoutSeconds: z.number().optional(),
+  phases: z.array(PhaseDefinitionSchema).optional(),
+  execution: ExecutionConfigSchema.optional(),
+  contextQueries: z.record(z.string(), z.array(ContextQuerySchema)).optional(),
+  schemaVersion: z.number().optional(),
+});

--- a/src/agent/schemas.ts
+++ b/src/agent/schemas.ts
@@ -63,6 +63,13 @@ export const AgentDefinitionSchema = z.object({
 // Task schemas
 // ---------------------------------------------------------------------------
 
+/** Schema for orchestrator configuration on a task definition. */
+export const OrchestratorConfigSchema = z.object({
+  enabled: z.boolean(),
+  model: z.string().optional(),
+  maxTurns: z.number().optional(),
+});
+
 /** Schema for a single phase within a phased task pipeline. */
 export const PhaseDefinitionSchema = z.object({
   name: z.string(),
@@ -89,4 +96,5 @@ export const AgentTaskSchema = z.object({
   execution: ExecutionConfigSchema.optional(),
   contextQueries: z.record(z.string(), z.array(ContextQuerySchema)).optional(),
   schemaVersion: z.number().optional(),
+  orchestrator: OrchestratorConfigSchema.optional(),
 });

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -1,9 +1,9 @@
 /**
  * Vault MCP tool server for the agent.
  *
- * Creates 14 tools that expose PGlite query helpers to the agent
+ * Creates 15 tools that expose PGlite query helpers to the agent
  * via the Claude Agent SDK. Tools are grouped into:
- * - Read tools: vault_unprocessed, vault_spores, vault_sessions, vault_search, vault_state
+ * - Read tools: vault_unprocessed, vault_spores, vault_sessions, vault_search, vault_state, vault_read_digest
  * - Write tools: vault_create_spore, vault_create_entity, vault_create_edge,
  *                vault_resolve_spore, vault_update_session, vault_set_state,
  *                vault_write_digest, vault_mark_processed
@@ -67,7 +67,7 @@ function textResult(data: unknown): { content: Array<{ type: 'text'; text: strin
 export const VAULT_TOOL_COUNT = 15;
 
 /**
- * Create the 14 vault tool definitions for the agent.
+ * Create the 15 vault tool definitions for the agent.
  *
  * Exposed for testing (call handler directly) and for the MCP server factory.
  *
@@ -505,7 +505,7 @@ export function createVaultTools(agentId: string, runId: string, turnOffset = 0)
 // ---------------------------------------------------------------------------
 
 /**
- * Create a vault MCP tool server with 14 tools for the agent.
+ * Create a vault MCP tool server with 15 tools for the agent.
  *
  * Wraps `createVaultTools()` with `createSdkMcpServer()` from the
  * Claude Agent SDK.

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -29,7 +29,7 @@ import { insertEntity } from '@myco/db/queries/entities.js';
 import { insertGraphEdge } from '@myco/db/queries/graph-edges.js';
 import { createSporeLineage } from '@myco/db/queries/lineage.js';
 import { insertResolutionEvent } from '@myco/db/queries/resolution-events.js';
-import { upsertDigestExtract } from '@myco/db/queries/digest-extracts.js';
+import { upsertDigestExtract, listDigestExtracts } from '@myco/db/queries/digest-extracts.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -64,7 +64,7 @@ function textResult(data: unknown): { content: Array<{ type: 'text'; text: strin
 // ---------------------------------------------------------------------------
 
 /** Total number of vault tools defined. */
-export const VAULT_TOOL_COUNT = 14;
+export const VAULT_TOOL_COUNT = 15;
 
 /**
  * Create the 14 vault tool definitions for the agent.
@@ -387,6 +387,31 @@ export function createVaultTools(agentId: string, runId: string, turnOffset = 0)
     },
   );
 
+  const vaultReadDigest = tool(
+    'vault_read_digest',
+    'Read current digest extracts. Without a tier parameter, returns a summary of all tiers (content length, generation time). With a tier parameter, returns the full content for that specific tier.',
+    {
+      tier: z.number().optional().describe('Specific tier to read in full (e.g., 1500, 3000). Omit to get summary of all tiers.'),
+    },
+    async (args) => {
+      recordTurn('vault_read_digest', args);
+      const extracts = await listDigestExtracts(agentId);
+
+      if (args.tier !== undefined) {
+        const extract = extracts.find(e => e.tier === args.tier);
+        if (!extract) return textResult({ tier: args.tier, content: null, message: 'No digest at this tier' });
+        return textResult({ tier: extract.tier, content: extract.content, generated_at: extract.generated_at });
+      }
+
+      // Summary mode — return metadata for all tiers
+      return textResult(extracts.map(e => ({
+        tier: e.tier,
+        content_length: e.content.length,
+        generated_at: e.generated_at,
+      })));
+    },
+  );
+
   const vaultWriteDigest = tool(
     'vault_write_digest',
     'Write or update a digest extract at a specific token tier. Uses UPSERT on (agent_id, tier).',
@@ -468,6 +493,7 @@ export function createVaultTools(agentId: string, runId: string, turnOffset = 0)
     vaultResolveSpore,
     vaultUpdateSession,
     vaultSetState,
+    vaultReadDigest,
     vaultWriteDigest,
     vaultMarkProcessed,
     vaultReport,

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -159,10 +159,11 @@ export function createVaultTools(agentId: string, runId: string, turnOffset = 0)
 
   const vaultSearch = tool(
     'vault_search',
-    'Semantic similarity search across vault content. Returns ranked results by cosine similarity. If no embeddings are available, returns an empty result set — use vault_spores or vault_sessions as a fallback.',
+    'Semantic similarity search across vault content. Returns ranked results by cosine similarity. Supports filtering by session_id (for spores table) to scope results. If no embeddings are available, returns an empty result set — use vault_spores or vault_sessions as a fallback.',
     {
       query: z.string().describe('Search query text to embed and compare'),
-      table: z.enum(EMBEDDABLE_TABLES).optional().describe('Table to search'),
+      table: z.enum(EMBEDDABLE_TABLES).optional().describe('Table to search (default: spores)'),
+      session_id: z.string().optional().describe('Filter results to a specific session (spores table only)'),
       limit: z.number().optional().describe('Maximum number of results to return'),
     },
     async (args) => {
@@ -175,8 +176,12 @@ export function createVaultTools(agentId: string, runId: string, turnOffset = 0)
         }
 
         const table = args.table ?? DEFAULT_SEARCH_TABLE;
+        const filters: Record<string, unknown> = {};
+        if (args.session_id) filters.session_id = args.session_id;
+
         const results = await searchSimilar(table, embedding, {
           limit: args.limit ?? DEFAULT_SEARCH_LIMIT,
+          filters: Object.keys(filters).length > 0 ? filters : undefined,
         });
         return textResult({ results });
       } catch {

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -27,7 +27,7 @@ import { insertTurn } from '@myco/db/queries/turns.js';
 import { searchSimilar, EMBEDDABLE_TABLES, type EmbeddableTable } from '@myco/db/queries/embeddings.js';
 import { insertEntity } from '@myco/db/queries/entities.js';
 import { insertGraphEdge } from '@myco/db/queries/graph-edges.js';
-import { createSporeLineage, autoLinkSporeToEntities, autoLinkEntityToSpores } from '@myco/db/queries/lineage.js';
+import { createSporeLineage } from '@myco/db/queries/lineage.js';
 import { insertResolutionEvent } from '@myco/db/queries/resolution-events.js';
 import { upsertDigestExtract } from '@myco/db/queries/digest-extracts.js';
 
@@ -233,9 +233,8 @@ export function createVaultTools(agentId: string, runId: string, turnOffset = 0)
         created_at: now,
       });
 
-      // Fire-and-forget: lineage edges + entity auto-linking
+      // Fire-and-forget: structural lineage edges (FROM_SESSION, EXTRACTED_FROM, DERIVED_FROM)
       try { await createSporeLineage(spore); } catch { /* lineage best-effort */ }
-      try { await autoLinkSporeToEntities({ ...spore, content: args.content }); } catch { /* auto-link best-effort */ }
 
       recordTurn('vault_create_spore', args);
       return textResult(spore);
@@ -264,9 +263,6 @@ export function createVaultTools(agentId: string, runId: string, turnOffset = 0)
         first_seen: now,
         last_seen: now,
       });
-
-      // Fire-and-forget: auto-link entity to existing spores that mention it
-      try { await autoLinkEntityToSpores({ id, agent_id: agentId, name: args.name, created_at: now }); } catch { /* auto-link best-effort */ }
 
       recordTurn('vault_create_entity', args);
       return textResult(entity);

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -27,7 +27,7 @@ import { insertTurn } from '@myco/db/queries/turns.js';
 import { searchSimilar, EMBEDDABLE_TABLES, type EmbeddableTable } from '@myco/db/queries/embeddings.js';
 import { insertEntity } from '@myco/db/queries/entities.js';
 import { insertGraphEdge } from '@myco/db/queries/graph-edges.js';
-import { createSporeLineage } from '@myco/db/queries/lineage.js';
+import { createSporeLineage, autoLinkSporeToEntities, autoLinkEntityToSpores } from '@myco/db/queries/lineage.js';
 import { insertResolutionEvent } from '@myco/db/queries/resolution-events.js';
 import { upsertDigestExtract } from '@myco/db/queries/digest-extracts.js';
 
@@ -233,8 +233,9 @@ export function createVaultTools(agentId: string, runId: string, turnOffset = 0)
         created_at: now,
       });
 
-      // Fire-and-forget lineage edges — failure should not break spore creation
+      // Fire-and-forget: lineage edges + entity auto-linking
       try { await createSporeLineage(spore); } catch { /* lineage best-effort */ }
+      try { await autoLinkSporeToEntities({ ...spore, content: args.content }); } catch { /* auto-link best-effort */ }
 
       recordTurn('vault_create_spore', args);
       return textResult(spore);
@@ -263,6 +264,9 @@ export function createVaultTools(agentId: string, runId: string, turnOffset = 0)
         first_seen: now,
         last_seen: now,
       });
+
+      // Fire-and-forget: auto-link entity to existing spores that mention it
+      try { await autoLinkEntityToSpores({ id, agent_id: agentId, name: args.name, created_at: now }); } catch { /* auto-link best-effort */ }
 
       recordTurn('vault_create_entity', args);
       return textResult(entity);

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -76,11 +76,12 @@ export const VAULT_TOOL_COUNT = 14;
  * @returns array of SdkMcpToolDefinition objects.
  */
 export function createVaultTools(agentId: string, runId: string, turnOffset = 0) {
-  /** Turn number counter — incremented per write tool call within a run. */
+  /** Turn number counter — incremented per tool call (read and write) within a run. */
   let turnCounter = turnOffset;
 
   /**
-   * Record a turn in the audit trail for write operations.
+   * Record a turn in the audit trail.
+   * Called for ALL tool invocations (read and write) for full visibility.
    * Fire-and-forget — does not block the tool response.
    */
   function recordTurn(toolName: string, toolInput: unknown): void {
@@ -109,6 +110,7 @@ export function createVaultTools(agentId: string, runId: string, turnOffset = 0)
       limit: z.number().optional().describe('Maximum number of batches to return'),
     },
     async (args) => {
+      recordTurn('vault_unprocessed', args);
       const batches = await getUnprocessedBatches({
         after_id: args.after_id,
         limit: args.limit ?? DEFAULT_UNPROCESSED_LIMIT,
@@ -127,6 +129,7 @@ export function createVaultTools(agentId: string, runId: string, turnOffset = 0)
       limit: z.number().optional().describe('Maximum number of spores to return'),
     },
     async (args) => {
+      recordTurn('vault_spores', args);
       const spores = await listSpores({
         agent_id: args.agent_id,
         observation_type: args.observation_type,
@@ -145,6 +148,7 @@ export function createVaultTools(agentId: string, runId: string, turnOffset = 0)
       status: z.string().optional().describe('Filter by status (active, completed)'),
     },
     async (args) => {
+      recordTurn('vault_sessions', args);
       const sessions = await listSessions({
         limit: args.limit ?? DEFAULT_SESSIONS_LIMIT,
         status: args.status,
@@ -162,6 +166,7 @@ export function createVaultTools(agentId: string, runId: string, turnOffset = 0)
       limit: z.number().optional().describe('Maximum number of results to return'),
     },
     async (args) => {
+      recordTurn('vault_search', args);
       try {
         const { tryEmbed } = await import('@myco/intelligence/embed-query.js');
         const embedding = await tryEmbed(args.query);
@@ -185,6 +190,7 @@ export function createVaultTools(agentId: string, runId: string, turnOffset = 0)
     'Get all state key-value pairs for the current agent.',
     {},
     async () => {
+      recordTurn('vault_state', {});
       const states = await getStatesForAgent(agentId);
       return textResult(states);
     },
@@ -425,6 +431,7 @@ export function createVaultTools(agentId: string, runId: string, turnOffset = 0)
       details: z.record(z.string(), z.unknown()).optional().describe('Structured details as key-value pairs'),
     },
     async (args) => {
+      recordTurn('vault_report', args);
       const now = epochSeconds();
 
       const report = await insertReport({

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -75,9 +75,9 @@ export const VAULT_TOOL_COUNT = 14;
  * @param runId — the current agent run ID, injected into reports and turns.
  * @returns array of SdkMcpToolDefinition objects.
  */
-export function createVaultTools(agentId: string, runId: string) {
+export function createVaultTools(agentId: string, runId: string, turnOffset = 0) {
   /** Turn number counter — incremented per write tool call within a run. */
-  let turnCounter = 0;
+  let turnCounter = turnOffset;
 
   /**
    * Record a turn in the audit trail for write operations.
@@ -501,8 +501,9 @@ export function createScopedVaultToolServer(
   agentId: string,
   runId: string,
   toolNames: string[],
+  turnOffset = 0,
 ) {
-  const allTools = createVaultTools(agentId, runId);
+  const allTools = createVaultTools(agentId, runId, turnOffset);
   const nameSet = new Set(toolNames);
   const scopedTools = allTools.filter((t) => nameSet.has(t.name));
 

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -485,3 +485,30 @@ export function createVaultToolServer(agentId: string, runId: string) {
     tools,
   });
 }
+
+/**
+ * Create a vault MCP tool server scoped to a subset of tools.
+ *
+ * Used by the phased executor to restrict each phase to only the tools
+ * it needs. Tools not in `toolNames` are excluded from the server.
+ *
+ * @param agentId — the agent identity, injected into all write operations.
+ * @param runId — the current agent run ID, injected into reports and turns.
+ * @param toolNames — tool names to include (e.g., ['vault_unprocessed', 'vault_create_spore']).
+ * @returns an MCP server config with only the specified tools.
+ */
+export function createScopedVaultToolServer(
+  agentId: string,
+  runId: string,
+  toolNames: string[],
+) {
+  const allTools = createVaultTools(agentId, runId);
+  const nameSet = new Set(toolNames);
+  const scopedTools = allTools.filter((t) => nameSet.has(t.name));
+
+  return createSdkMcpServer({
+    name: 'myco-vault',
+    version: getPluginVersion(),
+    tools: scopedTools,
+  });
+}

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -22,6 +22,31 @@ export interface AgentDefinition {
   tools: string[];
 }
 
+/**
+ * A single phase in a phased task pipeline.
+ *
+ * Phases run sequentially — the executor controls the loop, not the LLM.
+ * Each phase gets its own `query()` call with scoped tools and turn limit.
+ */
+export interface PhaseDefinition {
+  name: string;
+  prompt: string;
+  tools: string[];
+  maxTurns: number;
+  model?: string; // override model for this phase (falls back to task/agent model)
+  required: boolean;
+}
+
+/** Result of a single phase execution within a phased run. */
+export interface PhaseResult {
+  name: string;
+  status: 'completed' | 'failed' | 'skipped';
+  turnsUsed: number;
+  tokensUsed: number;
+  costUsd: number;
+  summary: string; // last assistant message or error
+}
+
 /** Shape of each task YAML file (e.g., `tasks/full-intelligence.yaml`). */
 export interface AgentTask {
   name: string;
@@ -34,6 +59,7 @@ export interface AgentTask {
   model?: string; // override model for this task
   maxTurns?: number; // override max turns for this task
   timeoutSeconds?: number; // override timeout for this task
+  phases?: PhaseDefinition[]; // phased execution pipeline (opt-in)
 }
 
 // ---------------------------------------------------------------------------
@@ -56,6 +82,7 @@ export interface EffectiveConfig {
   taskName: string;
   taskDisplayName: string;
   taskPrompt: string;
+  phases?: PhaseDefinition[];
 }
 
 /** Options passed to an agent run. */
@@ -73,4 +100,5 @@ export interface AgentRunResult {
   tokensUsed?: number;
   costUsd?: number;
   error?: string;
+  phases?: PhaseResult[];
 }

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -47,6 +47,42 @@ export interface PhaseResult {
   summary: string; // last assistant message or error
 }
 
+/** Context query that runs before task execution to gather vault state. */
+export interface ContextQuery {
+  tool: string;
+  queryTemplate: string;
+  limit: number;
+  purpose: string;
+  required: boolean;
+}
+
+/** API provider configuration for task execution. */
+export interface ProviderConfig {
+  type: 'cloud' | 'ollama' | 'lmstudio';
+  baseUrl?: string;
+  apiKey?: string;
+  model?: string;
+}
+
+/** Execution configuration overrides for a task. */
+export interface ExecutionConfig {
+  model?: string;
+  maxTurns?: number;
+  timeoutSeconds?: number;
+  provider?: ProviderConfig;
+}
+
+/**
+ * Extended config stored as JSON in the agent_tasks.config column.
+ * Structural data that doesn't fit in flat columns.
+ */
+export interface TaskConfig {
+  phases?: PhaseDefinition[];
+  execution?: ExecutionConfig;
+  contextQueries?: Record<string, ContextQuery[]>;
+  schemaVersion?: number;
+}
+
 /** Shape of each task YAML file (e.g., `tasks/full-intelligence.yaml`). */
 export interface AgentTask {
   name: string;
@@ -60,6 +96,11 @@ export interface AgentTask {
   maxTurns?: number; // override max turns for this task
   timeoutSeconds?: number; // override timeout for this task
   phases?: PhaseDefinition[]; // phased execution pipeline (opt-in)
+  execution?: ExecutionConfig; // extended execution config
+  contextQueries?: Record<string, ContextQuery[]>; // pre-execution vault queries
+  isBuiltin?: boolean; // true for tasks loaded from built-in YAML definitions
+  source?: string; // origin of the task (e.g., 'built-in', 'user')
+  schemaVersion?: number; // schema version for the task config
 }
 
 // ---------------------------------------------------------------------------

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -148,6 +148,8 @@ export interface EffectiveConfig {
   taskPrompt: string;
   phases?: PhaseDefinition[];
   orchestrator?: OrchestratorConfig;
+  contextQueries?: Record<string, ContextQuery[]>;
+  execution?: ExecutionConfig;
 }
 
 /** Options passed to an agent run. */

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -83,6 +83,28 @@ export interface TaskConfig {
   schemaVersion?: number;
 }
 
+/** Directive for a single phase from the orchestrator's plan. */
+export interface OrchestratorPhaseDirective {
+  name: string;
+  skip: boolean;
+  skipReason?: string;
+  maxTurns?: number;
+  contextNotes?: string;
+}
+
+/** The orchestrator's output — a plan for phase execution. */
+export interface OrchestratorPlan {
+  phases: OrchestratorPhaseDirective[];
+  reasoning: string;
+}
+
+/** Orchestrator configuration on a task definition. */
+export interface OrchestratorConfig {
+  enabled: boolean;
+  model?: string;
+  maxTurns?: number;
+}
+
 /** Shape of each task YAML file (e.g., `tasks/full-intelligence.yaml`). */
 export interface AgentTask {
   name: string;
@@ -101,6 +123,7 @@ export interface AgentTask {
   isBuiltin?: boolean; // true for tasks loaded from built-in YAML definitions
   source?: string; // origin of the task (e.g., 'built-in', 'user')
   schemaVersion?: number; // schema version for the task config
+  orchestrator?: OrchestratorConfig; // orchestrator configuration for phased tasks
 }
 
 // ---------------------------------------------------------------------------
@@ -124,6 +147,7 @@ export interface EffectiveConfig {
   taskDisplayName: string;
   taskPrompt: string;
   phases?: PhaseDefinition[];
+  orchestrator?: OrchestratorConfig;
 }
 
 /** Options passed to an agent run. */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ Commands:
   setup-llm [options]      Configure LLM and embedding providers
   setup-digest [options]   Configure digest and capture settings
   agent [options]          Run the intelligence agent
+  task <subcommand>        Manage agent task definitions
   restart                  Restart the daemon
   version                  Show plugin version
   mcp                     Start the MCP stdio server
@@ -77,6 +78,7 @@ async function main(): Promise<void> {
     case 'setup-llm': return (await import('./cli/setup-llm.js')).run(args, vaultDir);
     case 'setup-digest': return (await import('./cli/setup-digest.js')).run(args, vaultDir);
     case 'agent': return (await import('./cli/agent-run.js')).run(args, vaultDir);
+    case 'task': return (await import('./cli/agent-tasks.js')).run(args, vaultDir);
     case 'restart': return (await import('./cli/restart.js')).run(args, vaultDir);
     case 'logs': return (await import('./cli/logs.js')).run(args, vaultDir);
     default:

--- a/src/cli/agent-tasks.ts
+++ b/src/cli/agent-tasks.ts
@@ -1,0 +1,256 @@
+/**
+ * CLI `task` subcommands — manage agent task definitions via daemon API.
+ *
+ * Routes through the daemon HTTP API to avoid PGlite file lock conflicts.
+ *
+ * Subcommands:
+ *   task list [--source built-in|user]   List all tasks
+ *   task show <name>                     Show a single task with phases
+ *   task create <name> --from <template> Copy a template task to user dir
+ *   task delete <name>                   Delete a user task
+ *   task run <name> [--instruction TEXT] Run a task via the agent
+ */
+
+import { connectToDaemon } from './shared.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Column widths for the task list table. */
+const COL_NAME_WIDTH = 22;
+const COL_SOURCE_WIDTH = 10;
+const COL_PHASES_WIDTH = 7;
+
+/** Marker displayed in the Default column for the default task. */
+const DEFAULT_MARKER = '*';
+
+// ---------------------------------------------------------------------------
+// Types (local — mirrors the API response shape)
+// ---------------------------------------------------------------------------
+
+interface PhaseRow {
+  name: string;
+  maxTurns: number;
+  required: boolean;
+  model?: string;
+  tools: string[];
+}
+
+interface TaskRow {
+  name: string;
+  displayName: string;
+  description: string;
+  agent: string;
+  prompt: string;
+  isDefault: boolean;
+  source: string;
+  isBuiltin: boolean;
+  phases?: PhaseRow[];
+  model?: string;
+  maxTurns?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+function padRight(s: string, width: number): string {
+  return s.length >= width ? s : s + ' '.repeat(width - s.length);
+}
+
+function printTaskTable(tasks: TaskRow[]): void {
+  const header =
+    padRight('Name', COL_NAME_WIDTH) +
+    padRight('Source', COL_SOURCE_WIDTH) +
+    padRight('Phases', COL_PHASES_WIDTH) +
+    'Default';
+  console.log(header);
+  console.log('-'.repeat(header.length));
+
+  for (const t of tasks) {
+    const phaseCount = t.phases?.length ?? 0;
+    const row =
+      padRight(t.name, COL_NAME_WIDTH) +
+      padRight(t.source, COL_SOURCE_WIDTH) +
+      padRight(String(phaseCount), COL_PHASES_WIDTH) +
+      (t.isDefault ? DEFAULT_MARKER : '');
+    console.log(row);
+  }
+}
+
+function printTaskDetail(task: TaskRow): void {
+  console.log(`Name:        ${task.name}`);
+  console.log(`Display:     ${task.displayName}`);
+  console.log(`Description: ${task.description}`);
+  console.log(`Agent:       ${task.agent}`);
+  console.log(`Source:      ${task.source}`);
+  console.log(`Default:     ${task.isDefault ? 'yes' : 'no'}`);
+  if (task.model) console.log(`Model:       ${task.model}`);
+  if (task.maxTurns !== undefined) console.log(`Max turns:   ${task.maxTurns}`);
+  console.log(`Prompt:      ${task.prompt}`);
+
+  const phases = task.phases ?? [];
+  if (phases.length > 0) {
+    console.log(`\nPhases (${phases.length}):`);
+    for (let i = 0; i < phases.length; i++) {
+      const p = phases[i];
+      const req = p.required ? 'required' : 'optional';
+      const model = p.model ? ` [${p.model}]` : '';
+      console.log(`  ${i + 1}. ${p.name} — ${p.maxTurns} turns, ${req}${model}`);
+      if (p.tools.length > 0) {
+        console.log(`     tools: ${p.tools.join(', ')}`);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand handlers
+// ---------------------------------------------------------------------------
+
+async function listTasks(args: string[], vaultDir: string): Promise<void> {
+  const source = args.find((_, i) => args[i - 1] === '--source');
+  const endpoint = source
+    ? `/api/agent/tasks?source=${encodeURIComponent(source)}`
+    : '/api/agent/tasks';
+
+  const client = await connectToDaemon(vaultDir);
+  const result = await client.get(endpoint);
+
+  if (!result.ok || !result.data) {
+    console.error('Failed to fetch tasks from daemon');
+    process.exit(1);
+  }
+
+  const tasks = result.data as TaskRow[];
+  if (tasks.length === 0) {
+    console.log('No tasks found');
+    return;
+  }
+
+  printTaskTable(tasks);
+}
+
+async function showTask(args: string[], vaultDir: string): Promise<void> {
+  const name = args[0];
+  if (!name) {
+    console.error('Usage: myco task show <name>');
+    process.exit(1);
+  }
+
+  const client = await connectToDaemon(vaultDir);
+  const result = await client.get(`/api/agent/tasks/${encodeURIComponent(name)}`);
+
+  if (!result.ok || !result.data) {
+    console.error(`Task not found: ${name}`);
+    process.exit(1);
+  }
+
+  printTaskDetail(result.data as TaskRow);
+}
+
+async function createTask(args: string[], vaultDir: string): Promise<void> {
+  const name = args[0];
+  const from = args.find((_, i) => args[i - 1] === '--from');
+
+  if (!name || !from) {
+    console.error('Usage: myco task create <name> --from <template>');
+    process.exit(1);
+  }
+
+  const client = await connectToDaemon(vaultDir);
+  const result = await client.post(`/api/agent/tasks/${encodeURIComponent(from)}/copy`, { name });
+
+  if (!result.ok) {
+    console.error(`Failed to create task '${name}' from template '${from}'`);
+    if (result.data?.error) {
+      console.error(`  ${result.data.error}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Task '${name}' created from '${from}'`);
+}
+
+async function deleteTask(args: string[], vaultDir: string): Promise<void> {
+  const name = args[0];
+  if (!name) {
+    console.error('Usage: myco task delete <name>');
+    process.exit(1);
+  }
+
+  const client = await connectToDaemon(vaultDir);
+  const result = await client.delete(`/api/agent/tasks/${encodeURIComponent(name)}`);
+
+  if (!result.ok) {
+    const errCode = result.data?.error as string | undefined;
+    if (errCode === 'cannot_delete_builtin') {
+      console.error(`Cannot delete built-in task: ${name}`);
+    } else if (errCode === 'task_not_found') {
+      console.error(`Task not found: ${name}`);
+    } else {
+      console.error(`Failed to delete task: ${name}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Task '${name}' deleted`);
+}
+
+async function runTask(args: string[], vaultDir: string): Promise<void> {
+  const name = args[0];
+  const instruction = args.find((_, i) => args[i - 1] === '--instruction');
+
+  if (!name) {
+    console.error('Usage: myco task run <name> [--instruction TEXT]');
+    process.exit(1);
+  }
+
+  const client = await connectToDaemon(vaultDir);
+  console.log('Starting agent...');
+  const result = await client.post('/api/agent/run', { task: name, instruction });
+
+  if (!result.ok) {
+    console.error('Failed to start agent run');
+    process.exit(1);
+  }
+
+  console.log('Agent run dispatched to daemon');
+  if (result.data?.message) {
+    console.log(`  ${result.data.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+const TASK_USAGE = `Usage: myco task <subcommand> [args]
+
+Subcommands:
+  list [--source built-in|user]   List all tasks
+  show <name>                     Show task details and phases
+  create <name> --from <template> Copy a task template to your user dir
+  delete <name>                   Delete a user task
+  run <name> [--instruction TEXT] Run a task via the agent
+`;
+
+export async function run(args: string[], vaultDir: string): Promise<void> {
+  const subcommand = args[0];
+  const subArgs = args.slice(1);
+
+  switch (subcommand) {
+    case 'list': return listTasks(subArgs, vaultDir);
+    case 'show': return showTask(subArgs, vaultDir);
+    case 'create': return createTask(subArgs, vaultDir);
+    case 'delete': return deleteTask(subArgs, vaultDir);
+    case 'run': return runTask(subArgs, vaultDir);
+    default:
+      if (subcommand) {
+        console.error(`Unknown task subcommand: ${subcommand}`);
+      }
+      process.stdout.write(TASK_USAGE);
+      if (subcommand) process.exit(1);
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -286,6 +286,9 @@ export const USER_TASKS_DIR = 'tasks';
 /** Source label for user-created tasks. */
 export const USER_TASK_SOURCE = 'user';
 
+/** Source label for built-in tasks shipped with the package. */
+export const BUILT_IN_SOURCE = 'built-in';
+
 /** Task name validation pattern (lowercase, hyphens, digits). */
 export const TASK_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -128,9 +128,6 @@ export const EDGE_TYPE_EXTRACTED_FROM = 'EXTRACTED_FROM';
 export const EDGE_TYPE_DERIVED_FROM = 'DERIVED_FROM';
 /** Session contains this prompt batch. */
 export const EDGE_TYPE_HAS_BATCH = 'HAS_BATCH';
-/** Spore references an entity (auto-created by name matching). */
-export const EDGE_TYPE_REFERENCES = 'REFERENCES';
-
 // --- Query defaults ---
 /** Default row limit for query module list operations. */
 export const QUERY_DEFAULT_LIST_LIMIT = 100;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -128,6 +128,8 @@ export const EDGE_TYPE_EXTRACTED_FROM = 'EXTRACTED_FROM';
 export const EDGE_TYPE_DERIVED_FROM = 'DERIVED_FROM';
 /** Session contains this prompt batch. */
 export const EDGE_TYPE_HAS_BATCH = 'HAS_BATCH';
+/** Spore references an entity (auto-created by name matching). */
+export const EDGE_TYPE_REFERENCES = 'REFERENCES';
 
 // --- Query defaults ---
 /** Default row limit for query module list operations. */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -279,6 +279,19 @@ export const ITEM_STAGE_MAP: Record<string, PipelineStage[]> = {
   artifact: ['capture', 'embedding', 'digest'],
 };
 
+// --- User task registry ---
+/** Subdirectory within the vault for user-created task YAML files. */
+export const USER_TASKS_DIR = 'tasks';
+
+/** Source label for user-created tasks. */
+export const USER_TASK_SOURCE = 'user';
+
+/** Task name validation pattern (lowercase, hyphens, digits). */
+export const TASK_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
+
+/** Maximum length for task names. */
+export const MAX_TASK_NAME_LENGTH = 50;
+
 // --- Automatic consolidation ---
 /** Minimum cluster size required before asking LLM to consolidate. */
 export const CONSOLIDATION_MIN_CLUSTER_SIZE = 3;

--- a/src/daemon/api/agent-tasks.ts
+++ b/src/daemon/api/agent-tasks.ts
@@ -12,6 +12,8 @@
  *   DELETE /api/agent/tasks/:id      — delete a user task (built-ins blocked)
  */
 
+import { stringify as stringifyYaml, parse as parseYaml } from 'yaml';
+import { taskFromParsed } from '@myco/agent/loader.js';
 import { AgentTaskSchema } from '@myco/agent/schemas.js';
 import {
   loadAllTasks,
@@ -204,8 +206,7 @@ export async function handleGetTaskYaml(
 
   // Serialize task to YAML (strip internal fields)
   const { isBuiltin: _ib, source: _src, ...serializable } = task;
-  const { stringify } = await import('yaml');
-  const yaml = stringify(serializable);
+  const yaml = stringifyYaml(serializable);
 
   return { status: HTTP_OK, body: { yaml, source: task.source } };
 }
@@ -241,9 +242,7 @@ export async function handleUpdateTask(
   }
 
   try {
-    const { parse } = await import('yaml');
-    const parsed = AgentTaskSchema.parse(parse(yamlContent));
-    const { taskFromParsed } = await import('@myco/agent/loader.js');
+    const parsed = AgentTaskSchema.parse(parseYaml(yamlContent));
     const task = { ...taskFromParsed(parsed), isBuiltin: false, source: USER_TASK_SOURCE };
 
     // Ensure the name matches the URL param (prevent renaming via YAML)

--- a/src/daemon/api/agent-tasks.ts
+++ b/src/daemon/api/agent-tasks.ts
@@ -68,7 +68,7 @@ export async function handleListTasks(
     tasks = tasks.filter((t) => t.source === sourceFilter);
   }
 
-  return { status: HTTP_OK, body: tasks };
+  return { status: HTTP_OK, body: { tasks } };
 }
 
 /**
@@ -88,7 +88,7 @@ export async function handleGetTask(
     return { status: HTTP_NOT_FOUND, body: { error: 'task_not_found' } };
   }
 
-  return { status: HTTP_OK, body: task };
+  return { status: HTTP_OK, body: { task } };
 }
 
 /**

--- a/src/daemon/api/agent-tasks.ts
+++ b/src/daemon/api/agent-tasks.ts
@@ -143,7 +143,7 @@ export async function handleCreateTask(
 
   writeUserTask(vaultDir, task);
 
-  return { status: HTTP_CREATED, body: task };
+  return { status: HTTP_CREATED, body: { task } };
 }
 
 /**
@@ -173,7 +173,7 @@ export async function handleCopyTask(
 
   try {
     const copy = copyTaskToUser(definitionsDir, vaultDir, sourceName, newName);
-    return { status: HTTP_CREATED, body: copy };
+    return { status: HTTP_CREATED, body: { task: copy } };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (message.includes('not found')) {

--- a/src/daemon/api/agent-tasks.ts
+++ b/src/daemon/api/agent-tasks.ts
@@ -184,6 +184,82 @@ export async function handleCopyTask(
 }
 
 /**
+ * Get the raw YAML content of a user task file.
+ *
+ * Built-in tasks return their serialized AgentTask as YAML.
+ * Returns 404 if the task doesn't exist.
+ */
+export async function handleGetTaskYaml(
+  req: RouteRequest,
+  vaultDir: string,
+): Promise<RouteResponse> {
+  const taskName = req.params.id;
+  const definitionsDir = resolveDefinitionsDir();
+  const allTasks = loadAllTasks(definitionsDir, vaultDir);
+  const task = allTasks.get(taskName);
+
+  if (!task) {
+    return { status: HTTP_NOT_FOUND, body: { error: 'task_not_found', name: taskName } };
+  }
+
+  // Serialize task to YAML (strip internal fields)
+  const { isBuiltin: _ib, source: _src, ...serializable } = task;
+  const { stringify } = await import('yaml');
+  const yaml = stringify(serializable);
+
+  return { status: HTTP_OK, body: { yaml, source: task.source } };
+}
+
+/**
+ * Update a user task from raw YAML content.
+ *
+ * Parses the YAML through AgentTaskSchema for validation.
+ * Built-in tasks cannot be updated (returns 403).
+ * Returns the updated task on success.
+ */
+export async function handleUpdateTask(
+  req: RouteRequest,
+  vaultDir: string,
+): Promise<RouteResponse> {
+  const taskName = req.params.id;
+  const definitionsDir = resolveDefinitionsDir();
+  const allTasks = loadAllTasks(definitionsDir, vaultDir);
+  const existing = allTasks.get(taskName);
+
+  if (!existing) {
+    return { status: HTTP_NOT_FOUND, body: { error: 'task_not_found', name: taskName } };
+  }
+
+  if (existing.isBuiltin || existing.source !== USER_TASK_SOURCE) {
+    return { status: HTTP_FORBIDDEN, body: { error: 'cannot_update_builtin', name: taskName } };
+  }
+
+  const body = req.body as Record<string, unknown> | undefined;
+  const yamlContent = body?.yaml;
+  if (typeof yamlContent !== 'string') {
+    return { status: HTTP_BAD_REQUEST, body: { error: 'missing_yaml_field' } };
+  }
+
+  try {
+    const { parse } = await import('yaml');
+    const parsed = AgentTaskSchema.parse(parse(yamlContent));
+    const { taskFromParsed } = await import('@myco/agent/loader.js');
+    const task = { ...taskFromParsed(parsed), isBuiltin: false, source: USER_TASK_SOURCE };
+
+    // Ensure the name matches the URL param (prevent renaming via YAML)
+    if (task.name !== taskName) {
+      return { status: HTTP_BAD_REQUEST, body: { error: 'name_mismatch', expected: taskName, got: task.name } };
+    }
+
+    writeUserTask(vaultDir, task);
+    return { status: HTTP_OK, body: { task } };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { status: HTTP_BAD_REQUEST, body: { error: 'validation_failed', message } };
+  }
+}
+
+/**
  * Delete a user task by name.
  *
  * Built-in tasks may not be deleted (returns 403).

--- a/src/daemon/api/agent-tasks.ts
+++ b/src/daemon/api/agent-tasks.ts
@@ -1,0 +1,217 @@
+/**
+ * API route handlers for agent task CRUD.
+ *
+ * Thin handlers that delegate to the registry and loader. Each handler
+ * takes a RouteRequest and the vault directory, returning a RouteResponse.
+ *
+ * Route overview:
+ *   GET    /api/agent/tasks          — list all tasks (built-in + user)
+ *   GET    /api/agent/tasks/:id      — get a single task by name
+ *   POST   /api/agent/tasks          — create a new user task
+ *   POST   /api/agent/tasks/:id/copy — copy an existing task to user dir
+ *   DELETE /api/agent/tasks/:id      — delete a user task (built-ins blocked)
+ */
+
+import { AgentTaskSchema } from '@myco/agent/schemas.js';
+import {
+  loadAllTasks,
+  validateTaskName,
+  writeUserTask,
+  deleteUserTask,
+  copyTaskToUser,
+} from '@myco/agent/registry.js';
+import { resolveDefinitionsDir } from '@myco/agent/loader.js';
+import { USER_TASK_SOURCE } from '@myco/constants.js';
+import type { RouteRequest, RouteResponse } from '../router.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** HTTP status: 200 OK (returned as undefined — default) */
+const HTTP_OK = 200;
+
+/** HTTP status: 201 Created */
+const HTTP_CREATED = 201;
+
+/** HTTP status: 400 Bad Request */
+const HTTP_BAD_REQUEST = 400;
+
+/** HTTP status: 403 Forbidden */
+const HTTP_FORBIDDEN = 403;
+
+/** HTTP status: 404 Not Found */
+const HTTP_NOT_FOUND = 404;
+
+/** HTTP status: 409 Conflict */
+const HTTP_CONFLICT = 409;
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * List all tasks: built-in definitions merged with user-created overrides.
+ *
+ * Optionally filtered by `?source=user` or `?source=built-in`.
+ */
+export async function handleListTasks(
+  req: RouteRequest,
+  vaultDir: string,
+): Promise<RouteResponse> {
+  const definitionsDir = resolveDefinitionsDir();
+  const allTasks = loadAllTasks(definitionsDir, vaultDir);
+  let tasks = Array.from(allTasks.values());
+
+  const sourceFilter = req.query?.source as string | undefined;
+  if (sourceFilter) {
+    tasks = tasks.filter((t) => t.source === sourceFilter);
+  }
+
+  return { status: HTTP_OK, body: tasks };
+}
+
+/**
+ * Get a single task by its name (used as the URL `:id` parameter).
+ *
+ * Returns 404 if the task is not found.
+ */
+export async function handleGetTask(
+  req: RouteRequest,
+  vaultDir: string,
+): Promise<RouteResponse> {
+  const definitionsDir = resolveDefinitionsDir();
+  const allTasks = loadAllTasks(definitionsDir, vaultDir);
+  const task = allTasks.get(req.params.id);
+
+  if (!task) {
+    return { status: HTTP_NOT_FOUND, body: { error: 'task_not_found' } };
+  }
+
+  return { status: HTTP_OK, body: task };
+}
+
+/**
+ * Create a new user task from the request body.
+ *
+ * Validates:
+ * - Body must parse against AgentTaskSchema.
+ * - Task name must be valid (lowercase letters, digits, hyphens only).
+ * - No existing user task with the same name may exist.
+ *
+ * Returns 201 on success.
+ */
+export async function handleCreateTask(
+  req: RouteRequest,
+  vaultDir: string,
+): Promise<RouteResponse> {
+  // Parse and validate body against schema
+  const result = AgentTaskSchema.safeParse(req.body);
+  if (!result.success) {
+    return {
+      status: HTTP_BAD_REQUEST,
+      body: { error: 'validation_failed', issues: result.error.issues },
+    };
+  }
+
+  const parsed = result.data;
+
+  // Validate task name format
+  if (!validateTaskName(parsed.name)) {
+    return {
+      status: HTTP_BAD_REQUEST,
+      body: { error: 'invalid_task_name', name: parsed.name },
+    };
+  }
+
+  // Check for existing user task with the same name (built-ins can be shadowed)
+  const definitionsDir = resolveDefinitionsDir();
+  const allTasks = loadAllTasks(definitionsDir, vaultDir);
+  const existing = allTasks.get(parsed.name);
+  if (existing && existing.source === USER_TASK_SOURCE) {
+    return {
+      status: HTTP_CONFLICT,
+      body: { error: 'task_already_exists', name: parsed.name },
+    };
+  }
+
+  const task = {
+    ...parsed,
+    isBuiltin: false,
+    source: USER_TASK_SOURCE,
+  };
+
+  writeUserTask(vaultDir, task);
+
+  return { status: HTTP_CREATED, body: task };
+}
+
+/**
+ * Copy an existing task (built-in or user) to the user task directory.
+ *
+ * The source task is identified by `req.params.id`.
+ * An optional new name may be provided via `req.body.name`.
+ *
+ * Returns 201 on success.
+ */
+export async function handleCopyTask(
+  req: RouteRequest,
+  vaultDir: string,
+): Promise<RouteResponse> {
+  const sourceName = req.params.id;
+  const newName = (req.body as Record<string, unknown> | undefined)?.name as string | undefined;
+
+  const definitionsDir = resolveDefinitionsDir();
+
+  // Validate the new name if provided
+  if (newName !== undefined && !validateTaskName(newName)) {
+    return {
+      status: HTTP_BAD_REQUEST,
+      body: { error: 'invalid_task_name', name: newName },
+    };
+  }
+
+  try {
+    const copy = copyTaskToUser(definitionsDir, vaultDir, sourceName, newName);
+    return { status: HTTP_CREATED, body: copy };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes('not found')) {
+      return { status: HTTP_NOT_FOUND, body: { error: 'task_not_found', name: sourceName } };
+    }
+    return { status: HTTP_BAD_REQUEST, body: { error: 'copy_failed', message } };
+  }
+}
+
+/**
+ * Delete a user task by name.
+ *
+ * Built-in tasks may not be deleted (returns 403).
+ * Returns 404 if the task does not exist.
+ */
+export async function handleDeleteTask(
+  req: RouteRequest,
+  vaultDir: string,
+): Promise<RouteResponse> {
+  const taskName = req.params.id;
+  const definitionsDir = resolveDefinitionsDir();
+  const allTasks = loadAllTasks(definitionsDir, vaultDir);
+  const task = allTasks.get(taskName);
+
+  // Task must exist
+  if (!task) {
+    return { status: HTTP_NOT_FOUND, body: { error: 'task_not_found', name: taskName } };
+  }
+
+  // Built-in tasks cannot be deleted
+  if (task.isBuiltin || task.source !== USER_TASK_SOURCE) {
+    return {
+      status: HTTP_FORBIDDEN,
+      body: { error: 'cannot_delete_builtin', name: taskName },
+    };
+  }
+
+  deleteUserTask(vaultDir, taskName);
+
+  return { status: HTTP_OK, body: { deleted: taskName } };
+}

--- a/src/daemon/api/agent-tasks.ts
+++ b/src/daemon/api/agent-tasks.ts
@@ -13,6 +13,7 @@
  */
 
 import { stringify as stringifyYaml, parse as parseYaml } from 'yaml';
+import { errorMessage as toErrorMessage } from '@myco/utils/error-message.js';
 import { taskFromParsed } from '@myco/agent/loader.js';
 import { AgentTaskSchema } from '@myco/agent/schemas.js';
 import {
@@ -177,7 +178,7 @@ export async function handleCopyTask(
     const copy = copyTaskToUser(definitionsDir, vaultDir, sourceName, newName);
     return { status: HTTP_CREATED, body: { task: copy } };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = toErrorMessage(err);
     if (message.includes('not found')) {
       return { status: HTTP_NOT_FOUND, body: { error: 'task_not_found', name: sourceName } };
     }
@@ -253,7 +254,7 @@ export async function handleUpdateTask(
     writeUserTask(vaultDir, task);
     return { status: HTTP_OK, body: { task } };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = toErrorMessage(err);
     return { status: HTTP_BAD_REQUEST, body: { error: 'validation_failed', message } };
   }
 }

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -45,6 +45,8 @@ import { handleGetEmbeddingStatus } from './api/embedding.js';
 import {
   handleListTasks,
   handleGetTask,
+  handleGetTaskYaml,
+  handleUpdateTask,
   handleCreateTask,
   handleCopyTask,
   handleDeleteTask,
@@ -938,6 +940,8 @@ export async function main(): Promise<void> {
 
   server.registerRoute('GET', '/api/agent/tasks', async (req) => handleListTasks(req, vaultDir));
   server.registerRoute('GET', '/api/agent/tasks/:id', async (req) => handleGetTask(req, vaultDir));
+  server.registerRoute('GET', '/api/agent/tasks/:id/yaml', async (req) => handleGetTaskYaml(req, vaultDir));
+  server.registerRoute('PUT', '/api/agent/tasks/:id', async (req) => handleUpdateTask(req, vaultDir));
   server.registerRoute('POST', '/api/agent/tasks', async (req) => handleCreateTask(req, vaultDir));
   server.registerRoute('POST', '/api/agent/tasks/:id/copy', async (req) => handleCopyTask(req, vaultDir));
   server.registerRoute('DELETE', '/api/agent/tasks/:id', async (req) => handleDeleteTask(req, vaultDir));

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -42,8 +42,14 @@ import {
 import { handleSearch } from './api/search.js';
 import { handleGetFeed } from './api/feed.js';
 import { handleGetEmbeddingStatus } from './api/embedding.js';
+import {
+  handleListTasks,
+  handleGetTask,
+  handleCreateTask,
+  handleCopyTask,
+  handleDeleteTask,
+} from './api/agent-tasks.js';
 import { listTurnsByRun } from '../db/queries/turns.js';
-import { listTasksByAgent } from '../db/queries/tasks.js';
 import { gatherStats } from '../services/stats.js';
 import { initDatabaseForVault, closeDatabase, getDatabase } from '../db/client.js';
 import { upsertSession, closeSession, updateSession, listSessions, getSession } from '../db/queries/sessions.js';
@@ -930,11 +936,11 @@ export async function main(): Promise<void> {
     return { body: turns };
   });
 
-  server.registerRoute('GET', '/api/agent/tasks', async (req) => {
-    const agentId = req.query.agent_id ?? DEFAULT_AGENT_ID;
-    const tasks = await listTasksByAgent(agentId);
-    return { body: tasks };
-  });
+  server.registerRoute('GET', '/api/agent/tasks', async (req) => handleListTasks(req, vaultDir));
+  server.registerRoute('GET', '/api/agent/tasks/:id', async (req) => handleGetTask(req, vaultDir));
+  server.registerRoute('POST', '/api/agent/tasks', async (req) => handleCreateTask(req, vaultDir));
+  server.registerRoute('POST', '/api/agent/tasks/:id/copy', async (req) => handleCopyTask(req, vaultDir));
+  server.registerRoute('DELETE', '/api/agent/tasks/:id', async (req) => handleDeleteTask(req, vaultDir));
 
   // --- MCP proxy routes ---
   // These routes exist so the MCP server can proxy tool calls through the

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -903,10 +903,25 @@ export async function main(): Promise<void> {
     // before the async SDK call. Wait for the result since it's fast to start.
     resultPromise
       .then((result) => {
-        logger.info('agent', 'Agent run completed', { runId: result.runId, status: result.status });
+        if (result.status === 'failed') {
+          logger.error('agent', 'Agent run failed', {
+            runId: result.runId,
+            error: result.error ?? 'No error message',
+            phases: result.phases?.map(p => `${p.name}:${p.status}`) ?? [],
+          });
+        } else {
+          logger.info('agent', 'Agent run completed', {
+            runId: result.runId,
+            status: result.status,
+            phases: result.phases?.map(p => `${p.name}:${p.status}`) ?? [],
+          });
+        }
       })
       .catch((err) => {
-        logger.error('agent', 'Agent run failed', { error: (err as Error).message });
+        logger.error('agent', 'Agent run threw unhandled error', {
+          error: (err as Error).message ?? String(err),
+          stack: (err as Error).stack?.split('\n').slice(0, 3).join(' | '),
+        });
       });
 
     // Return immediately — the caller can poll /api/agent/runs for status

--- a/src/db/queries/lineage.ts
+++ b/src/db/queries/lineage.ts
@@ -12,24 +12,12 @@
  */
 
 import { insertGraphEdge } from './graph-edges.js';
-import { listEntities } from './entities.js';
-import { searchSimilar } from './embeddings.js';
 import {
   EDGE_TYPE_FROM_SESSION,
   EDGE_TYPE_EXTRACTED_FROM,
   EDGE_TYPE_DERIVED_FROM,
   EDGE_TYPE_HAS_BATCH,
-  EDGE_TYPE_REFERENCES,
 } from '@myco/constants.js';
-
-/** Minimum entity name length for auto-linking (avoids false positives). */
-const MIN_ENTITY_NAME_LENGTH = 3;
-
-/** Similarity threshold for entity ↔ spore auto-linking. */
-const AUTO_LINK_SIMILARITY_THRESHOLD = 0.45;
-
-/** Max spore results to consider per entity auto-link search. */
-const AUTO_LINK_SEARCH_LIMIT = 20;
 
 // ---------------------------------------------------------------------------
 // Spore lineage
@@ -115,100 +103,4 @@ export async function createBatchLineage(
     type: EDGE_TYPE_HAS_BATCH,
     created_at: createdAt,
   });
-}
-
-// ---------------------------------------------------------------------------
-// Entity ↔ Spore auto-linking (REFERENCES edges)
-// ---------------------------------------------------------------------------
-
-/**
- * Auto-link a newly created spore to existing entities.
- *
- * Uses a two-pass approach:
- * 1. Name matching (fast): check if any entity name appears in the spore content
- * 2. No embedding needed for spore→entity since entities are few and name match is reliable
- *
- * Creates REFERENCES edges (spore → entity). Fire-and-forget safe.
- */
-export async function autoLinkSporeToEntities(spore: {
-  id: string;
-  agent_id: string;
-  content: string;
-  created_at: number;
-}): Promise<number> {
-  // Entities are few (tens, not thousands) — name matching is fast and precise
-  const entities = await listEntities({ agent_id: spore.agent_id, status: 'active' });
-  const contentLower = spore.content.toLowerCase();
-  const edges: Promise<unknown>[] = [];
-
-  for (const entity of entities) {
-    if (entity.name.length < MIN_ENTITY_NAME_LENGTH) continue;
-    // Case-insensitive substring match — entities have descriptive names
-    if (contentLower.includes(entity.name.toLowerCase())) {
-      edges.push(insertGraphEdge({
-        agent_id: spore.agent_id,
-        source_id: spore.id,
-        source_type: 'spore',
-        target_id: entity.id,
-        target_type: 'entity',
-        type: EDGE_TYPE_REFERENCES,
-        created_at: spore.created_at,
-      }));
-    }
-  }
-
-  await Promise.all(edges);
-  return edges.length;
-}
-
-/**
- * Auto-link a newly created entity to existing spores.
- *
- * Uses semantic search (vector similarity) to find spores related to the
- * entity name. This scales to large vaults without scanning all spore content —
- * the embedding index handles the heavy lifting.
- *
- * Falls back to no-op if the embedding provider is unavailable.
- *
- * Creates REFERENCES edges (spore → entity). Fire-and-forget safe.
- */
-export async function autoLinkEntityToSpores(entity: {
-  id: string;
-  agent_id: string;
-  name: string;
-  created_at: number;
-}): Promise<number> {
-  if (entity.name.length < MIN_ENTITY_NAME_LENGTH) return 0;
-
-  // Use semantic search to find related spores via vector similarity
-  let embedding: number[] | null = null;
-  try {
-    const { tryEmbed } = await import('@myco/intelligence/embed-query.js');
-    embedding = await tryEmbed(entity.name);
-  } catch {
-    return 0; // Embedding unavailable — skip auto-linking
-  }
-  if (!embedding) return 0;
-
-  const results = await searchSimilar('spores', embedding, {
-    limit: AUTO_LINK_SEARCH_LIMIT,
-    filters: { agent_id: entity.agent_id },
-  });
-
-  const edges: Promise<unknown>[] = [];
-  for (const result of results) {
-    if ((result.similarity ?? 0) < AUTO_LINK_SIMILARITY_THRESHOLD) continue;
-    edges.push(insertGraphEdge({
-      agent_id: entity.agent_id,
-      source_id: result.id,
-      source_type: 'spore',
-      target_id: entity.id,
-      target_type: 'entity',
-      type: EDGE_TYPE_REFERENCES,
-      created_at: entity.created_at,
-    }));
-  }
-
-  await Promise.all(edges);
-  return edges.length;
 }

--- a/src/db/queries/lineage.ts
+++ b/src/db/queries/lineage.ts
@@ -12,12 +12,18 @@
  */
 
 import { insertGraphEdge } from './graph-edges.js';
+import { listEntities } from './entities.js';
+import { listSpores } from './spores.js';
 import {
   EDGE_TYPE_FROM_SESSION,
   EDGE_TYPE_EXTRACTED_FROM,
   EDGE_TYPE_DERIVED_FROM,
   EDGE_TYPE_HAS_BATCH,
+  EDGE_TYPE_REFERENCES,
 } from '@myco/constants.js';
+
+/** Minimum entity name length to match (avoids false positives on short names). */
+const MIN_ENTITY_NAME_LENGTH = 3;
 
 // ---------------------------------------------------------------------------
 // Spore lineage
@@ -103,4 +109,83 @@ export async function createBatchLineage(
     type: EDGE_TYPE_HAS_BATCH,
     created_at: createdAt,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Entity ↔ Spore auto-linking (REFERENCES edges)
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if spore content mentions an entity name (case-insensitive word boundary match).
+ */
+function contentMentionsEntity(content: string, entityName: string): boolean {
+  if (entityName.length < MIN_ENTITY_NAME_LENGTH) return false;
+  // Escape regex special chars in entity name, match case-insensitive
+  const escaped = entityName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`\\b${escaped}\\b`, 'i');
+  return pattern.test(content);
+}
+
+/**
+ * Auto-link a newly created spore to existing entities whose name appears in its content.
+ * Creates REFERENCES edges (spore → entity). Fire-and-forget safe.
+ */
+export async function autoLinkSporeToEntities(spore: {
+  id: string;
+  agent_id: string;
+  content: string;
+  created_at: number;
+}): Promise<number> {
+  const entities = await listEntities({ agent_id: spore.agent_id, status: 'active' });
+  const edges: Promise<unknown>[] = [];
+
+  for (const entity of entities) {
+    if (contentMentionsEntity(spore.content, entity.name)) {
+      edges.push(insertGraphEdge({
+        agent_id: spore.agent_id,
+        source_id: spore.id,
+        source_type: 'spore',
+        target_id: entity.id,
+        target_type: 'entity',
+        type: EDGE_TYPE_REFERENCES,
+        created_at: spore.created_at,
+      }));
+    }
+  }
+
+  await Promise.all(edges);
+  return edges.length;
+}
+
+/**
+ * Auto-link a newly created entity to existing spores whose content mentions it.
+ * Creates REFERENCES edges (spore → entity). Fire-and-forget safe.
+ */
+export async function autoLinkEntityToSpores(entity: {
+  id: string;
+  agent_id: string;
+  name: string;
+  created_at: number;
+}): Promise<number> {
+  if (entity.name.length < MIN_ENTITY_NAME_LENGTH) return 0;
+
+  const spores = await listSpores({ agent_id: entity.agent_id, status: 'active' });
+  const edges: Promise<unknown>[] = [];
+
+  for (const spore of spores) {
+    if (contentMentionsEntity(spore.content, entity.name)) {
+      edges.push(insertGraphEdge({
+        agent_id: entity.agent_id,
+        source_id: spore.id,
+        source_type: 'spore',
+        target_id: entity.id,
+        target_type: 'entity',
+        type: EDGE_TYPE_REFERENCES,
+        created_at: entity.created_at,
+      }));
+    }
+  }
+
+  await Promise.all(edges);
+  return edges.length;
 }

--- a/src/db/queries/lineage.ts
+++ b/src/db/queries/lineage.ts
@@ -13,7 +13,7 @@
 
 import { insertGraphEdge } from './graph-edges.js';
 import { listEntities } from './entities.js';
-import { listSpores } from './spores.js';
+import { searchSimilar } from './embeddings.js';
 import {
   EDGE_TYPE_FROM_SESSION,
   EDGE_TYPE_EXTRACTED_FROM,
@@ -22,8 +22,14 @@ import {
   EDGE_TYPE_REFERENCES,
 } from '@myco/constants.js';
 
-/** Minimum entity name length to match (avoids false positives on short names). */
+/** Minimum entity name length for auto-linking (avoids false positives). */
 const MIN_ENTITY_NAME_LENGTH = 3;
+
+/** Similarity threshold for entity ↔ spore auto-linking. */
+const AUTO_LINK_SIMILARITY_THRESHOLD = 0.45;
+
+/** Max spore results to consider per entity auto-link search. */
+const AUTO_LINK_SEARCH_LIMIT = 20;
 
 // ---------------------------------------------------------------------------
 // Spore lineage
@@ -116,18 +122,12 @@ export async function createBatchLineage(
 // ---------------------------------------------------------------------------
 
 /**
- * Check if spore content mentions an entity name (case-insensitive word boundary match).
- */
-function contentMentionsEntity(content: string, entityName: string): boolean {
-  if (entityName.length < MIN_ENTITY_NAME_LENGTH) return false;
-  // Escape regex special chars in entity name, match case-insensitive
-  const escaped = entityName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const pattern = new RegExp(`\\b${escaped}\\b`, 'i');
-  return pattern.test(content);
-}
-
-/**
- * Auto-link a newly created spore to existing entities whose name appears in its content.
+ * Auto-link a newly created spore to existing entities.
+ *
+ * Uses a two-pass approach:
+ * 1. Name matching (fast): check if any entity name appears in the spore content
+ * 2. No embedding needed for spore→entity since entities are few and name match is reliable
+ *
  * Creates REFERENCES edges (spore → entity). Fire-and-forget safe.
  */
 export async function autoLinkSporeToEntities(spore: {
@@ -136,11 +136,15 @@ export async function autoLinkSporeToEntities(spore: {
   content: string;
   created_at: number;
 }): Promise<number> {
+  // Entities are few (tens, not thousands) — name matching is fast and precise
   const entities = await listEntities({ agent_id: spore.agent_id, status: 'active' });
+  const contentLower = spore.content.toLowerCase();
   const edges: Promise<unknown>[] = [];
 
   for (const entity of entities) {
-    if (contentMentionsEntity(spore.content, entity.name)) {
+    if (entity.name.length < MIN_ENTITY_NAME_LENGTH) continue;
+    // Case-insensitive substring match — entities have descriptive names
+    if (contentLower.includes(entity.name.toLowerCase())) {
       edges.push(insertGraphEdge({
         agent_id: spore.agent_id,
         source_id: spore.id,
@@ -158,7 +162,14 @@ export async function autoLinkSporeToEntities(spore: {
 }
 
 /**
- * Auto-link a newly created entity to existing spores whose content mentions it.
+ * Auto-link a newly created entity to existing spores.
+ *
+ * Uses semantic search (vector similarity) to find spores related to the
+ * entity name. This scales to large vaults without scanning all spore content —
+ * the embedding index handles the heavy lifting.
+ *
+ * Falls back to no-op if the embedding provider is unavailable.
+ *
  * Creates REFERENCES edges (spore → entity). Fire-and-forget safe.
  */
 export async function autoLinkEntityToSpores(entity: {
@@ -169,21 +180,33 @@ export async function autoLinkEntityToSpores(entity: {
 }): Promise<number> {
   if (entity.name.length < MIN_ENTITY_NAME_LENGTH) return 0;
 
-  const spores = await listSpores({ agent_id: entity.agent_id, status: 'active' });
-  const edges: Promise<unknown>[] = [];
+  // Use semantic search to find related spores via vector similarity
+  let embedding: number[] | null = null;
+  try {
+    const { tryEmbed } = await import('@myco/intelligence/embed-query.js');
+    embedding = await tryEmbed(entity.name);
+  } catch {
+    return 0; // Embedding unavailable — skip auto-linking
+  }
+  if (!embedding) return 0;
 
-  for (const spore of spores) {
-    if (contentMentionsEntity(spore.content, entity.name)) {
-      edges.push(insertGraphEdge({
-        agent_id: entity.agent_id,
-        source_id: spore.id,
-        source_type: 'spore',
-        target_id: entity.id,
-        target_type: 'entity',
-        type: EDGE_TYPE_REFERENCES,
-        created_at: entity.created_at,
-      }));
-    }
+  const results = await searchSimilar('spores', embedding, {
+    limit: AUTO_LINK_SEARCH_LIMIT,
+    filters: { agent_id: entity.agent_id },
+  });
+
+  const edges: Promise<unknown>[] = [];
+  for (const result of results) {
+    if ((result.similarity ?? 0) < AUTO_LINK_SIMILARITY_THRESHOLD) continue;
+    edges.push(insertGraphEdge({
+      agent_id: entity.agent_id,
+      source_id: result.id,
+      source_type: 'spore',
+      target_id: entity.id,
+      target_type: 'entity',
+      type: EDGE_TYPE_REFERENCES,
+      created_at: entity.created_at,
+    }));
   }
 
   await Promise.all(edges);

--- a/src/db/queries/tasks.ts
+++ b/src/db/queries/tasks.ts
@@ -6,6 +6,7 @@
  */
 
 import { getDatabase } from '@myco/db/client.js';
+import { BUILT_IN_SOURCE } from '@myco/constants.js';
 import type { TaskConfig } from '@myco/agent/types.js';
 
 // ---------------------------------------------------------------------------
@@ -16,10 +17,7 @@ import type { TaskConfig } from '@myco/agent/types.js';
 const DEFAULT_LIST_LIMIT = 100;
 
 /** Default task source for new tasks. */
-const DEFAULT_SOURCE = 'built-in';
-
-/** Source label for built-in tasks — protected from deletion. */
-const BUILT_IN_SOURCE = 'built-in';
+const DEFAULT_SOURCE = BUILT_IN_SOURCE;
 
 /** Default is_default flag for new tasks. */
 const DEFAULT_IS_DEFAULT = 0;

--- a/src/db/queries/tasks.ts
+++ b/src/db/queries/tasks.ts
@@ -6,6 +6,7 @@
  */
 
 import { getDatabase } from '@myco/db/client.js';
+import type { TaskConfig } from '@myco/agent/types.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -16,6 +17,9 @@ const DEFAULT_LIST_LIMIT = 100;
 
 /** Default task source for new tasks. */
 const DEFAULT_SOURCE = 'built-in';
+
+/** Source label for built-in tasks — protected from deletion. */
+const BUILT_IN_SOURCE = 'built-in';
 
 /** Default is_default flag for new tasks. */
 const DEFAULT_IS_DEFAULT = 0;
@@ -107,6 +111,22 @@ function toTaskRow(row: Record<string, unknown>): TaskRow {
     created_at: row.created_at as number,
     updated_at: (row.updated_at as number) ?? null,
   };
+}
+
+/** Serialize a TaskConfig to a JSON string for storage. */
+export function serializeConfig(config: TaskConfig | null): string | null {
+  if (!config) return null;
+  return JSON.stringify(config);
+}
+
+/** Deserialize a TaskConfig from a stored JSON string. Returns null on failure. */
+export function deserializeConfig(raw: string | null): TaskConfig | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as TaskConfig;
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -261,4 +281,20 @@ export async function listTasksByAgent(
   );
 
   return (result.rows as Record<string, unknown>[]).map(toTaskRow);
+}
+
+/**
+ * Delete a task by id.
+ *
+ * Built-in tasks (source = 'built-in') are protected and cannot be deleted.
+ *
+ * @returns true if the task was deleted, false if not found or protected.
+ */
+export async function deleteTask(id: string): Promise<boolean> {
+  const db = getDatabase();
+  const result = await db.query(
+    `DELETE FROM agent_tasks WHERE id = $1 AND source != $2 RETURNING id`,
+    [id, BUILT_IN_SOURCE],
+  );
+  return result.rows.length > 0;
 }

--- a/src/hooks/client.ts
+++ b/src/hooks/client.ts
@@ -63,6 +63,24 @@ export class DaemonClient {
     }
   }
 
+  async delete(endpoint: string): Promise<ClientResult> {
+    try {
+      const info = this.readDaemonJson();
+      if (!info) return { ok: false };
+
+      const res = await fetch(`http://127.0.0.1:${info.port}${endpoint}`, {
+        method: 'DELETE',
+        signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
+      });
+
+      if (!res.ok) return { ok: false };
+      const data = await res.json();
+      return { ok: true, data };
+    } catch {
+      return { ok: false };
+    }
+  }
+
   async isHealthy(cachedInfo?: DaemonInfo | null): Promise<boolean> {
     try {
       const info = cachedInfo ?? this.readDaemonJson();

--- a/src/utils/error-message.ts
+++ b/src/utils/error-message.ts
@@ -1,0 +1,10 @@
+/**
+ * Extract a human-readable error message from an unknown thrown value.
+ *
+ * Handles Error instances, strings, and arbitrary objects. Never throws.
+ */
+export function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message || err.constructor.name || 'Error';
+  if (typeof err === 'string') return err || 'Empty string error';
+  try { return JSON.stringify(err); } catch { return 'Unserializable error'; }
+}

--- a/tests/agent/context-queries.test.ts
+++ b/tests/agent/context-queries.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Tests for context query execution.
+ *
+ * DB query functions are mocked via vi.mock() so tests never touch a real
+ * database. Each test exercises the routing logic and error handling of
+ * executeContextQueries().
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ContextQuery } from '@myco/agent/types.js';
+
+// ---------------------------------------------------------------------------
+// Mocks: DB query functions
+// ---------------------------------------------------------------------------
+
+vi.mock('@myco/db/queries/batches.js', () => ({
+  getUnprocessedBatches: vi.fn(),
+}));
+
+vi.mock('@myco/db/queries/spores.js', () => ({
+  listSpores: vi.fn(),
+}));
+
+vi.mock('@myco/db/queries/sessions.js', () => ({
+  listSessions: vi.fn(),
+}));
+
+vi.mock('@myco/db/queries/agent-state.js', () => ({
+  getStatesForAgent: vi.fn(),
+}));
+
+// Import mocked modules for controlling return values
+import { getUnprocessedBatches } from '@myco/db/queries/batches.js';
+import { listSpores } from '@myco/db/queries/spores.js';
+import { listSessions } from '@myco/db/queries/sessions.js';
+import { getStatesForAgent } from '@myco/db/queries/agent-state.js';
+
+// Import the module under test after mocks are registered
+import { executeContextQueries } from '@myco/agent/context-queries.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TEST_AGENT_ID = 'myco-agent';
+
+/** Default limit used when query.limit is not specified. */
+const DEFAULT_CONTEXT_QUERY_LIMIT = 10;
+
+/** Sample batch row shape (only fields relevant to assertions). */
+const MOCK_BATCH = { id: 1, session_id: 'sess-abc', processed: 0 };
+
+/** Sample spore row shape (only fields relevant to assertions). */
+const MOCK_SPORE = { id: 'spore-1', agent_id: TEST_AGENT_ID, observation_type: 'gotcha' };
+
+/** Sample session row shape. */
+const MOCK_SESSION = { id: 'sess-abc', agent: 'claude-code', status: 'active' };
+
+/** Sample agent state row. */
+const MOCK_STATE = { agent_id: TEST_AGENT_ID, key: 'cursor', value: '42', updated_at: 1000 };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal ContextQuery with sensible defaults. */
+function makeQuery(overrides: Partial<ContextQuery> = {}): ContextQuery {
+  return {
+    tool: 'vault_unprocessed',
+    queryTemplate: '',
+    limit: DEFAULT_CONTEXT_QUERY_LIMIT,
+    purpose: 'test purpose',
+    required: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reset mocks between tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('executeContextQueries', () => {
+  describe('vault_unprocessed', () => {
+    it('executes query and returns data', async () => {
+      vi.mocked(getUnprocessedBatches).mockResolvedValue([MOCK_BATCH] as never);
+
+      const results = await executeContextQueries(TEST_AGENT_ID, [
+        makeQuery({ tool: 'vault_unprocessed', purpose: 'check backlog' }),
+      ]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].tool).toBe('vault_unprocessed');
+      expect(results[0].purpose).toBe('check backlog');
+      expect(results[0].data).toEqual([MOCK_BATCH]);
+      expect(results[0].error).toBeUndefined();
+    });
+
+    it('passes limit to getUnprocessedBatches', async () => {
+      vi.mocked(getUnprocessedBatches).mockResolvedValue([]);
+
+      await executeContextQueries(TEST_AGENT_ID, [
+        makeQuery({ tool: 'vault_unprocessed', limit: 5 }),
+      ]);
+
+      expect(getUnprocessedBatches).toHaveBeenCalledWith({ limit: 5 });
+    });
+  });
+
+  describe('vault_spores', () => {
+    it('executes query with agent_id filter and returns data', async () => {
+      vi.mocked(listSpores).mockResolvedValue([MOCK_SPORE] as never);
+
+      const results = await executeContextQueries(TEST_AGENT_ID, [
+        makeQuery({ tool: 'vault_spores', purpose: 'review spores' }),
+      ]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].tool).toBe('vault_spores');
+      expect(results[0].data).toEqual([MOCK_SPORE]);
+      expect(listSpores).toHaveBeenCalledWith({
+        agent_id: TEST_AGENT_ID,
+        limit: DEFAULT_CONTEXT_QUERY_LIMIT,
+      });
+    });
+
+    it('passes custom limit to listSpores', async () => {
+      vi.mocked(listSpores).mockResolvedValue([]);
+
+      await executeContextQueries(TEST_AGENT_ID, [
+        makeQuery({ tool: 'vault_spores', limit: 20 }),
+      ]);
+
+      expect(listSpores).toHaveBeenCalledWith({
+        agent_id: TEST_AGENT_ID,
+        limit: 20,
+      });
+    });
+  });
+
+  describe('vault_sessions', () => {
+    it('executes query and returns data', async () => {
+      vi.mocked(listSessions).mockResolvedValue([MOCK_SESSION] as never);
+
+      const results = await executeContextQueries(TEST_AGENT_ID, [
+        makeQuery({ tool: 'vault_sessions', purpose: 'list recent sessions' }),
+      ]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].tool).toBe('vault_sessions');
+      expect(results[0].data).toEqual([MOCK_SESSION]);
+      expect(listSessions).toHaveBeenCalledWith({ limit: DEFAULT_CONTEXT_QUERY_LIMIT });
+    });
+  });
+
+  describe('vault_state', () => {
+    it('executes query with agent_id and returns data', async () => {
+      vi.mocked(getStatesForAgent).mockResolvedValue([MOCK_STATE]);
+
+      const results = await executeContextQueries(TEST_AGENT_ID, [
+        makeQuery({ tool: 'vault_state', purpose: 'read cursor position' }),
+      ]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].tool).toBe('vault_state');
+      expect(results[0].data).toEqual([MOCK_STATE]);
+      expect(getStatesForAgent).toHaveBeenCalledWith(TEST_AGENT_ID);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns error field for failed non-required query (does not throw)', async () => {
+      vi.mocked(getUnprocessedBatches).mockRejectedValue(new Error('DB unavailable'));
+
+      const results = await executeContextQueries(TEST_AGENT_ID, [
+        makeQuery({ tool: 'vault_unprocessed', required: false }),
+      ]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].data).toBeNull();
+      expect(results[0].error).toBe('DB unavailable');
+    });
+
+    it('throws on failed required query', async () => {
+      vi.mocked(listSpores).mockRejectedValue(new Error('Connection lost'));
+
+      await expect(
+        executeContextQueries(TEST_AGENT_ID, [
+          makeQuery({ tool: 'vault_spores', required: true }),
+        ]),
+      ).rejects.toThrow('Required context query "vault_spores" failed: Connection lost');
+    });
+
+    it('throws on unknown tool name', async () => {
+      await expect(
+        executeContextQueries(TEST_AGENT_ID, [
+          makeQuery({ tool: 'vault_nonexistent', required: false }),
+        ]),
+      ).rejects.toThrow('Unknown context query tool: "vault_nonexistent"');
+    });
+
+    it('throws on unknown tool name even when required is false', async () => {
+      await expect(
+        executeContextQueries(TEST_AGENT_ID, [
+          makeQuery({ tool: 'vault_unknown', required: false }),
+        ]),
+      ).rejects.toThrow('Unknown context query tool: "vault_unknown"');
+    });
+  });
+
+  describe('limit handling', () => {
+    it('uses default limit when query.limit not specified', async () => {
+      vi.mocked(getUnprocessedBatches).mockResolvedValue([]);
+
+      // Build query directly without specifying limit to use the type default
+      const query: ContextQuery = {
+        tool: 'vault_unprocessed',
+        queryTemplate: '',
+        limit: DEFAULT_CONTEXT_QUERY_LIMIT,
+        purpose: 'test',
+        required: false,
+      };
+
+      await executeContextQueries(TEST_AGENT_ID, [query]);
+
+      expect(getUnprocessedBatches).toHaveBeenCalledWith({ limit: DEFAULT_CONTEXT_QUERY_LIMIT });
+    });
+
+    it('uses custom limit when specified', async () => {
+      vi.mocked(listSessions).mockResolvedValue([]);
+
+      await executeContextQueries(TEST_AGENT_ID, [
+        makeQuery({ tool: 'vault_sessions', limit: 50 }),
+      ]);
+
+      expect(listSessions).toHaveBeenCalledWith({ limit: 50 });
+    });
+  });
+
+  describe('multiple queries', () => {
+    it('executes multiple queries and returns results in order', async () => {
+      vi.mocked(getUnprocessedBatches).mockResolvedValue([MOCK_BATCH] as never);
+      vi.mocked(getStatesForAgent).mockResolvedValue([MOCK_STATE]);
+
+      const results = await executeContextQueries(TEST_AGENT_ID, [
+        makeQuery({ tool: 'vault_unprocessed', purpose: 'backlog' }),
+        makeQuery({ tool: 'vault_state', purpose: 'cursor' }),
+      ]);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].tool).toBe('vault_unprocessed');
+      expect(results[1].tool).toBe('vault_state');
+    });
+
+    it('continues executing after a non-required failure', async () => {
+      vi.mocked(getUnprocessedBatches).mockRejectedValue(new Error('DB down'));
+      vi.mocked(getStatesForAgent).mockResolvedValue([MOCK_STATE]);
+
+      const results = await executeContextQueries(TEST_AGENT_ID, [
+        makeQuery({ tool: 'vault_unprocessed', required: false }),
+        makeQuery({ tool: 'vault_state', purpose: 'cursor' }),
+      ]);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].error).toBe('DB down');
+      expect(results[1].data).toEqual([MOCK_STATE]);
+    });
+  });
+});

--- a/tests/agent/context.test.ts
+++ b/tests/agent/context.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import { getDatabase } from '@myco/db/client.js';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
 import { upsertSession, type SessionInsert } from '@myco/db/queries/sessions.js';
 import { insertBatch, type BatchInsert } from '@myco/db/queries/batches.js';
 import { insertSpore, type SporeInsert } from '@myco/db/queries/spores.js';

--- a/tests/agent/context.test.ts
+++ b/tests/agent/context.test.ts
@@ -5,9 +5,9 @@
  * and verifies the markdown output of buildVaultContext.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase, getDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { getDatabase } from '@myco/db/client.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
 import { upsertSession, type SessionInsert } from '@myco/db/queries/sessions.js';
 import { insertBatch, type BatchInsert } from '@myco/db/queries/batches.js';
 import { insertSpore, type SporeInsert } from '@myco/db/queries/spores.js';
@@ -54,14 +54,11 @@ function makeSession(overrides: Partial<SessionInsert> = {}): SessionInsert {
 // ---------------------------------------------------------------------------
 
 describe('buildVaultContext', () => {
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
-    const db = await initDatabase(); // in-memory
-    await createSchema(db);
+    await cleanTestDb();
     await createAgent(TEST_AGENT_ID);
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   it('returns context with all zeros for empty vault', async () => {

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -14,7 +14,7 @@ import { upsertTask } from '@myco/db/queries/tasks.js';
 import { insertRun, getRun } from '@myco/db/queries/runs.js';
 import { epochSeconds } from '@myco/constants.js';
 import { composeTaskPrompt, composePhasePrompt } from '@myco/agent/executor.js';
-import type { PhaseDefinition, ExecutionConfig } from '@myco/agent/types.js';
+import type { PhaseDefinition, ExecutionConfig, OrchestratorConfig } from '@myco/agent/types.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -147,6 +147,9 @@ let mockYamlPhases: PhaseDefinition[] | undefined;
 /** Execution config to return from the registry mock. Set per-test. */
 let mockExecution: ExecutionConfig | undefined;
 
+/** Orchestrator config to return from the registry mock. Set per-test. */
+let mockOrchestratorConfig: OrchestratorConfig | undefined;
+
 vi.mock('@myco/agent/loader.js', async (importOriginal) => {
   const original = await importOriginal<typeof import('@myco/agent/loader.js')>();
   return {
@@ -205,6 +208,7 @@ vi.mock('@myco/agent/registry.js', () => ({
       isDefault: true,
       ...(mockYamlPhases ? { phases: mockYamlPhases } : {}),
       ...(mockExecution ? { execution: mockExecution } : {}),
+      ...(mockOrchestratorConfig ? { orchestrator: mockOrchestratorConfig } : {}),
     };
     tasks.set(TEST_TASK_NAME, task);
     return tasks;
@@ -293,6 +297,7 @@ function resetMockState(): void {
   mockErrorMessage = 'SDK exploded';
   mockYamlPhases = undefined;
   mockExecution = undefined;
+  mockOrchestratorConfig = undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -777,5 +782,142 @@ describe('runAgent — phased execution', () => {
     const run = await getRun(result.runId);
     expect(run!.tokens_used).toBe(5550);
     expect(run!.cost_usd).toBeCloseTo(0.0126);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Orchestrator tests
+  // ---------------------------------------------------------------------------
+
+  it('orchestrator disabled (default): runs all phases statically', async () => {
+    // No mockOrchestratorConfig set — orchestrator is disabled by default
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    await runAgent(TEST_VAULT_DIR);
+
+    // Exactly 3 query() calls — one per phase, no orchestrator call
+    expect(allQueryCalls.length).toBe(3);
+  });
+
+  it('orchestrator enabled: runs planning call before phases', async () => {
+    mockOrchestratorConfig = { enabled: true };
+
+    // mockResultTexts[0] = orchestrator JSON plan, then one per phase
+    mockResultTexts = [
+      JSON.stringify({
+        phases: [
+          { name: 'read-state', skip: false },
+          { name: 'extract', skip: false },
+          { name: 'report', skip: false },
+        ],
+        reasoning: 'Running all phases.',
+      }),
+      'Found 5 batches.',
+      'Created 3 spores.',
+      'Run complete.',
+    ];
+
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    const result = await runAgent(TEST_VAULT_DIR);
+
+    expect(result.status).toBe('completed');
+    // 1 orchestrator planning call + 3 phase calls = 4 total
+    expect(allQueryCalls.length).toBe(4);
+    // Orchestrator call uses no mcpServers (planning only)
+    const orchestratorCall = allQueryCalls[0];
+    expect((orchestratorCall.options as Record<string, unknown>).mcpServers).toBeUndefined();
+    expect((orchestratorCall.options as Record<string, unknown>).tools).toEqual([]);
+    // All 3 phases should have run
+    expect(result.phases!.length).toBe(3);
+  });
+
+  it('orchestrator skips non-required phase when directed', async () => {
+    // Make middle phase optional so orchestrator can skip it
+    mockYamlPhases = [
+      { name: 'read-state', prompt: 'Read state.', tools: ['vault_state'], maxTurns: 3, required: true },
+      { name: 'summarize', prompt: 'Update summaries.', tools: ['vault_sessions'], maxTurns: 5, required: false },
+      { name: 'report', prompt: 'Write report.', tools: ['vault_report'], maxTurns: 2, required: true },
+    ];
+    mockOrchestratorConfig = { enabled: true };
+
+    // Orchestrator plan skips the optional 'summarize' phase
+    mockResultTexts = [
+      JSON.stringify({
+        phases: [
+          { name: 'read-state', skip: false },
+          { name: 'summarize', skip: true, skipReason: 'No new sessions to summarize' },
+          { name: 'report', skip: false },
+        ],
+        reasoning: 'Skipping summarize — no new sessions.',
+      }),
+      'Vault state read.',
+      'Report written.',
+    ];
+
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    const result = await runAgent(TEST_VAULT_DIR);
+
+    expect(result.status).toBe('completed');
+    // 1 orchestrator + 2 phase calls (summarize was skipped)
+    expect(allQueryCalls.length).toBe(3);
+    // Only 2 phase results (read-state + report)
+    expect(result.phases!.length).toBe(2);
+    expect(result.phases!.map((p) => p.name)).toEqual(['read-state', 'report']);
+  });
+
+  it('orchestrator cannot skip required phase', async () => {
+    mockOrchestratorConfig = { enabled: true };
+
+    // Orchestrator attempts to skip the required 'extract' phase
+    mockResultTexts = [
+      JSON.stringify({
+        phases: [
+          { name: 'read-state', skip: false },
+          { name: 'extract', skip: true, skipReason: 'Looks clean' },
+          { name: 'report', skip: false },
+        ],
+        reasoning: 'Tried to skip required phase.',
+      }),
+      'State read.',
+      'Extracted anyway.',
+      'Report done.',
+    ];
+
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    const result = await runAgent(TEST_VAULT_DIR);
+
+    expect(result.status).toBe('completed');
+    // 1 orchestrator + 3 phase calls — required phase cannot be skipped
+    expect(allQueryCalls.length).toBe(4);
+    expect(result.phases!.length).toBe(3);
+    expect(result.phases!.map((p) => p.name)).toEqual(['read-state', 'extract', 'report']);
+  });
+
+  it('orchestrator adjusts turn budget per directive', async () => {
+    mockOrchestratorConfig = { enabled: true };
+
+    // Plan overrides maxTurns for the extract phase
+    mockResultTexts = [
+      JSON.stringify({
+        phases: [
+          { name: 'read-state', skip: false },
+          { name: 'extract', skip: false, maxTurns: 7 },
+          { name: 'report', skip: false },
+        ],
+        reasoning: 'Extract needs more turns than usual.',
+      }),
+      'State read.',
+      'Extracted spores.',
+      'Report done.',
+    ];
+
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    await runAgent(TEST_VAULT_DIR);
+
+    // Phase calls start at index 1 (index 0 is orchestrator)
+    expect((allQueryCalls[2].options as Record<string, unknown>).maxTurns).toBe(7);
   });
 });

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -484,13 +484,13 @@ describe('runAgent', () => {
     const result = await runAgent(TEST_VAULT_DIR);
 
     expect(result.status).toBe('failed');
-    expect(result.error).toBe('API rate limit exceeded');
+    expect(result.error).toContain('API rate limit exceeded');
     expect(result.runId).toBeDefined();
 
     const run = await getRun(result.runId);
     expect(run).not.toBeNull();
     expect(run!.status).toBe('failed');
-    expect(run!.error).toBe('API rate limit exceeded');
+    expect(run!.error).toContain('API rate limit exceeded');
     expect(run!.completed_at).toBeGreaterThan(0);
   });
 

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -6,9 +6,9 @@
  * instance with the full schema.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase, getDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+import { getDatabase } from '@myco/db/client.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import { upsertTask } from '@myco/db/queries/tasks.js';
 import { insertRun, getRun } from '@myco/db/queries/runs.js';
@@ -411,16 +411,13 @@ describe('composePhasePrompt', () => {
 // ---------------------------------------------------------------------------
 
 describe('runAgent', () => {
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
     resetMockState();
-    const db = await initDatabase();
-    await createSchema(db);
+    await cleanTestDb();
     await createTestAgent(TEST_AGENT_ID);
     await createTestTask();
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   it('completes a successful run with cost and token tracking', async () => {
@@ -607,18 +604,14 @@ describe('runAgent — phased execution', () => {
     },
   ];
 
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
     resetMockState();
     mockYamlPhases = TEST_PHASES;
-
-    const db = await initDatabase();
-    await createSchema(db);
+    await cleanTestDb();
     await createTestAgent(TEST_AGENT_ID);
     await createTestTask();
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   it('executes all phases sequentially', async () => {

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -13,7 +13,8 @@ import { registerAgent } from '@myco/db/queries/agents.js';
 import { upsertTask } from '@myco/db/queries/tasks.js';
 import { insertRun, getRun } from '@myco/db/queries/runs.js';
 import { epochSeconds } from '@myco/constants.js';
-import { composeTaskPrompt } from '@myco/agent/executor.js';
+import { composeTaskPrompt, composePhasePrompt } from '@myco/agent/executor.js';
+import type { PhaseDefinition } from '@myco/agent/types.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -32,29 +33,51 @@ const epochNow = () => Math.floor(Date.now() / 1000);
 // Mock: Agent SDK query
 // ---------------------------------------------------------------------------
 
-/** Captured arguments from the last query() call. */
+/** Captured arguments from ALL query() calls (supports phased execution). */
+let allQueryCalls: Array<{ prompt: string; options?: Record<string, unknown> }> = [];
+
+/** Captured arguments from the last query() call (backward compat). */
 let capturedQueryArgs: { prompt: string; options?: Record<string, unknown> } | null = null;
 
-/** Controls what the mock query() yields. Set per-test. */
+/**
+ * Per-call behaviors. Each query() call shifts the next behavior.
+ * Falls back to mockQueryBehavior when exhausted.
+ */
+let mockQueryBehaviors: Array<'success' | 'error' | 'empty'> = [];
+
+/** Default behavior when mockQueryBehaviors is empty. */
 let mockQueryBehavior: 'success' | 'error' | 'empty' = 'success';
 
 /** Custom error message for the 'error' behavior. */
 let mockErrorMessage = 'SDK exploded';
 
+/** Per-call result text. Shifts the next value per query() call. */
+let mockResultTexts: string[] = [];
+
+/** Default result text for successful queries. */
+const DEFAULT_RESULT_TEXT = 'Agent run complete.';
+
 vi.mock('@anthropic-ai/claude-agent-sdk', () => {
   return {
     query: (args: { prompt: string; options?: Record<string, unknown> }) => {
       capturedQueryArgs = args;
+      allQueryCalls.push(args);
 
-      // Return an async generator
+      const behavior = mockQueryBehaviors.length > 0
+        ? mockQueryBehaviors.shift()!
+        : mockQueryBehavior;
+
+      const resultText = mockResultTexts.length > 0
+        ? mockResultTexts.shift()!
+        : DEFAULT_RESULT_TEXT;
+
       return {
         [Symbol.asyncIterator]: async function* () {
-          if (mockQueryBehavior === 'error') {
+          if (behavior === 'error') {
             throw new Error(mockErrorMessage);
           }
 
-          if (mockQueryBehavior === 'success') {
-            // Yield a result message matching SDKResultMessage shape
+          if (behavior === 'success') {
             yield {
               type: 'result' as const,
               subtype: 'success' as const,
@@ -69,7 +92,7 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => {
               duration_ms: 5000,
               duration_api_ms: 4500,
               is_error: false,
-              result: 'Agent run complete.',
+              result: resultText,
               stop_reason: 'end_turn',
               modelUsage: {},
               permission_denials: [],
@@ -77,9 +100,8 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => {
               session_id: 'test-session',
             };
           }
-          // 'empty': yields nothing — for await loop ends without a result
+          // 'empty': yields nothing
         },
-        // Methods on the Query object that we don't use but exist on the type
         interrupt: async () => {},
         setPermissionMode: async () => {},
         setModel: async () => {},
@@ -103,7 +125,6 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => {
         throw: async () => ({ done: true, value: undefined }),
       };
     },
-    // Also mock createSdkMcpServer and tool since tools.ts imports them
     createSdkMcpServer: (opts: Record<string, unknown>) => ({
       type: 'sdk' as const,
       instance: {},
@@ -120,6 +141,9 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => {
 // Mock: loader (avoid filesystem reads for definitions)
 // ---------------------------------------------------------------------------
 
+/** YAML phases to return from the loader mock. Set per-test. */
+let mockYamlPhases: PhaseDefinition[] | undefined;
+
 vi.mock('@myco/agent/loader.js', async (importOriginal) => {
   const original = await importOriginal<typeof import('@myco/agent/loader.js')>();
   return {
@@ -135,13 +159,35 @@ vi.mock('@myco/agent/loader.js', async (importOriginal) => {
       systemPromptPath: 'prompts/system.md',
       tools: ['vault_unprocessed', 'vault_create_spore'],
     }),
+    loadAgentTasks: () => {
+      // Return a task with phases if mockYamlPhases is set
+      if (mockYamlPhases) {
+        return [{
+          name: TEST_TASK_NAME,
+          displayName: 'Full Intelligence',
+          description: 'Run full intelligence pipeline',
+          agent: 'myco-agent',
+          prompt: 'Phased pipeline overview.',
+          isDefault: true,
+          phases: mockYamlPhases,
+        }];
+      }
+      return [{
+        name: TEST_TASK_NAME,
+        displayName: 'Full Intelligence',
+        description: 'Run full intelligence pipeline',
+        agent: 'myco-agent',
+        prompt: TEST_TASK_PROMPT,
+        isDefault: true,
+      }];
+    },
     loadSystemPrompt: () => TEST_SYSTEM_PROMPT,
     // Keep resolveEffectiveConfig from the original module
   };
 });
 
 // ---------------------------------------------------------------------------
-// Mock: context (avoid DB queries in buildVaultContext since we test it separately)
+// Mock: context
 // ---------------------------------------------------------------------------
 
 vi.mock('@myco/agent/context.js', () => ({
@@ -149,8 +195,11 @@ vi.mock('@myco/agent/context.js', () => ({
 }));
 
 // ---------------------------------------------------------------------------
-// Mock: tools (avoid importing real Agent SDK tool/createSdkMcpServer at module level)
+// Mock: tools (track scoped tool server calls)
 // ---------------------------------------------------------------------------
+
+/** Captured calls to createScopedVaultToolServer. */
+let scopedToolCalls: Array<{ agentId: string; runId: string; toolNames: string[] }> = [];
 
 vi.mock('@myco/agent/tools.js', () => ({
   createVaultToolServer: (_agentId: string, _runId: string) => ({
@@ -158,6 +207,14 @@ vi.mock('@myco/agent/tools.js', () => ({
     name: 'myco-vault',
     instance: {},
   }),
+  createScopedVaultToolServer: (agentId: string, runId: string, toolNames: string[]) => {
+    scopedToolCalls.push({ agentId, runId, toolNames });
+    return {
+      type: 'sdk' as const,
+      name: 'myco-vault',
+      instance: {},
+    };
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -168,7 +225,6 @@ vi.mock('@myco/db/client.js', async (importOriginal) => {
   const original = await importOriginal<typeof import('@myco/db/client.js')>();
   return {
     ...original,
-    // Override initDatabaseForVault to be a no-op (DB is already initialized in beforeEach)
     initDatabaseForVault: async () => original.getDatabase(),
   };
 });
@@ -177,7 +233,6 @@ vi.mock('@myco/db/client.js', async (importOriginal) => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Insert an agent directly for test setup. */
 async function createTestAgent(id: string): Promise<void> {
   const now = epochNow();
   await registerAgent({
@@ -188,7 +243,6 @@ async function createTestAgent(id: string): Promise<void> {
   });
 }
 
-/** Insert a default task for the test agent. */
 async function createTestTask(): Promise<void> {
   const now = epochNow();
   await upsertTask({
@@ -203,8 +257,20 @@ async function createTestTask(): Promise<void> {
   });
 }
 
+/** Resets all mock state between tests. */
+function resetMockState(): void {
+  capturedQueryArgs = null;
+  allQueryCalls = [];
+  scopedToolCalls = [];
+  mockQueryBehavior = 'success';
+  mockQueryBehaviors = [];
+  mockResultTexts = [];
+  mockErrorMessage = 'SDK exploded';
+  mockYamlPhases = undefined;
+}
+
 // ---------------------------------------------------------------------------
-// Tests
+// Tests: composeTaskPrompt
 // ---------------------------------------------------------------------------
 
 describe('composeTaskPrompt', () => {
@@ -235,13 +301,88 @@ describe('composeTaskPrompt', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Tests: composePhasePrompt
+// ---------------------------------------------------------------------------
+
+describe('composePhasePrompt', () => {
+  const vaultContext = '## Vault State\nspores: 10';
+  const taskName = 'Full Intelligence';
+  const taskOverview = 'Complete intelligence pipeline.';
+
+  it('composes vault context + task overview + phase prompt', () => {
+    const result = composePhasePrompt(
+      vaultContext,
+      taskName,
+      taskOverview,
+      { name: 'extract', prompt: 'Extract spores from batches.', tools: [], maxTurns: 5, required: true },
+      [],
+    );
+
+    expect(result).toContain('## Vault State');
+    expect(result).toContain('## Task: Full Intelligence');
+    expect(result).toContain('Complete intelligence pipeline.');
+    expect(result).toContain('## Current Phase: extract');
+    expect(result).toContain('Extract spores from batches.');
+    expect(result).not.toContain('## Prior Phase Results');
+  });
+
+  it('includes prior phase results when available', () => {
+    const result = composePhasePrompt(
+      vaultContext,
+      taskName,
+      taskOverview,
+      { name: 'consolidate', prompt: 'Consolidate spores.', tools: [], maxTurns: 5, required: true },
+      [
+        { name: 'extract', status: 'completed', turnsUsed: 3, tokensUsed: 500, costUsd: 0.001, summary: 'Created 5 spores.' },
+        { name: 'summarize', status: 'completed', turnsUsed: 2, tokensUsed: 300, costUsd: 0.0005, summary: 'Updated 2 sessions.' },
+      ],
+    );
+
+    expect(result).toContain('## Prior Phase Results');
+    expect(result).toContain('### extract (completed)');
+    expect(result).toContain('Created 5 spores.');
+    expect(result).toContain('### summarize (completed)');
+    expect(result).toContain('Updated 2 sessions.');
+  });
+
+  it('truncates long phase summaries', () => {
+    const longSummary = 'A'.repeat(3000);
+    const result = composePhasePrompt(
+      vaultContext,
+      taskName,
+      taskOverview,
+      { name: 'graph', prompt: 'Build graph.', tools: [], maxTurns: 5, required: true },
+      [{ name: 'extract', status: 'completed', turnsUsed: 3, tokensUsed: 500, costUsd: 0.001, summary: longSummary }],
+    );
+
+    expect(result).toContain('...');
+    expect(result.indexOf(longSummary)).toBe(-1);
+  });
+
+  it('includes user instruction when provided', () => {
+    const result = composePhasePrompt(
+      vaultContext,
+      taskName,
+      taskOverview,
+      { name: 'extract', prompt: 'Extract spores.', tools: [], maxTurns: 5, required: true },
+      [],
+      'Focus on security issues.',
+    );
+
+    expect(result).toContain('## User Instruction');
+    expect(result).toContain('Focus on security issues.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: runAgent (non-phased, backward compatibility)
+// ---------------------------------------------------------------------------
+
 describe('runAgent', () => {
   beforeEach(async () => {
-    capturedQueryArgs = null;
-    mockQueryBehavior = 'success';
-    mockErrorMessage = 'SDK exploded';
-
-    const db = await initDatabase(); // in-memory
+    resetMockState();
+    const db = await initDatabase();
     await createSchema(db);
     await createTestAgent(TEST_AGENT_ID);
     await createTestTask();
@@ -252,17 +393,15 @@ describe('runAgent', () => {
   });
 
   it('completes a successful run with cost and token tracking', async () => {
-    // Dynamic import to get the version with mocks applied
     const { runAgent } = await import('@myco/agent/executor.js');
 
     const result = await runAgent(TEST_VAULT_DIR);
 
     expect(result.status).toBe('completed');
     expect(result.runId).toBeDefined();
-    expect(result.tokensUsed).toBe(1850); // 1500 + 350
+    expect(result.tokensUsed).toBe(1850);
     expect(result.costUsd).toBe(0.0042);
 
-    // Verify run record in DB
     const run = await getRun(result.runId);
     expect(run).not.toBeNull();
     expect(run!.status).toBe('completed');
@@ -289,7 +428,6 @@ describe('runAgent', () => {
   it('returns skipped when a run is already active for the agent', async () => {
     const { runAgent } = await import('@myco/agent/executor.js');
 
-    // Insert a running run for the same agent
     const existingRunId = crypto.randomUUID();
     await insertRun({
       id: existingRunId,
@@ -303,7 +441,6 @@ describe('runAgent', () => {
     expect(result.status).toBe('skipped');
     expect(result.reason).toBe('already_running');
     expect(result.runId).toBe(existingRunId);
-    // query() should NOT have been called
     expect(capturedQueryArgs).toBeNull();
   });
 
@@ -319,7 +456,6 @@ describe('runAgent', () => {
     expect(result.error).toBe('API rate limit exceeded');
     expect(result.runId).toBeDefined();
 
-    // Verify run record in DB
     const run = await getRun(result.runId);
     expect(run).not.toBeNull();
     expect(run!.status).toBe('failed');
@@ -336,11 +472,9 @@ describe('runAgent', () => {
 
     expect(result.status).toBe('completed');
 
-    // Verify instruction in run record
     const run = await getRun(result.runId);
     expect(run!.instruction).toBe('Focus on security observations only.');
 
-    // Verify instruction appears in the composed prompt
     expect(capturedQueryArgs!.prompt).toContain('## User Instruction');
     expect(capturedQueryArgs!.prompt).toContain('Focus on security observations only.');
   });
@@ -358,14 +492,12 @@ describe('runAgent', () => {
     expect(opts.allowDangerouslySkipPermissions).toBe(true);
     expect(opts.persistSession).toBe(false);
     expect(opts.mcpServers).toBeDefined();
-    // Tools should be empty array (all tools come from MCP server)
     expect(opts.tools).toEqual([]);
   });
 
   it('resolves config with agent DB overrides', async () => {
     const { runAgent } = await import('@myco/agent/executor.js');
 
-    // Update the agent with a different model
     const db = getDatabase();
     await db.query(
       `UPDATE agents SET model = $1, max_turns = $2 WHERE id = $3`,
@@ -377,5 +509,223 @@ describe('runAgent', () => {
     const opts = capturedQueryArgs!.options as Record<string, unknown>;
     expect(opts.model).toBe('claude-opus-4-20250514');
     expect(opts.maxTurns).toBe(20);
+  });
+
+  it('does not return phases for non-phased tasks', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    const result = await runAgent(TEST_VAULT_DIR);
+
+    expect(result.status).toBe('completed');
+    expect(result.phases).toBeUndefined();
+    expect(allQueryCalls.length).toBe(1);
+    expect(scopedToolCalls.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: runAgent — phased execution
+// ---------------------------------------------------------------------------
+
+describe('runAgent — phased execution', () => {
+  const TEST_PHASES: PhaseDefinition[] = [
+    {
+      name: 'read-state',
+      prompt: 'Read vault state.',
+      tools: ['vault_state', 'vault_unprocessed'],
+      maxTurns: 3,
+      required: true,
+    },
+    {
+      name: 'extract',
+      prompt: 'Extract spores from batches.',
+      tools: ['vault_unprocessed', 'vault_create_spore', 'vault_mark_processed'],
+      maxTurns: 15,
+      required: true,
+    },
+    {
+      name: 'report',
+      prompt: 'Write final report.',
+      tools: ['vault_report'],
+      maxTurns: 2,
+      required: true,
+    },
+  ];
+
+  beforeEach(async () => {
+    resetMockState();
+    mockYamlPhases = TEST_PHASES;
+
+    const db = await initDatabase();
+    await createSchema(db);
+    await createTestAgent(TEST_AGENT_ID);
+    await createTestTask();
+  });
+
+  afterEach(async () => {
+    await closeDatabase();
+  });
+
+  it('executes all phases sequentially', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    mockResultTexts = [
+      'Found 5 unprocessed batches.',
+      'Created 3 spores.',
+      'Run complete.',
+    ];
+
+    const result = await runAgent(TEST_VAULT_DIR);
+
+    expect(result.status).toBe('completed');
+    // 3 phases = 3 query() calls
+    expect(allQueryCalls.length).toBe(3);
+    // All phases should use scoped tools
+    expect(scopedToolCalls.length).toBe(3);
+  });
+
+  it('returns per-phase results with token tracking', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    const result = await runAgent(TEST_VAULT_DIR);
+
+    expect(result.phases).toBeDefined();
+    expect(result.phases!.length).toBe(3);
+
+    expect(result.phases![0].name).toBe('read-state');
+    expect(result.phases![0].status).toBe('completed');
+    expect(result.phases![0].tokensUsed).toBe(1850);
+    expect(result.phases![0].costUsd).toBe(0.0042);
+    expect(result.phases![0].turnsUsed).toBe(3);
+
+    expect(result.phases![1].name).toBe('extract');
+    expect(result.phases![2].name).toBe('report');
+
+    // Total should be sum of all phases
+    expect(result.tokensUsed).toBe(1850 * 3);
+    expect(result.costUsd).toBeCloseTo(0.0042 * 3);
+  });
+
+  it('scopes tools per phase', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    await runAgent(TEST_VAULT_DIR);
+
+    expect(scopedToolCalls.length).toBe(3);
+    expect(scopedToolCalls[0].toolNames).toEqual(['vault_state', 'vault_unprocessed']);
+    expect(scopedToolCalls[1].toolNames).toEqual(['vault_unprocessed', 'vault_create_spore', 'vault_mark_processed']);
+    expect(scopedToolCalls[2].toolNames).toEqual(['vault_report']);
+  });
+
+  it('passes phase-specific maxTurns to SDK', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    await runAgent(TEST_VAULT_DIR);
+
+    expect(allQueryCalls.length).toBe(3);
+    expect((allQueryCalls[0].options as Record<string, unknown>).maxTurns).toBe(3);
+    expect((allQueryCalls[1].options as Record<string, unknown>).maxTurns).toBe(15);
+    expect((allQueryCalls[2].options as Record<string, unknown>).maxTurns).toBe(2);
+  });
+
+  it('includes prior phase summaries in later phase prompts', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    mockResultTexts = [
+      'Found 5 batches to process.',
+      'Extracted 3 spores from 5 batches.',
+      'Done.',
+    ];
+
+    await runAgent(TEST_VAULT_DIR);
+
+    // Phase 1 prompt should NOT have prior results
+    expect(allQueryCalls[0].prompt).not.toContain('## Prior Phase Results');
+    expect(allQueryCalls[0].prompt).toContain('## Current Phase: read-state');
+
+    // Phase 2 prompt should have phase 1 results
+    expect(allQueryCalls[1].prompt).toContain('## Prior Phase Results');
+    expect(allQueryCalls[1].prompt).toContain('### read-state (completed)');
+    expect(allQueryCalls[1].prompt).toContain('Found 5 batches to process.');
+    expect(allQueryCalls[1].prompt).toContain('## Current Phase: extract');
+
+    // Phase 3 prompt should have phases 1 and 2
+    expect(allQueryCalls[2].prompt).toContain('### read-state (completed)');
+    expect(allQueryCalls[2].prompt).toContain('### extract (completed)');
+    expect(allQueryCalls[2].prompt).toContain('Extracted 3 spores from 5 batches.');
+  });
+
+  it('stops pipeline when a required phase fails', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    // Phase 1 succeeds, phase 2 (extract, required) fails
+    mockQueryBehaviors = ['success', 'error', 'success'];
+    mockErrorMessage = 'Model unavailable';
+
+    const result = await runAgent(TEST_VAULT_DIR);
+
+    expect(result.status).toBe('completed'); // run-level status still completed
+    expect(result.phases!.length).toBe(2); // stopped after phase 2 failed
+    expect(result.phases![0].status).toBe('completed');
+    expect(result.phases![1].status).toBe('failed');
+    expect(result.phases![1].summary).toContain('Model unavailable');
+    // Phase 3 (report) should NOT have run
+    expect(allQueryCalls.length).toBe(2);
+  });
+
+  it('continues pipeline when an optional phase fails', async () => {
+    // Override phases to make the middle one optional
+    mockYamlPhases = [
+      { name: 'read-state', prompt: 'Read state.', tools: ['vault_state'], maxTurns: 3, required: true },
+      { name: 'summarize', prompt: 'Update summaries.', tools: ['vault_sessions'], maxTurns: 5, required: false },
+      { name: 'report', prompt: 'Write report.', tools: ['vault_report'], maxTurns: 2, required: true },
+    ];
+
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    // Phase 1 succeeds, phase 2 (optional) fails, phase 3 succeeds
+    mockQueryBehaviors = ['success', 'error', 'success'];
+    mockErrorMessage = 'Timeout';
+
+    const result = await runAgent(TEST_VAULT_DIR);
+
+    expect(result.phases!.length).toBe(3);
+    expect(result.phases![0].status).toBe('completed');
+    expect(result.phases![1].status).toBe('failed');
+    expect(result.phases![2].status).toBe('completed');
+    // All 3 query() calls should have been made
+    expect(allQueryCalls.length).toBe(3);
+  });
+
+  it('uses phase-specific model when provided', async () => {
+    mockYamlPhases = [
+      { name: 'extract', prompt: 'Extract.', tools: ['vault_unprocessed'], maxTurns: 20, model: 'claude-haiku-4-5', required: true },
+      { name: 'graph', prompt: 'Build graph.', tools: ['vault_create_entity'], maxTurns: 10, required: true },
+    ];
+
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    await runAgent(TEST_VAULT_DIR);
+
+    expect(allQueryCalls.length).toBe(2);
+    // Phase 1 should use the phase-specific model
+    expect((allQueryCalls[0].options as Record<string, unknown>).model).toBe('claude-haiku-4-5');
+    // Phase 2 should fall back to the task/agent model
+    expect((allQueryCalls[1].options as Record<string, unknown>).model).toBe('claude-sonnet-4-20250514');
+  });
+
+  it('records correct aggregate tokens and cost', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    const result = await runAgent(TEST_VAULT_DIR);
+
+    // Each phase: 1850 tokens, $0.0042 — 3 phases total
+    expect(result.tokensUsed).toBe(5550);
+    expect(result.costUsd).toBeCloseTo(0.0126);
+
+    // Verify DB record
+    const run = await getRun(result.runId);
+    expect(run!.tokens_used).toBe(5550);
+    expect(run!.cost_usd).toBeCloseTo(0.0126);
   });
 });

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -14,7 +14,7 @@ import { upsertTask } from '@myco/db/queries/tasks.js';
 import { insertRun, getRun } from '@myco/db/queries/runs.js';
 import { epochSeconds } from '@myco/constants.js';
 import { composeTaskPrompt, composePhasePrompt } from '@myco/agent/executor.js';
-import type { PhaseDefinition } from '@myco/agent/types.js';
+import type { PhaseDefinition, ExecutionConfig } from '@myco/agent/types.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -144,6 +144,9 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => {
 /** YAML phases to return from the loader mock. Set per-test. */
 let mockYamlPhases: PhaseDefinition[] | undefined;
 
+/** Execution config to return from the registry mock. Set per-test. */
+let mockExecution: ExecutionConfig | undefined;
+
 vi.mock('@myco/agent/loader.js', async (importOriginal) => {
   const original = await importOriginal<typeof import('@myco/agent/loader.js')>();
   return {
@@ -185,6 +188,28 @@ vi.mock('@myco/agent/loader.js', async (importOriginal) => {
     // Keep resolveEffectiveConfig from the original module
   };
 });
+
+// ---------------------------------------------------------------------------
+// Mock: registry (wraps loadAgentTasks — avoids filesystem reads)
+// ---------------------------------------------------------------------------
+
+vi.mock('@myco/agent/registry.js', () => ({
+  loadAllTasks: (_definitionsDir: string, _vaultDir?: string) => {
+    const tasks = new Map();
+    const task = {
+      name: TEST_TASK_NAME,
+      displayName: 'Full Intelligence',
+      description: 'Run full intelligence pipeline',
+      agent: 'myco-agent',
+      prompt: mockYamlPhases ? 'Phased pipeline overview.' : TEST_TASK_PROMPT,
+      isDefault: true,
+      ...(mockYamlPhases ? { phases: mockYamlPhases } : {}),
+      ...(mockExecution ? { execution: mockExecution } : {}),
+    };
+    tasks.set(TEST_TASK_NAME, task);
+    return tasks;
+  },
+}));
 
 // ---------------------------------------------------------------------------
 // Mock: context
@@ -267,6 +292,7 @@ function resetMockState(): void {
   mockResultTexts = [];
   mockErrorMessage = 'SDK exploded';
   mockYamlPhases = undefined;
+  mockExecution = undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -520,6 +546,30 @@ describe('runAgent', () => {
     expect(result.phases).toBeUndefined();
     expect(allQueryCalls.length).toBe(1);
     expect(scopedToolCalls.length).toBe(0);
+  });
+
+  it('execution.model overrides task.model', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    // Set execution config with a different model — no phases
+    mockExecution = { model: 'claude-haiku-4-5' };
+
+    await runAgent(TEST_VAULT_DIR);
+
+    const opts = capturedQueryArgs!.options as Record<string, unknown>;
+    expect(opts.model).toBe('claude-haiku-4-5');
+  });
+
+  it('execution.maxTurns overrides task.maxTurns', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    // Set execution config with a custom maxTurns
+    mockExecution = { maxTurns: 42 };
+
+    await runAgent(TEST_VAULT_DIR);
+
+    const opts = capturedQueryArgs!.options as Record<string, unknown>;
+    expect(opts.maxTurns).toBe(42);
   });
 });
 

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
 import { getDatabase } from '@myco/db/client.js';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import { upsertTask } from '@myco/db/queries/tasks.js';
 import { insertRun, getRun } from '@myco/db/queries/runs.js';

--- a/tests/agent/loader.test.ts
+++ b/tests/agent/loader.test.ts
@@ -8,11 +8,10 @@
  * - Registering built-in agents and tasks into PGlite
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { initDatabase, closeDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
 import { getAgent } from '@myco/db/queries/agents.js';
 import { listTasks, getDefaultTask } from '@myco/db/queries/tasks.js';
 import {
@@ -347,14 +346,9 @@ describe('agent loader', () => {
   // -------------------------------------------------------------------------
 
   describe('registerBuiltInAgentsAndTasks', () => {
-    beforeEach(async () => {
-      const db = await initDatabase(); // in-memory
-      await createSchema(db);
-    });
-
-    afterEach(async () => {
-      await closeDatabase();
-    });
+    beforeAll(async () => { await setupTestDb(); });
+    afterAll(async () => { await teardownTestDb(); });
+    beforeEach(async () => { await cleanTestDb(); });
 
     it('registers the built-in agent in the database', async () => {
       await registerBuiltInAgentsAndTasks(DEFINITIONS_DIR);

--- a/tests/agent/loader.test.ts
+++ b/tests/agent/loader.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
 import { getAgent } from '@myco/db/queries/agents.js';
 import { listTasks, getDefaultTask } from '@myco/db/queries/tasks.js';
 import {

--- a/tests/agent/orchestrator.test.ts
+++ b/tests/agent/orchestrator.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Tests for the orchestrator module.
+ *
+ * The prompt template file is mocked via vi.mock('node:fs') so tests never
+ * touch the real filesystem. Each test suite exercises one exported function.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock node:fs so readFileSync returns a controlled template
+// ---------------------------------------------------------------------------
+
+vi.mock('node:fs', () => ({
+  default: {
+    readFileSync: vi.fn(),
+  },
+  readFileSync: vi.fn(),
+}));
+
+import fs from 'node:fs';
+
+// Import after mocks are registered
+import {
+  composeOrchestratorPrompt,
+  parseOrchestratorPlan,
+  applyDirectives,
+} from '@myco/agent/orchestrator.js';
+import type { PhaseDefinition, OrchestratorPhaseDirective } from '@myco/agent/types.js';
+import type { ContextQueryResult } from '@myco/agent/context-queries.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Minimal orchestrator template with all three placeholders. */
+const TEST_TEMPLATE = `VAULT:\n{{vault_state}}\nPHASES:\n{{phase_definitions}}\nCONTEXT:\n{{context_results}}`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePhase(overrides: Partial<PhaseDefinition> = {}): PhaseDefinition {
+  return {
+    name: 'extract',
+    prompt: 'Extract observations from unprocessed batches.',
+    tools: ['vault_search'],
+    maxTurns: 10,
+    required: false,
+    ...overrides,
+  };
+}
+
+function makeContextResult(overrides: Partial<ContextQueryResult> = {}): ContextQueryResult {
+  return {
+    tool: 'vault_unprocessed',
+    purpose: 'Check batch backlog',
+    data: [{ id: 1 }],
+    ...overrides,
+  };
+}
+
+function makeDirective(overrides: Partial<OrchestratorPhaseDirective> = {}): OrchestratorPhaseDirective {
+  return {
+    name: 'extract',
+    skip: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reset mocks between tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(fs.readFileSync).mockReturnValue(TEST_TEMPLATE);
+});
+
+// ---------------------------------------------------------------------------
+// composeOrchestratorPrompt
+// ---------------------------------------------------------------------------
+
+describe('composeOrchestratorPrompt', () => {
+  it('substitutes vault state into the template', () => {
+    const result = composeOrchestratorPrompt('14 unprocessed batches', [], []);
+    expect(result).toContain('14 unprocessed batches');
+  });
+
+  it('substitutes phase definitions into the template', () => {
+    const phases = [makePhase({ name: 'extract', maxTurns: 15, required: true })];
+    const result = composeOrchestratorPrompt('state', phases, []);
+    expect(result).toContain('**extract**');
+    expect(result).toContain('maxTurns: 15');
+    expect(result).toContain('required: true');
+  });
+
+  it('substitutes context results into the template', () => {
+    const results = [makeContextResult({ tool: 'vault_unprocessed', purpose: 'backlog check' })];
+    const result = composeOrchestratorPrompt('state', [], results);
+    expect(result).toContain('vault_unprocessed');
+    expect(result).toContain('backlog check');
+  });
+
+  it('shows "No context queries configured." when context results are empty', () => {
+    const result = composeOrchestratorPrompt('state', [], []);
+    expect(result).toContain('No context queries configured.');
+  });
+
+  it('shows phase name, maxTurns, and required flag in the phase list', () => {
+    const phases = [
+      makePhase({ name: 'graph', maxTurns: 5, required: false }),
+    ];
+    const result = composeOrchestratorPrompt('state', phases, []);
+    expect(result).toContain('**graph**');
+    expect(result).toContain('maxTurns: 5');
+    expect(result).toContain('required: false');
+  });
+
+  it('truncates long phase prompts to 100 chars with ellipsis', () => {
+    const longPrompt = 'A'.repeat(200);
+    const phases = [makePhase({ prompt: longPrompt })];
+    const result = composeOrchestratorPrompt('state', phases, []);
+    // Should have 100 'A's followed by '...'
+    expect(result).toContain('A'.repeat(100) + '...');
+    // Should NOT contain 101 'A's followed by '...'
+    expect(result).not.toContain('A'.repeat(101) + '...');
+  });
+
+  it('does not add ellipsis when prompt fits within 100 chars', () => {
+    const shortPrompt = 'Short prompt.';
+    const phases = [makePhase({ prompt: shortPrompt })];
+    const result = composeOrchestratorPrompt('state', phases, []);
+    expect(result).toContain('Short prompt.');
+    expect(result).not.toContain('Short prompt....');
+  });
+
+  it('includes error text for context results with errors', () => {
+    const results = [
+      makeContextResult({ tool: 'vault_spores', error: 'DB unavailable', data: null }),
+    ];
+    const result = composeOrchestratorPrompt('state', [], results);
+    expect(result).toContain('Error: DB unavailable');
+  });
+
+  it('replaces all three placeholders', () => {
+    const result = composeOrchestratorPrompt('vault-state-text', [makePhase()], [makeContextResult()]);
+    expect(result).not.toContain('{{vault_state}}');
+    expect(result).not.toContain('{{phase_definitions}}');
+    expect(result).not.toContain('{{context_results}}');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseOrchestratorPlan
+// ---------------------------------------------------------------------------
+
+describe('parseOrchestratorPlan', () => {
+  it('parses a valid JSON response with phases array', () => {
+    const response = JSON.stringify({
+      phases: [{ name: 'extract', skip: false }],
+      reasoning: 'Run all phases.',
+    });
+    const plan = parseOrchestratorPlan(response, []);
+    expect(plan.phases).toHaveLength(1);
+    expect(plan.phases[0].name).toBe('extract');
+    expect(plan.reasoning).toBe('Run all phases.');
+  });
+
+  it('extracts JSON from a markdown ```json code block', () => {
+    const response = '```json\n{"phases":[{"name":"consolidate","skip":true,"skipReason":"no spores"}],"reasoning":"skip consolidate"}\n```';
+    const plan = parseOrchestratorPlan(response, []);
+    expect(plan.phases).toHaveLength(1);
+    expect(plan.phases[0].name).toBe('consolidate');
+    expect(plan.phases[0].skip).toBe(true);
+  });
+
+  it('falls back to run-all plan on malformed JSON', () => {
+    const phases = [makePhase({ name: 'extract' }), makePhase({ name: 'graph' })];
+    const plan = parseOrchestratorPlan('not valid json {{{', phases);
+    expect(plan.phases).toHaveLength(2);
+    expect(plan.phases.every((p) => p.skip === false)).toBe(true);
+    expect(plan.reasoning).toMatch(/could not be parsed/i);
+  });
+
+  it('falls back to run-all plan when phases array is missing', () => {
+    const response = JSON.stringify({ reasoning: 'all good' }); // no phases field
+    const phases = [makePhase({ name: 'extract' })];
+    const plan = parseOrchestratorPlan(response, phases);
+    expect(plan.phases).toHaveLength(1);
+    expect(plan.phases[0].name).toBe('extract');
+    expect(plan.phases[0].skip).toBe(false);
+    expect(plan.reasoning).toMatch(/missing phases/i);
+  });
+
+  it('falls back to run-all plan on empty string', () => {
+    const phases = [makePhase({ name: 'digest' })];
+    const plan = parseOrchestratorPlan('', phases);
+    expect(plan.phases).toHaveLength(1);
+    expect(plan.phases[0].name).toBe('digest');
+    expect(plan.phases[0].skip).toBe(false);
+  });
+
+  it('falls back to run-all plan when phases is not an array', () => {
+    const response = JSON.stringify({ phases: 'not-an-array', reasoning: 'bad' });
+    const phases = [makePhase({ name: 'extract' })];
+    const plan = parseOrchestratorPlan(response, phases);
+    expect(plan.phases).toHaveLength(1);
+    expect(plan.phases[0].skip).toBe(false);
+  });
+
+  it('returns empty phases array in run-all plan when no phases defined', () => {
+    const plan = parseOrchestratorPlan('bad json', []);
+    expect(plan.phases).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyDirectives
+// ---------------------------------------------------------------------------
+
+describe('applyDirectives', () => {
+  it('passes phases through unchanged when no matching directives exist', () => {
+    const phases = [
+      makePhase({ name: 'extract' }),
+      makePhase({ name: 'graph' }),
+    ];
+    const result = applyDirectives(phases, []);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe('extract');
+    expect(result[1].name).toBe('graph');
+  });
+
+  it('skips non-required phases when directive has skip: true', () => {
+    const phases = [
+      makePhase({ name: 'extract', required: false }),
+      makePhase({ name: 'graph', required: false }),
+    ];
+    const directives = [makeDirective({ name: 'extract', skip: true })];
+    const result = applyDirectives(phases, directives);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('graph');
+  });
+
+  it('refuses to skip required phases — keeps them and logs a warning', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const phases = [makePhase({ name: 'extract', required: true })];
+    const directives = [makeDirective({ name: 'extract', skip: true, skipReason: 'nothing to do' })];
+    const result = applyDirectives(phases, directives);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('extract');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('extract'));
+    warnSpy.mockRestore();
+  });
+
+  it('applies maxTurns override from directive', () => {
+    const phases = [makePhase({ name: 'extract', maxTurns: 10 })];
+    const directives = [makeDirective({ name: 'extract', skip: false, maxTurns: 25 })];
+    const result = applyDirectives(phases, directives);
+    expect(result[0].maxTurns).toBe(25);
+  });
+
+  it('does not override maxTurns when directive has no maxTurns', () => {
+    const phases = [makePhase({ name: 'extract', maxTurns: 10 })];
+    const directives = [makeDirective({ name: 'extract', skip: false })];
+    const result = applyDirectives(phases, directives);
+    expect(result[0].maxTurns).toBe(10);
+  });
+
+  it('appends contextNotes to phase prompt under ## Orchestrator Guidance', () => {
+    const phases = [makePhase({ name: 'extract', prompt: 'Original prompt.' })];
+    const directives = [
+      makeDirective({ name: 'extract', skip: false, contextNotes: '14 unprocessed batches.' }),
+    ];
+    const result = applyDirectives(phases, directives);
+    expect(result[0].prompt).toContain('Original prompt.');
+    expect(result[0].prompt).toContain('## Orchestrator Guidance');
+    expect(result[0].prompt).toContain('14 unprocessed batches.');
+  });
+
+  it('does not append guidance section when contextNotes is absent', () => {
+    const phases = [makePhase({ name: 'extract', prompt: 'Original prompt.' })];
+    const directives = [makeDirective({ name: 'extract', skip: false })];
+    const result = applyDirectives(phases, directives);
+    expect(result[0].prompt).toBe('Original prompt.');
+    expect(result[0].prompt).not.toContain('## Orchestrator Guidance');
+  });
+
+  it('preserves phase order when directives do not reorder', () => {
+    const phases = [
+      makePhase({ name: 'extract' }),
+      makePhase({ name: 'consolidate' }),
+      makePhase({ name: 'graph' }),
+      makePhase({ name: 'digest' }),
+    ];
+    const directives = [makeDirective({ name: 'graph', skip: false, maxTurns: 8 })];
+    const result = applyDirectives(phases, directives);
+    expect(result.map((p) => p.name)).toEqual(['extract', 'consolidate', 'graph', 'digest']);
+  });
+
+  it('handles directive for unknown phase name gracefully (ignores it)', () => {
+    const phases = [makePhase({ name: 'extract' })];
+    const directives = [makeDirective({ name: 'nonexistent', skip: true })];
+    const result = applyDirectives(phases, directives);
+    // Phase list unchanged; unknown directive silently ignored
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('extract');
+  });
+
+  it('applies multiple directives in a single call', () => {
+    const phases = [
+      makePhase({ name: 'extract', maxTurns: 10, required: false }),
+      makePhase({ name: 'graph', maxTurns: 5, required: false }),
+      makePhase({ name: 'digest', maxTurns: 3, required: false }),
+    ];
+    const directives = [
+      makeDirective({ name: 'extract', skip: false, maxTurns: 20 }),
+      makeDirective({ name: 'graph', skip: true }),
+      makeDirective({ name: 'digest', skip: false, contextNotes: 'Regenerate all tiers.' }),
+    ];
+    const result = applyDirectives(phases, directives);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe('extract');
+    expect(result[0].maxTurns).toBe(20);
+    expect(result[1].name).toBe('digest');
+    expect(result[1].prompt).toContain('Regenerate all tiers.');
+  });
+});

--- a/tests/agent/orchestrator.test.ts
+++ b/tests/agent/orchestrator.test.ts
@@ -14,8 +14,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('node:fs', () => ({
   default: {
     readFileSync: vi.fn(),
+    existsSync: vi.fn(() => true),
   },
   readFileSync: vi.fn(),
+  existsSync: vi.fn(() => true),
 }));
 
 import fs from 'node:fs';

--- a/tests/agent/provider.test.ts
+++ b/tests/agent/provider.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for provider environment variable management.
+ *
+ * vi.stubEnv / vi.unstubAllEnvs() are used for all env manipulation to avoid
+ * race conditions with other test files running in vitest's threads pool.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  applyProviderEnv,
+  restoreProviderEnv,
+  getProviderEnvVars,
+} from '@myco/agent/provider.js';
+import type { ProviderConfig } from '@myco/agent/types.js';
+
+// ---------------------------------------------------------------------------
+// Constants matching the implementation (used in assertions)
+// ---------------------------------------------------------------------------
+
+const ENV_ANTHROPIC_BASE_URL = 'ANTHROPIC_BASE_URL';
+const ENV_ANTHROPIC_AUTH_TOKEN = 'ANTHROPIC_AUTH_TOKEN';
+const ENV_ANTHROPIC_API_KEY = 'ANTHROPIC_API_KEY';
+const DEFAULT_OLLAMA_URL = 'http://localhost:11434';
+const DEFAULT_LMSTUDIO_URL = 'http://localhost:1234';
+const OLLAMA_AUTH_TOKEN = 'ollama';
+const LMSTUDIO_AUTH_TOKEN = 'lmstudio';
+
+// ---------------------------------------------------------------------------
+// Env cleanup
+// ---------------------------------------------------------------------------
+
+// Restore all env stubs after each test so mutations don't bleed between tests
+// or across parallel threads that share process.env.
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+// ---------------------------------------------------------------------------
+// applyProviderEnv + restoreProviderEnv
+// ---------------------------------------------------------------------------
+
+describe('applyProviderEnv + restoreProviderEnv', () => {
+  it('sets Ollama env vars and restores originals', () => {
+    // Arrange: pre-set a known value that should be overwritten then restored
+    vi.stubEnv(ENV_ANTHROPIC_BASE_URL, 'https://original-url.example.com');
+    const originalBaseUrl = process.env[ENV_ANTHROPIC_BASE_URL];
+
+    const provider: ProviderConfig = { type: 'ollama' };
+
+    // Act: apply
+    const saved = applyProviderEnv(provider);
+
+    // Assert: env vars are set for Ollama
+    expect(process.env[ENV_ANTHROPIC_BASE_URL]).toBe(DEFAULT_OLLAMA_URL);
+    expect(process.env[ENV_ANTHROPIC_AUTH_TOKEN]).toBe(OLLAMA_AUTH_TOKEN);
+    expect(process.env[ENV_ANTHROPIC_API_KEY]).toBe('');
+
+    // Act: restore
+    restoreProviderEnv(saved);
+
+    // Assert: original values are restored
+    expect(process.env[ENV_ANTHROPIC_BASE_URL]).toBe(originalBaseUrl);
+  });
+
+  it('sets LM Studio env vars and restores originals', () => {
+    vi.stubEnv(ENV_ANTHROPIC_AUTH_TOKEN, 'original-token');
+    const originalToken = process.env[ENV_ANTHROPIC_AUTH_TOKEN];
+
+    const provider: ProviderConfig = { type: 'lmstudio' };
+
+    const saved = applyProviderEnv(provider);
+
+    expect(process.env[ENV_ANTHROPIC_BASE_URL]).toBe(DEFAULT_LMSTUDIO_URL);
+    expect(process.env[ENV_ANTHROPIC_AUTH_TOKEN]).toBe(LMSTUDIO_AUTH_TOKEN);
+    expect(process.env[ENV_ANTHROPIC_API_KEY]).toBe('');
+
+    restoreProviderEnv(saved);
+
+    expect(process.env[ENV_ANTHROPIC_AUTH_TOKEN]).toBe(originalToken);
+  });
+
+  it('cloud provider sets no env vars', () => {
+    // Arrange: set values that should remain untouched
+    vi.stubEnv(ENV_ANTHROPIC_BASE_URL, 'https://cloud-url.example.com');
+    vi.stubEnv(ENV_ANTHROPIC_AUTH_TOKEN, 'cloud-token');
+
+    const provider: ProviderConfig = { type: 'cloud' };
+
+    const saved = applyProviderEnv(provider);
+
+    // Assert: nothing changed
+    expect(process.env[ENV_ANTHROPIC_BASE_URL]).toBe('https://cloud-url.example.com');
+    expect(process.env[ENV_ANTHROPIC_AUTH_TOKEN]).toBe('cloud-token');
+
+    // Restore is a no-op but should not throw
+    restoreProviderEnv(saved);
+
+    expect(process.env[ENV_ANTHROPIC_BASE_URL]).toBe('https://cloud-url.example.com');
+    expect(process.env[ENV_ANTHROPIC_AUTH_TOKEN]).toBe('cloud-token');
+  });
+
+  it('restores undefined vars by deleting them when var was not set before apply', () => {
+    // Ensure the vars are not present in the stub layer (they may or may not
+    // exist in the real env — we test that after restore they are absent).
+    // Note: vi.stubEnv sets a value; we can only test this for vars that were
+    // genuinely absent. We rely on the saved state capturing undefined.
+
+    // Use vars that are very unlikely to be in the real environment
+    const UNLIKELY_KEY_1 = 'MYCO_TEST_PROVIDER_SENTINEL_1';
+    const UNLIKELY_KEY_2 = 'MYCO_TEST_PROVIDER_SENTINEL_2';
+
+    // Manually verify they are absent, then test applyProviderEnv saves them as undefined
+    delete process.env[UNLIKELY_KEY_1];
+    delete process.env[UNLIKELY_KEY_2];
+
+    // Build a saved state manually to replicate "var not present before apply"
+    const saved = {
+      vars: {
+        [UNLIKELY_KEY_1]: undefined,
+        [UNLIKELY_KEY_2]: 'some-value',
+      },
+    };
+
+    // Set them so we can verify restoration
+    process.env[UNLIKELY_KEY_1] = 'was-set';
+    process.env[UNLIKELY_KEY_2] = 'was-set';
+
+    restoreProviderEnv(saved);
+
+    // UNLIKELY_KEY_1 was undefined → should be deleted
+    expect(UNLIKELY_KEY_1 in process.env).toBe(false);
+    // UNLIKELY_KEY_2 had a value → should be restored to that value
+    expect(process.env[UNLIKELY_KEY_2]).toBe('some-value');
+
+    // Cleanup
+    delete process.env[UNLIKELY_KEY_2];
+  });
+
+  it('applyProviderEnv captures undefined for vars not previously set', () => {
+    // Use a sentinel var that is guaranteed absent
+    const SENTINEL_KEY = 'MYCO_TEST_SENTINEL_APPLY_CAPTURE';
+    delete process.env[SENTINEL_KEY];
+
+    // Temporarily inject into provider env vars by testing the real Ollama path
+    // with a key we know starts absent: ANTHROPIC_AUTH_TOKEN is likely unset in CI
+    // We use vi.stubEnv to control the baseline cleanly.
+    // Verify applyProviderEnv saves the original (undefined) and restoreProviderEnv deletes it.
+    vi.unstubAllEnvs();
+
+    // Set up: env vars absent (unstub restores them to their real values —
+    // assume ANTHROPIC_AUTH_TOKEN is absent in test env)
+    const originalAuthToken = process.env[ENV_ANTHROPIC_AUTH_TOKEN];
+
+    const provider: ProviderConfig = { type: 'ollama' };
+    const saved = applyProviderEnv(provider);
+
+    // Confirm it was applied
+    expect(process.env[ENV_ANTHROPIC_AUTH_TOKEN]).toBe(OLLAMA_AUTH_TOKEN);
+
+    // Saved state should capture whatever was there before (could be undefined)
+    expect(saved.vars[ENV_ANTHROPIC_AUTH_TOKEN]).toBe(originalAuthToken);
+
+    restoreProviderEnv(saved);
+
+    // Should be back to the original value
+    expect(process.env[ENV_ANTHROPIC_AUTH_TOKEN]).toBe(originalAuthToken);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getProviderEnvVars
+// ---------------------------------------------------------------------------
+
+describe('getProviderEnvVars', () => {
+  it('returns correct vars for ollama with default URL', () => {
+    const provider: ProviderConfig = { type: 'ollama' };
+    const vars = getProviderEnvVars(provider);
+
+    expect(vars).toEqual({
+      [ENV_ANTHROPIC_BASE_URL]: DEFAULT_OLLAMA_URL,
+      [ENV_ANTHROPIC_AUTH_TOKEN]: OLLAMA_AUTH_TOKEN,
+      [ENV_ANTHROPIC_API_KEY]: '',
+    });
+  });
+
+  it('returns correct vars for ollama with custom URL', () => {
+    const provider: ProviderConfig = { type: 'ollama', baseUrl: 'http://my-ollama:11434' };
+    const vars = getProviderEnvVars(provider);
+
+    expect(vars[ENV_ANTHROPIC_BASE_URL]).toBe('http://my-ollama:11434');
+    expect(vars[ENV_ANTHROPIC_AUTH_TOKEN]).toBe(OLLAMA_AUTH_TOKEN);
+  });
+
+  it('returns correct vars for lmstudio', () => {
+    const provider: ProviderConfig = { type: 'lmstudio' };
+    const vars = getProviderEnvVars(provider);
+
+    expect(vars).toEqual({
+      [ENV_ANTHROPIC_BASE_URL]: DEFAULT_LMSTUDIO_URL,
+      [ENV_ANTHROPIC_AUTH_TOKEN]: LMSTUDIO_AUTH_TOKEN,
+      [ENV_ANTHROPIC_API_KEY]: '',
+    });
+  });
+
+  it('returns correct vars for lmstudio with custom apiKey', () => {
+    const provider: ProviderConfig = { type: 'lmstudio', apiKey: 'my-lmstudio-key' };
+    const vars = getProviderEnvVars(provider);
+
+    expect(vars[ENV_ANTHROPIC_AUTH_TOKEN]).toBe('my-lmstudio-key');
+    expect(vars[ENV_ANTHROPIC_API_KEY]).toBe('');
+  });
+
+  it('returns correct vars for lmstudio with custom baseUrl', () => {
+    const provider: ProviderConfig = {
+      type: 'lmstudio',
+      baseUrl: 'http://my-lmstudio:1234',
+    };
+    const vars = getProviderEnvVars(provider);
+
+    expect(vars[ENV_ANTHROPIC_BASE_URL]).toBe('http://my-lmstudio:1234');
+  });
+
+  it('returns empty object for cloud', () => {
+    const provider: ProviderConfig = { type: 'cloud' };
+    const vars = getProviderEnvVars(provider);
+
+    expect(vars).toEqual({});
+  });
+
+  it('returns empty object for unknown provider type', () => {
+    // Cast to bypass type checking — testing the default branch of the switch
+    const provider = { type: 'unknown' } as unknown as ProviderConfig;
+    const vars = getProviderEnvVars(provider);
+
+    expect(vars).toEqual({});
+  });
+});

--- a/tests/agent/registry.test.ts
+++ b/tests/agent/registry.test.ts
@@ -15,9 +15,13 @@ import { parse as parseYaml } from 'yaml';
 // Mock loadAgentTasks so tests don't depend on the real definitions dir
 // ---------------------------------------------------------------------------
 
-vi.mock('@myco/agent/loader.js', () => ({
-  loadAgentTasks: vi.fn(),
-}));
+vi.mock('@myco/agent/loader.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@myco/agent/loader.js')>();
+  return {
+    ...original,
+    loadAgentTasks: vi.fn(),
+  };
+});
 
 import { loadAgentTasks } from '@myco/agent/loader.js';
 import { loadAllTasks, validateTaskName, writeUserTask, deleteUserTask, copyTaskToUser } from '@myco/agent/registry.js';

--- a/tests/agent/registry.test.ts
+++ b/tests/agent/registry.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Tests for the user task registry.
+ *
+ * Uses fs.mkdtempSync for isolated temp directories. Built-in task loading
+ * is mocked via vi.mock to avoid depending on the actual definitions directory.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { parse as parseYaml } from 'yaml';
+
+// ---------------------------------------------------------------------------
+// Mock loadAgentTasks so tests don't depend on the real definitions dir
+// ---------------------------------------------------------------------------
+
+vi.mock('@myco/agent/loader.js', () => ({
+  loadAgentTasks: vi.fn(),
+}));
+
+import { loadAgentTasks } from '@myco/agent/loader.js';
+import { loadAllTasks, validateTaskName, writeUserTask, deleteUserTask, copyTaskToUser } from '@myco/agent/registry.js';
+import type { AgentTask } from '@myco/agent/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a temp directory for test isolation. Cleaned up in test. */
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'myco-registry-test-'));
+}
+
+/** Remove a temp directory recursively. */
+function removeTempDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+/** Build a minimal valid AgentTask. */
+function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    name: 'test-task',
+    displayName: 'Test Task',
+    description: 'A task for testing',
+    agent: 'myco-agent',
+    prompt: 'Do the thing.',
+    isDefault: false,
+    ...overrides,
+  };
+}
+
+/** Write a YAML file for a task into `vaultDir/tasks/`. */
+function writeTaskYaml(vaultDir: string, task: AgentTask): void {
+  const tasksDir = path.join(vaultDir, 'tasks');
+  fs.mkdirSync(tasksDir, { recursive: true });
+  const { isBuiltin: _isBuiltin, source: _source, ...serializable } = task;
+  fs.writeFileSync(
+    path.join(tasksDir, `${task.name}.yaml`),
+    JSON.stringify(serializable), // JSON is valid YAML
+    'utf-8',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// loadAllTasks
+// ---------------------------------------------------------------------------
+
+describe('loadAllTasks', () => {
+  beforeEach(() => {
+    vi.mocked(loadAgentTasks).mockReset();
+  });
+
+  it('discovers built-in tasks from definitions dir', () => {
+    const builtIn = makeTask({ name: 'full-intelligence', isDefault: true });
+    vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
+
+    const tasks = loadAllTasks('/fake/definitions');
+
+    expect(tasks.size).toBe(1);
+    expect(tasks.has('full-intelligence')).toBe(true);
+    expect(tasks.get('full-intelligence')!.source).toBe('built-in');
+    expect(tasks.get('full-intelligence')!.isBuiltin).toBe(true);
+  });
+
+  it('discovers user tasks from vault tasks dir', () => {
+    vi.mocked(loadAgentTasks).mockReturnValue([]);
+    const vaultDir = makeTempDir();
+    try {
+      writeTaskYaml(vaultDir, makeTask({ name: 'my-task' }));
+
+      const tasks = loadAllTasks('/fake/definitions', vaultDir);
+
+      expect(tasks.has('my-task')).toBe(true);
+      expect(tasks.get('my-task')!.source).toBe('user');
+      expect(tasks.get('my-task')!.isBuiltin).toBe(false);
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('user task with same name overrides built-in', () => {
+    const builtIn = makeTask({ name: 'digest-only', displayName: 'Built-in Digest' });
+    vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
+
+    const vaultDir = makeTempDir();
+    try {
+      writeTaskYaml(vaultDir, makeTask({ name: 'digest-only', displayName: 'User Digest' }));
+
+      const tasks = loadAllTasks('/fake/definitions', vaultDir);
+
+      expect(tasks.size).toBe(1);
+      expect(tasks.get('digest-only')!.displayName).toBe('User Digest');
+      expect(tasks.get('digest-only')!.source).toBe('user');
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('skips malformed user task YAML without crashing', () => {
+    vi.mocked(loadAgentTasks).mockReturnValue([]);
+    const vaultDir = makeTempDir();
+    try {
+      const tasksDir = path.join(vaultDir, 'tasks');
+      fs.mkdirSync(tasksDir, { recursive: true });
+      // Write a YAML file that is missing required fields
+      fs.writeFileSync(path.join(tasksDir, 'bad.yaml'), 'not: valid: task: yaml: : :', 'utf-8');
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const tasks = loadAllTasks('/fake/definitions', vaultDir);
+      warnSpy.mockRestore();
+
+      expect(tasks.size).toBe(0);
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateTaskName
+// ---------------------------------------------------------------------------
+
+describe('validateTaskName', () => {
+  it('accepts valid multi-word name', () => {
+    expect(validateTaskName('my-task')).toBe(true);
+  });
+
+  it('accepts single character name', () => {
+    expect(validateTaskName('a')).toBe(true);
+  });
+
+  it('accepts name with digits', () => {
+    expect(validateTaskName('task-123')).toBe(true);
+  });
+
+  it('accepts name starting with digit', () => {
+    expect(validateTaskName('1-task')).toBe(true);
+  });
+
+  it('rejects uppercase letters', () => {
+    expect(validateTaskName('My-Task')).toBe(false);
+  });
+
+  it('rejects underscores', () => {
+    expect(validateTaskName('task_name')).toBe(false);
+  });
+
+  it('rejects leading hyphen', () => {
+    expect(validateTaskName('-leading')).toBe(false);
+  });
+
+  it('rejects trailing hyphen', () => {
+    expect(validateTaskName('trailing-')).toBe(false);
+  });
+
+  it('rejects names over 50 characters', () => {
+    const longName = 'a'.repeat(51);
+    expect(validateTaskName(longName)).toBe(false);
+  });
+
+  it('accepts name exactly at 50 characters', () => {
+    // 48 chars + 2 boundary chars = 50
+    const name = 'a' + 'b'.repeat(48) + 'c';
+    expect(name.length).toBe(50);
+    expect(validateTaskName(name)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeUserTask
+// ---------------------------------------------------------------------------
+
+describe('writeUserTask', () => {
+  it('creates YAML file in vault tasks dir', () => {
+    const vaultDir = makeTempDir();
+    try {
+      const tasksDir = path.join(vaultDir, 'tasks');
+      fs.mkdirSync(tasksDir, { recursive: true });
+
+      const task = makeTask({ name: 'my-new-task' });
+      const filePath = writeUserTask(vaultDir, task);
+
+      expect(fs.existsSync(filePath)).toBe(true);
+      expect(filePath).toBe(path.join(tasksDir, 'my-new-task.yaml'));
+
+      // Verify the YAML contains expected content
+      const raw = fs.readFileSync(filePath, 'utf-8');
+      const parsed = parseYaml(raw);
+      expect(parsed.name).toBe('my-new-task');
+      expect(parsed.displayName).toBe('Test Task');
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('creates tasks dir if it does not exist', () => {
+    const vaultDir = makeTempDir();
+    try {
+      const tasksDir = path.join(vaultDir, 'tasks');
+      expect(fs.existsSync(tasksDir)).toBe(false);
+
+      const task = makeTask({ name: 'auto-dir-task' });
+      writeUserTask(vaultDir, task);
+
+      expect(fs.existsSync(tasksDir)).toBe(true);
+      expect(fs.existsSync(path.join(tasksDir, 'auto-dir-task.yaml'))).toBe(true);
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('strips source and isBuiltin fields from YAML output', () => {
+    const vaultDir = makeTempDir();
+    try {
+      const task = makeTask({ name: 'stripped-task', source: 'user', isBuiltin: false });
+      const filePath = writeUserTask(vaultDir, task);
+
+      const raw = fs.readFileSync(filePath, 'utf-8');
+      const parsed = parseYaml(raw);
+      expect(parsed.source).toBeUndefined();
+      expect(parsed.isBuiltin).toBeUndefined();
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteUserTask
+// ---------------------------------------------------------------------------
+
+describe('deleteUserTask', () => {
+  it('removes file and returns true', () => {
+    const vaultDir = makeTempDir();
+    try {
+      const task = makeTask({ name: 'to-delete' });
+      writeUserTask(vaultDir, task);
+
+      const result = deleteUserTask(vaultDir, 'to-delete');
+
+      expect(result).toBe(true);
+      expect(fs.existsSync(path.join(vaultDir, 'tasks', 'to-delete.yaml'))).toBe(false);
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('returns false for non-existent file', () => {
+    const vaultDir = makeTempDir();
+    try {
+      const result = deleteUserTask(vaultDir, 'does-not-exist');
+      expect(result).toBe(false);
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// copyTaskToUser
+// ---------------------------------------------------------------------------
+
+describe('copyTaskToUser', () => {
+  beforeEach(() => {
+    vi.mocked(loadAgentTasks).mockReset();
+  });
+
+  it('creates user copy with -custom suffix', () => {
+    const builtIn = makeTask({ name: 'full-intelligence', displayName: 'Full Intelligence' });
+    vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
+
+    const vaultDir = makeTempDir();
+    try {
+      const copy = copyTaskToUser('/fake/definitions', vaultDir, 'full-intelligence');
+
+      expect(copy.name).toBe('full-intelligence-custom');
+      expect(copy.isDefault).toBe(false);
+      expect(copy.isBuiltin).toBe(false);
+      expect(copy.source).toBe('user');
+      expect(fs.existsSync(path.join(vaultDir, 'tasks', 'full-intelligence-custom.yaml'))).toBe(true);
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('uses custom name when provided', () => {
+    const builtIn = makeTask({ name: 'extract-only' });
+    vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
+
+    const vaultDir = makeTempDir();
+    try {
+      const copy = copyTaskToUser('/fake/definitions', vaultDir, 'extract-only', 'my-extract');
+
+      expect(copy.name).toBe('my-extract');
+      expect(fs.existsSync(path.join(vaultDir, 'tasks', 'my-extract.yaml'))).toBe(true);
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('throws on invalid task name', () => {
+    const builtIn = makeTask({ name: 'digest-only' });
+    vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
+
+    const vaultDir = makeTempDir();
+    try {
+      expect(() =>
+        copyTaskToUser('/fake/definitions', vaultDir, 'digest-only', 'Invalid_Name'),
+      ).toThrow();
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('throws when source task is not found', () => {
+    vi.mocked(loadAgentTasks).mockReturnValue([]);
+
+    const vaultDir = makeTempDir();
+    try {
+      expect(() =>
+        copyTaskToUser('/fake/definitions', vaultDir, 'nonexistent'),
+      ).toThrow('Task not found: nonexistent');
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+});

--- a/tests/agent/schemas.test.ts
+++ b/tests/agent/schemas.test.ts
@@ -1,0 +1,544 @@
+/**
+ * Tests for agent Zod schemas.
+ *
+ * Tests cover:
+ * - AgentTaskSchema validates minimal tasks (no optional fields)
+ * - AgentTaskSchema validates tasks with phases, execution overrides, contextQueries
+ * - AgentTaskSchema rejects tasks missing required fields
+ * - ProviderConfigSchema rejects invalid provider types
+ * - Backward compatibility: existing YAML task shapes still parse
+ * - CURRENT_TASK_SCHEMA_VERSION constant is defined and is a number
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  AgentDefinitionSchema,
+  PhaseDefinitionSchema,
+  AgentTaskSchema,
+  ProviderConfigSchema,
+  ExecutionConfigSchema,
+  ContextQuerySchema,
+  CURRENT_TASK_SCHEMA_VERSION,
+} from '@myco/agent/schemas.js';
+
+// ---------------------------------------------------------------------------
+// CURRENT_TASK_SCHEMA_VERSION
+// ---------------------------------------------------------------------------
+
+describe('CURRENT_TASK_SCHEMA_VERSION', () => {
+  it('is defined and is a number', () => {
+    expect(typeof CURRENT_TASK_SCHEMA_VERSION).toBe('number');
+    expect(CURRENT_TASK_SCHEMA_VERSION).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ProviderConfigSchema
+// ---------------------------------------------------------------------------
+
+describe('ProviderConfigSchema', () => {
+  it('validates a minimal cloud provider', () => {
+    const result = ProviderConfigSchema.parse({ type: 'cloud' });
+    expect(result.type).toBe('cloud');
+  });
+
+  it('validates all valid provider types', () => {
+    for (const type of ['cloud', 'ollama', 'lmstudio'] as const) {
+      const result = ProviderConfigSchema.parse({ type });
+      expect(result.type).toBe(type);
+    }
+  });
+
+  it('validates provider with all optional fields', () => {
+    const result = ProviderConfigSchema.parse({
+      type: 'ollama',
+      baseUrl: 'http://localhost:11434',
+      apiKey: 'sk-test',
+      model: 'llama3',
+    });
+
+    expect(result.type).toBe('ollama');
+    expect(result.baseUrl).toBe('http://localhost:11434');
+    expect(result.apiKey).toBe('sk-test');
+    expect(result.model).toBe('llama3');
+  });
+
+  it('rejects invalid provider type', () => {
+    expect(() => ProviderConfigSchema.parse({ type: 'openai' })).toThrow();
+    expect(() => ProviderConfigSchema.parse({ type: 'anthropic' })).toThrow();
+    expect(() => ProviderConfigSchema.parse({ type: '' })).toThrow();
+  });
+
+  it('rejects missing type field', () => {
+    expect(() => ProviderConfigSchema.parse({})).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ExecutionConfigSchema
+// ---------------------------------------------------------------------------
+
+describe('ExecutionConfigSchema', () => {
+  it('validates an empty execution config (all optional)', () => {
+    const result = ExecutionConfigSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it('validates execution config with all fields', () => {
+    const result = ExecutionConfigSchema.parse({
+      model: 'claude-opus-4-20250514',
+      maxTurns: 20,
+      timeoutSeconds: 600,
+      provider: { type: 'cloud' },
+    });
+
+    expect(result.model).toBe('claude-opus-4-20250514');
+    expect(result.maxTurns).toBe(20);
+    expect(result.timeoutSeconds).toBe(600);
+    expect(result.provider?.type).toBe('cloud');
+  });
+
+  it('validates execution config with only model', () => {
+    const result = ExecutionConfigSchema.parse({ model: 'claude-haiku-4-5' });
+    expect(result.model).toBe('claude-haiku-4-5');
+    expect(result.maxTurns).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ContextQuerySchema
+// ---------------------------------------------------------------------------
+
+describe('ContextQuerySchema', () => {
+  it('validates a complete context query', () => {
+    const result = ContextQuerySchema.parse({
+      tool: 'vault_search',
+      queryTemplate: 'unprocessed batches',
+      limit: 10,
+      purpose: 'Find recent unprocessed content',
+      required: true,
+    });
+
+    expect(result.tool).toBe('vault_search');
+    expect(result.queryTemplate).toBe('unprocessed batches');
+    expect(result.limit).toBe(10);
+    expect(result.purpose).toBe('Find recent unprocessed content');
+    expect(result.required).toBe(true);
+  });
+
+  it('rejects context query missing required fields', () => {
+    expect(() => ContextQuerySchema.parse({
+      tool: 'vault_search',
+      // missing queryTemplate, limit, purpose, required
+    })).toThrow();
+  });
+
+  it('rejects context query with wrong types', () => {
+    expect(() => ContextQuerySchema.parse({
+      tool: 'vault_search',
+      queryTemplate: 'q',
+      limit: 'ten', // should be number
+      purpose: 'test',
+      required: true,
+    })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PhaseDefinitionSchema
+// ---------------------------------------------------------------------------
+
+describe('PhaseDefinitionSchema', () => {
+  it('validates a minimal phase (no model override)', () => {
+    const result = PhaseDefinitionSchema.parse({
+      name: 'extract',
+      prompt: 'Extract spores from batches.',
+      tools: ['vault_unprocessed', 'vault_create_spore'],
+      maxTurns: 15,
+      required: true,
+    });
+
+    expect(result.name).toBe('extract');
+    expect(result.prompt).toBe('Extract spores from batches.');
+    expect(result.tools).toEqual(['vault_unprocessed', 'vault_create_spore']);
+    expect(result.maxTurns).toBe(15);
+    expect(result.required).toBe(true);
+    expect(result.model).toBeUndefined();
+  });
+
+  it('validates a phase with model override', () => {
+    const result = PhaseDefinitionSchema.parse({
+      name: 'digest',
+      prompt: 'Build digest.',
+      tools: ['vault_write_digest'],
+      maxTurns: 5,
+      model: 'claude-haiku-4-5',
+      required: false,
+    });
+
+    expect(result.model).toBe('claude-haiku-4-5');
+    expect(result.required).toBe(false);
+  });
+
+  it('rejects phase missing required fields', () => {
+    expect(() => PhaseDefinitionSchema.parse({
+      name: 'extract',
+      // missing prompt, tools, maxTurns, required
+    })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentTaskSchema — minimal (no optional fields)
+// ---------------------------------------------------------------------------
+
+describe('AgentTaskSchema — minimal task', () => {
+  it('validates a minimal task with only required fields', () => {
+    const result = AgentTaskSchema.parse({
+      name: 'test-task',
+      displayName: 'Test Task',
+      description: 'A simple test task.',
+      agent: 'myco-agent',
+      prompt: 'Do the thing.',
+      isDefault: false,
+    });
+
+    expect(result.name).toBe('test-task');
+    expect(result.displayName).toBe('Test Task');
+    expect(result.description).toBe('A simple test task.');
+    expect(result.agent).toBe('myco-agent');
+    expect(result.prompt).toBe('Do the thing.');
+    expect(result.isDefault).toBe(false);
+
+    // All optional fields should be undefined
+    expect(result.toolOverrides).toBeUndefined();
+    expect(result.model).toBeUndefined();
+    expect(result.maxTurns).toBeUndefined();
+    expect(result.timeoutSeconds).toBeUndefined();
+    expect(result.phases).toBeUndefined();
+    expect(result.execution).toBeUndefined();
+    expect(result.contextQueries).toBeUndefined();
+    expect(result.schemaVersion).toBeUndefined();
+  });
+
+  it('rejects task missing required fields', () => {
+    // Missing name
+    expect(() => AgentTaskSchema.parse({
+      displayName: 'Test',
+      description: 'desc',
+      agent: 'myco-agent',
+      prompt: 'Do it.',
+      isDefault: false,
+    })).toThrow();
+
+    // Missing prompt
+    expect(() => AgentTaskSchema.parse({
+      name: 'test',
+      displayName: 'Test',
+      description: 'desc',
+      agent: 'myco-agent',
+      isDefault: false,
+    })).toThrow();
+
+    // Missing agent
+    expect(() => AgentTaskSchema.parse({
+      name: 'test',
+      displayName: 'Test',
+      description: 'desc',
+      prompt: 'Do it.',
+      isDefault: false,
+    })).toThrow();
+
+    // Missing isDefault
+    expect(() => AgentTaskSchema.parse({
+      name: 'test',
+      displayName: 'Test',
+      description: 'desc',
+      agent: 'myco-agent',
+      prompt: 'Do it.',
+    })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentTaskSchema — with phases array
+// ---------------------------------------------------------------------------
+
+describe('AgentTaskSchema — with phases', () => {
+  it('validates a task with a phases array', () => {
+    const result = AgentTaskSchema.parse({
+      name: 'phased-task',
+      displayName: 'Phased Task',
+      description: 'A task with phases.',
+      agent: 'myco-agent',
+      prompt: 'Run the phased pipeline.',
+      isDefault: false,
+      phases: [
+        {
+          name: 'read-state',
+          prompt: 'Read vault state.',
+          tools: ['vault_state'],
+          maxTurns: 3,
+          required: true,
+        },
+        {
+          name: 'extract',
+          prompt: 'Extract spores.',
+          tools: ['vault_unprocessed', 'vault_create_spore'],
+          maxTurns: 15,
+          required: true,
+        },
+      ],
+    });
+
+    expect(result.phases).toBeDefined();
+    expect(result.phases!.length).toBe(2);
+    expect(result.phases![0].name).toBe('read-state');
+    expect(result.phases![1].name).toBe('extract');
+  });
+
+  it('validates a task with an empty phases array', () => {
+    const result = AgentTaskSchema.parse({
+      name: 'empty-phases',
+      displayName: 'Empty Phases',
+      description: 'Phases but empty.',
+      agent: 'myco-agent',
+      prompt: 'Nothing.',
+      isDefault: false,
+      phases: [],
+    });
+
+    expect(result.phases).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentTaskSchema — with execution overrides
+// ---------------------------------------------------------------------------
+
+describe('AgentTaskSchema — with execution overrides', () => {
+  it('validates a task with execution model override', () => {
+    const result = AgentTaskSchema.parse({
+      name: 'fast-task',
+      displayName: 'Fast Task',
+      description: 'Uses a cheaper model.',
+      agent: 'myco-agent',
+      prompt: 'Do something quickly.',
+      isDefault: false,
+      execution: {
+        model: 'claude-haiku-4-5',
+        maxTurns: 5,
+      },
+    });
+
+    expect(result.execution).toBeDefined();
+    expect(result.execution!.model).toBe('claude-haiku-4-5');
+    expect(result.execution!.maxTurns).toBe(5);
+  });
+
+  it('validates a task with execution provider config', () => {
+    const result = AgentTaskSchema.parse({
+      name: 'local-task',
+      displayName: 'Local Task',
+      description: 'Uses local Ollama.',
+      agent: 'myco-agent',
+      prompt: 'Run locally.',
+      isDefault: false,
+      execution: {
+        provider: {
+          type: 'ollama',
+          baseUrl: 'http://localhost:11434',
+          model: 'llama3',
+        },
+      },
+    });
+
+    expect(result.execution!.provider!.type).toBe('ollama');
+    expect(result.execution!.provider!.baseUrl).toBe('http://localhost:11434');
+    expect(result.execution!.provider!.model).toBe('llama3');
+  });
+
+  it('rejects task with invalid provider type in execution', () => {
+    expect(() => AgentTaskSchema.parse({
+      name: 'bad-task',
+      displayName: 'Bad Task',
+      description: 'Invalid provider.',
+      agent: 'myco-agent',
+      prompt: 'Run.',
+      isDefault: false,
+      execution: {
+        provider: { type: 'openai' }, // not a valid enum value
+      },
+    })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentTaskSchema — with contextQueries
+// ---------------------------------------------------------------------------
+
+describe('AgentTaskSchema — with contextQueries', () => {
+  it('validates a task with contextQueries', () => {
+    const result = AgentTaskSchema.parse({
+      name: 'context-task',
+      displayName: 'Context Task',
+      description: 'Pre-loads vault context.',
+      agent: 'myco-agent',
+      prompt: 'Use context to work.',
+      isDefault: false,
+      contextQueries: {
+        initial: [
+          {
+            tool: 'vault_search',
+            queryTemplate: 'recent spores',
+            limit: 20,
+            purpose: 'Load recent observations',
+            required: false,
+          },
+        ],
+        'pre-digest': [
+          {
+            tool: 'vault_unprocessed',
+            queryTemplate: '',
+            limit: 50,
+            purpose: 'Check unprocessed queue',
+            required: true,
+          },
+        ],
+      },
+    });
+
+    expect(result.contextQueries).toBeDefined();
+    expect(result.contextQueries!['initial']).toHaveLength(1);
+    expect(result.contextQueries!['initial'][0].tool).toBe('vault_search');
+    expect(result.contextQueries!['pre-digest']).toHaveLength(1);
+    expect(result.contextQueries!['pre-digest'][0].required).toBe(true);
+  });
+
+  it('validates a task with empty contextQueries record', () => {
+    const result = AgentTaskSchema.parse({
+      name: 'no-queries',
+      displayName: 'No Queries',
+      description: 'Empty context queries.',
+      agent: 'myco-agent',
+      prompt: 'Do nothing.',
+      isDefault: false,
+      contextQueries: {},
+    });
+
+    expect(result.contextQueries).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentTaskSchema — with schemaVersion
+// ---------------------------------------------------------------------------
+
+describe('AgentTaskSchema — with schemaVersion', () => {
+  it('validates a task with schemaVersion', () => {
+    const result = AgentTaskSchema.parse({
+      name: 'versioned-task',
+      displayName: 'Versioned Task',
+      description: 'Has a schema version.',
+      agent: 'myco-agent',
+      prompt: 'Run versioned.',
+      isDefault: false,
+      schemaVersion: 1,
+    });
+
+    expect(result.schemaVersion).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentTaskSchema — backward compatibility (existing YAML shape)
+// ---------------------------------------------------------------------------
+
+describe('AgentTaskSchema — backward compatibility', () => {
+  it('parses a task shaped like the existing digest-only YAML', () => {
+    // This is representative of what existing YAML files produce
+    const result = AgentTaskSchema.parse({
+      name: 'digest-only',
+      displayName: 'Digest Only',
+      description: 'Regenerates digests from existing vault content.',
+      agent: 'myco-agent',
+      prompt: 'Regenerate the vault digest extracts.',
+      isDefault: false,
+      toolOverrides: ['vault_write_digest', 'vault_state'],
+    });
+
+    expect(result.name).toBe('digest-only');
+    expect(result.toolOverrides).toEqual(['vault_write_digest', 'vault_state']);
+    expect(result.phases).toBeUndefined();
+    expect(result.execution).toBeUndefined();
+    expect(result.contextQueries).toBeUndefined();
+  });
+
+  it('parses a task shaped like the existing full-intelligence YAML', () => {
+    const result = AgentTaskSchema.parse({
+      name: 'full-intelligence',
+      displayName: 'Full Intelligence',
+      description: 'Complete intelligence pipeline.',
+      agent: 'myco-agent',
+      prompt: 'Run full intelligence pipeline.',
+      isDefault: true,
+    });
+
+    expect(result.name).toBe('full-intelligence');
+    expect(result.isDefault).toBe(true);
+    expect(result.toolOverrides).toBeUndefined();
+  });
+
+  it('parses a task with optional model and maxTurns (existing pattern)', () => {
+    const result = AgentTaskSchema.parse({
+      name: 'extract-only',
+      displayName: 'Extract Only',
+      description: 'Extract spores only.',
+      agent: 'myco-agent',
+      prompt: 'Extract spores from unprocessed batches.',
+      isDefault: false,
+      model: 'claude-haiku-4-5',
+      maxTurns: 20,
+      timeoutSeconds: 180,
+    });
+
+    expect(result.model).toBe('claude-haiku-4-5');
+    expect(result.maxTurns).toBe(20);
+    expect(result.timeoutSeconds).toBe(180);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentDefinitionSchema — basic coverage
+// ---------------------------------------------------------------------------
+
+describe('AgentDefinitionSchema', () => {
+  it('validates a complete agent definition', () => {
+    const result = AgentDefinitionSchema.parse({
+      name: 'myco-agent',
+      displayName: 'Myco Agent',
+      description: 'The built-in agent.',
+      model: 'claude-sonnet-4-20250514',
+      maxTurns: 30,
+      timeoutSeconds: 300,
+      systemPromptPath: '../prompts/agent.md',
+      tools: ['vault_unprocessed', 'vault_create_spore'],
+    });
+
+    expect(result.name).toBe('myco-agent');
+    expect(result.tools).toHaveLength(2);
+  });
+
+  it('rejects agent definition missing tools array', () => {
+    expect(() => AgentDefinitionSchema.parse({
+      name: 'myco-agent',
+      displayName: 'Myco Agent',
+      description: 'The built-in agent.',
+      model: 'claude-sonnet-4-20250514',
+      maxTurns: 30,
+      timeoutSeconds: 300,
+      systemPromptPath: '../prompts/agent.md',
+      // missing tools
+    })).toThrow();
+  });
+});

--- a/tests/agent/tools.test.ts
+++ b/tests/agent/tools.test.ts
@@ -5,14 +5,14 @@
  * and exercises tool handlers directly against the database.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { initDatabase, closeDatabase, getDatabase } from '@myco/db/client.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import { getDatabase } from '@myco/db/client.js';
 
 // Mock tryEmbed to return null immediately — no real embedding provider in tests
 vi.mock('@myco/intelligence/embed-query.js', () => ({
   tryEmbed: async () => null,
 }));
-import { createSchema } from '@myco/db/schema.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
 import { upsertSession, type SessionInsert } from '@myco/db/queries/sessions.js';
 import { insertBatch, type BatchInsert } from '@myco/db/queries/batches.js';
 import { insertRun, type RunInsert } from '@myco/db/queries/runs.js';
@@ -98,9 +98,10 @@ describe('vault tools', () => {
   let tools: ReturnType<typeof createVaultTools>;
   let sessionId: string;
 
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
-    const db = await initDatabase(); // in-memory
-    await createSchema(db);
+    await cleanTestDb();
 
     // Seed required parent rows
     await createAgent(TEST_AGENT_ID);
@@ -112,10 +113,6 @@ describe('vault tools', () => {
 
     // Create tools for this test
     tools = createVaultTools(TEST_AGENT_ID, TEST_RUN_ID);
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   // -------------------------------------------------------------------------

--- a/tests/agent/tools.test.ts
+++ b/tests/agent/tools.test.ts
@@ -12,7 +12,7 @@ import { getDatabase } from '@myco/db/client.js';
 vi.mock('@myco/intelligence/embed-query.js', () => ({
   tryEmbed: async () => null,
 }));
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
 import { upsertSession, type SessionInsert } from '@myco/db/queries/sessions.js';
 import { insertBatch, type BatchInsert } from '@myco/db/queries/batches.js';
 import { insertRun, type RunInsert } from '@myco/db/queries/runs.js';

--- a/tests/context/injector.test.ts
+++ b/tests/context/injector.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
 import { buildInjectedContext, buildPromptContext } from '@myco/context/injector';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
 
 // Mock tryEmbed to return null immediately — no real embedding provider in tests
 vi.mock('@myco/intelligence/embed-query.js', () => ({

--- a/tests/context/injector.test.ts
+++ b/tests/context/injector.test.ts
@@ -1,12 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
 import { buildInjectedContext, buildPromptContext } from '@myco/context/injector';
-import { initDatabase, closeDatabase } from '@myco/db/client';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
 
 // Mock tryEmbed to return null immediately — no real embedding provider in tests
 vi.mock('@myco/intelligence/embed-query.js', () => ({
   tryEmbed: async () => null,
 }));
-import { createSchema } from '@myco/db/schema';
 import { upsertSession } from '@myco/db/queries/sessions';
 import { upsertPlan } from '@myco/db/queries/plans';
 import { insertSpore } from '@myco/db/queries/spores';
@@ -18,14 +17,9 @@ describe('buildInjectedContext', () => {
     version: 3,
   });
 
-  beforeEach(async () => {
-    const db = await initDatabase(); // in-memory
-    await createSchema(db);
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
-  });
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
+  beforeEach(async () => { await cleanTestDb(); });
 
   it('returns empty text when DB has no data', async () => {
     const result = await buildInjectedContext(config, {});
@@ -131,14 +125,9 @@ describe('buildPromptContext', () => {
     version: 3,
   });
 
-  beforeEach(async () => {
-    const db = await initDatabase(); // in-memory
-    await createSchema(db);
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
-  });
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
+  beforeEach(async () => { await cleanTestDb(); });
 
   it('returns empty context for short prompts', async () => {
     const result = await buildPromptContext('hi', config);

--- a/tests/daemon/api/agent-tasks.test.ts
+++ b/tests/daemon/api/agent-tasks.test.ts
@@ -15,10 +15,14 @@ import path from 'node:path';
 // Mocks — must be declared before imports that use them
 // ---------------------------------------------------------------------------
 
-vi.mock('@myco/agent/loader.js', () => ({
-  loadAgentTasks: vi.fn(),
-  resolveDefinitionsDir: vi.fn(() => '/fake/definitions'),
-}));
+vi.mock('@myco/agent/loader.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@myco/agent/loader.js')>();
+  return {
+    ...original,
+    loadAgentTasks: vi.fn(),
+    resolveDefinitionsDir: vi.fn(() => '/fake/definitions'),
+  };
+});
 
 import { loadAgentTasks } from '@myco/agent/loader.js';
 import {
@@ -225,7 +229,7 @@ describe('handleCreateTask', () => {
       const result = await handleCreateTask(makeReq({ body }), vaultDir);
 
       expect(result.status).toBe(201);
-      const created = result.body as AgentTask;
+      const created = (result.body as { task: AgentTask }).task;
       expect(created.name).toBe('new-task');
       expect(created.source).toBe('user');
 
@@ -338,7 +342,7 @@ describe('handleCopyTask', () => {
       );
 
       expect(result.status).toBe(201);
-      const copy = result.body as AgentTask;
+      const copy = (result.body as { task: AgentTask }).task;
       expect(copy.name).toBe('full-intelligence-custom');
       expect(copy.isDefault).toBe(false);
       expect(copy.source).toBe('user');
@@ -359,7 +363,7 @@ describe('handleCopyTask', () => {
       );
 
       expect(result.status).toBe(201);
-      const copy = result.body as AgentTask;
+      const copy = (result.body as { task: AgentTask }).task;
       expect(copy.name).toBe('my-extract');
     } finally {
       removeTempDir(vaultDir);

--- a/tests/daemon/api/agent-tasks.test.ts
+++ b/tests/daemon/api/agent-tasks.test.ts
@@ -1,0 +1,446 @@
+/**
+ * Tests for agent-tasks API route handlers.
+ *
+ * Handlers are tested directly (no HTTP) by mocking the registry functions.
+ * loadAgentTasks is mocked so tests don't depend on the real definitions dir.
+ * resolveDefinitionsDir is mocked to return a sentinel path.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before imports that use them
+// ---------------------------------------------------------------------------
+
+vi.mock('@myco/agent/loader.js', () => ({
+  loadAgentTasks: vi.fn(),
+  resolveDefinitionsDir: vi.fn(() => '/fake/definitions'),
+}));
+
+import { loadAgentTasks } from '@myco/agent/loader.js';
+import {
+  handleListTasks,
+  handleGetTask,
+  handleCreateTask,
+  handleCopyTask,
+  handleDeleteTask,
+} from '@myco/daemon/api/agent-tasks';
+import type { AgentTask } from '@myco/agent/types.js';
+import type { RouteRequest } from '@myco/daemon/router';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal RouteRequest. */
+function makeReq(overrides: Partial<RouteRequest> = {}): RouteRequest {
+  return {
+    params: {},
+    query: {},
+    body: undefined,
+    pathname: '/api/agent/tasks',
+    ...overrides,
+  };
+}
+
+/** Build a minimal valid AgentTask. */
+function makeTask(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    name: 'test-task',
+    displayName: 'Test Task',
+    description: 'A task for testing',
+    agent: 'myco-agent',
+    prompt: 'Do the thing.',
+    isDefault: false,
+    ...overrides,
+  };
+}
+
+/** Write a YAML file for a task into `vaultDir/tasks/`. */
+function writeTaskYaml(vaultDir: string, task: AgentTask): void {
+  const tasksDir = path.join(vaultDir, 'tasks');
+  fs.mkdirSync(tasksDir, { recursive: true });
+  const { isBuiltin: _isBuiltin, source: _source, ...serializable } = task;
+  fs.writeFileSync(
+    path.join(tasksDir, `${task.name}.yaml`),
+    JSON.stringify(serializable),
+    'utf-8',
+  );
+}
+
+/** Create a temp directory for test isolation. */
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'myco-api-tasks-test-'));
+}
+
+/** Remove a temp directory recursively. */
+function removeTempDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// handleListTasks
+// ---------------------------------------------------------------------------
+
+describe('handleListTasks', () => {
+  beforeEach(() => {
+    vi.mocked(loadAgentTasks).mockReset();
+  });
+
+  it('returns both built-in and user tasks', async () => {
+    const builtIn = makeTask({ name: 'full-intelligence', isDefault: true });
+    vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
+
+    const vaultDir = makeTempDir();
+    try {
+      writeTaskYaml(vaultDir, makeTask({ name: 'my-custom-task' }));
+
+      const result = await handleListTasks(makeReq(), vaultDir);
+
+      expect(result.status).toBe(200);
+      const tasks = result.body as AgentTask[];
+      expect(tasks.length).toBe(2);
+      const names = tasks.map((t) => t.name);
+      expect(names).toContain('full-intelligence');
+      expect(names).toContain('my-custom-task');
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('filters by source=user', async () => {
+    const builtIn = makeTask({ name: 'built-in-task', isDefault: true });
+    vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
+
+    const vaultDir = makeTempDir();
+    try {
+      writeTaskYaml(vaultDir, makeTask({ name: 'user-task' }));
+
+      const result = await handleListTasks(makeReq({ query: { source: 'user' } }), vaultDir);
+
+      expect(result.status).toBe(200);
+      const tasks = result.body as AgentTask[];
+      expect(tasks.length).toBe(1);
+      expect(tasks[0].name).toBe('user-task');
+      expect(tasks[0].source).toBe('user');
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('filters by source=built-in', async () => {
+    const builtIn = makeTask({ name: 'built-in-task', isDefault: true });
+    vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
+
+    const vaultDir = makeTempDir();
+    try {
+      writeTaskYaml(vaultDir, makeTask({ name: 'user-task' }));
+
+      const result = await handleListTasks(
+        makeReq({ query: { source: 'built-in' } }),
+        vaultDir,
+      );
+
+      expect(result.status).toBe(200);
+      const tasks = result.body as AgentTask[];
+      expect(tasks.length).toBe(1);
+      expect(tasks[0].name).toBe('built-in-task');
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleGetTask
+// ---------------------------------------------------------------------------
+
+describe('handleGetTask', () => {
+  beforeEach(() => {
+    vi.mocked(loadAgentTasks).mockReset();
+  });
+
+  it('returns task with phases when found', async () => {
+    const task = makeTask({
+      name: 'phased-task',
+      phases: [
+        { name: 'plan', prompt: 'Plan it', tools: [], maxTurns: 3, required: true },
+      ],
+    });
+    vi.mocked(loadAgentTasks).mockReturnValue([task]);
+
+    const vaultDir = makeTempDir();
+    try {
+      const result = await handleGetTask(makeReq({ params: { id: 'phased-task' } }), vaultDir);
+
+      expect(result.status).toBe(200);
+      const body = result.body as AgentTask;
+      expect(body.name).toBe('phased-task');
+      expect(body.phases).toHaveLength(1);
+      expect(body.phases![0].name).toBe('plan');
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('returns 404 for unknown task', async () => {
+    vi.mocked(loadAgentTasks).mockReturnValue([]);
+
+    const vaultDir = makeTempDir();
+    try {
+      const result = await handleGetTask(makeReq({ params: { id: 'nonexistent' } }), vaultDir);
+      expect(result.status).toBe(404);
+      expect((result.body as { error: string }).error).toBe('task_not_found');
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCreateTask
+// ---------------------------------------------------------------------------
+
+describe('handleCreateTask', () => {
+  beforeEach(() => {
+    vi.mocked(loadAgentTasks).mockReset();
+  });
+
+  it('creates valid task and returns 201', async () => {
+    vi.mocked(loadAgentTasks).mockReturnValue([]);
+
+    const vaultDir = makeTempDir();
+    try {
+      const body = {
+        name: 'new-task',
+        displayName: 'New Task',
+        description: 'A brand new task',
+        agent: 'myco-agent',
+        prompt: 'Do the thing.',
+        isDefault: false,
+      };
+      const result = await handleCreateTask(makeReq({ body }), vaultDir);
+
+      expect(result.status).toBe(201);
+      const created = result.body as AgentTask;
+      expect(created.name).toBe('new-task');
+      expect(created.source).toBe('user');
+
+      // File should exist on disk
+      expect(fs.existsSync(path.join(vaultDir, 'tasks', 'new-task.yaml'))).toBe(true);
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('returns 400 for invalid body (missing required fields)', async () => {
+    vi.mocked(loadAgentTasks).mockReturnValue([]);
+
+    const vaultDir = makeTempDir();
+    try {
+      const result = await handleCreateTask(makeReq({ body: { name: 'only-name' } }), vaultDir);
+      expect(result.status).toBe(400);
+      expect((result.body as { error: string }).error).toBe('validation_failed');
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('returns 400 for invalid task name', async () => {
+    vi.mocked(loadAgentTasks).mockReturnValue([]);
+
+    const vaultDir = makeTempDir();
+    try {
+      const body = {
+        name: 'Invalid_Name',
+        displayName: 'Bad',
+        description: 'desc',
+        agent: 'myco-agent',
+        prompt: 'prompt',
+        isDefault: false,
+      };
+      const result = await handleCreateTask(makeReq({ body }), vaultDir);
+      expect(result.status).toBe(400);
+      expect((result.body as { error: string }).error).toBe('invalid_task_name');
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('returns 409 for duplicate user task', async () => {
+    vi.mocked(loadAgentTasks).mockReturnValue([]);
+
+    const vaultDir = makeTempDir();
+    try {
+      // Write an existing user task
+      writeTaskYaml(vaultDir, makeTask({ name: 'existing-task' }));
+
+      const body = {
+        name: 'existing-task',
+        displayName: 'Existing Task',
+        description: 'already there',
+        agent: 'myco-agent',
+        prompt: 'Do something.',
+        isDefault: false,
+      };
+      const result = await handleCreateTask(makeReq({ body }), vaultDir);
+      expect(result.status).toBe(409);
+      expect((result.body as { error: string }).error).toBe('task_already_exists');
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('allows creating task with same name as built-in (override)', async () => {
+    const builtIn = makeTask({ name: 'full-intelligence', isDefault: true });
+    vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
+
+    const vaultDir = makeTempDir();
+    try {
+      const body = {
+        name: 'full-intelligence',
+        displayName: 'My Full Intelligence',
+        description: 'Override the built-in',
+        agent: 'myco-agent',
+        prompt: 'Custom prompt.',
+        isDefault: false,
+      };
+      const result = await handleCreateTask(makeReq({ body }), vaultDir);
+      // Should succeed — built-in can be shadowed
+      expect(result.status).toBe(201);
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCopyTask
+// ---------------------------------------------------------------------------
+
+describe('handleCopyTask', () => {
+  beforeEach(() => {
+    vi.mocked(loadAgentTasks).mockReset();
+  });
+
+  it('creates user copy with -custom suffix', async () => {
+    const builtIn = makeTask({ name: 'full-intelligence', isDefault: true });
+    vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
+
+    const vaultDir = makeTempDir();
+    try {
+      const result = await handleCopyTask(
+        makeReq({ params: { id: 'full-intelligence' } }),
+        vaultDir,
+      );
+
+      expect(result.status).toBe(201);
+      const copy = result.body as AgentTask;
+      expect(copy.name).toBe('full-intelligence-custom');
+      expect(copy.isDefault).toBe(false);
+      expect(copy.source).toBe('user');
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('uses provided name when given', async () => {
+    const builtIn = makeTask({ name: 'extract-only' });
+    vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
+
+    const vaultDir = makeTempDir();
+    try {
+      const result = await handleCopyTask(
+        makeReq({ params: { id: 'extract-only' }, body: { name: 'my-extract' } }),
+        vaultDir,
+      );
+
+      expect(result.status).toBe(201);
+      const copy = result.body as AgentTask;
+      expect(copy.name).toBe('my-extract');
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('returns 404 for unknown source task', async () => {
+    vi.mocked(loadAgentTasks).mockReturnValue([]);
+
+    const vaultDir = makeTempDir();
+    try {
+      const result = await handleCopyTask(
+        makeReq({ params: { id: 'does-not-exist' } }),
+        vaultDir,
+      );
+      expect(result.status).toBe(404);
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleDeleteTask
+// ---------------------------------------------------------------------------
+
+describe('handleDeleteTask', () => {
+  beforeEach(() => {
+    vi.mocked(loadAgentTasks).mockReset();
+  });
+
+  it('deletes user task and returns 200', async () => {
+    vi.mocked(loadAgentTasks).mockReturnValue([]);
+
+    const vaultDir = makeTempDir();
+    try {
+      writeTaskYaml(vaultDir, makeTask({ name: 'removable-task' }));
+
+      const result = await handleDeleteTask(
+        makeReq({ params: { id: 'removable-task' } }),
+        vaultDir,
+      );
+
+      expect(result.status).toBe(200);
+      expect((result.body as { deleted: string }).deleted).toBe('removable-task');
+      expect(fs.existsSync(path.join(vaultDir, 'tasks', 'removable-task.yaml'))).toBe(false);
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('returns 403 when attempting to delete a built-in task', async () => {
+    const builtIn = makeTask({ name: 'full-intelligence', isDefault: true });
+    vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
+
+    const vaultDir = makeTempDir();
+    try {
+      const result = await handleDeleteTask(
+        makeReq({ params: { id: 'full-intelligence' } }),
+        vaultDir,
+      );
+
+      expect(result.status).toBe(403);
+      expect((result.body as { error: string }).error).toBe('cannot_delete_builtin');
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+
+  it('returns 404 for non-existent task', async () => {
+    vi.mocked(loadAgentTasks).mockReturnValue([]);
+
+    const vaultDir = makeTempDir();
+    try {
+      const result = await handleDeleteTask(
+        makeReq({ params: { id: 'ghost-task' } }),
+        vaultDir,
+      );
+      expect(result.status).toBe(404);
+    } finally {
+      removeTempDir(vaultDir);
+    }
+  });
+});

--- a/tests/daemon/api/agent-tasks.test.ts
+++ b/tests/daemon/api/agent-tasks.test.ts
@@ -101,7 +101,7 @@ describe('handleListTasks', () => {
       const result = await handleListTasks(makeReq(), vaultDir);
 
       expect(result.status).toBe(200);
-      const tasks = result.body as AgentTask[];
+      const tasks = (result.body as { tasks: AgentTask[] }).tasks;
       expect(tasks.length).toBe(2);
       const names = tasks.map((t) => t.name);
       expect(names).toContain('full-intelligence');
@@ -122,7 +122,7 @@ describe('handleListTasks', () => {
       const result = await handleListTasks(makeReq({ query: { source: 'user' } }), vaultDir);
 
       expect(result.status).toBe(200);
-      const tasks = result.body as AgentTask[];
+      const tasks = (result.body as { tasks: AgentTask[] }).tasks;
       expect(tasks.length).toBe(1);
       expect(tasks[0].name).toBe('user-task');
       expect(tasks[0].source).toBe('user');
@@ -145,7 +145,7 @@ describe('handleListTasks', () => {
       );
 
       expect(result.status).toBe(200);
-      const tasks = result.body as AgentTask[];
+      const tasks = (result.body as { tasks: AgentTask[] }).tasks;
       expect(tasks.length).toBe(1);
       expect(tasks[0].name).toBe('built-in-task');
     } finally {
@@ -177,7 +177,7 @@ describe('handleGetTask', () => {
       const result = await handleGetTask(makeReq({ params: { id: 'phased-task' } }), vaultDir);
 
       expect(result.status).toBe(200);
-      const body = result.body as AgentTask;
+      const body = (result.body as { task: AgentTask }).task;
       expect(body.name).toBe('phased-task');
       expect(body.phases).toHaveLength(1);
       expect(body.phases![0].name).toBe('plan');

--- a/tests/daemon/capture.test.ts
+++ b/tests/daemon/capture.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
 import { upsertSession, getSession } from '@myco/db/queries/sessions.js';
 import { getUnprocessedBatches } from '@myco/db/queries/batches.js';
 import { listActivities, countActivities } from '@myco/db/queries/activities.js';

--- a/tests/daemon/capture.test.ts
+++ b/tests/daemon/capture.test.ts
@@ -7,9 +7,8 @@
  * Verifies: 1 session row, 2 batch rows, 4 activity rows, session is completed.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
 import { upsertSession, getSession } from '@myco/db/queries/sessions.js';
 import { getUnprocessedBatches } from '@myco/db/queries/batches.js';
 import { listActivities, countActivities } from '@myco/db/queries/activities.js';
@@ -26,14 +25,11 @@ const epochNow = () => Math.floor(Date.now() / 1000);
 describe('daemon capture flow', () => {
   let batchState: BatchStateMap;
 
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
-    const db = await initDatabase(); // in-memory
-    await createSchema(db);
+    await cleanTestDb();
     batchState = new Map();
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   it('tracks batches and activities through a full session lifecycle', async () => {

--- a/tests/db/queries/activities.test.ts
+++ b/tests/db/queries/activities.test.ts
@@ -5,9 +5,8 @@
  * exercises the query function, and tears down the database.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import { insertBatch } from '@myco/db/queries/batches.js';
 import type { SessionInsert } from '@myco/db/queries/sessions.js';
@@ -63,17 +62,14 @@ function makeActivity(
 describe('activity query helpers', () => {
   let sessionId: string;
 
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
-    const db = await initDatabase(); // in-memory
-    await createSchema(db);
+    await cleanTestDb();
 
     const session = makeSession();
     await upsertSession(session);
     sessionId = session.id;
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/db/queries/activities.test.ts
+++ b/tests/db/queries/activities.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import { insertBatch } from '@myco/db/queries/batches.js';
 import type { SessionInsert } from '@myco/db/queries/sessions.js';

--- a/tests/db/queries/agent-state.test.ts
+++ b/tests/db/queries/agent-state.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import { getDatabase } from '@myco/db/client.js';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import {
   getState,
   setState,

--- a/tests/db/queries/agent-state.test.ts
+++ b/tests/db/queries/agent-state.test.ts
@@ -5,9 +5,9 @@
  * exercises the query function, and tears down the database.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase, getDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { getDatabase } from '@myco/db/client.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import {
   getState,
   setState,
@@ -31,16 +31,13 @@ async function createAgent(id: string): Promise<string> {
 describe('agent state query helpers', () => {
   let agentId: string;
 
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
-    const db = await initDatabase(); // in-memory
-    await createSchema(db);
+    await cleanTestDb();
 
     // Create an agent for FK references
     agentId = await createAgent('agent-test');
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/db/queries/agents.test.ts
+++ b/tests/db/queries/agents.test.ts
@@ -5,9 +5,8 @@
  * exercises the query function, and tears down the database.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import {
   registerAgent,
   getAgent,
@@ -30,14 +29,9 @@ function makeAgent(overrides: Partial<AgentInsert> = {}): AgentInsert {
 }
 
 describe('agent query helpers', () => {
-  beforeEach(async () => {
-    const db = await initDatabase(); // in-memory
-    await createSchema(db);
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
-  });
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
+  beforeEach(async () => { await cleanTestDb(); });
 
   // ---------------------------------------------------------------------------
   // registerAgent + getAgent

--- a/tests/db/queries/agents.test.ts
+++ b/tests/db/queries/agents.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import {
   registerAgent,
   getAgent,

--- a/tests/db/queries/attachments.test.ts
+++ b/tests/db/queries/attachments.test.ts
@@ -5,18 +5,15 @@
  * exercises the query function, and tears down the database.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import { insertAttachment, listAttachmentsBySession } from '@myco/db/queries/attachments.js';
 
 describe('attachment queries', () => {
-  beforeEach(async () => {
-    const db = await initDatabase();
-    await createSchema(db);
-  });
-  afterEach(async () => { await closeDatabase(); });
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
+  beforeEach(async () => { await cleanTestDb(); });
 
   it('inserts and lists attachments by session', async () => {
     const now = Math.floor(Date.now() / 1000);

--- a/tests/db/queries/attachments.test.ts
+++ b/tests/db/queries/attachments.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import { insertAttachment, listAttachmentsBySession } from '@myco/db/queries/attachments.js';
 

--- a/tests/db/queries/batches.test.ts
+++ b/tests/db/queries/batches.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import type { SessionInsert } from '@myco/db/queries/sessions.js';
 import {

--- a/tests/db/queries/batches.test.ts
+++ b/tests/db/queries/batches.test.ts
@@ -5,9 +5,8 @@
  * exercises the query function, and tears down the database.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import type { SessionInsert } from '@myco/db/queries/sessions.js';
 import {
@@ -48,18 +47,15 @@ function makeBatch(sessionId: string, overrides: Partial<BatchInsert> = {}): Bat
 describe('prompt batch query helpers', () => {
   let sessionId: string;
 
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
-    const db = await initDatabase(); // in-memory
-    await createSchema(db);
+    await cleanTestDb();
 
     // Create a parent session for FK references
     const session = makeSession();
     await upsertSession(session);
     sessionId = session.id;
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/db/queries/embeddings.test.ts
+++ b/tests/db/queries/embeddings.test.ts
@@ -5,9 +5,10 @@
  * exercises the query function, and tears down the database.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase, getDatabase } from '@myco/db/client.js';
-import { createSchema, EMBEDDING_DIMENSIONS } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { getDatabase } from '@myco/db/client.js';
+import { EMBEDDING_DIMENSIONS } from '@myco/db/schema.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import { insertSpore } from '@myco/db/queries/spores.js';
 import type { SessionInsert } from '@myco/db/queries/sessions.js';
@@ -75,14 +76,9 @@ function makeUnitVector(hotIndex: number): number[] {
 }
 
 describe('embedding query helpers', () => {
-  beforeEach(async () => {
-    const db = await initDatabase(); // in-memory
-    await createSchema(db);
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
-  });
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
+  beforeEach(async () => { await cleanTestDb(); });
 
   // ---------------------------------------------------------------------------
   // setEmbedding

--- a/tests/db/queries/embeddings.test.ts
+++ b/tests/db/queries/embeddings.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import { getDatabase } from '@myco/db/client.js';
 import { EMBEDDING_DIMENSIONS } from '@myco/db/schema.js';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import { insertSpore } from '@myco/db/queries/spores.js';
 import type { SessionInsert } from '@myco/db/queries/sessions.js';

--- a/tests/db/queries/extended-queries.test.ts
+++ b/tests/db/queries/extended-queries.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import { insertBatch, listBatchesBySession } from '@myco/db/queries/batches.js';

--- a/tests/db/queries/extended-queries.test.ts
+++ b/tests/db/queries/extended-queries.test.ts
@@ -15,9 +15,8 @@
  * beforeEach and torn down in afterEach.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import { insertBatch, listBatchesBySession } from '@myco/db/queries/batches.js';
@@ -157,9 +156,10 @@ function makeSpore(overrides: Partial<SporeInsert> = {}): SporeInsert {
 describe('extended list-by-parent query helpers', () => {
   let sessionId: string;
 
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
-    const db = await initDatabase();
-    await createSchema(db);
+    await cleanTestDb();
 
     // Agent FK required by several tables
     await registerAgent({
@@ -179,10 +179,6 @@ describe('extended list-by-parent query helpers', () => {
       agent_id: TEST_AGENT_ID,
       started_at: epochNow(),
     });
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   // =========================================================================

--- a/tests/db/queries/feed.test.ts
+++ b/tests/db/queries/feed.test.ts
@@ -5,9 +5,8 @@
  * exercises getActivityFeed, and tears down the database.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import { insertRun } from '@myco/db/queries/runs.js';
@@ -21,19 +20,16 @@ const epochNow = () => Math.floor(Date.now() / 1000);
 const TEST_AGENT_ID = 'agent-feed-test';
 
 describe('getActivityFeed', () => {
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
-    const db = await initDatabase(); // in-memory
-    await createSchema(db);
+    await cleanTestDb();
     // Insert agent required as FK for agent_runs and spores
     await registerAgent({
       id: TEST_AGENT_ID,
       name: 'Feed Test Agent',
       created_at: epochNow(),
     });
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/db/queries/feed.test.ts
+++ b/tests/db/queries/feed.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import { insertRun } from '@myco/db/queries/runs.js';

--- a/tests/db/queries/graph-edges.test.ts
+++ b/tests/db/queries/graph-edges.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import { getDatabase } from '@myco/db/client.js';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import {
   insertGraphEdge,
   listGraphEdges,

--- a/tests/db/queries/graph-edges.test.ts
+++ b/tests/db/queries/graph-edges.test.ts
@@ -2,9 +2,9 @@
  * Tests for graph edge CRUD query helpers.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase, getDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { getDatabase } from '@myco/db/client.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import {
   insertGraphEdge,
   listGraphEdges,
@@ -41,14 +41,11 @@ function makeEdge(overrides: Partial<GraphEdgeInsert> = {}): GraphEdgeInsert {
 }
 
 describe('graph edge query helpers', () => {
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
-    const db = await initDatabase();
-    await createSchema(db);
+    await cleanTestDb();
     await createAgent(TEST_AGENT_ID);
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   describe('insertGraphEdge', () => {

--- a/tests/db/queries/lineage.test.ts
+++ b/tests/db/queries/lineage.test.ts
@@ -2,9 +2,9 @@
  * Tests for lineage edge creation helpers.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase, getDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { getDatabase } from '@myco/db/client.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import { createSporeLineage, createBatchLineage } from '@myco/db/queries/lineage.js';
 import { listGraphEdges } from '@myco/db/queries/graph-edges.js';
 
@@ -23,14 +23,11 @@ async function createAgent(id: string): Promise<void> {
 }
 
 describe('lineage helpers', () => {
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
-    const db = await initDatabase();
-    await createSchema(db);
+    await cleanTestDb();
     await createAgent(TEST_AGENT_ID);
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   describe('createSporeLineage', () => {

--- a/tests/db/queries/lineage.test.ts
+++ b/tests/db/queries/lineage.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import { getDatabase } from '@myco/db/client.js';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import { createSporeLineage, createBatchLineage } from '@myco/db/queries/lineage.js';
 import { listGraphEdges } from '@myco/db/queries/graph-edges.js';
 

--- a/tests/db/queries/plans.test.ts
+++ b/tests/db/queries/plans.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import {
   upsertPlan,
   getPlan,

--- a/tests/db/queries/plans.test.ts
+++ b/tests/db/queries/plans.test.ts
@@ -5,9 +5,8 @@
  * exercises the query function, and tears down the database.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import {
   upsertPlan,
   getPlan,
@@ -29,14 +28,9 @@ function makePlan(overrides: Partial<PlanInsert> = {}): PlanInsert {
 }
 
 describe('plan query helpers', () => {
-  beforeEach(async () => {
-    const db = await initDatabase(); // in-memory
-    await createSchema(db);
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
-  });
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
+  beforeEach(async () => { await cleanTestDb(); });
 
   // ---------------------------------------------------------------------------
   // upsertPlan + getPlan

--- a/tests/db/queries/reports.test.ts
+++ b/tests/db/queries/reports.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import { insertRun } from '@myco/db/queries/runs.js';
 import {

--- a/tests/db/queries/reports.test.ts
+++ b/tests/db/queries/reports.test.ts
@@ -5,9 +5,8 @@
  * exercises the query function, and tears down the database.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import { insertRun } from '@myco/db/queries/runs.js';
 import {
@@ -37,9 +36,10 @@ function makeReport(overrides: Partial<ReportInsert> = {}): ReportInsert {
 }
 
 describe('report query helpers', () => {
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
-    const db = await initDatabase();
-    await createSchema(db);
+    await cleanTestDb();
     // Insert FK targets
     await registerAgent({
       id: TEST_AGENT_ID,
@@ -51,10 +51,6 @@ describe('report query helpers', () => {
       agent_id: TEST_AGENT_ID,
       started_at: epochNow(),
     });
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/db/queries/runs.test.ts
+++ b/tests/db/queries/runs.test.ts
@@ -5,9 +5,8 @@
  * exercises the query function, and tears down the database.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import {
   insertRun,
@@ -34,19 +33,16 @@ function makeRun(overrides: Partial<RunInsert> = {}): RunInsert {
 }
 
 describe('run query helpers', () => {
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
-    const db = await initDatabase();
-    await createSchema(db);
+    await cleanTestDb();
     // Insert the agent FK target
     await registerAgent({
       id: TEST_AGENT_ID,
       name: 'Test Agent',
       created_at: epochNow(),
     });
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/db/queries/runs.test.ts
+++ b/tests/db/queries/runs.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import {
   insertRun,

--- a/tests/db/queries/search.test.ts
+++ b/tests/db/queries/search.test.ts
@@ -9,9 +9,10 @@
  * exercises the search function, and tears down the database.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase, getDatabase } from '@myco/db/client.js';
-import { createSchema, EMBEDDING_DIMENSIONS } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { getDatabase } from '@myco/db/client.js';
+import { EMBEDDING_DIMENSIONS } from '@myco/db/schema.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import { insertBatch } from '@myco/db/queries/batches.js';
 import { insertActivity } from '@myco/db/queries/activities.js';
@@ -111,17 +112,14 @@ async function insertSporeWithEmbedding(
 describe('fullTextSearch', () => {
   let sessionId: string;
 
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
-    const db = await initDatabase();
-    await createSchema(db);
+    await cleanTestDb();
 
     const session = makeSession();
     await upsertSession(session);
     sessionId = session.id;
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   it('finds matching prompt batches by keyword in user_prompt', async () => {
@@ -222,19 +220,16 @@ describe('semanticSearch', () => {
   let sessionId: string;
   let agentId: string;
 
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
-    const db = await initDatabase();
-    await createSchema(db);
+    await cleanTestDb();
 
     const session = makeSession();
     await upsertSession(session);
     sessionId = session.id;
 
     agentId = await createAgent('agent-search-test');
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   it('returns session with identical embedding first', async () => {

--- a/tests/db/queries/search.test.ts
+++ b/tests/db/queries/search.test.ts
@@ -12,7 +12,7 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import { getDatabase } from '@myco/db/client.js';
 import { EMBEDDING_DIMENSIONS } from '@myco/db/schema.js';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import { insertBatch } from '@myco/db/queries/batches.js';
 import { insertActivity } from '@myco/db/queries/activities.js';

--- a/tests/db/queries/sessions.test.ts
+++ b/tests/db/queries/sessions.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import {
   upsertSession,
   getSession,

--- a/tests/db/queries/sessions.test.ts
+++ b/tests/db/queries/sessions.test.ts
@@ -5,9 +5,8 @@
  * exercises the query function, and tears down the database.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import {
   upsertSession,
   getSession,
@@ -33,14 +32,9 @@ function makeSession(overrides: Partial<SessionInsert> = {}): SessionInsert {
 }
 
 describe('session query helpers', () => {
-  beforeEach(async () => {
-    const db = await initDatabase(); // in-memory
-    await createSchema(db);
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
-  });
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
+  beforeEach(async () => { await cleanTestDb(); });
 
   // ---------------------------------------------------------------------------
   // upsertSession + getSession

--- a/tests/db/queries/spores.test.ts
+++ b/tests/db/queries/spores.test.ts
@@ -5,9 +5,9 @@
  * exercises the query function, and tears down the database.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase, getDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { getDatabase } from '@myco/db/client.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import type { SessionInsert } from '@myco/db/queries/sessions.js';
 import {
@@ -64,9 +64,10 @@ describe('spore query helpers', () => {
   let agentId: string;
   let sessionId: string;
 
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
-    const db = await initDatabase(); // in-memory
-    await createSchema(db);
+    await cleanTestDb();
 
     // Create an agent for FK references
     agentId = await createAgent('agent-test');
@@ -75,10 +76,6 @@ describe('spore query helpers', () => {
     const session = makeSession();
     await upsertSession(session);
     sessionId = session.id;
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/db/queries/spores.test.ts
+++ b/tests/db/queries/spores.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import { getDatabase } from '@myco/db/client.js';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import type { SessionInsert } from '@myco/db/queries/sessions.js';
 import {

--- a/tests/db/queries/tasks.test.ts
+++ b/tests/db/queries/tasks.test.ts
@@ -5,9 +5,8 @@
  * exercises the query function, and tears down the database.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import {
   upsertTask,
@@ -39,19 +38,16 @@ function makeTask(overrides: Partial<TaskInsert> = {}): TaskInsert {
 }
 
 describe('task query helpers', () => {
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
-    const db = await initDatabase();
-    await createSchema(db);
+    await cleanTestDb();
     // Insert the agent FK target
     await registerAgent({
       id: TEST_AGENT_ID,
       name: 'Test Agent',
       created_at: epochNow(),
     });
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/db/queries/tasks.test.ts
+++ b/tests/db/queries/tasks.test.ts
@@ -14,8 +14,12 @@ import {
   getTask,
   listTasks,
   getDefaultTask,
+  deleteTask,
+  serializeConfig,
+  deserializeConfig,
 } from '@myco/db/queries/tasks.js';
 import type { TaskInsert } from '@myco/db/queries/tasks.js';
+import type { TaskConfig } from '@myco/agent/types.js';
 
 /** Epoch seconds helper. */
 const epochNow = () => Math.floor(Date.now() / 1000);
@@ -216,6 +220,147 @@ describe('task query helpers', () => {
     it('returns null for agent with no tasks', async () => {
       const defaultTask = await getDefaultTask('no-such-agent');
       expect(defaultTask).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // config column — serialization helpers and round-trip
+  // ---------------------------------------------------------------------------
+
+  describe('config column', () => {
+    it('upsert with phases config round-trips correctly', async () => {
+      const phases = [
+        {
+          name: 'gather',
+          prompt: 'Gather data.',
+          tools: ['vault_unprocessed'],
+          maxTurns: 5,
+          required: true,
+        },
+        {
+          name: 'extract',
+          prompt: 'Extract spores.',
+          tools: ['vault_create_spore'],
+          maxTurns: 10,
+          required: false,
+        },
+      ];
+      const config: TaskConfig = { phases, schemaVersion: 1 };
+
+      const data = makeTask({ config: serializeConfig(config) });
+      await upsertTask(data);
+
+      const row = await getTask(data.id);
+      expect(row).not.toBeNull();
+      expect(row!.config).not.toBeNull();
+
+      const parsed = deserializeConfig(row!.config);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.phases).toHaveLength(2);
+      expect(parsed!.phases![0].name).toBe('gather');
+      expect(parsed!.phases![1].name).toBe('extract');
+      expect(parsed!.schemaVersion).toBe(1);
+    });
+
+    it('upsert with execution overrides config round-trips correctly', async () => {
+      const config: TaskConfig = {
+        execution: {
+          model: 'claude-3-haiku',
+          maxTurns: 20,
+          timeoutSeconds: 180,
+        },
+        schemaVersion: 1,
+      };
+
+      const data = makeTask({ config: serializeConfig(config) });
+      await upsertTask(data);
+
+      const row = await getTask(data.id);
+      expect(row).not.toBeNull();
+
+      const parsed = deserializeConfig(row!.config);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.execution).toBeDefined();
+      expect(parsed!.execution!.model).toBe('claude-3-haiku');
+      expect(parsed!.execution!.maxTurns).toBe(20);
+      expect(parsed!.execution!.timeoutSeconds).toBe(180);
+    });
+
+    it('config column is null when no extended config provided', async () => {
+      const data = makeTask(); // no config field
+      const row = await upsertTask(data);
+
+      expect(row.config).toBeNull();
+
+      const fetched = await getTask(data.id);
+      expect(fetched!.config).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // serializeConfig / deserializeConfig helpers
+  // ---------------------------------------------------------------------------
+
+  describe('serializeConfig', () => {
+    it('serializes a config to JSON string', () => {
+      const config: TaskConfig = { schemaVersion: 1, phases: [] };
+      const result = serializeConfig(config);
+      expect(typeof result).toBe('string');
+      expect(JSON.parse(result!)).toEqual(config);
+    });
+
+    it('returns null for null input', () => {
+      expect(serializeConfig(null)).toBeNull();
+    });
+  });
+
+  describe('deserializeConfig', () => {
+    it('deserializes a valid JSON string to TaskConfig', () => {
+      const config: TaskConfig = { schemaVersion: 2 };
+      const raw = JSON.stringify(config);
+      const result = deserializeConfig(raw);
+      expect(result).toEqual(config);
+    });
+
+    it('returns null for null input', () => {
+      expect(deserializeConfig(null)).toBeNull();
+    });
+
+    it('returns null for malformed JSON', () => {
+      expect(deserializeConfig('not-json')).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteTask
+  // ---------------------------------------------------------------------------
+
+  describe('deleteTask', () => {
+    it('deletes a user task (source=user) and returns true', async () => {
+      const data = makeTask({ id: 'task-to-delete', source: 'user' });
+      await upsertTask(data);
+
+      const deleted = await deleteTask(data.id);
+      expect(deleted).toBe(true);
+
+      const fetched = await getTask(data.id);
+      expect(fetched).toBeNull();
+    });
+
+    it('returns false for a non-existent task', async () => {
+      const deleted = await deleteTask('does-not-exist');
+      expect(deleted).toBe(false);
+    });
+
+    it('returns false for a built-in task and does not delete it', async () => {
+      const data = makeTask({ id: 'task-builtin', source: 'built-in' });
+      await upsertTask(data);
+
+      const deleted = await deleteTask(data.id);
+      expect(deleted).toBe(false);
+
+      const fetched = await getTask(data.id);
+      expect(fetched).not.toBeNull();
     });
   });
 });

--- a/tests/db/queries/tasks.test.ts
+++ b/tests/db/queries/tasks.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import {
   upsertTask,

--- a/tests/db/queries/turns.test.ts
+++ b/tests/db/queries/turns.test.ts
@@ -5,9 +5,8 @@
  * exercises the query function, and tears down the database.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { initDatabase, closeDatabase } from '@myco/db/client.js';
-import { createSchema } from '@myco/db/schema.js';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import { insertRun } from '@myco/db/queries/runs.js';
 import { insertTurn, listTurns } from '@myco/db/queries/turns.js';
@@ -32,9 +31,10 @@ function makeTurn(overrides: Partial<TurnInsert> = {}): TurnInsert {
 }
 
 describe('turn query helpers', () => {
+  beforeAll(async () => { await setupTestDb(); });
+  afterAll(async () => { await teardownTestDb(); });
   beforeEach(async () => {
-    const db = await initDatabase();
-    await createSchema(db);
+    await cleanTestDb();
     // Insert FK targets
     await registerAgent({
       id: TEST_AGENT_ID,
@@ -46,10 +46,6 @@ describe('turn query helpers', () => {
       agent_id: TEST_AGENT_ID,
       started_at: epochNow(),
     });
-  });
-
-  afterEach(async () => {
-    await closeDatabase();
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/db/queries/turns.test.ts
+++ b/tests/db/queries/turns.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
-import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import { insertRun } from '@myco/db/queries/runs.js';
 import { insertTurn, listTurns } from '@myco/db/queries/turns.js';

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared test database helpers.
+ *
+ * Provides a fast setup/teardown pattern for tests that need PGlite:
+ * - `setupTestDb()` in beforeAll — creates DB + schema once per suite
+ * - `cleanTestDb()` in beforeEach — truncates all tables (fast, no re-init)
+ * - `teardownTestDb()` in afterAll — closes the DB
+ *
+ * This replaces the per-test initDatabase()/createSchema()/closeDatabase()
+ * pattern which was creating a fresh PGlite instance for every single test.
+ */
+
+import { initDatabase, closeDatabase, getDatabase } from '@myco/db/client.js';
+import { createSchema } from '@myco/db/schema.js';
+
+/** Tables to truncate between tests (order matters for FK constraints). */
+const TRUNCATE_TABLES = [
+  'agent_turns',
+  'agent_reports',
+  'agent_state',
+  'agent_runs',
+  'agent_tasks',
+  'resolution_events',
+  'entity_mentions',
+  'graph_edges',
+  'edges',
+  'entities',
+  'digest_extracts',
+  'attachments',
+  'activities',
+  'spores',
+  'prompt_batches',
+  'plans',
+  'artifacts',
+  'team_members',
+  'sessions',
+  'agents',
+];
+
+/**
+ * Initialize the test database once per suite.
+ * Call in `beforeAll`.
+ */
+export async function setupTestDb() {
+  const db = await initDatabase();
+  await createSchema(db);
+  return db;
+}
+
+/**
+ * Truncate all tables between tests.
+ * Call in `beforeEach` — much faster than re-creating the DB.
+ */
+export async function cleanTestDb() {
+  const db = getDatabase();
+  // TRUNCATE CASCADE handles FK constraints in one statement
+  await db.query(`TRUNCATE ${TRUNCATE_TABLES.join(', ')} CASCADE`);
+}
+
+/**
+ * Close the test database after all tests in a suite.
+ * Call in `afterAll`.
+ */
+export async function teardownTestDb() {
+  await closeDatabase();
+}

--- a/ui/src/components/agent/PhaseTimeline.tsx
+++ b/ui/src/components/agent/PhaseTimeline.tsx
@@ -1,0 +1,60 @@
+import { formatTokens, formatCost } from './helpers';
+
+/* ---------- Types ---------- */
+
+export interface PhaseResult {
+  name: string;
+  status: 'completed' | 'failed' | 'skipped';
+  turnsUsed: number;
+  tokensUsed: number;
+  costUsd: number;
+  summary: string;
+}
+
+export interface PhaseTimelineProps {
+  phases: PhaseResult[];
+}
+
+/* ---------- Constants ---------- */
+
+/** Tailwind class map for phase status badge coloring. */
+const PHASE_STATUS_CLASSES: Record<string, string> = {
+  completed: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+  failed: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+  skipped: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200',
+};
+
+/** Tailwind class for clamping phase summary to 2 lines. */
+const SUMMARY_LINE_CLAMP = 'line-clamp-2';
+
+/* ---------- Component ---------- */
+
+export function PhaseTimeline({ phases }: PhaseTimelineProps) {
+  return (
+    <div className="space-y-3">
+      <h3 className="font-medium text-sm">Phase Execution</h3>
+      {phases.map((phase, i) => (
+        <div key={phase.name} className="flex items-start gap-3">
+          <div
+            className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium shrink-0 ${PHASE_STATUS_CLASSES[phase.status] ?? PHASE_STATUS_CLASSES['skipped']}`}
+          >
+            {i + 1}
+          </div>
+          <div className="flex-1 p-3 rounded-lg border text-sm">
+            <div className="flex justify-between items-center">
+              <span className="font-medium">{phase.name}</span>
+              <div className="flex gap-3 text-muted-foreground">
+                <span>{phase.turnsUsed} turns</span>
+                <span>{formatTokens(phase.tokensUsed)}</span>
+                <span>{formatCost(phase.costUsd)}</span>
+              </div>
+            </div>
+            {phase.summary && (
+              <p className={`text-muted-foreground mt-1 ${SUMMARY_LINE_CLAMP}`}>{phase.summary}</p>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/components/agent/PhaseTimeline.tsx
+++ b/ui/src/components/agent/PhaseTimeline.tsx
@@ -24,9 +24,6 @@ const PHASE_STATUS_CLASSES: Record<string, string> = {
   skipped: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200',
 };
 
-/** Tailwind class for clamping phase summary to 2 lines. */
-const SUMMARY_LINE_CLAMP = 'line-clamp-2';
-
 /* ---------- Component ---------- */
 
 export function PhaseTimeline({ phases }: PhaseTimelineProps) {
@@ -50,7 +47,7 @@ export function PhaseTimeline({ phases }: PhaseTimelineProps) {
               </div>
             </div>
             {phase.summary && (
-              <p className={`text-muted-foreground mt-1 ${SUMMARY_LINE_CLAMP}`}>{phase.summary}</p>
+              <p className="text-muted-foreground mt-1 line-clamp-2">{phase.summary}</p>
             )}
           </div>
         </div>

--- a/ui/src/components/agent/RunDetail.tsx
+++ b/ui/src/components/agent/RunDetail.tsx
@@ -6,6 +6,7 @@ import { useAgentRun, useAgentReports, useAgentTurns, type ReportRow, type TurnR
 import { cn } from '../../lib/cn';
 import { formatEpochAgo, truncate, capitalize } from '../../lib/format';
 import { runStatusClass, formatCost, formatTokens, formatDuration } from './helpers';
+import { PhaseTimeline, type PhaseResult } from './PhaseTimeline';
 
 /* ---------- Constants ---------- */
 
@@ -186,6 +187,24 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
   const reports = reportsData?.reports ?? [];
   const turns = turnsData ?? [];
 
+  // Parse phase results from actions_taken if present
+  let phaseResults: PhaseResult[] | null = null;
+  if (run.actions_taken) {
+    try {
+      const parsed = JSON.parse(run.actions_taken) as unknown;
+      if (
+        parsed !== null &&
+        typeof parsed === 'object' &&
+        'phases' in parsed &&
+        Array.isArray((parsed as { phases: unknown }).phases)
+      ) {
+        phaseResults = (parsed as { phases: PhaseResult[] }).phases;
+      }
+    } catch {
+      // Malformed JSON — silently ignore, don't render timeline
+    }
+  }
+
   return (
     <div className="space-y-6">
       {/* Back nav */}
@@ -226,6 +245,13 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
           </div>
         )}
       </div>
+
+      {/* Phase Timeline (only shown for phased runs) */}
+      {phaseResults && phaseResults.length > 0 && (
+        <div className="rounded-lg border border-border bg-card p-4">
+          <PhaseTimeline phases={phaseResults} />
+        </div>
+      )}
 
       {/* Decisions / Reports */}
       <div className="space-y-3">

--- a/ui/src/components/agent/RunDetail.tsx
+++ b/ui/src/components/agent/RunDetail.tsx
@@ -121,7 +121,7 @@ function ReportCard({ report }: { report: ReportRow }) {
 function TurnTableRow({ turn }: { turn: TurnRow }) {
   const durationMs =
     turn.started_at !== null && turn.completed_at !== null
-      ? (turn.completed_at - turn.started_at) * 1000
+      ? (turn.completed_at - turn.started_at) * MS_PER_SECOND
       : null;
 
   return (
@@ -136,9 +136,9 @@ function TurnTableRow({ turn }: { turn: TurnRow }) {
       </td>
       <td className="px-3 py-2 text-xs text-muted-foreground font-mono">
         {durationMs !== null
-          ? durationMs < 1_000
+          ? durationMs < MS_PER_SECOND
             ? `${durationMs}ms`
-            : `${(durationMs / 1_000).toFixed(1)}s`
+            : `${(durationMs / MS_PER_SECOND).toFixed(1)}s`
           : '—'}
       </td>
     </tr>

--- a/ui/src/components/agent/RunDetail.tsx
+++ b/ui/src/components/agent/RunDetail.tsx
@@ -156,8 +156,9 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
   const [showAudit, setShowAudit] = useState(false);
 
   const { data: runData, isLoading: runLoading, isError: runError } = useAgentRun(runId);
-  const { data: reportsData, isLoading: reportsLoading } = useAgentReports(runId);
-  const { data: turnsData, isLoading: turnsLoading } = useAgentTurns(showAudit ? runId : undefined);
+  const runStatus = runData?.run?.status;
+  const { data: reportsData, isLoading: reportsLoading } = useAgentReports(runId, runStatus);
+  const { data: turnsData, isLoading: turnsLoading } = useAgentTurns(showAudit ? runId : undefined, runStatus);
 
   if (runLoading) {
     return (

--- a/ui/src/components/agent/TaskActions.tsx
+++ b/ui/src/components/agent/TaskActions.tsx
@@ -1,4 +1,5 @@
 import { useTriggerRun, useCopyTask, useDeleteTask, type TaskRow } from '../../hooks/use-agent';
+import { TASK_SOURCE_BUILTIN, TASK_SOURCE_USER } from '../../lib/constants';
 
 /* ---------- Types ---------- */
 
@@ -27,7 +28,7 @@ export function TaskActions({ task, onRunTriggered, onDeleted }: TaskActionsProp
         Run Now
       </button>
 
-      {task.source === 'built-in' && (
+      {task.source === TASK_SOURCE_BUILTIN && (
         <button
           onClick={() => copyTask.mutate({ taskId: task.id })}
           className="px-3 py-1.5 text-sm font-medium rounded-md border hover:bg-accent"
@@ -36,7 +37,7 @@ export function TaskActions({ task, onRunTriggered, onDeleted }: TaskActionsProp
         </button>
       )}
 
-      {task.source === 'user' && (
+      {task.source === TASK_SOURCE_USER && (
         <button
           onClick={() => {
             deleteTask.mutate(task.id, { onSuccess: () => onDeleted?.() });

--- a/ui/src/components/agent/TaskActions.tsx
+++ b/ui/src/components/agent/TaskActions.tsx
@@ -8,11 +8,12 @@ interface TaskActionsProps {
   task: TaskRow;
   onRunTriggered?: () => void;
   onDeleted?: () => void;
+  onCustomized?: (newTaskName: string) => void;
 }
 
 /* ---------- Component ---------- */
 
-export function TaskActions({ task, onRunTriggered, onDeleted }: TaskActionsProps) {
+export function TaskActions({ task, onRunTriggered, onDeleted, onCustomized }: TaskActionsProps) {
   const triggerRun = useTriggerRun();
   const copyTask = useCopyTask();
   const deleteTask = useDeleteTask();
@@ -33,7 +34,12 @@ export function TaskActions({ task, onRunTriggered, onDeleted }: TaskActionsProp
         <Button
           variant="outline"
           size="sm"
-          onClick={() => copyTask.mutate({ taskId: task.name })}
+          onClick={() => copyTask.mutate({ taskId: task.name }, {
+            onSuccess: (data) => {
+              const newName = data?.task?.name;
+              if (newName && onCustomized) onCustomized(newName);
+            },
+          })}
         >
           Customize
         </Button>

--- a/ui/src/components/agent/TaskActions.tsx
+++ b/ui/src/components/agent/TaskActions.tsx
@@ -1,0 +1,51 @@
+import { useTriggerRun, useCopyTask, useDeleteTask, type TaskRow } from '../../hooks/use-agent';
+
+/* ---------- Types ---------- */
+
+interface TaskActionsProps {
+  task: TaskRow;
+  onRunTriggered?: () => void;
+  onDeleted?: () => void;
+}
+
+/* ---------- Component ---------- */
+
+export function TaskActions({ task, onRunTriggered, onDeleted }: TaskActionsProps) {
+  const triggerRun = useTriggerRun();
+  const copyTask = useCopyTask();
+  const deleteTask = useDeleteTask();
+
+  return (
+    <div className="flex gap-2">
+      <button
+        onClick={() => {
+          triggerRun.mutate({ task: task.id });
+          onRunTriggered?.();
+        }}
+        className="px-3 py-1.5 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90"
+      >
+        Run Now
+      </button>
+
+      {task.source === 'built-in' && (
+        <button
+          onClick={() => copyTask.mutate({ taskId: task.id })}
+          className="px-3 py-1.5 text-sm font-medium rounded-md border hover:bg-accent"
+        >
+          Customize
+        </button>
+      )}
+
+      {task.source === 'user' && (
+        <button
+          onClick={() => {
+            deleteTask.mutate(task.id, { onSuccess: () => onDeleted?.() });
+          }}
+          className="px-3 py-1.5 text-sm font-medium rounded-md border border-destructive text-destructive hover:bg-destructive/10"
+        >
+          Delete
+        </button>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/agent/TaskActions.tsx
+++ b/ui/src/components/agent/TaskActions.tsx
@@ -1,5 +1,6 @@
 import { useTriggerRun, useCopyTask, useDeleteTask, type TaskRow } from '../../hooks/use-agent';
 import { TASK_SOURCE_BUILTIN, TASK_SOURCE_USER } from '../../lib/constants';
+import { Button } from '../ui/button';
 
 /* ---------- Types ---------- */
 
@@ -18,34 +19,36 @@ export function TaskActions({ task, onRunTriggered, onDeleted }: TaskActionsProp
 
   return (
     <div className="flex gap-2">
-      <button
+      <Button
+        size="sm"
         onClick={() => {
-          triggerRun.mutate({ task: task.id });
+          triggerRun.mutate({ task: task.name });
           onRunTriggered?.();
         }}
-        className="px-3 py-1.5 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90"
       >
         Run Now
-      </button>
+      </Button>
 
       {task.source === TASK_SOURCE_BUILTIN && (
-        <button
-          onClick={() => copyTask.mutate({ taskId: task.id })}
-          className="px-3 py-1.5 text-sm font-medium rounded-md border hover:bg-accent"
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => copyTask.mutate({ taskId: task.name })}
         >
           Customize
-        </button>
+        </Button>
       )}
 
       {task.source === TASK_SOURCE_USER && (
-        <button
+        <Button
+          variant="destructive"
+          size="sm"
           onClick={() => {
-            deleteTask.mutate(task.id, { onSuccess: () => onDeleted?.() });
+            deleteTask.mutate(task.name, { onSuccess: () => onDeleted?.() });
           }}
-          className="px-3 py-1.5 text-sm font-medium rounded-md border border-destructive text-destructive hover:bg-destructive/10"
         >
           Delete
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/ui/src/components/agent/TaskDetail.tsx
+++ b/ui/src/components/agent/TaskDetail.tsx
@@ -5,6 +5,7 @@ import { cn } from '../../lib/cn';
 import { capitalize } from '../../lib/format';
 import { taskSourceClass } from './helpers';
 import { TaskActions } from './TaskActions';
+import { TaskEditor } from './TaskEditor';
 
 /* ---------- Constants ---------- */
 
@@ -16,6 +17,7 @@ const CONFIG_GRID_COLS = 3;
 interface TaskDetailProps {
   taskId: string;
   onBack: () => void;
+  onNavigate?: (taskId: string) => void;
 }
 
 /* ---------- Helpers ---------- */
@@ -89,7 +91,7 @@ function PhaseCard({ phase, index }: { phase: PhaseDefinition; index: number }) 
 
 /* ---------- Component ---------- */
 
-export function TaskDetail({ taskId, onBack }: TaskDetailProps) {
+export function TaskDetail({ taskId, onBack, onNavigate }: TaskDetailProps) {
   const { data, isPending, isError } = useTask(taskId);
 
   if (isPending) {
@@ -145,7 +147,11 @@ export function TaskDetail({ taskId, onBack }: TaskDetailProps) {
           </span>
         </div>
 
-        <TaskActions task={task} />
+        <TaskActions
+          task={task}
+          onDeleted={onBack}
+          onCustomized={(newName) => onNavigate?.(newName)}
+        />
       </div>
 
       {/* Execution config */}
@@ -201,6 +207,9 @@ export function TaskDetail({ taskId, onBack }: TaskDetailProps) {
           </pre>
         </div>
       )}
+
+      {/* YAML Editor */}
+      <TaskEditor taskId={taskId} />
     </div>
   );
 }

--- a/ui/src/components/agent/TaskDetail.tsx
+++ b/ui/src/components/agent/TaskDetail.tsx
@@ -1,0 +1,252 @@
+import { ArrowLeft, AlertCircle } from 'lucide-react';
+import { Button } from '../ui/button';
+import { useTask } from '../../hooks/use-agent';
+import { cn } from '../../lib/cn';
+import { capitalize } from '../../lib/format';
+import { taskSourceClass } from './helpers';
+import { TaskActions } from './TaskActions';
+
+/* ---------- Constants ---------- */
+
+/** Columns in the execution config grid. */
+const CONFIG_GRID_COLS = 3;
+
+/* ---------- Types ---------- */
+
+interface TaskDetailProps {
+  taskId: string;
+  onBack: () => void;
+}
+
+interface ParsedPhase {
+  name: string;
+  prompt: string;
+  tools: string[];
+  maxTurns: number;
+  model?: string;
+  required: boolean;
+}
+
+interface ParsedExecution {
+  model?: string;
+  maxTurns?: number;
+  timeoutSeconds?: number;
+}
+
+interface ParsedConfig {
+  phases?: ParsedPhase[];
+  execution?: ParsedExecution;
+  model?: string;
+  maxTurns?: number;
+  timeoutSeconds?: number;
+}
+
+/* ---------- Helpers ---------- */
+
+function parsePhases(config: string | null): ParsedPhase[] {
+  if (!config) return [];
+  try {
+    const parsed = JSON.parse(config) as unknown;
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      'phases' in parsed &&
+      Array.isArray((parsed as { phases: unknown }).phases)
+    ) {
+      return (parsed as { phases: ParsedPhase[] }).phases;
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+function parseExecution(config: string | null): ParsedExecution {
+  if (!config) return {};
+  try {
+    const parsed = JSON.parse(config) as ParsedConfig;
+    return {
+      model: parsed.execution?.model ?? parsed.model,
+      maxTurns: parsed.execution?.maxTurns ?? parsed.maxTurns,
+      timeoutSeconds: parsed.execution?.timeoutSeconds ?? parsed.timeoutSeconds,
+    };
+  } catch {
+    return {};
+  }
+}
+
+/* ---------- Sub-components ---------- */
+
+function SkeletonDetail() {
+  return (
+    <div className="space-y-6">
+      <div className="h-8 w-24 animate-pulse rounded bg-muted" />
+      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+        <div className="h-6 w-48 animate-pulse rounded bg-muted" />
+        <div className="h-4 w-64 animate-pulse rounded bg-muted" />
+        <div className="h-8 w-32 animate-pulse rounded bg-muted" />
+      </div>
+      <div className="rounded-lg border border-border bg-card p-4 space-y-2">
+        {Array.from({ length: CONFIG_GRID_COLS }).map((_, i) => (
+          <div key={i} className="h-5 animate-pulse rounded bg-muted" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PhaseCard({ phase, index }: { phase: ParsedPhase; index: number }) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="flex h-6 w-6 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground shrink-0">
+            {index + 1}
+          </span>
+          <span className="font-medium text-sm">{phase.name}</span>
+          {!phase.required && (
+            <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">optional</span>
+          )}
+        </div>
+        <span className="text-xs text-muted-foreground font-mono shrink-0">
+          max {phase.maxTurns} turns
+        </span>
+      </div>
+
+      {phase.tools.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {phase.tools.map((tool) => (
+            <span
+              key={tool}
+              className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-mono"
+            >
+              {tool}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <pre className="rounded bg-muted p-3 text-xs font-mono text-muted-foreground whitespace-pre-wrap break-words overflow-auto max-h-40">
+        {phase.prompt}
+      </pre>
+    </div>
+  );
+}
+
+/* ---------- Component ---------- */
+
+export function TaskDetail({ taskId, onBack }: TaskDetailProps) {
+  const { data, isPending, isError } = useTask(taskId);
+
+  if (isPending) {
+    return <SkeletonDetail />;
+  }
+
+  if (isError || !data?.task) {
+    return (
+      <div className="space-y-4">
+        <Button variant="ghost" size="sm" onClick={onBack} className="gap-2 text-muted-foreground">
+          <ArrowLeft className="h-4 w-4" />
+          Tasks
+        </Button>
+        <div className="flex h-40 flex-col items-center justify-center gap-2 text-destructive">
+          <AlertCircle className="h-5 w-5" />
+          <span className="text-sm">Task not found</span>
+        </div>
+      </div>
+    );
+  }
+
+  const task = data.task;
+  const phases = parsePhases(task.config);
+  const execution = parseExecution(task.config);
+
+  return (
+    <div className="space-y-6">
+      {/* Back nav */}
+      <Button variant="ghost" size="sm" onClick={onBack} className="gap-2 text-muted-foreground">
+        <ArrowLeft className="h-4 w-4" />
+        Tasks
+      </Button>
+
+      {/* Header card */}
+      <div className="rounded-lg border border-border bg-card p-4 space-y-4">
+        <div className="flex flex-wrap items-start gap-3">
+          <div className="flex-1 space-y-1 min-w-0">
+            <h1 className="text-lg font-semibold text-foreground">
+              {task.display_name ?? task.id}
+            </h1>
+            {task.description && (
+              <p className="text-sm text-muted-foreground">{task.description}</p>
+            )}
+          </div>
+
+          <span
+            className={cn(
+              'text-xs px-2 py-0.5 rounded-full shrink-0',
+              taskSourceClass(task.source),
+            )}
+          >
+            {capitalize(task.source)}
+          </span>
+        </div>
+
+        <TaskActions task={task} />
+      </div>
+
+      {/* Execution config */}
+      {(execution.model !== undefined || execution.maxTurns !== undefined || execution.timeoutSeconds !== undefined) && (
+        <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+          <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+            Execution Config
+          </h2>
+          <div className="grid grid-cols-3 gap-4">
+            {execution.model !== undefined && (
+              <div>
+                <p className="text-xs text-muted-foreground">Model</p>
+                <p className="text-sm font-mono text-foreground mt-0.5">{execution.model}</p>
+              </div>
+            )}
+            {execution.maxTurns !== undefined && (
+              <div>
+                <p className="text-xs text-muted-foreground">Max Turns</p>
+                <p className="text-sm font-mono text-foreground mt-0.5">{execution.maxTurns}</p>
+              </div>
+            )}
+            {execution.timeoutSeconds !== undefined && (
+              <div>
+                <p className="text-xs text-muted-foreground">Timeout</p>
+                <p className="text-sm font-mono text-foreground mt-0.5">{execution.timeoutSeconds}s</p>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Phases */}
+      {phases.length > 0 ? (
+        <div className="space-y-3">
+          <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+            Phases
+            <span className="ml-2 text-foreground normal-case font-normal">
+              {phases.length} {phases.length === 1 ? 'phase' : 'phases'}
+            </span>
+          </h2>
+          {phases.map((phase, i) => (
+            <PhaseCard key={phase.name} phase={phase} index={i} />
+          ))}
+        </div>
+      ) : (
+        /* Single-phase prompt */
+        <div className="space-y-3">
+          <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+            Prompt
+          </h2>
+          <pre className="rounded-lg border border-border bg-muted p-4 text-xs font-mono text-muted-foreground whitespace-pre-wrap break-words overflow-auto max-h-96">
+            {task.prompt}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/agent/TaskDetail.tsx
+++ b/ui/src/components/agent/TaskDetail.tsx
@@ -114,7 +114,7 @@ export function TaskDetail({ taskId, onBack, onNavigate }: TaskDetailProps) {
   }
 
   const task = data.task;
-  const phases = task.phases ?? [];
+  const phases: PhaseDefinition[] = task.phases ?? [];
   const execution = getExecution(task);
 
   return (

--- a/ui/src/components/agent/TaskDetail.tsx
+++ b/ui/src/components/agent/TaskDetail.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeft, AlertCircle } from 'lucide-react';
 import { Button } from '../ui/button';
-import { useTask } from '../../hooks/use-agent';
+import { useTask, type PhaseDefinition } from '../../hooks/use-agent';
 import { cn } from '../../lib/cn';
 import { capitalize } from '../../lib/format';
 import { taskSourceClass } from './helpers';
@@ -18,61 +18,15 @@ interface TaskDetailProps {
   onBack: () => void;
 }
 
-interface ParsedPhase {
-  name: string;
-  prompt: string;
-  tools: string[];
-  maxTurns: number;
-  model?: string;
-  required: boolean;
-}
-
-interface ParsedExecution {
-  model?: string;
-  maxTurns?: number;
-  timeoutSeconds?: number;
-}
-
-interface ParsedConfig {
-  phases?: ParsedPhase[];
-  execution?: ParsedExecution;
-  model?: string;
-  maxTurns?: number;
-  timeoutSeconds?: number;
-}
-
 /* ---------- Helpers ---------- */
 
-function parsePhases(config: string | null): ParsedPhase[] {
-  if (!config) return [];
-  try {
-    const parsed = JSON.parse(config) as unknown;
-    if (
-      parsed !== null &&
-      typeof parsed === 'object' &&
-      'phases' in parsed &&
-      Array.isArray((parsed as { phases: unknown }).phases)
-    ) {
-      return (parsed as { phases: ParsedPhase[] }).phases;
-    }
-    return [];
-  } catch {
-    return [];
-  }
-}
-
-function parseExecution(config: string | null): ParsedExecution {
-  if (!config) return {};
-  try {
-    const parsed = JSON.parse(config) as ParsedConfig;
-    return {
-      model: parsed.execution?.model ?? parsed.model,
-      maxTurns: parsed.execution?.maxTurns ?? parsed.maxTurns,
-      timeoutSeconds: parsed.execution?.timeoutSeconds ?? parsed.timeoutSeconds,
-    };
-  } catch {
-    return {};
-  }
+/** Resolve effective execution config from task fields. */
+function getExecution(task: { execution?: { model?: string; maxTurns?: number; timeoutSeconds?: number }; model?: string; maxTurns?: number; timeoutSeconds?: number }) {
+  return {
+    model: task.execution?.model ?? task.model,
+    maxTurns: task.execution?.maxTurns ?? task.maxTurns,
+    timeoutSeconds: task.execution?.timeoutSeconds ?? task.timeoutSeconds,
+  };
 }
 
 /* ---------- Sub-components ---------- */
@@ -95,7 +49,7 @@ function SkeletonDetail() {
   );
 }
 
-function PhaseCard({ phase, index }: { phase: ParsedPhase; index: number }) {
+function PhaseCard({ phase, index }: { phase: PhaseDefinition; index: number }) {
   return (
     <div className="rounded-lg border border-border bg-card p-4 space-y-3">
       <div className="flex items-center justify-between gap-3">
@@ -158,8 +112,8 @@ export function TaskDetail({ taskId, onBack }: TaskDetailProps) {
   }
 
   const task = data.task;
-  const phases = parsePhases(task.config);
-  const execution = parseExecution(task.config);
+  const phases = task.phases ?? [];
+  const execution = getExecution(task);
 
   return (
     <div className="space-y-6">
@@ -174,7 +128,7 @@ export function TaskDetail({ taskId, onBack }: TaskDetailProps) {
         <div className="flex flex-wrap items-start gap-3">
           <div className="flex-1 space-y-1 min-w-0">
             <h1 className="text-lg font-semibold text-foreground">
-              {task.display_name ?? task.id}
+              {task.displayName}
             </h1>
             {task.description && (
               <p className="text-sm text-muted-foreground">{task.description}</p>
@@ -184,10 +138,10 @@ export function TaskDetail({ taskId, onBack }: TaskDetailProps) {
           <span
             className={cn(
               'text-xs px-2 py-0.5 rounded-full shrink-0',
-              taskSourceClass(task.source),
+              taskSourceClass(task.source ?? ''),
             )}
           >
-            {capitalize(task.source)}
+            {capitalize(task.source ?? 'built-in')}
           </span>
         </div>
 

--- a/ui/src/components/agent/TaskEditor.tsx
+++ b/ui/src/components/agent/TaskEditor.tsx
@@ -1,0 +1,122 @@
+import { useState, useEffect } from 'react';
+import { Button } from '../ui/button';
+import { useTaskYaml, useUpdateTask } from '../../hooks/use-agent';
+
+/* ---------- Constants ---------- */
+
+/** Minimum height for the YAML editor textarea. */
+const EDITOR_MIN_ROWS = 20;
+
+/* ---------- Types ---------- */
+
+interface TaskEditorProps {
+  taskId: string;
+  onSaved?: () => void;
+}
+
+/* ---------- Component ---------- */
+
+export function TaskEditor({ taskId, onSaved }: TaskEditorProps) {
+  const { data, isLoading, isError } = useTaskYaml(taskId);
+  const updateTask = useUpdateTask();
+  const [yaml, setYaml] = useState('');
+  const [dirty, setDirty] = useState(false);
+
+  // Sync editor content when data loads
+  useEffect(() => {
+    if (data?.yaml) {
+      setYaml(data.yaml);
+      setDirty(false);
+    }
+  }, [data?.yaml]);
+
+  function handleChange(value: string) {
+    setYaml(value);
+    setDirty(true);
+  }
+
+  function handleSave() {
+    updateTask.mutate(
+      { taskId, yaml },
+      {
+        onSuccess: () => {
+          setDirty(false);
+          onSaved?.();
+        },
+      },
+    );
+  }
+
+  function handleReset() {
+    if (data?.yaml) {
+      setYaml(data.yaml);
+      setDirty(false);
+    }
+  }
+
+  if (isLoading) {
+    return <div className="h-64 animate-pulse rounded-lg bg-muted" />;
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+        Failed to load task YAML.
+      </div>
+    );
+  }
+
+  const isReadOnly = data?.source !== 'user';
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+          Task Definition {isReadOnly && '(read-only)'}
+        </h2>
+        {!isReadOnly && (
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleReset}
+              disabled={!dirty}
+            >
+              Reset
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleSave}
+              disabled={!dirty || updateTask.isPending}
+            >
+              {updateTask.isPending ? 'Saving...' : 'Save'}
+            </Button>
+          </div>
+        )}
+      </div>
+
+      <textarea
+        value={yaml}
+        onChange={(e) => handleChange(e.target.value)}
+        readOnly={isReadOnly}
+        rows={EDITOR_MIN_ROWS}
+        spellCheck={false}
+        className={`w-full rounded-lg border bg-muted p-4 font-mono text-sm text-foreground leading-relaxed resize-y focus:outline-none focus:ring-2 focus:ring-ring ${
+          isReadOnly ? 'opacity-75 cursor-not-allowed' : ''
+        }`}
+      />
+
+      {updateTask.isError && (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+          {updateTask.error.message}
+        </div>
+      )}
+
+      {updateTask.isSuccess && !dirty && (
+        <div className="rounded-lg border border-green-500/30 bg-green-500/5 p-3 text-sm text-green-700 dark:text-green-400">
+          Task saved successfully.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/agent/TaskList.tsx
+++ b/ui/src/components/agent/TaskList.tsx
@@ -1,8 +1,14 @@
 import { useAgentTasks, type TaskRow } from '../../hooks/use-agent';
-import { taskSourceClass, formatPhaseCount } from './helpers';
+import { taskSourceClass } from './helpers';
 
 interface TaskListProps {
   onSelect: (taskId: string) => void;
+}
+
+/** Format phase count from the task's phases array. */
+function formatPhaseCount(task: TaskRow): string {
+  if (!task.phases || task.phases.length === 0) return 'Single query';
+  return `${task.phases.length} phases`;
 }
 
 export function TaskList({ onSelect }: TaskListProps) {
@@ -27,22 +33,22 @@ export function TaskList({ onSelect }: TaskListProps) {
     <div className="space-y-2">
       {tasks.map((task: TaskRow) => (
         <button
-          key={task.id}
-          onClick={() => onSelect(task.id)}
+          key={task.name}
+          onClick={() => onSelect(task.name)}
           className="w-full text-left p-4 rounded-lg border hover:bg-accent/50 transition-colors"
         >
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <span className="font-medium text-sm">{task.display_name ?? task.id}</span>
-              <span className={`text-xs px-2 py-0.5 rounded-full ${taskSourceClass(task.source)}`}>
-                {task.source}
+              <span className="font-medium text-sm">{task.displayName}</span>
+              <span className={`text-xs px-2 py-0.5 rounded-full ${taskSourceClass(task.source ?? '')}`}>
+                {task.source ?? 'built-in'}
               </span>
-              {task.is_default === 1 && (
+              {task.isDefault && (
                 <span className="text-xs text-muted-foreground">(default)</span>
               )}
             </div>
             <span className="text-xs text-muted-foreground">
-              {formatPhaseCount(task.config)}
+              {formatPhaseCount(task)}
             </span>
           </div>
           {task.description && (

--- a/ui/src/components/agent/TaskList.tsx
+++ b/ui/src/components/agent/TaskList.tsx
@@ -1,0 +1,55 @@
+import { useAgentTasks, type TaskRow } from '../../hooks/use-agent';
+import { taskSourceClass, formatPhaseCount } from './helpers';
+
+interface TaskListProps {
+  onSelect: (taskId: string) => void;
+}
+
+export function TaskList({ onSelect }: TaskListProps) {
+  const { data, isLoading } = useAgentTasks();
+  const tasks = data?.tasks ?? [];
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-20 rounded-lg border animate-pulse bg-muted" />
+        ))}
+      </div>
+    );
+  }
+
+  if (tasks.length === 0) {
+    return <p className="text-muted-foreground text-sm">No tasks found.</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      {tasks.map((task: TaskRow) => (
+        <button
+          key={task.id}
+          onClick={() => onSelect(task.id)}
+          className="w-full text-left p-4 rounded-lg border hover:bg-accent/50 transition-colors"
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className="font-medium text-sm">{task.display_name ?? task.id}</span>
+              <span className={`text-xs px-2 py-0.5 rounded-full ${taskSourceClass(task.source)}`}>
+                {task.source}
+              </span>
+              {task.is_default === 1 && (
+                <span className="text-xs text-muted-foreground">(default)</span>
+              )}
+            </div>
+            <span className="text-xs text-muted-foreground">
+              {formatPhaseCount(task.config)}
+            </span>
+          </div>
+          {task.description && (
+            <p className="text-xs text-muted-foreground mt-1 line-clamp-1">{task.description}</p>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/components/agent/TriggerRun.tsx
+++ b/ui/src/components/agent/TriggerRun.tsx
@@ -18,11 +18,6 @@ import {
 } from '../ui/select';
 import { useAgentTasks, useTriggerRun, type TaskRow } from '../../hooks/use-agent';
 
-/* ---------- Constants ---------- */
-
-/** Placeholder value for "no task selected" in the Select component. */
-const NO_TASK_VALUE = '__default__';
-
 /* ---------- Helpers ---------- */
 
 function taskLabel(task: TaskRow): string {
@@ -41,11 +36,11 @@ export function TriggerRun({ open, onOpenChange, onTriggered }: TriggerRunProps)
   const [selectedTask, setSelectedTask] = useState<string | undefined>(undefined);
   const [instruction, setInstruction] = useState('');
 
-  const { data: tasks, isLoading: tasksLoading } = useAgentTasks();
+  const { data: tasksData, isLoading: tasksLoading } = useAgentTasks();
   const { mutate: triggerRun, isPending, error } = useTriggerRun();
 
   // Pre-select the default task once tasks load
-  const availableTasks = tasks ?? [];
+  const availableTasks = tasksData?.tasks ?? [];
   const defaultTask = availableTasks.find(t => t.is_default === 1);
   const effectiveSelection = selectedTask ?? defaultTask?.id ?? availableTasks[0]?.id ?? '';
 

--- a/ui/src/components/agent/TriggerRun.tsx
+++ b/ui/src/components/agent/TriggerRun.tsx
@@ -21,7 +21,7 @@ import { useAgentTasks, useTriggerRun, type TaskRow } from '../../hooks/use-agen
 /* ---------- Helpers ---------- */
 
 function taskLabel(task: TaskRow): string {
-  return task.display_name ?? task.id;
+  return task.displayName ?? task.name;
 }
 
 /* ---------- Component ---------- */
@@ -41,8 +41,8 @@ export function TriggerRun({ open, onOpenChange, onTriggered }: TriggerRunProps)
 
   // Pre-select the default task once tasks load
   const availableTasks = tasksData?.tasks ?? [];
-  const defaultTask = availableTasks.find(t => t.is_default === 1);
-  const effectiveSelection = selectedTask ?? defaultTask?.id ?? availableTasks[0]?.id ?? '';
+  const defaultTask = availableTasks.find(t => t.isDefault);
+  const effectiveSelection = selectedTask ?? defaultTask?.name ?? availableTasks[0]?.name ?? '';
 
   function handleRun() {
     const payload = {
@@ -86,9 +86,9 @@ export function TriggerRun({ open, onOpenChange, onTriggered }: TriggerRunProps)
                 </SelectTrigger>
                 <SelectContent>
                   {availableTasks.map((task) => (
-                    <SelectItem key={task.id} value={task.id}>
+                    <SelectItem key={task.name} value={task.name}>
                       {taskLabel(task)}
-                      {task.is_default === 1 && (
+                      {task.isDefault && (
                         <span className="ml-1 text-xs text-muted-foreground">(default)</span>
                       )}
                     </SelectItem>

--- a/ui/src/components/agent/TriggerRun.tsx
+++ b/ui/src/components/agent/TriggerRun.tsx
@@ -40,8 +40,8 @@ export function TriggerRun({ open, onOpenChange, onTriggered }: TriggerRunProps)
   const { mutate: triggerRun, isPending, error } = useTriggerRun();
 
   // Pre-select the default task once tasks load
-  const availableTasks = tasksData?.tasks ?? [];
-  const defaultTask = availableTasks.find(t => t.isDefault);
+  const availableTasks: TaskRow[] = tasksData?.tasks ?? [];
+  const defaultTask = availableTasks.find((t: TaskRow) => t.isDefault);
   const effectiveSelection = selectedTask ?? defaultTask?.name ?? availableTasks[0]?.name ?? '';
 
   function handleRun() {

--- a/ui/src/components/agent/helpers.ts
+++ b/ui/src/components/agent/helpers.ts
@@ -1,5 +1,7 @@
 /** Shared helpers for agent run components. */
 
+import { TASK_SOURCE_USER } from '../../lib/constants';
+
 /** Tailwind class string for run status badges. */
 export function runStatusClass(status: string): string {
   switch (status) {
@@ -22,20 +24,12 @@ export function formatTokens(tokens: number | null): string {
   return tokens.toLocaleString();
 }
 
-/** Format the duration between two epoch-second timestamps. */
-export function formatDuration(startEpoch: number | null, endEpoch: number | null): string {
-  if (startEpoch === null || endEpoch === null) return '\u2014';
-  const ms = (endEpoch - startEpoch) * 1000;
-  if (ms < 1_000) return `${ms}ms`;
-  if (ms < 60_000) return `${(ms / 1_000).toFixed(1)}s`;
-  const minutes = Math.floor(ms / 60_000);
-  const seconds = Math.floor((ms % 60_000) / 1_000);
-  return `${minutes}m ${seconds}s`;
-}
+// formatDuration re-exported from the shared format library.
+export { formatDuration } from '../../lib/format';
 
 /** Badge classes for task source (built-in vs user). */
 export function taskSourceClass(source: string): string {
-  return source === 'user'
+  return source === TASK_SOURCE_USER
     ? 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200'
     : 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200';
 }

--- a/ui/src/components/agent/helpers.ts
+++ b/ui/src/components/agent/helpers.ts
@@ -34,15 +34,3 @@ export function taskSourceClass(source: string): string {
     : 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200';
 }
 
-/** Format phase count for display. */
-export function formatPhaseCount(config: string | null | undefined): string {
-  if (!config) return 'Single query';
-  try {
-    const parsed = JSON.parse(config);
-    const phases = parsed?.phases;
-    if (!Array.isArray(phases) || phases.length === 0) return 'Single query';
-    return `${phases.length} phases`;
-  } catch {
-    return 'Single query';
-  }
-}

--- a/ui/src/components/agent/helpers.ts
+++ b/ui/src/components/agent/helpers.ts
@@ -32,3 +32,23 @@ export function formatDuration(startEpoch: number | null, endEpoch: number | nul
   const seconds = Math.floor((ms % 60_000) / 1_000);
   return `${minutes}m ${seconds}s`;
 }
+
+/** Badge classes for task source (built-in vs user). */
+export function taskSourceClass(source: string): string {
+  return source === 'user'
+    ? 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200'
+    : 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200';
+}
+
+/** Format phase count for display. */
+export function formatPhaseCount(config: string | null | undefined): string {
+  if (!config) return 'Single query';
+  try {
+    const parsed = JSON.parse(config);
+    const phases = parsed?.phases;
+    if (!Array.isArray(phases) || phases.length === 0) return 'Single query';
+    return `${phases.length} phases`;
+  } catch {
+    return 'Single query';
+  }
+}

--- a/ui/src/components/sessions/ActivityList.tsx
+++ b/ui/src/components/sessions/ActivityList.tsx
@@ -5,11 +5,7 @@ import { cn } from '../../lib/cn';
 
 /* ---------- Helpers ---------- */
 
-function formatDuration(ms: number | null): string {
-  if (ms === null) return '—';
-  if (ms < 1000) return `${ms}ms`;
-  return `${(ms / 1000).toFixed(1)}s`;
-}
+import { formatDurationMs as formatDuration } from '../../lib/format';
 
 /* ---------- Sub-components ---------- */
 

--- a/ui/src/components/sessions/SessionDetail.tsx
+++ b/ui/src/components/sessions/SessionDetail.tsx
@@ -27,14 +27,8 @@ function epochToAbsolute(epoch: number | null): string {
   return new Date(epoch * 1000).toLocaleString();
 }
 
-function formatDurationSec(startEpoch: number | null, endEpoch: number | null): string {
-  if (startEpoch === null || endEpoch === null) return '—';
-  const seconds = endEpoch - startEpoch;
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  const rem = seconds % 60;
-  return `${minutes}m ${rem}s`;
-}
+// Duration formatting imported from shared library
+import { formatDuration as formatDurationSec } from '../../lib/format';
 
 /* ---------- Sub-components ---------- */
 

--- a/ui/src/hooks/use-agent.ts
+++ b/ui/src/hooks/use-agent.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { fetchJson, postJson } from '../lib/api';
+import { fetchJson, postJson, deleteJson } from '../lib/api';
 
 /* ---------- Constants ---------- */
 
@@ -95,6 +95,41 @@ export interface TriggerRunResponse {
   message: string;
 }
 
+export interface TasksResponse {
+  tasks: TaskRow[];
+}
+
+export interface TaskDetailResponse {
+  task: TaskRow;
+}
+
+export interface PhaseDefinition {
+  name: string;
+  prompt: string;
+  tools: string[];
+  maxTurns: number;
+  model?: string;
+  required: boolean;
+}
+
+export interface CreateTaskPayload {
+  name: string;
+  displayName: string;
+  description: string;
+  agent: string;
+  prompt: string;
+  isDefault: boolean;
+  phases?: PhaseDefinition[];
+  model?: string;
+  maxTurns?: number;
+  timeoutSeconds?: number;
+}
+
+export interface CopyTaskPayload {
+  taskId: string;
+  name?: string;
+}
+
 /* ---------- Hooks ---------- */
 
 export function useAgentRuns(options?: { limit?: number }) {
@@ -139,10 +174,51 @@ export function useAgentTurns(runId: string | undefined) {
 }
 
 export function useAgentTasks() {
-  return useQuery<TaskRow[]>({
+  return useQuery<TasksResponse>({
     queryKey: ['agent-tasks'],
-    queryFn: ({ signal }) => fetchJson<TaskRow[]>('/agent/tasks', { signal }),
+    queryFn: ({ signal }) => fetchJson<TasksResponse>('/agent/tasks', { signal }),
     staleTime: TASKS_STALE_TIME,
+  });
+}
+
+export function useTask(taskId: string | undefined) {
+  return useQuery<TaskDetailResponse>({
+    queryKey: ['agent-task', taskId],
+    queryFn: ({ signal }) =>
+      fetchJson<TaskDetailResponse>(`/agent/tasks/${taskId}`, { signal }),
+    enabled: taskId !== undefined,
+    staleTime: TASKS_STALE_TIME,
+  });
+}
+
+export function useCreateTask() {
+  const queryClient = useQueryClient();
+  return useMutation<TaskDetailResponse, Error, CreateTaskPayload>({
+    mutationFn: (payload) => postJson<TaskDetailResponse>('/agent/tasks', payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['agent-tasks'] });
+    },
+  });
+}
+
+export function useCopyTask() {
+  const queryClient = useQueryClient();
+  return useMutation<TaskDetailResponse, Error, CopyTaskPayload>({
+    mutationFn: ({ taskId, name }) =>
+      postJson<TaskDetailResponse>(`/agent/tasks/${taskId}/copy`, name ? { name } : {}),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['agent-tasks'] });
+    },
+  });
+}
+
+export function useDeleteTask() {
+  const queryClient = useQueryClient();
+  return useMutation<{ ok: boolean }, Error, string>({
+    mutationFn: (taskId) => deleteJson<{ ok: boolean }>(`/agent/tasks/${taskId}`),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['agent-tasks'] });
+    },
   });
 }
 

--- a/ui/src/hooks/use-agent.ts
+++ b/ui/src/hooks/use-agent.ts
@@ -71,18 +71,28 @@ export interface TurnRow {
   completed_at: number | null;
 }
 
+/**
+ * Task shape returned by the registry-backed API.
+ * Uses camelCase field names matching the AgentTask interface on the backend.
+ */
 export interface TaskRow {
-  id: string;
-  agent_id: string;
-  source: string;
-  display_name: string | null;
-  description: string | null;
+  name: string;
+  displayName: string;
+  description: string;
+  agent: string;
   prompt: string;
-  is_default: number;
-  tool_overrides: string | null;
-  config: string | null;
-  created_at: number;
-  updated_at: number | null;
+  isDefault: boolean;
+  source?: string;
+  isBuiltin?: boolean;
+  toolOverrides?: string[];
+  model?: string;
+  maxTurns?: number;
+  timeoutSeconds?: number;
+  phases?: PhaseDefinition[];
+  execution?: { model?: string; maxTurns?: number; timeoutSeconds?: number };
+  contextQueries?: Record<string, unknown[]>;
+  orchestrator?: { enabled: boolean; model?: string; maxTurns?: number };
+  schemaVersion?: number;
 }
 
 export interface TriggerRunPayload {

--- a/ui/src/hooks/use-agent.ts
+++ b/ui/src/hooks/use-agent.ts
@@ -1,19 +1,21 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { usePowerQuery } from './use-power-query';
 import { fetchJson, postJson, putJson, deleteJson } from '../lib/api';
+import { POLL_INTERVALS } from '../lib/constants';
 
 /* ---------- Constants ---------- */
 
-/** Cache TTL for agent run list (10 seconds — runs are polled while one is active). */
-const RUNS_STALE_TIME = 10_000;
+/** Poll interval for agent run list (matches POLL_INTERVALS.STATS). */
+const RUNS_POLL_INTERVAL = POLL_INTERVALS.STATS;
 
-/** Cache TTL for a single run detail (10 seconds). */
-const RUN_DETAIL_STALE_TIME = 10_000;
+/** Poll interval for a single run detail (faster — watching active run). */
+const RUN_DETAIL_POLL_INTERVAL = POLL_INTERVALS.HEALTH;
 
-/** Cache TTL for run reports (30 seconds — reports don't change after a run ends). */
-const REPORTS_STALE_TIME = 30_000;
+/** Poll interval for run reports (moderate — updates during execution). */
+const REPORTS_POLL_INTERVAL = POLL_INTERVALS.STATS;
 
-/** Cache TTL for audit trail turns (30 seconds). */
-const TURNS_STALE_TIME = 30_000;
+/** Poll interval for audit trail turns. */
+const TURNS_POLL_INTERVAL = POLL_INTERVALS.STATS;
 
 /** Cache TTL for available task definitions (60 seconds — rarely changes). */
 const TASKS_STALE_TIME = 60_000;
@@ -145,41 +147,45 @@ export interface CopyTaskPayload {
 export function useAgentRuns(options?: { limit?: number }) {
   const limit = options?.limit ?? DEFAULT_RUNS_LIMIT;
 
-  return useQuery<RunsResponse>({
+  return usePowerQuery<RunsResponse>({
     queryKey: ['agent-runs', limit],
     queryFn: ({ signal }) =>
       fetchJson<RunsResponse>(`/agent/runs?limit=${limit}`, { signal }),
-    staleTime: RUNS_STALE_TIME,
+    pollCategory: 'standard',
+    refetchInterval: RUNS_POLL_INTERVAL,
   });
 }
 
 export function useAgentRun(id: string | undefined) {
-  return useQuery<RunDetailResponse>({
+  return usePowerQuery<RunDetailResponse>({
     queryKey: ['agent-run', id],
     queryFn: ({ signal }) =>
       fetchJson<RunDetailResponse>(`/agent/runs/${id}`, { signal }),
     enabled: id !== undefined,
-    staleTime: RUN_DETAIL_STALE_TIME,
+    pollCategory: 'realtime',
+    refetchInterval: RUN_DETAIL_POLL_INTERVAL,
   });
 }
 
 export function useAgentReports(runId: string | undefined) {
-  return useQuery<ReportsResponse>({
+  return usePowerQuery<ReportsResponse>({
     queryKey: ['agent-reports', runId],
     queryFn: ({ signal }) =>
       fetchJson<ReportsResponse>(`/agent/runs/${runId}/reports`, { signal }),
     enabled: runId !== undefined,
-    staleTime: REPORTS_STALE_TIME,
+    pollCategory: 'standard',
+    refetchInterval: REPORTS_POLL_INTERVAL,
   });
 }
 
 export function useAgentTurns(runId: string | undefined) {
-  return useQuery<TurnRow[]>({
+  return usePowerQuery<TurnRow[]>({
     queryKey: ['agent-turns', runId],
     queryFn: ({ signal }) =>
       fetchJson<TurnRow[]>(`/agent/runs/${runId}/turns`, { signal }),
     enabled: runId !== undefined,
-    staleTime: TURNS_STALE_TIME,
+    pollCategory: 'standard',
+    refetchInterval: TURNS_POLL_INTERVAL,
   });
 }
 

--- a/ui/src/hooks/use-agent.ts
+++ b/ui/src/hooks/use-agent.ts
@@ -14,6 +14,9 @@ const RUN_DETAIL_POLL_INTERVAL = POLL_INTERVALS.HEALTH;
 /** Poll interval for run reports (moderate — updates during execution). */
 const REPORTS_POLL_INTERVAL = POLL_INTERVALS.STATS;
 
+/** Run statuses that indicate the run is finished — stop polling. */
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'skipped']);
+
 /** Poll interval for audit trail turns. */
 const TURNS_POLL_INTERVAL = POLL_INTERVALS.STATS;
 
@@ -157,35 +160,43 @@ export function useAgentRuns(options?: { limit?: number }) {
 }
 
 export function useAgentRun(id: string | undefined) {
-  return usePowerQuery<RunDetailResponse>({
+  const result = useQuery<RunDetailResponse>({
     queryKey: ['agent-run', id],
     queryFn: ({ signal }) =>
       fetchJson<RunDetailResponse>(`/agent/runs/${id}`, { signal }),
     enabled: id !== undefined,
-    pollCategory: 'realtime',
-    refetchInterval: RUN_DETAIL_POLL_INTERVAL,
+    refetchInterval: (query) => {
+      const status = query.state.data?.run?.status;
+      if (status && TERMINAL_STATUSES.has(status)) return false;
+      return RUN_DETAIL_POLL_INTERVAL;
+    },
   });
+  return result;
 }
 
-export function useAgentReports(runId: string | undefined) {
+export function useAgentReports(runId: string | undefined, runStatus?: string) {
+  const isTerminal = runStatus ? TERMINAL_STATUSES.has(runStatus) : false;
+
   return usePowerQuery<ReportsResponse>({
     queryKey: ['agent-reports', runId],
     queryFn: ({ signal }) =>
       fetchJson<ReportsResponse>(`/agent/runs/${runId}/reports`, { signal }),
     enabled: runId !== undefined,
     pollCategory: 'standard',
-    refetchInterval: REPORTS_POLL_INTERVAL,
+    refetchInterval: isTerminal ? 0 : REPORTS_POLL_INTERVAL,
   });
 }
 
-export function useAgentTurns(runId: string | undefined) {
+export function useAgentTurns(runId: string | undefined, runStatus?: string) {
+  const isTerminal = runStatus ? TERMINAL_STATUSES.has(runStatus) : false;
+
   return usePowerQuery<TurnRow[]>({
     queryKey: ['agent-turns', runId],
     queryFn: ({ signal }) =>
       fetchJson<TurnRow[]>(`/agent/runs/${runId}/turns`, { signal }),
     enabled: runId !== undefined,
     pollCategory: 'standard',
-    refetchInterval: TURNS_POLL_INTERVAL,
+    refetchInterval: isTerminal ? 0 : TURNS_POLL_INTERVAL,
   });
 }
 

--- a/ui/src/hooks/use-agent.ts
+++ b/ui/src/hooks/use-agent.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { fetchJson, postJson, deleteJson } from '../lib/api';
+import { fetchJson, postJson, putJson, deleteJson } from '../lib/api';
 
 /* ---------- Constants ---------- */
 
@@ -228,6 +228,31 @@ export function useDeleteTask() {
     mutationFn: (taskId) => deleteJson<{ ok: boolean }>(`/agent/tasks/${taskId}`),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['agent-tasks'] });
+    },
+  });
+}
+
+/** Fetch a task's YAML representation for editing. */
+export function useTaskYaml(taskId: string | undefined) {
+  return useQuery<{ yaml: string; source: string }>({
+    queryKey: ['agent-task-yaml', taskId],
+    queryFn: ({ signal }) =>
+      fetchJson<{ yaml: string; source: string }>(`/agent/tasks/${taskId}/yaml`, { signal }),
+    enabled: taskId !== undefined,
+    staleTime: TASKS_STALE_TIME,
+  });
+}
+
+/** Update a user task from raw YAML content. */
+export function useUpdateTask() {
+  const queryClient = useQueryClient();
+  return useMutation<TaskDetailResponse, Error, { taskId: string; yaml: string }>({
+    mutationFn: ({ taskId, yaml }) =>
+      putJson<TaskDetailResponse>(`/agent/tasks/${taskId}`, { yaml }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['agent-tasks'] });
+      void queryClient.invalidateQueries({ queryKey: ['agent-task'] });
+      void queryClient.invalidateQueries({ queryKey: ['agent-task-yaml'] });
     },
   });
 }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -27,6 +27,10 @@ export async function putJson<T>(path: string, body: unknown): Promise<T> {
   return fetchJson(path, { method: 'PUT', body: JSON.stringify(body) });
 }
 
+export async function deleteJson<T>(path: string): Promise<T> {
+  return fetchJson(path, { method: 'DELETE' });
+}
+
 export class ApiError extends Error {
   constructor(public status: number, public body: unknown) {
     super(`API error ${status}`);

--- a/ui/src/lib/constants.ts
+++ b/ui/src/lib/constants.ts
@@ -14,3 +14,7 @@ export const MODELS_STALE_TIME = 30_000;
 export const LOG_LEVELS = ['debug', 'info', 'warn', 'error'] as const;
 export type LogLevel = (typeof LOG_LEVELS)[number];
 export const LEVEL_ORDER: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+
+/** Task source labels — must match backend BUILT_IN_SOURCE / USER_TASK_SOURCE. */
+export const TASK_SOURCE_BUILTIN = 'built-in';
+export const TASK_SOURCE_USER = 'user';

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -49,3 +49,27 @@ export function truncate(text: string | null, max: number): string {
 export function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
+
+/**
+ * Format the duration between two epoch-second timestamps as a human-readable string.
+ * Returns an em dash if either timestamp is null.
+ */
+export function formatDuration(startEpoch: number | null, endEpoch: number | null): string {
+  if (startEpoch === null || endEpoch === null) return '\u2014';
+  const ms = (endEpoch - startEpoch) * MS_PER_SECOND;
+  if (ms < MS_PER_SECOND) return `${ms}ms`;
+  if (ms < SECONDS_PER_MINUTE * MS_PER_SECOND) return `${(ms / MS_PER_SECOND).toFixed(1)}s`;
+  const minutes = Math.floor(ms / (SECONDS_PER_MINUTE * MS_PER_SECOND));
+  const seconds = Math.floor((ms % (SECONDS_PER_MINUTE * MS_PER_SECOND)) / MS_PER_SECOND);
+  return `${minutes}m ${seconds}s`;
+}
+
+/**
+ * Format a millisecond duration as a human-readable string.
+ * Returns an em dash if null.
+ */
+export function formatDurationMs(ms: number | null): string {
+  if (ms === null) return '\u2014';
+  if (ms < MS_PER_SECOND) return `${ms}ms`;
+  return `${(ms / MS_PER_SECOND).toFixed(1)}s`;
+}

--- a/ui/src/pages/Agent.tsx
+++ b/ui/src/pages/Agent.tsx
@@ -67,7 +67,11 @@ export default function Agent() {
       {/* Tasks tab */}
       {tab === 'tasks' && (
         selectedTaskId ? (
-          <TaskDetail taskId={selectedTaskId} onBack={() => setSelectedTaskId(undefined)} />
+          <TaskDetail
+            taskId={selectedTaskId}
+            onBack={() => setSelectedTaskId(undefined)}
+            onNavigate={setSelectedTaskId}
+          />
         ) : (
           <TaskList onSelect={setSelectedTaskId} />
         )

--- a/ui/src/pages/Agent.tsx
+++ b/ui/src/pages/Agent.tsx
@@ -4,9 +4,15 @@ import { Button } from '../components/ui/button';
 import { RunList } from '../components/agent/RunList';
 import { RunDetail } from '../components/agent/RunDetail';
 import { TriggerRun } from '../components/agent/TriggerRun';
+import { TaskList } from '../components/agent/TaskList';
+import { TaskDetail } from '../components/agent/TaskDetail';
+
+type AgentTab = 'runs' | 'tasks';
 
 export default function Agent() {
+  const [tab, setTab] = useState<AgentTab>('runs');
   const [selectedRunId, setSelectedRunId] = useState<string | undefined>();
+  const [selectedTaskId, setSelectedTaskId] = useState<string | undefined>();
   const [triggerOpen, setTriggerOpen] = useState(false);
 
   return (
@@ -15,24 +21,56 @@ export default function Agent() {
         <div>
           <h1 className="text-2xl font-bold">Agent</h1>
           <p className="text-sm text-muted-foreground mt-0.5">
-            Agent runs — what Myco observed, decided, and wrote
+            Intelligence runs and task configuration
           </p>
         </div>
-        <Button
-          variant="outline"
-          size="sm"
-          className="gap-2"
-          onClick={() => setTriggerOpen(true)}
-        >
-          <Play className="h-3.5 w-3.5" />
-          Run Now
-        </Button>
+
+        <div className="flex items-center gap-3">
+          {/* Tab switcher */}
+          <div className="flex gap-1 p-1 rounded-lg bg-muted">
+            <button
+              onClick={() => { setTab('runs'); setSelectedTaskId(undefined); }}
+              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                tab === 'runs' ? 'bg-background shadow-sm' : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Runs
+            </button>
+            <button
+              onClick={() => { setTab('tasks'); setSelectedRunId(undefined); }}
+              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                tab === 'tasks' ? 'bg-background shadow-sm' : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Tasks
+            </button>
+          </div>
+
+          {tab === 'runs' && (
+            <Button variant="outline" size="sm" className="gap-2" onClick={() => setTriggerOpen(true)}>
+              <Play className="h-3.5 w-3.5" />
+              Run Now
+            </Button>
+          )}
+        </div>
       </div>
 
-      {selectedRunId ? (
-        <RunDetail runId={selectedRunId} onBack={() => setSelectedRunId(undefined)} />
-      ) : (
-        <RunList onSelectRun={setSelectedRunId} onTriggerRun={() => setTriggerOpen(true)} />
+      {/* Runs tab */}
+      {tab === 'runs' && (
+        selectedRunId ? (
+          <RunDetail runId={selectedRunId} onBack={() => setSelectedRunId(undefined)} />
+        ) : (
+          <RunList onSelectRun={setSelectedRunId} onTriggerRun={() => setTriggerOpen(true)} />
+        )
+      )}
+
+      {/* Tasks tab */}
+      {tab === 'tasks' && (
+        selectedTaskId ? (
+          <TaskDetail taskId={selectedTaskId} onBack={() => setSelectedTaskId(undefined)} />
+        ) : (
+          <TaskList onSelect={setSelectedTaskId} />
+        )
       )}
 
       <TriggerRun

--- a/ui/src/pages/Agent.tsx
+++ b/ui/src/pages/Agent.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Play } from 'lucide-react';
 import { Button } from '../components/ui/button';
 import { RunList } from '../components/agent/RunList';
@@ -9,11 +9,58 @@ import { TaskDetail } from '../components/agent/TaskDetail';
 
 type AgentTab = 'runs' | 'tasks';
 
+/* ---------- URL state helpers ---------- */
+
+/** URL search param keys for persistent navigation state. */
+const PARAM_TAB = 'tab';
+const PARAM_RUN = 'run';
+const PARAM_TASK = 'task';
+
+/** Read initial state from URL search params. */
+function readUrlState(): { tab: AgentTab; runId?: string; taskId?: string } {
+  const params = new URLSearchParams(window.location.search);
+  const tab = params.get(PARAM_TAB) === 'tasks' ? 'tasks' : 'runs';
+  return {
+    tab,
+    runId: params.get(PARAM_RUN) ?? undefined,
+    taskId: params.get(PARAM_TASK) ?? undefined,
+  };
+}
+
+/** Write navigation state to URL search params (replaceState, no history entry). */
+function writeUrlState(tab: AgentTab, runId?: string, taskId?: string): void {
+  const params = new URLSearchParams();
+  if (tab !== 'runs') params.set(PARAM_TAB, tab);
+  if (runId) params.set(PARAM_RUN, runId);
+  if (taskId) params.set(PARAM_TASK, taskId);
+  const search = params.toString();
+  const url = search ? `${window.location.pathname}?${search}` : window.location.pathname;
+  window.history.replaceState(null, '', url);
+}
+
+/* ---------- Component ---------- */
+
 export default function Agent() {
-  const [tab, setTab] = useState<AgentTab>('runs');
-  const [selectedRunId, setSelectedRunId] = useState<string | undefined>();
-  const [selectedTaskId, setSelectedTaskId] = useState<string | undefined>();
+  const initial = readUrlState();
+  const [tab, setTab] = useState<AgentTab>(initial.tab);
+  const [selectedRunId, setSelectedRunId] = useState<string | undefined>(initial.runId);
+  const [selectedTaskId, setSelectedTaskId] = useState<string | undefined>(initial.taskId);
   const [triggerOpen, setTriggerOpen] = useState(false);
+
+  // Sync URL whenever state changes
+  useEffect(() => {
+    writeUrlState(tab, selectedRunId, selectedTaskId);
+  }, [tab, selectedRunId, selectedTaskId]);
+
+  const switchToRuns = useCallback(() => {
+    setTab('runs');
+    setSelectedTaskId(undefined);
+  }, []);
+
+  const switchToTasks = useCallback(() => {
+    setTab('tasks');
+    setSelectedRunId(undefined);
+  }, []);
 
   return (
     <div className="p-6 space-y-4">
@@ -29,7 +76,7 @@ export default function Agent() {
           {/* Tab switcher */}
           <div className="flex gap-1 p-1 rounded-lg bg-muted">
             <button
-              onClick={() => { setTab('runs'); setSelectedTaskId(undefined); }}
+              onClick={switchToRuns}
               className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
                 tab === 'runs' ? 'bg-background shadow-sm' : 'text-muted-foreground hover:text-foreground'
               }`}
@@ -37,7 +84,7 @@ export default function Agent() {
               Runs
             </button>
             <button
-              onClick={() => { setTab('tasks'); setSelectedRunId(undefined); }}
+              onClick={switchToTasks}
               className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
                 tab === 'tasks' ? 'bg-background shadow-sm' : 'text-muted-foreground hover:text-foreground'
               }`}


### PR DESCRIPTION
The agent was using 22/50 turns then stopping early because a single
query() call let the LLM decide when to stop. The phased executor
replaces the single call with a code-controlled phase loop where each
phase gets its own query() call with scoped tools and turn limits.

Key changes:
- PhaseDefinition type with name, prompt, tools, maxTurns, model, required
- Phase loop in executePhasedQuery() — sequential query() per phase
- Scoped tool server (createScopedVaultToolServer) per phase
- Phase context passing — prior phase summaries flow to next phase
- Backward compatible — tasks without phases still use single query()
- full-intelligence.yaml converted to 7-phase pipeline
- 14 new tests covering phased execution, tool scoping, failure handling

This pull request introduces comprehensive documentation and supporting code for "Agent Teams"—a new experimental feature enabling parallel, collaborative work by multiple Claude Code agents. It also revises the digest-only task workflow to leverage new vault context queries and digest read capabilities. The most significant changes are grouped below.

**Agent Teams Documentation & Guidelines:**

* Added a detailed reference guide for Agent Teams in `docs/agent-teams.md`, covering when to use teams vs subagents, setup instructions, architecture, lifecycle, best practices, troubleshooting, and known limitations. This guide helps users orchestrate multi-agent workflows effectively.
* Updated `CLAUDE.md` with a summary of Agent Teams usage, including scenarios for and against their use, and operational rules to avoid conflicts and maximize productivity.

**Vault Context Query Infrastructure:**

* Introduced `src/agent/context-queries.ts`, providing a utility to execute lightweight, pre-phase vault database queries (such as spores, sessions, and agent state) outside the MCP layer. This enables agents to efficiently gather context before planning.

**Digest Workflow Improvements:**

* Revised the digest-only task definition (`src/agent/definitions/tasks/digest-only.yaml`) to:
  - Add a new phase for checking current digest state using `vault_read_digest`.
  - Adjust the workflow to update only those digest tiers with new material, rather than all tiers.
  - Emphasize efficient updates and reporting of changed/unchanged tiers.
* Registered the new `vault_read_digest` tool in the agent's allowed tools list (`src/agent/definitions/agent.yaml`).

## Related Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [x] Enhancement / new feature
- [x] Refactor / code quality
- [ ] Documentation
- [ ] CI / workflow

## Validation

```bash
make check    # lint + 266 tests
```

## Checklist

- [ ] `make check` passes locally
- [ ] Tests added or updated where behavior changed
- [ ] Docs updated for user-visible changes
- [ ] No magic literals introduced (named constants in `src/constants.ts`)
