### PR TITLE
refactor: enhance team sync functionality and error handling

### DIFF
--- a/.agents/skills/cross-platform-hook-guard/SKILL.md
+++ b/.agents/skills/cross-platform-hook-guard/SKILL.md
@@ -1,126 +1,222 @@
 ---
 name: myco:cross-platform-hook-guard
-description: Use this skill when adding, updating, or debugging the cross-platform hook guard (`.agents/myco-hook.cjs`) in this project. Activates whenever you need to ensure Myco's agent hooks work safely across all contributor environments — including Windows (PowerShell, cmd.exe, Git Bash), macOS, and Linux — without breaking contributors who don't have Myco installed. Apply this skill even if the user doesn't explicitly mention cross-platform concerns; any time you're touching symbiont hook templates, `SymbiontInstaller`, or the `.agents/myco-hook.cjs` file itself, this skill applies. Also relevant when onboarding a new symbiont agent that needs hook integration.
+description: >
+  Use this skill when adding, updating, or debugging the cross-platform hook guard
+  (`.agents/myco-hook.cjs`) in this project. Activates whenever you need to ensure
+  Myco's agent hooks work safely across all contributor environments — including
+  Windows (PowerShell, cmd.exe, Git Bash), macOS, and Linux — without breaking
+  contributors who don't have Myco installed. Apply this skill even if the user
+  doesn't explicitly mention cross-platform concerns; any time you're touching
+  symbiont hook templates, `SymbiontInstaller`, or the `.agents/myco-hook.cjs`
+  file itself, this skill applies. Also relevant when onboarding a new symbiont
+  agent that needs hook integration.
 managed_by: myco
-user-invocable: false
-allowed-tools:
-  - Read
-  - Edit
-  - Write
-  - Bash
-  - Grep
-  - Glob
+user-invocable: true
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
 ---
 
 # Implementing the Cross-Platform Hook Guard for OSS Safety
 
-## Why This Exists
-
-Each AI agent symbiont uses a different shell on Windows:
-- **Claude Code** always uses Git Bash (POSIX works)
-- **Gemini CLI** uses PowerShell (`command -v` fails, needs `Get-Command`)
-- **Codex CLI** disables hooks on Windows entirely
-
-A single POSIX guard (`command -v myco-run ...`) in committed hook config silently fails for Gemini users on Windows.
-
-Install-time platform detection doesn't solve this either. Detecting `process.platform` during `myco init` generates a guard correct for the *installer's* machine, but hook configs (`.claude/settings.json`, `.cursor/hooks.json`, etc.) are committed to the repo. A Mac developer commits a POSIX guard; a Windows contributor clones and runs Gemini — the guard fails silently on their machine.
-
 ## Prerequisites
 
-- `.agents/myco-hook.cjs` exists in the project root `.agents/` directory
-- All symbiont hook configs invoke it as: `node .agents/myco-hook.cjs hook <event-name>`
-- `MYCO_AGENT_SESSION` is set in the environment for all executor `query()` calls (see Step 2)
+- Node.js available in the project (guaranteed by all AI agent symbionts)
+- Access to `.agents/myco-hook.cjs` and symbiont manifest files
+- Familiarity with the `.agents/` directory conventions
+
+---
+
+## Background: Why This Architecture
+
+### The shell matrix problem
+
+Each symbiont uses a different shell on Windows:
+- **Claude Code** — always uses Git Bash (POSIX works)
+- **Gemini CLI** — uses PowerShell (`command -v` fails; needs `Get-Command`)
+- **Codex CLI** — disables hooks on Windows entirely
+
+A single POSIX guard in committed hook config silently fails for Gemini users on Windows.
+
+### Why install-time detection fails for OSS
+
+Detecting `process.platform` during `myco init` generates a guard correct for the
+*installer's* machine, but hook config files (`.claude/settings.json`, etc.) are
+committed to the repo. A Mac developer installs and commits a POSIX guard; a Windows
+contributor clones and runs Gemini CLI — the committed guard fails in their PowerShell
+environment. Install-time conflates the installer's machine with every contributor's machine.
+
+### The solution: `.agents/myco-hook.cjs`
+
+A Node.js script committed to the repo, invoked as:
+```
+node .agents/myco-hook.cjs hook session-start
+```
+
+It wraps `myco-run`, silently exits (code 0) on ENOENT or exit 127 (not installed),
+and surfaces real errors. Works in bash, PowerShell, cmd.exe, and Git Bash — anywhere
+Node.js runs. Node is guaranteed available because all AI agent symbionts already
+require it.
+
+The `.cjs` extension is **required**: Myco's `package.json` uses `"type": "module"`
+(ESM default), so `.js` files default to ESM. The hook guard uses `require()` and
+synchronous `fs` calls (CommonJS). Using `.js` causes Node to throw
+`require is not defined in ES module scope`. The `.cjs` extension explicitly overrides
+the ESM default.
+
+The file is managed by `myco update` to stay current and mirrors the existing
+`.agents/skills/` convention.
+
+---
 
 ## Steps
 
-### 1. The Guard Script Structure
+### 1. Create `.agents/myco-hook.cjs`
 
-`.agents/myco-hook.cjs` must be:
-- **CommonJS (`.cjs` extension)** — The project `package.json` uses `"type": "module"`, making `.js` files default to ESM. The hook guard uses `require()` and synchronous `fs` calls (no top-level `await`). Using `.js` causes Node to throw `require is not defined in ES module scope`. The `.cjs` extension explicitly overrides the ESM default.
-- **A committed file, not a symlink** — A symlink into Myco's install directory breaks in the exact scenario the guard protects against (Myco not installed). The file must run standalone with zero Myco dependency for the not-installed path.
-- **Managed by `myco update`** — Never edit it directly in consumer repos; `myco update` keeps it current.
+The guard has four implementation decisions:
 
-### 2. Agent Session Filtering (Re-Entrancy Guard)
+**Error taxonomy — what to surface vs. silence:**
+- `ENOENT` / exit 127 ("not on PATH") → silent `exit 0`
+- Any other error → surface to user
 
-**Critical — platform behavioral change:** Claude Code changed behavior so hooks and marketplace plugins now fire for *all* SDK sessions, including those using `permissionMode: 'bypassPermissions'`. Previously, bypassPermissions sessions bypassed hook and plugin execution entirely.
+Do NOT use `2>/dev/null || true` — that silently swallows five categories of real
+errors: stale `myco-run` wrapper after uninstall, permission errors, Node.js version
+mismatch (requires Node 22+), vault not initialized, and daemon connection failures.
+All five occur when Myco is *partially installed* and need to reach the user.
 
-Myco's agent executor sessions always use `bypassPermissions`. Without an explicit guard, hooks fire re-entrantly during every agent pipeline `query()` call, loading plugins and calling back into the hook guard in a loop.
+**Distribution — committed `.cjs` file, not a symlink:**
+A symlink into Myco's install directory produces a broken-link error in the exact
+scenario the guard protects against (Myco not installed). The file must run standalone
+with zero Myco dependency for the not-installed path.
 
-The guard script must check for `MYCO_AGENT_SESSION` at the very top, before invoking `myco-run`:
+**Scope — hooks only, not MCP:**
+MCP errors surface once at session start. Hook errors fire on every prompt and every
+tool call — a broken hook floods the user with errors throughout the entire session.
+MCP also requires Myco to be installed; the not-installed silent-skip logic is
+irrelevant for MCP.
 
-```javascript
-// Re-entrancy guard: skip hooks inside agent executor sessions
-if (process.env.MYCO_AGENT_SESSION) {
-  process.exit(0);
+**Deployment:**
+Single `.agents/myco-hook.cjs` installed once; all hook configurations reference it
+via relative paths — no duplication across hook entries. Validate end-to-end by running
+`myco update` against the project itself rather than manually editing hooks.
+
+### 2. Update `SymbiontInstaller` detection
+
+`isMycoHookGroup` detection must match **both** prefixes:
+- New: `node .agents/myco-hook.cjs`
+- Legacy: `myco-run` (for `myco update` transitions from older installs)
+
+Both must be recognized so that `myco update` correctly identifies existing hook groups
+during reinstall.
+
+### 3. Wire Cursor symbiont hooks (format reference)
+
+Cursor hooks live at `.cursor/hooks.json` (standalone file, not embedded in settings)
+with 9 lifecycle events in flat camelCase format — **identical structure to Windsurf**:
+
+```json
+{
+  "version": 1,
+  "sessionStart": [...],
+  "beforeSubmitPrompt": [...],
+  "postToolUse": [...],
+  "postToolUseFailure": [...],
+  "stop": [...],
+  "sessionEnd": [...],
+  "subagentStart": [...],
+  "subagentStop": [...],
+  "preCompact": [...]
 }
 ```
 
-`executor.ts` sets `MYCO_AGENT_SESSION=1` in the environment for every `query()` call. Any hook invocation that sees this variable is an agent pipeline run — exit silently with code 0.
+Top-level `version: 1` field is required. Because the format matches Windsurf, the
+existing flat-hook installer path handles Cursor without modification — only a new
+template and `hooksTarget: .cursor/hooks.json` in the manifest are needed.
 
-### 3. Error Taxonomy: What to Surface vs Silence
+### 4. Protect internal SDK calls from re-entrancy
 
-**Silent exit (code 0):**
-- `ENOENT` — `myco-run` not found on PATH (Myco not installed)
-- Exit code 127 — command not found (shell form of ENOENT)
+Claude Code changed `bypassPermissions` mode so that hooks and marketplace plugins now
+fire for **all** SDK sessions — including agent-executor sessions that previously
+bypassed them entirely. This triggers re-entrant behavior: internal runs are captured
+as user sessions and unwanted browser launches occur.
 
-**Surface to user (non-zero exit):**
-1. Stale `myco-run` wrapper after uninstall — binary on PATH but Myco removed
-2. Permission errors — `myco-run` exists but not executable (corrupted install, missing `chmod +x`)
-3. Node.js version mismatch — Myco requires Node 22+; older versions crash on optional chaining/top-level await
-4. Vault not initialized — `myco init` never ran; binary and daemon present but vault missing
-5. Daemon connection failures — socket stale or daemon crashed
+**Two SDK controls are required on every internal `query()` call:**
 
-The pattern: `ENOENT`/exit 127 means "not installed" → silent. Anything else means "installed but broken" → surface to the user.
-
-### 4. Scope: Hooks Only, Not MCP
-
-The guard applies to hook commands only. MCP errors surface once at session start (or are silently retried by the client). Hook errors fire on *every prompt and every tool call* — a broken hook floods the user throughout the entire session. MCP also requires Myco to be installed to function, making the not-installed silent-skip logic irrelevant for MCP commands.
-
-### 5. SymbiontInstaller Detection
-
-`isMycoHookGroup()` in `SymbiontInstaller` must recognize both the current and legacy hook command prefixes for backward compatibility during `myco update` transitions:
-- Current: `node .agents/myco-hook.cjs`
-- Legacy: `myco-run` (pre-hook-guard era)
-
-### 6. Cursor Hooks Format
-
-Cursor's hooks system lives at `.cursor/hooks.json` (standalone file, not embedded in settings), with 9 lifecycle events in flat camelCase format — identical structure to Windsurf:
-
-```
-sessionStart, beforeSubmitPrompt, postToolUse, postToolUseFailure,
-stop, sessionEnd, subagentStart, subagentStop, preCompact
+```typescript
+await query({
+  prompt,
+  model,
+  // Re-entrancy isolation — BOTH required:
+  env: { MYCO_AGENT_SESSION: '1' },  // enables hook-guard filtering
+  strictMcpConfig: true,             // disables plugin loading
+  // ...other options
+});
 ```
 
-Top-level `version: 1` field is required. The manifest needs `hooksTarget: .cursor/hooks.json`.
+`bypassPermissions` is **no longer a reliable escape hatch** for suppressing
+hook/plugin execution — it controls permission scope only.
 
-### 7. Testing
+**Call-site completeness is critical.** There are four call sites in the executor
+pipeline that require both options:
+1. Task runner `query()` call
+2. Phase executor `query()` call
+3. Sub-agent `query()` call
+4. **`executor.ts` orchestrator `query()` call** — this was the final gap; its
+   omission caused intermittent session leaks even after the first three were patched
 
-Run `myco update` against the project itself rather than manually editing hook configs. This exercises the real install code path and validates the guard end-to-end. A single `.agents/myco-hook.cjs` is installed once; all hook configurations reference it via relative paths — no duplication across hook entries.
+Missing even one call site causes intermittent re-entrancy that is hard to diagnose
+because it only fires when that specific code path executes.
+
+**Forward-looking rule:** Every new internal `query()` call added to the executor
+pipeline must include both `env: { MYCO_AGENT_SESSION: '1' }` and
+`strictMcpConfig: true` from the start, without exception.
+
+**Audit pattern when adding a new `query()` call:**
+```bash
+grep -r "await query(" src/agent/ --include="*.ts"
+# Verify every result has both MYCO_AGENT_SESSION and strictMcpConfig
+```
+
+### 5. Verify before deploying hook-system changes
+
+For any change to the hook mechanism — guard script content, SDK re-entrancy isolation,
+hook registration — **pre-release smoke testing is non-negotiable**.
+
+An incorrect fix to the hook system breaks all subsequent session captures, not just the
+session under test. The failure mode is silent: sessions stop being recorded, and the
+root cause (broken hook) is invisible to the developer.
+
+Verification protocol before releasing a hook-related hotfix:
+1. Start a fresh Claude Code session in the project
+2. Confirm the session appears in `myco sessions` (capture working)
+3. Confirm no duplicate/re-entrant sessions are created (isolation working)
+4. Only then publish and run `myco update`
+
+---
 
 ## Common Pitfalls
 
-### `bypassPermissions` no longer suppresses hook execution
+**`.js` vs `.cjs` extension**
+Myco uses `"type": "module"` in `package.json`. Using `.js` causes
+`require is not defined in ES module scope`. Always use `.cjs` for the hook guard.
 
-**Platform change (2026-04):** Claude Code hooks and marketplace plugins now fire for *all* SDK sessions, including those using `permissionMode: 'bypassPermissions'`. Previously, bypassPermissions bypassed hook execution entirely.
+**`execFile` vs `exec` for Windows shell builtins**
+`execFile('start', [url])` silently fails on Windows because `start` is a cmd.exe
+shell builtin, not a standalone executable. Use `exec('start ' + url)` or
+`exec('cmd /c start ' + url)` to go through the shell and resolve builtins. Applies
+to the `myco open` CLI Windows branch; the macOS (`open`) and Linux (`xdg-open`)
+branches use standalone executables and work with `execFile`.
 
-Without the `MYCO_AGENT_SESSION` guard (Step 2), Myco's agent executor sessions re-entrantly trigger hooks on every `query()` call, loading marketplace plugins and calling back into the guard. Always check this env var at the very top of the guard script — before any other logic.
+**Incomplete `isMycoHookGroup` detection**
+If you add a new hook prefix or rename the guard script, update `isMycoHookGroup` in
+`SymbiontInstaller` immediately. Missing a prefix means `myco update` fails to
+recognize existing hook groups during reinstall and creates duplicates.
 
-**SDK escape hatches** for consumers who need additional control over hook/plugin execution:
-- `--strict-mcp-config` CLI flag — suppresses hook and plugin loading for the process
-- `plugins` option on `query()` — per-call override to control plugin execution
+**Incomplete call-site audit for MYCO_AGENT_SESSION**
+When patching re-entrancy isolation, grep for ALL `await query(` calls in
+`src/agent/` before declaring the fix complete. The executor.ts orchestrator query was
+missed in the first round, causing persistent intermittent leaks. Three patches is not
+the same as four.
 
-### Using `.js` instead of `.cjs`
-
-The project's `"type": "module"` in `package.json` makes all `.js` files ESM by default. The hook guard's CommonJS `require()` calls throw `require is not defined in ES module scope`. Always use the `.cjs` extension.
-
-### Installing as a symlink
-
-Symlinking into Myco's install directory breaks when Myco is uninstalled — the exact scenario the guard is designed to handle. The file must be committed directly to the repo.
-
-### `execFile('start', [url])` silently fails on Windows
-
-`start` is a cmd.exe shell builtin, not a standalone executable. `execFile` expects a real binary. Use `exec('start ' + url)` or `exec('cmd /c start ' + url)` instead to route through the shell.
-
-### Install-time platform detection for committed hook configs
-
-Generating a platform-specific guard during `myco init` produces a guard correct for the installer's machine only. Hook configs are committed to the repo — every contributor runs them on their own machine. A POSIX guard committed by a Mac developer silently fails for Gemini CLI users on Windows.
+**Assuming `bypassPermissions` suppresses hooks**
+It does not, as of the Claude Code update that changed this behavior.
+`bypassPermissions` controls permission scope only. Re-entrancy isolation requires
+explicit `MYCO_AGENT_SESSION` + `strictMcpConfig` on every internal SDK call.

--- a/.myco/myco.yaml
+++ b/.myco/myco.yaml
@@ -70,6 +70,7 @@ team:
   enabled: true
   worker_url: https://myco-team-974bc350.goondocks.workers.dev
   interval_minutes: 15
+  deployed_worker_version: 0.14.4
 skills:
   confidence_threshold: 0.7
   usage_stale_days: 30
@@ -81,3 +82,7 @@ notifications:
     skills:
       enabled: true
       mode: banner
+    sessions:
+      enabled: false
+    mycelium:
+      enabled: false

--- a/src/cli/team.ts
+++ b/src/cli/team.ts
@@ -12,6 +12,7 @@ import path from 'node:path';
 import { loadConfig, updateTeamConfig } from '../config/loader.js';
 import { writeSecret, readSecrets } from '../config/secrets.js';
 import { resolvePackageRoot } from '../symbionts/detect.js';
+import { getPluginVersion } from '../version.js';
 import { WRANGLER_COMMAND_TIMEOUT_MS, TEAM_API_KEY_SECRET } from '../constants.js';
 
 // ---------------------------------------------------------------------------
@@ -270,6 +271,7 @@ export async function teamInit(vaultDir: string): Promise<void> {
   updateTeamConfig(vaultDir, {
     enabled: true,
     worker_url: workerUrl,
+    deployed_worker_version: getPluginVersion(),
   });
   writeSecret(vaultDir, TEAM_API_KEY_SECRET, apiKey);
 
@@ -279,31 +281,39 @@ export async function teamInit(vaultDir: string): Promise<void> {
   console.log('\nShare the URL and API key with teammates so they can connect.');
 }
 
-export async function teamUpgrade(vaultDir: string): Promise<void> {
-  console.log('Upgrading team sync worker...\n');
+// ---------------------------------------------------------------------------
+// Shared upgrade logic (used by CLI and daemon API)
+// ---------------------------------------------------------------------------
 
+export interface UpgradeResult {
+  success: boolean;
+  worker_url?: string;
+  version?: string;
+  error?: string;
+}
+
+/**
+ * Upgrade the team sync worker: re-copy source, patch config, redeploy.
+ * Returns a result instead of calling process.exit — safe for both CLI and daemon.
+ */
+export function upgradeWorker(vaultDir: string): UpgradeResult {
   const config = loadConfig(vaultDir);
   if (!config.team.worker_url) {
-    console.error('No team sync configured. Run: myco team init');
-    process.exit(1);
+    return { success: false, error: 'No team sync configured. Run: myco team init' };
   }
 
   const deployDir = path.join(vaultDir, TEAM_WORKER_DIR);
   const tomlPath = path.join(deployDir, 'wrangler.toml');
 
   if (!fs.existsSync(tomlPath)) {
-    console.error('No deployment directory found. Run: myco team init');
-    process.exit(1);
+    return { success: false, error: 'No deployment directory found. Run: myco team init' };
   }
 
   // Read ALL existing resource identifiers from current wrangler.toml.
-  // These are immutable after init — regenerating from projectHash would
-  // break if the hash changed (e.g., after the projectHash bug fix).
   const existingToml = fs.readFileSync(tomlPath, 'utf-8');
   const d1Match = existingToml.match(TOML_DB_ID_REGEX);
   if (!d1Match || d1Match[1] === '<YOUR_D1_DATABASE_ID>') {
-    console.error('Cannot determine D1 database ID from existing deployment. Run: myco team init');
-    process.exit(1);
+    return { success: false, error: 'Cannot determine D1 database ID from existing deployment. Run: myco team init' };
   }
   const d1Id = d1Match[1];
 
@@ -312,11 +322,10 @@ export async function teamUpgrade(vaultDir: string): Promise<void> {
   const indexNameMatch = existingToml.match(/index_name\s*=\s*"([^"]*)"/);
 
   // Re-copy worker source from package (updated code)
-  console.log('Updating worker source...');
   const srcDir = locateWorkerSource();
   fs.cpSync(srcDir, deployDir, { recursive: true });
 
-  // Patch wrangler.toml preserving existing resource names — NOT regenerating
+  // Patch wrangler.toml preserving existing resource names
   let toml = fs.readFileSync(path.join(deployDir, 'wrangler.toml'), 'utf-8');
   const workerName = nameMatch?.[1] ?? resourceName(vaultDir);
   toml = toml.replace(TOML_NAME_REGEX, `name = "${workerName}"`);
@@ -326,7 +335,6 @@ export async function teamUpgrade(vaultDir: string): Promise<void> {
   fs.writeFileSync(path.join(deployDir, 'wrangler.toml'), toml, 'utf-8');
 
   // Re-set API key secret before deploy (deploy can wipe secrets)
-  console.log('Setting API key secret...');
   const secrets = readSecrets(vaultDir);
   const apiKey = secrets[TEAM_API_KEY_SECRET];
   if (apiKey) {
@@ -338,25 +346,40 @@ export async function teamUpgrade(vaultDir: string): Promise<void> {
         stdio: ['pipe', 'pipe', 'pipe'],
         cwd: deployDir,
       });
-      console.log('Secret set\n');
-    } catch (err) {
-      console.warn(`Warning: could not set API key secret: ${(err as Error).message}`);
+    } catch {
+      // Non-fatal — secret may already be set
     }
   }
 
   // Redeploy
-  console.log('Deploying...');
   try {
     const deployOutput = wrangler(['deploy'], { cwd: deployDir });
     const workerUrl = parseWorkerUrl(deployOutput);
-    console.log(`Worker deployed: ${workerUrl}\n`);
+    const version = getPluginVersion();
 
-    // Update URL in config in case it changed
-    updateTeamConfig(vaultDir, { worker_url: workerUrl });
+    updateTeamConfig(vaultDir, {
+      worker_url: workerUrl,
+      deployed_worker_version: version,
+    });
+
+    return { success: true, worker_url: workerUrl, version };
   } catch (err) {
-    console.error(`Failed to deploy worker: ${(err as Error).message}`);
+    return { success: false, error: `Failed to deploy worker: ${(err as Error).message}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI wrapper
+// ---------------------------------------------------------------------------
+
+export async function teamUpgrade(vaultDir: string): Promise<void> {
+  console.log('Upgrading team sync worker...\n');
+  const result = upgradeWorker(vaultDir);
+  if (!result.success) {
+    console.error(result.error);
     process.exit(1);
   }
-
-  console.log('Upgrade complete.');
+  console.log(`Worker deployed: ${result.worker_url}`);
+  console.log(`Version: ${result.version}`);
+  console.log('\nUpgrade complete.');
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -88,6 +88,8 @@ const TeamSchema = z.object({
   team_id: z.string().optional(),
   /** Sync interval in minutes. */
   interval_minutes: z.number().int().min(1).max(1440).default(15),
+  /** Package version of the last deployed worker. Used to detect when an upgrade is needed. */
+  deployed_worker_version: z.string().optional(),
 });
 
 const SkillsSchema = z.object({

--- a/src/constants/log-kinds.ts
+++ b/src/constants/log-kinds.ts
@@ -97,6 +97,8 @@ export const LOG_KINDS = {
   TEAM_SYNC_START: 'team-sync.start',
   TEAM_SYNC_COMPLETE: 'team-sync.complete',
   TEAM_SYNC_ERROR: 'team-sync.error',
+  TEAM_SYNC_RETRY: 'team-sync.retry',
+  TEAM_SYNC_DEAD_LETTER: 'team-sync.dead-letter',
 } as const;
 
 export type LogKind = (typeof LOG_KINDS)[keyof typeof LOG_KINDS];

--- a/src/daemon/api/team-connect.ts
+++ b/src/daemon/api/team-connect.ts
@@ -7,7 +7,7 @@
 
 import { updateTeamConfig, loadConfig } from '@myco/config/loader.js';
 import { writeSecret, readSecrets } from '@myco/config/secrets.js';
-import { countPending } from '@myco/db/queries/team-outbox.js';
+import { countPending, countDeadLettered } from '@myco/db/queries/team-outbox.js';
 import { TeamSyncClient } from '../team-sync.js';
 import { SYNC_PROTOCOL_VERSION, TEAM_API_KEY_SECRET } from '@myco/constants.js';
 import { getPluginVersion } from '@myco/version.js';
@@ -133,8 +133,10 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
     }
 
     let pendingCount = 0;
+    let deadLetterCount = 0;
     try {
       pendingCount = countPending();
+      deadLetterCount = countDeadLettered();
     } catch {
       // DB may not have the table yet
     }
@@ -148,8 +150,13 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
         healthy,
         health_error: healthError,
         pending_sync_count: pendingCount,
+        dead_letter_count: deadLetterCount,
         machine_id: machineId,
         package_version: getPluginVersion(),
+        deployed_worker_version: config.team.deployed_worker_version ?? null,
+        worker_update_available: config.team.enabled
+          ? config.team.deployed_worker_version !== getPluginVersion()
+          : false,
         schema_version: SCHEMA_VERSION,
         sync_protocol_version: SYNC_PROTOCOL_VERSION,
       },

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -30,7 +30,7 @@ import { createTeamHandlers } from './api/team-connect.js';
 import { TeamSyncClient } from './team-sync.js';
 import { initTeamContext, getTeamMachineId } from './team-context.js';
 import { createBackup } from './backup.js';
-import { listPending, markSent, markSourceRowsSynced, pruneOld, backfillUnsynced } from '../db/queries/team-outbox.js';
+import { listPending, markSent, markSourceRowsSynced, pruneOld, backfillUnsynced, incrementRetryCount, countPending, retryDeadLettered } from '../db/queries/team-outbox.js';
 import { readSecrets } from '../config/secrets.js';
 import { ProgressTracker, handleGetProgress } from './api/progress.js';
 import { handleGetModels } from './api/models.js';
@@ -129,6 +129,7 @@ import {
   POWER_ACTIVE_INTERVAL_MS,
   POWER_SLEEP_INTERVAL_MS,
   SYNC_PROTOCOL_VERSION,
+  TEAM_API_KEY_SECRET,
   RESTART_RESPONSE_FLUSH_MS,
   epochSeconds,
   MS_PER_SECOND,
@@ -1867,7 +1868,7 @@ export async function main(): Promise<void> {
   // Initialize team client from saved config if team sync is enabled
   if (config.team.enabled && config.team.worker_url) {
     const secrets = readSecrets(vaultDir);
-    const teamApiKey = secrets['MYCO_TEAM_API_KEY'];
+    const teamApiKey = secrets[TEAM_API_KEY_SECRET];
     if (teamApiKey) {
       teamClient = new TeamSyncClient({
         workerUrl: config.team.worker_url,
@@ -1914,6 +1915,32 @@ export async function main(): Promise<void> {
   server.registerRoute('POST', '/api/team/backfill', async () => {
     const count = backfillUnsynced(machineId);
     return { body: { enqueued: count } };
+  });
+
+  server.registerRoute('POST', '/api/team/retry-failed', async () => {
+    const count = retryDeadLettered();
+    return { body: { retried: count } };
+  });
+
+  server.registerRoute('POST', '/api/team/upgrade-worker', async () => {
+    const { upgradeWorker } = await import('../cli/team.js');
+    const result = upgradeWorker(vaultDir);
+    if (!result.success) {
+      return { status: 500, body: { error: result.error } };
+    }
+    // Reinitialize team client with potentially new URL
+    if (result.worker_url && teamClient) {
+      const apiKey = readSecrets(vaultDir)[TEAM_API_KEY_SECRET];
+      if (apiKey) {
+        teamClient = new TeamSyncClient({
+          workerUrl: result.worker_url,
+          apiKey,
+          machineId,
+          syncProtocolVersion: SYNC_PROTOCOL_VERSION,
+        });
+      }
+    }
+    return { body: result };
   });
 
   // --- Search, activity feed, and embedding status ---
@@ -2017,37 +2044,49 @@ export async function main(): Promise<void> {
 
   // Team outbox flush: push pending records to the team worker
   if (config.team.enabled) {
+    const logDeadLettered = (ids: number[]) => {
+      if (ids.length > 0) {
+        logger.error(LOG_KINDS.TEAM_SYNC_DEAD_LETTER, `Dead-lettered ${ids.length} records after max retries`, { ids });
+      }
+    };
+
     powerManager.register({
       name: 'team-sync-flush',
-      runIn: ['active', 'idle'],
+      runIn: ['active', 'idle', 'sleep'],
+      preventsDeepSleep: () => countPending() > 0,
       fn: async () => {
         const client = teamClient;
         if (!client) return;
 
-        try {
-          const pending = listPending();
-          if (pending.length === 0) return;
+        const pending = listPending();
+        if (pending.length === 0) return;
 
+        try {
           logger.info(LOG_KINDS.TEAM_SYNC_START, 'Flushing outbox', { count: pending.length });
           const result = await client.pushBatch(pending);
+          const now = epochSeconds();
 
           // Mark successfully synced records as sent
-          if (result.synced > 0 || result.skipped > 0) {
-            // Identify which records failed so we only mark the successes
-            const failedIds = new Set(result.errors.map((e) => e.id));
-            const sentRecords = pending.filter((r) => !failedIds.has(String(r.row_id)));
-            const sentIds = sentRecords.map((r) => r.id);
-            if (sentIds.length > 0) {
-              const now = epochSeconds();
-              markSent(sentIds, now);
-              markSourceRowsSynced(sentRecords, now);
-            }
+          const failedIds = new Set(result.errors.map((e) => e.id));
+          const sentRecords = pending.filter((r) => !failedIds.has(String(r.row_id)));
+          const sentIds = sentRecords.map((r) => r.id);
+          if (sentIds.length > 0) {
+            markSent(sentIds, now);
+            markSourceRowsSynced(sentRecords, now);
           }
 
+          // Increment retry count on per-record failures
           if (result.errors.length > 0) {
-            logger.warn(LOG_KINDS.TEAM_SYNC_ERROR, `Sync errors: ${result.errors.length}`, {
+            const failedOutboxIds = pending
+              .filter((r) => failedIds.has(String(r.row_id)))
+              .map((r) => r.id);
+            const deadLettered = incrementRetryCount(failedOutboxIds, now);
+
+            logger.warn(LOG_KINDS.TEAM_SYNC_RETRY, `Retrying ${failedOutboxIds.length} records`, {
               errors: result.errors.slice(0, 5),
             });
+
+            logDeadLettered(deadLettered);
           }
 
           pruneOld();
@@ -2055,6 +2094,18 @@ export async function main(): Promise<void> {
             synced: result.synced, skipped: result.skipped, errors: result.errors.length, total: pending.length,
           });
         } catch (err) {
+          // Batch-level failure: increment retry count on all records
+          try {
+            const now = epochSeconds();
+            const allIds = pending.map((r) => r.id);
+            const deadLettered = incrementRetryCount(allIds, now);
+
+            logger.warn(LOG_KINDS.TEAM_SYNC_RETRY, `Batch failed, retrying ${allIds.length} records`, {
+              error: (err as Error).message,
+            });
+
+            logDeadLettered(deadLettered);
+          } catch { /* best-effort retry tracking */ }
           logger.error(LOG_KINDS.TEAM_SYNC_ERROR, 'Outbox flush failed', { error: (err as Error).message });
         }
       },

--- a/src/daemon/power.ts
+++ b/src/daemon/power.ts
@@ -7,6 +7,8 @@ export interface PowerJob {
   name: string;
   runIn: PowerState[];
   fn: () => Promise<void>;
+  /** When true, prevents transition from sleep → deep_sleep. */
+  preventsDeepSleep?: () => boolean;
 }
 
 export interface PowerManagerConfig {
@@ -26,6 +28,7 @@ export class PowerManager {
   private running = false;
   private config: PowerManagerConfig;
   private logger: DaemonLogger;
+  private deepSleepHeld = false;
 
   constructor(config: PowerManagerConfig) {
     this.config = config;
@@ -38,6 +41,7 @@ export class PowerManager {
 
   recordActivity(): void {
     this.lastActivity = Date.now();
+    this.deepSleepHeld = false;
 
     if (this.state === 'deep_sleep') {
       this.logger.info(LOG_KINDS.POWER_STATE, 'Waking from deep sleep');
@@ -75,7 +79,17 @@ export class PowerManager {
     let target: PowerState;
 
     if (idleMs >= this.config.deepSleepThresholdMs) {
-      target = 'deep_sleep';
+      const blocker = this.jobs.find((j) => j.preventsDeepSleep?.());
+      if (blocker) {
+        target = 'sleep';
+        if (!this.deepSleepHeld) {
+          this.deepSleepHeld = true;
+          this.logger.info(LOG_KINDS.POWER_STATE, 'Deep sleep held', { by: blocker.name });
+        }
+      } else {
+        target = 'deep_sleep';
+        this.deepSleepHeld = false;
+      }
     } else if (idleMs >= this.config.sleepThresholdMs) {
       target = 'sleep';
     } else if (idleMs >= this.config.idleThresholdMs) {

--- a/src/db/queries/team-outbox.ts
+++ b/src/db/queries/team-outbox.ts
@@ -21,6 +21,9 @@ const BURST_BATCH_SIZE = 200;
 /** Age in seconds after which sent records are pruned (24 hours). */
 const SENT_PRUNE_AGE_SECONDS = 86_400;
 
+/** Max retry attempts before a record is dead-lettered. */
+export const MAX_OUTBOX_RETRIES = 10;
+
 /** Milliseconds-per-second multiplier for epoch math. */
 const MS_PER_SECOND = 1000;
 
@@ -48,6 +51,8 @@ export interface OutboxRow {
   machine_id: string;
   created_at: number;
   sent_at: number | null;
+  retry_count: number;
+  last_attempt_at: number | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -63,6 +68,8 @@ const OUTBOX_COLUMNS = [
   'machine_id',
   'created_at',
   'sent_at',
+  'retry_count',
+  'last_attempt_at',
 ] as const;
 
 const SELECT_COLUMNS = OUTBOX_COLUMNS.join(', ');
@@ -82,6 +89,8 @@ function toOutboxRow(row: Record<string, unknown>): OutboxRow {
     machine_id: row.machine_id as string,
     created_at: row.created_at as number,
     sent_at: (row.sent_at as number) ?? null,
+    retry_count: (row.retry_count as number) ?? 0,
+    last_attempt_at: (row.last_attempt_at as number) ?? null,
   };
 }
 
@@ -151,10 +160,10 @@ export function listPending(limit?: number): OutboxRow[] {
   const rows = db.prepare(
     `SELECT ${SELECT_COLUMNS}
      FROM team_outbox
-     WHERE sent_at IS NULL
+     WHERE sent_at IS NULL AND retry_count < ?
      ORDER BY created_at ASC
      LIMIT ?`,
-  ).all(limit ?? BURST_BATCH_SIZE) as Record<string, unknown>[];
+  ).all(MAX_OUTBOX_RETRIES, limit ?? BURST_BATCH_SIZE) as Record<string, unknown>[];
 
   return rows.map(toOutboxRow);
 }
@@ -194,6 +203,62 @@ export function markForRetry(ids: number[]): void {
 }
 
 /**
+ * Increment retry_count and set last_attempt_at for failed outbox records.
+ *
+ * @returns IDs of records that have now reached MAX_OUTBOX_RETRIES (newly dead-lettered).
+ */
+export function incrementRetryCount(ids: number[], attemptAt: number): number[] {
+  if (ids.length === 0) return [];
+
+  const db = getDatabase();
+  const placeholders = ids.map(() => '?').join(', ');
+
+  db.prepare(
+    `UPDATE team_outbox
+     SET retry_count = retry_count + 1, last_attempt_at = ?
+     WHERE id IN (${placeholders})`,
+  ).run(attemptAt, ...ids);
+
+  // Return IDs that just hit the threshold
+  const deadLettered = db.prepare(
+    `SELECT id FROM team_outbox
+     WHERE id IN (${placeholders}) AND retry_count >= ?`,
+  ).all(...ids, MAX_OUTBOX_RETRIES) as Array<{ id: number }>;
+
+  return deadLettered.map((r) => r.id);
+}
+
+/**
+ * Reset all dead-lettered records back to pending for retry.
+ *
+ * @returns the number of records reset.
+ */
+export function retryDeadLettered(): number {
+  const db = getDatabase();
+
+  const info = db.prepare(
+    `UPDATE team_outbox
+     SET retry_count = 0, last_attempt_at = NULL
+     WHERE sent_at IS NULL AND retry_count >= ?`,
+  ).run(MAX_OUTBOX_RETRIES);
+
+  return info.changes;
+}
+
+/**
+ * Count dead-lettered outbox records (exceeded max retries, never sent).
+ */
+export function countDeadLettered(): number {
+  const db = getDatabase();
+
+  const row = db.prepare(
+    `SELECT COUNT(*) as count FROM team_outbox WHERE sent_at IS NULL AND retry_count >= ?`,
+  ).get(MAX_OUTBOX_RETRIES) as { count: number };
+
+  return row.count;
+}
+
+/**
  * Prune old outbox records.
  *
  * Removes sent records older than 24 hours.
@@ -219,8 +284,8 @@ export function countPending(): number {
   const db = getDatabase();
 
   const row = db.prepare(
-    `SELECT COUNT(*) as count FROM team_outbox WHERE sent_at IS NULL`,
-  ).get() as { count: number };
+    `SELECT COUNT(*) as count FROM team_outbox WHERE sent_at IS NULL AND retry_count < ?`,
+  ).get(MAX_OUTBOX_RETRIES) as { count: number };
 
   return row.count;
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -17,7 +17,7 @@ import type { Database } from 'better-sqlite3';
 import { epochSeconds, DEFAULT_MACHINE_ID } from '@myco/constants.js';
 
 /** Current schema version -- fresh start for the SQLite era. */
-export const SCHEMA_VERSION = 8;
+export const SCHEMA_VERSION = 9;
 
 // Re-export for backwards compat (other modules import from schema.ts)
 export { DEFAULT_MACHINE_ID };
@@ -349,7 +349,9 @@ const TEAM_OUTBOX_TABLE = `
     payload     TEXT NOT NULL,
     machine_id  TEXT NOT NULL,
     created_at  INTEGER NOT NULL,
-    sent_at     INTEGER
+    sent_at     INTEGER,
+    retry_count    INTEGER NOT NULL DEFAULT 0,
+    last_attempt_at INTEGER
   )`;
 
 // -- Logging Layer ----------------------------------------------------------
@@ -1151,6 +1153,33 @@ function migrateV7ToV8(db: Database): void {
 }
 
 /**
+ * Version 9 adds retry tracking to the team outbox:
+ *   - retry_count INTEGER NOT NULL DEFAULT 0
+ *   - last_attempt_at INTEGER
+ *
+ * Records exceeding the max retry count are dead-lettered (excluded from
+ * pending queries) so they don't block the sync flush or deep sleep.
+ */
+function migrateV8ToV9(db: Database): void {
+  db.exec('BEGIN');
+  try {
+    db.exec('ALTER TABLE team_outbox ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0');
+    db.exec('ALTER TABLE team_outbox ADD COLUMN last_attempt_at INTEGER');
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at)
+       VALUES (?, ?)
+       ON CONFLICT (version) DO NOTHING`,
+    ).run(9, epochSeconds());
+
+    db.exec('COMMIT');
+  } catch (err) {
+    db.exec('ROLLBACK');
+    throw err;
+  }
+}
+
+/**
  * @param db — better-sqlite3 Database instance.
  * @param machineId — machine identifier for backfilling existing rows during
  *   v3→v4 and v6→v7 migrations. Defaults to `'local'` (tests, init).
@@ -1207,6 +1236,13 @@ export function createSchema(db: Database, machineId: string = DEFAULT_MACHINE_I
     ).get() as { version: number } | undefined)?.version ?? 0;
     if (afterV6Migration < 8) {
       migrateV7ToV8(db);
+    }
+    // Migration path: version 8 → 9
+    const afterV7Migration = (db.prepare(
+      'SELECT version FROM schema_version ORDER BY version DESC LIMIT 1'
+    ).get() as { version: number } | undefined)?.version ?? 0;
+    if (afterV7Migration < 9) {
+      migrateV8ToV9(db);
     }
     return;
   } catch {

--- a/src/worker/src/schema.ts
+++ b/src/worker/src/schema.ts
@@ -229,6 +229,7 @@ const SKILL_USAGE_TABLE = `
     skill_id        TEXT NOT NULL,
     session_id      TEXT NOT NULL,
     detected_at     INTEGER NOT NULL,
+    synced_at       INTEGER,
     PRIMARY KEY (id, machine_id)
   )`;
 
@@ -284,9 +285,22 @@ const ALL_DDLS = [
 
 /**
  * Create all D1 tables and indexes. Fully idempotent via IF NOT EXISTS.
+ * Includes ALTER TABLE migrations for columns added after initial deployment.
  */
 export async function initD1Schema(db: D1Database): Promise<void> {
   const statements = [...ALL_DDLS, ...SECONDARY_INDEXES];
   const batch = statements.map((sql) => db.prepare(sql));
   await db.batch(batch);
+
+  // Migrations for existing tables (safe to re-run — silently ignored if column exists)
+  const migrations = [
+    'ALTER TABLE skill_usage ADD COLUMN synced_at INTEGER',
+  ];
+  for (const sql of migrations) {
+    try {
+      await db.prepare(sql).run();
+    } catch {
+      // Column already exists — expected after first run
+    }
+  }
 }

--- a/tests/daemon/power.test.ts
+++ b/tests/daemon/power.test.ts
@@ -114,6 +114,39 @@ describe('PowerManager', () => {
     );
   });
 
+  it('preventsDeepSleep holds state at sleep when predicate returns true', () => {
+    const holdFn = vi.fn().mockReturnValue(true);
+    pm.register({
+      name: 'blocker',
+      runIn: ['active', 'idle', 'sleep'],
+      fn: vi.fn().mockResolvedValue(undefined),
+      preventsDeepSleep: holdFn,
+    });
+
+    pm.start();
+    vi.advanceTimersByTime(91_000);
+    expect(pm.getState()).toBe('sleep');
+    expect(holdFn).toHaveBeenCalled();
+  });
+
+  it('transitions to deep_sleep once preventsDeepSleep returns false', () => {
+    let pending = true;
+    pm.register({
+      name: 'blocker',
+      runIn: ['active', 'idle', 'sleep'],
+      fn: vi.fn().mockResolvedValue(undefined),
+      preventsDeepSleep: () => pending,
+    });
+
+    pm.start();
+    vi.advanceTimersByTime(91_000);
+    expect(pm.getState()).toBe('sleep');
+
+    pending = false;
+    vi.advanceTimersByTime(5_100);
+    expect(pm.getState()).toBe('deep_sleep');
+  });
+
   it('stops timer on deep_sleep and restarts on activity', async () => {
     const jobFn = vi.fn().mockResolvedValue(undefined);
     pm.register({ name: 'test', runIn: ['active'], fn: jobFn });

--- a/tests/db/queries/team-outbox.test.ts
+++ b/tests/db/queries/team-outbox.test.ts
@@ -11,6 +11,9 @@ import {
   markForRetry,
   pruneOld,
   countPending,
+  incrementRetryCount,
+  countDeadLettered,
+  MAX_OUTBOX_RETRIES,
 } from '@myco/db/queries/team-outbox.js';
 import type { OutboxInsert } from '@myco/db/queries/team-outbox.js';
 
@@ -254,6 +257,101 @@ describe('team outbox query helpers', () => {
 
       enqueueOutbox(makeOutbox());
       expect(countPending()).toBe(2);
+    });
+
+    it('excludes dead-lettered records', () => {
+      const row = enqueueOutbox(makeOutbox());
+      // Push retry count to max
+      for (let i = 0; i < MAX_OUTBOX_RETRIES; i++) {
+        incrementRetryCount([row.id], epochNow());
+      }
+
+      expect(countPending()).toBe(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // incrementRetryCount
+  // ---------------------------------------------------------------------------
+
+  describe('incrementRetryCount', () => {
+    it('increments retry_count and sets last_attempt_at', () => {
+      const row = enqueueOutbox(makeOutbox());
+      const now = epochNow();
+
+      incrementRetryCount([row.id], now);
+
+      const pending = listPending();
+      expect(pending).toHaveLength(1);
+      expect(pending[0].retry_count).toBe(1);
+      expect(pending[0].last_attempt_at).toBe(now);
+    });
+
+    it('returns empty when no records reach max retries', () => {
+      const row = enqueueOutbox(makeOutbox());
+      const deadLettered = incrementRetryCount([row.id], epochNow());
+
+      expect(deadLettered).toEqual([]);
+    });
+
+    it('returns ids of newly dead-lettered records', () => {
+      const row = enqueueOutbox(makeOutbox());
+      // Increment to one below max
+      for (let i = 0; i < MAX_OUTBOX_RETRIES - 1; i++) {
+        incrementRetryCount([row.id], epochNow());
+      }
+
+      // This push should dead-letter it
+      const deadLettered = incrementRetryCount([row.id], epochNow());
+      expect(deadLettered).toEqual([row.id]);
+    });
+
+    it('does nothing for empty ids array', () => {
+      enqueueOutbox(makeOutbox());
+      const deadLettered = incrementRetryCount([], epochNow());
+
+      expect(deadLettered).toEqual([]);
+      expect(listPending()).toHaveLength(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // dead-lettering (listPending / countDeadLettered)
+  // ---------------------------------------------------------------------------
+
+  describe('dead-lettering', () => {
+    it('listPending excludes records at max retries', () => {
+      const row = enqueueOutbox(makeOutbox());
+      for (let i = 0; i < MAX_OUTBOX_RETRIES; i++) {
+        incrementRetryCount([row.id], epochNow());
+      }
+
+      expect(listPending()).toHaveLength(0);
+    });
+
+    it('countDeadLettered counts records at max retries', () => {
+      expect(countDeadLettered()).toBe(0);
+
+      const row = enqueueOutbox(makeOutbox());
+      for (let i = 0; i < MAX_OUTBOX_RETRIES; i++) {
+        incrementRetryCount([row.id], epochNow());
+      }
+
+      expect(countDeadLettered()).toBe(1);
+    });
+
+    it('dead-lettered records are not returned by listPending but counted by countDeadLettered', () => {
+      const good = enqueueOutbox(makeOutbox());
+      const bad = enqueueOutbox(makeOutbox());
+
+      for (let i = 0; i < MAX_OUTBOX_RETRIES; i++) {
+        incrementRetryCount([bad.id], epochNow());
+      }
+
+      expect(listPending()).toHaveLength(1);
+      expect(listPending()[0].id).toBe(good.id);
+      expect(countPending()).toBe(1);
+      expect(countDeadLettered()).toBe(1);
     });
   });
 });

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -38,7 +38,7 @@ describe('Database schema', () => {
 
   describe('constants', () => {
     it('exports SCHEMA_VERSION as a positive integer', () => {
-      expect(SCHEMA_VERSION).toBe(8);
+      expect(SCHEMA_VERSION).toBe(9);
       expect(Number.isInteger(SCHEMA_VERSION)).toBe(true);
     });
 

--- a/ui/src/hooks/use-team.ts
+++ b/ui/src/hooks/use-team.ts
@@ -10,6 +10,9 @@ export interface TeamStatusResponse {
   healthy: boolean;
   health_error?: string;
   pending_sync_count: number;
+  dead_letter_count: number;
+  deployed_worker_version: string | null;
+  worker_update_available: boolean;
   machine_id: string;
   package_version: string;
   schema_version: number;

--- a/ui/src/pages/Logs.tsx
+++ b/ui/src/pages/Logs.tsx
@@ -27,11 +27,22 @@ function timeRangeToFrom(range: string): string {
 // ---------------------------------------------------------------------------
 
 export default function Logs() {
-  const [mode, setMode] = useState<LogMode>('live');
-  const [searchValue, setSearchValue] = useState('');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [activeLevel, setActiveLevel] = useState<LogLevel>('debug');
-  const [activeComponents, setActiveComponents] = useState<Set<string>>(new Set());
+  // Hydrate initial state from URL query params (deep-link support)
+  const initialParams = useMemo(() => {
+    const sp = new URLSearchParams(window.location.search);
+    const components = sp.get('component')?.split(',').filter(Boolean) ?? [];
+    const level = sp.get('level') as LogLevel | null;
+    const q = sp.get('q') ?? '';
+    // If any filter param is present, start in search mode
+    const hasFilters = components.length > 0 || !!level || !!q;
+    return { components, level, q, hasFilters };
+  }, []);
+
+  const [mode, setMode] = useState<LogMode>(initialParams.hasFilters ? 'search' : 'live');
+  const [searchValue, setSearchValue] = useState(initialParams.q);
+  const [searchQuery, setSearchQuery] = useState(initialParams.q);
+  const [activeLevel, setActiveLevel] = useState<LogLevel>(initialParams.level ?? 'debug');
+  const [activeComponents, setActiveComponents] = useState<Set<string>>(new Set(initialParams.components));
   const [timeRange, setTimeRange] = useState('24h');
   const [page, setPage] = useState(1);
   const [selectedEntry, setSelectedEntry] = useState<LogEntry | null>(null);
@@ -55,7 +66,7 @@ export default function Logs() {
   const { data: detailData } = useLogDetail(selectedEntry?.id ?? null);
 
   // Discover components from entries
-  const [knownComponents, setKnownComponents] = useState<string[]>([]);
+  const [knownComponents, setKnownComponents] = useState<string[]>(initialParams.components);
   useEffect(() => {
     const source = mode === 'live' ? liveEntries : (searchData?.entries ?? []);
     setKnownComponents((prev) => {

--- a/ui/src/pages/Team.tsx
+++ b/ui/src/pages/Team.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { Users, Wifi, WifiOff, RefreshCw, Copy, Check, Eye, EyeOff } from 'lucide-react';
+import { Wifi, WifiOff, RefreshCw, Copy, Check, Eye, EyeOff, ArrowUpCircle } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTeamStatus, type TeamStatusResponse } from '../hooks/use-team';
 import { postJson } from '../lib/api';
@@ -160,6 +160,10 @@ function ConnectedStatus({ status }: { status: TeamStatusResponse }) {
   const [disconnecting, setDisconnecting] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [syncMessage, setSyncMessage] = useState<string | null>(null);
+  const [upgrading, setUpgrading] = useState(false);
+  const [upgradeMessage, setUpgradeMessage] = useState<string | null>(null);
+  const [retrying, setRetrying] = useState(false);
+  const [retryMessage, setRetryMessage] = useState<string | null>(null);
 
   const handleDisconnect = async () => {
     setDisconnecting(true);
@@ -189,8 +193,79 @@ function ConnectedStatus({ status }: { status: TeamStatusResponse }) {
     }
   }, [queryClient]);
 
+  const handleUpgradeWorker = useCallback(async () => {
+    setUpgrading(true);
+    setUpgradeMessage(null);
+    try {
+      const res = await postJson<{ success: boolean; worker_url?: string; version?: string; error?: string }>('/team/upgrade-worker');
+      if (res.success) {
+        setUpgradeMessage(`Worker updated to v${res.version}`);
+        queryClient.invalidateQueries({ queryKey: ['team-status'] });
+      } else {
+        setUpgradeMessage(res.error ?? 'Upgrade failed');
+      }
+    } catch (err) {
+      setUpgradeMessage(err instanceof Error ? err.message : 'Upgrade failed');
+    } finally {
+      setUpgrading(false);
+    }
+  }, [queryClient]);
+
+  const handleRetryFailed = useCallback(async () => {
+    setRetrying(true);
+    setRetryMessage(null);
+    try {
+      const res = await postJson<{ retried: number }>('/team/retry-failed');
+      setRetryMessage(
+        res.retried > 0
+          ? `Re-queued ${res.retried} record${res.retried > 1 ? 's' : ''} for sync.`
+          : 'No failed records to retry.',
+      );
+      queryClient.invalidateQueries({ queryKey: ['team-status'] });
+    } catch {
+      setRetryMessage('Retry failed.');
+    } finally {
+      setRetrying(false);
+    }
+  }, [queryClient]);
+
   return (
     <div className="space-y-4">
+      {/* Worker update banner */}
+      {status.worker_update_available && (
+        <Surface level="low" ghostBorder className="p-4 border-l-2 border-l-ochre">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <ArrowUpCircle className="h-5 w-5 text-ochre flex-shrink-0" />
+              <div>
+                <p className="text-sm font-medium text-on-surface">Worker update available</p>
+                <p className="text-xs text-on-surface-variant">
+                  Deployed: v{status.deployed_worker_version ?? '?'} — Local: v{status.package_version}
+                </p>
+              </div>
+            </div>
+            <Button
+              variant="default"
+              size="sm"
+              onClick={handleUpgradeWorker}
+              disabled={upgrading}
+            >
+              {upgrading ? (
+                <>
+                  <RefreshCw className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                  Deploying...
+                </>
+              ) : (
+                'Update Worker'
+              )}
+            </Button>
+          </div>
+          {upgradeMessage && (
+            <p className="text-xs text-on-surface-variant mt-2">{upgradeMessage}</p>
+          )}
+        </Surface>
+      )}
+
       {/* Status overview */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         <StatCard
@@ -200,7 +275,10 @@ function ConnectedStatus({ status }: { status: TeamStatusResponse }) {
         />
         <StatCard
           label="Pending sync"
-          value={status.pending_sync_count}
+          value={String(status.pending_sync_count)}
+          accent={status.dead_letter_count > 0 ? 'terracotta' : 'outline'}
+          sublabel={status.dead_letter_count > 0 ? `${status.dead_letter_count} failed` : undefined}
+          href="/logs?component=team-sync"
         />
         <StatCard
           label="Protocol"
@@ -275,6 +353,25 @@ function ConnectedStatus({ status }: { status: TeamStatusResponse }) {
         </p>
         {syncMessage && (
           <p className="text-sm text-primary">{syncMessage}</p>
+        )}
+        {status.dead_letter_count > 0 && (
+          <div className="flex items-center justify-between pt-2 border-t border-outline-variant/10">
+            <p className="text-xs text-on-surface-variant">
+              <span className="text-tertiary font-medium">{status.dead_letter_count} failed</span> record{status.dead_letter_count > 1 ? 's' : ''} — exceeded max retries.{' '}
+              <a href="/logs?component=team-sync&level=error" className="underline hover:text-on-surface">View logs</a>
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleRetryFailed}
+              disabled={retrying}
+            >
+              {retrying ? 'Retrying...' : 'Retry Failed'}
+            </Button>
+          </div>
+        )}
+        {retryMessage && (
+          <p className="text-xs text-primary">{retryMessage}</p>
         )}
       </Surface>
 


### PR DESCRIPTION
- Updated the team configuration to include the deployed worker version for better tracking.
- Implemented retry logic for failed sync records, allowing for dead-lettering of records that exceed maximum retry attempts.
- Enhanced the team sync API to support worker upgrades and retrying failed records.
- Improved logging for team sync operations, including new log kinds for retries and dead-lettered records.
- Updated database schema to support retry tracking in the team outbox.
- Refactored related tests to ensure coverage for new functionality and error handling.

## Summary

This pull request introduces several improvements and refactors to the cross-platform hook guard documentation and the team sync worker upgrade logic. The main themes are (1) a major rewrite and clarification of the `.agents/skills/cross-platform-hook-guard/SKILL.md` documentation, and (2) a refactor of the team sync worker upgrade process to make it safer, more testable, and more informative.

**Key changes:**

### 1. Cross-platform Hook Guard Documentation Overhaul

- Completely rewrote and expanded `.agents/skills/cross-platform-hook-guard/SKILL.md` for clarity and maintainability. The new version explains the architectural rationale for the hook guard, details common pitfalls, and provides step-by-step implementation and verification instructions. It also clarifies the need for `.cjs` extension, proper error handling, and robust re-entrancy isolation in SDK calls.
- Updated the skill manifest to be more readable (YAML multiline), made the skill user-invocable, and simplified the `allowed-tools` list format.

### 2. Team Sync Worker Upgrade Refactor

- Refactored the team sync worker upgrade logic in `src/cli/team.ts` to use a new `upgradeWorker` function that returns a result object instead of exiting the process, making it reusable in both CLI and daemon contexts. [[1]](diffhunk://#diff-17fc9fe7be13dcb63a26312c9277b7cd7bc5e005b42606d215d00ee900a57fc8L282-R316) [[2]](diffhunk://#diff-17fc9fe7be13dcb63a26312c9277b7cd7bc5e005b42606d215d00ee900a57fc8L341-R384) [[3]](diffhunk://#diff-17fc9fe7be13dcb63a26312c9277b7cd7bc5e005b42606d215d00ee900a57fc8L329) [[4]](diffhunk://#diff-17fc9fe7be13dcb63a26312c9277b7cd7bc5e005b42606d215d00ee900a57fc8L315-R328)
- The upgrade process now updates and records the deployed worker version in both the config file (`.myco/myco.yaml`) and the schema, enabling detection of when an upgrade is needed. [[1]](diffhunk://#diff-17fc9fe7be13dcb63a26312c9277b7cd7bc5e005b42606d215d00ee900a57fc8R274) [[2]](diffhunk://#diff-a25ae601baae9bca444c00d66e4934596768a26eafd5208c8fa077dcf31b4ae9R91-R92) [[3]](diffhunk://#diff-432c34b61f92ab7f8c9e5e9da03000e2c7679531fbe93502e4221eaa60d6a31dR73)
- Improved error handling: the upgrade now safely returns errors instead of terminating the process, and secret-setting failures are treated as non-fatal. [[1]](diffhunk://#diff-17fc9fe7be13dcb63a26312c9277b7cd7bc5e005b42606d215d00ee900a57fc8L282-R316) [[2]](diffhunk://#diff-17fc9fe7be13dcb63a26312c9277b7cd7bc5e005b42606d215d00ee900a57fc8L341-R384)
- Added the current plugin version to the team config on both init and upgrade, and updated related schema definitions and config file. [[1]](diffhunk://#diff-17fc9fe7be13dcb63a26312c9277b7cd7bc5e005b42606d215d00ee900a57fc8R15) [[2]](diffhunk://#diff-17fc9fe7be13dcb63a26312c9277b7cd7bc5e005b42606d215d00ee900a57fc8R274) [[3]](diffhunk://#diff-a25ae601baae9bca444c00d66e4934596768a26eafd5208c8fa077dcf31b4ae9R91-R92) [[4]](diffhunk://#diff-432c34b61f92ab7f8c9e5e9da03000e2c7679531fbe93502e4221eaa60d6a31dR73)

### 3. Notification Settings Update

- Disabled notifications for `sessions` and `mycelium` in `.myco/myco.yaml` to reduce notification noise or for feature rollout control.

## Related Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [x] Enhancement / new feature
- [x] Refactor / code quality
- [ ] Documentation
- [ ] CI / workflow

## Validation

```bash
make check    # lint + 266 tests
```

## Checklist

- [x] `make check` passes locally
- [x] Tests added or updated where behavior changed
- [ ] Docs updated for user-visible changes
- [x] No magic literals introduced (named constants in `src/constants.ts`)
