### PR TITLE
Fix scoped config save reactions and notification UX

### DIFF
--- a/.agents/skills/daemon-ui-development/SKILL.md
+++ b/.agents/skills/daemon-ui-development/SKILL.md
@@ -5,16 +5,16 @@ description: >
   Myco daemon web UI or Collective UI — even if the user doesn't explicitly
   ask about design compliance or testing. Covers: design system token
   integration (6-theme system: sage/moss/terracotta/dusk/plum/slate with ochre
-  reserved for Collective, PostCSS @import ordering, CSS cascade specificity),
-  app shell grammar and master-detail layout enforcement, canary signal
-  detection and design drift recovery, React component patterns (useCallback
-  deps, SectionSaveRow, toFormState/builder, ScopedField), configuration page
-  architecture with collapsible sections and kebab menus, localStorage→file
-  migration with idempotent design, I/O optimization patterns, Playwright smoke
-  tests with computed CSS verification, favicon-per-theme SVG switching,
-  dynamic title pattern, RedactedField copy-button gotcha. Activates whenever
-  building daemon UI pages, reviewing components for visual compliance, or
-  debugging stale-closure bugs.
+  reserved for Collective, PostCSS @import ordering, CSS cascade specificity,
+  theme authoring and browser verification), app shell grammar and
+  master-detail layout enforcement, canary signal detection and design drift
+  recovery, React component patterns (useCallback deps, SectionSaveRow,
+  ScopedField with useScopedConfig, write-on-blur, DotPaths<T>), config page
+  architecture with collapsible sections and kebab menus, localStorage
+  migration, I/O optimization, Playwright tests, favicon switching, title
+  pattern, AppearanceProvider constraints, Vitest fixtures, RedactedField
+  gotcha, hard-refresh gotcha. Activates whenever building daemon UI or
+  reviewing components for visual compliance.
 managed_by: myco
 user-invocable: true
 allowed-tools: Read, Edit, Write, Bash, Grep, Glob
@@ -22,103 +22,253 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob
 
 # Daemon UI Development
 
-The Myco daemon UI has a deliberate design language — a specific color palette, layout grammar, and component vocabulary. Deviating from it is the single most common source of rework in new UI surfaces. Two full rounds of rework on the Collective UI confirm this is a recurring risk, not a one-time mistake.
+The Myco daemon UI has deliberate design language, layout patterns, and configuration system. Deviating from established patterns causes rework. Two full rewrites of the Collective UI confirm this is a recurring risk.
 
-Apply these procedures whenever touching daemon or Collective UI code.
+Apply these procedures whenever touching daemon or Collective UI code, especially for settings and configuration interfaces.
 
 ## Prerequisites
 
-- Locate the daemon UI source: `packages/daemon/src/ui/` (or equivalent)
-- Locate the Collective UI source: `packages/collective-ui/`
-- Have a browser open for screenshot review before merging any visual changes
-- Confirm ESLint is running with `react-hooks/exhaustive-deps` enabled and treated as an error
-- Review the 6-theme system and theme CSS file organization in `packages/daemon/src/ui/styles/themes/`
+- Daemon UI source: `packages/daemon/src/ui/`
+- Config module: `src/config/loader.ts` is canonical
+- ESLint: `react-hooks/exhaustive-deps` enabled as error
+- Theme files: `packages/daemon/src/ui/styles/themes/`
+- AppearanceProvider: `packages/daemon/src/ui/components/AppearanceProvider.tsx`
+- All YAML writes flow through `updateConfig()` — never write `myco.yaml` or `.myco/local.yaml` directly
 
 ## Procedure 1: Design System Token Integration
 
-The daemon uses CSS custom properties for color, typography, and spacing. Never introduce custom color values — even one hardcoded hex breaks visual consistency across the surface.
+Never introduce custom color values. Even one hardcoded hex breaks visual consistency.
 
 ### 6-Theme System
 
-The design system includes **6 named themes**. Each theme has a unique primary color mapped to `--color-primary` and related accent/structural tokens. Ochre is reserved exclusively for the Collective UI and must not appear in daemon theme files.
-
-**Available themes:**
-- Sage (cool green, daemon default)
-- Moss (saturated green)
-- Terracotta (warm orange-red)
-- Dusk (cool purple-blue)
-- Plum (warm purple)
-- Slate (neutral blue-gray)
-
-**Ochre (Collective-only):** Do not reference or define `--color-ochre` in daemon theme CSS. This prevents visual bleed when the Collective is embedded.
+Six named themes: Sage (default), Moss, Terracotta, Dusk, Plum, Slate. Ochre is reserved for Collective UI only.
 
 ### Palette tokens structure
 
-Theme files are imported via PostCSS in `src/ui/styles/main.css`:
+Theme files imported via PostCSS in `src/ui/styles/main.css`:
 
 ```css
 /* CRITICAL: @import must precede @tailwind directives */
-/* Otherwise theme CSS is silently dropped from the bundle (no build error) */
 @import './themes/sage.css';
 @import './themes/moss.css';
-@import './themes/terracotta.css';
-@import './themes/dusk.css';
-@import './themes/plum.css';
-@import './themes/slate.css';
-
-/* @tailwind directives come AFTER theme imports */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 ```
 
-If `@tailwind` appears before theme `@import`, the theme CSS is discarded silently — no build warning, but the themes don't work at runtime.
+If `@tailwind` precedes theme `@import`, the theme CSS is silently discarded — no build error.
 
 ### CSS cascade and specificity
 
-Theme selectors must use `:root[data-theme="...\"]` (not bare `[data-theme="...\"]`) to match the specificity of `:root` baseline styles. A selector like `[data-theme="sage"]` has the same specificity as `:root`, and source-order becomes unpredictable — the last declaration wins, breaking theme switching.
+Theme selectors must use `:root[data-theme="...\"]` to match `:root` specificity. Bare selectors cause source-order nondeterminism:
 
 ```css
-/* CORRECT — :root specificity */
-:root[data-theme="sage"] {
-  --color-primary: #4a7c59;
-}
+/* CORRECT */
+:root[data-theme="sage"] { --color-primary: #4a7c59; }
 
-/* WRONG — same specificity as :root, source order wins */
-[data-theme="sage"] {
-  --color-primary: #4a7c59;
+/* WRONG — source order wins unpredictably */
+[data-theme="sage"] { --color-primary: #4a7c59; }
+```
+
+**Before writing CSS:**
+1. Inventory current custom properties from theme files
+2. Search for hardcoded values: `grep -rn "#[0-9a-fA-F]{3,6}" src/your-surface/`
+3. Use daemon tokens; don't invent new variables
+
+## Procedure 1b: Adding a New Theme and Configuring the Appearance System
+
+Adding a new theme requires coordinated changes across a CSS file, a TypeScript union type, `AppearanceProvider`, and the picker component. Several failure modes are invisible to TypeScript/Vitest and only surface in browser.
+
+### Step 1 — Create the CSS file
+
+Create the theme file:
+
+```
+packages/daemon/src/ui/styles/themes/<name>.css
+```
+
+Minimal structure:
+
+```css
+/* IMPORTANT: All @import must precede @tailwind — see Procedure 1 */
+:root[data-theme="<name>"] {
+  --color-primary: #…;
+  --color-surface: #…;
+  /* mirror the full token set from an existing theme like sage.css */
 }
 ```
 
-**Typography hierarchy** — three fonts, each with a distinct role:
-- Display/heading font: large structural labels
-- Body font: content and descriptions
-- Mono font: code, IDs, config values
+Use `:root[data-theme="<name>"]` (specificity 0,2,0). Bare `[data-theme="<name>"]` (0,1,0) loses to `:root` baseline overrides. See Procedure 1 for the full specificity explanation.
 
-**Tonal layering**: backgrounds use tonal steps of the primary color or neutral grays — not flat white or arbitrary colors.
+### Step 2 — Import in main.css
 
-**Before writing any CSS in a new component:**
-1. Read the daemon shell's theme files to inventory all current custom properties
-2. Search for hardcoded values in your new file: `grep -rn "#[0-9a-fA-F]{3,6}|rgb(" src/your-surface/`
-3. If a color isn't available as a daemon token, do not invent a new variable — decide whether the token belongs in the design system
+In `packages/daemon/src/ui/styles/main.css`:
 
-Warm neutrals and ochre (`#brown`, beige tones, warm hex values, any use of `--color-ochre`) are the primary canary signals for design drift. See Procedure 3.
+```css
+@import './themes/sage.css';
+@import './themes/moss.css';
+/* … existing themes … */
+@import './themes/<name>.css';   /* ← add here, BEFORE @tailwind */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+`@import` must precede `@tailwind`. If placed after, PostCSS silently discards the import — no error, no warning.
+
+### Step 3 — Extend the ThemeName union type
+
+Locate `ThemeName` (in `AppearanceProvider.tsx` or a co-located types file):
+
+```typescript
+export type ThemeName = 'sage' | 'moss' | 'terracotta' | 'dusk' | 'plum' | 'slate' | '<name>';
+```
+
+TypeScript will surface callers via exhaustiveness checks. It will NOT catch missing CSS custom properties.
+
+### Step 4 — Register in AppearanceProvider and the theme picker
+
+In `AppearanceProvider.tsx`, add the new theme to the `THEMES` array used to apply `data-theme` on `<html>`:
+
+```typescript
+const THEMES: ThemeName[] = ['sage', 'moss', 'terracotta', 'dusk', 'plum', 'slate', '<name>'];
+```
+
+In the theme picker component (e.g., `ThemePicker.tsx`), add a tile:
+
+```tsx
+<ThemeTile name="<name>" label="<Display Name>" />
+```
+
+The tile order in the picker should match the order in `THEMES[]`.
+
+**After all four steps, proceed to the browser verification procedure below.**
+
+### Browser-Only Verification — Mandatory Smoke Test
+
+The TypeScript, Vitest, ESLint, and tsc toolchain is completely blind to CSS build and render semantics. A theme can pass all CI checks while being broken in browser. Browser verification is mandatory before shipping any theme change.
+
+**Smoke test steps:**
+
+1. Start the daemon UI dev server (`pnpm dev` in `packages/daemon`)
+2. Open DevTools → Elements → select the `<html>` element
+3. Confirm `data-theme` attribute is set to the new theme name
+4. Open DevTools → Computed tab → filter by `--color-primary` (or another key token)
+5. Verify the expected hex value resolves — not empty, not inherited from another theme
+6. Switch themes via the Appearance picker → confirm `data-theme` updates on `<html>`
+7. Verify the new theme's computed values change correctly on switch
+8. Hard-refresh (Cmd+Shift+R / Ctrl+Shift+R) to rule out stale browser cache
+9. Screenshot the rendered result before committing
+
+**Diagnosis table — "passes CI, broken in browser":**
+
+| Symptom | Root cause | Fix |
+|---------|-----------|--------|
+| All custom properties empty | `@import` placed after `@tailwind` | Move `@import` before `@tailwind base` in main.css |
+| Theme partially applies | Bare `[data-theme]` specificity loss | Use `:root[data-theme=\"...\"]` |
+| Computed properties missing | CSS file not imported in main.css | Add `@import './themes/<name>.css'` |
+| Picker shows tile, theme doesn't apply | ThemeName added but THEMES[] not updated | Add to THEMES array in AppearanceProvider |
+| Correct DevTools values but wrong on screen | Browser cache stale | Hard-refresh (Cmd+Shift+R) |
+
+### AppearanceProvider Server-Side Import Constraint
+
+`AppearanceProvider` runs in browser context. It must not import any module that references Node.js-only APIs (`node:path`, `node:fs`, `node:os`, etc.). Bundle splits that pull daemon internals into the UI bundle will silently break AppearanceProvider in browser.
+
+**Symptom:** AppearanceProvider starts failing after a refactor that touched config-adjacent imports.
+
+**Wrong pattern — pulls node:* into UI bundle:**
+
+```typescript
+import { loadConfig } from '../../config/loader'; // ← node:path inside loader
+
+export function AppearanceProvider({ children }: Props) {
+  const config = loadConfig(vaultDir); // breaks in browser
+}
+```
+
+**Correct pattern — delegate to useScopedConfig hook:**
+
+```typescript
+import { useScopedConfig } from '../hooks/useScopedConfig';
+import type { AppearanceConfig } from '../../types/config';
+
+export function AppearanceProvider({ children }: Props) {
+  const { value: appearance } = useScopedConfig<AppearanceConfig>('appearance', 'personal');
+  
+  // use appearance.theme, appearance.fontScale, etc. directly
+  return (
+    <html data-theme={appearance?.theme || 'sage'}>
+      {/* … */}
+    </html>
+  );
+}
+```
+
+The hook handles config loading outside the UI bundle. No Node.js imports reach the browser. Run `vite build --reporter verbose` to confirm no unexpected Node.js modules appear in the UI bundle.
+
+### Appearance Section UX Pattern
+
+The Appearance settings section follows a locked UX pattern. New appearance controls must fit inside it; do not introduce alternative layouts.
+
+**Locked pattern:**
+
+```
+┌─ Appearance ──────────────────── [personal pill: Sage] ──┐
+│  (collapsed by default; click header to expand)           │
+│                                                           │
+│  ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ │
+│  │ Sage │ │ Moss │ │Terra │ │ Dusk │ │ Plum │ │Slate │ │
+│  └──────┘ └──────┘ └──────┘ └──────┘ └──────┘ └──────┘ │
+│  [Font Scale selector]                                    │
+└───────────────────────────────────────────────────────────┘
+```
+
+Rules:
+- The section header always shows a preview pill of the current personal theme
+- Expanding reveals the full theme grid picker
+- Theme and font scale default to **Personal** scope (written to `.myco/local.yaml`)
+- New appearance controls (e.g., density, icon size) go inside this collapsible section, following the same personal-scope default
+- If a design calls for a non-collapsible or non-pill appearance control, redirect to this pattern
+
+### Vitest and the local.yaml Test Mental Model
+
+Vitest tests that mock `vaultDir` load `myco.yaml` from the fixture directory but **do not load `.myco/local.yaml`** unless the fixture explicitly contains one. Appearance preferences (theme, font scale) are written to the local scope. Tests that omit `local.yaml` from their fixture will see project defaults instead of personal overrides.
+
+**Symptom:** Test passes. In production, the user's chosen theme reverts to the project default on next load. The write went to `local.yaml`, but the test fixture never included it.
+
+**Incomplete fixture — misses personal layer:**
+
+```
+test-fixtures/vault/
+  myco.yaml          ← loads fine, but personal prefs invisible
+```
+
+**Complete fixture — covers both config layers:**
+
+```
+test-fixtures/vault/
+  myco.yaml          ← project defaults
+  local.yaml         ← personal overrides (appearance.theme, appearance.fontScale)
+```
+
+**Assert the write scope and verify round-trip:**
+
+```typescript
+// 1. Confirm the write went to local scope
+expect(writtenScope).toBe('local');
+
+// 2. Read local.yaml directly to verify the value persisted
+const localConfig = readYaml(path.join(testVaultDir, 'local.yaml'));
+expect(localConfig.appearance?.theme).toBe('moss');
+```
+
+When authoring tests for any appearance preference, always include `local.yaml` in the fixture and assert `scope === 'local'` on the write.
 
 ## Procedure 2: App Shell Grammar and Master-Detail Layout
 
-Daemon UI pages follow a **master-detail layout**: a list/overview panel on the left, a detail/inspector panel on the right. Full-width cards or centered-column editorial layouts are incorrect for daemon pages.
+Daemon pages use **master-detail layout**: left list/overview, right detail/inspector. Full-width or centered-column layouts are incorrect.
 
-**App shell components — extract, do not rebuild:**
-- **Nav rail**: solid structural rail, left-anchored, no rounded "bubble" borders on nav items
-- **Sidebar**: same structural treatment as the nav rail
-- **Page shell wrapper**: consistent padding, title placement, content area
-
-Do not rebuild the chrome from scratch when creating a new UI surface. Extract the daemon's shell primitives and compose your page inside them. Both times the Collective UI was rebuilt from scratch, the result required full visual rework because the structural language diverged.
-
-**How to extract and reuse:**
-1. Read the daemon's main layout component to identify shell primitives
-2. Import those primitives into the new surface
-3. Compose your page content inside the shell — do not recreate structural HTML
+**Extract, do not rebuild:** Nav rail, sidebar, and page shell are structural primitives. Extract them rather than rebuilding chrome from scratch. Both Collective UI rewrites required full visual rework because the structural language diverged.
 
 **Master-detail pattern:**
 ```
@@ -126,458 +276,235 @@ Do not rebuild the chrome from scratch when creating a new UI surface. Extract t
 │  Left: list/overview │  Right: detail/inspector   │
 └──────────────────────┴───────────────────────────┘
 ```
-If your page renders a single centered column of cards, stop and re-evaluate the layout.
 
 ## Procedure 3: Canary Signal Detection and Design Drift Recovery
 
-Design drift is detectable early via three canary signals. When any signal appears, **stop and audit before writing more code**.
+Design drift is detectable via three signals. Stop and audit when any appear.
 
-**The three canary signals:**
+**The three signals:**
 
 | Signal | Correct | Wrong |
-|--------|---------|----------|
-| Color palette | Sage, moss, terracotta, dusk, plum, slate (via `--color-primary` theme variable); ochre only in Collective | Brown, warm neutrals, arbitrary hex values, ochre in daemon CSS |
-| Navigation elements | Solid structural rail | Bubble-bordered or rounded nav pills |
-| Base font size | Daemon density scale (tighter) | Large editorial scale |
+|--------|---------|------------|
+| Color | Sage, moss, terracotta, dusk, plum, slate via `--color-primary` | Brown, warm neutrals, arbitrary hex, ochre in daemon CSS |
+| Navigation | Solid structural rail | Bubble-bordered or rounded nav pills |
+| Font size | Daemon density (tight) | Large editorial scale |
 
-**Detection — run both checks:**
-```bash
-# Should only see daemon tokens
-grep -rn "var(--" src/your-surface/
-
-# Should return nothing
-grep -rn "#[0-9a-fA-F]{3,6}|ochre" src/your-surface/
-```
-Screenshot the live page and visually scan all three signals.
-
-**Recovery procedure** (apply in order):
-
-1. **List custom CSS variables** defined in the new surface's CSS files — any `--custom-var` not sourced from the daemon shell
-2. **Replace each** with the daemon token equivalent (warm neutral → `--color-charcoal`, theme color → `--color-primary`, etc.)
-3. **Identify rebuilt structural chrome** — find nav, sidebar, or shell HTML built from scratch in the new surface
-4. **Replace** with extracted daemon shell components (see Procedure 2)
-5. **Verify master-detail layout** — confirm the page uses the two-panel pattern, not a centered column
-6. **Verify PostCSS @import ordering** — check `main.css` theme imports precede `@tailwind` directives
-7. **Verify theme CSS specificity** — all theme selectors use `:root[data-theme="...\"]`
-8. **Re-run detection** — grep + screenshot
-9. **Screenshot review before merging** — do not merge without a visual comparison against the daemon design language
+**Recovery (in order):**
+1. List custom CSS variables not from daemon shell
+2. Replace with daemon token equivalents
+3. Find rebuilt structural chrome; replace with extracted components
+4. Verify master-detail layout, PostCSS order, theme CSS specificity
+5. Re-run detection
+6. Screenshot before merging
 
 ## Procedure 4: React Component Patterns
 
 ### useCallback dep completeness
 
-Every `useCallback` and `useEffect` must list all captured state and prop variables in the dependency array. A missing dep causes stale-closure bugs where the callback holds an outdated value at call time.
+Every `useCallback` must list all captured state/prop variables. Missing deps cause stale-closure bugs:
 
 ```typescript
-// WRONG — ignoreInGit is captured from state but not listed
-const handleSave = useCallback(async () => {
-  await saveConfig({ ignoreInGit });
-}, []);  // ← stale closure: ignoreInGit is always the initial value
-
 // CORRECT
 const handleSave = useCallback(async () => {
   await saveConfig({ ignoreInGit });
-}, [ignoreInGit]);  // ← dep listed; callback refreshes when value changes
+}, [ignoreInGit]);
 ```
 
-ESLint's `react-hooks/exhaustive-deps` rule catches this automatically. Never disable it to silence a warning — fix the dependency array instead. This class of bug is invisible in unit tests but caught by Playwright (the API call posts the stale value).
+ESLint's `react-hooks/exhaustive-deps` catches these. Never suppress it.
 
-### SectionSaveRow pattern
+### SectionSaveRow and builder pattern
 
-Config forms use per-section save, not a single form-wide submit. Each editable section ends with a `<SectionSaveRow>` that shows Save/Cancel only when the section has unsaved changes.
-
-```tsx
-<SectionSaveRow
-  dirty={dirty}
-  onSave={handleSave}
-  onCancel={handleCancel}
-/>
-```
-
-The `dirty` flag compares current form state to the last-saved value, not to the initially loaded value. This allows the user to reset to the last save without reloading the page.
-
-### toFormState / dirty-check / builder pattern
-
-Config pages follow a three-function pattern for state management:
+Config forms use per-section save. Each section ends with `<SectionSaveRow>` showing Save/Cancel only when unsaved changes exist.
 
 ```typescript
-// 1. Load config → form state
-function toFormState(config: MyConfig): FormState { ... }
-
-// 2. Compute dirty flag
-const dirty = !isEqual(formState, toFormState(savedConfig));
-
-// 3. Build updated config for save — spread original FIRST, overlay form values
+// 3. Build updated config — spread original FIRST, overlay form
 function formToConfig(original: MyConfig, form: FormState): MyConfig {
-  return { ...original, ...form };
+  return { ...original, ...form };  // ← original FIRST
 }
 ```
 
-**Critical**: `formToConfig` must spread `original` before overlaying `form`. This preserves config fields not present in the form (server-managed fields, future fields the form doesn't know about). Reversing the order silently drops those fields from every save.
+**CRITICAL**: Spread `original` before overlaying `form`. Reversing silently drops fields not in the form.
 
-### ScopedField pattern — Personal vs. Team settings
+### ScopedField pattern — Path-based API (PR #80+)
 
-When a setting can be scoped to Personal (machine-local) or Team (shared), use the `ScopedField` component pattern:
+`ScopedField` uses path-based declarative API for composability and type-safety:
 
 ```tsx
 <ScopedField
-  label="Provider Model"
-  scope={scope}  // 'personal' | 'team'
-  onScopeChange={setScope}
-  hint="Where this setting is stored"
+  path="daemon.log_level"
+  defaultScope="personal"
+  label="Log Level"
 >
-  <ProviderModelSelector value={model} onChange={setModel} />
+  {(value, onChange) => (
+    <Select value={value} onChange={onChange} />
+  )}
 </ScopedField>
 ```
 
-Each scoped field includes:
-- **Personal pill** — a clickable label showing current scope (top-right of the field)
-- **Scope menu** — on click, toggle between Personal and Team
-- **Promote/reset semantics** — changing scope may promote a personal setting to team or reset team to personal
+**Key behaviors:** DotPath<T> typing (type-safe paths at compile-time), render prop pattern, Personal/Team scope UI with clickable scope pill, requiresRestart flag for daemon restarts, automatic notification emissions.
 
-**Key behaviors:**
-- When scope is "Team," the field is visually distinct (slightly different background or border)
-- A button or dropdown on the field lets the user change scope; the field itself is read-only to the scope
-- Saving a Team-scoped field syncs it across all machines in the team; Personal stays local
+### useScopedConfig hook
 
-See Procedure 5 (Configuration Page Architecture) for how to surface scope toggles in the UI layout.
-
-## Procedure 5: Configuration Page Architecture
-
-### Dashboard page = status summary only
-
-The dashboard page shows status and quick-glance information. It is not the configuration authority for complex features.
-
-```
-Dashboard widget:
-  ✓ Status indicator (enabled/disabled, connected/disconnected)
-  ✓ Key metric or last-updated time
-  ✓ "Configure →" link to dedicated page
-  ✗ Multi-step setup forms
-  ✗ Agent-specific instructions
-  ✗ Token input fields
-```
-
-### Dedicated config page
-
-A feature deserves its own dedicated route (e.g., `/mcp-settings`) when it has:
-- Multi-step setup (generate token → copy to agent → verify)
-- Agent-specific instructions that vary by configuration
-- Multiple independent config sections
-
-**Registering a new dedicated page:**
-1. Add a route entry in the daemon UI router config
-2. Add a nav link in the appropriate nav section
-3. Create the page component: `src/ui/pages/MyFeaturePage.tsx`
-4. Apply master-detail layout (Procedure 2)
-5. Use `SectionSaveRow` per editable section (Procedure 4)
-
-### Token/secret reveal state consistency
-
-When a page shows multiple sensitive fields (API tokens, secrets), all fields must share a single reveal/hide state — one `showTokens` boolean, not one state variable per field.
+For reading/updating scoped config outside `ScopedField`, use `useScopedConfig`:
 
 ```typescript
-// CORRECT — single toggle controls all fields
-const [showTokens, setShowTokens] = useState(false);
-
-// WRONG — divergent state; fields get out of sync
-const [showToken1, setShowToken1] = useState(false);
-const [showToken2, setShowToken2] = useState(false);
+const { value, setValue, scope, setScope, isDirty, isSaving, error } = 
+  useScopedConfig<T>(path, defaultScope);
 ```
 
-## Procedure 6: Playwright Smoke Test Authoring for Config UI
+Hook automatically persists changes and emits notifications.
 
-Every config UI form should have a Playwright smoke test that verifies the form doesn't silently discard or corrupt values.
+### Write-on-blur vs. write-on-change
 
-### What to test
+**Write-on-blur (text inputs):** Collect locally, save on blur. Prevents daemon validation of incomplete values.
 
-1. **Toggle state round-trip**: enable a toggle → save → reload → toggle is still enabled
-2. **API POST with correct value**: intercept the save request and assert the payload contains the current form value (not a stale/default value — this is the `useCallback` dep bug in production)
-3. **Visual state consistency**: verify the UI reflects the saved state after reload (badge, token field, status indicator)
-4. **Computed style verification**: check that CSS theme values are applied at runtime, not just that files exist
+**Write-on-change (toggles/selects):** Save immediately for finite-value inputs.
 
-### Test structure
+## Procedure 5: Config System Architecture — Two-Tier File Model
+
+Configuration splits across two YAML files that deep-merge on load:
+
+| File | Committed | Scope | Purpose |
+|------|-----------|-------|------------|
+| `myco.yaml` | ✅ yes | Project/team | Shared defaults |
+| `.myco/local.yaml` | ❌ gitignored | Per-machine | Personal overrides |
+
+`loadConfig()` deep-merges with local winning. **Arrays are replaced, not concatenated.**
+
+### Config write invariant — updateConfig() single write path
+
+**INVARIANT**: All YAML writes flow through `updateConfig()` in `src/config/loader.ts`. Never write files directly. Diverging write paths cause silent serialisation bugs.
+
+```typescript
+await updateConfig(vaultDir, partialConfig, scope);  // scope: 'project' | 'local'
+```
+
+### REST API: scope-aware patch endpoint
+
+```
+PUT /api/config/scoped
+Body: { "scope": "project" | "local", ...fieldUpdates }
+```
+
+Patch-style: merges partial object onto file. Route handlers call `updateConfig()` internally.
+
+## Procedure 6: Config Toggle Side-Effects and Managed Blocks
+
+Some toggles require file mutations beyond `myco.yaml` (e.g., `.gitignore`, `tsconfig.json`). Use managed-block pattern:
+
+**Step 1:** Single opt-in boolean in `myco.yaml`
+**Step 2:** Static managed block in affected file, inserted by `myco init`, reconciled by `myco update`
+**Step 3:** In-process reconciliation after config save:
+
+```typescript
+await symbionts.reconcile(vaultDir, updatedConfig);
+```
+
+## Procedure 7: Configuration Page Architecture and Form Safety
+
+### Page types
+
+**Dashboard:** Status summary only. "Configure →" link to dedicated page.
+
+**Dedicated config page:** Route (e.g., `/mcp-settings`) for multi-step setup, agent-specific instructions, multiple sections.
+
+### React form safety
+
+**Failure 1 — Field loss:**
+
+```typescript
+// ✅ CORRECT — preserves unrelated fields
+return { ...current, theme: formValues.theme, font: formValues.font };
+```
+
+**Failure 2 — Stale closure:**
+
+```typescript
+// ✅ CORRECT — recreates when state changes
+const handleSave = useCallback(() => {
+  await saveFn(formToConfig(formValues, currentConfig));
+}, [formValues, currentConfig]);
+```
+
+## Procedure 8: Configuration Page UI and Scope Defaults
+
+### Collapsible sections
+
+**Sidebar:** Collapse to icon-only. Persist to `localStorage` under `sidebar-collapsed`.
+
+**Content:** Hide content, title remains. Persist to `localStorage` under `section-visibility-<name>`.
+
+**localStorage exception:** UI layout state uses `localStorage`. Config values use vault/project file.
+
+### Section kebab menu
+
+**Batch promote:** Copy all Personal settings in section to Team scope.
+
+**Reset all:** Clear overrides, revert to project defaults.
+
+### Scope defaults matrix
+
+**Personal (machine-local):** Log level, bind address, TLS paths, IDE paths, font size, theme, timezone, resource limits, refresh intervals.
+
+**Team (shared):** Project name, notification modes, MCP servers, archive policies, symbiont config, experimental features, excluded paths.
+
+Default to **Personal** scope when unlisted.
+
+## Procedure 9: Playwright Smoke Tests
+
+Every config form needs Playwright smoke test verifying no silent value discards.
+
+**What to test:**
+1. Toggle round-trip (save → reload → still enabled)
+2. API POST has correct value (intercept, assert payload)
+3. Visual state consistency (UI reflects saved state after reload)
 
 ```typescript
 test('config toggle round-trips correctly', async ({ page }) => {
   await page.goto('/mcp-settings');
-
-  // Capture the outgoing save request
   const [request] = await Promise.all([
-    page.waitForRequest(
-      req => req.url().includes('/api/config') && req.method() === 'POST'
-    ),
-    page.click('[data-testid="ignore-in-git-toggle"]'),
+    page.waitForRequest(req => req.url().includes('/api/config') && req.method() === 'POST'),
+    page.click('[data-testid="toggle"]'),
     page.click('[data-testid="save-section"]'),
   ]);
-
-  const body = request.postDataJSON();
-  expect(body.ignoreInGit).toBe(true);  // not the stale pre-toggle value
-
-  // Verify UI reflects saved state after reload
+  expect(request.postDataJSON().field).toBe(true);
   await page.reload();
-  await expect(
-    page.locator('[data-testid="ignore-in-git-toggle"]')
-  ).toBeChecked();
-});
-
-// CSS verification — check theme colors are applied at runtime
-test('theme CSS is applied and renders correctly', async ({ page }) => {
-  await page.goto('/mcp-settings?theme=sage');
-  
-  const primaryElement = page.locator('[data-testid="primary-color-swatch"]');
-  const computedColor = await primaryElement.evaluate(
-    (el) => getComputedStyle(el).backgroundColor
-  );
-  
-  // Verify the computed style matches the theme (not a fallback or error state)
-  expect(computedColor).toMatch(/rgb\(\d+,\s*\d+,\s*\d+\)/);
-  // Do not test exact hex values; test that a color is computed
+  await expect(page.locator('[data-testid="toggle"]')).toBeChecked();
 });
 ```
 
-### Wire to CI
+## Procedure 10: Configuration Migration and I/O Optimization
 
-Add the spec file to the Playwright config's `testDir`. Run locally:
-```bash
-npx playwright test path/to/config-ui.spec.ts
-```
+### localStorage → file migration
 
-### What Playwright catches that unit tests miss
-
-- **`useCallback` dep bugs** — the API call posts the stale pre-toggle value; unit tests mock the call and never see the staleness
-- **`formToConfig` field-drop bugs** — the saved payload is missing fields; only caught by inspecting the actual POST body
-- **State-after-reload inconsistencies** — save returns 200 but the UI doesn't reflect it on reload
-- **CSS bundle gaps** — the theme CSS file exists but `@import` ordering is wrong or specificity is broken, so computed styles are fallback values
-
-## Procedure 7: Appearance Configuration UI and Settings Forms
-
-Config pages with collapsible sections and multi-field layouts must follow specific patterns to maintain consistency across the daemon.
-
-### Collapsible section UX
-
-When a config page has many sections, implement collapsible sections to reduce visual density and focus. The collapsible behavior differs by section type:
-
-**Sidebar sections that collapse to icon-only:**
-- Each sidebar nav item can collapse to show only an icon (typically the first character or a symbol)
-- On hover of the collapsed icon, show a tooltip with the full section name
-- Use `localStorage` to persist the collapsed/expanded state for UX continuity across page reloads
-- Do NOT use the daemon's main config file to store UI layout state — this is an ephemeral, machine-local preference
-
-**Content sections that fully hide:**
-- For non-sidebar content sections (e.g., "Appearance" settings), when collapsed, the entire section content hides — no compact icon state
-- Expand/collapse is controlled by a clickable header or chevron button
-- The section title remains visible even when collapsed
-- State is persisted to `localStorage` under a key like `section-visibility-<sectionName>`
-
-**localStorage ephemeral state exception:**
-Unlike config values (which go to the vault or shared project file), UI layout state (collapsed sections, revealed tokens, form scroll position) should use browser `localStorage`. This is a documented exception to the "all state in config files" rule.
+Check if `localStorage` has old keys. If found, read them, merge into config, write to persistent store. Add cleanup TODO:
 
 ```typescript
-// Ephemeral UI state — use localStorage
-const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
-  return localStorage.getItem('sidebar-collapsed') === 'true';
-});
-
-const handleCollapse = useCallback((collapsed: boolean) => {
-  setSidebarCollapsed(collapsed);
-  localStorage.setItem('sidebar-collapsed', collapsed.toString());
-}, []);
+// TODO(2026-04-30): Remove localStorage migration code
 ```
 
-### Section kebab menu (batch actions)
+Do NOT set sentinel flags.
 
-When a config section has multiple fields that can be overridden or reset, expose a "kebab" menu (three-dot `⋮` button) next to the section title with these options:
+### I/O optimization
 
-**Batch promote to project defaults:**
-- "Promote all to project defaults" action
-- When clicked, copy all current Personal (machine-local) settings in this section to the Team/project scope
-- Shows a confirmation: "This will update Team settings for 4 fields"
-- After promotion, the fields visually transition to Team scope (e.g., different background or icon)
-
-**Reset all to defaults:**
-- "Reset all to defaults" action
-- Clears all overrides in the section back to the project defaults
-- Only appears if at least one field differs from the defaults
-- Confirmation: "This will reset 3 fields to project defaults. This cannot be undone."
-
-**Implementation:**
-```tsx
-function SectionKebabMenu({ 
-  fields,  // array of {name, isOverridden, isTeamScope}
-  onPromoteAll,
-  onResetAll,
-}) {
-  const overriddenCount = fields.filter(f => f.isOverridden).length;
-  const isAnyLocal = fields.some(f => !f.isTeamScope);
-  
-  return (
-    <Dropdown>
-      {isAnyLocal && (
-        <MenuItem 
-          onClick={() => onPromoteAll()}
-        >
-          Promote all to project defaults ({overriddenCount})
-        </MenuItem>
-      )}
-      {overriddenCount > 0 && (
-        <MenuItem 
-          onClick={() => onResetAll()}
-          appearance="danger"
-        >
-          Reset all to defaults
-        </MenuItem>
-      )}
-    </Dropdown>
-  );
-}
-```
-
-## Procedure 8: Configuration Migration and I/O Optimization
-
-When evolving a config surface (e.g., moving settings from localStorage to persisted config files), follow these patterns to maintain data integrity and optimize performance.
-
-### localStorage → file migration procedure
-
-When a feature stored settings in browser `localStorage` and now must move to persistent config files (vault or project file):
-
-**Idempotent migration design:**
-1. On first page load, check if `localStorage` has the old keys: `appearance.theme`, `appearance.density`, `appearance.fontSize`, `appearance.syncTheme`
-2. If found, read them and merge into the current config state
-3. Immediately write the merged config to the persistent store via the normal save endpoint
-4. Add a cleanup TODO comment with a deadline: `// TODO(2026-04-30): Remove localStorage migration code`
-5. Do NOT set a sentinel flag (like `migrationComplete: true`) in config — the deadline comment is sufficient
-
-**Why not a sentinel flag?**
-- A flag in config becomes a permanent part of the codebase
-- If the migration logic is removed (see cleanup deadline), the flag is orphaned
-- Deadline comments are self-documenting and easily grep-able for cleanup
-
-**Implementation:**
-```typescript
-// Load existing config first
-const [config, setConfig] = useState(loadedConfig);
-
-useEffect(() => {
-  // Check for and migrate localStorage settings
-  const oldTheme = localStorage.getItem('appearance.theme');
-  const oldDensity = localStorage.getItem('appearance.density');
-  const oldFontSize = localStorage.getItem('appearance.fontSize');
-  const oldSyncTheme = localStorage.getItem('appearance.syncTheme');
-
-  if (oldTheme || oldDensity || oldFontSize || oldSyncTheme) {
-    const migratedConfig = {
-      ...config,
-      appearance: {
-        ...config.appearance,
-        ...(oldTheme && { theme: oldTheme }),
-        ...(oldDensity && { density: oldDensity }),
-        ...(oldFontSize && { fontSize: oldFontSize }),
-        ...(oldSyncTheme && { syncTheme: oldSyncTheme === 'true' }),
-      },
-    };
-
-    // Save the migrated config to persistent store
-    saveConfig(migratedConfig);
-    setConfig(migratedConfig);
-
-    // Clear the old localStorage keys
-    localStorage.removeItem('appearance.theme');
-    localStorage.removeItem('appearance.density');
-    localStorage.removeItem('appearance.fontSize');
-    localStorage.removeItem('appearance.syncTheme');
-
-    // TODO(2026-04-30): Remove this migration block entirely
-  }
-}, []);
-```
-
-### I/O optimization patterns
-
-Config pages often perform frequent reads and writes. Apply these patterns to avoid redundant requests and DOM mutations:
-
-**Skip write when content unchanged:**
-- Before calling the save endpoint, compare the form state to the last-saved config
-- If they are identical, do not make the POST request
-- This is already handled by the `dirty` flag (Procedure 4), but verify in your `onSave` handler:
-
-```typescript
-const handleSave = useCallback(async () => {
-  if (!dirty) {
-    console.log('No changes; skipping save');
-    return;
-  }
-  await saveConfig(formToConfig(savedConfig, formState));
-}, [dirty, formState, savedConfig]);
-```
-
-**useMemo for appearance context on primitive keys:**
-- When creating a context for appearance settings (theme, density, font size), memoize the context value by primitive fields, not by object reference
-- Without memoization, every render creates a new object, causing all consumers to re-render unnecessarily
-
-```typescript
-// WRONG — new object on every render
-const appearanceValue = {
-  theme: currentTheme,
-  density: currentDensity,
-  fontSize: currentFontSize,
-};
-
-// CORRECT — memoized on primitive field values
-const appearanceValue = useMemo(() => ({
-  theme: currentTheme,
-  density: currentDensity,
-  fontSize: currentFontSize,
-}), [currentTheme, currentDensity, currentFontSize]);
-```
-
-**Guard DOM mutation before setAttribute/favicon href swap:**
-- When updating the favicon or applying theme CSS via DOM manipulation, check the current value before mutating
-- Unnecessary mutations can trigger page reflows and layout thrashing
-
-```typescript
-const updateFavicon = useCallback((theme: string) => {
-  const faviconLink = document.querySelector('link[rel="icon"]');
-  if (!faviconLink) return;
-
-  const newHref = `/favicons/theme-${theme}.svg`;
-  
-  // Guard: only mutate if href actually changed
-  if (faviconLink.getAttribute('href') !== newHref) {
-    faviconLink.setAttribute('href', newHref);
-  }
-}, []);
-```
-
-**Single loadConfig() in HTTP handlers:**
-- When a page has multiple sections that each call the config endpoint, consolidate to a single `loadConfig()` call in the page-level effect
-- Pass the full config down to child sections as props; do not have each section independently fetch config
-- Reduces request count and keeps config state synchronized across the page
-
-```typescript
-// Page-level: fetch once
-const [config, setConfig] = useState(null);
-
-useEffect(() => {
-  loadConfig().then(setConfig);
-}, []);
-
-// Child section receives config as prop
-<AppearanceSection config={config} onSave={handleSave} />
-<NotificationSection config={config} onSave={handleSave} />
-```
+Skip write when unchanged, use useMemo for appearance context, guard DOM mutations, single loadConfig() per page.
 
 ## Cross-Cutting Gotchas
 
-- **Warm neutral ≠ neutral** — in the daemon design system, "neutral" is charcoal-based. Brown/beige tones immediately signal a design system mismatch. Ochre in daemon CSS is also a canary for Collective UI code bleeding into daemon.
-- **PostCSS @import ordering is silent** — if theme `@import` statements appear AFTER `@tailwind`, the theme CSS is discarded silently. No build error, no warning. The only symptom is missing theme colors at runtime. Check `main.css` import order if themes don't render.
-- **CSS specificity requires `:root[data-theme="...\"]`** — bare `[data-theme="...\"]` has the same specificity as `:root`, causing source-order nondeterminism. Always use `:root[data-theme="...\"]`.
-- **Collective UI is a separate package but must inherit daemon design language** — it has its own deployment (`oss.goondocks.workers.dev`) but is not a separate visual system. Use `make collective-ui-dev` for a local proxy against live worker settings.
-- **ESLint hooks rule is your first line of defence** — never suppress `react-hooks/exhaustive-deps`. The warning is the bug report.
-- **Screenshot before merging** — visual consistency is the primary review signal for daemon UI. A screenshot comparison catches design drift that code review misses.
-- **`formToConfig` spread order is silent** — there is no runtime error when you get the spread order wrong. The only symptom is data loss in production. Test it with Playwright.
-- **Favicon-per-theme SVG switching** — the daemon renders 6 pre-generated SVG favicon variants (one per theme). At runtime, on theme change, the UI updates `<link rel="icon" href={faviconForTheme(theme)} />` to swap the favicon. The SVG files must exist in `public/favicons/theme-{name}.svg`. Missing SVG files show the fallback browser favicon (not an error).
-- **Dynamic page title pattern** — the page title follows the format `Myco — <project-name>`, sourced from the loaded `myco.yaml` config. Multiple local instances of Myco (different projects) must have distinct titles in browser tabs. If the title is not populated, check that `projectName` is loaded from config before rendering the page shell.
-- **RedactedField copy-button gotcha** — when displaying a masked token (e.g., `***`), the `<CopyButton>` component must receive the real token value, not the `displayValue`. Passing `displayValue` results in copying `***` to the clipboard. Correct usage: `<CopyButton value={realToken} />` with the button rendering the masked display separately.
-- **localStorage for UI state is ephemeral-only** — collapse/expand state, revealed token visibility, form scroll position belong in `localStorage`. Config values, team settings, and anything that should sync across machines belong in the vault or project config file. Never conflate the two.
-- **Cleanup deadline comments instead of sentinel flags** — when migrating data from one storage to another (localStorage → file), use TODO comments with deadlines, not sentinel config flags. Flags become orphaned when cleanup code is removed.
+- **PostCSS @import ordering is silent:** If theme `@import` appears AFTER `@tailwind`, theme CSS discarded silently.
+- **CSS specificity requires `:root[data-theme=\"...\"]`:** Bare selectors cause source-order nondeterminism.
+- **Screenshot before merging:** Catches design drift code review misses.
+- **`formToConfig` spread order is silent:** No runtime error when reversed. Symptom: production data loss. Test with Playwright.
+- **ESLint hooks rule is first line of defence:** Never suppress `react-hooks/exhaustive-deps`.
+- **updateConfig() is the single write path:** Never write YAML directly.
+- **Local .myco/local.yaml path is already scoped:** Don't prepend `.myco/` again. Use `path.join(vaultDir, 'local.yaml')`.
+- **Array replacement, not merge:** Local array completely replaces project array.
+- **Hard-refresh browser cache:** Cmd+Shift+R (Mac) or Ctrl+Shift+R (Windows/Linux).
+- **DotPaths<T> recursive template literal typing:** Type-check config paths at compile time.
+- **Favicon-per-theme SVG switching:** SVG files must exist in `public/favicons/theme-{name}.svg`.
+- **Dynamic page title pattern:** Format `Myco — <project-name>` from `myco.yaml`.
+- **RedactedField copy-button gotcha:** Pass real token to CopyButton, not masked displayValue.
+- **localStorage for UI state only:** Collapse/reveal state in localStorage. Config values in vault/project file.
+- **Theme file creation without registration:** Creating a .css file without adding it to ThemeName union and THEMES array results in silent no-op.
+- **AppearanceProvider bundle split risk:** Never import config loaders or Node.js modules inside AppearanceProvider. Use the useScopedConfig hook pattern instead, which handles config loading outside the UI bundle context.
+- **Appearance preference write scope is always 'local':** Theme and font scale overrides go to `.myco/local.yaml`, not `myco.yaml`. Personal machine scope.

--- a/.agents/skills/myco-collective-connect-and-operate/SKILL.md
+++ b/.agents/skills/myco-collective-connect-and-operate/SKILL.md
@@ -1,0 +1,286 @@
+---
+name: myco:myco-collective-connect-and-operate
+description: |
+  Use this skill when bootstrapping a Myco Collective instance, connecting an
+  existing project to a live Collective, managing admin token lifecycle,
+  verifying Collective health and identity, using collective_* MCP tools,
+  setting up the local dev proxy (make collective-ui-dev), enforcing design
+  system compliance for Collective UI, or running the V1 integration gate
+  checklist. Covers: CLI bootstrap, project connection and config scoping
+  (home-scoped ~/.myco-collective/<name>/ vs project-scoped .myco/team/),
+  admin token rotation across team workers, the deploy → upgrade → verify
+  cycle, collective_* vs org_* MCP tool distinctions, Vite proxy setup, and
+  integration gate. Activate even if the user only asks to "connect to
+  Collective" or "check Collective status" without mentioning the full
+  workflow.
+managed_by: myco
+user-invocable: true
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+# Myco Collective: Connect, Verify, and Operate
+
+Myco Collective is the org-level intelligence layer: a Cloudflare Worker + D1
++ Vectorize + KV deployment that federates knowledge across multiple projects
+and machines. This skill covers operational procedures after infrastructure is
+deployed — connecting projects, managing tokens, verifying correctness, using
+MCP tools, and maintaining the Collective UI design system. For Worker
+deployment mechanics (Wrangler, KV provisioning, wrangler.toml), see
+`cloudflare-worker-infrastructure-lifecycle`.
+
+## Prerequisites
+
+- A running Collective Worker (deployed via `myco collective create` or manual
+  Wrangler deploy)
+- `myco` CLI installed and at least one project initialized with `myco init`
+- Admin token available from `~/.myco-collective/<name>/config.json`
+- Node 18+ and `make` available for local dev proxy work
+
+---
+
+## Procedure 1: Bootstrap a New Collective (CLI Only)
+
+Collective bootstrap is **CLI-only** — the same pattern as `myco init` and
+`myco team deploy`. Do NOT attempt to bootstrap from the daemon UI.
+
+```bash
+myco collective create <name>
+```
+
+This creates:
+- A Cloudflare Worker named after `<name>`
+- D1 database, Vectorize index, and KV namespace
+- Home-scoped config at `~/.myco-collective/<name>/config.json`
+
+After bootstrap, always run the verification protocol (Procedure 4) before
+connecting any projects. A Worker that returns the wrong `collective_name`
+needs an upgrade before use.
+
+---
+
+## Procedure 2: Connect a Project to a Collective
+
+Each project that joins a Collective gets its own connection entry. Config
+splits across two scopes — understanding this boundary prevents the most
+common operational mistakes:
+
+| Scope        | Location                                      | Contains                                      |
+|--------------|-----------------------------------------------|-----------------------------------------------|
+| Home (machine-wide) | `~/.myco-collective/<name>/config.json` | Worker URL, admin token, operator settings   |
+| Project      | `.myco/team/config.json`                      | Project-specific Collective reference         |
+
+**Steps:**
+
+1. Confirm the Collective Worker URL and token from the home-scoped config:
+   ```json
+   {
+     "workerUrl": "https://my-collective.workers.dev",
+     "adminToken": "<token>"
+   }
+   ```
+
+2. Connect the project:
+   ```bash
+   myco collective connect <name>
+   ```
+   This writes `.myco/team/config.json` with the Collective reference.
+
+3. Verify the connection responds correctly (see Procedure 4).
+
+**Config scoping invariant**: `myco.yaml` holds static project config only.
+Collective operator config (Worker URL, admin token) is home-scoped and
+machine-wide. `.myco/secrets.env` is for project-scoped API keys only — admin
+tokens do NOT belong there.
+
+---
+
+## Procedure 3: Admin Token Lifecycle
+
+Admin tokens authenticate Collective API calls. They live at the home-scoped
+config, not in any project file.
+
+**Canonical token location:**
+```
+~/.myco-collective/<name>/config.json
+```
+
+**Not** `.myco/secrets.env` — that file is reserved for project-scoped keys.
+
+### Rotating a Token
+
+1. Generate a new token via the Collective admin UI or API.
+2. Update `~/.myco-collective/<name>/config.json` on **every machine** that
+   uses this Collective.
+3. Check `.myco/secrets.env` for a stale `MYCO_COLLECTIVE_TOKEN` entry — this
+   leftover survives the home-scoped refactor and shadows the correct value.
+   Remove it if present.
+4. Confirm each team Worker's KV binding has been updated. Stale tokens in KV
+   bindings fail silently with 401.
+5. Verify the rotation succeeded: `myco collective status`
+
+### Token Format Gotcha
+
+The UI token input expects the **plain token value** — no `Bearer ` prefix.
+Pasting `Bearer <token>` makes the reveal state appear correct but all API
+calls will return 401. Strip the prefix before saving.
+
+---
+
+## Procedure 4: Verification Protocol
+
+Run this sequence after every deploy, upgrade, or token change. Order matters —
+verify after upgrading, not before.
+
+```bash
+# Step 1: CLI health check
+myco collective status
+
+# Step 2: HTTP health endpoint
+curl https://<worker-url>/health
+
+# Step 3: Identity verification (critical)
+curl -H "Authorization: Bearer <token>" \
+  https://<worker-url>/api/auth/verify
+```
+
+The `/api/auth/verify` response must include a deployment-specific name:
+
+```json
+{ "collective_name": "OSS Collective" }
+```
+
+If `collective_name` returns the generic `"Myco Collective"`, the Worker is
+running with default branding. The `COLLECTIVE_NAME` environment variable was
+not set, or the Worker predates the branding feature and needs an upgrade:
+
+```bash
+# Upgrade cycle
+wrangler deploy
+wrangler secret put COLLECTIVE_NAME   # enter "OSS Collective" (or your name)
+
+# Re-verify — must see deployment-specific name
+curl -H "Authorization: Bearer <token>" https://<worker-url>/api/auth/verify
+```
+
+**Deploy → upgrade → verify** is the required cycle. Running verify before
+the upgrade gives stale results from the cached Worker bundle.
+
+---
+
+## Procedure 5: Using collective_* and org_* MCP Tools
+
+The Collective exposes two tiers of MCP tools. Confusing the tiers is a
+common source of "where are my tools?" debugging sessions:
+
+| Tier           | Tool prefix   | Accessed via                                     |
+|----------------|---------------|--------------------------------------------------|
+| Project-local  | `collective_*`| The LOCAL MCP server (same as all project tools) |
+| Cloud org-level| `org_*`       | Dedicated cloud-facing Collective MCP endpoint   |
+
+**`collective_*` tools** appear when the project is Collective-connected. You
+do NOT need a separate cloud connection — they proxy through the local daemon.
+If they are missing, the project is not connected: check `.myco/team/config.json`.
+
+**`org_*` tools** live on the dedicated Collective MCP endpoint for
+cross-project org operations. The endpoint URL and a copy-ready Claude agent
+configuration snippet are on the **Settings → MCP** page in the Collective UI.
+This is the primary Collective feature surface — do not look for it in the
+main dashboard widget.
+
+---
+
+## Procedure 6: Local Dev Proxy Setup
+
+When developing Collective UI locally, always use the `make collective-ui-dev`
+target rather than pointing Vite directly at a local Wrangler instance.
+
+```bash
+make collective-ui-dev
+```
+
+This starts Vite with a proxy to the **live** Cloudflare Worker. Rationale:
+the live Worker has real data and established auth; local Wrangler has neither.
+
+**Config resolution:**
+1. Reads Worker URL from `~/.myco-collective/<name>/config.json` (defaults to
+   the `oss` named config if no name is set)
+2. Override with `COLLECTIVE_UI_PROXY_TARGET` for local Wrangler testing:
+   ```bash
+   COLLECTIVE_UI_PROXY_TARGET=http://127.0.0.1:8787 make collective-ui-dev
+   ```
+
+Use the override only when explicitly testing unreleased Worker changes against
+a `wrangler dev` session. For all other UI development, default to the live
+Worker so you work against real data.
+
+---
+
+## Procedure 7: Design System Compliance for Collective UI
+
+The Collective UI is **not** a separate editorial product. It shares the daemon
+design system exactly. Two documented drift incidents have occurred; treat
+canary signals as blockers, not cosmetic issues.
+
+**Required tokens and patterns:**
+- CSS tokens: sage, ochre, terracotta (from daemon design system)
+- App shell: solid structural sidebar — same grammar as the Team UI
+- Type scale: dense, not editorial (no large base font)
+
+**Canary signals that drift has occurred:**
+- Brown or warm palette replacing sage/ochre/terracotta
+- Bubble-bordered or pill-shaped navigation
+- Large base font (editorial/marketing style)
+- Layout that diverges from the daemon app shell
+
+**Correction approach:** replace palette with charcoal and green accents; adopt
+the solid structural sidebar from Team UI; tighten type scale for density.
+Do not accumulate further drift once a canary signal appears — course-correct
+in the same PR.
+
+---
+
+## Procedure 8: V1 Integration Gate Checklist
+
+Before promoting the Collective to production team use, verify all integration
+points. This is the Teams Gate (decision `a317226c`).
+
+- [ ] **Machine ID keying** — D1 and Vectorize records are keyed by machine
+      ID; confirm no cross-project data contamination in query results
+- [ ] **Federation scope** — write from Project A, confirm the record is NOT
+      visible in Project B's query results
+- [ ] **Cross-machine visibility** — Machine A writes a record → Machine B
+      reads it via MCP (the core value proposition of the Collective)
+- [ ] **Backup/restore bootstrap** — new team member runs `myco restore` →
+      Collective connection re-established without manual config steps
+- [ ] **Token round-trip** — rotate admin token → propagate to all Workers →
+      confirm all API calls succeed
+- [ ] **MCP endpoint reachability** — `org_*` tools surface correctly on the
+      dedicated MCP Settings page in the Collective UI
+
+Do not mark the Collective production-ready until all items pass.
+
+---
+
+## Cross-Cutting Gotchas
+
+**Stale token in `.myco/secrets.env`**: After the home-scoped config refactor,
+`.myco/secrets.env` may still hold a `MYCO_COLLECTIVE_TOKEN` entry. Current
+code ignores it, but it causes confusion during debugging. Remove it.
+
+**`Bearer` prefix breaks auth silently**: The token input field in Collective
+UI settings expects the raw token — no `Bearer ` prefix. The field will show
+the value as valid but every API call will 401.
+
+**`collective_*` tools require no separate cloud connection**: They appear
+automatically when `.myco/team/config.json` exists and the project is
+connected. Missing tools almost always mean a disconnected project, not a
+cloud MCP issue.
+
+**Always verify after upgrading, not before**: Running `/api/auth/verify`
+against an unupgraded Worker returns stale identity. The deploy → upgrade →
+verify sequence is mandatory.
+
+**`myco doctor` after connection**: Installation audits have surfaced redundant
+UI package entries post-connect. Run `myco doctor` after connecting a project
+to a Collective to catch installation anomalies before they cause silent
+failures downstream.

--- a/.agents/skills/team-sync-data-layer/SKILL.md
+++ b/.agents/skills/team-sync-data-layer/SKILL.md
@@ -1,0 +1,377 @@
+---
+name: myco:team-sync-data-layer
+description: |
+  Use this skill when working on Myco's team sync data pipeline: the outbox →
+  D1/Vectorize → Worker federation layer. Covers the full protocol domain —
+  outbox/tombstone design, machine_id keying, drain mechanics, D1 schema
+  management, backfill idempotency, the three silent failure modes, Worker
+  federation topology, cross-machine verification, and composite index
+  optimization. Activate this even if the user doesn't explicitly ask for
+  "team sync" — trigger whenever adding a new sync-able entity type, debugging
+  why data isn't appearing on a remote machine, investigating D1 schema drift,
+  fixing stale outbox rows, or verifying a new team member's vault is
+  bootstrapped correctly. Complements cloudflare-worker-infrastructure-lifecycle
+  (deploy mechanics) and vault-schema-extension (local migration authoring) but
+  covers the data protocol layer that neither addresses.
+managed_by: myco
+user-invocable: true
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+# Myco Team Sync Data Layer
+
+The team sync pipeline moves local SQLite vault data to Cloudflare D1 (structured) and Vectorize (embeddings) via an outbox pattern, then federates that data to other machines through a Worker. Every sync-able entity type (spores, sessions, plans, artifacts, skills) must participate in the full protocol — write-through outbox insert, tombstone on delete, machine_id keying — or remote machines will silently diverge with no error.
+
+This skill covers the **data protocol layer**. For Worker deployment mechanics, see `cloudflare-worker-infrastructure-lifecycle`. For local migration authoring, see `vault-schema-extension`.
+
+## Prerequisites
+
+- Daemon is running and connected to a D1 database binding
+- `machine_id` is set in daemon identity (not `null`); `local` is the v7 backfill fallback for pre-identity rows
+- `wrangler.toml` has the correct D1 binding name matching the Worker's expected binding
+- Local SQLite schema and D1 schema are in sync before adding new entity types
+
+---
+
+## Procedure A: Adding a New Sync-able Entity Type
+
+When adding a new table or entity type to the sync pipeline (e.g., skills, plans, artifacts), every step below is required. Skipping any one causes silent data loss on remote machines.
+
+### 1. Add machine_id column to the local table
+
+Every sync-able table must have a `machine_id` column. Without it, D1 rows cannot be attributed to the correct machine and federation filtering breaks.
+
+```sql
+-- In the versioned migration file (src/db/migrations/vXX_add_<entity>.sql)
+ALTER TABLE <entity> ADD COLUMN machine_id TEXT NOT NULL DEFAULT 'local';
+```
+
+### 2. Define the outbox row schema
+
+The `outbox` table holds pending sync operations. Each row must contain:
+
+```sql
+entity_type TEXT NOT NULL,       -- e.g. 'spore', 'skill', 'plan'
+entity_id   TEXT NOT NULL,       -- entity primary key
+machine_id  TEXT NOT NULL,       -- from daemon identity
+operation   TEXT NOT NULL,       -- 'upsert' | 'tombstone'
+payload     TEXT,                -- JSON-serialized entity (NULL for tombstone)
+created_at  INTEGER NOT NULL,
+synced_at   INTEGER,             -- NULL until D1 confirms receipt
+status      TEXT NOT NULL DEFAULT 'pending'  -- 'pending' | 'sent' | 'dead'
+```
+
+### 3. Write-through on every INSERT/UPDATE
+
+Every write to a sync-able table must also insert an outbox row **in the same SQLite transaction**. If the outbox insert fails, the entity write rolls back.
+
+```typescript
+db.transaction(() => {
+  db.prepare(`INSERT INTO <entity> (...) VALUES (...)`).run(...);
+  db.prepare(`
+    INSERT INTO outbox (entity_type, entity_id, machine_id, operation, payload, created_at, status)
+    VALUES (?, ?, ?, 'upsert', ?, unixepoch(), 'pending')
+  `).run(entityType, entityId, machineId, JSON.stringify(entity));
+})();
+```
+
+### 4. Tombstone on delete — never hard DELETE
+
+Hard deletes silently orphan remote replicas because no outbox row is written. On delete, write a tombstone outbox row first, then soft-delete the local row.
+
+```typescript
+db.transaction(() => {
+  // Soft-delete the entity
+  db.prepare(`UPDATE <entity> SET deleted_at = unixepoch() WHERE id = ?`).run(entityId);
+  // Write tombstone — this is what propagates the deletion remotely
+  db.prepare(`
+    INSERT INTO outbox (entity_type, entity_id, machine_id, operation, payload, created_at, status)
+    VALUES (?, ?, ?, 'tombstone', NULL, unixepoch(), 'pending')
+  `).run(entityType, entityId, machineId);
+})();
+```
+
+> **Gotcha:** A hard `DELETE` removes the local row but no tombstone outbox row is written. The remote machine retains a stale copy indefinitely. This is **silent failure mode #2**.
+
+### 5. Mirror the schema change in D1
+
+Add the same column (and tombstone column if new) to the D1 migration file under `workers/migrations/`. D1 migrations apply lazily — see Procedure D for the drift window.
+
+### 6. Add the composite drain index
+
+For each new entity type participating in drain queries, ensure the outbox has a composite index (see Procedure G).
+
+---
+
+## Procedure B: Outbox Drain Mechanics
+
+The drain loop runs on a configurable interval (`drainIntervalMs`) and flushes `pending` outbox rows to D1 via the Worker.
+
+### Drain rate
+
+Rows are batched — typically 50–100 per cycle. Tune `drainBatchSize` in daemon config if the outbox grows faster than the drain rate.
+
+### sleep/deep_sleep drain gap (known issue)
+
+When the daemon enters `sleep` or `deep_sleep` states, the drain loop does **not** run. Outbox rows accumulate and are flushed only after the daemon wakes. This is a known team sync gap. Design downstream consumers to tolerate the latency, and do not rely on real-time sync during low-activity periods.
+
+### Drain confirmation
+
+A D1 write is confirmed only when the Worker returns HTTP 200 with a success response body. On confirmation, mark the row sent:
+
+```sql
+UPDATE outbox SET status = 'sent', synced_at = unixepoch() WHERE id = ?;
+```
+
+> **Gotcha (silent failure mode #1):** The drain can complete locally (no exception thrown) but the D1 write fails silently if the Worker swallows errors and returns 200 anyway. Detect by watching for outbox rows that stay `pending` across multiple drain cycles, then check Worker logs.
+
+### Pruning
+
+Prune sent rows after confirmed D1 ack to keep the outbox table bounded:
+
+```sql
+DELETE FROM outbox WHERE status = 'sent' AND synced_at < unixepoch() - 86400;
+```
+
+Dead-lettered rows (`status = 'dead'`, stuck > N drain cycles) indicate a persistent Worker or D1 error — log them and investigate before re-queueing.
+
+### Startup backfill
+
+On daemon start, backfill unsynced rows from settled sessions into the outbox. This covers crashes mid-drain and offline periods. The backfill query must be idempotent — see Procedure C.
+
+### settledSessionIdleMinutes interaction
+
+The drain only processes rows from sessions that have reached `settled` state. If `settledSessionIdleMinutes` is high, recently-written rows wait longer before becoming eligible. Tune this value to balance drain latency against premature settlement of active sessions.
+
+---
+
+## Procedure C: Backfill Idempotency
+
+Startup backfill runs every time the daemon starts and must be safe to run multiple times (crash recovery, rapid restarts).
+
+### INSERT OR IGNORE with a dedup index
+
+Use a unique partial index and `INSERT OR IGNORE` to prevent duplicate outbox rows:
+
+```sql
+-- Dedup index (create once in migration)
+CREATE UNIQUE INDEX IF NOT EXISTS outbox_dedup
+  ON outbox (entity_type, entity_id, operation)
+  WHERE status = 'pending';
+
+-- Idempotent backfill query
+INSERT OR IGNORE INTO outbox
+  (entity_type, entity_id, machine_id, operation, payload, created_at, status)
+SELECT
+  'spore', id, machine_id, 'upsert', json_object(...), unixepoch(), 'pending'
+FROM spores
+WHERE synced_at IS NULL
+  AND session_id IN (SELECT id FROM sessions WHERE status = 'settled');
+```
+
+### Idempotency key design
+
+The key is `(entity_type, entity_id, operation)`. Do **not** include timestamps in the key — the same entity may be re-inserted at different times during retries, and timestamps would allow duplicates.
+
+### Dead-letter recovery
+
+Rows stuck in `pending` for more than N cycles (configurable, e.g., 10 attempts) should be transitioned to `dead` and logged. To re-queue after diagnosing the Worker/D1 issue:
+
+```sql
+UPDATE outbox SET status = 'pending', synced_at = NULL WHERE status = 'dead' AND entity_type = ?;
+```
+
+---
+
+## Procedure D: D1 Schema Management
+
+D1 uses **lazy migration** — `ALTER TABLE` applies on the first Worker request after deploy, not at deploy time. This creates a schema drift window between `wrangler deploy` completing and the first request arriving.
+
+### The drift window
+
+During the drift window, queries against new columns fail. This window is typically seconds to minutes depending on traffic, but in low-traffic environments it can persist indefinitely.
+
+**Mitigation:** Trigger a warm-up request immediately after every deploy:
+
+```bash
+# In CI/CD, after wrangler deploy
+curl -X POST https://<worker>.workers.dev/health \
+  -H "Authorization: Bearer $MYCO_TEAM_TOKEN"
+```
+
+This forces the lazy migration to run before any real traffic hits the new schema.
+
+### Sync checklist for schema changes
+
+Include in the PR description for any schema change:
+
+- [ ] Local migration file added (`src/db/migrations/vXX_*.sql`)
+- [ ] D1 migration file added (`workers/migrations/`)
+- [ ] Column names and types match exactly between local and D1
+- [ ] `myco team upgrade` tested locally with `wrangler dev`
+- [ ] Warm-up step added to deploy pipeline
+
+### Testing D1 migrations without a live account
+
+Use `wrangler dev --local` with `--persist-to` to run D1 migrations locally:
+
+```bash
+wrangler dev --local --persist-to .wrangler/state
+# Migrations apply on first request
+curl http://localhost:8787/health
+```
+
+The local state persists across dev restarts, so subsequent starts reflect the migrated schema.
+
+---
+
+## Procedure E: Machine ID Keying and Verification
+
+The `machine_id` column flows from daemon identity through the outbox into D1. Correct keying is required for Worker federation to route data to the right machine.
+
+### machine_id source
+
+The daemon reads `machine_id` from its identity config at startup. The v7 migration backfilled `machine_id = 'local'` for pre-identity-system rows — `local` is a valid sentinel but indicates a row that cannot be federated to a specific machine.
+
+### Verifying correct keying in D1
+
+```sql
+-- Which machines have written to D1?
+SELECT machine_id, count(*) as row_count
+FROM spores
+GROUP BY machine_id;
+
+-- Detect null or empty machine_id — these rows cannot be federated (failure mode #3)
+SELECT count(*) FROM spores WHERE machine_id IS NULL OR machine_id = '';
+```
+
+### Cross-machine contamination prevention
+
+The Worker federation query must scope to **both** `project_id` and `machine_id`. A missing `project_id` filter allows data from other projects to leak across project boundaries.
+
+```typescript
+// Correct — scoped to project + machine
+const rows = await db.prepare(`
+  SELECT * FROM spores
+  WHERE project_id = ? AND machine_id = ?
+`).bind(projectId, machineId).all();
+```
+
+> **Gotcha (silent failure mode #3):** If `machine_id` is NULL or `'local'`, rows are written to D1 but the Worker cannot federate them to the correct remote machine. Remote machines will not see the data, with no error on either side. Detect with the D1 verification query above.
+
+---
+
+## Procedure F: Cross-Machine Verification
+
+Use this procedure to confirm team sync is working end-to-end between two machines, or as an integration gate before merging team sync changes.
+
+### Integration gate checklist
+
+**On Machine A (writer):**
+
+1. Write a test entity via the daemon (e.g., create a spore)
+2. Verify the outbox row was created:
+   ```sql
+   SELECT * FROM outbox
+   WHERE entity_type = 'spore' AND status = 'pending'
+   ORDER BY created_at DESC LIMIT 5;
+   ```
+3. Wait for the drain cycle (or trigger drain manually if a dev endpoint exists)
+4. Verify the outbox row is marked `sent`:
+   ```sql
+   SELECT status, synced_at FROM outbox
+   ORDER BY synced_at DESC LIMIT 5;
+   ```
+5. Verify D1 contains the row with the correct `machine_id`:
+   ```bash
+   wrangler d1 execute <DB_NAME> --remote \
+     --command "SELECT id, machine_id FROM spores ORDER BY created_at DESC LIMIT 5;"
+   ```
+
+**On Machine B (reader):**
+
+6. Query via vault API or MCP — `vault_spores` or `vault_search_semantic` should return the entity written on Machine A
+7. Confirm the `machine_id` on the retrieved row matches Machine A's identity
+
+If step 6 fails: check Machine A's drain status, Machine B's sync backfill, and the Worker's federation scope query.
+
+### New team member bootstrap
+
+Two onboarding paths — choose based on vault size:
+
+**Backup/restore** (faster for large vaults):
+```bash
+# On existing machine
+myco backup --output team-vault-snapshot.zip
+
+# On new machine
+myco restore --input team-vault-snapshot.zip
+```
+
+**Fresh sync** (always pulls latest state, slower):
+- Start daemon on new machine with empty vault
+- Daemon's startup backfill re-queues all settled sessions from D1
+- Drain loop populates the local vault
+
+Fresh sync requires the D1 schema to be fully migrated (warm-up after deploy) before the new machine's first request.
+
+---
+
+## Procedure G: Composite Index Optimization
+
+The drain query scans the outbox table at every drain cycle. Without a composite index, this is O(n) on total outbox size regardless of how many rows are `pending`.
+
+### Required drain index
+
+```sql
+CREATE INDEX IF NOT EXISTS outbox_drain_idx
+  ON outbox (machine_id, status, synced_at);
+```
+
+This index directly supports the drain query shape:
+
+```sql
+SELECT * FROM outbox
+WHERE machine_id = ? AND status = 'pending'
+ORDER BY created_at ASC
+LIMIT ?;
+```
+
+### Partial index for large outbox tables
+
+If the outbox grows large (millions of rows), a partial index on only `pending` rows reduces the index size significantly:
+
+```sql
+CREATE INDEX IF NOT EXISTS outbox_drain_pending_idx
+  ON outbox (machine_id, created_at)
+  WHERE status = 'pending';
+```
+
+This is more efficient than the full composite index when most rows are `sent`.
+
+### Index vs. trigger trade-offs
+
+- **Composite index on outbox**: 5–10% write overhead, O(log n) drain queries. Always prefer this.
+- **Triggers for FTS sync**: Use triggers only for FTS table maintenance (e.g., `spores_fts`), not for outbox status updates. Triggers on outbox status changes risk recursion and complicate transaction semantics.
+
+---
+
+## Cross-Cutting Gotchas
+
+### The three silent failure modes
+
+These produce no logged errors — data is simply missing or stale on remote machines:
+
+| Mode | Symptom | Detection | Fix |
+|------|---------|-----------|-----|
+| **1. Drain ack swallowed** | Outbox rows stay `pending` across multiple cycles | Check Worker logs; look for 200 with error body | Fix Worker error handling; reset rows to `pending` |
+| **2. Tombstone missing** | Deleted entity still visible on remote machine | `SELECT * FROM outbox WHERE entity_id = ? AND operation = 'tombstone'` | Write tombstone row manually; audit code for hard DELETEs |
+| **3. machine_id null/local** | Remote machine cannot see rows written on local | `SELECT count(*) FROM spores WHERE machine_id IS NULL OR machine_id = ''` | Backfill correct machine_id; re-queue affected outbox rows |
+
+### D1 lazy migration is silent
+
+D1 does not emit errors at deploy time when schema is stale. Queries against new columns fail silently until the first post-deploy request triggers the ALTER TABLE. Always warm up immediately after deploy.
+
+### Outbox and backfill must share idempotency scope
+
+If write-through and startup backfill use different idempotency keys (or one doesn't use `INSERT OR IGNORE`), you will get duplicate outbox rows that produce duplicate D1 upserts. Upserts are idempotent in D1, but duplicate rows inflate drain cost and complicate debugging.

--- a/.myco/myco.yaml
+++ b/.myco/myco.yaml
@@ -1,5 +1,5 @@
 version: 3
-config_version: 4
+config_version: 5
 embedding:
   provider: ollama
   model: bge-m3:latest
@@ -106,6 +106,9 @@ notifications:
       enabled: false
     mycelium:
       enabled: true
+    settings:
+      enabled: true
+      mode: banner
 appearance:
   theme: sage
   mode: dark

--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -94,10 +94,12 @@ const PROMPT_SECTION_CURRENT_PHASE = '## Current Phase: ';
 // The daemon sets this env var automatically when log_level is "debug"
 // (see src/daemon/main.ts). It can also be set manually for ad-hoc runs.
 
-const DEBUG_TOOL_CALLS = process.env.MYCO_AGENT_DEBUG === '1';
-
 /** Max chars to print from tool input/output payloads. */
 const TOOL_DEBUG_PREVIEW_CHARS = 240;
+
+function debugToolCallsEnabled(): boolean {
+  return process.env.MYCO_AGENT_DEBUG === '1';
+}
 
 interface SdkContentBlock {
   type: string;
@@ -121,7 +123,7 @@ function previewPayload(value: unknown): string {
 }
 
 function logToolUseBlocks(phaseName: string, message: unknown): void {
-  if (!DEBUG_TOOL_CALLS) return;
+  if (!debugToolCallsEnabled()) return;
   const blocks = (message as SdkMessageWithContent).message?.content;
   if (!Array.isArray(blocks)) return;
   for (const block of blocks) {
@@ -134,7 +136,7 @@ function logToolUseBlocks(phaseName: string, message: unknown): void {
 }
 
 function logToolResultBlocks(phaseName: string, message: unknown): void {
-  if (!DEBUG_TOOL_CALLS) return;
+  if (!debugToolCallsEnabled()) return;
   const blocks = (message as SdkMessageWithContent).message?.content;
   if (!Array.isArray(blocks)) return;
   for (const block of blocks) {

--- a/packages/myco/src/config/focus.ts
+++ b/packages/myco/src/config/focus.ts
@@ -1,0 +1,248 @@
+export const CONFIG_FOCUS_SECTION_PARAM = 'configSection';
+export const CONFIG_FOCUS_FIELD_PARAM = 'configField';
+
+const FIELD_ID_PREFIX = 'config-field-';
+
+export const CONFIG_SECTION_IDS = {
+  appearance: 'config-section-appearance',
+  settingsAgent: 'config-section-settings-agent',
+  settingsEmbedding: 'config-section-settings-embedding',
+  settingsContextInjection: 'config-section-settings-context-injection',
+  settingsNotifications: 'config-section-settings-notifications',
+  settingsPlanCapture: 'config-section-settings-plan-capture',
+  settingsProject: 'config-section-settings-project',
+  agentOperations: 'config-section-agent-operations',
+  operationsMaintenance: 'config-section-operations-maintenance',
+  operationsBackup: 'config-section-operations-backup',
+} as const;
+
+type ConfigPagePath = '/settings' | '/agent' | '/operations';
+
+interface ConfigSectionTarget {
+  page: ConfigPagePath;
+  sectionId: string;
+  sectionLabel: string;
+  searchParams?: Record<string, string>;
+}
+
+export interface ConfigFocusTarget extends ConfigSectionTarget {
+  fieldPath: string;
+  fieldLabel: string;
+}
+
+interface PrefixRule extends ConfigSectionTarget {
+  prefix: string;
+}
+
+const SECTION_RULES: PrefixRule[] = [
+  {
+    prefix: 'appearance',
+    page: '/settings',
+    sectionId: CONFIG_SECTION_IDS.appearance,
+    sectionLabel: 'Appearance',
+  },
+  {
+    prefix: 'agent.provider',
+    page: '/settings',
+    sectionId: CONFIG_SECTION_IDS.settingsAgent,
+    sectionLabel: 'Myco Agent',
+  },
+  {
+    prefix: 'embedding',
+    page: '/settings',
+    sectionId: CONFIG_SECTION_IDS.settingsEmbedding,
+    sectionLabel: 'Embedding',
+  },
+  {
+    prefix: 'context',
+    page: '/settings',
+    sectionId: CONFIG_SECTION_IDS.settingsContextInjection,
+    sectionLabel: 'Context Injection',
+  },
+  {
+    prefix: 'notifications',
+    page: '/settings',
+    sectionId: CONFIG_SECTION_IDS.settingsNotifications,
+    sectionLabel: 'Notifications',
+  },
+  {
+    prefix: 'capture',
+    page: '/settings',
+    sectionId: CONFIG_SECTION_IDS.settingsPlanCapture,
+    sectionLabel: 'Plan Capture',
+  },
+  {
+    prefix: 'daemon',
+    page: '/settings',
+    sectionId: CONFIG_SECTION_IDS.settingsProject,
+    sectionLabel: 'Project',
+  },
+  {
+    prefix: 'agent.scheduled_tasks_enabled',
+    page: '/agent',
+    sectionId: CONFIG_SECTION_IDS.agentOperations,
+    sectionLabel: 'Agent Operations',
+    searchParams: { tab: 'config' },
+  },
+  {
+    prefix: 'agent.event_tasks_enabled',
+    page: '/agent',
+    sectionId: CONFIG_SECTION_IDS.agentOperations,
+    sectionLabel: 'Agent Operations',
+    searchParams: { tab: 'config' },
+  },
+  {
+    prefix: 'agent.summary_batch_interval',
+    page: '/agent',
+    sectionId: CONFIG_SECTION_IDS.agentOperations,
+    sectionLabel: 'Agent Operations',
+    searchParams: { tab: 'config' },
+  },
+  {
+    prefix: 'maintenance',
+    page: '/operations',
+    sectionId: CONFIG_SECTION_IDS.operationsMaintenance,
+    sectionLabel: 'Scheduled Maintenance',
+  },
+  {
+    prefix: 'backup',
+    page: '/operations',
+    sectionId: CONFIG_SECTION_IDS.operationsBackup,
+    sectionLabel: 'Backup & Restore',
+  },
+];
+
+const EXACT_FIELD_LABELS: Record<string, string> = {
+  'appearance.theme': 'Color Theme',
+  'appearance.mode': 'Mode',
+  'appearance.font': 'Font',
+  'appearance.density': 'Density',
+  'agent.provider': 'Provider',
+  'agent.provider.type': 'Provider',
+  'agent.provider.model': 'Model',
+  'agent.provider.base_url': 'Base URL',
+  'agent.provider.context_length': 'Context Length',
+  'embedding.provider': 'Provider',
+  'embedding.model': 'Model',
+  'embedding.base_url': 'Base URL',
+  'context.digest_tier': 'Digest Tier',
+  'context.prompt_search': 'Prompt Search',
+  'context.prompt_max_spores': 'Max Spores per Prompt',
+  'notifications.enabled': 'Notifications',
+  'notifications.default_mode': 'Default Display',
+  'notifications.system_notifications': 'Browser Notifications',
+  'capture.ignore_plan_dirs_in_git': 'Ignore Custom Plan Dirs In Git',
+  'capture.plan_dirs': 'Custom Directories',
+  'daemon.port': 'Daemon Port',
+  'daemon.log_level': 'Log Level',
+  'daemon.log_retention_days': 'Log Retention (days)',
+  'agent.scheduled_tasks_enabled': 'Scheduled Tasks',
+  'agent.event_tasks_enabled': 'Event-Driven Tasks',
+  'agent.summary_batch_interval': 'Title & Summary Batch Interval',
+  'maintenance.auto_optimize': 'Auto-optimize',
+  'maintenance.auto_optimize_interval_hours': 'Auto-optimize Interval',
+  'backup.dir': 'Backup Directory',
+};
+
+const DYNAMIC_FIELD_LABEL_RULES: Array<{
+  prefix: string;
+  format: (path: string) => string | null;
+}> = [
+  {
+    prefix: 'notifications.domains.',
+    format: (path) => {
+      const match = /^notifications\.domains\.([^.]+)\.(enabled|mode)$/.exec(path);
+      if (!match) return null;
+      const [, domain, leaf] = match;
+      const domainLabel = humanizeToken(domain);
+      return leaf === 'mode' ? `${domainLabel} Display` : `${domainLabel} Notifications`;
+    },
+  },
+];
+
+const SAVE_MESSAGE_LABEL_LIMIT = 3;
+
+export function configFieldId(path: string): string {
+  return `${FIELD_ID_PREFIX}${path.replace(/[^a-zA-Z0-9]+/g, '-')}`;
+}
+
+export function resolveConfigFocusTarget(path: string): ConfigFocusTarget | null {
+  const section = findSectionRule(path);
+  if (!section) return null;
+  return {
+    ...section,
+    fieldPath: path,
+    fieldLabel: resolveFieldLabel(path),
+  };
+}
+
+export function buildConfigFocusLink(target: ConfigFocusTarget): string {
+  const params = new URLSearchParams(target.searchParams);
+  params.set(CONFIG_FOCUS_SECTION_PARAM, target.sectionId);
+  params.set(CONFIG_FOCUS_FIELD_PARAM, target.fieldPath);
+  return `${target.page}?${params.toString()}`;
+}
+
+export function buildScopedConfigSaveNotification(scope: 'project' | 'local', touchedPaths: string[]) {
+  const uniquePaths = [...new Set(touchedPaths)];
+  const scopeLabel = scope === 'local' ? 'Personal' : 'Project';
+  const focusTarget = uniquePaths.map(resolveConfigFocusTarget).find((target) => target !== null) ?? null;
+  const fieldLabels = uniquePaths.map(resolveFieldLabel);
+  const primaryLabel = fieldLabels[0] ?? 'Setting';
+  const labelList = fieldLabels.slice(0, SAVE_MESSAGE_LABEL_LIMIT).join(', ');
+  const remainingCount = Math.max(0, fieldLabels.length - SAVE_MESSAGE_LABEL_LIMIT);
+  const messageLabel = remainingCount > 0 ? `${labelList}, +${remainingCount} more` : labelList;
+
+  return {
+    title: uniquePaths.length === 1 ? `${primaryLabel} saved` : `${uniquePaths.length} settings saved`,
+    message: focusTarget
+      ? `${focusTarget.sectionLabel} · ${messageLabel} · ${scopeLabel}`
+      : `${messageLabel} · ${scopeLabel}`,
+    link: focusTarget ? buildConfigFocusLink(focusTarget) : null,
+    metadata: {
+      scope,
+      touched_paths: uniquePaths,
+      field_labels: fieldLabels,
+      focus_target: focusTarget
+        ? {
+            page: focusTarget.page,
+            section_id: focusTarget.sectionId,
+            field_path: focusTarget.fieldPath,
+            field_label: focusTarget.fieldLabel,
+          }
+        : null,
+    },
+  };
+}
+
+function findSectionRule(path: string): ConfigSectionTarget | null {
+  for (const rule of SECTION_RULES) {
+    if (path === rule.prefix || path.startsWith(`${rule.prefix}.`)) {
+      const { page, sectionId, sectionLabel, searchParams } = rule;
+      return { page, sectionId, sectionLabel, searchParams };
+    }
+  }
+  return null;
+}
+
+function resolveFieldLabel(path: string): string {
+  const exact = EXACT_FIELD_LABELS[path];
+  if (exact) return exact;
+
+  for (const rule of DYNAMIC_FIELD_LABEL_RULES) {
+    if (path === rule.prefix || path.startsWith(rule.prefix)) {
+      const label = rule.format(path);
+      if (label) return label;
+    }
+  }
+
+  return humanizeToken(path.split('.').pop() ?? 'setting');
+}
+
+function humanizeToken(value: string): string {
+  return value
+    .split(/[-_]/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}

--- a/packages/myco/src/config/loader.ts
+++ b/packages/myco/src/config/loader.ts
@@ -4,7 +4,6 @@ import YAML from 'yaml';
 import { MycoConfigSchema, type MycoConfig, type BackupConfig, type TeamConfig } from './schema.js';
 import { runMigrations, CURRENT_MIGRATION_VERSION } from './migrations.js';
 import { deepMerge } from '../utils/deep-merge.js';
-import { unsetAtPath } from '../utils/dot-path.js';
 
 export const CONFIG_FILENAME = 'myco.yaml';
 export const LOCAL_CONFIG_FILENAME = 'local.yaml';
@@ -190,18 +189,25 @@ export function loadMergedConfig(vaultDir: string): MycoConfig {
   return MycoConfigSchema.parse(merged);
 }
 
-/** Write a partial to <vaultDir>/local.yaml, deep-merging with existing local content. */
-export function saveLocalConfig(vaultDir: string, patch: Partial<MycoConfig>): Partial<MycoConfig> {
-  const existing = loadLocalConfig(vaultDir);
-  const next = deepMergeConfig(existing as Record<string, unknown>, patch as Record<string, unknown>) as Partial<MycoConfig>;
-
-  const existingYaml = YAML.stringify(existing);
+/**
+ * Write local.yaml only when the serialized contents differ from `current`.
+ * Skips the write (and mkdirSync) on a no-op to avoid noisy file mtimes.
+ */
+function writeLocalYamlIfChanged<T>(vaultDir: string, current: T, next: T): T {
+  const existingYaml = YAML.stringify(current);
   const nextYaml = YAML.stringify(next);
   if (existingYaml === nextYaml) return next;
 
   fs.mkdirSync(vaultDir, { recursive: true });
   fs.writeFileSync(localConfigPath(vaultDir), nextYaml, 'utf-8');
   return next;
+}
+
+/** Write a partial to <vaultDir>/local.yaml, deep-merging with existing local content. */
+export function saveLocalConfig(vaultDir: string, patch: Partial<MycoConfig>): Partial<MycoConfig> {
+  const existing = loadLocalConfig(vaultDir);
+  const next = deepMergeConfig(existing as Record<string, unknown>, patch as Record<string, unknown>) as Partial<MycoConfig>;
+  return writeLocalYamlIfChanged(vaultDir, existing, next);
 }
 
 /**
@@ -215,28 +221,5 @@ export function updateLocalConfig(
   fn: (local: Partial<MycoConfig>) => Partial<MycoConfig>,
 ): Partial<MycoConfig> {
   const current = loadLocalConfig(vaultDir);
-  const updated = fn(current);
-
-  const existingYaml = YAML.stringify(current);
-  const nextYaml = YAML.stringify(updated);
-  if (existingYaml === nextYaml) return updated;
-
-  fs.mkdirSync(vaultDir, { recursive: true });
-  fs.writeFileSync(localConfigPath(vaultDir), nextYaml, 'utf-8');
-  return updated;
-}
-
-/**
- * Clear one or more top-level keys from local config (e.g. to "reset to project default").
- * Accepts dotted paths (e.g. 'appearance.theme') for single-field resets.
- */
-export function clearLocalConfigKeys(vaultDir: string, keys: string[]): Partial<MycoConfig> {
-  const current = loadLocalConfig(vaultDir) as Record<string, unknown>;
-  const changed = keys.reduce((acc, key) => unsetAtPath(current, key) || acc, false);
-
-  if (!changed) return current;
-
-  fs.mkdirSync(vaultDir, { recursive: true });
-  fs.writeFileSync(localConfigPath(vaultDir), YAML.stringify(current), 'utf-8');
-  return current;
+  return writeLocalYamlIfChanged(vaultDir, current, fn(current));
 }

--- a/packages/myco/src/config/loader.ts
+++ b/packages/myco/src/config/loader.ts
@@ -106,7 +106,8 @@ export function loadConfig(vaultDir: string): MycoConfig {
 }
 
 export function saveConfig(vaultDir: string, config: MycoConfig): void {
-  // Validate before writing — OAK lesson: validate on write, not just read
+  // Validate before writing — OAK lesson: validate on write, not just read.
+  // This is the single parse point for all write paths.
   const validated = MycoConfigSchema.parse(config);
 
   const configPath = path.join(vaultDir, CONFIG_FILENAME);

--- a/packages/myco/src/config/loader.ts
+++ b/packages/myco/src/config/loader.ts
@@ -204,14 +204,26 @@ export function saveLocalConfig(vaultDir: string, patch: Partial<MycoConfig>): P
   return next;
 }
 
-/** Callback-style update for local config. */
+/**
+ * Callback-style update for local config. Replace-semantics: the value
+ * returned by `fn` is written verbatim (so callers can remove keys by
+ * omitting them). Callers that want merge-semantics should spread
+ * `...local` inside their callback, or use `saveLocalConfig` directly.
+ */
 export function updateLocalConfig(
   vaultDir: string,
   fn: (local: Partial<MycoConfig>) => Partial<MycoConfig>,
 ): Partial<MycoConfig> {
   const current = loadLocalConfig(vaultDir);
   const updated = fn(current);
-  return saveLocalConfig(vaultDir, updated);
+
+  const existingYaml = YAML.stringify(current);
+  const nextYaml = YAML.stringify(updated);
+  if (existingYaml === nextYaml) return updated;
+
+  fs.mkdirSync(vaultDir, { recursive: true });
+  fs.writeFileSync(localConfigPath(vaultDir), nextYaml, 'utf-8');
+  return updated;
 }
 
 /**

--- a/packages/myco/src/config/migrations.ts
+++ b/packages/myco/src/config/migrations.ts
@@ -206,6 +206,18 @@ export const MIGRATIONS: Migration[] = [
       }
     },
   },
+  {
+    version: 5,
+    name: 'seed-settings-notification-domain-default',
+    migrate(doc: Record<string, unknown>, _vaultDir: string): void {
+      const notifications = (doc.notifications ??= {}) as Record<string, unknown>;
+      const domains = (notifications.domains ??= {}) as Record<string, unknown>;
+      const settings = (domains.settings ??= {}) as Record<string, unknown>;
+
+      if (!('enabled' in settings)) settings.enabled = true;
+      if (!('mode' in settings)) settings.mode = 'banner';
+    },
+  },
 ];
 
 /** Current migration version — the highest version in MIGRATIONS. */

--- a/packages/myco/src/daemon/api/config.ts
+++ b/packages/myco/src/daemon/api/config.ts
@@ -1,14 +1,16 @@
 import {
   loadConfig,
   updateConfig,
+  updateLocalConfig,
   loadMergedConfig,
   loadLocalConfig,
-  saveLocalConfig,
   clearLocalConfigKeys,
   deepMergeConfig,
 } from '../../config/loader.js';
 import { z } from 'zod';
 import { MycoConfigSchema, type MycoConfig } from '../../config/schema.js';
+import { unsetAtPath } from '../../utils/dot-path.js';
+import { enumerateLeafPaths } from '../config-reactions/touched-paths.js';
 import type { PlanWatchConfig } from '../plan-capture.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 
@@ -35,26 +37,61 @@ export async function handleGetLocalConfig(vaultDir: string): Promise<RouteRespo
 interface ScopedPutBody {
   scope?: 'project' | 'local';
   patch?: Record<string, unknown>;
+  clear?: string[];
 }
 
-/** PUT /api/config/scoped — deep-merge a partial patch into project or local config. */
+/**
+ * PUT /api/config/scoped — atomic patch + clear against project or local config.
+ *
+ * Request body:
+ *   { scope: 'project' | 'local',
+ *     patch?: DeepPartial<MycoConfig>,   // deep-merged into scope
+ *     clear?: string[] }                  // dot-paths removed from scope
+ *
+ * At least one of `patch` (non-empty object) or `clear` (non-empty array) is
+ * required. If both are present, overlapping keys are rejected (400). The
+ * server applies `clear` first, then merges `patch`, in a single write.
+ */
 export async function handlePutScopedConfig(vaultDir: string, body: unknown): Promise<RouteResponse> {
   const payload = (body ?? {}) as ScopedPutBody;
   const scope = payload.scope ?? 'project';
-  const patch = payload.patch;
+  const patch = payload.patch ?? {};
+  const clear = payload.clear;
 
-  if (!patch || typeof patch !== 'object') {
-    return { status: 400, body: { error: 'patch required' } };
+  if (clear !== undefined && !Array.isArray(clear)) {
+    return { status: 400, body: { error: 'clear must be an array of dot-paths' } };
+  }
+  const clearList = clear ?? [];
+
+  if (typeof patch !== 'object' || patch === null || Array.isArray(patch)) {
+    return { status: 400, body: { error: 'patch must be an object' } };
+  }
+  const patchLeaves = enumerateLeafPaths(patch);
+  const hasPatch = patchLeaves.length > 0;
+  const hasClear = clearList.length > 0;
+  if (!hasPatch && !hasClear) {
+    return { status: 400, body: { error: 'patch or clear required' } };
+  }
+
+  const overlap = patchLeaves.filter((leaf) => clearList.includes(leaf));
+  if (overlap.length > 0) {
+    return { status: 400, body: { error: 'patch_clear_overlap', keys: overlap } };
   }
 
   if (scope === 'local') {
-    const updated = saveLocalConfig(vaultDir, patch as Partial<MycoConfig>);
+    const updated = updateLocalConfig(vaultDir, (local) => {
+      const working = structuredClone(local) as Record<string, unknown>;
+      for (const key of clearList) unsetAtPath(working, key);
+      return deepMergeConfig(working, patch as Record<string, unknown>) as Partial<MycoConfig>;
+    });
     return { body: updated };
   }
 
   try {
     const updated = updateConfig(vaultDir, (current) => {
-      const merged = deepMergeConfig(current as Record<string, unknown>, patch as Record<string, unknown>);
+      const working = structuredClone(current) as Record<string, unknown>;
+      for (const key of clearList) unsetAtPath(working, key);
+      const merged = deepMergeConfig(working, patch as Record<string, unknown>);
       return MycoConfigSchema.parse(merged);
     });
     return { body: updated };

--- a/packages/myco/src/daemon/api/config.ts
+++ b/packages/myco/src/daemon/api/config.ts
@@ -4,7 +4,6 @@ import {
   updateLocalConfig,
   loadMergedConfig,
   loadLocalConfig,
-  clearLocalConfigKeys,
   deepMergeConfig,
 } from '../../config/loader.js';
 import { z } from 'zod';
@@ -101,18 +100,6 @@ export async function handlePutScopedConfig(vaultDir: string, body: unknown): Pr
     }
     throw err;
   }
-}
-
-interface ClearLocalBody { keys?: string[]; }
-
-/** POST /api/config/local/clear — delete specific keys (supports dotted paths) from local overrides. */
-export async function handleClearLocalConfig(vaultDir: string, body: unknown): Promise<RouteResponse> {
-  const { keys } = (body ?? {}) as ClearLocalBody;
-  if (!Array.isArray(keys) || keys.length === 0) {
-    return { status: 400, body: { error: 'keys array required' } };
-  }
-  const updated = clearLocalConfigKeys(vaultDir, keys);
-  return { body: updated };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/myco/src/daemon/api/config.ts
+++ b/packages/myco/src/daemon/api/config.ts
@@ -10,7 +10,6 @@ import { z } from 'zod';
 import { MycoConfigSchema, type MycoConfig } from '../../config/schema.js';
 import { unsetAtPath } from '../../utils/dot-path.js';
 import { enumerateLeafPaths } from '../config-reactions/touched-paths.js';
-import type { PlanWatchConfig } from '../plan-capture.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 
 export async function handleGetConfig(vaultDir: string): Promise<RouteResponse> {
@@ -107,64 +106,19 @@ export async function handlePutScopedConfig(vaultDir: string, body: unknown): Pr
 // ---------------------------------------------------------------------------
 
 export interface PlanDirDeps {
-  vaultDir: string;
   symbiontPlanDirsByAgent: Record<string, string[]>;
-  symbiontPlanDirs: string[];
-  planWatchConfig: PlanWatchConfig;
-  setPlanWatchConfig: (config: PlanWatchConfig) => void;
-  reconcileProjectFiles?: () => void;
-}
-
-interface PlanDirRequestBody {
-  plan_dirs: string[];
-  ignore_plan_dirs_in_git?: boolean;
 }
 
 export function createPlanDirHandlers(deps: PlanDirDeps) {
-  const { vaultDir, symbiontPlanDirsByAgent, symbiontPlanDirs } = deps;
-
-  /** GET /api/config/plan-dirs */
+  /**
+   * GET /api/config/plan-dirs — returns the symbiont-derived plan dir
+   * inventory (manifest-driven, never user-editable). Custom plan dirs
+   * are read/written through /api/config/scoped like any other config
+   * field.
+   */
   async function handleGetPlanDirs(_req: RouteRequest): Promise<RouteResponse> {
-    const config = loadConfig(vaultDir);
-    return {
-      body: {
-        symbiont: symbiontPlanDirsByAgent,
-        custom: deps.planWatchConfig.watchDirs.filter((d) => !symbiontPlanDirs.includes(d)),
-        ignore_plan_dirs_in_git: config.capture.ignore_plan_dirs_in_git,
-      },
-    };
+    return { body: { symbiont: deps.symbiontPlanDirsByAgent } };
   }
 
-  /** POST /api/config/plan-dirs */
-  async function handleUpdatePlanDirs(req: RouteRequest): Promise<RouteResponse> {
-    const body = req.body as PlanDirRequestBody;
-    if (!Array.isArray(body.plan_dirs)) {
-      return { status: 400, body: { error: 'plan_dirs must be an array' } };
-    }
-    if (body.ignore_plan_dirs_in_git !== undefined && typeof body.ignore_plan_dirs_in_git !== 'boolean') {
-      return { status: 400, body: { error: 'ignore_plan_dirs_in_git must be a boolean' } };
-    }
-    const updated = updateConfig(vaultDir, (cfg) => ({
-      ...cfg,
-      capture: {
-        ...cfg.capture,
-        plan_dirs: body.plan_dirs,
-        ignore_plan_dirs_in_git: body.ignore_plan_dirs_in_git ?? cfg.capture.ignore_plan_dirs_in_git,
-      },
-    }));
-    // Refresh in-memory config so plan capture picks up new dirs immediately
-    deps.setPlanWatchConfig({
-      ...deps.planWatchConfig,
-      watchDirs: [...new Set([...symbiontPlanDirs, ...body.plan_dirs])],
-    });
-    deps.reconcileProjectFiles?.();
-    return {
-      body: {
-        custom: updated.capture.plan_dirs,
-        ignore_plan_dirs_in_git: updated.capture.ignore_plan_dirs_in_git,
-      },
-    };
-  }
-
-  return { handleGetPlanDirs, handleUpdatePlanDirs };
+  return { handleGetPlanDirs };
 }

--- a/packages/myco/src/daemon/api/config.ts
+++ b/packages/myco/src/daemon/api/config.ts
@@ -7,7 +7,7 @@ import {
   deepMergeConfig,
 } from '../../config/loader.js';
 import { z } from 'zod';
-import { MycoConfigSchema, type MycoConfig } from '../../config/schema.js';
+import type { MycoConfig } from '../../config/schema.js';
 import { unsetAtPath } from '../../utils/dot-path.js';
 import { enumerateLeafPaths } from '../config-reactions/touched-paths.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
@@ -86,11 +86,13 @@ export async function handlePutScopedConfig(vaultDir: string, body: unknown): Pr
   }
 
   try {
+    // saveConfig (called by updateConfig) runs the Zod parse — the callback
+    // returns the deep-merged object without validating, and any invalid
+    // shape raises a ZodError that we convert to a 400 below.
     const updated = updateConfig(vaultDir, (current) => {
       const working = structuredClone(current) as Record<string, unknown>;
       for (const key of clearList) unsetAtPath(working, key);
-      const merged = deepMergeConfig(working, patch as Record<string, unknown>);
-      return MycoConfigSchema.parse(merged);
+      return deepMergeConfig(working, patch as Record<string, unknown>) as MycoConfig;
     });
     return { body: updated };
   } catch (err) {

--- a/packages/myco/src/daemon/api/config.ts
+++ b/packages/myco/src/daemon/api/config.ts
@@ -7,7 +7,7 @@ import {
   deepMergeConfig,
 } from '../../config/loader.js';
 import { z } from 'zod';
-import type { MycoConfig } from '../../config/schema.js';
+import { MycoConfigSchema, type MycoConfig } from '../../config/schema.js';
 import { unsetAtPath } from '../../utils/dot-path.js';
 import { enumerateLeafPaths } from '../config-reactions/touched-paths.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
@@ -38,6 +38,29 @@ interface ScopedPutBody {
   clear?: string[];
 }
 
+const SCOPED_CONFIG_SCOPES = ['project', 'local'] as const;
+
+function isScopedConfigScope(value: unknown): value is ScopedPutBody['scope'] {
+  return typeof value === 'string'
+    && (SCOPED_CONFIG_SCOPES as readonly string[]).includes(value);
+}
+
+function validateClearList(clear: unknown): string[] | RouteResponse {
+  if (clear === undefined) return [];
+  if (!Array.isArray(clear)) {
+    return { status: 400, body: { error: 'clear must be an array of dot-paths' } };
+  }
+  const invalidEntry = clear.find((entry) => typeof entry !== 'string' || entry.trim().length === 0);
+  if (invalidEntry !== undefined) {
+    return { status: 400, body: { error: 'clear entries must be non-empty strings' } };
+  }
+  return clear;
+}
+
+function pathsOverlap(a: string, b: string): boolean {
+  return a === b || a.startsWith(`${b}.`) || b.startsWith(`${a}.`);
+}
+
 /**
  * PUT /api/config/scoped — atomic patch + clear against project or local config.
  *
@@ -52,14 +75,14 @@ interface ScopedPutBody {
  */
 export async function handlePutScopedConfig(vaultDir: string, body: unknown): Promise<RouteResponse> {
   const payload = (body ?? {}) as ScopedPutBody;
-  const scope = payload.scope ?? 'project';
-  const patch = payload.patch ?? {};
-  const clear = payload.clear;
-
-  if (clear !== undefined && !Array.isArray(clear)) {
-    return { status: 400, body: { error: 'clear must be an array of dot-paths' } };
+  if (!isScopedConfigScope(payload.scope)) {
+    return { status: 400, body: { error: 'scope must be project or local' } };
   }
-  const clearList = clear ?? [];
+  const scope = payload.scope;
+  const patch = payload.patch ?? {};
+  const clearListOrError = validateClearList(payload.clear);
+  if (Array.isArray(clearListOrError) === false) return clearListOrError;
+  const clearList = clearListOrError;
 
   if (typeof patch !== 'object' || patch === null || Array.isArray(patch)) {
     return { status: 400, body: { error: 'patch must be an object' } };
@@ -71,18 +94,35 @@ export async function handlePutScopedConfig(vaultDir: string, body: unknown): Pr
     return { status: 400, body: { error: 'patch or clear required' } };
   }
 
-  const overlap = patchLeaves.filter((leaf) => clearList.includes(leaf));
+  const overlap = patchLeaves.filter((leaf) => clearList.some((clearPath) => pathsOverlap(leaf, clearPath)));
   if (overlap.length > 0) {
     return { status: 400, body: { error: 'patch_clear_overlap', keys: overlap } };
   }
 
   if (scope === 'local') {
-    const updated = updateLocalConfig(vaultDir, (local) => {
-      const working = structuredClone(local) as Record<string, unknown>;
-      for (const key of clearList) unsetAtPath(working, key);
-      return deepMergeConfig(working, patch as Record<string, unknown>) as Partial<MycoConfig>;
-    });
-    return { body: updated };
+    try {
+      const project = loadConfig(vaultDir);
+      const updated = updateLocalConfig(vaultDir, (local) => {
+        const working = structuredClone(local) as Record<string, unknown>;
+        for (const key of clearList) unsetAtPath(working, key);
+        const nextLocal = deepMergeConfig(
+          working,
+          patch as Record<string, unknown>,
+        ) as Partial<MycoConfig>;
+        const merged = deepMergeConfig(
+          project as Record<string, unknown>,
+          nextLocal as Record<string, unknown>,
+        );
+        MycoConfigSchema.parse(merged);
+        return nextLocal;
+      });
+      return { body: updated };
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        return { status: 400, body: { error: 'validation_failed', issues: err.issues } };
+      }
+      throw err;
+    }
   }
 
   try {

--- a/packages/myco/src/daemon/config-reactions/context.ts
+++ b/packages/myco/src/daemon/config-reactions/context.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+import { loadMergedConfig } from '../../config/loader.js';
+import type { MycoConfig } from '../../config/schema.js';
+import type { Logger } from '../logger.js';
+
+/**
+ * Best-effort merged config load for post-write reactions. A stale invalid
+ * local overlay should not turn an already-persisted scoped write into a 500.
+ */
+export function loadReactionContext(vaultDir: string, logger: Logger): MycoConfig | null {
+  try {
+    return loadMergedConfig(vaultDir);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      logger.warn('config-reactions', 'skipping reactions because merged config is invalid', {
+        issues: err.issues.map((issue) => ({
+          path: issue.path.join('.'),
+          message: issue.message,
+        })),
+      });
+      return null;
+    }
+    throw err;
+  }
+}

--- a/packages/myco/src/daemon/config-reactions/index.ts
+++ b/packages/myco/src/daemon/config-reactions/index.ts
@@ -1,3 +1,3 @@
 export { createConfigReactionRegistry } from './registry.js';
-export type { ConfigReactionRegistry, ReactionLogger } from './registry.js';
+export type { ConfigReactionRegistry } from './registry.js';
 export { computeTouchedPaths, enumerateLeafPaths } from './touched-paths.js';

--- a/packages/myco/src/daemon/config-reactions/index.ts
+++ b/packages/myco/src/daemon/config-reactions/index.ts
@@ -1,3 +1,3 @@
 export { createConfigReactionRegistry } from './registry.js';
-export type { ConfigReactionRegistry } from './registry.js';
+export type { ConfigReactionRegistry, ConfigReaction } from './registry.js';
 export { computeTouchedPaths, enumerateLeafPaths } from './touched-paths.js';

--- a/packages/myco/src/daemon/config-reactions/index.ts
+++ b/packages/myco/src/daemon/config-reactions/index.ts
@@ -1,0 +1,3 @@
+export { createConfigReactionRegistry } from './registry.js';
+export type { ConfigReactionRegistry, ReactionLogger } from './registry.js';
+export { computeTouchedPaths, enumerateLeafPaths } from './touched-paths.js';

--- a/packages/myco/src/daemon/config-reactions/index.ts
+++ b/packages/myco/src/daemon/config-reactions/index.ts
@@ -1,3 +1,4 @@
 export { createConfigReactionRegistry } from './registry.js';
 export type { ConfigReactionRegistry, ConfigReaction } from './registry.js';
+export { loadReactionContext } from './context.js';
 export { computeTouchedPaths, enumerateLeafPaths } from './touched-paths.js';

--- a/packages/myco/src/daemon/config-reactions/registry.ts
+++ b/packages/myco/src/daemon/config-reactions/registry.ts
@@ -11,6 +11,9 @@
  */
 
 import type { Logger } from '../logger.js';
+import type { MycoConfig } from '../../config/schema.js';
+
+export type ConfigReaction = (ctx: MycoConfig) => void | Promise<void>;
 
 export interface ConfigReactionRegistry {
   /**
@@ -21,20 +24,24 @@ export interface ConfigReactionRegistry {
    * A prefix `p` matches a touched path `t` when `t === p` or
    * `t.startsWith(p + '.')`. So `'capture'` matches `'capture.plan_dirs'`
    * but not `'captures.x'` or `'capture_mode'`.
+   *
+   * The reaction receives the post-write merged config (project + local
+   * overlay). Use this instead of reloading — the registry has already paid
+   * the YAML + schema parse cost once.
    */
-  on(paths: string[], reaction: () => void | Promise<void>): void;
+  on(paths: string[], reaction: ConfigReaction): void;
 
   /**
    * Fire every matching reaction in registration order. Awaits each in turn.
    * If a reaction throws, the error is logged and subsequent reactions still
    * run — the scoped write itself has already succeeded by this point.
    */
-  fire(touchedPaths: string[]): Promise<void>;
+  fire(touchedPaths: string[], ctx: MycoConfig): Promise<void>;
 }
 
 interface Entry {
   paths: string[];
-  fn: () => void | Promise<void>;
+  fn: ConfigReaction;
 }
 
 export function createConfigReactionRegistry(logger: Logger): ConfigReactionRegistry {
@@ -44,11 +51,11 @@ export function createConfigReactionRegistry(logger: Logger): ConfigReactionRegi
     on(paths, fn) {
       entries.push({ paths, fn });
     },
-    async fire(touchedPaths) {
+    async fire(touchedPaths, ctx) {
       for (const entry of entries) {
         if (!shouldFire(entry.paths, touchedPaths)) continue;
         try {
-          await entry.fn();
+          await entry.fn(ctx);
         } catch (err) {
           logger.error('config-reactions', 'reaction threw', { error: String(err) });
         }

--- a/packages/myco/src/daemon/config-reactions/registry.ts
+++ b/packages/myco/src/daemon/config-reactions/registry.ts
@@ -10,9 +10,7 @@
  * - A reaction MUST NOT issue a scoped-config write itself (would recurse).
  */
 
-export interface ReactionLogger {
-  error(kind: string, message: string, data?: Record<string, unknown>): void;
-}
+import type { Logger } from '../logger.js';
 
 export interface ConfigReactionRegistry {
   /**
@@ -39,7 +37,7 @@ interface Entry {
   fn: () => void | Promise<void>;
 }
 
-export function createConfigReactionRegistry(logger: ReactionLogger): ConfigReactionRegistry {
+export function createConfigReactionRegistry(logger: Logger): ConfigReactionRegistry {
   const entries: Entry[] = [];
 
   return {

--- a/packages/myco/src/daemon/config-reactions/registry.ts
+++ b/packages/myco/src/daemon/config-reactions/registry.ts
@@ -1,0 +1,70 @@
+/**
+ * In-process registry for "things that should happen after any successful
+ * scoped-config write." Reactions register once at daemon startup with a
+ * list of path prefixes; `fire(touchedPaths)` runs every reaction whose
+ * registered prefixes match.
+ *
+ * Contract (documented, not enforced):
+ * - A reaction MUST be idempotent: firing twice with the same touched paths
+ *   produces the same observable state.
+ * - A reaction MUST NOT issue a scoped-config write itself (would recurse).
+ */
+
+export interface ReactionLogger {
+  error(kind: string, message: string, data?: Record<string, unknown>): void;
+}
+
+export interface ConfigReactionRegistry {
+  /**
+   * Register a reaction. `paths` is a list of dot-path prefixes. The reaction
+   * fires when any touched path matches any listed prefix. Pass `[]` to fire
+   * on every write.
+   *
+   * A prefix `p` matches a touched path `t` when `t === p` or
+   * `t.startsWith(p + '.')`. So `'capture'` matches `'capture.plan_dirs'`
+   * but not `'captures.x'` or `'capture_mode'`.
+   */
+  on(paths: string[], reaction: () => void | Promise<void>): void;
+
+  /**
+   * Fire every matching reaction in registration order. Awaits each in turn.
+   * If a reaction throws, the error is logged and subsequent reactions still
+   * run — the scoped write itself has already succeeded by this point.
+   */
+  fire(touchedPaths: string[]): Promise<void>;
+}
+
+interface Entry {
+  paths: string[];
+  fn: () => void | Promise<void>;
+}
+
+export function createConfigReactionRegistry(logger: ReactionLogger): ConfigReactionRegistry {
+  const entries: Entry[] = [];
+
+  return {
+    on(paths, fn) {
+      entries.push({ paths, fn });
+    },
+    async fire(touchedPaths) {
+      for (const entry of entries) {
+        if (!shouldFire(entry.paths, touchedPaths)) continue;
+        try {
+          await entry.fn();
+        } catch (err) {
+          logger.error('config-reactions', 'reaction threw', { error: String(err) });
+        }
+      }
+    },
+  };
+}
+
+function shouldFire(registeredPaths: string[], touched: string[]): boolean {
+  if (registeredPaths.length === 0) return true;
+  for (const prefix of registeredPaths) {
+    for (const path of touched) {
+      if (path === prefix || path.startsWith(`${prefix}.`)) return true;
+    }
+  }
+  return false;
+}

--- a/packages/myco/src/daemon/config-reactions/touched-paths.ts
+++ b/packages/myco/src/daemon/config-reactions/touched-paths.ts
@@ -1,0 +1,28 @@
+/**
+ * Enumerate leaf paths in a plain-object patch. A "leaf" is any value that
+ * isn't a non-array plain object — primitives, arrays, and `null` all count.
+ * Used to determine which config paths a patch touches so reactions can
+ * decide whether to fire.
+ */
+export function enumerateLeafPaths(obj: unknown, prefix = ''): string[] {
+  if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
+    return prefix ? [prefix] : [];
+  }
+  const out: string[] = [];
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    const next = prefix ? `${prefix}.${key}` : key;
+    out.push(...enumerateLeafPaths(value, next));
+  }
+  return out;
+}
+
+/**
+ * Compute the union of paths touched by a patch object and a list of
+ * explicit clear-key strings, deduplicated. This is the input to
+ * `ConfigReactionRegistry.fire()`.
+ */
+export function computeTouchedPaths(patch: unknown, clear: string[] | undefined): string[] {
+  const patchLeaves = patch && typeof patch === 'object' ? enumerateLeafPaths(patch) : [];
+  const clearList = Array.isArray(clear) ? clear : [];
+  return [...new Set([...patchLeaves, ...clearList])];
+}

--- a/packages/myco/src/daemon/logger.ts
+++ b/packages/myco/src/daemon/logger.ts
@@ -67,6 +67,15 @@ export class DaemonLogger {
     this.persistFn = fn;
   }
 
+  /**
+   * Change the active log level at runtime. Subsequent writes use the new
+   * threshold immediately — no restart required. Used by the
+   * daemon.log_level config reaction.
+   */
+  setLevel(level: LogLevel): void {
+    this.level = level;
+  }
+
   debug(kind: string, message: string, data?: Record<string, unknown>): void {
     this.write('debug', kind, message, data);
   }

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -205,7 +205,7 @@ export async function main(): Promise<void> {
   const symbiontPlanDirs = manifests.flatMap((m) => m.capture?.planDirs ?? []);
   const symbiontPlanTags = [...new Set(manifests.flatMap((m) => m.capture?.planTags ?? []))];
   const projectRoot = process.cwd();
-  let planWatchConfig: PlanWatchConfig = {
+  const planWatchConfig: PlanWatchConfig = {
     watchDirs: [...new Set([...symbiontPlanDirs, ...(config.capture.plan_dirs ?? [])])],
     projectRoot,
     extensions: config.capture.artifact_extensions,
@@ -521,32 +521,25 @@ export async function main(): Promise<void> {
   // packages/myco/src/daemon/config-reactions/registry.ts for the contract.
   const reactions = createConfigReactionRegistry(logger);
 
-  // Fires on every write — keeps the live-stats configHash in sync.
+  // Refresh the live-stats configHash on every write.
   reactions.on([], () => { configHash = computeConfigHash(vaultDir); });
 
-  // Fires on every write — preserves today's symbiont reconcile behavior.
-  // TODO(follow-up): narrow to ['capture.plan_dirs', 'capture.ignore_plan_dirs_in_git']
-  // once reconcile's actual dependencies are audited.
-  reactions.on([], () => {
+  // Reinstall symbiont artefacts (agent hooks, .gitignore) when capture dirs
+  // or symbiont enablement change. The reconcile has no other config inputs.
+  reactions.on(['capture', 'symbionts'], () => {
     reconcileConfiguredSymbionts(path.dirname(vaultDir), vaultDir);
   });
 
-  // Fires when capture.* changes — updates the in-memory watch dir list.
+  // Refresh the in-memory plan-watch list on capture changes.
   reactions.on(['capture'], createPlanWatchReaction({
     vaultDir,
     symbiontPlanDirs,
     planWatchConfig,
   }));
 
-  // Fires when daemon.log_level changes — live-reconfigures the logger.
-  // Reads the MERGED config because log_level defaults to local scope in the
-  // UI; reading project-only would miss per-machine overrides.
+  // Live-reconfigure the logger on daemon.log_level change.
   reactions.on(['daemon.log_level'], () => {
-    try {
-      logger.setLevel(loadMergedConfig(vaultDir).daemon.log_level);
-    } catch {
-      // Swallow transient load failures; next reaction still runs.
-    }
+    logger.setLevel(loadMergedConfig(vaultDir).daemon.log_level);
   });
 
   server.registerRoute('PUT', '/api/config/scoped', async (req) => {

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -516,8 +516,9 @@ export async function main(): Promise<void> {
   }
 
   // --- Config-change reaction registry ---
-  // Reactions register once at daemon startup. `fire(touchedPaths)` runs every
-  // matching reaction after a successful scoped-config write. See
+  // Reactions register once at daemon startup. `fire(touchedPaths, ctx)` runs
+  // every matching reaction after a successful scoped-config write, passing
+  // the freshly merged config so reactions don't reload it themselves. See
   // packages/myco/src/daemon/config-reactions/registry.ts for the contract.
   const reactions = createConfigReactionRegistry(logger);
 
@@ -526,27 +527,26 @@ export async function main(): Promise<void> {
 
   // Reinstall symbiont artefacts (agent hooks, .gitignore) when capture dirs
   // or symbiont enablement change. The reconcile has no other config inputs.
-  reactions.on(['capture', 'symbionts'], () => {
-    reconcileConfiguredSymbionts(path.dirname(vaultDir), vaultDir);
+  reactions.on(['capture', 'symbionts'], (ctx) => {
+    reconcileConfiguredSymbionts(path.dirname(vaultDir), vaultDir, ctx);
   });
 
   // Refresh the in-memory plan-watch list on capture changes.
   reactions.on(['capture'], createPlanWatchReaction({
-    vaultDir,
     symbiontPlanDirs,
     planWatchConfig,
   }));
 
   // Live-reconfigure the logger on daemon.log_level change.
-  reactions.on(['daemon.log_level'], () => {
-    logger.setLevel(loadMergedConfig(vaultDir).daemon.log_level);
+  reactions.on(['daemon.log_level'], (ctx) => {
+    logger.setLevel(ctx.daemon.log_level);
   });
 
   server.registerRoute('PUT', '/api/config/scoped', async (req) => {
     const result = await handlePutScopedConfig(vaultDir, req.body);
     if (!result.status || result.status < 400) {
       const body = req.body as { patch?: unknown; clear?: string[] };
-      await reactions.fire(computeTouchedPaths(body.patch, body.clear));
+      await reactions.fire(computeTouchedPaths(body.patch, body.clear), loadMergedConfig(vaultDir));
     }
     return result;
   });

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -142,6 +142,8 @@ import {
 import { createReconciler } from './reconciliation.js';
 import { createStopProcessor } from './stop-processing.js';
 import { createEventDispatcher } from './event-dispatch.js';
+import { createConfigReactionRegistry, computeTouchedPaths } from './config-reactions/index.js';
+import { createPlanWatchReaction } from './plan-watch-reaction.js';
 export {
   handleUserPrompt, handleToolUse, handleStopBatches, handleToolFailure,
   handleSubagentStart, handleSubagentStop, handleStopFailure,
@@ -514,51 +516,54 @@ export async function main(): Promise<void> {
     if (dirs.length > 0) symbiontPlanDirsByAgent[m.displayName] = dirs;
   }
 
-  /** Refresh the in-memory planWatchConfig to reflect the current
-   *  `capture.plan_dirs` in myco.yaml. Called after any config write so new
-   *  directories are picked up without a daemon restart. Idempotent — if the
-   *  watchDirs set is unchanged the setter is a no-op. */
-  function reconcilePlanWatch() {
-    try {
-      const cfg = loadConfig(vaultDir);
-      const customDirs = cfg.capture.plan_dirs ?? [];
-      planWatchConfig = {
-        ...planWatchConfig,
-        watchDirs: [...new Set([...symbiontPlanDirs, ...customDirs])],
-      };
-    } catch {
-      // loadConfig can throw on malformed YAML; the scoped write already
-      // validated the result so this should not fire, but swallow to avoid
-      // taking down the route handler on a rare reconciliation failure.
-    }
-  }
+  // --- Config-change reaction registry ---
+  // Reactions register once at daemon startup. `fire(touchedPaths)` runs every
+  // matching reaction after a successful scoped-config write. See
+  // packages/myco/src/daemon/config-reactions/registry.ts for the contract.
+  const reactions = createConfigReactionRegistry(logger);
 
-  // /simplify E3: only re-read the config + reconcile plan dirs when the
-  // patch actually touches `capture` — toggling notifications shouldn't
-  // force a YAML read on every write.
-  function patchTouchesCapture(body: unknown): boolean {
-    const patch = (body as { patch?: Record<string, unknown> } | null)?.patch;
-    return patch !== undefined && patch !== null && 'capture' in patch;
-  }
-  function clearKeysTouchCapture(body: unknown): boolean {
-    const keys = (body as { keys?: string[] } | null)?.keys;
-    return Array.isArray(keys) && keys.some((k) => k === 'capture' || k.startsWith('capture.'));
-  }
+  // Fires on every write — keeps the live-stats configHash in sync.
+  reactions.on([], () => { configHash = computeConfigHash(vaultDir); });
+
+  // Fires on every write — preserves today's symbiont reconcile behavior.
+  // TODO(follow-up): narrow to ['capture.plan_dirs', 'capture.ignore_plan_dirs_in_git']
+  // once reconcile's actual dependencies are audited.
+  reactions.on([], () => {
+    reconcileConfiguredSymbionts(path.dirname(vaultDir), vaultDir);
+  });
+
+  // Fires when capture.* changes — updates the in-memory watch dir list.
+  reactions.on(['capture'], createPlanWatchReaction({
+    vaultDir,
+    symbiontPlanDirs,
+    planWatchConfig,
+  }));
+
+  // Fires when daemon.log_level changes — live-reconfigures the logger.
+  reactions.on(['daemon.log_level'], () => {
+    try {
+      logger.setLevel(loadConfig(vaultDir).daemon.log_level);
+    } catch {
+      // Swallow transient load failures; next reaction still runs.
+    }
+  });
 
   server.registerRoute('PUT', '/api/config/scoped', async (req) => {
     const result = await handlePutScopedConfig(vaultDir, req.body);
     if (!result.status || result.status < 400) {
-      reconcileConfiguredSymbionts(path.dirname(vaultDir), vaultDir);
-      if (patchTouchesCapture(req.body)) reconcilePlanWatch();
-      configHash = computeConfigHash(vaultDir);
+      const body = req.body as { patch?: unknown; clear?: string[] };
+      await reactions.fire(computeTouchedPaths(body.patch, body.clear));
     }
     return result;
   });
+  // NOTE: POST /api/config/local/clear remains with its inline hooks until the
+  // UI migrates to the unified PUT endpoint (T8), after which this route
+  // is deleted in T9.
   server.registerRoute('POST', '/api/config/local/clear', async (req) => {
     const result = await handleClearLocalConfig(vaultDir, req.body);
     if (!result.status || result.status < 400) {
-      if (clearKeysTouchCapture(req.body)) reconcilePlanWatch();
-      configHash = computeConfigHash(vaultDir);
+      const body = req.body as { keys?: string[] };
+      await reactions.fire(computeTouchedPaths(undefined, body.keys));
     }
     return result;
   });

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -557,21 +557,9 @@ export async function main(): Promise<void> {
   });
 
   const planDirHandlers = createPlanDirHandlers({
-    vaultDir,
     symbiontPlanDirsByAgent,
-    symbiontPlanDirs,
-    planWatchConfig,
-    setPlanWatchConfig: (cfg) => { planWatchConfig = cfg; },
-    reconcileProjectFiles: () => { reconcileConfiguredSymbionts(path.dirname(vaultDir), vaultDir); },
   });
   server.registerRoute('GET', '/api/config/plan-dirs', planDirHandlers.handleGetPlanDirs);
-  server.registerRoute('POST', '/api/config/plan-dirs', async (req) => {
-    const result = await planDirHandlers.handleUpdatePlanDirs(req);
-    if (!result.status || result.status < 400) {
-      configHash = computeConfigHash(vaultDir);
-    }
-    return result;
-  });
 
   // V2 stats — vault counts, embedding coverage, agent status, digest freshness
   const configHashRef = { get: () => configHash };

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -10,7 +10,7 @@
 import { DaemonServer } from './server.js';
 import { SessionRegistry } from './lifecycle.js';
 import { DaemonLogger } from './logger.js';
-import { loadConfig, loadMergedConfig, updateConfig } from '../config/loader.js';
+import { loadConfig, updateConfig } from '../config/loader.js';
 import { resolvePort } from './port.js';
 import { TranscriptMiner } from '../capture/transcript-miner.js';
 import { createPerProjectAdapter } from '../symbionts/adapter.js';
@@ -130,6 +130,7 @@ import {
   epochSeconds,
 } from '../constants.js';
 import { RESTART_REASON_FILENAME } from '../constants/update.js';
+import { buildScopedConfigSaveNotification } from '../config/focus.js';
 import { notify } from '../notifications/notify.js';
 import { PowerManager } from './power.js';
 import { registerPowerJobs } from './power-jobs.js';
@@ -141,7 +142,7 @@ import {
 import { createReconciler } from './reconciliation.js';
 import { createStopProcessor } from './stop-processing.js';
 import { createEventDispatcher } from './event-dispatch.js';
-import { createConfigReactionRegistry, computeTouchedPaths } from './config-reactions/index.js';
+import { createConfigReactionRegistry, computeTouchedPaths, loadReactionContext } from './config-reactions/index.js';
 import { createPlanWatchReaction } from './plan-watch-reaction.js';
 export {
   handleUserPrompt, handleToolUse, handleStopBatches, handleToolFailure,
@@ -540,13 +541,33 @@ export async function main(): Promise<void> {
   // Live-reconfigure the logger on daemon.log_level change.
   reactions.on(['daemon.log_level'], (ctx) => {
     logger.setLevel(ctx.daemon.log_level);
+    if (ctx.daemon.log_level === 'debug') {
+      process.env.MYCO_AGENT_DEBUG = '1';
+    } else {
+      delete process.env.MYCO_AGENT_DEBUG;
+    }
   });
 
   server.registerRoute('PUT', '/api/config/scoped', async (req) => {
     const result = await handlePutScopedConfig(vaultDir, req.body);
     if (!result.status || result.status < 400) {
-      const body = req.body as { patch?: unknown; clear?: string[] };
-      await reactions.fire(computeTouchedPaths(body.patch, body.clear), loadMergedConfig(vaultDir));
+      const body = req.body as { scope: 'project' | 'local'; patch?: unknown; clear?: string[] };
+      const touchedPaths = computeTouchedPaths(body.patch, body.clear);
+      const reactionContext = loadReactionContext(vaultDir, logger);
+      if (reactionContext) {
+        await reactions.fire(touchedPaths, reactionContext);
+        const summary = buildScopedConfigSaveNotification(body.scope, touchedPaths);
+        notify(vaultDir, {
+          domain: 'settings',
+          type: 'settings.saved',
+          title: summary.title,
+          message: summary.message,
+          link: summary.link ?? undefined,
+          metadata: summary.metadata,
+        }, reactionContext);
+      } else {
+        configHash = computeConfigHash(vaultDir);
+      }
     }
     return result;
   });

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -24,7 +24,6 @@ import {
   handleGetMergedConfig,
   handleGetLocalConfig,
   handlePutScopedConfig,
-  handleClearLocalConfig,
   createPlanDirHandlers,
 } from './api/config.js';
 import { handleLogSearch, handleLogStream, handleLogDetail, createLogIngestionHandler } from './api/log-explorer.js';
@@ -553,17 +552,6 @@ export async function main(): Promise<void> {
     if (!result.status || result.status < 400) {
       const body = req.body as { patch?: unknown; clear?: string[] };
       await reactions.fire(computeTouchedPaths(body.patch, body.clear));
-    }
-    return result;
-  });
-  // NOTE: POST /api/config/local/clear remains with its inline hooks until the
-  // UI migrates to the unified PUT endpoint (T8), after which this route
-  // is deleted in T9.
-  server.registerRoute('POST', '/api/config/local/clear', async (req) => {
-    const result = await handleClearLocalConfig(vaultDir, req.body);
-    if (!result.status || result.status < 400) {
-      const body = req.body as { keys?: string[] };
-      await reactions.fire(computeTouchedPaths(undefined, body.keys));
     }
     return result;
   });

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -10,7 +10,7 @@
 import { DaemonServer } from './server.js';
 import { SessionRegistry } from './lifecycle.js';
 import { DaemonLogger } from './logger.js';
-import { loadConfig, updateConfig } from '../config/loader.js';
+import { loadConfig, loadMergedConfig, updateConfig } from '../config/loader.js';
 import { resolvePort } from './port.js';
 import { TranscriptMiner } from '../capture/transcript-miner.js';
 import { createPerProjectAdapter } from '../symbionts/adapter.js';
@@ -539,9 +539,11 @@ export async function main(): Promise<void> {
   }));
 
   // Fires when daemon.log_level changes — live-reconfigures the logger.
+  // Reads the MERGED config because log_level defaults to local scope in the
+  // UI; reading project-only would miss per-machine overrides.
   reactions.on(['daemon.log_level'], () => {
     try {
-      logger.setLevel(loadConfig(vaultDir).daemon.log_level);
+      logger.setLevel(loadMergedConfig(vaultDir).daemon.log_level);
     } catch {
       // Swallow transient load failures; next reaction still runs.
     }

--- a/packages/myco/src/daemon/plan-watch-reaction.ts
+++ b/packages/myco/src/daemon/plan-watch-reaction.ts
@@ -14,26 +14,19 @@ export interface PlanWatchReactionDeps {
 
 /**
  * Returns a reaction that refreshes `planWatchConfig.watchDirs` from the
- * current `capture.plan_dirs` (project + local overlay). Mutates the
- * config object in place so consumers that closed over the reference see
- * the update.
+ * merged (project + local) `capture.plan_dirs`. Mutates the config object
+ * in place so consumers that closed over the reference see the update.
  *
- * Reads the MERGED config (project + local) because `capture.plan_dirs`
- * can be overridden at local scope — reading project-only would miss
- * per-machine additions.
+ * Reads the merged config so a local-scope override is honored — reading
+ * project-only would miss per-machine additions made via the UI.
  *
- * Swallows loadConfig errors (malformed YAML) so a transient write failure
- * doesn't propagate through fire() to other reactions.
+ * Errors propagate to the reaction registry, which logs and continues so
+ * other reactions still run.
  */
 export function createPlanWatchReaction(deps: PlanWatchReactionDeps): () => void {
   return () => {
-    try {
-      const cfg = loadMergedConfig(deps.vaultDir);
-      const customDirs = cfg.capture.plan_dirs ?? [];
-      deps.planWatchConfig.watchDirs = [...new Set([...deps.symbiontPlanDirs, ...customDirs])];
-    } catch {
-      // loadMergedConfig throws on malformed YAML; the write just succeeded so
-      // this should not happen, but swallowing keeps other reactions running.
-    }
+    const cfg = loadMergedConfig(deps.vaultDir);
+    const customDirs = cfg.capture.plan_dirs ?? [];
+    deps.planWatchConfig.watchDirs = [...new Set([...deps.symbiontPlanDirs, ...customDirs])];
   };
 }

--- a/packages/myco/src/daemon/plan-watch-reaction.ts
+++ b/packages/myco/src/daemon/plan-watch-reaction.ts
@@ -1,8 +1,7 @@
-import { loadMergedConfig } from '../config/loader.js';
+import type { ConfigReaction } from './config-reactions/registry.js';
 import type { PlanWatchConfig } from './plan-capture.js';
 
 export interface PlanWatchReactionDeps {
-  vaultDir: string;
   symbiontPlanDirs: string[];
   /**
    * The live PlanWatchConfig object. This factory mutates `.watchDirs` in
@@ -14,19 +13,13 @@ export interface PlanWatchReactionDeps {
 
 /**
  * Returns a reaction that refreshes `planWatchConfig.watchDirs` from the
- * merged (project + local) `capture.plan_dirs`. Mutates the config object
- * in place so consumers that closed over the reference see the update.
- *
- * Reads the merged config so a local-scope override is honored — reading
- * project-only would miss per-machine additions made via the UI.
- *
- * Errors propagate to the reaction registry, which logs and continues so
- * other reactions still run.
+ * merged `capture.plan_dirs` passed through by the registry. Mutates the
+ * config object in place so consumers that closed over the reference see
+ * the update.
  */
-export function createPlanWatchReaction(deps: PlanWatchReactionDeps): () => void {
-  return () => {
-    const cfg = loadMergedConfig(deps.vaultDir);
-    const customDirs = cfg.capture.plan_dirs ?? [];
+export function createPlanWatchReaction(deps: PlanWatchReactionDeps): ConfigReaction {
+  return (ctx) => {
+    const customDirs = ctx.capture.plan_dirs ?? [];
     deps.planWatchConfig.watchDirs = [...new Set([...deps.symbiontPlanDirs, ...customDirs])];
   };
 }

--- a/packages/myco/src/daemon/plan-watch-reaction.ts
+++ b/packages/myco/src/daemon/plan-watch-reaction.ts
@@ -1,0 +1,37 @@
+import { loadConfig } from '../config/loader.js';
+import type { PlanWatchConfig } from './plan-capture.js';
+
+export interface PlanWatchReactionDeps {
+  vaultDir: string;
+  symbiontPlanDirs: string[];
+  /**
+   * The live PlanWatchConfig object. This factory mutates `.watchDirs` in
+   * place — do NOT pass a fresh copy. Downstream consumers (event dispatcher)
+   * close over this same object reference for hot-reload to work.
+   */
+  planWatchConfig: PlanWatchConfig;
+}
+
+/**
+ * Returns a reaction that refreshes `planWatchConfig.watchDirs` from the
+ * current `capture.plan_dirs` in myco.yaml. Mutates the config object in
+ * place so consumers that closed over the reference see the update.
+ *
+ * Idempotent: if the new watchDirs equals the old set, the assignment is
+ * still made but observable behavior is unchanged.
+ *
+ * Swallows loadConfig errors (malformed YAML) so a transient write failure
+ * doesn't propagate through fire() to other reactions.
+ */
+export function createPlanWatchReaction(deps: PlanWatchReactionDeps): () => void {
+  return () => {
+    try {
+      const cfg = loadConfig(deps.vaultDir);
+      const customDirs = cfg.capture.plan_dirs ?? [];
+      deps.planWatchConfig.watchDirs = [...new Set([...deps.symbiontPlanDirs, ...customDirs])];
+    } catch {
+      // loadConfig throws on malformed YAML; the write just succeeded so this
+      // should not happen, but swallowing keeps other reactions running.
+    }
+  };
+}

--- a/packages/myco/src/daemon/plan-watch-reaction.ts
+++ b/packages/myco/src/daemon/plan-watch-reaction.ts
@@ -21,5 +21,6 @@ export function createPlanWatchReaction(deps: PlanWatchReactionDeps): ConfigReac
   return (ctx) => {
     const customDirs = ctx.capture.plan_dirs ?? [];
     deps.planWatchConfig.watchDirs = [...new Set([...deps.symbiontPlanDirs, ...customDirs])];
+    deps.planWatchConfig.extensions = ctx.capture.artifact_extensions;
   };
 }

--- a/packages/myco/src/daemon/plan-watch-reaction.ts
+++ b/packages/myco/src/daemon/plan-watch-reaction.ts
@@ -1,4 +1,4 @@
-import { loadConfig } from '../config/loader.js';
+import { loadMergedConfig } from '../config/loader.js';
 import type { PlanWatchConfig } from './plan-capture.js';
 
 export interface PlanWatchReactionDeps {
@@ -14,11 +14,13 @@ export interface PlanWatchReactionDeps {
 
 /**
  * Returns a reaction that refreshes `planWatchConfig.watchDirs` from the
- * current `capture.plan_dirs` in myco.yaml. Mutates the config object in
- * place so consumers that closed over the reference see the update.
+ * current `capture.plan_dirs` (project + local overlay). Mutates the
+ * config object in place so consumers that closed over the reference see
+ * the update.
  *
- * Idempotent: if the new watchDirs equals the old set, the assignment is
- * still made but observable behavior is unchanged.
+ * Reads the MERGED config (project + local) because `capture.plan_dirs`
+ * can be overridden at local scope — reading project-only would miss
+ * per-machine additions.
  *
  * Swallows loadConfig errors (malformed YAML) so a transient write failure
  * doesn't propagate through fire() to other reactions.
@@ -26,12 +28,12 @@ export interface PlanWatchReactionDeps {
 export function createPlanWatchReaction(deps: PlanWatchReactionDeps): () => void {
   return () => {
     try {
-      const cfg = loadConfig(deps.vaultDir);
+      const cfg = loadMergedConfig(deps.vaultDir);
       const customDirs = cfg.capture.plan_dirs ?? [];
       deps.planWatchConfig.watchDirs = [...new Set([...deps.symbiontPlanDirs, ...customDirs])];
     } catch {
-      // loadConfig throws on malformed YAML; the write just succeeded so this
-      // should not happen, but swallowing keeps other reactions running.
+      // loadMergedConfig throws on malformed YAML; the write just succeeded so
+      // this should not happen, but swallowing keeps other reactions running.
     }
   };
 }

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -16,6 +16,7 @@ import type { DatabaseMaintenanceManager } from './database/manager.js';
 import { runSessionMaintenance } from './jobs/session-maintenance.js';
 import { createBackup } from './backup.js';
 import { deleteOldLogs } from '@myco/db/queries/logs.js';
+import { loadConfig } from '../config/loader.js';
 import {
   listStaleStagingDirs,
   cleanupStagedSkill,
@@ -84,7 +85,7 @@ export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps
     name: 'log-retention',
     runIn: ['idle', 'sleep'],
     fn: async () => {
-      const retentionDays = config.daemon.log_retention_days;
+      const retentionDays = loadConfig(vaultDir).daemon.log_retention_days;
       const cutoff = new Date(Date.now() - retentionDays * MS_PER_DAY).toISOString();
       const deleted = deleteOldLogs(cutoff);
       if (deleted > 0) {

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -16,7 +16,7 @@ import type { DatabaseMaintenanceManager } from './database/manager.js';
 import { runSessionMaintenance } from './jobs/session-maintenance.js';
 import { createBackup } from './backup.js';
 import { deleteOldLogs } from '@myco/db/queries/logs.js';
-import { loadConfig } from '../config/loader.js';
+import { loadMergedConfig } from '../config/loader.js';
 import {
   listStaleStagingDirs,
   cleanupStagedSkill,
@@ -85,7 +85,7 @@ export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps
     name: 'log-retention',
     runIn: ['idle', 'sleep'],
     fn: async () => {
-      const retentionDays = loadConfig(vaultDir).daemon.log_retention_days;
+      const retentionDays = loadMergedConfig(vaultDir).daemon.log_retention_days;
       const cutoff = new Date(Date.now() - retentionDays * MS_PER_DAY).toISOString();
       const deleted = deleteOldLogs(cutoff);
       if (deleted > 0) {

--- a/packages/myco/src/notifications/domains.ts
+++ b/packages/myco/src/notifications/domains.ts
@@ -53,4 +53,12 @@ export function registerBuiltinDomains(): void {
       { id: 'daemon.version_sync', label: 'Version sync restart', defaultMode: 'summary', defaultLevel: 'info' },
     ],
   });
+
+  register({
+    domain: 'settings',
+    label: 'Settings',
+    types: [
+      { id: 'settings.saved', label: 'Settings saved', defaultMode: 'banner', defaultLevel: 'success' },
+    ],
+  });
 }

--- a/packages/myco/src/symbionts/reconcile.ts
+++ b/packages/myco/src/symbionts/reconcile.ts
@@ -15,8 +15,12 @@ export function getConfiguredManifests(projectRoot: string, config: MycoConfig) 
   return allManifests.filter((manifest) => fs.existsSync(path.join(projectRoot, manifest.configDir)));
 }
 
-export function reconcileConfiguredSymbionts(projectRoot: string, vaultDir = path.join(projectRoot, '.myco')): number {
-  const config = loadConfig(vaultDir);
+export function reconcileConfiguredSymbionts(
+  projectRoot: string,
+  vaultDir = path.join(projectRoot, '.myco'),
+  preloadedConfig?: MycoConfig,
+): number {
+  const config = preloadedConfig ?? loadConfig(vaultDir);
   const manifests = getConfiguredManifests(projectRoot, config);
   const packageRoot = resolvePackageRoot();
   let updatedCount = 0;

--- a/packages/myco/ui/src/components/agent/AgentConfig.tsx
+++ b/packages/myco/ui/src/components/agent/AgentConfig.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { CONFIG_SECTION_IDS } from '@myco/config/focus';
 import {
   Settings2,
   Activity,
@@ -170,7 +171,11 @@ export function AgentConfig() {
   return (
     <div className="space-y-6">
       {/* ---------- Agent Operations (editable) ---------- */}
-      <Surface level="low" className="p-6 space-y-5 border-t-2 border-t-sage">
+      <Surface
+        id={CONFIG_SECTION_IDS.agentOperations}
+        level="low"
+        className="rounded-lg p-6 space-y-5 border-t-2 border-t-sage transition-all duration-300"
+      >
         <SectionHeader>
           <span className="flex items-center gap-2">
             <Settings2 className="h-4 w-4 text-primary" />

--- a/packages/myco/ui/src/components/config/PlanCaptureCard.tsx
+++ b/packages/myco/ui/src/components/config/PlanCaptureCard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { CONFIG_SECTION_IDS } from '@myco/config/focus';
 import { fetchJson } from '../../lib/api';
 import { Surface } from '../ui/surface';
 import { SectionHeader } from '../ui/section-header';
@@ -37,7 +38,11 @@ export function PlanCaptureCard() {
   const symbiontEntries = Object.entries(symbiont);
 
   return (
-    <Surface level="low" className="p-6 space-y-5 border-t-2 border-t-amber-500">
+    <Surface
+      id={CONFIG_SECTION_IDS.settingsPlanCapture}
+      level="low"
+      className="rounded-lg p-6 space-y-5 border-t-2 border-t-amber-500 transition-all duration-300"
+    >
       <SectionHeader>Plan Capture</SectionHeader>
 
       {isLoading ? (

--- a/packages/myco/ui/src/components/config/ScopePill.tsx
+++ b/packages/myco/ui/src/components/config/ScopePill.tsx
@@ -1,10 +1,48 @@
 import { useState } from 'react';
 
+type ScopeLabel = 'Personal' | 'Project';
+
 interface ScopePillProps {
   /** Promote local override to project scope. */
   onPromote: () => void | Promise<void>;
   /** Clear the local override so the project value shines through. */
   onReset: () => void | Promise<void>;
+}
+
+interface ScopeBadgeProps {
+  scope: 'personal' | 'project';
+}
+
+const SCOPE_BADGE_LABELS: Record<ScopeBadgeProps['scope'], ScopeLabel> = {
+  personal: 'Personal',
+  project: 'Project',
+};
+
+const SCOPE_BADGE_TITLES: Record<ScopeBadgeProps['scope'], string> = {
+  personal: 'This setting is overridden on this machine',
+  project: 'This setting is using the shared project value',
+};
+
+const SCOPE_BADGE_CLASSES: Record<ScopeBadgeProps['scope'], string> = {
+  personal: 'border-primary/40 bg-primary/5 text-primary',
+  project: 'border-outline-variant/30 bg-surface-container-high/40 text-on-surface-variant',
+};
+
+export function ScopeBadge({ scope }: ScopeBadgeProps) {
+  const label = SCOPE_BADGE_LABELS[scope];
+
+  return (
+    <span
+      title={SCOPE_BADGE_TITLES[scope]}
+      className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] uppercase tracking-wider ${SCOPE_BADGE_CLASSES[scope]}`}
+    >
+      <span
+        className={`inline-block h-1.5 w-1.5 rounded-full ${scope === 'personal' ? 'bg-primary' : 'bg-outline-variant/80'}`}
+        aria-hidden
+      />
+      {label}
+    </span>
+  );
 }
 
 /**
@@ -26,10 +64,9 @@ export function ScopePill({ onPromote, onReset }: ScopePillProps) {
         type="button"
         onClick={() => setOpen((o) => !o)}
         title="This setting is overridden on this machine"
-        className="inline-flex items-center gap-1 rounded border border-primary/40 bg-primary/5 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-primary hover:bg-primary/10 transition-colors cursor-pointer"
+        className="cursor-pointer transition-colors hover:bg-primary/10"
       >
-        <span className="inline-block h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
-        Personal
+        <ScopeBadge scope="personal" />
       </button>
       {open && (
         <div className="absolute left-0 top-full z-10 mt-1 w-44 rounded-md border border-outline-variant/20 bg-surface-container-high p-1 text-xs shadow-lg">

--- a/packages/myco/ui/src/components/config/ScopedField.tsx
+++ b/packages/myco/ui/src/components/config/ScopedField.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useCallback, useRef, type ReactNode } from 'react';
 import { AlertCircle } from 'lucide-react';
 import { getAtPath } from '@myco/utils/dot-path';
+import { configFieldId } from '@myco/config/focus';
 import { useScopedConfig, type Scope } from '../../hooks/use-scoped-config';
 import { useMarkRestartDirty } from './restart-gate';
-import { ScopePill } from './ScopePill';
+import { ScopeBadge, ScopePill } from './ScopePill';
 import type { ConfigPath, ConfigValueAt } from '../../lib/config-paths';
 
 interface ScopedFieldRenderArgs<T> {
@@ -52,7 +53,7 @@ export function ScopedField<P extends ConfigPath, T = ConfigValueAt<P>>({
   // callback identity doesn't churn on every refetch (React Query returns a
   // new object reference even when data is unchanged).
   const effective = getAtPath((effectiveConfig ?? {}) as Record<string, unknown>, path) as T | undefined;
-  const isPersonal = !lockScope && getAtPath((local ?? {}) as Record<string, unknown>, path) !== undefined;
+  const hasLocalOverride = !lockScope && getAtPath((local ?? {}) as Record<string, unknown>, path) !== undefined;
   const writeScope: Scope = lockScope ?? defaultScope;
 
   const effectiveRef = useRef(effective);
@@ -106,17 +107,19 @@ export function ScopedField<P extends ConfigPath, T = ConfigValueAt<P>>({
   }, [commit, commitOn, draft]);
 
   return (
-    <div className="space-y-1.5">
+    <div id={configFieldId(path)} data-config-field={path} className="space-y-1.5 rounded-md transition-all duration-300">
       <div className="flex items-center gap-2">
         <label className="font-sans text-sm font-medium text-on-surface">{label}</label>
         {hint && (
           <span className="font-sans text-xs text-on-surface-variant font-normal">({hint})</span>
         )}
-        {isPersonal && (
+        {hasLocalOverride ? (
           <ScopePill
             onPromote={() => promoteField(path).catch((err) => console.error('[scoped-field] promote failed', err))}
             onReset={() => resetField(path).catch((err) => console.error('[scoped-field] reset failed', err))}
           />
+        ) : (
+          <ScopeBadge scope={lockScope === 'local' ? 'personal' : 'project'} />
         )}
       </div>
       {children({ value: draft, onChange: handleChange, onBlur: handleBlur })}
@@ -129,4 +132,3 @@ export function ScopedField<P extends ConfigPath, T = ConfigValueAt<P>>({
     </div>
   );
 }
-

--- a/packages/myco/ui/src/components/notifications/NotificationBanner.tsx
+++ b/packages/myco/ui/src/components/notifications/NotificationBanner.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { X, CheckCircle2, AlertTriangle, AlertCircle, Info } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { POLL_INTERVALS } from '../../lib/constants';
-import { useLiveNotifications, useUpdateNotification, type Notification, type NotificationLevel } from '../../hooks/use-notifications';
+import { useNotifications, useUpdateNotification, type Notification, type NotificationLevel } from '../../hooks/use-notifications';
 
 const BANNER_MAX_VISIBLE = 3;
 const BANNER_AUTO_DISMISS_MS = 5_000;
@@ -26,7 +26,7 @@ const LEVEL_ICONS: Record<NotificationLevel, typeof Info> = {
 };
 
 export function NotificationBanner({ panelOpen = false }: { panelOpen?: boolean }) {
-  const { data } = useLiveNotifications({
+  const { data } = useNotifications({
     status: 'unread',
     mode: 'banner',
     limit: BANNER_MAX_VISIBLE,

--- a/packages/myco/ui/src/components/notifications/NotificationBanner.tsx
+++ b/packages/myco/ui/src/components/notifications/NotificationBanner.tsx
@@ -2,10 +2,14 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { X, CheckCircle2, AlertTriangle, AlertCircle, Info } from 'lucide-react';
 import { cn } from '../../lib/cn';
-import { useNotifications, useUpdateNotification, type Notification, type NotificationLevel } from '../../hooks/use-notifications';
+import { POLL_INTERVALS } from '../../lib/constants';
+import { useLiveNotifications, useUpdateNotification, type Notification, type NotificationLevel } from '../../hooks/use-notifications';
 
 const BANNER_MAX_VISIBLE = 3;
 const BANNER_AUTO_DISMISS_MS = 5_000;
+const BANNER_EDGE_OFFSET_PX = 12;
+const BANNER_PANEL_OFFSET_PX = 400;
+const NOTIFICATION_NAVIGATION_SOURCE = 'notification-banner';
 
 const LEVEL_STYLES: Record<NotificationLevel, string> = {
   info: 'bg-primary/10 border-primary/20 text-primary',
@@ -21,8 +25,14 @@ const LEVEL_ICONS: Record<NotificationLevel, typeof Info> = {
   error: AlertCircle,
 };
 
-export function NotificationBanner() {
-  const { data } = useNotifications({ status: 'unread', mode: 'banner', limit: BANNER_MAX_VISIBLE });
+export function NotificationBanner({ panelOpen = false }: { panelOpen?: boolean }) {
+  const { data } = useLiveNotifications({
+    status: 'unread',
+    mode: 'banner',
+    limit: BANNER_MAX_VISIBLE,
+    pollCategory: 'realtime',
+    refetchInterval: POLL_INTERVALS.LOGS,
+  });
   const updateNotification = useUpdateNotification();
   const navigate = useNavigate();
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
@@ -49,7 +59,14 @@ export function NotificationBanner() {
   const handleClick = (n: Notification) => {
     updateNotification.mutate({ id: n.id, status: 'read' });
     setDismissed((prev) => new Set(prev).add(n.id));
-    if (n.link) navigate(n.link);
+    if (n.link) {
+      navigate(n.link, {
+        state: {
+          source: NOTIFICATION_NAVIGATION_SOURCE,
+          triggeredAt: Date.now(),
+        },
+      });
+    }
   };
 
   const handleDismiss = (e: React.MouseEvent, n: Notification) => {
@@ -59,7 +76,10 @@ export function NotificationBanner() {
   };
 
   return (
-    <div className="fixed top-3 right-3 z-50 flex flex-col gap-2 w-80">
+    <div
+      className="fixed top-3 z-[60] flex w-80 flex-col gap-2"
+      style={{ right: panelOpen ? BANNER_PANEL_OFFSET_PX : BANNER_EDGE_OFFSET_PX }}
+    >
       {banners.map((n) => {
         const Icon = LEVEL_ICONS[n.level];
         return (

--- a/packages/myco/ui/src/components/notifications/NotificationPanel.tsx
+++ b/packages/myco/ui/src/components/notifications/NotificationPanel.tsx
@@ -14,7 +14,7 @@ import { cn } from '../../lib/cn';
 import { Button } from '../ui/button';
 import { MarkdownContent } from '../ui/markdown-content';
 import {
-  useLiveNotifications,
+  useNotifications,
   useUpdateNotification,
   useMarkAllRead,
   useDismissAll,
@@ -146,7 +146,7 @@ function NotificationRow({
 }
 
 export function NotificationPanel({ open, onClose }: NotificationPanelProps) {
-  const { data, refetch } = useLiveNotifications({
+  const { data, refetch } = useNotifications({
     limit: 50,
     enabled: open,
     pollCategory: 'realtime',

--- a/packages/myco/ui/src/components/notifications/NotificationPanel.tsx
+++ b/packages/myco/ui/src/components/notifications/NotificationPanel.tsx
@@ -14,13 +14,14 @@ import { cn } from '../../lib/cn';
 import { Button } from '../ui/button';
 import { MarkdownContent } from '../ui/markdown-content';
 import {
-  useNotifications,
+  useLiveNotifications,
   useUpdateNotification,
   useMarkAllRead,
   useDismissAll,
   type Notification,
   type NotificationLevel,
 } from '../../hooks/use-notifications';
+import { POLL_INTERVALS } from '../../lib/constants';
 
 const LEVEL_DOT: Record<NotificationLevel, string> = {
   info: 'bg-primary',
@@ -145,7 +146,12 @@ function NotificationRow({
 }
 
 export function NotificationPanel({ open, onClose }: NotificationPanelProps) {
-  const { data, refetch } = useNotifications({ limit: 50 });
+  const { data, refetch } = useLiveNotifications({
+    limit: 50,
+    enabled: open,
+    pollCategory: 'realtime',
+    refetchInterval: POLL_INTERVALS.LOGS,
+  });
   const updateNotification = useUpdateNotification();
   const markAllRead = useMarkAllRead();
   const dismissAll = useDismissAll();

--- a/packages/myco/ui/src/components/notifications/NotificationSettings.tsx
+++ b/packages/myco/ui/src/components/notifications/NotificationSettings.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { CONFIG_SECTION_IDS } from '@myco/config/focus';
 import { useScopedConfig } from '../../hooks/use-scoped-config';
 import { useNotificationRegistry } from '../../hooks/use-notifications';
 import { Surface } from '../ui/surface';
@@ -12,7 +13,7 @@ import {
   SelectValue,
 } from '../ui/select';
 import { ScopedField } from '../config/ScopedField';
-import { ScopePill } from '../config/ScopePill';
+import { ScopeBadge, ScopePill } from '../config/ScopePill';
 
 const MODE_LABELS = {
   banner: 'Banner',
@@ -61,7 +62,11 @@ export function NotificationSettings() {
   if (!effective) return null;
 
   return (
-    <Surface level="low" className="p-6 space-y-5 border-t-2 border-t-sage">
+    <Surface
+      id={CONFIG_SECTION_IDS.settingsNotifications}
+      level="low"
+      className="rounded-lg p-6 space-y-5 border-t-2 border-t-sage transition-all duration-300"
+    >
       <SectionHeader>Notifications</SectionHeader>
 
       <div className="space-y-4">
@@ -148,11 +153,13 @@ export function NotificationSettings() {
                               <span className="rounded-full bg-surface-container-high px-2 py-0.5 text-[11px] text-on-surface-variant">
                                 {domainEnabled ? MODE_LABELS[effectiveMode] : 'Off'}
                               </span>
-                              {personal && (
+                              {personal ? (
                                 <ScopePill
                                   onPromote={() => promoteField(domainPath)}
                                   onReset={() => resetField(domainPath)}
                                 />
+                              ) : (
+                                <ScopeBadge scope="project" />
                               )}
                             </div>
                             <p className="text-[11px] text-on-surface-variant">
@@ -198,4 +205,3 @@ export function NotificationSettings() {
     </Surface>
   );
 }
-

--- a/packages/myco/ui/src/components/notifications/SystemNotifications.tsx
+++ b/packages/myco/ui/src/components/notifications/SystemNotifications.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useLiveNotifications, type Notification } from '../../hooks/use-notifications';
+import { useNotifications, type Notification } from '../../hooks/use-notifications';
 import { useScopedConfig } from '../../hooks/use-scoped-config';
 import { POLL_INTERVALS } from '../../lib/constants';
 
@@ -12,7 +12,7 @@ import { POLL_INTERVALS } from '../../lib/constants';
 export function SystemNotifications() {
   const { effective } = useScopedConfig();
   const enabled = effective?.notifications?.system_notifications ?? false;
-  const { data, refetch } = useLiveNotifications({
+  const { data, refetch } = useNotifications({
     status: 'unread',
     mode: 'banner',
     limit: 5,

--- a/packages/myco/ui/src/components/notifications/SystemNotifications.tsx
+++ b/packages/myco/ui/src/components/notifications/SystemNotifications.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
-import { useNotifications, type Notification } from '../../hooks/use-notifications';
+import { useLiveNotifications, type Notification } from '../../hooks/use-notifications';
 import { useScopedConfig } from '../../hooks/use-scoped-config';
+import { POLL_INTERVALS } from '../../lib/constants';
 
 /**
  * Invisible component that fires browser Notification API alerts
@@ -11,7 +12,14 @@ import { useScopedConfig } from '../../hooks/use-scoped-config';
 export function SystemNotifications() {
   const { effective } = useScopedConfig();
   const enabled = effective?.notifications?.system_notifications ?? false;
-  const { data } = useNotifications({ status: 'unread', mode: 'banner', limit: 5 });
+  const { data, refetch } = useLiveNotifications({
+    status: 'unread',
+    mode: 'banner',
+    limit: 5,
+    enabled,
+    pollCategory: 'heartbeat',
+    refetchInterval: POLL_INTERVALS.PROGRESS,
+  });
   const seenRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
@@ -34,6 +42,24 @@ export function SystemNotifications() {
       showSystemNotification(n);
     }
   }, [enabled, data]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const refetchWhenHidden = () => {
+      if (document.hidden || !document.hasFocus()) {
+        void refetch();
+      }
+    };
+
+    document.addEventListener('visibilitychange', refetchWhenHidden);
+    window.addEventListener('blur', refetchWhenHidden);
+
+    return () => {
+      document.removeEventListener('visibilitychange', refetchWhenHidden);
+      window.removeEventListener('blur', refetchWhenHidden);
+    };
+  }, [enabled, refetch]);
 
   return null;
 }

--- a/packages/myco/ui/src/components/operations/BackupCard.tsx
+++ b/packages/myco/ui/src/components/operations/BackupCard.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { CONFIG_SECTION_IDS } from '@myco/config/focus';
 import { HardDrive, Download, Upload, RefreshCw, FolderOpen } from 'lucide-react';
 import { postJson, fetchJson } from '../../lib/api';
 import { formatBytes } from '../../lib/format';
@@ -126,7 +127,11 @@ export function BackupCard() {
   }
 
   return (
-    <Surface level="low" className="p-6 space-y-4">
+    <Surface
+      id={CONFIG_SECTION_IDS.operationsBackup}
+      level="low"
+      className="rounded-lg p-6 space-y-4 transition-all duration-300"
+    >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <HardDrive className="h-4 w-4 text-primary" />

--- a/packages/myco/ui/src/hooks/use-notifications.ts
+++ b/packages/myco/ui/src/hooks/use-notifications.ts
@@ -51,6 +51,16 @@ interface RegistryResponse {
   domains: NotificationDomainDescriptor[];
 }
 
+interface NotificationQueryOptions {
+  status?: NotificationStatus;
+  domain?: string;
+  mode?: NotificationMode;
+  limit?: number;
+  enabled?: boolean;
+  pollCategory?: PollCategory;
+  refetchInterval?: number | false;
+}
+
 // ---------------------------------------------------------------------------
 // Poll interval for unread count badge
 // ---------------------------------------------------------------------------
@@ -72,40 +82,7 @@ export function useUnreadCount() {
 }
 
 /** Fetch notifications with optional filters. */
-export function useNotifications(opts?: {
-  status?: NotificationStatus;
-  domain?: string;
-  mode?: NotificationMode;
-  limit?: number;
-  enabled?: boolean;
-  pollCategory?: PollCategory;
-  refetchInterval?: number | false;
-}) {
-  const params = new URLSearchParams();
-  if (opts?.status) params.set('status', opts.status);
-  if (opts?.domain) params.set('domain', opts.domain);
-  if (opts?.mode) params.set('mode', opts.mode);
-  if (opts?.limit) params.set('limit', String(opts.limit));
-  const qs = params.toString();
-  const path = qs ? `/notifications?${qs}` : '/notifications';
-
-  return useQuery<NotificationListResponse>({
-    queryKey: ['notifications', 'list', opts],
-    queryFn: ({ signal }) => fetchJson<NotificationListResponse>(path, { signal }),
-    enabled: opts?.enabled,
-  });
-}
-
-/** Fetch notifications with power-aware polling support. */
-export function useLiveNotifications(opts?: {
-  status?: NotificationStatus;
-  domain?: string;
-  mode?: NotificationMode;
-  limit?: number;
-  enabled?: boolean;
-  pollCategory: PollCategory;
-  refetchInterval: number;
-}) {
+export function useNotifications(opts?: NotificationQueryOptions) {
   const params = new URLSearchParams();
   if (opts?.status) params.set('status', opts.status);
   if (opts?.domain) params.set('domain', opts.domain);
@@ -118,8 +95,8 @@ export function useLiveNotifications(opts?: {
     queryKey: ['notifications', 'list', opts],
     queryFn: ({ signal }) => fetchJson<NotificationListResponse>(path, { signal }),
     enabled: opts?.enabled,
-    pollCategory: opts.pollCategory,
-    refetchInterval: opts.refetchInterval,
+    pollCategory: opts?.pollCategory ?? 'standard',
+    refetchInterval: opts?.refetchInterval ?? false,
   });
 }
 

--- a/packages/myco/ui/src/hooks/use-notifications.ts
+++ b/packages/myco/ui/src/hooks/use-notifications.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchJson, postJson } from '../lib/api';
-import { usePowerQuery } from './use-power-query';
+import { usePowerQuery, type PollCategory } from './use-power-query';
 import { POLL_INTERVALS } from '../lib/constants';
 
 // ---------------------------------------------------------------------------
@@ -55,7 +55,7 @@ interface RegistryResponse {
 // Poll interval for unread count badge
 // ---------------------------------------------------------------------------
 
-const NOTIFICATION_POLL_MS = POLL_INTERVALS.STATS;
+const UNREAD_COUNT_POLL_MS = POLL_INTERVALS.LOGS;
 
 // ---------------------------------------------------------------------------
 // Hooks
@@ -66,7 +66,7 @@ export function useUnreadCount() {
   return usePowerQuery<UnreadCountResponse>({
     queryKey: ['notifications', 'unread-count'],
     queryFn: ({ signal }) => fetchJson<UnreadCountResponse>('/notifications/unread-count', { signal }),
-    refetchInterval: NOTIFICATION_POLL_MS,
+    refetchInterval: UNREAD_COUNT_POLL_MS,
     pollCategory: 'standard',
   });
 }
@@ -77,6 +77,9 @@ export function useNotifications(opts?: {
   domain?: string;
   mode?: NotificationMode;
   limit?: number;
+  enabled?: boolean;
+  pollCategory?: PollCategory;
+  refetchInterval?: number | false;
 }) {
   const params = new URLSearchParams();
   if (opts?.status) params.set('status', opts.status);
@@ -89,6 +92,34 @@ export function useNotifications(opts?: {
   return useQuery<NotificationListResponse>({
     queryKey: ['notifications', 'list', opts],
     queryFn: ({ signal }) => fetchJson<NotificationListResponse>(path, { signal }),
+    enabled: opts?.enabled,
+  });
+}
+
+/** Fetch notifications with power-aware polling support. */
+export function useLiveNotifications(opts?: {
+  status?: NotificationStatus;
+  domain?: string;
+  mode?: NotificationMode;
+  limit?: number;
+  enabled?: boolean;
+  pollCategory: PollCategory;
+  refetchInterval: number;
+}) {
+  const params = new URLSearchParams();
+  if (opts?.status) params.set('status', opts.status);
+  if (opts?.domain) params.set('domain', opts.domain);
+  if (opts?.mode) params.set('mode', opts.mode);
+  if (opts?.limit) params.set('limit', String(opts.limit));
+  const qs = params.toString();
+  const path = qs ? `/notifications?${qs}` : '/notifications';
+
+  return usePowerQuery<NotificationListResponse>({
+    queryKey: ['notifications', 'list', opts],
+    queryFn: ({ signal }) => fetchJson<NotificationListResponse>(path, { signal }),
+    enabled: opts?.enabled,
+    pollCategory: opts.pollCategory,
+    refetchInterval: opts.refetchInterval,
   });
 }
 

--- a/packages/myco/ui/src/hooks/use-power-query.ts
+++ b/packages/myco/ui/src/hooks/use-power-query.ts
@@ -10,7 +10,7 @@ const HEARTBEAT_DEEP_SLEEP_CAP_MS = 30_000;
 
 export interface UsePowerQueryOptions<T> extends Omit<UseQueryOptions<T>, 'refetchInterval'> {
   pollCategory: PollCategory;
-  refetchInterval: number;
+  refetchInterval: number | false;
 }
 
 /**
@@ -47,7 +47,9 @@ export function usePowerQuery<T>(options: UsePowerQueryOptions<T>): UseQueryResu
   const powerState = usePowerState();
   const { pollCategory, refetchInterval: baseInterval, ...queryOptions } = options;
 
-  const effectiveInterval = computePollInterval(baseInterval, pollCategory, powerState);
+  const effectiveInterval = baseInterval === false
+    ? false
+    : computePollInterval(baseInterval, pollCategory, powerState);
 
   return useQuery({
     ...queryOptions,

--- a/packages/myco/ui/src/hooks/use-scoped-config.ts
+++ b/packages/myco/ui/src/hooks/use-scoped-config.ts
@@ -14,6 +14,7 @@ export type Scope = 'project' | 'local';
 
 const MERGED_KEY = ['config', 'merged'] as const;
 const LOCAL_KEY = ['config', 'local'] as const;
+const NOTIFICATIONS_KEY = ['notifications'] as const;
 
 /**
  * Scoped config hook — generalizes the Appearance provider pattern so any
@@ -53,13 +54,18 @@ export function useScopedConfig() {
   // Local writes only need the local query refetched; project writes need both
   // (because merged = project + local). Splitting saves a network round-trip
   // per personal-default toggle, which is the common case.
+  const invalidateNotifications = useCallback(() => {
+    void qc.invalidateQueries({ queryKey: NOTIFICATIONS_KEY });
+  }, [qc]);
   const invalidateLocal = useCallback(() => {
     void qc.invalidateQueries({ queryKey: LOCAL_KEY });
     void qc.invalidateQueries({ queryKey: MERGED_KEY });
-  }, [qc]);
+    invalidateNotifications();
+  }, [invalidateNotifications, qc]);
   const invalidateProject = useCallback(() => {
     void qc.invalidateQueries({ queryKey: MERGED_KEY });
-  }, [qc]);
+    invalidateNotifications();
+  }, [invalidateNotifications, qc]);
   const invalidateForScope = useCallback(
     (scope: Scope) => (scope === 'local' ? invalidateLocal() : invalidateProject()),
     [invalidateLocal, invalidateProject],

--- a/packages/myco/ui/src/hooks/use-scoped-config.ts
+++ b/packages/myco/ui/src/hooks/use-scoped-config.ts
@@ -90,6 +90,28 @@ export function useScopedConfig() {
     [invalidateForScope],
   );
 
+  /**
+   * Atomic patch + clear at the chosen scope. One PUT to /config/scoped
+   * applies field writes and key removals together — useful for transitions
+   * that would otherwise race (e.g. Clear Provider needs to unset the
+   * provider and disable the tied task toggles in a single step).
+   */
+  const setFieldsAndClear = useCallback(
+    async (
+      fields: Array<{ path: ConfigPath; value: unknown }>,
+      clearPaths: ConfigPath[],
+      scope: Scope,
+    ): Promise<void> => {
+      const patch: Record<string, unknown> = {};
+      for (const { path, value } of fields) {
+        setAtPath(patch, path, value);
+      }
+      await writeScopedConfig(scope, patch, clearPaths as string[]);
+      invalidateForScope(scope);
+    },
+    [invalidateForScope],
+  );
+
   const resetField = useCallback(async (path: ConfigPath): Promise<void> => {
     await clearLocalConfigKeys([path]);
     invalidateLocal();
@@ -117,6 +139,7 @@ export function useScopedConfig() {
     isLocalOverride,
     setField,
     setFields,
+    setFieldsAndClear,
     resetField,
     promoteField,
   };

--- a/packages/myco/ui/src/hooks/use-scoped-config.ts
+++ b/packages/myco/ui/src/hooks/use-scoped-config.ts
@@ -75,38 +75,23 @@ export function useScopedConfig() {
     [invalidateForScope],
   );
 
+  /**
+   * Atomic write to the chosen scope. Applies a patch (field -> value pairs)
+   * and optionally clears a set of dot-paths — both in a single PUT so
+   * coupled transitions can't tear (e.g. Clear Provider unsets the provider
+   * and disables the tied task toggles together).
+   */
   const setFields = useCallback(
     async (
       fields: Array<{ path: ConfigPath; value: unknown }>,
       scope: Scope,
+      clearPaths?: ConfigPath[],
     ): Promise<void> => {
       const patch: Record<string, unknown> = {};
       for (const { path, value } of fields) {
         setAtPath(patch, path, value);
       }
-      await writeScopedConfig(scope, patch);
-      invalidateForScope(scope);
-    },
-    [invalidateForScope],
-  );
-
-  /**
-   * Atomic patch + clear at the chosen scope. One PUT to /config/scoped
-   * applies field writes and key removals together — useful for transitions
-   * that would otherwise race (e.g. Clear Provider needs to unset the
-   * provider and disable the tied task toggles in a single step).
-   */
-  const setFieldsAndClear = useCallback(
-    async (
-      fields: Array<{ path: ConfigPath; value: unknown }>,
-      clearPaths: ConfigPath[],
-      scope: Scope,
-    ): Promise<void> => {
-      const patch: Record<string, unknown> = {};
-      for (const { path, value } of fields) {
-        setAtPath(patch, path, value);
-      }
-      await writeScopedConfig(scope, patch, clearPaths as string[]);
+      await writeScopedConfig(scope, patch, clearPaths as string[] | undefined);
       invalidateForScope(scope);
     },
     [invalidateForScope],
@@ -139,7 +124,6 @@ export function useScopedConfig() {
     isLocalOverride,
     setField,
     setFields,
-    setFieldsAndClear,
     resetField,
     promoteField,
   };

--- a/packages/myco/ui/src/layout/AppearanceSection.tsx
+++ b/packages/myco/ui/src/layout/AppearanceSection.tsx
@@ -6,6 +6,7 @@ import {
   APPEARANCE_FONTS,
   APPEARANCE_DENSITIES,
 } from '@myco/config/appearance-values';
+import { CONFIG_SECTION_IDS, configFieldId } from '@myco/config/focus';
 import {
   useAppearance,
   type Theme,
@@ -13,7 +14,7 @@ import {
   type FontKey,
   type Appearance,
 } from '../providers/appearance';
-import { ScopePill } from '../components/config/ScopePill';
+import { ScopeBadge, ScopePill } from '../components/config/ScopePill';
 
 const THEME_LABELS: Record<Theme, { label: string; swatch: string }> = {
   sage: { label: 'Sage', swatch: '#abcfb8' },
@@ -71,14 +72,20 @@ export function AppearanceSection({ collapsed }: { collapsed: boolean }) {
     controlKey: K,
     children: ReactNode,
   ) => (
-    <div>
+    <div
+      id={configFieldId(`appearance.${controlKey}`)}
+      data-config-field={`appearance.${controlKey}`}
+      className="rounded-md transition-all duration-300"
+    >
       <div className="flex items-center text-xs text-on-surface-variant">
         {label}
-        {isPersonal(controlKey) && (
+        {isPersonal(controlKey) ? (
           <ScopePill
             onPromote={() => set(controlKey, effective[controlKey], 'project').catch((err) => console.error('[appearance] promote failed', err))}
             onReset={() => resetKey(controlKey).catch((err) => console.error('[appearance] reset failed', err))}
           />
+        ) : (
+          <ScopeBadge scope="project" />
         )}
       </div>
       {children}
@@ -86,7 +93,10 @@ export function AppearanceSection({ collapsed }: { collapsed: boolean }) {
   );
 
   return (
-    <div className={`rounded-md border border-[var(--ghost-border)] p-3 ${expanded ? 'space-y-3' : ''}`}>
+    <div
+      id={CONFIG_SECTION_IDS.appearance}
+      className={`rounded-md border border-[var(--ghost-border)] p-3 ${expanded ? 'space-y-3' : ''}`}
+    >
       <div className="flex items-center justify-between">
         <button
           type="button"

--- a/packages/myco/ui/src/layout/Layout.tsx
+++ b/packages/myco/ui/src/layout/Layout.tsx
@@ -1,6 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
 import { NavLink, Outlet, useLocation } from 'react-router-dom';
 import {
+  CONFIG_FOCUS_FIELD_PARAM,
+  CONFIG_FOCUS_SECTION_PARAM,
+  configFieldId,
+} from '@myco/config/focus';
+import {
   LayoutDashboard,
   Settings,
   Network,
@@ -48,6 +53,13 @@ const SIDEBAR_COLLAPSED_KEY = 'myco-ui-sidebar-collapsed';
 
 /** Tailwind `md` breakpoint in pixels. Below this, the sidebar becomes a mobile drawer. */
 const MOBILE_BREAKPOINT_PX = 768;
+const CONFIG_FOCUS_SCROLL_DELAY_MS = 80;
+const CONFIG_FOCUS_HIGHLIGHT_DURATION_MS = 2_000;
+const CONFIG_FOCUS_HIGHLIGHT_CLASSES = [
+  'ring-2',
+  'ring-primary/40',
+  'bg-primary/5',
+];
 
 /* ---------- Sidebar collapse hook ---------- */
 
@@ -339,10 +351,29 @@ export default function Layout() {
   const openNotifPanel = useCallback(() => setNotifPanelOpen(true), []);
   const closeNotifPanel = useCallback(() => setNotifPanelOpen(false), []);
 
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const field = params.get(CONFIG_FOCUS_FIELD_PARAM) ?? undefined;
+    const section = params.get(CONFIG_FOCUS_SECTION_PARAM) ?? undefined;
+    if (!field && !section) return;
+
+    const timeoutId = window.setTimeout(() => {
+      const target = findConfigFocusElement(field, section);
+      if (!target) return;
+      target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      target.classList.add(...CONFIG_FOCUS_HIGHLIGHT_CLASSES);
+      window.setTimeout(() => {
+        target.classList.remove(...CONFIG_FOCUS_HIGHLIGHT_CLASSES);
+      }, CONFIG_FOCUS_HIGHLIGHT_DURATION_MS);
+    }, CONFIG_FOCUS_SCROLL_DELAY_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [location.key, location.search]);
+
   return (
     <div className="flex h-screen bg-background">
       <GlobalSearch open={searchOpen} onOpenChange={setSearchOpen} />
-      <NotificationBanner />
+      <NotificationBanner panelOpen={notifPanelOpen} />
       <NotificationPanel open={notifPanelOpen} onClose={closeNotifPanel} />
       <SystemNotifications />
 
@@ -447,4 +478,24 @@ export default function Layout() {
       </main>
     </div>
   );
+}
+
+function findConfigFocusElement(field?: string, section?: string): HTMLElement | null {
+  if (field) {
+    let current = field;
+    while (current.length > 0) {
+      const element = document.getElementById(configFieldId(current));
+      if (element instanceof HTMLElement) return element;
+      const lastDot = current.lastIndexOf('.');
+      if (lastDot === -1) break;
+      current = current.slice(0, lastDot);
+    }
+  }
+
+  if (section) {
+    const sectionElement = document.getElementById(section);
+    if (sectionElement instanceof HTMLElement) return sectionElement;
+  }
+
+  return null;
 }

--- a/packages/myco/ui/src/lib/api.ts
+++ b/packages/myco/ui/src/lib/api.ts
@@ -64,7 +64,9 @@ export function writeScopedConfig(
 }
 
 export function clearLocalConfigKeys(keys: string[]): Promise<unknown> {
-  return postJson<unknown>('/config/local/clear', { keys });
+  // Unified scoped write: clear-only request. Empty patch is allowed when
+  // clear is non-empty (server validates this).
+  return putJson<unknown>('/config/scoped', { scope: 'local', patch: {}, clear: keys });
 }
 
 export class ApiError extends Error {

--- a/packages/myco/ui/src/lib/api.ts
+++ b/packages/myco/ui/src/lib/api.ts
@@ -59,8 +59,11 @@ export function fetchLocalConfig(signal?: AbortSignal): Promise<Partial<MergedCo
 export function writeScopedConfig(
   scope: 'project' | 'local',
   patch: Record<string, unknown>,
+  clear?: string[],
 ): Promise<unknown> {
-  return putJson<unknown>('/config/scoped', { scope, patch });
+  const body: Record<string, unknown> = { scope, patch };
+  if (clear && clear.length > 0) body.clear = clear;
+  return putJson<unknown>('/config/scoped', body);
 }
 
 export function clearLocalConfigKeys(keys: string[]): Promise<unknown> {

--- a/packages/myco/ui/src/pages/Operations.tsx
+++ b/packages/myco/ui/src/pages/Operations.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Cpu, Database, Play, Trash2, RefreshCw, RotateCcw, ArrowDown, Pause } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
+import { CONFIG_SECTION_IDS } from '@myco/config/focus';
 import { useEmbeddingDetails, type EmbeddingDetails } from '../hooks/use-embedding-details';
 import { useDatabaseDetails, type DatabaseDetails } from '../hooks/use-database-details';
 import { useScopedConfig } from '../hooks/use-scoped-config';
@@ -190,7 +191,11 @@ function IndexesPanel({ indexes }: { indexes: DatabaseDetails['indexes'] }) {
   const autoCount = indexes.filter((i) => i.type === 'auto').length;
 
   return (
-    <Surface level="low" className="p-6 space-y-4">
+    <Surface
+      id={CONFIG_SECTION_IDS.operationsMaintenance}
+      level="low"
+      className="rounded-lg p-6 space-y-4 transition-all duration-300"
+    >
       <div className="flex items-center justify-between">
         <SectionHeader>Indexes</SectionHeader>
         <button

--- a/packages/myco/ui/src/pages/Settings.tsx
+++ b/packages/myco/ui/src/pages/Settings.tsx
@@ -115,7 +115,7 @@ function providerToDraft(p: { type?: string; model?: string; base_url?: string; 
  *    • Clear Provider also disables both task toggles
  *  These mirror the previous batched-Save behaviour but happen atomically. */
 function AgentProviderCard() {
-  const { effective, setField, setFields, isLocalOverride, resetField, promoteField } = useScopedConfig();
+  const { effective, setField, setFields, setFieldsAndClear, isLocalOverride, resetField, promoteField } = useScopedConfig();
   const { data: providersData, isPending: isLoadingProviders } = useProviders();
   const agentTestMutation = useTestProvider();
 
@@ -192,25 +192,23 @@ function AgentProviderCard() {
   const handleClear = useCallback(async () => {
     setDraft({ type: '', model: '', baseUrl: '', contextLength: '' });
     agentTestMutation.reset();
-    // /simplify Q7: sequence the two writes so a partial failure (e.g. the
-    // toggles write succeeds but resetField fails) doesn't leave the user
-    // with disabled tasks AND a still-set provider — we'd rather both
-    // succeed or both error out.
-    //
-    // deepMerge skips undefined source values, so writing { provider: undefined }
-    // won't clear a project-scoped provider. resetField clears the local
-    // override only; a project-scoped provider must be removed from
-    // myco.yaml directly.
+    // One atomic PUT: disables both task toggles AND clears the local
+    // agent.provider override. Server applies clear-before-patch in a single
+    // write, so there's no partial-failure window. A project-scoped provider
+    // still requires editing myco.yaml directly.
     try {
-      await setFields([
-        { path: 'agent.scheduled_tasks_enabled', value: false },
-        { path: 'agent.event_tasks_enabled', value: false },
-      ], 'local');
-      await resetField('agent.provider');
+      await setFieldsAndClear(
+        [
+          { path: 'agent.scheduled_tasks_enabled', value: false },
+          { path: 'agent.event_tasks_enabled', value: false },
+        ],
+        ['agent.provider'],
+        'local',
+      );
     } catch (err) {
       console.error('[agent-card] clear provider failed', err);
     }
-  }, [setFields, resetField, agentTestMutation]);
+  }, [setFieldsAndClear, agentTestMutation]);
 
   const handleTestConnection = useCallback(() => {
     if (draft.type === '') return;

--- a/packages/myco/ui/src/pages/Settings.tsx
+++ b/packages/myco/ui/src/pages/Settings.tsx
@@ -115,7 +115,7 @@ function providerToDraft(p: { type?: string; model?: string; base_url?: string; 
  *    • Clear Provider also disables both task toggles
  *  These mirror the previous batched-Save behaviour but happen atomically. */
 function AgentProviderCard() {
-  const { effective, setField, setFields, setFieldsAndClear, isLocalOverride, resetField, promoteField } = useScopedConfig();
+  const { effective, setField, setFields, isLocalOverride, resetField, promoteField } = useScopedConfig();
   const { data: providersData, isPending: isLoadingProviders } = useProviders();
   const agentTestMutation = useTestProvider();
 
@@ -192,23 +192,22 @@ function AgentProviderCard() {
   const handleClear = useCallback(async () => {
     setDraft({ type: '', model: '', baseUrl: '', contextLength: '' });
     agentTestMutation.reset();
-    // One atomic PUT: disables both task toggles AND clears the local
-    // agent.provider override. Server applies clear-before-patch in a single
-    // write, so there's no partial-failure window. A project-scoped provider
-    // still requires editing myco.yaml directly.
+    // Atomic: disable both task toggles and clear the local agent.provider
+    // override in one PUT. A project-scoped provider still requires editing
+    // myco.yaml directly.
     try {
-      await setFieldsAndClear(
+      await setFields(
         [
           { path: 'agent.scheduled_tasks_enabled', value: false },
           { path: 'agent.event_tasks_enabled', value: false },
         ],
-        ['agent.provider'],
         'local',
+        ['agent.provider'],
       );
     } catch (err) {
       console.error('[agent-card] clear provider failed', err);
     }
-  }, [setFieldsAndClear, agentTestMutation]);
+  }, [setFields, agentTestMutation]);
 
   const handleTestConnection = useCallback(() => {
     if (draft.type === '') return;

--- a/packages/myco/ui/src/pages/Settings.tsx
+++ b/packages/myco/ui/src/pages/Settings.tsx
@@ -535,7 +535,6 @@ function ProjectCard({ vaultName }: { vaultName: string }) {
           path="daemon.log_level"
           label="Log Level"
           defaultScope="local"
-          requiresRestart
         >
           {({ value, onChange }) => (
             <Select value={value ?? 'info'} onValueChange={(v) => onChange(v as LogLevel)}>
@@ -557,7 +556,6 @@ function ProjectCard({ vaultName }: { vaultName: string }) {
           path="daemon.log_retention_days"
           label="Log Retention (days)"
           defaultScope="local"
-          requiresRestart
           commitOn="blur"
         >
           {({ value, onChange, onBlur }) => (

--- a/packages/myco/ui/src/pages/Settings.tsx
+++ b/packages/myco/ui/src/pages/Settings.tsx
@@ -2,6 +2,10 @@ import { useState, useCallback, useEffect } from 'react';
 import { CheckCircle, XCircle, Loader2 } from 'lucide-react';
 import { useDaemon } from '../hooks/use-daemon';
 import {
+  CONFIG_SECTION_IDS,
+  configFieldId,
+} from '@myco/config/focus';
+import {
   useProviders,
   useTestProvider,
   seedDraftFromProviderType,
@@ -26,7 +30,7 @@ import {
 import { Switch } from '../components/ui/switch';
 import { PlanCaptureCard } from '../components/config/PlanCaptureCard';
 import { ScopedField } from '../components/config/ScopedField';
-import { ScopePill } from '../components/config/ScopePill';
+import { ScopeBadge, ScopePill } from '../components/config/ScopePill';
 import { RestartGateProvider, RestartBanner } from '../components/config/restart-gate';
 import { useScopedConfig } from '../hooks/use-scoped-config';
 import { NotificationSettings } from '../components/notifications/NotificationSettings';
@@ -218,11 +222,20 @@ function AgentProviderCard() {
   }, [draft.type, draft.baseUrl, agentTestMutation]);
 
   return (
-    <Surface level="low" className="p-6 space-y-5 border-t-2 border-t-sage">
+    <Surface
+      id={CONFIG_SECTION_IDS.settingsAgent}
+      data-config-field="agent.provider"
+      level="low"
+      className="rounded-lg p-6 space-y-5 border-t-2 border-t-sage transition-all duration-300"
+    >
       <SectionHeader>
         <span className="flex items-center gap-2">
           Myco Agent
-          {personal && <ScopePill onPromote={() => promoteField('agent.provider')} onReset={() => resetField('agent.provider')} />}
+          {personal ? (
+            <ScopePill onPromote={() => promoteField('agent.provider')} onReset={() => resetField('agent.provider')} />
+          ) : (
+            <ScopeBadge scope="project" />
+          )}
         </span>
       </SectionHeader>
 
@@ -325,7 +338,11 @@ function EmbeddingCard() {
   }, [currentProvider, currentBaseUrl]);
 
   return (
-    <Surface level="low" className="p-6 space-y-5 border-t-2 border-t-ochre">
+    <Surface
+      id={CONFIG_SECTION_IDS.settingsEmbedding}
+      level="low"
+      className="rounded-lg p-6 space-y-5 border-t-2 border-t-ochre transition-all duration-300"
+    >
       <SectionHeader>Embedding</SectionHeader>
 
       <div className="space-y-4">
@@ -431,7 +448,11 @@ function EmbeddingCard() {
  *  by default. Still overridable per-machine via the Personal pill. */
 function ContextInjectionCard() {
   return (
-    <Surface level="low" className="p-6 space-y-5 border-t-2 border-t-ochre">
+    <Surface
+      id={CONFIG_SECTION_IDS.settingsContextInjection}
+      level="low"
+      className="rounded-lg p-6 space-y-5 border-t-2 border-t-ochre transition-all duration-300"
+    >
       <SectionHeader>Context Injection</SectionHeader>
 
       <div className="space-y-4">
@@ -497,12 +518,20 @@ function ContextInjectionCard() {
  *  lets any field be promoted/reset between personal and project scope. */
 function ProjectCard({ vaultName }: { vaultName: string }) {
   return (
-    <Surface level="low" className="p-6 space-y-5 border-t-2 border-t-sage">
+    <Surface
+      id={CONFIG_SECTION_IDS.settingsProject}
+      level="low"
+      className="rounded-lg p-6 space-y-5 border-t-2 border-t-sage transition-all duration-300"
+    >
       <SectionHeader>Project</SectionHeader>
 
       <div className="space-y-4">
         {/* Vault name -- read-only */}
-        <div className="space-y-1.5">
+        <div
+          id={configFieldId('vault.name')}
+          data-config-field="vault.name"
+          className="space-y-1.5 rounded-md transition-all duration-300"
+        >
           <label className="font-sans text-sm font-medium text-on-surface">Vault Name</label>
           <Input value={vaultName} readOnly disabled className="text-on-surface-variant bg-surface-container-lowest" />
         </div>

--- a/tests/config/focus.test.ts
+++ b/tests/config/focus.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CONFIG_SECTION_IDS,
+  buildConfigFocusLink,
+  buildScopedConfigSaveNotification,
+  configFieldId,
+  resolveConfigFocusTarget,
+} from '@myco/config/focus';
+
+describe('config focus helpers', () => {
+  it('resolves context.prompt_search to the settings context section', () => {
+    const target = resolveConfigFocusTarget('context.prompt_search');
+
+    expect(target).toEqual({
+      page: '/settings',
+      sectionId: CONFIG_SECTION_IDS.settingsContextInjection,
+      sectionLabel: 'Context Injection',
+      fieldPath: 'context.prompt_search',
+      fieldLabel: 'Prompt Search',
+    });
+  });
+
+  it('builds a focus link with section and field params', () => {
+    const target = resolveConfigFocusTarget('context.prompt_search');
+    expect(target).not.toBeNull();
+    expect(buildConfigFocusLink(target!)).toBe(
+      `/settings?configSection=${CONFIG_SECTION_IDS.settingsContextInjection}&configField=context.prompt_search`,
+    );
+  });
+
+  it('formats settings save notifications with an exact field label and link', () => {
+    const summary = buildScopedConfigSaveNotification('project', ['context.prompt_search']);
+
+    expect(summary.title).toBe('Prompt Search saved');
+    expect(summary.message).toBe('Context Injection · Prompt Search · Project');
+    expect(summary.link).toBe(
+      `/settings?configSection=${CONFIG_SECTION_IDS.settingsContextInjection}&configField=context.prompt_search`,
+    );
+    expect(summary.metadata.focus_target).toEqual({
+      page: '/settings',
+      section_id: CONFIG_SECTION_IDS.settingsContextInjection,
+      field_path: 'context.prompt_search',
+      field_label: 'Prompt Search',
+    });
+  });
+
+  it('falls back to ancestor field ids for custom cards', () => {
+    expect(configFieldId('agent.provider.model')).toBe('config-field-agent-provider-model');
+    expect(configFieldId('agent.provider')).toBe('config-field-agent-provider');
+  });
+});

--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { loadConfig, saveConfig, updateConfig } from '@myco/config/loader';
-import { loadLocalConfig, loadMergedConfig, saveLocalConfig, updateLocalConfig, clearLocalConfigKeys } from '@myco/config/loader';
+import { loadLocalConfig, loadMergedConfig, saveLocalConfig, updateLocalConfig } from '@myco/config/loader';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -198,31 +198,6 @@ describe('Local config overlay', () => {
     writeProject(tmpDir, `version: 3\nembedding:\n  provider: ollama\n  model: bge-m3\n`);
     updateLocalConfig(tmpDir, (local) => ({ ...local, appearance: { ...local.appearance, theme: 'dusk' } }));
     expect(loadLocalConfig(tmpDir).appearance?.theme).toBe('dusk');
-  });
-
-  it('clearLocalConfigKeys removes leaf overrides', () => {
-    writeProject(tmpDir, `version: 3\nembedding:\n  provider: ollama\n  model: bge-m3\n`);
-    saveLocalConfig(tmpDir, { appearance: { theme: 'plum', font: 'geist-mono' } });
-    clearLocalConfigKeys(tmpDir, ['appearance.theme']);
-    const local = loadLocalConfig(tmpDir);
-    expect(local.appearance).toEqual({ font: 'geist-mono' });
-  });
-
-  it('clearLocalConfigKeys does not create local.yaml when nothing to clear', () => {
-    writeProject(tmpDir, `version: 3\nembedding:\n  provider: ollama\n  model: bge-m3\n`);
-    // No local.yaml exists, no overrides to clear
-    clearLocalConfigKeys(tmpDir, ['appearance.theme']);
-    expect(fs.existsSync(path.join(tmpDir, 'local.yaml'))).toBe(false);
-  });
-
-  it('clearLocalConfigKeys does not write file when key is already absent', () => {
-    writeProject(tmpDir, `version: 3\nembedding:\n  provider: ollama\n  model: bge-m3\n`);
-    saveLocalConfig(tmpDir, { appearance: { theme: 'moss' } });
-    const mtimeBefore = fs.statSync(path.join(tmpDir, 'local.yaml')).mtimeMs;
-    // Clear a key that doesn't exist
-    clearLocalConfigKeys(tmpDir, ['appearance.font']);
-    const mtimeAfter = fs.statSync(path.join(tmpDir, 'local.yaml')).mtimeMs;
-    expect(mtimeAfter).toBe(mtimeBefore);
   });
 
   it('merged-array policy: local arrays replace project arrays', () => {

--- a/tests/config/migrations.test.ts
+++ b/tests/config/migrations.test.ts
@@ -150,6 +150,7 @@ describe('Migration v3: schedule-to-task-level', () => {
 });
 
 const v4 = MIGRATIONS.find((m) => m.version === 4)!;
+const v5 = MIGRATIONS.find((m) => m.version === 5)!;
 
 describe('Migration v4: rename-cloud-provider-to-anthropic', () => {
   it('renames global agent provider type from cloud to anthropic', () => {
@@ -218,8 +219,49 @@ describe('Migration v4: rename-cloud-provider-to-anthropic', () => {
 });
 
 describe('CURRENT_MIGRATION_VERSION', () => {
-  it('is 4', () => {
-    expect(CURRENT_MIGRATION_VERSION).toBe(4);
+  it('is 5', () => {
+    expect(CURRENT_MIGRATION_VERSION).toBe(5);
+  });
+});
+
+describe('Migration v5: seed-settings-notification-domain-default', () => {
+  it('adds the settings notification domain with banner mode when missing', () => {
+    const doc: Record<string, unknown> = {
+      notifications: {
+        default_mode: 'summary',
+      },
+    };
+
+    v5.migrate(doc, '/tmp');
+
+    const notifications = doc.notifications as Record<string, unknown>;
+    const domains = notifications.domains as Record<string, Record<string, unknown>>;
+    expect(domains.settings).toEqual({
+      enabled: true,
+      mode: 'banner',
+    });
+  });
+
+  it('preserves explicit settings domain preferences', () => {
+    const doc: Record<string, unknown> = {
+      notifications: {
+        domains: {
+          settings: {
+            enabled: false,
+            mode: 'summary',
+          },
+        },
+      },
+    };
+
+    v5.migrate(doc, '/tmp');
+
+    const notifications = doc.notifications as Record<string, unknown>;
+    const domains = notifications.domains as Record<string, Record<string, unknown>>;
+    expect(domains.settings).toEqual({
+      enabled: false,
+      mode: 'summary',
+    });
   });
 });
 
@@ -231,11 +273,17 @@ describe('runMigrations', () => {
     };
     const ran = runMigrations(doc, '/tmp');
     expect(ran).toBe(true);
-    expect(doc.config_version).toBe(4);
+    expect(doc.config_version).toBe(5);
 
     const agent = doc.agent as Record<string, unknown>;
     const tasks = agent.tasks as Record<string, Record<string, unknown>>;
     expect(tasks['full-intelligence'].schedule).toBeDefined();
+    const notifications = doc.notifications as Record<string, unknown>;
+    const domains = notifications.domains as Record<string, Record<string, unknown>>;
+    expect(domains.settings).toEqual({
+      enabled: true,
+      mode: 'banner',
+    });
   });
 
   it('runs v4 when config_version is 3', () => {
@@ -245,14 +293,33 @@ describe('runMigrations', () => {
     };
     const ran = runMigrations(doc, '/tmp');
     expect(ran).toBe(true);
-    expect(doc.config_version).toBe(4);
+    expect(doc.config_version).toBe(5);
     const agent = doc.agent as Record<string, unknown>;
     expect((agent.provider as Record<string, unknown>).type).toBe('anthropic');
   });
 
-  it('skips all migrations when config_version is already 4', () => {
+  it('runs v5 when config_version is 4', () => {
     const doc: Record<string, unknown> = {
       config_version: 4,
+      notifications: {
+        default_mode: 'summary',
+      },
+    };
+    const ran = runMigrations(doc, '/tmp');
+    expect(ran).toBe(true);
+    expect(doc.config_version).toBe(5);
+
+    const notifications = doc.notifications as Record<string, unknown>;
+    const domains = notifications.domains as Record<string, Record<string, unknown>>;
+    expect(domains.settings).toEqual({
+      enabled: true,
+      mode: 'banner',
+    });
+  });
+
+  it('skips all migrations when config_version is already 5', () => {
+    const doc: Record<string, unknown> = {
+      config_version: 5,
       agent: { auto_run: true, provider: { type: 'cloud' } },
     };
     const ran = runMigrations(doc, '/tmp');

--- a/tests/daemon/api/config-scope.test.ts
+++ b/tests/daemon/api/config-scope.test.ts
@@ -56,6 +56,21 @@ describe('scoped config HTTP handlers', () => {
     expect(res.status).toBe(400);
   });
 
+  it('PUT /scoped rejects missing scope', async () => {
+    const res = await handlePutScopedConfig(tmpDir, { patch: { appearance: { theme: 'moss' } } });
+    expect(res.status).toBe(400);
+    expect((res.body as any).error).toBe('scope must be project or local');
+  });
+
+  it('PUT /scoped rejects invalid scope', async () => {
+    const res = await handlePutScopedConfig(tmpDir, {
+      scope: 'bogus' as 'project',
+      patch: { appearance: { theme: 'moss' } },
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as any).error).toBe('scope must be project or local');
+  });
+
   it('PUT /scoped scope=local rejects missing patch', async () => {
     const res = await handlePutScopedConfig(tmpDir, { scope: 'local' });
     expect(res.status).toBe(400);
@@ -102,6 +117,16 @@ describe('scoped config HTTP handlers', () => {
     expect((res.body as any).error).toBe('patch_clear_overlap');
   });
 
+  it('PUT /scoped rejects 400 when patch and clear overlap by ancestry', async () => {
+    const res = await handlePutScopedConfig(tmpDir, {
+      scope: 'local',
+      patch: { agent: { provider: { model: 'sonnet' } } },
+      clear: ['agent.provider'],
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as any).error).toBe('patch_clear_overlap');
+  });
+
   it('PUT /scoped rejects 400 when neither patch nor clear present', async () => {
     const res = await handlePutScopedConfig(tmpDir, { scope: 'local' });
     expect(res.status).toBe(400);
@@ -112,11 +137,30 @@ describe('scoped config HTTP handlers', () => {
     expect(res.status).toBe(400);
   });
 
+  it('PUT /scoped rejects 400 when clear contains non-string entries', async () => {
+    const res = await handlePutScopedConfig(tmpDir, {
+      scope: 'local',
+      clear: [123 as unknown as string],
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as any).error).toBe('clear entries must be non-empty strings');
+  });
+
   it('PUT /scoped with empty patch object and non-empty clear is valid', async () => {
     await handlePutScopedConfig(tmpDir, { scope: 'local', patch: { appearance: { theme: 'moss' } } });
     const res = await handlePutScopedConfig(tmpDir, { scope: 'local', patch: {}, clear: ['appearance.theme'] });
     expect(res.status).toBeUndefined();
     const local = await handleGetLocalConfig(tmpDir);
     expect((local.body as any).appearance?.theme).toBeUndefined();
+  });
+
+  it('PUT /scoped rejects invalid local overlays before writing local.yaml', async () => {
+    const res = await handlePutScopedConfig(tmpDir, {
+      scope: 'local',
+      patch: { daemon: { log_level: 'verbose' } },
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as any).error).toBe('validation_failed');
+    expect(fs.existsSync(path.join(tmpDir, 'local.yaml'))).toBe(false);
   });
 });

--- a/tests/daemon/api/config-scope.test.ts
+++ b/tests/daemon/api/config-scope.test.ts
@@ -68,4 +68,63 @@ describe('scoped config HTTP handlers', () => {
     const res = await handlePutScopedConfig(tmpDir, { scope: 'local' });
     expect(res.status).toBe(400);
   });
+
+  it('PUT /scoped with clear only at scope=local removes keys', async () => {
+    await handlePutScopedConfig(tmpDir, { scope: 'local', patch: { appearance: { theme: 'moss' } } });
+    const res = await handlePutScopedConfig(tmpDir, { scope: 'local', clear: ['appearance.theme'] });
+    expect(res.status).toBeUndefined();
+    const local = await handleGetLocalConfig(tmpDir);
+    expect((local.body as any).appearance?.theme).toBeUndefined();
+  });
+
+  it('PUT /scoped with clear only at scope=project removes keys from myco.yaml', async () => {
+    await handlePutScopedConfig(tmpDir, { scope: 'project', patch: { appearance: { theme: 'plum' } } });
+    const res = await handlePutScopedConfig(tmpDir, { scope: 'project', clear: ['appearance.theme'] });
+    expect(res.status).toBeUndefined();
+    const project = fs.readFileSync(path.join(tmpDir, 'myco.yaml'), 'utf-8');
+    expect(project).not.toContain('theme: plum');
+  });
+
+  it('PUT /scoped applies patch and clear atomically', async () => {
+    // Seed: appearance.theme=sage (project), agent.provider set locally
+    await handlePutScopedConfig(tmpDir, { scope: 'local', patch: { agent: { provider: { type: 'anthropic' } } } });
+    // Atomic: clear agent.provider AND set scheduled_tasks_enabled=false
+    const res = await handlePutScopedConfig(tmpDir, {
+      scope: 'local',
+      patch: { agent: { scheduled_tasks_enabled: false } },
+      clear: ['agent.provider'],
+    });
+    expect(res.status).toBeUndefined();
+    const local = await handleGetLocalConfig(tmpDir);
+    expect((local.body as any).agent?.provider).toBeUndefined();
+    expect((local.body as any).agent?.scheduled_tasks_enabled).toBe(false);
+  });
+
+  it('PUT /scoped rejects 400 when patch and clear overlap', async () => {
+    const res = await handlePutScopedConfig(tmpDir, {
+      scope: 'local',
+      patch: { appearance: { theme: 'moss' } },
+      clear: ['appearance.theme'],
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as any).error).toBe('patch_clear_overlap');
+  });
+
+  it('PUT /scoped rejects 400 when neither patch nor clear present', async () => {
+    const res = await handlePutScopedConfig(tmpDir, { scope: 'local' });
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT /scoped rejects 400 when clear is not an array', async () => {
+    const res = await handlePutScopedConfig(tmpDir, { scope: 'local', clear: 'agent.provider' as unknown as string[] });
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT /scoped with empty patch object and non-empty clear is valid', async () => {
+    await handlePutScopedConfig(tmpDir, { scope: 'local', patch: { appearance: { theme: 'moss' } } });
+    const res = await handlePutScopedConfig(tmpDir, { scope: 'local', patch: {}, clear: ['appearance.theme'] });
+    expect(res.status).toBeUndefined();
+    const local = await handleGetLocalConfig(tmpDir);
+    expect((local.body as any).appearance?.theme).toBeUndefined();
+  });
 });

--- a/tests/daemon/api/config-scope.test.ts
+++ b/tests/daemon/api/config-scope.test.ts
@@ -6,7 +6,6 @@ import {
   handleGetMergedConfig,
   handleGetLocalConfig,
   handlePutScopedConfig,
-  handleClearLocalConfig,
 } from '@myco/daemon/api/config';
 
 function seedProject(dir: string) {
@@ -55,13 +54,6 @@ describe('scoped config HTTP handlers', () => {
   it('PUT /scoped scope=project without patch returns 400', async () => {
     const res = await handlePutScopedConfig(tmpDir, { scope: 'project' });
     expect(res.status).toBe(400);
-  });
-
-  it('POST /local/clear removes specified keys', async () => {
-    await handlePutScopedConfig(tmpDir, { scope: 'local', patch: { appearance: { theme: 'dusk', font: 'geist-mono' } } });
-    await handleClearLocalConfig(tmpDir, { keys: ['appearance.theme'] });
-    const local = await handleGetLocalConfig(tmpDir);
-    expect((local.body as any).appearance).toEqual({ font: 'geist-mono' });
   });
 
   it('PUT /scoped scope=local rejects missing patch', async () => {

--- a/tests/daemon/api/config.test.ts
+++ b/tests/daemon/api/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { createPlanDirHandlers, handleGetConfig, handlePutScopedConfig } from '@myco/daemon/api/config';
+import { handleGetConfig, handlePutScopedConfig } from '@myco/daemon/api/config';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -64,35 +64,5 @@ describe('config API', () => {
       patch: { embedding: { provider: 'invalid-provider' } },
     });
     expect(result.status).toBe(400);
-  });
-
-  it('plan dir handlers persist the gitignore toggle and run reconciliation', async () => {
-    let reconciled = false;
-    const handlers = createPlanDirHandlers({
-      vaultDir,
-      symbiontPlanDirsByAgent: {},
-      symbiontPlanDirs: [],
-      planWatchConfig: { watchDirs: [], projectRoot: path.dirname(vaultDir) },
-      setPlanWatchConfig: () => {},
-      reconcileProjectFiles: () => { reconciled = true; },
-    });
-
-    const result = await handlers.handleUpdatePlanDirs({ body: {
-      plan_dirs: ['docs/design'],
-      ignore_plan_dirs_in_git: true,
-    } } as never);
-
-    expect(result.status).toBeUndefined();
-    expect(reconciled).toBe(true);
-    expect(result.body).toMatchObject({
-      custom: ['docs/design'],
-      ignore_plan_dirs_in_git: true,
-    });
-
-    const saved = YAML.parse(fs.readFileSync(path.join(vaultDir, 'myco.yaml'), 'utf-8')) as {
-      capture?: { plan_dirs?: string[]; ignore_plan_dirs_in_git?: boolean };
-    };
-    expect(saved.capture?.plan_dirs).toEqual(['docs/design']);
-    expect(saved.capture?.ignore_plan_dirs_in_git).toBe(true);
   });
 });

--- a/tests/daemon/config-reactions/context.test.ts
+++ b/tests/daemon/config-reactions/context.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadReactionContext } from '@myco/daemon/config-reactions/context.js';
+
+function makeLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe('loadReactionContext', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-reaction-context-'));
+    fs.writeFileSync(
+      path.join(tmpDir, 'myco.yaml'),
+      'version: 3\nembedding:\n  provider: ollama\n  model: bge-m3\nappearance:\n  theme: sage\n',
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns merged config when project and local config are valid', () => {
+    fs.writeFileSync(path.join(tmpDir, 'local.yaml'), 'appearance:\n  theme: moss\n');
+    const logger = makeLogger();
+    const ctx = loadReactionContext(tmpDir, logger);
+    expect(ctx?.appearance.theme).toBe('moss');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('returns null and warns when merged config is invalid', () => {
+    fs.writeFileSync(path.join(tmpDir, 'local.yaml'), 'daemon:\n  log_level: verbose\n');
+    const logger = makeLogger();
+    const ctx = loadReactionContext(tmpDir, logger);
+    expect(ctx).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'config-reactions',
+      expect.stringContaining('skipping reactions'),
+      expect.objectContaining({ issues: expect.any(Array) }),
+    );
+  });
+});

--- a/tests/daemon/config-reactions/registry.test.ts
+++ b/tests/daemon/config-reactions/registry.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createConfigReactionRegistry } from '@myco/daemon/config-reactions/registry.js';
+
+function makeLogger() {
+  return { error: vi.fn() };
+}
+
+describe('ConfigReactionRegistry', () => {
+  it('fires reaction when touched path matches registered prefix', async () => {
+    const r = createConfigReactionRegistry(makeLogger());
+    const fn = vi.fn();
+    r.on(['capture'], fn);
+    await r.fire(['capture.plan_dirs']);
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it('does not fire when registered prefix does not match', async () => {
+    const r = createConfigReactionRegistry(makeLogger());
+    const fn = vi.fn();
+    r.on(['capture'], fn);
+    await r.fire(['daemon.log_level']);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('treats empty prefix list as "fire always"', async () => {
+    const r = createConfigReactionRegistry(makeLogger());
+    const fn = vi.fn();
+    r.on([], fn);
+    await r.fire(['anything.at.all']);
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it('fires on exact prefix match (path === prefix)', async () => {
+    const r = createConfigReactionRegistry(makeLogger());
+    const fn = vi.fn();
+    r.on(['daemon.log_level'], fn);
+    await r.fire(['daemon.log_level']);
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it('does not match sibling paths that share a prefix substring', async () => {
+    const r = createConfigReactionRegistry(makeLogger());
+    const fn = vi.fn();
+    r.on(['daemon.log_level'], fn);
+    await r.fire(['daemon.log_level_details']);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('fires when any registered prefix matches any touched path', async () => {
+    const r = createConfigReactionRegistry(makeLogger());
+    const fn = vi.fn();
+    r.on(['capture', 'daemon.log_level'], fn);
+    await r.fire(['daemon.log_level']);
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it('runs reactions in registration order', async () => {
+    const order: number[] = [];
+    const r = createConfigReactionRegistry(makeLogger());
+    r.on([], () => { order.push(1); });
+    r.on([], () => { order.push(2); });
+    r.on([], () => { order.push(3); });
+    await r.fire(['x']);
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('awaits async reactions', async () => {
+    const r = createConfigReactionRegistry(makeLogger());
+    let done = false;
+    r.on([], async () => {
+      await new Promise((res) => setTimeout(res, 5));
+      done = true;
+    });
+    await r.fire(['x']);
+    expect(done).toBe(true);
+  });
+
+  it('logs and continues when a reaction throws', async () => {
+    const logger = makeLogger();
+    const r = createConfigReactionRegistry(logger);
+    const after = vi.fn();
+    r.on([], () => { throw new Error('boom'); });
+    r.on([], after);
+    await r.fire(['x']);
+    expect(after).toHaveBeenCalledOnce();
+    expect(logger.error).toHaveBeenCalledWith('config-reactions', expect.any(String), expect.objectContaining({ error: expect.stringContaining('boom') }));
+  });
+
+  it('fires nothing when touched paths is empty and no empty-prefix reactions', async () => {
+    const r = createConfigReactionRegistry(makeLogger());
+    const fn = vi.fn();
+    r.on(['capture'], fn);
+    await r.fire([]);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/tests/daemon/config-reactions/registry.test.ts
+++ b/tests/daemon/config-reactions/registry.test.ts
@@ -1,16 +1,27 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createConfigReactionRegistry } from '@myco/daemon/config-reactions/registry.js';
+import type { MycoConfig } from '@myco/config/schema.js';
 
 function makeLogger() {
-  return { error: vi.fn() };
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
 }
+
+// Reactions accept a MycoConfig ctx but most of these tests don't read it.
+// A bare cast keeps the fixtures small; the few tests that care about the
+// value cast a literal into MycoConfig directly.
+const ctx = {} as MycoConfig;
 
 describe('ConfigReactionRegistry', () => {
   it('fires reaction when touched path matches registered prefix', async () => {
     const r = createConfigReactionRegistry(makeLogger());
     const fn = vi.fn();
     r.on(['capture'], fn);
-    await r.fire(['capture.plan_dirs']);
+    await r.fire(['capture.plan_dirs'], ctx);
     expect(fn).toHaveBeenCalledOnce();
   });
 
@@ -18,7 +29,7 @@ describe('ConfigReactionRegistry', () => {
     const r = createConfigReactionRegistry(makeLogger());
     const fn = vi.fn();
     r.on(['capture'], fn);
-    await r.fire(['daemon.log_level']);
+    await r.fire(['daemon.log_level'], ctx);
     expect(fn).not.toHaveBeenCalled();
   });
 
@@ -26,7 +37,7 @@ describe('ConfigReactionRegistry', () => {
     const r = createConfigReactionRegistry(makeLogger());
     const fn = vi.fn();
     r.on([], fn);
-    await r.fire(['anything.at.all']);
+    await r.fire(['anything.at.all'], ctx);
     expect(fn).toHaveBeenCalledOnce();
   });
 
@@ -34,7 +45,7 @@ describe('ConfigReactionRegistry', () => {
     const r = createConfigReactionRegistry(makeLogger());
     const fn = vi.fn();
     r.on(['daemon.log_level'], fn);
-    await r.fire(['daemon.log_level']);
+    await r.fire(['daemon.log_level'], ctx);
     expect(fn).toHaveBeenCalledOnce();
   });
 
@@ -42,7 +53,7 @@ describe('ConfigReactionRegistry', () => {
     const r = createConfigReactionRegistry(makeLogger());
     const fn = vi.fn();
     r.on(['daemon.log_level'], fn);
-    await r.fire(['daemon.log_level_details']);
+    await r.fire(['daemon.log_level_details'], ctx);
     expect(fn).not.toHaveBeenCalled();
   });
 
@@ -50,7 +61,7 @@ describe('ConfigReactionRegistry', () => {
     const r = createConfigReactionRegistry(makeLogger());
     const fn = vi.fn();
     r.on(['capture', 'daemon.log_level'], fn);
-    await r.fire(['daemon.log_level']);
+    await r.fire(['daemon.log_level'], ctx);
     expect(fn).toHaveBeenCalledOnce();
   });
 
@@ -60,7 +71,7 @@ describe('ConfigReactionRegistry', () => {
     r.on([], () => { order.push(1); });
     r.on([], () => { order.push(2); });
     r.on([], () => { order.push(3); });
-    await r.fire(['x']);
+    await r.fire(['x'], ctx);
     expect(order).toEqual([1, 2, 3]);
   });
 
@@ -71,8 +82,17 @@ describe('ConfigReactionRegistry', () => {
       await new Promise((res) => setTimeout(res, 5));
       done = true;
     });
-    await r.fire(['x']);
+    await r.fire(['x'], ctx);
     expect(done).toBe(true);
+  });
+
+  it('passes the merged config to each reaction', async () => {
+    const r = createConfigReactionRegistry(makeLogger());
+    const fn = vi.fn();
+    const sharedCtx = { daemon: { log_level: 'debug' } } as unknown as MycoConfig;
+    r.on([], fn);
+    await r.fire(['daemon.log_level'], sharedCtx);
+    expect(fn).toHaveBeenCalledWith(sharedCtx);
   });
 
   it('logs and continues when a reaction throws', async () => {
@@ -81,7 +101,7 @@ describe('ConfigReactionRegistry', () => {
     const after = vi.fn();
     r.on([], () => { throw new Error('boom'); });
     r.on([], after);
-    await r.fire(['x']);
+    await r.fire(['x'], ctx);
     expect(after).toHaveBeenCalledOnce();
     expect(logger.error).toHaveBeenCalledWith('config-reactions', expect.any(String), expect.objectContaining({ error: expect.stringContaining('boom') }));
   });
@@ -90,7 +110,7 @@ describe('ConfigReactionRegistry', () => {
     const r = createConfigReactionRegistry(makeLogger());
     const fn = vi.fn();
     r.on(['capture'], fn);
-    await r.fire([]);
+    await r.fire([], ctx);
     expect(fn).not.toHaveBeenCalled();
   });
 });

--- a/tests/daemon/config-reactions/touched-paths.test.ts
+++ b/tests/daemon/config-reactions/touched-paths.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { computeTouchedPaths, enumerateLeafPaths } from '@myco/daemon/config-reactions/touched-paths.js';
+
+describe('enumerateLeafPaths', () => {
+  it('emits leaves for nested object', () => {
+    expect(enumerateLeafPaths({ capture: { plan_dirs: ['a'] } })).toEqual(['capture.plan_dirs']);
+  });
+
+  it('emits multiple leaves under one key', () => {
+    expect(enumerateLeafPaths({ a: { b: 1, c: 2 } }).sort()).toEqual(['a.b', 'a.c']);
+  });
+
+  it('treats arrays and null as leaves', () => {
+    expect(enumerateLeafPaths({ a: [1, 2], b: null }).sort()).toEqual(['a', 'b']);
+  });
+
+  it('emits nothing for empty object', () => {
+    expect(enumerateLeafPaths({})).toEqual([]);
+  });
+
+  it('emits nothing for empty nested object', () => {
+    expect(enumerateLeafPaths({ a: {} })).toEqual([]);
+  });
+});
+
+describe('computeTouchedPaths', () => {
+  it('unions patch leaves with clear entries', () => {
+    const result = computeTouchedPaths({ capture: { plan_dirs: [] } }, ['agent.provider']);
+    expect(result.sort()).toEqual(['agent.provider', 'capture.plan_dirs']);
+  });
+
+  it('deduplicates', () => {
+    const result = computeTouchedPaths({ a: { b: 1 } }, ['a.b']);
+    expect(result).toEqual(['a.b']);
+  });
+
+  it('accepts missing patch or clear', () => {
+    expect(computeTouchedPaths(undefined, ['a'])).toEqual(['a']);
+    expect(computeTouchedPaths({ a: 1 }, undefined)).toEqual(['a']);
+    expect(computeTouchedPaths(undefined, undefined)).toEqual([]);
+  });
+});

--- a/tests/daemon/logger.test.ts
+++ b/tests/daemon/logger.test.ts
@@ -56,4 +56,20 @@ describe('DaemonLogger', () => {
     expect(files.length).toBeGreaterThan(1);
     expect(files.length).toBeLessThanOrEqual(4); // daemon.log + 3 rotated
   });
+
+  it('setLevel changes the active level for subsequent writes', () => {
+    const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-logger-setlevel-'));
+    try {
+      const logger = new DaemonLogger(logDir, { level: 'info' });
+      logger.debug('test', 'should-be-dropped');
+      logger.setLevel('debug');
+      logger.debug('test', 'should-appear');
+      const logFile = path.join(logDir, 'daemon.log');
+      const contents = fs.readFileSync(logFile, 'utf-8');
+      expect(contents).not.toContain('should-be-dropped');
+      expect(contents).toContain('should-appear');
+    } finally {
+      fs.rmSync(logDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/daemon/plan-watch-reaction.test.ts
+++ b/tests/daemon/plan-watch-reaction.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { createPlanWatchReaction } from '@myco/daemon/plan-watch-reaction.js';
+import type { PlanWatchConfig } from '@myco/daemon/plan-capture.js';
+
+describe('createPlanWatchReaction', () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-planwatch-'));
+    fs.writeFileSync(path.join(tmpDir, 'myco.yaml'),
+      `version: 3\ncapture:\n  plan_dirs:\n    - /custom/a\n`);
+  });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('mutates planWatchConfig.watchDirs in place so closure consumers see updates', () => {
+    const planWatchConfig: PlanWatchConfig = {
+      projectRoot: tmpDir,
+      watchDirs: ['/symbiont/x'],
+      recentBatchWindowMs: 5000,
+    };
+    const consumer = planWatchConfig; // simulates event-dispatch closure
+
+    const reaction = createPlanWatchReaction({
+      vaultDir: tmpDir,
+      symbiontPlanDirs: ['/symbiont/x'],
+      planWatchConfig,
+    });
+    reaction();
+
+    // Mutation in place — consumer sees the update without being passed a new ref.
+    expect(consumer.watchDirs).toContain('/symbiont/x');
+    expect(consumer.watchDirs).toContain('/custom/a');
+  });
+
+  it('deduplicates overlap between symbiont dirs and custom dirs', () => {
+    fs.writeFileSync(path.join(tmpDir, 'myco.yaml'),
+      `version: 3\ncapture:\n  plan_dirs:\n    - /symbiont/x\n    - /custom/a\n`);
+    const planWatchConfig: PlanWatchConfig = {
+      projectRoot: tmpDir,
+      watchDirs: [],
+      recentBatchWindowMs: 5000,
+    };
+    const reaction = createPlanWatchReaction({
+      vaultDir: tmpDir,
+      symbiontPlanDirs: ['/symbiont/x'],
+      planWatchConfig,
+    });
+    reaction();
+    expect(planWatchConfig.watchDirs.filter((d) => d === '/symbiont/x')).toHaveLength(1);
+  });
+
+  it('swallows loadConfig errors (malformed yaml during reconcile should not throw)', () => {
+    fs.writeFileSync(path.join(tmpDir, 'myco.yaml'), '::: not yaml');
+    const planWatchConfig: PlanWatchConfig = {
+      projectRoot: tmpDir,
+      watchDirs: ['/symbiont/x'],
+      recentBatchWindowMs: 5000,
+    };
+    const reaction = createPlanWatchReaction({
+      vaultDir: tmpDir,
+      symbiontPlanDirs: ['/symbiont/x'],
+      planWatchConfig,
+    });
+    expect(() => reaction()).not.toThrow();
+    // watchDirs unchanged on failure
+    expect(planWatchConfig.watchDirs).toEqual(['/symbiont/x']);
+  });
+});

--- a/tests/daemon/plan-watch-reaction.test.ts
+++ b/tests/daemon/plan-watch-reaction.test.ts
@@ -49,7 +49,26 @@ describe('createPlanWatchReaction', () => {
     expect(planWatchConfig.watchDirs.filter((d) => d === '/symbiont/x')).toHaveLength(1);
   });
 
-  it('swallows loadConfig errors (malformed yaml during reconcile should not throw)', () => {
+  it('picks up plan_dirs from local overlay (merged config, not project-only)', () => {
+    // Project has no custom plan dirs; local overlay adds one.
+    fs.writeFileSync(path.join(tmpDir, 'myco.yaml'),
+      `version: 3\ncapture:\n  plan_dirs: []\n`);
+    fs.writeFileSync(path.join(tmpDir, 'local.yaml'),
+      `capture:\n  plan_dirs:\n    - /local/override\n`);
+    const planWatchConfig: PlanWatchConfig = {
+      projectRoot: tmpDir,
+      watchDirs: [],
+    };
+    const reaction = createPlanWatchReaction({
+      vaultDir: tmpDir,
+      symbiontPlanDirs: [],
+      planWatchConfig,
+    });
+    reaction();
+    expect(planWatchConfig.watchDirs).toContain('/local/override');
+  });
+
+  it('swallows loadMergedConfig errors (malformed yaml during reconcile should not throw)', () => {
     fs.writeFileSync(path.join(tmpDir, 'myco.yaml'), '::: not yaml');
     const planWatchConfig: PlanWatchConfig = {
       projectRoot: tmpDir,

--- a/tests/daemon/plan-watch-reaction.test.ts
+++ b/tests/daemon/plan-watch-reaction.test.ts
@@ -1,86 +1,53 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import fs from 'node:fs';
-import path from 'node:path';
-import os from 'node:os';
+import { describe, it, expect } from 'vitest';
 import { createPlanWatchReaction } from '@myco/daemon/plan-watch-reaction.js';
 import type { PlanWatchConfig } from '@myco/daemon/plan-capture.js';
+import type { MycoConfig } from '@myco/config/schema.js';
+
+function ctxWithPlanDirs(planDirs: string[]): MycoConfig {
+  return { capture: { plan_dirs: planDirs } } as unknown as MycoConfig;
+}
 
 describe('createPlanWatchReaction', () => {
-  let tmpDir: string;
-  beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-planwatch-'));
-    fs.writeFileSync(path.join(tmpDir, 'myco.yaml'),
-      `version: 3\ncapture:\n  plan_dirs:\n    - /custom/a\n`);
-  });
-  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
-
   it('mutates planWatchConfig.watchDirs in place so closure consumers see updates', () => {
     const planWatchConfig: PlanWatchConfig = {
-      projectRoot: tmpDir,
+      projectRoot: '/tmp/project',
       watchDirs: ['/symbiont/x'],
     };
     const consumer = planWatchConfig; // simulates event-dispatch closure
 
     const reaction = createPlanWatchReaction({
-      vaultDir: tmpDir,
       symbiontPlanDirs: ['/symbiont/x'],
       planWatchConfig,
     });
-    reaction();
+    reaction(ctxWithPlanDirs(['/custom/a']));
 
-    // Mutation in place — consumer sees the update without being passed a new ref.
     expect(consumer.watchDirs).toContain('/symbiont/x');
     expect(consumer.watchDirs).toContain('/custom/a');
   });
 
   it('deduplicates overlap between symbiont dirs and custom dirs', () => {
-    fs.writeFileSync(path.join(tmpDir, 'myco.yaml'),
-      `version: 3\ncapture:\n  plan_dirs:\n    - /symbiont/x\n    - /custom/a\n`);
     const planWatchConfig: PlanWatchConfig = {
-      projectRoot: tmpDir,
+      projectRoot: '/tmp/project',
       watchDirs: [],
     };
     const reaction = createPlanWatchReaction({
-      vaultDir: tmpDir,
       symbiontPlanDirs: ['/symbiont/x'],
       planWatchConfig,
     });
-    reaction();
+    reaction(ctxWithPlanDirs(['/symbiont/x', '/custom/a']));
     expect(planWatchConfig.watchDirs.filter((d) => d === '/symbiont/x')).toHaveLength(1);
   });
 
-  it('picks up plan_dirs from local overlay (merged config, not project-only)', () => {
-    // Project has no custom plan dirs; local overlay adds one.
-    fs.writeFileSync(path.join(tmpDir, 'myco.yaml'),
-      `version: 3\ncapture:\n  plan_dirs: []\n`);
-    fs.writeFileSync(path.join(tmpDir, 'local.yaml'),
-      `capture:\n  plan_dirs:\n    - /local/override\n`);
+  it('handles missing plan_dirs (undefined -> empty)', () => {
     const planWatchConfig: PlanWatchConfig = {
-      projectRoot: tmpDir,
-      watchDirs: [],
+      projectRoot: '/tmp/project',
+      watchDirs: ['stale'],
     };
     const reaction = createPlanWatchReaction({
-      vaultDir: tmpDir,
-      symbiontPlanDirs: [],
-      planWatchConfig,
-    });
-    reaction();
-    expect(planWatchConfig.watchDirs).toContain('/local/override');
-  });
-
-  it('propagates load errors (registry is responsible for error isolation)', () => {
-    fs.writeFileSync(path.join(tmpDir, 'myco.yaml'), '::: not yaml');
-    const planWatchConfig: PlanWatchConfig = {
-      projectRoot: tmpDir,
-      watchDirs: ['/symbiont/x'],
-    };
-    const reaction = createPlanWatchReaction({
-      vaultDir: tmpDir,
       symbiontPlanDirs: ['/symbiont/x'],
       planWatchConfig,
     });
-    expect(() => reaction()).toThrow();
-    // watchDirs unchanged because the throw happened before the assignment.
+    reaction({ capture: {} } as unknown as MycoConfig);
     expect(planWatchConfig.watchDirs).toEqual(['/symbiont/x']);
   });
 });

--- a/tests/daemon/plan-watch-reaction.test.ts
+++ b/tests/daemon/plan-watch-reaction.test.ts
@@ -18,7 +18,6 @@ describe('createPlanWatchReaction', () => {
     const planWatchConfig: PlanWatchConfig = {
       projectRoot: tmpDir,
       watchDirs: ['/symbiont/x'],
-      recentBatchWindowMs: 5000,
     };
     const consumer = planWatchConfig; // simulates event-dispatch closure
 
@@ -40,7 +39,6 @@ describe('createPlanWatchReaction', () => {
     const planWatchConfig: PlanWatchConfig = {
       projectRoot: tmpDir,
       watchDirs: [],
-      recentBatchWindowMs: 5000,
     };
     const reaction = createPlanWatchReaction({
       vaultDir: tmpDir,
@@ -56,7 +54,6 @@ describe('createPlanWatchReaction', () => {
     const planWatchConfig: PlanWatchConfig = {
       projectRoot: tmpDir,
       watchDirs: ['/symbiont/x'],
-      recentBatchWindowMs: 5000,
     };
     const reaction = createPlanWatchReaction({
       vaultDir: tmpDir,

--- a/tests/daemon/plan-watch-reaction.test.ts
+++ b/tests/daemon/plan-watch-reaction.test.ts
@@ -68,7 +68,7 @@ describe('createPlanWatchReaction', () => {
     expect(planWatchConfig.watchDirs).toContain('/local/override');
   });
 
-  it('swallows loadMergedConfig errors (malformed yaml during reconcile should not throw)', () => {
+  it('propagates load errors (registry is responsible for error isolation)', () => {
     fs.writeFileSync(path.join(tmpDir, 'myco.yaml'), '::: not yaml');
     const planWatchConfig: PlanWatchConfig = {
       projectRoot: tmpDir,
@@ -79,8 +79,8 @@ describe('createPlanWatchReaction', () => {
       symbiontPlanDirs: ['/symbiont/x'],
       planWatchConfig,
     });
-    expect(() => reaction()).not.toThrow();
-    // watchDirs unchanged on failure
+    expect(() => reaction()).toThrow();
+    // watchDirs unchanged because the throw happened before the assignment.
     expect(planWatchConfig.watchDirs).toEqual(['/symbiont/x']);
   });
 });

--- a/tests/daemon/plan-watch-reaction.test.ts
+++ b/tests/daemon/plan-watch-reaction.test.ts
@@ -4,7 +4,12 @@ import type { PlanWatchConfig } from '@myco/daemon/plan-capture.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 
 function ctxWithPlanDirs(planDirs: string[]): MycoConfig {
-  return { capture: { plan_dirs: planDirs } } as unknown as MycoConfig;
+  return {
+    capture: {
+      plan_dirs: planDirs,
+      artifact_extensions: ['.md'],
+    },
+  } as unknown as MycoConfig;
 }
 
 describe('createPlanWatchReaction', () => {
@@ -42,12 +47,34 @@ describe('createPlanWatchReaction', () => {
     const planWatchConfig: PlanWatchConfig = {
       projectRoot: '/tmp/project',
       watchDirs: ['stale'],
+      extensions: ['.txt'],
     };
     const reaction = createPlanWatchReaction({
       symbiontPlanDirs: ['/symbiont/x'],
       planWatchConfig,
     });
-    reaction({ capture: {} } as unknown as MycoConfig);
+    reaction({ capture: { artifact_extensions: ['.md'] } } as unknown as MycoConfig);
     expect(planWatchConfig.watchDirs).toEqual(['/symbiont/x']);
+    expect(planWatchConfig.extensions).toEqual(['.md']);
+  });
+
+  it('refreshes artifact extensions alongside watch dirs', () => {
+    const planWatchConfig: PlanWatchConfig = {
+      projectRoot: '/tmp/project',
+      watchDirs: ['/symbiont/x'],
+      extensions: ['.txt'],
+    };
+    const reaction = createPlanWatchReaction({
+      symbiontPlanDirs: ['/symbiont/x'],
+      planWatchConfig,
+    });
+    reaction({
+      capture: {
+        plan_dirs: ['/custom/a'],
+        artifact_extensions: ['.md', '.yaml'],
+      },
+    } as unknown as MycoConfig);
+    expect(planWatchConfig.watchDirs).toEqual(['/symbiont/x', '/custom/a']);
+    expect(planWatchConfig.extensions).toEqual(['.md', '.yaml']);
   });
 });

--- a/tests/daemon/power-jobs.test.ts
+++ b/tests/daemon/power-jobs.test.ts
@@ -288,4 +288,31 @@ describe('log-retention power job', () => {
     const rows = getLogTail(50).entries;
     expect(rows.some((r) => r.message === 'old-entry')).toBe(true);
   });
+
+  it('honors local.yaml overrides for log_retention_days (merged config)', async () => {
+    registerPowerJobs(pm as never, buildDeps());
+
+    // Project config keeps retention=7; local overlay raises to 30.
+    fs.writeFileSync(path.join(tmpDir, 'local.yaml'),
+      `daemon:\n  log_retention_days: 30\n`);
+
+    const FOURTEEN_DAYS_AGO = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
+    insertLogEntry({
+      timestamp: FOURTEEN_DAYS_AGO,
+      level: 'info',
+      kind: 'test',
+      component: 'test',
+      message: 'overlay-entry',
+      data: null,
+      session_id: null,
+    });
+
+    await pm.find('log-retention').fn();
+
+    const { getLogTail } = await import('@myco/db/queries/logs');
+    const rows = getLogTail(50).entries;
+    // With merged config the overlay wins (30 days retention) and the 14-day-old entry survives.
+    // With project-only the stale 7-day retention would delete it.
+    expect(rows.some((r) => r.message === 'overlay-entry')).toBe(true);
+  });
 });

--- a/tests/daemon/power-jobs.test.ts
+++ b/tests/daemon/power-jobs.test.ts
@@ -222,3 +222,70 @@ describe('registerPowerJobs — staging-gc', () => {
     expect(fs.existsSync(path.resolve(stagingRoot(vaultDir), 'cand-b'))).toBe(true);
   });
 });
+
+describe('log-retention power job', () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let pm: FakePowerManager;
+  let databaseManager: DatabaseMaintenanceManager;
+  let logger: DaemonLogger;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-pj-retain-'));
+    dbPath = path.join(tmpDir, 'myco.db');
+    initDatabase(dbPath);
+    createSchema(getDatabase());
+    logger = new DaemonLogger(path.join(tmpDir, 'logs'));
+    databaseManager = new DatabaseMaintenanceManager(dbPath, tmpDir, logger);
+    pm = new FakePowerManager();
+    // Seed initial myco.yaml with retention=7
+    fs.writeFileSync(path.join(tmpDir, 'myco.yaml'),
+      `version: 3\ndaemon:\n  log_retention_days: 7\n`);
+  });
+
+  afterEach(() => {
+    logger.close();
+    closeDatabase();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function buildDeps() {
+    return {
+      embeddingManager: { reconcile: async () => ({ embedded: 0, stale_reembedded: 0, orphans_cleaned: 0, duration_ms: 0 }) } as never,
+      registry: { listActive: () => [], sessions: [] } as never,
+      logger: logger as never,
+      config: { daemon: { log_retention_days: 7 }, backup: {}, maintenance: { auto_optimize: false, auto_optimize_interval_hours: 24 } } as never,
+      db: getDatabase(),
+      backupDir: path.join(tmpDir, 'backups'),
+      machineId: 'test-machine',
+      vaultDir: tmpDir,
+      databaseManager,
+    };
+  }
+
+  it('reads log_retention_days fresh from disk on each run', async () => {
+    registerPowerJobs(pm as never, buildDeps());
+
+    // Insert a log entry dated 14 days ago — would be deleted with retention=7.
+    const FOURTEEN_DAYS_AGO = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
+    insertLogEntry({
+      timestamp: FOURTEEN_DAYS_AGO,
+      level: 'info',
+      kind: 'test',
+      component: 'test',
+      message: 'old-entry',
+      data: null,
+      session_id: null,
+    });
+
+    // Update yaml to retention=30. The job, if fresh-reading, should use 30 and keep the entry.
+    fs.writeFileSync(path.join(tmpDir, 'myco.yaml'),
+      `version: 3\ndaemon:\n  log_retention_days: 30\n`);
+
+    await pm.find('log-retention').fn();
+
+    const { getLogTail } = await import('@myco/db/queries/logs');
+    const rows = getLogTail(50).entries;
+    expect(rows.some((r) => r.message === 'old-entry')).toBe(true);
+  });
+});

--- a/tests/notifications/notify.test.ts
+++ b/tests/notifications/notify.test.ts
@@ -71,4 +71,30 @@ describe('notify', () => {
       mode: 'banner',
     });
   });
+
+  it('uses the migrated settings-domain banner default over the global summary mode', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'myco.yaml'),
+      [
+        'version: 3',
+        'config_version: 4',
+        'notifications:',
+        '  default_mode: summary',
+        '',
+      ].join('\n'),
+    );
+
+    const id = notify(tmpDir, {
+      domain: 'settings',
+      type: 'settings.saved',
+      title: 'Settings saved',
+    });
+
+    expect(id).toBeTruthy();
+    expect(getNotification(id!)).toMatchObject({
+      domain: 'settings',
+      type: 'settings.saved',
+      mode: 'banner',
+    });
+  });
 });

--- a/tests/ui/scoped-field.test.tsx
+++ b/tests/ui/scoped-field.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ScopedField } from '../../packages/myco/ui/src/components/config/ScopedField';
+import type { MycoConfig } from '../../packages/myco/ui/src/hooks/use-config';
+
+const useScopedConfigMock = vi.fn();
+
+vi.mock('../../packages/myco/ui/src/hooks/use-scoped-config', () => ({
+  useScopedConfig: () => useScopedConfigMock(),
+}));
+
+vi.mock('../../packages/myco/ui/src/components/config/restart-gate', () => ({
+  useMarkRestartDirty: () => vi.fn(),
+}));
+
+const baseConfig: MycoConfig = {
+  version: 3,
+  config_version: 5,
+  embedding: {
+    provider: 'ollama',
+    model: 'bge-m3',
+  },
+  daemon: {
+    port: null,
+    log_level: 'info',
+    log_retention_days: 30,
+  },
+  maintenance: {
+    auto_optimize: true,
+    auto_optimize_interval_hours: 24,
+  },
+  capture: {
+    transcript_paths: [],
+    plan_dirs: [],
+    artifact_extensions: ['md'],
+    buffer_max_events: 1000,
+    ignore_plan_dirs_in_git: false,
+  },
+  agent: {
+    summary_batch_interval: 5,
+  },
+  context: {
+    digest_tier: 5000,
+    prompt_search: true,
+    prompt_max_spores: 3,
+  },
+  backup: {},
+  appearance: {
+    theme: 'sage',
+    mode: 'dark',
+    font: 'default',
+    density: 'normal',
+  },
+  notifications: {
+    enabled: true,
+    system_notifications: false,
+    default_mode: 'summary',
+    domains: {
+      settings: {
+        enabled: true,
+        mode: 'banner',
+      },
+    },
+  },
+};
+
+describe('ScopedField scope badges', () => {
+  beforeEach(() => {
+    useScopedConfigMock.mockReturnValue({
+      effective: baseConfig,
+      local: {},
+      setField: vi.fn().mockResolvedValue(undefined),
+      resetField: vi.fn().mockResolvedValue(undefined),
+      promoteField: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  it('shows a project badge when a field has no local override', () => {
+    render(
+      <ScopedField path="context.prompt_search" label="Prompt Search" defaultScope="project">
+        {() => <div>control</div>}
+      </ScopedField>,
+    );
+
+    expect(screen.getByText('Project')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Personal' })).not.toBeInTheDocument();
+  });
+
+  it('shows the personal pill when a field has a local override', () => {
+    useScopedConfigMock.mockReturnValue({
+      effective: {
+        ...baseConfig,
+        context: {
+          prompt_search: false,
+        },
+      },
+      local: {
+        context: {
+          prompt_search: false,
+        },
+      },
+      setField: vi.fn().mockResolvedValue(undefined),
+      resetField: vi.fn().mockResolvedValue(undefined),
+      promoteField: vi.fn().mockResolvedValue(undefined),
+    });
+
+    render(
+      <ScopedField path="context.prompt_search" label="Prompt Search" defaultScope="project">
+        {() => <div>control</div>}
+      </ScopedField>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Personal' })).toBeInTheDocument();
+  });
+});

--- a/tests/ui/system-notifications.test.tsx
+++ b/tests/ui/system-notifications.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SystemNotifications } from '../../packages/myco/ui/src/components/notifications/SystemNotifications';
+
+const useNotificationsMock = vi.fn();
+const useScopedConfigMock = vi.fn();
+
+vi.mock('../../packages/myco/ui/src/hooks/use-notifications', () => ({
+  useLiveNotifications: () => useNotificationsMock(),
+}));
+
+vi.mock('../../packages/myco/ui/src/hooks/use-scoped-config', () => ({
+  useScopedConfig: () => useScopedConfigMock(),
+}));
+
+describe('SystemNotifications', () => {
+  beforeEach(() => {
+    useNotificationsMock.mockReset();
+    useScopedConfigMock.mockReset();
+    useScopedConfigMock.mockReturnValue({
+      effective: {
+        notifications: {
+          system_notifications: true,
+        },
+      },
+    });
+  });
+
+  it('refetches banner notifications when the window loses focus', () => {
+    const refetch = vi.fn();
+    useNotificationsMock.mockReturnValue({
+      data: { items: [] },
+      refetch,
+    });
+
+    Object.defineProperty(window, 'Notification', {
+      configurable: true,
+      value: { permission: 'granted' },
+    });
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: true,
+    });
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+
+    render(<SystemNotifications />);
+    window.dispatchEvent(new Event('blur'));
+
+    expect(refetch).toHaveBeenCalled();
+  });
+});

--- a/tests/ui/system-notifications.test.tsx
+++ b/tests/ui/system-notifications.test.tsx
@@ -8,7 +8,7 @@ const useNotificationsMock = vi.fn();
 const useScopedConfigMock = vi.fn();
 
 vi.mock('../../packages/myco/ui/src/hooks/use-notifications', () => ({
-  useLiveNotifications: () => useNotificationsMock(),
+  useNotifications: () => useNotificationsMock(),
 }));
 
 vi.mock('../../packages/myco/ui/src/hooks/use-scoped-config', () => ({

--- a/tests/ui/use-scoped-config.test.tsx
+++ b/tests/ui/use-scoped-config.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useScopedConfig } from '../../packages/myco/ui/src/hooks/use-scoped-config';
+
+const invalidateQueriesMock = vi.fn();
+const writeScopedConfigMock = vi.fn();
+const clearLocalConfigKeysMock = vi.fn();
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: vi.fn(({ queryKey }: { queryKey: readonly string[] }) => ({
+    data: queryKey[1] === 'merged'
+      ? {
+          notifications: { enabled: true, system_notifications: false, default_mode: 'summary', domains: {} },
+          context: { prompt_search: true },
+        }
+      : {},
+    isLoading: false,
+  })),
+  useQueryClient: () => ({
+    invalidateQueries: invalidateQueriesMock,
+  }),
+}));
+
+vi.mock('../../packages/myco/ui/src/lib/api', () => ({
+  fetchMergedConfig: vi.fn(),
+  fetchLocalConfig: vi.fn(),
+  writeScopedConfig: (...args: unknown[]) => writeScopedConfigMock(...args),
+  clearLocalConfigKeys: (...args: unknown[]) => clearLocalConfigKeysMock(...args),
+}));
+
+describe('useScopedConfig', () => {
+  beforeEach(() => {
+    invalidateQueriesMock.mockReset();
+    writeScopedConfigMock.mockReset();
+    clearLocalConfigKeysMock.mockReset();
+    writeScopedConfigMock.mockResolvedValue(undefined);
+    clearLocalConfigKeysMock.mockResolvedValue(undefined);
+  });
+
+  it('invalidates notification queries after a settings write', async () => {
+    const { result } = renderHook(() => useScopedConfig());
+
+    await act(async () => {
+      await result.current.setField('context.prompt_search', false, 'project');
+    });
+
+    expect(writeScopedConfigMock).toHaveBeenCalledWith('project', {
+      context: { prompt_search: false },
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({ queryKey: ['notifications'] });
+  });
+});


### PR DESCRIPTION
## Summary

This pull request tightens the new scoped-config save path and makes the Settings autosave UX actually visible in real time.

It includes:

- scoped config API hardening for invalid scope values, malformed `clear` payloads, and invalid local overlay writes
- config reaction fixes for live daemon updates, config reload fallback handling, and runtime executor debug flag updates
- a new `settings` notification domain with field-specific save notifications and deep links back to the relevant Settings section
- UI fixes for scope badges, notification banners, unread indicators, and live notification refresh after autosave without needing a browser reload
- the generated Myco skill updates that landed alongside this feature work

## Testing

- `pnpm vitest run tests/ui/use-scoped-config.test.tsx tests/ui/system-notifications.test.tsx tests/ui/scoped-field.test.tsx`
- `pnpm tsc --noEmit`
- `make build`
- `myco-dev restart`