### PR TITLE
feat: backup & team sync

### DIFF
--- a/.myco/.gitignore
+++ b/.myco/.gitignore
@@ -15,3 +15,6 @@ machine_id
 
 # Binary attachments — screenshots captured from transcripts
 attachments/
+
+# Team worker deployment — patched wrangler.toml + source copy
+.team-worker/

--- a/.myco/myco.yaml
+++ b/.myco/myco.yaml
@@ -43,3 +43,9 @@ context:
   digest_tier: 5000
   prompt_search: true
   prompt_max_spores: 3
+backup:
+  dir: /Users/chris/Repos
+team:
+  enabled: true
+  worker_url: https://myco-team-71861c57.goondocks.workers.dev
+  interval_minutes: 15

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Every coding session produces knowledge: decisions made, gotchas discovered, tra
 
 **For humans** — a local [dashboard](#dashboard) provides configuration, operational triggers, and monitoring. Manage providers, run intelligence cycles, and view live logs.
 
-**For teams** — vault configuration lives in your project. Share it through your existing Git workflow.
+**For teams** — [team sync](docs/team-sync.md) shares accumulated knowledge across machines through a Cloudflare Worker. Every teammate's agent gets access to the team's collective intelligence — spores, session context, and the knowledge graph — through the same search tools they already use.
 
 ## How it works
 
@@ -70,7 +70,6 @@ The digest system synthesizes accumulated knowledge into tiered **extracts** —
 | Tier | Purpose |
 |------|---------|
 | **1,500 tokens** | Executive briefing — what this project is, what's active, what to avoid |
-| **3,000 tokens** | Team standup — enough to start contributing |
 | **5,000 tokens** | Deep onboarding — trade-offs, patterns, team dynamics |
 | **10,000 tokens** | Institutional knowledge — full thread history and design tensions |
 
@@ -104,6 +103,24 @@ Myco integrates with coding agents through **symbiont** adapters — named for t
 | VS Code (Copilot) | Agent manifest available |
 
 Adding a new symbiont is declarative — define a YAML manifest in `src/symbionts/manifests/` and implement the transcript parser.
+
+### Team sync
+
+Share knowledge across machines and team members with one command:
+
+```bash
+myco team init    # Provisions Cloudflare D1 + Vectorize + Worker
+```
+
+Share the output URL and API key with teammates — they connect from the Team page in the dashboard. Once connected, knowledge syncs automatically: new spores, session summaries, plans, and graph edges push to the team store in the background. Search queries fan out to both local and cloud databases, merging results by relevance score.
+
+Local databases remain the source of truth. The cloud store is a queryable mirror — no data is pulled back down. Each record carries a machine identity for attribution.
+
+Runs on the Cloudflare free tier. See the [Team Sync docs](docs/team-sync.md) for the full guide.
+
+### Backup & restore
+
+Local SQL dump backups run automatically during daemon idle periods. Configure a custom backup directory (network share, git repo) from the Operations page. Restore with content-hash deduplication — never overwrites existing records.
 
 ## Health check
 

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -78,10 +78,22 @@ fi
 
 success "npm v$(npm -v) ✓"
 
-# Install
+# Install (suppress transitive deprecation warnings from native addons)
 echo ""
 info "Installing ${PACKAGE}..."
-npm install -g "${PACKAGE}"
+if ! npm install -g "${PACKAGE}" --loglevel=error 2>/tmp/myco-install-err.log; then
+  # EEXIST: a previous install or npm link left a conflicting binary
+  if grep -q "EEXIST" /tmp/myco-install-err.log 2>/dev/null; then
+    warn "Existing myco installation detected — removing before reinstall..."
+    npm rm -g "${PACKAGE}" 2>/dev/null || true
+    npm rm -g "@goondocks-co/myco" 2>/dev/null || true
+    npm install -g "${PACKAGE}" --loglevel=error
+  else
+    cat /tmp/myco-install-err.log >&2
+    exit 1
+  fi
+fi
+rm -f /tmp/myco-install-err.log
 
 echo ""
 success "Myco installed successfully!"

--- a/docs/team-sync.md
+++ b/docs/team-sync.md
@@ -1,0 +1,190 @@
+# Team Sync
+
+Share captured knowledge across machines and team members through a Cloudflare-backed sync layer. Local databases remain the source of truth — the cloud store is a queryable mirror that all connected nodes push to and search.
+
+## How it works
+
+Each machine runs its own Myco daemon with a local SQLite database. When team sync is enabled, writes to knowledge tables (spores, sessions, plans, entities, graph edges) are enqueued in a local **outbox**. A background job pushes outbox batches to a thin **Cloudflare Worker**, which stores structured data in **D1** (SQLite) and embeddings in **Vectorize** (vector database).
+
+When an agent searches for knowledge, Myco queries both the local database and the team Worker in parallel. Results are merged by relevance score and tagged with their source machine, so agents benefit from the entire team's accumulated intelligence.
+
+```
+Local Node A                    Cloudflare                     Local Node B
++-----------+                                                  +-----------+
+| myco.db   |    POST /sync     +------------------+           | myco.db   |
+| vectors.db| ───────────────> | Worker            |  <─────── | vectors.db|
+|           |                   |   D1 (SQLite)    |           |           |
+|           |  GET /search      |   Vectorize      |  GET /search
+|           | <───────────────> |   Workers AI     | <───────> |           |
++-----------+                   +------------------+           +-----------+
+```
+
+## Quick start
+
+### 1. Install Wrangler
+
+The Cloudflare CLI is required for provisioning.
+
+```bash
+npm install -g wrangler
+wrangler login
+```
+
+### 2. Create the team
+
+One team member provisions the infrastructure. This creates a D1 database, a Vectorize index, and deploys the sync Worker.
+
+```bash
+myco team init
+```
+
+The command outputs a **Worker URL** and **API key**. Share these with teammates.
+
+### 3. Connect teammates
+
+Each teammate opens the **Team** page in their Myco dashboard and pastes the Worker URL and API key. Click **Connect** — their node registers with the Worker and begins syncing.
+
+Alternatively, teammates can connect from the CLI by running `myco team init` with the same Cloudflare account, or by adding the credentials to their config manually:
+
+```yaml
+# myco.yaml
+team:
+  enabled: true
+  worker_url: https://myco-team-XXXXXXXX.your-account.workers.dev
+```
+
+```env
+# .myco/secrets.env
+MYCO_TEAM_API_KEY=your-api-key-here
+```
+
+Then restart the daemon.
+
+## What syncs
+
+| Synced | Not synced |
+|--------|------------|
+| Spores (observations, wisdom) | Activities (tool call detail) |
+| Sessions (metadata, title, summary) | Agent execution traces |
+| Prompt batches (prompts, AI summaries) | Log entries |
+| Entities and graph edges | Attachments (images) |
+| Plans and artifacts | Buffer files |
+| Resolution events | |
+| Digest extracts | |
+
+Prompt batches sync without individual tool call activities — teammates see what was asked and answered, not every file read or bash command.
+
+## Machine identity
+
+Every record is tagged with a **machine identity** — a deterministic `{github_username}_{machine_hash}` (e.g., `chris_a7b3c2`). This enables:
+
+- Attributing knowledge to its source
+- Filtering "my data" vs "team data" in search results
+- Restoring backups from other machines without ID collisions
+
+The identity is generated once and cached at `.myco/machine_id`. It uses the GitHub username (via `gh` CLI or `GITHUB_USER` env) and a SHA256 hash of the machine's hostname, OS username, and MAC address.
+
+## Search fan-out
+
+When team sync is enabled, search queries run against both local and cloud databases in parallel:
+
+1. Local SQLite + sqlite-vec (semantic + FTS)
+2. Worker `/search` endpoint (Workers AI embedding + Vectorize + D1 FTS)
+
+Results merge into a single ranked list by similarity score. Since the cloud uses Workers AI `@cf/baai/bge-m3` (the same model recommended for local use), scores are directly comparable. Each result is tagged with its source:
+
+- `source: "local"` — from this machine
+- `source: "team:chris_a7b3c2"` — from the team store, attributed to a specific machine
+
+If the Worker is slow or unreachable (strict 3-second timeout), local results return alone. Team search is additive, never blocking.
+
+## Cloud embedding alternative
+
+Since the team Worker uses Cloudflare Workers AI, team members who don't want to install Ollama locally can use Cloudflare's OpenAI-compatible embedding endpoint:
+
+```yaml
+# myco.yaml
+embedding:
+  provider: openai-compatible
+  model: "@cf/baai/bge-m3"
+  base_url: https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1
+```
+
+Store the Cloudflare API token in `secrets.env`. This uses the same model as the Worker, producing compatible embeddings.
+
+## Backup & restore
+
+Independent of team sync, Myco creates local SQL dump backups for data resilience.
+
+- **Automatic** — backups run during daemon idle periods via the PowerManager
+- **Manual** — click "Backup Now" on the Operations page
+- **Configurable directory** — set a custom backup path (network share, git repo) on the Operations page
+- **Restore with preview** — dry-run shows what would be imported before executing
+- **Content-hash deduplication** — restoring never overwrites existing records
+- **Cross-machine restore** — restore a teammate's backup file; machine identity preserves attribution
+
+Backups include all knowledge tables (sessions, spores, entities, plans, etc.) but exclude logs, tool call activities, and vector embeddings (rebuilt automatically after restore).
+
+## Version awareness
+
+Team members may run different Myco versions. A `sync_protocol_version` (integer) gates compatibility:
+
+- The Worker stores a minimum and maximum supported protocol version
+- Nodes include their protocol version in every sync payload
+- Incompatible versions receive a clear error with upgrade instructions
+- **Forward-compatible by default** — the Worker ignores unknown fields, so newer nodes can add data without breaking older Workers
+
+The protocol version is decoupled from the npm package version. It only bumps on breaking changes to the sync wire format, which should be rare.
+
+## Worker management
+
+### Upgrade
+
+Any team member with Wrangler access can update the Worker:
+
+```bash
+myco team upgrade
+```
+
+This redeploys the Worker with the current Myco version's bundled code.
+
+### Architecture
+
+The Worker is stateless — no WebSocket connections, no Durable Objects, no in-memory state. Each request reads from D1/Vectorize, processes, returns. Cloudflare handles scaling.
+
+**Worker endpoints:**
+
+| Method | Route | Purpose |
+|--------|-------|---------|
+| `GET` | `/health` | Connection status, node count (no auth required) |
+| `POST` | `/connect` | Register a node, return team config |
+| `POST` | `/sync` | Receive batch of records, write to D1 + Vectorize |
+| `GET` | `/search` | Semantic + FTS search across team data |
+| `GET` | `/config` | Return team configuration |
+| `PUT` | `/config` | Update team configuration |
+
+### Cloudflare free tier
+
+A small team (2-5 developers) stays well within free tier limits:
+
+| Service | Usage |
+|---------|-------|
+| Workers | Sync flushes + search queries |
+| D1 | Batch writes, search reads |
+| Vectorize | Embedding storage + similarity queries |
+| Workers AI | Embedding on sync + search |
+
+The $5/month paid tier provides significant headroom if needed.
+
+## Dashboard
+
+### Team page
+
+- **Not connected** — setup instructions and connect form (Worker URL + API key)
+- **Connected** — connection health, pending sync count, team credentials (copyable, with show/hide for the API key), machine identity, and a "Sync All" button for backfilling historical data
+
+### Operations page
+
+- Backup directory configuration
+- Backup Now button
+- Backup history with restore preview

--- a/docs/team-sync.md
+++ b/docs/team-sync.md
@@ -8,15 +8,32 @@ Each machine runs its own Myco daemon with a local SQLite database. When team sy
 
 When an agent searches for knowledge, Myco queries both the local database and the team Worker in parallel. Results are merged by relevance score and tagged with their source machine, so agents benefit from the entire team's accumulated intelligence.
 
-```
-Local Node A                    Cloudflare                     Local Node B
-+-----------+                                                  +-----------+
-| myco.db   |    POST /sync     +------------------+           | myco.db   |
-| vectors.db| ───────────────> | Worker            |  <─────── | vectors.db|
-|           |                   |   D1 (SQLite)    |           |           |
-|           |  GET /search      |   Vectorize      |  GET /search
-|           | <───────────────> |   Workers AI     | <───────> |           |
-+-----------+                   +------------------+           +-----------+
+```mermaid
+graph LR
+    subgraph Node A
+        A_DB[(myco.db)]
+        A_Vec[(vectors.db)]
+    end
+
+    subgraph Cloudflare
+        W[Worker]
+        D1[(D1)]
+        V[(Vectorize)]
+        AI[Workers AI]
+        W --> D1
+        W --> V
+        W --> AI
+    end
+
+    subgraph Node B
+        B_DB[(myco.db)]
+        B_Vec[(vectors.db)]
+    end
+
+    A_DB -- "POST /sync" --> W
+    W -- "GET /search" --> A_DB
+    B_DB -- "POST /sync" --> W
+    W -- "GET /search" --> B_DB
 ```
 
 ## Quick start
@@ -42,23 +59,9 @@ The command outputs a **Worker URL** and **API key**. Share these with teammates
 
 ### 3. Connect teammates
 
-Each teammate opens the **Team** page in their Myco dashboard and pastes the Worker URL and API key. Click **Connect** — their node registers with the Worker and begins syncing.
+Each teammate opens the **Team** page in their Myco dashboard (`http://localhost:<port>/team`), pastes the Worker URL and API key, and clicks **Connect**. Their node registers with the Worker and begins syncing immediately.
 
-Alternatively, teammates can connect from the CLI by running `myco team init` with the same Cloudflare account, or by adding the credentials to their config manually:
-
-```yaml
-# myco.yaml
-team:
-  enabled: true
-  worker_url: https://myco-team-XXXXXXXX.your-account.workers.dev
-```
-
-```env
-# .myco/secrets.env
-MYCO_TEAM_API_KEY=your-api-key-here
-```
-
-Then restart the daemon.
+On first connect, all existing local knowledge is backfilled into the outbox and pushed to the team store in batches. New writes sync automatically going forward.
 
 ## What syncs
 

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -86,7 +86,7 @@ export const VAULT_TOOL_COUNT = 18;
  * @param runId — the current agent run ID, injected into reports and turns.
  * @returns array of SdkMcpToolDefinition objects.
  */
-export function createVaultTools(agentId: string, runId: string, turnOffset = 0, embeddingManager?: EmbeddingManager, teamClient?: TeamSyncClient | null) {
+export function createVaultTools(agentId: string, runId: string, turnOffset = 0, embeddingManager?: EmbeddingManager, teamClient?: TeamSyncClient | null, machineId?: string) {
   /** Turn number counter — incremented per tool call (read and write) within a run. */
   let turnCounter = turnOffset;
 
@@ -234,10 +234,15 @@ export function createVaultTools(agentId: string, runId: string, turnOffset = 0,
             : Promise.resolve([] as Array<Record<string, unknown>>),
         ]);
 
+        // Deduplicate: skip team results from this machine (we already have them locally)
+        const dedupedTeam = machineId
+          ? teamResults.filter((r) => (r as Record<string, unknown>).machine_id !== machineId)
+          : teamResults;
+
         // Merge by similarity/score (normalize to common key), slice to limit
         const merged = [
           ...localResults.map((r) => ({ ...r, score: r.similarity })),
-          ...teamResults,
+          ...dedupedTeam,
         ]
           .sort((a, b) => ((b.score as number) ?? 0) - ((a.score as number) ?? 0))
           .slice(0, searchLimit);

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -18,7 +18,7 @@
 import crypto from 'node:crypto';
 import { z } from 'zod/v4';
 import { tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
-import { epochSeconds, SEARCH_SIMILARITY_THRESHOLD } from '@myco/constants.js';
+import { epochSeconds, SEARCH_SIMILARITY_THRESHOLD, TEAM_SOURCE_PREFIX } from '@myco/constants.js';
 import { getPluginVersion } from '@myco/version.js';
 import { getUnprocessedBatches, markBatchProcessed } from '@myco/db/queries/batches.js';
 import { listSpores, insertSpore, updateSporeStatus, DEFAULT_IMPORTANCE } from '@myco/db/queries/spores.js';
@@ -34,6 +34,7 @@ import { createSporeLineage } from '@myco/db/queries/lineage.js';
 import { insertResolutionEvent } from '@myco/db/queries/resolution-events.js';
 import { upsertDigestExtract, listDigestExtracts } from '@myco/db/queries/digest-extracts.js';
 import type { EmbeddingManager } from '@myco/daemon/embedding/index.js';
+import type { TeamSyncClient } from '@myco/daemon/team-sync.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -85,7 +86,7 @@ export const VAULT_TOOL_COUNT = 18;
  * @param runId — the current agent run ID, injected into reports and turns.
  * @returns array of SdkMcpToolDefinition objects.
  */
-export function createVaultTools(agentId: string, runId: string, turnOffset = 0, embeddingManager?: EmbeddingManager) {
+export function createVaultTools(agentId: string, runId: string, turnOffset = 0, embeddingManager?: EmbeddingManager, teamClient?: TeamSyncClient | null) {
   /** Turn number counter — incremented per tool call (read and write) within a run. */
   let turnCounter = turnOffset;
 
@@ -215,12 +216,33 @@ export function createVaultTools(agentId: string, runId: string, turnOffset = 0,
         if (!queryVector) {
           return textResult({ results: [], message: 'Embedding provider unavailable' });
         }
-        const results = embeddingManager.searchVectors(queryVector, {
-          namespace: args.namespace,
-          limit: args.limit ?? DEFAULT_SEARCH_LIMIT,
-          threshold: SEARCH_SIMILARITY_THRESHOLD,
-        });
-        return textResult({ results });
+        const searchLimit = args.limit ?? DEFAULT_SEARCH_LIMIT;
+
+        // Fire local and team search in parallel
+        const [localResults, teamResults] = await Promise.all([
+          Promise.resolve(
+            embeddingManager.searchVectors(queryVector, {
+              namespace: args.namespace,
+              limit: searchLimit,
+              threshold: SEARCH_SIMILARITY_THRESHOLD,
+            }).map((r) => ({ ...r, source: 'local' as const })),
+          ),
+          teamClient
+            ? teamClient.search(args.query, { limit: searchLimit })
+                .then((res) => res.results.map((r) => ({ ...r, source: `${TEAM_SOURCE_PREFIX}${r.machine_id}` })))
+                .catch(() => [] as Array<Record<string, unknown>>)
+            : Promise.resolve([] as Array<Record<string, unknown>>),
+        ]);
+
+        // Merge by similarity/score (normalize to common key), slice to limit
+        const merged = [
+          ...localResults.map((r) => ({ ...r, score: r.similarity })),
+          ...teamResults,
+        ]
+          .sort((a, b) => ((b.score as number) ?? 0) - ((a.score as number) ?? 0))
+          .slice(0, searchLimit);
+
+        return textResult({ results: merged });
       } catch {
         return textResult({ results: [], message: 'Semantic search unavailable' });
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ Commands:
   setup-digest [options]   Configure digest and capture settings
   agent [options]          Run the intelligence agent
   task <subcommand>        Manage agent task definitions
+  team <init|upgrade>      Provision or upgrade team sync infrastructure
   doctor [--fix]          Check vault health and repair issues
   restart                  Restart the daemon
   version                  Show plugin version
@@ -95,6 +96,14 @@ async function main(): Promise<void> {
     case 'setup-digest': return (await import('./cli/setup-digest.js')).run(args, vaultDir);
     case 'agent': return (await import('./cli/agent-run.js')).run(args, vaultDir);
     case 'task': return (await import('./cli/agent-tasks.js')).run(args, vaultDir);
+    case 'team': {
+      const sub = args[0];
+      if (sub === 'init') return (await import('./cli/team.js')).teamInit(vaultDir);
+      if (sub === 'upgrade') return (await import('./cli/team.js')).teamUpgrade(vaultDir);
+      console.error('Usage: myco team <init|upgrade>');
+      process.exit(1);
+      break;
+    }
     case 'restart': return (await import('./cli/restart.js')).run(args, vaultDir);
     case 'logs': return (await import('./cli/logs.js')).run(args, vaultDir);
     default:

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -73,6 +73,9 @@ machine_id
 
 # Binary attachments — screenshots captured from transcripts
 attachments/
+
+# Team worker deployment — patched wrangler.toml + source copy
+.team-worker/
 `;
 
 /** Collapse an absolute home-dir path to its `~/` form for portable config storage. */

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -13,7 +13,7 @@ import { fileURLToPath } from 'node:url';
 import { loadConfig, updateTeamConfig } from '../config/loader.js';
 import { writeSecret } from '../config/secrets.js';
 import { findPackageRoot } from '../utils/find-package-root.js';
-import { WRANGLER_COMMAND_TIMEOUT_MS } from '../constants.js';
+import { WRANGLER_COMMAND_TIMEOUT_MS, TEAM_API_KEY_SECRET } from '../constants.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -34,8 +34,6 @@ const TEAM_RESOURCE_PREFIX = 'myco-team';
 /** Length of the project hash suffix for unique resource naming. */
 const PROJECT_HASH_LENGTH = 8;
 
-/** Secrets key for the team API key. */
-const TEAM_API_KEY_SECRET = 'MYCO_TEAM_API_KEY';
 
 /** Source directory for worker files (relative to package root). */
 const WORKER_SOURCE_DIR = 'src/worker';

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -1,0 +1,337 @@
+/**
+ * CLI team commands — provision and manage Cloudflare team sync infrastructure.
+ *
+ * `myco team init`    — Provision D1 database, Vectorize index, deploy worker.
+ * `myco team upgrade` — Redeploy worker with updated source.
+ */
+
+import { execFileSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadConfig, updateTeamConfig } from '../config/loader.js';
+import { writeSecret } from '../config/secrets.js';
+import { findPackageRoot } from '../utils/find-package-root.js';
+import { WRANGLER_COMMAND_TIMEOUT_MS } from '../constants.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Number of random bytes for API key generation. */
+const API_KEY_BYTES = 32;
+
+/** Vectorize index dimensions (must match the embedding model). */
+const VECTORIZE_DIMENSIONS = '1024';
+
+/** Vectorize distance metric. */
+const VECTORIZE_METRIC = 'cosine';
+
+/** Prefix for team resource names. */
+const TEAM_RESOURCE_PREFIX = 'myco-team';
+
+/** Length of the project hash suffix for unique resource naming. */
+const PROJECT_HASH_LENGTH = 8;
+
+/** Secrets key for the team API key. */
+const TEAM_API_KEY_SECRET = 'MYCO_TEAM_API_KEY';
+
+/** Source directory for worker files (relative to package root). */
+const WORKER_SOURCE_DIR = 'src/worker';
+
+/** Deployment directory name within the vault. */
+const TEAM_WORKER_DIR = '.team-worker';
+
+/** Regex to extract D1 database ID from wrangler d1 create output (JSON format). */
+const D1_ID_JSON_REGEX = /"database_id"\s*:\s*"([0-9a-f-]{36})"/i;
+
+/** Regex to extract D1 database ID from wrangler d1 create output (text format). */
+const D1_ID_TEXT_REGEX = /id:\s*([0-9a-f-]{36})/i;
+
+/** Regex to extract worker URL from wrangler deploy output. */
+const WORKER_URL_REGEX = /(https:\/\/[^\s]+\.workers\.dev)/;
+
+/** Regex to match wrangler.toml name field. */
+const TOML_NAME_REGEX = /^name\s*=\s*"[^"]*"/m;
+
+/** Regex to match wrangler.toml D1 placeholder. */
+const TOML_D1_PLACEHOLDER_REGEX = /<YOUR_D1_DATABASE_ID>/g;
+
+/** Regex to match wrangler.toml database_name field. */
+const TOML_DB_NAME_REGEX = /database_name\s*=\s*"[^"]*"/g;
+
+/** Regex to match wrangler.toml index_name field. */
+const TOML_INDEX_NAME_REGEX = /index_name\s*=\s*"[^"]*"/g;
+
+/** Regex to match database_id in existing wrangler.toml. */
+const TOML_DB_ID_REGEX = /database_id\s*=\s*"([^"]+)"/;
+
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Generate a project hash from cwd for unique resource naming. */
+function projectHash(): string {
+  const hash = crypto.createHash('sha256').update(process.cwd()).digest('hex');
+  return hash.slice(0, PROJECT_HASH_LENGTH);
+}
+
+/** Build the unique resource name for this project's team infrastructure. */
+function resourceName(): string {
+  return `${TEAM_RESOURCE_PREFIX}-${projectHash()}`;
+}
+
+/** Run a wrangler command and return stdout. Throws on failure. */
+function wrangler(args: string[], options?: { cwd?: string }): string {
+  return execFileSync('wrangler', args, {
+    encoding: 'utf-8',
+    timeout: WRANGLER_COMMAND_TIMEOUT_MS,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    ...options,
+  });
+}
+
+/** Find the package root (where src/worker/ lives). */
+function locatePackageRoot(): string {
+  // Check CLAUDE_PLUGIN_ROOT first (dogfooding), then traverse up
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT ?? process.env.CURSOR_PLUGIN_ROOT;
+  if (pluginRoot && fs.existsSync(path.join(pluginRoot, WORKER_SOURCE_DIR))) {
+    return pluginRoot;
+  }
+
+  // Walk up from this file's compiled location
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const root = findPackageRoot(scriptDir);
+  if (root && fs.existsSync(path.join(root, WORKER_SOURCE_DIR))) return root;
+
+  throw new Error(`Cannot find ${WORKER_SOURCE_DIR} — are you running from the myco package?`);
+}
+
+/**
+ * Copy worker source to the vault deployment directory and patch wrangler.toml
+ * with actual D1 database ID and resource names.
+ */
+function prepareDeployDir(vaultDir: string, d1Id: string): string {
+  const pkgRoot = locatePackageRoot();
+  const srcDir = path.join(pkgRoot, WORKER_SOURCE_DIR);
+  const deployDir = path.join(vaultDir, TEAM_WORKER_DIR);
+
+  // Copy all worker source files
+  fs.cpSync(srcDir, deployDir, { recursive: true });
+
+  // Patch wrangler.toml with actual IDs
+  const tomlPath = path.join(deployDir, 'wrangler.toml');
+  let toml = fs.readFileSync(tomlPath, 'utf-8');
+  const name = resourceName();
+  toml = toml.replace(TOML_NAME_REGEX, `name = "${name}"`);
+  toml = toml.replace(TOML_D1_PLACEHOLDER_REGEX, d1Id);
+  toml = toml.replace(TOML_DB_NAME_REGEX, `database_name = "${name}"`);
+  toml = toml.replace(TOML_INDEX_NAME_REGEX, `index_name = "${name}-vectors"`);
+  fs.writeFileSync(tomlPath, toml, 'utf-8');
+
+  return deployDir;
+}
+
+/** Extract D1 database ID from wrangler d1 create output (handles both JSON and text formats). */
+function parseD1Id(output: string): string {
+  const jsonMatch = output.match(D1_ID_JSON_REGEX);
+  if (jsonMatch) return jsonMatch[1];
+  const textMatch = output.match(D1_ID_TEXT_REGEX);
+  if (textMatch) return textMatch[1];
+  throw new Error(`Could not parse D1 database ID from wrangler output:\n${output}`);
+}
+
+/** Extract worker URL from wrangler deploy output. */
+function parseWorkerUrl(output: string): string {
+  // Output typically contains: "https://<name>.<subdomain>.workers.dev"
+  const match = output.match(WORKER_URL_REGEX);
+  if (!match) throw new Error(`Could not parse worker URL from deploy output:\n${output}`);
+  return match[1];
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+export async function teamInit(vaultDir: string): Promise<void> {
+  console.log('Provisioning team sync infrastructure...\n');
+
+  // 1. Check for wrangler
+  try {
+    const version = wrangler(['--version']).trim();
+    console.log(`wrangler: ${version}`);
+  } catch {
+    console.error('Error: wrangler CLI not found. Install it with: npm install -g wrangler');
+    process.exit(1);
+  }
+
+  // 2. Check auth
+  try {
+    wrangler(['whoami']);
+    console.log('Cloudflare auth: OK\n');
+  } catch {
+    console.error('Error: Not authenticated with Cloudflare. Run: wrangler login');
+    process.exit(1);
+  }
+
+  const name = resourceName();
+  console.log(`Resource name: ${name}\n`);
+
+  // 3. Create D1 database (or reuse existing)
+  console.log('Creating D1 database...');
+  let d1Id: string;
+  try {
+    const d1Output = wrangler(['d1', 'create', name]);
+    d1Id = parseD1Id(d1Output);
+    console.log(`D1 database created: ${d1Id}\n`);
+  } catch (err) {
+    const errMsg = (err as Error).message;
+    if (errMsg.includes('already exists')) {
+      console.log('D1 database already exists, looking up ID...');
+      const listOutput = wrangler(['d1', 'list', '--json']);
+      const databases = JSON.parse(listOutput) as Array<{ name: string; uuid: string }>;
+      const existing = databases.find((db) => db.name === name);
+      if (!existing) {
+        console.error(`D1 database "${name}" reported as existing but not found in list`);
+        process.exit(1);
+      }
+      d1Id = existing.uuid;
+      console.log(`Reusing D1 database: ${d1Id}\n`);
+    } else {
+      console.error(`Failed to create D1 database: ${errMsg}`);
+      process.exit(1);
+    }
+  }
+
+  // 4. Create Vectorize index (or reuse existing)
+  console.log('Creating Vectorize index...');
+  try {
+    wrangler(['vectorize', 'create', `${name}-vectors`, '--dimensions', VECTORIZE_DIMENSIONS, '--metric', VECTORIZE_METRIC]);
+    console.log('Vectorize index created\n');
+  } catch (err) {
+    const errMsg = (err as Error).message;
+    if (errMsg.includes('already exists')) {
+      console.log('Vectorize index already exists, reusing\n');
+    } else {
+      console.error(`Failed to create Vectorize index: ${errMsg}`);
+      process.exit(1);
+    }
+  }
+
+  // 5. Generate API key
+  const apiKey = crypto.randomBytes(API_KEY_BYTES).toString('hex');
+
+  // 6. Prepare deployment directory
+  console.log('Preparing worker deployment...');
+  const deployDir = prepareDeployDir(vaultDir, d1Id);
+
+  // 7. Set API key secret via wrangler
+  console.log('Setting API key secret...');
+  try {
+    execFileSync('wrangler', ['secret', 'put', TEAM_API_KEY_SECRET, '--name', name], {
+      encoding: 'utf-8',
+      timeout: WRANGLER_COMMAND_TIMEOUT_MS,
+      input: apiKey,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: deployDir,
+    });
+    console.log('Secret set\n');
+  } catch (err) {
+    console.error(`Failed to set API key secret: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  // 8. Deploy worker
+  console.log('Deploying worker...');
+  let workerUrl: string;
+  try {
+    const deployOutput = wrangler(['deploy'], { cwd: deployDir });
+    workerUrl = parseWorkerUrl(deployOutput);
+    console.log(`Worker deployed: ${workerUrl}\n`);
+  } catch (err) {
+    console.error(`Failed to deploy worker: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  // 9. Seed team config in the Worker
+  console.log('Setting team configuration...');
+  try {
+    const { getMachineId } = await import('../daemon/machine-id.js');
+    const creatorMachineId = await getMachineId(vaultDir);
+    await fetch(`${workerUrl}/config`, {
+      method: 'PUT',
+      headers: { 'Authorization': `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        team_name: name,
+        embedding_model: '@cf/baai/bge-m3',
+        embedding_dimensions: '1024',
+        created_at: String(Math.floor(Date.now() / 1000)),
+        created_by: creatorMachineId,
+      }),
+    });
+    console.log('Team config saved\n');
+  } catch {
+    console.log('Warning: could not seed team config (non-fatal)\n');
+  }
+
+  // 10. Save config and API key locally
+  updateTeamConfig(vaultDir, {
+    enabled: true,
+    worker_url: workerUrl,
+  });
+  writeSecret(vaultDir, TEAM_API_KEY_SECRET, apiKey);
+
+  console.log('Team sync configured!\n');
+  console.log(`  URL:     ${workerUrl}`);
+  console.log(`  API Key: ${apiKey.slice(0, 8)}...${apiKey.slice(-4)}`);
+  console.log('\nShare the URL and API key with teammates so they can connect.');
+}
+
+export async function teamUpgrade(vaultDir: string): Promise<void> {
+  console.log('Upgrading team sync worker...\n');
+
+  const config = loadConfig(vaultDir);
+  if (!config.team.worker_url) {
+    console.error('No team sync configured. Run: myco team init');
+    process.exit(1);
+  }
+
+  const deployDir = path.join(vaultDir, TEAM_WORKER_DIR);
+  const tomlPath = path.join(deployDir, 'wrangler.toml');
+
+  if (!fs.existsSync(tomlPath)) {
+    console.error('No deployment directory found. Run: myco team init');
+    process.exit(1);
+  }
+
+  // Read existing D1 ID from current wrangler.toml
+  const existingToml = fs.readFileSync(tomlPath, 'utf-8');
+  const d1Match = existingToml.match(TOML_DB_ID_REGEX);
+  if (!d1Match || d1Match[1] === '<YOUR_D1_DATABASE_ID>') {
+    console.error('Cannot determine D1 database ID from existing deployment. Run: myco team init');
+    process.exit(1);
+  }
+  const d1Id = d1Match[1];
+
+  // Re-copy worker source and patch
+  console.log('Updating worker source...');
+  prepareDeployDir(vaultDir, d1Id);
+
+  // Redeploy
+  console.log('Deploying...');
+  try {
+    const deployOutput = wrangler(['deploy'], { cwd: deployDir });
+    const workerUrl = parseWorkerUrl(deployOutput);
+    console.log(`Worker deployed: ${workerUrl}\n`);
+
+    // Update URL in config in case it changed
+    updateTeamConfig(vaultDir, { worker_url: workerUrl });
+  } catch (err) {
+    console.error(`Failed to deploy worker: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  console.log('Upgrade complete.');
+}

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import YAML from 'yaml';
-import { MycoConfigSchema, type MycoConfig } from './schema.js';
+import { MycoConfigSchema, type MycoConfig, type BackupConfig, type TeamConfig } from './schema.js';
 import { runMigrations, CURRENT_MIGRATION_VERSION } from './migrations.js';
 
 export const CONFIG_FILENAME = 'myco.yaml';
@@ -109,4 +109,24 @@ export function updateConfig(
   const updated = fn(current);
   saveConfig(vaultDir, updated);
   return updated;
+}
+
+export function updateBackupConfig(
+  vaultDir: string,
+  backup: Partial<BackupConfig>,
+): MycoConfig {
+  return updateConfig(vaultDir, (config) => ({
+    ...config,
+    backup: { ...config.backup, ...backup },
+  }));
+}
+
+export function updateTeamConfig(
+  vaultDir: string,
+  team: Partial<TeamConfig>,
+): MycoConfig {
+  return updateConfig(vaultDir, (config) => ({
+    ...config,
+    team: { ...config.team, ...team },
+  }));
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -68,6 +68,22 @@ const AgentSchema = z.object({
   tasks: z.record(z.string(), TaskProviderOverrideSchema).optional(),
 });
 
+const BackupSchema = z.object({
+  /** Override directory for backup files (absolute path). When unset, defaults to {vaultDir}/backups. */
+  dir: z.string().optional(),
+});
+
+const TeamSchema = z.object({
+  /** Whether team sync is enabled. */
+  enabled: z.boolean().default(false),
+  /** Cloudflare Worker URL for team sync. */
+  worker_url: z.string().url().optional(),
+  /** Team identifier for sync grouping. */
+  team_id: z.string().optional(),
+  /** Sync interval in minutes. */
+  interval_minutes: z.number().int().min(1).max(1440).default(15),
+});
+
 export const MycoConfigSchema = z.preprocess(
   (raw: unknown) => {
     if (raw && typeof raw === 'object' && 'curation' in raw && !('agent' in raw)) {
@@ -84,6 +100,8 @@ export const MycoConfigSchema = z.preprocess(
     capture: CaptureSchema.default(() => CaptureSchema.parse({})),
     agent: AgentSchema.default(() => AgentSchema.parse({})),
     context: ContextSchema.default(() => ContextSchema.parse({})),
+    backup: BackupSchema.default(() => BackupSchema.parse({})),
+    team: TeamSchema.default(() => TeamSchema.parse({})),
   }),
 );
 
@@ -92,3 +110,5 @@ export type EmbeddingProviderConfig = z.infer<typeof EmbeddingProviderSchema>;
 export type TaskProviderOverride = z.infer<typeof TaskProviderOverrideSchema>;
 export type PhaseOverride = z.infer<typeof PhaseOverrideSchema>;
 export type ContextConfig = z.infer<typeof ContextSchema>;
+export type BackupConfig = z.infer<typeof BackupSchema>;
+export type TeamConfig = z.infer<typeof TeamSchema>;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -359,5 +359,7 @@ export const TEAM_SOURCE_PREFIX = 'team:';
 export const TEAM_SEARCH_TIMEOUT_MS = 3000;
 /** Timeout for team health check requests (ms). */
 export const TEAM_HEALTH_TIMEOUT_MS = 5000;
+/** Secrets key for the team API key in secrets.env. */
+export const TEAM_API_KEY_SECRET = 'MYCO_TEAM_API_KEY';
 /** Timeout for wrangler CLI commands (ms). */
 export const WRANGLER_COMMAND_TIMEOUT_MS = 60_000;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -345,3 +345,19 @@ export const DEFAULT_OLLAMA_EMBEDDING_MODEL = 'bge-m3';
 
 /** Default OpenAI embedding model recommended during init. */
 export const DEFAULT_OPENAI_EMBEDDING_MODEL = 'text-embedding-3-small';
+
+// --- Sync protocol ---
+/** Protocol version for backup and team sync wire format. */
+export const SYNC_PROTOCOL_VERSION = 1;
+
+// --- Team sync ---
+/** Default machine ID for rows created before multi-machine support. */
+export const DEFAULT_MACHINE_ID = 'local';
+/** Prefix for team search result source attribution. */
+export const TEAM_SOURCE_PREFIX = 'team:';
+/** Timeout for team search requests (ms). */
+export const TEAM_SEARCH_TIMEOUT_MS = 3000;
+/** Timeout for team health check requests (ms). */
+export const TEAM_HEALTH_TIMEOUT_MS = 5000;
+/** Timeout for wrangler CLI commands (ms). */
+export const WRANGLER_COMMAND_TIMEOUT_MS = 60_000;

--- a/src/constants/log-kinds.ts
+++ b/src/constants/log-kinds.ts
@@ -87,6 +87,16 @@ export const LOG_KINDS = {
 
   // Log retention
   LOG_RETENTION: 'log.retention',
+
+  // Backup
+  BACKUP_START: 'backup.start',
+  BACKUP_COMPLETE: 'backup.complete',
+  BACKUP_ERROR: 'backup.error',
+
+  // Team sync
+  TEAM_SYNC_START: 'team-sync.start',
+  TEAM_SYNC_COMPLETE: 'team-sync.complete',
+  TEAM_SYNC_ERROR: 'team-sync.error',
 } as const;
 
 export type LogKind = (typeof LOG_KINDS)[keyof typeof LOG_KINDS];

--- a/src/daemon/api/backup.ts
+++ b/src/daemon/api/backup.ts
@@ -1,0 +1,106 @@
+/**
+ * Backup API handlers — create, list, preview, and restore backups.
+ *
+ * Factory function injects backupDir and machineId; returns handlers
+ * for POST /api/backup, GET /api/backups, POST /api/restore/preview,
+ * and POST /api/restore.
+ */
+
+import type { Database } from 'better-sqlite3';
+import type { RouteRequest, RouteResponse } from '../router.js';
+import {
+  createBackup,
+  listBackups,
+  restorePreview,
+  restoreBackup,
+} from '../backup.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Dependencies injected by the daemon when registering backup routes. */
+export interface BackupDeps {
+  db: Database;
+  backupDir: string;
+  machineId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Handler factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create backup API handlers with injected dependencies.
+ *
+ * Returns an object with named handlers for each backup endpoint.
+ */
+export function createBackupHandlers(deps: BackupDeps) {
+  /** POST /api/backup — create a new backup of all synced tables. */
+  async function handleCreateBackup(_req: RouteRequest): Promise<RouteResponse> {
+    const filePath = createBackup(deps.db, deps.backupDir, deps.machineId);
+    const backups = listBackups(deps.backupDir);
+    const created = backups.find((b) => b.machine_id === deps.machineId);
+
+    return {
+      body: {
+        file_path: filePath,
+        machine_id: deps.machineId,
+        size_bytes: created?.size_bytes ?? 0,
+      },
+    };
+  }
+
+  /** GET /api/backups — list all backup files with metadata. */
+  async function handleListBackups(_req: RouteRequest): Promise<RouteResponse> {
+    const backups = listBackups(deps.backupDir);
+    return { body: { backups } };
+  }
+
+  /** POST /api/restore/preview — dry-run restore to show new/existing counts. */
+  async function handleRestorePreview(req: RouteRequest): Promise<RouteResponse> {
+    const { machine_id } = req.body as { machine_id?: string };
+    if (!machine_id) {
+      return { status: 400, body: { error: 'missing_machine_id' } };
+    }
+
+    const backups = listBackups(deps.backupDir);
+    const backup = backups.find((b) => b.machine_id === machine_id);
+    if (!backup) {
+      return { status: 404, body: { error: 'backup_not_found' } };
+    }
+
+    const backupPath = `${deps.backupDir}/${backup.file_name}`;
+    const tables = restorePreview(deps.db, backupPath);
+    const total_new = tables.reduce((sum, t) => sum + t.new, 0);
+    const total_existing = tables.reduce((sum, t) => sum + t.existing, 0);
+
+    return { body: { machine_id, tables, total_new, total_existing } };
+  }
+
+  /** POST /api/restore — execute restore from a backup file. */
+  async function handleRestore(req: RouteRequest): Promise<RouteResponse> {
+    const { machine_id } = req.body as { machine_id?: string };
+    if (!machine_id) {
+      return { status: 400, body: { error: 'missing_machine_id' } };
+    }
+
+    const backups = listBackups(deps.backupDir);
+    const backup = backups.find((b) => b.machine_id === machine_id);
+    if (!backup) {
+      return { status: 404, body: { error: 'backup_not_found' } };
+    }
+
+    const backupPath = `${deps.backupDir}/${backup.file_name}`;
+    const result = restoreBackup(deps.db, backupPath);
+
+    return { body: { machine_id, ...result } };
+  }
+
+  return {
+    handleCreateBackup,
+    handleListBackups,
+    handleRestorePreview,
+    handleRestore,
+  };
+}

--- a/src/daemon/api/config.ts
+++ b/src/daemon/api/config.ts
@@ -16,6 +16,8 @@ function mergeConfigSections(current: MycoConfig, incoming: MycoConfig): MycoCon
     capture: { ...current.capture, ...incoming.capture },
     agent: { ...current.agent, ...incoming.agent },
     context: { ...current.context, ...incoming.context },
+    backup: { ...current.backup, ...incoming.backup },
+    team: { ...current.team, ...incoming.team },
   };
 }
 

--- a/src/daemon/api/mycelium.ts
+++ b/src/daemon/api/mycelium.ts
@@ -224,6 +224,108 @@ export async function handleGetGraph(req: RouteRequest): Promise<RouteResponse> 
 }
 
 // ---------------------------------------------------------------------------
+// Full graph handler
+// ---------------------------------------------------------------------------
+
+/** Maximum nodes returned in full graph view to prevent overload. */
+const FULL_GRAPH_NODE_LIMIT = 500;
+
+export async function handleGetFullGraph(_req: RouteRequest): Promise<RouteResponse> {
+  const db = getDatabase();
+
+  // Fetch all entities
+  const entityRows = db.prepare(
+    `SELECT id, type, name, properties, status, first_seen as created_at
+     FROM entities WHERE agent_id = ? LIMIT ?`,
+  ).all(DEFAULT_AGENT_ID, FULL_GRAPH_NODE_LIMIT) as Array<Record<string, unknown>>;
+
+  // Fetch active spores (skip superseded)
+  const sporeRows = db.prepare(
+    `SELECT id, observation_type, status, content, properties, created_at
+     FROM spores WHERE agent_id = ? AND status = 'active' LIMIT ?`,
+  ).all(DEFAULT_AGENT_ID, FULL_GRAPH_NODE_LIMIT) as Array<Record<string, unknown>>;
+
+  // Fetch recent sessions
+  const sessionRows = db.prepare(
+    `SELECT id, title, summary, status, started_at as created_at
+     FROM sessions ORDER BY created_at DESC LIMIT ?`,
+  ).all(FULL_GRAPH_NODE_LIMIT) as Array<Record<string, unknown>>;
+
+  // Collect all node IDs for edge filtering
+  const allIds = new Set<string>();
+  for (const r of [...entityRows, ...sporeRows, ...sessionRows]) {
+    allIds.add(r.id as string);
+  }
+
+  // Fetch all edges between known nodes, excluding batch-level edges
+  const excludedTypes = Array.from(EXCLUDED_GRAPH_EDGE_TYPES).map(() => '?').join(', ');
+  const edgeRows = db.prepare(
+    `SELECT source_id, source_type, target_id, target_type, type, confidence
+     FROM graph_edges
+     WHERE agent_id = ? AND type NOT IN (${excludedTypes})`,
+  ).all(DEFAULT_AGENT_ID, ...Array.from(EXCLUDED_GRAPH_EDGE_TYPES)) as Array<Record<string, unknown>>;
+
+  // Only keep edges where both endpoints are in our node set
+  const filteredEdges = edgeRows.filter(
+    (e) => allIds.has(e.source_id as string) && allIds.has(e.target_id as string),
+  );
+
+  // Mention counts for entity sizing
+  const mentionCounts = new Map<string, number>();
+  const entityIdArray = entityRows.map((r) => r.id as string);
+  if (entityIdArray.length > 0) {
+    const placeholders = entityIdArray.map(() => '?').join(', ');
+    const mentionRows = db.prepare(
+      `SELECT entity_id, COUNT(*) as count FROM entity_mentions
+       WHERE entity_id IN (${placeholders}) GROUP BY entity_id`,
+    ).all(...entityIdArray) as Array<Record<string, unknown>>;
+    for (const row of mentionRows) {
+      mentionCounts.set(row.entity_id as string, Number(row.count));
+    }
+  }
+
+  // Build nodes
+  const nodes = [
+    ...entityRows.map((n) => ({
+      id: n.id as string,
+      name: n.name as string,
+      type: n.type as string,
+      status: (n.status as string) ?? undefined,
+      created_at: n.created_at as number | undefined,
+      properties: (n.properties as string) ?? undefined,
+      mention_count: mentionCounts.get(n.id as string) ?? 0,
+    })),
+    ...sporeRows.map((n) => ({
+      id: n.id as string,
+      name: ((n.content as string) ?? '').slice(0, SPORE_NAME_PREVIEW_CHARS),
+      type: 'spore' as const,
+      status: (n.status as string) ?? undefined,
+      created_at: n.created_at as number | undefined,
+      content: n.content as string | undefined,
+      properties: (n.properties as string) ?? undefined,
+      observation_type: n.observation_type as string | undefined,
+    })),
+    ...sessionRows.map((n) => ({
+      id: n.id as string,
+      name: (n.title as string) ?? `Session ${(n.id as string).slice(-6)}`,
+      type: 'session' as const,
+      status: (n.status as string) ?? undefined,
+      created_at: n.created_at as number | undefined,
+      content: (n.summary as string) ?? undefined,
+    })),
+  ];
+
+  const edges = filteredEdges.map((e) => ({
+    source_id: e.source_id as string,
+    target_id: e.target_id as string,
+    label: e.type as string,
+    weight: e.confidence as number | undefined,
+  }));
+
+  return { body: { nodes, edges } };
+}
+
+// ---------------------------------------------------------------------------
 // Digest handler
 // ---------------------------------------------------------------------------
 

--- a/src/daemon/api/mycelium.ts
+++ b/src/daemon/api/mycelium.ts
@@ -257,18 +257,20 @@ export async function handleGetFullGraph(_req: RouteRequest): Promise<RouteRespo
     allIds.add(r.id as string);
   }
 
-  // Fetch all edges between known nodes, excluding batch-level edges
+  // Fetch edges between known nodes, excluding batch-level edges
   const excludedTypes = Array.from(EXCLUDED_GRAPH_EDGE_TYPES).map(() => '?').join(', ');
+  const allIdsList = Array.from(allIds);
+  const idPlaceholders = allIdsList.map(() => '?').join(', ');
   const edgeRows = db.prepare(
     `SELECT source_id, source_type, target_id, target_type, type, confidence
      FROM graph_edges
-     WHERE agent_id = ? AND type NOT IN (${excludedTypes})`,
-  ).all(DEFAULT_AGENT_ID, ...Array.from(EXCLUDED_GRAPH_EDGE_TYPES)) as Array<Record<string, unknown>>;
+     WHERE agent_id = ?
+       AND type NOT IN (${excludedTypes})
+       AND source_id IN (${idPlaceholders})
+       AND target_id IN (${idPlaceholders})`,
+  ).all(DEFAULT_AGENT_ID, ...Array.from(EXCLUDED_GRAPH_EDGE_TYPES), ...allIdsList, ...allIdsList) as Array<Record<string, unknown>>;
 
-  // Only keep edges where both endpoints are in our node set
-  const filteredEdges = edgeRows.filter(
-    (e) => allIds.has(e.source_id as string) && allIds.has(e.target_id as string),
-  );
+  const filteredEdges = edgeRows;
 
   // Mention counts for entity sizing
   const mentionCounts = new Map<string, number>();

--- a/src/daemon/api/restart.ts
+++ b/src/daemon/api/restart.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import { z } from 'zod';
+import { resolveCliEntryPath } from '../../hooks/client.js';
 import type { RouteResponse } from '../router.js';
 import type { ProgressTracker } from './progress.js';
 
@@ -35,9 +36,8 @@ export async function handleRestart(
   // Schedule: respond → wait for flush → SIGTERM self → child starts after parent exits.
   // The child waits RESTART_CHILD_DELAY_SECONDS before starting to ensure the parent
   // has fully released the port and cleaned up daemon.json.
-  // Use MYCO_CMD to respawn through the same CLI path (myco or myco-dev).
-  const mycoCmd = process.env.MYCO_CMD || 'myco';
-  const shellCmd = `sleep ${RESTART_CHILD_DELAY_SECONDS} && ${mycoCmd} daemon --vault ${deps.vaultDir}`;
+  const { execPath, cliEntry } = resolveCliEntryPath();
+  const shellCmd = `sleep ${RESTART_CHILD_DELAY_SECONDS} && ${execPath} ${cliEntry} daemon --vault ${deps.vaultDir}`;
 
   const child = spawn('/bin/sh', ['-c', shellCmd], {
     detached: true,

--- a/src/daemon/api/search.ts
+++ b/src/daemon/api/search.ts
@@ -10,9 +10,11 @@ import { fullTextSearch, hydrateSearchResults } from '@myco/db/queries/search.js
 import {
   SEARCH_RESULTS_DEFAULT_LIMIT,
   SEARCH_SIMILARITY_THRESHOLD,
+  TEAM_SOURCE_PREFIX,
 } from '@myco/constants.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 import type { EmbeddingManager } from '../embedding/manager.js';
+import type { TeamSyncClient, TeamSearchResult } from '../team-sync.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -24,6 +26,7 @@ type SearchMode = 'auto' | 'semantic' | 'fts';
 /** Dependencies injected by the daemon when registering the route. */
 export interface SearchDeps {
   embeddingManager: EmbeddingManager;
+  getTeamClient?: () => TeamSyncClient | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -75,9 +78,32 @@ export function createSearchHandler(deps: SearchDeps) {
       threshold: SEARCH_SIMILARITY_THRESHOLD,
     });
 
-    // Hydrate vector results into full SearchResults
-    const results = hydrateSearchResults(vectorResults);
+    // Hydrate local vector results into full SearchResults
+    const localResults = hydrateSearchResults(vectorResults).map((r) => ({
+      ...r,
+      source: 'local',
+    }));
 
-    return { body: { mode: 'semantic', results } };
+    // Fan out to team search in parallel (if connected)
+    const teamClient = deps.getTeamClient?.();
+    let teamResults: Array<TeamSearchResult & { source: string }> = [];
+    if (teamClient) {
+      try {
+        const teamResponse = await teamClient.search(query, { limit });
+        teamResults = teamResponse.results.map((r) => ({
+          ...r,
+          source: `${TEAM_SOURCE_PREFIX}${r.machine_id}`,
+        }));
+      } catch {
+        // Team search failure is non-blocking — local results still returned
+      }
+    }
+
+    // Merge by score (highest first), slice to limit
+    const merged = [...localResults, ...teamResults]
+      .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+      .slice(0, limit);
+
+    return { body: { mode: 'semantic', results: merged } };
   };
 }

--- a/src/daemon/api/search.ts
+++ b/src/daemon/api/search.ts
@@ -27,6 +27,7 @@ type SearchMode = 'auto' | 'semantic' | 'fts';
 export interface SearchDeps {
   embeddingManager: EmbeddingManager;
   getTeamClient?: () => TeamSyncClient | null;
+  machineId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -99,8 +100,13 @@ export function createSearchHandler(deps: SearchDeps) {
       }
     }
 
+    // Deduplicate: skip team results from this machine (we already have them locally)
+    const dedupedTeam = deps.machineId
+      ? teamResults.filter((r) => r.machine_id !== deps.machineId)
+      : teamResults;
+
     // Merge by score (highest first), slice to limit
-    const merged = [...localResults, ...teamResults]
+    const merged = [...localResults, ...dedupedTeam]
       .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
       .slice(0, limit);
 

--- a/src/daemon/api/team-connect.ts
+++ b/src/daemon/api/team-connect.ts
@@ -9,7 +9,7 @@ import { updateTeamConfig, loadConfig } from '@myco/config/loader.js';
 import { writeSecret, readSecrets } from '@myco/config/secrets.js';
 import { countPending } from '@myco/db/queries/team-outbox.js';
 import { TeamSyncClient } from '../team-sync.js';
-import { SYNC_PROTOCOL_VERSION } from '@myco/constants.js';
+import { SYNC_PROTOCOL_VERSION, TEAM_API_KEY_SECRET } from '@myco/constants.js';
 import { getPluginVersion } from '@myco/version.js';
 import { SCHEMA_VERSION } from '@myco/db/schema.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
@@ -18,8 +18,6 @@ import type { RouteRequest, RouteResponse } from '../router.js';
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Secrets key for the team API key. */
-const TEAM_API_KEY_SECRET = 'MYCO_TEAM_API_KEY';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/daemon/api/team-connect.ts
+++ b/src/daemon/api/team-connect.ts
@@ -1,0 +1,162 @@
+/**
+ * Team connect/disconnect/status API handlers.
+ *
+ * Factory pattern: `createTeamHandlers(deps)` returns route handlers that
+ * close over the daemon's shared state (vault dir, machine ID, team client).
+ */
+
+import { updateTeamConfig, loadConfig } from '@myco/config/loader.js';
+import { writeSecret, readSecrets } from '@myco/config/secrets.js';
+import { countPending } from '@myco/db/queries/team-outbox.js';
+import { TeamSyncClient } from '../team-sync.js';
+import { SYNC_PROTOCOL_VERSION } from '@myco/constants.js';
+import { getPluginVersion } from '@myco/version.js';
+import { SCHEMA_VERSION } from '@myco/db/schema.js';
+import type { RouteRequest, RouteResponse } from '../router.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Secrets key for the team API key. */
+const TEAM_API_KEY_SECRET = 'MYCO_TEAM_API_KEY';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TeamHandlerDeps {
+  vaultDir: string;
+  machineId: string;
+  getTeamClient: () => TeamSyncClient | null;
+  setTeamClient: (client: TeamSyncClient | null) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createTeamHandlers(deps: TeamHandlerDeps) {
+  const { vaultDir, machineId } = deps;
+
+  /**
+   * POST /api/team/connect
+   * Body: { url: string, api_key: string }
+   *
+   * Creates a TeamSyncClient, tests the connection, saves config + secrets.
+   */
+  async function handleConnect(req: RouteRequest): Promise<RouteResponse> {
+    const { url, api_key } = req.body as { url?: string; api_key?: string };
+
+    if (!url || !api_key) {
+      return {
+        status: 400,
+        body: { error: 'missing_fields', message: 'Both url and api_key are required' },
+      };
+    }
+
+    // Validate URL format
+    try {
+      new URL(url);
+    } catch {
+      return {
+        status: 400,
+        body: { error: 'invalid_url', message: 'Invalid worker URL' },
+      };
+    }
+
+    // Create client and test connection
+    const client = new TeamSyncClient({
+      workerUrl: url,
+      apiKey: api_key,
+      machineId,
+      syncProtocolVersion: SYNC_PROTOCOL_VERSION,
+    });
+
+    try {
+      await client.health();
+    } catch (err) {
+      return {
+        status: 502,
+        body: {
+          error: 'connection_failed',
+          message: `Could not connect to team worker: ${(err as Error).message}`,
+        },
+      };
+    }
+
+    // Save config and secret
+    updateTeamConfig(vaultDir, {
+      enabled: true,
+      worker_url: url,
+    });
+    writeSecret(vaultDir, TEAM_API_KEY_SECRET, api_key);
+
+    // Set the live client
+    deps.setTeamClient(client);
+
+    const config = loadConfig(vaultDir);
+    return { body: { connected: true, team: config.team } };
+  }
+
+  /**
+   * POST /api/team/disconnect
+   *
+   * Disables team sync and clears the live client reference.
+   */
+  async function handleDisconnect(_req: RouteRequest): Promise<RouteResponse> {
+    updateTeamConfig(vaultDir, { enabled: false });
+    deps.setTeamClient(null);
+
+    return { body: { connected: false } };
+  }
+
+  /**
+   * GET /api/team/status
+   *
+   * Returns connection status, health check result, pending sync count, and machine_id.
+   */
+  async function handleStatus(_req: RouteRequest): Promise<RouteResponse> {
+    const config = loadConfig(vaultDir);
+    const client = deps.getTeamClient();
+    const secrets = readSecrets(vaultDir);
+    const hasApiKey = Boolean(secrets[TEAM_API_KEY_SECRET]);
+
+    let healthy = false;
+    let healthError: string | undefined;
+
+    if (client && config.team.enabled) {
+      try {
+        await client.health();
+        healthy = true;
+      } catch (err) {
+        healthError = (err as Error).message;
+      }
+    }
+
+    let pendingCount = 0;
+    try {
+      pendingCount = countPending();
+    } catch {
+      // DB may not have the table yet
+    }
+
+    return {
+      body: {
+        enabled: config.team.enabled,
+        worker_url: config.team.worker_url ?? null,
+        has_api_key: hasApiKey,
+        api_key: secrets[TEAM_API_KEY_SECRET] ?? null,
+        healthy,
+        health_error: healthError,
+        pending_sync_count: pendingCount,
+        machine_id: machineId,
+        package_version: getPluginVersion(),
+        schema_version: SCHEMA_VERSION,
+        sync_protocol_version: SYNC_PROTOCOL_VERSION,
+      },
+    };
+  }
+
+  return { handleConnect, handleDisconnect, handleStatus };
+}

--- a/src/daemon/backup.ts
+++ b/src/daemon/backup.ts
@@ -1,0 +1,326 @@
+/**
+ * Backup engine — SQL-dump backup and restore for synced vault tables.
+ *
+ * Produces portable `INSERT OR IGNORE` SQL dumps scoped to a single machine.
+ * Restore merges foreign machine data without overwriting local records.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Database } from 'better-sqlite3';
+import { SYNC_PROTOCOL_VERSION, epochSeconds } from '@myco/constants.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Tables included in backup dumps (all synced tables). */
+export const BACKUP_TABLES = [
+  'sessions',
+  'prompt_batches',
+  'spores',
+  'entities',
+  'graph_edges',
+  'entity_mentions',
+  'resolution_events',
+  'plans',
+  'artifacts',
+  'digest_extracts',
+  'team_members',
+] as const;
+
+/** File extension for backup dumps. */
+const BACKUP_EXTENSION = '.sql';
+
+/** Header comment template for backup files. */
+const BACKUP_HEADER_TEMPLATE = '-- Myco backup';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Metadata for a backup file on disk. */
+export interface BackupMeta {
+  machine_id: string;
+  file_name: string;
+  size_bytes: number;
+  modified_at: string;
+}
+
+/** Per-table counts returned by restore preview/execute. */
+export interface TableCounts {
+  table: string;
+  new: number;
+  existing: number;
+}
+
+/** Result returned by restoreBackup. */
+export interface RestoreResult {
+  tables: TableCounts[];
+  total_restored: number;
+  total_skipped: number;
+}
+
+// ---------------------------------------------------------------------------
+// SQL value serialization
+// ---------------------------------------------------------------------------
+
+/**
+ * Escape a string value for inclusion in a SQL literal.
+ * Doubles single quotes per SQL standard.
+ */
+function escapeSql(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+/**
+ * Serialize a JavaScript value into a SQL literal.
+ *
+ * - null / undefined → NULL
+ * - number → numeric literal
+ * - Buffer → X'hex'
+ * - string → 'escaped string'
+ */
+function toSqlLiteral(value: unknown): string {
+  if (value === null || value === undefined) return 'NULL';
+  if (typeof value === 'number') return String(value);
+  if (Buffer.isBuffer(value)) return `X'${value.toString('hex')}'`;
+  return `'${escapeSql(String(value))}'`;
+}
+
+// ---------------------------------------------------------------------------
+// Backup
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a SQL dump backup of all synced tables.
+ *
+ * Writes `INSERT OR IGNORE` statements for every row in BACKUP_TABLES
+ * to `{backupDir}/{machineId}.sql`. Idempotent — overwrites any existing
+ * backup for the same machine.
+ *
+ * @returns the absolute path of the created backup file.
+ */
+export function createBackup(
+  db: Database,
+  backupDir: string,
+  machineId: string,
+): string {
+  fs.mkdirSync(backupDir, { recursive: true });
+
+  const lines: string[] = [];
+  const timestamp = epochSeconds();
+
+  // Header
+  lines.push(`${BACKUP_HEADER_TEMPLATE}: machine_id=${machineId}, created_at=${timestamp}`);
+  lines.push(`-- Protocol version: ${SYNC_PROTOCOL_VERSION}`);
+  lines.push('');
+
+  for (const table of BACKUP_TABLES) {
+    const rows = db.prepare(`SELECT * FROM ${table}`).all() as Record<string, unknown>[];
+    if (rows.length === 0) continue;
+
+    lines.push(`-- Table: ${table} (${rows.length} rows)`);
+
+    // Get column names from the first row
+    const columns = Object.keys(rows[0]);
+    const columnList = columns.map((c) => `"${c}"`).join(', ');
+
+    for (const row of rows) {
+      const values = columns.map((c) => toSqlLiteral(row[c])).join(', ');
+      lines.push(`INSERT OR IGNORE INTO ${table} (${columnList}) VALUES (${values});`);
+    }
+
+    lines.push('');
+  }
+
+  const filePath = path.join(backupDir, `${machineId}${BACKUP_EXTENSION}`);
+  fs.writeFileSync(filePath, lines.join('\n'), 'utf-8');
+
+  return filePath;
+}
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan the backup directory for `.sql` files and return metadata.
+ *
+ * Machine ID is derived from the filename (stripping the extension).
+ */
+export function listBackups(backupDir: string): BackupMeta[] {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(backupDir);
+  } catch {
+    return [];
+  }
+
+  const backups: BackupMeta[] = [];
+
+  for (const entry of entries) {
+    if (!entry.endsWith(BACKUP_EXTENSION)) continue;
+
+    const filePath = path.join(backupDir, entry);
+    const stat = fs.statSync(filePath);
+
+    backups.push({
+      machine_id: entry.slice(0, -BACKUP_EXTENSION.length),
+      file_name: entry,
+      size_bytes: stat.size,
+      modified_at: stat.mtime.toISOString(),
+    });
+  }
+
+  return backups.sort((a, b) => b.modified_at.localeCompare(a.modified_at));
+}
+
+// ---------------------------------------------------------------------------
+// Restore helpers
+// ---------------------------------------------------------------------------
+
+/** Regex matching INSERT OR IGNORE statements generated by createBackup. */
+const INSERT_REGEX = /^INSERT OR IGNORE INTO (\w+)\s+\(([^)]+)\)\s+VALUES\s+\((.+)\);$/;
+
+/** Parsed INSERT statement. */
+interface ParsedInsert {
+  table: string;
+  columns: string[];
+  valueSql: string;
+}
+
+/**
+ * Parse all INSERT statements from a backup file.
+ */
+function parseBackupFile(backupPath: string): ParsedInsert[] {
+  const content = fs.readFileSync(backupPath, 'utf-8');
+  const inserts: ParsedInsert[] = [];
+
+  for (const line of content.split('\n')) {
+    const match = INSERT_REGEX.exec(line);
+    if (!match) continue;
+
+    inserts.push({
+      table: match[1],
+      columns: match[2].split(',').map((c) => c.trim().replace(/"/g, '')),
+      valueSql: match[3],
+    });
+  }
+
+  return inserts;
+}
+
+// ---------------------------------------------------------------------------
+// Restore preview
+// ---------------------------------------------------------------------------
+
+/**
+ * Preview what a restore would do without making changes.
+ *
+ * For each INSERT in the backup, checks if a conflicting row already exists
+ * (via INSERT OR IGNORE in a savepoint that gets rolled back).
+ *
+ * Returns per-table counts of new vs existing records.
+ */
+export function restorePreview(
+  db: Database,
+  backupPath: string,
+): TableCounts[] {
+  const inserts = parseBackupFile(backupPath);
+  const counts = new Map<string, { new: number; existing: number }>();
+
+  // Defer FK checks — backup may reference rows in non-synced tables
+  db.pragma('foreign_keys = OFF');
+  // Use a savepoint so we can test INSERTs without persisting
+  db.exec('SAVEPOINT restore_preview');
+  try {
+    for (const insert of inserts) {
+      if (!counts.has(insert.table)) {
+        counts.set(insert.table, { new: 0, existing: 0 });
+      }
+      const tableCounts = counts.get(insert.table)!;
+
+      try {
+        const columnList = insert.columns.map((c) => `"${c}"`).join(', ');
+        const stmt = `INSERT OR IGNORE INTO ${insert.table} (${columnList}) VALUES (${insert.valueSql})`;
+        const result = db.prepare(stmt).run();
+
+        if (result.changes > 0) {
+          tableCounts.new++;
+        } else {
+          tableCounts.existing++;
+        }
+      } catch {
+        tableCounts.existing++;
+      }
+    }
+  } finally {
+    db.exec('ROLLBACK TO restore_preview');
+    db.exec('RELEASE restore_preview');
+    db.pragma('foreign_keys = ON');
+  }
+
+  return Array.from(counts.entries()).map(([table, c]) => ({
+    table,
+    new: c.new,
+    existing: c.existing,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Restore
+// ---------------------------------------------------------------------------
+
+/**
+ * Restore a backup by running all INSERTs in a transaction.
+ *
+ * Uses `INSERT OR IGNORE` — existing records are skipped, new records
+ * are inserted. Returns per-table counts.
+ */
+export function restoreBackup(
+  db: Database,
+  backupPath: string,
+): RestoreResult {
+  const inserts = parseBackupFile(backupPath);
+  const counts = new Map<string, { new: number; existing: number }>();
+
+  // Defer FK checks — backup may reference rows in non-synced tables (e.g. agents)
+  // that don't exist yet. Re-enable after the transaction.
+  db.pragma('foreign_keys = OFF');
+  try {
+    const runRestore = db.transaction(() => {
+      for (const insert of inserts) {
+        if (!counts.has(insert.table)) {
+          counts.set(insert.table, { new: 0, existing: 0 });
+        }
+        const tableCounts = counts.get(insert.table)!;
+
+        const columnList = insert.columns.map((c) => `"${c}"`).join(', ');
+        const stmt = `INSERT OR IGNORE INTO ${insert.table} (${columnList}) VALUES (${insert.valueSql})`;
+        const result = db.prepare(stmt).run();
+
+        if (result.changes > 0) {
+          tableCounts.new++;
+        } else {
+          tableCounts.existing++;
+        }
+      }
+    });
+
+    runRestore();
+  } finally {
+    db.pragma('foreign_keys = ON');
+  }
+
+  const tables = Array.from(counts.entries()).map(([table, c]) => ({
+    table,
+    new: c.new,
+    existing: c.existing,
+  }));
+
+  const total_restored = tables.reduce((sum, t) => sum + t.new, 0);
+  const total_skipped = tables.reduce((sum, t) => sum + t.existing, 0);
+
+  return { tables, total_restored, total_skipped };
+}

--- a/src/daemon/machine-id.ts
+++ b/src/daemon/machine-id.ts
@@ -1,0 +1,86 @@
+/**
+ * Machine identity generation — deterministic `{github_user}_{machine_hash}` format.
+ *
+ * The machine ID uniquely identifies a (user, machine) pair for backup dedup
+ * and team sync. It is computed once, cached to `{vaultDir}/machine_id`,
+ * and reused on subsequent calls.
+ *
+ * Format: `{github_user}_{machine_hash}` where machine_hash is a truncated
+ * SHA-256 of `os.hostname() + os.homedir()`.
+ */
+
+import { execFileSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/** Length of the truncated machine hash suffix. */
+const MACHINE_HASH_LENGTH = 8;
+
+/** Filename for the cached machine ID within the vault. */
+const MACHINE_ID_FILE = 'machine_id';
+
+/** Fallback GitHub username when `gh` CLI is unavailable. */
+const FALLBACK_GITHUB_USER = 'local';
+
+/**
+ * Compute a deterministic machine hash from hostname + homedir.
+ *
+ * Returns the first MACHINE_HASH_LENGTH hex chars of the SHA-256 digest.
+ */
+export function computeMachineHash(): string {
+  const raw = `${os.hostname()}${os.homedir()}`;
+  const hash = crypto.createHash('sha256').update(raw).digest('hex');
+  return hash.slice(0, MACHINE_HASH_LENGTH);
+}
+
+/**
+ * Resolve the current GitHub username via the `gh` CLI.
+ *
+ * Returns FALLBACK_GITHUB_USER if `gh` is not installed or not authenticated.
+ */
+export function resolveGitHubUser(): string {
+  try {
+    const output = execFileSync('gh', ['api', 'user', '--jq', '.login'], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const login = output.trim();
+    return login.length > 0 ? login : FALLBACK_GITHUB_USER;
+  } catch {
+    return FALLBACK_GITHUB_USER;
+  }
+}
+
+/**
+ * Get or generate the machine ID for this vault.
+ *
+ * On first call, computes `{github_user}_{machine_hash}` and caches it
+ * to `{vaultDir}/machine_id`. Subsequent calls read from cache.
+ *
+ * @param vaultDir — vault root directory (e.g., `~/.myco/vaults/myco/`)
+ * @returns the machine ID string
+ */
+export function getMachineId(vaultDir: string): string {
+  const cachePath = path.join(vaultDir, MACHINE_ID_FILE);
+
+  // Read from cache if present
+  try {
+    const cached = fs.readFileSync(cachePath, 'utf-8').trim();
+    if (cached.length > 0) return cached;
+  } catch {
+    // File doesn't exist yet — fall through to generate
+  }
+
+  const githubUser = resolveGitHubUser();
+  const machineHash = computeMachineHash();
+  const machineId = `${githubUser}_${machineHash}`;
+
+  // Cache for future calls
+  fs.mkdirSync(vaultDir, { recursive: true });
+  fs.writeFileSync(cachePath, machineId, 'utf-8');
+
+  return machineId;
+}

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -1755,7 +1755,7 @@ export async function main(): Promise<void> {
 
   // --- Search, activity feed, and embedding status ---
 
-  server.registerRoute('GET', '/api/search', createSearchHandler({ embeddingManager, getTeamClient: () => teamClient }));
+  server.registerRoute('GET', '/api/search', createSearchHandler({ embeddingManager, getTeamClient: () => teamClient, machineId }));
   server.registerRoute('GET', '/api/activity', handleGetFeed);
   server.registerRoute('GET', '/api/embedding/status', async () => handleGetEmbeddingStatus(vaultDir));
   server.registerRoute('GET', '/api/embedding/details', async () => handleEmbeddingDetails(embeddingManager));

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -10,7 +10,7 @@
 import { DaemonServer } from './server.js';
 import { SessionRegistry } from './lifecycle.js';
 import { DaemonLogger } from './logger.js';
-import { loadConfig, updateConfig } from '../config/loader.js';
+import { loadConfig, updateConfig, updateBackupConfig } from '../config/loader.js';
 import { resolvePort } from './port.js';
 import { TranscriptMiner, extractTurnsFromBuffer } from '../capture/transcript-miner.js';
 import { createPerProjectAdapter, extensionForMimeType, type TranscriptTurn } from '../symbionts/adapter.js';
@@ -23,6 +23,14 @@ import type { RegisteredSession } from './lifecycle.js';
 import { handleGetConfig, handlePutConfig } from './api/config.js';
 import { handleLogSearch, handleLogStream, handleLogDetail } from './api/log-explorer.js';
 import { handleRestart } from './api/restart.js';
+import { getMachineId } from './machine-id.js';
+import { createBackupHandlers } from './api/backup.js';
+import { createTeamHandlers } from './api/team-connect.js';
+import { TeamSyncClient } from './team-sync.js';
+import { initTeamContext } from './team-context.js';
+import { createBackup } from './backup.js';
+import { listPending, markSent, pruneOld, backfillUnsynced } from '../db/queries/team-outbox.js';
+import { readSecrets } from '../config/secrets.js';
 import { ProgressTracker, handleGetProgress } from './api/progress.js';
 import { handleGetModels } from './api/models.js';
 import { computeConfigHash } from './api/stats.js';
@@ -95,6 +103,7 @@ import {
   POWER_DEEP_SLEEP_THRESHOLD_MS,
   POWER_ACTIVE_INTERVAL_MS,
   POWER_SLEEP_INTERVAL_MS,
+  SYNC_PROTOCOL_VERSION,
   epochSeconds,
   MS_PER_SECOND,
   MS_PER_DAY,
@@ -431,10 +440,17 @@ export async function main(): Promise<void> {
   });
   logger.info(LOG_KINDS.CAPTURE_PLAN, 'Plan watch directories', { dirs: planWatchConfig.watchDirs });
 
+  // --- Machine identity ---
+  const machineId = getMachineId(vaultDir);
+  logger.info(LOG_KINDS.DAEMON_START, 'Machine ID resolved', { machine_id: machineId });
+
   // --- SQLite initialization ---
   const db = initDatabase(vaultDbPath(vaultDir));
-  createSchema(db);
+  createSchema(db, machineId);
   logger.info(LOG_KINDS.DAEMON_START, 'SQLite initialized', { vault: vaultDir });
+
+  // --- Team context ---
+  initTeamContext(config.team.enabled, machineId);
 
   // Wire logger to SQLite persistence
   logger.setPersistFn((entry) => {
@@ -1661,9 +1677,85 @@ export async function main(): Promise<void> {
     };
   });
 
+  // --- Backup routes ---
+  const backupDir = config.backup.dir
+    ? path.resolve(config.backup.dir)
+    : path.resolve(vaultDir, 'backups');
+  const backupHandlers = createBackupHandlers({ db, backupDir, machineId });
+  server.registerRoute('POST', '/api/backup', backupHandlers.handleCreateBackup);
+  server.registerRoute('GET', '/api/backups', backupHandlers.handleListBackups);
+  server.registerRoute('POST', '/api/restore/preview', backupHandlers.handleRestorePreview);
+  server.registerRoute('POST', '/api/restore', backupHandlers.handleRestore);
+
+  server.registerRoute('GET', '/api/backup/config', async () => {
+    const cfg = loadConfig(vaultDir);
+    return { body: { dir: cfg.backup.dir ?? null, default_dir: path.resolve(vaultDir, 'backups') } };
+  });
+
+  server.registerRoute('PUT', '/api/backup/config', async (req) => {
+    const { dir } = req.body as { dir?: string | null };
+    updateBackupConfig(vaultDir, { dir: dir || undefined });
+    return { body: { dir: dir || null } };
+  });
+
+  // --- Team sync routes ---
+  let teamClient: TeamSyncClient | null = null;
+
+  // Initialize team client from saved config if team sync is enabled
+  if (config.team.enabled && config.team.worker_url) {
+    const secrets = readSecrets(vaultDir);
+    const teamApiKey = secrets['MYCO_TEAM_API_KEY'];
+    if (teamApiKey) {
+      teamClient = new TeamSyncClient({
+        workerUrl: config.team.worker_url,
+        apiKey: teamApiKey,
+        machineId,
+        syncProtocolVersion: SYNC_PROTOCOL_VERSION,
+      });
+      logger.info(LOG_KINDS.TEAM_SYNC_START, 'Team sync client initialized', { worker_url: config.team.worker_url });
+
+      // Register this node with the team worker (fire-and-forget)
+      teamClient.connect({
+        machine_id: machineId,
+        version: server.version,
+      }).then(() => {
+        logger.info(LOG_KINDS.TEAM_SYNC_START, 'Node registered with team worker');
+      }).catch((err) => {
+        logger.warn(LOG_KINDS.TEAM_SYNC_ERROR, 'Node registration failed (will retry on next flush)', { error: (err as Error).message });
+      });
+
+      // Backfill unsynced records into outbox (fire-and-forget — can be large)
+      setTimeout(() => {
+        try {
+          const backfilled = backfillUnsynced(machineId);
+          if (backfilled > 0) {
+            logger.info(LOG_KINDS.TEAM_SYNC_START, `Backfilled ${backfilled} unsynced records into outbox`);
+          }
+        } catch (err) {
+          logger.error(LOG_KINDS.TEAM_SYNC_ERROR, 'Backfill failed', { error: (err as Error).message });
+        }
+      }, 0);
+    }
+  }
+
+  const teamHandlers = createTeamHandlers({
+    vaultDir,
+    machineId,
+    getTeamClient: () => teamClient,
+    setTeamClient: (c) => { teamClient = c; },
+  });
+  server.registerRoute('POST', '/api/team/connect', teamHandlers.handleConnect);
+  server.registerRoute('POST', '/api/team/disconnect', teamHandlers.handleDisconnect);
+  server.registerRoute('GET', '/api/team/status', teamHandlers.handleStatus);
+
+  server.registerRoute('POST', '/api/team/backfill', async () => {
+    const count = backfillUnsynced(machineId);
+    return { body: { enqueued: count } };
+  });
+
   // --- Search, activity feed, and embedding status ---
 
-  server.registerRoute('GET', '/api/search', createSearchHandler({ embeddingManager }));
+  server.registerRoute('GET', '/api/search', createSearchHandler({ embeddingManager, getTeamClient: () => teamClient }));
   server.registerRoute('GET', '/api/activity', handleGetFeed);
   server.registerRoute('GET', '/api/embedding/status', async () => handleGetEmbeddingStatus(vaultDir));
   server.registerRoute('GET', '/api/embedding/details', async () => handleEmbeddingDetails(embeddingManager));
@@ -1783,6 +1875,64 @@ export async function main(): Promise<void> {
       }
     },
   });
+
+  // Auto-backup: create a local SQL dump during idle/sleep cycles
+  powerManager.register({
+    name: 'auto-backup',
+    runIn: ['idle', 'sleep'],
+    fn: async () => {
+      try {
+        logger.info(LOG_KINDS.BACKUP_START, 'Auto-backup starting');
+        const filePath = createBackup(db, backupDir, machineId);
+        logger.info(LOG_KINDS.BACKUP_COMPLETE, 'Auto-backup complete', { file_path: filePath });
+      } catch (err) {
+        logger.error(LOG_KINDS.BACKUP_ERROR, 'Auto-backup failed', { error: (err as Error).message });
+      }
+    },
+  });
+
+  // Team outbox flush: push pending records to the team worker
+  if (config.team.enabled) {
+    powerManager.register({
+      name: 'team-sync-flush',
+      runIn: ['active', 'idle'],
+      fn: async () => {
+        const client = teamClient;
+        if (!client) return;
+
+        try {
+          const pending = listPending();
+          if (pending.length === 0) return;
+
+          logger.info(LOG_KINDS.TEAM_SYNC_START, 'Flushing outbox', { count: pending.length });
+          const result = await client.pushBatch(pending);
+
+          // Mark successfully synced records as sent
+          if (result.synced > 0 || result.skipped > 0) {
+            // Identify which records failed so we only mark the successes
+            const failedIds = new Set(result.errors.map((e) => e.id));
+            const sentIds = pending.filter((r) => !failedIds.has(String(r.row_id))).map((r) => r.id);
+            if (sentIds.length > 0) {
+              markSent(sentIds, epochSeconds());
+            }
+          }
+
+          if (result.errors.length > 0) {
+            logger.warn(LOG_KINDS.TEAM_SYNC_ERROR, `Sync errors: ${result.errors.length}`, {
+              errors: result.errors.slice(0, 5),
+            });
+          }
+
+          pruneOld();
+          logger.info(LOG_KINDS.TEAM_SYNC_COMPLETE, 'Outbox flush complete', {
+            synced: result.synced, skipped: result.skipped, errors: result.errors.length, total: pending.length,
+          });
+        } catch (err) {
+          logger.error(LOG_KINDS.TEAM_SYNC_ERROR, 'Outbox flush failed', { error: (err as Error).message });
+        }
+      },
+    });
+  }
 
   powerManager.start();
 

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -47,6 +47,7 @@ import {
   handleGetSpore,
   handleListEntities,
   handleGetGraph,
+  handleGetFullGraph,
   handleGetDigest,
 } from './api/mycelium.js';
 import { createSearchHandler } from './api/search.js';
@@ -1380,6 +1381,7 @@ export async function main(): Promise<void> {
   server.registerRoute('GET', '/api/spores', handleListSpores);
   server.registerRoute('GET', '/api/spores/:id', handleGetSpore);
   server.registerRoute('GET', '/api/entities', handleListEntities);
+  server.registerRoute('GET', '/api/graph', handleGetFullGraph);
   server.registerRoute('GET', '/api/graph/:id', handleGetGraph);
   server.registerRoute('GET', '/api/digest', handleGetDigest);
 

--- a/src/daemon/team-context.ts
+++ b/src/daemon/team-context.ts
@@ -1,0 +1,59 @@
+/**
+ * Module-level state for team sync.
+ *
+ * Initialized once by the daemon on startup. Query modules import
+ * `isTeamSyncEnabled()` and `getTeamMachineId()` to decide whether
+ * to enqueue outbox records on write.
+ */
+
+import { SYNC_PROTOCOL_VERSION, DEFAULT_MACHINE_ID } from '@myco/constants.js';
+
+// ---------------------------------------------------------------------------
+// Module state
+// ---------------------------------------------------------------------------
+
+let teamSyncEnabled = false;
+let teamMachineId = DEFAULT_MACHINE_ID;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Initialize team context. Called once on daemon startup.
+ */
+export function initTeamContext(enabled: boolean, machineId: string): void {
+  teamSyncEnabled = enabled;
+  teamMachineId = machineId;
+}
+
+/**
+ * Whether team sync is currently enabled.
+ *
+ * Query modules check this before enqueuing outbox records.
+ */
+export function isTeamSyncEnabled(): boolean {
+  return teamSyncEnabled;
+}
+
+/**
+ * The machine ID for this instance.
+ */
+export function getTeamMachineId(): string {
+  return teamMachineId;
+}
+
+/**
+ * The sync protocol version in use.
+ */
+export function getTeamSyncProtocolVersion(): number {
+  return SYNC_PROTOCOL_VERSION;
+}
+
+/**
+ * Reset team context (for testing).
+ */
+export function resetTeamContext(): void {
+  teamSyncEnabled = false;
+  teamMachineId = DEFAULT_MACHINE_ID;
+}

--- a/src/daemon/team-sync.ts
+++ b/src/daemon/team-sync.ts
@@ -1,0 +1,205 @@
+/**
+ * Team sync HTTP client.
+ *
+ * Communicates with the Cloudflare Worker to push outbox records,
+ * search team knowledge, and check connection health.
+ */
+
+import type { OutboxRow } from '@myco/db/queries/team-outbox.js';
+import { TEAM_SEARCH_TIMEOUT_MS, TEAM_HEALTH_TIMEOUT_MS } from '@myco/constants.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TeamSyncClientOptions {
+  workerUrl: string;
+  apiKey: string;
+  machineId: string;
+  syncProtocolVersion: number;
+  /** Inject custom fetch for testing. */
+  fetch?: typeof globalThis.fetch;
+}
+
+export interface TeamSearchOptions {
+  limit?: number;
+  tables?: string[];
+  timeoutMs?: number;
+}
+
+export interface TeamSearchResult {
+  id: string;
+  table_name: string;
+  content: string;
+  score: number;
+  machine_id: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface TeamSearchResponse {
+  results: TeamSearchResult[];
+  machine_ids: string[];
+}
+
+export interface TeamHealthResponse {
+  status: string;
+  node_count: number;
+  sync_protocol_version: number;
+}
+
+export interface TeamConnectInfo {
+  machine_id: string;
+  vault_name?: string;
+  agent?: string;
+  version?: string;
+}
+
+export interface TeamConfigResponse {
+  config: Record<string, unknown>;
+  sync_protocol_version: number;
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+export class TeamSyncClient {
+  private readonly workerUrl: string;
+  private readonly apiKey: string;
+  private readonly machineId: string;
+  private readonly syncProtocolVersion: number;
+  private readonly fetchFn: typeof globalThis.fetch;
+
+  constructor(options: TeamSyncClientOptions) {
+    this.workerUrl = options.workerUrl.replace(/\/+$/, '');
+    this.apiKey = options.apiKey;
+    this.machineId = options.machineId;
+    this.syncProtocolVersion = options.syncProtocolVersion;
+    this.fetchFn = options.fetch ?? globalThis.fetch;
+  }
+
+  /**
+   * Register this machine with the team worker.
+   */
+  async connect(info: TeamConnectInfo): Promise<TeamConfigResponse> {
+    const res = await this.request('POST', '/connect', {
+      ...info,
+      machine_id: this.machineId,
+      sync_protocol_version: this.syncProtocolVersion,
+    });
+    return res as TeamConfigResponse;
+  }
+
+  /**
+   * Push a batch of outbox records to the team worker.
+   *
+   * @returns the number of records accepted by the worker.
+   */
+  async pushBatch(records: OutboxRow[]): Promise<{ synced: number; skipped: number; errors: Array<{ id: string; table: string; error: string }> }> {
+    const res = await this.request('POST', '/sync', {
+      machine_id: this.machineId,
+      sync_protocol_version: this.syncProtocolVersion,
+      records: records.map((r) => {
+        const data = typeof r.payload === 'string' ? JSON.parse(r.payload) : r.payload;
+        return {
+          table: r.table_name,
+          id: String(r.row_id),
+          machine_id: r.machine_id,
+          operation: r.operation,
+          data,
+          content_hash: data.content_hash ?? null,
+        };
+      }),
+    });
+    return res as { synced: number; skipped: number; errors: Array<{ id: string; table: string; error: string }> };
+  }
+
+  /**
+   * Search team knowledge across all connected machines.
+   *
+   * Uses AbortController for timeout enforcement.
+   */
+  async search(query: string, options: TeamSearchOptions = {}): Promise<TeamSearchResponse> {
+    const timeoutMs = options.timeoutMs ?? TEAM_SEARCH_TIMEOUT_MS;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const params = new URLSearchParams({ q: query });
+      if (options.limit) params.set('limit', String(options.limit));
+      if (options.tables) params.set('tables', options.tables.join(','));
+
+      const res = await this.fetchFn(`${this.workerUrl}/search?${params}`, {
+        method: 'GET',
+        headers: this.headers(),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        throw new Error(`Team search failed: ${res.status} ${res.statusText}`);
+      }
+
+      return (await res.json()) as TeamSearchResponse;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Check worker health.
+   */
+  async health(): Promise<TeamHealthResponse> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TEAM_HEALTH_TIMEOUT_MS);
+
+    try {
+      const res = await this.fetchFn(`${this.workerUrl}/health`, {
+        method: 'GET',
+        headers: this.headers(),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        throw new Error(`Health check failed: ${res.status} ${res.statusText}`);
+      }
+
+      return (await res.json()) as TeamHealthResponse;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Get team configuration from the worker.
+   */
+  async getConfig(): Promise<TeamConfigResponse> {
+    const res = await this.request('GET', '/config');
+    return res as TeamConfigResponse;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  private headers(): Record<string, string> {
+    return {
+      'Authorization': `Bearer ${this.apiKey}`,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  private async request(method: string, path: string, body?: unknown): Promise<unknown> {
+    const res = await this.fetchFn(`${this.workerUrl}${path}`, {
+      method,
+      headers: this.headers(),
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`Team sync request ${method} ${path} failed: ${res.status} ${text}`);
+    }
+
+    return res.json();
+  }
+}

--- a/src/db/queries/batches.ts
+++ b/src/db/queries/batches.ts
@@ -6,6 +6,8 @@
  */
 
 import { getDatabase } from '@myco/db/client.js';
+import { DEFAULT_MACHINE_ID } from '@myco/constants.js';
+import { syncRow } from '@myco/db/queries/team-outbox.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -59,6 +61,7 @@ export interface BatchInsert {
   activity_count?: number;
   processed?: number;
   content_hash?: string | null;
+  machine_id?: string;
 }
 
 /** Row shape returned from batch queries. */
@@ -76,6 +79,8 @@ export interface BatchRow {
   processed: number;
   content_hash: string | null;
   created_at: number;
+  machine_id: string;
+  synced_at: number | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -96,6 +101,8 @@ const BATCH_COLUMNS = [
   'processed',
   'content_hash',
   'created_at',
+  'machine_id',
+  'synced_at',
 ] as const;
 
 const SELECT_COLUMNS = BATCH_COLUMNS.join(', ');
@@ -120,6 +127,8 @@ function toBatchRow(row: Record<string, unknown>): BatchRow {
     processed: row.processed as number,
     content_hash: (row.content_hash as string) ?? null,
     created_at: row.created_at as number,
+    machine_id: (row.machine_id as string) ?? DEFAULT_MACHINE_ID,
+    synced_at: (row.synced_at as number) ?? null,
   };
 }
 
@@ -140,11 +149,11 @@ export function insertBatch(data: BatchInsert): BatchRow {
     `INSERT INTO prompt_batches (
        session_id, prompt_number, user_prompt, response_summary,
        classification, started_at, ended_at, status,
-       activity_count, processed, content_hash, created_at
+       activity_count, processed, content_hash, created_at, machine_id
      ) VALUES (
        ?, ?, ?, ?,
        ?, ?, ?, ?,
-       ?, ?, ?, ?
+       ?, ?, ?, ?, ?
      )`,
   ).run(
     data.session_id,
@@ -159,6 +168,7 @@ export function insertBatch(data: BatchInsert): BatchRow {
     data.processed ?? DEFAULT_PROCESSED,
     data.content_hash ?? null,
     data.created_at,
+    data.machine_id ?? DEFAULT_MACHINE_ID,
   );
 
   const batchId = Number(info.lastInsertRowid);
@@ -169,9 +179,13 @@ export function insertBatch(data: BatchInsert): BatchRow {
     db.prepare('INSERT INTO prompt_batches_fts(rowid, user_prompt) VALUES (?, ?)').run(batchId, userPrompt);
   }
 
-  return toBatchRow(
+  const row = toBatchRow(
     db.prepare(`SELECT ${SELECT_COLUMNS} FROM prompt_batches WHERE id = ?`).get(batchId) as Record<string, unknown>,
   );
+
+  syncRow('prompt_batches', row);
+
+  return row;
 }
 
 /**
@@ -373,13 +387,13 @@ export function insertBatchStateless(data: StatelessBatchInsert): BatchRow {
     `INSERT INTO prompt_batches (
        session_id, prompt_number, user_prompt, response_summary,
        classification, started_at, ended_at, status,
-       activity_count, processed, content_hash, created_at
+       activity_count, processed, content_hash, created_at, machine_id
      ) VALUES (
        ?,
        (SELECT COALESCE(MAX(prompt_number), 0) + 1 FROM prompt_batches WHERE session_id = ?),
        ?, NULL,
        NULL, ?, NULL, ?,
-       ?, ?, NULL, ?
+       ?, ?, NULL, ?, ?
      )`,
   ).run(
     data.session_id,
@@ -390,6 +404,7 @@ export function insertBatchStateless(data: StatelessBatchInsert): BatchRow {
     DEFAULT_ACTIVITY_COUNT,
     DEFAULT_PROCESSED,
     data.created_at,
+    DEFAULT_MACHINE_ID,
   );
 
   const batchId = Number(info.lastInsertRowid);

--- a/src/db/queries/digest-extracts.ts
+++ b/src/db/queries/digest-extracts.ts
@@ -6,7 +6,7 @@
  */
 
 import { getDatabase } from '@myco/db/client.js';
-import { DIGEST_TIERS } from '@myco/constants.js';
+import { DIGEST_TIERS, DEFAULT_MACHINE_ID } from '@myco/constants.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -63,7 +63,7 @@ function toDigestExtractRow(row: Record<string, unknown>): DigestExtractRow {
     content: row.content as string,
     substrate_hash: (row.substrate_hash as string) ?? null,
     generated_at: row.generated_at as number,
-    machine_id: (row.machine_id as string) ?? 'local',
+    machine_id: (row.machine_id as string) ?? DEFAULT_MACHINE_ID,
     synced_at: (row.synced_at as number) ?? null,
   };
 }

--- a/src/db/queries/digest-extracts.ts
+++ b/src/db/queries/digest-extracts.ts
@@ -18,6 +18,7 @@ export interface DigestExtractUpsert {
   tier: number;
   content: string;
   generated_at: number;
+  machine_id?: string;
 }
 
 /** Row shape returned from digest_extracts queries (all columns). */
@@ -28,6 +29,8 @@ export interface DigestExtractRow {
   content: string;
   substrate_hash: string | null;
   generated_at: number;
+  machine_id: string;
+  synced_at: number | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -41,6 +44,8 @@ const EXTRACT_COLUMNS = [
   'content',
   'substrate_hash',
   'generated_at',
+  'machine_id',
+  'synced_at',
 ] as const;
 
 const SELECT_COLUMNS = EXTRACT_COLUMNS.join(', ');
@@ -58,6 +63,8 @@ function toDigestExtractRow(row: Record<string, unknown>): DigestExtractRow {
     content: row.content as string,
     substrate_hash: (row.substrate_hash as string) ?? null,
     generated_at: row.generated_at as number,
+    machine_id: (row.machine_id as string) ?? 'local',
+    synced_at: (row.synced_at as number) ?? null,
   };
 }
 

--- a/src/db/queries/entities.ts
+++ b/src/db/queries/entities.ts
@@ -6,7 +6,9 @@
  */
 
 import { getDatabase } from '@myco/db/client.js';
+import { DEFAULT_MACHINE_ID } from '@myco/constants.js';
 import { getGraphForNode, type GraphEdgeRow } from '@myco/db/queries/graph-edges.js';
+import { syncRow } from '@myco/db/queries/team-outbox.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -28,6 +30,7 @@ export interface EntityInsert {
   first_seen: number;
   last_seen: number;
   properties?: string | null;
+  machine_id?: string;
 }
 
 /** Row shape returned from entity queries (all columns). */
@@ -40,6 +43,8 @@ export interface EntityRow {
   first_seen: number;
   last_seen: number;
   status: string;
+  machine_id: string;
+  synced_at: number | null;
 }
 
 /** Filter options for `listEntities`. */
@@ -78,6 +83,8 @@ const ENTITY_COLUMNS = [
   'first_seen',
   'last_seen',
   'status',
+  'machine_id',
+  'synced_at',
 ] as const;
 
 const SELECT_COLUMNS = ENTITY_COLUMNS.join(', ');
@@ -97,6 +104,8 @@ function toEntityRow(row: Record<string, unknown>): EntityRow {
     first_seen: row.first_seen as number,
     last_seen: row.last_seen as number,
     status: (row.status as string) ?? 'active',
+    machine_id: (row.machine_id as string) ?? DEFAULT_MACHINE_ID,
+    synced_at: (row.synced_at as number) ?? null,
   };
 }
 
@@ -113,8 +122,8 @@ export function insertEntity(data: EntityInsert): EntityRow {
   const db = getDatabase();
 
   db.prepare(
-    `INSERT INTO entities (id, agent_id, type, name, properties, first_seen, last_seen)
-     VALUES (?, ?, ?, ?, ?, ?, ?)
+    `INSERT INTO entities (id, agent_id, type, name, properties, first_seen, last_seen, machine_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT (agent_id, type, name) DO UPDATE SET
        properties = COALESCE(EXCLUDED.properties, entities.properties),
        last_seen = EXCLUDED.last_seen`,
@@ -126,16 +135,21 @@ export function insertEntity(data: EntityInsert): EntityRow {
     data.properties ?? null,
     data.first_seen,
     data.last_seen,
+    data.machine_id ?? DEFAULT_MACHINE_ID,
   );
 
   // On conflict, the passed-in id may not be the actual row id. Look up by unique key.
-  return toEntityRow(
+  const row = toEntityRow(
     db.prepare(`SELECT ${SELECT_COLUMNS} FROM entities WHERE agent_id = ? AND type = ? AND name = ?`).get(
       data.agent_id,
       data.type,
       data.name,
     ) as Record<string, unknown>,
   );
+
+  syncRow('entities', row);
+
+  return row;
 }
 
 /**

--- a/src/db/queries/graph-edges.ts
+++ b/src/db/queries/graph-edges.ts
@@ -10,7 +10,8 @@
 
 import crypto from 'node:crypto';
 import { getDatabase } from '@myco/db/client.js';
-import { QUERY_DEFAULT_LIST_LIMIT, GRAPH_EDGE_DEFAULT_CONFIDENCE } from '@myco/constants.js';
+import { QUERY_DEFAULT_LIST_LIMIT, GRAPH_EDGE_DEFAULT_CONFIDENCE, DEFAULT_MACHINE_ID } from '@myco/constants.js';
+import { syncRow } from '@myco/db/queries/team-outbox.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -50,6 +51,7 @@ export interface GraphEdgeInsert {
   session_id?: string;
   confidence?: number;
   properties?: string;
+  machine_id?: string;
 }
 
 /** Row shape returned from graph edge queries. */
@@ -65,6 +67,8 @@ export interface GraphEdgeRow {
   confidence: number;
   properties: string | null;
   created_at: number;
+  machine_id: string;
+  synced_at: number | null;
 }
 
 /** Filter options for `listGraphEdges`. */
@@ -92,6 +96,8 @@ const GRAPH_EDGE_COLUMNS = [
   'confidence',
   'properties',
   'created_at',
+  'machine_id',
+  'synced_at',
 ] as const;
 
 const SELECT_COLUMNS = GRAPH_EDGE_COLUMNS.join(', ');
@@ -114,6 +120,8 @@ function toGraphEdgeRow(row: Record<string, unknown>): GraphEdgeRow {
     confidence: row.confidence as number,
     properties: (row.properties as string) ?? null,
     created_at: row.created_at as number,
+    machine_id: (row.machine_id as string) ?? DEFAULT_MACHINE_ID,
+    synced_at: (row.synced_at as number) ?? null,
   };
 }
 
@@ -133,8 +141,8 @@ export function insertGraphEdge(data: GraphEdgeInsert): GraphEdgeRow {
   db.prepare(
     `INSERT INTO graph_edges (
        id, agent_id, source_id, source_type, target_id, target_type,
-       type, session_id, confidence, properties, created_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       type, session_id, confidence, properties, created_at, machine_id
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     id,
     data.agent_id,
@@ -147,11 +155,16 @@ export function insertGraphEdge(data: GraphEdgeInsert): GraphEdgeRow {
     data.confidence ?? GRAPH_EDGE_DEFAULT_CONFIDENCE,
     data.properties ?? null,
     data.created_at,
+    data.machine_id ?? DEFAULT_MACHINE_ID,
   );
 
-  return toGraphEdgeRow(
+  const row = toGraphEdgeRow(
     db.prepare(`SELECT ${SELECT_COLUMNS} FROM graph_edges WHERE id = ?`).get(id) as Record<string, unknown>,
   );
+
+  syncRow('graph_edges', row);
+
+  return row;
 }
 
 /**

--- a/src/db/queries/plans.ts
+++ b/src/db/queries/plans.ts
@@ -6,6 +6,8 @@
  */
 
 import { getDatabase } from '@myco/db/client.js';
+import { DEFAULT_MACHINE_ID } from '@myco/constants.js';
+import { syncRow } from '@myco/db/queries/team-outbox.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -39,6 +41,7 @@ export interface PlanInsert {
   content_hash?: string | null;
   processed?: number;
   updated_at?: number | null;
+  machine_id?: string;
 }
 
 /** Row shape returned from plan queries. */
@@ -57,6 +60,8 @@ export interface PlanRow {
   embedded: number;
   created_at: number;
   updated_at: number | null;
+  machine_id: string;
+  synced_at: number | null;
 }
 
 /** Filter options for `listPlans`. */
@@ -84,6 +89,8 @@ const PLAN_COLUMNS = [
   'embedded',
   'created_at',
   'updated_at',
+  'machine_id',
+  'synced_at',
 ] as const;
 
 const SELECT_COLUMNS = PLAN_COLUMNS.join(', ');
@@ -109,6 +116,8 @@ function toPlanRow(row: Record<string, unknown>): PlanRow {
     embedded: (row.embedded as number) ?? 0,
     created_at: row.created_at as number,
     updated_at: (row.updated_at as number) ?? null,
+    machine_id: (row.machine_id as string) ?? DEFAULT_MACHINE_ID,
+    synced_at: (row.synced_at as number) ?? null,
   };
 }
 
@@ -128,11 +137,11 @@ export function upsertPlan(data: PlanInsert): PlanRow {
     `INSERT INTO plans (
        id, status, author, title, content,
        source_path, tags, session_id, prompt_batch_id, content_hash,
-       processed, created_at, updated_at
+       processed, created_at, updated_at, machine_id
      ) VALUES (
        ?, ?, ?, ?, ?,
        ?, ?, ?, ?, ?,
-       ?, ?, ?
+       ?, ?, ?, ?
      )
      ON CONFLICT (id) DO UPDATE SET
        status          = EXCLUDED.status,
@@ -164,11 +173,16 @@ export function upsertPlan(data: PlanInsert): PlanRow {
     data.processed ?? DEFAULT_PROCESSED,
     data.created_at,
     data.updated_at ?? null,
+    data.machine_id ?? DEFAULT_MACHINE_ID,
   );
 
-  return toPlanRow(
+  const row = toPlanRow(
     db.prepare(`SELECT ${SELECT_COLUMNS} FROM plans WHERE id = ?`).get(data.id) as Record<string, unknown>,
   );
+
+  syncRow('plans', row);
+
+  return row;
 }
 
 /**

--- a/src/db/queries/resolution-events.ts
+++ b/src/db/queries/resolution-events.ts
@@ -6,6 +6,8 @@
  */
 
 import { getDatabase } from '@myco/db/client.js';
+import { DEFAULT_MACHINE_ID } from '@myco/constants.js';
+import { syncRow } from '@myco/db/queries/team-outbox.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -28,6 +30,7 @@ export interface ResolutionEventInsert {
   new_spore_id?: string | null;
   reason?: string | null;
   session_id?: string | null;
+  machine_id?: string;
 }
 
 /** Row shape returned from resolution_events queries (all columns). */
@@ -40,6 +43,8 @@ export interface ResolutionEventRow {
   reason: string | null;
   session_id: string | null;
   created_at: number;
+  machine_id: string;
+  synced_at: number | null;
 }
 
 /** Filter options for `listResolutionEvents`. */
@@ -62,6 +67,8 @@ const EVENT_COLUMNS = [
   'reason',
   'session_id',
   'created_at',
+  'machine_id',
+  'synced_at',
 ] as const;
 
 const SELECT_COLUMNS = EVENT_COLUMNS.join(', ');
@@ -81,6 +88,8 @@ function toResolutionEventRow(row: Record<string, unknown>): ResolutionEventRow 
     reason: (row.reason as string) ?? null,
     session_id: (row.session_id as string) ?? null,
     created_at: row.created_at as number,
+    machine_id: (row.machine_id as string) ?? DEFAULT_MACHINE_ID,
+    synced_at: (row.synced_at as number) ?? null,
   };
 }
 
@@ -98,8 +107,8 @@ export function insertResolutionEvent(
 
   db.prepare(
     `INSERT INTO resolution_events (
-       id, agent_id, spore_id, action, new_spore_id, reason, session_id, created_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+       id, agent_id, spore_id, action, new_spore_id, reason, session_id, created_at, machine_id
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     data.id,
     data.agent_id,
@@ -109,11 +118,16 @@ export function insertResolutionEvent(
     data.reason ?? null,
     data.session_id ?? null,
     data.created_at,
+    data.machine_id ?? DEFAULT_MACHINE_ID,
   );
 
-  return toResolutionEventRow(
+  const row = toResolutionEventRow(
     db.prepare(`SELECT ${SELECT_COLUMNS} FROM resolution_events WHERE id = ?`).get(data.id) as Record<string, unknown>,
   );
+
+  syncRow('resolution_events', row);
+
+  return row;
 }
 
 /**

--- a/src/db/queries/sessions.ts
+++ b/src/db/queries/sessions.ts
@@ -6,6 +6,8 @@
  */
 
 import { getDatabase } from '@myco/db/client.js';
+import { DEFAULT_MACHINE_ID } from '@myco/constants.js';
+import { syncRow } from '@myco/db/queries/team-outbox.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -53,6 +55,7 @@ export interface SessionInsert {
   parent_session_reason?: string | null;
   processed?: number;
   content_hash?: string | null;
+  machine_id?: string;
 }
 
 /** Row shape returned from session queries (all columns). */
@@ -76,6 +79,8 @@ export interface SessionRow {
   content_hash: string | null;
   embedded: number;
   created_at: number;
+  machine_id: string;
+  synced_at: number | null;
 }
 
 /** Updatable fields for `updateSession`. */
@@ -130,6 +135,8 @@ const SESSION_COLUMNS = [
   'content_hash',
   'embedded',
   'created_at',
+  'machine_id',
+  'synced_at',
 ] as const;
 
 const SELECT_COLUMNS = SESSION_COLUMNS.join(', ');
@@ -164,6 +171,8 @@ function toSessionRow(row: Record<string, unknown>): SessionRow {
     content_hash: (row.content_hash as string) ?? null,
     embedded: (row.embedded as number) ?? 0,
     created_at: row.created_at as number,
+    machine_id: (row.machine_id as string) ?? DEFAULT_MACHINE_ID,
+    synced_at: (row.synced_at as number) ?? null,
   };
 }
 
@@ -186,13 +195,13 @@ export function upsertSession(data: SessionInsert): SessionRow {
        started_at, ended_at, status, prompt_count, tool_count,
        title, summary, transcript_path,
        parent_session_id, parent_session_reason,
-       processed, content_hash, created_at
+       processed, content_hash, created_at, machine_id
      ) VALUES (
        ?, ?, ?, ?, ?,
        ?, ?, ?, ?, ?,
        ?, ?, ?,
        ?, ?,
-       ?, ?, ?
+       ?, ?, ?, ?
      )
      ON CONFLICT (id) DO UPDATE SET
        agent                 = EXCLUDED.agent,
@@ -230,13 +239,18 @@ export function upsertSession(data: SessionInsert): SessionRow {
     data.processed ?? DEFAULT_PROCESSED,
     data.content_hash ?? null,
     data.created_at,
+    data.machine_id ?? DEFAULT_MACHINE_ID,
     data.prompt_count !== undefined ? 1 : 0,
     data.tool_count !== undefined ? 1 : 0,
   );
 
-  return toSessionRow(
+  const row = toSessionRow(
     db.prepare(`SELECT ${SELECT_COLUMNS} FROM sessions WHERE id = ?`).get(data.id) as Record<string, unknown>,
   );
+
+  syncRow('sessions', row);
+
+  return row;
 }
 
 /**
@@ -372,7 +386,11 @@ export function updateSession(
      WHERE id = ?`,
   ).run(...params);
 
-  return getSession(id);
+  const updated = getSession(id);
+
+  if (updated) syncRow('sessions', updated);
+
+  return updated;
 }
 
 /**
@@ -392,7 +410,11 @@ export function closeSession(
      WHERE id = ?`,
   ).run(STATUS_COMPLETED, endedAt, id);
 
-  return getSession(id);
+  const closed = getSession(id);
+
+  if (closed) syncRow('sessions', closed);
+
+  return closed;
 }
 
 /**

--- a/src/db/queries/spores.ts
+++ b/src/db/queries/spores.ts
@@ -6,6 +6,8 @@
  */
 
 import { getDatabase } from '@myco/db/client.js';
+import { DEFAULT_MACHINE_ID } from '@myco/constants.js';
+import { syncRow } from '@myco/db/queries/team-outbox.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -41,6 +43,7 @@ export interface SporeInsert {
   content_hash?: string | null;
   properties?: string | null;
   updated_at?: number | null;
+  machine_id?: string;
 }
 
 /** Row shape returned from spore queries (all columns). */
@@ -61,6 +64,8 @@ export interface SporeRow {
   embedded: number;
   created_at: number;
   updated_at: number | null;
+  machine_id: string;
+  synced_at: number | null;
 }
 
 /** Filter options for `listSpores`. */
@@ -95,6 +100,8 @@ const SPORE_COLUMNS = [
   'embedded',
   'created_at',
   'updated_at',
+  'machine_id',
+  'synced_at',
 ] as const;
 
 const SELECT_COLUMNS = SPORE_COLUMNS.join(', ');
@@ -122,6 +129,8 @@ function toSporeRow(row: Record<string, unknown>): SporeRow {
     embedded: (row.embedded as number) ?? 0,
     created_at: row.created_at as number,
     updated_at: (row.updated_at as number) ?? null,
+    machine_id: (row.machine_id as string) ?? DEFAULT_MACHINE_ID,
+    synced_at: (row.synced_at as number) ?? null,
   };
 }
 
@@ -142,12 +151,12 @@ export function insertSpore(data: SporeInsert): SporeRow {
        id, agent_id, session_id, prompt_batch_id,
        observation_type, status, content, context,
        importance, file_path, tags, content_hash,
-       properties, created_at, updated_at
+       properties, created_at, updated_at, machine_id
      ) VALUES (
        ?, ?, ?, ?,
        ?, ?, ?, ?,
        ?, ?, ?, ?,
-       ?, ?, ?
+       ?, ?, ?, ?
      )`,
   ).run(
     data.id,
@@ -165,11 +174,16 @@ export function insertSpore(data: SporeInsert): SporeRow {
     data.properties ?? null,
     data.created_at,
     data.updated_at ?? null,
+    data.machine_id ?? DEFAULT_MACHINE_ID,
   );
 
-  return toSporeRow(
+  const row = toSporeRow(
     db.prepare(`SELECT ${SELECT_COLUMNS} FROM spores WHERE id = ?`).get(data.id) as Record<string, unknown>,
   );
+
+  syncRow('spores', row);
+
+  return row;
 }
 
 /**
@@ -285,7 +299,11 @@ export function updateSporeStatus(
 
   if (info.changes === 0) return null;
 
-  return toSporeRow(
+  const row = toSporeRow(
     db.prepare(`SELECT ${SELECT_COLUMNS} FROM spores WHERE id = ?`).get(id) as Record<string, unknown>,
   );
+
+  syncRow('spores', row);
+
+  return row;
 }

--- a/src/db/queries/team-outbox.ts
+++ b/src/db/queries/team-outbox.ts
@@ -258,33 +258,33 @@ export function backfillUnsynced(machineId: string): number {
 
   const now = Math.floor(Date.now() / MS_PER_SECOND);
 
-  const runBackfill = db.transaction(() => {
-    for (const table of BACKFILL_TABLES) {
-      // Get rows that haven't been synced and aren't already in the outbox
-      const rows = db.prepare(
-        `SELECT * FROM ${table}
-         WHERE synced_at IS NULL
-         AND NOT EXISTS (
-           SELECT 1 FROM team_outbox
-           WHERE team_outbox.table_name = ? AND team_outbox.row_id = CAST(${table}.id AS TEXT)
-         )`,
-      ).all(table) as Record<string, unknown>[];
+  // Process one table at a time in separate transactions to avoid long locks
+  for (const table of BACKFILL_TABLES) {
+    const rows = db.prepare(
+      `SELECT * FROM ${table}
+       WHERE synced_at IS NULL
+       AND NOT EXISTS (
+         SELECT 1 FROM team_outbox
+         WHERE team_outbox.table_name = ? AND team_outbox.row_id = CAST(${table}.id AS TEXT)
+       )`,
+    ).all(table) as Record<string, unknown>[];
 
-      if (rows.length === 0) continue;
+    if (rows.length === 0) continue;
 
+    const insertBatch = db.transaction((batchRows: Record<string, unknown>[]) => {
       const stmt = db.prepare(
         `INSERT INTO team_outbox (table_name, row_id, operation, payload, machine_id, created_at)
          VALUES (?, ?, 'upsert', ?, ?, ?)`,
       );
-
-      for (const row of rows) {
+      for (const row of batchRows) {
         stmt.run(table, String(row.id), JSON.stringify(row), machineId, now);
-        total++;
       }
-    }
-  });
+    });
 
-  runBackfill();
+    insertBatch(rows);
+    total += rows.length;
+  }
+
   return total;
 }
 

--- a/src/db/queries/team-outbox.ts
+++ b/src/db/queries/team-outbox.ts
@@ -1,0 +1,290 @@
+/**
+ * Team outbox CRUD query helpers.
+ *
+ * The outbox pattern: write paths enqueue records here when team sync is enabled.
+ * The sync client flushes pending records in batches to the Cloudflare Worker.
+ *
+ * All functions obtain the SQLite instance internally via `getDatabase()`.
+ * Queries use positional `?` placeholders throughout (better-sqlite3).
+ */
+
+import { getDatabase } from '@myco/db/client.js';
+import { isTeamSyncEnabled, getTeamMachineId } from '@myco/daemon/team-context.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Max records returned per listPending call. */
+const BURST_BATCH_SIZE = 200;
+
+/** Age in seconds after which sent records are pruned (24 hours). */
+const SENT_PRUNE_AGE_SECONDS = 86_400;
+
+/** Milliseconds-per-second multiplier for epoch math. */
+const MS_PER_SECOND = 1000;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Fields required when enqueuing an outbox record. */
+export interface OutboxInsert {
+  table_name: string;
+  row_id: string;
+  operation?: string;
+  payload: string;
+  machine_id: string;
+  created_at: number;
+}
+
+/** Row shape returned from outbox queries. */
+export interface OutboxRow {
+  id: number;
+  table_name: string;
+  row_id: string;
+  operation: string;
+  payload: string;
+  machine_id: string;
+  created_at: number;
+  sent_at: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Column list
+// ---------------------------------------------------------------------------
+
+const OUTBOX_COLUMNS = [
+  'id',
+  'table_name',
+  'row_id',
+  'operation',
+  'payload',
+  'machine_id',
+  'created_at',
+  'sent_at',
+] as const;
+
+const SELECT_COLUMNS = OUTBOX_COLUMNS.join(', ');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Normalize a SQLite result row into a typed OutboxRow. */
+function toOutboxRow(row: Record<string, unknown>): OutboxRow {
+  return {
+    id: row.id as number,
+    table_name: row.table_name as string,
+    row_id: row.row_id as string,
+    operation: row.operation as string,
+    payload: row.payload as string,
+    machine_id: row.machine_id as string,
+    created_at: row.created_at as number,
+    sent_at: (row.sent_at as number) ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Convenience helper — used by query modules
+// ---------------------------------------------------------------------------
+
+/**
+ * Enqueue a row for team sync if sync is enabled.
+ *
+ * Centralizes the if-enabled / enqueue / serialize pattern that every
+ * write-path query module previously duplicated inline.
+ */
+export function syncRow(tableName: string, row: { id: string | number; created_at?: number }): void {
+  if (!isTeamSyncEnabled()) return;
+  enqueueOutbox({
+    table_name: tableName,
+    row_id: String(row.id),
+    payload: JSON.stringify(row),
+    machine_id: getTeamMachineId(),
+    created_at: row.created_at ?? Math.floor(Date.now() / 1000),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Enqueue a record into the team outbox for later sync.
+ *
+ * Inserted with `sent_at = NULL` (pending).
+ */
+export function enqueueOutbox(data: OutboxInsert): OutboxRow {
+  const db = getDatabase();
+
+  const info = db.prepare(
+    `INSERT INTO team_outbox (
+       table_name, row_id, operation, payload, machine_id, created_at
+     ) VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(
+    data.table_name,
+    data.row_id,
+    data.operation ?? 'upsert',
+    data.payload,
+    data.machine_id,
+    data.created_at,
+  );
+
+  const id = Number(info.lastInsertRowid);
+
+  return toOutboxRow(
+    db.prepare(`SELECT ${SELECT_COLUMNS} FROM team_outbox WHERE id = ?`).get(id) as Record<string, unknown>,
+  );
+}
+
+/**
+ * List pending outbox records (oldest-first).
+ *
+ * Uses burst sizing: fetches BURST_BATCH_SIZE rows and returns them all.
+ * If fewer than BURST_THRESHOLD rows come back, callers get a normal-size
+ * batch; if more, the full burst. This avoids a separate COUNT query.
+ */
+export function listPending(limit?: number): OutboxRow[] {
+  const db = getDatabase();
+
+  const rows = db.prepare(
+    `SELECT ${SELECT_COLUMNS}
+     FROM team_outbox
+     WHERE sent_at IS NULL
+     ORDER BY created_at ASC
+     LIMIT ?`,
+  ).all(limit ?? BURST_BATCH_SIZE) as Record<string, unknown>[];
+
+  return rows.map(toOutboxRow);
+}
+
+/**
+ * Mark outbox records as sent by setting sent_at.
+ */
+export function markSent(ids: number[], sentAt: number): void {
+  if (ids.length === 0) return;
+
+  const db = getDatabase();
+  const placeholders = ids.map(() => '?').join(', ');
+
+  db.prepare(
+    `UPDATE team_outbox
+     SET sent_at = ?
+     WHERE id IN (${placeholders})`,
+  ).run(sentAt, ...ids);
+}
+
+/**
+ * Reset sent_at to NULL for records that need to be retried.
+ *
+ * This allows the sync client to re-enqueue specific records for retry.
+ */
+export function markForRetry(ids: number[]): void {
+  if (ids.length === 0) return;
+
+  const db = getDatabase();
+  const placeholders = ids.map(() => '?').join(', ');
+
+  db.prepare(
+    `UPDATE team_outbox
+     SET sent_at = NULL
+     WHERE id IN (${placeholders})`,
+  ).run(...ids);
+}
+
+/**
+ * Prune old outbox records.
+ *
+ * Removes sent records older than 24 hours.
+ *
+ * @returns the number of records deleted.
+ */
+export function pruneOld(): number {
+  const db = getDatabase();
+  const cutoff = Math.floor(Date.now() / MS_PER_SECOND) - SENT_PRUNE_AGE_SECONDS;
+
+  const info = db.prepare(
+    `DELETE FROM team_outbox
+     WHERE sent_at IS NOT NULL AND sent_at < ?`,
+  ).run(cutoff);
+
+  return info.changes;
+}
+
+/**
+ * Count pending (unsent) outbox records.
+ */
+export function countPending(): number {
+  const db = getDatabase();
+
+  const row = db.prepare(
+    `SELECT COUNT(*) as count FROM team_outbox WHERE sent_at IS NULL`,
+  ).get() as { count: number };
+
+  return row.count;
+}
+
+// ---------------------------------------------------------------------------
+// Backfill
+// ---------------------------------------------------------------------------
+
+/** Tables to backfill (must have id, machine_id, synced_at columns). */
+const BACKFILL_TABLES = [
+  'sessions',
+  'prompt_batches',
+  'spores',
+  'entities',
+  'graph_edges',
+  'resolution_events',
+  'plans',
+  'artifacts',
+  'digest_extracts',
+] as const;
+// entity_mentions excluded — no `id` column (composite key entity_id+note_id+note_type)
+
+/**
+ * Enqueue all unsynced records across all synced tables into the outbox.
+ *
+ * Scans each table for rows where `synced_at IS NULL`, serializes the full
+ * row as JSON, and inserts into the outbox. Idempotent — re-running only
+ * picks up rows not yet in the outbox (checked via existing outbox entries).
+ *
+ * @returns the total number of records enqueued.
+ */
+export function backfillUnsynced(machineId: string): number {
+  const db = getDatabase();
+  let total = 0;
+
+  const now = Math.floor(Date.now() / MS_PER_SECOND);
+
+  const runBackfill = db.transaction(() => {
+    for (const table of BACKFILL_TABLES) {
+      // Get rows that haven't been synced and aren't already in the outbox
+      const rows = db.prepare(
+        `SELECT * FROM ${table}
+         WHERE synced_at IS NULL
+         AND NOT EXISTS (
+           SELECT 1 FROM team_outbox
+           WHERE team_outbox.table_name = ? AND team_outbox.row_id = CAST(${table}.id AS TEXT)
+         )`,
+      ).all(table) as Record<string, unknown>[];
+
+      if (rows.length === 0) continue;
+
+      const stmt = db.prepare(
+        `INSERT INTO team_outbox (table_name, row_id, operation, payload, machine_id, created_at)
+         VALUES (?, ?, 'upsert', ?, ?, ?)`,
+      );
+
+      for (const row of rows) {
+        stmt.run(table, String(row.id), JSON.stringify(row), machineId, now);
+        total++;
+      }
+    }
+  });
+
+  runBackfill();
+  return total;
+}
+

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -462,6 +462,7 @@ const SECONDARY_INDEXES = [
   // Team outbox
   'CREATE INDEX IF NOT EXISTS idx_team_outbox_pending ON team_outbox (sent_at, created_at)',
   'CREATE INDEX IF NOT EXISTS idx_team_outbox_table_name ON team_outbox (table_name)',
+  'CREATE INDEX IF NOT EXISTS idx_team_outbox_row_lookup ON team_outbox (table_name, row_id)',
 
   // Machine ID (synced tables)
   'CREATE INDEX IF NOT EXISTS idx_sessions_machine_id ON sessions (machine_id)',
@@ -678,6 +679,7 @@ function migrateV3ToV4(db: Database, machineId: string): void {
     const newIndexes = [
       'CREATE INDEX IF NOT EXISTS idx_team_outbox_pending ON team_outbox (sent_at, created_at)',
       'CREATE INDEX IF NOT EXISTS idx_team_outbox_table_name ON team_outbox (table_name)',
+      'CREATE INDEX IF NOT EXISTS idx_team_outbox_row_lookup ON team_outbox (table_name, row_id)',
       'CREATE INDEX IF NOT EXISTS idx_sessions_machine_id ON sessions (machine_id)',
       'CREATE INDEX IF NOT EXISTS idx_spores_machine_id ON spores (machine_id)',
       'CREATE INDEX IF NOT EXISTS idx_graph_edges_machine_id ON graph_edges (machine_id)',

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -14,10 +14,13 @@
  */
 
 import type { Database } from 'better-sqlite3';
-import { epochSeconds } from '@myco/constants.js';
+import { epochSeconds, DEFAULT_MACHINE_ID } from '@myco/constants.js';
 
 /** Current schema version -- fresh start for the SQLite era. */
-export const SCHEMA_VERSION = 3;
+export const SCHEMA_VERSION = 4;
+
+// Re-export for backwards compat (other modules import from schema.ts)
+export { DEFAULT_MACHINE_ID };
 
 /** Embedding vector dimensions (bge-m3 default). */
 export const EMBEDDING_DIMENSIONS = 1024;
@@ -54,7 +57,9 @@ const SESSIONS_TABLE = `
     processed              INTEGER DEFAULT 0,
     content_hash           TEXT UNIQUE,
     created_at             INTEGER NOT NULL,
-    embedded               INTEGER DEFAULT 0
+    embedded               INTEGER DEFAULT 0,
+    machine_id             TEXT NOT NULL DEFAULT 'local',
+    synced_at              INTEGER
   )`;
 
 const PROMPT_BATCHES_TABLE = `
@@ -71,7 +76,9 @@ const PROMPT_BATCHES_TABLE = `
     activity_count    INTEGER DEFAULT 0,
     processed         INTEGER DEFAULT 0,
     content_hash      TEXT UNIQUE,
-    created_at        INTEGER NOT NULL
+    created_at        INTEGER NOT NULL,
+    machine_id        TEXT NOT NULL DEFAULT 'local',
+    synced_at         INTEGER
   )`;
 
 const ACTIVITIES_TABLE = `
@@ -108,7 +115,9 @@ const PLANS_TABLE = `
     processed        INTEGER DEFAULT 0,
     created_at       INTEGER NOT NULL,
     updated_at       INTEGER,
-    embedded         INTEGER DEFAULT 0
+    embedded         INTEGER DEFAULT 0,
+    machine_id       TEXT NOT NULL DEFAULT 'local',
+    synced_at        INTEGER
   )`;
 
 const ARTIFACTS_TABLE = `
@@ -122,16 +131,20 @@ const ARTIFACTS_TABLE = `
     tags             TEXT,
     created_at       INTEGER NOT NULL,
     updated_at       INTEGER,
-    embedded         INTEGER DEFAULT 0
+    embedded         INTEGER DEFAULT 0,
+    machine_id       TEXT NOT NULL DEFAULT 'local',
+    synced_at        INTEGER
   )`;
 
 const TEAM_MEMBERS_TABLE = `
   CREATE TABLE IF NOT EXISTS team_members (
-    id      TEXT PRIMARY KEY,
-    "user"  TEXT NOT NULL,
-    role    TEXT,
-    joined  TEXT,
-    tags    TEXT
+    id          TEXT PRIMARY KEY,
+    "user"      TEXT NOT NULL,
+    role        TEXT,
+    joined      TEXT,
+    tags        TEXT,
+    machine_id  TEXT NOT NULL DEFAULT 'local',
+    synced_at   INTEGER
   )`;
 
 const ATTACHMENTS_TABLE = `
@@ -184,7 +197,9 @@ const SPORES_TABLE = `
     properties        TEXT,
     created_at        INTEGER NOT NULL,
     updated_at        INTEGER,
-    embedded          INTEGER DEFAULT 0
+    embedded          INTEGER DEFAULT 0,
+    machine_id        TEXT NOT NULL DEFAULT 'local',
+    synced_at         INTEGER
   )`;
 
 const ENTITIES_TABLE = `
@@ -197,6 +212,8 @@ const ENTITIES_TABLE = `
     first_seen  INTEGER NOT NULL,
     last_seen   INTEGER NOT NULL,
     status      TEXT DEFAULT 'active',
+    machine_id  TEXT NOT NULL DEFAULT 'local',
+    synced_at   INTEGER,
     UNIQUE (agent_id, type, name)
   )`;
 
@@ -212,7 +229,9 @@ const GRAPH_EDGES_TABLE = `
     session_id      TEXT,
     confidence      REAL DEFAULT 1.0,
     properties      TEXT,
-    created_at      INTEGER NOT NULL
+    created_at      INTEGER NOT NULL,
+    machine_id      TEXT NOT NULL DEFAULT 'local',
+    synced_at       INTEGER
   )`;
 
 const ENTITY_MENTIONS_TABLE = `
@@ -221,6 +240,8 @@ const ENTITY_MENTIONS_TABLE = `
     note_id     TEXT NOT NULL,
     note_type   TEXT NOT NULL,
     agent_id    TEXT NOT NULL REFERENCES agents(id),
+    machine_id  TEXT NOT NULL DEFAULT 'local',
+    synced_at   INTEGER,
     UNIQUE (entity_id, note_id, note_type, agent_id)
   )`;
 
@@ -233,7 +254,9 @@ const RESOLUTION_EVENTS_TABLE = `
     new_spore_id  TEXT,
     reason        TEXT,
     session_id    TEXT,
-    created_at    INTEGER NOT NULL
+    created_at    INTEGER NOT NULL,
+    machine_id    TEXT NOT NULL DEFAULT 'local',
+    synced_at     INTEGER
   )`;
 
 const DIGEST_EXTRACTS_TABLE = `
@@ -244,6 +267,8 @@ const DIGEST_EXTRACTS_TABLE = `
     content         TEXT NOT NULL,
     substrate_hash  TEXT,
     generated_at    INTEGER NOT NULL,
+    machine_id      TEXT NOT NULL DEFAULT 'local',
+    synced_at       INTEGER,
     UNIQUE (agent_id, tier)
   )`;
 
@@ -311,6 +336,20 @@ const AGENT_STATE_TABLE = `
     value       TEXT NOT NULL,
     updated_at  INTEGER NOT NULL,
     PRIMARY KEY (agent_id, key)
+  )`;
+
+// -- Sync Layer -------------------------------------------------------------
+
+const TEAM_OUTBOX_TABLE = `
+  CREATE TABLE IF NOT EXISTS team_outbox (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    table_name  TEXT NOT NULL,
+    row_id      TEXT NOT NULL,
+    operation   TEXT NOT NULL DEFAULT 'upsert',
+    payload     TEXT NOT NULL,
+    machine_id  TEXT NOT NULL,
+    created_at  INTEGER NOT NULL,
+    sent_at     INTEGER
   )`;
 
 // -- Logging Layer ----------------------------------------------------------
@@ -420,6 +459,15 @@ const SECONDARY_INDEXES = [
   // Attachments
   'CREATE INDEX IF NOT EXISTS idx_attachments_file_path ON attachments (file_path)',
 
+  // Team outbox
+  'CREATE INDEX IF NOT EXISTS idx_team_outbox_pending ON team_outbox (sent_at, created_at)',
+  'CREATE INDEX IF NOT EXISTS idx_team_outbox_table_name ON team_outbox (table_name)',
+
+  // Machine ID (synced tables)
+  'CREATE INDEX IF NOT EXISTS idx_sessions_machine_id ON sessions (machine_id)',
+  'CREATE INDEX IF NOT EXISTS idx_spores_machine_id ON spores (machine_id)',
+  'CREATE INDEX IF NOT EXISTS idx_graph_edges_machine_id ON graph_edges (machine_id)',
+
   // Log entries
   'CREATE INDEX IF NOT EXISTS idx_log_entries_timestamp ON log_entries (timestamp)',
   'CREATE INDEX IF NOT EXISTS idx_log_entries_level ON log_entries (level)',
@@ -454,6 +502,8 @@ const TABLE_DDLS = [
   AGENT_TURNS_TABLE,
   AGENT_TASKS_TABLE,
   AGENT_STATE_TABLE,
+  // Sync layer
+  TEAM_OUTBOX_TABLE,
   // Logging layer
   LOG_ENTRIES_TABLE,
 ];
@@ -574,6 +624,82 @@ function migrateV2ToV3(db: Database): void {
   }
 }
 
+/**
+ * Migrate a version-3 database to version-4.
+ *
+ * Version 4 adds multi-machine support:
+ *   - machine_id TEXT NOT NULL DEFAULT 'local' on all synced tables
+ *   - synced_at INTEGER on all synced tables
+ *   - team_outbox table + indexes
+ *   - machine_id indexes on high-traffic tables
+ *
+ * Backfills existing rows with the provided machineId.
+ */
+function migrateV3ToV4(db: Database, machineId: string): void {
+  db.exec('BEGIN');
+  try {
+    // Tables that need machine_id + synced_at columns
+    const syncedTables = [
+      'sessions',
+      'prompt_batches',
+      'spores',
+      'entities',
+      'graph_edges',
+      'entity_mentions',
+      'resolution_events',
+      'plans',
+      'artifacts',
+      'digest_extracts',
+      'team_members',
+    ];
+
+    for (const table of syncedTables) {
+      try {
+        db.exec(`ALTER TABLE ${table} ADD COLUMN machine_id TEXT NOT NULL DEFAULT 'local'`);
+      } catch {
+        // Column already exists -- safe to ignore on re-run
+      }
+      try {
+        db.exec(`ALTER TABLE ${table} ADD COLUMN synced_at INTEGER`);
+      } catch {
+        // Column already exists -- safe to ignore on re-run
+      }
+    }
+
+    // Backfill machine_id on existing rows
+    for (const table of syncedTables) {
+      db.prepare(`UPDATE ${table} SET machine_id = ? WHERE machine_id = 'local'`).run(machineId);
+    }
+
+    // Create team_outbox table
+    db.exec(TEAM_OUTBOX_TABLE);
+
+    // Create new indexes (IF NOT EXISTS for idempotency)
+    const newIndexes = [
+      'CREATE INDEX IF NOT EXISTS idx_team_outbox_pending ON team_outbox (sent_at, created_at)',
+      'CREATE INDEX IF NOT EXISTS idx_team_outbox_table_name ON team_outbox (table_name)',
+      'CREATE INDEX IF NOT EXISTS idx_sessions_machine_id ON sessions (machine_id)',
+      'CREATE INDEX IF NOT EXISTS idx_spores_machine_id ON spores (machine_id)',
+      'CREATE INDEX IF NOT EXISTS idx_graph_edges_machine_id ON graph_edges (machine_id)',
+    ];
+
+    for (const idx of newIndexes) {
+      db.exec(idx);
+    }
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at)
+       VALUES (?, ?)
+       ON CONFLICT (version) DO NOTHING`
+    ).run(4, epochSeconds());
+
+    db.exec('COMMIT');
+  } catch (err) {
+    db.exec('ROLLBACK');
+    throw err;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -583,8 +709,12 @@ function migrateV2ToV3(db: Database): void {
  *
  * Fully idempotent -- safe to call on every startup. Uses `IF NOT EXISTS`
  * for all DDL and `ON CONFLICT DO NOTHING` for the version row.
+ *
+ * @param db — better-sqlite3 Database instance.
+ * @param machineId — machine identifier for backfilling existing rows during
+ *   v3→v4 migration. Defaults to `'local'` (tests, init).
  */
-export function createSchema(db: Database): void {
+export function createSchema(db: Database, machineId: string = DEFAULT_MACHINE_ID): void {
   // Fast-path: skip if already at current version
   try {
     const row = db.prepare(
@@ -601,6 +731,13 @@ export function createSchema(db: Database): void {
     ).get() as { version: number } | undefined)?.version ?? 0;
     if (afterV1Migration < 3) {
       migrateV2ToV3(db);
+    }
+    // Migration path: version 3 → 4
+    const afterV2Migration = (db.prepare(
+      'SELECT version FROM schema_version ORDER BY version DESC LIMIT 1'
+    ).get() as { version: number } | undefined)?.version ?? 0;
+    if (afterV2Migration < 4) {
+      migrateV3ToV4(db, machineId);
     }
     return;
   } catch {

--- a/src/hooks/client.ts
+++ b/src/hooks/client.ts
@@ -9,6 +9,15 @@ interface DaemonInfo {
   port: number;
 }
 
+/**
+ * Resolve the CLI entry point for spawning daemon processes.
+ * Uses process.argv[1] so the daemon restarts from the same binary
+ * (myco-dev vs global myco) that launched the current process.
+ */
+export function resolveCliEntryPath(): { execPath: string; cliEntry: string } {
+  return { execPath: process.execPath, cliEntry: process.argv[1] };
+}
+
 interface HealthResponse {
   myco: boolean;
   version?: string;
@@ -169,8 +178,8 @@ export class DaemonClient {
   }
 
   spawnDaemon(): void {
-    const mycoCmd = process.env.MYCO_CMD || 'myco';
-    const child = spawn(mycoCmd, ['daemon', '--vault', this.vaultDir], {
+    const { execPath, cliEntry } = resolveCliEntryPath();
+    const child = spawn(execPath, [cliEntry, 'daemon', '--vault', this.vaultDir], {
       detached: true,
       stdio: 'ignore',
     });

--- a/src/worker/package.json
+++ b/src/worker/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@goondocks/myco-worker",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Myco team sync Cloudflare Worker",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250320.0",
+    "typescript": "^5.7.0",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/src/worker/src/auth.ts
+++ b/src/worker/src/auth.ts
@@ -1,0 +1,31 @@
+/**
+ * Bearer token auth for the Myco team sync worker.
+ */
+
+export interface AuthEnv {
+  MYCO_TEAM_API_KEY: string;
+}
+
+/**
+ * Validate the Authorization header against the configured API key.
+ * Returns null on success, or a 401 Response on failure.
+ */
+export function validateAuth(request: Request, env: AuthEnv): Response | null {
+  const header = request.headers.get('Authorization');
+  if (!header) {
+    return new Response(JSON.stringify({ error: 'Missing Authorization header' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const token = header.startsWith('Bearer ') ? header.slice(7) : '';
+  if (!token || token !== env.MYCO_TEAM_API_KEY) {
+    return new Response(JSON.stringify({ error: 'Invalid API key' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return null;
+}

--- a/src/worker/src/index.ts
+++ b/src/worker/src/index.ts
@@ -1,0 +1,480 @@
+/**
+ * Myco Team Sync — Cloudflare Worker
+ *
+ * Provides team-wide storage and vector search backed by D1 + Vectorize + Workers AI.
+ * Each node (machine) pushes its outbox records here; the worker deduplicates by
+ * content_hash and maintains a shared Vectorize index for semantic search.
+ */
+
+import { initD1Schema } from './schema';
+import { validateAuth } from './auth';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface Env {
+  MYCO_TEAM_DB: D1Database;
+  MYCO_TEAM_VECTORS: VectorizeIndex;
+  AI: Ai;
+  MYCO_TEAM_API_KEY: string;
+  SYNC_PROTOCOL_VERSION: string;
+}
+
+/** Tables that support embedding in Vectorize. */
+const EMBEDDABLE_TABLES: Record<string, string> = {
+  spores: 'content',
+  sessions: 'summary',
+  plans: 'content',
+  artifacts: 'content',
+};
+
+/** All tables the sync endpoint accepts records for. */
+const SYNCED_TABLES = [
+  'sessions',
+  'prompt_batches',
+  'spores',
+  'entities',
+  'graph_edges',
+  'entity_mentions',
+  'resolution_events',
+  'plans',
+  'artifacts',
+  'digest_extracts',
+] as const;
+
+type SyncedTable = (typeof SYNCED_TABLES)[number];
+
+interface SyncRecord {
+  table: SyncedTable;
+  operation: 'upsert' | 'delete';
+  id: string;
+  machine_id: string;
+  content_hash?: string | null;
+  data: Record<string, unknown>;
+}
+
+interface ConnectPayload {
+  machine_id: string;
+  package_version?: string;
+  schema_version?: number;
+  sync_protocol_version?: number;
+}
+
+interface SyncPayload {
+  sync_protocol_version: number;
+  machine_id: string;
+  records: SyncRecord[];
+}
+
+interface SearchResult {
+  table: string;
+  id: string;
+  machine_id: string;
+  score: number;
+  data: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Whether initD1Schema has already run for this Worker instance. */
+let schemaInitialized = false;
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' } as const;
+const DEFAULT_TOP_K = 10;
+const MAX_TOP_K = 50;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+}
+
+function errorResponse(message: string, status: number): Response {
+  return jsonResponse({ error: message }, status);
+}
+
+function epochSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+/**
+ * Build a Vectorize namespace ID for a record: `{table}:{id}:{machine_id}`.
+ */
+function vectorId(table: string, id: string, machineId: string): string {
+  return `${table}:${id}:${machineId}`;
+}
+
+/**
+ * Embed text via Workers AI (bge-m3) and return the vector.
+ */
+async function embedText(ai: Ai, text: string): Promise<number[]> {
+  const result = await ai.run('@cf/baai/bge-m3', { text: [text] });
+  return result.data[0];
+}
+
+/**
+ * Build column names and placeholders for an INSERT OR REPLACE from a data object.
+ * Always includes id and machine_id.
+ */
+function buildInsertParts(
+  table: string,
+  data: Record<string, unknown>,
+  id: string,
+  machineId: string,
+): { sql: string; values: unknown[] } {
+  const row: Record<string, unknown> = { id, machine_id: machineId, ...data, synced_at: epochSeconds() };
+
+  // Remove fields that don't belong in D1 (local-only fields)
+  delete row.embedded;
+
+  const columns = Object.keys(row);
+  const placeholders = columns.map(() => '?').join(', ');
+  const quotedColumns = columns.map((c) => (c === 'user' ? `"user"` : c)).join(', ');
+
+  return {
+    sql: `INSERT OR REPLACE INTO ${table} (${quotedColumns}) VALUES (${placeholders})`,
+    values: Object.values(row),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers
+// ---------------------------------------------------------------------------
+
+async function handleHealth(env: Env): Promise<Response> {
+  const result = await env.MYCO_TEAM_DB.prepare('SELECT COUNT(*) as count FROM nodes').first<{
+    count: number;
+  }>();
+  return jsonResponse({ status: 'ok', nodes: result?.count ?? 0 });
+}
+
+async function handleConnect(request: Request, env: Env): Promise<Response> {
+  const body = (await request.json()) as ConnectPayload;
+  if (!body.machine_id) {
+    return errorResponse('machine_id is required', 400);
+  }
+
+  const now = epochSeconds();
+
+  await env.MYCO_TEAM_DB.prepare(
+    `INSERT INTO nodes (machine_id, package_version, schema_version, sync_protocol_version, last_seen, registered_at)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT (machine_id) DO UPDATE SET
+       package_version = excluded.package_version,
+       schema_version = excluded.schema_version,
+       sync_protocol_version = excluded.sync_protocol_version,
+       last_seen = excluded.last_seen`,
+  ).bind(
+    body.machine_id,
+    body.package_version ?? null,
+    body.schema_version ?? null,
+    body.sync_protocol_version ?? null,
+    now,
+    now,
+  ).run();
+
+  // Return team config
+  const configRows = await env.MYCO_TEAM_DB.prepare('SELECT key, value FROM team_config').all<{
+    key: string;
+    value: string;
+  }>();
+  const config: Record<string, string> = {};
+  for (const row of configRows.results) {
+    config[row.key] = row.value;
+  }
+
+  return jsonResponse({
+    status: 'connected',
+    sync_protocol_version: parseInt(env.SYNC_PROTOCOL_VERSION, 10),
+    config,
+  });
+}
+
+async function handleSync(request: Request, env: Env): Promise<Response> {
+  const body = (await request.json()) as SyncPayload;
+
+  // Version check
+  const serverVersion = parseInt(env.SYNC_PROTOCOL_VERSION, 10);
+  if (body.sync_protocol_version !== serverVersion) {
+    return errorResponse(
+      `Protocol version mismatch: client=${body.sync_protocol_version}, server=${serverVersion}`,
+      409,
+    );
+  }
+
+  if (!Array.isArray(body.records) || body.records.length === 0) {
+    return jsonResponse({ synced: 0, skipped: 0, errors: [] });
+  }
+
+  let synced = 0;
+  let skipped = 0;
+  const errors: Array<{ id: string; table: string; error: string }> = [];
+
+  // Collect embedding tasks so they can be parallelized after DB writes
+  const embeddingTasks: Array<() => Promise<void>> = [];
+
+  for (const record of body.records) {
+    try {
+      if (!SYNCED_TABLES.includes(record.table)) {
+        errors.push({ id: record.id, table: record.table, error: `Unknown table: ${record.table}` });
+        continue;
+      }
+
+      if (record.operation === 'delete') {
+        await handleDelete(env, record);
+        synced++;
+        continue;
+      }
+
+      // Check content_hash — skip if unchanged
+      if (record.content_hash) {
+        const existing = await env.MYCO_TEAM_DB.prepare(
+          `SELECT content_hash FROM ${record.table} WHERE id = ? AND machine_id = ?`,
+        )
+          .bind(record.id, record.machine_id)
+          .first<{ content_hash: string | null }>();
+
+        if (existing?.content_hash === record.content_hash) {
+          skipped++;
+          continue;
+        }
+      }
+
+      // INSERT OR REPLACE into D1
+      const { sql, values } = buildInsertParts(record.table, record.data, record.id, record.machine_id);
+      await env.MYCO_TEAM_DB.prepare(sql).bind(...values).run();
+
+      // Queue embedding if the table has embeddable content
+      const embeddableField = EMBEDDABLE_TABLES[record.table];
+      if (embeddableField) {
+        const textContent = record.data[embeddableField] as string | undefined;
+        if (textContent) {
+          const { table, id, machine_id } = record;
+          if (table === 'spores' && record.data.status === 'superseded') {
+            embeddingTasks.push(() => deleteVector(env, table, id, machine_id));
+          } else {
+            embeddingTasks.push(() => embedAndUpsert(env, table, id, machine_id, textContent));
+          }
+        }
+      }
+
+      synced++;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors.push({ id: record.id, table: record.table, error: message });
+    }
+  }
+
+  // Run all embedding tasks in parallel
+  if (embeddingTasks.length > 0) {
+    await Promise.allSettled(embeddingTasks.map((t) => t()));
+  }
+
+  // Update node last_seen
+  await env.MYCO_TEAM_DB.prepare('UPDATE nodes SET last_seen = ? WHERE machine_id = ?')
+    .bind(epochSeconds(), body.machine_id)
+    .run();
+
+  return jsonResponse({ synced, skipped, errors });
+}
+
+async function handleDelete(env: Env, record: SyncRecord): Promise<void> {
+  await env.MYCO_TEAM_DB.prepare(`DELETE FROM ${record.table} WHERE id = ? AND machine_id = ?`)
+    .bind(record.id, record.machine_id)
+    .run();
+
+  // Remove from Vectorize if embeddable
+  if (record.table in EMBEDDABLE_TABLES) {
+    await deleteVector(env, record.table, record.id, record.machine_id);
+  }
+}
+
+async function embedAndUpsert(
+  env: Env,
+  table: string,
+  id: string,
+  machineId: string,
+  text: string,
+): Promise<void> {
+  const vector = await embedText(env.AI, text);
+  const vid = vectorId(table, id, machineId);
+  await env.MYCO_TEAM_VECTORS.upsert([
+    {
+      id: vid,
+      values: vector,
+      metadata: { table, id, machine_id: machineId },
+    },
+  ]);
+}
+
+async function deleteVector(env: Env, table: string, id: string, machineId: string): Promise<void> {
+  const vid = vectorId(table, id, machineId);
+  try {
+    await env.MYCO_TEAM_VECTORS.deleteByIds([vid]);
+  } catch {
+    // Vector may not exist — safe to ignore
+  }
+}
+
+async function handleSearch(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  const query = url.searchParams.get('q');
+  if (!query) {
+    return errorResponse('Missing query parameter "q"', 400);
+  }
+
+  const topK = Math.min(parseInt(url.searchParams.get('top_k') ?? String(DEFAULT_TOP_K), 10), MAX_TOP_K);
+
+  // Embed query
+  const queryVector = await embedText(env.AI, query);
+
+  // Search Vectorize
+  const matches = await env.MYCO_TEAM_VECTORS.query(queryVector, {
+    topK,
+    returnMetadata: 'all',
+  });
+
+  // Group matches by table for batch hydration
+  const byTable = new Map<string, { id: string; machine_id: string; score: number }[]>();
+  for (const match of matches.matches) {
+    const meta = match.metadata as { table: string; id: string; machine_id: string } | undefined;
+    if (!meta) continue;
+    let group = byTable.get(meta.table);
+    if (!group) {
+      group = [];
+      byTable.set(meta.table, group);
+    }
+    group.push({ id: meta.id, machine_id: meta.machine_id, score: match.score });
+  }
+
+  // Batch-query each table and build results
+  const results: SearchResult[] = [];
+  for (const [table, items] of byTable) {
+    const placeholders = items.map(() => '(?, ?)').join(', ');
+    const binds = items.flatMap((i) => [i.id, i.machine_id]);
+    const { results: rows } = await env.MYCO_TEAM_DB.prepare(
+      `SELECT * FROM ${table} WHERE (id, machine_id) IN (VALUES ${placeholders})`,
+    ).bind(...binds).all();
+
+    const rowMap = new Map<string, Record<string, unknown>>();
+    for (const row of rows) {
+      const r = row as Record<string, unknown>;
+      rowMap.set(`${r.id}:${r.machine_id}`, r);
+    }
+
+    for (const item of items) {
+      const row = rowMap.get(`${item.id}:${item.machine_id}`);
+      if (row) {
+        results.push({
+          table,
+          id: item.id,
+          machine_id: item.machine_id,
+          score: item.score,
+          data: row,
+        });
+      }
+    }
+  }
+
+  // Sort by score to preserve ranking after batch hydration
+  results.sort((a, b) => b.score - a.score);
+
+  return jsonResponse({ results });
+}
+
+async function handleGetConfig(env: Env): Promise<Response> {
+  const rows = await env.MYCO_TEAM_DB.prepare('SELECT key, value FROM team_config').all<{
+    key: string;
+    value: string;
+  }>();
+
+  const config: Record<string, string> = {};
+  for (const row of rows.results) {
+    config[row.key] = row.value;
+  }
+
+  return jsonResponse({
+    config,
+    sync_protocol_version: parseInt(env.SYNC_PROTOCOL_VERSION, 10),
+  });
+}
+
+async function handlePutConfig(request: Request, env: Env): Promise<Response> {
+  const body = (await request.json()) as Record<string, string>;
+
+  const entries = Object.entries(body);
+  if (entries.length === 0) {
+    return errorResponse('Empty config body', 400);
+  }
+
+  const statements = entries.map(([key, value]) =>
+    env.MYCO_TEAM_DB.prepare('INSERT OR REPLACE INTO team_config (key, value) VALUES (?, ?)').bind(key, value),
+  );
+
+  await env.MYCO_TEAM_DB.batch(statements);
+
+  return jsonResponse({ updated: entries.length });
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const path = url.pathname;
+    const method = request.method;
+
+    // Health — no auth required
+    if (method === 'GET' && path === '/health') {
+      try {
+        if (!schemaInitialized) {
+          await initD1Schema(env.MYCO_TEAM_DB);
+          schemaInitialized = true;
+        }
+        return await handleHealth(env);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return errorResponse(`Health check failed: ${message}`, 500);
+      }
+    }
+
+    // All other routes require auth
+    const authError = validateAuth(request, env);
+    if (authError) return authError;
+
+    if (!schemaInitialized) {
+      await initD1Schema(env.MYCO_TEAM_DB);
+      schemaInitialized = true;
+    }
+
+    try {
+      if (method === 'POST' && path === '/connect') {
+        return await handleConnect(request, env);
+      }
+      if (method === 'POST' && path === '/sync') {
+        return await handleSync(request, env);
+      }
+      if (method === 'GET' && path === '/search') {
+        return await handleSearch(request, env);
+      }
+      if (method === 'GET' && path === '/config') {
+        return await handleGetConfig(env);
+      }
+      if (method === 'PUT' && path === '/config') {
+        return await handlePutConfig(request, env);
+      }
+
+      return errorResponse('Not found', 404);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return errorResponse(message, 500);
+    }
+  },
+} satisfies ExportedHandler<Env>;

--- a/src/worker/src/schema.ts
+++ b/src/worker/src/schema.ts
@@ -1,0 +1,236 @@
+/**
+ * D1 schema for the Myco team sync worker.
+ *
+ * Mirrors the synced subset of the local SQLite schema. Tables use
+ * (id, machine_id) composite primary keys so records from multiple
+ * machines coexist without collision.
+ *
+ * Fully idempotent — safe to call on every request.
+ */
+
+const SESSIONS_TABLE = `
+  CREATE TABLE IF NOT EXISTS sessions (
+    id                     TEXT NOT NULL,
+    machine_id             TEXT NOT NULL,
+    agent                  TEXT NOT NULL,
+    "user"                 TEXT,
+    project_root           TEXT,
+    branch                 TEXT,
+    started_at             INTEGER NOT NULL,
+    ended_at               INTEGER,
+    status                 TEXT DEFAULT 'active',
+    prompt_count           INTEGER DEFAULT 0,
+    tool_count             INTEGER DEFAULT 0,
+    title                  TEXT,
+    summary                TEXT,
+    transcript_path        TEXT,
+    parent_session_id      TEXT,
+    parent_session_reason  TEXT,
+    processed              INTEGER DEFAULT 0,
+    content_hash           TEXT,
+    created_at             INTEGER NOT NULL,
+    synced_at              INTEGER,
+    PRIMARY KEY (id, machine_id)
+  )`;
+
+const PROMPT_BATCHES_TABLE = `
+  CREATE TABLE IF NOT EXISTS prompt_batches (
+    id                INTEGER NOT NULL,
+    machine_id        TEXT NOT NULL,
+    session_id        TEXT NOT NULL,
+    prompt_number     INTEGER,
+    user_prompt       TEXT,
+    response_summary  TEXT,
+    classification    TEXT,
+    started_at        INTEGER,
+    ended_at          INTEGER,
+    status            TEXT DEFAULT 'active',
+    activity_count    INTEGER DEFAULT 0,
+    processed         INTEGER DEFAULT 0,
+    content_hash      TEXT,
+    created_at        INTEGER NOT NULL,
+    synced_at         INTEGER,
+    PRIMARY KEY (id, machine_id)
+  )`;
+
+const SPORES_TABLE = `
+  CREATE TABLE IF NOT EXISTS spores (
+    id                TEXT NOT NULL,
+    machine_id        TEXT NOT NULL,
+    agent_id          TEXT NOT NULL,
+    session_id        TEXT,
+    prompt_batch_id   INTEGER,
+    observation_type  TEXT NOT NULL,
+    status            TEXT DEFAULT 'active',
+    content           TEXT NOT NULL,
+    context           TEXT,
+    importance        INTEGER DEFAULT 5,
+    file_path         TEXT,
+    tags              TEXT,
+    content_hash      TEXT,
+    properties        TEXT,
+    created_at        INTEGER NOT NULL,
+    updated_at        INTEGER,
+    synced_at         INTEGER,
+    PRIMARY KEY (id, machine_id)
+  )`;
+
+const ENTITIES_TABLE = `
+  CREATE TABLE IF NOT EXISTS entities (
+    id          TEXT NOT NULL,
+    machine_id  TEXT NOT NULL,
+    agent_id    TEXT NOT NULL,
+    type        TEXT NOT NULL,
+    name        TEXT NOT NULL,
+    properties  TEXT,
+    first_seen  INTEGER NOT NULL,
+    last_seen   INTEGER NOT NULL,
+    status      TEXT DEFAULT 'active',
+    synced_at   INTEGER,
+    PRIMARY KEY (id, machine_id)
+  )`;
+
+const GRAPH_EDGES_TABLE = `
+  CREATE TABLE IF NOT EXISTS graph_edges (
+    id              TEXT NOT NULL,
+    machine_id      TEXT NOT NULL,
+    agent_id        TEXT NOT NULL,
+    source_id       TEXT NOT NULL,
+    source_type     TEXT NOT NULL,
+    target_id       TEXT NOT NULL,
+    target_type     TEXT NOT NULL,
+    type            TEXT NOT NULL,
+    session_id      TEXT,
+    confidence      REAL DEFAULT 1.0,
+    properties      TEXT,
+    created_at      INTEGER NOT NULL,
+    synced_at       INTEGER,
+    PRIMARY KEY (id, machine_id)
+  )`;
+
+const PLANS_TABLE = `
+  CREATE TABLE IF NOT EXISTS plans (
+    id               TEXT NOT NULL,
+    machine_id       TEXT NOT NULL,
+    status           TEXT DEFAULT 'active',
+    author           TEXT,
+    title            TEXT,
+    content          TEXT,
+    source_path      TEXT,
+    tags             TEXT,
+    session_id       TEXT,
+    prompt_batch_id  INTEGER,
+    content_hash     TEXT,
+    processed        INTEGER DEFAULT 0,
+    created_at       INTEGER NOT NULL,
+    updated_at       INTEGER,
+    synced_at        INTEGER,
+    PRIMARY KEY (id, machine_id)
+  )`;
+
+const ARTIFACTS_TABLE = `
+  CREATE TABLE IF NOT EXISTS artifacts (
+    id               TEXT NOT NULL,
+    machine_id       TEXT NOT NULL,
+    artifact_type    TEXT,
+    source_path      TEXT NOT NULL,
+    title            TEXT NOT NULL,
+    content          TEXT,
+    last_captured_by TEXT,
+    tags             TEXT,
+    created_at       INTEGER NOT NULL,
+    updated_at       INTEGER,
+    synced_at        INTEGER,
+    PRIMARY KEY (id, machine_id)
+  )`;
+
+const ENTITY_MENTIONS_TABLE = `
+  CREATE TABLE IF NOT EXISTS entity_mentions (
+    entity_id   TEXT NOT NULL,
+    note_id     TEXT NOT NULL,
+    note_type   TEXT NOT NULL,
+    agent_id    TEXT NOT NULL,
+    machine_id  TEXT NOT NULL,
+    synced_at   INTEGER,
+    UNIQUE (entity_id, note_id, note_type, agent_id)
+  )`;
+
+const RESOLUTION_EVENTS_TABLE = `
+  CREATE TABLE IF NOT EXISTS resolution_events (
+    id            TEXT NOT NULL,
+    machine_id    TEXT NOT NULL,
+    agent_id      TEXT NOT NULL,
+    spore_id      TEXT NOT NULL,
+    action        TEXT NOT NULL,
+    new_spore_id  TEXT,
+    reason        TEXT,
+    session_id    TEXT,
+    created_at    INTEGER NOT NULL,
+    synced_at     INTEGER,
+    PRIMARY KEY (id, machine_id)
+  )`;
+
+const DIGEST_EXTRACTS_TABLE = `
+  CREATE TABLE IF NOT EXISTS digest_extracts (
+    id              INTEGER NOT NULL,
+    machine_id      TEXT NOT NULL,
+    agent_id        TEXT NOT NULL,
+    tier            INTEGER NOT NULL,
+    content         TEXT NOT NULL,
+    substrate_hash  TEXT,
+    generated_at    INTEGER NOT NULL,
+    synced_at       INTEGER,
+    PRIMARY KEY (id, machine_id)
+  )`;
+
+const NODES_TABLE = `
+  CREATE TABLE IF NOT EXISTS nodes (
+    machine_id              TEXT PRIMARY KEY,
+    package_version         TEXT,
+    schema_version          INTEGER,
+    sync_protocol_version   INTEGER,
+    last_seen               INTEGER NOT NULL,
+    registered_at           INTEGER NOT NULL
+  )`;
+
+const TEAM_CONFIG_TABLE = `
+  CREATE TABLE IF NOT EXISTS team_config (
+    key    TEXT PRIMARY KEY,
+    value  TEXT NOT NULL
+  )`;
+
+const SECONDARY_INDEXES = [
+  'CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions (status)',
+  'CREATE INDEX IF NOT EXISTS idx_sessions_content_hash ON sessions (content_hash)',
+  'CREATE INDEX IF NOT EXISTS idx_spores_status ON spores (status)',
+  'CREATE INDEX IF NOT EXISTS idx_spores_content_hash ON spores (content_hash)',
+  'CREATE INDEX IF NOT EXISTS idx_spores_observation_type ON spores (observation_type)',
+  'CREATE INDEX IF NOT EXISTS idx_plans_content_hash ON plans (content_hash)',
+  'CREATE INDEX IF NOT EXISTS idx_graph_edges_source ON graph_edges (source_id, source_type)',
+  'CREATE INDEX IF NOT EXISTS idx_graph_edges_target ON graph_edges (target_id, target_type)',
+  'CREATE INDEX IF NOT EXISTS idx_entities_type ON entities (type)',
+];
+
+const ALL_DDLS = [
+  SESSIONS_TABLE,
+  PROMPT_BATCHES_TABLE,
+  SPORES_TABLE,
+  ENTITIES_TABLE,
+  GRAPH_EDGES_TABLE,
+  ENTITY_MENTIONS_TABLE,
+  RESOLUTION_EVENTS_TABLE,
+  PLANS_TABLE,
+  ARTIFACTS_TABLE,
+  DIGEST_EXTRACTS_TABLE,
+  NODES_TABLE,
+  TEAM_CONFIG_TABLE,
+];
+
+/**
+ * Create all D1 tables and indexes. Fully idempotent via IF NOT EXISTS.
+ */
+export async function initD1Schema(db: D1Database): Promise<void> {
+  const statements = [...ALL_DDLS, ...SECONDARY_INDEXES];
+  const batch = statements.map((sql) => db.prepare(sql));
+  await db.batch(batch);
+}

--- a/src/worker/tsconfig.json
+++ b/src/worker/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/src/worker/wrangler.toml
+++ b/src/worker/wrangler.toml
@@ -1,0 +1,21 @@
+name = "myco-team-sync"
+main = "src/index.ts"
+compatibility_date = "2025-03-27"
+
+[vars]
+SYNC_PROTOCOL_VERSION = "1"
+
+# D1 database — fill database_id after `wrangler d1 create myco-team`
+[[d1_databases]]
+binding = "MYCO_TEAM_DB"
+database_name = "myco-team"
+database_id = "<YOUR_D1_DATABASE_ID>"
+
+# Vectorize index — fill index_name after `wrangler vectorize create myco-team-vectors`
+[[vectorize]]
+binding = "MYCO_TEAM_VECTORS"
+index_name = "myco-team-vectors"
+
+# Workers AI binding
+[ai]
+binding = "AI"

--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -80,10 +80,9 @@ digest:
     expect(config.embedding.model).toBe('bge-m3');
     expect(config.daemon.port).toBe(7432);
     expect(config.daemon.log_level).toBe('debug');
-    // Removed fields should not be present
+    // Removed fields should not be present (team is now a new section, not the v2 one)
     const raw = config as Record<string, unknown>;
     expect(raw.intelligence).toBeUndefined();
-    expect(raw.team).toBeUndefined();
     expect(raw.digest).toBeUndefined();
   });
 

--- a/tests/config/schema.test.ts
+++ b/tests/config/schema.test.ts
@@ -67,7 +67,6 @@ describe('MycoConfigSchema v3', () => {
     const config = MycoConfigSchema.parse({ version: 3 });
     const raw = config as Record<string, unknown>;
     expect(raw.intelligence).toBeUndefined();
-    expect(raw.team).toBeUndefined();
     expect(raw.digest).toBeUndefined();
     expect(raw.pipeline).toBeUndefined();
   });

--- a/tests/daemon/backup.test.ts
+++ b/tests/daemon/backup.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Tests for the backup engine — create, list, preview, and restore.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
+import { getDatabase } from '@myco/db/client.js';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { upsertSession } from '@myco/db/queries/sessions.js';
+import { insertSpore } from '@myco/db/queries/spores.js';
+import { upsertPlan } from '@myco/db/queries/plans.js';
+import {
+  BACKUP_TABLES,
+  createBackup,
+  listBackups,
+  restorePreview,
+  restoreBackup,
+} from '@myco/daemon/backup.js';
+
+/** Epoch seconds helper. */
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+/** Test machine IDs. */
+const LOCAL_MACHINE = 'testuser_aaaa1111';
+const REMOTE_MACHINE = 'otheruser_bbbb2222';
+
+/** Test agent ID. */
+const TEST_AGENT_ID = 'test-agent';
+
+/** Create a temporary backup directory for each test. */
+function makeTmpBackupDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'myco-test-backup-'));
+}
+
+/** Seed the test agent row (needed for FK constraints). */
+function seedAgent() {
+  const now = epochNow();
+  registerAgent({
+    id: TEST_AGENT_ID,
+    name: 'Test Agent',
+    source: 'built-in',
+    created_at: now,
+  });
+}
+
+/** Insert a test session row. */
+function seedSession(id: string, machineId: string) {
+  const now = epochNow();
+  upsertSession({
+    id,
+    agent: 'claude-code',
+    started_at: now,
+    created_at: now,
+    machine_id: machineId,
+  });
+}
+
+/** Insert a test spore row. */
+function seedSpore(id: string, sessionId: string, machineId: string) {
+  const now = epochNow();
+  insertSpore({
+    id,
+    agent_id: TEST_AGENT_ID,
+    session_id: sessionId,
+    observation_type: 'gotcha',
+    content: `Test spore content for ${id}`,
+    created_at: now,
+    machine_id: machineId,
+  });
+}
+
+/** Insert a test plan row. */
+function seedPlan(id: string, machineId: string) {
+  const now = epochNow();
+  upsertPlan({
+    id,
+    title: `Test plan ${id}`,
+    content: 'Plan content here',
+    created_at: now,
+    machine_id: machineId,
+  });
+}
+
+describe('backup engine', () => {
+  let tmpDir: string;
+
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    tmpDir = makeTmpBackupDir();
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('BACKUP_TABLES', () => {
+    it('includes all synced tables', () => {
+      expect(BACKUP_TABLES).toContain('sessions');
+      expect(BACKUP_TABLES).toContain('spores');
+      expect(BACKUP_TABLES).toContain('plans');
+      expect(BACKUP_TABLES).toContain('entities');
+      expect(BACKUP_TABLES).toContain('graph_edges');
+      expect(BACKUP_TABLES).toContain('team_members');
+    });
+
+    it('excludes non-synced tables', () => {
+      expect(BACKUP_TABLES).not.toContain('activities');
+      expect(BACKUP_TABLES).not.toContain('log_entries');
+      expect(BACKUP_TABLES).not.toContain('agents');
+      expect(BACKUP_TABLES).not.toContain('agent_runs');
+    });
+  });
+
+  describe('createBackup()', () => {
+    it('creates a file named by machine_id', () => {
+      seedAgent();
+      seedSession('sess-001', LOCAL_MACHINE);
+
+      const filePath = createBackup(getDatabase(), tmpDir, LOCAL_MACHINE);
+
+      expect(filePath).toBe(path.join(tmpDir, `${LOCAL_MACHINE}.sql`));
+      expect(fs.existsSync(filePath)).toBe(true);
+    });
+
+    it('writes INSERT OR IGNORE statements for synced tables', () => {
+      seedAgent();
+      seedSession('sess-002', LOCAL_MACHINE);
+      seedSpore('spore-001', 'sess-002', LOCAL_MACHINE);
+
+      createBackup(getDatabase(), tmpDir, LOCAL_MACHINE);
+
+      const content = fs.readFileSync(
+        path.join(tmpDir, `${LOCAL_MACHINE}.sql`),
+        'utf-8',
+      );
+
+      expect(content).toContain('INSERT OR IGNORE INTO sessions');
+      expect(content).toContain('INSERT OR IGNORE INTO spores');
+      expect(content).toContain('sess-002');
+      expect(content).toContain('spore-001');
+    });
+
+    it('includes header with machine_id and protocol version', () => {
+      seedAgent();
+      seedSession('sess-003', LOCAL_MACHINE);
+
+      createBackup(getDatabase(), tmpDir, LOCAL_MACHINE);
+
+      const content = fs.readFileSync(
+        path.join(tmpDir, `${LOCAL_MACHINE}.sql`),
+        'utf-8',
+      );
+
+      expect(content).toContain(`machine_id=${LOCAL_MACHINE}`);
+      expect(content).toContain('Protocol version:');
+    });
+
+    it('excludes tables with no rows', () => {
+      // No data seeded — backup should have header only
+      createBackup(getDatabase(), tmpDir, LOCAL_MACHINE);
+
+      const content = fs.readFileSync(
+        path.join(tmpDir, `${LOCAL_MACHINE}.sql`),
+        'utf-8',
+      );
+
+      expect(content).not.toContain('INSERT OR IGNORE');
+    });
+
+    it('handles strings with single quotes', () => {
+      seedAgent();
+      seedSession('sess-quote', LOCAL_MACHINE);
+
+      const now = epochNow();
+      insertSpore({
+        id: 'spore-quote',
+        agent_id: TEST_AGENT_ID,
+        session_id: 'sess-quote',
+        observation_type: 'gotcha',
+        content: "It's a test with 'quotes'",
+        created_at: now,
+        machine_id: LOCAL_MACHINE,
+      });
+
+      createBackup(getDatabase(), tmpDir, LOCAL_MACHINE);
+
+      const content = fs.readFileSync(
+        path.join(tmpDir, `${LOCAL_MACHINE}.sql`),
+        'utf-8',
+      );
+
+      // Single quotes should be escaped as double single quotes
+      expect(content).toContain("It''s a test with ''quotes''");
+    });
+
+    it('is idempotent — second backup overwrites first', () => {
+      seedAgent();
+      seedSession('sess-004', LOCAL_MACHINE);
+
+      const path1 = createBackup(getDatabase(), tmpDir, LOCAL_MACHINE);
+      const content1 = fs.readFileSync(path1, 'utf-8');
+
+      const path2 = createBackup(getDatabase(), tmpDir, LOCAL_MACHINE);
+      const content2 = fs.readFileSync(path2, 'utf-8');
+
+      expect(path1).toBe(path2);
+      // Content may differ slightly in timestamp but both should contain the session
+      expect(content1).toContain('sess-004');
+      expect(content2).toContain('sess-004');
+    });
+  });
+
+  describe('listBackups()', () => {
+    it('returns empty array for non-existent directory', () => {
+      const result = listBackups('/nonexistent/path');
+      expect(result).toEqual([]);
+    });
+
+    it('returns metadata for backup files', () => {
+      seedAgent();
+      seedSession('sess-005', LOCAL_MACHINE);
+      createBackup(getDatabase(), tmpDir, LOCAL_MACHINE);
+
+      const backups = listBackups(tmpDir);
+
+      expect(backups).toHaveLength(1);
+      expect(backups[0].machine_id).toBe(LOCAL_MACHINE);
+      expect(backups[0].file_name).toBe(`${LOCAL_MACHINE}.sql`);
+      expect(backups[0].size_bytes).toBeGreaterThan(0);
+      expect(backups[0].modified_at).toBeTruthy();
+    });
+
+    it('ignores non-.sql files', () => {
+      fs.writeFileSync(path.join(tmpDir, 'readme.txt'), 'not a backup');
+      seedAgent();
+      seedSession('sess-006', LOCAL_MACHINE);
+      createBackup(getDatabase(), tmpDir, LOCAL_MACHINE);
+
+      const backups = listBackups(tmpDir);
+      expect(backups).toHaveLength(1);
+    });
+  });
+
+  describe('restorePreview()', () => {
+    it('shows all records as new when DB is empty', () => {
+      // Create backup with data, then clean DB
+      seedAgent();
+      seedSession('sess-010', LOCAL_MACHINE);
+      seedSpore('spore-010', 'sess-010', LOCAL_MACHINE);
+      createBackup(getDatabase(), tmpDir, LOCAL_MACHINE);
+      cleanTestDb();
+
+      const backupPath = path.join(tmpDir, `${LOCAL_MACHINE}.sql`);
+      const tables = restorePreview(getDatabase(), backupPath);
+
+      const sessionTable = tables.find((t) => t.table === 'sessions');
+      expect(sessionTable).toBeDefined();
+      expect(sessionTable!.new).toBe(1);
+      expect(sessionTable!.existing).toBe(0);
+    });
+
+    it('shows records as existing when they already exist', () => {
+      seedAgent();
+      seedSession('sess-011', LOCAL_MACHINE);
+      createBackup(getDatabase(), tmpDir, LOCAL_MACHINE);
+
+      // Data still in DB — preview should show existing
+      const backupPath = path.join(tmpDir, `${LOCAL_MACHINE}.sql`);
+      const tables = restorePreview(getDatabase(), backupPath);
+
+      const sessionTable = tables.find((t) => t.table === 'sessions');
+      expect(sessionTable).toBeDefined();
+      expect(sessionTable!.existing).toBe(1);
+      expect(sessionTable!.new).toBe(0);
+    });
+
+    it('does not modify the database', () => {
+      seedAgent();
+      seedSession('sess-012', LOCAL_MACHINE);
+      createBackup(getDatabase(), tmpDir, LOCAL_MACHINE);
+      cleanTestDb();
+
+      const db = getDatabase();
+      const backupPath = path.join(tmpDir, `${LOCAL_MACHINE}.sql`);
+
+      restorePreview(db, backupPath);
+
+      // DB should still be empty after preview
+      const count = db.prepare('SELECT COUNT(*) as c FROM sessions').get() as { c: number };
+      expect(count.c).toBe(0);
+    });
+  });
+
+  describe('restoreBackup()', () => {
+    it('inserts new records', () => {
+      seedAgent();
+      seedSession('sess-020', LOCAL_MACHINE);
+      seedSpore('spore-020', 'sess-020', LOCAL_MACHINE);
+      createBackup(getDatabase(), tmpDir, LOCAL_MACHINE);
+      cleanTestDb();
+
+      const backupPath = path.join(tmpDir, `${LOCAL_MACHINE}.sql`);
+      const result = restoreBackup(getDatabase(), backupPath);
+
+      expect(result.total_restored).toBeGreaterThan(0);
+
+      // Verify data is in the DB
+      const db = getDatabase();
+      const session = db.prepare('SELECT id FROM sessions WHERE id = ?').get('sess-020');
+      expect(session).toBeDefined();
+
+      const spore = db.prepare('SELECT id FROM spores WHERE id = ?').get('spore-020');
+      expect(spore).toBeDefined();
+    });
+
+    it('skips existing records without duplication', () => {
+      seedAgent();
+      seedSession('sess-021', LOCAL_MACHINE);
+      createBackup(getDatabase(), tmpDir, LOCAL_MACHINE);
+
+      // Restore into DB that already has the data
+      const backupPath = path.join(tmpDir, `${LOCAL_MACHINE}.sql`);
+      const result = restoreBackup(getDatabase(), backupPath);
+
+      const sessionTable = result.tables.find((t) => t.table === 'sessions');
+      expect(sessionTable).toBeDefined();
+      expect(sessionTable!.existing).toBe(1);
+      expect(sessionTable!.new).toBe(0);
+
+      // Still only 1 session
+      const db = getDatabase();
+      const count = db.prepare('SELECT COUNT(*) as c FROM sessions').get() as { c: number };
+      expect(count.c).toBe(1);
+    });
+
+    it('merges foreign machine data alongside local data', () => {
+      seedAgent();
+      // Local data
+      seedSession('local-sess', LOCAL_MACHINE);
+
+      // Create a backup from "remote" machine
+      seedSession('remote-sess', REMOTE_MACHINE);
+      createBackup(getDatabase(), tmpDir, REMOTE_MACHINE);
+
+      // Remove the remote session, keep local
+      getDatabase().prepare("DELETE FROM sessions WHERE id = 'remote-sess'").run();
+
+      // Restore — should add remote-sess without touching local-sess
+      const backupPath = path.join(tmpDir, `${REMOTE_MACHINE}.sql`);
+      const result = restoreBackup(getDatabase(), backupPath);
+
+      expect(result.total_restored).toBeGreaterThan(0);
+
+      const db = getDatabase();
+      const count = db.prepare('SELECT COUNT(*) as c FROM sessions').get() as { c: number };
+      expect(count.c).toBe(2);
+    });
+
+    it('returns per-table breakdown', () => {
+      seedAgent();
+      seedSession('sess-030', LOCAL_MACHINE);
+      seedSpore('spore-030', 'sess-030', LOCAL_MACHINE);
+      seedPlan('plan-030', LOCAL_MACHINE);
+      createBackup(getDatabase(), tmpDir, LOCAL_MACHINE);
+      cleanTestDb();
+
+      const backupPath = path.join(tmpDir, `${LOCAL_MACHINE}.sql`);
+      const result = restoreBackup(getDatabase(), backupPath);
+
+      expect(result.tables.length).toBeGreaterThan(0);
+      for (const t of result.tables) {
+        expect(t).toHaveProperty('table');
+        expect(t).toHaveProperty('new');
+        expect(t).toHaveProperty('existing');
+      }
+      expect(result.total_restored).toBe(
+        result.tables.reduce((sum, t) => sum + t.new, 0),
+      );
+      expect(result.total_skipped).toBe(
+        result.tables.reduce((sum, t) => sum + t.existing, 0),
+      );
+    });
+  });
+});

--- a/tests/daemon/machine-id.test.ts
+++ b/tests/daemon/machine-id.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for machine identity generation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { computeMachineHash, resolveGitHubUser, getMachineId } from '@myco/daemon/machine-id.js';
+
+/** Create a temporary vault dir for each test. */
+function makeTmpVault(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'myco-test-machine-id-'));
+}
+
+describe('machine-id', () => {
+  describe('computeMachineHash()', () => {
+    it('returns a hex string of expected length', () => {
+      const hash = computeMachineHash();
+      expect(hash).toMatch(/^[0-9a-f]{8}$/);
+    });
+
+    it('is deterministic — same result on repeated calls', () => {
+      const h1 = computeMachineHash();
+      const h2 = computeMachineHash();
+      expect(h1).toBe(h2);
+    });
+  });
+
+  describe('resolveGitHubUser()', () => {
+    it('returns a non-empty string', () => {
+      const user = resolveGitHubUser();
+      expect(user.length).toBeGreaterThan(0);
+    });
+
+    // The fallback path is implicitly tested via getMachineId with a cached file.
+    // Mocking execFileSync requires module-level interception that is fragile here.
+  });
+
+  describe('getMachineId()', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = makeTmpVault();
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('generates a machine ID in {user}_{hash} format', () => {
+      const id = getMachineId(tmpDir);
+      expect(id).toMatch(/^[a-zA-Z0-9._-]+_[0-9a-f]{8}$/);
+    });
+
+    it('caches the machine ID to a file', () => {
+      const id = getMachineId(tmpDir);
+      const cached = fs.readFileSync(path.join(tmpDir, 'machine_id'), 'utf-8').trim();
+      expect(cached).toBe(id);
+    });
+
+    it('returns cached value on subsequent calls', () => {
+      const id1 = getMachineId(tmpDir);
+      const id2 = getMachineId(tmpDir);
+      expect(id1).toBe(id2);
+    });
+
+    it('reads from existing cache file', () => {
+      const fakeId = 'testuser_abcd1234';
+      fs.writeFileSync(path.join(tmpDir, 'machine_id'), fakeId, 'utf-8');
+      const id = getMachineId(tmpDir);
+      expect(id).toBe(fakeId);
+    });
+
+    it('generates fresh ID if cache file is empty', () => {
+      fs.writeFileSync(path.join(tmpDir, 'machine_id'), '', 'utf-8');
+      const id = getMachineId(tmpDir);
+      expect(id.length).toBeGreaterThan(0);
+      expect(id).toMatch(/^[a-zA-Z0-9._-]+_[0-9a-f]{8}$/);
+    });
+  });
+});

--- a/tests/daemon/team-sync.test.ts
+++ b/tests/daemon/team-sync.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Tests for TeamSyncClient and team context module.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TeamSyncClient } from '../../src/daemon/team-sync.js';
+import type { OutboxRow } from '../../src/db/queries/team-outbox.js';
+import {
+  initTeamContext,
+  isTeamSyncEnabled,
+  getTeamMachineId,
+  getTeamSyncProtocolVersion,
+  resetTeamContext,
+} from '../../src/daemon/team-context.js';
+
+// ---------------------------------------------------------------------------
+// Mock fetch helper
+// ---------------------------------------------------------------------------
+
+function createMockFetch(responses: Record<string, { status: number; body: unknown }>) {
+  return vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const urlStr = typeof url === 'string' ? url : url.toString();
+    const path = new URL(urlStr).pathname;
+
+    const response = responses[path];
+    if (!response) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    return new Response(JSON.stringify(response.body), {
+      status: response.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as unknown as typeof globalThis.fetch;
+}
+
+/** Factory for a minimal OutboxRow. */
+function makeOutboxRow(overrides: Partial<OutboxRow> = {}): OutboxRow {
+  return {
+    id: 1,
+    table_name: 'spores',
+    row_id: 'spore-abc123',
+    operation: 'upsert',
+    payload: JSON.stringify({ id: 'spore-abc123', content: 'test' }),
+    machine_id: 'test_abc123',
+    created_at: Math.floor(Date.now() / 1000),
+    sent_at: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// TeamSyncClient
+// ---------------------------------------------------------------------------
+
+describe('TeamSyncClient', () => {
+  const baseOptions = {
+    workerUrl: 'https://myco-team.example.workers.dev',
+    apiKey: 'test-api-key-123',
+    machineId: 'test_abc123',
+    syncProtocolVersion: 1,
+  };
+
+  describe('health', () => {
+    it('returns health status from worker', async () => {
+      const mockFetch = createMockFetch({
+        '/health': {
+          status: 200,
+          body: { status: 'ok', node_count: 3, sync_protocol_version: 1 },
+        },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      const result = await client.health();
+
+      expect(result.status).toBe('ok');
+      expect(result.node_count).toBe(3);
+    });
+
+    it('sends Authorization header', async () => {
+      const mockFetch = createMockFetch({
+        '/health': {
+          status: 200,
+          body: { status: 'ok', node_count: 0, sync_protocol_version: 1 },
+        },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      await client.health();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Authorization': 'Bearer test-api-key-123',
+          }),
+        }),
+      );
+    });
+
+    it('throws on non-ok response', async () => {
+      const mockFetch = createMockFetch({
+        '/health': { status: 503, body: { error: 'unavailable' } },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      await expect(client.health()).rejects.toThrow(/Health check failed: 503/);
+    });
+  });
+
+  describe('connect', () => {
+    it('POSTs to /connect with machine info', async () => {
+      const mockFetch = createMockFetch({
+        '/connect': {
+          status: 200,
+          body: { config: {}, sync_protocol_version: 1 },
+        },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      const result = await client.connect({
+        machine_id: 'test_abc123',
+        vault_name: 'myco',
+        agent: 'claude-code',
+      });
+
+      expect(result.sync_protocol_version).toBe(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://myco-team.example.workers.dev/connect',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+
+  describe('pushBatch', () => {
+    it('POSTs records to /sync', async () => {
+      const mockFetch = createMockFetch({
+        '/sync': { status: 200, body: { accepted: 2 } },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      const records = [makeOutboxRow({ id: 1 }), makeOutboxRow({ id: 2 })];
+
+      const result = await client.pushBatch(records);
+      expect(result.accepted).toBe(2);
+    });
+
+    it('includes machine_id and sync_protocol_version', async () => {
+      let capturedBody: unknown;
+      const mockFetch = vi.fn(async (url: string, init: RequestInit) => {
+        capturedBody = JSON.parse(init.body as string);
+        return new Response(JSON.stringify({ accepted: 1 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }) as unknown as typeof globalThis.fetch;
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      await client.pushBatch([makeOutboxRow()]);
+
+      const body = capturedBody as { machine_id: string; sync_protocol_version: number; records: unknown[] };
+      expect(body.machine_id).toBe('test_abc123');
+      expect(body.sync_protocol_version).toBe(1);
+      expect(body.records).toHaveLength(1);
+    });
+
+    it('throws on sync error', async () => {
+      const mockFetch = createMockFetch({
+        '/sync': { status: 409, body: { error: 'version_mismatch' } },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      await expect(client.pushBatch([makeOutboxRow()])).rejects.toThrow(/failed: 409/);
+    });
+  });
+
+  describe('search', () => {
+    it('GETs /search with query params', async () => {
+      const mockFetch = createMockFetch({
+        '/search': {
+          status: 200,
+          body: { results: [], machine_ids: ['test_abc123'] },
+        },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      const result = await client.search('authentication patterns');
+
+      expect(result.results).toEqual([]);
+      expect(result.machine_ids).toContain('test_abc123');
+
+      const calledUrl = (mockFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('q=authentication+patterns');
+    });
+
+    it('passes limit and tables options', async () => {
+      const mockFetch = createMockFetch({
+        '/search': {
+          status: 200,
+          body: { results: [], machine_ids: [] },
+        },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      await client.search('test', { limit: 10, tables: ['spores', 'sessions'] });
+
+      const calledUrl = (mockFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('limit=10');
+      expect(calledUrl).toContain('tables=spores%2Csessions');
+    });
+
+    it('throws on non-ok response', async () => {
+      const mockFetch = createMockFetch({
+        '/search': { status: 500, body: { error: 'internal' } },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      await expect(client.search('test')).rejects.toThrow(/Team search failed: 500/);
+    });
+  });
+
+  describe('getConfig', () => {
+    it('GETs /config', async () => {
+      const mockFetch = createMockFetch({
+        '/config': {
+          status: 200,
+          body: { config: { team_name: 'myco' }, sync_protocol_version: 1 },
+        },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      const result = await client.getConfig();
+
+      expect(result.config).toEqual({ team_name: 'myco' });
+      expect(result.sync_protocol_version).toBe(1);
+    });
+  });
+
+  describe('URL normalization', () => {
+    it('strips trailing slash from worker URL', async () => {
+      const mockFetch = createMockFetch({
+        '/health': {
+          status: 200,
+          body: { status: 'ok', node_count: 0, sync_protocol_version: 1 },
+        },
+      });
+
+      const client = new TeamSyncClient({
+        ...baseOptions,
+        workerUrl: 'https://myco.workers.dev/',
+        fetch: mockFetch,
+      });
+
+      await client.health();
+
+      const calledUrl = (mockFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toBe('https://myco.workers.dev/health');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Team Context
+// ---------------------------------------------------------------------------
+
+describe('team context', () => {
+  beforeEach(() => {
+    resetTeamContext();
+  });
+
+  it('defaults to disabled', () => {
+    expect(isTeamSyncEnabled()).toBe(false);
+    expect(getTeamMachineId()).toBe('local');
+  });
+
+  it('enables when initialized', () => {
+    initTeamContext(true, 'chris_abc123');
+
+    expect(isTeamSyncEnabled()).toBe(true);
+    expect(getTeamMachineId()).toBe('chris_abc123');
+  });
+
+  it('disables when initialized with false', () => {
+    initTeamContext(true, 'chris_abc123');
+    initTeamContext(false, 'chris_abc123');
+
+    expect(isTeamSyncEnabled()).toBe(false);
+  });
+
+  it('returns sync protocol version', () => {
+    expect(getTeamSyncProtocolVersion()).toBe(1);
+  });
+
+  it('resets to defaults', () => {
+    initTeamContext(true, 'chris_abc123');
+    resetTeamContext();
+
+    expect(isTeamSyncEnabled()).toBe(false);
+    expect(getTeamMachineId()).toBe('local');
+  });
+});

--- a/tests/db/queries/team-outbox.test.ts
+++ b/tests/db/queries/team-outbox.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests for team outbox query helpers.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
+import {
+  enqueueOutbox,
+  listPending,
+  markSent,
+  markForRetry,
+  pruneOld,
+  countPending,
+} from '@myco/db/queries/team-outbox.js';
+import type { OutboxInsert } from '@myco/db/queries/team-outbox.js';
+
+/** Epoch seconds helper. */
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+/** Factory for minimal valid outbox data. */
+function makeOutbox(overrides: Partial<OutboxInsert> = {}): OutboxInsert {
+  const now = epochNow();
+  return {
+    table_name: 'spores',
+    row_id: `spore-${Math.random().toString(36).slice(2, 8)}`,
+    payload: JSON.stringify({ id: 'spore-1', content: 'test' }),
+    machine_id: 'test_abc123',
+    created_at: now,
+    ...overrides,
+  };
+}
+
+describe('team outbox query helpers', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => { cleanTestDb(); });
+
+  // ---------------------------------------------------------------------------
+  // enqueueOutbox
+  // ---------------------------------------------------------------------------
+
+  describe('enqueueOutbox', () => {
+    it('inserts a pending record with sent_at NULL', () => {
+      const row = enqueueOutbox(makeOutbox());
+
+      expect(row.id).toBeGreaterThan(0);
+      expect(row.table_name).toBe('spores');
+      expect(row.operation).toBe('upsert');
+      expect(row.sent_at).toBeNull();
+      expect(row.machine_id).toBe('test_abc123');
+    });
+
+    it('defaults operation to upsert', () => {
+      const row = enqueueOutbox(makeOutbox());
+      expect(row.operation).toBe('upsert');
+    });
+
+    it('respects custom operation', () => {
+      const row = enqueueOutbox(makeOutbox({ operation: 'delete' }));
+      expect(row.operation).toBe('delete');
+    });
+
+    it('stores payload as JSON string', () => {
+      const payload = JSON.stringify({ id: 'test', content: 'hello' });
+      const row = enqueueOutbox(makeOutbox({ payload }));
+      expect(row.payload).toBe(payload);
+    });
+
+    it('auto-increments id', () => {
+      const row1 = enqueueOutbox(makeOutbox());
+      const row2 = enqueueOutbox(makeOutbox());
+      expect(row2.id).toBeGreaterThan(row1.id);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // listPending
+  // ---------------------------------------------------------------------------
+
+  describe('listPending', () => {
+    it('returns empty array when no pending records', () => {
+      const rows = listPending();
+      expect(rows).toEqual([]);
+    });
+
+    it('returns records oldest-first', () => {
+      const now = epochNow();
+      enqueueOutbox(makeOutbox({ created_at: now + 2, row_id: 'c' }));
+      enqueueOutbox(makeOutbox({ created_at: now, row_id: 'a' }));
+      enqueueOutbox(makeOutbox({ created_at: now + 1, row_id: 'b' }));
+
+      const rows = listPending();
+
+      expect(rows[0].row_id).toBe('a');
+      expect(rows[1].row_id).toBe('b');
+      expect(rows[2].row_id).toBe('c');
+    });
+
+    it('excludes sent records', () => {
+      const row = enqueueOutbox(makeOutbox());
+      markSent([row.id], epochNow());
+
+      const pending = listPending();
+      expect(pending).toHaveLength(0);
+    });
+
+    it('respects explicit limit', () => {
+      for (let i = 0; i < 5; i++) {
+        enqueueOutbox(makeOutbox({ created_at: epochNow() + i }));
+      }
+
+      const rows = listPending(3);
+      expect(rows).toHaveLength(3);
+    });
+
+    it('uses default batch size when backlog is small', () => {
+      // Insert fewer than burst threshold
+      for (let i = 0; i < 10; i++) {
+        enqueueOutbox(makeOutbox({ created_at: epochNow() + i }));
+      }
+
+      // Should return all 10 (below DEFAULT_BATCH_SIZE of 50)
+      const rows = listPending();
+      expect(rows).toHaveLength(10);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // markSent
+  // ---------------------------------------------------------------------------
+
+  describe('markSent', () => {
+    it('sets sent_at on specified records', () => {
+      const row1 = enqueueOutbox(makeOutbox());
+      const row2 = enqueueOutbox(makeOutbox());
+      const sentAt = epochNow();
+
+      markSent([row1.id, row2.id], sentAt);
+
+      const pending = listPending();
+      expect(pending).toHaveLength(0);
+    });
+
+    it('does nothing for empty ids array', () => {
+      enqueueOutbox(makeOutbox());
+      markSent([], epochNow());
+
+      const pending = listPending();
+      expect(pending).toHaveLength(1);
+    });
+
+    it('only marks specified records', () => {
+      const row1 = enqueueOutbox(makeOutbox());
+      const row2 = enqueueOutbox(makeOutbox());
+
+      markSent([row1.id], epochNow());
+
+      const pending = listPending();
+      expect(pending).toHaveLength(1);
+      expect(pending[0].id).toBe(row2.id);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // markForRetry
+  // ---------------------------------------------------------------------------
+
+  describe('markForRetry', () => {
+    it('resets sent_at to NULL for re-processing', () => {
+      const row = enqueueOutbox(makeOutbox());
+      markSent([row.id], epochNow());
+
+      // Verify it's marked as sent
+      expect(listPending()).toHaveLength(0);
+
+      // Mark for retry
+      markForRetry([row.id]);
+
+      // Now it should be pending again
+      const pending = listPending();
+      expect(pending).toHaveLength(1);
+      expect(pending[0].id).toBe(row.id);
+    });
+
+    it('does nothing for empty ids array', () => {
+      const row = enqueueOutbox(makeOutbox());
+      markSent([row.id], epochNow());
+      markForRetry([]);
+
+      expect(listPending()).toHaveLength(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // pruneOld
+  // ---------------------------------------------------------------------------
+
+  describe('pruneOld', () => {
+    it('removes sent records older than 24 hours', () => {
+      const oldTime = epochNow() - 90_000; // 25 hours ago
+      const row = enqueueOutbox(makeOutbox({ created_at: oldTime }));
+      markSent([row.id], oldTime);
+
+      const deleted = pruneOld();
+      expect(deleted).toBe(1);
+    });
+
+    it('does not remove recently sent records', () => {
+      const row = enqueueOutbox(makeOutbox());
+      markSent([row.id], epochNow());
+
+      const deleted = pruneOld();
+      expect(deleted).toBe(0);
+    });
+
+    it('does not remove pending records', () => {
+      enqueueOutbox(makeOutbox({ created_at: epochNow() - 90_000 }));
+
+      const deleted = pruneOld();
+      expect(deleted).toBe(0);
+    });
+
+    it('returns count of deleted records', () => {
+      const oldTime = epochNow() - 90_000;
+      const row1 = enqueueOutbox(makeOutbox({ created_at: oldTime }));
+      const row2 = enqueueOutbox(makeOutbox({ created_at: oldTime }));
+      markSent([row1.id, row2.id], oldTime);
+
+      const deleted = pruneOld();
+      expect(deleted).toBe(2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // countPending
+  // ---------------------------------------------------------------------------
+
+  describe('countPending', () => {
+    it('returns 0 when no records', () => {
+      expect(countPending()).toBe(0);
+    });
+
+    it('counts only pending records', () => {
+      const row1 = enqueueOutbox(makeOutbox());
+      enqueueOutbox(makeOutbox());
+      markSent([row1.id], epochNow());
+
+      expect(countPending()).toBe(1);
+    });
+
+    it('increments as records are enqueued', () => {
+      enqueueOutbox(makeOutbox());
+      expect(countPending()).toBe(1);
+
+      enqueueOutbox(makeOutbox());
+      expect(countPending()).toBe(2);
+    });
+  });
+});

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -38,7 +38,7 @@ describe('Database schema', () => {
 
   describe('constants', () => {
     it('exports SCHEMA_VERSION as a positive integer', () => {
-      expect(SCHEMA_VERSION).toBe(3);
+      expect(SCHEMA_VERSION).toBe(4);
       expect(Number.isInteger(SCHEMA_VERSION)).toBe(true);
     });
 

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -28,6 +28,7 @@ const DELETE_TABLES = [
   'prompt_batches',
   'artifacts',
   'team_members',
+  'team_outbox',
   'sessions',
   'agents',
   'log_entries',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     }
   },
   "include": ["src/**/*", "plugin/**/*"],
-  "exclude": ["node_modules", "dist", "tests", "ui"]
+  "exclude": ["node_modules", "dist", "tests", "ui", "src/worker"]
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,6 +6,7 @@ import Mycelium from './pages/Mycelium';
 import Agent from './pages/Agent';
 import Settings from './pages/Settings';
 import Operations from './pages/Operations';
+import Team from './pages/Team';
 import Logs from './pages/Logs';
 
 export default function App() {
@@ -19,6 +20,7 @@ export default function App() {
         <Route path="/agent" element={<Agent />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/operations" element={<Operations />} />
+        <Route path="/team" element={<Team />} />
         <Route path="/logs" element={<Logs />} />
       </Route>
     </Routes>

--- a/ui/src/components/mycelium/Inspector.tsx
+++ b/ui/src/components/mycelium/Inspector.tsx
@@ -1,8 +1,9 @@
+import { useNavigate } from 'react-router-dom';
 import { Surface } from '../ui/surface';
 import { Badge } from '../ui/badge';
 import { SectionHeader } from '../ui/section-header';
 
-import { X, ArrowRight } from 'lucide-react';
+import { X, ArrowRight, ExternalLink } from 'lucide-react';
 import type { GraphNode, GraphEdge } from '../../hooks/use-graph-canvas';
 
 /* ---------- Constants ---------- */
@@ -66,7 +67,15 @@ function MetadataRow({ label, value }: { label: string; value: string }) {
 
 /* ---------- Component ---------- */
 
+/** Returns the route path for a node, or null if no detail page exists. */
+function getNodeRoute(node: GraphNode): string | null {
+  if (node.type === 'session') return `/sessions/${node.id}`;
+  if (node.type === 'spore') return `/mycelium?tab=spores&spore=${node.id}`;
+  return null;
+}
+
 export function Inspector({ node, edges, nodes, metadata, markdownPreview, connectedSpores, onClose, onNodeSelect }: InspectorProps) {
+  const navigate = useNavigate();
   if (!node) return null;
 
   const typeKey = node.type.toLowerCase();
@@ -115,6 +124,15 @@ export function Inspector({ node, edges, nodes, metadata, markdownPreview, conne
             <h2 className="font-serif text-lg text-on-surface leading-tight break-words">
               {node.name}
             </h2>
+            {getNodeRoute(node) && (
+              <button
+                onClick={() => navigate(getNodeRoute(node)!)}
+                className="inline-flex items-center gap-1 mt-1.5 font-sans text-xs text-on-surface-variant hover:text-primary transition-colors group cursor-pointer"
+              >
+                <span>View {node.type}</span>
+                <ExternalLink className="h-3 w-3 group-hover:translate-x-0.5 transition-transform" />
+              </button>
+            )}
           </div>
           {onClose && (
             <button

--- a/ui/src/components/operations/BackupCard.tsx
+++ b/ui/src/components/operations/BackupCard.tsx
@@ -1,0 +1,300 @@
+import { useState, useCallback, useEffect } from 'react';
+import { HardDrive, Download, Upload, RefreshCw, FolderOpen } from 'lucide-react';
+import { postJson, fetchJson, putJson } from '../../lib/api';
+import { Surface } from '../ui/surface';
+import { SectionHeader } from '../ui/section-header';
+import { Button } from '../ui/button';
+import { Badge } from '../ui/badge';
+import { cn } from '../../lib/cn';
+
+/* ---------- Types ---------- */
+
+interface BackupMeta {
+  machine_id: string;
+  file_name: string;
+  size_bytes: number;
+  modified_at: string;
+}
+
+interface BackupListResponse {
+  backups: BackupMeta[];
+}
+
+interface BackupCreateResponse {
+  file_path: string;
+  machine_id: string;
+  size_bytes: number;
+}
+
+interface TableCounts {
+  table: string;
+  new: number;
+  existing: number;
+}
+
+interface RestorePreviewResponse {
+  machine_id: string;
+  tables: TableCounts[];
+  total_new: number;
+  total_existing: number;
+}
+
+interface RestoreResponse {
+  machine_id: string;
+  tables: TableCounts[];
+  total_restored: number;
+  total_skipped: number;
+}
+
+/* ---------- Constants ---------- */
+
+const BYTES_PER_KB = 1024;
+
+/* ---------- Helpers ---------- */
+
+function formatBytes(bytes: number): string {
+  if (bytes < BYTES_PER_KB) return `${bytes} B`;
+  const kb = bytes / BYTES_PER_KB;
+  if (kb < BYTES_PER_KB) return `${kb.toFixed(1)} KB`;
+  const mb = kb / BYTES_PER_KB;
+  return `${mb.toFixed(1)} MB`;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/* ---------- BackupCard ---------- */
+
+export function BackupCard() {
+  const [backups, setBackups] = useState<BackupMeta[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [preview, setPreview] = useState<RestorePreviewResponse | null>(null);
+
+  // Backup directory config
+  const [dirOverride, setDirOverride] = useState('');
+  const [defaultDir, setDefaultDir] = useState('');
+  const [dirSaving, setDirSaving] = useState(false);
+
+  useEffect(() => {
+    fetchJson<{ dir: string | null; default_dir: string }>('/backup/config')
+      .then((res) => {
+        setDirOverride(res.dir ?? '');
+        setDefaultDir(res.default_dir);
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleSaveDir = useCallback(async () => {
+    setDirSaving(true);
+    try {
+      await putJson('/backup/config', { dir: dirOverride || null });
+      setMessage({ type: 'success', text: dirOverride ? 'Backup directory updated. Restart daemon to apply.' : 'Backup directory reset to default. Restart daemon to apply.' });
+    } catch {
+      setMessage({ type: 'error', text: 'Failed to save backup directory.' });
+    } finally {
+      setDirSaving(false);
+    }
+  }, [dirOverride]);
+
+  const refreshBackups = useCallback(async () => {
+    try {
+      const res = await fetchJson<BackupListResponse>('/backups');
+      setBackups(res.backups);
+      setLoaded(true);
+    } catch (err) {
+      setMessage({ type: 'error', text: `Failed to load backups: ${(err as Error).message}` });
+    }
+  }, []);
+
+  // Load backup list on first render
+  if (!loaded && !loading) {
+    setLoading(true);
+    refreshBackups().finally(() => setLoading(false));
+  }
+
+  async function handleCreateBackup() {
+    setMessage(null);
+    setPreview(null);
+    try {
+      const res = await postJson<BackupCreateResponse>('/backup');
+      setMessage({
+        type: 'success',
+        text: `Backup created: ${res.machine_id} (${formatBytes(res.size_bytes)})`,
+      });
+      await refreshBackups();
+    } catch (err) {
+      setMessage({ type: 'error', text: `Backup failed: ${(err as Error).message}` });
+    }
+  }
+
+  async function handlePreview(machineId: string) {
+    setMessage(null);
+    setPreview(null);
+    try {
+      const res = await postJson<RestorePreviewResponse>('/restore/preview', { machine_id: machineId });
+      setPreview(res);
+    } catch (err) {
+      setMessage({ type: 'error', text: `Preview failed: ${(err as Error).message}` });
+    }
+  }
+
+  async function handleRestore(machineId: string) {
+    setMessage(null);
+    setPreview(null);
+    try {
+      const res = await postJson<RestoreResponse>('/restore', { machine_id: machineId });
+      setMessage({
+        type: 'success',
+        text: `Restored ${res.total_restored} records, skipped ${res.total_skipped} duplicates`,
+      });
+    } catch (err) {
+      setMessage({ type: 'error', text: `Restore failed: ${(err as Error).message}` });
+    }
+  }
+
+  return (
+    <Surface level="low" className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <HardDrive className="h-4 w-4 text-primary" />
+          <SectionHeader>Backup &amp; Restore</SectionHeader>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="ghost" size="sm" onClick={refreshBackups}>
+            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+            Refresh
+          </Button>
+          <Button variant="default" size="sm" onClick={handleCreateBackup}>
+            <Download className="mr-1.5 h-3.5 w-3.5" />
+            Backup Now
+          </Button>
+        </div>
+      </div>
+
+      {/* Backup directory */}
+      <div className="space-y-1.5">
+        <label className="font-sans text-xs text-on-surface-variant flex items-center gap-1.5">
+          <FolderOpen className="h-3.5 w-3.5" />
+          Backup Directory
+        </label>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={dirOverride}
+            onChange={(e) => setDirOverride(e.target.value)}
+            placeholder={defaultDir || 'Default vault directory'}
+            className="flex-1 bg-surface-container text-on-surface font-mono text-sm rounded px-3 py-1.5 outline-none border border-outline-variant/15 focus:border-primary/40 placeholder:text-on-surface-variant/50"
+          />
+          <Button variant="ghost" size="sm" onClick={handleSaveDir} disabled={dirSaving}>
+            {dirSaving ? 'Saving...' : 'Save'}
+          </Button>
+        </div>
+        <p className="font-sans text-xs text-on-surface-variant">
+          Override where backups are stored. Leave empty for default ({defaultDir || 'vault/backups'}).
+          Useful for network shares or git-tracked directories.
+        </p>
+      </div>
+
+      {/* Message */}
+      {message && (
+        <p
+          className={cn(
+            'font-sans text-sm',
+            message.type === 'success' ? 'text-primary' : 'text-tertiary',
+          )}
+        >
+          {message.text}
+        </p>
+      )}
+
+      {/* Backup list */}
+      {backups.length > 0 ? (
+        <div className="space-y-2">
+          {backups.map((b) => (
+            <div
+              key={b.machine_id}
+              className={cn(
+                'flex items-center justify-between rounded-md px-4 py-3',
+                'bg-surface-container-lowest transition-colors',
+              )}
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <span className="font-mono text-sm text-on-surface truncate">{b.machine_id}</span>
+                <Badge variant="secondary">{formatBytes(b.size_bytes)}</Badge>
+                <span className="text-xs text-on-surface-variant">{formatDate(b.modified_at)}</span>
+              </div>
+              <div className="flex gap-2 flex-shrink-0 ml-3">
+                <Button variant="ghost" size="sm" onClick={() => handlePreview(b.machine_id)}>
+                  Preview
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => handleRestore(b.machine_id)}
+                >
+                  <Upload className="mr-1.5 h-3.5 w-3.5" />
+                  Restore
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : loaded ? (
+        <p className="font-sans text-sm text-on-surface-variant">
+          No backups yet. Click &quot;Backup Now&quot; to create one.
+        </p>
+      ) : null}
+
+      {/* Restore preview */}
+      {preview && (
+        <Surface level="lowest" className="p-4 space-y-3">
+          <div className="flex items-center gap-2">
+            <SectionHeader>Restore Preview</SectionHeader>
+            <Badge variant="outline">{preview.machine_id}</Badge>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full font-mono text-sm" aria-label="Restore preview">
+              <thead>
+                <tr className="text-left text-on-surface-variant">
+                  <th className="pb-2 pr-4 font-sans font-medium text-xs uppercase tracking-widest" scope="col">Table</th>
+                  <th className="pb-2 pr-4 font-sans font-medium text-xs uppercase tracking-widest text-right" scope="col">New</th>
+                  <th className="pb-2 font-sans font-medium text-xs uppercase tracking-widest text-right" scope="col">Existing</th>
+                </tr>
+              </thead>
+              <tbody>
+                {preview.tables.map((t, idx) => (
+                  <tr
+                    key={t.table}
+                    className={cn(
+                      'transition-colors hover:bg-surface-container-high/50',
+                      idx % 2 === 1 ? 'bg-surface-container-low/30' : '',
+                    )}
+                  >
+                    <td className="py-2 pr-4">{t.table}</td>
+                    <td className="py-2 pr-4 text-right">
+                      {t.new > 0 ? <span className="text-primary">{t.new}</span> : 0}
+                    </td>
+                    <td className="py-2 text-right text-on-surface-variant">{t.existing}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="flex gap-4 font-sans text-sm text-on-surface-variant">
+            <span>New: <strong className="text-primary">{preview.total_new}</strong></span>
+            <span>Existing: <strong>{preview.total_existing}</strong></span>
+          </div>
+        </Surface>
+      )}
+    </Surface>
+  );
+}

--- a/ui/src/components/sessions/SessionDetail.tsx
+++ b/ui/src/components/sessions/SessionDetail.tsx
@@ -7,7 +7,7 @@ import { Surface } from '../ui/surface';
 import { StatCard } from '../ui/stat-card';
 import { SectionHeader } from '../ui/section-header';
 import { ConfirmDialog } from '../ui/confirm-dialog';
-import { useSession, useDeleteSession, useSessionImpact } from '../../hooks/use-sessions';
+import { useSession, useDeleteSession, useSessionImpact, useSessionPlans } from '../../hooks/use-sessions';
 import { useSymbionts, buildResumeCommand } from '../../hooks/use-symbionts';
 import { useTriggerRun } from '../../hooks/use-agent';
 import { BatchTimeline } from './BatchTimeline';
@@ -21,19 +21,11 @@ import { cn } from '../../lib/cn';
 /** Characters shown from session ID in compact view. */
 const SESSION_ID_PREVIEW_LENGTH = 8;
 
-/** Characters shown from content hash in metadata. */
-const CONTENT_HASH_PREVIEW_LENGTH = 16;
-
 /* ---------- Helpers ---------- */
 
 function epochToRelative(epoch: number | null): string {
   if (epoch === null) return '\u2014';
   return formatTimeAgo(new Date(epoch * 1000).toISOString());
-}
-
-function epochToAbsolute(epoch: number | null): string {
-  if (epoch === null) return '\u2014';
-  return new Date(epoch * 1000).toLocaleString();
 }
 
 /* ---------- Sub-components ---------- */
@@ -121,6 +113,7 @@ export function SessionDetail({ id }: SessionDetailProps) {
   const [activeTab, setActiveTab] = useState<TabValue>('conversation');
   const deleteSession = useDeleteSession();
   const { data: impact } = useSessionImpact(deleteOpen ? id : null);
+  const { data: plans } = useSessionPlans(id);
 
   if (isLoading) {
     return (
@@ -233,19 +226,11 @@ export function SessionDetail({ id }: SessionDetailProps) {
         </div>
       </div>
 
-      {/* Stats + Metadata cards (horizontal, above conversation) */}
-      <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
+      {/* Key stats (compact row) */}
+      <div className="grid grid-cols-3 gap-4">
         <StatCard label="Prompts" value={String(session.prompt_count)} accent="sage" />
         <StatCard label="Tool Calls" value={String(session.tool_count)} accent="sage" />
-        <StatCard label="Status" value={session.status.charAt(0).toUpperCase() + session.status.slice(1)} accent="outline" />
-        <StatCard label="Started" value={epochToAbsolute(session.started_at)} accent="outline" />
-        <StatCard label="Ended" value={epochToAbsolute(session.ended_at)} accent="outline" />
-        <StatCard
-          label="Session ID"
-          value={id.slice(0, SESSION_ID_PREVIEW_LENGTH)}
-          sublabel={session.content_hash ? `hash: ${session.content_hash.slice(0, CONTENT_HASH_PREVIEW_LENGTH)}` : undefined}
-          accent="outline"
-        />
+        <StatCard label="Plans" value={String(plans?.length ?? 0)} accent="outline" />
       </div>
 
       {/* Metadata details (collapsible-style row) */}

--- a/ui/src/hooks/use-graph-canvas.ts
+++ b/ui/src/hooks/use-graph-canvas.ts
@@ -310,7 +310,18 @@ export function useGraphCanvas({ nodes, edges, onNodeSelect }: UseGraphCanvasOpt
       padding: FIT_PADDING,
     });
     layout.on('layoutstop', () => {
-      cy.fit(undefined, FIT_PADDING);
+      // Center on the most-connected node and zoom to show its neighborhood
+      const mostConnected = cy.nodes().maxDegree(false);
+      if (mostConnected.degree(false) > 2 && cy.nodes().length > 20) {
+        cy.animate({
+          center: { eles: mostConnected },
+          zoom: 1.2,
+          duration: 300,
+          easing: 'ease-out',
+        });
+      } else {
+        cy.fit(undefined, FIT_PADDING);
+      }
     });
     layout.run();
 

--- a/ui/src/hooks/use-spores.ts
+++ b/ui/src/hooks/use-spores.ts
@@ -155,6 +155,19 @@ export function useGraph(entityId: string | undefined, depth: number = 1) {
   });
 }
 
+export interface FullGraphResponse {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export function useFullGraph() {
+  return useQuery<FullGraphResponse>({
+    queryKey: ['full-graph'],
+    queryFn: ({ signal }) => fetchJson<FullGraphResponse>('/graph', { signal }),
+    staleTime: GRAPH_STALE_TIME,
+  });
+}
+
 export function useDigest(agentId?: string) {
   const path = agentId
     ? `/digest?agent_id=${encodeURIComponent(agentId)}`

--- a/ui/src/hooks/use-team.ts
+++ b/ui/src/hooks/use-team.ts
@@ -1,0 +1,26 @@
+import { usePowerQuery } from './use-power-query';
+import { fetchJson } from '../lib/api';
+import { POLL_INTERVALS } from '../lib/constants';
+
+export interface TeamStatusResponse {
+  enabled: boolean;
+  worker_url: string | null;
+  has_api_key: boolean;
+  api_key: string | null;
+  healthy: boolean;
+  health_error?: string;
+  pending_sync_count: number;
+  machine_id: string;
+  package_version: string;
+  schema_version: number;
+  sync_protocol_version: number;
+}
+
+export function useTeamStatus() {
+  return usePowerQuery<TeamStatusResponse>({
+    queryKey: ['team-status'],
+    queryFn: ({ signal }) => fetchJson<TeamStatusResponse>('/team/status', { signal }),
+    refetchInterval: POLL_INTERVALS.STATS,
+    pollCategory: 'standard',
+  });
+}

--- a/ui/src/layout/Layout.tsx
+++ b/ui/src/layout/Layout.tsx
@@ -17,6 +17,7 @@ import {
   MessageSquare,
   Bot,
   Wrench,
+  Users,
   Search,
   Menu,
   X,
@@ -38,6 +39,7 @@ const NAV_ITEMS = [
   { to: '/agent', label: 'Agent', icon: Bot },
   { to: '/settings', label: 'Settings', icon: Settings },
   { to: '/operations', label: 'Operations', icon: Wrench },
+  { to: '/team', label: 'Team', icon: Users },
   { to: '/logs', label: 'Logs', icon: ScrollText },
 ] as const;
 

--- a/ui/src/pages/Mycelium.tsx
+++ b/ui/src/pages/Mycelium.tsx
@@ -6,7 +6,7 @@ import { SporeList } from '../components/mycelium/SporeList';
 import { SporeDetail } from '../components/mycelium/SporeDetail';
 import { DigestView } from '../components/mycelium/DigestView';
 import { PageHeader } from '../components/ui/page-header';
-import { useEntities, useGraph } from '../hooks/use-spores';
+import { useEntities, useFullGraph } from '../hooks/use-spores';
 import type { GraphNode } from '../hooks/use-graph-canvas';
 import type { SporeSummary } from '../hooks/use-spores';
 import type { Tab } from '../components/ui/tab-switcher';
@@ -68,19 +68,12 @@ function GraphTab() {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
 
-  const { data: entitiesData } = useEntities();
-  const entities = entitiesData?.entities ?? [];
+  const { data: graphData } = useFullGraph();
 
-  /* Pick the first entity as the center for the graph if available */
-  const centerId = entities.length > 0 ? entities[0]?.id : undefined;
-  const { data: graphData } = useGraph(centerId, DEFAULT_GRAPH_DEPTH);
-
-  /* Merge center + nodes into a single array for filtering/display */
+  /* All nodes from the full graph */
   const allGraphNodes = useMemo(() => {
-    const nodes = [...(graphData?.nodes ?? [])];
-    if (graphData?.center) nodes.unshift(graphData.center);
-    return nodes;
-  }, [graphData?.center, graphData?.nodes]);
+    return graphData?.nodes ?? [];
+  }, [graphData?.nodes]);
 
   /* Build node type counts from graph data (all node types, not just entities) */
   const nodeCounts = useMemo(() => {

--- a/ui/src/pages/Operations.tsx
+++ b/ui/src/pages/Operations.tsx
@@ -13,6 +13,7 @@ import { SectionHeader } from '../components/ui/section-header';
 import { Button } from '../components/ui/button';
 import { Badge } from '../components/ui/badge';
 import { cn } from '../lib/cn';
+import { BackupCard } from '../components/operations/BackupCard';
 
 /* ---------- Constants ---------- */
 
@@ -390,6 +391,9 @@ export default function Operations() {
                   </p>
                 )}
               </Surface>
+
+              {/* Backup & Restore */}
+              <BackupCard />
 
               {/* Activity log — recessed terminal feel */}
               <Surface level="low" className="flex flex-col overflow-hidden">

--- a/ui/src/pages/Team.tsx
+++ b/ui/src/pages/Team.tsx
@@ -1,0 +1,360 @@
+import { useState, useCallback } from 'react';
+import { Users, Wifi, WifiOff, RefreshCw, Copy, Check, Eye, EyeOff } from 'lucide-react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTeamStatus, type TeamStatusResponse } from '../hooks/use-team';
+import { postJson } from '../lib/api';
+import { PageHeader } from '../components/ui/page-header';
+import { PageLoading } from '../components/ui/page-loading';
+import { Surface } from '../components/ui/surface';
+import { SectionHeader } from '../components/ui/section-header';
+import { Button } from '../components/ui/button';
+import { Badge } from '../components/ui/badge';
+import { Input } from '../components/ui/input';
+import { StatCard } from '../components/ui/stat-card';
+
+/* ---------- Helpers ---------- */
+
+function CopyableField({ label, value, mono = true }: { label: string; value: string; mono?: boolean }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [value]);
+
+  return (
+    <div className="space-y-1">
+      <span className="text-xs text-on-surface-variant">{label}</span>
+      <div className="flex items-center gap-2 group">
+        <span className={`text-sm text-on-surface break-all ${mono ? 'font-mono' : ''}`}>
+          {value}
+        </span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="flex-shrink-0 p-1 rounded text-on-surface-variant hover:text-on-surface opacity-0 group-hover:opacity-100 transition-opacity"
+          title="Copy to clipboard"
+        >
+          {copied ? <Check className="h-3.5 w-3.5 text-primary" /> : <Copy className="h-3.5 w-3.5" />}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function RedactedField({ label, value }: { label: string; value: string }) {
+  const [visible, setVisible] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [value]);
+
+  const redacted = `${value.slice(0, 8)}${'*'.repeat(Math.max(0, value.length - 12))}${value.slice(-4)}`;
+
+  return (
+    <div className="space-y-1">
+      <span className="text-xs text-on-surface-variant">{label}</span>
+      <div className="flex items-center gap-2 group">
+        <span className="text-sm text-on-surface font-mono break-all">
+          {visible ? value : redacted}
+        </span>
+        <button
+          type="button"
+          onClick={() => setVisible(!visible)}
+          className="flex-shrink-0 p-1 rounded text-on-surface-variant hover:text-on-surface transition-opacity"
+          title={visible ? 'Hide' : 'Reveal'}
+        >
+          {visible ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+        </button>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="flex-shrink-0 p-1 rounded text-on-surface-variant hover:text-on-surface opacity-0 group-hover:opacity-100 transition-opacity"
+          title="Copy to clipboard"
+        >
+          {copied ? <Check className="h-3.5 w-3.5 text-primary" /> : <Copy className="h-3.5 w-3.5" />}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ---------- Sub-components ---------- */
+
+function ConnectForm({ onConnected }: { onConnected: () => void }) {
+  const [url, setUrl] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      await postJson('/team/connect', { url, api_key: apiKey });
+      onConnected();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Connection failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Surface level="low" ghostBorder className="p-6">
+      <div className="flex items-center gap-2 mb-4">
+        <WifiOff className="h-4 w-4 text-on-surface-variant" />
+        <SectionHeader>Connect to team</SectionHeader>
+      </div>
+      <p className="text-sm text-on-surface-variant mb-4">
+        Enter the URL and API key for your team's Cloudflare Worker to enable cross-machine knowledge sharing.
+      </p>
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <div>
+          <label className="block text-xs font-medium text-on-surface-variant mb-1">Worker URL</label>
+          <Input
+            type="url"
+            placeholder="https://myco-team.your-account.workers.dev"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-on-surface-variant mb-1">API Key</label>
+          <Input
+            type="password"
+            placeholder="your-api-key"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            required
+          />
+        </div>
+        {error && (
+          <p className="text-sm text-tertiary">{error}</p>
+        )}
+        <Button type="submit" size="sm" disabled={loading || !url || !apiKey}>
+          {loading ? (
+            <>
+              <RefreshCw className="h-3.5 w-3.5 animate-spin mr-1.5" />
+              Connecting...
+            </>
+          ) : (
+            'Connect'
+          )}
+        </Button>
+      </form>
+    </Surface>
+  );
+}
+
+function ConnectedStatus({ status }: { status: TeamStatusResponse }) {
+  const queryClient = useQueryClient();
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [syncMessage, setSyncMessage] = useState<string | null>(null);
+
+  const handleDisconnect = async () => {
+    setDisconnecting(true);
+    try {
+      await postJson('/team/disconnect');
+      queryClient.invalidateQueries({ queryKey: ['team-status'] });
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  const handleSyncAll = useCallback(async () => {
+    setSyncing(true);
+    setSyncMessage(null);
+    try {
+      const res = await postJson<{ enqueued: number }>('/team/backfill');
+      setSyncMessage(
+        res.enqueued > 0
+          ? `Enqueued ${res.enqueued} records for sync. They'll push on the next flush cycle.`
+          : 'All records are already synced or enqueued.',
+      );
+      queryClient.invalidateQueries({ queryKey: ['team-status'] });
+    } catch {
+      setSyncMessage('Backfill failed.');
+    } finally {
+      setSyncing(false);
+    }
+  }, [queryClient]);
+
+  return (
+    <div className="space-y-4">
+      {/* Status overview */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <StatCard
+          label="Status"
+          value={status.healthy ? 'Connected' : 'Unhealthy'}
+          icon={status.healthy ? Wifi : WifiOff}
+        />
+        <StatCard
+          label="Pending sync"
+          value={status.pending_sync_count}
+        />
+        <StatCard
+          label="Protocol"
+          value={`v${status.sync_protocol_version}`}
+        />
+        <StatCard
+          label="Schema"
+          value={`v${status.schema_version}`}
+        />
+      </div>
+
+      {/* Share with teammates */}
+      <Surface level="low" ghostBorder className="p-5 space-y-4">
+        <div className="flex items-center justify-between">
+          <SectionHeader>Team Credentials</SectionHeader>
+          <Badge variant={status.healthy ? 'default' : 'destructive'}>
+            {status.healthy ? 'healthy' : 'unhealthy'}
+          </Badge>
+        </div>
+        <p className="text-xs text-on-surface-variant">
+          Share these with teammates so they can connect from the Team page.
+        </p>
+
+        <div className="space-y-3">
+          {status.worker_url && (
+            <CopyableField label="Worker URL" value={status.worker_url} />
+          )}
+          {status.api_key && (
+            <RedactedField label="API Key" value={status.api_key} />
+          )}
+        </div>
+      </Surface>
+
+      {/* Connection details */}
+      <Surface level="low" ghostBorder className="p-5 space-y-4">
+        <SectionHeader>This Node</SectionHeader>
+        <div className="grid gap-3">
+          <CopyableField label="Machine ID" value={status.machine_id} />
+          <CopyableField label="Package Version" value={status.package_version} />
+        </div>
+
+        {status.health_error && (
+          <p className="text-sm text-tertiary mt-2">
+            {status.health_error}
+          </p>
+        )}
+      </Surface>
+
+      {/* Sync actions */}
+      <Surface level="low" ghostBorder className="p-5 space-y-3">
+        <div className="flex items-center justify-between">
+          <SectionHeader>Sync</SectionHeader>
+          <Button
+            variant="default"
+            size="sm"
+            onClick={handleSyncAll}
+            disabled={syncing}
+          >
+            {syncing ? (
+              <>
+                <RefreshCw className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                Syncing...
+              </>
+            ) : (
+              'Sync All'
+            )}
+          </Button>
+        </div>
+        <p className="text-xs text-on-surface-variant">
+          Push all unsynced local knowledge to the team store. Records sync automatically on new writes,
+          but historical data needs a one-time backfill.
+        </p>
+        {syncMessage && (
+          <p className="text-sm text-primary">{syncMessage}</p>
+        )}
+      </Surface>
+
+      {/* Disconnect */}
+      <div className="flex justify-end">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleDisconnect}
+          disabled={disconnecting}
+        >
+          {disconnecting ? 'Disconnecting...' : 'Disconnect'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/* ---------- Page ---------- */
+
+export default function Team() {
+  const { data: status, isLoading } = useTeamStatus();
+  const queryClient = useQueryClient();
+
+  if (isLoading) return <PageLoading />;
+
+  const isConnected = status?.enabled && status?.worker_url;
+
+  return (
+    <div className="p-6 max-w-4xl">
+      <PageHeader
+        title="Team"
+        subtitle="Share knowledge across machines with team sync"
+      />
+
+      {isConnected && status ? (
+        <ConnectedStatus status={status} />
+      ) : (
+        <div className="space-y-4">
+          {/* Setup guide */}
+          <Surface level="low" ghostBorder className="p-6 space-y-4">
+            <SectionHeader>Getting Started</SectionHeader>
+            <p className="text-sm text-on-surface-variant">
+              Team sync lets multiple machines share captured knowledge through a Cloudflare Worker.
+              One team member provisions the infrastructure, then shares the connection details.
+            </p>
+
+            <div className="space-y-3">
+              <div>
+                <p className="text-sm font-medium text-on-surface mb-1">1. Install Wrangler</p>
+                <code className="block font-mono text-xs bg-surface-container rounded px-3 py-2 text-on-surface-variant">
+                  npm install -g wrangler && wrangler login
+                </code>
+              </div>
+
+              <div>
+                <p className="text-sm font-medium text-on-surface mb-1">2. Provision the team</p>
+                <code className="block font-mono text-xs bg-surface-container rounded px-3 py-2 text-on-surface-variant">
+                  myco team init
+                </code>
+                <p className="text-xs text-on-surface-variant mt-1">
+                  Creates a D1 database, Vectorize index, and deploys the sync worker.
+                  Outputs a Worker URL and API key to share with teammates.
+                </p>
+              </div>
+
+              <div>
+                <p className="text-sm font-medium text-on-surface mb-1">3. Connect</p>
+                <p className="text-xs text-on-surface-variant">
+                  Paste the Worker URL and API key below, or if you ran <code className="font-mono">myco team init</code>,
+                  you're already connected.
+                </p>
+              </div>
+            </div>
+          </Surface>
+
+          {/* Connect form */}
+          <ConnectForm onConnected={() => queryClient.invalidateQueries({ queryKey: ['team-status'] })} />
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Machine identity** — deterministic `{github_user}_{hash}` tagged on all knowledge records (schema v4). Enables attribution, backup organization, and cross-machine restore.
- **Local backup & restore** — SQL dump to configurable directory with content-hash dedup on restore. Auto-backup on idle via PowerManager. BackupCard UI on Operations page.
- **Team sync** — outbox pattern pushes knowledge to a Cloudflare Worker backed by D1 + Vectorize + Workers AI. Search fan-out queries local + cloud in parallel with 3s timeout and machine_id dedup. Team page UI for connect/disconnect/status/credentials/backfill.
- **CLI provisioning** — `myco team init` creates D1 database, Vectorize index, deploys Worker, seeds team config. `myco team upgrade` redeploys.
- **Full knowledge graph** — `/api/graph` endpoint returns all entities, active spores, and sessions with edges. Graph view centers on the most-connected node.
- **Documentation** — `docs/team-sync.md` comprehensive guide, README updated with team sync and backup sections.

57 files changed, +5,072/-80, 1258 tests passing.

## Test plan

- [x] `make check` — 1258 tests pass, 0 type errors
- [x] `make build` — clean build (tsup + vite)
- [x] Machine identity generates and caches correctly
- [x] Backup creates SQL dump, restore preview shows correct counts
- [x] `myco team init` provisions D1 + Vectorize + deploys Worker
- [x] Worker health endpoint responds
- [x] Outbox backfill enqueues historical records
- [x] Flush job pushes batches to D1 (verified via Cloudflare D1 query)
- [x] Vectorize embeddings created (team search returns results)
- [x] Search dedup filters own-machine results from team store
- [x] Team page shows credentials, sync status, Sync All button
- [x] Full graph endpoint returns all nodes and edges
- [x] Manual: test teammate connection via UI
- [x] Manual: verify search results from a different machine appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)