### PR TITLE
security: pre-0.21.0 hardening — lock down remote-provider baseUrl + CSRF gate

### DIFF
--- a/packages/myco/src/agent/cost/openrouter.ts
+++ b/packages/myco/src/agent/cost/openrouter.ts
@@ -8,6 +8,9 @@ const OPENROUTER_MODELS_ENDPOINT = '/models';
 const OPENROUTER_CATALOG_CACHE_TTL_MS = 5 * 60 * 1000;
 const OPENROUTER_MODELS_TIMEOUT_MS = 5_000;
 const OPENROUTER_PRICING_VERSION = 'openrouter-model-catalog-live';
+/** Hard cap on catalog entries — prevents cache poisoning / OOM if the
+ *  upstream returns a hostile or corrupt response. */
+const OPENROUTER_CATALOG_MAX_ENTRIES = 10_000;
 
 interface OpenRouterPricing {
   inputUsdPerToken?: number;
@@ -92,9 +95,16 @@ async function fetchPricingCatalog(baseUrl?: string): Promise<Map<string, OpenRo
     throw new Error(`OpenRouter models request failed with ${response.status}`);
   }
 
-  const data = await response.json() as { data?: OpenRouterCatalogEntry[] };
+  const parsed = await response.json() as unknown;
+  if (!parsed || typeof parsed !== 'object' || !Array.isArray((parsed as { data?: unknown }).data)) {
+    throw new Error('OpenRouter catalog response missing data array');
+  }
+  const entries = (parsed as { data: OpenRouterCatalogEntry[] }).data;
+  if (entries.length > OPENROUTER_CATALOG_MAX_ENTRIES) {
+    throw new Error(`OpenRouter catalog exceeded ${OPENROUTER_CATALOG_MAX_ENTRIES} entries`);
+  }
   const pricingByModel = new Map<string, OpenRouterPricing>();
-  for (const entry of data.data ?? []) {
+  for (const entry of entries) {
     if (!entry.id || !entry.pricing) continue;
     pricingByModel.set(entry.id, {
       inputUsdPerToken: parseRate(entry.pricing.prompt),

--- a/packages/myco/src/agent/provider.ts
+++ b/packages/myco/src/agent/provider.ts
@@ -60,14 +60,14 @@ export function getProviderEnvVars(provider: ProviderConfig): Record<string, str
         [ENV_ANTHROPIC_API_KEY]: '',
       };
     case 'openai':
+      // Remote providers: baseUrl is hardcoded so the daemon's API key
+      // cannot be sent to a caller-supplied host. Key flows from env only.
       return {
-        OPENAI_BASE_URL: provider.baseUrl ?? DEFAULT_OPENAI_URL,
-        ...(provider.apiKey ? { OPENAI_API_KEY: provider.apiKey } : {}),
+        OPENAI_BASE_URL: DEFAULT_OPENAI_URL,
       };
     case 'openrouter':
       return {
-        OPENAI_BASE_URL: provider.baseUrl ?? DEFAULT_OPENROUTER_URL,
-        ...(provider.apiKey ? { OPENAI_API_KEY: provider.apiKey } : {}),
+        OPENAI_BASE_URL: DEFAULT_OPENROUTER_URL,
       };
     case 'openai-compatible':
       return {

--- a/packages/myco/src/agent/runtime/openai.ts
+++ b/packages/myco/src/agent/runtime/openai.ts
@@ -111,13 +111,17 @@ const PROVIDER_CLIENT_CONFIG_RESOLVERS: Record<ProviderConfig['type'], (provider
     apiKey: provider?.apiKey ?? PLACEHOLDER,
     baseURL: provider?.baseUrl ?? toOpenAIBaseUrl(getLocalOpenAIBackendDefaultBaseUrl('lmstudio')),
   }),
-  openai: (provider) => ({
-    apiKey: provider?.apiKey ?? process.env[OPENAI_API_KEY_ENV] ?? process.env.OPENAI_API_KEY,
-    baseURL: provider?.baseUrl ?? DEFAULT_OPENAI_URL,
+  // Remote providers: the API key must come from the daemon's env (loaded
+  // from .myco/secrets.env), never from a ProviderConfig. The baseURL is
+  // locked to the hardcoded default so the bearer key cannot follow a
+  // caller-supplied redirect.
+  openai: () => ({
+    apiKey: process.env[OPENAI_API_KEY_ENV] ?? process.env.OPENAI_API_KEY,
+    baseURL: DEFAULT_OPENAI_URL,
   }),
-  openrouter: (provider) => ({
-    apiKey: provider?.apiKey ?? process.env[OPENROUTER_API_KEY_ENV],
-    baseURL: provider?.baseUrl ?? DEFAULT_OPENROUTER_URL,
+  openrouter: () => ({
+    apiKey: process.env[OPENROUTER_API_KEY_ENV],
+    baseURL: DEFAULT_OPENROUTER_URL,
   }),
   'openai-compatible': (provider) => ({
     apiKey: provider?.apiKey ?? PLACEHOLDER,

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -45,6 +45,43 @@ export const AGENT_RUNS_DEFAULT_LIMIT = 50;
  * handler — keep changes in the shared module.
  */
 
+/**
+ * Strip caller-supplied `baseUrl` from remote-provider overrides so the
+ * daemon's stored OpenAI/OpenRouter key can never be sent to an
+ * attacker-controlled host. Local providers (ollama, lmstudio,
+ * openai-compatible) legitimately need custom base URLs.
+ */
+const REMOTE_PROVIDER_TYPES = new Set(['openai', 'openrouter']);
+
+function sanitizeProviderOverride<T extends { type?: string; baseUrl?: string } | undefined>(
+  override: T,
+): T {
+  if (!override) return override;
+  if (override.type && REMOTE_PROVIDER_TYPES.has(override.type)) {
+    const { baseUrl: _dropped, ...rest } = override;
+    return rest as T;
+  }
+  return override;
+}
+
+function sanitizeExecutionOverrides(
+  overrides: z.infer<typeof ExecutionOverrideBody>,
+): z.infer<typeof ExecutionOverrideBody> {
+  if (!overrides) return overrides;
+  const next = { ...overrides };
+  if (next.provider) next.provider = sanitizeProviderOverride(next.provider);
+  if (next.phases) {
+    const nextPhases: Record<string, typeof next.phases[string]> = {};
+    for (const [name, phase] of Object.entries(next.phases)) {
+      nextPhases[name] = phase.provider
+        ? { ...phase, provider: sanitizeProviderOverride(phase.provider) }
+        : phase;
+    }
+    next.phases = nextPhases;
+  }
+  return next;
+}
+
 const AgentRunBody = z.object({
   task: z.string().optional(),
   instruction: z.string().optional(),
@@ -93,8 +130,12 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
       agentId,
       dryRun,
       evaluationId,
-      executionOverrides,
+      executionOverrides: rawExecutionOverrides,
     } = AgentRunBody.parse(req.body);
+
+    // SSRF defense: strip caller-supplied baseUrl from any remote-provider
+    // override. The daemon's bearer key cannot follow a redirected URL.
+    const executionOverrides = sanitizeExecutionOverrides(rawExecutionOverrides);
 
     // Guard: ensure a provider is configured before allowing a run.
     // Uses the same per-task-over-global precedence as the executor's resolver.

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -19,6 +19,7 @@ import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { notify } from '@myco/notifications/notify.js';
 import { buildPhaseAudit } from '@myco/services/phase-audit.js';
 import { ExecutionOverrideBody } from './schemas/execution-overrides.js';
+import { transformProviderOverrides } from './schemas/execution-overrides-traversal.js';
 import { serializeRun } from './run-serializer.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 import type { EmbeddingManager } from '../embedding/manager.js';
@@ -53,33 +54,29 @@ export const AGENT_RUNS_DEFAULT_LIMIT = 50;
  */
 const REMOTE_PROVIDER_TYPES = new Set(['openai', 'openrouter']);
 
-function sanitizeProviderOverride<T extends { type?: string; baseUrl?: string } | undefined>(
-  override: T,
-): T {
-  if (!override) return override;
-  if (override.type && REMOTE_PROVIDER_TYPES.has(override.type)) {
-    const { baseUrl: _dropped, ...rest } = override;
-    return rest as T;
+function stripBaseUrlForRemoteProviders(
+  provider: Record<string, unknown>,
+): Record<string, unknown> {
+  const type = provider.type;
+  if (typeof type === 'string' && REMOTE_PROVIDER_TYPES.has(type)) {
+    const { baseUrl: _dropped, ...rest } = provider;
+    return rest;
   }
-  return override;
+  return provider;
 }
 
 function sanitizeExecutionOverrides(
   overrides: z.infer<typeof ExecutionOverrideBody>,
 ): z.infer<typeof ExecutionOverrideBody> {
   if (!overrides) return overrides;
-  const next = { ...overrides };
-  if (next.provider) next.provider = sanitizeProviderOverride(next.provider);
-  if (next.phases) {
-    const nextPhases: Record<string, typeof next.phases[string]> = {};
-    for (const [name, phase] of Object.entries(next.phases)) {
-      nextPhases[name] = phase.provider
-        ? { ...phase, provider: sanitizeProviderOverride(phase.provider) }
-        : phase;
-    }
-    next.phases = nextPhases;
-  }
-  return next;
+  // Delegates structural traversal (top-level provider + phases) to the
+  // shared helper so adding future override fields is a one-line change
+  // per transform, not a parallel rewrite here and in run-serializer.
+  const result = transformProviderOverrides(
+    overrides as unknown as Record<string, unknown>,
+    stripBaseUrlForRemoteProviders,
+  );
+  return result as unknown as z.infer<typeof ExecutionOverrideBody>;
 }
 
 const AgentRunBody = z.object({

--- a/packages/myco/src/daemon/api/models.ts
+++ b/packages/myco/src/daemon/api/models.ts
@@ -67,13 +67,17 @@ function getRemoteProviderApiKey(provider: RemoteProviderType): string | undefin
 
 async function fetchRemoteProviderModels(
   provider: RemoteProviderType,
-  baseUrl?: string,
+  _baseUrl?: string,
   timeoutMs = REMOTE_PROVIDER_TIMEOUT_MS,
 ): Promise<string[]> {
   const apiKey = getRemoteProviderApiKey(provider);
   if (!apiKey) return [];
 
-  const response = await fetch(`${baseUrl ?? REMOTE_PROVIDER_DEFAULTS[provider]}${REMOTE_MODELS_ENDPOINT}`, {
+  // SSRF defense: remote providers carry the daemon's bearer secret, so the
+  // baseUrl is locked to the hardcoded provider default. Caller-supplied
+  // values (query string, executionOverrides) are intentionally ignored.
+  const baseUrl = REMOTE_PROVIDER_DEFAULTS[provider];
+  const response = await fetch(`${baseUrl}${REMOTE_MODELS_ENDPOINT}`, {
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },

--- a/packages/myco/src/daemon/api/models.ts
+++ b/packages/myco/src/daemon/api/models.ts
@@ -118,7 +118,10 @@ export async function handleGetModels(req: RouteRequest): Promise<RouteResponse>
     } else if (provider === 'anthropic') {
       models = ANTHROPIC_MODELS;
     } else if (provider === 'openai' || provider === 'openrouter') {
-      models = await fetchRemoteProviderModels(provider, req.query.base_url, MODEL_LIST_TIMEOUT_MS);
+      // fetchRemoteProviderModels ignores caller-supplied baseUrl (SSRF
+      // defense — see its implementation). Pass undefined explicitly so
+      // readers don't think `req.query.base_url` reaches the fetch.
+      models = await fetchRemoteProviderModels(provider, undefined, MODEL_LIST_TIMEOUT_MS);
     }
   } catch {
     // Provider unreachable — return empty list

--- a/packages/myco/src/daemon/api/providers.ts
+++ b/packages/myco/src/daemon/api/providers.ts
@@ -137,9 +137,11 @@ export async function handleTestProvider(req: RouteRequest): Promise<RouteRespon
     } else if (type === 'openai-compatible') {
       result = await testResolvedLocalProvider('openai-compatible', baseUrl, localBackend);
     } else if (type === 'openai') {
-      result = await testRemoteProvider('openai', 'OpenAI', baseUrl);
+      // baseUrl deliberately dropped — remote providers always use the
+      // hardcoded default to prevent SSRF via the daemon's bearer token.
+      result = await testRemoteProvider('openai', 'OpenAI');
     } else if (type === 'openrouter') {
-      result = await testRemoteProvider('openrouter', 'OpenRouter', baseUrl);
+      result = await testRemoteProvider('openrouter', 'OpenRouter');
     } else {
       result = testAnthropic();
     }
@@ -282,13 +284,12 @@ function testAnthropic(): TestResult {
 async function testRemoteProvider(
   provider: 'openai' | 'openrouter',
   label: string,
-  baseUrl?: string,
 ): Promise<TestResult> {
   if (!getRemoteProviderApiKey(provider)) {
     return { ok: false, error: `${label} API key not configured in daemon secrets or environment` };
   }
   try {
-    await fetchRemoteProviderModels(provider, baseUrl);
+    await fetchRemoteProviderModels(provider);
     return { ok: true };
   } catch (error) {
     return { ok: false, error: error instanceof Error ? error.message : `${label} connection failed` };

--- a/packages/myco/src/daemon/api/providers.ts
+++ b/packages/myco/src/daemon/api/providers.ts
@@ -224,7 +224,9 @@ async function detectRemoteProviderInfo(
 
   if (authConfigured) {
     try {
-      models = await fetchRemoteProviderModels(type, baseUrl, ANTHROPIC_MODELS_TIMEOUT_MS);
+      // baseUrl is intentionally ignored by fetchRemoteProviderModels for remote
+      // providers (always uses the hardcoded default); see SSRF lockdown.
+      models = await fetchRemoteProviderModels(type, undefined, ANTHROPIC_MODELS_TIMEOUT_MS);
       available = true;
     } catch {
       available = false;

--- a/packages/myco/src/daemon/api/run-serializer.ts
+++ b/packages/myco/src/daemon/api/run-serializer.ts
@@ -9,6 +9,7 @@
  */
 
 import type { RunRow } from '@myco/db/queries/runs.js';
+import { transformProviderOverrides } from './schemas/execution-overrides-traversal.js';
 
 export interface PhaseCheckpointSummary {
   name: string;
@@ -51,39 +52,29 @@ export function buildPhaseCheckpointSummary(
   }
 }
 
+// TODO(post-v0.22): remove once no historical agent_runs rows predate the apiKey drop in v0.21. See docs/superpowers/plans/2026-04-18-pre-0.21.0-quality-pass.md Bundle A.
 /**
  * Defensive mask for historical execution_overrides rows. Removes any
- * `apiKey` field (top-level or nested under `provider` / per-phase
- * `provider`) so the stored overrides column cannot echo a pre-patch
- * secret back to the UI.
+ * `apiKey` field nested under `provider` (top-level or per-phase) so the
+ * stored overrides column cannot echo a pre-patch secret back to the UI.
+ *
+ * Top-level `apiKey` — if a legacy row somehow stored one — is also
+ * stripped as belt-and-braces defense.
+ *
+ * Structural traversal is delegated to `transformProviderOverrides`; this
+ * function only encodes the per-provider transform (delete apiKey).
  */
 function scrubExecutionOverrides(
   overrides: Record<string, unknown> | null,
 ): Record<string, unknown> | null {
   if (!overrides || typeof overrides !== 'object') return overrides;
-  const cloned: Record<string, unknown> = { ...overrides };
-  if ('apiKey' in cloned) delete cloned.apiKey;
-  cloned.provider = scrubProviderOverride(cloned.provider);
-  if (cloned.phases && typeof cloned.phases === 'object') {
-    const phases: Record<string, unknown> = {};
-    for (const [name, phase] of Object.entries(cloned.phases as Record<string, unknown>)) {
-      if (phase && typeof phase === 'object') {
-        const clonedPhase: Record<string, unknown> = { ...(phase as Record<string, unknown>) };
-        if ('apiKey' in clonedPhase) delete clonedPhase.apiKey;
-        clonedPhase.provider = scrubProviderOverride(clonedPhase.provider);
-        phases[name] = clonedPhase;
-      } else {
-        phases[name] = phase;
-      }
-    }
-    cloned.phases = phases;
-  }
-  return cloned;
+  const topLevelStripped: Record<string, unknown> = { ...overrides };
+  if ('apiKey' in topLevelStripped) delete topLevelStripped.apiKey;
+  return transformProviderOverrides(topLevelStripped, stripApiKey);
 }
 
-function scrubProviderOverride(provider: unknown): unknown {
-  if (!provider || typeof provider !== 'object') return provider;
-  const cloned: Record<string, unknown> = { ...(provider as Record<string, unknown>) };
+function stripApiKey(provider: Record<string, unknown>): Record<string, unknown> {
+  const cloned = { ...provider };
   if ('apiKey' in cloned) delete cloned.apiKey;
   return cloned;
 }

--- a/packages/myco/src/daemon/api/run-serializer.ts
+++ b/packages/myco/src/daemon/api/run-serializer.ts
@@ -51,6 +51,43 @@ export function buildPhaseCheckpointSummary(
   }
 }
 
+/**
+ * Defensive mask for historical execution_overrides rows. Removes any
+ * `apiKey` field (top-level or nested under `provider` / per-phase
+ * `provider`) so the stored overrides column cannot echo a pre-patch
+ * secret back to the UI.
+ */
+function scrubExecutionOverrides(
+  overrides: Record<string, unknown> | null,
+): Record<string, unknown> | null {
+  if (!overrides || typeof overrides !== 'object') return overrides;
+  const cloned: Record<string, unknown> = { ...overrides };
+  if ('apiKey' in cloned) delete cloned.apiKey;
+  cloned.provider = scrubProviderOverride(cloned.provider);
+  if (cloned.phases && typeof cloned.phases === 'object') {
+    const phases: Record<string, unknown> = {};
+    for (const [name, phase] of Object.entries(cloned.phases as Record<string, unknown>)) {
+      if (phase && typeof phase === 'object') {
+        const clonedPhase: Record<string, unknown> = { ...(phase as Record<string, unknown>) };
+        if ('apiKey' in clonedPhase) delete clonedPhase.apiKey;
+        clonedPhase.provider = scrubProviderOverride(clonedPhase.provider);
+        phases[name] = clonedPhase;
+      } else {
+        phases[name] = phase;
+      }
+    }
+    cloned.phases = phases;
+  }
+  return cloned;
+}
+
+function scrubProviderOverride(provider: unknown): unknown {
+  if (!provider || typeof provider !== 'object') return provider;
+  const cloned: Record<string, unknown> = { ...(provider as Record<string, unknown>) };
+  if ('apiKey' in cloned) delete cloned.apiKey;
+  return cloned;
+}
+
 export interface SerializeRunOptions {
   /** Include resume-related fields (resumable/resume_status/resume_mode/resumed_at). Default true. */
   includeResumeFields?: boolean;
@@ -107,7 +144,9 @@ export function serializeRun(run: RunRow, opts: SerializeRunOptions = {}) {
     dry_run: run.dry_run,
     evaluation_id: run.evaluation_id,
     reasoning_level: run.reasoning_level,
-    execution_overrides: run.execution_overrides,
+    // Strip `apiKey` from historical rows defensively — before this PR the
+    // API accepted apiKey in executionOverrides and stored it unmasked.
+    execution_overrides: scrubExecutionOverrides(run.execution_overrides),
   };
 
   return {

--- a/packages/myco/src/daemon/api/schemas/execution-overrides-traversal.ts
+++ b/packages/myco/src/daemon/api/schemas/execution-overrides-traversal.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared traversal helper for executionOverrides provider fields.
+ *
+ * Two call sites need to walk the override shape and transform each provider
+ * object (top-level and per-phase):
+ *
+ *   - `sanitizeExecutionOverrides` (inbound, agent-runs.ts) strips
+ *     `baseUrl` from remote-provider overrides on request entry.
+ *   - `scrubExecutionOverrides` (outbound, run-serializer.ts) strips
+ *     `apiKey` from historical rows during serialization.
+ *
+ * Keeping the traversal itself in one place means adding a future override
+ * field (e.g. `headers`) is a one-line change per transform, not a
+ * structural rewrite of two separate walkers that could drift.
+ *
+ * The helper always returns a fresh top-level object and never mutates its
+ * input; clones are shallow because the override shape is JSON-column data
+ * with a known, finite schema.
+ */
+
+export type ProviderTransform = (
+  provider: Record<string, unknown>,
+) => Record<string, unknown> | null;
+
+/**
+ * Apply `transform` to every provider object inside an executionOverrides
+ * blob: the top-level `provider` and every `phases[name].provider`.
+ *
+ * If `transform` returns `null` for a given provider, that `provider` field
+ * is removed from its containing object entirely.
+ *
+ * `null`/`undefined` input passes through unchanged (returned as `null`
+ * when input is `null`, preserving the caller's nullable contract).
+ */
+export function transformProviderOverrides(
+  overrides: Record<string, unknown> | null | undefined,
+  transform: ProviderTransform,
+): Record<string, unknown> | null {
+  if (overrides === null || overrides === undefined) {
+    return overrides ?? null;
+  }
+  if (typeof overrides !== 'object') return overrides as never;
+
+  const cloned: Record<string, unknown> = { ...overrides };
+
+  if (isPlainObject(cloned.provider)) {
+    const next = transform({ ...cloned.provider });
+    if (next === null) {
+      delete cloned.provider;
+    } else {
+      cloned.provider = next;
+    }
+  }
+
+  if (isPlainObject(cloned.phases)) {
+    const nextPhases: Record<string, unknown> = {};
+    for (const [name, phase] of Object.entries(cloned.phases)) {
+      if (!isPlainObject(phase)) {
+        nextPhases[name] = phase;
+        continue;
+      }
+      const clonedPhase: Record<string, unknown> = { ...phase };
+      if (isPlainObject(clonedPhase.provider)) {
+        const nextProvider = transform({ ...clonedPhase.provider });
+        if (nextProvider === null) {
+          delete clonedPhase.provider;
+        } else {
+          clonedPhase.provider = nextProvider;
+        }
+      }
+      nextPhases[name] = clonedPhase;
+    }
+    cloned.phases = nextPhases;
+  }
+
+  return cloned;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/myco/src/daemon/api/schemas/execution-overrides.ts
+++ b/packages/myco/src/daemon/api/schemas/execution-overrides.ts
@@ -27,12 +27,21 @@ export const ProviderTypeEnum = z.enum([
   'openai-compatible',
 ]);
 
+/**
+ * Provider override wire shape.
+ *
+ * `apiKey` is intentionally not accepted here — secrets must flow through
+ * `.myco/secrets.env` and provider-specific env vars, never through an API
+ * body (feedback_secrets_not_in_yaml). `baseUrl` is parsed for all provider
+ * types but is stripped by the run handler for `openai` and `openrouter`
+ * before it can reach the runtime, so the daemon's bearer key cannot be
+ * redirected to an attacker-controlled host.
+ */
 export const ProviderOverrideWireSchema = z.object({
   runtime: RuntimeIdEnum.optional(),
   type: ProviderTypeEnum,
   localBackend: z.enum(['ollama', 'lmstudio']).optional(),
   baseUrl: z.string().optional(),
-  apiKey: z.string().optional(),
   model: z.string().optional(),
   reasoningMap: z.object({
     low: z.string().optional(),

--- a/packages/myco/src/daemon/api/sessions.ts
+++ b/packages/myco/src/daemon/api/sessions.ts
@@ -2,7 +2,8 @@ import { getSession, listSessions, countSessions, deleteSessionCascade, getSessi
 import { listBatchesBySession, countBatchesBySession } from '@myco/db/queries/batches.js';
 import { listActivitiesByBatch, countActivities } from '@myco/db/queries/activities.js';
 import { listAttachmentsBySession } from '@myco/db/queries/attachments.js';
-import { deletePlan, listPlansBySession } from '@myco/db/queries/plans.js';
+import { deletePlan, getPlan, listPlansBySession } from '@myco/db/queries/plans.js';
+import { getTeamMachineId } from '@myco/daemon/team-context.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { epochSeconds } from '@myco/constants.js';
 import { cleanupAfterSessionCascade } from '../jobs/session-cleanup.js';
@@ -148,8 +149,34 @@ export function createSessionMutationHandlers(deps: SessionMutationDeps) {
     return { body: impact };
   }
 
-  /** DELETE /api/plans/:id — remove a captured plan and its vector. */
+  /** DELETE /api/plans/:id — remove a captured plan and its vector.
+   *
+   *  Ownership check: deleting a plan that belongs to another machine
+   *  propagates a tombstone across the team. Require an explicit
+   *  `{force_remote: true}` opt-in before deleting someone else's row. */
   async function handleDeletePlan(req: RouteRequest): Promise<RouteResponse> {
+    const existing = getPlan(req.params.id);
+    if (!existing) return { status: 404, body: { error: 'Plan not found' } };
+
+    const localMachineId = getTeamMachineId();
+    const body = req.body as { force_remote?: boolean } | undefined;
+    const forceRemote = body?.force_remote === true;
+    if (existing.machine_id !== localMachineId && !forceRemote) {
+      logger.warn(LOG_KINDS.API_SESSION_DELETE, 'Cross-machine plan delete rejected', {
+        plan_id: existing.id,
+        plan_machine_id: existing.machine_id,
+        local_machine_id: localMachineId,
+      });
+      return { status: 403, body: { error: 'Plan belongs to another machine; pass {"force_remote": true} to delete.' } };
+    }
+    if (existing.machine_id !== localMachineId && forceRemote) {
+      logger.warn(LOG_KINDS.API_SESSION_DELETE, 'Cross-machine plan delete allowed by force_remote', {
+        plan_id: existing.id,
+        plan_machine_id: existing.machine_id,
+        local_machine_id: localMachineId,
+      });
+    }
+
     const deleted = deletePlan(req.params.id);
     if (!deleted) return { status: 404, body: { error: 'Plan not found' } };
 

--- a/packages/myco/src/daemon/server.ts
+++ b/packages/myco/src/daemon/server.ts
@@ -286,15 +286,14 @@ export function validateLoopbackRequest(
   return null;
 }
 
+// Node passes the listening host verbatim; some clients omit the port
+// entirely on default ports. The daemon never uses port 80, so require
+// an explicit port match. Keep the two-form allowlist tight.
 function isLoopbackHost(host: string, port: number): boolean {
   const portStr = String(port);
   return (
     host === `127.0.0.1:${portStr}` ||
-    host === `localhost:${portStr}` ||
-    // Node passes the listening host verbatim; some clients omit the port
-    // entirely on default ports. The daemon never uses port 80, so require
-    // an explicit port match. Keep the two-form allowlist tight.
-    false
+    host === `localhost:${portStr}`
   );
 }
 

--- a/packages/myco/src/daemon/server.ts
+++ b/packages/myco/src/daemon/server.ts
@@ -85,9 +85,21 @@ export class DaemonServer {
     const match = this.router.match(req.method!, req.url!);
 
     if (match) {
+      // CSRF defense: the daemon listens only on 127.0.0.1 but any web page
+      // the user visits can still POST cross-origin. Reject requests whose
+      // Host or Origin headers disagree with the loopback listener; block
+      // non-JSON mutating bodies so text/plain CSRF cannot slip JSON through.
+      const rejection = validateLoopbackRequest(req, this.port);
+      if (rejection) {
+        res.writeHead(rejection.status, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: rejection.error }));
+        return;
+      }
+
       this.onRequest?.();
       try {
-        const body = (req.method === 'POST' || req.method === 'PUT' || req.method === 'PATCH') ? await readBody(req) : undefined;
+        const needsBody = req.method === 'POST' || req.method === 'PUT' || req.method === 'PATCH' || req.method === 'DELETE';
+        const body = needsBody ? await readBody(req) : undefined;
         const result = await match.handler({
           body,
           query: match.query,
@@ -220,4 +232,76 @@ function readBody(req: http.IncomingMessage): Promise<unknown> {
     });
     req.on('error', reject);
   });
+}
+
+// ---------------------------------------------------------------------------
+// CSRF / Origin / Content-Type gate
+// ---------------------------------------------------------------------------
+
+interface Rejection {
+  status: number;
+  error: string;
+}
+
+/**
+ * Reject cross-origin / non-JSON mutating requests before they reach a route
+ * handler. Keeps the daemon's stored API keys and write operations out of
+ * reach of any webpage the user happens to visit.
+ *
+ * - Host header must identify the loopback listener (or be absent).
+ * - Origin header, when present, must point to the same loopback listener.
+ * - Mutating methods with a non-empty body must declare application/json.
+ */
+export function validateLoopbackRequest(
+  req: http.IncomingMessage,
+  port: number,
+): Rejection | null {
+  const host = req.headers.host;
+  if (host && !isLoopbackHost(host, port)) {
+    return { status: 403, error: 'forbidden_host' };
+  }
+
+  const origin = req.headers.origin;
+  if (origin && !isLoopbackOrigin(origin, port)) {
+    return { status: 403, error: 'forbidden_origin' };
+  }
+
+  const method = (req.method ?? '').toUpperCase();
+  const isMutating = method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE';
+  if (!isMutating) return null;
+
+  // DELETE with an empty body is the common case (e.g. /api/plans/:id) and
+  // is allowed without Content-Type. For any non-empty body on a mutating
+  // route, require JSON so text/plain CSRF cannot smuggle parsed JSON in.
+  const contentLengthHeader = req.headers['content-length'];
+  const contentLength = contentLengthHeader ? Number(contentLengthHeader) : NaN;
+  const hasBody = Number.isFinite(contentLength) ? contentLength > 0 : (req.headers['transfer-encoding'] ?? '').length > 0;
+  if (!hasBody) return null;
+
+  const contentType = (req.headers['content-type'] ?? '').toLowerCase();
+  if (!contentType.includes('application/json')) {
+    return { status: 415, error: 'unsupported_media_type' };
+  }
+
+  return null;
+}
+
+function isLoopbackHost(host: string, port: number): boolean {
+  const portStr = String(port);
+  return (
+    host === `127.0.0.1:${portStr}` ||
+    host === `localhost:${portStr}` ||
+    // Node passes the listening host verbatim; some clients omit the port
+    // entirely on default ports. The daemon never uses port 80, so require
+    // an explicit port match. Keep the two-form allowlist tight.
+    false
+  );
+}
+
+function isLoopbackOrigin(origin: string, port: number): boolean {
+  const portStr = String(port);
+  return (
+    origin === `http://127.0.0.1:${portStr}` ||
+    origin === `http://localhost:${portStr}`
+  );
 }

--- a/tests/agent/openrouter-catalog.test.ts
+++ b/tests/agent/openrouter-catalog.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Runtime validation for the OpenRouter pricing-catalog fetch.
+ *
+ * The original implementation trusted a raw JSON type assertion — a poisoned
+ * response could corrupt the in-memory cache or blow memory. These tests
+ * pin down the new guards: non-object response, non-array `data`, and a
+ * hard entry-count cap. On rejection the cache MUST NOT be populated.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { estimateOpenRouterCost } from '@myco/agent/cost/openrouter';
+import { OPENROUTER_API_KEY_ENV } from '@myco/cli/providers/openrouter.js';
+
+const fetchMock = vi.fn();
+global.fetch = fetchMock as unknown as typeof fetch;
+
+afterEach(() => {
+  fetchMock.mockReset();
+  vi.unstubAllEnvs();
+});
+
+const sampleUsage = {
+  inputTokens: 10, outputTokens: 5, totalTokens: 15, requests: 1,
+};
+
+describe('OpenRouter catalog validation', () => {
+  it('rejects a response with data=null (does not poison the cache)', async () => {
+    vi.stubEnv(OPENROUTER_API_KEY_ENV, 'sk-or-test');
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ data: null }) });
+
+    const result = await estimateOpenRouterCost('anthropic/claude-sonnet', sampleUsage, 'https://openrouter.test-null/api/v1');
+    expect(result.source).toBe('unavailable');
+    expect(result.message).toMatch(/missing data array/i);
+
+    // Second call should re-fetch (cache NOT populated by the rejected response)
+    fetchMock.mockClear();
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ data: null }) });
+    await estimateOpenRouterCost('anthropic/claude-sonnet', sampleUsage, 'https://openrouter.test-null/api/v1');
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it('rejects a response that is not an object', async () => {
+    vi.stubEnv(OPENROUTER_API_KEY_ENV, 'sk-or-test');
+    fetchMock.mockResolvedValue({ ok: true, json: async () => 'not-an-object' });
+
+    const result = await estimateOpenRouterCost('anthropic/claude-sonnet', sampleUsage, 'https://openrouter.test-str/api/v1');
+    expect(result.source).toBe('unavailable');
+    expect(result.message).toMatch(/missing data array/i);
+  });
+
+  it('rejects a response with more than 10_000 entries', async () => {
+    vi.stubEnv(OPENROUTER_API_KEY_ENV, 'sk-or-test');
+    const huge = Array.from({ length: 10_001 }, (_, i) => ({
+      id: `model-${i}`,
+      pricing: { prompt: '0.001', completion: '0.002' },
+    }));
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ data: huge }) });
+
+    const result = await estimateOpenRouterCost('model-0', sampleUsage, 'https://openrouter.test-huge/api/v1');
+    expect(result.source).toBe('unavailable');
+    expect(result.message).toMatch(/exceeded/i);
+
+    // Cache must not be populated
+    fetchMock.mockClear();
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ data: huge }) });
+    await estimateOpenRouterCost('model-0', sampleUsage, 'https://openrouter.test-huge/api/v1');
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it('accepts a valid response with a small data array', async () => {
+    vi.stubEnv(OPENROUTER_API_KEY_ENV, 'sk-or-test');
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: 'valid-model', pricing: { prompt: '0.001', completion: '0.002' } }],
+      }),
+    });
+
+    const result = await estimateOpenRouterCost('valid-model', sampleUsage, 'https://openrouter.test-ok/api/v1');
+    expect(result.source).toBe('estimated');
+  });
+});

--- a/tests/daemon/api/agent-runs-overrides-security.test.ts
+++ b/tests/daemon/api/agent-runs-overrides-security.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Security defenses for POST /api/agent/run executionOverrides.
+ *
+ * Two invariants under test:
+ *   1. `executionOverrides.provider.apiKey` is silently dropped (or rejected)
+ *      — the daemon never accepts secrets on the API surface.
+ *   2. `executionOverrides.provider.baseUrl` is dropped for `openai` /
+ *      `openrouter` remote providers, so the daemon's bearer key cannot
+ *      be sent to an attacker-controlled host via an override.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { createAgentRunHandlers } from '@myco/daemon/api/agent-runs';
+import type { RouteRequest } from '@myco/daemon/router';
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+const runAgentSpy = vi.fn(async () => ({ runId: 'stub', status: 'completed' as const }));
+vi.mock('@myco/agent/executor.js', () => ({
+  runAgent: (...args: unknown[]) => runAgentSpy(...args),
+}));
+vi.mock('@myco/config/loader.js', () => ({
+  loadMergedConfig: () => ({ agent: { tasks: {} } }),
+}));
+vi.mock('@myco/agent/config-resolver.js', () => ({
+  hasConfiguredProvider: () => true,
+}));
+
+function makeRequest(overrides: Partial<RouteRequest> = {}): RouteRequest {
+  return { params: {}, query: {}, body: undefined, pathname: '/', ...overrides } as RouteRequest;
+}
+
+function makeHandlers() {
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return createAgentRunHandlers({
+    vaultDir: '/tmp/fake-vault',
+    embeddingManager: {} as never,
+    logger: logger as never,
+  });
+}
+
+describe('POST /api/agent/run — executionOverrides security', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    runAgentSpy.mockClear();
+    registerAgent({ id: 'myco-agent', name: 'Test', created_at: epochNow() });
+  });
+
+  it('silently drops provider.apiKey from executionOverrides', async () => {
+    const { handleRun } = makeHandlers();
+    await handleRun(makeRequest({
+      body: {
+        task: 't', instruction: 'go', agentId: 'myco-agent',
+        executionOverrides: {
+          provider: { type: 'openai', apiKey: 'sk-attacker-captured' },
+        },
+      },
+    }));
+
+    expect(runAgentSpy).toHaveBeenCalledTimes(1);
+    const [, opts] = runAgentSpy.mock.calls[0] as [string, { executionOverrides?: unknown }];
+    const forwarded = JSON.stringify(opts.executionOverrides ?? {});
+    expect(forwarded).not.toContain('sk-attacker-captured');
+    expect(forwarded).not.toContain('apiKey');
+  });
+
+  it('strips provider.baseUrl from executionOverrides when type=openai', async () => {
+    const { handleRun } = makeHandlers();
+    await handleRun(makeRequest({
+      body: {
+        task: 't', instruction: 'go', agentId: 'myco-agent',
+        executionOverrides: {
+          provider: { type: 'openai', baseUrl: 'https://attacker.example/v1' },
+        },
+      },
+    }));
+
+    expect(runAgentSpy).toHaveBeenCalledTimes(1);
+    const [, opts] = runAgentSpy.mock.calls[0] as [string, { executionOverrides?: { provider?: { baseUrl?: string } } }];
+    expect(opts.executionOverrides?.provider?.baseUrl).toBeUndefined();
+  });
+
+  it('strips provider.baseUrl from executionOverrides when type=openrouter', async () => {
+    const { handleRun } = makeHandlers();
+    await handleRun(makeRequest({
+      body: {
+        task: 't', instruction: 'go', agentId: 'myco-agent',
+        executionOverrides: {
+          provider: { type: 'openrouter', baseUrl: 'https://attacker.example/v1' },
+        },
+      },
+    }));
+
+    const [, opts] = runAgentSpy.mock.calls[0] as [string, { executionOverrides?: { provider?: { baseUrl?: string } } }];
+    expect(opts.executionOverrides?.provider?.baseUrl).toBeUndefined();
+  });
+
+  it('PRESERVES provider.baseUrl for type=openai-compatible (legitimate local path)', async () => {
+    const { handleRun } = makeHandlers();
+    await handleRun(makeRequest({
+      body: {
+        task: 't', instruction: 'go', agentId: 'myco-agent',
+        executionOverrides: {
+          provider: { type: 'openai-compatible', baseUrl: 'http://localhost:8080' },
+        },
+      },
+    }));
+
+    const [, opts] = runAgentSpy.mock.calls[0] as [string, { executionOverrides?: { provider?: { baseUrl?: string } } }];
+    expect(opts.executionOverrides?.provider?.baseUrl).toBe('http://localhost:8080');
+  });
+
+  it('strips phase-level provider.baseUrl for openai/openrouter', async () => {
+    const { handleRun } = makeHandlers();
+    await handleRun(makeRequest({
+      body: {
+        task: 't', instruction: 'go', agentId: 'myco-agent',
+        executionOverrides: {
+          phases: {
+            extract: { provider: { type: 'openai', baseUrl: 'https://attacker.example/v1' } },
+            embed: { provider: { type: 'openai-compatible', baseUrl: 'http://localhost:8080' } },
+          },
+        },
+      },
+    }));
+
+    const [, opts] = runAgentSpy.mock.calls[0] as [string, {
+      executionOverrides?: { phases?: Record<string, { provider?: { baseUrl?: string } }> }
+    }];
+    expect(opts.executionOverrides?.phases?.extract?.provider?.baseUrl).toBeUndefined();
+    expect(opts.executionOverrides?.phases?.embed?.provider?.baseUrl).toBe('http://localhost:8080');
+  });
+});

--- a/tests/daemon/api/key-leak-guard.test.ts
+++ b/tests/daemon/api/key-leak-guard.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Cross-route guarantee: API keys never appear in response bodies.
+ *
+ * This test seeds sentinel values into the provider-key env vars, exercises
+ * every read and mutating route on the daemon that could plausibly echo a
+ * key, and asserts the sentinel strings never appear in any response body
+ * (success or error path). If a future regression reintroduces an
+ * echo-back channel, this test will catch it before release.
+ *
+ * The SSRF fix in this PR locks the catalog fetch URL for remote providers
+ * to the hardcoded default, and the CSRF/Origin/Content-Type gate blocks
+ * the web-page exfiltration path; this test guards the last mile.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { DaemonServer } from '@myco/daemon/server';
+import { DaemonLogger } from '@myco/daemon/logger';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { upsertSession } from '@myco/db/queries/sessions.js';
+import { upsertPlan } from '@myco/db/queries/plans.js';
+import { insertRun } from '@myco/db/queries/runs.js';
+import { handleGetProviders, handleTestProvider } from '@myco/daemon/api/providers';
+import { handleGetModels } from '@myco/daemon/api/models';
+import {
+  handleGetProviderSecrets,
+  handlePutProviderSecret,
+  handleDeleteProviderSecret,
+} from '@myco/daemon/api/provider-secrets';
+import { createAgentRunHandlers } from '@myco/daemon/api/agent-runs';
+import { createSessionMutationHandlers } from '@myco/daemon/api/sessions';
+import {
+  handleListSessions,
+  handleGetSession,
+  handleGetSessionBatches,
+  handleGetSessionPlans,
+} from '@myco/daemon/api/sessions';
+import { OPENAI_API_KEY_ENV } from '@myco/cli/providers/openai-embeddings.js';
+import { OPENROUTER_API_KEY_ENV } from '@myco/cli/providers/openrouter.js';
+
+const SENTINELS = {
+  openai: 'sk-sentinel-openai-ABCDEF1234567890',
+  openrouter: 'sk-or-sentinel-openrouter-ABCDEF1234567890',
+  anthropic: 'sk-ant-sentinel-anthropic-ABCDEF1234567890',
+};
+
+// Stub external backends so no network is required.
+vi.mock('@myco/intelligence/ollama.js', () => ({
+  OllamaBackend: class {
+    static DEFAULT_BASE_URL = 'http://localhost:11434';
+    async isAvailable() { return false; }
+    async listModels() { return []; }
+  },
+}));
+vi.mock('@myco/intelligence/lm-studio.js', () => ({
+  LmStudioBackend: class {
+    static DEFAULT_BASE_URL = 'http://localhost:1234';
+    async isAvailable() { return false; }
+    async listModels() { return []; }
+  },
+}));
+vi.mock('@myco/agent/executor.js', () => ({
+  runAgent: vi.fn(async () => ({ runId: 'stub', status: 'completed' as const })),
+}));
+vi.mock('@myco/config/loader.js', () => ({
+  loadMergedConfig: () => ({ agent: { tasks: {} } }),
+}));
+vi.mock('@myco/agent/config-resolver.js', () => ({
+  hasConfiguredProvider: () => true,
+}));
+
+// The /api/providers detection path hits fetch() when an OpenAI/OpenRouter
+// key is present. Intercept so we observe what URL was called AND so the
+// response itself doesn't echo the key. A compliant remote never includes
+// the caller's own bearer token in its body, but the test doubly-guards:
+// - If our SSRF defense holds, fetch is called with api.openai.com only.
+// - If a body were to contain a sentinel, the leak-scan assertion catches it.
+const realFetch = globalThis.fetch;
+const fetchMock = vi.fn();
+// Only mock outbound calls to provider hosts; let loopback calls (our own
+// test fetches to the daemon) fall through to the real fetch so response
+// bodies come back via Node's http stack unmodified.
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+  if (url.startsWith('http://127.0.0.1') || url.startsWith('http://localhost')) {
+    return realFetch(input, init);
+  }
+  fetchMock(url, init);
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ data: [{ id: 'gpt-5' }] }),
+    text: async () => JSON.stringify({ data: [{ id: 'gpt-5' }] }),
+  } as unknown as Response;
+}) as typeof fetch;
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+function makeLogger() {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe('cross-route API key leak guard', () => {
+  let server: DaemonServer;
+  let tmpVault: string;
+  let logger: DaemonLogger;
+
+  beforeAll(async () => {
+    // Seed sentinel values BEFORE setupTestDb so handlers see them.
+    process.env[OPENAI_API_KEY_ENV] = SENTINELS.openai;
+    process.env.OPENAI_API_KEY = SENTINELS.openai;
+    process.env[OPENROUTER_API_KEY_ENV] = SENTINELS.openrouter;
+    process.env.ANTHROPIC_API_KEY = SENTINELS.anthropic;
+
+    tmpVault = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-leak-guard-'));
+    fs.mkdirSync(path.join(tmpVault, 'logs'), { recursive: true });
+    logger = new DaemonLogger(path.join(tmpVault, 'logs'));
+    setupTestDb();
+
+    server = new DaemonServer({ vaultDir: tmpVault, logger });
+
+    // Wire up a representative surface of routes.
+    server.registerRoute('GET', '/api/providers', async () => handleGetProviders());
+    server.registerRoute('POST', '/api/providers/test', async (req) => handleTestProvider(req));
+    server.registerRoute('GET', '/api/providers/secrets', async () => handleGetProviderSecrets(tmpVault));
+    server.registerRoute('PUT', '/api/providers/secrets/:provider', async (req) => handlePutProviderSecret(tmpVault, req));
+    server.registerRoute('DELETE', '/api/providers/secrets/:provider', async (req) => handleDeleteProviderSecret(tmpVault, req));
+    server.registerRoute('GET', '/api/models', handleGetModels);
+
+    const embeddingManager = {
+      onRemoved: vi.fn(), remove: vi.fn(), reconcile: vi.fn(),
+    } as never;
+    const agentRunHandlers = createAgentRunHandlers({
+      vaultDir: tmpVault,
+      embeddingManager,
+      logger: makeLogger() as never,
+    });
+    server.registerRoute('POST', '/api/agent/run', agentRunHandlers.handleRun);
+    server.registerRoute('GET', '/api/agent/runs', agentRunHandlers.handleListRuns);
+    server.registerRoute('GET', '/api/agent/runs/:id', agentRunHandlers.handleGetRun);
+
+    const sessionMut = createSessionMutationHandlers({
+      embeddingManager,
+      vaultDir: tmpVault,
+      logger: makeLogger() as never,
+      liveConfig: { current: { agent: { event_tasks_enabled: false } } } as never,
+    });
+    server.registerRoute('GET', '/api/sessions', handleListSessions);
+    server.registerRoute('GET', '/api/sessions/:id', handleGetSession);
+    server.registerRoute('GET', '/api/sessions/:id/batches', handleGetSessionBatches);
+    server.registerRoute('GET', '/api/sessions/:id/plans', handleGetSessionPlans);
+    server.registerRoute('DELETE', '/api/plans/:id', sessionMut.handleDeletePlan);
+
+    await server.start();
+  });
+
+  beforeEach(() => {
+    cleanTestDb();
+    registerAgent({ id: 'myco-agent', name: 'Test', created_at: epochNow() });
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    logger.close();
+    teardownTestDb();
+    fs.rmSync(tmpVault, { recursive: true, force: true });
+    delete process.env[OPENAI_API_KEY_ENV];
+    delete process.env.OPENAI_API_KEY;
+    delete process.env[OPENROUTER_API_KEY_ENV];
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  function assertNoLeak(label: string, body: string) {
+    for (const [name, sentinel] of Object.entries(SENTINELS)) {
+      expect(body, `${label} leaked ${name} sentinel`).not.toContain(sentinel);
+    }
+  }
+
+  it('no route echoes a seeded API key sentinel in its response body', async () => {
+    const base = `http://127.0.0.1:${server.port}`;
+
+    // Seed a session/plan/run so list and detail routes have rows to serialize.
+    const now = epochNow();
+    upsertSession({ id: 'sess-1', agent: 'myco-agent', started_at: now, created_at: now });
+    upsertPlan({
+      id: 'plan-1',
+      logical_key: 'session:sess-1:key:primary',
+      session_id: 'sess-1',
+      title: 'p', content: 'c',
+      created_at: now,
+    });
+    insertRun({
+      id: 'run-1',
+      agent_id: 'myco-agent',
+      task: 'task',
+      instruction: 'do',
+      status: 'completed',
+      started_at: now,
+      // Simulate a pre-patch historical row that still carries an apiKey in
+      // execution_overrides. The serializer currently echoes this column
+      // verbatim — this test pins the expectation that any future route
+      // which reads it must mask secrets before returning to a client.
+      executionOverrides: {
+        provider: {
+          type: 'openai',
+          apiKey: SENTINELS.openai,
+          baseUrl: 'https://attacker.example/v1',
+        },
+      },
+    });
+
+    const routes: Array<{ method: string; path: string; body?: unknown }> = [
+      { method: 'GET', path: '/api/providers' },
+      { method: 'POST', path: '/api/providers/test', body: { type: 'openai' } },
+      { method: 'POST', path: '/api/providers/test', body: { type: 'openrouter' } },
+      // Attempt to exploit SSRF via an attacker-controlled baseUrl — the
+      // daemon MUST ignore it and not send the bearer key anywhere other
+      // than the hardcoded default.
+      { method: 'POST', path: '/api/providers/test', body: { type: 'openai', baseUrl: 'https://attacker.example/v1' } },
+      { method: 'POST', path: '/api/providers/test', body: { type: 'openrouter', base_url: 'https://attacker.example/v1' } },
+      { method: 'GET', path: '/api/providers/secrets' },
+      { method: 'GET', path: '/api/models?provider=openai&type=llm' },
+      { method: 'GET', path: '/api/models?provider=openrouter&type=llm' },
+      { method: 'GET', path: '/api/models?provider=openai&type=llm&base_url=https%3A%2F%2Fattacker.example%2Fv1' },
+      { method: 'GET', path: '/api/sessions' },
+      { method: 'GET', path: '/api/sessions/sess-1' },
+      { method: 'GET', path: '/api/sessions/sess-1/batches' },
+      { method: 'GET', path: '/api/sessions/sess-1/plans' },
+      { method: 'GET', path: '/api/agent/runs' },
+      { method: 'GET', path: '/api/agent/runs/run-1' },
+      // Attacker-controlled body; the daemon must not echo any key back.
+      {
+        method: 'POST',
+        path: '/api/agent/run',
+        body: {
+          task: 't', instruction: 'go', agentId: 'myco-agent',
+          executionOverrides: {
+            provider: { type: 'openai', apiKey: SENTINELS.openai, baseUrl: 'https://attacker.example/v1' },
+          },
+        },
+      },
+    ];
+
+    for (const r of routes) {
+      const init: RequestInit = { method: r.method };
+      if (r.body !== undefined) {
+        init.headers = { 'Content-Type': 'application/json' };
+        init.body = JSON.stringify(r.body);
+      }
+      const res = await fetch(`${base}${r.path}`, init);
+      const text = await res.text();
+      assertNoLeak(`${r.method} ${r.path}`, text);
+    }
+
+    // Also verify the SSRF defense held: fetch was only ever called on the
+    // hardcoded provider hosts, never the attacker hostname.
+    for (const call of fetchMock.mock.calls) {
+      const url = String(call[0]);
+      expect(url).not.toContain('attacker.example');
+    }
+  });
+});

--- a/tests/daemon/api/providers-ssrf.test.ts
+++ b/tests/daemon/api/providers-ssrf.test.ts
@@ -1,0 +1,111 @@
+/**
+ * SSRF defense on /api/providers/test and /api/models.
+ *
+ * Caller-supplied baseUrl MUST be ignored for `openai`/`openrouter` so the
+ * daemon's stored bearer key is never sent to an attacker-controlled host.
+ * `openai-compatible` / `ollama` / `lmstudio` remain user-configurable.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { handleTestProvider } from '@myco/daemon/api/providers';
+import { handleGetModels } from '@myco/daemon/api/models';
+import { OPENAI_API_KEY_ENV } from '@myco/cli/providers/openai-embeddings.js';
+import { OPENROUTER_API_KEY_ENV } from '@myco/cli/providers/openrouter.js';
+
+const fetchMock = vi.fn();
+global.fetch = fetchMock as unknown as typeof fetch;
+
+vi.mock('@myco/intelligence/ollama.js', () => ({
+  OllamaBackend: class {
+    static DEFAULT_BASE_URL = 'http://localhost:11434';
+    async isAvailable() { return true; }
+    async listModels() { return []; }
+  },
+}));
+vi.mock('@myco/intelligence/lm-studio.js', () => ({
+  LmStudioBackend: class {
+    static DEFAULT_BASE_URL = 'http://localhost:1234';
+    async isAvailable() { return true; }
+    async listModels() { return []; }
+  },
+}));
+
+afterEach(() => {
+  fetchMock.mockReset();
+  vi.unstubAllEnvs();
+});
+
+describe('POST /api/providers/test — SSRF defense', () => {
+  it('IGNORES caller-supplied baseUrl for openai (uses hardcoded default)', async () => {
+    vi.stubEnv(OPENAI_API_KEY_ENV, 'sk-sentinel-ssrf');
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ data: [{ id: 'gpt-5' }] }) });
+
+    const result = await handleTestProvider({
+      body: { type: 'openai', baseUrl: 'https://attacker.example/v1' },
+      query: {}, params: {}, pathname: '/api/providers/test',
+    });
+
+    expect(result.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl.startsWith('https://api.openai.com/v1/')).toBe(true);
+    expect(calledUrl).not.toContain('attacker.example');
+  });
+
+  it('IGNORES caller-supplied baseUrl for openrouter (uses hardcoded default)', async () => {
+    vi.stubEnv(OPENROUTER_API_KEY_ENV, 'sk-sentinel-ssrf');
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ data: [{ id: 'openai/gpt-5' }] }) });
+
+    const result = await handleTestProvider({
+      body: { type: 'openrouter', base_url: 'https://attacker.example/v1' },
+      query: {}, params: {}, pathname: '/api/providers/test',
+    });
+
+    expect(result.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl.startsWith('https://openrouter.ai/api/v1/')).toBe(true);
+    expect(calledUrl).not.toContain('attacker.example');
+  });
+
+  it('HONORS caller-supplied baseUrl for openai-compatible (legitimate local path)', async () => {
+    const result = await handleTestProvider({
+      body: { type: 'openai-compatible', baseUrl: 'http://localhost:8080' },
+      query: {}, params: {}, pathname: '/api/providers/test',
+    });
+    // We don't assert on outcome; just that the code path accepted the baseUrl
+    // (backend mocks always report available), and importantly did NOT call
+    // out to https://attacker.example.
+    expect(result.status).toBe(200);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/models — SSRF defense', () => {
+  it('IGNORES caller-supplied base_url for openai', async () => {
+    vi.stubEnv(OPENAI_API_KEY_ENV, 'sk-sentinel-ssrf');
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ data: [{ id: 'gpt-5' }] }) });
+
+    await handleGetModels({
+      body: undefined, params: {}, pathname: '/api/models',
+      query: { provider: 'openai', base_url: 'https://attacker.example/v1' },
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl.startsWith('https://api.openai.com/v1/')).toBe(true);
+  });
+
+  it('IGNORES caller-supplied base_url for openrouter', async () => {
+    vi.stubEnv(OPENROUTER_API_KEY_ENV, 'sk-sentinel-ssrf');
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ data: [{ id: 'gpt-5' }] }) });
+
+    await handleGetModels({
+      body: undefined, params: {}, pathname: '/api/models',
+      query: { provider: 'openrouter', base_url: 'https://attacker.example/v1' },
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl.startsWith('https://openrouter.ai/api/v1/')).toBe(true);
+  });
+});

--- a/tests/daemon/api/schemas/execution-overrides-traversal.test.ts
+++ b/tests/daemon/api/schemas/execution-overrides-traversal.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for the shared executionOverrides provider traversal helper.
+ *
+ * `transformProviderOverrides` is the structural walker reused by both
+ * `sanitizeExecutionOverrides` (inbound) and `scrubExecutionOverrides`
+ * (outbound). These tests exercise the walker directly so behavior that
+ * matters to both call sites (no-mutation, phase traversal, null-means-
+ * delete) stays pinned independent of either transform.
+ */
+import { describe, it, expect } from 'vitest';
+import { transformProviderOverrides } from '@myco/daemon/api/schemas/execution-overrides-traversal';
+
+describe('transformProviderOverrides', () => {
+  it('returns null for null input', () => {
+    expect(transformProviderOverrides(null, (p) => p)).toBeNull();
+  });
+
+  it('returns null for undefined input', () => {
+    expect(transformProviderOverrides(undefined, (p) => p)).toBeNull();
+  });
+
+  it('applies the transform to the top-level provider', () => {
+    const input = {
+      provider: { type: 'openai', baseUrl: 'https://evil.example', apiKey: 'sk-abc' },
+    };
+    const out = transformProviderOverrides(input, (provider) => {
+      const { apiKey: _drop, ...rest } = provider;
+      return rest;
+    });
+    expect(out).toEqual({
+      provider: { type: 'openai', baseUrl: 'https://evil.example' },
+    });
+  });
+
+  it('applies the transform to every phase provider', () => {
+    const input = {
+      phases: {
+        research: {
+          model: 'gpt-4o',
+          provider: { type: 'openai', apiKey: 'sk-phase-1' },
+        },
+        compose: {
+          provider: { type: 'openrouter', apiKey: 'sk-phase-2', baseUrl: 'https://x' },
+        },
+      },
+    };
+    const out = transformProviderOverrides(input, (provider) => {
+      const { apiKey: _drop, ...rest } = provider;
+      return rest;
+    });
+    expect(out).toEqual({
+      phases: {
+        research: {
+          model: 'gpt-4o',
+          provider: { type: 'openai' },
+        },
+        compose: {
+          provider: { type: 'openrouter', baseUrl: 'https://x' },
+        },
+      },
+    });
+  });
+
+  it('removes the provider field when the transform returns null', () => {
+    const input = {
+      provider: { type: 'anthropic' },
+      phases: {
+        research: { provider: { type: 'openai' }, model: 'gpt-4o' },
+        compose: { provider: { type: 'openai' } },
+      },
+    };
+    const out = transformProviderOverrides(input, () => null);
+    expect(out).toEqual({
+      phases: {
+        research: { model: 'gpt-4o' },
+        compose: {},
+      },
+    });
+    expect(out).not.toHaveProperty('provider');
+  });
+
+  it('does not mutate the input (frozen top level and phases)', () => {
+    const providerObj = { type: 'openai', apiKey: 'sk-abc', baseUrl: 'https://x' };
+    const phaseObj = { provider: { type: 'openrouter', apiKey: 'sk-xyz' }, model: 'm' };
+    const input = {
+      runtime: 'openai-agents',
+      provider: providerObj,
+      phases: { compose: phaseObj },
+    };
+    Object.freeze(input);
+    Object.freeze(input.provider);
+    Object.freeze(input.phases);
+    Object.freeze(phaseObj);
+    Object.freeze(phaseObj.provider);
+
+    // Transform would otherwise try to delete .apiKey — proves we clone.
+    const out = transformProviderOverrides(input, (p) => {
+      const { apiKey: _drop, ...rest } = p;
+      return rest;
+    });
+
+    // Input unchanged
+    expect(providerObj).toEqual({ type: 'openai', apiKey: 'sk-abc', baseUrl: 'https://x' });
+    expect(phaseObj.provider).toEqual({ type: 'openrouter', apiKey: 'sk-xyz' });
+
+    // Output has apiKey stripped
+    expect(out).toEqual({
+      runtime: 'openai-agents',
+      provider: { type: 'openai', baseUrl: 'https://x' },
+      phases: { compose: { provider: { type: 'openrouter' }, model: 'm' } },
+    });
+  });
+
+  it('preserves unrelated top-level and per-phase fields', () => {
+    const input = {
+      runtime: 'claude-sdk',
+      reasoningLevel: 'high',
+      model: 'claude-opus',
+      provider: { type: 'anthropic' },
+      phases: {
+        research: {
+          reasoningLevel: 'low',
+          maxTurns: 12,
+          provider: { type: 'openai' },
+        },
+        plainPhase: {
+          model: 'gpt-4o',
+        },
+      },
+    };
+    const out = transformProviderOverrides(input, (p) => ({ ...p, tagged: true }));
+    expect(out).toEqual({
+      runtime: 'claude-sdk',
+      reasoningLevel: 'high',
+      model: 'claude-opus',
+      provider: { type: 'anthropic', tagged: true },
+      phases: {
+        research: {
+          reasoningLevel: 'low',
+          maxTurns: 12,
+          provider: { type: 'openai', tagged: true },
+        },
+        plainPhase: {
+          model: 'gpt-4o',
+        },
+      },
+    });
+  });
+
+  it('leaves non-object phases untouched (defensive)', () => {
+    // Shouldn't happen per schema, but the helper shouldn't throw.
+    const input = {
+      phases: {
+        weird: null as unknown as Record<string, unknown>,
+      },
+    };
+    const out = transformProviderOverrides(input, (p) => p);
+    expect(out).toEqual({ phases: { weird: null } });
+  });
+});

--- a/tests/daemon/api/sessions.test.ts
+++ b/tests/daemon/api/sessions.test.ts
@@ -7,6 +7,7 @@ import { createSchema } from '@myco/db/schema';
 import { upsertSession, getSession } from '@myco/db/queries/sessions';
 import { upsertPlan, getPlan } from '@myco/db/queries/plans';
 import { createSessionMutationHandlers } from '@myco/daemon/api/sessions';
+import { initTeamContext, resetTeamContext } from '@myco/daemon/team-context';
 import type { RouteRequest } from '@myco/daemon/router';
 
 /**
@@ -178,5 +179,77 @@ describe('handleDeletePlan', () => {
 
     expect(res.status).toBe(404);
     expect((res.body as { error: string }).error).toBe('Plan not found');
+  });
+});
+
+describe('handleDeletePlan — machine_id ownership', () => {
+  let tmpDir: string;
+  let embeddingManager: { onRemoved: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-plans-ownership-'));
+    const dbPath = path.join(tmpDir, 'myco.db');
+    const db = initDatabase(dbPath);
+    createSchema(db);
+    embeddingManager = { onRemoved: vi.fn() };
+    // Simulate a team-sync-enabled daemon on a known local machine id.
+    initTeamContext(false, 'local-machine-a');
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    resetTeamContext();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeHandlers() {
+    return createSessionMutationHandlers({
+      embeddingManager: embeddingManager as never,
+      vaultDir: tmpDir,
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+      liveConfig: { current: { agent: { event_tasks_enabled: false } } } as never,
+    });
+  }
+
+  function seedPlan(machineId: string) {
+    const now = Math.floor(Date.now() / 1000);
+    upsertSession({ id: 'sess-own', agent: 'a', started_at: now, created_at: now });
+    upsertPlan({
+      id: 'plan-owned',
+      logical_key: 'session:sess-own:key:primary',
+      session_id: 'sess-own',
+      title: 't', content: 'c',
+      created_at: now,
+      machine_id: machineId,
+    });
+  }
+
+  it('rejects DELETE for a plan owned by another machine (no force_remote)', async () => {
+    seedPlan('some-other-machine');
+    const { handleDeletePlan } = makeHandlers();
+    const res = await handleDeletePlan(makeRequest({ params: { id: 'plan-owned' } }));
+    expect(res.status).toBe(403);
+    expect(getPlan('plan-owned')).not.toBeNull();
+    expect(embeddingManager.onRemoved).not.toHaveBeenCalled();
+  });
+
+  it('allows DELETE for a remote-owned plan when force_remote=true', async () => {
+    seedPlan('some-other-machine');
+    const { handleDeletePlan } = makeHandlers();
+    const res = await handleDeletePlan(makeRequest({
+      params: { id: 'plan-owned' },
+      body: { force_remote: true },
+    }));
+    expect(res.status === undefined || res.status < 400).toBe(true);
+    expect(getPlan('plan-owned')).toBeNull();
+    expect(embeddingManager.onRemoved).toHaveBeenCalledWith('plans', 'plan-owned');
+  });
+
+  it('allows DELETE for a locally-owned plan without force_remote', async () => {
+    seedPlan('local-machine-a');
+    const { handleDeletePlan } = makeHandlers();
+    const res = await handleDeletePlan(makeRequest({ params: { id: 'plan-owned' } }));
+    expect(res.status === undefined || res.status < 400).toBe(true);
+    expect(getPlan('plan-owned')).toBeNull();
   });
 });

--- a/tests/daemon/server-security.test.ts
+++ b/tests/daemon/server-security.test.ts
@@ -1,0 +1,133 @@
+/**
+ * CSRF / Origin / Content-Type gate on the DaemonServer.
+ *
+ * The daemon listens only on 127.0.0.1 but any web page the user visits
+ * can still issue cross-origin POSTs. These tests pin down the middleware
+ * that rejects forbidden hosts/origins and non-JSON mutating bodies, so
+ * a regression cannot silently re-open the CSRF window that enables SSRF
+ * exfiltration of the daemon's stored provider API keys.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { DaemonServer } from '@myco/daemon/server';
+import { DaemonLogger } from '@myco/daemon/logger';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+describe('DaemonServer CSRF/Origin/Content-Type gate', () => {
+  let vaultDir: string;
+  let logger: DaemonLogger;
+  let server: DaemonServer;
+
+  beforeEach(async () => {
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-sec-'));
+    fs.mkdirSync(path.join(vaultDir, 'logs'), { recursive: true });
+    logger = new DaemonLogger(path.join(vaultDir, 'logs'));
+    server = new DaemonServer({ vaultDir, logger });
+    // A representative mutating route and a representative DELETE route.
+    server.registerRoute('POST', '/test/echo', async (req) => ({ body: { ok: true, received: req.body } }));
+    server.registerRoute('DELETE', '/test/thing/:id', async (req) => ({ body: { ok: true, id: req.params.id } }));
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    logger.close();
+    fs.rmSync(vaultDir, { recursive: true, force: true });
+  });
+
+  async function request(method: string, path: string, headers: Record<string, string>, body?: string) {
+    return fetch(`http://127.0.0.1:${server.port}${path}`, { method, headers, body });
+  }
+
+  it('rejects bogus Origin headers on POST with 403', async () => {
+    const res = await request('POST', '/test/echo', {
+      Origin: 'https://evil.example',
+      'Content-Type': 'application/json',
+    }, JSON.stringify({ hello: 'world' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('allows Origin: http://localhost:<port>', async () => {
+    const res = await request('POST', '/test/echo', {
+      Origin: `http://localhost:${server.port}`,
+      'Content-Type': 'application/json',
+    }, JSON.stringify({ hello: 'world' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('allows Origin: http://127.0.0.1:<port>', async () => {
+    const res = await request('POST', '/test/echo', {
+      Origin: `http://127.0.0.1:${server.port}`,
+      'Content-Type': 'application/json',
+    }, JSON.stringify({ hello: 'world' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('allows requests with no Origin header (curl, MCP, etc.)', async () => {
+    const res = await request('POST', '/test/echo', {
+      'Content-Type': 'application/json',
+    }, JSON.stringify({ hello: 'world' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects POST with a bogus Host header with 403', async () => {
+    // fetch() sets Host automatically; override via manual TCP to simulate
+    // an attacker rewriting Host. Use Node's http module directly.
+    const http = await import('node:http');
+    const result: { status: number; body: string } = await new Promise((resolve, reject) => {
+      const req = http.request({
+        host: '127.0.0.1',
+        port: server.port,
+        method: 'POST',
+        path: '/test/echo',
+        headers: {
+          Host: 'evil.example',
+          'Content-Type': 'application/json',
+          'Content-Length': 2,
+        },
+      }, (res) => {
+        let data = '';
+        res.on('data', (c) => { data += c; });
+        res.on('end', () => resolve({ status: res.statusCode!, body: data }));
+      });
+      req.on('error', reject);
+      req.write('{}');
+      req.end();
+    });
+    expect(result.status).toBe(403);
+  });
+
+  it('returns 415 on POST with Content-Type: text/plain and a JSON body', async () => {
+    const res = await request('POST', '/test/echo', {
+      'Content-Type': 'text/plain',
+    }, JSON.stringify({ hello: 'world' }));
+    expect(res.status).toBe(415);
+  });
+
+  it('accepts POST with Content-Type: application/json; charset=utf-8', async () => {
+    const res = await request('POST', '/test/echo', {
+      'Content-Type': 'application/json; charset=utf-8',
+    }, JSON.stringify({ hello: 'world' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('allows DELETE with no body and no Content-Type', async () => {
+    const res = await fetch(`http://127.0.0.1:${server.port}/test/thing/42`, {
+      method: 'DELETE',
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 415 on DELETE with Content-Type: text/plain and a JSON body', async () => {
+    const res = await request('DELETE', '/test/thing/42', {
+      'Content-Type': 'text/plain',
+    }, JSON.stringify({ force_remote: true }));
+    expect(res.status).toBe(415);
+  });
+
+  it('GET requests bypass the Content-Type gate', async () => {
+    const res = await fetch(`http://127.0.0.1:${server.port}/health`);
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

**Bundle A of the pre-0.21.0 quality pass.** Tag-blocker resolving the P0 SSRF triad and P1 CSRF gap surfaced by the [`/ce-review` of `myco/v0.20.2..HEAD`](../../docs/superpowers/plans/2026-04-18-pre-0.21.0-quality-pass.md). Without these fixes, any page the user visits can exfiltrate stored `OPENAI_API_KEY` / `OPENROUTER_API_KEY` via CSRF or DNS rebinding.

## Findings resolved

| # | Severity | File | Issue |
|---|----------|------|-------|
| 1 | P0 | `daemon/api/providers.ts` | SSRF via `POST /api/providers/test` baseUrl |
| 2 | P0 | `daemon/api/models.ts` | SSRF via `GET /api/models` base_url |
| 3 | P0 | `daemon/api/schemas/execution-overrides.ts` | SSRF via `executionOverrides.provider.baseUrl` |
| 4 | P1 | `daemon/server.ts` | Missing Origin/Host validation + Content-Type gate |
| 5 | P1 | `daemon/api/schemas/execution-overrides.ts` | `apiKey` echoed unmasked in `/api/agent/runs` |
| 22 | P2 | `daemon/api/sessions.ts` | `DELETE /api/plans/:id` has no ownership check |
| 64 | P3 | `agent/cost/openrouter.ts` | OpenRouter response validation + cache cap |

## What changed

**Defense-in-depth SSRF lockdown (layered, not redundant):**
- HTTP wire schema: `apiKey` dropped from `ProviderOverrideWireSchema`; zod silently strips.
- HTTP handlers: `fetchRemoteProviderModels` and `testRemoteProvider` ignore caller-supplied `baseUrl` for `openai` / `openrouter` — always use hardcoded `REMOTE_PROVIDER_DEFAULTS`.
- Runtime layer: `agent/runtime/openai.ts` and `agent/provider.ts` hardcode the default `baseURL` for remote providers even if the override slips past earlier layers.
- **`openai-compatible` / `ollama` / `lmstudio` paths are intentionally untouched** — user-supplied `baseUrl` is legitimate there.

**Daemon request gate (`validateLoopbackRequest` in `daemon/server.ts`):**
- Rejects non-loopback `Host` / non-matching `Origin` with 403 (absent Origin is allowed for curl/MCP).
- Enforces `Content-Type: application/json` on POST/PUT/PATCH/DELETE with a non-empty body. Empty-body DELETE still allowed.
- GETs unchanged.

**Per-row defense for historical data:** `scrubExecutionOverrides` in `run-serializer.ts` masks `apiKey` fields that may have been persisted before this PR landed — closes the GET-after-upgrade leak channel.

**Plan delete ownership:** `DELETE /api/plans/:id` on a plan from another machine now requires explicit `{"force_remote": true}` in the body. Both the allow and deny paths log a warning.

**OpenRouter catalog:** response shape validated at runtime (must be `{data: Array}`); capped at 10_000 entries; throws on violation so cache isn't poisoned.

**Shared traversal helper:** `schemas/execution-overrides-traversal.ts` with 8 unit tests. Both inbound (`sanitizeExecutionOverrides`) and outbound (`scrubExecutionOverrides`) paths walk the same structure via the helper — adding a new override field next time requires one change, not two.

## Test plan

- [x] `make check` (lint + test) — **2888 passed, 3 skipped, 0 failed**
- [x] `make build` — all packages + UI bundle built
- [x] New `tests/daemon/api/key-leak-guard.test.ts` — integration test that seeds sentinel API keys into env and asserts they never appear in any response body across the route list (also asserts `attacker.example` is never fetched)
- [x] Origin/Host unit tests (`tests/daemon/server-security.test.ts`): bogus Origin → 403, valid loopback → 200, missing Origin → 200, bad Host via raw `http.request` → 403
- [x] Content-Type: text/plain POST → 415; application/json → 200; empty DELETE → 200
- [x] SSRF sinks (`tests/daemon/api/providers-ssrf.test.ts`, `agent-runs-overrides-security.test.ts`): attacker `baseUrl` for openai/openrouter ignored; `openai-compatible` + localhost unaffected; per-phase overrides sanitized
- [x] `executionOverrides.apiKey` schema rejection + stored-row scrub coverage
- [x] Plan-delete ownership: remote plan without `force_remote` → 403; with flag → 200 + tombstone; local plan → 200
- [x] OpenRouter (`tests/agent/openrouter-catalog.test.ts`): `data=null`, non-object, >10k entries all throw and leave cache empty
- [x] New `tests/daemon/api/schemas/execution-overrides-traversal.test.ts` — 8 helper tests (passthrough, top-level + phase transform, transform-returns-null removal, freeze-input no-mutation, preserve unrelated fields, non-object phase values)

## Deferred to follow-ups (not this PR)

- Registry-driven route iteration for `key-leak-guard.test.ts` (currently hardcoded list; acceptable short-term)
- IPv6 loopback (`[::1]`) in allowlist — daemon binds IPv4 only today
- `ProviderConfig.apiKey` in task YAML — legitimate path (user's own key), not an attacker-controlled API wire path
- Full allowlist scaffold `config.providers.<type>.allowed_base_urls` — YAGNI until a real use-case appears
- `scrubExecutionOverrides` removal trigger documented via TODO(post-v0.22) comment

## Next in the pre-0.21.0 sequence

Per [plan](../../docs/superpowers/plans/2026-04-18-pre-0.21.0-quality-pass.md): Bundles B (migration safety) / C (runtime + reliability) / D (MCP parity) / E (cleanup sweep) can run in parallel worktrees now that A has landed. Each is one squash-merged PR; total 5 PRs before the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)