### PR TITLE
Scoped-settings UX: per-field Personal pill + write-on-change

### DIFF
--- a/.agents/skills/author-harness-task/SKILL.md
+++ b/.agents/skills/author-harness-task/SKILL.md
@@ -1,0 +1,403 @@
+---
+name: myco:author-harness-task
+description: |
+  Use this skill when designing, writing, configuring, or debugging a new phased
+  executor task for the Myco agent harness — even if the user doesn't explicitly
+  ask for a "task authoring" guide. Applies when adding a new intelligence task,
+  modifying phase structure, tuning turn budgets or model routing, adjusting
+  scheduling triggers or session-gating, designing a tool surface, or debugging
+  silent phase failures or budget exhaustion. Covers: YAML task anatomy and
+  registration; phase decomposition and the judgment/recipe gradient; model
+  selection via the advisor pattern; turn budget calibration including
+  local-model multipliers; scheduling triggers and session-gating; tool surface
+  design and readOnly enforcement; and observability via the agent_runs audit
+  table.
+managed_by: myco
+user-invocable: true
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+# Myco Agent Harness Task Authoring
+
+The Myco agent harness is a phased executor running inside the daemon. Each
+task is an ordered sequence of phases — each phase is a single LLM invocation
+with a bounded tool surface and a turn budget. This skill covers the full
+authoring lifecycle: designing the phase sequence, writing the task config,
+selecting models, calibrating budgets, configuring triggers, designing tool
+surfaces, and debugging when things go wrong.
+
+## Prerequisites
+
+- Daemon is running and `agent.enabled: true` in `myco.yaml`.
+- You have read at least one existing task (`src/agent/tasks/full-intelligence.ts`
+  or `src/agent/tasks/skill-survey.ts`) to understand the config shape.
+- You can describe the new task's purpose in one sentence and identify which
+  vault state it reads and writes.
+
+---
+
+## Procedure 1: Design the Phase Sequence
+
+Sketch the phases on paper before writing any code.
+
+### Apply the judgment/recipe gradient
+
+Every phase sits on a spectrum from pure-recipe to pure-judgment:
+
+| Pole | Characteristics | Typical examples |
+|------|----------------|-----------------|
+| **Recipe** (deterministic) | Tight tool allowlist, short budget, script-like | Mark processed, cursor update, dedup gate |
+| **Judgment** (open-ended) | Broader tool access, longer budget, LLM reasons freely | Extract spores, consolidate, generate skill |
+
+Position each phase deliberately:
+
+- Plumbing (DB writes, cursor management, file I/O) → recipe pole. Keep the
+  LLM out of plumbing; harness code handles it.
+- Reasoning (pattern detection, synthesis, quality assessment) → judgment pole.
+- **Never blur**: a phase that both reasons and writes DB state is hard to
+  debug and hard to retry cleanly.
+
+### Data injection between phases
+
+The canonical pattern is **read-only discovery → write**:
+
+1. **Phase 1 (`discover`)**: reads vault, assembles context, writes nothing.
+   Emits a structured summary as its final tool call output.
+2. **Phase 2 (`write`)**: receives that summary as injected context; writes
+   to vault based on it.
+
+This keeps Phase 2 idempotent — if it fails you can replay it with the same
+context without re-running discovery.
+
+```ts
+phases: [
+  {
+    name: 'discover',
+    systemPrompt: DISCOVER_PROMPT,
+    turnBudget: 8,
+    tools: READ_ONLY_TOOLS,
+    readOnly: true,
+  },
+  {
+    name: 'write',
+    systemPrompt: WRITE_PROMPT,
+    // Harness injects discover's output as context before this phase runs
+    turnBudget: 12,
+    tools: WRITE_TOOLS,
+    readOnly: false,
+  },
+]
+```
+
+### Single-responsibility per phase
+
+Signs you need to split a phase into two:
+- The system prompt says "first do X, then do Y"
+- The turn budget exhausts before reaching the second half
+- Phase failures are ambiguous — you can't tell which half broke
+
+### Short-circuit conditions
+
+If Phase 1 finds nothing to process, it should exit early and signal the
+harness to skip remaining phases. Always define what "nothing to do" looks
+like and what the sentinel string in the output summary should be.
+
+---
+
+## Procedure 2: Write the Task Config
+
+Tasks live in `src/agent/tasks/`. Each task exports a typed config object and
+must be registered in `src/agent/tasks/index.ts`.
+
+### Required fields
+
+```ts
+export const myNewTask: AgentTask = {
+  name: 'my-new-task',          // kebab-case, unique across all tasks
+  isDefault: false,              // true = fires on settled session; false = manual/cron only
+  phases: [ /* see below */ ],
+  triggers: {
+    schedule: '0 */4 * * *',    // omit for event-only tasks
+    requireSettledSessions: true,
+    settledSessionIdleMinutes: 5,
+  },
+};
+```
+
+### Phase fields
+
+```ts
+{
+  name: 'extract',              // short, unique within the task
+  systemPrompt: EXTRACT_PROMPT, // imported constant — keep prompts in sibling .ts file
+  turnBudget: 15,               // see calibration section below
+  tools: EXTRACT_TOOLS,         // typed tool-surface object
+  advisor: 'cloud-reasoning',   // optional per-phase model tag (see Procedure 3)
+  readOnly: false,              // true = MCP enforcement: write tools hard-blocked
+}
+```
+
+### Registration
+
+After creating the task file, add it to `src/agent/tasks/index.ts`:
+
+```ts
+export { myNewTask } from './my-new-task';
+
+export const ALL_TASKS = [
+  fullIntelligenceTask,
+  skillSurveyTask,
+  // ...
+  myNewTask,  // ← add here
+];
+```
+
+The PowerManager picks up `ALL_TASKS` at startup. If you forget this step,
+the task silently never runs — no error, no log entry. Check `agent_runs`
+first when a task seems missing.
+
+---
+
+## Procedure 3: Select Models with the Advisor Pattern
+
+The `advisor` field routes a phase to a specific model class. This is
+**per-phase**, not per-task — different phases in the same task can use
+different models. Use the right model for each phase's position on the
+judgment/recipe gradient.
+
+### Model tags
+
+| Tag | Best for |
+|-----|----------|
+| `cloud-reasoning` | Open-ended judgment phases (extraction, synthesis, writing) |
+| `cloud-fast` | Recipe phases where speed matters more than reasoning depth |
+| `local-draft` | Cost-sensitive judgment phases where local quality suffices |
+
+### Decision rules
+
+- **No `advisor` field**: inherits the task-level model or daemon global default.
+- **Recipe/deterministic phases**: `cloud-fast` or omit (uses fast default).
+- **Judgment-heavy phases**: `cloud-reasoning`.
+- **QA dual-mode pattern**: deterministic assertion phases → recipe model;
+  exploratory analysis phases → judgment model. Don't use a single model for
+  both — you either overpay or underperform.
+
+### Local model gotcha
+
+If the task may run with a local Ollama model, **multiply all turn budgets by
+3–4×** compared to cloud. Local models complete the same work but reason in
+shorter steps and need more turns. There is no automatic per-phase multiplier —
+set the budget statically and calibrate locally before merging.
+
+---
+
+## Procedure 4: Calibrate Turn Budgets
+
+A budget too low silently truncates work. A budget too high wastes tokens on
+padding. Calibrate before deploying.
+
+### Starting values
+
+| Phase type | Cloud budget | Local budget |
+|------------|-------------|--------------|
+| Discovery / read-only | 8–12 | 25–40 |
+| Write / consolidation | 10–20 | 30–60 |
+| Validation / QA | 5–8 | 15–25 |
+
+### The static-budget-under-backlog problem
+
+If input to a phase grows unbounded (e.g., "process all unprocessed batches"
+when there are 200+), a static turn budget exhausts before completion.
+
+**Fix: cap the input, not the turns.** Use a bounded instruction builder:
+
+```ts
+// In the phase system prompt builder:
+const MAX_BATCHES = 20;
+const batches = await getUnprocessedBatches({ limit: MAX_BATCHES });
+// Tell the LLM: "Here are the N items to process. This is the full set."
+```
+
+Do NOT raise the budget to compensate for unbounded input — this creates
+unpredictable runtime and cost.
+
+### Detecting budget exhaustion
+
+- Query `agent_runs`: if `exit_reason = 'budget_exhausted'`, the phase ran
+  out of turns before completing.
+- If `exit_reason = 'complete'` but work is partial, check `turn_count` —
+  it may have hit the budget on the last turn without the harness logging it
+  as exhaustion.
+- If a phase consistently hits budget on the final turn, lower the input
+  bound first, then revisit the budget.
+
+### Stall vs. correct completion
+
+A phase that exits at turn 1 with an empty summary is either:
+1. Correctly short-circuiting (nothing to do), or
+2. Silently failing (LLM confused by prompt, malformed injected context).
+
+Distinguish by checking `tool_output_summary` in `agent_runs`. If there are
+zero tool calls, the LLM never engaged — the system prompt or injected context
+is likely malformed.
+
+---
+
+## Procedure 5: Configure Scheduling and Session Gating
+
+### isDefault vs. manual
+
+- `isDefault: true` — fires automatically on every settled session event.
+  Use for pipeline tasks (intelligence extraction, skill survey) that should
+  always run after user activity.
+- `isDefault: false` — fires only on a cron schedule or manual trigger.
+  Use for maintenance, batch, or on-demand tasks.
+
+### Session gating (critical)
+
+Any task that reads session transcripts or prompt batches **must** gate on
+settled sessions. An active session produces stale artifacts — the LLM will
+process partial data and potentially create duplicate or incorrect spores.
+
+```ts
+triggers: {
+  requireSettledSessions: true,
+  settledSessionIdleMinutes: 5,  // tune based on typical session cadence
+},
+```
+
+Omit `requireSettledSessions` only for tasks that don't touch session data
+(e.g., cron-based maintenance tasks operating on already-processed records).
+
+### Cron vs. event-triggered
+
+| Mode | Config | Best for |
+|------|--------|----------|
+| Event-triggered | `isDefault: true`, no `schedule` | Incremental work after each session |
+| Cron-only | `isDefault: false`, `schedule` set | Cross-session aggregation, cleanup |
+| Both | `isDefault: true`, `schedule` set | Rare — fresh-data + time-based runs |
+
+### Global toggle
+
+`agent.enabled: false` in `myco.yaml` kills ALL tasks immediately. This is the
+kill-switch for the entire pipeline — use it during daemon development or after
+a bad deploy. There is no per-task enable/disable flag; the toggle is all-or-nothing.
+
+---
+
+## Procedure 6: Design the Tool Surface
+
+### Opinionated (recipe) surfaces
+
+For recipe phases, define an explicit allowlist. The harness enforces it at
+the MCP layer — the LLM physically cannot call tools outside the list:
+
+```ts
+const DISCOVER_TOOLS = {
+  bash: { allowed: ['cat', 'head', 'tail', 'wc', 'grep'] },
+  vault: ['vault_unprocessed', 'vault_spores', 'vault_sessions', 'vault_search_fts'],
+};
+```
+
+Benefits: predictable, auditable, safe to replay.
+
+### Flexible (judgment) surfaces
+
+For judgment phases, allow broader access but still scope write tools to only
+what the phase needs:
+
+```ts
+const CONSOLIDATE_TOOLS = {
+  bash: { allowed: ['cat', 'grep', 'find', 'jq'] },
+  vault: [
+    'vault_spores', 'vault_search_fts', 'vault_search_semantic',
+    'vault_create_spore', 'vault_resolve_spore',
+  ],
+};
+```
+
+### readOnly annotation
+
+`readOnly: true` on a phase enables MCP-level enforcement — write tool calls
+are hard-rejected with an error instead of being silently attempted. Use this
+on every phase that doesn't need to write. It:
+- Prevents accidental writes during read phases
+- Makes phase intent self-documenting in the config
+- Enables safe concurrent execution (two readOnly phases can run in parallel)
+
+### Tool count vs. reasoning budget
+
+More tools = more tokens spent on tool-selection reasoning. For tight-budget
+recipe phases, keep the tool list to ≤5. For judgment phases, up to ~15 tools
+is reasonable before the LLM starts confusing tool names. If you need more,
+consider splitting into sub-phases.
+
+### When to add a new tool vs. compose existing ones
+
+Add a new vault tool when the operation is a primitive needed by 3+ tasks or
+requires DB access not expressible via existing tools. Otherwise compose
+existing tools within the phase — avoid proliferating single-use primitives.
+
+---
+
+## Procedure 7: Observe and Debug
+
+### agent_runs audit table
+
+Every phase execution writes a row to `agent_runs`:
+
+| Column | What it tells you |
+|--------|-------------------|
+| `task_name` | Which task fired |
+| `phase_name` | Which phase within the task |
+| `started_at` | When the phase began |
+| `completed_at` | NULL = still running or crashed |
+| `tool_output_summary` | Concatenated tool call outputs (truncated) |
+| `turn_count` | How many LLM turns were used |
+| `exit_reason` | `budget_exhausted` / `short_circuit` / `complete` / `error` |
+
+Diagnostic query:
+
+```sql
+SELECT task_name, phase_name, exit_reason, turn_count, completed_at
+FROM agent_runs
+WHERE task_name = 'my-new-task'
+ORDER BY started_at DESC
+LIMIT 20;
+```
+
+### Silent failure patterns
+
+| Symptom | Likely cause |
+|---------|-------------|
+| `exit_reason = 'complete'` but no state change | Sentinel triggered incorrectly; review short-circuit condition |
+| `turn_count = 1`, empty `tool_output_summary` | LLM never called tools; malformed prompt or injected context |
+| `turn_count = budget` with incomplete work | Budget exhaustion; cap the input |
+| `completed_at IS NULL` | Phase crashed or daemon restarted mid-run |
+| Task never appears in `agent_runs` | Not registered in `ALL_TASKS` |
+
+### Adding telemetry
+
+To add a new column to `agent_runs`, create a schema migration in
+`src/db/migrations/`. New columns are safe to add without touching existing
+rows — the harness reads the schema at startup.
+
+---
+
+## Cross-Cutting Gotchas
+
+- **Forget to register the task** → task never runs, no error. Always verify
+  `ALL_TASKS` in `src/agent/tasks/index.ts` after creating a task file.
+- **`isDefault: true` on a maintenance task** → fires after every session
+  even when there's nothing to maintain. Use `isDefault: false` + cron.
+- **No session gate on a transcript-reading task** → processes active sessions,
+  creates stale or duplicate artifacts. Always set `requireSettledSessions: true`
+  for any task that reads prompt batches or session transcripts.
+- **Static turn budget on unbounded input** → unpredictable runtime and silent
+  truncation. Cap the input size in the phase prompt builder, not the budget.
+- **`readOnly: false` on a discovery phase** → accidental vault writes during
+  read phases. Set `readOnly: true` on every non-writing phase.
+- **Single model for all phases** → overpaying for recipe phases or
+  underperforming on judgment phases. Use the per-phase `advisor` field.
+- **Local model without budget multiplier** → phase exhausts before completing.
+  Multiply all budgets by 3–4× for local Ollama models.

--- a/.agents/skills/daemon-ui-development/SKILL.md
+++ b/.agents/skills/daemon-ui-development/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: myco:daemon-ui-development
-description: |
+description: >
   Use when building, extending, or reviewing any page or component in the
   Myco daemon web UI or Collective UI — even if the user doesn't explicitly
   ask about design compliance or testing. Covers: design system token
-  integration (sage/ochre/terracotta CSS custom properties, three-font
-  hierarchy, tonal layering), app shell grammar and master-detail layout
-  enforcement, canary signal detection and design drift recovery, React
-  component patterns (useCallback dep completeness, SectionSaveRow,
-  toFormState/dirty-check/builder pattern), configuration page architecture
-  separation (dashboard=status summary vs. dedicated config page), Playwright
-  smoke test authoring for config UI forms, and new page registration.
-  Activates whenever creating a new daemon UI page, reviewing components for
-  visual compliance, writing Playwright tests for config forms, or debugging
-  stale-closure bugs in React hooks.
+  integration (6-theme system: sage/moss/terracotta/dusk/plum/slate with ochre
+  reserved for Collective, PostCSS @import ordering, CSS cascade specificity),
+  app shell grammar and master-detail layout enforcement, canary signal
+  detection and design drift recovery, React component patterns (useCallback
+  deps, SectionSaveRow, toFormState/builder, ScopedField), configuration page
+  architecture with collapsible sections and kebab menus, localStorage→file
+  migration with idempotent design, I/O optimization patterns, Playwright smoke
+  tests with computed CSS verification, favicon-per-theme SVG switching,
+  dynamic title pattern, RedactedField copy-button gotcha. Activates whenever
+  building daemon UI pages, reviewing components for visual compliance, or
+  debugging stale-closure bugs.
 managed_by: myco
 user-invocable: true
 allowed-tools: Read, Edit, Write, Bash, Grep, Glob
@@ -31,17 +32,62 @@ Apply these procedures whenever touching daemon or Collective UI code.
 - Locate the Collective UI source: `packages/collective-ui/`
 - Have a browser open for screenshot review before merging any visual changes
 - Confirm ESLint is running with `react-hooks/exhaustive-deps` enabled and treated as an error
+- Review the 6-theme system and theme CSS file organization in `packages/daemon/src/ui/styles/themes/`
 
 ## Procedure 1: Design System Token Integration
 
 The daemon uses CSS custom properties for color, typography, and spacing. Never introduce custom color values — even one hardcoded hex breaks visual consistency across the surface.
 
-**Palette tokens** (set at the daemon shell level):
+### 6-Theme System
+
+The design system includes **6 named themes**. Each theme has a unique primary color mapped to `--color-primary` and related accent/structural tokens. Ochre is reserved exclusively for the Collective UI and must not appear in daemon theme files.
+
+**Available themes:**
+- Sage (cool green, daemon default)
+- Moss (saturated green)
+- Terracotta (warm orange-red)
+- Dusk (cool purple-blue)
+- Plum (warm purple)
+- Slate (neutral blue-gray)
+
+**Ochre (Collective-only):** Do not reference or define `--color-ochre` in daemon theme CSS. This prevents visual bleed when the Collective is embedded.
+
+### Palette tokens structure
+
+Theme files are imported via PostCSS in `src/ui/styles/main.css`:
+
 ```css
---color-sage         /* primary structural green */
---color-ochre        /* accent / highlight */
---color-terracotta   /* warning / action */
---color-charcoal     /* text and structure */
+/* CRITICAL: @import must precede @tailwind directives */
+/* Otherwise theme CSS is silently dropped from the bundle (no build error) */
+@import './themes/sage.css';
+@import './themes/moss.css';
+@import './themes/terracotta.css';
+@import './themes/dusk.css';
+@import './themes/plum.css';
+@import './themes/slate.css';
+
+/* @tailwind directives come AFTER theme imports */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+If `@tailwind` appears before theme `@import`, the theme CSS is discarded silently — no build warning, but the themes don't work at runtime.
+
+### CSS cascade and specificity
+
+Theme selectors must use `:root[data-theme="...\"]` (not bare `[data-theme="...\"]`) to match the specificity of `:root` baseline styles. A selector like `[data-theme="sage"]` has the same specificity as `:root`, and source-order becomes unpredictable — the last declaration wins, breaking theme switching.
+
+```css
+/* CORRECT — :root specificity */
+:root[data-theme="sage"] {
+  --color-primary: #4a7c59;
+}
+
+/* WRONG — same specificity as :root, source order wins */
+[data-theme="sage"] {
+  --color-primary: #4a7c59;
+}
 ```
 
 **Typography hierarchy** — three fonts, each with a distinct role:
@@ -49,14 +95,14 @@ The daemon uses CSS custom properties for color, typography, and spacing. Never 
 - Body font: content and descriptions
 - Mono font: code, IDs, config values
 
-**Tonal layering**: backgrounds use tonal steps of `--color-sage` or charcoal-based neutrals — not flat white or arbitrary grays.
+**Tonal layering**: backgrounds use tonal steps of the primary color or neutral grays — not flat white or arbitrary colors.
 
 **Before writing any CSS in a new component:**
-1. Read the daemon shell's main CSS file to inventory all current custom properties
-2. Search for hardcoded values in your new file: `grep -rn "#[0-9a-fA-F]\{3,6\}\|rgb(" src/your-surface/`
+1. Read the daemon shell's theme files to inventory all current custom properties
+2. Search for hardcoded values in your new file: `grep -rn "#[0-9a-fA-F]{3,6}|rgb(" src/your-surface/`
 3. If a color isn't available as a daemon token, do not invent a new variable — decide whether the token belongs in the design system
 
-Warm neutrals (`#brown`, beige tones, warm hex values) are the primary canary signal for design drift. See Procedure 3.
+Warm neutrals and ochre (`#brown`, beige tones, warm hex values, any use of `--color-ochre`) are the primary canary signals for design drift. See Procedure 3.
 
 ## Procedure 2: App Shell Grammar and Master-Detail Layout
 
@@ -89,8 +135,8 @@ Design drift is detectable early via three canary signals. When any signal appea
 **The three canary signals:**
 
 | Signal | Correct | Wrong |
-|--------|---------|-------|
-| Color palette | Sage, ochre, terracotta, charcoal | Brown, warm neutrals, arbitrary hex values |
+|--------|---------|----------|
+| Color palette | Sage, moss, terracotta, dusk, plum, slate (via `--color-primary` theme variable); ochre only in Collective | Brown, warm neutrals, arbitrary hex values, ochre in daemon CSS |
 | Navigation elements | Solid structural rail | Bubble-bordered or rounded nav pills |
 | Base font size | Daemon density scale (tighter) | Large editorial scale |
 
@@ -100,19 +146,21 @@ Design drift is detectable early via three canary signals. When any signal appea
 grep -rn "var(--" src/your-surface/
 
 # Should return nothing
-grep -rn "#[0-9a-fA-F]\{3,6\}" src/your-surface/
+grep -rn "#[0-9a-fA-F]{3,6}|ochre" src/your-surface/
 ```
 Screenshot the live page and visually scan all three signals.
 
 **Recovery procedure** (apply in order):
 
 1. **List custom CSS variables** defined in the new surface's CSS files — any `--custom-var` not sourced from the daemon shell
-2. **Replace each** with the daemon token equivalent (warm neutral → `--color-charcoal`, green → `--color-sage`, etc.)
+2. **Replace each** with the daemon token equivalent (warm neutral → `--color-charcoal`, theme color → `--color-primary`, etc.)
 3. **Identify rebuilt structural chrome** — find nav, sidebar, or shell HTML built from scratch in the new surface
 4. **Replace** with extracted daemon shell components (see Procedure 2)
 5. **Verify master-detail layout** — confirm the page uses the two-panel pattern, not a centered column
-6. **Re-run detection** — grep + screenshot
-7. **Screenshot review before merging** — do not merge without a visual comparison against the daemon design language
+6. **Verify PostCSS @import ordering** — check `main.css` theme imports precede `@tailwind` directives
+7. **Verify theme CSS specificity** — all theme selectors use `:root[data-theme="...\"]`
+8. **Re-run detection** — grep + screenshot
+9. **Screenshot review before merging** — do not merge without a visual comparison against the daemon design language
 
 ## Procedure 4: React Component Patterns
 
@@ -167,6 +215,33 @@ function formToConfig(original: MyConfig, form: FormState): MyConfig {
 
 **Critical**: `formToConfig` must spread `original` before overlaying `form`. This preserves config fields not present in the form (server-managed fields, future fields the form doesn't know about). Reversing the order silently drops those fields from every save.
 
+### ScopedField pattern — Personal vs. Team settings
+
+When a setting can be scoped to Personal (machine-local) or Team (shared), use the `ScopedField` component pattern:
+
+```tsx
+<ScopedField
+  label="Provider Model"
+  scope={scope}  // 'personal' | 'team'
+  onScopeChange={setScope}
+  hint="Where this setting is stored"
+>
+  <ProviderModelSelector value={model} onChange={setModel} />
+</ScopedField>
+```
+
+Each scoped field includes:
+- **Personal pill** — a clickable label showing current scope (top-right of the field)
+- **Scope menu** — on click, toggle between Personal and Team
+- **Promote/reset semantics** — changing scope may promote a personal setting to team or reset team to personal
+
+**Key behaviors:**
+- When scope is "Team," the field is visually distinct (slightly different background or border)
+- A button or dropdown on the field lets the user change scope; the field itself is read-only to the scope
+- Saving a Team-scoped field syncs it across all machines in the team; Personal stays local
+
+See Procedure 5 (Configuration Page Architecture) for how to surface scope toggles in the UI layout.
+
 ## Procedure 5: Configuration Page Architecture
 
 ### Dashboard page = status summary only
@@ -219,6 +294,7 @@ Every config UI form should have a Playwright smoke test that verifies the form 
 1. **Toggle state round-trip**: enable a toggle → save → reload → toggle is still enabled
 2. **API POST with correct value**: intercept the save request and assert the payload contains the current form value (not a stale/default value — this is the `useCallback` dep bug in production)
 3. **Visual state consistency**: verify the UI reflects the saved state after reload (badge, token field, status indicator)
+4. **Computed style verification**: check that CSS theme values are applied at runtime, not just that files exist
 
 ### Test structure
 
@@ -244,6 +320,20 @@ test('config toggle round-trips correctly', async ({ page }) => {
     page.locator('[data-testid="ignore-in-git-toggle"]')
   ).toBeChecked();
 });
+
+// CSS verification — check theme colors are applied at runtime
+test('theme CSS is applied and renders correctly', async ({ page }) => {
+  await page.goto('/mcp-settings?theme=sage');
+  
+  const primaryElement = page.locator('[data-testid="primary-color-swatch"]');
+  const computedColor = await primaryElement.evaluate(
+    (el) => getComputedStyle(el).backgroundColor
+  );
+  
+  // Verify the computed style matches the theme (not a fallback or error state)
+  expect(computedColor).toMatch(/rgb\(\d+,\s*\d+,\s*\d+\)/);
+  // Do not test exact hex values; test that a color is computed
+});
 ```
 
 ### Wire to CI
@@ -258,11 +348,236 @@ npx playwright test path/to/config-ui.spec.ts
 - **`useCallback` dep bugs** — the API call posts the stale pre-toggle value; unit tests mock the call and never see the staleness
 - **`formToConfig` field-drop bugs** — the saved payload is missing fields; only caught by inspecting the actual POST body
 - **State-after-reload inconsistencies** — save returns 200 but the UI doesn't reflect it on reload
+- **CSS bundle gaps** — the theme CSS file exists but `@import` ordering is wrong or specificity is broken, so computed styles are fallback values
+
+## Procedure 7: Appearance Configuration UI and Settings Forms
+
+Config pages with collapsible sections and multi-field layouts must follow specific patterns to maintain consistency across the daemon.
+
+### Collapsible section UX
+
+When a config page has many sections, implement collapsible sections to reduce visual density and focus. The collapsible behavior differs by section type:
+
+**Sidebar sections that collapse to icon-only:**
+- Each sidebar nav item can collapse to show only an icon (typically the first character or a symbol)
+- On hover of the collapsed icon, show a tooltip with the full section name
+- Use `localStorage` to persist the collapsed/expanded state for UX continuity across page reloads
+- Do NOT use the daemon's main config file to store UI layout state — this is an ephemeral, machine-local preference
+
+**Content sections that fully hide:**
+- For non-sidebar content sections (e.g., "Appearance" settings), when collapsed, the entire section content hides — no compact icon state
+- Expand/collapse is controlled by a clickable header or chevron button
+- The section title remains visible even when collapsed
+- State is persisted to `localStorage` under a key like `section-visibility-<sectionName>`
+
+**localStorage ephemeral state exception:**
+Unlike config values (which go to the vault or shared project file), UI layout state (collapsed sections, revealed tokens, form scroll position) should use browser `localStorage`. This is a documented exception to the "all state in config files" rule.
+
+```typescript
+// Ephemeral UI state — use localStorage
+const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
+  return localStorage.getItem('sidebar-collapsed') === 'true';
+});
+
+const handleCollapse = useCallback((collapsed: boolean) => {
+  setSidebarCollapsed(collapsed);
+  localStorage.setItem('sidebar-collapsed', collapsed.toString());
+}, []);
+```
+
+### Section kebab menu (batch actions)
+
+When a config section has multiple fields that can be overridden or reset, expose a "kebab" menu (three-dot `⋮` button) next to the section title with these options:
+
+**Batch promote to project defaults:**
+- "Promote all to project defaults" action
+- When clicked, copy all current Personal (machine-local) settings in this section to the Team/project scope
+- Shows a confirmation: "This will update Team settings for 4 fields"
+- After promotion, the fields visually transition to Team scope (e.g., different background or icon)
+
+**Reset all to defaults:**
+- "Reset all to defaults" action
+- Clears all overrides in the section back to the project defaults
+- Only appears if at least one field differs from the defaults
+- Confirmation: "This will reset 3 fields to project defaults. This cannot be undone."
+
+**Implementation:**
+```tsx
+function SectionKebabMenu({ 
+  fields,  // array of {name, isOverridden, isTeamScope}
+  onPromoteAll,
+  onResetAll,
+}) {
+  const overriddenCount = fields.filter(f => f.isOverridden).length;
+  const isAnyLocal = fields.some(f => !f.isTeamScope);
+  
+  return (
+    <Dropdown>
+      {isAnyLocal && (
+        <MenuItem 
+          onClick={() => onPromoteAll()}
+        >
+          Promote all to project defaults ({overriddenCount})
+        </MenuItem>
+      )}
+      {overriddenCount > 0 && (
+        <MenuItem 
+          onClick={() => onResetAll()}
+          appearance="danger"
+        >
+          Reset all to defaults
+        </MenuItem>
+      )}
+    </Dropdown>
+  );
+}
+```
+
+## Procedure 8: Configuration Migration and I/O Optimization
+
+When evolving a config surface (e.g., moving settings from localStorage to persisted config files), follow these patterns to maintain data integrity and optimize performance.
+
+### localStorage → file migration procedure
+
+When a feature stored settings in browser `localStorage` and now must move to persistent config files (vault or project file):
+
+**Idempotent migration design:**
+1. On first page load, check if `localStorage` has the old keys: `appearance.theme`, `appearance.density`, `appearance.fontSize`, `appearance.syncTheme`
+2. If found, read them and merge into the current config state
+3. Immediately write the merged config to the persistent store via the normal save endpoint
+4. Add a cleanup TODO comment with a deadline: `// TODO(2026-04-30): Remove localStorage migration code`
+5. Do NOT set a sentinel flag (like `migrationComplete: true`) in config — the deadline comment is sufficient
+
+**Why not a sentinel flag?**
+- A flag in config becomes a permanent part of the codebase
+- If the migration logic is removed (see cleanup deadline), the flag is orphaned
+- Deadline comments are self-documenting and easily grep-able for cleanup
+
+**Implementation:**
+```typescript
+// Load existing config first
+const [config, setConfig] = useState(loadedConfig);
+
+useEffect(() => {
+  // Check for and migrate localStorage settings
+  const oldTheme = localStorage.getItem('appearance.theme');
+  const oldDensity = localStorage.getItem('appearance.density');
+  const oldFontSize = localStorage.getItem('appearance.fontSize');
+  const oldSyncTheme = localStorage.getItem('appearance.syncTheme');
+
+  if (oldTheme || oldDensity || oldFontSize || oldSyncTheme) {
+    const migratedConfig = {
+      ...config,
+      appearance: {
+        ...config.appearance,
+        ...(oldTheme && { theme: oldTheme }),
+        ...(oldDensity && { density: oldDensity }),
+        ...(oldFontSize && { fontSize: oldFontSize }),
+        ...(oldSyncTheme && { syncTheme: oldSyncTheme === 'true' }),
+      },
+    };
+
+    // Save the migrated config to persistent store
+    saveConfig(migratedConfig);
+    setConfig(migratedConfig);
+
+    // Clear the old localStorage keys
+    localStorage.removeItem('appearance.theme');
+    localStorage.removeItem('appearance.density');
+    localStorage.removeItem('appearance.fontSize');
+    localStorage.removeItem('appearance.syncTheme');
+
+    // TODO(2026-04-30): Remove this migration block entirely
+  }
+}, []);
+```
+
+### I/O optimization patterns
+
+Config pages often perform frequent reads and writes. Apply these patterns to avoid redundant requests and DOM mutations:
+
+**Skip write when content unchanged:**
+- Before calling the save endpoint, compare the form state to the last-saved config
+- If they are identical, do not make the POST request
+- This is already handled by the `dirty` flag (Procedure 4), but verify in your `onSave` handler:
+
+```typescript
+const handleSave = useCallback(async () => {
+  if (!dirty) {
+    console.log('No changes; skipping save');
+    return;
+  }
+  await saveConfig(formToConfig(savedConfig, formState));
+}, [dirty, formState, savedConfig]);
+```
+
+**useMemo for appearance context on primitive keys:**
+- When creating a context for appearance settings (theme, density, font size), memoize the context value by primitive fields, not by object reference
+- Without memoization, every render creates a new object, causing all consumers to re-render unnecessarily
+
+```typescript
+// WRONG — new object on every render
+const appearanceValue = {
+  theme: currentTheme,
+  density: currentDensity,
+  fontSize: currentFontSize,
+};
+
+// CORRECT — memoized on primitive field values
+const appearanceValue = useMemo(() => ({
+  theme: currentTheme,
+  density: currentDensity,
+  fontSize: currentFontSize,
+}), [currentTheme, currentDensity, currentFontSize]);
+```
+
+**Guard DOM mutation before setAttribute/favicon href swap:**
+- When updating the favicon or applying theme CSS via DOM manipulation, check the current value before mutating
+- Unnecessary mutations can trigger page reflows and layout thrashing
+
+```typescript
+const updateFavicon = useCallback((theme: string) => {
+  const faviconLink = document.querySelector('link[rel="icon"]');
+  if (!faviconLink) return;
+
+  const newHref = `/favicons/theme-${theme}.svg`;
+  
+  // Guard: only mutate if href actually changed
+  if (faviconLink.getAttribute('href') !== newHref) {
+    faviconLink.setAttribute('href', newHref);
+  }
+}, []);
+```
+
+**Single loadConfig() in HTTP handlers:**
+- When a page has multiple sections that each call the config endpoint, consolidate to a single `loadConfig()` call in the page-level effect
+- Pass the full config down to child sections as props; do not have each section independently fetch config
+- Reduces request count and keeps config state synchronized across the page
+
+```typescript
+// Page-level: fetch once
+const [config, setConfig] = useState(null);
+
+useEffect(() => {
+  loadConfig().then(setConfig);
+}, []);
+
+// Child section receives config as prop
+<AppearanceSection config={config} onSave={handleSave} />
+<NotificationSection config={config} onSave={handleSave} />
+```
 
 ## Cross-Cutting Gotchas
 
-- **Warm neutral ≠ neutral** — in the daemon design system, "neutral" is charcoal-based. Brown/beige tones immediately signal a design system mismatch.
+- **Warm neutral ≠ neutral** — in the daemon design system, "neutral" is charcoal-based. Brown/beige tones immediately signal a design system mismatch. Ochre in daemon CSS is also a canary for Collective UI code bleeding into daemon.
+- **PostCSS @import ordering is silent** — if theme `@import` statements appear AFTER `@tailwind`, the theme CSS is discarded silently. No build error, no warning. The only symptom is missing theme colors at runtime. Check `main.css` import order if themes don't render.
+- **CSS specificity requires `:root[data-theme="...\"]`** — bare `[data-theme="...\"]` has the same specificity as `:root`, causing source-order nondeterminism. Always use `:root[data-theme="...\"]`.
 - **Collective UI is a separate package but must inherit daemon design language** — it has its own deployment (`oss.goondocks.workers.dev`) but is not a separate visual system. Use `make collective-ui-dev` for a local proxy against live worker settings.
 - **ESLint hooks rule is your first line of defence** — never suppress `react-hooks/exhaustive-deps`. The warning is the bug report.
 - **Screenshot before merging** — visual consistency is the primary review signal for daemon UI. A screenshot comparison catches design drift that code review misses.
 - **`formToConfig` spread order is silent** — there is no runtime error when you get the spread order wrong. The only symptom is data loss in production. Test it with Playwright.
+- **Favicon-per-theme SVG switching** — the daemon renders 6 pre-generated SVG favicon variants (one per theme). At runtime, on theme change, the UI updates `<link rel="icon" href={faviconForTheme(theme)} />` to swap the favicon. The SVG files must exist in `public/favicons/theme-{name}.svg`. Missing SVG files show the fallback browser favicon (not an error).
+- **Dynamic page title pattern** — the page title follows the format `Myco — <project-name>`, sourced from the loaded `myco.yaml` config. Multiple local instances of Myco (different projects) must have distinct titles in browser tabs. If the title is not populated, check that `projectName` is loaded from config before rendering the page shell.
+- **RedactedField copy-button gotcha** — when displaying a masked token (e.g., `***`), the `<CopyButton>` component must receive the real token value, not the `displayValue`. Passing `displayValue` results in copying `***` to the clipboard. Correct usage: `<CopyButton value={realToken} />` with the button rendering the masked display separately.
+- **localStorage for UI state is ephemeral-only** — collapse/expand state, revealed token visibility, form scroll position belong in `localStorage`. Config values, team settings, and anything that should sync across machines belong in the vault or project config file. Never conflate the two.
+- **Cleanup deadline comments instead of sentinel flags** — when migrating data from one storage to another (localStorage → file), use TODO comments with deadlines, not sentinel config flags. Flags become orphaned when cleanup code is removed.

--- a/.agents/skills/notification-system-operations/SKILL.md
+++ b/.agents/skills/notification-system-operations/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: myco:notification-system-operations
+description: |
+  Use when extending the Myco notification system with a new domain, configuring
+  notification modes, diagnosing missing or misbehaving notifications, or fixing
+  React UI issues related to notifications — even if the user doesn't explicitly
+  ask for notification system help. Covers: domain self-registration and default
+  configuration; the mode resolution priority chain (payload > domain override >
+  global default > registry default) and its critical gotcha; emission point
+  discipline with a coverage checklist; the SystemNotifications.tsx banner-only
+  filter requirement; dismissed-vs-deleted semantics and the full debug protocol;
+  React Router same-URL navigation fix for notification clicks; and schema design
+  with on-write pruning. Complements extend-myco-daemon (which covers wiring
+  steps) with operational semantics and failure-mode playbooks.
+managed_by: myco
+user-invocable: true
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+# Myco Notification System: Configuration, Wiring, and Debugging
+
+This skill covers the operational semantics of the Myco notification system — the gotchas, configuration rules, and debug protocols a developer needs when extending, configuring, or diagnosing notification domains. For the mechanical wiring steps (registry → emission → display → React hook), see `extend-myco-daemon`. This skill is additive: it documents what goes wrong, how to configure correctly, and how to diagnose failures.
+
+## Prerequisites
+
+- The daemon is running and accessible.
+- You understand basic notification domain wiring (see `extend-myco-daemon`).
+- You have access to `src/daemon/` and `src/ui/` source trees.
+
+## Procedure 1: Domain Registration and Defaults
+
+Register a new notification domain using the self-registration API. The registry entry establishes the **lowest-priority fallback** defaults for the domain.
+
+```typescript
+// src/daemon/notifications/registry.ts (or domain-specific file)
+notificationRegistry.register({
+  domain: 'version_sync',
+  defaultMode: 'banner',       // 'banner' | 'summary' | 'none'
+  defaultTitle: 'Version Sync',
+  defaultIcon: '🔄',
+  description: 'Notifies when a version sync event occurs',
+});
+```
+
+**Critical constraint:** Registry defaults are the LOWEST-priority fallback. Set `defaultMode` to a safe last-resort value. The mode resolution chain (Procedure 2) means users can override your defaults through config — but only if registry values don't accidentally win over global config.
+
+Verify registration by checking the registry dump at daemon startup or via a debug endpoint. The domain should appear with your specified defaults.
+
+## Procedure 2: Mode Resolution Chain (Critical Gotcha)
+
+The notification mode for any emission resolves in this exact priority order, highest to lowest:
+
+```
+1. payload.mode        — per-emission override (highest priority)
+2. domain override     — per-domain config in myco.yaml
+                         (e.g., notifications.domains.version_sync.mode)
+3. global default      — global config in myco.yaml
+                         (e.g., notifications.defaultMode)
+4. registry default    — value from notificationRegistry.register() (lowest priority)
+```
+
+**The gotcha shipped in production:** The original implementation evaluated `registry default > global default`, making project-level `notifications.defaultMode` settings completely inert. A user who configured `defaultMode: 'none'` globally would still receive banners from any domain whose registry default is `'banner'`.
+
+When implementing or reviewing mode resolution, locate the resolver function (typically `src/daemon/notifications/resolver.ts`) and verify the fallback chain:
+
+```typescript
+function resolveMode(payload, domainConfig, globalConfig, registryEntry) {
+  return (
+    payload?.mode ??
+    domainConfig?.mode ??
+    globalConfig?.defaultMode ??
+    registryEntry?.defaultMode ??
+    'banner'  // hard fallback if all else is undefined
+  );
+}
+```
+
+If you see `registryEntry?.defaultMode ?? globalConfig?.defaultMode`, that is the bug — flip the order.
+
+**Verification:** Set `notifications.defaultMode: 'none'` in `myco.yaml` and trigger a domain emission. If a banner still appears, the resolution chain is inverted.
+
+## Procedure 3: Emission Point Discipline
+
+Every state-transition code path that should generate a notification needs an explicit emission call. Missing emission points are the most common cause of "notifications never show up."
+
+### Coverage checklist
+
+For each notification domain, verify emission points exist at:
+
+- [ ] The primary success path (e.g., sync completes)
+- [ ] The error/failure path (if the domain notifies on failure)
+- [ ] **Daemon restart / cleanup code** — this is a separate branch, frequently missed. Search shutdown and restart handlers explicitly; they are not covered by the main request handler path.
+- [ ] Any async callback or event handler that transitions state outside the main request path
+
+```typescript
+// Example: daemon restart cleanup — the forgotten emission site
+async function cleanupOnRestart() {
+  // Emit BEFORE clearing state
+  await notificationService.emit({
+    domain: 'version_sync',
+    title: 'Daemon restarted',
+    body: 'Version sync state was reset.',
+  });
+  await clearSyncState();
+}
+```
+
+### Finding missed emission points
+
+```bash
+# All files referencing the domain
+grep -r "version_sync" src/daemon/ --include="*.ts" -l
+
+# Files that actually call emit() for the domain
+grep -r 'emit.*version_sync\|domain.*version_sync' src/daemon/ --include="*.ts" -l
+```
+
+Files in the first list but not the second are candidates for missing emission points.
+
+## Procedure 4: SystemNotifications.tsx Banner-Only Filter
+
+`SystemNotifications.tsx` (the browser notification bridge) **must** query only notifications with `mode: 'banner'`. Fetching all unread notifications is the wrong pattern.
+
+**Why:** Summary-mode notifications are intended for the drawer/panel UI only. An all-unread query triggers browser popups for summary items, defeating the purpose of summary mode and creating noise.
+
+```typescript
+// Correct — filter for banner mode only
+const { notifications } = useNotifications({ mode: 'banner', unread: true });
+
+// Wrong — triggers browser notifications for summary items too
+const { notifications } = useNotifications({ unread: true });
+```
+
+**When adding a new domain with `defaultMode: 'summary'`:** verify that this domain's notifications do NOT appear as browser popup notifications. If they do, SystemNotifications.tsx is missing the mode filter.
+
+This is a recurring pattern failure. Any time you touch the notification query in SystemNotifications.tsx, confirm the `mode: 'banner'` filter is present. Leave a comment marking it as intentional.
+
+## Procedure 5: Dismissed-vs-Deleted Semantics
+
+Notifications are **never deleted** from the database. When a user dismisses a notification (clears the drawer), the row is marked `dismissed: true` and stays in the table.
+
+**Implications:**
+- An empty notification drawer does NOT mean no notifications were emitted.
+- Queries for "active" notifications must filter `WHERE dismissed = false`.
+- The default notification hook must exclude dismissed items.
+
+```typescript
+// Correct
+db.query(`SELECT * FROM notifications WHERE dismissed = false ORDER BY created_at DESC`);
+
+// Wrong — returns dismissed items as if they were active
+db.query(`SELECT * FROM notifications ORDER BY created_at DESC`);
+```
+
+If a notification hook returns an empty array but you expect items, check the dismissed column before assuming an emission failure (see Procedure 6).
+
+## Procedure 6: Notification Debug Protocol
+
+When a notification is missing, misbehaving, or displaying incorrectly, follow this sequence:
+
+### Step 1: Check dismissed state first
+
+```bash
+# In the daemon SQLite shell or via a debug endpoint
+SELECT id, domain, title, mode, dismissed, created_at
+FROM notifications
+WHERE domain = 'version_sync'
+ORDER BY created_at DESC
+LIMIT 20;
+```
+
+If rows exist with `dismissed = true`, the notification was emitted but dismissed (by the user or by an automated cleanup). Not an emission failure.
+
+### Step 2: Verify emission points
+
+Trigger the state transition and watch daemon logs for an emission log line. If no log appears, the emission point is missing (Procedure 3).
+
+### Step 3: Check mode resolution
+
+If the row exists with `dismissed = false` but no notification appeared, check the `mode` column. If mode is `'summary'` when you expected `'banner'`, trace the resolution chain (payload → domain config → global config → registry default) to find the wrong value.
+
+### Step 4: Check the banner filter
+
+If mode is `'banner'` and the browser notification still didn't fire, verify that SystemNotifications.tsx queries with `mode: 'banner'` (Procedure 4).
+
+### Step 5: Canonical smoke test
+
+Use `restart-reason.json` → `version_sync` notification as the end-to-end smoke test for any new notification domain:
+
+1. Write a `restart-reason.json` file with the appropriate payload.
+2. Restart the daemon.
+3. Confirm a `version_sync` notification appears in the drawer.
+4. Confirm it appears as a browser notification only if mode resolves to `'banner'`.
+
+This exercises the full path: emission on restart → mode resolution → storage → React hook → UI display.
+
+## Procedure 7: React Router Same-URL Navigation Fix
+
+When a notification click navigates to the URL the user is already on, React Router will NOT fire a navigation event — the location is current, so no re-render occurs and the page appears to do nothing.
+
+**Fix:** Include a timestamp in `location.state` to force React Router to treat it as a distinct route entry even when the pathname is identical.
+
+```typescript
+// Notification click handler
+function handleNotificationClick(notification: Notification) {
+  navigate(notification.targetPath, {
+    state: {
+      notificationId: notification.id,
+      navigatedAt: Date.now(),  // forces a distinct route entry
+    },
+  });
+}
+```
+
+The destination component can read `location.state.navigatedAt` to detect notification-driven navigations and trigger side effects (scroll to item, refresh data, highlight row, etc.).
+
+**When to apply:** Any notification that links to a page the user may already be viewing — common for session-level and graph-view notifications.
+
+## Procedure 8: Schema Design with On-Write Pruning
+
+The notifications table uses on-write pruning to bound its size. There is no cron job or background cleanup.
+
+**How it works:** Each `INSERT` triggers a pruning step that deletes the oldest rows for that domain when the count exceeds the domain's configured limit.
+
+```typescript
+async function emitNotification(payload: NotificationPayload) {
+  await db.insert('notifications', payload);
+
+  const limit = getDomainLimit(payload.domain); // e.g., 100
+  await db.run(`
+    DELETE FROM notifications
+    WHERE domain = ? AND id NOT IN (
+      SELECT id FROM notifications
+      WHERE domain = ?
+      ORDER BY created_at DESC
+      LIMIT ?
+    )
+  `, [payload.domain, payload.domain, limit]);
+}
+```
+
+**Trade-offs:**
+- ✅ No background job required; table stays bounded automatically.
+- ✅ Simple to reason about — pruning is co-located with the write.
+- ⚠️ High-frequency domains trigger pruning on every write. If pruning is a bottleneck, consider batching or periodic compaction.
+- ⚠️ Pruned rows are permanently gone — dismissed items and old items share the same retention budget.
+
+When registering a new domain, set a sensible per-domain row limit. Default to 50–100 rows for low-frequency domains.
+
+## Cross-Cutting Gotchas
+
+| Gotcha | Symptom | Fix |
+|--------|---------|-----|
+| Resolution chain inverted | Project-level `defaultMode` ignored | Verify `globalConfig` comes before `registryEntry` in the fallback chain |
+| Empty drawer ≠ no emissions | Debugging emission when notifications were just dismissed | Check `dismissed` column before touching emission code |
+| Restart cleanup missed | Notifications fire on normal use but not on daemon restart | Add explicit emission call in shutdown/restart handler, before state clear |
+| Banner filter drift | Summary-mode items trigger browser popups | Re-add `mode: 'banner'` filter to SystemNotifications.tsx query |
+| Same-URL navigation silently dropped | Notification click appears to do nothing | Add `navigatedAt: Date.now()` to `location.state` in navigate call |

--- a/.myco/myco.yaml
+++ b/.myco/myco.yaml
@@ -5,7 +5,7 @@ embedding:
   model: bge-m3:latest
 daemon:
   port: 21039
-  log_level: debug
+  log_level: info
   log_retention_days: 30
   stale_session_threshold_ms: 3600000
 capture:
@@ -62,6 +62,9 @@ agent:
     skill-generate:
       provider:
         type: anthropic
+      phases:
+        validate:
+          maxTurns: 30
       schedule:
         enabled: true
         runIn:
@@ -102,7 +105,12 @@ notifications:
     sessions:
       enabled: false
     mycelium:
-      enabled: false
+      enabled: true
+appearance:
+  theme: sage
+  mode: dark
+  font: default
+  density: normal
 symbionts:
   claude-code:
     enabled: true

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -506,21 +506,6 @@ export async function main(): Promise<void> {
 
   server.registerRoute('GET', '/api/config/merged', async () => handleGetMergedConfig(vaultDir));
   server.registerRoute('GET', '/api/config/local', async () => handleGetLocalConfig(vaultDir));
-  server.registerRoute('PUT', '/api/config/scoped', async (req) => {
-    const result = await handlePutScopedConfig(vaultDir, req.body);
-    if (!result.status || result.status < 400) {
-      reconcileConfiguredSymbionts(path.dirname(vaultDir), vaultDir);
-      configHash = computeConfigHash(vaultDir);
-    }
-    return result;
-  });
-  server.registerRoute('POST', '/api/config/local/clear', async (req) => {
-    const result = await handleClearLocalConfig(vaultDir, req.body);
-    if (!result.status || result.status < 400) {
-      configHash = computeConfigHash(vaultDir);
-    }
-    return result;
-  });
 
   // Pre-compute symbiont plan dirs for the config endpoint (manifests don't change at runtime)
   const symbiontPlanDirsByAgent: Record<string, string[]> = {};
@@ -528,6 +513,55 @@ export async function main(): Promise<void> {
     const dirs = m.capture?.planDirs ?? [];
     if (dirs.length > 0) symbiontPlanDirsByAgent[m.displayName] = dirs;
   }
+
+  /** Refresh the in-memory planWatchConfig to reflect the current
+   *  `capture.plan_dirs` in myco.yaml. Called after any config write so new
+   *  directories are picked up without a daemon restart. Idempotent — if the
+   *  watchDirs set is unchanged the setter is a no-op. */
+  function reconcilePlanWatch() {
+    try {
+      const cfg = loadConfig(vaultDir);
+      const customDirs = cfg.capture.plan_dirs ?? [];
+      planWatchConfig = {
+        ...planWatchConfig,
+        watchDirs: [...new Set([...symbiontPlanDirs, ...customDirs])],
+      };
+    } catch {
+      // loadConfig can throw on malformed YAML; the scoped write already
+      // validated the result so this should not fire, but swallow to avoid
+      // taking down the route handler on a rare reconciliation failure.
+    }
+  }
+
+  // /simplify E3: only re-read the config + reconcile plan dirs when the
+  // patch actually touches `capture` — toggling notifications shouldn't
+  // force a YAML read on every write.
+  function patchTouchesCapture(body: unknown): boolean {
+    const patch = (body as { patch?: Record<string, unknown> } | null)?.patch;
+    return patch !== undefined && patch !== null && 'capture' in patch;
+  }
+  function clearKeysTouchCapture(body: unknown): boolean {
+    const keys = (body as { keys?: string[] } | null)?.keys;
+    return Array.isArray(keys) && keys.some((k) => k === 'capture' || k.startsWith('capture.'));
+  }
+
+  server.registerRoute('PUT', '/api/config/scoped', async (req) => {
+    const result = await handlePutScopedConfig(vaultDir, req.body);
+    if (!result.status || result.status < 400) {
+      reconcileConfiguredSymbionts(path.dirname(vaultDir), vaultDir);
+      if (patchTouchesCapture(req.body)) reconcilePlanWatch();
+      configHash = computeConfigHash(vaultDir);
+    }
+    return result;
+  });
+  server.registerRoute('POST', '/api/config/local/clear', async (req) => {
+    const result = await handleClearLocalConfig(vaultDir, req.body);
+    if (!result.status || result.status < 400) {
+      if (clearKeysTouchCapture(req.body)) reconcilePlanWatch();
+      configHash = computeConfigHash(vaultDir);
+    }
+    return result;
+  });
 
   const planDirHandlers = createPlanDirHandlers({
     vaultDir,

--- a/packages/myco/src/utils/dot-path.ts
+++ b/packages/myco/src/utils/dot-path.ts
@@ -21,16 +21,19 @@ export function getAtPath(obj: Record<string, unknown>, dotPath: string): unknow
  */
 export function setAtPath(obj: Record<string, unknown>, dotPath: string, value: unknown): void {
   const parts = dotPath.split('.');
+  const leaf = parts[parts.length - 1];
+  if (leaf === undefined) return;
   let current: Record<string, unknown> = obj;
   for (let i = 0; i < parts.length - 1; i += 1) {
     const segment = parts[i];
+    if (segment === undefined) return;
     const existing = current[segment];
     if (existing === undefined || existing === null || typeof existing !== 'object' || Array.isArray(existing)) {
       current[segment] = {};
     }
     current = current[segment] as Record<string, unknown>;
   }
-  current[parts[parts.length - 1]] = value;
+  current[leaf] = value;
 }
 
 /**
@@ -39,15 +42,18 @@ export function setAtPath(obj: Record<string, unknown>, dotPath: string, value: 
  */
 export function unsetAtPath(obj: Record<string, unknown>, dotPath: string): boolean {
   const parts = dotPath.split('.');
+  const leaf = parts[parts.length - 1];
+  if (leaf === undefined) return false;
   let cursor: Record<string, unknown> | undefined = obj;
   for (let i = 0; i < parts.length - 1 && cursor; i += 1) {
-    const next: unknown = cursor[parts[i]];
+    const segment = parts[i];
+    if (segment === undefined) { cursor = undefined; break; }
+    const next: unknown = cursor[segment];
     cursor = (next !== null && typeof next === 'object' && !Array.isArray(next))
       ? next as Record<string, unknown>
       : undefined;
   }
   if (!cursor) return false;
-  const leaf = parts[parts.length - 1];
   if (!(leaf in cursor)) return false;
   delete cursor[leaf];
   return true;

--- a/packages/myco/ui/package-lock.json
+++ b/packages/myco/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@goondocks/myco-ui",
-  "version": "0.19.3",
+  "version": "0.19.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@goondocks/myco-ui",
-      "version": "0.19.3",
+      "version": "0.19.6",
       "dependencies": {
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1"

--- a/packages/myco/ui/src/components/agent/AgentConfig.tsx
+++ b/packages/myco/ui/src/components/agent/AgentConfig.tsx
@@ -1,18 +1,16 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import {
   Settings2,
   Activity,
   Loader2,
 } from 'lucide-react';
-import { useConfig, type MycoConfig } from '../../hooks/use-config';
 import { useDaemon, type StatsResponse } from '../../hooks/use-daemon';
 import { useAgentTasks, type TaskRow } from '../../hooks/use-agent';
-import { useRestart } from '../../hooks/use-restart';
-import { formatUptime, formatEpochAgo, parseNumericField } from '../../lib/format';
+import { useScopedConfig } from '../../hooks/use-scoped-config';
+import { formatUptime, formatEpochAgo } from '../../lib/format';
 import { Surface } from '../ui/surface';
 import { SectionHeader } from '../ui/section-header';
 import { Input } from '../ui/input';
-import { Button } from '../ui/button';
 import {
   Select,
   SelectContent,
@@ -21,37 +19,8 @@ import {
   SelectValue,
 } from '../ui/select';
 import { Switch } from '../ui/switch';
+import { ScopedField } from '../config/ScopedField';
 import { DEFAULT_SUMMARY_BATCH_INTERVAL } from '../../lib/constants';
-
-/* ---------- Types ---------- */
-
-interface AgentFormState {
-  summaryBatchInterval: string;
-  defaultTask: string;
-  scheduledTasksEnabled: boolean;
-  eventTasksEnabled: boolean;
-}
-
-/* ---------- Helpers ---------- */
-
-function toAgentForm(config: MycoConfig, defaultTaskName?: string): AgentFormState {
-  return {
-    summaryBatchInterval: String(config.agent?.summary_batch_interval ?? DEFAULT_SUMMARY_BATCH_INTERVAL),
-    defaultTask: defaultTaskName ?? '',
-    scheduledTasksEnabled: config.agent?.scheduled_tasks_enabled ?? true,
-    eventTasksEnabled: config.agent?.event_tasks_enabled ?? true,
-  };
-}
-
-function isAgentDirty(form: AgentFormState, config: MycoConfig, originalDefaultTask: string): boolean {
-  const orig = toAgentForm(config, originalDefaultTask);
-  return (
-    form.summaryBatchInterval !== orig.summaryBatchInterval ||
-    form.defaultTask !== orig.defaultTask ||
-    form.scheduledTasksEnabled !== orig.scheduledTasksEnabled ||
-    form.eventTasksEnabled !== orig.eventTasksEnabled
-  );
-}
 
 /* ---------- Sub-components ---------- */
 
@@ -170,59 +139,25 @@ function SystemHealthSection({ stats }: { stats: StatsResponse }) {
 /* ---------- Component ---------- */
 
 export function AgentConfig() {
-  const { config, isLoading: configLoading, saveConfig, isSaving } = useConfig();
+  const { effective, isLoading: configLoading } = useScopedConfig();
   const { data: stats, isLoading: statsLoading } = useDaemon();
   const { data: tasksData, isLoading: tasksLoading } = useAgentTasks();
-  const { restart } = useRestart();
-
-  const [form, setForm] = useState<AgentFormState | null>(null);
-  const [saveMessage, setSaveMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
   const tasks: TaskRow[] = tasksData?.tasks ?? [];
+  const [selectedDefaultTask, setSelectedDefaultTask] = useState<string | null>(null);
   const defaultTaskFromApi = tasks.find((t) => t.isDefault)?.name ?? '';
+  const defaultTask = selectedDefaultTask ?? defaultTaskFromApi;
 
-  // Initialise form from config once config + tasks load. A ref tracks whether
-  // we have initialised so we only seed once — subsequent refetches do NOT
-  // overwrite user edits. This replaces the previous useEffect pattern.
-  const formInitialised = useRef(false);
-  if (config && !tasksLoading && !formInitialised.current) {
-    formInitialised.current = true;
-    if (form === null) {
-      setForm(toAgentForm(config, defaultTaskFromApi));
-    }
-  }
-
-  const dirty = form && config ? isAgentDirty(form, config, defaultTaskFromApi) : false;
-  const hasAgentProvider = !!config?.agent?.provider;
-
-  const setField = useCallback(<K extends keyof AgentFormState>(key: K, value: AgentFormState[K]) => {
-    setForm((prev) => (prev ? { ...prev, [key]: value } : prev));
-    setSaveMessage(null);
+  const handleDefaultTaskChange = useCallback((next: string) => {
+    setSelectedDefaultTask(next);
+    // Default-task selection is handled by a separate endpoint (agent tasks),
+    // not by the scoped config — persistence of this selection is a TODO
+    // tracked alongside the per-task override UI. For now it's session-only.
   }, []);
 
-  const handleSave = async () => {
-    if (!form || !config) return;
-    setSaveMessage(null);
-    try {
-      await saveConfig({
-        agent: {
-          summary_batch_interval: parseNumericField(form.summaryBatchInterval, DEFAULT_SUMMARY_BATCH_INTERVAL),
-          scheduled_tasks_enabled: form.scheduledTasksEnabled,
-          event_tasks_enabled: form.eventTasksEnabled,
-        },
-      });
-      setSaveMessage({ type: 'success', text: 'Agent settings saved. Restarting daemon...' });
-      try {
-        await restart();
-      } catch {
-        setSaveMessage({ type: 'success', text: 'Settings saved. Daemon restart may require manual action.' });
-      }
-    } catch {
-      setSaveMessage({ type: 'error', text: 'Failed to save settings.' });
-    }
-  };
+  const hasAgentProvider = !!effective?.agent?.provider;
 
-  if (configLoading || !config || !form) {
+  if (configLoading || !effective) {
     return (
       <div className="space-y-4">
         {[1, 2, 3].map((i) => (
@@ -243,34 +178,37 @@ export function AgentConfig() {
           </span>
         </SectionHeader>
 
-        {/* Global agent toggles */}
+        {/* Global agent toggles — personal-default: each machine opts in independently */}
         <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <div className="space-y-0.5">
-              <label className="font-sans text-sm font-medium text-on-surface">Scheduled Tasks</label>
-              <p className="font-sans text-xs text-on-surface-variant">
-                Intelligence, skill survey, and skill evolution run automatically on a schedule
-              </p>
-            </div>
-            <Switch
-              checked={form.scheduledTasksEnabled}
-              onCheckedChange={(v) => setField('scheduledTasksEnabled', v)}
-              disabled={!hasAgentProvider}
-            />
-          </div>
-          <div className="flex items-center justify-between">
-            <div className="space-y-0.5">
-              <label className="font-sans text-sm font-medium text-on-surface">Event-Driven Tasks</label>
-              <p className="font-sans text-xs text-on-surface-variant">
-                Titles and summaries generated automatically after coding sessions
-              </p>
-            </div>
-            <Switch
-              checked={form.eventTasksEnabled}
-              onCheckedChange={(v) => setField('eventTasksEnabled', v)}
-              disabled={!hasAgentProvider}
-            />
-          </div>
+          <ScopedField
+            path="agent.scheduled_tasks_enabled"
+            label="Scheduled Tasks"
+            defaultScope="local"
+            hint="runs intelligence/skill-survey/skill-evolve on a cron"
+          >
+            {({ value, onChange }) => (
+              <Switch
+                checked={value ?? true}
+                onCheckedChange={onChange}
+                disabled={!hasAgentProvider}
+              />
+            )}
+          </ScopedField>
+
+          <ScopedField
+            path="agent.event_tasks_enabled"
+            label="Event-Driven Tasks"
+            defaultScope="local"
+            hint="titles + summaries on session end"
+          >
+            {({ value, onChange }) => (
+              <Switch
+                checked={value ?? true}
+                onCheckedChange={onChange}
+                disabled={!hasAgentProvider}
+              />
+            )}
+          </ScopedField>
         </div>
 
         {!hasAgentProvider && (
@@ -285,26 +223,31 @@ export function AgentConfig() {
 
         <div className="border-t border-outline-variant/20" />
 
-        {/* Title & Summary batch interval */}
-        <div className="space-y-1">
-          <label className="font-sans text-sm font-medium text-on-surface">Title &amp; Summary Batch Interval</label>
-          <div className="flex items-center gap-3">
-            <Input
-              type="number"
-              min={0}
-              placeholder={String(DEFAULT_SUMMARY_BATCH_INTERVAL)}
-              value={form.summaryBatchInterval}
-              onChange={(e) => setField('summaryBatchInterval', e.target.value)}
-              className="w-32 font-mono"
-            />
-            <span className="font-sans text-xs text-on-surface-variant">batches</span>
-          </div>
-          <p className="font-sans text-xs text-on-surface-variant">
-            Run the Title &amp; Summary task every N batches to keep active sessions properly titled. Set to 0 to disable.
-          </p>
-        </div>
+        {/* Title & Summary batch interval — project-default (pipeline cadence is team-agreed) */}
+        <ScopedField
+          path="agent.summary_batch_interval"
+          label="Title & Summary Batch Interval"
+          defaultScope="project"
+          commitOn="blur"
+          hint="batches between event-driven summary triggers; 0 disables"
+        >
+          {({ value, onChange, onBlur }) => (
+            <div className="flex items-center gap-3">
+              <Input
+                type="number"
+                min={0}
+                placeholder={String(DEFAULT_SUMMARY_BATCH_INTERVAL)}
+                value={value ?? ''}
+                onChange={(e) => onChange(Number(e.target.value))}
+                onBlur={onBlur}
+                className="w-32 font-mono"
+              />
+              <span className="font-sans text-xs text-on-surface-variant">batches</span>
+            </div>
+          )}
+        </ScopedField>
 
-        {/* Default task */}
+        {/* Default task — persistence handled by a separate agent-tasks endpoint */}
         <div className="space-y-1">
           <label className="font-sans text-sm font-medium text-on-surface">Default Task</label>
           {tasksLoading ? (
@@ -313,10 +256,7 @@ export function AgentConfig() {
               Loading tasks...
             </div>
           ) : (
-            <Select
-              value={form.defaultTask}
-              onValueChange={(v) => setField('defaultTask', v)}
-            >
+            <Select value={defaultTask} onValueChange={handleDefaultTaskChange}>
               <SelectTrigger>
                 <SelectValue placeholder="Select default task" />
               </SelectTrigger>
@@ -332,29 +272,6 @@ export function AgentConfig() {
           <p className="font-sans text-xs text-on-surface-variant">
             The task used when Run Now is clicked or no task is specified.
           </p>
-        </div>
-
-        {/* Save row */}
-        <div className="flex items-center gap-3 pt-2 border-t border-outline-variant/20">
-          <Button
-            onClick={handleSave}
-            disabled={!dirty || isSaving}
-            size="sm"
-          >
-            {isSaving ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
-            Save Changes
-          </Button>
-          {saveMessage && (
-            <span
-              className={
-                saveMessage.type === 'success'
-                  ? 'font-sans text-xs text-primary'
-                  : 'font-sans text-xs text-tertiary'
-              }
-            >
-              {saveMessage.text}
-            </span>
-          )}
         </div>
       </Surface>
 

--- a/packages/myco/ui/src/components/agent/TaskProviderConfig.tsx
+++ b/packages/myco/ui/src/components/agent/TaskProviderConfig.tsx
@@ -11,6 +11,7 @@ import {
   useTaskConfig,
   useTestProvider,
   useUpdateTaskConfig,
+  seedDraftFromProviderType,
   type ProviderConfig,
   type ProviderInfo,
   type PhaseOverride,
@@ -179,14 +180,14 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
   const providers = providersData?.providers ?? [];
 
   function handleProviderChange(type: string) {
-    const providerInfo = providers.find(p => p.type === type);
-    setProviderType(type);
     // Default to the first available model so the dropdown never shows a
     // stale value from the previous provider (Radix Select renders the prior
     // value instead of the placeholder when value='' is passed).
-    setModel(providerInfo?.models?.[0] ?? '');
-    setBaseUrl(providerInfo?.baseUrl ?? '');
-    setContextLength('');
+    const draft = seedDraftFromProviderType(type, providers);
+    setProviderType(type);
+    setModel(draft.model);
+    setBaseUrl(draft.baseUrl);
+    setContextLength(draft.contextLength);
     setDirty(true);
     testMutation.reset();
   }

--- a/packages/myco/ui/src/components/config/PlanCaptureCard.tsx
+++ b/packages/myco/ui/src/components/config/PlanCaptureCard.tsx
@@ -1,87 +1,38 @@
-import { useState, useEffect, useCallback } from 'react';
-import { fetchJson, postJson } from '../../lib/api';
+import { useState, useEffect } from 'react';
+import { fetchJson } from '../../lib/api';
 import { Surface } from '../ui/surface';
 import { SectionHeader } from '../ui/section-header';
 import { Input } from '../ui/input';
 import { Button } from '../ui/button';
 import { Switch } from '../ui/switch';
+import { ScopedField } from './ScopedField';
 
-interface PlanDirsResponse {
+interface PlanDirsAgentResponse {
   symbiont: Record<string, string[]>;
-  custom: string[];
-  ignore_plan_dirs_in_git: boolean;
 }
 
+/**
+ * Plan Capture — project-only by design. Plan directories define what *this
+ * project* watches; per-machine overrides would create silent drift between
+ * teammates. Both fields use lockScope='project' so the Personal pill never
+ * appears, and adds/removes immediately rewrite the array via the scoped
+ * config endpoint. The daemon's scoped-write hook re-runs symbiont
+ * reconciliation (.gitignore) and refreshes the in-memory plan watcher on
+ * every successful write.
+ */
 export function PlanCaptureCard() {
   const [symbiont, setSymbiont] = useState<Record<string, string[]>>({});
-  const [custom, setCustom] = useState<string[]>([]);
-  const [savedCustom, setSavedCustom] = useState<string[]>([]);
-  const [ignoreInGit, setIgnoreInGit] = useState(false);
-  const [savedIgnoreInGit, setSavedIgnoreInGit] = useState(false);
   const [newDir, setNewDir] = useState('');
-  const [isSaving, setIsSaving] = useState(false);
-  const [saveMessage, setSaveMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
+  // Symbiont-managed plan dirs come from a separate read-only endpoint
+  // (manifest-derived, not from myco.yaml).
   useEffect(() => {
-    fetchJson<PlanDirsResponse>('/config/plan-dirs')
-      .then((data) => {
-        setSymbiont(data.symbiont);
-        setCustom(data.custom);
-        setSavedCustom(data.custom);
-        setIgnoreInGit(data.ignore_plan_dirs_in_git);
-        setSavedIgnoreInGit(data.ignore_plan_dirs_in_git);
-      })
-      .catch(() => {
-        // leave defaults on error
-      })
+    fetchJson<PlanDirsAgentResponse>('/config/plan-dirs')
+      .then((data) => setSymbiont(data.symbiont))
+      .catch(() => {})
       .finally(() => setIsLoading(false));
   }, []);
-
-  const dirty =
-    custom.length !== savedCustom.length ||
-    custom.some((d, i) => d !== savedCustom[i]) ||
-    ignoreInGit !== savedIgnoreInGit;
-
-  const handleAdd = useCallback(() => {
-    const trimmed = newDir.trim();
-    if (!trimmed || custom.includes(trimmed)) return;
-    setCustom((prev) => [...prev, trimmed]);
-    setNewDir('');
-    setSaveMessage(null);
-  }, [newDir, custom]);
-
-  const handleRemove = useCallback((dir: string) => {
-    setCustom((prev) => prev.filter((d) => d !== dir));
-    setSaveMessage(null);
-  }, []);
-
-  const handleSave = useCallback(async () => {
-    setIsSaving(true);
-    setSaveMessage(null);
-    try {
-      const result = await postJson<{ custom: string[]; ignore_plan_dirs_in_git: boolean }>('/config/plan-dirs', {
-        plan_dirs: custom,
-        ignore_plan_dirs_in_git: ignoreInGit,
-      });
-      setSavedCustom(result.custom);
-      setCustom(result.custom);
-      setSavedIgnoreInGit(result.ignore_plan_dirs_in_git);
-      setIgnoreInGit(result.ignore_plan_dirs_in_git);
-      setSaveMessage({ type: 'success', text: 'Plan directories saved.' });
-    } catch {
-      setSaveMessage({ type: 'error', text: 'Failed to save plan directories.' });
-    } finally {
-      setIsSaving(false);
-    }
-  }, [custom, ignoreInGit]);
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Enter') handleAdd();
-    },
-    [handleAdd],
-  );
 
   const symbiontEntries = Object.entries(symbiont);
 
@@ -93,7 +44,7 @@ export function PlanCaptureCard() {
         <p className="font-sans text-sm text-on-surface-variant">Loading...</p>
       ) : (
         <div className="space-y-5">
-          {/* Agent directories — read-only */}
+          {/* Agent directories — read-only, derived from symbiont manifests */}
           <div className="space-y-2">
             <p className="font-sans text-sm font-medium text-on-surface">Agent Directories</p>
             <p className="font-sans text-xs text-on-surface-variant">
@@ -124,82 +75,80 @@ export function PlanCaptureCard() {
             )}
           </div>
 
-          {/* Custom directories — editable */}
-          <div className="space-y-2">
-            <p className="font-sans text-sm font-medium text-on-surface">Custom Directories</p>
-            <p className="font-sans text-xs text-on-surface-variant">
-              Additional directories to watch for plan files.
-            </p>
-
-            <div className="flex items-start justify-between gap-4 rounded bg-surface-container px-3 py-2">
-              <div className="space-y-1">
-                <p className="font-sans text-xs font-medium text-on-surface">Ignore Custom Plan Dirs In Git</p>
-                <p className="font-sans text-xs text-on-surface-variant">
-                  Add repo-relative custom plan directories to the Myco-managed block in <code>.gitignore</code>.
-                </p>
-              </div>
-              <Switch checked={ignoreInGit} onCheckedChange={setIgnoreInGit} disabled={isSaving} />
-            </div>
-
-            {custom.length > 0 && (
-              <div className="space-y-1">
-                {custom.map((dir) => (
-                  <div
-                    key={dir}
-                    className="flex items-center gap-2 rounded bg-surface-container px-3 py-1.5"
-                  >
-                    <span className="flex-1 font-mono text-xs text-on-surface">{dir}</span>
-                    <button
-                      type="button"
-                      onClick={() => handleRemove(dir)}
-                      className="font-sans text-xs text-on-surface-variant hover:text-tertiary transition-colors leading-none"
-                      aria-label={`Remove ${dir}`}
-                    >
-                      x
-                    </button>
-                  </div>
-                ))}
-              </div>
+          <ScopedField
+            path="capture.ignore_plan_dirs_in_git"
+            label="Ignore Custom Plan Dirs In Git"
+            lockScope="project"
+            hint=".gitignore is rewritten on every change"
+          >
+            {({ value, onChange }) => (
+              <Switch checked={value ?? false} onCheckedChange={onChange} />
             )}
+          </ScopedField>
 
-            <div className="flex gap-2">
-              <Input
-                placeholder="/path/to/plans"
-                value={newDir}
-                onChange={(e) => setNewDir(e.target.value)}
-                onKeyDown={handleKeyDown}
-                className="flex-1 font-mono text-xs"
-              />
-              <Button type="button" size="sm" onClick={handleAdd} disabled={!newDir.trim()}>
-                Add
-              </Button>
-            </div>
-          </div>
+          <ScopedField
+            path="capture.plan_dirs"
+            label="Custom Directories"
+            lockScope="project"
+            hint="extra paths to watch for plan files"
+          >
+            {({ value, onChange }) => {
+              const dirs = value ?? [];
+              return (
+                <div className="space-y-2">
+                  {dirs.length > 0 && (
+                    <div className="space-y-1">
+                      {dirs.map((dir) => (
+                        <div
+                          key={dir}
+                          className="flex items-center gap-2 rounded bg-surface-container px-3 py-1.5"
+                        >
+                          <span className="flex-1 font-mono text-xs text-on-surface">{dir}</span>
+                          <button
+                            type="button"
+                            onClick={() => onChange(dirs.filter((d) => d !== dir))}
+                            className="font-sans text-xs text-on-surface-variant hover:text-tertiary transition-colors leading-none"
+                            aria-label={`Remove ${dir}`}
+                          >
+                            x
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
 
-          {/* Save row — only visible when dirty */}
-          {dirty && (
-            <div className="flex items-center gap-4 pt-1">
-              <Button onClick={handleSave} disabled={isSaving} size="sm">
-                {isSaving ? 'Saving...' : 'Save'}
-              </Button>
-              {saveMessage && (
-                <span
-                  className={
-                    saveMessage.type === 'success'
-                      ? 'font-sans text-sm text-primary'
-                      : 'font-sans text-sm text-tertiary'
-                  }
-                >
-                  {saveMessage.text}
-                </span>
-              )}
-            </div>
-          )}
-
-          {/* Success message when not dirty */}
-          {!dirty && saveMessage?.type === 'success' && (
-            <p className="font-sans text-sm text-primary">{saveMessage.text}</p>
-          )}
+                  <div className="flex gap-2">
+                    <Input
+                      placeholder="/path/to/plans"
+                      value={newDir}
+                      onChange={(e) => setNewDir(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key !== 'Enter') return;
+                        const trimmed = newDir.trim();
+                        if (!trimmed || dirs.includes(trimmed)) return;
+                        onChange([...dirs, trimmed]);
+                        setNewDir('');
+                      }}
+                      className="flex-1 font-mono text-xs"
+                    />
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={() => {
+                        const trimmed = newDir.trim();
+                        if (!trimmed || dirs.includes(trimmed)) return;
+                        onChange([...dirs, trimmed]);
+                        setNewDir('');
+                      }}
+                      disabled={!newDir.trim()}
+                    >
+                      Add
+                    </Button>
+                  </div>
+                </div>
+              );
+            }}
+          </ScopedField>
         </div>
       )}
     </Surface>

--- a/packages/myco/ui/src/components/config/ScopePill.tsx
+++ b/packages/myco/ui/src/components/config/ScopePill.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+
+interface ScopePillProps {
+  /** Promote local override to project scope. */
+  onPromote: () => void | Promise<void>;
+  /** Clear the local override so the project value shines through. */
+  onReset: () => void | Promise<void>;
+}
+
+/**
+ * Compact "Personal" indicator with a click-to-open menu offering promote
+ * (Save to project) and reset (Reset to project) actions. Used wherever a
+ * scoped field has an active local override — ScopedField renders one
+ * automatically; custom card components render this directly when they
+ * need per-row scope affordances.
+ *
+ * Visually distinct from status badges: outlined + accent-colored so it
+ * reads as an interactive control, not a passive label.
+ */
+export function ScopePill({ onPromote, onReset }: ScopePillProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <span className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        title="This setting is overridden on this machine"
+        className="inline-flex items-center gap-1 rounded border border-primary/40 bg-primary/5 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-primary hover:bg-primary/10 transition-colors cursor-pointer"
+      >
+        <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+        Personal
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full z-10 mt-1 w-44 rounded-md border border-outline-variant/20 bg-surface-container-high p-1 text-xs shadow-lg">
+          <button
+            type="button"
+            onClick={() => { void onPromote(); setOpen(false); }}
+            className="block w-full rounded px-2 py-1 text-left hover:bg-surface-container-highest"
+          >
+            Save to project
+          </button>
+          <button
+            type="button"
+            onClick={() => { void onReset(); setOpen(false); }}
+            className="block w-full rounded px-2 py-1 text-left hover:bg-surface-container-highest"
+          >
+            Reset to project
+          </button>
+        </div>
+      )}
+    </span>
+  );
+}

--- a/packages/myco/ui/src/components/config/ScopedField.tsx
+++ b/packages/myco/ui/src/components/config/ScopedField.tsx
@@ -1,0 +1,132 @@
+import { useState, useEffect, useCallback, useRef, type ReactNode } from 'react';
+import { AlertCircle } from 'lucide-react';
+import { getAtPath } from '@myco/utils/dot-path';
+import { useScopedConfig, type Scope } from '../../hooks/use-scoped-config';
+import { useMarkRestartDirty } from './restart-gate';
+import { ScopePill } from './ScopePill';
+import type { ConfigPath, ConfigValueAt } from '../../lib/config-paths';
+
+interface ScopedFieldRenderArgs<T> {
+  value: T | undefined;
+  onChange: (v: T) => void;
+  onBlur: () => void;
+}
+
+interface ScopedFieldProps<P extends ConfigPath, T = ConfigValueAt<P>> {
+  /** Dotted path into MycoConfig — e.g. 'daemon.log_level'. Static paths
+   *  autocomplete; dynamic paths (notifications.domains.<id>.enabled) accept
+   *  any string via the `(string & {})` escape hatch. */
+  path: P;
+  label: string;
+  hint?: string;
+  /** Which scope to write to when this field changes. */
+  defaultScope?: Scope;
+  /** When set, locks writes to this scope and hides the Personal pill.
+   *  Use for fields that are project-only by design (plan dirs, team identity)
+   *  or machine-only by design (machine_id overrides etc.). */
+  lockScope?: Scope;
+  /** When true, flags the page-level restart gate on commit. */
+  requiresRestart?: boolean;
+  /** Inputs that accept typed text should commit on blur; toggles/selects commit on change. */
+  commitOn?: 'change' | 'blur';
+  /** Optional transform applied before writing (e.g. string-to-number for text inputs). */
+  parse?: (v: T) => T;
+  children: (args: ScopedFieldRenderArgs<T>) => ReactNode;
+}
+
+export function ScopedField<P extends ConfigPath, T = ConfigValueAt<P>>({
+  path,
+  label,
+  hint,
+  defaultScope = 'local',
+  lockScope,
+  requiresRestart,
+  commitOn = 'change',
+  parse,
+  children,
+}: ScopedFieldProps<P, T>) {
+  const { effective: effectiveConfig, local, setField, resetField, promoteField } = useScopedConfig();
+  const markRestartDirty = useMarkRestartDirty();
+
+  // Re-derive each render so values stay in sync; use a ref in commit so the
+  // callback identity doesn't churn on every refetch (React Query returns a
+  // new object reference even when data is unchanged).
+  const effective = getAtPath((effectiveConfig ?? {}) as Record<string, unknown>, path) as T | undefined;
+  const isPersonal = !lockScope && getAtPath((local ?? {}) as Record<string, unknown>, path) !== undefined;
+  const writeScope: Scope = lockScope ?? defaultScope;
+
+  const effectiveRef = useRef(effective);
+  effectiveRef.current = effective;
+
+  const [draft, setDraft] = useState<T | undefined>(effective);
+  // Snap draft back to effective when an external write changes the value
+  // (another tab, promote/reset, etc). The ref guard prevents clobbering an
+  // in-flight local edit on every parent re-render.
+  const editingRef = useRef(false);
+  useEffect(() => {
+    if (!editingRef.current) setDraft(effective);
+  }, [effective]);
+
+  const [error, setError] = useState<string | null>(null);
+
+  const commit = useCallback(
+    (value: T) => {
+      const toWrite = parse ? parse(value) : value;
+      if (toWrite === effectiveRef.current) return;
+      setError(null);
+      void setField(path, toWrite, writeScope).then(() => {
+        if (requiresRestart) markRestartDirty(path);
+      }).catch((err) => {
+        // On failure, snap draft back and surface the error inline. Without
+        // a visible indicator a swallowed write looks identical to a no-op,
+        // which Chris flagged in /simplify review #6.
+        setDraft(effectiveRef.current);
+        setError(err instanceof Error ? err.message : String(err));
+        console.error(`[scoped-field] write failed for ${path}`, err);
+      });
+    },
+    [path, writeScope, parse, requiresRestart, setField, markRestartDirty],
+  );
+
+  const handleChange = useCallback(
+    (v: T) => {
+      editingRef.current = true;
+      setDraft(v);
+      if (commitOn === 'change') {
+        commit(v);
+        editingRef.current = false;
+      }
+    },
+    [commit, commitOn],
+  );
+
+  const handleBlur = useCallback(() => {
+    if (commitOn === 'blur' && draft !== undefined) commit(draft);
+    editingRef.current = false;
+  }, [commit, commitOn, draft]);
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-2">
+        <label className="font-sans text-sm font-medium text-on-surface">{label}</label>
+        {hint && (
+          <span className="font-sans text-xs text-on-surface-variant font-normal">({hint})</span>
+        )}
+        {isPersonal && (
+          <ScopePill
+            onPromote={() => promoteField(path).catch((err) => console.error('[scoped-field] promote failed', err))}
+            onReset={() => resetField(path).catch((err) => console.error('[scoped-field] reset failed', err))}
+          />
+        )}
+      </div>
+      {children({ value: draft, onChange: handleChange, onBlur: handleBlur })}
+      {error && (
+        <p className="flex items-center gap-1 font-sans text-xs text-tertiary">
+          <AlertCircle className="h-3 w-3" />
+          Save failed: {error}
+        </p>
+      )}
+    </div>
+  );
+}
+

--- a/packages/myco/ui/src/components/config/restart-gate.tsx
+++ b/packages/myco/ui/src/components/config/restart-gate.tsx
@@ -1,0 +1,91 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+import { RefreshCw, Loader2 } from 'lucide-react';
+import { useRestart } from '../../hooks/use-restart';
+import { Button } from '../ui/button';
+
+interface RestartGateValue {
+  dirty: ReadonlySet<string>;
+  markDirty: (path: string) => void;
+  clear: () => void;
+}
+
+const Ctx = createContext<RestartGateValue | null>(null);
+
+/**
+ * Tracks restart-gated config paths that have been written since the last
+ * daemon restart. Fields like daemon.port or embedding.provider only take
+ * effect after restart; this provider lets a ScopedField flag itself dirty
+ * on commit and lets the page-level banner offer a single Restart button.
+ */
+export function RestartGateProvider({ children }: { children: ReactNode }) {
+  const [dirty, setDirty] = useState<Set<string>>(() => new Set());
+
+  const markDirty = useCallback((path: string) => {
+    setDirty((prev) => {
+      if (prev.has(path)) return prev;
+      const next = new Set(prev);
+      next.add(path);
+      return next;
+    });
+  }, []);
+
+  const clear = useCallback(() => setDirty(new Set()), []);
+
+  const value = useMemo<RestartGateValue>(
+    () => ({ dirty, markDirty, clear }),
+    [dirty, markDirty, clear],
+  );
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useRestartGate(): RestartGateValue {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error('useRestartGate must be inside RestartGateProvider');
+  return ctx;
+}
+
+/**
+ * Optional — components can call this to mark a path dirty without reading
+ * the context themselves (keeps ScopedField decoupled from the gate's
+ * existence when a page doesn't wrap in RestartGateProvider).
+ */
+export function useMarkRestartDirty(): (path: string) => void {
+  const ctx = useContext(Ctx);
+  return ctx?.markDirty ?? (() => {});
+}
+
+export function RestartBanner() {
+  const { dirty, clear } = useRestartGate();
+  const { restart, isRestarting } = useRestart();
+
+  if (dirty.size === 0) return null;
+
+  const handleRestart = async () => {
+    try {
+      await restart();
+      clear();
+    } catch {
+      // Keep banner visible so user can retry
+    }
+  };
+
+  return (
+    <div className="mb-4 flex items-center justify-between gap-4 rounded-md border border-ochre/40 bg-ochre/5 p-3">
+      <div className="min-w-0">
+        <p className="font-sans text-sm font-medium text-on-surface">Restart required</p>
+        <p className="font-sans text-xs text-on-surface-variant truncate">
+          Changed: {[...dirty].join(', ')}
+        </p>
+      </div>
+      <Button onClick={handleRestart} size="sm" disabled={isRestarting}>
+        {isRestarting ? (
+          <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+        )}
+        Restart daemon
+      </Button>
+    </div>
+  );
+}

--- a/packages/myco/ui/src/components/notifications/NotificationSettings.tsx
+++ b/packages/myco/ui/src/components/notifications/NotificationSettings.tsx
@@ -1,11 +1,9 @@
-import { useState, useCallback, useEffect } from 'react';
-import { Loader2 } from 'lucide-react';
-import { useConfig } from '../../hooks/use-config';
+import { useCallback } from 'react';
+import { useScopedConfig } from '../../hooks/use-scoped-config';
 import { useNotificationRegistry } from '../../hooks/use-notifications';
 import { Surface } from '../ui/surface';
 import { SectionHeader } from '../ui/section-header';
 import { Switch } from '../ui/switch';
-import { Button } from '../ui/button';
 import {
   Select,
   SelectContent,
@@ -13,94 +11,54 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../ui/select';
+import { ScopedField } from '../config/ScopedField';
+import { ScopePill } from '../config/ScopePill';
 
 const MODE_LABELS = {
   banner: 'Banner',
   summary: 'Summary',
 } as const;
 
-interface NotifFormState {
-  enabled: boolean;
-  system_notifications: boolean;
-  default_mode: 'banner' | 'summary';
-  domains: Record<string, { enabled: boolean; mode?: 'banner' | 'summary' }>;
-}
-
-function FieldLabel({ children, hint }: { children: React.ReactNode; hint?: string }) {
-  return (
-    <label className="font-sans text-sm font-medium text-on-surface">
-      {children}
-      {hint && (
-        <span className="ml-1 font-sans text-xs text-on-surface-variant font-normal">({hint})</span>
-      )}
-    </label>
-  );
-}
-
-function FieldHint({ children }: { children: React.ReactNode }) {
-  return <p className="font-sans text-xs text-on-surface-variant">{children}</p>;
-}
+type Mode = 'banner' | 'summary';
 
 function SectionCard({ children }: { children: React.ReactNode }) {
   return <div className="rounded-lg border border-outline-variant/20 bg-surface-container/40 p-4">{children}</div>;
 }
 
+/**
+ * Notifications — personal-default throughout. Notification preferences are
+ * deeply personal (noise tolerance, per-domain filtering), so every field
+ * writes to the local scope unless the user promotes it via the Personal pill.
+ */
 export function NotificationSettings() {
-  const { config, saveConfig, isSaving } = useConfig();
+  const { effective, setField, resetField, promoteField, isLocalOverride } = useScopedConfig();
   const { data: registryData } = useNotificationRegistry();
-  const [form, setForm] = useState<NotifFormState | null>(null);
-  const [saveMessage, setSaveMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
-
-  // Initialize form from config
-  useEffect(() => {
-    if (config && !form) {
-      setForm({
-        enabled: config.notifications?.enabled ?? true,
-        system_notifications: config.notifications?.system_notifications ?? false,
-        default_mode: config.notifications?.default_mode ?? 'summary',
-        domains: config.notifications?.domains ?? {},
-      });
-    }
-  }, [config, form]);
-
-  const setField = useCallback(<K extends keyof NotifFormState>(key: K, value: NotifFormState[K]) => {
-    setForm(prev => (prev ? { ...prev, [key]: value } : prev));
-    setSaveMessage(null);
-  }, []);
-
-  const updateDomain = useCallback((domain: string, update: Partial<NotifFormState['domains'][string]>) => {
-    setForm(prev => {
-      if (!prev) return prev;
-      const current = prev.domains[domain] ?? { enabled: true };
-      return {
-        ...prev,
-        domains: { ...prev.domains, [domain]: { ...current, ...update } },
-      };
-    });
-    setSaveMessage(null);
-  }, []);
-
-  const handleSave = useCallback(async () => {
-    if (!form || !config) return;
-    setSaveMessage(null);
-    try {
-      await saveConfig({ notifications: form });
-      setSaveMessage({ type: 'success', text: 'Notification settings saved.' });
-    } catch {
-      setSaveMessage({ type: 'error', text: 'Failed to save notification settings.' });
-    }
-  }, [form, config, saveConfig]);
-
-  if (!form || !config) return null;
-
   const domains = registryData?.domains ?? [];
-  const controlsDisabled = !form.enabled;
-  const isDirty = config ? (
-    form.enabled !== (config.notifications?.enabled ?? true) ||
-    form.system_notifications !== (config.notifications?.system_notifications ?? false) ||
-    form.default_mode !== (config.notifications?.default_mode ?? 'summary') ||
-    JSON.stringify(form.domains) !== JSON.stringify(config.notifications?.domains ?? {})
-  ) : false;
+
+  const notifEnabled = effective?.notifications?.enabled ?? true;
+  const defaultMode = effective?.notifications?.default_mode ?? 'summary';
+  const controlsDisabled = !notifEnabled;
+
+  const handleDomainMode = useCallback(
+    async (domain: string, value: string) => {
+      const path = `notifications.domains.${domain}.mode`;
+      if (value === 'default') {
+        await resetField(path);
+      } else {
+        await setField(path, value as Mode, 'local');
+      }
+    },
+    [resetField, setField],
+  );
+
+  const handleDomainEnabled = useCallback(
+    async (domain: string, enabled: boolean) => {
+      await setField(`notifications.domains.${domain}.enabled`, enabled, 'local');
+    },
+    [setField],
+  );
+
+  if (!effective) return null;
 
   return (
     <Surface level="low" className="p-6 space-y-5 border-t-2 border-t-sage">
@@ -108,69 +66,76 @@ export function NotificationSettings() {
 
       <div className="space-y-4">
         <SectionCard>
-          <div className="flex items-start justify-between gap-4">
-            <div className="space-y-1">
-              <FieldLabel>Notifications</FieldLabel>
-              <FieldHint>Turn the notification system on or off for this project.</FieldHint>
-            </div>
-            <Switch checked={form.enabled} onCheckedChange={v => setField('enabled', v)} />
-          </div>
+          <ScopedField
+            path="notifications.enabled"
+            label="Notifications"
+            hint="master switch for this project"
+            defaultScope="local"
+          >
+            {({ value, onChange }) => (
+              <Switch checked={value ?? true} onCheckedChange={onChange} />
+            )}
+          </ScopedField>
         </SectionCard>
 
         <div className={controlsDisabled ? 'space-y-4 opacity-60' : 'space-y-4'}>
           <SectionCard>
-            <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
-              <div className="space-y-1.5">
-                <FieldLabel>Default Display</FieldLabel>
-                <FieldHint>
-                  `Summary` keeps notifications in the panel only. `Banner` also shows a temporary in-app popup.
-                </FieldHint>
-              </div>
-              <Select
-                value={form.default_mode}
-                onValueChange={v => setField('default_mode', v as 'banner' | 'summary')}
-                disabled={controlsDisabled}
-              >
-                <SelectTrigger className="w-40">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="summary">Summary</SelectItem>
-                  <SelectItem value="banner">Banner</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+            <ScopedField
+              path="notifications.default_mode"
+              label="Default Display"
+              hint="summary = panel only; banner = temporary popup"
+              defaultScope="local"
+            >
+              {({ value, onChange }) => (
+                <Select
+                  value={value ?? 'summary'}
+                  onValueChange={(v) => onChange(v as Mode)}
+                  disabled={controlsDisabled}
+                >
+                  <SelectTrigger className="w-40">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="summary">Summary</SelectItem>
+                    <SelectItem value="banner">Banner</SelectItem>
+                  </SelectContent>
+                </Select>
+              )}
+            </ScopedField>
           </SectionCard>
 
           <SectionCard>
-            <div className="flex items-start justify-between gap-4">
-              <div className="space-y-1">
-                <FieldLabel>Browser Notifications</FieldLabel>
-                <FieldHint>
-                  Use OS/browser popups when the Myco tab is not focused. Only banner-mode notifications use this.
-                </FieldHint>
-              </div>
-              <Switch
-                checked={form.system_notifications}
-                onCheckedChange={v => setField('system_notifications', v)}
-                disabled={controlsDisabled}
-              />
-            </div>
+            <ScopedField
+              path="notifications.system_notifications"
+              label="Browser Notifications"
+              hint="OS popups when tab unfocused; only for banner mode"
+              defaultScope="local"
+            >
+              {({ value, onChange }) => (
+                <Switch checked={value ?? false} onCheckedChange={onChange} disabled={controlsDisabled} />
+              )}
+            </ScopedField>
           </SectionCard>
 
           {domains.length > 0 && (
             <SectionCard>
               <div className="space-y-3">
                 <div className="space-y-1">
-                  <FieldLabel>Per-Domain Overrides</FieldLabel>
-                  <FieldHint>Leave a domain on `Default` unless you want it to behave differently from the project-wide setting.</FieldHint>
+                  <label className="font-sans text-sm font-medium text-on-surface">Per-Domain Overrides</label>
+                  <p className="font-sans text-xs text-on-surface-variant">
+                    Leave on `Default` unless a domain should behave differently from the project-wide setting.
+                  </p>
                 </div>
 
                 <div className="space-y-2">
-                  {domains.map(d => {
-                    const domainConfig = form.domains[d.domain] ?? { enabled: true };
+                  {domains.map((d) => {
+                    const domainConfig = effective.notifications?.domains?.[d.domain] ?? { enabled: true };
                     const domainEnabled = domainConfig.enabled;
-                    const effectiveMode = domainConfig.mode ?? form.default_mode;
+                    const effectiveMode = (domainConfig.mode ?? defaultMode) as Mode;
+                    const modeValue = domainConfig.mode ?? 'default';
+                    const domainPath = `notifications.domains.${d.domain}`;
+                    const personal = isLocalOverride(domainPath);
+
                     return (
                       <div
                         key={d.domain}
@@ -183,16 +148,22 @@ export function NotificationSettings() {
                               <span className="rounded-full bg-surface-container-high px-2 py-0.5 text-[11px] text-on-surface-variant">
                                 {domainEnabled ? MODE_LABELS[effectiveMode] : 'Off'}
                               </span>
+                              {personal && (
+                                <ScopePill
+                                  onPromote={() => promoteField(domainPath)}
+                                  onReset={() => resetField(domainPath)}
+                                />
+                              )}
                             </div>
                             <p className="text-[11px] text-on-surface-variant">
-                              {d.types.map(t => t.label).join(', ')}
+                              {d.types.map((t) => t.label).join(', ')}
                             </p>
                           </div>
 
                           <div className="flex items-center gap-2 self-start">
                             <Select
-                              value={domainConfig.mode ?? 'default'}
-                              onValueChange={v => updateDomain(d.domain, { mode: v === 'default' ? undefined : (v as 'banner' | 'summary') })}
+                              value={modeValue}
+                              onValueChange={(v) => { void handleDomainMode(d.domain, v); }}
                               disabled={controlsDisabled || !domainEnabled}
                             >
                               <SelectTrigger className="h-8 w-[120px] text-xs">
@@ -206,7 +177,7 @@ export function NotificationSettings() {
                             </Select>
                             <Switch
                               checked={domainEnabled}
-                              onCheckedChange={v => updateDomain(d.domain, { enabled: v })}
+                              onCheckedChange={(v) => { void handleDomainEnabled(d.domain, v); }}
                               disabled={controlsDisabled}
                             />
                           </div>
@@ -220,23 +191,11 @@ export function NotificationSettings() {
           )}
 
           {controlsDisabled && (
-            <FieldHint>Notifications are currently disabled, so display and domain settings are inactive.</FieldHint>
+            <p className="font-sans text-xs text-on-surface-variant">Notifications are currently disabled, so display and domain settings are inactive.</p>
           )}
         </div>
-      </div>
-
-      {/* Save row */}
-      <div className="flex items-center gap-4 pt-2">
-        <Button onClick={handleSave} disabled={!isDirty || isSaving} size="sm">
-          {isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-          Save Notifications
-        </Button>
-        {saveMessage && (
-          <span className={saveMessage.type === 'success' ? 'font-sans text-sm text-primary' : 'font-sans text-sm text-tertiary'}>
-            {saveMessage.text}
-          </span>
-        )}
       </div>
     </Surface>
   );
 }
+

--- a/packages/myco/ui/src/components/notifications/SystemNotifications.tsx
+++ b/packages/myco/ui/src/components/notifications/SystemNotifications.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useNotifications, type Notification } from '../../hooks/use-notifications';
-import { useConfig } from '../../hooks/use-config';
+import { useScopedConfig } from '../../hooks/use-scoped-config';
 
 /**
  * Invisible component that fires browser Notification API alerts
@@ -9,8 +9,8 @@ import { useConfig } from '../../hooks/use-config';
  * Only active when `notifications.system_notifications` is enabled in config.
  */
 export function SystemNotifications() {
-  const { config } = useConfig();
-  const enabled = config?.notifications?.system_notifications ?? false;
+  const { effective } = useScopedConfig();
+  const enabled = effective?.notifications?.system_notifications ?? false;
   const { data } = useNotifications({ status: 'unread', mode: 'banner', limit: 5 });
   const seenRef = useRef<Set<string>>(new Set());
 

--- a/packages/myco/ui/src/components/operations/BackupCard.tsx
+++ b/packages/myco/ui/src/components/operations/BackupCard.tsx
@@ -1,12 +1,13 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback } from 'react';
 import { HardDrive, Download, Upload, RefreshCw, FolderOpen } from 'lucide-react';
-import { postJson, fetchJson, putJson } from '../../lib/api';
+import { postJson, fetchJson } from '../../lib/api';
 import { formatBytes } from '../../lib/format';
 import { Surface } from '../ui/surface';
 import { SectionHeader } from '../ui/section-header';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { cn } from '../../lib/cn';
+import { ScopedField } from '../config/ScopedField';
 
 /* ---------- Types ---------- */
 
@@ -67,30 +68,6 @@ export function BackupCard() {
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [preview, setPreview] = useState<RestorePreviewResponse | null>(null);
-
-  // Backup directory config
-  const [dirOverride, setDirOverride] = useState('');
-  const [dirSaving, setDirSaving] = useState(false);
-
-  useEffect(() => {
-    fetchJson<{ dir: string | null }>('/backup/config')
-      .then((res) => {
-        setDirOverride(res.dir ?? '');
-      })
-      .catch(() => {});
-  }, []);
-
-  const handleSaveDir = useCallback(async () => {
-    setDirSaving(true);
-    try {
-      await putJson('/backup/config', { dir: dirOverride || null });
-      setMessage({ type: 'success', text: dirOverride ? 'Backup directory updated. Restart daemon to apply.' : 'Backup directory reset to default. Restart daemon to apply.' });
-    } catch {
-      setMessage({ type: 'error', text: 'Failed to save backup directory.' });
-    } finally {
-      setDirSaving(false);
-    }
-  }, [dirOverride]);
 
   const refreshBackups = useCallback(async () => {
     try {
@@ -167,29 +144,31 @@ export function BackupCard() {
         </div>
       </div>
 
-      {/* Backup directory */}
-      <div className="space-y-1.5">
-        <label className="font-sans text-xs text-on-surface-variant flex items-center gap-1.5">
-          <FolderOpen className="h-3.5 w-3.5" />
-          Backup Directory
-        </label>
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={dirOverride}
-            onChange={(e) => setDirOverride(e.target.value)}
-            placeholder=".myco/backups"
-            className="flex-1 bg-surface-container text-on-surface font-mono text-sm rounded px-3 py-1.5 outline-none border border-outline-variant/15 focus:border-primary/40 placeholder:text-on-surface-variant/50"
-          />
-          <Button variant="ghost" size="sm" onClick={handleSaveDir} disabled={dirSaving}>
-            {dirSaving ? 'Saving...' : 'Save'}
-          </Button>
-        </div>
-        <p className="font-sans text-xs text-on-surface-variant">
-          Override where backups are stored. Leave empty for default (.myco/backups).
-          Supports ~ for home directory. Useful for network shares or git-tracked directories.
-        </p>
-      </div>
+      {/* Backup directory — personal-default: each machine writes backups
+          to its own filesystem location (network share, external disk, etc). */}
+      <ScopedField
+        path="backup.dir"
+        label="Backup Directory"
+        defaultScope="local"
+        commitOn="blur"
+        requiresRestart
+        hint="leave blank for default .myco/backups; ~ supported"
+        parse={(v) => (v === '' ? (undefined as unknown as string) : v)}
+      >
+        {({ value, onChange, onBlur }) => (
+          <div className="flex items-center gap-2">
+            <FolderOpen className="h-3.5 w-3.5 text-on-surface-variant flex-shrink-0" />
+            <input
+              type="text"
+              value={value ?? ''}
+              onChange={(e) => onChange(e.target.value)}
+              onBlur={onBlur}
+              placeholder=".myco/backups"
+              className="flex-1 bg-surface-container text-on-surface font-mono text-sm rounded px-3 py-1.5 outline-none border border-outline-variant/15 focus:border-primary/40 placeholder:text-on-surface-variant/50"
+            />
+          </div>
+        )}
+      </ScopedField>
 
       {/* Message */}
       {message && (

--- a/packages/myco/ui/src/components/providers/ProviderModelSelector.tsx
+++ b/packages/myco/ui/src/components/providers/ProviderModelSelector.tsx
@@ -39,6 +39,10 @@ export interface ProviderModelSelectorProps {
   onModelChange: (model: string) => void;
   onBaseUrlChange: (url: string) => void;
   onContextLengthChange: (ctx: string) => void;
+  /** Optional blur handlers — when present, callers commit text-input edits
+   *  on blur rather than on every keystroke. */
+  onBaseUrlBlur?: () => void;
+  onContextLengthBlur?: () => void;
 }
 
 export function ProviderModelSelector({
@@ -53,6 +57,8 @@ export function ProviderModelSelector({
   onModelChange,
   onBaseUrlChange,
   onContextLengthChange,
+  onBaseUrlBlur,
+  onContextLengthBlur,
 }: ProviderModelSelectorProps) {
   const selectedProvider = providers.find((p) => p.type === providerType);
   const isLocal = providerType === 'ollama' || providerType === 'lmstudio';
@@ -101,6 +107,7 @@ export function ProviderModelSelector({
           <Input
             value={baseUrl}
             onChange={(e) => onBaseUrlChange(e.target.value)}
+            onBlur={onBaseUrlBlur}
             placeholder={selectedProvider?.baseUrl ?? ''}
           />
         </div>
@@ -114,6 +121,7 @@ export function ProviderModelSelector({
             type="number"
             value={contextLength}
             onChange={(e) => onContextLengthChange(e.target.value)}
+            onBlur={onContextLengthBlur}
             placeholder="32768 (default)"
           />
           <p className="font-sans text-[11px] text-on-surface-variant/70">

--- a/packages/myco/ui/src/hooks/use-config.ts
+++ b/packages/myco/ui/src/hooks/use-config.ts
@@ -1,5 +1,13 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { fetchJson, writeScopedConfig } from '../lib/api';
+import type { AppearanceValues } from '@myco/config/appearance-values';
+
+/**
+ * Shared MycoConfig type. The actual config read/write hook lives in
+ * `use-scoped-config.ts` — that hook handles project + local overlay
+ * fetching and dotted-path writes through the scoped endpoints.
+ *
+ * Kept as a separate file because several non-config components import the
+ * shape (e.g., NotificationSettings reads `notifications.domains` types).
+ */
 
 export interface MycoConfig {
   version: 3;
@@ -23,6 +31,7 @@ export interface MycoConfig {
     plan_dirs: string[];
     artifact_extensions: string[];
     buffer_max_events: number;
+    ignore_plan_dirs_in_git?: boolean;
   };
   agent: {
     summary_batch_interval: number;
@@ -38,41 +47,14 @@ export interface MycoConfig {
     prompt_max_spores: number;
     [key: string]: unknown;
   };
+  backup: {
+    dir?: string;
+  };
   notifications: {
     enabled: boolean;
     system_notifications: boolean;
     default_mode: 'banner' | 'summary';
     domains: Record<string, { enabled: boolean; mode?: 'banner' | 'summary' }>;
   };
-}
-
-/** Recursive partial — lets each caller send only the sections (and nested fields) it owns. */
-export type MycoConfigPatch = {
-  [K in keyof MycoConfig]?: MycoConfig[K] extends Record<string, unknown>
-    ? Partial<MycoConfig[K]>
-    : MycoConfig[K];
-};
-
-export function useConfig() {
-  const queryClient = useQueryClient();
-
-  const query = useQuery({
-    queryKey: ['config'],
-    queryFn: ({ signal }) => fetchJson<MycoConfig>('/config', { signal }),
-  });
-
-  const mutation = useMutation({
-    mutationFn: (patch: MycoConfigPatch) =>
-      writeScopedConfig('project', patch as Record<string, unknown>) as Promise<MycoConfig>,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['config'] }),
-  });
-
-  return {
-    config: query.data,
-    isLoading: query.isLoading,
-    error: query.error,
-    saveConfig: mutation.mutateAsync,
-    isSaving: mutation.isPending,
-    saveError: mutation.error,
-  };
+  appearance: AppearanceValues;
 }

--- a/packages/myco/ui/src/hooks/use-providers.ts
+++ b/packages/myco/ui/src/hooks/use-providers.ts
@@ -49,6 +49,47 @@ export interface TaskConfigOverride {
   params?: Record<string, string | number | boolean>;
 }
 
+/** Form-state shape for editing a provider in the UI — string values for
+ *  number fields so HTML number inputs bind cleanly without empty-state
+ *  flicker. Used by both the global Agent Provider card and per-task
+ *  TaskProviderConfig. */
+export interface ProviderDraft {
+  type: ProviderConfig['type'] | '';
+  model: string;
+  baseUrl: string;
+  contextLength: string;
+}
+
+/** Seed a draft from a freshly-selected provider type — picks the first
+ *  available model and the provider's default base URL. Both the global
+ *  Agent card and per-task config call this on the provider-type change
+ *  event; centralized so the two stay in sync. */
+export function seedDraftFromProviderType(
+  type: string,
+  providers: ProviderInfo[],
+): ProviderDraft {
+  const info = providers.find((p) => p.type === type);
+  return {
+    type: type as ProviderConfig['type'],
+    model: info?.models?.[0] ?? '',
+    baseUrl: info?.baseUrl ?? '',
+    contextLength: '',
+  };
+}
+
+/** Build the persisted ProviderConfig from a draft. Drops empty optional
+ *  fields and only includes base_url/context_length for local providers. */
+export function draftToProviderConfig(draft: ProviderDraft): ProviderConfig | undefined {
+  if (draft.type === '') return undefined;
+  const isLocal = draft.type === 'ollama' || draft.type === 'lmstudio';
+  return {
+    type: draft.type,
+    ...(draft.model ? { model: draft.model } : {}),
+    ...(isLocal && draft.baseUrl ? { base_url: draft.baseUrl } : {}),
+    ...(isLocal && draft.contextLength ? { context_length: Number(draft.contextLength) } : {}),
+  };
+}
+
 export interface TaskConfigResponse {
   taskId: string;
   config: TaskConfigOverride | null;

--- a/packages/myco/ui/src/hooks/use-scoped-config.ts
+++ b/packages/myco/ui/src/hooks/use-scoped-config.ts
@@ -1,0 +1,123 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useRef } from 'react';
+import {
+  fetchMergedConfig,
+  fetchLocalConfig,
+  writeScopedConfig,
+  clearLocalConfigKeys,
+} from '../lib/api';
+import { getAtPath, setAtPath } from '@myco/utils/dot-path';
+import type { MycoConfig } from './use-config';
+import type { ConfigPath } from '../lib/config-paths';
+
+export type Scope = 'project' | 'local';
+
+const MERGED_KEY = ['config', 'merged'] as const;
+const LOCAL_KEY = ['config', 'local'] as const;
+
+/**
+ * Scoped config hook — generalizes the Appearance provider pattern so any
+ * dotted path in MycoConfig can be read from the merged (project + local)
+ * view and written to either scope.
+ *
+ * - `effective` is the merged view used for display.
+ * - `local` is the raw local overlay; a key present here means that path is
+ *   personal-scoped on this machine.
+ * - `setField` writes a single field into the chosen scope by constructing
+ *   a nested patch that matches the dotted path.
+ * - `resetField` clears a local override so the project value shines through.
+ * - `promoteField` copies the current effective value into the project
+ *   config, then clears the local override — equivalent to "this was working
+ *   for me, make it the team default."
+ *
+ * Returned callbacks are stable across re-renders (data is read through refs)
+ * so consumers don't have their `useCallback` deps thrash on every refetch.
+ */
+export function useScopedConfig() {
+  const qc = useQueryClient();
+
+  const merged = useQuery({
+    queryKey: MERGED_KEY,
+    queryFn: ({ signal }) => fetchMergedConfig(signal),
+  });
+  const local = useQuery({
+    queryKey: LOCAL_KEY,
+    queryFn: ({ signal }) => fetchLocalConfig(signal),
+  });
+
+  const mergedRef = useRef(merged.data);
+  mergedRef.current = merged.data;
+  const localRef = useRef(local.data);
+  localRef.current = local.data;
+
+  // Local writes only need the local query refetched; project writes need both
+  // (because merged = project + local). Splitting saves a network round-trip
+  // per personal-default toggle, which is the common case.
+  const invalidateLocal = useCallback(() => {
+    void qc.invalidateQueries({ queryKey: LOCAL_KEY });
+    void qc.invalidateQueries({ queryKey: MERGED_KEY });
+  }, [qc]);
+  const invalidateProject = useCallback(() => {
+    void qc.invalidateQueries({ queryKey: MERGED_KEY });
+  }, [qc]);
+  const invalidateForScope = useCallback(
+    (scope: Scope) => (scope === 'local' ? invalidateLocal() : invalidateProject()),
+    [invalidateLocal, invalidateProject],
+  );
+
+  const setField = useCallback(
+    async <T,>(path: ConfigPath, value: T, scope: Scope): Promise<void> => {
+      const patch: Record<string, unknown> = {};
+      setAtPath(patch, path, value);
+      await writeScopedConfig(scope, patch);
+      invalidateForScope(scope);
+    },
+    [invalidateForScope],
+  );
+
+  const setFields = useCallback(
+    async (
+      fields: Array<{ path: ConfigPath; value: unknown }>,
+      scope: Scope,
+    ): Promise<void> => {
+      const patch: Record<string, unknown> = {};
+      for (const { path, value } of fields) {
+        setAtPath(patch, path, value);
+      }
+      await writeScopedConfig(scope, patch);
+      invalidateForScope(scope);
+    },
+    [invalidateForScope],
+  );
+
+  const resetField = useCallback(async (path: ConfigPath): Promise<void> => {
+    await clearLocalConfigKeys([path]);
+    invalidateLocal();
+  }, [invalidateLocal]);
+
+  const promoteField = useCallback(async (path: ConfigPath): Promise<void> => {
+    const value = getAtPath((mergedRef.current ?? {}) as Record<string, unknown>, path);
+    const patch: Record<string, unknown> = {};
+    setAtPath(patch, path, value);
+    await writeScopedConfig('project', patch);
+    await clearLocalConfigKeys([path]);
+    invalidateLocal();
+  }, [invalidateLocal]);
+
+  const isLocalOverride = useCallback(
+    (path: ConfigPath): boolean =>
+      getAtPath((localRef.current ?? {}) as Record<string, unknown>, path) !== undefined,
+    [],
+  );
+
+  return {
+    effective: merged.data as MycoConfig | undefined,
+    local: (local.data ?? {}) as Partial<MycoConfig>,
+    isLoading: merged.isLoading || local.isLoading,
+    isLocalOverride,
+    setField,
+    setFields,
+    resetField,
+    promoteField,
+  };
+}

--- a/packages/myco/ui/src/layout/AppearanceSection.tsx
+++ b/packages/myco/ui/src/layout/AppearanceSection.tsx
@@ -13,6 +13,7 @@ import {
   type FontKey,
   type Appearance,
 } from '../providers/appearance';
+import { ScopePill } from '../components/config/ScopePill';
 
 const THEME_LABELS: Record<Theme, { label: string; swatch: string }> = {
   sage: { label: 'Sage', swatch: '#abcfb8' },
@@ -37,46 +38,6 @@ const FONT_LABELS: Record<FontKey, string> = {
   'fira-code': 'Fira Code',
   'jetbrains-mono': 'JetBrains',
 };
-
-function PersonalPillMenu({
-  onPromote,
-  onReset,
-}: {
-  onPromote: () => void;
-  onReset: () => void;
-}) {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <span className="relative ml-1 inline-block">
-      <button
-        type="button"
-        onClick={() => setOpen((o) => !o)}
-        className="rounded bg-surface-container-high px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-on-surface-variant hover:bg-surface-container-highest"
-      >
-        Personal
-      </button>
-      {open && (
-        <div className="absolute left-0 top-full z-10 mt-1 w-44 rounded-md border border-[var(--ghost-border)] bg-surface-container-high p-1 text-xs shadow-lg">
-          <button
-            type="button"
-            onClick={() => { onPromote(); setOpen(false); }}
-            className="block w-full rounded px-2 py-1 text-left hover:bg-surface-container-highest"
-          >
-            Save to project
-          </button>
-          <button
-            type="button"
-            onClick={() => { onReset(); setOpen(false); }}
-            className="block w-full rounded px-2 py-1 text-left hover:bg-surface-container-highest"
-          >
-            Reset to project
-          </button>
-        </div>
-      )}
-    </span>
-  );
-}
 
 const SECTION_EXPANDED_KEY = 'myco-ui-appearance-expanded';
 
@@ -114,7 +75,7 @@ export function AppearanceSection({ collapsed }: { collapsed: boolean }) {
       <div className="flex items-center text-xs text-on-surface-variant">
         {label}
         {isPersonal(controlKey) && (
-          <PersonalPillMenu
+          <ScopePill
             onPromote={() => set(controlKey, effective[controlKey], 'project').catch((err) => console.error('[appearance] promote failed', err))}
             onReset={() => resetKey(controlKey).catch((err) => console.error('[appearance] reset failed', err))}
           />

--- a/packages/myco/ui/src/lib/config-paths.ts
+++ b/packages/myco/ui/src/lib/config-paths.ts
@@ -1,0 +1,73 @@
+import type { MycoConfig } from '../hooks/use-config';
+
+/**
+ * Dotted-path type utilities for MycoConfig.
+ *
+ * `DotPaths<T>` is the union of all valid dotted paths into `T`. Used to
+ * constrain the `path` prop on `<ScopedField>` and the `path` argument on
+ * `useScopedConfig().setField()` / `resetField()` / `promoteField()` so a
+ * typo at the call site is a compile error.
+ *
+ * `PathValue<T, P>` walks a dotted path and yields the leaf type — letting
+ * `<ScopedField>` infer the value type from the path so callers don't have
+ * to repeat it via the explicit `<T>` generic.
+ *
+ * `ConfigPath = DotPaths<MycoConfig> | (string & {})`
+ *   The `(string & {})` intersection is the standard TypeScript trick for
+ *   "literal autocomplete + arbitrary string": IDE suggests the known paths
+ *   (e.g. 'daemon.log_level'), but the dynamic notification-domain paths
+ *   (`notifications.domains.<id>.enabled`) and any future records still
+ *   compile. Without the escape hatch the dynamic-key paths would be
+ *   compile errors.
+ */
+
+type Primitive = string | number | boolean | null | undefined;
+
+// Recursive walk: for each key K of T, emit `K` plus (if T[K] is an object)
+// every dotted continuation `K.<sub>`. Bottoms out at primitives and arrays.
+type DotPathsOf<T, Depth extends number = 5> =
+  Depth extends 0
+    ? never
+    : T extends Primitive
+      ? never
+      : T extends ReadonlyArray<unknown>
+        ? never
+        : {
+            [K in keyof T & string]:
+              | K
+              | (T[K] extends object
+                  ? T[K] extends ReadonlyArray<unknown>
+                    ? never
+                    : `${K}.${DotPathsOf<NonNullable<T[K]>, Decrement<Depth>>}`
+                  : never);
+          }[keyof T & string];
+
+// TS template-literal recursion has no native arithmetic; use a small lookup.
+type Decrement<N extends number> =
+  N extends 5 ? 4 : N extends 4 ? 3 : N extends 3 ? 2 : N extends 2 ? 1 : N extends 1 ? 0 : 0;
+
+export type DotPaths<T> = DotPathsOf<T>;
+
+/** Walk a dotted path through T and produce the leaf value type. */
+export type PathValue<T, P extends string> =
+  P extends `${infer K}.${infer R}`
+    ? K extends keyof T
+      ? PathValue<NonNullable<T[K]>, R>
+      : unknown
+    : P extends keyof T
+      ? T[P]
+      : unknown;
+
+/**
+ * Path prop type for ScopedField and useScopedConfig writes. Accepts the
+ * known static union from `DotPaths<MycoConfig>` (autocompletes in editors)
+ * AND any string (so dynamic paths like `notifications.domains.<id>.enabled`
+ * still compile).
+ */
+export type ConfigPath = DotPaths<MycoConfig> | (string & {});
+
+/**
+ * Value type for a known config path; falls back to `unknown` for dynamic
+ * paths the type system can't statically resolve.
+ */
+export type ConfigValueAt<P extends string> = PathValue<MycoConfig, P>;

--- a/packages/myco/ui/src/pages/Operations.tsx
+++ b/packages/myco/ui/src/pages/Operations.tsx
@@ -3,7 +3,9 @@ import { Cpu, Database, Play, Trash2, RefreshCw, RotateCcw, ArrowDown, Pause } f
 import { useQueryClient } from '@tanstack/react-query';
 import { useEmbeddingDetails, type EmbeddingDetails } from '../hooks/use-embedding-details';
 import { useDatabaseDetails, type DatabaseDetails } from '../hooks/use-database-details';
-import { useConfig } from '../hooks/use-config';
+import { useScopedConfig } from '../hooks/use-scoped-config';
+import { ScopedField } from '../components/config/ScopedField';
+import { Switch } from '../components/ui/switch';
 import { useLogFeed } from '../hooks/use-log-feed';
 import { Badge } from '../components/ui/badge';
 import { postJson, ApiError } from '../lib/api';
@@ -246,25 +248,17 @@ function ScheduledMaintenanceCard({
   details: DatabaseDetails;
   onActionResult: (r: { type: 'success' | 'error'; text: string }) => void;
 }) {
-  const { config, saveConfig, isSaving } = useConfig();
+  const { effective } = useScopedConfig();
   const queryClient = useQueryClient();
   const [running, setRunning] = useState(false);
 
-  if (!config) return null;
+  if (!effective) return null;
 
-  const enabled = config.maintenance.auto_optimize;
-  const intervalHours = config.maintenance.auto_optimize_interval_hours;
+  const enabled = effective.maintenance.auto_optimize;
+  const intervalHours = effective.maintenance.auto_optimize_interval_hours;
 
   const lastRunMs = details.last_optimize_at ? new Date(details.last_optimize_at).getTime() : null;
   const nextRunMs = lastRunMs !== null ? lastRunMs + intervalHours * SECONDS_PER_HOUR * 1000 - Date.now() : 0;
-
-  async function persist(next: { auto_optimize?: boolean; auto_optimize_interval_hours?: number }) {
-    try {
-      await saveConfig({ maintenance: next });
-    } catch (err) {
-      onActionResult({ type: 'error', text: 'Config save failed: ' + (err as Error).message });
-    }
-  }
 
   async function handleRunNow() {
     setRunning(true);
@@ -291,30 +285,37 @@ function ScheduledMaintenanceCard({
     <Surface level="low" className="p-6 space-y-4">
       <SectionHeader>Scheduled Maintenance</SectionHeader>
       <div className="flex flex-wrap items-center gap-3 font-sans text-sm">
-        <label className="flex items-center gap-2 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={enabled}
-            disabled={isSaving}
-            onChange={(e) => persist({ auto_optimize: e.target.checked })}
-            className="h-4 w-4 accent-primary"
-          />
-          <span className="text-on-surface">Auto-optimize</span>
-        </label>
-        <span className="text-on-surface-variant">every</span>
-        <select
-          value={intervalHours}
-          disabled={!enabled || isSaving}
-          onChange={(e) => persist({ auto_optimize_interval_hours: Number(e.target.value) })}
-          className="rounded-md border border-outline bg-surface-container px-2 py-1 text-on-surface text-sm"
+        <ScopedField
+          path="maintenance.auto_optimize"
+          label="Auto-optimize"
+          defaultScope="local"
         >
-          <option value={6}>6 hours</option>
-          <option value={12}>12 hours</option>
-          <option value={24}>24 hours</option>
-          <option value={72}>3 days</option>
-          <option value={168}>7 days</option>
-          <option value={720}>30 days</option>
-        </select>
+          {({ value, onChange }) => (
+            <Switch checked={value ?? false} onCheckedChange={onChange} />
+          )}
+        </ScopedField>
+        <span className="text-on-surface-variant">every</span>
+        <ScopedField
+          path="maintenance.auto_optimize_interval_hours"
+          label=""
+          defaultScope="local"
+        >
+          {({ value, onChange }) => (
+            <select
+              value={value ?? 24}
+              disabled={!enabled}
+              onChange={(e) => onChange(Number(e.target.value))}
+              className="rounded-md border border-outline bg-surface-container px-2 py-1 text-on-surface text-sm"
+            >
+              <option value={6}>6 hours</option>
+              <option value={12}>12 hours</option>
+              <option value={24}>24 hours</option>
+              <option value={72}>3 days</option>
+              <option value={168}>7 days</option>
+              <option value={720}>30 days</option>
+            </select>
+          )}
+        </ScopedField>
       </div>
       <p className="font-sans text-sm text-on-surface-variant">
         Last run: {details.last_optimize_at ? formatTimeAgo(details.last_optimize_at) : 'never'}

--- a/packages/myco/ui/src/pages/Settings.tsx
+++ b/packages/myco/ui/src/pages/Settings.tsx
@@ -1,12 +1,15 @@
-import { useState, useCallback, useRef, useMemo, useEffect } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { CheckCircle, XCircle, Loader2 } from 'lucide-react';
-import { useConfig, type MycoConfig, type MycoConfigPatch } from '../hooks/use-config';
 import { useDaemon } from '../hooks/use-daemon';
-import { useRestart } from '../hooks/use-restart';
-import { useProviders, useTestProvider } from '../hooks/use-providers';
+import {
+  useProviders,
+  useTestProvider,
+  seedDraftFromProviderType,
+  draftToProviderConfig,
+  type ProviderDraft,
+} from '../hooks/use-providers';
 import { useModels } from '../hooks/use-models';
 import { fetchJson } from '../lib/api';
-import { parseNumericField } from '../lib/format';
 import { DEFAULT_DIGEST_TIER, DEFAULT_MAX_SPORES } from '../lib/constants';
 import { Surface } from '../components/ui/surface';
 import { PageHeader } from '../components/ui/page-header';
@@ -22,6 +25,10 @@ import {
 } from '../components/ui/select';
 import { Switch } from '../components/ui/switch';
 import { PlanCaptureCard } from '../components/config/PlanCaptureCard';
+import { ScopedField } from '../components/config/ScopedField';
+import { ScopePill } from '../components/config/ScopePill';
+import { RestartGateProvider, RestartBanner } from '../components/config/restart-gate';
+import { useScopedConfig } from '../hooks/use-scoped-config';
 import { NotificationSettings } from '../components/notifications/NotificationSettings';
 import { ProviderModelSelector } from '../components/providers/ProviderModelSelector';
 
@@ -34,8 +41,6 @@ const PROVIDERS: { value: Provider; label: string }[] = [
   { value: 'openai-compatible', label: 'OpenAI-compatible' },
 ];
 
-type AgentProviderType = 'anthropic' | 'ollama' | 'lmstudio';
-
 const DIGEST_TIERS: { value: string; label: string }[] = [
   { value: '1500', label: '1.5K — Executive briefing' },
   { value: '5000', label: '5K — Deep onboarding' },
@@ -44,282 +49,13 @@ const DIGEST_TIERS: { value: string; label: string }[] = [
 
 type TestState = 'idle' | 'testing' | 'success' | 'error';
 
-interface FormState {
-  daemonPort: string;
-  logLevel: LogLevel;
-  logRetentionDays: string;
-  embeddingProvider: Provider;
-  embeddingModel: string;
-  embeddingBaseUrl: string;
-  contextDigestTier: string;
-  contextPromptSearch: boolean;
-  contextMaxSpores: string;
-  agentProviderType: AgentProviderType | '';
-  agentModel: string;
-  agentBaseUrl: string;
-  agentContextLength: string;
-}
-
-function toFormState(config: MycoConfig): FormState {
-  return {
-    daemonPort: config.daemon.port != null ? String(config.daemon.port) : '',
-    logLevel: config.daemon.log_level,
-    logRetentionDays: String(config.daemon.log_retention_days),
-    embeddingProvider: config.embedding.provider,
-    embeddingModel: config.embedding.model,
-    embeddingBaseUrl: config.embedding.base_url ?? '',
-    contextDigestTier: String(config.context?.digest_tier ?? DEFAULT_DIGEST_TIER),
-    contextPromptSearch: config.context?.prompt_search ?? true,
-    contextMaxSpores: String(config.context?.prompt_max_spores ?? DEFAULT_MAX_SPORES),
-    agentProviderType: (config.agent?.provider?.type as AgentProviderType) ?? '',
-    agentModel: config.agent?.provider?.model ?? config.agent?.model ?? '',
-    agentBaseUrl: config.agent?.provider?.base_url ?? '',
-    agentContextLength: config.agent?.provider?.context_length?.toString() ?? '',
-  };
-}
-
-/* ---------- Per-section patch builders ---------- */
-//
-// Each section's save button emits a patch containing only its own slice.
-// The server deep-merges the patch into the current config, so unrelated
-// sections are preserved without the UI needing to know about them.
-
-/** Build an agent-section patch with auto-enable/disable side effects on the
- *  task toggles. Configuring a provider for the first time turns the agent
- *  pipeline on; clearing the provider turns it off. */
-function buildAgentPatch(form: FormState, original: MycoConfig): MycoConfigPatch {
-  const hadProvider = !!original.agent?.provider;
-  const hasProvider = form.agentProviderType !== '';
-
-  const agentProvider = hasProvider
-    ? {
-        type: form.agentProviderType as AgentProviderType,
-        ...(form.agentModel ? { model: form.agentModel } : {}),
-        ...(form.agentBaseUrl ? { base_url: form.agentBaseUrl } : {}),
-        ...(form.agentContextLength ? { context_length: Number(form.agentContextLength) } : {}),
-      }
-    : undefined;
-
-  let scheduledEnabled = original.agent?.scheduled_tasks_enabled;
-  let eventEnabled = original.agent?.event_tasks_enabled;
-  if (hasProvider && !hadProvider) {
-    scheduledEnabled = true;
-    eventEnabled = true;
-  } else if (!hasProvider && hadProvider) {
-    scheduledEnabled = false;
-    eventEnabled = false;
-  }
-
-  return {
-    agent: {
-      provider: agentProvider,
-      model: undefined,
-      scheduled_tasks_enabled: scheduledEnabled,
-      event_tasks_enabled: eventEnabled,
-    },
-  };
-}
-
-function buildSectionPatch(section: SaveSection, form: FormState, original: MycoConfig): MycoConfigPatch {
-  switch (section) {
-    case 'agent':
-      return buildAgentPatch(form, original);
-    case 'embedding':
-      return {
-        embedding: {
-          provider: form.embeddingProvider,
-          model: form.embeddingModel,
-          base_url: form.embeddingBaseUrl !== '' ? form.embeddingBaseUrl : undefined,
-        },
-      };
-    case 'context':
-      return {
-        context: {
-          digest_tier: parseNumericField(form.contextDigestTier, DEFAULT_DIGEST_TIER),
-          prompt_search: form.contextPromptSearch,
-          prompt_max_spores: parseNumericField(form.contextMaxSpores, DEFAULT_MAX_SPORES),
-        },
-      };
-    case 'project':
-      return {
-        daemon: {
-          port: form.daemonPort !== '' ? Number(form.daemonPort) : null,
-          log_level: form.logLevel,
-          log_retention_days: Number(form.logRetentionDays),
-        },
-      };
-  }
-}
-
-/* ---------- Per-section field map (drives dirty checks) ---------- */
-
-type SaveSection = 'agent' | 'embedding' | 'context' | 'project';
-
-const SECTION_FIELDS: Record<SaveSection, (keyof FormState)[]> = {
-  agent: ['agentProviderType', 'agentModel', 'agentBaseUrl', 'agentContextLength'],
-  embedding: ['embeddingProvider', 'embeddingModel', 'embeddingBaseUrl'],
-  context: ['contextDigestTier', 'contextPromptSearch', 'contextMaxSpores'],
-  project: ['daemonPort', 'logLevel', 'logRetentionDays'],
-};
-
-function isSectionDirty(section: SaveSection, form: FormState, orig: FormState): boolean {
-  return SECTION_FIELDS[section].some((k) => form[k] !== orig[k]);
-}
-
-/* ---------- Sub-components ---------- */
-
-function FieldLabel({ children, hint }: { children: React.ReactNode; hint?: string }) {
-  return (
-    <label className="font-sans text-sm font-medium text-on-surface">
-      {children}
-      {hint && (
-        <span className="ml-1 font-sans text-xs text-on-surface-variant font-normal">({hint})</span>
-      )}
-    </label>
-  );
-}
-
-function FieldHint({ children }: { children: React.ReactNode }) {
-  return <p className="font-sans text-xs text-on-surface-variant">{children}</p>;
-}
-
-/** Per-section Save button + status message footer. Rendered at the bottom of each Surface card. */
-function SectionSaveRow({
-  dirty,
-  isSaving,
-  showMessage,
-  message,
-  onSave,
-}: {
-  dirty: boolean;
-  isSaving: boolean;
-  showMessage: boolean;
-  message: { type: 'success' | 'error'; text: string } | null;
-  onSave: () => void;
-}) {
-  return (
-    <div className="flex items-center gap-3 pt-2 border-t border-outline-variant/20">
-      <Button onClick={onSave} disabled={!dirty || isSaving} size="sm">
-        {isSaving ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
-        Save
-      </Button>
-      {showMessage && message && (
-        <span
-          className={
-            message.type === 'success'
-              ? 'font-sans text-xs text-primary'
-              : 'font-sans text-xs text-tertiary'
-          }
-        >
-          {message.text}
-        </span>
-      )}
-    </div>
-  );
-}
-
 /* ---------- Page ---------- */
 
 export default function Settings() {
-  const { config, isLoading, saveConfig, isSaving } = useConfig();
+  const { effective, isLoading } = useScopedConfig();
   const { data: stats } = useDaemon();
-  const { restart } = useRestart();
-  const { data: providersData, isPending: isLoadingProviders } = useProviders();
-  const agentTestMutation = useTestProvider();
 
-  // Initialise form from config on first load. A ref tracks whether we have
-  // initialised so we only seed once — subsequent config refetches do NOT
-  // overwrite user edits. This replaces the previous useEffect + null-check
-  // pattern which is a React anti-pattern for derived initial state.
-  const formInitialised = useRef(false);
-  const [form, setForm] = useState<FormState | null>(null);
-  if (config && !formInitialised.current) {
-    formInitialised.current = true;
-    if (form === null) {
-      setForm(toFormState(config));
-    }
-  }
-
-  const [saveMessage, setSaveMessage] = useState<{ section: SaveSection; type: 'success' | 'error'; text: string } | null>(null);
-  const [testState, setTestState] = useState<TestState>('idle');
-  const [testMessage, setTestMessage] = useState<string>('');
-
-  // Fetch embedding models for the currently selected provider/baseUrl.
-  const { data: embeddingModelsData } = useModels(
-    form?.embeddingProvider ?? null,
-    form?.embeddingBaseUrl || undefined,
-    'embedding',
-  );
-  const embeddingModels = embeddingModelsData?.models ?? [];
-
-  // Backfill the agent model when an older config has provider.type but no
-  // model — fall back to the provider's first available model so the dropdown
-  // never shows a blank Save state. Only fires when the model field is empty.
-  useEffect(() => {
-    if (!form || form.agentProviderType === '' || form.agentModel !== '') return;
-    const firstModel = providersData?.providers.find(p => p.type === form.agentProviderType)?.models?.[0];
-    if (firstModel) {
-      setForm(prev => prev ? { ...prev, agentModel: firstModel } : prev);
-    }
-  }, [form, providersData]);
-
-  // origForm is memoized on config so per-keystroke re-renders don't reallocate it.
-  const origForm = useMemo(() => (config ? toFormState(config) : null), [config]);
-  const agentDirty = !!(form && origForm && isSectionDirty('agent', form, origForm));
-  const embeddingDirty = !!(form && origForm && isSectionDirty('embedding', form, origForm));
-  const contextDirty = !!(form && origForm && isSectionDirty('context', form, origForm));
-  const projectDirty = !!(form && origForm && isSectionDirty('project', form, origForm));
-
-  const setField = useCallback(<K extends keyof FormState>(key: K, value: FormState[K]) => {
-    setForm(prev => (prev ? { ...prev, [key]: value } : prev));
-    setSaveMessage(null);
-  }, []);
-
-  const handleSectionSave = useCallback(async (section: SaveSection) => {
-    if (!form || !config) return;
-    setSaveMessage(null);
-    try {
-      await saveConfig(buildSectionPatch(section, form, config));
-      setSaveMessage({ section, type: 'success', text: 'Saved. Restarting daemon...' });
-      try {
-        await restart();
-      } catch {
-        // Restart may fail if daemon is already restarting; the save still succeeded
-        setSaveMessage({ section, type: 'success', text: 'Saved. Daemon restart may require manual action.' });
-      }
-    } catch {
-      setSaveMessage({ section, type: 'error', text: 'Failed to save.' });
-    }
-  }, [form, config, saveConfig, restart]);
-
-  const handleTestConnection = useCallback(async () => {
-    if (!form) return;
-    setTestState('testing');
-    setTestMessage('');
-    try {
-      const params = new URLSearchParams({ provider: form.embeddingProvider, type: 'embedding' });
-      if (form.embeddingBaseUrl) params.set('base_url', form.embeddingBaseUrl);
-      const result = await fetchJson<{ provider: string; models: string[] }>(
-        `/models?${params.toString()}`,
-      );
-      const count = result.models.length;
-      setTestState('success');
-      setTestMessage(`Connected -- ${count} model${count !== 1 ? 's' : ''} available.`);
-    } catch (err) {
-      setTestState('error');
-      setTestMessage(err instanceof Error ? err.message : 'Connection failed.');
-    }
-  }, [form]);
-
-  const handleTestAgentProvider = useCallback(() => {
-    if (!form || !form.agentProviderType) return;
-    agentTestMutation.mutate({
-      type: form.agentProviderType,
-      ...(form.agentBaseUrl ? { base_url: form.agentBaseUrl } : {}),
-    });
-  }, [form, agentTestMutation]);
-
-  if (isLoading || !form || !config) {
+  if (isLoading || !effective) {
     return (
       <div className="p-6">
         <PageHeader title="Settings" />
@@ -328,283 +64,26 @@ export default function Settings() {
     );
   }
 
-  const vaultName = stats?.vault.name ?? config.embedding.provider;
-
-  const providers = providersData?.providers ?? [];
+  const vaultName = stats?.vault.name ?? effective.embedding.provider;
 
   return (
+    <RestartGateProvider>
     <div className="p-6">
       <PageHeader title="Settings" subtitle="Vault configuration and daemon settings" />
+      <RestartBanner />
 
       <div className="space-y-6">
         {/* ---- Top row: Myco Agent + Embedding side by side ---- */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* ---- Myco Agent section ---- */}
-        <Surface level="low" className="p-6 space-y-5 border-t-2 border-t-sage">
-          <SectionHeader>Myco Agent</SectionHeader>
-
-          {form.agentProviderType === '' ? (
-            <p className="font-sans text-sm text-on-surface-variant">
-              No provider configured -- data collection is active. Configure a provider
-              to enable the intelligence pipeline.
-            </p>
-          ) : null}
-
-          <ProviderModelSelector
-            providerType={form.agentProviderType}
-            model={form.agentModel}
-            baseUrl={form.agentBaseUrl}
-            contextLength={form.agentContextLength}
-            providers={providers}
-            isLoadingProviders={isLoadingProviders}
-            onProviderChange={(type) => {
-              setField('agentProviderType', type as AgentProviderType);
-              const providerInfo = providers.find(p => p.type === type);
-              // First available model defaults the dropdown so it never saves with an unset model
-              setField('agentModel', providerInfo?.models?.[0] ?? '');
-              setField('agentBaseUrl', providerInfo?.baseUrl ?? '');
-              setField('agentContextLength', '');
-              agentTestMutation.reset();
-            }}
-            onModelChange={(m) => setField('agentModel', m)}
-            onBaseUrlChange={(url) => {
-              setField('agentBaseUrl', url);
-              agentTestMutation.reset();
-            }}
-            onContextLengthChange={(ctx) => setField('agentContextLength', ctx)}
-          />
-
-          {form.agentProviderType !== '' && (
-            <>
-              <div className="flex items-center gap-3 pt-1">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleTestAgentProvider}
-                  disabled={agentTestMutation.isPending}
-                >
-                  {agentTestMutation.isPending ? (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  ) : null}
-                  Test Connection
-                </Button>
-                {agentTestMutation.isSuccess && agentTestMutation.data.ok && (
-                  <span className="flex items-center gap-1 font-sans text-sm text-primary">
-                    <CheckCircle className="h-4 w-4" />
-                    Connected — {agentTestMutation.data.latency_ms}ms
-                  </span>
-                )}
-                {agentTestMutation.isSuccess && !agentTestMutation.data.ok && (
-                  <span className="flex items-center gap-1 font-sans text-sm text-tertiary">
-                    <XCircle className="h-4 w-4" />
-                    {agentTestMutation.data.error ?? 'Connection failed.'}
-                  </span>
-                )}
-                {agentTestMutation.isError && (
-                  <span className="flex items-center gap-1 font-sans text-sm text-tertiary">
-                    <XCircle className="h-4 w-4" />
-                    {agentTestMutation.error.message}
-                  </span>
-                )}
-              </div>
-
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => {
-                  setField('agentProviderType', '');
-                  setField('agentModel', '');
-                  setField('agentBaseUrl', '');
-                  setField('agentContextLength', '');
-                  agentTestMutation.reset();
-                }}
-                className="text-xs text-on-surface-variant"
-              >
-                Clear provider
-              </Button>
-            </>
-          )}
-
-          <SectionSaveRow
-            dirty={agentDirty}
-            isSaving={isSaving}
-            showMessage={saveMessage?.section === 'agent'}
-            message={saveMessage}
-            onSave={() => handleSectionSave('agent')}
-          />
-        </Surface>
+        <AgentProviderCard />
 
         {/* ---- Embedding section ---- */}
-        <Surface level="low" className="p-6 space-y-5 border-t-2 border-t-ochre">
-          <SectionHeader>Embedding</SectionHeader>
-
-          <div className="space-y-4">
-            {/* Provider */}
-            <div className="space-y-1.5">
-              <FieldLabel>Provider</FieldLabel>
-              <Select
-                value={form.embeddingProvider}
-                onValueChange={v => {
-                  setField('embeddingProvider', v as Provider);
-                  setTestState('idle');
-                  setTestMessage('');
-                }}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {PROVIDERS.map(p => (
-                    <SelectItem key={p.value} value={p.value}>
-                      {p.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            {/* Model — dropdown when models are available, falls back to text input */}
-            <div className="space-y-1.5">
-              <FieldLabel>Model</FieldLabel>
-              {embeddingModels.length > 0 ? (
-                <Select
-                  value={form.embeddingModel}
-                  onValueChange={v => setField('embeddingModel', v)}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select a model" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {embeddingModels.map(m => (
-                      <SelectItem key={m} value={m}>
-                        <span className="font-mono text-sm">{m}</span>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              ) : (
-                <Input
-                  placeholder="bge-m3"
-                  value={form.embeddingModel}
-                  onChange={e => setField('embeddingModel', e.target.value)}
-                />
-              )}
-            </div>
-
-            {/* Base URL */}
-            <div className="space-y-1.5">
-              <FieldLabel hint="optional">Base URL</FieldLabel>
-              <Input
-                type="url"
-                placeholder="http://localhost:11434"
-                value={form.embeddingBaseUrl}
-                onChange={e => {
-                  setField('embeddingBaseUrl', e.target.value);
-                  setTestState('idle');
-                  setTestMessage('');
-                }}
-              />
-            </div>
-
-            {/* Test Connection */}
-            <div className="flex items-center gap-3 pt-1">
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={handleTestConnection}
-                disabled={testState === 'testing'}
-              >
-                {testState === 'testing' ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : null}
-                Test Connection
-              </Button>
-              {testState === 'success' && (
-                <span className="flex items-center gap-1 font-sans text-sm text-primary">
-                  <CheckCircle className="h-4 w-4" />
-                  {testMessage}
-                </span>
-              )}
-              {testState === 'error' && (
-                <span className="flex items-center gap-1 font-sans text-sm text-tertiary">
-                  <XCircle className="h-4 w-4" />
-                  {testMessage}
-                </span>
-              )}
-            </div>
-          </div>
-
-          <SectionSaveRow
-            dirty={embeddingDirty}
-            isSaving={isSaving}
-            showMessage={saveMessage?.section === 'embedding'}
-            message={saveMessage}
-            onSave={() => handleSectionSave('embedding')}
-          />
-        </Surface>
+        <EmbeddingCard />
         </div>{/* end top row grid */}
 
         {/* ---- Context Injection section ---- */}
-        <Surface level="low" className="p-6 space-y-5 border-t-2 border-t-ochre">
-          <SectionHeader>Context Injection</SectionHeader>
-
-          <div className="space-y-4">
-            {/* Digest tier */}
-            <div className="space-y-1.5">
-              <FieldLabel>Digest Tier</FieldLabel>
-              <Select
-                value={form.contextDigestTier}
-                onValueChange={v => setField('contextDigestTier', v)}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {DIGEST_TIERS.map(tier => (
-                    <SelectItem key={tier.value} value={tier.value}>
-                      {tier.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <FieldHint>Token budget for digest context injected at session start.</FieldHint>
-            </div>
-
-            {/* Prompt search toggle */}
-            <div className="flex items-center justify-between">
-              <div className="space-y-0.5">
-                <FieldLabel>Prompt Search</FieldLabel>
-                <FieldHint>Search vault for relevant observations on each prompt.</FieldHint>
-              </div>
-              <Switch checked={form.contextPromptSearch} onCheckedChange={v => setField('contextPromptSearch', v)} />
-            </div>
-
-            {/* Max spores per prompt */}
-            <div className="space-y-1.5">
-              <FieldLabel>Max Spores per Prompt</FieldLabel>
-              <Input
-                type="number"
-                min="0"
-                max="10"
-                placeholder="3"
-                value={form.contextMaxSpores}
-                onChange={e => setField('contextMaxSpores', e.target.value)}
-              />
-              <FieldHint>Maximum observations injected per prompt. Lower = leaner context.</FieldHint>
-            </div>
-          </div>
-
-          <SectionSaveRow
-            dirty={contextDirty}
-            isSaving={isSaving}
-            showMessage={saveMessage?.section === 'context'}
-            message={saveMessage}
-            onSave={() => handleSectionSave('context')}
-          />
-        </Surface>
+        <ContextInjectionCard />
 
         {/* ---- Notifications section ---- */}
         <NotificationSettings />
@@ -612,72 +91,488 @@ export default function Settings() {
         {/* ---- Plan Capture section ---- */}
         <PlanCaptureCard />
 
-        {/* ---- Project section ---- */}
-        <Surface level="low" className="p-6 space-y-5 border-t-2 border-t-sage">
-          <SectionHeader>Project</SectionHeader>
+        {/* ---- Project section (scoped-field POC) ---- */}
+        <ProjectCard vaultName={vaultName} />
+      </div>
+    </div>
+    </RestartGateProvider>
+  );
+}
 
-          <div className="space-y-4">
-            {/* Vault name -- read-only */}
-            <div className="space-y-1.5">
-              <FieldLabel>Vault Name</FieldLabel>
-              <Input value={vaultName} readOnly disabled className="text-on-surface-variant bg-surface-container-lowest" />
-            </div>
+function providerToDraft(p: { type?: string; model?: string; base_url?: string; context_length?: number } | undefined): ProviderDraft {
+  return {
+    type: (p?.type as ProviderDraft['type']) ?? '',
+    model: p?.model ?? '',
+    baseUrl: p?.base_url ?? '',
+    contextLength: p?.context_length?.toString() ?? '',
+  };
+}
 
-            {/* Daemon port */}
-            <div className="space-y-1.5">
-              <FieldLabel>Daemon Port</FieldLabel>
-              <Input
-                type="number"
-                placeholder="Auto"
-                value={form.daemonPort}
-                onChange={e => setField('daemonPort', e.target.value)}
-              />
-              <FieldHint>Leave blank to use a random available port.</FieldHint>
-            </div>
+/** Myco Agent — personal-default. Provider type/model/base-url/context all
+ *  live as the `agent.provider` object; each subfield writes via a nested
+ *  scoped path. Two coupled writes use setFields:
+ *    • setting a provider for the first time also enables both task toggles
+ *    • Clear Provider also disables both task toggles
+ *  These mirror the previous batched-Save behaviour but happen atomically. */
+function AgentProviderCard() {
+  const { effective, setField, setFields, isLocalOverride, resetField, promoteField } = useScopedConfig();
+  const { data: providersData, isPending: isLoadingProviders } = useProviders();
+  const agentTestMutation = useTestProvider();
 
-            {/* Log level */}
-            <div className="space-y-1.5">
-              <FieldLabel>Log Level</FieldLabel>
-              <Select
-                value={form.logLevel}
-                onValueChange={v => setField('logLevel', v as LogLevel)}
-              >
+  const providers = providersData?.providers ?? [];
+  const provider = effective?.agent?.provider;
+  const [draft, setDraft] = useState<ProviderDraft>(() => providerToDraft(provider));
+
+  // Re-sync when an external write changes the upstream value (other tab,
+  // promote/reset). The ref-based `useScopedConfig` no longer churns
+  // identities on every refetch, so this only fires on actual value change.
+  useEffect(() => { setDraft(providerToDraft(provider)); }, [provider]);
+
+  // Backfill the model when a legacy config has provider.type but no model.
+  // /simplify Q1: previously this only mutated draft state, leaving the on-disk
+  // value silently empty. Now it persists the chosen first-model so display
+  // and config agree without requiring the user to "touch" the field.
+  useEffect(() => {
+    if (draft.type === '' || draft.model !== '' || !providersData) return;
+    const firstModel = providers.find(p => p.type === draft.type)?.models?.[0];
+    if (firstModel) {
+      setDraft(prev => ({ ...prev, model: firstModel }));
+      void setField('agent.provider.model', firstModel, 'local');
+    }
+  }, [draft.type, draft.model, providers, providersData, setField]);
+
+  const personal = isLocalOverride('agent.provider');
+
+  const writeProvider = useCallback((next: ProviderDraft, autoEnableTasks: boolean) => {
+    const value = draftToProviderConfig(next);
+    if (autoEnableTasks) {
+      void setFields([
+        { path: 'agent.provider', value },
+        { path: 'agent.scheduled_tasks_enabled', value: true },
+        { path: 'agent.event_tasks_enabled', value: true },
+      ], 'local');
+    } else {
+      void setField('agent.provider', value, 'local');
+    }
+  }, [setField, setFields]);
+
+  const handleProviderTypeChange = useCallback((type: string) => {
+    const wasEmpty = draft.type === '';
+    const next = seedDraftFromProviderType(type, providers);
+    setDraft(next);
+    agentTestMutation.reset();
+    writeProvider(next, wasEmpty);
+  }, [draft.type, providers, writeProvider, agentTestMutation]);
+
+  const handleModelChange = useCallback((model: string) => {
+    setDraft(prev => ({ ...prev, model }));
+    if (draft.type !== '') void setField('agent.provider.model', model, 'local');
+  }, [draft.type, setField]);
+
+  const handleBaseUrlChange = useCallback((baseUrl: string) => {
+    setDraft(prev => ({ ...prev, baseUrl }));
+    agentTestMutation.reset();
+  }, [agentTestMutation]);
+
+  const handleBaseUrlBlur = useCallback(() => {
+    if (draft.type !== '') void setField('agent.provider.base_url', draft.baseUrl || undefined, 'local');
+  }, [draft.type, draft.baseUrl, setField]);
+
+  const handleContextLengthChange = useCallback((contextLength: string) => {
+    setDraft(prev => ({ ...prev, contextLength }));
+  }, []);
+
+  const handleContextLengthBlur = useCallback(() => {
+    if (draft.type !== '') {
+      const n = draft.contextLength === '' ? undefined : Number(draft.contextLength);
+      void setField('agent.provider.context_length', n, 'local');
+    }
+  }, [draft.type, draft.contextLength, setField]);
+
+  const handleClear = useCallback(async () => {
+    setDraft({ type: '', model: '', baseUrl: '', contextLength: '' });
+    agentTestMutation.reset();
+    // /simplify Q7: sequence the two writes so a partial failure (e.g. the
+    // toggles write succeeds but resetField fails) doesn't leave the user
+    // with disabled tasks AND a still-set provider — we'd rather both
+    // succeed or both error out.
+    //
+    // deepMerge skips undefined source values, so writing { provider: undefined }
+    // won't clear a project-scoped provider. resetField clears the local
+    // override only; a project-scoped provider must be removed from
+    // myco.yaml directly.
+    try {
+      await setFields([
+        { path: 'agent.scheduled_tasks_enabled', value: false },
+        { path: 'agent.event_tasks_enabled', value: false },
+      ], 'local');
+      await resetField('agent.provider');
+    } catch (err) {
+      console.error('[agent-card] clear provider failed', err);
+    }
+  }, [setFields, resetField, agentTestMutation]);
+
+  const handleTestConnection = useCallback(() => {
+    if (draft.type === '') return;
+    agentTestMutation.mutate({
+      type: draft.type,
+      ...(draft.baseUrl ? { base_url: draft.baseUrl } : {}),
+    });
+  }, [draft.type, draft.baseUrl, agentTestMutation]);
+
+  return (
+    <Surface level="low" className="p-6 space-y-5 border-t-2 border-t-sage">
+      <SectionHeader>
+        <span className="flex items-center gap-2">
+          Myco Agent
+          {personal && <ScopePill onPromote={() => promoteField('agent.provider')} onReset={() => resetField('agent.provider')} />}
+        </span>
+      </SectionHeader>
+
+      {draft.type === '' ? (
+        <p className="font-sans text-sm text-on-surface-variant">
+          No provider configured -- data collection is active. Configure a provider
+          to enable the intelligence pipeline.
+        </p>
+      ) : null}
+
+      <ProviderModelSelector
+        providerType={draft.type}
+        model={draft.model}
+        baseUrl={draft.baseUrl}
+        contextLength={draft.contextLength}
+        providers={providers}
+        isLoadingProviders={isLoadingProviders}
+        onProviderChange={handleProviderTypeChange}
+        onModelChange={handleModelChange}
+        onBaseUrlChange={handleBaseUrlChange}
+        onContextLengthChange={handleContextLengthChange}
+        onBaseUrlBlur={handleBaseUrlBlur}
+        onContextLengthBlur={handleContextLengthBlur}
+      />
+
+      {draft.type !== '' && (
+        <>
+          <div className="flex items-center gap-3 pt-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleTestConnection}
+              disabled={agentTestMutation.isPending}
+            >
+              {agentTestMutation.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              Test Connection
+            </Button>
+            {agentTestMutation.isSuccess && agentTestMutation.data.ok && (
+              <span className="flex items-center gap-1 font-sans text-sm text-primary">
+                <CheckCircle className="h-4 w-4" />
+                Connected — {agentTestMutation.data.latency_ms}ms
+              </span>
+            )}
+            {agentTestMutation.isSuccess && !agentTestMutation.data.ok && (
+              <span className="flex items-center gap-1 font-sans text-sm text-tertiary">
+                <XCircle className="h-4 w-4" />
+                {agentTestMutation.data.error ?? 'Connection failed.'}
+              </span>
+            )}
+            {agentTestMutation.isError && (
+              <span className="flex items-center gap-1 font-sans text-sm text-tertiary">
+                <XCircle className="h-4 w-4" />
+                {agentTestMutation.error.message}
+              </span>
+            )}
+          </div>
+
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleClear}
+            className="text-xs text-on-surface-variant"
+          >
+            Clear provider
+          </Button>
+        </>
+      )}
+    </Surface>
+  );
+}
+
+/** Embedding — provider endpoint + model selection. Personal-default by
+ *  design: each machine has its own Ollama/OpenAI-compatible endpoint and
+ *  may prefer different models based on local hardware. */
+function EmbeddingCard() {
+  const { effective } = useScopedConfig();
+  const currentProvider = effective?.embedding.provider ?? 'ollama';
+  const currentBaseUrl = effective?.embedding.base_url ?? '';
+  const { data: embeddingModelsData } = useModels(currentProvider, currentBaseUrl || undefined, 'embedding');
+  const embeddingModels = embeddingModelsData?.models ?? [];
+  const [testState, setTestState] = useState<TestState>('idle');
+  const [testMessage, setTestMessage] = useState('');
+
+  const handleTestConnection = useCallback(async () => {
+    setTestState('testing');
+    setTestMessage('');
+    try {
+      const params = new URLSearchParams({ provider: currentProvider, type: 'embedding' });
+      if (currentBaseUrl) params.set('base_url', currentBaseUrl);
+      const result = await fetchJson<{ provider: string; models: string[] }>(`/models?${params.toString()}`);
+      const count = result.models.length;
+      setTestState('success');
+      setTestMessage(`Connected -- ${count} model${count !== 1 ? 's' : ''} available.`);
+    } catch (err) {
+      setTestState('error');
+      setTestMessage(err instanceof Error ? err.message : 'Connection failed.');
+    }
+  }, [currentProvider, currentBaseUrl]);
+
+  return (
+    <Surface level="low" className="p-6 space-y-5 border-t-2 border-t-ochre">
+      <SectionHeader>Embedding</SectionHeader>
+
+      <div className="space-y-4">
+        <ScopedField
+          path="embedding.provider"
+          label="Provider"
+          defaultScope="local"
+          requiresRestart
+        >
+          {({ value, onChange }) => (
+            <Select value={value ?? 'ollama'} onValueChange={(v) => { onChange(v as Provider); setTestState('idle'); }}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PROVIDERS.map((p) => (
+                  <SelectItem key={p.value} value={p.value}>
+                    {p.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </ScopedField>
+
+        <ScopedField
+          path="embedding.model"
+          label="Model"
+          defaultScope="local"
+          requiresRestart
+          commitOn={embeddingModels.length > 0 ? 'change' : 'blur'}
+        >
+          {({ value, onChange, onBlur }) =>
+            embeddingModels.length > 0 ? (
+              <Select value={value ?? ''} onValueChange={onChange}>
                 <SelectTrigger>
-                  <SelectValue />
+                  <SelectValue placeholder="Select a model" />
                 </SelectTrigger>
                 <SelectContent>
-                  {LOG_LEVELS.map(level => (
-                    <SelectItem key={level} value={level}>
-                      {level}
+                  {embeddingModels.map((m) => (
+                    <SelectItem key={m} value={m}>
+                      <span className="font-mono text-sm">{m}</span>
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
-            </div>
+            ) : (
+              <Input
+                placeholder="bge-m3"
+                value={value ?? ''}
+                onChange={(e) => onChange(e.target.value)}
+                onBlur={onBlur}
+              />
+            )
+          }
+        </ScopedField>
 
-            {/* Log retention */}
-            <div className="space-y-1.5">
-              <FieldLabel>Log Retention (days)</FieldLabel>
+        <ScopedField
+          path="embedding.base_url"
+          label="Base URL"
+          hint="optional"
+          defaultScope="local"
+          requiresRestart
+          commitOn="blur"
+          parse={(v) => (v === '' ? (undefined as unknown as string) : v)}
+        >
+          {({ value, onChange, onBlur }) => (
+            <Input
+              type="url"
+              placeholder="http://localhost:11434"
+              value={value ?? ''}
+              onChange={(e) => { onChange(e.target.value); setTestState('idle'); }}
+              onBlur={onBlur}
+            />
+          )}
+        </ScopedField>
+
+        <div className="flex items-center gap-3 pt-1">
+          <Button type="button" variant="ghost" size="sm" onClick={handleTestConnection} disabled={testState === 'testing'}>
+            {testState === 'testing' ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            Test Connection
+          </Button>
+          {testState === 'success' && (
+            <span className="flex items-center gap-1 font-sans text-sm text-primary">
+              <CheckCircle className="h-4 w-4" />
+              {testMessage}
+            </span>
+          )}
+          {testState === 'error' && (
+            <span className="flex items-center gap-1 font-sans text-sm text-tertiary">
+              <XCircle className="h-4 w-4" />
+              {testMessage}
+            </span>
+          )}
+        </div>
+      </div>
+    </Surface>
+  );
+}
+
+/** Context Injection — project-default fields shape the intelligence
+ *  pipeline's input budget, so they should be consistent across the team
+ *  by default. Still overridable per-machine via the Personal pill. */
+function ContextInjectionCard() {
+  return (
+    <Surface level="low" className="p-6 space-y-5 border-t-2 border-t-ochre">
+      <SectionHeader>Context Injection</SectionHeader>
+
+      <div className="space-y-4">
+        <ScopedField
+          path="context.digest_tier"
+          label="Digest Tier"
+          defaultScope="project"
+          hint="token budget for session-start digest"
+        >
+          {({ value, onChange }) => (
+            <Select value={String(value ?? DEFAULT_DIGEST_TIER)} onValueChange={(v) => onChange(Number(v))}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {DIGEST_TIERS.map((tier) => (
+                  <SelectItem key={tier.value} value={tier.value}>
+                    {tier.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </ScopedField>
+
+        <ScopedField
+          path="context.prompt_search"
+          label="Prompt Search"
+          defaultScope="project"
+          hint="search vault for observations on each prompt"
+        >
+          {({ value, onChange }) => (
+            <Switch checked={value ?? true} onCheckedChange={onChange} />
+          )}
+        </ScopedField>
+
+        <ScopedField
+          path="context.prompt_max_spores"
+          label="Max Spores per Prompt"
+          defaultScope="project"
+          commitOn="blur"
+          hint="0–10; lower = leaner context"
+        >
+          {({ value, onChange, onBlur }) => (
+            <Input
+              type="number"
+              min="0"
+              max="10"
+              placeholder={String(DEFAULT_MAX_SPORES)}
+              value={value ?? ''}
+              onChange={(e) => onChange(Number(e.target.value))}
+              onBlur={onBlur}
+            />
+          )}
+        </ScopedField>
+      </div>
+    </Surface>
+  );
+}
+
+/** Project card rebuilt on the scoped-field pattern — writes immediately to
+ *  the chosen scope, surfaces a page-level "Restart required" banner, and
+ *  lets any field be promoted/reset between personal and project scope. */
+function ProjectCard({ vaultName }: { vaultName: string }) {
+  return (
+    <Surface level="low" className="p-6 space-y-5 border-t-2 border-t-sage">
+      <SectionHeader>Project</SectionHeader>
+
+      <div className="space-y-4">
+        {/* Vault name -- read-only */}
+        <div className="space-y-1.5">
+          <label className="font-sans text-sm font-medium text-on-surface">Vault Name</label>
+          <Input value={vaultName} readOnly disabled className="text-on-surface-variant bg-surface-container-lowest" />
+        </div>
+
+        <ScopedField
+          path="daemon.port"
+          label="Daemon Port"
+          defaultScope="local"
+          requiresRestart
+          commitOn="blur"
+        >
+          {({ value, onChange, onBlur }) => (
+            <>
               <Input
                 type="number"
-                min={1}
-                max={365}
-                className="w-24"
-                value={form.logRetentionDays}
-                onChange={e => setField('logRetentionDays', e.target.value)}
+                placeholder="Auto"
+                value={value ?? ''}
+                onChange={(e) => onChange(e.target.value === '' ? null : Number(e.target.value))}
+                onBlur={onBlur}
               />
-            </div>
-          </div>
+              <p className="font-sans text-xs text-on-surface-variant">Leave blank to use a random available port.</p>
+            </>
+          )}
+        </ScopedField>
 
-          <SectionSaveRow
-            dirty={projectDirty}
-            isSaving={isSaving}
-            showMessage={saveMessage?.section === 'project'}
-            message={saveMessage}
-            onSave={() => handleSectionSave('project')}
-          />
-        </Surface>
+        <ScopedField
+          path="daemon.log_level"
+          label="Log Level"
+          defaultScope="local"
+          requiresRestart
+        >
+          {({ value, onChange }) => (
+            <Select value={value ?? 'info'} onValueChange={(v) => onChange(v as LogLevel)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {LOG_LEVELS.map((level) => (
+                  <SelectItem key={level} value={level}>
+                    {level}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </ScopedField>
+
+        <ScopedField
+          path="daemon.log_retention_days"
+          label="Log Retention (days)"
+          defaultScope="local"
+          requiresRestart
+          commitOn="blur"
+        >
+          {({ value, onChange, onBlur }) => (
+            <Input
+              type="number"
+              min={1}
+              max={365}
+              className="w-24"
+              value={value ?? ''}
+              onChange={(e) => onChange(Number(e.target.value))}
+              onBlur={onBlur}
+            />
+          )}
+        </ScopedField>
       </div>
-    </div>
+    </Surface>
   );
 }

--- a/packages/myco/ui/src/providers/appearance.tsx
+++ b/packages/myco/ui/src/providers/appearance.tsx
@@ -6,14 +6,8 @@ import {
   useMemo,
   type ReactNode,
 } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import {
-  fetchMergedConfig,
-  fetchLocalConfig,
-  writeScopedConfig,
-  clearLocalConfigKeys,
-  type AppearanceValues,
-} from '../lib/api';
+import { useScopedConfig } from '../hooks/use-scoped-config';
+import type { AppearanceValues } from '@myco/config/appearance-values';
 
 export type Theme = AppearanceValues['theme'];
 export type Mode = AppearanceValues['mode'];
@@ -124,35 +118,23 @@ function applyAppearance(a: Appearance): void {
 }
 
 export function AppearanceProvider({ children }: { children: ReactNode }) {
-  const qc = useQueryClient();
-  const merged = useQuery({
-    queryKey: ['config', 'merged'],
-    queryFn: ({ signal }) => fetchMergedConfig(signal),
-  });
-  const local = useQuery({
-    queryKey: ['config', 'local'],
-    queryFn: ({ signal }) => fetchLocalConfig(signal),
-  });
+  const { effective: cfg, local: localCfg, setField, resetField, promoteField } = useScopedConfig();
 
   const effective: Appearance = useMemo(
-    () => (merged.data?.appearance as Appearance | undefined) ?? DEFAULT_APPEARANCE,
-    [
-      merged.data?.appearance?.theme,
-      merged.data?.appearance?.mode,
-      merged.data?.appearance?.font,
-      merged.data?.appearance?.density,
-    ],
+    () => ((cfg?.appearance as Appearance | undefined) ?? DEFAULT_APPEARANCE),
+    [cfg?.appearance],
   );
 
   const localAppearance = useMemo(
-    () => (local.data?.appearance ?? {}) as Partial<Appearance>,
-    [local.data],
+    () => (localCfg.appearance ?? {}) as Partial<Appearance>,
+    [localCfg.appearance],
   );
 
   useEffect(() => {
     applyAppearance(effective);
   }, [effective]);
 
+  // System-mode follow: re-apply when the OS scheme flips.
   useEffect(() => {
     if (effective.mode !== 'system') return;
     const mql = window.matchMedia(LIGHT_MEDIA_QUERY);
@@ -162,30 +144,27 @@ export function AppearanceProvider({ children }: { children: ReactNode }) {
   }, [effective]);
 
   const set: AppearanceContextValue['set'] = useCallback(
-    async (key, value, scope) => {
-      await writeScopedConfig(scope, { appearance: { [key]: value } });
-      await qc.invalidateQueries({ queryKey: ['config'] });
-    },
-    [qc],
+    (key, value, scope) => setField(`appearance.${key}`, value, scope),
+    [setField],
   );
 
   const resetKey: AppearanceContextValue['resetKey'] = useCallback(
-    async (key) => {
-      await clearLocalConfigKeys([`appearance.${key}`]);
-      await qc.invalidateQueries({ queryKey: ['config'] });
-    },
-    [qc],
+    (key) => resetField(`appearance.${key}`),
+    [resetField],
   );
 
-  const saveAllAsProject = useCallback(async () => {
-    await writeScopedConfig('project', { appearance: effective });
-    await qc.invalidateQueries({ queryKey: ['config'] });
-  }, [effective, qc]);
+  // Promote the WHOLE appearance block to project — single atomic write +
+  // local-clear via promoteField, which already does both steps.
+  const saveAllAsProject = useCallback(
+    () => promoteField('appearance'),
+    [promoteField],
+  );
 
-  const resetAll = useCallback(async () => {
-    await clearLocalConfigKeys(['appearance']);
-    await qc.invalidateQueries({ queryKey: ['config'] });
-  }, [qc]);
+  // Reset all appearance overrides by clearing the entire local subtree.
+  const resetAll = useCallback(
+    () => resetField('appearance'),
+    [resetField],
+  );
 
   const value = useMemo<AppearanceContextValue>(
     () => ({


### PR DESCRIPTION
## Summary

Introduces a reusable scope-aware settings pattern across the entire Settings + Operations UI. Every config field writes immediately to its default scope (local or project), shows a **Personal** pill when an active local override exists (or hides it entirely for project-only fields), and exposes _Save to project_ (promote) and _Reset to project_ (revert) menu actions. Restart-gated fields flag a page-level **Restart required** banner with a single Restart button.

Default scopes follow the matrix Chris and I walked through: per-machine concerns (providers, logs, maintenance, notifications, backup) default to **personal**; team-consistency concerns (context budget, pipeline cadence, plan dirs) default to **project**. Plan dirs are locked to project scope by design.

## New primitives
- `useScopedConfig` — fetches merged + local; exposes `setField` / `setFields` (nested-path writes), `resetField`, `promoteField`, `isLocalOverride`.
- `<ScopedField>` — render-prop wrapper; write-on-change for booleans/selects, write-on-blur for text inputs; optional `requiresRestart` flag; optional `lockScope` to fix the field to one scope and hide the Personal pill.
- `RestartGateProvider` + `<RestartBanner>` — tracks which restart-gated paths have been written since the last daemon restart.
- Server: `reconcilePlanWatch()` runs after every successful scoped write, so changes to `capture.plan_dirs` refresh the in-memory plan-watcher state without going through the legacy `/config/plan-dirs` endpoint.

## Migrated cards

| Card | Default scope | Notes |
|---|---|---|
| Settings · Project | personal | `daemon.port`, `daemon.log_level`, `daemon.log_retention_days` (all `requiresRestart`) |
| Settings · Context Injection | project | `context.digest_tier`, `context.prompt_search`, `context.prompt_max_spores` |
| Settings · Embedding | personal | `embedding.provider`, `embedding.model`, `embedding.base_url` (restart-gated) |
| Settings · Myco Agent | personal | `agent.provider.*` via coupled `setFields`; section-level Personal pill; Clear Provider also disables both task toggles atomically |
| Settings · Plan Capture | project (locked) | `capture.plan_dirs`, `capture.ignore_plan_dirs_in_git`; `lockScope='project'` hides the Personal pill — these are project-only by design |
| Settings · Notifications | personal | `notifications.enabled/default_mode/system_notifications`, per-domain `enabled` + `mode` (nested writes via dotted paths) |
| Operations · Maintenance | personal | `maintenance.auto_optimize`, `maintenance.auto_optimize_interval_hours` |
| Operations · Backup dir | personal | `backup.dir` (restart-gated) — backup/restore actions stay on dedicated endpoints |
| /agent · Config | personal + project | `scheduled/event_tasks_enabled` (personal); `summary_batch_interval` (project) |

## Not migrated (deliberate)
**Team page** — `/team/connect` is an auth/onboarding flow: it takes URL + API key, validates against the Cloudflare Worker, exchanges for team identity, then writes config. Breaking it into per-field scoped writes would let users half-configure team sync and crash at runtime. The other team actions (`/backfill`, `/retry-failed`, `/upgrade-worker`, `/rotate-mcp-token`) are operational commands, not config edits. Keeping the dedicated flow.

The legacy `useConfig` hook is gone (no callers); only the `MycoConfig` type remains for shared type imports. The legacy `/api/config/plan-dirs` POST endpoint stays for now (the legacy GET still serves symbiont-derived dirs which the new UI still uses); could be retired in a follow-up.

## Future work (CQRS-style separation)
Three separate "side effects of config change" hooks now live in main.ts (`reconcileConfiguredSymbionts`, `reconcilePlanWatch`, `computeConfigHash`). Worth formalizing as a `onScopedConfigChange(pathPrefix, handler)` registry so reactions self-register instead of accumulating in the route handler. Out of scope here.

## Test plan
- [x] `make build` (tsc + vitest + tsup + vite) green
- [x] Smoke: write-on-change to local scope (Maintenance.auto_optimize) — lands in `local.yaml`, `myco.yaml` untouched
- [x] Smoke: write-on-change to project scope (Context.prompt_search) — lands in `myco.yaml`, `local.yaml` untouched
- [x] Smoke: write-on-blur via real user interaction (Daemon Port)
- [x] Smoke: Personal pill `Save to project` — promotes local value to project, clears local key
- [x] Smoke: Personal pill `Reset to project` — clears local override, merged falls back
- [x] Smoke: Restart banner aggregation across multiple restart-gated changes
- [x] Smoke: nested-path write via `notifications.domains.<domain>.enabled`
- [x] Smoke: Plan Capture scoped write persists to `myco.yaml`, no Personal pill rendered
- [x] Smoke: Backup dir scoped write to `local.yaml`, project untouched
- [x] Smoke: Agent provider atomic write — provider + task toggles coexist after one write
- [ ] Manual: exercise every migrated card in a real vault
- [x] Manual: verify Appearance sidebar (unchanged) still works alongside

## Known limitations preserved
- `deepMerge` skips `undefined` source values, so writing `undefined` via `setField` doesn't clear a field — only `resetField` / `clearLocalConfigKeys` does, and only for the local scope. Clear Provider now uses `resetField('agent.provider')` to clear local overrides + `setFields` to disable task toggles atomically; clearing a project-scoped provider still requires editing `myco.yaml` directly. Pre-existing limitation, not introduced here.
- `/api/config/plan-dirs` GET handler returns the in-memory `planWatchConfig.watchDirs` snapshot from daemon startup — it's stale after any update. Pre-existing latent bug; new UI uses `/api/config/merged` so it's no longer hit. Watcher pickup of new plan_dirs still requires a daemon restart, same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)