### PR TITLE
Harden MCP server tool contracts

### DIFF
--- a/packages/myco/src/daemon/api/mcp-proxy.ts
+++ b/packages/myco/src/daemon/api/mcp-proxy.ts
@@ -3,16 +3,24 @@
  * daemon instead of opening its own SQLite connection.
  *
  * Factory function injects machineId and embeddingManager; returns handlers
- * for remember, supersede, plans, sessions, and team endpoints.
+ * for remember, supersede, consolidate, plans, sessions, and team endpoints.
  */
 
 import { z } from 'zod';
-import { epochSeconds, USER_AGENT_ID, USER_AGENT_NAME } from '@myco/constants.js';
+import {
+  epochSeconds,
+  MCP_SESSIONS_DEFAULT_LIMIT,
+  SESSION_SUMMARY_PREVIEW_CHARS,
+  USER_AGENT_ID,
+  USER_AGENT_NAME,
+} from '@myco/constants.js';
+import { getDatabase } from '@myco/db/client.js';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import { insertSpore, updateSporeStatus } from '@myco/db/queries/spores.js';
-import { listPlans } from '@myco/db/queries/plans.js';
+import { getPlan, listPlans } from '@myco/db/queries/plans.js';
 import { listSessions } from '@myco/db/queries/sessions.js';
 import { listTeamMembers } from '@myco/db/queries/team-members.js';
+import { insertResolutionEvent } from '@myco/db/queries/resolution-events.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 import type { EmbeddingManager } from '../embedding/manager.js';
 
@@ -22,6 +30,7 @@ import type { EmbeddingManager } from '../embedding/manager.js';
 
 const SPORE_ID_RANDOM_BYTES = 4;
 const RESOLUTION_ID_RANDOM_BYTES = 8;
+const MIN_CONSOLIDATE_SOURCES = 2;
 
 // ---------------------------------------------------------------------------
 // Schemas
@@ -36,6 +45,43 @@ const RememberBody = z.object({
 const SupersedeBody = z.object({
   old_spore_id: z.string(),
   new_spore_id: z.string(),
+  reason: z.string().optional(),
+});
+
+/**
+ * Convert an ISO-8601 string to epoch seconds.
+ * Returns undefined if parsing fails (silently — callers treat undefined as "no filter").
+ */
+function isoToEpochSeconds(iso: string): number | undefined {
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? undefined : Math.floor(ms / 1000);
+}
+
+function registerMcpUserAgent(createdAt: number): void {
+  registerAgent({
+    id: USER_AGENT_ID,
+    name: USER_AGENT_NAME,
+    created_at: createdAt,
+  });
+}
+
+function toPlanProgress(content: string | null): string {
+  const planContent = content ?? '';
+  const checked = (planContent.match(/- \[x\]/gi) ?? []).length;
+  const unchecked = (planContent.match(/- \[ \]/g) ?? []).length;
+  const total = checked + unchecked;
+  return total === 0 ? 'N/A' : `${checked}/${total}`;
+}
+
+function toPlanTags(tags: string | null): string[] {
+  return tags ? tags.split(',').map((tag) => tag.trim()) : [];
+}
+
+const ConsolidateBody = z.object({
+  source_spore_ids: z.array(z.string()).min(MIN_CONSOLIDATE_SOURCES),
+  consolidated_content: z.string().min(1),
+  observation_type: z.string(),
+  tags: z.array(z.string()).optional(),
   reason: z.string().optional(),
 });
 
@@ -55,6 +101,24 @@ export interface McpProxyDeps {
 export function createMcpProxyHandlers(deps: McpProxyDeps) {
   const { machineId, embeddingManager } = deps;
 
+  function toPlanSummary(row: {
+    id: string;
+    title: string | null;
+    status: string;
+    content: string | null;
+    tags: string | null;
+    created_at: number;
+  }) {
+    return {
+      id: row.id,
+      title: row.title,
+      status: row.status,
+      progress: toPlanProgress(row.content),
+      tags: toPlanTags(row.tags),
+      created_at: row.created_at,
+    };
+  }
+
   /** POST /api/mcp/remember — create a spore and trigger embedding. */
   async function handleRemember(req: RouteRequest): Promise<RouteResponse> {
     const { content, type, tags } = RememberBody.parse(req.body);
@@ -64,12 +128,7 @@ export function createMcpProxyHandlers(deps: McpProxyDeps) {
     const id = `${observationType}-${randomBytes(SPORE_ID_RANDOM_BYTES).toString('hex')}`;
     const now = epochSeconds();
 
-    // Ensure the user agent exists (idempotent upsert)
-    registerAgent({
-      id: USER_AGENT_ID,
-      name: USER_AGENT_NAME,
-      created_at: now,
-    });
+    registerMcpUserAgent(now);
 
     const spore = insertSpore({
       id,
@@ -106,15 +165,9 @@ export function createMcpProxyHandlers(deps: McpProxyDeps) {
     updateSporeStatus(old_spore_id, 'superseded', now);
     try { embeddingManager.onStatusChanged('spores', old_spore_id, 'superseded'); } catch { /* best-effort */ }
 
-    // Ensure user agent exists (idempotent)
-    registerAgent({
-      id: USER_AGENT_ID,
-      name: USER_AGENT_NAME,
-      created_at: now,
-    });
+    registerMcpUserAgent(now);
 
     // Record resolution event for audit trail
-    const { insertResolutionEvent } = await import('@myco/db/queries/resolution-events.js');
     const resolutionId = `res-${randomBytes(RESOLUTION_ID_RANDOM_BYTES).toString('hex')}`;
 
     insertResolutionEvent({
@@ -137,39 +190,122 @@ export function createMcpProxyHandlers(deps: McpProxyDeps) {
     };
   }
 
-  /** GET /api/mcp/plans — list plans with progress calculation. */
+  /**
+   * POST /api/mcp/consolidate — merge source spores into a single wisdom spore.
+   *
+   * Inserts a new spore with the consolidated content, then for each source:
+   *   - marks its status as 'superseded'
+   *   - records a resolution_events row (action='consolidate', new_spore_id=wisdom)
+   *
+   * Returns { new_spore_id, sources_superseded, status: 'consolidated' }.
+   */
+  async function handleConsolidate(req: RouteRequest): Promise<RouteResponse> {
+    const { source_spore_ids, consolidated_content, observation_type, tags, reason } = ConsolidateBody.parse(req.body);
+    const { randomBytes } = await import('node:crypto');
+    const now = epochSeconds();
+    const newSporeId = `${observation_type}-${randomBytes(SPORE_ID_RANDOM_BYTES).toString('hex')}`;
+    const db = getDatabase();
+
+    registerMcpUserAgent(now);
+
+    const { wisdom, sourcesSuperseded } = db.transaction(() => {
+      const insertedWisdom = insertSpore({
+        id: newSporeId,
+        agent_id: USER_AGENT_ID,
+        machine_id: machineId,
+        observation_type,
+        content: consolidated_content,
+        tags: tags ? tags.join(', ') : null,
+        created_at: now,
+      });
+
+      const supersededSourceIds: string[] = [];
+      for (const sourceId of source_spore_ids) {
+        updateSporeStatus(sourceId, 'superseded', now);
+        insertResolutionEvent({
+          id: `res-${randomBytes(RESOLUTION_ID_RANDOM_BYTES).toString('hex')}`,
+          agent_id: USER_AGENT_ID,
+          machine_id: machineId,
+          spore_id: sourceId,
+          action: 'consolidate',
+          new_spore_id: newSporeId,
+          reason: reason ?? null,
+          created_at: now,
+        });
+        supersededSourceIds.push(sourceId);
+      }
+
+      return { wisdom: insertedWisdom, sourcesSuperseded: supersededSourceIds };
+    })();
+
+    embeddingManager.onContentWritten('spores', wisdom.id, consolidated_content, {
+      status: 'active',
+      observation_type,
+    }).catch(() => {});
+    for (const sourceId of sourcesSuperseded) {
+      try { embeddingManager.onStatusChanged('spores', sourceId, 'superseded'); } catch { /* best-effort */ }
+    }
+
+    return {
+      body: {
+        new_spore_id: newSporeId,
+        sources_superseded: sourcesSuperseded,
+        status: 'consolidated' as const,
+        created_at: now,
+      },
+    };
+  }
+
+  /** GET /api/mcp/plans — list plans, or return a single plan with content when id is set. */
   async function handlePlans(req: RouteRequest): Promise<RouteResponse> {
+    const id = typeof req.query.id === 'string' ? req.query.id : undefined;
+
+    if (id) {
+      const row = getPlan(id);
+      if (!row) return { body: { plans: [] } };
+      return {
+        body: {
+          plans: [{
+            ...toPlanSummary(row),
+            content: row.content,
+          }],
+        },
+      };
+    }
+
     const statusFilter = req.query.status === 'all' ? undefined : req.query.status;
     const limit = req.query.limit ? Number(req.query.limit) : undefined;
 
     const rows = listPlans({ status: statusFilter, limit });
-
-    const plans = rows.map((row) => {
-      const content = row.content ?? '';
-      const checked = (content.match(/- \[x\]/gi) ?? []).length;
-      const unchecked = (content.match(/- \[ \]/g) ?? []).length;
-      const total = checked + unchecked;
-      const progress = total === 0 ? 'N/A' : `${checked}/${total}`;
-
-      return {
-        id: row.id,
-        title: row.title,
-        status: row.status,
-        progress,
-        tags: row.tags ? row.tags.split(',').map((t) => t.trim()) : [],
-        created_at: row.created_at,
-      };
-    });
+    const plans = rows.map(toPlanSummary);
 
     return { body: { plans } };
   }
 
-  /** GET /api/mcp/sessions — list sessions with field mapping. */
+  /**
+   * GET /api/mcp/sessions — list sessions with optional filters.
+   *
+   * Supports query params: limit, status, branch, user, since (ISO string), plan.
+   * `plan` resolves to the session recorded for that plan via `getPlan().session_id`.
+   */
   async function handleSessions(req: RouteRequest): Promise<RouteResponse> {
-    const limit = req.query.limit ? Number(req.query.limit) : 20;
-    const status = req.query.status;
+    const limit = req.query.limit ? Number(req.query.limit) : MCP_SESSIONS_DEFAULT_LIMIT;
+    const status = typeof req.query.status === 'string' ? req.query.status : undefined;
+    const branch = typeof req.query.branch === 'string' ? req.query.branch : undefined;
+    const user = typeof req.query.user === 'string' ? req.query.user : undefined;
+    const plan = typeof req.query.plan === 'string' ? req.query.plan : undefined;
+    const sinceRaw = typeof req.query.since === 'string' ? req.query.since : undefined;
 
-    const rows = listSessions({ limit, status });
+    const since = sinceRaw ? isoToEpochSeconds(sinceRaw) : undefined;
+
+    let id: string | undefined;
+    if (plan) {
+      const planRow = getPlan(plan);
+      if (!planRow || !planRow.session_id) return { body: { sessions: [] } };
+      id = planRow.session_id;
+    }
+
+    const rows = listSessions({ limit, status, branch, user, since, id });
     const sessions = rows.map((row) => ({
       id: row.id,
       agent: row.agent,
@@ -179,7 +315,7 @@ export function createMcpProxyHandlers(deps: McpProxyDeps) {
       ended_at: row.ended_at,
       status: row.status,
       title: row.title,
-      summary: (row.summary ?? '').slice(0, 300),
+      summary: (row.summary ?? '').slice(0, SESSION_SUMMARY_PREVIEW_CHARS),
       prompt_count: row.prompt_count,
       tool_count: row.tool_count,
       parent_session_id: row.parent_session_id,
@@ -205,6 +341,7 @@ export function createMcpProxyHandlers(deps: McpProxyDeps) {
   return {
     handleRemember,
     handleSupersede,
+    handleConsolidate,
     handlePlans,
     handleSessions,
     handleTeam,

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -679,6 +679,7 @@ export async function main(): Promise<void> {
   const mcpProxy = createMcpProxyHandlers({ machineId, embeddingManager });
   server.registerRoute('POST', '/api/mcp/remember', mcpProxy.handleRemember);
   server.registerRoute('POST', '/api/mcp/supersede', mcpProxy.handleSupersede);
+  server.registerRoute('POST', '/api/mcp/consolidate', mcpProxy.handleConsolidate);
   server.registerRoute('GET', '/api/mcp/plans', mcpProxy.handlePlans);
   server.registerRoute('GET', '/api/mcp/sessions', mcpProxy.handleSessions);
   server.registerRoute('GET', '/api/mcp/team', mcpProxy.handleTeam);

--- a/packages/myco/src/db/queries/sessions.ts
+++ b/packages/myco/src/db/queries/sessions.ts
@@ -109,6 +109,12 @@ export interface ListSessionsOptions {
   status?: string;
   agent?: string;
   search?: string;
+  /** Filter to sessions that ran on this git branch. */
+  branch?: string;
+  /** Filter to sessions authored by this user. */
+  user?: string;
+  /** Filter to this exact session id (used for plan→session resolution). */
+  id?: string;
   /** Only return sessions created after this epoch-seconds timestamp. */
   since?: number;
   /**
@@ -292,6 +298,21 @@ function buildSessionsWhere(
   if (options.agent !== undefined) {
     conditions.push(`agent = ?`);
     params.push(options.agent);
+  }
+
+  if (options.branch !== undefined) {
+    conditions.push(`branch = ?`);
+    params.push(options.branch);
+  }
+
+  if (options.user !== undefined) {
+    conditions.push(`"user" = ?`);
+    params.push(options.user);
+  }
+
+  if (options.id !== undefined) {
+    conditions.push(`id = ?`);
+    params.push(options.id);
   }
 
   if (options.search !== undefined && options.search.length > 0) {

--- a/packages/myco/src/mcp/server.ts
+++ b/packages/myco/src/mcp/server.ts
@@ -115,7 +115,10 @@ export function createMycoServer(vaultDir: string, client: DaemonClient): MycoSe
         return { content: [{ type: 'text', text: JSON.stringify(result) }] };
       }
       case TOOL_SESSIONS: {
-        const sessionsInput = input as { limit?: number; status?: string };
+        const sessionsInput = input as {
+          plan?: string; branch?: string; user?: string; since?: string;
+          status?: string; limit?: number;
+        };
         const result = await handleMycoSessions(sessionsInput, client);
         logActivity(TOOL_SESSIONS, { count: result.length, duration_ms: Date.now() - start });
         return { content: [{ type: 'text', text: JSON.stringify(result) }] };
@@ -139,9 +142,20 @@ export function createMycoServer(vaultDir: string, client: DaemonClient): MycoSe
         return { content: [{ type: 'text', text: JSON.stringify(result) }] };
       }
       case TOOL_CONSOLIDATE: {
-        const consolidateInput = input as { source_spore_ids: string[] };
-        const result = await handleMycoConsolidate(consolidateInput);
-        logActivity(TOOL_CONSOLIDATE, { status: result.status, duration_ms: Date.now() - start });
+        const consolidateInput = input as {
+          source_spore_ids: string[];
+          consolidated_content: string;
+          observation_type: string;
+          tags?: string[];
+          reason?: string;
+        };
+        const result = await handleMycoConsolidate(consolidateInput, client);
+        logActivity(TOOL_CONSOLIDATE, {
+          status: result.status,
+          new_spore_id: result.new_spore_id,
+          sources: result.sources_superseded.length,
+          duration_ms: Date.now() - start,
+        });
         return { content: [{ type: 'text', text: JSON.stringify(result) }] };
       }
       case TOOL_CONTEXT: {

--- a/packages/myco/src/mcp/tool-definitions.ts
+++ b/packages/myco/src/mcp/tool-definitions.ts
@@ -59,15 +59,13 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: TOOL_REMEMBER,
-    description: 'Save a decision, gotcha, bug fix, discovery, or trade-off as a permanent spore. Use after making a key decision, fixing a tricky bug, discovering something non-obvious, or encountering a gotcha.',
+    description: 'Save a decision, gotcha, bug fix, discovery, or trade-off as a permanent spore. Use after making a key decision, fixing a tricky bug, discovering something non-obvious, or encountering a gotcha. Session association is derived by the daemon — the MCP client does not pass it.',
     inputSchema: {
       type: 'object' as const,
       properties: {
         content: { type: 'string', description: 'The observation — include context, reasoning, and what someone encountering this in the future needs to know' },
         type: { type: 'string', enum: OBSERVATION_TYPES, description: `Observation type: ${OBSERVATION_TYPES.join(', ')}` },
         tags: { type: 'array', items: { type: 'string' }, description: PROP_TAGS },
-        session: { type: 'string', description: 'Your current session ID — auto-detected if omitted' },
-        related_plan: { type: 'string', description: 'Plan ID if this observation relates to an active plan' },
       },
       required: ['content', 'type'],
     },
@@ -89,24 +87,21 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object' as const,
       properties: {
-        plan: { type: 'string', description: 'Filter sessions linked to a specific plan' },
+        plan: { type: 'string', description: 'Filter to the session linked to this plan id' },
         branch: { type: 'string', description: PROP_BRANCH },
         user: { type: 'string', description: 'Filter sessions by user' },
         since: { type: 'string', description: PROP_SINCE },
+        status: { type: 'string', description: 'Filter by session status (e.g., active, completed)' },
         limit: { type: 'number', description: `Max results (default: ${MCP_SESSIONS_DEFAULT_LIMIT})` },
       },
     },
   },
   {
     name: TOOL_TEAM,
-    description: 'See what teammates have been working on — filter by shared files or plan to understand who has context on a component.',
+    description: 'List team members registered in the vault. Returns id, user, role, joined, and tags per member. Phase-1 scope: no filters.',
     inputSchema: {
       type: 'object' as const,
-      properties: {
-        files: { type: 'array', items: { type: 'string' }, description: 'File paths to find teammates who worked on them' },
-        plan: { type: 'string', description: 'Plan ID to find teammates collaborating on it' },
-        since: { type: 'string', description: PROP_SINCE },
-      },
+      properties: {},
     },
   },
   {
@@ -137,7 +132,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: TOOL_CONSOLIDATE,
-    description: 'Merge 3+ related spores into a single comprehensive wisdom note. Use when multiple observations describe aspects of the same insight, share a root cause, or would be more useful as one reference. Source spores are marked superseded.',
+    description: 'Merge 2+ related spores into a single comprehensive wisdom note. Inserts a new spore with the consolidated content; each source spore is marked superseded with a resolution_events row linking it to the new wisdom spore. Use when multiple observations describe aspects of the same insight, share a root cause, or would be more useful as one reference.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -145,6 +140,7 @@ export const TOOL_DEFINITIONS = [
         consolidated_content: { type: 'string', description: 'The merged, comprehensive content — synthesize, do not just concatenate' },
         observation_type: { type: 'string', enum: OBSERVATION_TYPES, description: `Type for the consolidated wisdom note: ${OBSERVATION_TYPES.join(', ')}` },
         tags: { type: 'array', items: { type: 'string' }, description: PROP_TAGS },
+        reason: { type: 'string', description: 'Optional reason recorded on each resolution event' },
       },
       required: ['source_spore_ids', 'consolidated_content', 'observation_type'],
     },

--- a/packages/myco/src/mcp/tools/consolidate.ts
+++ b/packages/myco/src/mcp/tools/consolidate.ts
@@ -1,10 +1,13 @@
 /**
- * myco_consolidate — merge related spores into a single comprehensive note.
+ * myco_consolidate — merge related spores into a single wisdom spore.
  *
- * Phase 1 stub: consolidation requires intelligence configuration (LLM) which
- * is not yet wired into the SQLite flow. Returns a helpful message directing
- * users to Phase 2.
+ * Proxies through the daemon HTTP API via DaemonClient. The daemon inserts a
+ * new spore with the consolidated content, then for each source spore marks
+ * status='superseded' and records a resolution_events row linking it to the
+ * new wisdom spore.
  */
+
+import type { DaemonClient } from '@myco/hooks/client.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -12,11 +15,17 @@
 
 interface ConsolidateInput {
   source_spore_ids: string[];
+  consolidated_content: string;
+  observation_type: string;
+  tags?: string[];
+  reason?: string;
 }
 
 interface ConsolidateResult {
-  status: string;
-  message: string;
+  new_spore_id: string;
+  sources_superseded: string[];
+  status: 'consolidated';
+  created_at: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -24,10 +33,20 @@ interface ConsolidateResult {
 // ---------------------------------------------------------------------------
 
 export async function handleMycoConsolidate(
-  _input: ConsolidateInput,
+  input: ConsolidateInput,
+  client: DaemonClient,
 ): Promise<ConsolidateResult> {
-  return {
-    status: 'unavailable',
-    message: 'Consolidation requires intelligence configuration (Phase 2). Use myco_supersede to manually mark outdated spores.',
-  };
+  const result = await client.post('/api/mcp/consolidate', {
+    source_spore_ids: input.source_spore_ids,
+    consolidated_content: input.consolidated_content,
+    observation_type: input.observation_type,
+    tags: input.tags,
+    reason: input.reason,
+  });
+
+  if (!result.ok || !result.data) {
+    throw new Error('Failed to consolidate spores: daemon request failed');
+  }
+
+  return result.data as ConsolidateResult;
 }

--- a/packages/myco/src/mcp/tools/plans.ts
+++ b/packages/myco/src/mcp/tools/plans.ts
@@ -12,6 +12,7 @@ import { buildEndpoint } from './shared.js';
 // ---------------------------------------------------------------------------
 
 interface PlansInput {
+  id?: string;
   status?: string;
   limit?: number;
 }
@@ -23,6 +24,8 @@ interface PlanSummary {
   progress: string;
   tags: string[];
   created_at: number;
+  /** Full plan content — present only when looked up by id. */
+  content?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -34,6 +37,7 @@ export async function handleMycoPlans(
   client: DaemonClient,
 ): Promise<PlanSummary[]> {
   const endpoint = buildEndpoint('/api/mcp/plans', {
+    id: input.id,
     status: input.status,
     limit: input.limit,
   });

--- a/packages/myco/src/mcp/tools/sessions.ts
+++ b/packages/myco/src/mcp/tools/sessions.ts
@@ -12,8 +12,12 @@ import { buildEndpoint } from './shared.js';
 // ---------------------------------------------------------------------------
 
 interface SessionsInput {
-  limit?: number;
+  plan?: string;
+  branch?: string;
+  user?: string;
+  since?: string;
   status?: string;
+  limit?: number;
 }
 
 interface SessionSummary {
@@ -40,8 +44,12 @@ export async function handleMycoSessions(
   client: DaemonClient,
 ): Promise<SessionSummary[]> {
   const endpoint = buildEndpoint('/api/mcp/sessions', {
-    limit: input.limit,
+    plan: input.plan,
+    branch: input.branch,
+    user: input.user,
+    since: input.since,
     status: input.status,
+    limit: input.limit,
   });
   const result = await client.get(endpoint);
 

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -18,7 +18,7 @@ describe('MCP Server', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('creates server with all 12 tools registered', () => {
+  it('registers all 12 core tools', () => {
     const server = createMycoServer(tmpDir, client);
     const tools = server.getRegisteredTools();
     expect(tools).toContain('myco_search');
@@ -34,6 +34,14 @@ describe('MCP Server', () => {
     expect(tools).toContain('myco_skills');
     expect(tools).toContain('myco_skill_candidates');
     expect(tools).toHaveLength(12);
+  });
+
+  it('does not leak collective tools into the core registration', () => {
+    const server = createMycoServer(tmpDir, client);
+    const tools = server.getRegisteredTools();
+    expect(tools).not.toContain('collective_search');
+    expect(tools).not.toContain('collective_projects');
+    expect(tools).not.toContain('collective_project');
   });
 
   it('exports server name and version', () => {

--- a/tests/mcp/tool-definitions.test.ts
+++ b/tests/mcp/tool-definitions.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Anti-drift tests for `tool-definitions.ts`.
+ *
+ * These guard against the class of bugs where:
+ *   - a tool is registered in `TOOL_DEFINITIONS` but never dispatched in `server.ts`
+ *   - a tool is dispatched in `server.ts` but never declared in `TOOL_DEFINITIONS`
+ *   - a schema property exists but the handler doesn't forward it
+ *   - core and collective tool name sets overlap
+ *
+ * Real-world bug this catches (2026-04-15 regression sweep):
+ *   `myco_plans` declared an `id` schema property. The handler silently dropped it,
+ *   so single-plan lookup appeared to work but always returned the full list.
+ *   Anti-drift tests like `forwardsAllDocumentedQueryParams` would have caught it.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  TOOL_DEFINITIONS,
+  COLLECTIVE_TOOL_DEFINITIONS,
+} from '@myco/mcp/tool-definitions.js';
+import { handleMycoPlans } from '@myco/mcp/tools/plans.js';
+import { handleMycoRemember } from '@myco/mcp/tools/remember.js';
+import { handleMycoSupersede } from '@myco/mcp/tools/supersede.js';
+import { handleMycoConsolidate } from '@myco/mcp/tools/consolidate.js';
+import { handleMycoSearch } from '@myco/mcp/tools/search.js';
+import { handleMycoSessions } from '@myco/mcp/tools/sessions.js';
+import { handleMycoGraph } from '@myco/mcp/tools/graph.js';
+import {
+  handleCollectiveSearch,
+  handleCollectiveProject,
+} from '@myco/mcp/tools/collective.js';
+import { DaemonClient } from '@myco/hooks/client.js';
+
+function mockClient(data: unknown = {}, ok = true): DaemonClient {
+  return {
+    get: vi.fn().mockResolvedValue({ ok, data }),
+    post: vi.fn().mockResolvedValue({ ok, data }),
+    put: vi.fn().mockResolvedValue({ ok, data }),
+  } as unknown as DaemonClient;
+}
+
+// Read server.ts once so we can assert every tool name appears in a dispatch case.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SERVER_TS = fs.readFileSync(
+  path.resolve(__dirname, '../../packages/myco/src/mcp/server.ts'),
+  'utf-8',
+);
+
+describe('TOOL_DEFINITIONS registration coverage', () => {
+  it('every core tool name appears in server.ts dispatch', () => {
+    for (const tool of TOOL_DEFINITIONS) {
+      expect(SERVER_TS, `Tool ${tool.name} missing from server dispatch`).toContain(`case TOOL_`);
+      // Name appears as a string either via the TOOL_ constant or as literal in the file.
+      const literal = tool.name;
+      expect(SERVER_TS).toMatch(new RegExp(`TOOL_${literal.toUpperCase().replace(/^MYCO_/, '').replace(/^COLLECTIVE_/, 'COLLECTIVE_')}|['"]${literal}['"]`));
+    }
+  });
+
+  it('every collective tool name appears in server.ts dispatch', () => {
+    for (const tool of COLLECTIVE_TOOL_DEFINITIONS) {
+      const literal = tool.name;
+      expect(SERVER_TS).toMatch(new RegExp(`TOOL_COLLECTIVE_[A-Z_]+|['"]${literal}['"]`));
+    }
+  });
+
+  it('core and collective name sets do not overlap', () => {
+    const core = new Set(TOOL_DEFINITIONS.map((t) => t.name));
+    const collective = new Set(COLLECTIVE_TOOL_DEFINITIONS.map((t) => t.name));
+    for (const name of collective) {
+      expect(core.has(name), `Tool ${name} is both core and collective`).toBe(false);
+    }
+  });
+
+  it('every tool has an object-shaped inputSchema with a properties map', () => {
+    for (const tool of [...TOOL_DEFINITIONS, ...COLLECTIVE_TOOL_DEFINITIONS]) {
+      expect(tool.inputSchema.type).toBe('object');
+      expect(tool.inputSchema.properties).toBeDefined();
+    }
+  });
+
+  it('every tool name starts with myco_ or collective_', () => {
+    for (const tool of [...TOOL_DEFINITIONS, ...COLLECTIVE_TOOL_DEFINITIONS]) {
+      expect(tool.name).toMatch(/^(myco_|collective_)/);
+    }
+  });
+});
+
+/**
+ * For each tool whose schema advertises query or body parameters, assert the
+ * handler actually forwards them to the daemon. These tests exist specifically
+ * to catch silent schema-vs-handler drift.
+ */
+describe('handler forwards every documented schema property', () => {
+  it('myco_plans forwards id, status, and limit', async () => {
+    const client = mockClient({ plans: [] });
+    await handleMycoPlans({ id: 'p1', status: 'active', limit: 7 }, client);
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    expect(url).toContain('id=p1');
+    expect(url).toContain('status=active');
+    expect(url).toContain('limit=7');
+  });
+
+  it('myco_sessions forwards all documented filters', async () => {
+    const client = mockClient({ sessions: [] });
+    await handleMycoSessions({ plan: 'x', branch: 'main', user: 'alice', since: '2024-01-01', limit: 9 }, client);
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    expect(url).toContain('plan=x');
+    expect(url).toContain('branch=main');
+    expect(url).toContain('user=alice');
+    expect(url).toContain('since=2024-01-01');
+    expect(url).toContain('limit=9');
+  });
+
+  it('myco_search forwards query, type, limit', async () => {
+    const client = mockClient({ results: [] });
+    await handleMycoSearch({ query: 'auth', type: 'spore', limit: 4 }, client);
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    expect(url).toContain('q=auth');
+    expect(url).toContain('type=spore');
+    expect(url).toContain('limit=4');
+  });
+
+  it('myco_graph forwards note_id via path segment and direction/depth as query', async () => {
+    const client = mockClient({ edges: [], entities: [] });
+    await handleMycoGraph({ note_id: 'n1', direction: 'incoming', depth: 2 }, client);
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    // note_id appears as a path segment (not a query param) by design
+    expect(url).toContain('/api/graph/n1');
+    expect(url).toContain('direction=incoming');
+    expect(url).toContain('depth=2');
+  });
+
+  it('myco_remember forwards content, type, tags via POST body', async () => {
+    const client = mockClient({ id: 'g-1', observation_type: 'gotcha', status: 'active', created_at: 1 });
+    await handleMycoRemember({ content: 'x', type: 'gotcha', tags: ['t1', 't2'] }, client);
+    expect(client.post).toHaveBeenCalledWith('/api/mcp/remember', {
+      content: 'x',
+      type: 'gotcha',
+      tags: ['t1', 't2'],
+    });
+  });
+
+  it('myco_supersede forwards old_spore_id, new_spore_id, reason via POST body', async () => {
+    const client = mockClient({ old_spore: 'a', new_spore: 'b', status: 'superseded' });
+    await handleMycoSupersede({ old_spore_id: 'a', new_spore_id: 'b', reason: 'because' }, client);
+    expect(client.post).toHaveBeenCalledWith('/api/mcp/supersede', {
+      old_spore_id: 'a',
+      new_spore_id: 'b',
+      reason: 'because',
+    });
+  });
+
+  it('myco_consolidate forwards source_spore_ids, consolidated_content, observation_type, tags, reason', async () => {
+    const client = mockClient({
+      new_spore_id: 'w-1',
+      sources_superseded: ['a', 'b'],
+      status: 'consolidated',
+      created_at: 1,
+    });
+    await handleMycoConsolidate({
+      source_spore_ids: ['a', 'b'],
+      consolidated_content: 'merged',
+      observation_type: 'gotcha',
+      tags: ['t1'],
+      reason: 'merge',
+    }, client);
+    expect(client.post).toHaveBeenCalledWith('/api/mcp/consolidate', {
+      source_spore_ids: ['a', 'b'],
+      consolidated_content: 'merged',
+      observation_type: 'gotcha',
+      tags: ['t1'],
+      reason: 'merge',
+    });
+  });
+
+  it('collective_search forwards query, project, limit', async () => {
+    const client = mockClient({ results: [] });
+    await handleCollectiveSearch({ query: 'q', project: 'p', limit: 2 }, client);
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    expect(url).toContain('q=q');
+    expect(url).toContain('project=p');
+    expect(url).toContain('limit=2');
+  });
+
+  it('collective_project forwards project and include_digest', async () => {
+    const client = mockClient({ project: null });
+    await handleCollectiveProject({ project: 'p', include_digest: true }, client);
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    expect(url).toContain('project=p');
+    expect(url).toContain('include_digest=true');
+  });
+});

--- a/tests/mcp/tools/collective.test.ts
+++ b/tests/mcp/tools/collective.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for collective_search, collective_projects, and collective_project
+ * tool handlers — each proxies through DaemonClient to /api/collective/*.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  handleCollectiveProject,
+  handleCollectiveProjects,
+  handleCollectiveSearch,
+} from '@myco/mcp/tools/collective.js';
+import { DaemonClient } from '@myco/hooks/client.js';
+
+function mockClient(data: unknown = null, ok = true): DaemonClient {
+  return {
+    get: vi.fn().mockResolvedValue({ ok, data }),
+    post: vi.fn().mockResolvedValue({ ok, data }),
+  } as unknown as DaemonClient;
+}
+
+describe('collective_search', () => {
+  it('forwards query, project, and limit to the daemon', async () => {
+    const results = [{ table: 'spores', id: 's1', data: {} }];
+    const client = mockClient({ results });
+
+    const result = await handleCollectiveSearch({ query: 'auth', project: 'myco-main', limit: 3 }, client);
+
+    expect(result).toEqual(results);
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('/api/collective/search'));
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('q=auth'));
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('project=myco-main'));
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('limit=3'));
+  });
+
+  it('returns empty array on daemon failure', async () => {
+    const client = mockClient(null, false);
+    const result = await handleCollectiveSearch({ query: 'x' }, client);
+    expect(result).toEqual([]);
+  });
+
+  it('works without optional project and limit params', async () => {
+    const client = mockClient({ results: [] });
+    await handleCollectiveSearch({ query: 'just-query' }, client);
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    expect(url).toContain('q=just-query');
+    expect(url).not.toContain('project=');
+    expect(url).not.toContain('limit=');
+  });
+});
+
+describe('collective_projects', () => {
+  it('returns projects list from the daemon', async () => {
+    const projects = [{ id: 'p1', name: 'myco-main' }];
+    const client = mockClient({ projects });
+    const result = await handleCollectiveProjects(client);
+    expect(result).toEqual(projects);
+    expect(client.get).toHaveBeenCalledWith('/api/collective/projects');
+  });
+
+  it('returns empty array on daemon failure', async () => {
+    const client = mockClient(null, false);
+    const result = await handleCollectiveProjects(client);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('collective_project', () => {
+  it('forwards project name and include_digest=true as a query string', async () => {
+    const project = { id: 'p1', name: 'myco-main' };
+    const client = mockClient({ project });
+
+    const result = await handleCollectiveProject({ project: 'myco-main', include_digest: true }, client);
+
+    expect(result).toEqual(project);
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    expect(url).toContain('/api/collective/project');
+    expect(url).toContain('project=myco-main');
+    expect(url).toContain('include_digest=true');
+  });
+
+  it('omits include_digest when false (matches buildEndpoint undefined-stripping)', async () => {
+    const client = mockClient({ project: { id: 'p1' } });
+    await handleCollectiveProject({ project: 'p1', include_digest: false }, client);
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    expect(url).not.toContain('include_digest');
+  });
+
+  it('returns null on daemon failure', async () => {
+    const client = mockClient(null, false);
+    const result = await handleCollectiveProject({ project: 'missing' }, client);
+    expect(result).toBeNull();
+  });
+});

--- a/tests/mcp/tools/consolidate.test.ts
+++ b/tests/mcp/tools/consolidate.test.ts
@@ -1,17 +1,79 @@
 /**
- * Tests for myco_consolidate tool handler (Phase 1 stub).
+ * Tests for myco_consolidate tool handler.
+ *
+ * The handler proxies through DaemonClient to POST /api/mcp/consolidate.
+ * Tests mock the client to verify endpoint usage and response mapping.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { handleMycoConsolidate } from '@myco/mcp/tools/consolidate.js';
+import { DaemonClient } from '@myco/hooks/client.js';
+
+function mockClient(data: unknown = null, ok = true): DaemonClient {
+  return {
+    get: vi.fn().mockResolvedValue({ ok, data }),
+    post: vi.fn().mockResolvedValue({ ok, data }),
+  } as unknown as DaemonClient;
+}
 
 describe('myco_consolidate', () => {
-  it('returns unavailable status in Phase 1', async () => {
-    const result = await handleMycoConsolidate({
-      spore_ids: ['spore-1', 'spore-2', 'spore-3'],
+  it('posts to daemon with full body and returns the consolidation result', async () => {
+    const client = mockClient({
+      new_spore_id: 'gotcha-newwisdom',
+      sources_superseded: ['g-1', 'g-2', 'g-3'],
+      status: 'consolidated',
+      created_at: 1700000000,
     });
 
-    expect(result.status).toBe('unavailable');
-    expect(result.message).toContain('Phase 2');
+    const result = await handleMycoConsolidate({
+      source_spore_ids: ['g-1', 'g-2', 'g-3'],
+      consolidated_content: '# Merged gotchas',
+      observation_type: 'gotcha',
+      tags: ['sqlite'],
+      reason: 'Three SQLite gotchas',
+    }, client);
+
+    expect(result.status).toBe('consolidated');
+    expect(result.new_spore_id).toBe('gotcha-newwisdom');
+    expect(result.sources_superseded).toEqual(['g-1', 'g-2', 'g-3']);
+    expect(client.post).toHaveBeenCalledWith('/api/mcp/consolidate', {
+      source_spore_ids: ['g-1', 'g-2', 'g-3'],
+      consolidated_content: '# Merged gotchas',
+      observation_type: 'gotcha',
+      tags: ['sqlite'],
+      reason: 'Three SQLite gotchas',
+    });
+  });
+
+  it('forwards undefined optional fields rather than fabricating them', async () => {
+    const client = mockClient({
+      new_spore_id: 'decision-xyz',
+      sources_superseded: ['d-1', 'd-2'],
+      status: 'consolidated',
+      created_at: 1700000000,
+    });
+
+    await handleMycoConsolidate({
+      source_spore_ids: ['d-1', 'd-2'],
+      consolidated_content: 'merged',
+      observation_type: 'decision',
+    }, client);
+
+    expect(client.post).toHaveBeenCalledWith('/api/mcp/consolidate', {
+      source_spore_ids: ['d-1', 'd-2'],
+      consolidated_content: 'merged',
+      observation_type: 'decision',
+      tags: undefined,
+      reason: undefined,
+    });
+  });
+
+  it('throws on daemon failure', async () => {
+    const client = mockClient(null, false);
+    await expect(handleMycoConsolidate({
+      source_spore_ids: ['a', 'b'],
+      consolidated_content: 'x',
+      observation_type: 'gotcha',
+    }, client)).rejects.toThrow('Failed to consolidate');
   });
 });

--- a/tests/mcp/tools/plans.test.ts
+++ b/tests/mcp/tools/plans.test.ts
@@ -48,4 +48,30 @@ describe('myco_plans', () => {
     await handleMycoPlans({ limit: 5 }, client);
     expect(client.get).toHaveBeenCalledWith(expect.stringContaining('limit=5'));
   });
+
+  it('forwards id to daemon when looking up a specific plan', async () => {
+    const client = mockClient({
+      plans: [{
+        id: 'plan-auth',
+        title: 'Auth',
+        status: 'active',
+        progress: '0/3',
+        tags: [],
+        created_at: 1700000000,
+        content: '# Plan content here',
+      }],
+    });
+    await handleMycoPlans({ id: 'plan-auth' }, client);
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('id=plan-auth'));
+  });
+
+  it('surfaces plan content on single-plan lookup response', async () => {
+    const content = '# Auth Redesign\n\n- [x] Step 1\n- [ ] Step 2';
+    const client = mockClient({
+      plans: [{ id: 'plan-auth', title: 'Auth', status: 'active', progress: '1/2', tags: [], created_at: 1700000000, content }],
+    });
+    const results = await handleMycoPlans({ id: 'plan-auth' }, client);
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe(content);
+  });
 });

--- a/tests/mcp/tools/skills.test.ts
+++ b/tests/mcp/tools/skills.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for myco_skills and myco_skill_candidates tool handlers.
+ *
+ * Both handlers proxy through DaemonClient; skill candidates additionally
+ * dispatches on the `action` field to approve/dismiss via PUT.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { handleMycoSkills, handleMycoSkillCandidates } from '@myco/mcp/tools/skills.js';
+import { DaemonClient } from '@myco/hooks/client.js';
+
+function mockClient(data: unknown = null, ok = true): DaemonClient {
+  return {
+    get: vi.fn().mockResolvedValue({ ok, data }),
+    post: vi.fn().mockResolvedValue({ ok, data }),
+    put: vi.fn().mockResolvedValue({ ok, data }),
+  } as unknown as DaemonClient;
+}
+
+describe('myco_skills', () => {
+  it('lists skills from /api/skill-records with status + limit query', async () => {
+    const records = [{ id: 's1', name: 'demo', status: 'active' }];
+    const client = mockClient({ records });
+
+    const result = await handleMycoSkills({ status: 'active', limit: 5 }, client);
+
+    expect(result).toEqual(records);
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('/api/skill-records'));
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('status=active'));
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('limit=5'));
+  });
+
+  it('fetches a specific skill by id via path segment', async () => {
+    const skill = { id: 's1', name: 'demo', status: 'active' };
+    const client = mockClient(skill);
+
+    const result = await handleMycoSkills({ id: 'demo' }, client);
+
+    expect(result).toEqual(skill);
+    expect(client.get).toHaveBeenCalledWith('/api/skill-records/demo');
+  });
+
+  it('url-encodes the id', async () => {
+    const client = mockClient({ id: 'abc' });
+    await handleMycoSkills({ id: 'weird name/with slashes' }, client);
+    expect(client.get).toHaveBeenCalledWith('/api/skill-records/weird%20name%2Fwith%20slashes');
+  });
+
+  it('returns error shape when looking up a non-existent skill', async () => {
+    const client = mockClient(null, false);
+    const result = await handleMycoSkills({ id: 'missing' }, client);
+    expect(result).toEqual({ error: 'Skill not found' });
+  });
+
+  it('returns empty array when list call fails', async () => {
+    const client = mockClient(null, false);
+    const result = await handleMycoSkills({}, client);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('myco_skill_candidates', () => {
+  it('lists candidates with status + limit query', async () => {
+    const candidates = [{ id: 'c1', topic: 'demo', status: 'identified' }];
+    const client = mockClient({ candidates });
+
+    const result = await handleMycoSkillCandidates({ status: 'identified', limit: 10 }, client);
+
+    expect(result).toEqual(candidates);
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('/api/skill-candidates'));
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('status=identified'));
+  });
+
+  it('fetches a specific candidate by id', async () => {
+    const candidate = { id: 'c1', topic: 'demo' };
+    const client = mockClient(candidate);
+    const result = await handleMycoSkillCandidates({ id: 'c1' }, client);
+    expect(result).toEqual(candidate);
+    expect(client.get).toHaveBeenCalledWith('/api/skill-candidates/c1');
+  });
+
+  it('approves a candidate via PUT with status=approved', async () => {
+    const client = mockClient({ id: 'c1', status: 'approved' });
+    await handleMycoSkillCandidates({ action: 'approve', id: 'c1' }, client);
+    expect(client.put).toHaveBeenCalledWith('/api/skill-candidates/c1', { status: 'approved' });
+  });
+
+  it('dismisses a candidate via PUT with status=dismissed', async () => {
+    const client = mockClient({ id: 'c1', status: 'dismissed' });
+    await handleMycoSkillCandidates({ action: 'dismiss', id: 'c1' }, client);
+    expect(client.put).toHaveBeenCalledWith('/api/skill-candidates/c1', { status: 'dismissed' });
+  });
+
+  it('rejects approve/dismiss without an id', async () => {
+    const client = mockClient({});
+    const result = await handleMycoSkillCandidates({ action: 'approve' }, client);
+    expect(result).toEqual({ error: "Action 'approve' requires an id" });
+    expect(client.put).not.toHaveBeenCalled();
+  });
+
+  it('returns error shape when PUT fails', async () => {
+    const client = mockClient(null, false);
+    const result = await handleMycoSkillCandidates({ action: 'approve', id: 'c1' }, client);
+    expect(result).toEqual({ error: 'Failed to approve candidate' });
+  });
+});

--- a/tests/mcp/tools/team.test.ts
+++ b/tests/mcp/tools/team.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for myco_team tool handler.
+ *
+ * The handler proxies GET /api/mcp/team through DaemonClient.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { handleMycoTeam } from '@myco/mcp/tools/team.js';
+import { DaemonClient } from '@myco/hooks/client.js';
+
+function mockClient(data: unknown = null, ok = true): DaemonClient {
+  return {
+    get: vi.fn().mockResolvedValue({ ok, data }),
+    post: vi.fn().mockResolvedValue({ ok, data }),
+  } as unknown as DaemonClient;
+}
+
+describe('myco_team', () => {
+  it('returns the list of team members from the daemon', async () => {
+    const members = [
+      { id: 'm1', user: 'alice', role: 'lead', joined: '2024-01-02', tags: ['frontend'] },
+      { id: 'm2', user: 'bob', role: 'eng', joined: '2024-02-01', tags: [] },
+    ];
+    const client = mockClient({ members });
+
+    const result = await handleMycoTeam({}, client);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].user).toBe('alice');
+    expect(client.get).toHaveBeenCalledWith('/api/mcp/team');
+  });
+
+  it('returns empty array when daemon fails', async () => {
+    const client = mockClient(null, false);
+    const result = await handleMycoTeam({}, client);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when daemon response has no members key', async () => {
+    const client = mockClient({ somethingElse: [] });
+    const result = await handleMycoTeam({}, client);
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
This PR finishes the MCP server/tool contract hardening work and adds coverage for the drift bugs that prompted it.

- wire daemon-backed consolidation through the MCP proxy and server dispatch
- extend MCP plans/sessions support to match the documented tool schema
- tighten MCP tool definitions so they reflect the actual daemon-backed contracts
- add anti-drift tests for tool definitions and focused handler coverage for collective, skills, and team tools
- simplify the proxy layer and make consolidation writes atomic with a transaction

## Review Pass
The simplification/code-review pass addressed one real correctness risk in the new code path:

- consolidation previously performed a multi-row write without a transaction, which could leave a partially consolidated state on mid-operation failure; the daemon proxy now wraps the write set atomically

## Verification
- `npx vitest run tests/mcp/server.test.ts tests/mcp/tool-definitions.test.ts tests/mcp/tools/collective.test.ts tests/mcp/tools/consolidate.test.ts tests/mcp/tools/plans.test.ts tests/mcp/tools/sessions.test.ts tests/mcp/tools/skills.test.ts tests/mcp/tools/team.test.ts tests/mcp/tools/supersede.test.ts`
- `make build`