### PR TITLE
Improve notification UX and add focused Mycelium explorer

### DIFF
--- a/.agents/skills/cloudflare-worker-infrastructure-lifecycle/SKILL.md
+++ b/.agents/skills/cloudflare-worker-infrastructure-lifecycle/SKILL.md
@@ -1,0 +1,375 @@
+---
+name: myco:cloudflare-worker-infrastructure-lifecycle
+description: |
+  Use when deploying, upgrading, or operating any Cloudflare Worker-backed
+  service in Myco — the team-sync Worker, Cloud MCP Server, and Collective
+  Worker. Covers: initial Worker deployment with KV namespace provisioning
+  (idempotency pattern), Wrangler upgrade path engineering (5 documented
+  failure modes), MCP auth token lifecycle and rotation via Workers KV,
+  Collective Worker deployment with correct config scoping, and operational
+  safety patterns (cron validation, fanout timeouts, build script integrity,
+  UI package distribution). Activate this skill even if the user doesn't
+  explicitly mention Cloudflare — any task touching wrangler.toml, D1
+  bindings, Workers KV, or packages/myco-team or packages/myco-collective
+  falls in this domain. Supersedes the stale setup-cloudflare-team-sync skill.
+managed_by: myco
+user-invocable: true
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+# Cloudflare Worker Infrastructure Lifecycle
+
+Myco uses three Cloudflare Worker services: the **team-sync Worker** (cross-machine session sync via D1 + Vectorize), the **Cloud MCP Server** (remote tool access for non-local agents), and the **Collective Worker** (org-level knowledge aggregation). All three share the same Wrangler deployment model, Workers KV auth pattern, and D1 migration behavior. Mistakes in these areas are expensive — wrong KV provisioning hard-fails upgrades, wrong config scoping makes tokens invisible to other projects, and silent build failures deploy stale artifacts.
+
+## Prerequisites
+
+- Cloudflare account with Workers, D1, Vectorize, and KV enabled
+- `wrangler` CLI authenticated: `wrangler auth login`
+- Node.js accessible via absolute path (see Cross-Cutting Gotchas #9 for nvm/volta)
+- For Collective: admin token from the Collective operator, or generate one at first bootstrap
+- Account ID available in `wrangler.toml` or via `wrangler whoami`
+
+## Procedure A: Initial Worker Deployment and KV Provisioning
+
+### 1. Create or get a KV namespace (idempotency pattern)
+
+`wrangler kv namespace create` is **not idempotent** — a second call throws "already exists" and exits non-zero. Use this pattern wherever KV provisioning can run more than once:
+
+```typescript
+async function ensureKvNamespace(title: string): Promise<string> {
+  try {
+    const result = await runWrangler(['kv', 'namespace', 'create', title]);
+    const match = result.stdout.match(/"id":\s*"([^"]+)"/);
+    if (!match) throw new Error('Could not parse KV namespace ID from create output');
+    return match[1];
+  } catch (err: any) {
+    if (!err.stderr?.includes('already exists')) throw err;
+    // Namespace exists — list and match by title
+    const listResult = await runWrangler(['kv', 'namespace', 'list', '--json']);
+    const namespaces: Array<{ id: string; title: string }> = JSON.parse(listResult.stdout);
+    const ns = namespaces.find(n => n.title === title);
+    if (!ns) throw new Error(`KV namespace "${title}" not found after "already exists" error`);
+    return ns.id;
+  }
+}
+```
+
+Always capture both `stdout` **and** `stderr` from wrangler subprocesses — Wrangler writes progress and errors to stderr, so discarding it hides critical information.
+
+### 2. Bind KV namespace in wrangler.toml
+
+```toml
+[[kv_namespaces]]
+binding = "MCP_TOKENS"   # or AUTH_KV, COLLECTIVE_TOKENS, etc.
+id = "<namespace-id>"
+preview_id = "<preview-id>"  # optional for local dev
+```
+
+### 3. Provision D1 database
+
+```bash
+wrangler d1 create myco-team-db
+```
+
+```toml
+[[d1_databases]]
+binding = "DB"
+database_name = "myco-team-db"
+database_id = "<id-from-create-output>"
+```
+
+**D1 lazy migrations**: D1 migrations apply on the **first request after deploy**, not at deploy time. Do not assume the schema is ready immediately after `wrangler deploy`. Design for lazy `CREATE TABLE IF NOT EXISTS` or a health-check endpoint that triggers migration.
+
+### 4. Provision Vectorize collection (team-sync only)
+
+```bash
+wrangler vectorize create myco-embeddings --dimensions=1536 --metric=cosine
+```
+
+```toml
+[[vectorize]]
+binding = "VECTORIZE"
+index_name = "myco-embeddings"
+```
+
+### 5. Deploy
+
+```bash
+npm install       # always run before first deploy; also required after dep changes
+wrangler deploy
+```
+
+Add lifecycle markers to deployment scripts for log scannability:
+
+```
+[DEPLOY START] myco-team-sync
+...
+[DEPLOY COMPLETE] myco-team-sync
+```
+
+## Procedure B: Upgrading an Existing Worker
+
+Worker upgrades have five documented failure modes. Address all five before shipping any upgrade path.
+
+### Failure mode 1 — Wrangler stderr swallowed
+
+All subprocess output (stdout AND stderr) must be captured and surfaced. Use this helper:
+
+```typescript
+async function runWrangler(
+  args: string[],
+  opts: { cwd?: string } = {}
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('wrangler', args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      cwd: opts.cwd,
+    });
+    let stdout = '', stderr = '';
+    proc.stdout.on('data', (d: Buffer) => { stdout += d; process.stdout.write(d); });
+    proc.stderr.on('data', (d: Buffer) => { stderr += d; process.stderr.write(d); });
+    proc.on('close', code => {
+      if (code === 0) resolve({ stdout, stderr });
+      else reject(Object.assign(new Error(`wrangler exited ${code}`), { stdout, stderr }));
+    });
+  });
+}
+```
+
+Wrap the full upgrade sequence with `[UPGRADE START]` / `[UPGRADE COMPLETE]` / `[UPGRADE FAILED]` markers.
+
+### Failure mode 2 — KV namespace create non-idempotent
+
+Covered in Procedure A. Always use `ensureKvNamespace()` — never bare `wrangler kv namespace create` in upgrade paths.
+
+### Failure mode 3 — `fs.cpSync` overwrites wrangler.toml
+
+Copying fresh worker source over an existing directory with `fs.cpSync` will overwrite `wrangler.toml`, losing `compatibility_flags`, KV bindings, D1 bindings, and any post-deploy edits.
+
+Fix — read → parse → merge → write:
+
+```typescript
+import * as TOML from '@iarna/toml';
+
+function mergeWranglerToml(sourcePath: string, targetPath: string) {
+  const source = TOML.parse(fs.readFileSync(sourcePath, 'utf8')) as any;
+  const target = TOML.parse(fs.readFileSync(targetPath, 'utf8')) as any;
+  // Take runtime bindings and flags from target; code-level fields from source
+  const merged = {
+    ...source,
+    ...target,
+    kv_namespaces: target.kv_namespaces ?? source.kv_namespaces,
+    d1_databases:  target.d1_databases  ?? source.d1_databases,
+    vectorize:     target.vectorize     ?? source.vectorize,
+    compatibility_flags: target.compatibility_flags ?? source.compatibility_flags,
+    compatibility_date:  target.compatibility_date  ?? source.compatibility_date,
+  };
+  fs.writeFileSync(targetPath, TOML.stringify(merged));
+}
+```
+
+Never use `fs.cpSync` on any directory containing `wrangler.toml`. Copy individual source files or explicitly exclude `wrangler.toml`.
+
+### Failure mode 4 — Token/config values absent post-upgrade
+
+Any value not explicitly threaded to the upgrade template renderer will vanish from the rendered output. Enumerate every value your template uses and verify each is gathered before rendering.
+
+Cloud MCP upgrade checklist:
+- `mcpToken` — read from existing KV or generate new
+- Worker endpoint URL / `workerId`
+- `accountId`
+- D1 database ID
+- `compatibility_flags`
+
+### Failure mode 5 — Missing `ensureKvNamespace()` + `npm install` steps
+
+Upgrade paths that skip `npm install` will fail silently if worker dependencies changed. Always include both:
+
+```typescript
+await runCommand('npm', ['install'], { cwd: workerDir });
+const kvId = await ensureKvNamespace('myco-mcp-tokens');
+// update wrangler.toml with kvId via mergeWranglerToml
+await runWrangler(['deploy'], { cwd: workerDir });
+```
+
+## Procedure C: Auth Token Lifecycle and Rotation
+
+### MCP token storage
+
+MCP auth tokens live in a **Workers KV namespace**. Do NOT store them in:
+
+- D1 `team_config` — eviction and migration timing make it unreliable for hot-path auth
+- AES-256-GCM encrypted blobs — adds key-management complexity with no security benefit for server-side tokens
+
+Write:
+```typescript
+await env.MCP_TOKENS.put('mcp-auth-token', token); // no TTL = permanent
+```
+
+Auth middleware read:
+```typescript
+const stored = await env.MCP_TOKENS.get('mcp-auth-token');
+if (!stored || stored !== bearerToken) {
+  return new Response('Unauthorized', { status: 401 });
+}
+```
+
+### Token rotation
+
+Rotation happens via the `/connect` endpoint (POST with new token). The endpoint:
+1. Validates the caller's current token
+2. Writes the new token to KV
+3. Returns the new token to the caller
+4. Propagates the new token to connected team workers
+
+After rotation, update `.myco/team/config.json` with the new token so the local daemon reconnects.
+
+### Collective admin token
+
+Generated once at `myco collective create`, stored in `~/.myco-collective/<name>/config.json`. If missing or rotated, connected team workers will fail to authenticate against the Collective. Rotate with:
+
+```bash
+myco collective create --regenerate-token
+```
+
+This re-writes the home-scoped config and propagates the new token to connected workers.
+
+## Procedure D: Collective Worker Deployment and Config Scoping
+
+### Monorepo structure
+
+```
+packages/
+  myco/               # core daemon + CLI
+  myco-team/          # team-sync Worker
+  myco-collective/    # Collective Worker
+    src/
+      worker.ts       # Cloudflare Worker entry
+      fanout.ts       # project heartbeat fanout
+    dist/
+      ui/             # pre-built UI assets — ship this, NOT src/ui/
+    wrangler.toml
+```
+
+### Bootstrap (first deploy)
+
+`myco collective create` is a **CLI-only bootstrap** operation — same pattern as `myco init`. It:
+
+1. Generates admin token
+2. Runs `ensureKvNamespace('myco-collective-tokens')`
+3. Provisions D1 database
+4. Writes config to `~/.myco-collective/<name>/config.json` (home-scoped)
+5. Runs `npm install && wrangler deploy`
+
+**Config scoping rule**: Collective operator config MUST be home-scoped (`~/.myco-collective/<name>/config.json`), not project-scoped. The Collective serves multiple projects — storing its config under any one project's `.myco/` makes it invisible to every other project on the machine. Team operator config stays project-scoped (`.myco/team/config.json`) because it belongs to that project.
+
+### Cron heartbeat — MUST be in wrangler.toml
+
+Omitting the `[triggers]` block silently disables the scheduled job in production while appearing healthy in local dev (`wrangler dev --scheduled` simulates it regardless):
+
+```toml
+[triggers]
+crons = ["*/5 * * * *"]
+```
+
+**Verify this block exists before every deploy.** A missing cron block produces no deploy-time error — the worker deploys successfully but the heartbeat never fires.
+
+### UI package distribution
+
+Ship only pre-built `dist/ui/` assets in the `myco-collective` npm package. Shipping `src/ui/` causes a 126 MB dev-dependency pull on global install and `--ignore-scripts` CI deployment failures (Vite builds as a postinstall script).
+
+In `ensureUiBuild()`, short-circuit if pre-built assets exist:
+
+```typescript
+async function ensureUiBuild(workerDir: string) {
+  const prebuilt = path.join(workerDir, 'dist', 'ui', 'index.html');
+  if (fs.existsSync(prebuilt)) return; // pre-built assets present, skip build
+  // ... run vite build ...
+}
+```
+
+Add `src/ui/` to `.npmignore` and ensure `dist/ui/` is NOT in `.gitignore`.
+
+## Procedure E: Operational Safety Patterns
+
+### Fanout timeout
+
+`fanout.ts` makes outbound HTTP requests to each connected project worker. Without a per-project timeout, one hung project stalls the entire batch:
+
+```typescript
+const FANOUT_TIMEOUT_MS = 5_000;
+
+async function pingProject(url: string): Promise<void> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FANOUT_TIMEOUT_MS);
+  try {
+    await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Fan out in parallel — one failure must not block others
+await Promise.allSettled(projectUrls.map(pingProject));
+```
+
+Use `Promise.allSettled`, not `Promise.all`.
+
+### Build script integrity — remove `|| true`
+
+`|| true` in build scripts swallows non-zero exit codes, deploying stale artifacts silently:
+
+```json
+// BAD — stale UI deploys on build failure:
+"build": "vite build || true && wrangler deploy"
+
+// GOOD — build failure aborts deploy:
+"build": "vite build && wrangler deploy"
+```
+
+Audit all `package.json` scripts in `packages/myco-collective/` for `|| true` on build-critical commands and remove them.
+
+### Node binary PATH in nested spawns
+
+When a Myco daemon spawns a child that itself spawns `node` as a bare binary, the child shell may not inherit the user's PATH (especially under nvm or volta). The error is `env: node: No such file or directory`.
+
+Fix — resolve from the running process:
+
+```typescript
+const nodeBin = process.execPath; // absolute path to the active Node binary
+spawn(nodeBin, ['script.js'], { ... });
+
+// Or inject the node directory into PATH:
+spawn('node', ['script.js'], {
+  env: {
+    ...process.env,
+    PATH: `${path.dirname(process.execPath)}:${process.env.PATH ?? ''}`,
+  },
+});
+```
+
+### Verify compatibility_flags after any wrangler.toml merge
+
+Workers using Node.js built-ins require:
+
+```toml
+compatibility_flags = ["nodejs_compat"]
+compatibility_date = "2024-01-01"
+```
+
+A missing flag causes runtime errors on the first request, not at deploy time. Always verify this block is present after any merge or template render.
+
+## Cross-Cutting Gotchas
+
+| # | Gotcha | Fix |
+|---|--------|-----|
+| 1 | `wrangler kv namespace create` non-idempotent — fails on second run | Use `ensureKvNamespace()` with list-and-match fallback |
+| 2 | D1 migrations run on first request, not at deploy time | Design for lazy migration; don't assume schema is ready immediately post-deploy |
+| 3 | `fs.cpSync` overwrites `wrangler.toml`, losing bindings | Read-parse-merge-write pattern; never cpSync directories containing wrangler.toml |
+| 4 | Cron `[triggers]` block omitted → silent heartbeat disable | Verify triggers block before every Collective deploy |
+| 5 | `\|\| true` in build scripts → stale artifact deploys without error | Audit and remove from all build-critical scripts |
+| 6 | Wrangler subprocess stderr discarded → errors invisible | Capture both stdout and stderr; re-emit during deployment |
+| 7 | Collective config stored under `.myco/` → invisible to other projects | Use home-scoped `~/.myco-collective/<name>/config.json` |
+| 8 | Token not threaded through upgrade template renderer → absent post-upgrade | Enumerate all tokens in upgrade checklist; pass each explicitly |
+| 9 | `node` bare binary fails in nested spawns under nvm/volta | Use `process.execPath` or inject node's bin directory into PATH |
+| 10 | Shipping `src/ui/` in npm package → 126 MB install + CI failure | Ship only `dist/ui/`; short-circuit `ensureUiBuild()` on pre-built assets |

--- a/.agents/skills/daemon-settings-form-patterns/SKILL.md
+++ b/.agents/skills/daemon-settings-form-patterns/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: myco:daemon-settings-form-patterns
+description: |
+  Use when adding a new config toggle that mutates files beyond myco.yaml
+  (e.g., .gitignore writes, AGENTS.md managed blocks), or when building a
+  compound provider+model dropdown field in daemon settings UI. Covers two
+  patterns not in daemon-ui-development: (1) the 3-step config toggle
+  side-effects architecture — boolean flag in myco.yaml → managed block in
+  the target file → in-process registerSymbionts() reconciliation on save;
+  (2) the ProviderModelSelector compound enum pattern for paired
+  provider+model dropdowns where the provider selection resets and filters
+  the model list. Also covers .gitignore scope boundaries for file-mutation
+  toggles. For core form lifecycle triad (toFormState/builder/dirty-check),
+  SectionSaveRow, useCallback dep completeness, and Playwright smoke test
+  structure, see the daemon-ui-development skill.
+managed_by: myco
+user-invocable: true
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+# Daemon Settings Form Patterns: Toggle Side-Effects and Compound Fields
+
+This skill covers two advanced patterns for daemon settings UI that are **not** in `daemon-ui-development`:
+
+1. **Config toggle side-effects architecture** — when a settings boolean must write to files beyond `myco.yaml` (`.gitignore`, `AGENTS.md`, etc.)
+2. **ProviderModelSelector compound enum pattern** — paired provider+model dropdowns where parent selection drives child filtering and reset
+
+For foundational patterns — form lifecycle triad, `SectionSaveRow`, `useCallback` dep completeness, and Playwright smoke tests — see the **`daemon-ui-development`** skill first.
+
+## Prerequisites
+
+- Read `daemon-ui-development` for the base form lifecycle triad before adding any new settings section
+- Know the `myco.yaml` config schema for the feature area you're working on
+- Daemon UI source: `packages/daemon/src/ui/`
+- Config schema: `src/config/schema.ts`
+- Config save handler: `src/daemon/routes/config.ts` (or equivalent)
+- ESLint `react-hooks/exhaustive-deps` must be enabled and treated as an error
+
+---
+
+## Procedure 1: Config Toggle Side-Effects Architecture
+
+Use this procedure whenever a settings toggle must mutate files beyond `myco.yaml` — for example, writing entries to `.gitignore`, inserting a managed block into `AGENTS.md`, or managing an `.env` template.
+
+The pattern has exactly **3 steps**. Do not skip any step.
+
+### Step 1 — Single Boolean Flag in myco.yaml
+
+Add a single opt-in boolean to the `myco.yaml` config schema. Do **not** add a separate list field to track which paths were mutated — that creates redundancy with the file content itself.
+
+```typescript
+// src/config/schema.ts — add one boolean field:
+captureIgnorePlanDirsInGit: z.boolean().optional().default(false),
+```
+
+**Wrong** — separate list creates redundancy:
+```typescript
+captureIgnorePlanDirsInGit: z.boolean().optional().default(false),
+ignoredPlanDirs: z.array(z.string()).optional(),  // ← DO NOT add; redundant
+```
+
+The flag's presence in `myco.yaml` is the source of truth. The file content (managed block) is the derived artifact.
+
+### Step 2 — Managed Block in the Target File
+
+The target file gets a static fenced managed block. The daemon reads and rewrites this block on every reconciliation.
+
+**For `.gitignore`:**
+```
+# myco:managed:start
+plans/
+.myco/
+# myco:managed:end
+```
+
+**For `AGENTS.md` (HTML comment fences):**
+```markdown
+<!-- myco:managed:start -->
+## Myco Agent Rules
+
+...generated content...
+<!-- myco:managed:end -->
+```
+
+**Lifecycle:**
+- `myco init` inserts the block on first installation
+- Config save and `myco update` both reconcile the block contents — adding entries when the toggle is enabled, clearing or removing the block when disabled
+
+**Implement reconciliation as an idempotent pure function:**
+```typescript
+// src/config/reconcile.ts
+export function reconcileGitignoreBlock(
+  fileContent: string,
+  entries: string[],
+  enabled: boolean
+): string {
+  // 1. Strip any existing managed block
+  const stripped = stripManagedBlock(fileContent, '# myco:managed');
+  if (!enabled || entries.length === 0) return stripped;
+  // 2. Append current block
+  return stripped + formatManagedBlock('# myco:managed', entries);
+}
+```
+
+Idempotency requirement: running reconciliation twice must produce the same result as running it once. Always strip before re-inserting.
+
+### Step 3 — In-Process Reconciliation Trigger
+
+When the user saves the config toggle in the UI, trigger reconciliation via a direct in-process call from the API route handler. Do **not** spawn `myco update` as a subprocess.
+
+```typescript
+// src/daemon/routes/config.ts (or equivalent):
+async function handleConfigSave(req: Request) {
+  const newConfig = parseConfigFromRequest(req);
+  await updateConfig(newConfig);          // writes myco.yaml
+  await registerSymbionts(newConfig);     // in-process: reconciles .gitignore, AGENTS.md, etc.
+  return json({ ok: true });
+}
+```
+
+**Why in-process, not subprocess:**
+- Immediate effect — file mutations complete before the API response returns
+- The reconciliation function is unit-testable: pass file content in, assert the output string
+- A subprocess (`myco update`) would re-read config from disk, execute asynchronously, and return before the file write completes — Playwright assertions against the file state would be racy
+
+**Gotcha — subprocess timing:** If you spawn `myco update` instead, the `.gitignore` write happens after the API response. Playwright's `waitForRequest` resolves but the file hasn't been written yet. The test appears to pass but the file state is wrong.
+
+---
+
+## Procedure 2: .gitignore Scope Boundaries for File-Mutation Toggles
+
+`.gitignore` is repository-scoped. Only project-relative custom paths belong in the managed block. Apply this filter before computing what to write.
+
+| Path type | Include in managed block? | Reason |
+|-----------|--------------------------|--------|
+| `plans/` (project-relative) | ✅ Yes | Repo-scoped, correct |
+| `local/plans` (project-relative) | ✅ Yes | Repo-scoped, correct |
+| `/tmp/plans` (absolute) | ❌ No | Not repo-relative |
+| `~/plans` (home-relative) | ❌ No | Not repo-relative |
+| Symbiont manifest `planDirs` | ❌ No | Agent-owned; different ownership model |
+
+**Implementation — filter at write time, not read time:**
+
+```typescript
+// src/config/gitignore-entries.ts
+export function getGitignoreEntries(config: MycoConfig): string[] {
+  const customDirs = config.capture?.customPlanDirs ?? [];
+  return customDirs.filter(isProjectRelativePath);
+}
+
+function isProjectRelativePath(p: string): boolean {
+  return !path.isAbsolute(p) && !p.startsWith('~');
+}
+```
+
+Filter at write time so that if a path becomes non-relative between saves, it is automatically excluded from the next write — stale entries are not left in the block.
+
+**Gotcha — symbiont planDirs are agent-owned:** Symbiont manifest `planDirs` entries describe where an agent captures plans. They belong to the symbiont definition and are not user-configurable custom paths. Including them in `.gitignore` would silently affect agent capture without user intent. Query them separately if needed; never merge them into the user's custom plan dirs list.
+
+---
+
+## Procedure 3: ProviderModelSelector Compound Enum Pattern
+
+Use when a settings section requires the user to select a **provider** and then a **model** scoped to that provider. The provider is the parent field; the model is the child field. Changing the provider must reset the model to a valid default for the new provider.
+
+### Component Structure
+
+```tsx
+// packages/daemon/src/ui/components/ProviderModelSelector.tsx
+interface ProviderModelSelectorProps {
+  providers: Provider[];
+  selectedProvider: string;
+  selectedModel: string;
+  onProviderChange: (provider: string) => void;
+  onModelChange: (model: string) => void;
+  disabled?: boolean;
+}
+
+export function ProviderModelSelector({
+  providers,
+  selectedProvider,
+  selectedModel,
+  onProviderChange,
+  onModelChange,
+  disabled = false,
+}: ProviderModelSelectorProps) {
+  const availableModels = useMemo(
+    () => providers.find(p => p.id === selectedProvider)?.models ?? [],
+    [providers, selectedProvider]
+  );
+
+  return (
+    <div className="provider-model-selector">
+      <select
+        value={selectedProvider}
+        onChange={e => onProviderChange(e.target.value)}
+        disabled={disabled}
+      >
+        {providers.map(p => (
+          <option key={p.id} value={p.id}>{p.label}</option>
+        ))}
+      </select>
+
+      <select
+        value={selectedModel}
+        onChange={e => onModelChange(e.target.value)}
+        disabled={disabled || availableModels.length === 0}
+      >
+        {availableModels.map(m => (
+          <option key={m.id} value={m.id}>{m.label}</option>
+        ))}
+      </select>
+    </div>
+  );
+}
+```
+
+### Parent-Drives-Child-Reset
+
+When the provider changes, reset the model to the first available model for the new provider. Do this in the **parent's** `onProviderChange` handler — not inside `ProviderModelSelector` itself.
+
+```typescript
+// In the settings card that hosts ProviderModelSelector:
+function handleProviderChange(newProvider: string) {
+  const firstModel =
+    providers.find(p => p.id === newProvider)?.models[0]?.id ?? '';
+  // Atomic update — provider and model change together:
+  setForm(f => ({ ...f, provider: newProvider, model: firstModel }));
+}
+```
+
+**Why in the parent:** `ProviderModelSelector` is a controlled component with no knowledge of which model values are valid per provider. The parent holds the form state and must reset both fields atomically.
+
+**Gotcha — reset in child causes flash:** If you reset the model inside the component's `onChange`, the model resets before React re-renders with the new provider. This produces a brief render where `selectedModel` is no longer in `availableModels` — visible as a flash of blank selection or console warnings about uncontrolled inputs.
+
+### Dirty-Check with Compound Fields
+
+When computing the `dirty` flag for a section containing `ProviderModelSelector`, include **both** fields:
+
+```typescript
+const dirty =
+  form.provider !== saved.provider ||
+  form.model !== saved.model;
+```
+
+Do not check `form.provider` alone — the user may change the model while keeping the same provider.
+
+### useCallback Deps for Compound Save Handlers
+
+When the save handler reads both `form.provider` and `form.model`, both must appear in the `useCallback` dep array. Prefer collecting all form state into a single `form` object and using `builder(form)` to avoid omission:
+
+```typescript
+// Preferred — single form object eliminates per-field dep tracking:
+const handleSave = useCallback(async () => {
+  const patch = builder(form);   // reads all fields from one object
+  await updateConfig(patch);
+}, [form]);                       // one dep covers all fields
+```
+
+---
+
+## Related Skills
+
+| Skill | What it covers |
+|-------|---------------|
+| **daemon-ui-development** | Form lifecycle triad (toFormState/builder/dirty-check), SectionSaveRow, useCallback dep completeness, Playwright smoke test structure, design tokens, layout |
+| **safe-config-updates** | Server-side YAML write path safety — `updateConfig()` invariant, `formToConfig()` spread order |
+
+## Cross-Cutting Gotchas
+
+- **In-process vs subprocess:** always call `registerSymbionts()` directly from the API handler; a subprocess delays the effect and breaks Playwright file-state assertions
+- **Managed block idempotency:** always strip the existing block before re-inserting; running reconciliation twice must produce identical output
+- **Filter paths at write time:** compute `getGitignoreEntries()` fresh on each save so stale or newly-invalid paths are not persisted to the block
+- **Symbiont planDirs are agent-owned:** never merge symbiont manifest `planDirs` into user custom plan dir lists; they represent different ownership models
+- **Compound field reset is atomic:** changing provider and resetting model must happen in a single `setState` call to avoid invalid transient states

--- a/.agents/skills/daemon-ui-development/SKILL.md
+++ b/.agents/skills/daemon-ui-development/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: myco:daemon-ui-development
+description: |
+  Use when building, extending, or reviewing any page or component in the
+  Myco daemon web UI or Collective UI — even if the user doesn't explicitly
+  ask about design compliance or testing. Covers: design system token
+  integration (sage/ochre/terracotta CSS custom properties, three-font
+  hierarchy, tonal layering), app shell grammar and master-detail layout
+  enforcement, canary signal detection and design drift recovery, React
+  component patterns (useCallback dep completeness, SectionSaveRow,
+  toFormState/dirty-check/builder pattern), configuration page architecture
+  separation (dashboard=status summary vs. dedicated config page), Playwright
+  smoke test authoring for config UI forms, and new page registration.
+  Activates whenever creating a new daemon UI page, reviewing components for
+  visual compliance, writing Playwright tests for config forms, or debugging
+  stale-closure bugs in React hooks.
+managed_by: myco
+user-invocable: true
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+# Daemon UI Development
+
+The Myco daemon UI has a deliberate design language — a specific color palette, layout grammar, and component vocabulary. Deviating from it is the single most common source of rework in new UI surfaces. Two full rounds of rework on the Collective UI confirm this is a recurring risk, not a one-time mistake.
+
+Apply these procedures whenever touching daemon or Collective UI code.
+
+## Prerequisites
+
+- Locate the daemon UI source: `packages/daemon/src/ui/` (or equivalent)
+- Locate the Collective UI source: `packages/collective-ui/`
+- Have a browser open for screenshot review before merging any visual changes
+- Confirm ESLint is running with `react-hooks/exhaustive-deps` enabled and treated as an error
+
+## Procedure 1: Design System Token Integration
+
+The daemon uses CSS custom properties for color, typography, and spacing. Never introduce custom color values — even one hardcoded hex breaks visual consistency across the surface.
+
+**Palette tokens** (set at the daemon shell level):
+```css
+--color-sage         /* primary structural green */
+--color-ochre        /* accent / highlight */
+--color-terracotta   /* warning / action */
+--color-charcoal     /* text and structure */
+```
+
+**Typography hierarchy** — three fonts, each with a distinct role:
+- Display/heading font: large structural labels
+- Body font: content and descriptions
+- Mono font: code, IDs, config values
+
+**Tonal layering**: backgrounds use tonal steps of `--color-sage` or charcoal-based neutrals — not flat white or arbitrary grays.
+
+**Before writing any CSS in a new component:**
+1. Read the daemon shell's main CSS file to inventory all current custom properties
+2. Search for hardcoded values in your new file: `grep -rn "#[0-9a-fA-F]\{3,6\}\|rgb(" src/your-surface/`
+3. If a color isn't available as a daemon token, do not invent a new variable — decide whether the token belongs in the design system
+
+Warm neutrals (`#brown`, beige tones, warm hex values) are the primary canary signal for design drift. See Procedure 3.
+
+## Procedure 2: App Shell Grammar and Master-Detail Layout
+
+Daemon UI pages follow a **master-detail layout**: a list/overview panel on the left, a detail/inspector panel on the right. Full-width cards or centered-column editorial layouts are incorrect for daemon pages.
+
+**App shell components — extract, do not rebuild:**
+- **Nav rail**: solid structural rail, left-anchored, no rounded "bubble" borders on nav items
+- **Sidebar**: same structural treatment as the nav rail
+- **Page shell wrapper**: consistent padding, title placement, content area
+
+Do not rebuild the chrome from scratch when creating a new UI surface. Extract the daemon's shell primitives and compose your page inside them. Both times the Collective UI was rebuilt from scratch, the result required full visual rework because the structural language diverged.
+
+**How to extract and reuse:**
+1. Read the daemon's main layout component to identify shell primitives
+2. Import those primitives into the new surface
+3. Compose your page content inside the shell — do not recreate structural HTML
+
+**Master-detail pattern:**
+```
+┌──────────────────────┬───────────────────────────┐
+│  Left: list/overview │  Right: detail/inspector   │
+└──────────────────────┴───────────────────────────┘
+```
+If your page renders a single centered column of cards, stop and re-evaluate the layout.
+
+## Procedure 3: Canary Signal Detection and Design Drift Recovery
+
+Design drift is detectable early via three canary signals. When any signal appears, **stop and audit before writing more code**.
+
+**The three canary signals:**
+
+| Signal | Correct | Wrong |
+|--------|---------|-------|
+| Color palette | Sage, ochre, terracotta, charcoal | Brown, warm neutrals, arbitrary hex values |
+| Navigation elements | Solid structural rail | Bubble-bordered or rounded nav pills |
+| Base font size | Daemon density scale (tighter) | Large editorial scale |
+
+**Detection — run both checks:**
+```bash
+# Should only see daemon tokens
+grep -rn "var(--" src/your-surface/
+
+# Should return nothing
+grep -rn "#[0-9a-fA-F]\{3,6\}" src/your-surface/
+```
+Screenshot the live page and visually scan all three signals.
+
+**Recovery procedure** (apply in order):
+
+1. **List custom CSS variables** defined in the new surface's CSS files — any `--custom-var` not sourced from the daemon shell
+2. **Replace each** with the daemon token equivalent (warm neutral → `--color-charcoal`, green → `--color-sage`, etc.)
+3. **Identify rebuilt structural chrome** — find nav, sidebar, or shell HTML built from scratch in the new surface
+4. **Replace** with extracted daemon shell components (see Procedure 2)
+5. **Verify master-detail layout** — confirm the page uses the two-panel pattern, not a centered column
+6. **Re-run detection** — grep + screenshot
+7. **Screenshot review before merging** — do not merge without a visual comparison against the daemon design language
+
+## Procedure 4: React Component Patterns
+
+### useCallback dep completeness
+
+Every `useCallback` and `useEffect` must list all captured state and prop variables in the dependency array. A missing dep causes stale-closure bugs where the callback holds an outdated value at call time.
+
+```typescript
+// WRONG — ignoreInGit is captured from state but not listed
+const handleSave = useCallback(async () => {
+  await saveConfig({ ignoreInGit });
+}, []);  // ← stale closure: ignoreInGit is always the initial value
+
+// CORRECT
+const handleSave = useCallback(async () => {
+  await saveConfig({ ignoreInGit });
+}, [ignoreInGit]);  // ← dep listed; callback refreshes when value changes
+```
+
+ESLint's `react-hooks/exhaustive-deps` rule catches this automatically. Never disable it to silence a warning — fix the dependency array instead. This class of bug is invisible in unit tests but caught by Playwright (the API call posts the stale value).
+
+### SectionSaveRow pattern
+
+Config forms use per-section save, not a single form-wide submit. Each editable section ends with a `<SectionSaveRow>` that shows Save/Cancel only when the section has unsaved changes.
+
+```tsx
+<SectionSaveRow
+  dirty={dirty}
+  onSave={handleSave}
+  onCancel={handleCancel}
+/>
+```
+
+The `dirty` flag compares current form state to the last-saved value, not to the initially loaded value. This allows the user to reset to the last save without reloading the page.
+
+### toFormState / dirty-check / builder pattern
+
+Config pages follow a three-function pattern for state management:
+
+```typescript
+// 1. Load config → form state
+function toFormState(config: MyConfig): FormState { ... }
+
+// 2. Compute dirty flag
+const dirty = !isEqual(formState, toFormState(savedConfig));
+
+// 3. Build updated config for save — spread original FIRST, overlay form values
+function formToConfig(original: MyConfig, form: FormState): MyConfig {
+  return { ...original, ...form };
+}
+```
+
+**Critical**: `formToConfig` must spread `original` before overlaying `form`. This preserves config fields not present in the form (server-managed fields, future fields the form doesn't know about). Reversing the order silently drops those fields from every save.
+
+## Procedure 5: Configuration Page Architecture
+
+### Dashboard page = status summary only
+
+The dashboard page shows status and quick-glance information. It is not the configuration authority for complex features.
+
+```
+Dashboard widget:
+  ✓ Status indicator (enabled/disabled, connected/disconnected)
+  ✓ Key metric or last-updated time
+  ✓ "Configure →" link to dedicated page
+  ✗ Multi-step setup forms
+  ✗ Agent-specific instructions
+  ✗ Token input fields
+```
+
+### Dedicated config page
+
+A feature deserves its own dedicated route (e.g., `/mcp-settings`) when it has:
+- Multi-step setup (generate token → copy to agent → verify)
+- Agent-specific instructions that vary by configuration
+- Multiple independent config sections
+
+**Registering a new dedicated page:**
+1. Add a route entry in the daemon UI router config
+2. Add a nav link in the appropriate nav section
+3. Create the page component: `src/ui/pages/MyFeaturePage.tsx`
+4. Apply master-detail layout (Procedure 2)
+5. Use `SectionSaveRow` per editable section (Procedure 4)
+
+### Token/secret reveal state consistency
+
+When a page shows multiple sensitive fields (API tokens, secrets), all fields must share a single reveal/hide state — one `showTokens` boolean, not one state variable per field.
+
+```typescript
+// CORRECT — single toggle controls all fields
+const [showTokens, setShowTokens] = useState(false);
+
+// WRONG — divergent state; fields get out of sync
+const [showToken1, setShowToken1] = useState(false);
+const [showToken2, setShowToken2] = useState(false);
+```
+
+## Procedure 6: Playwright Smoke Test Authoring for Config UI
+
+Every config UI form should have a Playwright smoke test that verifies the form doesn't silently discard or corrupt values.
+
+### What to test
+
+1. **Toggle state round-trip**: enable a toggle → save → reload → toggle is still enabled
+2. **API POST with correct value**: intercept the save request and assert the payload contains the current form value (not a stale/default value — this is the `useCallback` dep bug in production)
+3. **Visual state consistency**: verify the UI reflects the saved state after reload (badge, token field, status indicator)
+
+### Test structure
+
+```typescript
+test('config toggle round-trips correctly', async ({ page }) => {
+  await page.goto('/mcp-settings');
+
+  // Capture the outgoing save request
+  const [request] = await Promise.all([
+    page.waitForRequest(
+      req => req.url().includes('/api/config') && req.method() === 'POST'
+    ),
+    page.click('[data-testid="ignore-in-git-toggle"]'),
+    page.click('[data-testid="save-section"]'),
+  ]);
+
+  const body = request.postDataJSON();
+  expect(body.ignoreInGit).toBe(true);  // not the stale pre-toggle value
+
+  // Verify UI reflects saved state after reload
+  await page.reload();
+  await expect(
+    page.locator('[data-testid="ignore-in-git-toggle"]')
+  ).toBeChecked();
+});
+```
+
+### Wire to CI
+
+Add the spec file to the Playwright config's `testDir`. Run locally:
+```bash
+npx playwright test path/to/config-ui.spec.ts
+```
+
+### What Playwright catches that unit tests miss
+
+- **`useCallback` dep bugs** — the API call posts the stale pre-toggle value; unit tests mock the call and never see the staleness
+- **`formToConfig` field-drop bugs** — the saved payload is missing fields; only caught by inspecting the actual POST body
+- **State-after-reload inconsistencies** — save returns 200 but the UI doesn't reflect it on reload
+
+## Cross-Cutting Gotchas
+
+- **Warm neutral ≠ neutral** — in the daemon design system, "neutral" is charcoal-based. Brown/beige tones immediately signal a design system mismatch.
+- **Collective UI is a separate package but must inherit daemon design language** — it has its own deployment (`oss.goondocks.workers.dev`) but is not a separate visual system. Use `make collective-ui-dev` for a local proxy against live worker settings.
+- **ESLint hooks rule is your first line of defence** — never suppress `react-hooks/exhaustive-deps`. The warning is the bug report.
+- **Screenshot before merging** — visual consistency is the primary review signal for daemon UI. A screenshot comparison catches design drift that code review misses.
+- **`formToConfig` spread order is silent** — there is no runtime error when you get the spread order wrong. The only symptom is data loss in production. Test it with Playwright.

--- a/.agents/skills/session-lifecycle-and-gating/SKILL.md
+++ b/.agents/skills/session-lifecycle-and-gating/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: myco:session-lifecycle-and-gating
+description: |
+  Use this skill whenever you are working with Myco session lifecycle,
+  state transitions, or the intelligence-task query gate — even if the
+  user does not explicitly mention session gating. This covers: the
+  session state machine (active → completed → active reactivation path)
+  and settlement timing; safely adding new session completion paths by
+  routing through triggerTitleSummary(); verifying that every vault read
+  surface honors requireSettledSessions; configuring settledSessionIdleMinutes
+  and requireSettledSessions in myco.yaml; and ensuring new intelligence
+  tasks inherit the gate. Apply any time you touch session completion,
+  session queries, or new intelligence task types.
+managed_by: myco
+user-invocable: true
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+# Myco Session Lifecycle and Query-Layer Gating
+
+Sessions in Myco pass through a defined state machine enforced by the daemon. The intelligence-task gate (`requireSettledSessions`) prevents in-flight transcript data from contaminating agent outputs. Both the state machine and the gate have invariants that must be honored whenever you add a new completion path, a new query surface, or a new intelligence task type.
+
+## Prerequisites
+
+- Understand the Myco daemon architecture: the daemon runs jobs and reacts to hooks. Session state is stored in SQLite.
+- Know the two session-related config keys in `myco.yaml` under the `agent:` section:
+  - `requireSettledSessions` — boolean; enables the intelligence-task gate
+  - `settledSessionIdleMinutes` — integer; idle threshold (default: 30 minutes)
+- Have daemon source open. Key locations: the session-maintenance job, the sessions API route, and the hook handler for `SessionStart`/`SessionEnd`.
+
+## Procedure 1: Understanding the Session State Machine
+
+Sessions follow a linear state machine with one reactivation path:
+
+```
+active  ──(SessionEnd hook or idle threshold)──►  completed
+  ▲                                                    │
+  └──────────(SessionStart on same session)────────────┘
+             (reactivates: status flips back to 'active')
+```
+
+**Settlement conditions** — a session is considered settled when either:
+1. A `SessionEnd` hook fires for that session, OR
+2. `last_prompt_at` is older than `settledSessionIdleMinutes` (default: 30 minutes)
+
+The session-maintenance job runs periodically and completes sessions that meet condition 2. The `SessionEnd` hook fires when the user closes the coding-agent window.
+
+**Reactivation invariant** — when `SessionStart` fires on a session that is already `completed`, the daemon MUST flip `status` back to `'active'`. This is non-negotiable: if a completed session is not reactivated, all of its new prompts become invisible to query surfaces that filter for settled data. The gate then silently drops live data — prompts arrive under a session that immediately re-completes on the next maintenance cycle.
+
+Verify reactivation logic exists in the `SessionStart` handler:
+
+```bash
+grep -n "SessionStart\|reactivat\|status.*active" src/daemon/hooks/*.ts
+```
+
+## Procedure 2: Adding a New Session Completion Path Safely
+
+Any code path that completes a session must route through the shared `triggerTitleSummary()` helper. This is the single chokepoint that enforces `requireSettledSessions` behavior. Duplicating the gate check inline will drift from config changes and will not inherit future gate improvements.
+
+**When to apply**: you are adding a new API endpoint, UI action, CLI command, or automation trigger that marks a session as completed.
+
+**Steps:**
+
+1. Locate the canonical `triggerTitleSummary()` implementation:
+   ```bash
+   grep -rn "triggerTitleSummary" src/
+   ```
+
+2. In your new completion path, call `triggerTitleSummary(sessionId)` *after* persisting `status: 'completed'` to SQLite — never before. The helper reads session state.
+
+3. Do NOT copy-paste gate logic from another route. The helper owns the gate logic.
+
+4. Use the manual complete API as your reference implementation — it was the canonical example where `triggerTitleSummary()` was initially missed and then fixed:
+   ```bash
+   grep -n "complete\|triggerTitleSummary" src/daemon/routes/sessions.ts
+   ```
+   The `POST /api/sessions/:id/complete` route is the before/after reference.
+
+5. Write a test that completes a session via your new path with `requireSettledSessions: false` and confirms title/summary generation fires.
+
+**Gotcha**: Inline gate logic (`if (!config.requireSettledSessions) triggerTitle()`) will silently diverge the next time the helper's semantics change. The helper is the contract.
+
+## Procedure 3: Verifying Gate Completeness Across Read Surfaces
+
+The `requireSettledSessions` gate must be honored by **every** vault read surface. A gate applied to only some query paths creates split-brain: the agent sees settled data from one tool and in-flight data from another.
+
+**The complete list of surfaces that must honor the gate:**
+
+| Surface | Description |
+|---------|-------------|
+| `vault_unprocessed` | Prompt batches — must exclude active sessions |
+| `vault_spores` | Spore queries — must filter by session settlement state |
+| `vault_sessions` | Session list — must omit active sessions |
+| `vault_search_fts` | Full-text search — must exclude active-session content |
+| `vault_search_semantic` | Semantic search — must exclude active-session embeddings |
+
+PR #72 shipped the gate for `vault_unprocessed`, `vault_spores`, and `vault_sessions` but initially missed `vault_search_fts` and `vault_search_semantic`. The two search surfaces were gated only after the gap was discovered post-merge.
+
+**Steps for verifying a new read surface:**
+
+1. Locate the SQL query or data-fetch path for the new surface:
+   ```bash
+   grep -rn "vault_search\|vault_spores\|FROM sessions" src/daemon/tools/*.ts
+   ```
+
+2. Confirm the query has a `WHERE` clause or join that restricts to settled sessions. The canonical settlement predicate looks like:
+   ```sql
+   WHERE s.status = 'completed'
+      OR s.last_prompt_at < datetime('now', '-' || :idleMinutes || ' minutes')
+   ```
+   If this join or subquery is absent, the surface bypasses the gate.
+
+3. Add the settlement filter using the same SQL fragment as the existing gated surfaces — copy it rather than writing a new predicate, so all surfaces stay in sync.
+
+4. Verify with an integration test: create an active session with content, enable `requireSettledSessions: true`, query the surface, confirm the active session's content does not appear.
+
+5. Add the new surface to the table above so future completeness checks include it.
+
+**Gotcha**: Search surfaces are the most commonly missed. Search feels "read-only" and low-stakes, but if an agent runs semantic search over an active session's spores it can act on mid-session data. Both FTS and semantic search must be gated.
+
+## Procedure 4: Configuring and Extending Intelligence Task Gating
+
+The gate configuration lives in `myco.yaml` under the `agent:` key:
+
+```yaml
+# myco.yaml
+agent:
+  requireSettledSessions: true      # boolean; disable for dev/test only
+  settledSessionIdleMinutes: 30     # integer minutes; default 30
+```
+
+**When to set `requireSettledSessions: false`:**
+- Local development and testing where you inject synthetic session data
+- CI environments where you control session state directly
+
+**When to keep it `true` (production default):**
+- Any deployment where the coding agent is actively running. Active sessions generate in-flight fragments that are not yet coherent intelligence input.
+
+**Adding a new intelligence task that must inherit the gate:**
+
+Any task that analyzes transcript semantics (e.g., a custom analysis task, a new variant of `skill-survey`) must check `requireSettledSessions` before reading session content.
+
+1. At the start of the task's execution logic, read the config and enforce the gate:
+   ```typescript
+   const gate = config.agent?.requireSettledSessions ?? false;
+   if (gate) {
+     // Only pass settled session IDs to downstream query surfaces
+   }
+   ```
+
+2. Pass only settled-session IDs to downstream tools. Do NOT call any read surface (FTS, semantic search, spore queries) with an unfiltered session scope when the gate is enabled.
+
+3. Document the gate behavior in the task's YAML definition under `description` so operators know the task is gate-aware.
+
+4. Test with `requireSettledSessions: true` and an active session present — confirm the task skips or gates that session's data correctly.
+
+**Gotcha**: Tasks copied from an older template may call `vault_search_fts` or `vault_search_semantic` directly without the session-scope filter. If those surfaces were not yet gated when the template was written, the gate is bypassed. Always cross-check Procedure 3's surface list when authoring a new task.
+
+## Cross-Cutting Gotchas
+
+**Reactivation is a co-invariant of gating.** If `SessionStart` on a completed session does not flip status back to `active`, the gate silently loses live data. Test reactivation alongside any gate change. An easy regression check:
+```bash
+# Confirm the SessionStart handler updates status unconditionally
+grep -A 10 "SessionStart" src/daemon/hooks/*.ts | grep "status.*active"
+```
+
+**`settledSessionIdleMinutes` too low causes false positives.** A developer pausing for 25 minutes can cause premature completion followed by immediate reactivation. The 30-minute default is conservative; tune only with real usage data and expect minor churn.
+
+**Dismissal reason semantics for skill candidates.** When dismissing a skill candidate during the skill-survey task:
+- `dismissal_reason: 'reject'` — permanently blocks this topic from future survey suggestions
+- `dismissal_reason: 'stale'` — marks the candidate as outdated but keeps the category eligible for re-survey
+
+These must not be conflated. Using `reject` when `stale` is correct silently closes off valid future skill suggestions for an entire topic area.

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -124,7 +124,7 @@ const NotificationsSchema = z.object({
   /** Allow browser system notifications (Notification API). */
   system_notifications: z.boolean().default(false),
   /** Default display mode for new notification types. */
-  default_mode: z.enum(['banner', 'summary']).default('banner'),
+  default_mode: z.enum(['banner', 'summary']).default('summary'),
   /** Per-domain settings. Keys are domain names from the registry. */
   domains: z.record(z.string(), z.object({
     enabled: z.boolean().default(true),

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -14,6 +14,7 @@ import { buildTaskInstruction, isInstructionRequiredTask } from '@myco/agent/ins
 import { hasConfiguredProvider } from '@myco/agent/config-resolver.js';
 import { loadConfig } from '@myco/config/loader.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+import { notify } from '@myco/notifications/notify.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 import type { EmbeddingManager } from '../embedding/manager.js';
 import type { DaemonLogger } from '../logger.js';
@@ -121,13 +122,29 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
 
     resultPromise
       .then((result) => {
+        const taskName = task ?? 'agent run';
         if (result.status === 'failed') {
+          notify(vaultDir, {
+            domain: 'agents',
+            type: 'agent.task.failure',
+            title: `Task failed: ${taskName}`,
+            message: result.error ?? 'Unknown error',
+            link: `/agent?run=${result.runId}`,
+            metadata: { taskName: task ?? null, runId: result.runId },
+          }, mycoConfig);
           logger.error(LOG_KINDS.AGENT_ERROR, 'Agent run failed', {
             runId: result.runId,
             error: result.error ?? 'No error message',
             phases: result.phases?.map(p => `${p.name}:${p.status}`) ?? [],
           });
         } else {
+          notify(vaultDir, {
+            domain: 'agents',
+            type: 'agent.task.success',
+            title: `Task completed: ${taskName}`,
+            link: `/agent?run=${result.runId}`,
+            metadata: { taskName: task ?? null, runId: result.runId },
+          }, mycoConfig);
           logger.info(LOG_KINDS.AGENT_RUN, 'Agent run completed', {
             runId: result.runId,
             status: result.status,

--- a/packages/myco/src/daemon/api/mycelium.ts
+++ b/packages/myco/src/daemon/api/mycelium.ts
@@ -1,5 +1,6 @@
 import { listSpores, countSpores, getSpore } from '@myco/db/queries/spores.js';
 import { listEntities, getEntity } from '@myco/db/queries/entities.js';
+import { getSession } from '@myco/db/queries/sessions.js';
 import { listDigestExtracts } from '@myco/db/queries/digest-extracts.js';
 import { getGraphForNode } from '@myco/db/queries/graph-edges.js';
 import { getDatabase } from '@myco/db/client.js';
@@ -24,6 +25,11 @@ const MAX_GRAPH_DEPTH = 3;
 
 /** Spore node name preview length (first N chars of content). */
 const SPORE_NAME_PREVIEW_CHARS = 60;
+
+/** Seed counts for focused graph startup. */
+const GRAPH_SEED_ENTITY_LIMIT = 4;
+const GRAPH_SEED_SPORE_LIMIT = 4;
+const GRAPH_SEED_SESSION_LIMIT = 4;
 
 /** Edge types to exclude from graph visualization (too granular). */
 const EXCLUDED_GRAPH_EDGE_TYPES = new Set(['HAS_BATCH', 'EXTRACTED_FROM']);
@@ -83,19 +89,114 @@ export async function handleListEntities(req: RouteRequest): Promise<RouteRespon
   return { body: { entities } };
 }
 
+export async function handleGetGraphSeeds(_req: RouteRequest): Promise<RouteResponse> {
+  const db = getDatabase();
+
+  const sporeRows = db.prepare(
+    `SELECT id, observation_type, status, content, created_at
+     FROM spores
+     WHERE agent_id = ? AND status = 'active'
+     ORDER BY created_at DESC
+     LIMIT ?`,
+  ).all(DEFAULT_AGENT_ID, GRAPH_SEED_SPORE_LIMIT) as Array<Record<string, unknown>>;
+
+  const sessionRows = db.prepare(
+    `SELECT id, title, summary, status, started_at as created_at
+     FROM sessions
+     WHERE status != 'active'
+     ORDER BY started_at DESC
+     LIMIT ?`,
+  ).all(GRAPH_SEED_SESSION_LIMIT) as Array<Record<string, unknown>>;
+
+  const entityRows = db.prepare(
+    `SELECT e.id, e.type, e.name, e.status, e.first_seen as created_at, COUNT(em.entity_id) as mention_count
+     FROM entities e
+     LEFT JOIN entity_mentions em ON em.entity_id = e.id
+     WHERE e.agent_id = ? AND e.status = 'active'
+     GROUP BY e.id
+     ORDER BY mention_count DESC, e.last_seen DESC
+     LIMIT ?`,
+  ).all(DEFAULT_AGENT_ID, GRAPH_SEED_ENTITY_LIMIT) as Array<Record<string, unknown>>;
+
+  const sporeSeeds = sporeRows.map((row) => ({
+      id: row.id as string,
+      name: ((row.content as string) ?? '').slice(0, SPORE_NAME_PREVIEW_CHARS),
+      type: 'spore' as const,
+      status: (row.status as string) ?? undefined,
+      created_at: row.created_at as number | undefined,
+      content: row.content as string | undefined,
+      observation_type: row.observation_type as string | undefined,
+    }));
+  const sessionSeeds = sessionRows.map((row) => ({
+      id: row.id as string,
+      name: (row.title as string) ?? `Session ${(row.id as string).slice(-6)}`,
+      type: 'session' as const,
+      status: (row.status as string) ?? undefined,
+      created_at: row.created_at as number | undefined,
+      content: (row.summary as string) ?? undefined,
+    }));
+  const entitySeeds = entityRows.map((row) => ({
+      id: row.id as string,
+      name: row.name as string,
+      type: row.type as string,
+      status: (row.status as string) ?? undefined,
+      created_at: row.created_at as number | undefined,
+      mention_count: Number(row.mention_count) || 0,
+    }));
+
+  const seeds = [
+    ...entitySeeds,
+    ...sessionSeeds,
+    ...sporeSeeds,
+  ];
+
+  const recommendedId = entitySeeds[0]?.id
+    ?? sessionSeeds[0]?.id
+    ?? sporeSeeds[0]?.id
+    ?? null;
+
+  return {
+    body: {
+      seeds,
+      recommended_id: recommendedId,
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Graph handler
 // ---------------------------------------------------------------------------
 
 export async function handleGetGraph(req: RouteRequest): Promise<RouteResponse> {
   const depth = Math.min(Number(req.query.depth) || DEFAULT_GRAPH_DEPTH, MAX_GRAPH_DEPTH);
+  const id = req.params.id;
 
-  // Verify center entity exists
-  const center = getEntity(req.params.id);
-  if (!center) return { status: 404, body: { error: 'not_found' } };
+  // Verify center node exists in any of the primary tables
+  let centerNode: any = null;
+  let centerType: 'entity' | 'spore' | 'session' = 'entity';
+
+  const entity = getEntity(id);
+  if (entity) {
+    centerNode = entity;
+    centerType = 'entity';
+  } else {
+    const spore = getSpore(id);
+    if (spore) {
+      centerNode = spore;
+      centerType = 'spore';
+    } else {
+      const session = getSession(id);
+      if (session) {
+        centerNode = session;
+        centerType = 'session';
+      }
+    }
+  }
+
+  if (!centerNode) return { status: 404, body: { error: 'not_found' } };
 
   // Use graph_edges for BFS traversal
-  const graph = getGraphForNode(req.params.id, 'entity', { depth });
+  const graph = getGraphForNode(id, centerType, { depth });
 
   // Filter out batch-related edges (too granular for visualization)
   const filteredEdges = graph.edges.filter(
@@ -110,20 +211,23 @@ export async function handleGetGraph(req: RouteRequest): Promise<RouteResponse> 
   const sessionIds = new Set<string>();
 
   for (const edge of filteredEdges) {
-    for (const [id, type] of [
+    for (const [nodeId, type] of [
       [edge.source_id, edge.source_type],
       [edge.target_id, edge.target_type],
     ] as [string, string][]) {
       switch (type) {
-        case 'entity': entityIds.add(id); break;
-        case 'spore': sporeIds.add(id); break;
-        case 'session': sessionIds.add(id); break;
+        case 'entity': entityIds.add(nodeId); break;
+        case 'spore': sporeIds.add(nodeId); break;
+        case 'session': sessionIds.add(nodeId); break;
         // batch nodes are intentionally excluded
       }
     }
   }
-  // Center entity is always included
-  entityIds.add(center.id);
+  
+  // Center node is always included in the appropriate set
+  if (centerType === 'entity') entityIds.add(id);
+  if (centerType === 'spore') sporeIds.add(id);
+  if (centerType === 'session') sessionIds.add(id);
 
   // --- Batch-fetch entity nodes ---
   const entityIdArray = Array.from(entityIds);
@@ -202,9 +306,6 @@ export async function handleGetGraph(req: RouteRequest): Promise<RouteResponse> 
     })),
   ];
 
-  // Identify the center node from the unified array
-  const centerNode = allNodes.find((n) => n.id === center.id);
-
   // Map edges to UI-friendly shape (label + weight instead of type + confidence)
   const uiEdges = filteredEdges.map((e) => ({
     source_id: e.source_id,
@@ -213,10 +314,12 @@ export async function handleGetGraph(req: RouteRequest): Promise<RouteResponse> 
     weight: e.confidence,
   }));
 
+  const centerResponseNode = allNodes.find((n) => n.id === id);
+
   return {
     body: {
-      center: centerNode ?? { ...center, mention_count: mentionCounts.get(center.id) ?? 0 },
-      nodes: allNodes.filter((n) => n.id !== center.id),
+      center: centerResponseNode,
+      nodes: allNodes.filter((n) => n.id !== id),
       edges: uiEdges,
       depth,
     },

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -365,13 +365,24 @@ export async function main(): Promise<void> {
     const staleDb = getDatabase();
     // SQLite doesn't support RETURNING — query first, then update
     const staleRows = staleDb.prepare(
-      `SELECT id FROM agent_runs WHERE status = 'running'`,
-    ).all() as Array<{ id: string }>;
+      `SELECT id, task FROM agent_runs WHERE status = 'running'`,
+    ).all() as Array<{ id: string; task: string | null }>;
 
     if (staleRows.length > 0) {
+      const completedAt = epochSeconds();
       staleDb.prepare(
         `UPDATE agent_runs SET status = 'failed', completed_at = ?, error = 'Daemon restarted while run was in progress' WHERE status = 'running'`,
-      ).run(epochSeconds());
+      ).run(completedAt);
+      for (const row of staleRows) {
+        notify(vaultDir, {
+          domain: 'agents',
+          type: 'agent.task.failure',
+          title: `Task failed: ${row.task ?? 'agent run'}`,
+          message: 'Daemon restarted while run was in progress',
+          link: `/agent?run=${row.id}`,
+          metadata: { taskName: row.task, runId: row.id, reason: 'daemon_restart' },
+        }, config);
+      }
       logger.info(LOG_KINDS.AGENT_RUN, 'Cleaned stale running agent runs', {
         count: staleRows.length,
         ids: staleRows.map((r) => r.id),

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -57,6 +57,7 @@ import {
   handleListSpores,
   handleGetSpore,
   handleListEntities,
+  handleGetGraphSeeds,
   handleGetGraph,
   handleGetFullGraph,
   handleGetDigest,
@@ -594,6 +595,7 @@ export async function main(): Promise<void> {
   server.registerRoute('GET', '/api/spores', handleListSpores);
   server.registerRoute('GET', '/api/spores/:id', handleGetSpore);
   server.registerRoute('GET', '/api/entities', handleListEntities);
+  server.registerRoute('GET', '/api/graph/seeds', handleGetGraphSeeds);
   server.registerRoute('GET', '/api/graph', handleGetFullGraph);
   server.registerRoute('GET', '/api/graph/:id', handleGetGraph);
   server.registerRoute('GET', '/api/digest', handleGetDigest);

--- a/packages/myco/src/notifications/domains.ts
+++ b/packages/myco/src/notifications/domains.ts
@@ -13,8 +13,8 @@ export function registerBuiltinDomains(): void {
     domain: 'agents',
     label: 'Agent Tasks',
     types: [
-      { id: 'agent.task.success', label: 'Task completed', defaultMode: 'banner', defaultLevel: 'success' },
-      { id: 'agent.task.failure', label: 'Task failed', defaultMode: 'banner', defaultLevel: 'error' },
+      { id: 'agent.task.success', label: 'Task completed', defaultMode: 'summary', defaultLevel: 'success' },
+      { id: 'agent.task.failure', label: 'Task failed', defaultMode: 'summary', defaultLevel: 'error' },
     ],
   });
 
@@ -32,8 +32,8 @@ export function registerBuiltinDomains(): void {
     label: 'Skills',
     types: [
       { id: 'skill.surveyed', label: 'Skill candidate surveyed', defaultMode: 'summary', defaultLevel: 'info' },
-      { id: 'skill.created', label: 'Skill created', defaultMode: 'banner', defaultLevel: 'success' },
-      { id: 'skill.evolved', label: 'Skill evolved', defaultMode: 'banner', defaultLevel: 'info' },
+      { id: 'skill.created', label: 'Skill created', defaultMode: 'summary', defaultLevel: 'success' },
+      { id: 'skill.evolved', label: 'Skill evolved', defaultMode: 'summary', defaultLevel: 'info' },
     ],
   });
 
@@ -50,7 +50,7 @@ export function registerBuiltinDomains(): void {
     domain: 'daemon',
     label: 'Daemon',
     types: [
-      { id: 'daemon.version_sync', label: 'Version sync restart', defaultMode: 'banner', defaultLevel: 'info' },
+      { id: 'daemon.version_sync', label: 'Version sync restart', defaultMode: 'summary', defaultLevel: 'info' },
     ],
   });
 }

--- a/packages/myco/src/notifications/notify.ts
+++ b/packages/myco/src/notifications/notify.ts
@@ -38,12 +38,14 @@ export function notify(
     const domainConfig = cfg.notifications.domains[payload.domain];
     if (domainConfig && !domainConfig.enabled) return null;
 
-    // Resolve mode: payload > domain config > type registry default > global default
+    // Resolve mode: payload > domain config > global default > type registry default.
+    // The project config is the user's explicit preference; registry defaults are
+    // only a fallback for older configs and unconfigured callers.
     const registeredType = getType(payload.type);
     const mode: NotificationMode = payload.mode
       ?? domainConfig?.mode
-      ?? registeredType?.type.defaultMode
-      ?? cfg.notifications.default_mode;
+      ?? cfg.notifications.default_mode
+      ?? registeredType?.type.defaultMode;
     const level: NotificationLevel = payload.level
       ?? registeredType?.type.defaultLevel
       ?? 'info';

--- a/packages/myco/ui/src/components/agent/AgentConfig.tsx
+++ b/packages/myco/ui/src/components/agent/AgentConfig.tsx
@@ -1,18 +1,13 @@
 import { useState, useCallback, useRef } from 'react';
 import {
   Settings2,
-  Cpu,
   Activity,
-  CheckCircle,
-  XCircle,
   Loader2,
-  ExternalLink,
 } from 'lucide-react';
 import { useConfig, type MycoConfig } from '../../hooks/use-config';
 import { useDaemon, type StatsResponse } from '../../hooks/use-daemon';
 import { useAgentTasks, type TaskRow } from '../../hooks/use-agent';
 import { useRestart } from '../../hooks/use-restart';
-import { fetchJson } from '../../lib/api';
 import { formatUptime, formatEpochAgo, parseNumericField } from '../../lib/format';
 import { Surface } from '../ui/surface';
 import { SectionHeader } from '../ui/section-header';
@@ -27,8 +22,6 @@ import {
 } from '../ui/select';
 import { Switch } from '../ui/switch';
 import { DEFAULT_SUMMARY_BATCH_INTERVAL } from '../../lib/constants';
-
-type TestState = 'idle' | 'testing' | 'success' | 'error';
 
 /* ---------- Types ---------- */
 
@@ -184,8 +177,6 @@ export function AgentConfig() {
 
   const [form, setForm] = useState<AgentFormState | null>(null);
   const [saveMessage, setSaveMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
-  const [testState, setTestState] = useState<TestState>('idle');
-  const [testMessage, setTestMessage] = useState('');
 
   const tasks: TaskRow[] = tasksData?.tasks ?? [];
   const defaultTaskFromApi = tasks.find((t) => t.isDefault)?.name ?? '';
@@ -231,28 +222,6 @@ export function AgentConfig() {
       }
     } catch {
       setSaveMessage({ type: 'error', text: 'Failed to save settings.' });
-    }
-  };
-
-  const handleTestEmbedding = async () => {
-    if (!config) return;
-    setTestState('testing');
-    setTestMessage('');
-    try {
-      const params = new URLSearchParams({
-        provider: config.embedding.provider,
-        type: 'embedding',
-      });
-      if (config.embedding.base_url) params.set('base_url', config.embedding.base_url);
-      const result = await fetchJson<{ provider: string; models: string[] }>(
-        `/models?${params.toString()}`,
-      );
-      const count = result.models.length;
-      setTestState('success');
-      setTestMessage(`Connected -- ${count} model${count !== 1 ? 's' : ''} available.`);
-    } catch (err) {
-      setTestState('error');
-      setTestMessage(err instanceof Error ? err.message : 'Connection failed.');
     }
   };
 
@@ -387,73 +356,6 @@ export function AgentConfig() {
               }
             >
               {saveMessage.text}
-            </span>
-          )}
-        </div>
-      </Surface>
-
-      {/* ---------- Embedding Configuration (read-only summary + link) ---------- */}
-      <Surface level="low" className="p-6 space-y-4 border-t-2 border-t-ochre">
-        <SectionHeader>
-          <span className="flex items-center gap-2">
-            <Cpu className="h-4 w-4 text-secondary" />
-            Embedding Configuration
-          </span>
-        </SectionHeader>
-
-        <div className="grid grid-cols-2 gap-x-6 gap-y-2">
-          <div>
-            <p className="font-sans text-xs text-on-surface-variant">Provider</p>
-            <p className="text-sm font-mono text-on-surface mt-0.5">
-              {config.embedding.provider}
-            </p>
-          </div>
-          <div>
-            <p className="font-sans text-xs text-on-surface-variant">Model</p>
-            <p className="text-sm font-mono text-on-surface mt-0.5 truncate" title={config.embedding.model}>
-              {config.embedding.model}
-            </p>
-          </div>
-          {config.embedding.base_url && (
-            <div className="col-span-2">
-              <p className="font-sans text-xs text-on-surface-variant">Base URL</p>
-              <p className="text-sm font-mono text-on-surface mt-0.5 truncate" title={config.embedding.base_url}>
-                {config.embedding.base_url}
-              </p>
-            </div>
-          )}
-        </div>
-
-        <div className="flex items-center gap-3 pt-2 border-t border-outline-variant/20">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={handleTestEmbedding}
-            disabled={testState === 'testing'}
-          >
-            {testState === 'testing' ? (
-              <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
-            ) : null}
-            Test Connection
-          </Button>
-          <a
-            href="/settings"
-            className="flex items-center gap-1 font-sans text-xs text-on-surface-variant hover:text-on-surface transition-colors"
-          >
-            <ExternalLink className="h-3 w-3" />
-            Edit in Settings
-          </a>
-          {testState === 'success' && (
-            <span className="flex items-center gap-1 font-sans text-xs text-primary">
-              <CheckCircle className="h-3.5 w-3.5" />
-              {testMessage}
-            </span>
-          )}
-          {testState === 'error' && (
-            <span className="flex items-center gap-1 font-sans text-xs text-tertiary">
-              <XCircle className="h-3.5 w-3.5" />
-              {testMessage}
             </span>
           )}
         </div>

--- a/packages/myco/ui/src/components/mycelium/EntityFilter.tsx
+++ b/packages/myco/ui/src/components/mycelium/EntityFilter.tsx
@@ -34,6 +34,7 @@ interface EntityFilterProps {
   onSearchChange: (query: string) => void;
   enabledEdgeTypes?: Set<string>;
   onToggleEdgeType?: (type: string) => void;
+  embedded?: boolean;
 }
 
 /* ---------- Component ---------- */
@@ -46,11 +47,119 @@ export function EntityFilter({
   onSearchChange,
   enabledEdgeTypes,
   onToggleEdgeType,
+  embedded = false,
 }: EntityFilterProps) {
   const [open, setOpen] = useState(false);
 
   const totalNodes = Object.values(entityCounts).reduce((a, b) => a + b, 0);
   const activeFilterCount = ENTITY_TYPES.length - enabledTypes.size;
+
+  const content = (
+    <div className="p-3 space-y-4">
+      <div className="relative">
+        <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-on-surface-variant/50" />
+        <Input
+          placeholder="Search nodes..."
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="text-xs pl-7 h-7"
+        />
+      </div>
+
+      <div className="space-y-1">
+        {ENTITY_TYPES.map((et) => {
+          const count = entityCounts[et.type] ?? 0;
+          const enabled = enabledTypes.has(et.type);
+          return (
+            <label
+              key={et.type}
+              className="flex items-center gap-2 py-1 cursor-pointer group"
+            >
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={() => onToggleType(et.type)}
+                className="sr-only"
+              />
+              <div
+                className={cn(
+                  'h-3 w-3 rounded-sm flex items-center justify-center transition-colors',
+                  enabled ? 'bg-surface-container-high' : 'bg-surface-container-lowest',
+                )}
+              >
+                {enabled && <div className={cn('h-1.5 w-1.5 rounded-full', et.dotColor)} />}
+              </div>
+              <span
+                className={cn(
+                  'font-sans text-xs transition-colors',
+                  enabled ? 'text-on-surface' : 'text-on-surface-variant/50',
+                )}
+              >
+                {et.label}
+              </span>
+              <span className="ml-auto font-mono text-[10px] text-on-surface-variant/50">
+                {count}
+              </span>
+            </label>
+          );
+        })}
+      </div>
+
+      {enabledEdgeTypes && onToggleEdgeType && (
+        <div className="space-y-1 pt-1 border-t border-outline-variant/10">
+          <div className="font-sans text-[10px] font-medium uppercase tracking-widest text-on-surface-variant/60 pt-1">
+            Edges
+          </div>
+          {EDGE_TYPES.map((et) => {
+            const enabled = enabledEdgeTypes.has(et.type);
+            return (
+              <label
+                key={et.type}
+                className="flex items-center gap-2 py-0.5 cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  checked={enabled}
+                  onChange={() => onToggleEdgeType(et.type)}
+                  className="sr-only"
+                />
+                <div
+                  className={cn(
+                    'h-2.5 w-2.5 rounded-sm flex items-center justify-center transition-colors',
+                    enabled ? 'bg-surface-container-high' : 'bg-surface-container-lowest',
+                  )}
+                >
+                  {enabled && <div className="h-1 w-1 rounded-full bg-outline" />}
+                </div>
+                <span
+                  className={cn(
+                    'font-sans text-[11px] transition-colors',
+                    enabled ? 'text-on-surface-variant' : 'text-on-surface-variant/40',
+                  )}
+                >
+                  {et.label}
+                </span>
+              </label>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+
+  if (embedded) {
+    return (
+      <div className="rounded-lg bg-surface-container/95 backdrop-blur-md shadow-lg border border-outline-variant/20 overflow-hidden">
+        <div className="flex items-center justify-between px-3 py-2 border-b border-outline-variant/10">
+          <span className="font-sans text-xs font-medium uppercase tracking-widest text-on-surface-variant">
+            Filters
+          </span>
+          <span className="font-mono text-[10px] text-on-surface-variant/50">{totalNodes}</span>
+        </div>
+        {content}
+      </div>
+    );
+  }
 
   return (
     <div className="absolute top-3 left-3 z-10">
@@ -91,99 +200,7 @@ export function EntityFilter({
             </button>
           </div>
 
-          <div className="p-3 space-y-4">
-            {/* Search */}
-            <div className="relative">
-              <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-on-surface-variant/50" />
-              <Input
-                placeholder="Search nodes..."
-                value={searchQuery}
-                onChange={(e) => onSearchChange(e.target.value)}
-                className="text-xs pl-7 h-7"
-              />
-            </div>
-
-            {/* Entity type filters */}
-            <div className="space-y-1">
-              {ENTITY_TYPES.map((et) => {
-                const count = entityCounts[et.type] ?? 0;
-                const enabled = enabledTypes.has(et.type);
-                return (
-                  <label
-                    key={et.type}
-                    className="flex items-center gap-2 py-1 cursor-pointer group"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={enabled}
-                      onChange={() => onToggleType(et.type)}
-                      className="sr-only"
-                    />
-                    <div
-                      className={cn(
-                        'h-3 w-3 rounded-sm flex items-center justify-center transition-colors',
-                        enabled ? 'bg-surface-container-high' : 'bg-surface-container-lowest',
-                      )}
-                    >
-                      {enabled && <div className={cn('h-1.5 w-1.5 rounded-full', et.dotColor)} />}
-                    </div>
-                    <span
-                      className={cn(
-                        'font-sans text-xs transition-colors',
-                        enabled ? 'text-on-surface' : 'text-on-surface-variant/50',
-                      )}
-                    >
-                      {et.label}
-                    </span>
-                    <span className="ml-auto font-mono text-[10px] text-on-surface-variant/50">
-                      {count}
-                    </span>
-                  </label>
-                );
-              })}
-            </div>
-
-            {/* Edge type filters */}
-            {enabledEdgeTypes && onToggleEdgeType && (
-              <div className="space-y-1 pt-1 border-t border-outline-variant/10">
-                <div className="font-sans text-[10px] font-medium uppercase tracking-widest text-on-surface-variant/60 pt-1">
-                  Edges
-                </div>
-                {EDGE_TYPES.map((et) => {
-                  const enabled = enabledEdgeTypes.has(et.type);
-                  return (
-                    <label
-                      key={et.type}
-                      className="flex items-center gap-2 py-0.5 cursor-pointer"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={enabled}
-                        onChange={() => onToggleEdgeType(et.type)}
-                        className="sr-only"
-                      />
-                      <div
-                        className={cn(
-                          'h-2.5 w-2.5 rounded-sm flex items-center justify-center transition-colors',
-                          enabled ? 'bg-surface-container-high' : 'bg-surface-container-lowest',
-                        )}
-                      >
-                        {enabled && <div className="h-1 w-1 rounded-full bg-outline" />}
-                      </div>
-                      <span
-                        className={cn(
-                          'font-sans text-[11px] transition-colors',
-                          enabled ? 'text-on-surface-variant' : 'text-on-surface-variant/40',
-                        )}
-                      >
-                        {et.label}
-                      </span>
-                    </label>
-                  );
-                })}
-              </div>
-            )}
-          </div>
+          {content}
         </div>
       )}
     </div>

--- a/packages/myco/ui/src/components/mycelium/GraphCanvas.tsx
+++ b/packages/myco/ui/src/components/mycelium/GraphCanvas.tsx
@@ -7,10 +7,12 @@ interface GraphCanvasProps {
   edges: GraphEdge[];
   onNodeSelect?: (node: GraphNode | null) => void;
   selectedNode?: GraphNode | null;
+  centerId?: string | null;
+  isLoading?: boolean;
 }
 
-export function GraphCanvas({ nodes, edges, onNodeSelect }: GraphCanvasProps) {
-  const { containerRef, resetView } = useGraphCanvas({ nodes, edges, onNodeSelect });
+export function GraphCanvas({ nodes, edges, onNodeSelect, centerId, isLoading }: GraphCanvasProps) {
+  const { containerRef, resetView } = useGraphCanvas({ nodes, edges, onNodeSelect, centerId });
 
   return (
     <div className="absolute inset-0">
@@ -25,21 +27,21 @@ export function GraphCanvas({ nodes, edges, onNodeSelect }: GraphCanvasProps) {
       />
       {/* Cytoscape container */}
       <div ref={containerRef} className="absolute inset-0 rounded-md" />
-      {/* Controls overlay */}
-      <div className="absolute top-3 right-3 z-10 flex items-center gap-2">
-        <Button variant="ghost" size="sm" onClick={resetView} className="gap-1.5">
-          <RotateCcw className="h-3.5 w-3.5" />
-          Reset
+      {/* Controls overlay — bottom left next to stats */}
+      <div className="absolute bottom-3 left-3 z-10 flex items-center gap-3">
+        {nodes.length > 0 && (
+          <div className="flex items-center gap-3 font-mono text-[10px] text-on-surface-variant/60 mr-1">
+            <span>{nodes.length} nodes</span>
+            <span>{edges.length} edges</span>
+          </div>
+        )}
+        <Button variant="ghost" size="sm" onClick={resetView} className="gap-1.5 h-7 text-[10px] px-2 bg-surface-container-high/40 backdrop-blur-sm">
+          <RotateCcw className="h-3 w-3" />
+          Reset View
         </Button>
       </div>
-      {/* Stats overlay */}
-      {nodes.length > 0 && (
-        <div className="absolute bottom-3 left-3 z-10 flex items-center gap-3 font-mono text-[10px] text-on-surface-variant/60">
-          <span>{nodes.length} nodes</span>
-          <span>{edges.length} edges</span>
-        </div>
-      )}
-      {nodes.length === 0 && (
+      {/* Empty state */}
+      {!isLoading && nodes.length === 0 && (
         <div className="absolute inset-0 flex items-center justify-center">
           <p className="font-sans text-sm text-on-surface-variant">No nodes to display</p>
         </div>

--- a/packages/myco/ui/src/components/mycelium/Inspector.tsx
+++ b/packages/myco/ui/src/components/mycelium/Inspector.tsx
@@ -2,8 +2,10 @@ import { useNavigate } from 'react-router-dom';
 import { Surface } from '../ui/surface';
 import { Badge } from '../ui/badge';
 import { SectionHeader } from '../ui/section-header';
+import { MarkdownContent } from '../ui/markdown-content';
+import { formatGraphLabel } from '../../lib/graph-labels';
 
-import { X, ArrowRight, ExternalLink } from 'lucide-react';
+import { X, ArrowRight, ExternalLink, Loader2 } from 'lucide-react';
 import type { GraphNode, GraphEdge } from '../../hooks/use-graph-canvas';
 
 /* ---------- Constants ---------- */
@@ -41,6 +43,7 @@ interface Connection {
   nodeType: string;
   edgeLabel: string;
   direction: 'outgoing' | 'incoming';
+  status?: string;
 }
 
 interface InspectorProps {
@@ -51,8 +54,9 @@ interface InspectorProps {
   markdownPreview?: string;
   connectedSpores?: Array<{ id: string; name: string; type: string }>;
   onClose?: () => void;
-  onNodeSelect?: (node: GraphNode) => void;
+  onNodeSelect?: (node: GraphNode, source?: 'canvas' | 'inspector') => void;
   onNavigateToSpore?: (id: string) => void;
+  isConnectionsLoading?: boolean;
 }
 
 /* ---------- Sub-components ---------- */
@@ -75,7 +79,7 @@ function getNodeRoute(node: GraphNode): string | null {
   return null;
 }
 
-export function Inspector({ node, edges, nodes, metadata, markdownPreview, connectedSpores, onClose, onNodeSelect, onNavigateToSpore }: InspectorProps) {
+export function Inspector({ node, edges, nodes, metadata, markdownPreview, connectedSpores, onClose, onNodeSelect, onNavigateToSpore, isConnectionsLoading }: InspectorProps) {
   const navigate = useNavigate();
   if (!node) return null;
 
@@ -90,15 +94,17 @@ export function Inspector({ node, edges, nodes, metadata, markdownPreview, conne
     if (edge.source_id === node.id) {
       const target = nodeMap.get(edge.target_id);
       if (target) {
-        connections.push({ nodeId: target.id, nodeName: target.name, nodeType: target.type, edgeLabel: edge.label ?? 'connected', direction: 'outgoing' });
+        connections.push({ nodeId: target.id, nodeName: target.name, nodeType: target.type, edgeLabel: edge.label ?? 'connected', direction: 'outgoing', status: target.status });
       }
     } else if (edge.target_id === node.id) {
       const source = nodeMap.get(edge.source_id);
       if (source) {
-        connections.push({ nodeId: source.id, nodeName: source.name, nodeType: source.type, edgeLabel: edge.label ?? 'connected', direction: 'incoming' });
+        connections.push({ nodeId: source.id, nodeName: source.name, nodeType: source.type, edgeLabel: edge.label ?? 'connected', direction: 'incoming', status: source.status });
       }
     }
   }
+
+  connections.sort((a, b) => a.nodeName.localeCompare(b.nodeName));
 
   // Use explicit markdownPreview prop, or fall back to node content (spore/session)
   const previewText = markdownPreview ?? node.content;
@@ -111,7 +117,7 @@ export function Inspector({ node, edges, nodes, metadata, markdownPreview, conne
   const previewLabel = node.type === 'spore' ? 'Observation' : node.type === 'session' ? 'Summary' : 'Notes';
 
   return (
-    <Surface glass className="absolute top-0 right-0 z-20 w-[320px] max-h-full overflow-y-auto flex flex-col shadow-lg border border-outline-variant/15 rounded-md">
+    <Surface glass className="absolute top-3 right-3 bottom-3 z-20 w-[320px] overflow-y-auto flex flex-col shadow-lg border border-outline-variant/15 rounded-md">
       {/* Header */}
       <div className="p-4 pb-3">
         <div className="flex items-start justify-between gap-2">
@@ -123,23 +129,25 @@ export function Inspector({ node, edges, nodes, metadata, markdownPreview, conne
               </Badge>
             </div>
             <h2 className="font-serif text-lg text-on-surface leading-tight break-words">
-              {node.name}
+              {formatGraphLabel(node.name)}
             </h2>
-            {getNodeRoute(node) && (
-              <button
-                onClick={() => {
-                  if (node.type === 'spore' && onNavigateToSpore) {
-                    onNavigateToSpore(node.id);
-                  } else {
-                    navigate(getNodeRoute(node)!);
-                  }
-                }}
-                className="inline-flex items-center gap-1 mt-1.5 font-sans text-xs text-on-surface-variant hover:text-primary transition-colors group cursor-pointer"
-              >
-                <span>View {node.type}</span>
-                <ExternalLink className="h-3 w-3 group-hover:translate-x-0.5 transition-transform" />
-              </button>
-            )}
+            <div className="flex flex-wrap items-center gap-3 mt-2">
+              {getNodeRoute(node) && (
+                <button
+                  onClick={() => {
+                    if (node.type === 'spore' && onNavigateToSpore) {
+                      onNavigateToSpore(node.id);
+                    } else {
+                      navigate(getNodeRoute(node)!);
+                    }
+                  }}
+                  className="inline-flex items-center gap-1 font-sans text-xs text-on-surface-variant hover:text-primary transition-colors group cursor-pointer"
+                >
+                  <span>View {node.type}</span>
+                  <ExternalLink className="h-3 w-3 group-hover:translate-x-0.5 transition-transform" />
+                </button>
+              )}
+            </div>
           </div>
           {onClose && (
             <button
@@ -189,39 +197,58 @@ export function Inspector({ node, edges, nodes, metadata, markdownPreview, conne
             <SectionHeader>{previewLabel}</SectionHeader>
             <Surface
               level="lowest"
-              className="p-3 font-sans text-xs text-on-surface-variant whitespace-pre-wrap leading-relaxed"
+              className="p-3"
             >
-              {truncatedPreview}
+              <MarkdownContent
+                content={truncatedPreview}
+                className="text-xs leading-relaxed text-on-surface-variant"
+              />
             </Surface>
           </div>
         </>
       )}
 
       {/* Connections */}
-      {connections.length > 0 && (
+      {(connections.length > 0 || isConnectionsLoading) && (
         <>
           <div className="h-px bg-surface-container-high/50" />
           <div className="px-4 py-3 space-y-2">
-            <SectionHeader>Connections ({connections.length})</SectionHeader>
+            <div className="flex items-center justify-between gap-2">
+              <SectionHeader>Connections ({connections.length})</SectionHeader>
+              {isConnectionsLoading && (
+                <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider text-on-surface-variant">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  Updating
+                </span>
+              )}
+            </div>
             <div className="space-y-1">
               {connections.map((conn, i) => {
                 const connTypeKey = conn.nodeType.toLowerCase();
                 const connDot = TYPE_DOT_COLOR[connTypeKey] ?? 'bg-outline';
-                const targetNode = nodeMap.get(conn.nodeId);
                 return (
                   <button
                     key={`${conn.nodeId}-${conn.edgeLabel}-${i}`}
-                    className="w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-surface-container-high/50 transition-colors group"
-                    onClick={() => targetNode && onNodeSelect?.(targetNode)}
+                    className="group w-full rounded-md border border-transparent px-2 py-2 text-left transition-colors hover:border-outline-variant/10 hover:bg-surface-container-high/50"
+                    onClick={() => {
+                      const existingNode = nodeMap.get(conn.nodeId);
+                      onNodeSelect?.(existingNode ?? { id: conn.nodeId, name: conn.nodeName, type: conn.nodeType, status: conn.status }, 'inspector');
+                    }}
                   >
-                    <div className={`h-2 w-2 rounded-full ${connDot} shrink-0`} />
-                    <span className="font-sans text-xs text-on-surface truncate flex-1 group-hover:text-primary transition-colors">
-                      {conn.nodeName}
-                    </span>
-                    <ArrowRight className={`h-3 w-3 shrink-0 ${conn.direction === 'incoming' ? 'rotate-180' : ''} text-on-surface-variant/50`} />
-                    <span className="font-mono text-[9px] text-on-surface-variant/60 shrink-0 max-w-[80px] truncate">
-                      {conn.edgeLabel}
-                    </span>
+                    <div className="flex items-start gap-2">
+                      <div className={`mt-1 h-2 w-2 rounded-full ${connDot} shrink-0`} />
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate font-sans text-xs text-on-surface transition-colors group-hover:text-primary">
+                          {formatGraphLabel(conn.nodeName)}
+                        </div>
+                        <div className="mt-0.5 flex items-center gap-1 text-[9px] uppercase tracking-wider text-on-surface-variant/60">
+                          <span>{conn.nodeType}</span>
+                          <span>•</span>
+                          <span>{conn.edgeLabel}</span>
+                        </div>
+                      </div>
+                      <ArrowRight className={`mt-0.5 h-3 w-3 shrink-0 text-on-surface-variant/50 ${conn.direction === 'incoming' ? 'rotate-180' : ''}`} />
+                    </div>
                   </button>
                 );
               })}

--- a/packages/myco/ui/src/components/notifications/NotificationBanner.tsx
+++ b/packages/myco/ui/src/components/notifications/NotificationBanner.tsx
@@ -5,7 +5,7 @@ import { cn } from '../../lib/cn';
 import { useNotifications, useUpdateNotification, type Notification, type NotificationLevel } from '../../hooks/use-notifications';
 
 const BANNER_MAX_VISIBLE = 3;
-const BANNER_AUTO_DISMISS_MS = 8_000;
+const BANNER_AUTO_DISMISS_MS = 5_000;
 
 const LEVEL_STYLES: Record<NotificationLevel, string> = {
   info: 'bg-primary/10 border-primary/20 text-primary',
@@ -29,18 +29,17 @@ export function NotificationBanner() {
 
   const banners = (data?.items ?? []).filter((n) => !dismissed.has(n.id));
 
-  // Auto-dismiss non-error banners after timeout
+  // Banner mode is intentionally transient. Even failure banners should clear
+  // quickly so the notification center remains the durable record.
   useEffect(() => {
     const timers: ReturnType<typeof setTimeout>[] = [];
     for (const n of banners) {
-      if (n.level !== 'error') {
-        timers.push(
-          setTimeout(() => {
-            setDismissed((prev) => new Set(prev).add(n.id));
-            updateNotification.mutate({ id: n.id, status: 'read' });
-          }, BANNER_AUTO_DISMISS_MS),
-        );
-      }
+      timers.push(
+        setTimeout(() => {
+          setDismissed((prev) => new Set(prev).add(n.id));
+          updateNotification.mutate({ id: n.id, status: 'read' });
+        }, BANNER_AUTO_DISMISS_MS),
+      );
     }
     return () => timers.forEach(clearTimeout);
   }, [banners.map((n) => n.id).join(',')]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/packages/myco/ui/src/components/notifications/NotificationPanel.tsx
+++ b/packages/myco/ui/src/components/notifications/NotificationPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   X,
+  Bell,
   CheckCircle2,
   AlertTriangle,
   AlertCircle,
@@ -35,6 +36,11 @@ const LEVEL_ICONS: Record<NotificationLevel, typeof Info> = {
   error: AlertCircle,
 };
 
+const SECTION_TITLES = {
+  unread: 'New',
+  read: 'Earlier',
+} as const;
+
 function timeAgo(epochSec: number): string {
   const seconds = Math.floor(Date.now() / 1000) - epochSec;
   if (seconds < 60) return 'just now';
@@ -51,6 +57,91 @@ interface NotificationPanelProps {
   onClose: () => void;
 }
 
+function NotificationSectionLabel({ title, count }: { title: string; count: number }) {
+  return (
+    <div className="flex items-center justify-between px-1">
+      <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-on-surface-variant">
+        {title}
+      </span>
+      <span className="text-[11px] text-on-surface-variant/70">{count}</span>
+    </div>
+  );
+}
+
+function NotificationRow({
+  notification,
+  onOpen,
+  onDismiss,
+}: {
+  notification: Notification;
+  onOpen: (notification: Notification) => void;
+  onDismiss: (e: React.MouseEvent, notification: Notification) => void;
+}) {
+  const Icon = LEVEL_ICONS[notification.level];
+  const isUnread = notification.status === 'unread';
+
+  return (
+    <div
+      onClick={() => onOpen(notification)}
+      className={cn(
+        'group cursor-pointer rounded-lg border border-transparent px-4 py-3 transition-colors hover:border-outline-variant/20 hover:bg-surface-container-high/70',
+        isUnread && 'border-primary/10 bg-primary/[0.04]',
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <div className="relative mt-0.5 shrink-0">
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-surface-container-high text-on-surface-variant">
+            <Icon className="h-4 w-4" />
+          </div>
+          {isUnread && (
+            <span
+              className={cn(
+                'absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full ring-2 ring-surface-container',
+                LEVEL_DOT[notification.level],
+              )}
+            />
+          )}
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 space-y-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className={cn('text-sm font-medium', isUnread ? 'text-on-surface' : 'text-on-surface-variant')}>
+                  {notification.title}
+                </span>
+                <span className="rounded-full bg-surface-container-high px-2 py-0.5 text-[10px] uppercase tracking-wider text-on-surface-variant">
+                  {notification.domain}
+                </span>
+              </div>
+              {notification.message && (
+                <MarkdownContent
+                  content={notification.message}
+                  compact
+                  className="line-clamp-3 text-xs leading-5 text-on-surface-variant"
+                />
+              )}
+            </div>
+
+            <div className="flex shrink-0 items-start gap-2">
+              <span className="pt-0.5 text-[10px] font-mono text-on-surface-variant/70">
+                {timeAgo(notification.created_at)}
+              </span>
+              <button
+                onClick={(e) => onDismiss(e, notification)}
+                className="rounded p-0.5 text-on-surface-variant/40 opacity-0 transition hover:text-on-surface-variant group-hover:opacity-100"
+                aria-label="Dismiss"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function NotificationPanel({ open, onClose }: NotificationPanelProps) {
   const { data, refetch } = useNotifications({ limit: 50 });
   const updateNotification = useUpdateNotification();
@@ -58,12 +149,10 @@ export function NotificationPanel({ open, onClose }: NotificationPanelProps) {
   const dismissAll = useDismissAll();
   const navigate = useNavigate();
 
-  // Refetch when panel opens
   useEffect(() => {
     if (open) refetch();
   }, [open, refetch]);
 
-  // Close on Escape
   useEffect(() => {
     if (!open) return;
     const handler = (e: KeyboardEvent) => {
@@ -77,12 +166,12 @@ export function NotificationPanel({ open, onClose }: NotificationPanelProps) {
   }, [open, onClose]);
 
   const handleClick = useCallback(
-    (n: Notification) => {
-      if (n.status === 'unread') {
-        updateNotification.mutate({ id: n.id, status: 'read' });
+    (notification: Notification) => {
+      if (notification.status === 'unread') {
+        updateNotification.mutate({ id: notification.id, status: 'read' });
       }
-      if (n.link) {
-        navigate(n.link);
+      if (notification.link) {
+        navigate(notification.link);
         onClose();
       }
     },
@@ -90,19 +179,20 @@ export function NotificationPanel({ open, onClose }: NotificationPanelProps) {
   );
 
   const handleDismiss = useCallback(
-    (e: React.MouseEvent, n: Notification) => {
+    (e: React.MouseEvent, notification: Notification) => {
       e.stopPropagation();
-      updateNotification.mutate({ id: n.id, status: 'dismissed' });
+      updateNotification.mutate({ id: notification.id, status: 'dismissed' });
     },
     [updateNotification],
   );
 
-  const items = (data?.items ?? []).filter(n => n.status !== 'dismissed');
+  const items = (data?.items ?? []).filter((notification) => notification.status !== 'dismissed');
   const unreadCount = data?.unread_count ?? 0;
+  const unreadItems = items.filter((notification) => notification.status === 'unread');
+  const readItems = items.filter((notification) => notification.status !== 'unread');
 
   return (
     <>
-      {/* Overlay */}
       {open && (
         <div
           className="fixed inset-0 z-40 bg-surface-dim/40 backdrop-blur-sm transition-opacity"
@@ -111,111 +201,103 @@ export function NotificationPanel({ open, onClose }: NotificationPanelProps) {
         />
       )}
 
-      {/* Panel */}
       <aside
         className={cn(
-          'fixed top-0 right-0 bottom-0 z-50 w-96 max-w-[calc(100vw-3rem)] flex flex-col bg-surface-container border-l border-outline-variant/20 shadow-2xl transition-transform duration-200 ease-out',
+          'fixed top-0 right-0 bottom-0 z-50 flex w-96 max-w-[calc(100vw-3rem)] flex-col border-l border-outline-variant/20 bg-surface-container shadow-2xl transition-transform duration-200 ease-out',
           open ? 'translate-x-0' : 'translate-x-full',
         )}
       >
-        {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-outline-variant/20">
-          <div className="flex items-center gap-2">
-            <h2 className="text-sm font-medium text-on-surface">Notifications</h2>
-            {unreadCount > 0 && (
-              <span className="inline-flex items-center justify-center h-5 min-w-5 px-1.5 rounded-full bg-primary/15 text-primary text-xs font-medium">
-                {unreadCount}
-              </span>
-            )}
-          </div>
-          <div className="flex items-center gap-1">
-            {unreadCount > 0 && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => markAllRead.mutate(undefined)}
-                title="Mark all as read"
-                className="h-7 px-2 gap-1 text-xs text-on-surface-variant"
-              >
-                <MailCheck className="h-3.5 w-3.5" />
-                Read all
+        <div className="border-b border-outline-variant/20 px-4 py-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <Bell className="h-4 w-4 text-primary" />
+                <h2 className="text-sm font-medium text-on-surface">Notifications</h2>
+                {unreadCount > 0 && (
+                  <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary/15 px-1.5 text-xs font-medium text-primary">
+                    {unreadCount}
+                  </span>
+                )}
+              </div>
+              <p className="text-xs text-on-surface-variant">
+                New items stay here until read or dismissed. Summary notifications live here even when no banner was shown.
+              </p>
+            </div>
+
+            <div className="flex items-center gap-1">
+              {unreadCount > 0 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => markAllRead.mutate(undefined)}
+                  title="Mark all as read"
+                  className="h-7 gap-1 px-2 text-xs text-on-surface-variant"
+                >
+                  <MailCheck className="h-3.5 w-3.5" />
+                  Mark all read
+                </Button>
+              )}
+              {items.length > 0 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => dismissAll.mutate(undefined)}
+                  title="Clear all notifications"
+                  className="h-7 gap-1 px-2 text-xs text-on-surface-variant"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Clear
+                </Button>
+              )}
+              <Button variant="ghost" size="sm" onClick={onClose} className="h-7 px-2">
+                <X className="h-4 w-4" />
               </Button>
-            )}
-            {items.length > 0 && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => dismissAll.mutate(undefined)}
-                title="Clear all notifications"
-                className="h-7 px-2 gap-1 text-xs text-on-surface-variant"
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-                Clear
-              </Button>
-            )}
-            <Button variant="ghost" size="sm" onClick={onClose} className="h-7 px-2">
-              <X className="h-4 w-4" />
-            </Button>
+            </div>
           </div>
         </div>
 
-        {/* List */}
         <div className="flex-1 overflow-y-auto">
           {items.length === 0 ? (
-            <div className="flex items-center justify-center h-32 text-sm text-on-surface-variant">
-              No notifications
+            <div className="flex h-40 flex-col items-center justify-center gap-2 px-6 text-center">
+              <Bell className="h-5 w-5 text-on-surface-variant/50" />
+              <div className="text-sm text-on-surface-variant">No notifications yet</div>
+              <div className="text-xs text-on-surface-variant/70">
+                New events will appear here whether they display as banners or summary-only items.
+              </div>
             </div>
           ) : (
-            <div className="divide-y divide-outline-variant/10">
-              {items.map((n) => {
-                const Icon = LEVEL_ICONS[n.level];
-                return (
-                  <div
-                    key={n.id}
-                    onClick={() => handleClick(n)}
-                    className={cn(
-                      'flex items-start gap-3 px-4 py-3 transition-colors cursor-pointer hover:bg-surface-container-high',
-                      n.status === 'unread' && 'bg-primary/[0.03]',
-                    )}
-                  >
-                    <div className="relative mt-0.5 shrink-0">
-                      <Icon className="h-4 w-4 text-on-surface-variant" />
-                      {n.status === 'unread' && (
-                        <span className={cn('absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full', LEVEL_DOT[n.level])} />
-                      )}
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-baseline justify-between gap-2">
-                        <span className={cn('text-sm font-medium truncate', n.status === 'unread' ? 'text-on-surface' : 'text-on-surface-variant')}>
-                          {n.title}
-                        </span>
-                        <span className="text-[10px] text-on-surface-variant/60 shrink-0 font-mono">
-                          {timeAgo(n.created_at)}
-                        </span>
-                      </div>
-                      {n.message && (
-                        <MarkdownContent
-                          content={n.message}
-                          compact
-                          className="text-xs mt-0.5 line-clamp-2"
-                        />
-                      )}
-                      <span className="text-[10px] text-on-surface-variant/40 uppercase tracking-wider mt-1 inline-block">
-                        {n.domain}
-                      </span>
-                    </div>
-                    {n.status !== 'dismissed' && (
-                      <button
-                        onClick={(e) => handleDismiss(e, n)}
-                        className="shrink-0 mt-0.5 rounded p-0.5 text-on-surface-variant/40 hover:text-on-surface-variant transition-colors"
-                        aria-label="Dismiss"
-                      >
-                        <X className="h-3.5 w-3.5" />
-                      </button>
-                    )}
+            <div className="space-y-4 px-3 py-3">
+              {unreadItems.length > 0 && (
+                <section className="space-y-2">
+                  <NotificationSectionLabel title={SECTION_TITLES.unread} count={unreadItems.length} />
+                  <div className="space-y-2">
+                    {unreadItems.map((notification) => (
+                      <NotificationRow
+                        key={notification.id}
+                        notification={notification}
+                        onOpen={handleClick}
+                        onDismiss={handleDismiss}
+                      />
+                    ))}
                   </div>
-                );
-              })}
+                </section>
+              )}
+
+              {readItems.length > 0 && (
+                <section className="space-y-2">
+                  <NotificationSectionLabel title={SECTION_TITLES.read} count={readItems.length} />
+                  <div className="space-y-2">
+                    {readItems.map((notification) => (
+                      <NotificationRow
+                        key={notification.id}
+                        notification={notification}
+                        onOpen={handleClick}
+                        onDismiss={handleDismiss}
+                      />
+                    ))}
+                  </div>
+                </section>
+              )}
             </div>
           )}
         </div>

--- a/packages/myco/ui/src/components/notifications/NotificationPanel.tsx
+++ b/packages/myco/ui/src/components/notifications/NotificationPanel.tsx
@@ -41,6 +41,8 @@ const SECTION_TITLES = {
   read: 'Earlier',
 } as const;
 
+const NOTIFICATION_NAVIGATION_SOURCE = 'notification-panel';
+
 function timeAgo(epochSec: number): string {
   const seconds = Math.floor(Date.now() / 1000) - epochSec;
   if (seconds < 60) return 'just now';
@@ -171,7 +173,12 @@ export function NotificationPanel({ open, onClose }: NotificationPanelProps) {
         updateNotification.mutate({ id: notification.id, status: 'read' });
       }
       if (notification.link) {
-        navigate(notification.link);
+        navigate(notification.link, {
+          state: {
+            source: NOTIFICATION_NAVIGATION_SOURCE,
+            triggeredAt: Date.now(),
+          },
+        });
         onClose();
       }
     },
@@ -220,7 +227,7 @@ export function NotificationPanel({ open, onClose }: NotificationPanelProps) {
                 )}
               </div>
               <p className="text-xs text-on-surface-variant">
-                New items stay here until read or dismissed. Summary notifications live here even when no banner was shown.
+                New items stay here until read or dismissed.
               </p>
             </div>
 

--- a/packages/myco/ui/src/components/notifications/NotificationSettings.tsx
+++ b/packages/myco/ui/src/components/notifications/NotificationSettings.tsx
@@ -14,6 +14,11 @@ import {
   SelectValue,
 } from '../ui/select';
 
+const MODE_LABELS = {
+  banner: 'Banner',
+  summary: 'Summary',
+} as const;
+
 interface NotifFormState {
   enabled: boolean;
   system_notifications: boolean;
@@ -36,6 +41,10 @@ function FieldHint({ children }: { children: React.ReactNode }) {
   return <p className="font-sans text-xs text-on-surface-variant">{children}</p>;
 }
 
+function SectionCard({ children }: { children: React.ReactNode }) {
+  return <div className="rounded-lg border border-outline-variant/20 bg-surface-container/40 p-4">{children}</div>;
+}
+
 export function NotificationSettings() {
   const { config, saveConfig, isSaving } = useConfig();
   const { data: registryData } = useNotificationRegistry();
@@ -48,7 +57,7 @@ export function NotificationSettings() {
       setForm({
         enabled: config.notifications?.enabled ?? true,
         system_notifications: config.notifications?.system_notifications ?? false,
-        default_mode: config.notifications?.default_mode ?? 'banner',
+        default_mode: config.notifications?.default_mode ?? 'summary',
         domains: config.notifications?.domains ?? {},
       });
     }
@@ -88,10 +97,11 @@ export function NotificationSettings() {
   if (!form || !config) return null;
 
   const domains = registryData?.domains ?? [];
+  const controlsDisabled = !form.enabled;
   const isDirty = config ? (
     form.enabled !== (config.notifications?.enabled ?? true) ||
     form.system_notifications !== (config.notifications?.system_notifications ?? false) ||
-    form.default_mode !== (config.notifications?.default_mode ?? 'banner') ||
+    form.default_mode !== (config.notifications?.default_mode ?? 'summary') ||
     JSON.stringify(form.domains) !== JSON.stringify(config.notifications?.domains ?? {})
   ) : false;
 
@@ -100,90 +110,122 @@ export function NotificationSettings() {
       <SectionHeader>Notifications</SectionHeader>
 
       <div className="space-y-4">
-        {/* Master toggle */}
-        <div className="flex items-center justify-between">
-          <div className="space-y-0.5">
-            <FieldLabel>Enabled</FieldLabel>
-            <FieldHint>Master switch for all notification types.</FieldHint>
-          </div>
-          <Switch checked={form.enabled} onCheckedChange={v => setField('enabled', v)} />
-        </div>
-
-        {/* System notifications */}
-        <div className="flex items-center justify-between">
-          <div className="space-y-0.5">
-            <FieldLabel>System Notifications</FieldLabel>
-            <FieldHint>Show browser notifications when the tab is not focused.</FieldHint>
-          </div>
-          <Switch
-            checked={form.system_notifications}
-            onCheckedChange={v => setField('system_notifications', v)}
-            disabled={!form.enabled}
-          />
-        </div>
-
-        {/* Default mode */}
-        <div className="space-y-1.5">
-          <FieldLabel>Default Mode</FieldLabel>
-          <Select
-            value={form.default_mode}
-            onValueChange={v => setField('default_mode', v as 'banner' | 'summary')}
-            disabled={!form.enabled}
-          >
-            <SelectTrigger className="w-40">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="banner">Banner</SelectItem>
-              <SelectItem value="summary">Summary</SelectItem>
-            </SelectContent>
-          </Select>
-          <FieldHint>Banner shows as a pop-up overlay. Summary shows only in the notification panel.</FieldHint>
-        </div>
-
-        {/* Per-domain toggles */}
-        {domains.length > 0 && (
-          <div className="space-y-3 pt-2">
-            <FieldLabel>Domain Notifications</FieldLabel>
-            <div className="space-y-3">
-              {domains.map(d => {
-                const domainConfig = form.domains[d.domain] ?? { enabled: true };
-                const domainEnabled = domainConfig.enabled;
-                return (
-                  <div key={d.domain} className="flex items-center justify-between gap-3 py-1">
-                    <div className="space-y-0.5 flex-1 min-w-0">
-                      <span className="text-sm text-on-surface">{d.label}</span>
-                      <p className="text-[11px] text-on-surface-variant">
-                        {d.types.map(t => t.label).join(', ')}
-                      </p>
-                    </div>
-                    <div className="flex items-center gap-2 shrink-0">
-                      <Select
-                        value={domainConfig.mode ?? 'default'}
-                        onValueChange={v => updateDomain(d.domain, { mode: v === 'default' ? undefined : (v as 'banner' | 'summary') })}
-                        disabled={!form.enabled || !domainEnabled}
-                      >
-                        <SelectTrigger className="w-[110px] h-8 text-xs">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="default">Default</SelectItem>
-                          <SelectItem value="banner">Banner</SelectItem>
-                          <SelectItem value="summary">Summary</SelectItem>
-                        </SelectContent>
-                      </Select>
-                      <Switch
-                        checked={domainEnabled}
-                        onCheckedChange={v => updateDomain(d.domain, { enabled: v })}
-                        disabled={!form.enabled}
-                      />
-                    </div>
-                  </div>
-                );
-              })}
+        <SectionCard>
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <FieldLabel>Notifications</FieldLabel>
+              <FieldHint>Turn the notification system on or off for this project.</FieldHint>
             </div>
+            <Switch checked={form.enabled} onCheckedChange={v => setField('enabled', v)} />
           </div>
-        )}
+        </SectionCard>
+
+        <div className={controlsDisabled ? 'space-y-4 opacity-60' : 'space-y-4'}>
+          <SectionCard>
+            <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
+              <div className="space-y-1.5">
+                <FieldLabel>Default Display</FieldLabel>
+                <FieldHint>
+                  `Summary` keeps notifications in the panel only. `Banner` also shows a temporary in-app popup.
+                </FieldHint>
+              </div>
+              <Select
+                value={form.default_mode}
+                onValueChange={v => setField('default_mode', v as 'banner' | 'summary')}
+                disabled={controlsDisabled}
+              >
+                <SelectTrigger className="w-40">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="summary">Summary</SelectItem>
+                  <SelectItem value="banner">Banner</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </SectionCard>
+
+          <SectionCard>
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-1">
+                <FieldLabel>Browser Notifications</FieldLabel>
+                <FieldHint>
+                  Use OS/browser popups when the Myco tab is not focused. Only banner-mode notifications use this.
+                </FieldHint>
+              </div>
+              <Switch
+                checked={form.system_notifications}
+                onCheckedChange={v => setField('system_notifications', v)}
+                disabled={controlsDisabled}
+              />
+            </div>
+          </SectionCard>
+
+          {domains.length > 0 && (
+            <SectionCard>
+              <div className="space-y-3">
+                <div className="space-y-1">
+                  <FieldLabel>Per-Domain Overrides</FieldLabel>
+                  <FieldHint>Leave a domain on `Default` unless you want it to behave differently from the project-wide setting.</FieldHint>
+                </div>
+
+                <div className="space-y-2">
+                  {domains.map(d => {
+                    const domainConfig = form.domains[d.domain] ?? { enabled: true };
+                    const domainEnabled = domainConfig.enabled;
+                    const effectiveMode = domainConfig.mode ?? form.default_mode;
+                    return (
+                      <div
+                        key={d.domain}
+                        className="rounded-md border border-outline-variant/20 bg-surface-container-low/40 px-3 py-3"
+                      >
+                        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                          <div className="min-w-0 flex-1 space-y-1">
+                            <div className="flex items-center gap-2">
+                              <span className="text-sm font-medium text-on-surface">{d.label}</span>
+                              <span className="rounded-full bg-surface-container-high px-2 py-0.5 text-[11px] text-on-surface-variant">
+                                {domainEnabled ? MODE_LABELS[effectiveMode] : 'Off'}
+                              </span>
+                            </div>
+                            <p className="text-[11px] text-on-surface-variant">
+                              {d.types.map(t => t.label).join(', ')}
+                            </p>
+                          </div>
+
+                          <div className="flex items-center gap-2 self-start">
+                            <Select
+                              value={domainConfig.mode ?? 'default'}
+                              onValueChange={v => updateDomain(d.domain, { mode: v === 'default' ? undefined : (v as 'banner' | 'summary') })}
+                              disabled={controlsDisabled || !domainEnabled}
+                            >
+                              <SelectTrigger className="h-8 w-[120px] text-xs">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="default">Default</SelectItem>
+                                <SelectItem value="summary">Summary</SelectItem>
+                                <SelectItem value="banner">Banner</SelectItem>
+                              </SelectContent>
+                            </Select>
+                            <Switch
+                              checked={domainEnabled}
+                              onCheckedChange={v => updateDomain(d.domain, { enabled: v })}
+                              disabled={controlsDisabled}
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </SectionCard>
+          )}
+
+          {controlsDisabled && (
+            <FieldHint>Notifications are currently disabled, so display and domain settings are inactive.</FieldHint>
+          )}
+        </div>
       </div>
 
       {/* Save row */}

--- a/packages/myco/ui/src/components/notifications/SystemNotifications.tsx
+++ b/packages/myco/ui/src/components/notifications/SystemNotifications.tsx
@@ -11,7 +11,7 @@ import { useConfig } from '../../hooks/use-config';
 export function SystemNotifications() {
   const { config } = useConfig();
   const enabled = config?.notifications?.system_notifications ?? false;
-  const { data } = useNotifications({ status: 'unread', limit: 5 });
+  const { data } = useNotifications({ status: 'unread', mode: 'banner', limit: 5 });
   const seenRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {

--- a/packages/myco/ui/src/hooks/use-graph-canvas.ts
+++ b/packages/myco/ui/src/hooks/use-graph-canvas.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback } from 'react';
 import cytoscape, { type Core, type ElementDefinition, type NodeSingular } from 'cytoscape';
+import { formatGraphLabel } from '../lib/graph-labels';
 
 /* ---------- Graph palette ---------- */
 
@@ -76,6 +77,15 @@ const COSE_GRAVITY = 0.2;
 /** COSE layout: animation duration (ms). */
 const COSE_ANIMATION_DURATION = 600;
 
+/** Focused COSE layout repulsion force. */
+const FOCUS_NODE_REPULSION = 6000;
+
+/** Focused COSE ideal edge length. */
+const FOCUS_IDEAL_EDGE_LENGTH = 150;
+
+/** Focused layout animation duration (ms). */
+const FOCUS_ANIMATION_DURATION = 300;
+
 /** Fit padding (px) used by resetView. */
 const FIT_PADDING = 50;
 
@@ -121,20 +131,23 @@ interface UseGraphCanvasOptions {
   nodes: GraphNode[];
   edges: GraphEdge[];
   onNodeSelect?: (node: GraphNode | null) => void;
+  centerId?: string | null;
 }
 
 /* ---------- Helpers ---------- */
 
 /** Compute node size based on its degree (connection count). */
-function nodeSizeFromDegree(degree: number): number {
+function nodeSizeFromDegree(degree: number, isCenter: boolean): number {
+  if (isCenter) return NODE_SIZE_MAX * 1.2;
   const t = Math.min(degree / NODE_SIZE_DEGREE_CAP, 1);
   return NODE_SIZE_MIN + t * (NODE_SIZE_MAX - NODE_SIZE_MIN);
 }
 
 /** Truncate label for display. */
 function truncateLabel(name: string): string {
-  if (name.length <= NODE_LABEL_MAX_LENGTH) return name;
-  return name.slice(0, NODE_LABEL_MAX_LENGTH - 1) + '\u2026';
+  const formatted = formatGraphLabel(name);
+  if (formatted.length <= NODE_LABEL_MAX_LENGTH) return formatted;
+  return formatted.slice(0, NODE_LABEL_MAX_LENGTH - 1) + '\u2026';
 }
 
 /** Get node color for a given type. */
@@ -144,7 +157,7 @@ function nodeColor(type: string): string {
 
 /* ---------- Hook ---------- */
 
-export function useGraphCanvas({ nodes, edges, onNodeSelect }: UseGraphCanvasOptions) {
+export function useGraphCanvas({ nodes, edges, onNodeSelect, centerId }: UseGraphCanvasOptions) {
   const containerRef = useRef<HTMLDivElement>(null);
   const cyRef = useRef<Core | null>(null);
   const onNodeSelectRef = useRef(onNodeSelect);
@@ -169,15 +182,18 @@ export function useGraphCanvas({ nodes, edges, onNodeSelect }: UseGraphCanvasOpt
     const elements: ElementDefinition[] = [
       ...nodes.map((n) => {
         const typeLabel = NODE_TYPE_LABELS[n.type?.toLowerCase()] ?? NODE_TYPE_LABELS.other;
+        const isCenter = n.id === centerId;
         return {
           data: {
             id: n.id,
             label: `${truncateLabel(n.name)}\n${typeLabel}`,
             fullLabel: n.name,
             type: n.type,
+            isCenter,
             degree: degreeMap.get(n.id) ?? 0,
-            nodeSize: nodeSizeFromDegree(degreeMap.get(n.id) ?? 0),
+            nodeSize: nodeSizeFromDegree(degreeMap.get(n.id) ?? 0, isCenter),
           },
+          classes: isCenter ? 'center' : '',
         };
       }),
       ...edges.map((e, i) => ({
@@ -222,6 +238,18 @@ export function useGraphCanvas({ nodes, edges, onNodeSelect }: UseGraphCanvasOpt
             'border-color': PALETTE.sage,
             'border-opacity': 0,
             'overlay-opacity': 0,
+          },
+        },
+        /* ---- Center node — extra prominent ---- */
+        {
+          selector: 'node.center',
+          style: {
+            'border-width': 2,
+            'border-color': PALETTE.onSurface,
+            'border-opacity': 0.4,
+            'text-outline-color': PALETTE.surface,
+            'text-outline-width': 3,
+            'font-weight': 'bold',
           },
         },
         /* ---- Node hover ---- */
@@ -297,31 +325,59 @@ export function useGraphCanvas({ nodes, edges, onNodeSelect }: UseGraphCanvasOpt
       maxZoom: 3,
     });
 
-    /* Run COSE layout and fit to viewport when done */
-    const layout = cy.layout({
-      name: 'cose',
-      animate: true,
-      animationDuration: COSE_ANIMATION_DURATION,
-      nodeRepulsion: () => COSE_NODE_REPULSION,
-      idealEdgeLength: () => COSE_IDEAL_EDGE_LENGTH,
-      gravity: COSE_GRAVITY,
-      nodeDimensionsIncludeLabels: true,
-      fit: true,
-      padding: FIT_PADDING,
-    });
-    layout.on('layoutstop', () => {
-      // Center on the most-connected node and zoom to show its neighborhood
-      const nodes = cy.nodes();
-      const { ele: mostConnected, value: maxDeg } = nodes.max((ele) => (ele as NodeSingular).degree(false));
-      if (maxDeg > 2 && nodes.length > 20) {
-        cy.animate({
-          center: { eles: mostConnected },
-          zoom: 1.2,
-          duration: 300,
-          easing: 'ease-out',
+    /* Use an organic layout in both modes; focus mode just fits the neighborhood
+       instead of forcing a zoomed center lock. */
+    const layout = centerId
+      ? cy.layout({
+          name: 'cose',
+          animate: true,
+          animationDuration: FOCUS_ANIMATION_DURATION,
+          nodeRepulsion: () => FOCUS_NODE_REPULSION,
+          idealEdgeLength: () => FOCUS_IDEAL_EDGE_LENGTH,
+          gravity: COSE_GRAVITY,
+          nodeDimensionsIncludeLabels: true,
+          fit: true,
+          padding: FIT_PADDING,
+          randomize: false,
+        })
+      : cy.layout({
+          name: 'cose',
+          animate: true,
+          animationDuration: COSE_ANIMATION_DURATION,
+          nodeRepulsion: () => COSE_NODE_REPULSION,
+          idealEdgeLength: () => COSE_IDEAL_EDGE_LENGTH,
+          gravity: COSE_GRAVITY,
+          nodeDimensionsIncludeLabels: true,
+          fit: true,
+          padding: FIT_PADDING,
         });
+    layout.on('layoutstop', () => {
+      const cy = cyRef.current;
+      if (!cy) return;
+
+      const nodes = cy.nodes();
+      const centerNode = cy.$('node.center');
+
+      if (centerNode.length > 0) {
+        const neighborhood = centerNode.closedNeighborhood();
+        cy.fit(neighborhood, FIT_PADDING * 1.5);
+        if (cy.zoom() > 1.05) {
+          cy.zoom(1.05);
+          cy.center(centerNode);
+        }
       } else {
-        cy.fit(undefined, FIT_PADDING);
+        // In global mode, center on the most-connected node or fit all
+        const { ele: mostConnected, value: maxDeg } = nodes.max((ele) => (ele as NodeSingular).degree(false));
+        if (maxDeg > 2 && nodes.length > 20) {
+          cy.animate({
+            center: { eles: mostConnected },
+            zoom: 1.2,
+            duration: 300,
+            easing: 'ease-out',
+          });
+        } else {
+          cy.fit(undefined, FIT_PADDING);
+        }
       }
     });
     layout.run();
@@ -385,7 +441,7 @@ export function useGraphCanvas({ nodes, edges, onNodeSelect }: UseGraphCanvasOpt
       cy.destroy();
       cyRef.current = null;
     };
-  }, [nodes, edges]);
+  }, [nodes, edges, centerId]);
 
   const resetView = useCallback(() => {
     const cy = cyRef.current;

--- a/packages/myco/ui/src/hooks/use-spores.ts
+++ b/packages/myco/ui/src/hooks/use-spores.ts
@@ -86,6 +86,11 @@ export interface GraphResponse {
   edges: GraphEdge[];
 }
 
+export interface GraphSeedResponse {
+  seeds: GraphNode[];
+  recommended_id: string | null;
+}
+
 export interface DigestTier {
   tier: number;
   content: string;
@@ -145,12 +150,12 @@ export function useEntities(options?: { mentioned_in?: string; note_type?: strin
   });
 }
 
-export function useGraph(entityId: string | undefined, depth: number = 1) {
+export function useGraph(entityId: string | undefined, depth: number = 1, enabled: boolean = true) {
   return useQuery<GraphResponse>({
     queryKey: ['graph', entityId, depth],
     queryFn: ({ signal }) =>
       fetchJson<GraphResponse>(`/graph/${entityId}?depth=${depth}`, { signal }),
-    enabled: entityId !== undefined,
+    enabled: enabled && entityId !== undefined,
     staleTime: GRAPH_STALE_TIME,
   });
 }
@@ -160,10 +165,19 @@ export interface FullGraphResponse {
   edges: GraphEdge[];
 }
 
-export function useFullGraph() {
+export function useFullGraph(enabled: boolean = true) {
   return useQuery<FullGraphResponse>({
     queryKey: ['full-graph'],
     queryFn: ({ signal }) => fetchJson<FullGraphResponse>('/graph', { signal }),
+    enabled,
+    staleTime: GRAPH_STALE_TIME,
+  });
+}
+
+export function useGraphSeeds() {
+  return useQuery<GraphSeedResponse>({
+    queryKey: ['graph-seeds'],
+    queryFn: ({ signal }) => fetchJson<GraphSeedResponse>('/graph/seeds', { signal }),
     staleTime: GRAPH_STALE_TIME,
   });
 }

--- a/packages/myco/ui/src/lib/graph-labels.ts
+++ b/packages/myco/ui/src/lib/graph-labels.ts
@@ -1,0 +1,11 @@
+const MARKDOWN_HEADING_PREFIX = /^#{1,6}\s+/;
+const MARKDOWN_EMPHASIS = /[*_`~]+/g;
+const COLLAPSE_WHITESPACE = /\s+/g;
+
+export function formatGraphLabel(value: string): string {
+  return value
+    .replace(MARKDOWN_HEADING_PREFIX, '')
+    .replace(MARKDOWN_EMPHASIS, '')
+    .replace(COLLAPSE_WHITESPACE, ' ')
+    .trim();
+}

--- a/packages/myco/ui/src/pages/Agent.tsx
+++ b/packages/myco/ui/src/pages/Agent.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Play } from 'lucide-react';
 import { Button } from '../components/ui/button';
 import { PageHeader } from '../components/ui/page-header';
@@ -58,6 +59,7 @@ const TABS: Tab[] = [
 /* ---------- Component ---------- */
 
 export default function Agent() {
+  const location = useLocation();
   const initial = readUrlState();
   const [tab, setTab] = useState<AgentTab>(initial.tab);
   const [selectedRunId, setSelectedRunId] = useState<string | undefined>(initial.runId);
@@ -73,18 +75,14 @@ export default function Agent() {
     writeUrlState(tab, selectedRunId, selectedTaskId);
   }, [tab, selectedRunId, selectedTaskId]);
 
-  // Restore state from URL on browser back/forward
+  // Sync state from URL when navigation updates search params.
   useEffect(() => {
-    function handlePopState() {
-      skipNextPush.current = true;
-      const state = readUrlState();
-      setTab(state.tab);
-      setSelectedRunId(state.runId);
-      setSelectedTaskId(state.taskId);
-    }
-    window.addEventListener('popstate', handlePopState);
-    return () => window.removeEventListener('popstate', handlePopState);
-  }, []);
+    skipNextPush.current = true;
+    const state = readUrlState();
+    setTab(state.tab);
+    setSelectedRunId(state.runId);
+    setSelectedTaskId(state.taskId);
+  }, [location.search, location.key]);
 
   const switchTab = useCallback((id: string) => {
     const t = id as AgentTab;

--- a/packages/myco/ui/src/pages/Mycelium.tsx
+++ b/packages/myco/ui/src/pages/Mycelium.tsx
@@ -1,23 +1,36 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { GraphCanvas } from '../components/mycelium/GraphCanvas';
-import { EntityFilter } from '../components/mycelium/EntityFilter';
 import { Inspector } from '../components/mycelium/Inspector';
 import { SporeList } from '../components/mycelium/SporeList';
 import { SporeDetail } from '../components/mycelium/SporeDetail';
 import { DigestView } from '../components/mycelium/DigestView';
 import { PageHeader } from '../components/ui/page-header';
-import { useFullGraph } from '../hooks/use-spores';
+import { Button } from '../components/ui/button';
+import { Input } from '../components/ui/input';
+import { useFullGraph, useGraph, useGraphSeeds } from '../hooks/use-spores';
+import { Network, Target, Info, Search } from 'lucide-react';
 import type { GraphNode } from '../hooks/use-graph-canvas';
 import type { SporeSummary } from '../hooks/use-spores';
 import type { Tab } from '../components/ui/tab-switcher';
+import { cn } from '../lib/cn';
+import { formatGraphLabel } from '../lib/graph-labels';
 
 /* ---------- Constants ---------- */
 
 const ALL_NODE_TYPES = new Set(['concept', 'component', 'bug', 'tool', 'file', 'spore', 'session', 'other']);
 
+/** Maximum nodes before suggesting focus mode */
+const LARGE_GRAPH_THRESHOLD = 200;
+
+const INSPECTOR_OFFSET_CLASS = 'right-[332px]';
+const SEARCH_MATCH_LIMIT = 6;
+const FOCUS_TRAIL_LIMIT = 3;
+const GRAPH_CANVAS_HEIGHT_CLASS = 'h-[calc(100vh-285px)]';
+
 /* ---------- Types ---------- */
 
 type ActiveTab = 'graph' | 'spores' | 'digest';
+type ViewMode = 'global' | 'focus';
 
 /** Tab definitions for the PageHeader TabSwitcher. */
 const MYCELIUM_TABS: Tab[] = [
@@ -59,48 +72,107 @@ function writeUrlState(tab: ActiveTab, sporeId?: string): void {
   window.history.pushState(null, '', url);
 }
 
+function extractGraphNodes(graphData: { center?: GraphNode; nodes?: GraphNode[] } | undefined): GraphNode[] {
+  if (!graphData) return [];
+
+  const nodes: GraphNode[] = [];
+  if ('center' in graphData && graphData.center) {
+    nodes.push(graphData.center);
+  }
+  if (graphData.nodes) {
+    nodes.push(...graphData.nodes);
+  }
+  return nodes;
+}
+
 /* ---------- Graph Tab ---------- */
 
 function GraphTab({ onNavigateToSpore }: { onNavigateToSpore?: (id: string) => void }) {
+  const [viewMode, setViewMode] = useState<ViewMode>('focus');
+  const [focusId, setFocusId] = useState<string | null>(null);
+  const [focusDepth, setFocusDepth] = useState<number>(2);
   const [enabledTypes, setEnabledTypes] = useState<Set<string>>(new Set(ALL_NODE_TYPES));
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
+  const [focusTrail, setFocusTrail] = useState<GraphNode[]>([]);
 
-  const { data: graphData } = useFullGraph();
+  const { data: seedData, isLoading: seedLoading } = useGraphSeeds();
+  const shouldFetchFocusGraph = viewMode === 'focus' && focusId !== null;
+  const shouldFetchFullGraph = viewMode === 'global';
+  const { data: fullGraphData, isLoading: fullGraphLoading } = useFullGraph(shouldFetchFullGraph || searchQuery.length > 0);
+  const { data: focusGraphData, isLoading: focusGraphLoading } = useGraph(
+    focusId ?? undefined,
+    focusDepth,
+    shouldFetchFocusGraph,
+  );
+  const shouldFetchInspectorGraph = selectedNode !== null && selectedNode.id !== focusId;
+  const { data: inspectorGraphData, isLoading: inspectorGraphLoading } = useGraph(
+    selectedNode?.id,
+    1,
+    shouldFetchInspectorGraph,
+  );
 
-  /* All nodes from the full graph */
-  const allGraphNodes = useMemo(() => {
-    return graphData?.nodes ?? [];
-  }, [graphData?.nodes]);
+  const graphData = viewMode === 'global' ? fullGraphData : focusGraphData;
+  const isLoading = viewMode === 'global'
+    ? fullGraphLoading
+    : seedLoading || (shouldFetchFocusGraph && focusGraphLoading);
+  const isLargeGraph = (fullGraphData?.nodes?.length ?? 0) > LARGE_GRAPH_THRESHOLD;
 
-  /* Build node type counts from graph data (all node types, not just entities) */
+  useEffect(() => {
+    if (!focusId && seedData?.recommended_id) {
+      const recommended = seedData.seeds.find((seed) => seed.id === seedData.recommended_id) ?? seedData.seeds[0];
+      if (recommended) {
+        setFocusId(recommended.id);
+        setSelectedNode(recommended);
+        setFocusTrail([recommended]);
+      }
+    }
+  }, [focusId, seedData]);
+
+  useEffect(() => {
+    if (viewMode === 'focus' && focusId && focusGraphData?.center?.id === focusId) {
+      setSelectedNode(focusGraphData.center);
+      setFocusTrail((prev) => {
+        if (prev.length === 0) return [focusGraphData.center];
+        const last = prev[prev.length - 1];
+        if (last?.id === focusGraphData.center.id) {
+          return [...prev.slice(0, -1), focusGraphData.center];
+        }
+        return prev;
+      });
+    }
+  }, [focusId, focusGraphData, viewMode]);
+
+  const inspectorNeighborhood = selectedNode?.id === focusId ? focusGraphData : inspectorGraphData;
+  const isInspectorLoading = selectedNode?.id === focusId ? focusGraphLoading : inspectorGraphLoading;
+  const inspectorNodes = useMemo(() => extractGraphNodes(inspectorNeighborhood), [inspectorNeighborhood]);
+  const inspectorEdges = inspectorNeighborhood?.edges ?? [];
+
+  const allGraphNodes = useMemo(() => extractGraphNodes(graphData), [graphData]);
+
   const nodeCounts = useMemo(() => {
     const counts: Record<string, number> = {};
-    for (const n of allGraphNodes) {
-      const type = n.type.toLowerCase();
+    for (const node of allGraphNodes) {
+      const type = node.type.toLowerCase();
       const bucket = ALL_NODE_TYPES.has(type) ? type : 'other';
       counts[bucket] = (counts[bucket] ?? 0) + 1;
     }
     return counts;
   }, [allGraphNodes]);
 
-  /* Filter nodes for the graph */
   const filteredNodes = useMemo(() => {
-    const lowerQuery = searchQuery.toLowerCase();
-    return allGraphNodes.filter((n) => {
-      const type = n.type.toLowerCase();
+    return allGraphNodes.filter((node) => {
+      const type = node.type.toLowerCase();
       const bucket = ALL_NODE_TYPES.has(type) ? type : 'other';
       if (!enabledTypes.has(bucket)) return false;
-      if (lowerQuery && !n.name.toLowerCase().includes(lowerQuery)) return false;
       return true;
     });
-  }, [allGraphNodes, enabledTypes, searchQuery]);
+  }, [allGraphNodes, enabledTypes]);
 
-  /* Edges filtered to only include visible nodes */
   const filteredEdges = useMemo(() => {
     const edges = graphData?.edges ?? [];
-    const visibleIds = new Set(filteredNodes.map((n) => n.id));
-    return edges.filter((e) => visibleIds.has(e.source_id) && visibleIds.has(e.target_id));
+    const visibleIds = new Set(filteredNodes.map((node) => node.id));
+    return edges.filter((edge) => visibleIds.has(edge.source_id) && visibleIds.has(edge.target_id));
   }, [graphData?.edges, filteredNodes]);
 
   const handleToggleType = useCallback((type: string) => {
@@ -115,36 +187,247 @@ function GraphTab({ onNavigateToSpore }: { onNavigateToSpore?: (id: string) => v
     });
   }, []);
 
-  const handleNodeSelect = useCallback((node: GraphNode | null) => {
+  const handleNodeSelect = useCallback((node: GraphNode | null, source: 'canvas' | 'inspector' = 'canvas') => {
     setSelectedNode(node);
+    if (!node) return;
+
+    if (viewMode === 'focus') {
+      setFocusId((prev) => {
+        if (prev === node.id) return prev;
+        setFocusTrail((trail) => {
+          const next = [...trail, node];
+          return next.slice(-FOCUS_TRAIL_LIMIT);
+        });
+        return node.id;
+      });
+      return;
+    }
+
+    if (source === 'inspector') {
+      setFocusId(node.id);
+      setViewMode('focus');
+    }
+  }, [viewMode]);
+
+  const handleShowOverview = useCallback(() => {
+    setViewMode('global');
   }, []);
 
+  const handleShowFocus = useCallback(() => {
+    if (!focusId && selectedNode) {
+      setFocusTrail([selectedNode]);
+      setFocusId(selectedNode.id);
+    }
+    setViewMode('focus');
+  }, [focusId, selectedNode]);
+
+  const handleTrailSelect = useCallback((trailNode: GraphNode) => {
+    setFocusTrail((trail) => {
+      const index = trail.findIndex((entry) => entry.id === trailNode.id);
+      return index >= 0 ? trail.slice(0, index + 1) : trail;
+    });
+    setFocusId(trailNode.id);
+    setSelectedNode(trailNode);
+    setViewMode('focus');
+  }, []);
+
+  const handleTrailBack = useCallback(() => {
+    setFocusTrail((trail) => {
+      if (trail.length <= 1) return trail;
+      const next = trail.slice(0, -1);
+      const previous = next[next.length - 1];
+      if (previous) {
+        setFocusId(previous.id);
+        setSelectedNode(previous);
+        setViewMode('focus');
+      }
+      return next;
+    });
+  }, []);
+
+  const searchCorpus = useMemo(() => {
+    const fullGraphNodes = fullGraphData?.nodes ?? [];
+    return fullGraphNodes.length > 0 ? fullGraphNodes : allGraphNodes;
+  }, [fullGraphData?.nodes, allGraphNodes]);
+  const searchMatches = searchQuery
+    ? searchCorpus
+        .filter((node, index, arr) => arr.findIndex((candidate) => candidate.id === node.id) === index)
+        .filter((node) => formatGraphLabel(node.name).toLowerCase().includes(searchQuery.toLowerCase()))
+        .slice(0, SEARCH_MATCH_LIMIT)
+    : [];
+
   return (
-    <div className="relative h-[calc(100vh-180px)]">
-      <GraphCanvas
-        nodes={filteredNodes}
-        edges={filteredEdges}
-        onNodeSelect={handleNodeSelect}
-        selectedNode={selectedNode}
-      />
-      <EntityFilter
-        entityCounts={nodeCounts}
-        enabledTypes={enabledTypes}
-        onToggleType={handleToggleType}
-        searchQuery={searchQuery}
-        onSearchChange={setSearchQuery}
-      />
+    <div className="space-y-3">
+      <div className="rounded-lg border border-outline-variant/20 bg-surface-container/72 px-4 py-3 shadow-sm">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="relative min-w-[260px] flex-1 max-w-[420px]">
+            <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-on-surface-variant/60" />
+            <Input
+              placeholder="Find a node or idea..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="h-9 pl-9"
+            />
+          </div>
+
+          <div className="flex rounded-lg border border-outline-variant/10 bg-surface-container-high p-1 shadow-sm">
+            <Button
+              variant="ghost"
+              size="sm"
+              className={cn(
+                'h-8 px-3 gap-1.5 transition-all',
+                viewMode === 'global' ? 'bg-surface-container-lowest text-primary shadow-sm' : 'text-on-surface-variant hover:text-on-surface',
+              )}
+              onClick={handleShowOverview}
+            >
+              <Network className="h-3.5 w-3.5" />
+              <span className="text-xs font-medium">Overview</span>
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={!focusId && !selectedNode}
+              className={cn(
+                'h-8 px-3 gap-1.5 transition-all',
+                viewMode === 'focus' ? 'bg-surface-container-lowest text-primary shadow-sm' : 'text-on-surface-variant hover:text-on-surface',
+                !focusId && !selectedNode && 'cursor-not-allowed opacity-50',
+              )}
+              onClick={handleShowFocus}
+            >
+              <Target className="h-3.5 w-3.5" />
+              <span className="text-xs font-medium">Focus</span>
+            </Button>
+          </div>
+
+          {viewMode === 'focus' && (
+            <div className="flex items-center gap-1 rounded-lg border border-outline-variant/10 bg-surface-container-high p-1 shadow-sm">
+              <span className="px-2 font-mono text-[10px] uppercase tracking-wider text-on-surface-variant">Depth</span>
+              {[1, 2, 3].map((depth) => (
+                <Button
+                  key={depth}
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    'h-7 min-w-7 rounded-md border px-2 font-mono text-[10px] transition-all',
+                    focusDepth === depth
+                      ? 'border-primary/40 bg-primary/15 text-primary shadow-sm font-bold'
+                      : 'border-transparent text-on-surface-variant hover:border-outline-variant/20 hover:text-on-surface',
+                  )}
+                  onClick={() => setFocusDepth(depth)}
+                >
+                  {depth}
+                </Button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {searchMatches.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-2 pt-1">
+            <span className="text-[11px] uppercase tracking-[0.16em] text-on-surface-variant">Jump To</span>
+            {searchMatches.map((match) => (
+              <button
+                key={match.id}
+                type="button"
+                onClick={() => handleNodeSelect(match, 'inspector')}
+                className={cn(
+                  'max-w-[220px] truncate rounded-full border px-3 py-1 text-[11px] transition-colors',
+                  selectedNode?.id === match.id
+                    ? 'border-primary/40 bg-primary/10 text-on-surface'
+                    : 'border-outline-variant/20 bg-surface-container-low/50 text-on-surface-variant hover:text-on-surface',
+                )}
+                title={formatGraphLabel(match.name)}
+              >
+                {formatGraphLabel(match.name)}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {searchQuery && searchMatches.length === 0 && fullGraphData && (
+          <div className="mt-3 border-t border-outline-variant/10 pt-3 text-sm text-on-surface-variant">
+            No graph nodes matched `"{searchQuery}"`.
+          </div>
+        )}
+
+        {focusTrail.length > 0 && (
+          <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-outline-variant/10 pt-3">
+            <span className="text-[11px] uppercase tracking-[0.16em] text-on-surface-variant">Trail</span>
+            {focusTrail.length > 1 && (
+              <Button variant="ghost" size="sm" className="h-7 shrink-0 px-2 text-[10px]" onClick={handleTrailBack}>
+                Back
+              </Button>
+            )}
+            {focusTrail.map((trailNode) => (
+              <button
+                key={trailNode.id}
+                type="button"
+                onClick={() => handleTrailSelect(trailNode)}
+                className={cn(
+                  'max-w-[180px] truncate rounded-full border px-3 py-1 text-[11px] transition-colors',
+                  focusId === trailNode.id ? 'border-primary/40 bg-primary/10 text-on-surface' : 'border-outline-variant/20 bg-surface-container-low/50 text-on-surface-variant hover:text-on-surface',
+                )}
+                title={formatGraphLabel(trailNode.name)}
+              >
+                {formatGraphLabel(trailNode.name)}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className={cn('relative', GRAPH_CANVAS_HEIGHT_CLASS)}>
+        {isLoading && (
+        <div className="absolute inset-0 z-30 flex items-center justify-center rounded-md bg-surface-container-lowest/50 backdrop-blur-[2px] transition-opacity">
+          <div className="flex flex-col items-center gap-3">
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            <span className="text-xs font-mono animate-pulse text-on-surface-variant">
+              Cultivating {viewMode} graph...
+            </span>
+          </div>
+        </div>
+      )}
+
+      <div className={cn('absolute inset-y-3 left-3', selectedNode ? INSPECTOR_OFFSET_CLASS : 'right-3')}>
+        <GraphCanvas
+          nodes={filteredNodes}
+          edges={filteredEdges}
+          onNodeSelect={handleNodeSelect}
+          selectedNode={selectedNode}
+          centerId={viewMode === 'focus' ? focusId : null}
+          isLoading={isLoading}
+        />
+      </div>
+
+      {viewMode === 'global' && isLargeGraph && (
+        <div className={cn('absolute bottom-3 left-3 z-10 flex max-w-[280px] flex-col items-start gap-2 rounded-lg border border-warning/20 bg-warning-container/80 p-3 text-on-warning-container shadow-lg backdrop-blur-sm', selectedNode ? INSPECTOR_OFFSET_CLASS : 'right-3')}>
+          <div className="flex items-center gap-2">
+            <Info className="h-4 w-4 shrink-0 text-warning" />
+            <span className="text-[11px] font-semibold uppercase tracking-wider">Overview Snapshot</span>
+          </div>
+          <p className="text-[11px] leading-relaxed text-on-warning-container/80">
+            This overview still contains {fullGraphData?.nodes?.length} nodes. Use Focus mode for navigation and step through connections from the drawer.
+          </p>
+          <Button variant="destructive" size="sm" className="mt-1 h-7 w-full px-3 text-[10px]" onClick={handleShowFocus}>
+            Return to Focus
+          </Button>
+        </div>
+      )}
+
       <Inspector
         node={selectedNode}
-        edges={filteredEdges}
-        nodes={filteredNodes}
+        edges={inspectorEdges}
+        nodes={inspectorNodes}
         onClose={() => setSelectedNode(null)}
-        onNodeSelect={(n) => setSelectedNode(n)}
+        onNodeSelect={handleNodeSelect}
         onNavigateToSpore={onNavigateToSpore}
+        isConnectionsLoading={isInspectorLoading}
       />
+      </div>
     </div>
   );
 }
+
 
 /* ---------- Component ---------- */
 

--- a/packages/myco/ui/src/pages/Mycelium.tsx
+++ b/packages/myco/ui/src/pages/Mycelium.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import { GraphCanvas } from '../components/mycelium/GraphCanvas';
 import { Inspector } from '../components/mycelium/Inspector';
 import { SporeList } from '../components/mycelium/SporeList';
@@ -432,6 +433,7 @@ function GraphTab({ onNavigateToSpore }: { onNavigateToSpore?: (id: string) => v
 /* ---------- Component ---------- */
 
 export default function Mycelium() {
+  const location = useLocation();
   const initial = readUrlState();
   const [activeTab, setActiveTab] = useState<ActiveTab>(initial.tab);
   const [selectedSpore, setSelectedSpore] = useState<SporeSummary | null>(
@@ -447,17 +449,13 @@ export default function Mycelium() {
     writeUrlState(activeTab, selectedSpore?.id);
   }, [activeTab, selectedSpore?.id]);
 
-  // Restore state from URL on browser back/forward
+  // Sync state from URL when navigation updates search params.
   useEffect(() => {
-    function handlePopState() {
-      skipNextPush.current = true;
-      const state = readUrlState();
-      setActiveTab(state.tab);
-      setSelectedSpore(state.sporeId ? { id: state.sporeId } as SporeSummary : null);
-    }
-    window.addEventListener('popstate', handlePopState);
-    return () => window.removeEventListener('popstate', handlePopState);
-  }, []);
+    skipNextPush.current = true;
+    const state = readUrlState();
+    setActiveTab(state.tab);
+    setSelectedSpore(state.sporeId ? { id: state.sporeId } as SporeSummary : null);
+  }, [location.search, location.key]);
 
   function handleSelectSpore(spore: SporeSummary) {
     setSelectedSpore(spore);

--- a/packages/myco/ui/src/pages/Skills.tsx
+++ b/packages/myco/ui/src/pages/Skills.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { HelpCircle, ExternalLink } from 'lucide-react';
 import { PageHeader } from '../components/ui/page-header';
 import type { Tab } from '../components/ui/tab-switcher';
@@ -132,6 +132,7 @@ function SkillsHelpDialog() {
 /* ---------- Component ---------- */
 
 export default function Skills() {
+  const location = useLocation();
   const initial = readUrlState();
   const [tab, setTab] = useState<SkillsTab>(initial.tab);
   const [selectedSkill, setSelectedSkill] = useState<string | undefined>(initial.skill);
@@ -145,6 +146,12 @@ export default function Skills() {
   useEffect(() => {
     writeUrlState(tab, selectedSkill);
   }, [tab, selectedSkill]);
+
+  useEffect(() => {
+    const state = readUrlState();
+    setTab(state.tab);
+    setSelectedSkill(state.skill);
+  }, [location.search, location.key]);
 
   const switchTab = useCallback((id: string) => {
     const t = id as SkillsTab;

--- a/tests/config/schema.test.ts
+++ b/tests/config/schema.test.ts
@@ -49,6 +49,7 @@ describe('MycoConfigSchema v3', () => {
     expect(config.capture.buffer_max_events).toBe(500);
     expect(config.daemon.log_level).toBe('info');
     expect(config.daemon.port).toBeNull();
+    expect(config.notifications.default_mode).toBe('summary');
   });
 
   it('accepts custom capture config', () => {

--- a/tests/daemon/api/mycelium.test.ts
+++ b/tests/daemon/api/mycelium.test.ts
@@ -1,0 +1,116 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { registerAgent } from '@myco/db/queries/agents';
+import { insertEntity } from '@myco/db/queries/entities';
+import { insertGraphEdge } from '@myco/db/queries/graph-edges';
+import { upsertSession } from '@myco/db/queries/sessions';
+import { insertSpore } from '@myco/db/queries/spores';
+import { getDatabase } from '@myco/db/client';
+import { DEFAULT_AGENT_ID } from '@myco/constants';
+import { handleGetGraph, handleGetGraphSeeds } from '@myco/daemon/api/mycelium';
+import type { RouteRequest } from '@myco/daemon/router';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
+
+const NOW = Math.floor(Date.now() / 1000);
+
+function makeReq(pathname: string, params: Record<string, string> = {}, query: Record<string, string> = {}): RouteRequest {
+  return { pathname, params, query, body: undefined };
+}
+
+describe('mycelium API handlers', () => {
+  beforeAll(() => {
+    setupTestDb();
+    registerAgent({ id: DEFAULT_AGENT_ID, name: 'myco-agent', created_at: NOW });
+  });
+
+  afterAll(() => {
+    teardownTestDb();
+  });
+
+  beforeEach(() => {
+    cleanTestDb();
+    registerAgent({ id: DEFAULT_AGENT_ID, name: 'myco-agent', created_at: NOW });
+  });
+
+  it('returns lightweight graph seeds with a recommended node', async () => {
+    insertEntity({
+      id: 'entity-1',
+      agent_id: DEFAULT_AGENT_ID,
+      type: 'concept',
+      name: 'Focused Explorer',
+      first_seen: NOW - 100,
+      last_seen: NOW - 10,
+    });
+    getDatabase().prepare('INSERT INTO entity_mentions (entity_id, note_id, note_type, agent_id) VALUES (?, ?, ?, ?)').run(
+      'entity-1',
+      'spore-1',
+      'spore',
+      DEFAULT_AGENT_ID,
+    );
+    upsertSession({
+      id: 'sess-1',
+      agent: 'claude-code',
+      created_at: NOW - 20,
+      started_at: NOW - 20,
+      ended_at: NOW - 5,
+      status: 'completed',
+      title: 'Graph redesign',
+      summary: 'Worked on the focused explorer flow.',
+    });
+    insertSpore({
+      id: 'spore-1',
+      agent_id: DEFAULT_AGENT_ID,
+      observation_type: 'discovery',
+      content: 'Focused graph startup should not require loading the full graph first.',
+      created_at: NOW - 1,
+      status: 'active',
+    });
+
+    const result = await handleGetGraphSeeds(makeReq('/graph/seeds'));
+    const body = result.body as { seeds: Array<{ id: string; type: string }>; recommended_id: string | null };
+
+    expect(body.seeds.length).toBeGreaterThan(0);
+    expect(body.recommended_id).toBe(body.seeds[0]?.id ?? null);
+    expect(body.seeds.map((seed) => seed.type)).toEqual(expect.arrayContaining(['spore', 'session', 'concept']));
+  });
+
+  it('returns a centered session neighborhood for focused graph requests', async () => {
+    upsertSession({
+      id: 'sess-graph',
+      agent: 'claude-code',
+      created_at: NOW - 30,
+      started_at: NOW - 30,
+      ended_at: NOW - 10,
+      status: 'completed',
+      title: 'Session center',
+      summary: 'Centered graph test.',
+    });
+    insertEntity({
+      id: 'entity-graph',
+      agent_id: DEFAULT_AGENT_ID,
+      type: 'component',
+      name: 'Mycelium graph',
+      first_seen: NOW - 40,
+      last_seen: NOW - 10,
+    });
+    insertGraphEdge({
+      agent_id: DEFAULT_AGENT_ID,
+      source_id: 'sess-graph',
+      source_type: 'session',
+      target_id: 'entity-graph',
+      target_type: 'entity',
+      type: 'RELATES_TO',
+      created_at: NOW - 5,
+    });
+
+    const result = await handleGetGraph(makeReq('/graph/sess-graph', { id: 'sess-graph' }, { depth: '1' }));
+    const body = result.body as {
+      center: { id: string; type: string; name: string };
+      nodes: Array<{ id: string; type: string }>;
+      edges: Array<{ source_id: string; target_id: string; label: string }>;
+    };
+
+    expect(body.center).toMatchObject({ id: 'sess-graph', type: 'session', name: 'Session center' });
+    expect(body.nodes).toEqual(expect.arrayContaining([expect.objectContaining({ id: 'entity-graph', type: 'component' })]));
+    expect(body.edges).toEqual(expect.arrayContaining([expect.objectContaining({ source_id: 'sess-graph', target_id: 'entity-graph', label: 'RELATES_TO' })]));
+  });
+});

--- a/tests/notifications/notify.test.ts
+++ b/tests/notifications/notify.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { initDatabase, closeDatabase } from '@myco/db/client';
+import { createSchema } from '@myco/db/schema';
+import { getNotification } from '@myco/db/queries/notifications';
+import { registerBuiltinDomains } from '@myco/notifications/domains';
+import { notify } from '@myco/notifications/notify';
+import { clearAll } from '@myco/notifications/registry';
+
+describe('notify', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-notify-'));
+    const db = initDatabase(path.join(tmpDir, 'index.db'));
+    createSchema(db);
+    clearAll();
+    registerBuiltinDomains();
+  });
+
+  afterEach(() => {
+    clearAll();
+    closeDatabase();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('respects the global summary default over registry defaults', () => {
+    fs.writeFileSync(path.join(tmpDir, 'myco.yaml'), 'version: 3\nnotifications:\n  default_mode: summary\n');
+
+    const id = notify(tmpDir, {
+      domain: 'agents',
+      type: 'agent.task.success',
+      title: 'Task completed: skill-survey',
+    });
+
+    expect(id).toBeTruthy();
+    expect(getNotification(id!)).toMatchObject({
+      domain: 'agents',
+      type: 'agent.task.success',
+      mode: 'summary',
+    });
+  });
+
+  it('still allows an explicit domain override to force banner mode', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'myco.yaml'),
+      [
+        'version: 3',
+        'notifications:',
+        '  default_mode: summary',
+        '  domains:',
+        '    agents:',
+        '      enabled: true',
+        '      mode: banner',
+        '',
+      ].join('\n'),
+    );
+
+    const id = notify(tmpDir, {
+      domain: 'agents',
+      type: 'agent.task.failure',
+      title: 'Task failed: skill-survey',
+    });
+
+    expect(id).toBeTruthy();
+    expect(getNotification(id!)).toMatchObject({
+      domain: 'agents',
+      type: 'agent.task.failure',
+      mode: 'banner',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- fix notification mode handling so summary-only settings stop producing banner/system popups and agent run failures surface correctly
- simplify the notification settings/panel UX and remove duplicate embedding configuration from Agent config
- redesign Mycelium around a focused graph explorer with jump-to search, cleaner inspector rendering, and improved graph navigation/layout
