### PR TITLE
feat: multi-project update coordination

### DIFF
--- a/.myco/.gitignore
+++ b/.myco/.gitignore
@@ -13,6 +13,10 @@ secrets.env
 # Machine ID
 machine_id
 
+# Update tracking — per-machine state
+last-update-version
+restart-reason.json
+
 # Binary attachments — screenshots captured from transcripts
 attachments/
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -79,15 +79,22 @@ myco logs           # Tail daemon logs
 myco restart        # Manual restart (rarely needed)
 ```
 
-## After plugin updates
+## Updates
 
-When you update Myco:
+Myco installs a single global npm package, but a single machine may run one daemon per project. When a new version is available, you only need to update once — other projects catch up on their own.
 
-1. The running daemon keeps going with the old code until it shuts down naturally
-2. The next session start spawns a new daemon from the updated package
-3. The new daemon picks up seamlessly — same database, same indexes, same config
+### How to update
 
-No manual restart needed. If you want to pick up changes immediately, run `myco restart`.
+- **From the Operations page** — when a new version is available, an **Update & Restart** button appears. Click it to install the new package and restart that daemon.
+- **From the command line** — `npm update -g @goondocks/myco` installs the new version directly.
+
+Both paths end at the same state: the globally installed Myco package is at the new version.
+
+### What other projects do
+
+Other projects on the same machine discover the new version the next time you open their dashboard. They restart themselves, refresh their local hooks and symbiont registration if anything needs to change, and post a notification to their Operations page so you know what happened. You don't need to run `myco restart` or `myco update` manually in each project.
+
+If you want a daemon to pick up changes immediately rather than waiting for the next dashboard visit, `myco restart` still works and is instant.
 
 ## Configuration
 

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -72,6 +72,10 @@ secrets.env
 # Machine ID
 machine_id
 
+# Update tracking — per-machine state
+last-update-version
+restart-reason.json
+
 # Binary attachments — screenshots captured from transcripts
 attachments/
 

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -2,6 +2,8 @@ import { resolveVaultDir } from '../vault/resolve.js';
 import { VAULT_GITIGNORE, registerSymbionts } from './shared.js';
 import { loadManifests, resolvePackageRoot } from '../symbionts/detect.js';
 import { loadConfig, getEnabledSymbiontNames } from '../config/loader.js';
+import { getPluginVersion } from '../version.js';
+import { UPDATE_STAMP_FILENAME } from '../constants/update.js';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -72,6 +74,14 @@ export async function run(args: string[]): Promise<void> {
     updatedCount += registered;
   } else {
     console.log('  \u2013 No configured agents found');
+  }
+
+  // --- Write version stamp ---
+  try {
+    const stampPath = path.join(vaultDir, UPDATE_STAMP_FILENAME);
+    fs.writeFileSync(stampPath, getPluginVersion(), 'utf-8');
+  } catch {
+    // Non-fatal — stamp write failure shouldn't break the update
   }
 
   // --- Summary ---

--- a/src/constants/update.ts
+++ b/src/constants/update.ts
@@ -16,6 +16,12 @@ export const UPDATE_CONFIG_PATH = path.join(MYCO_GLOBAL_DIR, 'update.yaml');
 /** Path to the update error file (written by update script on failure). */
 export const UPDATE_ERROR_PATH = path.join(MYCO_GLOBAL_DIR, 'update-error.json');
 
+/** Filename for the version stamp written by `myco update` (lives inside vault .myco/). */
+export const UPDATE_STAMP_FILENAME = 'last-update-version';
+
+/** Filename for the restart reason signal file (lives inside vault .myco/). */
+export const RESTART_REASON_FILENAME = 'restart-reason.json';
+
 /** Default check interval in hours. */
 export const UPDATE_CHECK_INTERVAL_HOURS = 6;
 

--- a/src/daemon/api/update.ts
+++ b/src/daemon/api/update.ts
@@ -20,9 +20,13 @@ import {
   writeUpdateConfig,
   clearCachedCheck,
   isCacheStale,
+  getInstalledVersion,
 } from '../update-checker.js';
-import { spawnUpdateScript } from '../update-installer.js';
-import { RELEASE_CHANNELS } from '../../constants/update.js';
+import { spawnUpdateScript, spawnRestartScript } from '../update-installer.js';
+import { RELEASE_CHANNELS, UPDATE_STAMP_FILENAME } from '../../constants/update.js';
+import semver from 'semver';
+import fs from 'node:fs';
+import path from 'node:path';
 import type { RouteRequest, RouteResponse } from '../router.js';
 
 // ---------------------------------------------------------------------------
@@ -39,6 +43,8 @@ export interface UpdateDeps {
   currentVersion: string;
   /** Callback that schedules a graceful daemon shutdown after the update script spawns. */
   scheduleShutdown: () => void;
+  /** npm global prefix, resolved once at daemon startup. Null if resolution failed. */
+  globalPrefix: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -59,7 +65,21 @@ const ChannelBodySchema = z.object({
  * Returns an object with named handlers for each update endpoint.
  */
 export function createUpdateHandlers(deps: UpdateDeps) {
-  const { vaultDir, projectRoot, currentVersion, scheduleShutdown } = deps;
+  const { vaultDir, projectRoot, currentVersion, scheduleShutdown, globalPrefix } = deps;
+
+  /** Prevents multiple restart scripts from racing during the shutdown window. */
+  let restartInitiated = false;
+
+  /** Returns true when the stamp file matches the current running version. */
+  function isStampCurrent(): boolean {
+    try {
+      const stampPath = path.join(vaultDir, UPDATE_STAMP_FILENAME);
+      const stamp = fs.readFileSync(stampPath, 'utf-8').trim();
+      return stamp === currentVersion;
+    } catch {
+      return false;
+    }
+  }
 
   /**
    * GET /api/update/status — returns cached update state.
@@ -72,6 +92,35 @@ export function createUpdateHandlers(deps: UpdateDeps) {
       return { body: { exempt: true, running_version: currentVersion } };
     }
 
+    // --- Installed-version check (short-circuits before registry) ---
+    if (globalPrefix && !restartInitiated) {
+      const installedVersion = getInstalledVersion(globalPrefix);
+      if (
+        installedVersion &&
+        semver.valid(installedVersion) &&
+        semver.valid(currentVersion) &&
+        semver.gt(installedVersion, currentVersion)
+      ) {
+        restartInitiated = true;
+        const runLocalUpdate = !isStampCurrent();
+        spawnRestartScript({
+          projectRoot, vaultDir, runLocalUpdate,
+          fromVersion: currentVersion,
+          toVersion: installedVersion,
+        });
+        scheduleShutdown();
+        return {
+          body: {
+            restarting: true,
+            reason: 'version_sync',
+            running_version: currentVersion,
+            installed_version: installedVersion,
+          },
+        };
+      }
+    }
+
+    // --- Normal registry check flow (unchanged) ---
     const config = readUpdateConfig();
     const cache = readCachedCheck();
 

--- a/src/daemon/backup.ts
+++ b/src/daemon/backup.ts
@@ -32,6 +32,21 @@ export const BACKUP_TABLES = [
 /** File extension for backup dumps. */
 const BACKUP_EXTENSION = '.sql';
 
+/**
+ * Pattern matching a valid backup filename: `<machine_id>.sql`.
+ *
+ * Machine IDs follow `{github_user}_{machine_hash}` (see machine-id.ts)
+ * which uses alphanumerics, underscore, and hyphen — but never dots.
+ * The stem is constrained to `[A-Za-z0-9_-]` so a single literal `.sql`
+ * extension is the only dot in the filename.
+ *
+ * Constraining the stem rejects conflict markers introduced by cloud
+ * sync services when the backup directory lives inside a synced folder.
+ * These typically insert spaces, parentheses, quotes, or extra dots
+ * into filenames — none of which match a valid machine ID.
+ */
+const BACKUP_FILENAME_PATTERN = /^[A-Za-z0-9_-]+\.sql$/;
+
 /** Header comment template for backup files. */
 const BACKUP_HEADER_TEMPLATE = '-- Myco backup';
 
@@ -160,7 +175,7 @@ export function listBackups(backupDir: string): BackupMeta[] {
   const backups: BackupMeta[] = [];
 
   for (const entry of entries) {
-    if (!entry.endsWith(BACKUP_EXTENSION)) continue;
+    if (!BACKUP_FILENAME_PATTERN.test(entry)) continue;
 
     const filePath = path.join(backupDir, entry);
     const stat = fs.statSync(filePath);

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -23,7 +23,7 @@ import { handleGetConfig, handlePutConfig, createPlanDirHandlers } from './api/c
 import { handleLogSearch, handleLogStream, handleLogDetail, createLogIngestionHandler } from './api/log-explorer.js';
 import { handleRestart } from './api/restart.js';
 import { createUpdateHandlers } from './api/update.js';
-import { resolveGlobalPrefix } from './update-checker.js';
+import { resolveGlobalPrefix, detectDevBuild } from './update-checker.js';
 import { getMachineId } from './machine-id.js';
 import { createBackupHandlers, createBackupConfigHandlers } from './api/backup.js';
 import { createTeamHandlers } from './api/team-connect.js';
@@ -224,7 +224,11 @@ export async function main(): Promise<void> {
   const machineId = getMachineId(vaultDir);
   logger.info(LOG_KINDS.DAEMON_START, 'Machine ID resolved', { machine_id: machineId });
 
-  // --- Resolve npm global prefix for installed-version detection ---
+  // --- Resolve npm global prefix + detect dev build ---
+  // globalPrefix is used both for installed-version detection (in the status
+  // handler) and for dev-build auto-detection. When MYCO_CMD is already set
+  // by a symbiont hook or explicit shell env, we skip both — nothing needs
+  // the prefix.
   let globalPrefix: string | null = null;
   if (!process.env.MYCO_CMD) {
     try {
@@ -233,6 +237,23 @@ export async function main(): Promise<void> {
     } catch (err) {
       logger.warn(LOG_KINDS.DAEMON_START, 'Failed to resolve npm global prefix', {
         error: (err as Error).message,
+      });
+    }
+
+    // Auto-detect dev builds: if the running binary isn't under the global
+    // prefix, set MYCO_CMD to the current CLI entry so update checks are
+    // exempted and any restart script respawns the same dev binary.
+    const devCliEntry = detectDevBuild(
+      globalPrefix,
+      process.argv[1],
+      process.env.MYCO_CMD,
+      fs.realpathSync,
+    );
+    if (devCliEntry) {
+      process.env.MYCO_CMD = devCliEntry;
+      globalPrefix = null;
+      logger.info(LOG_KINDS.DAEMON_START, 'Dev build detected; MYCO_CMD auto-set', {
+        cmd: devCliEntry,
       });
     }
   }

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -23,6 +23,7 @@ import { handleGetConfig, handlePutConfig, createPlanDirHandlers } from './api/c
 import { handleLogSearch, handleLogStream, handleLogDetail, createLogIngestionHandler } from './api/log-explorer.js';
 import { handleRestart } from './api/restart.js';
 import { createUpdateHandlers } from './api/update.js';
+import { resolveGlobalPrefix } from './update-checker.js';
 import { getMachineId } from './machine-id.js';
 import { createBackupHandlers, createBackupConfigHandlers } from './api/backup.js';
 import { createTeamHandlers } from './api/team-connect.js';
@@ -119,6 +120,8 @@ import {
   RESTART_RESPONSE_FLUSH_MS,
   epochSeconds,
 } from '../constants.js';
+import { RESTART_REASON_FILENAME } from '../constants/update.js';
+import { notify } from '../notifications/notify.js';
 import { PowerManager } from './power.js';
 import { registerPowerJobs } from './power-jobs.js';
 import {
@@ -221,12 +224,69 @@ export async function main(): Promise<void> {
   const machineId = getMachineId(vaultDir);
   logger.info(LOG_KINDS.DAEMON_START, 'Machine ID resolved', { machine_id: machineId });
 
+  // --- Resolve npm global prefix for installed-version detection ---
+  let globalPrefix: string | null = null;
+  if (!process.env.MYCO_CMD) {
+    try {
+      globalPrefix = resolveGlobalPrefix();
+      logger.debug(LOG_KINDS.DAEMON_START, 'npm global prefix resolved', { prefix: globalPrefix });
+    } catch (err) {
+      logger.warn(LOG_KINDS.DAEMON_START, 'Failed to resolve npm global prefix', {
+        error: (err as Error).message,
+      });
+    }
+  }
+
   // --- SQLite initialization ---
   const db = initDatabase(vaultDbPath(vaultDir));
   createSchema(db, machineId);
   registerBuiltinDomains();
 
   logger.info(LOG_KINDS.DAEMON_START, 'SQLite initialized', { vault: vaultDir });
+
+  // --- Check for restart-reason signal file (left by version sync restart script) ---
+  {
+    const reasonPath = path.join(vaultDir, RESTART_REASON_FILENAME);
+    try {
+      if (fs.existsSync(reasonPath)) {
+        const raw = JSON.parse(fs.readFileSync(reasonPath, 'utf-8')) as {
+          reason?: string;
+          from_version?: string;
+          to_version?: string;
+          local_update_ran?: boolean;
+        };
+        fs.unlinkSync(reasonPath);
+
+        if (raw.reason === 'version_sync' && raw.to_version) {
+          const message = raw.local_update_ran
+            ? 'Restarted and updated local project hooks.'
+            : 'Restarted to pick up the latest version.';
+
+          notify(vaultDir, {
+            domain: 'daemon',
+            type: 'daemon.version_sync',
+            title: `Updated to v${raw.to_version}`,
+            message,
+            metadata: {
+              from_version: raw.from_version ?? 'unknown',
+              to_version: raw.to_version,
+              local_update_ran: raw.local_update_ran ?? false,
+            },
+          });
+
+          logger.info(LOG_KINDS.DAEMON_START, 'Version sync restart detected', {
+            from: raw.from_version,
+            to: raw.to_version,
+            local_update: raw.local_update_ran,
+          });
+        }
+      }
+    } catch (err) {
+      logger.warn(LOG_KINDS.DAEMON_START, 'Failed to read restart-reason file', {
+        error: (err as Error).message,
+      });
+    }
+  }
 
   // --- Team context ---
   initTeamContext(config.team.enabled, machineId);
@@ -450,6 +510,7 @@ export async function main(): Promise<void> {
     vaultDir,
     projectRoot: updateProjectRoot,
     currentVersion: server.version,
+    globalPrefix,
     scheduleShutdown: () => {
       setTimeout(() => {
         process.kill(process.pid, 'SIGTERM');

--- a/src/daemon/update-checker.ts
+++ b/src/daemon/update-checker.ts
@@ -74,11 +74,55 @@ const REGISTRY_FETCH_TIMEOUT_MS = 10_000;
 // ---------------------------------------------------------------------------
 
 /**
- * Returns true when MYCO_CMD is set — indicates a dev symlink is in use and
- * update checks should be skipped.
+ * Returns true when MYCO_CMD is set — indicates a dev build is in use and
+ * update checks should be skipped. The daemon auto-sets MYCO_CMD at startup
+ * via detectDevBuild() when the running binary is not under the npm global
+ * prefix, so this check covers both explicit overrides (from symbiont hooks)
+ * and auto-detected dev runs.
  */
 export function isUpdateExempt(): boolean {
   return Boolean(process.env.MYCO_CMD);
+}
+
+/**
+ * Detects whether the running daemon is a dev build by comparing the CLI
+ * entry point's realpath against the npm global prefix's realpath. Returns
+ * the CLI entry path when a dev build is detected (so the caller can assign
+ * it to `process.env.MYCO_CMD`), or null when no auto-assignment applies.
+ *
+ * A dev build is any binary whose realpath is NOT under the npm global
+ * prefix — direct `myco-dev` invocations, `npm link` installs, local
+ * `node dist/cli.js` runs, etc.
+ *
+ * Returns null when:
+ * - envMycoCmd is truthy (explicit override always wins)
+ * - globalPrefix is null (npm prefix resolution failed; can't verify)
+ * - cliEntry is missing
+ * - realpath resolution throws
+ * - the binary IS under the global prefix (proper install — normal updates)
+ *
+ * All inputs are passed explicitly (no defaults) so tests can control the
+ * environment without inheriting from the enclosing process.
+ */
+export function detectDevBuild(
+  globalPrefix: string | null,
+  cliEntry: string | undefined,
+  envMycoCmd: string | undefined,
+  realpath: (p: string) => string,
+): string | null {
+  if (envMycoCmd) return null;
+  if (!globalPrefix) return null;
+  if (!cliEntry) return null;
+  try {
+    const resolvedEntry = realpath(cliEntry);
+    const resolvedPrefix = realpath(globalPrefix);
+    if (resolvedEntry.startsWith(resolvedPrefix + path.sep) || resolvedEntry === resolvedPrefix) {
+      return null;
+    }
+    return cliEntry;
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/daemon/update-checker.ts
+++ b/src/daemon/update-checker.ts
@@ -12,11 +12,13 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 import YAML from 'yaml';
 import semver from 'semver';
 
 import {
   NPM_REGISTRY_URL,
+  NPM_PACKAGE_NAME,
   MYCO_GLOBAL_DIR,
   UPDATE_CHECK_CACHE_PATH,
   UPDATE_CONFIG_PATH,
@@ -251,6 +253,41 @@ function buildCheckResult(
     last_check: cache.checked_at,
     error,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Installed version detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves the npm global prefix by running `npm prefix -g`.
+ * Returns the trimmed path string. Throws on failure.
+ *
+ * Uses execFileSync (not execSync) to avoid shell injection — consistent
+ * with codebase conventions per src/utils/execFileNoThrow.ts patterns.
+ */
+export function resolveGlobalPrefix(): string {
+  return execFileSync('npm', ['prefix', '-g'], { encoding: 'utf-8', timeout: 5_000 }).trim();
+}
+
+/**
+ * Reads the version of the globally installed @goondocks/myco package
+ * from disk. Returns null if the package isn't installed or unreadable.
+ *
+ * Uses a direct fs.readFileSync of the package.json at the expected
+ * npm global path — no module resolution, no cache involvement.
+ */
+export function getInstalledVersion(globalPrefix: string): string | null {
+  try {
+    const pkgPath = path.join(
+      globalPrefix, 'lib', 'node_modules', NPM_PACKAGE_NAME, 'package.json',
+    );
+    const raw = fs.readFileSync(pkgPath, 'utf-8');
+    const pkg = JSON.parse(raw) as { version?: string };
+    return pkg.version ?? null;
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/daemon/update-installer.ts
+++ b/src/daemon/update-installer.ts
@@ -16,6 +16,7 @@ import {
   MYCO_GLOBAL_DIR,
   UPDATE_ERROR_PATH,
   UPDATE_SCRIPT_DELAY_SECONDS,
+  RESTART_REASON_FILENAME,
 } from '../constants/update.js';
 
 // ---------------------------------------------------------------------------
@@ -91,20 +92,12 @@ rm -f "$0"
 // ---------------------------------------------------------------------------
 
 /**
- * Writes the generated update script to a temp file, spawns it detached, and
- * unrefs the child so the parent process can exit without waiting.
- *
- * Returns the path to the temporary script file.
+ * Writes a script to a temp file, spawns it detached, and unrefs the child
+ * so the parent process can exit without waiting.
  */
-export function spawnUpdateScript(params: InstallParams): string {
-  // Ensure ~/.myco/ exists before writing the error path or checking state.
-  fs.mkdirSync(MYCO_GLOBAL_DIR, { recursive: true });
-
-  const scriptName = `myco-update-${Date.now()}.sh`;
-  const scriptPath = path.join(os.tmpdir(), scriptName);
-
-  const script = generateUpdateScript(params);
-  fs.writeFileSync(scriptPath, script, { encoding: 'utf-8', mode: 0o755 });
+function spawnDetachedScript(namePrefix: string, content: string): string {
+  const scriptPath = path.join(os.tmpdir(), `${namePrefix}-${Date.now()}.sh`);
+  fs.writeFileSync(scriptPath, content, { encoding: 'utf-8', mode: 0o755 });
 
   const child = spawn('/bin/sh', [scriptPath], {
     detached: true,
@@ -113,4 +106,86 @@ export function spawnUpdateScript(params: InstallParams): string {
   child.unref();
 
   return scriptPath;
+}
+
+/**
+ * Generates and spawns the update script. Returns the script path.
+ */
+export function spawnUpdateScript(params: InstallParams): string {
+  // Ensure ~/.myco/ exists before writing the error path or checking state.
+  fs.mkdirSync(MYCO_GLOBAL_DIR, { recursive: true });
+  return spawnDetachedScript('myco-update', generateUpdateScript(params));
+}
+
+// ---------------------------------------------------------------------------
+// Restart script (no npm install — just restart + conditional local update)
+// ---------------------------------------------------------------------------
+
+/** Parameters for a restart-only script (no global npm install). */
+export interface RestartParams {
+  /** Absolute path to the project root for `myco update --project`. */
+  projectRoot: string;
+  /** Absolute path to the vault directory for `myco daemon --vault`. */
+  vaultDir: string;
+  /** Whether to run `myco update --project` before restarting. */
+  runLocalUpdate: boolean;
+  /** The version currently running (baked into the script to avoid shell interpolation). */
+  fromVersion: string;
+  /** The version that will be running after restart (baked into the script). */
+  toVersion: string;
+}
+
+/**
+ * Generates a POSIX shell script that:
+ * 1. Waits for the daemon to exit.
+ * 2. Optionally runs `myco update --project` when runLocalUpdate is true.
+ * 3. Writes restart-reason.json into the vault.
+ * 4. Starts `myco daemon --vault` in background.
+ * 5. Cleans up the script file.
+ */
+export function generateRestartScript(params: RestartParams): string {
+  const { projectRoot, vaultDir, runLocalUpdate, fromVersion, toVersion } = params;
+  const quotedProjectRoot = JSON.stringify(projectRoot);
+  const quotedVaultDir = JSON.stringify(vaultDir);
+  const reasonFile = JSON.stringify(path.join(vaultDir, RESTART_REASON_FILENAME));
+
+  // Bake version strings and reason JSON from Node to avoid shell interpolation
+  // in heredocs — prevents JSON corruption from unexpected characters.
+  const reasonJson = JSON.stringify(JSON.stringify({
+    reason: 'version_sync',
+    from_version: fromVersion,
+    to_version: toVersion,
+    local_update_ran: runLocalUpdate,
+  }));
+
+  const updateBlock = runLocalUpdate
+    ? `
+# Run local project update (hooks, symbionts, gitignore)
+"$MYCO" update --project ${quotedProjectRoot} || true`
+    : '';
+
+  return `#!/bin/sh
+set -e
+MYCO="\${MYCO_CMD:-myco}"
+
+# Wait for daemon to exit cleanly
+sleep ${UPDATE_SCRIPT_DELAY_SECONDS}
+${updateBlock}
+
+# Write restart reason for the new daemon to pick up
+echo ${reasonJson} > ${reasonFile}
+
+# Restart daemon
+"$MYCO" daemon --vault ${quotedVaultDir} &
+
+# Clean up this script
+rm -f "$0"
+`;
+}
+
+/**
+ * Generates and spawns the restart script. Returns the script path.
+ */
+export function spawnRestartScript(params: RestartParams): string {
+  return spawnDetachedScript('myco-restart', generateRestartScript(params));
 }

--- a/src/notifications/domains.ts
+++ b/src/notifications/domains.ts
@@ -45,4 +45,12 @@ export function registerBuiltinDomains(): void {
       { id: 'mycelium.spore.created', label: 'New spore extracted', defaultMode: 'summary', defaultLevel: 'info' },
     ],
   });
+
+  register({
+    domain: 'daemon',
+    label: 'Daemon',
+    types: [
+      { id: 'daemon.version_sync', label: 'Version sync restart', defaultMode: 'banner', defaultLevel: 'info' },
+    ],
+  });
 }

--- a/tests/cli/update.test.ts
+++ b/tests/cli/update.test.ts
@@ -147,4 +147,21 @@ describe('myco update', () => {
     const installedNames = vi.mocked(SymbiontInstaller).mock.calls.map((call) => call[0].name).sort();
     expect(installedNames).toEqual(['claude-code', 'cursor', 'gemini', 'vscode-copilot']);
   });
+
+  it('writes last-update-version stamp file after successful update', async () => {
+    const config = {
+      version: 3, config_version: 0,
+      symbionts: { 'claude-code': { enabled: true } },
+    };
+    fs.writeFileSync(path.join(vaultDir, 'myco.yaml'), YAML.stringify(config));
+    fs.mkdirSync(path.join(testDir, '.claude'), { recursive: true });
+
+    const { run } = await import('@myco/cli/update.js');
+    await run(['--project', testDir]);
+
+    const stampPath = path.join(vaultDir, 'last-update-version');
+    expect(fs.existsSync(stampPath)).toBe(true);
+    const stamp = fs.readFileSync(stampPath, 'utf-8').trim();
+    expect(stamp).toMatch(/^\d+\.\d+\.\d+/);
+  });
 });

--- a/tests/daemon/api/update.test.ts
+++ b/tests/daemon/api/update.test.ts
@@ -23,10 +23,12 @@ vi.mock('../../../src/daemon/update-checker.js', () => ({
   writeUpdateConfig: vi.fn(),
   clearCachedCheck: vi.fn(),
   isCacheStale: vi.fn(() => false),
+  getInstalledVersion: vi.fn(() => null),
 }));
 
 vi.mock('../../../src/daemon/update-installer.js', () => ({
   spawnUpdateScript: vi.fn(() => '/tmp/myco-update-123.sh'),
+  spawnRestartScript: vi.fn(() => '/tmp/myco-restart-123.sh'),
 }));
 
 import {
@@ -38,8 +40,9 @@ import {
   writeUpdateConfig,
   clearCachedCheck,
   isCacheStale,
+  getInstalledVersion,
 } from '../../../src/daemon/update-checker.js';
-import { spawnUpdateScript } from '../../../src/daemon/update-installer.js';
+import { spawnUpdateScript, spawnRestartScript } from '../../../src/daemon/update-installer.js';
 import { createUpdateHandlers } from '../../../src/daemon/api/update.js';
 import type { RouteRequest } from '../../../src/daemon/router.js';
 
@@ -349,5 +352,98 @@ describe('handleUpdateChannel', () => {
 
     expect(stable.status).toBeUndefined();
     expect(beta.status).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleUpdateStatus — restart_required detection
+// ---------------------------------------------------------------------------
+
+describe('handleUpdateStatus — restart_required', () => {
+  beforeEach(() => {
+    vi.mocked(isUpdateExempt).mockReturnValue(false);
+    vi.mocked(readCachedCheck).mockReturnValue(null);
+    vi.mocked(readUpdateConfig).mockReturnValue({ channel: 'stable', check_interval_hours: 6 });
+    vi.mocked(isCacheStale).mockReturnValue(false);
+    vi.mocked(statusFromCache).mockReturnValue(NO_UPDATE_STATUS);
+    vi.mocked(getInstalledVersion).mockReset();
+    vi.mocked(getInstalledVersion).mockReturnValue(null);
+    vi.mocked(spawnRestartScript).mockReset();
+    vi.mocked(spawnRestartScript).mockReturnValue('/tmp/myco-restart-123.sh');
+  });
+
+  it('triggers auto-restart when installed version > running version', async () => {
+    vi.mocked(getInstalledVersion).mockReturnValue('1.1.0');
+    const scheduleShutdown = vi.fn();
+    const { handleUpdateStatus } = createUpdateHandlers(
+      makeDeps({ scheduleShutdown, globalPrefix: '/usr/local' }),
+    );
+
+    const result = await handleUpdateStatus(makeReq());
+
+    expect(spawnRestartScript).toHaveBeenCalled();
+    expect(scheduleShutdown).toHaveBeenCalled();
+    expect(result.body).toMatchObject({ restarting: true, reason: 'version_sync' });
+  });
+
+  it('does not trigger restart when installed version matches running version', async () => {
+    vi.mocked(getInstalledVersion).mockReturnValue('1.0.0');
+    const { handleUpdateStatus } = createUpdateHandlers(
+      makeDeps({ globalPrefix: '/usr/local' }),
+    );
+
+    const result = await handleUpdateStatus(makeReq());
+
+    expect(spawnRestartScript).not.toHaveBeenCalled();
+    expect((result.body as Record<string, unknown>).restarting).toBeUndefined();
+  });
+
+  it('falls back to normal flow when installed version is null', async () => {
+    vi.mocked(getInstalledVersion).mockReturnValue(null);
+    vi.mocked(statusFromCache).mockReturnValue(NO_UPDATE_STATUS);
+    const { handleUpdateStatus } = createUpdateHandlers(
+      makeDeps({ globalPrefix: '/usr/local' }),
+    );
+
+    const result = await handleUpdateStatus(makeReq());
+
+    expect(spawnRestartScript).not.toHaveBeenCalled();
+    expect(result.body).toMatchObject({ exempt: false });
+  });
+
+  it('skips restart check when exempt (dev mode)', async () => {
+    vi.mocked(isUpdateExempt).mockReturnValue(true);
+    vi.mocked(getInstalledVersion).mockReturnValue('2.0.0');
+    const { handleUpdateStatus } = createUpdateHandlers(
+      makeDeps({ globalPrefix: '/usr/local' }),
+    );
+
+    const result = await handleUpdateStatus(makeReq());
+
+    expect(spawnRestartScript).not.toHaveBeenCalled();
+    expect(result.body).toMatchObject({ exempt: true });
+  });
+
+  it('skips restart check when globalPrefix is null', async () => {
+    vi.mocked(getInstalledVersion).mockReturnValue('1.1.0');
+    const { handleUpdateStatus } = createUpdateHandlers(
+      makeDeps({ globalPrefix: null }),
+    );
+
+    const result = await handleUpdateStatus(makeReq());
+
+    expect(spawnRestartScript).not.toHaveBeenCalled();
+    expect(getInstalledVersion).not.toHaveBeenCalled();
+  });
+
+  it('does not restart when installed version is lower than running (downgrade)', async () => {
+    vi.mocked(getInstalledVersion).mockReturnValue('0.9.0');
+    const { handleUpdateStatus } = createUpdateHandlers(
+      makeDeps({ globalPrefix: '/usr/local' }),
+    );
+
+    const result = await handleUpdateStatus(makeReq());
+
+    expect(spawnRestartScript).not.toHaveBeenCalled();
   });
 });

--- a/tests/daemon/backup.test.ts
+++ b/tests/daemon/backup.test.ts
@@ -243,6 +243,32 @@ describe('backup engine', () => {
       const backups = listBackups(tmpDir);
       expect(backups).toHaveLength(1);
     });
+
+    it('ignores cloud-sync conflict files with special characters', () => {
+      seedAgent();
+      seedSession('sess-007', LOCAL_MACHINE);
+      createBackup(getDatabase(), tmpDir, LOCAL_MACHINE);
+
+      // Conflict marker with spaces, parens, and hash (e.g. Proton Drive)
+      fs.writeFileSync(
+        path.join(tmpDir, `${LOCAL_MACHINE} (# Edit conflict 2000-01-01 XXXXXXX #).sql`),
+        'fake backup',
+      );
+      // Conflict marker with spaces and parens (e.g. Dropbox)
+      fs.writeFileSync(
+        path.join(tmpDir, `${LOCAL_MACHINE} (conflicted copy 2000-01-01).sql`),
+        'fake backup',
+      );
+      // Conflict marker with extra dots (e.g. Syncthing)
+      fs.writeFileSync(
+        path.join(tmpDir, `${LOCAL_MACHINE}.sync-conflict-20000101-000000-ABCDEF0.sql`),
+        'fake backup',
+      );
+
+      const backups = listBackups(tmpDir);
+      expect(backups).toHaveLength(1);
+      expect(backups[0].file_name).toBe(`${LOCAL_MACHINE}.sql`);
+    });
   });
 
   describe('restorePreview()', () => {

--- a/tests/daemon/update-checker.test.ts
+++ b/tests/daemon/update-checker.test.ts
@@ -35,6 +35,8 @@ import {
   isCacheStale,
   checkForUpdate,
   statusFromCache,
+  resolveGlobalPrefix,
+  getInstalledVersion,
   type CachedCheck,
   type UpdateConfig,
 } from '@myco/daemon/update-checker.js';
@@ -443,5 +445,59 @@ describe('statusFromCache()', () => {
     const result = statusFromCache('1.0.0');
     expect(result!.update_available).toBe(true);
     expect(result!.latest_version).toBe('1.1.0-beta.1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveGlobalPrefix
+// ---------------------------------------------------------------------------
+
+describe('resolveGlobalPrefix()', () => {
+  it('returns trimmed stdout from npm prefix -g', () => {
+    // This test runs against the real npm — just verify it returns a non-empty string
+    const prefix = resolveGlobalPrefix();
+    expect(typeof prefix).toBe('string');
+    expect(prefix.length).toBeGreaterThan(0);
+    expect(prefix).not.toMatch(/\n/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getInstalledVersion
+// ---------------------------------------------------------------------------
+
+describe('getInstalledVersion()', () => {
+  it('returns version string when package.json exists at expected path', () => {
+    vi.mocked(fs.readFileSync).mockImplementation((p, _opts) => {
+      if (String(p).includes('@goondocks/myco/package.json')) {
+        return JSON.stringify({ version: '1.2.3' });
+      }
+      const err: NodeJS.ErrnoException = new Error(`ENOENT: ${String(p)}`);
+      err.code = 'ENOENT';
+      throw err;
+    });
+
+    const result = getInstalledVersion('/usr/local');
+    expect(result).toBe('1.2.3');
+  });
+
+  it('returns null when package.json does not exist', () => {
+    mockNoFiles();
+    const result = getInstalledVersion('/usr/local');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when package.json is malformed', () => {
+    vi.mocked(fs.readFileSync).mockImplementation((p, _opts) => {
+      if (String(p).includes('@goondocks/myco/package.json')) {
+        return 'not json';
+      }
+      const err: NodeJS.ErrnoException = new Error(`ENOENT: ${String(p)}`);
+      err.code = 'ENOENT';
+      throw err;
+    });
+
+    const result = getInstalledVersion('/usr/local');
+    expect(result).toBeNull();
   });
 });

--- a/tests/daemon/update-checker.test.ts
+++ b/tests/daemon/update-checker.test.ts
@@ -37,6 +37,7 @@ import {
   statusFromCache,
   resolveGlobalPrefix,
   getInstalledVersion,
+  detectDevBuild,
   type CachedCheck,
   type UpdateConfig,
 } from '@myco/daemon/update-checker.js';
@@ -498,6 +499,94 @@ describe('getInstalledVersion()', () => {
     });
 
     const result = getInstalledVersion('/usr/local');
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectDevBuild
+// ---------------------------------------------------------------------------
+
+describe('detectDevBuild()', () => {
+  /** Identity resolver — test paths don't exist, so bypass real realpath. */
+  const identityResolver = (p: string) => p;
+
+  it('returns null when MYCO_CMD is already set', () => {
+    const result = detectDevBuild('/opt/homebrew', '/home/user/.local/bin/myco-dev', 'myco-dev', identityResolver);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when globalPrefix is null', () => {
+    const result = detectDevBuild(null, '/home/user/.local/bin/myco-dev', undefined, identityResolver);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when cliEntry is missing', () => {
+    const result = detectDevBuild('/opt/homebrew', undefined, undefined, identityResolver);
+    expect(result).toBeNull();
+  });
+
+  it('returns cliEntry when binary is outside global prefix (dev build)', () => {
+    const result = detectDevBuild(
+      '/opt/homebrew',
+      '/home/user/.local/bin/myco-dev',
+      undefined,
+      identityResolver,
+    );
+    expect(result).toBe('/home/user/.local/bin/myco-dev');
+  });
+
+  it('returns null when binary is inside global prefix (proper install)', () => {
+    const result = detectDevBuild(
+      '/opt/homebrew',
+      '/opt/homebrew/lib/node_modules/@goondocks/myco/dist/cli.js',
+      undefined,
+      identityResolver,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('does not match on path prefix that is only a string prefix, not a path boundary', () => {
+    // /opt/homebrew-foo should NOT be considered under /opt/homebrew
+    const result = detectDevBuild(
+      '/opt/homebrew',
+      '/opt/homebrew-foo/bin/myco',
+      undefined,
+      identityResolver,
+    );
+    expect(result).toBe('/opt/homebrew-foo/bin/myco');
+  });
+
+  it('resolves symlinks via realpath before comparing', () => {
+    // Simulate a symlink: /home/user/.local/bin/myco-dev → /opt/homebrew/lib/node_modules/...
+    // If we followed the symlink, it would look like a proper install.
+    const symlinkResolver = (p: string) => {
+      if (p === '/home/user/.local/bin/myco-dev') {
+        return '/opt/homebrew/lib/node_modules/@goondocks/myco/dist/cli.js';
+      }
+      return p;
+    };
+
+    const result = detectDevBuild(
+      '/opt/homebrew',
+      '/home/user/.local/bin/myco-dev',
+      undefined,
+      symlinkResolver,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null when realpath throws', () => {
+    const throwingResolver = () => {
+      throw new Error('ENOENT');
+    };
+
+    const result = detectDevBuild(
+      '/opt/homebrew',
+      '/home/user/.local/bin/myco-dev',
+      undefined,
+      throwingResolver,
+    );
     expect(result).toBeNull();
   });
 });

--- a/tests/daemon/update-installer.test.ts
+++ b/tests/daemon/update-installer.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { generateRestartScript, generateUpdateScript } from '@myco/daemon/update-installer.js';
+
+describe('generateRestartScript()', () => {
+  const baseParams = {
+    projectRoot: '/home/user/project',
+    vaultDir: '/home/user/project/.myco',
+    fromVersion: '0.17.0',
+    toVersion: '0.17.1',
+  };
+
+  it('includes myco update when runLocalUpdate is true', () => {
+    const script = generateRestartScript({ ...baseParams, runLocalUpdate: true });
+    expect(script).toContain('update --project');
+    expect(script).toContain('/home/user/project');
+  });
+
+  it('skips myco update when runLocalUpdate is false', () => {
+    const script = generateRestartScript({ ...baseParams, runLocalUpdate: false });
+    expect(script).not.toContain('update --project');
+  });
+
+  it('always starts the daemon with --vault', () => {
+    const script = generateRestartScript({ ...baseParams, runLocalUpdate: false });
+    expect(script).toContain('daemon --vault');
+    expect(script).toContain('/home/user/project/.myco');
+  });
+
+  it('writes restart-reason.json before starting daemon', () => {
+    const script = generateRestartScript({ ...baseParams, runLocalUpdate: true });
+    expect(script).toContain('restart-reason.json');
+  });
+
+  it('uses MYCO_CMD env var with fallback', () => {
+    const script = generateRestartScript({ ...baseParams, runLocalUpdate: false });
+    expect(script).toContain('${MYCO_CMD:-myco}');
+  });
+
+  it('cleans up the script file', () => {
+    const script = generateRestartScript({ ...baseParams, runLocalUpdate: false });
+    expect(script).toContain('rm -f "$0"');
+  });
+
+  it('bakes version strings into reason JSON from Node', () => {
+    const script = generateRestartScript({ ...baseParams, runLocalUpdate: true });
+    expect(script).toContain('0.17.0');
+    expect(script).toContain('0.17.1');
+    expect(script).toContain('version_sync');
+  });
+
+  it('handles paths with spaces via JSON quoting', () => {
+    const script = generateRestartScript({
+      ...baseParams,
+      projectRoot: '/home/user/my project',
+      vaultDir: '/home/user/my project/.myco',
+      runLocalUpdate: true,
+    });
+    expect(script).toContain('my project');
+  });
+});
+
+describe('generateUpdateScript()', () => {
+  it('generates a valid update script (existing behavior sanity check)', () => {
+    const script = generateUpdateScript({
+      targetVersion: '1.0.0',
+      projectRoot: '/project',
+      vaultDir: '/project/.myco',
+    });
+    expect(script).toContain('npm install -g');
+    expect(script).toContain('update --project');
+  });
+});

--- a/ui/src/components/operations/UpdateCard.tsx
+++ b/ui/src/components/operations/UpdateCard.tsx
@@ -1,10 +1,11 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { ArrowUpCircle, RefreshCw, CheckCircle2, AlertCircle, Shield } from 'lucide-react';
 import { Surface } from '../ui/surface';
 import { SectionHeader } from '../ui/section-header';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { cn } from '../../lib/cn';
+import { RELEASE_CHANNELS } from '../../lib/constants';
 import {
   useUpdateStatus,
   useUpdateCheck,
@@ -13,8 +14,6 @@ import {
 } from '../../hooks/use-update-status';
 
 /* ---------- Constants ---------- */
-
-const CHANNELS = ['stable', 'beta'] as const;
 
 /** Interval for polling /health after update apply (ms). */
 const HEALTH_POLL_INTERVAL_MS = 500;
@@ -44,6 +43,36 @@ export function UpdateCard() {
 
   const [applyState, setApplyState] = useState<ApplyState>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // Handle server-initiated restart (version sync)
+  useEffect(() => {
+    if (!status?.restarting) return;
+    if (applyState !== 'idle') return;
+
+    setApplyState('restarting');
+
+    const deadline = Date.now() + HEALTH_POLL_TIMEOUT_MS;
+    let cancelled = false;
+
+    const poll = async () => {
+      if (cancelled || Date.now() > deadline) return;
+      try {
+        const res = await fetch('/health');
+        if (res.ok) {
+          window.location.reload();
+          return;
+        }
+      } catch { /* daemon still down */ }
+      if (!cancelled) setTimeout(poll, HEALTH_POLL_INTERVAL_MS);
+    };
+
+    const timer = setTimeout(poll, HEALTH_POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [status?.restarting, applyState]);
 
   const handleApply = useCallback(async () => {
     setApplyState('applying');
@@ -176,7 +205,7 @@ export function UpdateCard() {
       {/* Channel toggle row */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1">
-          {CHANNELS.map((ch) => (
+          {RELEASE_CHANNELS.map((ch) => (
             <Button
               key={ch}
               variant={activeChannel === ch ? 'default' : 'ghost'}

--- a/ui/src/hooks/use-update-status.ts
+++ b/ui/src/hooks/use-update-status.ts
@@ -16,6 +16,9 @@ export interface UpdateStatus {
   check_interval_hours?: number;
   last_check?: string;
   error?: string | null;
+  /** Set when daemon is auto-restarting for a version sync. */
+  restarting?: boolean;
+  reason?: string;
 }
 
 interface ApplyResponse {

--- a/ui/src/lib/constants.ts
+++ b/ui/src/lib/constants.ts
@@ -20,6 +20,10 @@ export const LEVEL_ORDER: Record<LogLevel, number> = { debug: 0, info: 1, warn: 
 export const TASK_SOURCE_BUILTIN = 'built-in';
 export const TASK_SOURCE_USER = 'user';
 
+/** Release channels — must match backend RELEASE_CHANNELS. */
+export const RELEASE_CHANNELS = ['stable', 'beta'] as const;
+export type ReleaseChannel = (typeof RELEASE_CHANNELS)[number];
+
 /** Default page size for paginated list views. */
 export const DEFAULT_PAGE_SIZE = 50;
 


### PR DESCRIPTION
Adds transparent auto-restart for daemons running stale code when another
project on the same machine has already updated the global @goondocks/myco
package. Eliminates the redundant npm install loop, the "update available"
nag on already-updated installs, and the need to manually run `myco update`
across every project after a global update.

Three-state update detection:
- update_available → registry > installed → "Update & Restart" button (unchanged)
- restart_required → installed > running → silent auto-restart + notification
- up_to_date → no action

Detection reads the globally installed package.json directly from the npm
global prefix (resolved once at daemon startup via `npm prefix -g`). The
check runs before the registry fetch on each /api/update/status poll and
short-circuits to an auto-restart when installed > running.

Auto-restart flow:
- Detached restart script writes .myco/restart-reason.json with version
  metadata baked in from Node (no shell interpolation)
- Script conditionally runs `myco update --project` based on the
  .myco/last-update-version stamp file, written by every successful
  `myco update` invocation
- New daemon reads + deletes the restart-reason file on startup and emits
  a `daemon.version_sync` notification via the existing notification system
- UI recognizes `restarting: true` in the status response and enters the
  existing health-poll + reload flow

A restartInitiated guard prevents duplicate restart scripts from racing
during the shutdown window. Dev mode (MYCO_CMD) skips the entire installed-
version check — no more false "update available" nags when running myco-dev.

## Summary

This pull request introduces several improvements to update tracking, version synchronization, and backup file validation in the codebase. It adds mechanisms for the daemon to detect and handle version mismatches between the running and installed versions, manages per-machine update state, and strengthens backup file safety. Additionally, it introduces robust detection for development builds and improves notification handling for version sync restarts.

**Update tracking and version synchronization:**

* Added new per-machine state files (`last-update-version`, `restart-reason.json`) to `.gitignore` and update logic, enabling the daemon to track and respond to version changes and restarts. [[1]](diffhunk://#diff-a261922f70dca44dab9ac20809d2132ee48a32d9e7a37f39204aac0ce8c0830aR16-R19) [[2]](diffhunk://#diff-a8a11cbc40b7766f487470deca79ee5fcaf3b7e8c79d022df298492a22a1070aR75-R78) [[3]](diffhunk://#diff-38a9116e60cc94c62e6c4d64fce505e74e39f4e2e66c9768e18080db9c66af3fR19-R24)
* Implemented installed version detection using the npm global prefix; the daemon now compares the running version to the globally installed version and triggers a controlled restart if a newer version is detected, including writing and reading version stamp and restart reason files. [[1]](diffhunk://#diff-96db68f887b06630b636c16f3808a00528a6fe2c8ee4956443c22aff35071afbR302-R336) [[2]](diffhunk://#diff-37752edda9103bbf98ce99d8469231a1f3ddfd04d7edc974ddb8741584aaed18R46-R47) [[3]](diffhunk://#diff-37752edda9103bbf98ce99d8469231a1f3ddfd04d7edc974ddb8741584aaed18L62-R82) [[4]](diffhunk://#diff-37752edda9103bbf98ce99d8469231a1f3ddfd04d7edc974ddb8741584aaed18R95-R123) [[5]](diffhunk://#diff-c24dc3f7fbaab050ebdd02b561c3094ec46f9d2ab383e359c6e27487b46a70a7R227-R311) [[6]](diffhunk://#diff-c24dc3f7fbaab050ebdd02b561c3094ec46f9d2ab383e359c6e27487b46a70a7R534)

**Dev build detection and update exemption:**

* Added `detectDevBuild` to automatically exempt dev builds from update checks and ensure restarts respawn the correct binary; this is now used during daemon startup. [[1]](diffhunk://#diff-96db68f887b06630b636c16f3808a00528a6fe2c8ee4956443c22aff35071afbL75-R127) [[2]](diffhunk://#diff-c24dc3f7fbaab050ebdd02b561c3094ec46f9d2ab383e359c6e27487b46a70a7R227-R311)

**User notification and restart handling:**

* The daemon now checks for a `restart-reason.json` signal file on startup, sends a notification if a version sync occurred, and logs relevant metadata. [[1]](diffhunk://#diff-c24dc3f7fbaab050ebdd02b561c3094ec46f9d2ab383e359c6e27487b46a70a7R123-R124) [[2]](diffhunk://#diff-c24dc3f7fbaab050ebdd02b561c3094ec46f9d2ab383e359c6e27487b46a70a7R227-R311)

**Backup file validation:**

* Strengthened backup file validation by introducing a strict filename pattern, ensuring only legitimate backup files are processed and ignoring conflict marker files from cloud sync services. [[1]](diffhunk://#diff-6ee786feccd733ce91e6f2be84d6c4b1f4ec234c17672dc4dd963f3dc958b383R35-R49) [[2]](diffhunk://#diff-6ee786feccd733ce91e6f2be84d6c4b1f4ec234c17672dc4dd963f3dc958b383L163-R178)

**Internal refactoring:**

* Refactored script spawning logic for update and restart scripts to reduce duplication and improve clarity.

These changes collectively improve update safety, reliability, and user experience during version transitions.

## Related Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [x] Enhancement / new feature
- [x] Refactor / code quality
- [ ] Documentation
- [ ] CI / workflow

## Validation

```bash
make check    # lint + 266 tests
```

## Checklist

- [x] `make check` passes locally
- [x] Tests added or updated where behavior changed
- [ ] Docs updated for user-visible changes
- [ ] No magic literals introduced (named constants in `src/constants.ts`)
