### PR TITLE
mcp: add 5 follow-up tools (evaluations, write-intents, phase-audit, resume-run, digest-revisions)

### DIFF
--- a/packages/myco/src/mcp/server.ts
+++ b/packages/myco/src/mcp/server.ts
@@ -22,6 +22,11 @@ import { handleMycoSkills, handleMycoSkillCandidates } from './tools/skills.js';
 import { handleCollectiveProject, handleCollectiveProjects, handleCollectiveSearch } from './tools/collective.js';
 import { handleMycoCortex } from './tools/cortex.js';
 import { handleMycoRuns } from './tools/runs.js';
+import { handleMycoEvaluations } from './tools/evaluations.js';
+import { handleMycoWriteIntents } from './tools/write-intents.js';
+import { handleMycoPhaseAudit } from './tools/phase-audit.js';
+import { handleMycoResumeRun } from './tools/resume-run.js';
+import { handleMycoDigestRevisions } from './tools/digest-revisions.js';
 import { resolveVaultDir } from '../vault/resolve.js';
 import { DaemonClient } from '../hooks/client.js';
 import { DAEMON_CLIENT_TIMEOUT_MS } from '../constants.js';
@@ -33,6 +38,7 @@ import {
   TOOL_CONTEXT, TOOL_SKILLS, TOOL_SKILL_CANDIDATES,
   TOOL_COLLECTIVE_SEARCH, TOOL_COLLECTIVE_PROJECTS, TOOL_COLLECTIVE_PROJECT,
   TOOL_CORTEX, TOOL_RUNS,
+  TOOL_EVALUATIONS, TOOL_WRITE_INTENTS, TOOL_PHASE_AUDIT, TOOL_RESUME_RUN, TOOL_DIGEST_REVISIONS,
   COLLECTIVE_TOOL_DEFINITIONS,
 } from './tool-definitions.js';
 
@@ -258,6 +264,68 @@ export function createMycoServer(vaultDir: string, client: DaemonClient): MycoSe
         logActivity(TOOL_RUNS, {
           op: runsInput.op ?? 'list',
           id: runsInput.id,
+          ok: result.ok,
+          duration_ms: Date.now() - start,
+        });
+        return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+      }
+      case TOOL_EVALUATIONS: {
+        const evalInput = input as {
+          op?: 'list' | 'get' | 'create';
+          status?: string;
+          limit?: number;
+          id?: string;
+          task_id?: string;
+          matrix?: unknown;
+          notes?: string;
+        };
+        const result = await handleMycoEvaluations(evalInput, client);
+        logActivity(TOOL_EVALUATIONS, {
+          op: evalInput.op ?? 'list',
+          id: evalInput.id,
+          task_id: evalInput.task_id,
+          ok: result.ok,
+          duration_ms: Date.now() - start,
+        });
+        return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+      }
+      case TOOL_WRITE_INTENTS: {
+        const wiInput = input as { run_id: string; limit?: number; offset?: number };
+        const result = await handleMycoWriteIntents(wiInput, client);
+        logActivity(TOOL_WRITE_INTENTS, {
+          run_id: wiInput.run_id,
+          ok: result.ok,
+          duration_ms: Date.now() - start,
+        });
+        return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+      }
+      case TOOL_PHASE_AUDIT: {
+        const auditInput = input as { run_id: string };
+        const result = await handleMycoPhaseAudit(auditInput, client);
+        logActivity(TOOL_PHASE_AUDIT, {
+          run_id: auditInput.run_id,
+          ok: result.ok,
+          duration_ms: Date.now() - start,
+        });
+        return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+      }
+      case TOOL_RESUME_RUN: {
+        const resumeInput = input as { id: string; mode?: 'manual' | 'scheduled' };
+        const result = await handleMycoResumeRun(resumeInput, client);
+        logActivity(TOOL_RESUME_RUN, {
+          id: resumeInput.id,
+          mode: resumeInput.mode,
+          ok: result.ok,
+          duration_ms: Date.now() - start,
+        });
+        return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+      }
+      case TOOL_DIGEST_REVISIONS: {
+        const drInput = input as { agent_id?: string; tier?: number; limit?: number };
+        const result = await handleMycoDigestRevisions(drInput, client);
+        logActivity(TOOL_DIGEST_REVISIONS, {
+          agent_id: drInput.agent_id,
+          tier: drInput.tier,
           ok: result.ok,
           duration_ms: Date.now() - start,
         });

--- a/packages/myco/src/mcp/tool-definitions.ts
+++ b/packages/myco/src/mcp/tool-definitions.ts
@@ -80,6 +80,11 @@ export const TOOL_COLLECTIVE_PROJECTS = 'collective_projects';
 export const TOOL_COLLECTIVE_PROJECT = 'collective_project';
 export const TOOL_CORTEX = 'myco_cortex';
 export const TOOL_RUNS = 'myco_runs';
+export const TOOL_EVALUATIONS = 'myco_evaluations';
+export const TOOL_WRITE_INTENTS = 'myco_write_intents';
+export const TOOL_PHASE_AUDIT = 'myco_phase_audit';
+export const TOOL_RESUME_RUN = 'myco_resume_run';
+export const TOOL_DIGEST_REVISIONS = 'myco_digest_revisions';
 
 // --- Shared property descriptions (used by multiple tools) ---
 const PROP_BRANCH = 'Git branch name to find related sessions and plans';
@@ -362,6 +367,129 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
         agent_id: { type: 'string', description: 'Filter op: "list" by agent id' },
         limit: { type: 'number', description: 'Max results for op: "list" (default: 50)' },
       },
+    },
+  },
+  {
+    name: TOOL_EVALUATIONS,
+    description: 'Create, list, or fetch agent evaluations. An evaluation fans out a single task across a cartesian product of (runtime × reasoning × model) cells so outputs can be compared side by side. op: "list" (default) returns newest-first summaries with an optional limit. op: "get" with id returns the evaluation + child runs + aggregate stats. op: "create" requires task_id and matrix; cells execute sequentially in the background — the response returns the evaluationId + cellCount. op: "create" is NOT read-only; it starts background runs.',
+    annotations: {
+      // Mixed ops: list/get are read-only, create kicks off background runs.
+      // Mark conservatively so clients confirm before auto-running with op: "create".
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    cortex: {
+      guidance: 'Use op: "list" to see recent matrix evaluations, op: "get" to inspect cells + aggregate stats, and op: "create" to fan a task out across runtime/reasoning/model cells for side-by-side comparison.',
+      priority: 88,
+    },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        op: { type: 'string', enum: ['list', 'get', 'create'], description: 'Operation (default: "list")' },
+        status: { type: 'string', description: 'Filter op: "list" by status (reserved; currently ignored by the route)' },
+        limit: { type: 'number', description: 'Max results for op: "list" (default: 50)' },
+        id: { type: 'string', description: 'Required for op: "get" — the evaluation id' },
+        task_id: { type: 'string', description: 'Required for op: "create" — id of the agent task to evaluate' },
+        matrix: {
+          type: 'object',
+          description: 'Required for op: "create". Matrix payload: { runtimes?, reasoningLevels?, models?, dryRun?, notes?, phases? }. Empty arrays expand to defaults. See /api/agent/evaluations POST body for full shape.',
+        },
+        notes: { type: 'string', description: 'Optional notes stored alongside the evaluation row (op: "create" only)' },
+      },
+    },
+  },
+  {
+    name: TOOL_WRITE_INTENTS,
+    description: 'Inspect the write-intents recorded during a dry-run — what the agent would have done (tool_name, tool_input, synthetic_output) without actually writing. Paginated via limit (default 500, max 5000) and offset. Use with myco_runs to verify safety before re-running the same task without dry_run.',
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    cortex: {
+      guidance: 'Use after a dry-run to inspect what writes the agent would have performed — close the "dry-run → verify → real-run" loop before repeating the task without dry_run.',
+      priority: 86,
+    },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        run_id: { type: 'string', description: 'The run id whose write-intents you want to inspect' },
+        limit: { type: 'number', description: 'Max results (default: 500, max: 5000)' },
+        offset: { type: 'number', description: 'Pagination offset (default: 0)' },
+      },
+      required: ['run_id'],
+    },
+  },
+  {
+    name: TOOL_PHASE_AUDIT,
+    description: 'Read the per-phase audit trail for an agent run — what each phase did, its cost, tool-call counts, reasoning level, and any write intents. Returns a joined view over agent_runs, agent_reports, agent_turns, usage_data, checkpoints, and (for dry runs) agent_run_write_intents. Essential for debugging a failed or mis-executing run.',
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    cortex: {
+      guidance: 'Use when debugging a failed or mis-executing run — returns the per-phase cost, tool counts, reasoning level, and write intents in one payload.',
+      priority: 87,
+    },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        run_id: { type: 'string', description: 'The run id whose phase audit you want to inspect' },
+      },
+      required: ['run_id'],
+    },
+  },
+  {
+    name: TOOL_RESUME_RUN,
+    description: 'Resume a paused or interrupted agent run. The run must be in a resumable state (resumable=1 AND status="failed" per the route) — check status via myco_runs first. The resume starts a new background phase and returns immediately with {ok, message, runId}. NOT idempotent: each successful call starts a fresh phase.',
+    annotations: {
+      // Starts a new background phase; mark as mutating + non-idempotent so
+      // clients confirm before repeating. Not "destructive" (no data is
+      // removed) but also not "read-only".
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    cortex: {
+      guidance: 'Use to resume a paused or interrupted agent run after verifying (via myco_runs) that its resumable flag is set and its status is "failed".',
+      priority: 89,
+    },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        id: { type: 'string', description: 'The run id to resume' },
+        mode: { type: 'string', enum: ['manual', 'scheduled'], description: 'Resume mode (default: "manual"). Scheduled is reserved for the daemon scheduler.' },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: TOOL_DIGEST_REVISIONS,
+    description: 'List historical digest revisions for the given (agent_id, tier). Revisions are append-only, so this surface shows how the project\'s digest has evolved over time. tier is required; agent_id defaults to the primary agent on the daemon side. Restore (rolling a past revision back into the live digest) is intentionally UI-only and is NOT exposed via MCP.',
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    cortex: {
+      guidance: 'Use to see how the project digest has evolved for a given tier — restore is UI-only.',
+      priority: 92,
+    },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        agent_id: { type: 'string', description: 'Optional — defaults to the primary agent on the daemon side' },
+        tier: { type: 'number', description: 'Required — the digest tier (for example 1500, 5000, 10000)' },
+        limit: { type: 'number', description: 'Max results (default: 50)' },
+      },
+      required: ['tier'],
     },
   },
 ];

--- a/packages/myco/src/mcp/tools/digest-revisions.ts
+++ b/packages/myco/src/mcp/tools/digest-revisions.ts
@@ -1,0 +1,63 @@
+/**
+ * myco_digest_revisions — list historical digest revisions.
+ *
+ * Mirrors GET /api/digest/revisions. The revision log is scoped per
+ * (agent, tier); `tier` is required by the daemon route. Restore
+ * (POST /api/digest/revisions/:id/restore) is intentionally UI-only and
+ * NOT exposed via MCP.
+ *
+ * Proxies through the daemon HTTP API via DaemonClient.
+ */
+
+import type { DaemonClient } from '@myco/hooks/client.js';
+import { buildEndpoint } from './shared.js';
+import { extractErrorMessage } from './error.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DigestRevisionsInput {
+  /** Optional; the daemon route defaults to DEFAULT_AGENT_ID ('myco-agent'). */
+  agent_id?: string;
+  /**
+   * Required by the daemon route — passing an unset tier returns a 400.
+   * Kept optional on the input type so zod surfaces the error at parse
+   * time with a consistent message.
+   */
+  tier?: number;
+  limit?: number;
+}
+
+export interface DigestRevisionsHandlerResult {
+  ok: boolean;
+  data?: unknown;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export async function handleMycoDigestRevisions(
+  input: DigestRevisionsInput,
+  client: DaemonClient,
+): Promise<DigestRevisionsHandlerResult> {
+  if (input.tier === undefined || input.tier === null) {
+    return { ok: false, error: 'tier is required' };
+  }
+
+  const endpoint = buildEndpoint('/api/digest/revisions', {
+    agentId: input.agent_id,
+    tier: input.tier,
+    limit: input.limit,
+  });
+  const result = await client.get(endpoint);
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: extractErrorMessage(result.data, 'fetch_failed'),
+    };
+  }
+  return { ok: true, data: result.data };
+}

--- a/packages/myco/src/mcp/tools/error.ts
+++ b/packages/myco/src/mcp/tools/error.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared helpers for extracting error messages from DaemonClient failure
+ * responses. Thanks to DaemonClient.parseErrorBody (Bundle F), the daemon's
+ * structured error envelope rides on `result.data` even when `result.ok` is
+ * false — callers just need to normalize the handful of shapes we emit:
+ *
+ *   - undefined               → no body parsed (timeout, daemon unreachable)
+ *   - 'plain message'         → legacy routes
+ *   - { error: 'msg' }        → legacy routes that wrap strings
+ *   - { error: { message } }  → errorBody() canonical envelope
+ */
+
+export function extractErrorMessage(data: unknown, fallback: string): string {
+  if (typeof data === 'string') return data;
+  if (typeof data !== 'object' || data === null) return fallback;
+
+  const rawError = (data as { error?: unknown }).error;
+  if (typeof rawError === 'string') return rawError;
+  if (
+    typeof rawError === 'object'
+    && rawError !== null
+    && 'message' in rawError
+    && typeof (rawError as { message: unknown }).message === 'string'
+  ) {
+    return (rawError as { message: string }).message;
+  }
+
+  return fallback;
+}

--- a/packages/myco/src/mcp/tools/evaluations.ts
+++ b/packages/myco/src/mcp/tools/evaluations.ts
@@ -1,0 +1,108 @@
+/**
+ * myco_evaluations — agent evaluation (matrix) read + create surface.
+ *
+ * Mirrors /api/agent/evaluations so agents can:
+ *   - list recent evaluations (newest-first, paginated)
+ *   - fetch one evaluation with its child runs + aggregate
+ *   - create a new evaluation that fans out a single task across a matrix
+ *     of (runtime × reasoning × model) cells
+ *
+ * Proxies through the daemon HTTP API via DaemonClient.
+ */
+
+import type { DaemonClient } from '@myco/hooks/client.js';
+import { buildEndpoint } from './shared.js';
+import { extractErrorMessage } from './error.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type EvaluationsOp = 'list' | 'get' | 'create';
+
+export interface EvaluationsInput {
+  op?: EvaluationsOp;
+  // list filters
+  status?: string;
+  limit?: number;
+  // get
+  id?: string;
+  // create
+  task_id?: string;
+  matrix?: unknown;
+  notes?: string;
+}
+
+export interface EvaluationsHandlerResult {
+  ok: boolean;
+  op: EvaluationsOp;
+  data?: unknown;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export async function handleMycoEvaluations(
+  input: EvaluationsInput,
+  client: DaemonClient,
+): Promise<EvaluationsHandlerResult> {
+  const op = input.op ?? 'list';
+
+  if (op === 'get') {
+    if (!input.id) {
+      return { ok: false, op, error: 'id is required for op: get' };
+    }
+    const result = await client.get(
+      `/api/agent/evaluations/${encodeURIComponent(input.id)}`,
+    );
+    if (!result.ok) {
+      return {
+        ok: false,
+        op,
+        error: extractErrorMessage(result.data, 'not_found'),
+      };
+    }
+    return { ok: true, op, data: result.data };
+  }
+
+  if (op === 'create') {
+    if (!input.task_id) {
+      return { ok: false, op, error: 'task_id is required for op: create' };
+    }
+    if (input.matrix === undefined || input.matrix === null) {
+      return { ok: false, op, error: 'matrix is required for op: create' };
+    }
+    const body: Record<string, unknown> = {
+      taskId: input.task_id,
+      matrix: input.matrix,
+    };
+    if (input.notes !== undefined) body.notes = input.notes;
+
+    const result = await client.post('/api/agent/evaluations', body);
+    if (!result.ok) {
+      return {
+        ok: false,
+        op,
+        error: extractErrorMessage(result.data, 'create_failed'),
+      };
+    }
+    return { ok: true, op, data: result.data };
+  }
+
+  // op === 'list'
+  const endpoint = buildEndpoint('/api/agent/evaluations', {
+    status: input.status,
+    limit: input.limit,
+  });
+  const result = await client.get(endpoint);
+  if (!result.ok) {
+    return {
+      ok: false,
+      op,
+      error: extractErrorMessage(result.data, 'fetch_failed'),
+    };
+  }
+  return { ok: true, op, data: result.data };
+}

--- a/packages/myco/src/mcp/tools/phase-audit.ts
+++ b/packages/myco/src/mcp/tools/phase-audit.ts
@@ -1,0 +1,50 @@
+/**
+ * myco_phase_audit — read the per-phase audit trail for an agent run.
+ *
+ * Mirrors GET /api/agent/runs/:id/audit. Returns a joined view over
+ * agent_runs, agent_reports, agent_turns, usage_data, checkpoints, and
+ * (for dry runs) agent_run_write_intents.
+ *
+ * Proxies through the daemon HTTP API via DaemonClient.
+ */
+
+import type { DaemonClient } from '@myco/hooks/client.js';
+import { extractErrorMessage } from './error.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PhaseAuditInput {
+  run_id: string;
+}
+
+export interface PhaseAuditHandlerResult {
+  ok: boolean;
+  data?: unknown;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export async function handleMycoPhaseAudit(
+  input: PhaseAuditInput,
+  client: DaemonClient,
+): Promise<PhaseAuditHandlerResult> {
+  if (!input.run_id) {
+    return { ok: false, error: 'run_id is required' };
+  }
+
+  const result = await client.get(
+    `/api/agent/runs/${encodeURIComponent(input.run_id)}/audit`,
+  );
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: extractErrorMessage(result.data, 'not_found'),
+    };
+  }
+  return { ok: true, data: result.data };
+}

--- a/packages/myco/src/mcp/tools/plans.ts
+++ b/packages/myco/src/mcp/tools/plans.ts
@@ -9,6 +9,7 @@
  */
 
 import type { DaemonClient } from '@myco/hooks/client.js';
+import { extractErrorMessage } from './error.js';
 import { buildEndpoint } from './shared.js';
 
 // ---------------------------------------------------------------------------
@@ -68,13 +69,7 @@ export async function handleMycoPlans(
     const body = input.force_remote ? { force_remote: true } : undefined;
     const result = await client.delete(`/api/plans/${encodeURIComponent(input.id)}`, body);
     if (!result.ok) {
-      const rawError = result.data?.error;
-      const message = typeof rawError === 'string'
-        ? rawError
-        : typeof rawError === 'object' && rawError !== null && 'message' in rawError
-          ? String((rawError as { message: unknown }).message)
-          : 'delete_failed';
-      return { ok: false, error: message };
+      return { ok: false, error: extractErrorMessage(result.data, 'delete_failed') };
     }
     return {
       ok: Boolean(result.data?.ok),

--- a/packages/myco/src/mcp/tools/resume-run.ts
+++ b/packages/myco/src/mcp/tools/resume-run.ts
@@ -1,0 +1,60 @@
+/**
+ * myco_resume_run — resume a paused or interrupted agent run.
+ *
+ * Mirrors POST /api/agent/runs/:id/resume. The run must be in a resumable
+ * state (`resumable=1` AND `status='failed'` per the route); check status
+ * via myco_runs first.
+ *
+ * NOT read-only. NOT idempotent — each call starts a new background phase
+ * if the run is still resumable.
+ *
+ * Proxies through the daemon HTTP API via DaemonClient.
+ */
+
+import type { DaemonClient } from '@myco/hooks/client.js';
+import { extractErrorMessage } from './error.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ResumeRunMode = 'manual' | 'scheduled';
+
+export interface ResumeRunInput {
+  id: string;
+  mode?: ResumeRunMode;
+}
+
+export interface ResumeRunHandlerResult {
+  ok: boolean;
+  data?: unknown;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export async function handleMycoResumeRun(
+  input: ResumeRunInput,
+  client: DaemonClient,
+): Promise<ResumeRunHandlerResult> {
+  if (!input.id) {
+    return { ok: false, error: 'id is required' };
+  }
+
+  const body: Record<string, unknown> = {};
+  if (input.mode) body.mode = input.mode;
+
+  const result = await client.post(
+    `/api/agent/runs/${encodeURIComponent(input.id)}/resume`,
+    body,
+  );
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: extractErrorMessage(result.data, 'resume_failed'),
+    };
+  }
+  return { ok: true, data: result.data };
+}

--- a/packages/myco/src/mcp/tools/write-intents.ts
+++ b/packages/myco/src/mcp/tools/write-intents.ts
@@ -1,0 +1,55 @@
+/**
+ * myco_write_intents — inspect the writes a dry-run agent would have
+ * performed but skipped.
+ *
+ * Mirrors GET /api/agent/runs/:id/write-intents. Use with myco_runs to verify
+ * safety before re-running a task without dry_run.
+ *
+ * Proxies through the daemon HTTP API via DaemonClient.
+ */
+
+import type { DaemonClient } from '@myco/hooks/client.js';
+import { buildEndpoint } from './shared.js';
+import { extractErrorMessage } from './error.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WriteIntentsInput {
+  run_id: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface WriteIntentsHandlerResult {
+  ok: boolean;
+  data?: unknown;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export async function handleMycoWriteIntents(
+  input: WriteIntentsInput,
+  client: DaemonClient,
+): Promise<WriteIntentsHandlerResult> {
+  if (!input.run_id) {
+    return { ok: false, error: 'run_id is required' };
+  }
+
+  const endpoint = buildEndpoint(
+    `/api/agent/runs/${encodeURIComponent(input.run_id)}/write-intents`,
+    { limit: input.limit, offset: input.offset },
+  );
+  const result = await client.get(endpoint);
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: extractErrorMessage(result.data, 'fetch_failed'),
+    };
+  }
+  return { ok: true, data: result.data };
+}

--- a/tests/context/cortex-brief.test.ts
+++ b/tests/context/cortex-brief.test.ts
@@ -65,6 +65,33 @@ describe('RETRIEVAL_GUIDANCE', () => {
     expect(body).toContain('`myco_cortex`');
     expect(body).toContain('`myco_runs`');
   });
+
+  // Anti-drift for Bundle G (post-0.21 follow-ups). Every new MCP surface
+  // must show up in the Cortex brief by name — if a future refactor strips
+  // any tool's `cortex` entry, agents would silently lose the session-start
+  // guidance that tells them what the tool is for.
+  it('includes every Bundle G tool by name', () => {
+    const names = RETRIEVAL_GUIDANCE.map((entry) => entry.tool);
+    expect(names).toContain('myco_evaluations');
+    expect(names).toContain('myco_write_intents');
+    expect(names).toContain('myco_phase_audit');
+    expect(names).toContain('myco_resume_run');
+    expect(names).toContain('myco_digest_revisions');
+  });
+
+  it('injects Bundle G tool guidance into the brief body', () => {
+    const lines = buildRetrievalGuidanceLines({
+      teamEnabled: false,
+      collectiveConnected: false,
+      collectiveCapabilities: [],
+    });
+    const body = lines.join('\n');
+    expect(body).toContain('`myco_evaluations`');
+    expect(body).toContain('`myco_write_intents`');
+    expect(body).toContain('`myco_phase_audit`');
+    expect(body).toContain('`myco_resume_run`');
+    expect(body).toContain('`myco_digest_revisions`');
+  });
 });
 
 describe('resolveInstructionDelivery', () => {

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -18,7 +18,7 @@ describe('MCP Server', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('registers all 15 core tools', () => {
+  it('registers all 20 core tools', () => {
     const server = createMycoServer(tmpDir, client);
     const tools = server.getRegisteredTools();
     expect(tools).toContain('myco_search');
@@ -37,7 +37,13 @@ describe('MCP Server', () => {
     // Bundle D additions (pre-0.21.0 agent-native MCP parity).
     expect(tools).toContain('myco_cortex');
     expect(tools).toContain('myco_runs');
-    expect(tools).toHaveLength(15);
+    // Bundle G additions (post-0.21.0 follow-ups — #95..#99).
+    expect(tools).toContain('myco_evaluations');
+    expect(tools).toContain('myco_write_intents');
+    expect(tools).toContain('myco_phase_audit');
+    expect(tools).toContain('myco_resume_run');
+    expect(tools).toContain('myco_digest_revisions');
+    expect(tools).toHaveLength(20);
   });
 
   it('does not leak collective tools into the core registration', () => {

--- a/tests/mcp/tool-definitions.test.ts
+++ b/tests/mcp/tool-definitions.test.ts
@@ -121,9 +121,14 @@ describe('TOOL_DEFINITIONS registration coverage', () => {
   // Bundle D harness-properties discipline: every Bundle D tool (and any tool
   // that carries annotations) must set all four MCP annotation fields so
   // clients can render the correct confirmation UI. Missing any one of these
-  // is a regression.
-  it('Bundle D tools declare full MCP annotations', () => {
-    const required = ['myco_cortex', 'myco_plans', 'myco_runs'];
+  // is a regression. Bundle G extended the list with five new tools; they
+  // share the same discipline.
+  it('Bundle D + G tools declare full MCP annotations', () => {
+    const required = [
+      'myco_cortex', 'myco_plans', 'myco_runs',
+      'myco_evaluations', 'myco_write_intents', 'myco_phase_audit',
+      'myco_resume_run', 'myco_digest_revisions',
+    ];
     for (const name of required) {
       const tool = TOOL_DEFINITIONS.find((t) => t.name === name);
       expect(tool, `Tool ${name} missing from TOOL_DEFINITIONS`).toBeDefined();
@@ -170,6 +175,55 @@ describe('TOOL_DEFINITIONS registration coverage', () => {
     expect(plans?.annotations?.destructiveHint).toBe(true);
     expect(plans?.annotations?.idempotentHint).toBe(true);
     expect(plans?.annotations?.openWorldHint).toBe(false);
+  });
+
+  // Bundle G tools — 5 new MCP surfaces. Each annotation set is pinned
+  // so a silent flip (e.g. someone marking op: "create" as read-only)
+  // would fail the suite.
+  it('myco_evaluations annotations are pinned (mixed ops — conservative)', () => {
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'myco_evaluations');
+    // list/get are read-only, create starts background runs — mark
+    // conservatively so clients confirm before auto-running create.
+    expect(tool?.annotations?.readOnlyHint).toBe(false);
+    expect(tool?.annotations?.destructiveHint).toBe(false);
+    expect(tool?.annotations?.idempotentHint).toBe(false);
+    expect(tool?.annotations?.openWorldHint).toBe(false);
+  });
+
+  it('myco_write_intents annotations are pinned (read-only, idempotent, local)', () => {
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'myco_write_intents');
+    expect(tool?.annotations?.readOnlyHint).toBe(true);
+    expect(tool?.annotations?.destructiveHint).toBe(false);
+    expect(tool?.annotations?.idempotentHint).toBe(true);
+    expect(tool?.annotations?.openWorldHint).toBe(false);
+  });
+
+  it('myco_phase_audit annotations are pinned (read-only, idempotent, local)', () => {
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'myco_phase_audit');
+    expect(tool?.annotations?.readOnlyHint).toBe(true);
+    expect(tool?.annotations?.destructiveHint).toBe(false);
+    expect(tool?.annotations?.idempotentHint).toBe(true);
+    expect(tool?.annotations?.openWorldHint).toBe(false);
+  });
+
+  it('myco_resume_run annotations are pinned (mutating, non-idempotent, local)', () => {
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'myco_resume_run');
+    // Starts a new background phase; not destructive (no data removed)
+    // but also not read-only. Each call starts a fresh phase if the run
+    // is still resumable, so idempotentHint is false.
+    expect(tool?.annotations?.readOnlyHint).toBe(false);
+    expect(tool?.annotations?.destructiveHint).toBe(false);
+    expect(tool?.annotations?.idempotentHint).toBe(false);
+    expect(tool?.annotations?.openWorldHint).toBe(false);
+  });
+
+  it('myco_digest_revisions annotations are pinned (read-only, idempotent, local)', () => {
+    const tool = TOOL_DEFINITIONS.find((t) => t.name === 'myco_digest_revisions');
+    // List-only MCP surface — restore stays UI-only per policy.
+    expect(tool?.annotations?.readOnlyHint).toBe(true);
+    expect(tool?.annotations?.destructiveHint).toBe(false);
+    expect(tool?.annotations?.idempotentHint).toBe(true);
+    expect(tool?.annotations?.openWorldHint).toBe(false);
   });
 });
 

--- a/tests/mcp/tools/digest-revisions.test.ts
+++ b/tests/mcp/tools/digest-revisions.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for myco_digest_revisions tool handler.
+ *
+ * Mirrors GET /api/digest/revisions. Adapter-layer only (restore is UI-only
+ * and intentionally NOT exposed through this tool).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { handleMycoDigestRevisions } from '@myco/mcp/tools/digest-revisions.js';
+import type { DaemonClient } from '@myco/hooks/client.js';
+
+function mockClient(data: unknown = null, ok = true): DaemonClient {
+  return {
+    get: vi.fn().mockResolvedValue({ ok, data }),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as DaemonClient;
+}
+
+describe('myco_digest_revisions', () => {
+  it('requires tier (the daemon route 400s without it)', async () => {
+    const client = mockClient({});
+    const result = await handleMycoDigestRevisions({}, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/tier/);
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('GETs /api/digest/revisions with tier', async () => {
+    const payload = { revisions: [{ id: 7, agent_id: 'myco-agent', tier: 5000, content: '...' }], count: 1 };
+    const client = mockClient(payload);
+    const result = await handleMycoDigestRevisions({ tier: 5000 }, client);
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual(payload);
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    expect(url).toContain('/api/digest/revisions');
+    expect(url).toContain('tier=5000');
+  });
+
+  it('forwards agent_id as agentId to the route', async () => {
+    const client = mockClient({ revisions: [], count: 0 });
+    await handleMycoDigestRevisions({ agent_id: 'review-agent', tier: 1500 }, client);
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    expect(url).toContain('agentId=review-agent');
+    expect(url).toContain('tier=1500');
+  });
+
+  it('forwards limit', async () => {
+    const client = mockClient({ revisions: [], count: 0 });
+    await handleMycoDigestRevisions({ tier: 5000, limit: 10 }, client);
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    expect(url).toContain('limit=10');
+  });
+
+  it('surfaces the daemon error body on non-ok', async () => {
+    const client = mockClient({ error: 'tier must be numeric, got foo' }, false);
+    const result = await handleMycoDigestRevisions({ tier: 5000 }, client);
+    // The tool already forwarded tier — the 400 here is a stand-in for any
+    // route-side rejection. Assert the error body string reaches the caller.
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('tier must be numeric, got foo');
+  });
+
+  it('falls back to fetch_failed when the daemon is unreachable', async () => {
+    const client = mockClient(undefined, false);
+    const result = await handleMycoDigestRevisions({ tier: 5000 }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('fetch_failed');
+  });
+});

--- a/tests/mcp/tools/evaluations.test.ts
+++ b/tests/mcp/tools/evaluations.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for myco_evaluations tool handler.
+ *
+ * Mirrors /api/agent/evaluations. These tests verify the MCP adapter
+ * layer only (schema forwarding, op dispatch, error surfacing) — the
+ * matrix fan-out and run serialization are exercised elsewhere.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { handleMycoEvaluations } from '@myco/mcp/tools/evaluations.js';
+import type { DaemonClient } from '@myco/hooks/client.js';
+
+function mockClient(data: unknown = null, ok = true): DaemonClient {
+  return {
+    get: vi.fn().mockResolvedValue({ ok, data }),
+    post: vi.fn().mockResolvedValue({ ok, data }),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as DaemonClient;
+}
+
+describe('myco_evaluations op: list (default)', () => {
+  it('GETs /api/agent/evaluations without forwarding an unset limit', async () => {
+    const payload = { evaluations: [{ id: 'e-1', taskId: 'skill-generate', status: 'completed', createdAt: 1, completedAt: 2, matrix: {}, notes: null }], total: 1 };
+    const client = mockClient(payload);
+    const result = await handleMycoEvaluations({}, client);
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual(payload);
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    expect(url).toContain('/api/agent/evaluations');
+    expect(url).not.toContain('limit=');
+  });
+
+  it('forwards limit when set', async () => {
+    const client = mockClient({ evaluations: [], total: 0 });
+    await handleMycoEvaluations({ op: 'list', limit: 3 }, client);
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    expect(url).toContain('limit=3');
+  });
+
+  it('surfaces the richer error body when the daemon rejects', async () => {
+    const client = mockClient({ error: { code: 'ouch', message: 'daemon down' } }, false);
+    const result = await handleMycoEvaluations({ op: 'list' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('daemon down');
+  });
+});
+
+describe('myco_evaluations op: get', () => {
+  it('requires id', async () => {
+    const client = mockClient({});
+    const result = await handleMycoEvaluations({ op: 'get' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/id is required/);
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('GETs /api/agent/evaluations/:id', async () => {
+    const payload = {
+      evaluation: { id: 'eval-42', taskId: 'skill-generate', matrix: {}, notes: null, status: 'completed', createdAt: 1, completedAt: 2 },
+      runs: [],
+      aggregate: { total: 0, completed: 0, failed: 0, skipped: 0, totalTokens: 0, totalCostUsd: 0 },
+    };
+    const client = mockClient(payload);
+    const result = await handleMycoEvaluations({ op: 'get', id: 'eval-42' }, client);
+    expect(client.get).toHaveBeenCalledWith('/api/agent/evaluations/eval-42');
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual(payload);
+  });
+
+  it('surfaces "Evaluation not found" from the daemon 404 body', async () => {
+    const client = mockClient({ error: 'Evaluation not found' }, false);
+    const result = await handleMycoEvaluations({ op: 'get', id: 'missing' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Evaluation not found');
+  });
+});
+
+describe('myco_evaluations op: create', () => {
+  it('requires task_id', async () => {
+    const client = mockClient({});
+    const result = await handleMycoEvaluations({ op: 'create', matrix: { runtimes: ['claude-sdk'] } }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/task_id/);
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('requires matrix', async () => {
+    const client = mockClient({});
+    const result = await handleMycoEvaluations({ op: 'create', task_id: 'skill-generate' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/matrix/);
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('POSTs taskId and matrix to /api/agent/evaluations', async () => {
+    const client = mockClient({ evaluationId: 'e-1', cellCount: 2 });
+    const result = await handleMycoEvaluations(
+      {
+        op: 'create',
+        task_id: 'skill-generate',
+        matrix: { runtimes: ['claude-sdk'], reasoningLevels: ['low', 'high'] },
+      },
+      client,
+    );
+    expect(client.post).toHaveBeenCalledWith('/api/agent/evaluations', {
+      taskId: 'skill-generate',
+      matrix: { runtimes: ['claude-sdk'], reasoningLevels: ['low', 'high'] },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({ evaluationId: 'e-1', cellCount: 2 });
+  });
+
+  it('forwards notes when provided', async () => {
+    const client = mockClient({ evaluationId: 'e-1', cellCount: 1 });
+    await handleMycoEvaluations(
+      { op: 'create', task_id: 'skill-generate', matrix: {}, notes: 'tuning prompt v2' },
+      client,
+    );
+    expect(client.post).toHaveBeenCalledWith('/api/agent/evaluations', {
+      taskId: 'skill-generate',
+      matrix: {},
+      notes: 'tuning prompt v2',
+    });
+  });
+
+  it('surfaces the zod validation error body from the route', async () => {
+    const client = mockClient({ error: 'Invalid request body' }, false);
+    const result = await handleMycoEvaluations(
+      { op: 'create', task_id: 'bad', matrix: { runtimes: ['not-a-runtime'] } },
+      client,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Invalid request body');
+  });
+});

--- a/tests/mcp/tools/phase-audit.test.ts
+++ b/tests/mcp/tools/phase-audit.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for myco_phase_audit tool handler.
+ *
+ * Mirrors GET /api/agent/runs/:id/audit. Adapter-layer only.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { handleMycoPhaseAudit } from '@myco/mcp/tools/phase-audit.js';
+import type { DaemonClient } from '@myco/hooks/client.js';
+
+function mockClient(data: unknown = null, ok = true): DaemonClient {
+  return {
+    get: vi.fn().mockResolvedValue({ ok, data }),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as DaemonClient;
+}
+
+describe('myco_phase_audit', () => {
+  it('requires run_id', async () => {
+    const client = mockClient({});
+    const result = await handleMycoPhaseAudit({ run_id: '' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/run_id/);
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('GETs /api/agent/runs/:id/audit', async () => {
+    const payload = {
+      audit: {
+        run: { id: 'run-1', status: 'completed' },
+        phases: [
+          { name: 'plan', turns: 3, tokensUsed: 500, costUsd: 0.001 },
+          { name: 'execute', turns: 7, tokensUsed: 2000, costUsd: 0.004 },
+        ],
+      },
+    };
+    const client = mockClient(payload);
+    const result = await handleMycoPhaseAudit({ run_id: 'run-1' }, client);
+    expect(client.get).toHaveBeenCalledWith('/api/agent/runs/run-1/audit');
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual(payload);
+  });
+
+  it('URL-encodes the run_id path segment', async () => {
+    const client = mockClient({ audit: {} });
+    await handleMycoPhaseAudit({ run_id: 'run id with spaces' }, client);
+    expect(client.get).toHaveBeenCalledWith('/api/agent/runs/run%20id%20with%20spaces/audit');
+  });
+
+  it('surfaces a not-found error from the daemon', async () => {
+    const client = mockClient({ error: 'Run not found' }, false);
+    const result = await handleMycoPhaseAudit({ run_id: 'missing' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Run not found');
+  });
+
+  it('falls back to not_found when the daemon is unreachable (no body)', async () => {
+    const client = mockClient(undefined, false);
+    const result = await handleMycoPhaseAudit({ run_id: 'run-1' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('not_found');
+  });
+});

--- a/tests/mcp/tools/resume-run.test.ts
+++ b/tests/mcp/tools/resume-run.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for myco_resume_run tool handler.
+ *
+ * Mirrors POST /api/agent/runs/:id/resume. The MCP-adapter-layer tests cover
+ * input validation + error surfacing; the integration suite below drives the
+ * handler through a real DaemonServer + real DaemonClient so the 404
+ * (run-not-found) and 400 (not-resumable) branches of handleResumeRun are
+ * actually exercised end-to-end — matching the Bundle D plans-delete
+ * integration pattern.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { handleMycoResumeRun } from '@myco/mcp/tools/resume-run.js';
+import { DaemonClient } from '@myco/hooks/client.js';
+import { DaemonServer } from '@myco/daemon/server.js';
+import { DaemonLogger } from '@myco/daemon/logger.js';
+import { createAgentRunHandlers } from '@myco/daemon/api/agent-runs.js';
+import { insertRun, updateRunStatus } from '@myco/db/queries/runs.js';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+
+function mockClient(data: unknown = null, ok = true): DaemonClient {
+  return {
+    get: vi.fn().mockResolvedValue({ ok, data }),
+    post: vi.fn().mockResolvedValue({ ok, data }),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as DaemonClient;
+}
+
+describe('myco_resume_run (adapter layer)', () => {
+  it('requires id', async () => {
+    const client = mockClient({});
+    const result = await handleMycoResumeRun({ id: '' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/id/);
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('POSTs /api/agent/runs/:id/resume with an empty body by default', async () => {
+    const client = mockClient({ ok: true, message: 'Agent resume started', runId: 'run-1' });
+    const result = await handleMycoResumeRun({ id: 'run-1' }, client);
+    expect(client.post).toHaveBeenCalledWith('/api/agent/runs/run-1/resume', {});
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({ ok: true, message: 'Agent resume started', runId: 'run-1' });
+  });
+
+  it('forwards mode when provided', async () => {
+    const client = mockClient({ ok: true, message: 'Agent resume started', runId: 'run-1' });
+    await handleMycoResumeRun({ id: 'run-1', mode: 'scheduled' }, client);
+    expect(client.post).toHaveBeenCalledWith('/api/agent/runs/run-1/resume', { mode: 'scheduled' });
+  });
+
+  it('URL-encodes the id path segment', async () => {
+    const client = mockClient({ ok: true, runId: 'x' });
+    await handleMycoResumeRun({ id: 'run/with slash' }, client);
+    expect(client.post).toHaveBeenCalledWith('/api/agent/runs/run%2Fwith%20slash/resume', {});
+  });
+
+  it('surfaces the daemon error body on non-ok', async () => {
+    const client = mockClient({ error: 'Run is not resumable' }, false);
+    const result = await handleMycoResumeRun({ id: 'run-1' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Run is not resumable');
+  });
+
+  it('falls back to resume_failed when the daemon is unreachable (no body)', async () => {
+    const client = mockClient(undefined, false);
+    const result = await handleMycoResumeRun({ id: 'run-1' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('resume_failed');
+  });
+});
+
+/**
+ * Integration suite — drives handleMycoResumeRun through the real DaemonClient
+ * and a real in-process DaemonServer so the 404 + 400 branches of
+ * handleResumeRun actually run. The happy-path 202 branch fires
+ * runAgent() as a background import, which we deliberately do NOT exercise
+ * here (the agent executor has broad side effects). The adapter-layer suite
+ * above covers happy-path shape.
+ */
+describe('myco_resume_run (integration against real HTTP router)', () => {
+  let vaultDir: string;
+  let server: DaemonServer;
+  let logger: DaemonLogger;
+  let client: DaemonClient;
+  let now: number;
+
+  beforeAll(async () => {
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-resume-run-'));
+    fs.mkdirSync(path.join(vaultDir, 'logs'), { recursive: true });
+    logger = new DaemonLogger(path.join(vaultDir, 'logs'));
+    setupTestDb();
+
+    server = new DaemonServer({ vaultDir, logger });
+
+    const embeddingManager = {
+      onContentWritten: vi.fn(),
+      onStatusChanged: vi.fn(),
+      onRemoved: vi.fn(),
+    } as never;
+    const runHandlers = createAgentRunHandlers({
+      vaultDir,
+      embeddingManager,
+      logger,
+    });
+    server.registerRoute('POST', '/api/agent/runs/:id/resume', runHandlers.handleResumeRun);
+
+    await server.start();
+
+    fs.writeFileSync(
+      path.join(vaultDir, 'daemon.json'),
+      JSON.stringify({ pid: process.pid, port: server.port }),
+    );
+
+    client = new DaemonClient(vaultDir);
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    logger.close();
+    teardownTestDb();
+    fs.rmSync(vaultDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    cleanTestDb();
+    now = Math.floor(Date.now() / 1000);
+    registerAgent({ id: 'myco-agent', name: 'Test', created_at: now });
+  });
+
+  it('returns a 404-shaped error when the run does not exist', async () => {
+    const result = await handleMycoResumeRun({ id: 'missing-run' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Run not found/);
+  });
+
+  it('returns a 400-shaped error when the run is not resumable', async () => {
+    insertRun({
+      id: 'run-not-resumable',
+      agent_id: 'myco-agent',
+      status: 'completed',
+      started_at: now,
+      // resumable defaults to 0 via insertRun.
+    });
+
+    const result = await handleMycoResumeRun({ id: 'run-not-resumable' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not resumable/);
+  });
+
+  it('returns a 400-shaped error when the run is resumable but still running', async () => {
+    // resumable=1 but status='running' — the route requires status='failed'.
+    insertRun({
+      id: 'run-still-running',
+      agent_id: 'myco-agent',
+      status: 'running',
+      resumable: 1,
+      started_at: now,
+    });
+
+    const result = await handleMycoResumeRun({ id: 'run-still-running' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not resumable/);
+  });
+
+  // Pre-seed a row that looks resumable so the validation gate passes.
+  // We still don't exercise the background runAgent — the route returns
+  // {ok:true, message, runId} before awaiting it, and the import is lazy
+  // so ESM loads the executor on first call. The unresolved background
+  // promise is fine for a unit-style test boundary.
+  it('accepts a properly-resumable run (202-equivalent body)', async () => {
+    insertRun({
+      id: 'run-resumable',
+      agent_id: 'myco-agent',
+      status: 'running',
+      resumable: 1,
+      started_at: now,
+    });
+    updateRunStatus('run-resumable', 'failed', { error: 'ran out of turns' });
+
+    const result = await handleMycoResumeRun({ id: 'run-resumable' }, client);
+    expect(result.ok).toBe(true);
+    expect(result.data).toMatchObject({
+      ok: true,
+      message: 'Agent resume started',
+      runId: 'run-resumable',
+    });
+  });
+});

--- a/tests/mcp/tools/write-intents.test.ts
+++ b/tests/mcp/tools/write-intents.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for myco_write_intents tool handler.
+ *
+ * Mirrors GET /api/agent/runs/:id/write-intents. Adapter-layer only.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { handleMycoWriteIntents } from '@myco/mcp/tools/write-intents.js';
+import type { DaemonClient } from '@myco/hooks/client.js';
+
+function mockClient(data: unknown = null, ok = true): DaemonClient {
+  return {
+    get: vi.fn().mockResolvedValue({ ok, data }),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as DaemonClient;
+}
+
+describe('myco_write_intents', () => {
+  it('requires run_id', async () => {
+    const client = mockClient({});
+    const result = await handleMycoWriteIntents({ run_id: '' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/run_id/);
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('GETs /api/agent/runs/:id/write-intents', async () => {
+    const payload = {
+      intents: [{ id: 1, run_id: 'run-1', tool_name: 'fs.write', tool_input: { path: '/tmp/x' }, synthetic_output: { ok: true } }],
+      count: 1,
+      total: 1,
+    };
+    const client = mockClient(payload);
+    const result = await handleMycoWriteIntents({ run_id: 'run-1' }, client);
+    expect(client.get).toHaveBeenCalledWith('/api/agent/runs/run-1/write-intents');
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual(payload);
+  });
+
+  it('forwards limit and offset as query params', async () => {
+    const client = mockClient({ intents: [], count: 0, total: 0 });
+    await handleMycoWriteIntents({ run_id: 'run-1', limit: 10, offset: 5 }, client);
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    expect(url).toContain('/api/agent/runs/run-1/write-intents');
+    expect(url).toContain('limit=10');
+    expect(url).toContain('offset=5');
+  });
+
+  it('URL-encodes the run_id path segment', async () => {
+    const client = mockClient({ intents: [], count: 0, total: 0 });
+    await handleMycoWriteIntents({ run_id: 'run/with slash' }, client);
+    const url = (client.get as unknown as { mock: { calls: string[][] } }).mock.calls[0][0];
+    expect(url).toContain('run%2Fwith%20slash');
+  });
+
+  it('surfaces the daemon error body when non-ok', async () => {
+    const client = mockClient({ error: 'Run not found' }, false);
+    const result = await handleMycoWriteIntents({ run_id: 'missing' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Run not found');
+  });
+
+  it('falls back to fetch_failed when the daemon is unreachable (no body)', async () => {
+    const client = mockClient(undefined, false);
+    const result = await handleMycoWriteIntents({ run_id: 'run-1' }, client);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('fetch_failed');
+  });
+});


### PR DESCRIPTION
## Summary

**Bundle G — second of four v0.22 follow-up PRs.** Adds the remaining five MCP tools deferred during Bundle D of the pre-0.21.0 quality pass. Each tool closes a specific agent-native parity gap so an agent can reach every new HTTP surface introduced in v0.21.0. Targets `v0.22-dev`, not `main`.

Closes #95, #96, #97, #98, #99

## What changed

All five tools follow the pattern Bundle D established (`myco_cortex` / `myco_runs`): zod input schema → `DaemonClient` proxy → `TOOL_DEFINITIONS` entry with MCP annotations + Cortex brief guidance → handler + integration tests. Richer error bodies from Bundle F (`DaemonClient.parseErrorBody`) flow through via the new shared `extractErrorMessage` helper.

| Tool | Purpose | Annotations |
|---|---|---|
| `myco_evaluations({op: 'list'\|'get'\|'create'})` | matrix fan-out for prompt tuning / model comparison | non-readOnly (create), non-idempotent |
| `myco_write_intents({run_id, limit?, offset?})` | inspect dry-run write intents | readOnly, idempotent |
| `myco_phase_audit({run_id})` | per-phase cost, tool counts, outcomes | readOnly, idempotent |
| `myco_resume_run({id, mode?})` | resume paused/interrupted runs | non-readOnly, non-idempotent |
| `myco_digest_revisions({agent_id?, tier, limit?})` | digest history (list only; restore stays UI-only per policy) | readOnly, idempotent |

## Notable design choices

- **Shared `tools/error.ts` helper** (`extractErrorMessage(data, fallback)`) normalizes the four error-body shapes the daemon emits: `undefined`, plain string, `{error: 'msg'}`, `{error: {code, message}}`. Used by all 5 new tools AND the existing `myco_plans` delete handler (second commit consolidates it).
- **`myco_evaluations.task_id`** (snake_case at MCP layer) maps to route body `taskId` — matches codebase convention for MCP input schemas (`run_id`, `agent_id`, `plan_key`).
- **`myco_digest_revisions.tier` required** — the underlying route 400s without it, so surfacing the validation at the MCP layer gives agents a clearer error earlier.
- **Restore stays UI-only** — issue #99 policy: human-in-the-loop for destructive digest restore. No MCP op for it.
- **`myco_resume_run` integration test** — real `DaemonServer` + real `DaemonClient` + seeded DB rows; covers 404, two 400 paths, and happy path (matches Bundle D's plans-delete integration pattern).

## Anti-drift + annotation pinning

- `tests/mcp/tool-definitions.test.ts` — value-pinning assertions for all four annotation fields on every new tool (20 pinned values added). Flipping any single value fails the assertion.
- `tests/context/cortex-brief.test.ts` — asserts every new tool name appears in BOTH `RETRIEVAL_GUIDANCE` and the rendered brief body.
- `tests/mcp/server.test.ts` — `registers all 20 core tools` test bumped from 15 → 20 with explicit `toContain(...)` for each new tool.

## Test plan

- [x] `make build` — all packages + UI bundle
- [x] `make check` — **3040 passed, 3 skipped, 0 failed**
- [x] Targeted: 165/165 across `tests/mcp/` + `tests/context/cortex-brief.test.ts`
- [x] Review: ✅ Approved (combined spec + code-quality; one follow-up applied as a second commit)

## Pipeline

Implementer → combined review (✅ approved with one "finish the consolidation" ask) → `plans.ts` migrated to shared helper (second commit). Two commits on this branch; will squash-merge to `v0.22-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)