### PR TITLE
chore: pre-release quality pass on unreleased PRs (#86, #87, #88)

### DIFF
--- a/packages/myco/src/agent/cost/openai.ts
+++ b/packages/myco/src/agent/cost/openai.ts
@@ -6,51 +6,28 @@ const TOKENS_PER_MILLION = 1_000_000;
 const OPENAI_PRICING_VERSION = 'openai-api-pricing-2026-04-16';
 
 interface OpenAIPricing {
-  model: string;
   inputUsdPerMillion: number;
   cachedInputUsdPerMillion: number;
   outputUsdPerMillion: number;
 }
 
-const OPENAI_PRICING_RULES: Array<{
-  matches: (model: string) => boolean;
-  pricing: OpenAIPricing;
-}> = [
-  {
-    matches: (model) => model === 'gpt-5.4',
-    pricing: {
-      model: 'gpt-5.4',
-      inputUsdPerMillion: 2.5,
-      cachedInputUsdPerMillion: 0.25,
-      outputUsdPerMillion: 15,
-    },
+const OPENAI_PRICING: Record<string, OpenAIPricing> = {
+  'gpt-5.4': {
+    inputUsdPerMillion: 2.5,
+    cachedInputUsdPerMillion: 0.25,
+    outputUsdPerMillion: 15,
   },
-  {
-    matches: (model) => model === 'gpt-5.4-mini',
-    pricing: {
-      model: 'gpt-5.4-mini',
-      inputUsdPerMillion: 0.75,
-      cachedInputUsdPerMillion: 0.075,
-      outputUsdPerMillion: 4.5,
-    },
+  'gpt-5.4-mini': {
+    inputUsdPerMillion: 0.75,
+    cachedInputUsdPerMillion: 0.075,
+    outputUsdPerMillion: 4.5,
   },
-  {
-    matches: (model) => model === 'gpt-5.4-nano',
-    pricing: {
-      model: 'gpt-5.4-nano',
-      inputUsdPerMillion: 0.2,
-      cachedInputUsdPerMillion: 0.02,
-      outputUsdPerMillion: 1.25,
-    },
+  'gpt-5.4-nano': {
+    inputUsdPerMillion: 0.2,
+    cachedInputUsdPerMillion: 0.02,
+    outputUsdPerMillion: 1.25,
   },
-];
-
-function findPricing(model: string): OpenAIPricing | null {
-  for (const rule of OPENAI_PRICING_RULES) {
-    if (rule.matches(model)) return rule.pricing;
-  }
-  return null;
-}
+};
 
 function tokensToUsd(tokens: number, usdPerMillion: number): number {
   return (tokens * usdPerMillion) / TOKENS_PER_MILLION;
@@ -58,7 +35,7 @@ function tokensToUsd(tokens: number, usdPerMillion: number): number {
 
 export function estimateOpenAICost(model: string, usage: RuntimeUsage): CostResolution {
   const breakdown = buildTokenBreakdown(usage);
-  const pricing = findPricing(model);
+  const pricing = OPENAI_PRICING[model];
   if (!pricing) {
     return {
       source: 'unavailable',
@@ -75,10 +52,11 @@ export function estimateOpenAICost(model: string, usage: RuntimeUsage): CostReso
   const cachedInputCostUsd = tokensToUsd(breakdown.cachedInputTokens, pricing.cachedInputUsdPerMillion);
   const outputCostUsd = tokensToUsd(breakdown.outputTokens, pricing.outputUsdPerMillion);
   const totalCostUsd = inputCostUsd + cachedInputCostUsd + outputCostUsd;
-  const cacheSavingsUsd = tokensToUsd(
+  // Clamp at 0 — matches OpenRouter behavior and guards against flipped rates.
+  const cacheSavingsUsd = Math.max(0, tokensToUsd(
     breakdown.cachedInputTokens,
     pricing.inputUsdPerMillion - pricing.cachedInputUsdPerMillion,
-  );
+  ));
 
   return {
     source: 'estimated',
@@ -95,7 +73,7 @@ export function estimateOpenAICost(model: string, usage: RuntimeUsage): CostReso
     },
     pricingVersion: OPENAI_PRICING_VERSION,
     providerMetadata: {
-      model: pricing.model,
+      model,
       inputUsdPerMillion: pricing.inputUsdPerMillion,
       cachedInputUsdPerMillion: pricing.cachedInputUsdPerMillion,
       outputUsdPerMillion: pricing.outputUsdPerMillion,

--- a/packages/myco/src/agent/cost/openrouter.ts
+++ b/packages/myco/src/agent/cost/openrouter.ts
@@ -62,6 +62,12 @@ function resolveBaseUrl(baseUrl?: string): string {
   return baseUrl ?? OPENROUTER_DEFAULT_BASE_URL;
 }
 
+function pruneExpiredCatalogEntries(now: number): void {
+  for (const [key, entry] of catalogCache) {
+    if (entry.expiresAt <= now) catalogCache.delete(key);
+  }
+}
+
 async function fetchPricingCatalog(baseUrl?: string): Promise<Map<string, OpenRouterPricing>> {
   const resolvedBaseUrl = resolveBaseUrl(baseUrl);
   const now = Date.now();
@@ -69,6 +75,7 @@ async function fetchPricingCatalog(baseUrl?: string): Promise<Map<string, OpenRo
   if (cached && cached.expiresAt > now) {
     return cached.pricingByModel;
   }
+  pruneExpiredCatalogEntries(now);
 
   const apiKey = resolveOpenRouterApiKey();
   if (!apiKey) {

--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -1,16 +1,4 @@
-/**
- * Agent executor.
- *
- * Orchestrates a single agent run:
- *   1. Initializes the database for the vault.
- *   2. Resolves effective config (definition + agent DB overrides + task).
- *   3. Guards against concurrent runs for the same task.
- *   4. Creates or resumes a run record in the database.
- *   5. Builds the task prompt (vault context + task + optional instruction).
- *   6. Executes the selected runtime adapter — single call for flat tasks,
- *      wave-based parallel execution for phased tasks.
- *   7. Persists checkpoint, usage, and resume metadata as the run progresses.
- */
+/** Agent executor — orchestrates a single agent run end to end. */
 
 import crypto from 'node:crypto';
 import { resolve } from 'node:path';
@@ -23,6 +11,7 @@ import {
   insertRun,
   updateRunStatus,
   updateRun,
+  applyRunUpdate,
   getRun,
   getRunningRunForTask,
   RESUME_STATUS_READY,
@@ -409,7 +398,6 @@ async function executePhasedQuery(
   let effectivePhases = [...phases];
 
   if (config.orchestrator?.enabled) {
-    // 1. Run context queries (if any)
     const contextQueries = config.contextQueries
       ? Object.values(config.contextQueries).flat()
       : [];
@@ -417,7 +405,6 @@ async function executePhasedQuery(
       ? await executeContextQueries(agentId, contextQueries)
       : [];
 
-    // 2. Compose orchestrator prompt
     const orchestratorPrompt = composeOrchestratorPrompt(vaultContext, phases, contextResults);
     const orchestratorModel = config.orchestrator.model ?? resolveReasoningModel(
       config.orchestrator.reasoningLevel ?? config.execution?.reasoningLevel ?? config.reasoningLevel,
@@ -441,7 +428,6 @@ async function executePhasedQuery(
       abortController,
     });
 
-    // 4. Parse plan and apply directives
     const plan = parseOrchestratorPlan(planResponse.finalText, phases);
     effectivePhases = applyDirectives(phases, plan.phases);
   }
@@ -640,7 +626,6 @@ export async function runAgent(
   vaultDir: string,
   options?: RunOptions,
 ): Promise<AgentRunResult> {
-  // 1. Init DB (idempotent — returns existing instance if already open)
   const db = initDatabase(vaultDbPath(vaultDir));
   createSchema(db);
 
@@ -654,9 +639,7 @@ export async function runAgent(
     };
   }
 
-  // 2. Concurrency guard — block duplicate runs of the SAME task, not all tasks.
-  // Different tasks (e.g., full-intelligence and skill-generate) can run concurrently.
-  // When no task is specified, resolve the effective task name first so the guard applies.
+  // Block duplicate runs of the SAME task — different tasks may run concurrently.
   const requestedTask = options?.task ?? resumedRun?.task ?? undefined;
   {
     const effectiveTask = requestedTask
@@ -673,7 +656,6 @@ export async function runAgent(
     }
   }
 
-  // 3. Resolve config from all sources
   const {
     config,
     definitionsDir,
@@ -686,7 +668,6 @@ export async function runAgent(
   let taskProviderOverride = resolvedTaskProvider;
   let phaseProviderOverrides = resolvedPhaseOverrides;
 
-  // 4. Create run record
   const runId = options?.resumeRunId ?? crypto.randomUUID();
   const now = epochSeconds();
   let runtimeId = config.runtime;
@@ -728,33 +709,32 @@ export async function runAgent(
     checkpointState.model = checkpointState.model ?? effectiveModel;
   }
 
+  const runStart = {
+    status: STATUS_RUNNING,
+    runtime: runtimeId,
+    model: effectiveModel,
+    checkpoints: serializeCheckpointState(checkpointState),
+    started_at: now,
+  } as const;
   if (!resumedRun) {
     insertRun({
       id: runId,
       agent_id: agentId,
       task: config.taskName,
       instruction: options?.instruction ?? null,
-      status: STATUS_RUNNING,
-      runtime: runtimeId,
+      ...runStart,
       provider: effectiveProvider?.type ?? null,
-      model: effectiveModel,
-      checkpoints: serializeCheckpointState(checkpointState),
       usage_data: buildUsageData({}),
-      started_at: now,
     });
   } else {
-    updateRun(runId, {
-      status: STATUS_RUNNING,
-      runtime: runtimeId,
+    applyRunUpdate(runId, {
+      ...runStart,
       provider: effectiveProvider?.type ?? resumedRun.provider ?? null,
-      model: effectiveModel,
-      started_at: now,
       completed_at: null,
       resumable: 0,
       resume_status: null,
       resume_mode: options?.resumeMode ?? resumedRun.resume_mode ?? null,
       resumed_at: now,
-      checkpoints: serializeCheckpointState(checkpointState),
       usage_data: resumedRun.usage_data,
       cost_usd: resumedRun.cost_usd,
       actual_cost_usd: resumedRun.actual_cost_usd,
@@ -765,15 +745,13 @@ export async function runAgent(
     });
   }
 
-  // 5. Build prompt components
   const systemPrompt = loadSystemPrompt(definitionsDir, config.systemPromptPath);
   const vaultContext = buildVaultContext(agentId);
 
-  // 7. Resolve Ollama context variants across task + phase scopes.
-  //    Applies DEFAULT_OLLAMA_CONTEXT_LENGTH when no value is set, and
-  //    reconciles same-model-different-context conflicts to one variant
-  //    per model (max wins) so Ollama loads each model at most once.
-  //    Non-ollama providers are passed through unchanged.
+  // Resolve Ollama context variants across task + phase scopes. Applies
+  // DEFAULT_OLLAMA_CONTEXT_LENGTH when no value is set, and reconciles
+  // same-model-different-context conflicts (max wins) so Ollama loads
+  // each model at most once. Non-ollama providers pass through unchanged.
   {
     const resolved = await resolveOllamaContextVariants(
       taskProviderOverride,
@@ -791,8 +769,7 @@ export async function runAgent(
     }
   }
 
-  // 8. Execute — phased or single query
-  // Create abort controller for task-level timeout enforcement
+  // Task-level timeout enforcement — phased or single query executes below.
   const taskAbortController = new AbortController();
   const timeoutMs = config.timeoutSeconds * MS_PER_SECOND;
   const timeoutId = setTimeout(() => {
@@ -815,16 +792,14 @@ export async function runAgent(
       currentUsage: RuntimeUsage = aggregateUsage(currentPhaseResults.map((phase) => phase.usage)),
       currentCost: CostResolution = summarizePhaseCosts(currentPhaseResults),
     ) => {
-      await Promise.resolve(updateRun(runId, {
-        ...buildRunAccountingUpdate({
-          runtime: runtimeId,
-          provider: effectiveProvider,
-          model: effectiveModel,
-          checkpointState: currentCheckpointState,
-          usage: currentUsage,
-          costData: currentCost,
-          phaseResults: currentPhaseResults,
-        }),
+      applyRunUpdate(runId, buildRunAccountingUpdate({
+        runtime: runtimeId,
+        provider: effectiveProvider,
+        model: effectiveModel,
+        checkpointState: currentCheckpointState,
+        usage: currentUsage,
+        costData: currentCost,
+        phaseResults: currentPhaseResults,
       }));
     };
 
@@ -895,7 +870,6 @@ export async function runAgent(
       checkpointState.sessionRef = result.sessionRef;
       checkpointState.sessionData = result.sessionData;
       await persistRuntimeState(checkpointState, undefined, usage, costData);
-      logTokenBudgetPressure(config.taskName, usage, singleProvider);
 
       const postconditionError = validateTaskPostconditions({
         runId,
@@ -940,8 +914,8 @@ export async function runAgent(
     };
   } catch (err) {
     clearTimeout(timeoutId);
-    // 7. Error handling — mark run as failed, preserve phase results
-    // Aggressively extract error info — the SDK may throw non-Error objects
+    // Mark run as failed, preserving phase results. The SDK may throw
+    // non-Error objects, so extract a best-effort message.
     let errorMessage: string;
     if (err instanceof Error) {
       errorMessage = err.message || err.constructor.name || 'Error (no message)';

--- a/packages/myco/src/agent/provider.ts
+++ b/packages/myco/src/agent/provider.ts
@@ -8,10 +8,10 @@ const ENV_ANTHROPIC_BASE_URL = 'ANTHROPIC_BASE_URL';
 const ENV_ANTHROPIC_AUTH_TOKEN = 'ANTHROPIC_AUTH_TOKEN';
 const ENV_ANTHROPIC_API_KEY = 'ANTHROPIC_API_KEY';
 const ENV_OLLAMA_NUM_CTX = 'OLLAMA_NUM_CTX';
-const DEFAULT_OLLAMA_URL = 'http://localhost:11434';
-const DEFAULT_LMSTUDIO_URL = 'http://localhost:1234';
-const DEFAULT_OPENAI_URL = 'https://api.openai.com/v1';
-const DEFAULT_OPENROUTER_URL = 'https://openrouter.ai/api/v1';
+export const DEFAULT_OLLAMA_URL = 'http://localhost:11434';
+export const DEFAULT_LMSTUDIO_URL = 'http://localhost:1234';
+export const DEFAULT_OPENAI_URL = 'https://api.openai.com/v1';
+export const DEFAULT_OPENROUTER_URL = 'https://openrouter.ai/api/v1';
 const OLLAMA_AUTH_TOKEN = 'ollama';
 const LMSTUDIO_AUTH_TOKEN = 'lmstudio';
 

--- a/packages/myco/src/agent/run-accounting.ts
+++ b/packages/myco/src/agent/run-accounting.ts
@@ -61,18 +61,17 @@ export function analyzeRuntimeTokenBudget(
           (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)
         ),
       }];
-  const peakRequestInputTokens = requestEntries.reduce(
-    (max, entry) => Math.max(max, toRequestTokenNumber(entry, 'inputTokens')),
-    0,
-  );
-  const peakRequestOutputTokens = requestEntries.reduce(
-    (max, entry) => Math.max(max, toRequestTokenNumber(entry, 'outputTokens')),
-    0,
-  );
-  const peakRequestTotalTokens = requestEntries.reduce(
-    (max, entry) => Math.max(max, toRequestTokenNumber(entry, 'totalTokens')),
-    0,
-  );
+  let peakRequestInputTokens = 0;
+  let peakRequestOutputTokens = 0;
+  let peakRequestTotalTokens = 0;
+  for (const entry of requestEntries) {
+    const input = toRequestTokenNumber(entry, 'inputTokens');
+    const output = toRequestTokenNumber(entry, 'outputTokens');
+    const total = toRequestTokenNumber(entry, 'totalTokens');
+    if (input > peakRequestInputTokens) peakRequestInputTokens = input;
+    if (output > peakRequestOutputTokens) peakRequestOutputTokens = output;
+    if (total > peakRequestTotalTokens) peakRequestTotalTokens = total;
+  }
   const { tokens: contextWindowTokens, source: contextWindowSource } = resolveContextWindow(provider, usage);
 
   if (!contextWindowTokens) {
@@ -97,11 +96,17 @@ export function analyzeRuntimeTokenBudget(
     : utilizationPercent >= TOKEN_BUDGET_WARNING_PERCENT
       ? 'warning'
       : 'ok';
-  const message = status === 'critical'
+  const statusMessage = status === 'critical'
     ? 'Run operated near the model context limit.'
     : status === 'warning'
       ? 'Run used a large share of the model context window.'
       : undefined;
+  const isInferredWindow = contextWindowSource === 'provider-default';
+  const message = isInferredWindow
+    ? (statusMessage
+        ? `${statusMessage} Using inferred provider default context window.`
+        : 'Using inferred provider default context window.')
+    : statusMessage;
 
   return {
     contextWindowTokens,
@@ -113,9 +118,6 @@ export function analyzeRuntimeTokenBudget(
     headroomTokens,
     status,
     ...(message ? { message } : {}),
-    ...(contextWindowSource === 'provider-default'
-      ? { message: message ? `${message} Using inferred provider default context window.` : 'Using inferred provider default context window.' }
-      : {}),
   };
 }
 

--- a/packages/myco/src/agent/runtime/claude.ts
+++ b/packages/myco/src/agent/runtime/claude.ts
@@ -1,31 +1,9 @@
-import { query } from '@anthropic-ai/claude-agent-sdk';
+import { query, type SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import type { RuntimeExecuteInput, RuntimeExecuteResult, AgentRuntime, RuntimeCapability } from './types.js';
 import { createScopedVaultToolServer, createVaultToolServer } from '@myco/agent/tools.js';
 import { buildPhaseEnv } from '@myco/agent/provider.js';
 
 const MCP_SERVER_NAME = 'myco-vault';
-const PERSIST_SESSION = true;
-
-interface ClaudeAssistantMessage {
-  type: 'assistant';
-  message?: { content?: Array<{ type: string; name?: string; input?: unknown }> };
-}
-
-interface ClaudeUserMessage {
-  type: 'user';
-  message?: { content?: Array<{ type: string; content?: unknown; is_error?: boolean }> };
-}
-
-interface ClaudeResultMessage {
-  type: 'result';
-  usage: {
-    input_tokens?: number;
-    output_tokens?: number;
-  };
-  total_cost_usd?: number;
-  num_turns?: number;
-  result?: string;
-}
 
 function buildToolServer(input: RuntimeExecuteInput) {
   const { toolSurface } = input;
@@ -57,8 +35,7 @@ export class ClaudeSdkRuntime implements AgentRuntime {
   readonly id = 'claude-sdk' as const;
 
   supports(capability: RuntimeCapability): boolean {
-    return capability === 'supportsSessionResume'
-      || capability === 'supportsMcp';
+    return capability === 'supportsSessionResume' || capability === 'supportsMcp';
   }
 
   async execute(input: RuntimeExecuteInput): Promise<RuntimeExecuteResult> {
@@ -73,38 +50,36 @@ export class ClaudeSdkRuntime implements AgentRuntime {
     let costUsd = 0;
     let assistantMessages = 0;
 
-    for await (const message of query({
+    const messageStream: AsyncIterable<SDKMessage> = query({
       prompt: input.prompt,
       options: {
         model: input.model,
         systemPrompt: input.systemPrompt,
-        ...(toolServer ? {
-          mcpServers: { [MCP_SERVER_NAME]: toolServer },
-          strictMcpConfig: true,
-        } : { tools: [] }),
-        ...(toolServer ? { tools: [] } : {}),
+        tools: [],
+        ...(toolServer
+          ? { mcpServers: { [MCP_SERVER_NAME]: toolServer }, strictMcpConfig: true }
+          : {}),
         maxTurns: input.maxTurns,
         permissionMode: 'bypassPermissions',
         allowDangerouslySkipPermissions: true,
-        persistSession: PERSIST_SESSION,
+        persistSession: true,
         env,
         ...(input.sessionRef ? { sessionId: input.sessionRef } : {}),
         ...(input.abortController ? { abortController: input.abortController } : {}),
       },
-    })) {
-      if ((message as ClaudeAssistantMessage).type === 'assistant') {
+    });
+
+    for await (const message of messageStream) {
+      if (message.type === 'assistant') {
         assistantMessages += 1;
-      }
-      if ((message as ClaudeUserMessage).type === 'user') {
         continue;
       }
-      if ((message as ClaudeResultMessage).type === 'result') {
-        const resultMessage = message as ClaudeResultMessage;
-        finalText = typeof resultMessage.result === 'string' ? resultMessage.result : '';
-        turnsUsed = resultMessage.num_turns ?? assistantMessages;
-        inputTokens = resultMessage.usage.input_tokens ?? 0;
-        outputTokens = resultMessage.usage.output_tokens ?? 0;
-        costUsd = resultMessage.total_cost_usd ?? 0;
+      if (message.type === 'result' && message.subtype === 'success') {
+        finalText = message.result;
+        turnsUsed = message.num_turns ?? assistantMessages;
+        inputTokens = message.usage.input_tokens ?? 0;
+        outputTokens = message.usage.output_tokens ?? 0;
+        costUsd = message.total_cost_usd ?? 0;
       }
     }
 

--- a/packages/myco/src/agent/runtime/openai.ts
+++ b/packages/myco/src/agent/runtime/openai.ts
@@ -17,11 +17,11 @@ import { LmStudioBackend } from '@myco/intelligence/lm-studio.js';
 import {
   getLocalOpenAIBackendDefaultBaseUrl,
   inferLocalOpenAIBackendKind,
+  tryParseUrl,
   type LocalOpenAIBackendKind,
 } from '@myco/intelligence/local-openai-backends.js';
+import { DEFAULT_OPENAI_URL, DEFAULT_OPENROUTER_URL } from '@myco/agent/provider.js';
 
-const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
-const DEFAULT_OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
 const OPENAI_COMPATIBLE_PLACEHOLDER_API_KEY = 'myco-local-openai-compatible';
 const OPENAI_API_PATH = '/v1';
 
@@ -97,28 +97,30 @@ type OpenAIClientConfig = {
   baseURL?: string;
 };
 
+const PLACEHOLDER = OPENAI_COMPATIBLE_PLACEHOLDER_API_KEY;
+
 const PROVIDER_CLIENT_CONFIG_RESOLVERS: Record<ProviderConfig['type'], (provider?: ProviderConfig) => OpenAIClientConfig> = {
   anthropic: () => ({
-    apiKey: process.env.OPENAI_API_KEY ?? OPENAI_COMPATIBLE_PLACEHOLDER_API_KEY,
+    apiKey: process.env.OPENAI_API_KEY ?? PLACEHOLDER,
   }),
   ollama: (provider) => ({
-    apiKey: provider?.apiKey ?? OPENAI_COMPATIBLE_PLACEHOLDER_API_KEY,
+    apiKey: provider?.apiKey ?? PLACEHOLDER,
     baseURL: provider?.baseUrl ?? toOpenAIBaseUrl(getLocalOpenAIBackendDefaultBaseUrl('ollama')),
   }),
   lmstudio: (provider) => ({
-    apiKey: provider?.apiKey ?? OPENAI_COMPATIBLE_PLACEHOLDER_API_KEY,
+    apiKey: provider?.apiKey ?? PLACEHOLDER,
     baseURL: provider?.baseUrl ?? toOpenAIBaseUrl(getLocalOpenAIBackendDefaultBaseUrl('lmstudio')),
   }),
   openai: (provider) => ({
     apiKey: provider?.apiKey ?? process.env[OPENAI_API_KEY_ENV] ?? process.env.OPENAI_API_KEY,
-    baseURL: provider?.baseUrl ?? DEFAULT_OPENAI_BASE_URL,
+    baseURL: provider?.baseUrl ?? DEFAULT_OPENAI_URL,
   }),
   openrouter: (provider) => ({
     apiKey: provider?.apiKey ?? process.env[OPENROUTER_API_KEY_ENV],
-    baseURL: provider?.baseUrl ?? DEFAULT_OPENROUTER_BASE_URL,
+    baseURL: provider?.baseUrl ?? DEFAULT_OPENROUTER_URL,
   }),
   'openai-compatible': (provider) => ({
-    apiKey: provider?.apiKey ?? OPENAI_COMPATIBLE_PLACEHOLDER_API_KEY,
+    apiKey: provider?.apiKey ?? PLACEHOLDER,
     ...(provider?.baseUrl ? { baseURL: provider.baseUrl } : {}),
   }),
 };
@@ -133,14 +135,6 @@ export function shouldUseResponsesApi(provider?: ProviderConfig): boolean {
   return provider?.type !== 'openai-compatible'
     && provider?.type !== 'ollama'
     && provider?.type !== 'lmstudio';
-}
-
-function tryParseUrl(value: string): URL | null {
-  try {
-    return new URL(value);
-  } catch {
-    return null;
-  }
 }
 
 function toOpenAIBaseUrl(baseUrl: string): string {
@@ -251,9 +245,7 @@ export class OpenAIAgentsRuntime implements AgentRuntime {
   constructor(private readonly context: RuntimeFactoryContext) {}
 
   supports(capability: RuntimeCapability): boolean {
-    return capability === 'supportsSessionResume'
-      || capability === 'supportsMcp'
-      || capability === 'supportsReasoningUsageBreakdown';
+    return capability === 'supportsSessionResume' || capability === 'supportsMcp';
   }
 
   async execute(input: RuntimeExecuteInput): Promise<RuntimeExecuteResult> {

--- a/packages/myco/src/agent/runtime/types.ts
+++ b/packages/myco/src/agent/runtime/types.ts
@@ -4,11 +4,7 @@ import type { ProviderConfig, RuntimeId, RuntimeUsage } from '@myco/agent/types.
 
 export type RuntimeCapability =
   | 'supportsSessionResume'
-  | 'supportsMcp'
-  | 'supportsNativeTools'
-  | 'supportsHostedTools'
-  | 'supportsHandoffs'
-  | 'supportsReasoningUsageBreakdown';
+  | 'supportsMcp';
 
 export interface RuntimeToolSurface {
   agentId: string;

--- a/packages/myco/src/agent/types.ts
+++ b/packages/myco/src/agent/types.ts
@@ -76,13 +76,20 @@ export interface ContextQuery {
 export type RuntimeId = 'claude-sdk' | 'openai-agents';
 export type ReasoningLevel = 'low' | 'default' | 'high';
 
-export type ProviderType =
-  | 'anthropic'
-  | 'ollama'
-  | 'lmstudio'
-  | 'openai'
-  | 'openrouter'
-  | 'openai-compatible';
+export const PROVIDER_TYPES = [
+  'anthropic',
+  'ollama',
+  'lmstudio',
+  'openai',
+  'openrouter',
+  'openai-compatible',
+] as const;
+
+export type ProviderType = typeof PROVIDER_TYPES[number];
+
+export function isProviderType(value: unknown): value is ProviderType {
+  return typeof value === 'string' && (PROVIDER_TYPES as readonly string[]).includes(value);
+}
 
 /** API provider configuration for task execution. */
 export interface ProviderConfig {

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -84,8 +84,31 @@ function buildPhaseCheckpointSummary(checkpointsRaw: string | null): PhaseCheckp
 
 function serializeRun(run: RunRow) {
   return {
-    ...run,
+    id: run.id,
+    agent_id: run.agent_id,
+    task: run.task,
+    instruction: run.instruction,
+    status: run.status,
+    runtime: run.runtime,
+    provider: run.provider,
+    model: run.model,
+    session_ref: run.session_ref,
     resumable: run.resumable === 1,
+    resume_status: run.resume_status,
+    resume_mode: run.resume_mode,
+    resumed_at: run.resumed_at,
+    checkpoints: run.checkpoints,
+    usage_data: run.usage_data,
+    started_at: run.started_at,
+    completed_at: run.completed_at,
+    tokens_used: run.tokens_used,
+    cost_usd: run.cost_usd,
+    actual_cost_usd: run.actual_cost_usd,
+    estimated_cost_usd: run.estimated_cost_usd,
+    cost_source: run.cost_source,
+    cost_data: run.cost_data,
+    actions_taken: run.actions_taken,
+    error: run.error,
     phase_checkpoints: buildPhaseCheckpointSummary(run.checkpoints),
   };
 }

--- a/packages/myco/src/daemon/api/provider-secrets.ts
+++ b/packages/myco/src/daemon/api/provider-secrets.ts
@@ -31,9 +31,11 @@ function maskSecret(secret: string): string {
   return `${secret.slice(0, SECRET_PREVIEW_PREFIX_CHARS)}${'*'.repeat(secret.length - SECRET_PREVIEW_PREFIX_CHARS - SECRET_PREVIEW_SUFFIX_CHARS)}${secret.slice(-SECRET_PREVIEW_SUFFIX_CHARS)}`;
 }
 
-function getSecretInfo(vaultDir: string, provider: SecretProvider): SecretInfo {
+function buildSecretInfo(
+  provider: SecretProvider,
+  storedSecrets: Record<string, string>,
+): SecretInfo {
   const envKey = SECRET_ENV_BY_PROVIDER[provider];
-  const storedSecrets = readSecrets(vaultDir);
   const storedValue = storedSecrets[envKey];
   const envValue = process.env[envKey];
   const effectiveValue = storedValue ?? envValue;
@@ -46,12 +48,17 @@ function getSecretInfo(vaultDir: string, provider: SecretProvider): SecretInfo {
   };
 }
 
+function getSecretInfo(vaultDir: string, provider: SecretProvider): SecretInfo {
+  return buildSecretInfo(provider, readSecrets(vaultDir));
+}
+
 export async function handleGetProviderSecrets(vaultDir: string): Promise<RouteResponse> {
+  const storedSecrets = readSecrets(vaultDir);
   return {
     body: {
       secrets: {
-        openai: getSecretInfo(vaultDir, 'openai'),
-        openrouter: getSecretInfo(vaultDir, 'openrouter'),
+        openai: buildSecretInfo('openai', storedSecrets),
+        openrouter: buildSecretInfo('openrouter', storedSecrets),
       },
     },
   };

--- a/packages/myco/src/daemon/api/providers.ts
+++ b/packages/myco/src/daemon/api/providers.ts
@@ -23,7 +23,8 @@ import {
   getRemoteProviderApiKey,
 } from './models.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
-import type { RuntimeId, ProviderType } from '@myco/agent/types.js';
+import { PROVIDER_TYPES, isProviderType, type RuntimeId, type ProviderType } from '@myco/agent/types.js';
+import { DEFAULT_OPENAI_URL, DEFAULT_OPENROUTER_URL } from '@myco/agent/provider.js';
 
 /** Timeout for the live Anthropic model list query (short -- fall back fast). */
 const ANTHROPIC_MODELS_TIMEOUT_MS = 5000;
@@ -85,12 +86,12 @@ export async function handleGetProviders(): Promise<RouteResponse> {
       fallback: { type: 'lmstudio', runtime: 'claude-sdk', available: false, baseUrl: LmStudioBackend.DEFAULT_BASE_URL, models: [] },
     },
     {
-      detect: () => detectRemoteProviderInfo('openai', 'https://api.openai.com/v1'),
-      fallback: { type: 'openai', runtime: 'openai-agents', available: false, authConfigured: false, baseUrl: 'https://api.openai.com/v1', models: [] },
+      detect: () => detectRemoteProviderInfo('openai', DEFAULT_OPENAI_URL),
+      fallback: { type: 'openai', runtime: 'openai-agents', available: false, authConfigured: false, baseUrl: DEFAULT_OPENAI_URL, models: [] },
     },
     {
-      detect: () => detectRemoteProviderInfo('openrouter', 'https://openrouter.ai/api/v1'),
-      fallback: { type: 'openrouter', runtime: 'openai-agents', available: false, authConfigured: false, baseUrl: 'https://openrouter.ai/api/v1', models: [] },
+      detect: () => detectRemoteProviderInfo('openrouter', DEFAULT_OPENROUTER_URL),
+      fallback: { type: 'openrouter', runtime: 'openai-agents', available: false, authConfigured: false, baseUrl: DEFAULT_OPENROUTER_URL, models: [] },
     },
     {
       detect: () => detectLocalProviderInfo('openai-compatible', LmStudioBackend.DEFAULT_BASE_URL),
@@ -116,10 +117,10 @@ export async function handleTestProvider(req: RouteRequest): Promise<RouteRespon
   const body = req.body as Record<string, unknown> | undefined;
   const type = body?.type as string | undefined;
 
-  if (!type || !['anthropic', 'ollama', 'lmstudio', 'openai', 'openrouter', 'openai-compatible'].includes(type)) {
+  if (!type || !isProviderType(type)) {
     return {
       status: HTTP_BAD_REQUEST,
-      body: { error: 'type is required and must be one of: anthropic, ollama, lmstudio, openai, openrouter, openai-compatible' },
+      body: { error: `type is required and must be one of: ${PROVIDER_TYPES.join(', ')}` },
     };
   }
 

--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -66,6 +66,10 @@ export interface EventDispatchDeps {
 // Factory
 // ---------------------------------------------------------------------------
 
+// Cap dropped-session cache to bound memory. Dropped sessions are rarely
+// revisited; FIFO eviction via Map ordering is sufficient.
+const DROP_DECISION_CACHE_MAX = 1024;
+
 export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
   const {
     registry,
@@ -82,6 +86,20 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
 
   const projectRoot = process.cwd();
   const manifests = loadManifests();
+
+  // Cache drop decisions by session_id so a rejected session that keeps firing
+  // events doesn't re-open + re-read (up to 128 KB) its transcript every time.
+  // Transcript first-line metadata doesn't change once written, so session_id
+  // is a stable cache key.
+  const droppedSessions = new Map<string, string | undefined>();
+
+  function rememberDropped(sessionId: string, reason: string | undefined): void {
+    if (droppedSessions.size >= DROP_DECISION_CACHE_MAX) {
+      const oldest = droppedSessions.keys().next().value;
+      if (oldest !== undefined) droppedSessions.delete(oldest);
+    }
+    droppedSessions.set(sessionId, reason);
+  }
 
   function evaluateAutoRegistration(event: Record<string, unknown>): { action: 'pass' } | { action: 'drop'; reason?: string } {
     const transcriptPath = typeof event.transcript_path === 'string' && event.transcript_path.length > 0
@@ -107,8 +125,18 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
 
     // Ensure session is registered (idempotent — handles daemon restarts mid-session)
     if (!registry.getSession(event.session_id)) {
+      if (droppedSessions.has(event.session_id)) {
+        const reason = droppedSessions.get(event.session_id) ?? 'rule';
+        logger.debug(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Ignored event for previously-dropped session', {
+          session_id: event.session_id,
+          type: event.type,
+          reason,
+        });
+        return { body: { ok: true, ignored: reason } };
+      }
       const decision = evaluateAutoRegistration(event);
       if (decision.action === 'drop') {
+        rememberDropped(event.session_id, decision.reason);
         logger.info(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Ignored event that failed session capture rules', {
           session_id: event.session_id,
           type: event.type,

--- a/packages/myco/src/db/migrations.ts
+++ b/packages/myco/src/db/migrations.ts
@@ -49,6 +49,16 @@ export const MIGRATIONS: Migration[] = [
 // ---------------------------------------------------------------------------
 
 /**
+ * Return the set of column names on a table, via PRAGMA table_info.
+ * Used to make ADD COLUMN migrations idempotent without wrapping each
+ * statement in a try/catch inside a transaction (which poisons the txn).
+ */
+function getTableColumnSet(db: Database, tableName: string): Set<string> {
+  const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>;
+  return new Set(rows.map((r) => r.name));
+}
+
+/**
  * Migrate a version-1 database to version-2.
  *
  * Version 2 adds:
@@ -244,27 +254,25 @@ function migrateV3ToV4(db: Database, machineId: string): void {
  * resumed without overloading actions_taken JSON.
  */
 function migrateV12ToV13(db: Database): void {
+  const existing = getTableColumnSet(db, 'agent_runs');
+  const columnAdds: Array<[string, string]> = [
+    ['runtime', 'TEXT'],
+    ['provider', 'TEXT'],
+    ['model', 'TEXT'],
+    ['session_ref', 'TEXT'],
+    ['resumable', 'INTEGER DEFAULT 0'],
+    ['resume_status', 'TEXT'],
+    ['resume_mode', 'TEXT'],
+    ['resumed_at', 'INTEGER'],
+    ['checkpoints', 'TEXT'],
+    ['usage_data', 'TEXT'],
+  ];
+  const pendingAdds = columnAdds.filter(([name]) => !existing.has(name));
+
   db.exec('BEGIN');
   try {
-    const alterStatements = [
-      `ALTER TABLE agent_runs ADD COLUMN runtime TEXT`,
-      `ALTER TABLE agent_runs ADD COLUMN provider TEXT`,
-      `ALTER TABLE agent_runs ADD COLUMN model TEXT`,
-      `ALTER TABLE agent_runs ADD COLUMN session_ref TEXT`,
-      `ALTER TABLE agent_runs ADD COLUMN resumable INTEGER DEFAULT 0`,
-      `ALTER TABLE agent_runs ADD COLUMN resume_status TEXT`,
-      `ALTER TABLE agent_runs ADD COLUMN resume_mode TEXT`,
-      `ALTER TABLE agent_runs ADD COLUMN resumed_at INTEGER`,
-      `ALTER TABLE agent_runs ADD COLUMN checkpoints TEXT`,
-      `ALTER TABLE agent_runs ADD COLUMN usage_data TEXT`,
-    ];
-
-    for (const stmt of alterStatements) {
-      try {
-        db.exec(stmt);
-      } catch {
-        // Column already exists -- safe to ignore on re-run
-      }
+    for (const [name, decl] of pendingAdds) {
+      db.exec(`ALTER TABLE agent_runs ADD COLUMN ${name} ${decl}`);
     }
 
     const newIndexes = [
@@ -296,21 +304,19 @@ function migrateV12ToV13(db: Database): void {
  * part of team sync / outbox payloads.
  */
 function migrateV13ToV14(db: Database): void {
+  const existing = getTableColumnSet(db, 'agent_runs');
+  const columnAdds: Array<[string, string]> = [
+    ['actual_cost_usd', 'REAL'],
+    ['estimated_cost_usd', 'REAL'],
+    ['cost_source', 'TEXT'],
+    ['cost_data', 'TEXT'],
+  ];
+  const pendingAdds = columnAdds.filter(([name]) => !existing.has(name));
+
   db.exec('BEGIN');
   try {
-    const alterStatements = [
-      `ALTER TABLE agent_runs ADD COLUMN actual_cost_usd REAL`,
-      `ALTER TABLE agent_runs ADD COLUMN estimated_cost_usd REAL`,
-      `ALTER TABLE agent_runs ADD COLUMN cost_source TEXT`,
-      `ALTER TABLE agent_runs ADD COLUMN cost_data TEXT`,
-    ];
-
-    for (const statement of alterStatements) {
-      try {
-        db.exec(statement);
-      } catch {
-        // Column already exists -- safe to ignore on re-run
-      }
+    for (const [name, decl] of pendingAdds) {
+      db.exec(`ALTER TABLE agent_runs ADD COLUMN ${name} ${decl}`);
     }
 
     db.prepare(

--- a/packages/myco/src/db/queries/runs.ts
+++ b/packages/myco/src/db/queries/runs.ts
@@ -233,41 +233,39 @@ function buildRunsWhere(
   };
 }
 
-function buildUpdateClauses(update: RunUpdate): { setClauses: string[]; params: unknown[] } {
-  const mappings: Array<{ key: keyof RunUpdate; column: string }> = [
-    { key: 'status', column: 'status' },
-    { key: 'runtime', column: 'runtime' },
-    { key: 'provider', column: 'provider' },
-    { key: 'model', column: 'model' },
-    { key: 'session_ref', column: 'session_ref' },
-    { key: 'started_at', column: 'started_at' },
-    { key: 'resumable', column: 'resumable' },
-    { key: 'resume_status', column: 'resume_status' },
-    { key: 'resume_mode', column: 'resume_mode' },
-    { key: 'resumed_at', column: 'resumed_at' },
-    { key: 'checkpoints', column: 'checkpoints' },
-    { key: 'usage_data', column: 'usage_data' },
-    { key: 'completed_at', column: 'completed_at' },
-    { key: 'tokens_used', column: 'tokens_used' },
-    { key: 'cost_usd', column: 'cost_usd' },
-    { key: 'actual_cost_usd', column: 'actual_cost_usd' },
-    { key: 'estimated_cost_usd', column: 'estimated_cost_usd' },
-    { key: 'cost_source', column: 'cost_source' },
-    { key: 'cost_data', column: 'cost_data' },
-    { key: 'actions_taken', column: 'actions_taken' },
-    { key: 'error', column: 'error' },
-  ];
+const UPDATE_COLUMNS: readonly (keyof RunUpdate)[] = [
+  'status',
+  'runtime',
+  'provider',
+  'model',
+  'session_ref',
+  'started_at',
+  'resumable',
+  'resume_status',
+  'resume_mode',
+  'resumed_at',
+  'checkpoints',
+  'usage_data',
+  'completed_at',
+  'tokens_used',
+  'cost_usd',
+  'actual_cost_usd',
+  'estimated_cost_usd',
+  'cost_source',
+  'cost_data',
+  'actions_taken',
+  'error',
+];
 
+function buildUpdateClauses(update: RunUpdate): { setClauses: string[]; params: unknown[] } {
   const setClauses: string[] = [];
   const params: unknown[] = [];
-
-  for (const { key, column } of mappings) {
-    if (key in update) {
+  for (const column of UPDATE_COLUMNS) {
+    if (column in update) {
       setClauses.push(`${column} = ?`);
-      params.push(update[key]);
+      params.push(update[column]);
     }
   }
-
   return { setClauses, params };
 }
 
@@ -362,19 +360,28 @@ export function countRuns(
   return row.count;
 }
 
-export function updateRun(id: string, update: RunUpdate): RunRow | null {
-  const db = getDatabase();
+/**
+ * Apply a run update without re-SELECTing the row. Returns the number of
+ * changed rows. Use this in hot write paths (checkpoint persistence,
+ * in-run cost updates) where the caller does not need the updated row.
+ */
+export function applyRunUpdate(id: string, update: RunUpdate): number {
   const { setClauses, params } = buildUpdateClauses(update);
-  if (setClauses.length === 0) return getRun(id);
-
+  if (setClauses.length === 0) return 0;
   params.push(id);
-  const info = db.prepare(
+  const info = getDatabase().prepare(
     `UPDATE agent_runs
      SET ${setClauses.join(', ')}
      WHERE id = ?`,
   ).run(...params);
+  return info.changes;
+}
 
-  if (info.changes === 0) return null;
+export function updateRun(id: string, update: RunUpdate): RunRow | null {
+  const { setClauses } = buildUpdateClauses(update);
+  if (setClauses.length === 0) return getRun(id);
+  const changes = applyRunUpdate(id, update);
+  if (changes === 0) return null;
   return getRun(id);
 }
 

--- a/packages/myco/src/db/schema-ddl.ts
+++ b/packages/myco/src/db/schema-ddl.ts
@@ -569,6 +569,8 @@ export const SECONDARY_INDEXES = [
   'CREATE INDEX IF NOT EXISTS idx_agent_runs_status ON agent_runs (status)',
   'CREATE INDEX IF NOT EXISTS idx_agent_runs_agent_status ON agent_runs (agent_id, status)',
   'CREATE INDEX IF NOT EXISTS idx_agent_runs_task_completed ON agent_runs (task, status, completed_at)',
+  'CREATE INDEX IF NOT EXISTS idx_agent_runs_task_status_started_at ON agent_runs (task, status, started_at)',
+  'CREATE INDEX IF NOT EXISTS idx_agent_runs_resumable_task ON agent_runs (task, resumable, completed_at)',
 
   // Agent reports
   'CREATE INDEX IF NOT EXISTS idx_agent_reports_run_id ON agent_reports (run_id)',

--- a/packages/myco/src/intelligence/local-openai-backends.ts
+++ b/packages/myco/src/intelligence/local-openai-backends.ts
@@ -60,7 +60,7 @@ const LOCAL_BACKEND_DEFINITIONS: Record<LocalOpenAIBackendKind, LocalBackendDefi
   },
 };
 
-function tryParseUrl(value: string | undefined): URL | null {
+export function tryParseUrl(value: string | undefined): URL | null {
   if (!value) return null;
   try {
     return new URL(value);

--- a/packages/myco/ui/src/components/agent/RunDetail.tsx
+++ b/packages/myco/ui/src/components/agent/RunDetail.tsx
@@ -10,6 +10,8 @@ import { cn } from '../../lib/cn';
 import { formatEpochRelative, truncate, capitalize } from '../../lib/format';
 import { formatCost, formatTokens, formatDuration, resolveTaskName } from './helpers';
 import { PhaseTimeline, type PhaseResult } from './PhaseTimeline';
+import type { CostResolution } from '@myco/agent/cost/types';
+import type { RuntimeTokenBudget } from '@myco/agent/types';
 
 /* ---------- Constants ---------- */
 
@@ -42,7 +44,7 @@ function truncatePreview(text: string | null, limit: number): string {
   return truncate(text, limit) || '\u2014';
 }
 
-function formatBudgetSource(source: ParsedUsageData['runBudget']['contextWindowSource']): string {
+function formatBudgetSource(source: RuntimeTokenBudget['contextWindowSource'] | undefined): string {
   if (!source) return '\u2014';
   switch (source) {
     case 'provider-config':
@@ -65,29 +67,7 @@ function parseJson<T>(raw: string | null | undefined): T | null {
   }
 }
 
-interface ParsedCostData {
-  source: 'actual' | 'estimated' | 'unavailable';
-  costUsd: number | null;
-  actualCostUsd: number | null;
-  estimatedCostUsd: number | null;
-  pricingVersion?: string | null;
-  message?: string | null;
-  breakdown: {
-    inputTokens: number;
-    cachedInputTokens: number;
-    uncachedInputTokens: number;
-    outputTokens: number;
-    reasoningTokens: number;
-    requestCount: number;
-    inputCostUsd?: number;
-    cachedInputCostUsd?: number;
-    outputCostUsd?: number;
-    reasoningCostUsd?: number;
-    requestCostUsd?: number;
-    totalCostUsd?: number;
-    cacheSavingsUsd?: number;
-  };
-}
+type ParsedCostData = CostResolution;
 
 interface ParsedUsageData {
   run?: {
@@ -98,17 +78,16 @@ interface ParsedUsageData {
     cachedTokens?: number;
     requests?: number;
   };
-  runBudget?: {
-    contextWindowTokens: number | null;
-    contextWindowSource?: 'provider-config' | 'provider-metadata' | 'provider-default';
-    peakRequestInputTokens: number | null;
-    peakRequestOutputTokens: number | null;
-    peakRequestTotalTokens: number | null;
-    utilizationPercent: number | null;
-    headroomTokens: number | null;
-    status: 'unknown' | 'ok' | 'warning' | 'critical';
-    message?: string;
-  };
+  runBudget?: RuntimeTokenBudget;
+}
+
+function StatTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md bg-surface-container-lowest px-3 py-2">
+      <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">{label}</p>
+      <p className="font-mono text-sm text-on-surface">{value}</p>
+    </div>
+  );
 }
 
 /* ---------- Sub-components ---------- */
@@ -360,30 +339,12 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
             Cost Diagnostics
           </h2>
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
-            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
-              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Input</p>
-              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedCost?.breakdown.inputTokens ?? parsedUsage?.run?.inputTokens ?? null)}</p>
-            </div>
-            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
-              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Cached Input</p>
-              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedCost?.breakdown.cachedInputTokens ?? parsedUsage?.run?.cachedTokens ?? null)}</p>
-            </div>
-            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
-              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Uncached Input</p>
-              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedCost?.breakdown.uncachedInputTokens ?? null)}</p>
-            </div>
-            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
-              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Output</p>
-              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedCost?.breakdown.outputTokens ?? parsedUsage?.run?.outputTokens ?? null)}</p>
-            </div>
-            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
-              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Requests</p>
-              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedCost?.breakdown.requestCount ?? parsedUsage?.run?.requests ?? null)}</p>
-            </div>
-            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
-              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Cache Savings</p>
-              <p className="font-mono text-sm text-on-surface">{formatCost(parsedCost?.breakdown.cacheSavingsUsd ?? null, 'estimated')}</p>
-            </div>
+            <StatTile label="Input" value={formatTokens(parsedCost?.breakdown.inputTokens ?? parsedUsage?.run?.inputTokens ?? null)} />
+            <StatTile label="Cached Input" value={formatTokens(parsedCost?.breakdown.cachedInputTokens ?? parsedUsage?.run?.cachedTokens ?? null)} />
+            <StatTile label="Uncached Input" value={formatTokens(parsedCost?.breakdown.uncachedInputTokens ?? null)} />
+            <StatTile label="Output" value={formatTokens(parsedCost?.breakdown.outputTokens ?? parsedUsage?.run?.outputTokens ?? null)} />
+            <StatTile label="Requests" value={formatTokens(parsedCost?.breakdown.requestCount ?? parsedUsage?.run?.requests ?? null)} />
+            <StatTile label="Cache Savings" value={formatCost(parsedCost?.breakdown.cacheSavingsUsd ?? null, 'estimated')} />
           </div>
           {parsedCost?.message && (
             <p className="font-sans text-xs text-on-surface-variant">{parsedCost.message}</p>
@@ -397,32 +358,12 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
             Token Budget
           </h2>
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
-            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
-              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Context Window</p>
-              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedUsage.runBudget.contextWindowTokens)}</p>
-            </div>
-            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
-              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Peak Request</p>
-              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedUsage.runBudget.peakRequestTotalTokens)}</p>
-            </div>
-            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
-              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Peak Input</p>
-              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedUsage.runBudget.peakRequestInputTokens)}</p>
-            </div>
-            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
-              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Peak Output</p>
-              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedUsage.runBudget.peakRequestOutputTokens)}</p>
-            </div>
-            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
-              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Budget Used</p>
-              <p className="font-mono text-sm text-on-surface">
-                {parsedUsage.runBudget.utilizationPercent != null ? `${parsedUsage.runBudget.utilizationPercent}%` : '\u2014'}
-              </p>
-            </div>
-            <div className="rounded-md bg-surface-container-lowest px-3 py-2">
-              <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">Headroom</p>
-              <p className="font-mono text-sm text-on-surface">{formatTokens(parsedUsage.runBudget.headroomTokens)}</p>
-            </div>
+            <StatTile label="Context Window" value={formatTokens(parsedUsage.runBudget.contextWindowTokens)} />
+            <StatTile label="Peak Request" value={formatTokens(parsedUsage.runBudget.peakRequestTotalTokens)} />
+            <StatTile label="Peak Input" value={formatTokens(parsedUsage.runBudget.peakRequestInputTokens)} />
+            <StatTile label="Peak Output" value={formatTokens(parsedUsage.runBudget.peakRequestOutputTokens)} />
+            <StatTile label="Budget Used" value={parsedUsage.runBudget.utilizationPercent != null ? `${parsedUsage.runBudget.utilizationPercent}%` : '\u2014'} />
+            <StatTile label="Headroom" value={formatTokens(parsedUsage.runBudget.headroomTokens)} />
           </div>
           <div className="flex items-center gap-3 px-1">
             <span className="font-sans text-xs text-on-surface-variant">

--- a/packages/myco/ui/src/components/agent/TaskProviderConfig.tsx
+++ b/packages/myco/ui/src/components/agent/TaskProviderConfig.tsx
@@ -14,6 +14,7 @@ import {
 } from '../ui/select';
 import { SearchableSelect } from '../ui/searchable-select';
 import { ProviderModelSelector } from '../providers/ProviderModelSelector';
+import { ReasoningProfiles } from '../providers/ReasoningProfiles';
 import {
   defaultBaseUrlForProvider,
   useProviders,
@@ -327,7 +328,7 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
 
     // Build schedule payload: only include fields the user has overridden
     const schedulePayload = schedule
-      ? (Object.keys(scheduleOverride).length > 0 ? { schedule: scheduleOverride } : { schedule: null as unknown as ScheduleOverride })
+      ? (Object.keys(scheduleOverride).length > 0 ? { schedule: scheduleOverride } : { schedule: null })
       : {};
 
     // Build params payload: only include if task declares params
@@ -341,9 +342,9 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
         config: {
           runtime: effectiveRuntime as 'claude-sdk' | 'openai-agents',
           provider,
-          ...(maxTurns ? { maxTurns: Number(maxTurns) } : { maxTurns: null as unknown as number }),
-          ...(timeoutSeconds ? { timeoutSeconds: Number(timeoutSeconds) } : { timeoutSeconds: null as unknown as number }),
-          ...(Object.keys(phaseOverrides).length > 0 ? { phases: phaseOverrides } : { phases: null as unknown as Record<string, PhaseOverride> }),
+          maxTurns: maxTurns ? Number(maxTurns) : null,
+          timeoutSeconds: timeoutSeconds ? Number(timeoutSeconds) : null,
+          phases: Object.keys(phaseOverrides).length > 0 ? phaseOverrides : null,
           ...schedulePayload,
           ...paramsPayload,
         },
@@ -371,14 +372,14 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
       {
         taskId,
         config: {
-          runtime: null as unknown as 'claude-sdk' | 'openai-agents',
-          provider: null as unknown as ProviderConfig,
-          model: null as unknown as string,
-          maxTurns: null as unknown as number,
-          timeoutSeconds: null as unknown as number,
-          phases: null as unknown as Record<string, PhaseOverride>,
-          schedule: null as unknown as ScheduleOverride,
-          params: null as unknown as Record<string, string | number | boolean>,
+          runtime: null,
+          provider: null,
+          model: null,
+          maxTurns: null,
+          timeoutSeconds: null,
+          phases: null,
+          schedule: null,
+          params: null,
         },
       },
       {
@@ -442,59 +443,19 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
       />
 
       {providerType !== '' && (
-        <div className="space-y-3 rounded-md border border-[var(--ghost-border)] bg-surface-container-lowest p-3">
-          <div>
-            <p className="font-sans text-xs text-on-surface-variant uppercase tracking-wide">Reasoning Profiles</p>
-            <p className="font-sans text-xs text-on-surface-variant/80 mt-1">
-              Built-in task reasoning levels resolve through these task-level model mappings before falling back to the inherited defaults.
-            </p>
-          </div>
-          {([
-            ['low', 'Reasoning Low', reasoningLow],
-            ['default', 'Reasoning Default', reasoningDefault],
-            ['high', 'Reasoning High', reasoningHigh],
-          ] as const).map(([level, label, value]) => {
-            const placeholder = resolveReasoningModel(
-              level,
-              {
-                model: model || undefined,
-                reasoning_map: {
-                  ...(reasoningLow ? { low: reasoningLow } : {}),
-                  ...(reasoningDefault ? { default: reasoningDefault } : {}),
-                  ...(reasoningHigh ? { high: reasoningHigh } : {}),
-                },
-              },
-              defaults?.reasoningMap?.[level] ?? defaults?.model,
-            );
-
-            return (
-              <div key={level} className="space-y-1">
-                <label className="font-sans text-xs text-on-surface-variant">{label}</label>
-                {reasoningModels.length > 0 ? (
-                  <SearchableSelect
-                    value={value}
-                    onValueChange={(next) => { handleDraftReasoningChange(level, next); }}
-                    placeholder={placeholder || 'Use inherited model'}
-                    searchPlaceholder="Search models..."
-                    emptyMessage="No models match that search."
-                    options={reasoningModels.map((candidate) => ({
-                      value: candidate,
-                      label: candidate,
-                    }))}
-                    sortOptions
-                    monospace
-                  />
-                ) : (
-                  <Input
-                    value={value}
-                    onChange={(e) => { handleDraftReasoningChange(level, e.target.value); }}
-                    placeholder={placeholder || 'Use inherited model'}
-                  />
-                )}
-              </div>
-            );
-          })}
-        </div>
+        <ReasoningProfiles
+          description="Built-in task reasoning levels resolve through these task-level model mappings before falling back to the inherited defaults."
+          values={{
+            low: reasoningLow,
+            default: reasoningDefault,
+            high: reasoningHigh,
+          }}
+          onChange={handleDraftReasoningChange}
+          models={reasoningModels}
+          fallbackModel={model || defaults?.model}
+          fallbackReasoningMap={defaults?.reasoningMap}
+          placeholderWhenEmpty="Use inherited model"
+        />
       )}
 
       {/* Task-level maxTurns + timeout */}

--- a/packages/myco/ui/src/components/providers/ReasoningProfiles.tsx
+++ b/packages/myco/ui/src/components/providers/ReasoningProfiles.tsx
@@ -49,9 +49,16 @@ export function ReasoningProfiles({
       </div>
       {LEVELS.map(([level, label]) => {
         const value = values[level];
+        // Precedence for placeholder:
+        //   this scope's reasoning_map[level]  (values[level], held in reasoningMap)
+        //     -> inherited per-level fallback  (fallbackReasoningMap[level])
+        //       -> generic fallback model      (fallbackModel)
+        // Do NOT pass `model: fallbackModel` into the provider — that would
+        // short-circuit the per-level fallback since resolveReasoningModel
+        // prefers provider.model over its fallbackModel argument.
         const placeholder = resolveReasoningModel(
           level,
-          { model: fallbackModel || undefined, reasoning_map: reasoningMap },
+          { reasoning_map: reasoningMap },
           fallbackReasoningMap?.[level] ?? fallbackModel,
         );
         const resolvedPlaceholder = placeholder || placeholderWhenEmpty;

--- a/packages/myco/ui/src/components/providers/ReasoningProfiles.tsx
+++ b/packages/myco/ui/src/components/providers/ReasoningProfiles.tsx
@@ -1,0 +1,84 @@
+import { Input } from '../ui/input';
+import { SearchableSelect } from '../ui/searchable-select';
+import { resolveReasoningModel } from '../../hooks/use-providers';
+
+export type ReasoningLevel = 'low' | 'default' | 'high';
+
+const LEVELS: ReadonlyArray<readonly [ReasoningLevel, string]> = [
+  ['low', 'Reasoning Low'],
+  ['default', 'Reasoning Default'],
+  ['high', 'Reasoning High'],
+];
+
+export interface ReasoningProfilesProps {
+  description: string;
+  values: Record<ReasoningLevel, string>;
+  onChange: (level: ReasoningLevel, value: string) => void;
+  models: string[];
+  fallbackModel?: string;
+  fallbackReasoningMap?: Partial<Record<ReasoningLevel, string>>;
+  placeholderWhenEmpty?: string;
+}
+
+/**
+ * Reasoning profile editor (low / default / high model selections).
+ * Shared between the global Agent Provider settings card and per-task
+ * TaskProviderConfig override. The calling component controls the draft
+ * state; this component only renders the fields.
+ */
+export function ReasoningProfiles({
+  description,
+  values,
+  onChange,
+  models,
+  fallbackModel,
+  fallbackReasoningMap,
+  placeholderWhenEmpty = 'Use default model',
+}: ReasoningProfilesProps) {
+  const reasoningMap = {
+    ...(values.low ? { low: values.low } : {}),
+    ...(values.default ? { default: values.default } : {}),
+    ...(values.high ? { high: values.high } : {}),
+  };
+
+  return (
+    <div className="space-y-3 rounded-md border border-[var(--ghost-border)] bg-surface-container-lowest p-3">
+      <div>
+        <p className="font-sans text-xs text-on-surface-variant uppercase tracking-wide">Reasoning Profiles</p>
+        <p className="font-sans text-xs text-on-surface-variant/80 mt-1">{description}</p>
+      </div>
+      {LEVELS.map(([level, label]) => {
+        const value = values[level];
+        const placeholder = resolveReasoningModel(
+          level,
+          { model: fallbackModel || undefined, reasoning_map: reasoningMap },
+          fallbackReasoningMap?.[level] ?? fallbackModel,
+        );
+        const resolvedPlaceholder = placeholder || placeholderWhenEmpty;
+        return (
+          <div key={level} className="space-y-1">
+            <label className="font-sans text-xs text-on-surface-variant">{label}</label>
+            {models.length > 0 ? (
+              <SearchableSelect
+                value={value}
+                onValueChange={(next) => onChange(level, next)}
+                placeholder={resolvedPlaceholder}
+                searchPlaceholder="Search models..."
+                emptyMessage="No models match that search."
+                options={models.map((candidate) => ({ value: candidate, label: candidate }))}
+                sortOptions
+                monospace
+              />
+            ) : (
+              <Input
+                value={value}
+                onChange={(e) => onChange(level, e.target.value)}
+                placeholder={resolvedPlaceholder}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/myco/ui/src/hooks/use-provider-config-draft.ts
+++ b/packages/myco/ui/src/hooks/use-provider-config-draft.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   defaultBaseUrlForProvider,
   draftToProviderConfig,
@@ -186,10 +186,15 @@ export function useProviderConfigDraft({
   );
   const [savedDraft, setSavedDraft] = useState<ProviderDraft>(sourceDraft);
   const [draft, setDraft] = useState<ProviderDraft>(sourceDraft);
+  const savedDraftRef = useRef(savedDraft);
+  savedDraftRef.current = savedDraft;
 
   useEffect(() => {
     setSavedDraft(sourceDraft);
-    setDraft(sourceDraft);
+    // Only overwrite the user's working draft if they haven't made edits since
+    // the last sync. Otherwise a parent refetch would silently wipe in-flight
+    // field changes.
+    setDraft((prev) => providerDraftsEqual(prev, savedDraftRef.current) ? sourceDraft : prev);
   }, [sourceDraft]);
 
   const isDirty = !providerDraftsEqual(draft, savedDraft);

--- a/packages/myco/ui/src/hooks/use-providers.ts
+++ b/packages/myco/ui/src/hooks/use-providers.ts
@@ -71,6 +71,10 @@ export interface ProviderDraft {
   contextLength: string;
 }
 
+// Canonical defaults live server-side (OllamaBackend.DEFAULT_BASE_URL,
+// LmStudioBackend.DEFAULT_BASE_URL). Mirrored here so the UI can suggest
+// a default without waiting for the /providers round trip when the user
+// switches local_backend. Keep in sync with the server constants.
 export const LOCAL_BACKEND_DEFAULT_BASE_URLS = {
   ollama: 'http://localhost:11434',
   lmstudio: 'http://localhost:1234',
@@ -223,9 +227,14 @@ export interface TestProviderResponse {
   error?: string;
 }
 
+/** Patch shape: each field is optional and may be `null` to clear the override. */
+export type TaskConfigPatch = {
+  [K in keyof TaskConfigOverride]?: TaskConfigOverride[K] | null;
+};
+
 export interface UpdateTaskConfigPayload {
   taskId: string;
-  config: Partial<TaskConfigOverride> & { [key: string]: unknown };
+  config: TaskConfigPatch;
 }
 
 /* ---------- Hooks ---------- */

--- a/packages/myco/ui/src/pages/Settings.tsx
+++ b/packages/myco/ui/src/pages/Settings.tsx
@@ -47,6 +47,7 @@ import { RestartGateProvider, RestartBanner } from '../components/config/restart
 import { useScopedConfig } from '../hooks/use-scoped-config';
 import { NotificationSettings } from '../components/notifications/NotificationSettings';
 import { ProviderModelSelector } from '../components/providers/ProviderModelSelector';
+import { ReasoningProfiles } from '../components/providers/ReasoningProfiles';
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 type Provider = 'ollama' | 'openai-compatible';
@@ -317,60 +318,18 @@ function AgentProviderCard() {
       />
 
       {supportsReasoningMap && (
-        <div className="space-y-3 rounded-md border border-[var(--ghost-border)] bg-surface-container-lowest p-3">
-          <div>
-            <p className="font-sans text-xs text-on-surface-variant uppercase tracking-wide">Reasoning Profiles</p>
-            <p className="font-sans text-xs text-on-surface-variant/80 mt-1">
-              Built-in tasks resolve `low`, `default`, and `high` reasoning phases through these model mappings.
-            </p>
-          </div>
-          {([
-            ['low', 'Reasoning Low'],
-            ['default', 'Reasoning Default'],
-            ['high', 'Reasoning High'],
-          ] as const).map(([level, label]) => {
-            const value = level === 'low'
-              ? draft.reasoningLow
-              : level === 'default'
-                ? draft.reasoningDefault
-                : draft.reasoningHigh;
-            const setValue = (next: string) => handleReasoningChange(level, next);
-            const placeholder = resolveReasoningModel(level, {
-              model: draft.model || undefined,
-              reasoning_map: {
-                ...(draft.reasoningLow ? { low: draft.reasoningLow } : {}),
-                ...(draft.reasoningDefault ? { default: draft.reasoningDefault } : {}),
-                ...(draft.reasoningHigh ? { high: draft.reasoningHigh } : {}),
-              },
-            }, draft.model);
-            return (
-              <div key={level} className="space-y-1">
-                <label className="font-sans text-xs text-on-surface-variant">{label}</label>
-                {reasoningModels.length > 0 ? (
-                  <SearchableSelect
-                    value={value}
-                    onValueChange={setValue}
-                    placeholder={placeholder || 'Use default model'}
-                    searchPlaceholder="Search models..."
-                    emptyMessage="No models match that search."
-                    options={reasoningModels.map((candidate) => ({
-                      value: candidate,
-                      label: candidate,
-                    }))}
-                    sortOptions
-                    monospace
-                  />
-                ) : (
-                  <Input
-                    value={value}
-                    onChange={(e) => setValue(e.target.value)}
-                    placeholder={placeholder || 'Use default model'}
-                  />
-                )}
-              </div>
-            );
-          })}
-        </div>
+        <ReasoningProfiles
+          description="Built-in tasks resolve `low`, `default`, and `high` reasoning phases through these model mappings."
+          values={{
+            low: draft.reasoningLow,
+            default: draft.reasoningDefault,
+            high: draft.reasoningHigh,
+          }}
+          onChange={handleReasoningChange}
+          models={reasoningModels}
+          fallbackModel={draft.model}
+          placeholderWhenEmpty="Use default model"
+        />
       )}
 
       {secretProvider && (


### PR DESCRIPTION
## Summary

Quality review + fixes on all code merged into `main` since the last `myco` release (`myco/v0.20.2`) — PRs #86 (multi-runtime agent execution and resume), #87 (session-materialization gating), and #88 (RuntimeTokenBudget). Goal: land targeted correctness, performance, reuse, and type-safety fixes before tagging a new release.

**23 files changed, +440 / −476 lines** (net reduction; duplication removal outweighs additions).

- ✅ `npm run lint` (tsc --noEmit) clean
- ✅ `npm test` — **2468 passed, 3 skipped, 0 failed**
- ✅ Integration profile — **74 passed**
- ✅ `npm run build` — all 3 packages + UI bundle built
- ✅ Live daemon smoke: `/api/providers`, `/api/providers/test` (validator error message driven by `PROVIDER_TYPES.join`), `/api/providers/secrets`, `POST /events` (drop-cache behavior verified — 3 events → 1 rule-eval), `/api/agent/runs` (new explicit-pick serializer shape)
- ✅ Migration smoke on a fresh DB: reaches schema v14, all new columns present, `createSchema` idempotent under re-run

## What's in here

### Correctness / safety
- **`runtime/claude.ts`** — Collapsed the two colliding `mcpServers` / `tools` ternaries into a single conditional spread. Replaced hand-rolled `Claude{Assistant,User,Result}Message` interfaces with the SDK's `SDKMessage` discriminated union.
- **`ui/hooks/use-provider-config-draft.ts`** — Effect now preserves in-flight user edits across parent refetches (only overwrites draft when it equals the last `savedDraft`).
- **`db/migrations.ts`** — Replaced `try { ALTER } catch {}` inside `BEGIN/COMMIT` with PRAGMA-based idempotency via a new `getTableColumnSet` helper. Removes the latent poison-transaction risk.
- **`run-accounting.ts`** — Replaced `message` spread-then-overwrite with an explicit `resolveMessage` block; precedence is now obvious.
- **`db/schema-ddl.ts`** — 🔧 Surfaced during smoke testing: baseline DDL was missing two indexes (`idx_agent_runs_task_status_started_at`, `idx_agent_runs_resumable_task`) that the v13 migration adds. Fresh DBs silently missed them; migrated DBs had them. Added to baseline so both paths match.

### Performance
- **`daemon/event-dispatch.ts`** — Cache drop decisions by `session_id` (bounded 1024-entry FIFO) so a rejected session firing repeat events doesn't re-read up to 128 KB of transcript each time.
- **`run-accounting.ts`** — Fused three `reduce` passes into a single loop (O(3N) → O(N)).
- **`db/queries/runs.ts`** — New `applyRunUpdate` void variant skips the post-write re-SELECT; used in the hot checkpoint-persist path. Roughly halves SQLite round trips per tick.
- **`cost/openrouter.ts`** — Prune expired catalog cache entries on miss (Map was unbounded).
- **`daemon/api/provider-secrets.ts`** — Read `.myco/secrets.env` once per GET instead of twice.
- **`executor.ts`** — Dropped redundant `logTokenBudgetPressure` calls (was invoked 3× per run).

### Reuse / duplication
- Exported `DEFAULT_OPENAI_URL` / `OPENROUTER_URL` / `OLLAMA_URL` / `LMSTUDIO_URL` from `provider.ts`; `runtime/openai.ts` and `daemon/api/providers.ts` now consume them instead of repeating literals.
- Exported `tryParseUrl` from `local-openai-backends.ts`; removed the duplicate in `runtime/openai.ts`.
- `cost/openai.ts` — Flat `OPENAI_PRICING` dict replaces the three-entry `{matches, pricing}` rule array.
- `ui/RunDetail.tsx` — Deleted `ParsedCostData` / `ParsedUsageData` duplicates; imports `CostResolution` + `RuntimeTokenBudget` from `@myco/agent`.
- `ui/RunDetail.tsx` — Extracted `<StatTile>`; Cost Diagnostics + Token Budget grids collapsed from ~80 duplicated lines to two arrays.
- New `ui/components/providers/ReasoningProfiles.tsx` — Shared by `Settings.tsx` and `TaskProviderConfig.tsx` (deletes ~55 lines of copy-paste).

### Type safety
- **`agent/types.ts`** — Added `PROVIDER_TYPES` runtime constant + `isProviderType` guard. `daemon/api/providers.ts` validates via the guard now — adding a new provider surfaces a compile error at the API validator rather than silently accepting.
- **`ui/hooks/use-providers.ts`** — Replaced the `Partial<TaskConfigOverride> & { [key: string]: unknown }` hack with an explicit `TaskConfigPatch` mapped type where each field is `T | null`. `TaskProviderConfig.tsx` drops 9 `null as unknown as T` casts.
- **`runtime/types.ts`** — Trimmed `RuntimeCapability` enum from 6 members to the 2 actually queried (`supportsSessionResume`, `supportsMcp`).

### Quality
- **`executor.ts`** — Removed the narrative file header and numbered-step comments (`// 1. Init DB`, `// 2. Concurrency guard`, etc.) that had already drifted — the `// 3.` step was missing at audit time.
- **`daemon/api/agent-runs.ts`** — Replaced `serializeRun`'s `{...row, resumable: bool}` spread-and-overwrite with an explicit field picker.
- **`executor.ts`** — Extracted shared `runStart` object for the insert vs resume branches (removed ~10 duplicated fields).

## Deferred with explicit reasons

- **`executor-state.ts` checkpoint fields** duplicate `agent_runs` row columns (`runtime` / `provider` / `model` / `sessionRef`). Slimming changes the persisted JSON shape and reconciliation logic — meaningful refactor, no correctness risk today.
- **`executor.ts` 11–14 param functions** — grouping into options objects is a broad cross-function change; better owned by a dedicated cleanup PR.
- **`prepareLocalProviderExecution` per-phase** — `ensureOllamaContextVariant` and `LmStudioBackend.ensureLoaded` both already cache, so per-phase cost is mostly a cache hit.
- **`LOCAL_BACKEND_DEFAULT_BASE_URLS` in the UI** — Added a comment marking it as a server-constant mirror rather than reworking the signature to consume `providers[]`.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 2468 passed
- [x] Integration profile — 74 passed
- [x] `npm run build` — all packages + UI bundle
- [x] Fresh DB migration smoke (schema v14, columns present, idempotent, indexes present)
- [x] Live daemon: `/api/providers`, `/api/providers/test` (valid + invalid), `/api/providers/secrets`
- [x] Live daemon event-dispatch drop-cache (3 events → 1 INFO log; 2nd/3rd hit cache)
- [x] Live daemon `serializeRun` output shape (inserted dummy row, verified 25 columns + `phase_checkpoints`, `resumable` as boolean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)