### PR TITLE
feat(symbionts): add opencode as a plugin-based symbiont

### DIFF
--- a/.agents/skills/add-symbiont/SKILL.md
+++ b/.agents/skills/add-symbiont/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: myco:add-symbiont
-description: "Use this skill when adding a new symbiont (agent integration) to Myco's SymbiontInstaller — the component that manages agent lifecycle operations (init, update, remove, doctor) for all registered agents. Activates whenever you need to onboard a new AI agent (Claude Code, Cursor, Windsurf, a custom agent, etc.) so that `myco init`, `myco update`, and `myco doctor` manage its installation. Apply this skill even if the user doesn't explicitly mention SymbiontInstaller — any time you're adding a new agent type, creating a symbiont manifest, wiring new hook templates, or extending the supported agents list, this skill applies. Also relevant when a new symbiont needs the cross-platform hook guard or environment variable injection."
+description: "Use this skill when adding a new symbiont (agent integration) to Myco's SymbiontInstaller — the component that manages agent lifecycle operations (init, update, remove, doctor) for all registered agents. Activates whenever you need to onboard a new AI agent (Claude Code, Cursor, opencode, a custom agent, etc.) so that `myco init`, `myco update`, and `myco doctor` manage its installation. Apply this skill even if the user doesn't explicitly mention SymbiontInstaller — any time you're adding a new agent type, creating a symbiont manifest, wiring new hook templates, or extending the supported agents list, this skill applies. Also relevant when a new symbiont needs the cross-platform hook guard or environment variable injection."
 managed_by: myco
 user-invocable: true
 allowed-tools: Read, Edit, Write, Bash, Grep, Glob
@@ -10,9 +10,25 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob
 
 ## Prerequisites
 
-- Understand the new agent's hook format and config file locations
-- Know the agent's config directory name (e.g., `.claude/`, `.cursor/`, `.gemini/`)
-- Determined whether the agent reads `AGENTS.md` natively or needs a thin instruction stub
+- Understand the new agent's hook format: JSON config file entries, TOML sections, or a TypeScript/JavaScript plugin module.
+- Know the agent's config directory (e.g., `.claude/`, `.cursor/`, `.opencode/`) and its primary config file.
+- Determine whether the agent reads `AGENTS.md` natively or needs a thin instruction stub.
+- Know whether the agent's MCP config lives under the standard `mcpServers` key or a different one (opencode uses `mcp`).
+
+## How manifests are discovered
+
+Manifests in `src/symbionts/manifests/*.yaml` are **auto-discovered** by `loadManifests()` in `src/symbionts/detect.ts`. Drop a new YAML file in that directory and it is picked up at runtime — **no imports, no registry edit, no code change** is needed to make a new manifest visible. The previous `SYMBIONT_MANIFESTS` array no longer exists.
+
+## Hook delivery modes
+
+The installer supports two ways of delivering hooks to an agent:
+
+| Mode | When | Template file | How installed |
+|------|------|---------------|---------------|
+| **`json` (default)** | Agent reads hooks from a JSON (or TOML) settings file — the common case. | `templates/<agent>/hooks.json` | Merged into `registration.hooksTarget`, preserving non-Myco hook groups. |
+| **`plugin-file`** | Agent reads hooks via a plugin module auto-loaded at startup (e.g., opencode). | `templates/<agent>/plugin.ts` | Copied verbatim to `registration.hooksTarget` (a `.ts` file path). |
+
+Set `registration.hooksFormat: plugin-file` when adding the second class. See the "Plugin-file hook variant" section near the bottom.
 
 ## Steps
 
@@ -23,171 +39,180 @@ Manifests live in `src/symbionts/manifests/`. Create `<agent-name>.yaml`:
 ```yaml
 name: my-agent
 displayName: My Agent
-configDir: .myagent          # project-local config directory this agent uses
-
-# Required: controls per-project activation default at myco init
-defaultEnabled: true         # or false — SymbiontInstaller reads this at init time
-
-# Optional: declare 'toml' if the agent uses TOML config files (e.g., Codex)
-# settingsFormat: json       # default; omit for JSON-based config agents
-# settingsFormat: toml       # required for agents like Codex that use config.toml
-
+binary: my-agent                    # used by myco detect (is the CLI on PATH?)
+configDir: .myagent                 # project-local config directory this agent uses
+pluginRootEnvVar: MYAGENT_PLUGIN_ROOT  # env var Myco checks to detect the active agent at hook time
+resumeCommand: "my-agent resume {sessionId}"  # optional, {sessionId} placeholder
+hookFields:                         # canonical name → agent-specific payload field name
+  sessionId: session_id             # most agents; Windsurf uses trajectory_id, VS Code uses sessionId
+  transcriptPath: transcript_path
+  lastResponse: last_assistant_message
+  # sessionIdEnv: MYAGENT_SESSION_ID  # optional fallback when session_id is not in stdin
+capture:
+  planDirs:
+    - .myagent/plans/               # directories Myco watches for plan files (Write/Edit events captured as plan records)
 registration:
-  hooksTarget: .myagent/hooks.json   # where to write hook registrations
-  mcpTarget: .myagent/mcp.json       # where to write MCP server config
-  skillsTarget: .myagent/skills/     # where to symlink skills
-  hookFields:                         # payload field normalization (if needed)
-    session_id: sessionId             # agent-specific field name → canonical name
-  resumeCommand: my-agent resume      # optional: how to resume a session
-
-# Optional: for agents needing their own instruction file
-# instructionsFile: MY-AGENT.md       # omit if agent reads AGENTS.md natively
+  hooksTarget: .myagent/settings.json   # file where hooks are written (JSON) OR the plugin file path (plugin-file)
+  # hooksFormat: plugin-file            # set when hooks target is a verbatim file, not a JSON merge
+  mcpTarget: .myagent/settings.json     # where MCP server entries are written
+  # mcpServersKey: mcp                  # default 'mcpServers'; set to 'mcp' for opencode-style agents
+  # mcpFormat: toml                     # default 'json'; set to 'toml' for Codex-style agents
+  skillsTarget: .agents/skills          # canonical shared skills directory (see SymbiontInstaller.installSkills())
+  settingsTarget: .myagent/settings.json   # where permission/auto-approval settings are merged
+  # settingsFormat: toml                # default 'json'; set to 'toml' for Codex
+  # pluginPackageTarget: .myagent/package.json   # only for plugin-file agents — declares SDK deps
+  # instructionsFile: MY-AGENT.md       # only for agents that do NOT read AGENTS.md natively
 ```
 
-**`defaultEnabled` is required.** `SymbiontInstaller` reads this field during `myco init` to populate the project's `symbionts` list in `myco.yaml`. A manifest without `defaultEnabled` means the symbiont won't be included in the init-time activation list, even if installed on the machine. The field must be explicit — there is no fallback default.
+**Which targets to set:** only the ones that apply. Omit any target the agent doesn't support — the installer silently skips missing targets.
 
-**`settingsFormat`** controls how the installer reads and writes the agent's config file. Default is `'json'`. Set `settingsFormat: toml` for agents whose settings file is TOML-based (e.g., Codex uses `config.toml`). The installer dispatches on this field when writing MCP entries and hook registrations — an incorrect or missing value will write JSON syntax into a TOML file and break the agent's config.
+**`hookFields`** is mandatory and maps Myco's canonical field names to the names the agent uses in hook stdin payloads. At runtime, `normalizeHookInput()` in `src/hooks/normalize.ts` detects the active agent via `pluginRootEnvVar` (or `sessionIdEnv` as a fallback) and applies the mapping before any hook logic runs.
 
-### 2. Register in SymbiontInstaller
+**TOML agents:** Codex uses `config.toml`, so its manifest declares `mcpFormat: toml` and `settingsFormat: toml`. TOML read/write operations go through `src/symbionts/toml-helpers.ts` (`upsertTomlSection` / `removeTomlSectionKeys`). Codex also requires a `[features] codex_hooks = true` block in its settings template — without it, Codex silently ignores all hook registrations.
 
-Open `src/symbionts/installer.ts` and add the new symbiont to the registry:
+### 2. Create Template Files
 
-```typescript
-import myAgentManifest from './manifests/my-agent.yaml';
+Templates for each agent live under `src/symbionts/templates/<agent-name>/`.
 
-export const SYMBIONT_MANIFESTS = [
-  claudeCodeManifest,
-  cursorManifest,
-  // ... existing ...
-  myAgentManifest,  // add here
-];
-```
-
-The order in `SYMBIONT_MANIFESTS` determines display order in `myco init` interactive prompts and `myco doctor` output.
-
-### 3. Create Hook Templates
-
-Hook templates define the hook scripts written to the agent's config directory during `myco init`.
-
-Create template files in `src/symbionts/templates/<agent-name>/`:
+**For JSON-hook agents** (Claude Code, Cursor, Codex, Gemini, VS Code Copilot, Windsurf):
 
 ```
 src/symbionts/templates/my-agent/
-  session-start.sh
-  user-prompt-submit.sh
-  post-tool-use.sh
-  stop.sh
+  hooks.json       # merged under the "hooks" key in hooksTarget
+  mcp.json         # merged under mcpServersKey (default "mcpServers") in mcpTarget
+  settings.json    # deep-merged into settingsTarget
 ```
 
-Each hook script must:
-1. Include the cross-platform hook guard at the top (see below)
-2. Call `myco-run hook <event>` with the correct payload
-3. Forward `MYCO_AGENT_SESSION` to prevent re-entrancy
+Every hook command MUST use the shared cross-platform guard:
 
-**Template example:**
-```bash
-#!/bin/bash
-# Cross-platform hook guard — prevents execution if myco is not installed
-source "$(dirname "$0")/../myco-hook.cjs" 2>/dev/null || exit 0
-
-export MYCO_AGENT_SESSION=1
-myco-run hook session-start \
-  --session-id "$SESSION_ID" \
-  --agent my-agent
-```
-
-### 4. Wire the Cross-Platform Hook Guard
-
-The hook guard `.agents/myco-hook.cjs` prevents hooks from failing for OSS contributors who don't have Myco installed. It is a CJS module that:
-- Checks if `myco-run` is available on PATH
-- Exits cleanly if Myco is not installed (no error, no noise)
-- Is sourced at the top of every hook script before any Myco commands
-
-New symbiont hooks must source this guard. Do not inline the guard logic — reference the shared file to keep updates centralized.
-
-### 5. Handle Hook Payload Normalization
-
-If the new agent's hook payloads use different field names than the canonical format, declare the mapping in the manifest's `hookFields` section:
-
-```yaml
-hookFields:
-  session_id: trajectory_id          # agent uses trajectory_id, Myco expects session_id
-  tool_name: tool_info.command_line  # dot-path for nested fields
-  # session_id: $env:AGENT_SESSION   # env-var source (prefix with $env:)
-```
-
-`normalizeHookInput()` reads the active manifest at hook runtime and applies the mapping before any processing logic runs. Each hook invocation is a fresh process, so per-invocation manifest detection is correct.
-
-### 6. Wire Instruction File (If Needed)
-
-If the new agent does **not** read `AGENTS.md` natively, declare `instructionsFile` in the manifest:
-
-```yaml
-registration:
-  instructionsFile: MY-AGENT.md
-```
-
-`SymbiontInstaller.installInstructions()` will write a thin stub that defers to `AGENTS.md`. If the file already exists, a reference block is prepended (idempotently) rather than overwriting user content.
-
-Agents that read `AGENTS.md` natively (Cursor, Codex, Windsurf) should omit `instructionsFile` entirely — the installer skips instruction file management for them.
-
-### 7. Implement the Transcript Adapter
-
-The intelligence pipeline needs a transcript parser for each agent's session format:
-
-Create `src/symbionts/adapters/<agent-name>.ts`:
-
-```typescript
-export function parseMyAgentTranscript(content: string): Turn[] {
-  // Parse the agent's transcript format into canonical Turn objects
-  // Each Turn has: role ('user' | 'assistant'), content, and optional toolCalls
+```json
+{
+  "SessionStart": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "node .agents/myco-hook.cjs hook session-start",
+          "timeout": 10
+        }
+      ]
+    }
+  ]
 }
 ```
 
-Register the adapter in `src/symbionts/adapters/index.ts`.
+The hook guard script at `.agents/myco-hook.cjs` is installed automatically by `installHookGuard()` — you do NOT wire it by hand. It exits cleanly if `myco-run` is missing on the contributor's machine.
+
+**For plugin-file agents** (opencode):
+
+```
+src/symbionts/templates/opencode/
+  plugin.ts        # verbatim TypeScript plugin source — copied to .opencode/plugins/myco.ts
+  package.json     # declares the plugin SDK dep for Bun to install — copied to .opencode/package.json
+  mcp.json         # same as JSON-hook agents (written to opencode.json under the "mcp" key)
+  settings.json    # written to opencode.json under the "permission" key
+```
+
+The plugin file must include two markers near the top:
+```ts
+// Managed by Myco. Regenerated on `myco update`. Edit src/symbionts/templates/opencode/plugin.ts in the Myco repo instead.
+// myco:plugin-marker:opencode
+```
+The second line is the uninstall safety marker — `uninstallPluginHookFile()` only deletes files whose content contains `myco:plugin-marker`, so hand-edited files are preserved.
+
+### 3. The Hook Guard (automatic)
+
+`.agents/myco-hook.cjs` is the shared cross-platform guard. It's installed by `SymbiontInstaller.installHookGuard()` whenever any agent with `hooksTarget` is installed. You reference it from hook commands (`node .agents/myco-hook.cjs hook <event>`) but you never edit it from agent templates — the canonical source is `src/symbionts/templates/hook-guard.cjs`.
+
+### 4. Hook Payload Normalization
+
+If the agent's hook payloads use different field names than Claude Code's defaults, declare the mapping in `hookFields`:
+
+```yaml
+hookFields:
+  sessionId: trajectory_id          # Windsurf uses trajectory_id
+  transcriptPath: transcript_path
+  lastResponse: last_assistant_message
+  toolName: tool_info.command_line  # dot-path for nested fields is supported
+  sessionIdEnv: MYAGENT_SESSION_ID  # fallback env var when session_id not in stdin
+```
+
+`normalizeHookInput()` applies this mapping at the start of every hook invocation.
+
+### 5. Instruction File (only if needed)
+
+If the agent does **not** read `AGENTS.md` natively, declare `instructionsFile: MY-AGENT.md` in the manifest. `installInstructions()` writes a thin stub deferring to `AGENTS.md`, or prepends a reference block if the file already exists (idempotent).
+
+Agents that read `AGENTS.md` natively — **Cursor, Codex, Windsurf, opencode** — must NOT declare `instructionsFile`, or they'll get an unnecessary stub written at init time.
+
+### 6. Transcript Adapter — OPTIONAL
+
+Myco's intelligence pipeline can reconstruct conversation turns either from an on-disk transcript file (when the agent provides one) or from the buffered hook events (fallback). Implementing a transcript adapter lets session notes include accurate conversation text.
+
+**Skip this step** if the agent does not expose its transcript as a file on disk — opencode is the reference example: its messages are served programmatically via the SDK, and Myco reconstructs turns from the buffer instead.
+
+**If you do implement one:** create `src/symbionts/<name>.ts` (NOT `src/symbionts/adapters/<name>.ts` — that subdirectory does not exist). Export a `SymbiontAdapter` with `findTranscript(sessionId)` and `parseTurns(content)`. Reuse `parseJsonlTurns` from `src/symbionts/adapter.ts` if the agent uses a JSONL format similar to Claude Code or Cursor. Register the adapter in `src/symbionts/registry.ts` `ALL_ADAPTERS`.
 
 **Common format pitfalls:**
-- Some agents use JSONL (one JSON object per line) — parse line by line
-- Some use a single JSON file with a `messages` array — do NOT parse line by line
-- Some use delta JSONL (state-replay format) — must replay deltas in sequence
+- JSONL (one JSON object per line) — parse line by line.
+- Single JSON file with a `messages` array — parse the whole file as JSON.
+- Delta JSONL (state-replay format) — must replay deltas in sequence.
 
-### 8. Test the Integration
+### 7. Test the Integration
 
-After wiring everything:
+```sh
+make check               # lint + vitest run — MUST be clean before proceeding
+make build               # compiles and copies templates to dist/
 
-```bash
-myco init     # should include new symbiont in symbionts list if defaultEnabled: true
-myco doctor   # should check new symbiont's registration state
-myco update   # should refresh hooks and MCP for new symbiont
-make build    # must pass all 1,600+ tests with 0 TypeScript errors
+# Manual lifecycle test in a throwaway directory
+mkdir -p /tmp/myagent-test/.myagent && cd /tmp/myagent-test
+myco-dev init --non-interactive
+myco-dev doctor          # should list the new symbiont as registered
+myco-dev update          # should report "Everything is up to date" on a no-op run
+myco-dev remove --symbiont my-agent   # should clean up all registered files
 ```
 
-Verify `myco init` includes the new symbiont in the generated `myco.yaml`:
+Verify `myco.yaml` in the test project lists the new symbiont under `symbionts:` after init, and that the hook guard `.agents/myco-hook.cjs` exists.
+
+## Plugin-file hook variant (opencode)
+
+Agents with plugin-based hook systems (no JSON hook entries) use a different install path. All of the following fields are additive — JSON-hook agents ignore them.
+
 ```yaml
-symbionts:
-  - claude-code
-  - my-agent      # should appear if defaultEnabled: true
+registration:
+  hooksTarget: .opencode/plugins/myco.ts     # verbatim file path, NOT a JSON file
+  hooksFormat: plugin-file                    # selects installPluginHookFile() over the JSON merge path
+  pluginPackageTarget: .opencode/package.json # writes the plugin SDK deps manifest
+  mcpTarget: opencode.json
+  mcpServersKey: mcp                          # opencode puts MCP servers under "mcp", not "mcpServers"
+  settingsTarget: opencode.json
+  skillsTarget: .agents/skills
 ```
+
+**The plugin template file** (`templates/opencode/plugin.ts`) is copied verbatim — no substitutions, no templating. It must:
+1. Start with the two marker comments (`// Managed by Myco...` and `// myco:plugin-marker:<agent>`).
+2. Set `process.env.OPENCODE_PLUGIN_ROOT = directory` at plugin init so Myco's hook CLI detects the active agent via the standard `pluginRootEnvVar` mechanism (no new detection code needed).
+3. Spawn hooks with `node .agents/myco-hook.cjs hook <name>` piped JSON payload. The `2>/dev/null || true` guard makes missing-Myco a no-op.
+4. Forward `input.args` (not `output.metadata`) as `tool_input` for `tool.execute.after` events — `args` is where file paths live for write/edit/patch tools, which plan-capture needs.
+
+**The plugin package.json** declares the plugin SDK as a dep so the agent's package manager (opencode uses Bun) installs it at startup. It is **preserved on uninstall** — contributors may have added their own deps.
+
+**The `mcpServersKey` field** tells the installer which top-level JSON key holds MCP server entries. Downstream code that inspects MCP state (e.g., `src/cli/doctor.ts`) must also resolve this key via the manifest, not hardcode `mcpServers`.
 
 ## Common Pitfalls
 
-**Missing `defaultEnabled` in manifest.** This is the most impactful omission: `SymbiontInstaller` reads this field at `myco init` to seed the project's `symbionts` list. Without it, the symbiont will never be in the default activation list for new projects. Developers must add it manually after init. The field must be a boolean (`true` or `false`) — there is no implicit default.
+**Missing `hookFields` for camelCase or nested fields.** Many agents use non-snake-case names (VS Code uses `sessionId` not `session_id`; Windsurf uses `trajectory_id`). Declare the mapping in `hookFields` — do NOT special-case this in hook scripts or `normalizeHookInput`.
 
-**Missing or wrong `settingsFormat` for TOML-based agents.** Codex uses `config.toml`, not `settings.json`. Its manifest must declare `settingsFormat: toml`. Without this, the installer writes JSON syntax into a TOML file and silently corrupts the agent's config. Additionally, Codex hooks are experimental and require an explicit feature flag in `config.toml`:
+**Missing or wrong `settingsFormat` / `mcpFormat` for TOML agents.** Codex uses `config.toml`. Without `settingsFormat: toml` + `mcpFormat: toml`, the installer writes JSON syntax into a TOML file and silently corrupts the agent's config. Codex hooks additionally require `[features] codex_hooks = true` in the settings template — without it, Codex ignores hook registrations silently.
 
-```toml
-[features]
-codex_hooks = true
-```
+**Wrong `mcpServersKey`.** opencode stores MCP entries under `mcp`, not `mcpServers`. If you add a new agent with a non-standard key and forget to set `mcpServersKey`, the installer writes the entries under the wrong key and the agent never sees them.
 
-Without this block, hooks defined in the symbiont manifest are silently ignored by Codex regardless of how they are registered.
+**Hardcoded `mcpServers` in downstream consumers.** When adding code that inspects MCP state (doctor checks, config validators), always resolve the key via `reg.mcpServersKey ?? 'mcpServers'` — never hardcode the string. `src/cli/doctor.ts` is the canonical example of how to do this right.
 
-**Using `getEnabledSymbiontNames()` is the canonical read path.** Don't filter `myco.yaml.symbionts` inline in new code. Always call `getEnabledSymbiontNames(config)` from `src/config/loader.ts`. This was previously copy-pasted in 3 places before being canonicalized.
+**Forgetting the `myco:plugin-marker` header in plugin-file templates.** Without the marker, `uninstallPluginHookFile()` refuses to delete the file on the assumption that it was hand-edited. The template MUST include the marker or uninstall becomes a no-op.
 
-**Forgetting the hook guard.** Hooks without the cross-platform guard will fail loudly for contributors without Myco installed. Always source `.agents/myco-hook.cjs` at the top of every hook script.
+**`instructionsFile` for AGENTS.md-native agents.** Cursor, Codex, Windsurf, and opencode all read `AGENTS.md` natively. Declaring `instructionsFile` for them writes an unnecessary stub on every init.
 
-**hookFields for camelCase or nested fields.** Many agents use non-snake-case field names (e.g., VS Code uses `sessionId` not `session_id`). Declare the mapping in `hookFields` rather than special-casing it in hook scripts or normalizeHookInput logic.
+**Forgetting to add plan directories to `capture.planDirs`.** Plans written by the agent to a project-local directory (e.g., `.opencode/plans/`, `.claude/plans/`) are captured by Myco only if that directory is listed in the manifest's `capture.planDirs`. Without it, plan-mode workflows produce no plan records.
 
-**Hardcoding agent detection.** The installer uses config directory presence (`.myagent/` exists) as the signal for "agent is used in this project" — NOT binary-on-PATH presence. Binary detection was removed from the init flow. Don't add it back.
-
-**`instructionsFile` for AGENTS.md-native agents.** Cursor, Codex, and Windsurf read `AGENTS.md` natively — their manifests must NOT declare `instructionsFile`, or they'll get an unnecessary stub written at init time.
+**opencode tool naming: `plan-capture.ts` is case-sensitive.** opencode uses lowercase tool names (`write`, `edit`, `patch`) and camelCase argument fields (`filePath`), unlike Claude Code's PascalCase (`Write`) and snake_case (`file_path`). `src/daemon/plan-capture.ts` handles both sets — if you add another agent with a different naming convention, extend `FILE_WRITE_TOOLS` and the `filePath` field fallback in `isPlanWriteEvent()`.

--- a/.agents/skills/add-symbiont/SKILL.md
+++ b/.agents/skills/add-symbiont/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: myco:add-symbiont
-description: "Use this skill when adding a new symbiont (agent integration) to Myco's SymbiontInstaller — the component that manages agent lifecycle operations (init, update, remove, doctor) for all registered agents. Activates whenever you need to onboard a new AI agent (Claude Code, Cursor, opencode, a custom agent, etc.) so that `myco init`, `myco update`, and `myco doctor` manage its installation. Apply this skill even if the user doesn't explicitly mention SymbiontInstaller — any time you're adding a new agent type, creating a symbiont manifest, wiring new hook templates, or extending the supported agents list, this skill applies. Also relevant when a new symbiont needs the cross-platform hook guard or environment variable injection."
+description: "Use this skill when adding a new symbiont (agent integration) to Myco's SymbiontInstaller — the component that manages agent lifecycle operations (init, update, remove, doctor) for all registered agents. Activates whenever you need to onboard a new AI agent (Claude Code, Cursor, Windsurf, a custom agent, etc.) so that `myco init`, `myco update`, and `myco doctor` manage its installation. Apply this skill even if the user doesn't explicitly mention SymbiontInstaller — any time you're adding a new agent type, creating a symbiont manifest, wiring new hook templates, or extending the supported agents list, this skill applies. Also relevant when a new symbiont needs the cross-platform hook guard or environment variable injection."
 managed_by: myco
 user-invocable: true
 allowed-tools: Read, Edit, Write, Bash, Grep, Glob
@@ -10,25 +10,20 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob
 
 ## Prerequisites
 
-- Understand the new agent's hook format: JSON config file entries, TOML sections, or a TypeScript/JavaScript plugin module.
-- Know the agent's config directory (e.g., `.claude/`, `.cursor/`, `.opencode/`) and its primary config file.
-- Determine whether the agent reads `AGENTS.md` natively or needs a thin instruction stub.
-- Know whether the agent's MCP config lives under the standard `mcpServers` key or a different one (opencode uses `mcp`).
+- Understand the new agent's hook format and config file locations
+- Know the agent's config directory name (e.g., `.claude/`, `.cursor/`, `.gemini/`)
+- Determined whether the agent reads `AGENTS.md` natively or needs a thin instruction stub
 
-## How manifests are discovered
+## Integration Classes
 
-Manifests in `src/symbionts/manifests/*.yaml` are **auto-discovered** by `loadManifests()` in `src/symbionts/detect.ts`. Drop a new YAML file in that directory and it is picked up at runtime — **no imports, no registry edit, no code change** is needed to make a new manifest visible. The previous `SYMBIONT_MANIFESTS` array no longer exists.
+Not all agents can be wired via the same procedure. Before starting, identify which class applies:
 
-## Hook delivery modes
+| Class | Description | Example agents |
+|-------|-------------|----------------|
+| **Class 1 — Config-File** | Agent is configured via JSON or TOML files in a project directory. Hooks, MCP entries, and instructions are written by `SymbiontInstaller` as file I/O. | Claude Code, Cursor, Windsurf, Codex, Gemini CLI, VS Code Copilot |
+| **Class 2 — Plugin-API** | Agent exposes a plugin registration API; it cannot be configured by writing files into a config directory. Requires a dedicated, agent-specific installation path in `SymbiontInstaller` — the standard Steps 1–8 below do NOT apply. | opencode (v0.15.0+, 7th symbiont, implemented) |
 
-The installer supports two ways of delivering hooks to an agent:
-
-| Mode | When | Template file | How installed |
-|------|------|---------------|---------------|
-| **`json` (default)** | Agent reads hooks from a JSON (or TOML) settings file — the common case. | `templates/<agent>/hooks.json` | Merged into `registration.hooksTarget`, preserving non-Myco hook groups. |
-| **`plugin-file`** | Agent reads hooks via a plugin module auto-loaded at startup (e.g., opencode). | `templates/<agent>/plugin.ts` | Copied verbatim to `registration.hooksTarget` (a `.ts` file path). |
-
-Set `registration.hooksFormat: plugin-file` when adding the second class. See the "Plugin-file hook variant" section near the bottom.
+**If you are adding a Class 2 agent:** the steps below describe the Class 1 path only. Class 2 integration requires a separate SymbiontInstaller code path for plugin registration — consult the opencode implementation as the reference. Do not attempt to adapt the file-based manifest/hook steps for a plugin-API agent.
 
 ## Steps
 
@@ -39,180 +34,181 @@ Manifests live in `src/symbionts/manifests/`. Create `<agent-name>.yaml`:
 ```yaml
 name: my-agent
 displayName: My Agent
-binary: my-agent                    # used by myco detect (is the CLI on PATH?)
-configDir: .myagent                 # project-local config directory this agent uses
-pluginRootEnvVar: MYAGENT_PLUGIN_ROOT  # env var Myco checks to detect the active agent at hook time
-resumeCommand: "my-agent resume {sessionId}"  # optional, {sessionId} placeholder
-hookFields:                         # canonical name → agent-specific payload field name
-  sessionId: session_id             # most agents; Windsurf uses trajectory_id, VS Code uses sessionId
-  transcriptPath: transcript_path
-  lastResponse: last_assistant_message
-  # sessionIdEnv: MYAGENT_SESSION_ID  # optional fallback when session_id is not in stdin
-capture:
-  planDirs:
-    - .myagent/plans/               # directories Myco watches for plan files (Write/Edit events captured as plan records)
+configDir: .myagent          # project-local config directory this agent uses
+
+# Required: controls per-project activation default at myco init
+defaultEnabled: true         # or false — SymbiontInstaller reads this at init time
+
+# Optional: declare 'toml' if the agent uses TOML config files (e.g., Codex)
+# settingsFormat: json       # default; omit for JSON-based config agents
+# settingsFormat: toml       # required for agents like Codex that use config.toml
+
 registration:
-  hooksTarget: .myagent/settings.json   # file where hooks are written (JSON) OR the plugin file path (plugin-file)
-  # hooksFormat: plugin-file            # set when hooks target is a verbatim file, not a JSON merge
-  mcpTarget: .myagent/settings.json     # where MCP server entries are written
-  # mcpServersKey: mcp                  # default 'mcpServers'; set to 'mcp' for opencode-style agents
-  # mcpFormat: toml                     # default 'json'; set to 'toml' for Codex-style agents
-  skillsTarget: .agents/skills          # canonical shared skills directory (see SymbiontInstaller.installSkills())
-  settingsTarget: .myagent/settings.json   # where permission/auto-approval settings are merged
-  # settingsFormat: toml                # default 'json'; set to 'toml' for Codex
-  # pluginPackageTarget: .myagent/package.json   # only for plugin-file agents — declares SDK deps
-  # instructionsFile: MY-AGENT.md       # only for agents that do NOT read AGENTS.md natively
+  hooksTarget: .myagent/hooks.json   # where to write hook registrations
+  mcpTarget: .myagent/mcp.json       # where to write MCP server config
+  skillsTarget: .myagent/skills/     # where to symlink skills
+  hookFields:                         # payload field normalization (if needed)
+    session_id: sessionId             # agent-specific field name → canonical name
+  resumeCommand: my-agent resume      # optional: how to resume a session
+
+# Optional: for agents needing their own instruction file
+# instructionsFile: MY-AGENT.md       # omit if agent reads AGENTS.md natively
 ```
 
-**Which targets to set:** only the ones that apply. Omit any target the agent doesn't support — the installer silently skips missing targets.
+**`defaultEnabled` is required.** `SymbiontInstaller` reads this field during `myco init` to populate the project's `symbionts` list in `myco.yaml`. A manifest without `defaultEnabled` means the symbiont won't be included in the init-time activation list, even if installed on the machine. The field must be explicit — there is no fallback default.
 
-**`hookFields`** is mandatory and maps Myco's canonical field names to the names the agent uses in hook stdin payloads. At runtime, `normalizeHookInput()` in `src/hooks/normalize.ts` detects the active agent via `pluginRootEnvVar` (or `sessionIdEnv` as a fallback) and applies the mapping before any hook logic runs.
+**`settingsFormat`** controls how the installer reads and writes the agent's config file. Default is `'json'`. Set `settingsFormat: toml` for agents whose settings file is TOML-based (e.g., Codex uses `config.toml`). The installer dispatches on this field when writing MCP entries and hook registrations — an incorrect or missing value will write JSON syntax into a TOML file and break the agent's config. TOML read/write operations use `src/symbionts/toml-helpers.ts` (`upsertTomlSection` / `removeTomlSectionKeys`) — reference that module rather than hand-rolling TOML string manipulation.
 
-**TOML agents:** Codex uses `config.toml`, so its manifest declares `mcpFormat: toml` and `settingsFormat: toml`. TOML read/write operations go through `src/symbionts/toml-helpers.ts` (`upsertTomlSection` / `removeTomlSectionKeys`). Codex also requires a `[features] codex_hooks = true` block in its settings template — without it, Codex silently ignores all hook registrations.
+### 2. Register in SymbiontInstaller
 
-### 2. Create Template Files
+Open `src/symbionts/installer.ts` and add the new symbiont to the registry:
 
-Templates for each agent live under `src/symbionts/templates/<agent-name>/`.
+```typescript
+import myAgentManifest from './manifests/my-agent.yaml';
 
-**For JSON-hook agents** (Claude Code, Cursor, Codex, Gemini, VS Code Copilot, Windsurf):
+export const SYMBIONT_MANIFESTS = [
+  claudeCodeManifest,
+  cursorManifest,
+  // ... existing ...
+  myAgentManifest,  // add here
+];
+```
+
+The order in `SYMBIONT_MANIFESTS` determines display order in `myco init` interactive prompts and `myco doctor` output.
+
+### 3. Create Hook Templates
+
+Hook templates define the hook scripts written to the agent's config directory during `myco init`.
+
+Create template files in `src/symbionts/templates/<agent-name>/`:
 
 ```
 src/symbionts/templates/my-agent/
-  hooks.json       # merged under the "hooks" key in hooksTarget
-  mcp.json         # merged under mcpServersKey (default "mcpServers") in mcpTarget
-  settings.json    # deep-merged into settingsTarget
+  session-start.sh
+  user-prompt-submit.sh
+  post-tool-use.sh
+  stop.sh
 ```
 
-Every hook command MUST use the shared cross-platform guard:
+Each hook script must:
+1. Include the cross-platform hook guard at the top (see below)
+2. Call `myco-run hook <event>` with the correct payload
+3. Forward `MYCO_AGENT_SESSION` to prevent re-entrancy
 
-```json
-{
-  "SessionStart": [
-    {
-      "hooks": [
-        {
-          "type": "command",
-          "command": "node .agents/myco-hook.cjs hook session-start",
-          "timeout": 10
-        }
-      ]
-    }
-  ]
-}
+**Template example:**
+```bash
+#!/bin/bash
+# Cross-platform hook guard — prevents execution if myco is not installed
+source "$(dirname "$0")/../myco-hook.cjs" 2>/dev/null || exit 0
+
+export MYCO_AGENT_SESSION=1
+myco-run hook session-start \
+  --session-id "$SESSION_ID" \
+  --agent my-agent
 ```
 
-The hook guard script at `.agents/myco-hook.cjs` is installed automatically by `installHookGuard()` — you do NOT wire it by hand. It exits cleanly if `myco-run` is missing on the contributor's machine.
+### 4. Wire the Cross-Platform Hook Guard
 
-**For plugin-file agents** (opencode):
+The hook guard `.agents/myco-hook.cjs` prevents hooks from failing for OSS contributors who don't have Myco installed. It is a CJS module that:
+- Checks if `myco-run` is available on PATH
+- Exits cleanly if Myco is not installed (no error, no noise)
+- Is sourced at the top of every hook script before any Myco commands
 
-```
-src/symbionts/templates/opencode/
-  plugin.ts        # verbatim TypeScript plugin source — copied to .opencode/plugins/myco.ts
-  package.json     # declares the plugin SDK dep for Bun to install — copied to .opencode/package.json
-  mcp.json         # same as JSON-hook agents (written to opencode.json under the "mcp" key)
-  settings.json    # written to opencode.json under the "permission" key
-```
+New symbiont hooks must source this guard. Do not inline the guard logic — reference the shared file to keep updates centralized.
 
-The plugin file must include two markers near the top:
-```ts
-// Managed by Myco. Regenerated on `myco update`. Edit src/symbionts/templates/opencode/plugin.ts in the Myco repo instead.
-// myco:plugin-marker:opencode
-```
-The second line is the uninstall safety marker — `uninstallPluginHookFile()` only deletes files whose content contains `myco:plugin-marker`, so hand-edited files are preserved.
+### 5. Handle Hook Payload Normalization
 
-### 3. The Hook Guard (automatic)
-
-`.agents/myco-hook.cjs` is the shared cross-platform guard. It's installed by `SymbiontInstaller.installHookGuard()` whenever any agent with `hooksTarget` is installed. You reference it from hook commands (`node .agents/myco-hook.cjs hook <event>`) but you never edit it from agent templates — the canonical source is `src/symbionts/templates/hook-guard.cjs`.
-
-### 4. Hook Payload Normalization
-
-If the agent's hook payloads use different field names than Claude Code's defaults, declare the mapping in `hookFields`:
+If the new agent's hook payloads use different field names than the canonical format, declare the mapping in the manifest's `hookFields` section:
 
 ```yaml
 hookFields:
-  sessionId: trajectory_id          # Windsurf uses trajectory_id
-  transcriptPath: transcript_path
-  lastResponse: last_assistant_message
-  toolName: tool_info.command_line  # dot-path for nested fields is supported
-  sessionIdEnv: MYAGENT_SESSION_ID  # fallback env var when session_id not in stdin
+  session_id: trajectory_id          # agent uses trajectory_id, Myco expects session_id
+  tool_name: tool_info.command_line  # dot-path for nested fields
+  # session_id: $env:AGENT_SESSION   # env-var source (prefix with $env:)
 ```
 
-`normalizeHookInput()` applies this mapping at the start of every hook invocation.
+`normalizeHookInput()` reads the active manifest at hook runtime and applies the mapping before any processing logic runs. Each hook invocation is a fresh process, so per-invocation manifest detection is correct.
 
-### 5. Instruction File (only if needed)
+### 6. Wire Instruction File (If Needed)
 
-If the agent does **not** read `AGENTS.md` natively, declare `instructionsFile: MY-AGENT.md` in the manifest. `installInstructions()` writes a thin stub deferring to `AGENTS.md`, or prepends a reference block if the file already exists (idempotent).
-
-Agents that read `AGENTS.md` natively — **Cursor, Codex, Windsurf, opencode** — must NOT declare `instructionsFile`, or they'll get an unnecessary stub written at init time.
-
-### 6. Transcript Adapter — OPTIONAL
-
-Myco's intelligence pipeline can reconstruct conversation turns either from an on-disk transcript file (when the agent provides one) or from the buffered hook events (fallback). Implementing a transcript adapter lets session notes include accurate conversation text.
-
-**Skip this step** if the agent does not expose its transcript as a file on disk — opencode is the reference example: its messages are served programmatically via the SDK, and Myco reconstructs turns from the buffer instead.
-
-**If you do implement one:** create `src/symbionts/<name>.ts` (NOT `src/symbionts/adapters/<name>.ts` — that subdirectory does not exist). Export a `SymbiontAdapter` with `findTranscript(sessionId)` and `parseTurns(content)`. Reuse `parseJsonlTurns` from `src/symbionts/adapter.ts` if the agent uses a JSONL format similar to Claude Code or Cursor. Register the adapter in `src/symbionts/registry.ts` `ALL_ADAPTERS`.
-
-**Common format pitfalls:**
-- JSONL (one JSON object per line) — parse line by line.
-- Single JSON file with a `messages` array — parse the whole file as JSON.
-- Delta JSONL (state-replay format) — must replay deltas in sequence.
-
-### 7. Test the Integration
-
-```sh
-make check               # lint + vitest run — MUST be clean before proceeding
-make build               # compiles and copies templates to dist/
-
-# Manual lifecycle test in a throwaway directory
-mkdir -p /tmp/myagent-test/.myagent && cd /tmp/myagent-test
-myco-dev init --non-interactive
-myco-dev doctor          # should list the new symbiont as registered
-myco-dev update          # should report "Everything is up to date" on a no-op run
-myco-dev remove --symbiont my-agent   # should clean up all registered files
-```
-
-Verify `myco.yaml` in the test project lists the new symbiont under `symbionts:` after init, and that the hook guard `.agents/myco-hook.cjs` exists.
-
-## Plugin-file hook variant (opencode)
-
-Agents with plugin-based hook systems (no JSON hook entries) use a different install path. All of the following fields are additive — JSON-hook agents ignore them.
+If the new agent does **not** read `AGENTS.md` natively, declare `instructionsFile` in the manifest:
 
 ```yaml
 registration:
-  hooksTarget: .opencode/plugins/myco.ts     # verbatim file path, NOT a JSON file
-  hooksFormat: plugin-file                    # selects installPluginHookFile() over the JSON merge path
-  pluginPackageTarget: .opencode/package.json # writes the plugin SDK deps manifest
-  mcpTarget: opencode.json
-  mcpServersKey: mcp                          # opencode puts MCP servers under "mcp", not "mcpServers"
-  settingsTarget: opencode.json
-  skillsTarget: .agents/skills
+  instructionsFile: MY-AGENT.md
 ```
 
-**The plugin template file** (`templates/opencode/plugin.ts`) is copied verbatim — no substitutions, no templating. It must:
-1. Start with the two marker comments (`// Managed by Myco...` and `// myco:plugin-marker:<agent>`).
-2. Set `process.env.OPENCODE_PLUGIN_ROOT = directory` at plugin init so Myco's hook CLI detects the active agent via the standard `pluginRootEnvVar` mechanism (no new detection code needed).
-3. Spawn hooks with `node .agents/myco-hook.cjs hook <name>` piped JSON payload. The `2>/dev/null || true` guard makes missing-Myco a no-op.
-4. Forward `input.args` (not `output.metadata`) as `tool_input` for `tool.execute.after` events — `args` is where file paths live for write/edit/patch tools, which plan-capture needs.
+`SymbiontInstaller.installInstructions()` will write a thin stub that defers to `AGENTS.md`. If the file already exists, a reference block is prepended (idempotently) rather than overwriting user content.
 
-**The plugin package.json** declares the plugin SDK as a dep so the agent's package manager (opencode uses Bun) installs it at startup. It is **preserved on uninstall** — contributors may have added their own deps.
+Agents that read `AGENTS.md` natively (Cursor, Codex, Windsurf) should omit `instructionsFile` entirely — the installer skips instruction file management for them.
 
-**The `mcpServersKey` field** tells the installer which top-level JSON key holds MCP server entries. Downstream code that inspects MCP state (e.g., `src/cli/doctor.ts`) must also resolve this key via the manifest, not hardcode `mcpServers`.
+### 7. Implement the Transcript Adapter
+
+The intelligence pipeline needs a transcript parser for each agent's session format:
+
+Create `src/symbionts/adapters/<agent-name>.ts`:
+
+```typescript
+export function parseMyAgentTranscript(content: string): Turn[] {
+  // Parse the agent's transcript format into canonical Turn objects
+  // Each Turn has: role ('user' | 'assistant'), content, and optional toolCalls
+}
+```
+
+Register the adapter in `src/symbionts/adapters/index.ts`.
+
+**Common format pitfalls:**
+- Some agents use JSONL (one JSON object per line) — parse line by line
+- Some use a single JSON file with a `messages` array — do NOT parse line by line
+- Some use delta JSONL (state-replay format) — must replay deltas in sequence
+
+### 8. Test the Integration
+
+After wiring everything:
+
+```bash
+myco init     # should include new symbiont in symbionts list if defaultEnabled: true
+myco doctor   # should check new symbiont's registration state
+myco update   # should refresh hooks and MCP for new symbiont
+make build    # must pass all 1,600+ tests with 0 TypeScript errors
+```
+
+Verify `myco init` includes the new symbiont in the generated `myco.yaml`:
+```yaml
+symbionts:
+  - claude-code
+  - my-agent      # should appear if defaultEnabled: true
+```
 
 ## Common Pitfalls
 
-**Missing `hookFields` for camelCase or nested fields.** Many agents use non-snake-case names (VS Code uses `sessionId` not `session_id`; Windsurf uses `trajectory_id`). Declare the mapping in `hookFields` — do NOT special-case this in hook scripts or `normalizeHookInput`.
+**Missing `defaultEnabled` in manifest.** This is the most impactful omission: `SymbiontInstaller` reads this field at `myco init` to seed the project's `symbionts` list. Without it, the symbiont will never be in the default activation list for new projects. Developers must add it manually after init. The field must be a boolean (`true` or `false`) — there is no implicit default.
 
-**Missing or wrong `settingsFormat` / `mcpFormat` for TOML agents.** Codex uses `config.toml`. Without `settingsFormat: toml` + `mcpFormat: toml`, the installer writes JSON syntax into a TOML file and silently corrupts the agent's config. Codex hooks additionally require `[features] codex_hooks = true` in the settings template — without it, Codex ignores hook registrations silently.
+**Missing or wrong `settingsFormat` for TOML-based agents.** Codex uses `config.toml`, not `settings.json`. Its manifest must declare `settingsFormat: toml`. Without this, the installer writes JSON syntax into a TOML file and silently corrupts the agent's config. Additionally, Codex hooks are experimental and require an explicit feature flag in `config.toml`:
 
-**Wrong `mcpServersKey`.** opencode stores MCP entries under `mcp`, not `mcpServers`. If you add a new agent with a non-standard key and forget to set `mcpServersKey`, the installer writes the entries under the wrong key and the agent never sees them.
+```toml
+[features]
+codex_hooks = true
+```
 
-**Hardcoded `mcpServers` in downstream consumers.** When adding code that inspects MCP state (doctor checks, config validators), always resolve the key via `reg.mcpServersKey ?? 'mcpServers'` — never hardcode the string. `src/cli/doctor.ts` is the canonical example of how to do this right.
+Without this block, hooks defined in the symbiont manifest are silently ignored by Codex regardless of how they are registered.
 
-**Forgetting the `myco:plugin-marker` header in plugin-file templates.** Without the marker, `uninstallPluginHookFile()` refuses to delete the file on the assumption that it was hand-edited. The template MUST include the marker or uninstall becomes a no-op.
+**Class 2 agents cannot use this procedure.** Plugin-API agents (e.g., opencode) do not expose a config directory for file-based hook/MCP injection. Attempting to wire them via manifest + template steps will produce a silently incomplete integration. These agents require a dedicated installation code path in `SymbiontInstaller`. Do not adapt the Class 1 steps for a plugin-API agent.
 
-**`instructionsFile` for AGENTS.md-native agents.** Cursor, Codex, Windsurf, and opencode all read `AGENTS.md` natively. Declaring `instructionsFile` for them writes an unnecessary stub on every init.
+**Class 2 (opencode): `client.app.log` is silently swallowed.** Output via `client.app.log()` is swallowed by the TUI and does not appear anywhere observable. Use `console.error()` for debug output during Class 2 plugin development — it appears in opencode's stderr stream.
 
-**Forgetting to add plan directories to `capture.planDirs`.** Plans written by the agent to a project-local directory (e.g., `.opencode/plans/`, `.claude/plans/`) are captured by Myco only if that directory is listed in the manifest's `capture.planDirs`. Without it, plan-mode workflows produce no plan records.
+**Class 2 (opencode): `chat.message({ synthetic: true })` causes infinite crash loops.** Injecting synthetic messages via `chat.message()` triggers the model to respond, which re-enters the plugin callback, which injects another message — a hard crash loop with no escape. Use `session.prompt({ noReply: true })` with `TextPartInput.synthetic: true` to inject content without triggering a model response.
 
-**opencode tool naming: `plan-capture.ts` is case-sensitive.** opencode uses lowercase tool names (`write`, `edit`, `patch`) and camelCase argument fields (`filePath`), unlike Claude Code's PascalCase (`Write`) and snake_case (`file_path`). `src/daemon/plan-capture.ts` handles both sets — if you add another agent with a different naming convention, extend `FILE_WRITE_TOOLS` and the `filePath` field fallback in `isPlanWriteEvent()`.
+**Class 2 (opencode): OSS safety pattern differs from hook guard.** Unlike Class 1 symbiont hooks (which source `.agents/myco-hook.cjs`), Class 2 plugins check for `.myco/daemon.json` at startup using a filesystem check. If the file is absent (Myco not installed), the plugin exits silently as a no-op. Do not use shell guard sourcing — the plugin runs in the opencode process context.
+
+**Class 2 (opencode): Use `server.instance.disposed` for cleanup.** This event fires reliably on TUI exit (Ctrl+C or `q`). It is the correct hook for cleanup operations (closing connections, flushing state). Do not rely on process exit signals directly.
+
+**Using `getEnabledSymbiontNames()` is the canonical read path.** Don't filter `myco.yaml.symbionts` inline in new code. Always call `getEnabledSymbiontNames(config)` from `src/config/loader.ts`. This was previously copy-pasted in 3 places before being canonicalized.
+
+**Forgetting the hook guard.** Hooks without the cross-platform guard will fail loudly for contributors without Myco installed. Always source `.agents/myco-hook.cjs` at the top of every hook script.
+
+**hookFields for camelCase or nested fields.** Many agents use non-snake-case field names (e.g., VS Code uses `sessionId` not `session_id`). Declare the mapping in `hookFields` rather than special-casing it in hook scripts or normalizeHookInput logic.
+
+**Hardcoding agent detection.** The installer uses config directory presence (`.myagent/` exists) as the signal for "agent is used in this project" — NOT binary-on-PATH presence. Binary detection was removed from the init flow. Don't add it back.
+
+**`instructionsFile` for AGENTS.md-native agents.** Cursor, Codex, and Windsurf read `AGENTS.md` natively — their manifests must NOT declare `instructionsFile`, or they'll get an unnecessary stub written at init time.

--- a/.agents/skills/install-and-initialize-myco/SKILL.md
+++ b/.agents/skills/install-and-initialize-myco/SKILL.md
@@ -14,7 +14,7 @@ Myco is a project-local intelligence layer that captures developer sessions and 
 ## Prerequisites
 
 - Node.js 22+ installed
-- At least one supported coding agent present in the project (Claude Code, Cursor, Codex CLI, Gemini CLI, VS Code Copilot, or Windsurf)
+- At least one supported coding agent present in the project (Claude Code, Cursor, Codex CLI, Gemini CLI, VS Code Copilot, Windsurf, or OpenCode)
 - An Anthropic API key (or compatible key) for the intelligence pipeline
 - You are standing at your project root — Myco installs into `.myco/` relative to your working directory
 
@@ -55,6 +55,7 @@ The interactive wizard does five things:
    - `.gemini/` → Gemini CLI
    - `.vscode/` → VS Code Copilot
    - `.codeium/windsurf/` → Windsurf
+   - `.opencode/` → OpenCode
 
    Agents whose config dir exists are pre-checked as defaults. Detection is informational — you can select or deselect any agent freely.
 

--- a/.agents/skills/register-powermanager-job/SKILL.md
+++ b/.agents/skills/register-powermanager-job/SKILL.md
@@ -65,14 +65,14 @@ fn: () => {
   // Stamp lastRun and mark running synchronously, THEN dispatch without await:
   task.lastRun = Date.now();
   void context.runTask(task.name).catch((err) => {
-    logger.error(`Task ${task.name} failed`, err);
+    context.onTaskError(task.name, err);   // routes to AGENT_ERROR log sink
   }).finally(() => {
     context.markTaskDone(task.name);
   });
 }
 ```
 
-The `full-intelligence` task (18–23 min) hit this bug — every job scheduled after it in the same tick was silently delayed by the full task duration. The fix was removing the `await` and dispatching fire-and-forget. Short-lived tasks (< 1 min) may `await` safely, but fire-and-forget is the safer default for all tasks.
+**No built-in starvation warning:** If a task's `fn` blocks the tick loop (dispatches with `await`), the PowerManager has no built-in diagnostic or warning — the loop simply stops advancing for all subsequent jobs until the blocking call returns. This deferred feature means tick starvation is undetectable without external monitoring. Fire-and-forget dispatch is the only guard. The `full-intelligence` task (18–23 min) hit this bug — every job scheduled after it in the same tick was silently delayed by the full task duration.
 
 **User overrides:** Users can override `enabled` and `intervalSeconds` in `myco.yaml`:
 
@@ -135,7 +135,7 @@ The old top-level keys `agent.auto_run` and `agent.interval_seconds` were migrat
 - [ ] No raw `setInterval` or `setTimeout` anywhere in `src/daemon/`
 - [ ] `runIn` includes all states where the job should actually fire — double-check Sleep
 - [ ] `model` is explicitly set in any new task YAML
-- [ ] Tasks expected to run > ~1 minute use fire-and-forget dispatch (no `await` in the tick loop `fn`)
+- [ ] Tasks expected to run > ~1 minute use fire-and-forget dispatch (no `await` in the tick loop `fn`) — there is NO built-in starvation warning if a blocking task stalls the loop
 - [ ] If `preventsDeepSleep` is used, a dead-letter ceiling (≤ 10 retries) is in place
 - [ ] If a scheduled task is not firing, check `agent.scheduled_tasks_enabled` in `myco.yaml` first (global kill-switch, default `true`) before inspecting the task YAML
 - [ ] Daemon restarted after any YAML or `myco.yaml` schedule changes

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,33 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode/kimi-k2.5-free

--- a/.myco/myco.yaml
+++ b/.myco/myco.yaml
@@ -101,11 +101,13 @@ notifications:
 symbionts:
   claude-code:
     enabled: true
-  cursor:
-    enabled: true
   codex:
     enabled: true
+  cursor:
+    enabled: true
   gemini:
+    enabled: true
+  opencode:
     enabled: true
   vscode-copilot:
     enabled: true

--- a/.opencode/plugins/myco.ts
+++ b/.opencode/plugins/myco.ts
@@ -30,25 +30,34 @@ import { join } from "node:path";
 // Constants
 // ---------------------------------------------------------------------------
 
-const TOOL_OUTPUT_PREVIEW_CHARS = 500;
-
-/** Preferred context tier (matches Myco's default in src/mcp/tools/context.ts). */
-const MYCO_CONTEXT_TIER = 5000;
+/**
+ * Keep in sync with `TOOL_OUTPUT_PREVIEW_CHARS` in src/constants.ts (currently 200).
+ * The plugin file is standalone and cannot import from Myco — this value is copied
+ * so every symbiont records tool_output previews at the same length.
+ */
+const TOOL_OUTPUT_PREVIEW_CHARS = 200;
 
 /** Timeout for daemon HTTP calls — must be short so we never block opencode. */
 const MYCO_FETCH_TIMEOUT_MS = 3000;
 
-/** Heading prefixes for injected context so the model can recognize the source. */
-const DIGEST_HEADING = "## Myco — Project Context\n\n";
+/** Heading prefix for compaction context — makes Myco's contribution recognizable in the compacted summary. */
 const COMPACTION_HEADING = "## Myco — Project Context (preserved across compaction)\n\n";
 
 // ---------------------------------------------------------------------------
 // Daemon HTTP transport — all communication with the local Myco daemon.
-// Every function is best-effort: failures are logged to stderr and swallowed.
+// Every function is best-effort: failures are swallowed so the plugin cannot
+// interfere with opencode when Myco is absent or the daemon is unreachable.
 // ---------------------------------------------------------------------------
 
+/**
+ * Port cache for `.myco/daemon.json`. Read once on first access; refreshed on
+ * the next call that follows a failed HTTP request (handles daemon restarts
+ * mid-session). `undefined` = never loaded, `null` = loaded but absent.
+ */
+let cachedDaemonPort: number | null | undefined = undefined;
+
 /** Read the Myco daemon port from .myco/daemon.json in the project directory. */
-function readDaemonPort(directory: string): number | null {
+function readDaemonPortFromDisk(directory: string): number | null {
   try {
     const raw = readFileSync(join(directory, ".myco", "daemon.json"), "utf-8");
     const info = JSON.parse(raw) as { port?: number };
@@ -56,6 +65,18 @@ function readDaemonPort(directory: string): number | null {
   } catch {
     return null;
   }
+}
+
+/** Get the cached daemon port, loading from disk on first access. */
+function getDaemonPort(directory: string): number | null {
+  if (cachedDaemonPort === undefined) cachedDaemonPort = readDaemonPortFromDisk(directory);
+  return cachedDaemonPort;
+}
+
+/** Force-refresh the daemon port from disk — used after a fetch failure in case the daemon restarted. */
+function refreshDaemonPort(directory: string): number | null {
+  cachedDaemonPort = readDaemonPortFromDisk(directory);
+  return cachedDaemonPort;
 }
 
 /** Fetch with a short timeout. Returns the Response on success, null on failure. */
@@ -72,10 +93,26 @@ async function fetchWithTimeout(url: string, init?: RequestInit): Promise<Respon
   }
 }
 
-/** Build a daemon URL using the port read from .myco/daemon.json. Returns null if unreachable. */
-function daemonUrl(directory: string, path: string): string | null {
-  const port = readDaemonPort(directory);
-  return port ? `http://localhost:${port}${path}` : null;
+/**
+ * Fetch from a daemon endpoint with a single retry after refreshing the port.
+ * The retry handles the case where the daemon restarted on a different port
+ * mid-session; the cache hot-path avoids a sync disk read on every HTTP call.
+ */
+async function fetchFromDaemon(
+  directory: string,
+  path: string,
+  init?: RequestInit,
+): Promise<Response | null> {
+  const port = getDaemonPort(directory);
+  if (!port) return null;
+
+  const first = await fetchWithTimeout(`http://localhost:${port}${path}`, init);
+  if (first) return first;
+
+  // Retry once with a refreshed port — the daemon may have restarted.
+  const freshPort = refreshDaemonPort(directory);
+  if (!freshPort || freshPort === port) return null;
+  return fetchWithTimeout(`http://localhost:${freshPort}${path}`, init);
 }
 
 /** POST JSON to a daemon endpoint. Returns the parsed response body or null. */
@@ -84,9 +121,7 @@ async function postJson(
   path: string,
   body: Record<string, unknown>,
 ): Promise<unknown> {
-  const url = daemonUrl(directory, path);
-  if (!url) return null;
-  const res = await fetchWithTimeout(url, {
+  const res = await fetchFromDaemon(directory, path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -163,25 +198,29 @@ async function mycoPostStop(
   });
 }
 
-/** Fetch the project digest at the preferred tier. Returns the text or null. */
-async function fetchMycoDigest(directory: string): Promise<string | null> {
-  const url = daemonUrl(directory, "/api/digest");
-  if (!url) return null;
-  const res = await fetchWithTimeout(url);
+/**
+ * Fetch the session-start context for a new opencode session. Hits the daemon's
+ * config-aware `POST /context` endpoint, which selects the digest tier the user
+ * has configured (`config.context.digest_tier`, default 5000) and returns the
+ * full session context (digest + branch + session ID lines).
+ *
+ * This is the same endpoint Claude Code's session-start hook uses, so opencode
+ * sessions receive the same context the user has configured for every other agent.
+ */
+async function fetchMycoSessionContext(
+  directory: string,
+  sessionId: string,
+): Promise<string | null> {
+  const res = await fetchFromDaemon(directory, "/context", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ session_id: sessionId }),
+  });
   if (!res) return null;
-
   try {
-    const data = (await res.json()) as { tiers?: Array<{ tier: number; content: string }> };
-    if (!data.tiers?.length) return null;
-
-    const exact = data.tiers.find((t) => t.tier === MYCO_CONTEXT_TIER);
-    if (exact?.content) return exact.content;
-
-    // Fall back to nearest available tier
-    const sorted = [...data.tiers].sort(
-      (a, b) => Math.abs(a.tier - MYCO_CONTEXT_TIER) - Math.abs(b.tier - MYCO_CONTEXT_TIER),
-    );
-    return sorted[0]?.content ?? null;
+    const data = (await res.json()) as { text?: string };
+    const text = data.text?.trim() ?? "";
+    return text.length > 0 ? text : null;
   } catch {
     return null;
   }
@@ -279,20 +318,21 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         const sessionId: string | undefined = info.id;
         if (!sessionId) return;
 
-        // 1) Capture: register the session with the Myco daemon.
-        await mycoRegisterSession(directory, sessionId, info.parentID || undefined);
-
-        // 2) Inject: push the project digest into the new session as a synthetic turn
-        //    before the user types anything. Skip on resume — the parent session
-        //    already has whatever context was relevant.
+        // Run the capture (register session with Myco daemon) and context fetch
+        // concurrently — they don't depend on each other, and parallelizing saves
+        // one round-trip of latency before the user's first turn lands. Context
+        // is fetched only for fresh sessions; resume sessions inherit the parent's
+        // history and don't need another injection.
         //
         // Re-entrancy: the synthetic text part carries `synthetic: true`; if opencode
         // fires chat.message for it, our handler's synthetic-flag check skips it.
-        if (!info.parentID) {
-          const digest = await fetchMycoDigest(directory);
-          if (digest) {
-            await injectSyntheticContext(client, sessionId, DIGEST_HEADING + digest);
-          }
+        const [, sessionContext] = await Promise.all([
+          mycoRegisterSession(directory, sessionId, info.parentID || undefined),
+          info.parentID ? Promise.resolve(null) : fetchMycoSessionContext(directory, sessionId),
+        ]);
+
+        if (sessionContext) {
+          await injectSyntheticContext(client, sessionId, sessionContext);
         }
         return;
       }
@@ -308,6 +348,11 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         if (!sessionId) return;
 
         // Fetch the last assistant message for a response summary.
+        // Narrow local types for walking the messages response — avoids scattered
+        // `any` casts inside the loop while keeping the SDK boundary cast isolated.
+        type MessagePart = { type?: string; text?: string };
+        type SessionMessage = { info?: { role?: string }; parts?: MessagePart[] };
+
         let responseSummary = "";
         try {
           const result = await client.session.messages({
@@ -315,15 +360,13 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
             query: { directory },
           });
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const messages = ((result as any)?.data ?? []) as any[];
+          const messages = ((result as any)?.data ?? []) as SessionMessage[];
           for (let i = messages.length - 1; i >= 0; i--) {
             const msg = messages[i];
             if (msg?.info?.role === "assistant") {
               const textParts = (msg.parts ?? [])
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                .filter((p: any) => p.type === "text" && p.text)
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                .map((p: any) => p.text);
+                .filter((p) => p.type === "text" && p.text)
+                .map((p) => p.text as string);
               responseSummary = textParts.join("\n");
               break;
             }
@@ -407,18 +450,22 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
 
     /**
      * Compaction hook: fires BEFORE opencode generates a continuation summary
-     * during session compaction. Pushing the digest into output.context ensures
-     * Myco's project knowledge survives compaction rather than being dropped.
+     * during session compaction. Pushing the session context into output.context
+     * ensures Myco's project knowledge survives compaction rather than being
+     * dropped. The fetched context respects the user's configured digest tier.
      *
      * See https://opencode.ai/docs/plugins/#compaction-hooks
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    "experimental.session.compacting": async (_input: any, output: any) => {
-      const digest = await fetchMycoDigest(directory);
-      if (!digest) return;
+    "experimental.session.compacting": async (input: any, output: any) => {
+      const sessionId = input?.sessionID;
+      if (!sessionId) return;
+
+      const sessionContext = await fetchMycoSessionContext(directory, sessionId);
+      if (!sessionContext) return;
 
       if (Array.isArray(output?.context)) {
-        output.context.push(COMPACTION_HEADING + digest);
+        output.context.push(COMPACTION_HEADING + sessionContext);
       }
     },
   };

--- a/.opencode/plugins/myco.ts
+++ b/.opencode/plugins/myco.ts
@@ -56,6 +56,18 @@ const COMPACTION_HEADING = "## Myco — Project Context (preserved across compac
  */
 let cachedDaemonPort: number | null | undefined = undefined;
 
+/**
+ * Active opencode sessions tracked by this plugin instance. Populated on
+ * `session.created` and drained on `session.deleted` / `server.instance.disposed`.
+ *
+ * Opencode has no `session.end` event — when the TUI exits normally (Ctrl+C,
+ * close terminal), the session stays "active" from the daemon's perspective
+ * until the session-maintenance job sweeps it (1-hour threshold). To close
+ * sessions cleanly on TUI exit, we track them locally and call unregister
+ * for each one when `server.instance.disposed` fires.
+ */
+const activeOpencodeSessions = new Set<string>();
+
 /** Read the Myco daemon port from .myco/daemon.json in the project directory. */
 function readDaemonPortFromDisk(directory: string): number | null {
   try {
@@ -318,6 +330,8 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         const sessionId: string | undefined = info.id;
         if (!sessionId) return;
 
+        activeOpencodeSessions.add(sessionId);
+
         // Run the capture (register session with Myco daemon) and context fetch
         // concurrently — they don't depend on each other, and parallelizing saves
         // one round-trip of latency before the user's first turn lands. Context
@@ -339,7 +353,26 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
 
       if (event.type === "session.deleted") {
         const info = event.properties?.info ?? {};
-        if (info.id) await mycoUnregisterSession(directory, info.id);
+        if (info.id) {
+          activeOpencodeSessions.delete(info.id);
+          await mycoUnregisterSession(directory, info.id);
+        }
+        return;
+      }
+
+      if (event.type === "server.instance.disposed") {
+        // Opencode TUI is shutting down. Flush all tracked sessions so the
+        // daemon can mark them completed immediately rather than waiting for
+        // the stale-session maintenance sweep (1-hour threshold).
+        //
+        // Fire-and-forget-parallel: the Bun process is about to exit, so we
+        // can't rely on awaited fetches completing. Promise.all gives the
+        // unregister calls their best shot at landing before teardown; any
+        // that don't make it fall back to the session-maintenance job.
+        if (activeOpencodeSessions.size === 0) return;
+        const toClose = Array.from(activeOpencodeSessions);
+        activeOpencodeSessions.clear();
+        await Promise.all(toClose.map((id) => mycoUnregisterSession(directory, id)));
         return;
       }
 

--- a/.opencode/plugins/myco.ts
+++ b/.opencode/plugins/myco.ts
@@ -165,17 +165,26 @@ async function mycoUnregisterSession(directory: string, sessionId: string): Prom
   await postJson(directory, "/sessions/unregister", { session_id: sessionId });
 }
 
-/** Post a user prompt event. */
+/** Post a user prompt event. Images, if any, are shipped as an array of
+ * `{ data: base64, mediaType }` objects — the daemon's event dispatcher persists
+ * them as attachments keyed to the newly-opened prompt batch.
+ *
+ * Opencode has no on-disk transcript for Myco to mine, so images attached by
+ * the user in the TUI must travel with the prompt event itself. Other symbionts
+ * (claude-code, cursor) extract images from their JSONL transcripts at stop time.
+ */
 async function mycoPostUserPrompt(
   directory: string,
   sessionId: string,
   prompt: string,
+  images: Array<{ data: string; mediaType: string }>,
 ): Promise<void> {
   await postJson(directory, "/events", {
     type: "user_prompt",
     session_id: sessionId,
     agent: "opencode",
     prompt,
+    ...(images.length > 0 ? { images } : {}),
   });
 }
 
@@ -452,9 +461,15 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
       const sessionId = input?.sessionID;
       if (!sessionId) return;
 
+      // Part shapes we care about: text (for the prompt string) and file
+      // (for image attachments encoded as data URLs — FilePart.url is
+      // `data:<mime>;base64,<data>` per
+      // packages/app/src/components/prompt-input/attachments.ts in opencode).
       const allParts = (output?.parts ?? []) as Array<{
         type?: string;
         text?: string;
+        mime?: string;
+        url?: string;
         synthetic?: boolean;
       }>;
       // Skip our own injected synthetic turns — they're not real user prompts.
@@ -466,7 +481,26 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
       const prompt = textParts.join("\n");
       if (!prompt) return;
 
-      await mycoPostUserPrompt(directory, sessionId, prompt);
+      // Extract any image attachments from FilePart data URLs. Non-image file
+      // parts (code snippets, documents) are ignored here — only images travel
+      // to Myco as binary attachments via the existing attachment pipeline.
+      const images: Array<{ data: string; mediaType: string }> = [];
+      for (const part of allParts) {
+        if (
+          part.type !== "file" ||
+          !part.mime?.startsWith("image/") ||
+          typeof part.url !== "string" ||
+          !part.url.startsWith("data:")
+        ) {
+          continue;
+        }
+        const commaIdx = part.url.indexOf(",");
+        if (commaIdx <= 0) continue;
+        const base64 = part.url.slice(commaIdx + 1);
+        if (base64) images.push({ data: base64, mediaType: part.mime });
+      }
+
+      await mycoPostUserPrompt(directory, sessionId, prompt, images);
     },
 
     /**

--- a/.opencode/plugins/myco.ts
+++ b/.opencode/plugins/myco.ts
@@ -12,13 +12,16 @@
 //
 // See https://opencode.ai/docs/plugins/
 //
-// Contributor safety: this plugin has NO external runtime imports — only node:fs
-// and node:path (Node builtins). An OSS contributor who clones the repo without
-// having Myco installed will still have opencode load this plugin successfully.
-// Every path that would contact Myco gracefully no-ops when `.myco/daemon.json`
-// is absent or the daemon is unreachable, so the plugin becomes invisible rather
-// than throwing. Do NOT add runtime imports from @opencode-ai/plugin or any other
-// package — that would break the no-op guarantee.
+// Degraded-mode safety: this plugin ships committed inside any project that has
+// run `myco init` — the file lives at .opencode/plugins/myco.ts in that project's
+// repo. When a teammate clones such a project WITHOUT having Myco installed
+// locally, opencode will still load this plugin (the file is right there in the
+// cloned repo). To stay invisible in that case, the plugin has NO external
+// runtime imports — only node:fs and node:path, which are always available in
+// Bun's runtime. Every path that would contact the Myco daemon gracefully no-ops
+// when `.myco/daemon.json` is absent or the daemon is unreachable, so the plugin
+// becomes invisible rather than throwing. Do NOT add runtime imports from
+// @opencode-ai/plugin or any other package — that would break this guarantee.
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -243,8 +246,9 @@ function summarizeToolOutput(output: unknown): string {
 /**
  * Opencode plugin entry. The function signature matches opencode's Plugin type
  * via duck typing — we deliberately do NOT import the Plugin type from
- * @opencode-ai/plugin so the plugin file has zero external runtime dependencies
- * and contributors without Myco installed experience a silent no-op.
+ * @opencode-ai/plugin so this file has zero external runtime dependencies.
+ * That guarantee lets teammates who clone a project that uses Myco still run
+ * opencode cleanly even when they don't have Myco installed locally.
  *
  * @param {{ client: any, directory: string, worktree: string }} ctx
  */

--- a/.opencode/plugins/myco.ts
+++ b/.opencode/plugins/myco.ts
@@ -23,7 +23,7 @@
 // becomes invisible rather than throwing. Do NOT add runtime imports from
 // @opencode-ai/plugin or any other package — that would break this guarantee.
 
-import { readFileSync } from "node:fs";
+import { readFileSync, appendFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 // ---------------------------------------------------------------------------
@@ -142,22 +142,82 @@ async function fetchFromDaemon(
   return fetchWithTimeout(`http://localhost:${freshPort}${path}`, init);
 }
 
-/** POST JSON to a daemon endpoint. Returns the parsed response body or null. */
+/**
+ * POST JSON to a daemon endpoint.
+ * Returns `{ ok, data }` — `ok` is true when the HTTP call succeeded, `data`
+ * is the parsed response body (may be absent if the body was empty or not JSON).
+ */
 async function postJson(
   directory: string,
   path: string,
   body: Record<string, unknown>,
-): Promise<unknown> {
+): Promise<{ ok: boolean; data?: unknown }> {
   const res = await fetchFromDaemon(directory, path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  if (!res) return null;
+  if (!res) return { ok: false };
   try {
-    return await res.json();
+    return { ok: true, data: await res.json() };
   } catch {
-    return null;
+    return { ok: true };
+  }
+}
+
+/**
+ * Append an event to the local buffer at .myco/buffer/<session-id>.jsonl.
+ *
+ * Used as a fallback when the daemon HTTP POST fails (daemon down, network
+ * error, timeout). The daemon replays buffered events via reconcileBufferBatches
+ * at startup, so events captured here are NOT lost — they land in the vault
+ * the next time the daemon comes back up. Mirrors the fallback pattern in
+ * src/hooks/send-event.ts + src/capture/buffer.ts that every other symbiont
+ * uses (claude-code, cursor, codex, etc.) via the hook CLI path.
+ *
+ * Without this fallback, opencode would have a significant parity gap — all
+ * other symbionts preserve events across daemon downtime, but opencode events
+ * would be silently dropped the moment the daemon was unreachable.
+ *
+ * The entry shape matches EventBuffer.append(): event payload with session_id
+ * stripped (it's in the filename) and an auto-injected ISO timestamp.
+ */
+function bufferEvent(
+  directory: string,
+  sessionId: string,
+  event: Record<string, unknown>,
+): void {
+  try {
+    const bufferDir = join(directory, ".myco", "buffer");
+    mkdirSync(bufferDir, { recursive: true });
+    const filePath = join(bufferDir, `${sessionId}.jsonl`);
+    // Strip session_id from the entry — it's encoded in the filename
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { session_id: _sid, ...payload } = event;
+    const line = JSON.stringify({
+      ...payload,
+      timestamp: payload.timestamp ?? new Date().toISOString(),
+    });
+    appendFileSync(filePath, line + "\n");
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error("[myco] Failed to buffer event:", err);
+  }
+}
+
+/**
+ * POST a capture event to the daemon with buffer fallback on failure.
+ * Used for user_prompt and tool_use events — both are replayed from the
+ * buffer by reconcileBufferBatches when the daemon restarts.
+ */
+async function postEventWithBuffer(
+  directory: string,
+  sessionId: string,
+  event: Record<string, unknown>,
+): Promise<void> {
+  const result = await postJson(directory, "/events", event);
+  if (!result.ok) {
+    bufferEvent(directory, sessionId, event);
   }
 }
 
@@ -187,6 +247,10 @@ async function mycoUnregisterSession(directory: string, sessionId: string): Prom
  * Opencode has no on-disk transcript for Myco to mine, so images attached by
  * the user in the TUI must travel with the prompt event itself. Other symbionts
  * (claude-code, cursor) extract images from their JSONL transcripts at stop time.
+ *
+ * Falls back to the local buffer if the daemon is unreachable so events are
+ * replayed on daemon restart (same resilience the other symbionts get via
+ * src/hooks/send-event.ts).
  */
 async function mycoPostUserPrompt(
   directory: string,
@@ -194,7 +258,7 @@ async function mycoPostUserPrompt(
   prompt: string,
   images: Array<{ data: string; mediaType: string }>,
 ): Promise<void> {
-  await postJson(directory, "/events", {
+  await postEventWithBuffer(directory, sessionId, {
     type: "user_prompt",
     session_id: sessionId,
     agent: "opencode",
@@ -203,7 +267,7 @@ async function mycoPostUserPrompt(
   });
 }
 
-/** Post a tool use event. */
+/** Post a tool use event. Falls back to the local buffer on failure. */
 async function mycoPostToolUse(
   directory: string,
   sessionId: string,
@@ -211,7 +275,7 @@ async function mycoPostToolUse(
   toolInput: unknown,
   toolOutput: string,
 ): Promise<void> {
-  await postJson(directory, "/events", {
+  await postEventWithBuffer(directory, sessionId, {
     type: "tool_use",
     session_id: sessionId,
     agent: "opencode",
@@ -247,19 +311,11 @@ async function fetchMycoSessionContext(
   directory: string,
   sessionId: string,
 ): Promise<string | null> {
-  const res = await fetchFromDaemon(directory, "/context", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ session_id: sessionId }),
-  });
-  if (!res) return null;
-  try {
-    const data = (await res.json()) as { text?: string };
-    const text = data.text?.trim() ?? "";
-    return text.length > 0 ? text : null;
-  } catch {
-    return null;
-  }
+  const result = await postJson(directory, "/context", { session_id: sessionId });
+  if (!result.ok) return null;
+  const data = result.data as { text?: string } | undefined;
+  const text = data?.text?.trim() ?? "";
+  return text.length > 0 ? text : null;
 }
 
 // ---------------------------------------------------------------------------

--- a/.opencode/plugins/myco.ts
+++ b/.opencode/plugins/myco.ts
@@ -1,0 +1,400 @@
+// Managed by Myco. Regenerated on `myco update`. Edit src/symbionts/templates/opencode/plugin.ts in the Myco repo instead.
+// myco:plugin-marker:opencode
+//
+// Myco Codebase Intelligence Plugin for OpenCode.
+//
+// This plugin runs inside opencode's Bun runtime and communicates with the local
+// Myco daemon over HTTP — no subprocess spawns, no hook CLI, no stdin piping.
+//
+//   Capture: POST /sessions/register, /sessions/unregister, /events, /events/stop
+//   Context: GET  /api/digest, POST /context/prompt
+//   Inject:  client.session.prompt({ noReply: true, parts: [{ synthetic: true }] })
+//
+// See https://opencode.ai/docs/plugins/
+
+import type { Plugin } from "@opencode-ai/plugin";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TOOL_OUTPUT_PREVIEW_CHARS = 500;
+
+/** Preferred context tier (matches Myco's default in src/mcp/tools/context.ts). */
+const MYCO_CONTEXT_TIER = 5000;
+
+/** Timeout for daemon HTTP calls — must be short so we never block opencode. */
+const MYCO_FETCH_TIMEOUT_MS = 3000;
+
+/** Heading prefixes for injected context so the model can recognize the source. */
+const DIGEST_HEADING = "## Myco — Project Context\n\n";
+const COMPACTION_HEADING = "## Myco — Project Context (preserved across compaction)\n\n";
+
+// ---------------------------------------------------------------------------
+// Daemon HTTP transport — all communication with the local Myco daemon.
+// Every function is best-effort: failures are logged to stderr and swallowed.
+// ---------------------------------------------------------------------------
+
+/** Read the Myco daemon port from .myco/daemon.json in the project directory. */
+function readDaemonPort(directory: string): number | null {
+  try {
+    const raw = readFileSync(join(directory, ".myco", "daemon.json"), "utf-8");
+    const info = JSON.parse(raw) as { port?: number };
+    return typeof info.port === "number" ? info.port : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Fetch with a short timeout. Returns the Response on success, null on failure. */
+async function fetchWithTimeout(url: string, init?: RequestInit): Promise<Response | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), MYCO_FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal });
+    return res.ok ? res : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Build a daemon URL using the port read from .myco/daemon.json. Returns null if unreachable. */
+function daemonUrl(directory: string, path: string): string | null {
+  const port = readDaemonPort(directory);
+  return port ? `http://localhost:${port}${path}` : null;
+}
+
+/** POST JSON to a daemon endpoint. Returns the parsed response body or null. */
+async function postJson(
+  directory: string,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<unknown> {
+  const url = daemonUrl(directory, path);
+  if (!url) return null;
+  const res = await fetchWithTimeout(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res) return null;
+  try {
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+/** Register an opencode session with the daemon. */
+async function mycoRegisterSession(
+  directory: string,
+  sessionId: string,
+  parentSessionId: string | undefined,
+): Promise<void> {
+  await postJson(directory, "/sessions/register", {
+    session_id: sessionId,
+    agent: "opencode",
+    parent_session_id: parentSessionId,
+    started_at: new Date().toISOString(),
+  });
+}
+
+/** Unregister an opencode session. */
+async function mycoUnregisterSession(directory: string, sessionId: string): Promise<void> {
+  await postJson(directory, "/sessions/unregister", { session_id: sessionId });
+}
+
+/** Post a user prompt event. */
+async function mycoPostUserPrompt(
+  directory: string,
+  sessionId: string,
+  prompt: string,
+): Promise<void> {
+  await postJson(directory, "/events", {
+    type: "user_prompt",
+    session_id: sessionId,
+    agent: "opencode",
+    prompt,
+  });
+}
+
+/** Post a tool use event. */
+async function mycoPostToolUse(
+  directory: string,
+  sessionId: string,
+  toolName: string,
+  toolInput: unknown,
+  toolOutput: string,
+): Promise<void> {
+  await postJson(directory, "/events", {
+    type: "tool_use",
+    session_id: sessionId,
+    agent: "opencode",
+    tool_name: toolName,
+    tool_input: toolInput,
+    output_preview: toolOutput,
+  });
+}
+
+/** Post a stop event with the last assistant message as the response summary. */
+async function mycoPostStop(
+  directory: string,
+  sessionId: string,
+  lastAssistantMessage: string | undefined,
+): Promise<void> {
+  await postJson(directory, "/events/stop", {
+    session_id: sessionId,
+    agent: "opencode",
+    last_assistant_message: lastAssistantMessage,
+  });
+}
+
+/** Fetch the project digest at the preferred tier. Returns the text or null. */
+async function fetchMycoDigest(directory: string): Promise<string | null> {
+  const url = daemonUrl(directory, "/api/digest");
+  if (!url) return null;
+  const res = await fetchWithTimeout(url);
+  if (!res) return null;
+
+  try {
+    const data = (await res.json()) as { tiers?: Array<{ tier: number; content: string }> };
+    if (!data.tiers?.length) return null;
+
+    const exact = data.tiers.find((t) => t.tier === MYCO_CONTEXT_TIER);
+    if (exact?.content) return exact.content;
+
+    // Fall back to nearest available tier
+    const sorted = [...data.tiers].sort(
+      (a, b) => Math.abs(a.tier - MYCO_CONTEXT_TIER) - Math.abs(b.tier - MYCO_CONTEXT_TIER),
+    );
+    return sorted[0]?.content ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Opencode session injection — push synthetic context into session history.
+// ---------------------------------------------------------------------------
+
+/**
+ * Inject text into an opencode session as a synthetic (plugin-authored) user turn
+ * without triggering an AI response. Used for session-start and per-prompt context
+ * injection. Errors are swallowed — injection is best-effort.
+ */
+async function injectSyntheticContext(
+  client: unknown,
+  sessionId: string,
+  text: string,
+): Promise<void> {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const c = client as any;
+    await c.session.prompt({
+      path: { id: sessionId },
+      body: {
+        parts: [{ type: "text", text, synthetic: true }],
+        noReply: true,
+      },
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error("[myco] Failed to inject synthetic context:", error);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+/** Flatten todo items into a newline-separated summary. */
+function formatTodos(
+  todos: Array<{ id?: string; content?: string; status?: string }>,
+): string {
+  if (!todos || todos.length === 0) return "";
+  return todos
+    .map((t) => `[${t.status || "pending"}] ${t.content || ""}`)
+    .join("\n");
+}
+
+/** Truncate tool output for storage. */
+function summarizeToolOutput(output: unknown): string {
+  if (typeof output !== "string") return "";
+  return output.length > TOOL_OUTPUT_PREVIEW_CHARS
+    ? output.slice(0, TOOL_OUTPUT_PREVIEW_CHARS) + "..."
+    : output;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin entry
+// ---------------------------------------------------------------------------
+
+export const MycoPlugin: Plugin = async ({ client, directory, worktree }) => {
+  await client.app.log({
+    service: "myco",
+    level: "info",
+    message: "Myco plugin initialized",
+    extra: { directory, worktree },
+  });
+
+  return {
+    /**
+     * Generic event handler: session lifecycle, todos.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    event: async ({ event }: { event: any }) => {
+      if (event.type === "session.created") {
+        const info = event.properties?.info ?? {};
+        const sessionId: string | undefined = info.id;
+        if (!sessionId) return;
+
+        // 1) Capture: register the session with the Myco daemon.
+        await mycoRegisterSession(directory, sessionId, info.parentID || undefined);
+
+        // 2) Inject: push the project digest into the new session as a synthetic turn
+        //    before the user types anything. Skip on resume — the parent session
+        //    already has whatever context was relevant.
+        //
+        // Re-entrancy: the synthetic text part carries `synthetic: true`; if opencode
+        // fires chat.message for it, our handler's synthetic-flag check skips it.
+        if (!info.parentID) {
+          const digest = await fetchMycoDigest(directory);
+          if (digest) {
+            await injectSyntheticContext(client, sessionId, DIGEST_HEADING + digest);
+          }
+        }
+        return;
+      }
+
+      if (event.type === "session.deleted") {
+        const info = event.properties?.info ?? {};
+        if (info.id) await mycoUnregisterSession(directory, info.id);
+        return;
+      }
+
+      if (event.type === "session.idle") {
+        const sessionId = event.properties?.sessionID;
+        if (!sessionId) return;
+
+        // Fetch the last assistant message for a response summary.
+        let responseSummary = "";
+        try {
+          const result = await client.session.messages({
+            path: { id: sessionId },
+            query: { directory },
+          });
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const messages = ((result as any)?.data ?? []) as any[];
+          for (let i = messages.length - 1; i >= 0; i--) {
+            const msg = messages[i];
+            if (msg?.info?.role === "assistant") {
+              const textParts = (msg.parts ?? [])
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                .filter((p: any) => p.type === "text" && p.text)
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                .map((p: any) => p.text);
+              responseSummary = textParts.join("\n");
+              break;
+            }
+          }
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error("[myco] Failed to fetch messages for summary:", err);
+        }
+
+        await mycoPostStop(directory, sessionId, responseSummary || undefined);
+        return;
+      }
+
+      if (event.type === "todo.updated") {
+        const sessionId = event.properties?.sessionID;
+        if (!sessionId) return;
+        const todos = event.properties?.todos ?? [];
+        await mycoPostToolUse(
+          directory,
+          sessionId,
+          "TodoUpdate",
+          { todos, count: todos.length },
+          formatTodos(todos),
+        );
+      }
+    },
+
+    /**
+     * Chat message: capture the user prompt.
+     *
+     * Per-turn spore injection is intentionally not done here. A previous iteration
+     * injected spores via session.prompt({ noReply: true }) inside this handler, but
+     * opencode re-fires chat.message for the synthetic turn and the first real user
+     * message landed during the re-entrancy window. Agents can fetch context on
+     * demand via the myco_context and myco_search MCP tools.
+     *
+     * The `synthetic` flag check is kept as a cheap guard against re-entry from
+     * the session-start digest injection.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    "chat.message": async (input: any, output: any) => {
+      const sessionId = input?.sessionID;
+      if (!sessionId) return;
+
+      const allParts = (output?.parts ?? []) as Array<{
+        type?: string;
+        text?: string;
+        synthetic?: boolean;
+      }>;
+      // Skip our own injected synthetic turns — they're not real user prompts.
+      if (allParts.some((p) => p.synthetic === true)) return;
+
+      const textParts = allParts
+        .filter((p) => p.type === "text" && p.text)
+        .map((p) => p.text as string);
+      const prompt = textParts.join("\n");
+      if (!prompt) return;
+
+      await mycoPostUserPrompt(directory, sessionId, prompt);
+    },
+
+    /**
+     * Post-tool execution: ship tool usage to Myco.
+     *
+     * We forward `input.args` as `tool_input` — NOT `output.metadata` — because
+     * `args` carries the tool invocation arguments (including `filePath` for
+     * write/edit/patch tools), which Myco's plan-capture matcher needs to detect
+     * writes to .opencode/plans/*.md.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    "tool.execute.after": async (input: any, output: any) => {
+      const sessionId = input?.sessionID;
+      if (!sessionId) return;
+
+      const toolName = input?.tool ?? "unknown";
+      const toolInput = input?.args ?? output?.metadata ?? {};
+      const toolOutput = summarizeToolOutput(output?.output);
+
+      await mycoPostToolUse(directory, sessionId, toolName, toolInput, toolOutput);
+    },
+
+    /**
+     * Compaction hook: fires BEFORE opencode generates a continuation summary
+     * during session compaction. Pushing the digest into output.context ensures
+     * Myco's project knowledge survives compaction rather than being dropped.
+     *
+     * See https://opencode.ai/docs/plugins/#compaction-hooks
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    "experimental.session.compacting": async (_input: any, output: any) => {
+      const digest = await fetchMycoDigest(directory);
+      if (!digest) return;
+
+      if (Array.isArray(output?.context)) {
+        output.context.push(COMPACTION_HEADING + digest);
+      }
+    },
+  };
+};
+
+export default MycoPlugin;

--- a/.opencode/plugins/myco.ts
+++ b/.opencode/plugins/myco.ts
@@ -388,9 +388,17 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
 
         let responseSummary = "";
         try {
+          // `limit` is a tail-limit in opencode's server (returns the last N
+          // messages in chronological order — verified empirically against
+          // opencode v1.4.1 via `opencode serve`). A small bound is safe
+          // because session.idle fires at end-of-turn, so the last assistant
+          // message is always within the tail window. Using 5 (not 1) gives
+          // headroom for multi-message turns where the model produces
+          // reasoning → tool_use → final text across several assistant
+          // messages; we still find the last text part via the backward scan.
           const result = await client.session.messages({
             path: { id: sessionId },
-            query: { directory },
+            query: { directory, limit: 5 },
           });
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const messages = ((result as any)?.data ?? []) as SessionMessage[];

--- a/.opencode/plugins/myco.ts
+++ b/.opencode/plugins/myco.ts
@@ -7,12 +7,19 @@
 // Myco daemon over HTTP — no subprocess spawns, no hook CLI, no stdin piping.
 //
 //   Capture: POST /sessions/register, /sessions/unregister, /events, /events/stop
-//   Context: GET  /api/digest, POST /context/prompt
+//   Context: GET  /api/digest
 //   Inject:  client.session.prompt({ noReply: true, parts: [{ synthetic: true }] })
 //
 // See https://opencode.ai/docs/plugins/
+//
+// Contributor safety: this plugin has NO external runtime imports — only node:fs
+// and node:path (Node builtins). An OSS contributor who clones the repo without
+// having Myco installed will still have opencode load this plugin successfully.
+// Every path that would contact Myco gracefully no-ops when `.myco/daemon.json`
+// is absent or the daemon is unreachable, so the plugin becomes invisible rather
+// than throwing. Do NOT add runtime imports from @opencode-ai/plugin or any other
+// package — that would break the no-op guarantee.
 
-import type { Plugin } from "@opencode-ai/plugin";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -233,13 +240,29 @@ function summarizeToolOutput(output: unknown): string {
 // Plugin entry
 // ---------------------------------------------------------------------------
 
-export const MycoPlugin: Plugin = async ({ client, directory, worktree }) => {
-  await client.app.log({
-    service: "myco",
-    level: "info",
-    message: "Myco plugin initialized",
-    extra: { directory, worktree },
-  });
+/**
+ * Opencode plugin entry. The function signature matches opencode's Plugin type
+ * via duck typing — we deliberately do NOT import the Plugin type from
+ * @opencode-ai/plugin so the plugin file has zero external runtime dependencies
+ * and contributors without Myco installed experience a silent no-op.
+ *
+ * @param {{ client: any, directory: string, worktree: string }} ctx
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const MycoPlugin = async ({ client, directory, worktree }: { client: any; directory: string; worktree: string }) => {
+  // Best-effort init log. Wrapped in try-catch so a future SDK shape change in
+  // opencode (e.g. client.app.log moving) cannot prevent the plugin from
+  // registering its handlers.
+  try {
+    await client.app.log({
+      service: "myco",
+      level: "info",
+      message: "Myco plugin initialized",
+      extra: { directory, worktree },
+    });
+  } catch {
+    // Swallow — init log is diagnostic only.
+  }
 
   return {
     /**

--- a/.opencode/plugins/myco.ts
+++ b/.opencode/plugins/myco.ts
@@ -500,14 +500,22 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         text?: string;
         mime?: string;
         url?: string;
+        synthetic?: boolean;
         metadata?: { [key: string]: unknown };
       }>;
       // Skip if any part carries the Myco metadata marker — that means
       // chat.message is firing for our own injectSyntheticContext call.
       if (allParts.some((p) => p.metadata?.[MYCO_METADATA_MARKER] === true)) return;
 
+      // Prompt text = user's real text only. opencode emits `synthetic: true`
+      // text parts for internal scaffolding when the message contains file
+      // mentions, plan-mode switches, subagent tasks, and similar — see
+      // packages/opencode/src/session/prompt.ts. Those parts include full
+      // file contents, tool-call scaffolding, plan instructions, etc. Joining
+      // them into prompt_text would bloat every captured user prompt with
+      // system-level content that the user never typed.
       const textParts = allParts
-        .filter((p) => p.type === "text" && p.text)
+        .filter((p) => p.type === "text" && p.text && p.synthetic !== true)
         .map((p) => p.text as string);
       const prompt = textParts.join("\n");
       if (!prompt) return;

--- a/.opencode/plugins/myco.ts
+++ b/.opencode/plugins/myco.ts
@@ -40,6 +40,9 @@ const TOOL_OUTPUT_PREVIEW_CHARS = 200;
 /** Timeout for daemon HTTP calls — must be short so we never block opencode. */
 const MYCO_FETCH_TIMEOUT_MS = 3000;
 
+/** Tail window read from opencode when building the end-of-turn assistant summary. */
+const SESSION_IDLE_TAIL_LIMIT = 12;
+
 /** Heading prefix for compaction context — makes Myco's contribution recognizable in the compacted summary. */
 const COMPACTION_HEADING = "## Myco — Project Context (preserved across compaction)\n\n";
 
@@ -57,6 +60,70 @@ const COMPACTION_HEADING = "## Myco — Project Context (preserved across compac
  * to silently drop in live testing.
  */
 const MYCO_METADATA_MARKER = "myco";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type MessagePart = { type?: string; text?: string };
+type SessionMessage = { info?: { role?: string }; parts?: MessagePart[] };
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function pickString(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+export function normalizeToolInput(toolInput: unknown): unknown {
+  if (!isRecord(toolInput)) return toolInput;
+
+  const filePath = pickString(toolInput, ["file_path", "filePath", "path"]);
+  const workdir = pickString(toolInput, ["workdir", "cwd"]);
+  const command = pickString(toolInput, ["command", "cmd"]);
+
+  return {
+    ...toolInput,
+    ...(filePath ? { file_path: filePath } : {}),
+    ...(workdir ? { workdir } : {}),
+    ...(command ? { command } : {}),
+  };
+}
+
+export function collectAssistantSummaryFromMessages(messages: SessionMessage[]): string {
+  const summaryParts: string[] = [];
+  let foundAssistantBlock = false;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message?.info?.role !== "assistant") {
+      if (foundAssistantBlock) break;
+      continue;
+    }
+
+    foundAssistantBlock = true;
+    const text = (message.parts ?? [])
+      .filter((part) => part.type === "text" && part.text)
+      .map((part) => part.text as string)
+      .join("\n")
+      .trim();
+    if (text) summaryParts.unshift(text);
+  }
+
+  return summaryParts.join("\n").trim();
+}
 
 // ---------------------------------------------------------------------------
 // Daemon HTTP transport — all communication with the local Myco daemon.
@@ -358,10 +425,6 @@ async function injectSyntheticContext(
   }
 }
 
-// ---------------------------------------------------------------------------
-// Small helpers
-// ---------------------------------------------------------------------------
-
 /** Flatten todo items into a newline-separated summary. */
 function formatTodos(
   todos: Array<{ id?: string; content?: string; status?: string }>,
@@ -471,37 +534,20 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         if (!sessionId) return;
 
         // Fetch the last assistant message for a response summary.
-        // Narrow local types for walking the messages response — avoids scattered
-        // `any` casts inside the loop while keeping the SDK boundary cast isolated.
-        type MessagePart = { type?: string; text?: string };
-        type SessionMessage = { info?: { role?: string }; parts?: MessagePart[] };
-
         let responseSummary = "";
         try {
           // `limit` is a tail-limit in opencode's server (returns the last N
           // messages in chronological order — verified empirically against
-          // opencode v1.4.1 via `opencode serve`). A small bound is safe
-          // because session.idle fires at end-of-turn, so the last assistant
-          // message is always within the tail window. Using 5 (not 1) gives
-          // headroom for multi-message turns where the model produces
-          // reasoning → tool_use → final text across several assistant
-          // messages; we still find the last text part via the backward scan.
+          // opencode v1.4.1 via `opencode serve`). The tail window is large
+          // enough to capture a multi-message assistant block at end-of-turn
+          // without reading the full session history on every idle event.
           const result = await client.session.messages({
             path: { id: sessionId },
-            query: { directory, limit: 5 },
+            query: { directory, limit: SESSION_IDLE_TAIL_LIMIT },
           });
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const messages = ((result as any)?.data ?? []) as SessionMessage[];
-          for (let i = messages.length - 1; i >= 0; i--) {
-            const msg = messages[i];
-            if (msg?.info?.role === "assistant") {
-              const textParts = (msg.parts ?? [])
-                .filter((p) => p.type === "text" && p.text)
-                .map((p) => p.text as string);
-              responseSummary = textParts.join("\n");
-              break;
-            }
-          }
+          responseSummary = collectAssistantSummaryFromMessages(messages);
         } catch (err) {
           // eslint-disable-next-line no-console
           console.error("[myco] Failed to fetch messages for summary:", err);
@@ -612,7 +658,7 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
       if (!sessionId) return;
 
       const toolName = input?.tool ?? "unknown";
-      const toolInput = input?.args ?? output?.metadata ?? {};
+      const toolInput = normalizeToolInput(input?.args ?? output?.metadata ?? {});
       const toolOutput = summarizeToolOutput(output?.output);
 
       await mycoPostToolUse(directory, sessionId, toolName, toolInput, toolOutput);

--- a/.opencode/plugins/myco.ts
+++ b/.opencode/plugins/myco.ts
@@ -43,6 +43,21 @@ const MYCO_FETCH_TIMEOUT_MS = 3000;
 /** Heading prefix for compaction context — makes Myco's contribution recognizable in the compacted summary. */
 const COMPACTION_HEADING = "## Myco — Project Context (preserved across compaction)\n\n";
 
+/**
+ * Marker set on the `metadata` field of every synthetic TextPartInput this
+ * plugin injects via `client.session.prompt({ noReply: true, ... })`. The
+ * `chat.message` handler checks for this marker and skips matching messages
+ * so the injection doesn't re-enter as if it were a new user prompt.
+ *
+ * Why not the `synthetic` flag? opencode's own prompt.ts uses `synthetic: true`
+ * for ~20 distinct internal purposes (plan-mode prompts, build-switch
+ * transitions, subagent task summaries, shell-impl wrappers). Filtering on
+ * the synthetic flag rejects legitimate user messages whenever opencode has
+ * appended one of its own synthetic parts — which caused real user prompts
+ * to silently drop in live testing.
+ */
+const MYCO_METADATA_MARKER = "myco";
+
 // ---------------------------------------------------------------------------
 // Daemon HTTP transport — all communication with the local Myco daemon.
 // Every function is best-effort: failures are swallowed so the plugin cannot
@@ -253,8 +268,11 @@ async function fetchMycoSessionContext(
 
 /**
  * Inject text into an opencode session as a synthetic (plugin-authored) user turn
- * without triggering an AI response. Used for session-start and per-prompt context
- * injection. Errors are swallowed — injection is best-effort.
+ * without triggering an AI response. The text part carries:
+ *   - `synthetic: true` so opencode's TUI hides it from the chat log
+ *   - `metadata.myco: true` so our own `chat.message` handler can distinguish
+ *     this re-entry from a real user message (see MYCO_METADATA_MARKER)
+ * Errors are swallowed — injection is best-effort.
  */
 async function injectSyntheticContext(
   client: unknown,
@@ -267,7 +285,14 @@ async function injectSyntheticContext(
     await c.session.prompt({
       path: { id: sessionId },
       body: {
-        parts: [{ type: "text", text, synthetic: true }],
+        parts: [
+          {
+            type: "text",
+            text,
+            synthetic: true,
+            metadata: { [MYCO_METADATA_MARKER]: true },
+          },
+        ],
         noReply: true,
       },
     });
@@ -445,7 +470,7 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
     },
 
     /**
-     * Chat message: capture the user prompt.
+     * Chat message: capture the user prompt + any image attachments.
      *
      * Per-turn spore injection is intentionally not done here. A previous iteration
      * injected spores via session.prompt({ noReply: true }) inside this handler, but
@@ -453,8 +478,13 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
      * message landed during the re-entrancy window. Agents can fetch context on
      * demand via the myco_context and myco_search MCP tools.
      *
-     * The `synthetic` flag check is kept as a cheap guard against re-entry from
-     * the session-start digest injection.
+     * Re-entrancy guard: we check for `metadata.myco === true` on any part to
+     * detect our session-start digest injection coming back around. Opencode
+     * itself sets `synthetic: true` for many internal purposes (plan-mode
+     * prompts, build-switch transitions, subagent task summaries), so the
+     * `synthetic` flag alone is NOT reliable as a re-entrancy signal — it
+     * would silently drop any user prompt that opencode touched for one of
+     * those internal reasons.
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     "chat.message": async (input: any, output: any) => {
@@ -470,10 +500,11 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         text?: string;
         mime?: string;
         url?: string;
-        synthetic?: boolean;
+        metadata?: { [key: string]: unknown };
       }>;
-      // Skip our own injected synthetic turns — they're not real user prompts.
-      if (allParts.some((p) => p.synthetic === true)) return;
+      // Skip if any part carries the Myco metadata marker — that means
+      // chat.message is firing for our own injectSyntheticContext call.
+      if (allParts.some((p) => p.metadata?.[MYCO_METADATA_MARKER] === true)) return;
 
       const textParts = allParts
         .filter((p) => p.type === "text" && p.text)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ Exceptions: array indices (`[0]`), string operations (`.slice(0, 10)` for ISO da
 | **Lineage edge** | Automatic graph connection created by daemon on insert: FROM_SESSION, EXTRACTED_FROM, HAS_BATCH, DERIVED_FROM. No LLM needed. |
 | **Semantic edge** | Intelligence graph connection created by agent: RELATES_TO, SUPERSEDED_BY, REFERENCES, DEPENDS_ON, AFFECTS. LLM-driven. |
 | **Graph edge** | Stored in `graph_edges` table. Supports cross-type references between session, batch, spore, and entity nodes. |
-| **Symbiont** | External coding agent that Myco integrates with (Claude Code, Cursor, Codex, VS Code Copilot, Gemini CLI, Windsurf). Named for the mycorrhizal symbiotic relationship. Declared via YAML manifests in `src/symbionts/manifests/`. |
+| **Symbiont** | External coding agent that Myco integrates with (Claude Code, Cursor, Codex, VS Code Copilot, Gemini CLI, Windsurf, OpenCode). Named for the mycorrhizal symbiotic relationship. Declared via YAML manifests in `src/symbionts/manifests/`. |
 | **Wave** | Group of phases whose dependencies are all satisfied, executing in parallel via `Promise.allSettled()`. The executor computes waves from the phase `dependsOn` DAG using topological sort. |
 | **Phase dependency** | DAG edge between phases declared via `dependsOn` in task YAML. Phases depend on named predecessors; the executor resolves these into execution waves. |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Myco — Collective Agent Intelligence
 
-Captures session knowledge (events, observations, summaries) into a SQLite-backed intelligence graph and serves it back via MCP tools. Supports Claude Code, Cursor, Codex, VS Code Copilot, Gemini CLI, and Windsurf.
+Captures session knowledge (events, observations, summaries) into a SQLite-backed intelligence graph and serves it back via MCP tools. Supports Claude Code, Cursor, Codex, VS Code Copilot, Gemini CLI, Windsurf, and OpenCode.
 
 ## Dogfooding
 
@@ -285,10 +285,13 @@ make build
 
 ### Add a new symbiont
 
-1. Create manifest at `src/symbionts/manifests/<name>.yaml` with registration targets
-2. Create templates at `src/symbionts/templates/<name>/` (hooks.json, mcp.json, settings.json)
-3. Implement transcript adapter in `src/symbionts/<name>.ts`
-4. Register adapter in `src/symbionts/registry.ts`
+1. Create manifest at `src/symbionts/manifests/<name>.yaml` with registration targets. `loadManifests()` auto-discovers any YAML in this directory — no code change needed to register the manifest itself.
+2. Create templates at `src/symbionts/templates/<name>/`:
+   - **JSON hooks (default):** `hooks.json`, `mcp.json`, `settings.json` — merged into the agent's config files.
+   - **Plugin-file hooks (opencode):** `plugin.ts` + `package.json` + `mcp.json` + `settings.json`. Declare `hooksFormat: plugin-file` in the manifest and point `hooksTarget` at the plugin file path (e.g., `.opencode/plugins/myco.ts`). Also set `pluginPackageTarget` to write the plugin's deps manifest.
+   - **Non-standard MCP keys:** if the agent stores MCP servers under a key other than `mcpServers` (opencode uses `mcp`), set `mcpServersKey` in the manifest. Any downstream code that reads MCP state must resolve the key via the manifest, not hardcode `mcpServers`.
+3. **Optional** — implement a transcript adapter in `src/symbionts/<name>.ts` (NOT `src/symbionts/adapters/<name>.ts` — that subdirectory does not exist). Skip this step for agents that don't expose on-disk transcript files; Myco will reconstruct turns from the buffered hook events.
+4. If you implemented an adapter, register it in `src/symbionts/registry.ts` `ALL_ADAPTERS`.
 
 ### Test the vault and embeddings
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Myco
 
-Myco is a collective intelligence plugin for coding projects, supporting Claude Code and Cursor. This guide covers development setup and project conventions. For architecture details, see [Lifecycle docs](docs/lifecycle.md).
+Myco is a collective intelligence plugin for coding projects, supporting Claude Code, Cursor, Codex, VS Code Copilot, Gemini CLI, Windsurf, and OpenCode. This guide covers development setup and project conventions. For architecture details, see [Lifecycle docs](docs/lifecycle.md).
 
 ## Installing Myco (End Users)
 
@@ -20,7 +20,7 @@ This sets up the vault, configures your LLM backend, and starts capturing sessio
 ### Requirements
 
 - Node.js 22+
-- Claude Code or Cursor
+- One or more supported coding agents (Claude Code, Cursor, Codex, VS Code Copilot, Gemini CLI, Windsurf, or OpenCode)
 - **Embedding provider** (one of): [Ollama](https://ollama.com) with `bge-m3` (local, free), [OpenRouter](https://openrouter.ai), or [OpenAI](https://platform.openai.com)
 - **Intelligence provider** (one of): Cloud (Claude), [Ollama](https://ollama.com), or [LM Studio](https://lmstudio.ai)
 
@@ -95,7 +95,7 @@ myco/
 │   ├── mcp/               # MCP server + tool handlers
 │   ├── prompts/           # LLM prompt templates (extraction, summary, title, classification)
 │   ├── services/          # Shared service logic (used by both CLI and API)
-│   ├── symbionts/         # Symbiont adapters (Claude Code, Cursor, Codex) — transcript discovery, parsing, and project-local registration
+│   ├── symbionts/         # Symbiont adapters and manifests (Claude Code, Cursor, Codex, VS Code, Gemini, Windsurf, OpenCode) — transcript discovery, parsing, and project-local registration
 │   └── vault/             # Reader, writer, Zod schemas for database records
 ├── tests/                 # Mirrors src/ structure
 ├── ui/                    # React + Tailwind dashboard (Vite build → dist/ui/)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.npmjs.com/package/@goondocks/myco"><img src="https://img.shields.io/npm/v/@goondocks/myco?label=npm&color=22c55e" alt="npm"></a>
   <a href="https://github.com/goondocks-co/myco/blob/main/LICENSE"><img src="https://img.shields.io/github/license/goondocks-co/myco?color=22c55e" alt="License"></a>
   <img src="https://img.shields.io/badge/node-%3E%3D22-22c55e" alt="Node 22+">
-  <img src="https://img.shields.io/badge/agents-Claude%20Code%20%7C%20Cursor%20%7C%20Codex%20%7C%20VS%20Code%20%7C%20Gemini%20%7C%20Windsurf-22c55e" alt="Claude Code | Cursor | Codex | VS Code | Gemini | Windsurf">
+  <img src="https://img.shields.io/badge/agents-Claude%20Code%20%7C%20Cursor%20%7C%20Codex%20%7C%20VS%20Code%20%7C%20Gemini%20%7C%20Windsurf%20%7C%20OpenCode-22c55e" alt="Claude Code | Cursor | Codex | VS Code | Gemini | Windsurf | OpenCode">
 </p>
 
 ```bash
@@ -25,7 +25,7 @@ cd your-project
 myco init
 ```
 
-The wizard detects your coding agents, sets up intelligence and embedding providers, and starts capturing. Works with Claude Code, Cursor, Codex, VS Code Copilot, Gemini CLI, and Windsurf.
+The wizard detects your coding agents, sets up intelligence and embedding providers, and starts capturing. Works with Claude Code, Cursor, Codex, VS Code Copilot, Gemini CLI, Windsurf, and OpenCode.
 
 ## What is Myco?
 
@@ -110,8 +110,9 @@ Myco integrates with coding agents through **symbiont** adapters — named for t
 | [VS Code Copilot](https://code.visualstudio.com/docs/copilot) | `.github/hooks/` | `.vscode/mcp.json` | `.agents/skills/` | `autoApprove` | — |
 | [Gemini CLI](https://geminicli.com) | `.gemini/settings.json` | `.gemini/settings.json` | `.agents/skills/` | `coreTools` | `.gemini/plans/` |
 | [Windsurf](https://windsurf.com) | `.windsurf/hooks.json` | — | `.agents/skills/` | `cascadeCommandsAllowList` | `~/.windsurf/plans/` |
+| [OpenCode](https://opencode.ai) | `.opencode/plugins/myco.ts` (plugin) | `opencode.json` (`mcp` key) | `.agents/skills/` | `permission.bash` | `.opencode/plans/` |
 
-Skills are installed once to `.agents/skills/` (the emerging cross-agent standard) and symlinked to each agent's native skills directory. Adding a new agent requires only a YAML manifest and JSON templates — no code changes.
+Skills are installed once to `.agents/skills/` (the emerging cross-agent standard) and symlinked to each agent's native skills directory. Adding a new agent requires only a YAML manifest and templates — no code changes for JSON-hook agents, and a small manifest extension for plugin-based agents like OpenCode.
 
 See the [Symbiont docs](docs/symbionts.md) for detailed setup information per agent.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -614,6 +614,10 @@ myco init</code></div>
         <span class="agent-name">Windsurf</span>
         <span class="agent-status partial">Hooks + skills</span>
       </div>
+      <div class="agent-card">
+        <span class="agent-name">OpenCode</span>
+        <span class="agent-status full">Full support</span>
+      </div>
     </div>
   </section>
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -44,7 +44,7 @@ This guides you through:
 1. **Intelligence provider** — Cloud (Claude), Ollama, or LM Studio for agent tasks
 2. **Embedding provider** — Ollama (local), OpenRouter, OpenAI, or skip
 3. **Model selection** — picks from available models with recommended defaults
-4. **Agent detection** — finds Claude Code, Cursor, and registers the plugin
+4. **Agent detection** — finds any installed agents (Claude Code, Cursor, Codex, VS Code Copilot, Gemini CLI, Windsurf, OpenCode) and registers Myco per project
 
 ### Pull Ollama Models (if using local embeddings)
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -127,7 +127,7 @@ Skills are written to `.agents/skills/<name>/SKILL.md` — the emerging cross-ag
 .cursor/skills/deploy-worker/SKILL.md           (Cursor)
 ```
 
-Agents that use `.agents/skills/` natively (Codex, VS Code Copilot, Gemini CLI, Windsurf) need no symlinks. Run `myco init` or `myco update` to refresh symlinks after new skills are generated.
+Agents that use `.agents/skills/` natively (Codex, VS Code Copilot, Gemini CLI, Windsurf, OpenCode) need no symlinks. Run `myco init` or `myco update` to refresh symlinks after new skills are generated.
 
 ## Dashboard
 

--- a/docs/symbionts.md
+++ b/docs/symbionts.md
@@ -103,6 +103,37 @@ Hooks use a flat format with snake_case event names. MCP is user-level only (not
 | Plans | `~/.windsurf/plans/` (global) |
 | Transcripts | JSONL via `post_cascade_response_with_transcript` hook |
 
+### OpenCode
+
+The first plugin-based symbiont. OpenCode has no JSON hook file — hooks are delivered as a verbatim TypeScript plugin (`.opencode/plugins/myco.ts`) that opencode's Bun runtime loads at startup. The plugin communicates directly with the Myco daemon over HTTP; no subprocess spawns and no hook CLI.
+
+| Component | Location |
+|-----------|----------|
+| Hooks | `.opencode/plugins/myco.ts` (plugin file, 6 event hooks) |
+| Plugin deps | `.opencode/package.json` (declares `@opencode-ai/plugin`) |
+| MCP | `opencode.json` under the non-standard `mcp` key (not `mcpServers`) |
+| Skills | `.agents/skills/` (native) |
+| Auto-approve | `permission.bash` in `opencode.json` |
+| Plans | `.opencode/plans/` |
+| Transcripts | — (fetched via SDK at stop time; no on-disk transcript adapter) |
+
+**Handler coverage:**
+- `event: session.created` → session register + digest injection via `client.session.prompt({ noReply: true, parts: [{ synthetic: true }] })`
+- `event: session.deleted` → session unregister
+- `event: session.idle` → stop event with response summary
+- `chat.message` → user prompt capture
+- `tool.execute.after` → tool use capture (forwards `input.args` so `filePath` reaches plan-capture)
+- `experimental.session.compacting` → pushes digest into `output.context` so project knowledge survives compaction
+
+**Two new manifest fields** were introduced to fit OpenCode cleanly alongside the JSON-hook symbionts without special-casing:
+- `hooksFormat: plugin-file` — selects verbatim template copy instead of JSON merge
+- `pluginPackageTarget: .opencode/package.json` — writes a Bun-installable deps manifest
+- `mcpServersKey: mcp` — opencode's non-standard MCP top-level key
+
+**Plan mode UX note:** OpenCode's Plan mode disables the `write` tool entirely and only allows `edit` on existing files under `.opencode/plans/*.md`. To author a new plan in Plan mode, the plan file must already exist on disk — create it first in Build mode (`touch .opencode/plans/my-plan.md`) before switching to Plan mode.
+
+**Context injection** is session-start only (digest at `session.created`). Per-turn spore injection via `chat.message` is intentionally deferred pending more research on OpenCode's re-entrancy semantics; in the meantime, agents can fetch targeted context on demand via the `myco_context` and `myco_search` MCP tools.
+
 ## Skills Architecture
 
 Skills are installed once to `.agents/skills/` — the canonical cross-agent location — and symlinked to each agent's native skills directory:
@@ -117,15 +148,18 @@ Skills are installed once to `.agents/skills/` — the canonical cross-agent loc
   myco          → ../../.agents/skills/myco          (symlink to canonical)
 ```
 
-Agents that read `.agents/skills/` natively (Codex, VS Code, Gemini, Windsurf) don't need agent-specific symlinks.
+Agents that read `.agents/skills/` natively (Codex, VS Code, Gemini, Windsurf, OpenCode) don't need agent-specific symlinks.
 
 ## Adding a New Agent
 
-1. Create a manifest at `src/symbionts/manifests/<name>.yaml` declaring capabilities
-2. Create templates at `src/symbionts/templates/<name>/` (hooks.json, mcp.json, settings.json)
-3. Optionally implement a transcript adapter in `src/symbionts/<name>.ts`
+1. Create a manifest at `src/symbionts/manifests/<name>.yaml` declaring capabilities — `loadManifests()` auto-discovers it.
+2. Create templates at `src/symbionts/templates/<name>/`:
+   - **JSON-hook agents** (Claude Code, Cursor, Codex, Gemini, VS Code, Windsurf): `hooks.json`, `mcp.json`, `settings.json`.
+   - **Plugin-based agents** (OpenCode): `plugin.ts`, `package.json`, `mcp.json`, `settings.json`. Declare `hooksFormat: plugin-file` and `pluginPackageTarget` in the manifest.
+3. For agents with non-standard MCP config keys (e.g., OpenCode uses `"mcp"` instead of `"mcpServers"`), set `mcpServersKey` in the manifest.
+4. Optionally implement a transcript adapter in `src/symbionts/<name>.ts` — skip for agents that don't expose on-disk transcripts (OpenCode relies on SDK-fetched messages and buffer reconstruction).
 
-The installer is generic — it reads the manifest and templates without agent-specific code paths.
+The installer is generic — it reads the manifest and templates without agent-specific code paths. See the [`add-symbiont` skill](../.agents/skills/add-symbiont/SKILL.md) for a step-by-step walkthrough.
 
 ## Removing Myco
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "myco": {
+      "type": "local",
+      "command": [
+        "myco-run",
+        "mcp"
+      ]
+    }
+  },
+  "permission": {
+    "bash": {
+      "myco-run *": "allow",
+      "node .agents/myco-hook.cjs *": "allow"
+    }
+  }
+}

--- a/opencode.json
+++ b/opencode.json
@@ -12,7 +12,7 @@
   "permission": {
     "bash": {
       "myco-run *": "allow",
-      "node .agents/myco-hook.cjs *": "allow"
+      "myco *": "allow"
     }
   }
 }

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -41,7 +41,7 @@ Myco supports 6 coding agents. Each has its own instruction file format, but **`
 
 | File | Purpose | Who reads it |
 |------|---------|-------------|
-| `AGENTS.md` | **Canonical rules** — all architecture, conventions, golden paths | Codex, VS Code Copilot, Gemini CLI, Windsurf, Cursor |
+| `AGENTS.md` | **Canonical rules** — all architecture, conventions, golden paths | Codex, VS Code Copilot, Gemini CLI, Windsurf, Cursor, OpenCode |
 | `CLAUDE.md` | Thin stub pointing to `AGENTS.md` + Claude-specific overrides | Claude Code |
 | `GEMINI.md` | Thin stub pointing to `AGENTS.md` + Gemini-specific overrides | Gemini CLI |
 | `.github/copilot-instructions.md` | Thin stub pointing to `AGENTS.md` | VS Code Copilot |

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -199,9 +199,12 @@ function isSymbiontRegistered(
       return raw.includes(`[mcp_servers.${MYCO_MCP_SERVER_NAME}]`);
     }
 
-    // JSON: check for server entry
+    // JSON: check for server entry under the configured key (defaults to 'mcpServers').
+    // opencode uses 'mcp' — without the manifest lookup, doctor reports opencode as
+    // unregistered even after a successful install.
     const config = JSON.parse(raw) as Record<string, unknown>;
-    const servers = config.mcpServers as Record<string, unknown> | undefined;
+    const serversKey = d.manifest.registration?.mcpServersKey ?? 'mcpServers';
+    const servers = config[serversKey] as Record<string, unknown> | undefined;
     return !!servers?.[MYCO_MCP_SERVER_NAME];
   } catch { /* config missing or malformed */ }
   return false;

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -110,6 +110,7 @@ export function registerSymbionts(
         result.skills && 'skills',
         result.settings && 'settings',
         result.instructions && 'instructions',
+        result.pluginPackage && 'plugin deps',
       ].filter(Boolean);
 
       if (installed.length > 0) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -336,8 +336,18 @@ export const POWER_SLEEP_INTERVAL_MS = 5 * 60 * MS_PER_SECOND;
 // --- Session maintenance ---
 /** Time without new prompts before an active session is auto-completed (ms). */
 export const STALE_SESSION_THRESHOLD_MS = 60 * 60 * MS_PER_SECOND;
-/** Max prompt count for a session to be considered dead and auto-deleted. */
-export const DEAD_SESSION_MAX_PROMPTS = 1;
+/**
+ * Max prompt count for a session to be considered dead and auto-deleted.
+ *
+ * Set to 0: only sessions that were registered but never received a prompt
+ * are eligible for dead-session cleanup. A session with even ONE real user
+ * prompt has produced captured state worth preserving — the user did work,
+ * the agent likely responded, tool calls may have happened, code may have
+ * changed. Deleting such a session was a real data-loss failure mode seen
+ * during opencode testing where a 1-prompt session that made an actual
+ * committed code change was auto-deleted within a minute of TUI exit.
+ */
+export const DEAD_SESSION_MAX_PROMPTS = 0;
 
 // --- Init wizard ---
 /** Minimum Node.js major version required by Myco. */

--- a/src/daemon/capture-images.ts
+++ b/src/daemon/capture-images.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared image attachment persistence.
+ *
+ * Called from two paths that both produce the same attachment row shape:
+ *
+ * 1. `stop-processing.ts` — for claude-code / cursor, where images come from
+ *    transcript-mined `TranscriptTurn.images`. The transcript miner has
+ *    already decoded base64 blocks and produced a canonical `TranscriptImage`
+ *    per image per turn.
+ *
+ * 2. `event-dispatch.ts` — for opencode, where images come from the plugin
+ *    in the `user_prompt` event payload. The opencode plugin extracts each
+ *    image from a `FilePart.url` data URL and ships it straight to the
+ *    daemon, since opencode has no on-disk transcript to mine.
+ *
+ * Deterministic IDs (`${sessionShort}-b${promptNumber}-${index}`) keep the
+ * insert idempotent under replay: `insertAttachment` uses `ON CONFLICT DO NOTHING`.
+ */
+
+import { insertAttachment } from '@myco/db/queries/attachments.js';
+import { extensionForMimeType } from '@myco/symbionts/adapter.js';
+import { epochSeconds } from '@myco/constants.js';
+import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+import type { DaemonLogger } from './logger.js';
+
+/** Short session-id suffix used in attachment filenames and IDs. */
+const SESSION_SHORT_LEN = 6;
+
+/** Image attachment in canonical base64 form. Matches `TranscriptImage`. */
+export interface CapturedImage {
+  /** Base64-encoded image bytes. */
+  data: string;
+  /** MIME type (e.g. `image/png`). */
+  mediaType: string;
+}
+
+export interface CaptureBatchImagesInput {
+  sessionId: string;
+  promptBatchId: number | null | undefined;
+  promptNumber: number;
+  images: CapturedImage[];
+  logger: DaemonLogger;
+}
+
+/**
+ * Persist a batch of images as attachment rows linked to a specific prompt batch.
+ */
+export function captureBatchImages(input: CaptureBatchImagesInput): void {
+  const { sessionId, promptBatchId, promptNumber, images, logger } = input;
+  if (images.length === 0) return;
+
+  const sessionShort = sessionId.slice(-SESSION_SHORT_LEN);
+  for (let j = 0; j < images.length; j++) {
+    const img = images[j];
+    if (!img?.data || !img?.mediaType) continue;
+    try {
+      const ext = extensionForMimeType(img.mediaType);
+      const filename = `${sessionShort}-t${promptNumber}-${j + 1}.${ext}`;
+      const inserted = insertAttachment({
+        id: `${sessionShort}-b${promptNumber}-${j + 1}`,
+        session_id: sessionId,
+        prompt_batch_id: promptBatchId ?? undefined,
+        file_path: filename,
+        media_type: img.mediaType,
+        data: Buffer.from(img.data, 'base64'),
+        created_at: epochSeconds(),
+      });
+      // insertAttachment returns undefined on ON CONFLICT DO NOTHING — only
+      // log when a row was actually inserted, otherwise stop-event replays
+      // (or plugin retries) produce phantom "Image stored in DB" lines for
+      // attachments that were already persisted.
+      if (inserted) {
+        logger.debug(LOG_KINDS.CAPTURE_ATTACHMENT, 'Image stored in DB', {
+          filename,
+          batch: promptNumber,
+        });
+      }
+    } catch (err) {
+      logger.warn(LOG_KINDS.CAPTURE_ATTACHMENT, 'Failed to record attachment', {
+        error: String(err),
+      });
+    }
+  }
+}

--- a/src/daemon/event-dispatch.ts
+++ b/src/daemon/event-dispatch.ts
@@ -30,6 +30,7 @@ import {
 } from './event-handlers.js';
 import { getLatestBatch } from '@myco/db/queries/batches.js';
 import { upsertSession } from '@myco/db/queries/sessions.js';
+import { captureBatchImages, type CapturedImage } from './capture-images.js';
 import { epochSeconds, LOG_PROMPT_PREVIEW_CHARS } from '@myco/constants.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 
@@ -135,6 +136,22 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
         try {
           const { batchId, promptNumber } = handleUserPrompt(event.session_id, promptText || undefined);
           logger.debug(LOG_KINDS.CAPTURE_BATCH, 'Batch opened', { session_id: event.session_id, batch_id: batchId, prompt_number: promptNumber });
+
+          // Plugin-based symbionts (opencode) ship image attachments in the
+          // user_prompt event payload rather than in an on-disk transcript.
+          // The stop-event transcript-mining path handles claude-code/cursor;
+          // the persistence logic is shared between both paths via
+          // captureBatchImages.
+          const eventImages = event.images as CapturedImage[] | undefined;
+          if (Array.isArray(eventImages) && eventImages.length > 0) {
+            captureBatchImages({
+              sessionId: event.session_id,
+              promptBatchId: batchId,
+              promptNumber,
+              images: eventImages,
+              logger,
+            });
+          }
 
           // Batch-threshold summary trigger
           const batchCount = promptNumber;

--- a/src/daemon/event-handlers.ts
+++ b/src/daemon/event-handlers.ts
@@ -37,6 +37,20 @@ export function isSystemMessage(prompt: string): boolean {
   return SYSTEM_MESSAGE_PREFIXES.some((prefix) => trimmed.startsWith(prefix));
 }
 
+/** Extract a file path from tool input across snake_case and camelCase conventions. */
+function extractToolFilePath(toolInput: unknown): string | null {
+  const inputObj = toolInput as Record<string, unknown> | undefined;
+  if (!inputObj) return null;
+
+  const filePath = inputObj.file_path;
+  if (typeof filePath === 'string') return filePath;
+
+  const camelFilePath = inputObj.filePath;
+  if (typeof camelFilePath === 'string') return camelFilePath;
+
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Event handling helpers (exported for testing)
 // ---------------------------------------------------------------------------
@@ -93,9 +107,7 @@ export function handleToolUse(
 ): void {
   const now = epochSeconds();
 
-  // Extract file_path from tool input if present
-  const inputObj = toolInput as Record<string, unknown> | undefined;
-  const filePath = typeof inputObj?.file_path === 'string' ? inputObj.file_path : null;
+  const filePath = extractToolFilePath(toolInput);
 
   const activity = insertActivityWithBatch({
     session_id: sessionId,
@@ -143,8 +155,7 @@ export function handleToolFailure(
   isInterrupt: boolean | undefined,
 ): void {
   const now = epochSeconds();
-  const inputObj = toolInput as Record<string, unknown> | undefined;
-  const filePath = typeof inputObj?.file_path === 'string' ? inputObj.file_path : null;
+  const filePath = extractToolFilePath(toolInput);
 
   const activity = insertActivityWithBatch({
     session_id: sessionId,

--- a/src/daemon/jobs/session-maintenance.ts
+++ b/src/daemon/jobs/session-maintenance.ts
@@ -58,9 +58,17 @@ export function completeStaleActiveSessions(registeredSessionIds: string[]): num
 }
 
 /**
- * Find session IDs with prompt_count <= DEAD_SESSION_MAX_PROMPTS.
+ * Find session IDs eligible for dead-session cleanup.
  *
- * Excludes currently registered sessions.
+ * A session is "dead" only if BOTH:
+ *   1. Its status is NOT 'active' (prevents racing with a session that's
+ *      currently running — active sessions get swept by the stale-session
+ *      step first when truly idle).
+ *   2. Its prompt_count is at most DEAD_SESSION_MAX_PROMPTS (default 0,
+ *      meaning only empty "registered but never used" sessions qualify).
+ *
+ * Also excludes currently-registered in-memory sessions as a defense-in-depth
+ * guard against TOCTOU between the status check and the delete.
  */
 export function findDeadSessionIds(registeredSessionIds: string[]): string[] {
   const db = getDatabase();
@@ -74,6 +82,7 @@ export function findDeadSessionIds(registeredSessionIds: string[]): string[] {
   const rows = db.prepare(
     `SELECT id FROM sessions
      WHERE prompt_count <= ?
+       AND status != 'active'
        ${excludePlaceholders}`,
   ).all(...params) as { id: string }[];
 

--- a/src/daemon/plan-capture.ts
+++ b/src/daemon/plan-capture.ts
@@ -19,8 +19,15 @@ import type { PlanRow } from '@myco/db/queries/plans.js';
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Tool names that constitute a file write operation. */
-const FILE_WRITE_TOOLS = new Set(['Write', 'Edit', 'Create']);
+/**
+ * Tool names that constitute a file write operation.
+ * Includes both PascalCase (Claude Code, Cursor, Codex, Windsurf, Gemini) and
+ * lowercase (opencode) variants. `patch` is opencode's unified-diff tool.
+ */
+const FILE_WRITE_TOOLS = new Set([
+  'Write', 'Edit', 'Create',
+  'write', 'edit', 'patch', 'create',
+]);
 
 /** Regex matching a top-level markdown heading (# Title). */
 const HEADING_REGEX = /^#\s+(.+)$/m;
@@ -75,7 +82,9 @@ export function isPlanWriteEvent(
   config: PlanWatchConfig,
 ): string | null {
   if (!FILE_WRITE_TOOLS.has(toolName)) return null;
-  const filePath = toolInput?.file_path ?? toolInput?.path;
+  // `filePath` (camelCase) is opencode's convention — the plugin template ships
+  // `input.args` through as `tool_input`, and opencode tools use camelCase args.
+  const filePath = toolInput?.file_path ?? toolInput?.path ?? toolInput?.filePath;
   if (typeof filePath !== 'string') return null;
   if (!isInPlanDirectory(filePath, config.watchDirs, config.projectRoot)) return null;
   if (config.extensions?.length) {

--- a/src/daemon/stop-processing.ts
+++ b/src/daemon/stop-processing.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import fs from 'node:fs';
 import { TranscriptMiner, extractTurnsFromBuffer } from '@myco/capture/transcript-miner.js';
 import type { TranscriptTurn } from '@myco/symbionts/adapter.js';
-import { extensionForMimeType } from '@myco/symbionts/adapter.js';
+import { captureBatchImages } from './capture-images.js';
 import {
   getLatestBatch,
   setResponseSummary,
@@ -20,7 +20,6 @@ import {
   findBatchByPromptPrefix,
 } from '@myco/db/queries/batches.js';
 import { getSession, updateSession } from '@myco/db/queries/sessions.js';
-import { insertAttachment } from '@myco/db/queries/attachments.js';
 import { detectSkillUsage, SKILL_USAGE_DETECTION_ENABLED } from './skill-usage.js';
 import { epochSeconds, LOG_MESSAGE_PREVIEW_CHARS } from '@myco/constants.js';
 import { TITLE_PREVIEW_CHARS } from './event-handlers.js';
@@ -284,7 +283,6 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     // After context compaction, transcript turn indices no longer match batch prompt_numbers.
     // Instead, match each turn to its batch by prompt text (content-based, not position-based).
     // Binary data is stored in the DB BLOB column; DB uses ON CONFLICT DO NOTHING → idempotent.
-    const sessionShort = sessionId.slice(-6);
     for (let i = 0; i < allTurns.length; i++) {
       const turn = allTurns[i];
       if (!turn.images?.length) continue;
@@ -310,32 +308,13 @@ export function createStopProcessor(deps: StopProcessorDeps): {
         } catch { /* fallback to index-based */ }
       }
 
-      for (let j = 0; j < turn.images.length; j++) {
-        const img = turn.images[j];
-        const ext = extensionForMimeType(img.mediaType);
-        const filename = `${sessionShort}-t${resolvedPromptNumber}-${j + 1}.${ext}`;
-        const imageBuffer = Buffer.from(img.data, 'base64');
-        try {
-          const inserted = insertAttachment({
-            id: `${sessionShort}-b${resolvedPromptNumber}-${j + 1}`,
-            session_id: sessionId,
-            prompt_batch_id: resolvedBatchId ?? undefined,
-            file_path: filename,
-            media_type: img.mediaType,
-            data: imageBuffer,
-            created_at: epochSeconds(),
-          });
-          // insertAttachment returns undefined on ON CONFLICT DO NOTHING — only
-          // log when a row was actually inserted, otherwise stop-event replays
-          // produce phantom "Image stored in DB" lines for attachments that
-          // were already persisted on a previous run.
-          if (inserted) {
-            logger.debug(LOG_KINDS.CAPTURE_ATTACHMENT, 'Image stored in DB', { filename, batch: resolvedPromptNumber });
-          }
-        } catch (err) {
-          logger.warn(LOG_KINDS.CAPTURE_ATTACHMENT, 'Failed to record attachment', { error: String(err) });
-        }
-      }
+      captureBatchImages({
+        sessionId,
+        promptBatchId: resolvedBatchId,
+        promptNumber: resolvedPromptNumber,
+        images: turn.images,
+        logger,
+      });
     }
 
     logger.info(LOG_KINDS.PROCESSOR_SESSION, 'Session captured', {

--- a/src/mcp/tool-definitions.ts
+++ b/src/mcp/tool-definitions.ts
@@ -148,7 +148,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: TOOL_CONTEXT,
-    description: "Retrieve Myco's synthesized understanding of this project. Returns a pre-computed context extract at the requested token tier. Available tiers: 1500 (executive briefing), 5000 (deep onboarding), 10000 (institutional knowledge). This is a rich, always-current synthesis of project history, decisions, patterns, and active work — not a search result.",
+    description: "Retrieve Myco's pre-computed project digest — a rich, always-current synthesis of project history, decisions, patterns, active work, and institutional knowledge. Call this at the start of a new task or session to orient yourself on the project before taking action; call it again after long interruptions or when switching contexts. This is NOT a search — it's the project's accumulated understanding, served instantly. Available tiers: 1500 (executive briefing, one-screen overview), 5000 (deep onboarding, default), 10000 (comprehensive institutional knowledge). Prefer this over myco_search when you need broad project orientation; use myco_search when you need to find specific prior decisions or bug fixes.",
     inputSchema: {
       type: 'object' as const,
       properties: {

--- a/src/symbionts/installer.ts
+++ b/src/symbionts/installer.ts
@@ -36,6 +36,13 @@ const CANONICAL_SKILLS_DIR = '.agents/skills';
 /** MCP server name used by Myco in all symbiont configurations. */
 export const MYCO_MCP_SERVER_NAME = 'myco';
 
+/**
+ * Marker substring written into plugin-file hook templates (e.g., opencode's plugin.ts).
+ * Uninstall only deletes plugin files whose content contains this marker, so
+ * contributors who hand-edit a plugin file without removing the marker are protected.
+ */
+const MYCO_PLUGIN_FILE_MARKER = 'myco:plugin-marker';
+
 /** Marker text used to identify unmodified instruction stubs. */
 const INSTRUCTIONS_STUB_MARKER = 'Edit AGENTS.md, not this file';
 
@@ -56,6 +63,11 @@ export interface InstallResult {
   skills: boolean;
   settings: boolean;
   instructions: boolean;
+  /**
+   * Plugin deps package.json (e.g., .opencode/package.json). Only present for agents
+   * with `registration.pluginPackageTarget` set. False otherwise.
+   */
+  pluginPackage: boolean;
 }
 
 export class SymbiontInstaller {
@@ -133,6 +145,24 @@ export class SymbiontInstaller {
     return null;
   }
 
+  /**
+   * Load a template file verbatim (no JSON parsing).
+   * Used for plugin-file hook templates (e.g., opencode's plugin.ts) and any
+   * other template that is copied to the project without structural merging.
+   */
+  loadTemplateRaw(filename: string): string | null {
+    const candidates = [
+      path.join(this.packageRoot, TEMPLATES_SUBDIR, this.manifest.name, filename),
+      path.join(this.packageRoot, 'dist', TEMPLATES_SUBDIR, this.manifest.name, filename),
+    ];
+    for (const filePath of candidates) {
+      try {
+        return fs.readFileSync(filePath, 'utf-8');
+      } catch { /* not found — try next */ }
+    }
+    return null;
+  }
+
   /** Run all registration steps. */
   install(): InstallResult {
     const reg = this.manifest.registration;
@@ -146,7 +176,10 @@ export class SymbiontInstaller {
           skills: this.installSkills(),
           settings: this.installSettings(),
           instructions: this.installInstructions(),
+          pluginPackage: false,
         };
+    // Plugin deps package.json (plugin-file agents only)
+    result.pluginPackage = this.installPluginPackage();
     this.updateGitignore();
     return result;
   }
@@ -155,6 +188,9 @@ export class SymbiontInstaller {
    * Check if ALL non-null JSON targets share the same file (e.g., Gemini).
    * Only batches when every target resolves to one path — partial overlaps
    * (e.g., Claude Code: hooks+settings share but MCP is separate) use normal path.
+   *
+   * Plugin-file hooks (e.g., opencode) naturally fall out of batching because their
+   * hooksTarget is a distinct .ts file path, yielding a Set size ≥ 2.
    */
   private shouldBatchJsonTargets(reg: typeof this.manifest.registration): boolean {
     if (!reg) return false;
@@ -192,11 +228,12 @@ export class SymbiontInstaller {
     // Apply MCP transform
     const mcpTemplate = reg.mcpTarget ? this.loadTemplate('mcp') : null;
     if (mcpTemplate) {
-      const servers = (data.mcpServers ?? {}) as Record<string, unknown>;
+      const serversKey = reg.mcpServersKey ?? 'mcpServers';
+      const servers = (data[serversKey] ?? {}) as Record<string, unknown>;
       for (const [name, def] of Object.entries(mcpTemplate)) {
         servers[name] = def;
       }
-      data.mcpServers = servers;
+      data[serversKey] = servers;
       mcp = true;
     }
 
@@ -215,6 +252,9 @@ export class SymbiontInstaller {
       skills: this.installSkills(),
       settings,
       instructions: this.installInstructions(),
+      // Batched agents (Gemini) don't have plugin-file hooks, but install() sets this
+      // correctly after the dispatch returns.
+      pluginPackage: false,
     };
   }
 
@@ -229,6 +269,7 @@ export class SymbiontInstaller {
           skills: this.uninstallSkills(),
           settings: this.uninstallSettings(),
           instructions: this.uninstallInstructions(),
+          pluginPackage: false,
         };
     // Remove hook guard after hooks/settings so the file is cleaned up last
     this.uninstallHookGuard();
@@ -243,7 +284,14 @@ export class SymbiontInstaller {
     const targetPath = path.join(this.projectRoot, reg.hooksTarget ?? reg.mcpTarget ?? reg.settingsTarget!);
     const data = readJsonFile(targetPath);
     if (Object.keys(data).length === 0) {
-      return { hooks: false, mcp: false, skills: this.uninstallSkills(), settings: false, instructions: this.uninstallInstructions() };
+      return {
+        hooks: false,
+        mcp: false,
+        skills: this.uninstallSkills(),
+        settings: false,
+        instructions: this.uninstallInstructions(),
+        pluginPackage: false,
+      };
     }
 
     let hooks = false, mcp = false, settings = false;
@@ -268,11 +316,12 @@ export class SymbiontInstaller {
 
     // Remove MCP
     if (reg.mcpTarget) {
-      const servers = (data.mcpServers ?? {}) as Record<string, unknown>;
+      const serversKey = reg.mcpServersKey ?? 'mcpServers';
+      const servers = (data[serversKey] ?? {}) as Record<string, unknown>;
       if (servers[MYCO_MCP_SERVER_NAME]) {
         delete servers[MYCO_MCP_SERVER_NAME];
-        if (Object.keys(servers).length === 0) delete data.mcpServers;
-        else data.mcpServers = servers;
+        if (Object.keys(servers).length === 0) delete data[serversKey];
+        else data[serversKey] = servers;
         mcp = true;
       }
     }
@@ -285,7 +334,14 @@ export class SymbiontInstaller {
 
     writeOrDeleteJsonFile(targetPath, data);
 
-    return { hooks, mcp, skills: this.uninstallSkills(), settings, instructions: this.uninstallInstructions() };
+    return {
+      hooks,
+      mcp,
+      skills: this.uninstallSkills(),
+      settings,
+      instructions: this.uninstallInstructions(),
+      pluginPackage: false,
+    };
   }
 
   /**
@@ -449,10 +505,15 @@ export class SymbiontInstaller {
   /**
    * Merge hooks template into the target settings file.
    * Replaces all Myco-owned hook groups; preserves non-Myco hooks.
+   *
+   * For plugin-file agents (e.g., opencode) this dispatches to `installPluginHookFile()`
+   * which writes a verbatim .ts plugin source to hooksTarget instead of merging JSON.
    */
   installHooks(): boolean {
     const reg = this.manifest.registration;
     if (!reg?.hooksTarget) return false;
+
+    if (reg.hooksFormat === 'plugin-file') return this.installPluginHookFile();
 
     const template = this.loadTemplate('hooks');
     if (!template) return false;
@@ -485,6 +546,81 @@ export class SymbiontInstaller {
   }
 
   /**
+   * Install a plugin-file hook target by copying a verbatim template.
+   * Used for agents whose hook system is plugin-based rather than JSON entry-based
+   * (e.g., opencode's TypeScript plugin system).
+   *
+   * Content-diff gated: skips the write if the target already matches the template,
+   * so `myco update` is quiet when nothing changes.
+   */
+  private installPluginHookFile(): boolean {
+    const reg = this.manifest.registration;
+    if (!reg?.hooksTarget) return false;
+
+    const templateContent = this.loadTemplateRaw('plugin.ts');
+    if (templateContent === null) return false;
+
+    const targetPath = path.join(this.projectRoot, reg.hooksTarget);
+
+    // Content-diff gate: skip if already current
+    try {
+      if (fs.readFileSync(targetPath, 'utf-8') === templateContent) return false;
+    } catch { /* doesn't exist — proceed */ }
+
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    fs.writeFileSync(targetPath, templateContent, 'utf-8');
+    return true;
+  }
+
+  /**
+   * Remove a plugin-file hook target.
+   * Only deletes files whose content contains the Myco plugin marker — contributors
+   * who hand-edit the plugin file without removing the marker are protected.
+   */
+  private uninstallPluginHookFile(): boolean {
+    const reg = this.manifest.registration;
+    if (!reg?.hooksTarget) return false;
+
+    const targetPath = path.join(this.projectRoot, reg.hooksTarget);
+    let content: string;
+    try { content = fs.readFileSync(targetPath, 'utf-8'); } catch { return false; }
+
+    if (!content.includes(MYCO_PLUGIN_FILE_MARKER)) return false;
+
+    try {
+      fs.unlinkSync(targetPath);
+      // Remove parent plugins dir if now empty
+      try { fs.rmdirSync(path.dirname(targetPath)); } catch { /* not empty or missing */ }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Install a plugin deps package.json for plugin-file agents (e.g., opencode).
+   * Writes the template verbatim so the agent's package manager can install the SDK.
+   * Content-diff gated to keep `myco update` quiet.
+   */
+  private installPluginPackage(): boolean {
+    const reg = this.manifest.registration;
+    if (!reg?.pluginPackageTarget) return false;
+
+    const templateContent = this.loadTemplateRaw('package.json');
+    if (templateContent === null) return false;
+
+    const targetPath = path.join(this.projectRoot, reg.pluginPackageTarget);
+
+    try {
+      if (fs.readFileSync(targetPath, 'utf-8') === templateContent) return false;
+    } catch { /* doesn't exist — proceed */ }
+
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    fs.writeFileSync(targetPath, templateContent, 'utf-8');
+    return true;
+  }
+
+  /**
    * Merge MCP server template into the target config file.
    * Replaces the `myco` server entry; preserves other servers.
    */
@@ -501,19 +637,27 @@ export class SymbiontInstaller {
     if (mcpFormat === 'toml') {
       return this.installMcpToml(targetPath, template);
     }
-    return this.installMcpJson(targetPath, template);
+    const serversKey = reg.mcpServersKey ?? 'mcpServers';
+    return this.installMcpJson(targetPath, template, serversKey);
   }
 
-  /** Write MCP servers to a JSON config file. */
-  private installMcpJson(targetPath: string, template: Record<string, unknown>): boolean {
+  /**
+   * Write MCP servers to a JSON config file under the configured key.
+   * Most agents use the canonical `mcpServers` key, but opencode uses `mcp`.
+   */
+  private installMcpJson(
+    targetPath: string,
+    template: Record<string, unknown>,
+    serversKey: string,
+  ): boolean {
     const config = readJsonFile(targetPath);
-    const servers = (config.mcpServers ?? {}) as Record<string, unknown>;
+    const servers = (config[serversKey] ?? {}) as Record<string, unknown>;
 
     for (const [name, def] of Object.entries(template)) {
       servers[name] = def;
     }
 
-    config.mcpServers = servers;
+    config[serversKey] = servers;
     writeJsonFile(targetPath, config);
     return true;
   }
@@ -681,10 +825,17 @@ export class SymbiontInstaller {
     return true;
   }
 
-  /** Remove Myco hook groups from the target settings file. */
+  /**
+   * Remove Myco hook groups from the target settings file.
+   *
+   * For plugin-file agents (e.g., opencode) this dispatches to `uninstallPluginHookFile()`
+   * which deletes the verbatim plugin file (guarded by the Myco plugin marker).
+   */
   uninstallHooks(): boolean {
     const reg = this.manifest.registration;
     if (!reg?.hooksTarget) return false;
+
+    if (reg.hooksFormat === 'plugin-file') return this.uninstallPluginHookFile();
 
     const targetPath = path.join(this.projectRoot, reg.hooksTarget);
     const settings = readJsonFile(targetPath);
@@ -722,20 +873,21 @@ export class SymbiontInstaller {
     if (mcpFormat === 'toml') {
       return this.uninstallMcpToml(targetPath);
     }
-    return this.uninstallMcpJson(targetPath);
+    const serversKey = reg.mcpServersKey ?? 'mcpServers';
+    return this.uninstallMcpJson(targetPath, serversKey);
   }
 
-  private uninstallMcpJson(targetPath: string): boolean {
+  private uninstallMcpJson(targetPath: string, serversKey: string): boolean {
     const config = readJsonFile(targetPath);
-    const servers = (config.mcpServers ?? {}) as Record<string, unknown>;
+    const servers = (config[serversKey] ?? {}) as Record<string, unknown>;
     if (!servers[MYCO_MCP_SERVER_NAME]) return false;
 
     delete servers[MYCO_MCP_SERVER_NAME];
 
     if (Object.keys(servers).length === 0) {
-      delete config.mcpServers;
+      delete config[serversKey];
     } else {
-      config.mcpServers = servers;
+      config[serversKey] = servers;
     }
 
     writeOrDeleteJsonFile(targetPath, config);

--- a/src/symbionts/installer.ts
+++ b/src/symbionts/installer.ts
@@ -43,6 +43,9 @@ export const MYCO_MCP_SERVER_NAME = 'myco';
  */
 const MYCO_PLUGIN_FILE_MARKER = 'myco:plugin-marker';
 
+/** `hooksFormat` value selecting verbatim plugin-file install over JSON merge. */
+const HOOKS_FORMAT_PLUGIN_FILE = 'plugin-file';
+
 /** Marker text used to identify unmodified instruction stubs. */
 const INSTRUCTIONS_STUB_MARKER = 'Edit AGENTS.md, not this file';
 
@@ -78,6 +81,37 @@ export class SymbiontInstaller {
   ) {}
 
   /**
+   * Read a template file as raw text, checking both source and dist layouts.
+   * `relPath` is relative to `TEMPLATES_SUBDIR` — e.g. `'hook-guard.cjs'` for
+   * a shared template or `'opencode/plugin.ts'` for a per-agent template.
+   */
+  private readTemplateFile(relPath: string): string | null {
+    const candidates = [
+      path.join(this.packageRoot, TEMPLATES_SUBDIR, relPath),
+      // tsup preserves the src/ prefix under dist/, so the same subdir works in both layouts
+      path.join(this.packageRoot, 'dist', TEMPLATES_SUBDIR, relPath),
+    ];
+    for (const filePath of candidates) {
+      try { return fs.readFileSync(filePath, 'utf-8'); } catch { /* try next */ }
+    }
+    return null;
+  }
+
+  /**
+   * Write a Myco-managed file with a content-diff gate. Creates parent dirs as
+   * needed. Returns `true` if the file was written (new or updated), `false` if
+   * the on-disk content already matches and the write was skipped.
+   */
+  private writeManagedFile(absPath: string, content: string): boolean {
+    try {
+      if (fs.readFileSync(absPath, 'utf-8') === content) return false;
+    } catch { /* doesn't exist — proceed */ }
+    fs.mkdirSync(path.dirname(absPath), { recursive: true });
+    fs.writeFileSync(absPath, content, 'utf-8');
+    return true;
+  }
+
+  /**
    * Copy the hook-guard script into .agents/myco-hook.cjs.
    * Returns true if the file was written (or updated); false if skipped or N/A.
    */
@@ -85,19 +119,13 @@ export class SymbiontInstaller {
     const reg = this.manifest.registration;
     if (!reg?.hooksTarget) return false;
 
-    const guardTemplate = this.loadHookGuardTemplate();
+    const guardTemplate = this.readTemplateFile(HOOK_GUARD_TEMPLATE_FILENAME);
     if (!guardTemplate) return false;
 
-    const targetPath = path.join(this.projectRoot, HOOK_GUARD_PROJECT_PATH);
-
-    // Skip if already current
-    try {
-      if (fs.readFileSync(targetPath, 'utf-8') === guardTemplate) return false;
-    } catch { /* doesn't exist — proceed */ }
-
-    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-    fs.writeFileSync(targetPath, guardTemplate, 'utf-8');
-    return true;
+    return this.writeManagedFile(
+      path.join(this.projectRoot, HOOK_GUARD_PROJECT_PATH),
+      guardTemplate,
+    );
   }
 
   /**
@@ -117,32 +145,11 @@ export class SymbiontInstaller {
     }
   }
 
-  /** Load the hook-guard template from package root. */
-  private loadHookGuardTemplate(): string | null {
-    const candidates = [
-      path.join(this.packageRoot, TEMPLATES_SUBDIR, HOOK_GUARD_TEMPLATE_FILENAME),
-      path.join(this.packageRoot, 'dist', TEMPLATES_SUBDIR, HOOK_GUARD_TEMPLATE_FILENAME),
-    ];
-    for (const p of candidates) {
-      try { return fs.readFileSync(p, 'utf-8'); } catch { /* try next */ }
-    }
-    return null;
-  }
-
   /** Load a JSON template file for this symbiont. Returns null if not found. */
   loadTemplate(name: string): Record<string, unknown> | null {
-    // Check both source layout and dist layout
-    const candidates = [
-      path.join(this.packageRoot, TEMPLATES_SUBDIR, this.manifest.name, `${name}.json`),
-      // tsup preserves the src/ prefix under dist/, so the same subdir works in both layouts
-      path.join(this.packageRoot, 'dist', TEMPLATES_SUBDIR, this.manifest.name, `${name}.json`),
-    ];
-    for (const filePath of candidates) {
-      try {
-        return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-      } catch { /* not found or malformed — try next */ }
-    }
-    return null;
+    const raw = this.readTemplateFile(path.join(this.manifest.name, `${name}.json`));
+    if (raw === null) return null;
+    try { return JSON.parse(raw); } catch { return null; }
   }
 
   /**
@@ -151,16 +158,7 @@ export class SymbiontInstaller {
    * other template that is copied to the project without structural merging.
    */
   loadTemplateRaw(filename: string): string | null {
-    const candidates = [
-      path.join(this.packageRoot, TEMPLATES_SUBDIR, this.manifest.name, filename),
-      path.join(this.packageRoot, 'dist', TEMPLATES_SUBDIR, this.manifest.name, filename),
-    ];
-    for (const filePath of candidates) {
-      try {
-        return fs.readFileSync(filePath, 'utf-8');
-      } catch { /* not found — try next */ }
-    }
-    return null;
+    return this.readTemplateFile(path.join(this.manifest.name, filename));
   }
 
   /** Run all registration steps. */
@@ -176,10 +174,8 @@ export class SymbiontInstaller {
           skills: this.installSkills(),
           settings: this.installSettings(),
           instructions: this.installInstructions(),
-          pluginPackage: false,
+          pluginPackage: this.installPluginPackage(),
         };
-    // Plugin deps package.json (plugin-file agents only)
-    result.pluginPackage = this.installPluginPackage();
     this.updateGitignore();
     return result;
   }
@@ -252,9 +248,7 @@ export class SymbiontInstaller {
       skills: this.installSkills(),
       settings,
       instructions: this.installInstructions(),
-      // Batched agents (Gemini) don't have plugin-file hooks, but install() sets this
-      // correctly after the dispatch returns.
-      pluginPackage: false,
+      pluginPackage: this.installPluginPackage(),
     };
   }
 
@@ -513,7 +507,7 @@ export class SymbiontInstaller {
     const reg = this.manifest.registration;
     if (!reg?.hooksTarget) return false;
 
-    if (reg.hooksFormat === 'plugin-file') return this.installPluginHookFile();
+    if (reg.hooksFormat === HOOKS_FORMAT_PLUGIN_FILE) return this.installPluginHookFile();
 
     const template = this.loadTemplate('hooks');
     if (!template) return false;
@@ -549,9 +543,6 @@ export class SymbiontInstaller {
    * Install a plugin-file hook target by copying a verbatim template.
    * Used for agents whose hook system is plugin-based rather than JSON entry-based
    * (e.g., opencode's TypeScript plugin system).
-   *
-   * Content-diff gated: skips the write if the target already matches the template,
-   * so `myco update` is quiet when nothing changes.
    */
   private installPluginHookFile(): boolean {
     const reg = this.manifest.registration;
@@ -560,16 +551,10 @@ export class SymbiontInstaller {
     const templateContent = this.loadTemplateRaw('plugin.ts');
     if (templateContent === null) return false;
 
-    const targetPath = path.join(this.projectRoot, reg.hooksTarget);
-
-    // Content-diff gate: skip if already current
-    try {
-      if (fs.readFileSync(targetPath, 'utf-8') === templateContent) return false;
-    } catch { /* doesn't exist — proceed */ }
-
-    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-    fs.writeFileSync(targetPath, templateContent, 'utf-8');
-    return true;
+    return this.writeManagedFile(
+      path.join(this.projectRoot, reg.hooksTarget),
+      templateContent,
+    );
   }
 
   /**
@@ -600,7 +585,6 @@ export class SymbiontInstaller {
   /**
    * Install a plugin deps package.json for plugin-file agents (e.g., opencode).
    * Writes the template verbatim so the agent's package manager can install the SDK.
-   * Content-diff gated to keep `myco update` quiet.
    */
   private installPluginPackage(): boolean {
     const reg = this.manifest.registration;
@@ -609,15 +593,10 @@ export class SymbiontInstaller {
     const templateContent = this.loadTemplateRaw('package.json');
     if (templateContent === null) return false;
 
-    const targetPath = path.join(this.projectRoot, reg.pluginPackageTarget);
-
-    try {
-      if (fs.readFileSync(targetPath, 'utf-8') === templateContent) return false;
-    } catch { /* doesn't exist — proceed */ }
-
-    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-    fs.writeFileSync(targetPath, templateContent, 'utf-8');
-    return true;
+    return this.writeManagedFile(
+      path.join(this.projectRoot, reg.pluginPackageTarget),
+      templateContent,
+    );
   }
 
   /**
@@ -632,24 +611,21 @@ export class SymbiontInstaller {
     if (!template) return false;
 
     const targetPath = path.join(this.projectRoot, reg.mcpTarget);
-    const mcpFormat = reg.mcpFormat ?? 'json';
-
-    if (mcpFormat === 'toml') {
+    if (reg.mcpFormat === 'toml') {
       return this.installMcpToml(targetPath, template);
     }
-    const serversKey = reg.mcpServersKey ?? 'mcpServers';
-    return this.installMcpJson(targetPath, template, serversKey);
+    return this.installMcpJson(targetPath, template);
   }
 
   /**
-   * Write MCP servers to a JSON config file under the configured key.
-   * Most agents use the canonical `mcpServers` key, but opencode uses `mcp`.
+   * Write MCP servers to a JSON config file under the manifest-configured key.
+   * Most agents use the canonical `mcpServers` key; opencode uses `mcp`.
+   *
+   * The `?? 'mcpServers'` fallback protects against test fixtures that construct
+   * manifests as plain object literals and bypass the schema's default.
    */
-  private installMcpJson(
-    targetPath: string,
-    template: Record<string, unknown>,
-    serversKey: string,
-  ): boolean {
+  private installMcpJson(targetPath: string, template: Record<string, unknown>): boolean {
+    const serversKey = this.manifest.registration!.mcpServersKey ?? 'mcpServers';
     const config = readJsonFile(targetPath);
     const servers = (config[serversKey] ?? {}) as Record<string, unknown>;
 
@@ -835,7 +811,7 @@ export class SymbiontInstaller {
     const reg = this.manifest.registration;
     if (!reg?.hooksTarget) return false;
 
-    if (reg.hooksFormat === 'plugin-file') return this.uninstallPluginHookFile();
+    if (reg.hooksFormat === HOOKS_FORMAT_PLUGIN_FILE) return this.uninstallPluginHookFile();
 
     const targetPath = path.join(this.projectRoot, reg.hooksTarget);
     const settings = readJsonFile(targetPath);
@@ -868,16 +844,15 @@ export class SymbiontInstaller {
     if (!reg?.mcpTarget) return false;
 
     const targetPath = path.join(this.projectRoot, reg.mcpTarget);
-    const mcpFormat = reg.mcpFormat ?? 'json';
-
-    if (mcpFormat === 'toml') {
+    if (reg.mcpFormat === 'toml') {
       return this.uninstallMcpToml(targetPath);
     }
-    const serversKey = reg.mcpServersKey ?? 'mcpServers';
-    return this.uninstallMcpJson(targetPath, serversKey);
+    return this.uninstallMcpJson(targetPath);
   }
 
-  private uninstallMcpJson(targetPath: string, serversKey: string): boolean {
+  private uninstallMcpJson(targetPath: string): boolean {
+    // Fallback matches the schema default; protects test fixtures that bypass .parse().
+    const serversKey = this.manifest.registration!.mcpServersKey ?? 'mcpServers';
     const config = readJsonFile(targetPath);
     const servers = (config[serversKey] ?? {}) as Record<string, unknown>;
     if (!servers[MYCO_MCP_SERVER_NAME]) return false;

--- a/src/symbionts/manifest-schema.ts
+++ b/src/symbionts/manifest-schema.ts
@@ -6,8 +6,28 @@ const CaptureManifestSchema = z.object({
 
 const RegistrationSchema = z.object({
   hooksTarget: z.string().optional(),
+  /**
+   * Format of the hooks target.
+   * - 'json' (default): hooks template is merged into a JSON settings file.
+   * - 'plugin-file': the hooks template is a verbatim file (e.g., an opencode TS plugin)
+   *   copied to hooksTarget without JSON parsing. Used for agents with plugin-based hook
+   *   systems rather than JSON hook entries.
+   */
+  hooksFormat: z.enum(['json', 'plugin-file']).default('json'),
+  /**
+   * Optional file path for a plugin deps package.json. When set, the installer writes
+   * a package.json declaring the plugin SDK dependency so the agent's package manager
+   * (e.g., opencode's Bun) can install it at startup. Preserved on uninstall so
+   * contributors can keep their own deps.
+   */
+  pluginPackageTarget: z.string().optional(),
   mcpTarget: z.string().optional(),
   mcpFormat: z.enum(['json', 'toml']).default('json'),
+  /**
+   * JSON key under which MCP server entries are stored in the MCP config file.
+   * Defaults to 'mcpServers' (used by Claude Code, Cursor, etc.). opencode uses 'mcp'.
+   */
+  mcpServersKey: z.string().default('mcpServers'),
   skillsTarget: z.string().optional(),
   settingsTarget: z.string().optional(),
   /** Format of the settings file. TOML-format agents (e.g., Codex) emit top-level template keys as TOML sections. */

--- a/src/symbionts/manifests/claude-code.yaml
+++ b/src/symbionts/manifests/claude-code.yaml
@@ -11,6 +11,10 @@ hookFields:
   lastResponse: last_assistant_message
 capture:
   planDirs:
+    # Claude Code's plan mode writes to ~/.claude/plans/ (global), not the project-local
+    # .claude/plans/. We watch both: home for plan-mode output, project-local for any
+    # user-committed plans in the repo.
+    - ~/.claude/plans/
     - .claude/plans/
 registration:
   hooksTarget: .claude/settings.json

--- a/src/symbionts/manifests/opencode.yaml
+++ b/src/symbionts/manifests/opencode.yaml
@@ -1,0 +1,26 @@
+name: opencode
+displayName: OpenCode
+binary: opencode
+configDir: .opencode
+pluginRootEnvVar: OPENCODE_PLUGIN_ROOT
+resumeCommand: "opencode --session {sessionId}"
+hookFields:
+  sessionId: session_id
+  transcriptPath: transcript_path
+  lastResponse: last_assistant_message
+capture:
+  planDirs:
+    # opencode Plan mode permits edits only to .opencode/plans/*.md — captured by plan-capture.ts
+    - .opencode/plans/
+registration:
+  # Hooks are delivered as a verbatim TS plugin file, not a JSON merge
+  hooksTarget: .opencode/plugins/myco.ts
+  hooksFormat: plugin-file
+  # .opencode/package.json declares the plugin SDK dep so opencode's Bun installs it at startup
+  pluginPackageTarget: .opencode/package.json
+  # opencode.json hosts MCP + permissions under non-standard keys
+  mcpTarget: opencode.json
+  mcpServersKey: mcp
+  settingsTarget: opencode.json
+  skillsTarget: .agents/skills
+  # No instructionsFile — opencode reads AGENTS.md natively

--- a/src/symbionts/templates/opencode/mcp.json
+++ b/src/symbionts/templates/opencode/mcp.json
@@ -1,0 +1,6 @@
+{
+  "myco": {
+    "type": "local",
+    "command": ["myco-run", "mcp"]
+  }
+}

--- a/src/symbionts/templates/opencode/package.json
+++ b/src/symbionts/templates/opencode/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@opencode-ai/plugin": "^1.1.59"
+  }
+}

--- a/src/symbionts/templates/opencode/plugin.ts
+++ b/src/symbionts/templates/opencode/plugin.ts
@@ -30,25 +30,34 @@ import { join } from "node:path";
 // Constants
 // ---------------------------------------------------------------------------
 
-const TOOL_OUTPUT_PREVIEW_CHARS = 500;
-
-/** Preferred context tier (matches Myco's default in src/mcp/tools/context.ts). */
-const MYCO_CONTEXT_TIER = 5000;
+/**
+ * Keep in sync with `TOOL_OUTPUT_PREVIEW_CHARS` in src/constants.ts (currently 200).
+ * The plugin file is standalone and cannot import from Myco — this value is copied
+ * so every symbiont records tool_output previews at the same length.
+ */
+const TOOL_OUTPUT_PREVIEW_CHARS = 200;
 
 /** Timeout for daemon HTTP calls — must be short so we never block opencode. */
 const MYCO_FETCH_TIMEOUT_MS = 3000;
 
-/** Heading prefixes for injected context so the model can recognize the source. */
-const DIGEST_HEADING = "## Myco — Project Context\n\n";
+/** Heading prefix for compaction context — makes Myco's contribution recognizable in the compacted summary. */
 const COMPACTION_HEADING = "## Myco — Project Context (preserved across compaction)\n\n";
 
 // ---------------------------------------------------------------------------
 // Daemon HTTP transport — all communication with the local Myco daemon.
-// Every function is best-effort: failures are logged to stderr and swallowed.
+// Every function is best-effort: failures are swallowed so the plugin cannot
+// interfere with opencode when Myco is absent or the daemon is unreachable.
 // ---------------------------------------------------------------------------
 
+/**
+ * Port cache for `.myco/daemon.json`. Read once on first access; refreshed on
+ * the next call that follows a failed HTTP request (handles daemon restarts
+ * mid-session). `undefined` = never loaded, `null` = loaded but absent.
+ */
+let cachedDaemonPort: number | null | undefined = undefined;
+
 /** Read the Myco daemon port from .myco/daemon.json in the project directory. */
-function readDaemonPort(directory: string): number | null {
+function readDaemonPortFromDisk(directory: string): number | null {
   try {
     const raw = readFileSync(join(directory, ".myco", "daemon.json"), "utf-8");
     const info = JSON.parse(raw) as { port?: number };
@@ -56,6 +65,18 @@ function readDaemonPort(directory: string): number | null {
   } catch {
     return null;
   }
+}
+
+/** Get the cached daemon port, loading from disk on first access. */
+function getDaemonPort(directory: string): number | null {
+  if (cachedDaemonPort === undefined) cachedDaemonPort = readDaemonPortFromDisk(directory);
+  return cachedDaemonPort;
+}
+
+/** Force-refresh the daemon port from disk — used after a fetch failure in case the daemon restarted. */
+function refreshDaemonPort(directory: string): number | null {
+  cachedDaemonPort = readDaemonPortFromDisk(directory);
+  return cachedDaemonPort;
 }
 
 /** Fetch with a short timeout. Returns the Response on success, null on failure. */
@@ -72,10 +93,26 @@ async function fetchWithTimeout(url: string, init?: RequestInit): Promise<Respon
   }
 }
 
-/** Build a daemon URL using the port read from .myco/daemon.json. Returns null if unreachable. */
-function daemonUrl(directory: string, path: string): string | null {
-  const port = readDaemonPort(directory);
-  return port ? `http://localhost:${port}${path}` : null;
+/**
+ * Fetch from a daemon endpoint with a single retry after refreshing the port.
+ * The retry handles the case where the daemon restarted on a different port
+ * mid-session; the cache hot-path avoids a sync disk read on every HTTP call.
+ */
+async function fetchFromDaemon(
+  directory: string,
+  path: string,
+  init?: RequestInit,
+): Promise<Response | null> {
+  const port = getDaemonPort(directory);
+  if (!port) return null;
+
+  const first = await fetchWithTimeout(`http://localhost:${port}${path}`, init);
+  if (first) return first;
+
+  // Retry once with a refreshed port — the daemon may have restarted.
+  const freshPort = refreshDaemonPort(directory);
+  if (!freshPort || freshPort === port) return null;
+  return fetchWithTimeout(`http://localhost:${freshPort}${path}`, init);
 }
 
 /** POST JSON to a daemon endpoint. Returns the parsed response body or null. */
@@ -84,9 +121,7 @@ async function postJson(
   path: string,
   body: Record<string, unknown>,
 ): Promise<unknown> {
-  const url = daemonUrl(directory, path);
-  if (!url) return null;
-  const res = await fetchWithTimeout(url, {
+  const res = await fetchFromDaemon(directory, path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -163,25 +198,29 @@ async function mycoPostStop(
   });
 }
 
-/** Fetch the project digest at the preferred tier. Returns the text or null. */
-async function fetchMycoDigest(directory: string): Promise<string | null> {
-  const url = daemonUrl(directory, "/api/digest");
-  if (!url) return null;
-  const res = await fetchWithTimeout(url);
+/**
+ * Fetch the session-start context for a new opencode session. Hits the daemon's
+ * config-aware `POST /context` endpoint, which selects the digest tier the user
+ * has configured (`config.context.digest_tier`, default 5000) and returns the
+ * full session context (digest + branch + session ID lines).
+ *
+ * This is the same endpoint Claude Code's session-start hook uses, so opencode
+ * sessions receive the same context the user has configured for every other agent.
+ */
+async function fetchMycoSessionContext(
+  directory: string,
+  sessionId: string,
+): Promise<string | null> {
+  const res = await fetchFromDaemon(directory, "/context", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ session_id: sessionId }),
+  });
   if (!res) return null;
-
   try {
-    const data = (await res.json()) as { tiers?: Array<{ tier: number; content: string }> };
-    if (!data.tiers?.length) return null;
-
-    const exact = data.tiers.find((t) => t.tier === MYCO_CONTEXT_TIER);
-    if (exact?.content) return exact.content;
-
-    // Fall back to nearest available tier
-    const sorted = [...data.tiers].sort(
-      (a, b) => Math.abs(a.tier - MYCO_CONTEXT_TIER) - Math.abs(b.tier - MYCO_CONTEXT_TIER),
-    );
-    return sorted[0]?.content ?? null;
+    const data = (await res.json()) as { text?: string };
+    const text = data.text?.trim() ?? "";
+    return text.length > 0 ? text : null;
   } catch {
     return null;
   }
@@ -279,20 +318,21 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         const sessionId: string | undefined = info.id;
         if (!sessionId) return;
 
-        // 1) Capture: register the session with the Myco daemon.
-        await mycoRegisterSession(directory, sessionId, info.parentID || undefined);
-
-        // 2) Inject: push the project digest into the new session as a synthetic turn
-        //    before the user types anything. Skip on resume — the parent session
-        //    already has whatever context was relevant.
+        // Run the capture (register session with Myco daemon) and context fetch
+        // concurrently — they don't depend on each other, and parallelizing saves
+        // one round-trip of latency before the user's first turn lands. Context
+        // is fetched only for fresh sessions; resume sessions inherit the parent's
+        // history and don't need another injection.
         //
         // Re-entrancy: the synthetic text part carries `synthetic: true`; if opencode
         // fires chat.message for it, our handler's synthetic-flag check skips it.
-        if (!info.parentID) {
-          const digest = await fetchMycoDigest(directory);
-          if (digest) {
-            await injectSyntheticContext(client, sessionId, DIGEST_HEADING + digest);
-          }
+        const [, sessionContext] = await Promise.all([
+          mycoRegisterSession(directory, sessionId, info.parentID || undefined),
+          info.parentID ? Promise.resolve(null) : fetchMycoSessionContext(directory, sessionId),
+        ]);
+
+        if (sessionContext) {
+          await injectSyntheticContext(client, sessionId, sessionContext);
         }
         return;
       }
@@ -308,6 +348,11 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         if (!sessionId) return;
 
         // Fetch the last assistant message for a response summary.
+        // Narrow local types for walking the messages response — avoids scattered
+        // `any` casts inside the loop while keeping the SDK boundary cast isolated.
+        type MessagePart = { type?: string; text?: string };
+        type SessionMessage = { info?: { role?: string }; parts?: MessagePart[] };
+
         let responseSummary = "";
         try {
           const result = await client.session.messages({
@@ -315,15 +360,13 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
             query: { directory },
           });
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const messages = ((result as any)?.data ?? []) as any[];
+          const messages = ((result as any)?.data ?? []) as SessionMessage[];
           for (let i = messages.length - 1; i >= 0; i--) {
             const msg = messages[i];
             if (msg?.info?.role === "assistant") {
               const textParts = (msg.parts ?? [])
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                .filter((p: any) => p.type === "text" && p.text)
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                .map((p: any) => p.text);
+                .filter((p) => p.type === "text" && p.text)
+                .map((p) => p.text as string);
               responseSummary = textParts.join("\n");
               break;
             }
@@ -407,18 +450,22 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
 
     /**
      * Compaction hook: fires BEFORE opencode generates a continuation summary
-     * during session compaction. Pushing the digest into output.context ensures
-     * Myco's project knowledge survives compaction rather than being dropped.
+     * during session compaction. Pushing the session context into output.context
+     * ensures Myco's project knowledge survives compaction rather than being
+     * dropped. The fetched context respects the user's configured digest tier.
      *
      * See https://opencode.ai/docs/plugins/#compaction-hooks
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    "experimental.session.compacting": async (_input: any, output: any) => {
-      const digest = await fetchMycoDigest(directory);
-      if (!digest) return;
+    "experimental.session.compacting": async (input: any, output: any) => {
+      const sessionId = input?.sessionID;
+      if (!sessionId) return;
+
+      const sessionContext = await fetchMycoSessionContext(directory, sessionId);
+      if (!sessionContext) return;
 
       if (Array.isArray(output?.context)) {
-        output.context.push(COMPACTION_HEADING + digest);
+        output.context.push(COMPACTION_HEADING + sessionContext);
       }
     },
   };

--- a/src/symbionts/templates/opencode/plugin.ts
+++ b/src/symbionts/templates/opencode/plugin.ts
@@ -56,6 +56,18 @@ const COMPACTION_HEADING = "## Myco — Project Context (preserved across compac
  */
 let cachedDaemonPort: number | null | undefined = undefined;
 
+/**
+ * Active opencode sessions tracked by this plugin instance. Populated on
+ * `session.created` and drained on `session.deleted` / `server.instance.disposed`.
+ *
+ * Opencode has no `session.end` event — when the TUI exits normally (Ctrl+C,
+ * close terminal), the session stays "active" from the daemon's perspective
+ * until the session-maintenance job sweeps it (1-hour threshold). To close
+ * sessions cleanly on TUI exit, we track them locally and call unregister
+ * for each one when `server.instance.disposed` fires.
+ */
+const activeOpencodeSessions = new Set<string>();
+
 /** Read the Myco daemon port from .myco/daemon.json in the project directory. */
 function readDaemonPortFromDisk(directory: string): number | null {
   try {
@@ -318,6 +330,8 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         const sessionId: string | undefined = info.id;
         if (!sessionId) return;
 
+        activeOpencodeSessions.add(sessionId);
+
         // Run the capture (register session with Myco daemon) and context fetch
         // concurrently — they don't depend on each other, and parallelizing saves
         // one round-trip of latency before the user's first turn lands. Context
@@ -339,7 +353,26 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
 
       if (event.type === "session.deleted") {
         const info = event.properties?.info ?? {};
-        if (info.id) await mycoUnregisterSession(directory, info.id);
+        if (info.id) {
+          activeOpencodeSessions.delete(info.id);
+          await mycoUnregisterSession(directory, info.id);
+        }
+        return;
+      }
+
+      if (event.type === "server.instance.disposed") {
+        // Opencode TUI is shutting down. Flush all tracked sessions so the
+        // daemon can mark them completed immediately rather than waiting for
+        // the stale-session maintenance sweep (1-hour threshold).
+        //
+        // Fire-and-forget-parallel: the Bun process is about to exit, so we
+        // can't rely on awaited fetches completing. Promise.all gives the
+        // unregister calls their best shot at landing before teardown; any
+        // that don't make it fall back to the session-maintenance job.
+        if (activeOpencodeSessions.size === 0) return;
+        const toClose = Array.from(activeOpencodeSessions);
+        activeOpencodeSessions.clear();
+        await Promise.all(toClose.map((id) => mycoUnregisterSession(directory, id)));
         return;
       }
 

--- a/src/symbionts/templates/opencode/plugin.ts
+++ b/src/symbionts/templates/opencode/plugin.ts
@@ -165,17 +165,26 @@ async function mycoUnregisterSession(directory: string, sessionId: string): Prom
   await postJson(directory, "/sessions/unregister", { session_id: sessionId });
 }
 
-/** Post a user prompt event. */
+/** Post a user prompt event. Images, if any, are shipped as an array of
+ * `{ data: base64, mediaType }` objects — the daemon's event dispatcher persists
+ * them as attachments keyed to the newly-opened prompt batch.
+ *
+ * Opencode has no on-disk transcript for Myco to mine, so images attached by
+ * the user in the TUI must travel with the prompt event itself. Other symbionts
+ * (claude-code, cursor) extract images from their JSONL transcripts at stop time.
+ */
 async function mycoPostUserPrompt(
   directory: string,
   sessionId: string,
   prompt: string,
+  images: Array<{ data: string; mediaType: string }>,
 ): Promise<void> {
   await postJson(directory, "/events", {
     type: "user_prompt",
     session_id: sessionId,
     agent: "opencode",
     prompt,
+    ...(images.length > 0 ? { images } : {}),
   });
 }
 
@@ -452,9 +461,15 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
       const sessionId = input?.sessionID;
       if (!sessionId) return;
 
+      // Part shapes we care about: text (for the prompt string) and file
+      // (for image attachments encoded as data URLs — FilePart.url is
+      // `data:<mime>;base64,<data>` per
+      // packages/app/src/components/prompt-input/attachments.ts in opencode).
       const allParts = (output?.parts ?? []) as Array<{
         type?: string;
         text?: string;
+        mime?: string;
+        url?: string;
         synthetic?: boolean;
       }>;
       // Skip our own injected synthetic turns — they're not real user prompts.
@@ -466,7 +481,26 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
       const prompt = textParts.join("\n");
       if (!prompt) return;
 
-      await mycoPostUserPrompt(directory, sessionId, prompt);
+      // Extract any image attachments from FilePart data URLs. Non-image file
+      // parts (code snippets, documents) are ignored here — only images travel
+      // to Myco as binary attachments via the existing attachment pipeline.
+      const images: Array<{ data: string; mediaType: string }> = [];
+      for (const part of allParts) {
+        if (
+          part.type !== "file" ||
+          !part.mime?.startsWith("image/") ||
+          typeof part.url !== "string" ||
+          !part.url.startsWith("data:")
+        ) {
+          continue;
+        }
+        const commaIdx = part.url.indexOf(",");
+        if (commaIdx <= 0) continue;
+        const base64 = part.url.slice(commaIdx + 1);
+        if (base64) images.push({ data: base64, mediaType: part.mime });
+      }
+
+      await mycoPostUserPrompt(directory, sessionId, prompt, images);
     },
 
     /**

--- a/src/symbionts/templates/opencode/plugin.ts
+++ b/src/symbionts/templates/opencode/plugin.ts
@@ -12,13 +12,16 @@
 //
 // See https://opencode.ai/docs/plugins/
 //
-// Contributor safety: this plugin has NO external runtime imports — only node:fs
-// and node:path (Node builtins). An OSS contributor who clones the repo without
-// having Myco installed will still have opencode load this plugin successfully.
-// Every path that would contact Myco gracefully no-ops when `.myco/daemon.json`
-// is absent or the daemon is unreachable, so the plugin becomes invisible rather
-// than throwing. Do NOT add runtime imports from @opencode-ai/plugin or any other
-// package — that would break the no-op guarantee.
+// Degraded-mode safety: this plugin ships committed inside any project that has
+// run `myco init` — the file lives at .opencode/plugins/myco.ts in that project's
+// repo. When a teammate clones such a project WITHOUT having Myco installed
+// locally, opencode will still load this plugin (the file is right there in the
+// cloned repo). To stay invisible in that case, the plugin has NO external
+// runtime imports — only node:fs and node:path, which are always available in
+// Bun's runtime. Every path that would contact the Myco daemon gracefully no-ops
+// when `.myco/daemon.json` is absent or the daemon is unreachable, so the plugin
+// becomes invisible rather than throwing. Do NOT add runtime imports from
+// @opencode-ai/plugin or any other package — that would break this guarantee.
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -243,8 +246,9 @@ function summarizeToolOutput(output: unknown): string {
 /**
  * Opencode plugin entry. The function signature matches opencode's Plugin type
  * via duck typing — we deliberately do NOT import the Plugin type from
- * @opencode-ai/plugin so the plugin file has zero external runtime dependencies
- * and contributors without Myco installed experience a silent no-op.
+ * @opencode-ai/plugin so this file has zero external runtime dependencies.
+ * That guarantee lets teammates who clone a project that uses Myco still run
+ * opencode cleanly even when they don't have Myco installed locally.
  *
  * @param {{ client: any, directory: string, worktree: string }} ctx
  */

--- a/src/symbionts/templates/opencode/plugin.ts
+++ b/src/symbionts/templates/opencode/plugin.ts
@@ -23,7 +23,7 @@
 // becomes invisible rather than throwing. Do NOT add runtime imports from
 // @opencode-ai/plugin or any other package — that would break this guarantee.
 
-import { readFileSync } from "node:fs";
+import { readFileSync, appendFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 // ---------------------------------------------------------------------------
@@ -142,22 +142,82 @@ async function fetchFromDaemon(
   return fetchWithTimeout(`http://localhost:${freshPort}${path}`, init);
 }
 
-/** POST JSON to a daemon endpoint. Returns the parsed response body or null. */
+/**
+ * POST JSON to a daemon endpoint.
+ * Returns `{ ok, data }` — `ok` is true when the HTTP call succeeded, `data`
+ * is the parsed response body (may be absent if the body was empty or not JSON).
+ */
 async function postJson(
   directory: string,
   path: string,
   body: Record<string, unknown>,
-): Promise<unknown> {
+): Promise<{ ok: boolean; data?: unknown }> {
   const res = await fetchFromDaemon(directory, path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  if (!res) return null;
+  if (!res) return { ok: false };
   try {
-    return await res.json();
+    return { ok: true, data: await res.json() };
   } catch {
-    return null;
+    return { ok: true };
+  }
+}
+
+/**
+ * Append an event to the local buffer at .myco/buffer/<session-id>.jsonl.
+ *
+ * Used as a fallback when the daemon HTTP POST fails (daemon down, network
+ * error, timeout). The daemon replays buffered events via reconcileBufferBatches
+ * at startup, so events captured here are NOT lost — they land in the vault
+ * the next time the daemon comes back up. Mirrors the fallback pattern in
+ * src/hooks/send-event.ts + src/capture/buffer.ts that every other symbiont
+ * uses (claude-code, cursor, codex, etc.) via the hook CLI path.
+ *
+ * Without this fallback, opencode would have a significant parity gap — all
+ * other symbionts preserve events across daemon downtime, but opencode events
+ * would be silently dropped the moment the daemon was unreachable.
+ *
+ * The entry shape matches EventBuffer.append(): event payload with session_id
+ * stripped (it's in the filename) and an auto-injected ISO timestamp.
+ */
+function bufferEvent(
+  directory: string,
+  sessionId: string,
+  event: Record<string, unknown>,
+): void {
+  try {
+    const bufferDir = join(directory, ".myco", "buffer");
+    mkdirSync(bufferDir, { recursive: true });
+    const filePath = join(bufferDir, `${sessionId}.jsonl`);
+    // Strip session_id from the entry — it's encoded in the filename
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { session_id: _sid, ...payload } = event;
+    const line = JSON.stringify({
+      ...payload,
+      timestamp: payload.timestamp ?? new Date().toISOString(),
+    });
+    appendFileSync(filePath, line + "\n");
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error("[myco] Failed to buffer event:", err);
+  }
+}
+
+/**
+ * POST a capture event to the daemon with buffer fallback on failure.
+ * Used for user_prompt and tool_use events — both are replayed from the
+ * buffer by reconcileBufferBatches when the daemon restarts.
+ */
+async function postEventWithBuffer(
+  directory: string,
+  sessionId: string,
+  event: Record<string, unknown>,
+): Promise<void> {
+  const result = await postJson(directory, "/events", event);
+  if (!result.ok) {
+    bufferEvent(directory, sessionId, event);
   }
 }
 
@@ -187,6 +247,10 @@ async function mycoUnregisterSession(directory: string, sessionId: string): Prom
  * Opencode has no on-disk transcript for Myco to mine, so images attached by
  * the user in the TUI must travel with the prompt event itself. Other symbionts
  * (claude-code, cursor) extract images from their JSONL transcripts at stop time.
+ *
+ * Falls back to the local buffer if the daemon is unreachable so events are
+ * replayed on daemon restart (same resilience the other symbionts get via
+ * src/hooks/send-event.ts).
  */
 async function mycoPostUserPrompt(
   directory: string,
@@ -194,7 +258,7 @@ async function mycoPostUserPrompt(
   prompt: string,
   images: Array<{ data: string; mediaType: string }>,
 ): Promise<void> {
-  await postJson(directory, "/events", {
+  await postEventWithBuffer(directory, sessionId, {
     type: "user_prompt",
     session_id: sessionId,
     agent: "opencode",
@@ -203,7 +267,7 @@ async function mycoPostUserPrompt(
   });
 }
 
-/** Post a tool use event. */
+/** Post a tool use event. Falls back to the local buffer on failure. */
 async function mycoPostToolUse(
   directory: string,
   sessionId: string,
@@ -211,7 +275,7 @@ async function mycoPostToolUse(
   toolInput: unknown,
   toolOutput: string,
 ): Promise<void> {
-  await postJson(directory, "/events", {
+  await postEventWithBuffer(directory, sessionId, {
     type: "tool_use",
     session_id: sessionId,
     agent: "opencode",
@@ -247,19 +311,11 @@ async function fetchMycoSessionContext(
   directory: string,
   sessionId: string,
 ): Promise<string | null> {
-  const res = await fetchFromDaemon(directory, "/context", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ session_id: sessionId }),
-  });
-  if (!res) return null;
-  try {
-    const data = (await res.json()) as { text?: string };
-    const text = data.text?.trim() ?? "";
-    return text.length > 0 ? text : null;
-  } catch {
-    return null;
-  }
+  const result = await postJson(directory, "/context", { session_id: sessionId });
+  if (!result.ok) return null;
+  const data = result.data as { text?: string } | undefined;
+  const text = data?.text?.trim() ?? "";
+  return text.length > 0 ? text : null;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/symbionts/templates/opencode/plugin.ts
+++ b/src/symbionts/templates/opencode/plugin.ts
@@ -1,0 +1,400 @@
+// Managed by Myco. Regenerated on `myco update`. Edit src/symbionts/templates/opencode/plugin.ts in the Myco repo instead.
+// myco:plugin-marker:opencode
+//
+// Myco Codebase Intelligence Plugin for OpenCode.
+//
+// This plugin runs inside opencode's Bun runtime and communicates with the local
+// Myco daemon over HTTP — no subprocess spawns, no hook CLI, no stdin piping.
+//
+//   Capture: POST /sessions/register, /sessions/unregister, /events, /events/stop
+//   Context: GET  /api/digest, POST /context/prompt
+//   Inject:  client.session.prompt({ noReply: true, parts: [{ synthetic: true }] })
+//
+// See https://opencode.ai/docs/plugins/
+
+import type { Plugin } from "@opencode-ai/plugin";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TOOL_OUTPUT_PREVIEW_CHARS = 500;
+
+/** Preferred context tier (matches Myco's default in src/mcp/tools/context.ts). */
+const MYCO_CONTEXT_TIER = 5000;
+
+/** Timeout for daemon HTTP calls — must be short so we never block opencode. */
+const MYCO_FETCH_TIMEOUT_MS = 3000;
+
+/** Heading prefixes for injected context so the model can recognize the source. */
+const DIGEST_HEADING = "## Myco — Project Context\n\n";
+const COMPACTION_HEADING = "## Myco — Project Context (preserved across compaction)\n\n";
+
+// ---------------------------------------------------------------------------
+// Daemon HTTP transport — all communication with the local Myco daemon.
+// Every function is best-effort: failures are logged to stderr and swallowed.
+// ---------------------------------------------------------------------------
+
+/** Read the Myco daemon port from .myco/daemon.json in the project directory. */
+function readDaemonPort(directory: string): number | null {
+  try {
+    const raw = readFileSync(join(directory, ".myco", "daemon.json"), "utf-8");
+    const info = JSON.parse(raw) as { port?: number };
+    return typeof info.port === "number" ? info.port : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Fetch with a short timeout. Returns the Response on success, null on failure. */
+async function fetchWithTimeout(url: string, init?: RequestInit): Promise<Response | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), MYCO_FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal });
+    return res.ok ? res : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Build a daemon URL using the port read from .myco/daemon.json. Returns null if unreachable. */
+function daemonUrl(directory: string, path: string): string | null {
+  const port = readDaemonPort(directory);
+  return port ? `http://localhost:${port}${path}` : null;
+}
+
+/** POST JSON to a daemon endpoint. Returns the parsed response body or null. */
+async function postJson(
+  directory: string,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<unknown> {
+  const url = daemonUrl(directory, path);
+  if (!url) return null;
+  const res = await fetchWithTimeout(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res) return null;
+  try {
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+/** Register an opencode session with the daemon. */
+async function mycoRegisterSession(
+  directory: string,
+  sessionId: string,
+  parentSessionId: string | undefined,
+): Promise<void> {
+  await postJson(directory, "/sessions/register", {
+    session_id: sessionId,
+    agent: "opencode",
+    parent_session_id: parentSessionId,
+    started_at: new Date().toISOString(),
+  });
+}
+
+/** Unregister an opencode session. */
+async function mycoUnregisterSession(directory: string, sessionId: string): Promise<void> {
+  await postJson(directory, "/sessions/unregister", { session_id: sessionId });
+}
+
+/** Post a user prompt event. */
+async function mycoPostUserPrompt(
+  directory: string,
+  sessionId: string,
+  prompt: string,
+): Promise<void> {
+  await postJson(directory, "/events", {
+    type: "user_prompt",
+    session_id: sessionId,
+    agent: "opencode",
+    prompt,
+  });
+}
+
+/** Post a tool use event. */
+async function mycoPostToolUse(
+  directory: string,
+  sessionId: string,
+  toolName: string,
+  toolInput: unknown,
+  toolOutput: string,
+): Promise<void> {
+  await postJson(directory, "/events", {
+    type: "tool_use",
+    session_id: sessionId,
+    agent: "opencode",
+    tool_name: toolName,
+    tool_input: toolInput,
+    output_preview: toolOutput,
+  });
+}
+
+/** Post a stop event with the last assistant message as the response summary. */
+async function mycoPostStop(
+  directory: string,
+  sessionId: string,
+  lastAssistantMessage: string | undefined,
+): Promise<void> {
+  await postJson(directory, "/events/stop", {
+    session_id: sessionId,
+    agent: "opencode",
+    last_assistant_message: lastAssistantMessage,
+  });
+}
+
+/** Fetch the project digest at the preferred tier. Returns the text or null. */
+async function fetchMycoDigest(directory: string): Promise<string | null> {
+  const url = daemonUrl(directory, "/api/digest");
+  if (!url) return null;
+  const res = await fetchWithTimeout(url);
+  if (!res) return null;
+
+  try {
+    const data = (await res.json()) as { tiers?: Array<{ tier: number; content: string }> };
+    if (!data.tiers?.length) return null;
+
+    const exact = data.tiers.find((t) => t.tier === MYCO_CONTEXT_TIER);
+    if (exact?.content) return exact.content;
+
+    // Fall back to nearest available tier
+    const sorted = [...data.tiers].sort(
+      (a, b) => Math.abs(a.tier - MYCO_CONTEXT_TIER) - Math.abs(b.tier - MYCO_CONTEXT_TIER),
+    );
+    return sorted[0]?.content ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Opencode session injection — push synthetic context into session history.
+// ---------------------------------------------------------------------------
+
+/**
+ * Inject text into an opencode session as a synthetic (plugin-authored) user turn
+ * without triggering an AI response. Used for session-start and per-prompt context
+ * injection. Errors are swallowed — injection is best-effort.
+ */
+async function injectSyntheticContext(
+  client: unknown,
+  sessionId: string,
+  text: string,
+): Promise<void> {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const c = client as any;
+    await c.session.prompt({
+      path: { id: sessionId },
+      body: {
+        parts: [{ type: "text", text, synthetic: true }],
+        noReply: true,
+      },
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error("[myco] Failed to inject synthetic context:", error);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+/** Flatten todo items into a newline-separated summary. */
+function formatTodos(
+  todos: Array<{ id?: string; content?: string; status?: string }>,
+): string {
+  if (!todos || todos.length === 0) return "";
+  return todos
+    .map((t) => `[${t.status || "pending"}] ${t.content || ""}`)
+    .join("\n");
+}
+
+/** Truncate tool output for storage. */
+function summarizeToolOutput(output: unknown): string {
+  if (typeof output !== "string") return "";
+  return output.length > TOOL_OUTPUT_PREVIEW_CHARS
+    ? output.slice(0, TOOL_OUTPUT_PREVIEW_CHARS) + "..."
+    : output;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin entry
+// ---------------------------------------------------------------------------
+
+export const MycoPlugin: Plugin = async ({ client, directory, worktree }) => {
+  await client.app.log({
+    service: "myco",
+    level: "info",
+    message: "Myco plugin initialized",
+    extra: { directory, worktree },
+  });
+
+  return {
+    /**
+     * Generic event handler: session lifecycle, todos.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    event: async ({ event }: { event: any }) => {
+      if (event.type === "session.created") {
+        const info = event.properties?.info ?? {};
+        const sessionId: string | undefined = info.id;
+        if (!sessionId) return;
+
+        // 1) Capture: register the session with the Myco daemon.
+        await mycoRegisterSession(directory, sessionId, info.parentID || undefined);
+
+        // 2) Inject: push the project digest into the new session as a synthetic turn
+        //    before the user types anything. Skip on resume — the parent session
+        //    already has whatever context was relevant.
+        //
+        // Re-entrancy: the synthetic text part carries `synthetic: true`; if opencode
+        // fires chat.message for it, our handler's synthetic-flag check skips it.
+        if (!info.parentID) {
+          const digest = await fetchMycoDigest(directory);
+          if (digest) {
+            await injectSyntheticContext(client, sessionId, DIGEST_HEADING + digest);
+          }
+        }
+        return;
+      }
+
+      if (event.type === "session.deleted") {
+        const info = event.properties?.info ?? {};
+        if (info.id) await mycoUnregisterSession(directory, info.id);
+        return;
+      }
+
+      if (event.type === "session.idle") {
+        const sessionId = event.properties?.sessionID;
+        if (!sessionId) return;
+
+        // Fetch the last assistant message for a response summary.
+        let responseSummary = "";
+        try {
+          const result = await client.session.messages({
+            path: { id: sessionId },
+            query: { directory },
+          });
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const messages = ((result as any)?.data ?? []) as any[];
+          for (let i = messages.length - 1; i >= 0; i--) {
+            const msg = messages[i];
+            if (msg?.info?.role === "assistant") {
+              const textParts = (msg.parts ?? [])
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                .filter((p: any) => p.type === "text" && p.text)
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                .map((p: any) => p.text);
+              responseSummary = textParts.join("\n");
+              break;
+            }
+          }
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error("[myco] Failed to fetch messages for summary:", err);
+        }
+
+        await mycoPostStop(directory, sessionId, responseSummary || undefined);
+        return;
+      }
+
+      if (event.type === "todo.updated") {
+        const sessionId = event.properties?.sessionID;
+        if (!sessionId) return;
+        const todos = event.properties?.todos ?? [];
+        await mycoPostToolUse(
+          directory,
+          sessionId,
+          "TodoUpdate",
+          { todos, count: todos.length },
+          formatTodos(todos),
+        );
+      }
+    },
+
+    /**
+     * Chat message: capture the user prompt.
+     *
+     * Per-turn spore injection is intentionally not done here. A previous iteration
+     * injected spores via session.prompt({ noReply: true }) inside this handler, but
+     * opencode re-fires chat.message for the synthetic turn and the first real user
+     * message landed during the re-entrancy window. Agents can fetch context on
+     * demand via the myco_context and myco_search MCP tools.
+     *
+     * The `synthetic` flag check is kept as a cheap guard against re-entry from
+     * the session-start digest injection.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    "chat.message": async (input: any, output: any) => {
+      const sessionId = input?.sessionID;
+      if (!sessionId) return;
+
+      const allParts = (output?.parts ?? []) as Array<{
+        type?: string;
+        text?: string;
+        synthetic?: boolean;
+      }>;
+      // Skip our own injected synthetic turns — they're not real user prompts.
+      if (allParts.some((p) => p.synthetic === true)) return;
+
+      const textParts = allParts
+        .filter((p) => p.type === "text" && p.text)
+        .map((p) => p.text as string);
+      const prompt = textParts.join("\n");
+      if (!prompt) return;
+
+      await mycoPostUserPrompt(directory, sessionId, prompt);
+    },
+
+    /**
+     * Post-tool execution: ship tool usage to Myco.
+     *
+     * We forward `input.args` as `tool_input` — NOT `output.metadata` — because
+     * `args` carries the tool invocation arguments (including `filePath` for
+     * write/edit/patch tools), which Myco's plan-capture matcher needs to detect
+     * writes to .opencode/plans/*.md.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    "tool.execute.after": async (input: any, output: any) => {
+      const sessionId = input?.sessionID;
+      if (!sessionId) return;
+
+      const toolName = input?.tool ?? "unknown";
+      const toolInput = input?.args ?? output?.metadata ?? {};
+      const toolOutput = summarizeToolOutput(output?.output);
+
+      await mycoPostToolUse(directory, sessionId, toolName, toolInput, toolOutput);
+    },
+
+    /**
+     * Compaction hook: fires BEFORE opencode generates a continuation summary
+     * during session compaction. Pushing the digest into output.context ensures
+     * Myco's project knowledge survives compaction rather than being dropped.
+     *
+     * See https://opencode.ai/docs/plugins/#compaction-hooks
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    "experimental.session.compacting": async (_input: any, output: any) => {
+      const digest = await fetchMycoDigest(directory);
+      if (!digest) return;
+
+      if (Array.isArray(output?.context)) {
+        output.context.push(COMPACTION_HEADING + digest);
+      }
+    },
+  };
+};
+
+export default MycoPlugin;

--- a/src/symbionts/templates/opencode/plugin.ts
+++ b/src/symbionts/templates/opencode/plugin.ts
@@ -388,9 +388,17 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
 
         let responseSummary = "";
         try {
+          // `limit` is a tail-limit in opencode's server (returns the last N
+          // messages in chronological order — verified empirically against
+          // opencode v1.4.1 via `opencode serve`). A small bound is safe
+          // because session.idle fires at end-of-turn, so the last assistant
+          // message is always within the tail window. Using 5 (not 1) gives
+          // headroom for multi-message turns where the model produces
+          // reasoning → tool_use → final text across several assistant
+          // messages; we still find the last text part via the backward scan.
           const result = await client.session.messages({
             path: { id: sessionId },
-            query: { directory },
+            query: { directory, limit: 5 },
           });
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const messages = ((result as any)?.data ?? []) as SessionMessage[];

--- a/src/symbionts/templates/opencode/plugin.ts
+++ b/src/symbionts/templates/opencode/plugin.ts
@@ -7,12 +7,19 @@
 // Myco daemon over HTTP — no subprocess spawns, no hook CLI, no stdin piping.
 //
 //   Capture: POST /sessions/register, /sessions/unregister, /events, /events/stop
-//   Context: GET  /api/digest, POST /context/prompt
+//   Context: GET  /api/digest
 //   Inject:  client.session.prompt({ noReply: true, parts: [{ synthetic: true }] })
 //
 // See https://opencode.ai/docs/plugins/
+//
+// Contributor safety: this plugin has NO external runtime imports — only node:fs
+// and node:path (Node builtins). An OSS contributor who clones the repo without
+// having Myco installed will still have opencode load this plugin successfully.
+// Every path that would contact Myco gracefully no-ops when `.myco/daemon.json`
+// is absent or the daemon is unreachable, so the plugin becomes invisible rather
+// than throwing. Do NOT add runtime imports from @opencode-ai/plugin or any other
+// package — that would break the no-op guarantee.
 
-import type { Plugin } from "@opencode-ai/plugin";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -233,13 +240,29 @@ function summarizeToolOutput(output: unknown): string {
 // Plugin entry
 // ---------------------------------------------------------------------------
 
-export const MycoPlugin: Plugin = async ({ client, directory, worktree }) => {
-  await client.app.log({
-    service: "myco",
-    level: "info",
-    message: "Myco plugin initialized",
-    extra: { directory, worktree },
-  });
+/**
+ * Opencode plugin entry. The function signature matches opencode's Plugin type
+ * via duck typing — we deliberately do NOT import the Plugin type from
+ * @opencode-ai/plugin so the plugin file has zero external runtime dependencies
+ * and contributors without Myco installed experience a silent no-op.
+ *
+ * @param {{ client: any, directory: string, worktree: string }} ctx
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const MycoPlugin = async ({ client, directory, worktree }: { client: any; directory: string; worktree: string }) => {
+  // Best-effort init log. Wrapped in try-catch so a future SDK shape change in
+  // opencode (e.g. client.app.log moving) cannot prevent the plugin from
+  // registering its handlers.
+  try {
+    await client.app.log({
+      service: "myco",
+      level: "info",
+      message: "Myco plugin initialized",
+      extra: { directory, worktree },
+    });
+  } catch {
+    // Swallow — init log is diagnostic only.
+  }
 
   return {
     /**

--- a/src/symbionts/templates/opencode/plugin.ts
+++ b/src/symbionts/templates/opencode/plugin.ts
@@ -500,14 +500,22 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         text?: string;
         mime?: string;
         url?: string;
+        synthetic?: boolean;
         metadata?: { [key: string]: unknown };
       }>;
       // Skip if any part carries the Myco metadata marker — that means
       // chat.message is firing for our own injectSyntheticContext call.
       if (allParts.some((p) => p.metadata?.[MYCO_METADATA_MARKER] === true)) return;
 
+      // Prompt text = user's real text only. opencode emits `synthetic: true`
+      // text parts for internal scaffolding when the message contains file
+      // mentions, plan-mode switches, subagent tasks, and similar — see
+      // packages/opencode/src/session/prompt.ts. Those parts include full
+      // file contents, tool-call scaffolding, plan instructions, etc. Joining
+      // them into prompt_text would bloat every captured user prompt with
+      // system-level content that the user never typed.
       const textParts = allParts
-        .filter((p) => p.type === "text" && p.text)
+        .filter((p) => p.type === "text" && p.text && p.synthetic !== true)
         .map((p) => p.text as string);
       const prompt = textParts.join("\n");
       if (!prompt) return;

--- a/src/symbionts/templates/opencode/plugin.ts
+++ b/src/symbionts/templates/opencode/plugin.ts
@@ -40,6 +40,9 @@ const TOOL_OUTPUT_PREVIEW_CHARS = 200;
 /** Timeout for daemon HTTP calls — must be short so we never block opencode. */
 const MYCO_FETCH_TIMEOUT_MS = 3000;
 
+/** Tail window read from opencode when building the end-of-turn assistant summary. */
+const SESSION_IDLE_TAIL_LIMIT = 12;
+
 /** Heading prefix for compaction context — makes Myco's contribution recognizable in the compacted summary. */
 const COMPACTION_HEADING = "## Myco — Project Context (preserved across compaction)\n\n";
 
@@ -57,6 +60,70 @@ const COMPACTION_HEADING = "## Myco — Project Context (preserved across compac
  * to silently drop in live testing.
  */
 const MYCO_METADATA_MARKER = "myco";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type MessagePart = { type?: string; text?: string };
+type SessionMessage = { info?: { role?: string }; parts?: MessagePart[] };
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function pickString(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+export function normalizeToolInput(toolInput: unknown): unknown {
+  if (!isRecord(toolInput)) return toolInput;
+
+  const filePath = pickString(toolInput, ["file_path", "filePath", "path"]);
+  const workdir = pickString(toolInput, ["workdir", "cwd"]);
+  const command = pickString(toolInput, ["command", "cmd"]);
+
+  return {
+    ...toolInput,
+    ...(filePath ? { file_path: filePath } : {}),
+    ...(workdir ? { workdir } : {}),
+    ...(command ? { command } : {}),
+  };
+}
+
+export function collectAssistantSummaryFromMessages(messages: SessionMessage[]): string {
+  const summaryParts: string[] = [];
+  let foundAssistantBlock = false;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message?.info?.role !== "assistant") {
+      if (foundAssistantBlock) break;
+      continue;
+    }
+
+    foundAssistantBlock = true;
+    const text = (message.parts ?? [])
+      .filter((part) => part.type === "text" && part.text)
+      .map((part) => part.text as string)
+      .join("\n")
+      .trim();
+    if (text) summaryParts.unshift(text);
+  }
+
+  return summaryParts.join("\n").trim();
+}
 
 // ---------------------------------------------------------------------------
 // Daemon HTTP transport — all communication with the local Myco daemon.
@@ -358,10 +425,6 @@ async function injectSyntheticContext(
   }
 }
 
-// ---------------------------------------------------------------------------
-// Small helpers
-// ---------------------------------------------------------------------------
-
 /** Flatten todo items into a newline-separated summary. */
 function formatTodos(
   todos: Array<{ id?: string; content?: string; status?: string }>,
@@ -471,37 +534,20 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         if (!sessionId) return;
 
         // Fetch the last assistant message for a response summary.
-        // Narrow local types for walking the messages response — avoids scattered
-        // `any` casts inside the loop while keeping the SDK boundary cast isolated.
-        type MessagePart = { type?: string; text?: string };
-        type SessionMessage = { info?: { role?: string }; parts?: MessagePart[] };
-
         let responseSummary = "";
         try {
           // `limit` is a tail-limit in opencode's server (returns the last N
           // messages in chronological order — verified empirically against
-          // opencode v1.4.1 via `opencode serve`). A small bound is safe
-          // because session.idle fires at end-of-turn, so the last assistant
-          // message is always within the tail window. Using 5 (not 1) gives
-          // headroom for multi-message turns where the model produces
-          // reasoning → tool_use → final text across several assistant
-          // messages; we still find the last text part via the backward scan.
+          // opencode v1.4.1 via `opencode serve`). The tail window is large
+          // enough to capture a multi-message assistant block at end-of-turn
+          // without reading the full session history on every idle event.
           const result = await client.session.messages({
             path: { id: sessionId },
-            query: { directory, limit: 5 },
+            query: { directory, limit: SESSION_IDLE_TAIL_LIMIT },
           });
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const messages = ((result as any)?.data ?? []) as SessionMessage[];
-          for (let i = messages.length - 1; i >= 0; i--) {
-            const msg = messages[i];
-            if (msg?.info?.role === "assistant") {
-              const textParts = (msg.parts ?? [])
-                .filter((p) => p.type === "text" && p.text)
-                .map((p) => p.text as string);
-              responseSummary = textParts.join("\n");
-              break;
-            }
-          }
+          responseSummary = collectAssistantSummaryFromMessages(messages);
         } catch (err) {
           // eslint-disable-next-line no-console
           console.error("[myco] Failed to fetch messages for summary:", err);
@@ -612,7 +658,7 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
       if (!sessionId) return;
 
       const toolName = input?.tool ?? "unknown";
-      const toolInput = input?.args ?? output?.metadata ?? {};
+      const toolInput = normalizeToolInput(input?.args ?? output?.metadata ?? {});
       const toolOutput = summarizeToolOutput(output?.output);
 
       await mycoPostToolUse(directory, sessionId, toolName, toolInput, toolOutput);

--- a/src/symbionts/templates/opencode/plugin.ts
+++ b/src/symbionts/templates/opencode/plugin.ts
@@ -43,6 +43,21 @@ const MYCO_FETCH_TIMEOUT_MS = 3000;
 /** Heading prefix for compaction context — makes Myco's contribution recognizable in the compacted summary. */
 const COMPACTION_HEADING = "## Myco — Project Context (preserved across compaction)\n\n";
 
+/**
+ * Marker set on the `metadata` field of every synthetic TextPartInput this
+ * plugin injects via `client.session.prompt({ noReply: true, ... })`. The
+ * `chat.message` handler checks for this marker and skips matching messages
+ * so the injection doesn't re-enter as if it were a new user prompt.
+ *
+ * Why not the `synthetic` flag? opencode's own prompt.ts uses `synthetic: true`
+ * for ~20 distinct internal purposes (plan-mode prompts, build-switch
+ * transitions, subagent task summaries, shell-impl wrappers). Filtering on
+ * the synthetic flag rejects legitimate user messages whenever opencode has
+ * appended one of its own synthetic parts — which caused real user prompts
+ * to silently drop in live testing.
+ */
+const MYCO_METADATA_MARKER = "myco";
+
 // ---------------------------------------------------------------------------
 // Daemon HTTP transport — all communication with the local Myco daemon.
 // Every function is best-effort: failures are swallowed so the plugin cannot
@@ -253,8 +268,11 @@ async function fetchMycoSessionContext(
 
 /**
  * Inject text into an opencode session as a synthetic (plugin-authored) user turn
- * without triggering an AI response. Used for session-start and per-prompt context
- * injection. Errors are swallowed — injection is best-effort.
+ * without triggering an AI response. The text part carries:
+ *   - `synthetic: true` so opencode's TUI hides it from the chat log
+ *   - `metadata.myco: true` so our own `chat.message` handler can distinguish
+ *     this re-entry from a real user message (see MYCO_METADATA_MARKER)
+ * Errors are swallowed — injection is best-effort.
  */
 async function injectSyntheticContext(
   client: unknown,
@@ -267,7 +285,14 @@ async function injectSyntheticContext(
     await c.session.prompt({
       path: { id: sessionId },
       body: {
-        parts: [{ type: "text", text, synthetic: true }],
+        parts: [
+          {
+            type: "text",
+            text,
+            synthetic: true,
+            metadata: { [MYCO_METADATA_MARKER]: true },
+          },
+        ],
         noReply: true,
       },
     });
@@ -445,7 +470,7 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
     },
 
     /**
-     * Chat message: capture the user prompt.
+     * Chat message: capture the user prompt + any image attachments.
      *
      * Per-turn spore injection is intentionally not done here. A previous iteration
      * injected spores via session.prompt({ noReply: true }) inside this handler, but
@@ -453,8 +478,13 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
      * message landed during the re-entrancy window. Agents can fetch context on
      * demand via the myco_context and myco_search MCP tools.
      *
-     * The `synthetic` flag check is kept as a cheap guard against re-entry from
-     * the session-start digest injection.
+     * Re-entrancy guard: we check for `metadata.myco === true` on any part to
+     * detect our session-start digest injection coming back around. Opencode
+     * itself sets `synthetic: true` for many internal purposes (plan-mode
+     * prompts, build-switch transitions, subagent task summaries), so the
+     * `synthetic` flag alone is NOT reliable as a re-entrancy signal — it
+     * would silently drop any user prompt that opencode touched for one of
+     * those internal reasons.
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     "chat.message": async (input: any, output: any) => {
@@ -470,10 +500,11 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         text?: string;
         mime?: string;
         url?: string;
-        synthetic?: boolean;
+        metadata?: { [key: string]: unknown };
       }>;
-      // Skip our own injected synthetic turns — they're not real user prompts.
-      if (allParts.some((p) => p.synthetic === true)) return;
+      // Skip if any part carries the Myco metadata marker — that means
+      // chat.message is firing for our own injectSyntheticContext call.
+      if (allParts.some((p) => p.metadata?.[MYCO_METADATA_MARKER] === true)) return;
 
       const textParts = allParts
         .filter((p) => p.type === "text" && p.text)

--- a/src/symbionts/templates/opencode/settings.json
+++ b/src/symbionts/templates/opencode/settings.json
@@ -2,7 +2,7 @@
   "permission": {
     "bash": {
       "myco-run *": "allow",
-      "node .agents/myco-hook.cjs *": "allow"
+      "myco *": "allow"
     }
   }
 }

--- a/src/symbionts/templates/opencode/settings.json
+++ b/src/symbionts/templates/opencode/settings.json
@@ -1,0 +1,8 @@
+{
+  "permission": {
+    "bash": {
+      "myco-run *": "allow",
+      "node .agents/myco-hook.cjs *": "allow"
+    }
+  }
+}

--- a/tests/daemon/capture-images.test.ts
+++ b/tests/daemon/capture-images.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for the shared image-attachment persistence helper.
+ *
+ * Called by both stop-processing.ts (claude-code/cursor transcript path) and
+ * event-dispatch.ts (opencode plugin user_prompt path), so the same function
+ * must handle both callers' shapes.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
+import { upsertSession } from '@myco/db/queries/sessions.js';
+import { insertBatch } from '@myco/db/queries/batches.js';
+import { getDatabase } from '@myco/db/client.js';
+import { captureBatchImages } from '@myco/daemon/capture-images.js';
+import type { DaemonLogger } from '@myco/daemon/logger.js';
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+/** Minimal logger stub — captures calls without side effects. */
+function stubLogger(): DaemonLogger {
+  const calls: Array<{ level: string; kind: string; message: string; data?: unknown }> = [];
+  const noop = (level: string) => (kind: string, message: string, data?: unknown) => {
+    calls.push({ level, kind, message, data });
+  };
+  return {
+    debug: noop('debug'),
+    info: noop('info'),
+    warn: noop('warn'),
+    error: noop('error'),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+/** 1x1 transparent PNG encoded as base64 — smallest valid PNG. */
+const PNG_1x1 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9ZuUKhUAAAAASUVORK5CYII=';
+
+describe('captureBatchImages', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => { cleanTestDb(); });
+
+  it('inserts an attachment row from a base64 image', () => {
+    const sessionId = 'test-captureimg-001';
+    const now = epochNow();
+    upsertSession({ id: sessionId, agent: 'opencode', started_at: now, created_at: now });
+    const batch = insertBatch({
+      session_id: sessionId,
+      prompt_number: 1,
+      user_prompt: 'look at this',
+      started_at: now,
+      created_at: now,
+    });
+
+    captureBatchImages({
+      sessionId,
+      promptBatchId: batch.id,
+      promptNumber: 1,
+      images: [{ data: PNG_1x1, mediaType: 'image/png' }],
+      logger: stubLogger(),
+    });
+
+    const rows = getDatabase()
+      .prepare('SELECT id, session_id, prompt_batch_id, file_path, media_type FROM attachments WHERE session_id = ?')
+      .all(sessionId) as Array<Record<string, unknown>>;
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].prompt_batch_id).toBe(batch.id);
+    expect(rows[0].media_type).toBe('image/png');
+    expect(String(rows[0].file_path)).toMatch(/\.png$/);
+    expect(String(rows[0].file_path)).toMatch(/-t1-1\.png$/); // promptNumber 1, image index 1
+    expect(String(rows[0].id)).toMatch(/-b1-1$/);
+  });
+
+  it('handles multiple images in a single batch with distinct IDs', () => {
+    const sessionId = 'test-captureimg-002';
+    const now = epochNow();
+    upsertSession({ id: sessionId, agent: 'opencode', started_at: now, created_at: now });
+    const batch = insertBatch({
+      session_id: sessionId,
+      prompt_number: 3,
+      user_prompt: 'multi',
+      started_at: now,
+      created_at: now,
+    });
+
+    captureBatchImages({
+      sessionId,
+      promptBatchId: batch.id,
+      promptNumber: 3,
+      images: [
+        { data: PNG_1x1, mediaType: 'image/png' },
+        { data: PNG_1x1, mediaType: 'image/jpeg' },
+        { data: PNG_1x1, mediaType: 'image/webp' },
+      ],
+      logger: stubLogger(),
+    });
+
+    const rows = getDatabase()
+      .prepare('SELECT id, file_path, media_type FROM attachments WHERE session_id = ? ORDER BY id')
+      .all(sessionId) as Array<Record<string, unknown>>;
+
+    expect(rows).toHaveLength(3);
+    // Each image gets a unique ID ending in -b3-{1,2,3}
+    expect(rows.map((r) => String(r.id)).every((id) => id.includes('-b3-'))).toBe(true);
+    // Extensions reflect the mime types
+    expect(rows.map((r) => String(r.file_path))).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/\.png$/),
+        expect.stringMatching(/\.jpg$/),
+        expect.stringMatching(/\.webp$/),
+      ]),
+    );
+  });
+
+  it('is idempotent under replay — duplicate calls do not create duplicate rows', () => {
+    const sessionId = 'test-captureimg-003';
+    const now = epochNow();
+    upsertSession({ id: sessionId, agent: 'opencode', started_at: now, created_at: now });
+    const batch = insertBatch({
+      session_id: sessionId,
+      prompt_number: 1,
+      user_prompt: 'replay',
+      started_at: now,
+      created_at: now,
+    });
+
+    const image = { data: PNG_1x1, mediaType: 'image/png' };
+
+    // First capture
+    captureBatchImages({
+      sessionId,
+      promptBatchId: batch.id,
+      promptNumber: 1,
+      images: [image],
+      logger: stubLogger(),
+    });
+    // Same call again — simulates a stop-event replay or plugin retry
+    captureBatchImages({
+      sessionId,
+      promptBatchId: batch.id,
+      promptNumber: 1,
+      images: [image],
+      logger: stubLogger(),
+    });
+
+    const rows = getDatabase()
+      .prepare('SELECT id FROM attachments WHERE session_id = ?')
+      .all(sessionId) as Array<Record<string, unknown>>;
+
+    expect(rows).toHaveLength(1); // ON CONFLICT DO NOTHING
+  });
+
+  it('skips images with missing data or mediaType', () => {
+    const sessionId = 'test-captureimg-004';
+    const now = epochNow();
+    upsertSession({ id: sessionId, agent: 'opencode', started_at: now, created_at: now });
+    const batch = insertBatch({
+      session_id: sessionId,
+      prompt_number: 1,
+      user_prompt: 'partial',
+      started_at: now,
+      created_at: now,
+    });
+
+    captureBatchImages({
+      sessionId,
+      promptBatchId: batch.id,
+      promptNumber: 1,
+      images: [
+        { data: '', mediaType: 'image/png' }, // empty data — skip
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { data: PNG_1x1, mediaType: '' as any }, // empty mediaType — skip
+        { data: PNG_1x1, mediaType: 'image/png' }, // valid
+      ],
+      logger: stubLogger(),
+    });
+
+    const rows = getDatabase()
+      .prepare('SELECT id FROM attachments WHERE session_id = ?')
+      .all(sessionId) as Array<Record<string, unknown>>;
+
+    // Only the valid image landed. Note: the first two skipped images mean the
+    // valid image at index 2 lands with index suffix -b1-3 (1-based j+1).
+    expect(rows).toHaveLength(1);
+  });
+
+  it('no-ops on empty images array', () => {
+    const sessionId = 'test-captureimg-005';
+    const now = epochNow();
+    upsertSession({ id: sessionId, agent: 'opencode', started_at: now, created_at: now });
+
+    captureBatchImages({
+      sessionId,
+      promptBatchId: null,
+      promptNumber: 1,
+      images: [],
+      logger: stubLogger(),
+    });
+
+    const rows = getDatabase()
+      .prepare('SELECT id FROM attachments WHERE session_id = ?')
+      .all(sessionId);
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('allows null promptBatchId (fallback path for transcript-mined images without matched batch)', () => {
+    const sessionId = 'test-captureimg-006';
+    const now = epochNow();
+    upsertSession({ id: sessionId, agent: 'claude-code', started_at: now, created_at: now });
+
+    captureBatchImages({
+      sessionId,
+      promptBatchId: null,
+      promptNumber: 5,
+      images: [{ data: PNG_1x1, mediaType: 'image/png' }],
+      logger: stubLogger(),
+    });
+
+    const rows = getDatabase()
+      .prepare('SELECT id, prompt_batch_id FROM attachments WHERE session_id = ?')
+      .all(sessionId) as Array<Record<string, unknown>>;
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].prompt_batch_id).toBeNull();
+  });
+});

--- a/tests/daemon/capture.test.ts
+++ b/tests/daemon/capture.test.ts
@@ -148,6 +148,24 @@ describe('daemon capture flow', () => {
     expect(activities[0].tool_name).toBe('Read');
   });
 
+  it('extracts file_path from camelCase filePath tool input', async () => {
+    const sessionId = 'test-session-opencode-filepath';
+    const now = epochNow();
+
+    upsertSession({
+      id: sessionId,
+      agent: 'opencode',
+      started_at: now,
+      created_at: now,
+    });
+
+    handleToolUse(sessionId, 'edit', { filePath: '/tmp/opencode.ts' }, 'updated');
+
+    const activities = listActivities({ session_id: sessionId });
+    expect(activities.length).toBe(1);
+    expect(activities[0].file_path).toBe('/tmp/opencode.ts');
+  });
+
   it('handles stop with no open batch — session stays active', async () => {
     const sessionId = 'test-session-empty';
     const now = epochNow();
@@ -686,6 +704,18 @@ describe('new event type handlers', () => {
 
       const activities = listActivities({ session_id: sessionId });
       expect(activities[0].file_path).toBe('/tmp/readonly.ts');
+    });
+
+    it('extracts camelCase filePath from failed opencode tool input', async () => {
+      const sessionId = 'test-tool-failure-004';
+      const now = epochNow();
+
+      upsertSession({ id: sessionId, agent: 'opencode', started_at: now, created_at: now });
+
+      handleToolFailure(sessionId, 'edit', { filePath: '/tmp/opencode-readonly.ts' }, 'EACCES', false);
+
+      const activities = listActivities({ session_id: sessionId });
+      expect(activities[0].file_path).toBe('/tmp/opencode-readonly.ts');
     });
   });
 

--- a/tests/daemon/jobs/session-maintenance.test.ts
+++ b/tests/daemon/jobs/session-maintenance.test.ts
@@ -102,35 +102,56 @@ describe('findDeadSessionIds', () => {
   afterAll(() => { teardownTestDb(); });
   beforeEach(() => { cleanTestDb(); });
 
-  it('returns sessions with 0 prompts', () => {
-    seedSession('dead-0', { promptCount: 0 });
+  it('returns completed sessions with 0 prompts', () => {
+    seedSession('dead-0', { promptCount: 0, status: 'completed' });
 
     const ids = findDeadSessionIds([]);
 
     expect(ids).toContain('dead-0');
   });
 
-  it('returns sessions with 1 prompt', () => {
-    seedSession('dead-1', { promptCount: 1 });
+  it('does NOT return sessions with 1 prompt (1-prompt sessions have captured work)', () => {
+    seedSession('alive-1prompt', { promptCount: 1, status: 'completed' });
 
     const ids = findDeadSessionIds([]);
 
-    expect(ids).toContain('dead-1');
+    expect(ids).not.toContain('alive-1prompt');
   });
 
-  it('skips sessions with 2+ prompts', () => {
-    seedSession('alive-1', { promptCount: 2 });
+  it('does NOT return sessions with 2+ prompts', () => {
+    seedSession('alive-2prompts', { promptCount: 2, status: 'completed' });
 
     const ids = findDeadSessionIds([]);
 
-    expect(ids).not.toContain('alive-1');
+    expect(ids).not.toContain('alive-2prompts');
+  });
+
+  it('does NOT return active sessions even if they have 0 prompts (race protection)', () => {
+    seedSession('fresh-session', { promptCount: 0, status: 'active' });
+
+    const ids = findDeadSessionIds([]);
+
+    expect(ids).not.toContain('fresh-session');
   });
 
   it('skips registered sessions', () => {
-    seedSession('reg-dead', { promptCount: 0 });
+    seedSession('reg-dead', { promptCount: 0, status: 'completed' });
 
     const ids = findDeadSessionIds(['reg-dead']);
 
     expect(ids).not.toContain('reg-dead');
+  });
+
+  it('regression: 1-prompt session that made real changes survives cleanup (opencode test case)', () => {
+    // During live opencode testing, a session that had exactly 1 user prompt
+    // produced a real code change (LogTable.tsx sticky header, committed).
+    // The session was auto-deleted within ~45s of TUI exit because the old
+    // DEAD_SESSION_MAX_PROMPTS = 1 policy considered it "dead". This test
+    // pins the protection so that regression can't recur.
+    seedSession('ses_opencode_realwork', { promptCount: 1, status: 'completed' });
+
+    const ids = findDeadSessionIds([]);
+
+    expect(ids).not.toContain('ses_opencode_realwork');
   });
 });

--- a/tests/daemon/plan-capture.test.ts
+++ b/tests/daemon/plan-capture.test.ts
@@ -161,6 +161,51 @@ describe('isPlanWriteEvent', () => {
     expect(isPlanWriteEvent('Write', { file_path: '/home/user/myproject/docs/plans/c.ts' }, cfg))
       .toBeNull();
   });
+
+  // opencode tool conventions: lowercase tool names, camelCase filePath
+  // Without these, opencode Plan mode writes to .opencode/plans/*.md are silently dropped.
+
+  it('matches opencode lowercase write tool', () => {
+    expect(isPlanWriteEvent('write', { file_path: 'docs/plans/sprint.md' }, base))
+      .toBe('docs/plans/sprint.md');
+  });
+
+  it('matches opencode lowercase edit tool', () => {
+    expect(isPlanWriteEvent('edit', { file_path: 'docs/plans/sprint.md' }, base))
+      .toBe('docs/plans/sprint.md');
+  });
+
+  it('matches opencode patch tool (unified-diff applier)', () => {
+    expect(isPlanWriteEvent('patch', { file_path: 'docs/plans/sprint.md' }, base))
+      .toBe('docs/plans/sprint.md');
+  });
+
+  it('matches opencode lowercase create tool', () => {
+    expect(isPlanWriteEvent('create', { file_path: 'docs/plans/new.md' }, base))
+      .toBe('docs/plans/new.md');
+  });
+
+  it('extracts path from camelCase filePath field (opencode convention)', () => {
+    expect(isPlanWriteEvent('write', { filePath: 'docs/plans/sprint.md' }, base))
+      .toBe('docs/plans/sprint.md');
+  });
+
+  it('combined: opencode lowercase tool + camelCase filePath field', () => {
+    expect(isPlanWriteEvent('edit', { filePath: 'docs/plans/feature.md' }, base))
+      .toBe('docs/plans/feature.md');
+  });
+
+  it('still prefers snake_case file_path over camelCase filePath when both present', () => {
+    expect(isPlanWriteEvent('write', {
+      file_path: 'docs/plans/a.md',
+      filePath: 'docs/plans/b.md',
+    }, base)).toBe('docs/plans/a.md');
+  });
+
+  it('regression: Claude Code PascalCase Write still works alongside lowercase addition', () => {
+    expect(isPlanWriteEvent('Write', { file_path: '/home/user/myproject/docs/plans/sprint.md' }, base))
+      .toBe('/home/user/myproject/docs/plans/sprint.md');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/symbionts/installer.test.ts
+++ b/tests/symbionts/installer.test.ts
@@ -120,6 +120,39 @@ const WINDSURF_MANIFEST: SymbiontManifest = {
   },
 };
 
+const OPENCODE_MANIFEST: SymbiontManifest = {
+  name: 'opencode',
+  displayName: 'OpenCode',
+  binary: 'opencode',
+  configDir: '.opencode',
+  pluginRootEnvVar: 'OPENCODE_PLUGIN_ROOT',
+  hookFields: { transcriptPath: 'transcript_path', lastResponse: 'last_assistant_message', sessionId: 'session_id' },
+  registration: {
+    hooksTarget: '.opencode/plugins/myco.ts',
+    hooksFormat: 'plugin-file',
+    pluginPackageTarget: '.opencode/package.json',
+    mcpTarget: 'opencode.json',
+    mcpServersKey: 'mcp',
+    settingsTarget: 'opencode.json',
+    skillsTarget: '.agents/skills',
+  },
+};
+
+/** Fixture content written as the opencode plugin.ts template in tests. */
+const OPENCODE_PLUGIN_TEMPLATE_CONTENT = `// Managed by Myco. Regenerated on \`myco update\`.
+// myco:plugin-marker:opencode
+import type { Plugin } from "@opencode-ai/plugin";
+export const MycoPlugin: Plugin = async () => ({});
+export default MycoPlugin;
+`;
+
+const OPENCODE_PACKAGE_TEMPLATE_CONTENT = `{
+  "dependencies": {
+    "@opencode-ai/plugin": "^1.1.59"
+  }
+}
+`;
+
 // --- Minimal hooks template for tests ---
 
 const HOOKS_TEMPLATE = {
@@ -221,6 +254,18 @@ function setupPackageRoot(): void {
   writeJson(path.join(windsurfTemplateDir, 'hooks.json'), {
     pre_user_prompt: [{ command: 'node .agents/myco-hook.cjs hook user-prompt-submit' }],
     post_cascade_response: [{ command: 'node .agents/myco-hook.cjs hook stop' }],
+  });
+
+  // opencode uses plugin-file hooks + non-standard MCP key + a package.json for plugin deps
+  const opencodeTemplateDir = path.join(packageRoot, 'src/symbionts/templates/opencode');
+  fs.mkdirSync(opencodeTemplateDir, { recursive: true });
+  fs.writeFileSync(path.join(opencodeTemplateDir, 'plugin.ts'), OPENCODE_PLUGIN_TEMPLATE_CONTENT, 'utf-8');
+  fs.writeFileSync(path.join(opencodeTemplateDir, 'package.json'), OPENCODE_PACKAGE_TEMPLATE_CONTENT, 'utf-8');
+  writeJson(path.join(opencodeTemplateDir, 'mcp.json'), {
+    myco: { type: 'local', command: ['myco-run', 'mcp'] },
+  });
+  writeJson(path.join(opencodeTemplateDir, 'settings.json'), {
+    permission: { bash: { 'myco-run *': 'allow', 'node .agents/myco-hook.cjs *': 'allow' } },
   });
 
   // Copy hook-guard template so installHookGuard can find it
@@ -1662,6 +1707,158 @@ describe('hook template validation', () => {
         }
       }
     }
+  });
+});
+
+// =====================
+// opencode — plugin-file hooks + non-standard MCP key
+// =====================
+
+describe('opencode (plugin-file hooks)', () => {
+  it('install writes the plugin file verbatim with marker', () => {
+    const installer = new SymbiontInstaller(OPENCODE_MANIFEST, projectRoot, packageRoot);
+    const result = installer.install();
+
+    expect(result.hooks).toBe(true);
+    const pluginPath = path.join(projectRoot, '.opencode/plugins/myco.ts');
+    const written = fs.readFileSync(pluginPath, 'utf-8');
+    expect(written).toBe(OPENCODE_PLUGIN_TEMPLATE_CONTENT);
+    expect(written).toContain('myco:plugin-marker:opencode');
+  });
+
+  it('installPluginHookFile is content-diff gated (idempotent)', () => {
+    const installer = new SymbiontInstaller(OPENCODE_MANIFEST, projectRoot, packageRoot);
+    installer.install();
+
+    // Second install: hooks should be skipped because the file is already current.
+    // We can only observe this via the returned boolean (false = no-op).
+    const second = installer.install();
+    expect(second.hooks).toBe(false);
+  });
+
+  it('install writes plugin deps package.json', () => {
+    const installer = new SymbiontInstaller(OPENCODE_MANIFEST, projectRoot, packageRoot);
+    const result = installer.install();
+
+    expect(result.pluginPackage).toBe(true);
+    const pkgPath = path.join(projectRoot, '.opencode/package.json');
+    const written = fs.readFileSync(pkgPath, 'utf-8');
+    expect(written).toBe(OPENCODE_PACKAGE_TEMPLATE_CONTENT);
+    expect(JSON.parse(written)).toHaveProperty('dependencies.@opencode-ai/plugin');
+  });
+
+  it('installPluginPackage is content-diff gated', () => {
+    const installer = new SymbiontInstaller(OPENCODE_MANIFEST, projectRoot, packageRoot);
+    installer.install();
+    const second = installer.install();
+    expect(second.pluginPackage).toBe(false);
+  });
+
+  it('uninstall deletes plugin file when marker present', () => {
+    const installer = new SymbiontInstaller(OPENCODE_MANIFEST, projectRoot, packageRoot);
+    installer.install();
+    const pluginPath = path.join(projectRoot, '.opencode/plugins/myco.ts');
+    expect(fs.existsSync(pluginPath)).toBe(true);
+
+    const result = installer.uninstall();
+    expect(result.hooks).toBe(true);
+    expect(fs.existsSync(pluginPath)).toBe(false);
+  });
+
+  it('uninstall preserves hand-edited plugin file without marker', () => {
+    const pluginDir = path.join(projectRoot, '.opencode/plugins');
+    fs.mkdirSync(pluginDir, { recursive: true });
+    const pluginPath = path.join(pluginDir, 'myco.ts');
+    const handEdited = '// I am not a Myco-managed file\nexport default async () => ({});\n';
+    fs.writeFileSync(pluginPath, handEdited, 'utf-8');
+
+    const installer = new SymbiontInstaller(OPENCODE_MANIFEST, projectRoot, packageRoot);
+    const result = installer.uninstall();
+    expect(result.hooks).toBe(false);
+    expect(fs.readFileSync(pluginPath, 'utf-8')).toBe(handEdited);
+  });
+
+  it('uninstall preserves plugin deps package.json for contributor-added deps', () => {
+    const installer = new SymbiontInstaller(OPENCODE_MANIFEST, projectRoot, packageRoot);
+    installer.install();
+    const pkgPath = path.join(projectRoot, '.opencode/package.json');
+    expect(fs.existsSync(pkgPath)).toBe(true);
+
+    installer.uninstall();
+    // Plan: package.json is intentionally left in place — contributors may add their own deps.
+    expect(fs.existsSync(pkgPath)).toBe(true);
+  });
+
+  it('MCP entries are written under the custom mcpServersKey', () => {
+    const installer = new SymbiontInstaller(OPENCODE_MANIFEST, projectRoot, packageRoot);
+    installer.install();
+
+    const openCodeJson = readJson(path.join(projectRoot, 'opencode.json'));
+    // opencode uses 'mcp' not 'mcpServers'
+    expect(openCodeJson).toHaveProperty('mcp');
+    expect(openCodeJson).not.toHaveProperty('mcpServers');
+    const mcp = openCodeJson.mcp as Record<string, unknown>;
+    expect(mcp).toHaveProperty('myco');
+  });
+
+  it('array-form MCP command entries round-trip verbatim', () => {
+    const installer = new SymbiontInstaller(OPENCODE_MANIFEST, projectRoot, packageRoot);
+    installer.install();
+
+    const openCodeJson = readJson(path.join(projectRoot, 'opencode.json'));
+    const myco = (openCodeJson.mcp as Record<string, unknown>).myco as Record<string, unknown>;
+    // opencode's MCP entry shape: { type: "local", command: ["myco-run", "mcp"] }
+    expect(myco.type).toBe('local');
+    expect(myco.command).toEqual(['myco-run', 'mcp']);
+  });
+
+  it('uninstall removes only the myco MCP entry and leaves other servers intact', () => {
+    // Seed opencode.json with an unrelated MCP server
+    const openCodeJsonPath = path.join(projectRoot, 'opencode.json');
+    writeJson(openCodeJsonPath, {
+      mcp: {
+        otherSdk: { type: 'local', command: ['other', 'mcp'] },
+      },
+    });
+
+    const installer = new SymbiontInstaller(OPENCODE_MANIFEST, projectRoot, packageRoot);
+    installer.install();
+    installer.uninstall();
+
+    const after = readJson(openCodeJsonPath);
+    const mcp = after.mcp as Record<string, unknown> | undefined;
+    expect(mcp).toBeDefined();
+    expect(mcp).toHaveProperty('otherSdk');
+    expect(mcp).not.toHaveProperty('myco');
+  });
+
+  it('permission settings are merged under opencode.json permission key', () => {
+    const installer = new SymbiontInstaller(OPENCODE_MANIFEST, projectRoot, packageRoot);
+    installer.install();
+
+    const openCodeJson = readJson(path.join(projectRoot, 'opencode.json'));
+    const permission = openCodeJson.permission as Record<string, Record<string, string>>;
+    expect(permission.bash['myco-run *']).toBe('allow');
+    expect(permission.bash['node .agents/myco-hook.cjs *']).toBe('allow');
+  });
+
+  it('opencode does not trigger batched JSON install (hooks target is .ts)', () => {
+    const installer = new SymbiontInstaller(OPENCODE_MANIFEST, projectRoot, packageRoot);
+    // If the batched path incorrectly tried to JSON.parse the plugin .ts file,
+    // the install would throw. Success means the non-batched path ran.
+    expect(() => installer.install()).not.toThrow();
+
+    // Plugin file is the verbatim TS, NOT JSON
+    const plugin = fs.readFileSync(path.join(projectRoot, '.opencode/plugins/myco.ts'), 'utf-8');
+    expect(() => JSON.parse(plugin)).toThrow();
+  });
+
+  it('hook guard is installed for opencode', () => {
+    const installer = new SymbiontInstaller(OPENCODE_MANIFEST, projectRoot, packageRoot);
+    installer.install();
+
+    const guardPath = path.join(projectRoot, '.agents/myco-hook.cjs');
+    expect(fs.existsSync(guardPath)).toBe(true);
   });
 });
 

--- a/tests/symbionts/opencode-plugin.test.ts
+++ b/tests/symbionts/opencode-plugin.test.ts
@@ -1,0 +1,142 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  MycoPlugin,
+  collectAssistantSummaryFromMessages,
+  normalizeToolInput,
+} from '../../src/symbionts/templates/opencode/plugin.ts';
+
+function createProjectDir(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-opencode-plugin-'));
+  fs.mkdirSync(path.join(directory, '.myco'), { recursive: true });
+  fs.writeFileSync(
+    path.join(directory, '.myco', 'daemon.json'),
+    JSON.stringify({ port: 32123 }),
+    'utf-8',
+  );
+  return directory;
+}
+
+describe('opencode plugin helpers', () => {
+  it('normalizes high-signal tool metadata aliases', () => {
+    expect(
+      normalizeToolInput({
+        filePath: 'src/plugin.ts',
+        cwd: '/repo',
+        command: 'npm test',
+      }),
+    ).toEqual({
+      filePath: 'src/plugin.ts',
+      cwd: '/repo',
+      command: 'npm test',
+      file_path: 'src/plugin.ts',
+      workdir: '/repo',
+    });
+  });
+
+  it('collects the latest contiguous assistant block', () => {
+    const summary = collectAssistantSummaryFromMessages([
+      { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'older assistant block' }] },
+      { info: { role: 'user' }, parts: [{ type: 'text', text: 'new prompt' }] },
+      { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'step 1' }] },
+      { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'step 2' }] },
+    ]);
+
+    expect(summary).toBe('step 1\nstep 2');
+  });
+
+  it('ignores assistant messages without text parts', () => {
+    const summary = collectAssistantSummaryFromMessages([
+      { info: { role: 'assistant' }, parts: [{ type: 'tool_use' }] },
+      { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'final answer' }] },
+    ]);
+
+    expect(summary).toBe('final answer');
+  });
+});
+
+describe('opencode plugin runtime hooks', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('posts a richer assistant summary on session.idle', async () => {
+    const directory = createProjectDir();
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const client = {
+      app: { log: vi.fn().mockResolvedValue(undefined) },
+      session: {
+        messages: vi.fn().mockResolvedValue({
+          data: [
+            { info: { role: 'user' }, parts: [{ type: 'text', text: 'prompt' }] },
+            { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'first chunk' }] },
+            { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'second chunk' }] },
+          ],
+        }),
+      },
+    };
+
+    const plugin = await MycoPlugin({ client, directory, worktree: directory });
+    await plugin.event({ event: { type: 'session.idle', properties: { sessionID: 'ses-opencode-1' } } });
+
+    expect(client.session.messages).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://localhost:32123/events/stop');
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      session_id: 'ses-opencode-1',
+      agent: 'opencode',
+      last_assistant_message: 'first chunk\nsecond chunk',
+    });
+  });
+
+  it('normalizes tool metadata before posting tool_use events', async () => {
+    const directory = createProjectDir();
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const client = {
+      app: { log: vi.fn().mockResolvedValue(undefined) },
+      session: { messages: vi.fn() },
+    };
+
+    const plugin = await MycoPlugin({ client, directory, worktree: directory });
+    await plugin['tool.execute.after'](
+      {
+        sessionID: 'ses-opencode-2',
+        tool: 'edit',
+        args: {
+          filePath: 'src/foo.ts',
+          cwd: '/repo',
+        },
+      },
+      {
+        output: 'updated',
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://localhost:32123/events');
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      type: 'tool_use',
+      session_id: 'ses-opencode-2',
+      tool_name: 'edit',
+      tool_input: {
+        filePath: 'src/foo.ts',
+        cwd: '/repo',
+        file_path: 'src/foo.ts',
+        workdir: '/repo',
+      },
+      output_preview: 'updated',
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     }
   },
   "include": ["src/**/*", "plugin/**/*"],
-  "exclude": ["node_modules", "dist", "tests", "ui", "src/worker"]
+  "exclude": ["node_modules", "dist", "tests", "ui", "src/worker", "src/symbionts/templates"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -109,22 +109,18 @@ export default defineConfig({
       cpSync(workerSrc, 'dist/src/worker', { recursive: true });
     }
 
-    // Copy symbiont registration templates (JSON per agent + shared .md)
+    // Copy symbiont registration templates (per-agent dirs + shared root files)
     const symbiontTemplates = 'src/symbionts/templates';
     if (existsSync(symbiontTemplates)) {
       const destBase = 'dist/src/symbionts/templates';
       mkdirSync(destBase, { recursive: true });
       for (const entry of readdirSync(symbiontTemplates, { withFileTypes: true })) {
         if (entry.isDirectory()) {
-          // Per-agent template directories (JSON files)
+          // Per-agent template directories — copy everything (JSON, plugin source, package.json, etc.)
+          // so plugin-file agents like opencode ship their verbatim plugin file alongside JSON templates.
           const srcDir = path.join(symbiontTemplates, entry.name);
           const destDir = path.join(destBase, entry.name);
-          mkdirSync(destDir, { recursive: true });
-          for (const file of readdirSync(srcDir)) {
-            if (file.endsWith('.json')) {
-              copyFileSync(path.join(srcDir, file), path.join(destDir, file));
-            }
-          }
+          cpSync(srcDir, destDir, { recursive: true });
         } else if (entry.isFile()) {
           // Shared templates (root-level files like hook-guard.cjs, instructions-stub.md)
           copyFileSync(path.join(symbiontTemplates, entry.name), path.join(destBase, entry.name));

--- a/ui/src/components/logs/LogTable.tsx
+++ b/ui/src/components/logs/LogTable.tsx
@@ -126,6 +126,16 @@ export function LogTable({
         </div>
       ) : (
         <table className="w-full border-collapse" aria-label="Log entries">
+          <thead className="sticky top-0 z-10 bg-surface-container-lowest/95 backdrop-blur supports-[backdrop-filter]:bg-surface-container-lowest/80">
+            <tr className="border-b border-outline-variant/10 text-[10px] uppercase tracking-[0.16em] text-on-surface-variant/50">
+              <th className="w-[68px] px-3 py-2 text-left font-medium">Time</th>
+              <th className="w-[12px] px-0 py-2" aria-hidden="true" />
+              <th className="w-[48px] px-0 py-2 text-left font-medium">Level</th>
+              <th className="w-[90px] px-0 py-2 text-left font-medium">Area</th>
+              <th className="w-[72px] px-0 py-2 text-left font-medium">Session</th>
+              <th className="px-3 py-2 text-left font-medium">Message</th>
+            </tr>
+          </thead>
           <tbody>
             {entries.map((entry) => (
               <LogRow


### PR DESCRIPTION
## Summary

- Adds **opencode** as Myco's seventh symbiont — the first plugin-based integration, where hooks are a verbatim TypeScript plugin file (`.opencode/plugins/myco.ts`) rather than JSON merged into a settings file. The plugin talks directly to the Myco daemon over HTTP for capture, context, and injection.
- Extends the SymbiontInstaller with three agent-agnostic manifest fields (`hooksFormat`, `pluginPackageTarget`, `mcpServersKey`) so opencode fits cleanly alongside the existing JSON-hook symbionts without special-casing.
- Fixes a latent Claude Code plan-capture bug along the way: the claude-code manifest was watching project-local `.claude/plans/`, but Claude Code's plan mode actually writes to `~/.claude/plans/`. Claude Code plans were never being captured — now they are.
- Hardens `src/daemon/plan-capture.ts` for lowercase tool names (opencode uses `write`/`edit`/`patch`) and camelCase `filePath` argument keys — benefits any future agent with similar conventions.

## What opencode gets

| Capability | How |
|---|---|
| Session lifecycle | `event: session.created` → `POST /sessions/register`; `event: session.deleted` → `POST /sessions/unregister` |
| User prompts | `chat.message` hook → `POST /events { type: 'user_prompt' }` |
| Tool calls | `tool.execute.after` → `POST /events { type: 'tool_use' }` (forwards `input.args` as `tool_input` so `filePath` reaches plan-capture) |
| AI response summary | `event: session.idle` → fetch last assistant message via `client.session.messages` → `POST /events/stop { last_assistant_message }` |
| Session-start digest injection | `event: session.created` → `GET /api/digest` → `client.session.prompt({ noReply: true, parts: [{ type: 'text', text: digest, synthetic: true }] })` — model orients on project state before the user's first turn |
| Compaction context survival | `experimental.session.compacting` → `GET /api/digest` → `output.context.push(...)` — keeps Myco's project knowledge across opencode's compaction summary pass |
| MCP server | `opencode.json` `mcp.myco` with `{ type: "local", command: ["myco-run", "mcp"] }` — opencode's non-standard MCP key is handled via the new `mcpServersKey` manifest field |
| Auto-approvals | `opencode.json` `permission.bash`: `myco-run *`, `myco *` |

## Validated end-to-end

- Full lifecycle capture in a real opencode session (`ses_28c238235ffeCxaXHO64Kphpvx`): 2 prompts, 10 tool calls, response summaries, correct agent label.
- Session-start digest injection: the model answered a project-specific question without any tool calls on the first turn, purely from the injected digest.
- Claude Code plan capture: our own work-in-progress plan at `~/.claude/plans/indexed-drifting-lantern.md` is now captured in the vault after the manifest fix landed.
- Plan capture pipeline (synthetic test through real hook CLI): end-to-end validated for opencode's tool name + argument conventions.
- Teammate-without-Myco no-op: simulated a cloned project without `.myco/daemon.json`; all plugin HTTP paths returned null cleanly with no errors thrown. Plugin has zero non-Node-builtin runtime imports.
- 1910 tests passing (21 new cases: 13 installer, 8 plan-capture).
- `myco-dev init` + `update` + `doctor` + `remove --symbiont opencode` all work cleanly against opencode.

## Architectural decisions

### Direct HTTP, not shell subprocess
Earlier iterations of the plugin shelled out via Bun's `$` to `node .agents/myco-hook.cjs hook <name>`, mirroring how other symbionts call into Myco. Two problems surfaced:
- CWD / path resolution quirks in the spawned subprocess.
- The subprocess went through `src/hooks/normalize.ts`, which silently defaulted to `'claude-code'` when no `pluginRootEnvVar` matched — so every opencode event was getting tagged `agent: 'claude-code'` in the daemon.

The plugin now POSTs directly to the daemon's existing endpoints (`/sessions/register`, `/sessions/unregister`, `/events`, `/events/stop`, `/api/digest`) with explicit `agent: 'opencode'` in every body. No subprocess, no env-based agent detection, no hook guard needed.

### Zero runtime dependencies
The plugin file imports ONLY `node:fs` and `node:path`. The `Plugin` type from `@opencode-ai/plugin` is annotated inline (duck-typed) rather than imported. This is a hard constraint: the plugin is committed into downstream projects that have run `myco init`, and teammates of those projects may clone without having Myco installed locally. Opencode will still load and execute the plugin in that case, so every path that would touch Myco has to degrade gracefully to a silent no-op.

Safety measures:
- `readDaemonPort` returns `null` when `.myco/daemon.json` is absent (it's in `VAULT_GITIGNORE`, so clones without Myco init never have it).
- `fetchWithTimeout` has a 3 s abort and swallows errors.
- All `postJson`, `fetchMycoDigest`, and `injectSyntheticContext` calls degrade to null / no-op on failure.
- Every handler early-returns on missing `sessionID`.
- The init `client.app.log` call is wrapped in try-catch so a future opencode SDK-shape change cannot block handler registration.

### Session-start injection only (for now)
An earlier iteration also injected per-turn spore context from within `chat.message`. It created a re-entrancy loop: opencode fires `chat.message` for the synthetic noReply turn we inject, and a per-session injection lock I added to guard against that wound up blocking the real user's first prompt when it landed within the lock window. Per-turn injection is deferred until we understand opencode's `chat.message` re-entrancy semantics better. Agents can still fetch context on demand via the `myco_context` and `myco_search` MCP tools.

## Also in this PR (but broader in scope)

- **`src/daemon/plan-capture.ts`**: `FILE_WRITE_TOOLS` widened for lowercase tool names, `isPlanWriteEvent` accepts camelCase `filePath` in addition to `file_path` / `path`. Benefits any agent with opencode-style conventions.
- **`src/symbionts/manifests/claude-code.yaml`**: adds `~/.claude/plans/` to `capture.planDirs`. Claude Code plan mode writes to `$HOME`, not project-local — this was a silent bug that meant no Claude Code plans were ever getting captured.
- **`src/cli/doctor.ts`**: resolves MCP key via `manifest.mcpServersKey` instead of hardcoding `mcpServers`. Without this, `myco doctor` reported opencode as "not registered" even when the MCP entry was present (just under the `mcp` key instead of `mcpServers`).
- **`src/mcp/tool-definitions.ts`**: tightened `myco_context` tool description to guide agents toward session-start use — affects all symbionts, not just opencode.
- **`tsup.config.ts`**: per-agent template dirs now use `cpSync` (whole subtree) instead of `.json`-only filter, so `plugin.ts` and `package.json` land in `dist/`.
- **`tsconfig.json`**: excludes `src/symbionts/templates` from tsc (templates are static assets; `plugin.ts` imports symbols from `@opencode-ai/plugin` which isn't a Myco dependency).

## Documentation

- **`AGENTS.md`** — "Add a new symbiont" golden path refreshed; opencode added to the supported agents list; transcript adapter marked optional.
- **`.agents/skills/add-symbiont/SKILL.md`** — full rewrite to match the current auto-discovery manifest model. Drops stale content (`defaultEnabled` field, `SYMBIONT_MANIFESTS` registry, shell-script hook examples, the "Class 1 vs Class 2" distinction) and documents the new plugin-file hook variant with the `hooksFormat` / `pluginPackageTarget` / `mcpServersKey` escape hatches.

## Test plan

- [ ] `make check` passes (currently 1910 tests green)
- [ ] `make build` passes
- [ ] Fresh `myco-dev init` in a throwaway directory with `.opencode/` — confirm opencode is registered with hooks / MCP / skills / settings / plugin deps
- [ ] `myco-dev update` is idempotent (no-op on a clean install)
- [ ] `myco-dev doctor` reports opencode as registered
- [ ] `myco-dev remove --symbiont opencode` cleans up plugin file, MCP entry, permission settings (but preserves `.opencode/package.json` since contributors may add their own deps)
- [ ] Start opencode in the myco repo and verify the plugin initializes (log at `~/.local/share/opencode/log/*.log`)
- [ ] Submit a prompt and confirm `user_prompt` events reach the daemon with `agent: opencode`
- [ ] Trigger a tool call and confirm `tool_use` events reach the daemon
- [ ] Confirm response summary is populated on stop
- [ ] Confirm the model references project-specific content in the first turn without any tool calls (proves digest injection)
- [ ] Explicit plan write test: create `.opencode/plans/test.md` in Build mode, switch to Plan mode, ask opencode to fill it in, confirm plan is captured in the vault

## Known follow-ups (not blocking)

- **`DEFAULT_AGENT_NAME` → `DEFAULT_SYMBIONT_NAME`** rename in `src/hooks/normalize.ts`, plus a better fallback than silently defaulting to claude-code when no `pluginRootEnvVar` matches. Surfaced during opencode debug when events routed through the shell subprocess path were getting mislabeled as claude-code.
- **Per-turn spore injection** via `chat.message` — deferred pending more research on opencode's re-entrancy semantics. Agents still have MCP on-demand access.
- **Compaction hook** is validated by inspection only (matches opencode docs example exactly) — a runtime test requires triggering a real compaction cycle.
- **Opencode Plan mode UX quirk** — `write` is disabled even in Plan mode; only `edit` gets the `.opencode/plans/*.md` exception. Plan files must exist on disk before entering Plan mode, or the agent will refuse ("plan mode is read-only"). Worth documenting in AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)