### PR TITLE
feat(skills): skill lifecycle audit trail, staging pipeline, and workflow lockdown

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -7,3 +7,6 @@ MYCO_CMD = "myco-dev"
 [mcp_servers.myco]
 command = "myco-run"
 args = ["mcp"]
+
+[features]
+codex_hooks = true

--- a/.myco/myco.yaml
+++ b/.myco/myco.yaml
@@ -35,7 +35,8 @@ agent:
     title-summary:
       provider:
         type: cloud
-        model: claude-haiku-4-5-20251001
+        model: claude-sonnet-4-6
+      timeoutSeconds: 180
     title-summary-custom:
       provider:
         type: ollama
@@ -74,11 +75,14 @@ context:
   prompt_max_spores: 3
 backup:
   dir: ~/myco_backups/myco
+maintenance:
+  auto_optimize: true
+  auto_optimize_interval_hours: 24
 team:
   enabled: true
   worker_url: https://myco-team-974bc350.goondocks.workers.dev
   interval_minutes: 15
-  deployed_worker_version: 0.15.0
+  deployed_worker_version: 0.15.1
 skills:
   confidence_threshold: 0.7
   usage_stale_days: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,55 @@ Concrete requirements:
 
 If an operation cannot be made idempotent, it MUST be guarded by an explicit check (e.g., "skip if already migrated") and that guard MUST be documented in the code.
 
+## Dispatch Tables Over If-Ladders
+
+When the same shape of decision is repeated — "try these options in priority order", "map this kind to that handler", "pick the first non-null field" — encode the rules as **data**, not as a chain of `if`/`else if` statements. Iterate the table; don't branch through it.
+
+**Why:** an if-ladder buries the rule in control flow. Adding a rule means editing logic, and re-ordering priority means moving blocks around. A table puts the rules in one place, ordered top-to-bottom, with each rule self-contained. Adding a new rule is a one-line append. Re-ordering priority is moving a line. Reviewers see the whole decision at a glance.
+
+<Bad>
+```ts
+function dataHint(data: Record<string, unknown> | null): string {
+  if (!data) return '';
+  const toolName = pick('tool_name');
+  if (toolName) return toolName;
+  const type = pick('type');
+  if (type) return type;
+  const agentType = pick('agent_type');
+  if (agentType) return agentType;
+  // ...7 more identical branches
+}
+```
+</Bad>
+
+<Good>
+```ts
+const HINT_RULES: Array<{
+  pick: (d: Record<string, unknown>) => string | null;
+  format?: (v: string) => string;
+}> = [
+  { pick: (d) => str(d.tool_name) },
+  { pick: (d) => str(d.type) },
+  { pick: (d) => str(d.agent_type) },
+  { pick: (d) => str(d.task_subject), format: (s) => truncate(s, 40) },
+  { pick: (d) => str(d.source_path) ?? str(d.path), format: basename },
+];
+
+function dataHint(data: Record<string, unknown> | null): string {
+  if (!data) return '';
+  for (const { pick, format } of HINT_RULES) {
+    const v = pick(data);
+    if (v) return format ? format(v) : v;
+  }
+  return '';
+}
+```
+</Good>
+
+**Applies to:** priority-first-match lookups, kind-to-handler dispatch, field extraction, format routing, validation rule chains, any other place where a repeated branching shape starts to appear.
+
+**Does NOT apply to:** genuinely unique branches (two or three unrelated conditionals are clearer as `if`/`else`), guard clauses at the top of a function, or conditions that share no common shape. Only refactor to a table when the rules are structurally uniform.
+
 ## No Magic Literals
 
 Numeric and string constants MUST NOT appear inline in logic. Extract them as named constants at module scope or in a shared constants file.

--- a/src/agent/definitions/tasks/skill-generate.yaml
+++ b/src/agent/definitions/tasks/skill-generate.yaml
@@ -2,12 +2,13 @@ name: skill-generate
 displayName: Skill Generation
 description: >-
   Synthesize a project skill from a vault knowledge candidate.
-  Writes SKILL.md to .agents/skills/ following Anthropic skill design principles.
+  Stages SKILL.md under .myco/staging/skills/, validates it, then
+  promotes it to .agents/skills/ via vault_finalize_skill.
 agent: myco-agent
 prompt: >-
   Generate ONE project-specific skill from the next approved candidate.
   The instruction contains the candidate metadata and pre-assembled
-  source material. Write the skill, then validate it.
+  source material. Stage the skill, validate it, then finalize it.
 isDefault: false
 model: claude-sonnet-4-6
 maxTurns: 30
@@ -94,26 +95,40 @@ phases:
         the pattern, not just document the current state. If a file path
         changes, the procedure should still make sense.
 
-      Use vault_write_skill to write the file. Pass:
-      - name: kebab-case directory name (NO colon — directory-safe name)
-        The myco: prefix goes ONLY in the SKILL.md frontmatter name field,
-        not in the directory name.
+      ## Tool Call
+
+      Call `vault_stage_skill` — NOT `vault_write_skill`. Pass:
+
+      - candidate_id: the candidate ID from the instruction (required)
+      - name: kebab-case directory name (NO colon — directory-safe name).
+        The myco: prefix goes ONLY in the SKILL.md frontmatter name field.
       - display_name: human-readable title
       - description: the frontmatter description text
       - content: the full SKILL.md including frontmatter
-      - candidate_id: the candidate ID from the instruction
       - source_ids: JSON array of source item IDs from the instruction
       - rationale: "Initial generation from candidate survey"
+
+      **Important:** the skill is NOT live after vault_stage_skill.
+      The file is written to .myco/staging/skills/<candidate_id>/SKILL.md
+      and a manifest.json is written alongside. The validate phase will
+      read the staged content, run quality checks, and promote to the
+      live .agents/skills/ directory via vault_finalize_skill. Until
+      that happens, nothing user-visible has changed.
+
+      If vault_stage_skill returns an error (validation, dedup), address
+      the issue and re-call vault_stage_skill with corrected content.
+      The staging file will be overwritten.
     tools:
-      - vault_write_skill
-      - vault_skill_records
+      - vault_stage_skill
     maxTurns: 10
     required: true
 
   - name: validate
     prompt: |
-      Review the skill you just generated. Read it back from
-      vault_skill_records (action: get) to see the stored record.
+      Review the skill you just staged. The staged content is at
+      .myco/staging/skills/<candidate_id>/SKILL.md — read it back
+      directly from disk via the Read tool, or look it up by
+      candidate_id.
 
       Check against these criteria:
 
@@ -131,27 +146,46 @@ phases:
       4. **Length:** Under 500 lines?
 
       5. **Conflicts:** Does it overlap with existing skills?
-         Use vault_skill_records (action: list) to check.
+         Use vault_skill_records (action: list) to check. The
+         staging path's dedup gate already ran on your description;
+         this is a sanity check on the procedural content itself.
 
       6. **Accuracy:** Spot-check 2-3 specific claims against the
          vault. Use vault_search_fts to verify file paths and
          function names mentioned in the skill.
 
-      If any criterion fails, rewrite using vault_write_skill.
-      This automatically bumps the generation.
+      ## If criteria fail
 
-      **CRITICAL:** When rewriting, preserve ALL frontmatter fields from
-      the original — including user-invocable and allowed-tools. Read the
-      existing skill content first and carry every frontmatter field forward.
-      The quality gate will reject writes missing required fields.
+      Call `vault_stage_skill` again with the candidate_id and
+      corrected content. This overwrites the staging file — the
+      dedup gate runs again. Do NOT call vault_finalize_skill until
+      all criteria pass.
+
+      ## If all criteria pass
+
+      Call `vault_finalize_skill` with the candidate_id. This
+      atomically promotes the staged skill to `.agents/skills/<name>/`,
+      inserts the skill_records row + lineage, transitions the
+      candidate to 'generated', creates the symbiont symlinks, and
+      cleans up the staging directory. The preserved approved_at on
+      the candidate is carried through unchanged.
+
+      The skill is ONLY considered complete after vault_finalize_skill
+      returns success. If this phase fails (criterion failure or turn
+      budget exhausted), the task executor cleans up the staging
+      directory so the candidate stays in 'approved' state for the
+      next generate cycle.
+
+      ## Report
 
       Report results using vault_report with:
       - Skill name and path
-      - Generation number
+      - Whether finalize was called
       - Each criterion: pass/fail with brief note
-      - Any rewrites performed
+      - Any re-stages performed
     tools:
-      - vault_write_skill
+      - vault_stage_skill
+      - vault_finalize_skill
       - vault_skill_records
       - vault_skill_candidates
       - vault_spores

--- a/src/agent/executor.ts
+++ b/src/agent/executor.ts
@@ -36,6 +36,7 @@ import { buildPhaseEnv } from './provider.js';
 import { resolveRunConfig } from './config-resolver.js';
 import { resolveOllamaContextVariants } from './ollama-context.js';
 import { computeWaves, phaseSessionId } from './wave-computation.js';
+import { SKILL_GENERATE_TASK } from './instruction-builders.js';
 import type { ContextQueryResult } from './context-queries.js';
 import type { ProviderConfig } from './types.js';
 import type {
@@ -795,11 +796,53 @@ export async function runAgent(
       console.error(`[agent] Failed to save error to DB:`, dbErr);
     }
 
+    await cleanupOnTaskFailure({
+      taskName: config.taskName,
+      vaultDir,
+      runContext: options?.runContext,
+    });
+
     return {
       runId,
       status: STATUS_FAILED,
       error: errorMessage,
       ...(phaseResults ? { phases: phaseResults } : {}),
     };
+  }
+}
+
+/**
+ * Task-specific cleanup fired when a run ends in failure. Exported
+ * for direct unit testing — the real executor call site lives in
+ * runAgent's catch block.
+ *
+ * skill-generate: the draft phase stages SKILL.md + manifest to
+ * .myco/staging/skills/<candidate_id>/ via vault_stage_skill. If the
+ * validate phase (or any later required phase) fails, the staged
+ * content must be removed so the next generate cycle doesn't find an
+ * orphan draft. The daemon periodic sweep is the belt-and-suspenders
+ * backup for anything this hook misses.
+ */
+export async function cleanupOnTaskFailure(args: {
+  taskName: string | undefined;
+  vaultDir: string | undefined;
+  runContext: RunOptions['runContext'];
+}): Promise<void> {
+  if (args.taskName !== SKILL_GENERATE_TASK) return;
+  if (!args.vaultDir) return;
+  const candidateId = args.runContext?.candidate_id;
+  if (!candidateId) return;
+
+  try {
+    const { cleanupStagedSkill } = await import('./tools/skill-staging.js');
+    cleanupStagedSkill(args.vaultDir, candidateId);
+    console.warn(
+      `[agent] skill-generate failed — cleaned up staging for candidate ${candidateId}`,
+    );
+  } catch (cleanupErr) {
+    console.warn(
+      `[agent] Failed to clean staging for candidate ${candidateId}:`,
+      cleanupErr instanceof Error ? cleanupErr.message : cleanupErr,
+    );
   }
 }

--- a/src/agent/instruction-builders.ts
+++ b/src/agent/instruction-builders.ts
@@ -23,6 +23,26 @@ import { epochSeconds } from '@myco/constants.js';
 /** Task name that gets special candidate-injection handling. */
 export const SKILL_GENERATE_TASK = 'skill-generate';
 
+/**
+ * Structured run context dispatchers emit alongside the instruction
+ * string. Lets the executor and tools react to task metadata without
+ * re-parsing the prose instruction.
+ */
+export interface TaskRunContext {
+  candidate_id?: string;
+}
+
+/**
+ * Instruction + structured context bundle returned from the task
+ * dispatcher. The string portion is what the LLM sees; the context
+ * portion flows to the executor for hooks like skill-generate's
+ * staging cleanup.
+ */
+export interface BuiltTaskInstruction {
+  instruction: string;
+  context?: TaskRunContext;
+}
+
 /** Task name for the skill-evolve pipeline step. */
 export const SKILL_EVOLVE_TASK = 'skill-evolve';
 
@@ -37,9 +57,11 @@ export const SKILL_EVOLVE_TASK = 'skill-evolve';
  * material (spore content, session summaries) into the instruction text.
  * The draft phase receives this as context — no gathering tool calls needed.
  *
- * Used by both the API route handler and the scheduler.
+ * Returns both the prose instruction and a structured context bundle
+ * so the executor can read `candidate_id` without regex-parsing the
+ * instruction string.
  */
-export function buildSkillGenerateInstruction(): string | undefined {
+export function buildSkillGenerateInstruction(): BuiltTaskInstruction | undefined {
   const candidates = listCandidates({ status: 'approved', limit: 1 });
   if (candidates.length === 0) return undefined;
   const c = candidates[0];
@@ -75,7 +97,10 @@ export function buildSkillGenerateInstruction(): string | undefined {
     }
   }
 
-  return parts.join('\n');
+  return {
+    instruction: parts.join('\n'),
+    context: { candidate_id: c.id },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -188,21 +213,43 @@ export function buildSkillEvolveInstruction(
 /**
  * Build the pre-assembled instruction for a task that needs one.
  *
- * Returns undefined if the task doesn't need a custom instruction or
- * if no work is available (e.g., no approved candidates for skill-generate).
+ * Returns undefined if the task doesn't need a custom instruction
+ * (generic tasks use their default prompt) OR if no work is available
+ * (e.g., no approved candidates for skill-generate, no skills due for
+ * assessment for skill-evolve). Dispatchers should combine this with
+ * `isInstructionRequiredTask` to distinguish the two cases — see the
+ * scheduler's short-circuit for the "no work to do" path.
  *
  * Single dispatch point used by both the scheduler and the API handler.
  */
 export function buildTaskInstruction(
   taskName: string,
   taskParams?: Record<string, string | number | boolean>,
-): string | undefined {
+): BuiltTaskInstruction | undefined {
   switch (taskName) {
     case SKILL_GENERATE_TASK:
       return buildSkillGenerateInstruction();
-    case SKILL_EVOLVE_TASK:
-      return buildSkillEvolveInstruction(taskParams);
+    case SKILL_EVOLVE_TASK: {
+      const instruction = buildSkillEvolveInstruction(taskParams);
+      return instruction ? { instruction } : undefined;
+    }
     default:
       return undefined;
   }
+}
+
+/**
+ * True when the task cannot run meaningfully without a pre-assembled
+ * instruction — skill-generate needs an approved candidate, skill-evolve
+ * needs at least one skill due for assessment. When buildTaskInstruction
+ * returns undefined for one of these tasks, the dispatcher should skip
+ * the run entirely rather than dispatching the agent with the bare task
+ * prompt (which used to let skill-generate fall back to "pick any
+ * candidate you can find" — the 2026-04-08 unapproved-skill bug).
+ *
+ * Generic tasks like full-intelligence run with their default prompt
+ * and never call buildTaskInstruction, so this returns false for them.
+ */
+export function isInstructionRequiredTask(taskName: string): boolean {
+  return taskName === SKILL_GENERATE_TASK || taskName === SKILL_EVOLVE_TASK;
 }

--- a/src/agent/instruction-builders.ts
+++ b/src/agent/instruction-builders.ts
@@ -240,15 +240,14 @@ export function buildTaskInstruction(
 
 /**
  * True when the task cannot run meaningfully without a pre-assembled
- * instruction — skill-generate needs an approved candidate, skill-evolve
- * needs at least one skill due for assessment. When buildTaskInstruction
- * returns undefined for one of these tasks, the dispatcher should skip
- * the run entirely rather than dispatching the agent with the bare task
- * prompt (which used to let skill-generate fall back to "pick any
- * candidate you can find" — the 2026-04-08 unapproved-skill bug).
+ * instruction — skill-generate needs an approved candidate,
+ * skill-evolve needs at least one skill due for assessment. When
+ * buildTaskInstruction returns undefined for one of these, the
+ * dispatcher must skip the run rather than falling through to the
+ * bare default prompt.
  *
- * Generic tasks like full-intelligence run with their default prompt
- * and never call buildTaskInstruction, so this returns false for them.
+ * Generic tasks like full-intelligence never call buildTaskInstruction,
+ * so this returns false for them.
  */
 export function isInstructionRequiredTask(taskName: string): boolean {
   return taskName === SKILL_GENERATE_TASK || taskName === SKILL_EVOLVE_TASK;

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -34,9 +34,6 @@ export { validateSkillContent, MAX_SKILL_LINES, REQUIRED_FRONTMATTER_FIELDS } fr
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Total number of vault tools defined. */
-export const VAULT_TOOL_COUNT = 21;
-
 /** Options for createVaultTools beyond the required agentId and runId. */
 export interface VaultToolOptions {
   turnOffset?: number;
@@ -70,7 +67,20 @@ const OBSERVABILITY_TOOL_NAMES = new Set(['vault_report']);
 
 const SKILL_TOOL_NAMES = new Set([
   'vault_skill_candidates', 'vault_skill_records', 'vault_write_skill',
+  'vault_stage_skill', 'vault_finalize_skill',
 ]);
+
+/**
+ * Total number of vault tools defined. Derived from the union of the
+ * four tool-group sets above so this constant can never drift from the
+ * actual factory output — adding a tool to a group bumps the count
+ * automatically. Each set is disjoint so the straight sum is correct.
+ */
+export const VAULT_TOOL_COUNT =
+  READ_TOOL_NAMES.size +
+  WRITE_TOOL_NAMES.size +
+  OBSERVABILITY_TOOL_NAMES.size +
+  SKILL_TOOL_NAMES.size;
 
 function setsOverlap(a: Set<string>, b: Set<string>): boolean {
   for (const item of a) { if (b.has(item)) return true; }

--- a/src/agent/tools/skill-staging.ts
+++ b/src/agent/tools/skill-staging.ts
@@ -1,0 +1,166 @@
+/**
+ * Staging filesystem for provisional skill writes.
+ *
+ * Keyed by candidate id so draft-phase re-runs overwrite cleanly and
+ * executor-level cleanup can find the staged content without tracking
+ * additional per-run state.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { join, resolve } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+/** Absolute path to the staging root directory within a vault. */
+export function stagingRoot(vaultDir: string): string {
+  return resolve(vaultDir, 'staging', 'skills');
+}
+
+/** Absolute path to the staged SKILL.md for a given candidate id. */
+export function stagingPath(vaultDir: string, candidateId: string): string {
+  return join(stagingRoot(vaultDir), candidateId, 'SKILL.md');
+}
+
+/** Absolute path to the staged manifest.json for a given candidate id. */
+export function stagingManifestPath(vaultDir: string, candidateId: string): string {
+  return join(stagingRoot(vaultDir), candidateId, 'manifest.json');
+}
+
+// ---------------------------------------------------------------------------
+// Manifest shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Metadata the stage tool persists alongside SKILL.md so the finalize tool
+ * can promote the skill without the agent having to repeat the same fields.
+ * Structured JSON; shape is stable across stage/finalize calls.
+ */
+export interface StagedManifest {
+  candidate_id: string;
+  name: string;
+  display_name: string;
+  description: string;
+  /** JSON-encoded array of source IDs (session/spore/entity). */
+  source_ids: string;
+  /** Human-readable rationale for lineage. */
+  rationale: string;
+}
+
+// ---------------------------------------------------------------------------
+// Read / write
+// ---------------------------------------------------------------------------
+
+/**
+ * Write `content` to the staging path for `candidateId`. Creates
+ * intermediate directories. Returns the absolute path of the written file.
+ *
+ * Overwrites any existing staged content — the draft phase may call this
+ * multiple times during iterative rewrites before the validate phase.
+ */
+export function writeStagedSkill(
+  vaultDir: string,
+  candidateId: string,
+  content: string,
+): string {
+  const path = stagingPath(vaultDir, candidateId);
+  mkdirSync(resolve(path, '..'), { recursive: true });
+  writeFileSync(path, content, 'utf-8');
+  return path;
+}
+
+/** Read the staged SKILL.md for a candidate. Returns `null` if not staged. */
+export function readStagedSkill(vaultDir: string, candidateId: string): string | null {
+  const path = stagingPath(vaultDir, candidateId);
+  if (!existsSync(path)) return null;
+  return readFileSync(path, 'utf-8');
+}
+
+/**
+ * Write the staged manifest for a candidate. Creates intermediate
+ * directories. The manifest is read back by vault_finalize_skill so the
+ * finalize call only needs the candidate_id to know what to promote.
+ */
+export function writeStagedManifest(
+  vaultDir: string,
+  candidateId: string,
+  manifest: StagedManifest,
+): string {
+  const path = stagingManifestPath(vaultDir, candidateId);
+  mkdirSync(resolve(path, '..'), { recursive: true });
+  writeFileSync(path, JSON.stringify(manifest, null, 2), 'utf-8');
+  return path;
+}
+
+/** Read the staged manifest for a candidate. Returns `null` if not staged. */
+export function readStagedManifest(
+  vaultDir: string,
+  candidateId: string,
+): StagedManifest | null {
+  const path = stagingManifestPath(vaultDir, candidateId);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as StagedManifest;
+  } catch {
+    // Corrupt manifest — treat as unstaged so the caller can rewrite
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove the staging directory for a candidate. Idempotent — safe to call
+ * on entries that don't exist, or to call multiple times.
+ */
+export function cleanupStagedSkill(vaultDir: string, candidateId: string): void {
+  const dir = resolve(stagingRoot(vaultDir), candidateId);
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* best-effort — cleanup never blocks callers */
+  }
+}
+
+/**
+ * Return candidate IDs whose staging directories are older than
+ * `maxAgeMs`. Used by the daemon periodic sweep to GC abandoned entries
+ * from runs that crashed before either the finalize or executor-level
+ * cleanup could fire.
+ *
+ * Returns directory names only (not full paths) so callers can pass
+ * them directly to `cleanupStagedSkill`.
+ */
+export function listStaleStagingDirs(vaultDir: string, maxAgeMs: number): string[] {
+  const root = stagingRoot(vaultDir);
+  if (!existsSync(root)) return [];
+
+  const cutoff = Date.now() - maxAgeMs;
+  const stale: string[] = [];
+
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const dirPath = join(root, entry.name);
+    try {
+      const st = statSync(dirPath);
+      if (st.mtimeMs < cutoff) {
+        stale.push(entry.name);
+      }
+    } catch {
+      /* stat failed — skip entry, GC will retry next cycle */
+    }
+  }
+
+  return stale;
+}

--- a/src/agent/tools/skill-tools.ts
+++ b/src/agent/tools/skill-tools.ts
@@ -62,59 +62,22 @@ export function createSkillTools(deps: VaultToolDeps) {
   const { agentId, machineId, projectRoot, vaultDir, recordTurn } = deps;
 
   /**
-   * Tokenize a topic string into a set of significant words. Matches
-   * the tokenization descriptionSimilarity uses internally so the
-   * similarity comparison below is consistent with the skill-level
-   * dedup gate.
-   */
-  function topicTokens(topic: string): Set<string> {
-    return new Set(
-      topic
-        .toLowerCase()
-        .replace(/[^a-z0-9\s]/g, ' ')
-        .split(/\s+/)
-        .filter((w) => w.length > 3),
-    );
-  }
-
-  /**
-   * Compute Jaccard similarity between two topic strings using the
-   * tokenization above. Returns a value in [0, 1].
-   */
-  function topicSimilarity(a: string, b: string): number {
-    const setA = topicTokens(a);
-    const setB = topicTokens(b);
-    if (setA.size === 0 || setB.size === 0) return 0;
-    let intersection = 0;
-    for (const token of setA) {
-      if (setB.has(token)) intersection++;
-    }
-    const union = setA.size + setB.size - intersection;
-    return intersection / union;
-  }
-
-  /**
-   * Threshold for rejecting a new candidate whose topic overlaps an
-   * existing one. Tuned empirically — "Add MCP tool" vs "Add a new
-   * MCP tool to the Myco vault daemon" scores ~0.5; truly distinct
-   * topics like "Install Myco" vs "Render notification" score near 0.
-   */
-  const TOPIC_OVERLAP_THRESHOLD = 0.4;
-
-  /**
    * Find the best-matching existing candidate (if any) whose topic
-   * overlaps the proposed new topic above the threshold. Returns the
-   * candidate with the similarity score attached, or null.
+   * overlaps the proposed new topic above the dedup threshold. Reuses
+   * descriptionSimilarity (Jaccard on significant-word tokens with
+   * stopword filtering) — the same metric the skill-level dedup gate
+   * uses — so topic overlap and description overlap are evaluated on
+   * identical terms.
    */
   function findOverlappingCandidate(
     newTopic: string,
     existing: ReturnType<typeof listCandidates>,
-  ): (ReturnType<typeof listCandidates>[number] & { _score: number }) | null {
-    let best: (ReturnType<typeof listCandidates>[number] & { _score: number }) | null = null;
+  ): { candidate: typeof existing[number]; score: number } | null {
+    let best: { candidate: typeof existing[number]; score: number } | null = null;
     for (const candidate of existing) {
-      const score = topicSimilarity(newTopic, candidate.topic);
-      if (score >= TOPIC_OVERLAP_THRESHOLD && (!best || score > best._score)) {
-        best = { ...candidate, _score: score };
+      const score = descriptionSimilarity(newTopic, candidate.topic);
+      if (score >= DESCRIPTION_DUPLICATE_THRESHOLD && (!best || score > best.score)) {
+        best = { candidate, score };
       }
     }
     return best;
@@ -145,16 +108,8 @@ export function createSkillTools(deps: VaultToolDeps) {
   /**
    * Structural gate enforcing the skill lifecycle invariant: ONLY
    * candidates in 'approved' state can be materialized into skills.
-   *
-   * Used by vault_stage_skill, vault_finalize_skill, and the
-   * vault_write_skill create path. Returns `null` when the candidate
-   * is ready to proceed, or an error payload ready for textResult()
-   * when the caller should be refused.
-   *
-   * This is the defense that closes the 2026-04-08 workflow bug where
-   * skill-generate was writing skills for candidates nobody approved.
-   * The scheduler short-circuits when there are no approved candidates
-   * (belt); this helper rejects any attempt to bypass that (suspenders).
+   * Used by vault_stage_skill, vault_finalize_skill, and
+   * vault_write_skill's create path.
    */
   function requireApprovedCandidate(
     candidateId: string,
@@ -481,19 +436,18 @@ export function createSkillTools(deps: VaultToolDeps) {
           // Guard 2: reject if an existing candidate (any status) has an
           // overlapping topic. The skill-survey prompt tells the agent to
           // check dismissed/generated candidates before re-identifying,
-          // but self-grading is unreliable — this structural check is
-          // the enforcement layer. See feedback_tool_gates_over_self_checks.
+          // but self-grading is unreliable so the check is enforced here.
           const allExisting = listCandidates({ agent_id: agentId, limit: 500 });
-          const existingMatch = findOverlappingCandidate(args.topic, allExisting);
-          if (existingMatch) {
+          const match = findOverlappingCandidate(args.topic, allExisting);
+          if (match) {
             return textResult({
-              error: candidateOverlapError(existingMatch),
+              error: candidateOverlapError(match.candidate),
               existing_candidate: {
-                id: existingMatch.id,
-                status: existingMatch.status,
-                topic: existingMatch.topic,
+                id: match.candidate.id,
+                status: match.candidate.status,
+                topic: match.candidate.topic,
               },
-              similarity: existingMatch._score,
+              similarity: match.score,
             });
           }
 

--- a/src/agent/tools/skill-tools.ts
+++ b/src/agent/tools/skill-tools.ts
@@ -1,7 +1,21 @@
 /**
  * Skill lifecycle vault tools.
  *
- * 3 tools: vault_skill_candidates, vault_skill_records, vault_write_skill
+ * 5 tools:
+ *   - vault_skill_candidates: CRUD over skill candidate rows. The agent
+ *     can only set 'identified' or 'dismissed' on updates; human-only
+ *     'approved' transitions go through the UI / MCP approve action, and
+ *     'generated' is set internally by vault_finalize_skill.
+ *   - vault_skill_records: read/update/delete live skill records.
+ *   - vault_write_skill: one-shot create-or-evolve write path used by
+ *     skill-evolve and any non-staged skill authoring.
+ *   - vault_stage_skill: provisional write used by skill-generate's draft
+ *     phase. Stages SKILL.md + manifest.json under .myco/staging/skills/
+ *     without touching the live DB or .agents/skills/ directory.
+ *   - vault_finalize_skill: promotes a staged skill. Only commit point;
+ *     re-runs dedup + validation as defense in depth, then atomically
+ *     inserts the skill_records row, lineage, candidate transition to
+ *     'generated', disk file, and symlinks. Cleans up staging on success.
  */
 
 import crypto from 'node:crypto';
@@ -21,11 +35,23 @@ import {
 import { insertLineage } from '@myco/db/queries/skill-lineage.js';
 import { notify } from '@myco/notifications/notify.js';
 import {
+  CANDIDATE_STATUS,
+  AGENT_SETTABLE_STATUSES,
+} from '@myco/constants/skill-candidate-status.js';
+import {
   validateSkillContent,
   checkFrontmatterPreservation,
   descriptionSimilarity,
   DESCRIPTION_DUPLICATE_THRESHOLD,
 } from './skill-validator.js';
+import {
+  writeStagedSkill,
+  readStagedSkill,
+  writeStagedManifest,
+  readStagedManifest,
+  cleanupStagedSkill,
+  type StagedManifest,
+} from './skill-staging.js';
 import { textResult, type VaultToolDeps } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -34,6 +60,363 @@ import { textResult, type VaultToolDeps } from './types.js';
 
 export function createSkillTools(deps: VaultToolDeps) {
   const { agentId, machineId, projectRoot, vaultDir, recordTurn } = deps;
+
+  /**
+   * Tokenize a topic string into a set of significant words. Matches
+   * the tokenization descriptionSimilarity uses internally so the
+   * similarity comparison below is consistent with the skill-level
+   * dedup gate.
+   */
+  function topicTokens(topic: string): Set<string> {
+    return new Set(
+      topic
+        .toLowerCase()
+        .replace(/[^a-z0-9\s]/g, ' ')
+        .split(/\s+/)
+        .filter((w) => w.length > 3),
+    );
+  }
+
+  /**
+   * Compute Jaccard similarity between two topic strings using the
+   * tokenization above. Returns a value in [0, 1].
+   */
+  function topicSimilarity(a: string, b: string): number {
+    const setA = topicTokens(a);
+    const setB = topicTokens(b);
+    if (setA.size === 0 || setB.size === 0) return 0;
+    let intersection = 0;
+    for (const token of setA) {
+      if (setB.has(token)) intersection++;
+    }
+    const union = setA.size + setB.size - intersection;
+    return intersection / union;
+  }
+
+  /**
+   * Threshold for rejecting a new candidate whose topic overlaps an
+   * existing one. Tuned empirically — "Add MCP tool" vs "Add a new
+   * MCP tool to the Myco vault daemon" scores ~0.5; truly distinct
+   * topics like "Install Myco" vs "Render notification" score near 0.
+   */
+  const TOPIC_OVERLAP_THRESHOLD = 0.4;
+
+  /**
+   * Find the best-matching existing candidate (if any) whose topic
+   * overlaps the proposed new topic above the threshold. Returns the
+   * candidate with the similarity score attached, or null.
+   */
+  function findOverlappingCandidate(
+    newTopic: string,
+    existing: ReturnType<typeof listCandidates>,
+  ): (ReturnType<typeof listCandidates>[number] & { _score: number }) | null {
+    let best: (ReturnType<typeof listCandidates>[number] & { _score: number }) | null = null;
+    for (const candidate of existing) {
+      const score = topicSimilarity(newTopic, candidate.topic);
+      if (score >= TOPIC_OVERLAP_THRESHOLD && (!best || score > best._score)) {
+        best = { ...candidate, _score: score };
+      }
+    }
+    return best;
+  }
+
+  /**
+   * Build a status-aware rejection message. Each status gets guidance
+   * that matches the lifecycle: dismissed → stay away; generated →
+   * already fulfilled; approved → already queued; identified → update
+   * the existing entry instead of duplicating.
+   */
+  function candidateOverlapError(match: { status: string; topic: string }): string {
+    const common = `already has an existing candidate with a similar topic: "${match.topic}"`;
+    switch (match.status) {
+      case CANDIDATE_STATUS.DISMISSED:
+        return `Candidate rejected: the vault ${common} that was previously dismissed. Do not re-identify dismissed topics.`;
+      case CANDIDATE_STATUS.GENERATED:
+        return `Candidate rejected: the vault ${common} that was already fulfilled by a generated skill. Do not re-identify.`;
+      case CANDIDATE_STATUS.APPROVED:
+        return `Candidate rejected: the vault ${common} that is already queued in approved state. Wait for the generate task to process it.`;
+      case CANDIDATE_STATUS.IDENTIFIED:
+        return `Candidate rejected: the vault ${common} already in the review queue. Update the existing candidate with new evidence (action: update) instead of creating a duplicate.`;
+      default:
+        return `Candidate rejected: the vault ${common} in status '${match.status}'.`;
+    }
+  }
+
+  /**
+   * Structural gate enforcing the skill lifecycle invariant: ONLY
+   * candidates in 'approved' state can be materialized into skills.
+   *
+   * Used by vault_stage_skill, vault_finalize_skill, and the
+   * vault_write_skill create path. Returns `null` when the candidate
+   * is ready to proceed, or an error payload ready for textResult()
+   * when the caller should be refused.
+   *
+   * This is the defense that closes the 2026-04-08 workflow bug where
+   * skill-generate was writing skills for candidates nobody approved.
+   * The scheduler short-circuits when there are no approved candidates
+   * (belt); this helper rejects any attempt to bypass that (suspenders).
+   */
+  function requireApprovedCandidate(
+    candidateId: string,
+  ): Record<string, unknown> | null {
+    const candidate = getCandidate(candidateId);
+    if (!candidate) {
+      return {
+        error:
+          `Candidate ${candidateId} not found. Skill writes require a ` +
+          'candidate in the approved state.',
+      };
+    }
+    if (candidate.status !== CANDIDATE_STATUS.APPROVED) {
+      return {
+        error:
+          `Candidate ${candidateId} is in '${candidate.status}' state. ` +
+          "Skills can only be generated from candidates in 'approved' " +
+          'state — the human review step. If a candidate in an earlier ' +
+          'state needs to become a skill, route it through the normal ' +
+          'approval flow first.',
+        candidate_status: candidate.status,
+      };
+    }
+    return null;
+  }
+
+  /**
+   * Self-contained dedup gate for skill create paths. Returns `null`
+   * when the write is allowed, or an error payload object ready for
+   * textResult() when it should be rejected.
+   *
+   * The gate is a no-op on the evolve path (same name as an existing
+   * active skill) — the caller does not need to guard the call.
+   *
+   * Three checks, in order:
+   *   (1) Same-name exists: delegate to the evolve path. Return null
+   *       so vault_write_skill's existing-record branch can handle it;
+   *       callers that only want create (vault_stage_skill,
+   *       vault_finalize_skill) opt in via `rejectSameName: true`.
+   *   (2) Candidate-already-fulfilled: if the candidate is already
+   *       linked to a different-named active skill.
+   *   (3) Description similarity: Jaccard on significant-word tokens
+   *       against all active skills for this agent.
+   */
+  function checkDedupGates(args: {
+    candidate_id?: string;
+    name: string;
+    description: string;
+    /**
+     * When true, treat an existing skill with the same name as a
+     * rejection (create-only callers). When false, same-name passes
+     * through silently so the caller can dispatch the evolve path.
+     */
+    rejectSameName?: boolean;
+  }): Record<string, unknown> | null {
+    // (1) Same-name check
+    const existingSameName = getSkillRecordByName(args.name);
+    if (existingSameName) {
+      if (args.rejectSameName) {
+        return {
+          error:
+            `Skill "${args.name}" already exists. This path is create-only. ` +
+            'Use vault_write_skill to evolve the existing skill (it bumps the generation), ' +
+            'or mark the current record stale via vault_skill_records first.',
+          existing_skill: {
+            id: existingSameName.id,
+            name: existingSameName.name,
+            path: existingSameName.path,
+          },
+        };
+      }
+      return null;
+    }
+
+    // (2) Candidate-already-fulfilled check
+    if (args.candidate_id) {
+      const candidate = getCandidate(args.candidate_id);
+      if (candidate?.skill_id) {
+        const linkedSkill = getSkillRecord(candidate.skill_id);
+        if (linkedSkill && linkedSkill.name !== args.name) {
+          return {
+            error:
+              `Candidate ${args.candidate_id} is already fulfilled by skill "${linkedSkill.name}". ` +
+              'Do not create a sibling skill. If the existing skill needs changes, ' +
+              'write to the same name to evolve it (this bumps its generation), or ' +
+              'mark it stale via vault_skill_records before replacing.',
+            existing_skill: {
+              id: linkedSkill.id,
+              name: linkedSkill.name,
+              description: linkedSkill.description,
+              path: linkedSkill.path,
+            },
+          };
+        }
+      }
+    }
+
+    // (3) Description similarity check
+    const activeSkills = listSkillRecords({ agent_id: agentId, status: 'active', limit: 200 });
+    let bestMatch: { skill: typeof activeSkills[number]; score: number } | null = null;
+    for (const skill of activeSkills) {
+      const score = descriptionSimilarity(args.description, skill.description);
+      if (score >= DESCRIPTION_DUPLICATE_THRESHOLD && (!bestMatch || score > bestMatch.score)) {
+        bestMatch = { skill, score };
+      }
+    }
+    if (bestMatch) {
+      return {
+        error:
+          `Description overlaps with existing active skill "${bestMatch.skill.name}" ` +
+          `(Jaccard ${bestMatch.score.toFixed(2)}, threshold ${DESCRIPTION_DUPLICATE_THRESHOLD}). ` +
+          'Do not create a duplicate. Either evolve the existing skill by writing to ' +
+          `its name ("${bestMatch.skill.name}"), or reframe this skill so its description ` +
+          'describes a distinct procedure.',
+        overlapping_skill: {
+          id: bestMatch.skill.id,
+          name: bestMatch.skill.name,
+          description: bestMatch.skill.description,
+          path: bestMatch.skill.path,
+        },
+        similarity: bestMatch.score,
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Shared create-path promotion: write SKILL.md to the live
+   * .agents/skills/<name>/ directory, create symbiont symlinks, then
+   * insert the skill_records row + lineage entry in one DB transaction.
+   * If the transaction throws, the disk write is reversed so no orphan
+   * file survives.
+   *
+   * Used by both vault_write_skill's create branch and
+   * vault_finalize_skill. Evolve (generation > 1) stays inline in
+   * vault_write_skill because its rollback semantics differ — it
+   * restores prior content rather than deleting the whole directory.
+   *
+   * `linkCandidate` runs inside the same transaction after the record
+   * is inserted. Callers use it for their own candidate-linking policy:
+   * vault_write_skill does an exact/prefix search over approved
+   * candidates; vault_finalize_skill sets the candidate directly from
+   * the staged manifest.
+   */
+  async function promoteNewSkill(params: {
+    name: string;
+    display_name: string;
+    description: string;
+    content: string;
+    source_ids?: string;
+    candidate_id?: string | null;
+    rationale?: string;
+    linkCandidate?: (recordId: string, now: number) => void;
+    label: string;
+  }): Promise<
+    | { id: string; name: string; path: string; generation: number }
+    | { error: string }
+  > {
+    const root = projectRoot ?? process.cwd();
+    const skillDir = resolve(root, '.agents', 'skills', params.name);
+    const skillPath = resolve(skillDir, 'SKILL.md');
+    // If the directory already exists for a create, it's an orphan
+    // from a prior failed run — we overwrite the file and only remove
+    // the file itself on rollback (not the whole directory) to avoid
+    // clobbering anything else that may share the dir.
+    const skillDirPreexisted = existsSync(skillDir);
+
+    try {
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(skillPath, params.content, 'utf-8');
+    } catch (err) {
+      return {
+        error: `Failed to write skill file: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    try {
+      const { syncSkillSymlinks } = await import('@myco/symbionts/installer.js');
+      syncSkillSymlinks(root, params.name);
+    } catch (err) {
+      console.warn(
+        `[${params.label}] syncSkillSymlinks failed:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+
+    const now = epochSeconds();
+    const relativePath = `.agents/skills/${params.name}/SKILL.md`;
+    const recordId = crypto.randomUUID();
+    const generation = 1;
+
+    const txDb = getDatabase();
+    try {
+      txDb.transaction(() => {
+        insertSkillRecord({
+          id: recordId,
+          agent_id: agentId,
+          machine_id: machineId,
+          name: params.name,
+          display_name: params.display_name,
+          description: params.description,
+          candidate_id: params.candidate_id ?? null,
+          source_ids: params.source_ids,
+          path: relativePath,
+          created_at: now,
+          updated_at: now,
+        });
+
+        insertLineage({
+          id: crypto.randomUUID(),
+          skill_id: recordId,
+          generation,
+          action: 'created',
+          rationale: params.rationale ?? 'Initial skill creation',
+          source_ids_added: params.source_ids,
+          content_snapshot: params.content,
+          created_at: now,
+        });
+
+        params.linkCandidate?.(recordId, now);
+      })();
+    } catch (err) {
+      try {
+        if (!skillDirPreexisted) {
+          rmSync(skillDir, { recursive: true, force: true });
+        } else {
+          rmSync(skillPath, { force: true });
+        }
+      } catch (rollbackErr) {
+        console.warn(
+          `[${params.label}] file rollback after DB failure also failed:`,
+          rollbackErr instanceof Error ? rollbackErr.message : rollbackErr,
+        );
+      }
+      return {
+        error: `Skill write aborted: database transaction failed and on-disk state was rolled back. ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    return {
+      id: recordId,
+      name: params.name,
+      path: relativePath,
+      generation,
+    };
+  }
+
+  /** Emit the standard notification after a successful create or evolve. */
+  function emitSkillNotification(
+    kind: 'created' | 'evolved',
+    opts: { name: string; display_name: string; description: string; recordId: string; generation: number },
+  ) {
+    notify(vaultDir, {
+      domain: 'skills',
+      type: kind === 'created' ? 'skill.created' : 'skill.evolved',
+      title: `Skill ${kind}: ${opts.display_name}`,
+      message: opts.description.slice(0, 120),
+      link: `/skills?skill=${encodeURIComponent(opts.name)}`,
+      metadata: { skillId: opts.recordId, name: opts.name, generation: opts.generation },
+    });
+  }
 
   const vaultSkillCandidates = tool(
     'vault_skill_candidates',
@@ -44,7 +427,12 @@ export function createSkillTools(deps: VaultToolDeps) {
       topic: z.string().optional().describe('Skill topic (required for create)'),
       rationale: z.string().optional().describe('Why this should be a skill (required for create)'),
       confidence: z.number().optional().describe('Confidence score 0-1'),
-      status: z.enum(['identified', 'approved', 'generated', 'dismissed']).optional().describe('Candidate status. Only these values are valid.'),
+      status: z.enum(AGENT_SETTABLE_STATUSES as readonly [string, ...string[]]).optional().describe(
+        "Candidate status — agent-settable values only. 'identified' is " +
+        "the initial state; 'dismissed' retires a candidate. 'approved' " +
+        "and 'generated' are lifecycle transitions owned by the human UI " +
+        'and vault_finalize_skill respectively.',
+      ),
       source_ids: z.string().optional().describe('JSON array of source spore/entity IDs'),
       skill_id: z.string().optional().describe('Associated skill record ID (after materialization)'),
       limit: z.number().optional().describe('Maximum candidates to return (for list)'),
@@ -74,7 +462,7 @@ export function createSkillTools(deps: VaultToolDeps) {
             return textResult({ error: 'topic and rationale are required for create action' });
           }
 
-          // Guard: reject if an active skill already covers this topic.
+          // Guard 1: reject if an active skill already covers this topic.
           // Checks whether all significant words from a skill name appear in the topic.
           const activeSkills = listSkillRecords({ agent_id: agentId, status: 'active', limit: 100 });
           const topicLower = args.topic.toLowerCase();
@@ -87,6 +475,25 @@ export function createSkillTools(deps: VaultToolDeps) {
             return textResult({
               error: 'Candidate rejected: active skill(s) already cover this topic. Update the existing skill via vault_skill_records instead.',
               overlapping_skills: overlapping.map((s) => ({ name: s.name, display_name: s.display_name, description: s.description })),
+            });
+          }
+
+          // Guard 2: reject if an existing candidate (any status) has an
+          // overlapping topic. The skill-survey prompt tells the agent to
+          // check dismissed/generated candidates before re-identifying,
+          // but self-grading is unreliable — this structural check is
+          // the enforcement layer. See feedback_tool_gates_over_self_checks.
+          const allExisting = listCandidates({ agent_id: agentId, limit: 500 });
+          const existingMatch = findOverlappingCandidate(args.topic, allExisting);
+          if (existingMatch) {
+            return textResult({
+              error: candidateOverlapError(existingMatch),
+              existing_candidate: {
+                id: existingMatch.id,
+                status: existingMatch.status,
+                topic: existingMatch.topic,
+              },
+              similarity: existingMatch._score,
             });
           }
 
@@ -206,7 +613,7 @@ export function createSkillTools(deps: VaultToolDeps) {
               console.warn('[vault_skill_records] Failed to remove skill directory:', err instanceof Error ? err.message : err);
             }
             try {
-              const { syncSkillSymlinks } = await import('../../symbionts/installer.js');
+              const { syncSkillSymlinks } = await import('@myco/symbionts/installer.js');
               syncSkillSymlinks(root, result.name, { remove: true });
             } catch (err) {
               console.warn('[vault_skill_records] Failed to remove symlinks:', err instanceof Error ? err.message : err);
@@ -253,84 +660,24 @@ export function createSkillTools(deps: VaultToolDeps) {
         });
       }
 
-      // Dedup gate -- prevents the skill lifecycle from creating sibling
-      // skills that cover the same topic under different names. Two
-      // deterministic checks, both skipped when the write is updating an
-      // existing skill under the same name (the normal evolve path).
-      //
-      // The reason this lives in the tool and not in the validate phase's
-      // prompt: self-graded conflict checks are unreliable, especially for
-      // weaker local models. Observed failure: run fcb66275 passed its own
-      // "no overlap" self-check while an obvious duplicate sat on disk.
-      // See feedback_structural_enforcement — enforce in tools, not prompts.
-      const existingSameName = getSkillRecordByName(args.name);
-      if (!existingSameName) {
-        // (1) Candidate-already-fulfilled check. If the caller passed a
-        //     candidate_id that is already linked to an active skill with a
-        //     different name, refuse the write and point the agent at the
-        //     existing skill.
-        if (args.candidate_id) {
-          const candidate = getCandidate(args.candidate_id);
-          if (candidate?.skill_id) {
-            const linkedSkill = getSkillRecord(candidate.skill_id);
-            if (linkedSkill && linkedSkill.name !== args.name) {
-              recordTurn('vault_write_skill', args);
-              return textResult({
-                error:
-                  `Candidate ${args.candidate_id} is already fulfilled by skill "${linkedSkill.name}". ` +
-                  'Do not create a sibling skill. If the existing skill needs changes, ' +
-                  'write to the same name to evolve it (this bumps its generation), or ' +
-                  'mark it stale via vault_skill_records before replacing.',
-                existing_skill: {
-                  id: linkedSkill.id,
-                  name: linkedSkill.name,
-                  description: linkedSkill.description,
-                  path: linkedSkill.path,
-                },
-              });
-            }
-          }
-        }
-
-        // (2) Description similarity check. Jaccard on significant-word
-        //     tokens — deterministic and cheap. Compares against all active
-        //     skills for this agent; rejects on the highest-scoring match
-        //     above DESCRIPTION_DUPLICATE_THRESHOLD.
-        const activeSkills = listSkillRecords({ agent_id: agentId, status: 'active', limit: 200 });
-        let bestMatch: { skill: typeof activeSkills[number]; score: number } | null = null;
-        for (const skill of activeSkills) {
-          const score = descriptionSimilarity(args.description, skill.description);
-          if (score >= DESCRIPTION_DUPLICATE_THRESHOLD && (!bestMatch || score > bestMatch.score)) {
-            bestMatch = { skill, score };
-          }
-        }
-        if (bestMatch) {
-          recordTurn('vault_write_skill', args);
-          return textResult({
-            error:
-              `Description overlaps with existing active skill "${bestMatch.skill.name}" ` +
-              `(Jaccard ${bestMatch.score.toFixed(2)}, threshold ${DESCRIPTION_DUPLICATE_THRESHOLD}). ` +
-              'Do not create a duplicate. Either evolve the existing skill by writing to ' +
-              `its name ("${bestMatch.skill.name}"), or reframe this skill so its description ` +
-              'describes a distinct procedure.',
-            overlapping_skill: {
-              id: bestMatch.skill.id,
-              name: bestMatch.skill.name,
-              description: bestMatch.skill.description,
-              path: bestMatch.skill.path,
-            },
-            similarity: bestMatch.score,
-          });
-        }
+      // Dedup gate is self-gating: returns null when same-name exists
+      // (the evolve path) so the caller falls through.
+      const dedupError = checkDedupGates({
+        candidate_id: args.candidate_id,
+        name: args.name,
+        description: args.description,
+      });
+      if (dedupError) {
+        recordTurn('vault_write_skill', args);
+        return textResult(dedupError);
       }
+      const existing = getSkillRecordByName(args.name);
 
       const root = projectRoot ?? process.cwd();
-      const skillDir = resolve(root, '.agents', 'skills', args.name);
-      const skillPath = resolve(skillDir, 'SKILL.md');
+      const skillPath = resolve(root, '.agents', 'skills', args.name, 'SKILL.md');
 
       // Frontmatter preservation guard — when updating an existing skill,
       // reject writes that change protected fields (user-invocable, allowed-tools).
-      // These fields are set by the skill author, not the evolve pipeline.
       if (existsSync(skillPath)) {
         const existingContent = readFileSync(skillPath, 'utf-8');
         const violations = checkFrontmatterPreservation(existingContent, args.content);
@@ -343,60 +690,87 @@ export function createSkillTools(deps: VaultToolDeps) {
         }
       }
 
-      // Snapshot the on-disk state BEFORE writing so we can roll back
-      // accurately if the DB transaction fails. Two cases:
-      //   - Skill directory didn't exist: full cleanup on failure
-      //   - Skill directory already existed (update path): restore prior
-      //     SKILL.md content rather than deleting the whole directory
-      const skillDirPreexisted = existsSync(skillDir);
-      let priorSkillContent: string | null = null;
-      if (existsSync(skillPath)) {
-        try { priorSkillContent = readFileSync(skillPath, 'utf-8'); } catch {
-          // If we can't read it, we can't restore it — treat as "no prior"
-          priorSkillContent = null;
+      // Create path: delegate to the shared promoteNewSkill helper.
+      // Candidate linking uses exact-then-prefix matching since the
+      // agent may pass a truncated UUID in the instruction.
+      if (!existing) {
+        // Structural gate: if the caller passed a candidate_id, the
+        // candidate must be in 'approved' state. Evolve path (above)
+        // skips this because the caller is updating an existing skill,
+        // not materializing a fresh candidate.
+        if (args.candidate_id) {
+          const candidateError = requireApprovedCandidate(args.candidate_id);
+          if (candidateError) {
+            recordTurn('vault_write_skill', args);
+            return textResult(candidateError);
+          }
         }
+
+        const linkCandidate = (recordId: string, now: number) => {
+          if (!args.candidate_id) return;
+          const exact = updateCandidate(args.candidate_id, {
+            status: CANDIDATE_STATUS.GENERATED, skill_id: recordId, updated_at: now,
+          });
+          if (exact) return;
+          const approvedCandidates = listCandidates({ status: CANDIDATE_STATUS.APPROVED, limit: 10 });
+          const prefixMatch = approvedCandidates.find((c) => c.id.startsWith(args.candidate_id!));
+          if (prefixMatch) {
+            updateCandidate(prefixMatch.id, {
+              status: CANDIDATE_STATUS.GENERATED, skill_id: recordId, updated_at: now,
+            });
+          }
+        };
+
+        const result = await promoteNewSkill({
+          name: args.name,
+          display_name: args.display_name,
+          description: args.description,
+          content: args.content,
+          source_ids: args.source_ids,
+          candidate_id: args.candidate_id,
+          rationale: args.rationale,
+          linkCandidate,
+          label: 'vault_write_skill',
+        });
+        recordTurn('vault_write_skill', args);
+        if ('error' in result) return textResult(result);
+        emitSkillNotification('created', {
+          name: result.name,
+          display_name: args.display_name,
+          description: args.description,
+          recordId: result.id,
+          generation: result.generation,
+        });
+        return textResult(result);
       }
 
-      // Write file to disk -- must succeed before any DB operations
+      // Evolve path: update existing record, bump generation, preserve
+      // prior SKILL.md content on rollback. This branch stays inline
+      // because its rollback semantics (restore prior content) differ
+      // from the create helper.
+      const priorSkillContent = readFileSync(skillPath, 'utf-8');
+
       try {
-        mkdirSync(skillDir, { recursive: true });
         writeFileSync(skillPath, args.content, 'utf-8');
       } catch (err) {
         return textResult({ error: `Failed to write skill file: ${err instanceof Error ? err.message : String(err)}` });
       }
 
-      // Create agent-specific symlinks so each symbiont discovers the skill.
-      // Uses the shared syncSkillSymlinks which reads manifest skillsTarget paths.
       try {
         const { syncSkillSymlinks } = await import('@myco/symbionts/installer.js');
         syncSkillSymlinks(root, args.name);
       } catch (err) {
-        // Best-effort -- skill file is written, symlinks are convenience
         console.warn('[vault_write_skill] syncSkillSymlinks failed:', err instanceof Error ? err.message : err);
       }
 
       const now = epochSeconds();
       const relativePath = `.agents/skills/${args.name}/SKILL.md`;
+      const generation = existing.generation + 1;
+      const recordId = existing.id;
 
-      // Check for existing record
-      const existing = getSkillRecordByName(args.name);
-
-      let recordId = '';
-      let generation = 0;
-
-      // All DB mutations wrapped in a transaction for atomicity.
-      // File write (above) is the source of truth; DB is derived.
-      //
-      // Rollback policy: if the transaction throws, reverse the on-disk
-      // mutation so a partial write cannot leave an orphaned skill file
-      // that the next generate cycle would then "find" and duplicate.
       const txDb = getDatabase();
       try {
-      txDb.transaction(() => {
-        if (existing) {
-          // Update existing record -- bump generation
-          generation = existing.generation + 1;
-          recordId = existing.id;
+        txDb.transaction(() => {
           updateSkillRecord(existing.id, {
             display_name: args.display_name,
             description: args.description,
@@ -406,7 +780,6 @@ export function createSkillTools(deps: VaultToolDeps) {
             updated_at: now,
           });
 
-          // Record lineage
           insertLineage({
             id: crypto.randomUUID(),
             skill_id: existing.id,
@@ -417,80 +790,10 @@ export function createSkillTools(deps: VaultToolDeps) {
             content_snapshot: args.content,
             created_at: now,
           });
-        } else {
-          // Create new record
-          recordId = crypto.randomUUID();
-          generation = 1;
-          insertSkillRecord({
-            id: recordId,
-            agent_id: agentId,
-            machine_id: machineId,
-            name: args.name,
-            display_name: args.display_name,
-            description: args.description,
-            candidate_id: args.candidate_id ?? null,
-            source_ids: args.source_ids,
-            path: relativePath,
-            created_at: now,
-            updated_at: now,
-          });
-
-          // Record lineage
-          insertLineage({
-            id: crypto.randomUUID(),
-            skill_id: recordId,
-            generation,
-            action: 'created',
-            rationale: args.rationale ?? 'Initial skill creation',
-            source_ids_added: args.source_ids,
-            content_snapshot: args.content,
-            created_at: now,
-          });
-
-          // Auto-link candidate: find the approved candidate this skill was generated from.
-          // Strategy: exact candidate_id -> prefix match.
-          // Does NOT depend on the agent passing the correct ID.
-          const approvedCandidates = listCandidates({ status: 'approved', limit: 10 });
-          let linkedCandidate = false;
-
-          // 1. Try exact candidate_id if provided
-          if (args.candidate_id && !linkedCandidate) {
-            const exact = updateCandidate(args.candidate_id, {
-              status: 'generated', skill_id: recordId, updated_at: now,
-            });
-            if (exact) linkedCandidate = true;
-          }
-
-          // 2. Try prefix match on candidate_id (agent truncates UUIDs)
-          if (args.candidate_id && !linkedCandidate) {
-            const prefixMatch = approvedCandidates.find((c) => c.id.startsWith(args.candidate_id!));
-            if (prefixMatch) {
-              updateCandidate(prefixMatch.id, {
-                status: 'generated', skill_id: recordId, updated_at: now,
-              });
-              linkedCandidate = true;
-            }
-          }
-
-          // No blind fallback -- if neither exact nor prefix match found the candidate,
-          // skip linking. The candidate stays 'approved' for the next generate cycle.
-          // The daemon injection (Layer 2) ensures candidate_id is always provided in
-          // scheduled runs, making this fallback-skip path rare.
-        }
-      })();
+        })();
       } catch (err) {
-        // DB transaction failed after the file was written. Reverse the
-        // on-disk mutation so we don't leave an orphan SKILL.md that will
-        // confuse the next generate cycle. Best-effort — failures here are
-        // logged but not propagated, since we're already in an error path.
         try {
-          if (priorSkillContent !== null) {
-            writeFileSync(skillPath, priorSkillContent, 'utf-8');
-          } else if (!skillDirPreexisted) {
-            rmSync(skillDir, { recursive: true, force: true });
-          } else {
-            rmSync(skillPath, { force: true });
-          }
+          writeFileSync(skillPath, priorSkillContent, 'utf-8');
         } catch (rollbackErr) {
           console.warn(
             '[vault_write_skill] file rollback after DB failure also failed:',
@@ -503,14 +806,12 @@ export function createSkillTools(deps: VaultToolDeps) {
         });
       }
 
-      const isNew = generation === 1;
-      notify(vaultDir, {
-        domain: 'skills',
-        type: isNew ? 'skill.created' : 'skill.evolved',
-        title: isNew ? `Skill created: ${args.display_name}` : `Skill evolved: ${args.display_name}`,
-        message: args.description.slice(0, 120),
-        link: `/skills?skill=${encodeURIComponent(args.name)}`,
-        metadata: { skillId: recordId, name: args.name, generation },
+      emitSkillNotification('evolved', {
+        name: args.name,
+        display_name: args.display_name,
+        description: args.description,
+        recordId,
+        generation,
       });
 
       recordTurn('vault_write_skill', args);
@@ -524,9 +825,189 @@ export function createSkillTools(deps: VaultToolDeps) {
     { annotations: { openWorldHint: true } },
   );
 
+  const vaultStageSkill = tool(
+    'vault_stage_skill',
+    "Stage a provisional SKILL.md under .myco/staging/skills/<candidate_id>/ for later promotion by vault_finalize_skill. Use this from the skill-generate draft phase. The write is NOT live — the skill does not appear under .agents/skills/ and no DB rows are created until vault_finalize_skill is called with the same candidate_id.",
+    {
+      candidate_id: z.string().describe(
+        'Candidate ID from the instruction. Required — staging is keyed by candidate so the validate phase (and on-failure cleanup) can find the staged content.',
+      ),
+      name: z.string().describe('Final skill directory name (kebab-case, no colon). Stored in the manifest for finalize.'),
+      display_name: z.string().describe('Human-readable display name'),
+      description: z.string().describe('Short description — used for the dedup gate and the final skill record'),
+      content: z.string().describe('Full SKILL.md content in markdown including frontmatter'),
+      source_ids: z.string().optional().describe('JSON array of source spore/entity IDs'),
+      rationale: z.string().optional().describe('Why this skill is being created — stored in lineage after finalize'),
+    },
+    async (args) => {
+      recordTurn('vault_stage_skill', args);
+
+      if (!vaultDir) {
+        return textResult({
+          error: 'vault_stage_skill requires vaultDir on the tool deps — staging has no location otherwise',
+        });
+      }
+
+      // Static validation — same rules as vault_write_skill
+      const validationErrors = validateSkillContent(args.content, args.name);
+      if (validationErrors.length > 0) {
+        return textResult({
+          error: 'Skill validation failed. Fix these issues and re-stage.',
+          issues: validationErrors,
+        });
+      }
+
+      // Path traversal guard for the skill name (which becomes a directory)
+      if (!args.name || /[/\\]|\.\./.test(args.name)) {
+        return textResult({
+          error: 'Invalid skill name: must be a simple directory name without path separators or ".."',
+        });
+      }
+
+      // Structural gate: candidate must exist and be in 'approved' state.
+      const candidateError = requireApprovedCandidate(args.candidate_id);
+      if (candidateError) return textResult(candidateError);
+
+      // Dedup gate — create-only, so rejectSameName surfaces the
+      // evolve path as an explicit error. Finalize re-runs the same
+      // gate as defense in depth.
+      const dedupError = checkDedupGates({
+        candidate_id: args.candidate_id,
+        name: args.name,
+        description: args.description,
+        rejectSameName: true,
+      });
+      if (dedupError) return textResult(dedupError);
+
+      // Write staging content + manifest
+      let stagingFilePath: string;
+      try {
+        stagingFilePath = writeStagedSkill(vaultDir, args.candidate_id, args.content);
+        const manifest: StagedManifest = {
+          candidate_id: args.candidate_id,
+          name: args.name,
+          display_name: args.display_name,
+          description: args.description,
+          source_ids: args.source_ids ?? '[]',
+          rationale: args.rationale ?? 'Initial draft',
+        };
+        writeStagedManifest(vaultDir, args.candidate_id, manifest);
+      } catch (err) {
+        return textResult({
+          error: `Failed to write staged skill: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+
+      return textResult({
+        candidate_id: args.candidate_id,
+        staging_path: stagingFilePath,
+        status: 'staged',
+      });
+    },
+    { annotations: { openWorldHint: true } },
+  );
+
+  const vaultFinalizeSkill = tool(
+    'vault_finalize_skill',
+    'Promote a staged skill to live at .agents/skills/<name>/ and insert the skill_records / lineage rows. Call this from skill-generate validate phase after your quality checks pass. Requires vault_stage_skill to have been called earlier with the same candidate_id; reads the staged SKILL.md + manifest rather than taking duplicate metadata.',
+    {
+      candidate_id: z.string().describe('Candidate ID whose staged skill should be promoted. Must match a previous vault_stage_skill call.'),
+    },
+    async (args) => {
+      recordTurn('vault_finalize_skill', args);
+
+      if (!vaultDir) {
+        return textResult({
+          error: 'vault_finalize_skill requires vaultDir on the tool deps',
+        });
+      }
+
+      // Read staged content + manifest
+      const stagedContent = readStagedSkill(vaultDir, args.candidate_id);
+      const manifest = readStagedManifest(vaultDir, args.candidate_id);
+      if (!stagedContent || !manifest) {
+        return textResult({
+          error:
+            `No staged skill found for candidate ${args.candidate_id}. ` +
+            'Call vault_stage_skill first.',
+        });
+      }
+
+      // Defense-in-depth: candidate must still be 'approved' at
+      // finalize time. If a human (or another tool) dismissed the
+      // candidate between stage and finalize, the finalize should
+      // refuse rather than promote the now-rescinded skill.
+      const candidateError = requireApprovedCandidate(args.candidate_id);
+      if (candidateError) return textResult(candidateError);
+
+      // Defense-in-depth: re-run validation against the staged content.
+      // The staging write already validated once, but the file on disk
+      // could have been mutated (tests do this explicitly to check the
+      // guard; a crash between stage and finalize could too).
+      const validationErrors = validateSkillContent(stagedContent, manifest.name);
+      if (validationErrors.length > 0) {
+        return textResult({
+          error: 'Staged skill failed validation on finalize. Re-stage with valid content.',
+          issues: validationErrors,
+        });
+      }
+
+      // Defense-in-depth: re-run dedup against the manifest-declared
+      // description. Catches the "agent staged a fresh description,
+      // then tampered the manifest to collide with a live skill" case,
+      // and also trips if a concurrent evolve landed a same-named skill
+      // between stage and finalize.
+      const dedupError = checkDedupGates({
+        candidate_id: args.candidate_id,
+        name: manifest.name,
+        description: manifest.description,
+        rejectSameName: true,
+      });
+      if (dedupError) return textResult(dedupError);
+
+      // Promote via the shared helper. Candidate link is direct — the
+      // staged manifest guarantees candidate_id exists, so no search.
+      // updateCandidate moves the candidate OUT of 'approved' so its
+      // approved_at audit timestamp is preserved by construction.
+      const result = await promoteNewSkill({
+        name: manifest.name,
+        display_name: manifest.display_name,
+        description: manifest.description,
+        content: stagedContent,
+        source_ids: manifest.source_ids,
+        candidate_id: manifest.candidate_id,
+        rationale: manifest.rationale,
+        linkCandidate: (recordId, now) => {
+          updateCandidate(manifest.candidate_id, {
+            status: CANDIDATE_STATUS.GENERATED,
+            skill_id: recordId,
+            updated_at: now,
+          });
+        },
+        label: 'vault_finalize_skill',
+      });
+      if ('error' in result) return textResult(result);
+
+      // Success — clean up staging and notify.
+      cleanupStagedSkill(vaultDir, args.candidate_id);
+      emitSkillNotification('created', {
+        name: manifest.name,
+        display_name: manifest.display_name,
+        description: manifest.description,
+        recordId: result.id,
+        generation: result.generation,
+      });
+
+      return textResult(result);
+    },
+    { annotations: { openWorldHint: true } },
+  );
+
   return [
     vaultSkillCandidates,
     vaultSkillRecords,
     vaultWriteSkill,
+    vaultStageSkill,
+    vaultFinalizeSkill,
   ];
 }

--- a/src/agent/tools/skill-tools.ts
+++ b/src/agent/tools/skill-tools.ts
@@ -278,6 +278,31 @@ export function createSkillTools(deps: VaultToolDeps) {
     // clobbering anything else that may share the dir.
     const skillDirPreexisted = existsSync(skillDir);
 
+    async function cleanupCreatedSkillArtifactsOnRollback(): Promise<void> {
+      try {
+        if (!skillDirPreexisted) {
+          rmSync(skillDir, { recursive: true, force: true });
+        } else {
+          rmSync(skillPath, { force: true });
+        }
+      } catch (rollbackErr) {
+        console.warn(
+          `[${params.label}] file rollback after DB failure also failed:`,
+          rollbackErr instanceof Error ? rollbackErr.message : rollbackErr,
+        );
+      }
+
+      try {
+        const { syncSkillSymlinks } = await import('@myco/symbionts/installer.js');
+        syncSkillSymlinks(root, params.name, { remove: true });
+      } catch (rollbackErr) {
+        console.warn(
+          `[${params.label}] symlink rollback after DB failure also failed:`,
+          rollbackErr instanceof Error ? rollbackErr.message : rollbackErr,
+        );
+      }
+    }
+
     try {
       mkdirSync(skillDir, { recursive: true });
       writeFileSync(skillPath, params.content, 'utf-8');
@@ -333,18 +358,7 @@ export function createSkillTools(deps: VaultToolDeps) {
         params.linkCandidate?.(recordId, now);
       })();
     } catch (err) {
-      try {
-        if (!skillDirPreexisted) {
-          rmSync(skillDir, { recursive: true, force: true });
-        } else {
-          rmSync(skillPath, { force: true });
-        }
-      } catch (rollbackErr) {
-        console.warn(
-          `[${params.label}] file rollback after DB failure also failed:`,
-          rollbackErr instanceof Error ? rollbackErr.message : rollbackErr,
-        );
-      }
+      await cleanupCreatedSkillArtifactsOnRollback();
       return {
         error: `Skill write aborted: database transaction failed and on-disk state was rolled back. ${err instanceof Error ? err.message : String(err)}`,
       };

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -185,6 +185,17 @@ export interface RunOptions {
   resumeRunId?: string;
   /** Embedding manager for immediate vector operations during agent tool calls. */
   embeddingManager?: import('@myco/daemon/embedding/manager.js').EmbeddingManager;
+  /**
+   * Structured metadata about the run. Populated by the dispatcher (e.g.
+   * instruction-builders.ts) alongside the free-form `instruction` string
+   * so the executor and tools can react without re-parsing prose.
+   *
+   * `candidate_id` is used by the skill-generate task-failure cleanup
+   * hook to find and remove the staged SKILL.md for a failed run.
+   */
+  runContext?: {
+    candidate_id?: string;
+  };
 }
 
 /** Result of a single agent run. */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,8 +60,6 @@ export const SEARCH_PREVIEW_CHARS = 300;
 export const LOG_PROMPT_PREVIEW_CHARS = 50;
 /** Max chars for an assistant message preview in log entries. */
 export const LOG_MESSAGE_PREVIEW_CHARS = 80;
-/** Max chars for injected context preview in log entries. */
-export const LOG_CONTEXT_PREVIEW_CHARS = 200;
 
 // --- Context injection layer budgets (chars, not tokens — used with .slice()) ---
 export const CONTEXT_SESSION_PREVIEW_CHARS = 80;

--- a/src/constants/log-kinds.ts
+++ b/src/constants/log-kinds.ts
@@ -86,6 +86,7 @@ export const LOG_KINDS = {
   // Session maintenance job
   MAINTENANCE_SESSION: 'maintenance.session',
   MAINTENANCE_EMBEDDING: 'maintenance.embedding',
+  MAINTENANCE_STAGING_GC: 'maintenance.staging-gc',
 
   // API operations
   API_SESSION_DELETE: 'api.session-delete',

--- a/src/constants/skill-candidate-status.ts
+++ b/src/constants/skill-candidate-status.ts
@@ -1,0 +1,49 @@
+/**
+ * Canonical string values for skill_candidates.status.
+ *
+ * The skill lifecycle uses four states:
+ *   - identified: discovered by skill-survey, awaiting human review
+ *   - approved:   human approved; queued for skill-generate
+ *   - generated:  vault_finalize_skill promoted the staged skill to live
+ *   - dismissed:  retired (human or agent)
+ *
+ * See docs/superpowers/plans/2026-04-08-skill-lifecycle-audit-and-staging.md
+ * for the lifecycle transitions and who is allowed to make each one.
+ */
+export const CANDIDATE_STATUS = {
+  IDENTIFIED: 'identified',
+  APPROVED: 'approved',
+  GENERATED: 'generated',
+  DISMISSED: 'dismissed',
+} as const;
+
+export type SkillCandidateStatus = (typeof CANDIDATE_STATUS)[keyof typeof CANDIDATE_STATUS];
+
+/**
+ * Statuses the agent-facing vault_skill_candidates tool is allowed to set
+ * on an update. Human-only transitions (approved) and internal-only
+ * transitions (generated, via vault_finalize_skill) are excluded.
+ */
+export const AGENT_SETTABLE_STATUSES: readonly SkillCandidateStatus[] = [
+  CANDIDATE_STATUS.IDENTIFIED,
+  CANDIDATE_STATUS.DISMISSED,
+];
+
+/**
+ * Statuses REST callers (UI + MCP myco_skill_candidates) are allowed to
+ * set. 'generated' is internal — only vault_finalize_skill sets it, and
+ * that path calls updateCandidate directly rather than going through REST.
+ */
+export const REST_SETTABLE_STATUSES: readonly SkillCandidateStatus[] = [
+  CANDIDATE_STATUS.IDENTIFIED,
+  CANDIDATE_STATUS.APPROVED,
+  CANDIDATE_STATUS.DISMISSED,
+];
+
+/**
+ * Composite UI filter value that the REST handler translates into a
+ * multi-status query (`status IN ('approved', 'generated')`). Kept here
+ * so the UI and backend share a single source of truth for the wire
+ * encoding.
+ */
+export const PIPELINE_FILTER_VALUE = `${CANDIDATE_STATUS.APPROVED},${CANDIDATE_STATUS.GENERATED}`;

--- a/src/daemon/api/agent-runs.ts
+++ b/src/daemon/api/agent-runs.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import { listRuns, countRuns, getRun, getLatestRunId } from '@myco/db/queries/runs.js';
 import { listReports } from '@myco/db/queries/reports.js';
 import { listTurnsByRun } from '@myco/db/queries/turns.js';
-import { buildTaskInstruction } from '@myco/agent/instruction-builders.js';
+import { buildTaskInstruction, isInstructionRequiredTask } from '@myco/agent/instruction-builders.js';
 import { loadConfig } from '@myco/config/loader.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
@@ -58,18 +58,44 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
     const { task, instruction: rawInstruction, agentId } = AgentRunBody.parse(req.body);
 
     let instruction = rawInstruction;
+    let runContext: { candidate_id?: string } | undefined;
     if (task && !instruction) {
+      let built;
       try {
         const mycoConfig = loadConfig(vaultDir);
         const taskParams = mycoConfig.agent.tasks?.[task]?.params;
-        instruction = buildTaskInstruction(task, taskParams);
+        built = buildTaskInstruction(task, taskParams);
       } catch {
-        instruction = buildTaskInstruction(task);
+        built = buildTaskInstruction(task);
+      }
+      instruction = built?.instruction;
+      runContext = built?.context;
+
+      // Short-circuit: instruction-required tasks (skill-generate,
+      // skill-evolve) must not run when there's no work to do. For a
+      // manual trigger via the API, surface this as a 200 with a
+      // skipped status rather than a failed run row — the caller
+      // should see "nothing to do" as a valid outcome.
+      if (task && isInstructionRequiredTask(task) && !built) {
+        return {
+          body: {
+            ok: true,
+            message: `Task ${task} skipped — no work to do`,
+            status: 'skipped',
+            reason: 'no-work',
+          },
+        };
       }
     }
 
     const { runAgent } = await import('@myco/agent/executor.js');
-    const resultPromise = runAgent(vaultDir, { task, instruction, agentId, embeddingManager });
+    const resultPromise = runAgent(vaultDir, {
+      task,
+      instruction,
+      agentId,
+      embeddingManager,
+      runContext,
+    });
 
     // runAgent inserts the run row synchronously before the first await.
     // Query for the most recently created run matching this task to get

--- a/src/daemon/api/context.ts
+++ b/src/daemon/api/context.ts
@@ -11,7 +11,6 @@ import { hydrateSearchResults } from '@myco/db/queries/search.js';
 import {
   DEFAULT_AGENT_ID,
   EXCLUDED_SPORE_STATUSES,
-  LOG_CONTEXT_PREVIEW_CHARS,
   PROMPT_CONTEXT_MIN_LENGTH,
   PROMPT_CONTEXT_MIN_SIMILARITY,
   PROMPT_CONTEXT_MAX_TOKENS,
@@ -97,19 +96,19 @@ export function createSessionContextHandler(deps: ContextDeps) {
       const contextText = parts.join('\n\n');
 
       const estimatedTokens = estimateTokens(contextText);
-      const preview = contextText.slice(0, LOG_CONTEXT_PREVIEW_CHARS);
-      logger.info(LOG_KINDS.CONTEXT_SESSION, 'Session context injected', {
-        session_id,
-        source,
-        tier: extract ? tier : undefined,
-        text_length: contextText.length,
-        estimated_tokens: estimatedTokens,
-        generated_at: extract?.generated_at,
-        preview,
-      });
-      logger.debug(LOG_KINDS.CONTEXT_SESSION, `Session context: "${preview}…" (${estimatedTokens} est. tokens, source=${source}${extract ? `, tier=${tier}, generated=${extract.generated_at}` : ''})`, {
-        session_id,
-      });
+      logger.info(
+        LOG_KINDS.CONTEXT_SESSION,
+        `Session context: ${estimatedTokens} est. tokens, source=${source}${extract ? `, tier=${tier}` : ''}`,
+        {
+          session_id,
+          source,
+          tier: extract ? tier : undefined,
+          text_length: contextText.length,
+          estimated_tokens: estimatedTokens,
+          generated_at: extract?.generated_at,
+          injected_text: contextText,
+        },
+      );
 
       return {
         body: {
@@ -211,17 +210,17 @@ export function createPromptContextHandler(deps: ContextDeps) {
 
     const promptTokens = estimateTokens(text);
     const titles = spores.map((s) => s.title);
-    logger.info(LOG_KINDS.CONTEXT_PROMPT, 'Prompt context injected', {
+    // Single log line: summary in the message, full injected text in the data
+    // blob so the log detail panel shows exactly what the model received.
+    // No separate debug line — debug mode shouldn't hide information, and
+    // splitting summary vs. detail across two rows just doubles clicks.
+    logger.info(LOG_KINDS.CONTEXT_PROMPT, `Prompt context: ${spores.length} spores [${titles.join(', ')}] (~${promptTokens} tokens)`, {
       session_id,
       spore_count: spores.length,
-      scores: spores.map((s) => s.score.toFixed(3)),
       spore_titles: titles,
-      estimated_tokens: promptTokens,
-      preview: text.slice(0, LOG_CONTEXT_PREVIEW_CHARS),
-    });
-    logger.debug(LOG_KINDS.CONTEXT_PROMPT, `Prompt context: ${spores.length} spores [${titles.join(', ')}] (~${promptTokens} tokens)`, {
-      session_id,
       scores: spores.map((s) => s.score.toFixed(3)),
+      estimated_tokens: promptTokens,
+      injected_text: text,
     });
 
     return { body: { text } };

--- a/src/daemon/api/log-explorer.ts
+++ b/src/daemon/api/log-explorer.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { searchLogs, getLogsSince, getLogEntry } from '@myco/db/queries/logs.js';
+import { searchLogs, getLogsSince, getLogTail, getLogEntry } from '@myco/db/queries/logs.js';
 import type { LogEntryRow } from '@myco/db/queries/logs.js';
 import { getSession } from '@myco/db/queries/sessions.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
@@ -47,10 +47,14 @@ export async function handleLogStream(req: RouteRequest): Promise<RouteResponse>
   const sinceStr = req.query.since;
   const limitStr = req.query.limit;
   const categoryFilter = req.query.category || undefined;
-  const sinceId = sinceStr ? parseInt(sinceStr, 10) : 0;
   const limit = limitStr ? parseInt(limitStr, 10) : undefined;
 
-  const result = getLogsSince(sinceId, limit);
+  // No `since` param → tail mode: return the latest N entries so the UI can
+  // show "now" on initial load. Explicit `since=<id>` (including `since=0`)
+  // keeps the forward-scan behavior for the follow path.
+  const result = sinceStr === undefined
+    ? getLogTail(limit)
+    : getLogsSince(parseInt(sinceStr, 10), limit);
   const entries = result.entries.map(formatEntry);
   const filtered = categoryFilter
     ? entries.filter((e) => e.category === categoryFilter)

--- a/src/daemon/api/skills.ts
+++ b/src/daemon/api/skills.ts
@@ -34,6 +34,8 @@ import { listLineageForSkill } from '@myco/db/queries/skill-lineage.js';
 import { countUsageForSkill } from '@myco/db/queries/skill-usage.js';
 import { enqueueOutbox } from '@myco/db/queries/team-outbox.js';
 import { isTeamSyncEnabled, getTeamMachineId } from '@myco/daemon/team-context.js';
+import { REST_SETTABLE_STATUSES } from '@myco/constants/skill-candidate-status.js';
+import { parseCsvList } from '@myco/utils/parse-csv-list.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -48,14 +50,20 @@ const DEFAULT_LIST_OFFSET = 0;
 /**
  * List skill candidates with optional status filter and pagination.
  *
- * Query params: status, limit, offset
+ * Query params:
+ *   - status: exact match, or a comma-separated list for multi-status
+ *     filtering (e.g. `status=approved,generated`)
+ *   - limit, offset: standard pagination
  */
 export async function handleListCandidates(req: RouteRequest): Promise<RouteResponse> {
-  const status = req.query.status || undefined;
   const limit = req.query.limit ? Number(req.query.limit) : DEFAULT_LIST_LIMIT;
   const offset = req.query.offset ? Number(req.query.offset) : DEFAULT_LIST_OFFSET;
 
-  const { items: candidates, total } = listCandidatesWithCount({ status, limit, offset });
+  const { items: candidates, total } = listCandidatesWithCount({
+    statuses: parseCsvList(req.query.status),
+    limit,
+    offset,
+  });
 
   return { status: 200, body: { candidates, total } };
 }
@@ -74,10 +82,18 @@ export async function handleGetCandidate(req: RouteRequest): Promise<RouteRespon
 }
 
 /**
+ * Status values REST callers (UI + MCP) are allowed to set.
+ * 'generated' is internal — only vault_finalize_skill sets it, and that
+ * path calls updateCandidate directly rather than going through REST.
+ */
+const ALLOWED_REST_STATUSES = new Set<string>(REST_SETTABLE_STATUSES);
+
+/**
  * Update a skill candidate's fields (typically used to advance its status).
  *
  * Automatically sets updated_at to the current epoch seconds.
- * Returns 400 if no body, 404 if candidate not found.
+ * Returns 400 if no body or if the status value is not in ALLOWED_REST_STATUSES,
+ * 404 if candidate not found.
  */
 export async function handleUpdateCandidate(req: RouteRequest): Promise<RouteResponse> {
   const id = req.params.id;
@@ -86,6 +102,25 @@ export async function handleUpdateCandidate(req: RouteRequest): Promise<RouteRes
 
   // Pick only allowed mutable fields — reject arbitrary body fields
   const { status, topic, rationale, confidence, source_ids, skill_id } = body as Record<string, unknown>;
+
+  // Status whitelist guard — defense in depth against a compromised or
+  // misconfigured MCP client reaching this endpoint with an internal
+  // status. The agent-facing vault_skill_candidates tool also narrows
+  // its Zod enum to the same set.
+  if (status !== undefined) {
+    if (typeof status !== 'string' || !ALLOWED_REST_STATUSES.has(status)) {
+      return {
+        status: 400,
+        body: {
+          error:
+            `Invalid status '${String(status)}'. REST callers may only set: ` +
+            `${[...ALLOWED_REST_STATUSES].join(', ')}. The 'generated' status ` +
+            "is set internally by vault_finalize_skill after validation.",
+        },
+      };
+    }
+  }
+
   const updated = updateCandidate(id, {
     ...(status !== undefined ? { status: status as string } : {}),
     ...(topic !== undefined ? { topic: topic as string } : {}),

--- a/src/daemon/power-jobs.ts
+++ b/src/daemon/power-jobs.ts
@@ -16,8 +16,19 @@ import type { DatabaseMaintenanceManager } from './database/manager.js';
 import { runSessionMaintenance } from './jobs/session-maintenance.js';
 import { createBackup } from './backup.js';
 import { deleteOldLogs } from '@myco/db/queries/logs.js';
+import {
+  listStaleStagingDirs,
+  cleanupStagedSkill,
+} from '@myco/agent/tools/skill-staging.js';
 import { EMBEDDING_BATCH_SIZE, MS_PER_DAY, MS_PER_HOUR } from '@myco/constants.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+
+/**
+ * Maximum age for a staging directory before the sweep reclaims it.
+ * 24 hours is well beyond any legitimate skill-generate run — a task
+ * that failed to clean up via the executor hook has long since gone.
+ */
+const STAGING_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -112,6 +123,28 @@ export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps
           error: (err as Error).message,
         });
       }
+    },
+  });
+
+  // Staging GC: belt-and-suspenders cleanup for skill-generate staging
+  // dirs that escaped the executor's per-run failure hook — e.g., a
+  // daemon crash between draft stage and the failure handler. Running
+  // on every idle tick is cheap because the happy path has zero stale
+  // entries and the check is a single readdir on a typically-empty
+  // directory.
+  powerManager.register({
+    name: 'staging-gc',
+    runIn: ['idle', 'sleep'],
+    fn: async () => {
+      const stale = listStaleStagingDirs(vaultDir, STAGING_MAX_AGE_MS);
+      if (stale.length === 0) return;
+      for (const candidateId of stale) {
+        cleanupStagedSkill(vaultDir, candidateId);
+      }
+      logger.info(LOG_KINDS.MAINTENANCE_STAGING_GC, 'Staging GC swept stale skill drafts', {
+        count: stale.length,
+        candidate_ids: stale,
+      });
     },
   });
 }

--- a/src/daemon/stop-processing.ts
+++ b/src/daemon/stop-processing.ts
@@ -316,7 +316,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
         const filename = `${sessionShort}-t${resolvedPromptNumber}-${j + 1}.${ext}`;
         const imageBuffer = Buffer.from(img.data, 'base64');
         try {
-          insertAttachment({
+          const inserted = insertAttachment({
             id: `${sessionShort}-b${resolvedPromptNumber}-${j + 1}`,
             session_id: sessionId,
             prompt_batch_id: resolvedBatchId ?? undefined,
@@ -325,7 +325,13 @@ export function createStopProcessor(deps: StopProcessorDeps): {
             data: imageBuffer,
             created_at: epochSeconds(),
           });
-          logger.debug(LOG_KINDS.CAPTURE_ATTACHMENT, 'Image stored in DB', { filename, batch: resolvedPromptNumber });
+          // insertAttachment returns undefined on ON CONFLICT DO NOTHING — only
+          // log when a row was actually inserted, otherwise stop-event replays
+          // produce phantom "Image stored in DB" lines for attachments that
+          // were already persisted on a previous run.
+          if (inserted) {
+            logger.debug(LOG_KINDS.CAPTURE_ATTACHMENT, 'Image stored in DB', { filename, batch: resolvedPromptNumber });
+          }
         } catch (err) {
           logger.warn(LOG_KINDS.CAPTURE_ATTACHMENT, 'Failed to record attachment', { error: String(err) });
         }

--- a/src/daemon/task-scheduler.ts
+++ b/src/daemon/task-scheduler.ts
@@ -31,6 +31,13 @@ export interface ScheduledJobContext {
   runTask: (taskName: string) => Promise<void>;
   /** Pre-condition checkers keyed by preCondition name. */
   preConditions: Record<string, () => boolean>;
+  /**
+   * Optional error sink for detached task runs. Because scheduled tasks are
+   * kicked off without awaiting (so the PowerManager tick loop stays
+   * responsive), unhandled rejections from `runTask` land here instead of
+   * propagating through the tick.
+   */
+  onTaskError?: (taskName: string, err: unknown) => void;
 }
 
 /**
@@ -78,13 +85,24 @@ export function buildScheduledJobs(
           if (!check()) return;
         }
 
-        try {
-          context.setTaskRunning(task.name, true);
-          await context.runTask(task.name);
-        } finally {
-          lastRun = Date.now();
-          context.setTaskRunning(task.name, false);
-        }
+        // Kick off the task detached from the PowerManager tick loop.
+        // Scheduled agent runs can take 20+ minutes; awaiting them inside
+        // the tick would starve every other power job (team-sync-flush,
+        // embedding-reconcile, session-maintenance) for the duration.
+        // Re-entry is prevented by the isTaskRunning check above, and
+        // lastRun is stamped before dispatch so interval throttling stays
+        // correct even if the task is still in flight on the next tick.
+        const ctx = context;
+        ctx.setTaskRunning(task.name, true);
+        lastRun = Date.now();
+
+        void ctx.runTask(task.name)
+          .catch((err) => {
+            ctx.onTaskError?.(task.name, err);
+          })
+          .finally(() => {
+            ctx.setTaskRunning(task.name, false);
+          });
       },
     });
   }

--- a/src/daemon/task-scheduling.ts
+++ b/src/daemon/task-scheduling.ts
@@ -13,7 +13,7 @@ import type { PowerManager } from './power.js';
 import type { EmbeddingManager } from './embedding/manager.js';
 import type { ScheduledJobContext } from './task-scheduler.js';
 import { buildScheduledJobs } from './task-scheduler.js';
-import { buildTaskInstruction } from '@myco/agent/instruction-builders.js';
+import { buildTaskInstruction, isInstructionRequiredTask } from '@myco/agent/instruction-builders.js';
 import { countSkillRecords } from '@myco/db/queries/skill-records.js';
 import { countCandidates } from '@myco/db/queries/skill-candidates.js';
 import { getDatabase } from '@myco/db/client.js';
@@ -83,9 +83,29 @@ export async function registerScheduledTasks(
       const { runAgent } = await import('@myco/agent/executor.js');
 
       const taskConfig = config.agent.tasks?.[taskName];
-      const instruction = buildTaskInstruction(taskName, taskConfig?.params);
+      const built = buildTaskInstruction(taskName, taskConfig?.params);
 
-      const result = await runAgent(vaultDir, { task: taskName, instruction, embeddingManager });
+      // Short-circuit: instruction-required tasks (skill-generate,
+      // skill-evolve) must not dispatch the agent when there's no work
+      // to do. For skill-generate this means "no approved candidates" —
+      // dispatching anyway used to let the agent fall back to picking
+      // whatever candidate it could find, which produced unapproved
+      // skills (2026-04-08 workflow bug).
+      if (isInstructionRequiredTask(taskName) && !built) {
+        logger.info(
+          LOG_KINDS.AGENT_RUN,
+          `Scheduled task ${taskName} skipped — no work to do`,
+          { task: taskName, reason: 'no-work' },
+        );
+        return;
+      }
+
+      const result = await runAgent(vaultDir, {
+        task: taskName,
+        instruction: built?.instruction,
+        runContext: built?.context,
+        embeddingManager,
+      });
       logger.info(LOG_KINDS.AGENT_RUN, `Scheduled task ${taskName} completed`, {
         status: result.status,
         runId: result.runId,

--- a/src/daemon/task-scheduling.ts
+++ b/src/daemon/task-scheduling.ts
@@ -85,12 +85,10 @@ export async function registerScheduledTasks(
       const taskConfig = config.agent.tasks?.[taskName];
       const built = buildTaskInstruction(taskName, taskConfig?.params);
 
-      // Short-circuit: instruction-required tasks (skill-generate,
-      // skill-evolve) must not dispatch the agent when there's no work
-      // to do. For skill-generate this means "no approved candidates" —
-      // dispatching anyway used to let the agent fall back to picking
-      // whatever candidate it could find, which produced unapproved
-      // skills (2026-04-08 workflow bug).
+      // Short-circuit: instruction-required tasks must not dispatch
+      // the agent when there's no work. For skill-generate this means
+      // no approved candidates — without the guard the agent falls
+      // back to its default prompt and picks whatever it finds.
       if (isInstructionRequiredTask(taskName) && !built) {
         logger.info(
           LOG_KINDS.AGENT_RUN,

--- a/src/daemon/task-scheduling.ts
+++ b/src/daemon/task-scheduling.ts
@@ -168,6 +168,11 @@ export async function registerScheduledTasks(
         return countCandidates({ status: 'approved' }) > 0;
       },
     },
+    onTaskError: (taskName, err) => {
+      logger.error(LOG_KINDS.AGENT_ERROR, `Detached task "${taskName}" threw`, {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    },
   };
 
   const scheduledJobs = buildScheduledJobs(

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -8,6 +8,7 @@
 
 import type { Database } from 'better-sqlite3';
 import { epochSeconds, DEFAULT_MACHINE_ID } from '@myco/constants.js';
+import { CANDIDATE_STATUS } from '@myco/constants/skill-candidate-status.js';
 import {
   LOG_ENTRIES_TABLE,
   TEAM_OUTBOX_TABLE,
@@ -36,6 +37,7 @@ export const MIGRATIONS: Migration[] = [
   { version: 7, migrate: migrateV6ToV7 },
   { version: 8, migrate: (db) => migrateV7ToV8(db) },
   { version: 9, migrate: (db) => migrateV8ToV9(db) },
+  { version: 10, migrate: (db) => migrateV9ToV10(db) },
 ];
 
 // ---------------------------------------------------------------------------
@@ -527,6 +529,55 @@ function migrateV8ToV9(db: Database): void {
        VALUES (?, ?)
        ON CONFLICT (version) DO NOTHING`,
     ).run(9, epochSeconds());
+
+    db.exec('COMMIT');
+  } catch (err) {
+    db.exec('ROLLBACK');
+    throw err;
+  }
+}
+
+/**
+ * Version 10 adds an audit trail for skill candidate approvals.
+ *
+ *   - skill_candidates.approved_at INTEGER (nullable) — timestamp of the
+ *     first transition into status='approved'. Auto-managed by
+ *     updateCandidate going forward.
+ *
+ * Backfill: rows currently in status 'approved' or 'generated' get
+ * approved_at set to the migration timestamp. This is a one-time,
+ * deliberately-imprecise assumption — the true approval time is lost
+ * for existing rows, so we record "as of the migration, these were
+ * considered approved" rather than inventing timestamps.
+ *
+ * Rows in 'identified' or 'dismissed' state keep approved_at = NULL.
+ *
+ * Idempotent: the ALTER is wrapped in try/catch so re-runs tolerate the
+ * existing column; the backfill uses `WHERE approved_at IS NULL` so it
+ * never overwrites a previously-recorded timestamp.
+ */
+function migrateV9ToV10(db: Database): void {
+  db.exec('BEGIN');
+  try {
+    try {
+      db.exec('ALTER TABLE skill_candidates ADD COLUMN approved_at INTEGER');
+    } catch {
+      // Column already exists -- safe to ignore on re-run
+    }
+
+    const now = epochSeconds();
+    db.prepare(
+      `UPDATE skill_candidates
+         SET approved_at = ?
+       WHERE approved_at IS NULL
+         AND status IN (?, ?)`,
+    ).run(now, CANDIDATE_STATUS.APPROVED, CANDIDATE_STATUS.GENERATED);
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at)
+       VALUES (?, ?)
+       ON CONFLICT (version) DO NOTHING`,
+    ).run(10, epochSeconds());
 
     db.exec('COMMIT');
   } catch (err) {

--- a/src/db/queries/logs.ts
+++ b/src/db/queries/logs.ts
@@ -251,6 +251,31 @@ export function getLogsSince(sinceId: number, limit?: number): LogStreamResult {
 }
 
 /**
+ * Return the most recent N log entries, sorted ASC (oldest of the tail first).
+ *
+ * Used to prime a live-tail stream on initial load — callers then follow the
+ * stream forward with `getLogsSince(cursor)`. Cursor is the max id returned,
+ * or 0 when the table is empty.
+ */
+export function getLogTail(limit?: number): LogStreamResult {
+  const db = getDatabase();
+  const effectiveLimit = limit ?? DEFAULT_STREAM_LIMIT;
+
+  // Select newest first, then reverse — this uses the id index efficiently.
+  const rows = db.prepare(
+    `SELECT id, timestamp, level, kind, component, message, data, session_id
+     FROM log_entries
+     ORDER BY id DESC
+     LIMIT ?`,
+  ).all(effectiveLimit) as Record<string, unknown>[];
+
+  const entries = rows.map(toLogEntryRow).reverse();
+  const cursor = entries.length > 0 ? entries[entries.length - 1].id : 0;
+
+  return { entries, cursor };
+}
+
+/**
  * Retrieve a single log entry by id.
  *
  * @returns the entry row, or null if not found.

--- a/src/db/queries/logs.ts
+++ b/src/db/queries/logs.ts
@@ -7,6 +7,7 @@
 
 import { getDatabase } from '@myco/db/client.js';
 import { LEVEL_ORDER, type LogLevel } from '@myco/daemon/logger.js';
+import { parseCsvList } from '@myco/utils/parse-csv-list.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -172,7 +173,7 @@ export function searchLogs(params: LogSearchParams): LogSearchResult {
 
   // Component filter — comma-separated list
   if (params.component !== undefined && params.component.length > 0) {
-    const components = params.component.split(',').map((c) => c.trim()).filter(Boolean);
+    const components = parseCsvList(params.component);
     if (components.length > 0) {
       conditions.push(`le.component IN (SELECT value FROM json_each(?))`);
       queryParams.push(JSON.stringify(components));

--- a/src/db/queries/skill-candidates.ts
+++ b/src/db/queries/skill-candidates.ts
@@ -32,11 +32,18 @@ export interface CandidateInsert {
   status?: string;
   source_ids?: string;
   skill_id?: string | null;
+  approved_at?: number | null;
   created_at: number;
   updated_at: number;
 }
 
-/** Fields that may be updated on a skill candidate. */
+/**
+ * Fields that may be updated on a skill candidate.
+ *
+ * `approved_at` is normally auto-managed by `updateCandidate` on first
+ * transition into `'approved'` — callers should not set it manually.
+ * It is exposed here so the backfill migration and tests can seed it.
+ */
 export interface CandidateUpdate {
   topic?: string;
   rationale?: string;
@@ -44,6 +51,7 @@ export interface CandidateUpdate {
   status?: string;
   source_ids?: string;
   skill_id?: string | null;
+  approved_at?: number | null;
   updated_at: number;
 }
 
@@ -58,6 +66,7 @@ export interface CandidateRow {
   status: string;
   source_ids: string;
   skill_id: string | null;
+  approved_at: number | null;
   created_at: number;
   updated_at: number;
   synced_at: number | null;
@@ -66,7 +75,15 @@ export interface CandidateRow {
 /** Filter options for `listCandidates`. */
 export interface ListCandidatesOptions {
   agent_id?: string;
+  /** Exact-match status filter. Ignored when `statuses` is provided. */
   status?: string;
+  /**
+   * Multi-status filter emitted as `status IN (?, ?, ...)`. Takes
+   * precedence over `status` when both are set. An empty array is
+   * treated as "no filter" so REST callers can forward user input
+   * without branching.
+   */
+  statuses?: string[];
   limit?: number;
   offset?: number;
 }
@@ -85,6 +102,7 @@ export const CANDIDATE_COLUMNS = [
   'status',
   'source_ids',
   'skill_id',
+  'approved_at',
   'created_at',
   'updated_at',
   'synced_at',
@@ -108,6 +126,7 @@ function toCandidateRow(row: Record<string, unknown>): CandidateRow {
     status: row.status as string,
     source_ids: (row.source_ids as string) ?? '[]',
     skill_id: (row.skill_id as string) ?? null,
+    approved_at: (row.approved_at as number) ?? null,
     created_at: row.created_at as number,
     updated_at: row.updated_at as number,
     synced_at: (row.synced_at as number) ?? null,
@@ -126,7 +145,14 @@ function buildWhere(
     params.push(options.agent_id);
   }
 
-  if (options.status !== undefined) {
+  // Multi-status wins over single-status when both are provided. Empty
+  // array is treated as "no status filter" so REST handlers can forward
+  // user input without branching on presence.
+  if (options.statuses !== undefined && options.statuses.length > 0) {
+    const placeholders = options.statuses.map(() => '?').join(', ');
+    conditions.push(`status IN (${placeholders})`);
+    params.push(...options.statuses);
+  } else if (options.status !== undefined) {
     conditions.push(`status = ?`);
     params.push(options.status);
   }
@@ -152,11 +178,11 @@ export function insertCandidate(data: CandidateInsert): CandidateRow {
   db.prepare(
     `INSERT INTO skill_candidates (
        id, agent_id, machine_id, topic, rationale,
-       confidence, status, source_ids, skill_id,
+       confidence, status, source_ids, skill_id, approved_at,
        created_at, updated_at
      ) VALUES (
        ?, ?, ?, ?, ?,
-       ?, ?, ?, ?,
+       ?, ?, ?, ?, ?,
        ?, ?
      )`,
   ).run(
@@ -169,6 +195,7 @@ export function insertCandidate(data: CandidateInsert): CandidateRow {
     data.status ?? DEFAULT_STATUS,
     data.source_ids ?? '[]',
     data.skill_id ?? null,
+    data.approved_at ?? null,
     data.created_at,
     data.updated_at,
   );
@@ -233,8 +260,24 @@ export function updateCandidate(
 ): CandidateRow | null {
   const db = getDatabase();
 
-  const setClauses: string[] = [];
-  const params: unknown[] = [];
+  // Auto-manage approved_at: stamp on the FIRST transition into 'approved'
+  // and never overwrite thereafter. Single audit trail source of truth —
+  // callers should not set approved_at directly (the field is exposed on
+  // CandidateUpdate only so the backfill migration and tests can seed it).
+  //
+  // Compute the auto-stamped value as a local, then fold it into the
+  // fieldMap iteration below alongside the caller-supplied fields. No
+  // defensive clone of `updates` needed.
+  let autoApprovedAt: number | undefined;
+  if (
+    updates.status === 'approved' &&
+    updates.approved_at === undefined
+  ) {
+    const existing = getCandidate(id);
+    if (existing && existing.approved_at === null) {
+      autoApprovedAt = updates.updated_at;
+    }
+  }
 
   const fieldMap: Record<string, string> = {
     topic: 'topic',
@@ -243,13 +286,21 @@ export function updateCandidate(
     status: 'status',
     source_ids: 'source_ids',
     skill_id: 'skill_id',
+    approved_at: 'approved_at',
     updated_at: 'updated_at',
   };
+
+  const setClauses: string[] = [];
+  const params: unknown[] = [];
+  const updateValues = updates as unknown as Record<string, unknown>;
 
   for (const [key, column] of Object.entries(fieldMap)) {
     if (key in updates) {
       setClauses.push(`${column} = ?`);
-      params.push((updates as unknown as Record<string, unknown>)[key] ?? null);
+      params.push(updateValues[key] ?? null);
+    } else if (key === 'approved_at' && autoApprovedAt !== undefined) {
+      setClauses.push(`${column} = ?`);
+      params.push(autoApprovedAt);
     }
   }
 
@@ -271,16 +322,46 @@ export function updateCandidate(
 }
 
 /**
- * List candidates and return the total count in a single call.
+ * List candidates and return the unpaginated total count in a single
+ * SQL round-trip. The `COUNT(*) OVER ()` window function computes the
+ * total against the full filter set, and then `LIMIT`/`OFFSET` clip
+ * the result set — so `total` always reflects the count before
+ * pagination, matching the two-query implementation this replaces.
  *
- * Runs listCandidates and countCandidates with the same filter options.
- * Saves callers from issuing two separate function calls.
+ * When the filter matches zero rows, the result set is empty and we
+ * fall back to a bare COUNT query for the total. In practice this is
+ * a fast index lookup and happens only on empty pages.
  */
 export function listCandidatesWithCount(
   options: ListCandidatesOptions = {},
 ): { items: CandidateRow[]; total: number } {
-  const items = listCandidates(options);
-  const total = countCandidates(options);
+  const db = getDatabase();
+  const { where, params } = buildWhere(options);
+  const limit = options.limit ?? DEFAULT_LIST_LIMIT;
+  const offset = options.offset ?? 0;
+
+  const rows = db.prepare(
+    `SELECT ${SELECT_COLUMNS}, COUNT(*) OVER () AS __total
+     FROM skill_candidates
+     ${where}
+     ORDER BY confidence DESC, created_at DESC
+     LIMIT ?
+     OFFSET ?`,
+  ).all(...params, limit, offset) as Array<Record<string, unknown> & { __total: number }>;
+
+  if (rows.length === 0) {
+    // Empty page — fall back to COUNT for the total. This keeps
+    // callers that query beyond the last page (offset > total) from
+    // losing visibility into the true count.
+    return { items: [], total: countCandidates(options) };
+  }
+
+  const total = Number(rows[0].__total);
+  const items = rows.map((row) => {
+    // Strip the window-function column before the row mapper sees it.
+    const { __total: _drop, ...rest } = row;
+    return toCandidateRow(rest);
+  });
   return { items, total };
 }
 

--- a/src/db/schema-ddl.ts
+++ b/src/db/schema-ddl.ts
@@ -364,6 +364,7 @@ export const SKILL_CANDIDATES_TABLE = `
     skill_id        TEXT,
     created_at      INTEGER NOT NULL,
     updated_at      INTEGER NOT NULL,
+    approved_at     INTEGER,
     synced_at       INTEGER
   )`;
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -19,7 +19,7 @@ import { TABLE_DDLS, FTS_TABLES, SECONDARY_INDEXES } from './schema-ddl.js';
 import { MIGRATIONS } from './migrations.js';
 
 /** Current schema version -- fresh start for the SQLite era. */
-export const SCHEMA_VERSION = 9;
+export const SCHEMA_VERSION = 10;
 
 // Re-export for backwards compat (other modules import from schema.ts)
 export { DEFAULT_MACHINE_ID };

--- a/src/symbionts/installer.ts
+++ b/src/symbionts/installer.ts
@@ -1,7 +1,7 @@
 import type { SymbiontManifest } from './manifest-schema.js';
 import fs from 'node:fs';
 import path from 'node:path';
-import { findTomlSectionEnd, buildTomlMcpSection } from './toml-helpers.js';
+import { findTomlSectionEnd, buildTomlMcpSection, upsertTomlSection, removeTomlSectionKeys } from './toml-helpers.js';
 import { deepMergeSettings, deepRemoveSettings } from './settings-merge.js';
 import { readJsonFile, writeJsonFile, writeOrDeleteJsonFile } from './json-helpers.js';
 import { ensureAgentsMd, ensureSymlink, isMycoHookGroup } from './install-helpers.js';
@@ -575,7 +575,8 @@ export class SymbiontInstaller {
 
   /**
    * Merge settings template into the target settings file.
-   * Deep merges objects and deduplicates arrays.
+   * JSON targets: deep-merges objects and deduplicates arrays.
+   * TOML targets: emits each top-level template key as a [section] with scalar children.
    */
   installSettings(): boolean {
     const reg = this.manifest.registration;
@@ -585,6 +586,12 @@ export class SymbiontInstaller {
     if (!template) return false;
 
     const targetPath = path.join(this.projectRoot, reg.settingsTarget);
+    const settingsFormat = reg.settingsFormat ?? 'json';
+
+    if (settingsFormat === 'toml') {
+      return this.installSettingsToml(targetPath, template);
+    }
+
     const existing = readJsonFile(targetPath);
     const merged = deepMergeSettings(existing, template);
     writeJsonFile(targetPath, merged);
@@ -592,10 +599,31 @@ export class SymbiontInstaller {
   }
 
   /**
+   * Merge a settings template into a TOML config file.
+   * Each top-level key in the template becomes a [section] header, with its
+   * children written as scalar key = value lines. Existing sections and keys
+   * outside the template (including unrelated sections like [mcp_servers.*])
+   * are preserved.
+   */
+  private installSettingsToml(targetPath: string, template: Record<string, unknown>): boolean {
+    let raw = '';
+    try { raw = fs.readFileSync(targetPath, 'utf-8'); } catch { /* doesn't exist */ }
+
+    for (const [sectionName, values] of Object.entries(template)) {
+      if (!values || typeof values !== 'object' || Array.isArray(values)) continue;
+      raw = upsertTomlSection(raw, sectionName, values as Record<string, unknown>);
+    }
+
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    fs.writeFileSync(targetPath, raw, 'utf-8');
+    return true;
+  }
+
+  /**
    * Remove Myco entries from the target settings file.
    * Template-driven: loads the settings template and removes matching values.
-   * Arrays: filter out values present in the template.
-   * Objects: delete keys present in the template.
+   * JSON: arrays filtered by template values, object keys deleted by name.
+   * TOML: removes each template key from its section; empty sections are dropped.
    */
   uninstallSettings(): boolean {
     const reg = this.manifest.registration;
@@ -605,6 +633,12 @@ export class SymbiontInstaller {
     if (!template) return false;
 
     const targetPath = path.join(this.projectRoot, reg.settingsTarget);
+    const settingsFormat = reg.settingsFormat ?? 'json';
+
+    if (settingsFormat === 'toml') {
+      return this.uninstallSettingsToml(targetPath, template);
+    }
+
     const settings = readJsonFile(targetPath);
     if (Object.keys(settings).length === 0) return false;
 
@@ -612,6 +646,38 @@ export class SymbiontInstaller {
     if (!changed) return false;
 
     writeOrDeleteJsonFile(targetPath, settings);
+    return true;
+  }
+
+  /**
+   * Remove template-defined keys from TOML settings file.
+   * For each section in the template, deletes only the keys the template owns;
+   * other keys and unrelated sections stay intact. Empty sections are stripped.
+   * Deletes the file entirely if no TOML content remains.
+   */
+  private uninstallSettingsToml(targetPath: string, template: Record<string, unknown>): boolean {
+    let raw = '';
+    try { raw = fs.readFileSync(targetPath, 'utf-8'); } catch { return false; }
+    if (!raw.trim()) return false;
+
+    let changed = false;
+    for (const [sectionName, values] of Object.entries(template)) {
+      if (!values || typeof values !== 'object' || Array.isArray(values)) continue;
+      const keys = Object.keys(values as Record<string, unknown>);
+      const next = removeTomlSectionKeys(raw, sectionName, keys);
+      if (next !== raw) {
+        raw = next;
+        changed = true;
+      }
+    }
+
+    if (!changed) return false;
+
+    if (!raw.trim()) {
+      try { fs.unlinkSync(targetPath); } catch { /* ignore */ }
+    } else {
+      fs.writeFileSync(targetPath, raw, 'utf-8');
+    }
     return true;
   }
 
@@ -684,7 +750,7 @@ export class SymbiontInstaller {
     if (!raw.includes(sectionHeader)) return false;
 
     const startIdx = raw.indexOf(sectionHeader);
-    const endIdx = findTomlSectionEnd(raw, startIdx + sectionHeader.length, MYCO_MCP_SERVER_NAME);
+    const endIdx = findTomlSectionEnd(raw, startIdx + sectionHeader.length, `mcp_servers.${MYCO_MCP_SERVER_NAME}`);
     const before = raw.slice(0, startIdx).trimEnd();
     const after = raw.slice(endIdx).trimStart();
     const updated = (before + (before && after ? '\n\n' : '') + after).trimEnd();

--- a/src/symbionts/manifest-schema.ts
+++ b/src/symbionts/manifest-schema.ts
@@ -10,6 +10,8 @@ const RegistrationSchema = z.object({
   mcpFormat: z.enum(['json', 'toml']).default('json'),
   skillsTarget: z.string().optional(),
   settingsTarget: z.string().optional(),
+  /** Format of the settings file. TOML-format agents (e.g., Codex) emit top-level template keys as TOML sections. */
+  settingsFormat: z.enum(['json', 'toml']).default('json'),
   /** Instruction file that stubs out to AGENTS.md. Only for agents that don't read AGENTS.md natively. */
   instructionsFile: z.string().optional(),
 });

--- a/src/symbionts/manifests/codex.yaml
+++ b/src/symbionts/manifests/codex.yaml
@@ -17,3 +17,4 @@ registration:
   mcpFormat: toml
   skillsTarget: .agents/skills
   settingsTarget: .codex/config.toml
+  settingsFormat: toml

--- a/src/symbionts/templates/codex/settings.json
+++ b/src/symbionts/templates/codex/settings.json
@@ -1,0 +1,5 @@
+{
+  "features": {
+    "codex_hooks": true
+  }
+}

--- a/src/symbionts/toml-helpers.ts
+++ b/src/symbionts/toml-helpers.ts
@@ -1,50 +1,174 @@
 /** TOML section header pattern. */
 const TOML_SECTION_RE = /^\[([^\]]+)\]/;
 
-/** Find where a [mcp_servers.<name>] section ends in a TOML string. */
-export function findTomlSectionEnd(raw: string, searchStart: number, serverName: string): number {
-  const subsectionPrefix = `mcp_servers.${serverName}.`;
+/**
+ * Find where a named TOML section ends.
+ *
+ * Walks forward from `searchStart` until it hits a section header that is
+ * NEITHER the named section itself NOR any of its subtables (headers that
+ * start with `${sectionName}.`). Returns `raw.length` if the section extends
+ * to the end of the file.
+ */
+export function findTomlSectionEnd(
+  raw: string,
+  searchStart: number,
+  sectionName: string,
+): number {
+  const subsectionPrefix = `${sectionName}.`;
   const rawLines = raw.slice(searchStart).split('\n');
   let offset = searchStart;
   for (const line of rawLines) {
     offset += line.length + 1;
     const m = line.match(TOML_SECTION_RE);
-    if (m && !m[1].startsWith(subsectionPrefix) && m[1] !== `mcp_servers.${serverName}`) {
+    if (m && !m[1].startsWith(subsectionPrefix) && m[1] !== sectionName) {
       return offset - line.length - 1;
     }
   }
   return raw.length;
 }
 
+/** Format a single TOML key = value line from a JS value. Skips unsupported types. */
+function formatTomlScalarLine(key: string, val: unknown): string | null {
+  if (typeof val === 'string') return `${key} = "${val}"`;
+  if (typeof val === 'boolean') return `${key} = ${val}`;
+  if (typeof val === 'number' && Number.isFinite(val)) return `${key} = ${val}`;
+  if (Array.isArray(val)) {
+    return `${key} = [${val.map((v: unknown) => `"${v}"`).join(', ')}]`;
+  }
+  return null;
+}
+
+/**
+ * Insert or replace a top-level TOML section with the given scalar key/value pairs.
+ *
+ * - Scalar values (string, boolean, number, string[]) are written as `key = value`.
+ * - Nested objects are ignored — use {@link buildTomlMcpSection} or call
+ *   `upsertTomlSection` once per subtable if you need nested tables.
+ * - Idempotent: running twice with the same inputs produces identical output.
+ * - Preserves content before and after the section.
+ */
+export function upsertTomlSection(
+  raw: string,
+  sectionName: string,
+  values: Record<string, unknown>,
+): string {
+  const sectionHeader = `[${sectionName}]`;
+
+  const lines: string[] = [sectionHeader];
+  for (const [key, val] of Object.entries(values)) {
+    const line = formatTomlScalarLine(key, val);
+    if (line !== null) lines.push(line);
+  }
+  const block = lines.join('\n');
+
+  if (raw.includes(sectionHeader)) {
+    const startIdx = raw.indexOf(sectionHeader);
+    const endIdx = findTomlSectionEnd(raw, startIdx + sectionHeader.length, sectionName);
+    const before = raw.slice(0, startIdx).trimEnd();
+    const after = raw.slice(endIdx);
+    const separator = before ? '\n\n' : '';
+    return (before + separator + block + after).trimEnd() + '\n';
+  }
+
+  const separator = raw.trim() ? '\n\n' : '';
+  return (raw.trimEnd() + separator + block).trimEnd() + '\n';
+}
+
+/**
+ * Remove specific keys from a top-level TOML section.
+ *
+ * - Only the listed keys are removed. Other keys in the section are preserved.
+ * - If the section ends up with no content after removal, the whole section
+ *   (header and body) is stripped.
+ * - Returns the updated string; equal to the input if no changes were made.
+ */
+export function removeTomlSectionKeys(
+  raw: string,
+  sectionName: string,
+  keys: string[],
+): string {
+  const sectionHeader = `[${sectionName}]`;
+  if (!raw.includes(sectionHeader)) return raw;
+
+  const startIdx = raw.indexOf(sectionHeader);
+  const endIdx = findTomlSectionEnd(raw, startIdx + sectionHeader.length, sectionName);
+  const sectionBody = raw.slice(startIdx + sectionHeader.length, endIdx);
+
+  const keyRes = keys.map((k) => new RegExp(`^\\s*${escapeRegExp(k)}\\s*=`));
+  const bodyLines = sectionBody.split('\n');
+  const kept: string[] = [];
+  let removedAny = false;
+  let subtableSeen = false;
+  for (const line of bodyLines) {
+    // Once we hit a subtable header, everything after stays (keys belong to the parent)
+    if (subtableSeen || TOML_SECTION_RE.test(line.trim())) {
+      subtableSeen = true;
+      kept.push(line);
+      continue;
+    }
+    if (keyRes.some((re) => re.test(line))) {
+      removedAny = true;
+      continue;
+    }
+    kept.push(line);
+  }
+  if (!removedAny) return raw;
+
+  // Determine whether the parent section still has any key = value lines.
+  const hasRemainingKeys = kept.some((line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) return false;
+    if (TOML_SECTION_RE.test(trimmed)) return false;
+    return /=/.test(trimmed);
+  });
+
+  const before = raw.slice(0, startIdx).trimEnd();
+  let rebuilt: string;
+  if (hasRemainingKeys) {
+    const newBody = kept.join('\n');
+    const separator = before ? '\n\n' : '';
+    rebuilt = before + separator + sectionHeader + newBody;
+  } else {
+    // Drop the header entirely; keep any trailing subtables we preserved above.
+    const trailing = kept.join('\n').trimStart();
+    const separator = before && trailing ? '\n\n' : '';
+    rebuilt = before + separator + trailing;
+  }
+  return rebuilt.trimEnd() + (rebuilt.trim() ? '\n' : '');
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
  * Build/update a specific mcp_servers entry in a TOML string.
  * Pure transformation — returns updated content without writing to disk.
+ *
+ * Handles the MCP-specific `env` subtable pattern; for plain sections use
+ * {@link upsertTomlSection}.
  */
 export function buildTomlMcpSection(
   raw: string,
   serverName: string,
   server: Record<string, unknown>,
 ): string {
-  const sectionHeader = `[mcp_servers.${serverName}]`;
+  const sectionName = `mcp_servers.${serverName}`;
+  const sectionHeader = `[${sectionName}]`;
 
   // Build the TOML block for this server
   const lines: string[] = [sectionHeader];
   for (const [key, val] of Object.entries(server)) {
     if (key === 'env' && typeof val === 'object' && val !== null) continue; // Handle env as subtable
-    if (typeof val === 'string') {
-      lines.push(`${key} = "${val}"`);
-    } else if (Array.isArray(val)) {
-      lines.push(`${key} = [${val.map((v: unknown) => `"${v}"`).join(', ')}]`);
-    } else if (typeof val === 'boolean') {
-      lines.push(`${key} = ${val}`);
-    }
+    const line = formatTomlScalarLine(key, val);
+    if (line !== null) lines.push(line);
   }
 
   // Add env subtable if present
   const env = server.env as Record<string, string> | undefined;
   if (env && Object.keys(env).length > 0) {
     lines.push('');
-    lines.push(`[mcp_servers.${serverName}.env]`);
+    lines.push(`[${sectionName}.env]`);
     for (const [key, val] of Object.entries(env)) {
       lines.push(`${key} = "${val}"`);
     }
@@ -55,7 +179,7 @@ export function buildTomlMcpSection(
   let updated: string;
   if (raw.includes(sectionHeader)) {
     const startIdx = raw.indexOf(sectionHeader);
-    const endIdx = findTomlSectionEnd(raw, startIdx + sectionHeader.length, serverName);
+    const endIdx = findTomlSectionEnd(raw, startIdx + sectionHeader.length, sectionName);
     const before = raw.slice(0, startIdx).trimEnd();
     const after = raw.slice(endIdx);
     const separator = before ? '\n\n' : '';

--- a/src/utils/parse-csv-list.ts
+++ b/src/utils/parse-csv-list.ts
@@ -1,0 +1,16 @@
+/**
+ * Parse a comma-separated query-string value into a trimmed,
+ * non-empty list of tokens. Used by REST handlers that accept
+ * `?field=a,b,c` style multi-value parameters.
+ *
+ * Returns an empty array when the input is undefined, empty, or
+ * contains only whitespace — callers can treat an empty result as
+ * "no filter" without a branch.
+ */
+export function parseCsvList(raw: string | undefined | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+}

--- a/src/worker/src/schema.ts
+++ b/src/worker/src/schema.ts
@@ -8,6 +8,8 @@
  * Fully idempotent — safe to call on every request.
  */
 
+import { CANDIDATE_STATUS } from '@myco/constants/skill-candidate-status.js';
+
 const SESSIONS_TABLE = `
   CREATE TABLE IF NOT EXISTS sessions (
     id                     TEXT NOT NULL,
@@ -305,4 +307,16 @@ export async function initD1Schema(db: D1Database): Promise<void> {
       // Column already exists — expected after first run
     }
   }
+
+  // Backfill approved_at for already-synced historical rows so remote D1
+  // mirrors the local SQLite v10 migration semantics. Idempotent via the
+  // approved_at IS NULL guard.
+  await db.prepare(
+    `UPDATE skill_candidates
+       SET approved_at = strftime('%s', 'now')
+     WHERE approved_at IS NULL
+       AND status IN (?, ?)`,
+  )
+    .bind(CANDIDATE_STATUS.APPROVED, CANDIDATE_STATUS.GENERATED)
+    .run();
 }

--- a/src/worker/src/schema.ts
+++ b/src/worker/src/schema.ts
@@ -194,6 +194,7 @@ const SKILL_CANDIDATES_TABLE = `
     status          TEXT NOT NULL DEFAULT 'identified',
     source_ids      TEXT NOT NULL DEFAULT '[]',
     skill_id        TEXT,
+    approved_at     INTEGER,
     created_at      INTEGER NOT NULL,
     updated_at      INTEGER NOT NULL,
     synced_at       INTEGER,
@@ -295,6 +296,7 @@ export async function initD1Schema(db: D1Database): Promise<void> {
   // Migrations for existing tables (safe to re-run — silently ignored if column exists)
   const migrations = [
     'ALTER TABLE skill_usage ADD COLUMN synced_at INTEGER',
+    'ALTER TABLE skill_candidates ADD COLUMN approved_at INTEGER',
   ];
   for (const sql of migrations) {
     try {

--- a/tests/agent/executor-cleanup.test.ts
+++ b/tests/agent/executor-cleanup.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Direct unit tests for the executor's task-failure cleanup hook.
+ *
+ * The hook fires from runAgent's catch block when a run ends in
+ * failure. Testing the full catch path requires the SDK mock + the
+ * task registry mock, so the cleanup logic is extracted into
+ * `cleanupOnTaskFailure` and tested in isolation here. This keeps
+ * the coverage focused on the branching rules (task name match,
+ * vaultDir presence, runContext.candidate_id presence) and the
+ * filesystem side-effect.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { cleanupOnTaskFailure } from '@myco/agent/executor.js';
+import { SKILL_GENERATE_TASK } from '@myco/agent/instruction-builders.js';
+import {
+  writeStagedSkill,
+  stagingPath,
+  stagingRoot,
+} from '@myco/agent/tools/skill-staging.js';
+
+describe('cleanupOnTaskFailure', () => {
+  let tmpDir: string;
+  let vaultDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'myco-executor-cleanup-')));
+    vaultDir = path.join(tmpDir, '.myco');
+    fs.mkdirSync(vaultDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('removes the staging dir for skill-generate when candidate_id is provided', async () => {
+    writeStagedSkill(vaultDir, 'cand-cleanup-ok', 'content');
+    expect(fs.existsSync(stagingPath(vaultDir, 'cand-cleanup-ok'))).toBe(true);
+
+    await cleanupOnTaskFailure({
+      taskName: SKILL_GENERATE_TASK,
+      vaultDir,
+      runContext: { candidate_id: 'cand-cleanup-ok' },
+    });
+
+    expect(fs.existsSync(stagingPath(vaultDir, 'cand-cleanup-ok'))).toBe(false);
+  });
+
+  it('leaves sibling staging entries alone', async () => {
+    writeStagedSkill(vaultDir, 'cand-a', 'a');
+    writeStagedSkill(vaultDir, 'cand-b', 'b');
+
+    await cleanupOnTaskFailure({
+      taskName: SKILL_GENERATE_TASK,
+      vaultDir,
+      runContext: { candidate_id: 'cand-a' },
+    });
+
+    expect(fs.existsSync(stagingPath(vaultDir, 'cand-a'))).toBe(false);
+    expect(fs.existsSync(stagingPath(vaultDir, 'cand-b'))).toBe(true);
+  });
+
+  it('is a no-op when the task is not skill-generate', async () => {
+    writeStagedSkill(vaultDir, 'cand-unrelated', 'content');
+
+    await cleanupOnTaskFailure({
+      taskName: 'full-intelligence',
+      vaultDir,
+      runContext: { candidate_id: 'cand-unrelated' },
+    });
+
+    // Unrelated task should never touch staging even if a candidate_id
+    // happens to be in the runContext.
+    expect(fs.existsSync(stagingPath(vaultDir, 'cand-unrelated'))).toBe(true);
+  });
+
+  it('is a no-op when the task name is undefined', async () => {
+    writeStagedSkill(vaultDir, 'cand-notask', 'content');
+
+    await cleanupOnTaskFailure({
+      taskName: undefined,
+      vaultDir,
+      runContext: { candidate_id: 'cand-notask' },
+    });
+
+    expect(fs.existsSync(stagingPath(vaultDir, 'cand-notask'))).toBe(true);
+  });
+
+  it('is a no-op when vaultDir is undefined', async () => {
+    // Even if the caller forgot to thread vaultDir, the hook must not
+    // throw — it just silently skips.
+    await expect(
+      cleanupOnTaskFailure({
+        taskName: SKILL_GENERATE_TASK,
+        vaultDir: undefined,
+        runContext: { candidate_id: 'cand-novault' },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('is a no-op when runContext.candidate_id is missing', async () => {
+    writeStagedSkill(vaultDir, 'cand-present', 'content');
+
+    await cleanupOnTaskFailure({
+      taskName: SKILL_GENERATE_TASK,
+      vaultDir,
+      runContext: undefined,
+    });
+
+    // No candidate_id means we don't know which staging dir to clean,
+    // so we leave everything alone and let the periodic GC sweep handle it.
+    expect(fs.existsSync(stagingPath(vaultDir, 'cand-present'))).toBe(true);
+    // The staging root itself still exists (no directory-level sweep here).
+    expect(fs.existsSync(stagingRoot(vaultDir))).toBe(true);
+  });
+
+  it('is idempotent when no staging entry exists for the candidate', async () => {
+    await expect(
+      cleanupOnTaskFailure({
+        taskName: SKILL_GENERATE_TASK,
+        vaultDir,
+        runContext: { candidate_id: 'cand-never-staged' },
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/agent/instruction-builders.test.ts
+++ b/tests/agent/instruction-builders.test.ts
@@ -16,8 +16,17 @@ import { getDatabase } from '@myco/db/client.js';
 import { insertSkillRecord } from '@myco/db/queries/skill-records.js';
 import { insertLineage } from '@myco/db/queries/skill-lineage.js';
 import { insertSpore } from '@myco/db/queries/spores.js';
+import { insertCandidate, updateCandidate } from '@myco/db/queries/skill-candidates.js';
 import { epochSeconds } from '@myco/constants.js';
-import { buildSkillEvolveInstruction } from '@myco/agent/instruction-builders.js';
+import {
+  buildSkillEvolveInstruction,
+  buildSkillGenerateInstruction,
+  buildTaskInstruction,
+  isInstructionRequiredTask,
+  SKILL_GENERATE_TASK,
+  SKILL_EVOLVE_TASK,
+} from '@myco/agent/instruction-builders.js';
+import { CANDIDATE_STATUS } from '@myco/constants/skill-candidate-status.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -187,5 +196,134 @@ describe('buildSkillEvolveInstruction', () => {
 
     const result = buildSkillEvolveInstruction();
     expect(result).toContain(sporeId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSkillGenerateInstruction — returns undefined when no candidates are
+// in the 'approved' state, which is the signal to the dispatcher that the
+// run should be skipped rather than executed against the wrong candidate.
+// ---------------------------------------------------------------------------
+
+describe('buildSkillGenerateInstruction', () => {
+  beforeAll(() => {
+    setupTestDb();
+  });
+
+  afterAll(() => {
+    teardownTestDb();
+  });
+
+  beforeEach(() => {
+    cleanTestDb();
+    createAgent(TEST_AGENT_ID);
+  });
+
+  function seedCandidate(id: string, status: string): void {
+    const now = epochSeconds();
+    insertCandidate({
+      id,
+      agent_id: TEST_AGENT_ID,
+      topic: `Topic for ${id}`,
+      rationale: `Rationale for ${id}`,
+      created_at: now,
+      updated_at: now,
+    });
+    if (status !== CANDIDATE_STATUS.IDENTIFIED) {
+      updateCandidate(id, { status, updated_at: now });
+    }
+  }
+
+  it('returns undefined when no candidates exist', () => {
+    expect(buildSkillGenerateInstruction()).toBeUndefined();
+  });
+
+  it('returns undefined when all candidates are in identified state', () => {
+    seedCandidate('c-1', CANDIDATE_STATUS.IDENTIFIED);
+    seedCandidate('c-2', CANDIDATE_STATUS.IDENTIFIED);
+    expect(buildSkillGenerateInstruction()).toBeUndefined();
+  });
+
+  it('returns undefined when all candidates are in dismissed state', () => {
+    seedCandidate('c-d', CANDIDATE_STATUS.DISMISSED);
+    expect(buildSkillGenerateInstruction()).toBeUndefined();
+  });
+
+  it('returns undefined when all candidates are in generated state', () => {
+    seedCandidate('c-g', CANDIDATE_STATUS.GENERATED);
+    expect(buildSkillGenerateInstruction()).toBeUndefined();
+  });
+
+  it('returns instruction with context when an approved candidate exists', () => {
+    seedCandidate('c-a', CANDIDATE_STATUS.APPROVED);
+    const result = buildSkillGenerateInstruction();
+    expect(result).toBeDefined();
+    expect(result!.instruction).toContain('candidate_id: c-a');
+    expect(result!.context).toEqual({ candidate_id: 'c-a' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isInstructionRequiredTask — the dispatcher contract for "no work → skip".
+// ---------------------------------------------------------------------------
+
+describe('isInstructionRequiredTask', () => {
+  it('returns true for skill-generate', () => {
+    expect(isInstructionRequiredTask(SKILL_GENERATE_TASK)).toBe(true);
+  });
+
+  it('returns true for skill-evolve', () => {
+    expect(isInstructionRequiredTask(SKILL_EVOLVE_TASK)).toBe(true);
+  });
+
+  it('returns false for generic tasks like full-intelligence', () => {
+    expect(isInstructionRequiredTask('full-intelligence')).toBe(false);
+    expect(isInstructionRequiredTask('skill-survey')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTaskInstruction dispatch contract
+// ---------------------------------------------------------------------------
+
+describe('buildTaskInstruction', () => {
+  beforeAll(() => {
+    setupTestDb();
+  });
+
+  afterAll(() => {
+    teardownTestDb();
+  });
+
+  beforeEach(() => {
+    cleanTestDb();
+    createAgent(TEST_AGENT_ID);
+  });
+
+  it('returns undefined for tasks that do not use pre-assembled instructions', () => {
+    expect(buildTaskInstruction('full-intelligence')).toBeUndefined();
+    expect(buildTaskInstruction('skill-survey')).toBeUndefined();
+  });
+
+  it('returns undefined for skill-generate when no approved candidates exist', () => {
+    expect(buildTaskInstruction(SKILL_GENERATE_TASK)).toBeUndefined();
+  });
+
+  it('returns bundle for skill-generate when an approved candidate exists', () => {
+    const now = epochSeconds();
+    insertCandidate({
+      id: 'ready-to-generate',
+      agent_id: TEST_AGENT_ID,
+      topic: 'Ready topic',
+      rationale: 'Ready rationale',
+      created_at: now,
+      updated_at: now,
+    });
+    updateCandidate('ready-to-generate', { status: CANDIDATE_STATUS.APPROVED, updated_at: now });
+
+    const result = buildTaskInstruction(SKILL_GENERATE_TASK);
+    expect(result).toBeDefined();
+    expect(result!.instruction).toContain('Ready topic');
+    expect(result!.context?.candidate_id).toBe('ready-to-generate');
   });
 });

--- a/tests/agent/skill-staging.test.ts
+++ b/tests/agent/skill-staging.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for the skill staging filesystem helpers used by vault_write_skill
+ * and vault_finalize_skill. The staging layer writes provisional SKILL.md
+ * content to .myco/staging/skills/<candidate_id>/ and is cleaned up by
+ * vault_finalize_skill on success, by the task executor on phase failure,
+ * and by the daemon periodic sweep for abandoned entries.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  stagingRoot,
+  stagingPath,
+  stagingManifestPath,
+  writeStagedSkill,
+  readStagedSkill,
+  writeStagedManifest,
+  readStagedManifest,
+  cleanupStagedSkill,
+  listStaleStagingDirs,
+  type StagedManifest,
+} from '@myco/agent/tools/skill-staging.js';
+
+describe('skill staging helpers', () => {
+  let vaultDir: string;
+
+  beforeEach(() => {
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-staging-test-'));
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(vaultDir, { recursive: true, force: true }); } catch {
+      /* best-effort */
+    }
+  });
+
+  describe('stagingRoot / stagingPath', () => {
+    it('stagingRoot returns .myco/staging/skills under vaultDir', () => {
+      expect(stagingRoot(vaultDir)).toBe(path.resolve(vaultDir, 'staging', 'skills'));
+    });
+
+    it('stagingPath keys by candidate id', () => {
+      const candidateId = 'cand-abc-123';
+      expect(stagingPath(vaultDir, candidateId)).toBe(
+        path.resolve(vaultDir, 'staging', 'skills', candidateId, 'SKILL.md'),
+      );
+    });
+  });
+
+  describe('writeStagedSkill / readStagedSkill', () => {
+    it('round-trips SKILL.md content for a candidate', () => {
+      const content = '---\nname: myco:test-skill\n---\n\n# Test\n';
+      const written = writeStagedSkill(vaultDir, 'cand-1', content);
+
+      expect(fs.existsSync(written)).toBe(true);
+      expect(readStagedSkill(vaultDir, 'cand-1')).toBe(content);
+    });
+
+    it('readStagedSkill returns null when no staged content exists', () => {
+      expect(readStagedSkill(vaultDir, 'cand-missing')).toBeNull();
+    });
+
+    it('writeStagedSkill overwrites prior content for the same candidate', () => {
+      writeStagedSkill(vaultDir, 'cand-2', 'original');
+      writeStagedSkill(vaultDir, 'cand-2', 'rewritten');
+      expect(readStagedSkill(vaultDir, 'cand-2')).toBe('rewritten');
+    });
+
+    it('writeStagedSkill creates intermediate directories', () => {
+      const staging = stagingRoot(vaultDir);
+      expect(fs.existsSync(staging)).toBe(false); // not created yet
+      writeStagedSkill(vaultDir, 'cand-3', 'content');
+      expect(fs.existsSync(path.resolve(staging, 'cand-3', 'SKILL.md'))).toBe(true);
+    });
+  });
+
+  describe('manifest round-trip', () => {
+    const manifest: StagedManifest = {
+      candidate_id: 'cand-m',
+      name: 'test-skill',
+      display_name: 'Test Skill',
+      description: 'A skill for round-trip tests',
+      source_ids: '[]',
+      rationale: 'fixture',
+    };
+
+    it('stagingManifestPath points to manifest.json alongside SKILL.md', () => {
+      expect(stagingManifestPath(vaultDir, 'cand-m')).toBe(
+        path.resolve(vaultDir, 'staging', 'skills', 'cand-m', 'manifest.json'),
+      );
+    });
+
+    it('writes and reads a manifest', () => {
+      writeStagedManifest(vaultDir, 'cand-m', manifest);
+      expect(readStagedManifest(vaultDir, 'cand-m')).toEqual(manifest);
+    });
+
+    it('returns null when no manifest is staged', () => {
+      expect(readStagedManifest(vaultDir, 'cand-none')).toBeNull();
+    });
+
+    it('manifest and SKILL.md coexist in the same directory', () => {
+      writeStagedSkill(vaultDir, 'cand-both', '---\nname: myco:test\n---');
+      writeStagedManifest(vaultDir, 'cand-both', manifest);
+      expect(readStagedSkill(vaultDir, 'cand-both')).toContain('myco:test');
+      expect(readStagedManifest(vaultDir, 'cand-both')).toEqual(manifest);
+    });
+  });
+
+  describe('cleanupStagedSkill', () => {
+    it('removes the staging directory for a candidate', () => {
+      writeStagedSkill(vaultDir, 'cand-rm', 'doomed');
+      const dir = path.resolve(stagingRoot(vaultDir), 'cand-rm');
+      expect(fs.existsSync(dir)).toBe(true);
+
+      cleanupStagedSkill(vaultDir, 'cand-rm');
+      expect(fs.existsSync(dir)).toBe(false);
+    });
+
+    it('is idempotent when nothing is staged', () => {
+      expect(() => cleanupStagedSkill(vaultDir, 'cand-never-existed')).not.toThrow();
+    });
+
+    it('leaves sibling staging dirs alone', () => {
+      writeStagedSkill(vaultDir, 'cand-a', 'a');
+      writeStagedSkill(vaultDir, 'cand-b', 'b');
+
+      cleanupStagedSkill(vaultDir, 'cand-a');
+
+      expect(readStagedSkill(vaultDir, 'cand-a')).toBeNull();
+      expect(readStagedSkill(vaultDir, 'cand-b')).toBe('b');
+    });
+  });
+
+  describe('listStaleStagingDirs', () => {
+    it('returns an empty array when staging root does not exist', () => {
+      expect(listStaleStagingDirs(vaultDir, 1000)).toEqual([]);
+    });
+
+    it('excludes fresh entries under the age threshold', () => {
+      writeStagedSkill(vaultDir, 'cand-fresh', 'just written');
+      // 1 hour threshold — fresh entry should not be listed
+      expect(listStaleStagingDirs(vaultDir, 60 * 60 * 1000)).toEqual([]);
+    });
+
+    it('includes entries older than the age threshold', () => {
+      writeStagedSkill(vaultDir, 'cand-old', 'ancient');
+      // Backdate the directory mtime to 2 hours ago
+      const dir = path.resolve(stagingRoot(vaultDir), 'cand-old');
+      const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+      fs.utimesSync(dir, twoHoursAgo, twoHoursAgo);
+
+      // 1 hour threshold — old entry should be listed
+      expect(listStaleStagingDirs(vaultDir, 60 * 60 * 1000)).toEqual(['cand-old']);
+    });
+
+    it('returns only directory names, not full paths', () => {
+      writeStagedSkill(vaultDir, 'cand-named', 'c');
+      const dir = path.resolve(stagingRoot(vaultDir), 'cand-named');
+      const old = new Date(Date.now() - 2 * 60 * 60 * 1000);
+      fs.utimesSync(dir, old, old);
+
+      const stale = listStaleStagingDirs(vaultDir, 60 * 60 * 1000);
+      expect(stale).toHaveLength(1);
+      expect(stale[0]).toBe('cand-named'); // directory name only
+      expect(stale[0]).not.toContain(path.sep);
+    });
+  });
+});

--- a/tests/agent/tools-skills.test.ts
+++ b/tests/agent/tools-skills.test.ts
@@ -1314,6 +1314,63 @@ describe('vault skill tools', () => {
       expect(records.find((r) => r.name === 'defense-stage')).toBeUndefined();
     });
 
+    it('removes symbiont symlinks when finalize rolls back after creating them', async () => {
+      const candidateTool = findTool(tools, 'vault_skill_candidates');
+      const candidate = parseResult(
+        await candidateTool.handler(
+          { action: 'create', topic: 'Rollback cleanup topic', rationale: 'r' },
+          undefined,
+        ),
+      ) as { id: string };
+      approveCandidate(candidate.id);
+      await stageForFinalize(candidate.id, 'rollback-symlink-cleanup');
+
+      // Tamper the staged manifest so the DB transaction fails on the
+      // inserted skill_records.candidate_id FK after the live file and
+      // symbiont symlinks have already been created.
+      const manifestPath = path.join(
+        vaultDir,
+        'staging',
+        'skills',
+        candidate.id,
+        'manifest.json',
+      );
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+      manifest.candidate_id = 'cand-missing-after-stage';
+      fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+      const finalizeTool = findTool(tools, 'vault_finalize_skill');
+      const result = parseResult(
+        await finalizeTool.handler({ candidate_id: candidate.id }, undefined),
+      ) as { error?: string };
+
+      expect(result.error).toContain('database transaction failed');
+
+      const liveFile = path.join(
+        tmpDir,
+        '.agents',
+        'skills',
+        'rollback-symlink-cleanup',
+        'SKILL.md',
+      );
+      const claudeSymlink = path.join(
+        tmpDir,
+        '.claude',
+        'skills',
+        'rollback-symlink-cleanup',
+      );
+      const cursorSymlink = path.join(
+        tmpDir,
+        '.cursor',
+        'skills',
+        'rollback-symlink-cleanup',
+      );
+
+      expect(fs.existsSync(liveFile)).toBe(false);
+      expect(fs.existsSync(claudeSymlink)).toBe(false);
+      expect(fs.existsSync(cursorSymlink)).toBe(false);
+    });
+
     it('preserves approved_at on the candidate after transition to generated', async () => {
       // Seed an already-approved candidate with a known approved_at
       const candidateTool = findTool(tools, 'vault_skill_candidates');

--- a/tests/agent/tools-skills.test.ts
+++ b/tests/agent/tools-skills.test.ts
@@ -5,20 +5,22 @@
  * tool handlers directly against an in-memory database.
  */
 
-import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { z } from 'zod/v4';
 
 // Mock embedding before imports
 vi.mock('@myco/intelligence/embed-query.js', () => ({ tryEmbed: async () => null }));
 
 import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
 import { getDatabase } from '@myco/db/client.js';
-import { insertCandidate } from '@myco/db/queries/skill-candidates.js';
+import { insertCandidate, updateCandidate } from '@myco/db/queries/skill-candidates.js';
 import { insertSkillRecord } from '@myco/db/queries/skill-records.js';
 import { insertRun } from '@myco/db/queries/runs.js';
 import { createVaultTools } from '@myco/agent/tools.js';
+import { CANDIDATE_STATUS } from '@myco/constants/skill-candidate-status.js';
 import type { SdkMcpToolDefinition } from '@anthropic-ai/claude-agent-sdk';
 
 // ---------------------------------------------------------------------------
@@ -39,6 +41,17 @@ function validSkillContent(name: string, body = '# Skill\n\nContent here.') {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Flip a candidate to 'approved' so downstream tools (vault_stage_skill,
+ * vault_write_skill create path, vault_finalize_skill) accept it. The
+ * structural gate rejects non-approved candidates, matching the real
+ * skill-generate workflow where only human-approved candidates reach
+ * these tools.
+ */
+function approveCandidate(id: string): void {
+  updateCandidate(id, { status: CANDIDATE_STATUS.APPROVED, updated_at: epochNow() });
+}
 
 /** Insert an agent directly into the agents table. */
 function createAgent(id: string): void {
@@ -79,26 +92,37 @@ function parseResult(result: { content: Array<{ type: string; text: string }> })
 describe('vault skill tools', () => {
   let tools: ReturnType<typeof createVaultTools>;
   let tmpDir: string;
+  let vaultDir: string;
 
   beforeAll(() => {
     setupTestDb();
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-skills-test-'));
   });
 
   afterAll(() => {
     teardownTestDb();
-    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   beforeEach(() => {
     cleanTestDb();
 
-    // Seed required parent rows
+    // Per-test mkdtemp so tests never share staging or .agents/skills/
+    // state. Eliminates cross-test coupling by construction — no manual
+    // rm -rf needed between tests.
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-skills-test-'));
+    vaultDir = path.join(tmpDir, '.myco');
+    fs.mkdirSync(vaultDir, { recursive: true });
+
     createAgent(TEST_AGENT_ID);
     createRun(TEST_RUN_ID, TEST_AGENT_ID);
 
-    // Create tools for this test with projectRoot set to tmpDir
-    tools = createVaultTools(TEST_AGENT_ID, TEST_RUN_ID, { projectRoot: tmpDir });
+    tools = createVaultTools(TEST_AGENT_ID, TEST_RUN_ID, {
+      projectRoot: tmpDir,
+      vaultDir,
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   // -------------------------------------------------------------------------
@@ -175,17 +199,181 @@ describe('vault skill tools', () => {
     it('list returns created candidates', async () => {
       const t = findTool(tools, 'vault_skill_candidates');
       await t.handler(
-        { action: 'create', topic: 'Topic A', rationale: 'Rationale A' },
+        { action: 'create', topic: 'Author agent pipeline tasks', rationale: 'Rationale A' },
         undefined,
       );
       await t.handler(
-        { action: 'create', topic: 'Topic B', rationale: 'Rationale B' },
+        { action: 'create', topic: 'Configure cross-platform hook guard', rationale: 'Rationale B' },
         undefined,
       );
 
       const listResult = await t.handler({ action: 'list' }, undefined);
       const data = parseResult(listResult) as unknown[];
       expect(data).toHaveLength(2);
+    });
+
+    // Cross-status dedup — skill-survey must not re-identify topics
+    // that were already dismissed, generated, approved, or left as
+    // open identified candidates. The existing active-skill check is
+    // not enough; the full candidate table must be consulted. This is
+    // the structural fix for the 2026-04-08 "dismissed candidates keep
+    // coming back" workflow bug.
+    describe('create: cross-status candidate dedup', () => {
+      function makeTool() {
+        return findTool(tools, 'vault_skill_candidates');
+      }
+
+      async function seedCandidate(
+        topic: string,
+        targetStatus: string,
+      ): Promise<string> {
+        const t = makeTool();
+        const created = parseResult(
+          await t.handler({ action: 'create', topic, rationale: 'seed' }, undefined),
+        ) as { id: string };
+        if (targetStatus !== 'identified') {
+          updateCandidate(created.id, { status: targetStatus, updated_at: epochNow() });
+        }
+        return created.id;
+      }
+
+      it('rejects a new candidate whose topic overlaps a dismissed candidate', async () => {
+        await seedCandidate('How to add a new MCP tool to the Myco vault daemon', 'dismissed');
+
+        const t = makeTool();
+        const result = parseResult(
+          await t.handler(
+            {
+              action: 'create',
+              topic: 'Add a new MCP tool to the Myco vault daemon',
+              rationale: 'Re-identified from a later survey run',
+            },
+            undefined,
+          ),
+        ) as { error?: string; existing_candidate?: { status: string } };
+
+        expect(result.error).toBeDefined();
+        expect(result.error).toMatch(/dismissed/);
+        expect(result.existing_candidate?.status).toBe('dismissed');
+      });
+
+      it('rejects a new candidate whose topic overlaps a generated candidate', async () => {
+        await seedCandidate('Register a recurring PowerManager job', 'generated');
+
+        const t = makeTool();
+        const result = parseResult(
+          await t.handler(
+            {
+              action: 'create',
+              topic: 'Register a new PowerManager job',
+              rationale: 'Duplicate of already-generated skill',
+            },
+            undefined,
+          ),
+        ) as { error?: string; existing_candidate?: { status: string } };
+
+        expect(result.error).toBeDefined();
+        expect(result.error).toMatch(/already fulfilled|generated/);
+        expect(result.existing_candidate?.status).toBe('generated');
+      });
+
+      it('rejects a new candidate whose topic overlaps an approved candidate', async () => {
+        await seedCandidate('Configure Cloudflare team sync for Myco', 'approved');
+
+        const t = makeTool();
+        const result = parseResult(
+          await t.handler(
+            {
+              action: 'create',
+              topic: 'Configure Cloudflare team sync',
+              rationale: 'Duplicate of an already-queued candidate',
+            },
+            undefined,
+          ),
+        ) as { error?: string; existing_candidate?: { status: string } };
+
+        expect(result.error).toBeDefined();
+        expect(result.error).toMatch(/already queued|approved/);
+        expect(result.existing_candidate?.status).toBe('approved');
+      });
+
+      it('rejects a new candidate whose topic overlaps an identified candidate', async () => {
+        await seedCandidate('Install and initialize Myco in a new project', 'identified');
+
+        const t = makeTool();
+        const result = parseResult(
+          await t.handler(
+            {
+              action: 'create',
+              topic: 'Install and initialize Myco',
+              rationale: 'Duplicate of a pending identified candidate',
+            },
+            undefined,
+          ),
+        ) as { error?: string; existing_candidate?: { status: string } };
+
+        expect(result.error).toBeDefined();
+        expect(result.error).toMatch(/review queue|update existing|identified/);
+        expect(result.existing_candidate?.status).toBe('identified');
+      });
+
+      it('allows a genuinely distinct topic alongside a dismissed one', async () => {
+        await seedCandidate('How to author an agent pipeline task', 'dismissed');
+
+        const t = makeTool();
+        const result = parseResult(
+          await t.handler(
+            {
+              action: 'create',
+              topic: 'How to render a notification banner in the UI',
+              rationale: 'Unrelated topic',
+            },
+            undefined,
+          ),
+        ) as { error?: string; id?: string };
+
+        expect(result.error).toBeUndefined();
+        expect(result.id).toBeDefined();
+      });
+    });
+
+    // Privilege separation — humans approve, agents cannot. The MCP boundary
+    // parses args against the tool's inputSchema before invoking the handler.
+    // These tests exercise the schema directly (the test harness calls handler
+    // without schema validation) to prove the Zod enum refuses values the
+    // agent is not allowed to set.
+    describe('status enum narrowing (privilege separation)', () => {
+      it('inputSchema.status rejects "approved"', () => {
+        const t = findTool(tools, 'vault_skill_candidates');
+        const parsed = z.object(t.inputSchema).safeParse({
+          action: 'update',
+          id: 'some-id',
+          status: 'approved',
+        });
+        expect(parsed.success).toBe(false);
+      });
+
+      it('inputSchema.status rejects "generated"', () => {
+        const t = findTool(tools, 'vault_skill_candidates');
+        const parsed = z.object(t.inputSchema).safeParse({
+          action: 'update',
+          id: 'some-id',
+          status: 'generated',
+        });
+        expect(parsed.success).toBe(false);
+      });
+
+      it('inputSchema.status accepts "identified" and "dismissed"', () => {
+        const t = findTool(tools, 'vault_skill_candidates');
+        for (const allowed of ['identified', 'dismissed'] as const) {
+          const parsed = z.object(t.inputSchema).safeParse({
+            action: 'update',
+            id: 'some-id',
+            status: allowed,
+          });
+          expect(parsed.success, `expected ${allowed} to be accepted`).toBe(true);
+        }
+      });
     });
   });
 
@@ -319,13 +507,15 @@ describe('vault skill tools', () => {
     });
 
     it('updates candidate status when candidate_id provided', async () => {
-      // Create a candidate first
+      // Create a candidate first, then flip to approved so the
+      // skill-write tools' structural gate accepts it.
       const candidateTool = findTool(tools, 'vault_skill_candidates');
       const candidateResult = await candidateTool.handler(
         { action: 'create', topic: 'My topic', rationale: 'My rationale' },
         undefined,
       );
       const candidate = parseResult(candidateResult) as { id: string };
+      approveCandidate(candidate.id);
 
       // Write skill with candidate_id
       const t = findTool(tools, 'vault_write_skill');
@@ -457,6 +647,7 @@ describe('vault skill tools', () => {
         undefined,
       );
       const candidate = parseResult(candidateResult) as { id: string };
+      approveCandidate(candidate.id);
 
       const t = findTool(tools, 'vault_write_skill');
       await t.handler(
@@ -503,6 +694,7 @@ describe('vault skill tools', () => {
         undefined,
       );
       const candidate = parseResult(candidateResult) as { id: string };
+      approveCandidate(candidate.id);
 
       const t = findTool(tools, 'vault_write_skill');
       await t.handler(
@@ -629,6 +821,531 @@ describe('vault skill tools', () => {
       const parsed = parseResult(result) as { generation?: number; error?: string };
       expect(parsed.error).toBeUndefined();
       expect(parsed.generation).toBe(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // vault_stage_skill — provisional writes used by skill-generate's draft
+  // phase. Writes SKILL.md + manifest.json to .myco/staging/skills/<cand>/
+  // but does NOT touch the live DB or .agents/skills/ directory.
+  // -------------------------------------------------------------------------
+
+  describe('vault_stage_skill', () => {
+    it('stages a SKILL.md + manifest without creating a skill_records row', async () => {
+      // Seed a candidate
+      const candidateTool = findTool(tools, 'vault_skill_candidates');
+      const candidateResult = await candidateTool.handler(
+        { action: 'create', topic: 'Staging topic', rationale: 'Test rationale' },
+        undefined,
+      );
+      const candidate = parseResult(candidateResult) as { id: string };
+      approveCandidate(candidate.id);
+
+      // Stage a skill
+      const stageTool = findTool(tools, 'vault_stage_skill');
+      const result = await stageTool.handler(
+        {
+          candidate_id: candidate.id,
+          name: 'staged-skill',
+          display_name: 'Staged Skill',
+          description: 'A skill written to staging',
+          content: validSkillContent('staged-skill', '# Staged'),
+          rationale: 'Initial stage',
+        },
+        undefined,
+      );
+      const data = parseResult(result) as {
+        candidate_id: string;
+        staging_path: string;
+        status: string;
+      };
+
+      // Assert staging metadata returned
+      expect(data.candidate_id).toBe(candidate.id);
+      expect(data.status).toBe('staged');
+      expect(data.staging_path).toContain(candidate.id);
+      expect(fs.existsSync(data.staging_path)).toBe(true);
+
+      // Assert NO skill record was created
+      const recordsTool = findTool(tools, 'vault_skill_records');
+      const recordsResult = await recordsTool.handler({ action: 'list' }, undefined);
+      expect(parseResult(recordsResult)).toEqual([]);
+
+      // Assert the live .agents/skills/ directory does NOT contain the skill
+      const liveFile = path.join(tmpDir, '.agents', 'skills', 'staged-skill', 'SKILL.md');
+      expect(fs.existsSync(liveFile)).toBe(false);
+
+      // Candidate stays in 'approved' state — staging does not advance
+      // the lifecycle to 'generated' (that's finalize's job).
+      const getResult = await candidateTool.handler(
+        { action: 'get', id: candidate.id },
+        undefined,
+      );
+      const updated = parseResult(getResult) as { status: string; skill_id: string | null };
+      expect(updated.status).toBe('approved');
+      expect(updated.skill_id).toBeNull();
+    });
+
+    it('overwrites a prior staged version for the same candidate (iterative drafts)', async () => {
+      const candidateTool = findTool(tools, 'vault_skill_candidates');
+      const candidate = parseResult(
+        await candidateTool.handler(
+          { action: 'create', topic: 'Iteration test', rationale: 'r' },
+          undefined,
+        ),
+      ) as { id: string };
+      approveCandidate(candidate.id);
+
+      const stageTool = findTool(tools, 'vault_stage_skill');
+      await stageTool.handler(
+        {
+          candidate_id: candidate.id,
+          name: 'iter-skill',
+          display_name: 'Iter Skill',
+          description: 'First draft',
+          content: validSkillContent('iter-skill', '# Version 1'),
+          rationale: 'first pass',
+        },
+        undefined,
+      );
+
+      const secondResult = await stageTool.handler(
+        {
+          candidate_id: candidate.id,
+          name: 'iter-skill',
+          display_name: 'Iter Skill',
+          description: 'Second draft',
+          content: validSkillContent('iter-skill', '# Version 2'),
+          rationale: 'revision',
+        },
+        undefined,
+      );
+      const parsed = parseResult(secondResult) as { staging_path: string; status: string };
+      expect(parsed.status).toBe('staged');
+
+      // Read back via staging helper and confirm it reflects v2
+      expect(fs.readFileSync(parsed.staging_path, 'utf-8')).toContain('# Version 2');
+    });
+
+    it('rejects staging when validation fails on the content', async () => {
+      const candidateTool = findTool(tools, 'vault_skill_candidates');
+      const candidate = parseResult(
+        await candidateTool.handler(
+          { action: 'create', topic: 'Invalid staging', rationale: 'r' },
+          undefined,
+        ),
+      ) as { id: string };
+      approveCandidate(candidate.id);
+
+      const stageTool = findTool(tools, 'vault_stage_skill');
+      const result = await stageTool.handler(
+        {
+          candidate_id: candidate.id,
+          name: 'broken-skill',
+          display_name: 'Broken',
+          description: 'Bad content',
+          content: 'no frontmatter here — should fail validation',
+          rationale: 'test',
+        },
+        undefined,
+      );
+      const parsed = parseResult(result) as { error?: string };
+      expect(parsed.error).toBeDefined();
+      expect(parsed.error).toMatch(/validation failed/i);
+    });
+
+    it('rejects staging when description overlaps an existing active skill', async () => {
+      // Seed an active skill via vault_write_skill
+      const writeTool = findTool(tools, 'vault_write_skill');
+      await writeTool.handler(
+        {
+          name: 'existing-live',
+          display_name: 'Existing Live',
+          description: 'Structured error logging patterns for async background handlers',
+          content: validSkillContent('existing-live', '# Live'),
+        },
+        undefined,
+      );
+
+      // Try to stage a new skill with a near-duplicate description
+      const candidateTool = findTool(tools, 'vault_skill_candidates');
+      const candidate = parseResult(
+        await candidateTool.handler(
+          { action: 'create', topic: 'Overlap test', rationale: 'r' },
+          undefined,
+        ),
+      ) as { id: string };
+      approveCandidate(candidate.id);
+
+      const stageTool = findTool(tools, 'vault_stage_skill');
+      const result = await stageTool.handler(
+        {
+          candidate_id: candidate.id,
+          name: 'overlap-stage',
+          display_name: 'Overlap Stage',
+          description: 'Structured error logging patterns for async background handlers, retried',
+          content: validSkillContent('overlap-stage', '# Stage'),
+          rationale: 'test',
+        },
+        undefined,
+      );
+      const parsed = parseResult(result) as { error?: string };
+      expect(parsed.error).toContain('overlaps with existing active skill');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Approved-status gate — skill-write tools must refuse to operate on
+  // candidates that are not in 'approved' state. This is the structural
+  // enforcement that prevents skill-generate from writing skills for
+  // candidates a human never signed off on.
+  // -------------------------------------------------------------------------
+
+  describe('approved-status gate', () => {
+    async function stage(candidateId: string, name: string) {
+      const stageTool = findTool(tools, 'vault_stage_skill');
+      return parseResult(
+        await stageTool.handler(
+          {
+            candidate_id: candidateId,
+            name,
+            display_name: name,
+            description: `Gate test for ${name}`,
+            content: validSkillContent(name),
+            rationale: 'gate test',
+          },
+          undefined,
+        ),
+      ) as { error?: string; status?: string };
+    }
+
+    it('vault_stage_skill rejects a candidate in identified state', async () => {
+      const candidateTool = findTool(tools, 'vault_skill_candidates');
+      const candidate = parseResult(
+        await candidateTool.handler(
+          { action: 'create', topic: 'Gate identified', rationale: 'r' },
+          undefined,
+        ),
+      ) as { id: string; status: string };
+      expect(candidate.status).toBe('identified');
+
+      const result = await stage(candidate.id, 'gate-identified');
+      expect(result.error).toBeDefined();
+      expect(result.error).toMatch(/identified/);
+      expect(result.error).toMatch(/approved/);
+    });
+
+    it('vault_stage_skill rejects a candidate in dismissed state', async () => {
+      const candidateTool = findTool(tools, 'vault_skill_candidates');
+      const candidate = parseResult(
+        await candidateTool.handler(
+          { action: 'create', topic: 'Gate dismissed', rationale: 'r' },
+          undefined,
+        ),
+      ) as { id: string };
+      updateCandidate(candidate.id, { status: 'dismissed', updated_at: epochNow() });
+
+      const result = await stage(candidate.id, 'gate-dismissed');
+      expect(result.error).toBeDefined();
+      expect(result.error).toMatch(/dismissed|not approved/i);
+    });
+
+    it('vault_stage_skill rejects a candidate in generated state', async () => {
+      // A generated candidate is already fulfilled — re-staging would
+      // create a duplicate under a different name.
+      const candidateTool = findTool(tools, 'vault_skill_candidates');
+      const candidate = parseResult(
+        await candidateTool.handler(
+          { action: 'create', topic: 'Gate generated', rationale: 'r' },
+          undefined,
+        ),
+      ) as { id: string };
+      updateCandidate(candidate.id, { status: 'generated', updated_at: epochNow() });
+
+      const result = await stage(candidate.id, 'gate-generated');
+      expect(result.error).toBeDefined();
+      expect(result.error).toMatch(/generated|already fulfilled|not approved/i);
+    });
+
+    it('vault_stage_skill rejects when candidate_id does not exist', async () => {
+      const result = await stage('cand-does-not-exist', 'gate-missing');
+      expect(result.error).toBeDefined();
+      expect(result.error).toMatch(/not found|missing/i);
+    });
+
+    it('vault_stage_skill accepts a candidate in approved state', async () => {
+      const candidateTool = findTool(tools, 'vault_skill_candidates');
+      const candidate = parseResult(
+        await candidateTool.handler(
+          { action: 'create', topic: 'Gate approved', rationale: 'r' },
+          undefined,
+        ),
+      ) as { id: string };
+      approveCandidate(candidate.id);
+
+      const result = await stage(candidate.id, 'gate-approved');
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe('staged');
+    });
+
+    it('vault_write_skill rejects create path when candidate is not approved', async () => {
+      const candidateTool = findTool(tools, 'vault_skill_candidates');
+      const candidate = parseResult(
+        await candidateTool.handler(
+          { action: 'create', topic: 'Gate write identified', rationale: 'r' },
+          undefined,
+        ),
+      ) as { id: string };
+      // Leave candidate in 'identified' state.
+
+      const writeTool = findTool(tools, 'vault_write_skill');
+      const result = parseResult(
+        await writeTool.handler(
+          {
+            name: 'gate-write-identified',
+            display_name: 'Gate Write',
+            description: 'Test write gate against identified candidate',
+            content: validSkillContent('gate-write-identified'),
+            candidate_id: candidate.id,
+          },
+          undefined,
+        ),
+      ) as { error?: string };
+      expect(result.error).toBeDefined();
+      expect(result.error).toMatch(/identified/);
+      expect(result.error).toMatch(/approved/);
+    });
+
+    it('vault_write_skill allows evolve path regardless of candidate_id status', async () => {
+      // Seed a live skill first (no candidate linkage).
+      const writeTool = findTool(tools, 'vault_write_skill');
+      await writeTool.handler(
+        {
+          name: 'evolve-no-candidate',
+          display_name: 'Evolve Gate Test',
+          description: 'Seed for evolve-path gate test',
+          content: validSkillContent('evolve-no-candidate', '# V1'),
+        },
+        undefined,
+      );
+
+      // Evolve path is triggered by same-name write. Candidate status is
+      // irrelevant here — the caller is updating an existing skill, not
+      // creating a new one. No structural gate should fire.
+      const result = parseResult(
+        await writeTool.handler(
+          {
+            name: 'evolve-no-candidate',
+            display_name: 'Evolve Gate Test',
+            description: 'Updated during evolve path',
+            content: validSkillContent('evolve-no-candidate', '# V2'),
+          },
+          undefined,
+        ),
+      ) as { generation?: number; error?: string };
+      expect(result.error).toBeUndefined();
+      expect(result.generation).toBe(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // vault_finalize_skill — promotes a staged skill to live. Reads the
+  // manifest.json + SKILL.md written by vault_stage_skill, re-runs the
+  // dedup + validation gates as defense in depth, then atomically creates
+  // the skill_records row, lineage entry, candidate transition to
+  // 'generated', disk file, and symbiont symlinks. Cleans up staging on
+  // success.
+  // -------------------------------------------------------------------------
+
+  describe('vault_finalize_skill', () => {
+    async function stageForFinalize(candidateId: string, name: string) {
+      const stageTool = findTool(tools, 'vault_stage_skill');
+      return parseResult(
+        await stageTool.handler(
+          {
+            candidate_id: candidateId,
+            name,
+            display_name: name,
+            description: `Description for ${name}`,
+            content: validSkillContent(name, `# ${name}`),
+            rationale: 'Initial draft',
+          },
+          undefined,
+        ),
+      );
+    }
+
+    it('promotes a staged skill to .agents/skills and creates DB rows', async () => {
+      // Seed candidate + stage content
+      const candidateTool = findTool(tools, 'vault_skill_candidates');
+      const candidate = parseResult(
+        await candidateTool.handler(
+          { action: 'create', topic: 'Finalize topic', rationale: 'r' },
+          undefined,
+        ),
+      ) as { id: string };
+      approveCandidate(candidate.id);
+      await stageForFinalize(candidate.id, 'finalize-me');
+
+      // Finalize
+      const finalizeTool = findTool(tools, 'vault_finalize_skill');
+      const result = await finalizeTool.handler(
+        { candidate_id: candidate.id },
+        undefined,
+      );
+      const data = parseResult(result) as {
+        id: string;
+        name: string;
+        path: string;
+        generation: number;
+      };
+
+      expect(data.name).toBe('finalize-me');
+      expect(data.generation).toBe(1);
+      expect(data.path).toBe('.agents/skills/finalize-me/SKILL.md');
+
+      // Disk file
+      const liveFile = path.join(tmpDir, '.agents', 'skills', 'finalize-me', 'SKILL.md');
+      expect(fs.existsSync(liveFile)).toBe(true);
+
+      // DB row
+      const recordsTool = findTool(tools, 'vault_skill_records');
+      const record = parseResult(
+        await recordsTool.handler({ action: 'get', id: 'finalize-me' }, undefined),
+      ) as { name: string };
+      expect(record.name).toBe('finalize-me');
+
+      // Candidate flipped to generated
+      const updated = parseResult(
+        await candidateTool.handler({ action: 'get', id: candidate.id }, undefined),
+      ) as { status: string; skill_id: string };
+      expect(updated.status).toBe('generated');
+      expect(updated.skill_id).toBe(data.id);
+
+      // Staging cleaned up
+      const stagingFile = path.join(
+        vaultDir,
+        'staging',
+        'skills',
+        candidate.id,
+        'SKILL.md',
+      );
+      expect(fs.existsSync(stagingFile)).toBe(false);
+    });
+
+    it('errors when no staged content exists for the candidate', async () => {
+      const finalizeTool = findTool(tools, 'vault_finalize_skill');
+      const result = await finalizeTool.handler(
+        { candidate_id: 'cand-never-staged' },
+        undefined,
+      );
+      const parsed = parseResult(result) as { error?: string };
+      expect(parsed.error).toBeDefined();
+      expect(parsed.error).toMatch(/no staged/i);
+    });
+
+    it('re-runs dedup gate on the staged content before promoting', async () => {
+      // Seed a live skill with a distinctive description
+      const writeTool = findTool(tools, 'vault_write_skill');
+      await writeTool.handler(
+        {
+          name: 'live-defense',
+          display_name: 'Live Defense',
+          description: 'Very specific error retry patterns for async worker queues and jobs',
+          content: validSkillContent('live-defense', '# Live'),
+        },
+        undefined,
+      );
+
+      // Stage a skill with a fresh candidate whose description does NOT overlap
+      // (to bypass stage-time gate), then mutate the staged content to overlap
+      // before finalize.
+      const candidateTool = findTool(tools, 'vault_skill_candidates');
+      const candidate = parseResult(
+        await candidateTool.handler(
+          { action: 'create', topic: 'Defense test', rationale: 'r' },
+          undefined,
+        ),
+      ) as { id: string };
+      approveCandidate(candidate.id);
+
+      const stageTool = findTool(tools, 'vault_stage_skill');
+      await stageTool.handler(
+        {
+          candidate_id: candidate.id,
+          name: 'defense-stage',
+          display_name: 'Defense Stage',
+          description: 'Completely unrelated topic about caching',
+          content: validSkillContent('defense-stage', '# Defense'),
+          rationale: 'Defense test',
+        },
+        undefined,
+      );
+
+      // Tamper the manifest to overlap with the live skill's description.
+      const manifestPath = path.join(
+        vaultDir,
+        'staging',
+        'skills',
+        candidate.id,
+        'manifest.json',
+      );
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+      manifest.description =
+        'Very specific error retry patterns for async worker queues and jobs, tuned';
+      fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+      // Finalize should reject
+      const finalizeTool = findTool(tools, 'vault_finalize_skill');
+      const result = await finalizeTool.handler(
+        { candidate_id: candidate.id },
+        undefined,
+      );
+      const parsed = parseResult(result) as { error?: string };
+      expect(parsed.error).toContain('overlaps with existing active skill');
+
+      // Assert no skill record created and no live file
+      const liveFile = path.join(tmpDir, '.agents', 'skills', 'defense-stage', 'SKILL.md');
+      expect(fs.existsSync(liveFile)).toBe(false);
+      const recordsTool = findTool(tools, 'vault_skill_records');
+      const records = parseResult(
+        await recordsTool.handler({ action: 'list' }, undefined),
+      ) as Array<{ name: string }>;
+      expect(records.find((r) => r.name === 'defense-stage')).toBeUndefined();
+    });
+
+    it('preserves approved_at on the candidate after transition to generated', async () => {
+      // Seed an already-approved candidate with a known approved_at
+      const candidateTool = findTool(tools, 'vault_skill_candidates');
+      const candidateRaw = parseResult(
+        await candidateTool.handler(
+          { action: 'create', topic: 'Approved audit', rationale: 'r' },
+          undefined,
+        ),
+      ) as { id: string };
+
+      // Flip to approved via the REST handler path (simulates UI click).
+      // The agent tool has been locked down in Task 2, so we use the
+      // query helper directly to simulate the human approval.
+      const { updateCandidate } = await import('@myco/db/queries/skill-candidates.js');
+      const approvedAt = epochNow();
+      updateCandidate(candidateRaw.id, {
+        status: 'approved',
+        updated_at: approvedAt,
+      });
+
+      await stageForFinalize(candidateRaw.id, 'audit-preserve');
+      const finalizeTool = findTool(tools, 'vault_finalize_skill');
+      await finalizeTool.handler(
+        { candidate_id: candidateRaw.id },
+        undefined,
+      );
+
+      const final = parseResult(
+        await candidateTool.handler({ action: 'get', id: candidateRaw.id }, undefined),
+      ) as { status: string; approved_at: number | null };
+      expect(final.status).toBe('generated');
+      expect(final.approved_at).toBe(approvedAt);
     });
   });
 });

--- a/tests/constants/skill-candidate-status.test.ts
+++ b/tests/constants/skill-candidate-status.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Sync-check between the backend CANDIDATE_STATUS constants and the
+ * UI mirror in ui/src/lib/skill-candidate-status.ts. The two files
+ * exist separately because the UI is a distinct TypeScript project
+ * with no alias into the backend src tree — this test catches any
+ * drift at CI time.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  CANDIDATE_STATUS,
+  AGENT_SETTABLE_STATUSES,
+  REST_SETTABLE_STATUSES,
+  PIPELINE_FILTER_VALUE,
+} from '@myco/constants/skill-candidate-status.js';
+
+describe('skill-candidate-status constants', () => {
+  it('AGENT_SETTABLE_STATUSES contains only identified and dismissed', () => {
+    expect([...AGENT_SETTABLE_STATUSES].sort()).toEqual(
+      [CANDIDATE_STATUS.IDENTIFIED, CANDIDATE_STATUS.DISMISSED].sort(),
+    );
+  });
+
+  it('REST_SETTABLE_STATUSES contains identified, approved, dismissed but not generated', () => {
+    const rest = [...REST_SETTABLE_STATUSES].sort();
+    expect(rest).toEqual(
+      [
+        CANDIDATE_STATUS.IDENTIFIED,
+        CANDIDATE_STATUS.APPROVED,
+        CANDIDATE_STATUS.DISMISSED,
+      ].sort(),
+    );
+    expect(rest).not.toContain(CANDIDATE_STATUS.GENERATED);
+  });
+
+  it('PIPELINE_FILTER_VALUE concatenates approved and generated with comma', () => {
+    expect(PIPELINE_FILTER_VALUE).toBe(
+      `${CANDIDATE_STATUS.APPROVED},${CANDIDATE_STATUS.GENERATED}`,
+    );
+  });
+
+  it('UI mirror file at ui/src/lib/skill-candidate-status.ts has matching string values', () => {
+    const uiMirrorPath = path.resolve(
+      process.cwd(),
+      'ui/src/lib/skill-candidate-status.ts',
+    );
+    expect(fs.existsSync(uiMirrorPath)).toBe(true);
+
+    const uiSource = fs.readFileSync(uiMirrorPath, 'utf-8');
+
+    // Every backend status value must appear as a string literal in
+    // the UI mirror. This is the load-bearing invariant — if the UI
+    // uses different strings for the same semantic status, the filter
+    // dropdown breaks silently.
+    for (const value of Object.values(CANDIDATE_STATUS)) {
+      expect(uiSource).toContain(`'${value}'`);
+    }
+
+    // The PIPELINE_FILTER_VALUE export must exist with the same name
+    // so components can import it. Actual value is derived from the
+    // same status strings above, which we already verified.
+    expect(uiSource).toContain('PIPELINE_FILTER_VALUE');
+  });
+});

--- a/tests/daemon/api/log-explorer.test.ts
+++ b/tests/daemon/api/log-explorer.test.ts
@@ -134,11 +134,52 @@ describe('log explorer API handlers', () => {
   // ---------------------------------------------------------------------------
 
   describe('handleLogStream', () => {
-    it('returns all entries when no cursor provided (since=0)', async () => {
+    it('tail mode: returns the most recent N entries when no since param given', async () => {
+      // Insert 10 entries with distinct messages so we can tell which ones came back
+      for (let i = 1; i <= 10; i++) {
+        insertLogEntry(makeEntry({ message: `entry-${i}` }));
+      }
+
+      // No since param, limit=3 → should return the 3 NEWEST entries, sorted ASC
+      const req = makeRequest({ query: { limit: '3' } });
+      const res = await handleLogStream(req);
+
+      const body = res.body as Record<string, unknown>;
+      const entries = body.entries as Array<Record<string, unknown>>;
+      expect(entries.length).toBe(3);
+      expect(entries.map((e) => e.message)).toEqual(['entry-8', 'entry-9', 'entry-10']);
+      // Cursor = max id returned (the last, newest entry)
+      expect(body.cursor).toBe((entries[2] as Record<string, unknown>).id);
+    });
+
+    it('tail mode: cursor equals max id in table when entries exist but fewer than limit', async () => {
       insertLogEntry(makeEntry({ message: 'first' }));
       insertLogEntry(makeEntry({ message: 'second' }));
 
       const req = makeRequest({ query: {} });
+      const res = await handleLogStream(req);
+
+      const body = res.body as Record<string, unknown>;
+      const entries = body.entries as Array<Record<string, unknown>>;
+      expect(entries.length).toBe(2);
+      expect(entries[0].message).toBe('first');
+      expect(entries[1].message).toBe('second');
+    });
+
+    it('tail mode: empty table returns no entries and cursor=0', async () => {
+      const req = makeRequest({ query: {} });
+      const res = await handleLogStream(req);
+
+      const body = res.body as Record<string, unknown>;
+      expect((body.entries as unknown[]).length).toBe(0);
+      expect(body.cursor).toBe(0);
+    });
+
+    it('forward scan: explicit since=0 still returns all entries from the beginning', async () => {
+      insertLogEntry(makeEntry({ message: 'first' }));
+      insertLogEntry(makeEntry({ message: 'second' }));
+
+      const req = makeRequest({ query: { since: '0' } });
       const res = await handleLogStream(req);
 
       const body = res.body as Record<string, unknown>;
@@ -169,18 +210,6 @@ describe('log explorer API handlers', () => {
       const body = res.body as Record<string, unknown>;
       expect((body.entries as unknown[]).length).toBe(0);
       expect(body.cursor).toBe(id);
-    });
-
-    it('returns latest when no since param given', async () => {
-      insertLogEntry(makeEntry());
-      insertLogEntry(makeEntry());
-
-      const req = makeRequest({ query: {} });
-      const res = await handleLogStream(req);
-
-      const body = res.body as Record<string, unknown>;
-      expect((body.entries as unknown[]).length).toBe(2);
-      expect(typeof body.cursor).toBe('number');
     });
 
     it('respects limit parameter', async () => {

--- a/tests/daemon/api/skills.test.ts
+++ b/tests/daemon/api/skills.test.ts
@@ -156,18 +156,62 @@ describe('handleGetCandidate', () => {
 // handleUpdateCandidate
 // ---------------------------------------------------------------------------
 
+describe('handleListCandidates multi-status filter', () => {
+  it('returns candidates matching any of the comma-separated statuses', async () => {
+    insertCandidate(makeCandidate({ id: 'ml-id', status: 'identified' }));
+    insertCandidate(makeCandidate({ id: 'ml-ap', status: 'approved' }));
+    insertCandidate(makeCandidate({ id: 'ml-gn', status: 'generated' }));
+    insertCandidate(makeCandidate({ id: 'ml-dm', status: 'dismissed' }));
+
+    const result = await handleListCandidates(
+      makeReq({ query: { status: 'approved,generated' } }),
+    );
+
+    expect(result.status).toBe(200);
+    const body = result.body as {
+      candidates: Array<{ id: string; status: string }>;
+      total: number;
+    };
+    const ids = body.candidates.map((c) => c.id).sort();
+    expect(ids).toEqual(['ml-ap', 'ml-gn']);
+    expect(body.total).toBe(2);
+  });
+
+  it('trims whitespace between values', async () => {
+    insertCandidate(makeCandidate({ id: 'ws-ap', status: 'approved' }));
+    insertCandidate(makeCandidate({ id: 'ws-gn', status: 'generated' }));
+
+    const result = await handleListCandidates(
+      makeReq({ query: { status: ' approved , generated ' } }),
+    );
+    const body = result.body as { total: number };
+    expect(body.total).toBe(2);
+  });
+
+  it('still supports single-status filter (no comma)', async () => {
+    insertCandidate(makeCandidate({ id: 'sg-ap', status: 'approved' }));
+    insertCandidate(makeCandidate({ id: 'sg-dm', status: 'dismissed' }));
+
+    const result = await handleListCandidates(
+      makeReq({ query: { status: 'approved' } }),
+    );
+    const body = result.body as { total: number };
+    expect(body.total).toBe(1);
+  });
+});
+
 describe('handleUpdateCandidate', () => {
   it('updates the candidate status and returns updated row', async () => {
     insertCandidate(makeCandidate({ id: 'cand-update', status: 'identified' }));
 
     const result = await handleUpdateCandidate(
-      makeReq({ params: { id: 'cand-update' }, body: { status: 'promoted' } }),
+      makeReq({ params: { id: 'cand-update' }, body: { status: 'approved' } }),
     );
 
     expect(result.status).toBe(200);
     const body = result.body as { candidate: { id: string; status: string } };
     expect(body.candidate.id).toBe('cand-update');
-    expect(body.candidate.status).toBe('promoted');
+    expect(body.candidate.status).toBe('approved');
   });
 
   it('returns 400 when body is missing', async () => {
@@ -182,11 +226,58 @@ describe('handleUpdateCandidate', () => {
 
   it('returns 404 for unknown candidate', async () => {
     const result = await handleUpdateCandidate(
-      makeReq({ params: { id: 'ghost' }, body: { status: 'promoted' } }),
+      makeReq({ params: { id: 'ghost' }, body: { status: 'approved' } }),
     );
 
     expect(result.status).toBe(404);
     expect((result.body as { error: string }).error).toMatch('ghost');
+  });
+
+  // Privilege separation: REST is the human-driven surface (UI + MCP). It
+  // accepts 'identified', 'approved', and 'dismissed' but rejects
+  // 'generated' — the only legitimate writer of that status is the internal
+  // vault_finalize_skill tool which calls updateCandidate directly.
+  describe('status value guard', () => {
+    it('rejects status=generated with 400', async () => {
+      insertCandidate(makeCandidate({ id: 'cand-gen-guard', status: 'approved' }));
+
+      const result = await handleUpdateCandidate(
+        makeReq({ params: { id: 'cand-gen-guard' }, body: { status: 'generated' } }),
+      );
+
+      expect(result.status).toBe(400);
+      expect((result.body as { error: string }).error).toMatch(/generated/i);
+    });
+
+    it('rejects an arbitrary unknown status value with 400', async () => {
+      insertCandidate(makeCandidate({ id: 'cand-unknown-guard' }));
+
+      const result = await handleUpdateCandidate(
+        makeReq({ params: { id: 'cand-unknown-guard' }, body: { status: 'promoted' } }),
+      );
+
+      expect(result.status).toBe(400);
+    });
+
+    it('accepts status=identified', async () => {
+      insertCandidate(makeCandidate({ id: 'cand-ident', status: 'approved' }));
+
+      const result = await handleUpdateCandidate(
+        makeReq({ params: { id: 'cand-ident' }, body: { status: 'identified' } }),
+      );
+
+      expect(result.status).toBe(200);
+    });
+
+    it('accepts status=dismissed', async () => {
+      insertCandidate(makeCandidate({ id: 'cand-dism', status: 'identified' }));
+
+      const result = await handleUpdateCandidate(
+        makeReq({ params: { id: 'cand-dism' }, body: { status: 'dismissed' } }),
+      );
+
+      expect(result.status).toBe(200);
+    });
   });
 });
 

--- a/tests/daemon/power-jobs.test.ts
+++ b/tests/daemon/power-jobs.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+
 import { initDatabase, closeDatabase, getDatabase } from '@myco/db/client';
 import { createSchema } from '@myco/db/schema';
 import { insertLogEntry } from '@myco/db/queries/logs';
-import { DatabaseMaintenanceManager } from '../../src/daemon/database/manager';
-import { DaemonLogger } from '../../src/daemon/logger';
-import { registerPowerJobs } from '../../src/daemon/power-jobs';
+import { DatabaseMaintenanceManager } from '@myco/daemon/database/manager.js';
+import { DaemonLogger } from '@myco/daemon/logger.js';
+import { registerPowerJobs, type PowerJobDeps } from '@myco/daemon/power-jobs.js';
+import { writeStagedSkill, stagingRoot } from '@myco/agent/tools/skill-staging.js';
 
 class FakePowerManager {
   jobs: Array<{ name: string; runIn: string[]; fn: () => Promise<void>; preventsDeepSleep?: () => boolean }> = [];
@@ -21,6 +23,10 @@ class FakePowerManager {
   }
 }
 
+// ---------------------------------------------------------------------------
+// database-optimize job (covers the auto-optimize scheduling toggle added in
+// main's database-maintenance-tab feature)
+// ---------------------------------------------------------------------------
 describe('database-optimize power job', () => {
   let tmpDir: string;
   let dbPath: string;
@@ -115,8 +121,104 @@ describe('database-optimize power job', () => {
     await pm.find('database-optimize').fn();
     expect(optimizeSpy).toHaveBeenCalledTimes(1);
     expect(errorSpy).toHaveBeenCalled();
-    // Verify the error log used the right kind
     const call = errorSpy.mock.calls.find((c) => c[0] === 'database.error' || c[0]?.includes?.('database.error'));
     expect(call).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// staging-gc job (covers the skill-generate staging sweep added for the
+// 2026-04-08 skill lifecycle audit)
+// ---------------------------------------------------------------------------
+
+function createMockLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+function buildStagingDeps(vaultDir: string): PowerJobDeps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return {
+    embeddingManager: { reconcile: async () => 0 } as any,
+    registry: { sessions: new Set<string>() } as any,
+    logger: createMockLogger() as any,
+    config: {
+      daemon: { log_retention_days: 30 },
+      maintenance: { auto_optimize: false, auto_optimize_interval_hours: 24 },
+    } as any,
+    db: {} as any,
+    backupDir: path.join(vaultDir, 'backups'),
+    machineId: 'test-machine',
+    vaultDir,
+    databaseManager: {
+      getLastOptimizeAt: async () => null,
+      optimize: async () => undefined,
+    } as any,
+  };
+}
+
+describe('registerPowerJobs — staging-gc', () => {
+  let tmpDir: string;
+  let vaultDir: string;
+  let pm: FakePowerManager;
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'myco-power-gc-')));
+    vaultDir = path.join(tmpDir, '.myco');
+    fs.mkdirSync(vaultDir, { recursive: true });
+    pm = new FakePowerManager();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('registers a staging-gc job that runs in idle and sleep states', () => {
+    registerPowerJobs(pm as never, buildStagingDeps(vaultDir));
+    const gc = pm.find('staging-gc');
+    expect(gc.runIn).toContain('idle');
+    expect(gc.runIn).toContain('sleep');
+  });
+
+  it('removes stale staging entries when the job runs', async () => {
+    registerPowerJobs(pm as never, buildStagingDeps(vaultDir));
+    const gc = pm.find('staging-gc');
+
+    // Fresh entry (should survive)
+    writeStagedSkill(vaultDir, 'cand-fresh', 'fresh content');
+
+    // Stale entry (should be swept)
+    writeStagedSkill(vaultDir, 'cand-stale', 'old content');
+    const stalePath = path.resolve(stagingRoot(vaultDir), 'cand-stale');
+    const twoDaysAgo = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    fs.utimesSync(stalePath, twoDaysAgo, twoDaysAgo);
+
+    await gc.fn();
+
+    expect(fs.existsSync(path.resolve(stagingRoot(vaultDir), 'cand-fresh'))).toBe(true);
+    expect(fs.existsSync(stalePath)).toBe(false);
+  });
+
+  it('is a no-op when the staging root does not exist', async () => {
+    registerPowerJobs(pm as never, buildStagingDeps(vaultDir));
+    const gc = pm.find('staging-gc');
+    await expect(gc.fn()).resolves.toBeUndefined();
+  });
+
+  it('is a no-op when all entries are fresh', async () => {
+    registerPowerJobs(pm as never, buildStagingDeps(vaultDir));
+    const gc = pm.find('staging-gc');
+
+    writeStagedSkill(vaultDir, 'cand-a', 'a');
+    writeStagedSkill(vaultDir, 'cand-b', 'b');
+
+    await gc.fn();
+
+    expect(fs.existsSync(path.resolve(stagingRoot(vaultDir), 'cand-a'))).toBe(true);
+    expect(fs.existsSync(path.resolve(stagingRoot(vaultDir), 'cand-b'))).toBe(true);
   });
 });

--- a/tests/daemon/task-scheduler.test.ts
+++ b/tests/daemon/task-scheduler.test.ts
@@ -148,7 +148,73 @@ describe('buildScheduledJobs', () => {
     const jobs = buildScheduledJobs(tasks, {}, ctx);
     await jobs[0].fn();
 
+    // `true` fires synchronously before dispatch.
     expect(setRunning).toHaveBeenCalledWith('task-a', true);
+
+    // `false` fires in the detached finally — flush microtasks to observe it.
+    await new Promise((r) => setImmediate(r));
     expect(setRunning).toHaveBeenCalledWith('task-a', false);
+  });
+
+  it('returns immediately without awaiting the task (fire-and-forget)', async () => {
+    const tasks = [
+      makeTask('long-task', { enabled: true, intervalSeconds: 1, runIn: ['active'] }),
+    ];
+    let resolveTask: () => void = () => {};
+    const taskPromise = new Promise<void>((resolve) => {
+      resolveTask = resolve;
+    });
+    const ctx = makeContext({
+      runTask: vi.fn().mockReturnValue(taskPromise),
+    });
+
+    const jobs = buildScheduledJobs(tasks, {}, ctx);
+
+    // Job fn must resolve even while runTask is still pending —
+    // otherwise a multi-minute agent task would block the PowerManager
+    // tick loop and starve other jobs like team-sync-flush.
+    await jobs[0].fn();
+
+    expect(ctx.runTask).toHaveBeenCalledWith('long-task');
+    // Task is still in flight; resolve it to let the finally clean up.
+    resolveTask();
+    await new Promise((r) => setImmediate(r));
+  });
+
+  it('routes detached task errors to onTaskError', async () => {
+    const tasks = [
+      makeTask('failing', { enabled: true, intervalSeconds: 1, runIn: ['active'] }),
+    ];
+    const onTaskError = vi.fn();
+    const boom = new Error('task exploded');
+    const ctx = makeContext({
+      runTask: vi.fn().mockRejectedValue(boom),
+      onTaskError,
+    });
+
+    const jobs = buildScheduledJobs(tasks, {}, ctx);
+    await jobs[0].fn();
+    await new Promise((r) => setImmediate(r));
+
+    expect(onTaskError).toHaveBeenCalledWith('failing', boom);
+  });
+
+  it('clears running flag even when task throws', async () => {
+    const tasks = [
+      makeTask('failing', { enabled: true, intervalSeconds: 1, runIn: ['active'] }),
+    ];
+    const setRunning = vi.fn();
+    const ctx = makeContext({
+      runTask: vi.fn().mockRejectedValue(new Error('boom')),
+      setTaskRunning: setRunning,
+      onTaskError: () => {},
+    });
+
+    const jobs = buildScheduledJobs(tasks, {}, ctx);
+    await jobs[0].fn();
+    await new Promise((r) => setImmediate(r));
+
+    expect(setRunning).toHaveBeenCalledWith('failing', true);
+    expect(setRunning).toHaveBeenCalledWith('failing', false);
   });
 });

--- a/tests/db/queries/skill-candidates.test.ts
+++ b/tests/db/queries/skill-candidates.test.ts
@@ -254,6 +254,44 @@ describe('skill candidate query helpers', () => {
       expect(row!.confidence).toBe(0.5);
       expect(row!.status).toBe('rejected');
     });
+
+    it('auto-sets approved_at on first transition to approved', () => {
+      const data = makeCandidate();
+      const inserted = insertCandidate(data);
+      expect(inserted.approved_at).toBeNull();
+
+      const t1 = epochNow() + 100;
+      const row = updateCandidate(data.id, { status: 'approved', updated_at: t1 });
+      expect(row).not.toBeNull();
+      expect(row!.status).toBe('approved');
+      expect(row!.approved_at).toBe(t1);
+    });
+
+    it('does not overwrite approved_at on subsequent updates', () => {
+      const data = makeCandidate();
+      insertCandidate(data);
+
+      const t1 = epochNow() + 100;
+      updateCandidate(data.id, { status: 'approved', updated_at: t1 });
+
+      // Unrelated update — should not touch approved_at
+      const t2 = t1 + 50;
+      updateCandidate(data.id, { topic: 'Renamed', updated_at: t2 });
+      expect(getCandidate(data.id)!.approved_at).toBe(t1);
+
+      // Re-setting status to approved (no-op in practice) — must not overwrite
+      const t3 = t1 + 100;
+      updateCandidate(data.id, { status: 'approved', updated_at: t3 });
+      expect(getCandidate(data.id)!.approved_at).toBe(t1);
+    });
+
+    it('leaves approved_at null for candidates never approved', () => {
+      const data = makeCandidate();
+      insertCandidate(data);
+
+      updateCandidate(data.id, { status: 'dismissed', updated_at: epochNow() + 10 });
+      expect(getCandidate(data.id)!.approved_at).toBeNull();
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -279,6 +317,29 @@ describe('skill candidate query helpers', () => {
       expect(countCandidates({ status: 'identified' })).toBe(2);
       expect(countCandidates({ status: 'promoted' })).toBe(1);
       expect(countCandidates({ status: 'rejected' })).toBe(0);
+    });
+
+    it('counts candidates matching a multi-status filter', () => {
+      const now = epochNow();
+      insertCandidate(makeCandidate({ status: 'identified', created_at: now }));
+      insertCandidate(makeCandidate({ status: 'approved', created_at: now + 1 }));
+      insertCandidate(makeCandidate({ status: 'generated', created_at: now + 2 }));
+      insertCandidate(makeCandidate({ status: 'dismissed', created_at: now + 3 }));
+
+      expect(countCandidates({ statuses: ['approved', 'generated'] })).toBe(2);
+      expect(countCandidates({ statuses: ['identified', 'dismissed'] })).toBe(2);
+      expect(countCandidates({ statuses: ['approved'] })).toBe(1);
+      expect(countCandidates({ statuses: [] })).toBe(4); // empty list = no filter
+    });
+
+    it('lists candidates matching a multi-status filter', () => {
+      const now = epochNow();
+      insertCandidate(makeCandidate({ id: 'cand-q-id', status: 'identified', created_at: now }));
+      insertCandidate(makeCandidate({ id: 'cand-q-ap', status: 'approved', created_at: now + 1 }));
+      insertCandidate(makeCandidate({ id: 'cand-q-gn', status: 'generated', created_at: now + 2 }));
+
+      const rows = listCandidates({ statuses: ['approved', 'generated'] });
+      expect(rows.map((r) => r.id).sort()).toEqual(['cand-q-ap', 'cand-q-gn']);
     });
 
     it('counts candidates matching an agent_id filter', () => {

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { initDatabase, closeDatabase } from '@myco/db/client.js';
 import { createSchema, SCHEMA_VERSION, EMBEDDING_DIMENSIONS } from '@myco/db/schema.js';
+import { MIGRATIONS } from '@myco/db/migrations.js';
 import type { Database } from 'better-sqlite3';
 
 /** Helper: check if a table exists in SQLite. */
@@ -38,7 +39,7 @@ describe('Database schema', () => {
 
   describe('constants', () => {
     it('exports SCHEMA_VERSION as a positive integer', () => {
-      expect(SCHEMA_VERSION).toBe(9);
+      expect(SCHEMA_VERSION).toBe(10);
       expect(Number.isInteger(SCHEMA_VERSION)).toBe(true);
     });
 
@@ -430,6 +431,7 @@ describe('Database schema', () => {
         expect(colNames).toContain('skill_id');
         expect(colNames).toContain('created_at');
         expect(colNames).toContain('updated_at');
+        expect(colNames).toContain('approved_at');
         expect(colNames).toContain('synced_at');
       });
 
@@ -608,6 +610,136 @@ describe('Database schema', () => {
         expect(indexExists(db, 'idx_graph_edges_target')).toBe(true);
         expect(indexExists(db, 'idx_graph_edges_type')).toBe(true);
         expect(indexExists(db, 'idx_graph_edges_agent')).toBe(true);
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Migrations — exercises individual migration functions on hand-built
+  // pre-migration DB states so we can verify both the DDL change AND any
+  // backfill logic. Uses the MIGRATIONS registry directly rather than
+  // createSchema so the test can control the starting point.
+  // ---------------------------------------------------------------------------
+  describe('migrations', () => {
+    describe('v9 to v10: skill_candidates.approved_at with backfill', () => {
+      /**
+       * Build a v9-shape DB: pre-v10 skill_candidates table + required FKs.
+       * Runs each DDL as an individual prepared statement to keep the
+       * test deterministic and compatible with the Edit hook guard.
+       */
+      function buildV9Db(target: Database) {
+        const ddl = [
+          `CREATE TABLE schema_version (
+            version    INTEGER PRIMARY KEY,
+            applied_at INTEGER NOT NULL
+          )`,
+          `CREATE TABLE agents (
+            id         TEXT PRIMARY KEY,
+            name       TEXT NOT NULL,
+            created_at INTEGER NOT NULL
+          )`,
+          `CREATE TABLE skill_candidates (
+            id              TEXT PRIMARY KEY,
+            agent_id        TEXT NOT NULL REFERENCES agents(id),
+            machine_id      TEXT NOT NULL DEFAULT 'local',
+            topic           TEXT NOT NULL,
+            rationale       TEXT NOT NULL,
+            confidence      REAL NOT NULL DEFAULT 0.0,
+            status          TEXT NOT NULL DEFAULT 'identified',
+            source_ids      TEXT NOT NULL DEFAULT '[]',
+            skill_id        TEXT,
+            created_at      INTEGER NOT NULL,
+            updated_at      INTEGER NOT NULL,
+            synced_at       INTEGER
+          )`,
+        ];
+        for (const stmt of ddl) target.prepare(stmt).run();
+        target.prepare(
+          `INSERT INTO schema_version (version, applied_at) VALUES (9, 1000)`,
+        ).run();
+        target.prepare(
+          `INSERT INTO agents (id, name, created_at) VALUES ('agent-test', 'Test', 1000)`,
+        ).run();
+      }
+
+      /** Insert a candidate directly (no TS helpers — we're pre-migration). */
+      function seedCandidate(target: Database, id: string, status: string) {
+        target.prepare(
+          `INSERT INTO skill_candidates (id, agent_id, topic, rationale, status, created_at, updated_at)
+           VALUES (?, 'agent-test', ?, ?, ?, 1000, 1100)`,
+        ).run(id, `topic-${id}`, `rationale-${id}`, status);
+      }
+
+      it('adds approved_at column to existing skill_candidates', () => {
+        buildV9Db(db);
+        expect(getColumnNames(db, 'skill_candidates')).not.toContain('approved_at');
+
+        const migration = MIGRATIONS.find((m) => m.version === 10);
+        expect(migration).toBeDefined();
+        migration!.migrate(db, 'local');
+
+        expect(getColumnNames(db, 'skill_candidates')).toContain('approved_at');
+      });
+
+      it('records schema_version row 10 after migration', () => {
+        buildV9Db(db);
+        const migration = MIGRATIONS.find((m) => m.version === 10)!;
+        migration.migrate(db, 'local');
+
+        const row = db.prepare(
+          'SELECT version FROM schema_version WHERE version = 10',
+        ).get() as { version: number } | undefined;
+        expect(row?.version).toBe(10);
+      });
+
+      it('backfills approved_at for approved and generated rows only', () => {
+        buildV9Db(db);
+        seedCandidate(db, 'c-identified', 'identified');
+        seedCandidate(db, 'c-approved', 'approved');
+        seedCandidate(db, 'c-generated', 'generated');
+        seedCandidate(db, 'c-dismissed', 'dismissed');
+
+        const migration = MIGRATIONS.find((m) => m.version === 10)!;
+        migration.migrate(db, 'local');
+
+        const rows = db.prepare(
+          `SELECT id, status, approved_at FROM skill_candidates ORDER BY id`,
+        ).all() as Array<{ id: string; status: string; approved_at: number | null }>;
+
+        const byId = Object.fromEntries(rows.map((r) => [r.id, r]));
+        expect(byId['c-identified'].approved_at).toBeNull();
+        expect(byId['c-approved'].approved_at).not.toBeNull();
+        expect(byId['c-generated'].approved_at).not.toBeNull();
+        expect(byId['c-dismissed'].approved_at).toBeNull();
+      });
+
+      it('is idempotent — running twice does not throw', () => {
+        buildV9Db(db);
+        const migration = MIGRATIONS.find((m) => m.version === 10)!;
+        migration.migrate(db, 'local');
+        expect(() => migration.migrate(db, 'local')).not.toThrow();
+      });
+
+      it('does not overwrite existing approved_at on re-run', () => {
+        buildV9Db(db);
+        seedCandidate(db, 'c-approved', 'approved');
+
+        const migration = MIGRATIONS.find((m) => m.version === 10)!;
+        migration.migrate(db, 'local');
+
+        const first = db.prepare(
+          `SELECT approved_at FROM skill_candidates WHERE id = 'c-approved'`,
+        ).get() as { approved_at: number };
+        expect(first.approved_at).toBeGreaterThan(0);
+
+        // Second run must be safe under re-execution — the backfill should
+        // skip already-populated rows and not modify them.
+        migration.migrate(db, 'local');
+
+        const second = db.prepare(
+          `SELECT approved_at FROM skill_candidates WHERE id = 'c-approved'`,
+        ).get() as { approved_at: number };
+        expect(second.approved_at).toBe(first.approved_at);
       });
     });
   });

--- a/tests/integration/skill-stage-finalize.test.ts
+++ b/tests/integration/skill-stage-finalize.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Integration tests for the staging → finalize skill pipeline.
+ *
+ * These exercise the two new tools (vault_stage_skill, vault_finalize_skill)
+ * in the realistic scenarios that motivated the 2026-04-08 audit:
+ *
+ *   1. Happy path: stage → finalize promotes atomically, cleans staging,
+ *      and preserves approved_at on the candidate.
+ *   2. Failure path: stage succeeds, something blocks finalize, staging
+ *      is NOT promoted — no skill_records row, no .agents/skills/ file,
+ *      candidate stays in its pre-finalize state. This is the inverse of
+ *      the original orphan-skill bug.
+ *   3. Cleanup on required-phase failure: the executor hook detects
+ *      skill-generate failure and removes the staging directory.
+ *
+ * The executor-hook test imports the cleanup helper directly rather
+ * than actually running the agent executor (the executor spawns a
+ * subprocess and an LLM provider; that's covered by end-to-end smoke
+ * tests in the daemon).
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Mock embedding like the skill-tools unit test suite
+vi.mock('@myco/intelligence/embed-query.js', () => ({ tryEmbed: async () => null }));
+
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { insertCandidate, getCandidate, updateCandidate } from '@myco/db/queries/skill-candidates.js';
+import { listSkillRecords, getSkillRecordByName } from '@myco/db/queries/skill-records.js';
+import { insertRun } from '@myco/db/queries/runs.js';
+import { createVaultTools } from '@myco/agent/tools.js';
+import { cleanupStagedSkill, stagingPath, stagingManifestPath } from '@myco/agent/tools/skill-staging.js';
+import type { SdkMcpToolDefinition } from '@anthropic-ai/claude-agent-sdk';
+
+const AGENT_ID = 'agent-int';
+const RUN_ID = 'run-int-001';
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+function validSkillContent(name: string, body = '# Content') {
+  return `---\nname: myco:${name}\ndescription: ${name} description\nmanaged_by: myco\nuser-invocable: true\nallowed-tools: Read, Grep, Glob\n---\n\n${body}`;
+}
+
+function findTool(tools: ReturnType<typeof createVaultTools>, name: string) {
+  const t = tools.find((tool) => tool.name === name);
+  if (!t) throw new Error(`Tool not found: ${name}`);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return t as SdkMcpToolDefinition<any>;
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }): unknown {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('skill staging → finalize pipeline', () => {
+  let tools: ReturnType<typeof createVaultTools>;
+  let tmpDir: string;
+  let vaultDir: string;
+
+  beforeAll(() => {
+    setupTestDb();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-stage-finalize-'));
+    vaultDir = path.join(tmpDir, '.myco');
+    fs.mkdirSync(vaultDir, { recursive: true });
+  });
+
+  afterAll(() => {
+    teardownTestDb();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    cleanTestDb();
+    const now = epochNow();
+    registerAgent({ id: AGENT_ID, name: 'Integration Test Agent', created_at: now });
+    insertRun({
+      id: RUN_ID,
+      agent_id: AGENT_ID,
+      status: 'running',
+      started_at: now,
+    });
+
+    // Wipe staging between tests to prevent candidate_id collisions
+    fs.rmSync(path.join(vaultDir, 'staging'), { recursive: true, force: true });
+
+    tools = createVaultTools(AGENT_ID, RUN_ID, { projectRoot: tmpDir, vaultDir });
+  });
+
+  // --------------------------------------------------------------------------
+  // Happy path
+  // --------------------------------------------------------------------------
+
+  it('stage → finalize: atomic promotion, staging cleaned, approved_at preserved', async () => {
+    // Seed an approved candidate with a known approved_at
+    const now = epochNow();
+    const candidate = insertCandidate({
+      id: 'cand-happy',
+      agent_id: AGENT_ID,
+      topic: 'Happy path topic',
+      rationale: 'Integration rationale',
+      created_at: now - 100,
+      updated_at: now - 100,
+    });
+    expect(candidate.approved_at).toBeNull();
+
+    const approvedAt = now - 50;
+    updateCandidate('cand-happy', { status: 'approved', updated_at: approvedAt });
+    expect(getCandidate('cand-happy')!.approved_at).toBe(approvedAt);
+
+    // Stage
+    const stageTool = findTool(tools, 'vault_stage_skill');
+    const stageResult = parseResult(
+      await stageTool.handler(
+        {
+          candidate_id: 'cand-happy',
+          name: 'happy-skill',
+          display_name: 'Happy Skill',
+          description: 'Test integration happy path',
+          content: validSkillContent('happy-skill'),
+          rationale: 'first stage',
+        },
+        undefined,
+      ),
+    ) as { status: string };
+    expect(stageResult.status).toBe('staged');
+
+    // After stage: live file/row MUST NOT exist
+    expect(getSkillRecordByName('happy-skill')).toBeNull();
+    expect(fs.existsSync(path.join(tmpDir, '.agents', 'skills', 'happy-skill', 'SKILL.md'))).toBe(false);
+    expect(getCandidate('cand-happy')!.status).toBe('approved');
+
+    // Finalize
+    const finalizeTool = findTool(tools, 'vault_finalize_skill');
+    const finalizeResult = parseResult(
+      await finalizeTool.handler({ candidate_id: 'cand-happy' }, undefined),
+    ) as { name: string; path: string; generation: number };
+    expect(finalizeResult.name).toBe('happy-skill');
+    expect(finalizeResult.generation).toBe(1);
+
+    // Live file and row exist now
+    expect(fs.existsSync(path.join(tmpDir, '.agents', 'skills', 'happy-skill', 'SKILL.md'))).toBe(true);
+    expect(getSkillRecordByName('happy-skill')).not.toBeNull();
+
+    // Candidate flipped, approved_at preserved
+    const finalCandidate = getCandidate('cand-happy')!;
+    expect(finalCandidate.status).toBe('generated');
+    expect(finalCandidate.approved_at).toBe(approvedAt);
+    expect(finalCandidate.skill_id).not.toBeNull();
+
+    // Staging cleaned
+    expect(fs.existsSync(stagingPath(vaultDir, 'cand-happy'))).toBe(false);
+    expect(fs.existsSync(stagingManifestPath(vaultDir, 'cand-happy'))).toBe(false);
+  });
+
+  // --------------------------------------------------------------------------
+  // Failure path — the inverse of the original orphan-skill bug
+  // --------------------------------------------------------------------------
+
+  it('draft success + validate failure (no finalize) + cleanup: candidate stays approved, no orphan', async () => {
+    const now = epochNow();
+    insertCandidate({
+      id: 'cand-orphan',
+      agent_id: AGENT_ID,
+      topic: 'Orphan test',
+      rationale: 'Integration rationale',
+      created_at: now - 100,
+      updated_at: now - 100,
+    });
+    const approvedAt = now - 50;
+    updateCandidate('cand-orphan', { status: 'approved', updated_at: approvedAt });
+
+    // Stage (draft phase succeeds)
+    const stageTool = findTool(tools, 'vault_stage_skill');
+    await stageTool.handler(
+      {
+        candidate_id: 'cand-orphan',
+        name: 'orphan-skill',
+        display_name: 'Orphan Skill',
+        description: 'Integration orphan test',
+        content: validSkillContent('orphan-skill'),
+        rationale: 'draft',
+      },
+      undefined,
+    );
+
+    // Assert staging exists
+    expect(fs.existsSync(stagingPath(vaultDir, 'cand-orphan'))).toBe(true);
+
+    // Simulate validate phase failing (no finalize call) — then
+    // the executor cleanup hook runs. We call the cleanup helper
+    // directly here to mirror what the executor does.
+    cleanupStagedSkill(vaultDir, 'cand-orphan');
+
+    // Assert no orphan skill anywhere
+    expect(getSkillRecordByName('orphan-skill')).toBeNull();
+    expect(listSkillRecords({ agent_id: AGENT_ID })).toEqual([]);
+    expect(fs.existsSync(path.join(tmpDir, '.agents', 'skills', 'orphan-skill', 'SKILL.md'))).toBe(false);
+    expect(fs.existsSync(stagingPath(vaultDir, 'cand-orphan'))).toBe(false);
+
+    // Candidate is still approved and still carries its audit timestamp —
+    // ready for the next generate cycle.
+    const stillApproved = getCandidate('cand-orphan')!;
+    expect(stillApproved.status).toBe('approved');
+    expect(stillApproved.approved_at).toBe(approvedAt);
+    expect(stillApproved.skill_id).toBeNull();
+  });
+
+  // --------------------------------------------------------------------------
+  // Iterative rewrite — the draft phase may re-stage multiple times
+  // --------------------------------------------------------------------------
+
+  it('iterative drafts: last stage wins and finalize uses it', async () => {
+    const now = epochNow();
+    insertCandidate({
+      id: 'cand-iter',
+      agent_id: AGENT_ID,
+      topic: 'Iterative test',
+      rationale: 'r',
+      created_at: now,
+      updated_at: now,
+    });
+    updateCandidate('cand-iter', { status: 'approved', updated_at: now });
+
+    const stageTool = findTool(tools, 'vault_stage_skill');
+    await stageTool.handler(
+      {
+        candidate_id: 'cand-iter',
+        name: 'iter-skill',
+        display_name: 'Iter Skill',
+        description: 'First pass',
+        content: validSkillContent('iter-skill', '# Version 1'),
+        rationale: 'first',
+      },
+      undefined,
+    );
+
+    // Re-stage with refined content (validate phase found an issue)
+    await stageTool.handler(
+      {
+        candidate_id: 'cand-iter',
+        name: 'iter-skill',
+        display_name: 'Iter Skill',
+        description: 'Refined pass',
+        content: validSkillContent('iter-skill', '# Version 2 with additional concrete examples'),
+        rationale: 'revision',
+      },
+      undefined,
+    );
+
+    // Finalize — should promote v2
+    const finalizeTool = findTool(tools, 'vault_finalize_skill');
+    await finalizeTool.handler({ candidate_id: 'cand-iter' }, undefined);
+
+    const liveFile = path.join(tmpDir, '.agents', 'skills', 'iter-skill', 'SKILL.md');
+    expect(fs.readFileSync(liveFile, 'utf-8')).toContain('# Version 2');
+  });
+
+  // --------------------------------------------------------------------------
+  // Edge: concurrent live skill appeared between stage and finalize
+  // --------------------------------------------------------------------------
+
+  it('finalize refuses if a live skill with the same name appeared after stage', async () => {
+    const now = epochNow();
+    insertCandidate({
+      id: 'cand-race',
+      agent_id: AGENT_ID,
+      topic: 'Race test',
+      rationale: 'r',
+      created_at: now,
+      updated_at: now,
+    });
+    updateCandidate('cand-race', { status: 'approved', updated_at: now });
+
+    // Stage
+    const stageTool = findTool(tools, 'vault_stage_skill');
+    await stageTool.handler(
+      {
+        candidate_id: 'cand-race',
+        name: 'race-skill',
+        display_name: 'Race Skill',
+        description: 'Race test description',
+        content: validSkillContent('race-skill'),
+        rationale: 'first',
+      },
+      undefined,
+    );
+
+    // Simulate a concurrent write that creates the same-named live skill
+    // (e.g., an evolve task ran in parallel). Use the DB helper directly
+    // so this mirrors any external path.
+    const writeTool = findTool(tools, 'vault_write_skill');
+    await writeTool.handler(
+      {
+        name: 'race-skill',
+        display_name: 'Race Skill',
+        description: 'Different origin',
+        content: validSkillContent('race-skill', '# Concurrent'),
+      },
+      undefined,
+    );
+
+    // Finalize must refuse
+    const finalizeTool = findTool(tools, 'vault_finalize_skill');
+    const result = parseResult(
+      await finalizeTool.handler({ candidate_id: 'cand-race' }, undefined),
+    ) as { error?: string };
+    expect(result.error).toMatch(/already exists/i);
+
+    // The live (concurrent) skill is intact, not overwritten
+    const liveFile = path.join(tmpDir, '.agents', 'skills', 'race-skill', 'SKILL.md');
+    expect(fs.readFileSync(liveFile, 'utf-8')).toContain('# Concurrent');
+
+    // Staging still exists — finalize doesn't clean up on failure
+    expect(fs.existsSync(stagingPath(vaultDir, 'cand-race'))).toBe(true);
+  });
+});

--- a/tests/smoke/review-fixes.test.ts
+++ b/tests/smoke/review-fixes.test.ts
@@ -337,8 +337,8 @@ describe('MCP tools: myco_skills and myco_skill_candidates', () => {
 // VAULT_TOOL_COUNT consistency
 // ---------------------------------------------------------------------------
 describe('VAULT_TOOL_COUNT', () => {
-  it('matches expected count (21)', () => {
-    expect(VAULT_TOOL_COUNT).toBe(21);
+  it('matches expected count (23)', () => {
+    expect(VAULT_TOOL_COUNT).toBe(23);
   });
 });
 

--- a/tests/smoke/skill-staging-pipeline.test.ts
+++ b/tests/smoke/skill-staging-pipeline.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Smoke test for the skill staging pipeline against a real on-disk
+ * SQLite database. Complements the in-memory integration tests by
+ * exercising WAL mode and the fresh-install DDL on a real file.
+ *
+ * macOS /var/folders → /private/var/folders symlinks are resolved via
+ * realpathSync on the tmp path so downstream assertions are stable.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+vi.mock('@myco/intelligence/embed-query.js', () => ({ tryEmbed: async () => null }));
+
+import { initDatabase, closeDatabase, getDatabase, SQLITE_DB_FILE } from '@myco/db/client.js';
+import { createSchema, SCHEMA_VERSION } from '@myco/db/schema.js';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { insertCandidate, getCandidate, updateCandidate } from '@myco/db/queries/skill-candidates.js';
+import { getSkillRecordByName, listSkillRecords } from '@myco/db/queries/skill-records.js';
+import { insertRun } from '@myco/db/queries/runs.js';
+import { createVaultTools } from '@myco/agent/tools.js';
+import { cleanupStagedSkill, stagingPath } from '@myco/agent/tools/skill-staging.js';
+import type { SdkMcpToolDefinition } from '@anthropic-ai/claude-agent-sdk';
+
+// ---------------------------------------------------------------------------
+// Test harness constants
+// ---------------------------------------------------------------------------
+
+const AGENT_ID = 'smoke-agent';
+const RUN_ID = 'smoke-run-001';
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+function validSkillContent(name: string, body = '# Steps\n\n1. First step\n2. Second step') {
+  return `---
+name: myco:${name}
+description: Smoke test skill ${name} exercising the staging pipeline end-to-end
+managed_by: myco
+user-invocable: true
+allowed-tools: Read, Grep, Glob
+---
+
+${body}`;
+}
+
+function findTool(tools: ReturnType<typeof createVaultTools>, name: string) {
+  const t = tools.find((tool) => tool.name === name);
+  if (!t) throw new Error(`Tool not found: ${name}`);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return t as SdkMcpToolDefinition<any>;
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }): unknown {
+  return JSON.parse(result.content[0].text);
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('smoke: skill staging pipeline (real on-disk SQLite)', () => {
+  let tmpDir: string;
+  let vaultDir: string;
+  let dbPath: string;
+
+  beforeAll(() => {
+    // fs.realpathSync resolves /var/folders symlinks to /private/var/folders
+    // so any downstream path comparison against the tmp dir is stable.
+    const raw = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-smoke-staging-'));
+    tmpDir = fs.realpathSync(raw);
+    vaultDir = path.join(tmpDir, '.myco');
+    fs.mkdirSync(vaultDir, { recursive: true });
+    dbPath = path.join(vaultDir, SQLITE_DB_FILE);
+
+    // Fresh v10 install via the app's normal initDatabase + createSchema
+    // path — exercises WAL mode, the full fresh-install DDL, and the
+    // schema_version row insert on a real SQLite file.
+    closeDatabase(); // clear any singleton from a prior test
+    const db = initDatabase(dbPath);
+    createSchema(db, 'local');
+
+    // Seed the agent + run rows that vault tools require as FKs
+    registerAgent({
+      id: AGENT_ID,
+      name: 'Smoke Agent',
+      created_at: epochNow(),
+    });
+    insertRun({
+      id: RUN_ID,
+      agent_id: AGENT_ID,
+      status: 'running',
+      started_at: epochNow(),
+    });
+  });
+
+  afterAll(() => {
+    closeDatabase();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // --------------------------------------------------------------------------
+  // Schema lands at v10 on a fresh install against a real on-disk file
+  // --------------------------------------------------------------------------
+
+  it('fresh install records schema v10 and exposes approved_at on skill_candidates', () => {
+    const db = getDatabase();
+
+    const row = db
+      .prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1')
+      .get() as { version: number };
+    expect(row.version).toBe(SCHEMA_VERSION);
+    expect(row.version).toBe(10);
+
+    const cols = db
+      .prepare('PRAGMA table_info(skill_candidates)')
+      .all() as Array<{ name: string }>;
+    expect(cols.some((c) => c.name === 'approved_at')).toBe(true);
+  });
+
+  // --------------------------------------------------------------------------
+  // Happy path — full stage → finalize cycle in one test. Both halves
+  // assert the full filesystem + DB state at each checkpoint so a
+  // regression in either stage or finalize fails with a clear message.
+  // --------------------------------------------------------------------------
+
+  it('stage → finalize: atomic promotion, staging cleaned, approved_at preserved', async () => {
+    const candidateId = 'cand-smoke-happy';
+    const now = epochNow();
+    insertCandidate({
+      id: candidateId,
+      agent_id: AGENT_ID,
+      topic: 'Smoke happy topic',
+      rationale: 'Smoke rationale',
+      created_at: now,
+      updated_at: now,
+    });
+    updateCandidate(candidateId, { status: 'approved', updated_at: now });
+    const approvedAtBefore = getCandidate(candidateId)!.approved_at;
+    expect(approvedAtBefore).toBeGreaterThan(0);
+
+    const tools = createVaultTools(AGENT_ID, RUN_ID, {
+      projectRoot: tmpDir,
+      vaultDir,
+    });
+
+    // -------- Stage --------
+    const stageTool = findTool(tools, 'vault_stage_skill');
+    const stageResult = parseResult(
+      await stageTool.handler(
+        {
+          candidate_id: candidateId,
+          name: 'smoke-happy',
+          display_name: 'Smoke Happy',
+          description: 'End-to-end smoke test — exercises the happy path',
+          content: validSkillContent('smoke-happy'),
+          rationale: 'smoke run',
+        },
+        undefined,
+      ),
+    ) as { status: string; staging_path: string };
+
+    expect(stageResult.status).toBe('staged');
+    expect(stageResult.staging_path).toContain(candidateId);
+
+    const stagedFile = stagingPath(vaultDir, candidateId);
+    expect(fs.existsSync(stagedFile)).toBe(true);
+    const manifestFile = path.join(path.dirname(stagedFile), 'manifest.json');
+    expect(fs.existsSync(manifestFile)).toBe(true);
+
+    const manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf-8'));
+    expect(manifest.name).toBe('smoke-happy');
+    expect(manifest.candidate_id).toBe(candidateId);
+
+    // Nothing written to the live area yet
+    expect(
+      fs.existsSync(path.join(tmpDir, '.agents', 'skills', 'smoke-happy', 'SKILL.md')),
+    ).toBe(false);
+    expect(getSkillRecordByName('smoke-happy')).toBeNull();
+    expect(getCandidate(candidateId)!.status).toBe('approved');
+
+    // -------- Finalize --------
+    const finalizeTool = findTool(tools, 'vault_finalize_skill');
+    const finalizeResult = parseResult(
+      await finalizeTool.handler({ candidate_id: candidateId }, undefined),
+    ) as { name: string; path: string; generation: number };
+
+    expect(finalizeResult.name).toBe('smoke-happy');
+    expect(finalizeResult.generation).toBe(1);
+    expect(finalizeResult.path).toBe('.agents/skills/smoke-happy/SKILL.md');
+
+    const liveFile = path.join(tmpDir, '.agents', 'skills', 'smoke-happy', 'SKILL.md');
+    expect(fs.existsSync(liveFile)).toBe(true);
+    expect(fs.readFileSync(liveFile, 'utf-8')).toContain('Smoke test skill smoke-happy');
+
+    const record = getSkillRecordByName('smoke-happy');
+    expect(record).not.toBeNull();
+    expect(record!.description).toContain('End-to-end smoke test');
+
+    const afterFinalize = getCandidate(candidateId)!;
+    expect(afterFinalize.status).toBe('generated');
+    expect(afterFinalize.approved_at).toBe(approvedAtBefore);
+    expect(afterFinalize.skill_id).toBe(record!.id);
+
+    // Staging cleaned; exactly one live skill now registered
+    expect(fs.existsSync(stagedFile)).toBe(false);
+    const records = listSkillRecords({ agent_id: AGENT_ID });
+    expect(records).toHaveLength(1);
+    expect(records[0].name).toBe('smoke-happy');
+  });
+
+  // --------------------------------------------------------------------------
+  // Failure path — inverse of the original orphan-skill bug
+  // --------------------------------------------------------------------------
+
+  it('draft stages, validate fails, executor cleanup: no orphan anywhere', async () => {
+    // Fresh candidate for the failure path
+    const candidateId = 'cand-smoke-orphan';
+    const now = epochNow();
+    insertCandidate({
+      id: candidateId,
+      agent_id: AGENT_ID,
+      topic: 'Smoke orphan topic',
+      rationale: 'Test inverse of original orphan bug',
+      created_at: now,
+      updated_at: now,
+    });
+    updateCandidate(candidateId, { status: 'approved', updated_at: now });
+    const approvedAtBeforeFailure = getCandidate(candidateId)!.approved_at!;
+    expect(approvedAtBeforeFailure).toBeGreaterThan(0);
+
+    // Stage (draft phase)
+    const tools = createVaultTools(AGENT_ID, RUN_ID, {
+      projectRoot: tmpDir,
+      vaultDir,
+    });
+    const stageTool = findTool(tools, 'vault_stage_skill');
+    await stageTool.handler(
+      {
+        candidate_id: candidateId,
+        name: 'smoke-orphan',
+        display_name: 'Smoke Orphan',
+        description: 'This skill should never become live because validate will fail',
+        content: validSkillContent('smoke-orphan'),
+        rationale: 'pre-failure draft',
+      },
+      undefined,
+    );
+
+    // Confirm staged
+    expect(fs.existsSync(stagingPath(vaultDir, candidateId))).toBe(true);
+
+    // Simulate validate-phase failure path: the agent runs out of turns
+    // and never calls vault_finalize_skill. The task executor's failure
+    // hook fires cleanupStagedSkill. We call the same helper directly
+    // here — this is exactly what src/agent/executor.ts does on
+    // required-phase failure for skill-generate.
+    cleanupStagedSkill(vaultDir, candidateId);
+
+    // No orphan anywhere
+    expect(fs.existsSync(stagingPath(vaultDir, candidateId))).toBe(false);
+    expect(getSkillRecordByName('smoke-orphan')).toBeNull();
+    expect(
+      fs.existsSync(path.join(tmpDir, '.agents', 'skills', 'smoke-orphan', 'SKILL.md')),
+    ).toBe(false);
+
+    // Candidate still approved, audit trail intact — ready for the
+    // next generate cycle to retry.
+    const afterFailure = getCandidate(candidateId)!;
+    expect(afterFailure.status).toBe('approved');
+    expect(afterFailure.approved_at).toBe(approvedAtBeforeFailure);
+    expect(afterFailure.skill_id).toBeNull();
+
+    // No stray staging dirs anywhere (not just for this candidate)
+    const stagingRootPath = path.join(vaultDir, 'staging', 'skills');
+    if (fs.existsSync(stagingRootPath)) {
+      const entries = fs.readdirSync(stagingRootPath);
+      expect(entries).toEqual([]);
+    }
+  });
+});

--- a/tests/symbionts/installer.test.ts
+++ b/tests/symbionts/installer.test.ts
@@ -69,6 +69,8 @@ const CODEX_MANIFEST: SymbiontManifest = {
     mcpTarget: '.codex/config.toml',
     mcpFormat: 'toml',
     skillsTarget: '.agents/skills',
+    settingsTarget: '.codex/config.toml',
+    settingsFormat: 'toml',
   },
 };
 
@@ -191,6 +193,9 @@ function setupPackageRoot(): void {
   });
   writeJson(path.join(codexTemplateDir, 'mcp.json'), {
     myco: { command: 'myco-run', args: ['mcp'] },
+  });
+  writeJson(path.join(codexTemplateDir, 'settings.json'), {
+    features: { codex_hooks: true },
   });
   writeJson(path.join(vscodeTemplateDir, 'hooks.json'), {
     SessionStart: [{ hooks: [{ type: 'command', command: 'node .agents/myco-hook.cjs hook session-start', timeout: 10 }] }],
@@ -840,6 +845,168 @@ describe('installMcp (TOML)', () => {
     const content = fs.readFileSync(path.join(codexDir, 'config.toml'), 'utf-8');
     expect(content).toContain('command = "myco-run"');
     expect(content).not.toContain('old-command');
+  });
+});
+
+// =====================
+// installSettings (TOML)
+// =====================
+
+describe('installSettings (TOML)', () => {
+  it('writes [features] section to Codex config.toml', () => {
+    fs.mkdirSync(path.join(projectRoot, '.codex'), { recursive: true });
+    const installer = new SymbiontInstaller(CODEX_MANIFEST, projectRoot, packageRoot);
+    const result = installer.installSettings();
+
+    expect(result).toBe(true);
+    const content = fs.readFileSync(path.join(projectRoot, '.codex/config.toml'), 'utf-8');
+    expect(content).toContain('[features]');
+    expect(content).toContain('codex_hooks = true');
+  });
+
+  it('preserves unrelated sections when adding [features]', () => {
+    const codexDir = path.join(projectRoot, '.codex');
+    fs.mkdirSync(codexDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(codexDir, 'config.toml'),
+      '[shell_environment_policy]\ninherit = "core"\n\n[shell_environment_policy.set]\nMYCO_CMD = "myco-dev"\n\n[mcp_servers.myco]\ncommand = "myco-run"\nargs = ["mcp"]\n',
+    );
+
+    const installer = new SymbiontInstaller(CODEX_MANIFEST, projectRoot, packageRoot);
+    installer.installSettings();
+
+    const content = fs.readFileSync(path.join(codexDir, 'config.toml'), 'utf-8');
+    expect(content).toContain('[shell_environment_policy]');
+    expect(content).toContain('inherit = "core"');
+    expect(content).toContain('[shell_environment_policy.set]');
+    expect(content).toContain('MYCO_CMD = "myco-dev"');
+    expect(content).toContain('[mcp_servers.myco]');
+    expect(content).toContain('command = "myco-run"');
+    expect(content).toContain('[features]');
+    expect(content).toContain('codex_hooks = true');
+  });
+
+  it('is idempotent on repeated install', () => {
+    fs.mkdirSync(path.join(projectRoot, '.codex'), { recursive: true });
+    const installer = new SymbiontInstaller(CODEX_MANIFEST, projectRoot, packageRoot);
+    installer.installSettings();
+    const first = fs.readFileSync(path.join(projectRoot, '.codex/config.toml'), 'utf-8');
+    installer.installSettings();
+    const second = fs.readFileSync(path.join(projectRoot, '.codex/config.toml'), 'utf-8');
+    expect(second).toBe(first);
+    // And only one [features] header exists
+    expect(first.match(/\[features\]/g)?.length).toBe(1);
+  });
+
+  it('replaces stale value on update', () => {
+    const codexDir = path.join(projectRoot, '.codex');
+    fs.mkdirSync(codexDir, { recursive: true });
+    fs.writeFileSync(path.join(codexDir, 'config.toml'), '[features]\ncodex_hooks = false\n');
+
+    const installer = new SymbiontInstaller(CODEX_MANIFEST, projectRoot, packageRoot);
+    installer.installSettings();
+
+    const content = fs.readFileSync(path.join(codexDir, 'config.toml'), 'utf-8');
+    expect(content).toContain('codex_hooks = true');
+    expect(content).not.toContain('codex_hooks = false');
+  });
+
+  it('install() composes MCP + settings into one TOML file', () => {
+    fs.mkdirSync(path.join(projectRoot, '.codex'), { recursive: true });
+    const installer = new SymbiontInstaller(CODEX_MANIFEST, projectRoot, packageRoot);
+    const result = installer.install();
+
+    expect(result.mcp).toBe(true);
+    expect(result.settings).toBe(true);
+
+    const content = fs.readFileSync(path.join(projectRoot, '.codex/config.toml'), 'utf-8');
+    expect(content).toContain('[mcp_servers.myco]');
+    expect(content).toContain('command = "myco-run"');
+    expect(content).toContain('[features]');
+    expect(content).toContain('codex_hooks = true');
+  });
+});
+
+// =====================
+// uninstallSettings (TOML)
+// =====================
+
+describe('uninstallSettings (TOML)', () => {
+  it('removes codex_hooks key and drops empty [features] section', () => {
+    const codexDir = path.join(projectRoot, '.codex');
+    fs.mkdirSync(codexDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(codexDir, 'config.toml'),
+      '[mcp_servers.myco]\ncommand = "myco-run"\nargs = ["mcp"]\n\n[features]\ncodex_hooks = true\n',
+    );
+
+    const installer = new SymbiontInstaller(CODEX_MANIFEST, projectRoot, packageRoot);
+    const result = installer.uninstallSettings();
+
+    expect(result).toBe(true);
+    const content = fs.readFileSync(path.join(codexDir, 'config.toml'), 'utf-8');
+    expect(content).not.toContain('[features]');
+    expect(content).not.toContain('codex_hooks');
+    expect(content).toContain('[mcp_servers.myco]');
+  });
+
+  it('preserves sibling feature flags in [features]', () => {
+    const codexDir = path.join(projectRoot, '.codex');
+    fs.mkdirSync(codexDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(codexDir, 'config.toml'),
+      '[features]\nsome_other_flag = true\ncodex_hooks = true\n',
+    );
+
+    const installer = new SymbiontInstaller(CODEX_MANIFEST, projectRoot, packageRoot);
+    installer.uninstallSettings();
+
+    const content = fs.readFileSync(path.join(codexDir, 'config.toml'), 'utf-8');
+    expect(content).toContain('[features]');
+    expect(content).toContain('some_other_flag = true');
+    expect(content).not.toContain('codex_hooks');
+  });
+
+  it('deletes file when no TOML content remains', () => {
+    const codexDir = path.join(projectRoot, '.codex');
+    fs.mkdirSync(codexDir, { recursive: true });
+    fs.writeFileSync(path.join(codexDir, 'config.toml'), '[features]\ncodex_hooks = true\n');
+
+    const installer = new SymbiontInstaller(CODEX_MANIFEST, projectRoot, packageRoot);
+    installer.uninstallSettings();
+
+    expect(fs.existsSync(path.join(codexDir, 'config.toml'))).toBe(false);
+  });
+
+  it('returns false when template key is already absent', () => {
+    const codexDir = path.join(projectRoot, '.codex');
+    fs.mkdirSync(codexDir, { recursive: true });
+    fs.writeFileSync(path.join(codexDir, 'config.toml'), '[mcp_servers.other]\ncommand = "other"\n');
+
+    const installer = new SymbiontInstaller(CODEX_MANIFEST, projectRoot, packageRoot);
+    const result = installer.uninstallSettings();
+    expect(result).toBe(false);
+  });
+
+  it('full install then uninstall restores original content', () => {
+    const codexDir = path.join(projectRoot, '.codex');
+    fs.mkdirSync(codexDir, { recursive: true });
+    const original = '[shell_environment_policy]\ninherit = "core"\n\n[shell_environment_policy.set]\nMYCO_CMD = "myco-dev"\n';
+    fs.writeFileSync(path.join(codexDir, 'config.toml'), original);
+
+    const installer = new SymbiontInstaller(CODEX_MANIFEST, projectRoot, packageRoot);
+    installer.installMcp();
+    installer.installSettings();
+
+    installer.uninstallSettings();
+    installer.uninstallMcp();
+
+    const content = fs.readFileSync(path.join(codexDir, 'config.toml'), 'utf-8');
+    expect(content).toContain('[shell_environment_policy]');
+    expect(content).toContain('inherit = "core"');
+    expect(content).toContain('MYCO_CMD = "myco-dev"');
+    expect(content).not.toContain('[features]');
+    expect(content).not.toContain('[mcp_servers.myco]');
   });
 });
 

--- a/tests/utils/parse-csv-list.test.ts
+++ b/tests/utils/parse-csv-list.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { parseCsvList } from '@myco/utils/parse-csv-list.js';
+
+describe('parseCsvList', () => {
+  it('returns empty array for undefined', () => {
+    expect(parseCsvList(undefined)).toEqual([]);
+  });
+
+  it('returns empty array for null', () => {
+    expect(parseCsvList(null)).toEqual([]);
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(parseCsvList('')).toEqual([]);
+  });
+
+  it('returns empty array for whitespace-only input', () => {
+    expect(parseCsvList('   ,  , ')).toEqual([]);
+  });
+
+  it('splits a simple comma-separated list', () => {
+    expect(parseCsvList('a,b,c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('trims surrounding whitespace on each token', () => {
+    expect(parseCsvList(' a , b , c ')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('drops empty tokens (consecutive commas)', () => {
+    expect(parseCsvList('a,,b,,,c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns a single-element array for a value with no commas', () => {
+    expect(parseCsvList('lonely')).toEqual(['lonely']);
+  });
+});

--- a/tests/worker/schema.test.ts
+++ b/tests/worker/schema.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { initD1Schema } from '../../src/worker/src/schema';
+
+interface RecordedRun {
+  sql: string;
+  values: unknown[];
+}
+
+function createFakeD1() {
+  const runs: RecordedRun[] = [];
+  const batchedSql: string[] = [];
+
+  return {
+    runs,
+    batchedSql,
+    db: {
+      prepare(sql: string) {
+        const state = { values: [] as unknown[] };
+        return {
+          sql,
+          bind(...values: unknown[]) {
+            state.values = values;
+            return this;
+          },
+          async run() {
+            runs.push({ sql, values: [...state.values] });
+            return { success: true };
+          },
+        };
+      },
+      async batch(statements: Array<{ sql: string }>) {
+        batchedSql.push(...statements.map((statement) => statement.sql));
+        return [];
+      },
+    },
+  };
+}
+
+describe('initD1Schema', () => {
+  it('adds approved_at and backfills approved/generated skill candidates', async () => {
+    const fake = createFakeD1();
+
+    await initD1Schema(fake.db as never);
+
+    expect(fake.runs).toContainEqual({
+      sql: 'ALTER TABLE skill_candidates ADD COLUMN approved_at INTEGER',
+      values: [],
+    });
+
+    expect(fake.runs).toContainEqual({
+      sql:
+        `UPDATE skill_candidates
+       SET approved_at = strftime('%s', 'now')
+     WHERE approved_at IS NULL
+       AND status IN (?, ?)`,
+      values: ['approved', 'generated'],
+    });
+  });
+});

--- a/ui/src/components/logs/LogTable.tsx
+++ b/ui/src/components/logs/LogTable.tsx
@@ -2,7 +2,7 @@ import { useRef, useEffect, memo } from 'react';
 import { Badge } from '../ui/badge';
 import { cn } from '../../lib/cn';
 import { levelDotColor, levelBadgeVariant } from '../../lib/constants';
-import { formatTimeAgo } from '../../lib/format';
+import { formatTimeAgo, truncate, basename, shortSession } from '../../lib/format';
 import type { LogEntry } from '../../hooks/use-logs';
 
 // ---------------------------------------------------------------------------
@@ -40,6 +40,51 @@ function formatTimestamp(iso: string, relative: boolean): string {
   const mm = String(d.getMinutes()).padStart(2, '0');
   const ss = String(d.getSeconds()).padStart(2, '0');
   return `${hh}:${mm}:${ss}`;
+}
+
+// ---------------------------------------------------------------------------
+// Data hint: pick the single most informative field out of a log entry's
+// `data` blob to render inline next to the message. Turns "8 identical-looking
+// rows" into "8 visually-distinct rows" without forcing the user to open the
+// detail panel.
+// ---------------------------------------------------------------------------
+
+/** Max chars for a task subject preview — keeps the list row compact. */
+const TASK_SUBJECT_HINT_MAX = 40;
+/** Max chars for an error preview — long enough to identify, short enough to fit. */
+const ERROR_HINT_MAX = 60;
+
+/** Non-empty string or null — used by pick functions to skip absent fields. */
+function nonEmpty(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null;
+}
+
+/**
+ * Priority-ordered rules. The first rule whose `pick` returns a non-empty
+ * value wins; `format` (optional) post-processes it for display. New rules are
+ * a one-liner — no branching, no reordering.
+ */
+const HINT_RULES: Array<{
+  pick: (d: Record<string, unknown>) => string | null;
+  format?: (v: string) => string;
+}> = [
+  { pick: (d) => nonEmpty(d.tool_name) },
+  { pick: (d) => nonEmpty(d.type) },
+  { pick: (d) => nonEmpty(d.agent_type) },
+  { pick: (d) => nonEmpty(d.task_subject), format: (s) => truncate(s, TASK_SUBJECT_HINT_MAX) },
+  { pick: (d) => nonEmpty(d.filename) },
+  { pick: (d) => nonEmpty(d.source_path) ?? nonEmpty(d.path), format: basename },
+  { pick: (d) => nonEmpty(d.error), format: (s) => truncate(s, ERROR_HINT_MAX) },
+  { pick: (d) => (typeof d.pid === 'number' ? `pid ${d.pid}` : null) },
+];
+
+function dataHint(data: Record<string, unknown> | null): string {
+  if (!data) return '';
+  for (const { pick, format } of HINT_RULES) {
+    const v = pick(data);
+    if (v) return format ? format(v) : v;
+  }
+  return '';
 }
 
 // ---------------------------------------------------------------------------
@@ -117,6 +162,8 @@ const LogRow = memo(function LogRow({
   compact: boolean;
 }) {
   const py = compact ? 'py-0.5' : 'py-1.5';
+  const session = shortSession(entry.session_id);
+  const hint = dataHint(entry.data);
 
   return (
     <tr
@@ -146,8 +193,17 @@ const LogRow = memo(function LogRow({
       <td className={cn('whitespace-nowrap pr-2 align-top w-[90px] truncate max-w-[90px]', py, COMPONENT_COLOR[entry.component] ?? 'text-on-surface-variant/60')}>
         {entry.component}
       </td>
+      <td
+        className={cn('whitespace-nowrap pr-2 align-top w-[72px] tabular-nums text-on-surface-variant/40', py)}
+        title={entry.session_id ?? ''}
+      >
+        {session}
+      </td>
       <td className={cn('pr-3 text-on-surface align-top break-words', py)}>
-        {entry.message}
+        <span>{entry.message}</span>
+        {hint && (
+          <span className="ml-2 text-on-surface-variant/50">· {hint}</span>
+        )}
       </td>
     </tr>
   );

--- a/ui/src/components/logs/LogToolbar.tsx
+++ b/ui/src/components/logs/LogToolbar.tsx
@@ -1,4 +1,4 @@
-import { Search, Radio, Clock } from 'lucide-react';
+import { Search, Radio, Clock, Pause, Play } from 'lucide-react';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { cn } from '../../lib/cn';
@@ -26,6 +26,9 @@ interface LogToolbarProps {
   timeRange: string;
   onTimeRangeChange: (range: string) => void;
   totalResults?: number;
+  /** Live-mode pause state — only meaningful when `mode === 'live'`. */
+  paused?: boolean;
+  onPausedToggle?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -60,6 +63,8 @@ export function LogToolbar({
   timeRange,
   onTimeRangeChange,
   totalResults,
+  paused = false,
+  onPausedToggle,
 }: LogToolbarProps) {
   return (
     <Surface level="default" className="rounded-md p-3 space-y-2">
@@ -86,6 +91,21 @@ export function LogToolbar({
             Search
           </Button>
         </div>
+
+        {/* Pause/resume (live mode only) */}
+        {mode === 'live' && onPausedToggle && (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 gap-1.5 px-2.5 text-xs"
+            onClick={onPausedToggle}
+            aria-label={paused ? 'Resume log stream' : 'Pause log stream'}
+            title={paused ? 'Resume' : 'Pause'}
+          >
+            {paused ? <Play className="h-3 w-3" /> : <Pause className="h-3 w-3" />}
+            {paused ? 'Resume' : 'Pause'}
+          </Button>
+        )}
 
         {/* Time range (search mode only) */}
         {mode === 'search' && (

--- a/ui/src/components/mycelium/SporeList.tsx
+++ b/ui/src/components/mycelium/SporeList.tsx
@@ -2,23 +2,21 @@ import { AlertCircle, Sprout } from 'lucide-react';
 import { Surface } from '../ui/surface';
 import { ListToolbar, type FilterDefinition } from '../ui/list-toolbar';
 import { Pagination } from '../ui/pagination';
+import { MarkdownContent } from '../ui/markdown-content';
 import { useSpores, type SporeSummary } from '../../hooks/use-spores';
 import { useListFilters, FILTER_ALL } from '../../hooks/use-list-filters';
 import { DEFAULT_PAGE_SIZE } from '../../lib/constants';
-import { truncate } from '../../lib/format';
+import { truncate, shortSession } from '../../lib/format';
 import { cn } from '../../lib/cn';
 import { observationTypeClass, statusClass, formatLabel } from './helpers';
 
 /* ---------- Constants ---------- */
 
-/** Maximum content preview length. */
+/** Maximum content preview length (in characters, used for aria-label only). */
 const CONTENT_PREVIEW_CHARS = 120;
 
 /** Milliseconds per second for epoch conversion. */
 const MS_PER_SECOND = 1_000;
-
-/** Session ID preview length. */
-const SESSION_ID_PREVIEW = 8;
 
 const OBSERVATION_TYPES = [FILTER_ALL, 'gotcha', 'decision', 'discovery', 'trade_off', 'bug_fix'] as const;
 const STATUS_OPTIONS = [FILTER_ALL, 'active', 'superseded', 'consolidated'] as const;
@@ -104,14 +102,16 @@ function SporeRow({
               </span>
             )}
           </div>
-          <p className="font-sans text-sm text-on-surface">
-            {truncate(spore.content, CONTENT_PREVIEW_CHARS)}
-          </p>
+          <MarkdownContent
+            content={spore.content}
+            compact
+            className="text-on-surface line-clamp-2"
+          />
         </div>
         <div className="shrink-0 text-right space-y-1">
           {spore.session_id && (
             <div className="font-mono text-xs text-on-surface-variant">
-              {spore.session_id.slice(0, SESSION_ID_PREVIEW)}
+              {shortSession(spore.session_id)}
             </div>
           )}
           <div className="font-sans text-xs text-on-surface-variant">

--- a/ui/src/components/notifications/NotificationPanel.tsx
+++ b/ui/src/components/notifications/NotificationPanel.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { Button } from '../ui/button';
+import { MarkdownContent } from '../ui/markdown-content';
 import {
   useNotifications,
   useUpdateNotification,
@@ -193,7 +194,11 @@ export function NotificationPanel({ open, onClose }: NotificationPanelProps) {
                         </span>
                       </div>
                       {n.message && (
-                        <p className="text-xs text-on-surface-variant mt-0.5 line-clamp-2">{n.message}</p>
+                        <MarkdownContent
+                          content={n.message}
+                          compact
+                          className="text-xs mt-0.5 line-clamp-2"
+                        />
                       )}
                       <span className="text-[10px] text-on-surface-variant/40 uppercase tracking-wider mt-1 inline-block">
                         {n.domain}

--- a/ui/src/components/sessions/SessionDetail.tsx
+++ b/ui/src/components/sessions/SessionDetail.tsx
@@ -13,13 +13,8 @@ import { useTriggerRun } from '../../hooks/use-agent';
 import { BatchTimeline } from './BatchTimeline';
 import { SessionPlans } from './SessionPlans';
 import { StatusBadge } from './status-helpers';
-import { formatTimeAgo, formatDuration as formatDurationSec } from '../../lib/format';
+import { formatTimeAgo, formatDuration as formatDurationSec, shortSession } from '../../lib/format';
 import { cn } from '../../lib/cn';
-
-/* ---------- Constants ---------- */
-
-/** Characters shown from session ID in compact view. */
-const SESSION_ID_PREVIEW_LENGTH = 8;
 
 /* ---------- Helpers ---------- */
 
@@ -179,7 +174,7 @@ export function SessionDetail({ id }: SessionDetailProps) {
       <div className="space-y-2">
         <div className="flex items-center gap-3 flex-wrap">
           <h1 className="font-serif text-2xl font-normal text-on-surface tracking-wide">
-            {session.title ?? session.id.slice(0, SESSION_ID_PREVIEW_LENGTH)}
+            {session.title ?? shortSession(session.id)}
           </h1>
           <StatusBadge status={session.status} />
           {session.agent && (
@@ -287,8 +282,8 @@ export function SessionDetail({ id }: SessionDetailProps) {
         description="This will permanently remove this session and all related data. This action cannot be undone."
         icon={<Trash2 className="h-4 w-4 text-tertiary" />}
         meta={session ? [
-          { label: 'ID', value: session.id.slice(0, SESSION_ID_PREVIEW_LENGTH) },
-          { label: 'Title', value: session.title || session.id.slice(0, SESSION_ID_PREVIEW_LENGTH) },
+          { label: 'ID', value: shortSession(session.id) },
+          { label: 'Title', value: session.title || shortSession(session.id) },
         ] : []}
         impact={impact ? [
           { label: 'Prompts', value: impact.promptCount },

--- a/ui/src/components/sessions/SessionList.tsx
+++ b/ui/src/components/sessions/SessionList.tsx
@@ -9,6 +9,7 @@ import { Pagination } from '../ui/pagination';
 import { useSessions, useDeleteSession, useSessionImpact, type SessionSummary } from '../../hooks/use-sessions';
 import { useListFilters, FILTER_ALL } from '../../hooks/use-list-filters';
 import { DEFAULT_PAGE_SIZE } from '../../lib/constants';
+import { shortSession } from '../../lib/format';
 import { StatusBadge } from './status-helpers';
 import { cn } from '../../lib/cn';
 import { useState } from 'react';
@@ -17,9 +18,6 @@ import { useState } from 'react';
 
 /** Number of skeleton rows to show during loading. */
 const SKELETON_ROW_COUNT = 5;
-
-/** Characters shown from session ID in compact view. */
-const SESSION_ID_PREVIEW_LENGTH = 8;
 
 /** Characters shown from session ID in table column. */
 const SESSION_ID_COLUMN_LENGTH = 12;
@@ -56,7 +54,7 @@ function SessionTableRow({
   onClick: () => void;
   onDelete: () => void;
 }) {
-  const sessionLabel = session.title || session.id.slice(0, SESSION_ID_PREVIEW_LENGTH);
+  const sessionLabel = session.title || shortSession(session.id);
 
   return (
     <tr
@@ -291,8 +289,8 @@ export function SessionList() {
         description="This will permanently remove this session and all related data. This action cannot be undone."
         icon={<Trash2 className="h-4 w-4 text-tertiary" />}
         meta={deleteTarget ? [
-          { label: 'ID', value: deleteTarget.id.slice(0, SESSION_ID_PREVIEW_LENGTH) },
-          { label: 'Title', value: deleteTarget.title || deleteTarget.id.slice(0, SESSION_ID_PREVIEW_LENGTH) },
+          { label: 'ID', value: shortSession(deleteTarget.id) },
+          { label: 'Title', value: deleteTarget.title || shortSession(deleteTarget.id) },
         ] : []}
         impact={impact ? [
           { label: 'Prompts', value: impact.promptCount },

--- a/ui/src/components/skills/CandidateList.tsx
+++ b/ui/src/components/skills/CandidateList.tsx
@@ -10,6 +10,7 @@ import { Pagination } from '../ui/pagination';
 import { useSkillCandidates, useUpdateCandidate, type SkillCandidate } from '../../hooks/use-skills';
 import { useListFilters, FILTER_ALL } from '../../hooks/use-list-filters';
 import { DEFAULT_PAGE_SIZE } from '../../lib/constants';
+import { CANDIDATE_STATUS, PIPELINE_FILTER_VALUE } from '../../lib/skill-candidate-status';
 
 /* ---------- Constants ---------- */
 
@@ -19,10 +20,11 @@ const CANDIDATE_FILTERS: FilterDefinition[] = [
     label: 'Status',
     options: [
       { value: FILTER_ALL, label: 'All statuses' },
-      { value: 'identified', label: 'Identified' },
-      { value: 'approved', label: 'Approved' },
-      { value: 'generated', label: 'Generated' },
-      { value: 'dismissed', label: 'Dismissed' },
+      { value: CANDIDATE_STATUS.IDENTIFIED, label: 'Identified' },
+      { value: PIPELINE_FILTER_VALUE, label: 'Approved & generated' },
+      { value: CANDIDATE_STATUS.APPROVED, label: 'Awaiting generation' },
+      { value: CANDIDATE_STATUS.GENERATED, label: 'Generated' },
+      { value: CANDIDATE_STATUS.DISMISSED, label: 'Dismissed' },
     ],
   },
 ];
@@ -46,10 +48,10 @@ function timeAgo(epoch: number): string {
 
 function statusBadge(status: string) {
   switch (status) {
-    case 'identified': return <Badge variant="outline">Identified</Badge>;
-    case 'approved': return <Badge variant="secondary">Approved</Badge>;
-    case 'generated': return <Badge variant="default">Generated</Badge>;
-    case 'dismissed': return <Badge variant="outline" className="opacity-50">Dismissed</Badge>;
+    case CANDIDATE_STATUS.IDENTIFIED: return <Badge variant="outline">Identified</Badge>;
+    case CANDIDATE_STATUS.APPROVED: return <Badge variant="secondary">Awaiting generation</Badge>;
+    case CANDIDATE_STATUS.GENERATED: return <Badge variant="default">Generated</Badge>;
+    case CANDIDATE_STATUS.DISMISSED: return <Badge variant="outline" className="opacity-50">Dismissed</Badge>;
     default: return <Badge variant="outline">{status}</Badge>;
   }
 }
@@ -70,7 +72,9 @@ function CandidateCard({
   isDismissing: boolean;
 }) {
   const conf = confidenceLabel(candidate.confidence);
-  const showActions = candidate.status === 'identified' || candidate.status === 'approved';
+  const showActions =
+    candidate.status === CANDIDATE_STATUS.IDENTIFIED ||
+    candidate.status === CANDIDATE_STATUS.APPROVED;
 
   return (
     <Surface level="low" className="p-5 space-y-3">
@@ -80,6 +84,15 @@ function CandidateCard({
           <h3 className="font-serif text-lg text-on-surface leading-tight">
             {candidate.topic}
           </h3>
+          {/* Approval audit line — renders whenever approved_at is set,
+              so the user can trace "I approved this Xd ago" even after
+              the candidate has advanced to generated. */}
+          {candidate.approved_at !== null && (
+            <p className="font-sans text-xs text-on-surface-variant mt-1">
+              Approved {timeAgo(candidate.approved_at)}
+              {candidate.status === CANDIDATE_STATUS.GENERATED && ' · generated'}
+            </p>
+          )}
         </div>
         <div className="flex items-center gap-2 shrink-0">
           {statusBadge(candidate.status)}
@@ -97,7 +110,7 @@ function CandidateCard({
       {/* Actions — only for identified/approved candidates */}
       {showActions && (
         <div className="flex items-center gap-2 pt-1">
-          {candidate.status === 'identified' && (
+          {candidate.status === CANDIDATE_STATUS.IDENTIFIED && (
             <>
               <Button
                 size="sm"
@@ -120,7 +133,7 @@ function CandidateCard({
               </Button>
             </>
           )}
-          {candidate.status === 'approved' && (
+          {candidate.status === CANDIDATE_STATUS.APPROVED && (
             <span className="font-sans text-xs text-on-surface-variant">
               Awaiting generation
             </span>
@@ -154,7 +167,7 @@ function SkeletonCard() {
 export function CandidateList() {
   const updateCandidate = useUpdateCandidate();
   const { searchInput, debouncedSearch, filterValues, offset, setOffset, handleSearchChange, handleFilterChange, activeFilter } = useListFilters({
-    initialFilters: { status: 'identified' },
+    initialFilters: { status: CANDIDATE_STATUS.IDENTIFIED },
   });
 
   const activeStatus = activeFilter('status');
@@ -178,11 +191,11 @@ export function CandidateList() {
   }, [candidates, debouncedSearch]);
 
   function handleApprove(candidate: SkillCandidate) {
-    updateCandidate.mutate({ id: candidate.id, status: 'approved' });
+    updateCandidate.mutate({ id: candidate.id, status: CANDIDATE_STATUS.APPROVED });
   }
 
   function handleDismiss(candidate: SkillCandidate) {
-    updateCandidate.mutate({ id: candidate.id, status: 'dismissed' });
+    updateCandidate.mutate({ id: candidate.id, status: CANDIDATE_STATUS.DISMISSED });
   }
 
   const toolbar = (
@@ -279,12 +292,12 @@ export function CandidateList() {
               isApproving={
                 updateCandidate.isPending &&
                 updateCandidate.variables?.id === candidate.id &&
-                updateCandidate.variables?.status === 'approved'
+                updateCandidate.variables?.status === CANDIDATE_STATUS.APPROVED
               }
               isDismissing={
                 updateCandidate.isPending &&
                 updateCandidate.variables?.id === candidate.id &&
-                updateCandidate.variables?.status === 'dismissed'
+                updateCandidate.variables?.status === CANDIDATE_STATUS.DISMISSED
               }
             />
           ))}

--- a/ui/src/components/ui/markdown-content.tsx
+++ b/ui/src/components/ui/markdown-content.tsx
@@ -5,11 +5,17 @@ import { cn } from '../../lib/cn';
 interface MarkdownContentProps {
   content: string;
   className?: string;
+  /**
+   * Compact rendering for list-row previews — headings are flattened to inline
+   * body text and block margins are removed so the result lives happily inside
+   * a `line-clamp-N` container.
+   */
+  compact?: boolean;
 }
 
-export function MarkdownContent({ content, className }: MarkdownContentProps) {
+export function MarkdownContent({ content, className, compact = false }: MarkdownContentProps) {
   return (
-    <div className={cn('prose-myco', className)}>
+    <div className={cn(compact ? 'prose-myco-compact' : 'prose-myco', className)}>
       <ReactMarkdown remarkPlugins={[remarkGfm]}>
         {content}
       </ReactMarkdown>

--- a/ui/src/hooks/use-logs.ts
+++ b/ui/src/hooks/use-logs.ts
@@ -52,22 +52,50 @@ export interface LogDetailEntry extends LogEntry {
 
 const MAX_LIVE_ENTRIES = 5000;
 
-export function useLogStream() {
+/**
+ * Tail the daemon log stream.
+ *
+ * First fetch omits `since`, which the backend treats as tail mode and returns
+ * the most recent N entries. Subsequent polls pass `since=<cursor>` so only
+ * new entries are returned. Pass `paused=true` to halt polling without clearing
+ * the buffer; resuming triggers an immediate refetch so the user doesn't wait
+ * out the remainder of the current 3s interval.
+ *
+ * Returned `clear()` resets both the buffer AND the cursor — callers can use
+ * it to re-prime the stream from a fresh tail (e.g., when toggling modes).
+ */
+export function useLogStream(paused: boolean = false) {
   const [entries, setEntries] = useState<LogEntry[]>([]);
-  const cursorRef = useRef<number>(0);
+  // null = tail mode (first fetch); number = follow mode from this cursor
+  const cursorRef = useRef<number | null>(null);
 
-  const { data } = useQuery({
+  const { data, refetch } = useQuery({
     queryKey: ['logs-stream'],
-    queryFn: ({ signal }) =>
-      fetchJson<LogStreamResponse>(
-        `/logs/stream?since=${cursorRef.current}`,
-        { signal },
-      ),
-    refetchInterval: POLL_INTERVALS.LOGS,
+    queryFn: ({ signal }) => {
+      const path = cursorRef.current === null
+        ? '/logs/stream'
+        : `/logs/stream?since=${cursorRef.current}`;
+      return fetchJson<LogStreamResponse>(path, { signal });
+    },
+    refetchInterval: paused ? false : POLL_INTERVALS.LOGS,
   });
 
+  // Immediate refetch on resume so the UI catches up without waiting for the
+  // next 3s tick. Harmless while paused — the effect is a no-op until paused
+  // transitions back to false.
+  const wasPausedRef = useRef(paused);
   useEffect(() => {
-    if (!data?.entries.length) return;
+    if (wasPausedRef.current && !paused) refetch();
+    wasPausedRef.current = paused;
+  }, [paused, refetch]);
+
+  useEffect(() => {
+    if (!data?.entries.length) {
+      // Even with no entries, seed the cursor from the first response so the
+      // follow path starts from "now" rather than refetching tail forever.
+      if (data && cursorRef.current === null) cursorRef.current = data.cursor;
+      return;
+    }
     cursorRef.current = data.cursor;
     setEntries((prev) => {
       const combined = [...prev, ...data.entries];
@@ -77,6 +105,7 @@ export function useLogStream() {
 
   const clear = useCallback(() => {
     setEntries([]);
+    cursorRef.current = null;
   }, []);
 
   return { entries, clear };

--- a/ui/src/hooks/use-skills.ts
+++ b/ui/src/hooks/use-skills.ts
@@ -12,6 +12,13 @@ export interface SkillCandidate {
   status: string;
   source_ids: string; // JSON-encoded string
   skill_id: string | null;
+  /**
+   * Epoch seconds of the first transition into status='approved'.
+   * Null for candidates that have never been approved. Auto-set by
+   * the backend and never overwritten. Drives the "Approved Xd ago"
+   * card badge and the combined "pending + generated" filter view.
+   */
+  approved_at: number | null;
   created_at: number;
   updated_at: number;
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -370,3 +370,93 @@
 .prose-myco *:last-child {
   margin-bottom: 0;
 }
+
+/* ---------- Markdown prose — compact (list row previews) ---------- */
+
+/*
+ * Compact variant: used inside list-row previews where content must fit in a
+ * `line-clamp-2/3` container. Headings and paragraphs are flattened to inline
+ * body text so the whole blob flows as a single clippable run; emphasis and
+ * inline code still render.
+ */
+.prose-myco-compact {
+  font-family: var(--font-ui, 'Inter', system-ui, sans-serif);
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: var(--on-surface-variant);
+}
+
+.prose-myco-compact h1,
+.prose-myco-compact h2,
+.prose-myco-compact h3,
+.prose-myco-compact h4,
+.prose-myco-compact h5,
+.prose-myco-compact h6,
+.prose-myco-compact p {
+  display: inline;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  color: inherit;
+  margin: 0;
+}
+
+/* Separate consecutive blocks with a space rather than a line break. */
+.prose-myco-compact h1 + *::before,
+.prose-myco-compact h2 + *::before,
+.prose-myco-compact h3 + *::before,
+.prose-myco-compact h4 + *::before,
+.prose-myco-compact p + *::before {
+  content: ' ';
+}
+
+.prose-myco-compact strong {
+  color: var(--on-surface);
+  font-weight: 600;
+}
+
+.prose-myco-compact em {
+  font-style: italic;
+}
+
+.prose-myco-compact code {
+  font-family: var(--font-data, 'JetBrains Mono', monospace);
+  font-size: 0.85em;
+  padding: 0 0.25em;
+  border-radius: 0.2rem;
+  background: var(--surface-container);
+  color: var(--primary);
+}
+
+.prose-myco-compact ul,
+.prose-myco-compact ol {
+  display: inline;
+  padding: 0;
+  margin: 0;
+}
+
+.prose-myco-compact li {
+  display: inline;
+  margin: 0;
+}
+
+.prose-myco-compact li::before {
+  content: '• ';
+}
+
+.prose-myco-compact li + li::before {
+  content: ' • ';
+}
+
+.prose-myco-compact a {
+  color: inherit;
+  text-decoration: none;
+}
+
+/* Hide block elements that can't be meaningfully flattened. */
+.prose-myco-compact pre,
+.prose-myco-compact blockquote,
+.prose-myco-compact hr,
+.prose-myco-compact table {
+  display: none;
+}

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -45,6 +45,19 @@ export function truncate(text: string | null, max: number): string {
   return text.length > max ? text.slice(0, max) + '\u2026' : text;
 }
 
+/** Number of leading characters to show when rendering a session id compactly. */
+export const SESSION_ID_PREVIEW_LENGTH = 8;
+
+/** Return the first N characters of a session id, or empty string if null. */
+export function shortSession(id: string | null | undefined): string {
+  return id ? id.slice(0, SESSION_ID_PREVIEW_LENGTH) : '';
+}
+
+/** Return the final segment of a slash-separated path, or the input unchanged. */
+export function basename(path: string): string {
+  return path.split('/').pop() || path;
+}
+
 /** Capitalize the first letter of a string. */
 export function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1);

--- a/ui/src/lib/skill-candidate-status.ts
+++ b/ui/src/lib/skill-candidate-status.ts
@@ -1,0 +1,23 @@
+/**
+ * Canonical string values for skill_candidates.status — UI mirror of
+ * src/constants/skill-candidate-status.ts. Kept as a separate file
+ * because the UI is a distinct TypeScript project with no path alias
+ * into the backend's src tree.
+ *
+ * MUST stay in sync with src/constants/skill-candidate-status.ts.
+ * A smoke test asserts the two files agree so drift is caught at CI time.
+ */
+export const CANDIDATE_STATUS = {
+  IDENTIFIED: 'identified',
+  APPROVED: 'approved',
+  GENERATED: 'generated',
+  DISMISSED: 'dismissed',
+} as const;
+
+export type SkillCandidateStatus = (typeof CANDIDATE_STATUS)[keyof typeof CANDIDATE_STATUS];
+
+/**
+ * Composite UI filter value that the REST handler translates into a
+ * multi-status query. Same wire encoding used on the backend.
+ */
+export const PIPELINE_FILTER_VALUE = `${CANDIDATE_STATUS.APPROVED},${CANDIDATE_STATUS.GENERATED}`;

--- a/ui/src/pages/Logs.tsx
+++ b/ui/src/pages/Logs.tsx
@@ -46,9 +46,10 @@ export default function Logs() {
   const [timeRange, setTimeRange] = useState('24h');
   const [page, setPage] = useState(1);
   const [selectedEntry, setSelectedEntry] = useState<LogEntry | null>(null);
+  const [paused, setPaused] = useState(false);
 
   // Live mode
-  const { entries: liveEntries } = useLogStream();
+  const { entries: liveEntries, clear: clearLive } = useLogStream(paused);
 
   // Search mode
   const searchParams = useMemo(() => ({
@@ -97,7 +98,13 @@ export default function Logs() {
   const handleModeChange = useCallback((newMode: LogMode) => {
     setMode(newMode);
     setSelectedEntry(null);
-  }, []);
+    // Reset the live buffer on mode toggle so re-entering live mode starts
+    // from a fresh tail instead of replaying stale entries.
+    if (newMode === 'live') {
+      clearLive();
+      setPaused(false);
+    }
+  }, [clearLive]);
 
   const handleSearchSubmit = useCallback(() => {
     setSearchQuery(searchValue);
@@ -147,6 +154,8 @@ export default function Logs() {
           timeRange={timeRange}
           onTimeRangeChange={(r) => { setTimeRange(r); setPage(1); }}
           totalResults={mode === 'search' ? searchData?.total : undefined}
+          paused={paused}
+          onPausedToggle={() => setPaused((p) => !p)}
         />
       </div>
 
@@ -158,7 +167,7 @@ export default function Logs() {
             entries={displayEntries}
             selectedId={selectedEntry?.id ?? null}
             onSelect={handleSelect}
-            autoScroll={mode === 'live'}
+            autoScroll={mode === 'live' && !paused}
             relativeTime={mode === 'live'}
             compact
           />


### PR DESCRIPTION
Closes three classes of defects in the skill lifecycle, discovered
while debugging an orphan add-daemon-ui-feature skill on 2026-04-08:

## 1. No audit trail for candidate approvals

Added skill_candidates.approved_at via schema v10. The column is
auto-managed by updateCandidate on the first transition into
'approved' and never overwritten thereafter, so the audit trail
survives the later 'approved → generated' transition. Existing
approved + generated rows are backfilled with the migration
timestamp — a one-time assumption flagged as such in the migration
docblock rather than inventing per-row history. The D1 worker
schema is mirrored (fresh DDL + ALTER via initD1Schema).

## 2. Privilege escalation: agent could self-promote candidates

The agent-facing vault_skill_candidates tool accepted status=
'approved' / 'generated' on its update action with no guard, letting
any task run (skill-survey, skill-evolve, digest) mark its own
candidates as approved and trigger generation without human review.

Narrowed the Zod enum on the update action to ['identified',
'dismissed']. Added a REST whitelist in handleUpdateCandidate that
rejects 'generated' entirely — only vault_finalize_skill's internal
call sets that status, and it does so via updateCandidate directly
rather than going through REST.

## 3. Phase-failure orphans: draft commits survived validate failure

vault_write_skill committed SKILL.md, the skill_records row, and
the candidate transition inside the draft phase — before the
validate phase ran. When validate later hit its turn budget and
failed, the commit stood. The next generate cycle then "found" the
orphan skill file and worked around it.

Introduced a two-step staging pipeline:

  - vault_stage_skill writes SKILL.md + manifest.json to a
    .myco/staging/skills/<candidate_id>/ directory. No DB rows, no
    symlinks, no candidate transition.
  - vault_finalize_skill reads the staged content, re-runs
    validation + dedup gates as defense in depth, then atomically
    promotes the staged skill: inserts skill_records + lineage,
    flips the candidate to 'generated' (approved_at preserved),
    copies to .agents/skills/<name>/, creates symbiont symlinks,
    emits the skill.created notification, and cleans up staging.
    On DB transaction failure, the on-disk live file is rolled
    back and staging is preserved so the agent can retry.
  - The executor's task-failure hook calls cleanupStagedSkill for
    skill-generate failures via a new runContext.candidate_id
    field threaded through RunOptions. Replaces the previous regex
    parse-back from the instruction string.
  - A daemon PowerManager job (staging-gc) sweeps stale staging
    dirs older than 24h as belt-and-suspenders for crash paths the
    executor hook can't reach.
  - skill-generate.yaml rewritten: draft phase calls
    vault_stage_skill; validate phase re-stages on failure, calls
    vault_finalize_skill only on success.

## 4. Workflow enforcement follow-ups

Closed three related workflow gaps the user identified after the
staging pipeline landed:

  a. Skill writes now require approved candidates. vault_stage_skill,
     vault_finalize_skill, and vault_write_skill's create path all
     call a shared requireApprovedCandidate() helper that rejects
     with a clear error unless status === 'approved'. Closes a hole
     where callers could materialize identified / dismissed
     candidates into skills.

  b. Scheduler + API short-circuit when there's no work. Added
     isInstructionRequiredTask(taskName). When buildTaskInstruction
     returns undefined for an instruction-required task
     (skill-generate, skill-evolve), both dispatchers log
     "skipped — no work to do" and return without dispatching.
     Fixes the root cause of unapproved-skill generation: the
     scheduler used to dispatch the agent with the default prompt
     and no candidate metadata, letting it pick anything it found.

  c. Candidate create checks all existing candidate statuses.
     vault_skill_candidates create previously only checked active
     skill names; dismissed / generated / approved / identified
     candidates were invisible to the gate. Added a topic-word
     Jaccard check with status-aware rejection messages: dismissed
     → 'do not re-identify', generated → 'already fulfilled',
     approved → 'already queued', identified → 'update existing'.

## 5. Audit + data cleanup

Deleted the orphaned add-daemon-ui-feature skill via
DELETE /api/skill-records/:id (cascades to lineage + resets the
linked candidate to dismissed with skill_id = NULL).

## Other lifecycle improvements bundled in the same branch

  - UI: new 'Approved & generated' combined filter, 'Approved X
    ago' audit badge on candidate cards, statusBadge uses the new
    CANDIDATE_STATUS constants
  - REST: comma-separated status filter (?status=approved,generated)
  - DB: listCandidatesWithCount uses COUNT(*) OVER () window
    function for one round-trip instead of two queries
  - Shared CANDIDATE_STATUS / PIPELINE_FILTER_VALUE constants with
    a UI mirror and sync-check test
  - New parseCsvList utility shared by skills REST + logs query
  - VAULT_TOOL_COUNT auto-derived from tool-group Set sizes
  - Narrative comments removed across skill-tools.ts, skill-staging.ts,
    daemon/api/skills.ts, and tests
  - Per-test mkdtemp in tools-skills.test.ts eliminates shared
    staging dir coupling; smoke test order coupling fixed

## Tests

  - 1864 passing / 4 skipped across 134 test files
  - New coverage:
      * schema v10 migration (add column, backfill, idempotency)
      * approved_at auto-set + no-overwrite invariants
      * Zod enum narrowing on agent tool
      * REST status whitelist
      * staging helpers (round-trip, cleanup, stale listing,
        manifest serialization)
      * stage → finalize integration (happy path, orphan cleanup,
        iterative re-staging, concurrent-live-skill race)
      * on-disk smoke test against real SQLite + WAL mode
      * executor cleanup hook (7 branching rules)
      * staging-gc PowerManager job
      * buildSkillGenerateInstruction status handling
      * cross-status candidate dedup
      * approved-only gate on stage/finalize/write-create

Part of a single feature branch originally developed as
feature/skill-lifecycle-audit-staging in a worktree, squash-merged
to this branch for review.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>## Summary

What changed and why.

## Related Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [ ] Enhancement / new feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] CI / workflow

## Validation

```bash
make check    # lint + 266 tests
```

## Checklist

- [ ] `make check` passes locally
- [ ] Tests added or updated where behavior changed
- [ ] Docs updated for user-visible changes
- [ ] No magic literals introduced (named constants in `src/constants.ts`)
