### PR TITLE
Feat: myco auto updated via daemon ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,16 +16,19 @@
         "better-sqlite3": "^12.8.0",
         "chokidar": "^5.0.0",
         "gray-matter": "^4.0.3",
+        "semver": "^7.7.4",
         "sqlite-vec": "^0.1.7",
         "yaml": "^2.4.0",
         "zod": "^4.3.6"
       },
       "bin": {
-        "myco": "dist/src/cli.js"
+        "myco": "dist/src/cli.js",
+        "myco-run": "bin/myco-run"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^25.5.0",
+        "@types/semver": "^7.7.1",
         "tsup": "^8.0.0",
         "tsx": "^4.0.0",
         "typescript": "^5.5.0",
@@ -1994,6 +1997,13 @@
       "dependencies": {
         "undici-types": "~7.18.0"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "better-sqlite3": "^12.8.0",
     "chokidar": "^5.0.0",
     "gray-matter": "^4.0.3",
+    "semver": "^7.7.4",
     "sqlite-vec": "^0.1.7",
     "yaml": "^2.4.0",
     "zod": "^4.3.6"
@@ -48,6 +49,7 @@
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.5.0",
+    "@types/semver": "^7.7.1",
     "tsup": "^8.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.5.0",

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -5,7 +5,16 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 export async function run(args: string[]): Promise<void> {
-  const vaultDir = resolveVaultDir();
+  // Support --project <path> for detached update scripts
+  let projectRoot: string | undefined;
+  const projectIdx = args.indexOf('--project');
+  if (projectIdx !== -1 && args[projectIdx + 1]) {
+    projectRoot = args[projectIdx + 1];
+  }
+
+  const vaultDir = projectRoot
+    ? path.join(projectRoot, '.myco')
+    : resolveVaultDir();
   if (!fs.existsSync(path.join(vaultDir, 'myco.yaml'))) {
     console.error(`No myco.yaml found in ${vaultDir}. Run 'myco init' first.`);
     process.exit(1);
@@ -32,16 +41,16 @@ export async function run(args: string[]): Promise<void> {
 
   // --- Update symbiont registration (only agents already configured) ---
 
-  const projectRoot = path.dirname(vaultDir);
+  const resolvedProjectRoot = projectRoot ?? path.dirname(vaultDir);
   const allManifests = loadManifests();
   const pkgRoot = resolvePackageRoot();
   // Only update agents whose config directory already exists in the project
   const configured = allManifests.filter((m) =>
-    fs.existsSync(path.join(projectRoot, m.configDir)),
+    fs.existsSync(path.join(resolvedProjectRoot, m.configDir)),
   );
 
   if (configured.length > 0) {
-    const registered = registerSymbionts(configured, projectRoot, pkgRoot, 'Updated');
+    const registered = registerSymbionts(configured, resolvedProjectRoot, pkgRoot, 'Updated');
     updatedCount += registered;
   } else {
     console.log('  \u2013 No configured agents found');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -364,6 +364,10 @@ export const TEAM_API_KEY_SECRET = 'MYCO_TEAM_API_KEY';
 /** Timeout for wrangler CLI commands (ms). */
 export const WRANGLER_COMMAND_TIMEOUT_MS = 60_000;
 
+// --- HTTP response flush ---
+/** Delay before initiating shutdown — allows the HTTP response to flush. */
+export const RESTART_RESPONSE_FLUSH_MS = 500;
+
 // --- Self-update ---
 export {
   NPM_REGISTRY_URL,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -363,3 +363,19 @@ export const TEAM_HEALTH_TIMEOUT_MS = 5000;
 export const TEAM_API_KEY_SECRET = 'MYCO_TEAM_API_KEY';
 /** Timeout for wrangler CLI commands (ms). */
 export const WRANGLER_COMMAND_TIMEOUT_MS = 60_000;
+
+// --- Self-update ---
+export {
+  NPM_REGISTRY_URL,
+  MYCO_GLOBAL_DIR,
+  UPDATE_CHECK_CACHE_PATH,
+  UPDATE_CONFIG_PATH,
+  UPDATE_ERROR_PATH,
+  UPDATE_CHECK_INTERVAL_HOURS,
+  MS_PER_HOUR,
+  NPM_PACKAGE_NAME,
+  UPDATE_SCRIPT_DELAY_SECONDS,
+  RELEASE_CHANNELS,
+  DEFAULT_RELEASE_CHANNEL,
+  type ReleaseChannel,
+} from './constants/update.js';

--- a/src/constants/update.ts
+++ b/src/constants/update.ts
@@ -1,0 +1,36 @@
+import path from 'node:path';
+import os from 'node:os';
+
+/** npm registry URL for the Myco package. */
+export const NPM_REGISTRY_URL = 'https://registry.npmjs.org/@goondocks/myco';
+
+/** Global Myco directory for machine-wide state. */
+export const MYCO_GLOBAL_DIR = path.join(os.homedir(), '.myco');
+
+/** Path to the cached update check result. */
+export const UPDATE_CHECK_CACHE_PATH = path.join(MYCO_GLOBAL_DIR, 'last-update-check.json');
+
+/** Path to the update configuration file (channel, interval). */
+export const UPDATE_CONFIG_PATH = path.join(MYCO_GLOBAL_DIR, 'update.yaml');
+
+/** Path to the update error file (written by update script on failure). */
+export const UPDATE_ERROR_PATH = path.join(MYCO_GLOBAL_DIR, 'update-error.json');
+
+/** Default check interval in hours. */
+export const UPDATE_CHECK_INTERVAL_HOURS = 6;
+
+/** Milliseconds per hour. */
+export const MS_PER_HOUR = 3_600_000;
+
+/** npm package name. */
+export const NPM_PACKAGE_NAME = '@goondocks/myco';
+
+/** Delay in seconds before update script starts (allows daemon to exit). */
+export const UPDATE_SCRIPT_DELAY_SECONDS = 2;
+
+/** Valid release channels. */
+export const RELEASE_CHANNELS = ['stable', 'beta'] as const;
+export type ReleaseChannel = (typeof RELEASE_CHANNELS)[number];
+
+/** Default release channel. */
+export const DEFAULT_RELEASE_CHANNEL: ReleaseChannel = 'stable';

--- a/src/daemon/api/restart.ts
+++ b/src/daemon/api/restart.ts
@@ -3,13 +3,11 @@ import { z } from 'zod';
 import { resolveCliEntryPath } from '../../hooks/client.js';
 import type { RouteResponse } from '../router.js';
 import type { ProgressTracker } from './progress.js';
+import { RESTART_RESPONSE_FLUSH_MS } from '../../constants.js';
 
 const RestartBodySchema = z.object({
   force: z.boolean().optional(),
 }).optional();
-
-/** Delay before initiating shutdown — allows the HTTP response to flush. */
-const RESTART_RESPONSE_FLUSH_MS = 500;
 /** Delay before the child process starts — allows the parent to fully release the port. */
 const RESTART_CHILD_DELAY_SECONDS = 3;
 

--- a/src/daemon/api/update.ts
+++ b/src/daemon/api/update.ts
@@ -81,7 +81,25 @@ export function createUpdateHandlers(deps: UpdateDeps) {
     }
 
     // Pass pre-read config and cache to avoid reading the files a second time.
-    return { body: { exempt: false, ...statusFromCache(currentVersion, cache, config) } };
+    const status = statusFromCache(currentVersion, cache, config);
+    if (!status) {
+      // No cache yet — return minimal response; background check will populate it.
+      return {
+        body: {
+          exempt: false,
+          update_available: false,
+          running_version: currentVersion,
+          latest_version: currentVersion,
+          latest_stable: currentVersion,
+          latest_beta: null,
+          channel: config.channel,
+          check_interval_hours: config.check_interval_hours,
+          last_check: '',
+          error: null,
+        },
+      };
+    }
+    return { body: { exempt: false, ...status } };
   }
 
   /**
@@ -140,7 +158,24 @@ export function createUpdateHandlers(deps: UpdateDeps) {
     writeUpdateConfig({ ...config, channel });
     clearCachedCheck();
 
-    return { body: { exempt: false, ...statusFromCache(currentVersion) } };
+    const channelStatus = statusFromCache(currentVersion);
+    if (!channelStatus) {
+      return {
+        body: {
+          exempt: false,
+          update_available: false,
+          running_version: currentVersion,
+          latest_version: currentVersion,
+          latest_stable: currentVersion,
+          latest_beta: null,
+          channel,
+          check_interval_hours: config.check_interval_hours,
+          last_check: '',
+          error: null,
+        },
+      };
+    }
+    return { body: { exempt: false, ...channelStatus } };
   }
 
   return {

--- a/src/daemon/api/update.ts
+++ b/src/daemon/api/update.ts
@@ -80,7 +80,8 @@ export function createUpdateHandlers(deps: UpdateDeps) {
       checkForUpdate(currentVersion).catch(() => {});
     }
 
-    return { body: { exempt: false, ...statusFromCache(currentVersion) } };
+    // Pass pre-read config and cache to avoid reading the files a second time.
+    return { body: { exempt: false, ...statusFromCache(currentVersion, cache, config) } };
   }
 
   /**

--- a/src/daemon/api/update.ts
+++ b/src/daemon/api/update.ts
@@ -1,0 +1,151 @@
+/**
+ * Update API handlers — status, manual check, apply, and channel switch.
+ *
+ * Factory function injects vaultDir, projectRoot, currentVersion, and a
+ * scheduleShutdown callback; returns handlers for:
+ *   GET  /api/update/status
+ *   POST /api/update/check
+ *   POST /api/update/apply
+ *   PUT  /api/update/channel
+ */
+
+import { z } from 'zod';
+
+import {
+  isUpdateExempt,
+  checkForUpdate,
+  statusFromCache,
+  readCachedCheck,
+  readUpdateConfig,
+  writeUpdateConfig,
+  clearCachedCheck,
+  isCacheStale,
+} from '../update-checker.js';
+import { spawnUpdateScript } from '../update-installer.js';
+import { RELEASE_CHANNELS } from '../../constants/update.js';
+import type { RouteRequest, RouteResponse } from '../router.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Dependencies injected by the daemon when registering update routes. */
+export interface UpdateDeps {
+  /** Absolute path to the active vault directory. */
+  vaultDir: string;
+  /** Absolute path to the project root (used by `myco update --project`). */
+  projectRoot: string;
+  /** The currently running version (from package.json at startup). */
+  currentVersion: string;
+  /** Callback that schedules a graceful daemon shutdown after the update script spawns. */
+  scheduleShutdown: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Zod schema
+// ---------------------------------------------------------------------------
+
+const ChannelBodySchema = z.object({
+  channel: z.enum(RELEASE_CHANNELS),
+});
+
+// ---------------------------------------------------------------------------
+// Handler factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create update API handlers with injected dependencies.
+ *
+ * Returns an object with named handlers for each update endpoint.
+ */
+export function createUpdateHandlers(deps: UpdateDeps) {
+  const { vaultDir, projectRoot, currentVersion, scheduleShutdown } = deps;
+
+  /**
+   * GET /api/update/status — returns cached update state.
+   *
+   * When the cache is stale, kicks off a background registry check
+   * (fire-and-forget) and immediately returns the current cached value.
+   */
+  async function handleUpdateStatus(_req: RouteRequest): Promise<RouteResponse> {
+    if (isUpdateExempt()) {
+      return { body: { exempt: true, running_version: currentVersion } };
+    }
+
+    const config = readUpdateConfig();
+    const cache = readCachedCheck();
+
+    if (isCacheStale(cache, config.check_interval_hours)) {
+      // Fire-and-forget — don't block the response on the registry fetch.
+      checkForUpdate(currentVersion).catch(() => {});
+    }
+
+    return { body: { exempt: false, ...statusFromCache(currentVersion) } };
+  }
+
+  /**
+   * POST /api/update/check — forces an immediate registry check (blocking).
+   *
+   * Intended for user-initiated "Check Now" actions where the caller wants
+   * fresh data before rendering.
+   */
+  async function handleUpdateCheck(_req: RouteRequest): Promise<RouteResponse> {
+    if (isUpdateExempt()) {
+      return {
+        status: 400,
+        body: { error: 'update_exempt', message: 'Updates disabled in dev mode' },
+      };
+    }
+
+    const result = await checkForUpdate(currentVersion);
+    return { body: { exempt: false, ...result } };
+  }
+
+  /**
+   * POST /api/update/apply — spawns the update script and schedules shutdown.
+   *
+   * Returns 400 when no update is available or when in dev mode.
+   */
+  async function handleUpdateApply(_req: RouteRequest): Promise<RouteResponse> {
+    if (isUpdateExempt()) {
+      return { status: 400, body: { error: 'update_exempt' } };
+    }
+
+    const status = statusFromCache(currentVersion);
+    if (!status || !status.update_available) {
+      return { status: 400, body: { error: 'no_update_available' } };
+    }
+
+    spawnUpdateScript({ targetVersion: status.latest_version, projectRoot, vaultDir });
+    scheduleShutdown();
+
+    return { body: { status: 'applying', version: status.latest_version } };
+  }
+
+  /**
+   * PUT /api/update/channel — switches the release channel and clears the cache.
+   *
+   * Returns 400 when the channel value is not in RELEASE_CHANNELS.
+   */
+  async function handleUpdateChannel(req: RouteRequest): Promise<RouteResponse> {
+    const parsed = ChannelBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return { status: 400, body: { error: 'invalid_channel' } };
+    }
+
+    const { channel } = parsed.data;
+    const config = readUpdateConfig();
+
+    writeUpdateConfig({ ...config, channel });
+    clearCachedCheck();
+
+    return { body: { exempt: false, ...statusFromCache(currentVersion) } };
+  }
+
+  return {
+    handleUpdateStatus,
+    handleUpdateCheck,
+    handleUpdateApply,
+    handleUpdateChannel,
+  };
+}

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -23,6 +23,7 @@ import type { RegisteredSession } from './lifecycle.js';
 import { handleGetConfig, handlePutConfig } from './api/config.js';
 import { handleLogSearch, handleLogStream, handleLogDetail } from './api/log-explorer.js';
 import { handleRestart } from './api/restart.js';
+import { createUpdateHandlers } from './api/update.js';
 import { getMachineId } from './machine-id.js';
 import { createBackupHandlers } from './api/backup.js';
 import { createTeamHandlers } from './api/team-connect.js';
@@ -105,6 +106,7 @@ import {
   POWER_ACTIVE_INTERVAL_MS,
   POWER_SLEEP_INTERVAL_MS,
   SYNC_PROTOCOL_VERSION,
+  RESTART_RESPONSE_FLUSH_MS,
   epochSeconds,
   MS_PER_SECOND,
   MS_PER_DAY,
@@ -1346,6 +1348,25 @@ export async function main(): Promise<void> {
 
   server.registerRoute('GET', '/api/models', async (req) => handleGetModels(req));
   server.registerRoute('POST', '/api/restart', async (req) => handleRestart({ vaultDir, progressTracker }, req.body));
+
+  // --- Update routes ---
+  const updateProjectRoot = path.dirname(vaultDir);
+  const updateHandlers = createUpdateHandlers({
+    vaultDir,
+    projectRoot: updateProjectRoot,
+    currentVersion: server.version,
+    scheduleShutdown: () => {
+      setTimeout(() => {
+        process.kill(process.pid, 'SIGTERM');
+      }, RESTART_RESPONSE_FLUSH_MS);
+    },
+  });
+
+  server.registerRoute('GET', '/api/update/status', async (req) => updateHandlers.handleUpdateStatus(req));
+  server.registerRoute('POST', '/api/update/check', async (req) => updateHandlers.handleUpdateCheck(req));
+  server.registerRoute('POST', '/api/update/apply', async (req) => updateHandlers.handleUpdateApply(req));
+  server.registerRoute('PUT', '/api/update/channel', async (req) => updateHandlers.handleUpdateChannel(req));
+
   server.registerRoute('GET', '/api/progress/:token', async (req) => handleGetProgress(progressTracker, req.params.token));
 
   server.registerRoute('GET', '/api/sessions', handleListSessions);

--- a/src/daemon/update-checker.ts
+++ b/src/daemon/update-checker.ts
@@ -1,0 +1,345 @@
+/**
+ * Update checker — fetches the npm registry for @goondocks/myco, compares
+ * versions against the current installation, caches results, and supports
+ * stable/beta release channels.
+ *
+ * - Stable channel: compare against dist-tags.latest only.
+ * - Beta channel: compare against max(dist-tags.latest, dist-tags.beta).
+ *   Beta users can always reach stable (no-downgrade rule).
+ * - Dev mode exemption: if MYCO_CMD is set the binary is a dev symlink;
+ *   update checks are skipped entirely.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import YAML from 'yaml';
+import semver from 'semver';
+
+import {
+  NPM_REGISTRY_URL,
+  MYCO_GLOBAL_DIR,
+  UPDATE_CHECK_CACHE_PATH,
+  UPDATE_CONFIG_PATH,
+  UPDATE_ERROR_PATH,
+  UPDATE_CHECK_INTERVAL_HOURS,
+  MS_PER_HOUR,
+  DEFAULT_RELEASE_CHANNEL,
+  RELEASE_CHANNELS,
+  type ReleaseChannel,
+} from '../constants/update.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Persisted update configuration stored in ~/.myco/update.yaml */
+export interface UpdateConfig {
+  channel: ReleaseChannel;
+  check_interval_hours: number;
+}
+
+/** Cached result of a registry check stored in ~/.myco/last-update-check.json */
+export interface CachedCheck {
+  checked_at: string;
+  current_version: string;
+  latest_stable: string;
+  latest_beta: string | null;
+  channel: ReleaseChannel;
+}
+
+/** Result returned to callers of checkForUpdate / statusFromCache */
+export interface CheckResult {
+  update_available: boolean;
+  running_version: string;
+  latest_version: string;
+  latest_stable: string;
+  latest_beta: string | null;
+  channel: ReleaseChannel;
+  check_interval_hours: number;
+  last_check: string;
+  error: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Fetch timeout for registry requests. */
+const REGISTRY_FETCH_TIMEOUT_MS = 10_000;
+
+// ---------------------------------------------------------------------------
+// Dev-mode exemption
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when MYCO_CMD is set — indicates a dev symlink is in use and
+ * update checks should be skipped.
+ */
+export function isUpdateExempt(): boolean {
+  return Boolean(process.env.MYCO_CMD);
+}
+
+// ---------------------------------------------------------------------------
+// Config helpers
+// ---------------------------------------------------------------------------
+
+/** Default config returned when no update.yaml exists. */
+function defaultUpdateConfig(): UpdateConfig {
+  return {
+    channel: DEFAULT_RELEASE_CHANNEL,
+    check_interval_hours: UPDATE_CHECK_INTERVAL_HOURS,
+  };
+}
+
+/**
+ * Reads ~/.myco/update.yaml. Returns defaults when the file is missing or
+ * unparseable.
+ */
+export function readUpdateConfig(): UpdateConfig {
+  try {
+    const raw = fs.readFileSync(UPDATE_CONFIG_PATH, 'utf-8');
+    const parsed = YAML.parse(raw) as Partial<UpdateConfig>;
+
+    const channel = RELEASE_CHANNELS.includes(parsed?.channel as ReleaseChannel)
+      ? (parsed.channel as ReleaseChannel)
+      : DEFAULT_RELEASE_CHANNEL;
+
+    const check_interval_hours =
+      typeof parsed?.check_interval_hours === 'number' && parsed.check_interval_hours > 0
+        ? parsed.check_interval_hours
+        : UPDATE_CHECK_INTERVAL_HOURS;
+
+    return { channel, check_interval_hours };
+  } catch {
+    return defaultUpdateConfig();
+  }
+}
+
+/**
+ * Writes UpdateConfig to ~/.myco/update.yaml. Creates ~/.myco/ if needed.
+ */
+export function writeUpdateConfig(config: UpdateConfig): void {
+  fs.mkdirSync(MYCO_GLOBAL_DIR, { recursive: true });
+  fs.writeFileSync(UPDATE_CONFIG_PATH, YAML.stringify(config), 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Cache helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads ~/.myco/last-update-check.json. Returns null when the file is missing
+ * or unparseable.
+ */
+export function readCachedCheck(): CachedCheck | null {
+  try {
+    const raw = fs.readFileSync(UPDATE_CHECK_CACHE_PATH, 'utf-8');
+    return JSON.parse(raw) as CachedCheck;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Deletes the cache file. Used when switching channels so the stale cached
+ * result is not returned.
+ */
+export function clearCachedCheck(): void {
+  try {
+    fs.unlinkSync(UPDATE_CHECK_CACHE_PATH);
+  } catch {
+    // File not present — that's fine.
+  }
+}
+
+/**
+ * Returns true when the cache is null (never checked) or older than
+ * intervalHours.
+ */
+export function isCacheStale(cache: CachedCheck | null, intervalHours: number): boolean {
+  if (cache === null) return true;
+
+  const checkedAt = new Date(cache.checked_at).getTime();
+  if (isNaN(checkedAt)) return true;
+
+  const ageMs = Date.now() - checkedAt;
+  return ageMs > intervalHours * MS_PER_HOUR;
+}
+
+// ---------------------------------------------------------------------------
+// Error file
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads ~/.myco/update-error.json. Returns the error string when present, null
+ * otherwise.
+ */
+export function readUpdateError(): string | null {
+  try {
+    const raw = fs.readFileSync(UPDATE_ERROR_PATH, 'utf-8');
+    const parsed = JSON.parse(raw) as { error?: string };
+    return parsed?.error ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Registry types
+// ---------------------------------------------------------------------------
+
+interface NpmDistTags {
+  latest: string;
+  beta?: string;
+  [tag: string]: string | undefined;
+}
+
+interface NpmRegistryResponse {
+  'dist-tags': NpmDistTags;
+}
+
+// ---------------------------------------------------------------------------
+// Channel comparison logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the target version to compare against based on channel.
+ * - Stable: dist-tags.latest
+ * - Beta: max(dist-tags.latest, dist-tags.beta) — no-downgrade rule
+ */
+function resolveTargetVersion(distTags: NpmDistTags, channel: ReleaseChannel): string {
+  const stable = distTags.latest;
+  const beta = distTags.beta ?? null;
+
+  if (channel === 'stable' || beta === null) {
+    return stable;
+  }
+
+  // Beta channel: pick whichever is higher (stable can exceed beta tag)
+  const higher = semver.gt(beta, stable) ? beta : stable;
+  return higher;
+}
+
+// ---------------------------------------------------------------------------
+// CheckResult builder
+// ---------------------------------------------------------------------------
+
+function buildCheckResult(
+  currentVersion: string,
+  cache: CachedCheck,
+  config: UpdateConfig,
+  error: string | null,
+): CheckResult {
+  const targetVersion = cache.channel === 'stable'
+    ? cache.latest_stable
+    : resolveHigherVersion(cache.latest_stable, cache.latest_beta);
+
+  const update_available =
+    semver.valid(currentVersion) !== null &&
+    semver.valid(targetVersion) !== null &&
+    semver.gt(targetVersion, currentVersion);
+
+  return {
+    update_available,
+    running_version: currentVersion,
+    latest_version: targetVersion,
+    latest_stable: cache.latest_stable,
+    latest_beta: cache.latest_beta,
+    channel: cache.channel,
+    check_interval_hours: config.check_interval_hours,
+    last_check: cache.checked_at,
+    error,
+  };
+}
+
+/** Returns the higher of two semver strings. When beta is null, returns stable. */
+function resolveHigherVersion(stable: string, beta: string | null): string {
+  if (beta === null) return stable;
+  return semver.gt(beta, stable) ? beta : stable;
+}
+
+// ---------------------------------------------------------------------------
+// Primary exports
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches the npm registry, compares versions, and writes the result to cache.
+ *
+ * On network failure, returns the last cached result (with an error field) if
+ * one exists. If no cache exists and the fetch fails, the error field is set
+ * and update_available is false.
+ */
+export async function checkForUpdate(currentVersion: string): Promise<CheckResult> {
+  const config = readUpdateConfig();
+  const existingCache = readCachedCheck();
+
+  let distTags: NpmDistTags;
+  let fetchError: string | null = null;
+
+  try {
+    const response = await fetch(NPM_REGISTRY_URL, {
+      signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Registry responded with ${response.status}`);
+    }
+
+    const data = (await response.json()) as NpmRegistryResponse;
+    distTags = data['dist-tags'];
+  } catch (err) {
+    fetchError = err instanceof Error ? err.message : String(err);
+
+    // Fall back to stale cache on network error
+    if (existingCache !== null) {
+      return buildCheckResult(currentVersion, existingCache, config, fetchError);
+    }
+
+    // No cache at all — return a no-update result with the error
+    return {
+      update_available: false,
+      running_version: currentVersion,
+      latest_version: currentVersion,
+      latest_stable: currentVersion,
+      latest_beta: null,
+      channel: config.channel,
+      check_interval_hours: config.check_interval_hours,
+      last_check: new Date().toISOString(),
+      error: fetchError,
+    };
+  }
+
+  const latestStable = distTags.latest;
+  const latestBeta = distTags.beta ?? null;
+  const targetVersion = resolveTargetVersion(distTags, config.channel);
+
+  // Write fresh cache
+  const freshCache: CachedCheck = {
+    checked_at: new Date().toISOString(),
+    current_version: currentVersion,
+    latest_stable: latestStable,
+    latest_beta: latestBeta,
+    channel: config.channel,
+  };
+
+  try {
+    fs.mkdirSync(path.dirname(UPDATE_CHECK_CACHE_PATH), { recursive: true });
+    fs.writeFileSync(UPDATE_CHECK_CACHE_PATH, JSON.stringify(freshCache, null, 2), 'utf-8');
+  } catch {
+    // Cache write failure is non-fatal
+  }
+
+  return buildCheckResult(currentVersion, freshCache, config, null);
+}
+
+/**
+ * Builds a CheckResult from cached data without hitting the registry.
+ * Returns null when no cache exists.
+ */
+export function statusFromCache(currentVersion: string): CheckResult | null {
+  const cache = readCachedCheck();
+  if (cache === null) return null;
+
+  const config = readUpdateConfig();
+  return buildCheckResult(currentVersion, cache, config, null);
+}

--- a/src/daemon/update-checker.ts
+++ b/src/daemon/update-checker.ts
@@ -230,9 +230,10 @@ function buildCheckResult(
   config: UpdateConfig,
   error: string | null,
 ): CheckResult {
-  const targetVersion = cache.channel === 'stable'
-    ? cache.latest_stable
-    : resolveHigherVersion(cache.latest_stable, cache.latest_beta);
+  const targetVersion = resolveTargetVersion(
+    { latest: cache.latest_stable, beta: cache.latest_beta ?? undefined },
+    cache.channel,
+  );
 
   const update_available =
     semver.valid(currentVersion) !== null &&
@@ -250,12 +251,6 @@ function buildCheckResult(
     last_check: cache.checked_at,
     error,
   };
-}
-
-/** Returns the higher of two semver strings. When beta is null, returns stable. */
-function resolveHigherVersion(stable: string, beta: string | null): string {
-  if (beta === null) return stable;
-  return semver.gt(beta, stable) ? beta : stable;
 }
 
 // ---------------------------------------------------------------------------
@@ -335,11 +330,18 @@ export async function checkForUpdate(currentVersion: string): Promise<CheckResul
 /**
  * Builds a CheckResult from cached data without hitting the registry.
  * Returns null when no cache exists.
+ *
+ * Accepts optional pre-read `cache` and `config` to avoid redundant file
+ * reads when the caller has already loaded them (e.g. for a staleness check).
  */
-export function statusFromCache(currentVersion: string): CheckResult | null {
-  const cache = readCachedCheck();
-  if (cache === null) return null;
+export function statusFromCache(
+  currentVersion: string,
+  cache?: CachedCheck | null,
+  config?: UpdateConfig,
+): CheckResult | null {
+  const resolvedCache = cache !== undefined ? cache : readCachedCheck();
+  if (resolvedCache === null) return null;
 
-  const config = readUpdateConfig();
-  return buildCheckResult(currentVersion, cache, config, null);
+  const resolvedConfig = config !== undefined ? config : readUpdateConfig();
+  return buildCheckResult(currentVersion, resolvedCache, resolvedConfig, null);
 }

--- a/src/daemon/update-installer.ts
+++ b/src/daemon/update-installer.ts
@@ -1,0 +1,113 @@
+/**
+ * Update installer — generates and spawns a detached shell script that installs
+ * the npm update and restarts the daemon after the current process exits.
+ *
+ * The script is written to a temp file with mode 0o755, spawned detached with
+ * stdio ignored, and unreffed so the parent process can exit immediately.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+import {
+  NPM_PACKAGE_NAME,
+  MYCO_GLOBAL_DIR,
+  UPDATE_ERROR_PATH,
+  UPDATE_SCRIPT_DELAY_SECONDS,
+} from '../constants/update.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Parameters required to generate and spawn an update script. */
+export interface InstallParams {
+  /** The target version to install (e.g. "0.11.0"). */
+  targetVersion: string;
+  /** Absolute path to the project root for `myco update --project`. */
+  projectRoot: string;
+  /** Absolute path to the vault directory for `myco daemon --vault`. */
+  vaultDir: string;
+}
+
+// ---------------------------------------------------------------------------
+// Script generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates a POSIX shell script string that:
+ * 1. Waits UPDATE_SCRIPT_DELAY_SECONDS for the daemon to exit.
+ * 2. Runs `npm install -g <package>@<version>`.
+ * 3. On success: runs `myco update --project <projectRoot>` (non-fatal).
+ * 4. On success: clears ~/.myco/update-error.json.
+ * 5. On failure: writes error JSON to ~/.myco/update-error.json.
+ * 6. Always: starts `myco daemon --vault <vaultDir>` in background.
+ * 7. Cleans up the script file itself.
+ */
+export function generateUpdateScript(params: InstallParams): string {
+  const { targetVersion, projectRoot, vaultDir } = params;
+
+  // Use JSON.stringify for safe path quoting (handles spaces, special chars).
+  const packageSpec = `${NPM_PACKAGE_NAME}@${targetVersion}`;
+  const quotedProjectRoot = JSON.stringify(projectRoot);
+  const quotedVaultDir = JSON.stringify(vaultDir);
+  const quotedErrorPath = JSON.stringify(UPDATE_ERROR_PATH);
+  const errorJson = JSON.stringify(
+    JSON.stringify({ error: `npm install failed for ${packageSpec}` }),
+  );
+
+  return `#!/bin/sh
+set -e
+
+# Wait for daemon to exit cleanly
+sleep ${UPDATE_SCRIPT_DELAY_SECONDS}
+
+# Attempt the update
+if npm install -g ${packageSpec} 2>&1; then
+  # Sync project files (gitignore, symbiont registration)
+  myco update --project ${quotedProjectRoot} || true
+  # Clear any previous error
+  rm -f ${quotedErrorPath}
+else
+  # Write error and attempt restart with old version
+  echo ${errorJson} > ${quotedErrorPath}
+fi
+
+# Restart daemon (works whether install succeeded or failed)
+myco daemon --vault ${quotedVaultDir} &
+
+# Clean up this script
+rm -f "$0"
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Script spawning
+// ---------------------------------------------------------------------------
+
+/**
+ * Writes the generated update script to a temp file, spawns it detached, and
+ * unrefs the child so the parent process can exit without waiting.
+ *
+ * Returns the path to the temporary script file.
+ */
+export function spawnUpdateScript(params: InstallParams): string {
+  // Ensure ~/.myco/ exists before writing the error path or checking state.
+  fs.mkdirSync(MYCO_GLOBAL_DIR, { recursive: true });
+
+  const scriptName = `myco-update-${Date.now()}.sh`;
+  const scriptPath = path.join(os.tmpdir(), scriptName);
+
+  const script = generateUpdateScript(params);
+  fs.writeFileSync(scriptPath, script, { encoding: 'utf-8', mode: 0o755 });
+
+  const child = spawn('/bin/sh', [scriptPath], {
+    detached: true,
+    stdio: 'ignore',
+  });
+  child.unref();
+
+  return scriptPath;
+}

--- a/src/db/queries/search.ts
+++ b/src/db/queries/search.ts
@@ -172,6 +172,7 @@ interface PlanRow {
   id: string;
   title: string | null;
   content: string | null;
+  session_id: string | null;
 }
 
 /** Row shape returned from artifacts table for hydration. */
@@ -212,7 +213,7 @@ export function hydrateSearchResults(
     `SELECT id, observation_type, content, session_id FROM spores WHERE id IN (SELECT value FROM json_each(?))`,
   );
   const planStmt = db.prepare(
-    `SELECT id, title, content FROM plans WHERE id IN (SELECT value FROM json_each(?))`,
+    `SELECT id, title, content, session_id FROM plans WHERE id IN (SELECT value FROM json_each(?))`,
   );
   const artifactStmt = db.prepare(
     `SELECT id, title, content FROM artifacts WHERE id IN (SELECT value FROM json_each(?))`,
@@ -275,6 +276,7 @@ export function hydrateSearchResults(
         title: row.title ?? `Plan ${row.id.slice(-6)}`,
         preview: (row.content ?? '').slice(0, SEARCH_PREVIEW_CHARS),
         score: vr.similarity,
+        ...(row.session_id != null ? { session_id: row.session_id } : {}),
       });
     }
   }

--- a/tests/daemon/api/update.test.ts
+++ b/tests/daemon/api/update.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Tests for the update API route handlers.
+ *
+ * Covers:
+ * - handleUpdateStatus: exempt, fresh cache (no background check), stale cache (background check)
+ * - handleUpdateCheck: forces registry fetch, 400 when exempt
+ * - handleUpdateApply: spawns script + schedules shutdown, 400 when no update, 400 when exempt
+ * - handleUpdateChannel: writes config + clears cache, 400 for invalid channel
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Module mocks — hoisted before imports
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../src/daemon/update-checker.js', () => ({
+  isUpdateExempt: vi.fn(() => false),
+  checkForUpdate: vi.fn(),
+  statusFromCache: vi.fn(),
+  readCachedCheck: vi.fn(() => null),
+  readUpdateConfig: vi.fn(() => ({ channel: 'stable', check_interval_hours: 6 })),
+  writeUpdateConfig: vi.fn(),
+  clearCachedCheck: vi.fn(),
+  isCacheStale: vi.fn(() => false),
+}));
+
+vi.mock('../../../src/daemon/update-installer.js', () => ({
+  spawnUpdateScript: vi.fn(() => '/tmp/myco-update-123.sh'),
+}));
+
+import {
+  isUpdateExempt,
+  checkForUpdate,
+  statusFromCache,
+  readCachedCheck,
+  readUpdateConfig,
+  writeUpdateConfig,
+  clearCachedCheck,
+  isCacheStale,
+} from '../../../src/daemon/update-checker.js';
+import { spawnUpdateScript } from '../../../src/daemon/update-installer.js';
+import { createUpdateHandlers } from '../../../src/daemon/api/update.js';
+import type { RouteRequest } from '../../../src/daemon/router.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal stub RouteRequest. */
+function makeReq(overrides: Partial<RouteRequest> = {}): RouteRequest {
+  return {
+    body: {},
+    query: {},
+    params: {},
+    pathname: '/api/update/status',
+    ...overrides,
+  };
+}
+
+/** A representative CheckResult with update available. */
+const UPDATE_AVAILABLE_STATUS = {
+  update_available: true,
+  running_version: '1.0.0',
+  latest_version: '1.1.0',
+  latest_stable: '1.1.0',
+  latest_beta: null,
+  channel: 'stable' as const,
+  check_interval_hours: 6,
+  last_check: '2026-03-28T00:00:00.000Z',
+  error: null,
+};
+
+/** A representative CheckResult with no update available. */
+const NO_UPDATE_STATUS = {
+  ...UPDATE_AVAILABLE_STATUS,
+  update_available: false,
+  latest_version: '1.0.0',
+  latest_stable: '1.0.0',
+};
+
+/** Default deps for tests. */
+function makeDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    vaultDir: '/vault',
+    projectRoot: '/project',
+    currentVersion: '1.0.0',
+    scheduleShutdown: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// handleUpdateStatus
+// ---------------------------------------------------------------------------
+
+describe('handleUpdateStatus', () => {
+  beforeEach(() => {
+    vi.mocked(isUpdateExempt).mockReturnValue(false);
+    vi.mocked(readCachedCheck).mockReturnValue(null);
+    vi.mocked(readUpdateConfig).mockReturnValue({ channel: 'stable', check_interval_hours: 6 });
+    vi.mocked(isCacheStale).mockReturnValue(false);
+    vi.mocked(statusFromCache).mockReturnValue(NO_UPDATE_STATUS);
+    vi.mocked(checkForUpdate).mockResolvedValue(NO_UPDATE_STATUS);
+  });
+
+  it('returns exempt:true when in dev mode', async () => {
+    vi.mocked(isUpdateExempt).mockReturnValue(true);
+    const { handleUpdateStatus } = createUpdateHandlers(makeDeps());
+
+    const result = await handleUpdateStatus(makeReq());
+
+    expect(result.status).toBeUndefined();
+    expect(result.body).toEqual({ exempt: true, running_version: '1.0.0' });
+  });
+
+  it('returns status from cache when cache is fresh', async () => {
+    const freshCache = {
+      checked_at: new Date().toISOString(),
+      current_version: '1.0.0',
+      latest_stable: '1.0.0',
+      latest_beta: null,
+      channel: 'stable' as const,
+    };
+    vi.mocked(readCachedCheck).mockReturnValue(freshCache);
+    vi.mocked(isCacheStale).mockReturnValue(false);
+    vi.mocked(statusFromCache).mockReturnValue(NO_UPDATE_STATUS);
+
+    const { handleUpdateStatus } = createUpdateHandlers(makeDeps());
+    const result = await handleUpdateStatus(makeReq());
+
+    expect(result.body).toMatchObject({ exempt: false, update_available: false });
+    // Should NOT trigger a background check
+    expect(checkForUpdate).not.toHaveBeenCalled();
+  });
+
+  it('kicks off background check when cache is stale', async () => {
+    vi.mocked(isCacheStale).mockReturnValue(true);
+    vi.mocked(statusFromCache).mockReturnValue(NO_UPDATE_STATUS);
+    vi.mocked(checkForUpdate).mockResolvedValue(NO_UPDATE_STATUS);
+
+    const { handleUpdateStatus } = createUpdateHandlers(makeDeps());
+    const result = await handleUpdateStatus(makeReq());
+
+    // Response returned immediately (does not await checkForUpdate)
+    expect(result.body).toMatchObject({ exempt: false });
+    // Background check was triggered
+    expect(checkForUpdate).toHaveBeenCalledWith('1.0.0');
+  });
+
+  it('returns exempt:false in body when not exempt', async () => {
+    vi.mocked(statusFromCache).mockReturnValue(NO_UPDATE_STATUS);
+    const { handleUpdateStatus } = createUpdateHandlers(makeDeps());
+
+    const result = await handleUpdateStatus(makeReq());
+
+    expect((result.body as Record<string, unknown>).exempt).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleUpdateCheck
+// ---------------------------------------------------------------------------
+
+describe('handleUpdateCheck', () => {
+  beforeEach(() => {
+    vi.mocked(isUpdateExempt).mockReturnValue(false);
+    vi.mocked(checkForUpdate).mockResolvedValue(UPDATE_AVAILABLE_STATUS);
+  });
+
+  it('returns 400 when exempt', async () => {
+    vi.mocked(isUpdateExempt).mockReturnValue(true);
+    const { handleUpdateCheck } = createUpdateHandlers(makeDeps());
+
+    const result = await handleUpdateCheck(makeReq());
+
+    expect(result.status).toBe(400);
+    expect((result.body as Record<string, unknown>).error).toBe('update_exempt');
+  });
+
+  it('awaits checkForUpdate and returns result', async () => {
+    const { handleUpdateCheck } = createUpdateHandlers(makeDeps());
+
+    const result = await handleUpdateCheck(makeReq());
+
+    expect(checkForUpdate).toHaveBeenCalledWith('1.0.0');
+    expect(result.body).toMatchObject({ exempt: false, update_available: true });
+  });
+
+  it('propagates update_available:false when already up to date', async () => {
+    vi.mocked(checkForUpdate).mockResolvedValue(NO_UPDATE_STATUS);
+    const { handleUpdateCheck } = createUpdateHandlers(makeDeps());
+
+    const result = await handleUpdateCheck(makeReq());
+
+    expect((result.body as Record<string, unknown>).update_available).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleUpdateApply
+// ---------------------------------------------------------------------------
+
+describe('handleUpdateApply', () => {
+  beforeEach(() => {
+    vi.mocked(isUpdateExempt).mockReturnValue(false);
+    vi.mocked(statusFromCache).mockReturnValue(UPDATE_AVAILABLE_STATUS);
+    vi.mocked(spawnUpdateScript).mockReset();
+    vi.mocked(spawnUpdateScript).mockReturnValue('/tmp/myco-update-123.sh');
+  });
+
+  it('returns 400 when exempt', async () => {
+    vi.mocked(isUpdateExempt).mockReturnValue(true);
+    const { handleUpdateApply } = createUpdateHandlers(makeDeps());
+
+    const result = await handleUpdateApply(makeReq());
+
+    expect(result.status).toBe(400);
+    expect((result.body as Record<string, unknown>).error).toBe('update_exempt');
+  });
+
+  it('returns 400 when no update is available', async () => {
+    vi.mocked(statusFromCache).mockReturnValue(NO_UPDATE_STATUS);
+    const { handleUpdateApply } = createUpdateHandlers(makeDeps());
+
+    const result = await handleUpdateApply(makeReq());
+
+    expect(result.status).toBe(400);
+    expect((result.body as Record<string, unknown>).error).toBe('no_update_available');
+  });
+
+  it('returns 400 when cache is empty (no status)', async () => {
+    vi.mocked(statusFromCache).mockReturnValue(null);
+    const { handleUpdateApply } = createUpdateHandlers(makeDeps());
+
+    const result = await handleUpdateApply(makeReq());
+
+    expect(result.status).toBe(400);
+  });
+
+  it('spawns update script and schedules shutdown', async () => {
+    const scheduleShutdown = vi.fn();
+    const { handleUpdateApply } = createUpdateHandlers(makeDeps({ scheduleShutdown }));
+
+    const result = await handleUpdateApply(makeReq());
+
+    expect(spawnUpdateScript).toHaveBeenCalledWith({
+      targetVersion: '1.1.0',
+      projectRoot: '/project',
+      vaultDir: '/vault',
+    });
+    expect(scheduleShutdown).toHaveBeenCalled();
+    expect(result.body).toMatchObject({ status: 'applying', version: '1.1.0' });
+  });
+
+  it('does not spawn script when update is unavailable', async () => {
+    vi.mocked(statusFromCache).mockReturnValue(NO_UPDATE_STATUS);
+    const { handleUpdateApply } = createUpdateHandlers(makeDeps());
+
+    await handleUpdateApply(makeReq());
+
+    expect(spawnUpdateScript).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleUpdateChannel
+// ---------------------------------------------------------------------------
+
+describe('handleUpdateChannel', () => {
+  beforeEach(() => {
+    vi.mocked(isUpdateExempt).mockReturnValue(false);
+    vi.mocked(readUpdateConfig).mockReturnValue({ channel: 'stable', check_interval_hours: 6 });
+    vi.mocked(statusFromCache).mockReturnValue(NO_UPDATE_STATUS);
+    vi.mocked(writeUpdateConfig).mockImplementation(() => {});
+    vi.mocked(clearCachedCheck).mockImplementation(() => {});
+  });
+
+  it('returns 400 for an invalid channel', async () => {
+    const { handleUpdateChannel } = createUpdateHandlers(makeDeps());
+
+    const result = await handleUpdateChannel(makeReq({ body: { channel: 'nightly' } }));
+
+    expect(result.status).toBe(400);
+    expect((result.body as Record<string, unknown>).error).toBe('invalid_channel');
+  });
+
+  it('returns 400 when channel is missing', async () => {
+    const { handleUpdateChannel } = createUpdateHandlers(makeDeps());
+
+    const result = await handleUpdateChannel(makeReq({ body: {} }));
+
+    expect(result.status).toBe(400);
+  });
+
+  it('writes updated config and clears cache for valid channel', async () => {
+    const { handleUpdateChannel } = createUpdateHandlers(makeDeps());
+
+    const result = await handleUpdateChannel(makeReq({ body: { channel: 'beta' } }));
+
+    expect(writeUpdateConfig).toHaveBeenCalledWith({ channel: 'beta', check_interval_hours: 6 });
+    expect(clearCachedCheck).toHaveBeenCalled();
+    expect(result.status).toBeUndefined();
+  });
+
+  it('returns status from cache with exempt:false after channel change', async () => {
+    vi.mocked(statusFromCache).mockReturnValue(NO_UPDATE_STATUS);
+    const { handleUpdateChannel } = createUpdateHandlers(makeDeps());
+
+    const result = await handleUpdateChannel(makeReq({ body: { channel: 'stable' } }));
+
+    expect(result.body).toMatchObject({ exempt: false });
+  });
+
+  it('accepts both valid channels: stable and beta', async () => {
+    const { handleUpdateChannel } = createUpdateHandlers(makeDeps());
+
+    const stable = await handleUpdateChannel(makeReq({ body: { channel: 'stable' } }));
+    const beta = await handleUpdateChannel(makeReq({ body: { channel: 'beta' } }));
+
+    expect(stable.status).toBeUndefined();
+    expect(beta.status).toBeUndefined();
+  });
+});

--- a/tests/daemon/api/update.test.ts
+++ b/tests/daemon/api/update.test.ts
@@ -156,6 +156,22 @@ describe('handleUpdateStatus', () => {
 
     expect((result.body as Record<string, unknown>).exempt).toBe(false);
   });
+
+  it('returns default status when cache is empty (null)', async () => {
+    vi.mocked(statusFromCache).mockReturnValue(null);
+    vi.mocked(isCacheStale).mockReturnValue(true);
+    vi.mocked(checkForUpdate).mockResolvedValue(NO_UPDATE_STATUS);
+
+    const { handleUpdateStatus } = createUpdateHandlers(makeDeps());
+    const result = await handleUpdateStatus(makeReq());
+    const body = result.body as Record<string, unknown>;
+
+    expect(body.exempt).toBe(false);
+    expect(body.update_available).toBe(false);
+    expect(body.running_version).toBe('1.0.0');
+    expect(body.channel).toBe('stable');
+    expect(body.last_check).toBe('');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -310,6 +326,19 @@ describe('handleUpdateChannel', () => {
     const result = await handleUpdateChannel(makeReq({ body: { channel: 'stable' } }));
 
     expect(result.body).toMatchObject({ exempt: false });
+  });
+
+  it('returns default status when cache is empty after channel switch', async () => {
+    vi.mocked(statusFromCache).mockReturnValue(null);
+    const { handleUpdateChannel } = createUpdateHandlers(makeDeps());
+
+    const result = await handleUpdateChannel(makeReq({ body: { channel: 'beta' } }));
+    const body = result.body as Record<string, unknown>;
+
+    expect(body.exempt).toBe(false);
+    expect(body.update_available).toBe(false);
+    expect(body.channel).toBe('beta');
+    expect(body.last_check).toBe('');
   });
 
   it('accepts both valid channels: stable and beta', async () => {

--- a/tests/daemon/update-checker.test.ts
+++ b/tests/daemon/update-checker.test.ts
@@ -1,0 +1,447 @@
+/**
+ * Tests for the update checker module.
+ *
+ * Covers:
+ * - isUpdateExempt — dev-mode detection via MYCO_CMD
+ * - readUpdateConfig — defaults when missing, reads YAML when present
+ * - isCacheStale — null cache, fresh cache, expired cache
+ * - checkForUpdate — fetches registry, update detection, channel logic
+ * - statusFromCache — builds CheckResult from cache without registry
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MS_PER_HOUR } from '../../src/constants/update.js';
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be hoisted before any imports that use the mocked modules
+// ---------------------------------------------------------------------------
+
+vi.mock('node:fs');
+vi.mock('node:os', () => ({
+  default: {
+    homedir: () => '/mock-home',
+  },
+}));
+
+// The constants module re-exports paths based on os.homedir(). Since vitest
+// hoists vi.mock calls before imports, mocking 'node:os' here ensures that
+// the constants are computed against '/mock-home' when the module is first
+// evaluated during tests.
+
+import fs from 'node:fs';
+import {
+  isUpdateExempt,
+  readUpdateConfig,
+  isCacheStale,
+  checkForUpdate,
+  statusFromCache,
+  type CachedCheck,
+  type UpdateConfig,
+} from '@myco/daemon/update-checker.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a CachedCheck with sensible defaults for test isolation. */
+function makeCachedCheck(overrides: Partial<CachedCheck> = {}): CachedCheck {
+  return {
+    checked_at: new Date().toISOString(),
+    current_version: '1.0.0',
+    latest_stable: '1.1.0',
+    latest_beta: null,
+    channel: 'stable',
+    ...overrides,
+  };
+}
+
+/** Build a minimal npm registry response. */
+function makeRegistryResponse(latest: string, beta?: string): Record<string, unknown> {
+  return {
+    'dist-tags': {
+      latest,
+      ...(beta !== undefined ? { beta } : {}),
+    },
+  };
+}
+
+/** Helper: mock fs.readFileSync to return specific content for a path. */
+function mockFileContent(filePath: string, content: string): void {
+  vi.mocked(fs.readFileSync).mockImplementation((p, _opts) => {
+    if (p === filePath) return content;
+    const err: NodeJS.ErrnoException = new Error(`ENOENT: ${String(p)}`);
+    err.code = 'ENOENT';
+    throw err;
+  });
+}
+
+/** Helper: make all file reads throw ENOENT. */
+function mockNoFiles(): void {
+  vi.mocked(fs.readFileSync).mockImplementation((p) => {
+    const err: NodeJS.ErrnoException = new Error(`ENOENT: ${String(p)}`);
+    err.code = 'ENOENT';
+    throw err;
+  });
+}
+
+/** Helper: mock a successful fetch response. */
+function mockFetchSuccess(data: Record<string, unknown>): void {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => data,
+  } as Response);
+}
+
+/** Helper: mock a failed fetch. */
+function mockFetchFailure(message = 'network error'): void {
+  global.fetch = vi.fn().mockRejectedValue(new Error(message));
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.unstubAllEnvs();
+  vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
+  vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+  vi.mocked(fs.unlinkSync).mockReturnValue(undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+// ---------------------------------------------------------------------------
+// isUpdateExempt
+// ---------------------------------------------------------------------------
+
+describe('isUpdateExempt()', () => {
+  it('returns false when MYCO_CMD is not set', () => {
+    vi.stubEnv('MYCO_CMD', '');
+    expect(isUpdateExempt()).toBe(false);
+  });
+
+  it('returns true when MYCO_CMD is set', () => {
+    vi.stubEnv('MYCO_CMD', 'myco-dev');
+    expect(isUpdateExempt()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readUpdateConfig
+// ---------------------------------------------------------------------------
+
+describe('readUpdateConfig()', () => {
+  it('returns defaults when the config file is missing', () => {
+    mockNoFiles();
+    const config = readUpdateConfig();
+    expect(config.channel).toBe('stable');
+    expect(config.check_interval_hours).toBeGreaterThan(0);
+  });
+
+  it('reads channel from yaml when file exists', () => {
+    mockFileContent(
+      '/mock-home/.myco/update.yaml',
+      'channel: beta\ncheck_interval_hours: 12\n',
+    );
+    const config = readUpdateConfig();
+    expect(config.channel).toBe('beta');
+    expect(config.check_interval_hours).toBe(12);
+  });
+
+  it('falls back to stable channel for unknown channel values', () => {
+    mockFileContent(
+      '/mock-home/.myco/update.yaml',
+      'channel: nightly\ncheck_interval_hours: 6\n',
+    );
+    const config = readUpdateConfig();
+    expect(config.channel).toBe('stable');
+  });
+
+  it('falls back to default interval for invalid interval value', () => {
+    mockFileContent(
+      '/mock-home/.myco/update.yaml',
+      'channel: stable\ncheck_interval_hours: -5\n',
+    );
+    const config: UpdateConfig = readUpdateConfig();
+    expect(config.check_interval_hours).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isCacheStale
+// ---------------------------------------------------------------------------
+
+describe('isCacheStale()', () => {
+  it('returns true when cache is null', () => {
+    expect(isCacheStale(null, 6)).toBe(true);
+  });
+
+  it('returns false when cache is fresh (just created)', () => {
+    const fresh = makeCachedCheck({ checked_at: new Date().toISOString() });
+    expect(isCacheStale(fresh, 6)).toBe(false);
+  });
+
+  it('returns true when cache is older than the interval', () => {
+    const hoursAgo8 = new Date(Date.now() - 8 * MS_PER_HOUR).toISOString();
+    const stale = makeCachedCheck({ checked_at: hoursAgo8 });
+    expect(isCacheStale(stale, 6)).toBe(true);
+  });
+
+  it('returns false when cache age is exactly within the interval', () => {
+    const hoursAgo4 = new Date(Date.now() - 4 * MS_PER_HOUR).toISOString();
+    const recent = makeCachedCheck({ checked_at: hoursAgo4 });
+    expect(isCacheStale(recent, 6)).toBe(false);
+  });
+
+  it('returns true when checked_at is not a valid date', () => {
+    const bad = makeCachedCheck({ checked_at: 'not-a-date' });
+    expect(isCacheStale(bad, 6)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkForUpdate
+// ---------------------------------------------------------------------------
+
+describe('checkForUpdate()', () => {
+  beforeEach(() => {
+    // No pre-existing config or cache by default
+    mockNoFiles();
+  });
+
+  it('fetches the registry and returns an update when a newer version exists', async () => {
+    mockFetchSuccess(makeRegistryResponse('2.0.0'));
+
+    const result = await checkForUpdate('1.0.0');
+
+    expect(result.update_available).toBe(true);
+    expect(result.running_version).toBe('1.0.0');
+    expect(result.latest_stable).toBe('2.0.0');
+    expect(result.latest_version).toBe('2.0.0');
+    expect(result.error).toBeNull();
+  });
+
+  it('returns no update when running the latest version', async () => {
+    mockFetchSuccess(makeRegistryResponse('1.0.0'));
+
+    const result = await checkForUpdate('1.0.0');
+
+    expect(result.update_available).toBe(false);
+    expect(result.latest_stable).toBe('1.0.0');
+    expect(result.error).toBeNull();
+  });
+
+  it('returns no update when running a newer version than registry (pre-release dev)', async () => {
+    mockFetchSuccess(makeRegistryResponse('1.0.0'));
+
+    const result = await checkForUpdate('2.0.0');
+
+    expect(result.update_available).toBe(false);
+  });
+
+  it('writes cache after a successful fetch', async () => {
+    mockFetchSuccess(makeRegistryResponse('1.5.0'));
+
+    await checkForUpdate('1.0.0');
+
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledOnce();
+    const writtenContent = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+    const cached = JSON.parse(writtenContent) as CachedCheck;
+    expect(cached.latest_stable).toBe('1.5.0');
+    expect(cached.current_version).toBe('1.0.0');
+  });
+
+  describe('beta channel', () => {
+    beforeEach(() => {
+      // Config file returns beta channel
+      mockFileContent(
+        '/mock-home/.myco/update.yaml',
+        'channel: beta\ncheck_interval_hours: 6\n',
+      );
+    });
+
+    it('considers the beta dist-tag when on beta channel', async () => {
+      mockFetchSuccess(makeRegistryResponse('1.0.0', '1.1.0-beta.1'));
+
+      const result = await checkForUpdate('1.0.0');
+
+      expect(result.update_available).toBe(true);
+      expect(result.latest_version).toBe('1.1.0-beta.1');
+      expect(result.latest_beta).toBe('1.1.0-beta.1');
+    });
+
+    it('picks stable over beta when stable is higher (no-downgrade rule)', async () => {
+      // stable 2.0.0 > beta 1.9.0-beta.1
+      mockFetchSuccess(makeRegistryResponse('2.0.0', '1.9.0-beta.1'));
+
+      const result = await checkForUpdate('1.0.0');
+
+      expect(result.update_available).toBe(true);
+      expect(result.latest_version).toBe('2.0.0');
+    });
+
+    it('reports latest_beta even when not selected as target', async () => {
+      mockFetchSuccess(makeRegistryResponse('2.0.0', '1.9.0-beta.1'));
+
+      const result = await checkForUpdate('1.0.0');
+
+      expect(result.latest_beta).toBe('1.9.0-beta.1');
+    });
+
+    it('sets channel to beta in the result', async () => {
+      mockFetchSuccess(makeRegistryResponse('1.0.0', '1.1.0-beta.1'));
+
+      const result = await checkForUpdate('1.0.0');
+
+      expect(result.channel).toBe('beta');
+    });
+  });
+
+  describe('stable channel', () => {
+    it('ignores beta dist-tag on stable channel', async () => {
+      // stable channel — beta tag should not be selected as target
+      mockFetchSuccess(makeRegistryResponse('1.0.0', '1.5.0-beta.1'));
+
+      const result = await checkForUpdate('1.0.0');
+
+      expect(result.update_available).toBe(false);
+      expect(result.latest_version).toBe('1.0.0');
+      // But latest_beta is still reported
+      expect(result.latest_beta).toBe('1.5.0-beta.1');
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns cached result with error when fetch fails and cache exists', async () => {
+      const staleCache = makeCachedCheck({
+        latest_stable: '1.2.0',
+        channel: 'stable',
+      });
+      vi.mocked(fs.readFileSync).mockImplementation((p) => {
+        if (String(p).endsWith('last-update-check.json')) {
+          return JSON.stringify(staleCache);
+        }
+        const err: NodeJS.ErrnoException = new Error(`ENOENT: ${String(p)}`);
+        err.code = 'ENOENT';
+        throw err;
+      });
+
+      mockFetchFailure('fetch failed');
+
+      const result = await checkForUpdate('1.0.0');
+
+      expect(result.error).toMatch(/fetch failed/);
+      expect(result.latest_stable).toBe('1.2.0');
+    });
+
+    it('returns no-update with error when fetch fails and no cache exists', async () => {
+      mockNoFiles();
+      mockFetchFailure('connection refused');
+
+      const result = await checkForUpdate('1.0.0');
+
+      expect(result.update_available).toBe(false);
+      expect(result.error).toMatch(/connection refused/);
+    });
+
+    it('handles non-ok HTTP response', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({}),
+      } as Response);
+      mockNoFiles();
+
+      const result = await checkForUpdate('1.0.0');
+
+      expect(result.update_available).toBe(false);
+      expect(result.error).toMatch(/503/);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// statusFromCache
+// ---------------------------------------------------------------------------
+
+describe('statusFromCache()', () => {
+  it('returns null when no cache file exists', () => {
+    mockNoFiles();
+    const result = statusFromCache('1.0.0');
+    expect(result).toBeNull();
+  });
+
+  it('builds a CheckResult from cache when cache exists', () => {
+    const cache = makeCachedCheck({
+      latest_stable: '1.5.0',
+      latest_beta: null,
+      channel: 'stable',
+      checked_at: new Date().toISOString(),
+    });
+
+    vi.mocked(fs.readFileSync).mockImplementation((p) => {
+      if (String(p).endsWith('last-update-check.json')) {
+        return JSON.stringify(cache);
+      }
+      const err: NodeJS.ErrnoException = new Error(`ENOENT: ${String(p)}`);
+      err.code = 'ENOENT';
+      throw err;
+    });
+
+    const result = statusFromCache('1.0.0');
+
+    expect(result).not.toBeNull();
+    expect(result!.update_available).toBe(true);
+    expect(result!.running_version).toBe('1.0.0');
+    expect(result!.latest_stable).toBe('1.5.0');
+    expect(result!.latest_version).toBe('1.5.0');
+    expect(result!.channel).toBe('stable');
+    expect(result!.error).toBeNull();
+  });
+
+  it('correctly detects no update from cache', () => {
+    const cache = makeCachedCheck({
+      current_version: '1.5.0',
+      latest_stable: '1.5.0',
+      latest_beta: null,
+      channel: 'stable',
+    });
+
+    vi.mocked(fs.readFileSync).mockImplementation((p) => {
+      if (String(p).endsWith('last-update-check.json')) {
+        return JSON.stringify(cache);
+      }
+      const err: NodeJS.ErrnoException = new Error(`ENOENT: ${String(p)}`);
+      err.code = 'ENOENT';
+      throw err;
+    });
+
+    const result = statusFromCache('1.5.0');
+    expect(result!.update_available).toBe(false);
+  });
+
+  it('uses beta channel logic when cache channel is beta', () => {
+    const cache = makeCachedCheck({
+      latest_stable: '1.0.0',
+      latest_beta: '1.1.0-beta.1',
+      channel: 'beta',
+    });
+
+    vi.mocked(fs.readFileSync).mockImplementation((p) => {
+      if (String(p).endsWith('last-update-check.json')) {
+        return JSON.stringify(cache);
+      }
+      const err: NodeJS.ErrnoException = new Error(`ENOENT: ${String(p)}`);
+      err.code = 'ENOENT';
+      throw err;
+    });
+
+    const result = statusFromCache('1.0.0');
+    expect(result!.update_available).toBe(true);
+    expect(result!.latest_version).toBe('1.1.0-beta.1');
+  });
+});

--- a/ui/src/components/operations/UpdateCard.tsx
+++ b/ui/src/components/operations/UpdateCard.tsx
@@ -13,6 +13,10 @@ import {
 } from '../../hooks/use-update-status';
 import { useRestart } from '../../hooks/use-restart';
 
+/* ---------- Constants ---------- */
+
+const CHANNELS = ['stable', 'beta'] as const;
+
 /* ---------- Types ---------- */
 
 type ApplyState = 'idle' | 'applying' | 'restarting' | 'error';
@@ -150,7 +154,7 @@ export function UpdateCard() {
       {/* Channel toggle row */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1">
-          {(['stable', 'beta'] as const).map((ch) => (
+          {CHANNELS.map((ch) => (
             <Button
               key={ch}
               variant={activeChannel === ch ? 'default' : 'ghost'}

--- a/ui/src/components/operations/UpdateCard.tsx
+++ b/ui/src/components/operations/UpdateCard.tsx
@@ -1,0 +1,181 @@
+import { useState, useCallback } from 'react';
+import { ArrowUpCircle, RefreshCw, CheckCircle2, AlertCircle, Shield } from 'lucide-react';
+import { Surface } from '../ui/surface';
+import { SectionHeader } from '../ui/section-header';
+import { Button } from '../ui/button';
+import { Badge } from '../ui/badge';
+import { cn } from '../../lib/cn';
+import {
+  useUpdateStatus,
+  useUpdateCheck,
+  useUpdateApply,
+  useUpdateChannel,
+} from '../../hooks/use-update-status';
+import { useRestart } from '../../hooks/use-restart';
+
+/* ---------- Types ---------- */
+
+type ApplyState = 'idle' | 'applying' | 'restarting' | 'error';
+
+/* ---------- Helpers ---------- */
+
+function formatLastCheck(iso: string | undefined | null): string {
+  if (!iso) return 'Never';
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+/* ---------- UpdateCard ---------- */
+
+export function UpdateCard() {
+  const { data: status } = useUpdateStatus();
+  const checkMutation = useUpdateCheck();
+  const applyMutation = useUpdateApply();
+  const channelMutation = useUpdateChannel();
+  const { restart } = useRestart();
+
+  const [applyState, setApplyState] = useState<ApplyState>('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleApply = useCallback(async () => {
+    setApplyState('applying');
+    setErrorMessage(null);
+    try {
+      await applyMutation.mutateAsync();
+      setApplyState('restarting');
+      try {
+        await restart(true);
+      } catch {
+        setApplyState('error');
+        setErrorMessage('Daemon did not restart within the expected time. Check the terminal.');
+      }
+    } catch (err) {
+      setApplyState('error');
+      setErrorMessage((err as Error).message);
+    }
+  }, [applyMutation, restart]);
+
+  const handleCheck = useCallback(() => {
+    checkMutation.mutate();
+  }, [checkMutation]);
+
+  const handleChannelToggle = useCallback(
+    (channel: string) => {
+      channelMutation.mutate(channel);
+    },
+    [channelMutation],
+  );
+
+  // State 1: no data yet
+  if (!status) return null;
+
+  const isChecking = checkMutation.isPending;
+  const isApplying = applyState === 'applying' || applyState === 'restarting';
+  const updateAvailable = status.update_available === true;
+  const activeChannel = status.channel ?? 'stable';
+
+  // State 2: exempt (dev mode)
+  if (status.exempt) {
+    return (
+      <Surface level="low" className="p-6 space-y-4">
+        <div className="flex items-center gap-2">
+          <Shield className="h-4 w-4 text-primary" />
+          <SectionHeader>Updates</SectionHeader>
+        </div>
+        <p className="font-sans text-sm text-on-surface-variant">
+          Updates are disabled in development mode.{' '}
+          <span className="font-mono text-xs text-outline">{status.running_version}</span>
+        </p>
+      </Surface>
+    );
+  }
+
+  return (
+    <Surface level="low" className="p-6 space-y-4">
+      {/* Header row */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <ArrowUpCircle
+            className={cn('h-4 w-4', updateAvailable ? 'text-secondary' : 'text-primary')}
+          />
+          <SectionHeader>Updates</SectionHeader>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-xs text-outline">{status.running_version}</span>
+          {updateAvailable && status.latest_version && (
+            <Badge variant="warning">{status.latest_version}</Badge>
+          )}
+        </div>
+      </div>
+
+      {/* Status row */}
+      <div className="flex items-center gap-3 flex-wrap">
+        {updateAvailable ? (
+          <Button
+            variant="default"
+            size="sm"
+            onClick={handleApply}
+            disabled={isApplying}
+          >
+            {isApplying ? (
+              <>
+                <RefreshCw className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                {applyState === 'restarting' ? 'Restarting…' : 'Updating…'}
+              </>
+            ) : (
+              <>
+                <ArrowUpCircle className="mr-1.5 h-3.5 w-3.5" />
+                Update &amp; Restart
+              </>
+            )}
+          </Button>
+        ) : (
+          <div className="flex items-center gap-1.5 text-primary">
+            <CheckCircle2 className="h-4 w-4" />
+            <span className="font-sans text-sm">Up to date</span>
+          </div>
+        )}
+
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleCheck}
+          disabled={isChecking || isApplying}
+        >
+          <RefreshCw className={cn('mr-1.5 h-3.5 w-3.5', isChecking && 'animate-spin')} />
+          Check Now
+        </Button>
+      </div>
+
+      {/* Channel toggle row */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1">
+          {(['stable', 'beta'] as const).map((ch) => (
+            <Button
+              key={ch}
+              variant={activeChannel === ch ? 'default' : 'ghost'}
+              className="text-xs capitalize h-6 px-2"
+              onClick={() => handleChannelToggle(ch)}
+              disabled={channelMutation.isPending || isApplying}
+            >
+              {ch}
+            </Button>
+          ))}
+        </div>
+        <span className="font-sans text-xs text-on-surface-variant">
+          Checked: {formatLastCheck(status.last_check)}
+        </span>
+      </div>
+
+      {/* Error row */}
+      {(applyState === 'error' || status.error) && (
+        <div className="flex items-start gap-2 text-tertiary">
+          <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+          <span className="font-sans text-sm">
+            {errorMessage ?? status.error}
+          </span>
+        </div>
+      )}
+    </Surface>
+  );
+}

--- a/ui/src/components/search/GlobalSearch.tsx
+++ b/ui/src/components/search/GlobalSearch.tsx
@@ -22,7 +22,9 @@ function getResultPath(result: SearchResult): string {
     case 'spore':
       return `/mycelium?spore=${encodeURIComponent(result.id)}`;
     case 'plan':
-      return result.session_id ? `/sessions/${result.session_id}` : '/sessions';
+      return result.session_id
+        ? `/sessions/${result.session_id}?tab=plans&plan=${encodeURIComponent(result.id)}`
+        : '/sessions';
     case 'prompt_batch':
       return result.session_id ? `/sessions/${result.session_id}` : '/sessions';
     case 'activity':

--- a/ui/src/components/sessions/SessionDetail.tsx
+++ b/ui/src/components/sessions/SessionDetail.tsx
@@ -110,7 +110,17 @@ export function SessionDetail({ id }: SessionDetailProps) {
   const triggerRun = useTriggerRun();
   const [summaryStatus, setSummaryStatus] = useState<'idle' | 'running' | 'done' | 'error'>('idle');
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState<TabValue>('conversation');
+
+  // Read initial tab and plan from URL query params (e.g., ?tab=plans&plan=123)
+  const [activeTab, setActiveTab] = useState<TabValue>(() => {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('tab') === 'plans' ? 'plans' : 'conversation';
+  });
+  const [expandedPlanId] = useState<string | null>(() => {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('plan');
+  });
+
   const deleteSession = useDeleteSession();
   const { data: impact } = useSessionImpact(deleteOpen ? id : null);
   const { data: plans } = useSessionPlans(id);
@@ -267,7 +277,7 @@ export function SessionDetail({ id }: SessionDetailProps) {
         </div>
 
         {activeTab === 'conversation' && <BatchTimeline sessionId={id} />}
-        {activeTab === 'plans' && <SessionPlans sessionId={id} />}
+        {activeTab === 'plans' && <SessionPlans sessionId={id} expandedPlanId={expandedPlanId} />}
       </div>
 
       <ConfirmDialog

--- a/ui/src/components/sessions/SessionPlans.tsx
+++ b/ui/src/components/sessions/SessionPlans.tsx
@@ -45,10 +45,11 @@ function PlanStatusBadge({ status }: { status: string }) {
 
 interface PlanCardProps {
   plan: SessionPlanRow;
+  initialExpanded?: boolean;
 }
 
-function PlanCard({ plan }: PlanCardProps) {
-  const [expanded, setExpanded] = useState(false);
+function PlanCard({ plan, initialExpanded = false }: PlanCardProps) {
+  const [expanded, setExpanded] = useState(initialExpanded);
 
   const checklist = useMemo(
     () => plan.content ? parseChecklist(plan.content) : null,
@@ -129,9 +130,10 @@ function PlanCard({ plan }: PlanCardProps) {
 
 export interface SessionPlansProps {
   sessionId: string;
+  expandedPlanId?: string | null;
 }
 
-export function SessionPlans({ sessionId }: SessionPlansProps) {
+export function SessionPlans({ sessionId, expandedPlanId }: SessionPlansProps) {
   const { data: plans, isLoading, isError } = useSessionPlans(sessionId);
 
   if (isLoading) {
@@ -161,7 +163,7 @@ export function SessionPlans({ sessionId }: SessionPlansProps) {
   return (
     <div className="space-y-3">
       {plans.map(plan => (
-        <PlanCard key={plan.id} plan={plan} />
+        <PlanCard key={plan.id} plan={plan} initialExpanded={String(plan.id) === expandedPlanId} />
       ))}
     </div>
   );

--- a/ui/src/hooks/use-update-status.ts
+++ b/ui/src/hooks/use-update-status.ts
@@ -1,0 +1,65 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { usePowerQuery } from './use-power-query';
+import { fetchJson, postJson, putJson } from '../lib/api';
+import { POLL_INTERVALS } from '../lib/constants';
+
+/* ---------- Types ---------- */
+
+export interface UpdateStatus {
+  exempt: boolean;
+  running_version: string;
+  update_available?: boolean;
+  latest_version?: string;
+  latest_stable?: string;
+  latest_beta?: string | null;
+  channel?: string;
+  check_interval_hours?: number;
+  last_check?: string;
+  error?: string | null;
+}
+
+interface ApplyResponse {
+  status: string;
+  version: string;
+}
+
+/* ---------- Query ---------- */
+
+const UPDATE_QUERY_KEY = ['update-status'] as const;
+
+export function useUpdateStatus() {
+  return usePowerQuery<UpdateStatus>({
+    queryKey: [...UPDATE_QUERY_KEY],
+    queryFn: ({ signal }) => fetchJson<UpdateStatus>('/update/status', { signal }),
+    refetchInterval: POLL_INTERVALS.UPDATE,
+    pollCategory: 'standard',
+  });
+}
+
+/* ---------- Mutations ---------- */
+
+export function useUpdateCheck() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => postJson<UpdateStatus>('/update/check'),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...UPDATE_QUERY_KEY] });
+    },
+  });
+}
+
+export function useUpdateApply() {
+  return useMutation({
+    mutationFn: () => postJson<ApplyResponse>('/update/apply'),
+  });
+}
+
+export function useUpdateChannel() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (channel: string) => putJson<UpdateStatus>('/update/channel', { channel }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...UPDATE_QUERY_KEY] });
+    },
+  });
+}

--- a/ui/src/layout/Layout.tsx
+++ b/ui/src/layout/Layout.tsx
@@ -23,6 +23,7 @@ import {
   X,
 } from 'lucide-react';
 import { useTheme } from '../providers/theme';
+import { useUpdateStatus } from '../hooks/use-update-status';
 import { useFont, type FontOption } from '../providers/font';
 import { useDaemon } from '../hooks/use-daemon';
 import { useRestart } from '../hooks/use-restart';
@@ -295,6 +296,7 @@ function SidebarContent({
   onSearchOpen,
   onCollapseToggle,
   showCollapseToggle,
+  updateAvailable,
 }: {
   collapsed: boolean;
   vaultName: string | undefined;
@@ -303,6 +305,7 @@ function SidebarContent({
   onSearchOpen: () => void;
   onCollapseToggle?: () => void;
   showCollapseToggle: boolean;
+  updateAvailable: boolean;
 }) {
   return (
     <>
@@ -371,6 +374,9 @@ function SidebarContent({
           >
             <item.icon className="h-4 w-4 shrink-0" />
             {!collapsed && item.label}
+            {item.to === '/operations' && updateAvailable && (
+              <span className="h-2 w-2 rounded-full bg-secondary shrink-0 ml-auto" />
+            )}
           </NavLink>
         ))}
       </nav>
@@ -414,6 +420,8 @@ export default function Layout() {
   const vaultName = stats?.vault.name;
   const [searchOpen, setSearchOpen] = useState(false);
   const drawer = useMobileDrawer();
+  const { data: updateData } = useUpdateStatus();
+  const updateAvailable = !!(updateData && !updateData.exempt && updateData.update_available);
 
   // Register Cmd+K / Ctrl+K global shortcut
   useEffect(() => {
@@ -498,6 +506,7 @@ export default function Layout() {
             setDensity={setDensity}
             onSearchOpen={openSearch}
             showCollapseToggle={false}
+            updateAvailable={updateAvailable}
           />
         </aside>
       )}
@@ -518,6 +527,7 @@ export default function Layout() {
             onSearchOpen={openSearch}
             onCollapseToggle={toggle}
             showCollapseToggle={true}
+            updateAvailable={updateAvailable}
           />
         </aside>
       )}

--- a/ui/src/layout/Layout.tsx
+++ b/ui/src/layout/Layout.tsx
@@ -288,11 +288,33 @@ function DensityControl({ density, setDensity }: { density: Density; setDensity:
 
 /* ---------- Sidebar content (shared between mobile and desktop) ---------- */
 
-/** Self-contained badge dot for the Operations nav item. */
-function UpdateBadge() {
+/** Self-contained Operations nav link — owns update polling, controls link target and badge. */
+function OperationsNavLink({ collapsed }: { collapsed: boolean }) {
   const { data } = useUpdateStatus();
-  if (!data || data.exempt || !data.update_available) return null;
-  return <span className="h-2 w-2 rounded-full bg-secondary shrink-0 ml-auto" />;
+  const hasUpdate = !!(data && !data.exempt && data.update_available);
+  const to = hasUpdate ? '/operations?tab=system' : '/operations';
+
+  return (
+    <NavLink
+      to={to}
+      title={collapsed ? 'Operations' : undefined}
+      className={({ isActive }) =>
+        cn(
+          'flex items-center rounded-md text-sm font-medium transition-colors',
+          collapsed ? 'justify-center px-2 py-2' : 'gap-3 px-3 py-2',
+          isActive
+            ? 'bg-primary/10 text-primary'
+            : 'text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface',
+        )
+      }
+    >
+      <Wrench className="h-4 w-4 shrink-0" />
+      {!collapsed && 'Operations'}
+      {hasUpdate && (
+        <span className="h-2 w-2 rounded-full bg-secondary shrink-0 ml-auto" />
+      )}
+    </NavLink>
+  );
 }
 
 function SidebarContent({
@@ -361,27 +383,30 @@ function SidebarContent({
 
       {/* Navigation */}
       <nav className="flex-1 space-y-1 px-2 py-2" aria-label="Main navigation">
-        {NAV_ITEMS.map((item) => (
-          <NavLink
-            key={item.to}
-            to={item.to}
-            end={item.to === '/'}
-            title={collapsed ? item.label : undefined}
-            className={({ isActive }) =>
-              cn(
-                'flex items-center rounded-md text-sm font-medium transition-colors',
-                collapsed ? 'justify-center px-2 py-2' : 'gap-3 px-3 py-2',
-                isActive
-                  ? 'bg-primary/10 text-primary'
-                  : 'text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface',
-              )
-            }
-          >
-            <item.icon className="h-4 w-4 shrink-0" />
-            {!collapsed && item.label}
-            {item.to === '/operations' && <UpdateBadge />}
-          </NavLink>
-        ))}
+        {NAV_ITEMS.map((item) =>
+          item.to === '/operations' ? (
+            <OperationsNavLink key={item.to} collapsed={collapsed} />
+          ) : (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              end={item.to === '/'}
+              title={collapsed ? item.label : undefined}
+              className={({ isActive }) =>
+                cn(
+                  'flex items-center rounded-md text-sm font-medium transition-colors',
+                  collapsed ? 'justify-center px-2 py-2' : 'gap-3 px-3 py-2',
+                  isActive
+                    ? 'bg-primary/10 text-primary'
+                    : 'text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface',
+                )
+              }
+            >
+              <item.icon className="h-4 w-4 shrink-0" />
+              {!collapsed && item.label}
+            </NavLink>
+          ),
+        )}
       </nav>
 
       {/* Footer */}

--- a/ui/src/layout/Layout.tsx
+++ b/ui/src/layout/Layout.tsx
@@ -288,6 +288,13 @@ function DensityControl({ density, setDensity }: { density: Density; setDensity:
 
 /* ---------- Sidebar content (shared between mobile and desktop) ---------- */
 
+/** Self-contained badge dot for the Operations nav item. */
+function UpdateBadge() {
+  const { data } = useUpdateStatus();
+  if (!data || data.exempt || !data.update_available) return null;
+  return <span className="h-2 w-2 rounded-full bg-secondary shrink-0 ml-auto" />;
+}
+
 function SidebarContent({
   collapsed,
   vaultName,
@@ -296,7 +303,6 @@ function SidebarContent({
   onSearchOpen,
   onCollapseToggle,
   showCollapseToggle,
-  updateAvailable,
 }: {
   collapsed: boolean;
   vaultName: string | undefined;
@@ -305,7 +311,6 @@ function SidebarContent({
   onSearchOpen: () => void;
   onCollapseToggle?: () => void;
   showCollapseToggle: boolean;
-  updateAvailable: boolean;
 }) {
   return (
     <>
@@ -374,9 +379,7 @@ function SidebarContent({
           >
             <item.icon className="h-4 w-4 shrink-0" />
             {!collapsed && item.label}
-            {item.to === '/operations' && updateAvailable && (
-              <span className="h-2 w-2 rounded-full bg-secondary shrink-0 ml-auto" />
-            )}
+            {item.to === '/operations' && <UpdateBadge />}
           </NavLink>
         ))}
       </nav>
@@ -420,8 +423,6 @@ export default function Layout() {
   const vaultName = stats?.vault.name;
   const [searchOpen, setSearchOpen] = useState(false);
   const drawer = useMobileDrawer();
-  const { data: updateData } = useUpdateStatus();
-  const updateAvailable = !!(updateData && !updateData.exempt && updateData.update_available);
 
   // Register Cmd+K / Ctrl+K global shortcut
   useEffect(() => {
@@ -506,7 +507,6 @@ export default function Layout() {
             setDensity={setDensity}
             onSearchOpen={openSearch}
             showCollapseToggle={false}
-            updateAvailable={updateAvailable}
           />
         </aside>
       )}
@@ -527,7 +527,6 @@ export default function Layout() {
             onSearchOpen={openSearch}
             onCollapseToggle={toggle}
             showCollapseToggle={true}
-            updateAvailable={updateAvailable}
           />
         </aside>
       )}

--- a/ui/src/lib/constants.ts
+++ b/ui/src/lib/constants.ts
@@ -3,6 +3,7 @@ export const POLL_INTERVALS = {
   STATS: 10_000,
   LOGS: 3_000,
   PROGRESS: 1_000,
+  UPDATE: 300_000,
 } as const;
 
 export const STALE_TIME = 10_000;

--- a/ui/src/pages/Operations.tsx
+++ b/ui/src/pages/Operations.tsx
@@ -15,6 +15,7 @@ import { Badge } from '../components/ui/badge';
 import { cn } from '../lib/cn';
 import { BackupCard } from '../components/operations/BackupCard';
 import { UpdateCard } from '../components/operations/UpdateCard';
+import type { Tab } from '../components/ui/tab-switcher';
 
 /* ---------- Constants ---------- */
 
@@ -26,6 +27,32 @@ const SCROLL_BOTTOM_THRESHOLD_PX = 40;
 
 /** Number of recent data points to show in stat card sparklines. */
 const SPARKLINE_HISTORY_LENGTH = 20;
+
+/* ---------- Tabs ---------- */
+
+type ActiveTab = 'embedding' | 'system';
+
+const OPERATIONS_TABS: Tab[] = [
+  { id: 'embedding', label: 'Embedding' },
+  { id: 'system', label: 'System' },
+];
+
+const VALID_TABS = new Set<ActiveTab>(['embedding', 'system']);
+const PARAM_TAB = 'tab';
+
+function readTabFromUrl(): ActiveTab {
+  const params = new URLSearchParams(window.location.search);
+  const raw = params.get(PARAM_TAB);
+  return raw && VALID_TABS.has(raw as ActiveTab) ? (raw as ActiveTab) : 'embedding';
+}
+
+function writeTabToUrl(tab: ActiveTab): void {
+  const params = new URLSearchParams();
+  if (tab !== 'embedding') params.set(PARAM_TAB, tab);
+  const search = params.toString();
+  const url = search ? `${window.location.pathname}?${search}` : window.location.pathname;
+  window.history.replaceState(null, '', url);
+}
 
 /* ---------- Types ---------- */
 
@@ -146,10 +173,9 @@ function EmbeddingLogRow({ entry }: { entry: LogEntry }) {
   );
 }
 
-/* ---------- Operations Page ---------- */
+/* ---------- Embedding Tab ---------- */
 
-export default function Operations() {
-  const { data, isLoading, isError, error } = useEmbeddingDetails();
+function EmbeddingTab({ data }: { data: EmbeddingDetails }) {
   const queryClient = useQueryClient();
   const [actionResult, setActionResult] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
@@ -157,14 +183,12 @@ export default function Operations() {
   const [totalHistory, setTotalHistory] = useState<number[]>([]);
 
   useEffect(() => {
-    if (data) {
-      setTotalHistory((prev) => {
-        const next = [...prev, data.total];
-        return next.length > SPARKLINE_HISTORY_LENGTH
-          ? next.slice(-SPARKLINE_HISTORY_LENGTH)
-          : next;
-      });
-    }
+    setTotalHistory((prev) => {
+      const next = [...prev, data.total];
+      return next.length > SPARKLINE_HISTORY_LENGTH
+        ? next.slice(-SPARKLINE_HISTORY_LENGTH)
+        : next;
+    });
   }, [data]);
 
   // --- Embedding log feed ---
@@ -306,159 +330,193 @@ export default function Operations() {
   }
 
   // --- Aggregate totals ---
-  const totalPending = data ? Object.values(data.pending).reduce((a, b) => a + b, 0) : 0;
-  const totalStale = data
-    ? Object.values(data.by_namespace).reduce((a, ns) => a + ns.stale, 0)
-    : 0;
+  const totalPending = Object.values(data.pending).reduce((a, b) => a + b, 0);
+  const totalStale = Object.values(data.by_namespace).reduce((a, ns) => a + ns.stale, 0);
+
+  return (
+    <div className="space-y-6">
+      {/* Provider status bar */}
+      <div className="flex flex-wrap items-center gap-4 font-sans text-sm">
+        <div className="flex items-center gap-2">
+          <Cpu className="h-4 w-4 text-primary" />
+          <span className="text-on-surface-variant">Provider</span>
+          <span className="font-mono text-on-surface">{data.provider.name}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-on-surface-variant">Model</span>
+          <span className="font-mono text-xs text-on-surface truncate max-w-[200px]" title={data.provider.model}>
+            {data.provider.model}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className={cn('h-2 w-2 rounded-full', statusDotColor(data))} />
+          <span className="text-on-surface-variant capitalize">{statusLabel(data)}</span>
+        </div>
+      </div>
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <StatCard label="Total Vectors" value={String(data.total)} sparklineData={totalHistory} accent="sage" />
+        <StatCard label="Pending" value={String(totalPending)} accent={totalPending > 0 ? 'ochre' : 'outline'} />
+        <StatCard label="Stale" value={String(totalStale)} accent={totalStale > 0 ? 'terracotta' : 'outline'} />
+      </div>
+
+      {/* Namespace breakdown */}
+      <Surface level="low" className="p-6 space-y-4">
+        <SectionHeader>Namespace Breakdown</SectionHeader>
+        <NamespaceTable data={data} />
+      </Surface>
+
+      {/* Action toolbar */}
+      <Surface level="low" className="p-6 space-y-3">
+        <SectionHeader>Actions</SectionHeader>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="ghost" size="sm" onClick={handleReembedStale}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Re-embed stale
+          </Button>
+          <Button variant="ghost" size="sm" onClick={handleCleanOrphans}>
+            <Trash2 className="mr-2 h-4 w-4" />
+            Clean orphans
+          </Button>
+          <Button variant="secondary" size="sm" onClick={handleReconcile}>
+            <Play className="mr-2 h-4 w-4" />
+            Force reconcile
+          </Button>
+          <Button variant="destructive" size="sm" onClick={handleRebuild}>
+            <RotateCcw className="mr-2 h-4 w-4" />
+            Rebuild all
+          </Button>
+        </div>
+
+        {/* Action result message */}
+        {actionResult && (
+          <p
+            className={cn(
+              'font-sans text-sm',
+              actionResult.type === 'success' ? 'text-primary' : 'text-tertiary',
+            )}
+          >
+            {actionResult.text}
+          </p>
+        )}
+      </Surface>
+
+      {/* Activity log — recessed terminal feel */}
+      <Surface level="low" className="flex flex-col overflow-hidden">
+        <div className="flex items-center justify-between px-6 py-4">
+          <SectionHeader>Activity Log</SectionHeader>
+          <Button
+            size="sm"
+            variant={autoScroll ? 'default' : 'ghost'}
+            className="h-7 gap-1.5 px-2 text-xs"
+            onClick={() => {
+              if (autoScroll) {
+                setAutoScroll(false);
+              } else {
+                scrollToBottom();
+              }
+            }}
+            title={autoScroll ? 'Pause auto-scroll' : 'Resume auto-scroll'}
+          >
+            {autoScroll ? <Pause className="h-3 w-3" /> : <Play className="h-3 w-3" />}
+            {autoScroll ? 'Pause' : 'Resume'}
+          </Button>
+        </div>
+        <div className="relative flex-1 p-0">
+          <div
+            ref={scrollRef}
+            onScroll={handleScroll}
+            className="h-64 overflow-y-auto font-mono text-xs bg-surface-container-lowest"
+          >
+            {filteredEntries.length === 0 ? (
+              <div className="flex h-32 items-center justify-center font-sans text-on-surface-variant">
+                No embedding log entries
+              </div>
+            ) : (
+              <table className="w-full border-collapse" aria-label="Embedding activity log">
+                <tbody>
+                  {filteredEntries.map((entry, idx) => (
+                    <EmbeddingLogRow key={`${entry.timestamp}-${idx}`} entry={entry} />
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+
+          {/* "New entries below" indicator */}
+          {hasNewEntries && !autoScroll && (
+            <button
+              type="button"
+              onClick={scrollToBottom}
+              className={cn(
+                'absolute bottom-4 left-1/2 -translate-x-1/2',
+                'flex items-center gap-1.5 rounded-full',
+                'bg-surface-container-high px-3 py-1.5 text-xs font-medium shadow-ambient',
+                'text-on-surface-variant transition-colors hover:text-on-surface',
+              )}
+            >
+              <ArrowDown className="h-3 w-3" />
+              New entries below
+            </button>
+          )}
+        </div>
+      </Surface>
+    </div>
+  );
+}
+
+/* ---------- System Tab ---------- */
+
+function SystemTab() {
+  return (
+    <div className="space-y-6">
+      <UpdateCard />
+      <BackupCard />
+    </div>
+  );
+}
+
+/* ---------- Operations Page ---------- */
+
+const TAB_SUBTITLES: Record<ActiveTab, string> = {
+  embedding: 'Embedding health, maintenance actions, and activity log',
+  system: 'Software updates and backup management',
+};
+
+export default function Operations() {
+  const { data, isLoading, isError, error } = useEmbeddingDetails();
+  const [activeTab, setActiveTab] = useState<ActiveTab>(readTabFromUrl);
+
+  const handleTabChange = useCallback((tabId: string) => {
+    const tab = tabId as ActiveTab;
+    setActiveTab(tab);
+    writeTabToUrl(tab);
+  }, []);
 
   return (
     <PageLoading
       isLoading={isLoading}
       error={isError ? (error instanceof Error ? error : new Error('Unable to reach daemon')) : null}
-      loadingText="Loading embedding details..."
+      loadingText="Loading operations..."
     >
       {data && (
         <div className="flex h-full flex-col">
-          {/* Header */}
+          {/* Header with tabs */}
           <div className="px-6 pt-6">
-            <PageHeader title="Operations" subtitle="Embedding health, maintenance actions, and activity log" />
+            <PageHeader
+              title="Operations"
+              subtitle={TAB_SUBTITLES[activeTab]}
+              tabs={OPERATIONS_TABS}
+              activeTab={activeTab}
+              onTabChange={handleTabChange}
+            />
           </div>
 
           <div className="flex-1 overflow-auto">
-            <div className="space-y-6 px-6 pb-6">
-              {/* Provider status bar */}
-              <div className="flex flex-wrap items-center gap-4 font-sans text-sm">
-                <div className="flex items-center gap-2">
-                  <Cpu className="h-4 w-4 text-primary" />
-                  <span className="text-on-surface-variant">Provider</span>
-                  <span className="font-mono text-on-surface">{data.provider.name}</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className="text-on-surface-variant">Model</span>
-                  <span className="font-mono text-xs text-on-surface truncate max-w-[200px]" title={data.provider.model}>
-                    {data.provider.model}
-                  </span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <div className={cn('h-2 w-2 rounded-full', statusDotColor(data))} />
-                  <span className="text-on-surface-variant capitalize">{statusLabel(data)}</span>
-                </div>
-              </div>
-
-              {/* Stat cards */}
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                <StatCard label="Total Vectors" value={String(data.total)} sparklineData={totalHistory} accent="sage" />
-                <StatCard label="Pending" value={String(totalPending)} accent={totalPending > 0 ? 'ochre' : 'outline'} />
-                <StatCard label="Stale" value={String(totalStale)} accent={totalStale > 0 ? 'terracotta' : 'outline'} />
-              </div>
-
-              {/* Namespace breakdown */}
-              <Surface level="low" className="p-6 space-y-4">
-                <SectionHeader>Namespace Breakdown</SectionHeader>
-                <NamespaceTable data={data} />
-              </Surface>
-
-              {/* Action toolbar */}
-              <Surface level="low" className="p-6 space-y-3">
-                <SectionHeader>Actions</SectionHeader>
-                <div className="flex flex-wrap gap-2">
-                  <Button variant="ghost" size="sm" onClick={handleReembedStale}>
-                    <RefreshCw className="mr-2 h-4 w-4" />
-                    Re-embed stale
-                  </Button>
-                  <Button variant="ghost" size="sm" onClick={handleCleanOrphans}>
-                    <Trash2 className="mr-2 h-4 w-4" />
-                    Clean orphans
-                  </Button>
-                  <Button variant="secondary" size="sm" onClick={handleReconcile}>
-                    <Play className="mr-2 h-4 w-4" />
-                    Force reconcile
-                  </Button>
-                  <Button variant="destructive" size="sm" onClick={handleRebuild}>
-                    <RotateCcw className="mr-2 h-4 w-4" />
-                    Rebuild all
-                  </Button>
-                </div>
-
-                {/* Action result message */}
-                {actionResult && (
-                  <p
-                    className={cn(
-                      'font-sans text-sm',
-                      actionResult.type === 'success' ? 'text-primary' : 'text-tertiary',
-                    )}
-                  >
-                    {actionResult.text}
-                  </p>
-                )}
-              </Surface>
-
-              {/* Update */}
-              <UpdateCard />
-
-              {/* Backup & Restore */}
-              <BackupCard />
-
-              {/* Activity log — recessed terminal feel */}
-              <Surface level="low" className="flex flex-col overflow-hidden">
-                <div className="flex items-center justify-between px-6 py-4">
-                  <SectionHeader>Activity Log</SectionHeader>
-                  <Button
-                    size="sm"
-                    variant={autoScroll ? 'default' : 'ghost'}
-                    className="h-7 gap-1.5 px-2 text-xs"
-                    onClick={() => {
-                      if (autoScroll) {
-                        setAutoScroll(false);
-                      } else {
-                        scrollToBottom();
-                      }
-                    }}
-                    title={autoScroll ? 'Pause auto-scroll' : 'Resume auto-scroll'}
-                  >
-                    {autoScroll ? <Pause className="h-3 w-3" /> : <Play className="h-3 w-3" />}
-                    {autoScroll ? 'Pause' : 'Resume'}
-                  </Button>
-                </div>
-                <div className="relative flex-1 p-0">
-                  <div
-                    ref={scrollRef}
-                    onScroll={handleScroll}
-                    className="h-64 overflow-y-auto font-mono text-xs bg-surface-container-lowest"
-                  >
-                    {filteredEntries.length === 0 ? (
-                      <div className="flex h-32 items-center justify-center font-sans text-on-surface-variant">
-                        No embedding log entries
-                      </div>
-                    ) : (
-                      <table className="w-full border-collapse" aria-label="Embedding activity log">
-                        <tbody>
-                          {filteredEntries.map((entry, idx) => (
-                            <EmbeddingLogRow key={`${entry.timestamp}-${idx}`} entry={entry} />
-                          ))}
-                        </tbody>
-                      </table>
-                    )}
-                  </div>
-
-                  {/* "New entries below" indicator */}
-                  {hasNewEntries && !autoScroll && (
-                    <button
-                      type="button"
-                      onClick={scrollToBottom}
-                      className={cn(
-                        'absolute bottom-4 left-1/2 -translate-x-1/2',
-                        'flex items-center gap-1.5 rounded-full',
-                        'bg-surface-container-high px-3 py-1.5 text-xs font-medium shadow-ambient',
-                        'text-on-surface-variant transition-colors hover:text-on-surface',
-                      )}
-                    >
-                      <ArrowDown className="h-3 w-3" />
-                      New entries below
-                    </button>
-                  )}
-                </div>
-              </Surface>
+            <div className="px-6 pb-6">
+              {activeTab === 'embedding' && <EmbeddingTab data={data} />}
+              {activeTab === 'system' && <SystemTab />}
             </div>
           </div>
         </div>

--- a/ui/src/pages/Operations.tsx
+++ b/ui/src/pages/Operations.tsx
@@ -14,6 +14,7 @@ import { Button } from '../components/ui/button';
 import { Badge } from '../components/ui/badge';
 import { cn } from '../lib/cn';
 import { BackupCard } from '../components/operations/BackupCard';
+import { UpdateCard } from '../components/operations/UpdateCard';
 
 /* ---------- Constants ---------- */
 
@@ -391,6 +392,9 @@ export default function Operations() {
                   </p>
                 )}
               </Surface>
+
+              {/* Update */}
+              <UpdateCard />
 
               {/* Backup & Restore */}
               <BackupCard />


### PR DESCRIPTION
## Summary

This pull request introduces a new self-update API for the daemon, refactors related constants, and improves support for detached project updates. The most significant changes are the addition of update API handlers, extraction of update-related constants, and enhancements to the update CLI for project path flexibility.

**Self-update API and infrastructure:**

* Added a new `src/daemon/api/update.ts` module that implements API handlers for checking update status, forcing update checks, applying updates, and switching release channels. The handlers are injected into the daemon and handle all update-related API endpoints.
* Registered new update routes (`/api/update/status`, `/api/update/check`, `/api/update/apply`, `/api/update/channel`) in the daemon's main server initialization, wiring them to the new handlers.

**Constants and configuration refactoring:**

* Extracted all update-related constants (such as file paths, intervals, and release channels) into a new `src/constants/update.ts` module, and re-exported them from the main `src/constants.ts` for centralized configuration. [[1]](diffhunk://#diff-38a9116e60cc94c62e6c4d64fce505e74e39f4e2e66c9768e18080db9c66af3fR1-R36) [[2]](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199R366-R385)
* Moved the `RESTART_RESPONSE_FLUSH_MS` constant to `src/constants.ts` for reuse, and updated its usage in the restart and update flows. [[1]](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199R366-R385) [[2]](diffhunk://#diff-55d184acac2dbf12482ec99ef577f5f6588ced018bca0d6d0afdad72e8662b36R6-L12)

**CLI improvements:**

* Enhanced the `myco update` CLI command to support a `--project <path>` argument, allowing update scripts to operate on detached or non-standard project directories. This improves flexibility for update automation. [[1]](diffhunk://#diff-d4fc84a8d2dd32cdaea580560459781d18dba290f6eaa7ac7909c07316f77a15L8-R17) [[2]](diffhunk://#diff-d4fc84a8d2dd32cdaea580560459781d18dba290f6eaa7ac7909c07316f77a15L35-R53)

**Dependency updates:**

* Added `semver` and its type definitions to `package.json` dependencies, which are likely used for version comparison in the update logic.

## Related Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [x] Enhancement / new feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] CI / workflow

## Validation

```bash
make check    # lint + 266 tests
```

## Checklist

- [ ] `make check` passes locally
- [ ] Tests added or updated where behavior changed
- [ ] Docs updated for user-visible changes
- [ ] No magic literals introduced (named constants in `src/constants.ts`)
