### PR TITLE
feat: add pi coding agent as 8th symbiont

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Myco — Collective Agent Intelligence
 
-Captures session knowledge (events, observations, summaries) into a SQLite-backed intelligence graph and serves it back via MCP tools. Supports Claude Code, Cursor, Codex, VS Code Copilot, Gemini CLI, Windsurf, and OpenCode.
+Captures session knowledge (events, observations, summaries) into a SQLite-backed intelligence graph and serves it back via MCP tools. Supports Claude Code, Cursor, Codex, VS Code Copilot, Gemini CLI, Windsurf, OpenCode, and Pi.
 
 ## Dogfooding
 
@@ -198,7 +198,7 @@ Exceptions: array indices (`[0]`), string operations (`.slice(0, 10)` for ISO da
 | **Lineage edge** | Automatic graph connection created by daemon on insert: FROM_SESSION, EXTRACTED_FROM, HAS_BATCH, DERIVED_FROM. No LLM needed. |
 | **Semantic edge** | Intelligence graph connection created by agent: RELATES_TO, SUPERSEDED_BY, REFERENCES, DEPENDS_ON, AFFECTS. LLM-driven. |
 | **Graph edge** | Stored in `graph_edges` table. Supports cross-type references between session, batch, spore, and entity nodes. |
-| **Symbiont** | External coding agent that Myco integrates with (Claude Code, Cursor, Codex, VS Code Copilot, Gemini CLI, Windsurf, OpenCode). Named for the mycorrhizal symbiotic relationship. Declared via YAML manifests in `src/symbionts/manifests/`. |
+| **Symbiont** | External coding agent that Myco integrates with (Claude Code, Cursor, Codex, VS Code Copilot, Gemini CLI, Windsurf, OpenCode, Pi). Named for the mycorrhizal symbiotic relationship. Declared via YAML manifests in `src/symbionts/manifests/`. |
 | **Wave** | Group of phases whose dependencies are all satisfied, executing in parallel via `Promise.allSettled()`. The executor computes waves from the phase `dependsOn` DAG using topological sort. |
 | **Phase dependency** | DAG edge between phases declared via `dependsOn` in task YAML. Phases depend on named predecessors; the executor resolves these into execution waves. |
 
@@ -288,7 +288,7 @@ make build
 1. Create manifest at `src/symbionts/manifests/<name>.yaml` with registration targets. `loadManifests()` auto-discovers any YAML in this directory — no code change needed to register the manifest itself.
 2. Create templates at `src/symbionts/templates/<name>/`:
    - **JSON hooks (default):** `hooks.json`, `mcp.json`, `settings.json` — merged into the agent's config files.
-   - **Plugin-file hooks (opencode):** `plugin.ts` + `package.json` + `mcp.json` + `settings.json`. Declare `hooksFormat: plugin-file` in the manifest and point `hooksTarget` at the plugin file path (e.g., `.opencode/plugins/myco.ts`). Also set `pluginPackageTarget` to write the plugin's deps manifest.
+   - **Plugin-file hooks (opencode, pi):** `plugin.ts` + `package.json` + optional `mcp.json` + `settings.json`. Declare `hooksFormat: plugin-file` in the manifest and point `hooksTarget` at the plugin file path (e.g., `.opencode/plugins/myco.ts`, `.pi/extensions/myco/index.ts`). Also set `pluginPackageTarget` to write the plugin's deps manifest.
    - **Non-standard MCP keys:** if the agent stores MCP servers under a key other than `mcpServers` (opencode uses `mcp`), set `mcpServersKey` in the manifest. Any downstream code that reads MCP state must resolve the key via the manifest, not hardcode `mcpServers`.
 3. **Optional** — implement a transcript adapter in `src/symbionts/<name>.ts` (NOT `src/symbionts/adapters/<name>.ts` — that subdirectory does not exist). Skip this step for agents that don't expose on-disk transcript files; Myco will reconstruct turns from the buffered hook events.
 4. If you implemented an adapter, register it in `src/symbionts/registry.ts` `ALL_ADAPTERS`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -618,6 +618,10 @@ myco init</code></div>
         <span class="agent-name">OpenCode</span>
         <span class="agent-status full">Full support</span>
       </div>
+      <div class="agent-card">
+        <span class="agent-name">Pi</span>
+        <span class="agent-status full">Full support</span>
+      </div>
     </div>
   </section>
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -4,7 +4,7 @@ Myco runs a long-lived background daemon that captures session activity, process
 
 ## Session capture
 
-When you start a session in any configured agent (Claude Code, Cursor, Codex, etc.), the symbiont's hooks register the session with the daemon and begin capturing events:
+When you start a session in any configured agent (Claude Code, Cursor, Codex, Pi, etc.), the symbiont's hooks register the session with the daemon and begin capturing events:
 
 - **User prompts** — every message you send the agent
 - **Tool uses** — every file read, bash command, edit, or search the agent runs

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ Myco is a collective agent intelligence plugin that captures session knowledge �
 ## Requirements
 
 - **Node.js 22+**
-- **At least one supported coding agent** — Claude Code, Cursor, Codex, VS Code Copilot, Gemini CLI, Windsurf, or OpenCode
+- **At least one supported coding agent** — Claude Code, Cursor, Codex, VS Code Copilot, Gemini CLI, Windsurf, OpenCode, or Pi
 
 Provider configuration (Myco Agent and embedding) is **optional** at install time — Myco works in data-collection mode out of the box, with full-text search over captured sessions. To enable the intelligence pipeline (spores, digest, skill lifecycle), configure providers in the dashboard after init.
 
@@ -57,7 +57,7 @@ myco init
 
 `myco init` is a fast bootstrap. It:
 
-1. **Detects coding agents** — finds Claude Code, Cursor, Codex, VS Code Copilot, Gemini CLI, Windsurf, or OpenCode and lets you pick which to register
+1. **Detects coding agents** — finds Claude Code, Cursor, Codex, VS Code Copilot, Gemini CLI, Windsurf, OpenCode, or Pi and lets you pick which to register
 2. **Installs hooks, MCP entries, and skills** for each selected agent
 3. **Starts the daemon** in the background
 4. **Opens the dashboard** to the Settings page so you can configure providers when ready

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -64,7 +64,7 @@ A validation gate enforces these conventions. Skills that fail validation are re
 
 ## How skills reach agents
 
-Skills are written to `.agents/skills/<name>/SKILL.md` — the emerging cross-agent standard directory. Agents that use `.agents/skills/` natively (Codex, VS Code Copilot, Gemini CLI, Windsurf, OpenCode) pick them up directly. For Claude Code and Cursor, `myco init` and `myco update` create symlinks from the agent's native skills directory to the canonical location.
+Skills are written to `.agents/skills/<name>/SKILL.md` — the emerging cross-agent standard directory. Agents that use `.agents/skills/` natively (Codex, VS Code Copilot, Gemini CLI, Windsurf, OpenCode, Pi) pick them up directly. For Claude Code and Cursor, `myco init` and `myco update` create symlinks from the agent's native skills directory to the canonical location.
 
 Run `myco update` after new skills are generated to refresh the symlinks.
 

--- a/docs/symbionts.md
+++ b/docs/symbionts.md
@@ -99,6 +99,17 @@ The first plugin-based symbiont. OpenCode has no JSON hook file — hooks are de
 
 **Plan mode note:** OpenCode's Plan mode only allows `edit` on existing files under `.opencode/plans/*.md`. To author a new plan in Plan mode, create the file first in Build mode (`touch .opencode/plans/my-plan.md`) before switching to Plan mode.
 
+### Pi
+
+A plugin-based symbiont like OpenCode. Pi has no JSON hook file or native MCP — hooks and Myco tools are delivered as a TypeScript extension that pi's runtime loads at startup.
+
+| Component | Location |
+|-----------|----------|
+| Extension | `.pi/extensions/myco/index.ts` |
+| MCP tools | Registered via `pi.registerTool()` (no separate MCP config) |
+| Skills | `.agents/skills/` (native) |
+| Plans | `.pi/plans/` |
+
 ## Removing Myco
 
 ```bash

--- a/packages/myco/src/symbionts/manifests/pi.yaml
+++ b/packages/myco/src/symbionts/manifests/pi.yaml
@@ -1,0 +1,22 @@
+name: pi
+displayName: Pi
+binary: pi
+configDir: .pi
+pluginRootEnvVar: PI_PLUGIN_ROOT
+hookFields:
+  sessionId: session_id
+  transcriptPath: transcript_path
+  lastResponse: last_assistant_message
+capture:
+  planDirs:
+    - .pi/plans/
+registration:
+  # Pi uses an extension file, not JSON hook entries
+  hooksTarget: .pi/extensions/myco/index.ts
+  hooksFormat: plugin-file
+  # package.json for the extension's deps
+  pluginPackageTarget: .pi/extensions/myco/package.json
+  # Pi has no native MCP — Myco tools are registered via pi.registerTool()
+  # mcpTarget is omitted; tools are wired in the extension itself.
+  skillsTarget: .agents/skills
+  # No instructionsFile — pi reads AGENTS.md natively via context files

--- a/packages/myco/src/symbionts/templates/pi/package.json
+++ b/packages/myco/src/symbionts/templates/pi/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@mariozechner/pi-coding-agent": "*",
+    "@sinclair/typebox": "*"
+  }
+}

--- a/packages/myco/src/symbionts/templates/pi/plugin.ts
+++ b/packages/myco/src/symbionts/templates/pi/plugin.ts
@@ -1,0 +1,559 @@
+// Managed by Myco. Regenerated on `myco update`. Edit src/symbionts/templates/pi/plugin.ts in the Myco repo instead.
+// myco:plugin-marker:pi
+//
+// Myco Codebase Intelligence Extension for Pi.
+//
+// This extension runs inside pi's extension runtime (jiti) and communicates with
+// the local Myco daemon over HTTP — no subprocess spawns, no hook CLI, no stdin piping.
+//
+//   Capture: POST /sessions/register, /sessions/unregister, /events, /events/stop
+//   Context: POST /context, /context/resume
+//   Inject:  before_agent_start → systemPrompt augmentation
+//
+// See https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/extensions.md
+//
+// Degraded-mode safety: this extension ships committed inside any project that has
+// run `myco init` — the file lives at .pi/extensions/myco/index.ts in that project's
+// repo. When a teammate clones such a project WITHOUT having Myco installed
+// locally, pi will still load this extension. Every path that would contact the
+// Myco daemon gracefully no-ops when `.myco/daemon.json` is absent or the daemon
+// is unreachable, so the extension becomes invisible rather than throwing.
+// Do NOT add runtime imports from Myco packages — only use pi's own exports
+// and Node.js built-ins.
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { readFileSync, appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { Type } from "@sinclair/typebox";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Keep in sync with `TOOL_OUTPUT_PREVIEW_CHARS` in src/constants.ts (currently 200).
+ * The extension file is standalone and cannot import from Myco — this value is copied
+ * so every symbiont records tool_output previews at the same length.
+ */
+const TOOL_OUTPUT_PREVIEW_CHARS = 200;
+
+/** Timeout for daemon HTTP calls — must be short so we never block pi. */
+const MYCO_FETCH_TIMEOUT_MS = 3000;
+
+/** Max size of resume context injection to keep resumed sessions lean. */
+const RESUME_CONTEXT_MAX_CHARS = 4000;
+
+// ---------------------------------------------------------------------------
+// Daemon HTTP transport
+// ---------------------------------------------------------------------------
+
+let cachedDaemonPort: number | null | undefined = undefined;
+
+function readDaemonPortFromDisk(directory: string): number | null {
+  try {
+    const raw = readFileSync(join(directory, ".myco", "daemon.json"), "utf-8");
+    const info = JSON.parse(raw) as { port?: number };
+    return typeof info.port === "number" ? info.port : null;
+  } catch {
+    return null;
+  }
+}
+
+function getDaemonPort(directory: string): number | null {
+  if (cachedDaemonPort === undefined) cachedDaemonPort = readDaemonPortFromDisk(directory);
+  return cachedDaemonPort;
+}
+
+function refreshDaemonPort(directory: string): number | null {
+  cachedDaemonPort = readDaemonPortFromDisk(directory);
+  return cachedDaemonPort;
+}
+
+async function fetchWithTimeout(url: string, init?: RequestInit): Promise<Response | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), MYCO_FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal });
+    return res.ok ? res : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function fetchFromDaemon(
+  directory: string,
+  urlPath: string,
+  init?: RequestInit,
+): Promise<Response | null> {
+  const port = getDaemonPort(directory);
+  if (!port) return null;
+
+  const first = await fetchWithTimeout(`http://localhost:${port}${urlPath}`, init);
+  if (first) return first;
+
+  // Retry once with a refreshed port — the daemon may have restarted.
+  const freshPort = refreshDaemonPort(directory);
+  if (!freshPort || freshPort === port) return null;
+  return fetchWithTimeout(`http://localhost:${freshPort}${urlPath}`, init);
+}
+
+async function postJson(
+  directory: string,
+  urlPath: string,
+  body: Record<string, unknown>,
+): Promise<{ ok: boolean; data?: unknown }> {
+  const res = await fetchFromDaemon(directory, urlPath, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res) return { ok: false };
+  try {
+    return { ok: true, data: await res.json() };
+  } catch {
+    return { ok: true };
+  }
+}
+
+async function getJson(
+  directory: string,
+  urlPath: string,
+): Promise<{ ok: boolean; data?: unknown }> {
+  const res = await fetchFromDaemon(directory, urlPath);
+  if (!res) return { ok: false };
+  try {
+    return { ok: true, data: await res.json() };
+  } catch {
+    return { ok: true };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Buffer fallback — identical pattern to opencode plugin
+// ---------------------------------------------------------------------------
+
+function bufferEvent(
+  directory: string,
+  sessionId: string,
+  event: Record<string, unknown>,
+): void {
+  try {
+    const bufferDir = join(directory, ".myco", "buffer");
+    mkdirSync(bufferDir, { recursive: true });
+    const filePath = join(bufferDir, `${sessionId}.jsonl`);
+    const { session_id: _sid, ...payload } = event;
+    const line = JSON.stringify({
+      ...payload,
+      timestamp: payload.timestamp ?? new Date().toISOString(),
+    });
+    appendFileSync(filePath, line + "\n");
+  } catch {
+    // Best-effort — swallow to never crash pi
+  }
+}
+
+async function postEventWithBuffer(
+  directory: string,
+  sessionId: string,
+  event: Record<string, unknown>,
+): Promise<void> {
+  const result = await postJson(directory, "/events", event);
+  if (!result.ok) {
+    bufferEvent(directory, sessionId, event);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Daemon API wrappers
+// ---------------------------------------------------------------------------
+
+async function mycoRegisterSession(
+  directory: string,
+  sessionId: string,
+): Promise<void> {
+  await postJson(directory, "/sessions/register", {
+    session_id: sessionId,
+    agent: "pi",
+    started_at: new Date().toISOString(),
+  });
+}
+
+async function mycoUnregisterSession(directory: string, sessionId: string): Promise<void> {
+  await postJson(directory, "/sessions/unregister", { session_id: sessionId });
+}
+
+async function mycoPostUserPrompt(
+  directory: string,
+  sessionId: string,
+  prompt: string,
+  images: Array<{ data: string; mediaType: string }>,
+): Promise<void> {
+  await postEventWithBuffer(directory, sessionId, {
+    type: "user_prompt",
+    session_id: sessionId,
+    agent: "pi",
+    prompt,
+    ...(images.length > 0 ? { images } : {}),
+  });
+}
+
+async function mycoPostToolUse(
+  directory: string,
+  sessionId: string,
+  toolName: string,
+  toolInput: unknown,
+  toolOutput: string,
+): Promise<void> {
+  await postEventWithBuffer(directory, sessionId, {
+    type: "tool_use",
+    session_id: sessionId,
+    agent: "pi",
+    tool_name: toolName,
+    tool_input: toolInput,
+    output_preview: toolOutput,
+  });
+}
+
+async function mycoPostStop(
+  directory: string,
+  sessionId: string,
+  lastAssistantMessage: string | undefined,
+): Promise<void> {
+  await postJson(directory, "/events/stop", {
+    session_id: sessionId,
+    agent: "pi",
+    last_assistant_message: lastAssistantMessage,
+  });
+}
+
+async function fetchMycoSessionContext(
+  directory: string,
+  sessionId: string,
+): Promise<string | null> {
+  const result = await postJson(directory, "/context", { session_id: sessionId });
+  if (!result.ok) return null;
+  const data = result.data as { text?: string } | undefined;
+  const text = data?.text?.trim() ?? "";
+  return text.length > 0 ? text : null;
+}
+
+async function fetchMycoResumeContext(
+  directory: string,
+  sessionId: string,
+  parentSessionId: string,
+): Promise<string | null> {
+  const result = await postJson(directory, "/context/resume", {
+    session_id: sessionId,
+    parent_session_id: parentSessionId,
+  });
+  if (!result.ok) return null;
+  const data = result.data as { text?: string } | undefined;
+  const text = data?.text?.trim() ?? "";
+  if (!text || text.length > RESUME_CONTEXT_MAX_CHARS) return null;
+  return text;
+}
+
+async function mycoPostCompact(
+  directory: string,
+  sessionId: string,
+): Promise<void> {
+  await postEventWithBuffer(directory, sessionId, {
+    type: "pre_compact",
+    session_id: sessionId,
+    agent: "pi",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function summarizeToolOutput(output: unknown): string {
+  if (typeof output !== "string") return "";
+  return output.length > TOOL_OUTPUT_PREVIEW_CHARS
+    ? output.slice(0, TOOL_OUTPUT_PREVIEW_CHARS) + "..."
+    : output;
+}
+
+/**
+ * Derive a stable session ID from pi's session file path.
+ * Pi sessions are stored as JSONL files with UUID-based names
+ * at ~/.pi/agent/sessions/<path-hash>/<timestamp>_<uuid>.jsonl.
+ * We extract the filename (without extension) as the session ID.
+ */
+function deriveSessionId(sessionFile: string | null): string | null {
+  if (!sessionFile) return null;
+  const base = sessionFile.split("/").pop() ?? sessionFile;
+  return base.replace(/\.jsonl$/, "");
+}
+
+/**
+ * Extract text content from pi message content (string or content block array).
+ */
+function extractTextFromContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((c: { type?: string; text?: string }) => c.type === "text" && c.text)
+    .map((c: { text: string }) => c.text)
+    .join("\n");
+}
+
+/**
+ * Extract images from a pi message content array.
+ */
+function extractImagesFromContent(content: unknown): Array<{ data: string; mediaType: string }> {
+  if (!Array.isArray(content)) return [];
+  return content
+    .filter((c: { type?: string; data?: string; mimeType?: string }) =>
+      c.type === "image" && c.data && c.mimeType)
+    .map((c: { data: string; mimeType: string }) => ({
+      data: c.data,
+      mediaType: c.mimeType,
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Extension entry
+// ---------------------------------------------------------------------------
+
+export default function (pi: ExtensionAPI) {
+  let currentSessionId: string | null = null;
+  let currentCwd: string = process.cwd();
+  let lastAssistantMessage: string = "";
+
+  // ── Session lifecycle ──────────────────────────────────────────────────
+
+  pi.on("session_start", async (event, ctx) => {
+    currentCwd = ctx.cwd;
+
+    // Check if daemon is available — silent no-op if not
+    if (!getDaemonPort(currentCwd)) return;
+
+    const sessionFile = ctx.sessionManager.getSessionFile();
+    const sessionId = deriveSessionId(sessionFile);
+    if (!sessionId) return;
+
+    currentSessionId = sessionId;
+    lastAssistantMessage = "";
+
+    const isResume = event.reason === "resume";
+    const isFork = event.reason === "fork";
+
+    // Register with the daemon
+    await mycoRegisterSession(currentCwd, sessionId);
+
+    // Fetch and inject context as a persistent custom message.
+    // Pi's before_agent_start hook augments the system prompt each turn,
+    // but this initial injection ensures context is visible in the session
+    // history and survives compaction.
+    let contextText: string | null = null;
+
+    if (isResume && event.previousSessionFile) {
+      const previousSessionId = deriveSessionId(event.previousSessionFile);
+      if (previousSessionId) {
+        contextText = await fetchMycoResumeContext(currentCwd, sessionId, previousSessionId);
+      }
+    } else if (!isFork) {
+      contextText = await fetchMycoSessionContext(currentCwd, sessionId);
+    }
+
+    if (contextText) {
+      pi.sendMessage({
+        customType: "myco-context",
+        content: contextText,
+        display: false,
+      }, {
+        deliverAs: "nextTurn",
+      });
+    }
+  });
+
+  pi.on("session_shutdown", async () => {
+    if (!currentSessionId) return;
+
+    await mycoPostStop(currentCwd, currentSessionId, lastAssistantMessage || undefined);
+    await mycoUnregisterSession(currentCwd, currentSessionId);
+    currentSessionId = null;
+    lastAssistantMessage = "";
+  });
+
+  // ── User prompt capture + context injection ────────────────────────────
+  //
+  // Single before_agent_start handler: captures the user prompt AND
+  // augments the system prompt with Myco context. This avoids registering
+  // two handlers for the same event (pi chains them, but the second
+  // handler's return value would overwrite the first).
+
+  pi.on("before_agent_start", async (event, _ctx) => {
+    if (!currentSessionId) return;
+
+    // 1. Capture the user prompt
+    const prompt = event.prompt ?? "";
+    const images = extractImagesFromContent(event.images);
+    if (prompt) {
+      // Fire-and-forget capture — don't block the agent start
+      mycoPostUserPrompt(currentCwd, currentSessionId, prompt, images);
+    }
+
+    // 2. Augment system prompt with Myco context
+    const contextText = await fetchMycoSessionContext(currentCwd, currentSessionId);
+    if (contextText) {
+      return {
+        systemPrompt: event.systemPrompt + "\n\n" + contextText,
+      };
+    }
+    return undefined;
+  });
+
+  // ── Tool use capture ───────────────────────────────────────────────────
+
+  pi.on("tool_result", async (event) => {
+    if (!currentSessionId) return;
+
+    const toolName = event.toolName ?? "unknown";
+    const toolInput = event.input ?? {};
+    const rawOutput = Array.isArray(event.content)
+      ? event.content
+          .filter((c: { type?: string; text?: string }) => c.type === "text")
+          .map((c: { text: string }) => c.text)
+          .join("\n")
+      : "";
+    const toolOutput = summarizeToolOutput(rawOutput);
+
+    // Fire-and-forget — don't block tool result processing
+    mycoPostToolUse(currentCwd, currentSessionId, toolName, toolInput, toolOutput);
+    return undefined;
+  });
+
+  // ── Track last assistant message ───────────────────────────────────────
+
+  pi.on("message_end", async (event) => {
+    if (!currentSessionId) return;
+    if (event.message?.role === "assistant") {
+      const text = extractTextFromContent(event.message.content);
+      if (text) {
+        lastAssistantMessage = text;
+      }
+    }
+  });
+
+  // ── Agent end → post stop for agentic loop completion ──────────────────
+  //
+  // Pi fires agent_end after each user prompt's agentic loop completes.
+  // We post a stop event so the daemon can process the turn. session_shutdown
+  // handles the final cleanup on exit.
+
+  pi.on("agent_end", async () => {
+    if (!currentSessionId) return;
+    await mycoPostStop(currentCwd, currentSessionId, lastAssistantMessage || undefined);
+  });
+
+  // ── Compaction hook — notify daemon of context compaction ──────────────
+
+  pi.on("session_before_compact", async () => {
+    if (!currentSessionId) return;
+    await mycoPostCompact(currentCwd, currentSessionId);
+    return undefined;
+  });
+
+  // ── MCP tool proxies — expose Myco's intelligence to the LLM ──────────
+  //
+  // Pi has no native MCP support. Instead, we register Myco's core tools
+  // directly via pi.registerTool() so the LLM can query the knowledge vault.
+
+  pi.registerTool({
+    name: "myco_context",
+    label: "Myco Context",
+    description:
+      "Get project context, observations, and intelligence from Myco's knowledge vault. " +
+      "Use this to understand the project's history, prior decisions, gotchas, and patterns.",
+    promptSnippet: "Query Myco vault for project intelligence, prior decisions, and observations",
+    promptGuidelines: [
+      "Use myco_context at the start of complex tasks to understand project history and prior decisions.",
+      "Use myco_context when you encounter unfamiliar code patterns or architecture choices.",
+    ],
+    parameters: Type.Object({}),
+    async execute() {
+      if (!currentSessionId) {
+        return { content: [{ type: "text" as const, text: "No active session" }], details: {} };
+      }
+      const result = await fetchMycoSessionContext(currentCwd, currentSessionId);
+      return {
+        content: [{ type: "text" as const, text: result ?? "No context available from Myco vault." }],
+        details: {},
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "myco_search",
+    label: "Myco Search",
+    description:
+      "Search Myco's knowledge vault for specific topics, patterns, or prior observations. " +
+      "Returns relevant spores (observations), session summaries, and related intelligence.",
+    promptSnippet: "Search Myco vault for specific topics, patterns, or observations",
+    promptGuidelines: [
+      "Use myco_search when you need specific information about a topic, pattern, or past decision.",
+      "Prefer myco_search over myco_context when you have a focused query.",
+    ],
+    parameters: Type.Object({
+      query: Type.String({ description: "Search query — topic, pattern, or question" }),
+    }),
+    async execute(_toolCallId, params) {
+      if (!currentSessionId) {
+        return { content: [{ type: "text" as const, text: "No active session" }], details: {} };
+      }
+      const result = await getJson(currentCwd, `/api/search?q=${encodeURIComponent(params.query)}`);
+      if (!result.ok || !result.data) {
+        return { content: [{ type: "text" as const, text: "Search unavailable — Myco daemon may not be running." }], details: {} };
+      }
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result.data, null, 2) }],
+        details: {},
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "myco_observe",
+    label: "Myco Observe",
+    description:
+      "Record an observation (gotcha, decision, discovery, trade-off, bug fix) in Myco's knowledge vault. " +
+      "Use this when you discover something important about the codebase that future sessions should know.",
+    promptSnippet: "Record an observation in Myco vault for future sessions",
+    promptGuidelines: [
+      "Use myco_observe to record important discoveries, gotchas, decisions, and trade-offs.",
+      "Include enough context that a future session can understand the observation without seeing this conversation.",
+    ],
+    parameters: Type.Object({
+      observation_type: Type.String({
+        description: "Type: gotcha, decision, discovery, trade-off, bug_fix, pattern, or any descriptive string",
+      }),
+      title: Type.String({ description: "Short title for the observation" }),
+      content: Type.String({ description: "Detailed observation with context" }),
+      tags: Type.Optional(Type.Array(Type.String(), { description: "Optional tags for categorization" })),
+    }),
+    async execute(_toolCallId, params) {
+      if (!currentSessionId) {
+        return { content: [{ type: "text" as const, text: "No active session" }], details: {} };
+      }
+      const result = await postJson(currentCwd, "/api/spores", {
+        session_id: currentSessionId,
+        observation_type: params.observation_type,
+        title: params.title,
+        content: params.content,
+        tags: params.tags ?? [],
+      });
+      if (!result.ok) {
+        return { content: [{ type: "text" as const, text: "Failed to record observation — Myco daemon may not be running." }], details: {} };
+      }
+      return {
+        content: [{ type: "text" as const, text: `Observation recorded: ${params.title}` }],
+        details: {},
+      };
+    },
+  });
+}

--- a/tests/symbionts/injection-support.test.ts
+++ b/tests/symbionts/injection-support.test.ts
@@ -27,6 +27,7 @@ const EXPECTED_SUPPORT: Record<string, { session: boolean; prompt: boolean }> = 
   cursor: { session: true, prompt: true },
   gemini: { session: true, prompt: true },
   opencode: { session: true, prompt: false },
+  pi: { session: true, prompt: false },
   'vscode-copilot': { session: true, prompt: true },
   windsurf: { session: false, prompt: true },
 };


### PR DESCRIPTION
Class 2 (plugin-file) integration using pi's extension API:

- Manifest: .pi config dir, plugin-file hooks format, extension package deps
- Extension (plugin.ts): full lifecycle capture via pi events
  - session_start/session_shutdown: register/unregister with daemon
  - before_agent_start: capture user prompts + augment system prompt with Myco context
  - tool_result: capture tool usage with output previews
  - message_end: track last assistant message for stop summaries
  - agent_end: post stop events after each agentic loop
  - session_before_compact: notify daemon of compaction events
- Context injection: session context on startup, resume context on session resume
- MCP tool proxies via pi.registerTool() (pi has no native MCP):
  - myco_context: fetch vault context
  - myco_search: search vault knowledge
  - myco_observe: record observations
- Buffer fallback: events persisted to .myco/buffer/ when daemon unreachable
- Degraded-mode safe: silent no-op when Myco not installed (zero external deps)

## Summary

This pull request introduces initial support for the "Pi" symbiont in the Myco project. The main changes include adding a manifest file for Pi, defining its dependencies, and updating test coverage to reflect its supported features.

**Pi symbiont integration:**

* Added a new manifest file `pi.yaml` under `packages/myco/src/symbionts/manifests/` to define Pi's configuration, plugin integration points, and capture/registration behavior.
* Introduced a template `package.json` for Pi extensions, specifying dependencies on `@mariozechner/pi-coding-agent` and `@sinclair/typebox`.

**Test updates:**

* Updated the `EXPECTED_SUPPORT` record in `injection-support.test.ts` to include Pi, indicating it supports session injection but not prompt injection.

## Related Issues

- Closes #
- Related #

## Change Type

- [ ] Bug fix
- [x] Enhancement / new feature
- [ ] Refactor / code quality
- [x] Documentation
- [ ] CI / workflow

## Validation

```bash
make check    # lint + 266 tests
```

## Checklist

- [x] `make check` passes locally
- [x] Tests added or updated where behavior changed
- [x] Docs updated for user-visible changes
- [ ] No magic literals introduced (named constants in `src/constants.ts`)
