### PR TITLE
feat: add RuntimeTokenBudget interface and related functionality

### DIFF
--- a/.myco/myco.yaml
+++ b/.myco/myco.yaml
@@ -26,23 +26,6 @@ agent:
     type: anthropic
     model: claude-sonnet-4-6
   tasks:
-    full-intelligence:
-      provider:
-        type: anthropic
-        model: claude-sonnet-4-6
-      phases:
-        read-state:
-          maxTurns: 20
-        extract:
-          maxTurns: 35
-      schedule:
-        enabled: true
-        intervalSeconds: 1800
-    title-summary:
-      provider:
-        type: anthropic
-        model: claude-sonnet-4-6
-      timeoutSeconds: 180
     title-summary-custom:
       provider:
         type: ollama
@@ -78,6 +61,19 @@ agent:
       schedule:
         enabled: false
         intervalSeconds: 1800
+    title-summary:
+      provider:
+        runtime: openai-agents
+        type: lmstudio
+        base_url: http://localhost:1234
+        model: google/gemma-4-26b-a4b
+        reasoning_map:
+          low: google/gemma-4-26b-a4b
+          default: google/gemma-4-26b-a4b
+          high: openai/gpt-oss-120b
+      runtime: openai-agents
+      maxTurns: 50
+      timeoutSeconds: 600
 context:
   digest_tier: 5000
   prompt_search: true

--- a/packages/myco/src/agent/context-queries.ts
+++ b/packages/myco/src/agent/context-queries.ts
@@ -12,6 +12,11 @@ import { getUnprocessedBatches } from '@myco/db/queries/batches.js';
 import { listSpores } from '@myco/db/queries/spores.js';
 import { listSessions } from '@myco/db/queries/sessions.js';
 import { getStatesForAgent } from '@myco/db/queries/agent-state.js';
+import {
+  projectBatchForAgent,
+  projectSessionForAgent,
+  projectSporeForAgent,
+} from './tools/read-projections.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -133,13 +138,14 @@ async function executeQuery(
     case 'vault_unprocessed':
       // Agent pre-planning context should only see settled work — a task
       // planning against in-flight batches is working from partial signal.
-      return getUnprocessedBatches({ limit, includeActive: false });
+      return getUnprocessedBatches({ limit, includeActive: false }).map(projectBatchForAgent);
 
     case 'vault_spores':
-      return listSpores({ agent_id: agentId, limit, includeActive: false });
+      return listSpores({ agent_id: agentId, limit, includeActive: false })
+        .map((spore) => projectSporeForAgent(spore, { exact: false }));
 
     case 'vault_sessions':
-      return listSessions({ limit, includeActive: false });
+      return listSessions({ limit, includeActive: false }).map(projectSessionForAgent);
 
     case 'vault_state':
       return getStatesForAgent(agentId);

--- a/packages/myco/src/agent/context-windows.ts
+++ b/packages/myco/src/agent/context-windows.ts
@@ -1,0 +1,8 @@
+/** Default context window Myco applies for local agent runs when no override is set. */
+export const DEFAULT_LOCAL_AGENT_CONTEXT_WINDOW_TOKENS = 32_768;
+
+/** Inferred frontier-model context window when the provider does not expose one. */
+export const DEFAULT_FRONTIER_CONTEXT_WINDOW_TOKENS = 200_000;
+
+/** Inferred OpenAI-compatible cloud context window when the provider does not expose one. */
+export const DEFAULT_COMPATIBLE_CONTEXT_WINDOW_TOKENS = 128_000;

--- a/packages/myco/src/agent/definitions/agent.yaml
+++ b/packages/myco/src/agent/definitions/agent.yaml
@@ -15,6 +15,7 @@ systemPromptPath: ../prompts/agent.md
 tools:
   # Read tools
   - vault_unprocessed
+  - vault_session_summary_material
   - vault_spores
   - vault_sessions
   - vault_search_fts

--- a/packages/myco/src/agent/definitions/tasks/title-summary.yaml
+++ b/packages/myco/src/agent/definitions/tasks/title-summary.yaml
@@ -28,28 +28,24 @@ prompt: |
 
   **If a target session ID is specified above:**
   Always process it — the user explicitly requested regeneration.
-  Call `vault_sessions` with `id: <target session>` and `include_active: true`
-  to get its current title/summary (the session may still be active).
-  Call `vault_batches` with the same session ID to read ALL its prompt batches
-  (processed and unprocessed). Do NOT skip even if there are no new
-  unprocessed batches.
+  Call `vault_session_summary_material` with `session_id: <target session>`
+  to get the current title/summary plus the compact ordered prompt-batch arc.
+  Do NOT skip even if there are no new unprocessed batches.
 
   **If no target session specified (automatic run):**
   Call `vault_unprocessed` with `include_active: true` — titles are needed
   mid-flight, not just after a session completes. Group by session_id —
-  each session with unprocessed batches needs its summary updated. Call
-  `vault_sessions` with `include_active: true` for those sessions. If no
-  sessions have unprocessed batches, report "skip" and finish.
+  each session with unprocessed batches needs its summary updated. For each
+  session, call `vault_session_summary_material`. If no sessions have
+  unprocessed batches, report "skip" and finish.
 
   ## Phase 2 — Update Each Session (budget: 8 turns)
 
   For each session to process:
   1. Read the EXISTING title and summary — context from prior runs.
-  2. Read the session's prompt batches — user_prompt + response_summary.
-     For targeted sessions, use `vault_batches` results from Phase 1.
-     For automatic runs, use `vault_unprocessed` results.
-     This is your PRIMARY source — read through the full set to understand
-     the complete arc of work.
+  2. Read the session's compact prompt-batch arc — user_prompt +
+     response_summary. This is your PRIMARY source — read through the full
+     set to understand the complete arc of work.
   3. Generate a title and summary from the full session content.
   4. Call `vault_update_session` with BOTH title and summary.
 
@@ -82,10 +78,6 @@ prompt: |
 
 toolOverrides:
   - vault_unprocessed
-  - vault_batches
-  - vault_sessions
-  - vault_spores
-  - vault_state
+  - vault_session_summary_material
   - vault_update_session
-  - vault_set_state
   - vault_report

--- a/packages/myco/src/agent/executor-state.ts
+++ b/packages/myco/src/agent/executor-state.ts
@@ -6,6 +6,7 @@ import type {
   ProviderConfig,
   ProviderType,
   RuntimeId,
+  RuntimeTokenBudget,
   RuntimeUsage,
 } from './types.js';
 
@@ -140,10 +141,12 @@ export function buildUsageData(
   runUsage: RuntimeUsage,
   runCost?: CostResolution,
   phaseResults?: PhaseResult[],
+  runBudget?: RuntimeTokenBudget,
 ): string {
   return JSON.stringify({
     run: runUsage,
     runCost: runCost ?? null,
+    runBudget: runBudget ?? null,
     phases: phaseResults?.map((phase) => ({
       name: phase.name,
       usage: phase.usage ?? null,

--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -53,6 +53,7 @@ import {
   type RunCheckpointState,
 } from './executor-state.js';
 import {
+  analyzeRuntimeTokenBudget,
   buildRunAccountingUpdate,
   summarizePhaseCosts,
 } from './run-accounting.js';
@@ -96,6 +97,21 @@ const PROMPT_SECTION_PRIOR_PHASES = '## Prior Phase Results';
 
 /** Header for the current phase in phased prompts. */
 const PROMPT_SECTION_CURRENT_PHASE = '## Current Phase: ';
+const TOKEN_BUDGET_PRESSURE_STATUSES = new Set(['warning', 'critical']);
+
+function logTokenBudgetPressure(
+  taskName: string,
+  usage: RuntimeUsage,
+  provider?: ProviderConfig,
+): void {
+  const budget = analyzeRuntimeTokenBudget(usage, provider);
+  if (!TOKEN_BUDGET_PRESSURE_STATUSES.has(budget.status)) return;
+  console.warn(
+    `[agent] ${taskName} token budget ${budget.status}: ` +
+    `${budget.utilizationPercent}% of ${budget.contextWindowTokens} tokens ` +
+    `at peak request (${budget.peakRequestTotalTokens} tokens)`,
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Prompt composition
@@ -879,6 +895,7 @@ export async function runAgent(
       checkpointState.sessionRef = result.sessionRef;
       checkpointState.sessionData = result.sessionData;
       await persistRuntimeState(checkpointState, undefined, usage, costData);
+      logTokenBudgetPressure(config.taskName, usage, singleProvider);
 
       const postconditionError = validateTaskPostconditions({
         runId,
@@ -890,6 +907,7 @@ export async function runAgent(
     }
 
     clearTimeout(timeoutId);
+    logTokenBudgetPressure(config.taskName, usage, effectiveProvider);
     const completedAt = epochSeconds();
     updateRunStatus(runId, STATUS_COMPLETED, {
       resumable: 0,
@@ -940,6 +958,7 @@ export async function runAgent(
 
     try {
       const usage = aggregateUsage(phaseResults?.map((phase) => phase.usage) ?? []);
+      logTokenBudgetPressure(config.taskName, usage, effectiveProvider);
       const costData = phaseResults ? summarizePhaseCosts(phaseResults) : await resolveCost({
         runtime: runtimeId,
         provider: effectiveProvider,

--- a/packages/myco/src/agent/ollama-context.ts
+++ b/packages/myco/src/agent/ollama-context.ts
@@ -7,6 +7,7 @@ import { writeFileSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { ProviderConfig } from './types.js';
+import { DEFAULT_LOCAL_AGENT_CONTEXT_WINDOW_TOKENS } from './context-windows.js';
 
 /** Timeout for Ollama model pre-load request (ms). */
 const OLLAMA_PRELOAD_TIMEOUT_MS = 30_000;
@@ -23,7 +24,7 @@ const OLLAMA_PRELOAD_TIMEOUT_MS = 30_000;
  * globally, per-task, or per-phase (all scopes are reconciled to a single
  * variant per model — see `resolveOllamaContextVariants`).
  */
-export const DEFAULT_OLLAMA_CONTEXT_LENGTH = 32768;
+export const DEFAULT_OLLAMA_CONTEXT_LENGTH = DEFAULT_LOCAL_AGENT_CONTEXT_WINDOW_TOKENS;
 
 /**
  * Ensure an Ollama model variant exists with the desired context length.

--- a/packages/myco/src/agent/prompts/agent.md
+++ b/packages/myco/src/agent/prompts/agent.md
@@ -12,6 +12,7 @@ You operate on a vault database. The capture layer writes raw data (sessions, pr
 - **vault_unprocessed** — Get prompt batches not yet processed, ordered by ID. Supports cursor-based pagination via `after_id`.
 - **vault_spores** — List existing spores with filters: `observation_type`, `status` (active/superseded/archived), `agent_id`, `session_id`, or fetch exact spores by `ids` when you need full content for a semantic shortlist.
 - **vault_sessions** — List sessions with optional `status` filter, ordered by most recent.
+- **vault_session_summary_material** — Get compact title/summary material for one session in a single read: current title/summary plus the ordered prompt-batch arc with only user prompts and assistant summaries.
 - **vault_search_fts** — Full-text search across prompt batches and activities using FTS5. Best for keyword matches and finding session content. Params: `query`, `type` (prompt_batch, activity), `limit`.
 - **vault_search_semantic** — Semantic similarity search across embedded vault content (spores, sessions, plans, artifacts). Best for finding conceptually related content and shortlist candidates before reading exact records. Params: `query`, `namespace` (spores, sessions, plans, artifacts — omit to search all), `limit`.
 - **vault_read_digest** — Read current digest extracts. Call with no params for metadata, or with a `tier` number (1500/5000/10000) to read that tier's content.

--- a/packages/myco/src/agent/provider-runtime.ts
+++ b/packages/myco/src/agent/provider-runtime.ts
@@ -1,15 +1,51 @@
 import type { ProviderType, RuntimeId } from './types.js';
+import {
+  DEFAULT_COMPATIBLE_CONTEXT_WINDOW_TOKENS,
+  DEFAULT_FRONTIER_CONTEXT_WINDOW_TOKENS,
+  DEFAULT_LOCAL_AGENT_CONTEXT_WINDOW_TOKENS,
+} from './context-windows.js';
 
-const PROVIDER_RUNTIME_BY_TYPE: Record<ProviderType, RuntimeId> = {
-  anthropic: 'claude-sdk',
-  ollama: 'claude-sdk',
-  lmstudio: 'claude-sdk',
-  openai: 'openai-agents',
-  openrouter: 'openai-agents',
-  'openai-compatible': 'openai-agents',
+interface ProviderMetadata {
+  runtime: RuntimeId;
+  defaultContextWindowTokens?: number;
+}
+
+const PROVIDER_METADATA_BY_TYPE: Record<ProviderType, ProviderMetadata> = {
+  anthropic: {
+    runtime: 'claude-sdk',
+    defaultContextWindowTokens: DEFAULT_FRONTIER_CONTEXT_WINDOW_TOKENS,
+  },
+  ollama: {
+    runtime: 'claude-sdk',
+    defaultContextWindowTokens: DEFAULT_LOCAL_AGENT_CONTEXT_WINDOW_TOKENS,
+  },
+  lmstudio: {
+    runtime: 'claude-sdk',
+    defaultContextWindowTokens: DEFAULT_LOCAL_AGENT_CONTEXT_WINDOW_TOKENS,
+  },
+  openai: {
+    runtime: 'openai-agents',
+    defaultContextWindowTokens: DEFAULT_FRONTIER_CONTEXT_WINDOW_TOKENS,
+  },
+  openrouter: {
+    runtime: 'openai-agents',
+    defaultContextWindowTokens: DEFAULT_FRONTIER_CONTEXT_WINDOW_TOKENS,
+  },
+  'openai-compatible': {
+    runtime: 'openai-agents',
+    defaultContextWindowTokens: DEFAULT_COMPATIBLE_CONTEXT_WINDOW_TOKENS,
+  },
 };
 
-export function inferRuntimeFromProviderType(providerType: ProviderType | undefined): RuntimeId | undefined {
+export function getProviderMetadata(providerType: ProviderType | undefined): ProviderMetadata | undefined {
   if (!providerType) return undefined;
-  return PROVIDER_RUNTIME_BY_TYPE[providerType];
+  return PROVIDER_METADATA_BY_TYPE[providerType];
+}
+
+export function inferRuntimeFromProviderType(providerType: ProviderType | undefined): RuntimeId | undefined {
+  return getProviderMetadata(providerType)?.runtime;
+}
+
+export function inferDefaultContextWindowFromProviderType(providerType: ProviderType | undefined): number | null {
+  return getProviderMetadata(providerType)?.defaultContextWindowTokens ?? null;
 }

--- a/packages/myco/src/agent/run-accounting.ts
+++ b/packages/myco/src/agent/run-accounting.ts
@@ -6,7 +6,118 @@ import {
   serializeCheckpointState,
   type RunCheckpointState,
 } from './executor-state.js';
-import type { PhaseResult, ProviderConfig, RuntimeId, RuntimeUsage } from './types.js';
+import { inferDefaultContextWindowFromProviderType } from './provider-runtime.js';
+import type { PhaseResult, ProviderConfig, RuntimeId, RuntimeTokenBudget, RuntimeUsage } from './types.js';
+
+const TOKEN_BUDGET_WARNING_PERCENT = 75;
+const TOKEN_BUDGET_CRITICAL_PERCENT = 90;
+
+function toRequestTokenNumber(
+  entry: Record<string, unknown>,
+  key: 'inputTokens' | 'outputTokens' | 'totalTokens',
+): number {
+  const value = entry[key];
+  return typeof value === 'number' ? value : 0;
+}
+
+function resolveContextWindow(
+  provider: ProviderConfig | undefined,
+  usage: RuntimeUsage,
+): { tokens: number | null; source?: RuntimeTokenBudget['contextWindowSource'] } {
+  if (provider?.contextLength) {
+    return { tokens: provider.contextLength, source: 'provider-config' };
+  }
+  const providerData = usage.providerData;
+  if (providerData) {
+    const candidates = [
+      providerData.contextWindowTokens,
+      providerData.context_window,
+      providerData.maxContextTokens,
+      providerData.max_context_tokens,
+    ];
+    for (const candidate of candidates) {
+      if (typeof candidate === 'number' && candidate > 0) {
+        return { tokens: candidate, source: 'provider-metadata' };
+      }
+    }
+  }
+  const providerDefault = inferDefaultContextWindowFromProviderType(provider?.type);
+  if (providerDefault) {
+    return { tokens: providerDefault, source: 'provider-default' };
+  }
+  return { tokens: null };
+}
+
+export function analyzeRuntimeTokenBudget(
+  usage: RuntimeUsage,
+  provider?: ProviderConfig,
+): RuntimeTokenBudget {
+  const requestEntries = usage.requestUsageEntries && usage.requestUsageEntries.length > 0
+    ? usage.requestUsageEntries
+    : [{
+        inputTokens: usage.inputTokens ?? 0,
+        outputTokens: usage.outputTokens ?? 0,
+        totalTokens: usage.totalTokens ?? (
+          (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)
+        ),
+      }];
+  const peakRequestInputTokens = requestEntries.reduce(
+    (max, entry) => Math.max(max, toRequestTokenNumber(entry, 'inputTokens')),
+    0,
+  );
+  const peakRequestOutputTokens = requestEntries.reduce(
+    (max, entry) => Math.max(max, toRequestTokenNumber(entry, 'outputTokens')),
+    0,
+  );
+  const peakRequestTotalTokens = requestEntries.reduce(
+    (max, entry) => Math.max(max, toRequestTokenNumber(entry, 'totalTokens')),
+    0,
+  );
+  const { tokens: contextWindowTokens, source: contextWindowSource } = resolveContextWindow(provider, usage);
+
+  if (!contextWindowTokens) {
+    return {
+      contextWindowTokens: null,
+      peakRequestInputTokens: peakRequestInputTokens || null,
+      peakRequestOutputTokens: peakRequestOutputTokens || null,
+      peakRequestTotalTokens: peakRequestTotalTokens || null,
+      utilizationPercent: null,
+      headroomTokens: null,
+      status: 'unknown',
+      message: 'Context window unavailable for this provider/model.',
+    };
+  }
+
+  const utilizationPercent = peakRequestTotalTokens > 0
+    ? Math.round((peakRequestTotalTokens / contextWindowTokens) * 100)
+    : 0;
+  const headroomTokens = Math.max(0, contextWindowTokens - peakRequestTotalTokens);
+  const status = utilizationPercent >= TOKEN_BUDGET_CRITICAL_PERCENT
+    ? 'critical'
+    : utilizationPercent >= TOKEN_BUDGET_WARNING_PERCENT
+      ? 'warning'
+      : 'ok';
+  const message = status === 'critical'
+    ? 'Run operated near the model context limit.'
+    : status === 'warning'
+      ? 'Run used a large share of the model context window.'
+      : undefined;
+
+  return {
+    contextWindowTokens,
+    ...(contextWindowSource ? { contextWindowSource } : {}),
+    peakRequestInputTokens: peakRequestInputTokens || null,
+    peakRequestOutputTokens: peakRequestOutputTokens || null,
+    peakRequestTotalTokens: peakRequestTotalTokens || null,
+    utilizationPercent,
+    headroomTokens,
+    status,
+    ...(message ? { message } : {}),
+    ...(contextWindowSource === 'provider-default'
+      ? { message: message ? `${message} Using inferred provider default context window.` : 'Using inferred provider default context window.' }
+      : {}),
+  };
+}
 
 export function serializeCostData(cost: CostResolution | undefined): string | null {
   return cost ? JSON.stringify(cost) : null;
@@ -120,13 +231,14 @@ interface RunAccountingUpdateFields extends Pick<
 }
 
 export function buildRunAccountingUpdate(input: RunAccountingUpdateInput): RunAccountingUpdateFields {
+  const tokenBudget = analyzeRuntimeTokenBudget(input.usage, input.provider);
   return {
     runtime: input.runtime,
     provider: input.provider?.type ?? null,
     model: input.model,
     session_ref: input.sessionRef ?? input.checkpointState.sessionRef ?? null,
     checkpoints: serializeCheckpointState(input.checkpointState),
-    usage_data: buildUsageData(input.usage, input.costData, input.phaseResults),
+    usage_data: buildUsageData(input.usage, input.costData, input.phaseResults, tokenBudget),
     cost_usd: input.costData.costUsd ?? null,
     actual_cost_usd: input.costData.actualCostUsd,
     estimated_cost_usd: input.costData.estimatedCostUsd,

--- a/packages/myco/src/agent/runtime/claude.ts
+++ b/packages/myco/src/agent/runtime/claude.ts
@@ -117,6 +117,13 @@ export class ClaudeSdkRuntime implements AgentRuntime {
         outputTokens,
         totalTokens: inputTokens + outputTokens,
         costUsd,
+        requestUsageEntries: turnsUsed > 0
+          ? [{
+              inputTokens,
+              outputTokens,
+              totalTokens: inputTokens + outputTokens,
+            }]
+          : [],
       },
       sessionRef: input.sessionRef,
     };

--- a/packages/myco/src/agent/runtime/openai.ts
+++ b/packages/myco/src/agent/runtime/openai.ts
@@ -9,7 +9,8 @@ import {
 } from '@openai/agents';
 import type { AgentRuntime, RuntimeCapability, RuntimeExecuteInput, RuntimeExecuteResult, RuntimeFactoryContext } from './types.js';
 import type { ProviderConfig, RuntimeUsage } from '@myco/agent/types.js';
-import { ensureOllamaContextVariant, DEFAULT_OLLAMA_CONTEXT_LENGTH } from '@myco/agent/ollama-context.js';
+import { DEFAULT_LOCAL_AGENT_CONTEXT_WINDOW_TOKENS } from '@myco/agent/context-windows.js';
+import { ensureOllamaContextVariant } from '@myco/agent/ollama-context.js';
 import { OPENAI_API_KEY_ENV } from '@myco/cli/providers/openai-embeddings.js';
 import { OPENROUTER_API_KEY_ENV } from '@myco/cli/providers/openrouter.js';
 import { LmStudioBackend } from '@myco/intelligence/lm-studio.js';
@@ -164,7 +165,7 @@ function toLocalControlBaseUrl(baseUrl: string): string {
 }
 
 function resolveLocalContextLength(provider?: ProviderConfig): number {
-  return provider?.contextLength ?? DEFAULT_OLLAMA_CONTEXT_LENGTH;
+  return provider?.contextLength ?? DEFAULT_LOCAL_AGENT_CONTEXT_WINDOW_TOKENS;
 }
 
 function normalizeProviderForOpenAIClient(provider?: ProviderConfig): ProviderConfig | undefined {

--- a/packages/myco/src/agent/tools.ts
+++ b/packages/myco/src/agent/tools.ts
@@ -3,14 +3,15 @@
  *
  * Creates vault tools that expose SQLite query helpers to the agent
  * via the Claude Agent SDK. Tools are grouped into:
- * - Read tools (9): vault_unprocessed, vault_batches, vault_spores, vault_sessions,
- *                   vault_search_fts, vault_search_semantic, vault_state,
- *                   vault_entities, vault_edges
+ * - Read tools (10): vault_unprocessed, vault_batches, vault_session_summary_material,
+ *                    vault_spores, vault_sessions, vault_search_fts,
+ *                    vault_search_semantic, vault_state, vault_entities, vault_edges
  * - Write tools (9): vault_create_spore, vault_create_entity, vault_create_edge,
  *                     vault_resolve_spore, vault_update_session, vault_set_state,
  *                     vault_read_digest, vault_write_digest, vault_mark_processed
  * - Observability (1): vault_report
- * - Skill tools (3): vault_skill_candidates, vault_skill_records, vault_write_skill
+ * - Skill tools (5): vault_skill_candidates, vault_skill_records, vault_write_skill,
+ *                    vault_stage_skill, vault_finalize_skill
  *
  * `agentId` and `runId` are captured in closures — tools inject them
  * automatically so the agent cannot impersonate another agent.
@@ -54,8 +55,9 @@ export interface VaultToolOptions {
 // ---------------------------------------------------------------------------
 
 const READ_TOOL_NAMES = new Set([
-  'vault_unprocessed', 'vault_batches', 'vault_spores', 'vault_sessions', 'vault_search_fts',
-  'vault_search_semantic', 'vault_state', 'vault_entities', 'vault_edges',
+  'vault_unprocessed', 'vault_batches', 'vault_session_summary_material', 'vault_spores',
+  'vault_sessions', 'vault_search_fts', 'vault_search_semantic', 'vault_state',
+  'vault_entities', 'vault_edges',
 ]);
 
 const WRITE_TOOL_NAMES = new Set([
@@ -73,6 +75,20 @@ const SKILL_TOOL_NAMES = new Set([
 
 /** Max chars stored from a tool response in the run audit trail. */
 const TOOL_OUTPUT_SUMMARY_LIMIT = 240;
+/** Read tools that can explode context if the agent loops on identical payloads. */
+const LOOP_GUARDED_READ_TOOL_NAMES = new Set([
+  'vault_unprocessed',
+  'vault_batches',
+  'vault_session_summary_material',
+  'vault_spores',
+  'vault_sessions',
+  'vault_entities',
+  'vault_edges',
+]);
+/** On the third identical guarded read, stop resending the large payload and tell the agent to reuse prior context. */
+const REPEATED_READ_SUPPRESSION_THRESHOLD = 2;
+/** On the fifth identical guarded read, fail fast — the run is not making progress. */
+const REPEATED_READ_FAILURE_THRESHOLD = 4;
 
 /**
  * Total number of vault tools defined. Derived from the union of the
@@ -114,11 +130,32 @@ function summarizeToolError(error: unknown): string {
   return truncateSummary(String(error)) ?? 'Tool failed';
 }
 
+function buildRepeatedReadSuppressionResult(
+  toolName: string,
+  repeatedCalls: number,
+): { content: Array<{ type: 'text'; text: string }> } {
+  return {
+    content: [{
+      type: 'text' as const,
+      text: JSON.stringify({
+        message: `Repeated identical ${toolName} read suppressed.`,
+        repeated_calls: repeatedCalls,
+        reuse_prior_result: true,
+        next_step: 'Use the prior tool result already in context and continue with analysis, write, or report.',
+      }),
+    }],
+  };
+}
+
+function shouldGuardRepeatedRead(toolDef: SdkMcpToolDefinition<any>): boolean {
+  return toolDef.annotations?.readOnlyHint === true && LOOP_GUARDED_READ_TOOL_NAMES.has(toolDef.name);
+}
+
 /**
  * Create vault tool definitions for the agent.
  *
  * When `onlyNames` is provided, only tool groups that contain at least one
- * requested name are instantiated — avoids building all 21 closures when
+ * requested name are instantiated — avoids building all tool closures when
  * a phase only needs 2-3 tools.
  *
  * Exposed for testing (call handler directly) and for the MCP server factory.
@@ -128,6 +165,8 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
 
   /** Turn number counter — incremented per tool call (read and write) within a run. */
   let turnCounter = turnOffset;
+  /** Exact-read loop counters for the current tool server instance. */
+  const repeatedReadCounts = new Map<string, number>();
 
   /**
    * Record a turn in the audit trail.
@@ -179,9 +218,47 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
     return {
       ...toolDef,
       handler: async (args, extra) => {
+        const serializedArgs = JSON.stringify(args);
+        const repeatedReadKey = shouldGuardRepeatedRead(toolDef)
+          ? `${toolDef.name}\u0000${serializedArgs}`
+          : null;
+        const priorIdenticalCalls = repeatedReadKey
+          ? (repeatedReadCounts.get(repeatedReadKey) ?? 0)
+          : 0;
         const turnId = recordTurn(toolDef.name, args);
         try {
+          if (priorIdenticalCalls >= REPEATED_READ_FAILURE_THRESHOLD) {
+            throw new Error(
+              `Repeated identical ${toolDef.name} reads detected (${priorIdenticalCalls + 1} calls). ` +
+              'Reuse the prior result already in context and proceed to a write, report, or different query.',
+            );
+          }
+
+          if (priorIdenticalCalls >= REPEATED_READ_SUPPRESSION_THRESHOLD) {
+            if (repeatedReadKey) {
+              repeatedReadCounts.set(repeatedReadKey, priorIdenticalCalls + 1);
+            }
+            const result = buildRepeatedReadSuppressionResult(toolDef.name, priorIdenticalCalls + 1);
+            if (turnId !== null) {
+              try {
+                updateTurn(turnId, {
+                  tool_output_summary: summarizeToolResult(result),
+                  completed_at: epochSeconds(),
+                });
+              } catch {
+                /* audit trail is best-effort */
+              }
+            }
+            return result;
+          }
+
           const result = await originalHandler(args, extra);
+          if (repeatedReadKey) {
+            repeatedReadCounts.set(repeatedReadKey, priorIdenticalCalls + 1);
+          }
+          if (toolDef.annotations?.readOnlyHint !== true) {
+            repeatedReadCounts.clear();
+          }
           if (turnId !== null) {
             try {
               updateTurn(turnId, {
@@ -216,7 +293,7 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
 // ---------------------------------------------------------------------------
 
 /**
- * Create a vault MCP tool server with 21 tools for the agent.
+ * Create a vault MCP tool server with the full vault tool surface for the agent.
  *
  * Wraps `createVaultTools()` with `createSdkMcpServer()` from the
  * Claude Agent SDK.

--- a/packages/myco/src/agent/tools/read-projections.ts
+++ b/packages/myco/src/agent/tools/read-projections.ts
@@ -1,0 +1,98 @@
+import type { BatchRow } from '@myco/db/queries/batches.js';
+import type { EntityRow } from '@myco/db/queries/entities.js';
+import type { GraphEdgeRow } from '@myco/db/queries/graph-edges.js';
+import type { SporeRow } from '@myco/db/queries/spores.js';
+import type { SessionRow } from '@myco/db/queries/sessions.js';
+
+/** Maximum characters from each user prompt returned to the agent by batch tools. */
+export const BATCH_USER_PROMPT_CHARS = 400;
+/** Maximum characters from each response summary returned to the agent by batch tools. */
+export const BATCH_RESPONSE_SUMMARY_CHARS = 1200;
+/** Maximum characters from each spore content preview returned by spore listings. */
+export const SPORE_CONTENT_PREVIEW_CHARS = 600;
+/** Maximum characters from each spore context preview returned by exact spore lookups. */
+export const SPORE_CONTEXT_PREVIEW_CHARS = 240;
+
+export function truncateProjectionText(value: string | null, limit: number): string | null {
+  if (value === null) return null;
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= limit) return normalized;
+  return `${normalized.slice(0, limit - 1)}…`;
+}
+
+export function projectBatchForAgent(batch: BatchRow): Record<string, unknown> {
+  return {
+    id: batch.id,
+    session_id: batch.session_id,
+    prompt_number: batch.prompt_number,
+    user_prompt: truncateProjectionText(batch.user_prompt, BATCH_USER_PROMPT_CHARS),
+    response_summary: truncateProjectionText(batch.response_summary, BATCH_RESPONSE_SUMMARY_CHARS),
+    ...(batch.classification ? { classification: batch.classification } : {}),
+  };
+}
+
+export function projectBatchForSessionSummary(batch: BatchRow): Record<string, unknown> {
+  return {
+    prompt_number: batch.prompt_number,
+    ...(batch.user_prompt ? { user_prompt: truncateProjectionText(batch.user_prompt, BATCH_USER_PROMPT_CHARS) } : {}),
+    ...(batch.response_summary ? { response_summary: truncateProjectionText(batch.response_summary, BATCH_RESPONSE_SUMMARY_CHARS) } : {}),
+  };
+}
+
+export function projectSessionForAgent(session: SessionRow): Record<string, unknown> {
+  return {
+    id: session.id,
+    agent: session.agent,
+    status: session.status,
+    ...(session.title ? { title: session.title } : {}),
+    ...(session.summary ? { summary: session.summary } : {}),
+    prompt_count: session.prompt_count,
+    ...(session.started_at ? { started_at: session.started_at } : {}),
+    ...(session.ended_at ? { ended_at: session.ended_at } : {}),
+  };
+}
+
+export function projectSporeForAgent(
+  spore: SporeRow,
+  options: { exact: boolean },
+): Record<string, unknown> {
+  const contentField = options.exact
+    ? { content: spore.content }
+    : { content_preview: truncateProjectionText(spore.content, SPORE_CONTENT_PREVIEW_CHARS) };
+  return {
+    id: spore.id,
+    observation_type: spore.observation_type,
+    ...contentField,
+    ...(spore.session_id ? { session_id: spore.session_id } : {}),
+    ...(spore.importance ? { importance: spore.importance } : {}),
+    ...(options.exact && spore.context
+      ? { context_preview: truncateProjectionText(spore.context, SPORE_CONTEXT_PREVIEW_CHARS) }
+      : {}),
+    created_at: spore.created_at,
+  };
+}
+
+export function projectEntityForAgent(entity: EntityRow): Record<string, unknown> {
+  return {
+    id: entity.id,
+    type: entity.type,
+    name: entity.name,
+    status: entity.status,
+    first_seen: entity.first_seen,
+    last_seen: entity.last_seen,
+  };
+}
+
+export function projectEdgeForAgent(edge: GraphEdgeRow): Record<string, unknown> {
+  return {
+    id: edge.id,
+    source_id: edge.source_id,
+    source_type: edge.source_type,
+    target_id: edge.target_id,
+    target_type: edge.target_type,
+    type: edge.type,
+    confidence: edge.confidence,
+    ...(edge.session_id ? { session_id: edge.session_id } : {}),
+    created_at: edge.created_at,
+  };
+}

--- a/packages/myco/src/agent/tools/read-tools.ts
+++ b/packages/myco/src/agent/tools/read-tools.ts
@@ -1,9 +1,9 @@
 /**
  * Read-only vault tools.
  *
- * 9 tools: vault_unprocessed, vault_batches, vault_spores, vault_sessions,
- * vault_search_fts, vault_search_semantic, vault_state, vault_entities,
- * vault_edges
+ * 10 tools: vault_unprocessed, vault_batches, vault_session_summary_material,
+ * vault_spores, vault_sessions, vault_search_fts, vault_search_semantic,
+ * vault_state, vault_entities, vault_edges
  */
 
 import { z } from 'zod/v4';
@@ -11,12 +11,20 @@ import { tool } from '@anthropic-ai/claude-agent-sdk';
 import { SEARCH_SIMILARITY_THRESHOLD, TEAM_SOURCE_PREFIX } from '@myco/constants.js';
 import { getUnprocessedBatches, listBatchesBySession } from '@myco/db/queries/batches.js';
 import { getSpore, listSpores } from '@myco/db/queries/spores.js';
-import { listSessions, getActiveSessionIds } from '@myco/db/queries/sessions.js';
+import { getSession, listSessions, getActiveSessionIds } from '@myco/db/queries/sessions.js';
 import { getStatesForAgent } from '@myco/db/queries/agent-state.js';
 import { fullTextSearch, hydrateSearchResults } from '@myco/db/queries/search.js';
 import { listEntities } from '@myco/db/queries/entities.js';
 import { listGraphEdges } from '@myco/db/queries/graph-edges.js';
 import { textResult, type VaultToolDeps } from './types.js';
+import {
+  projectBatchForAgent,
+  projectBatchForSessionSummary,
+  projectEdgeForAgent,
+  projectEntityForAgent,
+  projectSessionForAgent,
+  projectSporeForAgent,
+} from './read-projections.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -39,6 +47,18 @@ const DEFAULT_ENTITIES_LIMIT = 50;
 
 /** Default limit for edge listing. */
 const DEFAULT_EDGES_LIMIT = 50;
+/** Default projection mode for read tools. */
+const DEFAULT_INCLUDE_METADATA = false;
+
+function projectToolRows<T>(
+  rows: T[],
+  includeMetadata: boolean,
+  project: (row: T) => Record<string, unknown>,
+): ReturnType<typeof textResult> {
+  return includeMetadata
+    ? textResult(rows)
+    : textResult(rows.map(project));
+}
 
 // ---------------------------------------------------------------------------
 // Factory
@@ -54,6 +74,7 @@ export function createReadTools(deps: VaultToolDeps) {
       after_id: z.number().optional().describe('Return batches with id greater than this'),
       limit: z.number().optional().describe('Maximum number of batches to return'),
       include_active: z.boolean().optional().describe('Include batches from sessions still in active status (default: false)'),
+      include_metadata: z.boolean().optional().describe('Return full batch metadata instead of the compact task-oriented projection'),
     },
     async (args) => {
       const batches = getUnprocessedBatches({
@@ -61,7 +82,11 @@ export function createReadTools(deps: VaultToolDeps) {
         limit: args.limit ?? DEFAULT_UNPROCESSED_LIMIT,
         includeActive: args.include_active === true,
       });
-      return textResult(batches);
+      return projectToolRows(
+        batches,
+        args.include_metadata ?? DEFAULT_INCLUDE_METADATA,
+        projectBatchForAgent,
+      );
     },
     { annotations: { readOnlyHint: true } },
   );
@@ -73,13 +98,47 @@ export function createReadTools(deps: VaultToolDeps) {
       session_id: z.string().describe('Session ID whose batches should be returned'),
       limit: z.number().optional().describe('Maximum number of batches to return'),
       offset: z.number().optional().describe('Number of batches to skip from the start'),
+      include_metadata: z.boolean().optional().describe('Return full batch metadata instead of the compact task-oriented projection'),
     },
     async (args) => {
       const batches = listBatchesBySession(args.session_id, {
         limit: args.limit,
         offset: args.offset,
       });
-      return textResult(batches);
+      return projectToolRows(
+        batches,
+        args.include_metadata ?? DEFAULT_INCLUDE_METADATA,
+        projectBatchForAgent,
+      );
+    },
+    { annotations: { readOnlyHint: true } },
+  );
+
+  const vaultSessionSummaryMaterial = tool(
+    'vault_session_summary_material',
+    'Get compact title-and-summary material for one session in a single read: current title/summary plus an ordered prompt-batch arc with only user prompts and assistant summaries.',
+    {
+      session_id: z.string().describe('Session ID whose summary material should be returned'),
+      include_active: z.boolean().optional().describe('Allow active sessions (default: true for exact session reads)'),
+    },
+    async (args) => {
+      const session = getSession(args.session_id);
+      if (!session) {
+        return textResult({ session_id: args.session_id, found: false, batches: [] });
+      }
+      if (args.include_active === false && session.status === 'active') {
+        return textResult({ session_id: args.session_id, found: false, message: 'Session is still active' });
+      }
+      const batches = listBatchesBySession(args.session_id);
+      return textResult({
+        session_id: session.id,
+        status: session.status,
+        ...(session.title ? { current_title: session.title } : {}),
+        ...(session.summary ? { current_summary: session.summary } : {}),
+        prompt_count: session.prompt_count,
+        batch_count: batches.length,
+        batches: batches.map(projectBatchForSessionSummary),
+      });
     },
     { annotations: { readOnlyHint: true } },
   );
@@ -95,13 +154,19 @@ export function createReadTools(deps: VaultToolDeps) {
       session_id: z.string().optional().describe('Filter by session ID (bypasses active-session gating)'),
       limit: z.number().optional().describe('Maximum number of spores to return'),
       include_active: z.boolean().optional().describe('Include spores from sessions still in active status (default: false)'),
+      include_metadata: z.boolean().optional().describe('Return full spore metadata instead of the compact task-oriented projection'),
     },
     async (args) => {
+      const includeMetadata = args.include_metadata ?? DEFAULT_INCLUDE_METADATA;
       if (args.ids && args.ids.length > 0) {
         const spores = args.ids
           .map((id) => getSpore(id))
           .filter((spore): spore is NonNullable<typeof spore> => spore !== null);
-        return textResult(spores);
+        return projectToolRows(
+          spores,
+          includeMetadata,
+          (spore) => projectSporeForAgent(spore, { exact: true }),
+        );
       }
       const spores = listSpores({
         agent_id: args.agent_id,
@@ -111,7 +176,11 @@ export function createReadTools(deps: VaultToolDeps) {
         limit: args.limit ?? DEFAULT_SPORES_LIMIT,
         includeActive: args.include_active === true,
       });
-      return textResult(spores);
+      return projectToolRows(
+        spores,
+        includeMetadata,
+        (spore) => projectSporeForAgent(spore, { exact: false }),
+      );
     },
     { annotations: { readOnlyHint: true } },
   );
@@ -124,6 +193,7 @@ export function createReadTools(deps: VaultToolDeps) {
       limit: z.number().optional().describe('Maximum number of sessions to return'),
       status: z.string().optional().describe('Filter by status (active, completed)'),
       include_active: z.boolean().optional().describe('Include sessions still in active status (default: false)'),
+      include_metadata: z.boolean().optional().describe('Return full session metadata instead of the compact task-oriented projection'),
     },
     async (args) => {
       const sessions = listSessions({
@@ -132,7 +202,11 @@ export function createReadTools(deps: VaultToolDeps) {
         status: args.status,
         includeActive: args.include_active === true,
       });
-      return textResult(sessions);
+      return projectToolRows(
+        sessions,
+        args.include_metadata ?? DEFAULT_INCLUDE_METADATA,
+        projectSessionForAgent,
+      );
     },
     { annotations: { readOnlyHint: true } },
   );
@@ -256,6 +330,7 @@ export function createReadTools(deps: VaultToolDeps) {
       type: z.enum(['component', 'concept', 'person']).optional().describe('Filter by entity type'),
       name: z.string().optional().describe('Filter by entity name (exact match)'),
       limit: z.number().optional().describe('Maximum entities to return'),
+      include_metadata: z.boolean().optional().describe('Return full entity metadata instead of the compact task-oriented projection'),
     },
     async (args) => {
       const entities = listEntities({
@@ -264,7 +339,11 @@ export function createReadTools(deps: VaultToolDeps) {
         name: args.name,
         limit: args.limit ?? DEFAULT_ENTITIES_LIMIT,
       });
-      return textResult(entities);
+      return projectToolRows(
+        entities,
+        args.include_metadata ?? DEFAULT_INCLUDE_METADATA,
+        projectEntityForAgent,
+      );
     },
     { annotations: { readOnlyHint: true } },
   );
@@ -277,6 +356,7 @@ export function createReadTools(deps: VaultToolDeps) {
       target_id: z.string().optional().describe('Filter by target node ID'),
       type: z.string().optional().describe('Filter by edge type (REFERENCES, DEPENDS_ON, AFFECTS, etc.)'),
       limit: z.number().optional().describe('Maximum edges to return'),
+      include_metadata: z.boolean().optional().describe('Return full edge metadata instead of the compact task-oriented projection'),
     },
     async (args) => {
       const edges = listGraphEdges({
@@ -286,7 +366,11 @@ export function createReadTools(deps: VaultToolDeps) {
         agentId: agentId,
         limit: args.limit ?? DEFAULT_EDGES_LIMIT,
       });
-      return textResult(edges);
+      return projectToolRows(
+        edges,
+        args.include_metadata ?? DEFAULT_INCLUDE_METADATA,
+        projectEdgeForAgent,
+      );
     },
     { annotations: { readOnlyHint: true } },
   );
@@ -294,6 +378,7 @@ export function createReadTools(deps: VaultToolDeps) {
   return [
     vaultUnprocessed,
     vaultBatches,
+    vaultSessionSummaryMaterial,
     vaultSpores,
     vaultSessions,
     vaultSearchFts,

--- a/packages/myco/src/agent/types.ts
+++ b/packages/myco/src/agent/types.ts
@@ -110,6 +110,18 @@ export interface RuntimeUsage {
   providerData?: Record<string, unknown>;
 }
 
+export interface RuntimeTokenBudget {
+  contextWindowTokens: number | null;
+  contextWindowSource?: 'provider-config' | 'provider-metadata' | 'provider-default';
+  peakRequestInputTokens: number | null;
+  peakRequestOutputTokens: number | null;
+  peakRequestTotalTokens: number | null;
+  utilizationPercent: number | null;
+  headroomTokens: number | null;
+  status: 'unknown' | 'ok' | 'warning' | 'critical';
+  message?: string;
+}
+
 /** Execution configuration overrides for a task. */
 export interface ExecutionConfig {
   runtime?: RuntimeId;

--- a/packages/myco/src/db/queries/turns.ts
+++ b/packages/myco/src/db/queries/turns.ts
@@ -189,3 +189,18 @@ export function countToolCallsByRun(
   }
   return result;
 }
+
+/** Count exact tool calls for a run by tool name and serialized input payload. */
+export function countExactToolCallsByRun(
+  runId: string,
+  toolName: string,
+  toolInput: string,
+): number {
+  const db = getDatabase();
+  const row = db.prepare(
+    `SELECT COUNT(*) as count
+     FROM agent_turns
+     WHERE run_id = ? AND tool_name = ? AND tool_input = ?`,
+  ).get(runId, toolName, toolInput) as { count: number };
+  return row.count;
+}

--- a/packages/myco/ui/src/components/agent/RunDetail.tsx
+++ b/packages/myco/ui/src/components/agent/RunDetail.tsx
@@ -42,6 +42,20 @@ function truncatePreview(text: string | null, limit: number): string {
   return truncate(text, limit) || '\u2014';
 }
 
+function formatBudgetSource(source: ParsedUsageData['runBudget']['contextWindowSource']): string {
+  if (!source) return '\u2014';
+  switch (source) {
+    case 'provider-config':
+      return 'provider config';
+    case 'provider-metadata':
+      return 'provider metadata';
+    case 'provider-default':
+      return 'inferred provider default';
+    default:
+      return source;
+  }
+}
+
 function parseJson<T>(raw: string | null | undefined): T | null {
   if (!raw) return null;
   try {
@@ -83,6 +97,17 @@ interface ParsedUsageData {
     reasoningTokens?: number;
     cachedTokens?: number;
     requests?: number;
+  };
+  runBudget?: {
+    contextWindowTokens: number | null;
+    contextWindowSource?: 'provider-config' | 'provider-metadata' | 'provider-default';
+    peakRequestInputTokens: number | null;
+    peakRequestOutputTokens: number | null;
+    peakRequestTotalTokens: number | null;
+    utilizationPercent: number | null;
+    headroomTokens: number | null;
+    status: 'unknown' | 'ok' | 'warning' | 'critical';
+    message?: string;
   };
 }
 
@@ -362,6 +387,53 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
           </div>
           {parsedCost?.message && (
             <p className="font-sans text-xs text-on-surface-variant">{parsedCost.message}</p>
+          )}
+        </Surface>
+      )}
+
+      {parsedUsage?.runBudget && (
+        <Surface level="low" className="p-4 space-y-3">
+          <h2 className="font-sans text-sm font-medium text-on-surface-variant uppercase tracking-wide">
+            Token Budget
+          </h2>
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
+            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
+              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Context Window</p>
+              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedUsage.runBudget.contextWindowTokens)}</p>
+            </div>
+            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
+              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Peak Request</p>
+              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedUsage.runBudget.peakRequestTotalTokens)}</p>
+            </div>
+            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
+              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Peak Input</p>
+              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedUsage.runBudget.peakRequestInputTokens)}</p>
+            </div>
+            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
+              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Peak Output</p>
+              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedUsage.runBudget.peakRequestOutputTokens)}</p>
+            </div>
+            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
+              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Budget Used</p>
+              <p className="font-mono text-sm text-on-surface">
+                {parsedUsage.runBudget.utilizationPercent != null ? `${parsedUsage.runBudget.utilizationPercent}%` : '\u2014'}
+              </p>
+            </div>
+            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
+              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Headroom</p>
+              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedUsage.runBudget.headroomTokens)}</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-3 px-1">
+            <span className="font-sans text-xs text-on-surface-variant">
+              Budget status: <span className="font-mono text-on-surface">{parsedUsage.runBudget.status}</span>
+            </span>
+            <span className="font-sans text-xs text-on-surface-variant">
+              Context source: <span className="font-mono text-on-surface">{formatBudgetSource(parsedUsage.runBudget.contextWindowSource)}</span>
+            </span>
+          </div>
+          {parsedUsage.runBudget.message && (
+            <p className="font-sans text-xs text-on-surface-variant">{parsedUsage.runBudget.message}</p>
           )}
         </Surface>
       )}

--- a/tests/agent/context-queries.test.ts
+++ b/tests/agent/context-queries.test.ts
@@ -48,13 +48,34 @@ const TEST_AGENT_ID = 'myco-agent';
 const DEFAULT_CONTEXT_QUERY_LIMIT = 10;
 
 /** Sample batch row shape (only fields relevant to assertions). */
-const MOCK_BATCH = { id: 1, session_id: 'sess-abc', processed: 0 };
+const MOCK_BATCH = {
+  id: 1,
+  session_id: 'sess-abc',
+  prompt_number: 1,
+  user_prompt: 'Inspect the failing harness run',
+  response_summary: 'Added budget diagnostics',
+  processed: 0,
+};
 
 /** Sample spore row shape (only fields relevant to assertions). */
-const MOCK_SPORE = { id: 'spore-1', agent_id: TEST_AGENT_ID, observation_type: 'gotcha' };
+const MOCK_SPORE = {
+  id: 'spore-1',
+  agent_id: TEST_AGENT_ID,
+  observation_type: 'gotcha',
+  content: 'Prompt compaction can hide follow-up work',
+  created_at: 1000,
+};
 
 /** Sample session row shape. */
-const MOCK_SESSION = { id: 'sess-abc', agent: 'claude-code', status: 'active' };
+const MOCK_SESSION = {
+  id: 'sess-abc',
+  agent: 'claude-code',
+  status: 'active',
+  title: 'Tighten harness telemetry',
+  summary: 'Added compact read payloads',
+  prompt_count: 3,
+  started_at: 1000,
+};
 
 /** Sample agent state row. */
 const MOCK_STATE = { agent_id: TEST_AGENT_ID, key: 'cursor', value: '42', updated_at: 1000 };
@@ -90,7 +111,7 @@ beforeEach(() => {
 describe('executeContextQueries', () => {
   describe('vault_unprocessed', () => {
     it('executes query and returns data', async () => {
-      vi.mocked(getUnprocessedBatches).mockResolvedValue([MOCK_BATCH] as never);
+      vi.mocked(getUnprocessedBatches).mockReturnValue([MOCK_BATCH] as never);
 
       const results = await executeContextQueries(TEST_AGENT_ID, [
         makeQuery({ tool: 'vault_unprocessed', purpose: 'check backlog' }),
@@ -99,12 +120,18 @@ describe('executeContextQueries', () => {
       expect(results).toHaveLength(1);
       expect(results[0].tool).toBe('vault_unprocessed');
       expect(results[0].purpose).toBe('check backlog');
-      expect(results[0].data).toEqual([MOCK_BATCH]);
+      expect(results[0].data).toEqual([{
+        id: 1,
+        session_id: 'sess-abc',
+        prompt_number: 1,
+        user_prompt: 'Inspect the failing harness run',
+        response_summary: 'Added budget diagnostics',
+      }]);
       expect(results[0].error).toBeUndefined();
     });
 
     it('passes limit to getUnprocessedBatches', async () => {
-      vi.mocked(getUnprocessedBatches).mockResolvedValue([]);
+      vi.mocked(getUnprocessedBatches).mockReturnValue([]);
 
       await executeContextQueries(TEST_AGENT_ID, [
         makeQuery({ tool: 'vault_unprocessed', limit: 5 }),
@@ -116,7 +143,7 @@ describe('executeContextQueries', () => {
 
   describe('vault_spores', () => {
     it('executes query with agent_id filter and returns data', async () => {
-      vi.mocked(listSpores).mockResolvedValue([MOCK_SPORE] as never);
+      vi.mocked(listSpores).mockReturnValue([MOCK_SPORE] as never);
 
       const results = await executeContextQueries(TEST_AGENT_ID, [
         makeQuery({ tool: 'vault_spores', purpose: 'review spores' }),
@@ -124,7 +151,12 @@ describe('executeContextQueries', () => {
 
       expect(results).toHaveLength(1);
       expect(results[0].tool).toBe('vault_spores');
-      expect(results[0].data).toEqual([MOCK_SPORE]);
+      expect(results[0].data).toEqual([{
+        id: 'spore-1',
+        observation_type: 'gotcha',
+        content_preview: 'Prompt compaction can hide follow-up work',
+        created_at: 1000,
+      }]);
       expect(listSpores).toHaveBeenCalledWith({
         agent_id: TEST_AGENT_ID,
         limit: DEFAULT_CONTEXT_QUERY_LIMIT,
@@ -133,7 +165,7 @@ describe('executeContextQueries', () => {
     });
 
     it('passes custom limit to listSpores', async () => {
-      vi.mocked(listSpores).mockResolvedValue([]);
+      vi.mocked(listSpores).mockReturnValue([]);
 
       await executeContextQueries(TEST_AGENT_ID, [
         makeQuery({ tool: 'vault_spores', limit: 20 }),
@@ -149,7 +181,7 @@ describe('executeContextQueries', () => {
 
   describe('vault_sessions', () => {
     it('executes query and returns data', async () => {
-      vi.mocked(listSessions).mockResolvedValue([MOCK_SESSION] as never);
+      vi.mocked(listSessions).mockReturnValue([MOCK_SESSION] as never);
 
       const results = await executeContextQueries(TEST_AGENT_ID, [
         makeQuery({ tool: 'vault_sessions', purpose: 'list recent sessions' }),
@@ -157,14 +189,22 @@ describe('executeContextQueries', () => {
 
       expect(results).toHaveLength(1);
       expect(results[0].tool).toBe('vault_sessions');
-      expect(results[0].data).toEqual([MOCK_SESSION]);
+      expect(results[0].data).toEqual([{
+        id: 'sess-abc',
+        agent: 'claude-code',
+        status: 'active',
+        title: 'Tighten harness telemetry',
+        summary: 'Added compact read payloads',
+        prompt_count: 3,
+        started_at: 1000,
+      }]);
       expect(listSessions).toHaveBeenCalledWith({ limit: DEFAULT_CONTEXT_QUERY_LIMIT, includeActive: false });
     });
   });
 
   describe('vault_state', () => {
     it('executes query with agent_id and returns data', async () => {
-      vi.mocked(getStatesForAgent).mockResolvedValue([MOCK_STATE]);
+      vi.mocked(getStatesForAgent).mockReturnValue([MOCK_STATE]);
 
       const results = await executeContextQueries(TEST_AGENT_ID, [
         makeQuery({ tool: 'vault_state', purpose: 'read cursor position' }),
@@ -179,7 +219,9 @@ describe('executeContextQueries', () => {
 
   describe('error handling', () => {
     it('returns error field for failed non-required query (does not throw)', async () => {
-      vi.mocked(getUnprocessedBatches).mockRejectedValue(new Error('DB unavailable'));
+      vi.mocked(getUnprocessedBatches).mockImplementation(() => {
+        throw new Error('DB unavailable');
+      });
 
       const results = await executeContextQueries(TEST_AGENT_ID, [
         makeQuery({ tool: 'vault_unprocessed', required: false }),
@@ -191,7 +233,9 @@ describe('executeContextQueries', () => {
     });
 
     it('throws on failed required query', async () => {
-      vi.mocked(listSpores).mockRejectedValue(new Error('Connection lost'));
+      vi.mocked(listSpores).mockImplementation(() => {
+        throw new Error('Connection lost');
+      });
 
       await expect(
         executeContextQueries(TEST_AGENT_ID, [
@@ -219,7 +263,7 @@ describe('executeContextQueries', () => {
 
   describe('limit handling', () => {
     it('uses default limit when query.limit not specified', async () => {
-      vi.mocked(getUnprocessedBatches).mockResolvedValue([]);
+      vi.mocked(getUnprocessedBatches).mockReturnValue([]);
 
       // Build query directly without specifying limit to use the type default
       const query: ContextQuery = {
@@ -239,7 +283,7 @@ describe('executeContextQueries', () => {
     });
 
     it('uses custom limit when specified', async () => {
-      vi.mocked(listSessions).mockResolvedValue([]);
+      vi.mocked(listSessions).mockReturnValue([]);
 
       await executeContextQueries(TEST_AGENT_ID, [
         makeQuery({ tool: 'vault_sessions', limit: 50 }),
@@ -251,8 +295,8 @@ describe('executeContextQueries', () => {
 
   describe('multiple queries', () => {
     it('executes multiple queries and returns results in order', async () => {
-      vi.mocked(getUnprocessedBatches).mockResolvedValue([MOCK_BATCH] as never);
-      vi.mocked(getStatesForAgent).mockResolvedValue([MOCK_STATE]);
+      vi.mocked(getUnprocessedBatches).mockReturnValue([MOCK_BATCH] as never);
+      vi.mocked(getStatesForAgent).mockReturnValue([MOCK_STATE]);
 
       const results = await executeContextQueries(TEST_AGENT_ID, [
         makeQuery({ tool: 'vault_unprocessed', purpose: 'backlog' }),
@@ -265,8 +309,10 @@ describe('executeContextQueries', () => {
     });
 
     it('continues executing after a non-required failure', async () => {
-      vi.mocked(getUnprocessedBatches).mockRejectedValue(new Error('DB down'));
-      vi.mocked(getStatesForAgent).mockResolvedValue([MOCK_STATE]);
+      vi.mocked(getUnprocessedBatches).mockImplementation(() => {
+        throw new Error('DB down');
+      });
+      vi.mocked(getStatesForAgent).mockReturnValue([MOCK_STATE]);
 
       const results = await executeContextQueries(TEST_AGENT_ID, [
         makeQuery({ tool: 'vault_unprocessed', required: false }),

--- a/tests/agent/harness-properties.test.ts
+++ b/tests/agent/harness-properties.test.ts
@@ -57,7 +57,7 @@ describe('harness properties', () => {
 
     it('read tools are annotated readOnlyHint: true', () => {
       const readToolNames = [
-        'vault_unprocessed', 'vault_batches', 'vault_spores', 'vault_sessions',
+        'vault_unprocessed', 'vault_batches', 'vault_session_summary_material', 'vault_spores', 'vault_sessions',
         'vault_search_fts', 'vault_search_semantic', 'vault_state',
         'vault_entities', 'vault_edges', 'vault_read_digest',
       ];

--- a/tests/agent/loader.test.ts
+++ b/tests/agent/loader.test.ts
@@ -121,6 +121,7 @@ describe('agent loader', () => {
       expect(def.tools).toContain('vault_unprocessed');
       expect(def.tools).toContain('vault_spores');
       expect(def.tools).toContain('vault_sessions');
+      expect(def.tools).toContain('vault_session_summary_material');
       expect(def.tools).toContain('vault_search_fts');
       expect(def.tools).toContain('vault_search_semantic');
       expect(def.tools).toContain('vault_state');

--- a/tests/agent/run-accounting.test.ts
+++ b/tests/agent/run-accounting.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeRuntimeTokenBudget, buildRunAccountingUpdate } from '@myco/agent/run-accounting.js';
+import type { CostResolution } from '@myco/agent/cost/types.js';
+
+describe('analyzeRuntimeTokenBudget', () => {
+  it('computes utilization and headroom when context length is known', () => {
+    const budget = analyzeRuntimeTokenBudget(
+      {
+        requests: 2,
+        inputTokens: 28_000,
+        outputTokens: 1_100,
+        totalTokens: 29_100,
+        requestUsageEntries: [
+          { inputTokens: 7_000, outputTokens: 200, totalTokens: 7_200 },
+          { inputTokens: 20_000, outputTokens: 900, totalTokens: 20_900 },
+        ],
+      },
+      {
+        type: 'lmstudio',
+        model: 'google/gemma-4-26b-a4b',
+        contextLength: 32_768,
+      },
+    );
+
+    expect(budget.contextWindowTokens).toBe(32_768);
+    expect(budget.peakRequestInputTokens).toBe(20_000);
+    expect(budget.peakRequestOutputTokens).toBe(900);
+    expect(budget.peakRequestTotalTokens).toBe(20_900);
+    expect(budget.utilizationPercent).toBe(64);
+    expect(budget.headroomTokens).toBe(11_868);
+    expect(budget.status).toBe('ok');
+  });
+
+  it('marks usage as warning when nearing the context limit', () => {
+    const budget = analyzeRuntimeTokenBudget(
+      {
+        requestUsageEntries: [
+          { inputTokens: 24_000, outputTokens: 4_000, totalTokens: 28_000 },
+        ],
+      },
+      {
+        type: 'ollama',
+        model: 'gemma4:26b',
+        contextLength: 32_768,
+      },
+    );
+
+    expect(budget.utilizationPercent).toBe(85);
+    expect(budget.status).toBe('warning');
+    expect(budget.message).toContain('large share');
+  });
+
+  it('uses an inferred provider default for frontier cloud models', () => {
+    const budget = analyzeRuntimeTokenBudget(
+      {
+        requestUsageEntries: [
+          { inputTokens: 10_000, outputTokens: 500, totalTokens: 10_500 },
+        ],
+      },
+      {
+        type: 'openai',
+        model: 'gpt-5.4-mini',
+      },
+    );
+
+    expect(budget.contextWindowTokens).toBe(200_000);
+    expect(budget.contextWindowSource).toBe('provider-default');
+    expect(budget.peakRequestTotalTokens).toBe(10_500);
+    expect(budget.status).toBe('ok');
+    expect(budget.message).toContain('inferred provider default');
+  });
+
+  it('returns unknown when no provider context is available at all', () => {
+    const budget = analyzeRuntimeTokenBudget(
+      {
+        requestUsageEntries: [
+          { inputTokens: 10_000, outputTokens: 500, totalTokens: 10_500 },
+        ],
+      },
+      undefined,
+    );
+
+    expect(budget.contextWindowTokens).toBeNull();
+    expect(budget.contextWindowSource).toBeUndefined();
+    expect(budget.peakRequestTotalTokens).toBe(10_500);
+    expect(budget.status).toBe('unknown');
+  });
+
+  it('uses the local 32k default for lmstudio when no override is set', () => {
+    const budget = analyzeRuntimeTokenBudget(
+      {
+        requestUsageEntries: [
+          { inputTokens: 20_107, outputTokens: 1_288, totalTokens: 21_395 },
+        ],
+      },
+      {
+        type: 'lmstudio',
+        model: 'google/gemma-4-26b-a4b',
+      },
+    );
+
+    expect(budget.contextWindowTokens).toBe(32_768);
+    expect(budget.contextWindowSource).toBe('provider-default');
+    expect(budget.utilizationPercent).toBe(65);
+    expect(budget.status).toBe('ok');
+  });
+
+  it('prefers provider metadata over inferred defaults', () => {
+    const budget = analyzeRuntimeTokenBudget(
+      {
+        requestUsageEntries: [
+          { inputTokens: 50_000, outputTokens: 1_000, totalTokens: 51_000 },
+        ],
+        providerData: {
+          contextWindowTokens: 1_000_000,
+        },
+      },
+      {
+        type: 'openai',
+        model: 'gpt-5.4',
+      },
+    );
+
+    expect(budget.contextWindowTokens).toBe(1_000_000);
+    expect(budget.contextWindowSource).toBe('provider-metadata');
+    expect(budget.utilizationPercent).toBe(5);
+  });
+
+  it('falls back to aggregate usage when per-request entries are unavailable', () => {
+    const budget = analyzeRuntimeTokenBudget(
+      {
+        requests: 1,
+        inputTokens: 180_000,
+        outputTokens: 12_000,
+        totalTokens: 192_000,
+      },
+      {
+        type: 'anthropic',
+        model: 'claude-sonnet-4-6',
+      },
+    );
+
+    expect(budget.peakRequestInputTokens).toBe(180_000);
+    expect(budget.peakRequestOutputTokens).toBe(12_000);
+    expect(budget.peakRequestTotalTokens).toBe(192_000);
+    expect(budget.contextWindowTokens).toBe(200_000);
+    expect(budget.utilizationPercent).toBe(96);
+    expect(budget.status).toBe('critical');
+  });
+});
+
+describe('buildRunAccountingUpdate', () => {
+  it('embeds token budget diagnostics into usage_data', () => {
+    const costData: CostResolution = {
+      source: 'unavailable',
+      costUsd: null,
+      actualCostUsd: null,
+      estimatedCostUsd: null,
+      pricingVersion: null,
+      breakdown: {
+        inputTokens: 28_000,
+        cachedInputTokens: 0,
+        uncachedInputTokens: 28_000,
+        outputTokens: 1_100,
+        reasoningTokens: 0,
+        requestCount: 2,
+      },
+    };
+
+    const update = buildRunAccountingUpdate({
+      runtime: 'openai-agents',
+      provider: {
+        type: 'lmstudio',
+        model: 'google/gemma-4-26b-a4b',
+        contextLength: 32_768,
+      },
+      model: 'google/gemma-4-26b-a4b',
+      checkpointState: {
+        runtime: 'openai-agents',
+        provider: 'lmstudio',
+        phases: {},
+      },
+      usage: {
+        requests: 2,
+        inputTokens: 28_000,
+        outputTokens: 1_100,
+        totalTokens: 29_100,
+        requestUsageEntries: [
+          { inputTokens: 7_000, outputTokens: 200, totalTokens: 7_200 },
+          { inputTokens: 20_000, outputTokens: 900, totalTokens: 20_900 },
+        ],
+      },
+      costData,
+    });
+
+    const usageData = JSON.parse(update.usage_data ?? '{}') as {
+      runBudget?: { contextWindowTokens: number; peakRequestTotalTokens: number; utilizationPercent: number };
+    };
+
+    expect(usageData.runBudget).toMatchObject({
+      contextWindowTokens: 32_768,
+      peakRequestTotalTokens: 20_900,
+      utilizationPercent: 64,
+    });
+  });
+});

--- a/tests/agent/tools.test.ts
+++ b/tests/agent/tools.test.ts
@@ -18,7 +18,9 @@ import { upsertSession, type SessionInsert } from '@myco/db/queries/sessions.js'
 import { insertBatch, type BatchInsert } from '@myco/db/queries/batches.js';
 import { insertRun, type RunInsert } from '@myco/db/queries/runs.js';
 import { insertSpore, type SporeInsert } from '@myco/db/queries/spores.js';
+import { insertEntity } from '@myco/db/queries/entities.js';
 import { setState } from '@myco/db/queries/agent-state.js';
+import { insertGraphEdge } from '@myco/db/queries/graph-edges.js';
 import { createVaultTools, VAULT_TOOL_COUNT } from '@myco/agent/tools.js';
 import type { SdkMcpToolDefinition } from '@anthropic-ai/claude-agent-sdk';
 
@@ -188,6 +190,41 @@ describe('vault tools', () => {
       const data = parseResult(result) as unknown[];
       expect(data).toHaveLength(1);
     });
+
+    it('returns a compact projection by default', async () => {
+      insertBatch(makeBatch(sessionId, {
+        prompt_number: 1,
+        response_summary: 'Summary text',
+        status: 'completed',
+        activity_count: 42,
+      }));
+
+      const t = findTool(tools, 'vault_unprocessed');
+      const result = await t.handler({ include_active: true }, undefined);
+      const data = parseResult(result) as Array<Record<string, unknown>>;
+
+      expect(data[0].id).toBeDefined();
+      expect(data[0].session_id).toBe(sessionId);
+      expect(data[0].response_summary).toBe('Summary text');
+      expect(data[0].status).toBeUndefined();
+      expect(data[0].activity_count).toBeUndefined();
+    });
+
+    it('returns full batch metadata when include_metadata=true', async () => {
+      insertBatch(makeBatch(sessionId, {
+        prompt_number: 1,
+        response_summary: 'Summary text',
+        status: 'completed',
+        activity_count: 42,
+      }));
+
+      const t = findTool(tools, 'vault_unprocessed');
+      const result = await t.handler({ include_active: true, include_metadata: true }, undefined);
+      const data = parseResult(result) as Array<Record<string, unknown>>;
+
+      expect(data[0].status).toBe('completed');
+      expect(data[0].activity_count).toBe(42);
+    });
   });
 
   describe('vault_batches', () => {
@@ -206,6 +243,132 @@ describe('vault tools', () => {
       expect(data).toHaveLength(2);
       expect(data.map((row) => row.session_id)).toEqual([sessionId, sessionId]);
       expect(data.map((row) => row.prompt_number)).toEqual([1, 2]);
+    });
+
+    it('returns a compact task-oriented projection by default', async () => {
+      insertBatch(makeBatch(sessionId, {
+        prompt_number: 1,
+        response_summary: 'Summary text',
+        classification: 'analysis',
+        status: 'completed',
+        activity_count: 42,
+      }));
+
+      const t = findTool(tools, 'vault_batches');
+      const result = await t.handler({ session_id: sessionId }, undefined);
+      const data = parseResult(result) as Array<Record<string, unknown>>;
+
+      expect(data[0].id).toBeDefined();
+      expect(data[0].user_prompt).toBe('Test prompt');
+      expect(data[0].response_summary).toBe('Summary text');
+      expect(data[0].classification).toBe('analysis');
+      expect(data[0].status).toBeUndefined();
+      expect(data[0].activity_count).toBeUndefined();
+      expect(data[0].processed).toBeUndefined();
+    });
+
+    it('returns full metadata when include_metadata=true', async () => {
+      insertBatch(makeBatch(sessionId, {
+        prompt_number: 1,
+        response_summary: 'Summary text',
+        status: 'completed',
+        activity_count: 42,
+      }));
+
+      const t = findTool(tools, 'vault_batches');
+      const result = await t.handler({ session_id: sessionId, include_metadata: true }, undefined);
+      const data = parseResult(result) as Array<Record<string, unknown>>;
+
+      expect(data[0].status).toBe('completed');
+      expect(data[0].activity_count).toBe(42);
+      expect(data[0].processed).toBeDefined();
+    });
+
+    it('suppresses repeated identical reads before they balloon context', async () => {
+      insertBatch(makeBatch(sessionId, { prompt_number: 1 }));
+
+      const t = findTool(tools, 'vault_batches');
+      await t.handler({ session_id: sessionId }, undefined);
+      await t.handler({ session_id: sessionId }, undefined);
+      const result = await t.handler({ session_id: sessionId }, undefined);
+      const data = parseResult(result) as {
+        message: string;
+        repeated_calls: number;
+        reuse_prior_result: boolean;
+      };
+
+      expect(data.message).toContain('Repeated identical vault_batches read suppressed');
+      expect(data.repeated_calls).toBe(3);
+      expect(data.reuse_prior_result).toBe(true);
+    });
+
+    it('fails fast after too many identical repeated reads', async () => {
+      insertBatch(makeBatch(sessionId, { prompt_number: 1 }));
+
+      const t = findTool(tools, 'vault_batches');
+      await t.handler({ session_id: sessionId }, undefined);
+      await t.handler({ session_id: sessionId }, undefined);
+      await t.handler({ session_id: sessionId }, undefined);
+      await t.handler({ session_id: sessionId }, undefined);
+
+      await expect(
+        t.handler({ session_id: sessionId }, undefined),
+      ).rejects.toThrow('Repeated identical vault_batches reads detected');
+    });
+  });
+
+  describe('vault_session_summary_material', () => {
+    it('returns compact session summary material in a single read', async () => {
+      upsertSession(makeSession({
+        id: 'sess-summary-material',
+        status: 'active',
+        title: 'Existing title',
+        summary: 'Existing summary',
+        prompt_count: 2,
+      }));
+      insertBatch(makeBatch('sess-summary-material', {
+        prompt_number: 1,
+        user_prompt: 'First prompt',
+        response_summary: 'First summary',
+      }));
+      insertBatch(makeBatch('sess-summary-material', {
+        prompt_number: 2,
+        user_prompt: 'Second prompt',
+        response_summary: 'Second summary',
+      }));
+
+      const t = findTool(tools, 'vault_session_summary_material');
+      const result = await t.handler({ session_id: 'sess-summary-material' }, undefined);
+      const data = parseResult(result) as {
+        session_id: string;
+        current_title: string;
+        current_summary: string;
+        prompt_count: number;
+        batch_count: number;
+        batches: Array<Record<string, unknown>>;
+      };
+
+      expect(data.session_id).toBe('sess-summary-material');
+      expect(data.current_title).toBe('Existing title');
+      expect(data.current_summary).toBe('Existing summary');
+      expect(data.prompt_count).toBe(2);
+      expect(data.batch_count).toBe(2);
+      expect(data.batches).toEqual([
+        { prompt_number: 1, user_prompt: 'First prompt', response_summary: 'First summary' },
+        { prompt_number: 2, user_prompt: 'Second prompt', response_summary: 'Second summary' },
+      ]);
+    });
+
+    it('returns not-found payload for missing sessions', async () => {
+      const t = findTool(tools, 'vault_session_summary_material');
+      const result = await t.handler({ session_id: 'missing-session' }, undefined);
+      const data = parseResult(result) as { session_id: string; found: boolean; batches: unknown[] };
+
+      expect(data).toEqual({
+        session_id: 'missing-session',
+        found: false,
+        batches: [],
+      });
     });
   });
 
@@ -235,9 +398,56 @@ describe('vault tools', () => {
 
       const t = findTool(tools, 'vault_spores');
       const result = await t.handler({ observation_type: 'gotcha' }, undefined);
-      const data = parseResult(result) as Array<{ observation_type: string }>;
+      const data = parseResult(result) as Array<{ observation_type: string; content_preview: string }>;
       expect(data).toHaveLength(1);
       expect(data[0].observation_type).toBe('gotcha');
+      expect(data[0].content_preview).toBe('A gotcha');
+    });
+
+    it('returns a compact projection by default', async () => {
+      insertSpore({
+        id: 'spore-compact',
+        agent_id: TEST_AGENT_ID,
+        session_id: sessionId,
+        observation_type: 'decision',
+        content: 'Compact content',
+        context: 'Verbose context that should not flow by default',
+        importance: 8,
+        created_at: epochNow(),
+      });
+
+      const t = findTool(tools, 'vault_spores');
+      const result = await t.handler({ include_active: true }, undefined);
+      const data = parseResult(result) as Array<Record<string, unknown>>;
+
+      expect(data).toHaveLength(1);
+      expect(data[0].id).toBe('spore-compact');
+      expect(data[0].content_preview).toBe('Compact content');
+      expect(data[0].importance).toBe(8);
+      expect(data[0].context).toBeUndefined();
+      expect(data[0].properties).toBeUndefined();
+    });
+
+    it('returns full spore metadata when include_metadata=true', async () => {
+      insertSpore({
+        id: 'spore-full',
+        agent_id: TEST_AGENT_ID,
+        session_id: sessionId,
+        observation_type: 'decision',
+        content: 'Full content',
+        context: 'Stored context',
+        properties: JSON.stringify({ foo: 'bar' }),
+        created_at: epochNow(),
+      });
+
+      const t = findTool(tools, 'vault_spores');
+      const result = await t.handler({ include_active: true, include_metadata: true }, undefined);
+      const data = parseResult(result) as Array<Record<string, unknown>>;
+
+      expect(data).toHaveLength(1);
+      expect(data[0].content).toBe('Full content');
+      expect(data[0].context).toBe('Stored context');
+      expect(data[0].properties).toBe(JSON.stringify({ foo: 'bar' }));
     });
 
     it('returns exact spores by id in the requested order', async () => {
@@ -261,6 +471,51 @@ describe('vault tools', () => {
       const data = parseResult(result) as Array<{ id: string; content: string }>;
       expect(data.map((row) => row.id)).toEqual(['spore-b', 'spore-a']);
       expect(data.map((row) => row.content)).toEqual(['Beta', 'Alpha']);
+    });
+  });
+
+  describe('vault_sessions', () => {
+    it('returns a compact projection by default', async () => {
+      upsertSession(makeSession({
+        id: 'sess-compact',
+        status: 'completed',
+        title: 'Compact title',
+        summary: 'Compact summary',
+        prompt_count: 12,
+        tool_count: 900,
+      }));
+
+      const t = findTool(tools, 'vault_sessions');
+      const result = await t.handler({ id: 'sess-compact', include_active: true }, undefined);
+      const data = parseResult(result) as Array<Record<string, unknown>>;
+
+      expect(data).toHaveLength(1);
+      expect(data[0].id).toBe('sess-compact');
+      expect(data[0].title).toBe('Compact title');
+      expect(data[0].summary).toBe('Compact summary');
+      expect(data[0].prompt_count).toBe(12);
+      expect(data[0].tool_count).toBeUndefined();
+      expect(data[0].transcript_path).toBeUndefined();
+    });
+
+    it('returns full session metadata when include_metadata=true', async () => {
+      upsertSession(makeSession({
+        id: 'sess-full',
+        status: 'completed',
+        title: 'Full title',
+        summary: 'Full summary',
+        prompt_count: 12,
+        tool_count: 900,
+        transcript_path: '/tmp/transcript.jsonl',
+      }));
+
+      const t = findTool(tools, 'vault_sessions');
+      const result = await t.handler({ id: 'sess-full', include_active: true, include_metadata: true }, undefined);
+      const data = parseResult(result) as Array<Record<string, unknown>>;
+
+      expect(data).toHaveLength(1);
+      expect(data[0].tool_count).toBe(900);
+      expect(data[0].transcript_path).toBe('/tmp/transcript.jsonl');
     });
   });
 
@@ -393,6 +648,125 @@ describe('vault tools', () => {
       expect(data).toHaveLength(2);
       const keys = data.map((s) => s.key).sort();
       expect(keys).toEqual(['cursor', 'mode']);
+    });
+
+    it('resets identical-read suppression after a successful write', async () => {
+      const sessionsTool = findTool(tools, 'vault_sessions');
+      const updateSessionTool = findTool(tools, 'vault_update_session');
+
+      await sessionsTool.handler({ id: sessionId, include_active: true }, undefined);
+      await sessionsTool.handler({ id: sessionId, include_active: true }, undefined);
+      const suppressed = await sessionsTool.handler({ id: sessionId, include_active: true }, undefined);
+      expect(parseResult(suppressed)).toMatchObject({
+        reuse_prior_result: true,
+        repeated_calls: 3,
+      });
+
+      await updateSessionTool.handler({ session_id: sessionId, title: 'Updated title' }, undefined);
+      const refreshed = await sessionsTool.handler({ id: sessionId, include_active: true }, undefined);
+      const data = parseResult(refreshed) as Array<{ id: string; title: string }>;
+      expect(data).toEqual([{
+        id: sessionId,
+        agent: 'claude-code',
+        status: 'active',
+        title: 'Updated title',
+        prompt_count: 0,
+        started_at: expect.any(Number),
+      }]);
+    });
+  });
+
+  describe('vault_entities', () => {
+    it('returns a compact projection by default', async () => {
+      insertEntity({
+        id: 'entity-compact',
+        agent_id: TEST_AGENT_ID,
+        type: 'component',
+        name: 'AuthModule',
+        properties: JSON.stringify({ language: 'TypeScript' }),
+        first_seen: epochNow() - 10,
+        last_seen: epochNow(),
+      });
+
+      const t = findTool(tools, 'vault_entities');
+      const result = await t.handler({ name: 'AuthModule' }, undefined);
+      const data = parseResult(result) as Array<Record<string, unknown>>;
+
+      expect(data).toHaveLength(1);
+      expect(data[0].name).toBe('AuthModule');
+      expect(data[0].type).toBe('component');
+      expect(data[0].properties).toBeUndefined();
+      expect(data[0].agent_id).toBeUndefined();
+    });
+
+    it('returns full entity metadata when include_metadata=true', async () => {
+      insertEntity({
+        id: 'entity-full',
+        agent_id: TEST_AGENT_ID,
+        type: 'component',
+        name: 'BillingModule',
+        properties: JSON.stringify({ owner: 'payments' }),
+        first_seen: epochNow() - 10,
+        last_seen: epochNow(),
+      });
+
+      const t = findTool(tools, 'vault_entities');
+      const result = await t.handler({ name: 'BillingModule', include_metadata: true }, undefined);
+      const data = parseResult(result) as Array<Record<string, unknown>>;
+
+      expect(data).toHaveLength(1);
+      expect(data[0].properties).toBe(JSON.stringify({ owner: 'payments' }));
+      expect(data[0].agent_id).toBe(TEST_AGENT_ID);
+    });
+  });
+
+  describe('vault_edges', () => {
+    it('returns a compact projection by default', async () => {
+      insertGraphEdge({
+        agent_id: TEST_AGENT_ID,
+        source_id: 'session-a',
+        source_type: 'session',
+        target_id: 'spore-a',
+        target_type: 'spore',
+        type: 'REFERENCES',
+        confidence: 0.8,
+        session_id: sessionId,
+        created_at: epochNow(),
+        properties: JSON.stringify({ rationale: 'linked during audit' }),
+      });
+
+      const t = findTool(tools, 'vault_edges');
+      const result = await t.handler({ source_id: 'session-a' }, undefined);
+      const data = parseResult(result) as Array<Record<string, unknown>>;
+
+      expect(data).toHaveLength(1);
+      expect(data[0].source_id).toBe('session-a');
+      expect(data[0].target_id).toBe('spore-a');
+      expect(data[0].properties).toBeUndefined();
+      expect(data[0].agent_id).toBeUndefined();
+    });
+
+    it('returns full edge metadata when include_metadata=true', async () => {
+      insertGraphEdge({
+        agent_id: TEST_AGENT_ID,
+        source_id: 'session-b',
+        source_type: 'session',
+        target_id: 'spore-b',
+        target_type: 'spore',
+        type: 'AFFECTS',
+        confidence: 0.9,
+        session_id: sessionId,
+        created_at: epochNow(),
+        properties: JSON.stringify({ rationale: 'full metadata' }),
+      });
+
+      const t = findTool(tools, 'vault_edges');
+      const result = await t.handler({ source_id: 'session-b', include_metadata: true }, undefined);
+      const data = parseResult(result) as Array<Record<string, unknown>>;
+
+      expect(data).toHaveLength(1);
+      expect(data[0].properties).toBe(JSON.stringify({ rationale: 'full metadata' }));
+      expect(data[0].agent_id).toBe(TEST_AGENT_ID);
     });
   });
 

--- a/tests/smoke/review-fixes.test.ts
+++ b/tests/smoke/review-fixes.test.ts
@@ -360,8 +360,8 @@ describe('MCP tools: myco_skills and myco_skill_candidates', () => {
 // VAULT_TOOL_COUNT consistency
 // ---------------------------------------------------------------------------
 describe('VAULT_TOOL_COUNT', () => {
-  it('matches expected count (24)', () => {
-    expect(VAULT_TOOL_COUNT).toBe(24);
+  it('matches expected count (25)', () => {
+    expect(VAULT_TOOL_COUNT).toBe(25);
   });
 });
 


### PR DESCRIPTION
- Introduced RuntimeTokenBudget interface to track token usage metrics.
- Implemented countExactToolCallsByRun function for precise tool call counting.
- Enhanced RunDetail component to display token budget information, including context window, peak request tokens, and utilization percentage.
- Updated tests to cover new functionality and ensure accurate behavior of context queries and tool handling.
- Adjusted VAULT_TOOL_COUNT to reflect the addition of vault_session_summary_material tool.

## Summary

This pull request introduces several improvements to agent context handling, token budget analysis, and task definitions in the Myco codebase. The most significant changes are the addition of token budget tracking and warnings, the introduction of a new `vault_session_summary_material` tool for more efficient session summarization, and the standardization of default context window sizes for various providers. These updates enhance reliability, observability, and efficiency for agent runs.

**Token budget analysis and logging:**
- Added `analyzeRuntimeTokenBudget` to compute token usage relative to provider context window, with warning/critical thresholds and detailed status reporting. Token budget pressure is now logged during agent runs if thresholds are exceeded. [[1]](diffhunk://#diff-28347346e0d030099910d131241c677b8c35858baca17b83b34825b89a572d2aL9-R120) [[2]](diffhunk://#diff-84e724b1a92d3e1db4273f412f0c413a756fe4831f9b3dcaa7224ffff48cda51R100-R114) [[3]](diffhunk://#diff-84e724b1a92d3e1db4273f412f0c413a756fe4831f9b3dcaa7224ffff48cda51R898) [[4]](diffhunk://#diff-84e724b1a92d3e1db4273f412f0c413a756fe4831f9b3dcaa7224ffff48cda51R910) [[5]](diffhunk://#diff-84e724b1a92d3e1db4273f412f0c413a756fe4831f9b3dcaa7224ffff48cda51R961)
- Token budget analysis results are now included in run accounting and usage data for improved auditability. [[1]](diffhunk://#diff-5e4bbfa3048c39bf7e8fdd527e857f600ee7f19af36271b29e97ddcb34198c35R144-R149) [[2]](diffhunk://#diff-28347346e0d030099910d131241c677b8c35858baca17b83b34825b89a572d2aR234-R241)

**Context window standardization:**
- Introduced `DEFAULT_LOCAL_AGENT_CONTEXT_WINDOW_TOKENS`, `DEFAULT_FRONTIER_CONTEXT_WINDOW_TOKENS`, and `DEFAULT_COMPATIBLE_CONTEXT_WINDOW_TOKENS` constants to standardize context window sizes for different providers. [[1]](diffhunk://#diff-e353e2d174eab35aa3981963731edf67252ca8af994064b905880fae53a91fd9R1-R8) [[2]](diffhunk://#diff-9a2427f190923ec5ce1d9aecc6a9951a54e34c664339751bf0e130d06e994450R10) [[3]](diffhunk://#diff-9a2427f190923ec5ce1d9aecc6a9951a54e34c664339751bf0e130d06e994450L26-R27)
- Refactored provider runtime inference to also expose default context window sizes, and used these defaults when provider metadata is missing. [[1]](diffhunk://#diff-845af8ad8c0055396d16dcc2bdf8fddb1d84e2efb8671e8e26af6c2da9632ffaR2-R50) [[2]](diffhunk://#diff-28347346e0d030099910d131241c677b8c35858baca17b83b34825b89a572d2aL9-R120)

**Session summarization improvements:**
- Introduced a new `vault_session_summary_material` tool for retrieving compact session summaries and prompt arcs, replacing multiple previous tool calls in the `title-summary` task flow. [[1]](diffhunk://#diff-3995122a6057ab65053ba3e609ef9359d60d581a9f7ba18f57c2f18f4c20f916R18) [[2]](diffhunk://#diff-7a267c820af1c1bf3f2080856d7d738bca1eb890aafe122b1fd885276d0557aeR15) [[3]](diffhunk://#diff-ff10c48cabb06ed914b96e93934b2291b013890f96e6bb541f26cb4e0971a206L31-R48) [[4]](diffhunk://#diff-ff10c48cabb06ed914b96e93934b2291b013890f96e6bb541f26cb4e0971a206L85-L90)
- Updated the `title-summary` task to use this new tool, simplifying and making the summarization process more efficient. [[1]](diffhunk://#diff-ff10c48cabb06ed914b96e93934b2291b013890f96e6bb541f26cb4e0971a206L31-R48) [[2]](diffhunk://#diff-ff10c48cabb06ed914b96e93934b2291b013890f96e6bb541f26cb4e0971a206L85-L90)

**Task and agent configuration updates:**
- Updated `.myco/myco.yaml` to reconfigure the `title-summary` task to use a local `lmstudio` model via OpenAI-compatible runtime, and removed the old `full-intelligence` task. [[1]](diffhunk://#diff-432c34b61f92ab7f8c9e5e9da03000e2c7679531fbe93502e4221eaa60d6a31dL29-L45) [[2]](diffhunk://#diff-432c34b61f92ab7f8c9e5e9da03000e2c7679531fbe93502e4221eaa60d6a31dR64-R76)

**Query and projection improvements:**
- Updated agent context queries to project batch, session, and spore data for agent consumption, improving consistency and encapsulation. [[1]](diffhunk://#diff-178c4c96d33a7f60dadda4f6b1eb51d09c57bcd277e2c869e920840dbf23bc28R15-R19) [[2]](diffhunk://#diff-178c4c96d33a7f60dadda4f6b1eb51d09c57bcd277e2c869e920840dbf23bc28L136-R148)

These changes collectively improve agent robustness, monitoring, and efficiency in handling large context windows and summarization tasks.

## Related Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [ ] Enhancement / new feature
- [x] Refactor / code quality
- [ ] Documentation
- [ ] CI / workflow

## Validation

```bash
make check    # lint + 266 tests
```

## Checklist

- [x] `make check` passes locally
- [x] Tests added or updated where behavior changed
- [ ] Docs updated for user-visible changes
- [ ] No magic literals introduced (named constants in `src/constants.ts`)
