### PR TITLE
feat(agent): add vault-seed, rename vault-evolve, refactor phase plumbing

### DIFF
--- a/.agents/skills/author-harness-task/SKILL.md
+++ b/.agents/skills/author-harness-task/SKILL.md
@@ -29,8 +29,8 @@ surfaces, and debugging when things go wrong.
 ## Prerequisites
 
 - Daemon is running and `agent.enabled: true` in `myco.yaml`.
-- You have read at least one existing task (`src/agent/tasks/full-intelligence.ts`
-  or `src/agent/tasks/skill-survey.ts`) to understand the config shape.
+- You have read at least one existing task YAML (`src/agent/definitions/tasks/vault-evolve.yaml`
+  or `src/agent/definitions/tasks/skill-survey.yaml`) to understand the config shape.
 - You can describe the new task's purpose in one sentence and identify which
   vault state it reads and writes.
 
@@ -145,7 +145,7 @@ After creating the task file, add it to `src/agent/tasks/index.ts`:
 export { myNewTask } from './my-new-task';
 
 export const ALL_TASKS = [
-  fullIntelligenceTask,
+  vaultEvolveTask,
   skillSurveyTask,
   // ...
   myNewTask,  // ← add here

--- a/.agents/skills/safe-config-updates/SKILL.md
+++ b/.agents/skills/safe-config-updates/SKILL.md
@@ -118,11 +118,70 @@ Config data loss from the `formToConfig()` bug is silent at the UI layer — the
 
 ---
 
+## Patch-Based Settings API — Modern Granular Updates
+
+### Why patch endpoints?
+
+The Settings UI redesign introduces dedicated PATCH endpoints (`/api/settings/scoped` and `/api/settings/operations`) that replace the monolithic PUT `/api/config` pattern. This enables granular field-level updates without requiring clients to manage the full configuration object. The ScopedField React component automatically handles the patch semantics and scope resolution.
+
+### Steps
+
+1. **Use ScopedField components for settings UI:**
+   ```tsx
+   import { ScopedField } from '../components/ScopedField';
+
+   // The component automatically handles patch-based updates
+   <ScopedField 
+     path="embedding.model" 
+     scope="personal" 
+     label="Embedding Model" 
+   />
+   ```
+
+2. **ScopedField automatically patches via the correct endpoint:**
+   - Personal-scoped settings → `/api/settings/scoped` 
+   - Operations settings → `/api/settings/operations`
+   - Handles the patch semantics internally
+
+3. **When building custom settings forms, use patch endpoints directly:**
+   ```ts
+   // For personal/team scoped settings
+   await fetch('/api/settings/scoped', {
+     method: 'PATCH',
+     body: JSON.stringify({
+       path: 'embedding.model',
+       value: 'text-embedding-3-large',
+       scope: 'personal'
+     })
+   });
+
+   // For operations settings
+   await fetch('/api/settings/operations', {
+     method: 'PATCH', 
+     body: JSON.stringify({
+       field: 'auto_run',
+       value: true
+     })
+   });
+   ```
+
+4. **Legacy full-config PUT is retired.** New settings UI should use patch-based endpoints exclusively. The `/api/config` PUT endpoint remains for compatibility but is not the primary pattern.
+
+### Benefits over monolithic updates
+
+- **Eliminates config reconstruction bugs** — no need to manage the full config object in forms
+- **Automatic scope resolution** — ScopedField handles personal vs team scope assignment  
+- **Field-level granularity** — only the specific setting being changed is updated
+- **No spread-before-overlay complexity** — the patch semantics handle preservation automatically
+
+---
+
 ## Checklist Before Submitting a Config Change
 
 - [ ] YAML write goes through `updateConfig()` (or a named helper that uses it)
 - [ ] Every partial update spreads sibling keys at each level
-- [ ] `formToConfig()` accepts and spreads the original config
+- [ ] `formToConfig()` accepts and spreads the original config (legacy forms only)
 - [ ] Settings page only sets fields it owns — no pass-through of other pages' sections
+- [ ] Modern settings UI uses ScopedField components or patch endpoints directly
 - [ ] If touching daemon-behavior fields, reload signal is sent
 - [ ] Manual verification: inspect `myco.yaml` after a test save to confirm no data loss

--- a/.myco/myco.yaml
+++ b/.myco/myco.yaml
@@ -1,5 +1,5 @@
 version: 3
-config_version: 5
+config_version: 6
 embedding:
   provider: ollama
   model: bge-m3:latest

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -14,13 +14,14 @@ Every piece of this comes from the same source material: the prompts, tool calls
 
 ## Tasks
 
-Ten tasks cover the full lifecycle. Most users only interact with `full-intelligence` (the default scheduled task) — the others are available for manual trigger or specialized workflows.
+Twelve tasks cover the full lifecycle. Most users only interact with `vault-evolve` (the default scheduled task) or `vault-seed` (a one-shot for brownfield repos) — the others are available for manual trigger or specialized workflows.
 
 ### Intelligence
 
 | Task | What it does |
 |------|-------------|
-| `full-intelligence` | The complete pipeline. Runs on unprocessed batches, extracts spores, maintains the graph, refreshes digests. Scheduled by default. |
+| `vault-evolve` | The complete pipeline. Runs on unprocessed batches, extracts spores, consolidates wisdom, refreshes digests. Scheduled by default. |
+| `vault-seed` | One-shot manual seeding for brownfield codebases — explores the repo with filesystem + grep tools and creates the initial spore set and digest. |
 | `title-summary` | Generates or updates a session title and summary. Runs automatically after each session turn. |
 | `extract-only` | Spore extraction without the graph or digest work. Useful for catching up after a long gap. |
 | `review-session` | Deep end-to-end processing of a single session. Trigger from the session detail page. |
@@ -84,12 +85,12 @@ For local providers, set a `context_length` that matches the model's capabilitie
 
 ### Per-phase overrides (advanced)
 
-For phased tasks like `full-intelligence`, you can override the provider for individual phases. Useful for mixing cloud quality and local cost:
+For phased tasks like `vault-evolve`, you can override the provider for individual phases. Useful for mixing cloud quality and local cost:
 
 ```yaml
 agent:
   tasks:
-    full-intelligence:
+    vault-evolve:
       phases:
         extract:
           provider:
@@ -110,7 +111,7 @@ agent:
   scheduled_tasks_enabled: true      # Master switch for all scheduled tasks
   event_tasks_enabled: true          # Master switch for event-driven tasks (title-summary)
   tasks:
-    full-intelligence:
+    vault-evolve:
       schedule:
         enabled: true
         intervalSeconds: 300         # Check for unprocessed batches every 5 min
@@ -131,7 +132,7 @@ From the dashboard's **Operations** page you can kick off any task on demand —
 From the CLI:
 
 ```bash
-myco agent run full-intelligence      # Run the default pipeline now
+myco agent run vault-evolve      # Run the default pipeline now
 myco agent run skill-survey            # Survey for new skill candidates
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2592,6 +2592,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vscode/ripgrep": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.17.1.tgz",
+      "integrity": "sha512-xTs7DGyAO3IsJYOCTBP8LnTvPiYVKEuyv8s0xyJDBXfs8rhBfqnZPvb6xDT+RnwWzcXqW27xLS/aGrkjX7lNWw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "https-proxy-agent": "^7.0.2",
+        "proxy-from-env": "^1.1.0",
+        "yauzl": "^2.9.2"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -2616,6 +2628,15 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2822,6 +2843,15 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/bundle-require": {
@@ -3508,6 +3538,15 @@
         "fast-string-width": "^3.0.2"
       }
     },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -3760,6 +3799,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -4620,6 +4672,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4798,6 +4856,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -6302,6 +6366,16 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
     "node_modules/zod": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
@@ -6331,6 +6405,7 @@
         "@inquirer/prompts": "^8.4.1",
         "@modelcontextprotocol/sdk": "^1.28.0",
         "@openai/agents": "^0.8.3",
+        "@vscode/ripgrep": "^1.15.14",
         "better-sqlite3": "^12.9.0",
         "chokidar": "^5.0.0",
         "gray-matter": "^4.0.3",

--- a/packages/myco/package.json
+++ b/packages/myco/package.json
@@ -60,6 +60,7 @@
     "@openai/agents": "^0.8.3",
     "@inquirer/prompts": "^8.4.1",
     "@modelcontextprotocol/sdk": "^1.28.0",
+    "@vscode/ripgrep": "^1.15.14",
     "better-sqlite3": "^12.9.0",
     "chokidar": "^5.0.0",
     "gray-matter": "^4.0.3",

--- a/packages/myco/skills/myco-curate/SKILL.md
+++ b/packages/myco/skills/myco-curate/SKILL.md
@@ -14,7 +14,7 @@ This skill triggers an intelligence agent run via the daemon API. The intelligen
 ## Arguments
 
 The user may provide:
-- **task name** — which intelligence task to run (e.g., "full-intelligence", "extraction-only")
+- **task name** — which intelligence task to run (e.g., "vault-evolve", "extract-only")
 - **instruction** — free-text instruction to guide the agent's focus
 
 Parse the user's message for these. Both are optional.

--- a/packages/myco/skills/myco/references/cli-usage.md
+++ b/packages/myco/skills/myco/references/cli-usage.md
@@ -319,7 +319,7 @@ Runs the intelligence agent to process unprocessed session data, extract observa
 
 | Flag | Type | Description |
 |------|------|-------------|
-| `--task <name>` | string | Which task to run (e.g., `full-intelligence`, `extract-only`) |
+| `--task <name>` | string | Which task to run (e.g., `vault-evolve`, `extract-only`) |
 | `--instruction <text>` | string | Free-text instruction to guide the agent's focus |
 | `--dry-run` | boolean | Run LLM evaluation but print results without writing |
 

--- a/packages/myco/src/agent/definitions/agent.yaml
+++ b/packages/myco/src/agent/definitions/agent.yaml
@@ -33,3 +33,9 @@ tools:
   - vault_write_digest
   - vault_set_state
   - vault_report
+  # Code exploration tools — used by vault-seed to infer knowledge from
+  # source when no session data exists yet.
+  - fs_read
+  - fs_list
+  - fs_tree
+  - code_grep

--- a/packages/myco/src/agent/definitions/tasks/vault-evolve.yaml
+++ b/packages/myco/src/agent/definitions/tasks/vault-evolve.yaml
@@ -1,5 +1,5 @@
 # =============================================================================
-# Built-in Task: Full Intelligence (Phased)
+# Built-in Task: Vault Evolve (Phased)
 # =============================================================================
 # Default task for: myco-agent
 #
@@ -8,13 +8,13 @@
 # controls the loop — the LLM cannot skip phases.
 # =============================================================================
 
-name: full-intelligence
-displayName: Full Intelligence
+name: vault-evolve
+displayName: Vault Evolve
 description: >
   Complete intelligence pass over all unprocessed session data. Extracts
   observations as spores, updates session summaries, consolidates related
-  spores into wisdom, builds knowledge graph entities and edges, and
-  regenerates digest extracts.
+  spores into wisdom, and regenerates digest extracts. Runs automatically
+  on a schedule once sessions have settled.
 agent: myco-agent
 isDefault: true
 maxTurns: 150

--- a/packages/myco/src/agent/definitions/tasks/vault-seed.yaml
+++ b/packages/myco/src/agent/definitions/tasks/vault-seed.yaml
@@ -1,0 +1,370 @@
+# =============================================================================
+# Built-in Task: Vault Seed (Phased)
+# =============================================================================
+# Manual-only task for: myco-agent
+#
+# One-shot seeding pass for brownfield codebases. Unlike vault-evolve,
+# which processes session transcripts, vault-seed infers knowledge
+# directly from source files using filesystem + grep tools. Intended to
+# be run when adopting Myco on an existing repo — fills the vault with
+# an initial spore set and digest so the assistant has useful context
+# from day one.
+# =============================================================================
+
+name: vault-seed
+displayName: Vault Seed
+description: >
+  One-shot seeding pass for a brownfield codebase. Explores the project
+  with filesystem and grep tools, identifies architectural patterns,
+  conventions, and gotchas, then populates the vault with an initial
+  spore set and a starter digest. Manual trigger only — no session data
+  required.
+agent: myco-agent
+isDefault: false
+maxTurns: 300
+timeoutSeconds: 3600
+reasoningLevel: default
+
+# No schedule — always manual. Running automatically would re-seed an
+# already-populated vault.
+
+prompt: >
+  You are running a one-shot seeding pass over a brownfield codebase.
+  There are no session transcripts to process — infer knowledge directly
+  from source. Focus on architectural patterns, conventions, trade-offs,
+  and gotchas that a new developer or agent onboarding to this code
+  would benefit from. Quality over quantity — one precise observation is
+  worth more than ten vague ones.
+
+  IMPORTANT: the pipeline is phased, and each phase has a different
+  tool surface. Early phases explore source with filesystem tools;
+  later phases write observations to the vault using vault_* tools.
+  Each phase's prompt lists the tools it has. Trust that list and call
+  those tools directly. Do not rationalize that a declared tool is
+  "unavailable" based on what earlier phases used.
+
+phases:
+  - name: orient
+    reasoningLevel: default
+    readOnly: true
+    prompt: |
+      **Your ONLY job this phase: produce a 3-8 item theme list from
+      surface signals.** You are NOT verifying themes, NOT reading
+      implementation, and NOT building a comprehensive understanding.
+      That work belongs to the next phase (explore-themes), which has
+      a much larger budget and is designed for it.
+
+      **Hard turn budget: {{max_turns}}.** Each tool call costs one
+      turn. If you exhaust the budget before calling `vault_report`
+      with the theme list, this phase fails and blocks the rest of
+      the pipeline. Treat the budget as a constraint, not a suggestion
+      — finish well under it.
+
+      **Scope guard:** if you find yourself opening a file under
+      `packages/*/src/**`, `src/**`, `lib/**`, or any implementation
+      directory, STOP. That is explore-themes's job. Orient reads
+      top-level metadata and docs only.
+
+      ## Exact tool plan (budget: ~8 tool calls total)
+
+      Call ONLY these tools, in this order. Do NOT add calls.
+
+      1. `fs_tree` at `.` with depth=1 — 1 call, 1 turn.
+      2. `fs_read` the README (no line window) — 1 call, 1 turn.
+      3. `fs_read` the primary manifest (package.json / pyproject.toml /
+         Cargo.toml / go.mod / Gemfile / pom.xml — pick the one that
+         exists, skip if unclear) — 0 or 1 call.
+      4. `fs_list` at `.` — 1 call, 1 turn. After this call you have
+         seen every top-level tooling signal. DO NOT list additional
+         directories in this phase; recursive layout exploration is
+         explore-themes's job.
+      5. (Optional) `fs_list` on `docs/` — 0 or 1 call. If you do, then
+         `fs_read` AT MOST 2 files that clearly look like architecture
+         or overview docs — max 2 more calls.
+      6. `vault_report` with action "orient" and the theme list — 1
+         call. This is your last tool call. The phase ends here.
+
+      Skipping steps is fine. Adding steps is not. If you are tempted
+      to list a subdirectory to "see what's inside it," resist —
+      explore-themes will do that with more budget.
+
+      **Frugality:** every tool response comes back as tokens on your
+      next turn's input. Narrow calls keep the budget healthy.
+
+      ## Output: theme outline
+
+      From those surface signals alone, name 3-8 themes worth deeper
+      exploration in the next phase. Name them confidently even if you
+      don't have full evidence yet — the next phase will verify them.
+      Good themes:
+      - major architectural layers ("agent harness", "daemon", "UI")
+      - cross-cutting domain concepts ("team sync", "session lifecycle")
+      - notable integration points ("MCP server", "SQLite vault")
+      - conventions worth surfacing (testing style, error handling)
+
+      Avoid generic themes like "TypeScript code" or "tests exist".
+
+      Call `vault_report` with action "orient" and the structured theme
+      list. This is your final tool call for this phase.
+    tools:
+      - fs_tree
+      - fs_list
+      - fs_read
+      - vault_report
+    maxTurns: 25
+    required: true
+
+  - name: explore-themes
+    reasoningLevel: default
+    readOnly: true
+    dependsOn: [orient]
+    prompt: |
+      For each theme identified in the orient phase, drill down with
+      `code_grep` and targeted `fs_read` calls. Collect specific,
+      concrete observations that would survive the code evolving.
+
+      ## Strategy (budget: 4-6 turns per theme)
+
+      For each theme:
+      1. `code_grep` for signature patterns — class/interface names,
+         distinctive function names, keywords. Use a `glob` filter when
+         the language is known (e.g., `*.ts`, `*.py`).
+      2. `fs_read` the 2-4 most informative files you find. Prefer
+         cross-cutting modules over leaf files.
+      3. Note 3-6 concrete observations for the theme. Anchor each to
+         file paths or function names.
+
+      ## What makes a good observation
+
+      - Anchored to specific file paths, function names, or patterns
+      - Captures trade-offs, gotchas, or non-obvious invariants
+      - Explains WHY when the reasoning is evident from the code
+      - Would be useful to an agent or developer onboarding
+
+      ## What to skip
+
+      - Boilerplate (standard manifest fields, generated code)
+      - Implementation details that change frequently
+      - Things obvious from the README
+      - Generic advice ("use TypeScript") — only observations specific to
+        THIS codebase belong in the vault
+
+      ## Output
+
+      Produce a structured summary grouped by theme, focused on
+      OBSERVATIONS (the conclusions) rather than a log of what you did.
+      Write the summary as if a separate agent will read it cold and
+      turn each observation into a durable note. Avoid phrases like
+      "I ran fs_tree on…" or "I read the README" — name the observation
+      and anchor it to specific paths. The seed-spores phase runs with
+      a different tool surface and should not be primed to expect
+      filesystem access.
+
+      Call `vault_report` with action "explore" and the structured result.
+    tools:
+      - fs_tree
+      - fs_list
+      - fs_read
+      - code_grep
+      - vault_report
+    maxTurns: 120
+    required: true
+
+  - name: seed-spores
+    reasoningLevel: default
+    dependsOn: [explore-themes]
+    prompt: |
+      Create spores for the observations from the explore phase.
+
+      **Hard turn budget: {{max_turns}}.** Each tool call costs one
+      turn. Every observation needs one `vault_create_spore` call;
+      budget your work accordingly.
+
+      ## Your tools this phase
+
+      You have these tools and ONLY these tools: {{phase_tools}}.
+      They are registered and available. Call them directly. Do NOT
+      verify or second-guess. Filesystem tools from earlier phases
+      are not needed here — the explore-themes summary in your
+      context contains everything you need to create spores.
+
+      ## Step 1: Re-seed check (1 tool call)
+
+      This phase runs on cold vaults AND on vaults that have been
+      seeded before. Call `vault_search_semantic` ONCE with a broad
+      query derived from the strongest theme (e.g. the name of the
+      highest-signal architectural layer from the explore summary).
+
+      - If the search returns several high-similarity results (many
+        scores > 0.85), the vault is already populated. Call
+        `vault_report` with action "skip" and reason "vault already
+        populated" and STOP. Do not create duplicate spores.
+      - If the search returns nothing or only low-similarity results
+        (typical for a cold vault with no embeddings, or a vault with
+        unrelated prior content), proceed to Step 2.
+
+      Do NOT run per-observation similarity searches — dedup across
+      existing spores is the job of the separate consolidation task,
+      not seed-spores. One broad re-seed check is enough.
+
+      ## Step 2: Create spores (the bulk of your budget)
+
+      For each observation in the explore summary, call
+      `vault_create_spore` with:
+      - observation_type: "decision", "pattern", "wisdom", "gotcha",
+        or "architecture" based on what the observation captures
+      - content: the full observation — concrete and specific
+      - importance: 1-10 (10 = load-bearing architectural invariant,
+        3 = minor stylistic preference)
+      - tags: 2-4 tags covering theme and domain
+      - file_path: the primary source file when the observation
+        anchors to one specific location
+      - session_id: null (no session provenance — this is seed data)
+      - prompt_batch_id: null
+      - context: "Seeded from vault-seed exploration pass"
+
+      ## Quality rules
+
+      - One observation per spore — specific, not vague
+      - Prefer fewer, higher-signal spores over many low-signal ones
+      - Target: 10-40 spores per seed run. If the exploration produced
+        far more candidates, prioritize by importance and drop the rest
+        rather than creating everything
+      - Observations anchored to specific file paths are stronger than
+        abstract statements
+    tools:
+      - vault_search_semantic
+      - vault_create_spore
+      - vault_report
+    maxTurns: 80
+    required: true
+
+  # ---- Digest tiers (parallel after seed-spores) ----
+  # Mirrors the vault-evolve pattern: three tiers writing in the same
+  # wave after seeding completes.
+
+  - name: digest-10000
+    reasoningLevel: default
+    dependsOn: [seed-spores]
+    prompt: |
+      Write digest tier 10000 — Full institutional knowledge (~10k tokens).
+
+      ## Your tools this phase
+
+      You have these tools and ONLY these tools:
+      `vault_spores`, `vault_search_semantic`, `vault_read_digest`,
+      `vault_write_digest`, `vault_report`. They are registered and
+      available. Call them directly. Filesystem tools from earlier
+      phases are NOT in scope here — the spores created in seed-spores
+      contain everything you need.
+
+      If the seed-spores phase short-circuited with "vault already populated",
+      call `vault_report` with action "skip" for tier 10000 and finish.
+
+      1. Call `vault_read_digest` with tier 10000 to see any existing content.
+         If this is a first seed run, it will be empty.
+      2. Call `vault_spores` with status "active" to read the freshly seeded
+         observations.
+      3. Organize the digest around the themes from the explore phase.
+         Include concrete file paths and function names. A reader should
+         come away with a thorough picture of the architecture, key
+         decisions, and gotchas.
+      4. Call `vault_write_digest` with tier 10000.
+
+      If the existing digest already contains comparable content (re-seed
+      case), integrate rather than overwrite — preserve well-crafted text.
+    tools:
+      - vault_spores
+      - vault_search_semantic
+      - vault_read_digest
+      - vault_write_digest
+      - vault_report
+    maxTurns: 15
+    required: false
+
+  - name: digest-5000
+    reasoningLevel: default
+    dependsOn: [seed-spores]
+    prompt: |
+      Write digest tier 5000 — Deep onboarding (~5k tokens).
+
+      ## Your tools this phase
+
+      You have these tools and ONLY these tools:
+      `vault_spores`, `vault_read_digest`, `vault_write_digest`,
+      `vault_report`. They are registered and available. Call them
+      directly. Filesystem tools from earlier phases are NOT in scope.
+
+      If the seed-spores phase short-circuited, call `vault_report` with
+      action "skip" for tier 5000 and finish.
+
+      This tier focuses on trade-offs and patterns — what a developer
+      needs after the README but before diving into code.
+
+      1. Call `vault_read_digest` with tier 5000 for the baseline.
+      2. Call `vault_spores` as the primary source (digest-10000 may still
+         be in-flight — don't depend on it).
+      3. Call `vault_write_digest` with tier 5000. Trim and synthesize;
+         this tier is a compression of tier 10000's material.
+    tools:
+      - vault_spores
+      - vault_read_digest
+      - vault_write_digest
+      - vault_report
+    maxTurns: 12
+    required: false
+
+  - name: digest-1500
+    reasoningLevel: default
+    dependsOn: [seed-spores]
+    prompt: |
+      Write digest tier 1500 — Executive briefing (~1.5k tokens).
+
+      ## Your tools this phase
+
+      You have these tools and ONLY these tools:
+      `vault_spores`, `vault_read_digest`, `vault_write_digest`,
+      `vault_report`. They are registered and available. Call them
+      directly. Filesystem tools from earlier phases are NOT in scope.
+
+      If the seed-spores phase short-circuited, call `vault_report` with
+      action "skip" for tier 1500 and finish.
+
+      The tightest tier: what someone needs to know in 2 minutes.
+      Architectural overview in 1-2 sentences, 2-3 load-bearing decisions,
+      the critical gotchas. Ruthlessly selective.
+
+      1. Call `vault_spores` filtered to importance >= 8 to find the
+         top-signal observations.
+      2. Call `vault_write_digest` with tier 1500.
+    tools:
+      - vault_spores
+      - vault_read_digest
+      - vault_write_digest
+      - vault_report
+    maxTurns: 8
+    required: false
+
+  - name: report
+    reasoningLevel: low
+    dependsOn: [seed-spores, digest-10000, digest-5000, digest-1500]
+    prompt: |
+      Summarize the seeding pass.
+
+      Your only tool this phase is `vault_report`. Call it — it is
+      registered and available.
+
+      Call `vault_report` with action "complete" and these details:
+      - Themes explored: N
+      - Spores created: N (by type)
+      - Spores superseded: N
+      - Digest tiers written: [list]
+      - Thin coverage: any themes where the exploration surfaced fewer than
+        3 observations — surface these so the user can follow up with a
+        targeted review-session or additional manual curation
+
+      This report MUST be the last tool call of the run.
+    tools:
+      - vault_report
+    maxTurns: 5
+    required: true

--- a/packages/myco/src/agent/executor-state.ts
+++ b/packages/myco/src/agent/executor-state.ts
@@ -85,18 +85,61 @@ export function checkpointResultsForResume(
   return Object.values(checkpointState.phases)
     .filter((phase) => phase.status === 'completed')
     .sort((a, b) => (order.get(a.name) ?? 0) - (order.get(b.name) ?? 0))
-    .map((phase) => ({
+    .map((phase) => buildPhaseResult({
       name: phase.name,
       status: 'completed',
-      turnsUsed: phase.turnsUsed ?? 0,
-      tokensUsed: phase.tokensUsed ?? 0,
-      costUsd: phase.costUsd ?? 0,
+      summary: phase.summary ?? '',
+      turnsUsed: phase.turnsUsed,
+      tokensUsed: phase.tokensUsed,
+      costUsd: phase.costUsd,
       costSource: phase.costSource,
       costData: phase.costData,
-      summary: phase.summary ?? '',
       usage: phase.usage,
       sessionRef: phase.sessionRef,
     }));
+}
+
+/**
+ * Construct a `PhaseResult` from whatever telemetry is available.
+ *
+ * Three callers hit this: (1) executePhase's success path has a full
+ * `RuntimeUsage` + `CostResolution`; (2) executePhase's failure path has
+ * partial telemetry attached to a `RuntimeExecutionError`; (3)
+ * `checkpointResultsForResume` has pre-computed scalar fields from a
+ * persisted checkpoint. Each caller passes what it has — the helper
+ * derives `turnsUsed`/`tokensUsed`/`costUsd` from `usage` + `costData`
+ * when available, and falls back to the direct scalar fields when not.
+ */
+export function buildPhaseResult(input: {
+  name: string;
+  status: PhaseResult['status'];
+  summary: string;
+  usage?: RuntimeUsage;
+  costData?: CostResolution;
+  turnsUsed?: number;
+  tokensUsed?: number;
+  costUsd?: number;
+  costSource?: CostSource;
+  sessionRef?: string;
+  sessionData?: unknown;
+}): PhaseResult & { sessionData?: unknown } {
+  const {
+    name, status, summary, usage, costData,
+    turnsUsed, tokensUsed, costUsd, costSource,
+    sessionRef, sessionData,
+  } = input;
+  return {
+    name,
+    status,
+    turnsUsed: turnsUsed ?? usage?.requests ?? 0,
+    tokensUsed: tokensUsed ?? usage?.totalTokens ?? 0,
+    costUsd: costUsd ?? costData?.costUsd ?? 0,
+    ...(costData ? { costSource: costData.source, costData } : costSource ? { costSource } : {}),
+    ...(usage ? { usage } : {}),
+    ...(sessionRef ? { sessionRef } : {}),
+    ...(sessionData !== undefined ? { sessionData } : {}),
+    summary,
+  };
 }
 
 export function serializeCheckpointState(state: RunCheckpointState): string {

--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -391,12 +391,12 @@ export async function runAgent(
       }
     } else {
       // Single-query execution (backward compatible)
-      const taskPrompt = composeTaskPrompt(
+      const taskPrompt = composeTaskPrompt({
         vaultContext,
-        config.taskDisplayName,
-        config.taskPrompt,
-        options?.instruction,
-      );
+        taskDisplayName: config.taskDisplayName,
+        taskPrompt: config.taskPrompt,
+        instruction: options?.instruction,
+      });
 
       // Provider priority for single-query: myco.yaml task override → task execution config → default
       const singleProvider = taskProviderOverride ?? config.execution?.provider;

--- a/packages/myco/src/agent/instruction-builders.ts
+++ b/packages/myco/src/agent/instruction-builders.ts
@@ -644,7 +644,7 @@ export async function buildTaskInstruction(
  * dispatcher must skip the run rather than falling through to the
  * bare default prompt.
  *
- * Generic tasks like full-intelligence never call buildTaskInstruction,
+ * Generic tasks like vault-evolve never call buildTaskInstruction,
  * so this returns false for them.
  */
 export function isInstructionRequiredTask(taskName: string): boolean {

--- a/packages/myco/src/agent/loader.ts
+++ b/packages/myco/src/agent/loader.ts
@@ -229,8 +229,8 @@ export function resolveEffectiveConfig(
   }
 
   // Task prompt and display info (fall back to a generic prompt)
-  const taskName = taskOverrides?.name ?? 'full-intelligence';
-  const taskDisplayName = taskOverrides?.displayName ?? 'Full Intelligence';
+  const taskName = taskOverrides?.name ?? 'vault-evolve';
+  const taskDisplayName = taskOverrides?.displayName ?? 'Vault Evolve';
   const taskPrompt = taskOverrides?.prompt ?? '';
 
   return {

--- a/packages/myco/src/agent/phase-loop.ts
+++ b/packages/myco/src/agent/phase-loop.ts
@@ -28,11 +28,13 @@ import { computeWaves, phaseSessionId } from './wave-computation.js';
 import { resolveCost } from './cost/index.js';
 import {
   abortReasonMessage,
+  buildPhaseResult,
   checkpointResultsForResume,
   isSessionResumeFailure,
   type RunCheckpointState,
 } from './executor-state.js';
 import { getAgentRuntime } from './runtime/index.js';
+import { RuntimeExecutionError, type RuntimeToolSurface } from './runtime/types.js';
 import { composePhasePrompt } from './prompt-composition.js';
 import { resolvePhaseExecution, type MycoYamlPhaseOverrides } from './phase-resolver.js';
 import type { CostResolution } from './cost/types.js';
@@ -104,26 +106,21 @@ export interface PhaseLoopContext {
  * `Promise.allSettled`. Emits a runtime retry when session-resume fails
  * against an adapter that advertises `supportsSessionResume`.
  */
+export interface ExecutePhaseInput {
+  ctx: PhaseLoopContext;
+  phasePrompt: string;
+  phaseModel: string;
+  phase: PhaseDefinition;
+  toolSurface: RuntimeToolSurface;
+  provider?: ProviderConfig;
+  sessionId?: string;
+  sessionData?: unknown;
+}
+
 export async function executePhase(
-  ctx: PhaseLoopContext,
-  phasePrompt: string,
-  phaseModel: string,
-  phase: PhaseDefinition,
-  toolSurface: {
-    agentId: string;
-    runId: string;
-    toolNames: string[];
-    turnOffset: number;
-    projectRoot?: string;
-    vaultDir?: string;
-    readOnly?: boolean;
-    embeddingManager?: RunOptions['embeddingManager'];
-    dryRun?: boolean;
-  },
-  provider?: ProviderConfig,
-  sessionId?: string,
-  sessionData?: unknown,
+  input: ExecutePhaseInput,
 ): Promise<PhaseResult & { sessionData?: unknown }> {
+  const { ctx, phasePrompt, phaseModel, phase, toolSurface, provider, sessionId, sessionData } = input;
   const runtime = getAgentRuntime(ctx.config.runtime);
   try {
     let result;
@@ -170,29 +167,34 @@ export async function executePhase(
       usage: result.usage,
     });
 
-    return {
+    return buildPhaseResult({
       name: phase.name,
       status: 'completed',
-      turnsUsed: result.turnsUsed,
-      tokensUsed: result.usage.totalTokens ?? 0,
-      costUsd: costData.costUsd ?? 0,
-      costSource: costData.source,
-      costData,
       summary: result.finalText,
       usage: result.usage,
+      costData,
       sessionRef: result.sessionRef,
       sessionData: result.sessionData,
-    };
+    });
   } catch (err) {
     const abortReason = abortReasonMessage(ctx.abortController);
-    return {
+    const telemetry = err instanceof RuntimeExecutionError ? err.telemetry : undefined;
+    const costData = telemetry
+      ? await resolveCost({
+          runtime: ctx.config.runtime,
+          provider,
+          model: phaseModel,
+          usage: telemetry.usage,
+        })
+      : undefined;
+    return buildPhaseResult({
       name: phase.name,
       status: 'failed',
-      turnsUsed: 0,
-      tokensUsed: 0,
-      costUsd: 0,
       summary: abortReason ? `Error: ${abortReason}` : `Error: ${toErrorMessage(err)}`,
-    };
+      usage: telemetry?.usage,
+      costData,
+      sessionRef: telemetry?.sessionRef,
+    });
   }
 }
 
@@ -350,19 +352,12 @@ export async function executePhasedQuery(
     }
 
     const waveInputs = runnableWave.map((phase, indexInWave) => {
-      const phasePrompt = composePhasePrompt(
-        vaultContext,
-        config.taskDisplayName,
-        config.taskPrompt,
-        phase,
-        phaseResults,
-        ctx.instruction,
-      );
-
-      // Single canonical precedence resolution — covers run overrides,
-      // phase YAML, myco.yaml per-phase overrides, top-level run override,
-      // and the task default. See `resolvePhaseExecution` JSDoc for the
-      // full precedence table.
+      // Resolve execution config FIRST so the prompt can be templated
+      // with the resolved `maxTurns` (and future per-phase runtime
+      // knobs). Single canonical precedence resolution — covers run
+      // overrides, phase YAML, myco.yaml per-phase overrides, top-level
+      // run override, and the task default. See `resolvePhaseExecution`
+      // JSDoc for the full precedence table.
       const resolved = resolvePhaseExecution(
         phase,
         ctx.options,
@@ -373,6 +368,16 @@ export async function executePhasedQuery(
       const phaseProvider = resolved.provider;
       const effectiveMaxTurns = resolved.maxTurns;
       const phaseModel = resolved.model;
+
+      const phasePrompt = composePhasePrompt({
+        vaultContext,
+        taskDisplayName: config.taskDisplayName,
+        taskOverview: config.taskPrompt,
+        phase,
+        priorPhaseResults: phaseResults,
+        instruction: ctx.instruction,
+        effectiveMaxTurns,
+      });
       const existingCheckpoint = state.phases[phase.name];
       // If the prior attempt failed without producing any turns, its sessionRef
       // points at a poisoned/never-initialized SDK session. Re-attaching to it
@@ -429,17 +434,17 @@ export async function executePhasedQuery(
     }
 
     const settled = await Promise.allSettled(
-      waveInputs.map((input) =>
-        executePhase(
+      waveInputs.map((waveInput) =>
+        executePhase({
           ctx,
-          input.phasePrompt,
-          input.phaseModel,
-          input.effectivePhase,
-          input.toolSurface,
-          input.phaseProvider,
-          input.sessionId,
-          input.sessionData,
-        ),
+          phasePrompt: waveInput.phasePrompt,
+          phaseModel: waveInput.phaseModel,
+          phase: waveInput.effectivePhase,
+          toolSurface: waveInput.toolSurface,
+          provider: waveInput.phaseProvider,
+          sessionId: waveInput.sessionId,
+          sessionData: waveInput.sessionData,
+        }),
       ),
     );
 

--- a/packages/myco/src/agent/prompt-composition.ts
+++ b/packages/myco/src/agent/prompt-composition.ts
@@ -8,78 +8,98 @@
  */
 
 import { PHASE_SUMMARY_MAX_CHARS } from '@myco/constants.js';
+import { interpolate } from '@myco/utils/interpolate.js';
 import type { PhaseDefinition, PhaseResult } from './types.js';
 
-/** Section header for vault context in the composed prompt. */
 const PROMPT_SECTION_TASK = '## Task: ';
-/** Section header for user instruction in the composed prompt. */
 const PROMPT_SECTION_INSTRUCTION = '## User Instruction';
-/** Separator between prompt sections. */
 const PROMPT_SECTION_SEPARATOR = '\n\n';
-/** Header for prior phase context in phased prompts. */
 const PROMPT_SECTION_PRIOR_PHASES = '## Prior Phase Results';
-/** Header for the current phase in phased prompts. */
 const PROMPT_SECTION_CURRENT_PHASE = '## Current Phase: ';
+
+const UUID_PATTERN = /\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b/i;
+
+// ---------------------------------------------------------------------------
+// Task prompts
+// ---------------------------------------------------------------------------
+
+export interface TaskPromptInput {
+  vaultContext: string;
+  taskDisplayName: string;
+  taskPrompt: string;
+  instruction?: string;
+}
 
 /**
  * Build the full task prompt from vault context, task definition, and
  * optional user instruction.
  *
- * Task prompts support template variables:
+ * Task prompts support:
  * - `{{session_id}}` — replaced with the session ID from instruction (if present)
  * - `{{instruction}}` — the raw user instruction text
  */
-export function composeTaskPrompt(
-  vaultContext: string,
-  taskDisplayName: string,
-  taskPrompt: string,
-  instruction?: string,
-): string {
-  // Extract session_id from instruction if it contains one (UUID pattern)
-  const sessionIdMatch = instruction?.match(/\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b/i);
-  const sessionId = sessionIdMatch?.[1] ?? '';
+export function composeTaskPrompt(input: TaskPromptInput): string {
+  const { vaultContext, taskDisplayName, taskPrompt, instruction } = input;
 
-  // Template variable substitution in task prompt
-  let resolvedPrompt = taskPrompt;
-  resolvedPrompt = resolvedPrompt.replace(/\{\{session_id\}\}/g, sessionId);
-  resolvedPrompt = resolvedPrompt.replace(/\{\{instruction\}\}/g, instruction ?? '');
+  const sessionId = instruction?.match(UUID_PATTERN)?.[1] ?? '';
+  const resolvedPrompt = interpolate(taskPrompt, {
+    session_id: sessionId,
+    instruction: instruction ?? '',
+  });
 
   const parts = [
     vaultContext,
     `${PROMPT_SECTION_TASK}${taskDisplayName}\n${resolvedPrompt}`,
   ];
-
   if (instruction) {
     parts.push(`${PROMPT_SECTION_INSTRUCTION}\n${instruction}`);
   }
-
   return parts.join(PROMPT_SECTION_SEPARATOR);
+}
+
+// ---------------------------------------------------------------------------
+// Phase prompts
+// ---------------------------------------------------------------------------
+
+export interface PhasePromptInput {
+  vaultContext: string;
+  taskDisplayName: string;
+  taskOverview: string;
+  phase: PhaseDefinition;
+  priorPhaseResults: PhaseResult[];
+  instruction?: string;
+  /** Resolved `maxTurns` after applying myco.yaml + run overrides. */
+  effectiveMaxTurns?: number;
 }
 
 /**
  * Build the prompt for a single phase in a phased execution.
  *
- * Includes vault context, the task overview, prior phase summaries,
- * and the current phase instructions.
+ * Includes vault context, the task overview, prior phase summaries, and
+ * the current phase instructions.
+ *
+ * Phase prompts support, resolved against the effective phase config:
+ * - `{{max_turns}}` — the phase's resolved turn budget (number)
+ * - `{{phase_name}}` — the phase's name
+ * - `{{phase_tools}}` — comma-separated list of tool names for this phase
+ *
+ * Authors should prefer these variables over hard-coded numbers or tool
+ * lists; users can override `maxTurns` (and other fields) in `myco.yaml`
+ * per-task or per-phase.
  */
-export function composePhasePrompt(
-  vaultContext: string,
-  taskDisplayName: string,
-  taskOverview: string,
-  phase: PhaseDefinition,
-  priorPhaseResults: PhaseResult[],
-  instruction?: string,
-): string {
+export function composePhasePrompt(input: PhasePromptInput): string {
+  const {
+    vaultContext, taskDisplayName, taskOverview, phase,
+    priorPhaseResults, instruction, effectiveMaxTurns,
+  } = input;
+
   const parts = [
     vaultContext,
     `${PROMPT_SECTION_TASK}${taskDisplayName}\n${taskOverview}`,
   ];
-
   if (instruction) {
     parts.push(`${PROMPT_SECTION_INSTRUCTION}\n${instruction}`);
   }
-
-  // Include prior phase results as context (unless the phase opts out)
   if (priorPhaseResults.length > 0 && !phase.skipPriorContext) {
     const summaries = priorPhaseResults.map((pr) => {
       const truncated = pr.summary.length > PHASE_SUMMARY_MAX_CHARS
@@ -90,8 +110,20 @@ export function composePhasePrompt(
     parts.push(`${PROMPT_SECTION_PRIOR_PHASES}\n${summaries.join('\n\n')}`);
   }
 
-  // Current phase instructions
-  parts.push(`${PROMPT_SECTION_CURRENT_PHASE}${phase.name}\n${phase.prompt}`);
+  const resolvedPhasePrompt = substitutePhaseVariables(phase, effectiveMaxTurns);
+  parts.push(`${PROMPT_SECTION_CURRENT_PHASE}${phase.name}\n${resolvedPhasePrompt}`);
 
   return parts.join(PROMPT_SECTION_SEPARATOR);
+}
+
+function substitutePhaseVariables(
+  phase: PhaseDefinition,
+  effectiveMaxTurns: number | undefined,
+): string {
+  const maxTurns = effectiveMaxTurns ?? phase.maxTurns;
+  return interpolate(phase.prompt, {
+    max_turns: maxTurns !== undefined ? String(maxTurns) : 'the configured budget',
+    phase_name: phase.name,
+    phase_tools: (phase.tools ?? []).join(', '),
+  });
 }

--- a/packages/myco/src/agent/runtime/claude.ts
+++ b/packages/myco/src/agent/runtime/claude.ts
@@ -85,15 +85,21 @@ export class ClaudeSdkRuntime implements AgentRuntime {
     let costUsd = 0;
     let assistantMessages = 0;
 
+    // Always pass `strictMcpConfig: true`, even when the phase wants no
+    // MCP tools (e.g., the orchestrator planner with `toolNames: []`).
+    // Without strict mode, the SDK falls back to loading every MCP server
+    // the user has configured in ~/.claude/mcp.json, ~/.claude.json, and
+    // every installed plugin — 130+ unrelated tools leak into the agent's
+    // tool surface, inflating context and occasionally triggering API
+    // schema rejections (Anthropic's 400 on top-level oneOf/allOf/anyOf).
     const messageStream: AsyncIterable<SDKMessage> = query({
       prompt: input.prompt,
       options: {
         model: input.model,
         systemPrompt: input.systemPrompt,
         tools: [],
-        ...(toolServer
-          ? { mcpServers: { [MCP_SERVER_NAME]: toolServer }, strictMcpConfig: true }
-          : {}),
+        mcpServers: toolServer ? { [MCP_SERVER_NAME]: toolServer } : {},
+        strictMcpConfig: true,
         maxTurns: input.maxTurns,
         permissionMode: 'bypassPermissions',
         allowDangerouslySkipPermissions: true,

--- a/packages/myco/src/agent/runtime/claude.ts
+++ b/packages/myco/src/agent/runtime/claude.ts
@@ -1,5 +1,6 @@
 import { query, type SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import type { RuntimeExecuteInput, RuntimeExecuteResult, AgentRuntime, RuntimeCapability } from './types.js';
+import { RuntimeExecutionError } from './types.js';
 import { createScopedVaultToolServer, createVaultToolServer } from '@myco/agent/tools.js';
 import { buildPhaseEnv } from '@myco/agent/provider.js';
 
@@ -71,37 +72,54 @@ export class ClaudeSdkRuntime implements AgentRuntime {
       },
     });
 
-    for await (const message of messageStream) {
-      if (message.type === 'assistant') {
-        assistantMessages += 1;
-        continue;
+    const buildUsage = () => ({
+      requests: turnsUsed,
+      inputTokens,
+      outputTokens,
+      totalTokens: inputTokens + outputTokens,
+      costUsd,
+      requestUsageEntries: turnsUsed > 0
+        ? [{
+            inputTokens,
+            outputTokens,
+            totalTokens: inputTokens + outputTokens,
+          }]
+        : [],
+    });
+
+    try {
+      for await (const message of messageStream) {
+        if (message.type === 'assistant') {
+          assistantMessages += 1;
+          continue;
+        }
+        if (message.type === 'result') {
+          // Capture usage on any subtype — error variants still burn tokens.
+          // finalText only exists on a successful result.
+          turnsUsed = message.num_turns ?? assistantMessages;
+          inputTokens = message.usage?.input_tokens ?? 0;
+          outputTokens = message.usage?.output_tokens ?? 0;
+          costUsd = message.total_cost_usd ?? 0;
+          if (message.subtype === 'success') {
+            finalText = message.result;
+          }
+        }
       }
-      if (message.type === 'result' && message.subtype === 'success') {
-        finalText = message.result;
-        turnsUsed = message.num_turns ?? assistantMessages;
-        inputTokens = message.usage.input_tokens ?? 0;
-        outputTokens = message.usage.output_tokens ?? 0;
-        costUsd = message.total_cost_usd ?? 0;
+    } catch (err) {
+      if (turnsUsed > 0 || inputTokens > 0 || outputTokens > 0) {
+        throw new RuntimeExecutionError(
+          err instanceof Error ? err.message : String(err),
+          { usage: buildUsage(), sessionRef: input.sessionRef },
+          { cause: err },
+        );
       }
+      throw err;
     }
 
     return {
       finalText,
       turnsUsed,
-      usage: {
-        requests: turnsUsed,
-        inputTokens,
-        outputTokens,
-        totalTokens: inputTokens + outputTokens,
-        costUsd,
-        requestUsageEntries: turnsUsed > 0
-          ? [{
-              inputTokens,
-              outputTokens,
-              totalTokens: inputTokens + outputTokens,
-            }]
-          : [],
-      },
+      usage: buildUsage(),
       sessionRef: input.sessionRef,
     };
   }

--- a/packages/myco/src/agent/runtime/claude.ts
+++ b/packages/myco/src/agent/runtime/claude.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { query, type SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import type { RuntimeExecuteInput, RuntimeExecuteResult, AgentRuntime, RuntimeCapability } from './types.js';
 import { RuntimeExecutionError } from './types.js';
@@ -5,6 +8,27 @@ import { createScopedVaultToolServer, createVaultToolServer } from '@myco/agent/
 import { buildPhaseEnv } from '@myco/agent/provider.js';
 
 const MCP_SERVER_NAME = 'myco-vault';
+
+/**
+ * Per-process isolated plugin cache directory for agent runs. The Claude
+ * SDK reads `~/.claude/plugins/installed_plugins.json` by default, which
+ * pulls in every plugin the user has installed in their developer Claude
+ * Code — dozens of extra tools we didn't register, some with schemas
+ * Anthropic's API now rejects (top-level `oneOf`/`allOf`/`anyOf`). Setting
+ * `CLAUDE_CODE_PLUGIN_CACHE_DIR` to an empty directory gives the agent a
+ * clean, deterministic tool surface: only our MCP vault tools.
+ *
+ * Created once per daemon process and reused across runs.
+ */
+let isolatedPluginCacheDir: string | undefined;
+
+function getIsolatedPluginCacheDir(): string {
+  if (isolatedPluginCacheDir) return isolatedPluginCacheDir;
+  const dir = path.join(os.tmpdir(), `myco-agent-plugin-cache-${process.pid}`);
+  fs.mkdirSync(dir, { recursive: true });
+  isolatedPluginCacheDir = dir;
+  return dir;
+}
 
 function buildToolServer(input: RuntimeExecuteInput) {
   const { toolSurface } = input;
@@ -44,7 +68,15 @@ export class ClaudeSdkRuntime implements AgentRuntime {
   async execute(input: RuntimeExecuteInput): Promise<RuntimeExecuteResult> {
     const toolServer = buildToolServer(input);
     const baseEnv = buildPhaseEnv(input.provider);
-    const env = { ...(baseEnv ?? process.env), MYCO_AGENT_SESSION: '1' };
+    const env = {
+      ...(baseEnv ?? process.env),
+      MYCO_AGENT_SESSION: '1',
+      // Isolate from the user's Claude Code plugin registry — see
+      // `getIsolatedPluginCacheDir()` docs above. Only honored when the
+      // user hasn't explicitly overridden the cache dir themselves.
+      CLAUDE_CODE_PLUGIN_CACHE_DIR:
+        process.env.CLAUDE_CODE_PLUGIN_CACHE_DIR ?? getIsolatedPluginCacheDir(),
+    };
 
     let finalText = '';
     let turnsUsed = 0;

--- a/packages/myco/src/agent/runtime/types.ts
+++ b/packages/myco/src/agent/runtime/types.ts
@@ -48,3 +48,32 @@ export interface AgentRuntime {
   execute(input: RuntimeExecuteInput): Promise<RuntimeExecuteResult>;
   supports(capability: RuntimeCapability): boolean;
 }
+
+/**
+ * Partial telemetry a runtime attaches to a thrown error when the underlying
+ * SDK burned real tokens before terminating. Without this, the phase
+ * executor's catch block cannot distinguish "run crashed after spending $5"
+ * from "run crashed before doing anything." Turn count lives on
+ * `usage.requests` (same invariant as the success-path RuntimeExecuteResult).
+ */
+export interface RuntimeErrorTelemetry {
+  usage: RuntimeUsage;
+  sessionRef?: string;
+  sessionData?: unknown;
+}
+
+/**
+ * Thrown when an SDK raises an error AFTER emitting usage-bearing messages
+ * (e.g., Claude SDK's max-turns error, which arrives as a result message
+ * immediately followed by a throw). Carries the usage captured before the
+ * throw so the caller can record accurate telemetry for the failed run.
+ */
+export class RuntimeExecutionError extends Error {
+  readonly telemetry: RuntimeErrorTelemetry;
+
+  constructor(message: string, telemetry: RuntimeErrorTelemetry, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'RuntimeExecutionError';
+    this.telemetry = telemetry;
+  }
+}

--- a/packages/myco/src/agent/tools.ts
+++ b/packages/myco/src/agent/tools.ts
@@ -27,6 +27,7 @@ import { createReadTools } from './tools/read-tools.js';
 import { createWriteTools } from './tools/write-tools.js';
 import { createObservabilityTools } from './tools/observability-tools.js';
 import { createSkillTools } from './tools/skill-tools.js';
+import { createExplorationTools } from './tools/exploration-tools.js';
 import type { SdkMcpToolDefinition, VaultToolDeps } from './tools/types.js';
 import type { EmbeddingManager } from '@myco/daemon/embedding/index.js';
 import type { TeamSyncClient } from '@myco/daemon/team-sync.js';
@@ -177,6 +178,10 @@ const SKILL_TOOL_NAMES = new Set([
   'vault_stage_skill', 'vault_finalize_skill',
 ]);
 
+const EXPLORATION_TOOL_NAMES = new Set([
+  'fs_read', 'fs_list', 'fs_tree', 'code_grep',
+]);
+
 /** Max chars stored from a tool response in the run audit trail. */
 const TOOL_OUTPUT_SUMMARY_LIMIT = 240;
 /** Read tools that can explode context if the agent loops on identical payloads. */
@@ -203,7 +208,8 @@ export const VAULT_TOOL_COUNT =
   READ_TOOL_NAMES.size +
   WRITE_TOOL_NAMES.size +
   OBSERVABILITY_TOOL_NAMES.size +
-  SKILL_TOOL_NAMES.size;
+  SKILL_TOOL_NAMES.size +
+  EXPLORATION_TOOL_NAMES.size;
 
 function setsOverlap(a: Set<string>, b: Set<string>): boolean {
   for (const item of a) { if (b.has(item)) return true; }
@@ -333,6 +339,7 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
     ...(needsAll || setsOverlap(onlyNames!, WRITE_TOOL_NAMES) ? createWriteTools(deps) : []),
     ...(needsAll || setsOverlap(onlyNames!, OBSERVABILITY_TOOL_NAMES) ? createObservabilityTools(deps) : []),
     ...(needsAll || setsOverlap(onlyNames!, SKILL_TOOL_NAMES) ? createSkillTools(deps) : []),
+    ...(needsAll || setsOverlap(onlyNames!, EXPLORATION_TOOL_NAMES) ? createExplorationTools(deps) : []),
   ];
 
   return tools.map((toolDef) => {

--- a/packages/myco/src/agent/tools/exploration-tools.ts
+++ b/packages/myco/src/agent/tools/exploration-tools.ts
@@ -1,0 +1,360 @@
+/**
+ * Code exploration tools: filesystem reads + ripgrep content search.
+ *
+ * 4 tools: fs_read, fs_list, fs_tree, code_grep
+ *
+ * Unlike the vault tools, these operate on the user's project files rather
+ * than the vault database. They're scoped to `projectRoot` — any path that
+ * resolves outside the root is rejected. Available to tasks that explicitly
+ * request them (notably vault-seed, which has no session data to draw on
+ * and must infer knowledge from source).
+ *
+ * Frugality is a first-class design goal. Tool responses and descriptions
+ * mirror Claude Code's native conventions: bounded default output sizes,
+ * explicit paging via offset-style args, and descriptions that teach
+ * narrow-first exploration. The alternative is a tight feedback loop
+ * where the agent reads gigabytes in a handful of turns and burns the
+ * provider's token-per-minute cap before doing any useful work.
+ *
+ * Schema note: Zod argument shapes use plain `.optional()` / `.string()` /
+ * `.number()` and avoid `.default()`, `.min()`, `.max()`, `.int()`,
+ * `.positive()` because OpenAI's strict function-calling rejects the
+ * JSON-schema keywords those produce (`default`, `minimum`, `maximum`,
+ * `exclusiveMinimum`). The defaulting and clamping happens in the handler
+ * instead — same behavior, compatible with both SDKs.
+ */
+
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { tool } from '@anthropic-ai/claude-agent-sdk';
+import { rgPath } from '@vscode/ripgrep';
+import { z } from 'zod/v4';
+import { textResult, type VaultToolDeps } from './types.js';
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// Limits and defaults (applied in handlers, not schemas)
+// ---------------------------------------------------------------------------
+
+/**
+ * Cap on bytes returned by fs_read when the agent reads an entire file.
+ * Protects against 1MB+ generated files blowing the budget in a single call.
+ * Most source files are well under this; paged reads are preferred regardless.
+ */
+const MAX_FILE_BYTES = 500_000;
+/** Default line count for fs_read when the agent omits start/end. Matches Claude Code's convention. */
+const DEFAULT_READ_LINES = 200;
+/** Hard ceiling on fs_read line window regardless of args. */
+const MAX_READ_LINES = 2000;
+/** Default entries-per-directory cap for fs_list. */
+const DEFAULT_LIST_LIMIT = 200;
+/** Absolute ceiling on fs_list limit regardless of what the agent passes. */
+const MAX_LIST_LIMIT = 1000;
+/** Default recursion depth for fs_tree — intentionally shallow. */
+const DEFAULT_TREE_DEPTH = 1;
+/** Max recursion depth allowed for fs_tree regardless of input. */
+const MAX_TREE_DEPTH = 4;
+/** Max total tree entries surfaced per fs_tree call — tail-truncates with a marker. */
+const MAX_TREE_ENTRIES = 200;
+/** Default result cap for code_grep. */
+const DEFAULT_GREP_RESULTS = 50;
+/** Hard ceiling on code_grep matches — ripgrep is stopped as soon as we hit this. */
+const MAX_GREP_RESULTS = 200;
+/** Max context lines allowed per grep match. */
+const MAX_GREP_CONTEXT = 5;
+/** Per-match text cap for code_grep — survives minified files without blowing the budget. */
+const MAX_GREP_MATCH_CHARS = 200;
+/** Directories skipped by fs_tree and fs_list during recursive walk. */
+const IGNORE_DIRS = new Set([
+  'node_modules', '.git', 'dist', 'build', '.next', 'coverage',
+  '.myco', '.agents', '.turbo', '.cache', 'out',
+]);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Guard at call time rather than factory time so the tools always register
+ * in the runtime tool registry. Callers without a project root get a clear
+ * error instead of a silently missing tool.
+ */
+function assertProjectRoot(projectRoot: string | undefined): asserts projectRoot is string {
+  if (!projectRoot) {
+    throw new Error('Code exploration tools require a project root; none was configured for this run.');
+  }
+}
+
+/**
+ * Resolve `inputPath` relative to `projectRoot` and reject anything that
+ * escapes it. Returns the absolute path inside the project.
+ */
+function resolveScoped(projectRoot: string | undefined, inputPath: string): string {
+  assertProjectRoot(projectRoot);
+  const resolved = path.resolve(projectRoot, inputPath);
+  const rel = path.relative(projectRoot, resolved);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    throw new Error(`Path resolves outside project root: ${inputPath}`);
+  }
+  return resolved;
+}
+
+function clampInt(value: number | undefined, fallback: number, min: number, max: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  const n = Math.trunc(value);
+  return Math.min(Math.max(n, min), max);
+}
+
+function truncateLine(line: string, max: number): string {
+  return line.length > max ? `${line.slice(0, max - 1)}…` : line;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createExplorationTools(deps: VaultToolDeps) {
+  const { projectRoot } = deps;
+
+  const fsRead = tool(
+    'fs_read',
+    `Read a window of lines from a text file. Paths are resolved relative to the project root; paths that escape the root are rejected. ` +
+    `By default returns up to ${DEFAULT_READ_LINES} lines starting at the top. Page through longer files with start_line + end_line (1-indexed, inclusive). ` +
+    `The response includes total_lines so you know how much remains. Prefer narrow line windows over whole-file reads. ` +
+    `Files larger than ${Math.floor(MAX_FILE_BYTES / 1000)}KB are head+tail truncated before line-slicing. Max window: ${MAX_READ_LINES} lines.`,
+    {
+      path: z.string().describe('File path relative to the project root.'),
+      start_line: z.number().optional().describe(`First line to return (1-indexed). Omit to start at line 1.`),
+      end_line: z.number().optional().describe(`Last line to return (inclusive). Omit to return the default window (${DEFAULT_READ_LINES} lines from start_line).`),
+    },
+    async (args) => {
+      const fullPath = resolveScoped(projectRoot, args.path);
+      const stat = await fs.promises.stat(fullPath);
+      if (!stat.isFile()) throw new Error(`Not a file: ${args.path}`);
+
+      let content = await fs.promises.readFile(fullPath, 'utf-8');
+      let bytesTruncated = false;
+      if (stat.size > MAX_FILE_BYTES) {
+        const half = Math.floor(MAX_FILE_BYTES / 2);
+        content = `${content.slice(0, half)}\n\n... [truncated ${stat.size - MAX_FILE_BYTES} bytes] ...\n\n${content.slice(-half)}`;
+        bytesTruncated = true;
+      }
+
+      const lines = content.split('\n');
+      const totalLines = lines.length;
+
+      const requestedStart = args.start_line !== undefined ? Math.max(1, Math.trunc(args.start_line)) : 1;
+      const requestedEnd = args.end_line !== undefined
+        ? Math.max(requestedStart, Math.trunc(args.end_line))
+        : requestedStart + DEFAULT_READ_LINES - 1;
+      const cappedEnd = Math.min(requestedEnd, requestedStart + MAX_READ_LINES - 1, totalLines);
+
+      const sliced = lines.slice(requestedStart - 1, cappedEnd).join('\n');
+      const linesTruncated = cappedEnd < totalLines || cappedEnd < requestedEnd;
+
+      return textResult({
+        path: args.path,
+        size: stat.size,
+        total_lines: totalLines,
+        start_line: requestedStart,
+        end_line: cappedEnd,
+        bytes_truncated: bytesTruncated,
+        truncated: linesTruncated,
+        content: sliced,
+      });
+    },
+    { annotations: { readOnlyHint: true } },
+  );
+
+  const fsList = tool(
+    'fs_list',
+    `List entries in ONE directory (non-recursive). Returns name, type (file|dir|other), and size for each. ` +
+    `Start narrow: call with path="." to see the top level, then drill into specific subdirs. ` +
+    `Dotfiles are hidden unless include_hidden=true. Use fs_tree for nested structure, not fs_list in a loop. ` +
+    `Defaults: path=".", include_hidden=false, limit=${DEFAULT_LIST_LIMIT} (max ${MAX_LIST_LIMIT}).`,
+    {
+      path: z.string().optional().describe('Directory path relative to the project root (default ".").'),
+      include_hidden: z.boolean().optional().describe('Include entries starting with "." (default false).'),
+      limit: z.number().optional().describe(`Max entries to return (default ${DEFAULT_LIST_LIMIT}, max ${MAX_LIST_LIMIT}).`),
+    },
+    async (args) => {
+      const targetPath = args.path ?? '.';
+      const includeHidden = args.include_hidden === true;
+      const limit = clampInt(args.limit, DEFAULT_LIST_LIMIT, 1, MAX_LIST_LIMIT);
+
+      const fullPath = resolveScoped(projectRoot, targetPath);
+      const entries = await fs.promises.readdir(fullPath, { withFileTypes: true });
+      const visible = includeHidden ? entries : entries.filter((e) => !e.name.startsWith('.'));
+      const sorted = visible.sort((a, b) => {
+        // Directories first, then alphabetical.
+        const dirDiff = Number(b.isDirectory()) - Number(a.isDirectory());
+        return dirDiff !== 0 ? dirDiff : a.name.localeCompare(b.name);
+      });
+      const limited = sorted.slice(0, limit);
+      const items = await Promise.all(limited.map(async (entry) => {
+        // Only stat files — directory sizes aren't reported, so the syscall
+        // would be discarded. Cuts syscalls roughly in half on dir-heavy paths.
+        const isFile = entry.isFile();
+        const stat = isFile
+          ? await fs.promises.stat(path.join(fullPath, entry.name)).catch(() => null)
+          : null;
+        return {
+          name: entry.name,
+          type: entry.isDirectory() ? 'dir' : isFile ? 'file' : 'other',
+          size: stat?.size ?? null,
+        };
+      }));
+      return textResult({
+        path: targetPath,
+        total: visible.length,
+        truncated: visible.length > limit,
+        items,
+      });
+    },
+    { annotations: { readOnlyHint: true } },
+  );
+
+  const fsTree = tool(
+    'fs_tree',
+    `Print a shallow directory tree. Skips common noise (node_modules, .git, dist, build, .myco, .agents, etc.). ` +
+    `Start with depth=1 at "." to survey the top level, then drill into specific subdirectories with deeper depth if needed. ` +
+    `The response is hard-capped at ${MAX_TREE_ENTRIES} entries and tail-truncates with a "… N more hidden" marker; going deep on a big repo will hit the cap and hide useful structure. ` +
+    `Defaults: path=".", depth=${DEFAULT_TREE_DEPTH} (max ${MAX_TREE_DEPTH}), include_hidden=false.`,
+    {
+      path: z.string().optional().describe('Root directory relative to the project root (default ".").'),
+      depth: z.number().optional().describe(`Recursion depth (default ${DEFAULT_TREE_DEPTH}, max ${MAX_TREE_DEPTH}). Start with 1 and go deeper only for specific subtrees.`),
+      include_hidden: z.boolean().optional().describe('Include entries starting with "." (default false).'),
+    },
+    async (args) => {
+      const targetPath = args.path ?? '.';
+      const depth = clampInt(args.depth, DEFAULT_TREE_DEPTH, 1, MAX_TREE_DEPTH);
+      const includeHidden = args.include_hidden === true;
+
+      const root = resolveScoped(projectRoot, targetPath);
+
+      const lines: string[] = [];
+      let hiddenCount = 0;
+
+      async function walk(dir: string, remainingDepth: number, prefix: string): Promise<void> {
+        if (remainingDepth <= 0) return;
+        const raw = await fs.promises.readdir(dir, { withFileTypes: true }).catch(() => []);
+        const entries = raw
+          .filter((e) => !IGNORE_DIRS.has(e.name))
+          .filter((e) => includeHidden || !e.name.startsWith('.'))
+          .sort((a, b) => {
+            const dirDiff = Number(b.isDirectory()) - Number(a.isDirectory());
+            return dirDiff !== 0 ? dirDiff : a.name.localeCompare(b.name);
+          });
+
+        for (let i = 0; i < entries.length; i++) {
+          const entry = entries[i];
+          const isLast = i === entries.length - 1;
+          if (lines.length >= MAX_TREE_ENTRIES) {
+            hiddenCount += entries.length - i;
+            // Account for subdirectory descendants we won't walk into.
+            return;
+          }
+          const connector = isLast ? '└── ' : '├── ';
+          const suffix = entry.isDirectory() ? '/' : '';
+          lines.push(`${prefix}${connector}${entry.name}${suffix}`);
+          if (entry.isDirectory() && remainingDepth > 1) {
+            const childPrefix = prefix + (isLast ? '    ' : '│   ');
+            await walk(path.join(dir, entry.name), remainingDepth - 1, childPrefix);
+          }
+        }
+      }
+
+      await walk(root, depth, '');
+      const treeText = hiddenCount > 0
+        ? `${lines.join('\n')}\n… ${hiddenCount} more entries hidden (cap ${MAX_TREE_ENTRIES}); call fs_tree on a narrower path or fs_list on a specific directory`
+        : lines.join('\n');
+
+      return textResult({
+        path: targetPath,
+        depth,
+        entries_returned: lines.length,
+        entries_hidden: hiddenCount,
+        tree: treeText,
+      });
+    },
+    { annotations: { readOnlyHint: true } },
+  );
+
+  const codeGrep = tool(
+    'code_grep',
+    `Search file contents using ripgrep. Returns up to ${MAX_GREP_RESULTS} matches (path, line number, matched text). ` +
+    `Honors .gitignore by default and skips binary files. Matched lines are truncated at ${MAX_GREP_MATCH_CHARS} chars to survive minified files. ` +
+    `Use this instead of reading many files when looking for a pattern — it is dramatically faster and cheaper. ` +
+    `Narrow aggressively: prefer a concrete directory over "." and a glob filter (e.g. "*.ts") when you know the language. ` +
+    `Defaults: path=".", case_insensitive=false, context_lines=0, max_results=${DEFAULT_GREP_RESULTS} (max ${MAX_GREP_RESULTS}).`,
+    {
+      pattern: z.string().describe('Regex pattern (ripgrep / Rust regex syntax).'),
+      path: z.string().optional().describe('Directory or file to search, relative to the project root (default ".").'),
+      glob: z.string().optional().describe('Optional glob filter, e.g. "*.ts" or "!**/*.test.ts".'),
+      case_insensitive: z.boolean().optional().describe('Case-insensitive match (default false).'),
+      context_lines: z.number().optional().describe(`Lines of surrounding context to include per match (default 0, max ${MAX_GREP_CONTEXT}). Increase only when line-only output is ambiguous.`),
+      max_results: z.number().optional().describe(`Max matches to return (default ${DEFAULT_GREP_RESULTS}, max ${MAX_GREP_RESULTS}).`),
+    },
+    async (args) => {
+      const targetPath = args.path ?? '.';
+      const caseInsensitive = args.case_insensitive === true;
+      const contextLines = clampInt(args.context_lines, 0, 0, MAX_GREP_CONTEXT);
+      const maxResults = clampInt(args.max_results, DEFAULT_GREP_RESULTS, 1, MAX_GREP_RESULTS);
+
+      assertProjectRoot(projectRoot);
+      const searchPath = resolveScoped(projectRoot, targetPath);
+      const rgArgs: string[] = [
+        '--json',
+        '--max-count', String(maxResults),
+        ...(caseInsensitive ? ['-i'] : []),
+        ...(contextLines > 0 ? ['-C', String(contextLines)] : []),
+        ...(args.glob ? ['-g', args.glob] : []),
+        '--', args.pattern, searchPath,
+      ];
+
+      let stdout: string;
+      try {
+        ({ stdout } = await execFileAsync(rgPath, rgArgs, { maxBuffer: 10_000_000 }));
+      } catch (err) {
+        // ripgrep exits 1 when no matches — treat as empty result, not error.
+        const exitCode = (err as { code?: number }).code;
+        if (exitCode === 1) {
+          return textResult({ pattern: args.pattern, matches: [], truncated: false });
+        }
+        throw err;
+      }
+
+      const matches: Array<{ path: string; line: number; text: string }> = [];
+      for (const line of stdout.split('\n')) {
+        if (!line.trim()) continue;
+        let evt: { type?: string; data?: { path?: { text?: string } | string; line_number?: number; lines?: { text?: string } } };
+        try {
+          evt = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (evt.type !== 'match' || !evt.data) continue;
+        const rawPath = typeof evt.data.path === 'string' ? evt.data.path : evt.data.path?.text;
+        if (!rawPath) continue;
+        const relPath = path.relative(projectRoot, rawPath);
+        matches.push({
+          path: relPath,
+          line: evt.data.line_number ?? 0,
+          text: truncateLine((evt.data.lines?.text ?? '').replace(/\n$/, ''), MAX_GREP_MATCH_CHARS),
+        });
+        if (matches.length >= maxResults) break;
+      }
+      return textResult({
+        pattern: args.pattern,
+        matches,
+        truncated: matches.length >= maxResults,
+      });
+    },
+    { annotations: { readOnlyHint: true } },
+  );
+
+  return [fsRead, fsList, fsTree, codeGrep];
+}

--- a/packages/myco/src/agent/types.ts
+++ b/packages/myco/src/agent/types.ts
@@ -211,7 +211,7 @@ export interface TaskSchedule {
   preCondition?: 'has-unprocessed-batches' | 'has-active-skills' | 'has-approved-candidates' | 'has-skill-survey-evidence';
 }
 
-/** Shape of each task YAML file (e.g., `tasks/full-intelligence.yaml`). */
+/** Shape of each task YAML file (e.g., `tasks/vault-evolve.yaml`). */
 export interface AgentTask {
   name: string;
   displayName: string;

--- a/packages/myco/src/cli/agent-eval.ts
+++ b/packages/myco/src/cli/agent-eval.ts
@@ -109,9 +109,9 @@ Options:
   --help, -h                  Show this help message
 
 Examples:
-  myco agent eval --task full-intelligence --dry-run --no-wait
-  myco agent eval --task full-intelligence --runtimes claude-sdk,openai-agents --dry-run
-  myco agent eval --task full-intelligence --reasoning low,high --models claude-opus-4-5
+  myco agent eval --task vault-evolve --dry-run --no-wait
+  myco agent eval --task vault-evolve --runtimes claude-sdk,openai-agents --dry-run
+  myco agent eval --task vault-evolve --reasoning low,high --models claude-opus-4-5
 `;
 
 // ---------------------------------------------------------------------------

--- a/packages/myco/src/config/migrations.ts
+++ b/packages/myco/src/config/migrations.ts
@@ -218,6 +218,29 @@ export const MIGRATIONS: Migration[] = [
       if (!('mode' in settings)) settings.mode = 'banner';
     },
   },
+  {
+    version: 6,
+    name: 'rename-full-intelligence-to-vault-evolve',
+    migrate(doc: Record<string, unknown>, _vaultDir: string): void {
+      // The built-in task `full-intelligence` was renamed to `vault-evolve`.
+      // Move any user overrides stored under the old task key so their
+      // schedule, model, and phase settings keep applying.
+      const agent = doc.agent as Record<string, unknown> | undefined;
+      if (!agent) return;
+      const tasks = agent.tasks as Record<string, unknown> | undefined;
+      if (!tasks || !('full-intelligence' in tasks)) return;
+
+      const legacy = tasks['full-intelligence'];
+      const existing = tasks['vault-evolve'];
+
+      // If a user somehow has both (e.g., hand-edited config), keep the
+      // newer key and drop the legacy one rather than clobbering.
+      if (!existing) {
+        tasks['vault-evolve'] = legacy;
+      }
+      delete tasks['full-intelligence'];
+    },
+  },
 ];
 
 /** Current migration version — the highest version in MIGRATIONS. */

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -14,7 +14,7 @@ const DaemonSchema = z.object({
   log_retention_days: z.number().int().min(1).max(365).default(30),
   /**
    * Time without new prompts before an active session is auto-completed (ms).
-   * Intelligence tasks (full-intelligence, skill-survey, etc.) only process
+   * Intelligence tasks (vault-evolve, skill-survey, etc.) only process
    * settled sessions, so this threshold directly controls how fresh their
    * inputs are. Defaults to 1 hour.
    */

--- a/packages/myco/src/daemon/task-scheduling.ts
+++ b/packages/myco/src/daemon/task-scheduling.ts
@@ -218,7 +218,7 @@ export async function registerScheduledTasks(
     preConditions: {
       'has-unprocessed-batches': () => {
         // Only count unprocessed batches from sessions that have settled
-        // (status != 'active'). Otherwise full-intelligence fires on every
+        // (status != 'active'). Otherwise vault-evolve fires on every
         // live prompt and then filters everything out — wasted agent runs.
         const row = getDatabase().prepare(
           `SELECT 1 FROM prompt_batches pb

--- a/packages/myco/src/templates/index.ts
+++ b/packages/myco/src/templates/index.ts
@@ -8,6 +8,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { findPackageRoot } from '../utils/find-package-root.js';
+import { interpolate } from '../utils/interpolate.js';
 
 /**
  * Resolve the templates directory. Same strategy as prompts loader.
@@ -36,10 +37,5 @@ export function loadTemplate(name: string, vars: Record<string, string> = {}): s
     raw = fs.readFileSync(path.join(TEMPLATES_DIR, `${name}.md`), 'utf-8');
     templateCache.set(name, raw);
   }
-
-  let result = raw;
-  for (const [key, value] of Object.entries(vars)) {
-    result = result.replaceAll(`{{${key}}}`, value);
-  }
-  return result;
+  return interpolate(raw, vars);
 }

--- a/packages/myco/src/utils/interpolate.ts
+++ b/packages/myco/src/utils/interpolate.ts
@@ -1,0 +1,14 @@
+/**
+ * Replace `{{name}}` placeholders in a template with values from `vars`.
+ *
+ * Missing keys are left in place — callers who need strict substitution
+ * should validate their inputs before calling. Used by prompt composition
+ * (task + phase prompts) and template-file loading.
+ */
+export function interpolate(template: string, vars: Record<string, string>): string {
+  let result = template;
+  for (const [key, value] of Object.entries(vars)) {
+    result = result.replaceAll(`{{${key}}}`, value);
+  }
+  return result;
+}

--- a/packages/myco/ui/src/components/agent/RunDetail.tsx
+++ b/packages/myco/ui/src/components/agent/RunDetail.tsx
@@ -458,7 +458,7 @@ function PhaseAuditSection({ runId }: { runId: string }) {
 
 /* ---------- Digest revisions section ---------- */
 
-/** Default digest tier to surface in the revisions panel (matches full-intelligence writes). */
+/** Default digest tier to surface in the revisions panel (matches vault-evolve writes). */
 const DEFAULT_DIGEST_TIER = 5000;
 
 function DigestRevisionRowView({
@@ -640,9 +640,9 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
   const isDryRun = run.dry_run === true;
   // Detect whether this run produced digest writes so we know whether to
   // render the revisions section. turns is empty until the audit trail is
-  // opened; fall back to task name ('full-intelligence' always writes a
+  // opened; fall back to task name ('vault-evolve' always writes a
   // digest) to avoid hiding the section on initial page load.
-  const hasDigestActivity = !isDryRun && (run.task === 'full-intelligence' || hasDigestWrites(turns));
+  const hasDigestActivity = !isDryRun && (run.task === 'vault-evolve' || hasDigestWrites(turns));
 
   return (
     <div className="space-y-6">

--- a/tests/agent/executor-cleanup.test.ts
+++ b/tests/agent/executor-cleanup.test.ts
@@ -77,7 +77,7 @@ describe('cleanupOnTaskFailure', () => {
     writeStagedSkill(vaultDir, 'cand-unrelated', 'content');
 
     await cleanupOnTaskFailure({
-      taskName: 'full-intelligence',
+      taskName: 'vault-evolve',
       vaultDir,
       runContext: { candidate_id: 'cand-unrelated' },
     });
@@ -225,7 +225,7 @@ describe('finalizeOnTaskSuccess', () => {
   it('is a no-op for unrelated tasks', async () => {
     await expect(
       finalizeOnTaskSuccess({
-        taskName: 'full-intelligence',
+        taskName: 'vault-evolve',
         agentId: DEFAULT_AGENT_ID,
         runId: 'run-unrelated',
         runContext: undefined,

--- a/tests/agent/executor-dry-run.test.ts
+++ b/tests/agent/executor-dry-run.test.ts
@@ -301,12 +301,12 @@ describe('executor dry-run threading', () => {
     const { runAgent } = await import('@myco/agent/executor.js');
 
     // Use a task without a postcondition to avoid the run failing for other reasons
-    const noPostconditionTask = 'full-intelligence';
+    const noPostconditionTask = 'vault-evolve';
     upsertTask({
       id: noPostconditionTask,
       agent_id: TEST_AGENT_ID,
       prompt: 'Run full intelligence pipeline.',
-      display_name: 'Full Intelligence',
+      display_name: 'Vault Evolve',
       description: 'Full intelligence pipeline',
       is_default: 0,
       created_at: epochSeconds(),
@@ -315,7 +315,7 @@ describe('executor dry-run threading', () => {
 
     const result = await runAgent(TEST_VAULT_DIR, { task: noPostconditionTask });
 
-    // full-intelligence has no postcondition rule, so it completes.
+    // vault-evolve has no postcondition rule, so it completes.
     const run = getRun(result.runId);
     expect(run).not.toBeNull();
     expect(run!.dry_run).toBe(false);

--- a/tests/agent/executor-openai-agents.test.ts
+++ b/tests/agent/executor-openai-agents.test.ts
@@ -22,7 +22,7 @@ import { epochSeconds } from '@myco/constants.js';
 
 const TEST_AGENT_ID = 'myco-agent';
 const TEST_VAULT_DIR = '/tmp/test-vault-openai-agents';
-const TEST_TASK_NAME = 'full-intelligence'; // no postcondition, easy path
+const TEST_TASK_NAME = 'vault-evolve'; // no postcondition, easy path
 const TEST_TASK_PROMPT = 'Do the thing.';
 const TEST_SYSTEM_PROMPT = 'You are a vault agent.';
 
@@ -141,7 +141,7 @@ vi.mock('@myco/agent/loader.js', async (importOriginal) => {
     }),
     loadAgentTasks: () => [{
       name: TEST_TASK_NAME,
-      displayName: 'Full Intelligence',
+      displayName: 'Vault Evolve',
       description: 'Run full intelligence pipeline.',
       agent: TEST_AGENT_ID,
       prompt: TEST_TASK_PROMPT,
@@ -156,7 +156,7 @@ vi.mock('@myco/agent/registry.js', () => ({
     const tasks = new Map();
     tasks.set(TEST_TASK_NAME, {
       name: TEST_TASK_NAME,
-      displayName: 'Full Intelligence',
+      displayName: 'Vault Evolve',
       description: 'Run full intelligence pipeline.',
       agent: TEST_AGENT_ID,
       prompt: TEST_TASK_PROMPT,
@@ -238,7 +238,7 @@ function createTestTask(): void {
     id: TEST_TASK_NAME,
     agent_id: TEST_AGENT_ID,
     prompt: TEST_TASK_PROMPT,
-    display_name: 'Full Intelligence',
+    display_name: 'Vault Evolve',
     description: 'Run full intelligence pipeline.',
     is_default: 0,
     created_at: now,

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -1583,9 +1583,12 @@ describe('runAgent — phased execution', () => {
     expect(result.status).toBe('completed');
     // 1 orchestrator planning call + 3 phase calls = 4 total
     expect(allQueryCalls.length).toBe(4);
-    // Orchestrator call uses no mcpServers (planning only)
+    // Orchestrator call uses an empty mcpServers map with strictMcpConfig
+    // — planning needs no vault tools, but we still lock down the surface
+    // so the SDK doesn't fall back to loading the user's MCP registry.
     const orchestratorCall = allQueryCalls[0];
-    expect((orchestratorCall.options as Record<string, unknown>).mcpServers).toBeUndefined();
+    expect((orchestratorCall.options as Record<string, unknown>).mcpServers).toEqual({});
+    expect((orchestratorCall.options as Record<string, unknown>).strictMcpConfig).toBe(true);
     expect((orchestratorCall.options as Record<string, unknown>).tools).toEqual([]);
     // All 3 phases should have run
     expect(result.phases!.length).toBe(3);

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -24,7 +24,7 @@ import type { ReportRow } from '@myco/db/queries/reports.js';
 
 const TEST_AGENT_ID = 'myco-agent';
 const TEST_VAULT_DIR = '/tmp/test-vault';
-const TEST_TASK_NAME = 'full-intelligence';
+const TEST_TASK_NAME = 'vault-evolve';
 const TEST_TASK_PROMPT = 'Run full intelligence pipeline.';
 const TEST_SYSTEM_PROMPT = 'You are a vault agent.';
 
@@ -198,7 +198,7 @@ vi.mock('@myco/agent/loader.js', async (importOriginal) => {
       if (mockYamlPhases) {
         return [{
           name: TEST_TASK_NAME,
-          displayName: 'Full Intelligence',
+          displayName: 'Vault Evolve',
           description: 'Run full intelligence pipeline',
           agent: 'myco-agent',
           prompt: 'Phased pipeline overview.',
@@ -208,7 +208,7 @@ vi.mock('@myco/agent/loader.js', async (importOriginal) => {
       }
       return [{
         name: TEST_TASK_NAME,
-        displayName: 'Full Intelligence',
+        displayName: 'Vault Evolve',
         description: 'Run full intelligence pipeline',
         agent: 'myco-agent',
         prompt: TEST_TASK_PROMPT,
@@ -229,7 +229,7 @@ vi.mock('@myco/agent/registry.js', () => ({
     const tasks = new Map();
       const task = {
         name: TEST_TASK_NAME,
-        displayName: 'Full Intelligence',
+        displayName: 'Vault Evolve',
         description: 'Run full intelligence pipeline',
         agent: 'myco-agent',
         prompt: mockYamlPhases ? 'Phased pipeline overview.' : TEST_TASK_PROMPT,
@@ -341,7 +341,7 @@ async function createTestTask(): Promise<void> {
     id: TEST_TASK_NAME,
     agent_id: TEST_AGENT_ID,
     prompt: TEST_TASK_PROMPT,
-    display_name: 'Full Intelligence',
+    display_name: 'Vault Evolve',
     description: 'Run full intelligence pipeline',
     is_default: 1,
     created_at: now,
@@ -395,26 +395,26 @@ function resetMockState(): void {
 
 describe('composeTaskPrompt', () => {
   it('composes vault context + task without instruction', () => {
-    const result = composeTaskPrompt(
-      '## Vault State\nspores: 10',
-      'Full Intelligence',
-      'Run full intelligence.',
-    );
+    const result = composeTaskPrompt({
+      vaultContext: '## Vault State\nspores: 10',
+      taskDisplayName: 'Vault Evolve',
+      taskPrompt: 'Run full intelligence.',
+    });
 
     expect(result).toContain('## Vault State');
     expect(result).toContain('spores: 10');
-    expect(result).toContain('## Task: Full Intelligence');
+    expect(result).toContain('## Task: Vault Evolve');
     expect(result).toContain('Run full intelligence.');
     expect(result).not.toContain('## User Instruction');
   });
 
   it('appends user instruction when provided', () => {
-    const result = composeTaskPrompt(
-      '## Vault State',
-      'Full Intelligence',
-      'Run full intelligence.',
-      'Focus on gotchas only.',
-    );
+    const result = composeTaskPrompt({
+      vaultContext: '## Vault State',
+      taskDisplayName: 'Vault Evolve',
+      taskPrompt: 'Run full intelligence.',
+      instruction: 'Focus on gotchas only.',
+    });
 
     expect(result).toContain('## User Instruction');
     expect(result).toContain('Focus on gotchas only.');
@@ -427,20 +427,20 @@ describe('composeTaskPrompt', () => {
 
 describe('composePhasePrompt', () => {
   const vaultContext = '## Vault State\nspores: 10';
-  const taskName = 'Full Intelligence';
+  const taskName = 'Vault Evolve';
   const taskOverview = 'Complete intelligence pipeline.';
 
   it('composes vault context + task overview + phase prompt', () => {
-    const result = composePhasePrompt(
+    const result = composePhasePrompt({
       vaultContext,
-      taskName,
+      taskDisplayName: taskName,
       taskOverview,
-      { name: 'extract', prompt: 'Extract spores from batches.', tools: [], maxTurns: 5, required: true },
-      [],
-    );
+      phase: { name: 'extract', prompt: 'Extract spores from batches.', tools: [], maxTurns: 5, required: true },
+      priorPhaseResults: [],
+    });
 
     expect(result).toContain('## Vault State');
-    expect(result).toContain('## Task: Full Intelligence');
+    expect(result).toContain('## Task: Vault Evolve');
     expect(result).toContain('Complete intelligence pipeline.');
     expect(result).toContain('## Current Phase: extract');
     expect(result).toContain('Extract spores from batches.');
@@ -448,16 +448,16 @@ describe('composePhasePrompt', () => {
   });
 
   it('includes prior phase results when available', () => {
-    const result = composePhasePrompt(
+    const result = composePhasePrompt({
       vaultContext,
-      taskName,
+      taskDisplayName: taskName,
       taskOverview,
-      { name: 'consolidate', prompt: 'Consolidate spores.', tools: [], maxTurns: 5, required: true },
-      [
+      phase: { name: 'consolidate', prompt: 'Consolidate spores.', tools: [], maxTurns: 5, required: true },
+      priorPhaseResults: [
         { name: 'extract', status: 'completed', turnsUsed: 3, tokensUsed: 500, costUsd: 0.001, summary: 'Created 5 spores.' },
         { name: 'summarize', status: 'completed', turnsUsed: 2, tokensUsed: 300, costUsd: 0.0005, summary: 'Updated 2 sessions.' },
       ],
-    );
+    });
 
     expect(result).toContain('## Prior Phase Results');
     expect(result).toContain('### extract (completed)');
@@ -468,27 +468,27 @@ describe('composePhasePrompt', () => {
 
   it('truncates long phase summaries', () => {
     const longSummary = 'A'.repeat(5000);
-    const result = composePhasePrompt(
+    const result = composePhasePrompt({
       vaultContext,
-      taskName,
+      taskDisplayName: taskName,
       taskOverview,
-      { name: 'graph', prompt: 'Build graph.', tools: [], maxTurns: 5, required: true },
-      [{ name: 'extract', status: 'completed', turnsUsed: 3, tokensUsed: 500, costUsd: 0.001, summary: longSummary }],
-    );
+      phase: { name: 'graph', prompt: 'Build graph.', tools: [], maxTurns: 5, required: true },
+      priorPhaseResults: [{ name: 'extract', status: 'completed', turnsUsed: 3, tokensUsed: 500, costUsd: 0.001, summary: longSummary }],
+    });
 
     expect(result).toContain('...');
     expect(result.indexOf(longSummary)).toBe(-1);
   });
 
   it('includes user instruction when provided', () => {
-    const result = composePhasePrompt(
+    const result = composePhasePrompt({
       vaultContext,
-      taskName,
+      taskDisplayName: taskName,
       taskOverview,
-      { name: 'extract', prompt: 'Extract spores.', tools: [], maxTurns: 5, required: true },
-      [],
-      'Focus on security issues.',
-    );
+      phase: { name: 'extract', prompt: 'Extract spores.', tools: [], maxTurns: 5, required: true },
+      priorPhaseResults: [],
+      instruction: 'Focus on security issues.',
+    });
 
     expect(result).toContain('## User Instruction');
     expect(result).toContain('Focus on security issues.');
@@ -518,8 +518,8 @@ describe('resolvePhaseExecution', () => {
     timeoutSeconds: 300,
     systemPromptPath: 'prompts/system.md',
     tools: [],
-    taskName: 'full-intelligence',
-    taskDisplayName: 'Full Intelligence',
+    taskName: 'vault-evolve',
+    taskDisplayName: 'Vault Evolve',
     taskPrompt: 'overview',
   };
 
@@ -844,7 +844,7 @@ describe('runAgent', () => {
 
     expect(capturedQueryArgs).not.toBeNull();
     expect(capturedQueryArgs!.prompt).toContain('## Current Vault State');
-    expect(capturedQueryArgs!.prompt).toContain('## Task: Full Intelligence');
+    expect(capturedQueryArgs!.prompt).toContain('## Task: Vault Evolve');
     expect(capturedQueryArgs!.prompt).toContain(TEST_TASK_PROMPT);
     expect(capturedQueryArgs!.options?.systemPrompt).toBe(TEST_SYSTEM_PROMPT);
   });
@@ -856,13 +856,13 @@ describe('runAgent', () => {
     insertRun({
       id: existingRunId,
       agent_id: TEST_AGENT_ID,
-      task: 'full-intelligence',
+      task: 'vault-evolve',
       status: 'running',
       started_at: epochSeconds(),
     });
 
     // Same task running → skipped
-    const result = await runAgent(TEST_VAULT_DIR, { task: 'full-intelligence' });
+    const result = await runAgent(TEST_VAULT_DIR, { task: 'vault-evolve' });
 
     expect(result.status).toBe('skipped');
     expect(result.reason).toBe('already_running');
@@ -1732,7 +1732,7 @@ describe('computeWaves', () => {
   it('full intelligence DAG: 7 phases → 5 waves', async () => {
     const { computeWaves } = await import('@myco/agent/executor.js');
 
-    // Matches full-intelligence.yaml dependency graph
+    // Matches vault-evolve.yaml dependency graph
     const phases = [
       makePhase('read-state'),
       makePhase('extract', ['read-state']),

--- a/tests/agent/harness-properties.test.ts
+++ b/tests/agent/harness-properties.test.ts
@@ -165,7 +165,7 @@ describe('harness properties', () => {
 
   describe('scheduled task preConditions', () => {
     const UNCONDITIONAL_ALLOWLIST = [
-      'full-intelligence',
+      'vault-evolve',
       'skill-survey',
       // Self-gated by buildScheduledCortexInstruction(), which compares the
       // stored input hash against the newly assembled payload before dispatch.

--- a/tests/agent/instruction-builders.test.ts
+++ b/tests/agent/instruction-builders.test.ts
@@ -425,8 +425,8 @@ describe('isInstructionRequiredTask', () => {
     expect(isInstructionRequiredTask(SKILL_EVOLVE_TASK)).toBe(true);
   });
 
-  it('returns false for generic tasks like full-intelligence', () => {
-    expect(isInstructionRequiredTask('full-intelligence')).toBe(false);
+  it('returns false for generic tasks like vault-evolve', () => {
+    expect(isInstructionRequiredTask('vault-evolve')).toBe(false);
     expect(isInstructionRequiredTask('skill-survey')).toBe(true);
   });
 });
@@ -450,7 +450,7 @@ describe('buildTaskInstruction', () => {
   });
 
   it('returns undefined for tasks that do not use pre-assembled instructions', async () => {
-    await expect(buildTaskInstruction('full-intelligence')).resolves.toBeUndefined();
+    await expect(buildTaskInstruction('vault-evolve')).resolves.toBeUndefined();
     await expect(buildTaskInstruction('skill-survey')).resolves.toBeUndefined();
   });
 

--- a/tests/agent/loader.test.ts
+++ b/tests/agent/loader.test.ts
@@ -29,7 +29,7 @@ import type { AgentDefinition, AgentTask } from '@myco/agent/types.js';
 // ---------------------------------------------------------------------------
 
 /** Number of built-in task YAML files. */
-const EXPECTED_TASK_COUNT = 11;
+const EXPECTED_TASK_COUNT = 12;
 
 /** Built-in agent name from agent.yaml. */
 const BUILT_IN_AGENT_NAME = 'myco-agent';
@@ -180,14 +180,15 @@ describe('agent loader', () => {
       const tasks = loadAgentTasks(DEFINITIONS_DIR);
       const defaults = tasks.filter((t) => t.isDefault);
       expect(defaults).toHaveLength(1);
-      expect(defaults[0].name).toBe('full-intelligence');
+      expect(defaults[0].name).toBe('vault-evolve');
     });
 
     it('loads expected task names', () => {
       const tasks = loadAgentTasks(DEFINITIONS_DIR);
       const names = tasks.map((t) => t.name).sort();
 
-      expect(names).toContain('full-intelligence');
+      expect(names).toContain('vault-evolve');
+      expect(names).toContain('vault-seed');
       expect(names).toContain('digest-only');
       expect(names).toContain('review-session');
       expect(names).toContain('extract-only');
@@ -213,9 +214,9 @@ describe('agent loader', () => {
       expect(tasks).toEqual([]);
     });
 
-    it('loads schedule from full-intelligence task', () => {
+    it('loads schedule from vault-evolve task', () => {
       const tasks = loadAgentTasks(DEFINITIONS_DIR);
-      const fi = tasks.find((t) => t.name === 'full-intelligence');
+      const fi = tasks.find((t) => t.name === 'vault-evolve');
       expect(fi?.schedule).toBeDefined();
       expect(fi!.schedule!.enabled).toBe(true);
       expect(fi!.schedule!.intervalSeconds).toBe(300);
@@ -277,8 +278,8 @@ describe('agent loader', () => {
       expect(config.timeoutSeconds).toBe(300);
       expect(config.tools).toEqual(def.tools);
       expect(config.systemPromptPath).toBe('../prompts/agent.md');
-      expect(config.taskName).toBe('full-intelligence');
-      expect(config.taskDisplayName).toBe('Full Intelligence');
+      expect(config.taskName).toBe('vault-evolve');
+      expect(config.taskDisplayName).toBe('Vault Evolve');
     });
 
     it('applies agent DB overrides for model', () => {
@@ -402,7 +403,8 @@ describe('agent loader', () => {
       expect(tasks).toHaveLength(EXPECTED_TASK_COUNT);
 
       const names = tasks.map((t) => t.id).sort();
-      expect(names).toContain('full-intelligence');
+      expect(names).toContain('vault-evolve');
+      expect(names).toContain('vault-seed');
       expect(names).toContain('digest-only');
       expect(names).toContain('review-session');
       expect(names).toContain('extract-only');
@@ -413,12 +415,12 @@ describe('agent loader', () => {
       expect(names).toContain('skill-evolve');
     });
 
-    it('marks full-intelligence as the default task', async () => {
+    it('marks vault-evolve as the default task', async () => {
       registerBuiltInAgentsAndTasks(DEFINITIONS_DIR);
 
       const defaultTask = getDefaultTask(BUILT_IN_AGENT_NAME);
       expect(defaultTask).not.toBeNull();
-      expect(defaultTask!.id).toBe('full-intelligence');
+      expect(defaultTask!.id).toBe('vault-evolve');
       expect(defaultTask!.is_default).toBe(1);
     });
 

--- a/tests/agent/phase-loop.test.ts
+++ b/tests/agent/phase-loop.test.ts
@@ -181,18 +181,18 @@ describe('executePhase', () => {
   it('returns a completed PhaseResult on runtime success', async () => {
     const ctx = baseContext();
     const p = phase('draft');
-    const result = await executePhase(
+    const result = await executePhase({
       ctx,
-      'PROMPT',
-      'claude-sonnet-4',
-      p,
-      {
+      phasePrompt: 'PROMPT',
+      phaseModel: 'claude-sonnet-4',
+      phase: p,
+      toolSurface: {
         agentId: ctx.agentId,
         runId: ctx.runId,
         toolNames: [],
         turnOffset: 0,
       },
-    );
+    });
     expect(result.status).toBe('completed');
     expect(result.name).toBe('draft');
     expect(result.turnsUsed).toBe(1);
@@ -203,13 +203,13 @@ describe('executePhase', () => {
   it('returns a failed PhaseResult when runtime throws', async () => {
     defaultRuntimeBehavior = { kind: 'error', message: 'boom' };
     const ctx = baseContext();
-    const result = await executePhase(
+    const result = await executePhase({
       ctx,
-      'PROMPT',
-      'claude-sonnet-4',
-      phase('draft'),
-      { agentId: ctx.agentId, runId: ctx.runId, toolNames: [], turnOffset: 0 },
-    );
+      phasePrompt: 'PROMPT',
+      phaseModel: 'claude-sonnet-4',
+      phase: phase('draft'),
+      toolSurface: { agentId: ctx.agentId, runId: ctx.runId, toolNames: [], turnOffset: 0 },
+    });
     expect(result.status).toBe('failed');
     expect(result.summary).toContain('boom');
   });
@@ -217,13 +217,13 @@ describe('executePhase', () => {
   it('reports abort reason when the run is aborted mid-execution', async () => {
     defaultRuntimeBehavior = { kind: 'abort' };
     const ctx = baseContext();
-    const result = await executePhase(
+    const result = await executePhase({
       ctx,
-      'PROMPT',
-      'claude-sonnet-4',
-      phase('draft'),
-      { agentId: ctx.agentId, runId: ctx.runId, toolNames: [], turnOffset: 0 },
-    );
+      phasePrompt: 'PROMPT',
+      phaseModel: 'claude-sonnet-4',
+      phase: phase('draft'),
+      toolSurface: { agentId: ctx.agentId, runId: ctx.runId, toolNames: [], turnOffset: 0 },
+    });
     expect(result.status).toBe('failed');
     expect(result.summary).toContain('aborted');
     expect(ctx.abortController!.signal.aborted).toBe(true);
@@ -234,15 +234,14 @@ describe('executePhase', () => {
     runtimeBehaviors = [{ kind: 'error', message: 'unable to resume session' }];
     // Default success for the retry
     const ctx = baseContext();
-    const result = await executePhase(
+    const result = await executePhase({
       ctx,
-      'PROMPT',
-      'claude-sonnet-4',
-      phase('draft'),
-      { agentId: ctx.agentId, runId: ctx.runId, toolNames: [], turnOffset: 0 },
-      undefined,
-      'prior-session',
-    );
+      phasePrompt: 'PROMPT',
+      phaseModel: 'claude-sonnet-4',
+      phase: phase('draft'),
+      toolSurface: { agentId: ctx.agentId, runId: ctx.runId, toolNames: [], turnOffset: 0 },
+      sessionId: 'prior-session',
+    });
     expect(result.status).toBe('completed');
     // Two execute calls: first with sessionRef, retry without.
     expect(capturedExecuteInputs).toHaveLength(2);

--- a/tests/agent/registry.test.ts
+++ b/tests/agent/registry.test.ts
@@ -76,15 +76,15 @@ describe('loadAllTasks', () => {
   });
 
   it('discovers built-in tasks from definitions dir', () => {
-    const builtIn = makeTask({ name: 'full-intelligence', isDefault: true });
+    const builtIn = makeTask({ name: 'vault-evolve', isDefault: true });
     vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
 
     const tasks = loadAllTasks('/fake/definitions');
 
     expect(tasks.size).toBe(1);
-    expect(tasks.has('full-intelligence')).toBe(true);
-    expect(tasks.get('full-intelligence')!.source).toBe('built-in');
-    expect(tasks.get('full-intelligence')!.isBuiltin).toBe(true);
+    expect(tasks.has('vault-evolve')).toBe(true);
+    expect(tasks.get('vault-evolve')!.source).toBe('built-in');
+    expect(tasks.get('vault-evolve')!.isBuiltin).toBe(true);
   });
 
   it('discovers user tasks from vault tasks dir', () => {
@@ -291,18 +291,18 @@ describe('copyTaskToUser', () => {
   });
 
   it('creates user copy with -custom suffix', () => {
-    const builtIn = makeTask({ name: 'full-intelligence', displayName: 'Full Intelligence' });
+    const builtIn = makeTask({ name: 'vault-evolve', displayName: 'Vault Evolve' });
     vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
 
     const vaultDir = makeTempDir();
     try {
-      const copy = copyTaskToUser('/fake/definitions', vaultDir, 'full-intelligence');
+      const copy = copyTaskToUser('/fake/definitions', vaultDir, 'vault-evolve');
 
-      expect(copy.name).toBe('full-intelligence-custom');
+      expect(copy.name).toBe('vault-evolve-custom');
       expect(copy.isDefault).toBe(false);
       expect(copy.isBuiltin).toBe(false);
       expect(copy.source).toBe('user');
-      expect(fs.existsSync(path.join(vaultDir, 'tasks', 'full-intelligence-custom.yaml'))).toBe(true);
+      expect(fs.existsSync(path.join(vaultDir, 'tasks', 'vault-evolve-custom.yaml'))).toBe(true);
     } finally {
       removeTempDir(vaultDir);
     }

--- a/tests/agent/runtime-claude.test.ts
+++ b/tests/agent/runtime-claude.test.ts
@@ -187,7 +187,12 @@ describe('ClaudeSdkRuntime.execute', () => {
     expect(scopedServerCalls).toHaveLength(0);
   });
 
-  it('skips the MCP server entirely when toolNames is an empty list', async () => {
+  it('passes an empty mcpServers + strictMcpConfig when toolNames is an empty list', async () => {
+    // Even when the phase wants no vault tools (e.g., the orchestrator
+    // planner with toolNames: []), we MUST still pass strictMcpConfig:
+    // true with an empty mcpServers map — otherwise the SDK falls back
+    // to loading every MCP server the user has configured in
+    // ~/.claude/mcp.json and every installed plugin (130+ tools leak).
     const Runtime = await loadRuntime();
     const runtime = new Runtime();
 
@@ -195,7 +200,8 @@ describe('ClaudeSdkRuntime.execute', () => {
       toolSurface: { agentId: 'a1', runId: 'r1', toolNames: [] },
     }));
 
-    expect(queryCalls[0].options.mcpServers).toBeUndefined();
+    expect(queryCalls[0].options.mcpServers).toEqual({});
+    expect(queryCalls[0].options.strictMcpConfig).toBe(true);
     expect(scopedServerCalls).toHaveLength(0);
     expect(fullServerCalls).toHaveLength(0);
   });

--- a/tests/agent/schemas.test.ts
+++ b/tests/agent/schemas.test.ts
@@ -474,17 +474,17 @@ describe('AgentTaskSchema — backward compatibility', () => {
     expect(result.contextQueries).toBeUndefined();
   });
 
-  it('parses a task shaped like the existing full-intelligence YAML', () => {
+  it('parses a task shaped like the existing vault-evolve YAML', () => {
     const result = AgentTaskSchema.parse({
-      name: 'full-intelligence',
-      displayName: 'Full Intelligence',
+      name: 'vault-evolve',
+      displayName: 'Vault Evolve',
       description: 'Complete intelligence pipeline.',
       agent: 'myco-agent',
       prompt: 'Run full intelligence pipeline.',
       isDefault: true,
     });
 
-    expect(result.name).toBe('full-intelligence');
+    expect(result.name).toBe('vault-evolve');
     expect(result.isDefault).toBe(true);
     expect(result.toolOverrides).toBeUndefined();
   });

--- a/tests/agent/tools-dry-run.test.ts
+++ b/tests/agent/tools-dry-run.test.ts
@@ -2,7 +2,7 @@
  * Tests for the dry-run interceptor in createVaultTools.
  *
  * Dry-run is the mechanism the eval harness uses to re-run
- * `full-intelligence` against a live vault snapshot without corrupting
+ * `vault-evolve` against a live vault snapshot without corrupting
  * state. Reads stay live, writes get intercepted: the intent is
  * recorded to `agent_run_write_intents`, a synthetic shape-compatible
  * payload is returned, and downstream tool calls that reference

--- a/tests/cli/agent-eval.test.ts
+++ b/tests/cli/agent-eval.test.ts
@@ -24,8 +24,8 @@ describe('parseArgs', () => {
   });
 
   it('parses required --task flag', () => {
-    const result = parseArgs(['--task', 'full-intelligence']);
-    expect(result.taskId).toBe('full-intelligence');
+    const result = parseArgs(['--task', 'vault-evolve']);
+    expect(result.taskId).toBe('vault-evolve');
   });
 
   it('parses --runtimes comma-separated', () => {

--- a/tests/config/migrations.test.ts
+++ b/tests/config/migrations.test.ts
@@ -219,8 +219,63 @@ describe('Migration v4: rename-cloud-provider-to-anthropic', () => {
 });
 
 describe('CURRENT_MIGRATION_VERSION', () => {
-  it('is 5', () => {
-    expect(CURRENT_MIGRATION_VERSION).toBe(5);
+  it('is 6', () => {
+    expect(CURRENT_MIGRATION_VERSION).toBe(6);
+  });
+});
+
+const v6 = MIGRATIONS.find((m) => m.version === 6)!;
+
+describe('Migration v6: rename-full-intelligence-to-vault-evolve', () => {
+  it('renames agent.tasks["full-intelligence"] to agent.tasks["vault-evolve"]', () => {
+    const doc: Record<string, unknown> = {
+      agent: {
+        tasks: {
+          'full-intelligence': {
+            schedule: { enabled: true, intervalSeconds: 600 },
+            model: 'claude-sonnet-4-6',
+          },
+        },
+      },
+    };
+    v6.migrate(doc, '/tmp');
+
+    const tasks = (doc.agent as Record<string, unknown>).tasks as Record<string, Record<string, unknown>>;
+    expect(tasks['full-intelligence']).toBeUndefined();
+    expect(tasks['vault-evolve']).toEqual({
+      schedule: { enabled: true, intervalSeconds: 600 },
+      model: 'claude-sonnet-4-6',
+    });
+  });
+
+  it('keeps the existing vault-evolve entry when both keys are present', () => {
+    const doc: Record<string, unknown> = {
+      agent: {
+        tasks: {
+          'full-intelligence': { model: 'legacy' },
+          'vault-evolve': { model: 'already-there' },
+        },
+      },
+    };
+    v6.migrate(doc, '/tmp');
+
+    const tasks = (doc.agent as Record<string, unknown>).tasks as Record<string, Record<string, unknown>>;
+    expect(tasks['full-intelligence']).toBeUndefined();
+    expect(tasks['vault-evolve']).toEqual({ model: 'already-there' });
+  });
+
+  it('is a no-op when no full-intelligence key exists', () => {
+    const doc: Record<string, unknown> = {
+      agent: { tasks: { 'skill-survey': { schedule: { enabled: true } } } },
+    };
+    expect(() => v6.migrate(doc, '/tmp')).not.toThrow();
+    const tasks = (doc.agent as Record<string, unknown>).tasks as Record<string, unknown>;
+    expect(tasks['vault-evolve']).toBeUndefined();
+  });
+
+  it('is a no-op when there is no agent section', () => {
+    const doc: Record<string, unknown> = { embedding: { provider: 'ollama' } };
+    expect(() => v6.migrate(doc, '/tmp')).not.toThrow();
   });
 });
 
@@ -266,18 +321,20 @@ describe('Migration v5: seed-settings-notification-domain-default', () => {
 });
 
 describe('runMigrations', () => {
-  it('runs v3 when config_version is 2', () => {
+  it('runs v3 through v6 when config_version is 2', () => {
     const doc: Record<string, unknown> = {
       config_version: 2,
       agent: { auto_run: true, interval_seconds: 300 },
     };
     const ran = runMigrations(doc, '/tmp');
     expect(ran).toBe(true);
-    expect(doc.config_version).toBe(5);
+    expect(doc.config_version).toBe(6);
 
     const agent = doc.agent as Record<string, unknown>;
     const tasks = agent.tasks as Record<string, Record<string, unknown>>;
-    expect(tasks['full-intelligence'].schedule).toBeDefined();
+    // v3 creates the schedule under the legacy key; v6 renames it.
+    expect(tasks['full-intelligence']).toBeUndefined();
+    expect(tasks['vault-evolve'].schedule).toBeDefined();
     const notifications = doc.notifications as Record<string, unknown>;
     const domains = notifications.domains as Record<string, Record<string, unknown>>;
     expect(domains.settings).toEqual({
@@ -286,19 +343,19 @@ describe('runMigrations', () => {
     });
   });
 
-  it('runs v4 when config_version is 3', () => {
+  it('runs v4 onward when config_version is 3', () => {
     const doc: Record<string, unknown> = {
       config_version: 3,
       agent: { provider: { type: 'cloud' } },
     };
     const ran = runMigrations(doc, '/tmp');
     expect(ran).toBe(true);
-    expect(doc.config_version).toBe(5);
+    expect(doc.config_version).toBe(6);
     const agent = doc.agent as Record<string, unknown>;
     expect((agent.provider as Record<string, unknown>).type).toBe('anthropic');
   });
 
-  it('runs v5 when config_version is 4', () => {
+  it('runs v5 onward when config_version is 4', () => {
     const doc: Record<string, unknown> = {
       config_version: 4,
       notifications: {
@@ -307,7 +364,7 @@ describe('runMigrations', () => {
     };
     const ran = runMigrations(doc, '/tmp');
     expect(ran).toBe(true);
-    expect(doc.config_version).toBe(5);
+    expect(doc.config_version).toBe(6);
 
     const notifications = doc.notifications as Record<string, unknown>;
     const domains = notifications.domains as Record<string, Record<string, unknown>>;
@@ -317,9 +374,22 @@ describe('runMigrations', () => {
     });
   });
 
-  it('skips all migrations when config_version is already 5', () => {
+  it('runs only v6 when config_version is 5', () => {
     const doc: Record<string, unknown> = {
       config_version: 5,
+      agent: { tasks: { 'full-intelligence': { model: 'claude-sonnet-4-6' } } },
+    };
+    const ran = runMigrations(doc, '/tmp');
+    expect(ran).toBe(true);
+    expect(doc.config_version).toBe(6);
+    const tasks = (doc.agent as Record<string, unknown>).tasks as Record<string, Record<string, unknown>>;
+    expect(tasks['full-intelligence']).toBeUndefined();
+    expect(tasks['vault-evolve']).toEqual({ model: 'claude-sonnet-4-6' });
+  });
+
+  it('skips all migrations when config_version is already 6', () => {
+    const doc: Record<string, unknown> = {
+      config_version: 6,
       agent: { auto_run: true, provider: { type: 'cloud' } },
     };
     const ran = runMigrations(doc, '/tmp');

--- a/tests/config/updates.test.ts
+++ b/tests/config/updates.test.ts
@@ -127,7 +127,7 @@ describe('withTaskConfig', () => {
   });
 
   it('sets phase-level overrides', () => {
-    const result = withTaskConfig(baseConfig(), 'full-intelligence', {
+    const result = withTaskConfig(baseConfig(), 'vault-evolve', {
       phases: {
         extraction: {
           provider: { type: 'ollama', model: 'granite4:small-h' },
@@ -135,23 +135,23 @@ describe('withTaskConfig', () => {
         },
       },
     });
-    const phase = result.agent.tasks?.['full-intelligence']?.phases?.extraction;
+    const phase = result.agent.tasks?.['vault-evolve']?.phases?.extraction;
     expect(phase?.provider?.type).toBe('ollama');
     expect(phase?.maxTurns).toBe(3);
   });
 
   it('null phase removes a specific phase', () => {
-    let config = withTaskConfig(baseConfig(), 'full-intelligence', {
+    let config = withTaskConfig(baseConfig(), 'vault-evolve', {
       phases: {
         extraction: { provider: { type: 'ollama' } },
         linking: { provider: { type: 'anthropic' } },
       },
     });
-    config = withTaskConfig(config, 'full-intelligence', {
+    config = withTaskConfig(config, 'vault-evolve', {
       phases: { extraction: null },
     });
-    expect(config.agent.tasks?.['full-intelligence']?.phases?.extraction).toBeUndefined();
-    expect(config.agent.tasks?.['full-intelligence']?.phases?.linking).toBeDefined();
+    expect(config.agent.tasks?.['vault-evolve']?.phases?.extraction).toBeUndefined();
+    expect(config.agent.tasks?.['vault-evolve']?.phases?.linking).toBeDefined();
   });
 
   it('removes empty task entries', () => {

--- a/tests/daemon/api/agent-evaluations.test.ts
+++ b/tests/daemon/api/agent-evaluations.test.ts
@@ -88,7 +88,7 @@ describe('agent-evaluations API', () => {
 
       const res = await handleCreate(makeRequest({
         body: {
-          taskId: 'full-intelligence',
+          taskId: 'vault-evolve',
           matrix: {
             runtimes: ['claude-sdk', 'openai-agents'],
             reasoningLevels: ['low', 'high'],
@@ -107,7 +107,7 @@ describe('agent-evaluations API', () => {
       const { handleCreate } = makeHandlers();
 
       const res = await handleCreate(makeRequest({
-        body: { taskId: 'full-intelligence', matrix: {} },
+        body: { taskId: 'vault-evolve', matrix: {} },
       }));
       expect((res.body as { cellCount: number }).cellCount).toBe(1);
     });
@@ -132,7 +132,7 @@ describe('agent-evaluations API', () => {
 
       const { handleCreate } = makeHandlers();
       const created = await handleCreate(makeRequest({
-        body: { taskId: 'full-intelligence', matrix: {} },
+        body: { taskId: 'vault-evolve', matrix: {} },
       }));
       const { evaluationId } = created.body as { evaluationId: string };
 
@@ -157,7 +157,7 @@ describe('agent-evaluations API', () => {
       const { handleCreate } = makeHandlers();
       await handleCreate(makeRequest({
         body: {
-          taskId: 'full-intelligence',
+          taskId: 'vault-evolve',
           matrix: {
             runtimes: ['claude-sdk'],
             reasoningLevels: ['low', 'high'],
@@ -184,7 +184,7 @@ describe('agent-evaluations API', () => {
       const { handleCreate } = makeHandlers();
       await handleCreate(makeRequest({
         body: {
-          taskId: 'full-intelligence',
+          taskId: 'vault-evolve',
           matrix: {
             runtimes: ['claude-sdk'],
             reasoningLevels: ['low', 'high'],
@@ -224,7 +224,7 @@ describe('agent-evaluations API', () => {
 
       const created = await handleCreate(makeRequest({
         body: {
-          taskId: 'full-intelligence',
+          taskId: 'vault-evolve',
           matrix: { runtimes: ['claude-sdk', 'openai-agents'], dryRun: true },
         },
       }));
@@ -248,7 +248,7 @@ describe('agent-evaluations API', () => {
         aggregate: { total: number; completed: number; failed: number; totalTokens: number; totalCostUsd: number };
       };
       expect(body.evaluation.id).toBe(evaluationId);
-      expect(body.evaluation.taskId).toBe('full-intelligence');
+      expect(body.evaluation.taskId).toBe('vault-evolve');
       expect(body.runs).toHaveLength(2);
       expect(body.aggregate.total).toBe(2);
       expect(body.aggregate.completed).toBe(1);
@@ -263,7 +263,7 @@ describe('agent-evaluations API', () => {
 
       const created = await handleCreate(makeRequest({
         body: {
-          taskId: 'full-intelligence',
+          taskId: 'vault-evolve',
           matrix: { runtimes: ['claude-sdk'], dryRun: true },
         },
       }));
@@ -324,7 +324,7 @@ describe('agent-evaluations API', () => {
 
       const created = await handleCreate(makeRequest({
         body: {
-          taskId: 'full-intelligence',
+          taskId: 'vault-evolve',
           matrix: {
             runtimes: ['claude-sdk'],
             phases: { extract: { reasoningLevel: 'low' } },

--- a/tests/daemon/api/agent-runs-dry-run.test.ts
+++ b/tests/daemon/api/agent-runs-dry-run.test.ts
@@ -59,7 +59,7 @@ describe('agent-runs API dry-run + write-intents', () => {
       const { handleRun } = makeHandlers();
       await handleRun(makeRequest({
         body: {
-          task: 'full-intelligence',
+          task: 'vault-evolve',
           instruction: 'do the thing',
           agentId: 'myco-agent',
           dryRun: true,
@@ -76,7 +76,7 @@ describe('agent-runs API dry-run + write-intents', () => {
     it('defaults dryRun / evaluationId to undefined when omitted', async () => {
       const { handleRun } = makeHandlers();
       await handleRun(makeRequest({
-        body: { task: 'full-intelligence', instruction: 'go', agentId: 'myco-agent' },
+        body: { task: 'vault-evolve', instruction: 'go', agentId: 'myco-agent' },
       }));
       const [, opts] = runAgentSpy.mock.calls[0] as [string, { dryRun?: boolean; evaluationId?: string | null }];
       expect(opts.dryRun).toBeUndefined();
@@ -87,7 +87,7 @@ describe('agent-runs API dry-run + write-intents', () => {
       const { handleRun } = makeHandlers();
       await handleRun(makeRequest({
         body: {
-          task: 'full-intelligence',
+          task: 'vault-evolve',
           instruction: 'go',
           agentId: 'myco-agent',
           executionOverrides: {
@@ -121,7 +121,7 @@ describe('agent-runs API dry-run + write-intents', () => {
       await expect(
         handleRun(makeRequest({
           body: {
-            task: 'full-intelligence',
+            task: 'vault-evolve',
             instruction: 'go',
             agentId: 'myco-agent',
             executionOverrides: { reasoningLevel: 'medium' },

--- a/tests/daemon/api/agent-tasks.test.ts
+++ b/tests/daemon/api/agent-tasks.test.ts
@@ -95,7 +95,7 @@ describe('handleListTasks', () => {
   });
 
   it('returns both built-in and user tasks', async () => {
-    const builtIn = makeTask({ name: 'full-intelligence', isDefault: true });
+    const builtIn = makeTask({ name: 'vault-evolve', isDefault: true });
     vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
 
     const vaultDir = makeTempDir();
@@ -108,7 +108,7 @@ describe('handleListTasks', () => {
       const tasks = (result.body as { tasks: AgentTask[] }).tasks;
       expect(tasks.length).toBe(2);
       const names = tasks.map((t) => t.name);
-      expect(names).toContain('full-intelligence');
+      expect(names).toContain('vault-evolve');
       expect(names).toContain('my-custom-task');
     } finally {
       removeTempDir(vaultDir);
@@ -299,14 +299,14 @@ describe('handleCreateTask', () => {
   });
 
   it('allows creating task with same name as built-in (override)', async () => {
-    const builtIn = makeTask({ name: 'full-intelligence', isDefault: true });
+    const builtIn = makeTask({ name: 'vault-evolve', isDefault: true });
     vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
 
     const vaultDir = makeTempDir();
     try {
       const body = {
-        name: 'full-intelligence',
-        displayName: 'My Full Intelligence',
+        name: 'vault-evolve',
+        displayName: 'My Vault Evolve',
         description: 'Override the built-in',
         agent: 'myco-agent',
         prompt: 'Custom prompt.',
@@ -331,19 +331,19 @@ describe('handleCopyTask', () => {
   });
 
   it('creates user copy with -custom suffix', async () => {
-    const builtIn = makeTask({ name: 'full-intelligence', isDefault: true });
+    const builtIn = makeTask({ name: 'vault-evolve', isDefault: true });
     vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
 
     const vaultDir = makeTempDir();
     try {
       const result = await handleCopyTask(
-        makeReq({ params: { id: 'full-intelligence' } }),
+        makeReq({ params: { id: 'vault-evolve' } }),
         vaultDir,
       );
 
       expect(result.status).toBe(201);
       const copy = (result.body as { task: AgentTask }).task;
-      expect(copy.name).toBe('full-intelligence-custom');
+      expect(copy.name).toBe('vault-evolve-custom');
       expect(copy.isDefault).toBe(false);
       expect(copy.source).toBe('user');
     } finally {
@@ -416,13 +416,13 @@ describe('handleDeleteTask', () => {
   });
 
   it('returns 403 when attempting to delete a built-in task', async () => {
-    const builtIn = makeTask({ name: 'full-intelligence', isDefault: true });
+    const builtIn = makeTask({ name: 'vault-evolve', isDefault: true });
     vi.mocked(loadAgentTasks).mockReturnValue([builtIn]);
 
     const vaultDir = makeTempDir();
     try {
       const result = await handleDeleteTask(
-        makeReq({ params: { id: 'full-intelligence' } }),
+        makeReq({ params: { id: 'vault-evolve' } }),
         vaultDir,
       );
 

--- a/tests/daemon/task-scheduler.test.ts
+++ b/tests/daemon/task-scheduler.test.ts
@@ -54,10 +54,10 @@ describe('buildScheduledJobs', () => {
 
   it('respects config override to disable an enabled task', () => {
     const tasks = [
-      makeTask('full-intelligence', { enabled: true, intervalSeconds: 300, runIn: ['active', 'idle'] }),
+      makeTask('vault-evolve', { enabled: true, intervalSeconds: 300, runIn: ['active', 'idle'] }),
     ];
     const overrides = {
-      'full-intelligence': { schedule: { enabled: false } },
+      'vault-evolve': { schedule: { enabled: false } },
     };
 
     const jobs = buildScheduledJobs(tasks, overrides);

--- a/tests/daemon/task-scheduling.test.ts
+++ b/tests/daemon/task-scheduling.test.ts
@@ -4,9 +4,9 @@ import type { AgentTask } from '@myco/agent/types.js';
 
 vi.mock('@myco/agent/registry.js', () => ({
   loadAllTasks: () => new Map<string, AgentTask>([
-    ['full-intelligence', {
-      name: 'full-intelligence',
-      displayName: 'Full Intelligence',
+    ['vault-evolve', {
+      name: 'vault-evolve',
+      displayName: 'Vault Evolve',
       description: 'test',
       agent: 'myco-agent',
       prompt: 'test',
@@ -45,7 +45,7 @@ describe('registerScheduledTasks', () => {
         agent: {
           scheduled_tasks_enabled: true,
           tasks: {
-            'full-intelligence': {
+            'vault-evolve': {
               schedule: { enabled: true },
             },
           },
@@ -64,7 +64,7 @@ describe('registerScheduledTasks', () => {
     expect(powerManager.replaceGroup).toHaveBeenLastCalledWith(
       'scheduled:',
       expect.arrayContaining([
-        expect.objectContaining({ name: 'scheduled:full-intelligence' }),
+        expect.objectContaining({ name: 'scheduled:vault-evolve' }),
       ]),
     );
 
@@ -72,7 +72,7 @@ describe('registerScheduledTasks', () => {
       agent: {
         scheduled_tasks_enabled: true,
         tasks: {
-          'full-intelligence': {
+          'vault-evolve': {
             schedule: { enabled: false },
           },
         },

--- a/tests/db/queries/evaluations.test.ts
+++ b/tests/db/queries/evaluations.test.ts
@@ -38,13 +38,13 @@ describe('evaluation query helpers', () => {
 
       const inserted = insertEvaluation({
         id: 'eval-1',
-        taskId: 'full-intelligence',
+        taskId: 'vault-evolve',
         matrix,
         notes: 'quick A/B',
       });
 
       expect(inserted.id).toBe('eval-1');
-      expect(inserted.task_id).toBe('full-intelligence');
+      expect(inserted.task_id).toBe('vault-evolve');
       expect(inserted.matrix).toEqual(matrix);
       expect(inserted.notes).toBe('quick A/B');
       expect(inserted.status).toBe('pending');
@@ -118,7 +118,7 @@ describe('evaluation query helpers', () => {
 
   describe('listRunsForEvaluation', () => {
     it('returns all runs linked to an evaluation, newest first', () => {
-      insertEvaluation({ id: 'eval-runs', taskId: 'full-intelligence', matrix: {} });
+      insertEvaluation({ id: 'eval-runs', taskId: 'vault-evolve', matrix: {} });
 
       insertRun({
         id: 'run-1',

--- a/tests/db/queries/write-intents.test.ts
+++ b/tests/db/queries/write-intents.test.ts
@@ -24,7 +24,7 @@ function seedRun(id: string) {
   insertRun({
     id,
     agent_id: TEST_AGENT_ID,
-    task: 'full-intelligence',
+    task: 'vault-evolve',
     started_at: epochNow(),
   });
 }
@@ -155,14 +155,14 @@ describe('write intents query helpers', () => {
       insertRun({
         id: runId,
         agent_id: TEST_AGENT_ID,
-        task: 'full-intelligence',
+        task: 'vault-evolve',
         started_at: epochNow(),
         evaluationId,
       });
     }
 
     it('groups counts by run_id and tool_name across all runs in an evaluation', () => {
-      insertEvaluation({ id: 'eval-batch', taskId: 'full-intelligence', matrix: {} });
+      insertEvaluation({ id: 'eval-batch', taskId: 'vault-evolve', matrix: {} });
       seedRunInEval('eval-batch-run-1', 'eval-batch');
       seedRunInEval('eval-batch-run-2', 'eval-batch');
 
@@ -180,8 +180,8 @@ describe('write intents query helpers', () => {
     });
 
     it('excludes runs that belong to other evaluations', () => {
-      insertEvaluation({ id: 'eval-iso-a', taskId: 'full-intelligence', matrix: {} });
-      insertEvaluation({ id: 'eval-iso-b', taskId: 'full-intelligence', matrix: {} });
+      insertEvaluation({ id: 'eval-iso-a', taskId: 'vault-evolve', matrix: {} });
+      insertEvaluation({ id: 'eval-iso-b', taskId: 'vault-evolve', matrix: {} });
       seedRunInEval('iso-run-a', 'eval-iso-a');
       seedRunInEval('iso-run-b', 'eval-iso-b');
 
@@ -194,12 +194,12 @@ describe('write intents query helpers', () => {
     });
 
     it('returns an empty object for an evaluation with no child runs', () => {
-      insertEvaluation({ id: 'eval-no-runs', taskId: 'full-intelligence', matrix: {} });
+      insertEvaluation({ id: 'eval-no-runs', taskId: 'vault-evolve', matrix: {} });
       expect(countWriteIntentsByToolForEvaluation('eval-no-runs')).toEqual({});
     });
 
     it('omits runs that have no intents', () => {
-      insertEvaluation({ id: 'eval-mixed', taskId: 'full-intelligence', matrix: {} });
+      insertEvaluation({ id: 'eval-mixed', taskId: 'vault-evolve', matrix: {} });
       seedRunInEval('mixed-run-1', 'eval-mixed');
       seedRunInEval('mixed-run-2', 'eval-mixed');
       insertWriteIntent({ runId: 'mixed-run-1', toolName: 't', toolInput: '{}', syntheticOutput: '{}' });

--- a/tests/services/phase-audit.test.ts
+++ b/tests/services/phase-audit.test.ts
@@ -131,7 +131,7 @@ describe('buildPhaseAudit', () => {
     insertRun({
       id: 'run-a',
       agent_id: 'myco-agent',
-      task: 'full-intelligence',
+      task: 'vault-evolve',
       usage_data: buildUsageDataJson([
         { name: 'draft', tokensUsed: 1000, costUsd: 0.01, costSource: 'actual' },
         { name: 'review', tokensUsed: 500, costUsd: 0.005, costSource: 'actual' },
@@ -173,7 +173,7 @@ describe('buildPhaseAudit', () => {
 
     expect(audit).not.toBeNull();
     expect(audit!.runId).toBe('run-a');
-    expect(audit!.taskName).toBe('full-intelligence');
+    expect(audit!.taskName).toBe('vault-evolve');
     expect(audit!.dryRun).toBe(false);
     expect(audit!.phases).toHaveLength(2);
 
@@ -219,7 +219,7 @@ describe('buildPhaseAudit', () => {
     insertRun({
       id: 'run-dry',
       agent_id: 'myco-agent',
-      task: 'full-intelligence',
+      task: 'vault-evolve',
       dryRun: true,
       usage_data: buildUsageDataJson([
         { name: 'draft', tokensUsed: 800 },
@@ -420,7 +420,7 @@ describe('handleGetRunAudit', () => {
     insertRun({
       id: 'run-handler',
       agent_id: 'myco-agent',
-      task: 'full-intelligence',
+      task: 'vault-evolve',
       usage_data: buildUsageDataJson([{ name: 'draft', tokensUsed: 100 }]),
       checkpoints: buildCheckpointsJson([{ name: 'draft', status: 'completed', turnsUsed: 1 }]),
     });

--- a/tests/smoke/review-fixes.test.ts
+++ b/tests/smoke/review-fixes.test.ts
@@ -70,17 +70,17 @@ describe('P1 #2: Concurrency guard query helpers', () => {
 
   it('getRunningRunForTask returns running task ID', () => {
     insertRun({
-      id: 'run-1', agent_id: AGENT_ID, task: 'full-intelligence',
+      id: 'run-1', agent_id: AGENT_ID, task: 'vault-evolve',
       status: STATUS_RUNNING, started_at: now, created_at: now,
     });
 
-    const result = getRunningRunForTask(AGENT_ID, 'full-intelligence');
+    const result = getRunningRunForTask(AGENT_ID, 'vault-evolve');
     expect(result).toBe('run-1');
   });
 
   it('getRunningRunForTask returns null for different task', () => {
     insertRun({
-      id: 'run-1', agent_id: AGENT_ID, task: 'full-intelligence',
+      id: 'run-1', agent_id: AGENT_ID, task: 'vault-evolve',
       status: STATUS_RUNNING, started_at: now, created_at: now,
     });
 
@@ -360,8 +360,8 @@ describe('MCP tools: myco_skills and myco_skill_candidates', () => {
 // VAULT_TOOL_COUNT consistency
 // ---------------------------------------------------------------------------
 describe('VAULT_TOOL_COUNT', () => {
-  it('matches expected count (22)', () => {
-    expect(VAULT_TOOL_COUNT).toBe(22);
+  it('matches expected count (26)', () => {
+    expect(VAULT_TOOL_COUNT).toBe(26);
   });
 });
 

--- a/tests/ui/comparison-view.test.ts
+++ b/tests/ui/comparison-view.test.ts
@@ -28,7 +28,7 @@ function fakeRun(over: Partial<EvaluationRunSummary>): EvaluationRunSummary {
   return {
     id: 'run-x',
     agent_id: 'myco-agent',
-    task: 'full-intelligence',
+    task: 'vault-evolve',
     instruction: null,
     status: 'completed',
     runtime: null,
@@ -119,8 +119,8 @@ describe('detectDrift', () => {
   it('does not fire when runs span less than the threshold and share a task', () => {
     const base = 1_700_000_000;
     const drift = detectDrift([
-      fakeRun({ id: 'a', task: 'full-intelligence', started_at: base }),
-      fakeRun({ id: 'b', task: 'full-intelligence', started_at: base + 60 }),
+      fakeRun({ id: 'a', task: 'vault-evolve', started_at: base }),
+      fakeRun({ id: 'b', task: 'vault-evolve', started_at: base + 60 }),
     ]);
     expect(drift.show).toBe(false);
     expect(drift.differentTasks).toBe(false);
@@ -130,8 +130,8 @@ describe('detectDrift', () => {
   it('fires when the span exceeds the threshold', () => {
     const base = 1_700_000_000;
     const drift = detectDrift([
-      fakeRun({ id: 'a', task: 'full-intelligence', started_at: base }),
-      fakeRun({ id: 'b', task: 'full-intelligence', started_at: base + (DRIFT_THRESHOLD_MINUTES + 1) * 60 }),
+      fakeRun({ id: 'a', task: 'vault-evolve', started_at: base }),
+      fakeRun({ id: 'b', task: 'vault-evolve', started_at: base + (DRIFT_THRESHOLD_MINUTES + 1) * 60 }),
     ]);
     expect(drift.show).toBe(true);
     expect(drift.differentTasks).toBe(false);
@@ -141,7 +141,7 @@ describe('detectDrift', () => {
   it('fires when tasks differ, even with small spans', () => {
     const base = 1_700_000_000;
     const drift = detectDrift([
-      fakeRun({ id: 'a', task: 'full-intelligence', started_at: base }),
+      fakeRun({ id: 'a', task: 'vault-evolve', started_at: base }),
       fakeRun({ id: 'b', task: 'skill-survey', started_at: base + 30 }),
     ]);
     expect(drift.show).toBe(true);

--- a/tests/ui/evaluation-helpers.test.ts
+++ b/tests/ui/evaluation-helpers.test.ts
@@ -27,7 +27,7 @@ function fakeRun(over: Partial<EvaluationRunSummary>): EvaluationRunSummary {
   return {
     id: 'run-x',
     agent_id: 'myco-agent',
-    task: 'full-intelligence',
+    task: 'vault-evolve',
     instruction: null,
     status: 'completed',
     runtime: null,

--- a/tests/ui/rerun-prefill.test.ts
+++ b/tests/ui/rerun-prefill.test.ts
@@ -24,7 +24,7 @@ function makeRun(over: Partial<RunRow> = {}): RunRow {
   return {
     id: 'abcdef12-3456-7890-abcd-ef1234567890',
     agent_id: 'agent-default',
-    task: 'full-intelligence',
+    task: 'vault-evolve',
     instruction: null,
     status: 'completed',
     runtime: null,
@@ -57,7 +57,7 @@ function makeRun(over: Partial<RunRow> = {}): RunRow {
 
 function makeTask(over: Partial<TaskRow> = {}): TaskRow {
   return {
-    name: 'full-intelligence',
+    name: 'vault-evolve',
     displayName: 'Full intelligence',
     description: 'Full intelligence pass',
     agent: 'myco',
@@ -71,7 +71,7 @@ describe('buildRerunPrefill', () => {
   it('copies task, instruction, dry_run with no overrides', () => {
     const run = makeRun({ instruction: 'plain reminder', dry_run: true });
     const prefill = buildRerunPrefill(run, [makeTask()]);
-    expect(prefill.taskName).toBe('full-intelligence');
+    expect(prefill.taskName).toBe('vault-evolve');
     expect(prefill.instruction).toBe('plain reminder');
     expect(prefill.dryRun).toBe(true);
     expect(prefill.hasAnyOverride).toBe(false);
@@ -156,7 +156,7 @@ describe('buildRerunPrefill', () => {
 
   it('flags taskMissing when the source task is not in the task list', () => {
     const run = makeRun({ task: 'removed-task' });
-    const prefill = buildRerunPrefill(run, [makeTask({ name: 'full-intelligence' })]);
+    const prefill = buildRerunPrefill(run, [makeTask({ name: 'vault-evolve' })]);
     expect(prefill.taskMissing).toBe(true);
     expect(prefill.taskName).toBe('removed-task');
   });


### PR DESCRIPTION
## Summary

- Renames default intelligence task `full-intelligence` → `vault-evolve` and adds migration v6 that moves user overrides.
- Adds new manual-only `vault-seed` task for brownfield codebases — explores the repo via `fs_read`/`fs_list`/`fs_tree`/`code_grep` (thin wrapper around `@vscode/ripgrep`) and produces an initial spore set + digest.
- Hardens Claude SDK runtime: `RuntimeExecutionError` preserves tokens/turns/cost on errors like max-turns instead of reporting zero.
- Phase prompts now support `{{max_turns}}` / `{{phase_name}}` / `{{phase_tools}}` template variables resolved against the effective phase config (post myco.yaml override).
- Internal refactors: shared `interpolate` helper, params-object signatures for `composeTaskPrompt` / `composePhasePrompt` / `executePhase`, and a `buildPhaseResult` factory that unifies success + failure + checkpoint-replay call sites.

## Why

Myco's existing tasks only operate on captured session transcripts, which is useless on a freshly-adopted repo. Vault-seed fills that gap: on a cold vault it infers knowledge directly from source via filesystem and grep tools, producing a meaningful spore set and digest on first run. The `full-intelligence` → `vault-evolve` rename pairs naturally with the new `vault-seed` verb — seed the vault, evolve the vault.

The claude-sdk telemetry gap became visible while debugging max-turn failures on vault-seed: runs that really spent tokens were showing as `tokens_used = 0`, which made tuning impossible.

## Design notes

**Runtime portability.** Exploration tools live in-process behind the same MCP plumbing as vault tools (works on both claude-sdk and openai-agents runtimes, no subprocess MCP servers). Tool schemas use plain `.optional()` / `.string()` / `.number()` and avoid `.default()`, `.min()`, `.max()`, `.int()`, `.positive()` — those Zod refinements emit JSON-schema keywords (`default`, `minimum`, `exclusiveMinimum`, etc.) that OpenAI's strict function-calling rejects, which otherwise silently breaks tool registration on that runtime.

**No model pinning.** Vault-seed uses reasoning levels, not explicit model names, so it tracks the user's provider config uniformly across runtimes.

**Template variables.** Turn budgets and tool lists are configurable per phase in myco.yaml. Hard-coding them in prompts drifts from reality when users override — template vars resolve against the effective phase config at dispatch time.

## Verification

- [x] `tsc --noEmit` clean
- [x] `npx vitest run` — 2986 / 2989 passing (3 pre-existing skips)
- [x] `make build` — green end-to-end
- [x] Standalone verification script covered: template substitution for all 7 vault-seed phases, `buildPhaseResult` in all three call shapes, migration v6 edge cases, OpenAI strict-mode schema compatibility of the 4 exploration tools
- [x] Live dry-run on Claude SDK: vault-seed completed end-to-end on this repo — 23 spores (13 decisions / 6 gotchas / 4 architecture, importance 6-9), 3 digest tiers written, ~\$2.40 for a full brownfield seed

## Test plan

- [ ] Verify on a cold vault (no existing spores): vault-seed creates the initial set cleanly, re-seed check returns empty, no `vault_resolve_spore` calls
- [ ] Verify on a warm vault: re-running vault-seed triggers the "vault already populated" short-circuit via the Step 1 re-seed check
- [ ] Verify `vault-evolve` task still runs as the default scheduled intelligence task (no behavior regression beyond the rename)
- [ ] Verify existing installs with `agent.tasks['full-intelligence']` configured in myco.yaml: migration v6 moves the overrides to `agent.tasks['vault-evolve']` and preserves schedule/model/phase settings
- [ ] Spot-check Claude SDK telemetry on a max-turns failure: tokens/turns/cost populate instead of zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)