### PR TITLE
fix: live config hot reload and TeamSync runtime reconciliation

### DIFF
--- a/packages/myco/src/agent/config-resolver.ts
+++ b/packages/myco/src/agent/config-resolver.ts
@@ -20,7 +20,7 @@ import {
   resolveEffectiveConfig,
 } from './loader.js';
 import { loadAllTasks } from './registry.js';
-import { loadConfig } from '@myco/config/loader.js';
+import { loadMergedConfig } from '@myco/config/loader.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import type { ProviderConfig, EffectiveConfig } from './types.js';
 
@@ -147,7 +147,7 @@ export function resolveRunConfig(
   let phaseProviderOverrides: Record<string, { provider?: ProviderConfig; maxTurns?: number }> = {};
   let taskParams: Record<string, string | number | boolean> | undefined;
   try {
-    const mycoConfig = loadConfig(vaultDir);
+    const mycoConfig = loadMergedConfig(vaultDir);
 
     // Per-task override takes priority over global
     const taskConfig = taskName ? mycoConfig.agent.tasks?.[taskName] : undefined;

--- a/packages/myco/src/cli/doctor.ts
+++ b/packages/myco/src/cli/doctor.ts
@@ -46,8 +46,8 @@ async function checkVault(vaultDir: string): Promise<{ check: DoctorCheck; confi
     return { check: { name: 'Vault', status: 'fail', detail: `${CONFIG_FILENAME} not found in ${vaultDir}`, fixable: false }, config: null };
   }
   try {
-    const { loadConfig } = await import('../config/loader.js');
-    const config = loadConfig(vaultDir);
+    const { loadMergedConfig } = await import('../config/loader.js');
+    const config = loadMergedConfig(vaultDir);
     return { check: { name: 'Vault', status: 'ok', detail: `.myco/ (v${config.version})`, fixable: false }, config };
   } catch (err) {
     return { check: { name: 'Vault', status: 'fail', detail: `${CONFIG_FILENAME} parse error: ${(err as Error).message}`, fixable: false }, config: null };

--- a/packages/myco/src/cli/init.ts
+++ b/packages/myco/src/cli/init.ts
@@ -64,8 +64,8 @@ export async function run(args: string[]): Promise<void> {
 
   // Show existing config summary on re-init
   if (alreadyInitialized && isInteractive) {
-    const { loadConfig } = await import('../config/loader.js');
-    const config = loadConfig(vaultDir);
+    const { loadMergedConfig } = await import('../config/loader.js');
+    const config = loadMergedConfig(vaultDir);
     const agentProvider = config.agent.provider;
     const embConfig = config.embedding;
 
@@ -84,14 +84,12 @@ export async function run(args: string[]): Promise<void> {
       fs.mkdirSync(path.join(vaultDir, dir), { recursive: true });
     }
 
-    // Agent disabled by default -- user enables via dashboard after configuring a provider
+    // Let schema defaults fill the agent section. Scheduled/event toggles
+    // default to true, but the agent only runs once the user configures a
+    // provider in Settings, so a no-op "enabled" state is safe.
     const config = MycoConfigSchema.parse({
       version: 3,
       ...(Object.keys(embeddingFromFlags).length > 0 ? { embedding: embeddingFromFlags } : {}),
-      agent: {
-        scheduled_tasks_enabled: false,
-        event_tasks_enabled: false,
-      },
     });
 
     saveConfig(vaultDir, config);
@@ -113,8 +111,8 @@ export async function run(args: string[]): Promise<void> {
   let existingSymbionts: Record<string, { enabled: boolean }> | undefined;
   if (alreadyInitialized && isInteractive) {
     try {
-      const { loadConfig } = await import('../config/loader.js');
-      const existing = loadConfig(vaultDir);
+      const { loadMergedConfig } = await import('../config/loader.js');
+      const existing = loadMergedConfig(vaultDir);
       existingSymbionts = existing.symbionts;
     } catch { /* config not loadable — skip pre-check */ }
   }

--- a/packages/myco/src/cli/verify.ts
+++ b/packages/myco/src/cli/verify.ts
@@ -1,10 +1,10 @@
-import { loadConfig } from '../config/loader.js';
+import { loadMergedConfig } from '../config/loader.js';
 import { createEmbeddingProvider } from '../intelligence/llm.js';
 
 const VERIFY_EMBEDDING_INPUT = 'test';
 
 export async function run(_args: string[], vaultDir: string): Promise<void> {
-  const config = loadConfig(vaultDir);
+  const config = loadMergedConfig(vaultDir);
   const embeddingConfig = config.embedding;
 
   let embeddingOk = false;

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -12,7 +12,7 @@ import { listReports } from '@myco/db/queries/reports.js';
 import { listTurnsByRun } from '@myco/db/queries/turns.js';
 import { buildTaskInstruction, isInstructionRequiredTask } from '@myco/agent/instruction-builders.js';
 import { hasConfiguredProvider } from '@myco/agent/config-resolver.js';
-import { loadConfig } from '@myco/config/loader.js';
+import { loadMergedConfig } from '@myco/config/loader.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { notify } from '@myco/notifications/notify.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
@@ -62,7 +62,7 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
 
     // Guard: ensure a provider is configured before allowing a run.
     // Uses the same per-task-over-global precedence as the executor's resolver.
-    const mycoConfig = loadConfig(vaultDir);
+    const mycoConfig = loadMergedConfig(vaultDir);
     if (!hasConfiguredProvider(mycoConfig, task)) {
       return {
         status: 400,

--- a/packages/myco/src/daemon/api/agent-tasks.ts
+++ b/packages/myco/src/daemon/api/agent-tasks.ts
@@ -25,7 +25,7 @@ import {
 } from '@myco/agent/registry.js';
 import { resolveDefinitionsDir } from '@myco/agent/loader.js';
 import { USER_TASK_SOURCE } from '@myco/constants.js';
-import { loadConfig, updateConfig } from '../../config/loader.js';
+import { loadMergedConfig, updateConfig } from '../../config/loader.js';
 import { withTaskConfig } from '../../config/updates.js';
 import type { TaskConfigUpdate } from '../../config/updates.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
@@ -305,7 +305,7 @@ export async function handleGetTaskConfig(
   vaultDir: string,
 ): Promise<RouteResponse> {
   const taskId = req.params.id;
-  const config = loadConfig(vaultDir);
+  const config = loadMergedConfig(vaultDir);
   const taskConfig = config.agent.tasks?.[taskId] ?? null;
   return { status: HTTP_OK, body: { taskId, config: taskConfig } };
 }

--- a/packages/myco/src/daemon/api/backup.ts
+++ b/packages/myco/src/daemon/api/backup.ts
@@ -8,13 +8,15 @@
 
 import type { Database } from 'better-sqlite3';
 import type { RouteRequest, RouteResponse } from '../router.js';
+import type { MycoConfig } from '../../config/schema.js';
 import {
   createBackup,
   listBackups,
   restorePreview,
   restoreBackup,
 } from '../backup.js';
-import { loadConfig, updateBackupConfig } from '../../config/loader.js';
+import { loadMergedConfig, updateBackupConfig } from '../../config/loader.js';
+import os from 'node:os';
 import path from 'node:path';
 
 // ---------------------------------------------------------------------------
@@ -24,8 +26,26 @@ import path from 'node:path';
 /** Dependencies injected by the daemon when registering backup routes. */
 export interface BackupDeps {
   db: Database;
-  backupDir: string;
   machineId: string;
+  vaultDir: string;
+  // Holder so the dir is re-resolved on every request — a user can change
+  // `backup.dir` in Settings (either scope) and the next backup writes to
+  // the new location without a daemon restart.
+  liveConfig: { current: MycoConfig };
+}
+
+/**
+ * Resolve the effective backup directory from the current config. The user's
+ * configured path may be relative or start with `~/`; absent, it falls back
+ * to `<vaultDir>/backups`.
+ */
+export function resolveBackupDir(config: MycoConfig, vaultDir: string): string {
+  const rawDir = config.backup.dir;
+  if (!rawDir) return path.resolve(vaultDir, 'backups');
+  const expanded = rawDir.startsWith('~/')
+    ? path.join(os.homedir(), rawDir.slice(2))
+    : rawDir;
+  return path.resolve(expanded);
 }
 
 // ---------------------------------------------------------------------------
@@ -38,10 +58,13 @@ export interface BackupDeps {
  * Returns an object with named handlers for each backup endpoint.
  */
 export function createBackupHandlers(deps: BackupDeps) {
+  const currentBackupDir = () => resolveBackupDir(deps.liveConfig.current, deps.vaultDir);
+
   /** POST /api/backup — create a new backup of all synced tables. */
   async function handleCreateBackup(_req: RouteRequest): Promise<RouteResponse> {
-    const filePath = createBackup(deps.db, deps.backupDir, deps.machineId);
-    const backups = listBackups(deps.backupDir);
+    const backupDir = currentBackupDir();
+    const filePath = createBackup(deps.db, backupDir, deps.machineId);
+    const backups = listBackups(backupDir);
     const created = backups.find((b) => b.machine_id === deps.machineId);
 
     return {
@@ -55,7 +78,7 @@ export function createBackupHandlers(deps: BackupDeps) {
 
   /** GET /api/backups — list all backup files with metadata. */
   async function handleListBackups(_req: RouteRequest): Promise<RouteResponse> {
-    const backups = listBackups(deps.backupDir);
+    const backups = listBackups(currentBackupDir());
     return { body: { backups } };
   }
 
@@ -66,13 +89,14 @@ export function createBackupHandlers(deps: BackupDeps) {
       return { status: 400, body: { error: 'missing_machine_id' } };
     }
 
-    const backups = listBackups(deps.backupDir);
+    const backupDir = currentBackupDir();
+    const backups = listBackups(backupDir);
     const backup = backups.find((b) => b.machine_id === machine_id);
     if (!backup) {
       return { status: 404, body: { error: 'backup_not_found' } };
     }
 
-    const backupPath = `${deps.backupDir}/${backup.file_name}`;
+    const backupPath = `${backupDir}/${backup.file_name}`;
     const tables = restorePreview(deps.db, backupPath);
     const total_new = tables.reduce((sum, t) => sum + t.new, 0);
     const total_existing = tables.reduce((sum, t) => sum + t.existing, 0);
@@ -87,13 +111,14 @@ export function createBackupHandlers(deps: BackupDeps) {
       return { status: 400, body: { error: 'missing_machine_id' } };
     }
 
-    const backups = listBackups(deps.backupDir);
+    const backupDir = currentBackupDir();
+    const backups = listBackups(backupDir);
     const backup = backups.find((b) => b.machine_id === machine_id);
     if (!backup) {
       return { status: 404, body: { error: 'backup_not_found' } };
     }
 
-    const backupPath = `${deps.backupDir}/${backup.file_name}`;
+    const backupPath = `${backupDir}/${backup.file_name}`;
     const result = restoreBackup(deps.db, backupPath);
 
     return { body: { machine_id, ...result } };
@@ -121,9 +146,9 @@ export interface BackupConfigDeps {
 export function createBackupConfigHandlers(deps: BackupConfigDeps) {
   const { vaultDir } = deps;
 
-  /** GET /api/backup/config — read the configured backup directory. */
+  /** GET /api/backup/config — read the configured backup directory (merged). */
   async function handleGetBackupConfig(): Promise<RouteResponse> {
-    const cfg = loadConfig(vaultDir);
+    const cfg = loadMergedConfig(vaultDir);
     return { body: { dir: cfg.backup.dir ?? null, default_dir: path.resolve(vaultDir, 'backups') } };
   }
 

--- a/packages/myco/src/daemon/api/context.ts
+++ b/packages/myco/src/daemon/api/context.ts
@@ -32,7 +32,10 @@ import type { DaemonLogger } from '../logger.js';
 export interface ContextDeps {
   embeddingManager: EmbeddingManager;
   logger: DaemonLogger;
-  config: MycoConfig;
+  // Holder so each request reads the current merged config — a user can
+  // flip `context.prompt_search` or bump `context.digest_tier` and the
+  // very next request sees the change without a daemon restart.
+  liveConfig: { current: MycoConfig };
 }
 
 // ---------------------------------------------------------------------------
@@ -68,7 +71,8 @@ const PromptContextBody = z.object({
 export function createSessionContextHandler(deps: ContextDeps) {
   return async function handleSessionContext(req: RouteRequest): Promise<RouteResponse> {
     const { session_id, branch } = SessionContextBody.parse(req.body);
-    const { logger, config } = deps;
+    const { logger, liveConfig } = deps;
+    const config = liveConfig.current;
 
     logger.debug(LOG_KINDS.CONTEXT_QUERY, 'Session context query', { session_id });
 
@@ -225,7 +229,8 @@ export function createResumeContextHandler(deps: ContextDeps) {
 export function createPromptContextHandler(deps: ContextDeps) {
   return async function handlePromptContext(req: RouteRequest): Promise<RouteResponse> {
     const { prompt, session_id } = PromptContextBody.parse(req.body);
-    const { logger, config, embeddingManager } = deps;
+    const { logger, liveConfig, embeddingManager } = deps;
+    const config = liveConfig.current;
 
     // Guard: prompt search disabled
     if (!config.context.prompt_search) {

--- a/packages/myco/src/daemon/api/embedding.ts
+++ b/packages/myco/src/daemon/api/embedding.ts
@@ -1,5 +1,5 @@
 import { getEmbeddingQueueDepth } from '@myco/db/queries/embeddings.js';
-import { loadConfig } from '../../config/loader.js';
+import { loadMergedConfig } from '../../config/loader.js';
 import { EMBEDDING_BATCH_SIZE } from '../../constants.js';
 import type { EmbeddingManager } from '../embedding/index.js';
 import type { RouteResponse } from '../router.js';
@@ -19,7 +19,7 @@ const EMBEDDING_STATUS_PENDING = 'pending';
 // ---------------------------------------------------------------------------
 
 export async function handleGetEmbeddingStatus(vaultDir: string): Promise<RouteResponse> {
-  const config = loadConfig(vaultDir);
+  const config = loadMergedConfig(vaultDir);
 
   const { queue_depth, embedded_count } = getEmbeddingQueueDepth();
 

--- a/packages/myco/src/daemon/api/notifications.ts
+++ b/packages/myco/src/daemon/api/notifications.ts
@@ -16,7 +16,7 @@ import {
 } from '../../db/queries/notifications.js';
 import { getAllDomains } from '../../notifications/registry.js';
 import { notify } from '../../notifications/notify.js';
-import { loadConfig } from '../../config/loader.js';
+import { loadMergedConfig } from '../../config/loader.js';
 import type { NotificationMode } from '../../notifications/types.js';
 
 // ---------------------------------------------------------------------------
@@ -77,7 +77,7 @@ export async function handleCreateNotification(
   const { domain, type, title, message, link, metadata } = parsed.data;
 
   // Check config for structured HTTP responses before delegating
-  const config = loadConfig(vaultDir);
+  const config = loadMergedConfig(vaultDir);
   if (!config.notifications.enabled) {
     return { body: { ok: true, suppressed: true, reason: 'notifications_disabled' } };
   }

--- a/packages/myco/src/daemon/api/session-lifecycle.ts
+++ b/packages/myco/src/daemon/api/session-lifecycle.ts
@@ -49,7 +49,10 @@ export interface SessionLifecycleDeps {
   powerManager: PowerManager;
   machineId: string;
   logger: DaemonLogger;
-  config: MycoConfig;
+  // Holder so notify() consults the current merged config — a user toggling
+  // notifications.enabled or a domain's enabled flag sees the next event gate
+  // respect the change without a daemon restart.
+  liveConfig: { current: MycoConfig };
   vaultDir: string;
 }
 
@@ -67,7 +70,7 @@ export function createSessionLifecycleHandlers(deps: SessionLifecycleDeps) {
     powerManager,
     machineId,
     logger,
-    config,
+    liveConfig,
     vaultDir,
   } = deps;
 
@@ -108,7 +111,7 @@ export function createSessionLifecycleHandlers(deps: SessionLifecycleDeps) {
       message: branch ? `Branch: ${branch}` : undefined,
       link: `/sessions/${session_id}`,
       metadata: { sessionId: session_id, agent: agent ?? 'claude-code', branch },
-    }, config);
+    }, liveConfig.current);
 
     return { body: { ok: true, sessions: registry.sessions } };
   }
@@ -138,7 +141,7 @@ export function createSessionLifecycleHandlers(deps: SessionLifecycleDeps) {
       title: 'Session ended',
       link: `/sessions/${session_id}`,
       metadata: { sessionId: session_id },
-    }, config);
+    }, liveConfig.current);
 
     return { body: { ok: true, sessions: registry.sessions } };
   }

--- a/packages/myco/src/daemon/api/sessions.ts
+++ b/packages/myco/src/daemon/api/sessions.ts
@@ -82,11 +82,11 @@ export interface SessionMutationDeps {
   embeddingManager: EmbeddingManager;
   vaultDir: string;
   logger: DaemonLogger;
-  config: MycoConfig;
+  liveConfig: { current: MycoConfig };
 }
 
 export function createSessionMutationHandlers(deps: SessionMutationDeps) {
-  const { embeddingManager, vaultDir, logger, config } = deps;
+  const { embeddingManager, vaultDir, logger, liveConfig } = deps;
 
   /** DELETE /api/sessions/:id — cascade delete with post-transaction cleanup. */
   async function handleDeleteSession(req: RouteRequest): Promise<RouteResponse> {
@@ -129,7 +129,7 @@ export function createSessionMutationHandlers(deps: SessionMutationDeps) {
       });
     }
 
-    await triggerTitleSummary(sessionId, { vaultDir, embeddingManager, config, logger });
+    await triggerTitleSummary(sessionId, { vaultDir, embeddingManager, liveConfig, logger });
 
     logger.info(LOG_KINDS.API_SESSION_COMPLETE, 'Session manually completed', {
       session_id: sessionId,

--- a/packages/myco/src/daemon/api/symbionts.ts
+++ b/packages/myco/src/daemon/api/symbionts.ts
@@ -1,5 +1,5 @@
 import { loadManifests } from '@myco/symbionts/detect.js';
-import { loadConfig, getEnabledSymbiontNames } from '../../config/loader.js';
+import { loadMergedConfig, getEnabledSymbiontNames } from '../../config/loader.js';
 import type { RouteResponse } from '../router.js';
 
 // ---------------------------------------------------------------------------
@@ -32,7 +32,7 @@ export async function handleListSymbionts(vaultDir: string): Promise<RouteRespon
 
   let enabledNames: Set<string> | null = null;
   try {
-    enabledNames = getEnabledSymbiontNames(loadConfig(vaultDir));
+    enabledNames = getEnabledSymbiontNames(loadMergedConfig(vaultDir));
   } catch { /* config not loadable */ }
 
   const symbionts: SymbiontInfo[] = manifests.map((m) => ({

--- a/packages/myco/src/daemon/api/team-connect.ts
+++ b/packages/myco/src/daemon/api/team-connect.ts
@@ -5,7 +5,7 @@
  * close over the daemon's shared state (vault dir, machine ID, team client).
  */
 
-import { updateTeamConfig, loadConfig } from '@myco/config/loader.js';
+import { updateTeamConfig, loadMergedConfig } from '@myco/config/loader.js';
 import { writeSecret, readSecrets } from '@myco/config/secrets.js';
 import { countPending, countDeadLettered, backfillUnsynced, retryDeadLettered } from '@myco/db/queries/team-outbox.js';
 import { readJsonConfig, resolveVaultConfigPath } from '@myco-deploy/index.js';
@@ -105,10 +105,7 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
     });
     writeSecret(vaultDir, TEAM_API_KEY_SECRET, api_key);
 
-    // Set the live client
-    deps.setTeamClient(client);
-
-    const config = loadConfig(vaultDir);
+    const config = loadMergedConfig(vaultDir);
     return { body: { connected: true, team: config.team } };
   }
 
@@ -119,7 +116,6 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
    */
   async function handleDisconnect(_req: RouteRequest): Promise<RouteResponse> {
     updateTeamConfig(vaultDir, { enabled: false });
-    deps.setTeamClient(null);
 
     return { body: { connected: false } };
   }
@@ -130,7 +126,7 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
    * Returns connection status, health check result, pending sync count, and machine_id.
    */
   async function handleStatus(_req: RouteRequest): Promise<RouteResponse> {
-    const config = loadConfig(vaultDir);
+    const config = loadMergedConfig(vaultDir);
     const client = deps.getTeamClient();
     const secrets = readSecrets(vaultDir);
     const hasApiKey = Boolean(secrets[TEAM_API_KEY_SECRET]);

--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -50,7 +50,9 @@ export interface EventDispatchDeps {
   powerManager: PowerManager;
   logger: DaemonLogger;
   machineId: string;
-  config: MycoConfig;
+  // Holder so summary_batch_interval is read fresh on each user_prompt event —
+  // changing the interval in Settings takes effect on the very next prompt.
+  liveConfig: { current: MycoConfig };
   vaultDir: string;
   reconcileSession: (sessionId: string) => void;
   planWatchConfig: PlanWatchConfig; // object reference — mutated in place for hot-reload
@@ -68,7 +70,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
     powerManager,
     logger,
     machineId,
-    config,
+    liveConfig,
     vaultDir: vaultDir,
     reconcileSession,
     planWatchConfig,
@@ -165,7 +167,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
 
           // Batch-threshold summary trigger
           const batchCount = promptNumber;
-          const summaryInterval = config.agent.summary_batch_interval;
+          const summaryInterval = liveConfig.current.agent.summary_batch_interval;
           if (summaryInterval > 0 && batchCount > 0 && batchCount % summaryInterval === 0) {
             triggerTitleSummary(event.session_id);
           }

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -10,7 +10,7 @@
 import { DaemonServer } from './server.js';
 import { SessionRegistry } from './lifecycle.js';
 import { DaemonLogger } from './logger.js';
-import { loadConfig, updateConfig } from '../config/loader.js';
+import { loadMergedConfig, updateConfig } from '../config/loader.js';
 import { resolvePort } from './port.js';
 import { TranscriptMiner } from '../capture/transcript-miner.js';
 import { createPerProjectAdapter } from '../symbionts/adapter.js';
@@ -200,7 +200,14 @@ export async function main(): Promise<void> {
   // Load API keys from secrets.env into process.env before any provider init
   loadSecrets(vaultDir);
 
-  const config = loadConfig(vaultDir);
+  // Merged = project (myco.yaml) + personal overlay (local.yaml). Any gate
+  // downstream of this needs to see personal overrides, so the daemon loads
+  // the merged view and never the raw project config.
+  const config = loadMergedConfig(vaultDir);
+  // Mutable holder that reactions update after each scoped-config write, so
+  // runtime gates (scheduled-task registration, event triggers) observe the
+  // flipped value without a daemon restart.
+  const liveConfig: { current: typeof config } = { current: config };
 
   const manifests = loadManifests();
   const symbiontPlanDirs = manifests.flatMap((m) => m.capture?.planDirs ?? []);
@@ -391,7 +398,7 @@ export async function main(): Promise<void> {
           message: 'Daemon restarted while run was in progress',
           link: `/agent?run=${row.id}`,
           metadata: { taskName: row.task, runId: row.id, reason: 'daemon_restart' },
-        }, config);
+        }, liveConfig.current);
       }
       logger.info(LOG_KINDS.AGENT_RUN, 'Cleaned stale running agent runs', {
         count: staleRows.length,
@@ -460,7 +467,7 @@ export async function main(): Promise<void> {
     transcriptMiner,
     embeddingManager,
     logger,
-    config,
+    liveConfig,
     vaultDir,
     planTags: symbiontPlanTags,
   });
@@ -468,7 +475,7 @@ export async function main(): Promise<void> {
   // --- Session routes ---
   const sessionLifecycle = createSessionLifecycleHandlers({
     registry, sessionBuffers, reconciler, stopProcessor,
-    server, powerManager, machineId, logger, config, vaultDir,
+    server, powerManager, machineId, logger, liveConfig, vaultDir,
   });
   server.registerRoute('POST', '/sessions/register', sessionLifecycle.handleRegister);
   server.registerRoute('POST', '/sessions/unregister', sessionLifecycle.handleUnregister);
@@ -481,7 +488,7 @@ export async function main(): Promise<void> {
     powerManager,
     logger,
     machineId,
-    config,
+    liveConfig,
     vaultDir,
     reconcileSession: reconciler.reconcileSession,
     planWatchConfig,
@@ -494,7 +501,7 @@ export async function main(): Promise<void> {
   server.registerRoute('POST', '/events/stop', stopProcessor.handleStopRoute);
 
   // --- Context injection (digest + semantic spore search) ---
-  const contextDeps = { embeddingManager, config, logger };
+  const contextDeps = { embeddingManager, liveConfig, logger };
   server.registerRoute('POST', '/context', createSessionContextHandler(contextDeps));
   server.registerRoute('POST', '/context/resume', createResumeContextHandler(contextDeps));
   server.registerRoute('POST', '/context/prompt', createPromptContextHandler(contextDeps));
@@ -526,6 +533,11 @@ export async function main(): Promise<void> {
   // Refresh the live-stats configHash on every write.
   reactions.on([], () => { configHash = computeConfigHash(vaultDir); });
 
+  // Keep liveConfig pointed at the latest merged config so runtime gates
+  // (agent.scheduled_tasks_enabled, agent.event_tasks_enabled) pick up
+  // toggle flips immediately.
+  reactions.on([], (ctx) => { liveConfig.current = ctx; });
+
   // Reinstall symbiont artefacts (agent hooks, .gitignore) when capture dirs
   // or symbiont enablement change. The reconcile has no other config inputs.
   reactions.on(['capture', 'symbionts'], (ctx) => {
@@ -548,14 +560,31 @@ export async function main(): Promise<void> {
     }
   });
 
+  async function syncScheduledTasks() {
+    await registerScheduledTasks(powerManager, { definitionsDir, vaultDir, embeddingManager, logger, liveConfig });
+  }
+
+  reactions.on(['agent.tasks'], async () => {
+    await syncScheduledTasks();
+  });
+
+  async function applyConfigWriteReactions(touchedPaths: string[]) {
+    const reactionContext = loadReactionContext(vaultDir, logger);
+    if (!reactionContext) {
+      configHash = computeConfigHash(vaultDir);
+      return null;
+    }
+    await reactions.fire(touchedPaths, reactionContext);
+    return reactionContext;
+  }
+
   server.registerRoute('PUT', '/api/config/scoped', async (req) => {
     const result = await handlePutScopedConfig(vaultDir, req.body);
     if (!result.status || result.status < 400) {
       const body = req.body as { scope: 'project' | 'local'; patch?: unknown; clear?: string[] };
       const touchedPaths = computeTouchedPaths(body.patch, body.clear);
-      const reactionContext = loadReactionContext(vaultDir, logger);
+      const reactionContext = await applyConfigWriteReactions(touchedPaths);
       if (reactionContext) {
-        await reactions.fire(touchedPaths, reactionContext);
         const summary = buildScopedConfigSaveNotification(body.scope, touchedPaths);
         notify(vaultDir, {
           domain: 'settings',
@@ -621,7 +650,7 @@ export async function main(): Promise<void> {
   server.registerRoute('GET', '/api/sessions', handleListSessions);
 
   server.registerRoute('GET', '/api/sessions/:id', handleGetSession);
-  const sessionMutations = createSessionMutationHandlers({ embeddingManager, vaultDir, logger, config });
+  const sessionMutations = createSessionMutationHandlers({ embeddingManager, vaultDir, logger, liveConfig });
   server.registerRoute('GET', '/api/sessions/:id/impact', sessionMutations.handleGetSessionImpact);
   server.registerRoute('POST', '/api/sessions/:id/complete', sessionMutations.handleCompleteSession);
   server.registerRoute('DELETE', '/api/sessions/:id', sessionMutations.handleDeleteSession);
@@ -662,12 +691,42 @@ export async function main(): Promise<void> {
   server.registerRoute('GET', '/api/agent/tasks', async (req) => handleListTasks(req, vaultDir));
   server.registerRoute('GET', '/api/agent/tasks/:id', async (req) => handleGetTask(req, vaultDir));
   server.registerRoute('GET', '/api/agent/tasks/:id/yaml', async (req) => handleGetTaskYaml(req, vaultDir));
-  server.registerRoute('PUT', '/api/agent/tasks/:id', async (req) => handleUpdateTask(req, vaultDir));
-  server.registerRoute('POST', '/api/agent/tasks', async (req) => handleCreateTask(req, vaultDir));
-  server.registerRoute('POST', '/api/agent/tasks/:id/copy', async (req) => handleCopyTask(req, vaultDir));
-  server.registerRoute('DELETE', '/api/agent/tasks/:id', async (req) => handleDeleteTask(req, vaultDir));
+  server.registerRoute('PUT', '/api/agent/tasks/:id', async (req) => {
+    const result = await handleUpdateTask(req, vaultDir);
+    if (!result.status || result.status < 400) {
+      await syncScheduledTasks();
+    }
+    return result;
+  });
+  server.registerRoute('POST', '/api/agent/tasks', async (req) => {
+    const result = await handleCreateTask(req, vaultDir);
+    if (!result.status || result.status < 400) {
+      await syncScheduledTasks();
+    }
+    return result;
+  });
+  server.registerRoute('POST', '/api/agent/tasks/:id/copy', async (req) => {
+    const result = await handleCopyTask(req, vaultDir);
+    if (!result.status || result.status < 400) {
+      await syncScheduledTasks();
+    }
+    return result;
+  });
+  server.registerRoute('DELETE', '/api/agent/tasks/:id', async (req) => {
+    const result = await handleDeleteTask(req, vaultDir);
+    if (!result.status || result.status < 400) {
+      await syncScheduledTasks();
+    }
+    return result;
+  });
   server.registerRoute('GET', '/api/agent/tasks/:id/config', async (req) => handleGetTaskConfig(req, vaultDir));
-  server.registerRoute('PUT', '/api/agent/tasks/:id/config', async (req) => handleUpdateTaskConfig(req, vaultDir));
+  server.registerRoute('PUT', '/api/agent/tasks/:id/config', async (req) => {
+    const result = await handleUpdateTaskConfig(req, vaultDir);
+    if (!result.status || result.status < 400) {
+      await applyConfigWriteReactions([`agent.tasks.${req.params.id}`]);
+    }
+    return result;
+  });
 
   // --- Provider detection & testing ---
   server.registerRoute('GET', '/api/providers', async () => handleGetProviders());
@@ -685,11 +744,7 @@ export async function main(): Promise<void> {
   server.registerRoute('GET', '/api/mcp/team', mcpProxy.handleTeam);
 
   // --- Backup routes ---
-  const rawBackupDir = config.backup.dir;
-  const backupDir = rawBackupDir
-    ? path.resolve(rawBackupDir.startsWith('~/') ? path.join(os.homedir(), rawBackupDir.slice(2)) : rawBackupDir)
-    : path.resolve(vaultDir, 'backups');
-  const backupHandlers = createBackupHandlers({ db, backupDir, machineId });
+  const backupHandlers = createBackupHandlers({ db, machineId, vaultDir, liveConfig });
   server.registerRoute('POST', '/api/backup', backupHandlers.handleCreateBackup);
   server.registerRoute('GET', '/api/backups', backupHandlers.handleListBackups);
   server.registerRoute('POST', '/api/restore/preview', backupHandlers.handleRestorePreview);
@@ -697,10 +752,20 @@ export async function main(): Promise<void> {
 
   const backupConfigHandlers = createBackupConfigHandlers({ vaultDir });
   server.registerRoute('GET', '/api/backup/config', backupConfigHandlers.handleGetBackupConfig);
-  server.registerRoute('PUT', '/api/backup/config', backupConfigHandlers.handlePutBackupConfig);
+  server.registerRoute('PUT', '/api/backup/config', async (req) => {
+    const result = await backupConfigHandlers.handlePutBackupConfig(req);
+    if (!result.status || result.status < 400) {
+      await applyConfigWriteReactions(['backup.dir']);
+    }
+    return result;
+  });
 
   // --- Team sync ---
-  const teamSync = initTeamSync({ config, machineId, logger, vaultDir, serverVersion: server.version });
+  const teamSync = initTeamSync({ liveConfig, machineId, logger, vaultDir, serverVersion: server.version });
+  reactions.on(['team'], async () => {
+    await teamSync.reconcileClient();
+  });
+  await teamSync.reconcileClient();
 
   const teamHandlers = createTeamHandlers({
     vaultDir,
@@ -709,8 +774,20 @@ export async function main(): Promise<void> {
     getTeamClient: teamSync.getTeamClient,
     setTeamClient: teamSync.setTeamClient,
   });
-  server.registerRoute('POST', '/api/team/connect', teamHandlers.handleConnect);
-  server.registerRoute('POST', '/api/team/disconnect', teamHandlers.handleDisconnect);
+  server.registerRoute('POST', '/api/team/connect', async (req) => {
+    const result = await teamHandlers.handleConnect(req);
+    if (!result.status || result.status < 400) {
+      await applyConfigWriteReactions(['team.enabled', 'team.worker_url']);
+    }
+    return result;
+  });
+  server.registerRoute('POST', '/api/team/disconnect', async (req) => {
+    const result = await teamHandlers.handleDisconnect(req);
+    if (!result.status || result.status < 400) {
+      await applyConfigWriteReactions(['team.enabled', 'team.worker_url']);
+    }
+    return result;
+  });
   server.registerRoute('GET', '/api/team/status', teamHandlers.handleStatus);
   server.registerRoute('POST', '/api/team/backfill', teamHandlers.handleBackfill);
   server.registerRoute('POST', '/api/team/retry-failed', teamHandlers.handleRetryFailed);
@@ -775,11 +852,11 @@ export async function main(): Promise<void> {
   }
 
   // --- Register power-managed jobs ---
-  registerPowerJobs(powerManager, { embeddingManager, registry, logger, config, db, backupDir, machineId, vaultDir, databaseManager });
+  registerPowerJobs(powerManager, { embeddingManager, registry, logger, liveConfig, db, machineId, vaultDir, databaseManager });
   teamSync.registerFlushJob(powerManager);
 
   // -- Dynamic task scheduling --
-  await registerScheduledTasks(powerManager, { definitionsDir, vaultDir, embeddingManager, logger, config });
+  await registerScheduledTasks(powerManager, { definitionsDir, vaultDir, embeddingManager, logger, liveConfig });
 
   powerManager.start();
 

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -15,8 +15,8 @@ import type { MycoConfig } from '@myco/config/schema.js';
 import type { DatabaseMaintenanceManager } from './database/manager.js';
 import { runSessionMaintenance } from './jobs/session-maintenance.js';
 import { createBackup } from './backup.js';
+import { resolveBackupDir } from './api/backup.js';
 import { deleteOldLogs } from '@myco/db/queries/logs.js';
-import { loadMergedConfig } from '../config/loader.js';
 import {
   listStaleStagingDirs,
   cleanupStagedSkill,
@@ -39,9 +39,10 @@ export interface PowerJobDeps {
   embeddingManager: EmbeddingManager;
   registry: SessionRegistry;
   logger: DaemonLogger;
-  config: MycoConfig;
+  // Holder so each job observes the current merged config at run time and
+  // picks up setting flips without a daemon restart.
+  liveConfig: { current: MycoConfig };
   db: Database;
-  backupDir: string;
   machineId: string;
   vaultDir: string;
   databaseManager: DatabaseMaintenanceManager;
@@ -52,7 +53,7 @@ export interface PowerJobDeps {
 // ---------------------------------------------------------------------------
 
 export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps): void {
-  const { embeddingManager, registry, logger, config, db, backupDir, machineId, vaultDir, databaseManager } = deps;
+  const { embeddingManager, registry, logger, liveConfig, db, machineId, vaultDir, databaseManager } = deps;
 
   let reconcileRunning = false;
   powerManager.register({
@@ -77,7 +78,7 @@ export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps
       registeredSessionIds: () => registry.sessions,
       embeddingManager,
       vaultDir,
-      staleThresholdMs: config.daemon.stale_session_threshold_ms,
+      staleThresholdMs: liveConfig.current.daemon.stale_session_threshold_ms,
     }),
   });
 
@@ -85,7 +86,7 @@ export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps
     name: 'log-retention',
     runIn: ['idle', 'sleep'],
     fn: async () => {
-      const retentionDays = loadMergedConfig(vaultDir).daemon.log_retention_days;
+      const retentionDays = liveConfig.current.daemon.log_retention_days;
       const cutoff = new Date(Date.now() - retentionDays * MS_PER_DAY).toISOString();
       const deleted = deleteOldLogs(cutoff);
       if (deleted > 0) {
@@ -100,6 +101,7 @@ export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps
     runIn: ['idle', 'sleep'],
     fn: async () => {
       try {
+        const backupDir = resolveBackupDir(liveConfig.current, vaultDir);
         logger.info(LOG_KINDS.BACKUP_START, 'Auto-backup starting');
         const filePath = createBackup(db, backupDir, machineId);
         logger.info(LOG_KINDS.BACKUP_COMPLETE, 'Auto-backup complete', { file_path: filePath });
@@ -114,6 +116,7 @@ export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps
     name: 'database-optimize',
     runIn: ['idle', 'sleep'],
     fn: async () => {
+      const config = liveConfig.current;
       if (!config.maintenance?.auto_optimize) return;
       const intervalMs = (config.maintenance.auto_optimize_interval_hours ?? 24) * MS_PER_HOUR;
       const lastRun = await databaseManager.getLastOptimizeAt();

--- a/packages/myco/src/daemon/power.ts
+++ b/packages/myco/src/daemon/power.ts
@@ -39,6 +39,11 @@ export class PowerManager {
     this.jobs.push(job);
   }
 
+  replaceGroup(prefix: string, jobs: PowerJob[]): void {
+    this.jobs = this.jobs.filter((job) => !job.name.startsWith(prefix));
+    this.jobs.push(...jobs);
+  }
+
   recordActivity(): void {
     this.lastActivity = Date.now();
     this.deepSleepHeld = false;

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -48,7 +48,7 @@ export interface StopProcessorDeps {
   transcriptMiner: TranscriptMiner;
   embeddingManager: EmbeddingManager;
   logger: DaemonLogger;
-  config: MycoConfig;
+  liveConfig: { current: MycoConfig };
   vaultDir: string;
   /** Plan tag names to extract from transcript responses. Merged from all symbiont manifests. */
   planTags: string[];
@@ -100,7 +100,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
   getActiveProcessing: () => Promise<void> | null;
   triggerTitleSummary: (sessionId: string) => Promise<void>;
 } {
-  const { registry, sessionBuffers, transcriptMiner, embeddingManager, logger, config, vaultDir } = deps;
+  const { registry, sessionBuffers, transcriptMiner, embeddingManager, logger, liveConfig, vaultDir } = deps;
 
   // Internal state
   let activeStopProcessing: Promise<void> | null = null;
@@ -124,7 +124,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
   });
 
   const triggerTitleSummary = (sessionId: string) =>
-    sharedTriggerTitleSummary(sessionId, { vaultDir, embeddingManager, config, logger });
+    sharedTriggerTitleSummary(sessionId, { vaultDir, embeddingManager, liveConfig, logger });
 
   function cleanupInvalidCapturedSession(sessionId: string): boolean {
     registry.unregister(sessionId);

--- a/packages/myco/src/daemon/task-scheduling.ts
+++ b/packages/myco/src/daemon/task-scheduling.ts
@@ -21,6 +21,8 @@ import { getDatabase } from '@myco/db/client.js';
 import { notify } from '@myco/notifications/notify.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 
+const SCHEDULED_JOB_PREFIX = 'scheduled:';
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -30,7 +32,9 @@ export interface TaskSchedulingDeps {
   vaultDir: string;
   embeddingManager: EmbeddingManager;
   logger: DaemonLogger;
-  config: MycoConfig;
+  // Holder so the run-time gate below sees toggle flips
+  // (agent.scheduled_tasks_enabled) without a daemon restart.
+  liveConfig: { current: MycoConfig };
 }
 
 // ---------------------------------------------------------------------------
@@ -41,7 +45,7 @@ export async function registerScheduledTasks(
   powerManager: PowerManager,
   deps: TaskSchedulingDeps,
 ): Promise<void> {
-  const { definitionsDir, vaultDir, embeddingManager, logger, config } = deps;
+  const { definitionsDir, vaultDir, embeddingManager, logger, liveConfig } = deps;
   const runningTasks = new Set<string>();
 
   if (!definitionsDir) {
@@ -49,10 +53,12 @@ export async function registerScheduledTasks(
     return;
   }
 
-  // Global agent toggle — skip all scheduled task registration when disabled
-  if (config.agent.scheduled_tasks_enabled === false) {
-    logger.info(LOG_KINDS.AGENT_RUN, 'Scheduled agent tasks disabled globally (agent.scheduled_tasks_enabled: false)');
-    return;
+  // Jobs always register. The scheduled_tasks_enabled gate lives inside
+  // runTask so flipping the toggle in Settings takes effect immediately —
+  // registration-time gating would lock the scheduler to its startup value.
+  let lastEnabled = liveConfig.current.agent.scheduled_tasks_enabled !== false;
+  if (!lastEnabled) {
+    logger.info(LOG_KINDS.AGENT_RUN, 'Scheduled agent tasks disabled (agent.scheduled_tasks_enabled: false) — jobs registered but will no-op until enabled');
   }
 
   const { loadAllTasks } = await import('@myco/agent/registry.js');
@@ -87,6 +93,22 @@ export async function registerScheduledTasks(
       else runningTasks.delete(name);
     },
     runTask: async (taskName) => {
+      const config = liveConfig.current;
+
+      // Runtime gate — honors the toggle flipped since startup. We log once
+      // per transition so the log doesn't repeat on every scheduler tick.
+      const enabled = config.agent.scheduled_tasks_enabled !== false;
+      if (enabled !== lastEnabled) {
+        logger.info(
+          LOG_KINDS.AGENT_RUN,
+          enabled
+            ? 'Scheduled agent tasks re-enabled — resuming'
+            : 'Scheduled agent tasks disabled — skipping until re-enabled',
+        );
+        lastEnabled = enabled;
+      }
+      if (!enabled) return;
+
       const { runAgent } = await import('@myco/agent/executor.js');
 
       const taskConfig = config.agent.tasks?.[taskName];
@@ -194,14 +216,12 @@ export async function registerScheduledTasks(
 
   const scheduledJobs = buildScheduledJobs(
     allTasks,
-    config.agent.tasks ?? {},
+    liveConfig.current.agent.tasks ?? {},
     scheduledContext,
     initialLastRuns,
   );
-  for (const job of scheduledJobs) {
-    powerManager.register(job);
-  }
-  logger.info(LOG_KINDS.DAEMON_START, `Registered ${scheduledJobs.length} scheduled task(s)`, {
+  powerManager.replaceGroup(SCHEDULED_JOB_PREFIX, scheduledJobs);
+  logger.info(LOG_KINDS.DAEMON_START, `Synced ${scheduledJobs.length} scheduled task(s)`, {
     tasks: scheduledJobs.map((j) => j.name),
   });
 }

--- a/packages/myco/src/daemon/team-sync-init.ts
+++ b/packages/myco/src/daemon/team-sync-init.ts
@@ -32,7 +32,10 @@ import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 // ---------------------------------------------------------------------------
 
 export interface TeamSyncDeps {
-  config: MycoConfig;
+  // Holder so the flush job and client reconciliation both read the current
+  // value of team settings and can hot-reload team sync without a daemon
+  // restart.
+  liveConfig: { current: MycoConfig };
   machineId: string;
   logger: DaemonLogger;
   vaultDir: string;
@@ -42,6 +45,7 @@ export interface TeamSyncDeps {
 export interface TeamSyncResult {
   getTeamClient: () => TeamSyncClient | null;
   setTeamClient: (client: TeamSyncClient | null) => void;
+  reconcileClient: () => Promise<void>;
   registerFlushJob: (powerManager: PowerManager) => void;
 }
 
@@ -50,53 +54,74 @@ export interface TeamSyncResult {
 // ---------------------------------------------------------------------------
 
 export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
-  const { config, machineId, logger, vaultDir, serverVersion } = deps;
-
+  const { liveConfig, machineId, logger, vaultDir, serverVersion } = deps;
   let teamClient: TeamSyncClient | null = null;
+  let clientSignature: string | null = null;
 
-  // Initialize team client from saved config if team sync is enabled
-  if (config.team.enabled && config.team.worker_url) {
-    const secrets = readSecrets(vaultDir);
-    const teamApiKey = secrets[TEAM_API_KEY_SECRET];
-    if (teamApiKey) {
-      teamClient = new TeamSyncClient({
-        workerUrl: config.team.worker_url,
-        apiKey: teamApiKey,
-        machineId,
-        syncProtocolVersion: SYNC_PROTOCOL_VERSION,
-      });
-      logger.info(LOG_KINDS.TEAM_SYNC_START, 'Team sync client initialized', { worker_url: config.team.worker_url });
+  async function reconcileClient(): Promise<void> {
+    const config = liveConfig.current;
+    const workerUrl = config.team.worker_url?.trim() || null;
+    const apiKey = readSecrets(vaultDir)[TEAM_API_KEY_SECRET]?.trim() || null;
+    const nextSignature = config.team.enabled && workerUrl && apiKey
+      ? `${workerUrl}\n${apiKey}`
+      : null;
 
-      // Register this node with the team worker (fire-and-forget)
-      teamClient.connect({
+    if (!nextSignature) {
+      if (teamClient) {
+        logger.info(LOG_KINDS.TEAM_SYNC_START, 'Team sync client cleared', {
+          enabled: config.team.enabled,
+          has_worker_url: Boolean(workerUrl),
+          has_api_key: Boolean(apiKey),
+        });
+      }
+      teamClient = null;
+      clientSignature = null;
+      return;
+    }
+
+    if (teamClient && clientSignature === nextSignature) return;
+
+    const activeWorkerUrl = workerUrl!;
+    const activeApiKey = apiKey!;
+    teamClient = new TeamSyncClient({
+      workerUrl: activeWorkerUrl,
+      apiKey: activeApiKey,
+      machineId,
+      syncProtocolVersion: SYNC_PROTOCOL_VERSION,
+    });
+    clientSignature = nextSignature;
+
+    logger.info(LOG_KINDS.TEAM_SYNC_START, 'Team sync client initialized', { worker_url: activeWorkerUrl });
+
+    try {
+      await teamClient.connect({
         machine_id: machineId,
         version: serverVersion,
-      }).then(() => {
-        logger.info(LOG_KINDS.TEAM_SYNC_START, 'Node registered with team worker');
-      }).catch((err) => {
-        logger.warn(LOG_KINDS.TEAM_SYNC_ERROR, 'Node registration failed (will retry on next flush)', { error: (err as Error).message });
       });
+      logger.info(LOG_KINDS.TEAM_SYNC_START, 'Node registered with team worker');
+    } catch (err) {
+      logger.warn(LOG_KINDS.TEAM_SYNC_ERROR, 'Node registration failed (will retry on next flush)', {
+        error: (err as Error).message,
+      });
+    }
 
-      // Backfill unsynced records into outbox (fire-and-forget — can be large)
-      setTimeout(() => {
-        try {
-          const backfilled = backfillUnsynced(machineId);
-          if (backfilled > 0) {
-            logger.info(LOG_KINDS.TEAM_SYNC_START, `Backfilled ${backfilled} unsynced records into outbox`);
-          }
-        } catch (err) {
-          logger.error(LOG_KINDS.TEAM_SYNC_ERROR, 'Backfill failed', { error: (err as Error).message });
-        }
-      }, 0);
+    try {
+      const backfilled = backfillUnsynced(machineId);
+      if (backfilled > 0) {
+        logger.info(LOG_KINDS.TEAM_SYNC_START, `Backfilled ${backfilled} unsynced records into outbox`);
+      }
+    } catch (err) {
+      logger.error(LOG_KINDS.TEAM_SYNC_ERROR, 'Backfill failed', { error: (err as Error).message });
     }
   }
 
   return {
     getTeamClient: () => teamClient,
     setTeamClient: (client) => { teamClient = client; },
+    reconcileClient,
     registerFlushJob: (powerManager) => {
-      if (!config.team.enabled) return;
-
+      // Always register the flush job; gate at run time so toggling
+      // team.enabled in Settings takes effect without a daemon restart.
       const logDeadLettered = (ids: number[]) => {
         if (ids.length > 0) {
           logger.error(LOG_KINDS.TEAM_SYNC_DEAD_LETTER, `Dead-lettered ${ids.length} records after max retries`, { ids });
@@ -106,8 +131,9 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
       powerManager.register({
         name: 'team-sync-flush',
         runIn: ['active', 'idle', 'sleep'],
-        preventsDeepSleep: () => countPending() > 0,
+        preventsDeepSleep: () => liveConfig.current.team.enabled && countPending() > 0,
         fn: async () => {
+          if (!liveConfig.current.team.enabled) return;
           const client = teamClient;
           if (!client) return;
 

--- a/packages/myco/src/daemon/trigger-title-summary.ts
+++ b/packages/myco/src/daemon/trigger-title-summary.ts
@@ -15,7 +15,10 @@ import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 export interface TriggerTitleSummaryDeps {
   vaultDir: string;
   embeddingManager: EmbeddingManager;
-  config: MycoConfig;
+  // Holder rather than snapshot so the gates below observe toggle flips
+  // (agent.event_tasks_enabled, agent.summary_batch_interval) from Settings
+  // without a daemon restart.
+  liveConfig: { current: MycoConfig };
   logger: DaemonLogger;
 }
 
@@ -34,7 +37,8 @@ export async function triggerTitleSummary(
   sessionId: string,
   deps: TriggerTitleSummaryDeps,
 ): Promise<void> {
-  const { vaultDir, embeddingManager, config, logger } = deps;
+  const { vaultDir, embeddingManager, liveConfig, logger } = deps;
+  const config = liveConfig.current;
 
   if (config.agent.summary_batch_interval <= 0) return;
   if (config.agent.event_tasks_enabled === false) return;

--- a/packages/myco/src/hooks/session-start.ts
+++ b/packages/myco/src/hooks/session-start.ts
@@ -4,7 +4,7 @@ import { normalizeHookInput } from './normalize.js';
 import { evaluateSessionCaptureRules } from './capture-rules.js';
 import { readTranscriptMeta } from './transcript-meta.js';
 import { loadManifests } from '../symbionts/detect.js';
-import { loadConfig } from '../config/loader.js';
+import { loadMergedConfig } from '../config/loader.js';
 import { buildInjectedContext } from '../context/injector.js';
 import { initDatabase, vaultDbPath } from '../db/client.js';
 import { createSchema } from '../db/schema.js';
@@ -37,7 +37,7 @@ export async function main() {
       return;
     }
 
-    const config = loadConfig(VAULT_DIR);
+    const config = loadMergedConfig(VAULT_DIR);
     const client = new DaemonClient(VAULT_DIR);
     const healthy = await client.ensureRunning();
 

--- a/packages/myco/src/intelligence/embed-query.ts
+++ b/packages/myco/src/intelligence/embed-query.ts
@@ -26,11 +26,11 @@ export async function tryEmbed(text: string): Promise<number[] | null> {
       // Dynamic import to avoid hard dependency on config at load time.
       // In Phase 1, embedding providers may not be configured.
       const { createEmbeddingProvider } = await import('./llm.js');
-      const { loadConfig } = await import('@myco/config/loader.js');
+      const { loadMergedConfig } = await import('@myco/config/loader.js');
       const { resolveVaultDir } = await import('@myco/vault/resolve.js');
 
       const vaultDir = resolveVaultDir();
-      const config = loadConfig(vaultDir);
+      const config = loadMergedConfig(vaultDir);
       if (!config.embedding) return null;
 
       cachedProvider = createEmbeddingProvider(config.embedding);

--- a/packages/myco/src/notifications/notify.ts
+++ b/packages/myco/src/notifications/notify.ts
@@ -7,7 +7,7 @@
  */
 
 import crypto from 'node:crypto';
-import { loadConfig } from '@myco/config/loader.js';
+import { loadMergedConfig } from '@myco/config/loader.js';
 import { insertNotification } from '@myco/db/queries/notifications.js';
 import { getType } from './registry.js';
 import type { MycoConfig } from '@myco/config/schema.js';
@@ -21,7 +21,7 @@ import type { NotificationMode, NotificationLevel, CreateNotificationPayload } f
  *
  * @param vaultDir — vault directory; pass undefined to no-op (avoids if-guards at call sites).
  * @param payload — notification content.
- * @param config — pre-loaded config to avoid redundant loadConfig() disk reads.
+ * @param config — pre-loaded merged config to avoid redundant disk reads.
  */
 export function notify(
   vaultDir: string | undefined,
@@ -31,7 +31,7 @@ export function notify(
   if (!vaultDir) return null;
 
   try {
-    const cfg = config ?? loadConfig(vaultDir);
+    const cfg = config ?? loadMergedConfig(vaultDir);
 
     if (!cfg.notifications.enabled) return null;
 

--- a/packages/myco/src/services/stats.ts
+++ b/packages/myco/src/services/stats.ts
@@ -4,7 +4,7 @@
 
 import { getDatabase } from '@myco/db/client.js';
 import { getEmbeddingQueueDepth } from '@myco/db/queries/embeddings.js';
-import { loadConfig } from '@myco/config/loader.js';
+import { loadMergedConfig } from '@myco/config/loader.js';
 import { isProcessAlive } from '@myco/cli/shared.js';
 import { DIGEST_TIERS } from '@myco/constants.js';
 import fs from 'node:fs';
@@ -78,7 +78,7 @@ export function gatherStats(vaultDir: string, options?: { active_sessions?: stri
   const db = getDatabase();
 
   // Load config for embedding provider info (sync — already on disk)
-  const config = loadConfig(vaultDir);
+  const config = loadMergedConfig(vaultDir);
 
   // All queries are synchronous — no Promise.all needed
   const session_count = countTable(db, 'sessions');

--- a/packages/myco/src/symbionts/installer.ts
+++ b/packages/myco/src/symbionts/installer.ts
@@ -5,7 +5,7 @@ import { findTomlSectionEnd, buildTomlMcpSection, upsertTomlSection, removeTomlS
 import { deepMergeSettings, deepRemoveSettings } from './settings-merge.js';
 import { readJsonFile, writeJsonFile, writeOrDeleteJsonFile } from './json-helpers.js';
 import { ensureAgentsMd, ensureSymlink, isMycoHookGroup } from './install-helpers.js';
-import { loadConfig } from '../config/loader.js';
+import { loadMergedConfig } from '../config/loader.js';
 
 /** Current comment header for Myco-managed .gitignore block. */
 const GITIGNORE_COMMENT = '# Myco managed (machine-specific)';
@@ -265,7 +265,7 @@ export class SymbiontInstaller {
 
   private loadProjectConfig() {
     try {
-      return loadConfig(path.join(this.projectRoot, '.myco'));
+      return loadMergedConfig(path.join(this.projectRoot, '.myco'));
     } catch {
       return null;
     }

--- a/packages/myco/src/symbionts/reconcile.ts
+++ b/packages/myco/src/symbionts/reconcile.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { getEnabledSymbiontNames, loadConfig } from '../config/loader.js';
+import { getEnabledSymbiontNames, loadMergedConfig } from '../config/loader.js';
 import type { MycoConfig } from '../config/schema.js';
 import { loadManifests, resolvePackageRoot } from './detect.js';
 import { SymbiontInstaller } from './installer.js';
@@ -20,7 +20,7 @@ export function reconcileConfiguredSymbionts(
   vaultDir = path.join(projectRoot, '.myco'),
   preloadedConfig?: MycoConfig,
 ): number {
-  const config = preloadedConfig ?? loadConfig(vaultDir);
+  const config = preloadedConfig ?? loadMergedConfig(vaultDir);
   const manifests = getConfiguredManifests(projectRoot, config);
   const packageRoot = resolvePackageRoot();
   let updatedCount = 0;

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -131,6 +131,19 @@ describe('myco init', () => {
     consoleSpy.mockRestore();
   });
 
+  it('leaves agent toggles at their schema default (true) — init no longer scaffolds them as false', async () => {
+    // Regression: init used to explicitly write scheduled_tasks_enabled=false
+    // and event_tasks_enabled=false into myco.yaml. Combined with the daemon
+    // reading project-only config, this meant the scheduler never ran on a
+    // fresh install even when the user enabled the toggles at personal scope.
+    const vault = path.join(testDir, 'vault');
+    await run(['--vault', vault, '--embedding-model', 'bge-m3']);
+
+    const config = YAML.parse(fs.readFileSync(path.join(vault, 'myco.yaml'), 'utf-8'));
+    expect(config.agent.scheduled_tasks_enabled).toBe(true);
+    expect(config.agent.event_tasks_enabled).toBe(true);
+  });
+
   it('initializes plan_dirs as empty array (agent-specific dirs come from symbiont manifests)', async () => {
     const vault = path.join(testDir, 'vault');
     await run(['--vault', vault, '--embedding-model', 'bge-m3']);

--- a/tests/daemon/api/backup-liveconfig.test.ts
+++ b/tests/daemon/api/backup-liveconfig.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createBackupHandlers, resolveBackupDir } from '@myco/daemon/api/backup';
+import type { MycoConfig } from '@myco/config/schema';
+import type { RouteRequest } from '@myco/daemon/router';
+
+function makeConfig(overrides: Partial<MycoConfig['backup']> = {}): MycoConfig {
+  return { backup: { ...overrides } } as MycoConfig;
+}
+
+function makeRequest(body: unknown = {}): RouteRequest {
+  return { params: {}, query: {}, body } as RouteRequest;
+}
+
+describe('resolveBackupDir', () => {
+  it('falls back to <vault>/backups when no dir is configured', () => {
+    const vault = '/tmp/vault';
+    const dir = resolveBackupDir(makeConfig({}), vault);
+    expect(dir).toBe(path.resolve(vault, 'backups'));
+  });
+
+  it('expands ~/ to the home directory', () => {
+    const dir = resolveBackupDir(makeConfig({ dir: '~/custom-backups' }), '/tmp/vault');
+    expect(dir).toBe(path.resolve(path.join(os.homedir(), 'custom-backups')));
+  });
+
+  it('resolves absolute paths directly', () => {
+    const dir = resolveBackupDir(makeConfig({ dir: '/var/mybackups' }), '/tmp/vault');
+    expect(dir).toBe('/var/mybackups');
+  });
+});
+
+describe('createBackupHandlers — liveConfig hot-reload', () => {
+  let vaultDir: string;
+  let firstDir: string;
+  let secondDir: string;
+
+  beforeEach(() => {
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-backup-lc-'));
+    firstDir = path.join(vaultDir, 'first');
+    secondDir = path.join(vaultDir, 'second');
+    fs.mkdirSync(firstDir, { recursive: true });
+    fs.mkdirSync(secondDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(vaultDir, { recursive: true, force: true });
+  });
+
+  it('re-resolves the backup dir from liveConfig on every listBackups call', async () => {
+    // Drop two distinct backup files, one in each directory, so we can
+    // verify the handler is reading from the current dir and not the
+    // startup-captured value.
+    fs.writeFileSync(path.join(firstDir, 'machineA.sql'), '-- first');
+    fs.writeFileSync(path.join(secondDir, 'machineB.sql'), '-- second');
+
+    const liveConfig = { current: makeConfig({ dir: firstDir }) };
+    const handlers = createBackupHandlers({
+      db: { close: vi.fn() } as never,
+      machineId: 'machineA',
+      vaultDir,
+      liveConfig,
+    });
+
+    const firstRes = await handlers.handleListBackups(makeRequest());
+    expect((firstRes.body as { backups: Array<{ machine_id: string }> }).backups
+      .some((b) => b.machine_id === 'machineA')).toBe(true);
+
+    // Flip the setting — simulates a user saving a new backup.dir in Settings.
+    liveConfig.current = makeConfig({ dir: secondDir });
+
+    const secondRes = await handlers.handleListBackups(makeRequest());
+    const secondList = (secondRes.body as { backups: Array<{ machine_id: string }> }).backups;
+    expect(secondList.some((b) => b.machine_id === 'machineB')).toBe(true);
+    expect(secondList.some((b) => b.machine_id === 'machineA')).toBe(false);
+  });
+});

--- a/tests/daemon/api/context.test.ts
+++ b/tests/daemon/api/context.test.ts
@@ -39,12 +39,15 @@ function mockEmbeddingManager(overrides: Record<string, unknown> = {}): Embeddin
   } as unknown as EmbeddingManager;
 }
 
-function makeDeps(overrides: Partial<ContextDeps> = {}): ContextDeps {
+function makeDeps(overrides: Partial<ContextDeps> & { config?: MycoConfig } = {}): ContextDeps {
+  // Legacy tests pass `config` directly; translate into the liveConfig holder
+  // that the handler now reads from at call time.
+  const { config, liveConfig, ...rest } = overrides;
   return {
     embeddingManager: mockEmbeddingManager(),
     logger: mockLogger(),
-    config: MycoConfigSchema.parse({ version: 3 }),
-    ...overrides,
+    liveConfig: liveConfig ?? { current: config ?? MycoConfigSchema.parse({ version: 3 }) },
+    ...rest,
   };
 }
 

--- a/tests/daemon/api/sessions.test.ts
+++ b/tests/daemon/api/sessions.test.ts
@@ -50,14 +50,16 @@ describe('handleCompleteSession', () => {
     // `event_tasks_enabled: false` short-circuits triggerTitleSummary before
     // it tries to dynamic-import the agent executor — test isolation without
     // needing to mock the whole module.
-    const config = {
-      agent: { summary_batch_interval: 5, event_tasks_enabled: false },
+    const liveConfig = {
+      current: {
+        agent: { summary_batch_interval: 5, event_tasks_enabled: false },
+      },
     };
     return createSessionMutationHandlers({
       embeddingManager: makeEmbeddingManagerStub() as never,
       vaultDir: tmpDir,
       logger: makeLogger() as never,
-      config: config as never,
+      liveConfig: liveConfig as never,
     });
   }
 

--- a/tests/daemon/power-jobs.test.ts
+++ b/tests/daemon/power-jobs.test.ts
@@ -68,14 +68,15 @@ describe('database-optimize power job', () => {
       embeddingManager: { reconcile: async () => ({ embedded: 0, stale_reembedded: 0, orphans_cleaned: 0, duration_ms: 0 }) } as never,
       registry: { listActive: () => [], sessions: [] } as never,
       logger: logger as never,
-      config: {
-        daemon: { log_retention_days: 30 },
-        backup: {},
-        maintenance: { auto_optimize: true, auto_optimize_interval_hours: 24 },
-        ...overrides,
+      liveConfig: {
+        current: {
+          daemon: { log_retention_days: 30 },
+          backup: {},
+          maintenance: { auto_optimize: true, auto_optimize_interval_hours: 24 },
+          ...overrides,
+        },
       } as never,
       db: getDatabase(),
-      backupDir: path.join(tmpDir, 'backups'),
       machineId: 'test-machine',
       vaultDir: tmpDir,
       databaseManager,
@@ -146,12 +147,14 @@ function buildStagingDeps(vaultDir: string): PowerJobDeps {
     embeddingManager: { reconcile: async () => 0 } as any,
     registry: { sessions: new Set<string>() } as any,
     logger: createMockLogger() as any,
-    config: {
-      daemon: { log_retention_days: 30 },
-      maintenance: { auto_optimize: false, auto_optimize_interval_hours: 24 },
+    liveConfig: {
+      current: {
+        daemon: { log_retention_days: 30 },
+        backup: {},
+        maintenance: { auto_optimize: false, auto_optimize_interval_hours: 24 },
+      },
     } as any,
     db: {} as any,
-    backupDir: path.join(vaultDir, 'backups'),
     machineId: 'test-machine',
     vaultDir,
     databaseManager: {
@@ -250,23 +253,35 @@ describe('log-retention power job', () => {
   });
 
   function buildDeps() {
+    const liveConfig = {
+      current: {
+        daemon: { log_retention_days: 7 },
+        backup: {},
+        maintenance: { auto_optimize: false, auto_optimize_interval_hours: 24 },
+      } as never,
+    };
     return {
-      embeddingManager: { reconcile: async () => ({ embedded: 0, stale_reembedded: 0, orphans_cleaned: 0, duration_ms: 0 }) } as never,
-      registry: { listActive: () => [], sessions: [] } as never,
-      logger: logger as never,
-      config: { daemon: { log_retention_days: 7 }, backup: {}, maintenance: { auto_optimize: false, auto_optimize_interval_hours: 24 } } as never,
-      db: getDatabase(),
-      backupDir: path.join(tmpDir, 'backups'),
-      machineId: 'test-machine',
-      vaultDir: tmpDir,
-      databaseManager,
+      deps: {
+        embeddingManager: { reconcile: async () => ({ embedded: 0, stale_reembedded: 0, orphans_cleaned: 0, duration_ms: 0 }) } as never,
+        registry: { listActive: () => [], sessions: [] } as never,
+        logger: logger as never,
+        liveConfig: liveConfig as never,
+        db: getDatabase(),
+        machineId: 'test-machine',
+        vaultDir: tmpDir,
+        databaseManager,
+      },
+      liveConfig,
     };
   }
 
-  it('reads log_retention_days fresh from disk on each run', async () => {
-    registerPowerJobs(pm as never, buildDeps());
+  it('reads log_retention_days from liveConfig on each run', async () => {
+    // Regression: the job must not capture log_retention_days at registration.
+    // Mutating liveConfig.current between runs (as a reaction would) must
+    // flip the retention window on the very next invocation.
+    const { deps, liveConfig } = buildDeps();
+    registerPowerJobs(pm as never, deps);
 
-    // Insert a log entry dated 14 days ago — would be deleted with retention=7.
     const FOURTEEN_DAYS_AGO = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
     insertLogEntry({
       timestamp: FOURTEEN_DAYS_AGO,
@@ -278,41 +293,16 @@ describe('log-retention power job', () => {
       session_id: null,
     });
 
-    // Update yaml to retention=30. The job, if fresh-reading, should use 30 and keep the entry.
-    fs.writeFileSync(path.join(tmpDir, 'myco.yaml'),
-      `version: 3\ndaemon:\n  log_retention_days: 30\n`);
+    // Simulate a Settings write that moves retention from 7 → 30 days.
+    liveConfig.current = {
+      ...liveConfig.current,
+      daemon: { log_retention_days: 30 },
+    } as never;
 
     await pm.find('log-retention').fn();
 
     const { getLogTail } = await import('@myco/db/queries/logs');
     const rows = getLogTail(50).entries;
     expect(rows.some((r) => r.message === 'old-entry')).toBe(true);
-  });
-
-  it('honors local.yaml overrides for log_retention_days (merged config)', async () => {
-    registerPowerJobs(pm as never, buildDeps());
-
-    // Project config keeps retention=7; local overlay raises to 30.
-    fs.writeFileSync(path.join(tmpDir, 'local.yaml'),
-      `daemon:\n  log_retention_days: 30\n`);
-
-    const FOURTEEN_DAYS_AGO = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
-    insertLogEntry({
-      timestamp: FOURTEEN_DAYS_AGO,
-      level: 'info',
-      kind: 'test',
-      component: 'test',
-      message: 'overlay-entry',
-      data: null,
-      session_id: null,
-    });
-
-    await pm.find('log-retention').fn();
-
-    const { getLogTail } = await import('@myco/db/queries/logs');
-    const rows = getLogTail(50).entries;
-    // With merged config the overlay wins (30 days retention) and the 14-day-old entry survives.
-    // With project-only the stale 7-day retention would delete it.
-    expect(rows.some((r) => r.message === 'overlay-entry')).toBe(true);
   });
 });

--- a/tests/daemon/power.test.ts
+++ b/tests/daemon/power.test.ts
@@ -165,4 +165,18 @@ describe('PowerManager', () => {
     await vi.advanceTimersByTimeAsync(1_100);
     expect(jobFn).toHaveBeenCalled();
   });
+
+  it('replaces a named job group without disturbing other jobs', () => {
+    pm.register({ name: 'scheduled:old-task', runIn: ['active'], fn: vi.fn().mockResolvedValue(undefined) });
+    pm.register({ name: 'embedding-reconcile', runIn: ['idle'], fn: vi.fn().mockResolvedValue(undefined) });
+
+    pm.replaceGroup('scheduled:', [
+      { name: 'scheduled:new-task', runIn: ['sleep'], fn: vi.fn().mockResolvedValue(undefined) },
+    ]);
+
+    expect((pm as unknown as { jobs: Array<{ name: string }> }).jobs.map((job) => job.name)).toEqual([
+      'embedding-reconcile',
+      'scheduled:new-task',
+    ]);
+  });
 });

--- a/tests/daemon/stop-processing.test.ts
+++ b/tests/daemon/stop-processing.test.ts
@@ -79,7 +79,7 @@ function makeStopProcessor(vaultDir: string) {
       warn: vi.fn(),
       error: vi.fn(),
     } as never,
-    config: { agent: { event_tasks_enabled: false } } as never,
+    liveConfig: { current: { agent: { event_tasks_enabled: false } } } as never,
     vaultDir,
     planTags: [],
   });

--- a/tests/daemon/task-scheduling.test.ts
+++ b/tests/daemon/task-scheduling.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { registerScheduledTasks } from '@myco/daemon/task-scheduling.js';
+import type { AgentTask } from '@myco/agent/types.js';
+
+vi.mock('@myco/agent/registry.js', () => ({
+  loadAllTasks: () => new Map<string, AgentTask>([
+    ['full-intelligence', {
+      name: 'full-intelligence',
+      displayName: 'Full Intelligence',
+      description: 'test',
+      agent: 'myco-agent',
+      prompt: 'test',
+      isDefault: false,
+      schedule: { enabled: true, intervalSeconds: 300, runIn: ['idle'] },
+    }],
+  ]),
+}));
+
+vi.mock('@myco/db/client.js', () => ({
+  getDatabase: () => ({
+    prepare: () => ({
+      all: () => [],
+    }),
+  }),
+}));
+
+describe('registerScheduledTasks', () => {
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('replaces scheduled jobs when task schedule overrides change', async () => {
+    const powerManager = {
+      replaceGroup: vi.fn(),
+    };
+    const liveConfig = {
+      current: {
+        agent: {
+          scheduled_tasks_enabled: true,
+          tasks: {
+            'full-intelligence': {
+              schedule: { enabled: true },
+            },
+          },
+        },
+      },
+    };
+
+    await registerScheduledTasks(powerManager as never, {
+      definitionsDir: '/tmp/defs',
+      vaultDir: '/tmp/vault',
+      embeddingManager: {} as never,
+      logger: logger as never,
+      liveConfig: liveConfig as never,
+    });
+
+    expect(powerManager.replaceGroup).toHaveBeenLastCalledWith(
+      'scheduled:',
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'scheduled:full-intelligence' }),
+      ]),
+    );
+
+    liveConfig.current = {
+      agent: {
+        scheduled_tasks_enabled: true,
+        tasks: {
+          'full-intelligence': {
+            schedule: { enabled: false },
+          },
+        },
+      },
+    };
+
+    await registerScheduledTasks(powerManager as never, {
+      definitionsDir: '/tmp/defs',
+      vaultDir: '/tmp/vault',
+      embeddingManager: {} as never,
+      logger: logger as never,
+      liveConfig: liveConfig as never,
+    });
+
+    expect(powerManager.replaceGroup).toHaveBeenLastCalledWith('scheduled:', []);
+  });
+});

--- a/tests/daemon/team-sync-init.test.ts
+++ b/tests/daemon/team-sync-init.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { initTeamSync } from '@myco/daemon/team-sync-init.js';
+
+const {
+  connectMock,
+  backfillUnsyncedMock,
+  readSecretsMock,
+} = vi.hoisted(() => ({
+  connectMock: vi.fn(),
+  backfillUnsyncedMock: vi.fn(),
+  readSecretsMock: vi.fn(),
+}));
+
+vi.mock('@myco/config/secrets.js', () => ({
+  readSecrets: readSecretsMock,
+}));
+
+vi.mock('@myco/db/queries/team-outbox.js', () => ({
+  listPending: vi.fn(() => []),
+  markSent: vi.fn(),
+  markSourceRowsSynced: vi.fn(),
+  pruneOld: vi.fn(),
+  backfillUnsynced: backfillUnsyncedMock,
+  incrementRetryCount: vi.fn(() => []),
+  countPending: vi.fn(() => 0),
+}));
+
+vi.mock('@myco/daemon/team-sync.js', () => ({
+  TeamSyncClient: class {
+    connect = connectMock;
+    pushBatch = vi.fn();
+    getCollectiveStatus = vi.fn();
+    getMcpToken = vi.fn(() => null);
+    getMcpEndpoint = vi.fn(() => null);
+  },
+}));
+
+describe('initTeamSync.reconcileClient', () => {
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    connectMock.mockResolvedValue({});
+    backfillUnsyncedMock.mockReturnValue(3);
+    readSecretsMock.mockReturnValue({ MYCO_TEAM_API_KEY: 'secret-token' });
+  });
+
+  it('initializes and registers a client when team sync is enabled', async () => {
+    const teamSync = initTeamSync({
+      liveConfig: {
+        current: {
+          team: { enabled: true, worker_url: 'https://team.example.workers.dev' },
+        },
+      } as never,
+      machineId: 'machine-1',
+      logger: logger as never,
+      vaultDir: '/tmp/vault',
+      serverVersion: '1.2.3',
+    });
+
+    await teamSync.reconcileClient();
+
+    expect(connectMock).toHaveBeenCalledWith({
+      machine_id: 'machine-1',
+      version: '1.2.3',
+    });
+    expect(backfillUnsyncedMock).toHaveBeenCalledWith('machine-1');
+    expect(teamSync.getTeamClient()).not.toBeNull();
+  });
+
+  it('does nothing when the same client inputs are reconciled twice', async () => {
+    const teamSync = initTeamSync({
+      liveConfig: {
+        current: {
+          team: { enabled: true, worker_url: 'https://team.example.workers.dev' },
+        },
+      } as never,
+      machineId: 'machine-1',
+      logger: logger as never,
+      vaultDir: '/tmp/vault',
+      serverVersion: '1.2.3',
+    });
+
+    await teamSync.reconcileClient();
+    await teamSync.reconcileClient();
+
+    expect(connectMock).toHaveBeenCalledTimes(1);
+    expect(backfillUnsyncedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the live client when team sync becomes disabled', async () => {
+    const liveConfig = {
+      current: {
+        team: { enabled: true, worker_url: 'https://team.example.workers.dev' },
+      },
+    };
+    const teamSync = initTeamSync({
+      liveConfig: liveConfig as never,
+      machineId: 'machine-1',
+      logger: logger as never,
+      vaultDir: '/tmp/vault',
+      serverVersion: '1.2.3',
+    });
+
+    await teamSync.reconcileClient();
+    expect(teamSync.getTeamClient()).not.toBeNull();
+
+    liveConfig.current = {
+      team: { enabled: false, worker_url: 'https://team.example.workers.dev' },
+    };
+    await teamSync.reconcileClient();
+
+    expect(teamSync.getTeamClient()).toBeNull();
+  });
+});

--- a/tests/daemon/trigger-title-summary.test.ts
+++ b/tests/daemon/trigger-title-summary.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { triggerTitleSummary } from '@myco/daemon/trigger-title-summary';
+import type { MycoConfig } from '@myco/config/schema';
+
+function makeLogger() {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function makeEmbeddingManagerStub(): unknown {
+  return { remove: vi.fn(), reconcile: vi.fn() };
+}
+
+function makeConfig(overrides: Partial<MycoConfig['agent']> = {}): MycoConfig {
+  return {
+    agent: {
+      summary_batch_interval: 5,
+      event_tasks_enabled: true,
+      ...overrides,
+    },
+  } as MycoConfig;
+}
+
+describe('triggerTitleSummary live-config gating', () => {
+  it('reads the current value from the holder at call time (not the initial snapshot)', async () => {
+    // The trigger should observe a mutation to the holder between calls — this
+    // is the contract that makes Settings toggles take effect without a daemon
+    // restart.
+    const liveConfig = { current: makeConfig({ event_tasks_enabled: false }) };
+    const deps = {
+      vaultDir: '/tmp/ignored',
+      embeddingManager: makeEmbeddingManagerStub() as never,
+      liveConfig,
+      logger: makeLogger() as never,
+    };
+
+    // Disabled state: trigger returns immediately without touching the
+    // dynamic-imported agent executor.
+    await expect(triggerTitleSummary('sess-1', deps)).resolves.toBeUndefined();
+
+    // Flip the holder — simulates a scoped-config write that fired the
+    // reaction registered in main.ts.
+    liveConfig.current = makeConfig({ event_tasks_enabled: true });
+
+    // Enabled state: the executor import is attempted; it may fail because
+    // we're not in a real daemon, but it MUST proceed past the gate. The
+    // shared trigger wraps the import in a try/catch and swallows module
+    // load failures as a silent no-op, so resolution is still clean.
+    await expect(triggerTitleSummary('sess-1', deps)).resolves.toBeUndefined();
+  });
+
+  it('summary_batch_interval <= 0 short-circuits regardless of event_tasks_enabled', async () => {
+    const liveConfig = {
+      current: makeConfig({ summary_batch_interval: 0, event_tasks_enabled: true }),
+    };
+    const logger = makeLogger();
+    await expect(triggerTitleSummary('sess-1', {
+      vaultDir: '/tmp/ignored',
+      embeddingManager: makeEmbeddingManagerStub() as never,
+      liveConfig,
+      logger: logger as never,
+    })).resolves.toBeUndefined();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
This patch finishes the live-config runtime fix so daemon behavior follows the merged effective config without requiring a restart.

It also closes the remaining gaps found during review:
- switch runtime and request-time reads from raw project config to merged config where the effective value matters
- keep `liveConfig.current` in sync after config-writing routes, including task config updates, team connect/disconnect, and backup-dir writes
- resync scheduled jobs by replacement instead of accumulating stale schedule registrations
- move TeamSync client lifecycle into a reconcile path that runs at startup and after `team.*` updates
- remove the `myco init` scaffold that disabled scheduler and event tasks on fresh installs
- add regression coverage for live backup-dir resolution, trigger-time config reads, schedule replacement, and TeamSync client reconciliation

## Verification
- `make build`
- `pnpm exec tsc --noEmit`
- `MYCO_TEST_PROFILE=fast npx vitest run`
- `npm run build:core -w @goondocks/myco`

## Notes
Unrelated local edits in skills, local config, and package lockfiles were intentionally left out of this branch.