### PR TITLE
Migrate Settings UI to patch-style config writes

### DIFF
--- a/packages/myco/src/daemon/api/config.ts
+++ b/packages/myco/src/daemon/api/config.ts
@@ -17,20 +17,6 @@ export async function handleGetConfig(vaultDir: string): Promise<RouteResponse> 
   return { body: config };
 }
 
-export async function handlePutConfig(vaultDir: string, body: unknown): Promise<RouteResponse> {
-  const result = MycoConfigSchema.safeParse(body);
-  if (!result.success) {
-    return {
-      status: 400,
-      body: { error: 'validation_failed', issues: result.error.issues },
-    };
-  }
-  const updated = updateConfig(vaultDir, (current) =>
-    deepMergeConfig(current as Record<string, unknown>, result.data as Record<string, unknown>) as MycoConfig,
-  );
-  return { body: updated };
-}
-
 // ---------------------------------------------------------------------------
 // Scoped config handlers (project vs. local overlay)
 // ---------------------------------------------------------------------------
@@ -49,39 +35,35 @@ export async function handleGetLocalConfig(vaultDir: string): Promise<RouteRespo
 interface ScopedPutBody {
   scope?: 'project' | 'local';
   patch?: Record<string, unknown>;
-  config?: unknown; // legacy full-config body (scope='project' only)
 }
 
-/** PUT /api/config/scoped — scope-aware write (project patch, project full-config, or local patch). */
+/** PUT /api/config/scoped — deep-merge a partial patch into project or local config. */
 export async function handlePutScopedConfig(vaultDir: string, body: unknown): Promise<RouteResponse> {
   const payload = (body ?? {}) as ScopedPutBody;
   const scope = payload.scope ?? 'project';
   const patch = payload.patch;
 
+  if (!patch || typeof patch !== 'object') {
+    return { status: 400, body: { error: 'patch required' } };
+  }
+
   if (scope === 'local') {
-    if (!patch || typeof patch !== 'object') {
-      return { status: 400, body: { error: 'patch required for scope=local' } };
-    }
     const updated = saveLocalConfig(vaultDir, patch as Partial<MycoConfig>);
     return { body: updated };
   }
 
-  if (patch && typeof patch === 'object') {
-    try {
-      const updated = updateConfig(vaultDir, (current) => {
-        const merged = deepMergeConfig(current as Record<string, unknown>, patch as Record<string, unknown>);
-        return MycoConfigSchema.parse(merged);
-      });
-      return { body: updated };
-    } catch (err) {
-      if (err instanceof z.ZodError) {
-        return { status: 400, body: { error: 'validation_failed', issues: err.issues } };
-      }
-      throw err;
+  try {
+    const updated = updateConfig(vaultDir, (current) => {
+      const merged = deepMergeConfig(current as Record<string, unknown>, patch as Record<string, unknown>);
+      return MycoConfigSchema.parse(merged);
+    });
+    return { body: updated };
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return { status: 400, body: { error: 'validation_failed', issues: err.issues } };
     }
+    throw err;
   }
-  // Legacy full-config body
-  return handlePutConfig(vaultDir, payload.config ?? body);
 }
 
 interface ClearLocalBody { keys?: string[]; }

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -21,7 +21,6 @@ import { loadManifests } from '../symbionts/detect.js';
 import type { PlanWatchConfig } from './plan-capture.js';
 import {
   handleGetConfig,
-  handlePutConfig,
   handleGetMergedConfig,
   handleGetLocalConfig,
   handlePutScopedConfig,
@@ -504,14 +503,6 @@ export async function main(): Promise<void> {
 
   server.registerRoute('GET', '/api/config', async () => handleGetConfig(vaultDir));
   server.registerRoute('GET', '/api/symbionts', async () => handleListSymbionts(vaultDir));
-  server.registerRoute('PUT', '/api/config', async (req) => {
-    const result = await handlePutConfig(vaultDir, req.body);
-    if (!result.status || result.status < 400) {
-      reconcileConfiguredSymbionts(path.dirname(vaultDir), vaultDir);
-      configHash = computeConfigHash(vaultDir);
-    }
-    return result;
-  });
 
   server.registerRoute('GET', '/api/config/merged', async () => handleGetMergedConfig(vaultDir));
   server.registerRoute('GET', '/api/config/local', async () => handleGetLocalConfig(vaultDir));

--- a/packages/myco/ui/src/components/agent/AgentConfig.tsx
+++ b/packages/myco/ui/src/components/agent/AgentConfig.tsx
@@ -204,16 +204,13 @@ export function AgentConfig() {
     if (!form || !config) return;
     setSaveMessage(null);
     try {
-      const updated: MycoConfig = {
-        ...config,
+      await saveConfig({
         agent: {
-          ...config.agent,
           summary_batch_interval: parseNumericField(form.summaryBatchInterval, DEFAULT_SUMMARY_BATCH_INTERVAL),
           scheduled_tasks_enabled: form.scheduledTasksEnabled,
           event_tasks_enabled: form.eventTasksEnabled,
         },
-      };
-      await saveConfig(updated);
+      });
       setSaveMessage({ type: 'success', text: 'Agent settings saved. Restarting daemon...' });
       try {
         await restart();

--- a/packages/myco/ui/src/components/notifications/NotificationSettings.tsx
+++ b/packages/myco/ui/src/components/notifications/NotificationSettings.tsx
@@ -84,10 +84,7 @@ export function NotificationSettings() {
     if (!form || !config) return;
     setSaveMessage(null);
     try {
-      await saveConfig({
-        ...config,
-        notifications: form,
-      });
+      await saveConfig({ notifications: form });
       setSaveMessage({ type: 'success', text: 'Notification settings saved.' });
     } catch {
       setSaveMessage({ type: 'error', text: 'Failed to save notification settings.' });

--- a/packages/myco/ui/src/hooks/use-config.ts
+++ b/packages/myco/ui/src/hooks/use-config.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { fetchJson, putJson } from '../lib/api';
+import { fetchJson, writeScopedConfig } from '../lib/api';
 
 export interface MycoConfig {
   version: 3;
@@ -28,7 +28,6 @@ export interface MycoConfig {
     summary_batch_interval: number;
     scheduled_tasks_enabled?: boolean;
     event_tasks_enabled?: boolean;
-    /** Fields below are set via Agent Tasks page, not Settings — preserve on save. */
     provider?: { type: string; base_url?: string; model?: string; context_length?: number };
     model?: string;
     tasks?: Record<string, unknown>;
@@ -37,7 +36,6 @@ export interface MycoConfig {
     digest_tier: number;
     prompt_search: boolean;
     prompt_max_spores: number;
-    /** Extensible — preserve unknown fields on save. */
     [key: string]: unknown;
   };
   notifications: {
@@ -48,6 +46,13 @@ export interface MycoConfig {
   };
 }
 
+/** Recursive partial — lets each caller send only the sections (and nested fields) it owns. */
+export type MycoConfigPatch = {
+  [K in keyof MycoConfig]?: MycoConfig[K] extends Record<string, unknown>
+    ? Partial<MycoConfig[K]>
+    : MycoConfig[K];
+};
+
 export function useConfig() {
   const queryClient = useQueryClient();
 
@@ -57,7 +62,8 @@ export function useConfig() {
   });
 
   const mutation = useMutation({
-    mutationFn: (config: MycoConfig) => putJson<MycoConfig>('/config', config),
+    mutationFn: (patch: MycoConfigPatch) =>
+      writeScopedConfig('project', patch as Record<string, unknown>) as Promise<MycoConfig>,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['config'] }),
   });
 

--- a/packages/myco/ui/src/pages/Operations.tsx
+++ b/packages/myco/ui/src/pages/Operations.tsx
@@ -260,13 +260,7 @@ function ScheduledMaintenanceCard({
 
   async function persist(next: { auto_optimize?: boolean; auto_optimize_interval_hours?: number }) {
     try {
-      await saveConfig({
-        ...config!,
-        maintenance: {
-          ...config!.maintenance,
-          ...next,
-        },
-      });
+      await saveConfig({ maintenance: next });
     } catch (err) {
       onActionResult({ type: 'error', text: 'Config save failed: ' + (err as Error).message });
     }

--- a/packages/myco/ui/src/pages/Settings.tsx
+++ b/packages/myco/ui/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, useMemo, useEffect } from 'react';
 import { CheckCircle, XCircle, Loader2 } from 'lucide-react';
-import { useConfig, type MycoConfig } from '../hooks/use-config';
+import { useConfig, type MycoConfig, type MycoConfigPatch } from '../hooks/use-config';
 import { useDaemon } from '../hooks/use-daemon';
 import { useRestart } from '../hooks/use-restart';
 import { useProviders, useTestProvider } from '../hooks/use-providers';
@@ -78,17 +78,16 @@ function toFormState(config: MycoConfig): FormState {
   };
 }
 
-/* ---------- Per-section config builders ---------- */
+/* ---------- Per-section patch builders ---------- */
 //
-// Each section's save button writes only its own slice of the config.
-// All branches preserve unrelated sections via `...original` spread,
-// letting users save sections independently without committing
-// half-finished edits elsewhere on the page.
+// Each section's save button emits a patch containing only its own slice.
+// The server deep-merges the patch into the current config, so unrelated
+// sections are preserved without the UI needing to know about them.
 
-/** Build an agent-section update with auto-enable/disable side effects on the
+/** Build an agent-section patch with auto-enable/disable side effects on the
  *  task toggles. Configuring a provider for the first time turns the agent
  *  pipeline on; clearing the provider turns it off. */
-function buildAgentSection(form: FormState, original: MycoConfig): MycoConfig {
+function buildAgentPatch(form: FormState, original: MycoConfig): MycoConfigPatch {
   const hadProvider = !!original.agent?.provider;
   const hasProvider = form.agentProviderType !== '';
 
@@ -112,9 +111,7 @@ function buildAgentSection(form: FormState, original: MycoConfig): MycoConfig {
   }
 
   return {
-    ...original,
     agent: {
-      ...original.agent,
       provider: agentProvider,
       model: undefined,
       scheduled_tasks_enabled: scheduledEnabled,
@@ -123,15 +120,13 @@ function buildAgentSection(form: FormState, original: MycoConfig): MycoConfig {
   };
 }
 
-function buildSectionUpdate(section: SaveSection, form: FormState, original: MycoConfig): MycoConfig {
+function buildSectionPatch(section: SaveSection, form: FormState, original: MycoConfig): MycoConfigPatch {
   switch (section) {
     case 'agent':
-      return buildAgentSection(form, original);
+      return buildAgentPatch(form, original);
     case 'embedding':
       return {
-        ...original,
         embedding: {
-          ...original.embedding,
           provider: form.embeddingProvider,
           model: form.embeddingModel,
           base_url: form.embeddingBaseUrl !== '' ? form.embeddingBaseUrl : undefined,
@@ -139,9 +134,7 @@ function buildSectionUpdate(section: SaveSection, form: FormState, original: Myc
       };
     case 'context':
       return {
-        ...original,
         context: {
-          ...original.context,
           digest_tier: parseNumericField(form.contextDigestTier, DEFAULT_DIGEST_TIER),
           prompt_search: form.contextPromptSearch,
           prompt_max_spores: parseNumericField(form.contextMaxSpores, DEFAULT_MAX_SPORES),
@@ -149,9 +142,7 @@ function buildSectionUpdate(section: SaveSection, form: FormState, original: Myc
       };
     case 'project':
       return {
-        ...original,
         daemon: {
-          ...original.daemon,
           port: form.daemonPort !== '' ? Number(form.daemonPort) : null,
           log_level: form.logLevel,
           log_retention_days: Number(form.logRetentionDays),
@@ -288,7 +279,7 @@ export default function Settings() {
     if (!form || !config) return;
     setSaveMessage(null);
     try {
-      await saveConfig(buildSectionUpdate(section, form, config));
+      await saveConfig(buildSectionPatch(section, form, config));
       setSaveMessage({ section, type: 'success', text: 'Saved. Restarting daemon...' });
       try {
         await restart();

--- a/tests/daemon/api/config-scope.test.ts
+++ b/tests/daemon/api/config-scope.test.ts
@@ -52,13 +52,9 @@ describe('scoped config HTTP handlers', () => {
     expect(Array.isArray((res.body as any).issues)).toBe(true);
   });
 
-  it('PUT /scoped scope=project without patch falls back to full-config path', async () => {
-    await handlePutScopedConfig(tmpDir, {
-      scope: 'project',
-      config: { version: 3, embedding: { provider: 'ollama', model: 'bge-m3' }, appearance: { theme: 'dusk', mode: 'dark', font: 'default', density: 'normal' } },
-    });
-    const project = fs.readFileSync(path.join(tmpDir, 'myco.yaml'), 'utf-8');
-    expect(project).toContain('theme: dusk');
+  it('PUT /scoped scope=project without patch returns 400', async () => {
+    const res = await handlePutScopedConfig(tmpDir, { scope: 'project' });
+    expect(res.status).toBe(400);
   });
 
   it('POST /local/clear removes specified keys', async () => {

--- a/tests/daemon/api/config.test.ts
+++ b/tests/daemon/api/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { createPlanDirHandlers, handleGetConfig, handlePutConfig } from '@myco/daemon/api/config';
+import { createPlanDirHandlers, handleGetConfig, handlePutScopedConfig } from '@myco/daemon/api/config';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -23,21 +23,46 @@ describe('config API', () => {
     expect(result.body).toHaveProperty('version', 3);
   });
 
-  it('PUT validates and saves config', async () => {
-    const newConfig = {
-      version: 3,
-      embedding: { provider: 'ollama', model: 'nomic-embed-text' },
-      capture: { ignore_plan_dirs_in_git: true },
-    };
-    const result = await handlePutConfig(vaultDir, newConfig);
+  it('PUT scoped patch merges and saves config', async () => {
+    const result = await handlePutScopedConfig(vaultDir, {
+      scope: 'project',
+      patch: {
+        embedding: { provider: 'ollama', model: 'nomic-embed-text' },
+        capture: { ignore_plan_dirs_in_git: true },
+      },
+    });
     expect(result.status).toBeUndefined(); // 200 default
-    const saved = YAML.parse(fs.readFileSync(path.join(vaultDir, 'myco.yaml'), 'utf-8')) as { capture?: { ignore_plan_dirs_in_git?: boolean } };
+    const saved = YAML.parse(fs.readFileSync(path.join(vaultDir, 'myco.yaml'), 'utf-8')) as {
+      embedding?: { model?: string };
+      capture?: { ignore_plan_dirs_in_git?: boolean };
+    };
+    expect(saved.embedding?.model).toBe('nomic-embed-text');
     expect(saved.capture?.ignore_plan_dirs_in_git).toBe(true);
   });
 
-  it('PUT returns 400 for invalid config', async () => {
-    const invalid = { version: 3, embedding: { provider: 'invalid-provider' } };
-    const result = await handlePutConfig(vaultDir, invalid);
+  it('PUT scoped patch preserves unrelated sections', async () => {
+    await handlePutScopedConfig(vaultDir, {
+      scope: 'project',
+      patch: { daemon: { log_level: 'debug' } },
+    });
+    const saved = YAML.parse(fs.readFileSync(path.join(vaultDir, 'myco.yaml'), 'utf-8')) as {
+      embedding?: { model?: string };
+      daemon?: { log_level?: string };
+    };
+    expect(saved.embedding?.model).toBe('bge-m3');
+    expect(saved.daemon?.log_level).toBe('debug');
+  });
+
+  it('PUT scoped returns 400 for missing patch', async () => {
+    const result = await handlePutScopedConfig(vaultDir, { scope: 'project' });
+    expect(result.status).toBe(400);
+  });
+
+  it('PUT scoped returns 400 for schema-invalid patch', async () => {
+    const result = await handlePutScopedConfig(vaultDir, {
+      scope: 'project',
+      patch: { embedding: { provider: 'invalid-provider' } },
+    });
     expect(result.status).toBe(400);
   });
 


### PR DESCRIPTION
## Summary
- All four Settings-UI callers (`Settings.tsx`, `Operations.tsx`, `AgentConfig.tsx`, `NotificationSettings.tsx`) now send only the changed section as a partial patch via `PUT /api/config/scoped`. The server-side deep-merge preserves every other section, so the UI no longer needs to know about sections it doesn't own.
- Retires the legacy full-config write path: `PUT /api/config` route, `handlePutConfig`, and the full-config fallback branch in `handlePutScopedConfig`.
- `useConfig().saveConfig` now accepts a `MycoConfigPatch` (recursive partial) instead of the full `MycoConfig`.

## Why
The full-config PUT was a foot-gun: the UI had to reconstruct the whole config from a single page's view, and the server's `mergeConfigSections` had to be updated for every new section to prevent clobbering. With patch writes the merge happens server-side on the authoritative config, so new sections "just work" and no client has to spread `...original` defensively.

Follows the `safe-config-updates` skill: one YAML write gate (`updateConfig`), deep-merge at every level, no reconstruction from partial view.

## Test plan
- [x] `make build` passes (tsc + vitest + tsup + vite)
- [x] `tests/daemon/api/config.test.ts` migrated to `handlePutScopedConfig` and passes
- [x] `tests/daemon/api/config-scope.test.ts` updated for removed fallback path and passes
- [ ] Manual: open each Settings card (Agent, Embedding, Context, Project, Notifications, Maintenance in Operations), save a change, inspect \`myco.yaml\` — verify the changed field updated and untouched sections are intact
- [ ] Manual: clear the agent provider from Settings and verify the \`scheduled_tasks_enabled\` auto-flip still fires
- [ ] Manual: theme/appearance local-scope writes still work (already used \`writeScopedConfig\`, just regression-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)