### PR TITLE
mcp(parity): add myco_cortex, myco_runs, extend myco_plans

### DIFF
--- a/packages/myco/src/daemon/api/mcp-proxy.ts
+++ b/packages/myco/src/daemon/api/mcp-proxy.ts
@@ -18,7 +18,7 @@ import { getDatabase } from '@myco/db/client.js';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import { getLatestOpenBatch } from '@myco/db/queries/batches.js';
 import { insertSpore, updateSporeStatus } from '@myco/db/queries/spores.js';
-import { getPlan, listPlans } from '@myco/db/queries/plans.js';
+import { getPlan, listPlans, listPlansBySession } from '@myco/db/queries/plans.js';
 import { getSession, listSessions } from '@myco/db/queries/sessions.js';
 import { listTeamMembers } from '@myco/db/queries/team-members.js';
 import { insertResolutionEvent } from '@myco/db/queries/resolution-events.js';
@@ -320,9 +320,22 @@ export function createMcpProxyHandlers(deps: McpProxyDeps) {
     };
   }
 
-  /** GET /api/mcp/plans — list plans, or return a single plan with content when id is set. */
+  /** GET /api/mcp/plans — list plans, or return a single plan with content when id is set.
+   *
+   * Supports:
+   *   - id: single plan lookup (returns plan with content)
+   *   - session: filter plans for a given session (mirrors /api/sessions/:id/plans)
+   *   - status/limit: list filters
+   *
+   * `id` and `session` are mutually exclusive; passing both yields a 400.
+   */
   async function handlePlans(req: RouteRequest): Promise<RouteResponse> {
     const id = typeof req.query.id === 'string' ? req.query.id : undefined;
+    const session = typeof req.query.session === 'string' ? req.query.session : undefined;
+
+    if (id && session) {
+      return { status: 400, body: { error: 'Pass either id or session, not both' } };
+    }
 
     if (id) {
       const row = getPlan(id);
@@ -335,6 +348,12 @@ export function createMcpProxyHandlers(deps: McpProxyDeps) {
           }],
         },
       };
+    }
+
+    if (session) {
+      const rows = listPlansBySession(session);
+      const plans = rows.map(toPlanSummary);
+      return { body: { plans } };
     }
 
     const statusFilter = req.query.status === 'all' ? undefined : req.query.status;

--- a/packages/myco/src/hooks/client.ts
+++ b/packages/myco/src/hooks/client.ts
@@ -92,15 +92,21 @@ export class DaemonClient {
     }
   }
 
-  async delete(endpoint: string): Promise<ClientResult> {
+  async delete(endpoint: string, body?: unknown): Promise<ClientResult> {
     try {
       const info = this.readDaemonJson();
       if (!info) return { ok: false };
 
-      const res = await fetch(`http://127.0.0.1:${info.port}${endpoint}`, {
+      const init: RequestInit = {
         method: 'DELETE',
         signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
-      });
+      };
+      if (body !== undefined) {
+        init.headers = { 'Content-Type': 'application/json' };
+        init.body = JSON.stringify(body);
+      }
+
+      const res = await fetch(`http://127.0.0.1:${info.port}${endpoint}`, init);
 
       if (!res.ok) return { ok: false };
       const data = await res.json();

--- a/packages/myco/src/hooks/client.ts
+++ b/packages/myco/src/hooks/client.ts
@@ -108,7 +108,15 @@ export class DaemonClient {
 
       const res = await fetch(`http://127.0.0.1:${info.port}${endpoint}`, init);
 
-      if (!res.ok) return { ok: false };
+      if (!res.ok) {
+        // Attempt to parse JSON error body so callers (e.g. the myco_plans
+        // delete path) can surface daemon guidance like the force_remote hint.
+        // post/put/get currently discard error bodies — see note on the DELETE
+        // flow in packages/myco/src/mcp/tools/plans.ts. Expanding the pattern
+        // to those methods is a separate follow-up.
+        const body = await res.json().catch(() => undefined);
+        return { ok: false, data: body };
+      }
       const data = await res.json();
       return { ok: true, data };
     } catch {

--- a/packages/myco/src/mcp/server.ts
+++ b/packages/myco/src/mcp/server.ts
@@ -20,6 +20,8 @@ import { handleMycoConsolidate } from './tools/consolidate.js';
 import { handleMycoContext } from './tools/context.js';
 import { handleMycoSkills, handleMycoSkillCandidates } from './tools/skills.js';
 import { handleCollectiveProject, handleCollectiveProjects, handleCollectiveSearch } from './tools/collective.js';
+import { handleMycoCortex } from './tools/cortex.js';
+import { handleMycoRuns } from './tools/runs.js';
 import { resolveVaultDir } from '../vault/resolve.js';
 import { DaemonClient } from '../hooks/client.js';
 import { DAEMON_CLIENT_TIMEOUT_MS } from '../constants.js';
@@ -30,6 +32,7 @@ import {
   TOOL_TEAM, TOOL_GRAPH, TOOL_SUPERSEDE, TOOL_CONSOLIDATE,
   TOOL_CONTEXT, TOOL_SKILLS, TOOL_SKILL_CANDIDATES,
   TOOL_COLLECTIVE_SEARCH, TOOL_COLLECTIVE_PROJECTS, TOOL_COLLECTIVE_PROJECT,
+  TOOL_CORTEX, TOOL_RUNS,
   COLLECTIVE_TOOL_DEFINITIONS,
 } from './tool-definitions.js';
 
@@ -110,9 +113,23 @@ export function createMycoServer(vaultDir: string, client: DaemonClient): MycoSe
         return { content: [{ type: 'text', text: JSON.stringify(result) }] };
       }
       case TOOL_PLANS: {
-        const plansInput = input as { id?: string; status?: string; limit?: number };
+        const plansInput = input as {
+          op?: 'list' | 'delete';
+          id?: string;
+          session?: string;
+          status?: string;
+          limit?: number;
+          force_remote?: boolean;
+        };
         const result = await handleMycoPlans(plansInput, client);
-        logActivity(TOOL_PLANS, { count: result.length, duration_ms: Date.now() - start });
+        const count = Array.isArray(result) ? result.length : undefined;
+        logActivity(TOOL_PLANS, {
+          op: plansInput.op ?? 'list',
+          id: plansInput.id,
+          session: plansInput.session,
+          count,
+          duration_ms: Date.now() - start,
+        });
         return { content: [{ type: 'text', text: JSON.stringify(result) }] };
       }
       case TOOL_SAVE_PLAN: {
@@ -211,6 +228,39 @@ export function createMycoServer(vaultDir: string, client: DaemonClient): MycoSe
         const collectiveInput = input as { project: string; include_digest?: boolean };
         const result = await handleCollectiveProject(collectiveInput, client);
         logActivity(TOOL_COLLECTIVE_PROJECT, { project: collectiveInput.project, duration_ms: Date.now() - start });
+        return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+      }
+      case TOOL_CORTEX: {
+        const cortexInput = input as {
+          op: 'get' | 'refresh' | 'build_prompt' | 'get_prompt_result';
+          run_id?: string;
+          goal?: string;
+          symbiont?: string;
+        };
+        const result = await handleMycoCortex(cortexInput, client);
+        logActivity(TOOL_CORTEX, {
+          op: cortexInput.op,
+          run_id: cortexInput.run_id,
+          ok: result.ok,
+          duration_ms: Date.now() - start,
+        });
+        return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+      }
+      case TOOL_RUNS: {
+        const runsInput = input as {
+          op?: 'list' | 'get';
+          id?: string;
+          task?: string;
+          agent_id?: string;
+          limit?: number;
+        };
+        const result = await handleMycoRuns(runsInput, client);
+        logActivity(TOOL_RUNS, {
+          op: runsInput.op ?? 'list',
+          id: runsInput.id,
+          ok: result.ok,
+          duration_ms: Date.now() - start,
+        });
         return { content: [{ type: 'text', text: JSON.stringify(result) }] };
       }
       default:

--- a/packages/myco/src/mcp/tool-definitions.ts
+++ b/packages/myco/src/mcp/tool-definitions.ts
@@ -28,10 +28,32 @@ export interface ToolCortexMetadata {
   requiresCollective?: boolean;
 }
 
+/**
+ * MCP tool annotations. These follow the MCP spec's `annotations` envelope
+ * so clients can show the right UI affordances (confirm-before-run for
+ * destructive tools, quiet auto-run for read-only ones, etc.). Bundle D
+ * makes these mandatory for every Myco-registered tool.
+ */
+export interface ToolAnnotations {
+  /** True if the tool never mutates state. */
+  readOnlyHint: boolean;
+  /**
+   * True if the tool can destroy data or start work that's hard to undo.
+   * For multi-op tools, set true if ANY op is destructive and describe
+   * the op matrix in the tool description.
+   */
+  destructiveHint: boolean;
+  /** True if calling the tool twice with the same input is safe. */
+  idempotentHint: boolean;
+  /** True if the tool reaches outside the local vault (network, other machines). */
+  openWorldHint: boolean;
+}
+
 export interface ToolDefinition {
   name: string;
   description: string;
   inputSchema: ToolInputSchema;
+  annotations?: ToolAnnotations;
   cortex?: ToolCortexMetadata;
 }
 
@@ -56,6 +78,8 @@ export const TOOL_SKILL_CANDIDATES = 'myco_skill_candidates';
 export const TOOL_COLLECTIVE_SEARCH = 'collective_search';
 export const TOOL_COLLECTIVE_PROJECTS = 'collective_projects';
 export const TOOL_COLLECTIVE_PROJECT = 'collective_project';
+export const TOOL_CORTEX = 'myco_cortex';
+export const TOOL_RUNS = 'myco_runs';
 
 // --- Shared property descriptions (used by multiple tools) ---
 const PROP_BRANCH = 'Git branch name to find related sessions and plans';
@@ -115,16 +139,28 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   },
   {
     name: TOOL_PLANS,
-    description: 'List active implementation plans and their status. Use to check what work is in flight before starting new tasks.',
+    description: 'List or delete implementation plans. op: "list" (default) returns plan summaries — filter by status, session, or a single id. op: "delete" removes a plan by id; cross-machine rows require force_remote: true. Use list to check what work is in flight before starting new tasks; use delete when retiring obsolete plans.',
+    annotations: {
+      // Destructive because op: "delete" removes a plan and enqueues a tombstone.
+      // Consumers should confirm before running this tool with op: "delete".
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     cortex: {
-      guidance: 'Use before implementation when approved plans or specs may already exist.',
+      guidance: 'Use op: "list" before implementation when approved plans or specs may already exist; pass session to scope to the current work, or id to fetch a single plan with content.',
       priority: 50,
     },
     inputSchema: {
       type: 'object' as const,
       properties: {
-        status: { type: 'string', enum: PLAN_STATUS_FILTER, description: 'Filter by status (default: all statuses)' },
-        id: { type: 'string', description: 'Get a specific plan by ID' },
+        op: { type: 'string', enum: ['list', 'delete'], description: 'Operation (default: "list")' },
+        status: { type: 'string', enum: PLAN_STATUS_FILTER, description: 'Filter by status (default: all statuses); ignored for op: "delete"' },
+        id: { type: 'string', description: 'Plan id. Required for op: "delete". For op: "list" returns that plan with content.' },
+        session: { type: 'string', description: 'Filter list to plans belonging to this session; mutually exclusive with id.' },
+        limit: { type: 'number', description: 'Max results for op: "list"' },
+        force_remote: { type: 'boolean', description: 'Allow op: "delete" to remove a plan belonging to another machine. Enqueues a tombstone for team sync.' },
       },
     },
   },
@@ -274,6 +310,57 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
         action: { type: 'string', enum: ['list', 'approve', 'dismiss'], description: "Action to perform (default: 'list')" },
         status: { type: 'string', description: 'Filter by status: identified, approved, generated, dismissed' },
         limit: { type: 'number', description: `Max results (default: ${MCP_SKILLS_DEFAULT_LIMIT})` },
+      },
+    },
+  },
+  {
+    name: TOOL_CORTEX,
+    description: 'Cortex instruction + prompt-builder surface. op: "get" returns the current session-start instructions snapshot. op: "refresh" triggers the cortex-instructions task to regenerate them. op: "build_prompt" starts the cortex-prompt-builder task for a goal (required) and optional symbiont. op: "get_prompt_result" polls a prompt-builder run by run_id. Refresh and build_prompt are not read-only — they start background runs.',
+    annotations: {
+      // Mixed: get/get_prompt_result are read-only, refresh/build_prompt kick
+      // off background work. Mark conservatively — consumers should not silently
+      // auto-run this tool.
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    cortex: {
+      guidance: 'Use op: "get" to read your own session-start Cortex instructions; use op: "build_prompt" + "get_prompt_result" when you need the prompt-builder to draft a prompt for a specific goal.',
+      priority: 95,
+    },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        op: { type: 'string', enum: ['get', 'refresh', 'build_prompt', 'get_prompt_result'], description: 'Cortex operation' },
+        run_id: { type: 'string', description: 'Required for op: "get_prompt_result"' },
+        goal: { type: 'string', description: 'Required for op: "build_prompt" — the task the prompt will be built for' },
+        symbiont: { type: 'string', description: 'Optional symbiont/agent name the prompt should be tuned for; defaults to the first enabled symbiont' },
+      },
+      required: ['op'],
+    },
+  },
+  {
+    name: TOOL_RUNS,
+    description: 'Read agent run history. op: "list" (default) returns recent runs with runtime/provider/model/token/cost/reasoning fields — filter by task, agent_id, limit. op: "get" with id returns a single run including write_intents totals and duration_ms. Use after a run completes to check your own token budget, cost, and reasoning level — particularly useful when debugging a run that exhausted context.',
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    cortex: {
+      guidance: 'Use op: "get" with your run id to check your own token budget, cost, and reasoning level — especially after a run that exhausted context or failed. Use op: "list" to browse recent runs for a task.',
+      priority: 85,
+    },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        op: { type: 'string', enum: ['list', 'get'], description: 'Operation (default: "list")' },
+        id: { type: 'string', description: 'Required for op: "get" — the run id' },
+        task: { type: 'string', description: 'Filter op: "list" by task name' },
+        agent_id: { type: 'string', description: 'Filter op: "list" by agent id' },
+        limit: { type: 'number', description: 'Max results for op: "list" (default: 50)' },
       },
     },
   },

--- a/packages/myco/src/mcp/tools/cortex.ts
+++ b/packages/myco/src/mcp/tools/cortex.ts
@@ -1,0 +1,86 @@
+/**
+ * myco_cortex — Cortex instruction + prompt-builder surface.
+ *
+ * Mirrors /api/cortex/* so agents can:
+ *   - read their current session-start instructions
+ *   - refresh them (kicks off the cortex-instructions task)
+ *   - start a prompt-builder run for a goal
+ *   - poll the prompt-builder result by run id
+ *
+ * Proxies through the daemon HTTP API via DaemonClient.
+ */
+
+import type { DaemonClient } from '@myco/hooks/client.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type CortexOp = 'get' | 'refresh' | 'build_prompt' | 'get_prompt_result';
+
+export interface CortexInput {
+  op: CortexOp;
+  run_id?: string;
+  goal?: string;
+  symbiont?: string;
+}
+
+export interface CortexHandlerResult {
+  ok: boolean;
+  op: CortexOp;
+  data?: unknown;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export async function handleMycoCortex(
+  input: CortexInput,
+  client: DaemonClient,
+): Promise<CortexHandlerResult> {
+  switch (input.op) {
+    case 'get': {
+      const result = await client.get('/api/cortex/instructions');
+      if (!result.ok) return { ok: false, op: input.op, error: 'fetch_failed' };
+      return { ok: true, op: input.op, data: result.data };
+    }
+
+    case 'refresh': {
+      const result = await client.post('/api/cortex/instructions/refresh', {});
+      if (!result.ok) return { ok: false, op: input.op, error: 'refresh_failed' };
+      return { ok: true, op: input.op, data: result.data };
+    }
+
+    case 'build_prompt': {
+      if (!input.goal || input.goal.trim().length === 0) {
+        return { ok: false, op: input.op, error: 'goal is required' };
+      }
+      const body: Record<string, unknown> = { goal: input.goal };
+      if (input.symbiont) body.symbiont = input.symbiont;
+      const result = await client.post('/api/cortex/prompt-builder', body);
+      if (!result.ok) return { ok: false, op: input.op, error: 'build_prompt_failed' };
+      return { ok: true, op: input.op, data: result.data };
+    }
+
+    case 'get_prompt_result': {
+      if (!input.run_id) {
+        return { ok: false, op: input.op, error: 'run_id is required' };
+      }
+      const result = await client.get(
+        `/api/cortex/prompt-builder/${encodeURIComponent(input.run_id)}`,
+      );
+      if (!result.ok) {
+        return { ok: false, op: input.op, error: 'not_ready_or_not_found' };
+      }
+      return { ok: true, op: input.op, data: result.data };
+    }
+
+    default: {
+      // TypeScript exhaustiveness — should be unreachable.
+      const _exhaustive: never = input.op;
+      return { ok: false, op: _exhaustive, error: 'unknown_op' };
+    }
+  }
+}

--- a/packages/myco/src/mcp/tools/plans.ts
+++ b/packages/myco/src/mcp/tools/plans.ts
@@ -1,7 +1,11 @@
 /**
- * myco_plans — list active implementation plans and their status.
+ * myco_plans — list active implementation plans or delete one.
  *
  * Proxies through the daemon HTTP API via DaemonClient.
+ *
+ * Ops:
+ *   - list: list plans, filterable by status, session, or a single id.
+ *   - delete: remove a plan; cross-machine rows require {force_remote: true}.
  */
 
 import type { DaemonClient } from '@myco/hooks/client.js';
@@ -11,13 +15,16 @@ import { buildEndpoint } from './shared.js';
 // Types
 // ---------------------------------------------------------------------------
 
-interface PlansInput {
+export interface PlansInput {
+  op?: 'list' | 'delete';
   id?: string;
+  session?: string;
   status?: string;
   limit?: number;
+  force_remote?: boolean;
 }
 
-interface PlanSummary {
+export interface PlanSummary {
   id: string;
   title: string | null;
   status: string;
@@ -28,6 +35,15 @@ interface PlanSummary {
   content?: string | null;
 }
 
+export interface PlanDeleteResult {
+  ok: boolean;
+  id?: string;
+  session_id?: string | null;
+  error?: string;
+}
+
+export type PlansResult = PlanSummary[] | PlanDeleteResult;
+
 // ---------------------------------------------------------------------------
 // Handler
 // ---------------------------------------------------------------------------
@@ -35,9 +51,37 @@ interface PlanSummary {
 export async function handleMycoPlans(
   input: PlansInput,
   client: DaemonClient,
-): Promise<PlanSummary[]> {
+): Promise<PlansResult> {
+  const op = input.op ?? 'list';
+
+  if (op === 'delete') {
+    if (!input.id) {
+      return { ok: false, error: 'id is required for op: delete' };
+    }
+    const body = input.force_remote ? { force_remote: true } : undefined;
+    const result = await client.delete(`/api/plans/${encodeURIComponent(input.id)}`, body);
+    if (!result.ok) {
+      return {
+        ok: false,
+        error: result.data?.error ?? 'delete_failed',
+      };
+    }
+    return {
+      ok: Boolean(result.data?.ok),
+      id: result.data?.id,
+      session_id: result.data?.session_id ?? null,
+    };
+  }
+
+  // op === 'list' (default)
+  if (input.id && input.session) {
+    // Defensive: the daemon also rejects this, but fail fast here for clarity.
+    return [];
+  }
+
   const endpoint = buildEndpoint('/api/mcp/plans', {
     id: input.id,
+    session: input.session,
     status: input.status,
     limit: input.limit,
   });

--- a/packages/myco/src/mcp/tools/plans.ts
+++ b/packages/myco/src/mcp/tools/plans.ts
@@ -42,7 +42,14 @@ export interface PlanDeleteResult {
   error?: string;
 }
 
-export type PlansResult = PlanSummary[] | PlanDeleteResult;
+/** Error shape returned from op: "list" when input validation fails
+ *  (e.g. both `id` and `session` supplied). Matches the daemon's 400 body. */
+export interface PlansListError {
+  ok: false;
+  error: string;
+}
+
+export type PlansResult = PlanSummary[] | PlanDeleteResult | PlansListError;
 
 // ---------------------------------------------------------------------------
 // Handler
@@ -75,8 +82,9 @@ export async function handleMycoPlans(
 
   // op === 'list' (default)
   if (input.id && input.session) {
-    // Defensive: the daemon also rejects this, but fail fast here for clarity.
-    return [];
+    // Match the daemon's /api/mcp/plans 400 behavior — surface the rejection
+    // as a structured error instead of silently returning [].
+    return { ok: false, error: 'Pass either id or session, not both' };
   }
 
   const endpoint = buildEndpoint('/api/mcp/plans', {

--- a/packages/myco/src/mcp/tools/runs.ts
+++ b/packages/myco/src/mcp/tools/runs.ts
@@ -31,8 +31,6 @@ export interface RunsHandlerResult {
   error?: string;
 }
 
-const DEFAULT_LIMIT = 50;
-
 // ---------------------------------------------------------------------------
 // Handler
 // ---------------------------------------------------------------------------
@@ -56,11 +54,12 @@ export async function handleMycoRuns(
     return { ok: true, op, data: result.data };
   }
 
-  // op === 'list'
+  // op === 'list' — defer the default limit to the HTTP route so the two
+  // defaults can't drift. Only forward `limit` when the caller sets it.
   const endpoint = buildEndpoint('/api/agent/runs', {
     task: input.task,
     agentId: input.agent_id,
-    limit: input.limit ?? DEFAULT_LIMIT,
+    limit: input.limit,
   });
   const result = await client.get(endpoint);
   if (!result.ok) {

--- a/packages/myco/src/mcp/tools/runs.ts
+++ b/packages/myco/src/mcp/tools/runs.ts
@@ -1,0 +1,70 @@
+/**
+ * myco_runs — agent run read surface.
+ *
+ * Mirrors GET /api/agent/runs and GET /api/agent/runs/:id so agents can see
+ * their own token budget, cost, reasoning level, and phase checkpoints.
+ *
+ * Proxies through the daemon HTTP API via DaemonClient.
+ */
+
+import type { DaemonClient } from '@myco/hooks/client.js';
+import { buildEndpoint } from './shared.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RunsOp = 'list' | 'get';
+
+export interface RunsInput {
+  op?: RunsOp;
+  id?: string;
+  task?: string;
+  agent_id?: string;
+  limit?: number;
+}
+
+export interface RunsHandlerResult {
+  ok: boolean;
+  op: RunsOp;
+  data?: unknown;
+  error?: string;
+}
+
+const DEFAULT_LIMIT = 50;
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export async function handleMycoRuns(
+  input: RunsInput,
+  client: DaemonClient,
+): Promise<RunsHandlerResult> {
+  const op = input.op ?? 'list';
+
+  if (op === 'get') {
+    if (!input.id) {
+      return { ok: false, op, error: 'id is required for op: get' };
+    }
+    const result = await client.get(
+      `/api/agent/runs/${encodeURIComponent(input.id)}`,
+    );
+    if (!result.ok) {
+      return { ok: false, op, error: 'not_found' };
+    }
+    return { ok: true, op, data: result.data };
+  }
+
+  // op === 'list'
+  const endpoint = buildEndpoint('/api/agent/runs', {
+    task: input.task,
+    agentId: input.agent_id,
+    limit: input.limit ?? DEFAULT_LIMIT,
+  });
+  const result = await client.get(endpoint);
+  if (!result.ok) {
+    return { ok: false, op, error: 'fetch_failed' };
+  }
+  return { ok: true, op, data: result.data };
+}

--- a/tests/context/cortex-brief.test.ts
+++ b/tests/context/cortex-brief.test.ts
@@ -35,4 +35,28 @@ describe('RETRIEVAL_GUIDANCE', () => {
       'myco_recall',
     ]);
   });
+
+  // Anti-drift for Bundle D (pre-0.21.0 MCP parity).
+  // If someone removes one of these tools from TOOL_DEFINITIONS or strips
+  // its `cortex` entry, the brief would silently stop advertising the new
+  // parity surfaces and agents would lose the session-start guidance.
+  it('includes the Bundle D must-ship tools so the Cortex brief advertises them', () => {
+    const names = RETRIEVAL_GUIDANCE.map((entry) => entry.tool);
+    expect(names).toContain('myco_cortex');
+    expect(names).toContain('myco_runs');
+    // myco_plans has always been in the brief, but Bundle D extended its
+    // schema. Keep a presence check so a future refactor can't drop it.
+    expect(names).toContain('myco_plans');
+  });
+
+  it('injects Bundle D tool guidance into the brief body', () => {
+    const lines = buildRetrievalGuidanceLines({
+      teamEnabled: false,
+      collectiveConnected: false,
+      collectiveCapabilities: [],
+    });
+    const body = lines.join('\n');
+    expect(body).toContain('`myco_cortex`');
+    expect(body).toContain('`myco_runs`');
+  });
 });

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -18,7 +18,7 @@ describe('MCP Server', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('registers all 13 core tools', () => {
+  it('registers all 15 core tools', () => {
     const server = createMycoServer(tmpDir, client);
     const tools = server.getRegisteredTools();
     expect(tools).toContain('myco_search');
@@ -34,7 +34,10 @@ describe('MCP Server', () => {
     expect(tools).toContain('myco_context');
     expect(tools).toContain('myco_skills');
     expect(tools).toContain('myco_skill_candidates');
-    expect(tools).toHaveLength(13);
+    // Bundle D additions (pre-0.21.0 agent-native MCP parity).
+    expect(tools).toContain('myco_cortex');
+    expect(tools).toContain('myco_runs');
+    expect(tools).toHaveLength(15);
   });
 
   it('does not leak collective tools into the core registration', () => {

--- a/tests/mcp/tool-definitions.test.ts
+++ b/tests/mcp/tool-definitions.test.ts
@@ -117,6 +117,34 @@ describe('TOOL_DEFINITIONS registration coverage', () => {
       expect(tool.name).toMatch(/^(myco_|collective_)/);
     }
   });
+
+  // Bundle D harness-properties discipline: every Bundle D tool (and any tool
+  // that carries annotations) must set all four MCP annotation fields so
+  // clients can render the correct confirmation UI. Missing any one of these
+  // is a regression.
+  it('Bundle D tools declare full MCP annotations', () => {
+    const required = ['myco_cortex', 'myco_plans', 'myco_runs'];
+    for (const name of required) {
+      const tool = TOOL_DEFINITIONS.find((t) => t.name === name);
+      expect(tool, `Tool ${name} missing from TOOL_DEFINITIONS`).toBeDefined();
+      expect(tool!.annotations, `Tool ${name} missing annotations`).toBeDefined();
+      expect(typeof tool!.annotations!.readOnlyHint).toBe('boolean');
+      expect(typeof tool!.annotations!.destructiveHint).toBe('boolean');
+      expect(typeof tool!.annotations!.idempotentHint).toBe('boolean');
+      expect(typeof tool!.annotations!.openWorldHint).toBe('boolean');
+    }
+  });
+
+  it('myco_runs is annotated as fully read-only', () => {
+    const runs = TOOL_DEFINITIONS.find((t) => t.name === 'myco_runs');
+    expect(runs?.annotations?.readOnlyHint).toBe(true);
+    expect(runs?.annotations?.destructiveHint).toBe(false);
+  });
+
+  it('myco_plans declares destructive: true because op: delete removes plans', () => {
+    const plans = TOOL_DEFINITIONS.find((t) => t.name === 'myco_plans');
+    expect(plans?.annotations?.destructiveHint).toBe(true);
+  });
 });
 
 /**

--- a/tests/mcp/tool-definitions.test.ts
+++ b/tests/mcp/tool-definitions.test.ts
@@ -135,15 +135,41 @@ describe('TOOL_DEFINITIONS registration coverage', () => {
     }
   });
 
-  it('myco_runs is annotated as fully read-only', () => {
+  // Pin every annotation VALUE for every Bundle D tool. The shape-only check
+  // above would pass even if someone silently flipped an annotation (e.g.
+  // set destructiveHint: false on myco_plans, suppressing the confirmation
+  // UI). These assertions freeze the intended semantics.
+  it('myco_cortex annotations are pinned (mixed read/mutating ops — conservative)', () => {
+    const cortex = TOOL_DEFINITIONS.find((t) => t.name === 'myco_cortex');
+    // Conservative single set covering all ops: refresh/build_prompt kick off
+    // background runs, so readOnlyHint must stay false. None of the ops
+    // destroy data, so destructiveHint is false. The set is not idempotent
+    // because repeated build_prompt calls produce distinct runs. Everything
+    // is local-only, so openWorldHint is false.
+    expect(cortex?.annotations?.readOnlyHint).toBe(false);
+    expect(cortex?.annotations?.destructiveHint).toBe(false);
+    expect(cortex?.annotations?.idempotentHint).toBe(false);
+    expect(cortex?.annotations?.openWorldHint).toBe(false);
+  });
+
+  it('myco_runs annotations are pinned (fully read-only, idempotent, local)', () => {
     const runs = TOOL_DEFINITIONS.find((t) => t.name === 'myco_runs');
     expect(runs?.annotations?.readOnlyHint).toBe(true);
     expect(runs?.annotations?.destructiveHint).toBe(false);
+    expect(runs?.annotations?.idempotentHint).toBe(true);
+    expect(runs?.annotations?.openWorldHint).toBe(false);
   });
 
-  it('myco_plans declares destructive: true because op: delete removes plans', () => {
+  it('myco_plans annotations are pinned (destructive via op: "delete", idempotent, local)', () => {
     const plans = TOOL_DEFINITIONS.find((t) => t.name === 'myco_plans');
+    // op: "delete" mutates and removes data, so readOnlyHint must be false
+    // and destructiveHint true. Deleting an already-deleted plan is a no-op
+    // (returns 404), so idempotentHint is true. Tombstones for remote
+    // deletes are still local-only state, so openWorldHint is false.
+    expect(plans?.annotations?.readOnlyHint).toBe(false);
     expect(plans?.annotations?.destructiveHint).toBe(true);
+    expect(plans?.annotations?.idempotentHint).toBe(true);
+    expect(plans?.annotations?.openWorldHint).toBe(false);
   });
 });
 

--- a/tests/mcp/tools/cortex.test.ts
+++ b/tests/mcp/tools/cortex.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for myco_cortex tool handler.
+ *
+ * Covers the four op discriminators: get / refresh / build_prompt /
+ * get_prompt_result. Each mirror a /api/cortex/* HTTP endpoint — these
+ * tests only verify the MCP adapter layer forwards inputs correctly.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { handleMycoCortex } from '@myco/mcp/tools/cortex.js';
+import type { DaemonClient } from '@myco/hooks/client.js';
+
+function mockClient(data: unknown = null, ok = true): DaemonClient {
+  return {
+    get: vi.fn().mockResolvedValue({ ok, data }),
+    post: vi.fn().mockResolvedValue({ ok, data }),
+    delete: vi.fn(),
+    put: vi.fn(),
+  } as unknown as DaemonClient;
+}
+
+describe('myco_cortex op: get', () => {
+  it('reads the instructions snapshot from /api/cortex/instructions', async () => {
+    const snapshot = {
+      content: 'cortex instructions body',
+      generatedAt: 1700000000,
+      sourceRunId: 'run-1',
+      enabled: true,
+      stored: true,
+    };
+    const client = mockClient(snapshot);
+    const result = await handleMycoCortex({ op: 'get' }, client);
+    expect(client.get).toHaveBeenCalledWith('/api/cortex/instructions');
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual(snapshot);
+  });
+
+  it('surfaces a failure when the daemon is unreachable', async () => {
+    const client = mockClient(null, false);
+    const result = await handleMycoCortex({ op: 'get' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('fetch_failed');
+  });
+});
+
+describe('myco_cortex op: refresh', () => {
+  it('POSTs to /api/cortex/instructions/refresh and returns the started status', async () => {
+    const client = mockClient({ started: true, run_id: 'run-7' });
+    const result = await handleMycoCortex({ op: 'refresh' }, client);
+    expect(client.post).toHaveBeenCalledWith('/api/cortex/instructions/refresh', {});
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({ started: true, run_id: 'run-7' });
+  });
+});
+
+describe('myco_cortex op: build_prompt', () => {
+  it('requires a goal', async () => {
+    const client = mockClient({ started: true, runId: 'x' });
+    const result = await handleMycoCortex({ op: 'build_prompt' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/goal/i);
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('POSTs goal and symbiont to /api/cortex/prompt-builder', async () => {
+    const client = mockClient({ started: true, runId: 'run-build-1' });
+    const result = await handleMycoCortex(
+      { op: 'build_prompt', goal: 'refactor X', symbiont: 'claude-code' },
+      client,
+    );
+    expect(client.post).toHaveBeenCalledWith('/api/cortex/prompt-builder', {
+      goal: 'refactor X',
+      symbiont: 'claude-code',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.data).toMatchObject({ runId: 'run-build-1' });
+  });
+
+  it('omits symbiont when not provided', async () => {
+    const client = mockClient({ started: true, runId: 'run-1' });
+    await handleMycoCortex({ op: 'build_prompt', goal: 'do a thing' }, client);
+    expect(client.post).toHaveBeenCalledWith('/api/cortex/prompt-builder', {
+      goal: 'do a thing',
+    });
+  });
+});
+
+describe('myco_cortex op: get_prompt_result', () => {
+  it('requires run_id', async () => {
+    const client = mockClient({});
+    const result = await handleMycoCortex({ op: 'get_prompt_result' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/run_id/i);
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('GETs /api/cortex/prompt-builder/:runId', async () => {
+    const payload = { runId: 'run-1', status: 'completed', prompt: 'built prompt', reports: [] };
+    const client = mockClient(payload);
+    const result = await handleMycoCortex(
+      { op: 'get_prompt_result', run_id: 'run-1' },
+      client,
+    );
+    expect(client.get).toHaveBeenCalledWith('/api/cortex/prompt-builder/run-1');
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual(payload);
+  });
+
+  it('returns a not-ready error when the daemon returns 404', async () => {
+    const client = mockClient(null, false);
+    const result = await handleMycoCortex(
+      { op: 'get_prompt_result', run_id: 'missing' },
+      client,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not_ready|not_found/);
+  });
+});

--- a/tests/mcp/tools/plans.test.ts
+++ b/tests/mcp/tools/plans.test.ts
@@ -1,14 +1,27 @@
 /**
  * Tests for myco_plans tool handler.
  *
- * The handler now proxies through DaemonClient. Tests mock the client
- * to verify correct endpoint usage and response mapping, and cover the
- * Bundle D additions: op discriminator, session filter, and delete op.
+ * The list-op tests mock DaemonClient to verify endpoint shape. The delete-op
+ * tests spin up a real DaemonServer with the real /api/plans/:id route and
+ * drive the real DaemonClient, so the 403 / force_remote / local branches of
+ * handleDeletePlan are actually exercised end-to-end (Bundle D spec review
+ * flagged this surface as under-covered).
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
 import { handleMycoPlans } from '@myco/mcp/tools/plans.js';
 import { DaemonClient } from '@myco/hooks/client.js';
+import { DaemonServer } from '@myco/daemon/server.js';
+import { DaemonLogger } from '@myco/daemon/logger.js';
+import { createSessionMutationHandlers } from '@myco/daemon/api/sessions.js';
+import { upsertSession } from '@myco/db/queries/sessions.js';
+import { upsertPlan, getPlan } from '@myco/db/queries/plans.js';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { initTeamContext } from '@myco/daemon/team-context.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 
 function mockClient(getData: unknown = null, ok = true): DaemonClient {
   const client = {
@@ -83,10 +96,12 @@ describe('myco_plans op: list (default)', () => {
     expect(client.get).toHaveBeenCalledWith(expect.stringContaining('session=sess-abc'));
   });
 
-  it('refuses both id and session in same list call', async () => {
+  it('refuses both id and session in same list call with a structured error', async () => {
     const client = mockClient({ plans: [] });
     const result = await handleMycoPlans({ id: 'p1', session: 'sess-1' }, client);
-    expect(result).toEqual([]);
+    // Match the daemon's /api/mcp/plans 400 behavior — surface the rejection
+    // explicitly so agents can correct the call, rather than swallowing into [].
+    expect(result).toEqual({ ok: false, error: 'Pass either id or session, not both' });
     // No HTTP roundtrip should happen when the input is contradictory.
     expect(client.get).not.toHaveBeenCalled();
   });
@@ -99,39 +114,144 @@ describe('myco_plans op: list (default)', () => {
   });
 });
 
-describe('myco_plans op: delete', () => {
+/**
+ * Integration suite — drives handleMycoPlans through the real DaemonClient
+ * and a real in-process DaemonServer so handleDeletePlan's ownership check
+ * actually runs. Catches two regressions:
+ *   1. Silent fallback to 'delete_failed' when the daemon returned a helpful
+ *      403 body (Wrong #2 from Bundle D review).
+ *   2. Any future route-level behavior change (e.g. status code, error
+ *      wording) that the hand-mocked tests would miss.
+ */
+describe('myco_plans op: delete (integration against real HTTP router)', () => {
+  const LOCAL_MACHINE = 'local-machine';
+  const REMOTE_MACHINE = 'other-machine';
+
+  let vaultDir: string;
+  let server: DaemonServer;
+  let logger: DaemonLogger;
+  let client: DaemonClient;
+  let now: number;
+
+  beforeAll(async () => {
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-plans-delete-'));
+    fs.mkdirSync(path.join(vaultDir, 'logs'), { recursive: true });
+    logger = new DaemonLogger(path.join(vaultDir, 'logs'));
+    setupTestDb();
+
+    // Pin the daemon's machine identity so we can deterministically seed
+    // rows that are "local" vs "remote" relative to this test.
+    initTeamContext(false, LOCAL_MACHINE);
+
+    server = new DaemonServer({ vaultDir, logger });
+
+    const embeddingManager = {
+      onRemoved: vi.fn(),
+      remove: vi.fn(),
+      reconcile: vi.fn(),
+    } as never;
+    const sessionMut = createSessionMutationHandlers({
+      embeddingManager,
+      vaultDir,
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+      liveConfig: { current: { agent: { event_tasks_enabled: false } } } as never,
+    });
+    server.registerRoute('DELETE', '/api/plans/:id', sessionMut.handleDeletePlan);
+
+    await server.start();
+
+    // Write daemon.json so DaemonClient can discover the test server.
+    fs.writeFileSync(
+      path.join(vaultDir, 'daemon.json'),
+      JSON.stringify({ pid: process.pid, port: server.port }),
+    );
+
+    client = new DaemonClient(vaultDir);
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    logger.close();
+    teardownTestDb();
+    fs.rmSync(vaultDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    cleanTestDb();
+    now = Math.floor(Date.now() / 1000);
+    registerAgent({ id: 'myco-agent', name: 'Test', created_at: now });
+    upsertSession({ id: 'sess-1', agent: 'myco-agent', started_at: now, created_at: now });
+  });
+
   it('requires id', async () => {
-    const client = mockClient({ ok: true });
-    const result = await handleMycoPlans({ op: 'delete' }, client);
+    // Input validation happens before any HTTP roundtrip, so a mock client
+    // suffices for this shape check.
+    const mc = mockClient({ ok: true });
+    const result = await handleMycoPlans({ op: 'delete' }, mc);
     expect(result).toMatchObject({ ok: false, error: expect.stringContaining('id is required') });
-    expect(client.delete).not.toHaveBeenCalled();
+    expect(mc.delete).not.toHaveBeenCalled();
   });
 
   it('calls DELETE /api/plans/:id without body when local', async () => {
-    const client = mockClient({ ok: true, id: 'plan-1', session_id: 'sess-1' });
-    const result = await handleMycoPlans({ op: 'delete', id: 'plan-1' }, client);
-    expect(client.delete).toHaveBeenCalledWith('/api/plans/plan-1', undefined);
-    expect(result).toMatchObject({ ok: true, id: 'plan-1', session_id: 'sess-1' });
+    upsertPlan({
+      id: 'plan-local',
+      logical_key: 'session:sess-1:key:primary',
+      session_id: 'sess-1',
+      title: 'Local plan',
+      content: '# local',
+      created_at: now,
+      machine_id: LOCAL_MACHINE,
+    });
+
+    const result = await handleMycoPlans({ op: 'delete', id: 'plan-local' }, client);
+
+    expect(result).toMatchObject({ ok: true, id: 'plan-local', session_id: 'sess-1' });
+    expect(getPlan('plan-local')).toBeNull();
   });
 
   it('forwards force_remote to the daemon when set', async () => {
-    const client = mockClient({ ok: true, id: 'plan-2', session_id: 'sess-2' });
-    await handleMycoPlans({ op: 'delete', id: 'plan-2', force_remote: true }, client);
-    expect(client.delete).toHaveBeenCalledWith('/api/plans/plan-2', { force_remote: true });
+    upsertPlan({
+      id: 'plan-remote-force',
+      logical_key: 'session:sess-1:key:force',
+      session_id: 'sess-1',
+      title: 'Remote plan (force)',
+      content: '# remote',
+      created_at: now,
+      machine_id: REMOTE_MACHINE,
+    });
+
+    const result = await handleMycoPlans(
+      { op: 'delete', id: 'plan-remote-force', force_remote: true },
+      client,
+    );
+
+    expect(result).toMatchObject({ ok: true, id: 'plan-remote-force' });
+    expect(getPlan('plan-remote-force')).toBeNull();
   });
 
   it('surfaces the daemon-side rejection when force_remote is omitted for a remote plan', async () => {
-    // DaemonClient.delete returns { ok: false } when the HTTP call is !res.ok;
-    // the handler converts that into a structured error payload.
-    const client = {
-      get: vi.fn(),
-      post: vi.fn(),
-      delete: vi.fn().mockResolvedValue({
-        ok: false,
-        data: { error: 'Plan belongs to another machine; pass {"force_remote": true} to delete.' },
-      }),
-    } as unknown as DaemonClient;
-    const result = await handleMycoPlans({ op: 'delete', id: 'plan-x' }, client);
-    expect(result).toMatchObject({ ok: false });
+    upsertPlan({
+      id: 'plan-remote-naked',
+      logical_key: 'session:sess-1:key:naked',
+      session_id: 'sess-1',
+      title: 'Remote plan (no force)',
+      content: '# remote',
+      created_at: now,
+      machine_id: REMOTE_MACHINE,
+    });
+
+    const result = await handleMycoPlans(
+      { op: 'delete', id: 'plan-remote-naked' },
+      client,
+    );
+
+    // Wrong #2 fix: the real 403 body must reach the MCP caller instead of
+    // the generic 'delete_failed' string.
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('force_remote'),
+    });
+    // Row must still exist — the daemon rejected the delete.
+    expect(getPlan('plan-remote-naked')).not.toBeNull();
   });
 });

--- a/tests/mcp/tools/plans.test.ts
+++ b/tests/mcp/tools/plans.test.ts
@@ -2,7 +2,8 @@
  * Tests for myco_plans tool handler.
  *
  * The handler now proxies through DaemonClient. Tests mock the client
- * to verify correct endpoint usage and response mapping.
+ * to verify correct endpoint usage and response mapping, and cover the
+ * Bundle D additions: op discriminator, session filter, and delete op.
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -13,11 +14,12 @@ function mockClient(getData: unknown = null, ok = true): DaemonClient {
   const client = {
     get: vi.fn().mockResolvedValue({ ok, data: getData }),
     post: vi.fn().mockResolvedValue({ ok, data: getData }),
+    delete: vi.fn().mockResolvedValue({ ok, data: getData }),
   } as unknown as DaemonClient;
   return client;
 }
 
-describe('myco_plans', () => {
+describe('myco_plans op: list (default)', () => {
   it('lists plans from daemon response', async () => {
     const plans = [
       { id: 'auth', title: 'Auth Redesign', status: 'active', progress: '1/2', tags: [], created_at: 1700000000 },
@@ -26,14 +28,15 @@ describe('myco_plans', () => {
     const client = mockClient({ plans });
 
     const results = await handleMycoPlans({}, client);
-    expect(results).toHaveLength(2);
+    expect(Array.isArray(results)).toBe(true);
+    expect((results as unknown[]).length).toBe(2);
   });
 
   it('passes status filter to daemon', async () => {
     const client = mockClient({ plans: [{ id: 'auth', title: 'Auth', status: 'active', progress: '1/2', tags: [], created_at: 1700000000 }] });
 
     const results = await handleMycoPlans({ status: 'active' }, client);
-    expect(results).toHaveLength(1);
+    expect((results as unknown[]).length).toBe(1);
     expect(client.get).toHaveBeenCalledWith(expect.stringContaining('status=active'));
   });
 
@@ -71,7 +74,64 @@ describe('myco_plans', () => {
       plans: [{ id: 'plan-auth', title: 'Auth', status: 'active', progress: '1/2', tags: [], created_at: 1700000000, content }],
     });
     const results = await handleMycoPlans({ id: 'plan-auth' }, client);
-    expect(results).toHaveLength(1);
-    expect(results[0].content).toBe(content);
+    expect((results as Array<{ content?: string }>)[0].content).toBe(content);
+  });
+
+  it('forwards session filter to daemon', async () => {
+    const client = mockClient({ plans: [] });
+    await handleMycoPlans({ session: 'sess-abc' }, client);
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('session=sess-abc'));
+  });
+
+  it('refuses both id and session in same list call', async () => {
+    const client = mockClient({ plans: [] });
+    const result = await handleMycoPlans({ id: 'p1', session: 'sess-1' }, client);
+    expect(result).toEqual([]);
+    // No HTTP roundtrip should happen when the input is contradictory.
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('explicit op: "list" works the same as default', async () => {
+    const plans = [{ id: 'auth', title: 'A', status: 'active', progress: '0/0', tags: [], created_at: 0 }];
+    const client = mockClient({ plans });
+    const r = await handleMycoPlans({ op: 'list' }, client);
+    expect((r as unknown[]).length).toBe(1);
+  });
+});
+
+describe('myco_plans op: delete', () => {
+  it('requires id', async () => {
+    const client = mockClient({ ok: true });
+    const result = await handleMycoPlans({ op: 'delete' }, client);
+    expect(result).toMatchObject({ ok: false, error: expect.stringContaining('id is required') });
+    expect(client.delete).not.toHaveBeenCalled();
+  });
+
+  it('calls DELETE /api/plans/:id without body when local', async () => {
+    const client = mockClient({ ok: true, id: 'plan-1', session_id: 'sess-1' });
+    const result = await handleMycoPlans({ op: 'delete', id: 'plan-1' }, client);
+    expect(client.delete).toHaveBeenCalledWith('/api/plans/plan-1', undefined);
+    expect(result).toMatchObject({ ok: true, id: 'plan-1', session_id: 'sess-1' });
+  });
+
+  it('forwards force_remote to the daemon when set', async () => {
+    const client = mockClient({ ok: true, id: 'plan-2', session_id: 'sess-2' });
+    await handleMycoPlans({ op: 'delete', id: 'plan-2', force_remote: true }, client);
+    expect(client.delete).toHaveBeenCalledWith('/api/plans/plan-2', { force_remote: true });
+  });
+
+  it('surfaces the daemon-side rejection when force_remote is omitted for a remote plan', async () => {
+    // DaemonClient.delete returns { ok: false } when the HTTP call is !res.ok;
+    // the handler converts that into a structured error payload.
+    const client = {
+      get: vi.fn(),
+      post: vi.fn(),
+      delete: vi.fn().mockResolvedValue({
+        ok: false,
+        data: { error: 'Plan belongs to another machine; pass {"force_remote": true} to delete.' },
+      }),
+    } as unknown as DaemonClient;
+    const result = await handleMycoPlans({ op: 'delete', id: 'plan-x' }, client);
+    expect(result).toMatchObject({ ok: false });
   });
 });

--- a/tests/mcp/tools/runs.test.ts
+++ b/tests/mcp/tools/runs.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for myco_runs tool handler.
+ *
+ * Mirrors /api/agent/runs[/:id]. These tests verify the MCP adapter
+ * layer only — the serializeRun path is exercised by HTTP tests.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { handleMycoRuns } from '@myco/mcp/tools/runs.js';
+import type { DaemonClient } from '@myco/hooks/client.js';
+
+function mockClient(data: unknown = null, ok = true): DaemonClient {
+  return {
+    get: vi.fn().mockResolvedValue({ ok, data }),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as DaemonClient;
+}
+
+describe('myco_runs op: list (default)', () => {
+  it('lists runs from /api/agent/runs with a default limit', async () => {
+    const payload = { runs: [{ id: 'run-1', agent_id: 'myco-agent', tokens_used: 100 }], total: 1, offset: 0, limit: 50 };
+    const client = mockClient(payload);
+    const result = await handleMycoRuns({}, client);
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual(payload);
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    expect(url).toContain('/api/agent/runs');
+    expect(url).toContain('limit=50');
+  });
+
+  it('forwards task, agent_id, and limit', async () => {
+    const client = mockClient({ runs: [], total: 0 });
+    await handleMycoRuns(
+      { op: 'list', task: 'skill-generate', agent_id: 'myco-agent', limit: 5 },
+      client,
+    );
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    expect(url).toContain('task=skill-generate');
+    expect(url).toContain('agentId=myco-agent');
+    expect(url).toContain('limit=5');
+  });
+
+  it('returns fetch_failed when daemon is unhealthy', async () => {
+    const client = mockClient(null, false);
+    const result = await handleMycoRuns({ op: 'list' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('fetch_failed');
+  });
+});
+
+describe('myco_runs op: get', () => {
+  it('requires id', async () => {
+    const client = mockClient({});
+    const result = await handleMycoRuns({ op: 'get' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/id is required/);
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('GETs /api/agent/runs/:id', async () => {
+    const payload = {
+      run: {
+        id: 'run-42',
+        agent_id: 'myco-agent',
+        task: 'skill-generate',
+        tokens_used: 12000,
+        cost_usd: 0.042,
+        reasoning_level: 'medium',
+        status: 'completed',
+        write_intents: { total: 0, by_tool: {} },
+        duration_ms: 1500,
+      },
+    };
+    const client = mockClient(payload);
+    const result = await handleMycoRuns({ op: 'get', id: 'run-42' }, client);
+    expect(client.get).toHaveBeenCalledWith('/api/agent/runs/run-42');
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual(payload);
+  });
+
+  it('returns not_found when the daemon returns 404', async () => {
+    const client = mockClient(null, false);
+    const result = await handleMycoRuns({ op: 'get', id: 'missing' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('not_found');
+  });
+});

--- a/tests/mcp/tools/runs.test.ts
+++ b/tests/mcp/tools/runs.test.ts
@@ -19,7 +19,7 @@ function mockClient(data: unknown = null, ok = true): DaemonClient {
 }
 
 describe('myco_runs op: list (default)', () => {
-  it('lists runs from /api/agent/runs with a default limit', async () => {
+  it('lists runs from /api/agent/runs and defers the default limit to the HTTP route', async () => {
     const payload = { runs: [{ id: 'run-1', agent_id: 'myco-agent', tokens_used: 100 }], total: 1, offset: 0, limit: 50 };
     const client = mockClient(payload);
     const result = await handleMycoRuns({}, client);
@@ -27,7 +27,9 @@ describe('myco_runs op: list (default)', () => {
     expect(result.data).toEqual(payload);
     const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
     expect(url).toContain('/api/agent/runs');
-    expect(url).toContain('limit=50');
+    // When the caller omits `limit`, the MCP tool must NOT forward one —
+    // the HTTP route owns the default (AGENT_RUNS_DEFAULT_LIMIT).
+    expect(url).not.toContain('limit=');
   });
 
   it('forwards task, agent_id, and limit', async () => {


### PR DESCRIPTION
## Summary

**Bundle D of the pre-0.21.0 quality pass.** Closes the agent-native parity gap from the [`/ce-review` of `myco/v0.20.2..HEAD`](../../docs/superpowers/plans/2026-04-18-pre-0.21.0-quality-pass.md). The #92 Cortex surface, #93 plan-lifecycle surface, and #86 multi-runtime run surface shipped with no MCP equivalent — an agent using Myco's MCP today cannot read its own session-start brief, trigger an instruction refresh, build a prompt, list plans for its session, or see its own run's token budget. This PR fixes the three highest-leverage gaps.

## Finding resolved

**#9 (P1)** — Agent-native parity gap. Must-ship tools shipped; deferred tools (myco_evaluations, myco_write_intents, myco_phase_audit, myco_resume_run, myco_digest_revisions) filed as follow-up issues.

## What's new

### `myco_cortex({ op: 'get' | 'refresh' | 'build_prompt' | 'get_prompt_result' })`

Mirrors `/api/cortex/*`:
- `op: 'get'` — current instructions snapshot
- `op: 'refresh'` — trigger `cortex-instructions` task (returns `{started, run_id?, reason?}`)
- `op: 'build_prompt'` — start `cortex-prompt-builder` with `goal` + optional `symbiont`
- `op: 'get_prompt_result'` — poll by `run_id`

### `myco_plans` extended

- Add `op: 'list' | 'delete'` (default `list`)
- Add `session?` filter (mutually exclusive with `id` — returns `{ok: false, error}` if both passed; matches the HTTP route's 400)
- Add `force_remote?` for cross-machine delete — mirrors the ownership check Bundle A landed on `DELETE /api/plans/:id`
- `PlansResult` is now a 3-arm discriminated union (`PlanSummary[] | PlanDeleteResult | PlansListError`); consumers that switch on shape need to handle the new arm

### `myco_runs({ op: 'list' | 'get' })`

Mirrors `GET /api/agent/runs[/:id]` via `serializeRun` — agents can now see their own token budget, cost, reasoning level without going through the UI.

### `TOOL_DEFINITIONS` + annotations

Each new tool carries `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint`, plus a `cortex: {priority, guidance}` entry so they appear in the session-start brief. New `ToolAnnotations` interface in `tool-definitions.ts` (minimal — single interface, optional field; not a broader refactor).

### `DaemonClient.delete` error-body propagation

On non-ok responses, `DaemonClient.delete` now parses the JSON error body so the daemon's structured guidance (e.g. "pass force_remote") reaches callers instead of being flattened to `{ok: false}`. Tracked follow-up #101 extends this to `get`/`post`/`put`.

## Test plan

- [x] `make check` — **2930 passed, 3 skipped, 0 failed**
- [x] 115/115 in targeted MCP + Cortex-brief suites
- [x] `tests/mcp/tools/cortex.test.ts` — new, covers all 4 ops (happy path + validation)
- [x] `tests/mcp/tools/plans.test.ts` — `session` filter, `id+session` mutual-exclusion error, and **real-HTTP integration test** for the three delete scenarios (local allow, remote+force allow, remote-without-flag 403 with `force_remote` substring in error). Uses the Bundle A key-leak-guard harness pattern (real `DaemonServer`, real `DaemonClient`, `initTeamContext`).
- [x] `tests/mcp/tools/runs.test.ts` — new, covers list + get, plus "no `limit=` param when caller omits limit" to prevent mirror drift from the HTTP default
- [x] `tests/mcp/tool-definitions.test.ts` — value-pinning tests for all 4 annotation fields on each new tool (flip-detection manually verified)
- [x] `tests/context/cortex-brief.test.ts` — anti-drift assertion that all 3 new tools appear by name in both `RETRIEVAL_GUIDANCE` and the rendered brief body

## Deferred (tracked follow-up issues)

Filed during original implementation:
- `myco_evaluations` — #95
- `myco_write_intents` — #96
- `myco_phase_audit` — #97
- `myco_resume_run` — #98
- `myco_digest_revisions` — #99

Filed during fix-pass:
- DaemonClient error-body propagation for get/post/put — #101

## Pipeline

Implementer (DONE) → spec review (❌ 3 real issues: silent empty-list on id+session, lost 403 reason on delete, missing real-HTTP test) → fix-pass (addresses all 5 items) → focused re-review (⚠️ approved with minor; see "Remaining nits" below). Two commits on this branch; will squash-merge.

## Remaining nits (for the squash-merge)

- `PlansResult` is now a 3-arm discriminated union. Only consumer today is `plans.ts` itself, so no breakage, but worth naming so future consumers aren't surprised.
- The new integration-test harness pattern (real `DaemonServer` + real `DaemonClient` + deterministic `initTeamContext`) is the reference to follow for any future MCP tool that needs end-to-end route coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)