### PR TITLE
fix: gate late session materialization on capture rules

### DIFF
--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -33,6 +33,9 @@ import { upsertSession, reactivateSessionIfCompleted } from '@myco/db/queries/se
 import { captureBatchImages, type CapturedImage } from './capture-images.js';
 import { epochSeconds, LOG_PROMPT_PREVIEW_CHARS } from '@myco/constants.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+import { evaluateSessionCaptureRules } from '@myco/hooks/capture-rules.js';
+import { readTranscriptMeta } from '@myco/hooks/transcript-meta.js';
+import { loadManifests } from '@myco/symbionts/detect.js';
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -78,6 +81,20 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
   } = deps;
 
   const projectRoot = process.cwd();
+  const manifests = loadManifests();
+
+  function evaluateAutoRegistration(event: Record<string, unknown>): { action: 'pass' } | { action: 'drop'; reason?: string } {
+    const transcriptPath = typeof event.transcript_path === 'string' && event.transcript_path.length > 0
+      ? event.transcript_path
+      : undefined;
+    const transcriptMeta = transcriptPath ? readTranscriptMeta(transcriptPath) ?? undefined : undefined;
+    const detectedAgent = typeof event.agent === 'string' ? event.agent : 'claude-code';
+
+    return evaluateSessionCaptureRules(manifests, detectedAgent, {
+      transcriptPath,
+      transcriptMeta,
+    });
+  }
 
   return async (req) => {
     const validated = EventBody.parse(req.body);
@@ -90,6 +107,16 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
 
     // Ensure session is registered (idempotent — handles daemon restarts mid-session)
     if (!registry.getSession(event.session_id)) {
+      const decision = evaluateAutoRegistration(event);
+      if (decision.action === 'drop') {
+        logger.info(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Ignored event that failed session capture rules', {
+          session_id: event.session_id,
+          type: event.type,
+          reason: decision.reason ?? 'rule',
+        });
+        return { body: { ok: true, ignored: decision.reason ?? 'rule' } };
+      }
+
       registry.register(event.session_id, { started_at: event.timestamp });
       logger.debug(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Auto-registered session from event', { session_id: event.session_id });
 

--- a/packages/myco/src/hooks/post-tool-use.ts
+++ b/packages/myco/src/hooks/post-tool-use.ts
@@ -27,6 +27,7 @@ export async function main() {
       output_preview: typeof input.toolOutput === 'string' ? input.toolOutput.slice(0, TOOL_OUTPUT_PREVIEW_CHARS) : undefined,
       session_id: sessionId,
       agent: input.agent,
+      transcript_path: input.transcriptPath,
     });
 
     if (!result.ok) {
@@ -36,6 +37,7 @@ export async function main() {
         tool: input.toolName,
         input: input.toolInput,
         output_preview: typeof input.toolOutput === 'string' ? input.toolOutput.slice(0, TOOL_OUTPUT_PREVIEW_CHARS) : undefined,
+        transcript_path: input.transcriptPath,
       });
     }
   } catch (error) {

--- a/packages/myco/src/hooks/send-event.ts
+++ b/packages/myco/src/hooks/send-event.ts
@@ -34,15 +34,17 @@ export async function sendEvent(
     const input = normalizeHookInput(rawInput);
 
     const event = buildEvent(input);
+    const eventWithContext = {
+      ...event,
+      transcript_path: input.transcriptPath,
+    };
 
     const client = new DaemonClient(VAULT_DIR);
-    const result = await client.post('/events', { ...event, session_id: input.sessionId, agent: input.agent });
+    const result = await client.post('/events', { ...eventWithContext, session_id: input.sessionId, agent: input.agent });
 
     if (!result.ok) {
       const buffer = new EventBuffer(path.join(VAULT_DIR, 'buffer'), input.sessionId);
-      // Strip session_id from buffer entry — it's in the filename
-      const { session_id: _, ...bufferPayload } = event;
-      buffer.append(bufferPayload);
+      buffer.append(eventWithContext);
     }
   } catch (error) {
     process.stderr.write(`[myco] ${hookName} error: ${(error as Error).message}\n`);

--- a/packages/myco/src/hooks/user-prompt-submit.ts
+++ b/packages/myco/src/hooks/user-prompt-submit.ts
@@ -56,13 +56,17 @@ export async function main() {
 
     // Forward prompt as event for capture
     const eventResult = await client.post('/events', {
-      type: 'user_prompt', prompt, session_id: sessionId, agent: input.agent,
+      type: 'user_prompt',
+      prompt,
+      session_id: sessionId,
+      agent: input.agent,
+      transcript_path: input.transcriptPath,
     });
 
     if (!eventResult.ok) {
       // Daemon still unreachable — write directly to buffer for later processing
       const buffer = new EventBuffer(path.join(VAULT_DIR, 'buffer'), sessionId);
-      buffer.append({ type: 'user_prompt', prompt });
+      buffer.append({ type: 'user_prompt', prompt, transcript_path: input.transcriptPath });
     }
 
     // Search for relevant spores to inject as context for this prompt.

--- a/tests/daemon/event-dispatch.test.ts
+++ b/tests/daemon/event-dispatch.test.ts
@@ -1,0 +1,111 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
+import { createEventDispatcher } from '@myco/daemon/event-dispatch.js';
+import { SessionRegistry } from '@myco/daemon/lifecycle.js';
+import { PowerManager } from '@myco/daemon/power.js';
+import { DaemonLogger } from '@myco/daemon/logger.js';
+import { getSession } from '@myco/db/queries/sessions.js';
+import { countActivities } from '@myco/db/queries/activities.js';
+
+function makeHandler() {
+  const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-event-dispatch-'));
+  const logger = new DaemonLogger(logDir, { level: 'debug' });
+  const registry = new SessionRegistry({ gracePeriod: 1, onEmpty: () => {} });
+  const powerManager = new PowerManager({
+    idleThresholdMs: 60_000,
+    sleepThresholdMs: 120_000,
+    deepSleepThresholdMs: 180_000,
+    activeIntervalMs: 60_000,
+    sleepIntervalMs: 60_000,
+    logger,
+  });
+  const sessionBuffers = new Map();
+  const vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-event-vault-'));
+
+  const handler = createEventDispatcher({
+    registry,
+    sessionBuffers,
+    powerManager,
+    logger,
+    machineId: 'local',
+    liveConfig: { current: { agent: { summary_batch_interval: 20 } } as never },
+    vaultDir,
+    reconcileSession: () => {},
+    planWatchConfig: { enabled: false, planDirs: [] },
+    triggerTitleSummary: async () => {},
+  });
+
+  return { handler, registry, sessionBuffers, logger, vaultDir };
+}
+
+describe('createEventDispatcher', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => { cleanTestDb(); });
+
+  it('drops an orphan Codex tool event with no transcript before auto-registration', async () => {
+    const { handler, registry, sessionBuffers, logger, vaultDir } = makeHandler();
+    const sessionId = 'codex-orphan-tool-001';
+
+    const res = await handler({
+      body: {
+        type: 'tool_use',
+        session_id: sessionId,
+        agent: 'codex',
+        tool_name: 'Bash',
+        tool_input: { command: 'pwd' },
+      },
+      query: {},
+      params: {},
+      pathname: '/events',
+    });
+
+    expect(res.body).toEqual({ ok: true, ignored: 'ephemeral-sub-invocation' });
+    expect(registry.getSession(sessionId)).toBeUndefined();
+    expect(getSession(sessionId)).toBeNull();
+    expect(countActivities(sessionId)).toBe(0);
+    expect(sessionBuffers.has(sessionId)).toBe(false);
+
+    logger.close();
+    fs.rmSync(vaultDir, { recursive: true, force: true });
+  });
+
+  it('materializes a Codex tool event when a transcript path proves the session is real', async () => {
+    const { handler, registry, logger, vaultDir } = makeHandler();
+    const sessionId = 'codex-real-tool-001';
+    const transcriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-codex-real-'));
+    const transcriptPath = path.join(transcriptDir, `rollout-${sessionId}.jsonl`);
+
+    fs.writeFileSync(
+      transcriptPath,
+      `${JSON.stringify({ type: 'session_meta', source: 'vscode' })}\n`,
+      'utf-8',
+    );
+
+    const res = await handler({
+      body: {
+        type: 'tool_use',
+        session_id: sessionId,
+        agent: 'codex',
+        transcript_path: transcriptPath,
+        tool_name: 'Bash',
+        tool_input: { command: 'pwd' },
+      },
+      query: {},
+      params: {},
+      pathname: '/events',
+    });
+
+    expect(res.body).toEqual({ ok: true });
+    expect(registry.getSession(sessionId)).toBeDefined();
+    expect(getSession(sessionId)?.agent).toBe('codex');
+    expect(countActivities(sessionId)).toBe(1);
+
+    logger.close();
+    fs.rmSync(vaultDir, { recursive: true, force: true });
+    fs.rmSync(transcriptDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
Run session capture rules before /events auto-registers an unknown session and preserve transcript_path on forwarded hook events so late materialization has the same structural evidence as session-start and stop.

This prevents Codex tool-only phantom sessions from being created when the first event is PostToolUse without a real transcript.

## Summary

This pull request introduces a new session auto-registration policy for the event dispatcher, ensuring that only valid sessions are registered based on capture rules and transcript evidence. It also propagates the `transcript_path` throughout event handling and adds comprehensive tests for the new behavior. The key changes are grouped below:

**Session Auto-Registration Policy:**

* Added logic in `event-dispatch.ts` to evaluate incoming events against session capture rules using `evaluateSessionCaptureRules`, `readTranscriptMeta`, and `loadManifests`. Events failing these rules (e.g., orphan tool events from Codex without a transcript) are dropped before session registration, with a reason logged and returned. [[1]](diffhunk://#diff-20b1b9639604432e676eb1f138e5e2d7bd410944da377868393df8126594616bR36-R38) [[2]](diffhunk://#diff-20b1b9639604432e676eb1f138e5e2d7bd410944da377868393df8126594616bR84-R97) [[3]](diffhunk://#diff-20b1b9639604432e676eb1f138e5e2d7bd410944da377868393df8126594616bR110-R119)

**Event Context Propagation:**

* Ensured `transcript_path` is included in all relevant event payloads and buffers in `send-event.ts`, `user-prompt-submit.ts`, and `post-tool-use.ts`, so that downstream handlers and policies have the necessary context to make decisions. [[1]](diffhunk://#diff-56d37b26b29013bdb856fb45bbb5f8f152b446bfd056aa1a5a74987bba131874R37-R47) [[2]](diffhunk://#diff-ae869e6e1d008ca8563d270eddb67f6b2f5641cfef5ff4d9a3826d913c6d946eL59-R69) [[3]](diffhunk://#diff-289c0aef56bf79ef322692ec0d92e9e05fb74520b959805ec15c91925cba61c0R30) [[4]](diffhunk://#diff-289c0aef56bf79ef322692ec0d92e9e05fb74520b959805ec15c91925cba61c0R40)

**Testing and Validation:**

* Added new tests in `event-dispatch.test.ts` to verify that orphan Codex tool events without a transcript are dropped and that valid events with a transcript are properly registered and persisted.

## Related Issues

- Closes #
- Related #

## Change Type

- [x] Bug fix
- [x] Enhancement / new feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] CI / workflow

## Validation

```bash
make check    # lint + 266 tests
```

## Checklist

- [x] `make check` passes locally
- [ ] Tests added or updated where behavior changed
- [ ] Docs updated for user-visible changes
- [ ] No magic literals introduced (named constants in `src/constants.ts`)
