### PR TITLE
chore: Refactor Myco hook commands to use project directory context

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook session-start",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook session-start",
             "timeout": 10
           }
         ]
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook user-prompt-submit",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook user-prompt-submit",
             "timeout": 5
           }
         ]
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook post-tool-use",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook post-tool-use",
             "timeout": 5
           }
         ]
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook post-tool-use-failure",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook post-tool-use-failure",
             "timeout": 5
           }
         ]
@@ -52,7 +52,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook stop",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook stop",
             "timeout": 30
           }
         ]
@@ -63,7 +63,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook session-end",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook session-end",
             "timeout": 10
           }
         ]
@@ -74,7 +74,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook subagent-start",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook subagent-start",
             "timeout": 5
           }
         ]
@@ -85,7 +85,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook subagent-stop",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook subagent-stop",
             "timeout": 10
           }
         ]
@@ -96,7 +96,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook stop-failure",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook stop-failure",
             "timeout": 10
           }
         ]
@@ -107,7 +107,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook task-completed",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook task-completed",
             "timeout": 5
           }
         ]
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook pre-compact",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook pre-compact",
             "timeout": 5
           }
         ]
@@ -129,7 +129,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook post-compact",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook post-compact",
             "timeout": 5
           }
         ]

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook session-start",
+            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-hook.cjs hook session-start",
             "timeout": 10
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook user-prompt-submit",
+            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-hook.cjs hook user-prompt-submit",
             "timeout": 5
           }
         ]
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook post-tool-use",
+            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-hook.cjs hook post-tool-use",
             "timeout": 5
           }
         ]
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook stop",
+            "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-hook.cjs hook stop",
             "timeout": 30
           }
         ]

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -2,63 +2,63 @@
   "hooks": {
     "sessionStart": [
       {
-        "command": "node .agents/myco-hook.cjs hook session-start",
+        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook session-start",
         "type": "command",
         "timeout": 10
       }
     ],
     "beforeSubmitPrompt": [
       {
-        "command": "node .agents/myco-hook.cjs hook user-prompt-submit",
+        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook user-prompt-submit",
         "type": "command",
         "timeout": 5
       }
     ],
     "postToolUse": [
       {
-        "command": "node .agents/myco-hook.cjs hook post-tool-use",
+        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook post-tool-use",
         "type": "command",
         "timeout": 5
       }
     ],
     "postToolUseFailure": [
       {
-        "command": "node .agents/myco-hook.cjs hook post-tool-use-failure",
+        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook post-tool-use-failure",
         "type": "command",
         "timeout": 5
       }
     ],
     "stop": [
       {
-        "command": "node .agents/myco-hook.cjs hook stop",
+        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook stop",
         "type": "command",
         "timeout": 30
       }
     ],
     "sessionEnd": [
       {
-        "command": "node .agents/myco-hook.cjs hook session-end",
+        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook session-end",
         "type": "command",
         "timeout": 10
       }
     ],
     "subagentStart": [
       {
-        "command": "node .agents/myco-hook.cjs hook subagent-start",
+        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook subagent-start",
         "type": "command",
         "timeout": 5
       }
     ],
     "subagentStop": [
       {
-        "command": "node .agents/myco-hook.cjs hook subagent-stop",
+        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook subagent-stop",
         "type": "command",
         "timeout": 10
       }
     ],
     "preCompact": [
       {
-        "command": "node .agents/myco-hook.cjs hook pre-compact",
+        "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook pre-compact",
         "type": "command",
         "timeout": 5
       }

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -6,7 +6,7 @@
           {
             "name": "myco-session-start",
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook session-start",
+            "command": "cd \"${GEMINI_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook session-start",
             "timeout": 10000
           }
         ]
@@ -18,7 +18,7 @@
           {
             "name": "myco-user-prompt-submit",
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook user-prompt-submit",
+            "command": "cd \"${GEMINI_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook user-prompt-submit",
             "timeout": 5000
           }
         ]
@@ -30,7 +30,7 @@
           {
             "name": "myco-post-tool-use",
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook post-tool-use",
+            "command": "cd \"${GEMINI_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook post-tool-use",
             "timeout": 5000
           }
         ]
@@ -42,7 +42,7 @@
           {
             "name": "myco-stop",
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook stop",
+            "command": "cd \"${GEMINI_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook stop",
             "timeout": 30000
           }
         ]
@@ -54,7 +54,7 @@
           {
             "name": "myco-session-end",
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook session-end",
+            "command": "cd \"${GEMINI_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook session-end",
             "timeout": 10000
           }
         ]
@@ -66,7 +66,7 @@
           {
             "name": "myco-pre-compact",
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook pre-compact",
+            "command": "cd \"${GEMINI_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook pre-compact",
             "timeout": 5000
           }
         ]

--- a/.github/hooks/myco-hooks.json
+++ b/.github/hooks/myco-hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook session-start",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook session-start",
             "timeout": 10
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook user-prompt-submit",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook user-prompt-submit",
             "timeout": 5
           }
         ]
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook post-tool-use",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook post-tool-use",
             "timeout": 5
           }
         ]
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook pre-compact",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook pre-compact",
             "timeout": 5
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook subagent-start",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook subagent-start",
             "timeout": 5
           }
         ]
@@ -60,7 +60,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook subagent-stop",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook subagent-stop",
             "timeout": 10
           }
         ]
@@ -71,7 +71,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node .agents/myco-hook.cjs hook stop",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook stop",
             "timeout": 30
           }
         ]

--- a/.windsurf/hooks.json
+++ b/.windsurf/hooks.json
@@ -2,22 +2,22 @@
   "hooks": {
     "pre_user_prompt": [
       {
-        "command": "node .agents/myco-hook.cjs hook user-prompt-submit"
+        "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-hook.cjs hook user-prompt-submit"
       }
     ],
     "post_run_command": [
       {
-        "command": "node .agents/myco-hook.cjs hook post-tool-use"
+        "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-hook.cjs hook post-tool-use"
       }
     ],
     "post_write_code": [
       {
-        "command": "node .agents/myco-hook.cjs hook post-tool-use"
+        "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-hook.cjs hook post-tool-use"
       }
     ],
     "post_cascade_response": [
       {
-        "command": "node .agents/myco-hook.cjs hook stop"
+        "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-hook.cjs hook stop"
       }
     ]
   }

--- a/src/symbionts/install-helpers.ts
+++ b/src/symbionts/install-helpers.ts
@@ -3,19 +3,18 @@ import path from 'node:path';
 
 /** Prefix used to identify Myco-owned hooks in settings files. */
 const MYCO_HOOK_COMMAND_PREFIX = 'myco-run';
-const MYCO_HOOK_GUARD_PREFIX = 'node .agents/myco-hook.cjs';
 
 /** Check if a command string belongs to Myco (old or new guard format). */
 export function isMycoHookCommand(command: string): boolean {
-  return command.startsWith(MYCO_HOOK_COMMAND_PREFIX) || command.startsWith(MYCO_HOOK_GUARD_PREFIX);
+  return command.startsWith(MYCO_HOOK_COMMAND_PREFIX) || command.includes('.agents/myco-hook.cjs');
 }
 
 /**
  * Check if a hook group is Myco-owned.
  * Handles both nested format (Claude Code, Codex, etc.) and flat format (Windsurf).
  *
- * Nested: { hooks: [{ command: "node .agents/myco-hook.cjs ..." }] }
- * Flat:   { command: "node .agents/myco-hook.cjs ..." }
+ * Nested: { hooks: [{ command: "cd \"$(git rev-parse ...)\" && node .agents/myco-hook.cjs ..." }] }
+ * Flat:   { command: "cd \"$(git rev-parse ...)\" && node .agents/myco-hook.cjs ..." }
  */
 export function isMycoHookGroup(group: Record<string, unknown>): boolean {
   // Nested format: { hooks: [{ command: "..." }] }

--- a/src/symbionts/templates/claude-code/hooks.json
+++ b/src/symbionts/templates/claude-code/hooks.json
@@ -4,7 +4,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook session-start",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook session-start",
           "timeout": 10
         }
       ]
@@ -15,7 +15,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook user-prompt-submit",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook user-prompt-submit",
           "timeout": 5
         }
       ]
@@ -26,7 +26,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook post-tool-use",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook post-tool-use",
           "timeout": 5
         }
       ]
@@ -37,7 +37,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook post-tool-use-failure",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook post-tool-use-failure",
           "timeout": 5
         }
       ]
@@ -48,7 +48,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook stop",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook stop",
           "timeout": 30
         }
       ]
@@ -59,7 +59,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook session-end",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook session-end",
           "timeout": 10
         }
       ]
@@ -70,7 +70,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook subagent-start",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook subagent-start",
           "timeout": 5
         }
       ]
@@ -81,7 +81,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook subagent-stop",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook subagent-stop",
           "timeout": 10
         }
       ]
@@ -92,7 +92,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook stop-failure",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook stop-failure",
           "timeout": 10
         }
       ]
@@ -103,7 +103,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook task-completed",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook task-completed",
           "timeout": 5
         }
       ]
@@ -114,7 +114,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook pre-compact",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook pre-compact",
           "timeout": 5
         }
       ]
@@ -125,7 +125,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook post-compact",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook post-compact",
           "timeout": 5
         }
       ]

--- a/src/symbionts/templates/codex/hooks.json
+++ b/src/symbionts/templates/codex/hooks.json
@@ -4,7 +4,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook session-start",
+          "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-hook.cjs hook session-start",
           "timeout": 10
         }
       ]
@@ -15,7 +15,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook user-prompt-submit",
+          "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-hook.cjs hook user-prompt-submit",
           "timeout": 5
         }
       ]
@@ -26,7 +26,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook post-tool-use",
+          "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-hook.cjs hook post-tool-use",
           "timeout": 5
         }
       ]
@@ -37,7 +37,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook stop",
+          "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-hook.cjs hook stop",
           "timeout": 30
         }
       ]

--- a/src/symbionts/templates/cursor/hooks.json
+++ b/src/symbionts/templates/cursor/hooks.json
@@ -1,63 +1,63 @@
 {
   "sessionStart": [
     {
-      "command": "node .agents/myco-hook.cjs hook session-start",
+      "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook session-start",
       "type": "command",
       "timeout": 10
     }
   ],
   "beforeSubmitPrompt": [
     {
-      "command": "node .agents/myco-hook.cjs hook user-prompt-submit",
+      "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook user-prompt-submit",
       "type": "command",
       "timeout": 5
     }
   ],
   "postToolUse": [
     {
-      "command": "node .agents/myco-hook.cjs hook post-tool-use",
+      "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook post-tool-use",
       "type": "command",
       "timeout": 5
     }
   ],
   "postToolUseFailure": [
     {
-      "command": "node .agents/myco-hook.cjs hook post-tool-use-failure",
+      "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook post-tool-use-failure",
       "type": "command",
       "timeout": 5
     }
   ],
   "stop": [
     {
-      "command": "node .agents/myco-hook.cjs hook stop",
+      "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook stop",
       "type": "command",
       "timeout": 30
     }
   ],
   "sessionEnd": [
     {
-      "command": "node .agents/myco-hook.cjs hook session-end",
+      "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook session-end",
       "type": "command",
       "timeout": 10
     }
   ],
   "subagentStart": [
     {
-      "command": "node .agents/myco-hook.cjs hook subagent-start",
+      "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook subagent-start",
       "type": "command",
       "timeout": 5
     }
   ],
   "subagentStop": [
     {
-      "command": "node .agents/myco-hook.cjs hook subagent-stop",
+      "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook subagent-stop",
       "type": "command",
       "timeout": 10
     }
   ],
   "preCompact": [
     {
-      "command": "node .agents/myco-hook.cjs hook pre-compact",
+      "command": "cd \"${CURSOR_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook pre-compact",
       "type": "command",
       "timeout": 5
     }

--- a/src/symbionts/templates/gemini/hooks.json
+++ b/src/symbionts/templates/gemini/hooks.json
@@ -5,7 +5,7 @@
         {
           "name": "myco-session-start",
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook session-start",
+          "command": "cd \"${GEMINI_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook session-start",
           "timeout": 10000
         }
       ]
@@ -17,7 +17,7 @@
         {
           "name": "myco-user-prompt-submit",
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook user-prompt-submit",
+          "command": "cd \"${GEMINI_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook user-prompt-submit",
           "timeout": 5000
         }
       ]
@@ -29,7 +29,7 @@
         {
           "name": "myco-post-tool-use",
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook post-tool-use",
+          "command": "cd \"${GEMINI_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook post-tool-use",
           "timeout": 5000
         }
       ]
@@ -41,7 +41,7 @@
         {
           "name": "myco-stop",
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook stop",
+          "command": "cd \"${GEMINI_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook stop",
           "timeout": 30000
         }
       ]
@@ -53,7 +53,7 @@
         {
           "name": "myco-session-end",
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook session-end",
+          "command": "cd \"${GEMINI_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook session-end",
           "timeout": 10000
         }
       ]
@@ -65,7 +65,7 @@
         {
           "name": "myco-pre-compact",
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook pre-compact",
+          "command": "cd \"${GEMINI_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook pre-compact",
           "timeout": 5000
         }
       ]

--- a/src/symbionts/templates/vscode-copilot/hooks.json
+++ b/src/symbionts/templates/vscode-copilot/hooks.json
@@ -4,7 +4,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook session-start",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook session-start",
           "timeout": 10
         }
       ]
@@ -15,7 +15,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook user-prompt-submit",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook user-prompt-submit",
           "timeout": 5
         }
       ]
@@ -26,7 +26,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook post-tool-use",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook post-tool-use",
           "timeout": 5
         }
       ]
@@ -37,7 +37,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook pre-compact",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook pre-compact",
           "timeout": 5
         }
       ]
@@ -48,7 +48,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook subagent-start",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook subagent-start",
           "timeout": 5
         }
       ]
@@ -59,7 +59,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook subagent-stop",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook subagent-stop",
           "timeout": 10
         }
       ]
@@ -70,7 +70,7 @@
       "hooks": [
         {
           "type": "command",
-          "command": "node .agents/myco-hook.cjs hook stop",
+          "command": "cd \"${CLAUDE_PROJECT_DIR:-.}\" && node .agents/myco-hook.cjs hook stop",
           "timeout": 30
         }
       ]

--- a/src/symbionts/templates/windsurf/hooks.json
+++ b/src/symbionts/templates/windsurf/hooks.json
@@ -1,22 +1,22 @@
 {
   "pre_user_prompt": [
     {
-      "command": "node .agents/myco-hook.cjs hook user-prompt-submit"
+      "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-hook.cjs hook user-prompt-submit"
     }
   ],
   "post_run_command": [
     {
-      "command": "node .agents/myco-hook.cjs hook post-tool-use"
+      "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-hook.cjs hook post-tool-use"
     }
   ],
   "post_write_code": [
     {
-      "command": "node .agents/myco-hook.cjs hook post-tool-use"
+      "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-hook.cjs hook post-tool-use"
     }
   ],
   "post_cascade_response": [
     {
-      "command": "node .agents/myco-hook.cjs hook stop"
+      "command": "cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && node .agents/myco-hook.cjs hook stop"
     }
   ]
 }

--- a/tests/cli/update.test.ts
+++ b/tests/cli/update.test.ts
@@ -23,9 +23,11 @@ vi.mock('@myco/symbionts/detect.js', () => ({
 }));
 
 vi.mock('@myco/symbionts/installer.js', () => ({
-  SymbiontInstaller: vi.fn().mockImplementation(() => ({
+  SymbiontInstaller: vi.fn(function MockSymbiontInstaller() {
+    return {
     install: vi.fn().mockReturnValue({ hooks: false, mcp: false, skills: false, settings: false, instructions: false }),
-  })),
+    };
+  }),
   MYCO_MCP_SERVER_NAME: 'myco',
 }));
 
@@ -37,6 +39,7 @@ describe('myco update', () => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-update-test-'));
     vaultDir = path.join(testDir, '.myco');
     fs.mkdirSync(vaultDir, { recursive: true });
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
@@ -89,5 +92,59 @@ describe('myco update', () => {
     await run(['--project', testDir]);
 
     expect(SymbiontInstaller).toHaveBeenCalled();
+  });
+
+  it('updates all enabled telemetry-capable symbionts from config', async () => {
+    const { loadManifests } = await import('@myco/symbionts/detect.js');
+    vi.mocked(loadManifests).mockReturnValue([
+      {
+        name: 'claude-code', displayName: 'Claude Code', binary: 'claude',
+        configDir: '.claude', pluginRootEnvVar: 'CLAUDE_PLUGIN_ROOT',
+        registration: { hooksTarget: '.claude/settings.json', skillsTarget: '.claude/skills' },
+        hookFields: { sessionId: 'session_id', transcriptPath: 'transcript_path', lastResponse: 'last_response', prompt: 'prompt', toolName: 'tool_name', toolInput: 'tool_input', toolOutput: 'tool_output' },
+      },
+      {
+        name: 'cursor', displayName: 'Cursor', binary: 'cursor',
+        configDir: '.cursor', pluginRootEnvVar: 'CURSOR_PLUGIN_ROOT',
+        registration: { hooksTarget: '.cursor/hooks.json', skillsTarget: '.cursor/skills' },
+        hookFields: { sessionId: 'session_id', transcriptPath: 'transcript_path', lastResponse: 'last_response', prompt: 'prompt', toolName: 'tool_name', toolInput: 'tool_input', toolOutput: 'tool_output' },
+      },
+      {
+        name: 'gemini', displayName: 'Gemini CLI', binary: 'gemini',
+        configDir: '.gemini', pluginRootEnvVar: 'GEMINI_PLUGIN_ROOT',
+        registration: { hooksTarget: '.gemini/settings.json', skillsTarget: '.agents/skills' },
+        hookFields: { sessionId: 'session_id', transcriptPath: 'transcript_path', lastResponse: 'last_response', prompt: 'prompt', toolName: 'tool_name', toolInput: 'tool_input', toolOutput: 'tool_output' },
+      },
+      {
+        name: 'vscode-copilot', displayName: 'VS Code Copilot', binary: 'code',
+        configDir: '.vscode', pluginRootEnvVar: 'VSCODE_PLUGIN_ROOT',
+        registration: { hooksTarget: '.github/hooks/myco-hooks.json', skillsTarget: '.agents/skills' },
+        hookFields: { sessionId: 'session_id', transcriptPath: 'transcript_path', lastResponse: 'last_response', prompt: 'prompt', toolName: 'tool_name', toolInput: 'tool_input', toolOutput: 'tool_output' },
+      },
+    ]);
+
+    const config = {
+      version: 3, config_version: 0,
+      symbionts: {
+        'claude-code': { enabled: true },
+        cursor: { enabled: true },
+        gemini: { enabled: true },
+        'vscode-copilot': { enabled: true },
+      },
+    };
+    fs.writeFileSync(path.join(vaultDir, 'myco.yaml'), YAML.stringify(config));
+    fs.mkdirSync(path.join(testDir, '.claude'), { recursive: true });
+    fs.mkdirSync(path.join(testDir, '.cursor'), { recursive: true });
+    fs.mkdirSync(path.join(testDir, '.gemini'), { recursive: true });
+    fs.mkdirSync(path.join(testDir, '.vscode'), { recursive: true });
+    fs.mkdirSync(path.join(testDir, '.github/hooks'), { recursive: true });
+
+    const { SymbiontInstaller } = await import('@myco/symbionts/installer.js');
+    const { run } = await import('@myco/cli/update.js');
+    await run(['--project', testDir]);
+
+    expect(SymbiontInstaller).toHaveBeenCalledTimes(4);
+    const installedNames = vi.mocked(SymbiontInstaller).mock.calls.map((call) => call[0].name).sort();
+    expect(installedNames).toEqual(['claude-code', 'cursor', 'gemini', 'vscode-copilot']);
   });
 });

--- a/tests/symbionts/installer.test.ts
+++ b/tests/symbionts/installer.test.ts
@@ -159,14 +159,28 @@ const HOOKS_TEMPLATE = {
   SessionStart: [
     {
       hooks: [
-        { type: 'command', command: 'node .agents/myco-hook.cjs hook session-start', timeout: 10 },
+        { type: 'command', command: 'cd "${CLAUDE_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook session-start', timeout: 10 },
       ],
     },
   ],
   Stop: [
     {
       hooks: [
-        { type: 'command', command: 'node .agents/myco-hook.cjs hook stop', timeout: 30 },
+        { type: 'command', command: 'cd "${CLAUDE_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook stop', timeout: 30 },
+      ],
+    },
+  ],
+  PreCompact: [
+    {
+      hooks: [
+        { type: 'command', command: 'cd "${CLAUDE_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook pre-compact', timeout: 5 },
+      ],
+    },
+  ],
+  PostCompact: [
+    {
+      hooks: [
+        { type: 'command', command: 'cd "${CLAUDE_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook post-compact', timeout: 5 },
       ],
     },
   ],
@@ -213,16 +227,17 @@ function setupPackageRoot(): void {
     permissions: { allow: ['Bash(myco-run *)', 'Bash(myco-run:*)', 'Bash(myco *)', 'Bash(myco:*)'] },
   });
   writeJson(path.join(cursorTemplateDir, 'hooks.json'), {
-    sessionStart: [{ command: 'node .agents/myco-hook.cjs hook session-start', type: 'command', timeout: 10 }],
-    stop: [{ command: 'node .agents/myco-hook.cjs hook stop', type: 'command', timeout: 30 }],
+    sessionStart: [{ command: 'cd "${CURSOR_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook session-start', type: 'command', timeout: 10 }],
+    stop: [{ command: 'cd "${CURSOR_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook stop', type: 'command', timeout: 30 }],
+    preCompact: [{ command: 'cd "${CURSOR_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook pre-compact', type: 'command', timeout: 5 }],
   });
   writeJson(path.join(cursorTemplateDir, 'mcp.json'), MCP_TEMPLATE);
   writeJson(path.join(cursorTemplateDir, 'settings.json'), {
     'chat.tools.terminal.autoApprove': { 'myco-run': true, 'myco': true },
   });
   writeJson(path.join(codexTemplateDir, 'hooks.json'), {
-    SessionStart: [{ hooks: [{ type: 'command', command: 'node .agents/myco-hook.cjs hook session-start', timeout: 10 }] }],
-    Stop: [{ hooks: [{ type: 'command', command: 'node .agents/myco-hook.cjs hook stop', timeout: 30 }] }],
+    SessionStart: [{ hooks: [{ type: 'command', command: 'cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" && node .agents/myco-hook.cjs hook session-start', timeout: 10 }] }],
+    Stop: [{ hooks: [{ type: 'command', command: 'cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" && node .agents/myco-hook.cjs hook stop', timeout: 30 }] }],
   });
   writeJson(path.join(codexTemplateDir, 'mcp.json'), {
     myco: { command: 'myco-run', args: ['mcp'] },
@@ -231,16 +246,18 @@ function setupPackageRoot(): void {
     features: { codex_hooks: true },
   });
   writeJson(path.join(vscodeTemplateDir, 'hooks.json'), {
-    SessionStart: [{ hooks: [{ type: 'command', command: 'node .agents/myco-hook.cjs hook session-start', timeout: 10 }] }],
-    Stop: [{ hooks: [{ type: 'command', command: 'node .agents/myco-hook.cjs hook stop', timeout: 30 }] }],
+    SessionStart: [{ hooks: [{ type: 'command', command: 'cd "${CLAUDE_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook session-start', timeout: 10 }] }],
+    Stop: [{ hooks: [{ type: 'command', command: 'cd "${CLAUDE_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook stop', timeout: 30 }] }],
+    PreCompact: [{ hooks: [{ type: 'command', command: 'cd "${CLAUDE_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook pre-compact', timeout: 5 }] }],
   });
   writeJson(path.join(vscodeTemplateDir, 'mcp.json'), MCP_TEMPLATE);
   writeJson(path.join(vscodeTemplateDir, 'settings.json'), {
     'chat.tools.terminal.autoApprove': { 'myco-run': true, 'myco': true },
   });
   writeJson(path.join(geminiTemplateDir, 'hooks.json'), {
-    SessionStart: [{ hooks: [{ name: 'myco-session-start', type: 'command', command: 'node .agents/myco-hook.cjs hook session-start', timeout: 10000 }] }],
-    AfterAgent: [{ hooks: [{ name: 'myco-stop', type: 'command', command: 'node .agents/myco-hook.cjs hook stop', timeout: 30000 }] }],
+    SessionStart: [{ hooks: [{ name: 'myco-session-start', type: 'command', command: 'cd "${GEMINI_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook session-start', timeout: 10000 }] }],
+    AfterAgent: [{ hooks: [{ name: 'myco-stop', type: 'command', command: 'cd "${GEMINI_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook stop', timeout: 30000 }] }],
+    PreCompress: [{ hooks: [{ name: 'myco-pre-compact', type: 'command', command: 'cd "${GEMINI_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook pre-compact', timeout: 5000 }] }],
   });
   writeJson(path.join(geminiTemplateDir, 'mcp.json'), {
     myco: { command: 'myco-run', args: ['mcp'] },
@@ -252,8 +269,8 @@ function setupPackageRoot(): void {
   const windsurfTemplateDir = path.join(packageRoot, 'src/symbionts/templates/windsurf');
   fs.mkdirSync(windsurfTemplateDir, { recursive: true });
   writeJson(path.join(windsurfTemplateDir, 'hooks.json'), {
-    pre_user_prompt: [{ command: 'node .agents/myco-hook.cjs hook user-prompt-submit' }],
-    post_cascade_response: [{ command: 'node .agents/myco-hook.cjs hook stop' }],
+    pre_user_prompt: [{ command: 'cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" && node .agents/myco-hook.cjs hook user-prompt-submit' }],
+    post_cascade_response: [{ command: 'cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" && node .agents/myco-hook.cjs hook stop' }],
   });
 
   // opencode uses plugin-file hooks + non-standard MCP key + a package.json for plugin deps
@@ -265,7 +282,7 @@ function setupPackageRoot(): void {
     myco: { type: 'local', command: ['myco-run', 'mcp'] },
   });
   writeJson(path.join(opencodeTemplateDir, 'settings.json'), {
-    permission: { bash: { 'myco-run *': 'allow', 'node .agents/myco-hook.cjs *': 'allow' } },
+    permission: { bash: { 'myco-run *': 'allow', 'cd "${CLAUDE_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs *': 'allow' } },
   });
 
   // Copy hook-guard template so installHookGuard can find it
@@ -389,7 +406,7 @@ describe('installHooks', () => {
       (g: unknown) => ((g as { hooks: Array<{ command: string }> }).hooks ?? []).map(h => h.command),
     );
     expect(commands).toContain('my-other-tool start');
-    expect(commands).toContain('node .agents/myco-hook.cjs hook session-start');
+    expect(commands).toContain('cd "${CLAUDE_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook session-start');
   });
 
   it('replaces stale Myco hooks on update', () => {
@@ -438,6 +455,53 @@ describe('installHooks', () => {
     const installer = new SymbiontInstaller(NO_HOOKS_MANIFEST, projectRoot, packageRoot);
     const result = installer.installHooks();
     expect(result).toBe(false);
+  });
+
+  it('installs pre and post compact hooks for Claude Code', () => {
+    const installer = new SymbiontInstaller(CLAUDE_MANIFEST, projectRoot, packageRoot);
+    installer.installHooks();
+
+    const settings = readJson(path.join(projectRoot, '.claude/settings.json'));
+    const hooks = settings.hooks as Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+
+    expect(hooks.PreCompact).toHaveLength(1);
+    expect(hooks.PostCompact).toHaveLength(1);
+    expect(hooks.PreCompact[0]?.hooks[0]?.command).toBe('cd "${CLAUDE_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook pre-compact');
+    expect(hooks.PostCompact[0]?.hooks[0]?.command).toBe('cd "${CLAUDE_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook post-compact');
+  });
+
+  it('installs pre-compact hook for Cursor', () => {
+    const installer = new SymbiontInstaller(CURSOR_MANIFEST, projectRoot, packageRoot);
+    installer.installHooks();
+
+    const settings = readJson(path.join(projectRoot, '.cursor/hooks.json'));
+    const preCompact = ((settings.hooks as Record<string, unknown[]>).preCompact as Array<{ command: string }>);
+
+    expect(preCompact).toHaveLength(1);
+    expect(preCompact[0]?.command).toBe('cd "${CURSOR_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook pre-compact');
+  });
+
+  it('installs pre-compact hook for Gemini CLI', () => {
+    fs.mkdirSync(path.join(projectRoot, '.gemini'), { recursive: true });
+    const installer = new SymbiontInstaller(GEMINI_MANIFEST, projectRoot, packageRoot);
+    installer.installHooks();
+
+    const settings = readJson(path.join(projectRoot, '.gemini/settings.json'));
+    const hooks = settings.hooks as Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+
+    expect(hooks.PreCompress).toHaveLength(1);
+    expect(hooks.PreCompress[0]?.hooks[0]?.command).toBe('cd "${GEMINI_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook pre-compact');
+  });
+
+  it('installs pre-compact hook for VS Code Copilot', () => {
+    const installer = new SymbiontInstaller(VSCODE_MANIFEST, projectRoot, packageRoot);
+    installer.installHooks();
+
+    const settings = readJson(path.join(projectRoot, '.github/hooks/myco-hooks.json'));
+    const preCompact = ((settings.hooks as Record<string, unknown[]>).PreCompact as Array<{ hooks: Array<{ command: string }> }>);
+
+    expect(preCompact).toHaveLength(1);
+    expect(preCompact[0]?.hooks[0]?.command).toBe('cd "${CLAUDE_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook pre-compact');
   });
 });
 
@@ -1284,7 +1348,7 @@ describe('Windsurf flat hook format', () => {
 
     const hooks = readJson(path.join(projectRoot, '.windsurf/hooks.json'));
     const groups = (hooks.hooks as Record<string, unknown[]>).pre_user_prompt as Array<Record<string, unknown>>;
-    expect(groups[0].command).toBe('node .agents/myco-hook.cjs hook user-prompt-submit');
+    expect(groups[0].command).toBe('cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" && node .agents/myco-hook.cjs hook user-prompt-submit');
     // Should NOT have nested hooks array
     expect(groups[0].hooks).toBeUndefined();
   });
@@ -1305,7 +1369,7 @@ describe('Windsurf flat hook format', () => {
     const commands = ((hooks.hooks as Record<string, unknown[]>).pre_user_prompt as Array<Record<string, unknown>>)
       .map((g) => g.command);
     expect(commands).toContain('other-tool check');
-    expect(commands).toContain('node .agents/myco-hook.cjs hook user-prompt-submit');
+    expect(commands).toContain('cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" && node .agents/myco-hook.cjs hook user-prompt-submit');
   });
 
   it('replaces stale Myco flat hooks', () => {
@@ -1324,7 +1388,7 @@ describe('Windsurf flat hook format', () => {
     const commands = ((hooks.hooks as Record<string, unknown[]>).pre_user_prompt as Array<Record<string, unknown>>)
       .map((g) => g.command);
     expect(commands).not.toContain('myco-run hook old-event');
-    expect(commands).toContain('node .agents/myco-hook.cjs hook user-prompt-submit');
+    expect(commands).toContain('cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" && node .agents/myco-hook.cjs hook user-prompt-submit');
   });
 
   it('uninstalls flat Myco hooks', () => {
@@ -1654,7 +1718,7 @@ describe('old-format hook backward compatibility', () => {
     // Old hooks replaced, not stacked
     expect(hooks.SessionStart).toHaveLength(1);
     const command = ((hooks.SessionStart[0] as { hooks: Array<{ command: string }> }).hooks[0]).command;
-    expect(command).toBe('node .agents/myco-hook.cjs hook session-start');
+    expect(command).toBe('cd "${CLAUDE_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs hook session-start');
   });
 
   it('replaces old-format flat hooks in Windsurf', () => {
@@ -1674,7 +1738,7 @@ describe('old-format hook backward compatibility', () => {
       .map((g) => g.command);
     // Old format removed, new format added
     expect(commands).not.toContain('myco-run hook user-prompt-submit');
-    expect(commands).toContain('node .agents/myco-hook.cjs hook user-prompt-submit');
+    expect(commands).toContain('cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)" && node .agents/myco-hook.cjs hook user-prompt-submit');
     // No duplication
     expect(commands).toHaveLength(1);
   });
@@ -1696,13 +1760,13 @@ describe('hook template validation', () => {
           if (Array.isArray(group.hooks)) {
             for (const hook of group.hooks as Array<{ command?: string }>) {
               if (hook.command) {
-                expect(hook.command).toMatch(/^node \.agents\/myco-hook\.cjs /);
+                expect(hook.command).toMatch(/\.agents\/myco-hook\.cjs /);
               }
             }
           }
           // Flat format
           if (typeof group.command === 'string') {
-            expect(group.command).toMatch(/^node \.agents\/myco-hook\.cjs /);
+            expect(group.command).toMatch(/\.agents\/myco-hook\.cjs /);
           }
         }
       }
@@ -1839,7 +1903,7 @@ describe('opencode (plugin-file hooks)', () => {
     const openCodeJson = readJson(path.join(projectRoot, 'opencode.json'));
     const permission = openCodeJson.permission as Record<string, Record<string, string>>;
     expect(permission.bash['myco-run *']).toBe('allow');
-    expect(permission.bash['node .agents/myco-hook.cjs *']).toBe('allow');
+    expect(permission.bash['cd "${CLAUDE_PROJECT_DIR:-.}" && node .agents/myco-hook.cjs *']).toBe('allow');
   });
 
   it('opencode does not trigger batched JSON install (hooks target is .ts)', () => {
@@ -1861,4 +1925,3 @@ describe('opencode (plugin-file hooks)', () => {
     expect(fs.existsSync(guardPath)).toBe(true);
   });
 });
-


### PR DESCRIPTION
- Updated hook commands across various configuration files to change the execution context to the project directory.
- Modified commands in `.cursor/hooks.json`, `.gemini/settings.json`, `.github/hooks/myco-hooks.json`, and `.windsurf/hooks.json` to use `cd "${PROJECT_DIR:-.}" && node .agents/myco-hook.cjs ...`.
- Adjusted related templates in `src/symbionts/templates` for `claude-code`, `codex`, `gemini`, `vscode-copilot`, and `windsurf` to ensure consistent command execution.
- Enhanced `install-helpers.ts` to check for Myco hook commands using the updated command format.
- Updated tests in `tests/cli/update.test.ts` and `tests/symbionts/installer.test.ts` to validate the new command structure and ensure proper installation of hooks.

## Summary

This pull request updates the way Myco agent hook commands are executed across multiple settings and configuration files for various integrations (Claude, Codex, Cursor, Gemini, Windsurf, GitHub). The main change is to ensure that each hook command is run from the correct project root directory by prepending a `cd` command to each hook invocation. This improves reliability regardless of the current working directory when the hook is triggered. Additionally, the Myco hook detection logic is updated to account for the new command format.

**Command execution improvements:**

* All Myco hook commands in settings/config files (e.g., `.claude/settings.json`, `.codex/hooks.json`, `.cursor/hooks.json`, `.gemini/settings.json`, `.github/hooks/myco-hooks.json`, `.windsurf/hooks.json`, and `src/symbionts/templates/claude-code/hooks.json`) now prepend a `cd` command to ensure execution from the project root. The method for determining the project root varies by integration (e.g., `${CLAUDE_PROJECT_DIR:-.}`, `$(git rev-parse --show-toplevel ...)`, `${CURSOR_PROJECT_DIR:-.}`, `${GEMINI_PROJECT_DIR:-.}`). [[1]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L11-R11) [[2]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L22-R22) [[3]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L33-R33) [[4]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L44-R44) [[5]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L55-R55) [[6]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L66-R66) [[7]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L77-R77) [[8]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L88-R88) [[9]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L99-R99) [[10]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L110-R110) [[11]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L121-R121) [[12]](diffhunk://#diff-f27ac6f39d89fe021c56900069198aa7d9968f2cd6645c00b11ffd1b78fcf546L132-R132) [[13]](diffhunk://#diff-82c735c2c8b1f488b042175dc6cdb87b0d096a73e37ce0e856be9839eaf2d3bfL8-R8) [[14]](diffhunk://#diff-82c735c2c8b1f488b042175dc6cdb87b0d096a73e37ce0e856be9839eaf2d3bfL19-R19) [[15]](diffhunk://#diff-82c735c2c8b1f488b042175dc6cdb87b0d096a73e37ce0e856be9839eaf2d3bfL30-R30) [[16]](diffhunk://#diff-82c735c2c8b1f488b042175dc6cdb87b0d096a73e37ce0e856be9839eaf2d3bfL41-R41) [[17]](diffhunk://#diff-2190b3739f11502c87a448fd4367f2c752de1918322b17c13de5502b41ce9277L5-R61) [[18]](diffhunk://#diff-a35d8b162b3ace88f15b157912306f86f3ffed751d9a0d46decb5dda65bb63b4L9-R9) [[19]](diffhunk://#diff-a35d8b162b3ace88f15b157912306f86f3ffed751d9a0d46decb5dda65bb63b4L21-R21) [[20]](diffhunk://#diff-a35d8b162b3ace88f15b157912306f86f3ffed751d9a0d46decb5dda65bb63b4L33-R33) [[21]](diffhunk://#diff-a35d8b162b3ace88f15b157912306f86f3ffed751d9a0d46decb5dda65bb63b4L45-R45) [[22]](diffhunk://#diff-a35d8b162b3ace88f15b157912306f86f3ffed751d9a0d46decb5dda65bb63b4L57-R57) [[23]](diffhunk://#diff-a35d8b162b3ace88f15b157912306f86f3ffed751d9a0d46decb5dda65bb63b4L69-R69) [[24]](diffhunk://#diff-929b11124e235ab2d31b0141efa9b36429a2736cbca099cf4a46d27056b40ea9L8-R8) [[25]](diffhunk://#diff-929b11124e235ab2d31b0141efa9b36429a2736cbca099cf4a46d27056b40ea9L19-R19) [[26]](diffhunk://#diff-929b11124e235ab2d31b0141efa9b36429a2736cbca099cf4a46d27056b40ea9L30-R30) [[27]](diffhunk://#diff-929b11124e235ab2d31b0141efa9b36429a2736cbca099cf4a46d27056b40ea9L41-R41) [[28]](diffhunk://#diff-929b11124e235ab2d31b0141efa9b36429a2736cbca099cf4a46d27056b40ea9L52-R52) [[29]](diffhunk://#diff-929b11124e235ab2d31b0141efa9b36429a2736cbca099cf4a46d27056b40ea9L63-R63) [[30]](diffhunk://#diff-929b11124e235ab2d31b0141efa9b36429a2736cbca099cf4a46d27056b40ea9L74-R74) [[31]](diffhunk://#diff-89091672475a415fc8f6711c8b71b9bab296e8a206160759780a47abe927ea1aL5-R20) [[32]](diffhunk://#diff-56f0133360540c2b8e3c525aae335301a860705097084b98c83d4d8c4d4a4bc0L7-R7)

**Detection logic update:**

* The `isMycoHookCommand` function in `src/symbionts/install-helpers.ts` is updated to recognize the new command format by checking for the presence of `.agents/myco-hook.cjs` anywhere in the command string, not just at the start. This ensures backward and forward compatibility with both old and new hook formats.

These changes make hook invocation more robust and compatible with different environments and project layouts.

## Related Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [ ] Enhancement / new feature
- [x] Refactor / code quality
- [ ] Documentation
- [ ] CI / workflow

## Validation

```bash
make check    # lint + 266 tests
```

## Checklist

- [x] `make check` passes locally
- [x] Tests added or updated where behavior changed
- [ ] Docs updated for user-visible changes
- [ ] No magic literals introduced (named constants in `src/constants.ts`)
