### PR TITLE
fix(capture): stop opencode events from being silently dropped

### DIFF
--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -450,6 +450,7 @@ export async function runAgent(
       runId,
       runContext: options?.runContext,
       instruction: options?.instruction,
+      dryRun: options?.dryRun,
     });
     const completedAt = epochSeconds();
     updateRunStatus(runId, STATUS_COMPLETED, {
@@ -626,8 +627,10 @@ export async function finalizeOnTaskSuccess(args: {
   runId: string;
   runContext: RunOptions['runContext'];
   instruction?: string;
+  dryRun?: boolean;
 }): Promise<void> {
   if (args.taskName !== CORTEX_INSTRUCTIONS_TASK) return;
+  if (args.dryRun) return;
 
   const reports = listReports(args.runId);
   let report: typeof reports[number] | undefined;

--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -34,7 +34,7 @@ import {
   handleCompact,
 } from './event-handlers.js';
 import { getLatestBatch } from '@myco/db/queries/batches.js';
-import { upsertSession, reactivateSessionIfCompleted } from '@myco/db/queries/sessions.js';
+import { getSession, upsertSession, reactivateSessionIfCompleted } from '@myco/db/queries/sessions.js';
 import { captureBatchImages, type CapturedImage } from './capture-images.js';
 import { DEFAULT_SYMBIONT_NAME, epochSeconds, LOG_PROMPT_PREVIEW_CHARS } from '@myco/constants.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
@@ -154,52 +154,68 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
 
     // Ensure session is registered (idempotent — handles daemon restarts mid-session)
     if (!registry.getSession(event.session_id)) {
-      const cached = droppedSessions.get(event.session_id);
-      const hasTranscriptNow = typeof event.transcript_path === 'string' && event.transcript_path.length > 0;
-      // Re-evaluate when a previously-unattended session newly supplies a
-      // transcript_path — the earlier drop was made without transcript meta.
-      const shouldReevaluate = cached && !cached.hadTranscriptMeta && hasTranscriptNow;
-      if (cached && !shouldReevaluate) {
-        const reason = cached.reason ?? 'rule';
-        logger.debug(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Ignored event for previously-dropped session', {
+      // Rehydrate from SQLite before running capture rules. A session row
+      // means we already admitted this session (on a prior run or earlier in
+      // this run); re-gating it risks applying phantom-detection rules to a
+      // legitimate mid-flight session whose in-memory registry was lost on
+      // daemon restart. The capture gate is for first-sight sessions only.
+      const existingRow = getSession(event.session_id);
+      if (existingRow) {
+        registry.register(event.session_id, { started_at: event.timestamp });
+        logger.info(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Rehydrated registry from DB', {
           session_id: event.session_id,
+          agent: existingRow.agent,
           type: event.type,
-          reason,
         });
-        return { body: { ok: true, ignored: reason } };
-      }
-      if (shouldReevaluate) {
-        droppedSessions.delete(event.session_id);
-      }
-      const { decision, hadTranscriptMeta } = evaluateAutoRegistration(event);
-      if (decision.action === 'drop') {
-        rememberDropped(event.session_id, decision.reason, hadTranscriptMeta);
-        logger.info(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Ignored event that failed session capture rules', {
-          session_id: event.session_id,
-          type: event.type,
-          reason: decision.reason ?? 'rule',
+        reconcileSession(event.session_id);
+      } else {
+        const cached = droppedSessions.get(event.session_id);
+        const hasTranscriptNow = typeof event.transcript_path === 'string' && event.transcript_path.length > 0;
+        // Re-evaluate when a previously-unattended session newly supplies a
+        // transcript_path — the earlier drop was made without transcript meta.
+        const shouldReevaluate = cached && !cached.hadTranscriptMeta && hasTranscriptNow;
+        if (cached && !shouldReevaluate) {
+          const reason = cached.reason ?? 'rule';
+          logger.debug(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Ignored event for previously-dropped session', {
+            session_id: event.session_id,
+            type: event.type,
+            reason,
+          });
+          return { body: { ok: true, ignored: reason } };
+        }
+        if (shouldReevaluate) {
+          droppedSessions.delete(event.session_id);
+        }
+        const { decision, hadTranscriptMeta } = evaluateAutoRegistration(event);
+        if (decision.action === 'drop') {
+          rememberDropped(event.session_id, decision.reason, hadTranscriptMeta);
+          logger.info(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Ignored event that failed session capture rules', {
+            session_id: event.session_id,
+            type: event.type,
+            reason: decision.reason ?? 'rule',
+          });
+          return { body: { ok: true, ignored: decision.reason ?? 'rule' } };
+        }
+
+        registry.register(event.session_id, { started_at: event.timestamp });
+        logger.debug(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Auto-registered session from event', { session_id: event.session_id });
+
+        // Ensure SQLite session exists — explicitly set status='active' so
+        // resumed sessions (previously 'completed') get reopened.
+        const now = epochSeconds();
+        const startedEpoch = Math.floor(new Date(event.timestamp).getTime() / 1000);
+        upsertSession({
+          id: event.session_id,
+          agent: (event as Record<string, unknown>).agent as string ?? DEFAULT_SYMBIONT_NAME,
+          status: 'active',
+          started_at: startedEpoch,
+          created_at: now,
+          machine_id: machineId,
         });
-        return { body: { ok: true, ignored: decision.reason ?? 'rule' } };
+
+        // Reconcile buffer against DB — recover any prompts lost during downtime.
+        reconcileSession(event.session_id);
       }
-
-      registry.register(event.session_id, { started_at: event.timestamp });
-      logger.debug(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Auto-registered session from event', { session_id: event.session_id });
-
-      // Ensure SQLite session exists — explicitly set status='active' so
-      // resumed sessions (previously 'completed') get reopened.
-      const now = epochSeconds();
-      const startedEpoch = Math.floor(new Date(event.timestamp).getTime() / 1000);
-      upsertSession({
-        id: event.session_id,
-        agent: (event as Record<string, unknown>).agent as string ?? DEFAULT_SYMBIONT_NAME,
-        status: 'active',
-        started_at: startedEpoch,
-        created_at: now,
-        machine_id: machineId,
-      });
-
-      // Reconcile buffer against DB — recover any prompts lost during downtime.
-      reconcileSession(event.session_id);
     }
 
     // Persist to disk so events survive daemon restarts

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -511,8 +511,13 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     // that session_id, so at this point we have no session row and no
     // meaningful Stop to process. Silently no-op rather than auto-
     // registering a row we then have nothing to update.
+    //
+    // A DB row for this session means it was previously registered, so the
+    // Stop is legitimate even when the in-memory registry missed it after a
+    // daemon restart — rehydrate before falling through to the phantom drop.
     const existingSessionMeta = registry.getSession(sessionId);
-    if (!hookTranscriptPath && !existingSessionMeta) {
+    const dbSession = existingSessionMeta ? undefined : getSession(sessionId);
+    if (!hookTranscriptPath && !existingSessionMeta && !dbSession) {
       // Info level so `grep hooks.stop` in the default daemon log confirms
       // the ephemeral-sub-invocation drop pattern is firing without
       // needing to crank the log level. Codex's sub-invocation behavior
@@ -527,7 +532,9 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     // Ensure session is registered (handles daemon restarts mid-session)
     if (!existingSessionMeta) {
       registry.register(sessionId, { started_at: new Date().toISOString() });
-      logger.debug(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Auto-registered session from stop event', { session_id: sessionId });
+      logger.debug(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, dbSession
+        ? 'Rehydrated registry from DB on stop event'
+        : 'Auto-registered session from stop event', { session_id: sessionId });
     }
     const sessionMeta = existingSessionMeta ?? registry.getSession(sessionId);
     logger.info(LOG_KINDS.HOOKS_STOP, 'Stop received', {

--- a/packages/myco/src/hooks/capture-rules.ts
+++ b/packages/myco/src/hooks/capture-rules.ts
@@ -21,6 +21,7 @@
 
 import type { CaptureRule, SymbiontManifest } from '../symbionts/manifest-schema.js';
 import { getAtPath } from '../utils/dot-path.js';
+import { DEFAULT_SYMBIONT_NAME } from '../constants.js';
 
 /** Structured context a rule can match against at UserPromptSubmit time. */
 export interface UserPromptRuleContext {
@@ -129,9 +130,21 @@ export function evaluateSessionCaptureRules(
   return evaluateSessionStartRules(manifests, detectedAgent, ctx);
 }
 
+/**
+ * `any_agent` scope lets a manifest's rule fire even when its own agent isn't
+ * the detected one — designed for phantom sub-invocations that arrive with
+ * ambiguous attribution. Detection falls back to `DEFAULT_SYMBIONT_NAME` when
+ * it fails (see normalize.ts and event-dispatch.ts), so `any_agent` only
+ * crosses the agent boundary in that exact case. Events carrying a specific
+ * non-default agent (e.g., plugin-delivered `agent: "opencode"`) are trusted
+ * attribution and must not be touched by another manifest's `any_agent` rules
+ * — otherwise codex's phantom-drop rule contaminates opencode, silently
+ * dropping every event for any opencode session whose registry was lost.
+ */
 function scopePermits(rule: CaptureRule, owningAgent: string, detectedAgent: string): boolean {
-  if (rule.scope === 'any_agent') return true;
-  return owningAgent === detectedAgent;
+  if (owningAgent === detectedAgent) return true;
+  if (rule.scope !== 'any_agent') return false;
+  return detectedAgent === DEFAULT_SYMBIONT_NAME;
 }
 
 function whenMatches(rule: CaptureRule, ctx: UserPromptRuleContext): boolean {

--- a/packages/myco/src/hooks/client.ts
+++ b/packages/myco/src/hooks/client.ts
@@ -42,6 +42,19 @@ async function parseErrorBody(res: Response): Promise<unknown> {
   }
 }
 
+/**
+ * True when the daemon returned 200 but its body carries `{ ignored: reason }`.
+ *
+ * Callers that write to the event buffer on failure also buffer on this
+ * signal — otherwise a capture-rule drop discards events silently even though
+ * the HTTP call "succeeded". reconcileBufferBatches replays on next startup.
+ */
+export function isIgnoredEventResponse(data: unknown): boolean {
+  if (typeof data !== 'object' || data === null) return false;
+  const ignored = (data as Record<string, unknown>).ignored;
+  return typeof ignored === 'string' && ignored.length > 0;
+}
+
 export class DaemonClient {
   private vaultDir: string;
 

--- a/packages/myco/src/hooks/send-event.ts
+++ b/packages/myco/src/hooks/send-event.ts
@@ -6,7 +6,7 @@
  * skeleton so each hook is a one-liner mapping input fields to event fields.
  */
 
-import { DaemonClient } from './client.js';
+import { DaemonClient, isIgnoredEventResponse } from './client.js';
 import { readStdin } from './read-stdin.js';
 import { normalizeHookInput, type NormalizedHookInput } from './normalize.js';
 import { EventBuffer } from '../capture/buffer.js';
@@ -42,7 +42,11 @@ export async function sendEvent(
     const client = new DaemonClient(VAULT_DIR);
     const result = await client.post('/events', { ...eventWithContext, session_id: input.sessionId, agent: input.agent });
 
-    if (!result.ok) {
+    // Two buffer paths: transport failure (daemon unreachable) and server-side
+    // drop (HTTP 200 with `{ ignored: reason }`). The second case catches
+    // capture-rule misfires that would otherwise silently discard live session
+    // events — `reconcileBufferBatches` replays the buffer on next startup.
+    if (!result.ok || isIgnoredEventResponse(result.data)) {
       const buffer = new EventBuffer(path.join(VAULT_DIR, 'buffer'), input.sessionId);
       buffer.append(eventWithContext);
     }

--- a/packages/myco/src/hooks/user-prompt-submit.ts
+++ b/packages/myco/src/hooks/user-prompt-submit.ts
@@ -1,4 +1,4 @@
-import { DaemonClient } from './client.js';
+import { DaemonClient, isIgnoredEventResponse } from './client.js';
 import { readStdin } from './read-stdin.js';
 import { normalizeHookInput } from './normalize.js';
 import { evaluateUserPromptRules } from './capture-rules.js';
@@ -63,8 +63,10 @@ export async function main() {
       transcript_path: input.transcriptPath,
     });
 
-    if (!eventResult.ok) {
-      // Daemon still unreachable — write directly to buffer for later processing
+    // Buffer on transport failure OR server-side drop (200 with `ignored`).
+    // A server-side drop means a capture rule discarded the event; buffering
+    // it lets reconcileBufferBatches recover the prompt once the rule is fixed.
+    if (!eventResult.ok || isIgnoredEventResponse(eventResult.data)) {
       const buffer = new EventBuffer(path.join(VAULT_DIR, 'buffer'), sessionId);
       buffer.append({ type: 'user_prompt', prompt, transcript_path: input.transcriptPath });
     }

--- a/packages/myco/src/symbionts/templates/opencode/plugin.ts
+++ b/packages/myco/src/symbionts/templates/opencode/plugin.ts
@@ -282,6 +282,16 @@ function bufferEvent(
  * POST a capture event to the daemon with buffer fallback on failure.
  * Used for user_prompt and tool_use events — both are replayed from the
  * buffer by reconcileBufferBatches when the daemon restarts.
+ *
+ * Two failure modes route to the buffer:
+ *   1. Transport failure — HTTP non-200, timeout, network error. `result.ok`
+ *      is false and we buffer exactly as you'd expect.
+ *   2. Server-side drop — HTTP 200 with body `{ ok: true, ignored: reason }`.
+ *      The daemon chose not to persist the event (capture rules, phantom
+ *      detection, etc.), but we've seen rule bugs silently discard entire
+ *      live sessions this way. Treat "ignored" as a drop and buffer it so
+ *      `reconcileBufferBatches` can recover on the next restart once the
+ *      underlying cause is fixed.
  */
 async function postEventWithBuffer(
   directory: string,
@@ -289,9 +299,16 @@ async function postEventWithBuffer(
   event: Record<string, unknown>,
 ): Promise<void> {
   const result = await postJson(directory, "/events", event);
-  if (!result.ok) {
+  if (!result.ok || isIgnoredResponse(result.data)) {
     bufferEvent(directory, sessionId, event);
   }
+}
+
+/** True when the daemon returned 200 but signalled it dropped the event. */
+function isIgnoredResponse(data: unknown): boolean {
+  if (!isRecord(data)) return false;
+  const ignored = data.ignored;
+  return typeof ignored === "string" && ignored.length > 0;
 }
 
 /** Register an opencode session with the daemon. */

--- a/tests/agent/executor-cleanup.test.ts
+++ b/tests/agent/executor-cleanup.test.ts
@@ -222,6 +222,38 @@ describe('finalizeOnTaskSuccess', () => {
     );
   });
 
+  it('does not materialize Cortex instructions for dry runs', async () => {
+    insertRun({
+      id: 'run-cortex-dry',
+      agent_id: DEFAULT_AGENT_ID,
+      task: CORTEX_INSTRUCTIONS_TASK,
+      status: 'completed',
+      started_at: NOW,
+      completed_at: NOW,
+      dryRun: true,
+    });
+    insertReport({
+      run_id: 'run-cortex-dry',
+      agent_id: DEFAULT_AGENT_ID,
+      action: 'cortex_instructions',
+      summary: 'would store new instructions',
+      details: JSON.stringify({
+        content: '## Myco-Enabled Project\n\nDry-run output should not persist.',
+      }),
+      created_at: NOW,
+    });
+
+    await finalizeOnTaskSuccess({
+      taskName: CORTEX_INSTRUCTIONS_TASK,
+      agentId: DEFAULT_AGENT_ID,
+      runId: 'run-cortex-dry',
+      runContext: { cortex_instruction_input_hash: 'hash-cortex-dry' },
+      dryRun: true,
+    });
+
+    expect(getCortexInstructions(DEFAULT_AGENT_ID)).toBeNull();
+  });
+
   it('is a no-op for unrelated tasks', async () => {
     await expect(
       finalizeOnTaskSuccess({

--- a/tests/daemon/event-dispatch.test.ts
+++ b/tests/daemon/event-dispatch.test.ts
@@ -158,4 +158,85 @@ describe('createEventDispatcher', () => {
     fs.rmSync(vaultDir, { recursive: true, force: true });
     fs.rmSync(transcriptDir, { recursive: true, force: true });
   });
+
+  describe('DB-backed registry rehydration after daemon restart', () => {
+    // Regression: an opencode session registered before a daemon restart used
+    // to lose every post-restart event because the in-memory SessionRegistry
+    // was empty and the capture gate then dropped the event as an
+    // ephemeral-sub-invocation (codex's any_agent transcript_path_missing
+    // rule). Events for sessions already persisted in SQLite must bypass the
+    // gate — it's a first-sight filter only.
+
+    it('rehydrates registry from DB and captures an opencode event with no transcript_path', async () => {
+      const { handler, registry, logger, vaultDir } = makeHandler();
+      const sessionId = 'opencode-rehydrate-001';
+
+      // Simulate: session exists in SQLite (registered before daemon restart)
+      // but NOT in the in-memory registry (registry was wiped on restart).
+      const { upsertSession } = await import('@myco/db/queries/sessions.js');
+      upsertSession({
+        id: sessionId,
+        agent: 'opencode',
+        status: 'active',
+        started_at: Math.floor(Date.now() / 1000) - 60,
+        created_at: Math.floor(Date.now() / 1000) - 60,
+        machine_id: 'local',
+      });
+      expect(registry.getSession(sessionId)).toBeUndefined();
+
+      // Opencode events never carry transcript_path. Before the fix this
+      // would get dropped by codex's any_agent rule via the capture gate.
+      const res = await handler({
+        body: {
+          type: 'user_prompt',
+          session_id: sessionId,
+          agent: 'opencode',
+          prompt: 'a real prompt that arrived after the daemon restarted',
+        },
+        query: {},
+        headers: {},
+        params: {},
+        pathname: '/events',
+      });
+
+      expect(res.body).toEqual({ ok: true });
+      expect(registry.getSession(sessionId)).toBeDefined();
+
+      const batches = listBatchesBySession(sessionId);
+      expect(batches).toHaveLength(1);
+      expect(batches[0].user_prompt).toBe('a real prompt that arrived after the daemon restarted');
+
+      logger.close();
+      fs.rmSync(vaultDir, { recursive: true, force: true });
+    });
+
+    it('still gates truly new sessions (no DB row) through capture rules', async () => {
+      const { handler, sessionBuffers, logger, vaultDir } = makeHandler();
+      const sessionId = 'codex-phantom-new-001';
+
+      // First-sight codex event with no transcript_path — the phantom case
+      // the codex manifest rule was written for. Must still drop.
+      const res = await handler({
+        body: {
+          type: 'tool_use',
+          session_id: sessionId,
+          agent: 'codex',
+          tool_name: 'Bash',
+          tool_input: {},
+          output_preview: '',
+        },
+        query: {},
+        headers: {},
+        params: {},
+        pathname: '/events',
+      });
+
+      expect(res.body).toEqual({ ok: true, ignored: 'ephemeral-sub-invocation' });
+      expect(getSession(sessionId)).toBeNull();
+      expect(sessionBuffers.has(sessionId)).toBe(false);
+
+      logger.close();
+      fs.rmSync(vaultDir, { recursive: true, force: true });
+    });
+  });
 });

--- a/tests/hooks/capture-rules.test.ts
+++ b/tests/hooks/capture-rules.test.ts
@@ -132,6 +132,62 @@ describe('evaluateUserPromptRules', () => {
       const result = evaluateUserPromptRules([textRule], 'claude-code', ctx({ prompt: 'hello there' }));
       expect(result).toEqual({ action: 'pass', prompt: 'hello there' });
     });
+
+    describe('any_agent cross-manifest contamination guard', () => {
+      // A codex-owned any_agent rule must not drop events that were explicitly
+      // attributed to a different non-default agent (e.g., opencode). This
+      // regression test locks in the fix for the silent capture-drop bug where
+      // codex's transcript_path_missing any_agent rule was discarding every
+      // opencode event because opencode events legitimately have no
+      // transcript_path.
+      const codexAnyAgentRule = manifestWithRules('codex', [
+        {
+          event: 'user_prompt',
+          scope: 'any_agent',
+          when: { transcript_path_missing: true },
+          action: 'drop',
+          reason: 'ephemeral-sub-invocation',
+          trim: true,
+        },
+      ]);
+
+      it('does NOT fire on an explicit opencode event even when transcript_path is missing', () => {
+        const result = evaluateUserPromptRules([codexAnyAgentRule], 'opencode', ctx({ prompt: 'real user prompt' }));
+        expect(result).toEqual({ action: 'pass', prompt: 'real user prompt' });
+      });
+
+      it('still fires on fallback (claude-code) attribution to catch codex phantoms', () => {
+        const result = evaluateUserPromptRules([codexAnyAgentRule], 'claude-code', ctx({ prompt: 'phantom' }));
+        expect(result).toEqual({ action: 'drop', reason: 'ephemeral-sub-invocation' });
+      });
+
+      it('still fires on codex-attributed events (owning === detected)', () => {
+        const result = evaluateUserPromptRules([codexAnyAgentRule], 'codex', ctx({ prompt: 'phantom' }));
+        expect(result).toEqual({ action: 'drop', reason: 'ephemeral-sub-invocation' });
+      });
+    });
+
+    describe('any_agent cross-manifest contamination guard — session_start rules', () => {
+      const codexSessionStartRule = manifestWithRules('codex', [
+        {
+          event: 'session_start',
+          scope: 'any_agent',
+          when: { transcript_path_missing: true },
+          action: 'drop',
+          reason: 'ephemeral-sub-invocation',
+        },
+      ]);
+
+      it('does NOT fire on opencode session_start without transcript_path', () => {
+        const result = evaluateSessionStartRules([codexSessionStartRule], 'opencode', {});
+        expect(result).toEqual({ action: 'pass' });
+      });
+
+      it('still fires on fallback (claude-code) session_start to catch phantoms', () => {
+        const result = evaluateSessionStartRules([codexSessionStartRule], 'claude-code', {});
+        expect(result).toEqual({ action: 'drop', reason: 'ephemeral-sub-invocation' });
+      });
+    });
   });
 
   describe('rewrite_prompt action (reserved for future structural upgrade)', () => {

--- a/tests/hooks/client.test.ts
+++ b/tests/hooks/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { DaemonClient } from '@myco/hooks/client';
+import { DaemonClient, isIgnoredEventResponse } from '@myco/hooks/client';
 import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -179,5 +179,29 @@ describe('DaemonClient error-body propagation', () => {
       expect(r.ok).toBe(false);
       expect(r.data).toBeUndefined();
     }
+  });
+});
+
+describe('isIgnoredEventResponse', () => {
+  it('returns true when body carries a non-empty ignored string', () => {
+    expect(isIgnoredEventResponse({ ok: true, ignored: 'ephemeral-sub-invocation' })).toBe(true);
+    expect(isIgnoredEventResponse({ ignored: 'rule' })).toBe(true);
+  });
+
+  it('returns false for happy-path 200 responses with no ignored field', () => {
+    expect(isIgnoredEventResponse({ ok: true })).toBe(false);
+    expect(isIgnoredEventResponse({})).toBe(false);
+  });
+
+  it('returns false for nullish or non-object bodies', () => {
+    expect(isIgnoredEventResponse(undefined)).toBe(false);
+    expect(isIgnoredEventResponse(null)).toBe(false);
+    expect(isIgnoredEventResponse('200 OK')).toBe(false);
+  });
+
+  it('returns false when ignored is present but empty or non-string', () => {
+    expect(isIgnoredEventResponse({ ignored: '' })).toBe(false);
+    expect(isIgnoredEventResponse({ ignored: null })).toBe(false);
+    expect(isIgnoredEventResponse({ ignored: 42 })).toBe(false);
   });
 });

--- a/tests/symbionts/opencode-plugin.test.ts
+++ b/tests/symbionts/opencode-plugin.test.ts
@@ -230,4 +230,89 @@ describe('opencode plugin runtime hooks', () => {
       '## Myco — Project Context (preserved across compaction)\n\nCompaction context',
     ]);
   });
+
+  describe('server-side drop buffering', () => {
+    // Regression: before the fix, the plugin treated HTTP 200 as success
+    // regardless of body. The daemon could return `{ ok: true, ignored: "..."}`
+    // to silently drop events, and the plugin would never route them to the
+    // on-disk buffer. That's how a stale capture rule erased every event of a
+    // live opencode session across a daemon restart. An ignored response must
+    // trigger the same buffer write as a transport failure would.
+
+    function bufferLinesFor(directory: string, sessionId: string): string[] {
+      const bufferPath = path.join(directory, '.myco', 'buffer', `${sessionId}.jsonl`);
+      if (!fs.existsSync(bufferPath)) return [];
+      return fs.readFileSync(bufferPath, 'utf-8').trim().split('\n').filter(Boolean);
+    }
+
+    it('buffers a chat.message event when daemon returns 200 with ignored field', async () => {
+      const directory = createProjectDir();
+      const fetchMock = vi.fn(async () =>
+        new Response(JSON.stringify({ ok: true, ignored: 'ephemeral-sub-invocation' }), { status: 200 }),
+      );
+      globalThis.fetch = fetchMock as typeof fetch;
+
+      const client = { app: { log: vi.fn().mockResolvedValue(undefined) }, session: { messages: vi.fn() } };
+      const plugin = await MycoPlugin({ client, directory, worktree: directory });
+
+      await plugin['chat.message'](
+        { sessionID: 'ses-silent-drop-1' },
+        { parts: [{ type: 'text', text: 'a real user prompt' }] },
+      );
+
+      const lines = bufferLinesFor(directory, 'ses-silent-drop-1');
+      expect(lines).toHaveLength(1);
+      expect(JSON.parse(lines[0])).toMatchObject({
+        type: 'user_prompt',
+        agent: 'opencode',
+        prompt: 'a real user prompt',
+      });
+
+      fs.rmSync(directory, { recursive: true, force: true });
+    });
+
+    it('does NOT buffer when daemon returns 200 without ignored field', async () => {
+      const directory = createProjectDir();
+      const fetchMock = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+      globalThis.fetch = fetchMock as typeof fetch;
+
+      const client = { app: { log: vi.fn().mockResolvedValue(undefined) }, session: { messages: vi.fn() } };
+      const plugin = await MycoPlugin({ client, directory, worktree: directory });
+
+      await plugin['chat.message'](
+        { sessionID: 'ses-silent-drop-2' },
+        { parts: [{ type: 'text', text: 'happy path prompt' }] },
+      );
+
+      expect(bufferLinesFor(directory, 'ses-silent-drop-2')).toEqual([]);
+
+      fs.rmSync(directory, { recursive: true, force: true });
+    });
+
+    it('buffers a tool.execute.after event when daemon returns 200 with ignored', async () => {
+      const directory = createProjectDir();
+      const fetchMock = vi.fn(async () =>
+        new Response(JSON.stringify({ ok: true, ignored: 'rule' }), { status: 200 }),
+      );
+      globalThis.fetch = fetchMock as typeof fetch;
+
+      const client = { app: { log: vi.fn().mockResolvedValue(undefined) }, session: { messages: vi.fn() } };
+      const plugin = await MycoPlugin({ client, directory, worktree: directory });
+
+      await plugin['tool.execute.after'](
+        { sessionID: 'ses-silent-drop-3', tool: 'read', args: { file_path: '/a/b.ts' } },
+        { output: 'file contents', metadata: {} },
+      );
+
+      const lines = bufferLinesFor(directory, 'ses-silent-drop-3');
+      expect(lines).toHaveLength(1);
+      expect(JSON.parse(lines[0])).toMatchObject({
+        type: 'tool_use',
+        agent: 'opencode',
+        tool_name: 'read',
+      });
+
+      fs.rmSync(directory, { recursive: true, force: true });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

A daemon restart mid-session was silently discarding every subsequent event for any in-flight opencode session. Root-caused to three layered defects, any one of which would have prevented the data loss on its own.

## What was happening

1. User's live opencode session `ses_…` was captured normally.
2. Daemon received `SIGTERM` and restarted.
3. In-memory `SessionRegistry` was empty on restart — session identity lost.
4. Next opencode event arrived with `agent: "opencode"` and (by design) no `transcript_path`.
5. The event-dispatcher's capture-rules gate saw the registry miss, ran `evaluateAutoRegistration`, and matched codex's `any_agent` `transcript_path_missing` rule — dropping the event as `ephemeral-sub-invocation`.
6. Daemon returned HTTP 200 `{ ok: true, ignored: "ephemeral-sub-invocation" }`. The plugin saw `res.ok === true` and never buffered.
7. The drop decision was cached; every user prompt, tool call, and stop event for the rest of the daemon's lifetime was ignored without trace.

Live confirmation: one active session showed 7 prompts captured pre-restart and ~30 min of continuous silent drops after. Another showed 1 of 3+ user prompts captured, `response_summary: null`, and a stuck-`active` batch despite the session being marked completed.

## The three fixes

### 1. DB-backed registry rehydration (`event-dispatch.ts`, `stop-processing.ts`)
Capture rules are for first-sight sessions only. If `getSession(event.session_id)` hits in SQLite, the session has been admitted before — rehydrate the in-memory registry and skip the gate. Applied symmetrically on the `/events` dispatch path and the `/events/stop` ephemeral-sub-invocation branch.

### 2. Restrict `any_agent` to the ambiguous case (`capture-rules.ts`)
`scopePermits` now only lets `any_agent` cross the agent boundary when detection fell back to `DEFAULT_SYMBIONT_NAME` — the exact case it was invented for. Codex phantom-detection still works (phantoms arrive with fallback attribution). Opencode events carry explicit `agent: "opencode"` and are no longer touched by codex's drops. No manifest YAML changes needed.

### 3. Buffer on server-side drop (`plugin.ts`, `send-event.ts`, `user-prompt-submit.ts`, `client.ts`)
Extracted `isIgnoredEventResponse` helper in `hooks/client.ts`; callers buffer on `!result.ok || isIgnoredEventResponse(result.data)`. The opencode plugin has its own inlined copy (plugin contract forbids runtime imports). So if a future daemon-side rule change discards live events again, `reconcileBufferBatches` can replay them on next restart.

## Test plan
- [x] `tests/hooks/capture-rules.test.ts` — codex `any_agent` rule does NOT drop opencode events, still drops fallback (phantom) and same-agent events, for both `user_prompt` and `session_start` rules
- [x] `tests/hooks/client.test.ts` — `isIgnoredEventResponse` unit tests covering positive, happy-path, nullish, and malformed cases
- [x] `tests/daemon/event-dispatch.test.ts` — DB-present opencode session event skips the gate and captures; first-sight codex phantom still dropped
- [x] `tests/symbionts/opencode-plugin.test.ts` — `chat.message` and `tool.execute.after` both buffer on 200+ignored; do not buffer on 200 without ignored
- [x] Full `make build`: 3127 tests pass, 0 failures, 0 new TS errors

## Follow-up (not in this PR)
One-off recovery of events already lost from the currently-live `ses_258e75a21ffeN0bRwhZKvGpk3C` session via opencode's export command, now that the bug can no longer re-corrupt new sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)