### PR TITLE
feat: add `myco open` command to launch dashboard in browser

### DIFF
--- a/.agents/myco-hook.cjs
+++ b/.agents/myco-hook.cjs
@@ -11,8 +11,6 @@ const bin = process.env.MYCO_CMD || 'myco-run';
 try {
   execFileSync(bin, process.argv.slice(2), { stdio: 'inherit' });
 } catch (e) {
-  // Binary not found — Myco not installed, exit silently
   if (e.code === 'ENOENT') process.exit(0);
-  // Command ran but failed — surface the real error
   process.exit(e.status ?? 1);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,7 @@ Commands:
   task <subcommand>        Manage agent task definitions
   team <init|upgrade>      Provision or upgrade team sync infrastructure
   doctor [--fix]          Check vault health and repair issues
+  open                     Open the dashboard in your browser
   restart                  Restart the daemon
   version                  Show plugin version
   mcp                     Start the MCP stdio server
@@ -106,6 +107,7 @@ async function main(): Promise<void> {
       process.exit(1);
       break;
     }
+    case 'open': return (await import('./cli/open.js')).run(args, vaultDir);
     case 'restart': return (await import('./cli/restart.js')).run(args, vaultDir);
     case 'logs': return (await import('./cli/logs.js')).run(args, vaultDir);
     default:

--- a/src/cli/open.ts
+++ b/src/cli/open.ts
@@ -1,5 +1,5 @@
 import { connectToDaemon } from './shared.js';
-import { execFile } from 'node:child_process';
+import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -7,13 +7,22 @@ export async function run(_args: string[], vaultDir: string): Promise<void> {
   await connectToDaemon(vaultDir);
 
   const daemonPath = path.join(vaultDir, 'daemon.json');
-  const info = JSON.parse(fs.readFileSync(daemonPath, 'utf-8'));
-  const url = `http://localhost:${info.port}/`;
+  let port: number;
+  try {
+    const info = JSON.parse(fs.readFileSync(daemonPath, 'utf-8'));
+    port = info.port;
+  } catch {
+    console.error('Could not read daemon.json. Try: myco restart');
+    process.exit(1);
+  }
 
-  const cmd = process.platform === 'darwin' ? 'open'
-    : process.platform === 'win32' ? 'start'
-    : 'xdg-open';
+  const url = `http://localhost:${port}/`;
 
-  execFile(cmd, [url]);
+  // `start` on Windows is a cmd.exe builtin, not an executable — must use exec, not execFile
+  const cmd = process.platform === 'darwin' ? `open ${url}`
+    : process.platform === 'win32' ? `start ${url}`
+    : `xdg-open ${url}`;
+
+  exec(cmd);
   console.log(`Opened ${url}`);
 }

--- a/src/cli/open.ts
+++ b/src/cli/open.ts
@@ -1,0 +1,19 @@
+import { connectToDaemon } from './shared.js';
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export async function run(_args: string[], vaultDir: string): Promise<void> {
+  await connectToDaemon(vaultDir);
+
+  const daemonPath = path.join(vaultDir, 'daemon.json');
+  const info = JSON.parse(fs.readFileSync(daemonPath, 'utf-8'));
+  const url = `http://localhost:${info.port}/`;
+
+  const cmd = process.platform === 'darwin' ? 'open'
+    : process.platform === 'win32' ? 'start'
+    : 'xdg-open';
+
+  execFile(cmd, [url]);
+  console.log(`Opened ${url}`);
+}

--- a/src/symbionts/templates/hook-guard.cjs
+++ b/src/symbionts/templates/hook-guard.cjs
@@ -11,8 +11,6 @@ const bin = process.env.MYCO_CMD || 'myco-run';
 try {
   execFileSync(bin, process.argv.slice(2), { stdio: 'inherit' });
 } catch (e) {
-  // Binary not found — Myco not installed, exit silently
   if (e.code === 'ENOENT') process.exit(0);
-  // Command ran but failed — surface the real error
   process.exit(e.status ?? 1);
 }


### PR DESCRIPTION
Ensures the daemon is running (starts it if needed), reads the port
from daemon.json, and opens the dashboard URL in the default browser.
Works on macOS (open), Windows (start), and Linux (xdg-open).

This pull request introduces a new CLI command to open the dashboard in the browser and makes minor improvements to error handling in hook scripts. The most significant change is the addition of the `open` command, which programmatically launches the dashboard URL based on the daemon's configuration.

New feature: Dashboard open command

* Added a new `open` command to the CLI, which opens the dashboard in the user's default browser by reading the port from `daemon.json` and launching the appropriate command for the user's platform (`open`, `start`, or `xdg-open`). (`src/cli.ts`, `src/cli/open.ts`, [[1]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR29) [[2]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR110) [[3]](diffhunk://#diff-ade673bd3bade5f5d51e5402b253762e1614dbdf3aaca9158ee40078d1cb0782R1-R28)

Improvements to error handling

* Removed unnecessary comments in the error handling logic for both `.agents/myco-hook.cjs` and `src/symbionts/templates/hook-guard.cjs`, making the code cleaner while maintaining the same behavior for handling missing binaries and command failures.

## Related Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [ ] Enhancement / new feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] CI / workflow

## Validation

```bash
make check    # lint + 266 tests
```

## Checklist

- [ ] `make check` passes locally
- [ ] Tests added or updated where behavior changed
- [ ] Docs updated for user-visible changes
- [ ] No magic literals introduced (named constants in `src/constants.ts`)
