### PR TITLE
refactor(vault): remove MYCO_VAULT_DIR / MYCO_PROJECT_ROOT overrides

### DIFF
--- a/.agents/skills/myco-symbiont-integration/SKILL.md
+++ b/.agents/skills/myco-symbiont-integration/SKILL.md
@@ -79,17 +79,9 @@ All four layers must be present.
 
 ---
 
-## Env Var Propagation and Priority Ordering
+## Vault Location Resolution
 
-Environment variables for vault location resolution follow a priority order in `src/hooks/resolve.ts`. When a hook needs to locate the vault:
-
-1. **Explicit args** (command-line arguments like `--vault-dir`) — highest priority
-2. **`MYCO_VAULT_DIR`** — if set, use this path directly (absolute)
-3. **`MYCO_PROJECT_ROOT`** — if set, resolve vault as `$MYCO_PROJECT_ROOT/.myco`
-4. **Hook guard cwd pinning** — use pinned cwd from `.agents/myco-hook.cjs` as fallback
-5. **Process cwd** — lowest priority, used only if all others are missing
-
-Claude Code injects env vars from `settings.json` into hook processes, but **not** from `settings.user.json`. Any env var required by a hook must live in `settings.json`. Always set `MYCO_PROJECT_ROOT` in `settings.json` for explicit, portable vault location resolution.
+The vault is always `<git-repo-root>/.myco/`. There are no env var overrides — `resolveVaultDir()` walks up to the git common dir and appends `.myco`. If a symbiont's MCP child or hook would otherwise launch with a cwd that breaks discovery, fix it at the launch surface (e.g. set `registration.mcpCwd` in the manifest), not by injecting `MYCO_VAULT_DIR` or `MYCO_PROJECT_ROOT` — those env vars are no longer honored.
 
 ---
 
@@ -130,5 +122,3 @@ Verify: stop the daemon, trigger a drop condition (e.g., null transcript_path, o
 **registration.mcpCwd is mandatory for portable MCP** — Without this field, MCP servers spawned from hooks run with agent-context `cwd`, breaking file resolution. Always set this in the manifest and expand to absolute path at install time.
 
 **source==exec filter must be in capture rules config** — `source` is an environment-variable-based filter evaluated by the rules engine. Ensure the filter is present in the YAML manifest, not hardcoded in the hook.
-
-**MYCO_VAULT_DIR/MYCO_PROJECT_ROOT priority ordering** — Environment variable resolution follows a 5-step priority in `src/hooks/resolve.ts`. Always set `MYCO_PROJECT_ROOT` in `settings.json` for explicit, portable vault location. Do not rely on process `cwd`.

--- a/packages/myco/src/symbionts/installer.ts
+++ b/packages/myco/src/symbionts/installer.ts
@@ -51,13 +51,6 @@ const CANONICAL_SKILLS_DIR = '.agents/skills';
 
 /** MCP server name used by Myco in all symbiont configurations. */
 export const MYCO_MCP_SERVER_NAME = 'myco';
-const MCP_ENV_PROJECT_ROOT_TOKEN = '{projectRoot}';
-const MCP_ENV_VAULT_DIR_TOKEN = '{vaultDir}';
-
-interface McpLaunchOverrides {
-  cwd?: string;
-  env: Record<string, string>;
-}
 
 /**
  * Marker substring written into plugin-file hook templates (e.g., opencode's plugin.ts).
@@ -878,56 +871,15 @@ export class SymbiontInstaller {
   ): Record<string, unknown> | null {
     if (!template) return null;
 
-    const overrides = this.resolveMcpLaunchOverrides();
-    if (!overrides.cwd && Object.keys(overrides.env).length === 0) return template;
+    const cwd = this.manifest.registration?.mcpCwd;
+    if (!cwd) return template;
 
     return Object.fromEntries(
       Object.entries(template).map(([name, def]) => {
         if (!def || typeof def !== 'object' || Array.isArray(def)) return [name, def];
-        const server = def as Record<string, unknown>;
-        const mergedEnv = {
-          ...(
-            server.env && typeof server.env === 'object' && !Array.isArray(server.env)
-              ? server.env
-              : {}
-          ),
-          ...overrides.env,
-        } as Record<string, unknown>;
-        return [
-          name,
-          {
-            ...server,
-            ...(overrides.cwd ? { cwd: overrides.cwd } : {}),
-            ...(Object.keys(mergedEnv).length > 0 ? { env: mergedEnv } : {}),
-          },
-        ];
+        return [name, { ...(def as Record<string, unknown>), cwd }];
       }),
     );
-  }
-
-  private resolveMcpLaunchOverrides(): McpLaunchOverrides {
-    const vaultDir = path.join(this.projectRoot, '.myco');
-    const registration = this.manifest.registration;
-    const envEntries = Object.entries(registration?.mcpEnv ?? {});
-    return {
-      cwd: this.resolveMcpPlaceholderValue(registration?.mcpCwd, vaultDir),
-      env: Object.fromEntries(
-        envEntries.flatMap(([key, value]) => {
-          const resolved = this.resolveMcpPlaceholderValue(value, vaultDir);
-          return resolved ? [[key, resolved] as const] : [];
-        }),
-      ),
-    };
-  }
-
-  private resolveMcpPlaceholderValue(
-    value: string | undefined,
-    vaultDir: string,
-  ): string | undefined {
-    if (!value) return value;
-    return value
-      .replaceAll(MCP_ENV_PROJECT_ROOT_TOKEN, this.projectRoot)
-      .replaceAll(MCP_ENV_VAULT_DIR_TOKEN, vaultDir);
   }
 
   /**

--- a/packages/myco/src/symbionts/manifest-schema.ts
+++ b/packages/myco/src/symbionts/manifest-schema.ts
@@ -120,18 +120,11 @@ const RegistrationSchema = z.object({
   mcpTarget: z.string().optional(),
   mcpFormat: z.enum(['json', 'toml']).default('json'),
   /**
-   * Optional working directory injected into the Myco MCP server entry. Values
-   * may use `{projectRoot}` and `{vaultDir}` placeholders, or remain relative
-   * (for example `.` in a project-local config file) when the host agent
-   * resolves paths against the config file location.
+   * Optional working directory injected verbatim into the Myco MCP server entry.
+   * Used by symbionts (for example Codex with `.`) whose MCP child would
+   * otherwise launch with a cwd that breaks vault discovery.
    */
   mcpCwd: z.string().optional(),
-  /**
-   * Optional env vars injected into the Myco MCP server entry. Values may use
-   * `{projectRoot}` and `{vaultDir}` placeholders so symbionts whose MCP child
-   * starts outside the repo can still anchor Myco to the correct project.
-   */
-  mcpEnv: z.record(z.string(), z.string()).default({}),
   /**
    * JSON key under which MCP server entries are stored in the MCP config file.
    * Defaults to 'mcpServers' (used by Claude Code, Cursor, etc.). opencode uses 'mcp'.

--- a/packages/myco/src/vault/resolve.ts
+++ b/packages/myco/src/vault/resolve.ts
@@ -1,40 +1,18 @@
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 
-export const MYCO_PROJECT_ROOT_ENV = 'MYCO_PROJECT_ROOT';
-export const MYCO_VAULT_DIR_ENV = 'MYCO_VAULT_DIR';
-
 /**
  * Resolve the vault directory.
  *
  * Always `.myco/` in the project root. The vault is a SQLite database
- * that lives with the project — no external overrides needed.
+ * that lives with the project — there is no escape hatch.
  *
  * Uses git to find the repo root so this works correctly in
  * git worktrees — worktree agents resolve to the same vault
- * as the main working tree. Some symbionts launch their MCP child with
- * cwd=/, so explicit env anchors win before any cwd-based fallback.
+ * as the main working tree.
  */
-export function resolveVaultDir(
-  cwd = process.cwd(),
-  env: NodeJS.ProcessEnv = process.env,
-): string {
-  const explicitVaultDir = readAbsoluteEnv(env, MYCO_VAULT_DIR_ENV);
-  if (explicitVaultDir) return explicitVaultDir;
-
-  const explicitProjectRoot = readAbsoluteEnv(env, MYCO_PROJECT_ROOT_ENV);
-  if (explicitProjectRoot) return path.join(explicitProjectRoot, '.myco');
-
+export function resolveVaultDir(cwd: string = process.cwd()): string {
   return path.join(resolveRepoRoot(cwd), '.myco');
-}
-
-function readAbsoluteEnv(
-  env: NodeJS.ProcessEnv,
-  key: string,
-): string | null {
-  const raw = env[key];
-  if (typeof raw !== 'string' || raw.length === 0) return null;
-  return path.isAbsolute(raw) ? raw : null;
 }
 
 /**

--- a/tests/symbionts/installer.test.ts
+++ b/tests/symbionts/installer.test.ts
@@ -1016,20 +1016,14 @@ describe('installMcp (TOML)', () => {
     expect(content).not.toContain('old-command');
   });
 
-  it('resolves mcpCwd placeholders through the manifest-owned installer path', () => {
+  it('writes mcpCwd verbatim into the installed MCP entry', () => {
     fs.mkdirSync(path.join(projectRoot, '.codex'), { recursive: true });
-    const installer = new SymbiontInstaller({
-      ...CODEX_MANIFEST,
-      registration: {
-        ...CODEX_MANIFEST.registration!,
-        mcpCwd: '{projectRoot}',
-      },
-    }, projectRoot, packageRoot);
+    const installer = new SymbiontInstaller(CODEX_MANIFEST, projectRoot, packageRoot);
 
     installer.installMcp();
 
     const content = fs.readFileSync(path.join(projectRoot, '.codex/config.toml'), 'utf-8');
-    expect(content).toContain(`cwd = "${projectRoot}"`);
+    expect(content).toContain('cwd = "."');
   });
 });
 

--- a/tests/vault/resolve.test.ts
+++ b/tests/vault/resolve.test.ts
@@ -1,34 +1,33 @@
-import { describe, expect, it } from 'vitest';
-import {
-  MYCO_PROJECT_ROOT_ENV,
-  MYCO_VAULT_DIR_ENV,
-  resolveVaultDir,
-} from '@myco/vault/resolve.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { resolveVaultDir } from '@myco/vault/resolve.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'myco-resolve-')));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
 
 describe('resolveVaultDir', () => {
-  it('prefers explicit vault dir env over cwd discovery', () => {
-    const result = resolveVaultDir('/', {
-      [MYCO_VAULT_DIR_ENV]: '/tmp/custom-vault',
-      [MYCO_PROJECT_ROOT_ENV]: '/tmp/project-root',
-    });
+  it('resolves to <git-root>/.myco when cwd is inside a git repo', () => {
+    execFileSync('git', ['init', '-q'], { cwd: tmpDir });
+    const subdir = path.join(tmpDir, 'pkg', 'src');
+    fs.mkdirSync(subdir, { recursive: true });
 
-    expect(result).toBe('/tmp/custom-vault');
+    const result = resolveVaultDir(subdir);
+
+    expect(result).toBe(path.join(tmpDir, '.myco'));
   });
 
-  it('derives vault dir from explicit project root env when present', () => {
-    const result = resolveVaultDir('/', {
-      [MYCO_PROJECT_ROOT_ENV]: '/tmp/project-root',
-    });
-
-    expect(result).toBe('/tmp/project-root/.myco');
-  });
-
-  it('ignores non-absolute env values and falls back to cwd resolution', () => {
-    const result = resolveVaultDir('/tmp/project-root', {
-      [MYCO_PROJECT_ROOT_ENV]: 'relative-root',
-      [MYCO_VAULT_DIR_ENV]: '.myco',
-    });
-
-    expect(result).toBe('/tmp/project-root/.myco');
+  it('falls back to <cwd>/.myco when cwd is not inside a git repo', () => {
+    const result = resolveVaultDir(tmpDir);
+    expect(result).toBe(path.join(tmpDir, '.myco'));
   });
 });


### PR DESCRIPTION
## Summary

`resolveVaultDir()` no longer honors `MYCO_VAULT_DIR` or `MYCO_PROJECT_ROOT`. The vault is always `<git-repo-root>/.myco`.

## Why

These env vars were the highest-priority anchor in the resolver, but **no symbiont manifest in-tree actually injects them**. They were retained as a contract for symbionts whose MCP child launches with `cwd=/`, but Codex (the motivating case) solves that with `registration.mcpCwd: \".\"` instead.

In practice the vars were a stale escape hatch — and they're hijackable. A real-world failure: an old project `.env` in `~/Repos/unifi-mcp/` contained
```
MYCO_VAULT_DIR=\"/Users/chris/.myco/vaults/unifi-mcp\"
```
from the pre-project-local-vault era. oh-my-zsh's `dotenv` plugin auto-sourced it on every `cd` into the repo, and `myco restart` then silently launched the daemon against a ghost vault on the wrong port. Project's real 22 MB vault sat untouched at `~/Repos/unifi-mcp/.myco/`.

Per `feedback_prove_consumer_before_building.md` and `feedback_vault_location.md`: a feature with no live consumer that can be hijacked from the user's environment shouldn't exist. Removing it.

## Changes

- `packages/myco/src/vault/resolve.ts` — drop env var checks; vault is always `git-root/.myco`.
- `packages/myco/src/symbionts/installer.ts` — drop `{projectRoot}` / `{vaultDir}` placeholder resolution and `mcpEnv` handling. `mcpCwd` is written verbatim.
- `packages/myco/src/symbionts/manifest-schema.ts` — drop the `mcpEnv` field and placeholder docs from `mcpCwd`.
- `tests/vault/resolve.test.ts` — replace env-precedence tests with deterministic `git init` tests.
- `tests/symbionts/installer.test.ts` — update placeholder test to assert verbatim `mcpCwd` injection.
- `.agents/skills/myco-symbiont-integration/SKILL.md` — rewrite the env-priority section to document the new \"no overrides\" contract.

## Test plan

- [x] \`make build\` clean (3063 tests pass, 0 failures)
- [x] Unit: \`resolveVaultDir()\` resolves to `<git-root>/.myco` from a subdirectory
- [x] Unit: falls back to `<cwd>/.myco` when not in a git repo
- [x] Unit: installer writes `mcpCwd` verbatim to Codex `config.toml`
- [x] Manual: `myco restart` from a project with a stale `MYCO_VAULT_DIR` in the shell env now correctly resolves to `<project>/.myco`

🤖 Generated with [Claude Code](https://claude.com/claude-code)