### PR TITLE
feat: add multi-runtime agent execution and resume

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@anthropic-ai/sdk": "^0.88.0",
         "@inquirer/prompts": "^8.4.1",
         "@modelcontextprotocol/sdk": "^1.28.0",
+        "@openai/agents": "^0.8.3",
         "better-sqlite3": "^12.9.0",
         "chokidar": "^5.0.0",
         "gray-matter": "^4.0.3",
@@ -1598,6 +1599,72 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@openai/agents": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.8.3.tgz",
+      "integrity": "sha512-VmUywYNVaOuBOOv5hdH6tj3UjU3ZOkvM5WyRyEgRXEVkYbISkZuVWlnzEtiZkQ3lWjp0M8GGtKfSq2Dbr5DaQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.8.3",
+        "@openai/agents-openai": "0.8.3",
+        "@openai/agents-realtime": "0.8.3",
+        "debug": "^4.4.0",
+        "openai": "^6.26.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openai/agents-core": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.8.3.tgz",
+      "integrity": "sha512-UWRwtGF4t+MkT2xMWTHuEUI2xgp58bKvMYN0rQu6rB9zWtiP0aY5tCXlWUdPKhpPlM/X68u6eUN7qDitqrf50g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "openai": "^6.26.0"
+      },
+      "optionalDependencies": {
+        "@modelcontextprotocol/sdk": "^1.26.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@openai/agents-openai": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.8.3.tgz",
+      "integrity": "sha512-n5bsRfVDINupkeSh/E/lRoGWUi9xVSRpf6muRjnEckIO0pmCG3NzKO+FQVhiyFA3c8i2vrn28SXF/ZdGcG4+vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.8.3",
+        "debug": "^4.4.0",
+        "openai": "^6.26.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openai/agents-realtime": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.8.3.tgz",
+      "integrity": "sha512-no5AdAfYM5V/1u32OEQpP+VOJP/Y/JyTCVOvcgAdSKIV43ZG82f72pxbB0B2aFRdLZwC7C6sDgCJz6pbp+TjRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.8.3",
+        "@types/ws": "^8.18.1",
+        "debug": "^4.4.0",
+        "ws": "^8.18.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.124.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
@@ -2391,7 +2458,6 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -2403,6 +2469,15 @@
       "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.4",
@@ -4476,6 +4551,27 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openai": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.34.0.tgz",
+      "integrity": "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
@@ -5863,7 +5959,6 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -6154,6 +6249,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -6214,6 +6330,7 @@
         "@anthropic-ai/sdk": "^0.88.0",
         "@inquirer/prompts": "^8.4.1",
         "@modelcontextprotocol/sdk": "^1.28.0",
+        "@openai/agents": "^0.8.3",
         "better-sqlite3": "^12.9.0",
         "chokidar": "^5.0.0",
         "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.104",
     "@anthropic-ai/sdk": "^0.88.0",
+    "@openai/agents": "^0.8.3",
     "@inquirer/prompts": "^8.4.1",
     "@modelcontextprotocol/sdk": "^1.28.0",
     "better-sqlite3": "^12.9.0",

--- a/packages/myco/package.json
+++ b/packages/myco/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.104",
     "@anthropic-ai/sdk": "^0.88.0",
+    "@openai/agents": "^0.8.3",
     "@inquirer/prompts": "^8.4.1",
     "@modelcontextprotocol/sdk": "^1.28.0",
     "better-sqlite3": "^12.9.0",

--- a/packages/myco/src/agent/config-resolver.ts
+++ b/packages/myco/src/agent/config-resolver.ts
@@ -22,7 +22,8 @@ import {
 import { loadAllTasks } from './registry.js';
 import { loadMergedConfig } from '@myco/config/loader.js';
 import type { MycoConfig } from '@myco/config/schema.js';
-import type { ProviderConfig, EffectiveConfig } from './types.js';
+import type { ProviderConfig, EffectiveConfig, RuntimeId } from './types.js';
+import { inferRuntimeFromProviderType } from './provider-runtime.js';
 
 /**
  * Returns true when an agent provider is configured for the given task —
@@ -47,12 +48,14 @@ export interface ResolvedRunConfig {
   definitionsDir: string;
   /** Task-level provider override from myco.yaml (global or per-task). */
   taskProviderOverride?: ProviderConfig;
-  /** Per-phase provider/maxTurns overrides from myco.yaml. */
-  phaseProviderOverrides: Record<string, { provider?: ProviderConfig; maxTurns?: number }>;
+  /** Per-phase provider/model/maxTurns overrides from myco.yaml. */
+  phaseProviderOverrides: Record<string, { provider?: ProviderConfig; model?: string; maxTurns?: number }>;
   /** Effective task name (from DB or options). */
   taskName?: string;
   /** Resolved task params — YAML defaults merged with myco.yaml overrides. */
   taskParams?: Record<string, string | number | boolean>;
+  /** Effective runtime after applying YAML + myco.yaml overrides. */
+  runtime: RuntimeId;
 }
 
 // ---------------------------------------------------------------------------
@@ -66,15 +69,19 @@ export interface ResolvedRunConfig {
  * (settings.json -> hooks -> daemon).
  */
 function toProviderConfig(p: {
-  type: 'anthropic' | 'ollama' | 'lmstudio';
+  runtime?: RuntimeId;
+  type: 'anthropic' | 'ollama' | 'lmstudio' | 'openai' | 'openrouter' | 'openai-compatible';
   base_url?: string;
   model?: string;
+  reasoning_map?: Partial<Record<'low' | 'default' | 'high', string>>;
   context_length?: number;
 }): ProviderConfig {
   return {
+    runtime: p.runtime ?? inferRuntimeFromProviderType(p.type),
     type: p.type,
     baseUrl: p.base_url,
     model: p.model,
+    reasoningMap: p.reasoning_map,
     contextLength: p.context_length,
   };
 }
@@ -130,6 +137,7 @@ export function resolveRunConfig(
           : {}),
         // Scalar config from YAML (model, turns, timeout) — DB doesn't store these
         ...(yamlTask?.model ? { model: yamlTask.model } : {}),
+        ...(yamlTask?.reasoningLevel ? { reasoningLevel: yamlTask.reasoningLevel } : {}),
         ...(yamlTask?.maxTurns ? { maxTurns: yamlTask.maxTurns } : {}),
         ...(yamlTask?.timeoutSeconds ? { timeoutSeconds: yamlTask.timeoutSeconds } : {}),
         // Structural config from YAML
@@ -144,14 +152,27 @@ export function resolveRunConfig(
 
   // Load myco.yaml for provider overrides (global, per-task, per-phase)
   let taskProviderOverride: ProviderConfig | undefined;
-  let phaseProviderOverrides: Record<string, { provider?: ProviderConfig; maxTurns?: number }> = {};
+  let phaseProviderOverrides: Record<string, { provider?: ProviderConfig; model?: string; maxTurns?: number }> = {};
   let taskParams: Record<string, string | number | boolean> | undefined;
+  let runtime: RuntimeId = config.execution?.runtime
+    ?? config.execution?.provider?.runtime
+    ?? 'claude-sdk';
   try {
     const mycoConfig = loadMergedConfig(vaultDir);
 
     // Per-task override takes priority over global
     const taskConfig = taskName ? mycoConfig.agent.tasks?.[taskName] : undefined;
     const globalProvider = mycoConfig.agent.provider;
+    runtime = taskConfig?.runtime
+      ?? taskConfig?.provider?.runtime
+      ?? inferRuntimeFromProviderType(taskConfig?.provider?.type)
+      ?? globalProvider?.runtime
+      ?? inferRuntimeFromProviderType(globalProvider?.type)
+      ?? mycoConfig.agent.runtime
+      ?? config.execution?.runtime
+      ?? config.execution?.provider?.runtime
+      ?? inferRuntimeFromProviderType(config.execution?.provider?.type)
+      ?? 'claude-sdk';
 
     if (taskConfig?.provider) {
       taskProviderOverride = toProviderConfig(taskConfig.provider);
@@ -164,6 +185,7 @@ export function resolveRunConfig(
       for (const [phaseName, phaseConfig] of Object.entries(taskConfig.phases)) {
         phaseProviderOverrides[phaseName] = {
           ...(phaseConfig.provider ? { provider: toProviderConfig(phaseConfig.provider) } : {}),
+          ...(phaseConfig.model != null ? { model: phaseConfig.model } : {}),
           ...(phaseConfig.maxTurns != null ? { maxTurns: phaseConfig.maxTurns } : {}),
         };
       }
@@ -180,11 +202,12 @@ export function resolveRunConfig(
   }
 
   return {
-    config,
+    config: { ...config, runtime },
     definitionsDir,
     taskProviderOverride,
     phaseProviderOverrides,
     taskName,
     taskParams,
+    runtime,
   };
 }

--- a/packages/myco/src/agent/config-resolver.ts
+++ b/packages/myco/src/agent/config-resolver.ts
@@ -21,7 +21,7 @@ import {
 } from './loader.js';
 import { loadAllTasks } from './registry.js';
 import { loadMergedConfig } from '@myco/config/loader.js';
-import type { MycoConfig } from '@myco/config/schema.js';
+import type { MycoConfig, PhaseOverride, TaskProviderOverride } from '@myco/config/schema.js';
 import type { ProviderConfig, EffectiveConfig, RuntimeId } from './types.js';
 import { inferRuntimeFromProviderType } from './provider-runtime.js';
 
@@ -71,6 +71,7 @@ export interface ResolvedRunConfig {
 function toProviderConfig(p: {
   runtime?: RuntimeId;
   type: 'anthropic' | 'ollama' | 'lmstudio' | 'openai' | 'openrouter' | 'openai-compatible';
+  local_backend?: 'ollama' | 'lmstudio';
   base_url?: string;
   model?: string;
   reasoning_map?: Partial<Record<'low' | 'default' | 'high', string>>;
@@ -79,10 +80,25 @@ function toProviderConfig(p: {
   return {
     runtime: p.runtime ?? inferRuntimeFromProviderType(p.type),
     type: p.type,
+    localBackend: p.local_backend,
     baseUrl: p.base_url,
     model: p.model,
     reasoningMap: p.reasoning_map,
     contextLength: p.context_length,
+  };
+}
+
+function applyTaskConfigOverrides(
+  config: EffectiveConfig,
+  taskConfig: TaskProviderOverride | undefined,
+  runtime: RuntimeId,
+): EffectiveConfig {
+  return {
+    ...config,
+    runtime,
+    ...(taskConfig?.model ? { model: taskConfig.model } : {}),
+    ...(taskConfig?.maxTurns ? { maxTurns: taskConfig.maxTurns } : {}),
+    ...(taskConfig?.timeoutSeconds ? { timeoutSeconds: taskConfig.timeoutSeconds } : {}),
   };
 }
 
@@ -152,6 +168,7 @@ export function resolveRunConfig(
 
   // Load myco.yaml for provider overrides (global, per-task, per-phase)
   let taskProviderOverride: ProviderConfig | undefined;
+  let taskConfig: TaskProviderOverride | undefined;
   let phaseProviderOverrides: Record<string, { provider?: ProviderConfig; model?: string; maxTurns?: number }> = {};
   let taskParams: Record<string, string | number | boolean> | undefined;
   let runtime: RuntimeId = config.execution?.runtime
@@ -161,7 +178,7 @@ export function resolveRunConfig(
     const mycoConfig = loadMergedConfig(vaultDir);
 
     // Per-task override takes priority over global
-    const taskConfig = taskName ? mycoConfig.agent.tasks?.[taskName] : undefined;
+    taskConfig = taskName ? mycoConfig.agent.tasks?.[taskName] : undefined;
     const globalProvider = mycoConfig.agent.provider;
     runtime = taskConfig?.runtime
       ?? taskConfig?.provider?.runtime
@@ -182,7 +199,7 @@ export function resolveRunConfig(
 
     // Per-phase overrides from myco.yaml
     if (taskConfig?.phases) {
-      for (const [phaseName, phaseConfig] of Object.entries(taskConfig.phases)) {
+      for (const [phaseName, phaseConfig] of Object.entries(taskConfig.phases) as Array<[string, PhaseOverride]>) {
         phaseProviderOverrides[phaseName] = {
           ...(phaseConfig.provider ? { provider: toProviderConfig(phaseConfig.provider) } : {}),
           ...(phaseConfig.model != null ? { model: phaseConfig.model } : {}),
@@ -202,7 +219,7 @@ export function resolveRunConfig(
   }
 
   return {
-    config: { ...config, runtime },
+    config: applyTaskConfigOverrides(config, taskConfig, runtime),
     definitionsDir,
     taskProviderOverride,
     phaseProviderOverrides,

--- a/packages/myco/src/agent/cost/breakdown.ts
+++ b/packages/myco/src/agent/cost/breakdown.ts
@@ -1,0 +1,15 @@
+import type { CostBreakdown } from './types.js';
+import type { RuntimeUsage } from '@myco/agent/types.js';
+
+export function buildTokenBreakdown(usage: RuntimeUsage): CostBreakdown {
+  const inputTokens = usage.inputTokens ?? 0;
+  const cachedInputTokens = usage.cachedTokens ?? 0;
+  return {
+    inputTokens,
+    cachedInputTokens,
+    uncachedInputTokens: Math.max(0, inputTokens - cachedInputTokens),
+    outputTokens: usage.outputTokens ?? 0,
+    reasoningTokens: usage.reasoningTokens ?? 0,
+    requestCount: usage.requests ?? 0,
+  };
+}

--- a/packages/myco/src/agent/cost/helpers.ts
+++ b/packages/myco/src/agent/cost/helpers.ts
@@ -1,0 +1,32 @@
+import { buildTokenBreakdown } from './breakdown.js';
+import type { CostResolution, CostResolutionInput } from './types.js';
+
+export function resolveActualCost(input: CostResolutionInput): CostResolution | null {
+  if (input.usage.costUsd === undefined || input.usage.costUsd === null) return null;
+  return {
+    source: 'actual',
+    costUsd: input.usage.costUsd,
+    actualCostUsd: input.usage.costUsd,
+    estimatedCostUsd: null,
+    breakdown: {
+      ...buildTokenBreakdown(input.usage),
+      totalCostUsd: input.usage.costUsd,
+    },
+    pricingVersion: null,
+  };
+}
+
+export function resolveUnavailableCost(
+  input: CostResolutionInput,
+  message?: string,
+): CostResolution {
+  return {
+    source: 'unavailable',
+    costUsd: null,
+    actualCostUsd: null,
+    estimatedCostUsd: null,
+    breakdown: buildTokenBreakdown(input.usage),
+    pricingVersion: null,
+    message: message ?? null,
+  };
+}

--- a/packages/myco/src/agent/cost/index.ts
+++ b/packages/myco/src/agent/cost/index.ts
@@ -1,0 +1,3 @@
+export * from './types.js';
+export * from './breakdown.js';
+export * from './resolver.js';

--- a/packages/myco/src/agent/cost/index.ts
+++ b/packages/myco/src/agent/cost/index.ts
@@ -1,3 +1,4 @@
 export * from './types.js';
 export * from './breakdown.js';
+export * from './providers.js';
 export * from './resolver.js';

--- a/packages/myco/src/agent/cost/openai.ts
+++ b/packages/myco/src/agent/cost/openai.ts
@@ -1,0 +1,104 @@
+import type { CostResolution } from './types.js';
+import type { RuntimeUsage } from '@myco/agent/types.js';
+import { buildTokenBreakdown } from './breakdown.js';
+
+const TOKENS_PER_MILLION = 1_000_000;
+const OPENAI_PRICING_VERSION = 'openai-api-pricing-2026-04-16';
+
+interface OpenAIPricing {
+  model: string;
+  inputUsdPerMillion: number;
+  cachedInputUsdPerMillion: number;
+  outputUsdPerMillion: number;
+}
+
+const OPENAI_PRICING_RULES: Array<{
+  matches: (model: string) => boolean;
+  pricing: OpenAIPricing;
+}> = [
+  {
+    matches: (model) => model === 'gpt-5.4',
+    pricing: {
+      model: 'gpt-5.4',
+      inputUsdPerMillion: 2.5,
+      cachedInputUsdPerMillion: 0.25,
+      outputUsdPerMillion: 15,
+    },
+  },
+  {
+    matches: (model) => model === 'gpt-5.4-mini',
+    pricing: {
+      model: 'gpt-5.4-mini',
+      inputUsdPerMillion: 0.75,
+      cachedInputUsdPerMillion: 0.075,
+      outputUsdPerMillion: 4.5,
+    },
+  },
+  {
+    matches: (model) => model === 'gpt-5.4-nano',
+    pricing: {
+      model: 'gpt-5.4-nano',
+      inputUsdPerMillion: 0.2,
+      cachedInputUsdPerMillion: 0.02,
+      outputUsdPerMillion: 1.25,
+    },
+  },
+];
+
+function findPricing(model: string): OpenAIPricing | null {
+  for (const rule of OPENAI_PRICING_RULES) {
+    if (rule.matches(model)) return rule.pricing;
+  }
+  return null;
+}
+
+function tokensToUsd(tokens: number, usdPerMillion: number): number {
+  return (tokens * usdPerMillion) / TOKENS_PER_MILLION;
+}
+
+export function estimateOpenAICost(model: string, usage: RuntimeUsage): CostResolution {
+  const breakdown = buildTokenBreakdown(usage);
+  const pricing = findPricing(model);
+  if (!pricing) {
+    return {
+      source: 'unavailable',
+      costUsd: null,
+      actualCostUsd: null,
+      estimatedCostUsd: null,
+      breakdown,
+      pricingVersion: OPENAI_PRICING_VERSION,
+      message: `No built-in pricing table entry for ${model}`,
+    };
+  }
+
+  const inputCostUsd = tokensToUsd(breakdown.uncachedInputTokens, pricing.inputUsdPerMillion);
+  const cachedInputCostUsd = tokensToUsd(breakdown.cachedInputTokens, pricing.cachedInputUsdPerMillion);
+  const outputCostUsd = tokensToUsd(breakdown.outputTokens, pricing.outputUsdPerMillion);
+  const totalCostUsd = inputCostUsd + cachedInputCostUsd + outputCostUsd;
+  const cacheSavingsUsd = tokensToUsd(
+    breakdown.cachedInputTokens,
+    pricing.inputUsdPerMillion - pricing.cachedInputUsdPerMillion,
+  );
+
+  return {
+    source: 'estimated',
+    costUsd: totalCostUsd,
+    actualCostUsd: null,
+    estimatedCostUsd: totalCostUsd,
+    breakdown: {
+      ...breakdown,
+      inputCostUsd,
+      cachedInputCostUsd,
+      outputCostUsd,
+      totalCostUsd,
+      cacheSavingsUsd,
+    },
+    pricingVersion: OPENAI_PRICING_VERSION,
+    providerMetadata: {
+      model: pricing.model,
+      inputUsdPerMillion: pricing.inputUsdPerMillion,
+      cachedInputUsdPerMillion: pricing.cachedInputUsdPerMillion,
+      outputUsdPerMillion: pricing.outputUsdPerMillion,
+    },
+  };
+}

--- a/packages/myco/src/agent/cost/openrouter.ts
+++ b/packages/myco/src/agent/cost/openrouter.ts
@@ -1,0 +1,184 @@
+import { OPENROUTER_API_KEY_ENV } from '@myco/cli/providers/openrouter.js';
+import type { CostResolution } from './types.js';
+import type { RuntimeUsage } from '@myco/agent/types.js';
+import { buildTokenBreakdown } from './breakdown.js';
+
+const OPENROUTER_DEFAULT_BASE_URL = 'https://openrouter.ai/api/v1';
+const OPENROUTER_MODELS_ENDPOINT = '/models';
+const OPENROUTER_CATALOG_CACHE_TTL_MS = 5 * 60 * 1000;
+const OPENROUTER_MODELS_TIMEOUT_MS = 5_000;
+const OPENROUTER_PRICING_VERSION = 'openrouter-model-catalog-live';
+
+interface OpenRouterPricing {
+  inputUsdPerToken?: number;
+  cachedInputUsdPerToken?: number;
+  outputUsdPerToken?: number;
+  reasoningUsdPerToken?: number;
+  requestUsd?: number;
+}
+
+interface OpenRouterCatalogEntry {
+  id?: string;
+  pricing?: {
+    prompt?: string;
+    completion?: string;
+    request?: string;
+    image?: string;
+    web_search?: string;
+    internal_reasoning?: string;
+    input_cache_read?: string;
+    input_cache_write?: string;
+  };
+}
+
+interface OpenRouterCatalogCacheEntry {
+  expiresAt: number;
+  pricingByModel: Map<string, OpenRouterPricing>;
+}
+
+const catalogCache = new Map<string, OpenRouterCatalogCacheEntry>();
+
+function parseRate(rate: string | undefined): number | undefined {
+  if (!rate) return undefined;
+  const parsed = Number(rate);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function hasAnyPricing(pricing: OpenRouterPricing): boolean {
+  return [
+    pricing.inputUsdPerToken,
+    pricing.cachedInputUsdPerToken,
+    pricing.outputUsdPerToken,
+    pricing.reasoningUsdPerToken,
+    pricing.requestUsd,
+  ].some((value) => value !== undefined);
+}
+
+function resolveOpenRouterApiKey(): string | undefined {
+  return process.env[OPENROUTER_API_KEY_ENV];
+}
+
+function resolveBaseUrl(baseUrl?: string): string {
+  return baseUrl ?? OPENROUTER_DEFAULT_BASE_URL;
+}
+
+async function fetchPricingCatalog(baseUrl?: string): Promise<Map<string, OpenRouterPricing>> {
+  const resolvedBaseUrl = resolveBaseUrl(baseUrl);
+  const now = Date.now();
+  const cached = catalogCache.get(resolvedBaseUrl);
+  if (cached && cached.expiresAt > now) {
+    return cached.pricingByModel;
+  }
+
+  const apiKey = resolveOpenRouterApiKey();
+  if (!apiKey) {
+    throw new Error('OpenRouter API key not configured');
+  }
+
+  const response = await fetch(`${resolvedBaseUrl}${OPENROUTER_MODELS_ENDPOINT}`, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+    signal: AbortSignal.timeout(OPENROUTER_MODELS_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`OpenRouter models request failed with ${response.status}`);
+  }
+
+  const data = await response.json() as { data?: OpenRouterCatalogEntry[] };
+  const pricingByModel = new Map<string, OpenRouterPricing>();
+  for (const entry of data.data ?? []) {
+    if (!entry.id || !entry.pricing) continue;
+    pricingByModel.set(entry.id, {
+      inputUsdPerToken: parseRate(entry.pricing.prompt),
+      cachedInputUsdPerToken: parseRate(entry.pricing.input_cache_read),
+      outputUsdPerToken: parseRate(entry.pricing.completion),
+      reasoningUsdPerToken: parseRate(entry.pricing.internal_reasoning),
+      requestUsd: parseRate(entry.pricing.request),
+    });
+  }
+
+  catalogCache.set(resolvedBaseUrl, {
+    expiresAt: now + OPENROUTER_CATALOG_CACHE_TTL_MS,
+    pricingByModel,
+  });
+  return pricingByModel;
+}
+
+export async function estimateOpenRouterCost(
+  model: string,
+  usage: RuntimeUsage,
+  baseUrl?: string,
+): Promise<CostResolution> {
+  const breakdown = buildTokenBreakdown(usage);
+
+  try {
+    const pricingByModel = await fetchPricingCatalog(baseUrl);
+    const pricing = pricingByModel.get(model);
+    if (!pricing) {
+      return {
+        source: 'unavailable',
+        costUsd: null,
+        actualCostUsd: null,
+        estimatedCostUsd: null,
+        breakdown,
+        pricingVersion: OPENROUTER_PRICING_VERSION,
+        message: `No OpenRouter pricing metadata found for ${model}`,
+      };
+    }
+    if (!hasAnyPricing(pricing)) {
+      return {
+        source: 'unavailable',
+        costUsd: null,
+        actualCostUsd: null,
+        estimatedCostUsd: null,
+        breakdown,
+        pricingVersion: OPENROUTER_PRICING_VERSION,
+        message: `OpenRouter pricing unavailable for ${model}`,
+      };
+    }
+
+    const inputCostUsd = (pricing.inputUsdPerToken ?? 0) * breakdown.uncachedInputTokens;
+    const cachedInputCostUsd = (pricing.cachedInputUsdPerToken ?? 0) * breakdown.cachedInputTokens;
+    const outputCostUsd = (pricing.outputUsdPerToken ?? 0) * breakdown.outputTokens;
+    const reasoningCostUsd = (pricing.reasoningUsdPerToken ?? 0) * breakdown.reasoningTokens;
+    const requestCostUsd = (pricing.requestUsd ?? 0) * breakdown.requestCount;
+    const totalCostUsd = inputCostUsd + cachedInputCostUsd + outputCostUsd + reasoningCostUsd + requestCostUsd;
+    const cacheSavingsUsd = Math.max(0, ((pricing.inputUsdPerToken ?? 0) - (pricing.cachedInputUsdPerToken ?? 0)) * breakdown.cachedInputTokens);
+
+    return {
+      source: 'estimated',
+      costUsd: totalCostUsd,
+      actualCostUsd: null,
+      estimatedCostUsd: totalCostUsd,
+      breakdown: {
+        ...breakdown,
+        inputCostUsd,
+        cachedInputCostUsd,
+        outputCostUsd,
+        reasoningCostUsd,
+        requestCostUsd,
+        totalCostUsd,
+        cacheSavingsUsd,
+      },
+      pricingVersion: OPENROUTER_PRICING_VERSION,
+      providerMetadata: {
+        inputUsdPerToken: pricing.inputUsdPerToken,
+        cachedInputUsdPerToken: pricing.cachedInputUsdPerToken,
+        outputUsdPerToken: pricing.outputUsdPerToken,
+        reasoningUsdPerToken: pricing.reasoningUsdPerToken,
+        requestUsd: pricing.requestUsd,
+      },
+    };
+  } catch (error) {
+    return {
+      source: 'unavailable',
+      costUsd: null,
+      actualCostUsd: null,
+      estimatedCostUsd: null,
+      breakdown,
+      pricingVersion: OPENROUTER_PRICING_VERSION,
+      message: error instanceof Error ? error.message : 'OpenRouter pricing lookup failed',
+    };
+  }
+}

--- a/packages/myco/src/agent/cost/providers.ts
+++ b/packages/myco/src/agent/cost/providers.ts
@@ -1,0 +1,92 @@
+import { estimateOpenAICost } from './openai.js';
+import { estimateOpenRouterCost } from './openrouter.js';
+import { resolveUnavailableCost } from './helpers.js';
+import type { ProviderType } from '@myco/agent/types.js';
+import type { CostProviderCapabilities, CostProviderResolver, CostResolutionInput } from './types.js';
+
+const CAPABILITIES_NONE: CostProviderCapabilities = {
+  estimateFromUsage: false,
+  fetchActualRunCost: false,
+  fetchCatalogPricing: false,
+};
+
+const CAPABILITIES_ANTHROPIC: CostProviderCapabilities = {
+  estimateFromUsage: false,
+  fetchActualRunCost: true,
+  fetchCatalogPricing: false,
+};
+
+const CAPABILITIES_OPENAI: CostProviderCapabilities = {
+  estimateFromUsage: true,
+  fetchActualRunCost: false,
+  fetchCatalogPricing: false,
+};
+
+const CAPABILITIES_OPENROUTER: CostProviderCapabilities = {
+  estimateFromUsage: true,
+  fetchActualRunCost: true,
+  fetchCatalogPricing: true,
+};
+
+const UNAVAILABLE_PROVIDER_RULES: Array<{
+  providerTypes: ProviderType[];
+  message: string;
+}> = [
+  {
+    providerTypes: ['anthropic'],
+    message: 'Anthropic runtime did not report cost for this run',
+  },
+  {
+    providerTypes: ['openai-compatible', 'ollama', 'lmstudio'],
+    message: 'No pricing resolver configured for this provider',
+  },
+];
+
+function matchesProviderType(providerType: ProviderType | undefined, candidates: ProviderType[]): boolean {
+  return providerType !== undefined && candidates.includes(providerType);
+}
+
+const COST_PROVIDERS: CostProviderResolver[] = [
+  {
+    id: 'openai',
+    capabilities: CAPABILITIES_OPENAI,
+    matches: (input) => input.provider?.type === 'openai',
+    resolve: async (input) => estimateOpenAICost(input.model, input.usage),
+  },
+  {
+    id: 'openrouter',
+    capabilities: CAPABILITIES_OPENROUTER,
+    matches: (input) => input.provider?.type === 'openrouter',
+    resolve: async (input) => estimateOpenRouterCost(input.model, input.usage, input.provider?.baseUrl),
+  },
+  {
+    id: 'anthropic-runtime',
+    capabilities: CAPABILITIES_ANTHROPIC,
+    matches: (input) => input.provider?.type === 'anthropic',
+    resolve: async (input) => resolveUnavailableCost(input, 'Anthropic runtime did not report cost for this run'),
+  },
+  {
+    id: 'generic-configured',
+    capabilities: CAPABILITIES_NONE,
+    matches: (input) => matchesProviderType(input.provider?.type, ['openai-compatible', 'ollama', 'lmstudio']),
+    resolve: async (input) => resolveUnavailableCost(input, 'No pricing resolver configured for this provider'),
+  },
+];
+
+export function getCostProvider(input: CostResolutionInput): CostProviderResolver | null {
+  for (const provider of COST_PROVIDERS) {
+    if (provider.matches(input)) {
+      return provider;
+    }
+  }
+  return null;
+}
+
+export function resolveProviderCostUnavailable(input: CostResolutionInput) {
+  for (const rule of UNAVAILABLE_PROVIDER_RULES) {
+    if (matchesProviderType(input.provider?.type, rule.providerTypes)) {
+      return resolveUnavailableCost(input, rule.message);
+    }
+  }
+  return resolveUnavailableCost(input, 'No provider cost resolver available');
+}

--- a/packages/myco/src/agent/cost/resolver.ts
+++ b/packages/myco/src/agent/cost/resolver.ts
@@ -1,0 +1,51 @@
+import { estimateOpenAICost } from './openai.js';
+import { estimateOpenRouterCost } from './openrouter.js';
+import type { CostResolution, CostResolutionInput } from './types.js';
+import { buildTokenBreakdown } from './breakdown.js';
+
+function resolveActualCost(input: CostResolutionInput): CostResolution | null {
+  if (input.usage.costUsd === undefined || input.usage.costUsd === null) return null;
+  return {
+    source: 'actual',
+    costUsd: input.usage.costUsd,
+    actualCostUsd: input.usage.costUsd,
+    estimatedCostUsd: null,
+    breakdown: {
+      ...buildTokenBreakdown(input.usage),
+      totalCostUsd: input.usage.costUsd,
+    },
+    pricingVersion: null,
+  };
+}
+
+function resolveUnavailable(input: CostResolutionInput, message?: string): CostResolution {
+  return {
+    source: 'unavailable',
+    costUsd: null,
+    actualCostUsd: null,
+    estimatedCostUsd: null,
+    breakdown: buildTokenBreakdown(input.usage),
+    pricingVersion: null,
+    message: message ?? null,
+  };
+}
+
+export async function resolveCost(input: CostResolutionInput): Promise<CostResolution> {
+  const actual = resolveActualCost(input);
+  if (actual) return actual;
+
+  switch (input.provider?.type) {
+    case 'openai':
+      return estimateOpenAICost(input.model, input.usage);
+    case 'openrouter':
+      return estimateOpenRouterCost(input.model, input.usage, input.provider.baseUrl);
+    case 'anthropic':
+      return resolveUnavailable(input, 'Anthropic runtime did not report cost for this run');
+    case 'openai-compatible':
+    case 'ollama':
+    case 'lmstudio':
+      return resolveUnavailable(input, 'No pricing resolver configured for this provider');
+    default:
+      return resolveUnavailable(input, 'No provider cost resolver available');
+  }
+}

--- a/packages/myco/src/agent/cost/resolver.ts
+++ b/packages/myco/src/agent/cost/resolver.ts
@@ -1,51 +1,13 @@
-import { estimateOpenAICost } from './openai.js';
-import { estimateOpenRouterCost } from './openrouter.js';
+import { resolveActualCost } from './helpers.js';
+import { getCostProvider, resolveProviderCostUnavailable } from './providers.js';
 import type { CostResolution, CostResolutionInput } from './types.js';
-import { buildTokenBreakdown } from './breakdown.js';
-
-function resolveActualCost(input: CostResolutionInput): CostResolution | null {
-  if (input.usage.costUsd === undefined || input.usage.costUsd === null) return null;
-  return {
-    source: 'actual',
-    costUsd: input.usage.costUsd,
-    actualCostUsd: input.usage.costUsd,
-    estimatedCostUsd: null,
-    breakdown: {
-      ...buildTokenBreakdown(input.usage),
-      totalCostUsd: input.usage.costUsd,
-    },
-    pricingVersion: null,
-  };
-}
-
-function resolveUnavailable(input: CostResolutionInput, message?: string): CostResolution {
-  return {
-    source: 'unavailable',
-    costUsd: null,
-    actualCostUsd: null,
-    estimatedCostUsd: null,
-    breakdown: buildTokenBreakdown(input.usage),
-    pricingVersion: null,
-    message: message ?? null,
-  };
-}
 
 export async function resolveCost(input: CostResolutionInput): Promise<CostResolution> {
   const actual = resolveActualCost(input);
   if (actual) return actual;
-
-  switch (input.provider?.type) {
-    case 'openai':
-      return estimateOpenAICost(input.model, input.usage);
-    case 'openrouter':
-      return estimateOpenRouterCost(input.model, input.usage, input.provider.baseUrl);
-    case 'anthropic':
-      return resolveUnavailable(input, 'Anthropic runtime did not report cost for this run');
-    case 'openai-compatible':
-    case 'ollama':
-    case 'lmstudio':
-      return resolveUnavailable(input, 'No pricing resolver configured for this provider');
-    default:
-      return resolveUnavailable(input, 'No provider cost resolver available');
+  const provider = getCostProvider(input);
+  if (!provider) {
+    return resolveProviderCostUnavailable(input);
   }
+  return provider.resolve(input);
 }

--- a/packages/myco/src/agent/cost/types.ts
+++ b/packages/myco/src/agent/cost/types.ts
@@ -35,3 +35,16 @@ export interface CostResolutionInput {
   usage: RuntimeUsage;
   provider?: ProviderConfig;
 }
+
+export interface CostProviderCapabilities {
+  estimateFromUsage: boolean;
+  fetchActualRunCost: boolean;
+  fetchCatalogPricing: boolean;
+}
+
+export interface CostProviderResolver {
+  id: string;
+  capabilities: CostProviderCapabilities;
+  matches: (input: CostResolutionInput) => boolean;
+  resolve: (input: CostResolutionInput) => Promise<CostResolution>;
+}

--- a/packages/myco/src/agent/cost/types.ts
+++ b/packages/myco/src/agent/cost/types.ts
@@ -1,0 +1,37 @@
+import type { ProviderConfig, RuntimeUsage } from '@myco/agent/types.js';
+
+export type CostSource = 'actual' | 'estimated' | 'unavailable';
+
+export interface CostBreakdown {
+  inputTokens: number;
+  cachedInputTokens: number;
+  uncachedInputTokens: number;
+  outputTokens: number;
+  reasoningTokens: number;
+  requestCount: number;
+  inputCostUsd?: number;
+  cachedInputCostUsd?: number;
+  outputCostUsd?: number;
+  reasoningCostUsd?: number;
+  requestCostUsd?: number;
+  totalCostUsd?: number;
+  cacheSavingsUsd?: number;
+}
+
+export interface CostResolution {
+  source: CostSource;
+  costUsd: number | null;
+  actualCostUsd: number | null;
+  estimatedCostUsd: number | null;
+  breakdown: CostBreakdown;
+  pricingVersion?: string | null;
+  message?: string | null;
+  providerMetadata?: Record<string, unknown>;
+}
+
+export interface CostResolutionInput {
+  runtime: string;
+  model: string;
+  usage: RuntimeUsage;
+  provider?: ProviderConfig;
+}

--- a/packages/myco/src/agent/definitions/tasks/digest-only.yaml
+++ b/packages/myco/src/agent/definitions/tasks/digest-only.yaml
@@ -13,7 +13,7 @@ description: >
   to spores or graph data.
 agent: myco-agent
 isDefault: false
-model: claude-sonnet-4-6
+reasoningLevel: default
 maxTurns: 28
 timeoutSeconds: 1800
 

--- a/packages/myco/src/agent/definitions/tasks/extract-only.yaml
+++ b/packages/myco/src/agent/definitions/tasks/extract-only.yaml
@@ -13,7 +13,7 @@ description: >
   quick pass that captures knowledge without full reasoning overhead.
 agent: myco-agent
 isDefault: false
-model: claude-haiku-4-5-20251001
+reasoningLevel: low
 maxTurns: 30
 timeoutSeconds: 300
 

--- a/packages/myco/src/agent/definitions/tasks/full-intelligence.yaml
+++ b/packages/myco/src/agent/definitions/tasks/full-intelligence.yaml
@@ -19,7 +19,7 @@ agent: myco-agent
 isDefault: true
 maxTurns: 150
 timeoutSeconds: 1800
-model: claude-sonnet-4-6
+reasoningLevel: default
 
 schedule:
   enabled: true
@@ -31,7 +31,7 @@ schedule:
 
 orchestrator:
   enabled: true
-  model: claude-sonnet-4-6
+  reasoningLevel: default
   maxTurns: 3
 
 contextQueries:
@@ -61,7 +61,7 @@ prompt: >
 
 phases:
   - name: read-state
-    model: claude-haiku-4-5-20251001
+    reasoningLevel: low
     # Root phase — no dependsOn
     prompt: |
       Read the current vault state to determine what needs processing.
@@ -81,7 +81,7 @@ phases:
     readOnly: true
 
   - name: extract
-    model: claude-haiku-4-5-20251001
+    reasoningLevel: low
     dependsOn: [read-state]
     prompt: |
       Extract observations from unprocessed batches as spores.
@@ -134,7 +134,7 @@ phases:
     required: true
 
   - name: summarize
-    model: claude-haiku-4-5-20251001
+    reasoningLevel: low
     dependsOn: [read-state]
     prompt: |
       Update session titles and summaries for sessions touched during extraction.
@@ -189,7 +189,7 @@ phases:
     required: false
 
   - name: consolidate
-    model: claude-sonnet-4-6
+    reasoningLevel: default
     dependsOn: [extract]
     prompt: |
       Consolidate related spores into wisdom and clean up redundancy.
@@ -255,7 +255,7 @@ phases:
     required: false
 
   - name: graph
-    model: claude-sonnet-4-6
+    reasoningLevel: default
     dependsOn: [extract]
     prompt: |
       Build the knowledge graph: create entities, then link spores to them.
@@ -323,7 +323,7 @@ phases:
   # in the same wave via Promise.allSettled().
 
   - name: digest-assess
-    model: claude-sonnet-4-6
+    reasoningLevel: default
     dependsOn: [consolidate]
     prompt: |
       Assess current digest state and gather material for tier updates.
@@ -390,7 +390,7 @@ phases:
     required: true
 
   - name: digest-10000
-    model: claude-haiku-4-5-20251001
+    reasoningLevel: low
     dependsOn: [digest-assess]
     prompt: |
       Update digest tier 10000 — Full institutional knowledge.
@@ -427,7 +427,7 @@ phases:
     required: false
 
   - name: digest-5000
-    model: claude-haiku-4-5-20251001
+    reasoningLevel: low
     dependsOn: [digest-assess]
     prompt: |
       Update digest tier 5000 — Deep onboarding.
@@ -463,7 +463,7 @@ phases:
     required: false
 
   - name: digest-1500
-    model: claude-haiku-4-5-20251001
+    reasoningLevel: low
     dependsOn: [digest-assess]
     prompt: |
       Update digest tier 1500 — Executive briefing.
@@ -499,7 +499,7 @@ phases:
     required: false
 
   - name: report
-    model: claude-haiku-4-5-20251001
+    reasoningLevel: low
     dependsOn: [extract, summarize, consolidate, graph, digest-assess, digest-10000, digest-5000, digest-1500]
     prompt: |
       Summarize what was done across all phases.

--- a/packages/myco/src/agent/definitions/tasks/graph-maintenance.yaml
+++ b/packages/myco/src/agent/definitions/tasks/graph-maintenance.yaml
@@ -13,7 +13,7 @@ description: >
   new spores or regenerate digest.
 agent: myco-agent
 isDefault: false
-model: claude-sonnet-4-6
+reasoningLevel: default
 maxTurns: 40
 timeoutSeconds: 480
 

--- a/packages/myco/src/agent/definitions/tasks/review-session.yaml
+++ b/packages/myco/src/agent/definitions/tasks/review-session.yaml
@@ -13,7 +13,7 @@ description: >
   checks, and generates the session title and summary.
 agent: myco-agent
 isDefault: false
-model: claude-sonnet-4-6
+reasoningLevel: default
 maxTurns: 40
 timeoutSeconds: 480
 

--- a/packages/myco/src/agent/definitions/tasks/skill-evolve.yaml
+++ b/packages/myco/src/agent/definitions/tasks/skill-evolve.yaml
@@ -10,7 +10,7 @@ prompt: >-
   overlap. The instruction contains pre-filtered skills with their
   content, new spore IDs, and pre-computed similarity analysis.
 isDefault: false
-model: claude-sonnet-4-6
+reasoningLevel: default
 maxTurns: 48
 timeoutSeconds: 1800
 schedule:
@@ -25,7 +25,7 @@ params:
   max_skills_per_run: 8
 phases:
   - name: inventory
-    model: claude-haiku-4-5-20251001
+    reasoningLevel: low
     prompt: |
       The instruction contains pre-computed structural analysis of
       all active skills. Two mechanical signals are provided:
@@ -82,7 +82,7 @@ phases:
     readOnly: true
 
   - name: assess
-    model: claude-sonnet-4-6
+    reasoningLevel: default
     prompt: |
       Read the inventory analysis from vault_state
       (key: skill-evolve-inventory).
@@ -157,7 +157,7 @@ phases:
       - inventory
 
   - name: act
-    model: claude-haiku-4-5-20251001
+    reasoningLevel: low
     prompt: |
       Read classifications from vault_state
       (key: skill-evolve-classifications). Parse the JSON.

--- a/packages/myco/src/agent/definitions/tasks/skill-generate.yaml
+++ b/packages/myco/src/agent/definitions/tasks/skill-generate.yaml
@@ -10,7 +10,7 @@ prompt: >-
   The instruction contains the candidate metadata and pre-assembled
   source material. Stage the skill, validate it, then finalize it.
 isDefault: false
-model: claude-sonnet-4-6
+reasoningLevel: default
 maxTurns: 30
 timeoutSeconds: 900
 schedule:

--- a/packages/myco/src/agent/definitions/tasks/skill-survey.yaml
+++ b/packages/myco/src/agent/definitions/tasks/skill-survey.yaml
@@ -9,7 +9,7 @@ prompt: >-
   Survey the vault knowledge graph for procedural domain candidates.
   The instruction contains pre-assembled vault context.
 isDefault: false
-model: claude-sonnet-4-6
+reasoningLevel: default
 maxTurns: 35
 timeoutSeconds: 1800
 schedule:
@@ -99,7 +99,7 @@ phases:
     readOnly: true
 
   - name: synthesize-evaluate
-    model: claude-sonnet-4-6
+    reasoningLevel: default
     prompt: |
       The explore phase identified procedural domain clusters from
       the vault. Now evaluate each and create candidates for domains

--- a/packages/myco/src/agent/definitions/tasks/supersession-sweep.yaml
+++ b/packages/myco/src/agent/definitions/tasks/supersession-sweep.yaml
@@ -13,7 +13,7 @@ description: >
   Records resolution events for audit trail.
 agent: myco-agent
 isDefault: false
-model: claude-haiku-4-5-20251001
+reasoningLevel: low
 maxTurns: 30
 timeoutSeconds: 300
 

--- a/packages/myco/src/agent/definitions/tasks/title-summary.yaml
+++ b/packages/myco/src/agent/definitions/tasks/title-summary.yaml
@@ -13,7 +13,7 @@ description: >
   title and informative summary.
 agent: myco-agent
 isDefault: false
-model: claude-haiku-4-5-20251001
+reasoningLevel: low
 maxTurns: 15
 timeoutSeconds: 120
 

--- a/packages/myco/src/agent/definitions/tasks/title-summary.yaml
+++ b/packages/myco/src/agent/definitions/tasks/title-summary.yaml
@@ -15,7 +15,7 @@ agent: myco-agent
 isDefault: false
 reasoningLevel: low
 maxTurns: 15
-timeoutSeconds: 120
+timeoutSeconds: 300
 
 prompt: |
   Generate or update session titles and summaries. Budget: ~12 turns.
@@ -28,10 +28,11 @@ prompt: |
 
   **If a target session ID is specified above:**
   Always process it — the user explicitly requested regeneration.
-  Call `vault_sessions` with `include_active: true` to get its current
-  title/summary (the session may still be active). Call `vault_search_fts`
-  with the session ID to find ALL its prompt batches (processed and
-  unprocessed). Do NOT skip even if there are no new unprocessed batches.
+  Call `vault_sessions` with `id: <target session>` and `include_active: true`
+  to get its current title/summary (the session may still be active).
+  Call `vault_batches` with the same session ID to read ALL its prompt batches
+  (processed and unprocessed). Do NOT skip even if there are no new
+  unprocessed batches.
 
   **If no target session specified (automatic run):**
   Call `vault_unprocessed` with `include_active: true` — titles are needed
@@ -45,7 +46,7 @@ prompt: |
   For each session to process:
   1. Read the EXISTING title and summary — context from prior runs.
   2. Read the session's prompt batches — user_prompt + response_summary.
-     For targeted sessions, use `vault_search_fts` results from Phase 1.
+     For targeted sessions, use `vault_batches` results from Phase 1.
      For automatic runs, use `vault_unprocessed` results.
      This is your PRIMARY source — read through the full set to understand
      the complete arc of work.
@@ -81,9 +82,9 @@ prompt: |
 
 toolOverrides:
   - vault_unprocessed
+  - vault_batches
   - vault_sessions
   - vault_spores
-  - vault_search_fts
   - vault_state
   - vault_update_session
   - vault_set_state

--- a/packages/myco/src/agent/executor-state.ts
+++ b/packages/myco/src/agent/executor-state.ts
@@ -1,0 +1,194 @@
+import { errorMessage as toErrorMessage } from '@myco/utils/error-message.js';
+import type { CostResolution, CostSource } from './cost/types.js';
+import type {
+  EffectiveConfig,
+  PhaseResult,
+  ProviderConfig,
+  ProviderType,
+  RuntimeId,
+  RuntimeUsage,
+} from './types.js';
+
+/** Error patterns that indicate an SDK/runtime session could not be resumed. */
+const SESSION_RESUME_ERROR_PATTERNS = [
+  /session/,
+  /resume/,
+  /previous[_ ]response/,
+  /conversation/,
+];
+
+export interface PhaseCheckpoint {
+  name: string;
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  summary?: string;
+  turnsUsed?: number;
+  tokensUsed?: number;
+  costUsd?: number;
+  costSource?: CostSource;
+  costData?: CostResolution;
+  sessionRef?: string;
+  sessionData?: unknown;
+  usage?: RuntimeUsage;
+  updatedAt: number;
+}
+
+export interface RunCheckpointState {
+  runtime: RuntimeId;
+  provider?: ProviderType;
+  providerConfig?: ProviderConfig;
+  model?: string;
+  sessionRef?: string;
+  sessionData?: unknown;
+  phases: Record<string, PhaseCheckpoint>;
+}
+
+export function abortReasonMessage(abortController?: AbortController): string | null {
+  if (!abortController?.signal.aborted) return null;
+  const reason = abortController.signal.reason;
+  if (reason instanceof Error) return reason.message;
+  if (typeof reason === 'string' && reason.length > 0) return reason;
+  return 'Agent run aborted';
+}
+
+export function isSessionResumeFailure(error: unknown): boolean {
+  const message = toErrorMessage(error).toLowerCase();
+  return SESSION_RESUME_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+export function parseCheckpointState(raw: string | null | undefined): RunCheckpointState {
+  if (!raw) {
+    return { runtime: 'claude-sdk', phases: {} };
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<RunCheckpointState>;
+    return {
+      runtime: parsed.runtime ?? 'claude-sdk',
+      provider: parsed.provider,
+      providerConfig: parsed.providerConfig,
+      model: parsed.model,
+      sessionRef: parsed.sessionRef,
+      sessionData: parsed.sessionData,
+      phases: parsed.phases ?? {},
+    };
+  } catch {
+    return { runtime: 'claude-sdk', phases: {} };
+  }
+}
+
+export function checkpointResultsForResume(
+  config: EffectiveConfig,
+  checkpointState: RunCheckpointState,
+): PhaseResult[] {
+  if (!config.phases) return [];
+  const order = new Map(config.phases.map((phase, index) => [phase.name, index]));
+  return Object.values(checkpointState.phases)
+    .filter((phase) => phase.status === 'completed')
+    .sort((a, b) => (order.get(a.name) ?? 0) - (order.get(b.name) ?? 0))
+    .map((phase) => ({
+      name: phase.name,
+      status: 'completed',
+      turnsUsed: phase.turnsUsed ?? 0,
+      tokensUsed: phase.tokensUsed ?? 0,
+      costUsd: phase.costUsd ?? 0,
+      costSource: phase.costSource,
+      costData: phase.costData,
+      summary: phase.summary ?? '',
+      usage: phase.usage,
+      sessionRef: phase.sessionRef,
+    }));
+}
+
+export function serializeCheckpointState(state: RunCheckpointState): string {
+  return JSON.stringify(state);
+}
+
+export function aggregateUsage(usages: Array<RuntimeUsage | undefined>): RuntimeUsage {
+  const aggregate: RuntimeUsage = {
+    requests: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    reasoningTokens: 0,
+    cachedTokens: 0,
+    durationMs: 0,
+  };
+  let sawCost = false;
+
+  for (const usage of usages) {
+    if (!usage) continue;
+    aggregate.requests = (aggregate.requests ?? 0) + (usage.requests ?? 0);
+    aggregate.inputTokens = (aggregate.inputTokens ?? 0) + (usage.inputTokens ?? 0);
+    aggregate.outputTokens = (aggregate.outputTokens ?? 0) + (usage.outputTokens ?? 0);
+    aggregate.totalTokens = (aggregate.totalTokens ?? 0) + (usage.totalTokens ?? 0);
+    aggregate.reasoningTokens = (aggregate.reasoningTokens ?? 0) + (usage.reasoningTokens ?? 0);
+    aggregate.cachedTokens = (aggregate.cachedTokens ?? 0) + (usage.cachedTokens ?? 0);
+    aggregate.durationMs = (aggregate.durationMs ?? 0) + (usage.durationMs ?? 0);
+    if (usage.costUsd !== undefined && usage.costUsd !== null) {
+      aggregate.costUsd = (aggregate.costUsd ?? 0) + usage.costUsd;
+      sawCost = true;
+    }
+  }
+
+  if (!sawCost) {
+    delete aggregate.costUsd;
+  }
+
+  return aggregate;
+}
+
+export function buildUsageData(
+  runUsage: RuntimeUsage,
+  runCost?: CostResolution,
+  phaseResults?: PhaseResult[],
+): string {
+  return JSON.stringify({
+    run: runUsage,
+    runCost: runCost ?? null,
+    phases: phaseResults?.map((phase) => ({
+      name: phase.name,
+      usage: phase.usage ?? null,
+      tokensUsed: phase.tokensUsed,
+      costUsd: phase.costUsd,
+      costSource: phase.costSource ?? null,
+      costData: phase.costData ?? null,
+    })) ?? [],
+  });
+}
+
+export function buildActionsTaken(
+  runtime: RuntimeId,
+  provider: ProviderConfig | undefined,
+  model: string,
+  phaseResults?: PhaseResult[],
+): string {
+  return JSON.stringify({
+    runtime,
+    model,
+    provider: provider?.type ?? 'anthropic',
+    ...(provider?.baseUrl ? { baseUrl: provider.baseUrl } : {}),
+    ...(phaseResults ? { phases: phaseResults } : {}),
+  });
+}
+
+export function resolveProviderForResume(
+  currentProvider: ProviderConfig | undefined,
+  resumedRun: {
+    provider: ProviderType | null;
+  } | null,
+  checkpointState: RunCheckpointState,
+  runtime: RuntimeId,
+  model: string,
+): ProviderConfig | undefined {
+  const persistedType = resumedRun?.provider ?? checkpointState.provider;
+  const persistedProvider = checkpointState.providerConfig;
+  if (!persistedType && !persistedProvider) return currentProvider;
+  const matchingCurrentProvider = currentProvider?.type === persistedType ? currentProvider : undefined;
+
+  return {
+    ...(persistedProvider ?? {}),
+    ...(matchingCurrentProvider ?? {}),
+    runtime,
+    type: persistedType ?? persistedProvider?.type ?? currentProvider?.type ?? 'anthropic',
+    model,
+  };
+}

--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -39,7 +39,9 @@ import { resolveOllamaContextVariants } from './ollama-context.js';
 import { resolveReasoningModel } from './reasoning-levels.js';
 import { computeWaves, phaseSessionId } from './wave-computation.js';
 import { SKILL_GENERATE_TASK } from './instruction-builders.js';
+import { resolveCost } from './cost/index.js';
 import { getAgentRuntime } from './runtime/index.js';
+import type { CostResolution, CostSource } from './cost/types.js';
 import type { ContextQueryResult } from './context-queries.js';
 import type { ProviderConfig } from './types.js';
 import type {
@@ -95,6 +97,8 @@ interface PhaseCheckpoint {
   turnsUsed?: number;
   tokensUsed?: number;
   costUsd?: number;
+  costSource?: CostSource;
+  costData?: CostResolution;
   sessionRef?: string;
   sessionData?: unknown;
   usage?: RuntimeUsage;
@@ -236,6 +240,8 @@ function checkpointResultsForResume(
       turnsUsed: phase.turnsUsed ?? 0,
       tokensUsed: phase.tokensUsed ?? 0,
       costUsd: phase.costUsd ?? 0,
+      costSource: phase.costSource,
+      costData: phase.costData,
       summary: phase.summary ?? '',
       usage: phase.usage,
       sessionRef: phase.sessionRef,
@@ -255,8 +261,8 @@ function aggregateUsage(usages: Array<RuntimeUsage | undefined>): RuntimeUsage {
     reasoningTokens: 0,
     cachedTokens: 0,
     durationMs: 0,
-    costUsd: 0,
   };
+  let sawCost = false;
 
   for (const usage of usages) {
     if (!usage) continue;
@@ -267,7 +273,14 @@ function aggregateUsage(usages: Array<RuntimeUsage | undefined>): RuntimeUsage {
     aggregate.reasoningTokens = (aggregate.reasoningTokens ?? 0) + (usage.reasoningTokens ?? 0);
     aggregate.cachedTokens = (aggregate.cachedTokens ?? 0) + (usage.cachedTokens ?? 0);
     aggregate.durationMs = (aggregate.durationMs ?? 0) + (usage.durationMs ?? 0);
-    aggregate.costUsd = (aggregate.costUsd ?? 0) + (usage.costUsd ?? 0);
+    if (usage.costUsd !== undefined && usage.costUsd !== null) {
+      aggregate.costUsd = (aggregate.costUsd ?? 0) + usage.costUsd;
+      sawCost = true;
+    }
+  }
+
+  if (!sawCost) {
+    delete aggregate.costUsd;
   }
 
   return aggregate;
@@ -275,15 +288,19 @@ function aggregateUsage(usages: Array<RuntimeUsage | undefined>): RuntimeUsage {
 
 function buildUsageData(
   runUsage: RuntimeUsage,
+  runCost?: CostResolution,
   phaseResults?: PhaseResult[],
 ): string {
   return JSON.stringify({
     run: runUsage,
+    runCost: runCost ?? null,
     phases: phaseResults?.map((phase) => ({
       name: phase.name,
       usage: phase.usage ?? null,
       tokensUsed: phase.tokensUsed,
       costUsd: phase.costUsd,
+      costSource: phase.costSource ?? null,
+      costData: phase.costData ?? null,
     })) ?? [],
   });
 }
@@ -319,6 +336,89 @@ function resolveProviderForResume(
     runtime,
     type: persistedType,
     model,
+  };
+}
+
+function serializeCostData(cost: CostResolution | undefined): string | null {
+  return cost ? JSON.stringify(cost) : null;
+}
+
+function summarizePhaseCosts(phaseResults: PhaseResult[]): CostResolution {
+  const costedPhases = phaseResults.filter((phase) => phase.costData && phase.costData.costUsd !== null);
+  if (costedPhases.length === 0) {
+    return {
+      source: 'unavailable',
+      costUsd: null,
+      actualCostUsd: null,
+      estimatedCostUsd: null,
+      breakdown: {
+        inputTokens: 0,
+        cachedInputTokens: 0,
+        uncachedInputTokens: 0,
+        outputTokens: 0,
+        reasoningTokens: 0,
+        requestCount: 0,
+      },
+      pricingVersion: null,
+      message: 'No phase cost data available',
+    };
+  }
+
+  const firstCost = costedPhases[0].costData!;
+  const aggregate = {
+    costUsd: 0,
+    actualCostUsd: 0,
+    estimatedCostUsd: 0,
+    breakdown: {
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      uncachedInputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      requestCount: 0,
+      inputCostUsd: 0,
+      cachedInputCostUsd: 0,
+      outputCostUsd: 0,
+      reasoningCostUsd: 0,
+      requestCostUsd: 0,
+      cacheSavingsUsd: 0,
+      totalCostUsd: 0,
+    },
+  };
+
+  for (const phase of costedPhases) {
+    const cost = phase.costData!;
+    const breakdown = cost.breakdown;
+    aggregate.costUsd += cost.costUsd ?? 0;
+    aggregate.actualCostUsd += cost.actualCostUsd ?? 0;
+    aggregate.estimatedCostUsd += cost.estimatedCostUsd ?? 0;
+    aggregate.breakdown.inputTokens += breakdown.inputTokens;
+    aggregate.breakdown.cachedInputTokens += breakdown.cachedInputTokens;
+    aggregate.breakdown.uncachedInputTokens += breakdown.uncachedInputTokens;
+    aggregate.breakdown.outputTokens += breakdown.outputTokens;
+    aggregate.breakdown.reasoningTokens += breakdown.reasoningTokens;
+    aggregate.breakdown.requestCount += breakdown.requestCount;
+    aggregate.breakdown.inputCostUsd += breakdown.inputCostUsd ?? 0;
+    aggregate.breakdown.cachedInputCostUsd += breakdown.cachedInputCostUsd ?? 0;
+    aggregate.breakdown.outputCostUsd += breakdown.outputCostUsd ?? 0;
+    aggregate.breakdown.reasoningCostUsd += breakdown.reasoningCostUsd ?? 0;
+    aggregate.breakdown.requestCostUsd += breakdown.requestCostUsd ?? 0;
+    aggregate.breakdown.cacheSavingsUsd += breakdown.cacheSavingsUsd ?? 0;
+  }
+  aggregate.breakdown.totalCostUsd = aggregate.costUsd;
+
+  const allActual = phaseResults.every((phase) => phase.costData?.source === 'actual');
+  const hasUnavailable = phaseResults.some((phase) => phase.costData?.source === 'unavailable');
+  return {
+    source: allActual ? 'actual' : 'estimated',
+    costUsd: aggregate.costUsd,
+    actualCostUsd: allActual ? aggregate.actualCostUsd : null,
+    estimatedCostUsd: allActual ? null : aggregate.costUsd,
+    breakdown: aggregate.breakdown,
+    pricingVersion: costedPhases.every((phase) => phase.costData?.pricingVersion === firstCost.pricingVersion)
+      ? firstCost.pricingVersion ?? null
+      : null,
+    ...(hasUnavailable ? { message: 'Some phase costs were unavailable; total reflects known phase costs only' } : {}),
   };
 }
 
@@ -389,12 +489,21 @@ async function executePhase(
       console.warn(`[agent] Required phase "${phase.name}" produced 0 turns`);
     }
 
+    const costData = await resolveCost({
+      runtime: config.runtime,
+      provider,
+      model: phaseModel,
+      usage: result.usage,
+    });
+
     return {
       name: phase.name,
       status: 'completed',
       turnsUsed: result.turnsUsed,
       tokensUsed: result.usage.totalTokens ?? 0,
-      costUsd: result.usage.costUsd ?? 0,
+      costUsd: costData.costUsd ?? 0,
+      costSource: costData.source,
+      costData,
       summary: result.finalText,
       usage: result.usage,
       sessionRef: result.sessionRef,
@@ -434,7 +543,7 @@ async function executeSingleQuery(
   vaultDir?: string,
   sessionRef?: string,
   sessionData?: unknown,
-): Promise<{ tokensUsed: number; costUsd: number; usage: RuntimeUsage; sessionRef?: string; sessionData?: unknown }> {
+): Promise<{ tokensUsed: number; costUsd: number | null; costData: CostResolution; usage: RuntimeUsage; sessionRef?: string; sessionData?: unknown }> {
   const runtime = getAgentRuntime(config.runtime);
   const effectiveModel = resolveReasoningModel(
     config.execution?.reasoningLevel ?? config.reasoningLevel,
@@ -457,10 +566,17 @@ async function executeSingleQuery(
       embeddingManager,
     },
   });
+  const costData = await resolveCost({
+    runtime: config.runtime,
+    provider,
+    model: effectiveModel,
+    usage: result.usage,
+  });
 
   return {
     tokensUsed: result.usage.totalTokens ?? 0,
-    costUsd: result.usage.costUsd ?? 0,
+    costUsd: costData.costUsd,
+    costData,
     usage: result.usage,
     sessionRef: result.sessionRef,
     sessionData: result.sessionData,
@@ -500,7 +616,7 @@ async function executePhasedQuery(
   vaultDir?: string,
   checkpointState?: RunCheckpointState,
   persistCheckpoints?: (state: RunCheckpointState, phases: PhaseResult[]) => Promise<void>,
-): Promise<{ tokensUsed: number; costUsd: number; usage: RuntimeUsage; phases: PhaseResult[] }> {
+): Promise<{ tokensUsed: number; costUsd: number | null; costData: CostResolution; usage: RuntimeUsage; phases: PhaseResult[] }> {
   const phases = config.phases!;
   const state = checkpointState ?? {
     runtime: config.runtime,
@@ -606,6 +722,8 @@ async function executePhasedQuery(
         turnsUsed: existingCheckpoint?.turnsUsed,
         tokensUsed: existingCheckpoint?.tokensUsed,
         costUsd: existingCheckpoint?.costUsd,
+        costSource: existingCheckpoint?.costSource,
+        costData: existingCheckpoint?.costData,
         sessionRef: sessionId,
         sessionData: existingCheckpoint?.sessionData,
         usage: existingCheckpoint?.usage,
@@ -691,6 +809,8 @@ async function executePhasedQuery(
         turnsUsed: result.turnsUsed,
         tokensUsed: result.tokensUsed,
         costUsd: result.costUsd,
+        costSource: result.costSource,
+        costData: result.costData,
         sessionRef: fulfilled?.sessionRef ?? priorCheckpoint?.sessionRef,
         sessionData: fulfilled?.sessionData ?? priorCheckpoint?.sessionData,
         usage: fulfilled?.usage ?? result.usage,
@@ -721,9 +841,11 @@ async function executePhasedQuery(
   }
 
   const usage = aggregateUsage(phaseResults.map((phase) => phase.usage));
+  const costData = summarizePhaseCosts(phaseResults);
   return {
     tokensUsed: usage.totalTokens ?? phaseResults.reduce((sum, phase) => sum + phase.tokensUsed, 0),
-    costUsd: usage.costUsd ?? phaseResults.reduce((sum, phase) => sum + phase.costUsd, 0),
+    costUsd: costData.costUsd,
+    costData,
     usage,
     phases: phaseResults,
   };
@@ -853,12 +975,19 @@ export async function runAgent(
       runtime: runtimeId,
       provider: effectiveProvider?.type ?? resumedRun.provider ?? null,
       model: effectiveModel,
+      started_at: now,
+      completed_at: null,
       resumable: 0,
       resume_status: null,
       resume_mode: options?.resumeMode ?? resumedRun.resume_mode ?? null,
       resumed_at: now,
       checkpoints: serializeCheckpointState(checkpointState),
       usage_data: resumedRun.usage_data,
+      cost_usd: resumedRun.cost_usd,
+      actual_cost_usd: resumedRun.actual_cost_usd,
+      estimated_cost_usd: resumedRun.estimated_cost_usd,
+      cost_source: resumedRun.cost_source,
+      cost_data: resumedRun.cost_data,
       error: null,
     });
   }
@@ -902,7 +1031,8 @@ export async function runAgent(
   let phaseResults: PhaseResult[] | undefined;
   try {
     let tokensUsed: number;
-    let costUsd: number;
+    let costUsd: number | null;
+    let costData: CostResolution;
     let usage: RuntimeUsage;
     let runSessionRef = checkpointState.sessionRef;
 
@@ -910,6 +1040,7 @@ export async function runAgent(
       currentCheckpointState: RunCheckpointState,
       currentPhaseResults: PhaseResult[] = [],
       currentUsage: RuntimeUsage = aggregateUsage(currentPhaseResults.map((phase) => phase.usage)),
+      currentCost: CostResolution = summarizePhaseCosts(currentPhaseResults),
     ) => {
       await Promise.resolve(updateRun(runId, {
         runtime: runtimeId,
@@ -917,7 +1048,12 @@ export async function runAgent(
         model: effectiveModel,
         session_ref: currentCheckpointState.sessionRef ?? null,
         checkpoints: serializeCheckpointState(currentCheckpointState),
-        usage_data: buildUsageData(currentUsage, currentPhaseResults),
+        usage_data: buildUsageData(currentUsage, currentCost, currentPhaseResults),
+        cost_usd: currentCost.costUsd ?? null,
+        actual_cost_usd: currentCost.actualCostUsd,
+        estimated_cost_usd: currentCost.estimatedCostUsd,
+        cost_source: currentCost.source,
+        cost_data: serializeCostData(currentCost),
         actions_taken: buildActionsTaken(runtimeId, effectiveProvider, effectiveModel, currentPhaseResults),
       }));
     };
@@ -942,6 +1078,7 @@ export async function runAgent(
       );
       tokensUsed = result.tokensUsed;
       costUsd = result.costUsd;
+      costData = result.costData;
       usage = result.usage;
       phaseResults = result.phases;
       const requiredPhaseNames = new Set(
@@ -982,11 +1119,12 @@ export async function runAgent(
       );
       tokensUsed = result.tokensUsed;
       costUsd = result.costUsd;
+      costData = result.costData;
       usage = result.usage;
       runSessionRef = result.sessionRef;
       checkpointState.sessionRef = result.sessionRef;
       checkpointState.sessionData = result.sessionData;
-      await persistRuntimeState(checkpointState, undefined, usage);
+      await persistRuntimeState(checkpointState, undefined, usage, costData);
     }
 
     clearTimeout(timeoutId);
@@ -1000,9 +1138,13 @@ export async function runAgent(
       resume_status: null,
       completed_at: completedAt,
       tokens_used: tokensUsed,
-      cost_usd: costUsd,
+      cost_usd: costData.costUsd ?? null,
+      actual_cost_usd: costData.actualCostUsd,
+      estimated_cost_usd: costData.estimatedCostUsd,
+      cost_source: costData.source,
+      cost_data: serializeCostData(costData),
       checkpoints: serializeCheckpointState(checkpointState),
-      usage_data: buildUsageData(usage, phaseResults),
+      usage_data: buildUsageData(usage, costData, phaseResults),
       actions_taken: buildActionsTaken(runtimeId, effectiveProvider, effectiveModel, phaseResults),
     });
 
@@ -1011,6 +1153,8 @@ export async function runAgent(
       status: STATUS_COMPLETED,
       tokensUsed,
       costUsd,
+      costSource: costData.source,
+      costData,
       runtime: runtimeId,
       provider: effectiveProvider?.type,
       model: effectiveModel,
@@ -1036,6 +1180,12 @@ export async function runAgent(
 
     try {
       const usage = aggregateUsage(phaseResults?.map((phase) => phase.usage) ?? []);
+      const costData = phaseResults ? summarizePhaseCosts(phaseResults) : await resolveCost({
+        runtime: runtimeId,
+        provider: effectiveProvider,
+        model: effectiveModel,
+        usage,
+      });
       updateRunStatus(runId, STATUS_FAILED, {
         runtime: runtimeId,
         provider: effectiveProvider?.type ?? null,
@@ -1044,10 +1194,14 @@ export async function runAgent(
         resumable: 1,
         resume_status: RESUME_STATUS_READY,
         checkpoints: serializeCheckpointState(checkpointState),
-        usage_data: buildUsageData(usage, phaseResults),
+        usage_data: buildUsageData(usage, costData, phaseResults),
         completed_at: failedAt,
         tokens_used: usage.totalTokens ?? phaseResults?.reduce((sum, phase) => sum + phase.tokensUsed, 0) ?? undefined,
-        cost_usd: usage.costUsd ?? phaseResults?.reduce((sum, phase) => sum + phase.costUsd, 0) ?? undefined,
+        cost_usd: costData.costUsd ?? null,
+        actual_cost_usd: costData.actualCostUsd,
+        estimated_cost_usd: costData.estimatedCostUsd,
+        cost_source: costData.source,
+        cost_data: serializeCostData(costData),
         error: errorMessage,
         actions_taken: buildActionsTaken(runtimeId, effectiveProvider, effectiveModel, phaseResults),
       });

--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -4,39 +4,42 @@
  * Orchestrates a single agent run:
  *   1. Initializes the database for the vault.
  *   2. Resolves effective config (definition + agent DB overrides + task).
- *   3. Guards against concurrent runs for the same agent.
- *   4. Creates a run record in the database.
+ *   3. Guards against concurrent runs for the same task.
+ *   4. Creates or resumes a run record in the database.
  *   5. Builds the task prompt (vault context + task + optional instruction).
- *   6. Executes the Claude Agent SDK query — single call for flat tasks,
+ *   6. Executes the selected runtime adapter — single call for flat tasks,
  *      wave-based parallel execution for phased tasks.
- *   7. Records cost/token data and marks the run completed or failed.
+ *   7. Persists checkpoint, usage, and resume metadata as the run progresses.
  */
 
 import crypto from 'node:crypto';
 import { resolve } from 'node:path';
 import { epochSeconds, DEFAULT_AGENT_ID, MS_PER_SECOND, PHASE_SUMMARY_MAX_CHARS } from '@myco/constants.js';
 import { errorMessage as toErrorMessage } from '@myco/utils/error-message.js';
-import { initDatabase, vaultDbPath, getDatabase } from '@myco/db/client.js';
+import { initDatabase, vaultDbPath } from '@myco/db/client.js';
 import { createSchema } from '@myco/db/schema.js';
 import { getDefaultTask } from '@myco/db/queries/tasks.js';
 import {
   insertRun,
   updateRunStatus,
+  updateRun,
+  getRun,
   getRunningRunForTask,
+  RESUME_STATUS_READY,
   STATUS_RUNNING,
   STATUS_COMPLETED,
   STATUS_FAILED,
 } from '@myco/db/queries/runs.js';
 import { loadSystemPrompt } from './loader.js';
-import { createVaultToolServer, createScopedVaultToolServer } from './tools.js';
 import { buildVaultContext } from './context.js';
 import { composeOrchestratorPrompt, parseOrchestratorPlan, applyDirectives, DEFAULT_ORCHESTRATOR_MAX_TURNS } from './orchestrator.js';
 import { executeContextQueries } from './context-queries.js';
-import { buildPhaseEnv } from './provider.js';
 import { resolveRunConfig } from './config-resolver.js';
 import { resolveOllamaContextVariants } from './ollama-context.js';
+import { resolveReasoningModel } from './reasoning-levels.js';
 import { computeWaves, phaseSessionId } from './wave-computation.js';
 import { SKILL_GENERATE_TASK } from './instruction-builders.js';
+import { getAgentRuntime } from './runtime/index.js';
 import type { ContextQueryResult } from './context-queries.js';
 import type { ProviderConfig } from './types.js';
 import type {
@@ -45,6 +48,8 @@ import type {
   EffectiveConfig,
   PhaseDefinition,
   PhaseResult,
+  ProviderType,
+  RuntimeUsage,
 } from './types.js';
 
 // Re-export computeWaves for backward compatibility (tests import from executor)
@@ -69,84 +74,40 @@ const PROMPT_SECTION_INSTRUCTION = '## User Instruction';
 /** Separator between prompt sections. */
 const PROMPT_SECTION_SEPARATOR = '\n\n';
 
-/** MCP server name for the vault tool server. */
-const MCP_SERVER_NAME = 'myco-vault';
-
-/** Whether to persist the agent session to disk. */
-const PERSIST_SESSION = true;
-
 /** Header for prior phase context in phased prompts. */
 const PROMPT_SECTION_PRIOR_PHASES = '## Prior Phase Results';
 
 /** Header for the current phase in phased prompts. */
 const PROMPT_SECTION_CURRENT_PHASE = '## Current Phase: ';
 
-// ---------------------------------------------------------------------------
-// Per-turn tool-call debug logging
-// ---------------------------------------------------------------------------
-//
-// When MYCO_AGENT_DEBUG=1, every tool_use and tool_result inside a phase is
-// logged to stdout with a short input/output preview. This is intended for
-// diagnosing turn-budget exhaustion: it surfaces rejection loops, malformed
-// tool-call retries, and unexpected exploration that the per-phase
-// `num_turns` summary alone cannot explain.
-//
-// The daemon sets this env var automatically when log_level is "debug"
-// (see src/daemon/main.ts). It can also be set manually for ad-hoc runs.
+/** Error patterns that indicate an SDK/runtime session could not be resumed. */
+const SESSION_RESUME_ERROR_PATTERNS = [
+  /session/,
+  /resume/,
+  /previous[_ ]response/,
+  /conversation/,
+];
 
-/** Max chars to print from tool input/output payloads. */
-const TOOL_DEBUG_PREVIEW_CHARS = 240;
-
-function debugToolCallsEnabled(): boolean {
-  return process.env.MYCO_AGENT_DEBUG === '1';
+interface PhaseCheckpoint {
+  name: string;
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  summary?: string;
+  turnsUsed?: number;
+  tokensUsed?: number;
+  costUsd?: number;
+  sessionRef?: string;
+  sessionData?: unknown;
+  usage?: RuntimeUsage;
+  updatedAt: number;
 }
 
-interface SdkContentBlock {
-  type: string;
-  name?: string;
-  input?: unknown;
-  tool_use_id?: string;
-  content?: unknown;
-  is_error?: boolean;
-}
-
-interface SdkMessageWithContent {
-  message?: { content?: SdkContentBlock[] };
-}
-
-function previewPayload(value: unknown): string {
-  const str = typeof value === 'string' ? value : JSON.stringify(value);
-  if (str === undefined) return '';
-  return str.length > TOOL_DEBUG_PREVIEW_CHARS
-    ? `${str.slice(0, TOOL_DEBUG_PREVIEW_CHARS)}…(${str.length - TOOL_DEBUG_PREVIEW_CHARS} more chars)`
-    : str;
-}
-
-function logToolUseBlocks(phaseName: string, message: unknown): void {
-  if (!debugToolCallsEnabled()) return;
-  const blocks = (message as SdkMessageWithContent).message?.content;
-  if (!Array.isArray(blocks)) return;
-  for (const block of blocks) {
-    if (block.type === 'tool_use') {
-      console.log(
-        `[agent:debug] ${phaseName} tool_use: ${block.name ?? 'unknown'} input=${previewPayload(block.input)}`,
-      );
-    }
-  }
-}
-
-function logToolResultBlocks(phaseName: string, message: unknown): void {
-  if (!debugToolCallsEnabled()) return;
-  const blocks = (message as SdkMessageWithContent).message?.content;
-  if (!Array.isArray(blocks)) return;
-  for (const block of blocks) {
-    if (block.type === 'tool_result') {
-      const flag = block.is_error ? ' [ERROR]' : '';
-      console.log(
-        `[agent:debug] ${phaseName} tool_result${flag}: ${previewPayload(block.content)}`,
-      );
-    }
-  }
+interface RunCheckpointState {
+  runtime: EffectiveConfig['runtime'];
+  provider?: ProviderType;
+  model?: string;
+  sessionRef?: string;
+  sessionData?: unknown;
+  phases: Record<string, PhaseCheckpoint>;
 }
 
 function abortReasonMessage(abortController?: AbortController): string | null {
@@ -155,6 +116,11 @@ function abortReasonMessage(abortController?: AbortController): string | null {
   if (reason instanceof Error) return reason.message;
   if (typeof reason === 'string' && reason.length > 0) return reason;
   return 'Agent run aborted';
+}
+
+function isSessionResumeFailure(error: unknown): boolean {
+  const message = toErrorMessage(error).toLowerCase();
+  return SESSION_RESUME_ERROR_PATTERNS.some((pattern) => pattern.test(message));
 }
 
 // ---------------------------------------------------------------------------
@@ -236,98 +202,212 @@ export function composePhasePrompt(
   return parts.join(PROMPT_SECTION_SEPARATOR);
 }
 
+function parseCheckpointState(raw: string | null | undefined): RunCheckpointState {
+  if (!raw) {
+    return { runtime: 'claude-sdk', phases: {} };
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<RunCheckpointState>;
+    return {
+      runtime: parsed.runtime ?? 'claude-sdk',
+      provider: parsed.provider,
+      model: parsed.model,
+      sessionRef: parsed.sessionRef,
+      sessionData: parsed.sessionData,
+      phases: parsed.phases ?? {},
+    };
+  } catch {
+    return { runtime: 'claude-sdk', phases: {} };
+  }
+}
+
+function checkpointResultsForResume(
+  config: EffectiveConfig,
+  checkpointState: RunCheckpointState,
+): PhaseResult[] {
+  if (!config.phases) return [];
+  const order = new Map(config.phases.map((phase, index) => [phase.name, index]));
+  return Object.values(checkpointState.phases)
+    .filter((phase) => phase.status === 'completed')
+    .sort((a, b) => (order.get(a.name) ?? 0) - (order.get(b.name) ?? 0))
+    .map((phase) => ({
+      name: phase.name,
+      status: 'completed',
+      turnsUsed: phase.turnsUsed ?? 0,
+      tokensUsed: phase.tokensUsed ?? 0,
+      costUsd: phase.costUsd ?? 0,
+      summary: phase.summary ?? '',
+      usage: phase.usage,
+      sessionRef: phase.sessionRef,
+    }));
+}
+
+function serializeCheckpointState(state: RunCheckpointState): string {
+  return JSON.stringify(state);
+}
+
+function aggregateUsage(usages: Array<RuntimeUsage | undefined>): RuntimeUsage {
+  const aggregate: RuntimeUsage = {
+    requests: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    reasoningTokens: 0,
+    cachedTokens: 0,
+    durationMs: 0,
+    costUsd: 0,
+  };
+
+  for (const usage of usages) {
+    if (!usage) continue;
+    aggregate.requests = (aggregate.requests ?? 0) + (usage.requests ?? 0);
+    aggregate.inputTokens = (aggregate.inputTokens ?? 0) + (usage.inputTokens ?? 0);
+    aggregate.outputTokens = (aggregate.outputTokens ?? 0) + (usage.outputTokens ?? 0);
+    aggregate.totalTokens = (aggregate.totalTokens ?? 0) + (usage.totalTokens ?? 0);
+    aggregate.reasoningTokens = (aggregate.reasoningTokens ?? 0) + (usage.reasoningTokens ?? 0);
+    aggregate.cachedTokens = (aggregate.cachedTokens ?? 0) + (usage.cachedTokens ?? 0);
+    aggregate.durationMs = (aggregate.durationMs ?? 0) + (usage.durationMs ?? 0);
+    aggregate.costUsd = (aggregate.costUsd ?? 0) + (usage.costUsd ?? 0);
+  }
+
+  return aggregate;
+}
+
+function buildUsageData(
+  runUsage: RuntimeUsage,
+  phaseResults?: PhaseResult[],
+): string {
+  return JSON.stringify({
+    run: runUsage,
+    phases: phaseResults?.map((phase) => ({
+      name: phase.name,
+      usage: phase.usage ?? null,
+      tokensUsed: phase.tokensUsed,
+      costUsd: phase.costUsd,
+    })) ?? [],
+  });
+}
+
+function buildActionsTaken(
+  runtime: EffectiveConfig['runtime'],
+  provider: ProviderConfig | undefined,
+  model: string,
+  phaseResults?: PhaseResult[],
+): string {
+  return JSON.stringify({
+    runtime,
+    model,
+    provider: provider?.type ?? 'anthropic',
+    ...(provider?.baseUrl ? { baseUrl: provider.baseUrl } : {}),
+    ...(phaseResults ? { phases: phaseResults } : {}),
+  });
+}
+
+function resolveProviderForResume(
+  currentProvider: ProviderConfig | undefined,
+  resumedRun: ReturnType<typeof getRun>,
+  checkpointState: RunCheckpointState,
+  runtime: EffectiveConfig['runtime'],
+  model: string,
+): ProviderConfig | undefined {
+  const persistedType = resumedRun?.provider ?? checkpointState.provider;
+  if (!persistedType) return currentProvider;
+  const matchingCurrentProvider = currentProvider?.type === persistedType ? currentProvider : undefined;
+
+  return {
+    ...(matchingCurrentProvider ?? {}),
+    runtime,
+    type: persistedType,
+    model,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Single-phase execution helper
 // ---------------------------------------------------------------------------
 
 /**
- * Execute a single phase query.
- *
- * Isolated helper that runs one query() call with scoped tools,
- * provider env, and phase-specific config.
+ * Execute a single phase query through the selected runtime adapter.
  */
 async function executePhase(
-  query: typeof import('@anthropic-ai/claude-agent-sdk').query,
+  config: EffectiveConfig,
   phasePrompt: string,
   phaseModel: string,
   systemPrompt: string,
-  toolServer: ReturnType<typeof createScopedVaultToolServer>,
   phase: PhaseDefinition,
-  env: Record<string, string | undefined> | undefined,
+  toolSurface: {
+    agentId: string;
+    runId: string;
+    toolNames: string[];
+    turnOffset: number;
+    projectRoot?: string;
+    vaultDir?: string;
+    readOnly?: boolean;
+    embeddingManager?: RunOptions['embeddingManager'];
+  },
+  provider?: ProviderConfig,
   sessionId?: string,
+  sessionData?: unknown,
   abortController?: AbortController,
-): Promise<PhaseResult> {
-  let phaseCost = 0;
-  let phaseTokens = 0;
-  let phaseTurns = 0;
-  let agenticTurns = 0;
-  let phaseSummary = '';
-
+): Promise<PhaseResult & { sessionData?: unknown }> {
+  const runtime = getAgentRuntime(config.runtime);
   try {
-    for await (const message of query({
-      prompt: phasePrompt,
-      options: {
+    let result;
+    try {
+      result = await runtime.execute({
+        prompt: phasePrompt,
         model: phaseModel,
-        systemPrompt,
-        mcpServers: { [MCP_SERVER_NAME]: toolServer },
-        strictMcpConfig: true,
         maxTurns: phase.maxTurns,
-        permissionMode: 'bypassPermissions',
-        allowDangerouslySkipPermissions: true,
-        persistSession: PERSIST_SESSION,
-        env,
-        tools: [],
-        ...(sessionId ? { sessionId } : {}),
-        ...(abortController ? { abortController } : {}),
-      },
-    })) {
-      if (message.type === 'assistant') {
-        agenticTurns++;
-        logToolUseBlocks(phase.name, message);
+        systemPrompt,
+        provider,
+        sessionRef: sessionId,
+        sessionData,
+        abortController,
+        toolSurface,
+      });
+    } catch (error) {
+      if (!sessionId || !runtime.supports('supportsSessionResume') || !isSessionResumeFailure(error)) {
+        throw error;
       }
-      if (message.type === 'user') {
-        logToolResultBlocks(phase.name, message);
-      }
-      if (message.type === 'result') {
-        phaseCost = message.total_cost_usd ?? 0;
-        phaseTokens =
-          (message.usage.input_tokens ?? 0) + (message.usage.output_tokens ?? 0);
-        phaseTurns = message.num_turns ?? 0;
-        if ('result' in message && typeof message.result === 'string') {
-          phaseSummary = message.result;
-        }
-      }
+      console.warn(`[agent] Resuming phase "${phase.name}" session failed, retrying without prior session`);
+      result = await runtime.execute({
+        prompt: phasePrompt,
+        model: phaseModel,
+        maxTurns: phase.maxTurns,
+        systemPrompt,
+        provider,
+        abortController,
+        toolSurface,
+      });
     }
 
-    if (phase.maxTurns) {
-      console.log(
-        `[agent] Phase "${phase.name}": num_turns=${phaseTurns}, assistant_msgs=${agenticTurns}, budget=${phase.maxTurns}`,
-      );
+    if (phase.maxTurns && result.turnsUsed > 0) {
+      console.log(`[agent] Phase "${phase.name}": num_turns=${result.turnsUsed}, budget=${phase.maxTurns}`);
     }
 
-    if (phase.required && phaseTurns === 0) {
+    if (phase.required && result.turnsUsed === 0) {
       console.warn(`[agent] Required phase "${phase.name}" produced 0 turns`);
     }
 
-    // Use SDK's num_turns — it's what the SDK enforces against.
-    // agenticTurns (assistant message count) is logged for diagnostics
-    // but not reliable as the primary metric.
     return {
       name: phase.name,
       status: 'completed',
-      turnsUsed: phaseTurns,
-      tokensUsed: phaseTokens,
-      costUsd: phaseCost,
-      summary: phaseSummary,
+      turnsUsed: result.turnsUsed,
+      tokensUsed: result.usage.totalTokens ?? 0,
+      costUsd: result.usage.costUsd ?? 0,
+      summary: result.finalText,
+      usage: result.usage,
+      sessionRef: result.sessionRef,
+      sessionData: result.sessionData,
     };
   } catch (err) {
     const abortReason = abortReasonMessage(abortController);
     return {
       name: phase.name,
       status: 'failed',
-      turnsUsed: phaseTurns,
-      tokensUsed: phaseTokens,
-      costUsd: phaseCost,
+      turnsUsed: 0,
+      tokensUsed: 0,
+      costUsd: 0,
       summary: abortReason ? `Error: ${abortReason}` : `Error: ${toErrorMessage(err)}`,
     };
   }
@@ -352,41 +432,39 @@ async function executeSingleQuery(
   embeddingManager?: RunOptions['embeddingManager'],
   abortController?: AbortController,
   vaultDir?: string,
-): Promise<{ tokensUsed: number; costUsd: number }> {
-  const { query } = await import('@anthropic-ai/claude-agent-sdk');
-  const toolServer = createVaultToolServer(agentId, runId, { embeddingManager, vaultDir });
-  const baseEnv = buildPhaseEnv(provider);
-  const env = { ...(baseEnv ?? process.env), MYCO_AGENT_SESSION: '1' };
-  // Model priority: provider model override → task YAML model
-  const effectiveModel = provider?.model ?? config.model;
-
-  let resultCostUsd = 0;
-  let resultTokens = 0;
-
-  for await (const message of query({
+  sessionRef?: string,
+  sessionData?: unknown,
+): Promise<{ tokensUsed: number; costUsd: number; usage: RuntimeUsage; sessionRef?: string; sessionData?: unknown }> {
+  const runtime = getAgentRuntime(config.runtime);
+  const effectiveModel = resolveReasoningModel(
+    config.execution?.reasoningLevel ?? config.reasoningLevel,
+    provider,
+    config.model,
+  );
+  const result = await runtime.execute({
     prompt: taskPrompt,
-    options: {
-      model: effectiveModel,
-      systemPrompt,
-      mcpServers: { [MCP_SERVER_NAME]: toolServer },
-      strictMcpConfig: true,
-      maxTurns: config.maxTurns,
-      permissionMode: 'bypassPermissions',
-      allowDangerouslySkipPermissions: true,
-      persistSession: PERSIST_SESSION,
-      env,
-      tools: [],
-      ...(abortController ? { abortController } : {}),
+    model: effectiveModel,
+    maxTurns: config.maxTurns,
+    systemPrompt,
+    provider,
+    abortController,
+    sessionRef,
+    sessionData,
+    toolSurface: {
+      agentId,
+      runId,
+      vaultDir,
+      embeddingManager,
     },
-  })) {
-    if (message.type === 'result') {
-      resultCostUsd = message.total_cost_usd ?? 0;
-      resultTokens =
-        (message.usage.input_tokens ?? 0) + (message.usage.output_tokens ?? 0);
-    }
-  }
+  });
 
-  return { tokensUsed: resultTokens, costUsd: resultCostUsd };
+  return {
+    tokensUsed: result.usage.totalTokens ?? 0,
+    costUsd: result.usage.costUsd ?? 0,
+    usage: result.usage,
+    sessionRef: result.sessionRef,
+    sessionData: result.sessionData,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -414,20 +492,29 @@ async function executePhasedQuery(
   agentId: string,
   runId: string,
   taskProviderOverride?: ProviderConfig,
-  phaseProviderOverrides?: Record<string, { provider?: ProviderConfig; maxTurns?: number }>,
+  phaseProviderOverrides?: Record<string, { provider?: ProviderConfig; model?: string; maxTurns?: number }>,
   instruction?: string,
   embeddingManager?: RunOptions['embeddingManager'],
   abortController?: AbortController,
   projectRoot?: string,
   vaultDir?: string,
-): Promise<{ tokensUsed: number; costUsd: number; phases: PhaseResult[] }> {
-  const { query } = await import('@anthropic-ai/claude-agent-sdk');
-
+  checkpointState?: RunCheckpointState,
+  persistCheckpoints?: (state: RunCheckpointState, phases: PhaseResult[]) => Promise<void>,
+): Promise<{ tokensUsed: number; costUsd: number; usage: RuntimeUsage; phases: PhaseResult[] }> {
   const phases = config.phases!;
-  const phaseResults: PhaseResult[] = [];
-  let totalTokens = 0;
-  let totalCost = 0;
-  let runningTurnCount = 0;
+  const state = checkpointState ?? {
+    runtime: config.runtime,
+    provider: taskProviderOverride?.type ?? config.execution?.provider?.type,
+    model: resolveReasoningModel(
+      config.execution?.reasoningLevel ?? config.reasoningLevel,
+      taskProviderOverride ?? config.execution?.provider,
+      config.model,
+    ),
+    phases: {},
+  };
+  const phaseResults: PhaseResult[] = checkpointResultsForResume(config, state);
+  let runningTurnCount = phaseResults.reduce((sum, phase) => sum + phase.turnsUsed, 0);
+  const completedPhaseNames = new Set(phaseResults.map((phase) => phase.name));
 
   // ---------------------------------------------------------------------------
   // Orchestrator planning (opt-in via config.orchestrator.enabled)
@@ -446,32 +533,30 @@ async function executePhasedQuery(
 
     // 2. Compose orchestrator prompt
     const orchestratorPrompt = composeOrchestratorPrompt(vaultContext, phases, contextResults);
-    const orchestratorModel = config.orchestrator.model ?? config.model;
+    const orchestratorModel = config.orchestrator.model ?? resolveReasoningModel(
+      config.orchestrator.reasoningLevel ?? config.execution?.reasoningLevel ?? config.reasoningLevel,
+      taskProviderOverride ?? config.execution?.provider,
+      config.model,
+    );
     const orchestratorMaxTurns = config.orchestrator.maxTurns ?? DEFAULT_ORCHESTRATOR_MAX_TURNS;
-
-    // 3. Call orchestrator (no tools — planning only)
-    const orchestratorEnv = { ...(buildPhaseEnv(taskProviderOverride) ?? process.env), MYCO_AGENT_SESSION: '1' };
-    let planResponse = '';
-    for await (const message of query({
+    const runtime = getAgentRuntime(config.runtime);
+    const planResponse = await runtime.execute({
       prompt: orchestratorPrompt,
-      options: {
-        model: orchestratorModel,
-        maxTurns: orchestratorMaxTurns,
-        permissionMode: 'bypassPermissions',
-        allowDangerouslySkipPermissions: true,
-        persistSession: PERSIST_SESSION,
-        strictMcpConfig: true,
-        env: orchestratorEnv,
-        tools: [],
+      model: orchestratorModel,
+      maxTurns: orchestratorMaxTurns,
+      systemPrompt,
+      provider: taskProviderOverride ?? config.execution?.provider,
+      toolSurface: {
+        agentId,
+        runId,
+        toolNames: [],
+        vaultDir,
       },
-    })) {
-      if (message.type === 'result' && 'result' in message && typeof message.result === 'string') {
-        planResponse = message.result;
-      }
-    }
+      abortController,
+    });
 
     // 4. Parse plan and apply directives
-    const plan = parseOrchestratorPlan(planResponse, phases);
+    const plan = parseOrchestratorPlan(planResponse.finalText, phases);
     effectivePhases = applyDirectives(phases, plan.phases);
   }
 
@@ -485,7 +570,12 @@ async function executePhasedQuery(
   const waves = computeWaves(effectivePhases);
 
   for (const wave of waves) {
-    const executions = wave.map((phase, indexInWave) => {
+    const runnableWave = wave.filter((phase) => !completedPhaseNames.has(phase.name));
+    if (runnableWave.length === 0) {
+      continue;
+    }
+
+    const waveInputs = runnableWave.map((phase, indexInWave) => {
       const phasePrompt = composePhasePrompt(
         vaultContext,
         config.taskDisplayName,
@@ -495,50 +585,89 @@ async function executePhasedQuery(
         instruction,
       );
 
-      // Apply myco.yaml per-phase overrides (maxTurns, provider)
       const phaseOverride = phaseProviderOverrides?.[phase.name];
       const effectiveMaxTurns = phaseOverride?.maxTurns ?? phase.maxTurns;
-
-      // Model priority: phase YAML → myco.yaml phase provider → myco.yaml task provider → task YAML
-      const phaseModel = phase.model ?? phaseOverride?.provider?.model ?? taskProviderOverride?.model ?? config.model;
-      const toolServer = createScopedVaultToolServer(
-        agentId,
-        runId,
-        phase.tools,
-        {
-          turnOffset: runningTurnCount + (indexInWave * effectiveMaxTurns),
-          embeddingManager,
-          projectRoot,
-          vaultDir,
-          readOnly: phase.readOnly,
-        },
+      const phaseModel = phaseOverride?.model ?? phase.model ?? resolveReasoningModel(
+        phase.reasoningLevel ?? config.execution?.reasoningLevel ?? config.reasoningLevel,
+        phase.provider ?? phaseOverride?.provider ?? taskProviderOverride ?? config.execution?.provider,
+        config.model,
       );
-
-      // Provider priority: phase YAML → myco.yaml phase → myco.yaml task → task YAML execution → default
       const phaseProvider = phase.provider ?? phaseOverride?.provider ?? taskProviderOverride ?? config.execution?.provider;
-      const baseEnv = buildPhaseEnv(phaseProvider);
-      const env = { ...(baseEnv ?? process.env), MYCO_AGENT_SESSION: '1' };
-      const sessionId = phaseSessionId(runId, phase.name);
-
-      // Pass effective maxTurns to executePhase via a modified phase object
+      const existingCheckpoint = state.phases[phase.name];
+      const sessionId = existingCheckpoint?.sessionRef ?? phaseSessionId(runId, phase.name);
       const effectivePhase = effectiveMaxTurns !== phase.maxTurns
         ? { ...phase, maxTurns: effectiveMaxTurns }
         : phase;
 
-      return executePhase(query, phasePrompt, phaseModel, systemPrompt, toolServer, effectivePhase, env, sessionId, abortController);
+      state.phases[phase.name] = {
+        name: phase.name,
+        status: 'running',
+        summary: existingCheckpoint?.summary,
+        turnsUsed: existingCheckpoint?.turnsUsed,
+        tokensUsed: existingCheckpoint?.tokensUsed,
+        costUsd: existingCheckpoint?.costUsd,
+        sessionRef: sessionId,
+        sessionData: existingCheckpoint?.sessionData,
+        usage: existingCheckpoint?.usage,
+        updatedAt: epochSeconds(),
+      };
+
+      return {
+        phase,
+        phasePrompt,
+        phaseModel,
+        phaseProvider,
+        effectivePhase,
+        sessionId,
+        sessionData: existingCheckpoint?.sessionData,
+        toolSurface: {
+          agentId,
+          runId,
+          toolNames: phase.tools,
+          turnOffset: runningTurnCount + (indexInWave * effectiveMaxTurns),
+          projectRoot,
+          vaultDir,
+          readOnly: phase.readOnly,
+          embeddingManager,
+        },
+      };
     });
 
-    const settled = await Promise.allSettled(executions);
+    if (persistCheckpoints) {
+      await persistCheckpoints(state, phaseResults);
+    }
+
+    const settled = await Promise.allSettled(
+      waveInputs.map((input) =>
+        executePhase(
+          config,
+          input.phasePrompt,
+          input.phaseModel,
+          systemPrompt,
+          input.effectivePhase,
+          input.toolSurface,
+          input.phaseProvider,
+          input.sessionId,
+          input.sessionData,
+          abortController,
+        ),
+      ),
+    );
+
+    const fulfilledByName = new Map<string, PhaseResult & { sessionData?: unknown }>();
+    for (const [index, outcome] of settled.entries()) {
+      if (outcome.status === 'fulfilled') {
+        fulfilledByName.set(runnableWave[index].name, outcome.value);
+      }
+    }
 
     // Map settled results to PhaseResult[]
     const waveResults: PhaseResult[] = settled.map((outcome, i) => {
       if (outcome.status === 'fulfilled') {
         return outcome.value;
       }
-      // Promise.allSettled rejected — shouldn't happen since executePhase catches,
-      // but handle defensively
       return {
-        name: wave[i].name,
+        name: runnableWave[i].name,
         status: 'failed' as const,
         turnsUsed: 0,
         tokensUsed: 0,
@@ -552,16 +681,34 @@ async function executePhasedQuery(
       (declarationOrder.get(a.name) ?? 0) - (declarationOrder.get(b.name) ?? 0),
     );
 
-    // Accumulate results and totals
-    for (const result of waveResults) {
+    for (const [index, result] of waveResults.entries()) {
+      const priorCheckpoint = state.phases[result.name];
+      const fulfilled = fulfilledByName.get(result.name) ?? null;
+      state.phases[result.name] = {
+        name: result.name,
+        status: result.status === 'completed' ? 'completed' : 'failed',
+        summary: result.summary,
+        turnsUsed: result.turnsUsed,
+        tokensUsed: result.tokensUsed,
+        costUsd: result.costUsd,
+        sessionRef: fulfilled?.sessionRef ?? priorCheckpoint?.sessionRef,
+        sessionData: fulfilled?.sessionData ?? priorCheckpoint?.sessionData,
+        usage: fulfilled?.usage ?? result.usage,
+        updatedAt: epochSeconds(),
+      };
+      if (result.status === 'completed') {
+        completedPhaseNames.add(result.name);
+      }
       phaseResults.push(result);
-      totalTokens += result.tokensUsed;
-      totalCost += result.costUsd;
       runningTurnCount += result.turnsUsed;
     }
 
+    if (persistCheckpoints) {
+      await persistCheckpoints(state, phaseResults);
+    }
+
     // If any required phase in this wave failed, stop the pipeline
-    const shouldStop = wave.some((phase, i) => {
+    const shouldStop = runnableWave.some((phase, i) => {
       if (!phase.required) return false;
       const outcome = settled[i];
       if (outcome.status === 'rejected') return true;
@@ -573,7 +720,13 @@ async function executePhasedQuery(
     }
   }
 
-  return { tokensUsed: totalTokens, costUsd: totalCost, phases: phaseResults };
+  const usage = aggregateUsage(phaseResults.map((phase) => phase.usage));
+  return {
+    tokensUsed: usage.totalTokens ?? phaseResults.reduce((sum, phase) => sum + phase.tokensUsed, 0),
+    costUsd: usage.costUsd ?? phaseResults.reduce((sum, phase) => sum + phase.costUsd, 0),
+    usage,
+    phases: phaseResults,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -600,11 +753,19 @@ export async function runAgent(
   createSchema(db);
 
   const agentId = options?.agentId ?? DEFAULT_AGENT_ID;
+  const resumedRun = options?.resumeRunId ? getRun(options.resumeRunId) : null;
+  if (options?.resumeRunId && !resumedRun) {
+    return {
+      runId: options.resumeRunId,
+      status: STATUS_FAILED,
+      error: `Run ${options.resumeRunId} not found`,
+    };
+  }
 
   // 2. Concurrency guard — block duplicate runs of the SAME task, not all tasks.
   // Different tasks (e.g., full-intelligence and skill-generate) can run concurrently.
   // When no task is specified, resolve the effective task name first so the guard applies.
-  const requestedTask = options?.task;
+  const requestedTask = options?.task ?? resumedRun?.task ?? undefined;
   {
     const effectiveTask = requestedTask
       ?? getDefaultTask(agentId)?.id;
@@ -636,30 +797,75 @@ export async function runAgent(
   // 4. Create run record
   const runId = options?.resumeRunId ?? crypto.randomUUID();
   const now = epochSeconds();
+  let runtimeId = config.runtime;
+  const baseProvider = taskProviderOverride ?? config.execution?.provider;
+  let effectiveModel = resolveReasoningModel(
+    config.execution?.reasoningLevel ?? config.reasoningLevel,
+    baseProvider,
+    config.model,
+  );
+  const checkpointState = resumedRun
+    ? parseCheckpointState(resumedRun.checkpoints)
+    : {
+      runtime: runtimeId,
+      provider: baseProvider?.type,
+      model: effectiveModel,
+      phases: {},
+    };
+  if (resumedRun) {
+    runtimeId = resumedRun.runtime ?? checkpointState.runtime ?? runtimeId;
+    effectiveModel = resumedRun.model ?? checkpointState.model ?? effectiveModel;
+  }
+  const effectiveProvider = resolveProviderForResume(
+    baseProvider,
+    resumedRun,
+    checkpointState,
+    runtimeId,
+    effectiveModel,
+  );
+  if (!resumedRun) {
+    checkpointState.runtime = runtimeId;
+    checkpointState.provider = effectiveProvider?.type;
+    checkpointState.model = effectiveModel;
+  } else {
+    checkpointState.runtime = checkpointState.runtime ?? runtimeId;
+    checkpointState.provider = checkpointState.provider ?? effectiveProvider?.type;
+    checkpointState.model = checkpointState.model ?? effectiveModel;
+  }
 
-  if (!options?.resumeRunId) {
+  if (!resumedRun) {
     insertRun({
       id: runId,
       agent_id: agentId,
       task: config.taskName,
       instruction: options?.instruction ?? null,
       status: STATUS_RUNNING,
+      runtime: runtimeId,
+      provider: effectiveProvider?.type ?? null,
+      model: effectiveModel,
+      checkpoints: serializeCheckpointState(checkpointState),
+      usage_data: buildUsageData({}),
       started_at: now,
+    });
+  } else {
+    updateRun(runId, {
+      status: STATUS_RUNNING,
+      runtime: runtimeId,
+      provider: effectiveProvider?.type ?? resumedRun.provider ?? null,
+      model: effectiveModel,
+      resumable: 0,
+      resume_status: null,
+      resume_mode: options?.resumeMode ?? resumedRun.resume_mode ?? null,
+      resumed_at: now,
+      checkpoints: serializeCheckpointState(checkpointState),
+      usage_data: resumedRun.usage_data,
+      error: null,
     });
   }
 
   // 5. Build prompt components
   const systemPrompt = loadSystemPrompt(definitionsDir, config.systemPromptPath);
   const vaultContext = buildVaultContext(agentId);
-
-  // 6. Build run metadata for audit trail
-  const effectiveProvider = taskProviderOverride ?? config.execution?.provider;
-  const effectiveModel = effectiveProvider?.model ?? config.model;
-  const runMeta = {
-    model: effectiveModel,
-    provider: effectiveProvider?.type ?? 'anthropic',
-    ...(effectiveProvider?.baseUrl ? { baseUrl: effectiveProvider.baseUrl } : {}),
-  };
 
   // 7. Resolve Ollama context variants across task + phase scopes.
   //    Applies DEFAULT_OLLAMA_CONTEXT_LENGTH when no value is set, and
@@ -697,9 +903,26 @@ export async function runAgent(
   try {
     let tokensUsed: number;
     let costUsd: number;
+    let usage: RuntimeUsage;
+    let runSessionRef = checkpointState.sessionRef;
+
+    const persistRuntimeState = async (
+      currentCheckpointState: RunCheckpointState,
+      currentPhaseResults: PhaseResult[] = [],
+      currentUsage: RuntimeUsage = aggregateUsage(currentPhaseResults.map((phase) => phase.usage)),
+    ) => {
+      await Promise.resolve(updateRun(runId, {
+        runtime: runtimeId,
+        provider: effectiveProvider?.type ?? null,
+        model: effectiveModel,
+        session_ref: currentCheckpointState.sessionRef ?? null,
+        checkpoints: serializeCheckpointState(currentCheckpointState),
+        usage_data: buildUsageData(currentUsage, currentPhaseResults),
+        actions_taken: buildActionsTaken(runtimeId, effectiveProvider, effectiveModel, currentPhaseResults),
+      }));
+    };
 
     if (config.phases && config.phases.length > 0) {
-      // Phased execution: wave-based parallel query() per phase with scoped tools
       const projectRoot = resolve(vaultDir, '..');
       const result = await executePhasedQuery(
         config,
@@ -714,15 +937,13 @@ export async function runAgent(
         taskAbortController,
         projectRoot,
         vaultDir,
+        checkpointState,
+        persistRuntimeState,
       );
       tokensUsed = result.tokensUsed;
       costUsd = result.costUsd;
+      usage = result.usage;
       phaseResults = result.phases;
-
-      // A required-phase failure stops the pipeline (executePhasedQuery breaks
-      // the wave loop) but returns normally. Surface it as a run-level failure
-      // by throwing — the catch block writes STATUS_FAILED while preserving
-      // the accumulated phase results in the DB row.
       const requiredPhaseNames = new Set(
         config.phases!.filter((p) => p.required).map((p) => p.name),
       );
@@ -756,18 +977,33 @@ export async function runAgent(
         options?.embeddingManager,
         taskAbortController,
         vaultDir,
+        checkpointState.sessionRef,
+        checkpointState.sessionData,
       );
       tokensUsed = result.tokensUsed;
       costUsd = result.costUsd;
+      usage = result.usage;
+      runSessionRef = result.sessionRef;
+      checkpointState.sessionRef = result.sessionRef;
+      checkpointState.sessionData = result.sessionData;
+      await persistRuntimeState(checkpointState, undefined, usage);
     }
 
     clearTimeout(timeoutId);
     const completedAt = epochSeconds();
     updateRunStatus(runId, STATUS_COMPLETED, {
+      runtime: runtimeId,
+      provider: effectiveProvider?.type ?? null,
+      model: effectiveModel,
+      session_ref: runSessionRef ?? null,
+      resumable: 0,
+      resume_status: null,
       completed_at: completedAt,
       tokens_used: tokensUsed,
       cost_usd: costUsd,
-      actions_taken: JSON.stringify({ ...runMeta, ...(phaseResults ? { phases: phaseResults } : {}) }),
+      checkpoints: serializeCheckpointState(checkpointState),
+      usage_data: buildUsageData(usage, phaseResults),
+      actions_taken: buildActionsTaken(runtimeId, effectiveProvider, effectiveModel, phaseResults),
     });
 
     return {
@@ -775,6 +1011,9 @@ export async function runAgent(
       status: STATUS_COMPLETED,
       tokensUsed,
       costUsd,
+      runtime: runtimeId,
+      provider: effectiveProvider?.type,
+      model: effectiveModel,
       ...(phaseResults ? { phases: phaseResults } : {}),
     };
   } catch (err) {
@@ -796,11 +1035,21 @@ export async function runAgent(
     console.error(`[agent] Run ${runId} failed: ${errorMessage}`);
 
     try {
+      const usage = aggregateUsage(phaseResults?.map((phase) => phase.usage) ?? []);
       updateRunStatus(runId, STATUS_FAILED, {
+        runtime: runtimeId,
+        provider: effectiveProvider?.type ?? null,
+        model: effectiveModel,
+        session_ref: checkpointState.sessionRef ?? null,
+        resumable: 1,
+        resume_status: RESUME_STATUS_READY,
+        checkpoints: serializeCheckpointState(checkpointState),
+        usage_data: buildUsageData(usage, phaseResults),
         completed_at: failedAt,
+        tokens_used: usage.totalTokens ?? phaseResults?.reduce((sum, phase) => sum + phase.tokensUsed, 0) ?? undefined,
+        cost_usd: usage.costUsd ?? phaseResults?.reduce((sum, phase) => sum + phase.costUsd, 0) ?? undefined,
         error: errorMessage,
-        // Preserve phase results collected before the failure
-        actions_taken: JSON.stringify({ ...runMeta, ...(phaseResults ? { phases: phaseResults } : {}) }),
+        actions_taken: buildActionsTaken(runtimeId, effectiveProvider, effectiveModel, phaseResults),
       });
     } catch (dbErr) {
       // DB failure in error path — log it but don't mask the original error
@@ -817,6 +1066,9 @@ export async function runAgent(
       runId,
       status: STATUS_FAILED,
       error: errorMessage,
+      runtime: runtimeId,
+      provider: effectiveProvider?.type,
+      model: effectiveModel,
       ...(phaseResults ? { phases: phaseResults } : {}),
     };
   }

--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -37,11 +37,27 @@ import { executeContextQueries } from './context-queries.js';
 import { resolveRunConfig } from './config-resolver.js';
 import { resolveOllamaContextVariants } from './ollama-context.js';
 import { resolveReasoningModel } from './reasoning-levels.js';
+import { validateTaskPostconditions } from './task-postconditions.js';
 import { computeWaves, phaseSessionId } from './wave-computation.js';
 import { SKILL_GENERATE_TASK } from './instruction-builders.js';
 import { resolveCost } from './cost/index.js';
+import {
+  aggregateUsage,
+  abortReasonMessage,
+  buildUsageData,
+  checkpointResultsForResume,
+  isSessionResumeFailure,
+  parseCheckpointState,
+  resolveProviderForResume,
+  serializeCheckpointState,
+  type RunCheckpointState,
+} from './executor-state.js';
+import {
+  buildRunAccountingUpdate,
+  summarizePhaseCosts,
+} from './run-accounting.js';
 import { getAgentRuntime } from './runtime/index.js';
-import type { CostResolution, CostSource } from './cost/types.js';
+import type { CostResolution } from './cost/types.js';
 import type { ContextQueryResult } from './context-queries.js';
 import type { ProviderConfig } from './types.js';
 import type {
@@ -50,7 +66,6 @@ import type {
   EffectiveConfig,
   PhaseDefinition,
   PhaseResult,
-  ProviderType,
   RuntimeUsage,
 } from './types.js';
 
@@ -81,51 +96,6 @@ const PROMPT_SECTION_PRIOR_PHASES = '## Prior Phase Results';
 
 /** Header for the current phase in phased prompts. */
 const PROMPT_SECTION_CURRENT_PHASE = '## Current Phase: ';
-
-/** Error patterns that indicate an SDK/runtime session could not be resumed. */
-const SESSION_RESUME_ERROR_PATTERNS = [
-  /session/,
-  /resume/,
-  /previous[_ ]response/,
-  /conversation/,
-];
-
-interface PhaseCheckpoint {
-  name: string;
-  status: 'pending' | 'running' | 'completed' | 'failed';
-  summary?: string;
-  turnsUsed?: number;
-  tokensUsed?: number;
-  costUsd?: number;
-  costSource?: CostSource;
-  costData?: CostResolution;
-  sessionRef?: string;
-  sessionData?: unknown;
-  usage?: RuntimeUsage;
-  updatedAt: number;
-}
-
-interface RunCheckpointState {
-  runtime: EffectiveConfig['runtime'];
-  provider?: ProviderType;
-  model?: string;
-  sessionRef?: string;
-  sessionData?: unknown;
-  phases: Record<string, PhaseCheckpoint>;
-}
-
-function abortReasonMessage(abortController?: AbortController): string | null {
-  if (!abortController?.signal.aborted) return null;
-  const reason = abortController.signal.reason;
-  if (reason instanceof Error) return reason.message;
-  if (typeof reason === 'string' && reason.length > 0) return reason;
-  return 'Agent run aborted';
-}
-
-function isSessionResumeFailure(error: unknown): boolean {
-  const message = toErrorMessage(error).toLowerCase();
-  return SESSION_RESUME_ERROR_PATTERNS.some((pattern) => pattern.test(message));
-}
 
 // ---------------------------------------------------------------------------
 // Prompt composition
@@ -204,222 +174,6 @@ export function composePhasePrompt(
   parts.push(`${PROMPT_SECTION_CURRENT_PHASE}${phase.name}\n${phase.prompt}`);
 
   return parts.join(PROMPT_SECTION_SEPARATOR);
-}
-
-function parseCheckpointState(raw: string | null | undefined): RunCheckpointState {
-  if (!raw) {
-    return { runtime: 'claude-sdk', phases: {} };
-  }
-  try {
-    const parsed = JSON.parse(raw) as Partial<RunCheckpointState>;
-    return {
-      runtime: parsed.runtime ?? 'claude-sdk',
-      provider: parsed.provider,
-      model: parsed.model,
-      sessionRef: parsed.sessionRef,
-      sessionData: parsed.sessionData,
-      phases: parsed.phases ?? {},
-    };
-  } catch {
-    return { runtime: 'claude-sdk', phases: {} };
-  }
-}
-
-function checkpointResultsForResume(
-  config: EffectiveConfig,
-  checkpointState: RunCheckpointState,
-): PhaseResult[] {
-  if (!config.phases) return [];
-  const order = new Map(config.phases.map((phase, index) => [phase.name, index]));
-  return Object.values(checkpointState.phases)
-    .filter((phase) => phase.status === 'completed')
-    .sort((a, b) => (order.get(a.name) ?? 0) - (order.get(b.name) ?? 0))
-    .map((phase) => ({
-      name: phase.name,
-      status: 'completed',
-      turnsUsed: phase.turnsUsed ?? 0,
-      tokensUsed: phase.tokensUsed ?? 0,
-      costUsd: phase.costUsd ?? 0,
-      costSource: phase.costSource,
-      costData: phase.costData,
-      summary: phase.summary ?? '',
-      usage: phase.usage,
-      sessionRef: phase.sessionRef,
-    }));
-}
-
-function serializeCheckpointState(state: RunCheckpointState): string {
-  return JSON.stringify(state);
-}
-
-function aggregateUsage(usages: Array<RuntimeUsage | undefined>): RuntimeUsage {
-  const aggregate: RuntimeUsage = {
-    requests: 0,
-    inputTokens: 0,
-    outputTokens: 0,
-    totalTokens: 0,
-    reasoningTokens: 0,
-    cachedTokens: 0,
-    durationMs: 0,
-  };
-  let sawCost = false;
-
-  for (const usage of usages) {
-    if (!usage) continue;
-    aggregate.requests = (aggregate.requests ?? 0) + (usage.requests ?? 0);
-    aggregate.inputTokens = (aggregate.inputTokens ?? 0) + (usage.inputTokens ?? 0);
-    aggregate.outputTokens = (aggregate.outputTokens ?? 0) + (usage.outputTokens ?? 0);
-    aggregate.totalTokens = (aggregate.totalTokens ?? 0) + (usage.totalTokens ?? 0);
-    aggregate.reasoningTokens = (aggregate.reasoningTokens ?? 0) + (usage.reasoningTokens ?? 0);
-    aggregate.cachedTokens = (aggregate.cachedTokens ?? 0) + (usage.cachedTokens ?? 0);
-    aggregate.durationMs = (aggregate.durationMs ?? 0) + (usage.durationMs ?? 0);
-    if (usage.costUsd !== undefined && usage.costUsd !== null) {
-      aggregate.costUsd = (aggregate.costUsd ?? 0) + usage.costUsd;
-      sawCost = true;
-    }
-  }
-
-  if (!sawCost) {
-    delete aggregate.costUsd;
-  }
-
-  return aggregate;
-}
-
-function buildUsageData(
-  runUsage: RuntimeUsage,
-  runCost?: CostResolution,
-  phaseResults?: PhaseResult[],
-): string {
-  return JSON.stringify({
-    run: runUsage,
-    runCost: runCost ?? null,
-    phases: phaseResults?.map((phase) => ({
-      name: phase.name,
-      usage: phase.usage ?? null,
-      tokensUsed: phase.tokensUsed,
-      costUsd: phase.costUsd,
-      costSource: phase.costSource ?? null,
-      costData: phase.costData ?? null,
-    })) ?? [],
-  });
-}
-
-function buildActionsTaken(
-  runtime: EffectiveConfig['runtime'],
-  provider: ProviderConfig | undefined,
-  model: string,
-  phaseResults?: PhaseResult[],
-): string {
-  return JSON.stringify({
-    runtime,
-    model,
-    provider: provider?.type ?? 'anthropic',
-    ...(provider?.baseUrl ? { baseUrl: provider.baseUrl } : {}),
-    ...(phaseResults ? { phases: phaseResults } : {}),
-  });
-}
-
-function resolveProviderForResume(
-  currentProvider: ProviderConfig | undefined,
-  resumedRun: ReturnType<typeof getRun>,
-  checkpointState: RunCheckpointState,
-  runtime: EffectiveConfig['runtime'],
-  model: string,
-): ProviderConfig | undefined {
-  const persistedType = resumedRun?.provider ?? checkpointState.provider;
-  if (!persistedType) return currentProvider;
-  const matchingCurrentProvider = currentProvider?.type === persistedType ? currentProvider : undefined;
-
-  return {
-    ...(matchingCurrentProvider ?? {}),
-    runtime,
-    type: persistedType,
-    model,
-  };
-}
-
-function serializeCostData(cost: CostResolution | undefined): string | null {
-  return cost ? JSON.stringify(cost) : null;
-}
-
-function summarizePhaseCosts(phaseResults: PhaseResult[]): CostResolution {
-  const costedPhases = phaseResults.filter((phase) => phase.costData && phase.costData.costUsd !== null);
-  if (costedPhases.length === 0) {
-    return {
-      source: 'unavailable',
-      costUsd: null,
-      actualCostUsd: null,
-      estimatedCostUsd: null,
-      breakdown: {
-        inputTokens: 0,
-        cachedInputTokens: 0,
-        uncachedInputTokens: 0,
-        outputTokens: 0,
-        reasoningTokens: 0,
-        requestCount: 0,
-      },
-      pricingVersion: null,
-      message: 'No phase cost data available',
-    };
-  }
-
-  const firstCost = costedPhases[0].costData!;
-  const aggregate = {
-    costUsd: 0,
-    actualCostUsd: 0,
-    estimatedCostUsd: 0,
-    breakdown: {
-      inputTokens: 0,
-      cachedInputTokens: 0,
-      uncachedInputTokens: 0,
-      outputTokens: 0,
-      reasoningTokens: 0,
-      requestCount: 0,
-      inputCostUsd: 0,
-      cachedInputCostUsd: 0,
-      outputCostUsd: 0,
-      reasoningCostUsd: 0,
-      requestCostUsd: 0,
-      cacheSavingsUsd: 0,
-      totalCostUsd: 0,
-    },
-  };
-
-  for (const phase of costedPhases) {
-    const cost = phase.costData!;
-    const breakdown = cost.breakdown;
-    aggregate.costUsd += cost.costUsd ?? 0;
-    aggregate.actualCostUsd += cost.actualCostUsd ?? 0;
-    aggregate.estimatedCostUsd += cost.estimatedCostUsd ?? 0;
-    aggregate.breakdown.inputTokens += breakdown.inputTokens;
-    aggregate.breakdown.cachedInputTokens += breakdown.cachedInputTokens;
-    aggregate.breakdown.uncachedInputTokens += breakdown.uncachedInputTokens;
-    aggregate.breakdown.outputTokens += breakdown.outputTokens;
-    aggregate.breakdown.reasoningTokens += breakdown.reasoningTokens;
-    aggregate.breakdown.requestCount += breakdown.requestCount;
-    aggregate.breakdown.inputCostUsd += breakdown.inputCostUsd ?? 0;
-    aggregate.breakdown.cachedInputCostUsd += breakdown.cachedInputCostUsd ?? 0;
-    aggregate.breakdown.outputCostUsd += breakdown.outputCostUsd ?? 0;
-    aggregate.breakdown.reasoningCostUsd += breakdown.reasoningCostUsd ?? 0;
-    aggregate.breakdown.requestCostUsd += breakdown.requestCostUsd ?? 0;
-    aggregate.breakdown.cacheSavingsUsd += breakdown.cacheSavingsUsd ?? 0;
-  }
-  aggregate.breakdown.totalCostUsd = aggregate.costUsd;
-
-  const allActual = phaseResults.every((phase) => phase.costData?.source === 'actual');
-  const hasUnavailable = phaseResults.some((phase) => phase.costData?.source === 'unavailable');
-  return {
-    source: allActual ? 'actual' : 'estimated',
-    costUsd: aggregate.costUsd,
-    actualCostUsd: allActual ? aggregate.actualCostUsd : null,
-    estimatedCostUsd: allActual ? null : aggregate.costUsd,
-    breakdown: aggregate.breakdown,
-    pricingVersion: costedPhases.every((phase) => phase.costData?.pricingVersion === firstCost.pricingVersion)
-      ? firstCost.pricingVersion ?? null
-      : null,
-    ...(hasUnavailable ? { message: 'Some phase costs were unavailable; total reflects known phase costs only' } : {}),
-  };
 }
 
 // ---------------------------------------------------------------------------
@@ -931,6 +685,7 @@ export async function runAgent(
     : {
       runtime: runtimeId,
       provider: baseProvider?.type,
+      providerConfig: baseProvider,
       model: effectiveModel,
       phases: {},
     };
@@ -948,10 +703,12 @@ export async function runAgent(
   if (!resumedRun) {
     checkpointState.runtime = runtimeId;
     checkpointState.provider = effectiveProvider?.type;
+    checkpointState.providerConfig = effectiveProvider;
     checkpointState.model = effectiveModel;
   } else {
     checkpointState.runtime = checkpointState.runtime ?? runtimeId;
     checkpointState.provider = checkpointState.provider ?? effectiveProvider?.type;
+    checkpointState.providerConfig = checkpointState.providerConfig ?? effectiveProvider;
     checkpointState.model = checkpointState.model ?? effectiveModel;
   }
 
@@ -1043,18 +800,15 @@ export async function runAgent(
       currentCost: CostResolution = summarizePhaseCosts(currentPhaseResults),
     ) => {
       await Promise.resolve(updateRun(runId, {
-        runtime: runtimeId,
-        provider: effectiveProvider?.type ?? null,
-        model: effectiveModel,
-        session_ref: currentCheckpointState.sessionRef ?? null,
-        checkpoints: serializeCheckpointState(currentCheckpointState),
-        usage_data: buildUsageData(currentUsage, currentCost, currentPhaseResults),
-        cost_usd: currentCost.costUsd ?? null,
-        actual_cost_usd: currentCost.actualCostUsd,
-        estimated_cost_usd: currentCost.estimatedCostUsd,
-        cost_source: currentCost.source,
-        cost_data: serializeCostData(currentCost),
-        actions_taken: buildActionsTaken(runtimeId, effectiveProvider, effectiveModel, currentPhaseResults),
+        ...buildRunAccountingUpdate({
+          runtime: runtimeId,
+          provider: effectiveProvider,
+          model: effectiveModel,
+          checkpointState: currentCheckpointState,
+          usage: currentUsage,
+          costData: currentCost,
+          phaseResults: currentPhaseResults,
+        }),
       }));
     };
 
@@ -1125,27 +879,33 @@ export async function runAgent(
       checkpointState.sessionRef = result.sessionRef;
       checkpointState.sessionData = result.sessionData;
       await persistRuntimeState(checkpointState, undefined, usage, costData);
+
+      const postconditionError = validateTaskPostconditions({
+        runId,
+        taskName: config.taskName,
+      });
+      if (postconditionError) {
+        throw new Error(postconditionError);
+      }
     }
 
     clearTimeout(timeoutId);
     const completedAt = epochSeconds();
     updateRunStatus(runId, STATUS_COMPLETED, {
-      runtime: runtimeId,
-      provider: effectiveProvider?.type ?? null,
-      model: effectiveModel,
-      session_ref: runSessionRef ?? null,
       resumable: 0,
       resume_status: null,
       completed_at: completedAt,
       tokens_used: tokensUsed,
-      cost_usd: costData.costUsd ?? null,
-      actual_cost_usd: costData.actualCostUsd,
-      estimated_cost_usd: costData.estimatedCostUsd,
-      cost_source: costData.source,
-      cost_data: serializeCostData(costData),
-      checkpoints: serializeCheckpointState(checkpointState),
-      usage_data: buildUsageData(usage, costData, phaseResults),
-      actions_taken: buildActionsTaken(runtimeId, effectiveProvider, effectiveModel, phaseResults),
+      ...buildRunAccountingUpdate({
+        runtime: runtimeId,
+        provider: effectiveProvider,
+        model: effectiveModel,
+        checkpointState,
+        usage,
+        costData,
+        phaseResults,
+        sessionRef: runSessionRef,
+      }),
     });
 
     return {
@@ -1187,23 +947,20 @@ export async function runAgent(
         usage,
       });
       updateRunStatus(runId, STATUS_FAILED, {
-        runtime: runtimeId,
-        provider: effectiveProvider?.type ?? null,
-        model: effectiveModel,
-        session_ref: checkpointState.sessionRef ?? null,
         resumable: 1,
         resume_status: RESUME_STATUS_READY,
-        checkpoints: serializeCheckpointState(checkpointState),
-        usage_data: buildUsageData(usage, costData, phaseResults),
         completed_at: failedAt,
         tokens_used: usage.totalTokens ?? phaseResults?.reduce((sum, phase) => sum + phase.tokensUsed, 0) ?? undefined,
-        cost_usd: costData.costUsd ?? null,
-        actual_cost_usd: costData.actualCostUsd,
-        estimated_cost_usd: costData.estimatedCostUsd,
-        cost_source: costData.source,
-        cost_data: serializeCostData(costData),
         error: errorMessage,
-        actions_taken: buildActionsTaken(runtimeId, effectiveProvider, effectiveModel, phaseResults),
+        ...buildRunAccountingUpdate({
+          runtime: runtimeId,
+          provider: effectiveProvider,
+          model: effectiveModel,
+          checkpointState,
+          usage,
+          costData,
+          phaseResults,
+        }),
       });
     } catch (dbErr) {
       // DB failure in error path — log it but don't mask the original error

--- a/packages/myco/src/agent/loader.ts
+++ b/packages/myco/src/agent/loader.ts
@@ -138,6 +138,7 @@ export function taskFromParsed(parsed: AgentTask): AgentTask {
     isDefault: parsed.isDefault,
     ...(parsed.toolOverrides ? { toolOverrides: parsed.toolOverrides } : {}),
     ...(parsed.model ? { model: parsed.model } : {}),
+    ...(parsed.reasoningLevel ? { reasoningLevel: parsed.reasoningLevel } : {}),
     ...(parsed.maxTurns ? { maxTurns: parsed.maxTurns } : {}),
     ...(parsed.timeoutSeconds ? { timeoutSeconds: parsed.timeoutSeconds } : {}),
     ...(parsed.phases ? { phases: parsed.phases } : {}),
@@ -185,8 +186,10 @@ export function resolveEffectiveConfig(
   agentOverrides?: AgentRow | null,
   taskOverrides?: AgentTask,
 ): EffectiveConfig {
+  let runtime = taskOverrides?.execution?.runtime ?? taskOverrides?.execution?.provider?.runtime ?? 'claude-sdk';
   // Start with definition defaults
   let model = definition.model;
+  let reasoningLevel = taskOverrides?.reasoningLevel;
   let maxTurns = definition.maxTurns;
   let timeoutSeconds = definition.timeoutSeconds;
   let tools = [...definition.tools];
@@ -209,6 +212,7 @@ export function resolveEffectiveConfig(
 
   // Apply task overrides (model, turns, timeout, tool list)
   if (taskOverrides?.model) model = taskOverrides.model;
+  if (taskOverrides?.reasoningLevel) reasoningLevel = taskOverrides.reasoningLevel;
   if (taskOverrides?.maxTurns) maxTurns = taskOverrides.maxTurns;
   if (taskOverrides?.timeoutSeconds) timeoutSeconds = taskOverrides.timeoutSeconds;
   if (taskOverrides?.toolOverrides) {
@@ -219,6 +223,7 @@ export function resolveEffectiveConfig(
   // Precedence: execution.model > task.model > agent.model
   if (taskOverrides?.execution) {
     if (taskOverrides.execution.model) model = taskOverrides.execution.model;
+    if (taskOverrides.execution.reasoningLevel) reasoningLevel = taskOverrides.execution.reasoningLevel;
     if (taskOverrides.execution.maxTurns) maxTurns = taskOverrides.execution.maxTurns;
     if (taskOverrides.execution.timeoutSeconds) timeoutSeconds = taskOverrides.execution.timeoutSeconds;
   }
@@ -230,7 +235,9 @@ export function resolveEffectiveConfig(
 
   return {
     agentId,
+    runtime,
     model,
+    ...(reasoningLevel ? { reasoningLevel } : {}),
     maxTurns,
     timeoutSeconds,
     systemPromptPath: definition.systemPromptPath,

--- a/packages/myco/src/agent/provider-runtime.ts
+++ b/packages/myco/src/agent/provider-runtime.ts
@@ -1,0 +1,15 @@
+import type { ProviderType, RuntimeId } from './types.js';
+
+const PROVIDER_RUNTIME_BY_TYPE: Record<ProviderType, RuntimeId> = {
+  anthropic: 'claude-sdk',
+  ollama: 'claude-sdk',
+  lmstudio: 'claude-sdk',
+  openai: 'openai-agents',
+  openrouter: 'openai-agents',
+  'openai-compatible': 'openai-agents',
+};
+
+export function inferRuntimeFromProviderType(providerType: ProviderType | undefined): RuntimeId | undefined {
+  if (!providerType) return undefined;
+  return PROVIDER_RUNTIME_BY_TYPE[providerType];
+}

--- a/packages/myco/src/agent/provider.ts
+++ b/packages/myco/src/agent/provider.ts
@@ -10,6 +10,8 @@ const ENV_ANTHROPIC_API_KEY = 'ANTHROPIC_API_KEY';
 const ENV_OLLAMA_NUM_CTX = 'OLLAMA_NUM_CTX';
 const DEFAULT_OLLAMA_URL = 'http://localhost:11434';
 const DEFAULT_LMSTUDIO_URL = 'http://localhost:1234';
+const DEFAULT_OPENAI_URL = 'https://api.openai.com/v1';
+const DEFAULT_OPENROUTER_URL = 'https://openrouter.ai/api/v1';
 const OLLAMA_AUTH_TOKEN = 'ollama';
 const LMSTUDIO_AUTH_TOKEN = 'lmstudio';
 
@@ -25,7 +27,15 @@ const LMSTUDIO_AUTH_TOKEN = 'lmstudio';
  * avoiding unnecessary copies of the full process.env.
  */
 export function buildPhaseEnv(provider?: ProviderConfig): Record<string, string | undefined> | undefined {
-  if (!provider || provider.type === 'anthropic') return undefined;
+  if (
+    !provider ||
+    provider.type === 'anthropic' ||
+    provider.type === 'openai' ||
+    provider.type === 'openrouter' ||
+    provider.type === 'openai-compatible'
+  ) {
+    return undefined;
+  }
   return { ...process.env, ...getProviderEnvVars(provider) };
 }
 
@@ -48,6 +58,21 @@ export function getProviderEnvVars(provider: ProviderConfig): Record<string, str
         [ENV_ANTHROPIC_BASE_URL]: provider.baseUrl ?? DEFAULT_LMSTUDIO_URL,
         [ENV_ANTHROPIC_AUTH_TOKEN]: provider.apiKey ?? LMSTUDIO_AUTH_TOKEN,
         [ENV_ANTHROPIC_API_KEY]: '',
+      };
+    case 'openai':
+      return {
+        OPENAI_BASE_URL: provider.baseUrl ?? DEFAULT_OPENAI_URL,
+        ...(provider.apiKey ? { OPENAI_API_KEY: provider.apiKey } : {}),
+      };
+    case 'openrouter':
+      return {
+        OPENAI_BASE_URL: provider.baseUrl ?? DEFAULT_OPENROUTER_URL,
+        ...(provider.apiKey ? { OPENAI_API_KEY: provider.apiKey } : {}),
+      };
+    case 'openai-compatible':
+      return {
+        ...(provider.baseUrl ? { OPENAI_BASE_URL: provider.baseUrl } : {}),
+        ...(provider.apiKey ? { OPENAI_API_KEY: provider.apiKey } : {}),
       };
     default:
       return {};

--- a/packages/myco/src/agent/reasoning-levels.ts
+++ b/packages/myco/src/agent/reasoning-levels.ts
@@ -1,0 +1,15 @@
+import type { ProviderConfig, ReasoningLevel } from './types.js';
+
+export const DEFAULT_REASONING_LEVEL: ReasoningLevel = 'default';
+
+export function resolveReasoningModel(
+  reasoningLevel: ReasoningLevel | undefined,
+  provider: ProviderConfig | undefined,
+  fallbackModel: string,
+): string {
+  const level = reasoningLevel ?? DEFAULT_REASONING_LEVEL;
+  return provider?.reasoningMap?.[level]
+    ?? provider?.model
+    ?? fallbackModel;
+}
+

--- a/packages/myco/src/agent/run-accounting.ts
+++ b/packages/myco/src/agent/run-accounting.ts
@@ -1,0 +1,137 @@
+import type { RunUpdate } from '@myco/db/queries/runs.js';
+import type { CostResolution } from './cost/types.js';
+import {
+  buildActionsTaken,
+  buildUsageData,
+  serializeCheckpointState,
+  type RunCheckpointState,
+} from './executor-state.js';
+import type { PhaseResult, ProviderConfig, RuntimeId, RuntimeUsage } from './types.js';
+
+export function serializeCostData(cost: CostResolution | undefined): string | null {
+  return cost ? JSON.stringify(cost) : null;
+}
+
+export function summarizePhaseCosts(phaseResults: PhaseResult[]): CostResolution {
+  const costedPhases = phaseResults.filter((phase) => phase.costData && phase.costData.costUsd !== null);
+  if (costedPhases.length === 0) {
+    return {
+      source: 'unavailable',
+      costUsd: null,
+      actualCostUsd: null,
+      estimatedCostUsd: null,
+      breakdown: {
+        inputTokens: 0,
+        cachedInputTokens: 0,
+        uncachedInputTokens: 0,
+        outputTokens: 0,
+        reasoningTokens: 0,
+        requestCount: 0,
+      },
+      pricingVersion: null,
+      message: 'No phase cost data available',
+    };
+  }
+
+  const firstCost = costedPhases[0].costData!;
+  const aggregate = {
+    costUsd: 0,
+    actualCostUsd: 0,
+    estimatedCostUsd: 0,
+    breakdown: {
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      uncachedInputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      requestCount: 0,
+      inputCostUsd: 0,
+      cachedInputCostUsd: 0,
+      outputCostUsd: 0,
+      reasoningCostUsd: 0,
+      requestCostUsd: 0,
+      cacheSavingsUsd: 0,
+      totalCostUsd: 0,
+    },
+  };
+
+  for (const phase of costedPhases) {
+    const cost = phase.costData!;
+    const breakdown = cost.breakdown;
+    aggregate.costUsd += cost.costUsd ?? 0;
+    aggregate.actualCostUsd += cost.actualCostUsd ?? 0;
+    aggregate.estimatedCostUsd += cost.estimatedCostUsd ?? 0;
+    aggregate.breakdown.inputTokens += breakdown.inputTokens;
+    aggregate.breakdown.cachedInputTokens += breakdown.cachedInputTokens;
+    aggregate.breakdown.uncachedInputTokens += breakdown.uncachedInputTokens;
+    aggregate.breakdown.outputTokens += breakdown.outputTokens;
+    aggregate.breakdown.reasoningTokens += breakdown.reasoningTokens;
+    aggregate.breakdown.requestCount += breakdown.requestCount;
+    aggregate.breakdown.inputCostUsd += breakdown.inputCostUsd ?? 0;
+    aggregate.breakdown.cachedInputCostUsd += breakdown.cachedInputCostUsd ?? 0;
+    aggregate.breakdown.outputCostUsd += breakdown.outputCostUsd ?? 0;
+    aggregate.breakdown.reasoningCostUsd += breakdown.reasoningCostUsd ?? 0;
+    aggregate.breakdown.requestCostUsd += breakdown.requestCostUsd ?? 0;
+    aggregate.breakdown.cacheSavingsUsd += breakdown.cacheSavingsUsd ?? 0;
+  }
+  aggregate.breakdown.totalCostUsd = aggregate.costUsd;
+
+  const allActual = phaseResults.every((phase) => phase.costData?.source === 'actual');
+  const hasUnavailable = phaseResults.some((phase) => phase.costData?.source === 'unavailable');
+  return {
+    source: allActual ? 'actual' : 'estimated',
+    costUsd: aggregate.costUsd,
+    actualCostUsd: allActual ? aggregate.actualCostUsd : null,
+    estimatedCostUsd: allActual ? null : aggregate.costUsd,
+    breakdown: aggregate.breakdown,
+    pricingVersion: costedPhases.every((phase) => phase.costData?.pricingVersion === firstCost.pricingVersion)
+      ? firstCost.pricingVersion ?? null
+      : null,
+    ...(hasUnavailable ? { message: 'Some phase costs were unavailable; total reflects known phase costs only' } : {}),
+  };
+}
+
+interface RunAccountingUpdateInput {
+  runtime: RuntimeId;
+  provider?: ProviderConfig;
+  model: string;
+  checkpointState: RunCheckpointState;
+  usage: RuntimeUsage;
+  costData: CostResolution;
+  phaseResults?: PhaseResult[];
+  sessionRef?: string | null;
+}
+
+interface RunAccountingUpdateFields extends Pick<
+  RunUpdate,
+  | 'runtime'
+  | 'provider'
+  | 'model'
+  | 'session_ref'
+  | 'checkpoints'
+  | 'usage_data'
+  | 'cost_usd'
+  | 'actual_cost_usd'
+  | 'estimated_cost_usd'
+  | 'cost_source'
+  | 'cost_data'
+> {
+  actions_taken: string;
+}
+
+export function buildRunAccountingUpdate(input: RunAccountingUpdateInput): RunAccountingUpdateFields {
+  return {
+    runtime: input.runtime,
+    provider: input.provider?.type ?? null,
+    model: input.model,
+    session_ref: input.sessionRef ?? input.checkpointState.sessionRef ?? null,
+    checkpoints: serializeCheckpointState(input.checkpointState),
+    usage_data: buildUsageData(input.usage, input.costData, input.phaseResults),
+    cost_usd: input.costData.costUsd ?? null,
+    actual_cost_usd: input.costData.actualCostUsd,
+    estimated_cost_usd: input.costData.estimatedCostUsd,
+    cost_source: input.costData.source,
+    cost_data: serializeCostData(input.costData),
+    actions_taken: buildActionsTaken(input.runtime, input.provider, input.model, input.phaseResults),
+  };
+}

--- a/packages/myco/src/agent/runtime/claude.ts
+++ b/packages/myco/src/agent/runtime/claude.ts
@@ -1,0 +1,124 @@
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import type { RuntimeExecuteInput, RuntimeExecuteResult, AgentRuntime, RuntimeCapability } from './types.js';
+import { createScopedVaultToolServer, createVaultToolServer } from '@myco/agent/tools.js';
+import { buildPhaseEnv } from '@myco/agent/provider.js';
+
+const MCP_SERVER_NAME = 'myco-vault';
+const PERSIST_SESSION = true;
+
+interface ClaudeAssistantMessage {
+  type: 'assistant';
+  message?: { content?: Array<{ type: string; name?: string; input?: unknown }> };
+}
+
+interface ClaudeUserMessage {
+  type: 'user';
+  message?: { content?: Array<{ type: string; content?: unknown; is_error?: boolean }> };
+}
+
+interface ClaudeResultMessage {
+  type: 'result';
+  usage: {
+    input_tokens?: number;
+    output_tokens?: number;
+  };
+  total_cost_usd?: number;
+  num_turns?: number;
+  result?: string;
+}
+
+function buildToolServer(input: RuntimeExecuteInput) {
+  const { toolSurface } = input;
+  if (toolSurface.toolNames && toolSurface.toolNames.length === 0) {
+    return null;
+  }
+  if (toolSurface.toolNames) {
+    return createScopedVaultToolServer(
+      toolSurface.agentId,
+      toolSurface.runId,
+      toolSurface.toolNames,
+      {
+        turnOffset: toolSurface.turnOffset,
+        projectRoot: toolSurface.projectRoot,
+        vaultDir: toolSurface.vaultDir,
+        embeddingManager: toolSurface.embeddingManager,
+        readOnly: toolSurface.readOnly,
+      },
+    );
+  }
+
+  return createVaultToolServer(toolSurface.agentId, toolSurface.runId, {
+    embeddingManager: toolSurface.embeddingManager,
+    vaultDir: toolSurface.vaultDir,
+  });
+}
+
+export class ClaudeSdkRuntime implements AgentRuntime {
+  readonly id = 'claude-sdk' as const;
+
+  supports(capability: RuntimeCapability): boolean {
+    return capability === 'supportsSessionResume'
+      || capability === 'supportsMcp';
+  }
+
+  async execute(input: RuntimeExecuteInput): Promise<RuntimeExecuteResult> {
+    const toolServer = buildToolServer(input);
+    const baseEnv = buildPhaseEnv(input.provider);
+    const env = { ...(baseEnv ?? process.env), MYCO_AGENT_SESSION: '1' };
+
+    let finalText = '';
+    let turnsUsed = 0;
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let costUsd = 0;
+    let assistantMessages = 0;
+
+    for await (const message of query({
+      prompt: input.prompt,
+      options: {
+        model: input.model,
+        systemPrompt: input.systemPrompt,
+        ...(toolServer ? {
+          mcpServers: { [MCP_SERVER_NAME]: toolServer },
+          strictMcpConfig: true,
+        } : { tools: [] }),
+        ...(toolServer ? { tools: [] } : {}),
+        maxTurns: input.maxTurns,
+        permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
+        persistSession: PERSIST_SESSION,
+        env,
+        ...(input.sessionRef ? { sessionId: input.sessionRef } : {}),
+        ...(input.abortController ? { abortController: input.abortController } : {}),
+      },
+    })) {
+      if ((message as ClaudeAssistantMessage).type === 'assistant') {
+        assistantMessages += 1;
+      }
+      if ((message as ClaudeUserMessage).type === 'user') {
+        continue;
+      }
+      if ((message as ClaudeResultMessage).type === 'result') {
+        const resultMessage = message as ClaudeResultMessage;
+        finalText = typeof resultMessage.result === 'string' ? resultMessage.result : '';
+        turnsUsed = resultMessage.num_turns ?? assistantMessages;
+        inputTokens = resultMessage.usage.input_tokens ?? 0;
+        outputTokens = resultMessage.usage.output_tokens ?? 0;
+        costUsd = resultMessage.total_cost_usd ?? 0;
+      }
+    }
+
+    return {
+      finalText,
+      turnsUsed,
+      usage: {
+        requests: turnsUsed > 0 ? 1 : 0,
+        inputTokens,
+        outputTokens,
+        totalTokens: inputTokens + outputTokens,
+        costUsd,
+      },
+      sessionRef: input.sessionRef,
+    };
+  }
+}

--- a/packages/myco/src/agent/runtime/index.ts
+++ b/packages/myco/src/agent/runtime/index.ts
@@ -1,0 +1,16 @@
+import { createLocalVaultMcpServer } from './openai-local-mcp.js';
+import { ClaudeSdkRuntime } from './claude.js';
+import { OpenAIAgentsRuntime } from './openai.js';
+import type { AgentRuntime } from './types.js';
+import type { RuntimeId } from '@myco/agent/types.js';
+
+export * from './types.js';
+
+export function getAgentRuntime(runtimeId: RuntimeId): AgentRuntime {
+  if (runtimeId === 'openai-agents') {
+    return new OpenAIAgentsRuntime({
+      createOpenAIMcpServer: (toolSurface) => createLocalVaultMcpServer(toolSurface),
+    });
+  }
+  return new ClaudeSdkRuntime();
+}

--- a/packages/myco/src/agent/runtime/openai-local-mcp.ts
+++ b/packages/myco/src/agent/runtime/openai-local-mcp.ts
@@ -1,0 +1,96 @@
+import type { MCPServer } from '@openai/agents';
+import { z } from 'zod/v4';
+import { createVaultTools } from '@myco/agent/tools.js';
+import type { RuntimeToolSurface } from './types.js';
+
+interface LocalMcpTool {
+  name: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+  handler: (args: Record<string, unknown>, extra?: unknown) => Promise<{ content: Array<{ type: 'text'; text: string }> }>;
+}
+
+class LocalVaultMcpServer implements MCPServer {
+  readonly cacheToolsList = true;
+  private readonly tools: LocalMcpTool[];
+  readonly name = 'myco-vault';
+
+  constructor(toolSurface: RuntimeToolSurface) {
+    const nameSet = toolSurface.toolNames ? new Set(toolSurface.toolNames) : null;
+    const allTools = createVaultTools(toolSurface.agentId, toolSurface.runId, {
+      onlyNames: toolSurface.toolNames ? new Set(toolSurface.toolNames) : undefined,
+      turnOffset: toolSurface.turnOffset,
+      projectRoot: toolSurface.projectRoot,
+      vaultDir: toolSurface.vaultDir,
+      embeddingManager: toolSurface.embeddingManager,
+    }).filter((tool) => !toolSurface.readOnly || tool.annotations?.readOnlyHint === true);
+    this.tools = (nameSet
+      ? allTools.filter((tool) => nameSet.has(tool.name))
+      : allTools) as LocalMcpTool[];
+  }
+
+  async connect(): Promise<void> {}
+  async close(): Promise<void> {}
+  async invalidateToolsCache(): Promise<void> {}
+
+  async listTools() {
+    return this.tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description ?? '',
+      inputSchema: normalizeInputSchema(tool.inputSchema),
+    }));
+  }
+
+  async callTool(toolName: string, args: Record<string, unknown> | null, _meta?: Record<string, unknown> | null) {
+    const tool = this.tools.find((candidate) => candidate.name === toolName);
+    if (!tool) {
+      throw new Error(`Unknown MCP tool: ${toolName}`);
+    }
+    const result = await tool.handler(args ?? {});
+    return result.content;
+  }
+
+  async listResources() {
+    return { resources: [] };
+  }
+
+  async listResourceTemplates() {
+    return { resourceTemplates: [] };
+  }
+
+  async readResource() {
+    return { contents: [] };
+  }
+}
+
+function normalizeInputSchema(schema: Record<string, unknown> | undefined) {
+  if (!schema) {
+    return {
+      type: 'object' as const,
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    };
+  }
+
+  if (schema.type === 'object' && typeof schema.properties === 'object' && schema.properties !== null) {
+    return {
+      type: 'object' as const,
+      properties: schema.properties as Record<string, unknown>,
+      required: Array.isArray(schema.required) ? (schema.required as string[]) : [],
+      additionalProperties: schema.additionalProperties === true,
+    };
+  }
+
+  const jsonSchema = z.toJSONSchema(z.object(schema as Record<string, z.ZodTypeAny>));
+  return {
+    type: 'object' as const,
+    properties: (jsonSchema.properties as Record<string, unknown> | undefined) ?? {},
+    required: Array.isArray(jsonSchema.required) ? jsonSchema.required : [],
+    additionalProperties: jsonSchema.additionalProperties === true,
+  };
+}
+
+export function createLocalVaultMcpServer(toolSurface: RuntimeToolSurface): MCPServer {
+  return new LocalVaultMcpServer(toolSurface);
+}

--- a/packages/myco/src/agent/runtime/openai.ts
+++ b/packages/myco/src/agent/runtime/openai.ts
@@ -1,0 +1,152 @@
+import crypto from 'node:crypto';
+import OpenAI from 'openai';
+import {
+  Agent,
+  Runner,
+  OpenAIProvider,
+  type AgentInputItem,
+  type Session,
+} from '@openai/agents';
+import type { AgentRuntime, RuntimeCapability, RuntimeExecuteInput, RuntimeExecuteResult, RuntimeFactoryContext } from './types.js';
+import type { RuntimeUsage } from '@myco/agent/types.js';
+import { OPENAI_API_KEY_ENV } from '@myco/cli/providers/openai-embeddings.js';
+import { OPENROUTER_API_KEY_ENV } from '@myco/cli/providers/openrouter.js';
+
+class PersistedSession implements Session {
+  private items: AgentInputItem[];
+  private readonly persist: (items: AgentInputItem[]) => void;
+  private readonly sessionId: string;
+
+  constructor(sessionId: string, items: AgentInputItem[] | undefined, persist: (items: AgentInputItem[]) => void) {
+    this.sessionId = sessionId;
+    this.items = items ? [...items] : [];
+    this.persist = persist;
+  }
+
+  async getSessionId(): Promise<string> {
+    return this.sessionId;
+  }
+
+  async getItems(): Promise<AgentInputItem[]> {
+    return [...this.items];
+  }
+
+  async addItems(items: AgentInputItem[]): Promise<void> {
+    this.items.push(...items);
+    this.persist(this.items);
+  }
+
+  async popItem(): Promise<AgentInputItem | undefined> {
+    const item = this.items.pop();
+    this.persist(this.items);
+    return item;
+  }
+
+  async clearSession(): Promise<void> {
+    this.items = [];
+    this.persist(this.items);
+  }
+}
+
+function toOpenAIUsage(rawResponses: Array<{
+  usage: {
+    requests: number;
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+    inputTokensDetails: Array<Record<string, number>>;
+    outputTokensDetails: Array<Record<string, number>>;
+  };
+}>): RuntimeUsage {
+  const usage = rawResponses.reduce(
+    (acc, response) => {
+      acc.requests += response.usage.requests;
+      acc.inputTokens += response.usage.inputTokens;
+      acc.outputTokens += response.usage.outputTokens;
+      acc.totalTokens += response.usage.totalTokens;
+      acc.reasoningTokens += response.usage.outputTokensDetails.reduce((sum, detail) => sum + (detail.reasoning_tokens ?? 0), 0);
+      acc.cachedTokens += response.usage.inputTokensDetails.reduce((sum, detail) => sum + (detail.cached_tokens ?? 0), 0);
+      return acc;
+    },
+    { requests: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0, reasoningTokens: 0, cachedTokens: 0 },
+  );
+
+  return usage;
+}
+
+function createProvider(input: RuntimeExecuteInput): OpenAIProvider {
+  const baseURL = input.provider?.type === 'openrouter'
+    ? (input.provider.baseUrl ?? 'https://openrouter.ai/api/v1')
+    : input.provider?.type === 'openai'
+      ? (input.provider.baseUrl ?? 'https://api.openai.com/v1')
+      : input.provider?.baseUrl;
+  const apiKey = input.provider?.apiKey
+    ?? (input.provider?.type === 'openrouter' ? process.env[OPENROUTER_API_KEY_ENV] : undefined)
+    ?? (input.provider?.type === 'openai' ? process.env[OPENAI_API_KEY_ENV] : undefined)
+    ?? process.env.OPENAI_API_KEY;
+  const client = new OpenAI({
+    apiKey,
+    ...(baseURL ? { baseURL } : {}),
+  });
+
+  return new OpenAIProvider({
+    openAIClient: client,
+    useResponses: true,
+  });
+}
+
+export class OpenAIAgentsRuntime implements AgentRuntime {
+  readonly id = 'openai-agents' as const;
+
+  constructor(private readonly context: RuntimeFactoryContext) {}
+
+  supports(capability: RuntimeCapability): boolean {
+    return capability === 'supportsSessionResume'
+      || capability === 'supportsMcp'
+      || capability === 'supportsReasoningUsageBreakdown';
+  }
+
+  async execute(input: RuntimeExecuteInput): Promise<RuntimeExecuteResult> {
+    let persistedItems = Array.isArray(input.sessionData)
+      ? (input.sessionData as AgentInputItem[])
+      : [];
+    const sessionRef = input.sessionRef ?? crypto.randomUUID();
+    const session = new PersistedSession(sessionRef, persistedItems, (items) => {
+      persistedItems = [...items];
+    });
+    const mcpServer = this.context.createOpenAIMcpServer(input.toolSurface);
+    await mcpServer.connect();
+
+    try {
+      const agent = new Agent({
+        name: 'myco-agent',
+        instructions: input.systemPrompt ?? 'You are the Myco agent runtime.',
+        model: input.model,
+        mcpServers: [mcpServer],
+      });
+      const runner = new Runner({
+        modelProvider: createProvider(input),
+      });
+      const result = await runner.run(agent, input.prompt, {
+        maxTurns: input.maxTurns,
+        session,
+        ...(input.abortController ? { signal: input.abortController.signal } : {}),
+      });
+
+      return {
+        finalText: typeof result.finalOutput === 'string'
+          ? result.finalOutput
+          : JSON.stringify(result.finalOutput ?? ''),
+        turnsUsed: result.rawResponses.length,
+        usage: toOpenAIUsage(result.rawResponses),
+        sessionRef,
+        sessionData: persistedItems,
+        rawRuntimeMetadata: {
+          lastResponseId: result.lastResponseId,
+        },
+      };
+    } finally {
+      await mcpServer.close();
+    }
+  }
+}

--- a/packages/myco/src/agent/runtime/openai.ts
+++ b/packages/myco/src/agent/runtime/openai.ts
@@ -8,9 +8,21 @@ import {
   type Session,
 } from '@openai/agents';
 import type { AgentRuntime, RuntimeCapability, RuntimeExecuteInput, RuntimeExecuteResult, RuntimeFactoryContext } from './types.js';
-import type { RuntimeUsage } from '@myco/agent/types.js';
+import type { ProviderConfig, RuntimeUsage } from '@myco/agent/types.js';
+import { ensureOllamaContextVariant, DEFAULT_OLLAMA_CONTEXT_LENGTH } from '@myco/agent/ollama-context.js';
 import { OPENAI_API_KEY_ENV } from '@myco/cli/providers/openai-embeddings.js';
 import { OPENROUTER_API_KEY_ENV } from '@myco/cli/providers/openrouter.js';
+import { LmStudioBackend } from '@myco/intelligence/lm-studio.js';
+import {
+  getLocalOpenAIBackendDefaultBaseUrl,
+  inferLocalOpenAIBackendKind,
+  type LocalOpenAIBackendKind,
+} from '@myco/intelligence/local-openai-backends.js';
+
+const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
+const DEFAULT_OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+const OPENAI_COMPATIBLE_PLACEHOLDER_API_KEY = 'myco-local-openai-compatible';
+const OPENAI_API_PATH = '/v1';
 
 class PersistedSession implements Session {
   private items: AgentInputItem[];
@@ -79,16 +91,148 @@ function toOpenAIUsage(rawResponses: Array<{
   };
 }
 
+type OpenAIClientConfig = {
+  apiKey?: string;
+  baseURL?: string;
+};
+
+const PROVIDER_CLIENT_CONFIG_RESOLVERS: Record<ProviderConfig['type'], (provider?: ProviderConfig) => OpenAIClientConfig> = {
+  anthropic: () => ({
+    apiKey: process.env.OPENAI_API_KEY ?? OPENAI_COMPATIBLE_PLACEHOLDER_API_KEY,
+  }),
+  ollama: (provider) => ({
+    apiKey: provider?.apiKey ?? OPENAI_COMPATIBLE_PLACEHOLDER_API_KEY,
+    baseURL: provider?.baseUrl ?? toOpenAIBaseUrl(getLocalOpenAIBackendDefaultBaseUrl('ollama')),
+  }),
+  lmstudio: (provider) => ({
+    apiKey: provider?.apiKey ?? OPENAI_COMPATIBLE_PLACEHOLDER_API_KEY,
+    baseURL: provider?.baseUrl ?? toOpenAIBaseUrl(getLocalOpenAIBackendDefaultBaseUrl('lmstudio')),
+  }),
+  openai: (provider) => ({
+    apiKey: provider?.apiKey ?? process.env[OPENAI_API_KEY_ENV] ?? process.env.OPENAI_API_KEY,
+    baseURL: provider?.baseUrl ?? DEFAULT_OPENAI_BASE_URL,
+  }),
+  openrouter: (provider) => ({
+    apiKey: provider?.apiKey ?? process.env[OPENROUTER_API_KEY_ENV],
+    baseURL: provider?.baseUrl ?? DEFAULT_OPENROUTER_BASE_URL,
+  }),
+  'openai-compatible': (provider) => ({
+    apiKey: provider?.apiKey ?? OPENAI_COMPATIBLE_PLACEHOLDER_API_KEY,
+    ...(provider?.baseUrl ? { baseURL: provider.baseUrl } : {}),
+  }),
+};
+
+export function resolveOpenAIClientConfig(provider?: ProviderConfig): OpenAIClientConfig {
+  const normalizedProvider = normalizeProviderForOpenAIClient(provider);
+  const type = normalizedProvider?.type ?? 'openai';
+  return PROVIDER_CLIENT_CONFIG_RESOLVERS[type](normalizedProvider);
+}
+
+export function shouldUseResponsesApi(provider?: ProviderConfig): boolean {
+  return provider?.type !== 'openai-compatible'
+    && provider?.type !== 'ollama'
+    && provider?.type !== 'lmstudio';
+}
+
+function tryParseUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+function toOpenAIBaseUrl(baseUrl: string): string {
+  const url = tryParseUrl(baseUrl);
+  if (!url) return baseUrl;
+  if (url.pathname === OPENAI_API_PATH || url.pathname.startsWith(`${OPENAI_API_PATH}/`)) {
+    return url.toString().replace(/\/$/, '');
+  }
+  url.pathname = `${url.pathname.replace(/\/$/, '')}${OPENAI_API_PATH}`;
+  return url.toString().replace(/\/$/, '');
+}
+
+function toLocalControlBaseUrl(baseUrl: string): string {
+  const url = tryParseUrl(baseUrl);
+  if (!url) return baseUrl;
+  if (url.pathname === OPENAI_API_PATH) {
+    url.pathname = '/';
+  } else if (url.pathname.startsWith(`${OPENAI_API_PATH}/`)) {
+    url.pathname = url.pathname.slice(OPENAI_API_PATH.length) || '/';
+  }
+  return url.toString().replace(/\/$/, '');
+}
+
+function resolveLocalContextLength(provider?: ProviderConfig): number {
+  return provider?.contextLength ?? DEFAULT_OLLAMA_CONTEXT_LENGTH;
+}
+
+function normalizeProviderForOpenAIClient(provider?: ProviderConfig): ProviderConfig | undefined {
+  if (!provider) return provider;
+  const localBackend = inferLocalOpenAIBackendKind({
+    type: provider.type,
+    localBackend: provider.localBackend,
+    baseUrl: provider.baseUrl,
+  });
+  if (!localBackend) {
+    return provider;
+  }
+  const baseUrl = provider.baseUrl ?? getLocalOpenAIBackendDefaultBaseUrl(localBackend);
+  return {
+    ...provider,
+    baseUrl: toOpenAIBaseUrl(baseUrl),
+  };
+}
+
+async function prepareLocalProviderExecution(
+  provider: ProviderConfig | undefined,
+  model: string,
+): Promise<{ provider: ProviderConfig | undefined; model: string }> {
+  const normalizedProvider = normalizeProviderForOpenAIClient(provider);
+  if (!normalizedProvider) {
+    return { provider: normalizedProvider, model };
+  }
+  const localBackend = inferLocalOpenAIBackendKind({
+    type: normalizedProvider.type,
+    localBackend: normalizedProvider.localBackend,
+    baseUrl: normalizedProvider.baseUrl,
+  });
+  if (!localBackend) {
+    return { provider: normalizedProvider, model };
+  }
+
+  const contextLength = resolveLocalContextLength(normalizedProvider);
+  if (localBackend === 'ollama') {
+    const variantModel = await ensureOllamaContextVariant(model, contextLength);
+    return {
+      provider: {
+        ...normalizedProvider,
+        contextLength,
+      },
+      model: variantModel,
+    };
+  }
+
+  const controlBaseUrl = toLocalControlBaseUrl(
+    normalizedProvider.baseUrl ?? getLocalOpenAIBackendDefaultBaseUrl('lmstudio'),
+  );
+  const backend = new LmStudioBackend({
+    base_url: controlBaseUrl,
+    model,
+    context_window: contextLength,
+  });
+  await backend.ensureLoaded(contextLength, false);
+  return {
+    provider: {
+      ...normalizedProvider,
+      contextLength,
+    },
+    model: backend.getLoadedInstanceId() ?? model,
+  };
+}
+
 function createProvider(input: RuntimeExecuteInput): OpenAIProvider {
-  const baseURL = input.provider?.type === 'openrouter'
-    ? (input.provider.baseUrl ?? 'https://openrouter.ai/api/v1')
-    : input.provider?.type === 'openai'
-      ? (input.provider.baseUrl ?? 'https://api.openai.com/v1')
-      : input.provider?.baseUrl;
-  const apiKey = input.provider?.apiKey
-    ?? (input.provider?.type === 'openrouter' ? process.env[OPENROUTER_API_KEY_ENV] : undefined)
-    ?? (input.provider?.type === 'openai' ? process.env[OPENAI_API_KEY_ENV] : undefined)
-    ?? process.env.OPENAI_API_KEY;
+  const { apiKey, baseURL } = resolveOpenAIClientConfig(input.provider);
   const client = new OpenAI({
     apiKey,
     ...(baseURL ? { baseURL } : {}),
@@ -96,7 +240,7 @@ function createProvider(input: RuntimeExecuteInput): OpenAIProvider {
 
   return new OpenAIProvider({
     openAIClient: client,
-    useResponses: true,
+    useResponses: shouldUseResponsesApi(input.provider),
   });
 }
 
@@ -112,6 +256,7 @@ export class OpenAIAgentsRuntime implements AgentRuntime {
   }
 
   async execute(input: RuntimeExecuteInput): Promise<RuntimeExecuteResult> {
+    const preparedExecution = await prepareLocalProviderExecution(input.provider, input.model);
     let persistedItems = Array.isArray(input.sessionData)
       ? (input.sessionData as AgentInputItem[])
       : [];
@@ -126,11 +271,14 @@ export class OpenAIAgentsRuntime implements AgentRuntime {
       const agent = new Agent({
         name: 'myco-agent',
         instructions: input.systemPrompt ?? 'You are the Myco agent runtime.',
-        model: input.model,
+        model: preparedExecution.model,
         mcpServers: [mcpServer],
       });
       const runner = new Runner({
-        modelProvider: createProvider(input),
+        modelProvider: createProvider({
+          ...input,
+          provider: preparedExecution.provider,
+        }),
       });
       const result = await runner.run(agent, input.prompt, {
         maxTurns: input.maxTurns,

--- a/packages/myco/src/agent/runtime/openai.ts
+++ b/packages/myco/src/agent/runtime/openai.ts
@@ -71,7 +71,12 @@ function toOpenAIUsage(rawResponses: Array<{
     { requests: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0, reasoningTokens: 0, cachedTokens: 0 },
   );
 
-  return usage;
+  return {
+    ...usage,
+    requestUsageEntries: rawResponses.map((response) => ({
+      ...response.usage,
+    })),
+  };
 }
 
 function createProvider(input: RuntimeExecuteInput): OpenAIProvider {
@@ -132,13 +137,17 @@ export class OpenAIAgentsRuntime implements AgentRuntime {
         session,
         ...(input.abortController ? { signal: input.abortController.signal } : {}),
       });
+      const usage = toOpenAIUsage(result.rawResponses);
+      usage.providerData = {
+        lastResponseId: result.lastResponseId,
+      };
 
       return {
         finalText: typeof result.finalOutput === 'string'
           ? result.finalOutput
           : JSON.stringify(result.finalOutput ?? ''),
         turnsUsed: result.rawResponses.length,
-        usage: toOpenAIUsage(result.rawResponses),
+        usage,
         sessionRef,
         sessionData: persistedItems,
         rawRuntimeMetadata: {

--- a/packages/myco/src/agent/runtime/types.ts
+++ b/packages/myco/src/agent/runtime/types.ts
@@ -1,0 +1,53 @@
+import type { MCPServer } from '@openai/agents';
+import type { EmbeddingManager } from '@myco/daemon/embedding/manager.js';
+import type { ProviderConfig, RuntimeId, RuntimeUsage } from '@myco/agent/types.js';
+
+export type RuntimeCapability =
+  | 'supportsSessionResume'
+  | 'supportsMcp'
+  | 'supportsNativeTools'
+  | 'supportsHostedTools'
+  | 'supportsHandoffs'
+  | 'supportsReasoningUsageBreakdown';
+
+export interface RuntimeToolSurface {
+  agentId: string;
+  runId: string;
+  toolNames?: string[];
+  turnOffset?: number;
+  projectRoot?: string;
+  vaultDir?: string;
+  readOnly?: boolean;
+  embeddingManager?: EmbeddingManager;
+}
+
+export interface RuntimeExecuteInput {
+  prompt: string;
+  model: string;
+  maxTurns?: number;
+  systemPrompt?: string;
+  provider?: ProviderConfig;
+  toolSurface: RuntimeToolSurface;
+  sessionRef?: string;
+  sessionData?: unknown;
+  abortController?: AbortController;
+}
+
+export interface RuntimeExecuteResult {
+  finalText: string;
+  turnsUsed: number;
+  usage: RuntimeUsage;
+  sessionRef?: string;
+  sessionData?: unknown;
+  rawRuntimeMetadata?: Record<string, unknown>;
+}
+
+export interface RuntimeFactoryContext {
+  createOpenAIMcpServer: (toolSurface: RuntimeToolSurface) => MCPServer;
+}
+
+export interface AgentRuntime {
+  readonly id: RuntimeId;
+  execute(input: RuntimeExecuteInput): Promise<RuntimeExecuteResult>;
+  supports(capability: RuntimeCapability): boolean;
+}

--- a/packages/myco/src/agent/schemas.ts
+++ b/packages/myco/src/agent/schemas.ts
@@ -26,6 +26,7 @@ export const ReasoningLevelSchema = z.enum(['low', 'default', 'high']);
 export const ProviderConfigSchema = z.object({
   runtime: RuntimeIdSchema.optional(),
   type: z.enum(['anthropic', 'ollama', 'lmstudio', 'openai', 'openrouter', 'openai-compatible']),
+  localBackend: z.enum(['ollama', 'lmstudio']).optional(),
   baseUrl: z.string().optional(),
   apiKey: z.string().optional(),
   model: z.string().optional(),

--- a/packages/myco/src/agent/schemas.ts
+++ b/packages/myco/src/agent/schemas.ts
@@ -15,21 +15,33 @@ import { SCHEDULABLE_POWER_STATES } from '@myco/constants.js';
 /** Current schema version for task config structures. */
 export const CURRENT_TASK_SCHEMA_VERSION = 1;
 
+export const RuntimeIdSchema = z.enum(['claude-sdk', 'openai-agents']);
+export const ReasoningLevelSchema = z.enum(['low', 'default', 'high']);
+
 // ---------------------------------------------------------------------------
 // Shared sub-schemas
 // ---------------------------------------------------------------------------
 
 /** Schema for API provider configuration. */
 export const ProviderConfigSchema = z.object({
-  type: z.enum(['anthropic', 'ollama', 'lmstudio']),
+  runtime: RuntimeIdSchema.optional(),
+  type: z.enum(['anthropic', 'ollama', 'lmstudio', 'openai', 'openrouter', 'openai-compatible']),
   baseUrl: z.string().optional(),
   apiKey: z.string().optional(),
   model: z.string().optional(),
+  reasoningMap: z.object({
+    low: z.string().optional(),
+    default: z.string().optional(),
+    high: z.string().optional(),
+  }).optional(),
+  contextLength: z.number().optional(),
 });
 
 /** Schema for execution configuration overrides. */
 export const ExecutionConfigSchema = z.object({
+  runtime: RuntimeIdSchema.optional(),
   model: z.string().optional(),
+  reasoningLevel: ReasoningLevelSchema.optional(),
   maxTurns: z.number().optional(),
   timeoutSeconds: z.number().optional(),
   provider: ProviderConfigSchema.optional(),
@@ -68,6 +80,7 @@ export const AgentDefinitionSchema = z.object({
 export const OrchestratorConfigSchema = z.object({
   enabled: z.boolean(),
   model: z.string().optional(),
+  reasoningLevel: ReasoningLevelSchema.optional(),
   maxTurns: z.number().optional(),
 });
 
@@ -98,6 +111,7 @@ export const PhaseDefinitionSchema = z.object({
   tools: z.array(z.string()),
   maxTurns: z.number(),
   model: z.string().optional(),
+  reasoningLevel: ReasoningLevelSchema.optional(),
   required: z.boolean(),
   dependsOn: z.array(z.string()).optional(),
   provider: ProviderConfigSchema.optional(),
@@ -115,6 +129,7 @@ export const AgentTaskSchema = z.object({
   isDefault: z.boolean(),
   toolOverrides: z.array(z.string()).optional(),
   model: z.string().optional(),
+  reasoningLevel: ReasoningLevelSchema.optional(),
   maxTurns: z.number().optional(),
   timeoutSeconds: z.number().optional(),
   phases: z.array(PhaseDefinitionSchema).optional(),

--- a/packages/myco/src/agent/task-postconditions.ts
+++ b/packages/myco/src/agent/task-postconditions.ts
@@ -1,0 +1,46 @@
+import { listReports } from '@myco/db/queries/reports.js';
+import { countToolCallsByRun } from '@myco/db/queries/turns.js';
+
+interface PostconditionInput {
+  runId: string;
+  taskName?: string;
+}
+
+type PostconditionValidator = (input: PostconditionInput) => string | null;
+
+function validateTitleSummaryRun({ runId }: PostconditionInput): string | null {
+  const reports = listReports(runId);
+  if (reports.length === 0) {
+    return 'title-summary completed without calling vault_report';
+  }
+
+  if (reports.some((report) => report.action === 'skip')) {
+    return null;
+  }
+
+  const toolCounts = countToolCallsByRun(runId, ['vault_update_session']);
+  if ((toolCounts.vault_update_session ?? 0) > 0) {
+    return null;
+  }
+
+  return 'title-summary completed without vault_update_session or an explicit skip report';
+}
+
+const TASK_POSTCONDITION_RULES: Array<{
+  taskNames: string[];
+  validate: PostconditionValidator;
+}> = [
+  {
+    taskNames: ['title-summary'],
+    validate: validateTitleSummaryRun,
+  },
+];
+
+export function validateTaskPostconditions(input: PostconditionInput): string | null {
+  for (const rule of TASK_POSTCONDITION_RULES) {
+    if (input.taskName && rule.taskNames.includes(input.taskName)) {
+      return rule.validate(input);
+    }
+  }
+  return null;
+}

--- a/packages/myco/src/agent/tools.ts
+++ b/packages/myco/src/agent/tools.ts
@@ -1,10 +1,11 @@
 /**
  * Vault MCP tool server for the agent.
  *
- * Creates 21 tools that expose SQLite query helpers to the agent
+ * Creates vault tools that expose SQLite query helpers to the agent
  * via the Claude Agent SDK. Tools are grouped into:
- * - Read tools (8): vault_unprocessed, vault_spores, vault_sessions, vault_search_fts,
- *                    vault_search_semantic, vault_state, vault_entities, vault_edges
+ * - Read tools (9): vault_unprocessed, vault_batches, vault_spores, vault_sessions,
+ *                   vault_search_fts, vault_search_semantic, vault_state,
+ *                   vault_entities, vault_edges
  * - Write tools (9): vault_create_spore, vault_create_entity, vault_create_edge,
  *                     vault_resolve_spore, vault_update_session, vault_set_state,
  *                     vault_read_digest, vault_write_digest, vault_mark_processed
@@ -53,7 +54,7 @@ export interface VaultToolOptions {
 // ---------------------------------------------------------------------------
 
 const READ_TOOL_NAMES = new Set([
-  'vault_unprocessed', 'vault_spores', 'vault_sessions', 'vault_search_fts',
+  'vault_unprocessed', 'vault_batches', 'vault_spores', 'vault_sessions', 'vault_search_fts',
   'vault_search_semantic', 'vault_state', 'vault_entities', 'vault_edges',
 ]);
 

--- a/packages/myco/src/agent/tools/read-tools.ts
+++ b/packages/myco/src/agent/tools/read-tools.ts
@@ -1,14 +1,15 @@
 /**
  * Read-only vault tools.
  *
- * 8 tools: vault_unprocessed, vault_spores, vault_sessions, vault_search_fts,
- * vault_search_semantic, vault_state, vault_entities, vault_edges
+ * 9 tools: vault_unprocessed, vault_batches, vault_spores, vault_sessions,
+ * vault_search_fts, vault_search_semantic, vault_state, vault_entities,
+ * vault_edges
  */
 
 import { z } from 'zod/v4';
 import { tool } from '@anthropic-ai/claude-agent-sdk';
 import { SEARCH_SIMILARITY_THRESHOLD, TEAM_SOURCE_PREFIX } from '@myco/constants.js';
-import { getUnprocessedBatches } from '@myco/db/queries/batches.js';
+import { getUnprocessedBatches, listBatchesBySession } from '@myco/db/queries/batches.js';
 import { getSpore, listSpores } from '@myco/db/queries/spores.js';
 import { listSessions, getActiveSessionIds } from '@myco/db/queries/sessions.js';
 import { getStatesForAgent } from '@myco/db/queries/agent-state.js';
@@ -65,6 +66,24 @@ export function createReadTools(deps: VaultToolDeps) {
     { annotations: { readOnlyHint: true } },
   );
 
+  const vaultBatches = tool(
+    'vault_batches',
+    'List prompt batches for one session, ordered by prompt_number ASC. Use this when you already know the session ID and need the full session arc rather than only unprocessed batches.',
+    {
+      session_id: z.string().describe('Session ID whose batches should be returned'),
+      limit: z.number().optional().describe('Maximum number of batches to return'),
+      offset: z.number().optional().describe('Number of batches to skip from the start'),
+    },
+    async (args) => {
+      const batches = listBatchesBySession(args.session_id, {
+        limit: args.limit,
+        offset: args.offset,
+      });
+      return textResult(batches);
+    },
+    { annotations: { readOnlyHint: true } },
+  );
+
   const vaultSpores = tool(
     'vault_spores',
     'List spores with optional filters (agent, observation type, status, session), or fetch exact spores by id for full-content inspection after a semantic shortlist. Spores from in-flight sessions are excluded by default; passing a specific session_id or ids bypasses this filter. Pass include_active=true to bulk-read live work.',
@@ -99,14 +118,16 @@ export function createReadTools(deps: VaultToolDeps) {
 
   const vaultSessions = tool(
     'vault_sessions',
-    'List sessions with optional status filter, ordered by created_at DESC. In-flight sessions are excluded by default; pass include_active=true or an explicit status to see them.',
+    'List sessions with optional status filter, or fetch one exact session by id. In-flight sessions are excluded by default; pass include_active=true or an explicit status to see them.',
     {
+      id: z.string().optional().describe('Exact session ID to fetch'),
       limit: z.number().optional().describe('Maximum number of sessions to return'),
       status: z.string().optional().describe('Filter by status (active, completed)'),
       include_active: z.boolean().optional().describe('Include sessions still in active status (default: false)'),
     },
     async (args) => {
       const sessions = listSessions({
+        id: args.id,
         limit: args.limit ?? DEFAULT_SESSIONS_LIMIT,
         status: args.status,
         includeActive: args.include_active === true,
@@ -272,6 +293,7 @@ export function createReadTools(deps: VaultToolDeps) {
 
   return [
     vaultUnprocessed,
+    vaultBatches,
     vaultSpores,
     vaultSessions,
     vaultSearchFts,

--- a/packages/myco/src/agent/types.ts
+++ b/packages/myco/src/agent/types.ts
@@ -6,6 +6,8 @@
  * database overrides.
  */
 
+import type { CostResolution, CostSource } from '@myco/agent/cost/types.js';
+
 // ---------------------------------------------------------------------------
 // YAML-sourced definitions (read from src/agent/definitions/)
 // ---------------------------------------------------------------------------
@@ -55,6 +57,8 @@ export interface PhaseResult {
   turnsUsed: number;
   tokensUsed: number;
   costUsd: number;
+  costSource?: CostSource;
+  costData?: CostResolution;
   summary: string; // last assistant message or error
   usage?: RuntimeUsage;
   sessionRef?: string;
@@ -240,7 +244,9 @@ export interface AgentRunResult {
   status: 'completed' | 'failed' | 'skipped';
   reason?: string;
   tokensUsed?: number;
-  costUsd?: number;
+  costUsd?: number | null;
+  costSource?: CostSource;
+  costData?: CostResolution;
   error?: string;
   phases?: PhaseResult[];
   runtime?: RuntimeId;

--- a/packages/myco/src/agent/types.ts
+++ b/packages/myco/src/agent/types.ts
@@ -36,6 +36,7 @@ export interface PhaseDefinition {
   tools: string[];
   maxTurns: number;
   model?: string;
+  reasoningLevel?: ReasoningLevel;
   required: boolean;
   /** Phase names this phase depends on. Phases with no dependencies are roots (wave 0). */
   dependsOn?: string[];
@@ -55,6 +56,8 @@ export interface PhaseResult {
   tokensUsed: number;
   costUsd: number;
   summary: string; // last assistant message or error
+  usage?: RuntimeUsage;
+  sessionRef?: string;
 }
 
 /** Context query that runs before task execution to gather vault state. */
@@ -66,19 +69,47 @@ export interface ContextQuery {
   required: boolean;
 }
 
+export type RuntimeId = 'claude-sdk' | 'openai-agents';
+export type ReasoningLevel = 'low' | 'default' | 'high';
+
+export type ProviderType =
+  | 'anthropic'
+  | 'ollama'
+  | 'lmstudio'
+  | 'openai'
+  | 'openrouter'
+  | 'openai-compatible';
+
 /** API provider configuration for task execution. */
 export interface ProviderConfig {
-  type: 'anthropic' | 'ollama' | 'lmstudio';
+  runtime?: RuntimeId;
+  type: ProviderType;
   baseUrl?: string;
   apiKey?: string;
   model?: string;
+  reasoningMap?: Partial<Record<ReasoningLevel, string>>;
   /** Context window size for local models (Ollama num_ctx, LM Studio context_length). */
   contextLength?: number;
 }
 
+export interface RuntimeUsage {
+  requests?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  reasoningTokens?: number;
+  cachedTokens?: number;
+  durationMs?: number;
+  costUsd?: number | null;
+  requestUsageEntries?: Array<Record<string, unknown>>;
+  providerData?: Record<string, unknown>;
+}
+
 /** Execution configuration overrides for a task. */
 export interface ExecutionConfig {
+  runtime?: RuntimeId;
   model?: string;
+  reasoningLevel?: ReasoningLevel;
   maxTurns?: number;
   timeoutSeconds?: number;
   provider?: ProviderConfig;
@@ -114,6 +145,7 @@ export interface OrchestratorPlan {
 export interface OrchestratorConfig {
   enabled: boolean;
   model?: string;
+  reasoningLevel?: ReasoningLevel;
   maxTurns?: number;
 }
 
@@ -135,6 +167,7 @@ export interface AgentTask {
   isDefault: boolean;
   toolOverrides?: string[]; // add/remove tools
   model?: string; // override model for this task
+  reasoningLevel?: ReasoningLevel; // preferred reasoning tier for this task
   maxTurns?: number; // override max turns for this task
   timeoutSeconds?: number; // override timeout for this task
   phases?: PhaseDefinition[]; // phased execution pipeline (opt-in)
@@ -160,7 +193,9 @@ export interface AgentTask {
  */
 export interface EffectiveConfig {
   agentId: string;
+  runtime: RuntimeId;
   model: string;
+  reasoningLevel?: ReasoningLevel;
   maxTurns: number;
   timeoutSeconds: number;
   systemPromptPath: string;
@@ -196,6 +231,7 @@ export interface RunOptions {
   runContext?: {
     candidate_id?: string;
   };
+  resumeMode?: 'manual' | 'scheduled';
 }
 
 /** Result of a single agent run. */
@@ -207,4 +243,7 @@ export interface AgentRunResult {
   costUsd?: number;
   error?: string;
   phases?: PhaseResult[];
+  runtime?: RuntimeId;
+  provider?: ProviderType;
+  model?: string;
 }

--- a/packages/myco/src/agent/types.ts
+++ b/packages/myco/src/agent/types.ts
@@ -88,6 +88,7 @@ export type ProviderType =
 export interface ProviderConfig {
   runtime?: RuntimeId;
   type: ProviderType;
+  localBackend?: 'ollama' | 'lmstudio';
   baseUrl?: string;
   apiKey?: string;
   model?: string;

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -33,6 +33,7 @@ const CaptureSchema = z.object({
 const ProviderOverrideSchema = z.object({
   runtime: RuntimeIdSchema.optional(),
   type: z.enum(['anthropic', 'ollama', 'lmstudio', 'openai', 'openrouter', 'openai-compatible']),
+  local_backend: z.enum(['ollama', 'lmstudio']).optional(),
   base_url: z.string().optional(),
   model: z.string().optional(),
   reasoning_map: z.object({

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { SCHEDULABLE_POWER_STATES } from '@myco/constants.js';
+import { ReasoningLevelSchema, RuntimeIdSchema } from '@myco/agent/schemas.js';
 
 const EmbeddingProviderSchema = z.object({
   provider: z.enum(['ollama', 'openai-compatible', 'openrouter', 'openai']).default('ollama'),
@@ -30,9 +31,15 @@ const CaptureSchema = z.object({
 
 /** Provider config shape used in both task-level and phase-level overrides. */
 const ProviderOverrideSchema = z.object({
-  type: z.enum(['anthropic', 'ollama', 'lmstudio']),
+  runtime: RuntimeIdSchema.optional(),
+  type: z.enum(['anthropic', 'ollama', 'lmstudio', 'openai', 'openrouter', 'openai-compatible']),
   base_url: z.string().optional(),
   model: z.string().optional(),
+  reasoning_map: z.object({
+    low: z.string().optional(),
+    default: z.string().optional(),
+    high: z.string().optional(),
+  }).optional(),
   /** Context window size for local models (Ollama num_ctx, LM Studio context_length). */
   context_length: z.number().int().positive().optional(),
 });
@@ -55,6 +62,7 @@ const ScheduleOverrideSchema = z.object({
 /** Per-task config override — stored in myco.yaml under agent.tasks. */
 const TaskProviderOverrideSchema = z.object({
   provider: ProviderOverrideSchema.optional(),
+  runtime: RuntimeIdSchema.optional(),
   model: z.string().optional(),
   maxTurns: z.number().int().positive().optional(),
   timeoutSeconds: z.number().int().positive().optional(),
@@ -82,6 +90,8 @@ const AgentSchema = z.object({
   event_tasks_enabled: z.boolean().default(true),
   /** Global default provider — applies to all tasks unless overridden per-task. */
   provider: ProviderOverrideSchema.optional(),
+  /** Global default runtime — applies to all tasks unless overridden per-task. */
+  runtime: RuntimeIdSchema.optional(),
   /** Global default model — applies to all tasks unless overridden per-task. */
   model: z.string().optional(),
   /** Per-task overrides keyed by task name. */

--- a/packages/myco/src/config/updates.ts
+++ b/packages/myco/src/config/updates.ts
@@ -15,6 +15,7 @@ export function withValue(config: MycoConfig, dotPath: string, value: unknown): 
 interface ProviderInput {
   runtime?: 'claude-sdk' | 'openai-agents';
   type: 'anthropic' | 'ollama' | 'lmstudio' | 'openai' | 'openrouter' | 'openai-compatible';
+  local_backend?: 'ollama' | 'lmstudio';
   model?: string;
   reasoning_map?: Partial<Record<'low' | 'default' | 'high', string>>;
   base_url?: string;

--- a/packages/myco/src/config/updates.ts
+++ b/packages/myco/src/config/updates.ts
@@ -13,8 +13,10 @@ export function withValue(config: MycoConfig, dotPath: string, value: unknown): 
 
 /** Provider override shape used in task config updates. Null means delete. */
 interface ProviderInput {
-  type: 'anthropic' | 'ollama' | 'lmstudio';
+  runtime?: 'claude-sdk' | 'openai-agents';
+  type: 'anthropic' | 'ollama' | 'lmstudio' | 'openai' | 'openrouter' | 'openai-compatible';
   model?: string;
+  reasoning_map?: Partial<Record<'low' | 'default' | 'high', string>>;
   base_url?: string;
   context_length?: number;
 }
@@ -29,6 +31,7 @@ interface PhaseInput {
 /** Input shape for task config updates. Null values mean "delete this field". */
 export interface TaskConfigUpdate {
   provider?: ProviderInput | null;
+  runtime?: 'claude-sdk' | 'openai-agents' | null;
   model?: string | null;
   maxTurns?: number | null;
   timeoutSeconds?: number | null;
@@ -55,6 +58,11 @@ export function withTaskConfig(
     } else if (update.provider !== undefined) {
       entry.provider = { ...update.provider };
     }
+  }
+
+  if ('runtime' in update) {
+    if (update.runtime === null) delete entry.runtime;
+    else if (update.runtime !== undefined) entry.runtime = update.runtime;
   }
 
   if ('model' in update) {

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -18,6 +18,7 @@ import { notify } from '@myco/notifications/notify.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 import type { EmbeddingManager } from '../embedding/manager.js';
 import type { DaemonLogger } from '../logger.js';
+import type { RunRow } from '@myco/db/queries/runs.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -36,6 +37,10 @@ const AgentRunBody = z.object({
   agentId: z.string().optional(),
 });
 
+const ResumeRunBody = z.object({
+  mode: z.enum(['manual', 'scheduled']).optional(),
+});
+
 // Re-export for backward compatibility
 export { buildTaskInstruction, SKILL_GENERATE_TASK, SKILL_EVOLVE_TASK, SKILL_SURVEY_TASK } from '@myco/agent/instruction-builders.js';
 
@@ -47,6 +52,40 @@ export interface AgentRunDeps {
   vaultDir: string;
   embeddingManager: EmbeddingManager;
   logger: DaemonLogger;
+}
+
+interface PhaseCheckpointSummary {
+  name: string;
+  status: string;
+  updatedAt: number;
+  tokensUsed?: number;
+  costUsd?: number;
+}
+
+function buildPhaseCheckpointSummary(checkpointsRaw: string | null): PhaseCheckpointSummary[] {
+  if (!checkpointsRaw) return [];
+  try {
+    const parsed = JSON.parse(checkpointsRaw) as {
+      phases?: Record<string, { name?: string; status?: string; updatedAt?: number; tokensUsed?: number; costUsd?: number }>;
+    };
+    return Object.entries(parsed.phases ?? {}).map(([name, phase]) => ({
+      name: phase.name ?? name,
+      status: phase.status ?? 'pending',
+      updatedAt: phase.updatedAt ?? 0,
+      ...(phase.tokensUsed !== undefined ? { tokensUsed: phase.tokensUsed } : {}),
+      ...(phase.costUsd !== undefined ? { costUsd: phase.costUsd } : {}),
+    }));
+  } catch {
+    return [];
+  }
+}
+
+function serializeRun(run: RunRow) {
+  return {
+    ...run,
+    resumable: run.resumable === 1,
+    phase_checkpoints: buildPhaseCheckpointSummary(run.checkpoints),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -175,7 +214,7 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
     const runs = listRuns({ ...filterOpts, limit, offset });
     const total = countRuns(filterOpts);
 
-    return { body: { runs, total, offset, limit } };
+    return { body: { runs: runs.map(serializeRun), total, offset, limit } };
   }
 
   /** GET /api/agent/runs/:id — get a single run. */
@@ -184,7 +223,48 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
     if (!run) {
       return { status: 404, body: { error: 'Run not found' } };
     }
-    return { body: { run } };
+    return { body: { run: serializeRun(run) } };
+  }
+
+  /** POST /api/agent/runs/:id/resume — resume a failed/interrupted run. */
+  async function handleResumeRun(req: RouteRequest): Promise<RouteResponse> {
+    const run = getRun(req.params.id);
+    if (!run) {
+      return { status: 404, body: { error: 'Run not found' } };
+    }
+    if (run.resumable !== 1 || run.status !== 'failed') {
+      return { status: 400, body: { error: 'Run is not resumable' } };
+    }
+
+    const { mode } = ResumeRunBody.parse(req.body ?? {});
+    const { runAgent } = await import('@myco/agent/executor.js');
+    const resultPromise = runAgent(vaultDir, {
+      agentId: run.agent_id,
+      task: run.task ?? undefined,
+      instruction: run.instruction ?? undefined,
+      resumeRunId: run.id,
+      resumeMode: mode ?? 'manual',
+      embeddingManager,
+    });
+
+    resultPromise
+      .then((result) => {
+        logger.info(LOG_KINDS.AGENT_RUN, 'Agent run resumed', {
+          runId: result.runId,
+          status: result.status,
+          runtime: result.runtime,
+          provider: result.provider,
+          model: result.model,
+        });
+      })
+      .catch((err) => {
+        logger.error(LOG_KINDS.AGENT_ERROR, 'Agent run resume threw unhandled error', {
+          runId: run.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+
+    return { body: { ok: true, message: 'Agent resume started', runId: run.id } };
   }
 
   /** GET /api/agent/runs/:id/reports — list reports for a run. */
@@ -203,6 +283,7 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
     handleRun,
     handleListRuns,
     handleGetRun,
+    handleResumeRun,
     handleGetRunReports,
     handleGetRunTurns,
   };

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -60,13 +60,14 @@ interface PhaseCheckpointSummary {
   updatedAt: number;
   tokensUsed?: number;
   costUsd?: number;
+  costSource?: string;
 }
 
 function buildPhaseCheckpointSummary(checkpointsRaw: string | null): PhaseCheckpointSummary[] {
   if (!checkpointsRaw) return [];
   try {
     const parsed = JSON.parse(checkpointsRaw) as {
-      phases?: Record<string, { name?: string; status?: string; updatedAt?: number; tokensUsed?: number; costUsd?: number }>;
+      phases?: Record<string, { name?: string; status?: string; updatedAt?: number; tokensUsed?: number; costUsd?: number; costSource?: string }>;
     };
     return Object.entries(parsed.phases ?? {}).map(([name, phase]) => ({
       name: phase.name ?? name,
@@ -74,6 +75,7 @@ function buildPhaseCheckpointSummary(checkpointsRaw: string | null): PhaseCheckp
       updatedAt: phase.updatedAt ?? 0,
       ...(phase.tokensUsed !== undefined ? { tokensUsed: phase.tokensUsed } : {}),
       ...(phase.costUsd !== undefined ? { costUsd: phase.costUsd } : {}),
+      ...(phase.costSource !== undefined ? { costSource: phase.costSource } : {}),
     }));
   } catch {
     return [];

--- a/packages/myco/src/daemon/api/models.ts
+++ b/packages/myco/src/daemon/api/models.ts
@@ -1,8 +1,14 @@
 import { OllamaBackend } from '../../intelligence/ollama.js';
 import { LmStudioBackend } from '../../intelligence/lm-studio.js';
+import { OPENAI_API_KEY_ENV } from '../../cli/providers/openai-embeddings.js';
+import { OPENROUTER_API_KEY_ENV } from '../../cli/providers/openrouter.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 
 const MODEL_LIST_TIMEOUT_MS = 5000;
+const REMOTE_MODELS_ENDPOINT = '/models';
+const OPENAI_DEFAULT_BASE_URL = 'https://api.openai.com/v1';
+const OPENROUTER_DEFAULT_BASE_URL = 'https://openrouter.ai/api/v1';
+const REMOTE_PROVIDER_TIMEOUT_MS = 5000;
 
 /** Well-known Anthropic models — no list API available locally.
  *  Sonnet is first because it's the recommended default for all built-in
@@ -34,6 +40,53 @@ export function filterLlmModels(models: string[]): string[] {
   });
 }
 
+type RemoteProviderType = 'openai' | 'openrouter';
+
+const REMOTE_PROVIDER_DEFAULTS: Record<RemoteProviderType, string> = {
+  openai: OPENAI_DEFAULT_BASE_URL,
+  openrouter: OPENROUTER_DEFAULT_BASE_URL,
+};
+
+const REMOTE_PROVIDER_ENV_VARS: Record<RemoteProviderType, string> = {
+  openai: OPENAI_API_KEY_ENV,
+  openrouter: OPENROUTER_API_KEY_ENV,
+};
+
+function getRemoteProviderApiKey(provider: RemoteProviderType): string | undefined {
+  const preferredKey = process.env[REMOTE_PROVIDER_ENV_VARS[provider]];
+  if (preferredKey) return preferredKey;
+  if (provider === 'openai') {
+    return process.env.OPENAI_API_KEY;
+  }
+  return undefined;
+}
+
+async function fetchRemoteProviderModels(
+  provider: RemoteProviderType,
+  baseUrl?: string,
+  timeoutMs = REMOTE_PROVIDER_TIMEOUT_MS,
+): Promise<string[]> {
+  const apiKey = getRemoteProviderApiKey(provider);
+  if (!apiKey) return [];
+
+  const response = await fetch(`${baseUrl ?? REMOTE_PROVIDER_DEFAULTS[provider]}${REMOTE_MODELS_ENDPOINT}`, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+
+  if (!response.ok) {
+    throw new Error(`${provider} models request failed with ${response.status}`);
+  }
+
+  const data = await response.json() as { data?: Array<{ id?: string }> };
+  const modelIds = (data.data ?? [])
+    .map((entry) => entry.id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+  return filterLlmModels(modelIds);
+}
+
 export async function handleGetModels(req: RouteRequest): Promise<RouteResponse> {
   const provider = req.query.provider;
   const type = req.query.type; // 'llm' | 'embedding' | undefined (all)
@@ -48,11 +101,13 @@ export async function handleGetModels(req: RouteRequest): Promise<RouteResponse>
     if (provider === 'ollama') {
       const backend = new OllamaBackend({ base_url: req.query.base_url });
       models = await backend.listModels(MODEL_LIST_TIMEOUT_MS);
-    } else if (provider === 'lm-studio' || provider === 'openai-compatible') {
+    } else if (provider === 'lmstudio' || provider === 'lm-studio' || provider === 'openai-compatible') {
       const backend = new LmStudioBackend({ base_url: req.query.base_url });
       models = await backend.listModels(MODEL_LIST_TIMEOUT_MS);
     } else if (provider === 'anthropic') {
       models = ANTHROPIC_MODELS;
+    } else if (provider === 'openai' || provider === 'openrouter') {
+      models = await fetchRemoteProviderModels(provider, req.query.base_url, MODEL_LIST_TIMEOUT_MS);
     }
   } catch {
     // Provider unreachable — return empty list
@@ -67,3 +122,8 @@ export async function handleGetModels(req: RouteRequest): Promise<RouteResponse>
 
   return { body: { provider, models } };
 }
+
+export {
+  getRemoteProviderApiKey,
+  fetchRemoteProviderModels,
+};

--- a/packages/myco/src/daemon/api/models.ts
+++ b/packages/myco/src/daemon/api/models.ts
@@ -1,5 +1,9 @@
 import { OllamaBackend } from '../../intelligence/ollama.js';
 import { LmStudioBackend } from '../../intelligence/lm-studio.js';
+import {
+  createLocalOpenAIBackend,
+  inferLocalOpenAIBackendKind,
+} from '../../intelligence/local-openai-backends.js';
 import { OPENAI_API_KEY_ENV } from '../../cli/providers/openai-embeddings.js';
 import { OPENROUTER_API_KEY_ENV } from '../../cli/providers/openrouter.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
@@ -90,6 +94,7 @@ async function fetchRemoteProviderModels(
 export async function handleGetModels(req: RouteRequest): Promise<RouteResponse> {
   const provider = req.query.provider;
   const type = req.query.type; // 'llm' | 'embedding' | undefined (all)
+  const localBackend = req.query.local_backend;
 
   if (!provider) {
     return { status: 400, body: { error: 'provider query parameter required' } };
@@ -98,11 +103,13 @@ export async function handleGetModels(req: RouteRequest): Promise<RouteResponse>
   let models: string[] = [];
 
   try {
-    if (provider === 'ollama') {
-      const backend = new OllamaBackend({ base_url: req.query.base_url });
-      models = await backend.listModels(MODEL_LIST_TIMEOUT_MS);
-    } else if (provider === 'lmstudio' || provider === 'lm-studio' || provider === 'openai-compatible') {
-      const backend = new LmStudioBackend({ base_url: req.query.base_url });
+    const localBackendKind = inferLocalOpenAIBackendKind({
+      type: provider === 'lm-studio' ? 'lmstudio' : provider as 'ollama' | 'lmstudio' | 'openai-compatible',
+      localBackend: localBackend as 'ollama' | 'lmstudio' | undefined,
+      baseUrl: req.query.base_url,
+    });
+    if (localBackendKind) {
+      const backend = createLocalOpenAIBackend(localBackendKind, req.query.base_url);
       models = await backend.listModels(MODEL_LIST_TIMEOUT_MS);
     } else if (provider === 'anthropic') {
       models = ANTHROPIC_MODELS;

--- a/packages/myco/src/daemon/api/provider-secrets.ts
+++ b/packages/myco/src/daemon/api/provider-secrets.ts
@@ -1,0 +1,106 @@
+import { deleteSecrets, readSecrets, writeSecret } from '@myco/config/secrets.js';
+import { OPENAI_API_KEY_ENV } from '../../cli/providers/openai-embeddings.js';
+import { OPENROUTER_API_KEY_ENV } from '../../cli/providers/openrouter.js';
+import type { RouteRequest, RouteResponse } from '../router.js';
+
+const SECRET_PREVIEW_PREFIX_CHARS = 8;
+const SECRET_PREVIEW_SUFFIX_CHARS = 4;
+
+type SecretProvider = 'openai' | 'openrouter';
+
+interface SecretInfo {
+  configured: boolean;
+  envKey: string;
+  maskedValue: string | null;
+  source: 'vault' | 'env' | 'none';
+}
+
+const SECRET_ENV_BY_PROVIDER: Record<SecretProvider, string> = {
+  openai: OPENAI_API_KEY_ENV,
+  openrouter: OPENROUTER_API_KEY_ENV,
+};
+
+function isSecretProvider(value: string): value is SecretProvider {
+  return value === 'openai' || value === 'openrouter';
+}
+
+function maskSecret(secret: string): string {
+  if (secret.length <= SECRET_PREVIEW_PREFIX_CHARS + SECRET_PREVIEW_SUFFIX_CHARS) {
+    return '*'.repeat(secret.length);
+  }
+  return `${secret.slice(0, SECRET_PREVIEW_PREFIX_CHARS)}${'*'.repeat(secret.length - SECRET_PREVIEW_PREFIX_CHARS - SECRET_PREVIEW_SUFFIX_CHARS)}${secret.slice(-SECRET_PREVIEW_SUFFIX_CHARS)}`;
+}
+
+function getSecretInfo(vaultDir: string, provider: SecretProvider): SecretInfo {
+  const envKey = SECRET_ENV_BY_PROVIDER[provider];
+  const storedSecrets = readSecrets(vaultDir);
+  const storedValue = storedSecrets[envKey];
+  const envValue = process.env[envKey];
+  const effectiveValue = storedValue ?? envValue;
+
+  return {
+    configured: Boolean(effectiveValue),
+    envKey,
+    maskedValue: effectiveValue ? maskSecret(effectiveValue) : null,
+    source: storedValue ? 'vault' : envValue ? 'env' : 'none',
+  };
+}
+
+export async function handleGetProviderSecrets(vaultDir: string): Promise<RouteResponse> {
+  return {
+    body: {
+      secrets: {
+        openai: getSecretInfo(vaultDir, 'openai'),
+        openrouter: getSecretInfo(vaultDir, 'openrouter'),
+      },
+    },
+  };
+}
+
+export async function handlePutProviderSecret(vaultDir: string, req: RouteRequest): Promise<RouteResponse> {
+  const provider = req.params.provider;
+  const body = req.body as { api_key?: string } | undefined;
+
+  if (!provider || !isSecretProvider(provider)) {
+    return { status: 400, body: { error: 'provider must be one of: openai, openrouter' } };
+  }
+  if (!body?.api_key?.trim()) {
+    return { status: 400, body: { error: 'api_key is required' } };
+  }
+
+  const envKey = SECRET_ENV_BY_PROVIDER[provider];
+  const apiKey = body.api_key.trim();
+  writeSecret(vaultDir, envKey, apiKey);
+  process.env[envKey] = apiKey;
+  if (provider === 'openai') {
+    process.env.OPENAI_API_KEY = apiKey;
+  }
+
+  return {
+    body: {
+      provider,
+      secret: getSecretInfo(vaultDir, provider),
+    },
+  };
+}
+
+export async function handleDeleteProviderSecret(vaultDir: string, req: RouteRequest): Promise<RouteResponse> {
+  const provider = req.params.provider;
+  if (!provider || !isSecretProvider(provider)) {
+    return { status: 400, body: { error: 'provider must be one of: openai, openrouter' } };
+  }
+
+  const envKey = SECRET_ENV_BY_PROVIDER[provider];
+  deleteSecrets(vaultDir, [envKey]);
+  delete process.env[envKey];
+  if (provider === 'openai') {
+    delete process.env.OPENAI_API_KEY;
+  }
+
+  return {
+    body: {
+      provider,
+      secret: getSecretInfo(vaultDir, provider),
+    },
+  };
+}

--- a/packages/myco/src/daemon/api/providers.ts
+++ b/packages/myco/src/daemon/api/providers.ts
@@ -7,9 +7,15 @@
  */
 
 import Anthropic from '@anthropic-ai/sdk';
+import { checkLocalProvider } from '../../intelligence/provider-check.js';
+import {
+  createLocalOpenAIBackend,
+  getLocalOpenAIBackendDefaultBaseUrl,
+  getLocalOpenAIBackendLabel,
+  inferLocalOpenAIBackendKind,
+} from '../../intelligence/local-openai-backends.js';
 import { OllamaBackend } from '../../intelligence/ollama.js';
 import { LmStudioBackend } from '../../intelligence/lm-studio.js';
-import { checkLocalProvider } from '../../intelligence/provider-check.js';
 import {
   ANTHROPIC_MODELS,
   filterLlmModels,
@@ -103,7 +109,7 @@ export async function handleGetProviders(): Promise<RouteResponse> {
 /**
  * Test connectivity to a specific provider.
  *
- * Accepts: { type: 'anthropic' | 'ollama' | 'lmstudio' | 'openai' | 'openrouter' | 'openai-compatible', baseUrl?: string, model?: string }
+ * Accepts: { type: 'anthropic' | 'ollama' | 'lmstudio' | 'openai' | 'openrouter' | 'openai-compatible', baseUrl?: string, local_backend?: 'ollama' | 'lmstudio', model?: string }
  * Returns: { ok: boolean, latency_ms?: number, error?: string }
  */
 export async function handleTestProvider(req: RouteRequest): Promise<RouteResponse> {
@@ -118,16 +124,17 @@ export async function handleTestProvider(req: RouteRequest): Promise<RouteRespon
   }
 
   const baseUrl = (body?.baseUrl as string | undefined) ?? (body?.base_url as string | undefined);
+  const localBackend = (body?.local_backend as 'ollama' | 'lmstudio' | undefined);
   const start = performance.now();
   let result: TestResult;
 
   try {
     if (type === 'ollama') {
-      result = await testLocalProvider(new OllamaBackend({ base_url: baseUrl }), 'Ollama', OllamaBackend.DEFAULT_BASE_URL, baseUrl);
+      result = await testResolvedLocalProvider('ollama', baseUrl);
     } else if (type === 'lmstudio') {
-      result = await testLocalProvider(new LmStudioBackend({ base_url: baseUrl }), 'LM Studio', LmStudioBackend.DEFAULT_BASE_URL, baseUrl);
+      result = await testResolvedLocalProvider('lmstudio', baseUrl);
     } else if (type === 'openai-compatible') {
-      result = await testLocalProvider(new LmStudioBackend({ base_url: baseUrl }), 'OpenAI-compatible provider', LmStudioBackend.DEFAULT_BASE_URL, baseUrl);
+      result = await testResolvedLocalProvider('openai-compatible', baseUrl, localBackend);
     } else if (type === 'openai') {
       result = await testRemoteProvider('openai', 'OpenAI', baseUrl);
     } else if (type === 'openrouter') {
@@ -247,6 +254,23 @@ async function testLocalProvider(
     return { ok: false, error: `${label} not reachable at ${baseUrl ?? defaultBaseUrl}` };
   }
   return { ok: true };
+}
+
+async function testResolvedLocalProvider(
+  type: 'ollama' | 'lmstudio' | 'openai-compatible',
+  baseUrl?: string,
+  localBackend?: 'ollama' | 'lmstudio',
+): Promise<TestResult> {
+  const kind = inferLocalOpenAIBackendKind({ type, localBackend, baseUrl }) ?? 'lmstudio';
+  const label = type === 'openai-compatible'
+    ? `OpenAI-compatible ${getLocalOpenAIBackendLabel(kind)} provider`
+    : getLocalOpenAIBackendLabel(kind);
+  return testLocalProvider(
+    createLocalOpenAIBackend(kind, baseUrl),
+    label,
+    getLocalOpenAIBackendDefaultBaseUrl(kind),
+    baseUrl,
+  );
 }
 
 function testAnthropic(): TestResult {

--- a/packages/myco/src/daemon/api/providers.ts
+++ b/packages/myco/src/daemon/api/providers.ts
@@ -10,8 +10,14 @@ import Anthropic from '@anthropic-ai/sdk';
 import { OllamaBackend } from '../../intelligence/ollama.js';
 import { LmStudioBackend } from '../../intelligence/lm-studio.js';
 import { checkLocalProvider } from '../../intelligence/provider-check.js';
-import { ANTHROPIC_MODELS, filterLlmModels } from './models.js';
+import {
+  ANTHROPIC_MODELS,
+  filterLlmModels,
+  fetchRemoteProviderModels,
+  getRemoteProviderApiKey,
+} from './models.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
+import type { RuntimeId, ProviderType } from '@myco/agent/types.js';
 
 /** Timeout for the live Anthropic model list query (short -- fall back fast). */
 const ANTHROPIC_MODELS_TIMEOUT_MS = 5000;
@@ -31,8 +37,10 @@ const HTTP_BAD_REQUEST = 400;
 // ---------------------------------------------------------------------------
 
 interface ProviderInfo {
-  type: string;
+  type: ProviderType;
+  runtime: RuntimeId;
   available: boolean;
+  authConfigured?: boolean;
   baseUrl?: string;
   models: string[];
 }
@@ -54,17 +62,39 @@ interface TestResult {
  * slow/unavailable provider doesn't block the others.
  */
 export async function handleGetProviders(): Promise<RouteResponse> {
-  // UI rendering order: Anthropic first (recommended default), then locals.
-  const results = await Promise.allSettled([
-    detectAnthropic(),
-    detectLocalProviderInfo('ollama', OllamaBackend.DEFAULT_BASE_URL),
-    detectLocalProviderInfo('lmstudio', LmStudioBackend.DEFAULT_BASE_URL),
-  ]);
+  const detectionPlan: Array<{
+    detect: () => Promise<ProviderInfo>;
+    fallback: ProviderInfo;
+  }> = [
+    {
+      detect: () => detectAnthropic(),
+      fallback: { type: 'anthropic', runtime: 'claude-sdk', available: false, models: [] },
+    },
+    {
+      detect: () => detectLocalProviderInfo('ollama', OllamaBackend.DEFAULT_BASE_URL),
+      fallback: { type: 'ollama', runtime: 'claude-sdk', available: false, baseUrl: OllamaBackend.DEFAULT_BASE_URL, models: [] },
+    },
+    {
+      detect: () => detectLocalProviderInfo('lmstudio', LmStudioBackend.DEFAULT_BASE_URL),
+      fallback: { type: 'lmstudio', runtime: 'claude-sdk', available: false, baseUrl: LmStudioBackend.DEFAULT_BASE_URL, models: [] },
+    },
+    {
+      detect: () => detectRemoteProviderInfo('openai', 'https://api.openai.com/v1'),
+      fallback: { type: 'openai', runtime: 'openai-agents', available: false, authConfigured: false, baseUrl: 'https://api.openai.com/v1', models: [] },
+    },
+    {
+      detect: () => detectRemoteProviderInfo('openrouter', 'https://openrouter.ai/api/v1'),
+      fallback: { type: 'openrouter', runtime: 'openai-agents', available: false, authConfigured: false, baseUrl: 'https://openrouter.ai/api/v1', models: [] },
+    },
+    {
+      detect: () => detectLocalProviderInfo('openai-compatible', LmStudioBackend.DEFAULT_BASE_URL),
+      fallback: { type: 'openai-compatible', runtime: 'openai-agents', available: false, baseUrl: LmStudioBackend.DEFAULT_BASE_URL, models: [] },
+    },
+  ];
 
-  const providers: ProviderInfo[] = results.map((r) =>
-    r.status === 'fulfilled'
-      ? r.value
-      : { type: 'unknown', available: false, models: [] },
+  const results = await Promise.allSettled(detectionPlan.map((entry) => entry.detect()));
+  const providers: ProviderInfo[] = results.map((result, index) =>
+    result.status === 'fulfilled' ? result.value : detectionPlan[index].fallback,
   );
 
   return { status: HTTP_OK, body: { providers } };
@@ -73,21 +103,21 @@ export async function handleGetProviders(): Promise<RouteResponse> {
 /**
  * Test connectivity to a specific provider.
  *
- * Accepts: { type: 'anthropic' | 'ollama' | 'lmstudio', baseUrl?: string, model?: string }
+ * Accepts: { type: 'anthropic' | 'ollama' | 'lmstudio' | 'openai' | 'openrouter' | 'openai-compatible', baseUrl?: string, model?: string }
  * Returns: { ok: boolean, latency_ms?: number, error?: string }
  */
 export async function handleTestProvider(req: RouteRequest): Promise<RouteResponse> {
   const body = req.body as Record<string, unknown> | undefined;
   const type = body?.type as string | undefined;
 
-  if (!type || !['anthropic', 'ollama', 'lmstudio'].includes(type)) {
+  if (!type || !['anthropic', 'ollama', 'lmstudio', 'openai', 'openrouter', 'openai-compatible'].includes(type)) {
     return {
       status: HTTP_BAD_REQUEST,
-      body: { error: 'type is required and must be one of: anthropic, ollama, lmstudio' },
+      body: { error: 'type is required and must be one of: anthropic, ollama, lmstudio, openai, openrouter, openai-compatible' },
     };
   }
 
-  const baseUrl = body?.baseUrl as string | undefined;
+  const baseUrl = (body?.baseUrl as string | undefined) ?? (body?.base_url as string | undefined);
   const start = performance.now();
   let result: TestResult;
 
@@ -96,6 +126,12 @@ export async function handleTestProvider(req: RouteRequest): Promise<RouteRespon
       result = await testLocalProvider(new OllamaBackend({ base_url: baseUrl }), 'Ollama', OllamaBackend.DEFAULT_BASE_URL, baseUrl);
     } else if (type === 'lmstudio') {
       result = await testLocalProvider(new LmStudioBackend({ base_url: baseUrl }), 'LM Studio', LmStudioBackend.DEFAULT_BASE_URL, baseUrl);
+    } else if (type === 'openai-compatible') {
+      result = await testLocalProvider(new LmStudioBackend({ base_url: baseUrl }), 'OpenAI-compatible provider', LmStudioBackend.DEFAULT_BASE_URL, baseUrl);
+    } else if (type === 'openai') {
+      result = await testRemoteProvider('openai', 'OpenAI', baseUrl);
+    } else if (type === 'openrouter') {
+      result = await testRemoteProvider('openrouter', 'OpenRouter', baseUrl);
     } else {
       result = testAnthropic();
     }
@@ -117,15 +153,21 @@ export async function handleTestProvider(req: RouteRequest): Promise<RouteRespon
 /** Detect a local provider (Ollama or LM Studio) and wrap as ProviderInfo.
  *  Filters embedding models out — the agent provider only runs LLM tasks. */
 async function detectLocalProviderInfo(
-  type: 'ollama' | 'lmstudio',
+  type: 'ollama' | 'lmstudio' | 'openai-compatible',
   defaultBaseUrl: string,
 ): Promise<ProviderInfo> {
-  const status = await checkLocalProvider(type);
+  const status = await checkLocalProvider(type === 'openai-compatible' ? 'lmstudio' : type);
   // Filter out Myco-created context variants (e.g., gpt-oss-ctx32768)
   const variantFiltered = status.models.filter(m => !/-ctx\d+/.test(m));
   // Drop embedding models -- the agent provider only runs LLM tasks
   const models = filterLlmModels(variantFiltered);
-  return { type, available: status.available, baseUrl: defaultBaseUrl, models };
+  return {
+    type,
+    runtime: type === 'openai-compatible' ? 'openai-agents' : 'claude-sdk',
+    available: status.available,
+    baseUrl: defaultBaseUrl,
+    models,
+  };
 }
 
 async function detectAnthropic(): Promise<ProviderInfo> {
@@ -139,7 +181,7 @@ async function detectAnthropic(): Promise<ProviderInfo> {
   // ANTHROPIC_MODELS constant so the dropdown is never empty.
   const now = Date.now();
   if (anthropicModelsCache && now - anthropicModelsCache.ts < ANTHROPIC_MODELS_CACHE_TTL_MS) {
-    return { type: 'anthropic', available: true, models: anthropicModelsCache.models };
+    return { type: 'anthropic', runtime: 'claude-sdk', available: true, models: anthropicModelsCache.models };
   }
 
   let models = ANTHROPIC_MODELS;
@@ -159,7 +201,34 @@ async function detectAnthropic(): Promise<ProviderInfo> {
     // Fall through to hardcoded ANTHROPIC_MODELS
   }
   anthropicModelsCache = { ts: now, models };
-  return { type: 'anthropic', available: true, models };
+  return { type: 'anthropic', runtime: 'claude-sdk', available: true, models };
+}
+
+async function detectRemoteProviderInfo(
+  type: 'openai' | 'openrouter',
+  baseUrl: string,
+): Promise<ProviderInfo> {
+  const authConfigured = Boolean(getRemoteProviderApiKey(type));
+  let models: string[] = [];
+  let available = false;
+
+  if (authConfigured) {
+    try {
+      models = await fetchRemoteProviderModels(type, baseUrl, ANTHROPIC_MODELS_TIMEOUT_MS);
+      available = true;
+    } catch {
+      available = false;
+    }
+  }
+
+  return {
+    type,
+    runtime: 'openai-agents',
+    available,
+    authConfigured,
+    baseUrl,
+    models,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -183,4 +252,20 @@ async function testLocalProvider(
 function testAnthropic(): TestResult {
   // SDK handles auth — always report OK. Auth failures surface at runtime.
   return { ok: true };
+}
+
+async function testRemoteProvider(
+  provider: 'openai' | 'openrouter',
+  label: string,
+  baseUrl?: string,
+): Promise<TestResult> {
+  if (!getRemoteProviderApiKey(provider)) {
+    return { ok: false, error: `${label} API key not configured in daemon secrets or environment` };
+  }
+  try {
+    await fetchRemoteProviderModels(provider, baseUrl);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : `${label} connection failed` };
+  }
 }

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -112,6 +112,11 @@ import {
   handleUpdateTaskConfig,
 } from './api/agent-tasks.js';
 import { handleGetProviders, handleTestProvider } from './api/providers.js';
+import {
+  handleDeleteProviderSecret,
+  handleGetProviderSecrets,
+  handlePutProviderSecret,
+} from './api/provider-secrets.js';
 import { registerScheduledTasks } from './task-scheduling.js';
 import { initDatabase, vaultDbPath, closeDatabase, getDatabase } from '../db/client.js';
 import { createSchema } from '../db/schema.js';
@@ -120,6 +125,7 @@ import { createMcpProxyHandlers } from './api/mcp-proxy.js';
 import { createAgentRunHandlers } from './api/agent-runs.js';
 import { createAttachmentHandler } from './api/attachments.js';
 import { reconcileLogBuffer } from './log-reconcile.js';
+import { markRunningRunsInterrupted } from '../db/queries/runs.js';
 import {
   POWER_IDLE_THRESHOLD_MS,
   POWER_SLEEP_THRESHOLD_MS,
@@ -282,6 +288,12 @@ export async function main(): Promise<void> {
   const db = initDatabase(vaultDbPath(vaultDir));
   createSchema(db, machineId);
   registerBuiltinDomains();
+  const interruptedRuns = markRunningRunsInterrupted('Daemon restarted before the run completed');
+  if (interruptedRuns > 0) {
+    logger.warn(LOG_KINDS.AGENT_RUN, 'Marked stale running runs as resumable after daemon restart', {
+      count: interruptedRuns,
+    });
+  }
 
   logger.info(LOG_KINDS.DAEMON_START, 'SQLite initialized', { vault: vaultDir });
 
@@ -685,6 +697,7 @@ export async function main(): Promise<void> {
   server.registerRoute('POST', '/api/agent/run', agentRunHandlers.handleRun);
   server.registerRoute('GET', '/api/agent/runs', agentRunHandlers.handleListRuns);
   server.registerRoute('GET', '/api/agent/runs/:id', agentRunHandlers.handleGetRun);
+  server.registerRoute('POST', '/api/agent/runs/:id/resume', agentRunHandlers.handleResumeRun);
   server.registerRoute('GET', '/api/agent/runs/:id/reports', agentRunHandlers.handleGetRunReports);
   server.registerRoute('GET', '/api/agent/runs/:id/turns', agentRunHandlers.handleGetRunTurns);
 
@@ -731,6 +744,9 @@ export async function main(): Promise<void> {
   // --- Provider detection & testing ---
   server.registerRoute('GET', '/api/providers', async () => handleGetProviders());
   server.registerRoute('POST', '/api/providers/test', async (req) => handleTestProvider(req));
+  server.registerRoute('GET', '/api/providers/secrets', async () => handleGetProviderSecrets(vaultDir));
+  server.registerRoute('PUT', '/api/providers/secrets/:provider', async (req) => handlePutProviderSecret(vaultDir, req));
+  server.registerRoute('DELETE', '/api/providers/secrets/:provider', async (req) => handleDeleteProviderSecret(vaultDir, req));
 
   // --- MCP proxy routes ---
   // These routes exist so the MCP server can proxy tool calls through the

--- a/packages/myco/src/daemon/task-scheduling.ts
+++ b/packages/myco/src/daemon/task-scheduling.ts
@@ -23,8 +23,10 @@ import {
 import { countSkillRecords } from '@myco/db/queries/skill-records.js';
 import { countCandidates } from '@myco/db/queries/skill-candidates.js';
 import { getDatabase } from '@myco/db/client.js';
+import { getLatestResumableRunForTask } from '@myco/db/queries/runs.js';
 import { notify } from '@myco/notifications/notify.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+import { DEFAULT_AGENT_ID } from '@myco/constants.js';
 
 const SCHEDULED_JOB_PREFIX = 'scheduled:';
 
@@ -115,6 +117,21 @@ export async function registerScheduledTasks(
       if (!enabled) return;
 
       const { runAgent } = await import('@myco/agent/executor.js');
+      const resumableRun = getLatestResumableRunForTask(DEFAULT_AGENT_ID, taskName);
+      if (resumableRun) {
+        const resumed = await runAgent(vaultDir, {
+          agentId: DEFAULT_AGENT_ID,
+          task: taskName,
+          resumeRunId: resumableRun.id,
+          resumeMode: 'scheduled',
+          embeddingManager,
+        });
+        logger.info(LOG_KINDS.AGENT_RUN, `Scheduled task ${taskName} resumed`, {
+          status: resumed.status,
+          runId: resumed.runId,
+        });
+        return;
+      }
 
       const taskConfig = config.agent.tasks?.[taskName];
       const projectRoot = resolve(vaultDir, '..');

--- a/packages/myco/src/db/migrations.ts
+++ b/packages/myco/src/db/migrations.ts
@@ -41,6 +41,7 @@ export const MIGRATIONS: Migration[] = [
   { version: 11, migrate: (db) => migrateV10ToV11(db) },
   { version: 12, migrate: (db) => migrateV11ToV12(db) },
   { version: 13, migrate: (db) => migrateV12ToV13(db) },
+  { version: 14, migrate: (db) => migrateV13ToV14(db) },
 ];
 
 // ---------------------------------------------------------------------------
@@ -279,6 +280,44 @@ function migrateV12ToV13(db: Database): void {
        VALUES (?, ?)
        ON CONFLICT (version) DO NOTHING`,
     ).run(13, epochSeconds());
+
+    db.exec('COMMIT');
+  } catch (err) {
+    db.exec('ROLLBACK');
+    throw err;
+  }
+}
+
+/**
+ * Migrate a version-13 database to version-14.
+ *
+ * Version 14 adds richer local-only cost accounting metadata for agent runs.
+ * These columns intentionally stay on the local SQLite vault only and are not
+ * part of team sync / outbox payloads.
+ */
+function migrateV13ToV14(db: Database): void {
+  db.exec('BEGIN');
+  try {
+    const alterStatements = [
+      `ALTER TABLE agent_runs ADD COLUMN actual_cost_usd REAL`,
+      `ALTER TABLE agent_runs ADD COLUMN estimated_cost_usd REAL`,
+      `ALTER TABLE agent_runs ADD COLUMN cost_source TEXT`,
+      `ALTER TABLE agent_runs ADD COLUMN cost_data TEXT`,
+    ];
+
+    for (const statement of alterStatements) {
+      try {
+        db.exec(statement);
+      } catch {
+        // Column already exists -- safe to ignore on re-run
+      }
+    }
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at)
+       VALUES (?, ?)
+       ON CONFLICT (version) DO NOTHING`
+    ).run(14, epochSeconds());
 
     db.exec('COMMIT');
   } catch (err) {

--- a/packages/myco/src/db/migrations.ts
+++ b/packages/myco/src/db/migrations.ts
@@ -40,6 +40,7 @@ export const MIGRATIONS: Migration[] = [
   { version: 10, migrate: (db) => migrateV9ToV10(db) },
   { version: 11, migrate: (db) => migrateV10ToV11(db) },
   { version: 12, migrate: (db) => migrateV11ToV12(db) },
+  { version: 13, migrate: (db) => migrateV12ToV13(db) },
 ];
 
 // ---------------------------------------------------------------------------
@@ -227,6 +228,57 @@ function migrateV3ToV4(db: Database, machineId: string): void {
        VALUES (?, ?)
        ON CONFLICT (version) DO NOTHING`
     ).run(4, epochSeconds());
+
+    db.exec('COMMIT');
+  } catch (err) {
+    db.exec('ROLLBACK');
+    throw err;
+  }
+}
+
+/**
+ * Migrate a version-12 database to version-13.
+ *
+ * Version 13 adds first-class agent runtime/checkpoint fields so runs can be
+ * resumed without overloading actions_taken JSON.
+ */
+function migrateV12ToV13(db: Database): void {
+  db.exec('BEGIN');
+  try {
+    const alterStatements = [
+      `ALTER TABLE agent_runs ADD COLUMN runtime TEXT`,
+      `ALTER TABLE agent_runs ADD COLUMN provider TEXT`,
+      `ALTER TABLE agent_runs ADD COLUMN model TEXT`,
+      `ALTER TABLE agent_runs ADD COLUMN session_ref TEXT`,
+      `ALTER TABLE agent_runs ADD COLUMN resumable INTEGER DEFAULT 0`,
+      `ALTER TABLE agent_runs ADD COLUMN resume_status TEXT`,
+      `ALTER TABLE agent_runs ADD COLUMN resume_mode TEXT`,
+      `ALTER TABLE agent_runs ADD COLUMN resumed_at INTEGER`,
+      `ALTER TABLE agent_runs ADD COLUMN checkpoints TEXT`,
+      `ALTER TABLE agent_runs ADD COLUMN usage_data TEXT`,
+    ];
+
+    for (const stmt of alterStatements) {
+      try {
+        db.exec(stmt);
+      } catch {
+        // Column already exists -- safe to ignore on re-run
+      }
+    }
+
+    const newIndexes = [
+      `CREATE INDEX IF NOT EXISTS idx_agent_runs_task_status_started_at ON agent_runs (task, status, started_at)`,
+      `CREATE INDEX IF NOT EXISTS idx_agent_runs_resumable_task ON agent_runs (task, resumable, completed_at)`,
+    ];
+    for (const idx of newIndexes) {
+      db.exec(idx);
+    }
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at)
+       VALUES (?, ?)
+       ON CONFLICT (version) DO NOTHING`,
+    ).run(13, epochSeconds());
 
     db.exec('COMMIT');
   } catch (err) {

--- a/packages/myco/src/db/queries/runs.ts
+++ b/packages/myco/src/db/queries/runs.ts
@@ -7,6 +7,7 @@
 
 import { getDatabase } from '@myco/db/client.js';
 import type { ProviderType, RuntimeId } from '@myco/agent/types.js';
+import type { CostSource } from '@myco/agent/cost/types.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -54,6 +55,10 @@ export interface RunInsert {
   completed_at?: number | null;
   tokens_used?: number | null;
   cost_usd?: number | null;
+  actual_cost_usd?: number | null;
+  estimated_cost_usd?: number | null;
+  cost_source?: CostSource | null;
+  cost_data?: string | null;
   actions_taken?: string | null;
   error?: string | null;
 }
@@ -78,6 +83,10 @@ export interface RunRow {
   completed_at: number | null;
   tokens_used: number | null;
   cost_usd: number | null;
+  actual_cost_usd: number | null;
+  estimated_cost_usd: number | null;
+  cost_source: CostSource | null;
+  cost_data: string | null;
   actions_taken: string | null;
   error: string | null;
 }
@@ -88,6 +97,7 @@ export interface RunUpdate {
   provider?: ProviderType | null;
   model?: string | null;
   session_ref?: string | null;
+  started_at?: number | null;
   resumable?: number | null;
   resume_status?: string | null;
   resume_mode?: string | null;
@@ -97,6 +107,10 @@ export interface RunUpdate {
   completed_at?: number | null;
   tokens_used?: number | null;
   cost_usd?: number | null;
+  actual_cost_usd?: number | null;
+  estimated_cost_usd?: number | null;
+  cost_source?: CostSource | null;
+  cost_data?: string | null;
   actions_taken?: string | null;
   error?: string | null;
 }
@@ -104,7 +118,11 @@ export interface RunUpdate {
 export interface RunCompletion extends RunUpdate {
   completed_at?: number;
   tokens_used?: number;
-  cost_usd?: number;
+  cost_usd?: number | null;
+  actual_cost_usd?: number | null;
+  estimated_cost_usd?: number | null;
+  cost_source?: CostSource | null;
+  cost_data?: string | null;
   actions_taken?: string;
   error?: string;
 }
@@ -142,6 +160,10 @@ const RUN_COLUMNS = [
   'completed_at',
   'tokens_used',
   'cost_usd',
+  'actual_cost_usd',
+  'estimated_cost_usd',
+  'cost_source',
+  'cost_data',
   'actions_taken',
   'error',
 ] as const;
@@ -173,6 +195,10 @@ function toRunRow(row: Record<string, unknown>): RunRow {
     completed_at: (row.completed_at as number) ?? null,
     tokens_used: (row.tokens_used as number) ?? null,
     cost_usd: (row.cost_usd as number) ?? null,
+    actual_cost_usd: (row.actual_cost_usd as number) ?? null,
+    estimated_cost_usd: (row.estimated_cost_usd as number) ?? null,
+    cost_source: (row.cost_source as CostSource) ?? null,
+    cost_data: (row.cost_data as string) ?? null,
     actions_taken: (row.actions_taken as string) ?? null,
     error: (row.error as string) ?? null,
   };
@@ -214,6 +240,7 @@ function buildUpdateClauses(update: RunUpdate): { setClauses: string[]; params: 
     { key: 'provider', column: 'provider' },
     { key: 'model', column: 'model' },
     { key: 'session_ref', column: 'session_ref' },
+    { key: 'started_at', column: 'started_at' },
     { key: 'resumable', column: 'resumable' },
     { key: 'resume_status', column: 'resume_status' },
     { key: 'resume_mode', column: 'resume_mode' },
@@ -223,6 +250,10 @@ function buildUpdateClauses(update: RunUpdate): { setClauses: string[]; params: 
     { key: 'completed_at', column: 'completed_at' },
     { key: 'tokens_used', column: 'tokens_used' },
     { key: 'cost_usd', column: 'cost_usd' },
+    { key: 'actual_cost_usd', column: 'actual_cost_usd' },
+    { key: 'estimated_cost_usd', column: 'estimated_cost_usd' },
+    { key: 'cost_source', column: 'cost_source' },
+    { key: 'cost_data', column: 'cost_data' },
     { key: 'actions_taken', column: 'actions_taken' },
     { key: 'error', column: 'error' },
   ];
@@ -253,11 +284,13 @@ export function insertRun(data: RunInsert): RunRow {
        runtime, provider, model, session_ref, resumable,
        resume_status, resume_mode, resumed_at, checkpoints, usage_data,
        started_at, completed_at, tokens_used, cost_usd,
+       actual_cost_usd, estimated_cost_usd, cost_source, cost_data,
        actions_taken, error
      ) VALUES (
        ?, ?, ?, ?, ?,
        ?, ?, ?, ?, ?,
        ?, ?, ?, ?, ?,
+       ?, ?, ?, ?,
        ?, ?, ?, ?,
        ?, ?
      )`,
@@ -281,6 +314,10 @@ export function insertRun(data: RunInsert): RunRow {
     data.completed_at ?? null,
     data.tokens_used ?? null,
     data.cost_usd ?? null,
+    data.actual_cost_usd ?? null,
+    data.estimated_cost_usd ?? null,
+    data.cost_source ?? null,
+    data.cost_data ?? null,
     data.actions_taken ?? null,
     data.error ?? null,
   );

--- a/packages/myco/src/db/queries/runs.ts
+++ b/packages/myco/src/db/queries/runs.ts
@@ -6,6 +6,7 @@
  */
 
 import { getDatabase } from '@myco/db/client.js';
+import type { ProviderType, RuntimeId } from '@myco/agent/types.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -26,17 +27,29 @@ export const STATUS_COMPLETED = 'completed';
 /** Run status for a run that encountered an error. */
 export const STATUS_FAILED = 'failed';
 
+/** Resume status used when a failed/interrupted run can be resumed. */
+export const RESUME_STATUS_READY = 'ready';
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-/** Fields required (or optional) when inserting a run. */
 export interface RunInsert {
   id: string;
   agent_id: string;
   task?: string | null;
   instruction?: string | null;
   status?: string;
+  runtime?: RuntimeId | null;
+  provider?: ProviderType | null;
+  model?: string | null;
+  session_ref?: string | null;
+  resumable?: number | null;
+  resume_status?: string | null;
+  resume_mode?: string | null;
+  resumed_at?: number | null;
+  checkpoints?: string | null;
+  usage_data?: string | null;
   started_at?: number | null;
   completed_at?: number | null;
   tokens_used?: number | null;
@@ -45,13 +58,22 @@ export interface RunInsert {
   error?: string | null;
 }
 
-/** Row shape returned from agent_runs queries (all columns). */
 export interface RunRow {
   id: string;
   agent_id: string;
   task: string | null;
   instruction: string | null;
   status: string;
+  runtime: RuntimeId | null;
+  provider: ProviderType | null;
+  model: string | null;
+  session_ref: string | null;
+  resumable: number;
+  resume_status: string | null;
+  resume_mode: string | null;
+  resumed_at: number | null;
+  checkpoints: string | null;
+  usage_data: string | null;
   started_at: number | null;
   completed_at: number | null;
   tokens_used: number | null;
@@ -60,8 +82,26 @@ export interface RunRow {
   error: string | null;
 }
 
-/** Completion data passed to updateRunStatus. */
-export interface RunCompletion {
+export interface RunUpdate {
+  status?: string;
+  runtime?: RuntimeId | null;
+  provider?: ProviderType | null;
+  model?: string | null;
+  session_ref?: string | null;
+  resumable?: number | null;
+  resume_status?: string | null;
+  resume_mode?: string | null;
+  resumed_at?: number | null;
+  checkpoints?: string | null;
+  usage_data?: string | null;
+  completed_at?: number | null;
+  tokens_used?: number | null;
+  cost_usd?: number | null;
+  actions_taken?: string | null;
+  error?: string | null;
+}
+
+export interface RunCompletion extends RunUpdate {
   completed_at?: number;
   tokens_used?: number;
   cost_usd?: number;
@@ -69,7 +109,6 @@ export interface RunCompletion {
   error?: string;
 }
 
-/** Filter options for `listRuns`. */
 export interface ListRunsOptions {
   limit?: number;
   offset?: number;
@@ -89,6 +128,16 @@ const RUN_COLUMNS = [
   'task',
   'instruction',
   'status',
+  'runtime',
+  'provider',
+  'model',
+  'session_ref',
+  'resumable',
+  'resume_status',
+  'resume_mode',
+  'resumed_at',
+  'checkpoints',
+  'usage_data',
   'started_at',
   'completed_at',
   'tokens_used',
@@ -103,7 +152,6 @@ const SELECT_COLUMNS = RUN_COLUMNS.join(', ');
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Normalize a SQLite result row into a typed RunRow. */
 function toRunRow(row: Record<string, unknown>): RunRow {
   return {
     id: row.id as string,
@@ -111,6 +159,16 @@ function toRunRow(row: Record<string, unknown>): RunRow {
     task: (row.task as string) ?? null,
     instruction: (row.instruction as string) ?? null,
     status: row.status as string,
+    runtime: (row.runtime as RuntimeId) ?? null,
+    provider: (row.provider as ProviderType) ?? null,
+    model: (row.model as string) ?? null,
+    session_ref: (row.session_ref as string) ?? null,
+    resumable: Number(row.resumable ?? 0),
+    resume_status: (row.resume_status as string) ?? null,
+    resume_mode: (row.resume_mode as string) ?? null,
+    resumed_at: (row.resumed_at as number) ?? null,
+    checkpoints: (row.checkpoints as string) ?? null,
+    usage_data: (row.usage_data as string) ?? null,
     started_at: (row.started_at as number) ?? null,
     completed_at: (row.completed_at as number) ?? null,
     tokens_used: (row.tokens_used as number) ?? null,
@@ -120,62 +178,6 @@ function toRunRow(row: Record<string, unknown>): RunRow {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
-
-/**
- * Insert a new agent run.
- */
-export function insertRun(data: RunInsert): RunRow {
-  const db = getDatabase();
-
-  db.prepare(
-    `INSERT INTO agent_runs (
-       id, agent_id, task, instruction, status,
-       started_at, completed_at, tokens_used, cost_usd,
-       actions_taken, error
-     ) VALUES (
-       ?, ?, ?, ?, ?,
-       ?, ?, ?, ?,
-       ?, ?
-     )`,
-  ).run(
-    data.id,
-    data.agent_id,
-    data.task ?? null,
-    data.instruction ?? null,
-    data.status ?? DEFAULT_STATUS,
-    data.started_at ?? null,
-    data.completed_at ?? null,
-    data.tokens_used ?? null,
-    data.cost_usd ?? null,
-    data.actions_taken ?? null,
-    data.error ?? null,
-  );
-
-  return toRunRow(
-    db.prepare(`SELECT ${SELECT_COLUMNS} FROM agent_runs WHERE id = ?`).get(data.id) as Record<string, unknown>,
-  );
-}
-
-/**
- * Retrieve a single run by id.
- *
- * @returns the run row, or null if not found.
- */
-export function getRun(id: string): RunRow | null {
-  const db = getDatabase();
-
-  const row = db.prepare(
-    `SELECT ${SELECT_COLUMNS} FROM agent_runs WHERE id = ?`,
-  ).get(id) as Record<string, unknown> | undefined;
-
-  if (!row) return null;
-  return toRunRow(row);
-}
-
-/** Build a WHERE clause and params array from ListRunsOptions filter fields. */
 function buildRunsWhere(
   options: Omit<ListRunsOptions, 'limit' | 'offset'>,
 ): { where: string; params: unknown[] } {
@@ -205,12 +207,96 @@ function buildRunsWhere(
   };
 }
 
-/**
- * List runs with optional filters, ordered by started_at DESC (nulls last).
- */
-export function listRuns(
-  options: ListRunsOptions = {},
-): RunRow[] {
+function buildUpdateClauses(update: RunUpdate): { setClauses: string[]; params: unknown[] } {
+  const mappings: Array<{ key: keyof RunUpdate; column: string }> = [
+    { key: 'status', column: 'status' },
+    { key: 'runtime', column: 'runtime' },
+    { key: 'provider', column: 'provider' },
+    { key: 'model', column: 'model' },
+    { key: 'session_ref', column: 'session_ref' },
+    { key: 'resumable', column: 'resumable' },
+    { key: 'resume_status', column: 'resume_status' },
+    { key: 'resume_mode', column: 'resume_mode' },
+    { key: 'resumed_at', column: 'resumed_at' },
+    { key: 'checkpoints', column: 'checkpoints' },
+    { key: 'usage_data', column: 'usage_data' },
+    { key: 'completed_at', column: 'completed_at' },
+    { key: 'tokens_used', column: 'tokens_used' },
+    { key: 'cost_usd', column: 'cost_usd' },
+    { key: 'actions_taken', column: 'actions_taken' },
+    { key: 'error', column: 'error' },
+  ];
+
+  const setClauses: string[] = [];
+  const params: unknown[] = [];
+
+  for (const { key, column } of mappings) {
+    if (key in update) {
+      setClauses.push(`${column} = ?`);
+      params.push(update[key]);
+    }
+  }
+
+  return { setClauses, params };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function insertRun(data: RunInsert): RunRow {
+  const db = getDatabase();
+
+  db.prepare(
+    `INSERT INTO agent_runs (
+       id, agent_id, task, instruction, status,
+       runtime, provider, model, session_ref, resumable,
+       resume_status, resume_mode, resumed_at, checkpoints, usage_data,
+       started_at, completed_at, tokens_used, cost_usd,
+       actions_taken, error
+     ) VALUES (
+       ?, ?, ?, ?, ?,
+       ?, ?, ?, ?, ?,
+       ?, ?, ?, ?, ?,
+       ?, ?, ?, ?,
+       ?, ?
+     )`,
+  ).run(
+    data.id,
+    data.agent_id,
+    data.task ?? null,
+    data.instruction ?? null,
+    data.status ?? DEFAULT_STATUS,
+    data.runtime ?? null,
+    data.provider ?? null,
+    data.model ?? null,
+    data.session_ref ?? null,
+    data.resumable ?? 0,
+    data.resume_status ?? null,
+    data.resume_mode ?? null,
+    data.resumed_at ?? null,
+    data.checkpoints ?? null,
+    data.usage_data ?? null,
+    data.started_at ?? null,
+    data.completed_at ?? null,
+    data.tokens_used ?? null,
+    data.cost_usd ?? null,
+    data.actions_taken ?? null,
+    data.error ?? null,
+  );
+
+  return getRun(data.id)!;
+}
+
+export function getRun(id: string): RunRow | null {
+  const db = getDatabase();
+  const row = db.prepare(
+    `SELECT ${SELECT_COLUMNS} FROM agent_runs WHERE id = ?`,
+  ).get(id) as Record<string, unknown> | undefined;
+  return row ? toRunRow(row) : null;
+}
+
+export function listRuns(options: ListRunsOptions = {}): RunRow[] {
   const db = getDatabase();
   const { where, params } = buildRunsWhere(options);
   const limit = options.limit ?? DEFAULT_LIST_LIMIT;
@@ -228,64 +314,23 @@ export function listRuns(
   return rows.map(toRunRow);
 }
 
-/**
- * Count runs matching the given filters (no limit/offset).
- */
 export function countRuns(
   options: Omit<ListRunsOptions, 'limit' | 'offset'> = {},
 ): number {
   const db = getDatabase();
   const { where, params } = buildRunsWhere(options);
-
   const row = db.prepare(
     `SELECT COUNT(*) as count FROM agent_runs ${where}`,
   ).get(...params) as { count: number };
-
   return row.count;
 }
 
-/**
- * Update a run's status, with optional completion data.
- *
- * @returns the updated row, or null if the run does not exist.
- */
-export function updateRunStatus(
-  id: string,
-  status: string,
-  completion?: RunCompletion,
-): RunRow | null {
+export function updateRun(id: string, update: RunUpdate): RunRow | null {
   const db = getDatabase();
-
-  const setClauses: string[] = ['status = ?'];
-  const params: unknown[] = [status];
-
-  if (completion?.completed_at !== undefined) {
-    setClauses.push(`completed_at = ?`);
-    params.push(completion.completed_at);
-  }
-
-  if (completion?.tokens_used !== undefined) {
-    setClauses.push(`tokens_used = ?`);
-    params.push(completion.tokens_used);
-  }
-
-  if (completion?.cost_usd !== undefined) {
-    setClauses.push(`cost_usd = ?`);
-    params.push(completion.cost_usd);
-  }
-
-  if (completion?.actions_taken !== undefined) {
-    setClauses.push(`actions_taken = ?`);
-    params.push(completion.actions_taken);
-  }
-
-  if (completion?.error !== undefined) {
-    setClauses.push(`error = ?`);
-    params.push(completion.error);
-  }
+  const { setClauses, params } = buildUpdateClauses(update);
+  if (setClauses.length === 0) return getRun(id);
 
   params.push(id);
-
   const info = db.prepare(
     `UPDATE agent_runs
      SET ${setClauses.join(', ')}
@@ -293,22 +338,19 @@ export function updateRunStatus(
   ).run(...params);
 
   if (info.changes === 0) return null;
-
-  return toRunRow(
-    db.prepare(`SELECT ${SELECT_COLUMNS} FROM agent_runs WHERE id = ?`).get(id) as Record<string, unknown>,
-  );
+  return getRun(id);
 }
 
-/**
- * Get the currently running run for an agent, if any.
- *
- * @returns the running run row, or null if no run is active.
- */
-export function getRunningRun(
-  agentId: string,
+export function updateRunStatus(
+  id: string,
+  status: string,
+  completion?: RunCompletion,
 ): RunRow | null {
-  const db = getDatabase();
+  return updateRun(id, { status, ...completion });
+}
 
+export function getRunningRun(agentId: string): RunRow | null {
+  const db = getDatabase();
   const row = db.prepare(
     `SELECT ${SELECT_COLUMNS}
      FROM agent_runs
@@ -316,36 +358,22 @@ export function getRunningRun(
      ORDER BY started_at DESC NULLS LAST
      LIMIT 1`,
   ).get(agentId, STATUS_RUNNING) as Record<string, unknown> | undefined;
-
-  if (!row) return null;
-  return toRunRow(row);
+  return row ? toRunRow(row) : null;
 }
 
-/**
- * Check if a specific task is already running for an agent.
- *
- * @returns the run ID if running, or null.
- */
 export function getRunningRunForTask(
   agentId: string,
   taskName: string,
 ): string | null {
   const db = getDatabase();
-
   const row = db.prepare(
     `SELECT id FROM agent_runs
      WHERE agent_id = ? AND task = ? AND status = ?
      LIMIT 1`,
   ).get(agentId, taskName, STATUS_RUNNING) as { id: string } | undefined;
-
   return row?.id ?? null;
 }
 
-/**
- * Get the most recently started run for an agent, optionally filtered by task.
- *
- * @returns the run ID if found, or null.
- */
 export function getLatestRunId(
   agentId: string,
   taskName?: string,
@@ -369,4 +397,35 @@ export function getLatestRunId(
      LIMIT 1`,
   ).get(agentId) as { id: string } | undefined;
   return row?.id ?? null;
+}
+
+export function getLatestResumableRunForTask(
+  agentId: string,
+  taskName: string,
+): RunRow | null {
+  const db = getDatabase();
+  const row = db.prepare(
+    `SELECT ${SELECT_COLUMNS}
+     FROM agent_runs
+     WHERE agent_id = ?
+       AND task = ?
+       AND resumable = 1
+       AND status = ?
+     ORDER BY completed_at DESC NULLS LAST, started_at DESC NULLS LAST
+     LIMIT 1`,
+  ).get(agentId, taskName, STATUS_FAILED) as Record<string, unknown> | undefined;
+  return row ? toRunRow(row) : null;
+}
+
+export function markRunningRunsInterrupted(message: string): number {
+  const db = getDatabase();
+  const info = db.prepare(
+    `UPDATE agent_runs
+     SET status = ?,
+         resumable = 1,
+         resume_status = ?,
+         error = COALESCE(error, ?)
+     WHERE status = ?`,
+  ).run(STATUS_FAILED, RESUME_STATUS_READY, message, STATUS_RUNNING);
+  return info.changes;
 }

--- a/packages/myco/src/db/schema-ddl.ts
+++ b/packages/myco/src/db/schema-ddl.ts
@@ -276,6 +276,10 @@ const AGENT_RUNS_TABLE = `
     completed_at   INTEGER,
     tokens_used    INTEGER,
     cost_usd       REAL,
+    actual_cost_usd REAL,
+    estimated_cost_usd REAL,
+    cost_source    TEXT,
+    cost_data      TEXT,
     actions_taken  TEXT,
     error          TEXT
   )`;

--- a/packages/myco/src/db/schema-ddl.ts
+++ b/packages/myco/src/db/schema-ddl.ts
@@ -257,17 +257,27 @@ const DIGEST_EXTRACTS_TABLE = `
 
 const AGENT_RUNS_TABLE = `
   CREATE TABLE IF NOT EXISTS agent_runs (
-    id            TEXT PRIMARY KEY,
-    agent_id      TEXT NOT NULL REFERENCES agents(id),
-    task          TEXT,
-    instruction   TEXT,
-    status        TEXT DEFAULT 'pending',
-    started_at    INTEGER,
-    completed_at  INTEGER,
-    tokens_used   INTEGER,
-    cost_usd      REAL,
-    actions_taken TEXT,
-    error         TEXT
+    id             TEXT PRIMARY KEY,
+    agent_id       TEXT NOT NULL REFERENCES agents(id),
+    task           TEXT,
+    instruction    TEXT,
+    status         TEXT DEFAULT 'pending',
+    runtime        TEXT,
+    provider       TEXT,
+    model          TEXT,
+    session_ref    TEXT,
+    resumable      INTEGER DEFAULT 0,
+    resume_status  TEXT,
+    resume_mode    TEXT,
+    resumed_at     INTEGER,
+    checkpoints    TEXT,
+    usage_data     TEXT,
+    started_at     INTEGER,
+    completed_at   INTEGER,
+    tokens_used    INTEGER,
+    cost_usd       REAL,
+    actions_taken  TEXT,
+    error          TEXT
   )`;
 
 const AGENT_REPORTS_TABLE = `

--- a/packages/myco/src/db/schema.ts
+++ b/packages/myco/src/db/schema.ts
@@ -19,7 +19,7 @@ import { TABLE_DDLS, FTS_TABLES, SECONDARY_INDEXES } from './schema-ddl.js';
 import { MIGRATIONS } from './migrations.js';
 
 /** Current schema version -- fresh start for the SQLite era. */
-export const SCHEMA_VERSION = 13;
+export const SCHEMA_VERSION = 14;
 
 // Re-export for backwards compat (other modules import from schema.ts)
 export { DEFAULT_MACHINE_ID };

--- a/packages/myco/src/db/schema.ts
+++ b/packages/myco/src/db/schema.ts
@@ -19,7 +19,7 @@ import { TABLE_DDLS, FTS_TABLES, SECONDARY_INDEXES } from './schema-ddl.js';
 import { MIGRATIONS } from './migrations.js';
 
 /** Current schema version -- fresh start for the SQLite era. */
-export const SCHEMA_VERSION = 12;
+export const SCHEMA_VERSION = 13;
 
 // Re-export for backwards compat (other modules import from schema.ts)
 export { DEFAULT_MACHINE_ID };

--- a/packages/myco/src/intelligence/lm-studio.ts
+++ b/packages/myco/src/intelligence/lm-studio.ts
@@ -223,6 +223,10 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
     }
   }
 
+  getLoadedInstanceId(): string | null {
+    return this.instanceId;
+  }
+
   /**
    * Query the LM Studio native API for loaded instances of this model.
    * Returns an empty array if the API is unavailable or the model has no loaded instances.

--- a/packages/myco/src/intelligence/local-openai-backends.ts
+++ b/packages/myco/src/intelligence/local-openai-backends.ts
@@ -1,0 +1,100 @@
+import { LmStudioBackend } from './lm-studio.js';
+import { OllamaBackend } from './ollama.js';
+
+export type LocalOpenAIBackendKind = 'ollama' | 'lmstudio';
+
+const LOCALHOST_NAMES = new Set(['localhost', '127.0.0.1', '::1']);
+
+const LOCAL_OPENAI_BACKEND_RULES: Array<{
+  kind: LocalOpenAIBackendKind;
+  matches: (input: {
+    type?: string;
+    localBackend?: LocalOpenAIBackendKind;
+    baseUrl?: string;
+  }) => boolean;
+}> = [
+  {
+    kind: 'ollama',
+    matches: ({ localBackend }) => localBackend === 'ollama',
+  },
+  {
+    kind: 'lmstudio',
+    matches: ({ localBackend }) => localBackend === 'lmstudio',
+  },
+  {
+    kind: 'ollama',
+    matches: ({ type }) => type === 'ollama',
+  },
+  {
+    kind: 'lmstudio',
+    matches: ({ type }) => type === 'lmstudio',
+  },
+  {
+    kind: 'ollama',
+    matches: ({ type, baseUrl }) => type === 'openai-compatible' && hasLocalPort(baseUrl, '11434'),
+  },
+  {
+    kind: 'lmstudio',
+    matches: ({ type, baseUrl }) => type === 'openai-compatible' && hasLocalPort(baseUrl, '1234'),
+  },
+];
+
+type LocalBackendInstance = OllamaBackend | LmStudioBackend;
+
+interface LocalBackendDefinition {
+  defaultBaseUrl: string;
+  label: string;
+  create: (baseUrl?: string) => LocalBackendInstance;
+}
+
+const LOCAL_BACKEND_DEFINITIONS: Record<LocalOpenAIBackendKind, LocalBackendDefinition> = {
+  ollama: {
+    defaultBaseUrl: OllamaBackend.DEFAULT_BASE_URL,
+    label: 'Ollama',
+    create: (baseUrl) => new OllamaBackend({ base_url: baseUrl }),
+  },
+  lmstudio: {
+    defaultBaseUrl: LmStudioBackend.DEFAULT_BASE_URL,
+    label: 'LM Studio',
+    create: (baseUrl) => new LmStudioBackend({ base_url: baseUrl }),
+  },
+};
+
+function tryParseUrl(value: string | undefined): URL | null {
+  if (!value) return null;
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+function hasLocalPort(baseUrl: string | undefined, port: string): boolean {
+  const url = tryParseUrl(baseUrl);
+  return !!url && LOCALHOST_NAMES.has(url.hostname) && url.port === port;
+}
+
+export function inferLocalOpenAIBackendKind(input: {
+  type?: string;
+  localBackend?: LocalOpenAIBackendKind;
+  baseUrl?: string;
+}): LocalOpenAIBackendKind | null {
+  for (const rule of LOCAL_OPENAI_BACKEND_RULES) {
+    if (rule.matches(input)) {
+      return rule.kind;
+    }
+  }
+  return null;
+}
+
+export function getLocalOpenAIBackendDefaultBaseUrl(kind: LocalOpenAIBackendKind): string {
+  return LOCAL_BACKEND_DEFINITIONS[kind].defaultBaseUrl;
+}
+
+export function getLocalOpenAIBackendLabel(kind: LocalOpenAIBackendKind): string {
+  return LOCAL_BACKEND_DEFINITIONS[kind].label;
+}
+
+export function createLocalOpenAIBackend(kind: LocalOpenAIBackendKind, baseUrl?: string): LocalBackendInstance {
+  return LOCAL_BACKEND_DEFINITIONS[kind].create(baseUrl);
+}

--- a/packages/myco/ui/package-lock.json
+++ b/packages/myco/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@goondocks/myco-ui",
-  "version": "0.20.0",
+  "version": "0.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@goondocks/myco-ui",
-      "version": "0.20.0",
+      "version": "0.20.2",
       "dependencies": {
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1"

--- a/packages/myco/ui/src/components/agent/PhaseTimeline.tsx
+++ b/packages/myco/ui/src/components/agent/PhaseTimeline.tsx
@@ -15,6 +15,7 @@ export interface PhaseResult {
   turnsUsed: number;
   tokensUsed: number;
   costUsd: number;
+  costSource?: 'actual' | 'estimated' | 'unavailable';
   summary: string;
 }
 
@@ -67,7 +68,7 @@ export function PhaseTimeline({ phases }: PhaseTimelineProps) {
               <div className="flex gap-3 font-mono text-xs text-on-surface-variant">
                 <span>{phase.turnsUsed} turns</span>
                 <span>{formatTokens(phase.tokensUsed)}</span>
-                <span>{formatCost(phase.costUsd)}</span>
+                <span>{formatCost(phase.costUsd, phase.costSource ?? null)}</span>
               </div>
             </div>
             {phase.summary && <PhaseSummary text={phase.summary} />}

--- a/packages/myco/ui/src/components/agent/RunDetail.tsx
+++ b/packages/myco/ui/src/components/agent/RunDetail.tsx
@@ -42,6 +42,50 @@ function truncatePreview(text: string | null, limit: number): string {
   return truncate(text, limit) || '\u2014';
 }
 
+function parseJson<T>(raw: string | null | undefined): T | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+interface ParsedCostData {
+  source: 'actual' | 'estimated' | 'unavailable';
+  costUsd: number | null;
+  actualCostUsd: number | null;
+  estimatedCostUsd: number | null;
+  pricingVersion?: string | null;
+  message?: string | null;
+  breakdown: {
+    inputTokens: number;
+    cachedInputTokens: number;
+    uncachedInputTokens: number;
+    outputTokens: number;
+    reasoningTokens: number;
+    requestCount: number;
+    inputCostUsd?: number;
+    cachedInputCostUsd?: number;
+    outputCostUsd?: number;
+    reasoningCostUsd?: number;
+    requestCostUsd?: number;
+    totalCostUsd?: number;
+    cacheSavingsUsd?: number;
+  };
+}
+
+interface ParsedUsageData {
+  run?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    reasoningTokens?: number;
+    cachedTokens?: number;
+    requests?: number;
+  };
+}
+
 /* ---------- Sub-components ---------- */
 
 function ReportCard({ report }: { report: ReportRow }) {
@@ -181,6 +225,14 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
   const { data: tasksData } = useAgentTasks();
   const resumeMutation = useResumeRun();
   const tasksList = useMemo(() => tasksData?.tasks ?? [], [tasksData]);
+  const parsedCost = useMemo(
+    () => parseJson<ParsedCostData>(runData?.run?.cost_data),
+    [runData?.run?.cost_data],
+  );
+  const parsedUsage = useMemo(
+    () => parseJson<ParsedUsageData>(runData?.run?.usage_data),
+    [runData?.run?.usage_data],
+  );
 
   if (runLoading) {
     return (
@@ -209,19 +261,13 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
   const run = runData.run;
   const reports = reportsData?.reports ?? [];
   const turns = turnsData ?? [];
-
-  // Parse run metadata and phase results from actions_taken
-  let phaseResults: PhaseResult[] | null = null;
-  if (run.actions_taken) {
-    try {
-      const parsed = JSON.parse(run.actions_taken) as Record<string, unknown>;
-      if (parsed?.phases && Array.isArray(parsed.phases)) {
-        phaseResults = parsed.phases as PhaseResult[];
-      }
-    } catch {
-      // Malformed JSON -- silently ignore
-    }
-  }
+  const costCardLabel = run.cost_source === 'estimated' ? 'Estimated Cost' : 'Cost';
+  const phaseResults = useMemo(() => {
+    const parsed = parseJson<Record<string, unknown>>(run.actions_taken);
+    return parsed?.phases && Array.isArray(parsed.phases)
+      ? parsed.phases as PhaseResult[]
+      : null;
+  }, [run.actions_taken]);
 
   return (
     <div className="space-y-6">
@@ -238,7 +284,7 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
         <StatCard label="Started" value={formatEpochRelative(run.started_at)} accent="outline" />
         <StatCard label="Duration" value={formatDuration(run.started_at, run.completed_at)} accent="outline" />
         <StatCard label="Tokens" value={formatTokens(run.tokens_used)} accent="ochre" />
-        <StatCard label="Cost" value={formatCost(run.cost_usd)} accent="ochre" />
+        <StatCard label={costCardLabel} value={formatCost(run.cost_usd, run.cost_source)} accent="ochre" />
       </div>
 
       {run.resumable && run.status === 'failed' && (
@@ -275,7 +321,49 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
               Model: <span className="font-mono text-on-surface">{run.model}</span>
             </span>
           )}
+          {run.cost_source && run.cost_source !== 'unavailable' && (
+            <span className="font-sans text-xs text-on-surface-variant">
+              Cost source: <span className="font-mono text-on-surface">{run.cost_source}</span>
+            </span>
+          )}
         </div>
+      )}
+
+      {(parsedCost || parsedUsage?.run) && (
+        <Surface level="low" className="p-4 space-y-3">
+          <h2 className="font-sans text-sm font-medium text-on-surface-variant uppercase tracking-wide">
+            Cost Diagnostics
+          </h2>
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
+            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
+              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Input</p>
+              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedCost?.breakdown.inputTokens ?? parsedUsage?.run?.inputTokens ?? null)}</p>
+            </div>
+            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
+              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Cached Input</p>
+              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedCost?.breakdown.cachedInputTokens ?? parsedUsage?.run?.cachedTokens ?? null)}</p>
+            </div>
+            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
+              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Uncached Input</p>
+              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedCost?.breakdown.uncachedInputTokens ?? null)}</p>
+            </div>
+            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
+              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Output</p>
+              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedCost?.breakdown.outputTokens ?? parsedUsage?.run?.outputTokens ?? null)}</p>
+            </div>
+            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
+              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Requests</p>
+              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedCost?.breakdown.requestCount ?? parsedUsage?.run?.requests ?? null)}</p>
+            </div>
+            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
+              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Cache Savings</p>
+              <p className="font-mono text-sm text-on-surface">{formatCost(parsedCost?.breakdown.cacheSavingsUsd ?? null, 'estimated')}</p>
+            </div>
+          </div>
+          {parsedCost?.message && (
+            <p className="font-sans text-xs text-on-surface-variant">{parsedCost.message}</p>
+          )}
+        </Surface>
       )}
 
       {run.error && (
@@ -301,7 +389,9 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
               <div key={phase.name} className="flex items-center justify-between gap-3 rounded-md bg-surface-container-lowest px-3 py-2">
                 <div>
                   <p className="font-sans text-sm text-on-surface">{phase.name}</p>
-                  <p className="font-mono text-xs text-on-surface-variant">{phase.status}</p>
+                  <p className="font-mono text-xs text-on-surface-variant">
+                    {phase.status}{phase.costSource ? ` • ${phase.costSource}` : ''}
+                  </p>
                 </div>
                 <p className="font-mono text-xs text-on-surface-variant">{formatEpochRelative(Math.floor(phase.updatedAt))}</p>
               </div>

--- a/packages/myco/ui/src/components/agent/RunDetail.tsx
+++ b/packages/myco/ui/src/components/agent/RunDetail.tsx
@@ -233,6 +233,12 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
     () => parseJson<ParsedUsageData>(runData?.run?.usage_data),
     [runData?.run?.usage_data],
   );
+  const phaseResults = useMemo(() => {
+    const parsed = parseJson<Record<string, unknown>>(runData?.run?.actions_taken);
+    return parsed?.phases && Array.isArray(parsed.phases)
+      ? parsed.phases as PhaseResult[]
+      : null;
+  }, [runData?.run?.actions_taken]);
 
   if (runLoading) {
     return (
@@ -262,12 +268,6 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
   const reports = reportsData?.reports ?? [];
   const turns = turnsData ?? [];
   const costCardLabel = run.cost_source === 'estimated' ? 'Estimated Cost' : 'Cost';
-  const phaseResults = useMemo(() => {
-    const parsed = parseJson<Record<string, unknown>>(run.actions_taken);
-    return parsed?.phases && Array.isArray(parsed.phases)
-      ? parsed.phases as PhaseResult[]
-      : null;
-  }, [run.actions_taken]);
 
   return (
     <div className="space-y-6">

--- a/packages/myco/ui/src/components/agent/RunDetail.tsx
+++ b/packages/myco/ui/src/components/agent/RunDetail.tsx
@@ -5,7 +5,7 @@ import { Badge } from '../ui/badge';
 import { Surface } from '../ui/surface';
 import { StatCard } from '../ui/stat-card';
 import { MarkdownContent } from '../ui/markdown-content';
-import { useAgentRun, useAgentReports, useAgentTurns, useAgentTasks, type ReportRow, type TurnRow } from '../../hooks/use-agent';
+import { useAgentRun, useAgentReports, useAgentTurns, useAgentTasks, useResumeRun, type ReportRow, type TurnRow } from '../../hooks/use-agent';
 import { cn } from '../../lib/cn';
 import { formatEpochRelative, truncate, capitalize } from '../../lib/format';
 import { formatCost, formatTokens, formatDuration, resolveTaskName } from './helpers';
@@ -179,6 +179,7 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
   const { data: reportsData, isLoading: reportsLoading } = useAgentReports(runId, runStatus);
   const { data: turnsData, isLoading: turnsLoading } = useAgentTurns(showAudit ? runId : undefined, runStatus);
   const { data: tasksData } = useAgentTasks();
+  const resumeMutation = useResumeRun();
   const tasksList = useMemo(() => tasksData?.tasks ?? [], [tasksData]);
 
   if (runLoading) {
@@ -211,16 +212,12 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
 
   // Parse run metadata and phase results from actions_taken
   let phaseResults: PhaseResult[] | null = null;
-  let runModel: string | undefined;
-  let runProvider: string | undefined;
   if (run.actions_taken) {
     try {
       const parsed = JSON.parse(run.actions_taken) as Record<string, unknown>;
       if (parsed?.phases && Array.isArray(parsed.phases)) {
         phaseResults = parsed.phases as PhaseResult[];
       }
-      if (typeof parsed?.model === 'string') runModel = parsed.model as string;
-      if (typeof parsed?.provider === 'string') runProvider = parsed.provider as string;
     } catch {
       // Malformed JSON -- silently ignore
     }
@@ -244,17 +241,38 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
         <StatCard label="Cost" value={formatCost(run.cost_usd)} accent="ochre" />
       </div>
 
+      {run.resumable && run.status === 'failed' && (
+        <div className="flex items-center gap-3">
+          <Button
+            size="sm"
+            onClick={() => resumeMutation.mutate({ runId: run.id, mode: 'manual' })}
+            disabled={resumeMutation.isPending}
+          >
+            {resumeMutation.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+            Resume Run
+          </Button>
+          <span className="font-sans text-xs text-on-surface-variant">
+            Resume status: {run.resume_status ?? 'ready'}
+          </span>
+        </div>
+      )}
+
       {/* Model / Provider info */}
-      {(runModel || runProvider) && (
+      {(run.runtime || run.provider || run.model) && (
         <div className="flex items-center gap-4 px-1">
-          {runProvider && (
+          {run.runtime && (
             <span className="font-sans text-xs text-on-surface-variant">
-              Provider: <span className="font-mono text-on-surface">{runProvider}</span>
+              Runtime: <span className="font-mono text-on-surface">{run.runtime}</span>
             </span>
           )}
-          {runModel && (
+          {run.provider && (
             <span className="font-sans text-xs text-on-surface-variant">
-              Model: <span className="font-mono text-on-surface">{runModel}</span>
+              Provider: <span className="font-mono text-on-surface">{run.provider}</span>
+            </span>
+          )}
+          {run.model && (
+            <span className="font-sans text-xs text-on-surface-variant">
+              Model: <span className="font-mono text-on-surface">{run.model}</span>
             </span>
           )}
         </div>
@@ -270,6 +288,25 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
       {phaseResults && phaseResults.length > 0 && (
         <Surface level="low" className="p-4">
           <PhaseTimeline phases={phaseResults} />
+        </Surface>
+      )}
+
+      {run.phase_checkpoints && run.phase_checkpoints.length > 0 && (
+        <Surface level="low" className="p-4 space-y-2">
+          <h2 className="font-sans text-sm font-medium text-on-surface-variant uppercase tracking-wide">
+            Checkpoints
+          </h2>
+          <div className="space-y-2">
+            {run.phase_checkpoints.map((phase) => (
+              <div key={phase.name} className="flex items-center justify-between gap-3 rounded-md bg-surface-container-lowest px-3 py-2">
+                <div>
+                  <p className="font-sans text-sm text-on-surface">{phase.name}</p>
+                  <p className="font-mono text-xs text-on-surface-variant">{phase.status}</p>
+                </div>
+                <p className="font-mono text-xs text-on-surface-variant">{formatEpochRelative(Math.floor(phase.updatedAt))}</p>
+              </div>
+            ))}
+          </div>
         </Surface>
       )}
 

--- a/packages/myco/ui/src/components/agent/RunList.tsx
+++ b/packages/myco/ui/src/components/agent/RunList.tsx
@@ -85,7 +85,12 @@ function RunRowItem({
         </div>
       </td>
       <td className="px-4 py-3">
-        <RunStatusBadge status={run.status} />
+        <div className="flex items-center gap-2">
+          <RunStatusBadge status={run.status} />
+          {run.resumable && run.status === 'failed' && (
+            <span className="font-sans text-[10px] uppercase tracking-wide text-secondary">resumable</span>
+          )}
+        </div>
       </td>
       <td className="px-4 py-3 text-xs text-on-surface-variant font-mono">
         {formatEpochRelative(run.started_at)}

--- a/packages/myco/ui/src/components/agent/RunList.tsx
+++ b/packages/myco/ui/src/components/agent/RunList.tsx
@@ -102,7 +102,12 @@ function RunRowItem({
         {formatTokens(run.tokens_used)}
       </td>
       <td className="px-4 py-3 text-xs text-on-surface-variant font-mono">
-        {formatCost(run.cost_usd)}
+        <div className="flex items-center gap-2">
+          <span>{formatCost(run.cost_usd, run.cost_source)}</span>
+          {run.cost_source === 'estimated' && (
+            <span className="font-sans text-[10px] uppercase tracking-wide text-secondary">est</span>
+          )}
+        </div>
       </td>
     </tr>
   );

--- a/packages/myco/ui/src/components/agent/TaskDetail.tsx
+++ b/packages/myco/ui/src/components/agent/TaskDetail.tsx
@@ -6,7 +6,7 @@ import { Surface } from '../ui/surface';
 import { MarkdownContent } from '../ui/markdown-content';
 import { useTask, type PhaseDefinition } from '../../hooks/use-agent';
 import { useScopedConfig } from '../../hooks/use-scoped-config';
-import { inferRuntimeFromProviderType, resolveReasoningModel } from '../../hooks/use-providers';
+import { maybeInferRuntimeFromProviderType, resolveReasoningModel } from '../../hooks/use-providers';
 import { capitalize } from '../../lib/format';
 import { sourceBadgeVariant } from './helpers';
 import { TaskActions } from './TaskActions';
@@ -97,9 +97,9 @@ function getInheritedExecution(
   return {
     runtime: task.execution?.runtime
       ?? taskProvider?.runtime
-      ?? inferRuntimeFromProviderType(taskProvider?.type as Parameters<typeof inferRuntimeFromProviderType>[0])
+      ?? maybeInferRuntimeFromProviderType(taskProvider?.type)
       ?? globalProvider?.runtime
-      ?? inferRuntimeFromProviderType(globalProvider?.type as Parameters<typeof inferRuntimeFromProviderType>[0])
+      ?? maybeInferRuntimeFromProviderType(globalProvider?.type)
       ?? config?.agent?.runtime,
     providerType: taskProvider?.type ?? globalProvider?.type,
     reasoningLevel,

--- a/packages/myco/ui/src/components/agent/TaskDetail.tsx
+++ b/packages/myco/ui/src/components/agent/TaskDetail.tsx
@@ -61,6 +61,7 @@ function getInheritedExecution(
       provider?: {
         runtime?: string;
         type?: string;
+        local_backend?: 'ollama' | 'lmstudio';
         model?: string;
         reasoning_map?: Partial<Record<'low' | 'default' | 'high', string>>;
         base_url?: string;
@@ -82,6 +83,7 @@ function getInheritedExecution(
       provider?: {
         runtime?: string;
         type?: string;
+        local_backend?: 'ollama' | 'lmstudio';
         model?: string;
         reasoning_map?: Partial<Record<'low' | 'default' | 'high', string>>;
         base_url?: string;
@@ -102,6 +104,7 @@ function getInheritedExecution(
       ?? maybeInferRuntimeFromProviderType(globalProvider?.type)
       ?? config?.agent?.runtime,
     providerType: taskProvider?.type ?? globalProvider?.type,
+    localBackend: taskProvider?.local_backend ?? globalProvider?.local_backend,
     reasoningLevel,
     model: resolveReasoningModel(reasoningLevel, taskProvider ?? globalProvider, fallbackModel),
     reasoningMap: taskProvider?.reasoning_map ?? globalProvider?.reasoning_map,
@@ -188,6 +191,7 @@ export function TaskDetail({ taskId, onBack, onNavigate, onRunTriggered }: TaskD
   const taskConfigDefaults = useMemo(() => ({
     runtime: inheritedExecution.runtime,
     providerType: inheritedExecution.providerType,
+    localBackend: inheritedExecution.localBackend,
     reasoningLevel: inheritedExecution.reasoningLevel,
     reasoningMap: inheritedExecution.reasoningMap,
     model: inheritedExecution.model,
@@ -198,6 +202,7 @@ export function TaskDetail({ taskId, onBack, onNavigate, onRunTriggered }: TaskD
   }), [
     inheritedExecution.runtime,
     inheritedExecution.providerType,
+    inheritedExecution.localBackend,
     inheritedExecution.reasoningLevel,
     inheritedExecution.reasoningMap,
     inheritedExecution.model,

--- a/packages/myco/ui/src/components/agent/TaskDetail.tsx
+++ b/packages/myco/ui/src/components/agent/TaskDetail.tsx
@@ -1,9 +1,12 @@
+import { useMemo } from 'react';
 import { ArrowLeft, AlertCircle } from 'lucide-react';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { Surface } from '../ui/surface';
 import { MarkdownContent } from '../ui/markdown-content';
 import { useTask, type PhaseDefinition } from '../../hooks/use-agent';
+import { useScopedConfig } from '../../hooks/use-scoped-config';
+import { inferRuntimeFromProviderType, resolveReasoningModel } from '../../hooks/use-providers';
 import { capitalize } from '../../lib/format';
 import { sourceBadgeVariant } from './helpers';
 import { TaskActions } from './TaskActions';
@@ -27,9 +30,83 @@ interface TaskDetailProps {
 /* ---------- Helpers ---------- */
 
 /** Resolve effective execution config from task fields. */
-function getExecution(task: { execution?: { model?: string; maxTurns?: number; timeoutSeconds?: number }; model?: string; maxTurns?: number; timeoutSeconds?: number }) {
+function getExecution(task: {
+  execution?: {
+    runtime?: string;
+    provider?: { type?: string };
+    model?: string;
+    reasoningLevel?: 'low' | 'default' | 'high';
+    maxTurns?: number;
+    timeoutSeconds?: number;
+  };
+  model?: string;
+  reasoningLevel?: 'low' | 'default' | 'high';
+  maxTurns?: number;
+  timeoutSeconds?: number;
+}) {
   return {
+    runtime: task.execution?.runtime,
+    provider: task.execution?.provider?.type,
     model: task.execution?.model ?? task.model,
+    reasoningLevel: task.execution?.reasoningLevel ?? task.reasoningLevel,
+    maxTurns: task.execution?.maxTurns ?? task.maxTurns,
+    timeoutSeconds: task.execution?.timeoutSeconds ?? task.timeoutSeconds,
+  };
+}
+
+function getInheritedExecution(
+  task: {
+    execution?: {
+      runtime?: string;
+      provider?: {
+        runtime?: string;
+        type?: string;
+        model?: string;
+        reasoning_map?: Partial<Record<'low' | 'default' | 'high', string>>;
+        base_url?: string;
+        context_length?: number;
+      };
+      model?: string;
+      reasoningLevel?: 'low' | 'default' | 'high';
+      maxTurns?: number;
+      timeoutSeconds?: number;
+    };
+    model?: string;
+    reasoningLevel?: 'low' | 'default' | 'high';
+    maxTurns?: number;
+    timeoutSeconds?: number;
+  },
+  config: {
+    agent?: {
+      runtime?: string;
+      provider?: {
+        runtime?: string;
+        type?: string;
+        model?: string;
+        reasoning_map?: Partial<Record<'low' | 'default' | 'high', string>>;
+        base_url?: string;
+        context_length?: number;
+      };
+    };
+  } | undefined,
+) {
+  const globalProvider = config?.agent?.provider;
+  const taskProvider = task.execution?.provider;
+  const reasoningLevel = task.execution?.reasoningLevel ?? task.reasoningLevel;
+  const fallbackModel = task.execution?.model ?? task.model ?? globalProvider?.model;
+  return {
+    runtime: task.execution?.runtime
+      ?? taskProvider?.runtime
+      ?? inferRuntimeFromProviderType(taskProvider?.type as Parameters<typeof inferRuntimeFromProviderType>[0])
+      ?? globalProvider?.runtime
+      ?? inferRuntimeFromProviderType(globalProvider?.type as Parameters<typeof inferRuntimeFromProviderType>[0])
+      ?? config?.agent?.runtime,
+    providerType: taskProvider?.type ?? globalProvider?.type,
+    reasoningLevel,
+    model: resolveReasoningModel(reasoningLevel, taskProvider ?? globalProvider, fallbackModel),
+    reasoningMap: taskProvider?.reasoning_map ?? globalProvider?.reasoning_map,
+    baseUrl: taskProvider?.base_url ?? globalProvider?.base_url,
+    contextLength: taskProvider?.context_length ?? globalProvider?.context_length,
     maxTurns: task.execution?.maxTurns ?? task.maxTurns,
     timeoutSeconds: task.execution?.timeoutSeconds ?? task.timeoutSeconds,
   };
@@ -73,6 +150,12 @@ function PhaseCard({ phase, index }: { phase: PhaseDefinition; index: number }) 
         </span>
       </div>
 
+      {phase.reasoningLevel && (
+        <div className="flex items-center gap-2">
+          <Badge variant="secondary">reasoning {phase.reasoningLevel}</Badge>
+        </div>
+      )}
+
       {phase.tools.length > 0 && (
         <div className="flex flex-wrap gap-1">
           {phase.tools.map((tool) => (
@@ -97,6 +180,32 @@ function PhaseCard({ phase, index }: { phase: PhaseDefinition; index: number }) 
 
 export function TaskDetail({ taskId, onBack, onNavigate, onRunTriggered }: TaskDetailProps) {
   const { data, isPending, isError } = useTask(taskId);
+  const { effective } = useScopedConfig();
+  const task = data?.task;
+  const phases: PhaseDefinition[] = task?.phases ?? [];
+  const execution = task ? getExecution(task) : {};
+  const inheritedExecution = task ? getInheritedExecution(task, effective) : {};
+  const taskConfigDefaults = useMemo(() => ({
+    runtime: inheritedExecution.runtime,
+    providerType: inheritedExecution.providerType,
+    reasoningLevel: inheritedExecution.reasoningLevel,
+    reasoningMap: inheritedExecution.reasoningMap,
+    model: inheritedExecution.model,
+    baseUrl: inheritedExecution.baseUrl,
+    contextLength: inheritedExecution.contextLength,
+    maxTurns: inheritedExecution.maxTurns,
+    timeoutSeconds: inheritedExecution.timeoutSeconds,
+  }), [
+    inheritedExecution.runtime,
+    inheritedExecution.providerType,
+    inheritedExecution.reasoningLevel,
+    inheritedExecution.reasoningMap,
+    inheritedExecution.model,
+    inheritedExecution.baseUrl,
+    inheritedExecution.contextLength,
+    inheritedExecution.maxTurns,
+    inheritedExecution.timeoutSeconds,
+  ]);
 
   if (isPending) {
     return <SkeletonDetail />;
@@ -116,10 +225,6 @@ export function TaskDetail({ taskId, onBack, onNavigate, onRunTriggered }: TaskD
       </div>
     );
   }
-
-  const task = data.task;
-  const phases: PhaseDefinition[] = task.phases ?? [];
-  const execution = getExecution(task);
 
   return (
     <div className="space-y-6">
@@ -158,22 +263,40 @@ export function TaskDetail({ taskId, onBack, onNavigate, onRunTriggered }: TaskD
       <TaskProviderConfig
         taskId={taskId}
         phases={phases}
-        defaults={{ model: execution.model, maxTurns: execution.maxTurns, timeoutSeconds: execution.timeoutSeconds }}
+        defaults={taskConfigDefaults}
         schedule={task.schedule}
         params={task.params}
       />
 
-      {/* Execution config */}
-      {(execution.model !== undefined || execution.maxTurns !== undefined || execution.timeoutSeconds !== undefined) && (
+      {/* Definition defaults */}
+      {(execution.model !== undefined || execution.reasoningLevel !== undefined || execution.maxTurns !== undefined || execution.timeoutSeconds !== undefined) && (
         <Surface level="low" className="p-4 space-y-3">
           <h2 className="font-sans text-sm font-medium text-on-surface-variant uppercase tracking-wide">
-            Execution Config
+            Task Definition
           </h2>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            {execution.runtime !== undefined && (
+              <div>
+                <p className="font-sans text-xs text-on-surface-variant">Runtime</p>
+                <p className="font-mono text-sm text-on-surface mt-0.5">{execution.runtime}</p>
+              </div>
+            )}
+            {execution.provider !== undefined && (
+              <div>
+                <p className="font-sans text-xs text-on-surface-variant">Provider</p>
+                <p className="font-mono text-sm text-on-surface mt-0.5">{execution.provider}</p>
+              </div>
+            )}
             {execution.model !== undefined && (
               <div>
                 <p className="font-sans text-xs text-on-surface-variant">Model</p>
                 <p className="font-mono text-sm text-on-surface mt-0.5">{execution.model}</p>
+              </div>
+            )}
+            {execution.reasoningLevel !== undefined && (
+              <div>
+                <p className="font-sans text-xs text-on-surface-variant">Reasoning</p>
+                <p className="font-mono text-sm text-on-surface mt-0.5">{execution.reasoningLevel}</p>
               </div>
             )}
             {execution.maxTurns !== undefined && (

--- a/packages/myco/ui/src/components/agent/TaskList.tsx
+++ b/packages/myco/ui/src/components/agent/TaskList.tsx
@@ -66,9 +66,9 @@ function TaskCard({ task, onClick }: { task: TaskRow; onClick: () => void }) {
           <span className="font-mono text-xs">{formatPhaseCount(task)}</span>
         </div>
 
-        {task.model && (
+        {task.reasoningLevel && (
           <span className="font-mono text-xs text-on-surface-variant/70 truncate max-w-[160px]">
-            {task.model}
+            reasoning {task.reasoningLevel}
           </span>
         )}
 

--- a/packages/myco/ui/src/components/agent/TaskProviderConfig.tsx
+++ b/packages/myco/ui/src/components/agent/TaskProviderConfig.tsx
@@ -15,6 +15,7 @@ import {
 import { SearchableSelect } from '../ui/searchable-select';
 import { ProviderModelSelector } from '../providers/ProviderModelSelector';
 import {
+  defaultBaseUrlForProvider,
   useProviders,
   useTaskConfig,
   useTestProvider,
@@ -49,6 +50,7 @@ interface TaskProviderConfigProps {
   defaults?: {
     runtime?: string;
     providerType?: string;
+    localBackend?: 'ollama' | 'lmstudio';
     reasoningLevel?: 'low' | 'default' | 'high';
     reasoningMap?: Partial<Record<'low' | 'default' | 'high', string>>;
     model?: string;
@@ -115,6 +117,7 @@ function PhaseConfigRow({
             <ProviderModelSelector
               runtime={override.provider?.runtime ?? taskRuntime}
               providerType={override.provider?.type ?? taskProviderType}
+              localBackend={override.provider?.local_backend ?? ''}
               model={override.provider?.model ?? override.model ?? ''}
               baseUrl={override.provider?.base_url ?? ''}
               contextLength={override.provider?.context_length != null ? String(override.provider.context_length) : ''}
@@ -135,6 +138,10 @@ function PhaseConfigRow({
                   model: undefined,
                 });
               }}
+              onLocalBackendChange={(localBackend) => onChange({
+                ...override,
+                provider: override.provider ? { ...override.provider, local_backend: localBackend || undefined } : undefined,
+              })}
               onModelChange={(m) => onChange({
                 ...override,
                 provider: override.provider ? { ...override.provider, model: m } : undefined,
@@ -223,6 +230,7 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
   const providerDraftDefaults = {
     runtime: defaults?.runtime,
     providerType: defaults?.providerType,
+    localBackend: defaults?.localBackend,
     model: defaults?.model,
     reasoningMap: defaults?.reasoningMap,
     baseUrl: defaults?.baseUrl,
@@ -235,6 +243,7 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
     handleRuntimeChange: handleDraftRuntimeChange,
     handleProviderChange: handleDraftProviderChange,
     handleModelChange: handleDraftModelChange,
+    handleLocalBackendChange: handleDraftLocalBackendChange,
     handleReasoningChange: handleDraftReasoningChange,
     handleBaseUrlChange: handleDraftBaseUrlChange,
     handleContextLengthChange: handleDraftContextLengthChange,
@@ -255,7 +264,8 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
   const reasoningHigh = draft.reasoningHigh;
   const baseUrl = draft.baseUrl;
   const contextLength = draft.contextLength;
-  const reasoningModelsQuery = useModels(providerType || null, baseUrl || undefined, 'llm');
+  const resolvedTaskBaseUrl = baseUrl || defaultBaseUrlForProvider(providerType, draft.localBackend);
+  const reasoningModelsQuery = useModels(providerType || null, resolvedTaskBaseUrl || undefined, 'llm', draft.localBackend || null);
   const reasoningModels = reasoningModelsQuery.data?.models ?? providers.find((provider) => provider.type === providerType)?.models ?? [];
   const effectiveRuntime = runtime
     || maybeInferRuntimeFromProviderType(providerType)
@@ -391,6 +401,7 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
     const config: ProviderConfig = {
       runtime: effectiveRuntime as ProviderConfig['runtime'],
       type: providerType as ProviderConfig['type'],
+      ...(providerType === 'openai-compatible' && draft.localBackend ? { local_backend: draft.localBackend } : {}),
       ...(isLocal && baseUrl ? { base_url: baseUrl } : {}),
     };
     testMutation.mutate(config);
@@ -413,6 +424,7 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
       <ProviderModelSelector
         runtime={effectiveRuntime}
         providerType={providerType}
+        localBackend={draft.localBackend}
         model={model}
         baseUrl={baseUrl}
         contextLength={contextLength}
@@ -423,6 +435,7 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
           handleDraftRuntimeChange(nextRuntime);
         }}
         onProviderChange={handleProviderChange}
+        onLocalBackendChange={handleDraftLocalBackendChange}
         onModelChange={handleDraftModelChange}
         onBaseUrlChange={handleDraftBaseUrlChange}
         onContextLengthChange={handleDraftContextLengthChange}
@@ -544,7 +557,7 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
         <Button
           size="sm"
           onClick={handleSave}
-          disabled={!dirty || updateMutation.isPending}
+          disabled={!isDirty || updateMutation.isPending}
           className="gap-1.5"
         >
           {updateMutation.isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}

--- a/packages/myco/ui/src/components/agent/TaskProviderConfig.tsx
+++ b/packages/myco/ui/src/components/agent/TaskProviderConfig.tsx
@@ -12,14 +12,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../ui/select';
+import { SearchableSelect } from '../ui/searchable-select';
 import { ProviderModelSelector } from '../providers/ProviderModelSelector';
 import {
   useProviders,
   useTaskConfig,
   useTestProvider,
   useUpdateTaskConfig,
-  seedDraftFromProviderType,
-  inferRuntimeFromProviderType,
+  maybeInferRuntimeFromProviderType,
   resolveReasoningModel,
   type ProviderConfig,
   type ProviderInfo,
@@ -28,6 +28,11 @@ import {
 } from '../../hooks/use-providers';
 import type { PhaseDefinition } from '../../hooks/use-agent';
 import { useModels } from '../../hooks/use-models';
+import {
+  draftToNormalizedProviderConfig,
+  providerDraftFromSource,
+  useProviderConfigDraft,
+} from '../../hooks/use-provider-config-draft';
 
 /* ---------- Types ---------- */
 
@@ -178,6 +183,26 @@ const POWER_STATE_LABELS: Record<PowerState, string> = {
   sleep: 'Sleep',
 };
 
+function serializeComparable(value: unknown): string {
+  return JSON.stringify(value ?? null);
+}
+
+function taskConfigSnapshot(config: {
+  maxTurns?: number;
+  timeoutSeconds?: number;
+  phases?: Record<string, PhaseOverride>;
+  schedule?: ScheduleOverride;
+  params?: Record<string, string | number | boolean>;
+} | null | undefined) {
+  return {
+    maxTurns: config?.maxTurns != null ? String(config.maxTurns) : '',
+    timeoutSeconds: config?.timeoutSeconds != null ? String(config.timeoutSeconds) : '',
+    phaseOverrides: config?.phases ?? {},
+    scheduleOverride: config?.schedule ?? {},
+    paramsOverride: config?.params ?? {},
+  };
+}
+
 /* ---------- Component ---------- */
 
 export function TaskProviderConfig({ taskId, phases, defaults, schedule, params }: TaskProviderConfigProps) {
@@ -187,82 +212,76 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
   const updateMutation = useUpdateTaskConfig();
 
   const currentConfig = taskConfigData?.config;
-
-  const [runtime, setRuntime] = useState<string>('claude-sdk');
-  const [providerType, setProviderType] = useState<string>('anthropic');
-  const [model, setModel] = useState<string>('');
-  const [reasoningLow, setReasoningLow] = useState<string>('');
-  const [reasoningDefault, setReasoningDefault] = useState<string>('');
-  const [reasoningHigh, setReasoningHigh] = useState<string>('');
-  const [baseUrl, setBaseUrl] = useState<string>('');
-  const [contextLength, setContextLength] = useState<string>('');
-  const [maxTurns, setMaxTurns] = useState<string>('');
-  const [timeoutSeconds, setTimeoutSeconds] = useState<string>('');
-  const [phaseOverrides, setPhaseOverrides] = useState<Record<string, PhaseOverride>>({});
-  const [scheduleOverride, setScheduleOverride] = useState<ScheduleOverride>({});
-  const [paramsOverride, setParamsOverride] = useState<Record<string, string | number | boolean>>({});
-  const [dirty, setDirty] = useState(false);
+  const initialTaskSnapshot = taskConfigSnapshot(currentConfig);
+  const [maxTurns, setMaxTurns] = useState<string>(initialTaskSnapshot.maxTurns);
+  const [timeoutSeconds, setTimeoutSeconds] = useState<string>(initialTaskSnapshot.timeoutSeconds);
+  const [phaseOverrides, setPhaseOverrides] = useState<Record<string, PhaseOverride>>(initialTaskSnapshot.phaseOverrides);
+  const [scheduleOverride, setScheduleOverride] = useState<ScheduleOverride>(initialTaskSnapshot.scheduleOverride);
+  const [paramsOverride, setParamsOverride] = useState<Record<string, string | number | boolean>>(initialTaskSnapshot.paramsOverride);
+  const [savedTaskSnapshot, setSavedTaskSnapshot] = useState(initialTaskSnapshot);
   const providers = providersData?.providers ?? [];
+  const providerDraftDefaults = {
+    runtime: defaults?.runtime,
+    providerType: defaults?.providerType,
+    model: defaults?.model,
+    reasoningMap: defaults?.reasoningMap,
+    baseUrl: defaults?.baseUrl,
+    contextLength: defaults?.contextLength,
+  };
+  const {
+    draft,
+    isDirty: isProviderDirty,
+    commitDraft,
+    handleRuntimeChange: handleDraftRuntimeChange,
+    handleProviderChange: handleDraftProviderChange,
+    handleModelChange: handleDraftModelChange,
+    handleReasoningChange: handleDraftReasoningChange,
+    handleBaseUrlChange: handleDraftBaseUrlChange,
+    handleContextLengthChange: handleDraftContextLengthChange,
+  } = useProviderConfigDraft({
+    source: {
+      runtime: currentConfig?.runtime,
+      provider: currentConfig?.provider,
+      model: currentConfig?.model,
+    },
+    defaults: providerDraftDefaults,
+    providers,
+  });
+  const runtime = draft.runtime;
+  const providerType = draft.type;
+  const model = draft.model;
+  const reasoningLow = draft.reasoningLow;
+  const reasoningDefault = draft.reasoningDefault;
+  const reasoningHigh = draft.reasoningHigh;
+  const baseUrl = draft.baseUrl;
+  const contextLength = draft.contextLength;
   const reasoningModelsQuery = useModels(providerType || null, baseUrl || undefined, 'llm');
   const reasoningModels = reasoningModelsQuery.data?.models ?? providers.find((provider) => provider.type === providerType)?.models ?? [];
   const effectiveRuntime = runtime
-    || inferRuntimeFromProviderType(providerType as Parameters<typeof inferRuntimeFromProviderType>[0])
+    || maybeInferRuntimeFromProviderType(providerType)
     || defaults?.runtime
-    || inferRuntimeFromProviderType(defaults?.providerType as Parameters<typeof inferRuntimeFromProviderType>[0])
+    || maybeInferRuntimeFromProviderType(defaults?.providerType)
     || 'claude-sdk';
-
-  useEffect(() => {
-    if (!runtime && effectiveRuntime) {
-      setRuntime(effectiveRuntime);
-    }
-  }, [effectiveRuntime, runtime]);
+  const isDirty = isProviderDirty
+    || maxTurns !== savedTaskSnapshot.maxTurns
+    || timeoutSeconds !== savedTaskSnapshot.timeoutSeconds
+    || serializeComparable(phaseOverrides) !== serializeComparable(savedTaskSnapshot.phaseOverrides)
+    || serializeComparable(scheduleOverride) !== serializeComparable(savedTaskSnapshot.scheduleOverride)
+    || serializeComparable(paramsOverride) !== serializeComparable(savedTaskSnapshot.paramsOverride);
 
   // Sync from myco.yaml config when it loads
   useEffect(() => {
     if (!taskConfigData) return;
-    setRuntime(
-      currentConfig?.runtime
-      ?? currentConfig?.provider?.runtime
-      ?? inferRuntimeFromProviderType(currentConfig?.provider?.type)
-      ?? defaults?.runtime
-      ?? inferRuntimeFromProviderType(defaults?.providerType as Parameters<typeof inferRuntimeFromProviderType>[0])
-      ?? 'claude-sdk',
-    );
-    setProviderType(currentConfig?.provider?.type ?? defaults?.providerType ?? 'anthropic');
-    setModel(currentConfig?.provider?.model ?? currentConfig?.model ?? defaults?.model ?? '');
-    setReasoningLow(currentConfig?.provider?.reasoning_map?.low ?? defaults?.reasoningMap?.low ?? '');
-    setReasoningDefault(
-      currentConfig?.provider?.reasoning_map?.default
-      ?? currentConfig?.provider?.model
-      ?? currentConfig?.model
-      ?? defaults?.reasoningMap?.default
-      ?? defaults?.model
-      ?? '',
-    );
-    setReasoningHigh(currentConfig?.provider?.reasoning_map?.high ?? defaults?.reasoningMap?.high ?? '');
-    setBaseUrl(currentConfig?.provider?.base_url ?? defaults?.baseUrl ?? '');
-    setContextLength(
-      currentConfig?.provider?.context_length != null
-        ? String(currentConfig.provider.context_length)
-        : defaults?.contextLength != null
-          ? String(defaults.contextLength)
-          : '',
-    );
-    setMaxTurns(currentConfig?.maxTurns != null ? String(currentConfig.maxTurns) : '');
-    setTimeoutSeconds(currentConfig?.timeoutSeconds != null ? String(currentConfig.timeoutSeconds) : '');
-    setPhaseOverrides(currentConfig?.phases ?? {});
-    setScheduleOverride(currentConfig?.schedule ?? {});
-    setParamsOverride(currentConfig?.params ?? {});
-    setDirty(false);
+    const snapshot = taskConfigSnapshot(currentConfig);
+    setMaxTurns(snapshot.maxTurns);
+    setTimeoutSeconds(snapshot.timeoutSeconds);
+    setPhaseOverrides(snapshot.phaseOverrides);
+    setScheduleOverride(snapshot.scheduleOverride);
+    setParamsOverride(snapshot.paramsOverride);
+    setSavedTaskSnapshot(snapshot);
   }, [
     currentConfig,
     taskConfigData,
-    defaults?.runtime,
-    defaults?.providerType,
-    defaults?.model,
-    defaults?.reasoningMap,
-    defaults?.baseUrl,
-    defaults?.contextLength,
     defaults?.maxTurns,
     defaults?.timeoutSeconds,
   ]);
@@ -271,19 +290,7 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
   const effectiveScheduleEnabled = scheduleOverride.enabled ?? schedule?.enabled ?? false;
   const effectiveRunIn = scheduleOverride.runIn ?? schedule?.runIn ?? [];
   function handleProviderChange(type: string) {
-    // Default to the first available model so the dropdown never shows a
-    // stale value from the previous provider (Radix Select renders the prior
-    // value instead of the placeholder when value='' is passed).
-      const draft = seedDraftFromProviderType(type, providers);
-      setRuntime(draft.runtime || runtime);
-      setProviderType(type);
-      setModel(draft.model || defaults?.model || '');
-      setReasoningLow(draft.reasoningLow);
-      setReasoningDefault(draft.reasoningDefault || draft.model || defaults?.model || '');
-      setReasoningHigh(draft.reasoningHigh);
-    setBaseUrl(draft.baseUrl);
-    setContextLength(draft.contextLength);
-    setDirty(true);
+    handleDraftProviderChange(type);
     testMutation.reset();
   }
 
@@ -297,24 +304,16 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
       }
       return next;
     });
-    setDirty(true);
   }
 
   function handleSave() {
-    const isLocal = providerType === 'ollama' || providerType === 'lmstudio' || providerType === 'openai-compatible';
-    const reasoningMap = {
-      ...(reasoningLow ? { low: reasoningLow } : {}),
-      ...(reasoningDefault ? { default: reasoningDefault } : {}),
-      ...(reasoningHigh ? { high: reasoningHigh } : {}),
-    };
-    const provider: ProviderConfig = {
-      runtime: effectiveRuntime as ProviderConfig['runtime'],
-      type: providerType as ProviderConfig['type'],
-      ...(model ? { model } : {}),
-      ...(Object.keys(reasoningMap).length > 0 ? { reasoning_map: reasoningMap } : {}),
-      ...(isLocal && baseUrl ? { base_url: baseUrl } : {}),
-      ...(isLocal && contextLength ? { context_length: Number(contextLength) } : {}),
-    };
+    const provider = draftToNormalizedProviderConfig(
+      { ...draft, runtime: effectiveRuntime as ProviderConfig['runtime'] },
+      reasoningModels,
+    );
+    if (!provider) {
+      return;
+    }
 
     // Build schedule payload: only include fields the user has overridden
     const schedulePayload = schedule
@@ -339,7 +338,21 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
           ...paramsPayload,
         },
       },
-      { onSuccess: () => setDirty(false) },
+      {
+        onSuccess: () => {
+          commitDraft(providerDraftFromSource(
+            { runtime: effectiveRuntime, provider },
+            providerDraftDefaults,
+          ));
+          setSavedTaskSnapshot({
+            maxTurns,
+            timeoutSeconds,
+            phaseOverrides,
+            scheduleOverride,
+            paramsOverride,
+          });
+        },
+      },
     );
   }
 
@@ -360,24 +373,14 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
       },
       {
         onSuccess: () => {
-          setRuntime(
-            defaults?.runtime
-            ?? inferRuntimeFromProviderType(defaults?.providerType as Parameters<typeof inferRuntimeFromProviderType>[0])
-            ?? 'claude-sdk',
-          );
-          setProviderType(defaults?.providerType ?? 'anthropic');
-          setModel(defaults?.model ?? '');
-          setReasoningLow(defaults?.reasoningMap?.low ?? '');
-          setReasoningDefault(defaults?.reasoningMap?.default ?? defaults?.model ?? '');
-          setReasoningHigh(defaults?.reasoningMap?.high ?? '');
-          setBaseUrl(defaults?.baseUrl ?? '');
-          setContextLength(defaults?.contextLength != null ? String(defaults.contextLength) : '');
-          setMaxTurns('');
-          setTimeoutSeconds('');
-          setPhaseOverrides({});
-          setScheduleOverride({});
-          setParamsOverride({});
-          setDirty(false);
+          const clearedSnapshot = taskConfigSnapshot(null);
+          commitDraft(providerDraftFromSource(null, providerDraftDefaults));
+          setMaxTurns(clearedSnapshot.maxTurns);
+          setTimeoutSeconds(clearedSnapshot.timeoutSeconds);
+          setPhaseOverrides(clearedSnapshot.phaseOverrides);
+          setScheduleOverride(clearedSnapshot.scheduleOverride);
+          setParamsOverride(clearedSnapshot.paramsOverride);
+          setSavedTaskSnapshot(clearedSnapshot);
         },
       },
     );
@@ -417,24 +420,12 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
         providers={providers}
         isLoadingProviders={isLoadingProviders}
         onRuntimeChange={(nextRuntime) => {
-          setRuntime(nextRuntime);
-          const firstProvider = providers.find((provider) => provider.runtime === nextRuntime);
-          if (firstProvider) {
-            const draft = seedDraftFromProviderType(firstProvider.type, providers);
-            setProviderType(draft.type);
-            setModel(draft.model);
-            setReasoningLow(draft.reasoningLow);
-            setReasoningDefault(draft.reasoningDefault || draft.model);
-            setReasoningHigh(draft.reasoningHigh);
-            setBaseUrl(draft.baseUrl);
-            setContextLength(draft.contextLength);
-          }
-          setDirty(true);
+          handleDraftRuntimeChange(nextRuntime);
         }}
         onProviderChange={handleProviderChange}
-        onModelChange={(m) => { setModel(m); setDirty(true); }}
-        onBaseUrlChange={(url) => { setBaseUrl(url); setDirty(true); }}
-        onContextLengthChange={(ctx) => { setContextLength(ctx); setDirty(true); }}
+        onModelChange={handleDraftModelChange}
+        onBaseUrlChange={handleDraftBaseUrlChange}
+        onContextLengthChange={handleDraftContextLengthChange}
       />
 
       {providerType !== '' && (
@@ -446,10 +437,10 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
             </p>
           </div>
           {([
-            ['low', 'Reasoning Low', reasoningLow, setReasoningLow],
-            ['default', 'Reasoning Default', reasoningDefault, setReasoningDefault],
-            ['high', 'Reasoning High', reasoningHigh, setReasoningHigh],
-          ] as const).map(([level, label, value, setValue]) => {
+            ['low', 'Reasoning Low', reasoningLow],
+            ['default', 'Reasoning Default', reasoningDefault],
+            ['high', 'Reasoning High', reasoningHigh],
+          ] as const).map(([level, label, value]) => {
             const placeholder = resolveReasoningModel(
               level,
               {
@@ -467,22 +458,23 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
               <div key={level} className="space-y-1">
                 <label className="font-sans text-xs text-on-surface-variant">{label}</label>
                 {reasoningModels.length > 0 ? (
-                  <Select value={value} onValueChange={(next) => { setValue(next); setDirty(true); }}>
-                    <SelectTrigger>
-                      <SelectValue placeholder={placeholder || 'Use inherited model'} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {reasoningModels.map((candidate) => (
-                        <SelectItem key={`${level}-${candidate}`} value={candidate}>
-                          <span className="font-mono text-sm">{candidate}</span>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <SearchableSelect
+                    value={value}
+                    onValueChange={(next) => { handleDraftReasoningChange(level, next); }}
+                    placeholder={placeholder || 'Use inherited model'}
+                    searchPlaceholder="Search models..."
+                    emptyMessage="No models match that search."
+                    options={reasoningModels.map((candidate) => ({
+                      value: candidate,
+                      label: candidate,
+                    }))}
+                    sortOptions
+                    monospace
+                  />
                 ) : (
                   <Input
                     value={value}
-                    onChange={(e) => { setValue(e.target.value); setDirty(true); }}
+                    onChange={(e) => { handleDraftReasoningChange(level, e.target.value); }}
                     placeholder={placeholder || 'Use inherited model'}
                   />
                 )}
@@ -499,7 +491,7 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
           <Input
             type="number"
             value={maxTurns}
-            onChange={(e) => { setMaxTurns(e.target.value); setDirty(true); }}
+            onChange={(e) => { setMaxTurns(e.target.value); }}
             placeholder={defaults?.maxTurns != null ? String(defaults.maxTurns) : '—'}
           />
         </div>
@@ -508,7 +500,7 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
           <Input
             type="number"
             value={timeoutSeconds}
-            onChange={(e) => { setTimeoutSeconds(e.target.value); setDirty(true); }}
+            onChange={(e) => { setTimeoutSeconds(e.target.value); }}
             placeholder={defaults?.timeoutSeconds != null ? String(defaults.timeoutSeconds) : '—'}
           />
         </div>
@@ -588,7 +580,6 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
               checked={effectiveScheduleEnabled}
               onCheckedChange={(checked) => {
                 setScheduleOverride((prev) => ({ ...prev, enabled: checked }));
-                setDirty(true);
               }}
             />
           </div>
@@ -611,7 +602,6 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
                       ...prev,
                       intervalSeconds: val ? Number(val) : undefined,
                     }));
-                    setDirty(true);
                   }}
                   placeholder={schedule.intervalSeconds != null ? String(schedule.intervalSeconds) : '300'}
                 />
@@ -634,7 +624,6 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
                             : [...effectiveRunIn, state];
                           // Only set override if different from YAML default
                           setScheduleOverride((prev) => ({ ...prev, runIn: next.length > 0 ? next : undefined }));
-                          setDirty(true);
                         }}
                         className={`
                           rounded-md border px-3 py-1.5 font-sans text-xs font-medium transition-colors
@@ -672,7 +661,6 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
                     checked={effectiveValue as boolean}
                     onCheckedChange={(v) => {
                       setParamsOverride(prev => ({ ...prev, [key]: v }));
-                      setDirty(true);
                     }}
                   />
                 </div>
@@ -700,7 +688,6 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
                       } else {
                         setParamsOverride(prev => ({ ...prev, [key]: val }));
                       }
-                      setDirty(true);
                     }}
                     className="w-40 font-mono"
                   />

--- a/packages/myco/ui/src/components/agent/TaskProviderConfig.tsx
+++ b/packages/myco/ui/src/components/agent/TaskProviderConfig.tsx
@@ -5,6 +5,13 @@ import { Input } from '../ui/input';
 import { Surface } from '../ui/surface';
 import { Badge } from '../ui/badge';
 import { Switch } from '../ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../ui/select';
 import { ProviderModelSelector } from '../providers/ProviderModelSelector';
 import {
   useProviders,
@@ -12,12 +19,15 @@ import {
   useTestProvider,
   useUpdateTaskConfig,
   seedDraftFromProviderType,
+  inferRuntimeFromProviderType,
+  resolveReasoningModel,
   type ProviderConfig,
   type ProviderInfo,
   type PhaseOverride,
   type ScheduleOverride,
 } from '../../hooks/use-providers';
 import type { PhaseDefinition } from '../../hooks/use-agent';
+import { useModels } from '../../hooks/use-models';
 
 /* ---------- Types ---------- */
 
@@ -31,7 +41,17 @@ interface ScheduleDefaults {
 interface TaskProviderConfigProps {
   taskId: string;
   phases?: PhaseDefinition[];
-  defaults?: { model?: string; maxTurns?: number; timeoutSeconds?: number };
+  defaults?: {
+    runtime?: string;
+    providerType?: string;
+    reasoningLevel?: 'low' | 'default' | 'high';
+    reasoningMap?: Partial<Record<'low' | 'default' | 'high', string>>;
+    model?: string;
+    baseUrl?: string;
+    contextLength?: number;
+    maxTurns?: number;
+    timeoutSeconds?: number;
+  };
   schedule?: ScheduleDefaults;
   params?: Record<string, string | number | boolean>;
 }
@@ -42,20 +62,35 @@ interface TaskProviderConfigProps {
 function PhaseConfigRow({
   phase,
   override,
+  taskRuntime,
+  taskProviderType,
   taskModel,
+  taskReasoningMap,
   providers,
   isLoadingProviders,
   onChange,
 }: {
   phase: PhaseDefinition;
   override: PhaseOverride;
+  taskRuntime: string;
+  taskProviderType: string;
   taskModel: string;
+  taskReasoningMap?: Partial<Record<'low' | 'default' | 'high', string>>;
   providers: ProviderInfo[];
   isLoadingProviders: boolean;
   onChange: (update: PhaseOverride | null) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   const hasOverride = override.provider !== undefined || override.model !== undefined || override.maxTurns !== undefined;
+  const modelPlaceholder = phase.model
+    ?? resolveReasoningModel(
+      phase.reasoningLevel,
+      {
+        model: taskModel || undefined,
+        reasoning_map: taskReasoningMap,
+      },
+      taskModel,
+    );
 
   return (
     <div className="border border-[var(--ghost-border)] rounded-md">
@@ -73,18 +108,25 @@ function PhaseConfigRow({
         <div className="px-3 pb-3 space-y-3 border-t border-[var(--ghost-border)]">
           <div className="pt-3">
             <ProviderModelSelector
-              providerType={override.provider?.type ?? 'anthropic'}
+              runtime={override.provider?.runtime ?? taskRuntime}
+              providerType={override.provider?.type ?? taskProviderType}
               model={override.provider?.model ?? override.model ?? ''}
               baseUrl={override.provider?.base_url ?? ''}
               contextLength={override.provider?.context_length != null ? String(override.provider.context_length) : ''}
-              modelPlaceholder={phase.model ?? taskModel}
+              modelPlaceholder={modelPlaceholder}
               providers={providers}
               isLoadingProviders={isLoadingProviders}
+              showRuntimeSelector={false}
+              onRuntimeChange={() => {}}
               onProviderChange={(type) => {
                 const bp = providers.find(p => p.type === type)?.baseUrl;
                 onChange({
                   ...override,
-                  provider: { type: type as ProviderConfig['type'], base_url: bp },
+                  provider: {
+                    runtime: (override.provider?.runtime ?? taskRuntime) as ProviderConfig['runtime'],
+                    type: type as ProviderConfig['type'],
+                    base_url: bp,
+                  },
                   model: undefined,
                 });
               }}
@@ -146,8 +188,12 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
 
   const currentConfig = taskConfigData?.config;
 
+  const [runtime, setRuntime] = useState<string>('claude-sdk');
   const [providerType, setProviderType] = useState<string>('anthropic');
   const [model, setModel] = useState<string>('');
+  const [reasoningLow, setReasoningLow] = useState<string>('');
+  const [reasoningDefault, setReasoningDefault] = useState<string>('');
+  const [reasoningHigh, setReasoningHigh] = useState<string>('');
   const [baseUrl, setBaseUrl] = useState<string>('');
   const [contextLength, setContextLength] = useState<string>('');
   const [maxTurns, setMaxTurns] = useState<string>('');
@@ -156,36 +202,85 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
   const [scheduleOverride, setScheduleOverride] = useState<ScheduleOverride>({});
   const [paramsOverride, setParamsOverride] = useState<Record<string, string | number | boolean>>({});
   const [dirty, setDirty] = useState(false);
+  const providers = providersData?.providers ?? [];
+  const reasoningModelsQuery = useModels(providerType || null, baseUrl || undefined, 'llm');
+  const reasoningModels = reasoningModelsQuery.data?.models ?? providers.find((provider) => provider.type === providerType)?.models ?? [];
+  const effectiveRuntime = runtime
+    || inferRuntimeFromProviderType(providerType as Parameters<typeof inferRuntimeFromProviderType>[0])
+    || defaults?.runtime
+    || inferRuntimeFromProviderType(defaults?.providerType as Parameters<typeof inferRuntimeFromProviderType>[0])
+    || 'claude-sdk';
+
+  useEffect(() => {
+    if (!runtime && effectiveRuntime) {
+      setRuntime(effectiveRuntime);
+    }
+  }, [effectiveRuntime, runtime]);
 
   // Sync from myco.yaml config when it loads
   useEffect(() => {
-    if (currentConfig) {
-      setProviderType(currentConfig.provider?.type ?? 'anthropic');
-      setModel(currentConfig.provider?.model ?? currentConfig.model ?? '');
-      setBaseUrl(currentConfig.provider?.base_url ?? '');
-      setContextLength(currentConfig.provider?.context_length != null ? String(currentConfig.provider.context_length) : '');
-      setMaxTurns(currentConfig.maxTurns != null ? String(currentConfig.maxTurns) : '');
-      setTimeoutSeconds(currentConfig.timeoutSeconds != null ? String(currentConfig.timeoutSeconds) : '');
-      setPhaseOverrides(currentConfig.phases ?? {});
-      setScheduleOverride(currentConfig.schedule ?? {});
-      setParamsOverride(currentConfig.params ?? {});
-      setDirty(false);
-    }
-  }, [currentConfig]);
+    if (!taskConfigData) return;
+    setRuntime(
+      currentConfig?.runtime
+      ?? currentConfig?.provider?.runtime
+      ?? inferRuntimeFromProviderType(currentConfig?.provider?.type)
+      ?? defaults?.runtime
+      ?? inferRuntimeFromProviderType(defaults?.providerType as Parameters<typeof inferRuntimeFromProviderType>[0])
+      ?? 'claude-sdk',
+    );
+    setProviderType(currentConfig?.provider?.type ?? defaults?.providerType ?? 'anthropic');
+    setModel(currentConfig?.provider?.model ?? currentConfig?.model ?? defaults?.model ?? '');
+    setReasoningLow(currentConfig?.provider?.reasoning_map?.low ?? defaults?.reasoningMap?.low ?? '');
+    setReasoningDefault(
+      currentConfig?.provider?.reasoning_map?.default
+      ?? currentConfig?.provider?.model
+      ?? currentConfig?.model
+      ?? defaults?.reasoningMap?.default
+      ?? defaults?.model
+      ?? '',
+    );
+    setReasoningHigh(currentConfig?.provider?.reasoning_map?.high ?? defaults?.reasoningMap?.high ?? '');
+    setBaseUrl(currentConfig?.provider?.base_url ?? defaults?.baseUrl ?? '');
+    setContextLength(
+      currentConfig?.provider?.context_length != null
+        ? String(currentConfig.provider.context_length)
+        : defaults?.contextLength != null
+          ? String(defaults.contextLength)
+          : '',
+    );
+    setMaxTurns(currentConfig?.maxTurns != null ? String(currentConfig.maxTurns) : '');
+    setTimeoutSeconds(currentConfig?.timeoutSeconds != null ? String(currentConfig.timeoutSeconds) : '');
+    setPhaseOverrides(currentConfig?.phases ?? {});
+    setScheduleOverride(currentConfig?.schedule ?? {});
+    setParamsOverride(currentConfig?.params ?? {});
+    setDirty(false);
+  }, [
+    currentConfig,
+    taskConfigData,
+    defaults?.runtime,
+    defaults?.providerType,
+    defaults?.model,
+    defaults?.reasoningMap,
+    defaults?.baseUrl,
+    defaults?.contextLength,
+    defaults?.maxTurns,
+    defaults?.timeoutSeconds,
+  ]);
 
   // Effective schedule values: user override merged over YAML defaults
   const effectiveScheduleEnabled = scheduleOverride.enabled ?? schedule?.enabled ?? false;
   const effectiveRunIn = scheduleOverride.runIn ?? schedule?.runIn ?? [];
-
-  const providers = providersData?.providers ?? [];
-
   function handleProviderChange(type: string) {
     // Default to the first available model so the dropdown never shows a
     // stale value from the previous provider (Radix Select renders the prior
     // value instead of the placeholder when value='' is passed).
-    const draft = seedDraftFromProviderType(type, providers);
-    setProviderType(type);
-    setModel(draft.model);
+      const draft = seedDraftFromProviderType(type, providers);
+      setRuntime(draft.runtime || runtime);
+      setProviderType(type);
+      setModel(draft.model || defaults?.model || '');
+      setReasoningLow(draft.reasoningLow);
+      setReasoningDefault(draft.reasoningDefault || draft.model || defaults?.model || '');
+      setReasoningHigh(draft.reasoningHigh);
     setBaseUrl(draft.baseUrl);
     setContextLength(draft.contextLength);
     setDirty(true);
@@ -206,10 +301,17 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
   }
 
   function handleSave() {
-    const isLocal = providerType === 'ollama' || providerType === 'lmstudio';
+    const isLocal = providerType === 'ollama' || providerType === 'lmstudio' || providerType === 'openai-compatible';
+    const reasoningMap = {
+      ...(reasoningLow ? { low: reasoningLow } : {}),
+      ...(reasoningDefault ? { default: reasoningDefault } : {}),
+      ...(reasoningHigh ? { high: reasoningHigh } : {}),
+    };
     const provider: ProviderConfig = {
+      runtime: effectiveRuntime as ProviderConfig['runtime'],
       type: providerType as ProviderConfig['type'],
       ...(model ? { model } : {}),
+      ...(Object.keys(reasoningMap).length > 0 ? { reasoning_map: reasoningMap } : {}),
       ...(isLocal && baseUrl ? { base_url: baseUrl } : {}),
       ...(isLocal && contextLength ? { context_length: Number(contextLength) } : {}),
     };
@@ -228,6 +330,7 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
       {
         taskId,
         config: {
+          runtime: effectiveRuntime as 'claude-sdk' | 'openai-agents',
           provider,
           ...(maxTurns ? { maxTurns: Number(maxTurns) } : { maxTurns: null as unknown as number }),
           ...(timeoutSeconds ? { timeoutSeconds: Number(timeoutSeconds) } : { timeoutSeconds: null as unknown as number }),
@@ -245,6 +348,7 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
       {
         taskId,
         config: {
+          runtime: null as unknown as 'claude-sdk' | 'openai-agents',
           provider: null as unknown as ProviderConfig,
           model: null as unknown as string,
           maxTurns: null as unknown as number,
@@ -256,10 +360,18 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
       },
       {
         onSuccess: () => {
-          setProviderType('anthropic');
-          setModel('');
-          setBaseUrl('');
-          setContextLength('');
+          setRuntime(
+            defaults?.runtime
+            ?? inferRuntimeFromProviderType(defaults?.providerType as Parameters<typeof inferRuntimeFromProviderType>[0])
+            ?? 'claude-sdk',
+          );
+          setProviderType(defaults?.providerType ?? 'anthropic');
+          setModel(defaults?.model ?? '');
+          setReasoningLow(defaults?.reasoningMap?.low ?? '');
+          setReasoningDefault(defaults?.reasoningMap?.default ?? defaults?.model ?? '');
+          setReasoningHigh(defaults?.reasoningMap?.high ?? '');
+          setBaseUrl(defaults?.baseUrl ?? '');
+          setContextLength(defaults?.contextLength != null ? String(defaults.contextLength) : '');
           setMaxTurns('');
           setTimeoutSeconds('');
           setPhaseOverrides({});
@@ -272,8 +384,9 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
   }
 
   function handleTest() {
-    const isLocal = providerType === 'ollama' || providerType === 'lmstudio';
+    const isLocal = providerType === 'ollama' || providerType === 'lmstudio' || providerType === 'openai-compatible';
     const config: ProviderConfig = {
+      runtime: effectiveRuntime as ProviderConfig['runtime'],
       type: providerType as ProviderConfig['type'],
       ...(isLocal && baseUrl ? { base_url: baseUrl } : {}),
     };
@@ -295,6 +408,7 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
 
       {/* Task-level provider/model */}
       <ProviderModelSelector
+        runtime={effectiveRuntime}
         providerType={providerType}
         model={model}
         baseUrl={baseUrl}
@@ -302,11 +416,81 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
         modelPlaceholder={defaults?.model}
         providers={providers}
         isLoadingProviders={isLoadingProviders}
+        onRuntimeChange={(nextRuntime) => {
+          setRuntime(nextRuntime);
+          const firstProvider = providers.find((provider) => provider.runtime === nextRuntime);
+          if (firstProvider) {
+            const draft = seedDraftFromProviderType(firstProvider.type, providers);
+            setProviderType(draft.type);
+            setModel(draft.model);
+            setReasoningLow(draft.reasoningLow);
+            setReasoningDefault(draft.reasoningDefault || draft.model);
+            setReasoningHigh(draft.reasoningHigh);
+            setBaseUrl(draft.baseUrl);
+            setContextLength(draft.contextLength);
+          }
+          setDirty(true);
+        }}
         onProviderChange={handleProviderChange}
         onModelChange={(m) => { setModel(m); setDirty(true); }}
         onBaseUrlChange={(url) => { setBaseUrl(url); setDirty(true); }}
         onContextLengthChange={(ctx) => { setContextLength(ctx); setDirty(true); }}
       />
+
+      {providerType !== '' && (
+        <div className="space-y-3 rounded-md border border-[var(--ghost-border)] bg-surface-container-lowest p-3">
+          <div>
+            <p className="font-sans text-xs text-on-surface-variant uppercase tracking-wide">Reasoning Profiles</p>
+            <p className="font-sans text-xs text-on-surface-variant/80 mt-1">
+              Built-in task reasoning levels resolve through these task-level model mappings before falling back to the inherited defaults.
+            </p>
+          </div>
+          {([
+            ['low', 'Reasoning Low', reasoningLow, setReasoningLow],
+            ['default', 'Reasoning Default', reasoningDefault, setReasoningDefault],
+            ['high', 'Reasoning High', reasoningHigh, setReasoningHigh],
+          ] as const).map(([level, label, value, setValue]) => {
+            const placeholder = resolveReasoningModel(
+              level,
+              {
+                model: model || undefined,
+                reasoning_map: {
+                  ...(reasoningLow ? { low: reasoningLow } : {}),
+                  ...(reasoningDefault ? { default: reasoningDefault } : {}),
+                  ...(reasoningHigh ? { high: reasoningHigh } : {}),
+                },
+              },
+              defaults?.reasoningMap?.[level] ?? defaults?.model,
+            );
+
+            return (
+              <div key={level} className="space-y-1">
+                <label className="font-sans text-xs text-on-surface-variant">{label}</label>
+                {reasoningModels.length > 0 ? (
+                  <Select value={value} onValueChange={(next) => { setValue(next); setDirty(true); }}>
+                    <SelectTrigger>
+                      <SelectValue placeholder={placeholder || 'Use inherited model'} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {reasoningModels.map((candidate) => (
+                        <SelectItem key={`${level}-${candidate}`} value={candidate}>
+                          <span className="font-mono text-sm">{candidate}</span>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  <Input
+                    value={value}
+                    onChange={(e) => { setValue(e.target.value); setDirty(true); }}
+                    placeholder={placeholder || 'Use inherited model'}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
 
       {/* Task-level maxTurns + timeout */}
       <div className="grid grid-cols-2 gap-3">
@@ -541,7 +725,15 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
               key={phase.name}
               phase={phase}
               override={phaseOverrides[phase.name] ?? {}}
-              taskModel={model || 'claude-sonnet-4-6'}
+              taskRuntime={effectiveRuntime}
+              taskProviderType={providerType}
+              taskModel={model || defaults?.model || ''}
+              taskReasoningMap={{
+                ...(defaults?.reasoningMap ?? {}),
+                ...(reasoningLow ? { low: reasoningLow } : {}),
+                ...(reasoningDefault ? { default: reasoningDefault } : {}),
+                ...(reasoningHigh ? { high: reasoningHigh } : {}),
+              }}
               providers={providers}
               isLoadingProviders={isLoadingProviders}
               onChange={(update) => handlePhaseChange(phase.name, update)}

--- a/packages/myco/ui/src/components/agent/TriggerRun.tsx
+++ b/packages/myco/ui/src/components/agent/TriggerRun.tsx
@@ -18,7 +18,7 @@ import {
 } from '../ui/select';
 import { useAgentTasks, useTriggerRun, type TaskRow } from '../../hooks/use-agent';
 import { useScopedConfig } from '../../hooks/use-scoped-config';
-import { inferRuntimeFromProviderType, resolveReasoningModel, useTaskConfig } from '../../hooks/use-providers';
+import { maybeInferRuntimeFromProviderType, resolveReasoningModel, useTaskConfig } from '../../hooks/use-providers';
 
 /* ---------- Helpers ---------- */
 
@@ -53,12 +53,12 @@ export function TriggerRun({ open, onOpenChange, onTriggered }: TriggerRunProps)
   const globalProvider = effective?.agent?.provider;
   const effectiveRuntime = taskConfig?.runtime
     ?? taskConfig?.provider?.runtime
-    ?? inferRuntimeFromProviderType(taskConfig?.provider?.type)
+    ?? maybeInferRuntimeFromProviderType(taskConfig?.provider?.type)
     ?? execution?.runtime
     ?? execution?.provider?.runtime
-    ?? inferRuntimeFromProviderType(execution?.provider?.type)
+    ?? maybeInferRuntimeFromProviderType(execution?.provider?.type)
     ?? globalProvider?.runtime
-    ?? inferRuntimeFromProviderType(globalProvider?.type)
+    ?? maybeInferRuntimeFromProviderType(globalProvider?.type)
     ?? effective?.agent?.runtime
     ?? 'claude-sdk';
   const effectiveProvider = taskConfig?.provider?.type

--- a/packages/myco/ui/src/components/agent/TriggerRun.tsx
+++ b/packages/myco/ui/src/components/agent/TriggerRun.tsx
@@ -17,6 +17,8 @@ import {
   SelectValue,
 } from '../ui/select';
 import { useAgentTasks, useTriggerRun, type TaskRow } from '../../hooks/use-agent';
+import { useScopedConfig } from '../../hooks/use-scoped-config';
+import { inferRuntimeFromProviderType, resolveReasoningModel, useTaskConfig } from '../../hooks/use-providers';
 
 /* ---------- Helpers ---------- */
 
@@ -35,6 +37,7 @@ export interface TriggerRunProps {
 export function TriggerRun({ open, onOpenChange, onTriggered }: TriggerRunProps) {
   const [selectedTask, setSelectedTask] = useState<string | undefined>(undefined);
   const [instruction, setInstruction] = useState('');
+  const { effective } = useScopedConfig();
 
   const { data: tasksData, isLoading: tasksLoading } = useAgentTasks();
   const { mutate: triggerRun, isPending, error } = useTriggerRun();
@@ -43,6 +46,34 @@ export function TriggerRun({ open, onOpenChange, onTriggered }: TriggerRunProps)
   const availableTasks: TaskRow[] = tasksData?.tasks ?? [];
   const defaultTask = availableTasks.find((t: TaskRow) => t.isDefault);
   const effectiveSelection = selectedTask ?? defaultTask?.name ?? availableTasks[0]?.name ?? '';
+  const selectedTaskRow = availableTasks.find((task) => task.name === effectiveSelection);
+  const { data: taskConfigData } = useTaskConfig(effectiveSelection || undefined);
+  const taskConfig = taskConfigData?.config;
+  const execution = selectedTaskRow?.execution;
+  const globalProvider = effective?.agent?.provider;
+  const effectiveRuntime = taskConfig?.runtime
+    ?? taskConfig?.provider?.runtime
+    ?? inferRuntimeFromProviderType(taskConfig?.provider?.type)
+    ?? execution?.runtime
+    ?? execution?.provider?.runtime
+    ?? inferRuntimeFromProviderType(execution?.provider?.type)
+    ?? globalProvider?.runtime
+    ?? inferRuntimeFromProviderType(globalProvider?.type)
+    ?? effective?.agent?.runtime
+    ?? 'claude-sdk';
+  const effectiveProvider = taskConfig?.provider?.type
+    ?? execution?.provider?.type
+    ?? globalProvider?.type
+    ?? 'anthropic';
+  const effectiveModel = resolveReasoningModel(
+    execution?.reasoningLevel ?? selectedTaskRow?.reasoningLevel,
+    taskConfig?.provider ?? execution?.provider ?? globalProvider,
+    taskConfig?.provider?.model
+      ?? taskConfig?.model
+      ?? execution?.model
+      ?? selectedTaskRow?.model
+      ?? globalProvider?.model,
+  );
 
   function handleRun() {
     const payload = {
@@ -97,6 +128,17 @@ export function TriggerRun({ open, onOpenChange, onTriggered }: TriggerRunProps)
               </Select>
             )}
           </div>
+
+          {selectedTaskRow && (
+            <div className="rounded-md bg-surface-container-low p-3">
+              <p className="font-sans text-xs text-on-surface-variant">Effective execution</p>
+              <div className="mt-1 flex flex-wrap gap-4 font-mono text-xs text-on-surface">
+                <span>runtime: {effectiveRuntime}</span>
+                <span>provider: {effectiveProvider}</span>
+                {effectiveModel && <span>model: {effectiveModel}</span>}
+              </div>
+            </div>
+          )}
 
           {/* Instruction field */}
           <div className="space-y-1.5">

--- a/packages/myco/ui/src/components/agent/helpers.ts
+++ b/packages/myco/ui/src/components/agent/helpers.ts
@@ -4,9 +4,11 @@ import { TASK_SOURCE_USER } from '../../lib/constants';
 import type { TaskRow } from '../../hooks/use-agent';
 
 /** Format a USD cost value for display. */
-export function formatCost(cost: number | null): string {
+export function formatCost(cost: number | null, source?: 'actual' | 'estimated' | 'unavailable' | null): string {
+  if (source === 'unavailable') return '\u2014';
   if (cost === null) return '\u2014';
-  return `$${cost.toFixed(4)}`;
+  const prefix = source === 'estimated' ? '~' : '';
+  return `${prefix}$${cost.toFixed(4)}`;
 }
 
 /** Format a token count for display. */

--- a/packages/myco/ui/src/components/providers/ProviderModelSelector.tsx
+++ b/packages/myco/ui/src/components/providers/ProviderModelSelector.tsx
@@ -3,7 +3,7 @@
  * Used by both the Settings page (global agent provider) and the Agent
  * Tasks page (per-task provider override).
  */
-import { Cloud, Server, Cpu } from 'lucide-react';
+import { Cloud, Server, Cpu, Loader2 } from 'lucide-react';
 import { Input } from '../ui/input';
 import { Badge } from '../ui/badge';
 import {
@@ -14,20 +14,35 @@ import {
   SelectValue,
 } from '../ui/select';
 import type { ProviderInfo } from '../../hooks/use-providers';
+import { useModels } from '../../hooks/use-models';
+
+const RUNTIME_LABELS: Record<string, string> = {
+  'claude-sdk': 'Claude SDK',
+  'openai-agents': 'OpenAI Agents',
+};
 
 const PROVIDER_LABELS: Record<string, string> = {
   anthropic: 'Anthropic',
   ollama: 'Ollama',
   lmstudio: 'LM Studio',
+  openai: 'OpenAI',
+  openrouter: 'OpenRouter',
+  'openai-compatible': 'OpenAI-compatible',
 };
 
 const PROVIDER_ICONS: Record<string, typeof Cloud> = {
   anthropic: Cloud,
   ollama: Server,
   lmstudio: Cpu,
+  openai: Cloud,
+  openrouter: Cloud,
+  'openai-compatible': Server,
 };
 
+const MANUAL_MODEL_ENTRY_PROVIDERS = new Set(['ollama', 'lmstudio', 'openai-compatible']);
+
 export interface ProviderModelSelectorProps {
+  runtime: string;
   providerType: string;
   model: string;
   baseUrl: string;
@@ -35,6 +50,8 @@ export interface ProviderModelSelectorProps {
   modelPlaceholder?: string;
   providers: ProviderInfo[];
   isLoadingProviders: boolean;
+  showRuntimeSelector?: boolean;
+  onRuntimeChange: (runtime: string) => void;
   onProviderChange: (type: string) => void;
   onModelChange: (model: string) => void;
   onBaseUrlChange: (url: string) => void;
@@ -46,6 +63,7 @@ export interface ProviderModelSelectorProps {
 }
 
 export function ProviderModelSelector({
+  runtime,
   providerType,
   model,
   baseUrl,
@@ -53,6 +71,8 @@ export function ProviderModelSelector({
   modelPlaceholder,
   providers,
   isLoadingProviders,
+  showRuntimeSelector = true,
+  onRuntimeChange,
   onProviderChange,
   onModelChange,
   onBaseUrlChange,
@@ -60,16 +80,46 @@ export function ProviderModelSelector({
   onBaseUrlBlur,
   onContextLengthBlur,
 }: ProviderModelSelectorProps) {
-  const selectedProvider = providers.find((p) => p.type === providerType);
-  const isLocal = providerType === 'ollama' || providerType === 'lmstudio';
+  const providersForRuntime = providers.filter((provider) => provider.runtime === runtime);
+  const selectedProvider = providersForRuntime.find((p) => p.type === providerType);
+  const isLocal = providerType === 'ollama' || providerType === 'lmstudio' || providerType === 'openai-compatible';
   const hasSelection = providerType !== '';
-  const availableModels = selectedProvider?.models ?? [];
+  const modelsQuery = useModels(providerType || null, baseUrl || selectedProvider?.baseUrl, 'llm');
+  const availableModels = modelsQuery.data?.models ?? selectedProvider?.models ?? [];
+  const allowsManualModelEntry = MANUAL_MODEL_ENTRY_PROVIDERS.has(providerType);
+  const shouldShowModelSelect = availableModels.length > 0;
+  const isLoadingModels = modelsQuery.isPending && hasSelection;
+  const needsApiKey = selectedProvider?.authConfigured === false;
+  const modelEmptyState = needsApiKey
+    ? 'Configure an API key to load models.'
+    : selectedProvider?.available === false
+      ? 'Provider unavailable.'
+      : 'No models returned.';
+  const modelPlaceholderText = modelPlaceholder ?? 'Select a model';
 
   return (
     <div className="space-y-3">
+      {showRuntimeSelector && (
+        <div className="space-y-1">
+          <label className="font-sans text-xs text-on-surface-variant">Runtime</label>
+          <Select value={runtime} onValueChange={onRuntimeChange}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select a runtime" />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.entries(RUNTIME_LABELS).map(([value, label]) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
       {/* Provider selector — derived from /providers response order */}
       <div className="grid grid-cols-3 gap-2">
-        {providers.map((info) => {
+        {providersForRuntime.map((info) => {
           const Icon = PROVIDER_ICONS[info.type];
           if (!Icon) return null;
           const isSelected = providerType === info.type;
@@ -89,10 +139,10 @@ export function ProviderModelSelector({
               <span className="font-sans text-xs font-medium">{PROVIDER_LABELS[info.type] ?? info.type}</span>
               {!isLoadingProviders && (
                 <Badge
-                  variant={info.available ? 'secondary' : 'destructive'}
+                  variant={info.authConfigured === false || !info.available ? 'destructive' : 'secondary'}
                   className="text-[10px] px-1.5 py-0"
                 >
-                  {info.available ? 'online' : 'offline'}
+                  {info.authConfigured === false ? 'key required' : info.available ? 'online' : 'offline'}
                 </Badge>
               )}
             </button>
@@ -136,10 +186,15 @@ export function ProviderModelSelector({
       {hasSelection && (
         <div className="space-y-1">
           <label className="font-sans text-xs text-on-surface-variant">Model</label>
-          {availableModels.length > 0 ? (
+          {isLoadingModels ? (
+            <div className="flex items-center gap-2 rounded-md border border-[var(--ghost-border)] bg-surface-container-lowest px-3 py-2 text-sm text-on-surface-variant">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading models...
+            </div>
+          ) : shouldShowModelSelect ? (
             <Select value={model} onValueChange={onModelChange}>
               <SelectTrigger>
-                <SelectValue placeholder={modelPlaceholder ?? 'Select a model'} />
+                <SelectValue placeholder={modelPlaceholderText} />
               </SelectTrigger>
               <SelectContent>
                 {availableModels.map((m) => (
@@ -149,13 +204,17 @@ export function ProviderModelSelector({
                 ))}
               </SelectContent>
             </Select>
-          ) : (
+          ) : allowsManualModelEntry ? (
             <Input
               value={model}
               onChange={(e) => onModelChange(e.target.value)}
               placeholder={selectedProvider?.available === false ? 'Provider offline' : 'Enter model name'}
               disabled={selectedProvider?.available === false}
             />
+          ) : (
+            <div className="rounded-md border border-[var(--ghost-border)] bg-surface-container-lowest px-3 py-2">
+              <p className="font-sans text-sm text-on-surface-variant">{modelEmptyState}</p>
+            </div>
           )}
         </div>
       )}

--- a/packages/myco/ui/src/components/providers/ProviderModelSelector.tsx
+++ b/packages/myco/ui/src/components/providers/ProviderModelSelector.tsx
@@ -14,7 +14,7 @@ import {
   SelectValue,
 } from '../ui/select';
 import { SearchableSelect } from '../ui/searchable-select';
-import type { ProviderInfo } from '../../hooks/use-providers';
+import { defaultBaseUrlForProvider, providerSupportsRuntime, type ProviderInfo } from '../../hooks/use-providers';
 import { useModels } from '../../hooks/use-models';
 
 const RUNTIME_LABELS: Record<string, string> = {
@@ -41,10 +41,15 @@ const PROVIDER_ICONS: Record<string, typeof Cloud> = {
 };
 
 const MANUAL_MODEL_ENTRY_PROVIDERS = new Set(['ollama', 'lmstudio', 'openai-compatible']);
+const OPENAI_COMPATIBLE_BACKEND_OPTIONS = [
+  { value: 'lmstudio', label: 'LM Studio' },
+  { value: 'ollama', label: 'Ollama' },
+] as const;
 
 export interface ProviderModelSelectorProps {
   runtime: string;
   providerType: string;
+  localBackend?: 'ollama' | 'lmstudio' | '';
   model: string;
   baseUrl: string;
   contextLength: string;
@@ -54,6 +59,7 @@ export interface ProviderModelSelectorProps {
   showRuntimeSelector?: boolean;
   onRuntimeChange: (runtime: string) => void;
   onProviderChange: (type: string) => void;
+  onLocalBackendChange?: (localBackend: 'ollama' | 'lmstudio' | '') => void;
   onModelChange: (model: string) => void;
   onBaseUrlChange: (url: string) => void;
   onContextLengthChange: (ctx: string) => void;
@@ -66,6 +72,7 @@ export interface ProviderModelSelectorProps {
 export function ProviderModelSelector({
   runtime,
   providerType,
+  localBackend = '',
   model,
   baseUrl,
   contextLength,
@@ -75,17 +82,19 @@ export function ProviderModelSelector({
   showRuntimeSelector = true,
   onRuntimeChange,
   onProviderChange,
+  onLocalBackendChange,
   onModelChange,
   onBaseUrlChange,
   onContextLengthChange,
   onBaseUrlBlur,
   onContextLengthBlur,
 }: ProviderModelSelectorProps) {
-  const providersForRuntime = providers.filter((provider) => provider.runtime === runtime);
-  const selectedProvider = providersForRuntime.find((p) => p.type === providerType);
+  const providersForRuntime = providers.filter((provider) => providerSupportsRuntime(provider.type, runtime as 'claude-sdk' | 'openai-agents'));
+  const selectedProvider = providers.find((p) => p.type === providerType);
   const isLocal = providerType === 'ollama' || providerType === 'lmstudio' || providerType === 'openai-compatible';
   const hasSelection = providerType !== '';
-  const modelsQuery = useModels(providerType || null, baseUrl || selectedProvider?.baseUrl, 'llm');
+  const resolvedBaseUrl = baseUrl || defaultBaseUrlForProvider(providerType as 'ollama' | 'lmstudio' | 'openai-compatible' | undefined, localBackend, selectedProvider?.baseUrl);
+  const modelsQuery = useModels(providerType || null, resolvedBaseUrl, 'llm', localBackend || null);
   const availableModels = modelsQuery.data?.models ?? selectedProvider?.models ?? [];
   const allowsManualModelEntry = MANUAL_MODEL_ENTRY_PROVIDERS.has(providerType);
   const shouldShowModelSelect = availableModels.length > 0;
@@ -159,8 +168,30 @@ export function ProviderModelSelector({
             value={baseUrl}
             onChange={(e) => onBaseUrlChange(e.target.value)}
             onBlur={onBaseUrlBlur}
-            placeholder={selectedProvider?.baseUrl ?? ''}
+            placeholder={resolvedBaseUrl}
           />
+        </div>
+      )}
+
+      {providerType === 'openai-compatible' && onLocalBackendChange && (
+        <div className="space-y-1">
+          <label className="font-sans text-xs text-on-surface-variant">Local Backend</label>
+          <Select value={localBackend || 'lmstudio'} onValueChange={(value) => onLocalBackendChange(value as 'ollama' | 'lmstudio')}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select a backend" />
+            </SelectTrigger>
+            <SelectContent>
+              {OPENAI_COMPATIBLE_BACKEND_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="font-sans text-[11px] text-on-surface-variant/70">
+            OpenAI-compatible chat endpoints look the same, but local backends
+            still need different model-loading and context handling.
+          </p>
         </div>
       )}
 

--- a/packages/myco/ui/src/components/providers/ProviderModelSelector.tsx
+++ b/packages/myco/ui/src/components/providers/ProviderModelSelector.tsx
@@ -13,6 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../ui/select';
+import { SearchableSelect } from '../ui/searchable-select';
 import type { ProviderInfo } from '../../hooks/use-providers';
 import { useModels } from '../../hooks/use-models';
 
@@ -192,18 +193,19 @@ export function ProviderModelSelector({
               Loading models...
             </div>
           ) : shouldShowModelSelect ? (
-            <Select value={model} onValueChange={onModelChange}>
-              <SelectTrigger>
-                <SelectValue placeholder={modelPlaceholderText} />
-              </SelectTrigger>
-              <SelectContent>
-                {availableModels.map((m) => (
-                  <SelectItem key={m} value={m}>
-                    <span className="font-mono text-sm">{m}</span>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <SearchableSelect
+              value={model}
+              onValueChange={onModelChange}
+              placeholder={modelPlaceholderText}
+              searchPlaceholder="Search models..."
+              emptyMessage="No models match that search."
+              options={availableModels.map((candidate) => ({
+                value: candidate,
+                label: candidate,
+              }))}
+              sortOptions
+              monospace
+            />
           ) : allowsManualModelEntry ? (
             <Input
               value={model}

--- a/packages/myco/ui/src/components/ui/searchable-select.tsx
+++ b/packages/myco/ui/src/components/ui/searchable-select.tsx
@@ -1,0 +1,280 @@
+import { Check, ChevronDown, Search } from 'lucide-react';
+import {
+  useDeferredValue,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { cn } from '../../lib/cn';
+import { Input } from './input';
+
+const SEARCH_TOKEN_SPLIT = /[\s/_.:-]+/;
+const SEARCH_TOKEN_SPLIT_GLOBAL = /[\s/_.:-]+/g;
+const LABEL_COLLATOR = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: 'base',
+});
+
+export interface SearchableSelectOption {
+  value: string;
+  label: string;
+  searchText?: string;
+}
+
+interface SearchableSelectProps {
+  options: SearchableSelectOption[];
+  value?: string;
+  onValueChange: (value: string) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+  disabled?: boolean;
+  sortOptions?: boolean;
+  className?: string;
+  triggerClassName?: string;
+  contentClassName?: string;
+  monospace?: boolean;
+  renderOption?: (option: SearchableSelectOption) => ReactNode;
+  renderValue?: (option: SearchableSelectOption) => ReactNode;
+}
+
+function normalizeSearchText(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function tokenizeSearchText(value: string): string[] {
+  return normalizeSearchText(value).split(SEARCH_TOKEN_SPLIT).filter(Boolean);
+}
+
+function shouldUseTokenMatch(queryTokens: string[]): boolean {
+  return queryTokens.length > 1 && queryTokens.every((token) => token.length >= 2);
+}
+
+export function getSearchableSelectRank(
+  option: SearchableSelectOption,
+  rawQuery: string,
+): number | null {
+  const query = normalizeSearchText(rawQuery);
+  if (query === '') {
+    return 0;
+  }
+
+  const label = normalizeSearchText(option.label);
+  const value = normalizeSearchText(option.value);
+  const searchCorpus = normalizeSearchText(
+    `${option.label} ${option.value} ${option.searchText ?? ''}`,
+  );
+  const queryTokens = tokenizeSearchText(query);
+  const corpusTokens = tokenizeSearchText(searchCorpus);
+  const compactQuery = query.replace(SEARCH_TOKEN_SPLIT_GLOBAL, '');
+  const compactCorpus = searchCorpus.replace(SEARCH_TOKEN_SPLIT_GLOBAL, '');
+
+  if (label === query || value === query) {
+    return 0;
+  }
+  if (label.startsWith(query) || value.startsWith(query)) {
+    return 1;
+  }
+  if (label.includes(query) || value.includes(query) || searchCorpus.includes(query)) {
+    return 2;
+  }
+  if (corpusTokens.some((token) => token.startsWith(query))) {
+    return 3;
+  }
+  if (shouldUseTokenMatch(queryTokens) && queryTokens.every((token) => searchCorpus.includes(token))) {
+    return 4;
+  }
+  if (compactQuery !== '' && compactCorpus.includes(compactQuery)) {
+    return 5;
+  }
+
+  return null;
+}
+
+export function SearchableSelect({
+  options,
+  value,
+  onValueChange,
+  placeholder = 'Select an option',
+  searchPlaceholder = 'Search...',
+  emptyMessage = 'No matching options.',
+  disabled = false,
+  sortOptions = false,
+  className,
+  triggerClassName,
+  contentClassName,
+  monospace = false,
+  renderOption,
+  renderValue,
+}: SearchableSelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const deferredQuery = useDeferredValue(query);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const listboxId = useId();
+
+  const processedOptions = useMemo(() => {
+    const next = [...options];
+    if (sortOptions) {
+      next.sort((left, right) => (
+        LABEL_COLLATOR.compare(left.label, right.label)
+        || LABEL_COLLATOR.compare(left.value, right.value)
+      ));
+    }
+    return next;
+  }, [options, sortOptions]);
+
+  const filteredOptions = useMemo(() => {
+    const ranked = processedOptions
+      .map((option) => ({ option, rank: getSearchableSelectRank(option, deferredQuery) }))
+      .filter(
+        (entry): entry is { option: SearchableSelectOption; rank: number } => entry.rank !== null,
+      );
+
+    ranked.sort((left, right) => (
+      left.rank - right.rank
+      || LABEL_COLLATOR.compare(left.option.label, right.option.label)
+      || LABEL_COLLATOR.compare(left.option.value, right.option.value)
+    ));
+
+    return ranked.map((entry) => entry.option);
+  }, [deferredQuery, processedOptions]);
+
+  const selectedOption = processedOptions.find((option) => option.value === value);
+  const fallbackSelectedOption = value
+    ? { value, label: value }
+    : undefined;
+  const displayedOption = selectedOption ?? fallbackSelectedOption;
+
+  useEffect(() => {
+    if (!isOpen) {
+      setQuery('');
+      return;
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
+
+  return (
+    <div ref={containerRef} className={cn('relative', className)}>
+      <button
+        ref={triggerRef}
+        type="button"
+        disabled={disabled}
+        aria-expanded={isOpen}
+        aria-controls={listboxId}
+        className={cn(
+          'flex h-9 w-full items-center justify-between rounded-md border border-[var(--ghost-border)] bg-surface-container-lowest px-3 py-2 text-left text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:border-primary/40 disabled:cursor-not-allowed disabled:opacity-50',
+          triggerClassName,
+        )}
+        onClick={() => setIsOpen((current) => !current)}
+      >
+        <span className={cn('truncate text-on-surface', !displayedOption && 'text-on-surface-variant/60')}>
+          {displayedOption
+            ? renderValue?.(displayedOption) ?? (
+              <span className={cn(monospace && 'font-mono')}>{displayedOption.label}</span>
+            )
+            : placeholder}
+        </span>
+        <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
+      </button>
+
+      {isOpen ? (
+        <div
+          className={cn(
+            'absolute left-0 right-0 z-50 mt-1 rounded-md border border-[var(--ghost-border)] bg-surface-container-highest shadow-ambient',
+            contentClassName,
+          )}
+        >
+          <div className="border-b border-[var(--ghost-border)] p-2">
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-on-surface-variant/70" />
+              <Input
+                ref={searchInputRef}
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder={searchPlaceholder}
+                className="pl-9"
+              />
+            </div>
+          </div>
+
+          <div
+            id={listboxId}
+            role="listbox"
+            className="max-h-72 overflow-y-auto p-1"
+          >
+            {filteredOptions.length > 0 ? (
+              filteredOptions.map((option) => {
+                const isSelected = option.value === value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    role="option"
+                    aria-selected={isSelected}
+                    className={cn(
+                      'flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-left text-sm text-on-surface outline-none transition-colors hover:bg-surface-bright focus-visible:bg-surface-bright',
+                      isSelected && 'bg-surface-bright',
+                    )}
+                    onClick={() => {
+                      onValueChange(option.value);
+                      setIsOpen(false);
+                      triggerRef.current?.focus();
+                    }}
+                  >
+                    <span className={cn('truncate', monospace && 'font-mono')}>
+                      {renderOption?.(option) ?? option.label}
+                    </span>
+                    {isSelected ? <Check className="ml-2 h-4 w-4 shrink-0" /> : null}
+                  </button>
+                );
+              })
+            ) : (
+              <div className="px-2 py-3 text-sm text-on-surface-variant">
+                {emptyMessage}
+              </div>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/myco/ui/src/hooks/use-agent.ts
+++ b/packages/myco/ui/src/hooks/use-agent.ts
@@ -34,12 +34,29 @@ export interface RunRow {
   task: string | null;
   instruction: string | null;
   status: string;
+  runtime: string | null;
+  provider: string | null;
+  model: string | null;
+  session_ref: string | null;
+  resumable: boolean;
+  resume_status: string | null;
+  resume_mode: string | null;
+  resumed_at: number | null;
+  checkpoints: string | null;
+  usage_data: string | null;
   started_at: number | null;
   completed_at: number | null;
   tokens_used: number | null;
   cost_usd: number | null;
   actions_taken: string | null;
   error: string | null;
+  phase_checkpoints?: Array<{
+    name: string;
+    status: string;
+    updatedAt: number;
+    tokensUsed?: number;
+    costUsd?: number;
+  }>;
 }
 
 export interface RunsResponse {
@@ -94,12 +111,24 @@ export interface TaskRow {
   isBuiltin?: boolean;
   toolOverrides?: string[];
   model?: string;
+  reasoningLevel?: 'low' | 'default' | 'high';
   maxTurns?: number;
   timeoutSeconds?: number;
   phases?: PhaseDefinition[];
-  execution?: { model?: string; maxTurns?: number; timeoutSeconds?: number };
+  execution?: {
+    runtime?: string;
+    provider?: {
+      type?: string;
+      model?: string;
+      reasoning_map?: Partial<Record<'low' | 'default' | 'high', string>>;
+    };
+    model?: string;
+    reasoningLevel?: 'low' | 'default' | 'high';
+    maxTurns?: number;
+    timeoutSeconds?: number;
+  };
   contextQueries?: Record<string, unknown[]>;
-  orchestrator?: { enabled: boolean; model?: string; maxTurns?: number };
+  orchestrator?: { enabled: boolean; model?: string; reasoningLevel?: 'low' | 'default' | 'high'; maxTurns?: number };
   schedule?: { enabled: boolean; intervalSeconds: number; runIn: ('active' | 'idle' | 'sleep')[]; preCondition?: string };
   params?: Record<string, string | number | boolean>;
   schemaVersion?: number;
@@ -111,6 +140,12 @@ export interface TriggerRunPayload {
 }
 
 export interface TriggerRunResponse {
+  ok: boolean;
+  message: string;
+  runId?: string;
+}
+
+export interface ResumeRunResponse {
   ok: boolean;
   message: string;
   runId?: string;
@@ -130,6 +165,7 @@ export interface PhaseDefinition {
   tools: string[];
   maxTurns: number;
   model?: string;
+  reasoningLevel?: 'low' | 'default' | 'high';
   required: boolean;
 }
 
@@ -301,6 +337,19 @@ export function useTriggerRun() {
       postJson<TriggerRunResponse>('/agent/run', payload),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['agent-runs'] });
+    },
+  });
+}
+
+export function useResumeRun() {
+  const queryClient = useQueryClient();
+
+  return useMutation<ResumeRunResponse, Error, { runId: string; mode?: 'manual' | 'scheduled' }>({
+    mutationFn: ({ runId, mode }) =>
+      postJson<ResumeRunResponse>(`/agent/runs/${runId}/resume`, mode ? { mode } : {}),
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({ queryKey: ['agent-runs'] });
+      void queryClient.invalidateQueries({ queryKey: ['agent-run', variables.runId] });
     },
   });
 }

--- a/packages/myco/ui/src/hooks/use-agent.ts
+++ b/packages/myco/ui/src/hooks/use-agent.ts
@@ -48,6 +48,10 @@ export interface RunRow {
   completed_at: number | null;
   tokens_used: number | null;
   cost_usd: number | null;
+  actual_cost_usd: number | null;
+  estimated_cost_usd: number | null;
+  cost_source: 'actual' | 'estimated' | 'unavailable' | null;
+  cost_data: string | null;
   actions_taken: string | null;
   error: string | null;
   phase_checkpoints?: Array<{
@@ -56,6 +60,7 @@ export interface RunRow {
     updatedAt: number;
     tokensUsed?: number;
     costUsd?: number;
+    costSource?: 'actual' | 'estimated' | 'unavailable';
   }>;
 }
 

--- a/packages/myco/ui/src/hooks/use-config.ts
+++ b/packages/myco/ui/src/hooks/use-config.ts
@@ -37,7 +37,19 @@ export interface MycoConfig {
     summary_batch_interval: number;
     scheduled_tasks_enabled?: boolean;
     event_tasks_enabled?: boolean;
-    provider?: { type: string; base_url?: string; model?: string; context_length?: number };
+    runtime?: 'claude-sdk' | 'openai-agents';
+    provider?: {
+      runtime?: 'claude-sdk' | 'openai-agents';
+      type: string;
+      base_url?: string;
+      model?: string;
+      reasoning_map?: {
+        low?: string;
+        default?: string;
+        high?: string;
+      };
+      context_length?: number;
+    };
     model?: string;
     tasks?: Record<string, unknown>;
   };

--- a/packages/myco/ui/src/hooks/use-models.ts
+++ b/packages/myco/ui/src/hooks/use-models.ts
@@ -12,17 +12,23 @@ export const REQUIRES_BASE_URL = new Set(['openai-compatible']);
 
 export type ModelType = 'llm' | 'embedding';
 
-export function useModels(provider: string | null, baseUrl?: string | null, type?: ModelType) {
+export function useModels(
+  provider: string | null,
+  baseUrl?: string | null,
+  type?: ModelType,
+  localBackend?: 'ollama' | 'lmstudio' | null,
+) {
   // Don't fetch if provider needs a base_url and none is provided
   const needsUrl = provider ? REQUIRES_BASE_URL.has(provider) : false;
   const canFetch = !!provider && (!needsUrl || !!baseUrl);
 
   return useQuery<ModelsResponse>({
-    queryKey: ['models', provider, baseUrl, type],
+    queryKey: ['models', provider, baseUrl, type, localBackend],
     queryFn: ({ signal }) => {
       const params = new URLSearchParams({ provider: provider! });
       if (baseUrl) params.set('base_url', baseUrl);
       if (type) params.set('type', type);
+      if (localBackend) params.set('local_backend', localBackend);
       return fetchJson<ModelsResponse>(`/models?${params.toString()}`, { signal });
     },
     enabled: canFetch,

--- a/packages/myco/ui/src/hooks/use-provider-config-draft.ts
+++ b/packages/myco/ui/src/hooks/use-provider-config-draft.ts
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  defaultBaseUrlForProvider,
   draftToProviderConfig,
   maybeInferRuntimeFromProviderType,
+  providerSupportsRuntime,
   seedDraftFromProviderType,
   type ProviderConfig,
   type ProviderDraft,
@@ -16,6 +18,7 @@ export interface ProviderDraftSource {
   provider?: {
     runtime?: string;
     type?: string;
+    local_backend?: 'ollama' | 'lmstudio';
     model?: string;
     reasoning_map?: Partial<Record<ReasoningLevel, string>>;
     base_url?: string;
@@ -26,6 +29,7 @@ export interface ProviderDraftSource {
 export interface ProviderDraftDefaults {
   runtime?: string;
   providerType?: string;
+  localBackend?: 'ollama' | 'lmstudio';
   model?: string;
   reasoningMap?: Partial<Record<ReasoningLevel, string>>;
   baseUrl?: string;
@@ -36,6 +40,7 @@ export function emptyProviderDraft(): ProviderDraft {
   return {
     runtime: '',
     type: '',
+    localBackend: '',
     model: '',
     reasoningLow: '',
     reasoningDefault: '',
@@ -66,6 +71,7 @@ export function providerDraftFromSource(
     return {
       runtime: runtimeFromSource(source, defaults),
       type: providerType,
+      localBackend: source?.provider?.local_backend ?? defaults?.localBackend ?? '',
       model: source?.provider?.model ?? source?.model ?? '',
       reasoningLow: source?.provider?.reasoning_map?.low ?? '',
       reasoningDefault: source?.provider?.reasoning_map?.default
@@ -81,6 +87,7 @@ export function providerDraftFromSource(
   return {
     runtime: runtimeFromSource(source, defaults),
     type: (defaults?.providerType as ProviderDraft['type'] | undefined) ?? '',
+    localBackend: defaults?.localBackend ?? '',
     model: source?.model ?? defaults?.model ?? '',
     reasoningLow: defaults?.reasoningMap?.low ?? '',
     reasoningDefault: defaults?.reasoningMap?.default
@@ -96,6 +103,7 @@ export function providerDraftFromSource(
 export function providerDraftsEqual(left: ProviderDraft, right: ProviderDraft): boolean {
   return left.runtime === right.runtime
     && left.type === right.type
+    && left.localBackend === right.localBackend
     && left.model === right.model
     && left.reasoningLow === right.reasoningLow
     && left.reasoningDefault === right.reasoningDefault
@@ -123,10 +131,16 @@ export function draftToNormalizedProviderConfig(
   });
 }
 
+function isDefaultLocalBaseUrl(value: string): boolean {
+  return value === ''
+    || value === defaultBaseUrlForProvider('openai-compatible', 'ollama')
+    || value === defaultBaseUrlForProvider('openai-compatible', 'lmstudio');
+}
+
 function nextDraftForRuntime(runtime: string, providers: ProviderInfo[]): ProviderDraft {
-  const firstProvider = providers.find((provider) => provider.runtime === runtime);
+  const firstProvider = providers.find((provider) => providerSupportsRuntime(provider.type, runtime as ProviderDraft['runtime']));
   if (firstProvider) {
-    return seedDraftFromProviderType(firstProvider.type, providers);
+    return seedDraftFromProviderType(firstProvider.type, providers, runtime as ProviderDraft['runtime']);
   }
   return {
     ...emptyProviderDraft(),
@@ -152,6 +166,7 @@ export function useProviderConfigDraft({
       source?.model,
       source?.provider?.runtime,
       source?.provider?.type,
+      source?.provider?.local_backend,
       source?.provider?.model,
       source?.provider?.reasoning_map?.low,
       source?.provider?.reasoning_map?.default,
@@ -160,6 +175,7 @@ export function useProviderConfigDraft({
       source?.provider?.context_length,
       defaults?.runtime,
       defaults?.providerType,
+      defaults?.localBackend,
       defaults?.model,
       defaults?.reasoningMap?.low,
       defaults?.reasoningMap?.default,
@@ -179,11 +195,20 @@ export function useProviderConfigDraft({
   const isDirty = !providerDraftsEqual(draft, savedDraft);
 
   const handleRuntimeChange = useCallback((runtime: string) => {
-    setDraft(nextDraftForRuntime(runtime, providers));
+    setDraft((prev) => {
+      if (providerSupportsRuntime(prev.type, runtime as ProviderDraft['runtime'])) {
+        return { ...prev, runtime: runtime as ProviderDraft['runtime'] };
+      }
+      return nextDraftForRuntime(runtime, providers);
+    });
   }, [providers]);
 
   const handleProviderChange = useCallback((type: string) => {
-    setDraft(seedDraftFromProviderType(type, providers));
+    setDraft((prev) => seedDraftFromProviderType(
+      type,
+      providers,
+      providerSupportsRuntime(type as ProviderDraft['type'], prev.runtime) ? prev.runtime : undefined,
+    ));
   }, [providers]);
 
   const handleModelChange = useCallback((model: string) => {
@@ -191,6 +216,24 @@ export function useProviderConfigDraft({
       ...prev,
       model,
       reasoningDefault: prev.reasoningDefault || model,
+    }));
+  }, []);
+
+  const handleLocalBackendChange = useCallback((localBackend: ProviderDraft['localBackend']) => {
+    setDraft((prev) => ({
+      ...prev,
+      localBackend,
+      ...(prev.type === 'openai-compatible' && localBackend && isDefaultLocalBaseUrl(prev.baseUrl)
+        ? { baseUrl: defaultBaseUrlForProvider(prev.type, localBackend) }
+        : {}),
+      ...(prev.type === 'openai-compatible'
+        ? {
+            model: '',
+            reasoningLow: '',
+            reasoningDefault: '',
+            reasoningHigh: '',
+          }
+        : {}),
     }));
   }, []);
 
@@ -236,6 +279,7 @@ export function useProviderConfigDraft({
     handleRuntimeChange,
     handleProviderChange,
     handleModelChange,
+    handleLocalBackendChange,
     handleReasoningChange,
     handleBaseUrlChange,
     handleContextLengthChange,

--- a/packages/myco/ui/src/hooks/use-provider-config-draft.ts
+++ b/packages/myco/ui/src/hooks/use-provider-config-draft.ts
@@ -1,0 +1,243 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  draftToProviderConfig,
+  maybeInferRuntimeFromProviderType,
+  seedDraftFromProviderType,
+  type ProviderConfig,
+  type ProviderDraft,
+  type ProviderInfo,
+} from './use-providers';
+
+type ReasoningLevel = 'low' | 'default' | 'high';
+
+export interface ProviderDraftSource {
+  runtime?: string;
+  model?: string;
+  provider?: {
+    runtime?: string;
+    type?: string;
+    model?: string;
+    reasoning_map?: Partial<Record<ReasoningLevel, string>>;
+    base_url?: string;
+    context_length?: number;
+  };
+}
+
+export interface ProviderDraftDefaults {
+  runtime?: string;
+  providerType?: string;
+  model?: string;
+  reasoningMap?: Partial<Record<ReasoningLevel, string>>;
+  baseUrl?: string;
+  contextLength?: number;
+}
+
+export function emptyProviderDraft(): ProviderDraft {
+  return {
+    runtime: '',
+    type: '',
+    model: '',
+    reasoningLow: '',
+    reasoningDefault: '',
+    reasoningHigh: '',
+    baseUrl: '',
+    contextLength: '',
+  };
+}
+
+function runtimeFromSource(
+  source: ProviderDraftSource | null | undefined,
+  defaults?: ProviderDraftDefaults,
+): ProviderDraft['runtime'] | '' {
+  return (source?.runtime as ProviderDraft['runtime'] | undefined)
+    ?? (source?.provider?.runtime as ProviderDraft['runtime'] | undefined)
+    ?? maybeInferRuntimeFromProviderType(source?.provider?.type as ProviderDraft['type'] | undefined)
+    ?? (defaults?.runtime as ProviderDraft['runtime'] | undefined)
+    ?? maybeInferRuntimeFromProviderType(defaults?.providerType as ProviderDraft['type'] | undefined)
+    ?? '';
+}
+
+export function providerDraftFromSource(
+  source: ProviderDraftSource | null | undefined,
+  defaults?: ProviderDraftDefaults,
+): ProviderDraft {
+  const providerType = (source?.provider?.type as ProviderDraft['type'] | undefined) ?? '';
+  if (providerType !== '') {
+    return {
+      runtime: runtimeFromSource(source, defaults),
+      type: providerType,
+      model: source?.provider?.model ?? source?.model ?? '',
+      reasoningLow: source?.provider?.reasoning_map?.low ?? '',
+      reasoningDefault: source?.provider?.reasoning_map?.default
+        ?? source?.provider?.model
+        ?? source?.model
+        ?? '',
+      reasoningHigh: source?.provider?.reasoning_map?.high ?? '',
+      baseUrl: source?.provider?.base_url ?? '',
+      contextLength: source?.provider?.context_length?.toString() ?? '',
+    };
+  }
+
+  return {
+    runtime: runtimeFromSource(source, defaults),
+    type: (defaults?.providerType as ProviderDraft['type'] | undefined) ?? '',
+    model: source?.model ?? defaults?.model ?? '',
+    reasoningLow: defaults?.reasoningMap?.low ?? '',
+    reasoningDefault: defaults?.reasoningMap?.default
+      ?? source?.model
+      ?? defaults?.model
+      ?? '',
+    reasoningHigh: defaults?.reasoningMap?.high ?? '',
+    baseUrl: defaults?.baseUrl ?? '',
+    contextLength: defaults?.contextLength != null ? String(defaults.contextLength) : '',
+  };
+}
+
+export function providerDraftsEqual(left: ProviderDraft, right: ProviderDraft): boolean {
+  return left.runtime === right.runtime
+    && left.type === right.type
+    && left.model === right.model
+    && left.reasoningLow === right.reasoningLow
+    && left.reasoningDefault === right.reasoningDefault
+    && left.reasoningHigh === right.reasoningHigh
+    && left.baseUrl === right.baseUrl
+    && left.contextLength === right.contextLength;
+}
+
+export function normalizeSelectableModel(value: string, availableModels: string[]): string {
+  if (value === '' || availableModels.length === 0) {
+    return value;
+  }
+  return availableModels.includes(value) ? value : '';
+}
+
+export function draftToNormalizedProviderConfig(
+  draft: ProviderDraft,
+  availableModels: string[],
+): ProviderConfig | undefined {
+  return draftToProviderConfig({
+    ...draft,
+    reasoningLow: normalizeSelectableModel(draft.reasoningLow, availableModels),
+    reasoningDefault: normalizeSelectableModel(draft.reasoningDefault, availableModels),
+    reasoningHigh: normalizeSelectableModel(draft.reasoningHigh, availableModels),
+  });
+}
+
+function nextDraftForRuntime(runtime: string, providers: ProviderInfo[]): ProviderDraft {
+  const firstProvider = providers.find((provider) => provider.runtime === runtime);
+  if (firstProvider) {
+    return seedDraftFromProviderType(firstProvider.type, providers);
+  }
+  return {
+    ...emptyProviderDraft(),
+    runtime: runtime as ProviderDraft['runtime'],
+  };
+}
+
+interface UseProviderConfigDraftOptions {
+  source?: ProviderDraftSource | null;
+  defaults?: ProviderDraftDefaults;
+  providers: ProviderInfo[];
+}
+
+export function useProviderConfigDraft({
+  source,
+  defaults,
+  providers,
+}: UseProviderConfigDraftOptions) {
+  const sourceDraft = useMemo(
+    () => providerDraftFromSource(source, defaults),
+    [
+      source?.runtime,
+      source?.model,
+      source?.provider?.runtime,
+      source?.provider?.type,
+      source?.provider?.model,
+      source?.provider?.reasoning_map?.low,
+      source?.provider?.reasoning_map?.default,
+      source?.provider?.reasoning_map?.high,
+      source?.provider?.base_url,
+      source?.provider?.context_length,
+      defaults?.runtime,
+      defaults?.providerType,
+      defaults?.model,
+      defaults?.reasoningMap?.low,
+      defaults?.reasoningMap?.default,
+      defaults?.reasoningMap?.high,
+      defaults?.baseUrl,
+      defaults?.contextLength,
+    ],
+  );
+  const [savedDraft, setSavedDraft] = useState<ProviderDraft>(sourceDraft);
+  const [draft, setDraft] = useState<ProviderDraft>(sourceDraft);
+
+  useEffect(() => {
+    setSavedDraft(sourceDraft);
+    setDraft(sourceDraft);
+  }, [sourceDraft]);
+
+  const isDirty = !providerDraftsEqual(draft, savedDraft);
+
+  const handleRuntimeChange = useCallback((runtime: string) => {
+    setDraft(nextDraftForRuntime(runtime, providers));
+  }, [providers]);
+
+  const handleProviderChange = useCallback((type: string) => {
+    setDraft(seedDraftFromProviderType(type, providers));
+  }, [providers]);
+
+  const handleModelChange = useCallback((model: string) => {
+    setDraft((prev) => ({
+      ...prev,
+      model,
+      reasoningDefault: prev.reasoningDefault || model,
+    }));
+  }, []);
+
+  const handleReasoningChange = useCallback((level: ReasoningLevel, value: string) => {
+    setDraft((prev) => ({
+      ...prev,
+      ...(level === 'low' ? { reasoningLow: value } : {}),
+      ...(level === 'default' ? { reasoningDefault: value } : {}),
+      ...(level === 'high' ? { reasoningHigh: value } : {}),
+    }));
+  }, []);
+
+  const handleBaseUrlChange = useCallback((baseUrl: string) => {
+    setDraft((prev) => ({ ...prev, baseUrl }));
+  }, []);
+
+  const handleContextLengthChange = useCallback((contextLength: string) => {
+    setDraft((prev) => ({ ...prev, contextLength }));
+  }, []);
+
+  const resetDraft = useCallback(() => {
+    setDraft(savedDraft);
+  }, [savedDraft]);
+
+  const commitDraft = useCallback((nextDraft?: ProviderDraft) => {
+    const committedDraft = nextDraft ?? draft;
+    setSavedDraft(committedDraft);
+    setDraft(committedDraft);
+  }, [draft]);
+
+  const clearDraft = useCallback(() => {
+    setDraft(emptyProviderDraft());
+  }, []);
+
+  return {
+    draft,
+    savedDraft,
+    isDirty,
+    setDraft,
+    commitDraft,
+    resetDraft,
+    clearDraft,
+    handleRuntimeChange,
+    handleProviderChange,
+    handleModelChange,
+    handleReasoningChange,
+    handleBaseUrlChange,
+    handleContextLengthChange,
+  };
+}

--- a/packages/myco/ui/src/hooks/use-provider-secrets.ts
+++ b/packages/myco/ui/src/hooks/use-provider-secrets.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { deleteJson, fetchJson, putJson } from '../lib/api';
+
+const PROVIDER_SECRETS_QUERY_KEY = ['provider-secrets'] as const;
+const PROVIDERS_QUERY_KEY = ['providers'] as const;
+const MODELS_QUERY_KEY = ['models'] as const;
+
+export type SecretProvider = 'openai' | 'openrouter';
+
+export interface ProviderSecretInfo {
+  configured: boolean;
+  envKey: string;
+  maskedValue: string | null;
+  source: 'vault' | 'env' | 'none';
+}
+
+export interface ProviderSecretsResponse {
+  secrets: Record<SecretProvider, ProviderSecretInfo>;
+}
+
+export function useProviderSecrets() {
+  return useQuery<ProviderSecretsResponse>({
+    queryKey: PROVIDER_SECRETS_QUERY_KEY,
+    queryFn: ({ signal }) => fetchJson<ProviderSecretsResponse>('/providers/secrets', { signal }),
+  });
+}
+
+function invalidateProviderQueries(queryClient: ReturnType<typeof useQueryClient>) {
+  void queryClient.invalidateQueries({ queryKey: PROVIDER_SECRETS_QUERY_KEY });
+  void queryClient.invalidateQueries({ queryKey: PROVIDERS_QUERY_KEY });
+  void queryClient.invalidateQueries({ queryKey: MODELS_QUERY_KEY });
+}
+
+export function useSaveProviderSecret() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ provider, apiKey }: { provider: SecretProvider; apiKey: string }) =>
+      putJson(`/providers/secrets/${provider}`, { api_key: apiKey }),
+    onSuccess: () => invalidateProviderQueries(queryClient),
+  });
+}
+
+export function useDeleteProviderSecret() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (provider: SecretProvider) => deleteJson(`/providers/secrets/${provider}`),
+    onSuccess: () => invalidateProviderQueries(queryClient),
+  });
+}

--- a/packages/myco/ui/src/hooks/use-providers.ts
+++ b/packages/myco/ui/src/hooks/use-providers.ts
@@ -24,6 +24,7 @@ export interface ProvidersResponse {
 export interface ProviderConfig {
   runtime?: 'claude-sdk' | 'openai-agents';
   type: ProviderInfo['type'];
+  local_backend?: 'ollama' | 'lmstudio';
   model?: string;
   reasoning_map?: Partial<Record<'low' | 'default' | 'high', string>>;
   base_url?: string;
@@ -61,12 +62,29 @@ export interface TaskConfigOverride {
 export interface ProviderDraft {
   runtime: ProviderConfig['runtime'] | '';
   type: ProviderConfig['type'] | '';
+  localBackend: ProviderConfig['local_backend'] | '';
   model: string;
   reasoningLow: string;
   reasoningDefault: string;
   reasoningHigh: string;
   baseUrl: string;
   contextLength: string;
+}
+
+export const LOCAL_BACKEND_DEFAULT_BASE_URLS = {
+  ollama: 'http://localhost:11434',
+  lmstudio: 'http://localhost:1234',
+} as const;
+
+export function defaultBaseUrlForProvider(
+  type: ProviderDraft['type'] | undefined,
+  localBackend: ProviderDraft['localBackend'] | undefined,
+  fallbackBaseUrl?: string,
+): string {
+  if (type === 'openai-compatible' && localBackend) {
+    return LOCAL_BACKEND_DEFAULT_BASE_URLS[localBackend];
+  }
+  return fallbackBaseUrl ?? '';
 }
 
 const PROVIDER_RUNTIME_BY_TYPE: Record<ProviderInfo['type'], ProviderInfo['runtime']> = {
@@ -92,6 +110,23 @@ export function maybeInferRuntimeFromProviderType(
   return runtime || undefined;
 }
 
+const PROVIDER_RUNTIME_SUPPORT: Record<ProviderInfo['type'], Array<ProviderInfo['runtime']>> = {
+  anthropic: ['claude-sdk'],
+  ollama: ['claude-sdk', 'openai-agents'],
+  lmstudio: ['claude-sdk', 'openai-agents'],
+  openai: ['openai-agents'],
+  openrouter: ['openai-agents'],
+  'openai-compatible': ['openai-agents'],
+};
+
+export function providerSupportsRuntime(
+  type: ProviderDraft['type'] | undefined,
+  runtime: ProviderDraft['runtime'] | '' | undefined,
+): boolean {
+  if (!type || !runtime) return false;
+  return PROVIDER_RUNTIME_SUPPORT[type]?.includes(runtime) ?? false;
+}
+
 export function resolveReasoningModel(
   reasoningLevel: 'low' | 'default' | 'high' | undefined,
   provider: {
@@ -114,6 +149,7 @@ export function resolveReasoningModel(
 export function seedDraftFromProviderType(
   type: string,
   providers: ProviderInfo[],
+  runtimeOverride?: ProviderDraft['runtime'],
 ): ProviderDraft {
   const info = providers.find((p) => p.type === type);
   const modelSet = new Set(info?.models ?? []);
@@ -123,8 +159,11 @@ export function seedDraftFromProviderType(
   const pickExact = (candidate: string) =>
     info?.models?.find((model) => model === candidate) ?? '';
   return {
-    runtime: info?.runtime ?? inferRuntimeFromProviderType(type as ProviderDraft['type']),
+    runtime: runtimeOverride && providerSupportsRuntime(type as ProviderDraft['type'], runtimeOverride)
+      ? runtimeOverride
+      : info?.runtime ?? inferRuntimeFromProviderType(type as ProviderDraft['type']),
     type: type as ProviderConfig['type'],
+    localBackend: '',
     model: defaultModel,
     reasoningLow: modelSet.size > 0
       ? (
@@ -165,6 +204,7 @@ export function draftToProviderConfig(draft: ProviderDraft): ProviderConfig | un
   return {
     ...(draft.runtime ? { runtime: draft.runtime } : {}),
     type: draft.type,
+    ...(draft.type === 'openai-compatible' && draft.localBackend ? { local_backend: draft.localBackend } : {}),
     ...(draft.model ? { model: draft.model } : {}),
     ...(Object.keys(reasoningMap).length > 0 ? { reasoning_map: reasoningMap } : {}),
     ...(isLocal && draft.baseUrl ? { base_url: draft.baseUrl } : {}),

--- a/packages/myco/ui/src/hooks/use-providers.ts
+++ b/packages/myco/ui/src/hooks/use-providers.ts
@@ -85,6 +85,13 @@ export function inferRuntimeFromProviderType(
   return PROVIDER_RUNTIME_BY_TYPE[type];
 }
 
+export function maybeInferRuntimeFromProviderType(
+  type: ProviderDraft['type'] | undefined,
+): ProviderDraft['runtime'] | undefined {
+  const runtime = inferRuntimeFromProviderType(type);
+  return runtime || undefined;
+}
+
 export function resolveReasoningModel(
   reasoningLevel: 'low' | 'default' | 'high' | undefined,
   provider: {

--- a/packages/myco/ui/src/hooks/use-providers.ts
+++ b/packages/myco/ui/src/hooks/use-providers.ts
@@ -9,8 +9,10 @@ const PROVIDERS_STALE_TIME = 30_000;
 /* ---------- Types ---------- */
 
 export interface ProviderInfo {
-  type: 'anthropic' | 'ollama' | 'lmstudio';
+  type: 'anthropic' | 'ollama' | 'lmstudio' | 'openai' | 'openrouter' | 'openai-compatible';
+  runtime: 'claude-sdk' | 'openai-agents';
   available: boolean;
+  authConfigured?: boolean;
   baseUrl?: string;
   models: string[];
 }
@@ -20,8 +22,10 @@ export interface ProvidersResponse {
 }
 
 export interface ProviderConfig {
-  type: 'anthropic' | 'ollama' | 'lmstudio';
+  runtime?: 'claude-sdk' | 'openai-agents';
+  type: ProviderInfo['type'];
   model?: string;
+  reasoning_map?: Partial<Record<'low' | 'default' | 'high', string>>;
   base_url?: string;
   context_length?: number;
 }
@@ -40,6 +44,7 @@ export interface ScheduleOverride {
 }
 
 export interface TaskConfigOverride {
+  runtime?: 'claude-sdk' | 'openai-agents';
   provider?: ProviderConfig;
   model?: string;
   maxTurns?: number;
@@ -54,10 +59,45 @@ export interface TaskConfigOverride {
  *  flicker. Used by both the global Agent Provider card and per-task
  *  TaskProviderConfig. */
 export interface ProviderDraft {
+  runtime: ProviderConfig['runtime'] | '';
   type: ProviderConfig['type'] | '';
   model: string;
+  reasoningLow: string;
+  reasoningDefault: string;
+  reasoningHigh: string;
   baseUrl: string;
   contextLength: string;
+}
+
+const PROVIDER_RUNTIME_BY_TYPE: Record<ProviderInfo['type'], ProviderInfo['runtime']> = {
+  anthropic: 'claude-sdk',
+  ollama: 'claude-sdk',
+  lmstudio: 'claude-sdk',
+  openai: 'openai-agents',
+  openrouter: 'openai-agents',
+  'openai-compatible': 'openai-agents',
+};
+
+export function inferRuntimeFromProviderType(
+  type: ProviderDraft['type'] | undefined,
+): ProviderDraft['runtime'] | '' {
+  if (!type) return '';
+  return PROVIDER_RUNTIME_BY_TYPE[type];
+}
+
+export function resolveReasoningModel(
+  reasoningLevel: 'low' | 'default' | 'high' | undefined,
+  provider: {
+    model?: string;
+    reasoning_map?: Partial<Record<'low' | 'default' | 'high', string>>;
+  } | undefined,
+  fallbackModel: string | undefined,
+): string {
+  const level = reasoningLevel ?? 'default';
+  return provider?.reasoning_map?.[level]
+    ?? provider?.model
+    ?? fallbackModel
+    ?? '';
 }
 
 /** Seed a draft from a freshly-selected provider type — picks the first
@@ -69,9 +109,37 @@ export function seedDraftFromProviderType(
   providers: ProviderInfo[],
 ): ProviderDraft {
   const info = providers.find((p) => p.type === type);
+  const modelSet = new Set(info?.models ?? []);
+  const defaultModel = info?.models?.[0] ?? '';
+  const pick = (...patterns: string[]) =>
+    info?.models?.find((model) => patterns.some((pattern) => model.includes(pattern))) ?? '';
+  const pickExact = (candidate: string) =>
+    info?.models?.find((model) => model === candidate) ?? '';
   return {
+    runtime: info?.runtime ?? inferRuntimeFromProviderType(type as ProviderDraft['type']),
     type: type as ProviderConfig['type'],
-    model: info?.models?.[0] ?? '',
+    model: defaultModel,
+    reasoningLow: modelSet.size > 0
+      ? (
+        (type === 'anthropic' ? pick('haiku')
+          : type === 'openai' ? pick('nano')
+          : defaultModel)
+      )
+      : '',
+    reasoningDefault: modelSet.size > 0
+      ? (
+        (type === 'anthropic' ? pick('sonnet')
+          : type === 'openai' ? pick('mini')
+          : defaultModel)
+      ) || defaultModel
+      : '',
+    reasoningHigh: modelSet.size > 0
+      ? (
+        (type === 'anthropic' ? pick('opus')
+          : type === 'openai' ? pickExact('gpt-5.4')
+          : '')
+      )
+      : '',
     baseUrl: info?.baseUrl ?? '',
     contextLength: '',
   };
@@ -81,10 +149,17 @@ export function seedDraftFromProviderType(
  *  fields and only includes base_url/context_length for local providers. */
 export function draftToProviderConfig(draft: ProviderDraft): ProviderConfig | undefined {
   if (draft.type === '') return undefined;
-  const isLocal = draft.type === 'ollama' || draft.type === 'lmstudio';
+  const isLocal = draft.type === 'ollama' || draft.type === 'lmstudio' || draft.type === 'openai-compatible';
+  const reasoningMap = {
+    ...(draft.reasoningLow ? { low: draft.reasoningLow } : {}),
+    ...(draft.reasoningDefault ? { default: draft.reasoningDefault } : {}),
+    ...(draft.reasoningHigh ? { high: draft.reasoningHigh } : {}),
+  };
   return {
+    ...(draft.runtime ? { runtime: draft.runtime } : {}),
     type: draft.type,
     ...(draft.model ? { model: draft.model } : {}),
+    ...(Object.keys(reasoningMap).length > 0 ? { reasoning_map: reasoningMap } : {}),
     ...(isLocal && draft.baseUrl ? { base_url: draft.baseUrl } : {}),
     ...(isLocal && draft.contextLength ? { context_length: Number(draft.contextLength) } : {}),
   };

--- a/packages/myco/ui/src/pages/Agent.tsx
+++ b/packages/myco/ui/src/pages/Agent.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useState, useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Play } from 'lucide-react';
 import { Button } from '../components/ui/button';
 import { PageHeader } from '../components/ui/page-header';
@@ -24,8 +24,7 @@ const PARAM_TASK = 'task';
 const VALID_TABS = new Set<AgentTab>(['runs', 'tasks', 'config']);
 
 /** Read initial state from URL search params. */
-function readUrlState(): { tab: AgentTab; runId?: string; taskId?: string } {
-  const params = new URLSearchParams(window.location.search);
+function readUrlState(params: URLSearchParams): { tab: AgentTab; runId?: string; taskId?: string } {
   const rawTab = params.get(PARAM_TAB);
   const tab: AgentTab = rawTab && VALID_TABS.has(rawTab as AgentTab)
     ? (rawTab as AgentTab)
@@ -37,15 +36,12 @@ function readUrlState(): { tab: AgentTab; runId?: string; taskId?: string } {
   };
 }
 
-/** Write navigation state to URL search params. */
-function writeUrlState(tab: AgentTab, runId?: string, taskId?: string): void {
+function buildUrlState(tab: AgentTab, runId?: string, taskId?: string): URLSearchParams {
   const params = new URLSearchParams();
   if (tab !== 'runs') params.set(PARAM_TAB, tab);
   if (runId) params.set(PARAM_RUN, runId);
   if (taskId) params.set(PARAM_TASK, taskId);
-  const search = params.toString();
-  const url = search ? `${window.location.pathname}?${search}` : window.location.pathname;
-  window.history.pushState(null, '', url);
+  return params;
 }
 
 /* ---------- Tab definitions ---------- */
@@ -59,37 +55,21 @@ const TABS: Tab[] = [
 /* ---------- Component ---------- */
 
 export default function Agent() {
-  const location = useLocation();
-  const initial = readUrlState();
-  const [tab, setTab] = useState<AgentTab>(initial.tab);
-  const [selectedRunId, setSelectedRunId] = useState<string | undefined>(initial.runId);
-  const [selectedTaskId, setSelectedTaskId] = useState<string | undefined>(initial.taskId);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { tab, runId: selectedRunId, taskId: selectedTaskId } = useMemo(
+    () => readUrlState(searchParams),
+    [searchParams],
+  );
   const [triggerOpen, setTriggerOpen] = useState(false);
-  const hasMounted = useRef(false);
-  const skipNextPush = useRef(false);
 
-  // Push URL whenever state changes (skip on mount and popstate)
-  useEffect(() => {
-    if (!hasMounted.current) { hasMounted.current = true; return; }
-    if (skipNextPush.current) { skipNextPush.current = false; return; }
-    writeUrlState(tab, selectedRunId, selectedTaskId);
-  }, [tab, selectedRunId, selectedTaskId]);
-
-  // Sync state from URL when navigation updates search params.
-  useEffect(() => {
-    skipNextPush.current = true;
-    const state = readUrlState();
-    setTab(state.tab);
-    setSelectedRunId(state.runId);
-    setSelectedTaskId(state.taskId);
-  }, [location.search, location.key]);
+  const navigateState = useCallback((nextTab: AgentTab, nextRunId?: string, nextTaskId?: string) => {
+    setSearchParams(buildUrlState(nextTab, nextRunId, nextTaskId));
+  }, [setSearchParams]);
 
   const switchTab = useCallback((id: string) => {
     const t = id as AgentTab;
-    setTab(t);
-    if (t !== 'runs') setSelectedRunId(undefined);
-    if (t !== 'tasks') setSelectedTaskId(undefined);
-  }, []);
+    navigateState(t);
+  }, [navigateState]);
 
   return (
     <div className="p-6 space-y-4">
@@ -112,9 +92,9 @@ export default function Agent() {
       {/* Runs tab */}
       {tab === 'runs' && (
         selectedRunId ? (
-          <RunDetail runId={selectedRunId} onBack={() => setSelectedRunId(undefined)} />
+          <RunDetail runId={selectedRunId} onBack={() => navigateState('runs')} />
         ) : (
-          <RunList onSelectRun={setSelectedRunId} onTriggerRun={() => setTriggerOpen(true)} />
+          <RunList onSelectRun={(id) => navigateState('runs', id)} onTriggerRun={() => setTriggerOpen(true)} />
         )
       )}
 
@@ -123,16 +103,14 @@ export default function Agent() {
         selectedTaskId ? (
           <TaskDetail
             taskId={selectedTaskId}
-            onBack={() => setSelectedTaskId(undefined)}
-            onNavigate={setSelectedTaskId}
+            onBack={() => navigateState('tasks')}
+            onNavigate={(taskId) => navigateState('tasks', undefined, taskId)}
             onRunTriggered={(runId) => {
-              setSelectedTaskId(undefined);
-              setTab('runs');
-              if (runId) setSelectedRunId(runId);
+              navigateState('runs', runId);
             }}
           />
         ) : (
-          <TaskList onSelect={setSelectedTaskId} />
+          <TaskList onSelect={(taskId) => navigateState('tasks', undefined, taskId)} />
         )
       )}
 
@@ -142,7 +120,7 @@ export default function Agent() {
       <TriggerRun
         open={triggerOpen}
         onOpenChange={setTriggerOpen}
-        onTriggered={() => setSelectedRunId(undefined)}
+        onTriggered={() => navigateState('runs')}
       />
     </div>
   );

--- a/packages/myco/ui/src/pages/Settings.tsx
+++ b/packages/myco/ui/src/pages/Settings.tsx
@@ -8,12 +8,14 @@ import {
 import {
   useProviders,
   useTestProvider,
-  seedDraftFromProviderType,
-  draftToProviderConfig,
-  inferRuntimeFromProviderType,
+  maybeInferRuntimeFromProviderType,
   resolveReasoningModel,
-  type ProviderDraft,
 } from '../hooks/use-providers';
+import type { ProviderDraft } from '../hooks/use-providers';
+import {
+  draftToNormalizedProviderConfig,
+  useProviderConfigDraft,
+} from '../hooks/use-provider-config-draft';
 import {
   useDeleteProviderSecret,
   useProviderSecrets,
@@ -35,6 +37,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../components/ui/select';
+import { SearchableSelect } from '../components/ui/searchable-select';
 import { Switch } from '../components/ui/switch';
 import { PlanCaptureCard } from '../components/config/PlanCaptureCard';
 import { ScopedField } from '../components/config/ScopedField';
@@ -111,30 +114,6 @@ export default function Settings() {
   );
 }
 
-function providerToDraft(
-  p: {
-    runtime?: string;
-    type?: string;
-    model?: string;
-    reasoning_map?: { low?: string; default?: string; high?: string };
-    base_url?: string;
-    context_length?: number;
-  } | undefined,
-  runtimeOverride?: string,
-): ProviderDraft {
-  const type = (p?.type as ProviderDraft['type']) ?? '';
-  return {
-    runtime: (runtimeOverride as ProviderDraft['runtime'] | undefined) ?? (p?.runtime as ProviderDraft['runtime'] | undefined) ?? inferRuntimeFromProviderType(type),
-    type,
-    model: p?.model ?? '',
-    reasoningLow: p?.reasoning_map?.low ?? '',
-    reasoningDefault: p?.reasoning_map?.default ?? p?.model ?? '',
-    reasoningHigh: p?.reasoning_map?.high ?? '',
-    baseUrl: p?.base_url ?? '',
-    contextLength: p?.context_length?.toString() ?? '',
-  };
-}
-
 const REMOTE_SECRET_LABELS: Record<SecretProvider, string> = {
   openai: 'OpenAI API Key',
   openrouter: 'OpenRouter API Key',
@@ -144,14 +123,14 @@ function isSecretProvider(type: ProviderDraft['type']): type is SecretProvider {
   return type === 'openai' || type === 'openrouter';
 }
 
-/** Myco Agent — personal-default. Provider type/model/base-url/context all
- *  live as the `agent.provider` object; each subfield writes via a nested
- *  scoped path. Two coupled writes use setFields:
+/** Myco Agent — personal-default. Provider configuration is staged locally
+ *  and saved explicitly because runtime -> provider -> model -> reasoning is
+ *  a dependency chain that cannot be persisted safely as independent writes.
+ *  Two coupled writes use setFields:
  *    • setting a provider for the first time also enables both task toggles
- *    • Clear Provider also disables both task toggles
- *  These mirror the previous batched-Save behaviour but happen atomically. */
+ *    • clearing the provider disables both task toggles and removes overrides */
 function AgentProviderCard() {
-  const { effective, setField, setFields, isLocalOverride, resetField, promoteField } = useScopedConfig();
+  const { effective, setFields, isLocalOverride, resetField, promoteField } = useScopedConfig();
   const { data: providersData, isPending: isLoadingProviders } = useProviders();
   const { data: providerSecretsData } = useProviderSecrets();
   const saveProviderSecret = useSaveProviderSecret();
@@ -161,32 +140,32 @@ function AgentProviderCard() {
   const providers = providersData?.providers ?? [];
   const provider = effective?.agent?.provider;
   const agentRuntime = effective?.agent?.runtime;
-  const [draft, setDraft] = useState<ProviderDraft>(() => providerToDraft(provider, agentRuntime));
+  const {
+    draft,
+    savedDraft,
+    isDirty,
+    clearDraft,
+    resetDraft,
+    handleRuntimeChange,
+    handleProviderChange,
+    handleModelChange,
+    handleReasoningChange,
+    handleBaseUrlChange,
+    handleContextLengthChange,
+  } = useProviderConfigDraft({
+    source: {
+      runtime: agentRuntime,
+      provider,
+    },
+    providers,
+  });
   const [apiKeyInput, setApiKeyInput] = useState('');
   const secretProvider = isSecretProvider(draft.type) ? draft.type : null;
   const activeSecret = secretProvider ? providerSecretsData?.secrets[secretProvider] : undefined;
   const modelsQuery = useModels(draft.type || null, draft.baseUrl || undefined, 'llm');
   const reasoningModels = modelsQuery.data?.models ?? providers.find((info) => info.type === draft.type)?.models ?? [];
   const supportsReasoningMap = draft.type !== '';
-
-  // Re-sync when an external write changes the upstream value (other tab,
-  // promote/reset). The ref-based `useScopedConfig` no longer churns
-  // identities on every refetch, so this only fires on actual value change.
-  useEffect(() => { setDraft(providerToDraft(provider, agentRuntime)); }, [provider, agentRuntime]);
   useEffect(() => { setApiKeyInput(''); }, [draft.type]);
-
-  // Backfill the model when a legacy config has provider.type but no model.
-  // /simplify Q1: previously this only mutated draft state, leaving the on-disk
-  // value silently empty. Now it persists the chosen first-model so display
-  // and config agree without requiring the user to "touch" the field.
-  useEffect(() => {
-    if (draft.type === '' || draft.model !== '' || !providersData) return;
-    const firstModel = providers.find(p => p.type === draft.type)?.models?.[0];
-    if (firstModel) {
-      setDraft(prev => ({ ...prev, model: firstModel }));
-      void setField('agent.provider.model', firstModel, 'local');
-    }
-  }, [draft.type, draft.model, providers, providersData, setField]);
 
   const personal = isLocalOverride('agent.provider') || isLocalOverride('agent.runtime');
   const handleResetScope = useCallback(async () => {
@@ -207,9 +186,9 @@ function AgentProviderCard() {
   }, [isLocalOverride, promoteField]);
 
   const writeProvider = useCallback((next: ProviderDraft, autoEnableTasks: boolean) => {
-    const value = draftToProviderConfig(next);
+    const value = draftToNormalizedProviderConfig(next, reasoningModels);
     const fields: Array<{ path: 'agent.runtime' | 'agent.provider' | 'agent.scheduled_tasks_enabled' | 'agent.event_tasks_enabled'; value: unknown }> = [
-      { path: 'agent.runtime', value: next.runtime || inferRuntimeFromProviderType(next.type) || undefined },
+      { path: 'agent.runtime', value: next.runtime || maybeInferRuntimeFromProviderType(next.type) },
       { path: 'agent.provider', value },
     ];
     if (autoEnableTasks) {
@@ -219,74 +198,39 @@ function AgentProviderCard() {
       );
     }
     void setFields(fields, 'local');
-  }, [setFields]);
+  }, [reasoningModels, setFields]);
 
-  const handleProviderTypeChange = useCallback((type: string) => {
-    const wasEmpty = draft.type === '';
-    const next = seedDraftFromProviderType(type, providers);
-    setDraft(next);
+  const handleClear = useCallback(() => {
+    clearDraft();
     agentTestMutation.reset();
-    writeProvider(next, wasEmpty);
-  }, [draft.type, providers, writeProvider, agentTestMutation]);
+  }, [agentTestMutation, clearDraft]);
 
-  const handleModelChange = useCallback((model: string) => {
-    setDraft(prev => ({
-      ...prev,
-      model,
-      reasoningDefault: prev.reasoningDefault || model,
-    }));
-    if (draft.type !== '') void setField('agent.provider.model', model, 'local');
-  }, [draft.type, setField]);
-
-  const handleBaseUrlChange = useCallback((baseUrl: string) => {
-    setDraft(prev => ({ ...prev, baseUrl }));
+  const handleResetDraft = useCallback(() => {
+    resetDraft();
     agentTestMutation.reset();
-  }, [agentTestMutation]);
+  }, [agentTestMutation, resetDraft]);
 
-  const handleBaseUrlBlur = useCallback(() => {
-    if (draft.type !== '') void setField('agent.provider.base_url', draft.baseUrl || undefined, 'local');
-  }, [draft.type, draft.baseUrl, setField]);
-
-  const handleContextLengthChange = useCallback((contextLength: string) => {
-    setDraft(prev => ({ ...prev, contextLength }));
-  }, []);
-
-  const handleContextLengthBlur = useCallback(() => {
-    if (draft.type !== '') {
-      const n = draft.contextLength === '' ? undefined : Number(draft.contextLength);
-      void setField('agent.provider.context_length', n, 'local');
+  const handleSaveProvider = useCallback(async () => {
+    const isClearingProvider = draft.type === '';
+    if (isClearingProvider) {
+      try {
+        await setFields(
+          [
+            { path: 'agent.scheduled_tasks_enabled', value: false },
+            { path: 'agent.event_tasks_enabled', value: false },
+          ],
+          'local',
+          ['agent.provider', 'agent.runtime'],
+        );
+      } catch (err) {
+        console.error('[agent-card] clear provider failed', err);
+      }
+      return;
     }
-  }, [draft.type, draft.contextLength, setField]);
 
-  const handleClear = useCallback(async () => {
-    setDraft((prev) => ({
-      ...prev,
-      runtime: '',
-      type: '',
-      model: '',
-      reasoningLow: '',
-      reasoningDefault: '',
-      reasoningHigh: '',
-      baseUrl: '',
-      contextLength: '',
-    }));
-    agentTestMutation.reset();
-    // Atomic: disable both task toggles and clear the local agent.provider
-    // override in one PUT. A project-scoped provider still requires editing
-    // myco.yaml directly.
-    try {
-      await setFields(
-        [
-          { path: 'agent.scheduled_tasks_enabled', value: false },
-          { path: 'agent.event_tasks_enabled', value: false },
-        ],
-        'local',
-        ['agent.provider', 'agent.runtime'],
-      );
-    } catch (err) {
-      console.error('[agent-card] clear provider failed', err);
-    }
-  }, [setFields, agentTestMutation]);
+    const shouldAutoEnableTasks = savedDraft.type === '' && draft.type !== '';
+    writeProvider(draft, shouldAutoEnableTasks);
+  }, [draft, savedDraft.type, setFields, writeProvider]);
 
   const handleSaveApiKey = useCallback(() => {
     if (!secretProvider || apiKeyInput.trim() === '') return;
@@ -351,22 +295,16 @@ function AgentProviderCard() {
         providers={providers}
         isLoadingProviders={isLoadingProviders}
         onRuntimeChange={(runtime) => {
-          setDraft(prev => ({ ...prev, runtime: runtime as ProviderDraft['runtime'] }));
-          const firstProvider = providers.find((provider) => provider.runtime === runtime);
-          if (firstProvider) {
-            const next = seedDraftFromProviderType(firstProvider.type, providers);
-            setDraft(next);
-            writeProvider(next, draft.type === '');
-          } else {
-            void setField('agent.runtime', runtime as ProviderDraft['runtime'] | undefined, 'local');
-          }
+          handleRuntimeChange(runtime);
+          agentTestMutation.reset();
         }}
-        onProviderChange={handleProviderTypeChange}
+        onProviderChange={(type) => {
+          handleProviderChange(type);
+          agentTestMutation.reset();
+        }}
         onModelChange={handleModelChange}
         onBaseUrlChange={handleBaseUrlChange}
         onContextLengthChange={handleContextLengthChange}
-        onBaseUrlBlur={handleBaseUrlBlur}
-        onContextLengthBlur={handleContextLengthBlur}
       />
 
       {supportsReasoningMap && (
@@ -387,20 +325,7 @@ function AgentProviderCard() {
               : level === 'default'
                 ? draft.reasoningDefault
                 : draft.reasoningHigh;
-            const setValue = (next: string) => {
-              setDraft((prev) => {
-                const updated = {
-                  ...prev,
-                  ...(level === 'low' ? { reasoningLow: next } : {}),
-                  ...(level === 'default' ? { reasoningDefault: next } : {}),
-                  ...(level === 'high' ? { reasoningHigh: next } : {}),
-                };
-                if (prev.type !== '') {
-                  writeProvider(updated, false);
-                }
-                return updated;
-              });
-            };
+            const setValue = (next: string) => handleReasoningChange(level, next);
             const placeholder = resolveReasoningModel(level, {
               model: draft.model || undefined,
               reasoning_map: {
@@ -413,18 +338,19 @@ function AgentProviderCard() {
               <div key={level} className="space-y-1">
                 <label className="font-sans text-xs text-on-surface-variant">{label}</label>
                 {reasoningModels.length > 0 ? (
-                  <Select value={value} onValueChange={setValue}>
-                    <SelectTrigger>
-                      <SelectValue placeholder={placeholder || 'Use default model'} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {reasoningModels.map((m) => (
-                        <SelectItem key={`${level}-${m}`} value={m}>
-                          <span className="font-mono text-sm">{m}</span>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <SearchableSelect
+                    value={value}
+                    onValueChange={setValue}
+                    placeholder={placeholder || 'Use default model'}
+                    searchPlaceholder="Search models..."
+                    emptyMessage="No models match that search."
+                    options={reasoningModels.map((candidate) => ({
+                      value: candidate,
+                      label: candidate,
+                    }))}
+                    sortOptions
+                    monospace
+                  />
                 ) : (
                   <Input
                     value={value}
@@ -479,48 +405,73 @@ function AgentProviderCard() {
         </div>
       )}
 
-      {draft.type !== '' && (
+      {(draft.type !== '' || isDirty) && (
         <>
           <div className="flex items-center gap-3 pt-1">
             <Button
               type="button"
               variant="ghost"
               size="sm"
-              onClick={handleTestConnection}
-              disabled={agentTestMutation.isPending}
+              onClick={handleSaveProvider}
+              disabled={!isDirty}
             >
-              {agentTestMutation.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-              Test Connection
+              Save Changes
             </Button>
-            {agentTestMutation.isSuccess && agentTestMutation.data.ok && (
-              <span className="flex items-center gap-1 font-sans text-sm text-primary">
-                <CheckCircle className="h-4 w-4" />
-                Connected — {agentTestMutation.data.latency_ms}ms
-              </span>
-            )}
-            {agentTestMutation.isSuccess && !agentTestMutation.data.ok && (
-              <span className="flex items-center gap-1 font-sans text-sm text-tertiary">
-                <XCircle className="h-4 w-4" />
-                {agentTestMutation.data.error ?? 'Connection failed.'}
-              </span>
-            )}
-            {agentTestMutation.isError && (
-              <span className="flex items-center gap-1 font-sans text-sm text-tertiary">
-                <XCircle className="h-4 w-4" />
-                {agentTestMutation.error.message}
-              </span>
-            )}
+            {isDirty ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={handleResetDraft}
+              >
+                Reset
+              </Button>
+            ) : null}
+            {draft.type !== '' ? (
+              <>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleTestConnection}
+                  disabled={agentTestMutation.isPending}
+                >
+                  {agentTestMutation.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                  Test Connection
+                </Button>
+                {agentTestMutation.isSuccess && agentTestMutation.data.ok && (
+                  <span className="flex items-center gap-1 font-sans text-sm text-primary">
+                    <CheckCircle className="h-4 w-4" />
+                    Connected — {agentTestMutation.data.latency_ms}ms
+                  </span>
+                )}
+                {agentTestMutation.isSuccess && !agentTestMutation.data.ok && (
+                  <span className="flex items-center gap-1 font-sans text-sm text-tertiary">
+                    <XCircle className="h-4 w-4" />
+                    {agentTestMutation.data.error ?? 'Connection failed.'}
+                  </span>
+                )}
+                {agentTestMutation.isError && (
+                  <span className="flex items-center gap-1 font-sans text-sm text-tertiary">
+                    <XCircle className="h-4 w-4" />
+                    {agentTestMutation.error.message}
+                  </span>
+                )}
+              </>
+            ) : null}
           </div>
 
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={handleClear}
-            className="text-xs text-on-surface-variant"
-          >
-            Clear provider
-          </Button>
+          {draft.type !== '' || savedDraft.type !== '' ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleClear}
+              className="text-xs text-on-surface-variant"
+            >
+              Clear provider
+            </Button>
+          ) : null}
         </>
       )}
     </Surface>
@@ -595,18 +546,19 @@ function EmbeddingCard() {
         >
           {({ value, onChange, onBlur }) =>
             embeddingModels.length > 0 ? (
-              <Select value={value ?? ''} onValueChange={onChange}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select a model" />
-                </SelectTrigger>
-                <SelectContent>
-                  {embeddingModels.map((m) => (
-                    <SelectItem key={m} value={m}>
-                      <span className="font-mono text-sm">{m}</span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <SearchableSelect
+                value={value ?? ''}
+                onValueChange={onChange}
+                placeholder="Select a model"
+                searchPlaceholder="Search embedding models..."
+                emptyMessage="No embedding models match that search."
+                options={embeddingModels.map((candidate) => ({
+                  value: candidate,
+                  label: candidate,
+                }))}
+                sortOptions
+                monospace
+              />
             ) : (
               <Input
                 placeholder="bge-m3"

--- a/packages/myco/ui/src/pages/Settings.tsx
+++ b/packages/myco/ui/src/pages/Settings.tsx
@@ -10,8 +10,16 @@ import {
   useTestProvider,
   seedDraftFromProviderType,
   draftToProviderConfig,
+  inferRuntimeFromProviderType,
+  resolveReasoningModel,
   type ProviderDraft,
 } from '../hooks/use-providers';
+import {
+  useDeleteProviderSecret,
+  useProviderSecrets,
+  useSaveProviderSecret,
+  type SecretProvider,
+} from '../hooks/use-provider-secrets';
 import { useModels } from '../hooks/use-models';
 import { fetchJson } from '../lib/api';
 import { DEFAULT_DIGEST_TIER, DEFAULT_MAX_SPORES } from '../lib/constants';
@@ -103,13 +111,37 @@ export default function Settings() {
   );
 }
 
-function providerToDraft(p: { type?: string; model?: string; base_url?: string; context_length?: number } | undefined): ProviderDraft {
+function providerToDraft(
+  p: {
+    runtime?: string;
+    type?: string;
+    model?: string;
+    reasoning_map?: { low?: string; default?: string; high?: string };
+    base_url?: string;
+    context_length?: number;
+  } | undefined,
+  runtimeOverride?: string,
+): ProviderDraft {
+  const type = (p?.type as ProviderDraft['type']) ?? '';
   return {
-    type: (p?.type as ProviderDraft['type']) ?? '',
+    runtime: (runtimeOverride as ProviderDraft['runtime'] | undefined) ?? (p?.runtime as ProviderDraft['runtime'] | undefined) ?? inferRuntimeFromProviderType(type),
+    type,
     model: p?.model ?? '',
+    reasoningLow: p?.reasoning_map?.low ?? '',
+    reasoningDefault: p?.reasoning_map?.default ?? p?.model ?? '',
+    reasoningHigh: p?.reasoning_map?.high ?? '',
     baseUrl: p?.base_url ?? '',
     contextLength: p?.context_length?.toString() ?? '',
   };
+}
+
+const REMOTE_SECRET_LABELS: Record<SecretProvider, string> = {
+  openai: 'OpenAI API Key',
+  openrouter: 'OpenRouter API Key',
+};
+
+function isSecretProvider(type: ProviderDraft['type']): type is SecretProvider {
+  return type === 'openai' || type === 'openrouter';
 }
 
 /** Myco Agent — personal-default. Provider type/model/base-url/context all
@@ -121,16 +153,27 @@ function providerToDraft(p: { type?: string; model?: string; base_url?: string; 
 function AgentProviderCard() {
   const { effective, setField, setFields, isLocalOverride, resetField, promoteField } = useScopedConfig();
   const { data: providersData, isPending: isLoadingProviders } = useProviders();
+  const { data: providerSecretsData } = useProviderSecrets();
+  const saveProviderSecret = useSaveProviderSecret();
+  const deleteProviderSecret = useDeleteProviderSecret();
   const agentTestMutation = useTestProvider();
 
   const providers = providersData?.providers ?? [];
   const provider = effective?.agent?.provider;
-  const [draft, setDraft] = useState<ProviderDraft>(() => providerToDraft(provider));
+  const agentRuntime = effective?.agent?.runtime;
+  const [draft, setDraft] = useState<ProviderDraft>(() => providerToDraft(provider, agentRuntime));
+  const [apiKeyInput, setApiKeyInput] = useState('');
+  const secretProvider = isSecretProvider(draft.type) ? draft.type : null;
+  const activeSecret = secretProvider ? providerSecretsData?.secrets[secretProvider] : undefined;
+  const modelsQuery = useModels(draft.type || null, draft.baseUrl || undefined, 'llm');
+  const reasoningModels = modelsQuery.data?.models ?? providers.find((info) => info.type === draft.type)?.models ?? [];
+  const supportsReasoningMap = draft.type !== '';
 
   // Re-sync when an external write changes the upstream value (other tab,
   // promote/reset). The ref-based `useScopedConfig` no longer churns
   // identities on every refetch, so this only fires on actual value change.
-  useEffect(() => { setDraft(providerToDraft(provider)); }, [provider]);
+  useEffect(() => { setDraft(providerToDraft(provider, agentRuntime)); }, [provider, agentRuntime]);
+  useEffect(() => { setApiKeyInput(''); }, [draft.type]);
 
   // Backfill the model when a legacy config has provider.type but no model.
   // /simplify Q1: previously this only mutated draft state, leaving the on-disk
@@ -145,20 +188,38 @@ function AgentProviderCard() {
     }
   }, [draft.type, draft.model, providers, providersData, setField]);
 
-  const personal = isLocalOverride('agent.provider');
+  const personal = isLocalOverride('agent.provider') || isLocalOverride('agent.runtime');
+  const handleResetScope = useCallback(async () => {
+    if (isLocalOverride('agent.runtime')) {
+      await resetField('agent.runtime');
+    }
+    if (isLocalOverride('agent.provider')) {
+      await resetField('agent.provider');
+    }
+  }, [isLocalOverride, resetField]);
+  const handlePromoteScope = useCallback(async () => {
+    if (isLocalOverride('agent.runtime')) {
+      await promoteField('agent.runtime');
+    }
+    if (isLocalOverride('agent.provider')) {
+      await promoteField('agent.provider');
+    }
+  }, [isLocalOverride, promoteField]);
 
   const writeProvider = useCallback((next: ProviderDraft, autoEnableTasks: boolean) => {
     const value = draftToProviderConfig(next);
+    const fields: Array<{ path: 'agent.runtime' | 'agent.provider' | 'agent.scheduled_tasks_enabled' | 'agent.event_tasks_enabled'; value: unknown }> = [
+      { path: 'agent.runtime', value: next.runtime || inferRuntimeFromProviderType(next.type) || undefined },
+      { path: 'agent.provider', value },
+    ];
     if (autoEnableTasks) {
-      void setFields([
-        { path: 'agent.provider', value },
+      fields.push(
         { path: 'agent.scheduled_tasks_enabled', value: true },
         { path: 'agent.event_tasks_enabled', value: true },
-      ], 'local');
-    } else {
-      void setField('agent.provider', value, 'local');
+      );
     }
-  }, [setField, setFields]);
+    void setFields(fields, 'local');
+  }, [setFields]);
 
   const handleProviderTypeChange = useCallback((type: string) => {
     const wasEmpty = draft.type === '';
@@ -169,7 +230,11 @@ function AgentProviderCard() {
   }, [draft.type, providers, writeProvider, agentTestMutation]);
 
   const handleModelChange = useCallback((model: string) => {
-    setDraft(prev => ({ ...prev, model }));
+    setDraft(prev => ({
+      ...prev,
+      model,
+      reasoningDefault: prev.reasoningDefault || model,
+    }));
     if (draft.type !== '') void setField('agent.provider.model', model, 'local');
   }, [draft.type, setField]);
 
@@ -194,7 +259,17 @@ function AgentProviderCard() {
   }, [draft.type, draft.contextLength, setField]);
 
   const handleClear = useCallback(async () => {
-    setDraft({ type: '', model: '', baseUrl: '', contextLength: '' });
+    setDraft((prev) => ({
+      ...prev,
+      runtime: '',
+      type: '',
+      model: '',
+      reasoningLow: '',
+      reasoningDefault: '',
+      reasoningHigh: '',
+      baseUrl: '',
+      contextLength: '',
+    }));
     agentTestMutation.reset();
     // Atomic: disable both task toggles and clear the local agent.provider
     // override in one PUT. A project-scoped provider still requires editing
@@ -206,20 +281,41 @@ function AgentProviderCard() {
           { path: 'agent.event_tasks_enabled', value: false },
         ],
         'local',
-        ['agent.provider'],
+        ['agent.provider', 'agent.runtime'],
       );
     } catch (err) {
       console.error('[agent-card] clear provider failed', err);
     }
   }, [setFields, agentTestMutation]);
 
+  const handleSaveApiKey = useCallback(() => {
+    if (!secretProvider || apiKeyInput.trim() === '') return;
+    saveProviderSecret.mutate({ provider: secretProvider, apiKey: apiKeyInput.trim() }, {
+      onSuccess: () => {
+        setApiKeyInput('');
+        agentTestMutation.reset();
+      },
+    });
+  }, [agentTestMutation, apiKeyInput, saveProviderSecret, secretProvider]);
+
+  const handleClearApiKey = useCallback(() => {
+    if (!secretProvider) return;
+    deleteProviderSecret.mutate(secretProvider, {
+      onSuccess: () => {
+        setApiKeyInput('');
+        agentTestMutation.reset();
+      },
+    });
+  }, [agentTestMutation, deleteProviderSecret, secretProvider]);
+
   const handleTestConnection = useCallback(() => {
     if (draft.type === '') return;
     agentTestMutation.mutate({
       type: draft.type,
+      runtime: draft.runtime || undefined,
       ...(draft.baseUrl ? { base_url: draft.baseUrl } : {}),
     });
-  }, [draft.type, draft.baseUrl, agentTestMutation]);
+  }, [draft.baseUrl, draft.runtime, draft.type, agentTestMutation]);
 
   return (
     <Surface
@@ -232,7 +328,7 @@ function AgentProviderCard() {
         <span className="flex items-center gap-2">
           Myco Agent
           {personal ? (
-            <ScopePill onPromote={() => promoteField('agent.provider')} onReset={() => resetField('agent.provider')} />
+            <ScopePill onPromote={handlePromoteScope} onReset={handleResetScope} />
           ) : (
             <ScopeBadge scope="project" />
           )}
@@ -247,12 +343,24 @@ function AgentProviderCard() {
       ) : null}
 
       <ProviderModelSelector
+        runtime={draft.runtime}
         providerType={draft.type}
         model={draft.model}
         baseUrl={draft.baseUrl}
         contextLength={draft.contextLength}
         providers={providers}
         isLoadingProviders={isLoadingProviders}
+        onRuntimeChange={(runtime) => {
+          setDraft(prev => ({ ...prev, runtime: runtime as ProviderDraft['runtime'] }));
+          const firstProvider = providers.find((provider) => provider.runtime === runtime);
+          if (firstProvider) {
+            const next = seedDraftFromProviderType(firstProvider.type, providers);
+            setDraft(next);
+            writeProvider(next, draft.type === '');
+          } else {
+            void setField('agent.runtime', runtime as ProviderDraft['runtime'] | undefined, 'local');
+          }
+        }}
         onProviderChange={handleProviderTypeChange}
         onModelChange={handleModelChange}
         onBaseUrlChange={handleBaseUrlChange}
@@ -260,6 +368,116 @@ function AgentProviderCard() {
         onBaseUrlBlur={handleBaseUrlBlur}
         onContextLengthBlur={handleContextLengthBlur}
       />
+
+      {supportsReasoningMap && (
+        <div className="space-y-3 rounded-md border border-[var(--ghost-border)] bg-surface-container-lowest p-3">
+          <div>
+            <p className="font-sans text-xs text-on-surface-variant uppercase tracking-wide">Reasoning Profiles</p>
+            <p className="font-sans text-xs text-on-surface-variant/80 mt-1">
+              Built-in tasks resolve `low`, `default`, and `high` reasoning phases through these model mappings.
+            </p>
+          </div>
+          {([
+            ['low', 'Reasoning Low'],
+            ['default', 'Reasoning Default'],
+            ['high', 'Reasoning High'],
+          ] as const).map(([level, label]) => {
+            const value = level === 'low'
+              ? draft.reasoningLow
+              : level === 'default'
+                ? draft.reasoningDefault
+                : draft.reasoningHigh;
+            const setValue = (next: string) => {
+              setDraft((prev) => {
+                const updated = {
+                  ...prev,
+                  ...(level === 'low' ? { reasoningLow: next } : {}),
+                  ...(level === 'default' ? { reasoningDefault: next } : {}),
+                  ...(level === 'high' ? { reasoningHigh: next } : {}),
+                };
+                if (prev.type !== '') {
+                  writeProvider(updated, false);
+                }
+                return updated;
+              });
+            };
+            const placeholder = resolveReasoningModel(level, {
+              model: draft.model || undefined,
+              reasoning_map: {
+                ...(draft.reasoningLow ? { low: draft.reasoningLow } : {}),
+                ...(draft.reasoningDefault ? { default: draft.reasoningDefault } : {}),
+                ...(draft.reasoningHigh ? { high: draft.reasoningHigh } : {}),
+              },
+            }, draft.model);
+            return (
+              <div key={level} className="space-y-1">
+                <label className="font-sans text-xs text-on-surface-variant">{label}</label>
+                {reasoningModels.length > 0 ? (
+                  <Select value={value} onValueChange={setValue}>
+                    <SelectTrigger>
+                      <SelectValue placeholder={placeholder || 'Use default model'} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {reasoningModels.map((m) => (
+                        <SelectItem key={`${level}-${m}`} value={m}>
+                          <span className="font-mono text-sm">{m}</span>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  <Input
+                    value={value}
+                    onChange={(e) => setValue(e.target.value)}
+                    placeholder={placeholder || 'Use default model'}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {secretProvider && (
+        <div className="space-y-2 rounded-md border border-[var(--ghost-border)] bg-surface-container-lowest p-3">
+          <div className="space-y-1">
+            <label className="font-sans text-xs text-on-surface-variant">{REMOTE_SECRET_LABELS[secretProvider]}</label>
+            <Input
+              type="password"
+              value={apiKeyInput}
+              onChange={(e) => setApiKeyInput(e.target.value)}
+              placeholder={activeSecret?.configured ? 'Replace saved key' : 'Paste API key'}
+            />
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleSaveApiKey}
+              disabled={saveProviderSecret.isPending || apiKeyInput.trim() === ''}
+            >
+              Save key
+            </Button>
+            {activeSecret?.configured && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={handleClearApiKey}
+                disabled={deleteProviderSecret.isPending}
+              >
+                Clear key
+              </Button>
+            )}
+            <span className="font-sans text-xs text-on-surface-variant break-all">
+              {activeSecret?.configured
+                ? `${activeSecret.maskedValue} stored ${activeSecret.source === 'vault' ? 'in vault secrets' : 'from environment'}`
+                : 'Key is required for model discovery and connection tests.'}
+            </span>
+          </div>
+        </div>
+      )}
 
       {draft.type !== '' && (
         <>

--- a/packages/myco/ui/src/pages/Settings.tsx
+++ b/packages/myco/ui/src/pages/Settings.tsx
@@ -6,6 +6,7 @@ import {
   configFieldId,
 } from '@myco/config/focus';
 import {
+  defaultBaseUrlForProvider,
   useProviders,
   useTestProvider,
   maybeInferRuntimeFromProviderType,
@@ -149,6 +150,7 @@ function AgentProviderCard() {
     handleRuntimeChange,
     handleProviderChange,
     handleModelChange,
+    handleLocalBackendChange,
     handleReasoningChange,
     handleBaseUrlChange,
     handleContextLengthChange,
@@ -162,7 +164,8 @@ function AgentProviderCard() {
   const [apiKeyInput, setApiKeyInput] = useState('');
   const secretProvider = isSecretProvider(draft.type) ? draft.type : null;
   const activeSecret = secretProvider ? providerSecretsData?.secrets[secretProvider] : undefined;
-  const modelsQuery = useModels(draft.type || null, draft.baseUrl || undefined, 'llm');
+  const resolvedAgentBaseUrl = draft.baseUrl || defaultBaseUrlForProvider(draft.type, draft.localBackend);
+  const modelsQuery = useModels(draft.type || null, resolvedAgentBaseUrl || undefined, 'llm', draft.localBackend || null);
   const reasoningModels = modelsQuery.data?.models ?? providers.find((info) => info.type === draft.type)?.models ?? [];
   const supportsReasoningMap = draft.type !== '';
   useEffect(() => { setApiKeyInput(''); }, [draft.type]);
@@ -257,9 +260,10 @@ function AgentProviderCard() {
     agentTestMutation.mutate({
       type: draft.type,
       runtime: draft.runtime || undefined,
+      ...(draft.type === 'openai-compatible' && draft.localBackend ? { local_backend: draft.localBackend } : {}),
       ...(draft.baseUrl ? { base_url: draft.baseUrl } : {}),
     });
-  }, [draft.baseUrl, draft.runtime, draft.type, agentTestMutation]);
+  }, [draft.baseUrl, draft.localBackend, draft.runtime, draft.type, agentTestMutation]);
 
   return (
     <Surface
@@ -289,6 +293,7 @@ function AgentProviderCard() {
       <ProviderModelSelector
         runtime={draft.runtime}
         providerType={draft.type}
+        localBackend={draft.localBackend}
         model={draft.model}
         baseUrl={draft.baseUrl}
         contextLength={draft.contextLength}
@@ -300,6 +305,10 @@ function AgentProviderCard() {
         }}
         onProviderChange={(type) => {
           handleProviderChange(type);
+          agentTestMutation.reset();
+        }}
+        onLocalBackendChange={(localBackend) => {
+          handleLocalBackendChange(localBackend);
           agentTestMutation.reset();
         }}
         onModelChange={handleModelChange}

--- a/tests/agent/config-resolver.test.ts
+++ b/tests/agent/config-resolver.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { AgentDefinition, AgentTask } from '@myco/agent/types.js';
+import type { AgentRow } from '@myco/db/queries/agents.js';
+import type { TaskRow } from '@myco/db/queries/tasks.js';
+import { resolveRunConfig } from '@myco/agent/config-resolver.js';
+
+const TEST_VAULT_DIR = '/tmp/test-vault';
+
+const mockDefinition: AgentDefinition = {
+  name: 'myco-agent',
+  displayName: 'Myco Agent',
+  description: 'Test agent',
+  model: 'claude-sonnet-4-20250514',
+  maxTurns: 30,
+  timeoutSeconds: 300,
+  systemPromptPath: '../prompts/agent.md',
+  tools: ['vault_sessions'],
+};
+
+const mockTaskRow: TaskRow = {
+  id: 'title-summary',
+  agent_id: 'myco-agent',
+  source: 'built-in',
+  display_name: 'Title & Summary',
+  description: 'Generate titles and summaries',
+  prompt: 'Summarize the target session.',
+  is_default: 0,
+  tool_overrides: null,
+  model: null,
+  config: null,
+  created_at: 1000,
+  updated_at: null,
+};
+
+const mockYamlTask: AgentTask = {
+  name: 'title-summary',
+  displayName: 'Title & Summary',
+  description: 'Generate titles and summaries',
+  agent: 'myco-agent',
+  prompt: 'Summarize the target session.',
+  isDefault: false,
+  maxTurns: 15,
+  timeoutSeconds: 300,
+};
+
+const mockAgentRow: AgentRow = {
+  id: 'myco-agent',
+  name: 'Myco Agent',
+  provider: null,
+  model: null,
+  system_prompt_hash: null,
+  config: null,
+  source: 'built-in',
+  system_prompt: null,
+  max_turns: null,
+  timeout_seconds: null,
+  tool_access: null,
+  enabled: 1,
+  created_at: 1000,
+  updated_at: null,
+};
+
+vi.mock('@myco/db/queries/agents.js', () => ({
+  getAgent: () => mockAgentRow,
+}));
+
+vi.mock('@myco/db/queries/tasks.js', () => ({
+  getTask: () => mockTaskRow,
+  getDefaultTask: () => mockTaskRow,
+}));
+
+vi.mock('@myco/agent/loader.js', () => ({
+  resolveDefinitionsDir: () => '/mock/definitions',
+  loadAgentDefinition: () => mockDefinition,
+  resolveEffectiveConfig: (_definition: AgentDefinition, _agentRow: AgentRow | null, taskOverrides?: AgentTask) => ({
+    agentId: 'myco-agent',
+    runtime: 'claude-sdk' as const,
+    model: taskOverrides?.model ?? mockDefinition.model,
+    ...(taskOverrides?.reasoningLevel ? { reasoningLevel: taskOverrides.reasoningLevel } : {}),
+    maxTurns: taskOverrides?.maxTurns ?? mockDefinition.maxTurns,
+    timeoutSeconds: taskOverrides?.timeoutSeconds ?? mockDefinition.timeoutSeconds,
+    systemPromptPath: mockDefinition.systemPromptPath,
+    tools: mockDefinition.tools,
+    taskName: taskOverrides?.name ?? 'title-summary',
+    taskDisplayName: taskOverrides?.displayName ?? 'Title & Summary',
+    taskPrompt: taskOverrides?.prompt ?? 'Summarize the target session.',
+  }),
+}));
+
+vi.mock('@myco/agent/registry.js', () => ({
+  loadAllTasks: () => new Map([['title-summary', mockYamlTask]]),
+}));
+
+const mockLoadMergedConfig = vi.fn();
+
+vi.mock('@myco/config/loader.js', () => ({
+  loadMergedConfig: (...args: unknown[]) => mockLoadMergedConfig(...args),
+}));
+
+describe('resolveRunConfig', () => {
+  beforeEach(() => {
+    mockLoadMergedConfig.mockReset();
+  });
+
+  it('applies task-level maxTurns and timeoutSeconds from myco.yaml', () => {
+    mockLoadMergedConfig.mockReturnValue({
+      version: 3,
+      config_version: 5,
+      embedding: { provider: 'ollama', model: 'bge-m3:latest' },
+      daemon: { port: 21039, log_level: 'debug', log_retention_days: 30, stale_session_threshold_ms: 3600000 },
+      capture: { transcript_paths: [], plan_dirs: [], ignore_plan_dirs_in_git: false, artifact_extensions: ['.md'], buffer_max_events: 500 },
+      agent: {
+        summary_batch_interval: 5,
+        scheduled_tasks_enabled: false,
+        event_tasks_enabled: true,
+        tasks: {
+          'title-summary': {
+            runtime: 'openai-agents',
+            maxTurns: 30,
+            timeoutSeconds: 900,
+          },
+        },
+      },
+      context: { digest_tier: 5000, prompt_search: true, prompt_max_spores: 3 },
+      backup: {},
+      maintenance: { auto_optimize: true, auto_optimize_interval_hours: 24 },
+      team: { enabled: false, interval_minutes: 15 },
+      skills: { confidence_threshold: 0.7, usage_stale_days: 30 },
+      notifications: { enabled: true, system_notifications: false, default_mode: 'summary', domains: {} },
+      appearance: { theme: 'sage', mode: 'dark', font: 'default', density: 'normal' },
+    });
+
+    const resolved = resolveRunConfig('myco-agent', 'title-summary', TEST_VAULT_DIR);
+
+    expect(resolved.runtime).toBe('openai-agents');
+    expect(resolved.config.runtime).toBe('openai-agents');
+    expect(resolved.config.maxTurns).toBe(30);
+    expect(resolved.config.timeoutSeconds).toBe(900);
+  });
+
+  it('applies task-level model override from myco.yaml', () => {
+    mockLoadMergedConfig.mockReturnValue({
+      version: 3,
+      config_version: 5,
+      embedding: { provider: 'ollama', model: 'bge-m3:latest' },
+      daemon: { port: 21039, log_level: 'debug', log_retention_days: 30, stale_session_threshold_ms: 3600000 },
+      capture: { transcript_paths: [], plan_dirs: [], ignore_plan_dirs_in_git: false, artifact_extensions: ['.md'], buffer_max_events: 500 },
+      agent: {
+        summary_batch_interval: 5,
+        scheduled_tasks_enabled: false,
+        event_tasks_enabled: true,
+        tasks: {
+          'title-summary': {
+            model: 'gpt-5.4-mini',
+          },
+        },
+      },
+      context: { digest_tier: 5000, prompt_search: true, prompt_max_spores: 3 },
+      backup: {},
+      maintenance: { auto_optimize: true, auto_optimize_interval_hours: 24 },
+      team: { enabled: false, interval_minutes: 15 },
+      skills: { confidence_threshold: 0.7, usage_stale_days: 30 },
+      notifications: { enabled: true, system_notifications: false, default_mode: 'summary', domains: {} },
+      appearance: { theme: 'sage', mode: 'dark', font: 'default', density: 'normal' },
+    });
+
+    const resolved = resolveRunConfig('myco-agent', 'title-summary', TEST_VAULT_DIR);
+
+    expect(resolved.config.model).toBe('gpt-5.4-mini');
+  });
+
+  it('maps task-level openai-compatible local_backend config into runtime provider config', () => {
+    mockLoadMergedConfig.mockReturnValue({
+      version: 3,
+      config_version: 5,
+      embedding: { provider: 'ollama', model: 'bge-m3:latest' },
+      daemon: { port: 21039, log_level: 'debug', log_retention_days: 30, stale_session_threshold_ms: 3600000 },
+      capture: { transcript_paths: [], plan_dirs: [], ignore_plan_dirs_in_git: false, artifact_extensions: ['.md'], buffer_max_events: 500 },
+      agent: {
+        summary_batch_interval: 5,
+        scheduled_tasks_enabled: false,
+        event_tasks_enabled: true,
+        tasks: {
+          'title-summary': {
+            provider: {
+              type: 'openai-compatible',
+              local_backend: 'ollama',
+              base_url: 'http://localhost:11434',
+              model: 'gemma4:26b',
+            },
+          },
+        },
+      },
+      context: { digest_tier: 5000, prompt_search: true, prompt_max_spores: 3 },
+      backup: {},
+      maintenance: { auto_optimize: true, auto_optimize_interval_hours: 24 },
+      team: { enabled: false, interval_minutes: 15 },
+      skills: { confidence_threshold: 0.7, usage_stale_days: 30 },
+      notifications: { enabled: true, system_notifications: false, default_mode: 'summary', domains: {} },
+      appearance: { theme: 'sage', mode: 'dark', font: 'default', density: 'normal' },
+    });
+
+    const resolved = resolveRunConfig('myco-agent', 'title-summary', TEST_VAULT_DIR);
+
+    expect(resolved.taskProviderOverride).toEqual(expect.objectContaining({
+      type: 'openai-compatible',
+      localBackend: 'ollama',
+      baseUrl: 'http://localhost:11434',
+      model: 'gemma4:26b',
+    }));
+    expect(resolved.runtime).toBe('openai-agents');
+  });
+});

--- a/tests/agent/cost-resolver.test.ts
+++ b/tests/agent/cost-resolver.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveCost } from '@myco/agent/cost/index.js';
+import { OPENROUTER_API_KEY_ENV } from '@myco/cli/providers/openrouter.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env[OPENROUTER_API_KEY_ENV];
+});
+
+describe('resolveCost', () => {
+  it('prefers actual cost reported by the runtime', async () => {
+    const result = await resolveCost({
+      runtime: 'claude-sdk',
+      model: 'claude-sonnet-4-6',
+      provider: { type: 'anthropic', model: 'claude-sonnet-4-6' },
+      usage: {
+        inputTokens: 1_500,
+        outputTokens: 350,
+        totalTokens: 1_850,
+        costUsd: 0.0042,
+      },
+    });
+
+    expect(result.source).toBe('actual');
+    expect(result.costUsd).toBe(0.0042);
+    expect(result.actualCostUsd).toBe(0.0042);
+    expect(result.estimatedCostUsd).toBeNull();
+  });
+
+  it('estimates OpenAI pricing with cached-input discounts', async () => {
+    const result = await resolveCost({
+      runtime: 'openai-agents',
+      model: 'gpt-5.4-nano',
+      provider: { type: 'openai', model: 'gpt-5.4-nano' },
+      usage: {
+        inputTokens: 165_021,
+        cachedTokens: 111_104,
+        outputTokens: 453,
+        totalTokens: 165_474,
+      },
+    });
+
+    expect(result.source).toBe('estimated');
+    expect(result.costUsd).toBeCloseTo(0.01357173);
+    expect(result.breakdown.cachedInputTokens).toBe(111_104);
+    expect(result.breakdown.uncachedInputTokens).toBe(53_917);
+    expect(result.breakdown.cacheSavingsUsd).toBeCloseTo(0.01999872);
+  });
+
+  it('estimates OpenRouter pricing from the live model catalog', async () => {
+    process.env[OPENROUTER_API_KEY_ENV] = 'test-key';
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        data: [{
+          id: 'openai/gpt-5.4-mini',
+          pricing: {
+            prompt: '0.00000075',
+            input_cache_read: '0.000000075',
+            completion: '0.0000045',
+            request: '0',
+          },
+        }],
+      }),
+    })));
+
+    const result = await resolveCost({
+      runtime: 'openai-agents',
+      model: 'openai/gpt-5.4-mini',
+      provider: { type: 'openrouter', model: 'openai/gpt-5.4-mini' },
+      usage: {
+        requests: 2,
+        inputTokens: 2_000,
+        cachedTokens: 500,
+        outputTokens: 300,
+      },
+    });
+
+    expect(result.source).toBe('estimated');
+    expect(result.costUsd).toBeCloseTo(0.0025125);
+    expect(result.breakdown.inputCostUsd).toBeCloseTo(0.001125);
+    expect(result.breakdown.cachedInputCostUsd).toBeCloseTo(0.0000375);
+    expect(result.breakdown.outputCostUsd).toBeCloseTo(0.00135);
+  });
+
+  it('treats negative OpenRouter catalog rates as unavailable pricing', async () => {
+    process.env[OPENROUTER_API_KEY_ENV] = 'test-key';
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        data: [{
+          id: 'openrouter/auto',
+          pricing: {
+            prompt: '-1',
+            completion: '-1',
+          },
+        }],
+      }),
+    })));
+
+    const result = await resolveCost({
+      runtime: 'openai-agents',
+      model: 'openrouter/auto',
+      provider: { type: 'openrouter', model: 'openrouter/auto' },
+      usage: {
+        requests: 1,
+        inputTokens: 2_000,
+        outputTokens: 300,
+      },
+    });
+
+    expect(result.source).toBe('unavailable');
+    expect(result.costUsd).toBeNull();
+    expect(result.estimatedCostUsd).toBeNull();
+  });
+});

--- a/tests/agent/cost-resolver.test.ts
+++ b/tests/agent/cost-resolver.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { resolveCost } from '@myco/agent/cost/index.js';
+import { getCostProvider, resolveCost } from '@myco/agent/cost/index.js';
 import { OPENROUTER_API_KEY_ENV } from '@myco/cli/providers/openrouter.js';
 
 afterEach(() => {
@@ -8,6 +8,32 @@ afterEach(() => {
 });
 
 describe('resolveCost', () => {
+  it('exposes provider capabilities through the registry', () => {
+    const openRouterProvider = getCostProvider({
+      runtime: 'openai-agents',
+      model: 'openrouter/auto',
+      provider: { type: 'openrouter', model: 'openrouter/auto' },
+      usage: {},
+    });
+    const localProvider = getCostProvider({
+      runtime: 'claude-sdk',
+      model: 'llama3.2',
+      provider: { type: 'ollama', model: 'llama3.2' },
+      usage: {},
+    });
+
+    expect(openRouterProvider?.capabilities).toEqual({
+      estimateFromUsage: true,
+      fetchActualRunCost: true,
+      fetchCatalogPricing: true,
+    });
+    expect(localProvider?.capabilities).toEqual({
+      estimateFromUsage: false,
+      fetchActualRunCost: false,
+      fetchCatalogPricing: false,
+    });
+  });
+
   it('prefers actual cost reported by the runtime', async () => {
     const result = await resolveCost({
       runtime: 'claude-sdk',

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -171,6 +171,9 @@ let mockExecution: ExecutionConfig | undefined;
 /** Orchestrator config to return from the registry mock. Set per-test. */
 let mockOrchestratorConfig: OrchestratorConfig | undefined;
 
+/** Top-level task reasoning level from the registry mock. Set per-test. */
+let mockTaskReasoningLevel: 'low' | 'default' | 'high' | undefined;
+
 vi.mock('@myco/agent/loader.js', async (importOriginal) => {
   const original = await importOriginal<typeof import('@myco/agent/loader.js')>();
   return {
@@ -220,16 +223,17 @@ vi.mock('@myco/agent/loader.js', async (importOriginal) => {
 vi.mock('@myco/agent/registry.js', () => ({
   loadAllTasks: (_definitionsDir: string, _vaultDir?: string) => {
     const tasks = new Map();
-    const task = {
-      name: TEST_TASK_NAME,
-      displayName: 'Full Intelligence',
-      description: 'Run full intelligence pipeline',
-      agent: 'myco-agent',
-      prompt: mockYamlPhases ? 'Phased pipeline overview.' : TEST_TASK_PROMPT,
-      isDefault: true,
-      ...(mockYamlPhases ? { phases: mockYamlPhases } : {}),
-      ...(mockExecution ? { execution: mockExecution } : {}),
-      ...(mockOrchestratorConfig ? { orchestrator: mockOrchestratorConfig } : {}),
+      const task = {
+        name: TEST_TASK_NAME,
+        displayName: 'Full Intelligence',
+        description: 'Run full intelligence pipeline',
+        agent: 'myco-agent',
+        prompt: mockYamlPhases ? 'Phased pipeline overview.' : TEST_TASK_PROMPT,
+        isDefault: true,
+        ...(mockTaskReasoningLevel ? { reasoningLevel: mockTaskReasoningLevel } : {}),
+        ...(mockYamlPhases ? { phases: mockYamlPhases } : {}),
+        ...(mockExecution ? { execution: mockExecution } : {}),
+        ...(mockOrchestratorConfig ? { orchestrator: mockOrchestratorConfig } : {}),
     };
     tasks.set(TEST_TASK_NAME, task);
     return tasks;
@@ -283,15 +287,18 @@ vi.mock('@myco/db/client.js', async (importOriginal) => {
 // Mock: config loader (avoid filesystem reads for myco.yaml)
 // ---------------------------------------------------------------------------
 
+let mockMergedConfig: any = {
+  version: 3,
+  config_version: 0,
+  embedding: { provider: 'ollama', model: 'bge-m3' },
+  daemon: { port: null, log_level: 'info' },
+  capture: { transcript_paths: [], artifact_watch: [], artifact_extensions: [], buffer_max_events: 500 },
+  agent: { summary_batch_interval: 5 },
+};
+
 vi.mock('@myco/config/loader.js', () => ({
-  loadConfig: () => ({
-    version: 3,
-    config_version: 0,
-    embedding: { provider: 'ollama', model: 'bge-m3' },
-    daemon: { port: null, log_level: 'info' },
-    capture: { transcript_paths: [], artifact_watch: [], artifact_extensions: [], buffer_max_events: 500 },
-    agent: { summary_batch_interval: 5 },
-  }),
+  loadConfig: () => mockMergedConfig,
+  loadMergedConfig: () => mockMergedConfig,
 }));
 
 // ---------------------------------------------------------------------------
@@ -334,7 +341,16 @@ function resetMockState(): void {
   mockYamlPhases = undefined;
   mockExecution = undefined;
   mockOrchestratorConfig = undefined;
+  mockTaskReasoningLevel = undefined;
   mockAssistantCount = 0;
+  mockMergedConfig = {
+    version: 3,
+    config_version: 0,
+    embedding: { provider: 'ollama', model: 'bge-m3' },
+    daemon: { port: null, log_level: 'info' },
+    capture: { transcript_paths: [], artifact_watch: [], artifact_extensions: [], buffer_max_events: 500 },
+    agent: { summary_batch_interval: 5 },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -839,6 +855,54 @@ describe('runAgent — phased execution', () => {
     expect((allQueryCalls[0].options as Record<string, unknown>).model).toBe('claude-haiku-4-5');
     // Phase 2 should fall back to the task/agent model
     expect((allQueryCalls[1].options as Record<string, unknown>).model).toBe('claude-sonnet-4-20250514');
+  });
+
+  it('uses task-level reasoningLevel for single-query tasks', async () => {
+    mockYamlPhases = undefined;
+    mockTaskReasoningLevel = 'low';
+    mockExecution = {
+      provider: {
+        type: 'anthropic',
+        reasoningMap: {
+          low: 'claude-haiku-4-5',
+          default: 'claude-sonnet-4-6',
+        },
+      },
+    };
+
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    await runAgent(TEST_VAULT_DIR);
+
+    expect(allQueryCalls).toHaveLength(1);
+    expect((allQueryCalls[0].options as Record<string, unknown>).model).toBe('claude-haiku-4-5');
+  });
+
+  it('uses myco.yaml per-phase model overrides when present', async () => {
+    mockYamlPhases = [
+      { name: 'extract', prompt: 'Extract.', tools: ['vault_unprocessed'], maxTurns: 20, required: true },
+      { name: 'graph', prompt: 'Build graph.', tools: ['vault_create_entity'], maxTurns: 10, required: true, dependsOn: ['extract'] },
+    ];
+    mockMergedConfig = {
+      ...mockMergedConfig,
+      agent: {
+        ...mockMergedConfig.agent,
+        tasks: {
+          [TEST_TASK_NAME]: {
+            phases: {
+              extract: { model: 'claude-opus-4-6' },
+            },
+          },
+        },
+      },
+    };
+
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    await runAgent(TEST_VAULT_DIR);
+
+    expect(allQueryCalls).toHaveLength(2);
+    expect((allQueryCalls[0].options as Record<string, unknown>).model).toBe('claude-opus-4-6');
   });
 
   it('records correct aggregate tokens and cost', async () => {

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -6,6 +6,7 @@
  * instance with the full schema.
  */
 
+import crypto from 'node:crypto';
 import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
 import { getDatabase } from '@myco/db/client.js';
 import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
@@ -482,12 +483,17 @@ describe('runAgent', () => {
     expect(result.runId).toBeDefined();
     expect(result.tokensUsed).toBe(1850);
     expect(result.costUsd).toBe(0.0042);
+    expect(result.costSource).toBe('actual');
 
     const run = getRun(result.runId);
     expect(run).not.toBeNull();
     expect(run!.status).toBe('completed');
     expect(run!.tokens_used).toBe(1850);
     expect(run!.cost_usd).toBe(0.0042);
+    expect(run!.actual_cost_usd).toBe(0.0042);
+    expect(run!.estimated_cost_usd).toBeNull();
+    expect(run!.cost_source).toBe('actual');
+    expect(run!.cost_data).toBeTruthy();
     expect(run!.task).toBe(TEST_TASK_NAME);
     expect(run!.agent_id).toBe(TEST_AGENT_ID);
     expect(run!.started_at).toBeGreaterThan(0);
@@ -544,6 +550,44 @@ describe('runAgent', () => {
     expect(run!.status).toBe('failed');
     expect(run!.error).toContain('API rate limit exceeded');
     expect(run!.completed_at).toBeGreaterThan(0);
+  });
+
+  it('resets started_at to the resume attempt time when resuming a failed run', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    const existingRunId = crypto.randomUUID();
+    const originalStartedAt = epochSeconds() - 120;
+    const originalCompletedAt = epochSeconds() - 60;
+    insertRun({
+      id: existingRunId,
+      agent_id: TEST_AGENT_ID,
+      task: TEST_TASK_NAME,
+      status: 'failed',
+      instruction: 'Retry this run',
+      runtime: 'claude-sdk',
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      resumable: 1,
+      resume_status: 'ready',
+      checkpoints: JSON.stringify({ runtime: 'claude-sdk', phases: {} }),
+      started_at: originalStartedAt,
+      completed_at: originalCompletedAt,
+      error: 'boom',
+    });
+
+    const result = await runAgent(TEST_VAULT_DIR, {
+      task: TEST_TASK_NAME,
+      instruction: 'Retry this run',
+      resumeRunId: existingRunId,
+      resumeMode: 'manual',
+    });
+
+    expect(result.status).toBe('completed');
+    const run = getRun(existingRunId);
+    expect(run).not.toBeNull();
+    expect(run!.started_at).toBeGreaterThan(originalStartedAt);
+    expect(run!.started_at).toBeGreaterThanOrEqual(run!.resumed_at ?? 0);
+    expect(run!.completed_at).toBeGreaterThanOrEqual(run!.started_at ?? 0);
   });
 
   it('stores user instruction in run record and prompt', async () => {
@@ -712,6 +756,7 @@ describe('runAgent — phased execution', () => {
     expect(result.phases![0].status).toBe('completed');
     expect(result.phases![0].tokensUsed).toBe(1850);
     expect(result.phases![0].costUsd).toBe(0.0042);
+    expect(result.phases![0].costSource).toBe('actual');
     expect(result.phases![0].turnsUsed).toBe(3);
 
     expect(result.phases![1].name).toBe('extract');
@@ -918,6 +963,8 @@ describe('runAgent — phased execution', () => {
     const run = getRun(result.runId);
     expect(run!.tokens_used).toBe(5550);
     expect(run!.cost_usd).toBeCloseTo(0.0126);
+    expect(run!.actual_cost_usd).toBeCloseTo(0.0126);
+    expect(run!.cost_source).toBe('actual');
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -16,6 +16,7 @@ import { insertRun, getRun } from '@myco/db/queries/runs.js';
 import { epochSeconds } from '@myco/constants.js';
 import { composeTaskPrompt, composePhasePrompt } from '@myco/agent/executor.js';
 import type { PhaseDefinition, ExecutionConfig, OrchestratorConfig } from '@myco/agent/types.js';
+import type { ReportRow } from '@myco/db/queries/reports.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -62,6 +63,8 @@ const DEFAULT_RESULT_TEXT = 'Agent run complete.';
  * of using num_turns from the SDK result.
  */
 let mockAssistantCount = 0;
+let mockToolCallCounts: Record<string, number> = {};
+let mockRunReports: ReportRow[] = [];
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => {
   return {
@@ -272,6 +275,22 @@ vi.mock('@myco/agent/tools.js', () => ({
   },
 }));
 
+vi.mock('@myco/db/queries/turns.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@myco/db/queries/turns.js')>();
+  return {
+    ...original,
+    countToolCallsByRun: () => mockToolCallCounts,
+  };
+});
+
+vi.mock('@myco/db/queries/reports.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@myco/db/queries/reports.js')>();
+  return {
+    ...original,
+    listReports: () => mockRunReports,
+  };
+});
+
 // ---------------------------------------------------------------------------
 // Mock: initDatabaseForVault (we manage DB ourselves in tests)
 // ---------------------------------------------------------------------------
@@ -330,6 +349,20 @@ async function createTestTask(): Promise<void> {
   });
 }
 
+async function createTask(taskId: string, prompt = TEST_TASK_PROMPT): Promise<void> {
+  const now = epochSeconds();
+  upsertTask({
+    id: taskId,
+    agent_id: TEST_AGENT_ID,
+    prompt,
+    display_name: taskId,
+    description: `Run ${taskId}`,
+    is_default: 0,
+    created_at: now,
+    updated_at: now,
+  });
+}
+
 /** Resets all mock state between tests. */
 function resetMockState(): void {
   capturedQueryArgs = null;
@@ -344,6 +377,8 @@ function resetMockState(): void {
   mockOrchestratorConfig = undefined;
   mockTaskReasoningLevel = undefined;
   mockAssistantCount = 0;
+  mockToolCallCounts = {};
+  mockRunReports = [];
   mockMergedConfig = {
     version: 3,
     config_version: 0,
@@ -682,6 +717,58 @@ describe('runAgent', () => {
     // The executor creates an AbortController and passes it to the SDK
     expect(opts.abortController).toBeDefined();
     expect(opts.abortController).toBeInstanceOf(AbortController);
+  });
+
+  it('fails title-summary when no report or session update side effect occurred', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+    await createTask('title-summary', 'Generate or update session titles and summaries.');
+
+    const result = await runAgent(TEST_VAULT_DIR, { task: 'title-summary' });
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toContain('title-summary');
+    const run = getRun(result.runId);
+    expect(run?.status).toBe('failed');
+    expect(run?.error).toContain('title-summary');
+  });
+
+  it('allows title-summary to complete when it reports a skip', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+    await createTask('title-summary', 'Generate or update session titles and summaries.');
+
+    mockRunReports = [{
+      id: 1,
+      run_id: 'unused',
+      agent_id: TEST_AGENT_ID,
+      action: 'skip',
+      summary: 'No update needed',
+      details: null,
+      created_at: epochSeconds(),
+    }];
+
+    const result = await runAgent(TEST_VAULT_DIR, { task: 'title-summary' });
+
+    expect(result.status).toBe('completed');
+  });
+
+  it('allows title-summary to complete when it updates the session and reports', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+    await createTask('title-summary', 'Generate or update session titles and summaries.');
+
+    mockToolCallCounts = { vault_update_session: 1 };
+    mockRunReports = [{
+      id: 1,
+      run_id: 'unused',
+      agent_id: TEST_AGENT_ID,
+      action: 'summary',
+      summary: 'Sessions updated: 1',
+      details: null,
+      created_at: epochSeconds(),
+    }];
+
+    const result = await runAgent(TEST_VAULT_DIR, { task: 'title-summary' });
+
+    expect(result.status).toBe('completed');
   });
 });
 

--- a/tests/agent/harness-properties.test.ts
+++ b/tests/agent/harness-properties.test.ts
@@ -57,7 +57,7 @@ describe('harness properties', () => {
 
     it('read tools are annotated readOnlyHint: true', () => {
       const readToolNames = [
-        'vault_unprocessed', 'vault_spores', 'vault_sessions',
+        'vault_unprocessed', 'vault_batches', 'vault_spores', 'vault_sessions',
         'vault_search_fts', 'vault_search_semantic', 'vault_state',
         'vault_entities', 'vault_edges', 'vault_read_digest',
       ];

--- a/tests/agent/openai-local-mcp.test.ts
+++ b/tests/agent/openai-local-mcp.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { createLocalVaultMcpServer } from '@myco/agent/runtime/openai-local-mcp.js';
+
+describe('createLocalVaultMcpServer', () => {
+  it('exports JSON Schema for Anthropic SDK tools', async () => {
+    const server = createLocalVaultMcpServer({
+      agentId: 'agent-test',
+      runId: 'run-test',
+      toolNames: ['vault_create_spore'],
+    });
+
+    const tools = await server.listTools();
+    const createSpore = tools.find((tool) => tool.name === 'vault_create_spore');
+
+    expect(tools).toHaveLength(1);
+    expect(createSpore).toBeDefined();
+    expect(createSpore?.inputSchema).toMatchObject({
+      type: 'object',
+      required: ['observation_type', 'content'],
+      additionalProperties: false,
+      properties: {
+        observation_type: { type: 'string' },
+        content: { type: 'string' },
+        session_id: { type: 'string' },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      },
+    });
+    expect((createSpore?.inputSchema?.properties as Record<string, unknown>)?.optional).toBeUndefined();
+
+    await server.close();
+  });
+});

--- a/tests/agent/openai-runtime.test.ts
+++ b/tests/agent/openai-runtime.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderConfig } from '@myco/agent/types.js';
+import { resolveOpenAIClientConfig, shouldUseResponsesApi } from '@myco/agent/runtime/openai.js';
+import { OPENAI_API_KEY_ENV } from '@myco/cli/providers/openai-embeddings.js';
+import { OPENROUTER_API_KEY_ENV } from '@myco/cli/providers/openrouter.js';
+
+const LOCAL_BASE_URL = 'http://localhost:11434/v1';
+
+describe('resolveOpenAIClientConfig', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('allows openai-compatible providers without a configured key', () => {
+    const provider: ProviderConfig = {
+      type: 'openai-compatible',
+      baseUrl: LOCAL_BASE_URL,
+      model: 'google/gemma-4-26b-a4b',
+    };
+
+    expect(resolveOpenAIClientConfig(provider)).toEqual({
+      apiKey: 'myco-local-openai-compatible',
+      baseURL: LOCAL_BASE_URL,
+    });
+  });
+
+  it('prefers an explicit openai-compatible key when configured', () => {
+    const provider: ProviderConfig = {
+      type: 'openai-compatible',
+      baseUrl: LOCAL_BASE_URL,
+      model: 'google/gemma-4-26b-a4b',
+      apiKey: 'lmstudio-secret',
+    };
+
+    expect(resolveOpenAIClientConfig(provider)).toEqual({
+      apiKey: 'lmstudio-secret',
+      baseURL: LOCAL_BASE_URL,
+    });
+  });
+
+  it('uses OpenAI env auth for the OpenAI provider', () => {
+    vi.stubEnv(OPENAI_API_KEY_ENV, 'sk-openai');
+    const provider: ProviderConfig = {
+      type: 'openai',
+      model: 'gpt-5.4-mini',
+    };
+
+    expect(resolveOpenAIClientConfig(provider)).toEqual({
+      apiKey: 'sk-openai',
+      baseURL: 'https://api.openai.com/v1',
+    });
+  });
+
+  it('uses OpenRouter env auth for the OpenRouter provider', () => {
+    vi.stubEnv(OPENROUTER_API_KEY_ENV, 'sk-openrouter');
+    const provider: ProviderConfig = {
+      type: 'openrouter',
+      model: 'openrouter/auto',
+    };
+
+    expect(resolveOpenAIClientConfig(provider)).toEqual({
+      apiKey: 'sk-openrouter',
+      baseURL: 'https://openrouter.ai/api/v1',
+    });
+  });
+
+  it('defaults Ollama-backed OpenAI runtime calls to the Ollama port', () => {
+    expect(resolveOpenAIClientConfig({
+      type: 'ollama',
+      model: 'gemma4:26b',
+    })).toEqual({
+      apiKey: 'myco-local-openai-compatible',
+      baseURL: 'http://localhost:11434/v1',
+    });
+  });
+
+  it('normalizes localhost openai-compatible roots to the OpenAI /v1 path', () => {
+    expect(resolveOpenAIClientConfig({
+      type: 'openai-compatible',
+      baseUrl: 'http://localhost:1234',
+      model: 'google/gemma-4-26b-a4b',
+    })).toEqual({
+      apiKey: 'myco-local-openai-compatible',
+      baseURL: 'http://localhost:1234/v1',
+    });
+  });
+
+  it('uses the explicit local backend default for openai-compatible ollama', () => {
+    expect(resolveOpenAIClientConfig({
+      type: 'openai-compatible',
+      localBackend: 'ollama',
+      model: 'gemma4:26b',
+    })).toEqual({
+      apiKey: 'myco-local-openai-compatible',
+      baseURL: 'http://localhost:11434/v1',
+    });
+  });
+
+  it('uses chat completions mode for local-compatible providers', () => {
+    expect(shouldUseResponsesApi({
+      type: 'openai-compatible',
+      baseUrl: LOCAL_BASE_URL,
+      model: 'google/gemma-4-26b-a4b',
+    })).toBe(false);
+  });
+
+  it('keeps responses mode for frontier OpenAI providers', () => {
+    expect(shouldUseResponsesApi({
+      type: 'openai',
+      model: 'gpt-5.4-mini',
+    })).toBe(true);
+    expect(shouldUseResponsesApi({
+      type: 'openrouter',
+      model: 'openrouter/auto',
+    })).toBe(true);
+  });
+});

--- a/tests/agent/provider-runtime.test.ts
+++ b/tests/agent/provider-runtime.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { inferRuntimeFromProviderType } from '@myco/agent/provider-runtime.js';
+
+describe('inferRuntimeFromProviderType', () => {
+  it('maps Claude-shaped providers to the Claude runtime', () => {
+    expect(inferRuntimeFromProviderType('anthropic')).toBe('claude-sdk');
+    expect(inferRuntimeFromProviderType('ollama')).toBe('claude-sdk');
+    expect(inferRuntimeFromProviderType('lmstudio')).toBe('claude-sdk');
+  });
+
+  it('maps OpenAI-shaped providers to the OpenAI runtime', () => {
+    expect(inferRuntimeFromProviderType('openai')).toBe('openai-agents');
+    expect(inferRuntimeFromProviderType('openrouter')).toBe('openai-agents');
+    expect(inferRuntimeFromProviderType('openai-compatible')).toBe('openai-agents');
+  });
+});

--- a/tests/agent/schemas.test.ts
+++ b/tests/agent/schemas.test.ts
@@ -44,7 +44,7 @@ describe('ProviderConfigSchema', () => {
   });
 
   it('validates all valid provider types', () => {
-    for (const type of ['anthropic', 'ollama', 'lmstudio'] as const) {
+    for (const type of ['anthropic', 'ollama', 'lmstudio', 'openai', 'openrouter', 'openai-compatible'] as const) {
       const result = ProviderConfigSchema.parse({ type });
       expect(result.type).toBe(type);
     }
@@ -65,7 +65,6 @@ describe('ProviderConfigSchema', () => {
   });
 
   it('rejects invalid provider type', () => {
-    expect(() => ProviderConfigSchema.parse({ type: 'openai' })).toThrow();
     expect(() => ProviderConfigSchema.parse({ type: 'cloud' })).toThrow();
     expect(() => ProviderConfigSchema.parse({ type: '' })).toThrow();
   });
@@ -368,7 +367,7 @@ describe('AgentTaskSchema — with execution overrides', () => {
       prompt: 'Run.',
       isDefault: false,
       execution: {
-        provider: { type: 'openai' }, // not a valid enum value
+        provider: { type: 'cloud' }, // not a valid enum value
       },
     })).toThrow();
   });

--- a/tests/agent/tools.test.ts
+++ b/tests/agent/tools.test.ts
@@ -190,6 +190,25 @@ describe('vault tools', () => {
     });
   });
 
+  describe('vault_batches', () => {
+    it('returns batches for the requested session in prompt order', async () => {
+      insertBatch(makeBatch(sessionId, { prompt_number: 2 }));
+      insertBatch(makeBatch(sessionId, { prompt_number: 1 }));
+
+      const otherSession = makeSession({ id: 'sess-other', status: 'completed' });
+      upsertSession(otherSession);
+      insertBatch(makeBatch(otherSession.id, { prompt_number: 1 }));
+
+      const t = findTool(tools, 'vault_batches');
+      const result = await t.handler({ session_id: sessionId }, undefined);
+      const data = parseResult(result) as Array<{ session_id: string; prompt_number: number }>;
+
+      expect(data).toHaveLength(2);
+      expect(data.map((row) => row.session_id)).toEqual([sessionId, sessionId]);
+      expect(data.map((row) => row.prompt_number)).toEqual([1, 2]);
+    });
+  });
+
   describe('vault_spores', () => {
     it('returns empty array when no spores exist', async () => {
       const t = findTool(tools, 'vault_spores');
@@ -267,6 +286,18 @@ describe('vault tools', () => {
       const result = await t.handler({ status: 'completed' }, undefined);
       const data = parseResult(result) as unknown[];
       expect(data).toEqual([]);
+    });
+
+    it('fetches an exact session by id', async () => {
+      const completed = makeSession({ id: 'sess-completed', status: 'completed' });
+      upsertSession(completed);
+
+      const t = findTool(tools, 'vault_sessions');
+      const result = await t.handler({ id: completed.id }, undefined);
+      const data = parseResult(result) as Array<{ id: string; status: string }>;
+
+      expect(data).toHaveLength(1);
+      expect(data[0]).toMatchObject({ id: completed.id, status: 'completed' });
     });
   });
 

--- a/tests/config/updates.test.ts
+++ b/tests/config/updates.test.ts
@@ -85,6 +85,20 @@ describe('withTaskConfig', () => {
     expect(result.agent.tasks?.['title-summary']?.provider?.model).toBe('granite4:small-h');
   });
 
+  it('preserves openai-compatible local_backend on task provider overrides', () => {
+    const result = withTaskConfig(baseConfig(), 'title-summary', {
+      provider: {
+        type: 'openai-compatible',
+        local_backend: 'lmstudio',
+        base_url: 'http://localhost:1234',
+        model: 'google/gemma-4-26b-a4b',
+      },
+    });
+    expect(result.agent.tasks?.['title-summary']?.provider?.type).toBe('openai-compatible');
+    expect(result.agent.tasks?.['title-summary']?.provider?.local_backend).toBe('lmstudio');
+    expect(result.agent.tasks?.['title-summary']?.provider?.base_url).toBe('http://localhost:1234');
+  });
+
   it('sets model and maxTurns', () => {
     const result = withTaskConfig(baseConfig(), 'title-summary', {
       model: 'granite4:small-h',

--- a/tests/daemon/api/models.test.ts
+++ b/tests/daemon/api/models.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { handleGetModels } from '@myco/daemon/api/models.js';
+import { OPENAI_API_KEY_ENV } from '@myco/cli/providers/openai-embeddings.js';
+
+const fetchMock = vi.fn();
+global.fetch = fetchMock as unknown as typeof fetch;
+
+describe('handleGetModels', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+    delete process.env[OPENAI_API_KEY_ENV];
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it('returns remote OpenAI models when an API key is configured', async () => {
+    process.env[OPENAI_API_KEY_ENV] = 'sk-test';
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: 'gpt-5.4' }, { id: 'text-embedding-3-small' }],
+      }),
+    });
+
+    const result = await handleGetModels({
+      body: undefined,
+      params: {},
+      pathname: '/api/models',
+      query: { provider: 'openai', type: 'llm' },
+    });
+
+    expect((result.body as { models: string[] }).models).toEqual(['gpt-5.4']);
+  });
+
+  it('returns an empty list when remote auth is missing', async () => {
+    const result = await handleGetModels({
+      body: undefined,
+      params: {},
+      pathname: '/api/models',
+      query: { provider: 'openai', type: 'llm' },
+    });
+
+    expect((result.body as { models: string[] }).models).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/daemon/api/provider-secrets.test.ts
+++ b/tests/daemon/api/provider-secrets.test.ts
@@ -1,0 +1,64 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  handleDeleteProviderSecret,
+  handleGetProviderSecrets,
+  handlePutProviderSecret,
+} from '@myco/daemon/api/provider-secrets.js';
+import { OPENAI_API_KEY_ENV } from '@myco/cli/providers/openai-embeddings.js';
+
+describe('provider secret handlers', () => {
+  let vaultDir: string;
+
+  afterEach(() => {
+    if (vaultDir && fs.existsSync(vaultDir)) {
+      fs.rmSync(vaultDir, { recursive: true, force: true });
+    }
+    delete process.env[OPENAI_API_KEY_ENV];
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it('stores OpenAI keys in secrets.env and exposes masked status', async () => {
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-provider-secret-'));
+
+    const putResult = await handlePutProviderSecret(vaultDir, {
+      body: { api_key: 'sk-openai-secret-value' },
+      params: { provider: 'openai' },
+      query: {},
+      pathname: '/api/providers/secrets/openai',
+    });
+
+    expect(putResult.status ?? 200).toBe(200);
+    expect(process.env[OPENAI_API_KEY_ENV]).toBe('sk-openai-secret-value');
+    expect(process.env.OPENAI_API_KEY).toBe('sk-openai-secret-value');
+
+    const getResult = await handleGetProviderSecrets(vaultDir);
+    const openai = (getResult.body as { secrets: { openai: { configured: boolean; maskedValue: string | null } } }).secrets.openai;
+    expect(openai.configured).toBe(true);
+    expect(openai.maskedValue).toMatch(/^sk-opena/);
+  });
+
+  it('deletes stored keys and clears process env', async () => {
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-provider-secret-'));
+    await handlePutProviderSecret(vaultDir, {
+      body: { api_key: 'sk-openai-secret-value' },
+      params: { provider: 'openai' },
+      query: {},
+      pathname: '/api/providers/secrets/openai',
+    });
+
+    const deleteResult = await handleDeleteProviderSecret(vaultDir, {
+      body: undefined,
+      params: { provider: 'openai' },
+      query: {},
+      pathname: '/api/providers/secrets/openai',
+    });
+
+    expect(deleteResult.status ?? 200).toBe(200);
+    expect(process.env[OPENAI_API_KEY_ENV]).toBeUndefined();
+    expect(process.env.OPENAI_API_KEY).toBeUndefined();
+    expect(fs.existsSync(path.join(vaultDir, 'secrets.env'))).toBe(false);
+  });
+});

--- a/tests/daemon/api/providers.test.ts
+++ b/tests/daemon/api/providers.test.ts
@@ -9,6 +9,8 @@
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { handleGetProviders, handleTestProvider } from '@myco/daemon/api/providers';
+import { OPENAI_API_KEY_ENV } from '@myco/cli/providers/openai-embeddings.js';
+import { OPENROUTER_API_KEY_ENV } from '@myco/cli/providers/openrouter.js';
 
 // ---------------------------------------------------------------------------
 // Mock: intelligence backends (avoid real network calls)
@@ -18,6 +20,7 @@ let ollamaAvailable = false;
 let ollamaModels: string[] = [];
 let lmStudioAvailable = false;
 let lmStudioModels: string[] = [];
+const fetchMock = vi.fn();
 
 vi.mock('@myco/intelligence/ollama.js', () => ({
   OllamaBackend: class {
@@ -35,11 +38,14 @@ vi.mock('@myco/intelligence/lm-studio.js', () => ({
   },
 }));
 
+global.fetch = fetchMock as unknown as typeof fetch;
+
 afterEach(() => {
   ollamaAvailable = false;
   ollamaModels = [];
   lmStudioAvailable = false;
   lmStudioModels = [];
+  fetchMock.mockReset();
   vi.unstubAllEnvs();
 });
 
@@ -55,7 +61,7 @@ describe('handleGetProviders', () => {
     expect(result.body).toHaveProperty('providers');
     const providers = (result.body as { providers: unknown[] }).providers;
     expect(Array.isArray(providers)).toBe(true);
-    expect(providers.length).toBe(3);
+    expect(providers.length).toBe(6);
   });
 
   it('each provider has type, available, and models fields', async () => {
@@ -92,6 +98,36 @@ describe('handleGetProviders', () => {
     expect(anthropic!.available).toBe(true);
     expect((anthropic!.models as string[]).length).toBeGreaterThan(0);
   });
+
+  it('marks OpenAI as needing auth when no key is configured', async () => {
+    const result = await handleGetProviders();
+    const providers = (result.body as { providers: Array<Record<string, unknown>> }).providers;
+    const openai = providers.find((p) => p.type === 'openai');
+
+    expect(openai).toBeDefined();
+    expect(openai!.available).toBe(false);
+    expect(openai!.authConfigured).toBe(false);
+    expect(openai!.models).toEqual([]);
+  });
+
+  it('loads OpenAI models dynamically when a key is configured', async () => {
+    vi.stubEnv(OPENAI_API_KEY_ENV, 'sk-test');
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: 'gpt-5.4' }, { id: 'text-embedding-3-small' }],
+      }),
+    });
+
+    const result = await handleGetProviders();
+    const providers = (result.body as { providers: Array<Record<string, unknown>> }).providers;
+    const openai = providers.find((p) => p.type === 'openai');
+
+    expect(openai).toBeDefined();
+    expect(openai!.available).toBe(true);
+    expect(openai!.authConfigured).toBe(true);
+    expect(openai!.models).toEqual(['gpt-5.4']);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -113,7 +149,7 @@ describe('handleTestProvider — validation', () => {
 
   it('returns 400 for invalid provider type', async () => {
     const result = await handleTestProvider({
-      body: { type: 'openai' },
+      body: { type: 'cloud' },
       query: {},
       params: {},
       pathname: '/api/providers/test',
@@ -189,6 +225,41 @@ describe('handleTestProvider — connectivity', () => {
   it('tests anthropic provider always returns ok', async () => {
     const result = await handleTestProvider({
       body: { type: 'anthropic' },
+      query: {},
+      params: {},
+      pathname: '/api/providers/test',
+    });
+
+    expect(result.status).toBe(200);
+    const body = result.body as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+  });
+
+  it('tests OpenAI provider fails cleanly when key is missing', async () => {
+    const result = await handleTestProvider({
+      body: { type: 'openai' },
+      query: {},
+      params: {},
+      pathname: '/api/providers/test',
+    });
+
+    expect(result.status).toBe(200);
+    const body = result.body as Record<string, unknown>;
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/API key/);
+  });
+
+  it('tests OpenRouter provider by calling the remote models endpoint', async () => {
+    vi.stubEnv(OPENROUTER_API_KEY_ENV, 'sk-or-test');
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: 'openai/gpt-5.4' }],
+      }),
+    });
+
+    const result = await handleTestProvider({
+      body: { type: 'openrouter' },
       query: {},
       params: {},
       pathname: '/api/providers/test',

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -39,7 +39,7 @@ describe('Database schema', () => {
 
   describe('constants', () => {
     it('exports SCHEMA_VERSION as a positive integer', () => {
-      expect(SCHEMA_VERSION).toBe(12);
+      expect(SCHEMA_VERSION).toBe(13);
       expect(Number.isInteger(SCHEMA_VERSION)).toBe(true);
     });
 

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -39,7 +39,7 @@ describe('Database schema', () => {
 
   describe('constants', () => {
     it('exports SCHEMA_VERSION as a positive integer', () => {
-      expect(SCHEMA_VERSION).toBe(13);
+      expect(SCHEMA_VERSION).toBe(14);
       expect(Number.isInteger(SCHEMA_VERSION)).toBe(true);
     });
 

--- a/tests/smoke/review-fixes.test.ts
+++ b/tests/smoke/review-fixes.test.ts
@@ -360,8 +360,8 @@ describe('MCP tools: myco_skills and myco_skill_candidates', () => {
 // VAULT_TOOL_COUNT consistency
 // ---------------------------------------------------------------------------
 describe('VAULT_TOOL_COUNT', () => {
-  it('matches expected count (23)', () => {
-    expect(VAULT_TOOL_COUNT).toBe(23);
+  it('matches expected count (24)', () => {
+    expect(VAULT_TOOL_COUNT).toBe(24);
   });
 });
 

--- a/tests/smoke/skill-staging-pipeline.test.ts
+++ b/tests/smoke/skill-staging-pipeline.test.ts
@@ -101,17 +101,17 @@ describe('smoke: skill staging pipeline (real on-disk SQLite)', () => {
   });
 
   // --------------------------------------------------------------------------
-  // Schema lands at v10 on a fresh install against a real on-disk file
+  // Schema lands at the current version on a fresh install against a real on-disk file
   // --------------------------------------------------------------------------
 
-  it('fresh install records schema v13 and exposes approved_at on skill_candidates', () => {
+  it('fresh install records schema v14 and exposes approved_at on skill_candidates', () => {
     const db = getDatabase();
 
     const row = db
       .prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1')
       .get() as { version: number };
     expect(row.version).toBe(SCHEMA_VERSION);
-    expect(row.version).toBe(13);
+    expect(row.version).toBe(14);
 
     const cols = db
       .prepare('PRAGMA table_info(skill_candidates)')

--- a/tests/smoke/skill-staging-pipeline.test.ts
+++ b/tests/smoke/skill-staging-pipeline.test.ts
@@ -104,14 +104,14 @@ describe('smoke: skill staging pipeline (real on-disk SQLite)', () => {
   // Schema lands at v10 on a fresh install against a real on-disk file
   // --------------------------------------------------------------------------
 
-  it('fresh install records schema v10 and exposes approved_at on skill_candidates', () => {
+  it('fresh install records schema v13 and exposes approved_at on skill_candidates', () => {
     const db = getDatabase();
 
     const row = db
       .prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1')
       .get() as { version: number };
     expect(row.version).toBe(SCHEMA_VERSION);
-    expect(row.version).toBe(12);
+    expect(row.version).toBe(13);
 
     const cols = db
       .prepare('PRAGMA table_info(skill_candidates)')

--- a/tests/ui/searchable-select.test.ts
+++ b/tests/ui/searchable-select.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getSearchableSelectRank,
+  type SearchableSelectOption,
+} from '../../packages/myco/ui/src/components/ui/searchable-select';
+
+const OPENAI_41_OPTION: SearchableSelectOption = {
+  value: 'gpt-4.1-2025-04-14',
+  label: 'gpt-4.1-2025-04-14',
+};
+
+const OPENAI_54_OPTION: SearchableSelectOption = {
+  value: 'gpt-5.4-nano-2026-03-17',
+  label: 'gpt-5.4-nano-2026-03-17',
+};
+
+describe('getSearchableSelectRank', () => {
+  it('matches version-like queries only when the candidate contains that version', () => {
+    expect(getSearchableSelectRank(OPENAI_54_OPTION, '5.4')).not.toBeNull();
+    expect(getSearchableSelectRank(OPENAI_41_OPTION, '5.4')).toBeNull();
+  });
+
+  it('matches punctuation-insensitive compact queries for model ids', () => {
+    expect(getSearchableSelectRank(OPENAI_54_OPTION, 'gpt54nano')).not.toBeNull();
+  });
+
+  it('supports multi-token textual matching without requiring exact punctuation', () => {
+    expect(getSearchableSelectRank(
+      { value: 'o3-mini-2025-01-31', label: 'o3-mini-2025-01-31' },
+      'o3 mini',
+    )).not.toBeNull();
+  });
+});

--- a/tests/ui/task-provider-config.test.ts
+++ b/tests/ui/task-provider-config.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import {
+  draftToNormalizedProviderConfig,
+  normalizeSelectableModel,
+  providerDraftFromSource,
+} from '../../packages/myco/ui/src/hooks/use-provider-config-draft';
+
+describe('provider config draft helpers', () => {
+  it('preserves the inherited runtime when defaults provide a provider bundle', () => {
+    const draft = providerDraftFromSource(
+      null,
+      {
+        runtime: 'openai-agents',
+        providerType: 'openrouter',
+        model: 'openrouter/auto',
+        reasoningMap: {
+          low: 'openrouter/auto',
+          default: 'openrouter/auto',
+          high: 'openrouter/auto',
+        },
+      },
+    );
+
+    expect(draft.runtime).toBe('openai-agents');
+    expect(draft.type).toBe('openrouter');
+    expect(draft.model).toBe('openrouter/auto');
+  });
+
+  it('does not inherit cross-provider reasoning models when a task provider override exists', () => {
+    const draft = providerDraftFromSource(
+      {
+        runtime: 'openai-agents',
+        provider: {
+          type: 'openai',
+          model: 'gpt-5.4-nano',
+        },
+      },
+      {
+        providerType: 'openrouter',
+        model: 'openrouter/auto',
+        reasoningMap: {
+          low: 'openrouter/auto',
+          default: 'openrouter/auto',
+          high: 'openrouter/auto',
+        },
+      },
+    );
+
+    expect(draft.reasoningLow).toBe('');
+    expect(draft.reasoningDefault).toBe('gpt-5.4-nano');
+    expect(draft.reasoningHigh).toBe('');
+  });
+
+  it('drops stale reasoning selections that do not belong to the active provider model list', () => {
+    expect(normalizeSelectableModel('openrouter/auto', ['gpt-5.4', 'gpt-5.4-nano'])).toBe('');
+    expect(normalizeSelectableModel('gpt-5.4-nano', ['gpt-5.4', 'gpt-5.4-nano'])).toBe('gpt-5.4-nano');
+  });
+
+  it('normalizes a compound provider bundle before save', () => {
+    const provider = draftToNormalizedProviderConfig(
+      {
+        runtime: 'openai-agents',
+        type: 'openai',
+        model: 'gpt-5.4-nano',
+        reasoningLow: 'openrouter/auto',
+        reasoningDefault: 'gpt-5.4-nano',
+        reasoningHigh: '',
+        baseUrl: '',
+        contextLength: '',
+      },
+      ['gpt-5.4', 'gpt-5.4-nano'],
+    );
+
+    expect(provider).toEqual({
+      runtime: 'openai-agents',
+      type: 'openai',
+      model: 'gpt-5.4-nano',
+      reasoning_map: {
+        default: 'gpt-5.4-nano',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This pull request introduces a new, extensible cost estimation framework for agent runs, with built-in support for OpenAI and OpenRouter providers, and a foundation for additional providers in the future. It adds token/cost breakdown utilities, provider-specific pricing logic, and integrates these capabilities into the agent configuration resolution flow. The changes also update dependencies to support new providers.

**Cost estimation framework and provider support:**

* Introduced a modular cost estimation system in `packages/myco/src/agent/cost/`, including token breakdown utilities (`breakdown.ts`), helpers for actual/unavailable costs (`helpers.ts`), provider registry and dispatch logic (`providers.ts`), and the main resolver (`resolver.ts`). [[1]](diffhunk://#diff-53620febcfd51cd5566a833945820d02da34f458dbd825306fe35263874b8effR1-R15) [[2]](diffhunk://#diff-f3ec6ac310b541d2a77603a694891554bab3e0d89e60d4199ae4e6ca540fcfceR1-R32) [[3]](diffhunk://#diff-ae0ce01b5f8c72259392d10e10b1e0e12c4536aa0bf05d7f2b54516307d99a37R1-R92) [[4]](diffhunk://#diff-4dc26c44711b29929f0eaa37125f59fc140a752ca4631c195be0169a413a08d8R1-R13)
* Added OpenAI pricing logic (`openai.ts`) with built-in pricing tables for several GPT-5.4 models, and OpenRouter dynamic pricing via live model catalog lookup and caching (`openrouter.ts`). [[1]](diffhunk://#diff-2a23ba76d27785d092f4ad08a01d3d9969918249164b22a02b3f71ad472e2a8dR1-R104) [[2]](diffhunk://#diff-3936ea07daf858e57e186fe79d3a5c2ae55ae0b4fc92c4959472d9e280a9ab39R1-R184)
* Exported the new cost estimation utilities in the main cost module index (`index.ts`).

**Agent config and runtime enhancements:**

* Extended the agent config resolver to support new provider types (`openai`, `openrouter`, `openai-compatible`), phase-level model overrides, reasoning map, and runtime inference based on provider type. Updated the `ResolvedRunConfig` interface accordingly. [[1]](diffhunk://#diff-be494f243482dea2e97cfac4fe1f864b51b15029199e6a736a3e463c46c4fb45L24-R26) [[2]](diffhunk://#diff-be494f243482dea2e97cfac4fe1f864b51b15029199e6a736a3e463c46c4fb45L50-R58) [[3]](diffhunk://#diff-be494f243482dea2e97cfac4fe1f864b51b15029199e6a736a3e463c46c4fb45L69-R104) [[4]](diffhunk://#diff-be494f243482dea2e97cfac4fe1f864b51b15029199e6a736a3e463c46c4fb45R156) [[5]](diffhunk://#diff-be494f243482dea2e97cfac4fe1f864b51b15029199e6a736a3e463c46c4fb45L147-R192) [[6]](diffhunk://#diff-be494f243482dea2e97cfac4fe1f864b51b15029199e6a736a3e463c46c4fb45L164-R205) [[7]](diffhunk://#diff-be494f243482dea2e97cfac4fe1f864b51b15029199e6a736a3e463c46c4fb45L183-R228)
* Added logic to apply task-level config overrides, propagate effective runtime, and support new config fields such as `reasoningLevel`. [[1]](diffhunk://#diff-be494f243482dea2e97cfac4fe1f864b51b15029199e6a736a3e463c46c4fb45L69-R104) [[2]](diffhunk://#diff-be494f243482dea2e97cfac4fe1f864b51b15029199e6a736a3e463c46c4fb45L183-R228)

**Dependency updates:**

* Added `@openai/agents` as a dependency in both the root and myco package manifests to enable OpenAI agent support. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R29) [[2]](diffhunk://#diff-285d01a345598a886a1a65849f97ea3a1a01e75e400f40aae4cfeacf08148f0aR60)

## Related Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [ ] Enhancement / new feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] CI / workflow

## Validation

```bash
make check    # lint + 266 tests
```

## Checklist

- [ ] `make check` passes locally
- [ ] Tests added or updated where behavior changed
- [ ] Docs updated for user-visible changes
- [ ] No magic literals introduced (named constants in `src/constants.ts`)
