### PR TITLE
feat(agent): gate intelligence tasks on settled sessions + manual complete

### DIFF
--- a/packages/myco/src/agent/context-queries.ts
+++ b/packages/myco/src/agent/context-queries.ts
@@ -131,13 +131,15 @@ async function executeQuery(
 ): Promise<unknown> {
   switch (tool) {
     case 'vault_unprocessed':
-      return getUnprocessedBatches({ limit });
+      // Agent pre-planning context should only see settled work — a task
+      // planning against in-flight batches is working from partial signal.
+      return getUnprocessedBatches({ limit, includeActive: false });
 
     case 'vault_spores':
-      return listSpores({ agent_id: agentId, limit });
+      return listSpores({ agent_id: agentId, limit, includeActive: false });
 
     case 'vault_sessions':
-      return listSessions({ limit });
+      return listSessions({ limit, includeActive: false });
 
     case 'vault_state':
       return getStatesForAgent(agentId);

--- a/packages/myco/src/agent/definitions/tasks/title-summary.yaml
+++ b/packages/myco/src/agent/definitions/tasks/title-summary.yaml
@@ -28,16 +28,17 @@ prompt: |
 
   **If a target session ID is specified above:**
   Always process it — the user explicitly requested regeneration.
-  Call `vault_sessions` to get its current title/summary.
-  Call `vault_search_fts` with the session ID to find ALL its prompt
-  batches (processed and unprocessed). Do NOT skip even if there are
-  no new unprocessed batches.
+  Call `vault_sessions` with `include_active: true` to get its current
+  title/summary (the session may still be active). Call `vault_search_fts`
+  with the session ID to find ALL its prompt batches (processed and
+  unprocessed). Do NOT skip even if there are no new unprocessed batches.
 
   **If no target session specified (automatic run):**
-  Call `vault_unprocessed` to find sessions with new prompt batches.
-  Group by session_id — each session with unprocessed batches needs
-  its summary updated. Call `vault_sessions` for those sessions.
-  If no sessions have unprocessed batches, report "skip" and finish.
+  Call `vault_unprocessed` with `include_active: true` — titles are needed
+  mid-flight, not just after a session completes. Group by session_id —
+  each session with unprocessed batches needs its summary updated. Call
+  `vault_sessions` with `include_active: true` for those sessions. If no
+  sessions have unprocessed batches, report "skip" and finish.
 
   ## Phase 2 — Update Each Session (budget: 8 turns)
 

--- a/packages/myco/src/agent/instruction-builders.ts
+++ b/packages/myco/src/agent/instruction-builders.ts
@@ -162,10 +162,13 @@ export function buildSkillSurveyInstruction(
     parts.push('');
   }
 
-  // 2. Wisdom spores — highest signal observations
+  // 2. Wisdom spores — highest signal observations.
+  // Skill-survey runs against settled work only so spores from in-flight
+  // sessions don't bait candidates for procedures that haven't stabilized.
   const wisdomSpores = listSpores({
     observation_type: 'wisdom',
     limit: SURVEY_MAX_WISDOM_SPORES,
+    includeActive: false,
     ...sinceFilter,
   });
   if (wisdomSpores.length > 0) {
@@ -180,11 +183,13 @@ export function buildSkillSurveyInstruction(
   const decisions = listSpores({
     observation_type: 'decision',
     limit: 20,
+    includeActive: false,
     ...sinceFilter,
   });
   const gotchas = listSpores({
     observation_type: 'gotcha',
     limit: 10,
+    includeActive: false,
     ...sinceFilter,
   });
   if (decisions.length > 0 || gotchas.length > 0) {
@@ -198,6 +203,7 @@ export function buildSkillSurveyInstruction(
   // 4. Recent sessions
   const sessions = listSessions({
     limit: SURVEY_MAX_SESSIONS,
+    includeActive: false,
     ...sinceFilter,
   });
   if (sessions.length > 0) {

--- a/packages/myco/src/agent/tools/read-tools.ts
+++ b/packages/myco/src/agent/tools/read-tools.ts
@@ -10,7 +10,7 @@ import { tool } from '@anthropic-ai/claude-agent-sdk';
 import { SEARCH_SIMILARITY_THRESHOLD, TEAM_SOURCE_PREFIX } from '@myco/constants.js';
 import { getUnprocessedBatches } from '@myco/db/queries/batches.js';
 import { listSpores } from '@myco/db/queries/spores.js';
-import { listSessions } from '@myco/db/queries/sessions.js';
+import { listSessions, getActiveSessionIds } from '@myco/db/queries/sessions.js';
 import { getStatesForAgent } from '@myco/db/queries/agent-state.js';
 import { fullTextSearch } from '@myco/db/queries/search.js';
 import { listEntities } from '@myco/db/queries/entities.js';
@@ -48,16 +48,18 @@ export function createReadTools(deps: VaultToolDeps) {
 
   const vaultUnprocessed = tool(
     'vault_unprocessed',
-    'Get unprocessed prompt batches, ordered by id ASC. Supports cursor-based pagination.',
+    'Get unprocessed prompt batches, ordered by id ASC. Supports cursor-based pagination. Batches from in-flight sessions are excluded by default so intelligence tasks only process settled work; pass include_active=true only if you specifically need live data (e.g., title-summary).',
     {
       after_id: z.number().optional().describe('Return batches with id greater than this'),
       limit: z.number().optional().describe('Maximum number of batches to return'),
+      include_active: z.boolean().optional().describe('Include batches from sessions still in active status (default: false)'),
     },
     async (args) => {
       recordTurn('vault_unprocessed', args);
       const batches = getUnprocessedBatches({
         after_id: args.after_id,
         limit: args.limit ?? DEFAULT_UNPROCESSED_LIMIT,
+        includeActive: args.include_active === true,
       });
       return textResult(batches);
     },
@@ -66,13 +68,14 @@ export function createReadTools(deps: VaultToolDeps) {
 
   const vaultSpores = tool(
     'vault_spores',
-    'List spores with optional filters (agent, observation type, status, session).',
+    'List spores with optional filters (agent, observation type, status, session). Spores from in-flight sessions are excluded by default; passing a specific session_id bypasses this filter. Pass include_active=true to bulk-read live work.',
     {
       agent_id: z.string().optional().describe('Filter by agent ID'),
       observation_type: z.string().optional().describe('Filter by observation type (e.g., gotcha, decision)'),
       status: z.enum(['active', 'superseded', 'archived']).optional().describe('Filter by status'),
-      session_id: z.string().optional().describe('Filter by session ID'),
+      session_id: z.string().optional().describe('Filter by session ID (bypasses active-session gating)'),
       limit: z.number().optional().describe('Maximum number of spores to return'),
+      include_active: z.boolean().optional().describe('Include spores from sessions still in active status (default: false)'),
     },
     async (args) => {
       recordTurn('vault_spores', args);
@@ -82,6 +85,7 @@ export function createReadTools(deps: VaultToolDeps) {
         status: args.status,
         session_id: args.session_id,
         limit: args.limit ?? DEFAULT_SPORES_LIMIT,
+        includeActive: args.include_active === true,
       });
       return textResult(spores);
     },
@@ -90,16 +94,18 @@ export function createReadTools(deps: VaultToolDeps) {
 
   const vaultSessions = tool(
     'vault_sessions',
-    'List sessions with optional status filter, ordered by created_at DESC.',
+    'List sessions with optional status filter, ordered by created_at DESC. In-flight sessions are excluded by default; pass include_active=true or an explicit status to see them.',
     {
       limit: z.number().optional().describe('Maximum number of sessions to return'),
       status: z.string().optional().describe('Filter by status (active, completed)'),
+      include_active: z.boolean().optional().describe('Include sessions still in active status (default: false)'),
     },
     async (args) => {
       recordTurn('vault_sessions', args);
       const sessions = listSessions({
         limit: args.limit ?? DEFAULT_SESSIONS_LIMIT,
         status: args.status,
+        includeActive: args.include_active === true,
       });
       return textResult(sessions);
     },
@@ -108,11 +114,12 @@ export function createReadTools(deps: VaultToolDeps) {
 
   const vaultSearchFts = tool(
     'vault_search_fts',
-    'Full-text search across sessions, spores, prompt batches, and activities using FTS5. Best for finding exact keywords, file paths, function names, and specific text. Searches: session titles/summaries, spore content, user prompts, AI response summaries, tool calls.',
+    'Full-text search across sessions, spores, prompt batches, and activities using FTS5. Best for finding exact keywords, file paths, function names, and specific text. Results from in-flight sessions are hidden by default so intelligence tasks only see settled work; pass include_active=true to bypass.',
     {
       query: z.string().describe('Search query text'),
       type: z.string().optional().describe('Restrict to a result type (session, spore, prompt_batch, activity)'),
       limit: z.number().optional().describe('Maximum number of results to return'),
+      include_active: z.boolean().optional().describe('Include results from sessions still in active status (default: false)'),
     },
     async (args) => {
       recordTurn('vault_search_fts', args);
@@ -120,6 +127,7 @@ export function createReadTools(deps: VaultToolDeps) {
         const results = fullTextSearch(args.query, {
           type: args.type,
           limit: args.limit ?? DEFAULT_SEARCH_LIMIT,
+          includeActive: args.include_active === true,
         });
         return textResult({ results });
       } catch {
@@ -131,11 +139,12 @@ export function createReadTools(deps: VaultToolDeps) {
 
   const vaultSearchSemantic = tool(
     'vault_search_semantic',
-    'Semantic similarity search across embedded vault content (spores, sessions, plans, artifacts, skill_records). Best for finding conceptually related content. Returns results ranked by similarity score.',
+    'Semantic similarity search across embedded vault content (spores, sessions, plans, artifacts, skill_records). Best for finding conceptually related content. Returns results ranked by similarity score. Results from in-flight sessions are filtered out by default; pass include_active=true to bypass.',
     {
       query: z.string().describe('Search query text'),
       namespace: z.string().optional().describe('Restrict to a content type: spores, sessions, plans, artifacts, skill_records. Omit to search all.'),
       limit: z.number().optional().describe('Maximum results to return'),
+      include_active: z.boolean().optional().describe('Include results from sessions still in active status (default: false)'),
     },
     async (args) => {
       recordTurn('vault_search_semantic', args);
@@ -148,6 +157,7 @@ export function createReadTools(deps: VaultToolDeps) {
           return textResult({ results: [], message: 'Embedding provider unavailable' });
         }
         const searchLimit = args.limit ?? DEFAULT_SEARCH_LIMIT;
+        const excludeActive = args.include_active !== true;
 
         // Fire local and team search in parallel
         const [localResults, teamResults] = await Promise.all([
@@ -171,14 +181,27 @@ export function createReadTools(deps: VaultToolDeps) {
           : teamResults;
 
         // Merge by similarity/score (normalize to common key), slice to limit
-        const merged = [
+        let merged = [
           ...localResults.map((r) => ({ ...r, score: r.similarity })),
           ...dedupedTeam,
         ]
-          .sort((a, b) => ((b.score as number) ?? 0) - ((a.score as number) ?? 0))
-          .slice(0, searchLimit);
+          .sort((a, b) => ((b.score as number) ?? 0) - ((a.score as number) ?? 0));
 
-        return textResult({ results: merged });
+        // The vector store is a separate concern from the session table, so
+        // we filter active-session results in memory. Results without a
+        // session_id (agent-authored spores, project-scoped artifacts)
+        // always pass through.
+        if (excludeActive) {
+          const activeIds = getActiveSessionIds();
+          if (activeIds.size > 0) {
+            merged = merged.filter((r) => {
+              const sid = (r as { metadata?: { session_id?: unknown } }).metadata?.session_id;
+              return typeof sid !== 'string' || !activeIds.has(sid);
+            });
+          }
+        }
+
+        return textResult({ results: merged.slice(0, searchLimit) });
       } catch {
         return textResult({ results: [], message: 'Semantic search unavailable' });
       }

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -11,6 +11,13 @@ const DaemonSchema = z.object({
   port: z.number().int().min(1024).max(65535).nullable().default(null),
   log_level: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
   log_retention_days: z.number().int().min(1).max(365).default(30),
+  /**
+   * Time without new prompts before an active session is auto-completed (ms).
+   * Intelligence tasks (full-intelligence, skill-survey, etc.) only process
+   * settled sessions, so this threshold directly controls how fresh their
+   * inputs are. Defaults to 1 hour.
+   */
+  stale_session_threshold_ms: z.number().int().min(60_000).default(60 * 60 * 1000),
 });
 
 const CaptureSchema = z.object({

--- a/packages/myco/src/constants/log-kinds.ts
+++ b/packages/myco/src/constants/log-kinds.ts
@@ -90,6 +90,7 @@ export const LOG_KINDS = {
 
   // API operations
   API_SESSION_DELETE: 'api.session-delete',
+  API_SESSION_COMPLETE: 'api.session-complete',
 
   // MCP
   MCP_EVENT: 'mcp.event',

--- a/packages/myco/src/daemon/api/sessions.ts
+++ b/packages/myco/src/daemon/api/sessions.ts
@@ -1,13 +1,16 @@
-import { getSession, listSessions, countSessions, deleteSessionCascade, getSessionImpact } from '@myco/db/queries/sessions.js';
+import { getSession, listSessions, countSessions, deleteSessionCascade, getSessionImpact, updateSession } from '@myco/db/queries/sessions.js';
 import { listBatchesBySession, countBatchesBySession } from '@myco/db/queries/batches.js';
 import { listActivitiesByBatch, countActivities } from '@myco/db/queries/activities.js';
 import { listAttachmentsBySession } from '@myco/db/queries/attachments.js';
 import { listPlansBySession } from '@myco/db/queries/plans.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+import { epochSeconds } from '@myco/constants.js';
 import { cleanupAfterSessionCascade } from '../jobs/session-cleanup.js';
+import { triggerTitleSummary } from '../trigger-title-summary.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 import type { EmbeddingManager } from '../embedding/manager.js';
 import type { DaemonLogger } from '../logger.js';
+import type { MycoConfig } from '@myco/config/schema.js';
 
 const DEFAULT_LIST_LIMIT = 50;
 const DEFAULT_LIST_OFFSET = 0;
@@ -79,10 +82,11 @@ export interface SessionMutationDeps {
   embeddingManager: EmbeddingManager;
   vaultDir: string;
   logger: DaemonLogger;
+  config: MycoConfig;
 }
 
 export function createSessionMutationHandlers(deps: SessionMutationDeps) {
-  const { embeddingManager, vaultDir, logger } = deps;
+  const { embeddingManager, vaultDir, logger, config } = deps;
 
   /** DELETE /api/sessions/:id — cascade delete with post-transaction cleanup. */
   async function handleDeleteSession(req: RouteRequest): Promise<RouteResponse> {
@@ -100,6 +104,41 @@ export function createSessionMutationHandlers(deps: SessionMutationDeps) {
     return { body: { ok: true, counts: result.counts } };
   }
 
+  /**
+   * POST /api/sessions/:id/complete — manual mirror of the SessionEnd hook.
+   *
+   * Flips the session to `status = 'completed'` (if not already) and fires
+   * the title-summary task so the summary regenerates against the full arc.
+   * Kept deliberately forgiving: completing an already-completed session is
+   * idempotent — it re-triggers the regenerate without rewriting status.
+   *
+   * Exists because the SessionEnd hook isn't reliably fired by every
+   * symbiont, and because users sometimes know a session is done before
+   * any timer-based stale-sweep would catch it.
+   */
+  async function handleCompleteSession(req: RouteRequest): Promise<RouteResponse> {
+    const sessionId = req.params.id;
+    const session = getSession(sessionId);
+    if (!session) return { status: 404, body: { error: 'Session not found' } };
+
+    const wasActive = session.status === 'active';
+    if (wasActive) {
+      updateSession(sessionId, {
+        status: 'completed',
+        ended_at: session.ended_at ?? epochSeconds(),
+      });
+    }
+
+    await triggerTitleSummary(sessionId, { vaultDir, embeddingManager, config, logger });
+
+    logger.info(LOG_KINDS.API_SESSION_COMPLETE, 'Session manually completed', {
+      session_id: sessionId,
+      was_active: wasActive,
+    });
+
+    return { body: { ok: true, was_active: wasActive } };
+  }
+
   /** GET /api/sessions/:id/impact — get session impact data. */
   async function handleGetSessionImpact(req: RouteRequest): Promise<RouteResponse> {
     const sessionId = req.params.id;
@@ -109,5 +148,5 @@ export function createSessionMutationHandlers(deps: SessionMutationDeps) {
     return { body: impact };
   }
 
-  return { handleDeleteSession, handleGetSessionImpact };
+  return { handleDeleteSession, handleCompleteSession, handleGetSessionImpact };
 }

--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -29,7 +29,7 @@ import {
   handleCompact,
 } from './event-handlers.js';
 import { getLatestBatch } from '@myco/db/queries/batches.js';
-import { upsertSession } from '@myco/db/queries/sessions.js';
+import { upsertSession, reactivateSessionIfCompleted } from '@myco/db/queries/sessions.js';
 import { captureBatchImages, type CapturedImage } from './capture-images.js';
 import { epochSeconds, LOG_PROMPT_PREVIEW_CHARS } from '@myco/constants.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
@@ -133,6 +133,16 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
           prompt_preview: promptText.slice(0, LOG_PROMPT_PREVIEW_CHARS),
           prompt_length: promptText.length,
         });
+        // Flip a completed session back to active on genuine user activity.
+        // The auto-register branch above only reactivates when the session
+        // isn't in the in-memory registry (e.g., after daemon restart) —
+        // without this, a manually-completed or stale-swept session stays
+        // hidden from intelligence-task queries even after the user resumes.
+        if (reactivateSessionIfCompleted(event.session_id)) {
+          logger.info(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Reactivated completed session on new activity', {
+            session_id: event.session_id,
+          });
+        }
         try {
           const { batchId, promptNumber } = handleUserPrompt(event.session_id, promptText || undefined);
           logger.debug(LOG_KINDS.CAPTURE_BATCH, 'Batch opened', { session_id: event.session_id, batch_id: batchId, prompt_number: promptNumber });

--- a/packages/myco/src/daemon/jobs/session-maintenance.ts
+++ b/packages/myco/src/daemon/jobs/session-maintenance.ts
@@ -3,7 +3,7 @@
  *
  * Two tasks run in sequence:
  * 1. Complete stale active sessions — active sessions with no new prompts
- *    in more than STALE_SESSION_THRESHOLD_MS are marked completed.
+ *    in more than the configured stale threshold are marked completed.
  * 2. Delete dead sessions — sessions with ≤ DEAD_SESSION_MAX_PROMPTS prompts
  *    are deleted via cascade, including vault file and embedding vector cleanup.
  */
@@ -21,38 +21,36 @@ import type { EmbeddingManager } from '../embedding/manager.js';
 import { cleanupAfterSessionCascade } from './session-cleanup.js';
 import { LOG_KINDS } from '../../constants/log-kinds.js';
 
-/** Stale threshold in epoch seconds (derived from the ms constant). */
-const STALE_SESSION_THRESHOLD_S = STALE_SESSION_THRESHOLD_MS / MS_PER_SECOND;
-
 /**
  * Complete active sessions whose last prompt is older than the stale threshold.
  *
  * Uses COALESCE to fall back to the session's started_at when no prompt
  * batches exist (session was registered but never received a prompt).
  *
+ * The activity-timestamp predicate itself is the only protection: sessions
+ * with recent work fall outside the stale window and won't be swept. A
+ * previously-registered session that's been idle past the threshold is
+ * swept normally — if it later receives a new event, `event-dispatch.ts`
+ * upserts it back to `status='active'`, so marking completed is reversible.
+ *
+ * @param thresholdSeconds window of inactivity before a session is stale
  * @returns number of sessions completed
  */
-export function completeStaleActiveSessions(registeredSessionIds: string[]): number {
+export function completeStaleActiveSessions(
+  thresholdSeconds: number = STALE_SESSION_THRESHOLD_MS / MS_PER_SECOND,
+): number {
   const db = getDatabase();
-  const cutoff = epochSeconds() - STALE_SESSION_THRESHOLD_S;
-
-  // Build exclusion clause for registered sessions
-  const excludePlaceholders = registeredSessionIds.length > 0
-    ? `AND id NOT IN (${registeredSessionIds.map(() => '?').join(', ')})`
-    : '';
-
-  const params: unknown[] = [cutoff, ...registeredSessionIds];
+  const cutoff = epochSeconds() - thresholdSeconds;
 
   const info = db.prepare(
     `UPDATE sessions
-     SET status = 'completed'
+     SET status = 'completed', ended_at = COALESCE(ended_at, ?)
      WHERE status = 'active'
        AND COALESCE(
          (SELECT MAX(pb.started_at) FROM prompt_batches pb WHERE pb.session_id = sessions.id),
          sessions.started_at
-       ) < ?
-       ${excludePlaceholders}`,
-  ).run(...params);
+       ) < ?`,
+  ).run(epochSeconds(), cutoff);
 
   return info.changes;
 }
@@ -94,6 +92,11 @@ export interface SessionMaintenanceDeps {
   registeredSessionIds: () => string[];
   embeddingManager: EmbeddingManager;
   vaultDir: string;
+  /**
+   * Inactivity window (ms) after which an active session is marked completed.
+   * When omitted, falls back to `STALE_SESSION_THRESHOLD_MS`.
+   */
+  staleThresholdMs?: number;
 }
 
 /**
@@ -102,11 +105,12 @@ export interface SessionMaintenanceDeps {
  * 2. Delete dead sessions (cascade)
  */
 export async function runSessionMaintenance(deps: SessionMaintenanceDeps): Promise<void> {
-  const { logger, registeredSessionIds, embeddingManager, vaultDir } = deps;
+  const { logger, registeredSessionIds, embeddingManager, vaultDir, staleThresholdMs } = deps;
   const registered = registeredSessionIds();
 
   // Task 1: Complete stale sessions
-  const completed = completeStaleActiveSessions(registered);
+  const thresholdSeconds = (staleThresholdMs ?? STALE_SESSION_THRESHOLD_MS) / MS_PER_SECOND;
+  const completed = completeStaleActiveSessions(thresholdSeconds);
   if (completed > 0) {
     logger.info(LOG_KINDS.MAINTENANCE_SESSION, 'Completed stale sessions', { count: completed });
   }

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -552,8 +552,9 @@ export async function main(): Promise<void> {
   server.registerRoute('GET', '/api/sessions', handleListSessions);
 
   server.registerRoute('GET', '/api/sessions/:id', handleGetSession);
-  const sessionMutations = createSessionMutationHandlers({ embeddingManager, vaultDir, logger });
+  const sessionMutations = createSessionMutationHandlers({ embeddingManager, vaultDir, logger, config });
   server.registerRoute('GET', '/api/sessions/:id/impact', sessionMutations.handleGetSessionImpact);
+  server.registerRoute('POST', '/api/sessions/:id/complete', sessionMutations.handleCompleteSession);
   server.registerRoute('DELETE', '/api/sessions/:id', sessionMutations.handleDeleteSession);
   server.registerRoute('GET', '/api/sessions/:id/batches', handleGetSessionBatches);
   server.registerRoute('GET', '/api/batches/:id/activities', handleGetBatchActivities);

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -76,6 +76,7 @@ export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps
       registeredSessionIds: () => registry.sessions,
       embeddingManager,
       vaultDir,
+      staleThresholdMs: config.daemon.stale_session_threshold_ms,
     }),
   });
 

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -30,6 +30,7 @@ import { DaemonLogger } from './logger.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import { EmbeddingManager } from './embedding/index.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+import { triggerTitleSummary as sharedTriggerTitleSummary } from './trigger-title-summary.js';
 import type { RouteHandler } from './router.js';
 import type { RegisteredSession } from './lifecycle.js';
 
@@ -117,26 +118,8 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     last_assistant_message: z.string().nullish(),
   });
 
-  /**
-   * Fire-and-forget trigger for the title-summary agent task.
-   * Guards: summary_batch_interval must be > 0 (0 = disabled), no run
-   * already in progress. Callers add their own preconditions (e.g. batch
-   * threshold, missing title).
-   */
-  async function triggerTitleSummary(sessionId: string): Promise<void> {
-    if (config.agent.summary_batch_interval <= 0) return;
-    if (config.agent.event_tasks_enabled === false) return;
-    // No caller-side concurrency guard — the executor's per-task guard
-    // handles blocking duplicate title-summary runs.
-    try {
-      const { runAgent } = await import('../agent/executor.js');
-      runAgent(vaultDir, {
-        task: 'title-summary',
-        instruction: `Process session ${sessionId} only`,
-        embeddingManager,
-      }).catch(err => logger.warn(LOG_KINDS.AGENT_ERROR, 'Title-summary task failed', { error: String(err) }));
-    } catch { /* agent unavailable */ }
-  }
+  const triggerTitleSummary = (sessionId: string) =>
+    sharedTriggerTitleSummary(sessionId, { vaultDir, embeddingManager, config, logger });
 
   async function processStopEvent(
     sessionId: string,

--- a/packages/myco/src/daemon/task-scheduling.ts
+++ b/packages/myco/src/daemon/task-scheduling.ts
@@ -164,8 +164,17 @@ export async function registerScheduledTasks(
     },
     preConditions: {
       'has-unprocessed-batches': () => {
+        // Only count unprocessed batches from sessions that have settled
+        // (status != 'active'). Otherwise full-intelligence fires on every
+        // live prompt and then filters everything out — wasted agent runs.
         const row = getDatabase().prepare(
-          'SELECT 1 FROM prompt_batches WHERE processed = 0 LIMIT 1'
+          `SELECT 1 FROM prompt_batches pb
+           WHERE pb.processed = 0
+             AND EXISTS (
+               SELECT 1 FROM sessions s
+               WHERE s.id = pb.session_id AND s.status != 'active'
+             )
+           LIMIT 1`,
         ).get();
         return row !== undefined;
       },

--- a/packages/myco/src/daemon/trigger-title-summary.ts
+++ b/packages/myco/src/daemon/trigger-title-summary.ts
@@ -1,0 +1,57 @@
+/**
+ * Fire-and-forget trigger for the title-summary agent task.
+ *
+ * Shared between the Stop-hook pipeline (per-session activity) and the
+ * manual "Complete Session" API (user-initiated regenerate). Both paths
+ * need the same config gates and the same dynamic-import guard against a
+ * missing agent module; sharing avoids drift when either concern changes.
+ */
+
+import type { EmbeddingManager } from './embedding/manager.js';
+import type { DaemonLogger } from './logger.js';
+import type { MycoConfig } from '@myco/config/schema.js';
+import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+
+export interface TriggerTitleSummaryDeps {
+  vaultDir: string;
+  embeddingManager: EmbeddingManager;
+  config: MycoConfig;
+  logger: DaemonLogger;
+}
+
+/**
+ * Trigger `title-summary` for one session.
+ *
+ * Returns without scheduling a run when:
+ * - `agent.summary_batch_interval <= 0` (summaries disabled entirely), or
+ * - `agent.event_tasks_enabled === false` (event-driven tasks globally off), or
+ * - the agent module can't be loaded.
+ *
+ * Rejections from the executor surface via `logger.warn` — the task's own
+ * per-task concurrency guard handles overlap with in-flight runs.
+ */
+export async function triggerTitleSummary(
+  sessionId: string,
+  deps: TriggerTitleSummaryDeps,
+): Promise<void> {
+  const { vaultDir, embeddingManager, config, logger } = deps;
+
+  if (config.agent.summary_batch_interval <= 0) return;
+  if (config.agent.event_tasks_enabled === false) return;
+
+  try {
+    const { runAgent } = await import('../agent/executor.js');
+    runAgent(vaultDir, {
+      task: 'title-summary',
+      instruction: `Process session ${sessionId} only`,
+      embeddingManager,
+    }).catch((err) => {
+      logger.warn(LOG_KINDS.AGENT_ERROR, 'Title-summary task failed', {
+        session_id: sessionId,
+        error: String(err),
+      });
+    });
+  } catch {
+    // agent module unavailable — silently no-op
+  }
+}

--- a/packages/myco/src/db/queries/batches.ts
+++ b/packages/myco/src/db/queries/batches.ts
@@ -243,9 +243,14 @@ export function populateBatchResponses(
  * Get unprocessed batches, ordered by id ASC (insertion order).
  *
  * Supports cursor-based pagination via `after_id` and a `limit` cap.
+ *
+ * When `includeActive` is explicitly `false`, batches from sessions still
+ * in `status = 'active'` are excluded — intelligence tasks opt in to this
+ * so they don't reason over in-flight work. The default is permissive to
+ * preserve behavior for tests and any non-agent caller.
  */
 export function getUnprocessedBatches(
-  options: { after_id?: number; limit?: number } = {},
+  options: { after_id?: number; limit?: number; includeActive?: boolean } = {},
 ): BatchRow[] {
   const db = getDatabase();
 
@@ -255,6 +260,12 @@ export function getUnprocessedBatches(
   if (options.after_id !== undefined) {
     conditions.push(`id > ?`);
     params.push(options.after_id);
+  }
+
+  if (options.includeActive === false) {
+    conditions.push(
+      `EXISTS (SELECT 1 FROM sessions s WHERE s.id = prompt_batches.session_id AND s.status != 'active')`,
+    );
   }
 
   const limit = options.limit ?? DEFAULT_UNPROCESSED_LIMIT;

--- a/packages/myco/src/db/queries/search.ts
+++ b/packages/myco/src/db/queries/search.ts
@@ -45,6 +45,12 @@ export interface SearchOptions {
   type?: string;
   /** Maximum number of results to return (default: SEARCH_RESULTS_DEFAULT_LIMIT). */
   limit?: number;
+  /**
+   * When explicitly `false`, hide results belonging to sessions still in
+   * `status = 'active'` (and active sessions themselves). Intelligence-task
+   * reads opt in to this; UI/CLI callers leave it unset.
+   */
+  includeActive?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -75,18 +81,22 @@ export function fullTextSearch(
   const db = getDatabase();
   const limit = options.limit ?? SEARCH_RESULTS_DEFAULT_LIMIT;
   const typeFilter = options.type;
+  const excludeActive = options.includeActive === false;
 
   const results: SearchResult[] = [];
 
   // -- prompt_batches branch ------------------------------------------------
   if (typeFilter === undefined || typeFilter === 'prompt_batch') {
+    const activeGate = excludeActive
+      ? ` AND EXISTS (SELECT 1 FROM sessions s WHERE s.id = pb.session_id AND s.status != 'active')`
+      : '';
     const batchRows = db.prepare(
       `SELECT pb.id, pb.prompt_number, pb.session_id,
               substr(COALESCE(pb.user_prompt, '') || ' ' || COALESCE(pb.response_summary, ''), 1, ?) AS preview,
               fts.rank
        FROM prompt_batches_fts fts
        JOIN prompt_batches pb ON pb.id = fts.rowid
-       WHERE prompt_batches_fts MATCH ?
+       WHERE prompt_batches_fts MATCH ?${activeGate}
        ORDER BY fts.rank
        LIMIT ?`
     ).all(SEARCH_PREVIEW_CHARS, query, limit) as Array<{
@@ -113,12 +123,15 @@ export function fullTextSearch(
 
   // -- activities branch ----------------------------------------------------
   if (typeFilter === undefined || typeFilter === 'activity') {
+    const activeGate = excludeActive
+      ? ` AND EXISTS (SELECT 1 FROM sessions s WHERE s.id = a.session_id AND s.status != 'active')`
+      : '';
     const activityRows = db.prepare(
       `SELECT a.id, a.tool_name, a.tool_input, a.file_path, a.session_id,
               fts.rank
        FROM activities_fts fts
        JOIN activities a ON a.id = fts.rowid
-       WHERE activities_fts MATCH ?
+       WHERE activities_fts MATCH ?${activeGate}
        ORDER BY fts.rank
        LIMIT ?`
     ).all(query, limit) as Array<{
@@ -145,13 +158,19 @@ export function fullTextSearch(
 
   // -- spores branch --------------------------------------------------------
   if (typeFilter === undefined || typeFilter === 'spore') {
+    // Spores may have a NULL session_id (agent-authored, no source session),
+    // which are always kept; only spores attached to still-active sessions
+    // are excluded when the gate is on.
+    const activeGate = excludeActive
+      ? ` AND (s.session_id IS NULL OR EXISTS (SELECT 1 FROM sessions ss WHERE ss.id = s.session_id AND ss.status != 'active'))`
+      : '';
     const sporeRows = db.prepare(
       `SELECT s.id, s.observation_type, s.session_id,
               substr(COALESCE(s.content, ''), 1, ?) AS preview,
               fts.rank
        FROM spores_fts fts
        JOIN spores s ON s.rowid = fts.rowid
-       WHERE spores_fts MATCH ?
+       WHERE spores_fts MATCH ?${activeGate}
        ORDER BY fts.rank
        LIMIT ?`
     ).all(SEARCH_PREVIEW_CHARS, query, limit) as Array<{
@@ -176,13 +195,14 @@ export function fullTextSearch(
 
   // -- sessions branch ------------------------------------------------------
   if (typeFilter === undefined || typeFilter === 'session') {
+    const activeGate = excludeActive ? ` AND s.status != 'active'` : '';
     const sessionRows = db.prepare(
       `SELECT s.id, s.title,
               substr(COALESCE(s.summary, s.title, ''), 1, ?) AS preview,
               fts.rank
        FROM sessions_fts fts
        JOIN sessions s ON s.rowid = fts.rowid
-       WHERE sessions_fts MATCH ?
+       WHERE sessions_fts MATCH ?${activeGate}
        ORDER BY fts.rank
        LIMIT ?`
     ).all(SEARCH_PREVIEW_CHARS, query, limit) as Array<{

--- a/packages/myco/src/db/queries/sessions.ts
+++ b/packages/myco/src/db/queries/sessions.ts
@@ -111,6 +111,12 @@ export interface ListSessionsOptions {
   search?: string;
   /** Only return sessions created after this epoch-seconds timestamp. */
   since?: number;
+  /**
+   * When explicitly `false` and no `status` filter is set, exclude sessions
+   * still in `status = 'active'` — intelligence-task reads opt in to this.
+   * Defaults permissive so UI listings keep showing in-flight sessions.
+   */
+  includeActive?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -298,6 +304,13 @@ function buildSessionsWhere(
     params.push(options.since);
   }
 
+  // Exclude active sessions only when the caller explicitly opts in and
+  // hasn't already constrained `status`. Intelligence-task reads set this
+  // to avoid picking up in-flight work; UI/CLI leave it unset.
+  if (options.includeActive === false && options.status === undefined) {
+    conditions.push(`status != 'active'`);
+  }
+
   return {
     where: conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '',
     params,
@@ -341,6 +354,22 @@ export function countSessions(
   ).get(...params) as { count: number };
 
   return row.count;
+}
+
+/**
+ * Return the set of session IDs currently in `status = 'active'`.
+ *
+ * Used by the semantic-search path, which can't apply a SQL join against
+ * session status (the vector store is a separate concern), so it filters
+ * results in-memory against this set instead. Bounded by the number of
+ * concurrent in-flight sessions — typically small.
+ */
+export function getActiveSessionIds(): Set<string> {
+  const db = getDatabase();
+  const rows = db.prepare(
+    `SELECT id FROM sessions WHERE status = 'active'`,
+  ).all() as Array<{ id: string }>;
+  return new Set(rows.map((r) => r.id));
 }
 
 /**

--- a/packages/myco/src/db/queries/sessions.ts
+++ b/packages/myco/src/db/queries/sessions.ts
@@ -373,6 +373,34 @@ export function getActiveSessionIds(): Set<string> {
 }
 
 /**
+ * Flip a session back to `status = 'active'` if it's currently `'completed'`.
+ *
+ * Called on live user activity (`user_prompt` events) so a session that was
+ * auto-completed by the stale sweep or manually completed via the API snaps
+ * back to active transparently when the user resumes. No-op for sessions
+ * that are already active or don't exist.
+ *
+ * The `ended_at` column is intentionally preserved — it records the most
+ * recent completion time, and the next completion will overwrite it.
+ *
+ * @returns true if a row was updated (session was completed and is now active)
+ */
+export function reactivateSessionIfCompleted(id: string): boolean {
+  const db = getDatabase();
+  const info = db.prepare(
+    `UPDATE sessions SET status = 'active' WHERE id = ? AND status = 'completed'`,
+  ).run(id);
+  if (info.changes === 0) return false;
+
+  const row = db.prepare(
+    `SELECT ${SELECT_COLUMNS} FROM sessions WHERE id = ?`,
+  ).get(id) as Record<string, unknown> | undefined;
+  if (row) syncRow('sessions', toSessionRow(row));
+
+  return true;
+}
+
+/**
  * Update specific fields on an existing session.
  *
  * @returns the updated row, or null if the session does not exist.

--- a/packages/myco/src/db/queries/spores.ts
+++ b/packages/myco/src/db/queries/spores.ts
@@ -79,6 +79,15 @@ export interface ListSporesOptions {
   since?: number;
   limit?: number;
   offset?: number;
+  /**
+   * When explicitly `false`, exclude spores whose source session is still
+   * `status = 'active'` — intelligence-task reads (agent tools, context
+   * queries) should opt in to this. Defaults to permissive so UI listings
+   * and prompt-time context injection keep seeing in-flight work. Explicit
+   * `session_id` filters bypass this check: a direct lookup of one session's
+   * spores is always permitted.
+   */
+  includeActive?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -238,6 +247,16 @@ function buildSporeWhere(
   if (options.since !== undefined) {
     conditions.push('created_at > ?');
     params.push(options.since);
+  }
+
+  // Only exclude spores from in-flight sessions when the caller explicitly
+  // asks for it (intelligence tasks). UI and hook-level context injection
+  // leave this unset so they see everything. A direct session_id filter
+  // bypasses the gate — that lookup is always permitted.
+  if (options.includeActive === false && options.session_id === undefined) {
+    conditions.push(
+      `(session_id IS NULL OR EXISTS (SELECT 1 FROM sessions s WHERE s.id = spores.session_id AND s.status != 'active'))`,
+    );
   }
 
   return {

--- a/packages/myco/ui/src/components/sessions/SessionDetail.tsx
+++ b/packages/myco/ui/src/components/sessions/SessionDetail.tsx
@@ -1,13 +1,13 @@
 import { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, AlertCircle, Loader2, Sparkles, Check, Trash2 } from 'lucide-react';
+import { ArrowLeft, AlertCircle, Loader2, Sparkles, Check, Trash2, CheckCircle2 } from 'lucide-react';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { Surface } from '../ui/surface';
 import { StatCard } from '../ui/stat-card';
 import { SectionHeader } from '../ui/section-header';
 import { ConfirmDialog } from '../ui/confirm-dialog';
-import { useSession, useDeleteSession, useSessionImpact, useSessionPlans } from '../../hooks/use-sessions';
+import { useSession, useDeleteSession, useSessionImpact, useSessionPlans, useCompleteSession } from '../../hooks/use-sessions';
 import { useSymbionts, buildResumeCommand } from '../../hooks/use-symbionts';
 import { useTriggerRun } from '../../hooks/use-agent';
 import { BatchTimeline } from './BatchTimeline';
@@ -103,6 +103,7 @@ export function SessionDetail({ id }: SessionDetailProps) {
   const { data: session, isLoading, isError, error } = useSession(id);
   const { data: symbiontsData } = useSymbionts();
   const triggerRun = useTriggerRun();
+  const completeSession = useCompleteSession();
   const [summaryStatus, setSummaryStatus] = useState<'idle' | 'running' | 'done' | 'error'>('idle');
   const [deleteOpen, setDeleteOpen] = useState(false);
 
@@ -207,6 +208,35 @@ export function SessionDetail({ id }: SessionDetailProps) {
             )}
             {summaryStatus === 'done' ? 'Summary Requested' : 'Generate Summary'}
           </Button>
+          {(() => {
+            const isAlreadyCompleted = session.status !== 'active';
+            const label = completeSession.isSuccess
+              ? 'Session Completed'
+              : isAlreadyCompleted
+                ? 'Already Completed'
+                : 'Complete Session';
+            return (
+              <Button
+                variant="secondary"
+                size="sm"
+                className="gap-2"
+                disabled={completeSession.isPending || isAlreadyCompleted}
+                title={
+                  isAlreadyCompleted
+                    ? 'Session is already completed'
+                    : 'Mark this session completed and regenerate its summary'
+                }
+                onClick={() => completeSession.mutate(id)}
+              >
+                {completeSession.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <CheckCircle2 className="h-4 w-4" />
+                )}
+                {label}
+              </Button>
+            );
+          })()}
           <Button
             variant="ghost"
             size="sm"

--- a/packages/myco/ui/src/components/sessions/SessionList.tsx
+++ b/packages/myco/ui/src/components/sessions/SessionList.tsx
@@ -7,12 +7,13 @@ import { ConfirmDialog } from '../ui/confirm-dialog';
 import { ListToolbar, type FilterDefinition } from '../ui/list-toolbar';
 import { Pagination } from '../ui/pagination';
 import { useSessions, useDeleteSession, useSessionImpact, type SessionSummary } from '../../hooks/use-sessions';
+import { useSymbionts } from '../../hooks/use-symbionts';
 import { useListFilters, FILTER_ALL } from '../../hooks/use-list-filters';
 import { DEFAULT_PAGE_SIZE } from '../../lib/constants';
 import { shortSession } from '../../lib/format';
 import { StatusBadge } from './status-helpers';
 import { cn } from '../../lib/cn';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 /* ---------- Constants ---------- */
 
@@ -22,35 +23,26 @@ const SKELETON_ROW_COUNT = 5;
 /** Characters shown from session ID in table column. */
 const SESSION_ID_COLUMN_LENGTH = 12;
 
-const SESSION_FILTERS: FilterDefinition[] = [
-  {
-    key: 'status',
-    label: 'Status',
-    options: [
-      { value: FILTER_ALL, label: 'All statuses' },
-      { value: 'active', label: 'Active' },
-      { value: 'completed', label: 'Completed' },
-    ],
-  },
-  {
-    key: 'agent',
-    label: 'Agent',
-    options: [
-      { value: FILTER_ALL, label: 'All agents' },
-      { value: 'claude-code', label: 'Claude Code' },
-      { value: 'cursor', label: 'Cursor' },
-    ],
-  },
-];
+const STATUS_FILTER: FilterDefinition = {
+  key: 'status',
+  label: 'Status',
+  options: [
+    { value: FILTER_ALL, label: 'All statuses' },
+    { value: 'active', label: 'Active' },
+    { value: 'completed', label: 'Completed' },
+  ],
+};
 
 /* ---------- Sub-components ---------- */
 
 function SessionTableRow({
   session,
+  symbiontDisplayName,
   onClick,
   onDelete,
 }: {
   session: SessionSummary;
+  symbiontDisplayName: string;
   onClick: () => void;
   onDelete: () => void;
 }) {
@@ -84,10 +76,10 @@ function SessionTableRow({
         </span>
       </td>
 
-      {/* Agent */}
+      {/* Symbiont */}
       <td className="px-4 py-3">
         <Badge variant="outline" className="font-mono text-[10px] px-1.5 py-0">
-          {session.agent || 'unknown'}
+          {symbiontDisplayName}
         </Badge>
       </td>
 
@@ -163,6 +155,38 @@ export function SessionList() {
   const [deleteTarget, setDeleteTarget] = useState<SessionSummary | null>(null);
   const deleteSession = useDeleteSession();
   const { data: impact } = useSessionImpact(deleteTarget?.id ?? null);
+  const { data: symbiontsData } = useSymbionts();
+
+  // Build the Symbiont filter from whichever symbionts this project has
+  // enabled. The filter key stays `agent` because that's what the backend
+  // sessions query expects, but the label and options reflect the project's
+  // actual configuration rather than a hardcoded list.
+  const sessionFilters = useMemo<FilterDefinition[]>(() => {
+    const enabledSymbionts = (symbiontsData?.symbionts ?? []).filter((s) => s.enabled);
+    const symbiontFilter: FilterDefinition = {
+      key: 'agent',
+      label: 'Symbiont',
+      options: [
+        { value: FILTER_ALL, label: 'All symbionts' },
+        ...enabledSymbionts.map((s) => ({ value: s.name, label: s.displayName })),
+      ],
+    };
+    return [STATUS_FILTER, symbiontFilter];
+  }, [symbiontsData]);
+
+  // Lookup from the DB-stored agent name (e.g. 'claude-code') to the
+  // manifest display name. Falls back to the raw name for sessions whose
+  // symbiont is no longer present — better than showing "unknown".
+  const symbiontDisplayName = useMemo(() => {
+    const lookup = new Map<string, string>();
+    for (const s of symbiontsData?.symbionts ?? []) {
+      lookup.set(s.name, s.displayName);
+    }
+    return (agent: string | null | undefined): string => {
+      if (!agent) return 'unknown';
+      return lookup.get(agent) ?? agent;
+    };
+  }, [symbiontsData]);
 
   const activeStatus = activeFilter('status');
   const activeAgent = activeFilter('agent');
@@ -190,7 +214,7 @@ export function SessionList() {
       searchPlaceholder="Search sessions..."
       searchValue={searchInput}
       onSearchChange={handleSearchChange}
-      filters={SESSION_FILTERS}
+      filters={sessionFilters}
       filterValues={filterValues}
       onFilterChange={handleFilterChange}
     />
@@ -201,7 +225,7 @@ export function SessionList() {
       <tr className="border-b border-[var(--ghost-border)] bg-surface-container/50">
         <ColHeader>Session ID</ColHeader>
         <ColHeader>Title</ColHeader>
-        <ColHeader>Agent</ColHeader>
+        <ColHeader>Symbiont</ColHeader>
         <ColHeader>Status</ColHeader>
         <ColHeader className="text-center">Turns</ColHeader>
         <ColHeader>Date</ColHeader>
@@ -266,6 +290,7 @@ export function SessionList() {
                 <SessionTableRow
                   key={session.id}
                   session={session}
+                  symbiontDisplayName={symbiontDisplayName(session.agent)}
                   onClick={() => navigate(`/sessions/${session.id}`)}
                   onDelete={() => setDeleteTarget(session)}
                 />

--- a/packages/myco/ui/src/hooks/use-sessions.ts
+++ b/packages/myco/ui/src/hooks/use-sessions.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { fetchJson, deleteJson } from '../lib/api';
+import { fetchJson, deleteJson, postJson } from '../lib/api';
 import { usePowerQuery } from './use-power-query';
 import { POLL_INTERVALS } from '../lib/constants';
 
@@ -207,6 +207,18 @@ export function useDeleteSession() {
     mutationFn: (sessionId: string) =>
       deleteJson<{ ok: boolean; counts: Record<string, number> }>(`/sessions/${sessionId}`),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['sessions'] });
+    },
+  });
+}
+
+export function useCompleteSession() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (sessionId: string) =>
+      postJson<{ ok: boolean; was_active: boolean }>(`/sessions/${sessionId}/complete`),
+    onSuccess: (_data, sessionId) => {
+      queryClient.invalidateQueries({ queryKey: ['session', sessionId] });
       queryClient.invalidateQueries({ queryKey: ['sessions'] });
     },
   });

--- a/packages/myco/ui/src/hooks/use-symbionts.ts
+++ b/packages/myco/ui/src/hooks/use-symbionts.ts
@@ -12,6 +12,7 @@ export interface SymbiontInfo {
   name: string;
   displayName: string;
   binary: string;
+  enabled: boolean;
   resumeCommand?: string;
 }
 

--- a/tests/agent/context-queries.test.ts
+++ b/tests/agent/context-queries.test.ts
@@ -110,7 +110,7 @@ describe('executeContextQueries', () => {
         makeQuery({ tool: 'vault_unprocessed', limit: 5 }),
       ]);
 
-      expect(getUnprocessedBatches).toHaveBeenCalledWith({ limit: 5 });
+      expect(getUnprocessedBatches).toHaveBeenCalledWith({ limit: 5, includeActive: false });
     });
   });
 
@@ -128,6 +128,7 @@ describe('executeContextQueries', () => {
       expect(listSpores).toHaveBeenCalledWith({
         agent_id: TEST_AGENT_ID,
         limit: DEFAULT_CONTEXT_QUERY_LIMIT,
+        includeActive: false,
       });
     });
 
@@ -141,6 +142,7 @@ describe('executeContextQueries', () => {
       expect(listSpores).toHaveBeenCalledWith({
         agent_id: TEST_AGENT_ID,
         limit: 20,
+        includeActive: false,
       });
     });
   });
@@ -156,7 +158,7 @@ describe('executeContextQueries', () => {
       expect(results).toHaveLength(1);
       expect(results[0].tool).toBe('vault_sessions');
       expect(results[0].data).toEqual([MOCK_SESSION]);
-      expect(listSessions).toHaveBeenCalledWith({ limit: DEFAULT_CONTEXT_QUERY_LIMIT });
+      expect(listSessions).toHaveBeenCalledWith({ limit: DEFAULT_CONTEXT_QUERY_LIMIT, includeActive: false });
     });
   });
 
@@ -230,7 +232,10 @@ describe('executeContextQueries', () => {
 
       await executeContextQueries(TEST_AGENT_ID, [query]);
 
-      expect(getUnprocessedBatches).toHaveBeenCalledWith({ limit: DEFAULT_CONTEXT_QUERY_LIMIT });
+      expect(getUnprocessedBatches).toHaveBeenCalledWith({
+        limit: DEFAULT_CONTEXT_QUERY_LIMIT,
+        includeActive: false,
+      });
     });
 
     it('uses custom limit when specified', async () => {
@@ -240,7 +245,7 @@ describe('executeContextQueries', () => {
         makeQuery({ tool: 'vault_sessions', limit: 50 }),
       ]);
 
-      expect(listSessions).toHaveBeenCalledWith({ limit: 50 });
+      expect(listSessions).toHaveBeenCalledWith({ limit: 50, includeActive: false });
     });
   });
 

--- a/tests/agent/tools.test.ts
+++ b/tests/agent/tools.test.ts
@@ -150,14 +150,25 @@ describe('vault tools', () => {
       expect(data).toEqual([]);
     });
 
-    it('returns unprocessed batches', async () => {
+    it('returns unprocessed batches when include_active is set', async () => {
+      // The seeded session is `status = 'active'`, so the tool's default
+      // (exclude active) would return nothing. Opt in with include_active.
       insertBatch(makeBatch(sessionId));
+      insertBatch(makeBatch(sessionId));
+
+      const t = findTool(tools, 'vault_unprocessed');
+      const result = await t.handler({ include_active: true }, undefined);
+      const data = parseResult(result) as unknown[];
+      expect(data).toHaveLength(2);
+    });
+
+    it('excludes batches from active sessions by default', async () => {
       insertBatch(makeBatch(sessionId));
 
       const t = findTool(tools, 'vault_unprocessed');
       const result = await t.handler({}, undefined);
       const data = parseResult(result) as unknown[];
-      expect(data).toHaveLength(2);
+      expect(data).toEqual([]);
     });
 
     it('supports cursor-based pagination via after_id', async () => {
@@ -165,7 +176,7 @@ describe('vault tools', () => {
       insertBatch(makeBatch(sessionId));
 
       const t = findTool(tools, 'vault_unprocessed');
-      const result = await t.handler({ after_id: b1.id }, undefined);
+      const result = await t.handler({ after_id: b1.id, include_active: true }, undefined);
       const data = parseResult(result) as unknown[];
       expect(data).toHaveLength(1);
     });
@@ -204,12 +215,20 @@ describe('vault tools', () => {
   });
 
   describe('vault_sessions', () => {
-    it('returns sessions', async () => {
+    it('returns sessions when include_active is set', async () => {
+      // The seeded session is active — without include_active the tool
+      // defaults to excluding in-flight sessions.
+      const t = findTool(tools, 'vault_sessions');
+      const result = await t.handler({ include_active: true }, undefined);
+      const data = parseResult(result) as unknown[];
+      expect(data.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('excludes active sessions by default', async () => {
       const t = findTool(tools, 'vault_sessions');
       const result = await t.handler({}, undefined);
       const data = parseResult(result) as unknown[];
-      // At least the one session we created in beforeEach
-      expect(data.length).toBeGreaterThanOrEqual(1);
+      expect(data).toEqual([]);
     });
 
     it('filters by status', async () => {

--- a/tests/daemon/api/sessions.test.ts
+++ b/tests/daemon/api/sessions.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initDatabase, closeDatabase } from '@myco/db/client';
+import { createSchema } from '@myco/db/schema';
+import { upsertSession, getSession } from '@myco/db/queries/sessions';
+import { createSessionMutationHandlers } from '@myco/daemon/api/sessions';
+import type { RouteRequest } from '@myco/daemon/router';
+
+/**
+ * Handlers depend on an EmbeddingManager for the delete path; the complete
+ * path doesn't touch it, so a stub with the interface shape is enough.
+ */
+function makeEmbeddingManagerStub(): unknown {
+  return { remove: vi.fn(), reconcile: vi.fn() };
+}
+
+function makeLogger() {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function makeRequest(overrides: Partial<RouteRequest> = {}): RouteRequest {
+  return {
+    params: {},
+    query: {},
+    body: undefined,
+    ...overrides,
+  } as RouteRequest;
+}
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+describe('handleCompleteSession', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-sessions-api-'));
+    const dbPath = path.join(tmpDir, 'myco.db');
+    const db = initDatabase(dbPath);
+    createSchema(db);
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeHandlers() {
+    // `event_tasks_enabled: false` short-circuits triggerTitleSummary before
+    // it tries to dynamic-import the agent executor — test isolation without
+    // needing to mock the whole module.
+    const config = {
+      agent: { summary_batch_interval: 5, event_tasks_enabled: false },
+    };
+    return createSessionMutationHandlers({
+      embeddingManager: makeEmbeddingManagerStub() as never,
+      vaultDir: tmpDir,
+      logger: makeLogger() as never,
+      config: config as never,
+    });
+  }
+
+  it('flips an active session to completed and sets ended_at', async () => {
+    const now = epochNow();
+    upsertSession({
+      id: 'sess-active',
+      agent: 'test-agent',
+      started_at: now,
+      created_at: now,
+      status: 'active',
+    });
+
+    const { handleCompleteSession } = makeHandlers();
+    const res = await handleCompleteSession(makeRequest({ params: { id: 'sess-active' } }));
+
+    expect(res.status === undefined || res.status < 400).toBe(true);
+    expect((res.body as { ok: boolean; was_active: boolean })).toMatchObject({
+      ok: true,
+      was_active: true,
+    });
+
+    const after = getSession('sess-active');
+    expect(after?.status).toBe('completed');
+    expect(after?.ended_at).toBeGreaterThanOrEqual(now);
+  });
+
+  it('is idempotent — re-completing a completed session does not rewrite ended_at', async () => {
+    const now = epochNow();
+    const originalEnd = now - 100;
+    upsertSession({
+      id: 'sess-done',
+      agent: 'test-agent',
+      started_at: now - 200,
+      created_at: now - 200,
+      status: 'completed',
+      ended_at: originalEnd,
+    });
+
+    const { handleCompleteSession } = makeHandlers();
+    const res = await handleCompleteSession(makeRequest({ params: { id: 'sess-done' } }));
+
+    expect((res.body as { ok: boolean; was_active: boolean })).toMatchObject({
+      ok: true,
+      was_active: false,
+    });
+
+    const after = getSession('sess-done');
+    expect(after?.status).toBe('completed');
+    expect(after?.ended_at).toBe(originalEnd);
+  });
+
+  it('returns 404 for a missing session', async () => {
+    const { handleCompleteSession } = makeHandlers();
+    const res = await handleCompleteSession(makeRequest({ params: { id: 'missing' } }));
+    expect(res.status).toBe(404);
+    expect((res.body as { error: string }).error).toBe('Session not found');
+  });
+});

--- a/tests/daemon/jobs/session-maintenance.test.ts
+++ b/tests/daemon/jobs/session-maintenance.test.ts
@@ -48,7 +48,7 @@ describe('completeStaleActiveSessions', () => {
     const staleTime = epochNow() - STALE_THRESHOLD_S - 1;
     seedSession('stale-1', { status: 'active', startedAt: staleTime });
 
-    const count = completeStaleActiveSessions([]);
+    const count = completeStaleActiveSessions();
 
     expect(count).toBe(1);
     const session = getSession('stale-1');
@@ -59,28 +59,32 @@ describe('completeStaleActiveSessions', () => {
     const staleTime = epochNow() - STALE_THRESHOLD_S - 1;
     seedSession('stale-2', { status: 'active', batchStartedAt: staleTime });
 
-    const count = completeStaleActiveSessions([]);
+    const count = completeStaleActiveSessions();
 
     expect(count).toBe(1);
     const session = getSession('stale-2');
     expect(session?.status).toBe('completed');
   });
 
-  it('skips registered sessions', () => {
+  it('completes idle sessions regardless of whether they are still registered', () => {
+    // Registry-exclusion was previously applied here and created a bug: a
+    // user with the TUI open but idle for >24h kept a session indefinitely
+    // active, which blocked every intelligence task from seeing its data.
+    // The activity-timestamp check itself is sufficient protection — a
+    // resumed session gets flipped back to 'active' by event-dispatch.
     const staleTime = epochNow() - STALE_THRESHOLD_S - 1;
-    seedSession('registered-1', { status: 'active', startedAt: staleTime });
+    seedSession('registered-but-idle', { status: 'active', startedAt: staleTime });
 
-    const count = completeStaleActiveSessions(['registered-1']);
+    const count = completeStaleActiveSessions();
 
-    expect(count).toBe(0);
-    const session = getSession('registered-1');
-    expect(session?.status).toBe('active');
+    expect(count).toBe(1);
+    expect(getSession('registered-but-idle')?.status).toBe('completed');
   });
 
   it('skips recently active sessions', () => {
     seedSession('fresh-1', { status: 'active', batchStartedAt: epochNow() });
 
-    const count = completeStaleActiveSessions([]);
+    const count = completeStaleActiveSessions();
 
     expect(count).toBe(0);
     const session = getSession('fresh-1');
@@ -91,9 +95,33 @@ describe('completeStaleActiveSessions', () => {
     const staleTime = epochNow() - STALE_THRESHOLD_S - 1;
     seedSession('completed-1', { status: 'completed', startedAt: staleTime });
 
-    const count = completeStaleActiveSessions([]);
+    const count = completeStaleActiveSessions();
 
     expect(count).toBe(0);
+  });
+
+  it('honors the configured threshold override', () => {
+    // 10-minute session — stale under a 5-minute threshold, fresh under the default.
+    const tenMinAgo = epochNow() - 10 * 60;
+    seedSession('config-threshold', { status: 'active', batchStartedAt: tenMinAgo });
+
+    expect(completeStaleActiveSessions(STALE_THRESHOLD_S)).toBe(0);
+    expect(getSession('config-threshold')?.status).toBe('active');
+
+    expect(completeStaleActiveSessions(5 * 60)).toBe(1);
+    expect(getSession('config-threshold')?.status).toBe('completed');
+  });
+
+  it('sets ended_at on the completed row', () => {
+    const staleTime = epochNow() - STALE_THRESHOLD_S - 1;
+    seedSession('ended-at-check', { status: 'active', startedAt: staleTime });
+
+    const before = epochNow();
+    completeStaleActiveSessions();
+    const session = getSession('ended-at-check');
+
+    expect(session?.ended_at).not.toBeNull();
+    expect(session?.ended_at).toBeGreaterThanOrEqual(before);
   });
 });
 

--- a/tests/db/queries/batches.test.ts
+++ b/tests/db/queries/batches.test.ts
@@ -223,6 +223,37 @@ describe('prompt batch query helpers', () => {
       const rows = getUnprocessedBatches();
       expect(rows).toEqual([]);
     });
+
+    describe('active-session gating (includeActive flag)', () => {
+      it('by default (omitted) includes batches from active sessions', () => {
+        insertBatch(makeBatch(sessionId, { user_prompt: 'live' }));
+        const rows = getUnprocessedBatches();
+        expect(rows).toHaveLength(1);
+      });
+
+      it('with includeActive:false excludes batches from active sessions', () => {
+        insertBatch(makeBatch(sessionId, { user_prompt: 'live' }));
+        const rows = getUnprocessedBatches({ includeActive: false });
+        expect(rows).toEqual([]);
+      });
+
+      it('with includeActive:false includes batches from completed sessions', () => {
+        // Complete the session, then insert a batch referencing it.
+        const completedSession = makeSession({ status: 'completed' });
+        upsertSession(completedSession);
+        insertBatch(makeBatch(completedSession.id, { user_prompt: 'settled' }));
+
+        const rows = getUnprocessedBatches({ includeActive: false });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].user_prompt).toBe('settled');
+      });
+
+      it('with includeActive:true bypasses the filter even for active sessions', () => {
+        insertBatch(makeBatch(sessionId, { user_prompt: 'live' }));
+        const rows = getUnprocessedBatches({ includeActive: true });
+        expect(rows).toHaveLength(1);
+      });
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/db/queries/sessions.test.ts
+++ b/tests/db/queries/sessions.test.ts
@@ -223,6 +223,38 @@ describe('session query helpers', () => {
       expect(rows[0].id).toBe('s3');
     });
 
+    describe('active-session gating (includeActive flag)', () => {
+      it('by default (omitted) returns active sessions', async () => {
+        // Preserves existing UI behavior — the gate only engages when
+        // intelligence-task callers explicitly opt in.
+        const now = epochNow();
+        upsertSession(makeSession({ id: 'live', created_at: now, started_at: now }));
+        const rows = listSessions();
+        expect(rows.map((r) => r.id)).toContain('live');
+      });
+
+      it('with includeActive:false excludes active sessions', async () => {
+        const now = epochNow();
+        upsertSession(makeSession({ id: 'live', created_at: now, started_at: now }));
+        const done = makeSession({ id: 'done', created_at: now + 1, started_at: now + 1 });
+        upsertSession(done);
+        closeSession('done', now + 2);
+
+        const rows = listSessions({ includeActive: false });
+        expect(rows.map((r) => r.id)).toEqual(['done']);
+      });
+
+      it('an explicit status filter overrides includeActive:false', async () => {
+        const now = epochNow();
+        upsertSession(makeSession({ id: 'live', created_at: now, started_at: now }));
+
+        // Explicit status='active' takes precedence — caller is asking for
+        // in-flight sessions and shouldn't be silently filtered.
+        const rows = listSessions({ includeActive: false, status: 'active' });
+        expect(rows.map((r) => r.id)).toEqual(['live']);
+      });
+    });
+
     it('paginates with offset', async () => {
       const now = epochNow();
       for (let i = 0; i < 5; i++) {

--- a/tests/db/queries/sessions.test.ts
+++ b/tests/db/queries/sessions.test.ts
@@ -17,6 +17,7 @@ import {
   closeSession,
   getSessionImpact,
   deleteSessionCascade,
+  reactivateSessionIfCompleted,
 } from '@myco/db/queries/sessions.js';
 import type { SessionInsert } from '@myco/db/queries/sessions.js';
 
@@ -672,6 +673,45 @@ describe('session query helpers', () => {
 
       const second = deleteSessionCascade(session.id);
       expect(second.deleted).toBe(false);
+    });
+  });
+
+  describe('reactivateSessionIfCompleted', () => {
+    it('flips a completed session back to active and returns true', () => {
+      const now = epochNow();
+      const session = makeSession({ id: 'sess-completed', status: 'completed', created_at: now, started_at: now });
+      upsertSession(session);
+
+      const flipped = reactivateSessionIfCompleted('sess-completed');
+
+      expect(flipped).toBe(true);
+      expect(getSession('sess-completed')?.status).toBe('active');
+    });
+
+    it('is a no-op for an already-active session and returns false', () => {
+      const session = makeSession({ id: 'sess-active', status: 'active' });
+      upsertSession(session);
+
+      const flipped = reactivateSessionIfCompleted('sess-active');
+
+      expect(flipped).toBe(false);
+      expect(getSession('sess-active')?.status).toBe('active');
+    });
+
+    it('returns false for a missing session', () => {
+      expect(reactivateSessionIfCompleted('nope')).toBe(false);
+    });
+
+    it('preserves ended_at when reactivating — the next completion overwrites it', () => {
+      const now = epochNow();
+      upsertSession({
+        ...makeSession({ id: 'sess-keep-end', status: 'completed', created_at: now, started_at: now }),
+        ended_at: now + 100,
+      });
+
+      reactivateSessionIfCompleted('sess-keep-end');
+
+      expect(getSession('sess-keep-end')?.ended_at).toBe(now + 100);
     });
   });
 });

--- a/tests/db/queries/spores.test.ts
+++ b/tests/db/queries/spores.test.ts
@@ -274,6 +274,43 @@ describe('spore query helpers', () => {
       expect(page2).toHaveLength(1);
       expect(page2[0].id).toBe('sp1');
     });
+
+    describe('active-session gating (includeActive flag)', () => {
+      it('by default includes spores from active sessions', () => {
+        // beforeEach seeds `sessionId` as an active session.
+        insertSpore(makeSpore(agentId, { id: 'spore-live', session_id: sessionId }));
+        const rows = listSpores({ agent_id: agentId });
+        expect(rows.map((r) => r.id)).toContain('spore-live');
+      });
+
+      it('with includeActive:false excludes spores from active sessions', () => {
+        insertSpore(makeSpore(agentId, { id: 'spore-live', session_id: sessionId }));
+
+        // Create a completed session and a spore attached to it.
+        const completed = makeSession({ status: 'completed' });
+        upsertSession(completed);
+        insertSpore(makeSpore(agentId, { id: 'spore-settled', session_id: completed.id }));
+
+        const rows = listSpores({ agent_id: agentId, includeActive: false });
+        const ids = rows.map((r) => r.id);
+        expect(ids).toContain('spore-settled');
+        expect(ids).not.toContain('spore-live');
+      });
+
+      it('includeActive:false keeps spores with no session_id (agent-authored)', () => {
+        insertSpore(makeSpore(agentId, { id: 'spore-global', session_id: null }));
+        const rows = listSpores({ agent_id: agentId, includeActive: false });
+        expect(rows.map((r) => r.id)).toContain('spore-global');
+      });
+
+      it('an explicit session_id filter bypasses the active-session gate', () => {
+        // Direct session-scoped lookup is always permitted — useful for the
+        // UI when the user is viewing a session's own spores live.
+        insertSpore(makeSpore(agentId, { id: 'spore-live', session_id: sessionId }));
+        const rows = listSpores({ session_id: sessionId, includeActive: false });
+        expect(rows.map((r) => r.id)).toContain('spore-live');
+      });
+    });
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Intelligence tasks now skip in-flight sessions by default.** `full-intelligence`, `skill-survey`, and every other agent-path reader consumes only settled (`status != 'active'`) work via a new `includeActive` flag on `getUnprocessedBatches` / `listSpores` / `listSessions` / `fullTextSearch`; semantic search filters in-memory. UI, CLI, and tests keep the permissive default.
- **Auto-complete bug fixed.** `completeStaleActiveSessions` previously protected any session in the in-memory registry indefinitely, so an idle TUI session never settled. The activity-timestamp predicate is sufficient protection — resume is handled by `event-dispatch` flipping status back to active on the next event.
- **Threshold is now configurable** under `daemon.stale_session_threshold_ms` (default 1h). The `has-unprocessed-batches` scheduler precondition honors the same gate to avoid waking `full-intelligence` for batches it would filter out.
- **Manual "Complete Session"** button + `POST /api/sessions/:id/complete` for symbionts whose SessionEnd hook isn't reliable. Backend shares `triggerTitleSummary` with the Stop-hook path so both respect `event_tasks_enabled` / `summary_batch_interval` identically.
- **Symbiont filter rebuilt** from the project's enabled manifest list instead of a hardcoded pair; filter label, column header, and row cells render manifest `displayName`.

## Test plan

- [x] 2204 unit + integration tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)
- [x] Build clean (`npm run build`)
- [x] Live smoke test on `feat/agent-session-tuning`:
  - [x] **Symbiont filter**: dropdown lists all 7 enabled symbionts from myco.yaml (not the hardcoded 2); column header + row cells render display names ("Claude Code" vs `claude-code`)
  - [x] **Complete Session button**: clicked on active session → status flipped to `completed`, `ended_at` populated, `title-summary` agent run fired and completed, button state flipped to "Already Completed" on refresh
  - [x] **Query-layer gating**: SQL-verified that `has-unprocessed-batches` returns only settled-session batches (5 of 11 at test time; 6 active-session batches correctly excluded)
- [x] Auto-complete threshold — not smoke-tested (1h default); owner-verified on next day-long session

🤖 Generated with [Claude Code](https://claude.com/claude-code)