### PR TITLE
daemon-client+test: propagate error bodies + cover module-unavailable branch

### DIFF
--- a/packages/myco/src/daemon/trigger-cortex-instructions.ts
+++ b/packages/myco/src/daemon/trigger-cortex-instructions.ts
@@ -24,6 +24,12 @@ export interface TriggerCortexInstructionsDeps {
   getTeamClient?: () => TeamSyncClient | null;
   /** Optional registry that tracks the fire-and-forget run so daemon shutdown can await it. */
   registerInflightRun?: (promise: Promise<unknown>) => void;
+  /**
+   * Dynamic import seam for the agent executor. Defaults to the real import
+   * so tests can force the module-unavailable branch without monkey-patching
+   * the module system.
+   */
+  loadExecutor?: () => Promise<typeof import('../agent/executor.js')>;
 }
 
 export interface TriggerCortexInstructionsResult {
@@ -41,6 +47,7 @@ export async function triggerCortexInstructions(
   deps: TriggerCortexInstructionsDeps,
 ): Promise<TriggerCortexInstructionsResult> {
   const { vaultDir, embeddingManager, liveConfig, logger, getTeamClient } = deps;
+  const loadExecutor = deps.loadExecutor ?? (() => import('../agent/executor.js'));
   const config = liveConfig.current;
 
   if (config.agent.event_tasks_enabled === false) {
@@ -52,7 +59,7 @@ export async function triggerCortexInstructions(
 
   let runAgentFn: typeof import('../agent/executor.js').runAgent;
   try {
-    ({ runAgent: runAgentFn } = await import('../agent/executor.js'));
+    ({ runAgent: runAgentFn } = await loadExecutor());
   } catch (err) {
     logger.warn(LOG_KINDS.AGENT_ERROR, 'cortex-instructions: agent module unavailable', {
       error: String(err),

--- a/packages/myco/src/hooks/client.ts
+++ b/packages/myco/src/hooks/client.ts
@@ -28,6 +28,20 @@ interface ClientResult {
   data?: any;
 }
 
+/**
+ * Attempt to parse a non-ok response body as JSON so callers can surface
+ * the daemon's structured error envelope (e.g. `{error: {code, message}}`).
+ * Returns `undefined` if the body is empty, not JSON, or otherwise fails to
+ * parse — callers that ignore `data` on failure still work unchanged.
+ */
+async function parseErrorBody(res: Response): Promise<unknown> {
+  try {
+    return await res.json();
+  } catch {
+    return undefined;
+  }
+}
+
 export class DaemonClient {
   private vaultDir: string;
 
@@ -47,7 +61,7 @@ export class DaemonClient {
         signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
       });
 
-      if (!res.ok) return { ok: false };
+      if (!res.ok) return { ok: false, data: await parseErrorBody(res) };
       const data = await res.json();
       return { ok: true, data };
     } catch {
@@ -67,7 +81,7 @@ export class DaemonClient {
         signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
       });
 
-      if (!res.ok) return { ok: false };
+      if (!res.ok) return { ok: false, data: await parseErrorBody(res) };
       const data = await res.json();
       return { ok: true, data };
     } catch {
@@ -84,7 +98,7 @@ export class DaemonClient {
         signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
       });
 
-      if (!res.ok) return { ok: false };
+      if (!res.ok) return { ok: false, data: await parseErrorBody(res) };
       const data = await res.json();
       return { ok: true, data };
     } catch {
@@ -108,15 +122,7 @@ export class DaemonClient {
 
       const res = await fetch(`http://127.0.0.1:${info.port}${endpoint}`, init);
 
-      if (!res.ok) {
-        // Attempt to parse JSON error body so callers (e.g. the myco_plans
-        // delete path) can surface daemon guidance like the force_remote hint.
-        // post/put/get currently discard error bodies — see note on the DELETE
-        // flow in packages/myco/src/mcp/tools/plans.ts. Expanding the pattern
-        // to those methods is a separate follow-up.
-        const body = await res.json().catch(() => undefined);
-        return { ok: false, data: body };
-      }
+      if (!res.ok) return { ok: false, data: await parseErrorBody(res) };
       const data = await res.json();
       return { ok: true, data };
     } catch {

--- a/tests/daemon/trigger-cortex-instructions.test.ts
+++ b/tests/daemon/trigger-cortex-instructions.test.ts
@@ -132,6 +132,52 @@ describe('triggerCortexInstructions', () => {
     );
   });
 
+  it('returns agent-module-unavailable when loadExecutor throws (module-not-found path)', async () => {
+    const logger = makeLogger();
+    const loadExecutor = vi.fn(async () => {
+      throw new Error("Cannot find module '../agent/executor.js'");
+    });
+
+    const result = await triggerCortexInstructions({
+      vaultDir: '/tmp/myco',
+      embeddingManager: makeEmbeddingManagerStub() as never,
+      liveConfig: { current: makeConfig() },
+      logger: logger as never,
+      loadExecutor: loadExecutor as never,
+    });
+
+    expect(result.started).toBe(false);
+    expect(result.reason).toBe('agent-module-unavailable');
+    expect(result.error).toContain('Cannot find module');
+    expect(loadExecutor).toHaveBeenCalledTimes(1);
+    expect(buildCortexInstructionsInput).not.toHaveBeenCalled();
+    expect(runAgent).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'agent.error',
+      'cortex-instructions: agent module unavailable',
+      expect.objectContaining({ error: expect.stringContaining('Cannot find module') }),
+    );
+  });
+
+  it('uses the default loadExecutor (real dynamic import) when the seam is not injected', async () => {
+    // Happy path already mocks @myco/agent/executor.js at the vi.mock level;
+    // this assertion confirms the default code path is still exercised when
+    // no loadExecutor override is passed (sanity check that the seam is
+    // opt-in and backward-compatible).
+    const logger = makeLogger();
+
+    const result = await triggerCortexInstructions({
+      vaultDir: '/tmp/myco',
+      embeddingManager: makeEmbeddingManagerStub() as never,
+      liveConfig: { current: makeConfig() },
+      logger: logger as never,
+    });
+
+    expect(result.started).toBe(true);
+    expect(runAgent).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   it('registers the fire-and-forget promise with registerInflightRun when provided', async () => {
     const logger = makeLogger();
     const registerInflightRun = vi.fn();

--- a/tests/hooks/client.test.ts
+++ b/tests/hooks/client.test.ts
@@ -66,3 +66,118 @@ describe('DaemonClient', () => {
     expect(result.ok).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Error-body propagation — parseErrorBody helper applied to all four methods.
+// ---------------------------------------------------------------------------
+
+type ErrorBodyMode =
+  | { kind: 'json'; payload: unknown; status?: number }
+  | { kind: 'empty'; status?: number }
+  | { kind: 'invalid-json'; text: string; status?: number }
+  | { kind: 'text-plain'; text: string; status?: number };
+
+describe('DaemonClient error-body propagation', () => {
+  let vaultDir: string;
+  let mockServer: http.Server;
+  let mode: ErrorBodyMode;
+
+  beforeEach(async () => {
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-client-err-'));
+    mode = { kind: 'json', payload: { error: { code: 'boom', message: 'test' } } };
+
+    mockServer = http.createServer((_req, res) => {
+      const status = ('status' in mode && mode.status) || 500;
+      if (mode.kind === 'json') {
+        res.writeHead(status, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(mode.payload));
+      } else if (mode.kind === 'empty') {
+        res.writeHead(status, { 'Content-Type': 'application/json' });
+        res.end();
+      } else if (mode.kind === 'invalid-json') {
+        res.writeHead(status, { 'Content-Type': 'application/json' });
+        res.end(mode.text);
+      } else if (mode.kind === 'text-plain') {
+        res.writeHead(status, { 'Content-Type': 'text/plain' });
+        res.end(mode.text);
+      }
+    });
+
+    await new Promise<void>((resolve) => {
+      mockServer.listen(0, '127.0.0.1', () => {
+        const port = (mockServer.address() as { port: number }).port;
+        fs.writeFileSync(
+          path.join(vaultDir, 'daemon.json'),
+          JSON.stringify({ pid: process.pid, port }),
+        );
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((r) => mockServer.close(() => r()));
+    fs.rmSync(vaultDir, { recursive: true, force: true });
+  });
+
+  it('returns parsed JSON body on non-ok for post/put/get/delete', async () => {
+    const payload = { error: { code: 'plan-remote', message: 'force_remote required' } };
+    mode = { kind: 'json', payload };
+
+    const client = new DaemonClient(vaultDir);
+    const post = await client.post('/api/x', {});
+    const put = await client.put('/api/x', {});
+    const get = await client.get('/api/x');
+    const del = await client.delete('/api/x');
+
+    for (const r of [post, put, get, del]) {
+      expect(r.ok).toBe(false);
+      expect(r.data).toEqual(payload);
+    }
+  });
+
+  it('returns data: undefined on empty non-ok body for all four methods', async () => {
+    mode = { kind: 'empty' };
+    const client = new DaemonClient(vaultDir);
+
+    const post = await client.post('/api/x', {});
+    const put = await client.put('/api/x', {});
+    const get = await client.get('/api/x');
+    const del = await client.delete('/api/x');
+
+    for (const r of [post, put, get, del]) {
+      expect(r.ok).toBe(false);
+      expect(r.data).toBeUndefined();
+    }
+  });
+
+  it('returns data: undefined when the non-ok body is invalid JSON', async () => {
+    mode = { kind: 'invalid-json', text: '<<<not json>>>' };
+    const client = new DaemonClient(vaultDir);
+
+    const post = await client.post('/api/x', {});
+    const put = await client.put('/api/x', {});
+    const get = await client.get('/api/x');
+    const del = await client.delete('/api/x');
+
+    for (const r of [post, put, get, del]) {
+      expect(r.ok).toBe(false);
+      expect(r.data).toBeUndefined();
+    }
+  });
+
+  it('returns data: undefined when the non-ok body is text/plain (non-JSON)', async () => {
+    mode = { kind: 'text-plain', text: 'internal server error' };
+    const client = new DaemonClient(vaultDir);
+
+    const post = await client.post('/api/x', {});
+    const put = await client.put('/api/x', {});
+    const get = await client.get('/api/x');
+    const del = await client.delete('/api/x');
+
+    for (const r of [post, put, get, del]) {
+      expect(r.ok).toBe(false);
+      expect(r.data).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

**Bundle F — first of four v0.22 follow-up PRs.** Consolidates two small GitHub issues that came out of the pre-0.21.0 quality pass. Targets `v0.22-dev`, not `main`.

Closes #101
Closes #103

## What changed

### #101 — DaemonClient parses error bodies on all methods

Bundle D's fix-pass extended `DaemonClient.delete` to parse JSON response bodies on non-ok so the daemon's `{error: {code, message}}` envelope reaches callers. `get`, `post`, and `put` still discarded bodies. This PR extracts a `parseErrorBody(res)` helper and applies it uniformly across all four methods — every non-ok branch now returns `{ok: false, data: <body> | undefined}`.

**Caller audit:** every consumer that reads `result.data` on the non-ok path uses optional chaining (`result.data?.error`). No call sites needed updating. The `agent-tasks.ts` and `agent-eval.ts` surfaces that previously silently fell back to generic "failed" messages now surface the daemon's actual error.

### #103 — `agent-module-unavailable` branch is now testable

Bundle C wired warn-logging into `triggerCortexInstructions` with distinct reason codes (`'startup-failed'` vs `'agent-module-unavailable'`). The `startup-failed` path got coverage; `agent-module-unavailable` didn't because forcing a dynamic-import failure without monkey-patching is awkward.

This PR adds an optional `loadExecutor: () => Promise<typeof import('../agent/executor.js')>` dependency (defaulted to the current dynamic import), so tests can inject a function that throws. Two new tests:

- Injected `loadExecutor` throws → `{started: false, reason: 'agent-module-unavailable', error}` + `logger.warn` fires with `LOG_KINDS.AGENT_ERROR`
- Default seam with no override → happy path preserved (backward-compat)

## Test plan

- [x] `npm run lint -- --pretty false` — clean
- [x] Targeted: 14/14 (new client error-body suite + new trigger-cortex-instructions tests)
- [x] Full suite: **2995 passed, 3 skipped**
- [x] Review: ✅ Approved (combined spec + code-quality pass, no in-PR fixes needed)

## Pipeline

Implementer → combined review (✅ approved). One commit on this branch; will squash-merge to `v0.22-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)