### PR TITLE
fix(agent): harden skill validation and survey timeout handling

### DIFF
--- a/.agents/skills/author-and-debug-agent-pipeline-tasks/SKILL.md
+++ b/.agents/skills/author-and-debug-agent-pipeline-tasks/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: myco:author-and-debug-agent-pipeline-tasks
-description: How to author, configure, and debug Myco agent pipeline tasks — covering task YAML anatomy (phases, schedule, dependsOn, preCondition), sweep scheduling design, parameter injection patterns, the taskOverrides scalar-drop gotcha, the skipPriorContext hallucination trap, timeout wiring, concurrency guard behavior and correctness, concurrent run audit log interleaving, LLM data-fidelity failure patterns, turn budget exhaustion, skill lifecycle task specifics (generate/evolve responsibility split, embedding-based merge detection, evolve budget sizing, content-from-disk requirement), and fault-tolerance patterns. Also covers hardening new tasks and MCP tools: readOnly annotations, global toggle gate, phase-level readOnly enforcement, test coverage, and pre-ship checklist. Use this skill when creating a new task YAML, adding schedule blocks, debugging a task that silently aborts or returns wrong data, wiring phase dependencies, or hardening a task or MCP tool with safety controls. Apply it even if the user doesn't explicitly ask about task authoring — if they're modifying anything in src/agent/tasks/, src/agent/executor.ts, src/daemon/task-scheduler.ts, or src/mcp/tools/, this skill applies.
+description: >-
+  Use this skill when authoring, configuring, or debugging Myco agent pipeline
+  tasks. It covers task YAML anatomy, scheduling, parameter injection,
+  timeout and concurrency behavior, audit-log interpretation, turn-budget
+  failures, skill-lifecycle task constraints, and hardening patterns for
+  new tasks and MCP tools. Apply it whenever work touches
+  `src/agent/tasks/`, `src/agent/executor.ts`, `src/daemon/task-scheduler.ts`,
+  or `src/mcp/tools/`, even if the user does not explicitly mention task
+  authoring.
 managed_by: myco
 user-invocable: true
 allowed-tools: Read, Edit, Write, Bash, Grep, Glob

--- a/.agents/skills/feature-branch-worktree-squash-merge-delivery/SKILL.md
+++ b/.agents/skills/feature-branch-worktree-squash-merge-delivery/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: myco:feature-branch-worktree-squash-merge-delivery
-description: Use this skill when delivering a non-trivial Myco feature that spans multiple files and requires clean commit history in a PR. Activates whenever you need to use git worktrees for isolated implementation, run the /simplify quality pass (with full procedure: duplication extraction, dispatch table replacement, function signature simplification, React prop threading), use `make build` as the full quality gate, or squash all worktree commits into a single clean PR commit. Keywords: git worktree, feature branch, feature/my-feature-name, squash merge, make build, /simplify, clean commit history.
+description: >-
+  Use this skill when delivering a non-trivial Myco feature that spans
+  multiple files and needs clean PR history. It applies whenever you need
+  git worktrees for isolated implementation, the `/simplify` quality pass,
+  `make build` as the full quality gate, or a single clean squash-merge
+  commit for the final PR.
 managed_by: myco
 version: 1
 user-invocable: true

--- a/.agents/skills/myco-skill-lifecycle/SKILL.md
+++ b/.agents/skills/myco-skill-lifecycle/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: myco:myco-skill-lifecycle
-description: Use this skill when you need to run the Myco skill lifecycle end-to-end: identifying skill candidates from vault knowledge, curating them through the approval workflow, generating SKILL.md files on disk, and evolving existing skills as the vault grows. Activate even if the user only asks about one phase — understanding the full chain prevents common sequencing mistakes. Applies to tasks named skill-survey, skill-generate, skill-evolve, and to any work on the Skills dashboard in the Daemon UI. Also relevant when candidates appear but no skills materialize, when the survey returns zero results, or when a generated skill needs to be refreshed.
+description: >-
+  Use this skill when running or debugging the Myco skill lifecycle end to end:
+  identifying candidates from vault knowledge, curating them through approval,
+  generating `SKILL.md` files, and evolving existing skills as the vault grows.
+  It applies to `skill-survey`, `skill-generate`, `skill-evolve`, and any work
+  on the Skills dashboard, including cases where candidates appear but no
+  skills materialize, surveys return zero results, or generated skills need
+  refreshes.
 managed_by: myco
 user-invocable: true
 allowed-tools:

--- a/.agents/skills/myco-symbiont-integration/SKILL.md
+++ b/.agents/skills/myco-symbiont-integration/SKILL.md
@@ -1,7 +1,13 @@
 ---
-name: myco:symbiont-integration
-description: |
-  Use this skill when adding a new agent/IDE symbiont to Myco, maintaining an existing one, or debugging capture pipeline issues — even if the user doesn't explicitly ask for "symbiont integration." Covers the full lifecycle: authoring the capture manifest (CaptureManifestSchema, planDirs, planTags, rules, agent identity), creating and wiring hook templates with --symbiont argv binding, implementing the TranscriptParser OO interface (StandardJsonlParser / CodexJsonlParser pattern, parseTurns polymorphism, multi-message assistant turns, plugin-boundary normalization), handling image/attachment format differences across agents (Codex input_image+image_url data URL vs Claude Code image+source.data raw base64), configuring declarative capture rules (scope, drop, extract_after, transcript_path_missing), integrating the cross-platform hook guard (.agents/myco-hook.cjs), registering the symbiont in SymbiontInstaller (install/update/remove/doctor), and maintaining installer test fixtures. Also covers debugging the capture pipeline: session identity (transcript_path as canonical durable key), the 3-layer phantom session defense (Zod null-guard, filter-before-wake ordering, complete drop filter), hook entry point bifurcation, env var injection rules, and transcript path parsing failures.
+name: myco:myco-symbiont-integration
+description: >-
+  Use this skill when adding or maintaining a Myco symbiont integration,
+  or debugging capture-pipeline and installer issues for a supported agent.
+  It covers manifests, hook templates, transcript parsing, image and
+  attachment format differences, declarative capture rules, the cross-platform
+  hook guard, SymbiontInstaller wiring, installer fixtures, session identity,
+  phantom-session defenses, environment-variable injection, and transcript
+  path parsing failures.
 managed_by: myco
 user-invocable: true
 allowed-tools: Read, Edit, Write, Bash, Grep, Glob

--- a/.agents/skills/setup-cloudflare-team-sync/SKILL.md
+++ b/.agents/skills/setup-cloudflare-team-sync/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: myco:setup-cloudflare-team-sync
-description: Use this skill when setting up Myco's team sync feature using Cloudflare Workers, D1, and Vectorize — or when debugging issues with an existing sync deployment. Activates for tasks involving myco team init, the Team page in the daemon UI, Cloudflare Worker deployment, wrangler CLI setup, machine identity, or cross-machine vault sync. Also applies when diagnosing team sync failures even if the user doesn't explicitly frame it as a Cloudflare problem — symptoms like pending count not draining, sync not working, record count shortfall, or embeddings not appearing on another machine all fall under this skill. Also covers the outbox implementation pattern: paired writes, the drain loop, Power Manager integration (runIn states, preventsDeepSleep), dead-letter handling, and adding new record types to team sync.
+description: >-
+  Use this skill when setting up or debugging Myco team sync on Cloudflare.
+  It applies to `myco team init`, the Team page in the daemon UI, Worker
+  deployment, Wrangler setup, machine identity, cross-machine vault sync, and
+  failure modes like pending outbox drains, missing remote records, or
+  embeddings not appearing on another machine. It also covers the outbox
+  pattern, paired writes, drain-loop behavior, PowerManager integration, and
+  adding new record types to sync.
 managed_by: myco
 user-invocable: true
 allowed-tools: Read, Edit, Write, Bash, Grep, Glob

--- a/packages/myco/src/agent/definitions/tasks/skill-generate.yaml
+++ b/packages/myco/src/agent/definitions/tasks/skill-generate.yaml
@@ -73,6 +73,13 @@ phases:
 
       - **user-invocable: true** — makes the skill available as a slash
         command (e.g., `/add-symbiont`). Set this for all procedural skills.
+      - **description formatting** — keep the description YAML-safe.
+        Prefer the block-scalar form shown above (`description: |` or
+        `description: >-`) instead of a long plain scalar, because colons
+        inside an unquoted single-line value can produce invalid YAML.
+      - **description length** — keep the fully rendered description at or
+        under 1024 characters. Longer descriptions are rejected by Codex and
+        other skill loaders even if the rest of the file is valid.
       - **allowed-tools** — comma-separated list of **Claude Code tool
         names** that the skill needs. These skills run in developer
         Claude Code sessions, NOT in the agent pipeline. NEVER use
@@ -156,6 +163,8 @@ phases:
          Generic advice ("add a config file") is not enough.
 
       4. **Length:** Under 800 lines?
+      4a. **Frontmatter validity:** Does the YAML frontmatter parse cleanly,
+          and is the rendered description still <= 1024 characters?
 
       5. **Domain scope:** Does this skill cover a procedural domain
          (multiple related procedures as sections) or just a single

--- a/packages/myco/src/agent/definitions/tasks/skill-survey.yaml
+++ b/packages/myco/src/agent/definitions/tasks/skill-survey.yaml
@@ -11,7 +11,7 @@ prompt: >-
 isDefault: false
 model: claude-sonnet-4-6
 maxTurns: 35
-timeoutSeconds: 600
+timeoutSeconds: 1800
 schedule:
   enabled: true
   intervalSeconds: 600

--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -147,6 +147,14 @@ function logToolResultBlocks(phaseName: string, message: unknown): void {
   }
 }
 
+function abortReasonMessage(abortController?: AbortController): string | null {
+  if (!abortController?.signal.aborted) return null;
+  const reason = abortController.signal.reason;
+  if (reason instanceof Error) return reason.message;
+  if (typeof reason === 'string' && reason.length > 0) return reason;
+  return 'Agent run aborted';
+}
+
 // ---------------------------------------------------------------------------
 // Prompt composition
 // ---------------------------------------------------------------------------
@@ -311,13 +319,14 @@ async function executePhase(
       summary: phaseSummary,
     };
   } catch (err) {
+    const abortReason = abortReasonMessage(abortController);
     return {
       name: phase.name,
       status: 'failed',
       turnsUsed: phaseTurns,
       tokensUsed: phaseTokens,
       costUsd: phaseCost,
-      summary: `Error: ${toErrorMessage(err)}`,
+      summary: abortReason ? `Error: ${abortReason}` : `Error: ${toErrorMessage(err)}`,
     };
   }
 }
@@ -678,7 +687,7 @@ export async function runAgent(
   const timeoutMs = config.timeoutSeconds * MS_PER_SECOND;
   const timeoutId = setTimeout(() => {
     console.warn(`[agent] Run ${runId} exceeded timeout (${config.timeoutSeconds}s), aborting`);
-    taskAbortController.abort();
+    taskAbortController.abort(new Error(`Agent run timed out after ${config.timeoutSeconds} seconds`));
   }, timeoutMs);
   timeoutId.unref?.();
 

--- a/packages/myco/src/agent/tools/skill-validator.ts
+++ b/packages/myco/src/agent/tools/skill-validator.ts
@@ -5,8 +5,16 @@
  * a skill is accepted.
  */
 
+import { parse as parseYaml } from 'yaml';
+
 /** Maximum lines for a generated skill. */
 export const MAX_SKILL_LINES = 800;
+
+/** Maximum description length accepted by Codex skill frontmatter. */
+export const MAX_SKILL_DESCRIPTION_CHARS = 1024;
+
+/** Frontmatter delimiters at the top of a SKILL.md file. */
+const FRONTMATTER_PATTERN = /^---\n([\s\S]*?)\n---/;
 
 /** Required frontmatter fields for Myco-managed skills. */
 export const REQUIRED_FRONTMATTER_FIELDS = ['name', 'description', 'managed_by', 'user-invocable', 'allowed-tools'] as const;
@@ -28,14 +36,50 @@ export const ALLOWED_CLAUDE_CODE_TOOLS: ReadonlySet<string> = new Set([
   'Task', 'TodoWrite',
 ]);
 
+type ParsedFrontmatter = Record<string, unknown>;
+
+function extractFrontmatterBlock(content: string): string | undefined {
+  return content.match(FRONTMATTER_PATTERN)?.[1];
+}
+
+function parseFrontmatter(content: string): ParsedFrontmatter | null {
+  const block = extractFrontmatterBlock(content);
+  if (!block) return null;
+  const parsed = parseYaml(block);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null;
+  }
+  return parsed as ParsedFrontmatter;
+}
+
+function normalizeFrontmatterValue(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'boolean' || typeof value === 'number') return String(value);
+  if (Array.isArray(value)) {
+    const items = value
+      .map((item) => (typeof item === 'string' ? item : null))
+      .filter((item): item is string => item !== null);
+    return items.length > 0 ? items.join(', ') : undefined;
+  }
+  return undefined;
+}
+
 /**
  * Extract a frontmatter field value from SKILL.md content.
  * Returns the raw value string, or undefined if not found.
  */
 export function extractFrontmatterField(content: string, field: string): string | undefined {
-  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!fmMatch) return undefined;
-  const fm = fmMatch[1];
+  try {
+    const parsed = parseFrontmatter(content);
+    const normalized = normalizeFrontmatterValue(parsed?.[field]);
+    if (normalized !== undefined) return normalized;
+  } catch {
+    // Fall back to the legacy line-based extraction so callers can still
+    // compare or repair malformed frontmatter already on disk.
+  }
+
+  const fm = extractFrontmatterBlock(content);
+  if (!fm) return undefined;
 
   // Single-line value: `field: value`
   const match = fm.match(new RegExp(`^${field}:\\s*(.+)$`, 'm'));
@@ -297,37 +341,60 @@ export function validateSkillContent(content: string, dirName: string): string[]
   const issues: string[] = [];
 
   // Check for frontmatter delimiters
-  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!fmMatch) {
+  const frontmatter = extractFrontmatterBlock(content);
+  if (!frontmatter) {
     issues.push('Missing YAML frontmatter (must start with --- and end with ---)');
     return issues; // Can't check fields without frontmatter
   }
 
-  const frontmatter = fmMatch[1];
+  let parsedFrontmatter: ParsedFrontmatter | null = null;
+  try {
+    parsedFrontmatter = parseFrontmatter(content);
+  } catch (error) {
+    const message = error instanceof Error ? error.message.split('\n')[0] : String(error);
+    issues.push(`Invalid YAML frontmatter: ${message}`);
+    return issues;
+  }
+  if (!parsedFrontmatter) {
+    issues.push('Invalid YAML frontmatter: top-level frontmatter must be a mapping/object');
+    return issues;
+  }
 
   // Check required fields
   for (const field of REQUIRED_FRONTMATTER_FIELDS) {
-    if (!frontmatter.includes(`${field}:`)) {
+    if (!(field in parsedFrontmatter)) {
       issues.push(`Missing required frontmatter field: ${field}`);
     }
   }
 
   // Check myco: prefix on name
-  const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
-  if (nameMatch && !nameMatch[1].trim().startsWith('myco:')) {
-    issues.push(`Skill name must start with "myco:" prefix. Got: "${nameMatch[1].trim()}"`);
+  const nameValue = normalizeFrontmatterValue(parsedFrontmatter.name);
+  if (nameValue && !nameValue.startsWith('myco:')) {
+    issues.push(`Skill name must start with "myco:" prefix. Got: "${nameValue}"`);
+  }
+  if (nameValue && nameValue !== `myco:${dirName}`) {
+    issues.push(`Skill name must match directory name. Expected "myco:${dirName}", got "${nameValue}"`);
   }
 
   // Check managed_by: myco
-  const managedMatch = frontmatter.match(/^managed_by:\s*(.+)$/m);
-  if (managedMatch && managedMatch[1].trim() !== 'myco') {
-    issues.push(`managed_by must be "myco". Got: "${managedMatch[1].trim()}"`);
+  const managedByValue = normalizeFrontmatterValue(parsedFrontmatter.managed_by);
+  if (managedByValue && managedByValue !== 'myco') {
+    issues.push(`managed_by must be "myco". Got: "${managedByValue}"`);
+  }
+
+  // Codex and other agents reject overly long descriptions.
+  const descriptionValue = normalizeFrontmatterValue(parsedFrontmatter.description);
+  if (descriptionValue && descriptionValue.length > MAX_SKILL_DESCRIPTION_CHARS) {
+    issues.push(
+      `description exceeds maximum length of ${MAX_SKILL_DESCRIPTION_CHARS} characters ` +
+      `(got ${descriptionValue.length})`,
+    );
   }
 
   // Check allowed-tools values -- must be Claude Code tool names, not vault agent tools.
   // These skills run in developer Claude Code sessions, not the agent pipeline.
   // Uses extractFrontmatterField to handle both inline and YAML block-list formats.
-  const rawAllowedTools = extractFrontmatterField(content, 'allowed-tools');
+  const rawAllowedTools = normalizeFrontmatterValue(parsedFrontmatter['allowed-tools']);
   if (rawAllowedTools) {
     const rawValue = rawAllowedTools;
     // Reject vault_* tool names first — most informative message for the

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -41,10 +41,10 @@ let capturedQueryArgs: { prompt: string; options?: Record<string, unknown> } | n
  * Per-call behaviors. Each query() call shifts the next behavior.
  * Falls back to mockQueryBehavior when exhausted.
  */
-let mockQueryBehaviors: Array<'success' | 'error' | 'empty'> = [];
+let mockQueryBehaviors: Array<'success' | 'error' | 'empty' | 'abort'> = [];
 
 /** Default behavior when mockQueryBehaviors is empty. */
-let mockQueryBehavior: 'success' | 'error' | 'empty' = 'success';
+let mockQueryBehavior: 'success' | 'error' | 'empty' | 'abort' = 'success';
 
 /** Custom error message for the 'error' behavior. */
 let mockErrorMessage = 'SDK exploded';
@@ -80,6 +80,14 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => {
         [Symbol.asyncIterator]: async function* () {
           if (behavior === 'error') {
             throw new Error(mockErrorMessage);
+          }
+
+          if (behavior === 'abort') {
+            const controller = args.options?.abortController;
+            if (controller instanceof AbortController) {
+              controller.abort(new Error('Agent run timed out after 1 seconds'));
+            }
+            throw new Error('Claude Code process aborted by user');
           }
 
           if (behavior === 'success') {
@@ -773,6 +781,23 @@ describe('runAgent — phased execution', () => {
     const run = getRun(result.runId);
     expect(run!.status).toBe('failed');
     expect(run!.error).toContain('extract');
+  });
+
+  it('surfaces timeout abort reasons instead of generic user-abort text', async () => {
+    mockYamlPhases = [
+      { name: 'explore', prompt: 'Explore.', tools: ['vault_state'], maxTurns: 3, required: true },
+    ];
+
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    mockQueryBehaviors = ['abort'];
+
+    const result = await runAgent(TEST_VAULT_DIR);
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toContain('Agent run timed out after 1 seconds');
+    expect(result.error).not.toContain('Claude Code process aborted by user');
+    expect(result.phases?.[0].summary).toContain('Agent run timed out after 1 seconds');
   });
 
   it('continues pipeline when an optional phase fails', async () => {

--- a/tests/agent/tools-skills.test.ts
+++ b/tests/agent/tools-skills.test.ts
@@ -20,6 +20,7 @@ import { insertCandidate, updateCandidate } from '@myco/db/queries/skill-candida
 import { insertSkillRecord } from '@myco/db/queries/skill-records.js';
 import { insertRun } from '@myco/db/queries/runs.js';
 import { createVaultTools } from '@myco/agent/tools.js';
+import { MAX_SKILL_DESCRIPTION_CHARS } from '@myco/agent/tools/skill-validator.js';
 import { CANDIDATE_STATUS } from '@myco/constants/skill-candidate-status.js';
 import type { SdkMcpToolDefinition } from '@anthropic-ai/claude-agent-sdk';
 
@@ -1088,6 +1089,82 @@ describe('vault skill tools', () => {
       const result = await stage(candidate.id, 'gate-approved');
       expect(result.error).toBeUndefined();
       expect(result.status).toBe('staged');
+    });
+
+    it('vault_stage_skill rejects malformed YAML frontmatter', async () => {
+      const candidateTool = findTool(tools, 'vault_skill_candidates');
+      const candidate = parseResult(
+        await candidateTool.handler(
+          { action: 'create', topic: 'Gate malformed yaml', rationale: 'r' },
+          undefined,
+        ),
+      ) as { id: string };
+      approveCandidate(candidate.id);
+
+      const stageTool = findTool(tools, 'vault_stage_skill');
+      const result = parseResult(
+        await stageTool.handler(
+          {
+            candidate_id: candidate.id,
+            name: 'gate-malformed-yaml',
+            display_name: 'Gate Malformed YAML',
+            description: 'Malformed YAML skill',
+            content:
+              '---\n' +
+              'name: myco:gate-malformed-yaml\n' +
+              'description: Use this skill for end-to-end delivery: planning, coding, verification\n' +
+              'managed_by: myco\n' +
+              'user-invocable: true\n' +
+              'allowed-tools: Read, Grep, Glob\n' +
+              '---\n\n# Broken',
+            rationale: 'gate test',
+          },
+          undefined,
+        ),
+      ) as { error?: string; issues?: string[] };
+
+      expect(result.error).toContain('validation failed');
+      expect(result.issues?.some((issue) => issue.includes('Invalid YAML frontmatter'))).toBe(true);
+    });
+
+    it('vault_stage_skill rejects descriptions over the compatibility limit', async () => {
+      const candidateTool = findTool(tools, 'vault_skill_candidates');
+      const candidate = parseResult(
+        await candidateTool.handler(
+          { action: 'create', topic: 'Gate long description', rationale: 'r' },
+          undefined,
+        ),
+      ) as { id: string };
+      approveCandidate(candidate.id);
+
+      const tooLongDescription = 'a'.repeat(MAX_SKILL_DESCRIPTION_CHARS + 1);
+      const stageTool = findTool(tools, 'vault_stage_skill');
+      const result = parseResult(
+        await stageTool.handler(
+          {
+            candidate_id: candidate.id,
+            name: 'gate-long-description',
+            display_name: 'Gate Long Description',
+            description: tooLongDescription,
+            content:
+              '---\n' +
+              'name: myco:gate-long-description\n' +
+              `description: ${tooLongDescription}\n` +
+              'managed_by: myco\n' +
+              'user-invocable: true\n' +
+              'allowed-tools: Read, Grep, Glob\n' +
+              '---\n\n# Too long',
+            rationale: 'gate test',
+          },
+          undefined,
+        ),
+      ) as { error?: string; issues?: string[] };
+
+      expect(result.error).toContain('validation failed');
+      expect(
+        result.issues?.some((issue) =>
+          issue.includes(`description exceeds maximum length of ${MAX_SKILL_DESCRIPTION_CHARS}`)),
+      ).toBe(true);
     });
 
     it('vault_write_skill rejects create path when candidate is not approved', async () => {

--- a/tests/smoke/review-fixes.test.ts
+++ b/tests/smoke/review-fixes.test.ts
@@ -18,6 +18,7 @@ import {
   topicOverlapSimilarity,
   DESCRIPTION_DUPLICATE_THRESHOLD,
   TOPIC_OVERLAP_THRESHOLD,
+  MAX_SKILL_DESCRIPTION_CHARS,
 } from '@myco/agent/tools/skill-validator.js';
 import { buildScheduledJobs, type ScheduledJobContext } from '@myco/daemon/task-scheduler.js';
 import { loadConfig } from '@myco/config/loader.js';
@@ -369,44 +370,73 @@ describe('validateSkillContent quality gate', () => {
 
   it('accepts valid skill content', () => {
     const content = '---\nname: myco:test-skill\ndescription: A test skill\nmanaged_by: myco\nuser-invocable: true\nallowed-tools: Read, Grep, Glob\n---\n\nBody content here.';
-    const issues = validateSkillContent(content, 'test');
+    const issues = validateSkillContent(content, 'test-skill');
     expect(issues).toHaveLength(0);
   });
 
   it('rejects vault agent tool names in allowed-tools (comma format)', () => {
     const content = '---\nname: myco:test-skill\ndescription: A test skill\nmanaged_by: myco\nuser-invocable: true\nallowed-tools: vault_search_fts, vault_spores\n---\n\nBody';
-    const issues = validateSkillContent(content, 'test');
+    const issues = validateSkillContent(content, 'test-skill');
     expect(issues.some(i => i.includes('vault agent tool names'))).toBe(true);
   });
 
   it('rejects vault agent tool names in allowed-tools (YAML list format)', () => {
     const content = '---\nname: myco:test-skill\ndescription: A test skill\nmanaged_by: myco\nuser-invocable: true\nallowed-tools:\n  - vault_search_fts\n  - vault_spores\n---\n\nBody';
-    const issues = validateSkillContent(content, 'test');
+    const issues = validateSkillContent(content, 'test-skill');
     expect(issues.some(i => i.includes('vault agent tool names'))).toBe(true);
   });
 
   it('rejects allowed-tools: [None] — the model confabulation that prompted this gate', () => {
     const content = '---\nname: myco:test-skill\ndescription: A test skill\nmanaged_by: myco\nuser-invocable: true\nallowed-tools: [None]\n---\n\nBody';
-    const issues = validateSkillContent(content, 'test');
+    const issues = validateSkillContent(content, 'test-skill');
     expect(issues.some(i => i.includes('malformed'))).toBe(true);
   });
 
   it('rejects allowed-tools: None (bare sentinel)', () => {
     const content = '---\nname: myco:test-skill\ndescription: A test skill\nmanaged_by: myco\nuser-invocable: true\nallowed-tools: None\n---\n\nBody';
-    const issues = validateSkillContent(content, 'test');
+    const issues = validateSkillContent(content, 'test-skill');
     expect(issues.some(i => i.includes('malformed'))).toBe(true);
   });
 
   it('rejects unknown tool names in allowed-tools', () => {
     const content = '---\nname: myco:test-skill\ndescription: A test skill\nmanaged_by: myco\nuser-invocable: true\nallowed-tools: Read, ReadFile, Shell\n---\n\nBody';
-    const issues = validateSkillContent(content, 'test');
+    const issues = validateSkillContent(content, 'test-skill');
     expect(issues.some(i => i.includes('unknown tool name'))).toBe(true);
   });
 
   it('accepts inline YAML list format with valid tools', () => {
     const content = '---\nname: myco:test-skill\ndescription: A test skill\nmanaged_by: myco\nuser-invocable: true\nallowed-tools: [Read, Edit, Write]\n---\n\nBody';
-    const issues = validateSkillContent(content, 'test');
+    const issues = validateSkillContent(content, 'test-skill');
     expect(issues).toHaveLength(0);
+  });
+
+  it('rejects malformed YAML frontmatter even when required field substrings are present', () => {
+    const content =
+      '---\n' +
+      'name: myco:test-skill\n' +
+      'description: Use this skill for end-to-end delivery: planning, coding, verification\n' +
+      'managed_by: myco\n' +
+      'user-invocable: true\n' +
+      'allowed-tools: Read, Grep, Glob\n' +
+      '---\n\nBody';
+    const issues = validateSkillContent(content, 'test-skill');
+    expect(issues.some((issue) => issue.includes('Invalid YAML frontmatter'))).toBe(true);
+  });
+
+  it('rejects descriptions that exceed the Codex-compatible length limit', () => {
+    const description = 'a'.repeat(MAX_SKILL_DESCRIPTION_CHARS + 1);
+    const content =
+      '---\n' +
+      'name: myco:test-skill\n' +
+      `description: ${description}\n` +
+      'managed_by: myco\n' +
+      'user-invocable: true\n' +
+      'allowed-tools: Read, Grep, Glob\n' +
+      '---\n\nBody';
+    const issues = validateSkillContent(content, 'test-skill');
+    expect(
+      issues.some((issue) => issue.includes(`description exceeds maximum length of ${MAX_SKILL_DESCRIPTION_CHARS}`)),
+    ).toBe(true);
   });
 });
 

--- a/tests/smoke/skill-files-validation.test.ts
+++ b/tests/smoke/skill-files-validation.test.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+import { MAX_SKILL_DESCRIPTION_CHARS } from '@myco/agent/tools/skill-validator.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const SKILLS_DIR = path.join(REPO_ROOT, '.agents', 'skills');
+const FRONTMATTER_PATTERN = /^---\n([\s\S]*?)\n---/;
+
+describe('checked-in .agents skills', () => {
+  it('have YAML-parseable frontmatter and Codex-compatible descriptions', () => {
+    const failures: string[] = [];
+
+    for (const skillName of fs.readdirSync(SKILLS_DIR)) {
+      const skillPath = path.join(SKILLS_DIR, skillName, 'SKILL.md');
+      if (!fs.existsSync(skillPath)) continue;
+
+      const content = fs.readFileSync(skillPath, 'utf8');
+      const frontmatter = content.match(FRONTMATTER_PATTERN)?.[1];
+      if (!frontmatter) {
+        failures.push(`${skillName}: missing frontmatter`);
+        continue;
+      }
+
+      try {
+        const parsed = parseYaml(frontmatter) as { description?: unknown } | null;
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          failures.push(`${skillName}: frontmatter did not parse to an object`);
+          continue;
+        }
+
+        const description = typeof parsed.description === 'string' ? parsed.description : '';
+        if (description.length > MAX_SKILL_DESCRIPTION_CHARS) {
+          failures.push(
+            `${skillName}: description is ${description.length} chars ` +
+            `(max ${MAX_SKILL_DESCRIPTION_CHARS})`,
+          );
+        }
+      } catch (error) {
+        failures.push(
+          `${skillName}: ${error instanceof Error ? error.message.split('\n')[0] : String(error)}`,
+        );
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
This hardens Myco's skill lifecycle against invalid generated `SKILL.md` files and fixes a misleading `skill-survey` phase failure mode.

## What Changed
- switched skill frontmatter validation to real YAML parsing instead of substring checks
- enforced a `1024` character compatibility ceiling for skill descriptions
- updated `skill-generate` guidance so generated frontmatter stays YAML-safe
- repaired the currently-invalid checked-in generated skills under `.agents/skills/`
- increased `skill-survey` timeout from `600s` to `1800s`
- propagated task timeout reasons into phased-run failures so they no longer surface as generic `process aborted by user`
- added regression coverage for validator behavior, write-path enforcement, executor timeout reporting, and a repo-level scan of checked-in skills

## Why
Codex exposed that several generated skills in this repo were structurally invalid even though Myco's own gate accepted them. Separately, a released `skill-survey` run showed `synthesize-evaluate` failing with `Claude Code process aborted by user` after an exact `10m 0s` duration, which pointed to the task-level timeout aborting the controller before phase 2 started.

## Verification
- `npx vitest run tests/smoke/review-fixes.test.ts tests/smoke/skill-files-validation.test.ts tests/agent/tools-skills.test.ts tests/agent/executor.test.ts`
- `make check`
- `make build`
- `myco-dev restart`