### PR TITLE
runtime+reliability: harden cortex, openai runtime, plan capture + InflightRunRegistry

### DIFF
--- a/packages/myco/src/agent/runtime/openai.ts
+++ b/packages/myco/src/agent/runtime/openai.ts
@@ -61,14 +61,17 @@ class PersistedSession implements Session {
   }
 }
 
+// Local OpenAI-compatible providers (Ollama, LM Studio, llama.cpp) commonly
+// omit the *Details arrays entirely. Mark them optional so the compiler
+// enforces the `?? []` guard at every call site.
 function toOpenAIUsage(rawResponses: Array<{
   usage: {
     requests: number;
     inputTokens: number;
     outputTokens: number;
     totalTokens: number;
-    inputTokensDetails: Array<Record<string, number>>;
-    outputTokensDetails: Array<Record<string, number>>;
+    inputTokensDetails?: Array<Record<string, number>>;
+    outputTokensDetails?: Array<Record<string, number>>;
   };
 }>): RuntimeUsage {
   const usage = rawResponses.reduce(
@@ -77,8 +80,8 @@ function toOpenAIUsage(rawResponses: Array<{
       acc.inputTokens += response.usage.inputTokens;
       acc.outputTokens += response.usage.outputTokens;
       acc.totalTokens += response.usage.totalTokens;
-      acc.reasoningTokens += response.usage.outputTokensDetails.reduce((sum, detail) => sum + (detail.reasoning_tokens ?? 0), 0);
-      acc.cachedTokens += response.usage.inputTokensDetails.reduce((sum, detail) => sum + (detail.cached_tokens ?? 0), 0);
+      acc.reasoningTokens += (response.usage.outputTokensDetails ?? []).reduce((sum, detail) => sum + (detail.reasoning_tokens ?? 0), 0);
+      acc.cachedTokens += (response.usage.inputTokensDetails ?? []).reduce((sum, detail) => sum + (detail.cached_tokens ?? 0), 0);
       return acc;
     },
     { requests: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0, reasoningTokens: 0, cachedTokens: 0 },

--- a/packages/myco/src/constants.ts
+++ b/packages/myco/src/constants.ts
@@ -379,6 +379,17 @@ export const TEAM_SOURCE_PREFIX = 'team:';
 export const TEAM_SEARCH_TIMEOUT_MS = 3000;
 /** Timeout for team health check requests (ms). */
 export const TEAM_HEALTH_TIMEOUT_MS = 5000;
+/**
+ * Default timeout for generic team sync JSON requests (ms).
+ *
+ * Covers connect, getConfig, collective status/settings/query, rotate, and
+ * any other request() path that isn't already bounded by TEAM_SEARCH_TIMEOUT_MS
+ * or TEAM_HEALTH_TIMEOUT_MS. Callers making heavier requests (e.g. pushBatch
+ * during sync) can override per call.
+ */
+export const TEAM_REQUEST_TIMEOUT_MS = 15_000;
+/** Timeout for team sync pushBatch requests (ms). Larger than generic because payloads may be large. */
+export const TEAM_SYNC_TIMEOUT_MS = 30_000;
 /** Secrets key for the team API key in secrets.env. */
 export const TEAM_API_KEY_SECRET = 'MYCO_TEAM_API_KEY';
 /** Secrets key for the team MCP token in secrets.env. */

--- a/packages/myco/src/daemon/api/cortex.ts
+++ b/packages/myco/src/daemon/api/cortex.ts
@@ -16,6 +16,8 @@ export interface CortexDeps {
   getTeamClient?: () => TeamSyncClient | null;
   embeddingManager: EmbeddingManager;
   logger: DaemonLogger;
+  /** Optional registry that tracks fire-and-forget runs so daemon shutdown can await them. */
+  registerInflightRun?: (promise: Promise<unknown>) => void;
 }
 
 const PromptBuilderBody = z.object({
@@ -39,6 +41,7 @@ export function createCortexHandlers(vaultDir: string, deps: CortexDeps) {
       liveConfig: deps.liveConfig,
       logger: deps.logger,
       getTeamClient: deps.getTeamClient,
+      registerInflightRun: deps.registerInflightRun,
     });
     return { body: result };
   }
@@ -51,6 +54,8 @@ export function createCortexHandlers(vaultDir: string, deps: CortexDeps) {
         config: deps.liveConfig.current,
         embeddingManager: deps.embeddingManager,
         getTeamClient: deps.getTeamClient,
+        logger: deps.logger,
+        registerInflightRun: deps.registerInflightRun,
       },
       goal,
       symbiont,

--- a/packages/myco/src/daemon/api/mcp-proxy.ts
+++ b/packages/myco/src/daemon/api/mcp-proxy.ts
@@ -23,6 +23,7 @@ import { getSession, listSessions } from '@myco/db/queries/sessions.js';
 import { listTeamMembers } from '@myco/db/queries/team-members.js';
 import { insertResolutionEvent } from '@myco/db/queries/resolution-events.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
+import type { DaemonLogger } from '../logger.js';
 import type { EmbeddingManager } from '../embedding/manager.js';
 import { PLAN_STATUSES } from '@myco/vault/types.js';
 import {
@@ -114,6 +115,7 @@ export interface McpProxyDeps {
   machineId: string;
   embeddingManager: EmbeddingManager;
   projectRoot: string;
+  logger?: DaemonLogger;
 }
 
 // ---------------------------------------------------------------------------
@@ -121,7 +123,7 @@ export interface McpProxyDeps {
 // ---------------------------------------------------------------------------
 
 export function createMcpProxyHandlers(deps: McpProxyDeps) {
-  const { machineId, embeddingManager, projectRoot } = deps;
+  const { machineId, embeddingManager, projectRoot, logger } = deps;
 
   function toPlanSummary(row: {
     id: string;
@@ -302,6 +304,7 @@ export function createMcpProxyHandlers(deps: McpProxyDeps) {
       status,
       tags,
       planKey: plan_key ?? null,
+      logger,
     });
 
     return {

--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -116,10 +116,23 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
     const transcriptMeta = transcriptPath ? readTranscriptMeta(transcriptPath) ?? undefined : undefined;
     const detectedAgent = typeof event.agent === 'string' ? event.agent : DEFAULT_SYMBIONT_NAME;
 
-    return evaluateSessionCaptureRules(manifests, detectedAgent, {
-      transcriptPath,
-      transcriptMeta,
-    });
+    // Fail open: a manifest with a bad regex or schema error must not
+    // wedge the dispatcher and drop every subsequent event. The individual
+    // data-preservation contract is "capture by default" — keeping a noisy
+    // session is recoverable; dropping every event until restart is not.
+    try {
+      return evaluateSessionCaptureRules(manifests, detectedAgent, {
+        transcriptPath,
+        transcriptMeta,
+      });
+    } catch (err) {
+      logger.error(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Capture-rules evaluator threw', {
+        error: String(err),
+        session_id: typeof event.session_id === 'string' ? event.session_id : undefined,
+        agent: detectedAgent,
+      });
+      return { action: 'pass' };
+    }
   }
 
   function getPlanTagsForAgent(agent: unknown): string[] {
@@ -225,6 +238,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
                 content,
                 sessionId: event.session_id,
                 promptBatchId: batchId,
+                logger,
               });
               logger.info(LOG_KINDS.CAPTURE_PLAN, 'Plan captured from prompt tag', {
                 session_id: event.session_id,
@@ -290,6 +304,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
             content: planContent,
             sessionId: captureSessionId,
             promptBatchId: latestBatch?.id ?? null,
+            logger,
           });
           logger.info(LOG_KINDS.CAPTURE_PLAN, 'Plan captured', {
             session_id: captureSessionId,

--- a/packages/myco/src/daemon/inflight-runs.ts
+++ b/packages/myco/src/daemon/inflight-runs.ts
@@ -1,0 +1,57 @@
+/**
+ * Registry that tracks in-flight fire-and-forget agent runs so daemon
+ * shutdown can wait for them to settle.
+ *
+ * Without this, SIGTERM/SIGINT abandons any cortex-instructions or
+ * cortex-prompt-builder run launched via `runAgent()` fire-and-forget —
+ * leaving non-terminal rows in `agent_runs` and, on reasoning-heavy
+ * providers, real money on the table.
+ */
+
+const DEFAULT_DRAIN_TIMEOUT_MS = 30_000;
+
+export class InflightRunRegistry {
+  private readonly runs = new Set<Promise<unknown>>();
+
+  /**
+   * Track a fire-and-forget agent run. The promise is removed from the
+   * registry in a finally handler so a resolved/rejected run does not hold
+   * memory. Resolves immediately — callers must not await this directly.
+   */
+  register(promise: Promise<unknown>): void {
+    const tracked = Promise.resolve(promise).finally(() => {
+      this.runs.delete(tracked);
+    });
+    this.runs.add(tracked);
+  }
+
+  /** Number of runs currently being tracked. */
+  get size(): number {
+    return this.runs.size;
+  }
+
+  /**
+   * Wait for every tracked run to settle, up to `timeoutMs`. Returns when
+   * either every run completes or the deadline elapses — whichever happens
+   * first. The 30-second default mirrors a typical daemon shutdown budget;
+   * callers are free to override for tests or tighter environments.
+   */
+  async drain(timeoutMs: number = DEFAULT_DRAIN_TIMEOUT_MS): Promise<{ settled: boolean; remaining: number }> {
+    if (this.runs.size === 0) return { settled: true, remaining: 0 };
+
+    const snapshot = Array.from(this.runs);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<'timeout'>((resolve) => {
+      timer = setTimeout(() => resolve('timeout'), timeoutMs);
+    });
+
+    const allSettled = Promise.allSettled(snapshot).then(() => 'settled' as const);
+
+    try {
+      const outcome = await Promise.race([allSettled, timeoutPromise]);
+      return { settled: outcome === 'settled', remaining: this.runs.size };
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+}

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -142,6 +142,7 @@ import { RESTART_REASON_FILENAME } from '../constants/update.js';
 import { buildScopedConfigSaveNotification } from '../config/focus.js';
 import { notify } from '../notifications/notify.js';
 import { PowerManager } from './power.js';
+import { InflightRunRegistry } from './inflight-runs.js';
 import { registerPowerJobs } from './power-jobs.js';
 import {
   handleUserPrompt, handleToolUse, handleStopBatches, handleToolFailure,
@@ -446,6 +447,12 @@ export async function main(): Promise<void> {
     logger,
   });
 
+  // Tracks fire-and-forget Cortex runs so daemon shutdown can await them
+  // before exiting. Without this, SIGTERM orphans in-flight runs — leaving
+  // non-terminal agent_runs rows and costing real money on reasoning-heavy
+  // providers.
+  const inflightRuns = new InflightRunRegistry();
+
   const server = new DaemonServer({
     vaultDir,
     logger,
@@ -537,6 +544,7 @@ export async function main(): Promise<void> {
     embeddingManager,
     logger,
     getTeamClient: () => teamSync.getTeamClient(),
+    registerInflightRun: (p) => inflightRuns.register(p),
   });
 
   server.registerRoute('GET', '/api/config', async () => handleGetConfig(vaultDir));
@@ -796,7 +804,7 @@ export async function main(): Promise<void> {
   // --- MCP proxy routes ---
   // These routes exist so the MCP server can proxy tool calls through the
   // daemon instead of opening its own SQLite connection.
-  const mcpProxy = createMcpProxyHandlers({ machineId, embeddingManager, projectRoot });
+  const mcpProxy = createMcpProxyHandlers({ machineId, embeddingManager, projectRoot, logger });
   server.registerRoute('POST', '/api/mcp/remember', mcpProxy.handleRemember);
   server.registerRoute('POST', '/api/mcp/supersede', mcpProxy.handleSupersede);
   server.registerRoute('POST', '/api/mcp/consolidate', mcpProxy.handleConsolidate);
@@ -948,6 +956,20 @@ export async function main(): Promise<void> {
     if (activeStopProcessing) {
       logger.info(LOG_KINDS.DAEMON_START, 'Waiting for active stop processing to complete...');
       await activeStopProcessing;
+    }
+    // Drain fire-and-forget Cortex runs so we don't orphan non-terminal
+    // agent_runs rows or abandon reasoning-token spend. Bounded by a 30s
+    // default — longer runs continue in the background but we still exit.
+    if (inflightRuns.size > 0) {
+      logger.info(LOG_KINDS.DAEMON_START, 'Draining in-flight agent runs before shutdown...', {
+        inflight_count: inflightRuns.size,
+      });
+      const outcome = await inflightRuns.drain();
+      if (!outcome.settled) {
+        logger.warn(LOG_KINDS.DAEMON_START, 'Some in-flight runs did not settle before shutdown timeout', {
+          remaining: outcome.remaining,
+        });
+      }
     }
     registry.destroy();
     await server.stop();

--- a/packages/myco/src/daemon/plan-capture.ts
+++ b/packages/myco/src/daemon/plan-capture.ts
@@ -14,7 +14,7 @@ import { CONTENT_HASH_ALGORITHM } from '@myco/constants.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { getPlanByLogicalKey, upsertPlan } from '@myco/db/queries/plans.js';
 import type { PlanRow } from '@myco/db/queries/plans.js';
-import type { DaemonLogger } from './logger.js';
+import type { Logger } from './logger.js';
 import {
   buildPathPlanLogicalKey,
   buildPlanId,
@@ -189,7 +189,7 @@ export interface PersistPlanInput {
   createdAt?: number;
   updatedAt?: number | null;
   /** Optional logger for warn-level cross-channel overwrite detection. */
-  logger?: DaemonLogger;
+  logger?: Logger;
 }
 
 /**
@@ -274,7 +274,7 @@ export interface CapturePlanInput {
   /** Optional prompt batch ID at the time of capture. */
   promptBatchId?: number | null;
   /** Optional logger forwarded to persistPlan for cross-channel overwrite detection. */
-  logger?: DaemonLogger;
+  logger?: Logger;
 }
 
 /**
@@ -305,7 +305,7 @@ export interface CaptureTaggedPlanInput {
   content: string;
   sessionId: string;
   promptBatchId?: number | null;
-  logger?: DaemonLogger;
+  logger?: Logger;
 }
 
 export function captureTaggedPlan(input: CaptureTaggedPlanInput): PlanRow {

--- a/packages/myco/src/daemon/plan-capture.ts
+++ b/packages/myco/src/daemon/plan-capture.ts
@@ -11,8 +11,10 @@ import { createHash } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
 import { CONTENT_HASH_ALGORITHM } from '@myco/constants.js';
+import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { getPlanByLogicalKey, upsertPlan } from '@myco/db/queries/plans.js';
 import type { PlanRow } from '@myco/db/queries/plans.js';
+import type { DaemonLogger } from './logger.js';
 import {
   buildPathPlanLogicalKey,
   buildPlanId,
@@ -186,8 +188,24 @@ export interface PersistPlanInput {
   planKey?: string | null;
   createdAt?: number;
   updatedAt?: number | null;
+  /** Optional logger for warn-level cross-channel overwrite detection. */
+  logger?: DaemonLogger;
 }
 
+/**
+ * Persist a plan, comparing content against the existing row on the same
+ * logical_key.
+ *
+ * Behavior:
+ *   - If an existing row matches the incoming content AND title, short-circuit
+ *     and return the existing row unchanged. This avoids a redundant write and
+ *     the accompanying team-sync enqueue when two channels (MCP + file
+ *     reconciler) converge on the same logical_key with identical content.
+ *   - If the content differs, the write proceeds (last-write-wins — same as
+ *     before). When a logger is supplied and the source_path changed, emit a
+ *     warn log so operators have forensic signal that two channels clobbered
+ *     each other. A revisions table is a follow-up; this is the cheap guard.
+ */
 export function persistPlan(input: PersistPlanInput): PlanRow {
   const createdAt = input.createdAt ?? Math.floor(Date.now() / 1000);
   const updatedAt = input.updatedAt ?? createdAt;
@@ -197,16 +215,40 @@ export function persistPlan(input: PersistPlanInput): PlanRow {
   const promptBatchId = input.promptBatchId === undefined
     ? (existingPlan?.prompt_batch_id ?? null)
     : input.promptBatchId;
+  const resolvedTitle = resolvePlanTitle({
+    content: input.content,
+    title: input.title,
+    sourcePath: input.sourcePath,
+    planKey: input.planKey,
+  });
+
+  if (
+    existingPlan
+    && existingPlan.content_hash === contentHash
+    && existingPlan.title === resolvedTitle
+    && existingPlan.status === status
+  ) {
+    return existingPlan;
+  }
+
+  if (existingPlan && existingPlan.content_hash !== contentHash) {
+    const priorSource = existingPlan.source_path ?? null;
+    const newSource = input.sourcePath ?? null;
+    if (priorSource !== newSource) {
+      input.logger?.warn(LOG_KINDS.CAPTURE_PLAN, 'Plan overwritten mid-session', {
+        logical_key: input.logicalKey,
+        session_id: input.sessionId,
+        prior_source: priorSource,
+        new_source: newSource,
+        prior_updated_at: existingPlan.updated_at,
+      });
+    }
+  }
 
   return upsertPlan({
     id: buildPlanId(input.logicalKey),
     logical_key: input.logicalKey,
-    title: resolvePlanTitle({
-      content: input.content,
-      title: input.title,
-      sourcePath: input.sourcePath,
-      planKey: input.planKey,
-    }),
+    title: resolvedTitle,
     content: input.content,
     source_path: input.sourcePath ?? null,
     tags: normalizePlanTags(input.tags),
@@ -231,6 +273,8 @@ export interface CapturePlanInput {
   sessionId: string;
   /** Optional prompt batch ID at the time of capture. */
   promptBatchId?: number | null;
+  /** Optional logger forwarded to persistPlan for cross-channel overwrite detection. */
+  logger?: DaemonLogger;
 }
 
 /**
@@ -252,6 +296,7 @@ export function capturePlan(input: CapturePlanInput): PlanRow {
     logicalKey: buildPathPlanLogicalKey(normalizedSourcePath),
     sourcePath: normalizedSourcePath,
     promptBatchId: input.promptBatchId,
+    logger: input.logger,
   });
 }
 
@@ -260,6 +305,7 @@ export interface CaptureTaggedPlanInput {
   content: string;
   sessionId: string;
   promptBatchId?: number | null;
+  logger?: DaemonLogger;
 }
 
 export function captureTaggedPlan(input: CaptureTaggedPlanInput): PlanRow {
@@ -270,5 +316,6 @@ export function captureTaggedPlan(input: CaptureTaggedPlanInput): PlanRow {
     sourcePath: `${TRANSCRIPT_SOURCE_PREFIX}${input.tag}`,
     promptBatchId: input.promptBatchId,
     planKey: input.tag,
+    logger: input.logger,
   });
 }

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -357,6 +357,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
               content,
               sessionId,
               promptBatchId: latestBatch?.id ?? null,
+              logger,
             });
             logger.info(LOG_KINDS.CAPTURE_PLAN, 'Plan captured from transcript tag', {
               session_id: sessionId,
@@ -409,6 +410,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
             content,
             sessionId,
             promptBatchId,
+            logger,
           });
           logger.info(LOG_KINDS.CAPTURE_PLAN, 'Plan reconciled from configured plan dir', {
             session_id: sessionId,

--- a/packages/myco/src/daemon/team-sync.ts
+++ b/packages/myco/src/daemon/team-sync.ts
@@ -6,7 +6,12 @@
  */
 
 import type { OutboxRow } from '@myco/db/queries/team-outbox.js';
-import { TEAM_SEARCH_TIMEOUT_MS, TEAM_HEALTH_TIMEOUT_MS } from '@myco/constants.js';
+import {
+  TEAM_SEARCH_TIMEOUT_MS,
+  TEAM_HEALTH_TIMEOUT_MS,
+  TEAM_REQUEST_TIMEOUT_MS,
+  TEAM_SYNC_TIMEOUT_MS,
+} from '@myco/constants.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -147,7 +152,7 @@ export class TeamSyncClient {
           content_hash: data.content_hash ?? null,
         };
       }),
-    });
+    }, { timeoutMs: TEAM_SYNC_TIMEOUT_MS });
     return res as { synced: number; skipped: number; errors: Array<{ id: string; table: string; error: string }> };
   }
 
@@ -276,18 +281,32 @@ export class TeamSyncClient {
     };
   }
 
-  private async request(method: string, path: string, body?: unknown): Promise<unknown> {
-    const res = await this.fetchFn(`${this.workerUrl}${path}`, {
-      method,
-      headers: this.headers(),
-      body: body !== undefined ? JSON.stringify(body) : undefined,
-    });
+  private async request(
+    method: string,
+    path: string,
+    body?: unknown,
+    options: { timeoutMs?: number } = {},
+  ): Promise<unknown> {
+    const timeoutMs = options.timeoutMs ?? TEAM_REQUEST_TIMEOUT_MS;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-    if (!res.ok) {
-      const text = await res.text().catch(() => '');
-      throw new Error(`Team sync request ${method} ${path} failed: ${res.status} ${text}`);
+    try {
+      const res = await this.fetchFn(`${this.workerUrl}${path}`, {
+        method,
+        headers: this.headers(),
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`Team sync request ${method} ${path} failed: ${res.status} ${text}`);
+      }
+
+      return res.json();
+    } finally {
+      clearTimeout(timer);
     }
-
-    return res.json();
   }
 }

--- a/packages/myco/src/daemon/trigger-cortex-instructions.ts
+++ b/packages/myco/src/daemon/trigger-cortex-instructions.ts
@@ -22,12 +22,19 @@ export interface TriggerCortexInstructionsDeps {
   liveConfig: { current: MycoConfig };
   logger: DaemonLogger;
   getTeamClient?: () => TeamSyncClient | null;
+  /** Optional registry that tracks the fire-and-forget run so daemon shutdown can await it. */
+  registerInflightRun?: (promise: Promise<unknown>) => void;
 }
 
 export interface TriggerCortexInstructionsResult {
   started: boolean;
-  reason?: 'event-tasks-disabled' | 'provider-not-configured' | 'agent-module-unavailable';
+  reason?:
+    | 'event-tasks-disabled'
+    | 'provider-not-configured'
+    | 'agent-module-unavailable'
+    | 'startup-failed';
   runId?: string | null;
+  error?: string;
 }
 
 export async function triggerCortexInstructions(
@@ -43,10 +50,23 @@ export async function triggerCortexInstructions(
     return { started: false, reason: 'provider-not-configured' };
   }
 
+  let runAgentFn: typeof import('../agent/executor.js').runAgent;
   try {
-    const { runAgent } = await import('../agent/executor.js');
+    ({ runAgent: runAgentFn } = await import('../agent/executor.js'));
+  } catch (err) {
+    logger.warn(LOG_KINDS.AGENT_ERROR, 'cortex-instructions: agent module unavailable', {
+      error: String(err),
+    });
+    return {
+      started: false,
+      reason: 'agent-module-unavailable',
+      error: String(err),
+    };
+  }
+
+  try {
     const built = await buildCortexInstructionsInput(config, getTeamClient);
-    const resultPromise = runAgent(vaultDir, {
+    const resultPromise = runAgentFn(vaultDir, {
       task: 'cortex-instructions',
       agentId: DEFAULT_AGENT_ID,
       instruction: built.instruction,
@@ -55,15 +75,23 @@ export async function triggerCortexInstructions(
     });
     const runId = getLatestRunId(DEFAULT_AGENT_ID, 'cortex-instructions');
 
-    resultPromise.catch((err) => {
+    const tracked = resultPromise.catch((err) => {
       logger.warn(LOG_KINDS.AGENT_ERROR, 'Cortex instructions task failed', {
         error: String(err),
         run_id: runId ?? undefined,
       });
     });
+    deps.registerInflightRun?.(tracked);
 
     return { started: true, runId };
-  } catch {
-    return { started: false, reason: 'agent-module-unavailable' };
+  } catch (err) {
+    logger.warn(LOG_KINDS.AGENT_ERROR, 'Failed to start cortex-instructions task', {
+      error: String(err),
+    });
+    return {
+      started: false,
+      reason: 'startup-failed',
+      error: String(err),
+    };
   }
 }

--- a/packages/myco/src/mcp/tool-definitions.ts
+++ b/packages/myco/src/mcp/tool-definitions.ts
@@ -166,9 +166,9 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
   },
   {
     name: TOOL_SAVE_PLAN,
-    description: 'Persist a plan directly into Myco for a session. Use this when you generated or revised a plan and want it captured reliably. If the plan is also being written to disk, pass the same source_path so direct persistence and file capture reconcile to one logical plan.',
+    description: 'Persist a plan directly into Myco for a session. Use this when you generated or revised a plan and want it captured reliably. If the plan is also being written to disk, pass the same source_path so direct persistence and file capture reconcile to one logical plan. Note: plan_key creates a stable namespace (session:<id>:key:<name>) distinct from transcript <tag> capture (session:<id>:tag:<name>) — the two do not merge. Dropping the transcript tag while also calling myco_save_plan with plan_key=tag will produce two separate rows.',
     cortex: {
-      guidance: 'Use when you create or materially revise a plan and want it persisted to Myco. Pass `source_path` when the plan is also written to disk; otherwise use a stable `plan_key`.',
+      guidance: 'Use when you create or materially revise a plan and want it persisted to Myco. Pass `source_path` when the plan is also written to disk; otherwise use a stable `plan_key`. Note: `plan_key` rows are a separate namespace from transcript `<tag>` capture — reusing the same name in both channels creates two rows, not one.',
       priority: 60,
     },
     inputSchema: {

--- a/packages/myco/src/services/cortex.ts
+++ b/packages/myco/src/services/cortex.ts
@@ -19,7 +19,7 @@ interface CortexServicesDeps {
   config: MycoConfig;
   embeddingManager?: EmbeddingManager;
   getTeamClient?: () => TeamSyncClient | null;
-  logger?: DaemonLogger;
+  logger: DaemonLogger;
   /** Optional registry that tracks the fire-and-forget run so daemon shutdown can await it. */
   registerInflightRun?: (promise: Promise<unknown>) => void;
 }
@@ -141,7 +141,7 @@ export async function buildCortexPrompt(
   });
   const runId = getLatestRunId(DEFAULT_AGENT_ID, CORTEX_PROMPT_BUILDER_TASK);
   const tracked = resultPromise.catch((err) => {
-    deps.logger?.warn(LOG_KINDS.AGENT_ERROR, 'cortex-prompt-builder task failed', {
+    deps.logger.warn(LOG_KINDS.AGENT_ERROR, 'cortex-prompt-builder task failed', {
       run_id: runId ?? undefined,
       error: String(err),
     });

--- a/packages/myco/src/services/cortex.ts
+++ b/packages/myco/src/services/cortex.ts
@@ -1,9 +1,11 @@
 import { runAgent } from '@myco/agent/executor.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import { DEFAULT_AGENT_ID } from '@myco/constants.js';
+import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { getCortexInstructions } from '@myco/db/queries/cortex-instructions.js';
 import { listReports, type ReportRow } from '@myco/db/queries/reports.js';
 import { getLatestRunId, getRun } from '@myco/db/queries/runs.js';
+import type { DaemonLogger } from '@myco/daemon/logger.js';
 import type { EmbeddingManager } from '@myco/daemon/embedding/manager.js';
 import type { TeamSyncClient } from '@myco/daemon/team-sync.js';
 import { resolveInstructionDelivery } from '@myco/context/cortex-brief.js';
@@ -17,6 +19,9 @@ interface CortexServicesDeps {
   config: MycoConfig;
   embeddingManager?: EmbeddingManager;
   getTeamClient?: () => TeamSyncClient | null;
+  logger?: DaemonLogger;
+  /** Optional registry that tracks the fire-and-forget run so daemon shutdown can await it. */
+  registerInflightRun?: (promise: Promise<unknown>) => void;
 }
 
 export interface CortexInstructionsSnapshot {
@@ -135,7 +140,13 @@ export async function buildCortexPrompt(
     embeddingManager: deps.embeddingManager,
   });
   const runId = getLatestRunId(DEFAULT_AGENT_ID, CORTEX_PROMPT_BUILDER_TASK);
-  void resultPromise.catch(() => {});
+  const tracked = resultPromise.catch((err) => {
+    deps.logger?.warn(LOG_KINDS.AGENT_ERROR, 'cortex-prompt-builder task failed', {
+      run_id: runId ?? undefined,
+      error: String(err),
+    });
+  });
+  deps.registerInflightRun?.(tracked);
 
   return {
     started: true,

--- a/tests/agent/executor-openai-agents.test.ts
+++ b/tests/agent/executor-openai-agents.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Executor tests that exercise the openai-agents runtime path.
+ *
+ * Addresses findings #27 (dryRun not E2E tested for openai-agents) and
+ * #28 (resume semantics untested for openai-agents). The Claude SDK runtime
+ * has its own coverage in executor.test.ts and executor-dry-run.test.ts;
+ * this file stands up the parallel @openai/agents Runner mock and verifies
+ * the executor threads dryRun + resumes lastResponseId correctly.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import crypto from 'node:crypto';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { upsertTask } from '@myco/db/queries/tasks.js';
+import { getRun, insertRun } from '@myco/db/queries/runs.js';
+import { epochSeconds } from '@myco/constants.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TEST_AGENT_ID = 'myco-agent';
+const TEST_VAULT_DIR = '/tmp/test-vault-openai-agents';
+const TEST_TASK_NAME = 'full-intelligence'; // no postcondition, easy path
+const TEST_TASK_PROMPT = 'Do the thing.';
+const TEST_SYSTEM_PROMPT = 'You are a vault agent.';
+
+// ---------------------------------------------------------------------------
+// Mock: @openai/agents Runner — capture args + lastResponseId propagation
+// ---------------------------------------------------------------------------
+
+interface MockRunOptions {
+  session?: {
+    addItems: (items: unknown[]) => Promise<void>;
+    getItems: () => Promise<unknown[]>;
+  };
+  signal?: AbortSignal;
+  maxTurns?: number;
+}
+
+const runnerCalls: Array<{ agent: unknown; input: string; options: MockRunOptions; priorSessionItems: unknown[] }> = [];
+let mockLastResponseId = 'resp_openai_final';
+
+vi.mock('@openai/agents', () => {
+  class Agent {
+    constructor(public readonly config: Record<string, unknown>) {}
+  }
+  class OpenAIProvider {
+    constructor(public readonly config: Record<string, unknown>) {}
+  }
+  class Runner {
+    constructor(public readonly config: Record<string, unknown>) {}
+    async run(agent: unknown, input: string, options: MockRunOptions = {}) {
+      const priorItems = options.session ? await options.session.getItems() : [];
+      runnerCalls.push({ agent, input, options, priorSessionItems: priorItems });
+      if (options.session) {
+        await options.session.addItems([{ type: 'assistant', content: 'ok' }]);
+      }
+      return {
+        finalOutput: 'Agent run complete.',
+        lastResponseId: mockLastResponseId,
+        rawResponses: [
+          {
+            usage: {
+              requests: 1,
+              inputTokens: 42,
+              outputTokens: 7,
+              totalTokens: 49,
+            },
+          },
+        ],
+      };
+    }
+  }
+  return { Agent, Runner, OpenAIProvider };
+});
+
+// ---------------------------------------------------------------------------
+// Mock: openai
+// ---------------------------------------------------------------------------
+
+vi.mock('openai', () => ({
+  default: class OpenAI {
+    constructor(public readonly config: Record<string, unknown>) {}
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock: local provider prep
+// ---------------------------------------------------------------------------
+
+vi.mock('@myco/agent/ollama-context.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@myco/agent/ollama-context.js')>();
+  return {
+    ...original,
+    ensureOllamaContextVariant: async (model: string) => model,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock: Claude SDK (unused here, but pulled in by indirect imports)
+// ---------------------------------------------------------------------------
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: () => ({
+    [Symbol.asyncIterator]: async function* () {},
+    interrupt: async () => {},
+    setPermissionMode: async () => {},
+    setModel: async () => {},
+  }),
+  createSdkMcpServer: (opts: Record<string, unknown>) => ({
+    type: 'sdk' as const,
+    instance: {},
+    ...opts,
+  }),
+  tool: (_name: string, _desc: string, _schema: unknown, handler: unknown) => ({
+    name: _name,
+    handler,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock: loader
+// ---------------------------------------------------------------------------
+
+vi.mock('@myco/agent/loader.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@myco/agent/loader.js')>();
+  return {
+    ...original,
+    resolveDefinitionsDir: () => '/mock/definitions',
+    loadAgentDefinition: () => ({
+      name: TEST_AGENT_ID,
+      displayName: 'Myco Agent',
+      description: 'Built-in agent',
+      model: 'gpt-5.4-mini',
+      maxTurns: 5,
+      timeoutSeconds: 300,
+      systemPromptPath: 'prompts/system.md',
+      tools: ['vault_unprocessed'],
+    }),
+    loadAgentTasks: () => [{
+      name: TEST_TASK_NAME,
+      displayName: 'Full Intelligence',
+      description: 'Run full intelligence pipeline.',
+      agent: TEST_AGENT_ID,
+      prompt: TEST_TASK_PROMPT,
+      isDefault: true,
+    }],
+    loadSystemPrompt: () => TEST_SYSTEM_PROMPT,
+  };
+});
+
+vi.mock('@myco/agent/registry.js', () => ({
+  loadAllTasks: () => {
+    const tasks = new Map();
+    tasks.set(TEST_TASK_NAME, {
+      name: TEST_TASK_NAME,
+      displayName: 'Full Intelligence',
+      description: 'Run full intelligence pipeline.',
+      agent: TEST_AGENT_ID,
+      prompt: TEST_TASK_PROMPT,
+      isDefault: true,
+    });
+    return tasks;
+  },
+}));
+
+vi.mock('@myco/agent/context.js', () => ({
+  buildVaultContext: () => '## Current Vault State\nagent_id: myco-agent',
+}));
+
+// ---------------------------------------------------------------------------
+// Mock: openai-local-mcp server (capture options)
+// ---------------------------------------------------------------------------
+
+let localMcpCalls: Array<Record<string, unknown>> = [];
+
+vi.mock('@myco/agent/runtime/openai-local-mcp.js', () => ({
+  createLocalVaultMcpServer: (toolSurface: Record<string, unknown>) => {
+    localMcpCalls.push(toolSurface);
+    return {
+      connect: async () => {},
+      close: async () => {},
+    };
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock: DB client — use in-memory
+// ---------------------------------------------------------------------------
+
+vi.mock('@myco/db/client.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@myco/db/client.js')>();
+  return {
+    ...original,
+    initDatabase: (...args: unknown[]) => {
+      if (args.length > 0 && args[0] !== undefined) {
+        try { return original.getDatabase(); } catch { /* not yet */ }
+      }
+      return original.initDatabase(...(args as [string?]));
+    },
+    vaultDbPath: () => ':memory:',
+  };
+});
+
+vi.mock('@myco/config/loader.js', () => ({
+  loadConfig: () => ({
+    version: 3,
+    config_version: 0,
+    embedding: { provider: 'ollama', model: 'bge-m3' },
+    daemon: { port: null, log_level: 'info' },
+    capture: { transcript_paths: [], artifact_watch: [], artifact_extensions: [], buffer_max_events: 500 },
+    agent: { summary_batch_interval: 5 },
+  }),
+  loadMergedConfig: () => ({
+    version: 3,
+    config_version: 0,
+    embedding: { provider: 'ollama', model: 'bge-m3' },
+    daemon: { port: null, log_level: 'info' },
+    capture: { transcript_paths: [], artifact_watch: [], artifact_extensions: [], buffer_max_events: 500 },
+    agent: { summary_batch_interval: 5 },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createTestAgent(): void {
+  const now = epochSeconds();
+  registerAgent({ id: TEST_AGENT_ID, name: 'Myco Agent', created_at: now, updated_at: now });
+}
+
+function createTestTask(): void {
+  const now = epochSeconds();
+  upsertTask({
+    id: TEST_TASK_NAME,
+    agent_id: TEST_AGENT_ID,
+    prompt: TEST_TASK_PROMPT,
+    display_name: 'Full Intelligence',
+    description: 'Run full intelligence pipeline.',
+    is_default: 0,
+    created_at: now,
+    updated_at: now,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('executor with openai-agents runtime', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    createTestAgent();
+    createTestTask();
+    runnerCalls.length = 0;
+    localMcpCalls = [];
+    mockLastResponseId = 'resp_openai_final';
+  });
+
+  it('runs the openai-agents runtime and persists runtime=openai-agents on the row', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+    const result = await runAgent(TEST_VAULT_DIR, {
+      task: TEST_TASK_NAME,
+      executionOverrides: {
+        runtime: 'openai-agents',
+        provider: { type: 'openai', model: 'gpt-5.4-mini' },
+      },
+    });
+
+    expect(result.status).toBe('completed');
+    const run = getRun(result.runId);
+    expect(run?.runtime).toBe('openai-agents');
+    expect(runnerCalls).toHaveLength(1);
+  });
+
+  it('persists dry_run=true and forwards dryRun to the openai-local MCP server', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+    const result = await runAgent(TEST_VAULT_DIR, {
+      task: TEST_TASK_NAME,
+      dryRun: true,
+      executionOverrides: {
+        runtime: 'openai-agents',
+        provider: { type: 'openai', model: 'gpt-5.4-mini' },
+      },
+    });
+
+    expect(result.status).toBe('completed');
+    const run = getRun(result.runId);
+    expect(run?.dry_run).toBe(true);
+
+    expect(localMcpCalls.length).toBeGreaterThan(0);
+    expect(localMcpCalls.every((call) => call.dryRun === true)).toBe(true);
+  });
+
+  it('round-trips lastResponseId via rawRuntimeMetadata on resume', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    // First run — establishes checkpoint state with runtime=openai-agents
+    mockLastResponseId = 'resp_first_call';
+    const first = await runAgent(TEST_VAULT_DIR, {
+      task: TEST_TASK_NAME,
+      executionOverrides: {
+        runtime: 'openai-agents',
+        provider: { type: 'openai', model: 'gpt-5.4-mini' },
+      },
+    });
+    expect(first.status).toBe('completed');
+
+    // Seed a failed-but-resumable row mimicking a prior openai-agents run
+    // with lastResponseId stashed in checkpoints.
+    const existingRunId = crypto.randomUUID();
+    const now = epochSeconds();
+    insertRun({
+      id: existingRunId,
+      agent_id: TEST_AGENT_ID,
+      task: TEST_TASK_NAME,
+      status: 'failed',
+      instruction: 'Resume me',
+      runtime: 'openai-agents',
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
+      resumable: 1,
+      resume_status: 'ready',
+      checkpoints: JSON.stringify({
+        runtime: 'openai-agents',
+        phases: {},
+        rawRuntimeMetadata: { lastResponseId: 'resp_abc_prior' },
+        sessionData: [{ type: 'user', content: 'first turn before failure' }],
+      }),
+      started_at: now - 60,
+      completed_at: now - 30,
+      error: 'earlier failure',
+    });
+
+    mockLastResponseId = 'resp_abc_next';
+    const resumed = await runAgent(TEST_VAULT_DIR, {
+      task: TEST_TASK_NAME,
+      instruction: 'Resume me',
+      resumeRunId: existingRunId,
+      resumeMode: 'manual',
+      executionOverrides: {
+        runtime: 'openai-agents',
+        provider: { type: 'openai', model: 'gpt-5.4-mini' },
+      },
+    });
+    expect(resumed.status).toBe('completed');
+
+    // The second Runner invocation should have been fed the prior session items.
+    const resumeCall = runnerCalls[runnerCalls.length - 1];
+    expect(resumeCall.priorSessionItems).toEqual([
+      { type: 'user', content: 'first turn before failure' },
+    ]);
+
+    const run = getRun(existingRunId);
+    expect(run?.runtime).toBe('openai-agents');
+  });
+});

--- a/tests/agent/runtime-claude.test.ts
+++ b/tests/agent/runtime-claude.test.ts
@@ -173,6 +173,20 @@ describe('ClaudeSdkRuntime.execute', () => {
     expect(fullServerCalls).toHaveLength(0);
   });
 
+  it('constructs the full vault tool server when toolNames is omitted', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    await runtime.execute(makeInput({
+      toolSurface: { agentId: 'a1', runId: 'r1' },
+    }));
+
+    expect(fullServerCalls).toHaveLength(1);
+    expect(fullServerCalls[0].agentId).toBe('a1');
+    expect(fullServerCalls[0].runId).toBe('r1');
+    expect(scopedServerCalls).toHaveLength(0);
+  });
+
   it('skips the MCP server entirely when toolNames is an empty list', async () => {
     const Runtime = await loadRuntime();
     const runtime = new Runtime();

--- a/tests/agent/runtime-claude.test.ts
+++ b/tests/agent/runtime-claude.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for ClaudeSdkRuntime.execute() covering:
+ *   - session ref forwarding (sessionId is passed through to the SDK)
+ *   - abortController forwarded when present
+ *   - scoped tool server created with toolNames + dryRun
+ *   - usage aggregation from the result message
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock: claude-agent-sdk.query — capture args, control the stream
+// ---------------------------------------------------------------------------
+
+const queryCalls: Array<{ prompt: string; options: Record<string, unknown> }> = [];
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: (args: { prompt: string; options: Record<string, unknown> }) => {
+    queryCalls.push(args);
+    return {
+      [Symbol.asyncIterator]: async function* () {
+        yield {
+          type: 'assistant' as const,
+          message: { role: 'assistant', content: 'thinking' },
+          uuid: 'a-1',
+          session_id: 'test-session',
+        };
+        yield {
+          type: 'result' as const,
+          subtype: 'success' as const,
+          total_cost_usd: 0.0123,
+          usage: { input_tokens: 42, output_tokens: 7 },
+          num_turns: 1,
+          duration_ms: 100,
+          duration_api_ms: 80,
+          is_error: false,
+          result: 'final response',
+          stop_reason: 'end_turn',
+          modelUsage: {},
+          permission_denials: [],
+          uuid: 'r-1',
+          session_id: 'test-session',
+        };
+      },
+    };
+  },
+  createSdkMcpServer: (opts: Record<string, unknown>) => ({
+    type: 'sdk' as const,
+    instance: {},
+    ...opts,
+  }),
+  tool: (_name: string, _desc: string, _schema: unknown, handler: unknown) => ({
+    name: _name,
+    handler,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock: tool server constructors — capture options (dryRun, toolNames, ...)
+// ---------------------------------------------------------------------------
+
+const scopedServerCalls: Array<{ agentId: string; runId: string; toolNames: string[]; options: Record<string, unknown> }> = [];
+const fullServerCalls: Array<{ agentId: string; runId: string; options: Record<string, unknown> }> = [];
+
+vi.mock('@myco/agent/tools.js', () => ({
+  createVaultToolServer: (agentId: string, runId: string, options: Record<string, unknown> = {}) => {
+    fullServerCalls.push({ agentId, runId, options });
+    return { type: 'sdk' as const, name: 'myco-vault', instance: {} };
+  },
+  createScopedVaultToolServer: (agentId: string, runId: string, toolNames: string[], options: Record<string, unknown> = {}) => {
+    scopedServerCalls.push({ agentId, runId, toolNames, options });
+    return { type: 'sdk' as const, name: 'myco-vault', instance: {} };
+  },
+}));
+
+vi.mock('@myco/agent/provider.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@myco/agent/provider.js')>();
+  return {
+    ...original,
+    buildPhaseEnv: () => ({}),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+async function loadRuntime() {
+  const mod = await import('@myco/agent/runtime/claude.js');
+  return mod.ClaudeSdkRuntime;
+}
+
+function makeInput(overrides: Partial<import('@myco/agent/runtime/types.js').RuntimeExecuteInput> = {}) {
+  return {
+    prompt: 'Do the thing.',
+    model: 'claude-sonnet-4-6',
+    maxTurns: 5,
+    systemPrompt: 'You are a test agent.',
+    toolSurface: {
+      agentId: 'test-agent',
+      runId: 'test-run',
+      toolNames: ['vault_report'],
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ClaudeSdkRuntime.execute', () => {
+  beforeEach(() => {
+    queryCalls.length = 0;
+    scopedServerCalls.length = 0;
+    fullServerCalls.length = 0;
+  });
+
+  it('forwards sessionRef as sessionId to the SDK when provided', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    const result = await runtime.execute(makeInput({ sessionRef: 'sess-abc' }));
+
+    expect(queryCalls[0].options.sessionId).toBe('sess-abc');
+    expect(result.sessionRef).toBe('sess-abc');
+  });
+
+  it('omits sessionId when no sessionRef is provided', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    await runtime.execute(makeInput());
+
+    expect('sessionId' in queryCalls[0].options).toBe(false);
+  });
+
+  it('forwards abortController to the SDK when present', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    const controller = new AbortController();
+    await runtime.execute(makeInput({ abortController: controller }));
+
+    expect(queryCalls[0].options.abortController).toBe(controller);
+  });
+
+  it('omits abortController when not supplied', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    await runtime.execute(makeInput());
+
+    expect('abortController' in queryCalls[0].options).toBe(false);
+  });
+
+  it('constructs a scoped tool server when toolSurface.toolNames is provided', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    await runtime.execute(makeInput({
+      toolSurface: {
+        agentId: 'a1',
+        runId: 'r1',
+        toolNames: ['vault_report'],
+        dryRun: true,
+      },
+    }));
+
+    expect(scopedServerCalls).toHaveLength(1);
+    expect(scopedServerCalls[0].toolNames).toEqual(['vault_report']);
+    expect(scopedServerCalls[0].options.dryRun).toBe(true);
+    expect(fullServerCalls).toHaveLength(0);
+  });
+
+  it('skips the MCP server entirely when toolNames is an empty list', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    await runtime.execute(makeInput({
+      toolSurface: { agentId: 'a1', runId: 'r1', toolNames: [] },
+    }));
+
+    expect(queryCalls[0].options.mcpServers).toBeUndefined();
+    expect(scopedServerCalls).toHaveLength(0);
+    expect(fullServerCalls).toHaveLength(0);
+  });
+
+  it('aggregates usage from the final result message', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    const result = await runtime.execute(makeInput());
+    expect(result.finalText).toBe('final response');
+    expect(result.turnsUsed).toBe(1);
+    expect(result.usage.inputTokens).toBe(42);
+    expect(result.usage.outputTokens).toBe(7);
+    expect(result.usage.totalTokens).toBe(49);
+    expect(result.usage.costUsd).toBeCloseTo(0.0123);
+    expect(result.usage.requestUsageEntries).toHaveLength(1);
+  });
+});

--- a/tests/agent/runtime-openai.test.ts
+++ b/tests/agent/runtime-openai.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Tests for OpenAIAgentsRuntime.execute() covering the responsibilities not
+ * exercised by openai-runtime.test.ts (which only tests pure helpers):
+ *
+ *   - PersistedSession round-trips input items on fresh + resumed runs.
+ *   - mcpServer.close() runs on success AND on thrown paths (MCP lifecycle).
+ *   - abortController is forwarded to Runner.run() when present.
+ *   - Usage aggregation sums the rawResponses list and tolerates missing
+ *     *TokensDetails arrays (local OpenAI-compatible providers).
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock @openai/agents — capture Runner.run args, control the result
+// ---------------------------------------------------------------------------
+
+interface MockRunOptions {
+  maxTurns?: number;
+  session?: { addItems: (items: unknown[]) => Promise<void>; getItems: () => Promise<unknown[]> };
+  signal?: AbortSignal;
+}
+
+const runnerCalls: Array<{ agent: unknown; input: string; options: MockRunOptions }> = [];
+let mockRunBehavior: 'success' | 'throw' = 'success';
+let mockRunResult: {
+  finalOutput: unknown;
+  lastResponseId: string;
+  rawResponses: Array<{
+    usage: {
+      requests: number;
+      inputTokens: number;
+      outputTokens: number;
+      totalTokens: number;
+      inputTokensDetails?: Array<Record<string, number>>;
+      outputTokensDetails?: Array<Record<string, number>>;
+    };
+  }>;
+  appendItems: unknown[];
+} = {
+  finalOutput: 'done',
+  lastResponseId: 'resp_123',
+  rawResponses: [],
+  appendItems: [],
+};
+
+vi.mock('@openai/agents', () => {
+  class Agent {
+    constructor(public readonly config: Record<string, unknown>) {}
+  }
+  class OpenAIProvider {
+    constructor(public readonly config: Record<string, unknown>) {}
+  }
+  class Runner {
+    constructor(public readonly config: Record<string, unknown>) {}
+    async run(agent: unknown, input: string, options: MockRunOptions = {}) {
+      runnerCalls.push({ agent, input, options });
+      if (options.session && mockRunResult.appendItems.length > 0) {
+        await options.session.addItems(mockRunResult.appendItems);
+      }
+      if (mockRunBehavior === 'throw') {
+        throw new Error('Runner blew up');
+      }
+      return {
+        finalOutput: mockRunResult.finalOutput,
+        lastResponseId: mockRunResult.lastResponseId,
+        rawResponses: mockRunResult.rawResponses,
+      };
+    }
+  }
+  return { Agent, Runner, OpenAIProvider };
+});
+
+// ---------------------------------------------------------------------------
+// Mock openai (constructed as `new OpenAI(...)` in the runtime)
+// ---------------------------------------------------------------------------
+
+vi.mock('openai', () => {
+  return {
+    default: class OpenAI {
+      constructor(public readonly config: Record<string, unknown>) {}
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock local-provider prep to avoid touching Ollama/LM Studio backends
+// ---------------------------------------------------------------------------
+
+vi.mock('@myco/agent/ollama-context.js', () => ({
+  ensureOllamaContextVariant: async (model: string) => model,
+}));
+
+vi.mock('@myco/intelligence/lm-studio.js', () => ({
+  LmStudioBackend: class {
+    async ensureLoaded() {}
+    getLoadedInstanceId() { return null; }
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+async function loadRuntime() {
+  const mod = await import('@myco/agent/runtime/openai.js');
+  return mod.OpenAIAgentsRuntime;
+}
+
+function makeMcpServer() {
+  return {
+    connect: vi.fn(async () => {}),
+    close: vi.fn(async () => {}),
+  };
+}
+
+function makeContext(mcpServer: ReturnType<typeof makeMcpServer>) {
+  return {
+    createOpenAIMcpServer: vi.fn(() => mcpServer),
+  } as unknown as import('@myco/agent/runtime/types.js').RuntimeFactoryContext;
+}
+
+function makeInput(overrides: Partial<import('@myco/agent/runtime/types.js').RuntimeExecuteInput> = {}) {
+  return {
+    prompt: 'Hello',
+    model: 'gpt-5.4-mini',
+    maxTurns: 3,
+    provider: { type: 'openai' as const, model: 'gpt-5.4-mini' },
+    toolSurface: { agentId: 'test-agent', runId: 'test-run' },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OpenAIAgentsRuntime.execute', () => {
+  beforeEach(() => {
+    runnerCalls.length = 0;
+    mockRunBehavior = 'success';
+    mockRunResult = {
+      finalOutput: 'done',
+      lastResponseId: 'resp_ok',
+      rawResponses: [
+        {
+          usage: {
+            requests: 1,
+            inputTokens: 100,
+            outputTokens: 50,
+            totalTokens: 150,
+            inputTokensDetails: [{ cached_tokens: 40 }],
+            outputTokensDetails: [{ reasoning_tokens: 10 }],
+          },
+        },
+        {
+          usage: {
+            requests: 1,
+            inputTokens: 200,
+            outputTokens: 60,
+            totalTokens: 260,
+            inputTokensDetails: [{ cached_tokens: 60 }],
+            outputTokensDetails: [{ reasoning_tokens: 20 }],
+          },
+        },
+      ],
+      appendItems: [],
+    };
+  });
+
+  it('persists session items into sessionData when the run appends new turns', async () => {
+    const Runtime = await loadRuntime();
+    const mcp = makeMcpServer();
+    const runtime = new Runtime(makeContext(mcp));
+
+    mockRunResult.appendItems = [{ type: 'user', content: 'hi' }];
+
+    const result = await runtime.execute(makeInput({ sessionRef: 'sess-1', sessionData: [] }));
+
+    expect(result.sessionData).toEqual(mockRunResult.appendItems);
+    expect(result.sessionRef).toBe('sess-1');
+  });
+
+  it('hydrates prior sessionData into the Session passed to the Runner', async () => {
+    const Runtime = await loadRuntime();
+    const mcp = makeMcpServer();
+    const runtime = new Runtime(makeContext(mcp));
+
+    const priorItems = [{ type: 'user', content: 'previous turn' }];
+    await runtime.execute(makeInput({ sessionRef: 'sess-resume', sessionData: priorItems }));
+
+    expect(runnerCalls).toHaveLength(1);
+    const session = runnerCalls[0].options.session!;
+    expect(await session.getItems()).toEqual(priorItems);
+  });
+
+  it('calls mcpServer.close() on the successful path', async () => {
+    const Runtime = await loadRuntime();
+    const mcp = makeMcpServer();
+    const runtime = new Runtime(makeContext(mcp));
+
+    await runtime.execute(makeInput());
+
+    expect(mcp.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls mcpServer.close() even when the Runner throws', async () => {
+    const Runtime = await loadRuntime();
+    const mcp = makeMcpServer();
+    const runtime = new Runtime(makeContext(mcp));
+    mockRunBehavior = 'throw';
+
+    await expect(runtime.execute(makeInput())).rejects.toThrow('Runner blew up');
+    expect(mcp.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards the abortController.signal to Runner.run when provided', async () => {
+    const Runtime = await loadRuntime();
+    const mcp = makeMcpServer();
+    const runtime = new Runtime(makeContext(mcp));
+
+    const controller = new AbortController();
+    await runtime.execute(makeInput({ abortController: controller }));
+
+    expect(runnerCalls[0].options.signal).toBe(controller.signal);
+  });
+
+  it('omits signal when no abortController is supplied', async () => {
+    const Runtime = await loadRuntime();
+    const mcp = makeMcpServer();
+    const runtime = new Runtime(makeContext(mcp));
+
+    await runtime.execute(makeInput());
+
+    expect(runnerCalls[0].options.signal).toBeUndefined();
+  });
+
+  it('aggregates usage across rawResponses', async () => {
+    const Runtime = await loadRuntime();
+    const mcp = makeMcpServer();
+    const runtime = new Runtime(makeContext(mcp));
+
+    const result = await runtime.execute(makeInput());
+
+    expect(result.turnsUsed).toBe(2);
+    expect(result.usage.requests).toBe(2);
+    expect(result.usage.inputTokens).toBe(300);
+    expect(result.usage.outputTokens).toBe(110);
+    expect(result.usage.totalTokens).toBe(410);
+    expect(result.usage.reasoningTokens).toBe(30);
+    expect(result.usage.cachedTokens).toBe(100);
+    expect(result.rawRuntimeMetadata?.lastResponseId).toBe('resp_ok');
+  });
+
+  it('passes dryRun through toolSurface to createOpenAIMcpServer', async () => {
+    const Runtime = await loadRuntime();
+    const mcp = makeMcpServer();
+    const ctx = makeContext(mcp);
+    const runtime = new Runtime(ctx);
+
+    await runtime.execute(makeInput({
+      toolSurface: { agentId: 'a', runId: 'r', dryRun: true },
+    }));
+
+    expect(ctx.createOpenAIMcpServer).toHaveBeenCalledTimes(1);
+    const forwarded = (ctx.createOpenAIMcpServer as unknown as { mock: { calls: Array<Array<Record<string, unknown>>> } }).mock.calls[0][0];
+    expect(forwarded.dryRun).toBe(true);
+  });
+
+  it('round-trips lastResponseId into rawRuntimeMetadata for resume flow', async () => {
+    const Runtime = await loadRuntime();
+    const mcp = makeMcpServer();
+    const runtime = new Runtime(makeContext(mcp));
+
+    // Simulate a resumed session where the prior run produced lastResponseId='resp_abc'
+    mockRunResult.lastResponseId = 'resp_abc_next';
+    const priorItems = [{ type: 'user', content: 'resume-turn' }];
+
+    const result = await runtime.execute(makeInput({
+      sessionRef: 'resume-sess',
+      sessionData: priorItems,
+    }));
+
+    expect(result.rawRuntimeMetadata?.lastResponseId).toBe('resp_abc_next');
+    expect(result.usage.providerData).toEqual({ lastResponseId: 'resp_abc_next' });
+    // The prior items were loaded into the Session handed to Runner.run
+    const session = runnerCalls[0].options.session!;
+    expect(await session.getItems()).toEqual(priorItems);
+  });
+
+  it('tolerates responses without inputTokensDetails/outputTokensDetails arrays (local backends)', async () => {
+    const Runtime = await loadRuntime();
+    const mcp = makeMcpServer();
+    const runtime = new Runtime(makeContext(mcp));
+    mockRunResult.rawResponses = [
+      {
+        usage: {
+          requests: 1,
+          inputTokens: 42,
+          outputTokens: 7,
+          totalTokens: 49,
+          // No inputTokensDetails / outputTokensDetails — common for Ollama,
+          // LM Studio, and llama.cpp server responses.
+        },
+      },
+    ];
+
+    const result = await runtime.execute(makeInput());
+    expect(result.usage.inputTokens).toBe(42);
+    expect(result.usage.cachedTokens).toBe(0);
+    expect(result.usage.reasoningTokens).toBe(0);
+  });
+});

--- a/tests/daemon/inflight-runs.test.ts
+++ b/tests/daemon/inflight-runs.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { InflightRunRegistry } from '@myco/daemon/inflight-runs.js';
+
+describe('InflightRunRegistry', () => {
+  it('registers a promise and removes it once it settles', async () => {
+    const registry = new InflightRunRegistry();
+    let resolveFn!: () => void;
+    const p = new Promise<void>((resolve) => { resolveFn = resolve; });
+
+    registry.register(p);
+    expect(registry.size).toBe(1);
+
+    resolveFn();
+    // Allow the finally handler to execute
+    await registry.drain(100);
+    expect(registry.size).toBe(0);
+  });
+
+  it('tracks rejected promises without propagating the rejection', async () => {
+    const registry = new InflightRunRegistry();
+    let rejectFn!: (err: Error) => void;
+    const p = new Promise<void>((_resolve, reject) => { rejectFn = reject; });
+
+    registry.register(p);
+    // Prevent unhandled rejection
+    p.catch(() => {});
+    expect(registry.size).toBe(1);
+
+    rejectFn(new Error('boom'));
+    const outcome = await registry.drain(100);
+    expect(outcome.settled).toBe(true);
+    expect(outcome.remaining).toBe(0);
+  });
+
+  it('drain resolves immediately when the registry is empty', async () => {
+    const registry = new InflightRunRegistry();
+    const outcome = await registry.drain(5_000);
+    expect(outcome).toEqual({ settled: true, remaining: 0 });
+  });
+
+  it('returns settled=false when runs exceed the drain timeout', async () => {
+    const registry = new InflightRunRegistry();
+    // Never-settling promise — we rely on the drain timeout to bound the wait.
+    const pending = new Promise<void>(() => {});
+    registry.register(pending);
+
+    const start = Date.now();
+    const outcome = await registry.drain(50);
+    const elapsed = Date.now() - start;
+
+    expect(outcome.settled).toBe(false);
+    expect(outcome.remaining).toBeGreaterThanOrEqual(1);
+    // Allow generous slack — CI can be noisy but shouldn't exceed an order of magnitude.
+    expect(elapsed).toBeLessThan(1_000);
+  });
+
+  it('awaits multiple in-flight runs concurrently in drain()', async () => {
+    const registry = new InflightRunRegistry();
+    const resolvers: Array<() => void> = [];
+    for (let i = 0; i < 3; i += 1) {
+      registry.register(new Promise<void>((resolve) => {
+        resolvers.push(resolve);
+      }));
+    }
+    expect(registry.size).toBe(3);
+
+    // Resolve them asynchronously
+    setTimeout(() => resolvers.forEach((fn) => fn()), 10);
+
+    const outcome = await registry.drain(500);
+    expect(outcome.settled).toBe(true);
+    expect(outcome.remaining).toBe(0);
+  });
+});

--- a/tests/daemon/plan-capture.test.ts
+++ b/tests/daemon/plan-capture.test.ts
@@ -515,6 +515,121 @@ describe('capturePlan', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Cross-channel overwrite detection (Finding #11)
+// ---------------------------------------------------------------------------
+
+describe('persistPlan cross-channel overwrite detection', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => { cleanTestDb(); });
+
+  function makeLogger() {
+    return {
+      debug: () => {},
+      info: () => {},
+      warn: (...args: unknown[]) => { warnCalls.push(args); },
+      error: () => {},
+      warnCalls: [] as unknown[][],
+    };
+  }
+  let warnCalls: unknown[][] = [];
+
+  it('short-circuits as a no-op when the same content+title is written twice on the same logical_key', () => {
+    const sessionId = 'test-overwrite-noop';
+    const now = epochNow();
+    const sourcePath = '/home/user/myproject/docs/plans/sprint.md';
+
+    upsertSession({ id: sessionId, agent: 'claude-code', started_at: now, created_at: now });
+
+    const first = persistPlan({
+      sessionId,
+      content: '# Sprint\n\nSame content.',
+      logicalKey: buildPathPlanLogicalKey(sourcePath),
+      sourcePath,
+    });
+    const firstUpdatedAt = first.updated_at;
+
+    // Sleep a beat so updated_at would change if the write did run.
+    const second = persistPlan({
+      sessionId,
+      content: '# Sprint\n\nSame content.',
+      logicalKey: buildPathPlanLogicalKey(sourcePath),
+      sourcePath,
+      updatedAt: (firstUpdatedAt ?? now) + 10,
+    });
+
+    // No-op: the second call returns the existing row (same updated_at).
+    expect(second.updated_at).toBe(firstUpdatedAt);
+    expect(second.content_hash).toBe(first.content_hash);
+  });
+
+  it('warn-logs when the same logical_key is overwritten by a different source_path', () => {
+    warnCalls = [];
+    const logger = makeLogger();
+    const sessionId = 'test-overwrite-warn';
+    const now = epochNow();
+    const logicalKey = `session:${sessionId}:key:primary`;
+
+    upsertSession({ id: sessionId, agent: 'claude-code', started_at: now, created_at: now });
+
+    // First write: via MCP save_plan — no source_path (plan_key only)
+    persistPlan({
+      sessionId,
+      content: 'Version A of the plan.',
+      logicalKey,
+      sourcePath: null,
+      planKey: 'primary',
+      logger: logger as never,
+    });
+
+    // Second write: same logical_key, different content AND different source_path
+    persistPlan({
+      sessionId,
+      content: 'Version B of the plan — completely different.',
+      logicalKey,
+      sourcePath: '/docs/plans/primary.md',
+      planKey: 'primary',
+      logger: logger as never,
+    });
+
+    expect(warnCalls.length).toBeGreaterThanOrEqual(1);
+    const firstWarn = warnCalls[0];
+    expect(firstWarn[1]).toBe('Plan overwritten mid-session');
+    const warnPayload = firstWarn[2] as Record<string, unknown>;
+    expect(warnPayload.logical_key).toBe(logicalKey);
+    expect(warnPayload.prior_source).toBeNull();
+    expect(warnPayload.new_source).toBe('/docs/plans/primary.md');
+  });
+
+  it('does not warn when content changes but source_path is unchanged (normal edit)', () => {
+    warnCalls = [];
+    const logger = makeLogger();
+    const sessionId = 'test-overwrite-sameroute';
+    const now = epochNow();
+    const sourcePath = '/docs/plans/primary.md';
+
+    upsertSession({ id: sessionId, agent: 'claude-code', started_at: now, created_at: now });
+
+    persistPlan({
+      sessionId,
+      content: 'Original.',
+      logicalKey: buildPathPlanLogicalKey(sourcePath),
+      sourcePath,
+      logger: logger as never,
+    });
+    persistPlan({
+      sessionId,
+      content: 'Updated content.',
+      logicalKey: buildPathPlanLogicalKey(sourcePath),
+      sourcePath,
+      logger: logger as never,
+    });
+
+    expect(warnCalls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // extractTaggedPlans
 // ---------------------------------------------------------------------------
 

--- a/tests/daemon/plan-capture.test.ts
+++ b/tests/daemon/plan-capture.test.ts
@@ -28,6 +28,7 @@ import {
   type PlanWatchConfig,
 } from '@myco/daemon/plan-capture.js';
 import { buildPathPlanLogicalKey } from '@myco/plans/identity.js';
+import type { Logger } from '@myco/daemon/logger.js';
 
 /** Epoch seconds helper. */
 const epochNow = () => Math.floor(Date.now() / 1000);
@@ -523,13 +524,14 @@ describe('persistPlan cross-channel overwrite detection', () => {
   afterAll(() => { teardownTestDb(); });
   beforeEach(() => { cleanTestDb(); });
 
-  function makeLogger() {
+  function makeLogger(): Logger {
     return {
       debug: () => {},
       info: () => {},
-      warn: (...args: unknown[]) => { warnCalls.push(args); },
+      warn: (_kind: string, _message: string, data?: Record<string, unknown>) => {
+        warnCalls.push([_kind, _message, data]);
+      },
       error: () => {},
-      warnCalls: [] as unknown[][],
     };
   }
   let warnCalls: unknown[][] = [];
@@ -549,6 +551,15 @@ describe('persistPlan cross-channel overwrite detection', () => {
     });
     const firstUpdatedAt = first.updated_at;
 
+    const db = getDatabase();
+    const countOutboxRows = (): number => {
+      const row = db
+        .prepare("SELECT COUNT(*) AS n FROM team_outbox WHERE table_name = 'plans' AND row_id = ?")
+        .get(first.id) as { n: number };
+      return row.n;
+    };
+    const outboxBefore = countOutboxRows();
+
     // Sleep a beat so updated_at would change if the write did run.
     const second = persistPlan({
       sessionId,
@@ -561,6 +572,8 @@ describe('persistPlan cross-channel overwrite detection', () => {
     // No-op: the second call returns the existing row (same updated_at).
     expect(second.updated_at).toBe(firstUpdatedAt);
     expect(second.content_hash).toBe(first.content_hash);
+    // And the no-op MUST NOT enqueue a new outbox row.
+    expect(countOutboxRows()).toBe(outboxBefore);
   });
 
   it('warn-logs when the same logical_key is overwritten by a different source_path', () => {
@@ -579,7 +592,7 @@ describe('persistPlan cross-channel overwrite detection', () => {
       logicalKey,
       sourcePath: null,
       planKey: 'primary',
-      logger: logger as never,
+      logger,
     });
 
     // Second write: same logical_key, different content AND different source_path
@@ -589,7 +602,7 @@ describe('persistPlan cross-channel overwrite detection', () => {
       logicalKey,
       sourcePath: '/docs/plans/primary.md',
       planKey: 'primary',
-      logger: logger as never,
+      logger,
     });
 
     expect(warnCalls.length).toBeGreaterThanOrEqual(1);
@@ -615,14 +628,14 @@ describe('persistPlan cross-channel overwrite detection', () => {
       content: 'Original.',
       logicalKey: buildPathPlanLogicalKey(sourcePath),
       sourcePath,
-      logger: logger as never,
+      logger,
     });
     persistPlan({
       sessionId,
       content: 'Updated content.',
       logicalKey: buildPathPlanLogicalKey(sourcePath),
       sourcePath,
-      logger: logger as never,
+      logger,
     });
 
     expect(warnCalls).toHaveLength(0);

--- a/tests/daemon/team-sync.test.ts
+++ b/tests/daemon/team-sync.test.ts
@@ -236,6 +236,56 @@ describe('TeamSyncClient', () => {
     });
   });
 
+  describe('request timeout', () => {
+    it('attaches an AbortSignal to every request() call', async () => {
+      const mockFetch = vi.fn(async () => new Response(JSON.stringify({ config: {}, sync_protocol_version: 1 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as unknown as typeof globalThis.fetch;
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      await client.getConfig();
+
+      const initArg = (mockFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+      expect(initArg.signal).toBeInstanceOf(AbortSignal);
+      expect((initArg.signal as AbortSignal).aborted).toBe(false);
+    });
+
+    it('aborts a stalled request via the internal deadline', async () => {
+      // Capture the signal from the fetch() call and await its abort event.
+      // We use fake timers so the real 15s default timeout fires within
+      // the test budget.
+      vi.useFakeTimers();
+      try {
+        let capturedSignal: AbortSignal | undefined;
+        const mockFetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+          capturedSignal = init?.signal as AbortSignal | undefined;
+          return await new Promise<Response>((_resolve, reject) => {
+            capturedSignal?.addEventListener('abort', () => {
+              const err = new Error('aborted');
+              err.name = 'AbortError';
+              reject(err);
+            });
+          });
+        }) as unknown as typeof globalThis.fetch;
+
+        const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+        const pending = client.getConfig();
+        // Silence the rejection while we advance the clock.
+        const expectation = expect(pending).rejects.toThrow(/aborted/i);
+
+        // Advance past TEAM_REQUEST_TIMEOUT_MS (15s) to trigger the internal
+        // controller.abort().
+        await vi.advanceTimersByTimeAsync(16_000);
+
+        await expectation;
+        expect(capturedSignal?.aborted).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe('URL normalization', () => {
     it('strips trailing slash from worker URL', async () => {
       const mockFetch = createMockFetch({

--- a/tests/daemon/trigger-cortex-instructions.test.ts
+++ b/tests/daemon/trigger-cortex-instructions.test.ts
@@ -110,4 +110,42 @@ describe('triggerCortexInstructions', () => {
     });
     expect(logger.warn).not.toHaveBeenCalled();
   });
+
+  it('returns startup-failed with a log when buildCortexInstructionsInput throws', async () => {
+    const logger = makeLogger();
+    buildCortexInstructionsInput.mockRejectedValueOnce(new Error('DB unavailable'));
+
+    const result = await triggerCortexInstructions({
+      vaultDir: '/tmp/myco',
+      embeddingManager: makeEmbeddingManagerStub() as never,
+      liveConfig: { current: makeConfig() },
+      logger: logger as never,
+    });
+
+    expect(result.started).toBe(false);
+    expect(result.reason).toBe('startup-failed');
+    expect(result.error).toContain('DB unavailable');
+    expect(logger.warn).toHaveBeenCalledWith(
+      'agent.error',
+      'Failed to start cortex-instructions task',
+      expect.objectContaining({ error: expect.stringContaining('DB unavailable') }),
+    );
+  });
+
+  it('registers the fire-and-forget promise with registerInflightRun when provided', async () => {
+    const logger = makeLogger();
+    const registerInflightRun = vi.fn();
+
+    const result = await triggerCortexInstructions({
+      vaultDir: '/tmp/myco',
+      embeddingManager: makeEmbeddingManagerStub() as never,
+      liveConfig: { current: makeConfig() },
+      logger: logger as never,
+      registerInflightRun,
+    });
+
+    expect(result.started).toBe(true);
+    expect(registerInflightRun).toHaveBeenCalledTimes(1);
+    expect(registerInflightRun.mock.calls[0][0]).toBeInstanceOf(Promise);
+  });
 });

--- a/tests/plans/identity.test.ts
+++ b/tests/plans/identity.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Anti-drift tests for plan logical-key builders.
+ *
+ * The MCP `myco_save_plan` tool and the transcript-tag capture path both
+ * compose session-scoped logical keys, but they MUST land in distinct
+ * namespaces so an agent that drops a `<primary>` tag *and* calls
+ * myco_save_plan({plan_key: 'primary'}) produces two rows, not one.
+ *
+ * Finding #10 of the pre-0.21 runtime review.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildSessionPlanLogicalKey,
+  buildSessionTagPlanLogicalKey,
+  buildPathPlanLogicalKey,
+} from '@myco/plans/identity.js';
+
+describe('plan logical-key namespaces', () => {
+  it('session tag capture and session plan_key use different namespaces', () => {
+    const sessionId = 'sess-001';
+    const name = 'primary';
+
+    const fromTag = buildSessionTagPlanLogicalKey(sessionId, name);
+    const fromKey = buildSessionPlanLogicalKey(sessionId, name);
+
+    expect(fromTag).not.toBe(fromKey);
+    expect(fromTag).toBe('session:sess-001:tag:primary');
+    expect(fromKey).toBe('session:sess-001:key:primary');
+  });
+
+  it('session-scoped keys (tag or key) never collide with path-scoped keys', () => {
+    const sessionId = 'sess-002';
+    expect(buildSessionPlanLogicalKey(sessionId, 'plan.md'))
+      .not.toBe(buildPathPlanLogicalKey('plan.md'));
+    expect(buildSessionTagPlanLogicalKey(sessionId, 'plan.md'))
+      .not.toBe(buildPathPlanLogicalKey('plan.md'));
+  });
+
+  it('distinct sessions produce distinct keys for the same tag/name', () => {
+    expect(buildSessionTagPlanLogicalKey('sess-a', 'primary'))
+      .not.toBe(buildSessionTagPlanLogicalKey('sess-b', 'primary'));
+    expect(buildSessionPlanLogicalKey('sess-a', 'primary'))
+      .not.toBe(buildSessionPlanLogicalKey('sess-b', 'primary'));
+  });
+});


### PR DESCRIPTION
## Summary

**Bundle C of the pre-0.21.0 quality pass.** Addresses 11 reliability and runtime-coverage findings from the [`/ce-review` of `myco/v0.20.2..HEAD`](../../docs/superpowers/plans/2026-04-18-pre-0.21.0-quality-pass.md). Silent failure modes in Cortex task launchers, missing runtime test coverage, and a hang-forever TeamSync client are the load-bearing fixes.

## Findings resolved

| # | Severity | Area | Issue |
|---|----------|------|-------|
| 8 | P1 | runtime tests | `OpenAIAgentsRuntime.execute` + `ClaudeSdkRuntime` had no direct tests |
| 10 | P2 | plans | `myco_save_plan` `plan_key` vs transcript-tag namespace mismatch — two rows for same intent |
| 11 | P2 | plans | Last-write-wins with no revisions; cross-channel overwrites silently destroy content |
| 12 | P2 | cortex | `triggerCortexInstructions` `catch {}` with misleading `'agent-module-unavailable'` reason |
| 13 | P2 | cortex | `buildCortexPrompt` fire-and-forget `.catch(() => {})` swallowed every failure |
| 14 | P2 | team-sync | `TeamSyncClient.request()` had no timeout — any team API call could hang forever |
| 15 | P2 | runtime | OpenAI usage aggregation crashed on missing `outputTokensDetails` for Ollama/LM Studio |
| 16 | P2 | daemon | Fire-and-forget Cortex runs not tracked for graceful shutdown — SIGTERM abandoned them |
| 27 | P2 | tests | No openai-agents + dryRun end-to-end coverage |
| 28 | P2 | tests | No openai-agents resume (`lastResponseId`) round-trip test |
| 51 | P3 | dispatcher | `evaluateAutoRegistration` not wrapped in try/catch — manifest regex bug → 500 on `/events` |

## What changed

**Cortex launchers stop silently swallowing errors** (`trigger-cortex-instructions.ts`, `services/cortex.ts`). Distinct reason codes (`'startup-failed'` vs `'agent-module-unavailable'`), both logged via `LOG_KINDS.AGENT_ERROR`. `CortexServicesDeps.logger` is now required — prevents future callers from re-introducing the silent-error regression.

**TeamSync has a bounded wait** (`team-sync.ts`). `TEAM_REQUEST_TIMEOUT_MS = 15_000` default via `AbortSignal.timeout`; `pushBatch` overrides to `TEAM_SYNC_TIMEOUT_MS = 30_000`. Consistent with existing `TEAM_SEARCH_TIMEOUT_MS` / `TEAM_HEALTH_TIMEOUT_MS` pattern. Every `request()` call path (connect, getConfig, getCollectiveStatus, getCollectiveSettings, collectiveQuery, rotateMcpToken) inherits.

**OpenAI runtime no longer crashes on local-compat providers** (`runtime/openai.ts`). `(response.usage.outputTokensDetails ?? []).reduce(...)` and matching type widening so the compiler enforces the guard. Ollama / LM Studio / llama.cpp backends that omit the details arrays now produce valid usage records.

**New `InflightRunRegistry`** (`daemon/inflight-runs.ts`). Small focused class with `register` / `size` / `drain(timeoutMs)`. Fire-and-forget Cortex launchers register their promises; shutdown awaits drain with a 30s bounded timeout. Drain race handles the timeout cleanly — unsettled promises continue to completion with their `finally` cleanup; no leak.

**Plan capture last-write-wins gets a cheap safety net** (`plan-capture.ts`, `plans.ts`). `persistPlan` short-circuits when `content_hash` + `title` + `status` match — no-op writes don't touch `updated_at` or the outbox. Cross-channel writes under the same `logical_key` from different `source_path`s warn-log via `LOG_KINDS.CAPTURE_PLAN` with prior + new source for forensic signal. No revisions table (that's tracked follow-up).

**Plan namespace split is now explicit** (`mcp/tool-definitions.ts`). `myco_save_plan` tool description + Cortex guidance spell out: `plan_key` creates a stable namespace distinct from transcript `<tag>` capture; the two do not merge. Anti-drift test in new `tests/plans/identity.test.ts`.

**Capture-rule evaluation fails open** (`event-dispatch.ts`). `evaluateAutoRegistration` wraps `evaluateSessionCaptureRules` in try/catch, defaulting to `{action: 'pass'}` on throw with `logger.error`. A manifest regex bug can no longer 500 the dispatcher.

## Test plan

- [x] `make build` — all packages + UI bundle
- [x] `make check` — **2966 passed, 3 skipped, 0 failed** (+29 new vs baseline)
- [x] New test files:
  - `tests/daemon/inflight-runs.test.ts` — 5 tests (empty drain, rejection tracking, timeout bound, concurrent settle)
  - `tests/plans/identity.test.ts` — 3 tests (`buildSessionTagPlanLogicalKey !== buildSessionPlanLogicalKey` anti-drift)
  - `tests/agent/runtime-openai.test.ts` — 10 tests (session persist, mcpServer.close on success + throw, abort signal, usage aggregation, dryRun forward)
  - `tests/agent/runtime-claude.test.ts` — 8 tests (scoped / empty / **full** tool-server paths, sessionRef/sessionId round-trip, abortController forwarding, usage sum)
  - `tests/agent/executor-openai-agents.test.ts` — 3 tests (dryRun persists through openai-agents runtime; resume with `lastResponseId` + `sessionData` round-trips prior items)
- [x] Augmented: `tests/daemon/plan-capture.test.ts` (cross-channel overwrite, no-op short-circuit with direct outbox-row-count assertion), `tests/daemon/team-sync.test.ts` (timeout wiring via `vi.useFakeTimers()` + captured `AbortSignal`), `tests/daemon/trigger-cortex-instructions.test.ts` (`startup-failed` reason + InflightRunRegistry registration)

## Deferred follow-up

- **#103** — `test(daemon): cover agent-module-unavailable branch in trigger-cortex-instructions` — the dynamic-import catch path is reachable but needs a `loadExecutor` seam to test cleanly; deferred to a small follow-up.

## Pipeline

Implementer (DONE) → spec review (✅ compliant, 3 advisories) → code quality review (⚠️ approved with minor, 4 suggestions) → fix-pass (addresses 3 in-PR + 1 as follow-up issue). Two commits on this branch; will squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)