### PR TITLE
feat(symbionts): Codex plan capture + transcript parser architecture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.18.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.92",
-        "@anthropic-ai/sdk": "^0.82.0",
-        "@inquirer/prompts": "^8.3.2",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.104",
+        "@anthropic-ai/sdk": "^0.88.0",
+        "@inquirer/prompts": "^8.4.1",
         "@modelcontextprotocol/sdk": "^1.28.0",
-        "better-sqlite3": "^12.8.0",
+        "better-sqlite3": "^12.9.0",
         "chokidar": "^5.0.0",
         "gray-matter": "^4.0.3",
         "semver": "^7.7.4",
@@ -27,22 +27,22 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.6.0",
         "@types/semver": "^7.7.1",
         "tsup": "^8.0.0",
         "tsx": "^4.0.0",
         "typescript": "^6.0.2",
-        "vitest": "^4.1.2"
+        "vitest": "^4.1.4"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.92",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.92.tgz",
-      "integrity": "sha512-loYyxVUC5gBwHjGi9Fv0b84mduJTp9Z3Pum+y/7IVQDb4NynKfVQl6l4VeDKZaW+1QTQtd25tY4hwUznD7Krqw==",
+      "version": "0.2.104",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.104.tgz",
+      "integrity": "sha512-lVm+nS79r6WWlDnv5AgRzTtAlbP8O6M6kkWmDZAWE3nt9agmngxls9frJFvH55uzws2+6l0yyup/JYspfijkzw==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.80.0",
-        "@modelcontextprotocol/sdk": "^1.27.1"
+        "@anthropic-ai/sdk": "^0.81.0",
+        "@modelcontextprotocol/sdk": "^1.29.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -63,9 +63,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/sdk": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.80.0.tgz",
-      "integrity": "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -83,9 +83,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.82.0.tgz",
-      "integrity": "sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.88.0.tgz",
+      "integrity": "sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -112,38 +112,35 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -907,24 +904,24 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.4.tgz",
-      "integrity": "sha512-DpcZrQObd7S0R/U3bFdkcT5ebRwbTTC4D3tCc1vsJizmgPLxNJBo+AAFmrZwe8zk30P2QzgzGWZ3Q9uJwWuhIg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.2.tgz",
-      "integrity": "sha512-PubpMPO2nJgMufkoB3P2wwxNXEMUXnBIKi/ACzDUYfaoPuM7gSTmuxJeMscoLVEsR4qqrCMf5p0SiYGWnVJ8kw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.3.tgz",
+      "integrity": "sha512-+G7I8CT+EHv/hasNfUl3P37DVoMoZfpA+2FXmM54dA8MxYle1YqucxbacxHalw1iAFSdKNEDTGNV7F+j1Ldqcg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.4",
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/figures": "^2.0.4",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -939,13 +936,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.10.tgz",
-      "integrity": "sha512-tiNyA73pgpQ0FQ7axqtoLUe4GDYjNCDcVsbgcA5anvwg2z6i+suEngLKKJrWKJolT//GFPZHwN30binDIHgSgQ==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.11.tgz",
+      "integrity": "sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -960,14 +957,14 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "11.1.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.7.tgz",
-      "integrity": "sha512-1BiBNDk9btIwYIzNZpkikIHXWeNzNncJePPqwDyVMhXhD1ebqbpn1mKGctpoqAbzywZfdG0O4tvmsGIcOevAPQ==",
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.8.tgz",
+      "integrity": "sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.4",
-        "@inquirer/figures": "^2.0.4",
-        "@inquirer/type": "^4.0.4",
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -986,14 +983,14 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.10.tgz",
-      "integrity": "sha512-VJx4XyaKea7t8hEApTw5dxeIyMtWXre2OiyJcICCRZI4hkoHsMoCnl/KbUnJJExLbH9csLLHMVR144ZhFE1CwA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.1.0.tgz",
+      "integrity": "sha512-6wlkYl65Qfayy48gPCfU4D7li6KCAGN79mLXa/tYHZH99OfZ820yY+HA+DgE88r8YwwgeuY6PQgNqMeK6LuMmw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/external-editor": "^2.0.4",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/external-editor": "^3.0.0",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1008,13 +1005,13 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.10.tgz",
-      "integrity": "sha512-fC0UHJPXsTRvY2fObiwuQYaAnHrp3aDqfwKUJSdfpgv18QUG054ezGbaRNStk/BKD5IPijeMKWej8VV8O5Q/eQ==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.12.tgz",
+      "integrity": "sha512-vOfrB33b7YIZfDauXS8vNNz2Z86FozTZLIt7e+7/dCaPJ1RXZsHCuI9TlcERzEUq57vkM+UdnBgxP0rFd23JYQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1029,9 +1026,9 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-2.0.4.tgz",
-      "integrity": "sha512-Prenuv9C1PHj2Itx0BcAOVBTonz02Hc2Nd2DbU67PdGUaqn0nPCnV34oDyyoaZHnmfRxkpuhh/u51ThkrO+RdA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.0.tgz",
+      "integrity": "sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==",
       "license": "MIT",
       "dependencies": {
         "chardet": "^2.1.1",
@@ -1050,22 +1047,22 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.4.tgz",
-      "integrity": "sha512-eLBsjlS7rPS3WEhmOmh1znQ5IsQrxWzxWDxO51e4urv+iVrSnIHbq4zqJIOiyNdYLa+BVjwOtdetcQx1lWPpiQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.10.tgz",
-      "integrity": "sha512-nvZ6qEVeX/zVtZ1dY2hTGDQpVGD3R7MYPLODPgKO8Y+RAqxkrP3i/3NwF3fZpLdaMiNuK0z2NaYIx9tPwiSegQ==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.11.tgz",
+      "integrity": "sha512-twUWidn4ocPO8qi6fRM7tNWt7W1FOnOZqQ+/+PsfLUacMR5rFLDPK9ql0nBPwxi0oELbo8T5NhRs8B2+qQEqFQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1080,13 +1077,13 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.10.tgz",
-      "integrity": "sha512-Ht8OQstxiS3APMGjHV0aYAjRAysidWdwurWEo2i8yI5xbhOBWqizT0+MU1S2GCcuhIBg+3SgWVjEoXgfhY+XaA==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.11.tgz",
+      "integrity": "sha512-Vscmim9TCksQsfjPtka/JwPUcbLhqWYrgfPf1cHrCm24X/F2joFwnageD50yMKsaX14oNGOyKf/RNXAFkNjWpA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1101,14 +1098,14 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.10.tgz",
-      "integrity": "sha512-QbNyvIE8q2GTqKLYSsA8ATG+eETo+m31DSR0+AU7x3d2FhaTWzqQek80dj3JGTo743kQc6mhBR0erMjYw5jQ0A==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.11.tgz",
+      "integrity": "sha512-9KZFeRaNHIcejtPb0wN4ddFc7EvobVoAFa049eS3LrDZFxI8O7xUXiITEOinBzkZFAIwY5V4yzQae/QfO9cbbg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.4",
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1123,21 +1120,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.3.2.tgz",
-      "integrity": "sha512-yFroiSj2iiBFlm59amdTvAcQFvWS6ph5oKESls/uqPBect7rTU2GbjyZO2DqxMGuIwVA8z0P4K6ViPcd/cp+0w==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.1.tgz",
+      "integrity": "sha512-AH5xPQ997K7e0F0vulPlteIHke2awMkFi8F0dBemrDfmvtPmHJo82mdHbONC4F/t8d1NHwrbI5cGVI+RbLWdoQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.1.2",
-        "@inquirer/confirm": "^6.0.10",
-        "@inquirer/editor": "^5.0.10",
-        "@inquirer/expand": "^5.0.10",
-        "@inquirer/input": "^5.0.10",
-        "@inquirer/number": "^4.0.10",
-        "@inquirer/password": "^5.0.10",
-        "@inquirer/rawlist": "^5.2.6",
-        "@inquirer/search": "^4.1.6",
-        "@inquirer/select": "^5.1.2"
+        "@inquirer/checkbox": "^5.1.3",
+        "@inquirer/confirm": "^6.0.11",
+        "@inquirer/editor": "^5.1.0",
+        "@inquirer/expand": "^5.0.12",
+        "@inquirer/input": "^5.0.11",
+        "@inquirer/number": "^4.0.11",
+        "@inquirer/password": "^5.0.11",
+        "@inquirer/rawlist": "^5.2.7",
+        "@inquirer/search": "^4.1.7",
+        "@inquirer/select": "^5.1.3"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1152,13 +1149,13 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.6.tgz",
-      "integrity": "sha512-jfw0MLJ5TilNsa9zlJ6nmRM0ZFVZhhTICt4/6CU2Dv1ndY7l3sqqo1gIYZyMMDw0LvE1u1nzJNisfHEhJIxq5w==",
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.7.tgz",
+      "integrity": "sha512-AqRMiD9+uE1lskDPrdqHwrV/EUmxKEBLX44SR7uxK3vD2413AmVfE5EQaPeNzYf5Pq5SitHJDYUFVF0poIr09w==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1173,14 +1170,14 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.6.tgz",
-      "integrity": "sha512-3/6kTRae98hhDevENScy7cdFEuURnSpM3JbBNg8yfXLw88HgTOl+neUuy/l9W0No5NzGsLVydhBzTIxZP7yChQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.7.tgz",
+      "integrity": "sha512-1y7+0N65AWk5RdlXH/Kn13txf3IjIQ7OEfhCEkDTU+h5wKMLq8DUF3P6z+/kLSxDGDtQT1dRBWEUC3o/VvImsQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/figures": "^2.0.4",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1195,15 +1192,15 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.2.tgz",
-      "integrity": "sha512-kTK8YIkHV+f02y7bWCh7E0u2/11lul5WepVTclr3UMBtBr05PgcZNWfMa7FY57ihpQFQH/spLMHTcr0rXy50tA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.3.tgz",
+      "integrity": "sha512-zYyqWgGQi3NhBcNq4Isc5rB3oEdQEh1Q/EcAnOW0FK4MpnXWkvSBYgA4cYrTM4A9UB573omouZbnL9JJ74Mq3A==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.4",
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/figures": "^2.0.4",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1218,9 +1215,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.4.tgz",
-      "integrity": "sha512-PamArxO3cFJZoOzspzo6cxVlLeIftyBsZw/S9bKY5DzxqJVZgjoj1oP8d0rskKtp7sZxBycsoer1g6UeJV1BBA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1314,9 +1311,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1333,9 +1330,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1343,9 +1340,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
       "cpu": [
         "arm64"
       ],
@@ -1360,9 +1357,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
       "cpu": [
         "arm64"
       ],
@@ -1377,9 +1374,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
       "cpu": [
         "x64"
       ],
@@ -1394,9 +1391,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
       "cpu": [
         "x64"
       ],
@@ -1411,9 +1408,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
       "cpu": [
         "arm"
       ],
@@ -1428,13 +1425,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1445,13 +1445,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1462,13 +1465,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1479,13 +1485,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1496,13 +1505,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1513,13 +1525,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1530,9 +1545,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
       "cpu": [
         "arm64"
       ],
@@ -1547,9 +1562,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
       "cpu": [
         "wasm32"
       ],
@@ -1557,16 +1572,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
       "cpu": [
         "arm64"
       ],
@@ -1581,9 +1598,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
       "cpu": [
         "x64"
       ],
@@ -1598,9 +1615,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
       "dev": true,
       "license": "MIT"
     },
@@ -2008,13 +2025,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/semver": {
@@ -2025,16 +2042,16 @@
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2043,13 +2060,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.2",
+        "@vitest/spy": "4.1.4",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2070,9 +2087,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
-      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2083,13 +2100,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.2",
+        "@vitest/utils": "4.1.4",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2097,14 +2114,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2113,9 +2130,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
-      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2123,13 +2140,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
+        "@vitest/pretty-format": "4.1.4",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2243,9 +2260,9 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
-      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3449,6 +3466,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3470,6 +3490,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3491,6 +3514,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3512,6 +3538,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4147,14 +4176,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -4163,21 +4192,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
     "node_modules/rollup": {
@@ -4960,9 +4989,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -4991,16 +5020,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
+        "rolldown": "1.0.0-rc.15",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -5018,7 +5047,7 @@
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
         "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",
@@ -5069,19 +5098,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.2",
-        "@vitest/mocker": "4.1.2",
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/runner": "4.1.2",
-        "@vitest/snapshot": "4.1.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -5109,10 +5138,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.2",
-        "@vitest/browser-preview": "4.1.2",
-        "@vitest/browser-webdriverio": "4.1.2",
-        "@vitest/ui": "4.1.2",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -5134,6 +5165,12 @@
           "optional": true
         },
         "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
     "url": "https://github.com/goondocks-co/myco.git"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.92",
-    "@anthropic-ai/sdk": "^0.82.0",
-    "@inquirer/prompts": "^8.3.2",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.104",
+    "@anthropic-ai/sdk": "^0.88.0",
+    "@inquirer/prompts": "^8.4.1",
     "@modelcontextprotocol/sdk": "^1.28.0",
-    "better-sqlite3": "^12.8.0",
+    "better-sqlite3": "^12.9.0",
     "chokidar": "^5.0.0",
     "gray-matter": "^4.0.3",
     "semver": "^7.7.4",
@@ -52,11 +52,11 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
-    "@types/node": "^25.5.0",
+    "@types/node": "^25.6.0",
     "@types/semver": "^7.7.1",
     "tsup": "^8.0.0",
     "tsx": "^4.0.0",
     "typescript": "^6.0.2",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.4"
   }
 }

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -192,6 +192,7 @@ export async function main(): Promise<void> {
 
   const manifests = loadManifests();
   const symbiontPlanDirs = manifests.flatMap((m) => m.capture?.planDirs ?? []);
+  const symbiontPlanTags = [...new Set(manifests.flatMap((m) => m.capture?.planTags ?? []))];
   const projectRoot = process.cwd();
   let planWatchConfig: PlanWatchConfig = {
     watchDirs: [...new Set([...symbiontPlanDirs, ...(config.capture.plan_dirs ?? [])])],
@@ -219,6 +220,9 @@ export async function main(): Promise<void> {
     embedding_provider: config.embedding.provider,
   });
   logger.info(LOG_KINDS.CAPTURE_PLAN, 'Plan watch directories', { dirs: planWatchConfig.watchDirs });
+  if (symbiontPlanTags.length > 0) {
+    logger.info(LOG_KINDS.CAPTURE_PLAN, 'Plan transcript tags', { tags: symbiontPlanTags });
+  }
 
   // --- Machine identity ---
   const machineId = getMachineId(vaultDir);
@@ -435,6 +439,7 @@ export async function main(): Promise<void> {
     logger,
     config,
     vaultDir,
+    planTags: symbiontPlanTags,
   });
 
   // --- Session routes ---

--- a/src/daemon/plan-capture.ts
+++ b/src/daemon/plan-capture.ts
@@ -16,8 +16,41 @@ import { upsertPlan } from '@myco/db/queries/plans.js';
 import type { PlanRow } from '@myco/db/queries/plans.js';
 
 // ---------------------------------------------------------------------------
+// Transcript-based plan extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract plan content from XML-style tags in transcript text.
+ *
+ * Scans the input text for each declared tag name and returns all matches.
+ * Tags are exact names (e.g., 'proposed_plan' matches `<proposed_plan>...</proposed_plan>`).
+ * Returns all occurrences — the caller decides upsert semantics (e.g., last one wins).
+ */
+export function extractTaggedPlans(
+  text: string,
+  tags: string[],
+): Array<{ tag: string; content: string }> {
+  const results: Array<{ tag: string; content: string }> = [];
+  for (const tag of tags) {
+    const regex = new RegExp(`<${tag}>\\n?([\\s\\S]*?)\\n?</${tag}>`, 'g');
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+      const content = match[1].trim();
+      if (content) results.push({ tag, content });
+    }
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
+
+/**
+ * Source path prefix for plans extracted from transcript tags.
+ * Used to build deterministic plan IDs: `transcript:<tagName>`.
+ */
+export const TRANSCRIPT_SOURCE_PREFIX = 'transcript:';
 
 /**
  * Tool names that constitute a file write operation.

--- a/src/daemon/stop-processing.ts
+++ b/src/daemon/stop-processing.ts
@@ -11,6 +11,7 @@ import fs from 'node:fs';
 import { TranscriptMiner, extractTurnsFromBuffer } from '@myco/capture/transcript-miner.js';
 import type { TranscriptTurn } from '@myco/symbionts/adapter.js';
 import { captureBatchImages } from './capture-images.js';
+import { extractTaggedPlans, capturePlan, TRANSCRIPT_SOURCE_PREFIX } from './plan-capture.js';
 import {
   getLatestBatch,
   setResponseSummary,
@@ -44,6 +45,8 @@ export interface StopProcessorDeps {
   logger: DaemonLogger;
   config: MycoConfig;
   vaultDir: string;
+  /** Plan tag names to extract from transcript responses. Merged from all symbiont manifests. */
+  planTags: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -280,6 +283,35 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     if (responses.length > 0) {
       try { populateBatchResponses(sessionId, responses); }
       catch (err) { logger.warn(LOG_KINDS.PROCESSOR_BATCH, 'Failed to populate batch responses', { error: String(err) }); }
+    }
+
+    // --- Plan tag extraction from transcript responses ---
+    if (deps.planTags.length > 0) {
+      for (const turn of allTurns) {
+        if (!turn.aiResponse) continue;
+        const taggedPlans = extractTaggedPlans(turn.aiResponse, deps.planTags);
+        for (const { tag, content } of taggedPlans) {
+          try {
+            capturePlan({
+              sourcePath: `${TRANSCRIPT_SOURCE_PREFIX}${tag}`,
+              content,
+              sessionId,
+              promptBatchId: latestBatch?.id ?? null,
+            });
+            logger.info(LOG_KINDS.CAPTURE_PLAN, 'Plan captured from transcript tag', {
+              session_id: sessionId,
+              tag,
+              content_length: content.length,
+            });
+          } catch (err) {
+            logger.warn(LOG_KINDS.CAPTURE_PLAN, 'Failed to capture plan from transcript tag', {
+              session_id: sessionId,
+              tag,
+              error: (err as Error).message,
+            });
+          }
+        }
+      }
     }
 
     // Trigger title/summary if the session still needs one.

--- a/src/symbionts/adapter.ts
+++ b/src/symbionts/adapter.ts
@@ -140,10 +140,7 @@ export function mimeTypeForExtension(ext: string): string {
   return EXT_TO_MIME[ext.toLowerCase()] ?? 'image/png';
 }
 
-import { PROMPT_PREVIEW_CHARS } from '../constants.js';
-
-/** Claude Code injects [Image: source: /path] text alongside base64 image blocks. Strip these since the actual images are captured as attachments. */
-const IMAGE_TEXT_REF_PATTERN = /\[Image: source: [^\]]+\]\n*/g;
+import { StandardJsonlParser } from './parsers/standard-jsonl.js';
 
 export interface ParseJsonlOptions {
   /** Field name containing the message role ('type' for Claude Code, 'role' for Cursor) */
@@ -161,56 +158,5 @@ export interface ParseJsonlOptions {
  * Handles user/assistant role detection, text/image extraction, and tool counting.
  */
 export function parseJsonlTurns(content: string, opts: ParseJsonlOptions): TranscriptTurn[] {
-  const lines = content.split('\n').filter(Boolean);
-  const turns: TranscriptTurn[] = [];
-  let current: TranscriptTurn | null = null;
-
-  for (const line of lines) {
-    let entry: Record<string, unknown>;
-    try { entry = JSON.parse(line); } catch { continue; }
-
-    const role = entry[opts.roleField] as string;
-    const timestamp = opts.extractTimestamp ? (entry.timestamp as string ?? '') : '';
-
-    if (role === 'user') {
-      // Skip meta messages (skill injections, deprecation notices, etc.) — they are
-      // not real user prompts and should not appear as turns or influence the title.
-      if (entry.isMeta === true) continue;
-
-      const msg = entry.message as { content?: Array<{ type: string; text?: string; source?: { type?: string; data?: string; media_type?: string } }> } | undefined;
-      const blocks = Array.isArray(msg?.content) ? msg!.content : [];
-      const hasText = blocks.some((b) => b.type === 'text' && b.text?.trim());
-
-      if (!hasText && opts.skipToolResultUsers) continue;
-      if (!hasText) continue;
-
-      if (current) turns.push(current);
-
-      const rawPrompt = blocks
-        .filter((b) => b.type === 'text' && b.text)
-        .map((b) => b.text!)
-        .join('\n');
-
-      const promptText = (opts.stripImageTextRefs ? rawPrompt.replace(IMAGE_TEXT_REF_PATTERN, '') : rawPrompt)
-        .trim()
-        .slice(0, PROMPT_PREVIEW_CHARS);
-
-      const images: TranscriptImage[] = blocks
-        .filter((b) => b.type === 'image' && b.source?.type === 'base64' && b.source.data)
-        .map((b) => ({ data: b.source!.data!, mediaType: b.source!.media_type ?? 'image/png' }));
-
-      current = { prompt: promptText, toolCount: 0, timestamp, ...(images.length > 0 ? { images } : {}) };
-    } else if (role === 'assistant' && current) {
-      const msg = entry.message as { content?: Array<{ type: string; text?: string }> } | undefined;
-      if (Array.isArray(msg?.content)) {
-        const textParts = msg!.content.filter((b) => b.type === 'text' && b.text).map((b) => b.text!);
-        const text = textParts.join('\n').trim();
-        if (text) current.aiResponse = text;
-        current.toolCount += msg!.content.filter((b) => b.type === 'tool_use').length;
-      }
-    }
-  }
-
-  if (current) turns.push(current);
-  return turns;
+  return new StandardJsonlParser(opts).parseTurns(content);
 }

--- a/src/symbionts/codex.ts
+++ b/src/symbionts/codex.ts
@@ -1,9 +1,46 @@
 import type { SymbiontAdapter } from './adapter.js';
-import { findJsonlInSubdirs, parseJsonlTurns } from './adapter.js';
+import { CodexJsonlParser } from './parsers/codex-jsonl.js';
+import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 
 const TRANSCRIPT_BASE = path.join(os.homedir(), '.codex');
+const codexParser = new CodexJsonlParser();
+
+/**
+ * Find a Codex transcript file by session ID.
+ *
+ * Codex stores transcripts at:
+ *   <baseDir>/sessions/YYYY/MM/DD/rollout-<timestamp>-<sessionId>.jsonl
+ *
+ * Recursively scans the sessions directory for a JSONL file whose name
+ * contains the session ID.
+ */
+export function findCodexTranscript(baseDir: string, sessionId: string): string | null {
+  const sessionsDir = path.join(baseDir, 'sessions');
+  try {
+    return scanForSessionFile(sessionsDir, sessionId);
+  } catch {
+    return null;
+  }
+}
+
+function scanForSessionFile(dir: string, sessionId: string): string | null {
+  let entries: fs.Dirent[];
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); }
+  catch { return null; }
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const found = scanForSessionFile(fullPath, sessionId);
+      if (found) return found;
+    } else if (entry.isFile() && entry.name.includes(sessionId) && entry.name.endsWith('.jsonl')) {
+      return fullPath;
+    }
+  }
+  return null;
+}
 
 export const codexAdapter: SymbiontAdapter = {
   name: 'codex',
@@ -19,13 +56,7 @@ export const codexAdapter: SymbiontAdapter = {
     toolOutput: 'tool_output',
   },
 
-  findTranscript: (sessionId) => findJsonlInSubdirs(TRANSCRIPT_BASE, sessionId),
+  findTranscript: (sessionId) => findCodexTranscript(TRANSCRIPT_BASE, sessionId),
 
-  // Codex uses 'role' field (like Cursor), not 'type' (like Claude Code)
-  parseTurns: (content) => parseJsonlTurns(content, {
-    roleField: 'role',
-    extractTimestamp: false,
-    skipToolResultUsers: false,
-    stripImageTextRefs: false,
-  }),
+  parseTurns: (content) => codexParser.parseTurns(content),
 };

--- a/src/symbionts/manifest-schema.ts
+++ b/src/symbionts/manifest-schema.ts
@@ -66,6 +66,7 @@ export type CaptureRule = z.infer<typeof CaptureRuleSchema>;
 
 const CaptureManifestSchema = z.object({
   planDirs: z.array(z.string()).default([]),
+  planTags: z.array(z.string()).default([]),
   rules: z.array(CaptureRuleSchema).default([]),
 });
 

--- a/src/symbionts/manifests/codex.yaml
+++ b/src/symbionts/manifests/codex.yaml
@@ -11,6 +11,8 @@ hookFields:
   lastResponse: last_assistant_message
 capture:
   planDirs: []
+  planTags:
+    - proposed_plan
   rules:
     # Ephemeral sub-invocation filter (structural, two-layer defense).
     #
@@ -51,13 +53,23 @@ capture:
       action: drop
       reason: ephemeral-sub-invocation
 
-    # NOTE: the VS Code Codex extension wraps user prompts with an IDE
-    # context preamble (`# Context from my IDE setup:` … `## My request
-    # for Codex:`). Stripping that belongs in a follow-up that keys on
-    # the transcript's `session_meta.payload.originator == "codex_vscode"`
-    # signal rather than matching preamble text, per Chris's correctness
-    # bar against fragile text matching. Leaving unfiltered for now —
-    # session data is preserved, just shown with the wrapper.
+    # Codex Desktop wraps user prompts with a file-mention preamble when
+    # screenshots or files are attached:
+    #   "# Files mentioned by the user:\n## <filename>: <path>\n## My request for Codex:\n<actual prompt>"
+    # Strip the preamble so the captured prompt contains only the user's text.
+    - event: user_prompt
+      scope: this_agent
+      when:
+        prompt_contains: "## My request for Codex:"
+      action: rewrite_prompt
+      extract_after: "## My request for Codex:\n"
+      reason: codex-desktop-file-preamble
+
+    # NOTE: the VS Code Codex extension uses a different preamble
+    # (`# Context from my IDE setup:` … `## My request for Codex:`).
+    # Keying on the shared `## My request for Codex:` marker above
+    # should handle both Desktop and VS Code variants. If the VS Code
+    # preamble diverges, add a separate rule keyed on its specific marker.
 registration:
   hooksTarget: .codex/hooks.json
   mcpTarget: .codex/config.toml

--- a/src/symbionts/parsers/codex-jsonl.ts
+++ b/src/symbionts/parsers/codex-jsonl.ts
@@ -1,0 +1,118 @@
+import type { TranscriptParser } from './types.js';
+import type { TranscriptTurn, TranscriptImage } from '../adapter.js';
+import { PROMPT_PREVIEW_CHARS } from '../../constants.js';
+
+/** Parse a data URL (data:<mime>;base64,<data>) into media type and base64 data. */
+function parseDataUrl(url: string): { mediaType: string; data: string } | null {
+  const match = url.match(/^data:([^;]+);base64,(.+)$/);
+  if (!match) return null;
+  return { mediaType: match[1], data: match[2] };
+}
+
+/**
+ * Codex Desktop wraps user prompts with file-mention preambles when screenshots
+ * are attached, and injects <image> wrapper tags around image blocks. Strip both
+ * so the captured prompt contains only the user's actual text.
+ *
+ * Preamble pattern:
+ *   "# Files mentioned by the user:\n\n## <filename>: <path>\n\n## My request for Codex:\n<actual prompt>"
+ *
+ * Image wrapper tags (separate input_text blocks):
+ *   "<image name=[Image #1]>"  /  "</image>"
+ */
+const IMAGE_WRAPPER_TAG = /^<\/?image\b[^>]*>$/;
+const CODEX_PROMPT_MARKER = '## My request for Codex:\n';
+
+function cleanCodexPromptText(text: string): string {
+  // Strip image wrapper tags
+  if (IMAGE_WRAPPER_TAG.test(text.trim())) return '';
+  // Extract actual prompt from file-mention preamble
+  const idx = text.indexOf(CODEX_PROMPT_MARKER);
+  if (idx !== -1) return text.slice(idx + CODEX_PROMPT_MARKER.length);
+  return text;
+}
+
+/**
+ * Parses Codex's nested-payload JSONL transcript format.
+ *
+ * Codex JSONL entries have the structure:
+ *   { type: "response_item", payload: { type: "message", role: "user"|"assistant"|"developer", content: [...] } }
+ *
+ * Key differences from the standard (Claude Code) format:
+ * - Role is at payload.role, not top-level
+ * - Content is at payload.content, not message.content
+ * - User content blocks use type: "input_text", assistant use type: "output_text"
+ * - Tool use is separate "function_call" entries, not nested blocks
+ * - Images are data URLs in "input_image" blocks (data:<mime>;base64,<data>), not structured source objects
+ * - Codex Desktop wraps prompts with file-mention preambles and <image> tags when screenshots are attached — these are stripped
+ * - Non-conversation entries (event_msg, session_meta, turn_context, reasoning) are skipped
+ */
+export class CodexJsonlParser implements TranscriptParser {
+  parseTurns(content: string): TranscriptTurn[] {
+    const lines = content.split('\n').filter(Boolean);
+    const turns: TranscriptTurn[] = [];
+    let current: TranscriptTurn | null = null;
+
+    for (const line of lines) {
+      let entry: Record<string, unknown>;
+      try { entry = JSON.parse(line); } catch { continue; }
+
+      // Only process response_item entries — skip event_msg, session_meta, turn_context
+      if (entry.type !== 'response_item') continue;
+
+      const payload = entry.payload as Record<string, unknown> | undefined;
+      if (!payload) continue;
+
+      const payloadType = payload.type as string;
+      const timestamp = (entry.timestamp as string) ?? '';
+
+      // Function calls are separate entries — count them as tool use
+      if (payloadType === 'function_call') {
+        if (current) current.toolCount++;
+        continue;
+      }
+
+      // Only process message payloads from here
+      if (payloadType !== 'message') continue;
+
+      const role = payload.role as string;
+      const blocks = Array.isArray(payload.content)
+        ? (payload.content as Array<{ type: string; text?: string; image_url?: string }>)
+        : [];
+
+      if (role === 'user') {
+        const textParts = blocks
+          .filter((b) => b.type === 'input_text' && b.text?.trim())
+          .map((b) => cleanCodexPromptText(b.text!))
+          .filter((t) => t.trim());
+
+        if (textParts.length === 0) continue;
+
+        if (current) turns.push(current);
+
+        const promptText = textParts.join('\n').trim().slice(0, PROMPT_PREVIEW_CHARS);
+
+        // Extract images from input_image blocks (data URL format: data:<mime>;base64,<data>)
+        const images: TranscriptImage[] = [];
+        for (const b of blocks) {
+          if (b.type === 'input_image' && b.image_url) {
+            const parsed = parseDataUrl(b.image_url);
+            if (parsed) images.push(parsed);
+          }
+        }
+
+        current = { prompt: promptText, toolCount: 0, timestamp, ...(images.length > 0 ? { images } : {}) };
+      } else if (role === 'assistant' && current) {
+        const textParts = blocks
+          .filter((b) => b.type === 'output_text' && b.text)
+          .map((b) => b.text!);
+        const text = textParts.join('\n').trim();
+        if (text) current.aiResponse = text;
+      }
+      // role === 'developer' is silently skipped
+    }
+
+    if (current) turns.push(current);
+    return turns;
+  }
+}

--- a/src/symbionts/parsers/index.ts
+++ b/src/symbionts/parsers/index.ts
@@ -1,0 +1,3 @@
+export { CodexJsonlParser } from './codex-jsonl.js';
+export { StandardJsonlParser } from './standard-jsonl.js';
+export type { TranscriptParser } from './types.js';

--- a/src/symbionts/parsers/standard-jsonl.ts
+++ b/src/symbionts/parsers/standard-jsonl.ts
@@ -1,0 +1,72 @@
+import type { TranscriptTurn, TranscriptImage, ParseJsonlOptions } from '../adapter.js';
+import type { TranscriptParser } from './types.js';
+import { PROMPT_PREVIEW_CHARS } from '../../constants.js';
+
+/** Claude Code injects [Image: source: /path] text alongside base64 image blocks. Strip these since the actual images are captured as attachments. */
+const IMAGE_TEXT_REF_PATTERN = /\[Image: source: [^\]]+\]\n*/g;
+
+/**
+ * Standard JSONL transcript parser — handles the flat JSONL format used by
+ * Claude Code, Cursor, and other adapters with top-level role fields.
+ *
+ * Extracts user/assistant turn pairs with text, images, and tool-use counts.
+ * Behavior is controlled by ParseJsonlOptions (role field name, timestamp extraction,
+ * tool_result skipping, image text reference stripping).
+ */
+export class StandardJsonlParser implements TranscriptParser {
+  constructor(private readonly opts: ParseJsonlOptions) {}
+
+  parseTurns(content: string): TranscriptTurn[] {
+    const lines = content.split('\n').filter(Boolean);
+    const turns: TranscriptTurn[] = [];
+    let current: TranscriptTurn | null = null;
+
+    for (const line of lines) {
+      let entry: Record<string, unknown>;
+      try { entry = JSON.parse(line); } catch { continue; }
+
+      const role = entry[this.opts.roleField] as string;
+      const timestamp = this.opts.extractTimestamp ? (entry.timestamp as string ?? '') : '';
+
+      if (role === 'user') {
+        // Skip meta messages (skill injections, deprecation notices, etc.) — they are
+        // not real user prompts and should not appear as turns or influence the title.
+        if (entry.isMeta === true) continue;
+
+        const msg = entry.message as { content?: Array<{ type: string; text?: string; source?: { type?: string; data?: string; media_type?: string } }> } | undefined;
+        const blocks = Array.isArray(msg?.content) ? msg!.content : [];
+        const hasText = blocks.some((b) => b.type === 'text' && b.text?.trim());
+
+        if (!hasText) continue;
+
+        if (current) turns.push(current);
+
+        const rawPrompt = blocks
+          .filter((b) => b.type === 'text' && b.text)
+          .map((b) => b.text!)
+          .join('\n');
+
+        const promptText = (this.opts.stripImageTextRefs ? rawPrompt.replace(IMAGE_TEXT_REF_PATTERN, '') : rawPrompt)
+          .trim()
+          .slice(0, PROMPT_PREVIEW_CHARS);
+
+        const images: TranscriptImage[] = blocks
+          .filter((b) => b.type === 'image' && b.source?.type === 'base64' && b.source.data)
+          .map((b) => ({ data: b.source!.data!, mediaType: b.source!.media_type ?? 'image/png' }));
+
+        current = { prompt: promptText, toolCount: 0, timestamp, ...(images.length > 0 ? { images } : {}) };
+      } else if (role === 'assistant' && current) {
+        const msg = entry.message as { content?: Array<{ type: string; text?: string }> } | undefined;
+        if (Array.isArray(msg?.content)) {
+          const textParts = msg!.content.filter((b) => b.type === 'text' && b.text).map((b) => b.text!);
+          const text = textParts.join('\n').trim();
+          if (text) current.aiResponse = text;
+          current.toolCount += msg!.content.filter((b) => b.type === 'tool_use').length;
+        }
+      }
+    }
+
+    if (current) turns.push(current);
+    return turns;
+  }
+}

--- a/src/symbionts/parsers/types.ts
+++ b/src/symbionts/parsers/types.ts
@@ -1,0 +1,12 @@
+import type { TranscriptTurn } from '../adapter.js';
+
+/**
+ * Contract for parsing agent transcript files into normalized conversation turns.
+ *
+ * Each agent's transcript format (JSONL structure, field names, content block types)
+ * gets its own implementation. The daemon and capture pipeline operate on
+ * TranscriptTurn[] — they never see agent-specific formats.
+ */
+export interface TranscriptParser {
+  parseTurns(content: string): TranscriptTurn[];
+}

--- a/tests/daemon/codex-plan-capture.test.ts
+++ b/tests/daemon/codex-plan-capture.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Integration test: Codex plan capture end-to-end.
+ *
+ * Verifies that a Codex transcript with <proposed_plan> tags
+ * produces a captured plan in the database when processed through
+ * the CodexJsonlParser -> stop processor pipeline.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
+import { CodexJsonlParser } from '@myco/symbionts/parsers/codex-jsonl.js';
+import { extractTaggedPlans, capturePlan } from '@myco/daemon/plan-capture.js';
+import { upsertSession } from '@myco/db/queries/sessions.js';
+import { insertBatch } from '@myco/db/queries/batches.js';
+import { listPlansBySession } from '@myco/db/queries/plans.js';
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+describe('Codex plan capture integration', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => { cleanTestDb(); });
+
+  const planMarkdown = '# Collective V1 Plan\n\n## Summary\n\nBuild the collective layer.\n\n## Steps\n\n1. Create packages\n2. Deploy workers\n3. Wire settings';
+
+  function buildCodexTranscript(planContent: string): string {
+    return [
+      JSON.stringify({
+        timestamp: '2026-04-13T10:00:00Z',
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'developer',
+          content: [{ type: 'input_text', text: 'System instructions' }],
+        },
+      }),
+      JSON.stringify({
+        timestamp: '2026-04-13T10:00:05Z',
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'Build a plan for the collective' }],
+        },
+      }),
+      JSON.stringify({
+        timestamp: '2026-04-13T10:01:00Z',
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: `<proposed_plan>\n${planContent}\n</proposed_plan>` }],
+        },
+      }),
+    ].join('\n');
+  }
+
+  it('parses Codex transcript, extracts plan tag, and captures to database', () => {
+    const sessionId = 'codex-plan-integration-001';
+    const now = epochNow();
+    upsertSession({ id: sessionId, agent: 'codex', started_at: now, created_at: now });
+    const batch = insertBatch({ session_id: sessionId, prompt_number: 1, user_prompt: 'Build a plan', started_at: now, created_at: now });
+
+    // Step 1: Parse transcript
+    const parser = new CodexJsonlParser();
+    const transcript = buildCodexTranscript(planMarkdown);
+    const turns = parser.parseTurns(transcript);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].aiResponse).toContain('<proposed_plan>');
+
+    // Step 2: Extract tagged plans
+    const planTags = ['proposed_plan'];
+    for (const turn of turns) {
+      if (!turn.aiResponse) continue;
+      const taggedPlans = extractTaggedPlans(turn.aiResponse, planTags);
+
+      // Step 3: Capture each plan
+      for (const { tag, content } of taggedPlans) {
+        capturePlan({
+          sourcePath: `transcript:${tag}`,
+          content,
+          sessionId,
+          promptBatchId: batch.id,
+        });
+      }
+    }
+
+    // Step 4: Verify database state
+    const plans = listPlansBySession(sessionId);
+    expect(plans).toHaveLength(1);
+    expect(plans[0].title).toBe('Collective V1 Plan');
+    expect(plans[0].content).toBe(planMarkdown);
+    expect(plans[0].session_id).toBe(sessionId);
+    expect(plans[0].prompt_batch_id).toBe(batch.id);
+    expect(plans[0].source_path).toBe('transcript:proposed_plan');
+  });
+
+  it('revised plan upserts over original (same source path)', () => {
+    const sessionId = 'codex-plan-integration-002';
+    const now = epochNow();
+    upsertSession({ id: sessionId, agent: 'codex', started_at: now, created_at: now });
+
+    // Capture original
+    const original = capturePlan({
+      sourcePath: 'transcript:proposed_plan',
+      content: '# Original Plan\n\nFirst version.',
+      sessionId,
+    });
+
+    // Capture revision (same source path)
+    const revised = capturePlan({
+      sourcePath: 'transcript:proposed_plan',
+      content: '# Revised Plan\n\nSecond version.',
+      sessionId,
+    });
+
+    // Same ID — upserted, not duplicated
+    expect(revised.id).toBe(original.id);
+
+    const plans = listPlansBySession(sessionId);
+    expect(plans).toHaveLength(1);
+    expect(plans[0].title).toBe('Revised Plan');
+    expect(plans[0].content).toBe('# Revised Plan\n\nSecond version.');
+  });
+});

--- a/tests/daemon/plan-capture.test.ts
+++ b/tests/daemon/plan-capture.test.ts
@@ -19,6 +19,7 @@ import {
   isPlanWriteEvent,
   parsePlanTitle,
   capturePlan,
+  extractTaggedPlans,
   type PlanWatchConfig,
 } from '@myco/daemon/plan-capture.js';
 
@@ -456,5 +457,70 @@ describe('capturePlan', () => {
     });
 
     expect(result.title).toBe('roadmap.md');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractTaggedPlans
+// ---------------------------------------------------------------------------
+
+describe('extractTaggedPlans', () => {
+  it('extracts content from a single proposed_plan tag', () => {
+    const text = 'Some preamble.\n<proposed_plan>\n# My Plan\n\n## Steps\n1. Do this\n</proposed_plan>\nSome epilogue.';
+    const results = extractTaggedPlans(text, ['proposed_plan']);
+    expect(results).toHaveLength(1);
+    expect(results[0].tag).toBe('proposed_plan');
+    expect(results[0].content).toBe('# My Plan\n\n## Steps\n1. Do this');
+  });
+
+  it('returns empty array when no tags match', () => {
+    const text = 'Just regular text with no plan tags.';
+    const results = extractTaggedPlans(text, ['proposed_plan']);
+    expect(results).toEqual([]);
+  });
+
+  it('returns empty array when tags list is empty', () => {
+    const text = '<proposed_plan>\n# Plan\n</proposed_plan>';
+    const results = extractTaggedPlans(text, []);
+    expect(results).toEqual([]);
+  });
+
+  it('extracts from multiple different tag names', () => {
+    const text = '<proposed_plan>\n# Plan A\n</proposed_plan>\n\n<implementation_plan>\n# Plan B\n</implementation_plan>';
+    const results = extractTaggedPlans(text, ['proposed_plan', 'implementation_plan']);
+    expect(results).toHaveLength(2);
+    expect(results[0].tag).toBe('proposed_plan');
+    expect(results[0].content).toBe('# Plan A');
+    expect(results[1].tag).toBe('implementation_plan');
+    expect(results[1].content).toBe('# Plan B');
+  });
+
+  it('skips empty tag content', () => {
+    const text = '<proposed_plan>\n\n</proposed_plan>';
+    const results = extractTaggedPlans(text, ['proposed_plan']);
+    expect(results).toEqual([]);
+  });
+
+  it('handles tag content without leading/trailing newlines', () => {
+    const text = '<proposed_plan># Direct Plan</proposed_plan>';
+    const results = extractTaggedPlans(text, ['proposed_plan']);
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe('# Direct Plan');
+  });
+
+  it('handles multi-line markdown plan content', () => {
+    const planMd = '# Comprehensive Plan\n\n## Summary\n\nBuild the thing.\n\n## Steps\n\n1. Step one\n2. Step two\n\n## Notes\n\n- Note A\n- Note B';
+    const text = `<proposed_plan>\n${planMd}\n</proposed_plan>`;
+    const results = extractTaggedPlans(text, ['proposed_plan']);
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe(planMd);
+  });
+
+  it('returns all occurrences when same tag appears multiple times', () => {
+    const text = '<proposed_plan>\n# Original Plan\n</proposed_plan>\n\nSome discussion.\n\n<proposed_plan>\n# Revised Plan\n</proposed_plan>';
+    const results = extractTaggedPlans(text, ['proposed_plan']);
+    expect(results).toHaveLength(2);
+    expect(results[0].content).toBe('# Original Plan');
+    expect(results[1].content).toBe('# Revised Plan');
   });
 });

--- a/tests/symbionts/codex-capture-rules.test.ts
+++ b/tests/symbionts/codex-capture-rules.test.ts
@@ -91,4 +91,27 @@ describe('codex.yaml capture rules', () => {
       expect(result).toEqual({ action: 'pass', prompt: 'real user question' });
     });
   });
+
+  describe('file-mention preamble rewrite', () => {
+    it('strips Codex Desktop file-mention preamble from screenshot prompts', () => {
+      const prompt = '\n# Files mentioned by the user:\n\n## CleanShot 2026-04-13.png: /Users/chris/Library/Application Support/CleanShot/media/screenshot.png\n\n## My request for Codex:\nhello, what do you see?\n';
+      const result = evaluateUserPromptRules(loadManifests(), 'codex', {
+        prompt,
+        transcriptPath: '/Users/chris/.codex/sessions/2026/04/13/rollout-abc.jsonl',
+      });
+      expect(result.action).toBe('rewrite');
+      if (result.action === 'rewrite') {
+        expect(result.prompt).toBe('hello, what do you see?');
+        expect(result.reason).toBe('codex-desktop-file-preamble');
+      }
+    });
+
+    it('passes normal prompts without preamble through unchanged', () => {
+      const result = evaluateUserPromptRules(loadManifests(), 'codex', {
+        prompt: 'Fix the bug in main.ts',
+        transcriptPath: '/Users/chris/.codex/sessions/2026/04/13/rollout-abc.jsonl',
+      });
+      expect(result).toEqual({ action: 'pass', prompt: 'Fix the bug in main.ts' });
+    });
+  });
 });

--- a/tests/symbionts/codex-find-transcript.test.ts
+++ b/tests/symbionts/codex-find-transcript.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { findCodexTranscript } from '@myco/symbionts/codex.js';
+
+describe('findCodexTranscript', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-transcript-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('finds transcript in nested YYYY/MM/DD directory with rollout prefix', () => {
+    const sessionId = '019d839a-0c22-7072-97fa-3d1b16910b0d';
+    const dateDir = path.join(tmpDir, 'sessions', '2026', '04', '12');
+    fs.mkdirSync(dateDir, { recursive: true });
+    const filename = `rollout-2026-04-12T17-30-04-${sessionId}.jsonl`;
+    fs.writeFileSync(path.join(dateDir, filename), '{}');
+
+    const result = findCodexTranscript(tmpDir, sessionId);
+
+    expect(result).toBe(path.join(dateDir, filename));
+  });
+
+  it('returns null when session ID not found', () => {
+    const result = findCodexTranscript(tmpDir, 'nonexistent-session-id');
+    expect(result).toBeNull();
+  });
+
+  it('finds transcript across different date directories', () => {
+    const sessionId = 'abc-123-def';
+    const dateDir = path.join(tmpDir, 'sessions', '2026', '03', '28');
+    fs.mkdirSync(dateDir, { recursive: true });
+    const filename = `rollout-2026-03-28T09-15-00-${sessionId}.jsonl`;
+    fs.writeFileSync(path.join(dateDir, filename), '{}');
+
+    const result = findCodexTranscript(tmpDir, sessionId);
+
+    expect(result).toBe(path.join(dateDir, filename));
+  });
+
+  it('returns null when sessions directory does not exist', () => {
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-empty-'));
+    try {
+      const result = findCodexTranscript(emptyDir, 'some-session');
+      expect(result).toBeNull();
+    } finally {
+      fs.rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/symbionts/codex.test.ts
+++ b/tests/symbionts/codex.test.ts
@@ -6,6 +6,28 @@ function toJsonl(entries: Record<string, unknown>[]): string {
   return entries.map((e) => JSON.stringify(e)).join('\n');
 }
 
+/** Helper: build a Codex response_item with a message payload. */
+function messageItem(
+  role: string,
+  blocks: Array<{ type: string; text?: string }>,
+  timestamp?: string,
+): Record<string, unknown> {
+  return {
+    type: 'response_item',
+    payload: { type: 'message', role, content: blocks },
+    ...(timestamp ? { timestamp } : {}),
+  };
+}
+
+/** Helper: build a Codex response_item with a function_call payload. */
+function functionCallItem(name: string, args: string, timestamp?: string): Record<string, unknown> {
+  return {
+    type: 'response_item',
+    payload: { type: 'function_call', name, arguments: args },
+    ...(timestamp ? { timestamp } : {}),
+  };
+}
+
 describe('codexAdapter', () => {
   it('has correct adapter metadata', () => {
     expect(codexAdapter.name).toBe('codex');
@@ -17,19 +39,13 @@ describe('codexAdapter', () => {
   describe('parseTurns', () => {
     it('parses user and assistant turns from JSONL with role field', () => {
       const content = toJsonl([
-        {
-          role: 'user',
-          message: { content: [{ type: 'text', text: 'Hello from Codex' }] },
-        },
-        {
-          role: 'assistant',
-          message: {
-            content: [
-              { type: 'text', text: 'Hi there!' },
-              { type: 'tool_use', name: 'Read', id: 't1' },
-            ],
-          },
-        },
+        messageItem('user', [{ type: 'input_text', text: 'Hello from Codex' }], '2026-04-13T10:00:00Z'),
+        messageItem(
+          'assistant',
+          [{ type: 'output_text', text: 'Hi there!' }],
+          '2026-04-13T10:00:30Z',
+        ),
+        functionCallItem('Read', '{}', '2026-04-13T10:00:20Z'),
       ]);
 
       const turns = codexAdapter.parseTurns(content);
@@ -41,28 +57,20 @@ describe('codexAdapter', () => {
 
     it('handles multiple conversation turns', () => {
       const content = toJsonl([
-        {
-          role: 'user',
-          message: { content: [{ type: 'text', text: 'First prompt' }] },
-        },
-        {
-          role: 'assistant',
-          message: { content: [{ type: 'text', text: 'First response' }] },
-        },
-        {
-          role: 'user',
-          message: { content: [{ type: 'text', text: 'Second prompt' }] },
-        },
-        {
-          role: 'assistant',
-          message: {
-            content: [
-              { type: 'tool_use', name: 'Edit', id: 't1' },
-              { type: 'tool_use', name: 'Write', id: 't2' },
-              { type: 'text', text: 'Done editing' },
-            ],
-          },
-        },
+        messageItem('user', [{ type: 'input_text', text: 'First prompt' }], '2026-04-13T10:00:00Z'),
+        messageItem(
+          'assistant',
+          [{ type: 'output_text', text: 'First response' }],
+          '2026-04-13T10:00:30Z',
+        ),
+        messageItem('user', [{ type: 'input_text', text: 'Second prompt' }], '2026-04-13T10:01:00Z'),
+        functionCallItem('Edit', '{"path":"/foo.ts"}', '2026-04-13T10:01:10Z'),
+        functionCallItem('Write', '{"path":"/bar.ts"}', '2026-04-13T10:01:20Z'),
+        messageItem(
+          'assistant',
+          [{ type: 'output_text', text: 'Done editing' }],
+          '2026-04-13T10:01:30Z',
+        ),
       ]);
 
       const turns = codexAdapter.parseTurns(content);
@@ -77,18 +85,14 @@ describe('codexAdapter', () => {
 
     it('skips entries with no text content', () => {
       const content = toJsonl([
-        {
-          role: 'user',
-          message: { content: [{ type: 'image', source: { data: 'abc' } }] },
-        },
-        {
-          role: 'user',
-          message: { content: [{ type: 'text', text: 'Real prompt' }] },
-        },
-        {
-          role: 'assistant',
-          message: { content: [{ type: 'text', text: 'Response' }] },
-        },
+        // user message with no input_text blocks — should be skipped
+        messageItem('user', [{ type: 'other_type', text: 'ignored' }], '2026-04-13T10:00:00Z'),
+        messageItem('user', [{ type: 'input_text', text: 'Real prompt' }], '2026-04-13T10:00:10Z'),
+        messageItem(
+          'assistant',
+          [{ type: 'output_text', text: 'Response' }],
+          '2026-04-13T10:00:30Z',
+        ),
       ]);
 
       const turns = codexAdapter.parseTurns(content);
@@ -101,10 +105,10 @@ describe('codexAdapter', () => {
     });
 
     it('skips malformed JSON lines', () => {
-      const content = 'not json\n' + JSON.stringify({
-        role: 'user',
-        message: { content: [{ type: 'text', text: 'Valid line' }] },
-      });
+      const validLine = JSON.stringify(
+        messageItem('user', [{ type: 'input_text', text: 'Valid line' }], '2026-04-13T10:00:00Z'),
+      );
+      const content = 'not json\n' + validLine;
 
       const turns = codexAdapter.parseTurns(content);
       expect(turns).toHaveLength(1);

--- a/tests/symbionts/manifest-schema.test.ts
+++ b/tests/symbionts/manifest-schema.test.ts
@@ -175,6 +175,84 @@ describe('symbiont manifests', () => {
     expect(manifest.capture?.planDirs).toEqual(['.gemini/plans/']);
   });
 
+  it('accepts planTags array in capture block', () => {
+    const result = SymbiontManifestSchema.parse({
+      name: 'test-agent',
+      displayName: 'Test Agent',
+      binary: 'test',
+      configDir: '.test',
+      pluginRootEnvVar: 'TEST_PLUGIN_ROOT',
+      hookFields: {
+        sessionId: 'session_id',
+        transcriptPath: 'transcript_path',
+        lastResponse: 'last_assistant_message',
+      },
+      capture: { planTags: ['proposed_plan'] },
+    });
+    expect(result.capture?.planTags).toEqual(['proposed_plan']);
+  });
+
+  it('defaults planTags to empty array when not specified', () => {
+    const result = SymbiontManifestSchema.parse({
+      name: 'test-agent',
+      displayName: 'Test Agent',
+      binary: 'test',
+      configDir: '.test',
+      pluginRootEnvVar: 'TEST_PLUGIN_ROOT',
+      hookFields: {
+        sessionId: 'session_id',
+        transcriptPath: 'transcript_path',
+        lastResponse: 'last_assistant_message',
+      },
+      capture: { planDirs: ['.test/plans/'] },
+    });
+    expect(result.capture?.planTags).toEqual([]);
+  });
+
+  it('accepts multiple plan tags', () => {
+    const result = SymbiontManifestSchema.parse({
+      name: 'test-agent',
+      displayName: 'Test Agent',
+      binary: 'test',
+      configDir: '.test',
+      pluginRootEnvVar: 'TEST_PLUGIN_ROOT',
+      hookFields: {
+        sessionId: 'session_id',
+        transcriptPath: 'transcript_path',
+        lastResponse: 'last_assistant_message',
+      },
+      capture: { planTags: ['proposed_plan', 'implementation_plan'] },
+    });
+    expect(result.capture?.planTags).toEqual(['proposed_plan', 'implementation_plan']);
+  });
+
+  it('planTags coexists with planDirs', () => {
+    const result = SymbiontManifestSchema.parse({
+      name: 'test-agent',
+      displayName: 'Test Agent',
+      binary: 'test',
+      configDir: '.test',
+      pluginRootEnvVar: 'TEST_PLUGIN_ROOT',
+      hookFields: {
+        sessionId: 'session_id',
+        transcriptPath: 'transcript_path',
+        lastResponse: 'last_assistant_message',
+      },
+      capture: {
+        planDirs: ['.test/plans/'],
+        planTags: ['proposed_plan'],
+      },
+    });
+    expect(result.capture?.planDirs).toEqual(['.test/plans/']);
+    expect(result.capture?.planTags).toEqual(['proposed_plan']);
+  });
+
+  it('codex manifest has planTags with proposed_plan', () => {
+    const raw = fs.readFileSync(path.join(MANIFESTS_DIR, 'codex.yaml'), 'utf-8');
+    const manifest = SymbiontManifestSchema.parse(YAML.parse(raw));
+    expect(manifest.capture?.planTags).toEqual(['proposed_plan']);
+  });
+
   it('defaults mcpFormat to json when not specified', () => {
     const manifest = SymbiontManifestSchema.parse({
       name: 'test-agent',

--- a/tests/symbionts/parsers/codex-jsonl.test.ts
+++ b/tests/symbionts/parsers/codex-jsonl.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect } from 'vitest';
+import { CodexJsonlParser } from '../../../src/symbionts/parsers/codex-jsonl.js';
+
+/**
+ * Build a JSONL string from an array of entry objects.
+ */
+function toJsonl(entries: Record<string, unknown>[]): string {
+  return entries.map((e) => JSON.stringify(e)).join('\n') + '\n';
+}
+
+/** Helper to build a Codex response_item with a message payload. */
+function messageItem(role: string, blocks: Array<{ type: string; text?: string }>, timestamp?: string): Record<string, unknown> {
+  return {
+    type: 'response_item',
+    payload: { type: 'message', role, content: blocks },
+    ...(timestamp ? { timestamp } : {}),
+  };
+}
+
+/** Helper to build a Codex response_item with a function_call payload. */
+function functionCallItem(name: string, args: string, timestamp?: string): Record<string, unknown> {
+  return {
+    type: 'response_item',
+    payload: { type: 'function_call', name, arguments: args },
+    ...(timestamp ? { timestamp } : {}),
+  };
+}
+
+describe('CodexJsonlParser', () => {
+  const parser = new CodexJsonlParser();
+
+  it('parses user and assistant messages from nested payload', () => {
+    const content = toJsonl([
+      messageItem('user', [{ type: 'input_text', text: 'Fix the bug' }], '2026-04-12T10:00:00Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'I found the issue and fixed it.' }], '2026-04-12T10:00:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].prompt).toBe('Fix the bug');
+    expect(turns[0].aiResponse).toBe('I found the issue and fixed it.');
+    expect(turns[0].toolCount).toBe(0);
+    expect(turns[0].timestamp).toBe('2026-04-12T10:00:00Z');
+  });
+
+  it('counts function_call entries as tool use', () => {
+    const content = toJsonl([
+      messageItem('user', [{ type: 'input_text', text: 'Read and edit the file' }], '2026-04-12T10:00:00Z'),
+      functionCallItem('read_file', '{"path":"/foo.ts"}', '2026-04-12T10:00:10Z'),
+      functionCallItem('edit_file', '{"path":"/foo.ts"}', '2026-04-12T10:00:20Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'Done.' }], '2026-04-12T10:00:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].toolCount).toBe(2);
+    expect(turns[0].aiResponse).toBe('Done.');
+  });
+
+  it('skips developer messages', () => {
+    const content = toJsonl([
+      messageItem('developer', [{ type: 'input_text', text: 'System instructions here' }], '2026-04-12T09:59:00Z'),
+      messageItem('user', [{ type: 'input_text', text: 'Hello' }], '2026-04-12T10:00:00Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'Hi!' }], '2026-04-12T10:00:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].prompt).toBe('Hello');
+  });
+
+  it('skips event_msg, session_meta, turn_context, and reasoning entries', () => {
+    const content = toJsonl([
+      { type: 'event_msg', data: 'connected' },
+      { type: 'session_meta', session_id: 'abc123' },
+      { type: 'turn_context', context: 'something' },
+      { type: 'reasoning', content: 'thinking...' },
+      messageItem('user', [{ type: 'input_text', text: 'Hello' }], '2026-04-12T10:00:00Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'Hi!' }], '2026-04-12T10:00:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].prompt).toBe('Hello');
+    expect(turns[0].aiResponse).toBe('Hi!');
+  });
+
+  it('handles multiple user-assistant turns', () => {
+    const content = toJsonl([
+      messageItem('user', [{ type: 'input_text', text: 'First question' }], '2026-04-12T10:00:00Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'First answer' }], '2026-04-12T10:00:30Z'),
+      messageItem('user', [{ type: 'input_text', text: 'Second question' }], '2026-04-12T10:01:00Z'),
+      functionCallItem('read_file', '{"path":"/bar.ts"}', '2026-04-12T10:01:10Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'Second answer' }], '2026-04-12T10:01:30Z'),
+      messageItem('user', [{ type: 'input_text', text: 'Third question' }], '2026-04-12T10:02:00Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'Third answer' }], '2026-04-12T10:02:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(3);
+    expect(turns[0].prompt).toBe('First question');
+    expect(turns[0].aiResponse).toBe('First answer');
+    expect(turns[0].toolCount).toBe(0);
+    expect(turns[1].prompt).toBe('Second question');
+    expect(turns[1].aiResponse).toBe('Second answer');
+    expect(turns[1].toolCount).toBe(1);
+    expect(turns[2].prompt).toBe('Third question');
+    expect(turns[2].aiResponse).toBe('Third answer');
+    expect(turns[2].toolCount).toBe(0);
+  });
+
+  it('concatenates multiple output_text blocks in a single assistant message', () => {
+    const content = toJsonl([
+      messageItem('user', [{ type: 'input_text', text: 'Explain' }], '2026-04-12T10:00:00Z'),
+      messageItem('assistant', [
+        { type: 'output_text', text: 'First part.' },
+        { type: 'output_text', text: 'Second part.' },
+      ], '2026-04-12T10:00:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].aiResponse).toBe('First part.\nSecond part.');
+  });
+
+  it('preserves proposed_plan tags in aiResponse', () => {
+    const planText = '<proposed_plan>\n## Phase 1\nDo the thing\n</proposed_plan>\n\nHere is my plan.';
+    const content = toJsonl([
+      messageItem('user', [{ type: 'input_text', text: 'Plan the feature' }], '2026-04-12T10:00:00Z'),
+      messageItem('assistant', [{ type: 'output_text', text: planText }], '2026-04-12T10:00:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].aiResponse).toContain('<proposed_plan>');
+    expect(turns[0].aiResponse).toContain('</proposed_plan>');
+    expect(turns[0].aiResponse).toBe(planText);
+  });
+
+  it('returns empty array for empty content', () => {
+    expect(parser.parseTurns('')).toEqual([]);
+  });
+
+  it('skips malformed JSON lines', () => {
+    const validEntry = JSON.stringify(
+      messageItem('user', [{ type: 'input_text', text: 'Hello' }], '2026-04-12T10:00:00Z'),
+    );
+    const content = `not json\n${validEntry}\n{broken\n`;
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].prompt).toBe('Hello');
+  });
+
+  it('skips user messages with no text content', () => {
+    const content = toJsonl([
+      messageItem('user', [{ type: 'input_text', text: '' }], '2026-04-12T10:00:00Z'),
+      messageItem('user', [{ type: 'input_text', text: '   ' }], '2026-04-12T10:00:10Z'),
+      messageItem('user', [{ type: 'other_type', text: 'ignored' }], '2026-04-12T10:00:20Z'),
+      messageItem('user', [{ type: 'input_text', text: 'Real prompt' }], '2026-04-12T10:01:00Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'Response' }], '2026-04-12T10:01:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].prompt).toBe('Real prompt');
+  });
+
+  it('handles response_item with missing payload', () => {
+    const content = toJsonl([
+      { type: 'response_item' },
+      messageItem('user', [{ type: 'input_text', text: 'Hello' }], '2026-04-12T10:00:00Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'Hi!' }], '2026-04-12T10:00:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].prompt).toBe('Hello');
+  });
+
+  it('defaults timestamp to empty string when not present', () => {
+    const content = toJsonl([
+      messageItem('user', [{ type: 'input_text', text: 'No timestamp' }]),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].timestamp).toBe('');
+  });
+
+  it('extracts images from input_image blocks with data URLs', () => {
+    const content = toJsonl([
+      {
+        type: 'response_item',
+        timestamp: '2026-04-13T10:00:00Z',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'Here is a screenshot' },
+            { type: 'input_image', image_url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==' },
+            { type: 'input_text', text: 'What do you see?' },
+          ],
+        },
+      },
+      messageItem('assistant', [{ type: 'output_text', text: 'I see a screenshot.' }], '2026-04-13T10:00:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].prompt).toContain('Here is a screenshot');
+    expect(turns[0].images).toHaveLength(1);
+    expect(turns[0].images![0].data).toBe('iVBORw0KGgoAAAANSUhEUg==');
+    expect(turns[0].images![0].mediaType).toBe('image/png');
+  });
+
+  it('extracts multiple images from a single user message', () => {
+    const content = toJsonl([
+      {
+        type: 'response_item',
+        timestamp: '2026-04-13T10:00:00Z',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'Compare these two screenshots' },
+            { type: 'input_image', image_url: 'data:image/png;base64,AAAA' },
+            { type: 'input_image', image_url: 'data:image/jpeg;base64,BBBB' },
+          ],
+        },
+      },
+      messageItem('assistant', [{ type: 'output_text', text: 'They look different.' }], '2026-04-13T10:00:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].images).toHaveLength(2);
+    expect(turns[0].images![0].mediaType).toBe('image/png');
+    expect(turns[0].images![0].data).toBe('AAAA');
+    expect(turns[0].images![1].mediaType).toBe('image/jpeg');
+    expect(turns[0].images![1].data).toBe('BBBB');
+  });
+
+  it('does not set images field when no input_image blocks present', () => {
+    const content = toJsonl([
+      messageItem('user', [{ type: 'input_text', text: 'No images here' }], '2026-04-13T10:00:00Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'Ok.' }], '2026-04-13T10:00:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].images).toBeUndefined();
+  });
+
+  it('skips input_image blocks with invalid data URLs', () => {
+    const content = toJsonl([
+      {
+        type: 'response_item',
+        timestamp: '2026-04-13T10:00:00Z',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'Broken images' },
+            { type: 'input_image', image_url: 'not-a-data-url' },
+            { type: 'input_image', image_url: 'data:image/png;base64,VALID' },
+          ],
+        },
+      },
+      messageItem('assistant', [{ type: 'output_text', text: 'Got it.' }], '2026-04-13T10:00:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].images).toHaveLength(1);
+    expect(turns[0].images![0].data).toBe('VALID');
+  });
+
+  it('strips Codex Desktop file-mention preamble from prompts', () => {
+    const content = toJsonl([
+      {
+        type: 'response_item',
+        timestamp: '2026-04-13T10:00:00Z',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: '\n# Files mentioned by the user:\n\n## CleanShot 2026-04-13.png: /Users/chris/Library/Application Support/CleanShot/media/screenshot.png\n\n## My request for Codex:\nhello, what do you see in this screenshot?\n' },
+            { type: 'input_text', text: '<image name=[Image #1]>' },
+            { type: 'input_image', image_url: 'data:image/png;base64,AAAA' },
+            { type: 'input_text', text: '</image>' },
+          ],
+        },
+      },
+      messageItem('assistant', [{ type: 'output_text', text: 'I see a screenshot.' }], '2026-04-13T10:00:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    // Preamble stripped, image wrapper tags stripped, only the actual question remains
+    expect(turns[0].prompt).toBe('hello, what do you see in this screenshot?');
+    expect(turns[0].images).toHaveLength(1);
+  });
+
+  it('strips image wrapper tags from prompts', () => {
+    const content = toJsonl([
+      {
+        type: 'response_item',
+        timestamp: '2026-04-13T10:00:00Z',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'Look at this' },
+            { type: 'input_text', text: '<image name=[Image #1]>' },
+            { type: 'input_image', image_url: 'data:image/png;base64,AAAA' },
+            { type: 'input_text', text: '</image>' },
+          ],
+        },
+      },
+      messageItem('assistant', [{ type: 'output_text', text: 'Got it.' }], '2026-04-13T10:00:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].prompt).toBe('Look at this');
+    // Image wrapper tags should not appear in the prompt
+    expect(turns[0].prompt).not.toContain('<image');
+    expect(turns[0].prompt).not.toContain('</image>');
+  });
+
+  it('passes through normal prompts without preamble unchanged', () => {
+    const content = toJsonl([
+      messageItem('user', [{ type: 'input_text', text: 'Fix the bug in main.ts' }], '2026-04-13T10:00:00Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'On it.' }], '2026-04-13T10:00:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].prompt).toBe('Fix the bug in main.ts');
+  });
+
+  it('function_call before any user message does not crash', () => {
+    const content = toJsonl([
+      functionCallItem('init_fn', '{}', '2026-04-12T09:59:00Z'),
+      messageItem('user', [{ type: 'input_text', text: 'Hello' }], '2026-04-12T10:00:00Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'Hi!' }], '2026-04-12T10:00:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].toolCount).toBe(0); // function_call before user message is ignored
+  });
+});

--- a/tests/symbionts/parsers/standard-jsonl.test.ts
+++ b/tests/symbionts/parsers/standard-jsonl.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect } from 'vitest';
+import { StandardJsonlParser } from '../../../src/symbionts/parsers/standard-jsonl.js';
+
+/**
+ * Build a JSONL string from an array of entry objects.
+ */
+function toJsonl(entries: Record<string, unknown>[]): string {
+  return entries.map((e) => JSON.stringify(e)).join('\n') + '\n';
+}
+
+describe('StandardJsonlParser', () => {
+  describe('Claude Code JSONL (type-based roles)', () => {
+    const parser = new StandardJsonlParser({
+      roleField: 'type',
+      extractTimestamp: true,
+      skipToolResultUsers: true,
+      stripImageTextRefs: true,
+    });
+
+    it('parses user-assistant turn pairs', () => {
+      const content = toJsonl([
+        { type: 'system', content: 'init', timestamp: '2026-03-15T10:00:00Z' },
+        {
+          type: 'user',
+          message: { content: [{ type: 'text', text: 'Fix the bug' }] },
+          timestamp: '2026-03-15T10:01:00Z',
+        },
+        {
+          type: 'assistant',
+          message: { content: [{ type: 'text', text: 'I found the issue.' }] },
+          timestamp: '2026-03-15T10:01:30Z',
+        },
+        {
+          type: 'user',
+          message: { content: [{ type: 'text', text: 'Ship it' }] },
+          timestamp: '2026-03-15T10:02:00Z',
+        },
+        {
+          type: 'assistant',
+          message: { content: [{ type: 'text', text: 'Done.' }] },
+          timestamp: '2026-03-15T10:02:30Z',
+        },
+      ]);
+
+      const turns = parser.parseTurns(content);
+
+      expect(turns).toHaveLength(2);
+      expect(turns[0].prompt).toBe('Fix the bug');
+      expect(turns[0].aiResponse).toBe('I found the issue.');
+      expect(turns[0].timestamp).toBe('2026-03-15T10:01:00Z');
+      expect(turns[1].prompt).toBe('Ship it');
+      expect(turns[1].aiResponse).toBe('Done.');
+    });
+
+    it('counts tool_use blocks in assistant messages', () => {
+      const content = toJsonl([
+        {
+          type: 'user',
+          message: { content: [{ type: 'text', text: 'Read the file' }] },
+          timestamp: '2026-03-15T10:00:00Z',
+        },
+        {
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'tool_use', id: 't1', name: 'Read', input: {} },
+              { type: 'tool_use', id: 't2', name: 'Grep', input: {} },
+              { type: 'text', text: 'Here is the content.' },
+            ],
+          },
+          timestamp: '2026-03-15T10:00:30Z',
+        },
+      ]);
+
+      const turns = parser.parseTurns(content);
+
+      expect(turns).toHaveLength(1);
+      expect(turns[0].toolCount).toBe(2);
+      expect(turns[0].aiResponse).toBe('Here is the content.');
+    });
+
+    it('skips tool_result user messages when skipToolResultUsers is true', () => {
+      const content = toJsonl([
+        {
+          type: 'user',
+          message: { content: [{ type: 'text', text: 'Fix the bug' }] },
+          timestamp: '2026-03-15T10:00:00Z',
+        },
+        {
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'tool_use', id: 't1', name: 'Read', input: { file_path: '/foo.ts' } },
+            ],
+          },
+          timestamp: '2026-03-15T10:00:10Z',
+        },
+        {
+          type: 'user',
+          message: {
+            content: [
+              { type: 'tool_result', tool_use_id: 't1', content: 'file contents here' },
+            ],
+          },
+          timestamp: '2026-03-15T10:00:11Z',
+        },
+        {
+          type: 'assistant',
+          message: { content: [{ type: 'text', text: 'Fixed the null check.' }] },
+          timestamp: '2026-03-15T10:00:30Z',
+        },
+      ]);
+
+      const turns = parser.parseTurns(content);
+
+      expect(turns).toHaveLength(1);
+      expect(turns[0].prompt).toBe('Fix the bug');
+      expect(turns[0].toolCount).toBe(1);
+      expect(turns[0].aiResponse).toBe('Fixed the null check.');
+    });
+
+    it('strips image text references when configured', () => {
+      const content = toJsonl([
+        {
+          type: 'user',
+          message: {
+            content: [
+              { type: 'text', text: '[Image: source: /tmp/screenshot.png]\nFix this layout' },
+            ],
+          },
+          timestamp: '2026-03-15T10:00:00Z',
+        },
+        {
+          type: 'assistant',
+          message: { content: [{ type: 'text', text: 'Fixed.' }] },
+          timestamp: '2026-03-15T10:00:30Z',
+        },
+      ]);
+
+      const turns = parser.parseTurns(content);
+
+      expect(turns).toHaveLength(1);
+      expect(turns[0].prompt).toBe('Fix this layout');
+    });
+
+    it('skips isMeta user messages', () => {
+      const content = toJsonl([
+        {
+          type: 'user',
+          isMeta: true,
+          message: { content: [{ type: 'text', text: 'System injection' }] },
+          timestamp: '2026-03-15T10:00:00Z',
+        },
+        {
+          type: 'user',
+          message: { content: [{ type: 'text', text: 'Real prompt' }] },
+          timestamp: '2026-03-15T10:01:00Z',
+        },
+        {
+          type: 'assistant',
+          message: { content: [{ type: 'text', text: 'Ok' }] },
+          timestamp: '2026-03-15T10:01:30Z',
+        },
+      ]);
+
+      const turns = parser.parseTurns(content);
+
+      expect(turns).toHaveLength(1);
+      expect(turns[0].prompt).toBe('Real prompt');
+    });
+
+    it('extracts images from user messages', () => {
+      const content = toJsonl([
+        {
+          type: 'user',
+          message: {
+            content: [
+              { type: 'text', text: 'What is this?' },
+              {
+                type: 'image',
+                source: { type: 'base64', data: 'abc123', media_type: 'image/png' },
+              },
+            ],
+          },
+          timestamp: '2026-03-15T10:00:00Z',
+        },
+        {
+          type: 'assistant',
+          message: { content: [{ type: 'text', text: 'A screenshot.' }] },
+          timestamp: '2026-03-15T10:00:30Z',
+        },
+      ]);
+
+      const turns = parser.parseTurns(content);
+
+      expect(turns).toHaveLength(1);
+      expect(turns[0].images).toHaveLength(1);
+      expect(turns[0].images![0].data).toBe('abc123');
+      expect(turns[0].images![0].mediaType).toBe('image/png');
+    });
+  });
+
+  describe('Cursor JSONL (role-based fields)', () => {
+    const parser = new StandardJsonlParser({
+      roleField: 'role',
+      extractTimestamp: false,
+      skipToolResultUsers: false,
+      stripImageTextRefs: false,
+    });
+
+    it('parses role-based JSONL format', () => {
+      const content = toJsonl([
+        {
+          role: 'user',
+          message: { content: [{ type: 'text', text: 'Refactor this' }] },
+        },
+        {
+          role: 'assistant',
+          message: {
+            content: [
+              { type: 'tool_use', id: 't1', name: 'Edit', input: {} },
+              { type: 'text', text: 'Done refactoring.' },
+            ],
+          },
+        },
+      ]);
+
+      const turns = parser.parseTurns(content);
+
+      expect(turns).toHaveLength(1);
+      expect(turns[0].prompt).toBe('Refactor this');
+      expect(turns[0].toolCount).toBe(1);
+      expect(turns[0].aiResponse).toBe('Done refactoring.');
+      expect(turns[0].timestamp).toBe('');
+    });
+
+    it('does not skip tool_result user messages when skipToolResultUsers is false', () => {
+      // With skipToolResultUsers: false, a user message without text still gets skipped
+      // because hasText is checked unconditionally — but if a user message has text, it starts a new turn
+      const content = toJsonl([
+        {
+          role: 'user',
+          message: { content: [{ type: 'text', text: 'First prompt' }] },
+        },
+        {
+          role: 'assistant',
+          message: {
+            content: [
+              { type: 'tool_use', id: 't1', name: 'Read', input: {} },
+            ],
+          },
+        },
+        {
+          role: 'user',
+          message: {
+            content: [
+              { type: 'tool_result', tool_use_id: 't1', content: 'file data' },
+            ],
+          },
+        },
+        {
+          role: 'assistant',
+          message: { content: [{ type: 'text', text: 'Here you go.' }] },
+        },
+      ]);
+
+      const turns = parser.parseTurns(content);
+
+      // tool_result has no text block, so it's skipped regardless
+      expect(turns).toHaveLength(1);
+      expect(turns[0].prompt).toBe('First prompt');
+      expect(turns[0].toolCount).toBe(1);
+      expect(turns[0].aiResponse).toBe('Here you go.');
+    });
+  });
+
+  describe('edge cases', () => {
+    const parser = new StandardJsonlParser({
+      roleField: 'type',
+      extractTimestamp: true,
+      skipToolResultUsers: true,
+      stripImageTextRefs: false,
+    });
+
+    it('handles empty content', () => {
+      expect(parser.parseTurns('')).toEqual([]);
+    });
+
+    it('handles invalid JSON lines gracefully', () => {
+      const content = 'not json\n{"type":"user","message":{"content":[{"type":"text","text":"Hello"}]},"timestamp":"2026-01-01T00:00:00Z"}\n{broken\n';
+
+      const turns = parser.parseTurns(content);
+
+      expect(turns).toHaveLength(1);
+      expect(turns[0].prompt).toBe('Hello');
+    });
+
+    it('handles turn without AI response (trailing user)', () => {
+      const content = toJsonl([
+        {
+          type: 'user',
+          message: { content: [{ type: 'text', text: 'Do something' }] },
+          timestamp: '2026-03-15T10:00:00Z',
+        },
+      ]);
+
+      const turns = parser.parseTurns(content);
+
+      expect(turns).toHaveLength(1);
+      expect(turns[0].prompt).toBe('Do something');
+      expect(turns[0].aiResponse).toBeUndefined();
+    });
+
+    it('accumulates tool counts across multiple assistant messages', () => {
+      const content = toJsonl([
+        {
+          type: 'user',
+          message: { content: [{ type: 'text', text: 'Do many things' }] },
+          timestamp: '2026-03-15T10:00:00Z',
+        },
+        {
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'tool_use', id: 't1', name: 'Read', input: {} },
+            ],
+          },
+          timestamp: '2026-03-15T10:00:10Z',
+        },
+        {
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'tool_use', id: 't2', name: 'Edit', input: {} },
+              { type: 'tool_use', id: 't3', name: 'Bash', input: {} },
+              { type: 'text', text: 'All done.' },
+            ],
+          },
+          timestamp: '2026-03-15T10:00:20Z',
+        },
+      ]);
+
+      const turns = parser.parseTurns(content);
+
+      expect(turns).toHaveLength(1);
+      expect(turns[0].toolCount).toBe(3);
+      expect(turns[0].aiResponse).toBe('All done.');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Transcript parser architecture**: `TranscriptParser` interface with `StandardJsonlParser` (refactored from `parseJsonlTurns`) and `CodexJsonlParser` for Codex's nested-payload JSONL format — fixes the broken parser that was producing zero turns from real Codex transcripts
- **Plan tag extraction**: `planTags` manifest field + stop processor integration — captures plans from `<proposed_plan>` tags in Codex transcript responses
- **Image capture**: `CodexJsonlParser` extracts screenshots from `input_image` data URL blocks, closing the image capture gap for Codex sessions
- **Prompt cleanup**: Strips Codex Desktop's file-mention preamble from screenshot-attached prompts (both transcript-side parser and hook-side capture rule)
- **findTranscript fix**: Recursive scan for Codex's nested `sessions/YYYY/MM/DD/rollout-*` directory structure

## Test plan

- [x] 53 new tests across 5 new test files (parser, manifest schema, integration, capture rules, findTranscript)
- [x] Full suite: 2150 passing, 0 failing
- [x] Smoke-tested against real Codex session `019d839a-...` — plan captured, images extracted, turns parsed
- [x] Verified retroactive plan capture in vault DB and daemon API
- [x] Verified prompt cleanup strips file-mention preamble from screenshot prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)