### PR TITLE
Fix Codex MCP vault resolution and session capture

### DIFF
--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import fs from 'node:fs';
 import { TranscriptMiner, extractTurnsFromBuffer } from '@myco/capture/transcript-miner.js';
 import type { TranscriptTurn } from '@myco/symbionts/adapter.js';
+import { loadManifests } from '@myco/symbionts/detect.js';
 import { captureBatchImages } from './capture-images.js';
 import { extractTaggedPlans, capturePlan, TRANSCRIPT_SOURCE_PREFIX } from './plan-capture.js';
 import {
@@ -20,7 +21,7 @@ import {
   listBatchesBySession,
   findBatchByPromptPrefix,
 } from '@myco/db/queries/batches.js';
-import { getSession, updateSession } from '@myco/db/queries/sessions.js';
+import { deleteSessionCascade, getSession, updateSession } from '@myco/db/queries/sessions.js';
 import { detectSkillUsage, SKILL_USAGE_DETECTION_ENABLED } from './skill-usage.js';
 import { epochSeconds, LOG_MESSAGE_PREVIEW_CHARS } from '@myco/constants.js';
 import { TITLE_PREVIEW_CHARS } from './event-handlers.js';
@@ -33,6 +34,9 @@ import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { triggerTitleSummary as sharedTriggerTitleSummary } from './trigger-title-summary.js';
 import type { RouteHandler } from './router.js';
 import type { RegisteredSession } from './lifecycle.js';
+import { evaluateSessionCaptureRules } from '@myco/hooks/capture-rules.js';
+import { readTranscriptMeta } from '@myco/hooks/transcript-meta.js';
+import { cleanupAfterSessionCascade } from './jobs/session-cleanup.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -113,6 +117,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
   // that case as a silent no-op rather than erroring.
   const StopBody = z.object({
     session_id: z.string(),
+    agent: z.string().optional(),
     user: z.string().optional(),
     transcript_path: z.string().nullish(),
     last_assistant_message: z.string().nullish(),
@@ -120,6 +125,18 @@ export function createStopProcessor(deps: StopProcessorDeps): {
 
   const triggerTitleSummary = (sessionId: string) =>
     sharedTriggerTitleSummary(sessionId, { vaultDir, embeddingManager, config, logger });
+
+  function cleanupInvalidCapturedSession(sessionId: string): boolean {
+    registry.unregister(sessionId);
+    sessionBuffers.delete(sessionId);
+    sessionTitleCache.delete(sessionId);
+
+    const result = deleteSessionCascade(sessionId);
+    if (!result.deleted) return false;
+
+    cleanupAfterSessionCascade(sessionId, result, embeddingManager, vaultDir).catch(() => {});
+    return true;
+  }
 
   async function processStopEvent(
     sessionId: string,
@@ -349,7 +366,31 @@ export function createStopProcessor(deps: StopProcessorDeps): {
   }
 
   const handleStopRoute: RouteHandler = async (req) => {
-    const { session_id: sessionId, user, transcript_path: hookTranscriptPath, last_assistant_message: lastAssistantMessage } = StopBody.parse(req.body);
+    const {
+      session_id: sessionId,
+      agent,
+      user,
+      transcript_path: hookTranscriptPath,
+      last_assistant_message: lastAssistantMessage,
+    } = StopBody.parse(req.body);
+
+    if (hookTranscriptPath) {
+      const transcriptMeta = readTranscriptMeta(hookTranscriptPath) ?? undefined;
+      const detectedAgent = agent ?? getSession(sessionId)?.agent ?? 'claude-code';
+      const decision = evaluateSessionCaptureRules(loadManifests(), detectedAgent, {
+        transcriptPath: hookTranscriptPath,
+        transcriptMeta,
+      });
+      if (decision.action === 'drop') {
+        const deleted = cleanupInvalidCapturedSession(sessionId);
+        logger.info(LOG_KINDS.HOOKS_STOP, 'Stop ignored — invalid captured session', {
+          session_id: sessionId,
+          reason: decision.reason ?? 'rule',
+          deleted_existing_session: deleted,
+        });
+        return { body: { ok: true, ignored: decision.reason ?? 'rule' } };
+      }
+    }
 
     // Ephemeral sub-invocation guard.
     //

--- a/packages/myco/src/hooks/capture-rules.ts
+++ b/packages/myco/src/hooks/capture-rules.ts
@@ -46,7 +46,7 @@ export type UserPromptDecision =
   | { action: 'rewrite'; prompt: string; reason?: string }
   | { action: 'drop'; reason?: string };
 
-/** Outcome of evaluating session_start rules. No rewrite — there's no prompt text yet. */
+/** Outcome of evaluating session capture rules. No rewrite — there's no prompt text yet. */
 export type SessionStartDecision =
   | { action: 'pass' }
   | { action: 'drop'; reason?: string };
@@ -110,6 +110,23 @@ export function evaluateSessionStartRules(
     }
   }
   return { action: 'pass' };
+}
+
+/**
+ * Evaluate whether a session should be materialized at a lifecycle boundary.
+ *
+ * SessionStart uses this before registering a session row. Stop processing uses
+ * the same decision before transcript-backed capture or stop-driven
+ * auto-registration. Keeping both boundaries on the same manifest-driven
+ * evaluator makes the rule sustainable for every symbiont, not just the one
+ * that first exposed the gap.
+ */
+export function evaluateSessionCaptureRules(
+  manifests: SymbiontManifest[],
+  detectedAgent: string,
+  ctx: SessionStartRuleContext,
+): SessionStartDecision {
+  return evaluateSessionStartRules(manifests, detectedAgent, ctx);
 }
 
 function scopePermits(rule: CaptureRule, owningAgent: string, detectedAgent: string): boolean {

--- a/packages/myco/src/hooks/session-start.ts
+++ b/packages/myco/src/hooks/session-start.ts
@@ -1,7 +1,7 @@
 import { DaemonClient } from './client.js';
 import { readStdin } from './read-stdin.js';
 import { normalizeHookInput } from './normalize.js';
-import { evaluateSessionStartRules } from './capture-rules.js';
+import { evaluateSessionCaptureRules } from './capture-rules.js';
 import { readTranscriptMeta } from './transcript-meta.js';
 import { loadManifests } from '../symbionts/detect.js';
 import { loadConfig } from '../config/loader.js';
@@ -28,7 +28,7 @@ export async function main() {
     // Read the transcript's session_meta for rules that inspect it
     // (e.g., detecting sub-agent thread spawns via source.subagent).
     const transcriptMeta = transcriptPath ? readTranscriptMeta(transcriptPath) : undefined;
-    const decision = evaluateSessionStartRules(loadManifests(), agent, {
+    const decision = evaluateSessionCaptureRules(loadManifests(), agent, {
       transcriptPath,
       transcriptMeta: transcriptMeta ?? undefined,
     });

--- a/packages/myco/src/symbionts/installer.ts
+++ b/packages/myco/src/symbionts/installer.ts
@@ -51,6 +51,8 @@ const CANONICAL_SKILLS_DIR = '.agents/skills';
 
 /** MCP server name used by Myco in all symbiont configurations. */
 export const MYCO_MCP_SERVER_NAME = 'myco';
+const MCP_ENV_PROJECT_ROOT_TOKEN = '{projectRoot}';
+const MCP_ENV_VAULT_DIR_TOKEN = '{vaultDir}';
 
 /**
  * Marker substring written into plugin-file hook templates (e.g., opencode's plugin.ts).
@@ -856,7 +858,7 @@ export class SymbiontInstaller {
     const reg = this.manifest.registration;
     if (!reg?.mcpTarget) return false;
 
-    const template = this.loadTemplate('mcp');
+    const template = this.buildMcpTemplate(this.loadTemplate('mcp'));
     if (!template) return false;
 
     const targetPath = path.join(this.projectRoot, reg.mcpTarget);
@@ -864,6 +866,52 @@ export class SymbiontInstaller {
       return this.installMcpToml(targetPath, template);
     }
     return this.installMcpJson(targetPath, template);
+  }
+
+  private buildMcpTemplate(
+    template: Record<string, unknown> | null,
+  ): Record<string, unknown> | null {
+    if (!template) return null;
+
+    const resolvedEnv = this.resolveMcpEnv();
+    if (Object.keys(resolvedEnv).length === 0) return template;
+
+    return Object.fromEntries(
+      Object.entries(template).map(([name, def]) => {
+        if (!def || typeof def !== 'object' || Array.isArray(def)) return [name, def];
+        const server = def as Record<string, unknown>;
+        const existingEnv = (
+          server.env && typeof server.env === 'object' && !Array.isArray(server.env)
+            ? server.env
+            : {}
+        ) as Record<string, unknown>;
+        return [
+          name,
+          {
+            ...server,
+            env: {
+              ...existingEnv,
+              ...resolvedEnv,
+            },
+          },
+        ];
+      }),
+    );
+  }
+
+  private resolveMcpEnv(): Record<string, string> {
+    const entries = Object.entries(this.manifest.registration?.mcpEnv ?? {});
+    if (entries.length === 0) return {};
+
+    const vaultDir = path.join(this.projectRoot, '.myco');
+    return Object.fromEntries(
+      entries.map(([key, value]) => [
+        key,
+        value
+          .replaceAll(MCP_ENV_PROJECT_ROOT_TOKEN, this.projectRoot)
+          .replaceAll(MCP_ENV_VAULT_DIR_TOKEN, vaultDir),
+      ]),
+    );
   }
 
   /**

--- a/packages/myco/src/symbionts/manifest-schema.ts
+++ b/packages/myco/src/symbionts/manifest-schema.ts
@@ -29,8 +29,11 @@ import { z } from 'zod';
  *
  * Events:
  *   - `session_start`: fires on SessionStart, before any prompts or
- *     tools are captured. The right place to catch ephemeral sub-
- *     invocations so they're never registered as sessions at all.
+ *     tools are captured. The same rules are also reusable at later
+ *     lifecycle boundaries that could still materialize a session row
+ *     (for example, transcript-backed stop processing after a missed
+ *     SessionStart). This is the durable "session capture rules"
+ *     contract for every symbiont.
  *   - `user_prompt`: fires on UserPromptSubmit. Safety net for anything
  *     that slips past session_start, and the only layer where
  *     `rewrite_prompt` makes sense (prompt text doesn't exist until
@@ -102,6 +105,12 @@ const RegistrationSchema = z.object({
   pluginPackageTarget: z.string().optional(),
   mcpTarget: z.string().optional(),
   mcpFormat: z.enum(['json', 'toml']).default('json'),
+  /**
+   * Optional env vars injected into the Myco MCP server entry. Values may use
+   * `{projectRoot}` and `{vaultDir}` placeholders so symbionts whose MCP child
+   * starts outside the repo can still anchor Myco to the correct project.
+   */
+  mcpEnv: z.record(z.string(), z.string()).default({}),
   /**
    * JSON key under which MCP server entries are stored in the MCP config file.
    * Defaults to 'mcpServers' (used by Claude Code, Cursor, etc.). opencode uses 'mcp'.

--- a/packages/myco/src/symbionts/manifests/codex.yaml
+++ b/packages/myco/src/symbionts/manifests/codex.yaml
@@ -100,6 +100,8 @@ registration:
   hooksTarget: .codex/hooks.json
   mcpTarget: .codex/config.toml
   mcpFormat: toml
+  mcpEnv:
+    MYCO_PROJECT_ROOT: "{projectRoot}"
   skillsTarget: .agents/skills
   settingsTarget: .codex/config.toml
   settingsFormat: toml

--- a/packages/myco/src/vault/resolve.ts
+++ b/packages/myco/src/vault/resolve.ts
@@ -1,6 +1,9 @@
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 
+export const MYCO_PROJECT_ROOT_ENV = 'MYCO_PROJECT_ROOT';
+export const MYCO_VAULT_DIR_ENV = 'MYCO_VAULT_DIR';
+
 /**
  * Resolve the vault directory.
  *
@@ -9,10 +12,29 @@ import { execFileSync } from 'node:child_process';
  *
  * Uses git to find the repo root so this works correctly in
  * git worktrees — worktree agents resolve to the same vault
- * as the main working tree.
+ * as the main working tree. Some symbionts launch their MCP child with
+ * cwd=/, so explicit env anchors win before any cwd-based fallback.
  */
-export function resolveVaultDir(cwd = process.cwd()): string {
+export function resolveVaultDir(
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const explicitVaultDir = readAbsoluteEnv(env, MYCO_VAULT_DIR_ENV);
+  if (explicitVaultDir) return explicitVaultDir;
+
+  const explicitProjectRoot = readAbsoluteEnv(env, MYCO_PROJECT_ROOT_ENV);
+  if (explicitProjectRoot) return path.join(explicitProjectRoot, '.myco');
+
   return path.join(resolveRepoRoot(cwd), '.myco');
+}
+
+function readAbsoluteEnv(
+  env: NodeJS.ProcessEnv,
+  key: string,
+): string | null {
+  const raw = env[key];
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+  return path.isAbsolute(raw) ? raw : null;
 }
 
 /**

--- a/tests/daemon/stop-processing.test.ts
+++ b/tests/daemon/stop-processing.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
+import { createStopProcessor } from '@myco/daemon/stop-processing.js';
+import { SessionRegistry } from '@myco/daemon/lifecycle.js';
+import { getSession, upsertSession } from '@myco/db/queries/sessions.js';
+import { insertBatch, listBatchesBySession } from '@myco/db/queries/batches.js';
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+function writeCodexSubagentTranscript(sessionId: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-codex-subagent-'));
+  const transcriptPath = path.join(dir, `rollout-${sessionId}.jsonl`);
+  const lines = [
+    JSON.stringify({
+      type: 'session_meta',
+      payload: {
+        id: sessionId,
+        source: {
+          subagent: {
+            thread_spawn: {
+              parent_thread_id: 'parent-session',
+              depth: 1,
+              agent_role: 'default',
+            },
+          },
+        },
+      },
+    }),
+    JSON.stringify({
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'Review this diff' }],
+      },
+    }),
+  ];
+  fs.writeFileSync(transcriptPath, `${lines.join('\n')}\n`);
+  return transcriptPath;
+}
+
+function makeStopProcessor(vaultDir: string) {
+  return createStopProcessor({
+    registry: new SessionRegistry({ gracePeriod: 1, onEmpty: () => {} }),
+    sessionBuffers: new Map(),
+    transcriptMiner: { getAllTurnsWithSource: vi.fn() } as never,
+    embeddingManager: { onRemoved: vi.fn() } as never,
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as never,
+    config: { agent: { event_tasks_enabled: false } } as never,
+    vaultDir,
+    planTags: [],
+  });
+}
+
+describe('createStopProcessor session capture rules', () => {
+  let vaultDir: string;
+
+  beforeAll(() => {
+    setupTestDb();
+  });
+
+  beforeEach(() => {
+    cleanTestDb();
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-stop-processor-'));
+  });
+
+  afterAll(() => {
+    teardownTestDb();
+  });
+
+  it('ignores a sub-agent transcript before any session row exists', async () => {
+    const sessionId = 'codex-subagent-stop-001';
+    const transcriptPath = writeCodexSubagentTranscript(sessionId);
+    const stopProcessor = makeStopProcessor(vaultDir);
+
+    const res = await stopProcessor.handleStopRoute({
+      body: {
+        session_id: sessionId,
+        agent: 'codex',
+        transcript_path: transcriptPath,
+        last_assistant_message: 'done',
+      },
+    } as never);
+
+    expect(res.body).toEqual({ ok: true, ignored: 'subagent-thread-spawn' });
+    expect(getSession(sessionId)).toBeNull();
+  });
+
+  it('deletes a leaked session row when stop re-evaluates the capture rules', async () => {
+    const sessionId = 'codex-subagent-stop-002';
+    const now = epochNow();
+    const transcriptPath = writeCodexSubagentTranscript(sessionId);
+    const stopProcessor = makeStopProcessor(vaultDir);
+
+    upsertSession({
+      id: sessionId,
+      agent: 'codex',
+      status: 'active',
+      started_at: now,
+      created_at: now,
+    });
+    insertBatch({
+      session_id: sessionId,
+      prompt_number: 1,
+      user_prompt: 'stale prompt',
+      started_at: now,
+      created_at: now,
+    });
+
+    expect(getSession(sessionId)).not.toBeNull();
+    expect(listBatchesBySession(sessionId)).toHaveLength(1);
+
+    const res = await stopProcessor.handleStopRoute({
+      body: {
+        session_id: sessionId,
+        agent: 'codex',
+        transcript_path: transcriptPath,
+        last_assistant_message: 'done',
+      },
+    } as never);
+
+    expect(res.body).toEqual({ ok: true, ignored: 'subagent-thread-spawn' });
+    expect(getSession(sessionId)).toBeNull();
+    expect(listBatchesBySession(sessionId)).toHaveLength(0);
+  });
+});

--- a/tests/symbionts/installer.test.ts
+++ b/tests/symbionts/installer.test.ts
@@ -68,6 +68,9 @@ const CODEX_MANIFEST: SymbiontManifest = {
     hooksTarget: '.codex/hooks.json',
     mcpTarget: '.codex/config.toml',
     mcpFormat: 'toml',
+    mcpEnv: {
+      MYCO_PROJECT_ROOT: '{projectRoot}',
+    },
     skillsTarget: '.agents/skills',
     settingsTarget: '.codex/config.toml',
     settingsFormat: 'toml',
@@ -983,6 +986,8 @@ describe('installMcp (TOML)', () => {
     expect(content).toContain('[mcp_servers.myco]');
     expect(content).toContain('command = "myco-run"');
     expect(content).toContain('args = ["mcp"]');
+    expect(content).toContain('[mcp_servers.myco.env]');
+    expect(content).toContain(`MYCO_PROJECT_ROOT = "${projectRoot}"`);
   });
 
   it('preserves existing TOML content', () => {

--- a/tests/symbionts/manifest-schema.test.ts
+++ b/tests/symbionts/manifest-schema.test.ts
@@ -145,6 +145,9 @@ describe('symbiont manifests', () => {
     expect(manifest.registration).toBeDefined();
     expect(manifest.registration!.mcpTarget).toBe('.codex/config.toml');
     expect(manifest.registration!.mcpFormat).toBe('toml');
+    expect(manifest.registration!.mcpEnv).toEqual({
+      MYCO_PROJECT_ROOT: '{projectRoot}',
+    });
     expect(manifest.registration!.skillsTarget).toBe('.agents/skills');
     expect(manifest.registration!.hooksTarget).toBe('.codex/hooks.json');
   });

--- a/tests/vault/resolve.test.ts
+++ b/tests/vault/resolve.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MYCO_PROJECT_ROOT_ENV,
+  MYCO_VAULT_DIR_ENV,
+  resolveVaultDir,
+} from '@myco/vault/resolve.js';
+
+describe('resolveVaultDir', () => {
+  it('prefers explicit vault dir env over cwd discovery', () => {
+    const result = resolveVaultDir('/', {
+      [MYCO_VAULT_DIR_ENV]: '/tmp/custom-vault',
+      [MYCO_PROJECT_ROOT_ENV]: '/tmp/project-root',
+    });
+
+    expect(result).toBe('/tmp/custom-vault');
+  });
+
+  it('derives vault dir from explicit project root env when present', () => {
+    const result = resolveVaultDir('/', {
+      [MYCO_PROJECT_ROOT_ENV]: '/tmp/project-root',
+    });
+
+    expect(result).toBe('/tmp/project-root/.myco');
+  });
+
+  it('ignores non-absolute env values and falls back to cwd resolution', () => {
+    const result = resolveVaultDir('/tmp/project-root', {
+      [MYCO_PROJECT_ROOT_ENV]: 'relative-root',
+      [MYCO_VAULT_DIR_ENV]: '.myco',
+    });
+
+    expect(result).toBe('/tmp/project-root/.myco');
+  });
+});


### PR DESCRIPTION
## Summary
This PR fixes two Codex/Myco integration failures that were producing invalid session data and broken MCP writes.

- hardens session capture so Codex sub-agent transcripts are filtered at stop-processing time, not just at session start
- adds a manifest-driven MCP env anchor so symbionts can point the Myco MCP child back at the owning project root
- teaches vault resolution to honor explicit env anchors before falling back to `process.cwd()`
- adds regression coverage for Codex TOML MCP install output, env-based vault resolution, and leaked sub-agent session cleanup

## Verification
- `npx vitest run tests/vault/resolve.test.ts tests/symbionts/manifest-schema.test.ts tests/symbionts/installer.test.ts tests/mcp/tools/remember.test.ts`
- `make build`