### PR TITLE
fix(claude-code): capture ultraplan plans from prompt tags

### DIFF
--- a/packages/myco/src/constants.ts
+++ b/packages/myco/src/constants.ts
@@ -173,6 +173,8 @@ export const EXCLUDED_SPORE_STATUSES = new Set(['superseded', 'archived']);
 // --- Agent identity ---
 /** Default agent ID for the built-in intelligence agent. */
 export const DEFAULT_AGENT_ID = 'myco-agent';
+/** Fallback symbiont name when hook events arrive without agent attribution. */
+export const DEFAULT_SYMBIONT_NAME = 'claude-code';
 /** Agent ID for user-initiated MCP operations. */
 export const USER_AGENT_ID = 'user';
 /** Agent name for user-initiated MCP operations. */

--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -16,7 +16,12 @@ import { PowerManager } from './power.js';
 import { DaemonLogger } from './logger.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import type { PlanWatchConfig } from './plan-capture.js';
-import { isPlanWriteEvent, capturePlan } from './plan-capture.js';
+import {
+  isPlanWriteEvent,
+  capturePlan,
+  extractTaggedPlans,
+  TRANSCRIPT_SOURCE_PREFIX,
+} from './plan-capture.js';
 import {
   isSystemMessage,
   handleUserPrompt,
@@ -31,7 +36,7 @@ import {
 import { getLatestBatch } from '@myco/db/queries/batches.js';
 import { upsertSession, reactivateSessionIfCompleted } from '@myco/db/queries/sessions.js';
 import { captureBatchImages, type CapturedImage } from './capture-images.js';
-import { epochSeconds, LOG_PROMPT_PREVIEW_CHARS } from '@myco/constants.js';
+import { DEFAULT_SYMBIONT_NAME, epochSeconds, LOG_PROMPT_PREVIEW_CHARS } from '@myco/constants.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { evaluateSessionCaptureRules } from '@myco/hooks/capture-rules.js';
 import { readTranscriptMeta } from '@myco/hooks/transcript-meta.js';
@@ -86,6 +91,9 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
 
   const projectRoot = process.cwd();
   const manifests = loadManifests();
+  const planTagsByAgent = new Map(
+    manifests.map((manifest) => [manifest.name, manifest.capture?.planTags ?? []] as const),
+  );
 
   // Cache drop decisions by session_id so a rejected session that keeps firing
   // events doesn't re-open + re-read (up to 128 KB) its transcript every time.
@@ -106,12 +114,17 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
       ? event.transcript_path
       : undefined;
     const transcriptMeta = transcriptPath ? readTranscriptMeta(transcriptPath) ?? undefined : undefined;
-    const detectedAgent = typeof event.agent === 'string' ? event.agent : 'claude-code';
+    const detectedAgent = typeof event.agent === 'string' ? event.agent : DEFAULT_SYMBIONT_NAME;
 
     return evaluateSessionCaptureRules(manifests, detectedAgent, {
       transcriptPath,
       transcriptMeta,
     });
+  }
+
+  function getPlanTagsForAgent(agent: unknown): string[] {
+    const agentName = typeof agent === 'string' && agent.length > 0 ? agent : DEFAULT_SYMBIONT_NAME;
+    return planTagsByAgent.get(agentName) ?? [];
   }
 
   return async (req) => {
@@ -154,7 +167,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
       const startedEpoch = Math.floor(new Date(event.timestamp).getTime() / 1000);
       upsertSession({
         id: event.session_id,
-        agent: (event as Record<string, unknown>).agent as string ?? 'claude-code',
+        agent: (event as Record<string, unknown>).agent as string ?? DEFAULT_SYMBIONT_NAME,
         status: 'active',
         started_at: startedEpoch,
         created_at: now,
@@ -203,6 +216,31 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
         try {
           const { batchId, promptNumber } = handleUserPrompt(event.session_id, promptText || undefined);
           logger.debug(LOG_KINDS.CAPTURE_BATCH, 'Batch opened', { session_id: event.session_id, batch_id: batchId, prompt_number: promptNumber });
+
+          const taggedPlans = extractTaggedPlans(promptText, getPlanTagsForAgent(event.agent));
+          for (const { tag, content } of taggedPlans) {
+            try {
+              // Reuse the tag-derived source key used by transcript extraction so
+              // prompt-injected and transcript-derived copies upsert rather than duplicate.
+              capturePlan({
+                sourcePath: `${TRANSCRIPT_SOURCE_PREFIX}${tag}`,
+                content,
+                sessionId: event.session_id,
+                promptBatchId: batchId,
+              });
+              logger.info(LOG_KINDS.CAPTURE_PLAN, 'Plan captured from prompt tag', {
+                session_id: event.session_id,
+                tag,
+                content_length: content.length,
+              });
+            } catch (err) {
+              logger.warn(LOG_KINDS.CAPTURE_PLAN, 'Failed to capture plan from prompt tag', {
+                session_id: event.session_id,
+                tag,
+                error: (err as Error).message,
+              });
+            }
+          }
 
           // Plugin-based symbionts (opencode) ship image attachments in the
           // user_prompt event payload rather than in an on-disk transcript.

--- a/packages/myco/src/symbionts/manifests/claude-code.yaml
+++ b/packages/myco/src/symbionts/manifests/claude-code.yaml
@@ -16,6 +16,10 @@ capture:
     # user-committed plans in the repo.
     - ~/.claude/plans/
     - .claude/plans/
+  planTags:
+    # Ultraplan sends the approved cloud plan back to the terminal by injecting
+    # it into the next user prompt as <ultraplan>...</ultraplan>.
+    - ultraplan
 registration:
   hooksTarget: .claude/settings.json
   mcpTarget: .mcp.json

--- a/tests/daemon/event-dispatch.test.ts
+++ b/tests/daemon/event-dispatch.test.ts
@@ -9,6 +9,8 @@ import { PowerManager } from '@myco/daemon/power.js';
 import { DaemonLogger } from '@myco/daemon/logger.js';
 import { getSession } from '@myco/db/queries/sessions.js';
 import { countActivities } from '@myco/db/queries/activities.js';
+import { listBatchesBySession } from '@myco/db/queries/batches.js';
+import { listPlansBySession } from '@myco/db/queries/plans.js';
 
 function makeHandler() {
   const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-event-dispatch-'));
@@ -34,7 +36,7 @@ function makeHandler() {
     liveConfig: { current: { agent: { summary_batch_interval: 20 } } as never },
     vaultDir,
     reconcileSession: () => {},
-    planWatchConfig: { enabled: false, planDirs: [] },
+    planWatchConfig: { watchDirs: [], projectRoot: vaultDir },
     triggerTitleSummary: async () => {},
   });
 
@@ -103,6 +105,54 @@ describe('createEventDispatcher', () => {
     expect(registry.getSession(sessionId)).toBeDefined();
     expect(getSession(sessionId)?.agent).toBe('codex');
     expect(countActivities(sessionId)).toBe(1);
+
+    logger.close();
+    fs.rmSync(vaultDir, { recursive: true, force: true });
+    fs.rmSync(transcriptDir, { recursive: true, force: true });
+  });
+
+  it('captures a Claude Ultraplan prompt tag into the session plans table', async () => {
+    const { handler, logger, vaultDir } = makeHandler();
+    const sessionId = 'claude-ultraplan-prompt-001';
+    const transcriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-claude-ultraplan-'));
+    const transcriptPath = path.join(transcriptDir, `${sessionId}.jsonl`);
+    const prompt = [
+      'Ultraplan approved in browser. Here is the plan:',
+      '',
+      '<ultraplan>',
+      '# Full-Intelligence Efficiency & Tuning Harness',
+      '',
+      '## Steps',
+      '1. Add dry-run harness',
+      '2. Add eval matrix',
+      '</ultraplan>',
+    ].join('\n');
+
+    const res = await handler({
+      body: {
+        type: 'user_prompt',
+        session_id: sessionId,
+        agent: 'claude-code',
+        transcript_path: transcriptPath,
+        prompt,
+      },
+      query: {},
+      params: {},
+      pathname: '/events',
+    });
+
+    expect(res.body).toEqual({ ok: true });
+
+    const batches = listBatchesBySession(sessionId);
+    expect(batches).toHaveLength(1);
+    expect(batches[0].user_prompt).toBe(prompt);
+
+    const plans = listPlansBySession(sessionId);
+    expect(plans).toHaveLength(1);
+    expect(plans[0].title).toBe('Full-Intelligence Efficiency & Tuning Harness');
+    expect(plans[0].prompt_batch_id).toBe(batches[0].id);
+    expect(plans[0].source_path).toBe('transcript:ultraplan');
+    expect(plans[0].content).toContain('Add dry-run harness');
 
     logger.close();
     fs.rmSync(vaultDir, { recursive: true, force: true });

--- a/tests/symbionts/manifest-schema.test.ts
+++ b/tests/symbionts/manifest-schema.test.ts
@@ -271,6 +271,12 @@ describe('symbiont manifests', () => {
     expect(manifest.capture?.planTags).toEqual(['proposed_plan']);
   });
 
+  it('claude-code manifest has planTags with ultraplan', () => {
+    const raw = fs.readFileSync(path.join(MANIFESTS_DIR, 'claude-code.yaml'), 'utf-8');
+    const manifest = SymbiontManifestSchema.parse(YAML.parse(raw));
+    expect(manifest.capture?.planTags).toEqual(['ultraplan']);
+  });
+
   it('defaults mcpFormat to json when not specified', () => {
     const manifest = SymbiontManifestSchema.parse({
       name: 'test-agent',


### PR DESCRIPTION
## Summary
Claude Code's new Ultraplan flow sends the approved plan back into the terminal as a tagged prompt payload instead of a normal assistant response. This change teaches Myco to capture those prompt-injected Claude plans using the existing tagged-plan pattern.

## Changes
- add `ultraplan` as a declarative Claude plan tag in the symbiont manifest
- capture tagged plans from `user_prompt` batches so Claude's prompt-injected Ultraplan payloads become session-linked plan rows immediately
- keep the existing stop-time transcript tag extraction path unchanged for Codex and other response-tag symbionts
- replace the new inline Claude fallback string usage with a shared `DEFAULT_SYMBIONT_NAME` constant
- add regression coverage for Claude prompt-tag capture and the Claude manifest plan-tag declaration

## Validation
- `npm run lint -- --pretty false`
- `npm test -- --run tests/daemon/event-dispatch.test.ts tests/daemon/plan-capture.test.ts tests/daemon/codex-plan-capture.test.ts tests/daemon/stop-processing.test.ts tests/symbionts/manifest-schema.test.ts`