### PR TITLE
feat: add myco update command and fix marketplace plugin install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,11 +9,7 @@
   "plugins": [
     {
       "name": "myco",
-      "source": {
-        "source": "github",
-        "repo": "goondocks-co/myco",
-        "version": "0.9.0"
-      },
+      "source": ".",
       "description": "Collective agent intelligence — captures session knowledge and serves it back via MCP",
       "license": "MIT",
       "keywords": [

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -226,7 +226,6 @@ jobs:
           npm version "$VERSION" --no-git-tag-version --allow-same-version
           jq --arg v "$VERSION" '.version = $v' .claude-plugin/plugin.json > tmp.json && mv tmp.json .claude-plugin/plugin.json
           jq --arg v "$VERSION" '.version = $v' .cursor-plugin/plugin.json > tmp.json && mv tmp.json .cursor-plugin/plugin.json
-          jq --arg v "$VERSION" '.plugins[0].source.version = $v' .claude-plugin/marketplace.json > tmp.json && mv tmp.json .claude-plugin/marketplace.json
           jq --arg v "$VERSION" '.plugins[0].source.version = $v' .cursor-plugin/marketplace.json > tmp.json && mv tmp.json .cursor-plugin/marketplace.json
 
       - name: Commit version bump
@@ -235,7 +234,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json .claude-plugin/plugin.json .cursor-plugin/plugin.json .claude-plugin/marketplace.json .cursor-plugin/marketplace.json
+          git add package.json package-lock.json .claude-plugin/plugin.json .cursor-plugin/plugin.json .cursor-plugin/marketplace.json
           git diff --cached --quiet && exit 0
           git commit -m "chore: sync version to $VERSION [skip ci]"
           git push

--- a/.myco/.gitignore
+++ b/.myco/.gitignore
@@ -1,14 +1,17 @@
-# PGlite database — rebuilt from capture data
-pgdata/
+# SQLite database
+myco.db*
+vectors.db*
 
 # Daemon state — per-machine, ephemeral
 daemon.json
 buffer/
 logs/
 
+# Secrets — API keys for cloud providers
+secrets.env
+
+# Machine ID
+machine_id
+
 # Binary attachments — screenshots captured from transcripts
 attachments/
-
-# SQLite databases
-myco.db*
-vectors.db*

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ const USAGE = `Usage: myco <command> [args]
 
 Commands:
   init [options]           Initialize a new vault
+  update                   Update vault files and symbiont plugins
   config <get|set> [args]  Get or set vault config values
   detect-providers         Detect available LLM/embedding providers (JSON)
   verify                   Test LLM and embedding connectivity
@@ -74,6 +75,8 @@ async function main(): Promise<void> {
     const vaultDir = resolveVaultDir();
     return (await import('./cli/doctor.js')).run(args, vaultDir);
   }
+
+  if (cmd === 'update') return (await import('./cli/update.js')).run(args);
 
   const vaultDir = resolveVaultDir();
   if (!fs.existsSync(path.join(vaultDir, 'myco.yaml'))) {

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -57,9 +57,8 @@ export const PROVIDER_DEFAULTS: Record<string, { base_url: string }> = {
 
 
 export const VAULT_GITIGNORE = `# SQLite database
-myco.db
-myco.db-wal
-myco.db-shm
+myco.db*
+vectors.db*
 
 # Daemon state — per-machine, ephemeral
 daemon.json
@@ -68,6 +67,9 @@ logs/
 
 # Secrets — API keys for cloud providers
 secrets.env
+
+# Machine ID
+machine_id
 
 # Binary attachments — screenshots captured from transcripts
 attachments/

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,0 +1,69 @@
+import { resolveVaultDir } from '../vault/resolve.js';
+import { VAULT_GITIGNORE } from './shared.js';
+import { detectSymbionts } from '../symbionts/detect.js';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export async function run(args: string[]): Promise<void> {
+  const vaultDir = resolveVaultDir();
+  if (!fs.existsSync(path.join(vaultDir, 'myco.yaml'))) {
+    console.error(`No myco.yaml found in ${vaultDir}. Run 'myco init' first.`);
+    process.exit(1);
+  }
+
+  console.log(`Updating Myco vault at ${vaultDir}\n`);
+
+  let updatedCount = 0;
+
+  // --- Update .gitignore to match current template ---
+
+  const gitignorePath = path.join(vaultDir, '.gitignore');
+  const currentGitignore = fs.existsSync(gitignorePath)
+    ? fs.readFileSync(gitignorePath, 'utf-8')
+    : '';
+
+  if (currentGitignore !== VAULT_GITIGNORE) {
+    fs.writeFileSync(gitignorePath, VAULT_GITIGNORE, 'utf-8');
+    console.log('  \u2713 Updated .gitignore');
+    updatedCount++;
+  } else {
+    console.log('  \u2013 .gitignore is current');
+  }
+
+  // --- Update symbiont plugins ---
+
+  const projectRoot = path.dirname(vaultDir);
+  const detected = detectSymbionts(projectRoot);
+
+  if (detected.length > 0) {
+    for (const d of detected) {
+      try {
+        if (d.manifest.pluginInstallCommands.length > 0) {
+          for (const cmd of d.manifest.pluginInstallCommands) {
+            const [bin, ...cmdArgs] = cmd.split(' ');
+            execFileSync(bin, cmdArgs, { stdio: 'inherit' });
+          }
+          console.log(`  \u2713 Updated ${d.manifest.displayName} plugin`);
+          updatedCount++;
+        } else {
+          console.log(`  \u2013 ${d.manifest.displayName}: no automated update available`);
+        }
+      } catch (err) {
+        console.error(`  \u2717 Failed to update ${d.manifest.displayName}: ${(err as Error).message}`);
+      }
+    }
+  } else {
+    console.log('  \u2013 No agents detected');
+  }
+
+  // --- Summary ---
+
+  console.log('');
+  if (updatedCount > 0) {
+    console.log(`Updated ${updatedCount} item${updatedCount > 1 ? 's' : ''}.`);
+  } else {
+    console.log('Everything is up to date.');
+  }
+  console.log('Run `myco doctor` to verify setup health.');
+}


### PR DESCRIPTION
## Summary
- Adds `myco update` CLI command — syncs vault `.gitignore` to current template and re-runs symbiont plugin install/update commands
- Fixes Claude Code marketplace source from GitHub repo reference (`"source": "github"`) to local path (`"source": "."`) — the repo reference caused `plugin install` to attempt a separate SSH clone, failing on machines without SSH keys configured. Local path resolves the plugin from the already-cloned marketplace cache, matching the pattern used by compound-engineering
- Updates publish workflow to stop syncing version into Claude `marketplace.json` (version now comes from `plugin.json` via local path resolution; Cursor npm source still version-synced)
- Updates vault `.gitignore` template with glob patterns for SQLite files, `machine_id`, and `secrets.env`

## Test plan
- [x] `make check` passes (1193 tests)
- [ ] After merge, run `claude plugin marketplace add goondocks-co/myco` to refresh cache, then `claude plugin install myco@myco-plugins` to verify local path resolution works
- [ ] Run `myco update` to verify .gitignore sync and plugin update flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)