### PR TITLE
feat(agent): harden skill pipeline for local-model dogfooding

### DIFF
--- a/src/agent/executor.ts
+++ b/src/agent/executor.ts
@@ -34,7 +34,7 @@ import { composeOrchestratorPrompt, parseOrchestratorPlan, applyDirectives, DEFA
 import { executeContextQueries } from './context-queries.js';
 import { buildPhaseEnv } from './provider.js';
 import { resolveRunConfig } from './config-resolver.js';
-import { ensureOllamaContextVariant } from './ollama-context.js';
+import { resolveOllamaContextVariants } from './ollama-context.js';
 import { computeWaves, phaseSessionId } from './wave-computation.js';
 import type { ContextQueryResult } from './context-queries.js';
 import type { ProviderConfig } from './types.js';
@@ -613,11 +613,13 @@ export async function runAgent(
     config,
     definitionsDir,
     taskProviderOverride: resolvedTaskProvider,
-    phaseProviderOverrides,
+    phaseProviderOverrides: resolvedPhaseOverrides,
   } = resolveRunConfig(agentId, requestedTask, vaultDir);
 
-  // Allow mutation for Ollama context variant
+  // Both are mutated by the Ollama variant resolver below — it rewrites
+  // provider.model to the variant name and may reconcile context conflicts.
   let taskProviderOverride = resolvedTaskProvider;
+  let phaseProviderOverrides = resolvedPhaseOverrides;
 
   // 4. Create run record
   const runId = options?.resumeRunId ?? crypto.randomUUID();
@@ -647,14 +649,26 @@ export async function runAgent(
     ...(effectiveProvider?.baseUrl ? { baseUrl: effectiveProvider.baseUrl } : {}),
   };
 
-  // 7. Ensure Ollama model has correct context length (creates variant if needed)
-  if (effectiveProvider?.type === 'ollama' && effectiveProvider.contextLength && effectiveProvider.model) {
-    const variantModel = await ensureOllamaContextVariant(
-      effectiveProvider.model,
-      effectiveProvider.contextLength,
+  // 7. Resolve Ollama context variants across task + phase scopes.
+  //    Applies DEFAULT_OLLAMA_CONTEXT_LENGTH when no value is set, and
+  //    reconciles same-model-different-context conflicts to one variant
+  //    per model (max wins) so Ollama loads each model at most once.
+  //    Non-ollama providers are passed through unchanged.
+  {
+    const resolved = await resolveOllamaContextVariants(
+      taskProviderOverride,
+      phaseProviderOverrides,
     );
-    // Override the model name so the SDK uses the context-aware variant
-    taskProviderOverride = { ...taskProviderOverride!, model: variantModel };
+    taskProviderOverride = resolved.taskProvider;
+    phaseProviderOverrides = resolved.phaseOverrides;
+    for (const conflict of resolved.conflicts) {
+      console.warn(
+        `[agent] Ollama model "${conflict.model}" referenced with conflicting ` +
+        `context_length values [${conflict.values.join(', ')}] — reconciled to ` +
+        `${conflict.resolved} to avoid loading multiple variants. Configure one ` +
+        `value per model to silence this warning.`,
+      );
+    }
   }
 
   // 8. Execute — phased or single query

--- a/src/agent/executor.ts
+++ b/src/agent/executor.ts
@@ -81,6 +81,72 @@ const PROMPT_SECTION_PRIOR_PHASES = '## Prior Phase Results';
 const PROMPT_SECTION_CURRENT_PHASE = '## Current Phase: ';
 
 // ---------------------------------------------------------------------------
+// Per-turn tool-call debug logging
+// ---------------------------------------------------------------------------
+//
+// When MYCO_AGENT_DEBUG=1, every tool_use and tool_result inside a phase is
+// logged to stdout with a short input/output preview. This is intended for
+// diagnosing turn-budget exhaustion: it surfaces rejection loops, malformed
+// tool-call retries, and unexpected exploration that the per-phase
+// `num_turns` summary alone cannot explain.
+//
+// The daemon sets this env var automatically when log_level is "debug"
+// (see src/daemon/main.ts). It can also be set manually for ad-hoc runs.
+
+const DEBUG_TOOL_CALLS = process.env.MYCO_AGENT_DEBUG === '1';
+
+/** Max chars to print from tool input/output payloads. */
+const TOOL_DEBUG_PREVIEW_CHARS = 240;
+
+interface SdkContentBlock {
+  type: string;
+  name?: string;
+  input?: unknown;
+  tool_use_id?: string;
+  content?: unknown;
+  is_error?: boolean;
+}
+
+interface SdkMessageWithContent {
+  message?: { content?: SdkContentBlock[] };
+}
+
+function previewPayload(value: unknown): string {
+  const str = typeof value === 'string' ? value : JSON.stringify(value);
+  if (str === undefined) return '';
+  return str.length > TOOL_DEBUG_PREVIEW_CHARS
+    ? `${str.slice(0, TOOL_DEBUG_PREVIEW_CHARS)}…(${str.length - TOOL_DEBUG_PREVIEW_CHARS} more chars)`
+    : str;
+}
+
+function logToolUseBlocks(phaseName: string, message: unknown): void {
+  if (!DEBUG_TOOL_CALLS) return;
+  const blocks = (message as SdkMessageWithContent).message?.content;
+  if (!Array.isArray(blocks)) return;
+  for (const block of blocks) {
+    if (block.type === 'tool_use') {
+      console.log(
+        `[agent:debug] ${phaseName} tool_use: ${block.name ?? 'unknown'} input=${previewPayload(block.input)}`,
+      );
+    }
+  }
+}
+
+function logToolResultBlocks(phaseName: string, message: unknown): void {
+  if (!DEBUG_TOOL_CALLS) return;
+  const blocks = (message as SdkMessageWithContent).message?.content;
+  if (!Array.isArray(blocks)) return;
+  for (const block of blocks) {
+    if (block.type === 'tool_result') {
+      const flag = block.is_error ? ' [ERROR]' : '';
+      console.log(
+        `[agent:debug] ${phaseName} tool_result${flag}: ${previewPayload(block.content)}`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Prompt composition
 // ---------------------------------------------------------------------------
 
@@ -206,6 +272,10 @@ async function executePhase(
     })) {
       if (message.type === 'assistant') {
         agenticTurns++;
+        logToolUseBlocks(phase.name, message);
+      }
+      if (message.type === 'user') {
+        logToolResultBlocks(phase.name, message);
       }
       if (message.type === 'result') {
         phaseCost = message.total_cost_usd ?? 0;

--- a/src/agent/ollama-context.ts
+++ b/src/agent/ollama-context.ts
@@ -6,9 +6,24 @@ import { execFileSync } from 'node:child_process';
 import { writeFileSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { ProviderConfig } from './types.js';
 
 /** Timeout for Ollama model pre-load request (ms). */
 const OLLAMA_PRELOAD_TIMEOUT_MS = 30_000;
+
+/**
+ * Default context window for Ollama models when no `context_length` is
+ * configured. 32K is comfortably larger than any current agent task prompt
+ * (skill-generate's source-material payload is the worst case and stays
+ * well under 16K) and dramatically smaller than the 128K–256K native
+ * defaults modern Ollama models ship with — which would otherwise allocate
+ * tens of GB of KV cache for context that is never filled.
+ *
+ * Override by setting `context_length` on the provider config, either
+ * globally, per-task, or per-phase (all scopes are reconciled to a single
+ * variant per model — see `resolveOllamaContextVariants`).
+ */
+export const DEFAULT_OLLAMA_CONTEXT_LENGTH = 32768;
 
 /**
  * Ensure an Ollama model variant exists with the desired context length.
@@ -46,4 +61,132 @@ export async function ensureOllamaContextVariant(
   } catch {
     return model; // Fall back to original
   }
+}
+
+// ---------------------------------------------------------------------------
+// Unified variant resolution for task + phase scopes
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-phase provider override shape. Mirrors the record passed through
+ * `runAgent` → `executePhasedQuery`; kept here so the ollama-context module
+ * doesn't have to import executor-internal types.
+ */
+export interface PhaseProviderOverride {
+  provider?: ProviderConfig;
+  maxTurns?: number;
+}
+
+/**
+ * Resolve every Ollama model referenced by a task run into a single variant
+ * per (model) pair and return rewritten providers that point at those
+ * variants.
+ *
+ * Why this exists at all:
+ *   - The runtime default for gemma4:26b and similar modern Ollama models
+ *     is 128K–256K tokens, which allocates tens of GB of KV cache for
+ *     context we never come close to filling. Applying a sensible default
+ *     (32K) on behalf of users who haven't set `context_length` recovers
+ *     that VRAM without changing anything else.
+ *   - Historically the variant-creation call only ran at the task scope,
+ *     so a phase override that pointed at a different Ollama model bypassed
+ *     the variant logic entirely and loaded at native default.
+ *   - If the same model is referenced at multiple scopes with different
+ *     `context_length` values, creating a variant per scope would load the
+ *     same base model multiple times. That's the failure mode this function
+ *     prevents — one (model) → one variant → one Ollama load per run.
+ *
+ * Reconciliation rule: when the same model appears with different
+ * `context_length` values across scopes, the MAX is used. This guarantees
+ * every call site has at least as much context as it asked for, at the cost
+ * of slightly more VRAM than the smallest-asking scope requested. Users who
+ * want scope-specific contexts should use different *models*, not different
+ * context values on the same model.
+ *
+ * Providers that aren't Ollama (cloud, lmstudio) and providers without a
+ * resolved model name pass through unchanged.
+ */
+export async function resolveOllamaContextVariants(
+  taskProvider: ProviderConfig | undefined,
+  phaseOverrides: Record<string, PhaseProviderOverride>,
+  // Injected variant creator for testability. Defaults to the real
+  // `ensureOllamaContextVariant` which shells out to `ollama`; tests pass
+  // a pure stub so the logic can be exercised without the CLI.
+  createVariant: (model: string, contextLength: number) => Promise<string> = ensureOllamaContextVariant,
+): Promise<{
+  taskProvider: ProviderConfig | undefined;
+  phaseOverrides: Record<string, PhaseProviderOverride>;
+  conflicts: Array<{ model: string; values: number[]; resolved: number }>;
+}> {
+  // --- Pass 1: collect ---------------------------------------------------
+  // For each Ollama model we find, track every distinct context value we
+  // saw for it. We need the full set (not just a running max) so we can
+  // report conflicts afterwards.
+  const seen = new Map<string, Set<number>>();
+
+  const recordOllama = (p: ProviderConfig | undefined): void => {
+    if (p?.type !== 'ollama' || !p.model) return;
+    const ctx = p.contextLength ?? DEFAULT_OLLAMA_CONTEXT_LENGTH;
+    const set = seen.get(p.model) ?? new Set<number>();
+    set.add(ctx);
+    seen.set(p.model, set);
+  };
+
+  recordOllama(taskProvider);
+  for (const override of Object.values(phaseOverrides)) {
+    recordOllama(override.provider);
+  }
+
+  // No Ollama providers at all — pass through unchanged.
+  if (seen.size === 0) {
+    return { taskProvider, phaseOverrides, conflicts: [] };
+  }
+
+  // --- Pass 2: reconcile -------------------------------------------------
+  const resolvedContext = new Map<string, number>();
+  const conflicts: Array<{ model: string; values: number[]; resolved: number }> = [];
+  for (const [model, values] of seen) {
+    const sorted = [...values].sort((a, b) => a - b);
+    const max = sorted[sorted.length - 1];
+    resolvedContext.set(model, max);
+    if (sorted.length > 1) {
+      conflicts.push({ model, values: sorted, resolved: max });
+    }
+  }
+
+  // --- Pass 3: create variants in parallel -------------------------------
+  const variantEntries = await Promise.all(
+    [...resolvedContext.entries()].map(async ([model, ctx]) => {
+      const variant = await createVariant(model, ctx);
+      return [model, variant] as const;
+    }),
+  );
+  const variantByModel = new Map(variantEntries);
+
+  // --- Pass 4: rewrite providers -----------------------------------------
+  const rewriteProvider = (p: ProviderConfig | undefined): ProviderConfig | undefined => {
+    if (!p) return p;
+    if (p.type !== 'ollama' || !p.model) return p;
+    const variant = variantByModel.get(p.model);
+    const resolvedCtx = resolvedContext.get(p.model);
+    if (!variant) return p;
+    // Preserve the resolved context_length on the rewritten provider so
+    // downstream code (env var builders, diagnostics) sees the effective
+    // value rather than undefined. Update the model to the variant name.
+    return { ...p, model: variant, contextLength: resolvedCtx };
+  };
+
+  const rewrittenPhaseOverrides: Record<string, PhaseProviderOverride> = {};
+  for (const [name, override] of Object.entries(phaseOverrides)) {
+    rewrittenPhaseOverrides[name] = {
+      ...override,
+      ...(override.provider ? { provider: rewriteProvider(override.provider) } : {}),
+    };
+  }
+
+  return {
+    taskProvider: rewriteProvider(taskProvider),
+    phaseOverrides: rewrittenPhaseOverrides,
+    conflicts,
+  };
 }

--- a/src/agent/tools/skill-tools.ts
+++ b/src/agent/tools/skill-tools.ts
@@ -20,7 +20,12 @@ import {
 } from '@myco/db/queries/skill-records.js';
 import { insertLineage } from '@myco/db/queries/skill-lineage.js';
 import { notify } from '@myco/notifications/notify.js';
-import { validateSkillContent, checkFrontmatterPreservation } from './skill-validator.js';
+import {
+  validateSkillContent,
+  checkFrontmatterPreservation,
+  descriptionSimilarity,
+  DESCRIPTION_DUPLICATE_THRESHOLD,
+} from './skill-validator.js';
 import { textResult, type VaultToolDeps } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -248,6 +253,77 @@ export function createSkillTools(deps: VaultToolDeps) {
         });
       }
 
+      // Dedup gate -- prevents the skill lifecycle from creating sibling
+      // skills that cover the same topic under different names. Two
+      // deterministic checks, both skipped when the write is updating an
+      // existing skill under the same name (the normal evolve path).
+      //
+      // The reason this lives in the tool and not in the validate phase's
+      // prompt: self-graded conflict checks are unreliable, especially for
+      // weaker local models. Observed failure: run fcb66275 passed its own
+      // "no overlap" self-check while an obvious duplicate sat on disk.
+      // See feedback_structural_enforcement — enforce in tools, not prompts.
+      const existingSameName = getSkillRecordByName(args.name);
+      if (!existingSameName) {
+        // (1) Candidate-already-fulfilled check. If the caller passed a
+        //     candidate_id that is already linked to an active skill with a
+        //     different name, refuse the write and point the agent at the
+        //     existing skill.
+        if (args.candidate_id) {
+          const candidate = getCandidate(args.candidate_id);
+          if (candidate?.skill_id) {
+            const linkedSkill = getSkillRecord(candidate.skill_id);
+            if (linkedSkill && linkedSkill.name !== args.name) {
+              recordTurn('vault_write_skill', args);
+              return textResult({
+                error:
+                  `Candidate ${args.candidate_id} is already fulfilled by skill "${linkedSkill.name}". ` +
+                  'Do not create a sibling skill. If the existing skill needs changes, ' +
+                  'write to the same name to evolve it (this bumps its generation), or ' +
+                  'mark it stale via vault_skill_records before replacing.',
+                existing_skill: {
+                  id: linkedSkill.id,
+                  name: linkedSkill.name,
+                  description: linkedSkill.description,
+                  path: linkedSkill.path,
+                },
+              });
+            }
+          }
+        }
+
+        // (2) Description similarity check. Jaccard on significant-word
+        //     tokens — deterministic and cheap. Compares against all active
+        //     skills for this agent; rejects on the highest-scoring match
+        //     above DESCRIPTION_DUPLICATE_THRESHOLD.
+        const activeSkills = listSkillRecords({ agent_id: agentId, status: 'active', limit: 200 });
+        let bestMatch: { skill: typeof activeSkills[number]; score: number } | null = null;
+        for (const skill of activeSkills) {
+          const score = descriptionSimilarity(args.description, skill.description);
+          if (score >= DESCRIPTION_DUPLICATE_THRESHOLD && (!bestMatch || score > bestMatch.score)) {
+            bestMatch = { skill, score };
+          }
+        }
+        if (bestMatch) {
+          recordTurn('vault_write_skill', args);
+          return textResult({
+            error:
+              `Description overlaps with existing active skill "${bestMatch.skill.name}" ` +
+              `(Jaccard ${bestMatch.score.toFixed(2)}, threshold ${DESCRIPTION_DUPLICATE_THRESHOLD}). ` +
+              'Do not create a duplicate. Either evolve the existing skill by writing to ' +
+              `its name ("${bestMatch.skill.name}"), or reframe this skill so its description ` +
+              'describes a distinct procedure.',
+            overlapping_skill: {
+              id: bestMatch.skill.id,
+              name: bestMatch.skill.name,
+              description: bestMatch.skill.description,
+              path: bestMatch.skill.path,
+            },
+            similarity: bestMatch.score,
+          });
+        }
+      }
+
       const root = projectRoot ?? process.cwd();
       const skillDir = resolve(root, '.agents', 'skills', args.name);
       const skillPath = resolve(skillDir, 'SKILL.md');
@@ -264,6 +340,20 @@ export function createSkillTools(deps: VaultToolDeps) {
             error: 'Skill update rejected: protected frontmatter fields were changed. Read the existing skill and preserve these values exactly.',
             violations,
           });
+        }
+      }
+
+      // Snapshot the on-disk state BEFORE writing so we can roll back
+      // accurately if the DB transaction fails. Two cases:
+      //   - Skill directory didn't exist: full cleanup on failure
+      //   - Skill directory already existed (update path): restore prior
+      //     SKILL.md content rather than deleting the whole directory
+      const skillDirPreexisted = existsSync(skillDir);
+      let priorSkillContent: string | null = null;
+      if (existsSync(skillPath)) {
+        try { priorSkillContent = readFileSync(skillPath, 'utf-8'); } catch {
+          // If we can't read it, we can't restore it — treat as "no prior"
+          priorSkillContent = null;
         }
       }
 
@@ -296,7 +386,12 @@ export function createSkillTools(deps: VaultToolDeps) {
 
       // All DB mutations wrapped in a transaction for atomicity.
       // File write (above) is the source of truth; DB is derived.
+      //
+      // Rollback policy: if the transaction throws, reverse the on-disk
+      // mutation so a partial write cannot leave an orphaned skill file
+      // that the next generate cycle would then "find" and duplicate.
       const txDb = getDatabase();
+      try {
       txDb.transaction(() => {
         if (existing) {
           // Update existing record -- bump generation
@@ -383,6 +478,30 @@ export function createSkillTools(deps: VaultToolDeps) {
           // scheduled runs, making this fallback-skip path rare.
         }
       })();
+      } catch (err) {
+        // DB transaction failed after the file was written. Reverse the
+        // on-disk mutation so we don't leave an orphan SKILL.md that will
+        // confuse the next generate cycle. Best-effort — failures here are
+        // logged but not propagated, since we're already in an error path.
+        try {
+          if (priorSkillContent !== null) {
+            writeFileSync(skillPath, priorSkillContent, 'utf-8');
+          } else if (!skillDirPreexisted) {
+            rmSync(skillDir, { recursive: true, force: true });
+          } else {
+            rmSync(skillPath, { force: true });
+          }
+        } catch (rollbackErr) {
+          console.warn(
+            '[vault_write_skill] file rollback after DB failure also failed:',
+            rollbackErr instanceof Error ? rollbackErr.message : rollbackErr,
+          );
+        }
+        recordTurn('vault_write_skill', args);
+        return textResult({
+          error: `Skill write aborted: database transaction failed and on-disk state was rolled back. ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
 
       const isNew = generation === 1;
       notify(vaultDir, {

--- a/src/agent/tools/skill-validator.ts
+++ b/src/agent/tools/skill-validator.ts
@@ -15,6 +15,20 @@ export const REQUIRED_FRONTMATTER_FIELDS = ['name', 'description', 'managed_by',
 export const PROTECTED_FRONTMATTER_FIELDS = ['user-invocable', 'allowed-tools'] as const;
 
 /**
+ * Whitelist of Claude Code tool names that may appear in `allowed-tools`.
+ * Myco-managed skills run in developer Claude Code sessions — anything not
+ * on this list is almost certainly a model confabulation (e.g. "[None]",
+ * "ReadFile", "search", or a vault_* tool copied from the agent's own context).
+ *
+ * Kept intentionally narrow: add entries when a legitimate tool is rejected.
+ */
+export const ALLOWED_CLAUDE_CODE_TOOLS: ReadonlySet<string> = new Set([
+  'Read', 'Edit', 'Write', 'MultiEdit', 'Bash', 'Grep', 'Glob',
+  'NotebookRead', 'NotebookEdit', 'WebFetch', 'WebSearch',
+  'Task', 'TodoWrite',
+]);
+
+/**
  * Extract a frontmatter field value from SKILL.md content.
  * Returns the raw value string, or undefined if not found.
  */
@@ -24,6 +38,105 @@ export function extractFrontmatterField(content: string, field: string): string 
   const match = fmMatch[1].match(new RegExp(`^${field}:\\s*(.+)$`, 'm'));
   return match?.[1].trim();
 }
+
+/**
+ * Parse the `allowed-tools` frontmatter value into a list of tool names.
+ *
+ * Accepts either of these YAML shapes:
+ *   allowed-tools: Read, Edit, Write
+ *   allowed-tools: [Read, Edit, Write]
+ *
+ * Returns null if the value is absent, empty, or clearly malformed
+ * (e.g. a bare word like `None`, or a list containing `None` / `null`).
+ * Caller treats null as a validation failure.
+ */
+export function parseAllowedTools(rawValue: string | undefined): string[] | null {
+  if (!rawValue) return null;
+  let stripped = rawValue.trim();
+  if (stripped.length === 0) return null;
+
+  // Strip YAML inline-list brackets if present: [Read, Edit] -> Read, Edit
+  if (stripped.startsWith('[') && stripped.endsWith(']')) {
+    stripped = stripped.slice(1, -1).trim();
+  }
+  if (stripped.length === 0) return null;
+
+  const parts = stripped
+    .split(',')
+    .map((s) => s.trim().replace(/^['"]|['"]$/g, '')) // strip quotes
+    .filter((s) => s.length > 0);
+
+  if (parts.length === 0) return null;
+
+  // Reject literal "None" / "null" / "~" — common model confabulations
+  // when the model means "no tools needed."
+  const sentinels = new Set(['None', 'none', 'null', 'Null', '~']);
+  if (parts.some((p) => sentinels.has(p))) return null;
+
+  return parts;
+}
+
+/**
+ * Lowercase-word token set from a string, excluding stopwords and
+ * short/noise tokens. Used for Jaccard description similarity.
+ */
+function tokenSet(text: string): Set<string> {
+  const stopwords = new Set([
+    'the', 'a', 'an', 'and', 'or', 'but', 'is', 'are', 'was', 'were',
+    'be', 'been', 'being', 'have', 'has', 'had', 'do', 'does', 'did',
+    'will', 'would', 'should', 'could', 'may', 'might', 'must', 'can',
+    'this', 'that', 'these', 'those', 'with', 'from', 'into', 'onto',
+    'for', 'when', 'where', 'which', 'what', 'who', 'how', 'why',
+    'use', 'uses', 'used', 'using', 'not', 'also', 'than', 'then',
+    'ensure', 'ensures', 'make', 'makes',
+  ]);
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9_\s]/g, ' ')
+      .split(/\s+/)
+      .filter((w) => w.length >= 4 && !stopwords.has(w)),
+  );
+}
+
+/**
+ * Jaccard similarity between two text strings on their significant-word
+ * token sets. Returns a value in [0, 1].
+ *
+ * Purpose: detect near-duplicate skill descriptions so `vault_write_skill`
+ * can refuse to create sibling skills covering the same topic. This is a
+ * deterministic gate — unlike asking the model to self-check for conflicts,
+ * which is known to hallucinate "no overlap" on visibly overlapping pairs.
+ */
+export function descriptionSimilarity(a: string, b: string): number {
+  const aTokens = tokenSet(a);
+  const bTokens = tokenSet(b);
+  if (aTokens.size === 0 || bTokens.size === 0) return 0;
+
+  let intersection = 0;
+  for (const token of aTokens) {
+    if (bTokens.has(token)) intersection++;
+  }
+  const union = aTokens.size + bTokens.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+/**
+ * Similarity threshold above which two descriptions are treated as
+ * covering the same topic. Chosen empirically from the unifi-mcp incident
+ * that motivated this gate: the real duplicate pair
+ * (`unifi-validator-coercion-pattern` vs `unifi-validator-registry-coercion`)
+ * scored ~0.42 on this metric — lower than intuition suggests because each
+ * description reframes roughly half its content with different wording.
+ * Clearly-distinct skill pairs score under 0.2 on the same metric, so 0.4
+ * is a comfortable middle that catches real duplicates without flagging
+ * incidentally-adjacent topics.
+ *
+ * Tuning note: the cost of a false positive here is "agent must reframe
+ * its description and try again" (low); the cost of a false negative is
+ * "sibling skill on disk for the same topic" (high). Lean aggressive.
+ */
+export const DESCRIPTION_DUPLICATE_THRESHOLD = 0.4;
 
 /**
  * Compare protected frontmatter fields between existing and new content.
@@ -97,14 +210,35 @@ export function validateSkillContent(content: string, dirName: string): string[]
   // These skills run in developer Claude Code sessions, not the agent pipeline.
   const allowedToolsMatch = frontmatter.match(/^allowed-tools:\s*(.+)$/m);
   if (allowedToolsMatch) {
-    const toolsValue = allowedToolsMatch[1].trim();
-    // Reject vault_* tool names -- common LLM mistake of copying its own tool context
-    if (toolsValue.includes('vault_')) {
+    const rawValue = allowedToolsMatch[1].trim();
+    // Reject vault_* tool names first — most informative message for the
+    // common LLM mistake of copying its own agent tool context into the skill.
+    if (rawValue.includes('vault_')) {
       issues.push(
         'allowed-tools contains vault agent tool names (vault_*). ' +
         'Skills run in Claude Code sessions -- use Claude Code tool names instead: ' +
-        'Read, Edit, Write, Bash, Grep, Glob'
+        'Read, Edit, Write, Bash, Grep, Glob',
       );
+    } else {
+      // Positive whitelist check — catches "[None]", "None", invented tool
+      // names, and other confabulations that the vault_* reject misses.
+      const parsed = parseAllowedTools(rawValue);
+      if (parsed === null) {
+        issues.push(
+          `allowed-tools value is malformed or empty: "${rawValue}". ` +
+          'Provide a comma-separated list of Claude Code tools, e.g. ' +
+          '"Read, Edit, Write, Bash, Grep, Glob". Use the narrowest set ' +
+          'the skill actually needs.',
+        );
+      } else {
+        const unknown = parsed.filter((t) => !ALLOWED_CLAUDE_CODE_TOOLS.has(t));
+        if (unknown.length > 0) {
+          issues.push(
+            `allowed-tools contains unknown tool name(s): ${unknown.join(', ')}. ` +
+            `Valid Claude Code tools: ${[...ALLOWED_CLAUDE_CODE_TOOLS].join(', ')}.`,
+          );
+        }
+      }
     }
   }
   // Also check YAML list format (- vault_search_fts etc.)
@@ -113,7 +247,7 @@ export function validateSkillContent(content: string, dirName: string): string[]
     issues.push(
       'allowed-tools contains vault agent tool names (vault_*). ' +
       'Skills run in Claude Code sessions -- use Claude Code tool names instead: ' +
-      'Read, Edit, Write, Bash, Grep, Glob'
+      'Read, Edit, Write, Bash, Grep, Glob',
     );
   }
 

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -192,6 +192,14 @@ export async function main(): Promise<void> {
     level: config.daemon.log_level,
   });
 
+  // When debug logging is on, surface per-turn tool_use / tool_result detail
+  // from the agent executor. The executor reads this env var directly because
+  // it has no logger handle. Used to diagnose turn-budget exhaustion (e.g.
+  // local-model rejection loops in skill-generate).
+  if (config.daemon.log_level === 'debug') {
+    process.env.MYCO_AGENT_DEBUG = '1';
+  }
+
   // Kill any stale daemon for this vault before starting
   killStaleDaemon(vaultDir, logger);
 

--- a/tests/agent/ollama-context.test.ts
+++ b/tests/agent/ollama-context.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for the Ollama context variant resolver.
+ *
+ * Exercises `resolveOllamaContextVariants` in isolation by injecting a pure
+ * stub variant-creator — no `ollama` CLI required. Covers the default,
+ * explicit overrides, same-model multi-scope reconciliation, non-ollama
+ * pass-through, and the phase-override rewriting.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveOllamaContextVariants,
+  DEFAULT_OLLAMA_CONTEXT_LENGTH,
+} from '@myco/agent/ollama-context.js';
+import type { ProviderConfig } from '@myco/agent/types.js';
+
+/**
+ * Deterministic stub that mirrors the naming scheme of the real
+ * `ensureOllamaContextVariant` without touching disk or invoking `ollama`.
+ * Also records every invocation so tests can assert the resolver created
+ * the expected set of variants.
+ */
+function makeStubCreator() {
+  const calls: Array<{ model: string; ctx: number }> = [];
+  const createVariant = async (model: string, ctx: number) => {
+    calls.push({ model, ctx });
+    return `${model}-ctx${ctx}`;
+  };
+  return { createVariant, calls };
+}
+
+describe('resolveOllamaContextVariants', () => {
+  it('passes through when there are no Ollama providers', async () => {
+    const { createVariant, calls } = makeStubCreator();
+    const taskProvider: ProviderConfig = { type: 'cloud', model: 'claude-sonnet-4-6' };
+
+    const result = await resolveOllamaContextVariants(taskProvider, {}, createVariant);
+
+    expect(result.taskProvider).toEqual(taskProvider);
+    expect(result.phaseOverrides).toEqual({});
+    expect(result.conflicts).toEqual([]);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('applies DEFAULT_OLLAMA_CONTEXT_LENGTH when context_length is unset', async () => {
+    const { createVariant, calls } = makeStubCreator();
+    const taskProvider: ProviderConfig = {
+      type: 'ollama',
+      model: 'gemma4:26b',
+      baseUrl: 'http://localhost:11434',
+    };
+
+    const result = await resolveOllamaContextVariants(taskProvider, {}, createVariant);
+
+    // The variant should be created at the default, and the rewritten
+    // provider should carry both the variant model name and the default
+    // contextLength (so downstream code sees the effective value).
+    expect(calls).toEqual([{ model: 'gemma4:26b', ctx: DEFAULT_OLLAMA_CONTEXT_LENGTH }]);
+    expect(result.taskProvider).toMatchObject({
+      type: 'ollama',
+      model: `gemma4:26b-ctx${DEFAULT_OLLAMA_CONTEXT_LENGTH}`,
+      contextLength: DEFAULT_OLLAMA_CONTEXT_LENGTH,
+      baseUrl: 'http://localhost:11434',
+    });
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it('respects an explicit context_length value', async () => {
+    const { createVariant, calls } = makeStubCreator();
+    const taskProvider: ProviderConfig = {
+      type: 'ollama',
+      model: 'gemma4:26b',
+      contextLength: 16384,
+    };
+
+    const result = await resolveOllamaContextVariants(taskProvider, {}, createVariant);
+
+    expect(calls).toEqual([{ model: 'gemma4:26b', ctx: 16384 }]);
+    expect(result.taskProvider).toMatchObject({
+      model: 'gemma4:26b-ctx16384',
+      contextLength: 16384,
+    });
+  });
+
+  it('rewrites phase-level Ollama providers too, not just the task level', async () => {
+    const { createVariant, calls } = makeStubCreator();
+    const taskProvider: ProviderConfig = {
+      type: 'ollama',
+      model: 'gemma4:26b',
+      contextLength: 32768,
+    };
+    const phaseOverrides = {
+      draft: { maxTurns: 20 },  // inherits task provider
+      validate: {
+        maxTurns: 30,
+        provider: { type: 'ollama' as const, model: 'qwen:14b' },
+      },
+    };
+
+    const result = await resolveOllamaContextVariants(taskProvider, phaseOverrides, createVariant);
+
+    // Two distinct models → two variant creations.
+    expect(calls).toHaveLength(2);
+    const callModels = new Set(calls.map((c) => c.model));
+    expect(callModels).toEqual(new Set(['gemma4:26b', 'qwen:14b']));
+
+    // Phase that inherits from task provider has no provider override of
+    // its own, so it stays unchanged — the task-level rewrite handles it.
+    expect(result.phaseOverrides.draft).toEqual({ maxTurns: 20 });
+
+    // Phase that overrides the provider should get its provider rewritten
+    // to the variant name, with the default context length applied.
+    expect(result.phaseOverrides.validate.provider).toMatchObject({
+      type: 'ollama',
+      model: `qwen:14b-ctx${DEFAULT_OLLAMA_CONTEXT_LENGTH}`,
+      contextLength: DEFAULT_OLLAMA_CONTEXT_LENGTH,
+    });
+  });
+
+  it('reconciles same-model-different-context to a single variant (max wins)', async () => {
+    const { createVariant, calls } = makeStubCreator();
+    const taskProvider: ProviderConfig = {
+      type: 'ollama',
+      model: 'gemma4:26b',
+      contextLength: 16384,
+    };
+    const phaseOverrides = {
+      draft: {
+        maxTurns: 20,
+        provider: {
+          type: 'ollama' as const,
+          model: 'gemma4:26b',
+          contextLength: 8192,
+        },
+      },
+      validate: {
+        maxTurns: 30,
+        provider: {
+          type: 'ollama' as const,
+          model: 'gemma4:26b',
+          contextLength: 32768, // largest — should win
+        },
+      },
+    };
+
+    const result = await resolveOllamaContextVariants(taskProvider, phaseOverrides, createVariant);
+
+    // Exactly ONE variant created, at the max context.
+    expect(calls).toEqual([{ model: 'gemma4:26b', ctx: 32768 }]);
+
+    // Every scope that referenced gemma4:26b gets rewritten to the same
+    // variant name with the reconciled context length.
+    expect(result.taskProvider?.model).toBe('gemma4:26b-ctx32768');
+    expect(result.taskProvider?.contextLength).toBe(32768);
+    expect(result.phaseOverrides.draft.provider?.model).toBe('gemma4:26b-ctx32768');
+    expect(result.phaseOverrides.draft.provider?.contextLength).toBe(32768);
+    expect(result.phaseOverrides.validate.provider?.model).toBe('gemma4:26b-ctx32768');
+
+    // The conflict is surfaced so the caller can log/warn.
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]).toEqual({
+      model: 'gemma4:26b',
+      values: [8192, 16384, 32768],
+      resolved: 32768,
+    });
+  });
+
+  it('does not report a conflict when all scopes resolve to the same value', async () => {
+    const { createVariant, calls } = makeStubCreator();
+    const taskProvider: ProviderConfig = {
+      type: 'ollama',
+      model: 'gemma4:26b',
+      contextLength: 32768,
+    };
+    const phaseOverrides = {
+      draft: {
+        maxTurns: 20,
+        provider: { type: 'ollama' as const, model: 'gemma4:26b', contextLength: 32768 },
+      },
+    };
+
+    const result = await resolveOllamaContextVariants(taskProvider, phaseOverrides, createVariant);
+
+    expect(calls).toEqual([{ model: 'gemma4:26b', ctx: 32768 }]);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it('handles cloud task provider with ollama phase override', async () => {
+    // The inverse of the user's planned per-phase model split: cloud for
+    // the task baseline, ollama for a specific phase. The ollama phase
+    // should still get a variant with the default context.
+    const { createVariant, calls } = makeStubCreator();
+    const taskProvider: ProviderConfig = { type: 'cloud', model: 'claude-sonnet-4-6' };
+    const phaseOverrides = {
+      draft: {
+        maxTurns: 20,
+        provider: { type: 'ollama' as const, model: 'gemma4:26b' },
+      },
+    };
+
+    const result = await resolveOllamaContextVariants(taskProvider, phaseOverrides, createVariant);
+
+    // Task provider is cloud — pass through untouched.
+    expect(result.taskProvider).toEqual(taskProvider);
+
+    // Phase provider is ollama — variant created with default context.
+    expect(calls).toEqual([{ model: 'gemma4:26b', ctx: DEFAULT_OLLAMA_CONTEXT_LENGTH }]);
+    expect(result.phaseOverrides.draft.provider?.model).toBe(
+      `gemma4:26b-ctx${DEFAULT_OLLAMA_CONTEXT_LENGTH}`,
+    );
+  });
+
+  it('skips providers with no model set', async () => {
+    const { createVariant, calls } = makeStubCreator();
+    // Incomplete config: type is ollama but no model — should be left alone.
+    const taskProvider: ProviderConfig = { type: 'ollama', baseUrl: 'http://localhost:11434' };
+
+    const result = await resolveOllamaContextVariants(taskProvider, {}, createVariant);
+
+    expect(calls).toHaveLength(0);
+    expect(result.taskProvider).toEqual(taskProvider);
+  });
+});

--- a/tests/agent/tools-skills.test.ts
+++ b/tests/agent/tools-skills.test.ts
@@ -444,5 +444,191 @@ describe('vault skill tools', () => {
       const parsed = parseResult(result) as { generation?: number };
       expect(parsed.generation).toBe(2);
     });
+
+    // -----------------------------------------------------------------------
+    // Dedup gates — prevent sibling skills for the same topic.
+    // -----------------------------------------------------------------------
+
+    it('rejects writes whose candidate_id is already fulfilled by a different skill', async () => {
+      // Seed a candidate and fulfill it by writing a first skill.
+      const candidateTool = findTool(tools, 'vault_skill_candidates');
+      const candidateResult = await candidateTool.handler(
+        { action: 'create', topic: 'Validator coercion', rationale: 'Seen twice in contributor PRs' },
+        undefined,
+      );
+      const candidate = parseResult(candidateResult) as { id: string };
+
+      const t = findTool(tools, 'vault_write_skill');
+      await t.handler(
+        {
+          name: 'validator-coercion-pattern',
+          display_name: 'Validator Coercion Pattern',
+          description: 'Use the coerced validated_data, not the original params',
+          content: validSkillContent('validator-coercion-pattern', '# Step 1'),
+          candidate_id: candidate.id,
+        },
+        undefined,
+      );
+
+      // Second write for the same candidate under a different name — should be rejected
+      const result = await t.handler(
+        {
+          name: 'validator-registry-coercion',
+          display_name: 'Validator Registry Coercion',
+          description: 'A different write targeting the same candidate',
+          content: validSkillContent('validator-registry-coercion', '# Step 1'),
+          candidate_id: candidate.id,
+        },
+        undefined,
+      );
+
+      const parsed = parseResult(result) as {
+        error?: string;
+        existing_skill?: { name: string };
+      };
+      expect(parsed.error).toContain('already fulfilled');
+      expect(parsed.existing_skill?.name).toBe('validator-coercion-pattern');
+
+      // The second skill's directory must NOT exist on disk — rejection is early.
+      const rejectedPath = path.join(
+        tmpDir, '.agents', 'skills', 'validator-registry-coercion', 'SKILL.md',
+      );
+      expect(fs.existsSync(rejectedPath)).toBe(false);
+    });
+
+    it('allows writes to the same name when candidate is already linked (evolve path)', async () => {
+      const candidateTool = findTool(tools, 'vault_skill_candidates');
+      const candidateResult = await candidateTool.handler(
+        { action: 'create', topic: 'Evolution test', rationale: 'Needs to allow bumping generation' },
+        undefined,
+      );
+      const candidate = parseResult(candidateResult) as { id: string };
+
+      const t = findTool(tools, 'vault_write_skill');
+      await t.handler(
+        {
+          name: 'evolution-test',
+          display_name: 'Evolution Test',
+          description: 'Initial version',
+          content: validSkillContent('evolution-test', '# Version 1'),
+          candidate_id: candidate.id,
+        },
+        undefined,
+      );
+
+      // Same name — should bump generation, not trip the dedup gate.
+      const result = await t.handler(
+        {
+          name: 'evolution-test',
+          display_name: 'Evolution Test',
+          description: 'Initial version',
+          content: validSkillContent('evolution-test', '# Version 2'),
+          candidate_id: candidate.id,
+        },
+        undefined,
+      );
+      const parsed = parseResult(result) as { generation?: number; error?: string };
+      expect(parsed.error).toBeUndefined();
+      expect(parsed.generation).toBe(2);
+    });
+
+    it('rejects writes whose description overlaps an existing active skill', async () => {
+      const t = findTool(tools, 'vault_write_skill');
+
+      // Seed an active skill with a distinctive description.
+      await t.handler(
+        {
+          name: 'validator-coercion-first',
+          display_name: 'First Skill',
+          description:
+            'Use when implementing or modifying tools that use UniFiValidatorRegistry.validate(). ' +
+            'Ensures you use the coerced normalized validated_data returned by the registry ' +
+            'rather than the original params, preventing silent failures in the controller.',
+          content: validSkillContent('validator-coercion-first', '# Content'),
+        },
+        undefined,
+      );
+
+      // New skill with a near-duplicate description — should be rejected.
+      const result = await t.handler(
+        {
+          name: 'validator-coercion-second',
+          display_name: 'Second Skill',
+          description:
+            'Use when implementing or modifying any tool in unifi-mcp that uses ' +
+            'UniFiValidatorRegistry.validate(). Prevents the silent bypass bug by ensuring ' +
+            'the coerced normalized validated_data is used instead of the original params dict.',
+          content: validSkillContent('validator-coercion-second', '# Content'),
+        },
+        undefined,
+      );
+
+      const parsed = parseResult(result) as {
+        error?: string;
+        overlapping_skill?: { name: string };
+        similarity?: number;
+      };
+      expect(parsed.error).toContain('overlaps with existing active skill');
+      expect(parsed.overlapping_skill?.name).toBe('validator-coercion-first');
+      expect(parsed.similarity).toBeGreaterThanOrEqual(0.4);
+    });
+
+    it('allows writes whose description is distinct from existing skills', async () => {
+      const t = findTool(tools, 'vault_write_skill');
+
+      await t.handler(
+        {
+          name: 'error-logging',
+          display_name: 'Error Logging',
+          description: 'Structured error logging patterns for async handlers',
+          content: validSkillContent('error-logging', '# Logging'),
+        },
+        undefined,
+      );
+
+      // Completely unrelated topic — should be allowed.
+      const result = await t.handler(
+        {
+          name: 'database-migrations',
+          display_name: 'Database Migrations',
+          description: 'Safe schema migration procedures for production SQLite',
+          content: validSkillContent('database-migrations', '# Migrations'),
+        },
+        undefined,
+      );
+      const parsed = parseResult(result) as { generation?: number; error?: string };
+      expect(parsed.error).toBeUndefined();
+      expect(parsed.generation).toBe(1);
+    });
+
+    it('allows updating an existing skill that overlaps its own description', async () => {
+      const t = findTool(tools, 'vault_write_skill');
+
+      // Seed
+      await t.handler(
+        {
+          name: 'self-overlap',
+          display_name: 'Self Overlap',
+          description: 'Structured error logging patterns for async background handlers',
+          content: validSkillContent('self-overlap', '# V1'),
+        },
+        undefined,
+      );
+
+      // Update with a description that obviously overlaps its own prior description —
+      // should NOT trip the dedup gate because existingSameName is found first.
+      const result = await t.handler(
+        {
+          name: 'self-overlap',
+          display_name: 'Self Overlap',
+          description: 'Structured error logging patterns for async background handlers, refined',
+          content: validSkillContent('self-overlap', '# V2'),
+        },
+        undefined,
+      );
+      const parsed = parseResult(result) as { generation?: number; error?: string };
+      expect(parsed.error).toBeUndefined();
+      expect(parsed.generation).toBe(2);
+    });
   });
 });

--- a/tests/smoke/review-fixes.test.ts
+++ b/tests/smoke/review-fixes.test.ts
@@ -12,6 +12,11 @@ import { insertSkillRecord, deleteSkillRecordCascade, getSkillRecord } from '@my
 import { insertLineage, listLineageForSkill } from '@myco/db/queries/skill-lineage.js';
 import { insertSkillUsage, countUsageForSkill } from '@myco/db/queries/skill-usage.js';
 import { validateSkillContent, VAULT_TOOL_COUNT } from '@myco/agent/tools.js';
+import {
+  parseAllowedTools,
+  descriptionSimilarity,
+  DESCRIPTION_DUPLICATE_THRESHOLD,
+} from '@myco/agent/tools/skill-validator.js';
 import { buildScheduledJobs, type ScheduledJobContext } from '@myco/daemon/task-scheduler.js';
 import { loadConfig } from '@myco/config/loader.js';
 import type { AgentTask } from '@myco/agent/types.js';
@@ -376,6 +381,105 @@ describe('validateSkillContent quality gate', () => {
     const content = '---\nname: myco:test-skill\ndescription: A test skill\nmanaged_by: myco\nuser-invocable: true\nallowed-tools:\n  - vault_search_fts\n  - vault_spores\n---\n\nBody';
     const issues = validateSkillContent(content, 'test');
     expect(issues.some(i => i.includes('vault agent tool names'))).toBe(true);
+  });
+
+  it('rejects allowed-tools: [None] — the model confabulation that prompted this gate', () => {
+    const content = '---\nname: myco:test-skill\ndescription: A test skill\nmanaged_by: myco\nuser-invocable: true\nallowed-tools: [None]\n---\n\nBody';
+    const issues = validateSkillContent(content, 'test');
+    expect(issues.some(i => i.includes('malformed'))).toBe(true);
+  });
+
+  it('rejects allowed-tools: None (bare sentinel)', () => {
+    const content = '---\nname: myco:test-skill\ndescription: A test skill\nmanaged_by: myco\nuser-invocable: true\nallowed-tools: None\n---\n\nBody';
+    const issues = validateSkillContent(content, 'test');
+    expect(issues.some(i => i.includes('malformed'))).toBe(true);
+  });
+
+  it('rejects unknown tool names in allowed-tools', () => {
+    const content = '---\nname: myco:test-skill\ndescription: A test skill\nmanaged_by: myco\nuser-invocable: true\nallowed-tools: Read, ReadFile, Shell\n---\n\nBody';
+    const issues = validateSkillContent(content, 'test');
+    expect(issues.some(i => i.includes('unknown tool name'))).toBe(true);
+  });
+
+  it('accepts inline YAML list format with valid tools', () => {
+    const content = '---\nname: myco:test-skill\ndescription: A test skill\nmanaged_by: myco\nuser-invocable: true\nallowed-tools: [Read, Edit, Write]\n---\n\nBody';
+    const issues = validateSkillContent(content, 'test');
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAllowedTools helper
+// ---------------------------------------------------------------------------
+describe('parseAllowedTools', () => {
+  it('parses comma-separated values', () => {
+    expect(parseAllowedTools('Read, Edit, Write')).toEqual(['Read', 'Edit', 'Write']);
+  });
+
+  it('parses inline YAML list format', () => {
+    expect(parseAllowedTools('[Read, Edit, Write]')).toEqual(['Read', 'Edit', 'Write']);
+  });
+
+  it('strips surrounding quotes', () => {
+    expect(parseAllowedTools('"Read", "Edit"')).toEqual(['Read', 'Edit']);
+  });
+
+  it('returns null for bare None sentinel', () => {
+    expect(parseAllowedTools('None')).toBeNull();
+  });
+
+  it('returns null for [None]', () => {
+    expect(parseAllowedTools('[None]')).toBeNull();
+  });
+
+  it('returns null for empty input', () => {
+    expect(parseAllowedTools('')).toBeNull();
+    expect(parseAllowedTools('   ')).toBeNull();
+    expect(parseAllowedTools(undefined)).toBeNull();
+  });
+
+  it('returns null when any element is a null-sentinel', () => {
+    expect(parseAllowedTools('Read, None')).toBeNull();
+    expect(parseAllowedTools('Read, null')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// descriptionSimilarity helper — the deterministic dedup signal
+// ---------------------------------------------------------------------------
+describe('descriptionSimilarity', () => {
+  it('returns 1.0 for identical strings', () => {
+    const a = 'Use the coerced validated_data, not the original params';
+    expect(descriptionSimilarity(a, a)).toBe(1);
+  });
+
+  it('returns near-zero for clearly distinct topics', () => {
+    const a = 'Structured error logging patterns for async handlers';
+    const b = 'Safe schema migration procedures for SQLite production';
+    expect(descriptionSimilarity(a, b)).toBeLessThan(0.2);
+  });
+
+  it('scores near-duplicates above DESCRIPTION_DUPLICATE_THRESHOLD', () => {
+    // The real pair that prompted this helper — run fcb66275's new skill
+    // vs the pre-existing one it failed to notice.
+    const a =
+      'Use when implementing or modifying tools that use UniFiValidatorRegistry.validate(). ' +
+      'Ensures you use the coerced normalized validated_data returned by the registry ' +
+      'rather than the original params, preventing silent failures in the controller.';
+    const b =
+      'Use when implementing or modifying any tool in unifi-mcp that uses ' +
+      'UniFiValidatorRegistry.validate(). Prevents the silent bypass bug by ensuring ' +
+      'the coerced normalized validated_data is used instead of the original params dict.';
+    const score = descriptionSimilarity(a, b);
+    expect(score).toBeGreaterThanOrEqual(DESCRIPTION_DUPLICATE_THRESHOLD);
+  });
+
+  it('ignores stopwords and short tokens so boilerplate does not inflate scores', () => {
+    const a = 'the quick brown fox jumps over the lazy dog today';
+    const b = 'the cat sat on the mat today and yesterday';
+    // Both contain lots of stopwords, but only "today" is a shared content word
+    // — should score low, not high.
+    expect(descriptionSimilarity(a, b)).toBeLessThan(0.3);
   });
 });
 

--- a/ui/src/components/agent/TaskProviderConfig.tsx
+++ b/ui/src/components/agent/TaskProviderConfig.tsx
@@ -142,8 +142,13 @@ function ProviderModelSelector({
             type="number"
             value={contextLength}
             onChange={(e) => onContextLengthChange(e.target.value)}
-            placeholder="32768"
+            placeholder="32768 (default)"
           />
+          <p className="font-sans text-[11px] text-on-surface-variant/70">
+            Leave blank to use the 32K default. Myco creates a Modelfile
+            variant at this size so the model loads at the size you asked
+            for, not its (much larger) native default.
+          </p>
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Three linked hardening changes that came out of a gemma4:26b dogfood run of `skill-generate` on the unifi-mcp project. The run exposed rough edges that matter far more for weaker local models than for Sonnet — turn-budget exhaustion that was invisible to diagnose, a validate-phase self-check that cheerfully passed a visibly duplicated skill, a failed run that leaked an orphan SKILL.md to disk with no backing DB record, and a silent VRAM footgun where Ollama models loaded at their 128K–256K native context defaults despite the UI implying a 32K default. Each gap is addressed at the level where it can actually be enforced.

## Why now

Myco's agent pipeline has been implicitly tuned around Sonnet's "intelligence per turn," its honesty about its own output, and its cloud-hosted-ness. All three assumptions break on smaller local models:

- **Intelligence per turn:** gemma4:26b needs ~2–4× the turns for the same work, and when the draft phase burns its budget, the only signal is a phase-level `num_turns` summary. There's no way to tell whether the model looped on tool-call retries, got stuck in a quality-gate rejection loop, or wandered off-prompt.
- **Self-grading honesty:** the skill-generate `validate` phase asks the model to check its own output for conflicts with existing skills. Run `fcb66275` reported `Conflicts: Pass (No overlap found)` while an obvious duplicate (`unifi-validator-coercion-pattern`) sat in the same directory. Weaker models are uniformly forgiving of their own output.
- **Atomicity:** `vault_write_skill` writes the file before the DB transaction. If the transaction throws, the file stays on disk as an orphan. A later generate cycle has no record of it, so the scheduler can re-generate the same candidate under a different name — which is exactly what happened to candidate `4649a5e5`.
- **VRAM footprint:** modern Ollama models ship with 128K–256K native context windows, which Ollama allocates fully at load time. The UI placeholder implied a 32K default was in effect, but the runtime only applied `context_length` when explicitly set, so gemma4:26b actually loaded at 262144 context — 34GB resident with the model weights taking only roughly half.

The same skill pipeline happens to work fine on Sonnet, so none of these surfaced in earlier runs. Fixing them before leaning into per-phase model splits or local-first provider configurations.

## What changed

### Per-turn tool-call debug logging (`688c504`)

`src/agent/executor.ts` + `src/daemon/main.ts`

When `MYCO_AGENT_DEBUG=1`, every `tool_use` and `tool_result` inside a phase logs to stdout with a ~240-char payload preview. Errors flagged with `[ERROR]`. The daemon sets the env var automatically when `daemon.log_level === 'debug'`, so there's no second toggle to flip. Zero overhead when disabled.

This is the minimum instrumentation needed to diagnose turn-budget exhaustion empirically — next time a local-model run burns its budget, the trace answers "doing what?" instead of leaving that as inference.

### `vault_write_skill` hardening (`c668c85`)

`src/agent/tools/skill-validator.ts` + `src/agent/tools/skill-tools.ts`

Three deterministic gates moved from the validate phase prompt (where the model self-graded them) into the tool code (where the model can't fudge them):

**1. Frontmatter whitelist for `allowed-tools`.** Positive allowlist of Claude Code tool names (`Read`, `Edit`, `Write`, `Bash`, `Grep`, `Glob`, etc.). Rejects the literal `None`/`null`/`~` sentinels and invented tool names like `ReadFile` or `Shell`. New `parseAllowedTools()` helper handles both comma-separated and inline-list YAML formats.

**2. Candidate-already-fulfilled gate.** If the incoming write carries a `candidate_id` that is already linked to an existing active skill under a different name, the write is refused with a structured error pointing at the existing skill. Prevents the "fail → re-approve → generate under a new name" loop that produced the unifi-mcp duplicate.

**3. Description Jaccard similarity gate.** `descriptionSimilarity()` tokenizes both descriptions into significant-word sets (≥4 chars, stopwords removed) and computes Jaccard overlap. Writes whose description scores ≥ `DESCRIPTION_DUPLICATE_THRESHOLD` against any active skill are refused.

| Tuning signal | Value |
|---|---|
| Real duplicate pair (`unifi-validator-coercion-pattern` vs `unifi-validator-registry-coercion`) | 0.42 |
| Clearly-distinct skill pairs in the same repo | < 0.2 |
| Chosen threshold | **0.4** |

The threshold leans aggressive on purpose: a false positive is "agent has to reframe its description" (cheap), a false negative is "sibling skill on disk for the same topic" (expensive).

Both dedup gates are skipped when the write target already exists under the same name, so the normal evolve path (bumping generation on an existing skill) is unaffected.

**4. File-write rollback on DB transaction failure.** `vault_write_skill` now snapshots the prior SKILL.md content (or directory existence) before writing, and wraps the DB transaction in a try/catch. On throw, the prior state is restored — either rewriting the prior content or removing the skill directory. Closes the file-leak window where a partial write would leave an orphan file that the next generate cycle would "find" and duplicate.

### Ollama context default + unified variant resolution (`0b8857a`)

`src/agent/ollama-context.ts` + `src/agent/executor.ts` + `ui/src/components/agent/TaskProviderConfig.tsx`

Applies `DEFAULT_OLLAMA_CONTEXT_LENGTH = 32768` when no `context_length` is configured, and consolidates variant creation across task and phase scopes into a single upfront resolution step. New `resolveOllamaContextVariants()` helper scans both scopes, applies the default where unset, creates variants for every unique model in parallel via `ensureOllamaContextVariant`, and rewrites providers to use the variant names. Injectable variant-creator dependency keeps the logic pure and testable.

**Reconciliation rule.** If the same model is referenced at multiple scopes with different `context_length` values, the max wins. This guarantees one Ollama load per model per run regardless of how the user structured their overrides. Conflicts are surfaced via `console.warn` so the user can tighten their config — without blocking the run. Users who want scope-specific contexts should use different *models*, not different context values on the same model.

**Why this matters.** Before: a bare `gemma4:26b` config loaded at 262144 context → 34GB VRAM resident. After: automatically loads at 32768 context → roughly half the VRAM, with no config changes required. The UI placeholder text was also updated from ambiguous `"32768"` to `"32768 (default)"` with an explanatory helper line so the runtime behavior and the UI hint now agree.

The previous task-level-only variant creation is also fixed as a side effect: phase-level Ollama providers that previously bypassed variant creation entirely now get the same treatment.

## Not in scope

A few things I noticed but intentionally deferred:

- **Per-phase model class turn budget multiplier** (auto-scaling turn budgets when the resolved provider is a local model). Wanted to gather empirical evidence on the real cost curve first — the dedup gate alone may make this unnecessary if paired with a per-phase model split.
- **Failed-phase audit log flushing** — failed phases currently lose their in-flight tool_call history because the executor's catch block fires before the SDK drains. Real gap but orthogonal to this PR.
- **Stale `cost_usd` on Ollama runs** — the cost estimator reports non-zero dollar amounts for local runs. Cosmetic but misleading in the run log.

## Test plan

- `npx vitest run` — **1,723 passed, 4 skipped** (24 new tests on the feature, no regressions)
- `make build` — full quality gate (typecheck + tests + UI build + bundler)
- New tests target the non-obvious edges:
  - The real unifi-mcp duplicate pair as a regression case for `descriptionSimilarity()`
  - `allowed-tools: [None]` as a regression case for the frontmatter whitelist
  - Evolve path (same-name update) allowed to bypass both dedup gates
  - Self-overlap on update allowed (a skill shouldn't reject itself)
  - Same-model-different-context reconciliation picks the max and reports a conflict
  - Cloud task provider + Ollama phase override — Ollama phase still gets a variant with default context
  - Phase-level Ollama provider rewriting (the previously-bypassed path)
  - Providers with no model set are left alone

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)