### PR TITLE
Agent harness: zombie-resume fix, plugin isolation, observability through DaemonLogger

### DIFF
--- a/.agents/skills/scoped-config-architecture/SKILL.md
+++ b/.agents/skills/scoped-config-architecture/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: myco:scoped-config-architecture
+description: |
+  Covers adding and classifying new config settings using Myco's two-tier scoped config model 
+  (myco.yaml + .myco/local.yaml), implementing the PUT /api/config/scoped endpoint contract, 
+  and setting up config-change reactions via the ConfigReactionRegistry. Includes scope 
+  classification matrix (Personal vs Project vs Team-boundary), closure factory patterns 
+  for reactions, and config toggle side-effects management. Use when adding any new 
+  user-configurable behavior, daemon settings, or agent preferences that need live-reload 
+  capabilities.
+managed_by: myco
+user-invocable: true
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+# Scoped Config Architecture and Reaction System
+
+Myco uses a two-tier scoped configuration model where team settings live in committed `myco.yaml` while personal overrides live in gitignored `.myco/local.yaml`. This architecture enables per-machine personalization without affecting team defaults, plus a reactive system for live-reloading daemon subsystems when config changes.
+
+## Prerequisites
+
+- Understand that `myco.yaml` is committed (team-shared) while `.myco/local.yaml` is vault-scoped (gitignored, per-machine)
+- Know that config is deep-merged via `loadConfig()` with `arrayStrategy: 'replace'` where local values win
+- Recognize that daemon subsystems can subscribe to config changes for live-reload without restart
+
+## Procedure A: Classify New Config Settings by Scope
+
+When adding any new user-configurable behavior, follow these steps to determine which scope tier it belongs in:
+
+**Step 1: Apply the scope decision rule**
+If the setting affects how the team collaborates or shares data, it's Project-scoped. If it's about individual developer experience or machine-specific constraints, it's Personal-scoped. Auth flows remain unscoped for security isolation.
+
+**Step 2: Reference the classification matrix**
+Use these established patterns as precedent:
+
+*Personal Settings (13 fields):* Per-machine preferences that don't affect team collaboration
+- Agent provider/model selection (`agent.provider`, `agent.model`)
+- Embedding provider configuration (`embedding.provider`)
+- Daemon operational settings (`daemon.port`, `daemon.log_level`)
+- UI personalization (`appearance.theme`, `appearance.font_size`, `appearance.dark_mode`, `appearance.density`)
+- Notification preferences (`notifications.*`)
+- Maintenance automation (`maintenance.auto_optimize`)
+
+*Project Settings (7 fields):* Shared team configuration affecting workflow behavior
+- Task configuration (`tasks.*`)
+- Symbiont manifest (`symbionts.*`)
+- Agent operational limits (`agent.timeout`, `agent.context_window`)
+- Vault data policies (`vault.retention_days`, `vault.max_sessions`)
+- Team sync enablement (`sync.enabled`)
+
+*Team-Boundary (4 fields):* Auth/onboarding flows deliberately not scoped
+- Authentication configuration
+- Onboarding workflow settings
+- Access control policies
+- Audit trail configuration
+
+**Step 3: Document your decision**
+Add the new field to the appropriate scope in comments and update any scope defaults matrices in the UI layer.
+
+## Procedure B: Add New Scoped Config Fields
+
+**Step 1: Update the config schema**
+Add the new field to the appropriate section in `packages/myco/src/config/schema.ts`:
+
+```typescript
+// For Personal-scoped field - add to the appropriate schema
+const DaemonSchema = z.object({
+  // existing fields...
+  new_personal_field: z.string().default("defaultValue"),
+});
+
+// For Project-scoped field - add to the appropriate schema
+const TasksSchema = z.object({
+  // existing fields...
+  new_project_field: z.boolean().default(false),
+});
+```
+
+**Step 2: Verify the PUT /api/config/scoped endpoint handles your field**
+The endpoint at `packages/myco/src/daemon/api/config.ts` handles partial patch merging with validation:
+
+```typescript
+// Endpoint contract: { scope: 'project' | 'local', patch: {...}, clear?: [...] }
+// patch_clear_overlap validation prevents same key in both patch and clear arrays
+```
+
+Your new field should automatically work through this endpoint once added to the schema.
+
+**Step 3: Add field to scope defaults matrix (for UI)**
+If your field will appear in the daemon UI, update the scope defaults in the appropriate Settings component:
+
+```typescript
+// In settings UI component
+const scopeDefaults = {
+  'existing.field': 'local' as const,
+  'new.personal.field': 'local' as const,
+  'new.project.field': 'project' as const,
+};
+```
+
+**Step 4: Handle restart-required fields (if applicable)**
+If the field requires daemon restart rather than live-reload, add it to the restart-required pattern in the UI:
+
+```typescript
+const RESTART_REQUIRED_PATHS = [
+  'daemon.port',
+  'daemon.log_level', 
+  'new_field_requiring_restart'
+];
+```
+
+## Procedure C: Set Up Config-Change Reactions
+
+Use `registry.on(pathPrefixes, handler)` from the ConfigReactionRegistry to subscribe daemon subsystems to config changes for live-reload.
+
+**Step 1: Get access to the registry**
+In the subsystem initialization code, obtain the ConfigReactionRegistry instance:
+
+```typescript
+import type { ConfigReactionRegistry } from '../config-reactions/registry.js';
+
+// Registry is typically passed as a dependency during daemon startup
+function initializeSubsystem(registry: ConfigReactionRegistry, deps: Dependencies) {
+  // Register reactions here
+}
+```
+
+**Step 2: Register the reaction**
+```typescript
+// Path-prefix semantics: array of strings, prefix match triggers
+// Empty array [] fires on every config write
+registry.on(['agent.model', 'embedding'], createModelReaction(dependencies));
+```
+
+**Step 3: Implement closure factory pattern**
+Create reactions using the standard closure factory:
+
+```typescript
+// Dependencies explicit at call site, testable in isolation
+function createModelReaction(deps: { logger: Logger, embedManager: EmbedManager }) {
+  return (config: MycoConfig) => {
+    // Handler must be idempotent - no self-writes
+    // Use the provided config object (already parsed, optimized)
+    
+    deps.logger.info('Model config changed, updating embedding provider');
+    deps.embedManager.updateProvider(config.embedding.provider);
+  };
+}
+```
+
+**Step 4: Follow idempotency constraints**
+Reactions must be idempotent and cannot trigger self-writes that would create feedback loops. If a reaction needs to write config, it should do so through a separate mechanism outside the reaction system.
+
+## Procedure D: Implement Config Toggle Side-Effects
+
+For `myco.yaml` boolean toggles requiring file mutations (like symbiont installation), use the established pattern:
+
+**Step 1: Single opt-in flag in schema**
+```typescript
+const ConfigSchema = z.object({
+  enable_new_feature: z.boolean().default(false),
+});
+```
+
+**Step 2: Static managed block**
+Insert managed blocks on `myco init` and reconcile on `myco update`:
+```bash
+# Generated by myco - do not edit directly
+# myco:feature-block:start
+generated content here
+# myco:feature-block:end
+```
+
+**Step 3: In-process reconciliation**
+Trigger reconciliation via SymbiontInstaller after config save - NOT CLI subprocess:
+
+```typescript
+// In config write handler
+if (newConfig.enable_new_feature !== oldConfig.enable_new_feature) {
+  await SymbiontInstaller.reconcileFeatureBlocks();
+}
+```
+
+This pattern keeps side-effects deterministic and avoids the complexity of subprocess coordination.
+
+## Cross-Cutting Gotchas
+
+**Local config path construction:** In `localConfigPath()`, `vaultDir` already includes `.myco`, so use `path.join(vaultDir, LOCAL_CONFIG_FILENAME)` directly. Don't prepend `.myco/` again or you'll get `.myco/.myco/local.yaml` double-nesting.
+
+**Path-prefix subscription semantics:** `registry.on(['agent'])` triggers for `agent.model`, `agent.provider`, `agent.timeout`, etc. Use specific paths like `['agent.model']` if you only care about model changes.
+
+**Merge strategy implications:** `arrayStrategy: 'replace'` in `deepMergeConfig()` means local arrays completely replace project arrays. For additive behavior, use object merging instead of arrays.
+
+**Scope pill UX pattern:** The UI uses per-field scope indicators (Personal/Project pills) rather than section-level grouping. This supports mixed-scope forms and field-level override visibility.
+
+**Registry vs. direct config reads:** Use the `config` parameter passed to reactions for performance. The registry has already paid the YAML + schema parse cost once. Only call `loadConfig()` separately if you need to detect concurrent changes during reaction processing, which is rare.

--- a/packages/myco/src/agent/executor-state.ts
+++ b/packages/myco/src/agent/executor-state.ts
@@ -18,6 +18,28 @@ const SESSION_RESUME_ERROR_PATTERNS = [
   /conversation/,
 ];
 
+/**
+ * Error patterns that specifically indicate the Claude Agent SDK subprocess
+ * crashed while trying to attach to an expired or missing session.
+ *
+ * The SDK TTLs its sessions on Anthropic's side (hours to days). When the
+ * scheduler resumes a run after that TTL, the `claude` subprocess exits 1
+ * within ~100 seconds with 0 turns recorded — the generic "Claude Code
+ * process exited with code 1" message contains no `session`/`resume`
+ * substring, so `SESSION_RESUME_ERROR_PATTERNS` misses it and the resume
+ * keeps re-queuing forever.
+ *
+ * These patterns are only safe to apply in contexts where a `sessionRef`
+ * was passed to the runtime (see `isExpiredSessionError` callers), since
+ * "exited with code" also fires on unrelated SDK crashes.
+ */
+const EXPIRED_SESSION_ERROR_PATTERNS = [
+  /exited with code/i,
+  /session[\s_-]*not[\s_-]*found/i,
+  /session[\s_-]*expired/i,
+  /session[\s_-]*(is|was)?[\s_-]*(gone|missing|invalid)/i,
+];
+
 export interface PhaseCheckpoint {
   name: string;
   status: 'pending' | 'running' | 'completed' | 'failed';
@@ -54,6 +76,18 @@ export function abortReasonMessage(abortController?: AbortController): string | 
 export function isSessionResumeFailure(error: unknown): boolean {
   const message = toErrorMessage(error).toLowerCase();
   return SESSION_RESUME_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+/**
+ * Matches errors that look like "the Claude SDK session we tried to resume
+ * is no longer alive." Callers MUST gate this on actually having passed a
+ * `sessionRef` — otherwise an unrelated "exited with code" SDK crash would
+ * be falsely classified as expired-session and the run would stop being
+ * retried.
+ */
+export function isExpiredSessionError(error: unknown): boolean {
+  const message = toErrorMessage(error);
+  return EXPIRED_SESSION_ERROR_PATTERNS.some((pattern) => pattern.test(message));
 }
 
 export function parseCheckpointState(raw: string | null | undefined): RunCheckpointState {

--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -21,6 +21,7 @@ import {
   getRun,
   getRunningRunForTask,
   RESUME_STATUS_READY,
+  RESUME_STATUS_SESSION_EXPIRED,
   STATUS_RUNNING,
   STATUS_COMPLETED,
   STATUS_FAILED,
@@ -36,6 +37,7 @@ import { resolveCost } from './cost/index.js';
 import {
   aggregateUsage,
   buildUsageData,
+  isExpiredSessionError,
   parseCheckpointState,
   resolveProviderForResume,
   serializeCheckpointState,
@@ -495,21 +497,44 @@ export async function runAgent(
         model: effectiveModel,
         usage,
       });
+
+      // Detect the "expired SDK session" zombie-run pattern: we were
+      // resuming a run whose checkpoint carried a sessionRef, the runtime
+      // crashed without producing any turns, and the error message looks
+      // like an expired/missing session. Marking it `resumable=1, ready`
+      // here would re-enqueue it next scheduler tick and loop forever
+      // (37 zombies accumulated in issue #118). Terminal-mark it instead
+      // and null the checkpoint so nothing else tries to reuse the dead
+      // session id.
+      const hadPriorSession = Boolean(checkpointState.sessionRef)
+        || Object.values(checkpointState.phases).some((phase) => Boolean(phase.sessionRef));
+      const recordedAnyTurns = (usage.requests ?? 0) > 0
+        || (phaseResults?.some((phase) => phase.turnsUsed > 0) ?? false);
+      const sessionExpired = Boolean(options?.resumeRunId)
+        && hadPriorSession
+        && !recordedAnyTurns
+        && isExpiredSessionError(err);
+
+      const accountingUpdate = buildRunAccountingUpdate({
+        runtime: runtimeId,
+        provider: effectiveProvider,
+        model: effectiveModel,
+        checkpointState,
+        usage,
+        costData,
+        phaseResults,
+      });
+      if (sessionExpired) {
+        accountingUpdate.checkpoints = null;
+      }
+
       updateRunStatus(runId, STATUS_FAILED, {
-        resumable: 1,
-        resume_status: RESUME_STATUS_READY,
+        resumable: sessionExpired ? 0 : 1,
+        resume_status: sessionExpired ? RESUME_STATUS_SESSION_EXPIRED : RESUME_STATUS_READY,
         completed_at: failedAt,
         tokens_used: usage.totalTokens ?? phaseResults?.reduce((sum, phase) => sum + phase.tokensUsed, 0) ?? undefined,
         error: errorMessage,
-        ...buildRunAccountingUpdate({
-          runtime: runtimeId,
-          provider: effectiveProvider,
-          model: effectiveModel,
-          checkpointState,
-          usage,
-          costData,
-          phaseResults,
-        }),
+        ...accountingUpdate,
       });
     } catch (dbErr) {
       // DB failure in error path — log it but don't mask the original error

--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -9,6 +9,7 @@ import {
   CONTENT_HASH_ALGORITHM,
 } from '@myco/constants.js';
 import { tryParseJson } from '@myco/utils/json.js';
+import { errorMessage as toErrorMessage } from '@myco/utils/error-message.js';
 import { initDatabase, vaultDbPath } from '@myco/db/client.js';
 import { createSchema } from '@myco/db/schema.js';
 import { upsertCortexInstructions } from '@myco/db/queries/cortex-instructions.js';
@@ -553,7 +554,7 @@ export async function runAgent(
       // DB failure in error path — log it but don't mask the original error
       options?.logger?.error('agent.run.db-save-failed', `Failed to save error to DB for run ${runId}`, {
         runId,
-        error: dbErr instanceof Error ? dbErr.message : String(dbErr),
+        error: toErrorMessage(dbErr),
       });
     }
 

--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -88,15 +88,18 @@ const TOKEN_BUDGET_PRESSURE_STATUSES = new Set(['warning', 'post_run_pressure'])
 function logTokenBudgetPressure(
   taskName: string,
   usage: RuntimeUsage,
-  provider?: ProviderConfig,
+  provider: ProviderConfig | undefined,
+  logger: RunOptions['logger'],
 ): void {
   const budget = analyzeRuntimeTokenBudget(usage, provider);
   if (!TOKEN_BUDGET_PRESSURE_STATUSES.has(budget.status)) return;
-  console.warn(
-    `[agent] ${taskName} token budget ${budget.status}: ` +
-    `${budget.utilizationPercent}% of ${budget.contextWindowTokens} tokens ` +
-    `at peak request (${budget.peakRequestTotalTokens} tokens)`,
-  );
+  logger?.warn('agent.token-budget-pressure', `${taskName} token budget ${budget.status}`, {
+    task: taskName,
+    status: budget.status,
+    utilizationPercent: budget.utilizationPercent,
+    contextWindowTokens: budget.contextWindowTokens,
+    peakRequestTotalTokens: budget.peakRequestTotalTokens,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -307,11 +310,14 @@ export async function runAgent(
     taskProviderOverride = resolved.taskProvider;
     phaseProviderOverrides = resolved.phaseOverrides;
     for (const conflict of resolved.conflicts) {
-      console.warn(
-        `[agent] Ollama model "${conflict.model}" referenced with conflicting ` +
-        `context_length values [${conflict.values.join(', ')}] — reconciled to ` +
-        `${conflict.resolved} to avoid loading multiple variants. Configure one ` +
-        `value per model to silence this warning.`,
+      options?.logger?.warn(
+        'agent.ollama.context-variant-conflict',
+        `Ollama model "${conflict.model}" referenced with conflicting context_length values — reconciled to ${conflict.resolved}`,
+        {
+          model: conflict.model,
+          values: conflict.values,
+          resolved: conflict.resolved,
+        },
       );
     }
   }
@@ -320,7 +326,11 @@ export async function runAgent(
   const taskAbortController = new AbortController();
   const timeoutMs = config.timeoutSeconds * MS_PER_SECOND;
   const timeoutId = setTimeout(() => {
-    console.warn(`[agent] Run ${runId} exceeded timeout (${config.timeoutSeconds}s), aborting`);
+    options?.logger?.warn('agent.run.timeout', `Run ${runId} exceeded timeout, aborting`, {
+      runId,
+      taskName: config.taskName,
+      timeoutSeconds: config.timeoutSeconds,
+    });
     taskAbortController.abort(new Error(`Agent run timed out after ${config.timeoutSeconds} seconds`));
   }, timeoutMs);
   timeoutId.unref?.();
@@ -432,7 +442,7 @@ export async function runAgent(
     }
 
     clearTimeout(timeoutId);
-    logTokenBudgetPressure(config.taskName, usage, effectiveProvider);
+    logTokenBudgetPressure(config.taskName, usage, effectiveProvider, options?.logger);
     await finalizeOnTaskSuccess({
       taskName: config.taskName,
       agentId,
@@ -485,12 +495,15 @@ export async function runAgent(
     }
     const failedAt = epochSeconds();
 
-    // Log to stderr (daemon may capture) and to structured log
-    console.error(`[agent] Run ${runId} failed: ${errorMessage}`);
+    options?.logger?.error('agent.run.failed', `Run ${runId} failed`, {
+      runId,
+      taskName: config.taskName,
+      error: errorMessage,
+    });
 
     try {
       const usage = aggregateUsage(phaseResults?.map((phase) => phase.usage) ?? []);
-      logTokenBudgetPressure(config.taskName, usage, effectiveProvider);
+      logTokenBudgetPressure(config.taskName, usage, effectiveProvider, options?.logger);
       const costData = phaseResults ? summarizePhaseCosts(phaseResults) : await resolveCost({
         runtime: runtimeId,
         provider: effectiveProvider,
@@ -538,7 +551,10 @@ export async function runAgent(
       });
     } catch (dbErr) {
       // DB failure in error path — log it but don't mask the original error
-      console.error(`[agent] Failed to save error to DB:`, dbErr);
+      options?.logger?.error('agent.run.db-save-failed', `Failed to save error to DB for run ${runId}`, {
+        runId,
+        error: dbErr instanceof Error ? dbErr.message : String(dbErr),
+      });
     }
 
     await cleanupOnTaskFailure({

--- a/packages/myco/src/agent/loader.ts
+++ b/packages/myco/src/agent/loader.ts
@@ -204,8 +204,13 @@ export function resolveEffectiveConfig(
       try {
         const parsed = JSON.parse(agentOverrides.tool_access);
         if (Array.isArray(parsed)) tools = parsed as string[];
-      } catch {
-        // Invalid JSON in tool_access — keep definition defaults
+      } catch (err) {
+        // Keep definition defaults but surface the error so operators can
+        // tell why their per-agent tool override isn't taking effect.
+        const detail = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[agent] Ignoring malformed tool_access JSON for agent "${agentId}": ${detail}`,
+        );
       }
     }
   }

--- a/packages/myco/src/agent/loader.ts
+++ b/packages/myco/src/agent/loader.ts
@@ -10,6 +10,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { findPackageRoot } from '@myco/utils/find-package-root.js';
+import { errorMessage } from '@myco/utils/error-message.js';
 import { parse as parseYaml } from 'yaml';
 import { epochSeconds, DEFAULT_AGENT_ID, BUILT_IN_SOURCE, USER_TASK_SOURCE } from '@myco/constants.js';
 import { getDatabase } from '@myco/db/client.js';
@@ -207,7 +208,7 @@ export function resolveEffectiveConfig(
       } catch (err) {
         // Keep definition defaults but surface the error so operators can
         // tell why their per-agent tool override isn't taking effect.
-        const detail = err instanceof Error ? err.message : String(err);
+        const detail = errorMessage(err);
         console.warn(
           `[agent] Ignoring malformed tool_access JSON for agent "${agentId}": ${detail}`,
         );

--- a/packages/myco/src/agent/orchestrator.ts
+++ b/packages/myco/src/agent/orchestrator.ts
@@ -41,6 +41,9 @@ const FALLBACK_REASONING_PARSE_ERROR = 'Orchestrator response could not be parse
 /** Fallback reasoning string used when the parsed plan has no phases array. */
 const FALLBACK_REASONING_MISSING_PHASES = 'Orchestrator plan missing phases array — running all phases with defaults.';
 
+/** Max chars of the underlying parser error we surface into the fallback reasoning. */
+const ORCHESTRATOR_PARSE_ERROR_PREVIEW_CHARS = 200;
+
 // ---------------------------------------------------------------------------
 // Template placeholder names
 // ---------------------------------------------------------------------------
@@ -154,8 +157,13 @@ export function parseOrchestratorPlan(
     }
 
     return parsed;
-  } catch {
-    return buildRunAllPlan(phases, FALLBACK_REASONING_PARSE_ERROR);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    const truncated = detail.length > ORCHESTRATOR_PARSE_ERROR_PREVIEW_CHARS
+      ? `${detail.slice(0, ORCHESTRATOR_PARSE_ERROR_PREVIEW_CHARS)}…`
+      : detail;
+    console.warn(`[agent] Orchestrator plan parse failed: ${detail}`);
+    return buildRunAllPlan(phases, `${FALLBACK_REASONING_PARSE_ERROR} (${truncated})`);
   }
 }
 

--- a/packages/myco/src/agent/orchestrator.ts
+++ b/packages/myco/src/agent/orchestrator.ts
@@ -142,6 +142,7 @@ export function composeOrchestratorPrompt(
 export function parseOrchestratorPlan(
   response: string,
   phases: PhaseDefinition[],
+  logger?: import('./types.js').RunLogger,
 ): OrchestratorPlan {
   const trimmed = response.trim();
 
@@ -162,7 +163,10 @@ export function parseOrchestratorPlan(
     const truncated = detail.length > ORCHESTRATOR_PARSE_ERROR_PREVIEW_CHARS
       ? `${detail.slice(0, ORCHESTRATOR_PARSE_ERROR_PREVIEW_CHARS)}…`
       : detail;
-    console.warn(`[agent] Orchestrator plan parse failed: ${detail}`);
+    logger?.warn('agent.orchestrator.parse-failed', 'Orchestrator plan parse failed', {
+      error: detail,
+      responsePreview: trimmed.slice(0, 200),
+    });
     return buildRunAllPlan(phases, `${FALLBACK_REASONING_PARSE_ERROR} (${truncated})`);
   }
 }

--- a/packages/myco/src/agent/orchestrator.ts
+++ b/packages/myco/src/agent/orchestrator.ts
@@ -12,6 +12,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { findPackageRoot } from '@myco/utils/find-package-root.js';
+import { errorMessage } from '@myco/utils/error-message.js';
 import { extractJson } from '@myco/intelligence/response.js';
 import type { PhaseDefinition, OrchestratorPlan, OrchestratorPhaseDirective } from './types.js';
 import type { ContextQueryResult } from './context-queries.js';
@@ -159,7 +160,7 @@ export function parseOrchestratorPlan(
 
     return parsed;
   } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
+    const detail = errorMessage(err);
     const truncated = detail.length > ORCHESTRATOR_PARSE_ERROR_PREVIEW_CHARS
       ? `${detail.slice(0, ORCHESTRATOR_PARSE_ERROR_PREVIEW_CHARS)}…`
       : detail;

--- a/packages/myco/src/agent/phase-loop.ts
+++ b/packages/myco/src/agent/phase-loop.ts
@@ -160,7 +160,7 @@ export async function executePhase(
         runId: ctx.runId,
         phase: phase.name,
         priorSession: sessionId,
-        error: error instanceof Error ? error.message : String(error),
+        error: toErrorMessage(error),
       });
       result = await runtime.execute({
         prompt: phasePrompt,
@@ -305,7 +305,7 @@ export async function executeSingleQuery(
       {
         runId: ctx.runId,
         priorSession: sessionRef,
-        error: err instanceof Error ? err.message : String(err),
+        error: toErrorMessage(err),
       },
     );
     result = await runtime.execute(baseInput);

--- a/packages/myco/src/agent/phase-loop.ts
+++ b/packages/myco/src/agent/phase-loop.ts
@@ -30,6 +30,7 @@ import {
   abortReasonMessage,
   buildPhaseResult,
   checkpointResultsForResume,
+  isExpiredSessionError,
   isSessionResumeFailure,
   type RunCheckpointState,
 } from './executor-state.js';
@@ -137,7 +138,11 @@ export async function executePhase(
         toolSurface,
       });
     } catch (error) {
-      if (!sessionId || !runtime.supports('supportsSessionResume') || !isSessionResumeFailure(error)) {
+      if (
+        !sessionId
+        || !runtime.supports('supportsSessionResume')
+        || (!isSessionResumeFailure(error) && !isExpiredSessionError(error))
+      ) {
         throw error;
       }
       console.warn(`[agent] Resuming phase "${phase.name}" session failed, retrying without prior session`);
@@ -226,23 +231,41 @@ export async function executeSingleQuery(
     provider,
     ctx.config.model,
   );
-  const result = await runtime.execute({
+  const toolSurface = {
+    agentId: ctx.agentId,
+    runId: ctx.runId,
+    vaultDir: ctx.vaultDir,
+    embeddingManager: ctx.embeddingManager,
+    dryRun: ctx.config.dryRun ?? false,
+  };
+  const baseInput = {
     prompt: taskPrompt,
     model: effectiveModel,
     maxTurns: ctx.config.maxTurns,
     systemPrompt: ctx.systemPrompt,
     provider,
     abortController: ctx.abortController,
-    sessionRef,
-    sessionData,
-    toolSurface: {
-      agentId: ctx.agentId,
-      runId: ctx.runId,
-      vaultDir: ctx.vaultDir,
-      embeddingManager: ctx.embeddingManager,
-      dryRun: ctx.config.dryRun ?? false,
-    },
-  });
+    toolSurface,
+  };
+  let result;
+  try {
+    result = await runtime.execute({ ...baseInput, sessionRef, sessionData });
+  } catch (err) {
+    // Mirror executePhase's retry: if we had a sessionRef and the runtime
+    // supports resume, try once more with a fresh session. Without this,
+    // single-query tasks (title-summary, review-session) loop forever in
+    // the scheduler whenever their SDK session TTLs out — the caller sees
+    // "exited with code 1" and has no way to recover.
+    if (
+      !sessionRef
+      || !runtime.supports('supportsSessionResume')
+      || (!isSessionResumeFailure(err) && !isExpiredSessionError(err))
+    ) {
+      throw err;
+    }
+    console.warn('[agent] Single-query session failed, retrying without prior session');
+    result = await runtime.execute(baseInput);
+  }
   const costData = await resolveCost({
     runtime: ctx.config.runtime,
     provider,

--- a/packages/myco/src/agent/phase-loop.ts
+++ b/packages/myco/src/agent/phase-loop.ts
@@ -122,7 +122,17 @@ export async function executePhase(
   input: ExecutePhaseInput,
 ): Promise<PhaseResult & { sessionData?: unknown }> {
   const { ctx, phasePrompt, phaseModel, phase, toolSurface, provider, sessionId, sessionData } = input;
+  const logger = ctx.options?.logger;
   const runtime = getAgentRuntime(ctx.config.runtime);
+  logger?.debug('agent.phase.start', `Phase ${phase.name} starting`, {
+    runId: ctx.runId,
+    phase: phase.name,
+    model: phaseModel,
+    maxTurns: phase.maxTurns,
+    required: phase.required ?? false,
+    toolNames: toolSurface.toolNames ?? null,
+    sessionRef: sessionId ?? null,
+  });
   try {
     let result;
     try {
@@ -136,7 +146,7 @@ export async function executePhase(
         sessionData,
         abortController: ctx.abortController,
         toolSurface,
-        logger: ctx.options?.logger,
+        logger,
       });
     } catch (error) {
       if (
@@ -146,7 +156,12 @@ export async function executePhase(
       ) {
         throw error;
       }
-      console.warn(`[agent] Resuming phase "${phase.name}" session failed, retrying without prior session`);
+      logger?.info('agent.phase.session-retry', `Phase ${phase.name} session failed, retrying without prior session`, {
+        runId: ctx.runId,
+        phase: phase.name,
+        priorSession: sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
       result = await runtime.execute({
         prompt: phasePrompt,
         model: phaseModel,
@@ -155,16 +170,25 @@ export async function executePhase(
         provider,
         abortController: ctx.abortController,
         toolSurface,
-        logger: ctx.options?.logger,
+        logger,
       });
     }
 
-    if (phase.maxTurns && result.turnsUsed > 0) {
-      console.log(`[agent] Phase "${phase.name}": num_turns=${result.turnsUsed}, budget=${phase.maxTurns}`);
-    }
+    logger?.debug('agent.phase.end', `Phase ${phase.name} finished`, {
+      runId: ctx.runId,
+      phase: phase.name,
+      status: 'completed',
+      turnsUsed: result.turnsUsed,
+      maxTurns: phase.maxTurns ?? null,
+      tokensUsed: result.usage.totalTokens ?? 0,
+      costUsd: result.usage.costUsd ?? null,
+    });
 
     if (phase.required && result.turnsUsed === 0) {
-      console.warn(`[agent] Required phase "${phase.name}" produced 0 turns`);
+      logger?.warn('agent.phase.zero-turns', `Required phase ${phase.name} produced 0 turns`, {
+        runId: ctx.runId,
+        phase: phase.name,
+      });
     }
 
     const costData = await resolveCost({
@@ -194,6 +218,15 @@ export async function executePhase(
           usage: telemetry.usage,
         })
       : undefined;
+    logger?.debug('agent.phase.end', `Phase ${phase.name} failed`, {
+      runId: ctx.runId,
+      phase: phase.name,
+      status: 'failed',
+      turnsUsed: telemetry?.usage.requests ?? 0,
+      tokensUsed: telemetry?.usage.totalTokens ?? 0,
+      costUsd: telemetry?.usage.costUsd ?? null,
+      error: abortReason ?? toErrorMessage(err),
+    });
     return buildPhaseResult({
       name: phase.name,
       status: 'failed',
@@ -266,7 +299,15 @@ export async function executeSingleQuery(
     ) {
       throw err;
     }
-    console.warn('[agent] Single-query session failed, retrying without prior session');
+    ctx.options?.logger?.info(
+      'agent.single-query.session-retry',
+      'Single-query session failed, retrying without prior session',
+      {
+        runId: ctx.runId,
+        priorSession: sessionRef,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
     result = await runtime.execute(baseInput);
   }
   const costData = await resolveCost({
@@ -359,8 +400,14 @@ export async function executePhasedQuery(
       logger: ctx.options?.logger,
     });
 
-    const plan = parseOrchestratorPlan(planResponse.finalText, phases);
+    const plan = parseOrchestratorPlan(planResponse.finalText, phases, ctx.options?.logger);
     effectivePhases = applyDirectives(phases, plan.phases);
+    ctx.options?.logger?.debug('agent.orchestrator.plan', 'Orchestrator plan applied', {
+      runId,
+      reasoning: plan.reasoning,
+      effectivePhases: effectivePhases.map((p) => p.name),
+      skippedPhases: plan.phases.filter((d) => d.skip).map((d) => d.name),
+    });
   }
 
   // -------------------------------------------------------------------------

--- a/packages/myco/src/agent/phase-loop.ts
+++ b/packages/myco/src/agent/phase-loop.ts
@@ -136,6 +136,7 @@ export async function executePhase(
         sessionData,
         abortController: ctx.abortController,
         toolSurface,
+        logger: ctx.options?.logger,
       });
     } catch (error) {
       if (
@@ -154,6 +155,7 @@ export async function executePhase(
         provider,
         abortController: ctx.abortController,
         toolSurface,
+        logger: ctx.options?.logger,
       });
     }
 
@@ -246,6 +248,7 @@ export async function executeSingleQuery(
     provider,
     abortController: ctx.abortController,
     toolSurface,
+    logger: ctx.options?.logger,
   };
   let result;
   try {
@@ -353,6 +356,7 @@ export async function executePhasedQuery(
         dryRun: config.dryRun ?? false,
       },
       abortController: ctx.abortController,
+      logger: ctx.options?.logger,
     });
 
     const plan = parseOrchestratorPlan(planResponse.finalText, phases);

--- a/packages/myco/src/agent/runtime/claude.ts
+++ b/packages/myco/src/agent/runtime/claude.ts
@@ -6,6 +6,7 @@ import type { RuntimeExecuteInput, RuntimeExecuteResult, AgentRuntime, RuntimeCa
 import { RuntimeExecutionError } from './types.js';
 import { createScopedVaultToolServer, createVaultToolServer } from '@myco/agent/tools.js';
 import { buildPhaseEnv } from '@myco/agent/provider.js';
+import { errorMessage } from '@myco/utils/error-message.js';
 
 const MCP_SERVER_NAME = 'myco-vault';
 
@@ -18,12 +19,12 @@ const MCP_SERVER_NAME = 'myco-vault';
  * `CLAUDE_CODE_PLUGIN_CACHE_DIR` to an empty directory gives the agent a
  * clean, deterministic tool surface: only our MCP vault tools.
  *
- * Empty isn't enough, though: observed 2026-04-19 (issue #118 follow-up),
- * when the SDK boots against an empty cache dir it *populates* it from
- * the user's global `~/.claude/plugins/installed_plugins.json` on first
- * use, re-introducing every plugin we meant to exclude. Pre-seeding the
- * dir with an explicit empty manifest short-circuits that sync — the SDK
- * sees a valid-but-empty plugins list and loads none.
+ * Empty isn't enough, though: when the SDK boots against an empty cache
+ * dir it *populates* it from the user's global
+ * `~/.claude/plugins/installed_plugins.json` on first use, re-introducing
+ * every plugin we meant to exclude. Pre-seeding the dir with an explicit
+ * empty manifest short-circuits that sync — the SDK sees a valid-but-
+ * empty plugins list and loads none.
  *
  * Created once per daemon process and reused across runs.
  */
@@ -126,13 +127,12 @@ export class ClaudeSdkRuntime implements AgentRuntime {
     // tool surface, inflating context and occasionally triggering API
     // schema rejections (Anthropic's 400 on top-level oneOf/allOf/anyOf).
     //
-    // `settingSources: []` completes the isolation: the SDK's P_7() path
-    // reads `enabledPlugins` from `~/.claude/settings.json` / project
+    // `settingSources: []` completes the isolation: the SDK's plugin-sync
+    // path reads `enabledPlugins` from `~/.claude/settings.json` / project
     // settings and syncs them into our "isolated" plugin cache dir,
-    // re-introducing every developer plugin we meant to exclude
-    // (observed 2026-04-19 on a dev machine with 21 enabled plugins).
-    // Per the SDK docs: "When omitted or empty, no filesystem settings
-    // are loaded (SDK isolation mode)."
+    // re-introducing every developer plugin we meant to exclude. Per the
+    // SDK docs: "When omitted or empty, no filesystem settings are
+    // loaded (SDK isolation mode)."
     const messageStream: AsyncIterable<SDKMessage> = query({
       prompt: input.prompt,
       options: {
@@ -188,7 +188,7 @@ export class ClaudeSdkRuntime implements AgentRuntime {
     } catch (err) {
       if (turnsUsed > 0 || inputTokens > 0 || outputTokens > 0) {
         throw new RuntimeExecutionError(
-          err instanceof Error ? err.message : String(err),
+          errorMessage(err),
           { usage: buildUsage(), sessionRef: input.sessionRef },
           { cause: err },
         );

--- a/packages/myco/src/agent/runtime/claude.ts
+++ b/packages/myco/src/agent/runtime/claude.ts
@@ -92,6 +92,25 @@ export class ClaudeSdkRuntime implements AgentRuntime {
         process.env.CLAUDE_CODE_PLUGIN_CACHE_DIR ?? getIsolatedPluginCacheDir(),
     };
 
+    // Debug-level record of the per-request tool surface. Filtered out
+    // unless daemon.log_level is set to 'debug' — when it is, operators
+    // can grep the log viewer for `agent.runtime.request` to see what
+    // tools each phase actually sent, which is how you catch a plugin
+    // leak before it blows up a real run with a 400 tool-schema error.
+    if (input.logger) {
+      const mcpToolNames = input.toolSurface.toolNames
+        ?? (toolServer ? ['<full-vault-surface>'] : []);
+      input.logger.debug('agent.runtime.request', 'Agent runtime request', {
+        runId: input.toolSurface.runId,
+        agentId: input.toolSurface.agentId,
+        model: input.model,
+        mcpToolCount: mcpToolNames.length,
+        mcpTools: mcpToolNames,
+        pluginCacheDir: env.CLAUDE_CODE_PLUGIN_CACHE_DIR,
+        sessionRef: input.sessionRef ?? null,
+      });
+    }
+
     let finalText = '';
     let turnsUsed = 0;
     let inputTokens = 0;

--- a/packages/myco/src/agent/runtime/claude.ts
+++ b/packages/myco/src/agent/runtime/claude.ts
@@ -18,6 +18,13 @@ const MCP_SERVER_NAME = 'myco-vault';
  * `CLAUDE_CODE_PLUGIN_CACHE_DIR` to an empty directory gives the agent a
  * clean, deterministic tool surface: only our MCP vault tools.
  *
+ * Empty isn't enough, though: observed 2026-04-19 (issue #118 follow-up),
+ * when the SDK boots against an empty cache dir it *populates* it from
+ * the user's global `~/.claude/plugins/installed_plugins.json` on first
+ * use, re-introducing every plugin we meant to exclude. Pre-seeding the
+ * dir with an explicit empty manifest short-circuits that sync — the SDK
+ * sees a valid-but-empty plugins list and loads none.
+ *
  * Created once per daemon process and reused across runs.
  */
 let isolatedPluginCacheDir: string | undefined;
@@ -26,6 +33,13 @@ function getIsolatedPluginCacheDir(): string {
   if (isolatedPluginCacheDir) return isolatedPluginCacheDir;
   const dir = path.join(os.tmpdir(), `myco-agent-plugin-cache-${process.pid}`);
   fs.mkdirSync(dir, { recursive: true });
+  const manifestPath = path.join(dir, 'installed_plugins.json');
+  if (!fs.existsSync(manifestPath)) {
+    fs.writeFileSync(
+      manifestPath,
+      JSON.stringify({ version: 2, plugins: {} }),
+    );
+  }
   isolatedPluginCacheDir = dir;
   return dir;
 }
@@ -92,6 +106,14 @@ export class ClaudeSdkRuntime implements AgentRuntime {
     // every installed plugin — 130+ unrelated tools leak into the agent's
     // tool surface, inflating context and occasionally triggering API
     // schema rejections (Anthropic's 400 on top-level oneOf/allOf/anyOf).
+    //
+    // `settingSources: []` completes the isolation: the SDK's P_7() path
+    // reads `enabledPlugins` from `~/.claude/settings.json` / project
+    // settings and syncs them into our "isolated" plugin cache dir,
+    // re-introducing every developer plugin we meant to exclude
+    // (observed 2026-04-19 on a dev machine with 21 enabled plugins).
+    // Per the SDK docs: "When omitted or empty, no filesystem settings
+    // are loaded (SDK isolation mode)."
     const messageStream: AsyncIterable<SDKMessage> = query({
       prompt: input.prompt,
       options: {
@@ -100,6 +122,7 @@ export class ClaudeSdkRuntime implements AgentRuntime {
         tools: [],
         mcpServers: toolServer ? { [MCP_SERVER_NAME]: toolServer } : {},
         strictMcpConfig: true,
+        settingSources: [],
         maxTurns: input.maxTurns,
         permissionMode: 'bypassPermissions',
         allowDangerouslySkipPermissions: true,

--- a/packages/myco/src/agent/runtime/types.ts
+++ b/packages/myco/src/agent/runtime/types.ts
@@ -1,5 +1,5 @@
 import type { EmbeddingManager } from '@myco/daemon/embedding/manager.js';
-import type { ProviderConfig, RuntimeId, RuntimeUsage } from '@myco/agent/types.js';
+import type { ProviderConfig, RunLogger, RuntimeId, RuntimeUsage } from '@myco/agent/types.js';
 
 export type RuntimeCapability =
   | 'supportsSessionResume'
@@ -32,6 +32,8 @@ export interface RuntimeExecuteInput {
   sessionRef?: string;
   sessionData?: unknown;
   abortController?: AbortController;
+  /** Optional logger for runtime-level debug diagnostics. */
+  logger?: RunLogger;
 }
 
 export interface RuntimeExecuteResult {

--- a/packages/myco/src/agent/types.ts
+++ b/packages/myco/src/agent/types.ts
@@ -270,6 +270,19 @@ export interface EffectiveConfig {
   dryRun?: boolean;
 }
 
+/**
+ * Minimal logger shape accepted by the agent runtime for diagnostic output.
+ * Structurally compatible with `DaemonLogger` so the daemon can pass its
+ * logger straight in; kept here as a narrow interface so agent code never
+ * imports daemon modules (that direction of dependency is inverted).
+ */
+export interface RunLogger {
+  debug(kind: string, message: string, data?: Record<string, unknown>): void;
+  info(kind: string, message: string, data?: Record<string, unknown>): void;
+  warn(kind: string, message: string, data?: Record<string, unknown>): void;
+  error(kind: string, message: string, data?: Record<string, unknown>): void;
+}
+
 /** Options passed to an agent run. */
 export interface RunOptions {
   agentId?: string;
@@ -279,6 +292,12 @@ export interface RunOptions {
   resumeRunId?: string;
   /** Embedding manager for immediate vector operations during agent tool calls. */
   embeddingManager?: import('@myco/daemon/embedding/manager.js').EmbeddingManager;
+  /**
+   * Optional logger. When provided (the daemon always provides one),
+   * runtime diagnostics are emitted at `debug` level — visible once
+   * `daemon.log_level` is set to `debug`, otherwise filtered out.
+   */
+  logger?: RunLogger;
   /**
    * Structured metadata about the run. Populated by the dispatcher (e.g.
    * instruction-builders.ts) alongside the free-form `instruction` string

--- a/packages/myco/src/daemon/api/agent-evaluations.ts
+++ b/packages/myco/src/daemon/api/agent-evaluations.ts
@@ -199,6 +199,7 @@ export function createAgentEvaluationHandlers(deps: AgentEvaluationDeps) {
           evaluationId: evalId,
           dryRun,
           embeddingManager,
+          logger,
           executionOverrides: {
             ...(cell.runtime ? { runtime: cell.runtime } : {}),
             ...(cell.reasoningLevel ? { reasoningLevel: cell.reasoningLevel } : {}),

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -255,7 +255,7 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
     const runs = listRuns({ ...filterOpts, limit, offset });
     const total = countRuns(filterOpts);
 
-    return { body: { runs: runs.map((run) => serializeRun(run)), total, offset, limit } };
+    return { body: { runs: runs.map((run) => serializeRun(run, { logger })), total, offset, limit } };
   }
 
   /**
@@ -278,6 +278,7 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
         run: serializeRun(run, {
           writeIntents: { total, by_tool: byTool },
           duration_ms: runDurationMs(run),
+          logger,
         }),
       },
     };

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -192,6 +192,7 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
       dryRun,
       evaluationId,
       executionOverrides,
+      logger,
     });
 
     // runAgent inserts the run row synchronously before the first await.
@@ -303,6 +304,7 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
       resumeRunId: run.id,
       resumeMode: mode ?? 'manual',
       embeddingManager,
+      logger,
     });
 
     resultPromise

--- a/packages/myco/src/daemon/api/models.ts
+++ b/packages/myco/src/daemon/api/models.ts
@@ -7,6 +7,7 @@ import {
 import { OPENAI_API_KEY_ENV } from '../../cli/providers/openai-embeddings.js';
 import { OPENROUTER_API_KEY_ENV } from '../../cli/providers/openrouter.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
+import type { DaemonLogger } from '../logger.js';
 
 const MODEL_LIST_TIMEOUT_MS = 5000;
 const REMOTE_MODELS_ENDPOINT = '/models';
@@ -95,7 +96,7 @@ async function fetchRemoteProviderModels(
   return filterLlmModels(modelIds);
 }
 
-export async function handleGetModels(req: RouteRequest): Promise<RouteResponse> {
+export async function handleGetModels(req: RouteRequest, logger?: DaemonLogger): Promise<RouteResponse> {
   const provider = req.query.provider;
   const type = req.query.type; // 'llm' | 'embedding' | undefined (all)
   const localBackend = req.query.local_backend;
@@ -129,7 +130,7 @@ export async function handleGetModels(req: RouteRequest): Promise<RouteResponse>
     // underlying reason so the caller can show "connection refused" /
     // "API key rejected" instead of an unexplained empty dropdown.
     fetchError = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`[models] ${provider} model list unavailable: ${fetchError}\n`);
+    logger?.warn(`models.${provider}.list-unavailable`, `${provider} model list unavailable`, { error: fetchError });
   }
 
   // Filter by type if requested

--- a/packages/myco/src/daemon/api/models.ts
+++ b/packages/myco/src/daemon/api/models.ts
@@ -105,6 +105,7 @@ export async function handleGetModels(req: RouteRequest): Promise<RouteResponse>
   }
 
   let models: string[] = [];
+  let fetchError: string | undefined;
 
   try {
     const localBackendKind = inferLocalOpenAIBackendKind({
@@ -123,8 +124,12 @@ export async function handleGetModels(req: RouteRequest): Promise<RouteResponse>
       // readers don't think `req.query.base_url` reaches the fetch.
       models = await fetchRemoteProviderModels(provider, undefined, MODEL_LIST_TIMEOUT_MS);
     }
-  } catch {
-    // Provider unreachable — return empty list
+  } catch (err) {
+    // Return the empty list so the UI still renders, but surface the
+    // underlying reason so the caller can show "connection refused" /
+    // "API key rejected" instead of an unexplained empty dropdown.
+    fetchError = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[models] ${provider} model list unavailable: ${fetchError}\n`);
   }
 
   // Filter by type if requested
@@ -134,7 +139,13 @@ export async function handleGetModels(req: RouteRequest): Promise<RouteResponse>
     models = filterLlmModels(models);
   }
 
-  return { body: { provider, models } };
+  return {
+    body: {
+      provider,
+      models,
+      ...(fetchError ? { error: fetchError } : {}),
+    },
+  };
 }
 
 export {

--- a/packages/myco/src/daemon/api/models.ts
+++ b/packages/myco/src/daemon/api/models.ts
@@ -8,6 +8,7 @@ import { OPENAI_API_KEY_ENV } from '../../cli/providers/openai-embeddings.js';
 import { OPENROUTER_API_KEY_ENV } from '../../cli/providers/openrouter.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 import type { DaemonLogger } from '../logger.js';
+import { errorMessage } from '@myco/utils/error-message.js';
 
 const MODEL_LIST_TIMEOUT_MS = 5000;
 const REMOTE_MODELS_ENDPOINT = '/models';
@@ -129,7 +130,7 @@ export async function handleGetModels(req: RouteRequest, logger?: DaemonLogger):
     // Return the empty list so the UI still renders, but surface the
     // underlying reason so the caller can show "connection refused" /
     // "API key rejected" instead of an unexplained empty dropdown.
-    fetchError = err instanceof Error ? err.message : String(err);
+    fetchError = errorMessage(err);
     logger?.warn(`models.${provider}.list-unavailable`, `${provider} model list unavailable`, { error: fetchError });
   }
 

--- a/packages/myco/src/daemon/api/providers.ts
+++ b/packages/myco/src/daemon/api/providers.ts
@@ -27,6 +27,7 @@ import type { RouteRequest, RouteResponse } from '../router.js';
 import type { DaemonLogger } from '../logger.js';
 import { PROVIDER_TYPES, type RuntimeId, type ProviderType } from '@myco/agent/types.js';
 import { DEFAULT_OPENAI_URL, DEFAULT_OPENROUTER_URL } from '@myco/agent/provider.js';
+import { errorMessage } from '@myco/utils/error-message.js';
 
 /** Timeout for the live Anthropic model list query (short -- fall back fast). */
 const ANTHROPIC_MODELS_TIMEOUT_MS = 5000;
@@ -166,7 +167,7 @@ export async function handleTestProvider(req: RouteRequest): Promise<RouteRespon
   } catch (err) {
     result = {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: errorMessage(err),
     };
   }
 
@@ -233,7 +234,7 @@ async function detectAnthropic(logger?: DaemonLogger): Promise<ProviderInfo> {
     // is never empty, but surface why the live list was unreachable so an
     // operator can diagnose a missing key / network block without SDK
     // debug logs.
-    const detail = err instanceof Error ? err.message : String(err);
+    const detail = errorMessage(err);
     logger?.warn('providers.anthropic.models-unavailable', 'Anthropic model list unavailable', { error: detail });
   }
   anthropicModelsCache = { ts: now, models };
@@ -257,7 +258,7 @@ async function detectRemoteProviderInfo(
       available = true;
     } catch (err) {
       available = false;
-      const detail = err instanceof Error ? err.message : String(err);
+      const detail = errorMessage(err);
       logger?.warn(`providers.${type}.models-unavailable`, `${type} model list unavailable`, { error: detail });
     }
   }

--- a/packages/myco/src/daemon/api/providers.ts
+++ b/packages/myco/src/daemon/api/providers.ts
@@ -163,7 +163,10 @@ export async function handleTestProvider(req: RouteRequest): Promise<RouteRespon
       result = testAnthropic();
     }
   } catch (err) {
-    result = { ok: false, error: String(err) };
+    result = {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
   }
 
   if (result.ok) {
@@ -224,8 +227,13 @@ async function detectAnthropic(): Promise<ProviderInfo> {
     if (liveModels.length > 0) {
       models = liveModels;
     }
-  } catch {
-    // Fall through to hardcoded ANTHROPIC_MODELS
+  } catch (err) {
+    // Fall through to the hardcoded ANTHROPIC_MODELS list so the dropdown
+    // is never empty, but surface why the live list was unreachable so an
+    // operator can diagnose a missing key / network block without SDK
+    // debug logs.
+    const detail = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[providers] Anthropic model list unavailable: ${detail}\n`);
   }
   anthropicModelsCache = { ts: now, models };
   return { type: 'anthropic', runtime: 'claude-sdk', available: true, models };
@@ -245,8 +253,10 @@ async function detectRemoteProviderInfo(
       // providers (always uses the hardcoded default); see SSRF lockdown.
       models = await fetchRemoteProviderModels(type, undefined, ANTHROPIC_MODELS_TIMEOUT_MS);
       available = true;
-    } catch {
+    } catch (err) {
       available = false;
+      const detail = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[providers] ${type} model list unavailable: ${detail}\n`);
     }
   }
 

--- a/packages/myco/src/daemon/api/providers.ts
+++ b/packages/myco/src/daemon/api/providers.ts
@@ -24,6 +24,7 @@ import {
   getRemoteProviderApiKey,
 } from './models.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
+import type { DaemonLogger } from '../logger.js';
 import { PROVIDER_TYPES, type RuntimeId, type ProviderType } from '@myco/agent/types.js';
 import { DEFAULT_OPENAI_URL, DEFAULT_OPENROUTER_URL } from '@myco/agent/provider.js';
 
@@ -69,13 +70,13 @@ interface TestResult {
  * Uses Promise.allSettled for parallel detection with timeouts so one
  * slow/unavailable provider doesn't block the others.
  */
-export async function handleGetProviders(): Promise<RouteResponse> {
+export async function handleGetProviders(logger?: DaemonLogger): Promise<RouteResponse> {
   const detectionPlan: Array<{
     detect: () => Promise<ProviderInfo>;
     fallback: ProviderInfo;
   }> = [
     {
-      detect: () => detectAnthropic(),
+      detect: () => detectAnthropic(logger),
       fallback: { type: 'anthropic', runtime: 'claude-sdk', available: false, models: [] },
     },
     {
@@ -87,11 +88,11 @@ export async function handleGetProviders(): Promise<RouteResponse> {
       fallback: { type: 'lmstudio', runtime: 'claude-sdk', available: false, baseUrl: LmStudioBackend.DEFAULT_BASE_URL, models: [] },
     },
     {
-      detect: () => detectRemoteProviderInfo('openai', DEFAULT_OPENAI_URL),
+      detect: () => detectRemoteProviderInfo('openai', DEFAULT_OPENAI_URL, logger),
       fallback: { type: 'openai', runtime: 'openai-agents', available: false, authConfigured: false, baseUrl: DEFAULT_OPENAI_URL, models: [] },
     },
     {
-      detect: () => detectRemoteProviderInfo('openrouter', DEFAULT_OPENROUTER_URL),
+      detect: () => detectRemoteProviderInfo('openrouter', DEFAULT_OPENROUTER_URL, logger),
       fallback: { type: 'openrouter', runtime: 'openai-agents', available: false, authConfigured: false, baseUrl: DEFAULT_OPENROUTER_URL, models: [] },
     },
     {
@@ -200,7 +201,7 @@ async function detectLocalProviderInfo(
   };
 }
 
-async function detectAnthropic(): Promise<ProviderInfo> {
+async function detectAnthropic(logger?: DaemonLogger): Promise<ProviderInfo> {
   // Anthropic is always available — the SDK handles auth internally via OAuth,
   // API key, Bedrock, Vertex, or Foundry. The daemon can't reliably detect
   // which method is in use since env vars aren't always inherited.
@@ -233,7 +234,7 @@ async function detectAnthropic(): Promise<ProviderInfo> {
     // operator can diagnose a missing key / network block without SDK
     // debug logs.
     const detail = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`[providers] Anthropic model list unavailable: ${detail}\n`);
+    logger?.warn('providers.anthropic.models-unavailable', 'Anthropic model list unavailable', { error: detail });
   }
   anthropicModelsCache = { ts: now, models };
   return { type: 'anthropic', runtime: 'claude-sdk', available: true, models };
@@ -242,6 +243,7 @@ async function detectAnthropic(): Promise<ProviderInfo> {
 async function detectRemoteProviderInfo(
   type: 'openai' | 'openrouter',
   baseUrl: string,
+  logger?: DaemonLogger,
 ): Promise<ProviderInfo> {
   const authConfigured = Boolean(getRemoteProviderApiKey(type));
   let models: string[] = [];
@@ -256,7 +258,7 @@ async function detectRemoteProviderInfo(
     } catch (err) {
       available = false;
       const detail = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`[providers] ${type} model list unavailable: ${detail}\n`);
+      logger?.warn(`providers.${type}.models-unavailable`, `${type} model list unavailable`, { error: detail });
     }
   }
 

--- a/packages/myco/src/daemon/api/run-serializer.ts
+++ b/packages/myco/src/daemon/api/run-serializer.ts
@@ -9,6 +9,7 @@
  */
 
 import type { RunRow } from '@myco/db/queries/runs.js';
+import type { DaemonLogger } from '../logger.js';
 import { transformProviderOverrides } from './schemas/execution-overrides-traversal.js';
 
 export interface PhaseCheckpointSummary {
@@ -26,6 +27,7 @@ export interface PhaseCheckpointSummary {
  */
 export function buildPhaseCheckpointSummary(
   checkpointsRaw: string | null,
+  logger?: DaemonLogger,
 ): PhaseCheckpointSummary[] {
   if (!checkpointsRaw) return [];
   try {
@@ -52,7 +54,7 @@ export function buildPhaseCheckpointSummary(
     // detail still renders, but surface the parse error so an operator can
     // distinguish "no phases yet" from "blob was truncated mid-write".
     const detail = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`[run-serializer] checkpoints JSON parse failed: ${detail}\n`);
+    logger?.warn('run-serializer.checkpoints-parse-failed', 'checkpoints JSON parse failed', { error: detail });
     return [];
   }
 }
@@ -100,6 +102,12 @@ export interface SerializeRunOptions {
    * skip; evaluation child rows attach it, plain run rows do not.
    */
   duration_ms?: number | null;
+  /**
+   * Daemon logger — when provided, checkpoint JSON corruption is logged
+   * through it instead of being swallowed. Optional so MCP / test call
+   * sites that don't have a logger can still serialize rows.
+   */
+  logger?: DaemonLogger;
 }
 
 /**
@@ -114,6 +122,7 @@ export function serializeRun(run: RunRow, opts: SerializeRunOptions = {}) {
     includePhaseCheckpoints = true,
     writeIntents,
     duration_ms,
+    logger,
   } = opts;
 
   const base = {
@@ -157,7 +166,7 @@ export function serializeRun(run: RunRow, opts: SerializeRunOptions = {}) {
         }
       : {}),
     ...(includePhaseCheckpoints
-      ? { phase_checkpoints: buildPhaseCheckpointSummary(run.checkpoints) }
+      ? { phase_checkpoints: buildPhaseCheckpointSummary(run.checkpoints, logger) }
       : {}),
     ...(writeIntents !== undefined && writeIntents !== null
       ? { write_intents: writeIntents }

--- a/packages/myco/src/daemon/api/run-serializer.ts
+++ b/packages/myco/src/daemon/api/run-serializer.ts
@@ -47,7 +47,12 @@ export function buildPhaseCheckpointSummary(
       ...(phase.costUsd !== undefined ? { costUsd: phase.costUsd } : {}),
       ...(phase.costSource !== undefined ? { costSource: phase.costSource } : {}),
     }));
-  } catch {
+  } catch (err) {
+    // Corrupt checkpoints JSON — degrade to an empty phase list so the run
+    // detail still renders, but surface the parse error so an operator can
+    // distinguish "no phases yet" from "blob was truncated mid-write".
+    const detail = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[run-serializer] checkpoints JSON parse failed: ${detail}\n`);
     return [];
   }
 }

--- a/packages/myco/src/daemon/api/run-serializer.ts
+++ b/packages/myco/src/daemon/api/run-serializer.ts
@@ -10,6 +10,7 @@
 
 import type { RunRow } from '@myco/db/queries/runs.js';
 import type { DaemonLogger } from '../logger.js';
+import { errorMessage } from '@myco/utils/error-message.js';
 import { transformProviderOverrides } from './schemas/execution-overrides-traversal.js';
 
 export interface PhaseCheckpointSummary {
@@ -53,7 +54,7 @@ export function buildPhaseCheckpointSummary(
     // Corrupt checkpoints JSON — degrade to an empty phase list so the run
     // detail still renders, but surface the parse error so an operator can
     // distinguish "no phases yet" from "blob was truncated mid-write".
-    const detail = err instanceof Error ? err.message : String(err);
+    const detail = errorMessage(err);
     logger?.warn('run-serializer.checkpoints-parse-failed', 'checkpoints JSON parse failed', { error: detail });
     return [];
   }

--- a/packages/myco/src/daemon/api/team-connect.ts
+++ b/packages/myco/src/daemon/api/team-connect.ts
@@ -12,6 +12,7 @@ import { readJsonConfig, resolveVaultConfigPath } from '@myco-deploy/index.js';
 import { getTeamPackageVersion } from '@myco/cli/team.js';
 import { TeamSyncClient } from '../team-sync.js';
 import { SYNC_PROTOCOL_VERSION, TEAM_API_KEY_SECRET } from '@myco/constants.js';
+import { errorMessage } from '@myco/utils/error-message.js';
 import { getPluginVersion } from '@myco/version.js';
 import { SCHEMA_VERSION } from '@myco/db/schema.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
@@ -155,7 +156,7 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
     } catch (err) {
       // DB may not have the table yet — log so we don't silently report
       // "0 pending" when the team-outbox queries are actually broken.
-      const detail = err instanceof Error ? err.message : String(err);
+      const detail = errorMessage(err);
       logger.warn('team-sync.outbox.count-failed', 'team-outbox counts unavailable', { error: detail });
     }
 
@@ -164,7 +165,7 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
       try {
         collectiveStatus = await client.getCollectiveStatus();
       } catch (err) {
-        const detail = err instanceof Error ? err.message : String(err);
+        const detail = errorMessage(err);
         logger.warn('team-sync.collective.status-failed', 'Collective status unavailable', { error: detail });
         collectiveStatus = null;
       }
@@ -260,7 +261,7 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
       logger.info('team-sync.mcp-token.rotated', 'MCP access token rotated');
       return { body: { token } };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = errorMessage(err);
       logger.error('team-sync.mcp-token.rotate-failed', 'MCP token rotation failed', { error: message });
       return {
         status: 500,

--- a/packages/myco/src/daemon/api/team-connect.ts
+++ b/packages/myco/src/daemon/api/team-connect.ts
@@ -152,15 +152,20 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
     try {
       pendingCount = countPending();
       deadLetterCount = countDeadLettered();
-    } catch {
-      // DB may not have the table yet
+    } catch (err) {
+      // DB may not have the table yet — log so we don't silently report
+      // "0 pending" when the team-outbox queries are actually broken.
+      const detail = err instanceof Error ? err.message : String(err);
+      logger.warn('team-sync.outbox.count-failed', 'team-outbox counts unavailable', { error: detail });
     }
 
     let collectiveStatus: Awaited<ReturnType<TeamSyncClient['getCollectiveStatus']>> | null = null;
     if (client && config.team.enabled) {
       try {
         collectiveStatus = await client.getCollectiveStatus();
-      } catch {
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        logger.warn('team-sync.collective.status-failed', 'Collective status unavailable', { error: detail });
         collectiveStatus = null;
       }
     }

--- a/packages/myco/src/daemon/cortex.ts
+++ b/packages/myco/src/daemon/cortex.ts
@@ -216,6 +216,7 @@ export async function buildCortexPrompt(
     agentId: DEFAULT_AGENT_ID,
     instruction: builderInstruction,
     embeddingManager: deps.embeddingManager,
+    logger: deps.logger,
   });
   const runId = getLatestRunId(DEFAULT_AGENT_ID, CORTEX_PROMPT_BUILDER_TASK);
   const tracked = resultPromise.catch((err) => {

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -671,7 +671,7 @@ export async function main(): Promise<void> {
   // External log ingestion: allows MCP server (separate process) to write through the daemon logger
   server.registerRoute('POST', '/api/log', createLogIngestionHandler(logger));
 
-  server.registerRoute('GET', '/api/models', async (req) => handleGetModels(req));
+  server.registerRoute('GET', '/api/models', async (req) => handleGetModels(req, logger));
   server.registerRoute('POST', '/api/restart', async (req) => handleRestart({ vaultDir, progressTracker }, req.body));
 
   // --- Update routes ---
@@ -795,7 +795,7 @@ export async function main(): Promise<void> {
   });
 
   // --- Provider detection & testing ---
-  server.registerRoute('GET', '/api/providers', async () => handleGetProviders());
+  server.registerRoute('GET', '/api/providers', async () => handleGetProviders(logger));
   server.registerRoute('POST', '/api/providers/test', async (req) => handleTestProvider(req));
   server.registerRoute('GET', '/api/providers/secrets', async () => handleGetProviderSecrets(vaultDir));
   server.registerRoute('PUT', '/api/providers/secrets/:provider', async (req) => handlePutProviderSecret(vaultDir, req));

--- a/packages/myco/src/daemon/task-scheduling.ts
+++ b/packages/myco/src/daemon/task-scheduling.ts
@@ -126,6 +126,7 @@ export async function registerScheduledTasks(
           resumeRunId: resumableRun.id,
           resumeMode: 'scheduled',
           embeddingManager,
+          logger,
         });
         logger.info(LOG_KINDS.AGENT_RUN, `Scheduled task ${taskName} resumed`, {
           status: resumed.status,
@@ -164,6 +165,7 @@ export async function registerScheduledTasks(
         instruction: built?.instruction,
         runContext: built?.context,
         embeddingManager,
+        logger,
       });
       logger.info(LOG_KINDS.AGENT_RUN, `Scheduled task ${taskName} completed`, {
         status: result.status,

--- a/packages/myco/src/daemon/trigger-title-summary.ts
+++ b/packages/myco/src/daemon/trigger-title-summary.ts
@@ -49,6 +49,7 @@ export async function triggerTitleSummary(
       task: 'title-summary',
       instruction: `Process session ${sessionId} only`,
       embeddingManager,
+      logger,
     }).catch((err) => {
       logger.warn(LOG_KINDS.AGENT_ERROR, 'Title-summary task failed', {
         session_id: sessionId,

--- a/packages/myco/src/db/queries/runs.ts
+++ b/packages/myco/src/db/queries/runs.ts
@@ -31,6 +31,16 @@ export const STATUS_FAILED = 'failed';
 /** Resume status used when a failed/interrupted run can be resumed. */
 export const RESUME_STATUS_READY = 'ready';
 
+/**
+ * Resume status used when a run's underlying SDK session has expired
+ * (Claude Agent SDK sessions TTL out after hours/days on Anthropic's side).
+ * Without this terminal state the scheduler would pick the run up every
+ * tick, re-attach to the dead session, crash within ~100s on 0 turns, and
+ * loop forever. `resumable=0` stops the loop; the status tells operators
+ * why the run is final.
+ */
+export const RESUME_STATUS_SESSION_EXPIRED = 'session_expired';
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------

--- a/packages/myco/src/db/schema.ts
+++ b/packages/myco/src/db/schema.ts
@@ -78,7 +78,10 @@ function hasSchemaVersionTable(db: Database): boolean {
 export function createSchema(db: Database, machineId: string = DEFAULT_MACHINE_ID): void {
   if (hasSchemaVersionTable(db)) {
     const currentVersion = getCurrentVersion(db);
-    if (currentVersion === SCHEMA_VERSION) return;
+    if (currentVersion === SCHEMA_VERSION) {
+      reapplyCurrentSchemaDdl(db);
+      return;
+    }
 
     // Run pending migrations in order. Errors propagate intentionally so
     // partial upgrade failures are visible to the caller.
@@ -88,6 +91,7 @@ export function createSchema(db: Database, machineId: string = DEFAULT_MACHINE_I
         migration.migrate(db, machineId);
       }
     }
+    reapplyCurrentSchemaDdl(db);
     return;
   }
 
@@ -101,4 +105,69 @@ export function createSchema(db: Database, machineId: string = DEFAULT_MACHINE_I
      VALUES (?, ?)
      ON CONFLICT (version) DO NOTHING`
   ).run(SCHEMA_VERSION, epochSeconds());
+}
+
+// ---------------------------------------------------------------------------
+// Schema-drift reconciliation
+//
+// createSchema installs everything on fresh install and each migration
+// adds its own delta, but existing DBs at the current schema version
+// skip all that — so if any schema object goes missing after the fact
+// (restore from a partial dump, manual DROP, an aborted beta build), the
+// version gate lets the drift ride until somebody notices the symptom.
+// Observed 2026-04: a vault at v21 had the log_entries FTS sync triggers
+// silently dropped, so 141k log entries piled up with an empty FTS index
+// and search returned zero hits.
+//
+// Rather than proliferate one reconcile-X helper per schema-object class
+// (triggers, indexes, tables, FTS virtual tables), this reapplies ALL
+// current-schema DDL on every createSchema() call. Every CREATE uses
+// IF NOT EXISTS, so replay is idempotent and costs microseconds. The
+// only non-DDL step is rebuilding an FTS index when its sync trigger
+// was just reinstalled — the DDL reinstalls the trigger but doesn't
+// repopulate writes it missed while absent.
+//
+// Known gap: column drift (someone dropping a column) is not covered —
+// SQLite's ALTER TABLE ADD COLUMN isn't IF NOT EXISTS-aware, and today's
+// migrations don't re-run past ALTERs either. We haven't seen this in
+// the wild; defer until we do.
+// ---------------------------------------------------------------------------
+
+interface FtsTriggerGroup {
+  ftsTable: string;
+  baseTable: string;
+  triggers: readonly string[];
+}
+
+const FTS_TRIGGER_GROUPS: readonly FtsTriggerGroup[] = [
+  { ftsTable: 'log_entries_fts',    baseTable: 'log_entries',    triggers: ['log_entries_ai', 'log_entries_ad'] },
+  { ftsTable: 'prompt_batches_fts', baseTable: 'prompt_batches', triggers: ['prompt_batches_fts_ai', 'prompt_batches_fts_au', 'prompt_batches_fts_ad'] },
+  { ftsTable: 'activities_fts',     baseTable: 'activities',     triggers: ['activities_fts_ai', 'activities_fts_au', 'activities_fts_ad'] },
+  { ftsTable: 'spores_fts',         baseTable: 'spores',         triggers: ['spores_fts_ai', 'spores_fts_au', 'spores_fts_ad'] },
+  { ftsTable: 'sessions_fts',       baseTable: 'sessions',       triggers: ['sessions_fts_ai', 'sessions_fts_au', 'sessions_fts_ad'] },
+];
+
+function reapplyCurrentSchemaDdl(db: Database): void {
+  const triggersBefore = new Set(
+    (db.prepare("SELECT name FROM sqlite_master WHERE type = 'trigger'").all() as Array<{ name: string }>)
+      .map((row) => row.name),
+  );
+
+  for (const ddl of TABLE_DDLS) { db.exec(ddl); }
+  for (const ddl of FTS_TABLES) { db.exec(ddl); }
+  for (const idx of SECONDARY_INDEXES) { db.exec(idx); }
+
+  let rebuiltAny = false;
+  for (const group of FTS_TRIGGER_GROUPS) {
+    const wasMissing = group.triggers.some((name) => !triggersBefore.has(name));
+    if (!wasMissing) continue;
+    const baseCount = (db.prepare(`SELECT COUNT(*) AS n FROM ${group.baseTable}`).get() as { n: number }).n;
+    if (baseCount === 0) continue;
+    db.prepare(`INSERT INTO ${group.ftsTable}(${group.ftsTable}) VALUES('rebuild')`).run();
+    rebuiltAny = true;
+  }
+
+  if (rebuiltAny) {
+    process.stderr.write('[schema] Rebuilt one or more FTS indexes after detecting missing sync triggers\n');
+  }
 }

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -889,6 +889,96 @@ describe('runAgent', () => {
     expect(run!.completed_at).toBeGreaterThan(0);
   });
 
+  it('terminal-marks a resume attempt whose SDK session has expired so it stops re-enqueueing', async () => {
+    // Regression for issue #118: when the Claude SDK subprocess exits 1
+    // because its session TTLed out, runAgent's catch was re-flagging the
+    // run as resumable=1/ready, so the scheduler would pick it up every
+    // tick and loop forever. The expired-session detector should redirect
+    // to resumable=0/session_expired and null the checkpoint.
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    const existingRunId = crypto.randomUUID();
+    insertRun({
+      id: existingRunId,
+      agent_id: TEST_AGENT_ID,
+      task: TEST_TASK_NAME,
+      status: 'failed',
+      runtime: 'claude-sdk',
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      resumable: 1,
+      resume_status: 'ready',
+      session_ref: 'stale-session-id',
+      checkpoints: JSON.stringify({
+        runtime: 'claude-sdk',
+        sessionRef: 'stale-session-id',
+        phases: {},
+      }),
+      started_at: epochSeconds() - 600,
+      completed_at: epochSeconds() - 300,
+      error: 'Claude Code process exited with code 1',
+    });
+
+    mockQueryBehavior = 'error';
+    mockErrorMessage = 'Claude Code process exited with code 1';
+
+    const result = await runAgent(TEST_VAULT_DIR, {
+      task: TEST_TASK_NAME,
+      resumeRunId: existingRunId,
+      resumeMode: 'scheduled',
+    });
+
+    expect(result.status).toBe('failed');
+    const run = getRun(existingRunId);
+    expect(run).not.toBeNull();
+    expect(run!.resumable).toBe(0);
+    expect(run!.resume_status).toBe('session_expired');
+    expect(run!.checkpoints).toBeNull();
+  });
+
+  it('leaves non-expired resume failures as resumable=ready', async () => {
+    // Counterpart to the session-expired test — a garden-variety SDK crash
+    // on resume should still be retryable. Otherwise one bad run would
+    // become permanently abandoned on a transient failure.
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    const existingRunId = crypto.randomUUID();
+    insertRun({
+      id: existingRunId,
+      agent_id: TEST_AGENT_ID,
+      task: TEST_TASK_NAME,
+      status: 'failed',
+      runtime: 'claude-sdk',
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      resumable: 1,
+      resume_status: 'ready',
+      session_ref: 'session-id',
+      checkpoints: JSON.stringify({
+        runtime: 'claude-sdk',
+        sessionRef: 'session-id',
+        phases: {},
+      }),
+      started_at: epochSeconds() - 120,
+      completed_at: epochSeconds() - 60,
+      error: 'boom',
+    });
+
+    mockQueryBehavior = 'error';
+    mockErrorMessage = 'Upstream 500 from model provider';
+
+    const result = await runAgent(TEST_VAULT_DIR, {
+      task: TEST_TASK_NAME,
+      resumeRunId: existingRunId,
+      resumeMode: 'scheduled',
+    });
+
+    expect(result.status).toBe('failed');
+    const run = getRun(existingRunId);
+    expect(run!.resumable).toBe(1);
+    expect(run!.resume_status).toBe('ready');
+  });
+
   it('resets started_at to the resume attempt time when resuming a failed run', async () => {
     const { runAgent } = await import('@myco/agent/executor.js');
 

--- a/tests/agent/orchestrator.test.ts
+++ b/tests/agent/orchestrator.test.ts
@@ -185,6 +185,18 @@ describe('parseOrchestratorPlan', () => {
     expect(plan.reasoning).toMatch(/could not be parsed/i);
   });
 
+  it('surfaces the underlying parser error in the fallback reasoning', () => {
+    // Regression for issue #118 item 2: the catch used to swallow the
+    // parser error, leaving operators with no way to tell whether the
+    // planner produced malformed JSON, wrong shape, or a typo.
+    const phases = [makePhase({ name: 'extract' })];
+    const plan = parseOrchestratorPlan('{"phases": [invalid}', phases);
+    expect(plan.reasoning).toMatch(/could not be parsed/i);
+    // The parenthetical carries the parser's actual complaint — anything
+    // non-empty is fine; we only care that it's no longer swallowed.
+    expect(plan.reasoning).toMatch(/\(.+\)/);
+  });
+
   it('falls back to run-all plan when phases array is missing', () => {
     const response = JSON.stringify({ reasoning: 'all good' }); // no phases field
     const phases = [makePhase({ name: 'extract' })];

--- a/tests/agent/phase-loop.test.ts
+++ b/tests/agent/phase-loop.test.ts
@@ -276,6 +276,29 @@ describe('executeSingleQuery', () => {
     const ctx = baseContext();
     await expect(executeSingleQuery(ctx, 'PROMPT')).rejects.toThrow(/sdk_fail/);
   });
+
+  it('retries without sessionRef when the prior session exit-codes out', async () => {
+    // Regression for issue #118 item 1: single-query tasks (title-summary,
+    // review-session) had no retry — an expired Claude SDK session meant
+    // the run looped in the scheduler forever. `isExpiredSessionError`
+    // now matches "exited with code" and the retry path triggers.
+    runtimeSupportsSessionResume = true;
+    runtimeBehaviors = [{ kind: 'error', message: 'Claude Code process exited with code 1' }];
+    const ctx = baseContext();
+    const result = await executeSingleQuery(ctx, 'PROMPT', undefined, 'stale-session');
+    expect(result.tokensUsed).toBe(300);
+    expect(capturedExecuteInputs).toHaveLength(2);
+    expect(capturedExecuteInputs[0].sessionRef).toBe('stale-session');
+    expect(capturedExecuteInputs[1].sessionRef).toBeUndefined();
+  });
+
+  it('does not retry when no sessionRef was supplied', async () => {
+    runtimeSupportsSessionResume = true;
+    runtimeBehaviors = [{ kind: 'error', message: 'Claude Code process exited with code 1' }];
+    const ctx = baseContext();
+    await expect(executeSingleQuery(ctx, 'PROMPT')).rejects.toThrow(/exited with code/);
+    expect(capturedExecuteInputs).toHaveLength(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/agent/runtime-claude.test.ts
+++ b/tests/agent/runtime-claude.test.ts
@@ -187,6 +187,22 @@ describe('ClaudeSdkRuntime.execute', () => {
     expect(scopedServerCalls).toHaveLength(0);
   });
 
+  it('isolates the agent from user settings via settingSources: []', async () => {
+    // Regression: the SDK's plugin-sync path reads `enabledPlugins` from
+    // ~/.claude/settings.json / project .claude/settings.json when
+    // settingSources is unset, and hydrates the "isolated" plugin cache
+    // with every enabled developer plugin (observed 21 plugins leaking
+    // through on a dev machine 2026-04-19). Per the SDK docs:
+    // "When omitted or empty, no filesystem settings are loaded (SDK
+    // isolation mode)."
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    await runtime.execute(makeInput());
+
+    expect(queryCalls[0].options.settingSources).toEqual([]);
+  });
+
   it('passes an empty mcpServers + strictMcpConfig when toolNames is an empty list', async () => {
     // Even when the phase wants no vault tools (e.g., the orchestrator
     // planner with toolNames: []), we MUST still pass strictMcpConfig:
@@ -204,6 +220,27 @@ describe('ClaudeSdkRuntime.execute', () => {
     expect(queryCalls[0].options.strictMcpConfig).toBe(true);
     expect(scopedServerCalls).toHaveLength(0);
     expect(fullServerCalls).toHaveLength(0);
+  });
+
+  it('pre-seeds the isolated plugin cache dir with an empty manifest', async () => {
+    // Regression: CLAUDE_CODE_PLUGIN_CACHE_DIR isolates the directory but
+    // the SDK otherwise populates it from ~/.claude/plugins on first use,
+    // re-introducing user plugins whose tool schemas Anthropic's API
+    // rejects (top-level oneOf/allOf/anyOf). Writing an empty manifest
+    // before the SDK starts short-circuits the sync.
+    const fs = await import('node:fs');
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    await runtime.execute(makeInput());
+
+    const cacheDir = queryCalls[0].options.env as Record<string, string>;
+    const dir = cacheDir.CLAUDE_CODE_PLUGIN_CACHE_DIR;
+    expect(dir).toBeTruthy();
+    const manifestPath = `${dir}/installed_plugins.json`;
+    expect(fs.existsSync(manifestPath)).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    expect(parsed.plugins).toEqual({});
   });
 
   it('aggregates usage from the final result message', async () => {

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -26,6 +26,14 @@ function indexExists(db: Database, indexName: string): boolean {
   return row.cnt > 0;
 }
 
+/** Helper: check if a trigger exists. */
+function triggerExists(db: Database, triggerName: string): boolean {
+  const row = db.prepare(
+    `SELECT count(*) AS cnt FROM sqlite_master WHERE type = 'trigger' AND name = ?`,
+  ).get(triggerName) as { cnt: number };
+  return row.cnt > 0;
+}
+
 describe('Database schema', () => {
   let db: Database;
 
@@ -657,6 +665,88 @@ describe('Database schema', () => {
         expect(indexExists(db, 'idx_graph_edges_target')).toBe(true);
         expect(indexExists(db, 'idx_graph_edges_type')).toBe(true);
         expect(indexExists(db, 'idx_graph_edges_agent')).toBe(true);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Schema-drift reconciliation
+    //
+    // Regression guard for the bug observed 2026-04 on a production vault at
+    // schema v21: the log_entries FTS sync triggers (installed by
+    // migrateV2ToV3) had been lost — likely via restore from a pre-v3 dump —
+    // so 141k log rows existed with an empty FTS index and search returned
+    // zero results. Schema version stayed at SCHEMA_VERSION, so the migration
+    // gate did nothing. createSchema() now replays all current-schema DDL
+    // on every call (CREATE ... IF NOT EXISTS throughout) and rebuilds any
+    // FTS index whose sync trigger was just reinstalled.
+    // -----------------------------------------------------------------------
+    describe('schema-drift reconciliation', () => {
+      it('reinstalls dropped FTS sync triggers on the current-version path', () => {
+        createSchema(db);
+        db.prepare('DROP TRIGGER IF EXISTS log_entries_ai').run();
+        db.prepare('DROP TRIGGER IF EXISTS log_entries_ad').run();
+        expect(triggerExists(db, 'log_entries_ai')).toBe(false);
+        expect(triggerExists(db, 'log_entries_ad')).toBe(false);
+
+        createSchema(db);
+
+        expect(triggerExists(db, 'log_entries_ai')).toBe(true);
+        expect(triggerExists(db, 'log_entries_ad')).toBe(true);
+      });
+
+      it('rebuilds the FTS index when its sync trigger was missing before replay', () => {
+        createSchema(db);
+        db.prepare(
+          `INSERT INTO log_entries (timestamp, level, kind, component, message)
+             VALUES (?, ?, ?, ?, ?)`,
+        ).run(new Date().toISOString(), 'info', 'session.start', 'session', 'searchablexyz');
+        db.prepare('DROP TRIGGER IF EXISTS log_entries_ai').run();
+        db.prepare('DROP TRIGGER IF EXISTS log_entries_ad').run();
+        db.prepare(`INSERT INTO log_entries_fts(log_entries_fts) VALUES('delete-all')`).run();
+
+        const beforeMatch = db.prepare(
+          `SELECT COUNT(*) AS n FROM log_entries_fts WHERE log_entries_fts MATCH ?`,
+        ).get('searchablexyz') as { n: number };
+        expect(beforeMatch.n).toBe(0);
+
+        createSchema(db);
+
+        const afterMatch = db.prepare(
+          `SELECT COUNT(*) AS n FROM log_entries_fts WHERE log_entries_fts MATCH ?`,
+        ).get('searchablexyz') as { n: number };
+        expect(afterMatch.n).toBe(1);
+      });
+
+      it('reinstalls dropped secondary indexes on the current-version path', () => {
+        createSchema(db);
+        expect(indexExists(db, 'idx_log_entries_timestamp')).toBe(true);
+        db.prepare('DROP INDEX idx_log_entries_timestamp').run();
+        expect(indexExists(db, 'idx_log_entries_timestamp')).toBe(false);
+
+        createSchema(db);
+
+        expect(indexExists(db, 'idx_log_entries_timestamp')).toBe(true);
+      });
+
+      it('leaves a healthy DB untouched — no spurious rebuilds or re-creations', () => {
+        createSchema(db);
+        const beforeTriggers = db.prepare(
+          `SELECT name FROM sqlite_master WHERE type = 'trigger' ORDER BY name`,
+        ).all() as Array<{ name: string }>;
+        const beforeIndexes = db.prepare(
+          `SELECT name FROM sqlite_master WHERE type = 'index' AND name NOT LIKE 'sqlite_%' ORDER BY name`,
+        ).all() as Array<{ name: string }>;
+
+        createSchema(db);
+
+        const afterTriggers = db.prepare(
+          `SELECT name FROM sqlite_master WHERE type = 'trigger' ORDER BY name`,
+        ).all() as Array<{ name: string }>;
+        const afterIndexes = db.prepare(
+          `SELECT name FROM sqlite_master WHERE type = 'index' AND name NOT LIKE 'sqlite_%' ORDER BY name`,
+        ).all() as Array<{ name: string }>;
+        expect(afterTriggers).toEqual(beforeTriggers);
+        expect(afterIndexes).toEqual(beforeIndexes);
       });
     });
   });


### PR DESCRIPTION
Closes #118.

Followup work from the silent-failure audit surfaced three concrete bugs beyond the #118 punch list; all are fixed here as seven stacked commits on this branch.

## Summary

- **Zombie resume loop (#118 Item 1)** — a run whose Claude SDK session TTL'd out was being re-flagged `resumable=1/ready` every scheduler tick, accumulating 37 zombies that each cost ~100s of daemon time per retry. Terminal-marks the SDK-exited-with-code-1 case as `resume_status='session_expired'` and adds a single-query retry-without-session fallback so title-summary / review-session can self-heal.
- **Orchestrator + loader silent failures (#118 Item 2)** — malformed planner JSON now surfaces the parser error in the fallback reasoning; malformed `tool_access` JSON logs which agent it came from.
- **Daemon API silent failures (#118 Item 3)** — `/api/providers/test` and `/api/models` now return structured error messages; provider-detection and team-connect failure paths route through `DaemonLogger`.
- **Claude SDK plugin leak (not in #118, discovered mid-session)** — on a dev machine with ~20 Claude Code plugins installed, the SDK was populating the “isolated” plugin cache dir from `~/.claude/plugins/installed_plugins.json` and `enabledPlugins` in `~/.claude/settings.json`, re-introducing every plugin's tools into every agent request. One of them (`myco_save_plan`) ships a top-level `oneOf` schema that Anthropic's API rejects with `400 invalid_request_error: tools.N.custom.input_schema`. Fix: pre-seed the cache dir with an empty manifest **and** pass `settingSources: []` to the SDK (belt-and-suspenders against two separate sync paths).
- **Observability for agent runs** — `console.warn` / `console.error` calls throughout `executor.ts`, `phase-loop.ts`, `orchestrator.ts`, and `runtime/claude.ts` were going to daemon stderr, which on the production daemon is piped to `/dev/null`. Routes phase lifecycle, session retries, token-budget pressure, timeouts, and run failures through a threaded `RunLogger` interface so operators can see what's happening at `debug` level in the existing log viewer. Hot-path fields on `agent.runtime.request` (`mcpToolCount`, `mcpTools`, `pluginCacheDir`) make the next plugin leak visible at glance rather than at token burn.
- **Schema-drift self-healing** — a vault at v21 had the `log_entries_fts` sync triggers silently dropped (pre-v3 dump restore or equivalent), so 141k log rows had an empty FTS index and log search returned zero hits. The version gate kept the migration system from noticing. `createSchema()` now replays all current-schema DDL on every call — `CREATE … IF NOT EXISTS` throughout, idempotent, microseconds — and rebuilds an FTS index when its sync trigger was missing before replay. One consolidated helper instead of per-class reconcile functions.

## Commits

| Commit | Area |
|---|---|
| `dbed5c1b` | Item 1 (zombie loop) + Item 2 + Item 3 + tests |
| `aa86fc14` | Thread `DaemonLogger` into providers/models/run-serializer handlers |
| `6d3d322f` | Claude SDK plugin isolation (`settingSources: []` + pre-seed manifest) + tests |
| `29fd9fc1` | `RunLogger` interface threaded through `RuntimeExecuteInput` + `agent.runtime.request` debug entry |
| `2dfc8974` | Route harness lifecycle signals (`agent.phase.*`, `agent.run.*`, `agent.orchestrator.*`) through `DaemonLogger` |
| `593bdc4c` | `/simplify` pass: consolidate `errorMessage()` helper usage, trim dated comments |
| `9f80d3ea` | Schema-drift self-healing + 4 regression tests |

## Test plan

- [x] 2996 tests pass on the `MYCO_TEST_PROFILE=fast` suite (added 13 new tests — session-expired terminal-mark, single-query retry, orchestrator parse error, plugin isolation, schema-drift reconcile)
- [x] `tsc --noEmit` clean
- [x] `npm run build:core` clean
- [x] Live smoke tested against the dev daemon:
  - Confirmed Ollama/openai-compatible `/api/providers/test` with bogus base URL returns specific message
  - Applied the one-shot SQL trigger reinstall + FTS rebuild to the live vault; search went from 0 hits to 431 on `agent`
  - After daemon restart with the new binary: plugin cache manifest is the pre-seeded 26-byte empty form (was 9426 bytes / 21 leaked plugins), 12 `agent.runtime.request` / 11 `agent.phase.start` entries flowing through the log viewer, `providers.anthropic.models-unavailable` warn routing working

🤖 Generated with [Claude Code](https://claude.com/claude-code)