### PR TITLE
feat: opencode resume context

### DIFF
--- a/.agents/skills/debug-daemon-errors/SKILL.md
+++ b/.agents/skills/debug-daemon-errors/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: myco:debug-daemon-errors
+description: |
+  Use this skill whenever the Myco daemon is misbehaving — even if the user doesn't explicitly ask for a debugging procedure. Activates for: daemon process crashes, uncaught exceptions, FK constraint violations, PowerManager jobs not firing, scheduler starvation, outbox drain loops, duplicate or phantom sessions, executor tasks that silently succeed or stall, and any log output from the daemon's core subsystems (PowerManager, SQLite, outbox, session lifecycle, phased executor). This is the cross-cutting playbook for investigating, tracing, and surgically fixing daemon-layer bugs — distinct from debugging agent task YAML, schema migrations, or outbox architecture design.
+managed_by: myco
+user-invocable: true
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+# Debug Production Daemon Errors
+
+The Myco daemon is a long-running process that hosts multiple subsystems: a PowerManager job scheduler, SQLite-backed state, an outbox drain loop, session lifecycle tracking, and a phased task executor. Bugs in each subsystem have distinct failure signatures and require different surgical fixes. This skill teaches you how to identify which subsystem is implicated, trace to the root cause, apply a minimal fix, and prevent regression.
+
+## Prerequisites
+
+- Daemon is running (or you have daemon logs from a failed run)
+- You have access to the SQLite vault at `.myco/vault.db`
+- You can restart the daemon process to confirm a fix
+
+---
+
+## Step 1 — Read the Logs Before Touching Code
+
+Daemon logs are the ground truth. Before forming any hypothesis, capture the exact sequence of events.
+
+```bash
+# Tail live daemon output
+myco daemon:logs --follow
+
+# Or inspect the log file directly
+cat ~/.myco/daemon.log | tail -200
+```
+
+Look for the **first anomalous line**, not just the error message. The error is often a symptom thrown several steps after the actual cause. Record:
+- The timestamp of the first unexpected event
+- The subsystem prefix in the log line (e.g., `[PowerManager]`, `[Outbox]`, `[Session]`, `[Executor]`)
+- Whether the error is a hard crash, a silent return, or a loop
+
+**Pitfall:** Don't jump to fixing based on the exception message alone. `FOREIGN KEY constraint failed` looks like a schema bug but is almost always a deletion order problem. `Task completed` with no output is a status-swallowing bug in the executor, not a task configuration issue.
+
+---
+
+## Step 2 — Map the Error to Its Subsystem
+
+Each daemon subsystem has a distinct failure signature:
+
+| Subsystem | Failure Signature |
+|-----------|------------------|
+| **PowerManager** | A registered job stops firing after initial runs; scheduler log goes quiet; work is inserted but nothing picks it up |
+| **SQLite FK cascade** | `FOREIGN KEY constraint failed` on delete; or orphaned child rows after parent deletion |
+| **Outbox drain** | Drain runs on every tick but the same records never leave; loop visible in logs with no progress |
+| **Session lifecycle** | Two sessions created for one conversation; session ID missing mid-run; `sessionStart` fires twice |
+| **Session maintenance** | Active sessions vanish mid-run; sessions deleted with no explicit error; real sessions treated as dead |
+| **Executor (phased tasks)** | Task status transitions to `complete` or `failed` silently; no error thrown; output is empty |
+
+Map your log output to one of these categories. If you're unsure, search the daemon source for the log prefix:
+
+```bash
+# Find where a log line originates
+grep -rn "your log text here" src/daemon/
+```
+
+---
+
+## Step 3 — Trace the Root Cause (Subsystem Playbooks)
+
+### PowerManager — Scheduler Starvation
+
+The scheduler wakes on a timer OR when work is inserted. If new work is inserted but the scheduler doesn't wake, the job starves until the next timer tick (which may be minutes away).
+
+**Trace:** Check whether `scheduleNextRun` or the equivalent wake signal is called immediately after inserting the new work row. If the insert happens in a code path that doesn't call the wake signal, the scheduler won't pick it up until the next interval.
+
+**Fix pattern:**
+```typescript
+// After inserting work, explicitly wake the scheduler
+await db.insert(workTable).values(newWork);
+scheduler.wake(); // <-- ensure this exists in every insert path
+```
+
+Search for all places that insert into the work/job table and confirm each one wakes the scheduler:
+```bash
+grep -rn "insert.*work\|insert.*job\|insert.*task" src/daemon/ --include="*.ts"
+```
+
+---
+
+### SQLite FK Cascade — Wrong Deletion Order
+
+SQLite enforces FK constraints at statement time, not transaction commit time. If you delete a parent row before its child rows, the constraint fires immediately even inside a transaction.
+
+**Trace:** Identify the parent–child relationship from the error. Check the schema:
+```bash
+sqlite3 .myco/vault.db ".schema"
+```
+
+Look for `REFERENCES parent_table(id)` on the table mentioned in the error.
+
+**Fix pattern:** Always delete children before parents, in the same transaction:
+```typescript
+await db.transaction(async (tx) => {
+  await tx.delete(childTable).where(eq(childTable.parentId, id));
+  await tx.delete(parentTable).where(eq(parentTable.id, id));
+});
+```
+
+**Pitfall:** If there are multiple levels of FK nesting (grandchild → child → parent), delete from the leaf up. Draw the dependency tree before writing the delete sequence.
+
+---
+
+### Outbox Drain — Backfill Loop
+
+If the outbox drain processes a record, marks it as sent, but then the same record re-appears on the next tick, look for a backfill path that resets the status without a guard.
+
+**Trace:** Add a temporary log before the status update to confirm whether the record is being re-inserted or re-flagged:
+```bash
+grep -rn "approved_at\|outbox.*status\|drain.*update" src/daemon/ --include="*.ts"
+```
+
+**Fix pattern:** Guard the status transition so it only applies on first promotion:
+```typescript
+// Only set approved_at if it hasn't been set yet
+if (!record.approved_at) {
+  await db.update(outbox)
+    .set({ approved_at: new Date() })
+    .where(eq(outbox.id, record.id));
+}
+```
+
+Without this guard, any backfill or re-survey will reset `approved_at` on records already processed, causing them to drain again.
+
+---
+
+### Session Lifecycle — Re-entrancy / Phantom Sessions
+
+If a second session is created for the same conversation, look for a code path that creates a session without checking whether one already exists for the incoming session ID.
+
+**Trace:** Search for all session creation sites:
+```bash
+grep -rn "createSession\|insertSession\|sessions.*insert" src/daemon/ --include="*.ts"
+```
+
+For each creation site, check whether it guards against duplicates:
+```typescript
+// Bad — no guard
+const session = await db.insert(sessions).values({ id: incomingId, ... });
+
+// Good — check first
+const existing = await db.select().from(sessions).where(eq(sessions.id, incomingId)).get();
+if (!existing) {
+  await db.insert(sessions).values({ id: incomingId, ... });
+}
+```
+
+The session ID (from the hook payload) is the source of truth. If the hook fires twice for the same session, the second fire should be a no-op, not a second insert.
+
+---
+
+### Session Maintenance — Over-Aggressive Dead-Session Cleanup
+
+If real, in-progress sessions vanish mid-run with no explicit error, the session maintenance job's `findDeadSessionIds()` may be deleting them.
+
+This failure mode has two independent compounding bugs (spore `1cf8bbc9`):
+
+1. **`DEAD_SESSION_MAX_PROMPTS` threshold too high** — if set to `1`, any session with ≤1 prompt is eligible for deletion. A legitimate session that has started but only received one prompt is wiped. The correct value is `0`: only sessions with zero prompts are truly dead (they were registered but never sent any content).
+
+2. **Missing `status != 'active'` filter** — `findDeadSessionIds()` ran against ALL sessions regardless of status. An active, in-progress session with few prompts could be selected. The filter must exclude any session where `status = 'active'`.
+
+**Trace:** Check `src/daemon/jobs/session-maintenance.ts` (or equivalent) for both issues:
+```bash
+grep -rn "DEAD_SESSION_MAX_PROMPTS\|findDeadSessionIds\|status.*active" src/daemon/ --include="*.ts"
+```
+
+**Fix pattern:**
+```typescript
+// In constants.ts or the maintenance job
+const DEAD_SESSION_MAX_PROMPTS = 0; // only truly empty sessions qualify
+
+// In findDeadSessionIds()
+export function findDeadSessionIds(registeredSessionIds: string[]): string[] {
+  return db.select({ id: sessions.id })
+    .from(sessions)
+    .where(
+      and(
+        lte(sessions.promptCount, DEAD_SESSION_MAX_PROMPTS),
+        ne(sessions.status, 'active'),          // <-- required guard
+        notInArray(sessions.id, registeredSessionIds),
+      )
+    )
+    .all()
+    .map(r => r.id);
+}
+```
+
+**Pitfall:** Both bugs must be fixed together. Fixing only the threshold (setting it to `0`) still leaves the `status` gap — a real session with zero prompts that is actively registered but not yet in `registeredSessionIds` can still be deleted. Fixing only the `status` filter still allows sessions with `prompt_count = 1` to be deleted if `DEAD_SESSION_MAX_PROMPTS = 1`. Always apply both guards.
+
+---
+
+### Executor — Status Swallowing
+
+If an executor task transitions to a terminal status (`complete`, `failed`) without producing output or logging an error, the executor is catching an exception and recording "success" rather than propagating the failure.
+
+**Trace:** Find the executor's task runner loop and look for broad `try/catch` blocks that swallow errors:
+```bash
+grep -rn "catch\|status.*complete\|status.*failed" src/daemon/executor/ --include="*.ts"
+```
+
+**Fix pattern:** Distinguish between expected task completion and unexpected errors. Never record `complete` inside a `catch` block unless you're explicitly handling a known-recoverable error:
+```typescript
+try {
+  const result = await runPhase(task, phase);
+  await markComplete(task.id, result);
+} catch (err) {
+  // Don't swallow — mark failed and surface the error
+  await markFailed(task.id, err.message);
+  logger.error('[Executor] Phase failed', { taskId: task.id, err });
+  throw err; // re-throw if the outer loop should also know
+}
+```
+
+---
+
+## Step 4 — Write the Regression Test First
+
+Before applying the fix, write a test that fails with the current code. This confirms you've correctly identified the root cause and gives you a green signal to trust after the fix.
+
+Tests for daemon subsystems live in:
+- `src/daemon/__tests__/` — unit tests for individual subsystem functions
+- `tests/integration/` — integration tests that spin up the daemon
+
+Write the smallest test that reproduces the failure. For FK violations, this is usually an in-memory SQLite test. For scheduler starvation, mock the wake signal and assert it's called.
+
+---
+
+## Step 5 — Apply the Fix and Verify
+
+1. Apply the minimal surgical fix — change only what's needed to address the root cause.
+2. Run the targeted test first: confirm it goes green.
+3. Run the full test suite:
+   ```bash
+   npm test
+   ```
+4. Restart the daemon and smoke-test the affected subsystem:
+   ```bash
+   myco daemon:restart
+   myco daemon:logs --follow
+   ```
+5. Confirm no adjacent regressions in the log output.
+
+**Pitfall:** Resist the urge to refactor while fixing. The goal is a minimal change that surgically addresses the root cause. Larger refactors should be separate commits with their own test coverage.
+
+---
+
+## Quick Reference — Error to Fix Map
+
+| Error / Symptom | Likely Cause | Fix |
+|----------------|--------------|-----|
+| `FOREIGN KEY constraint failed` on delete | Wrong deletion order | Delete children before parents |
+| Job registered but never fires | Scheduler not woken after insert | Call `scheduler.wake()` after inserting work |
+| Outbox drain loops without progress | Missing `approved_at` guard | Guard status transitions to set value only once |
+| Two sessions for one conversation | No duplicate guard on session insert | Check for existing session ID before insert |
+| Sessions vanish mid-run, no explicit error | `findDeadSessionIds()` too aggressive | Set `DEAD_SESSION_MAX_PROMPTS = 0`; add `status != 'active'` filter |
+| Task status = `complete`, no output | Exception swallowed in executor | Separate success path from catch block; mark failed on error |

--- a/.agents/skills/harden-agent-harness/SKILL.md
+++ b/.agents/skills/harden-agent-harness/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: myco:harden-agent-harness
+description: Apply this skill whenever you add a new agent task (src/agent/tasks/) or MCP tool (src/mcp/tools/) to the Myco project — even if the user doesn't explicitly ask about safety. Every new task and tool must be hardened with three interlocking controls before shipping: (1) readOnly MCP annotations on non-mutating tools, (2) global enable/disable toggle wiring at the daemon's registration and trigger boundaries, and (3) phase-level readOnly enforcement in task YAML. This skill covers the gap left by register-mcp-tool (which covers tool anatomy but not readOnly annotations) and author-and-debug-agent-pipeline-tasks (which covers task YAML but not harness safety controls). Also apply when auditing existing tasks for missing safety controls or debugging toggle-related test failures.
+managed_by: myco
+user-invocable: true
+allowed-tools: [Read, Write, Edit, Bash]
+version: 1
+tags:
+  - agent-harness
+  - safety
+  - readOnly
+  - mcp
+  - testing
+  - agent-tasks
+---
+
+# Hardening a Myco Agent Task or MCP Tool
+
+## When to Use
+
+**Do apply this skill when:**
+- Creating any new file under `src/agent/tasks/` (pipeline tasks)
+- Creating any new file under `src/mcp/tools/` (MCP tools)
+- Auditing an existing task or tool for missing safety controls
+- Debugging failures related to `readOnly`, toggle flags, or phase enforcement
+
+**Do NOT use for:**
+- Debugging LLM behavior or hallucinations inside tasks → use `author-and-debug-agent-pipeline-tasks`
+- Adding MCP tool anatomy (Zod schema, server.ts registration) → use `register-mcp-tool`
+- Modifying the config write path → use `safe-config-updates`
+
+---
+
+## Control 1: MCP `readOnly` Annotation
+
+**File:** The tool definition object in `src/mcp/tools/<tool-name>.ts`
+
+Add `readOnly: true` to any tool that does not mutate vault state:
+
+```typescript
+// src/mcp/tools/vault-read-digest.ts
+export const vaultReadDigestTool = {
+  name: "vault_read_digest",
+  description: "...",
+  readOnly: true,          // ← required for read-only tools
+  inputSchema: {
+    type: "object",
+    properties: { /* ... */ },
+  },
+};
+```
+
+**Classification rules:**
+- `vault_read_*`, `vault_search_*`, `vault_spores`, `vault_entities`, `vault_edges` → add `readOnly: true`
+- `vault_create_*`, `vault_update_*`, `vault_resolve_*`, `vault_write_*`, `vault_mark_*` → omit `readOnly`
+
+The MCP host uses this annotation to decide whether to show a confirmation dialog. Tools marked `readOnly: true` skip the confirmation step.
+
+**Gotcha:** Annotating a mutating tool as `readOnly: true` silently suppresses the MCP host's confirmation dialog. The host trusts your annotation. Before marking a tool read-only, trace the full call chain (including DB writes and FS operations) to confirm no state mutation occurs anywhere in the path.
+
+---
+
+## Control 2: Global Toggle Gate
+
+**Config keys** in `myco.yaml`:
+
+```yaml
+agent:
+  scheduled_tasks_enabled: true   # controls cron/interval task registration
+  event_tasks_enabled: true       # controls hook-triggered task dispatch
+```
+
+**Enforcement lives at the daemon registration and trigger boundaries — not inside task execute functions.**
+
+### Scheduled tasks — gate in `registerScheduledTasks()`
+
+```typescript
+// src/daemon/task-scheduler.ts
+function registerScheduledTasks(config: MycoConfig) {
+  if (!config.agent?.scheduled_tasks_enabled) {
+    log.info("Scheduled tasks disabled — skipping all registration");
+    return;  // nothing registered; no LLM work starts
+  }
+  // ... register tasks with PowerManager ...
+}
+```
+
+When adding a new scheduled task, verify the `scheduled_tasks_enabled` check precedes all task registration in this function. The single registration-level gate covers all scheduled tasks — do not add per-task toggle checks inside each task's execute function.
+
+### Event-triggered tasks — gate in the trigger function
+
+```typescript
+// wherever event tasks are dispatched, e.g. triggerTitleSummary
+function triggerTitleSummary(sessionId: string, config: MycoConfig) {
+  if (!config.agent?.event_tasks_enabled) {
+    return;  // return early before any dispatch
+  }
+  // ... dispatch task ...
+}
+```
+
+When adding a new event-triggered task, add the `event_tasks_enabled` check at the start of its trigger function — before any async work or logging that would imply the task ran.
+
+### What NOT to do
+
+Do not add toggle checks inside a task's `execute()` function. By the time `execute()` is called, the task has already been dispatched — the gate must live at the outermost boundary (registration or trigger), not inside the task body.
+
+### Manual runs always work
+
+The **Run now** button in the Operations page UI bypasses both toggle flags and always executes the task immediately. This is intentional — developers retain an escape hatch to run tasks manually even when automatic execution is disabled.
+
+---
+
+## Control 3: Phase-Level `readOnly` Enforcement
+
+**File:** `src/agent/tasks/<task-name>.yaml`
+
+For pipeline tasks with multiple phases, mark each read-only phase explicitly:
+
+```yaml
+# src/agent/tasks/skill-generate.yaml
+phases:
+  - name: gather
+    readOnly: true          # this phase only reads; no writes allowed
+    description: Gather source material for the skill
+    tools:
+      - vault_spores
+      - vault_search_fts
+      - vault_skill_candidates
+      # list ONLY read-only tools here
+
+  - name: draft
+    readOnly: false         # this phase writes (vault_stage_skill)
+    description: Stage the skill content
+    tools:
+      - vault_stage_skill
+      - vault_skill_candidates
+```
+
+The executor enforces this contract: if a phase is marked `readOnly: true` and the LLM calls a write tool, the executor rejects the call with a gate error before the tool executes.
+
+**Why enforcement is in the tool layer, not the prompt:** Prompts are suggestions. A confused or token-pressured LLM might attempt a write despite instructions. The executor gate is deterministic and cannot be bypassed by the LLM's reasoning.
+
+**Gotcha — audit the tool list:** After setting `readOnly: true` on a phase, review its `tools:` list and remove any tool with write capability. A phase marked `readOnly: true` with a write tool in its `tools:` list is self-contradictory and will produce spurious gate errors when the LLM legitimately tries to use that tool.
+
+---
+
+## Control 4: Test Coverage
+
+Add at minimum three tests before shipping. Place them in `tests/` alongside the relevant file.
+
+### Test A — Toggle-off rejection
+
+```typescript
+it("does not register new task when scheduled_tasks_enabled is false", async () => {
+  const config = buildTestConfig({
+    agent: { scheduled_tasks_enabled: false, event_tasks_enabled: true },
+  });
+
+  const jobs = registerScheduledTasks(config);
+
+  expect(jobs).toHaveLength(0);
+  // or verify the specific task name is absent from jobs
+});
+```
+
+### Test B — Write rejected during readOnly phase
+
+```typescript
+it("rejects write tool call during readOnly phase", async () => {
+  const phase = { name: "gather", readOnly: true };
+
+  const result = await executor.callTool(
+    "vault_create_spore",
+    { observation_type: "gotcha", content: "test" },
+    { phase }
+  );
+
+  expect(result.isError).toBe(true);
+  expect(result.content[0].text).toContain("readOnly");
+});
+```
+
+### Test C — Happy-path enabled state
+
+```typescript
+it("registers new task when scheduled_tasks_enabled is true", async () => {
+  const config = buildTestConfig({
+    agent: { scheduled_tasks_enabled: true, event_tasks_enabled: true },
+  });
+
+  const jobs = registerScheduledTasks(config);
+
+  const taskNames = jobs.map((j) => j.name);
+  expect(taskNames).toContain("<your-new-task-name>");
+});
+```
+
+Use `buildTestConfig()` from `tests/helpers/` — do not construct config objects inline across multiple tests.
+
+---
+
+## Smoke Test
+
+```bash
+make build    # full quality gate: tsc + vitest + tsup + vite
+myco doctor   # confirm daemon sees the new task/tool cleanly
+```
+
+Then in the daemon UI (Operations → Agent Tasks):
+1. Toggle `scheduled_tasks_enabled` **OFF**
+2. Wait for the next scheduled tick — confirm the new task does **not** run
+3. Toggle **ON** — confirm the task runs on the next tick
+4. Hit **Run now** — confirm it executes immediately regardless of toggle state
+
+**Why live checks matter:** The toggle check reads config at registration time. If the daemon was not restarted after a `myco.yaml` change, the config cache may be stale and the toggle will behave unexpectedly in production despite passing unit tests. The live smoke test catches stale-cache failures that unit tests cannot.
+
+---
+
+## Pre-Ship Checklist
+
+- [ ] Read-only MCP tools have `readOnly: true` in their tool definition
+- [ ] Mutating tools do **not** have `readOnly: true`
+- [ ] `registerScheduledTasks()` checks `config.agent?.scheduled_tasks_enabled` before registering the new task
+- [ ] New event trigger function checks `config.agent?.event_tasks_enabled` before dispatching
+- [ ] Phase-level `readOnly: true` set in task YAML for all read-only phases
+- [ ] No write tools listed under `readOnly: true` phases
+- [ ] Tests A, B, and C passing
+- [ ] `make build` passes clean
+- [ ] Live smoke test with daemon UI toggle completed

--- a/.opencode/plugins/myco.ts
+++ b/.opencode/plugins/myco.ts
@@ -43,6 +43,9 @@ const MYCO_FETCH_TIMEOUT_MS = 3000;
 /** Tail window read from opencode when building the end-of-turn assistant summary. */
 const SESSION_IDLE_TAIL_LIMIT = 12;
 
+/** Max size of resume context injection to keep resumed sessions lean. */
+const RESUME_CONTEXT_MAX_CHARS = 4000;
+
 /** Heading prefix for compaction context — makes Myco's contribution recognizable in the compacted summary. */
 const COMPACTION_HEADING = "## Myco — Project Context (preserved across compaction)\n\n";
 
@@ -149,6 +152,9 @@ let cachedDaemonPort: number | null | undefined = undefined;
  * for each one when `server.instance.disposed` fires.
  */
 const activeOpencodeSessions = new Set<string>();
+
+/** Resume injections are process-local and should run at most once per session. */
+const resumeInjectedSessions = new Set<string>();
 
 /** Read the Myco daemon port from .myco/daemon.json in the project directory. */
 function readDaemonPortFromDisk(directory: string): number | null {
@@ -385,6 +391,37 @@ async function fetchMycoSessionContext(
   return text.length > 0 ? text : null;
 }
 
+/** Fetch a small resume recap for a resumed opencode session. */
+async function fetchMycoResumeContext(
+  directory: string,
+  sessionId: string,
+  parentSessionId: string,
+): Promise<string | null> {
+  const result = await postJson(directory, "/context/resume", {
+    session_id: sessionId,
+    parent_session_id: parentSessionId,
+  });
+  if (!result.ok) return null;
+  const data = result.data as { text?: string } | undefined;
+  const text = data?.text?.trim() ?? "";
+  if (!text || text.length > RESUME_CONTEXT_MAX_CHARS) return null;
+  return text;
+}
+
+/** Post a compaction telemetry event. */
+async function mycoPostCompact(
+  directory: string,
+  sessionId: string,
+  trigger: string | undefined,
+): Promise<void> {
+  await postEventWithBuffer(directory, sessionId, {
+    type: "pre_compact",
+    session_id: sessionId,
+    agent: "opencode",
+    ...(trigger ? { trigger } : {}),
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Opencode session injection — push synthetic context into session history.
 // ---------------------------------------------------------------------------
@@ -485,21 +522,23 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
 
         activeOpencodeSessions.add(sessionId);
 
-        // Run the capture (register session with Myco daemon) and context fetch
-        // concurrently — they don't depend on each other, and parallelizing saves
-        // one round-trip of latency before the user's first turn lands. Context
-        // is fetched only for fresh sessions; resume sessions inherit the parent's
-        // history and don't need another injection.
-        //
-        // Re-entrancy: the synthetic text part carries `synthetic: true`; if opencode
-        // fires chat.message for it, our handler's synthetic-flag check skips it.
+        const parentSessionId = info.parentID || undefined;
+        const contextPromise = parentSessionId
+          ? (resumeInjectedSessions.has(sessionId)
+            ? Promise.resolve(null)
+            : fetchMycoResumeContext(directory, sessionId, parentSessionId))
+          : fetchMycoSessionContext(directory, sessionId);
+
+        // Run registration and context fetch concurrently — they don't depend
+        // on each other, and parallelizing saves one round-trip of latency.
         const [, sessionContext] = await Promise.all([
-          mycoRegisterSession(directory, sessionId, info.parentID || undefined),
-          info.parentID ? Promise.resolve(null) : fetchMycoSessionContext(directory, sessionId),
+          mycoRegisterSession(directory, sessionId, parentSessionId),
+          contextPromise,
         ]);
 
         if (sessionContext) {
           await injectSyntheticContext(client, sessionId, sessionContext);
+          if (parentSessionId) resumeInjectedSessions.add(sessionId);
         }
         return;
       }
@@ -508,6 +547,7 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         const info = event.properties?.info ?? {};
         if (info.id) {
           activeOpencodeSessions.delete(info.id);
+          resumeInjectedSessions.delete(info.id);
           await mycoUnregisterSession(directory, info.id);
         }
         return;
@@ -525,6 +565,7 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         if (activeOpencodeSessions.size === 0) return;
         const toClose = Array.from(activeOpencodeSessions);
         activeOpencodeSessions.clear();
+        for (const id of toClose) resumeInjectedSessions.delete(id);
         await Promise.all(toClose.map((id) => mycoUnregisterSession(directory, id)));
         return;
       }
@@ -676,6 +717,8 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
     "experimental.session.compacting": async (input: any, output: any) => {
       const sessionId = input?.sessionID;
       if (!sessionId) return;
+
+      await mycoPostCompact(directory, sessionId, typeof input?.trigger === "string" ? input.trigger : undefined);
 
       const sessionContext = await fetchMycoSessionContext(directory, sessionId);
       if (!sessionContext) return;

--- a/src/daemon/api/context.ts
+++ b/src/daemon/api/context.ts
@@ -8,6 +8,7 @@
 import { z } from 'zod';
 import { getDigestExtract } from '@myco/db/queries/digest-extracts.js';
 import { hydrateSearchResults } from '@myco/db/queries/search.js';
+import { getSession } from '@myco/db/queries/sessions.js';
 import {
   DEFAULT_AGENT_ID,
   EXCLUDED_SPORE_STATUSES,
@@ -40,6 +41,12 @@ export interface ContextDeps {
 
 const SessionContextBody = z.object({
   session_id: z.string().optional(),
+  branch: z.string().optional(),
+});
+
+const ResumeContextBody = z.object({
+  session_id: z.string(),
+  parent_session_id: z.string().optional(),
   branch: z.string().optional(),
 });
 
@@ -119,6 +126,87 @@ export function createSessionContextHandler(deps: ContextDeps) {
       };
     } catch (error) {
       logger.error(LOG_KINDS.CONTEXT_SESSION, 'Session context failed', { error: (error as Error).message });
+      return { body: { text: '' } };
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Resume context handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a handler that injects a small resume-specific recap for opencode.
+ *
+ * Resume sessions already inherit their chat history, so this endpoint avoids
+ * repeating the full digest. It returns only a terse recap from the parent
+ * session when there is meaningful prior context to surface.
+ */
+export function createResumeContextHandler(deps: ContextDeps) {
+  return async function handleResumeContext(req: RouteRequest): Promise<RouteResponse> {
+    const { session_id, parent_session_id, branch } = ResumeContextBody.parse(req.body);
+    const { logger } = deps;
+
+    logger.debug(LOG_KINDS.CONTEXT_QUERY, 'Resume context query', {
+      session_id,
+      parent_session_id,
+    });
+
+    try {
+      const parentSession = parent_session_id ? getSession(parent_session_id) : null;
+      const resolvedBranch = branch ?? parentSession?.branch ?? null;
+      const parts: string[] = [];
+
+      if (parentSession?.title) {
+        parts.push(`Resuming work from: ${parentSession.title}`);
+      }
+
+      if (parentSession?.summary) {
+        parts.push(parentSession.summary);
+      }
+
+      if (resolvedBranch) {
+        parts.push(`Branch:: \`${resolvedBranch}\``);
+      }
+
+      if (parentSession && parent_session_id) {
+        parts.push(`Previous Session:: \`${parent_session_id}\``);
+      }
+
+      if (parts.length === 0) {
+        logger.debug(LOG_KINDS.CONTEXT_SESSION, 'No resume context available', { session_id, parent_session_id });
+        return { body: { text: '' } };
+      }
+
+      parts.push(`Session:: \`${session_id}\``);
+      const contextText = parts.join('\n\n');
+      const estimatedTokens = estimateTokens(contextText);
+
+      logger.info(
+        LOG_KINDS.CONTEXT_SESSION,
+        `Resume context: ${estimatedTokens} est. tokens`,
+        {
+          session_id,
+          parent_session_id,
+          branch: resolvedBranch ?? undefined,
+          text_length: contextText.length,
+          estimated_tokens: estimatedTokens,
+          injected_text: contextText,
+        },
+      );
+
+      return {
+        body: {
+          text: contextText,
+          source: 'resume',
+        },
+      };
+    } catch (error) {
+      logger.error(LOG_KINDS.CONTEXT_SESSION, 'Resume context failed', {
+        session_id,
+        parent_session_id,
+        error: (error as Error).message,
+      });
       return { body: { text: '' } };
     }
   };

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -59,7 +59,7 @@ import {
   handleGetDigest,
 } from './api/mycelium.js';
 import { createSearchHandler } from './api/search.js';
-import { createSessionContextHandler, createPromptContextHandler } from './api/context.js';
+import { createSessionContextHandler, createPromptContextHandler, createResumeContextHandler } from './api/context.js';
 import { handleGetFeed } from './api/feed.js';
 import { handleListSymbionts } from './api/symbionts.js';
 import {
@@ -390,6 +390,7 @@ export async function main(): Promise<void> {
   // --- Context injection (digest + semantic spore search) ---
   const contextDeps = { embeddingManager, config, logger };
   server.registerRoute('POST', '/context', createSessionContextHandler(contextDeps));
+  server.registerRoute('POST', '/context/resume', createResumeContextHandler(contextDeps));
   server.registerRoute('POST', '/context/prompt', createPromptContextHandler(contextDeps));
 
   // --- Dashboard API routes ---

--- a/src/symbionts/templates/opencode/plugin.ts
+++ b/src/symbionts/templates/opencode/plugin.ts
@@ -43,6 +43,9 @@ const MYCO_FETCH_TIMEOUT_MS = 3000;
 /** Tail window read from opencode when building the end-of-turn assistant summary. */
 const SESSION_IDLE_TAIL_LIMIT = 12;
 
+/** Max size of resume context injection to keep resumed sessions lean. */
+const RESUME_CONTEXT_MAX_CHARS = 4000;
+
 /** Heading prefix for compaction context — makes Myco's contribution recognizable in the compacted summary. */
 const COMPACTION_HEADING = "## Myco — Project Context (preserved across compaction)\n\n";
 
@@ -149,6 +152,9 @@ let cachedDaemonPort: number | null | undefined = undefined;
  * for each one when `server.instance.disposed` fires.
  */
 const activeOpencodeSessions = new Set<string>();
+
+/** Resume injections are process-local and should run at most once per session. */
+const resumeInjectedSessions = new Set<string>();
 
 /** Read the Myco daemon port from .myco/daemon.json in the project directory. */
 function readDaemonPortFromDisk(directory: string): number | null {
@@ -385,6 +391,37 @@ async function fetchMycoSessionContext(
   return text.length > 0 ? text : null;
 }
 
+/** Fetch a small resume recap for a resumed opencode session. */
+async function fetchMycoResumeContext(
+  directory: string,
+  sessionId: string,
+  parentSessionId: string,
+): Promise<string | null> {
+  const result = await postJson(directory, "/context/resume", {
+    session_id: sessionId,
+    parent_session_id: parentSessionId,
+  });
+  if (!result.ok) return null;
+  const data = result.data as { text?: string } | undefined;
+  const text = data?.text?.trim() ?? "";
+  if (!text || text.length > RESUME_CONTEXT_MAX_CHARS) return null;
+  return text;
+}
+
+/** Post a compaction telemetry event. */
+async function mycoPostCompact(
+  directory: string,
+  sessionId: string,
+  trigger: string | undefined,
+): Promise<void> {
+  await postEventWithBuffer(directory, sessionId, {
+    type: "pre_compact",
+    session_id: sessionId,
+    agent: "opencode",
+    ...(trigger ? { trigger } : {}),
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Opencode session injection — push synthetic context into session history.
 // ---------------------------------------------------------------------------
@@ -485,21 +522,23 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
 
         activeOpencodeSessions.add(sessionId);
 
-        // Run the capture (register session with Myco daemon) and context fetch
-        // concurrently — they don't depend on each other, and parallelizing saves
-        // one round-trip of latency before the user's first turn lands. Context
-        // is fetched only for fresh sessions; resume sessions inherit the parent's
-        // history and don't need another injection.
-        //
-        // Re-entrancy: the synthetic text part carries `synthetic: true`; if opencode
-        // fires chat.message for it, our handler's synthetic-flag check skips it.
+        const parentSessionId = info.parentID || undefined;
+        const contextPromise = parentSessionId
+          ? (resumeInjectedSessions.has(sessionId)
+            ? Promise.resolve(null)
+            : fetchMycoResumeContext(directory, sessionId, parentSessionId))
+          : fetchMycoSessionContext(directory, sessionId);
+
+        // Run registration and context fetch concurrently — they don't depend
+        // on each other, and parallelizing saves one round-trip of latency.
         const [, sessionContext] = await Promise.all([
-          mycoRegisterSession(directory, sessionId, info.parentID || undefined),
-          info.parentID ? Promise.resolve(null) : fetchMycoSessionContext(directory, sessionId),
+          mycoRegisterSession(directory, sessionId, parentSessionId),
+          contextPromise,
         ]);
 
         if (sessionContext) {
           await injectSyntheticContext(client, sessionId, sessionContext);
+          if (parentSessionId) resumeInjectedSessions.add(sessionId);
         }
         return;
       }
@@ -508,6 +547,7 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         const info = event.properties?.info ?? {};
         if (info.id) {
           activeOpencodeSessions.delete(info.id);
+          resumeInjectedSessions.delete(info.id);
           await mycoUnregisterSession(directory, info.id);
         }
         return;
@@ -525,6 +565,7 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
         if (activeOpencodeSessions.size === 0) return;
         const toClose = Array.from(activeOpencodeSessions);
         activeOpencodeSessions.clear();
+        for (const id of toClose) resumeInjectedSessions.delete(id);
         await Promise.all(toClose.map((id) => mycoUnregisterSession(directory, id)));
         return;
       }
@@ -676,6 +717,8 @@ export const MycoPlugin = async ({ client, directory, worktree }: { client: any;
     "experimental.session.compacting": async (input: any, output: any) => {
       const sessionId = input?.sessionID;
       if (!sessionId) return;
+
+      await mycoPostCompact(directory, sessionId, typeof input?.trigger === "string" ? input.trigger : undefined);
 
       const sessionContext = await fetchMycoSessionContext(directory, sessionId);
       if (!sessionContext) return;

--- a/tests/daemon/api/context.test.ts
+++ b/tests/daemon/api/context.test.ts
@@ -5,7 +5,8 @@ import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import { upsertDigestExtract } from '@myco/db/queries/digest-extracts';
 import { insertSpore } from '@myco/db/queries/spores';
 import { registerAgent } from '@myco/db/queries/agents';
-import { createSessionContextHandler, createPromptContextHandler } from '@myco/daemon/api/context';
+import { upsertSession } from '@myco/db/queries/sessions';
+import { createSessionContextHandler, createPromptContextHandler, createResumeContextHandler } from '@myco/daemon/api/context';
 import type { ContextDeps } from '@myco/daemon/api/context';
 import type { RouteRequest } from '@myco/daemon/router';
 import type { EmbeddingManager } from '@myco/daemon/embedding/manager';
@@ -68,6 +69,7 @@ describe('createSessionContextHandler', () => {
   afterAll(() => { teardownTestDb(); });
   beforeEach(() => {
     getDatabase().prepare('DELETE FROM digest_extracts').run();
+    getDatabase().prepare('DELETE FROM sessions').run();
   });
 
   it('returns basic context when no digest extract exists', async () => {
@@ -129,6 +131,47 @@ describe('createSessionContextHandler', () => {
 
     expect(body.source).toBe('basic');
     expect(body.text).not.toContain('# Wrong tier');
+  });
+});
+
+describe('createResumeContextHandler', () => {
+  beforeAll(() => {
+    setupTestDb();
+    registerAgent({ id: DEFAULT_AGENT_ID, name: 'myco-agent', created_at: NOW });
+  });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    getDatabase().prepare('DELETE FROM sessions').run();
+  });
+
+  it('returns empty when no parent session exists', async () => {
+    const handler = createResumeContextHandler(makeDeps());
+    const result = await handler(makeReq({ session_id: 'resume-1', parent_session_id: 'missing-parent' }));
+
+    expect((result.body as { text: string }).text).toBe('');
+  });
+
+  it('returns a compact recap from the parent session', async () => {
+    upsertSession({
+      id: 'parent-1',
+      agent: 'opencode',
+      started_at: NOW,
+      created_at: NOW,
+      branch: 'feat/opencode',
+      title: 'Opencode capture follow-up',
+      summary: 'Added richer tool metadata and improved idle-time assistant summaries.',
+    });
+
+    const handler = createResumeContextHandler(makeDeps());
+    const result = await handler(makeReq({ session_id: 'resume-2', parent_session_id: 'parent-1' }));
+    const body = result.body as { text: string; source: string };
+
+    expect(body.source).toBe('resume');
+    expect(body.text).toContain('Resuming work from: Opencode capture follow-up');
+    expect(body.text).toContain('Added richer tool metadata');
+    expect(body.text).toContain('Branch:: `feat/opencode`');
+    expect(body.text).toContain('Previous Session:: `parent-1`');
+    expect(body.text).toContain('Session:: `resume-2`');
   });
 });
 

--- a/tests/symbionts/opencode-plugin.test.ts
+++ b/tests/symbionts/opencode-plugin.test.ts
@@ -139,4 +139,95 @@ describe('opencode plugin runtime hooks', () => {
       output_preview: 'updated',
     });
   });
+
+  it('fetches resume context for resumed sessions and injects it once', async () => {
+    const directory = createProjectDir();
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/sessions/register')) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (url.endsWith('/context/resume')) {
+        return new Response(JSON.stringify({ text: 'Resume recap' }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const client = {
+      app: { log: vi.fn().mockResolvedValue(undefined) },
+      session: {
+        messages: vi.fn(),
+        prompt: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    const plugin = await MycoPlugin({ client, directory, worktree: directory });
+    const resumeEvent = {
+      event: {
+        type: 'session.created',
+        properties: { info: { id: 'resume-session', parentID: 'parent-session' } },
+      },
+    };
+
+    await plugin.event(resumeEvent);
+    await plugin.event(resumeEvent);
+
+    expect(client.session.prompt).toHaveBeenCalledTimes(1);
+    expect(client.session.prompt).toHaveBeenCalledWith({
+      path: { id: 'resume-session' },
+      body: {
+        parts: [
+          {
+            type: 'text',
+            text: 'Resume recap',
+            synthetic: true,
+            metadata: { myco: true },
+          },
+        ],
+        noReply: true,
+      },
+    });
+
+    const urls = fetchMock.mock.calls.map((call) => call[0]);
+    expect(urls).toContain('http://localhost:32123/context/resume');
+    expect(urls).not.toContain('http://localhost:32123/context');
+  });
+
+  it('posts pre-compaction telemetry before appending context', async () => {
+    const directory = createProjectDir();
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/events')) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (url.endsWith('/context')) {
+        return new Response(JSON.stringify({ text: 'Compaction context' }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const client = {
+      app: { log: vi.fn().mockResolvedValue(undefined) },
+      session: { messages: vi.fn() },
+    };
+
+    const plugin = await MycoPlugin({ client, directory, worktree: directory });
+    const output = { context: [] as string[] };
+
+    await plugin['experimental.session.compacting'](
+      { sessionID: 'ses-compact-1', trigger: 'auto' },
+      output,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('http://localhost:32123/events');
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toMatchObject({
+      type: 'pre_compact',
+      session_id: 'ses-compact-1',
+      trigger: 'auto',
+    });
+    expect(output.context).toEqual([
+      '## Myco — Project Context (preserved across compaction)\n\nCompaction context',
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

This pull request introduces two new agent skills for the Myco project and enhances the session resume logic in the Opencode Myco plugin. The new skills provide comprehensive playbooks for debugging daemon errors and hardening agent harnesses, while the plugin changes streamline and safeguard session resume context injection, preventing duplicate injections and enforcing a strict size limit.

**New Agent Skills:**

* **Debug Daemon Errors Skill**:
  - Adds `.agents/skills/debug-daemon-errors/SKILL.md`, a detailed playbook for investigating and fixing Myco daemon bugs across subsystems (PowerManager, SQLite, outbox, session lifecycle, executor). It includes step-by-step diagnosis, subsystem-specific fix patterns, regression test guidance, and a quick reference table mapping errors to fixes.
* **Harden Agent Harness Skill**:
  - Adds `.agents/skills/harden-agent-harness/SKILL.md`, a comprehensive checklist for securing new agent tasks and MCP tools. It covers MCP `readOnly` annotations, global enable/disable toggles, phase-level enforcement, required test cases, and a pre-ship checklist to ensure safety controls are in place.

**Opencode Myco Plugin Improvements:**

* **Session Resume Context Injection**:
  - Introduces a `RESUME_CONTEXT_MAX_CHARS` limit (4000 chars) and a `resumeInjectedSessions` set to ensure resume context is injected at most once per session and remains within a safe size. [[1]](diffhunk://#diff-f6459d12f2f6628159eec71183e6516b1e2df370a3cf27bbb43a56b59f97aee6R46-R48) [[2]](diffhunk://#diff-f6459d12f2f6628159eec71183e6516b1e2df370a3cf27bbb43a56b59f97aee6R156-R158)
  - Adds `fetchMycoResumeContext()` to fetch and validate the resume context, and updates session initialization logic to use it only when appropriate. [[1]](diffhunk://#diff-f6459d12f2f6628159eec71183e6516b1e2df370a3cf27bbb43a56b59f97aee6R394-R424) [[2]](diffhunk://#diff-f6459d12f2f6628159eec71183e6516b1e2df370a3cf27bbb43a56b59f97aee6L488-R541)
  - Prevents duplicate or oversized resume context injections, improving reliability and performance during session resumes.

These changes collectively improve developer experience, operational safety, and session management robustness in the Myco ecosystem.

## Related Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [x] Enhancement / new feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] CI / workflow

## Validation

```bash
make check    # lint + 266 tests
```

## Checklist

- [x] `make check` passes locally
- [x] Tests added or updated where behavior changed
- [ ] Docs updated for user-visible changes
- [ ] No magic literals introduced (named constants in `src/constants.ts`)
