### PR TITLE
refactor(agent): extract phase-loop from executor.ts

### DIFF
--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -8,7 +8,6 @@ import {
   MS_PER_SECOND,
   CONTENT_HASH_ALGORITHM,
 } from '@myco/constants.js';
-import { errorMessage as toErrorMessage } from '@myco/utils/error-message.js';
 import { tryParseJson } from '@myco/utils/json.js';
 import { initDatabase, vaultDbPath } from '@myco/db/client.js';
 import { createSchema } from '@myco/db/schema.js';
@@ -18,7 +17,6 @@ import { getDefaultTask } from '@myco/db/queries/tasks.js';
 import {
   insertRun,
   updateRunStatus,
-  updateRun,
   applyRunUpdate,
   getRun,
   getRunningRunForTask,
@@ -29,44 +27,38 @@ import {
 } from '@myco/db/queries/runs.js';
 import { loadSystemPrompt } from './loader.js';
 import { buildVaultContext } from './context.js';
-import { composeOrchestratorPrompt, parseOrchestratorPlan, applyDirectives, DEFAULT_ORCHESTRATOR_MAX_TURNS } from './orchestrator.js';
-import { executeContextQueries } from './context-queries.js';
 import { resolveRunConfig } from './config-resolver.js';
 import { resolveOllamaContextVariants } from './ollama-context.js';
 import { resolveReasoningModel } from './reasoning-levels.js';
 import { validateTaskPostconditions } from './task-postconditions.js';
-import { computeWaves, phaseSessionId } from './wave-computation.js';
 import { CORTEX_INSTRUCTIONS_TASK, SKILL_GENERATE_TASK } from './instruction-builders.js';
 import { resolveCost } from './cost/index.js';
 import {
   aggregateUsage,
-  abortReasonMessage,
   buildUsageData,
-  checkpointResultsForResume,
-  isSessionResumeFailure,
   parseCheckpointState,
   resolveProviderForResume,
   serializeCheckpointState,
-  type RunCheckpointState,
 } from './executor-state.js';
 import {
   analyzeRuntimeTokenBudget,
   buildRunAccountingUpdate,
   summarizePhaseCosts,
 } from './run-accounting.js';
-import { getAgentRuntime } from './runtime/index.js';
 import { composeTaskPrompt, composePhasePrompt } from './prompt-composition.js';
+import { warnUnknownPhaseOverrides, resolvePhaseExecution } from './phase-resolver.js';
+import { executePhasedQuery, executeSingleQuery, type PhaseLoopContext } from './phase-loop.js';
+import type { RunCheckpointState } from './executor-state.js';
 export { composeTaskPrompt, composePhasePrompt };
+export { resolvePhaseExecution } from './phase-resolver.js';
+export type { MycoYamlPhaseOverrides } from './phase-resolver.js';
 import type { CostResolution } from './cost/types.js';
-import type { ContextQueryResult } from './context-queries.js';
 import type { ProviderConfig } from './types.js';
 import type {
   RunOptions,
   AgentRunResult,
   EffectiveConfig,
-  PhaseDefinition,
   PhaseResult,
-  ReasoningLevel,
   RuntimeUsage,
 } from './types.js';
 
@@ -103,579 +95,6 @@ function logTokenBudgetPressure(
     `${budget.utilizationPercent}% of ${budget.contextWindowTokens} tokens ` +
     `at peak request (${budget.peakRequestTotalTokens} tokens)`,
   );
-}
-
-/**
- * myco.yaml-sourced per-phase provider / model / maxTurns overrides, keyed
- * by phase name. Passed through `resolveRunConfig` alongside the
- * task-level provider override.
- */
-export interface MycoYamlPhaseOverrides {
-  [phaseName: string]: {
-    provider?: ProviderConfig;
-    model?: string;
-    maxTurns?: number;
-  };
-}
-
-/**
- * Compute the effective `{ reasoningLevel, model, provider, maxTurns }` for
- * a single phase by reconciling all layered sources. Extracted for
- * unit-testability — the wave loop calls this helper directly.
- *
- * Provider precedence (highest → lowest):
- *   1. `options.executionOverrides.phases[name].provider` — run override
- *   2. `phase.provider` — task YAML
- *   3. `phaseProviderOverrides[name].provider` — myco.yaml per-phase override
- *   4. `options.executionOverrides.provider` — top-level run override
- *   5. `provider` parameter — task default / task override from myco.yaml
- *
- * Model precedence (highest → lowest):
- *   1. `options.executionOverrides.phases[name].model`
- *   2. `phaseProviderOverrides[name].model` (myco.yaml)
- *   3. `resolveReasoningModel(effectiveReasoning, provider, fallback)`
- *      where `fallback = phase.model ?? options.executionOverrides.model
- *      ?? config.model`
- *
- * Reasoning precedence (highest → lowest):
- *   1. `options.executionOverrides.phases[name].reasoningLevel`
- *   2. `phase.reasoningLevel` (task YAML)
- *   3. `options.executionOverrides.reasoningLevel`
- *   4. `config.execution.reasoningLevel`
- *   5. `config.reasoningLevel`
- *
- * maxTurns precedence (highest → lowest):
- *   1. `options.executionOverrides.phases[name].maxTurns`
- *   2. `phaseProviderOverrides[name].maxTurns` (myco.yaml)
- *   3. `phase.maxTurns` (task YAML)
- */
-/**
- * Walk an ordered list of lookups and return the first defined value. Keeps
- * precedence chains declarative so unit tests can exercise each source
- * individually without re-running the entire resolver.
- */
-function firstDefined<T>(lookups: Array<() => T | undefined>): T | undefined {
-  for (const lookup of lookups) {
-    const value = lookup();
-    if (value !== undefined) return value;
-  }
-  return undefined;
-}
-
-export function resolvePhaseExecution(
-  phase: PhaseDefinition,
-  options: RunOptions | undefined,
-  config: EffectiveConfig,
-  provider: ProviderConfig | undefined,
-  phaseProviderOverrides?: MycoYamlPhaseOverrides,
-): { reasoningLevel: ReasoningLevel | undefined; model: string; maxTurns: number; provider: ProviderConfig | undefined } {
-  const runPhaseOverride = options?.executionOverrides?.phases?.[phase.name];
-  const topOverride = options?.executionOverrides;
-  const mycoYamlPhase = phaseProviderOverrides?.[phase.name];
-
-  const effectiveProvider = firstDefined<ProviderConfig>([
-    () => runPhaseOverride?.provider,
-    () => phase.provider,
-    () => mycoYamlPhase?.provider,
-    () => topOverride?.provider,
-    () => provider,
-  ]);
-
-  const effectiveReasoning = firstDefined<ReasoningLevel>([
-    () => runPhaseOverride?.reasoningLevel,
-    () => phase.reasoningLevel,
-    () => topOverride?.reasoningLevel,
-    () => config.execution?.reasoningLevel,
-    () => config.reasoningLevel,
-  ]);
-
-  const fallbackModel = firstDefined<string>([
-    () => phase.model,
-    () => topOverride?.model,
-    () => config.model,
-  ]);
-
-  const effectiveModel = firstDefined<string>([
-    () => runPhaseOverride?.model,
-    () => mycoYamlPhase?.model,
-    () => resolveReasoningModel(effectiveReasoning, effectiveProvider, fallbackModel ?? ''),
-  ]) ?? '';
-
-  const effectiveMaxTurns = runPhaseOverride?.maxTurns
-    ?? mycoYamlPhase?.maxTurns
-    ?? phase.maxTurns;
-
-  return {
-    reasoningLevel: effectiveReasoning,
-    model: effectiveModel,
-    maxTurns: effectiveMaxTurns,
-    provider: effectiveProvider,
-  };
-}
-
-/**
- * Warn once per run when `executionOverrides.phases` contains keys that do
- * not match any phase in the task. The warning lists the unknown keys and
- * the task's actual phase names so callers can correct their payload.
- */
-function warnUnknownPhaseOverrides(
-  options: RunOptions | undefined,
-  taskPhases: readonly PhaseDefinition[] | undefined,
-): void {
-  const overridePhases = options?.executionOverrides?.phases;
-  if (!overridePhases) return;
-  const keys = Object.keys(overridePhases);
-  if (keys.length === 0) return;
-  const known = new Set((taskPhases ?? []).map((p) => p.name));
-  const unknown = keys.filter((k) => !known.has(k));
-  if (unknown.length === 0) return;
-  const taskPhaseNames = (taskPhases ?? []).map((p) => p.name);
-  console.warn(
-    `[agent] Unknown phase override keys: ${unknown.join(', ')} ` +
-    `(task phases: ${taskPhaseNames.join(', ') || '<none>'})`,
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Prompt composition
-// ---------------------------------------------------------------------------
-
-
-// ---------------------------------------------------------------------------
-// Single-phase execution helper
-// ---------------------------------------------------------------------------
-
-/**
- * Execute a single phase query through the selected runtime adapter.
- */
-async function executePhase(
-  config: EffectiveConfig,
-  phasePrompt: string,
-  phaseModel: string,
-  systemPrompt: string,
-  phase: PhaseDefinition,
-  toolSurface: {
-    agentId: string;
-    runId: string;
-    toolNames: string[];
-    turnOffset: number;
-    projectRoot?: string;
-    vaultDir?: string;
-    readOnly?: boolean;
-    embeddingManager?: RunOptions['embeddingManager'];
-    dryRun?: boolean;
-  },
-  provider?: ProviderConfig,
-  sessionId?: string,
-  sessionData?: unknown,
-  abortController?: AbortController,
-): Promise<PhaseResult & { sessionData?: unknown }> {
-  const runtime = getAgentRuntime(config.runtime);
-  try {
-    let result;
-    try {
-      result = await runtime.execute({
-        prompt: phasePrompt,
-        model: phaseModel,
-        maxTurns: phase.maxTurns,
-        systemPrompt,
-        provider,
-        sessionRef: sessionId,
-        sessionData,
-        abortController,
-        toolSurface,
-      });
-    } catch (error) {
-      if (!sessionId || !runtime.supports('supportsSessionResume') || !isSessionResumeFailure(error)) {
-        throw error;
-      }
-      console.warn(`[agent] Resuming phase "${phase.name}" session failed, retrying without prior session`);
-      result = await runtime.execute({
-        prompt: phasePrompt,
-        model: phaseModel,
-        maxTurns: phase.maxTurns,
-        systemPrompt,
-        provider,
-        abortController,
-        toolSurface,
-      });
-    }
-
-    if (phase.maxTurns && result.turnsUsed > 0) {
-      console.log(`[agent] Phase "${phase.name}": num_turns=${result.turnsUsed}, budget=${phase.maxTurns}`);
-    }
-
-    if (phase.required && result.turnsUsed === 0) {
-      console.warn(`[agent] Required phase "${phase.name}" produced 0 turns`);
-    }
-
-    const costData = await resolveCost({
-      runtime: config.runtime,
-      provider,
-      model: phaseModel,
-      usage: result.usage,
-    });
-
-    return {
-      name: phase.name,
-      status: 'completed',
-      turnsUsed: result.turnsUsed,
-      tokensUsed: result.usage.totalTokens ?? 0,
-      costUsd: costData.costUsd ?? 0,
-      costSource: costData.source,
-      costData,
-      summary: result.finalText,
-      usage: result.usage,
-      sessionRef: result.sessionRef,
-      sessionData: result.sessionData,
-    };
-  } catch (err) {
-    const abortReason = abortReasonMessage(abortController);
-    return {
-      name: phase.name,
-      status: 'failed',
-      turnsUsed: 0,
-      tokensUsed: 0,
-      costUsd: 0,
-      summary: abortReason ? `Error: ${abortReason}` : `Error: ${toErrorMessage(err)}`,
-    };
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Single-query execution (non-phased tasks)
-// ---------------------------------------------------------------------------
-
-/**
- * Execute a single query() call for non-phased tasks.
- *
- * @returns tokens used, cost, and status.
- */
-async function executeSingleQuery(
-  config: EffectiveConfig,
-  systemPrompt: string,
-  taskPrompt: string,
-  agentId: string,
-  runId: string,
-  provider?: ProviderConfig,
-  embeddingManager?: RunOptions['embeddingManager'],
-  abortController?: AbortController,
-  vaultDir?: string,
-  sessionRef?: string,
-  sessionData?: unknown,
-): Promise<{ tokensUsed: number; costUsd: number | null; costData: CostResolution; usage: RuntimeUsage; sessionRef?: string; sessionData?: unknown }> {
-  const runtime = getAgentRuntime(config.runtime);
-  const effectiveModel = resolveReasoningModel(
-    config.execution?.reasoningLevel ?? config.reasoningLevel,
-    provider,
-    config.model,
-  );
-  const result = await runtime.execute({
-    prompt: taskPrompt,
-    model: effectiveModel,
-    maxTurns: config.maxTurns,
-    systemPrompt,
-    provider,
-    abortController,
-    sessionRef,
-    sessionData,
-    toolSurface: {
-      agentId,
-      runId,
-      vaultDir,
-      embeddingManager,
-      dryRun: config.dryRun ?? false,
-    },
-  });
-  const costData = await resolveCost({
-    runtime: config.runtime,
-    provider,
-    model: effectiveModel,
-    usage: result.usage,
-  });
-
-  return {
-    tokensUsed: result.usage.totalTokens ?? 0,
-    costUsd: costData.costUsd,
-    costData,
-    usage: result.usage,
-    sessionRef: result.sessionRef,
-    sessionData: result.sessionData,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Phased execution (wave-based parallel)
-// ---------------------------------------------------------------------------
-
-/**
- * Execute a phased task — wave-based parallel query() calls.
- *
- * Phases are sorted into waves via `computeWaves()`. Phases within the same
- * wave execute concurrently via `Promise.allSettled()`. Each phase gets:
- * - Scoped tools (only the tools listed in the phase definition)
- * - Its own turn budget (maxTurns)
- * - Optional model override (falls back to task/agent model)
- * - Isolated provider env (via SDK `env` option — no process.env mutation)
- * - Context from prior wave results
- * - Deterministic session ID derived from run ID + phase name
- *
- * The executor controls the loop — the LLM cannot skip phases.
- */
-async function executePhasedQuery(
-  config: EffectiveConfig,
-  systemPrompt: string,
-  vaultContext: string,
-  agentId: string,
-  runId: string,
-  taskProviderOverride?: ProviderConfig,
-  phaseProviderOverrides?: Record<string, { provider?: ProviderConfig; model?: string; maxTurns?: number }>,
-  instruction?: string,
-  embeddingManager?: RunOptions['embeddingManager'],
-  abortController?: AbortController,
-  projectRoot?: string,
-  vaultDir?: string,
-  checkpointState?: RunCheckpointState,
-  persistCheckpoints?: (state: RunCheckpointState, phases: PhaseResult[]) => Promise<void>,
-  options?: RunOptions,
-): Promise<{ tokensUsed: number; costUsd: number | null; costData: CostResolution; usage: RuntimeUsage; phases: PhaseResult[] }> {
-  const phases = config.phases!;
-  const state = checkpointState ?? {
-    runtime: config.runtime,
-    provider: taskProviderOverride?.type ?? config.execution?.provider?.type,
-    model: resolveReasoningModel(
-      config.execution?.reasoningLevel ?? config.reasoningLevel,
-      taskProviderOverride ?? config.execution?.provider,
-      config.model,
-    ),
-    phases: {},
-  };
-  const phaseResults: PhaseResult[] = checkpointResultsForResume(config, state);
-  let runningTurnCount = phaseResults.reduce((sum, phase) => sum + phase.turnsUsed, 0);
-  const completedPhaseNames = new Set(phaseResults.map((phase) => phase.name));
-
-  // ---------------------------------------------------------------------------
-  // Orchestrator planning (opt-in via config.orchestrator.enabled)
-  // ---------------------------------------------------------------------------
-
-  let effectivePhases = [...phases];
-
-  if (config.orchestrator?.enabled) {
-    const contextQueries = config.contextQueries
-      ? Object.values(config.contextQueries).flat()
-      : [];
-    const contextResults: ContextQueryResult[] = contextQueries.length > 0
-      ? await executeContextQueries(agentId, contextQueries)
-      : [];
-
-    const orchestratorPrompt = composeOrchestratorPrompt(vaultContext, phases, contextResults);
-    const orchestratorModel = config.orchestrator.model ?? resolveReasoningModel(
-      config.orchestrator.reasoningLevel ?? config.execution?.reasoningLevel ?? config.reasoningLevel,
-      taskProviderOverride ?? config.execution?.provider,
-      config.model,
-    );
-    const orchestratorMaxTurns = config.orchestrator.maxTurns ?? DEFAULT_ORCHESTRATOR_MAX_TURNS;
-    const runtime = getAgentRuntime(config.runtime);
-    const planResponse = await runtime.execute({
-      prompt: orchestratorPrompt,
-      model: orchestratorModel,
-      maxTurns: orchestratorMaxTurns,
-      systemPrompt,
-      provider: taskProviderOverride ?? config.execution?.provider,
-      toolSurface: {
-        agentId,
-        runId,
-        toolNames: [],
-        vaultDir,
-        dryRun: config.dryRun ?? false,
-      },
-      abortController,
-    });
-
-    const plan = parseOrchestratorPlan(planResponse.finalText, phases);
-    effectivePhases = applyDirectives(phases, plan.phases);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Wave-based phase execution
-  // ---------------------------------------------------------------------------
-
-  // Build a map from phase name to its YAML declaration order for stable output
-  const declarationOrder = new Map(phases.map((p, i) => [p.name, i]));
-
-  const waves = computeWaves(effectivePhases);
-
-  for (const wave of waves) {
-    const runnableWave = wave.filter((phase) => !completedPhaseNames.has(phase.name));
-    if (runnableWave.length === 0) {
-      continue;
-    }
-
-    const waveInputs = runnableWave.map((phase, indexInWave) => {
-      const phasePrompt = composePhasePrompt(
-        vaultContext,
-        config.taskDisplayName,
-        config.taskPrompt,
-        phase,
-        phaseResults,
-        instruction,
-      );
-
-      // Single canonical precedence resolution — covers run overrides,
-      // phase YAML, myco.yaml per-phase overrides, top-level run override,
-      // and the task default. See `resolvePhaseExecution` JSDoc for the
-      // full precedence table.
-      const resolved = resolvePhaseExecution(
-        phase,
-        options,
-        config,
-        taskProviderOverride ?? config.execution?.provider,
-        phaseProviderOverrides,
-      );
-      const phaseProvider = resolved.provider;
-      const effectiveMaxTurns = resolved.maxTurns;
-      const phaseModel = resolved.model;
-      const existingCheckpoint = state.phases[phase.name];
-      const sessionId = existingCheckpoint?.sessionRef ?? phaseSessionId(runId, phase.name);
-      const effectivePhase = effectiveMaxTurns !== phase.maxTurns
-        ? { ...phase, maxTurns: effectiveMaxTurns }
-        : phase;
-
-      state.phases[phase.name] = {
-        name: phase.name,
-        status: 'running',
-        summary: existingCheckpoint?.summary,
-        turnsUsed: existingCheckpoint?.turnsUsed,
-        tokensUsed: existingCheckpoint?.tokensUsed,
-        costUsd: existingCheckpoint?.costUsd,
-        costSource: existingCheckpoint?.costSource,
-        costData: existingCheckpoint?.costData,
-        sessionRef: sessionId,
-        sessionData: existingCheckpoint?.sessionData,
-        usage: existingCheckpoint?.usage,
-        updatedAt: epochSeconds(),
-      };
-
-      return {
-        phase,
-        phasePrompt,
-        phaseModel,
-        phaseProvider,
-        effectivePhase,
-        sessionId,
-        sessionData: existingCheckpoint?.sessionData,
-        toolSurface: {
-          agentId,
-          runId,
-          toolNames: phase.tools,
-          turnOffset: runningTurnCount + (indexInWave * effectiveMaxTurns),
-          projectRoot,
-          vaultDir,
-          readOnly: phase.readOnly,
-          embeddingManager,
-          dryRun: config.dryRun ?? false,
-        },
-      };
-    });
-
-    if (persistCheckpoints) {
-      await persistCheckpoints(state, phaseResults);
-    }
-
-    const settled = await Promise.allSettled(
-      waveInputs.map((input) =>
-        executePhase(
-          config,
-          input.phasePrompt,
-          input.phaseModel,
-          systemPrompt,
-          input.effectivePhase,
-          input.toolSurface,
-          input.phaseProvider,
-          input.sessionId,
-          input.sessionData,
-          abortController,
-        ),
-      ),
-    );
-
-    const fulfilledByName = new Map<string, PhaseResult & { sessionData?: unknown }>();
-    for (const [index, outcome] of settled.entries()) {
-      if (outcome.status === 'fulfilled') {
-        fulfilledByName.set(runnableWave[index].name, outcome.value);
-      }
-    }
-
-    // Map settled results to PhaseResult[]
-    const waveResults: PhaseResult[] = settled.map((outcome, i) => {
-      if (outcome.status === 'fulfilled') {
-        return outcome.value;
-      }
-      return {
-        name: runnableWave[i].name,
-        status: 'failed' as const,
-        turnsUsed: 0,
-        tokensUsed: 0,
-        costUsd: 0,
-        summary: `Error: ${toErrorMessage(outcome.reason)}`,
-      };
-    });
-
-    // Sort by YAML declaration order for stable output
-    waveResults.sort((a, b) =>
-      (declarationOrder.get(a.name) ?? 0) - (declarationOrder.get(b.name) ?? 0),
-    );
-
-    for (const [index, result] of waveResults.entries()) {
-      const priorCheckpoint = state.phases[result.name];
-      const fulfilled = fulfilledByName.get(result.name) ?? null;
-      state.phases[result.name] = {
-        name: result.name,
-        status: result.status === 'completed' ? 'completed' : 'failed',
-        summary: result.summary,
-        turnsUsed: result.turnsUsed,
-        tokensUsed: result.tokensUsed,
-        costUsd: result.costUsd,
-        costSource: result.costSource,
-        costData: result.costData,
-        sessionRef: fulfilled?.sessionRef ?? priorCheckpoint?.sessionRef,
-        sessionData: fulfilled?.sessionData ?? priorCheckpoint?.sessionData,
-        usage: fulfilled?.usage ?? result.usage,
-        updatedAt: epochSeconds(),
-      };
-      if (result.status === 'completed') {
-        completedPhaseNames.add(result.name);
-      }
-      phaseResults.push(result);
-      runningTurnCount += result.turnsUsed;
-    }
-
-    if (persistCheckpoints) {
-      await persistCheckpoints(state, phaseResults);
-    }
-
-    // If any required phase in this wave failed, stop the pipeline
-    const shouldStop = runnableWave.some((phase, i) => {
-      if (!phase.required) return false;
-      const outcome = settled[i];
-      if (outcome.status === 'rejected') return true;
-      return outcome.value.status === 'failed';
-    });
-
-    if (shouldStop) {
-      break;
-    }
-  }
-
-  const usage = aggregateUsage(phaseResults.map((phase) => phase.usage));
-  const costData = summarizePhaseCosts(phaseResults);
-  return {
-    tokensUsed: usage.totalTokens ?? phaseResults.reduce((sum, phase) => sum + phase.tokensUsed, 0),
-    costUsd: costData.costUsd,
-    costData,
-    usage,
-    phases: phaseResults,
-  };
 }
 
 // ---------------------------------------------------------------------------
@@ -795,7 +214,7 @@ export async function runAgent(
     baseProvider,
     config.model,
   );
-  const checkpointState = resumedRun
+  const checkpointState: RunCheckpointState = resumedRun
     ? parseCheckpointState(resumedRun.checkpoints)
     : {
       runtime: runtimeId,
@@ -929,25 +348,31 @@ export async function runAgent(
       }));
     };
 
+    const projectRoot = resolve(vaultDir, '..');
+
+    // Assemble the PhaseLoopContext once. `checkpointState` is mutable by
+    // reference — the loop updates it in place and we read back its final
+    // contents below for run finalization.
+    const ctx: PhaseLoopContext = {
+      config,
+      systemPrompt,
+      vaultContext,
+      agentId,
+      runId,
+      taskProviderOverride,
+      phaseProviderOverrides,
+      instruction: options?.instruction,
+      embeddingManager: options?.embeddingManager,
+      abortController: taskAbortController,
+      projectRoot,
+      vaultDir,
+      options,
+      checkpointState,
+      persistCheckpoints: persistRuntimeState,
+    };
+
     if (config.phases && config.phases.length > 0) {
-      const projectRoot = resolve(vaultDir, '..');
-      const result = await executePhasedQuery(
-        config,
-        systemPrompt,
-        vaultContext,
-        agentId,
-        runId,
-        taskProviderOverride,
-        phaseProviderOverrides,
-        options?.instruction,
-        options?.embeddingManager,
-        taskAbortController,
-        projectRoot,
-        vaultDir,
-        checkpointState,
-        persistRuntimeState,
-        options,
-      );
+      const result = await executePhasedQuery(ctx);
       tokensUsed = result.tokensUsed;
       costUsd = result.costUsd;
       costData = result.costData;
@@ -977,15 +402,9 @@ export async function runAgent(
       const singleProvider = taskProviderOverride ?? config.execution?.provider;
 
       const result = await executeSingleQuery(
-        config,
-        systemPrompt,
+        ctx,
         taskPrompt,
-        agentId,
-        runId,
         singleProvider,
-        options?.embeddingManager,
-        taskAbortController,
-        vaultDir,
         checkpointState.sessionRef,
         checkpointState.sessionData,
       );

--- a/packages/myco/src/agent/phase-loop.ts
+++ b/packages/myco/src/agent/phase-loop.ts
@@ -1,0 +1,515 @@
+/**
+ * Phase-loop execution for the agent executor.
+ *
+ * Extracted from `executor.ts` to keep that file focused on orchestrator-
+ * level concerns (run lifecycle, DB bookkeeping, finalization hooks). The
+ * functions here own the actual per-phase / per-query dispatch into the
+ * runtime adapter — `executePhase`, `executeSingleQuery`, and the wave-
+ * based loop in `executePhasedQuery`.
+ *
+ * The functions take a `PhaseLoopContext` parameter object that groups the
+ * orchestrator state previously threaded through long argument lists.
+ * Mutable fields (`checkpointState`, `persistCheckpoints`) remain
+ * references back into the orchestrator, so the outer `runAgent` can read
+ * them after the loop completes to drive run finalization.
+ */
+
+import { epochSeconds } from '@myco/constants.js';
+import { errorMessage as toErrorMessage } from '@myco/utils/error-message.js';
+import {
+  composeOrchestratorPrompt,
+  parseOrchestratorPlan,
+  applyDirectives,
+  DEFAULT_ORCHESTRATOR_MAX_TURNS,
+} from './orchestrator.js';
+import { executeContextQueries } from './context-queries.js';
+import { resolveReasoningModel } from './reasoning-levels.js';
+import { computeWaves, phaseSessionId } from './wave-computation.js';
+import { resolveCost } from './cost/index.js';
+import {
+  abortReasonMessage,
+  checkpointResultsForResume,
+  isSessionResumeFailure,
+  type RunCheckpointState,
+} from './executor-state.js';
+import { getAgentRuntime } from './runtime/index.js';
+import { composePhasePrompt } from './prompt-composition.js';
+import { resolvePhaseExecution, type MycoYamlPhaseOverrides } from './phase-resolver.js';
+import type { CostResolution } from './cost/types.js';
+import type { ContextQueryResult } from './context-queries.js';
+import type {
+  RunOptions,
+  EffectiveConfig,
+  PhaseDefinition,
+  PhaseResult,
+  ProviderConfig,
+  RuntimeUsage,
+} from './types.js';
+import { aggregateUsage } from './executor-state.js';
+import { summarizePhaseCosts } from './run-accounting.js';
+
+// ---------------------------------------------------------------------------
+// PhaseLoopContext — parameter object carrying orchestrator state into the
+// phase-execution functions. Fields marked "by reference" are mutated by the
+// loop; the orchestrator reads them back after the loop to finalize the run.
+// ---------------------------------------------------------------------------
+
+export interface PhaseLoopContext {
+  /** Effective run configuration (includes task YAML + per-run overrides). */
+  readonly config: EffectiveConfig;
+  /** System prompt loaded from the agent's definitions directory. */
+  readonly systemPrompt: string;
+  /** Vault context block prepended to every task / phase prompt. */
+  readonly vaultContext: string;
+  /** Logical agent identifier (e.g. "myco-agent"). */
+  readonly agentId: string;
+  /** Run UUID — shared across all phases in the run. */
+  readonly runId: string;
+  /** Task-level provider override (RunOptions > myco.yaml task override). */
+  readonly taskProviderOverride?: ProviderConfig;
+  /** Per-phase myco.yaml provider/model/maxTurns overrides. */
+  readonly phaseProviderOverrides?: MycoYamlPhaseOverrides;
+  /** Free-form instruction passed from the caller (RunOptions.instruction). */
+  readonly instruction?: string;
+  /** Embedding manager — forwarded to tool surface for RAG-enabled tools. */
+  readonly embeddingManager?: RunOptions['embeddingManager'];
+  /** Run-level abort controller; aborting aborts all in-flight phase queries. */
+  readonly abortController?: AbortController;
+  /** Absolute path to the project root (one level above the vault dir). */
+  readonly projectRoot?: string;
+  /** Absolute path to the vault directory. */
+  readonly vaultDir?: string;
+  /** Raw RunOptions — exposed to honor executionOverrides.phases per-phase. */
+  readonly options?: RunOptions;
+
+  // --- mutable, passed by reference ----------------------------------------
+
+  /**
+   * Run checkpoint state. `executePhasedQuery` mutates `state.phases[...]`
+   * in place and the orchestrator reads the final state for DB persistence.
+   */
+  readonly checkpointState: RunCheckpointState;
+  /** Optional checkpoint-persistence callback invoked between waves. */
+  readonly persistCheckpoints?: (state: RunCheckpointState, phases: PhaseResult[]) => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Single-phase execution helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a single phase query through the selected runtime adapter.
+ *
+ * Separated from `executePhasedQuery` so waves can dispatch it via
+ * `Promise.allSettled`. Emits a runtime retry when session-resume fails
+ * against an adapter that advertises `supportsSessionResume`.
+ */
+export async function executePhase(
+  ctx: PhaseLoopContext,
+  phasePrompt: string,
+  phaseModel: string,
+  phase: PhaseDefinition,
+  toolSurface: {
+    agentId: string;
+    runId: string;
+    toolNames: string[];
+    turnOffset: number;
+    projectRoot?: string;
+    vaultDir?: string;
+    readOnly?: boolean;
+    embeddingManager?: RunOptions['embeddingManager'];
+    dryRun?: boolean;
+  },
+  provider?: ProviderConfig,
+  sessionId?: string,
+  sessionData?: unknown,
+): Promise<PhaseResult & { sessionData?: unknown }> {
+  const runtime = getAgentRuntime(ctx.config.runtime);
+  try {
+    let result;
+    try {
+      result = await runtime.execute({
+        prompt: phasePrompt,
+        model: phaseModel,
+        maxTurns: phase.maxTurns,
+        systemPrompt: ctx.systemPrompt,
+        provider,
+        sessionRef: sessionId,
+        sessionData,
+        abortController: ctx.abortController,
+        toolSurface,
+      });
+    } catch (error) {
+      if (!sessionId || !runtime.supports('supportsSessionResume') || !isSessionResumeFailure(error)) {
+        throw error;
+      }
+      console.warn(`[agent] Resuming phase "${phase.name}" session failed, retrying without prior session`);
+      result = await runtime.execute({
+        prompt: phasePrompt,
+        model: phaseModel,
+        maxTurns: phase.maxTurns,
+        systemPrompt: ctx.systemPrompt,
+        provider,
+        abortController: ctx.abortController,
+        toolSurface,
+      });
+    }
+
+    if (phase.maxTurns && result.turnsUsed > 0) {
+      console.log(`[agent] Phase "${phase.name}": num_turns=${result.turnsUsed}, budget=${phase.maxTurns}`);
+    }
+
+    if (phase.required && result.turnsUsed === 0) {
+      console.warn(`[agent] Required phase "${phase.name}" produced 0 turns`);
+    }
+
+    const costData = await resolveCost({
+      runtime: ctx.config.runtime,
+      provider,
+      model: phaseModel,
+      usage: result.usage,
+    });
+
+    return {
+      name: phase.name,
+      status: 'completed',
+      turnsUsed: result.turnsUsed,
+      tokensUsed: result.usage.totalTokens ?? 0,
+      costUsd: costData.costUsd ?? 0,
+      costSource: costData.source,
+      costData,
+      summary: result.finalText,
+      usage: result.usage,
+      sessionRef: result.sessionRef,
+      sessionData: result.sessionData,
+    };
+  } catch (err) {
+    const abortReason = abortReasonMessage(ctx.abortController);
+    return {
+      name: phase.name,
+      status: 'failed',
+      turnsUsed: 0,
+      tokensUsed: 0,
+      costUsd: 0,
+      summary: abortReason ? `Error: ${abortReason}` : `Error: ${toErrorMessage(err)}`,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Single-query execution (non-phased tasks)
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a single `runtime.execute()` call for tasks without a `phases`
+ * array. Returns tokens used, cost, and session data for resume support.
+ */
+export async function executeSingleQuery(
+  ctx: PhaseLoopContext,
+  taskPrompt: string,
+  provider?: ProviderConfig,
+  sessionRef?: string,
+  sessionData?: unknown,
+): Promise<{
+  tokensUsed: number;
+  costUsd: number | null;
+  costData: CostResolution;
+  usage: RuntimeUsage;
+  sessionRef?: string;
+  sessionData?: unknown;
+}> {
+  const runtime = getAgentRuntime(ctx.config.runtime);
+  const effectiveModel = resolveReasoningModel(
+    ctx.config.execution?.reasoningLevel ?? ctx.config.reasoningLevel,
+    provider,
+    ctx.config.model,
+  );
+  const result = await runtime.execute({
+    prompt: taskPrompt,
+    model: effectiveModel,
+    maxTurns: ctx.config.maxTurns,
+    systemPrompt: ctx.systemPrompt,
+    provider,
+    abortController: ctx.abortController,
+    sessionRef,
+    sessionData,
+    toolSurface: {
+      agentId: ctx.agentId,
+      runId: ctx.runId,
+      vaultDir: ctx.vaultDir,
+      embeddingManager: ctx.embeddingManager,
+      dryRun: ctx.config.dryRun ?? false,
+    },
+  });
+  const costData = await resolveCost({
+    runtime: ctx.config.runtime,
+    provider,
+    model: effectiveModel,
+    usage: result.usage,
+  });
+
+  return {
+    tokensUsed: result.usage.totalTokens ?? 0,
+    costUsd: costData.costUsd,
+    costData,
+    usage: result.usage,
+    sessionRef: result.sessionRef,
+    sessionData: result.sessionData,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Phased execution (wave-based parallel)
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a phased task — wave-based parallel `runtime.execute()` calls.
+ *
+ * Phases are sorted into waves via `computeWaves()`. Phases within the same
+ * wave execute concurrently via `Promise.allSettled()`. Each phase gets:
+ * - Scoped tools (only the tools listed in the phase definition)
+ * - Its own turn budget (maxTurns)
+ * - Optional model override (falls back to task/agent model)
+ * - Isolated provider env (via SDK `env` option — no process.env mutation)
+ * - Context from prior wave results
+ * - Deterministic session ID derived from run ID + phase name
+ *
+ * The executor controls the loop — the LLM cannot skip phases.
+ */
+export async function executePhasedQuery(
+  ctx: PhaseLoopContext,
+): Promise<{
+  tokensUsed: number;
+  costUsd: number | null;
+  costData: CostResolution;
+  usage: RuntimeUsage;
+  phases: PhaseResult[];
+}> {
+  const { config, systemPrompt, vaultContext, agentId, runId } = ctx;
+  const phases = config.phases!;
+  const state = ctx.checkpointState;
+  const phaseResults: PhaseResult[] = checkpointResultsForResume(config, state);
+  let runningTurnCount = phaseResults.reduce((sum, phase) => sum + phase.turnsUsed, 0);
+  const completedPhaseNames = new Set(phaseResults.map((phase) => phase.name));
+
+  // -------------------------------------------------------------------------
+  // Orchestrator planning (opt-in via config.orchestrator.enabled)
+  // -------------------------------------------------------------------------
+
+  let effectivePhases = [...phases];
+
+  if (config.orchestrator?.enabled) {
+    const contextQueries = config.contextQueries
+      ? Object.values(config.contextQueries).flat()
+      : [];
+    const contextResults: ContextQueryResult[] = contextQueries.length > 0
+      ? await executeContextQueries(agentId, contextQueries)
+      : [];
+
+    const orchestratorPrompt = composeOrchestratorPrompt(vaultContext, phases, contextResults);
+    const orchestratorModel = config.orchestrator.model ?? resolveReasoningModel(
+      config.orchestrator.reasoningLevel ?? config.execution?.reasoningLevel ?? config.reasoningLevel,
+      ctx.taskProviderOverride ?? config.execution?.provider,
+      config.model,
+    );
+    const orchestratorMaxTurns = config.orchestrator.maxTurns ?? DEFAULT_ORCHESTRATOR_MAX_TURNS;
+    const runtime = getAgentRuntime(config.runtime);
+    const planResponse = await runtime.execute({
+      prompt: orchestratorPrompt,
+      model: orchestratorModel,
+      maxTurns: orchestratorMaxTurns,
+      systemPrompt,
+      provider: ctx.taskProviderOverride ?? config.execution?.provider,
+      toolSurface: {
+        agentId,
+        runId,
+        toolNames: [],
+        vaultDir: ctx.vaultDir,
+        dryRun: config.dryRun ?? false,
+      },
+      abortController: ctx.abortController,
+    });
+
+    const plan = parseOrchestratorPlan(planResponse.finalText, phases);
+    effectivePhases = applyDirectives(phases, plan.phases);
+  }
+
+  // -------------------------------------------------------------------------
+  // Wave-based phase execution
+  // -------------------------------------------------------------------------
+
+  // Build a map from phase name to its YAML declaration order for stable output
+  const declarationOrder = new Map(phases.map((p, i) => [p.name, i]));
+
+  const waves = computeWaves(effectivePhases);
+
+  for (const wave of waves) {
+    const runnableWave = wave.filter((phase) => !completedPhaseNames.has(phase.name));
+    if (runnableWave.length === 0) {
+      continue;
+    }
+
+    const waveInputs = runnableWave.map((phase, indexInWave) => {
+      const phasePrompt = composePhasePrompt(
+        vaultContext,
+        config.taskDisplayName,
+        config.taskPrompt,
+        phase,
+        phaseResults,
+        ctx.instruction,
+      );
+
+      // Single canonical precedence resolution — covers run overrides,
+      // phase YAML, myco.yaml per-phase overrides, top-level run override,
+      // and the task default. See `resolvePhaseExecution` JSDoc for the
+      // full precedence table.
+      const resolved = resolvePhaseExecution(
+        phase,
+        ctx.options,
+        config,
+        ctx.taskProviderOverride ?? config.execution?.provider,
+        ctx.phaseProviderOverrides,
+      );
+      const phaseProvider = resolved.provider;
+      const effectiveMaxTurns = resolved.maxTurns;
+      const phaseModel = resolved.model;
+      const existingCheckpoint = state.phases[phase.name];
+      const sessionId = existingCheckpoint?.sessionRef ?? phaseSessionId(runId, phase.name);
+      const effectivePhase = effectiveMaxTurns !== phase.maxTurns
+        ? { ...phase, maxTurns: effectiveMaxTurns }
+        : phase;
+
+      state.phases[phase.name] = {
+        name: phase.name,
+        status: 'running',
+        summary: existingCheckpoint?.summary,
+        turnsUsed: existingCheckpoint?.turnsUsed,
+        tokensUsed: existingCheckpoint?.tokensUsed,
+        costUsd: existingCheckpoint?.costUsd,
+        costSource: existingCheckpoint?.costSource,
+        costData: existingCheckpoint?.costData,
+        sessionRef: sessionId,
+        sessionData: existingCheckpoint?.sessionData,
+        usage: existingCheckpoint?.usage,
+        updatedAt: epochSeconds(),
+      };
+
+      return {
+        phase,
+        phasePrompt,
+        phaseModel,
+        phaseProvider,
+        effectivePhase,
+        sessionId,
+        sessionData: existingCheckpoint?.sessionData,
+        toolSurface: {
+          agentId,
+          runId,
+          toolNames: phase.tools,
+          turnOffset: runningTurnCount + (indexInWave * effectiveMaxTurns),
+          projectRoot: ctx.projectRoot,
+          vaultDir: ctx.vaultDir,
+          readOnly: phase.readOnly,
+          embeddingManager: ctx.embeddingManager,
+          dryRun: config.dryRun ?? false,
+        },
+      };
+    });
+
+    if (ctx.persistCheckpoints) {
+      await ctx.persistCheckpoints(state, phaseResults);
+    }
+
+    const settled = await Promise.allSettled(
+      waveInputs.map((input) =>
+        executePhase(
+          ctx,
+          input.phasePrompt,
+          input.phaseModel,
+          input.effectivePhase,
+          input.toolSurface,
+          input.phaseProvider,
+          input.sessionId,
+          input.sessionData,
+        ),
+      ),
+    );
+
+    const fulfilledByName = new Map<string, PhaseResult & { sessionData?: unknown }>();
+    for (const [index, outcome] of settled.entries()) {
+      if (outcome.status === 'fulfilled') {
+        fulfilledByName.set(runnableWave[index].name, outcome.value);
+      }
+    }
+
+    // Map settled results to PhaseResult[]
+    const waveResults: PhaseResult[] = settled.map((outcome, i) => {
+      if (outcome.status === 'fulfilled') {
+        return outcome.value;
+      }
+      return {
+        name: runnableWave[i].name,
+        status: 'failed' as const,
+        turnsUsed: 0,
+        tokensUsed: 0,
+        costUsd: 0,
+        summary: `Error: ${toErrorMessage(outcome.reason)}`,
+      };
+    });
+
+    // Sort by YAML declaration order for stable output
+    waveResults.sort((a, b) =>
+      (declarationOrder.get(a.name) ?? 0) - (declarationOrder.get(b.name) ?? 0),
+    );
+
+    for (const result of waveResults) {
+      const priorCheckpoint = state.phases[result.name];
+      const fulfilled = fulfilledByName.get(result.name) ?? null;
+      state.phases[result.name] = {
+        name: result.name,
+        status: result.status === 'completed' ? 'completed' : 'failed',
+        summary: result.summary,
+        turnsUsed: result.turnsUsed,
+        tokensUsed: result.tokensUsed,
+        costUsd: result.costUsd,
+        costSource: result.costSource,
+        costData: result.costData,
+        sessionRef: fulfilled?.sessionRef ?? priorCheckpoint?.sessionRef,
+        sessionData: fulfilled?.sessionData ?? priorCheckpoint?.sessionData,
+        usage: fulfilled?.usage ?? result.usage,
+        updatedAt: epochSeconds(),
+      };
+      if (result.status === 'completed') {
+        completedPhaseNames.add(result.name);
+      }
+      phaseResults.push(result);
+      runningTurnCount += result.turnsUsed;
+    }
+
+    if (ctx.persistCheckpoints) {
+      await ctx.persistCheckpoints(state, phaseResults);
+    }
+
+    // If any required phase in this wave failed, stop the pipeline
+    const shouldStop = runnableWave.some((phase, i) => {
+      if (!phase.required) return false;
+      const outcome = settled[i];
+      if (outcome.status === 'rejected') return true;
+      return outcome.value.status === 'failed';
+    });
+
+    if (shouldStop) {
+      break;
+    }
+  }
+
+  const usage = aggregateUsage(phaseResults.map((phase) => phase.usage));
+  const costData = summarizePhaseCosts(phaseResults);
+  return {
+    tokensUsed: usage.totalTokens ?? phaseResults.reduce((sum, phase) => sum + phase.tokensUsed, 0),
+    costUsd: costData.costUsd,
+    costData,
+    usage,
+    phases: phaseResults,
+  };
+}

--- a/packages/myco/src/agent/phase-resolver.ts
+++ b/packages/myco/src/agent/phase-resolver.ts
@@ -1,0 +1,154 @@
+/**
+ * Phase-level execution resolution — extracted so both `executor.ts` (for
+ * re-export / direct tests) and `phase-loop.ts` (for the actual loop) can
+ * depend on it without introducing a circular import.
+ *
+ * `resolvePhaseExecution` reconciles all sources that can contribute to a
+ * single phase's `{ reasoningLevel, model, provider, maxTurns }`:
+ *
+ *   - RunOptions.executionOverrides (top-level + per-phase)
+ *   - phase.* (task YAML)
+ *   - myco.yaml per-phase overrides (keyed by phase name)
+ *   - task-level provider override (resolved from myco.yaml)
+ *   - EffectiveConfig (task / agent defaults)
+ */
+
+import { resolveReasoningModel } from './reasoning-levels.js';
+import type {
+  EffectiveConfig,
+  PhaseDefinition,
+  ProviderConfig,
+  ReasoningLevel,
+  RunOptions,
+} from './types.js';
+
+/**
+ * myco.yaml-sourced per-phase provider / model / maxTurns overrides, keyed
+ * by phase name. Passed through `resolveRunConfig` alongside the
+ * task-level provider override.
+ */
+export interface MycoYamlPhaseOverrides {
+  [phaseName: string]: {
+    provider?: ProviderConfig;
+    model?: string;
+    maxTurns?: number;
+  };
+}
+
+/**
+ * Walk an ordered list of lookups and return the first defined value. Keeps
+ * precedence chains declarative so unit tests can exercise each source
+ * individually without re-running the entire resolver.
+ */
+function firstDefined<T>(lookups: Array<() => T | undefined>): T | undefined {
+  for (const lookup of lookups) {
+    const value = lookup();
+    if (value !== undefined) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Compute the effective `{ reasoningLevel, model, provider, maxTurns }` for
+ * a single phase by reconciling all layered sources. Extracted for
+ * unit-testability — the wave loop calls this helper directly.
+ *
+ * Provider precedence (highest → lowest):
+ *   1. `options.executionOverrides.phases[name].provider` — run override
+ *   2. `phase.provider` — task YAML
+ *   3. `phaseProviderOverrides[name].provider` — myco.yaml per-phase override
+ *   4. `options.executionOverrides.provider` — top-level run override
+ *   5. `provider` parameter — task default / task override from myco.yaml
+ *
+ * Model precedence (highest → lowest):
+ *   1. `options.executionOverrides.phases[name].model`
+ *   2. `phaseProviderOverrides[name].model` (myco.yaml)
+ *   3. `resolveReasoningModel(effectiveReasoning, provider, fallback)`
+ *      where `fallback = phase.model ?? options.executionOverrides.model
+ *      ?? config.model`
+ *
+ * Reasoning precedence (highest → lowest):
+ *   1. `options.executionOverrides.phases[name].reasoningLevel`
+ *   2. `phase.reasoningLevel` (task YAML)
+ *   3. `options.executionOverrides.reasoningLevel`
+ *   4. `config.execution.reasoningLevel`
+ *   5. `config.reasoningLevel`
+ *
+ * maxTurns precedence (highest → lowest):
+ *   1. `options.executionOverrides.phases[name].maxTurns`
+ *   2. `phaseProviderOverrides[name].maxTurns` (myco.yaml)
+ *   3. `phase.maxTurns` (task YAML)
+ */
+export function resolvePhaseExecution(
+  phase: PhaseDefinition,
+  options: RunOptions | undefined,
+  config: EffectiveConfig,
+  provider: ProviderConfig | undefined,
+  phaseProviderOverrides?: MycoYamlPhaseOverrides,
+): { reasoningLevel: ReasoningLevel | undefined; model: string; maxTurns: number; provider: ProviderConfig | undefined } {
+  const runPhaseOverride = options?.executionOverrides?.phases?.[phase.name];
+  const topOverride = options?.executionOverrides;
+  const mycoYamlPhase = phaseProviderOverrides?.[phase.name];
+
+  const effectiveProvider = firstDefined<ProviderConfig>([
+    () => runPhaseOverride?.provider,
+    () => phase.provider,
+    () => mycoYamlPhase?.provider,
+    () => topOverride?.provider,
+    () => provider,
+  ]);
+
+  const effectiveReasoning = firstDefined<ReasoningLevel>([
+    () => runPhaseOverride?.reasoningLevel,
+    () => phase.reasoningLevel,
+    () => topOverride?.reasoningLevel,
+    () => config.execution?.reasoningLevel,
+    () => config.reasoningLevel,
+  ]);
+
+  const fallbackModel = firstDefined<string>([
+    () => phase.model,
+    () => topOverride?.model,
+    () => config.model,
+  ]);
+
+  const effectiveModel = firstDefined<string>([
+    () => runPhaseOverride?.model,
+    () => mycoYamlPhase?.model,
+    () => resolveReasoningModel(effectiveReasoning, effectiveProvider, fallbackModel ?? ''),
+  ]) ?? '';
+
+  const effectiveMaxTurns = runPhaseOverride?.maxTurns
+    ?? mycoYamlPhase?.maxTurns
+    ?? phase.maxTurns;
+
+  return {
+    reasoningLevel: effectiveReasoning,
+    model: effectiveModel,
+    maxTurns: effectiveMaxTurns,
+    provider: effectiveProvider,
+  };
+}
+
+/**
+ * Warn once per run when `executionOverrides.phases` contains keys that do
+ * not match any phase in the task. The warning lists the unknown keys and
+ * the task's actual phase names so callers can correct their payload.
+ */
+export function warnUnknownPhaseOverrides(
+  options: RunOptions | undefined,
+  taskPhases: readonly PhaseDefinition[] | undefined,
+): void {
+  const overridePhases = options?.executionOverrides?.phases;
+  if (!overridePhases) return;
+  const keys = Object.keys(overridePhases);
+  if (keys.length === 0) return;
+  const known = new Set((taskPhases ?? []).map((p) => p.name));
+  const unknown = keys.filter((k) => !known.has(k));
+  if (unknown.length === 0) return;
+  const taskPhaseNames = (taskPhases ?? []).map((p) => p.name);
+  console.warn(
+    `[agent] Unknown phase override keys: ${unknown.join(', ')} ` +
+    `(task phases: ${taskPhaseNames.join(', ') || '<none>'})`,
+  );
+}

--- a/tests/agent/phase-loop.test.ts
+++ b/tests/agent/phase-loop.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Unit tests for the extracted phase-loop functions.
+ *
+ * These tests call executePhase / executeSingleQuery / executePhasedQuery
+ * directly with a hand-constructed PhaseLoopContext, bypassing runAgent's
+ * DB bookkeeping. The runtime adapter is mocked so dispatch goes through
+ * a programmable fake instead of a real SDK.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type {
+  EffectiveConfig,
+  PhaseDefinition,
+  RuntimeUsage,
+  RuntimeId,
+} from '@myco/agent/types.js';
+import type { AgentRuntime, RuntimeExecuteInput, RuntimeExecuteResult } from '@myco/agent/runtime/types.js';
+import type { RunCheckpointState } from '@myco/agent/executor-state.js';
+
+// ---------------------------------------------------------------------------
+// Runtime mock — controls execute() behavior per test.
+// ---------------------------------------------------------------------------
+
+type RuntimeBehavior =
+  | { kind: 'success'; result?: Partial<RuntimeExecuteResult> }
+  | { kind: 'error'; message?: string }
+  | { kind: 'abort' };
+
+let runtimeBehaviors: RuntimeBehavior[] = [];
+let defaultRuntimeBehavior: RuntimeBehavior = { kind: 'success' };
+let capturedExecuteInputs: RuntimeExecuteInput[] = [];
+let runtimeSupportsSessionResume = false;
+
+const DEFAULT_USAGE: RuntimeUsage = {
+  requests: 1,
+  inputTokens: 100,
+  outputTokens: 200,
+  totalTokens: 300,
+  reasoningTokens: 0,
+  cachedTokens: 0,
+  durationMs: 10,
+};
+
+function nextBehavior(): RuntimeBehavior {
+  return runtimeBehaviors.length > 0 ? runtimeBehaviors.shift()! : defaultRuntimeBehavior;
+}
+
+const fakeRuntime: AgentRuntime = {
+  id: 'claude-sdk' as RuntimeId,
+  async execute(input: RuntimeExecuteInput): Promise<RuntimeExecuteResult> {
+    capturedExecuteInputs.push(input);
+    const behavior = nextBehavior();
+    if (behavior.kind === 'error') {
+      throw new Error(behavior.message ?? 'runtime error');
+    }
+    if (behavior.kind === 'abort') {
+      const c = input.abortController;
+      if (c instanceof AbortController) {
+        c.abort(new Error('aborted by test'));
+      }
+      throw new Error('runtime aborted');
+    }
+    return {
+      finalText: 'ok',
+      turnsUsed: 1,
+      usage: DEFAULT_USAGE,
+      sessionRef: 'session-' + (capturedExecuteInputs.length),
+      ...behavior.result,
+    };
+  },
+  supports(capability) {
+    if (capability === 'supportsSessionResume') return runtimeSupportsSessionResume;
+    return false;
+  },
+};
+
+vi.mock('@myco/agent/runtime/index.js', () => ({
+  getAgentRuntime: () => fakeRuntime,
+}));
+
+// Cost resolution is async but doesn't need real numbers here.
+vi.mock('@myco/agent/cost/index.js', () => ({
+  resolveCost: async () => ({
+    source: 'actual' as const,
+    costUsd: 0.01,
+    actualCostUsd: 0.01,
+    estimatedCostUsd: 0,
+    breakdown: {
+      inputTokens: 100,
+      cachedInputTokens: 0,
+      uncachedInputTokens: 100,
+      outputTokens: 200,
+      reasoningTokens: 0,
+      requestCount: 1,
+      totalCostUsd: 0.01,
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports AFTER vi.mock() so the mocks apply.
+// ---------------------------------------------------------------------------
+
+import {
+  executePhase,
+  executeSingleQuery,
+  executePhasedQuery,
+  type PhaseLoopContext,
+} from '@myco/agent/phase-loop.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function baseConfig(phases?: PhaseDefinition[]): EffectiveConfig {
+  return {
+    taskName: 'test-task',
+    taskDisplayName: 'Test Task',
+    taskPrompt: 'Do the thing.',
+    systemPromptPath: 'prompts/system.md',
+    runtime: 'claude-sdk',
+    model: 'claude-sonnet-4',
+    maxTurns: 5,
+    timeoutSeconds: 60,
+    tools: [],
+    ...(phases ? { phases } : {}),
+  } as EffectiveConfig;
+}
+
+function baseCheckpoint(): RunCheckpointState {
+  return {
+    runtime: 'claude-sdk',
+    phases: {},
+  };
+}
+
+function baseContext(overrides: Partial<PhaseLoopContext> = {}): PhaseLoopContext {
+  return {
+    config: baseConfig(),
+    systemPrompt: 'SYSTEM',
+    vaultContext: 'VAULT CONTEXT',
+    agentId: 'myco-agent',
+    runId: 'run-123',
+    instruction: undefined,
+    abortController: new AbortController(),
+    projectRoot: '/tmp/project',
+    vaultDir: '/tmp/project/.myco',
+    options: undefined,
+    checkpointState: baseCheckpoint(),
+    ...overrides,
+  };
+}
+
+function phase(name: string, extra: Partial<PhaseDefinition> = {}): PhaseDefinition {
+  return {
+    name,
+    prompt: `prompt for ${name}`,
+    tools: [],
+    maxTurns: 3,
+    required: false,
+    ...extra,
+  } as PhaseDefinition;
+}
+
+// ---------------------------------------------------------------------------
+// Reset per test
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  runtimeBehaviors = [];
+  defaultRuntimeBehavior = { kind: 'success' };
+  capturedExecuteInputs = [];
+  runtimeSupportsSessionResume = false;
+});
+
+// ---------------------------------------------------------------------------
+// executePhase — happy path, error, abort
+// ---------------------------------------------------------------------------
+
+describe('executePhase', () => {
+  it('returns a completed PhaseResult on runtime success', async () => {
+    const ctx = baseContext();
+    const p = phase('draft');
+    const result = await executePhase(
+      ctx,
+      'PROMPT',
+      'claude-sonnet-4',
+      p,
+      {
+        agentId: ctx.agentId,
+        runId: ctx.runId,
+        toolNames: [],
+        turnOffset: 0,
+      },
+    );
+    expect(result.status).toBe('completed');
+    expect(result.name).toBe('draft');
+    expect(result.turnsUsed).toBe(1);
+    expect(capturedExecuteInputs).toHaveLength(1);
+    expect(capturedExecuteInputs[0].systemPrompt).toBe('SYSTEM');
+  });
+
+  it('returns a failed PhaseResult when runtime throws', async () => {
+    defaultRuntimeBehavior = { kind: 'error', message: 'boom' };
+    const ctx = baseContext();
+    const result = await executePhase(
+      ctx,
+      'PROMPT',
+      'claude-sonnet-4',
+      phase('draft'),
+      { agentId: ctx.agentId, runId: ctx.runId, toolNames: [], turnOffset: 0 },
+    );
+    expect(result.status).toBe('failed');
+    expect(result.summary).toContain('boom');
+  });
+
+  it('reports abort reason when the run is aborted mid-execution', async () => {
+    defaultRuntimeBehavior = { kind: 'abort' };
+    const ctx = baseContext();
+    const result = await executePhase(
+      ctx,
+      'PROMPT',
+      'claude-sonnet-4',
+      phase('draft'),
+      { agentId: ctx.agentId, runId: ctx.runId, toolNames: [], turnOffset: 0 },
+    );
+    expect(result.status).toBe('failed');
+    expect(result.summary).toContain('aborted');
+    expect(ctx.abortController!.signal.aborted).toBe(true);
+  });
+
+  it('retries without sessionRef when session resume fails on a supporting runtime', async () => {
+    runtimeSupportsSessionResume = true;
+    runtimeBehaviors = [{ kind: 'error', message: 'unable to resume session' }];
+    // Default success for the retry
+    const ctx = baseContext();
+    const result = await executePhase(
+      ctx,
+      'PROMPT',
+      'claude-sonnet-4',
+      phase('draft'),
+      { agentId: ctx.agentId, runId: ctx.runId, toolNames: [], turnOffset: 0 },
+      undefined,
+      'prior-session',
+    );
+    expect(result.status).toBe('completed');
+    // Two execute calls: first with sessionRef, retry without.
+    expect(capturedExecuteInputs).toHaveLength(2);
+    expect(capturedExecuteInputs[0].sessionRef).toBe('prior-session');
+    expect(capturedExecuteInputs[1].sessionRef).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executeSingleQuery — happy path
+// ---------------------------------------------------------------------------
+
+describe('executeSingleQuery', () => {
+  it('returns tokensUsed + cost on success', async () => {
+    const ctx = baseContext();
+    const result = await executeSingleQuery(ctx, 'PROMPT');
+    expect(result.tokensUsed).toBe(300);
+    expect(result.costUsd).toBe(0.01);
+    expect(result.usage.totalTokens).toBe(300);
+    expect(capturedExecuteInputs).toHaveLength(1);
+  });
+
+  it('forwards sessionRef/sessionData into the runtime call', async () => {
+    const ctx = baseContext();
+    await executeSingleQuery(ctx, 'PROMPT', undefined, 'prev-session', { key: 1 });
+    expect(capturedExecuteInputs[0].sessionRef).toBe('prev-session');
+    expect(capturedExecuteInputs[0].sessionData).toEqual({ key: 1 });
+  });
+
+  it('propagates errors by throwing', async () => {
+    defaultRuntimeBehavior = { kind: 'error', message: 'sdk_fail' };
+    const ctx = baseContext();
+    await expect(executeSingleQuery(ctx, 'PROMPT')).rejects.toThrow(/sdk_fail/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executePhasedQuery — waves, checkpoint mutation, required-phase stop.
+// ---------------------------------------------------------------------------
+
+describe('executePhasedQuery', () => {
+  it('runs phases in order and aggregates usage/cost', async () => {
+    const phases = [phase('a'), phase('b')];
+    const ctx = baseContext({ config: baseConfig(phases) });
+    const result = await executePhasedQuery(ctx);
+    expect(result.phases).toHaveLength(2);
+    expect(result.phases.map((p) => p.name)).toEqual(['a', 'b']);
+    expect(result.phases.every((p) => p.status === 'completed')).toBe(true);
+    // 2 phases × DEFAULT_USAGE.totalTokens(300) = 600
+    expect(result.tokensUsed).toBe(600);
+  });
+
+  it('mutates checkpointState on the context so finalization can read it back', async () => {
+    const phases = [phase('a'), phase('b')];
+    const checkpointState = baseCheckpoint();
+    const ctx = baseContext({ config: baseConfig(phases), checkpointState });
+    await executePhasedQuery(ctx);
+    expect(Object.keys(checkpointState.phases).sort()).toEqual(['a', 'b']);
+    expect(checkpointState.phases.a.status).toBe('completed');
+    expect(checkpointState.phases.b.status).toBe('completed');
+  });
+
+  it('invokes persistCheckpoints between waves', async () => {
+    const phases = [phase('a'), phase('b')];
+    const persistCheckpoints = vi.fn().mockResolvedValue(undefined);
+    const ctx = baseContext({
+      config: baseConfig(phases),
+      persistCheckpoints,
+    });
+    await executePhasedQuery(ctx);
+    expect(persistCheckpoints).toHaveBeenCalled();
+  });
+
+  it('stops the pipeline when a required phase fails in an earlier wave', async () => {
+    // Two waves: 'a' (required, wave 0) → 'b' (dependsOn a, wave 1).
+    // 'a' fails; 'b' must not run.
+    const phases = [
+      phase('a', { required: true }),
+      phase('b', { dependsOn: ['a'] } as Partial<PhaseDefinition>),
+    ];
+    runtimeBehaviors = [{ kind: 'error', message: 'required phase crashed' }];
+    defaultRuntimeBehavior = { kind: 'success' };
+    const ctx = baseContext({ config: baseConfig(phases) });
+    const result = await executePhasedQuery(ctx);
+    expect(result.phases.find((p) => p.name === 'a')?.status).toBe('failed');
+    expect(result.phases.find((p) => p.name === 'b')).toBeUndefined();
+  });
+
+  it('records failed phases when the abort signal fires mid-execution', async () => {
+    const phases = [phase('a')];
+    defaultRuntimeBehavior = { kind: 'abort' };
+    const ctx = baseContext({ config: baseConfig(phases) });
+    const result = await executePhasedQuery(ctx);
+    expect(result.phases[0].status).toBe('failed');
+    expect(ctx.abortController!.signal.aborted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

**Bundle I — final v0.22 follow-up PR.** Completes the executor.ts shrink that Bundle E started. Pure refactor, zero behavior change. Targets `v0.22-dev`, not `main`.

Closes #106

## What changed

### Line counts

| Before | After |
|---|---|
| `executor.ts`: **1207 lines** | `executor.ts`: **626 lines** |
| (monolith) | `phase-loop.ts`: **515 lines** (new) |
| (embedded) | `phase-resolver.ts`: **154 lines** (new) |

Target was < 700. Landed at 626.

### New modules

- **`packages/myco/src/agent/phase-loop.ts`** — owns `executePhase`, `executeSingleQuery`, `executePhasedQuery`, and their immediate helpers. All three take a `PhaseLoopContext` parameter object instead of closure-capturing state.
- **`packages/myco/src/agent/phase-resolver.ts`** — owns `resolvePhaseExecution`, `warnUnknownPhaseOverrides`, `MycoYamlPhaseOverrides`. Extracted because both `executor.ts` AND `phase-loop.ts` need to call the resolver; leaving it in either would create a circular import. `executor.ts` retains backward-compat re-exports so existing tests keep working without modification.

### `PhaseLoopContext`

15 fields total:
- **Read-only (13):** `config`, `systemPrompt`, `vaultContext`, `agentId`, `runId`, `taskProviderOverride`, `phaseProviderOverrides`, `instruction`, `embeddingManager`, `abortController`, `projectRoot`, `vaultDir`, `options`
- **Mutable-by-reference (2):** `checkpointState` (mutated in place by the wave loop; `runAgent` reads back final `.phases`/`.sessionRef` for DB finalization), `persistCheckpoints` (callback)

Context is a "view" over orchestrator state, not a copy. The mutation contract is documented inline.

### Behavior preservation

The `runAgent` body diff is purely mechanical:
1. Compute `projectRoot` once
2. Construct `PhaseLoopContext` (17-line literal)
3. Replace `executePhasedQuery(...17 positional args)` → `executePhasedQuery(ctx)`
4. Replace `executeSingleQuery(...11 positional args)` → `executeSingleQuery(ctx, taskPrompt, singleProvider, sessionRef, sessionData)`

No control-flow change, no conditional logic change, no finalization drift. One subtle **tightening**: old `executePhasedQuery` had a default for `checkpointState`; new `phase-loop.ts` requires it non-nullable. `runAgent` always constructs it before calling, so this is dead-code retirement, not a behavior change.

## Test plan

- [x] `make build` — all packages + UI bundle
- [x] `make check` — **3052 passed, 3 skipped, 0 failed** (baseline 3040 + 12 phase-loop cases)
- [x] Existing `executor.test.ts`, `executor-dry-run.test.ts`, `executor-openai-agents.test.ts` — unchanged and green
- [x] New `tests/agent/phase-loop.test.ts` — 12 cases: happy path for all three functions, runtime error propagation, abort mid-execution, session-resume retry on supporting runtime, wave scheduling + order, checkpoint-state mutation, `persistCheckpoints` invocation, required-phase stop across waves
- [x] Circular-import audit: `phase-resolver.ts` imports only `reasoning-levels` + `types`. `phase-loop.ts` does not import from `executor.ts`. Graph is a DAG.
- [x] Review: ✅ Approved — "ship it" verdict from combined spec + quality pass

## Pipeline

Implementer → combined review (✅ approved, no in-PR fixes). One commit on this branch; will squash-merge to `v0.22-dev`.

## After this merge

All 9 post-0.21 follow-up issues closed. `v0.22-dev` will be ready to open as its own PR against `main`, gated on your end-to-end validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)