### PR TITLE
chore(cleanup): pre-0.21.0 quality-pass sweep — types, contracts, dead code, tests

### DIFF
--- a/packages/myco/src/agent/cost/openrouter.ts
+++ b/packages/myco/src/agent/cost/openrouter.ts
@@ -40,6 +40,11 @@ interface OpenRouterCatalogCacheEntry {
 }
 
 const catalogCache = new Map<string, OpenRouterCatalogCacheEntry>();
+/**
+ * Coalesces concurrent cold-cache fetches for the same baseUrl so N callers
+ * don't spawn N parallel HTTP requests when the cache is empty or expired.
+ */
+const inflightFetches = new Map<string, Promise<Map<string, OpenRouterPricing>>>();
 
 function parseRate(rate: string | undefined): number | undefined {
   if (!rate) return undefined;
@@ -78,6 +83,21 @@ async function fetchPricingCatalog(baseUrl?: string): Promise<Map<string, OpenRo
   if (cached && cached.expiresAt > now) {
     return cached.pricingByModel;
   }
+  const inflight = inflightFetches.get(resolvedBaseUrl);
+  if (inflight) {
+    return inflight;
+  }
+  const fetchPromise = fetchPricingCatalogUncached(resolvedBaseUrl, now).finally(() => {
+    inflightFetches.delete(resolvedBaseUrl);
+  });
+  inflightFetches.set(resolvedBaseUrl, fetchPromise);
+  return fetchPromise;
+}
+
+async function fetchPricingCatalogUncached(
+  resolvedBaseUrl: string,
+  now: number,
+): Promise<Map<string, OpenRouterPricing>> {
   pruneExpiredCatalogEntries(now);
 
   const apiKey = resolveOpenRouterApiKey();

--- a/packages/myco/src/agent/cost/providers.ts
+++ b/packages/myco/src/agent/cost/providers.ts
@@ -2,45 +2,7 @@ import { estimateOpenAICost } from './openai.js';
 import { estimateOpenRouterCost } from './openrouter.js';
 import { resolveUnavailableCost } from './helpers.js';
 import type { ProviderType } from '@myco/agent/types.js';
-import type { CostProviderCapabilities, CostProviderResolver, CostResolutionInput } from './types.js';
-
-const CAPABILITIES_NONE: CostProviderCapabilities = {
-  estimateFromUsage: false,
-  fetchActualRunCost: false,
-  fetchCatalogPricing: false,
-};
-
-const CAPABILITIES_ANTHROPIC: CostProviderCapabilities = {
-  estimateFromUsage: false,
-  fetchActualRunCost: true,
-  fetchCatalogPricing: false,
-};
-
-const CAPABILITIES_OPENAI: CostProviderCapabilities = {
-  estimateFromUsage: true,
-  fetchActualRunCost: false,
-  fetchCatalogPricing: false,
-};
-
-const CAPABILITIES_OPENROUTER: CostProviderCapabilities = {
-  estimateFromUsage: true,
-  fetchActualRunCost: true,
-  fetchCatalogPricing: true,
-};
-
-const UNAVAILABLE_PROVIDER_RULES: Array<{
-  providerTypes: ProviderType[];
-  message: string;
-}> = [
-  {
-    providerTypes: ['anthropic'],
-    message: 'Anthropic runtime did not report cost for this run',
-  },
-  {
-    providerTypes: ['openai-compatible', 'ollama', 'lmstudio'],
-    message: 'No pricing resolver configured for this provider',
-  },
-];
+import type { CostProviderResolver, CostResolutionInput } from './types.js';
 
 function matchesProviderType(providerType: ProviderType | undefined, candidates: ProviderType[]): boolean {
   return providerType !== undefined && candidates.includes(providerType);
@@ -49,25 +11,21 @@ function matchesProviderType(providerType: ProviderType | undefined, candidates:
 const COST_PROVIDERS: CostProviderResolver[] = [
   {
     id: 'openai',
-    capabilities: CAPABILITIES_OPENAI,
     matches: (input) => input.provider?.type === 'openai',
     resolve: async (input) => estimateOpenAICost(input.model, input.usage),
   },
   {
     id: 'openrouter',
-    capabilities: CAPABILITIES_OPENROUTER,
     matches: (input) => input.provider?.type === 'openrouter',
     resolve: async (input) => estimateOpenRouterCost(input.model, input.usage, input.provider?.baseUrl),
   },
   {
     id: 'anthropic-runtime',
-    capabilities: CAPABILITIES_ANTHROPIC,
     matches: (input) => input.provider?.type === 'anthropic',
     resolve: async (input) => resolveUnavailableCost(input, 'Anthropic runtime did not report cost for this run'),
   },
   {
     id: 'generic-configured',
-    capabilities: CAPABILITIES_NONE,
     matches: (input) => matchesProviderType(input.provider?.type, ['openai-compatible', 'ollama', 'lmstudio']),
     resolve: async (input) => resolveUnavailableCost(input, 'No pricing resolver configured for this provider'),
   },
@@ -83,10 +41,5 @@ export function getCostProvider(input: CostResolutionInput): CostProviderResolve
 }
 
 export function resolveProviderCostUnavailable(input: CostResolutionInput) {
-  for (const rule of UNAVAILABLE_PROVIDER_RULES) {
-    if (matchesProviderType(input.provider?.type, rule.providerTypes)) {
-      return resolveUnavailableCost(input, rule.message);
-    }
-  }
   return resolveUnavailableCost(input, 'No provider cost resolver available');
 }

--- a/packages/myco/src/agent/cost/types.ts
+++ b/packages/myco/src/agent/cost/types.ts
@@ -36,15 +36,8 @@ export interface CostResolutionInput {
   provider?: ProviderConfig;
 }
 
-export interface CostProviderCapabilities {
-  estimateFromUsage: boolean;
-  fetchActualRunCost: boolean;
-  fetchCatalogPricing: boolean;
-}
-
 export interface CostProviderResolver {
   id: string;
-  capabilities: CostProviderCapabilities;
   matches: (input: CostResolutionInput) => boolean;
   resolve: (input: CostResolutionInput) => Promise<CostResolution>;
 }

--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -195,17 +195,15 @@ export function resolvePhaseExecution(
     () => config.model,
   ]);
 
-  const effectiveModel = (firstDefined<string>([
+  const effectiveModel = firstDefined<string>([
     () => runPhaseOverride?.model,
     () => mycoYamlPhase?.model,
     () => resolveReasoningModel(effectiveReasoning, effectiveProvider, fallbackModel ?? ''),
-  ]) ?? '') as string;
+  ]) ?? '';
 
-  const effectiveMaxTurns = firstDefined<number>([
-    () => runPhaseOverride?.maxTurns,
-    () => mycoYamlPhase?.maxTurns,
-    () => phase.maxTurns,
-  ]) as number;
+  const effectiveMaxTurns = runPhaseOverride?.maxTurns
+    ?? mycoYamlPhase?.maxTurns
+    ?? phase.maxTurns;
 
   return {
     reasoningLevel: effectiveReasoning,

--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -6,7 +6,6 @@ import {
   epochSeconds,
   DEFAULT_AGENT_ID,
   MS_PER_SECOND,
-  PHASE_SUMMARY_MAX_CHARS,
   CONTENT_HASH_ALGORITHM,
 } from '@myco/constants.js';
 import { errorMessage as toErrorMessage } from '@myco/utils/error-message.js';
@@ -56,6 +55,8 @@ import {
   summarizePhaseCosts,
 } from './run-accounting.js';
 import { getAgentRuntime } from './runtime/index.js';
+import { composeTaskPrompt, composePhasePrompt } from './prompt-composition.js';
+export { composeTaskPrompt, composePhasePrompt };
 import type { CostResolution } from './cost/types.js';
 import type { ContextQueryResult } from './context-queries.js';
 import type { ProviderConfig } from './types.js';
@@ -82,27 +83,13 @@ const STATUS_SKIPPED = 'skipped';
 /** Reason string when skipping due to concurrency guard. */
 const SKIP_REASON_ALREADY_RUNNING = 'already_running';
 
-/** Section header for vault context in the composed prompt. */
-const PROMPT_SECTION_TASK = '## Task: ';
-
-/** Section header for user instruction in the composed prompt. */
-const PROMPT_SECTION_INSTRUCTION = '## User Instruction';
-
 /** Report action emitted by the Cortex instructions task. */
 const CORTEX_INSTRUCTIONS_REPORT_ACTION = 'cortex_instructions';
 
 /** Details key storing the final markdown content in the Cortex report. */
 const CORTEX_INSTRUCTIONS_CONTENT_KEY = 'content';
 
-/** Separator between prompt sections. */
-const PROMPT_SECTION_SEPARATOR = '\n\n';
-
-/** Header for prior phase context in phased prompts. */
-const PROMPT_SECTION_PRIOR_PHASES = '## Prior Phase Results';
-
-/** Header for the current phase in phased prompts. */
-const PROMPT_SECTION_CURRENT_PHASE = '## Current Phase: ';
-const TOKEN_BUDGET_PRESSURE_STATUSES = new Set(['warning', 'critical']);
+const TOKEN_BUDGET_PRESSURE_STATUSES = new Set(['warning', 'post_run_pressure']);
 
 function logTokenBudgetPressure(
   taskName: string,
@@ -162,6 +149,19 @@ export interface MycoYamlPhaseOverrides {
  *   2. `phaseProviderOverrides[name].maxTurns` (myco.yaml)
  *   3. `phase.maxTurns` (task YAML)
  */
+/**
+ * Walk an ordered list of lookups and return the first defined value. Keeps
+ * precedence chains declarative so unit tests can exercise each source
+ * individually without re-running the entire resolver.
+ */
+function firstDefined<T>(lookups: Array<() => T | undefined>): T | undefined {
+  for (const lookup of lookups) {
+    const value = lookup();
+    if (value !== undefined) return value;
+  }
+  return undefined;
+}
+
 export function resolvePhaseExecution(
   phase: PhaseDefinition,
   options: RunOptions | undefined,
@@ -173,34 +173,39 @@ export function resolvePhaseExecution(
   const topOverride = options?.executionOverrides;
   const mycoYamlPhase = phaseProviderOverrides?.[phase.name];
 
-  const effectiveProvider: ProviderConfig | undefined =
-    runPhaseOverride?.provider
-    ?? phase.provider
-    ?? mycoYamlPhase?.provider
-    ?? topOverride?.provider
-    ?? provider;
+  const effectiveProvider = firstDefined<ProviderConfig>([
+    () => runPhaseOverride?.provider,
+    () => phase.provider,
+    () => mycoYamlPhase?.provider,
+    () => topOverride?.provider,
+    () => provider,
+  ]);
 
-  const effectiveReasoning: ReasoningLevel | undefined =
-    runPhaseOverride?.reasoningLevel
-    ?? phase.reasoningLevel
-    ?? topOverride?.reasoningLevel
-    ?? config.execution?.reasoningLevel
-    ?? config.reasoningLevel;
+  const effectiveReasoning = firstDefined<ReasoningLevel>([
+    () => runPhaseOverride?.reasoningLevel,
+    () => phase.reasoningLevel,
+    () => topOverride?.reasoningLevel,
+    () => config.execution?.reasoningLevel,
+    () => config.reasoningLevel,
+  ]);
 
-  const fallbackModel =
-    phase.model
-    ?? topOverride?.model
-    ?? config.model;
+  const fallbackModel = firstDefined<string>([
+    () => phase.model,
+    () => topOverride?.model,
+    () => config.model,
+  ]);
 
-  const effectiveModel =
-    runPhaseOverride?.model
-    ?? mycoYamlPhase?.model
-    ?? resolveReasoningModel(effectiveReasoning, effectiveProvider, fallbackModel);
+  const effectiveModel = (firstDefined<string>([
+    () => runPhaseOverride?.model,
+    () => mycoYamlPhase?.model,
+    () => resolveReasoningModel(effectiveReasoning, effectiveProvider, fallbackModel ?? ''),
+  ]) ?? '') as string;
 
-  const effectiveMaxTurns =
-    runPhaseOverride?.maxTurns
-    ?? mycoYamlPhase?.maxTurns
-    ?? phase.maxTurns;
+  const effectiveMaxTurns = firstDefined<number>([
+    () => runPhaseOverride?.maxTurns,
+    () => mycoYamlPhase?.maxTurns,
+    () => phase.maxTurns,
+  ]) as number;
 
   return {
     reasoningLevel: effectiveReasoning,
@@ -237,80 +242,6 @@ function warnUnknownPhaseOverrides(
 // Prompt composition
 // ---------------------------------------------------------------------------
 
-/**
- * Build the full task prompt from vault context, task definition, and
- * optional user instruction.
- *
- * Task prompts support template variables:
- * - `{{session_id}}` — replaced with the session ID from instruction (if present)
- * - `{{instruction}}` — the raw user instruction text
- */
-export function composeTaskPrompt(
-  vaultContext: string,
-  taskDisplayName: string,
-  taskPrompt: string,
-  instruction?: string,
-): string {
-  // Extract session_id from instruction if it contains one (UUID pattern)
-  const sessionIdMatch = instruction?.match(/\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b/i);
-  const sessionId = sessionIdMatch?.[1] ?? '';
-
-  // Template variable substitution in task prompt
-  let resolvedPrompt = taskPrompt;
-  resolvedPrompt = resolvedPrompt.replace(/\{\{session_id\}\}/g, sessionId);
-  resolvedPrompt = resolvedPrompt.replace(/\{\{instruction\}\}/g, instruction ?? '');
-
-  const parts = [
-    vaultContext,
-    `${PROMPT_SECTION_TASK}${taskDisplayName}\n${resolvedPrompt}`,
-  ];
-
-  if (instruction) {
-    parts.push(`${PROMPT_SECTION_INSTRUCTION}\n${instruction}`);
-  }
-
-  return parts.join(PROMPT_SECTION_SEPARATOR);
-}
-
-/**
- * Build the prompt for a single phase in a phased execution.
- *
- * Includes vault context, the task overview, prior phase summaries,
- * and the current phase instructions.
- */
-export function composePhasePrompt(
-  vaultContext: string,
-  taskDisplayName: string,
-  taskOverview: string,
-  phase: PhaseDefinition,
-  priorPhaseResults: PhaseResult[],
-  instruction?: string,
-): string {
-  const parts = [
-    vaultContext,
-    `${PROMPT_SECTION_TASK}${taskDisplayName}\n${taskOverview}`,
-  ];
-
-  if (instruction) {
-    parts.push(`${PROMPT_SECTION_INSTRUCTION}\n${instruction}`);
-  }
-
-  // Include prior phase results as context (unless the phase opts out)
-  if (priorPhaseResults.length > 0 && !phase.skipPriorContext) {
-    const summaries = priorPhaseResults.map((pr) => {
-      const truncated = pr.summary.length > PHASE_SUMMARY_MAX_CHARS
-        ? pr.summary.slice(0, PHASE_SUMMARY_MAX_CHARS) + '...'
-        : pr.summary;
-      return `### ${pr.name} (${pr.status})\n${truncated}`;
-    });
-    parts.push(`${PROMPT_SECTION_PRIOR_PHASES}\n${summaries.join('\n\n')}`);
-  }
-
-  // Current phase instructions
-  parts.push(`${PROMPT_SECTION_CURRENT_PHASE}${phase.name}\n${phase.prompt}`);
-
-  return parts.join(PROMPT_SECTION_SEPARATOR);
-}
 
 // ---------------------------------------------------------------------------
 // Single-phase execution helper
@@ -1251,7 +1182,10 @@ export async function finalizeOnTaskSuccess(args: {
     throw new Error('cortex-instructions completed without a cortex_instructions report');
   }
 
-  const details = tryParseJson<Record<string, unknown>>(report.details);
+  const parsedDetails = tryParseJson(report.details);
+  const details = (parsedDetails && typeof parsedDetails === 'object' && !Array.isArray(parsedDetails))
+    ? (parsedDetails as Record<string, unknown>)
+    : null;
   const rawContent = details?.[CORTEX_INSTRUCTIONS_CONTENT_KEY];
   const content = typeof rawContent === 'string' ? rawContent : null;
   if (!content) {

--- a/packages/myco/src/agent/prompt-composition.ts
+++ b/packages/myco/src/agent/prompt-composition.ts
@@ -1,0 +1,97 @@
+/**
+ * Prompt composition helpers for the executor.
+ *
+ * Extracted from `executor.ts` so the section-header constants and the
+ * task/phase prompt builders live in one place. `executor.ts` re-exports
+ * `composeTaskPrompt` and `composePhasePrompt` for tests that still
+ * import them from the old location.
+ */
+
+import { PHASE_SUMMARY_MAX_CHARS } from '@myco/constants.js';
+import type { PhaseDefinition, PhaseResult } from './types.js';
+
+/** Section header for vault context in the composed prompt. */
+const PROMPT_SECTION_TASK = '## Task: ';
+/** Section header for user instruction in the composed prompt. */
+const PROMPT_SECTION_INSTRUCTION = '## User Instruction';
+/** Separator between prompt sections. */
+const PROMPT_SECTION_SEPARATOR = '\n\n';
+/** Header for prior phase context in phased prompts. */
+const PROMPT_SECTION_PRIOR_PHASES = '## Prior Phase Results';
+/** Header for the current phase in phased prompts. */
+const PROMPT_SECTION_CURRENT_PHASE = '## Current Phase: ';
+
+/**
+ * Build the full task prompt from vault context, task definition, and
+ * optional user instruction.
+ *
+ * Task prompts support template variables:
+ * - `{{session_id}}` — replaced with the session ID from instruction (if present)
+ * - `{{instruction}}` — the raw user instruction text
+ */
+export function composeTaskPrompt(
+  vaultContext: string,
+  taskDisplayName: string,
+  taskPrompt: string,
+  instruction?: string,
+): string {
+  // Extract session_id from instruction if it contains one (UUID pattern)
+  const sessionIdMatch = instruction?.match(/\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b/i);
+  const sessionId = sessionIdMatch?.[1] ?? '';
+
+  // Template variable substitution in task prompt
+  let resolvedPrompt = taskPrompt;
+  resolvedPrompt = resolvedPrompt.replace(/\{\{session_id\}\}/g, sessionId);
+  resolvedPrompt = resolvedPrompt.replace(/\{\{instruction\}\}/g, instruction ?? '');
+
+  const parts = [
+    vaultContext,
+    `${PROMPT_SECTION_TASK}${taskDisplayName}\n${resolvedPrompt}`,
+  ];
+
+  if (instruction) {
+    parts.push(`${PROMPT_SECTION_INSTRUCTION}\n${instruction}`);
+  }
+
+  return parts.join(PROMPT_SECTION_SEPARATOR);
+}
+
+/**
+ * Build the prompt for a single phase in a phased execution.
+ *
+ * Includes vault context, the task overview, prior phase summaries,
+ * and the current phase instructions.
+ */
+export function composePhasePrompt(
+  vaultContext: string,
+  taskDisplayName: string,
+  taskOverview: string,
+  phase: PhaseDefinition,
+  priorPhaseResults: PhaseResult[],
+  instruction?: string,
+): string {
+  const parts = [
+    vaultContext,
+    `${PROMPT_SECTION_TASK}${taskDisplayName}\n${taskOverview}`,
+  ];
+
+  if (instruction) {
+    parts.push(`${PROMPT_SECTION_INSTRUCTION}\n${instruction}`);
+  }
+
+  // Include prior phase results as context (unless the phase opts out)
+  if (priorPhaseResults.length > 0 && !phase.skipPriorContext) {
+    const summaries = priorPhaseResults.map((pr) => {
+      const truncated = pr.summary.length > PHASE_SUMMARY_MAX_CHARS
+        ? pr.summary.slice(0, PHASE_SUMMARY_MAX_CHARS) + '...'
+        : pr.summary;
+      return `### ${pr.name} (${pr.status})\n${truncated}`;
+    });
+    parts.push(`${PROMPT_SECTION_PRIOR_PHASES}\n${summaries.join('\n\n')}`);
+  }
+
+  // Current phase instructions
+  parts.push(`${PROMPT_SECTION_CURRENT_PHASE}${phase.name}\n${phase.prompt}`);
+
+  return parts.join(PROMPT_SECTION_SEPARATOR);
+}

--- a/packages/myco/src/agent/run-accounting.ts
+++ b/packages/myco/src/agent/run-accounting.ts
@@ -106,11 +106,11 @@ export function analyzeRuntimeTokenBudget(
     : 0;
   const headroomTokens = Math.max(0, contextWindowTokens - peakRequestTotalTokens);
   const status = utilizationPercent >= TOKEN_BUDGET_CRITICAL_PERCENT
-    ? 'critical'
+    ? 'post_run_pressure'
     : utilizationPercent >= TOKEN_BUDGET_WARNING_PERCENT
       ? 'warning'
       : 'ok';
-  const statusMessage = status === 'critical'
+  const statusMessage = status === 'post_run_pressure'
     ? 'Run operated near the model context limit.'
     : status === 'warning'
       ? 'Run used a large share of the model context window.'
@@ -140,7 +140,10 @@ export function serializeCostData(cost: CostResolution | undefined): string | nu
 }
 
 export function summarizePhaseCosts(phaseResults: PhaseResult[]): CostResolution {
-  const costedPhases = phaseResults.filter((phase) => phase.costData && phase.costData.costUsd !== null);
+  const costedPhases = phaseResults.filter(
+    (phase): phase is PhaseResult & { costData: CostResolution } =>
+      phase.costData !== undefined && phase.costData !== null && phase.costData.costUsd !== null,
+  );
   if (costedPhases.length === 0) {
     return {
       source: 'unavailable',
@@ -160,7 +163,7 @@ export function summarizePhaseCosts(phaseResults: PhaseResult[]): CostResolution
     };
   }
 
-  const firstCost = costedPhases[0].costData!;
+  const firstCost = costedPhases[0].costData;
   const aggregate = {
     costUsd: 0,
     actualCostUsd: 0,
@@ -183,7 +186,7 @@ export function summarizePhaseCosts(phaseResults: PhaseResult[]): CostResolution
   };
 
   for (const phase of costedPhases) {
-    const cost = phase.costData!;
+    const cost = phase.costData;
     const breakdown = cost.breakdown;
     aggregate.costUsd += cost.costUsd ?? 0;
     aggregate.actualCostUsd += cost.actualCostUsd ?? 0;

--- a/packages/myco/src/agent/runtime/claude.ts
+++ b/packages/myco/src/agent/runtime/claude.ts
@@ -89,7 +89,7 @@ export class ClaudeSdkRuntime implements AgentRuntime {
       finalText,
       turnsUsed,
       usage: {
-        requests: turnsUsed > 0 ? 1 : 0,
+        requests: turnsUsed,
         inputTokens,
         outputTokens,
         totalTokens: inputTokens + outputTokens,

--- a/packages/myco/src/agent/runtime/index.ts
+++ b/packages/myco/src/agent/runtime/index.ts
@@ -1,4 +1,3 @@
-import { createLocalVaultMcpServer } from './openai-local-mcp.js';
 import { ClaudeSdkRuntime } from './claude.js';
 import { OpenAIAgentsRuntime } from './openai.js';
 import type { AgentRuntime } from './types.js';
@@ -7,10 +6,14 @@ import type { RuntimeId } from '@myco/agent/types.js';
 export * from './types.js';
 
 export function getAgentRuntime(runtimeId: RuntimeId): AgentRuntime {
-  if (runtimeId === 'openai-agents') {
-    return new OpenAIAgentsRuntime({
-      createOpenAIMcpServer: (toolSurface) => createLocalVaultMcpServer(toolSurface),
-    });
+  switch (runtimeId) {
+    case 'claude-sdk':
+      return new ClaudeSdkRuntime();
+    case 'openai-agents':
+      return new OpenAIAgentsRuntime();
+    default: {
+      const exhaustive: never = runtimeId;
+      throw new Error(`Unknown runtime id: ${String(exhaustive)}`);
+    }
   }
-  return new ClaudeSdkRuntime();
 }

--- a/packages/myco/src/agent/runtime/openai-local-mcp.ts
+++ b/packages/myco/src/agent/runtime/openai-local-mcp.ts
@@ -1,12 +1,13 @@
 import type { MCPServer } from '@openai/agents';
 import { z } from 'zod/v4';
+import type { ZodRawShape } from 'zod';
 import { createVaultTools } from '@myco/agent/tools.js';
 import type { RuntimeToolSurface } from './types.js';
 
 interface LocalMcpTool {
   name: string;
   description?: string;
-  inputSchema?: Record<string, unknown>;
+  inputSchema?: ZodRawShape;
   handler: (args: Record<string, unknown>, extra?: unknown) => Promise<{ content: Array<{ type: 'text'; text: string }> }>;
 }
 
@@ -64,22 +65,13 @@ class LocalVaultMcpServer implements MCPServer {
   }
 }
 
-function normalizeInputSchema(schema: Record<string, unknown> | undefined) {
+function normalizeInputSchema(schema: ZodRawShape | undefined) {
   if (!schema) {
     return {
       type: 'object' as const,
       properties: {},
       required: [],
       additionalProperties: false,
-    };
-  }
-
-  if (schema.type === 'object' && typeof schema.properties === 'object' && schema.properties !== null) {
-    return {
-      type: 'object' as const,
-      properties: schema.properties as Record<string, unknown>,
-      required: Array.isArray(schema.required) ? (schema.required as string[]) : [],
-      additionalProperties: schema.additionalProperties === true,
     };
   }
 

--- a/packages/myco/src/agent/runtime/openai.ts
+++ b/packages/myco/src/agent/runtime/openai.ts
@@ -7,7 +7,8 @@ import {
   type AgentInputItem,
   type Session,
 } from '@openai/agents';
-import type { AgentRuntime, RuntimeCapability, RuntimeExecuteInput, RuntimeExecuteResult, RuntimeFactoryContext } from './types.js';
+import type { AgentRuntime, RuntimeCapability, RuntimeExecuteInput, RuntimeExecuteResult } from './types.js';
+import { createLocalVaultMcpServer } from './openai-local-mcp.js';
 import type { ProviderConfig, RuntimeUsage } from '@myco/agent/types.js';
 import { DEFAULT_LOCAL_AGENT_CONTEXT_WINDOW_TOKENS } from '@myco/agent/context-windows.js';
 import { ensureOllamaContextVariant } from '@myco/agent/ollama-context.js';
@@ -249,8 +250,6 @@ function createProvider(input: RuntimeExecuteInput): OpenAIProvider {
 export class OpenAIAgentsRuntime implements AgentRuntime {
   readonly id = 'openai-agents' as const;
 
-  constructor(private readonly context: RuntimeFactoryContext) {}
-
   supports(capability: RuntimeCapability): boolean {
     return capability === 'supportsSessionResume' || capability === 'supportsMcp';
   }
@@ -264,7 +263,7 @@ export class OpenAIAgentsRuntime implements AgentRuntime {
     const session = new PersistedSession(sessionRef, persistedItems, (items) => {
       persistedItems = [...items];
     });
-    const mcpServer = this.context.createOpenAIMcpServer(input.toolSurface);
+    const mcpServer = createLocalVaultMcpServer(input.toolSurface);
     await mcpServer.connect();
 
     try {

--- a/packages/myco/src/agent/runtime/types.ts
+++ b/packages/myco/src/agent/runtime/types.ts
@@ -1,4 +1,3 @@
-import type { MCPServer } from '@openai/agents';
 import type { EmbeddingManager } from '@myco/daemon/embedding/manager.js';
 import type { ProviderConfig, RuntimeId, RuntimeUsage } from '@myco/agent/types.js';
 
@@ -42,10 +41,6 @@ export interface RuntimeExecuteResult {
   sessionRef?: string;
   sessionData?: unknown;
   rawRuntimeMetadata?: Record<string, unknown>;
-}
-
-export interface RuntimeFactoryContext {
-  createOpenAIMcpServer: (toolSurface: RuntimeToolSurface) => MCPServer;
 }
 
 export interface AgentRuntime {

--- a/packages/myco/src/agent/types.ts
+++ b/packages/myco/src/agent/types.ts
@@ -125,7 +125,14 @@ export interface RuntimeTokenBudget {
   peakRequestTotalTokens: number | null;
   utilizationPercent: number | null;
   headroomTokens: number | null;
-  status: 'unknown' | 'ok' | 'warning' | 'critical';
+  /**
+   * Budget status is observability-only. `post_run_pressure` (formerly
+   * `critical`) means this run hit the upper utilization band but was NOT
+   * aborted — naming it `critical` misled callers into assuming it signalled
+   * a pre-flight abort, which the runtime never performed. A future feature
+   * may add true pre-flight abort behavior behind a separate flag.
+   */
+  status: 'unknown' | 'ok' | 'warning' | 'post_run_pressure';
   message?: string;
 }
 

--- a/packages/myco/src/config/loader.ts
+++ b/packages/myco/src/config/loader.ts
@@ -88,6 +88,15 @@ export function loadConfig(vaultDir: string): MycoConfig {
     process.stderr.write(`[myco migration] ${msg}\n`);
   });
 
+  // Deprecation warning for legacy context.operating_brief_enabled →
+  // context.cortex_enabled (rewrite happens inside ContextSchema.preprocess).
+  const ctx = parsed.context as Record<string, unknown> | undefined;
+  if (ctx && 'operating_brief_enabled' in ctx && !('cortex_enabled' in ctx)) {
+    process.stderr.write(
+      '[myco config] context.operating_brief_enabled is deprecated; rename to context.cortex_enabled\n',
+    );
+  }
+
   // Parse with Zod to fill in defaults for new config sections
   const config = MycoConfigSchema.parse(parsed);
 

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -73,7 +73,21 @@ const TaskProviderOverrideSchema = z.object({
   params: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
 });
 
-const ContextSchema = z.object({
+/**
+ * Raw context shape inside zod preprocess — accepts the legacy
+ * `operating_brief_enabled` key and rewrites it to `cortex_enabled`.
+ * Loader emits a deprecation warning once per load (see `loader.ts`).
+ */
+const ContextSchema = z.preprocess((raw) => {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    const input = raw as Record<string, unknown>;
+    if ('operating_brief_enabled' in input && !('cortex_enabled' in input)) {
+      const { operating_brief_enabled, ...rest } = input;
+      return { ...rest, cortex_enabled: operating_brief_enabled };
+    }
+  }
+  return raw;
+}, z.object({
   /** Preferred digest tier when a user or agent explicitly requests Myco context. */
   digest_tier: z.number().int().default(5000),
   /** Append the preferred digest extract at session start after Cortex instructions. */
@@ -84,7 +98,7 @@ const ContextSchema = z.object({
   prompt_search: z.boolean().default(true),
   /** Max spores to inject per prompt (0-10). */
   prompt_max_spores: z.number().int().min(0).max(10).default(3),
-});
+}));
 
 const AgentSchema = z.object({
   /** Number of batches between event-driven summary triggers (0 to disable). */

--- a/packages/myco/src/context/injector.ts
+++ b/packages/myco/src/context/injector.ts
@@ -2,7 +2,8 @@ import type { MycoConfig } from '@myco/config/schema.js';
 import { estimateTokens, DEFAULT_AGENT_ID } from '@myco/constants.js';
 import { getCortexInstructions } from '@myco/db/queries/cortex-instructions.js';
 import { shouldInjectCortex } from './cortex-brief.js';
-import { getSessionStartDigestPayload, shouldInjectSessionStartDigest } from './session-start-digest.js';
+import { shouldInjectSessionStartDigest } from './session-start-digest.js';
+import { composeSessionStartContext } from './session-start-context.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -15,7 +16,6 @@ interface InjectionContext {
 interface InjectedContext {
   text: string;
   tokenEstimate: number;
-  brief: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -40,37 +40,13 @@ export async function buildInjectedContext(
   }
 
   const brief = includeBrief ? getCortexInstructions(DEFAULT_AGENT_ID)?.content ?? '' : '';
-  const digest = includeDigest ? getSessionStartDigestPayload(config.context) : { content: '', tier: null };
-  const parts: string[] = [];
-
-  if (brief) {
-    parts.push(brief);
-  }
-  if (digest.content) {
-    parts.push(`## Preferred Digest (Tier ${digest.tier ?? config.context.digest_tier})\n${digest.content}`);
-  }
-  const text = parts.join('\n\n');
+  const { parts } = composeSessionStartContext(config, brief);
+  const text = parts.map((p) => p.text).join('\n\n');
 
   return {
     text,
     tokenEstimate: estimateTokens(text),
-    brief,
   };
-}
-
-/**
- * Build per-prompt context using semantic search on spores.
- *
- * Semantic search via the daemon's in-process vector store is deferred to
- * Phase 2. For now, returns empty context. The hook (`user-prompt-submit`)
- * routes through the daemon API at `/context/prompt`, which will implement
- * vector search when ready.
- */
-export async function buildPromptContext(
-  _prompt: string,
-  _config: MycoConfig,
-): Promise<InjectedContext> {
-  return emptyContext();
 }
 
 // ---------------------------------------------------------------------------
@@ -81,6 +57,5 @@ function emptyContext(): InjectedContext {
   return {
     text: '',
     tokenEstimate: 0,
-    brief: '',
   };
 }

--- a/packages/myco/src/context/session-start-context.ts
+++ b/packages/myco/src/context/session-start-context.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared builder for session-start context text — used by BOTH the daemon's
+ * `/context` route and the degraded-path `buildInjectedContext()` in
+ * `injector.ts`. Keeping the heading format and join string here ensures the
+ * two paths emit identical strings; if they diverge, consumers see different
+ * session-start payloads depending on whether the daemon is up.
+ */
+
+import type { MycoConfig } from '@myco/config/schema.js';
+import { shouldInjectCortex } from './cortex-brief.js';
+import { getSessionStartDigestPayload, shouldInjectSessionStartDigest } from './session-start-digest.js';
+
+export interface SessionStartContextPart {
+  kind: 'cortex' | 'digest';
+  /** The rendered text chunk (without the inter-part separator). */
+  text: string;
+  /** Digest tier the content came from, when applicable. */
+  tier?: number;
+}
+
+export interface ComposedSessionStartContext {
+  /** Individual parts preserved so callers can log which sources contributed. */
+  parts: SessionStartContextPart[];
+  /** Whether cortex injection is enabled for this config. */
+  cortexEnabled: boolean;
+  /** Whether digest injection is enabled for this config. */
+  digestEnabled: boolean;
+}
+
+/**
+ * Compose the cortex + digest parts for a session-start context based on the
+ * live config. The daemon path supplies its own cortex content (via the
+ * signed snapshot), so it passes `cortexContent` explicitly; the degraded
+ * path reads the cortex content itself and passes it in the same way.
+ *
+ * Callers are responsible for:
+ *   - joining with `\n\n`
+ *   - appending per-session metadata (branch, session_id) after the parts
+ *   - logging source attribution
+ */
+export function composeSessionStartContext(
+  config: MycoConfig,
+  cortexContent: string,
+): ComposedSessionStartContext {
+  const cortexEnabled = shouldInjectCortex(config.context);
+  const digestEnabled = shouldInjectSessionStartDigest(config.context);
+  const parts: SessionStartContextPart[] = [];
+
+  if (cortexEnabled && cortexContent) {
+    parts.push({ kind: 'cortex', text: cortexContent });
+  }
+  if (digestEnabled) {
+    const digest = getSessionStartDigestPayload(config.context);
+    if (digest.content) {
+      const tier = digest.tier ?? config.context.digest_tier;
+      parts.push({
+        kind: 'digest',
+        text: `## Preferred Digest (Tier ${tier})\n${digest.content}`,
+        tier,
+      });
+    }
+  }
+
+  return { parts, cortexEnabled, digestEnabled };
+}

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import { listRuns, countRuns, getRun, getLatestRunId } from '@myco/db/queries/runs.js';
 import { listReports } from '@myco/db/queries/reports.js';
 import { listTurnsByRun } from '@myco/db/queries/turns.js';
-import { listWriteIntents, countWriteIntentsByTool } from '@myco/db/queries/write-intents.js';
+import { listWriteIntents, countWriteIntents, countWriteIntentsByTool } from '@myco/db/queries/write-intents.js';
 import { runDurationMs } from '@myco/agent/run-accounting.js';
 import { buildTaskInstruction, isInstructionRequiredTask } from '@myco/agent/instruction-builders.js';
 import { hasConfiguredProvider } from '@myco/agent/config-resolver.js';
@@ -342,8 +342,17 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
    * `synthetic_output` (see write-intents query helper).
    */
   async function handleGetRunWriteIntents(req: RouteRequest): Promise<RouteResponse> {
-    const intents = listWriteIntents(req.params.id);
-    return { body: { intents, count: intents.length } };
+    const rawLimit = req.query.limit ? Number(req.query.limit) : undefined;
+    const rawOffset = req.query.offset ? Number(req.query.offset) : undefined;
+    const limit = Number.isFinite(rawLimit) && rawLimit !== undefined && rawLimit > 0
+      ? Math.min(rawLimit, 5000)
+      : 500;
+    const offset = Number.isFinite(rawOffset) && rawOffset !== undefined && rawOffset >= 0
+      ? rawOffset
+      : 0;
+    const intents = listWriteIntents(req.params.id, { limit, offset });
+    const total = countWriteIntents(req.params.id);
+    return { body: { intents, count: intents.length, total } };
   }
 
   /**

--- a/packages/myco/src/daemon/api/context.ts
+++ b/packages/myco/src/daemon/api/context.ts
@@ -19,10 +19,8 @@ import type { MycoConfig } from '@myco/config/schema.js';
 import {
   shouldInjectCortex,
 } from '@myco/context/cortex-brief.js';
-import {
-  getSessionStartDigestPayload,
-  shouldInjectSessionStartDigest,
-} from '@myco/context/session-start-digest.js';
+import { shouldInjectSessionStartDigest } from '@myco/context/session-start-digest.js';
+import { composeSessionStartContext } from '@myco/context/session-start-context.js';
 import { getCortexInstructionsSnapshot } from '@myco/services/cortex.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 import type { EmbeddingManager } from '../embedding/manager.js';
@@ -81,22 +79,19 @@ export function createSessionContextHandler(deps: ContextDeps) {
     logger.debug(LOG_KINDS.CONTEXT_QUERY, 'Session context query', { session_id });
 
     try {
-      const includeBrief = shouldInjectCortex(config.context);
-      const includeDigest = shouldInjectSessionStartDigest(config.context);
-      if (!includeBrief && !includeDigest) {
+      const cortexEnabled = shouldInjectCortex(config.context);
+      const digestEnabled = shouldInjectSessionStartDigest(config.context);
+      if (!cortexEnabled && !digestEnabled) {
         logger.debug(LOG_KINDS.CONTEXT_SESSION, 'Session-start context disabled', { session_id });
         return { body: { text: '' } };
       }
 
-      const parts: string[] = [];
-      const sourceParts: string[] = [];
       let sourceRunId: string | null = null;
-
-      if (includeBrief) {
+      let cortexContent = '';
+      if (cortexEnabled) {
         const snapshot = getCortexInstructionsSnapshot(config);
         if (snapshot.content) {
-          parts.push(snapshot.content);
-          sourceParts.push('cortex');
+          cortexContent = snapshot.content;
           sourceRunId = snapshot.sourceRunId;
         } else {
           logger.debug(LOG_KINDS.CONTEXT_SESSION, 'No stored Cortex instructions available for session start', {
@@ -105,30 +100,30 @@ export function createSessionContextHandler(deps: ContextDeps) {
         }
       }
 
-      if (includeDigest) {
-        const digest = getSessionStartDigestPayload(config.context);
-        if (digest.content) {
-          parts.push(`## Preferred Digest (Tier ${digest.tier ?? config.context.digest_tier})\n${digest.content}`);
-          sourceParts.push(`digest:${digest.tier ?? config.context.digest_tier}`);
-        } else {
-          logger.debug(LOG_KINDS.CONTEXT_SESSION, 'No preferred digest extract available for session start', {
-            session_id,
-            preferred_tier: config.context.digest_tier,
-          });
-        }
+      const composed = composeSessionStartContext(config, cortexContent);
+      const textParts: string[] = composed.parts.map((p) => p.text);
+      const sourceParts: string[] = composed.parts.map((p) =>
+        p.kind === 'cortex' ? 'cortex' : `digest:${p.tier ?? config.context.digest_tier}`,
+      );
+
+      if (digestEnabled && !composed.parts.some((p) => p.kind === 'digest')) {
+        logger.debug(LOG_KINDS.CONTEXT_SESSION, 'No preferred digest extract available for session start', {
+          session_id,
+          preferred_tier: config.context.digest_tier,
+        });
       }
 
-      if (parts.length === 0) {
+      if (textParts.length === 0) {
         return { body: { text: '' } };
       }
 
       if (branch) {
-        parts.push(`Branch:: \`${branch}\``);
+        textParts.push(`Branch:: \`${branch}\``);
       }
-      parts.push(`Session:: \`${session_id}\``);
+      textParts.push(`Session:: \`${session_id}\``);
 
       const source = sourceParts.join('+') || 'cortex';
-      const contextText = parts.join('\n\n');
+      const contextText = textParts.join('\n\n');
       const estimatedTokens = estimateTokens(contextText);
       logger.info(
         LOG_KINDS.CONTEXT_SESSION,

--- a/packages/myco/src/daemon/api/context.ts
+++ b/packages/myco/src/daemon/api/context.ts
@@ -122,7 +122,7 @@ export function createSessionContextHandler(deps: ContextDeps) {
       }
       textParts.push(`Session:: \`${session_id}\``);
 
-      const source = sourceParts.join('+') || 'cortex';
+      const source = sourceParts.join('+');
       const contextText = textParts.join('\n\n');
       const estimatedTokens = estimateTokens(contextText);
       logger.info(

--- a/packages/myco/src/daemon/api/cortex.ts
+++ b/packages/myco/src/daemon/api/cortex.ts
@@ -10,6 +10,7 @@ import {
   getCortexInstructionsSnapshot,
 } from '@myco/services/cortex.js';
 import { triggerCortexInstructions } from '../trigger-cortex-instructions.js';
+import { errorBody } from './error-envelope.js';
 
 export interface CortexDeps {
   liveConfig: { current: MycoConfig };
@@ -43,6 +44,21 @@ export function createCortexHandlers(vaultDir: string, deps: CortexDeps) {
       getTeamClient: deps.getTeamClient,
       registerInflightRun: deps.registerInflightRun,
     });
+    if (!result.started && (result.reason === 'provider-not-configured' || result.reason === 'event-tasks-disabled')) {
+      return {
+        status: 400,
+        body: {
+          ...errorBody(
+            result.reason,
+            result.reason === 'provider-not-configured'
+              ? 'No agent provider configured. Configure one in Settings.'
+              : 'Event-driven tasks are disabled. Enable them in Settings.',
+          ),
+          started: false,
+          reason: result.reason,
+        },
+      };
+    }
     return { body: result };
   }
 
@@ -67,7 +83,7 @@ export function createCortexHandlers(vaultDir: string, deps: CortexDeps) {
     const { runId } = PromptBuilderStatusParams.parse(req.params);
     const result = getCortexPromptResult(runId);
     if (!result) {
-      return { status: 404, body: { error: 'Run not found' } };
+      return { status: 404, body: errorBody('run-not-found', 'Run not found') };
     }
     return { body: result };
   }

--- a/packages/myco/src/daemon/api/digest-revisions.ts
+++ b/packages/myco/src/daemon/api/digest-revisions.ts
@@ -13,6 +13,7 @@ import {
   rollbackDigestExtract,
 } from '@myco/db/queries/digest-extracts.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+import { DEFAULT_AGENT_ID } from '@myco/constants.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 import type { DaemonLogger } from '../logger.js';
 
@@ -20,7 +21,6 @@ import type { DaemonLogger } from '../logger.js';
 // Constants
 // ---------------------------------------------------------------------------
 
-const DEFAULT_AGENT_ID = 'myco-agent';
 const DEFAULT_LIMIT = 50;
 
 // ---------------------------------------------------------------------------

--- a/packages/myco/src/daemon/api/error-envelope.ts
+++ b/packages/myco/src/daemon/api/error-envelope.ts
@@ -1,0 +1,24 @@
+/**
+ * Structured error envelope shared across routes added in the 0.21.x window.
+ *
+ * Legacy routes stay on their existing shape (often `{error: 'message'}` or
+ * `{error: {...}}`) to avoid churn; new routes opt into this helper so the
+ * client has a single code+message pair to key against. See PR description
+ * for the list of routes that adopted this shape and the tech-debt note
+ * covering the rest.
+ */
+
+export interface ErrorBody {
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+/**
+ * Build a canonical error body. `code` should be a stable machine-readable
+ * slug (kebab-case or snake_case); `message` is a human-readable string.
+ */
+export function errorBody(code: string, message: string): ErrorBody {
+  return { error: { code, message } };
+}

--- a/packages/myco/src/daemon/api/mcp-proxy.ts
+++ b/packages/myco/src/daemon/api/mcp-proxy.ts
@@ -32,6 +32,7 @@ import {
   normalizePlanSourcePath,
 } from '@myco/plans/identity.js';
 import { persistPlan } from '../plan-capture.js';
+import { errorBody } from './error-envelope.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -284,7 +285,7 @@ export function createMcpProxyHandlers(deps: McpProxyDeps) {
   async function handleSavePlan(req: RouteRequest): Promise<RouteResponse> {
     const { session_id, content, source_path, plan_key, title, status, tags } = SavePlanBody.parse(req.body);
     const session = getSession(session_id);
-    if (!session) return { status: 404, body: { error: 'session_not_found' } };
+    if (!session) return { status: 404, body: errorBody('session-not-found', 'Session not found') };
 
     const openBatch = getLatestOpenBatch(session_id);
     const normalizedSourcePath = source_path
@@ -337,7 +338,7 @@ export function createMcpProxyHandlers(deps: McpProxyDeps) {
     const session = typeof req.query.session === 'string' ? req.query.session : undefined;
 
     if (id && session) {
-      return { status: 400, body: { error: 'Pass either id or session, not both' } };
+      return { status: 400, body: errorBody('mutually-exclusive-query', 'Pass either id or session, not both') };
     }
 
     if (id) {

--- a/packages/myco/src/daemon/api/providers.ts
+++ b/packages/myco/src/daemon/api/providers.ts
@@ -6,6 +6,7 @@
  *   POST /api/providers/test  — test connectivity to a specific provider
  */
 
+import { z } from 'zod';
 import Anthropic from '@anthropic-ai/sdk';
 import { checkLocalProvider } from '../../intelligence/provider-check.js';
 import {
@@ -23,7 +24,7 @@ import {
   getRemoteProviderApiKey,
 } from './models.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
-import { PROVIDER_TYPES, isProviderType, type RuntimeId, type ProviderType } from '@myco/agent/types.js';
+import { PROVIDER_TYPES, type RuntimeId, type ProviderType } from '@myco/agent/types.js';
 import { DEFAULT_OPENAI_URL, DEFAULT_OPENROUTER_URL } from '@myco/agent/provider.js';
 
 /** Timeout for the live Anthropic model list query (short -- fall back fast). */
@@ -113,19 +114,35 @@ export async function handleGetProviders(): Promise<RouteResponse> {
  * Accepts: { type: 'anthropic' | 'ollama' | 'lmstudio' | 'openai' | 'openrouter' | 'openai-compatible', baseUrl?: string, local_backend?: 'ollama' | 'lmstudio', model?: string }
  * Returns: { ok: boolean, latency_ms?: number, error?: string }
  */
-export async function handleTestProvider(req: RouteRequest): Promise<RouteResponse> {
-  const body = req.body as Record<string, unknown> | undefined;
-  const type = body?.type as string | undefined;
+const ProviderTestBody = z.object({
+  type: z.enum(PROVIDER_TYPES),
+  baseUrl: z.string().optional(),
+  /**
+   * Deprecated: `base_url` is the legacy snake_case key. Accepted for one
+   * release and then removed. Use `baseUrl` going forward.
+   */
+  base_url: z.string().optional(),
+  local_backend: z.enum(['ollama', 'lmstudio']).optional(),
+  model: z.string().optional(),
+});
 
-  if (!type || !isProviderType(type)) {
+export async function handleTestProvider(req: RouteRequest): Promise<RouteResponse> {
+  const parse = ProviderTestBody.safeParse(req.body);
+  if (!parse.success) {
     return {
       status: HTTP_BAD_REQUEST,
       body: { error: `type is required and must be one of: ${PROVIDER_TYPES.join(', ')}` },
     };
   }
-
-  const baseUrl = (body?.baseUrl as string | undefined) ?? (body?.base_url as string | undefined);
-  const localBackend = (body?.local_backend as 'ollama' | 'lmstudio' | undefined);
+  const parsed = parse.data;
+  if (parsed.base_url !== undefined && parsed.baseUrl === undefined) {
+    process.stderr.write(
+      '[myco providers] POST /api/providers/test: base_url is deprecated; use baseUrl\n',
+    );
+  }
+  const type = parsed.type;
+  const baseUrl = parsed.baseUrl ?? parsed.base_url;
+  const localBackend = parsed.local_backend;
   const start = performance.now();
   let result: TestResult;
 

--- a/packages/myco/src/daemon/api/sessions.ts
+++ b/packages/myco/src/daemon/api/sessions.ts
@@ -12,6 +12,7 @@ import type { RouteRequest, RouteResponse } from '../router.js';
 import type { EmbeddingManager } from '../embedding/manager.js';
 import type { DaemonLogger } from '../logger.js';
 import type { MycoConfig } from '@myco/config/schema.js';
+import { errorBody } from './error-envelope.js';
 
 const DEFAULT_LIST_LIMIT = 50;
 const DEFAULT_LIST_OFFSET = 0;
@@ -72,7 +73,7 @@ export async function handleGetSessionAttachments(req: RouteRequest): Promise<Ro
 
 export async function handleGetSessionPlans(req: RouteRequest): Promise<RouteResponse> {
   const plans = listPlansBySession(req.params.id);
-  return { body: plans };
+  return { body: { plans } };
 }
 
 // ---------------------------------------------------------------------------
@@ -156,7 +157,7 @@ export function createSessionMutationHandlers(deps: SessionMutationDeps) {
    *  `{force_remote: true}` opt-in before deleting someone else's row. */
   async function handleDeletePlan(req: RouteRequest): Promise<RouteResponse> {
     const existing = getPlan(req.params.id);
-    if (!existing) return { status: 404, body: { error: 'Plan not found' } };
+    if (!existing) return { status: 404, body: errorBody('plan-not-found', 'Plan not found') };
 
     const localMachineId = getTeamMachineId();
     const body = req.body as { force_remote?: boolean } | undefined;
@@ -167,7 +168,13 @@ export function createSessionMutationHandlers(deps: SessionMutationDeps) {
         plan_machine_id: existing.machine_id,
         local_machine_id: localMachineId,
       });
-      return { status: 403, body: { error: 'Plan belongs to another machine; pass {"force_remote": true} to delete.' } };
+      return {
+        status: 403,
+        body: errorBody(
+          'cross-machine-delete',
+          'Plan belongs to another machine; pass {"force_remote": true} to delete.',
+        ),
+      };
     }
     if (existing.machine_id !== localMachineId && forceRemote) {
       logger.warn(LOG_KINDS.API_SESSION_DELETE, 'Cross-machine plan delete allowed by force_remote', {
@@ -178,7 +185,7 @@ export function createSessionMutationHandlers(deps: SessionMutationDeps) {
     }
 
     const deleted = deletePlan(req.params.id);
-    if (!deleted) return { status: 404, body: { error: 'Plan not found' } };
+    if (!deleted) return { status: 404, body: errorBody('plan-not-found', 'Plan not found') };
 
     embeddingManager.onRemoved('plans', deleted.id);
 

--- a/packages/myco/src/daemon/capture-gating.ts
+++ b/packages/myco/src/daemon/capture-gating.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared helper for gating an incoming event (or stop-hook payload) against
+ * the per-agent capture rules. Used by `event-dispatch.ts` and
+ * `stop-processing.ts` to avoid drift between the two call sites — they
+ * both need to read transcript-meta, detect the agent, and call
+ * `evaluateSessionCaptureRules` with the same inputs.
+ */
+
+import { loadManifests } from '@myco/symbionts/detect.js';
+import type { SymbiontManifest } from '@myco/symbionts/manifest-schema.js';
+import { evaluateSessionCaptureRules, type SessionStartDecision } from '@myco/hooks/capture-rules.js';
+import { readTranscriptMeta } from '@myco/hooks/transcript-meta.js';
+
+export interface CaptureGateInput {
+  /** Detected agent id (falls back to caller-supplied default if absent). */
+  agent: string;
+  /** Path to the transcript file supplied by the hook, if any. */
+  transcriptPath?: string;
+}
+
+export interface CaptureGateResult {
+  decision: SessionStartDecision;
+  /** True when transcript-meta was successfully read and supplied to the evaluator. */
+  hadTranscriptMeta: boolean;
+}
+
+/**
+ * Evaluate the capture rules for an incoming event. Reads transcript meta
+ * when a path is supplied, and wraps the evaluator with the standard
+ * agent + metadata argument order so both call sites stay in sync.
+ *
+ * Callers can either pass pre-loaded manifests (hot path / tests) or let
+ * this helper load them lazily via `loadManifests()`.
+ */
+export function gateEventByCaptureRules(
+  event: CaptureGateInput,
+  options?: { manifests?: SymbiontManifest[] },
+): CaptureGateResult {
+  const transcriptMeta = event.transcriptPath
+    ? readTranscriptMeta(event.transcriptPath) ?? undefined
+    : undefined;
+  const manifests = options?.manifests ?? loadManifests();
+  const decision = evaluateSessionCaptureRules(manifests, event.agent, {
+    transcriptPath: event.transcriptPath,
+    transcriptMeta,
+  });
+  return { decision, hadTranscriptMeta: transcriptMeta !== undefined };
+}

--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -38,9 +38,8 @@ import { upsertSession, reactivateSessionIfCompleted } from '@myco/db/queries/se
 import { captureBatchImages, type CapturedImage } from './capture-images.js';
 import { DEFAULT_SYMBIONT_NAME, epochSeconds, LOG_PROMPT_PREVIEW_CHARS } from '@myco/constants.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
-import { evaluateSessionCaptureRules } from '@myco/hooks/capture-rules.js';
-import { readTranscriptMeta } from '@myco/hooks/transcript-meta.js';
 import { loadManifests } from '@myco/symbionts/detect.js';
+import { gateEventByCaptureRules } from './capture-gating.js';
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -97,23 +96,27 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
 
   // Cache drop decisions by session_id so a rejected session that keeps firing
   // events doesn't re-open + re-read (up to 128 KB) its transcript every time.
-  // Transcript first-line metadata doesn't change once written, so session_id
-  // is a stable cache key.
-  const droppedSessions = new Map<string, string | undefined>();
+  // Cache: sessionId → { reason, hadTranscriptMeta }. When an incoming event
+  // newly supplies a transcript_path but the cached decision was made with
+  // `transcriptMeta: undefined`, we re-evaluate once — a transcript showing
+  // up mid-session can flip the capture rules in the "accept" direction.
+  const droppedSessions = new Map<string, { reason: string | undefined; hadTranscriptMeta: boolean }>();
 
-  function rememberDropped(sessionId: string, reason: string | undefined): void {
+  function rememberDropped(sessionId: string, reason: string | undefined, hadTranscriptMeta: boolean): void {
     if (droppedSessions.size >= DROP_DECISION_CACHE_MAX) {
       const oldest = droppedSessions.keys().next().value;
       if (oldest !== undefined) droppedSessions.delete(oldest);
     }
-    droppedSessions.set(sessionId, reason);
+    droppedSessions.set(sessionId, { reason, hadTranscriptMeta });
   }
 
-  function evaluateAutoRegistration(event: Record<string, unknown>): { action: 'pass' } | { action: 'drop'; reason?: string } {
+  function evaluateAutoRegistration(event: Record<string, unknown>): {
+    decision: { action: 'pass' } | { action: 'drop'; reason?: string };
+    hadTranscriptMeta: boolean;
+  } {
     const transcriptPath = typeof event.transcript_path === 'string' && event.transcript_path.length > 0
       ? event.transcript_path
       : undefined;
-    const transcriptMeta = transcriptPath ? readTranscriptMeta(transcriptPath) ?? undefined : undefined;
     const detectedAgent = typeof event.agent === 'string' ? event.agent : DEFAULT_SYMBIONT_NAME;
 
     // Fail open: a manifest with a bad regex or schema error must not
@@ -121,17 +124,17 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
     // data-preservation contract is "capture by default" — keeping a noisy
     // session is recoverable; dropping every event until restart is not.
     try {
-      return evaluateSessionCaptureRules(manifests, detectedAgent, {
-        transcriptPath,
-        transcriptMeta,
-      });
+      return gateEventByCaptureRules(
+        { agent: detectedAgent, transcriptPath },
+        { manifests },
+      );
     } catch (err) {
       logger.error(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Capture-rules evaluator threw', {
         error: String(err),
         session_id: typeof event.session_id === 'string' ? event.session_id : undefined,
         agent: detectedAgent,
       });
-      return { action: 'pass' };
+      return { decision: { action: 'pass' }, hadTranscriptMeta: false };
     }
   }
 
@@ -151,8 +154,13 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
 
     // Ensure session is registered (idempotent — handles daemon restarts mid-session)
     if (!registry.getSession(event.session_id)) {
-      if (droppedSessions.has(event.session_id)) {
-        const reason = droppedSessions.get(event.session_id) ?? 'rule';
+      const cached = droppedSessions.get(event.session_id);
+      const hasTranscriptNow = typeof event.transcript_path === 'string' && event.transcript_path.length > 0;
+      // Re-evaluate when a previously-unattended session newly supplies a
+      // transcript_path — the earlier drop was made without transcript meta.
+      const shouldReevaluate = cached && !cached.hadTranscriptMeta && hasTranscriptNow;
+      if (cached && !shouldReevaluate) {
+        const reason = cached.reason ?? 'rule';
         logger.debug(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Ignored event for previously-dropped session', {
           session_id: event.session_id,
           type: event.type,
@@ -160,9 +168,12 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
         });
         return { body: { ok: true, ignored: reason } };
       }
-      const decision = evaluateAutoRegistration(event);
+      if (shouldReevaluate) {
+        droppedSessions.delete(event.session_id);
+      }
+      const { decision, hadTranscriptMeta } = evaluateAutoRegistration(event);
       if (decision.action === 'drop') {
-        rememberDropped(event.session_id, decision.reason);
+        rememberDropped(event.session_id, decision.reason, hadTranscriptMeta);
         logger.info(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Ignored event that failed session capture rules', {
           session_id: event.session_id,
           type: event.type,

--- a/packages/myco/src/daemon/server.ts
+++ b/packages/myco/src/daemon/server.ts
@@ -78,6 +78,9 @@ export class DaemonServer {
         uptime: process.uptime(),
       },
     }));
+    this.registerRoute('GET', '/api/version', async () => ({
+      body: { version: this.version },
+    }));
   }
 
   private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
@@ -97,6 +100,7 @@ export class DaemonServer {
       }
 
       this.onRequest?.();
+      const versionHeader = { 'X-Myco-Api-Version': this.version };
       try {
         const needsBody = req.method === 'POST' || req.method === 'PUT' || req.method === 'PATCH' || req.method === 'DELETE';
         const body = needsBody ? await readBody(req) : undefined;
@@ -108,11 +112,11 @@ export class DaemonServer {
         });
         const status = result.status ?? DEFAULT_STATUS;
         if (Buffer.isBuffer(result.body)) {
-          res.writeHead(status, result.headers ?? {});
+          res.writeHead(status, { ...versionHeader, ...result.headers });
           res.end(result.body);
           return;
         }
-        const headers = { 'Content-Type': 'application/json', ...result.headers };
+        const headers = { 'Content-Type': 'application/json', ...versionHeader, ...result.headers };
         res.writeHead(status, headers);
         res.end(JSON.stringify(result.body));
       } catch (error) {
@@ -120,7 +124,7 @@ export class DaemonServer {
           path: req.url,
           error: (error as Error).message,
         });
-        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.writeHead(500, { 'Content-Type': 'application/json', ...versionHeader });
         res.end(JSON.stringify({ error: (error as Error).message }));
       }
       return;

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -12,6 +12,7 @@ import path from 'node:path';
 import { TranscriptMiner, extractTurnsFromBuffer } from '@myco/capture/transcript-miner.js';
 import type { TranscriptTurn } from '@myco/symbionts/adapter.js';
 import { loadManifests } from '@myco/symbionts/detect.js';
+import { gateEventByCaptureRules } from './capture-gating.js';
 import { captureBatchImages } from './capture-images.js';
 import {
   extractTaggedPlans,
@@ -41,8 +42,6 @@ import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { triggerTitleSummary as sharedTriggerTitleSummary } from './trigger-title-summary.js';
 import type { RouteHandler } from './router.js';
 import type { RegisteredSession } from './lifecycle.js';
-import { evaluateSessionCaptureRules } from '@myco/hooks/capture-rules.js';
-import { readTranscriptMeta } from '@myco/hooks/transcript-meta.js';
 import { cleanupAfterSessionCascade } from './jobs/session-cleanup.js';
 import type { PlanWatchConfig } from './plan-capture.js';
 
@@ -487,12 +486,11 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     } = StopBody.parse(req.body);
 
     if (hookTranscriptPath) {
-      const transcriptMeta = readTranscriptMeta(hookTranscriptPath) ?? undefined;
       const detectedAgent = agent ?? getSession(sessionId)?.agent ?? 'claude-code';
-      const decision = evaluateSessionCaptureRules(loadManifests(), detectedAgent, {
-        transcriptPath: hookTranscriptPath,
-        transcriptMeta,
-      });
+      const { decision } = gateEventByCaptureRules(
+        { agent: detectedAgent, transcriptPath: hookTranscriptPath },
+        { manifests: loadManifests() },
+      );
       if (decision.action === 'drop') {
         const deleted = cleanupInvalidCapturedSession(sessionId);
         logger.info(LOG_KINDS.HOOKS_STOP, 'Stop ignored — invalid captured session', {

--- a/packages/myco/src/db/queries/digest-extracts.ts
+++ b/packages/myco/src/db/queries/digest-extracts.ts
@@ -269,7 +269,7 @@ export function listDigestRevisions(
     `SELECT ${REVISION_SELECT}
      FROM digest_extract_revisions
      WHERE agent_id = ? AND tier = ?
-     ORDER BY id DESC
+     ORDER BY created_at DESC, id DESC
      LIMIT ?`,
   ).all(options.agentId, options.tier, limit) as Record<string, unknown>[];
   return rows.map(toRevisionRow);

--- a/packages/myco/src/db/queries/runs.ts
+++ b/packages/myco/src/db/queries/runs.ts
@@ -119,6 +119,8 @@ export interface RunRow {
 
 export interface RunUpdate {
   status?: string;
+  task?: string | null;
+  instruction?: string | null;
   runtime?: RuntimeId | null;
   provider?: ProviderType | null;
   model?: string | null;
@@ -143,18 +145,6 @@ export interface RunUpdate {
   evaluationId?: string | null;
   reasoningLevel?: ReasoningLevel | null;
   executionOverrides?: Record<string, unknown> | null;
-}
-
-export interface RunCompletion extends RunUpdate {
-  completed_at?: number;
-  tokens_used?: number;
-  cost_usd?: number | null;
-  actual_cost_usd?: number | null;
-  estimated_cost_usd?: number | null;
-  cost_source?: CostSource | null;
-  cost_data?: string | null;
-  actions_taken?: string;
-  error?: string;
 }
 
 export interface ListRunsOptions {
@@ -244,6 +234,21 @@ function serializeExecutionOverrides(
   }
 }
 
+const COST_SOURCES: readonly CostSource[] = ['actual', 'estimated', 'unavailable'];
+const REASONING_LEVELS: readonly ReasoningLevel[] = ['low', 'default', 'high'];
+
+function toCostSourceOrNull(value: unknown): CostSource | null {
+  return typeof value === 'string' && (COST_SOURCES as readonly string[]).includes(value)
+    ? (value as CostSource)
+    : null;
+}
+
+function toReasoningLevelOrNull(value: unknown): ReasoningLevel | null {
+  return typeof value === 'string' && (REASONING_LEVELS as readonly string[]).includes(value)
+    ? (value as ReasoningLevel)
+    : null;
+}
+
 function toRunRow(row: Record<string, unknown>): RunRow {
   return {
     id: row.id as string,
@@ -267,13 +272,13 @@ function toRunRow(row: Record<string, unknown>): RunRow {
     cost_usd: (row.cost_usd as number) ?? null,
     actual_cost_usd: (row.actual_cost_usd as number) ?? null,
     estimated_cost_usd: (row.estimated_cost_usd as number) ?? null,
-    cost_source: (row.cost_source as CostSource) ?? null,
+    cost_source: toCostSourceOrNull(row.cost_source),
     cost_data: (row.cost_data as string) ?? null,
     actions_taken: (row.actions_taken as string) ?? null,
     error: (row.error as string) ?? null,
     dry_run: Boolean(Number(row.dry_run ?? 0)),
     evaluation_id: (row.evaluation_id as string) ?? null,
-    reasoning_level: (row.reasoning_level as ReasoningLevel) ?? null,
+    reasoning_level: toReasoningLevelOrNull(row.reasoning_level),
     execution_overrides: parseJsonObjectColumn(row.execution_overrides),
   };
 }
@@ -316,6 +321,8 @@ function buildRunsWhere(
  */
 const UPDATE_COLUMNS: readonly (keyof RunUpdate)[] = [
   'status',
+  'task',
+  'instruction',
   'runtime',
   'provider',
   'model',
@@ -491,7 +498,7 @@ export function updateRun(id: string, update: RunUpdate): RunRow | null {
 export function updateRunStatus(
   id: string,
   status: string,
-  completion?: RunCompletion,
+  completion?: RunUpdate,
 ): RunRow | null {
   return updateRun(id, { status, ...completion });
 }

--- a/packages/myco/src/db/queries/turns.ts
+++ b/packages/myco/src/db/queries/turns.ts
@@ -190,17 +190,3 @@ export function countToolCallsByRun(
   return result;
 }
 
-/** Count exact tool calls for a run by tool name and serialized input payload. */
-export function countExactToolCallsByRun(
-  runId: string,
-  toolName: string,
-  toolInput: string,
-): number {
-  const db = getDatabase();
-  const row = db.prepare(
-    `SELECT COUNT(*) as count
-     FROM agent_turns
-     WHERE run_id = ? AND tool_name = ? AND tool_input = ?`,
-  ).get(runId, toolName, toolInput) as { count: number };
-  return row.count;
-}

--- a/packages/myco/src/db/queries/write-intents.ts
+++ b/packages/myco/src/db/queries/write-intents.ts
@@ -115,16 +115,76 @@ export function insertWriteIntent(data: WriteIntentInsert): number {
 
 /**
  * List every write intent for a run, ordered by id (= insert order).
+ * Optional `limit` / `offset` for HTTP pagination; omit both for
+ * backward-compatible "return everything" behavior.
  */
-export function listWriteIntents(runId: string): WriteIntentRow[] {
+export function listWriteIntents(
+  runId: string,
+  options: { limit?: number; offset?: number } = {},
+): WriteIntentRow[] {
   const db = getDatabase();
+  const clauses = [`WHERE run_id = ?`];
+  const params: unknown[] = [runId];
+  let tail = 'ORDER BY id ASC';
+  if (options.limit !== undefined) {
+    tail += ' LIMIT ?';
+    params.push(options.limit);
+    if (options.offset !== undefined) {
+      tail += ' OFFSET ?';
+      params.push(options.offset);
+    }
+  }
   const rows = db.prepare(
     `SELECT ${SELECT_COLUMNS}
      FROM agent_run_write_intents
+     ${clauses.join(' ')}
+     ${tail}`,
+  ).all(...params) as Record<string, unknown>[];
+  return rows.map(toWriteIntentRow);
+}
+
+/**
+ * Row shape returned by {@link listWriteIntentTools} — id + metadata columns
+ * only, no JSON payloads. Used by phase-audit where tool counts are all the
+ * caller needs.
+ */
+export interface WriteIntentToolRow {
+  id: number;
+  run_id: string;
+  phase_id: string | null;
+  tool_name: string;
+}
+
+/**
+ * Lightweight listing of write intents for a run: metadata columns only,
+ * no JSON payload parsing. Preferred over {@link listWriteIntents} when
+ * the caller only needs tool names / phase grouping.
+ */
+export function listWriteIntentTools(runId: string): WriteIntentToolRow[] {
+  const db = getDatabase();
+  const rows = db.prepare(
+    `SELECT id, run_id, phase_id, tool_name
+     FROM agent_run_write_intents
      WHERE run_id = ?
      ORDER BY id ASC`,
-  ).all(runId) as Record<string, unknown>[];
-  return rows.map(toWriteIntentRow);
+  ).all(runId) as Array<Record<string, unknown>>;
+  return rows.map((row) => ({
+    id: row.id as number,
+    run_id: row.run_id as string,
+    phase_id: (row.phase_id as string) ?? null,
+    tool_name: row.tool_name as string,
+  }));
+}
+
+/** Return the total number of write intents for a run. */
+export function countWriteIntents(runId: string): number {
+  const db = getDatabase();
+  const row = db.prepare(
+    `SELECT COUNT(*) AS count
+     FROM agent_run_write_intents
+     WHERE run_id = ?`,
+  ).get(runId) as { count: number };
+  return Number(row.count);
 }
 
 /**

--- a/packages/myco/src/mcp/tools/plans.ts
+++ b/packages/myco/src/mcp/tools/plans.ts
@@ -68,10 +68,13 @@ export async function handleMycoPlans(
     const body = input.force_remote ? { force_remote: true } : undefined;
     const result = await client.delete(`/api/plans/${encodeURIComponent(input.id)}`, body);
     if (!result.ok) {
-      return {
-        ok: false,
-        error: result.data?.error ?? 'delete_failed',
-      };
+      const rawError = result.data?.error;
+      const message = typeof rawError === 'string'
+        ? rawError
+        : typeof rawError === 'object' && rawError !== null && 'message' in rawError
+          ? String((rawError as { message: unknown }).message)
+          : 'delete_failed';
+      return { ok: false, error: message };
     }
     return {
       ok: Boolean(result.data?.ok),

--- a/packages/myco/src/mcp/tools/save-plan.ts
+++ b/packages/myco/src/mcp/tools/save-plan.ts
@@ -16,7 +16,8 @@ interface SavePlanInput {
   tags?: string[];
 }
 
-interface SavePlanResult {
+interface SavePlanSuccess {
+  ok: true;
   id: string;
   logical_key: string;
   title: string | null;
@@ -29,10 +30,17 @@ interface SavePlanResult {
   updated_at: number | null;
 }
 
+interface SavePlanFailure {
+  ok: false;
+  error: string;
+}
+
+export type SavePlanResult = SavePlanSuccess | SavePlanFailure;
+
 export async function handleMycoSavePlan(
   input: SavePlanInput,
   client: DaemonClient,
-): Promise<SavePlanResult | null> {
+): Promise<SavePlanResult> {
   const result = await client.post('/api/mcp/plans', {
     session_id: input.session_id,
     content: input.content,
@@ -43,6 +51,14 @@ export async function handleMycoSavePlan(
     tags: input.tags,
   });
 
-  if (!result.ok || !result.data) return null;
-  return result.data as SavePlanResult;
+  if (!result.ok || !result.data) {
+    const errorMessage = typeof result.data === 'object'
+      && result.data !== null
+      && 'error' in result.data
+      && typeof (result.data as { error: unknown }).error === 'string'
+      ? (result.data as { error: string }).error
+      : 'unknown';
+    return { ok: false, error: errorMessage };
+  }
+  return { ok: true, ...(result.data as Omit<SavePlanSuccess, 'ok'>) };
 }

--- a/packages/myco/src/mcp/tools/save-plan.ts
+++ b/packages/myco/src/mcp/tools/save-plan.ts
@@ -52,13 +52,13 @@ export async function handleMycoSavePlan(
   });
 
   if (!result.ok || !result.data) {
-    const errorMessage = typeof result.data === 'object'
-      && result.data !== null
-      && 'error' in result.data
-      && typeof (result.data as { error: unknown }).error === 'string'
-      ? (result.data as { error: string }).error
-      : 'unknown';
-    return { ok: false, error: errorMessage };
+    const rawError = (result.data as { error?: unknown } | null | undefined)?.error;
+    const message = typeof rawError === 'string'
+      ? rawError
+      : typeof rawError === 'object' && rawError !== null && 'message' in rawError
+        ? String((rawError as { message: unknown }).message)
+        : 'unknown';
+    return { ok: false, error: message };
   }
   return { ok: true, ...(result.data as Omit<SavePlanSuccess, 'ok'>) };
 }

--- a/packages/myco/src/services/cortex.ts
+++ b/packages/myco/src/services/cortex.ts
@@ -56,6 +56,10 @@ interface CortexPromptBuilderDetails {
   prompt?: string;
 }
 
+function isCortexPromptBuilderDetails(value: unknown): value is CortexPromptBuilderDetails {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function getLatestReportForAction(runId: string, action: string): ReportRow | undefined {
   const reports = listReports(runId);
   for (let i = reports.length - 1; i >= 0; i -= 1) {
@@ -162,7 +166,7 @@ export function getCortexPromptResult(runId: string): CortexPromptBuilderResult 
 
   const reports = listReports(runId);
   const promptReport = getLatestReportForAction(runId, 'cortex_prompt_builder');
-  const details = tryParseJson<CortexPromptBuilderDetails>(promptReport?.details);
+  const details = tryParseJson(promptReport?.details, isCortexPromptBuilderDetails);
 
   return {
     runId,

--- a/packages/myco/src/services/phase-audit.ts
+++ b/packages/myco/src/services/phase-audit.ts
@@ -45,13 +45,13 @@
 import { getRun } from '@myco/db/queries/runs.js';
 import { listReports } from '@myco/db/queries/reports.js';
 import { listTurnsByRun } from '@myco/db/queries/turns.js';
-import { listWriteIntents } from '@myco/db/queries/write-intents.js';
+import { listWriteIntentTools } from '@myco/db/queries/write-intents.js';
 import { parseCheckpointState } from '@myco/agent/executor-state.js';
 import { runDurationMs } from '@myco/agent/run-accounting.js';
 import { tryParseJson } from '@myco/utils/json.js';
 import type { ReportRow } from '@myco/db/queries/reports.js';
 import type { TurnRow } from '@myco/db/queries/turns.js';
-import type { WriteIntentRow } from '@myco/db/queries/write-intents.js';
+import type { WriteIntentToolRow } from '@myco/db/queries/write-intents.js';
 
 // ---------------------------------------------------------------------------
 // Public interfaces
@@ -147,8 +147,12 @@ interface StoredUsageData {
 // Parsing helpers
 // ---------------------------------------------------------------------------
 
+function isStoredUsageData(value: unknown): value is StoredUsageData {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function parseUsageData(raw: string | null | undefined): StoredUsageData {
-  return tryParseJson<StoredUsageData>(raw) ?? {};
+  return tryParseJson(raw, isStoredUsageData) ?? {};
 }
 
 function normalizeStatus(
@@ -191,7 +195,7 @@ interface WriteIntentSummary {
   totalByTool: Record<string, number>;              // run total by tool
 }
 
-function aggregateWriteIntents(intents: WriteIntentRow[]): WriteIntentSummary {
+function aggregateWriteIntents(intents: WriteIntentToolRow[]): WriteIntentSummary {
   const byPhase: Record<string, Record<string, number>> = {};
   const unattributedByTool: Record<string, number> = {};
   const totalByTool: Record<string, number> = {};
@@ -291,7 +295,7 @@ export function buildPhaseAudit(runId: string): PhaseAudit | null {
   // Write intents (only loaded for dry runs)
   let intentSummary: WriteIntentSummary | null = null;
   if (dryRun) {
-    const intents = listWriteIntents(runId);
+    const intents = listWriteIntentTools(runId);
     intentSummary = aggregateWriteIntents(intents);
   }
 

--- a/packages/myco/src/utils/json.ts
+++ b/packages/myco/src/utils/json.ts
@@ -10,13 +10,20 @@
 
 /**
  * Parse a JSON string tolerantly. Returns `null` for non-strings, empty
- * strings, or any `JSON.parse` failure.
+ * strings, or any `JSON.parse` failure. Callers that pass a validator get
+ * the narrowed type; callers that omit a validator receive `unknown` and
+ * must narrow at the call site.
  */
-export function tryParseJson<T = unknown>(raw: unknown): T | null {
+export function tryParseJson<T>(raw: unknown, validator: (value: unknown) => value is T): T | null;
+export function tryParseJson(raw: unknown): unknown;
+export function tryParseJson<T>(raw: unknown, validator?: (value: unknown) => value is T): T | unknown | null {
   if (typeof raw !== 'string' || raw.length === 0) return null;
+  let parsed: unknown;
   try {
-    return JSON.parse(raw) as T;
+    parsed = JSON.parse(raw);
   } catch {
     return null;
   }
+  if (!validator) return parsed;
+  return validator(parsed) ? parsed : null;
 }

--- a/packages/myco/ui/src/components/agent/RunDetail.tsx
+++ b/packages/myco/ui/src/components/agent/RunDetail.tsx
@@ -89,6 +89,18 @@ interface ParsedUsageData {
   runBudget?: RuntimeTokenBudget;
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isParsedCostData(value: unknown): value is ParsedCostData {
+  return isPlainObject(value);
+}
+
+function isParsedUsageData(value: unknown): value is ParsedUsageData {
+  return isPlainObject(value);
+}
+
 function StatTile({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-md bg-surface-container-lowest px-3 py-2">
@@ -107,7 +119,7 @@ function ReportCard({ report }: { report: ReportRow }) {
   const isLongSummary = report.summary.length > 200 || report.summary.includes('\n');
 
   const parsedDetails: unknown = hasDetails
-    ? tryParseJson<unknown>(report.details) ?? report.details
+    ? tryParseJson(report.details) ?? report.details
     : null;
 
   return (
@@ -163,7 +175,7 @@ function TurnCard({ turn }: { turn: TurnRow }) {
   const [expanded, setExpanded] = useState(false);
 
   const parsedInput: unknown = turn.tool_input
-    ? tryParseJson<unknown>(turn.tool_input) ?? turn.tool_input
+    ? tryParseJson(turn.tool_input) ?? turn.tool_input
     : null;
 
   const inputPreview = turn.tool_input
@@ -583,15 +595,15 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
   const resumeMutation = useResumeRun();
   const tasksList = useMemo(() => tasksData?.tasks ?? [], [tasksData]);
   const parsedCost = useMemo(
-    () => tryParseJson<ParsedCostData>(runData?.run?.cost_data),
+    () => tryParseJson(runData?.run?.cost_data, isParsedCostData),
     [runData?.run?.cost_data],
   );
   const parsedUsage = useMemo(
-    () => tryParseJson<ParsedUsageData>(runData?.run?.usage_data),
+    () => tryParseJson(runData?.run?.usage_data, isParsedUsageData),
     [runData?.run?.usage_data],
   );
   const phaseResults = useMemo(() => {
-    const parsed = tryParseJson<Record<string, unknown>>(runData?.run?.actions_taken);
+    const parsed = tryParseJson(runData?.run?.actions_taken, isPlainObject);
     return parsed?.phases && Array.isArray(parsed.phases)
       ? parsed.phases as PhaseResult[]
       : null;

--- a/packages/myco/ui/src/components/agent/RunTaskDialog.tsx
+++ b/packages/myco/ui/src/components/agent/RunTaskDialog.tsx
@@ -32,6 +32,8 @@ import {
   useProviderConfigDraft,
 } from '../../hooks/use-provider-config-draft';
 import {
+  parseProviderType,
+  parseRuntimeId,
   resolveReasoningModel,
   useProviders,
   type PhaseOverride,
@@ -214,8 +216,8 @@ export function RunTaskDialog({
     // but points at the source run's provider shape.
     if (prefill.provider) {
       setProviderDraft({
-        runtime: (prefill.runtime ?? prefill.provider.runtime ?? providerDraftDefaults.runtime ?? 'claude-sdk') as 'claude-sdk' | 'openai-agents' | '',
-        type: prefill.provider.type as ProviderConfig['type'] | '',
+        runtime: parseRuntimeId(prefill.runtime ?? prefill.provider.runtime ?? providerDraftDefaults.runtime ?? 'claude-sdk') || 'claude-sdk',
+        type: parseProviderType(prefill.provider.type),
         localBackend: prefill.provider.local_backend ?? '',
         model: prefill.provider.model ?? '',
         reasoningLow: prefill.provider.reasoning_map?.low ?? '',
@@ -565,8 +567,8 @@ export function RunTaskDialog({
                         setReasoning(undefined);
                         setPhaseOverrides({});
                         setProviderDraft({
-                          runtime: (providerDraftDefaults.runtime ?? 'claude-sdk') as 'claude-sdk' | 'openai-agents' | '',
-                          type: (providerDraftDefaults.providerType ?? '') as ProviderConfig['type'] | '',
+                          runtime: parseRuntimeId(providerDraftDefaults.runtime ?? 'claude-sdk') || 'claude-sdk',
+                          type: parseProviderType(providerDraftDefaults.providerType ?? ''),
                           localBackend: providerDraftDefaults.localBackend ?? '',
                           model: providerDraftDefaults.model ?? '',
                           reasoningLow: providerDraftDefaults.reasoningMap?.low ?? '',

--- a/packages/myco/ui/src/components/agent/evaluation-helpers.ts
+++ b/packages/myco/ui/src/components/agent/evaluation-helpers.ts
@@ -218,9 +218,13 @@ function shortenToolName(name: string): string {
  * needs to read the raw JSON the daemon hands back without a round-trip
  * through the audit endpoint.
  */
+function isObjectWithPhases(value: unknown): value is { phases?: unknown } {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 export function sumPhaseTurns(usageData: string | null): number | null {
-  const parsed = tryParseJson<{ phases?: Array<{ turnsUsed?: number }> }>(usageData);
-  const phases = parsed?.phases;
+  const parsed = tryParseJson(usageData, isObjectWithPhases);
+  const phases = parsed?.phases as Array<{ turnsUsed?: number }> | undefined;
   if (!Array.isArray(phases) || phases.length === 0) return null;
   let sum = 0;
   let sawTurn = false;
@@ -437,7 +441,7 @@ interface UsagePhase {
 }
 
 function parseUsagePhases(usageData: string | null): UsagePhase[] {
-  const parsed = tryParseJson<{ phases?: UsagePhase[] }>(usageData);
+  const parsed = tryParseJson(usageData, isObjectWithPhases);
   const phases = parsed?.phases;
   if (!Array.isArray(phases)) return [];
   // Guard against entries missing a name (malformed persistence).

--- a/packages/myco/ui/src/hooks/use-provider-config-draft.ts
+++ b/packages/myco/ui/src/hooks/use-provider-config-draft.ts
@@ -3,6 +3,8 @@ import {
   defaultBaseUrlForProvider,
   draftToProviderConfig,
   maybeInferRuntimeFromProviderType,
+  parseProviderType,
+  parseRuntimeId,
   providerSupportsRuntime,
   seedDraftFromProviderType,
   type ProviderConfig,
@@ -54,19 +56,27 @@ function runtimeFromSource(
   source: ProviderDraftSource | null | undefined,
   defaults?: ProviderDraftDefaults,
 ): ProviderDraft['runtime'] | '' {
-  return (source?.runtime as ProviderDraft['runtime'] | undefined)
-    ?? (source?.provider?.runtime as ProviderDraft['runtime'] | undefined)
-    ?? maybeInferRuntimeFromProviderType(source?.provider?.type as ProviderDraft['type'] | undefined)
-    ?? (defaults?.runtime as ProviderDraft['runtime'] | undefined)
-    ?? maybeInferRuntimeFromProviderType(defaults?.providerType as ProviderDraft['type'] | undefined)
-    ?? '';
+  const sourceRuntime = source?.runtime ? parseRuntimeId(source.runtime) : '';
+  if (sourceRuntime) return sourceRuntime;
+  const providerRuntime = source?.provider?.runtime ? parseRuntimeId(source.provider.runtime) : '';
+  if (providerRuntime) return providerRuntime;
+  const inferredFromSourceType = source?.provider?.type
+    ? maybeInferRuntimeFromProviderType(parseProviderType(source.provider.type) || undefined)
+    : undefined;
+  if (inferredFromSourceType) return inferredFromSourceType;
+  const defaultRuntime = defaults?.runtime ? parseRuntimeId(defaults.runtime) : '';
+  if (defaultRuntime) return defaultRuntime;
+  const inferredFromDefaults = defaults?.providerType
+    ? maybeInferRuntimeFromProviderType(parseProviderType(defaults.providerType) || undefined)
+    : undefined;
+  return inferredFromDefaults ?? '';
 }
 
 export function providerDraftFromSource(
   source: ProviderDraftSource | null | undefined,
   defaults?: ProviderDraftDefaults,
 ): ProviderDraft {
-  const providerType = (source?.provider?.type as ProviderDraft['type'] | undefined) ?? '';
+  const providerType = source?.provider?.type ? parseProviderType(source.provider.type) : '';
   if (providerType !== '') {
     return {
       runtime: runtimeFromSource(source, defaults),
@@ -86,7 +96,7 @@ export function providerDraftFromSource(
 
   return {
     runtime: runtimeFromSource(source, defaults),
-    type: (defaults?.providerType as ProviderDraft['type'] | undefined) ?? '',
+    type: defaults?.providerType ? parseProviderType(defaults.providerType) : '',
     localBackend: defaults?.localBackend ?? '',
     model: source?.model ?? defaults?.model ?? '',
     reasoningLow: defaults?.reasoningMap?.low ?? '',
@@ -138,13 +148,14 @@ function isDefaultLocalBaseUrl(value: string): boolean {
 }
 
 function nextDraftForRuntime(runtime: string, providers: ProviderInfo[]): ProviderDraft {
-  const firstProvider = providers.find((provider) => providerSupportsRuntime(provider.type, runtime as ProviderDraft['runtime']));
+  const parsedRuntime = parseRuntimeId(runtime);
+  const firstProvider = providers.find((provider) => providerSupportsRuntime(provider.type, parsedRuntime));
   if (firstProvider) {
-    return seedDraftFromProviderType(firstProvider.type, providers, runtime as ProviderDraft['runtime']);
+    return seedDraftFromProviderType(firstProvider.type, providers, parsedRuntime || undefined);
   }
   return {
     ...emptyProviderDraft(),
-    runtime: runtime as ProviderDraft['runtime'],
+    runtime: parsedRuntime,
   };
 }
 
@@ -200,19 +211,21 @@ export function useProviderConfigDraft({
   const isDirty = !providerDraftsEqual(draft, savedDraft);
 
   const handleRuntimeChange = useCallback((runtime: string) => {
+    const parsedRuntime = parseRuntimeId(runtime);
     setDraft((prev) => {
-      if (providerSupportsRuntime(prev.type, runtime as ProviderDraft['runtime'])) {
-        return { ...prev, runtime: runtime as ProviderDraft['runtime'] };
+      if (providerSupportsRuntime(prev.type, parsedRuntime)) {
+        return { ...prev, runtime: parsedRuntime };
       }
       return nextDraftForRuntime(runtime, providers);
     });
   }, [providers]);
 
   const handleProviderChange = useCallback((type: string) => {
+    const parsedType = parseProviderType(type);
     setDraft((prev) => seedDraftFromProviderType(
       type,
       providers,
-      providerSupportsRuntime(type as ProviderDraft['type'], prev.runtime) ? prev.runtime : undefined,
+      providerSupportsRuntime(parsedType, prev.runtime) ? prev.runtime : undefined,
     ));
   }, [providers]);
 

--- a/packages/myco/ui/src/hooks/use-providers.ts
+++ b/packages/myco/ui/src/hooks/use-providers.ts
@@ -17,6 +17,36 @@ export interface ProviderInfo {
   models: string[];
 }
 
+export type RuntimeIdUi = ProviderInfo['runtime'];
+export type ProviderTypeUi = ProviderInfo['type'];
+
+const RUNTIME_IDS: readonly RuntimeIdUi[] = ['claude-sdk', 'openai-agents'];
+const PROVIDER_TYPES_UI: readonly ProviderTypeUi[] = [
+  'anthropic',
+  'ollama',
+  'lmstudio',
+  'openai',
+  'openrouter',
+  'openai-compatible',
+];
+
+/**
+ * Narrow an arbitrary string to RuntimeIdUi. Returns '' when the input
+ * isn't a known runtime id — callers can then treat '' as "no runtime
+ * selected" without blanket casting.
+ */
+export function parseRuntimeId(value: string): RuntimeIdUi | '' {
+  return (RUNTIME_IDS as readonly string[]).includes(value) ? (value as RuntimeIdUi) : '';
+}
+
+/**
+ * Narrow an arbitrary string to ProviderTypeUi. Returns '' when the input
+ * isn't a known provider type.
+ */
+export function parseProviderType(value: string): ProviderTypeUi | '' {
+  return (PROVIDER_TYPES_UI as readonly string[]).includes(value) ? (value as ProviderTypeUi) : '';
+}
+
 export interface ProvidersResponse {
   providers: ProviderInfo[];
 }

--- a/packages/myco/ui/src/hooks/use-sessions.ts
+++ b/packages/myco/ui/src/hooks/use-sessions.ts
@@ -236,8 +236,13 @@ export function useSessionImpact(sessionId: string | null) {
 export function useSessionPlans(sessionId: string | undefined) {
   return usePowerQuery<SessionPlanRow[]>({
     queryKey: ['session-plans', sessionId],
-    queryFn: ({ signal }) =>
-      fetchJson<SessionPlanRow[]>(`/sessions/${sessionId}/plans`, { signal }),
+    queryFn: async ({ signal }) => {
+      const response = await fetchJson<{ plans: SessionPlanRow[] }>(
+        `/sessions/${sessionId}/plans`,
+        { signal },
+      );
+      return response.plans;
+    },
     enabled: !!sessionId,
     pollCategory: 'standard',
     refetchInterval: PLANS_POLL_INTERVAL,

--- a/packages/myco/ui/src/hooks/use-task-execution-defaults.ts
+++ b/packages/myco/ui/src/hooks/use-task-execution-defaults.ts
@@ -16,6 +16,7 @@ import type { ProviderDraftDefaults, ProviderDraftSource } from './use-provider-
 import type { TaskRow } from './use-agent';
 import {
   maybeInferRuntimeFromProviderType,
+  parseProviderType,
   resolveReasoningModel,
   useTaskConfig,
   type ProviderConfig,
@@ -62,13 +63,17 @@ export function useTaskExecutionDefaults(
 
   const { effective } = useScopedConfig();
   const globalProvider = effective?.agent?.provider;
-  const globalProviderType = globalProvider?.type as ProviderConfig['type'] | undefined;
+  const globalProviderType = globalProvider?.type
+    ? parseProviderType(globalProvider.type) || undefined
+    : undefined;
   const globalRuntime = globalProvider?.runtime;
 
   const { data: taskConfigData } = useTaskConfig(taskName);
   const taskConfig = taskConfigData?.config;
   const execution = taskRow?.execution;
-  const executionProviderType = execution?.provider?.type as ProviderConfig['type'] | undefined;
+  const executionProviderType = execution?.provider?.type
+    ? parseProviderType(execution.provider.type) || undefined
+    : undefined;
 
   const runtime: RuntimeId = (taskConfig?.runtime
     ?? taskConfig?.provider?.runtime

--- a/packages/myco/ui/src/lib/api.ts
+++ b/packages/myco/ui/src/lib/api.ts
@@ -2,6 +2,24 @@ import type { AppearanceValues as AppearanceConfig } from '@myco/config/appearan
 
 const API_BASE = '/api';
 
+// Injected by Vite's `define` at build time — see vite.config.ts.
+declare const __MYCO_UI_VERSION__: string;
+const UI_VERSION: string = typeof __MYCO_UI_VERSION__ === 'string' ? __MYCO_UI_VERSION__ : 'dev';
+
+/** Track once-per-session so we don't spam the console on every fetch. */
+let versionMismatchWarned = false;
+function checkApiVersion(response: Response): void {
+  if (versionMismatchWarned) return;
+  const apiVersion = response.headers.get('X-Myco-Api-Version');
+  if (apiVersion && apiVersion !== UI_VERSION) {
+    versionMismatchWarned = true;
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[myco] UI version ${UI_VERSION} is talking to daemon ${apiVersion} — reload to pick up the new UI build.`,
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Appearance / scoped-config types
 // ---------------------------------------------------------------------------
@@ -25,6 +43,7 @@ export async function fetchJson<T>(path: string, init?: RequestInit): Promise<T>
     ...init,
     headers,
   });
+  checkApiVersion(res);
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
     throw new ApiError(res.status, body);

--- a/packages/myco/ui/vite.config.ts
+++ b/packages/myco/ui/vite.config.ts
@@ -1,13 +1,24 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
+import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Resolve the myco package version at build time so the UI can compare
+// against the X-Myco-Api-Version response header and surface a warning
+// when the bundled UI is older than the daemon it's talking to.
+const mycoPackageJson = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),
+) as { version: string };
+
 export default defineConfig({
   plugins: [react()],
   base: '/',
+  define: {
+    __MYCO_UI_VERSION__: JSON.stringify(mycoPackageJson.version),
+  },
   // Mirror the tsconfig paths entry so vite can resolve `@myco/*` imports
   // from `packages/myco/src/*` at dev time and during production builds.
   resolve: {

--- a/tests/agent/cost-resolver.test.ts
+++ b/tests/agent/cost-resolver.test.ts
@@ -8,7 +8,7 @@ afterEach(() => {
 });
 
 describe('resolveCost', () => {
-  it('exposes provider capabilities through the registry', () => {
+  it('returns the correct resolver for known provider types', () => {
     const openRouterProvider = getCostProvider({
       runtime: 'openai-agents',
       model: 'openrouter/auto',
@@ -22,16 +22,8 @@ describe('resolveCost', () => {
       usage: {},
     });
 
-    expect(openRouterProvider?.capabilities).toEqual({
-      estimateFromUsage: true,
-      fetchActualRunCost: true,
-      fetchCatalogPricing: true,
-    });
-    expect(localProvider?.capabilities).toEqual({
-      estimateFromUsage: false,
-      fetchActualRunCost: false,
-      fetchCatalogPricing: false,
-    });
+    expect(openRouterProvider?.id).toBe('openrouter');
+    expect(localProvider?.id).toBe('generic-configured');
   });
 
   it('prefers actual cost reported by the runtime', async () => {

--- a/tests/agent/run-accounting.test.ts
+++ b/tests/agent/run-accounting.test.ts
@@ -145,7 +145,7 @@ describe('analyzeRuntimeTokenBudget', () => {
     expect(budget.peakRequestTotalTokens).toBe(192_000);
     expect(budget.contextWindowTokens).toBe(200_000);
     expect(budget.utilizationPercent).toBe(96);
-    expect(budget.status).toBe('critical');
+    expect(budget.status).toBe('post_run_pressure');
   });
 });
 

--- a/tests/agent/runtime-openai.test.ts
+++ b/tests/agent/runtime-openai.test.ts
@@ -99,6 +99,23 @@ vi.mock('@myco/intelligence/lm-studio.js', () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Mock local MCP server — captures forwarded toolSurface
+// ---------------------------------------------------------------------------
+
+const mcpServerCalls: Array<Record<string, unknown>> = [];
+let mockMcpServer: { connect: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn> } = {
+  connect: vi.fn(async () => {}),
+  close: vi.fn(async () => {}),
+};
+
+vi.mock('@myco/agent/runtime/openai-local-mcp.js', () => ({
+  createLocalVaultMcpServer: (toolSurface: Record<string, unknown>) => {
+    mcpServerCalls.push(toolSurface);
+    return mockMcpServer;
+  },
+}));
+
+// ---------------------------------------------------------------------------
 // Test fixtures
 // ---------------------------------------------------------------------------
 
@@ -108,16 +125,12 @@ async function loadRuntime() {
 }
 
 function makeMcpServer() {
-  return {
+  const server = {
     connect: vi.fn(async () => {}),
     close: vi.fn(async () => {}),
   };
-}
-
-function makeContext(mcpServer: ReturnType<typeof makeMcpServer>) {
-  return {
-    createOpenAIMcpServer: vi.fn(() => mcpServer),
-  } as unknown as import('@myco/agent/runtime/types.js').RuntimeFactoryContext;
+  mockMcpServer = server;
+  return server;
 }
 
 function makeInput(overrides: Partial<import('@myco/agent/runtime/types.js').RuntimeExecuteInput> = {}) {
@@ -138,6 +151,7 @@ function makeInput(overrides: Partial<import('@myco/agent/runtime/types.js').Run
 describe('OpenAIAgentsRuntime.execute', () => {
   beforeEach(() => {
     runnerCalls.length = 0;
+    mcpServerCalls.length = 0;
     mockRunBehavior = 'success';
     mockRunResult = {
       finalOutput: 'done',
@@ -171,7 +185,7 @@ describe('OpenAIAgentsRuntime.execute', () => {
   it('persists session items into sessionData when the run appends new turns', async () => {
     const Runtime = await loadRuntime();
     const mcp = makeMcpServer();
-    const runtime = new Runtime(makeContext(mcp));
+    const runtime = new Runtime();
 
     mockRunResult.appendItems = [{ type: 'user', content: 'hi' }];
 
@@ -184,7 +198,7 @@ describe('OpenAIAgentsRuntime.execute', () => {
   it('hydrates prior sessionData into the Session passed to the Runner', async () => {
     const Runtime = await loadRuntime();
     const mcp = makeMcpServer();
-    const runtime = new Runtime(makeContext(mcp));
+    const runtime = new Runtime();
 
     const priorItems = [{ type: 'user', content: 'previous turn' }];
     await runtime.execute(makeInput({ sessionRef: 'sess-resume', sessionData: priorItems }));
@@ -197,7 +211,7 @@ describe('OpenAIAgentsRuntime.execute', () => {
   it('calls mcpServer.close() on the successful path', async () => {
     const Runtime = await loadRuntime();
     const mcp = makeMcpServer();
-    const runtime = new Runtime(makeContext(mcp));
+    const runtime = new Runtime();
 
     await runtime.execute(makeInput());
 
@@ -207,7 +221,7 @@ describe('OpenAIAgentsRuntime.execute', () => {
   it('calls mcpServer.close() even when the Runner throws', async () => {
     const Runtime = await loadRuntime();
     const mcp = makeMcpServer();
-    const runtime = new Runtime(makeContext(mcp));
+    const runtime = new Runtime();
     mockRunBehavior = 'throw';
 
     await expect(runtime.execute(makeInput())).rejects.toThrow('Runner blew up');
@@ -217,7 +231,7 @@ describe('OpenAIAgentsRuntime.execute', () => {
   it('forwards the abortController.signal to Runner.run when provided', async () => {
     const Runtime = await loadRuntime();
     const mcp = makeMcpServer();
-    const runtime = new Runtime(makeContext(mcp));
+    const runtime = new Runtime();
 
     const controller = new AbortController();
     await runtime.execute(makeInput({ abortController: controller }));
@@ -228,7 +242,7 @@ describe('OpenAIAgentsRuntime.execute', () => {
   it('omits signal when no abortController is supplied', async () => {
     const Runtime = await loadRuntime();
     const mcp = makeMcpServer();
-    const runtime = new Runtime(makeContext(mcp));
+    const runtime = new Runtime();
 
     await runtime.execute(makeInput());
 
@@ -238,7 +252,7 @@ describe('OpenAIAgentsRuntime.execute', () => {
   it('aggregates usage across rawResponses', async () => {
     const Runtime = await loadRuntime();
     const mcp = makeMcpServer();
-    const runtime = new Runtime(makeContext(mcp));
+    const runtime = new Runtime();
 
     const result = await runtime.execute(makeInput());
 
@@ -252,25 +266,23 @@ describe('OpenAIAgentsRuntime.execute', () => {
     expect(result.rawRuntimeMetadata?.lastResponseId).toBe('resp_ok');
   });
 
-  it('passes dryRun through toolSurface to createOpenAIMcpServer', async () => {
+  it('passes dryRun through toolSurface to createLocalVaultMcpServer', async () => {
     const Runtime = await loadRuntime();
-    const mcp = makeMcpServer();
-    const ctx = makeContext(mcp);
-    const runtime = new Runtime(ctx);
+    makeMcpServer();
+    const runtime = new Runtime();
 
     await runtime.execute(makeInput({
       toolSurface: { agentId: 'a', runId: 'r', dryRun: true },
     }));
 
-    expect(ctx.createOpenAIMcpServer).toHaveBeenCalledTimes(1);
-    const forwarded = (ctx.createOpenAIMcpServer as unknown as { mock: { calls: Array<Array<Record<string, unknown>>> } }).mock.calls[0][0];
-    expect(forwarded.dryRun).toBe(true);
+    expect(mcpServerCalls).toHaveLength(1);
+    expect(mcpServerCalls[0].dryRun).toBe(true);
   });
 
   it('round-trips lastResponseId into rawRuntimeMetadata for resume flow', async () => {
     const Runtime = await loadRuntime();
     const mcp = makeMcpServer();
-    const runtime = new Runtime(makeContext(mcp));
+    const runtime = new Runtime();
 
     // Simulate a resumed session where the prior run produced lastResponseId='resp_abc'
     mockRunResult.lastResponseId = 'resp_abc_next';
@@ -291,7 +303,7 @@ describe('OpenAIAgentsRuntime.execute', () => {
   it('tolerates responses without inputTokensDetails/outputTokensDetails arrays (local backends)', async () => {
     const Runtime = await loadRuntime();
     const mcp = makeMcpServer();
-    const runtime = new Runtime(makeContext(mcp));
+    const runtime = new Runtime();
     mockRunResult.rawResponses = [
       {
         usage: {

--- a/tests/context/cortex-brief.test.ts
+++ b/tests/context/cortex-brief.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { buildRetrievalGuidanceLines, RETRIEVAL_GUIDANCE } from '@myco/context/cortex-brief.js';
+import {
+  buildRetrievalGuidanceLines,
+  RETRIEVAL_GUIDANCE,
+  resolveCortexCapabilities,
+  resolveInstructionDelivery,
+} from '@myco/context/cortex-brief.js';
+import { MycoConfigSchema } from '@myco/config/schema.js';
 
 describe('buildRetrievalGuidanceLines', () => {
   it('does not encode myco_skills guidance into Cortex instructions', () => {
@@ -58,5 +64,68 @@ describe('RETRIEVAL_GUIDANCE', () => {
     const body = lines.join('\n');
     expect(body).toContain('`myco_cortex`');
     expect(body).toContain('`myco_runs`');
+  });
+});
+
+describe('resolveInstructionDelivery', () => {
+  const enabledContext = MycoConfigSchema.parse({ version: 3 }).context;
+  const disabledContext = MycoConfigSchema.parse({
+    version: 3,
+    context: { cortex_enabled: false },
+  }).context;
+
+  const cases: Array<{
+    label: string;
+    context: typeof enabledContext;
+    symbiont: { supportsSessionStartInjection: boolean } | null;
+    expected: ReturnType<typeof resolveInstructionDelivery>;
+  }> = [
+    {
+      label: 'null symbiont → inline with missing-symbiont reason',
+      context: enabledContext,
+      symbiont: null,
+      expected: { inlineInstructions: true, reason: 'missing-symbiont' },
+    },
+    {
+      label: 'cortex disabled → inline regardless of symbiont support',
+      context: disabledContext,
+      symbiont: { supportsSessionStartInjection: true },
+      expected: { inlineInstructions: true, reason: 'session-start-disabled' },
+    },
+    {
+      label: 'symbiont supports injection → NOT inline',
+      context: enabledContext,
+      symbiont: { supportsSessionStartInjection: true },
+      expected: { inlineInstructions: false, reason: 'session-start-supported' },
+    },
+    {
+      label: 'symbiont lacks injection support → inline with no-session-start',
+      context: enabledContext,
+      symbiont: { supportsSessionStartInjection: false },
+      expected: { inlineInstructions: true, reason: 'no-session-start' },
+    },
+  ];
+
+  for (const testCase of cases) {
+    it(testCase.label, () => {
+      expect(resolveInstructionDelivery(testCase.context, testCase.symbiont))
+        .toEqual(testCase.expected);
+    });
+  }
+});
+
+describe('resolveCortexCapabilities', () => {
+  it('returns collectiveConnected=false and empty capabilities when the team client throws', async () => {
+    const config = { team: { enabled: true } } as const;
+    const throwingClient = {
+      getCollectiveStatus: () => { throw new Error('team sync offline'); },
+    };
+    const result = await resolveCortexCapabilities(
+      config as never,
+      () => throwingClient as never,
+    );
+    expect(result.teamEnabled).toBe(true);
+    expect(result.collectiveConnected).toBe(false);
+    expect(result.collectiveCapabilities).toEqual([]);
   });
 });

--- a/tests/context/injector.test.ts
+++ b/tests/context/injector.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
-import { buildInjectedContext, buildPromptContext } from '@myco/context/injector';
+import { buildInjectedContext } from '@myco/context/injector';
 import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
 import { upsertSession } from '@myco/db/queries/sessions';
 import { insertSpore } from '@myco/db/queries/spores';
@@ -26,7 +26,6 @@ describe('buildInjectedContext', () => {
     const result = await buildInjectedContext(config, {});
 
     expect(result.text).toBe('');
-    expect(result.brief).toBe('');
     expect(result.tokenEstimate).toBe(0);
   });
 
@@ -120,24 +119,3 @@ describe('buildInjectedContext', () => {
   });
 });
 
-describe('buildPromptContext', () => {
-  const config = MycoConfigSchema.parse({
-    version: 3,
-  });
-
-  beforeAll(() => { setupTestDb(); });
-  afterAll(() => { teardownTestDb(); });
-  beforeEach(() => { cleanTestDb(); });
-
-  it('returns empty context for short prompts', async () => {
-    const result = await buildPromptContext('hi', config);
-    expect(result.text).toBe('');
-    expect(result.tokenEstimate).toBe(0);
-  });
-
-  it('returns empty context when no embedding provider is available', async () => {
-    const result = await buildPromptContext('How should I handle authentication middleware?', config);
-    expect(result.text).toBe('');
-    expect(result.tokenEstimate).toBe(0);
-  });
-});

--- a/tests/context/session-start-digest.test.ts
+++ b/tests/context/session-start-digest.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for shouldInjectSessionStartDigest + getSessionStartDigestPayload.
+ *
+ * Covers:
+ *   (a) returns the extract at the configured tier when present
+ *   (b) falls back to DIGEST_FALLBACK_TIER when the preferred tier is missing
+ *   (c) returns { content: '', tier: null } when both are missing
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import {
+  getSessionStartDigestPayload,
+  shouldInjectSessionStartDigest,
+} from '@myco/context/session-start-digest.js';
+import { DEFAULT_AGENT_ID, DIGEST_FALLBACK_TIER } from '@myco/constants.js';
+import { upsertDigestExtract } from '@myco/db/queries/digest-extracts.js';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { MycoConfigSchema } from '@myco/config/schema.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
+
+describe('session-start-digest', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    registerAgent({
+      id: DEFAULT_AGENT_ID,
+      name: 'myco-agent',
+      created_at: Math.floor(Date.now() / 1000),
+    });
+  });
+
+  const context = MycoConfigSchema.parse({
+    version: 3,
+    context: { session_start_digest_enabled: true },
+  }).context;
+
+  it('shouldInjectSessionStartDigest honors the config toggle', () => {
+    expect(shouldInjectSessionStartDigest(context)).toBe(true);
+    const disabled = MycoConfigSchema.parse({
+      version: 3,
+      context: { session_start_digest_enabled: false },
+    }).context;
+    expect(shouldInjectSessionStartDigest(disabled)).toBe(false);
+  });
+
+  it('returns the extract at the configured tier when present', () => {
+    const now = Math.floor(Date.now() / 1000);
+    upsertDigestExtract({
+      agent_id: DEFAULT_AGENT_ID,
+      tier: context.digest_tier,
+      content: 'Preferred-tier digest body',
+      generated_at: now,
+    });
+
+    const payload = getSessionStartDigestPayload(context);
+    expect(payload.content).toBe('Preferred-tier digest body');
+    expect(payload.tier).toBe(context.digest_tier);
+  });
+
+  it('falls back to DIGEST_FALLBACK_TIER when the preferred tier is missing', () => {
+    const now = Math.floor(Date.now() / 1000);
+    upsertDigestExtract({
+      agent_id: DEFAULT_AGENT_ID,
+      tier: DIGEST_FALLBACK_TIER,
+      content: 'Fallback-tier digest body',
+      generated_at: now,
+    });
+
+    const payload = getSessionStartDigestPayload(context);
+    expect(payload.content).toBe('Fallback-tier digest body');
+    expect(payload.tier).toBe(DIGEST_FALLBACK_TIER);
+  });
+
+  it('returns empty payload when both the preferred and fallback tiers are missing', () => {
+    const payload = getSessionStartDigestPayload(context);
+    expect(payload).toEqual({ content: '', tier: null });
+  });
+});

--- a/tests/daemon/api/cortex.test.ts
+++ b/tests/daemon/api/cortex.test.ts
@@ -89,6 +89,23 @@ describe('createCortexHandlers', () => {
     expect(getCortexInstructionsSnapshot).not.toHaveBeenCalled();
   });
 
+  it('returns 400 when refresh is rejected for misconfig reasons', async () => {
+    triggerCortexInstructions.mockResolvedValue({
+      started: false,
+      reason: 'provider-not-configured',
+    });
+    const handlers = makeHandlers();
+
+    const response = await handlers.handleRefreshInstructions();
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      error: { code: 'provider-not-configured' },
+      started: false,
+      reason: 'provider-not-configured',
+    });
+  });
+
   it('passes builder requests through to the prompt builder service', async () => {
     buildCortexPrompt.mockResolvedValue({
       started: true,

--- a/tests/daemon/api/mcp-proxy.test.ts
+++ b/tests/daemon/api/mcp-proxy.test.ts
@@ -112,6 +112,6 @@ describe('createMcpProxyHandlers handleSavePlan', () => {
     }));
 
     expect(res.status).toBe(404);
-    expect((res.body as { error: string }).error).toBe('session_not_found');
+    expect(res.body).toMatchObject({ error: { code: 'session-not-found' } });
   });
 });

--- a/tests/daemon/api/run-serializer.test.ts
+++ b/tests/daemon/api/run-serializer.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Poison-row resilience tests for the agent-runs API serializer.
+ *
+ * Historical rows can carry malformed JSON in `cost_data`, `usage_data`, or
+ * `execution_overrides` (corruption, partial writes, a bug in an older
+ * branch). The serializer MUST pass those values through cleanly rather
+ * than crashing the list endpoint and hiding every other row.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { serializeRun } from '@myco/daemon/api/run-serializer.js';
+import type { RunRow } from '@myco/db/queries/runs.js';
+
+function baseRun(overrides: Partial<RunRow>): RunRow {
+  return {
+    id: 'run-1',
+    agent_id: 'myco-agent',
+    task: 'test',
+    instruction: null,
+    status: 'completed',
+    runtime: null,
+    provider: null,
+    model: null,
+    session_ref: null,
+    resumable: 0,
+    resume_status: null,
+    resume_mode: null,
+    resumed_at: null,
+    checkpoints: null,
+    usage_data: null,
+    started_at: 0,
+    completed_at: 0,
+    tokens_used: 0,
+    cost_usd: 0,
+    actual_cost_usd: 0,
+    estimated_cost_usd: null,
+    cost_source: 'unavailable',
+    cost_data: null,
+    actions_taken: null,
+    error: null,
+    dry_run: false,
+    evaluation_id: null,
+    reasoning_level: null,
+    execution_overrides: null,
+    ...overrides,
+  };
+}
+
+describe('serializeRun — poison-row resilience', () => {
+  it('passes malformed cost_data string through without crashing', () => {
+    const row = baseRun({ cost_data: '{not-json' });
+    const out = serializeRun(row);
+    expect(out.cost_data).toBe('{not-json');
+  });
+
+  it('passes malformed usage_data string through without crashing', () => {
+    const row = baseRun({ usage_data: '{usage:broken' });
+    const out = serializeRun(row);
+    expect(out.usage_data).toBe('{usage:broken');
+  });
+
+  it('tolerates null execution_overrides (the common case)', () => {
+    const row = baseRun({ execution_overrides: null });
+    const out = serializeRun(row);
+    expect(out.execution_overrides).toBeNull();
+  });
+
+  it('strips apiKey from nested provider overrides even on otherwise well-formed rows', () => {
+    const row = baseRun({
+      execution_overrides: {
+        provider: { type: 'openai', apiKey: 'sk-secret' },
+      },
+    });
+    const out = serializeRun(row);
+    const providerOverride = (out.execution_overrides as Record<string, unknown>).provider as Record<string, unknown>;
+    expect(providerOverride.type).toBe('openai');
+    expect(providerOverride).not.toHaveProperty('apiKey');
+  });
+
+  it('builds an empty phase_checkpoints projection when checkpoints JSON is malformed', () => {
+    const row = baseRun({ checkpoints: '{phases:not-real-json' });
+    const out = serializeRun(row);
+    expect(out.phase_checkpoints).toEqual([]);
+  });
+});

--- a/tests/daemon/api/sessions.test.ts
+++ b/tests/daemon/api/sessions.test.ts
@@ -178,7 +178,7 @@ describe('handleDeletePlan', () => {
     const res = await handleDeletePlan(makeRequest({ params: { id: 'missing-plan' } }));
 
     expect(res.status).toBe(404);
-    expect((res.body as { error: string }).error).toBe('Plan not found');
+    expect(res.body).toMatchObject({ error: { code: 'plan-not-found' } });
   });
 });
 

--- a/tests/mcp/tools/save-plan.test.ts
+++ b/tests/mcp/tools/save-plan.test.ts
@@ -44,11 +44,25 @@ describe('myco_save_plan', () => {
       status: undefined,
       tags: ['planning'],
     });
-    expect(result?.id).toBe('plan-1234');
-    expect(result?.logical_key).toBe('session:sess-1:key:primary');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.id).toBe('plan-1234');
+      expect(result.logical_key).toBe('session:sess-1:key:primary');
+    }
   });
 
-  it('returns null when the daemon save fails', async () => {
+  it('returns a structured error when the daemon save fails', async () => {
+    const client = mockClient({ error: 'save-failed' }, false);
+    const result = await handleMycoSavePlan({
+      session_id: 'sess-1',
+      content: '# Plan',
+      plan_key: 'primary',
+    }, client);
+
+    expect(result).toEqual({ ok: false, error: 'save-failed' });
+  });
+
+  it('falls back to "unknown" when the failure payload lacks an error string', async () => {
     const client = mockClient(null, false);
     const result = await handleMycoSavePlan({
       session_id: 'sess-1',
@@ -56,6 +70,6 @@ describe('myco_save_plan', () => {
       plan_key: 'primary',
     }, client);
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ ok: false, error: 'unknown' });
   });
 });

--- a/tests/plans/identity.test.ts
+++ b/tests/plans/identity.test.ts
@@ -9,11 +9,14 @@
  * Finding #10 of the pre-0.21 runtime review.
  */
 
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   buildSessionPlanLogicalKey,
   buildSessionTagPlanLogicalKey,
   buildPathPlanLogicalKey,
+  humanizePlanToken,
+  normalizePlanSourcePath,
 } from '@myco/plans/identity.js';
 
 describe('plan logical-key namespaces', () => {
@@ -42,5 +45,37 @@ describe('plan logical-key namespaces', () => {
       .not.toBe(buildSessionTagPlanLogicalKey('sess-b', 'primary'));
     expect(buildSessionPlanLogicalKey('sess-a', 'primary'))
       .not.toBe(buildSessionPlanLogicalKey('sess-b', 'primary'));
+  });
+});
+
+describe('normalizePlanSourcePath', () => {
+  it('rewrites Windows-style separators to POSIX in the normalized output', () => {
+    const result = normalizePlanSourcePath('docs\\plans\\alpha.md', '/tmp/project');
+    expect(result).toBe('docs/plans/alpha.md');
+  });
+
+  it('returns a normalized absolute path when the input escapes the project root', () => {
+    const outside = path.resolve('/tmp/outside/plan.md');
+    const result = normalizePlanSourcePath(outside, '/tmp/project');
+    expect(path.isAbsolute(result)).toBe(true);
+    expect(result.includes('outside')).toBe(true);
+    // Forward slashes in result (POSIX normalization).
+    expect(result.includes('\\')).toBe(false);
+  });
+
+  it('passes through transcript:-prefixed sources unchanged', () => {
+    expect(normalizePlanSourcePath('transcript:abc123')).toBe('transcript:abc123');
+  });
+});
+
+describe('humanizePlanToken', () => {
+  it('converts camelCase to Title Case', () => {
+    expect(humanizePlanToken('primaryPlan')).toBe('Primary Plan');
+    expect(humanizePlanToken('multiWordCamelCase')).toBe('Multi Word Camel Case');
+  });
+
+  it('converts hyphen / underscore separators to spaces with each word capitalized', () => {
+    expect(humanizePlanToken('primary-plan')).toBe('Primary Plan');
+    expect(humanizePlanToken('rollout_phase_one')).toBe('Rollout Phase One');
   });
 });

--- a/tests/symbionts/injection-support.test.ts
+++ b/tests/symbionts/injection-support.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Manifest-coverage + anti-drift tests for `detectSymbiontInjectionSupport`.
+ *
+ * The detector reads each symbiont's hook template text and infers whether
+ * the template registers a session-start or user-prompt-submit hook. The
+ * expected-support map below pins the current truth for all built-in
+ * symbionts. When a template gains or loses a hook registration, the
+ * detector's output must flip; the anti-drift test below catches cases
+ * where the detector stops recognizing an existing registration.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { loadManifests } from '@myco/symbionts/detect.js';
+import { detectSymbiontInjectionSupport } from '@myco/symbionts/injection-support.js';
+
+/**
+ * Expected support map per symbiont, keyed by manifest.name. When a new
+ * symbiont is added to `packages/myco/src/symbionts/manifests/`, append
+ * an entry here — the first test below fails until this map is updated,
+ * which forces the author to think about session-start support.
+ */
+const EXPECTED_SUPPORT: Record<string, { session: boolean; prompt: boolean }> = {
+  'claude-code': { session: true, prompt: true },
+  codex: { session: true, prompt: true },
+  cursor: { session: true, prompt: true },
+  gemini: { session: true, prompt: true },
+  opencode: { session: true, prompt: false },
+  'vscode-copilot': { session: true, prompt: true },
+  windsurf: { session: false, prompt: true },
+};
+
+describe('detectSymbiontInjectionSupport', () => {
+  const manifests = loadManifests();
+
+  it('enumerates at least one manifest', () => {
+    expect(manifests.length).toBeGreaterThan(0);
+  });
+
+  it('matches the expected injection-support flags for every built-in symbiont', () => {
+    // Use only the flags we actually pin; if a symbiont has been added to
+    // the manifests directory but not the pin map, surface that via a
+    // separate expect so the failure message is informative.
+    const actual: Record<string, { session: boolean; prompt: boolean }> = {};
+    for (const manifest of manifests) {
+      const support = detectSymbiontInjectionSupport(manifest);
+      actual[manifest.name] = {
+        session: support.supportsSessionStartInjection,
+        prompt: support.supportsPromptSubmitInjection,
+      };
+    }
+    expect(actual).toEqual(EXPECTED_SUPPORT);
+  });
+
+  // Anti-drift: when a hook template contains `hook session-start` (the
+  // canonical Claude Code hook directive), the detector MUST report
+  // `supportsSessionStartInjection: true`. If the detector's signal list
+  // drifts away from the template vocabulary, this test fails.
+  it('never lies: templates with `hook session-start` always report supportsSessionStartInjection=true', () => {
+    for (const manifest of manifests) {
+      const templateFile = manifest.registration?.hooksFormat === 'plugin-file'
+        ? 'plugin.ts'
+        : 'hooks.json';
+      const templatePath = path.resolve(
+        import.meta.dirname,
+        '..',
+        '..',
+        'packages/myco/src/symbionts/templates',
+        manifest.name,
+        templateFile,
+      );
+      if (!fs.existsSync(templatePath)) continue;
+      const template = fs.readFileSync(templatePath, 'utf-8');
+      if (!template.includes('hook session-start')) continue;
+      const support = detectSymbiontInjectionSupport(manifest);
+      expect(
+        support.supportsSessionStartInjection,
+        `${manifest.name} template has "hook session-start" but detector reports false`,
+      ).toBe(true);
+    }
+  });
+});

--- a/tests/utils/json.test.ts
+++ b/tests/utils/json.test.ts
@@ -34,10 +34,18 @@ describe('tryParseJson', () => {
     expect(tryParseJson([])).toBeNull();
   });
 
-  it('narrows via generic type parameter when caller specifies a type', () => {
+  it('narrows via validator predicate when caller supplies one', () => {
     interface Shape { foo: number }
-    const parsed = tryParseJson<Shape>('{"foo":7}');
-    // If parsed is non-null, TS treats it as Shape — runtime-check the value
+    const isShape = (v: unknown): v is Shape =>
+      typeof v === 'object' && v !== null && typeof (v as Shape).foo === 'number';
+    const parsed = tryParseJson('{"foo":7}', isShape);
     expect(parsed?.foo).toBe(7);
+  });
+
+  it('returns null when the validator rejects the parsed value', () => {
+    interface Shape { foo: number }
+    const isShape = (v: unknown): v is Shape =>
+      typeof v === 'object' && v !== null && typeof (v as Shape).foo === 'number';
+    expect(tryParseJson('{"foo":"not-a-number"}', isShape)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

**Bundle E — final bundle of the pre-0.21.0 quality pass.** The broad-but-mostly-mechanical cleanup sweep from the [`/ce-review` of `myco/v0.20.2..HEAD`](../../docs/superpowers/plans/2026-04-18-pre-0.21.0-quality-pass.md). 33 findings addressed across 8 themes; 2 structural refactors deferred to follow-up issues. After this lands, `myco/v0.21.0` is tag-ready.

## What changed (by theme)

**Dead code + imports (8 items)** — removed `CostProviderCapabilities` + `CAPABILITIES_*` constants, `UNAVAILABLE_PROVIDER_RULES`, dead `countExactToolCallsByRun`, `RunCompletion` alias, `RuntimeFactoryContext` indirection, dead `buildPromptContext` stub, `InjectedContext.brief` unused field; imported `DEFAULT_AGENT_ID` from `@myco/constants` instead of local const.

**Type safety (6 items)** — `tryParseJson<T>` now takes an optional validator predicate (callers that don't pass one get `unknown` forcing narrowing); `LocalMcpTool.inputSchema: AnyZodRawShape | undefined` with the dead JSON-schema branch removed; `getAgentRuntime` switch with exhaustive `never` check on unknown `RuntimeId`; narrowing helpers `toCostSourceOrNull` / `toReasoningLevelOrNull` / `parseRuntimeId` / `parseProviderType` replace blanket `as EnumUnion` casts at DB and UI boundaries; type-predicate filter in `summarizePhaseCosts` drops the `costData!` non-null assertions.

**API contract (8 items)** — `operating_brief_* → cortex_enabled` migration via `z.preprocess` + once-per-load deprecation warning in `config/loader.ts`; new `errorBody({code, message})` envelope helper applied to 5 new-route call sites (`/api/cortex/instructions/refresh`, `/api/cortex/prompt-builder/:runId`, `/api/mcp/plans`, `DELETE /api/plans/:id`); `X-Myco-Api-Version` response header + `GET /api/version` endpoint + UI warn-on-mismatch via Vite `__MYCO_UI_VERSION__` define; `POST /api/cortex/instructions/refresh` returns 400 (not 200) for misconfig; `GET /api/sessions/:id/plans` wraps as `{plans: [...]}`; `myco_save_plan` returns structured error envelope instead of collapsing to `null`; `ProviderTestBody` zod schema with `base_url` deprecated alias; `RunUpdate` + `UPDATE_COLUMNS` gain `instruction` / `task` fields.

**Performance (3 items)** — OpenRouter catalog fetch coalesces concurrent cold-cache callers via in-flight `Map` (prevents thundering herd when evaluation matrices finish in parallel); `listWriteIntentTools` lighter query for phase-audit hot path + `?limit=&offset=` pagination on `/api/agent/runs/:id/write-intents`; `listDigestRevisions ORDER BY created_at DESC, id DESC` aligns with the composite index's trailing column (was `ORDER BY id DESC`, wasted the index's sort).

**Maintainability (3 items; 2 deferred)** — `composeSessionStartContext` helper dedups brief+digest composition between daemon route and degraded-mode injector (one source of truth for the `## Preferred Digest (Tier N)` heading); `gateEventByCaptureRules` helper dedups capture-rule gating between `event-dispatch` and `stop-processing`; `resolvePhaseExecution` precedence moved from prose-doc to a `firstDefined` chain of lookups. **Deferred:** #31 Cortex 6-module split → issue #105; #32 full phase-loop extraction → issue #106 (prompt-composition extracted; executor.ts down from 1275 to 1209 lines).

**Correctness (2 items)** — `ClaudeSdkRuntime` now reports `requests: turnsUsed` (was pinned to 0/1 regardless of multi-turn runs); `droppedSessions` cache re-evaluates when a previously-dropped session newly carries a transcript_path, closing the late-transcript re-registration path from PR #87.

**Reliability (1 item)** — `TokenBudgetStatus` renamed `'critical' → 'post_run_pressure'` with JSDoc explaining the status is observability-only (does not abort). Misleading name rotted; rename fixes the contract.

**Tests (5 new / extended)** — table-driven `resolveInstructionDelivery` coverage (4 branches); new `tests/symbionts/injection-support.test.ts` with `EXPECTED_SUPPORT` map for all built-in symbionts + anti-drift `hook session-start` → `supportsSessionStartInjection=true`; new `tests/context/session-start-digest.test.ts` covering fallback-tier branches; new `tests/daemon/api/run-serializer.test.ts` covering malformed-JSON poison rows; extended `tests/plans/identity.test.ts` with Windows separators + project-root-escaping paths.

## Test plan

- [x] `make build` — all packages + UI bundle
- [x] `make check` — **2989 passed, 3 skipped, 0 failed** (+23 new vs baseline)
- [x] Three commits on this branch; will squash-merge.

## Deferred to follow-ups

- **#105** — `refactor(cortex): consolidate 6-module Cortex concept split`
- **#106** — `refactor(agent): extract phase-loop from executor.ts (complete #32)`

## Pipeline

Implementer (DONE_WITH_CONCERNS, 2 deferrals) → spec review (❌ caught #41 which implementer had declared "already satisfied") → one-line fix for #41 → code quality review (⚠️ approved with 4 minors, all addressed) → final minor-fixes commit. Three commits; squash-merge.

## Release gate

This is the **last bundle of the pre-0.21.0 quality pass**. Ready to tag `myco/v0.21.0` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)