### PR TITLE
Reduce skill-evolve cost and harden daemon run safety

### DIFF
--- a/.agents/skills/mcp-tool-development-lifecycle/SKILL.md
+++ b/.agents/skills/mcp-tool-development-lifecycle/SKILL.md
@@ -303,6 +303,119 @@ Decide whether new tools belong in local or cloud MCP surface:
 
 5. **Document placement rationale** — explain why tool belongs in its chosen surface.
 
+## Procedure H: Skill Lifecycle Tool Registration Patterns
+
+The skill lifecycle system requires specific MCP tools that follow domain-specific registration patterns:
+
+1. **Register skill candidate management tools**:
+   ```typescript
+   // In tool-definitions.ts
+   export const TOOL_SKILL_CANDIDATES = 'myco_skill_candidates';
+   
+   {
+     name: TOOL_SKILL_CANDIDATES,
+     description: 'Manage skill candidates (identified topics that may become skills). Supports list, get, create, and update actions.',
+     cortex: {
+       guidance: 'Use for candidate discovery, approval workflows, and candidate lifecycle management',
+       priority: 80,
+       requiresTeam: false,
+       requiresCollective: false,
+     },
+     annotations: {
+       readOnlyHint: false,
+       destructiveHint: false,
+       idempotentHint: false,
+       openWorldHint: false,
+     },
+     inputSchema: {
+       type: 'object',
+       properties: {
+         action: {
+           type: 'string',
+           description: 'Action to perform: list, get, create, update, delete'
+         },
+         id: {
+           type: 'string',
+           description: 'Candidate ID (required for get/update)'
+         },
+         topic: {
+           type: 'string',
+           description: 'Skill topic (required for create)'
+         },
+         rationale: {
+           type: 'string',
+           description: 'Why this should be a skill (required for create)'
+         },
+         status: {
+           type: 'string',
+           description: 'Candidate status: identified, dismissed'
+         }
+       },
+       required: ['action']
+     }
+   }
+   ```
+
+2. **Register skill record management tools**:
+   ```typescript
+   export const TOOL_SKILL_RECORDS = 'myco_skill_records';
+   
+   {
+     name: TOOL_SKILL_RECORDS,
+     description: 'Read, update, and delete skill records (materialized skills on disk). Supports list, get, update, and delete actions.',
+     cortex: {
+       guidance: 'Use for skill lifecycle operations — reading existing skills, updating status, managing skill evolution',
+       priority: 80,
+     },
+     inputSchema: {
+       type: 'object',
+       properties: {
+         action: { type: 'string', description: 'Action: list, get, update, delete' },
+         id: { type: 'string', description: 'Skill record ID or name (for get/update/delete)' },
+         status: { type: 'string', description: 'Filter by or new status: active, stale, retired' },
+         generation: { type: 'number', description: 'New generation number (for update)' }
+       },
+       required: ['action']
+     }
+   }
+   ```
+
+3. **Register skill file writing tools**:
+   ```typescript
+   export const TOOL_WRITE_SKILL = 'myco_write_skill';
+   
+   {
+     name: TOOL_WRITE_SKILL,
+     description: 'Write a SKILL.md file to disk and create or update the corresponding skill record and lineage entry.',
+     cortex: {
+       guidance: 'Use when materializing a new skill from approved candidates or updating existing skills',
+       priority: 90,
+     },
+     annotations: {
+       readOnlyHint: false,
+       destructiveHint: false,
+       idempotentHint: false,
+       openWorldHint: false,
+     },
+     inputSchema: {
+       type: 'object',
+       properties: {
+         name: { type: 'string', description: 'Skill directory name (kebab-case, NO colon)' },
+         display_name: { type: 'string', description: 'Human-readable display name' },
+         description: { type: 'string', description: 'Short description of what the skill does' },
+         content: { type: 'string', description: 'Full SKILL.md content in markdown' },
+         rationale: { type: 'string', description: 'Why this skill was created or updated' },
+         candidate_id: { type: 'string', description: 'Candidate ID that prompted this skill creation' }
+       },
+       required: ['name', 'display_name', 'description', 'content']
+     }
+   }
+   ```
+
+4. **Implement domain-specific validation patterns** — skill tools require structural validation (YAML frontmatter, name prefixes, content length limits) that differs from general vault tools.
+
+5. **Test skill workflow integration** — verify tools support the complete skill lifecycle: survey → approve → generate → evolve.
+
 ## Cross-Cutting Gotchas
 
 **Silent parameter drops**: When schema defines a parameter but handler ignores it, agents receive no error — their input is silently dropped. This is the most common drift failure.
@@ -320,3 +433,5 @@ Decide whether new tools belong in local or cloud MCP surface:
 **Handler signature mismatch**: All handlers must accept `(input, client)` parameters. Missing DaemonClient parameter causes registration failures.
 
 **Cross-runtime schema compatibility**: OpenAI strict mode and Zod refinement patterns cause silent registration failures. Use plain JSON Schema types with descriptive documentation instead of complex validation constructs.
+
+**Skill tool registration gaps**: Skill lifecycle operations require complete tool registration (candidates, records, write_skill) — missing any component breaks agent workflows. Always register skill tools as a complete set.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ Myco captures project memory in a local vault and serves it back through context
 - We develop Myco using Myco. The project-local vault lives at `.myco/`.
 - Session data from development sessions is real vault data. Avoid destructive vault operations unless you mean it.
 - After changing hook or daemon code, run `make build` and then `myco-dev restart`. Hooks pick up new code on the next invocation; the daemon does not.
+- In git worktrees, prefer not to restart the daemon. Shared vault capture continuity is more valuable than forcing daemon restarts during isolated testing.
+- If a worktree must restart for debugging, run the local CLI entry (`node packages/myco/dist/src/cli.js restart`) from that worktree; avoid global `myco-dev restart` from worktrees.
 - `make dev-link` creates `myco-dev` and `myco-run` symlinks and writes `.myco/runtime.command`.
 - `make dev-unlink` removes those symlinks and `.myco/runtime.command`.
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 .PHONY: build build-fast build-only build-rebuild rebuild check check-fast test test-fast test-integration lint clean watch install dev-link dev-unlink ui-dev collective-ui-dev daemon-dev dev
 
 build:
-	$(MAKE) -j2 check
+	$(MAKE) check
 	npm run build
 
 build-fast:
-	$(MAKE) -j2 check-fast
+	$(MAKE) check-fast
 	npm run build
 
 build-only:

--- a/packages/myco/src/agent/definitions/tasks/skill-evolve.yaml
+++ b/packages/myco/src/agent/definitions/tasks/skill-evolve.yaml
@@ -9,16 +9,14 @@ agent: myco-agent
 prompt: >-
   Assess and evolve skills that have new knowledge, codebase drift,
   or structural overlap. The instruction contains pre-filtered skills
-  with their content, new spore IDs, and pre-computed similarity
-  analysis; the verify phase fact-checks the broader active skill
-  set against the codebase.
+  with new spore IDs plus pre-computed structural and drift analysis.
 isDefault: false
 reasoningLevel: default
 maxTurns: 72
 timeoutSeconds: 2400
 schedule:
   enabled: false
-  intervalSeconds: 900
+  intervalSeconds: 21600
   runIn:
     - idle
     - sleep
@@ -84,143 +82,12 @@ phases:
     required: true
     readOnly: true
 
-  - name: verify
-    reasoningLevel: default
-    prompt: |
-      Fact-check active skills against the actual codebase. This phase
-      catches silent drift from refactors that didn't produce spores —
-      e.g., a file was renamed, a function was removed, a pattern was
-      replaced — so the spore-driven assessment in the next phase would
-      otherwise leave the skill's stale content in place.
-
-      ## Selection
-
-      List active skills via vault_skill_records (action: list,
-      status: active). Prioritize up to 2 skills with the OLDEST
-      `last_verified_at` in properties (missing/zero counts as oldest,
-      so never-verified skills sort to the front). If fewer than 2
-      active skills exist, verify them all. This watermark is
-      independent of `last_assessed_at` — it rotates verify coverage
-      even when assess never touches the skill, which is the whole
-      point: skills that never get new spores still need to be
-      fact-checked for silent refactor drift. Full rotation time
-      scales with the active skill count divided by 2, so a larger
-      skill inventory naturally stretches the verify cadence.
-
-      Skills flagged by the inventory phase (merge_candidates or
-      narrow_candidates in vault_state:skill-evolve-inventory) can be
-      skipped here — they're already going to be rewritten in act.
-
-      ## Per-skill procedure
-
-      For each selected skill:
-
-      1. Read full content via vault_skill_records (action: get).
-      2. Identify the 3-5 most LOAD-BEARING concrete claims. A claim
-         is load-bearing if the procedure depends on it being true.
-         Examples:
-         - "Edit `packages/myco/src/db/schema.ts`" — path claim
-         - "Call `setFocusedPanel()`" — identifier claim
-         - "The daemon restarts executor on SIGHUP" — behavior claim
-         Skip generic advice ("use good naming"), tool names that are
-         universal (e.g., `grep`), and illustrative code snippets that
-         aren't literal file content.
-      3. Verify each claim with the cheapest tool that answers it:
-         - **Path claim** → fs_read with a narrow line window (e.g.,
-           start_line=1, end_line=30). ENOENT or unrelated content =
-           MISSING/OUTDATED. For a DIRECTORY path, use fs_list or
-           fs_tree instead — fs_read on a directory returns an error
-           and burns a turn.
-         - **Identifier claim** → code_grep for the symbol with a
-           path+glob filter. Zero hits in expected location = MISSING.
-         - **Behavior claim** → code_grep for signature patterns that
-           would implement it. Zero hits = MISSING.
-
-         HARD LIMIT: **at most 2 tool calls per claim**, and **at most
-         4 claims per skill**, so ~8 filesystem calls per skill
-         absolute maximum. If your first grep returns too many hits
-         or the wrong ones, DO NOT refine and retry — accept
-         INCONCLUSIVE and move on. Exploratory refinement is exactly
-         how this phase burned through budget on earlier runs.
-
-      4. Categorize each claim: VERIFIED / MISSING / OUTDATED /
-         INCONCLUSIVE. INCONCLUSIVE is fine when the claim is too
-         fuzzy to verify cheaply — don't burn turns on it.
-
-      5. Aggregate for the skill:
-         - confidence: high (>=80% verified), medium, or low
-         - severity: none / minor (1 cosmetic miss) / major
-           (load-bearing miss) / critical (most refs gone)
-
-      6. Update the skill's verify watermark REGARDLESS of severity —
-         skipping this step on severity=none would make verify re-pick
-         the same skill forever. Example call:
-
-           vault_skill_records({
-             action: "update",
-             id: "<the-skill-uuid>",
-             properties: "{\"last_verified_at\": 1776580022}"
-           })
-
-         `properties` is a JSON string, merged into the skill's existing
-         properties. Any recent epoch-seconds integer works as the
-         timestamp — this is a rotation cursor, not an audit timestamp.
-
-      ## Budget discipline
-
-      Total budget for this phase: {{max_turns}} turns covering ALL
-      selected skills combined. Plan per-skill budget as roughly
-      `{{max_turns}} / skills_selected` turns. Recommended shape:
-      1 content read + up to 4 claim checks × up to 2 tool calls +
-      1 watermark write. Stop verifying a skill as soon as severity
-      is clear — finding one MISSING load-bearing claim is enough
-      to flag the skill; don't check remaining claims.
-
-      Prefer narrow fs_read windows (start/end lines) over whole-file
-      reads. Prefer code_grep with a path/glob filter over an open grep.
-      When a tool returns "Not a file" or zero matches, accept that
-      answer and move on — do not retry with adjusted args.
-
-      Tools available for this phase: {{phase_tools}}.
-
-      ## Store results
-
-      Store via vault_set_state (key: skill-evolve-drift) as JSON:
-      {
-        "verified_at": <epoch-seconds>,
-        "reports": [
-          {
-            "skill_id": "...",
-            "name": "...",
-            "severity": "none|minor|major|critical",
-            "confidence": "high|medium|low",
-            "notes": "Short: what's missing or outdated.",
-            "load_bearing_misses": ["claim 1", "claim 2"]
-          }
-        ]
-      }
-
-      Report via vault_report. If no active skills are selectable
-      (e.g., all were flagged by inventory for merge), store an empty
-      reports array and report skip.
-    tools:
-      - vault_skill_records
-      - vault_set_state
-      - vault_report
-      - fs_read
-      - fs_list
-      - code_grep
-    maxTurns: 24
-    required: true
-    dependsOn:
-      - inventory
-
   - name: assess
-    reasoningLevel: default
+    reasoningLevel: low
     prompt: |
       Read two pre-computed inputs from vault_state:
         - key: skill-evolve-inventory (merge/narrow candidates)
-        - key: skill-evolve-drift (codebase verification reports)
+        - key: skill-evolve-drift (mechanical drift + growth reports)
 
       There are THREE sources of skills to assess:
 
@@ -244,20 +111,30 @@ phases:
       2. Verify the inventory's merge/narrow recommendation by
          reading both skills' content.
 
-      **C. Drift-flagged skills** — reports from the verify phase with
+      **C. Drift-flagged skills** — reports from the mechanical pass with
       severity of `minor`, `major`, or `critical`. These may NOT appear
       in the instruction (no new spores) but need attention because
       their content no longer matches the codebase. For each drift
       report not already covered above:
       1. Read the skill's content via vault_skill_records (action: get).
-      2. Trust the verify phase's load_bearing_misses as the STALE
-         detail set. You do NOT need to re-run fs_read/code_grep —
-         the verify phase already did that work. Only re-check if
-         the verify report's confidence is low.
+      2. Trust `load_bearing_misses` as the STALE detail set.
+         Re-check with fs_read/code_grep ONLY if confidence is low
+         OR a claim is inconclusive.
       3. Major/critical severity with confidence high/medium should
          classify as STALE (or DEPRECATED if the entire subsystem
          described is gone). Minor severity may stay CURRENT unless
          combined with new-spore evidence.
+
+      **D. Growth-flagged skills** — reports with non-empty `growth`
+      where referenced TS files gained new exports since the skill's
+      stored fingerprint baseline. For each growth report not already
+      covered above:
+      1. Read the skill's content via vault_skill_records (action: get).
+      2. For each growth claim, run at most one targeted fs_read or
+         code_grep call to decide if the new export is relevant to the
+         skill's domain.
+      3. If relevant, classify STALE and include details. If not
+         relevant, keep CURRENT and explain why.
 
       For ALL skills from all three sources, classify with one of:
          - CURRENT — still accurate, no changes needed.
@@ -285,7 +162,8 @@ phases:
          vault_skill_records (action: update, id: <skill_id>,
          properties: '{"last_assessed_at": <now>,
          "knowledge_watermark": <now>,
-         "last_classification": "<classification>"}')
+         "last_classification": "<classification>",
+         "file_fingerprints": {...latest_report.current_fingerprints...}}')
 
       6. Store classifications via vault_set_state
          (key: skill-evolve-classifications) as JSON:
@@ -296,21 +174,31 @@ phases:
 
       Report via vault_report.
 
-      If the instruction says "No skills need assessment" AND the
-      inventory has no merge/narrow candidates AND the drift report
-      has no minor+ severity entries, report skip via vault_report
-      and finish.
+      ## Budget discipline
+
+      Total budget for this phase: {{max_turns}} turns.
+      Tools available for this phase: {{phase_tools}}.
+      Spread budget across all flagged skills from A/B/C/D.
+      Plan per-skill budget roughly as `{{max_turns}} / skills_selected`
+      where skills_selected is the number of unique skills surfaced by
+      the pre-computed reports.
+
+      Hard limits:
+      - At most 2 tool calls per inconclusive or growth claim.
+      - Do not rerun broad exploration if a targeted check already
+        answers the classification decision.
     tools:
       - vault_spores
       - vault_search_fts
       - vault_skill_records
       - vault_set_state
       - vault_report
-    maxTurns: 18
+      - fs_read
+      - code_grep
+    maxTurns: 10
     required: true
     dependsOn:
       - inventory
-      - verify
 
   - name: act
     reasoningLevel: low

--- a/packages/myco/src/agent/definitions/tasks/skill-evolve.yaml
+++ b/packages/myco/src/agent/definitions/tasks/skill-evolve.yaml
@@ -78,12 +78,13 @@ phases:
       ## Output discipline
 
       Keep responses terse. No narrative explanations.
-      Prefer tool calls and short machine-readable summaries.
-      Final phase summary must be <= 4 lines.
+      Do not provide analytical prose, rationale paragraphs, or
+      walkthrough text outside tool payloads.
+      Final phase summary must be <= 2 lines.
       Required output shape:
       - One `vault_set_state` call with merge/narrow arrays.
       - One `vault_report` call with counts.
-      - Final assistant text <= 3 lines, no explanatory prose.
+      - Final assistant text <= 2 lines, no explanatory prose.
     tools:
       - vault_skill_records
       - vault_set_state

--- a/packages/myco/src/agent/definitions/tasks/skill-evolve.yaml
+++ b/packages/myco/src/agent/definitions/tasks/skill-evolve.yaml
@@ -74,6 +74,16 @@ phases:
 
       If the instruction says "No skills need assessment", report
       skip via vault_report and finish.
+
+      ## Output discipline
+
+      Keep responses terse. No narrative explanations.
+      Prefer tool calls and short machine-readable summaries.
+      Final phase summary must be <= 4 lines.
+      Required output shape:
+      - One `vault_set_state` call with merge/narrow arrays.
+      - One `vault_report` call with counts.
+      - Final assistant text <= 3 lines, no explanatory prose.
     tools:
       - vault_skill_records
       - vault_set_state
@@ -83,8 +93,18 @@ phases:
     readOnly: true
 
   - name: assess
-    reasoningLevel: low
+    reasoningLevel: default
     prompt: |
+      ## Scope boundary (critical)
+
+      Mechanical drift signals are TRIAGE only. They are cheap hints,
+      not source-of-truth code understanding.
+      - Use pre-computed drift/growth signals to decide where to look.
+      - Use agent exploration tools (vault_search_fts, fs_read, code_grep)
+        for final judgment on whether content is truly stale/current.
+      - Do NOT treat a single heuristic miss as authoritative when
+        surrounding evidence indicates the skill is still accurate.
+
       Read two pre-computed inputs from vault_state:
         - key: skill-evolve-inventory (merge/narrow candidates)
         - key: skill-evolve-drift (mechanical drift + growth reports)
@@ -120,10 +140,29 @@ phases:
       2. Trust `load_bearing_misses` as the STALE detail set.
          Re-check with fs_read/code_grep ONLY if confidence is low
          OR a claim is inconclusive.
+      2b. If a mechanical miss appears to be a heuristic artifact
+          (generic token, path-shape ambiguity, parser limitation),
+          classify conservatively and explain the uncertainty.
       3. Major/critical severity with confidence high/medium should
          classify as STALE (or DEPRECATED if the entire subsystem
          described is gone). Minor severity may stay CURRENT unless
          combined with new-spore evidence.
+
+      ## Drift classification threshold tuning
+
+      For drift-only skills (no meaningful new-spore evidence), use a
+      two-signal rule before STALE:
+      - Signal A: high-confidence mechanical miss
+        (major/critical severity with confidence high/medium), OR
+      - Signal B: targeted exploration confirms the miss affects a
+        load-bearing step in the current skill procedure.
+
+      Classification policy:
+      - STALE when A+B are both true, OR when there are 2+ independent
+        load-bearing misses in different parts of the procedure.
+      - CURRENT when only one weak/unconfirmed drift signal exists.
+      - INCONCLUSIVE behavior: when evidence is mixed, prefer CURRENT
+        with explicit "watch" details over forcing STALE.
 
       **D. Growth-flagged skills** — reports with non-empty `growth`
       where referenced TS files gained new exports since the skill's
@@ -135,6 +174,17 @@ phases:
          skill's domain.
       3. If relevant, classify STALE and include details. If not
          relevant, keep CURRENT and explain why.
+
+      ## Per-run scope cap
+
+      Assess at most 3 unique skills per run total across A/B/C/D.
+      Prioritize in this order:
+      1) Skills with new knowledge + high-confidence drift
+      2) Skills with new knowledge only
+      3) Drift-only skills with major/critical severity
+      4) Remaining drift/growth-only skills
+      Any remaining candidates must be deferred and listed in
+      vault_report details under `deferred_skills`.
 
       For ALL skills from all three sources, classify with one of:
          - CURRENT — still accurate, no changes needed.
@@ -157,6 +207,8 @@ phases:
          losing detail. Do NOT bias toward CURRENT when a drift report
          flags load-bearing misses with high confidence — that's
          exactly the refactor-drift case this pipeline exists to catch.
+         For drift-only cases with weak evidence, bias toward CURRENT
+         and carry forward actionable watch notes.
 
       5. Update the skill's properties with the new watermark:
          vault_skill_records (action: update, id: <skill_id>,
@@ -187,6 +239,28 @@ phases:
       - At most 2 tool calls per inconclusive or growth claim.
       - Do not rerun broad exploration if a targeted check already
         answers the classification decision.
+      - Mechanical triage should narrow search scope, not replace
+        repository exploration when a real decision is required.
+
+      Per-skill stop conditions:
+      - For drift-only skills, perform at most 1 targeted re-check
+        unless evidence directly conflicts.
+      - If classification reaches confidence threshold, stop tool calls
+        for that skill immediately.
+      - If still ambiguous after the allowed check, classify CURRENT
+        with explicit watch notes (do not continue probing).
+
+      ## Output discipline
+
+      Keep responses terse. No long prose or per-skill essays.
+      Store details in vault_set_state payloads, not in narrative text.
+      Final phase summary must be <= 6 lines.
+      Required output shape for this phase:
+      1. One `vault_set_state` write containing the complete
+         `skill-evolve-classifications` payload for all assessed skills.
+      2. One `vault_report` call with aggregate counts and any deferred/watch
+         notes.
+      3. Final assistant text <= 4 lines, no narrative walkthrough.
     tools:
       - vault_spores
       - vault_search_fts
@@ -256,11 +330,24 @@ phases:
 
       - Process MERGE/NARROW actions AFTER STALE updates, so you're
         merging already-refreshed content.
+      - Cost/quality guardrail: process at most 3 STALE updates per run.
+        If more than 3 are classified STALE, process the top 3 by impact
+        (critical drift > major drift > both drift+new knowledge > new knowledge only),
+        report deferred skill names via vault_report, and leave their
+        classifications in state for a future run.
       - If vault_write_skill rejects a merge (e.g., dedup gate trips),
         check the error and adjust content. If truly blocked, skip
         and report the issue.
 
       Report all actions via vault_report.
+
+      ## Output discipline
+
+      Keep responses terse. Avoid narrative writeups.
+      Final phase summary must be <= 5 lines plus deferred-skill list.
+      Required output shape:
+      - One `vault_report` with executed/deferred counts.
+      - Final assistant text <= 3 lines.
     tools:
       - vault_write_skill
       - vault_skill_records

--- a/packages/myco/src/agent/instruction-builders.ts
+++ b/packages/myco/src/agent/instruction-builders.ts
@@ -17,12 +17,13 @@ import { listCandidates } from '@myco/db/queries/skill-candidates.js';
 import { buildScheduledCortexInstruction } from '@myco/context/cortex-brief.js';
 import { countSpores, getSpore, listSpores } from '@myco/db/queries/spores.js';
 import { countSessions, getSession, listSessions } from '@myco/db/queries/sessions.js';
-import { listSkillRecords } from '@myco/db/queries/skill-records.js';
+import { listSkillRecords, updateSkillRecord } from '@myco/db/queries/skill-records.js';
 import { listLineageForSkill } from '@myco/db/queries/skill-lineage.js';
 import { listDigestExtracts } from '@myco/db/queries/digest-extracts.js';
 import { getState, setState } from '@myco/db/queries/agent-state.js';
 import { epochSeconds } from '@myco/constants.js';
 import { shortlistSemanticIds, type SemanticShortlistProvider } from '@myco/agent/semantic-shortlist.js';
+import { detectDrift, type SkillFileFingerprint } from '@myco/agent/skill-drift.js';
 import {
   descriptionSimilarity,
   DESCRIPTION_DUPLICATE_THRESHOLD,
@@ -341,6 +342,12 @@ interface SkillStructure {
   narrow: boolean;
 }
 
+interface SemanticPair {
+  idA: string;
+  idB: string;
+  similarity: number;
+}
+
 function normalizeSkillName(name: string): string {
   return name.replace(/[-_:]+/g, ' ');
 }
@@ -465,6 +472,28 @@ function headingOverlap(
   return { score: smaller > 0 ? shared.length / smaller : 0, shared };
 }
 
+function parseSkillProperties(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw || '{}');
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function selectOutlierPairs(
+  pairs: SemanticPair[],
+  opts: { kSigma: number; minSamples: number },
+): SemanticPair[] {
+  if (pairs.length < opts.minSamples) return [];
+  const values = pairs.map(p => p.similarity);
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  const variance = values.reduce((sum, value) => sum + ((value - mean) ** 2), 0) / values.length;
+  const stddev = Math.sqrt(variance);
+  const cutoff = mean + (opts.kSigma * stddev);
+  return pairs.filter(pair => pair.similarity > cutoff);
+}
+
 /**
  * Build the instruction for a skill-evolve run.
  *
@@ -490,7 +519,7 @@ export async function buildSkillEvolveInstruction(
   params?: Record<string, string | number | boolean>,
   projectRoot?: string,
   retrievalProvider?: SemanticSearchProvider,
-): Promise<string> {
+): Promise<string | undefined> {
   const assessIntervalHours = Number(params?.assess_interval_hours ?? SKILL_EVOLVE_DEFAULT_ASSESS_INTERVAL_HOURS);
   const maxSkillsPerRun = Number(params?.max_skills_per_run ?? SKILL_EVOLVE_DEFAULT_MAX_SKILLS_PER_RUN);
 
@@ -529,62 +558,128 @@ export async function buildSkillEvolveInstruction(
   needsAssessment.sort((a, b) => a.lastAssessedAt - b.lastAssessedAt);
   const selectedSkills = needsAssessment.slice(0, maxSkillsPerRun);
 
-  if (selectedSkills.length === 0) {
-    return 'No skills need assessment. All active skills are current or were recently assessed. Report skip via vault_report and finish.';
-  }
-
   // ----- Structural analysis: section counts + heading extraction -----
   // Read each skill's content from disk and extract H2 headings.
   // This gives the inventory phase mechanical signals for narrow/merge
   // detection that don't depend on LLM judgment.
   const structures: SkillStructure[] = [];
   const skillHeadings = new Map<string, string[]>();
-  for (const skill of allSkills) {
-    let content = '';
-    if (projectRoot && skill.path) {
-      try { content = readFileSync(resolve(projectRoot, skill.path), 'utf-8'); } catch { /* missing */ }
+  if (projectRoot) {
+    for (const skill of allSkills) {
+      let content = '';
+      if (skill.path) {
+        try { content = readFileSync(resolve(projectRoot, skill.path), 'utf-8'); } catch { /* missing */ }
+      }
+      const headings = extractHeadings(content);
+      skillHeadings.set(skill.name, headings);
+      structures.push({
+        name: skill.name,
+        sectionCount: headings.length,
+        headings,
+        narrow: headings.length < MIN_SECTIONS_FOR_STANDALONE,
+      });
     }
-    const headings = extractHeadings(content);
-    skillHeadings.set(skill.name, headings);
-    structures.push({
-      name: skill.name,
-      sectionCount: headings.length,
-      headings,
-      narrow: headings.length < MIN_SECTIONS_FOR_STANDALONE,
-    });
   }
 
   // ----- Pairwise similarity: description + heading overlap -----
   // Runs after the early-exit so we don't compute O(n²) scores for no-op runs.
   const overlaps: SkillOverlapPair[] = [];
-  for (let i = 0; i < allSkills.length; i++) {
-    for (let j = i + 1; j < allSkills.length; j++) {
-      const a = allSkills[i];
-      const b = allSkills[j];
-      const descJaccard = descriptionSimilarity(a.description, b.description);
-      const aHeadings = skillHeadings.get(a.name) ?? [];
-      const bHeadings = skillHeadings.get(b.name) ?? [];
-      const ho = headingOverlap(aHeadings, bHeadings);
+  if (projectRoot) {
+    for (let i = 0; i < allSkills.length; i++) {
+      for (let j = i + 1; j < allSkills.length; j++) {
+        const a = allSkills[i];
+        const b = allSkills[j];
+        const descJaccard = descriptionSimilarity(a.description, b.description);
+        const aHeadings = skillHeadings.get(a.name) ?? [];
+        const bHeadings = skillHeadings.get(b.name) ?? [];
+        const ho = headingOverlap(aHeadings, bHeadings);
 
-      // Flag if EITHER description similarity OR heading overlap is significant
-      const descFlag = descJaccard >= DESCRIPTION_DUPLICATE_THRESHOLD * 0.75;
-      const headingFlag = ho.score >= 0.4;
-      if (!descFlag && !headingFlag) continue;
+        // Flag if EITHER description similarity OR heading overlap is significant
+        const descFlag = descJaccard >= DESCRIPTION_DUPLICATE_THRESHOLD * 0.75;
+        const headingFlag = ho.score >= 0.4;
+        if (!descFlag && !headingFlag) continue;
 
-      const verdict = (descJaccard >= DESCRIPTION_DUPLICATE_THRESHOLD || ho.score >= 0.5)
-        ? 'potential-merge'
-        : 'potential-narrow';
+        const verdict = (descJaccard >= DESCRIPTION_DUPLICATE_THRESHOLD || ho.score >= 0.5)
+          ? 'potential-merge'
+          : 'potential-narrow';
 
-      overlaps.push({
-        skillA: a.name,
-        skillB: b.name,
-        descriptionJaccard: Math.round(descJaccard * 100) / 100,
-        headingOverlap: Math.round(ho.score * 100) / 100,
-        sharedHeadings: ho.shared,
-        verdict,
-      });
+        overlaps.push({
+          skillA: a.name,
+          skillB: b.name,
+          descriptionJaccard: Math.round(descJaccard * 100) / 100,
+          headingOverlap: Math.round(ho.score * 100) / 100,
+          sharedHeadings: ho.shared,
+          verdict,
+        });
+      }
     }
   }
+
+  const narrowSkills = structures.filter(s => s.narrow);
+
+  const nowEpoch = epochSeconds();
+  const oldestForVerify = [...allSkills]
+    .sort((a, b) => {
+      const propsA = parseSkillProperties(a.properties);
+      const propsB = parseSkillProperties(b.properties);
+      const tsA = typeof propsA.last_verified_at === 'number' ? propsA.last_verified_at : 0;
+      const tsB = typeof propsB.last_verified_at === 'number' ? propsB.last_verified_at : 0;
+      return tsA - tsB;
+    })
+    .slice(0, 5);
+  const drift = projectRoot
+    ? detectDrift(oldestForVerify, projectRoot, nowEpoch)
+    : {
+        verifiedAt: nowEpoch,
+        reports: [],
+        totalMissing: 0,
+        totalInconclusive: 0,
+        totalGrowth: 0,
+      };
+
+  for (const skill of oldestForVerify) {
+    const report = drift.reports.find(r => r.skillId === skill.id);
+    const props = parseSkillProperties(skill.properties);
+    const mergedFingerprints: Record<string, SkillFileFingerprint> = {
+      ...(props.file_fingerprints && typeof props.file_fingerprints === 'object'
+        ? props.file_fingerprints as Record<string, SkillFileFingerprint>
+        : {}),
+    };
+
+    if (report) {
+      for (const [path, fingerprint] of Object.entries(report.currentFingerprints)) {
+        if (!mergedFingerprints[path]) {
+          mergedFingerprints[path] = fingerprint;
+        }
+      }
+    }
+
+    props.last_verified_at = nowEpoch;
+    props.file_fingerprints = mergedFingerprints;
+    updateSkillRecord(skill.id, {
+      updated_at: nowEpoch,
+      properties: JSON.stringify(props),
+    });
+  }
+
+  let semanticPairs: Array<{ idA: string; idB: string; similarity: number }> = [];
+  if (retrievalProvider && projectRoot) {
+    try {
+      const allPairs = retrievalProvider.pairwiseSimilarity('skill_records', 0);
+      semanticPairs = selectOutlierPairs(allPairs, { kSigma: 2, minSamples: 10 });
+    } catch {
+      semanticPairs = [];
+    }
+  }
+
+  const anyWork = selectedSkills.length > 0
+    || overlaps.length > 0
+    || narrowSkills.length > 0
+    || semanticPairs.length > 0
+    || drift.totalMissing > 0
+    || drift.totalInconclusive > 0
+    || drift.totalGrowth > 0;
+  if (!anyWork) return undefined;
 
   const parts: string[] = [
     `${selectedSkills.length} skill(s) need assessment.`,
@@ -617,7 +712,6 @@ export async function buildSkillEvolveInstruction(
   }
 
   // Mechanically narrow skills — explicit flags for the inventory phase
-  const narrowSkills = structures.filter(s => s.narrow);
   if (narrowSkills.length > 0) {
     parts.push('');
     parts.push('## Mechanically Narrow Skills (<2 H2 sections)');
@@ -644,25 +738,39 @@ export async function buildSkillEvolveInstruction(
   // Semantic similarity from embeddings — strongest signal for overlap detection.
   // Uses cosine similarity on embedded skill descriptions. Catches semantic
   // overlap that token-based methods miss ("adding agent integration" ~= "onboarding a symbiont").
-  if (retrievalProvider) {
+  if (retrievalProvider && projectRoot) {
     // Build a name→id lookup for resolving embedding results
     const idToName = new Map(allSkills.map(s => [s.id, s.name]));
 
-    try {
-      const semanticPairs = retrievalProvider.pairwiseSimilarity('skill_records', 0.65);
-      if (semanticPairs.length > 0) {
-        parts.push('');
-        parts.push('## Semantic Similarity (embedding cosine distance)');
-        parts.push('Pairs with cosine similarity >= 0.65. This is the STRONGEST overlap signal.');
-        parts.push('High similarity (>0.8) means the skills describe nearly identical procedures.');
-        for (const p of semanticPairs) {
-          const nameA = idToName.get(p.idA) ?? p.idA;
-          const nameB = idToName.get(p.idB) ?? p.idB;
-          parts.push(`- **${nameA}** <-> **${nameB}**: cosine=${p.similarity}`);
-        }
+    if (semanticPairs.length > 0) {
+      parts.push('');
+      parts.push('## Semantic Similarity (distribution outliers)');
+      parts.push('Pairs selected by outlier filtering (mu + 2sigma) over this run\'s pairwise distribution.');
+      for (const p of semanticPairs) {
+        const nameA = idToName.get(p.idA) ?? p.idA;
+        const nameB = idToName.get(p.idB) ?? p.idB;
+        parts.push(`- **${nameA}** <-> **${nameB}**: cosine=${p.similarity}`);
       }
-    } catch {
-      // Embeddings not available — fall through to token-based signals only
+    }
+  }
+
+  parts.push('');
+  parts.push('## Pre-computed Drift Report');
+  parts.push(`verified_at: ${drift.verifiedAt}`);
+  parts.push(`totals: missing=${drift.totalMissing}, inconclusive=${drift.totalInconclusive}, growth=${drift.totalGrowth}`);
+  for (const report of drift.reports) {
+    parts.push(`- **${report.name}**: severity=${report.severity}, confidence=${report.confidence}`);
+    if (report.loadBearingMisses.length > 0) {
+      parts.push(`  load_bearing_misses: ${JSON.stringify(report.loadBearingMisses)}`);
+    }
+    if (report.inconclusive.length > 0) {
+      parts.push(`  inconclusive: ${JSON.stringify(report.inconclusive)}`);
+    }
+    if (report.growth.length > 0) {
+      parts.push(`  growth: ${JSON.stringify(report.growth)}`);
+    }
+    if (Object.keys(report.currentFingerprints).length > 0) {
+      parts.push(`  current_fingerprints: ${JSON.stringify(report.currentFingerprints)}`);
     }
   }
 

--- a/packages/myco/src/agent/skill-drift.ts
+++ b/packages/myco/src/agent/skill-drift.ts
@@ -52,30 +52,74 @@ const CLAIM_DENYLIST = new Set([
   'Array',
 ]);
 
+const SEARCHABLE_EXTENSIONS = new Set([
+  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
+  '.py', '.rb', '.go', '.java', '.kt', '.rs',
+  '.php', '.cs', '.cpp', '.c', '.h', '.swift',
+  '.scala', '.lua', '.sh', '.sql', '.yaml', '.yml',
+  '.json', '.toml', '.md',
+]);
+
+const SKIP_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  '.next',
+  '.turbo',
+  '.cache',
+]);
+
+const CONTAINS_PARENS_REGEX = /[()]/;
+const GENERIC_SLASH_WORD_REGEX = /^[a-z]+\/[a-z]+$/i;
+const DOT_TOKEN_REGEX = /^\.[A-Za-z_][A-Za-z0-9_]*$/;
+const DOT_METHOD_CALL_REGEX = /\.[A-Za-z_][A-Za-z0-9_]*\(\)$/;
+const KNOWN_METHOD_SUFFIX_REGEX = /\.(default|min|max|refine)$/;
+const PATH_SEGMENT_ALLOWED_CHARS_REGEX = /^[A-Za-z0-9._\-\/]+$/;
+const FILELIKE_EXTENSION_REGEX = /\.[A-Za-z0-9]{1,8}$/;
+const SYMBOL_TOKEN_REGEX = /^[A-Za-z_][A-Za-z0-9_]*\(\)?$/;
+const UPPER_CAMELISH_REGEX = /[A-Z].*[A-Z]/;
+const NON_ALNUM_SPACE_REGEX = /[^a-z0-9\s]/g;
+const FRONTMATTER_REGEX = /^---[\s\S]*?---\n/;
+const TRIPLE_BACKTICK_BLOCK_REGEX = /```[\s\S]*?```/g;
+const TRIPLE_TILDE_BLOCK_REGEX = /~~~[\s\S]*?~~~/g;
+const BACKTICK_TOKEN_REGEX = /`([^`\n]+)`/g;
+
 function stripFrontmatterAndCodeBlocks(content: string): string {
-  const body = content.replace(/^---[\s\S]*?---\n/, '');
+  const body = content.replace(FRONTMATTER_REGEX, '');
   return body
-    .replace(/```[\s\S]*?```/g, '')
-    .replace(/~~~[\s\S]*?~~~/g, '');
+    .replace(TRIPLE_BACKTICK_BLOCK_REGEX, '')
+    .replace(TRIPLE_TILDE_BLOCK_REGEX, '');
 }
 
 function isPathToken(token: string): boolean {
-  return token.includes('/')
-    || token.startsWith('.')
-    || /\.(ts|tsx|js|jsx|mjs|cjs|json|yaml|yml|md|sql)$/.test(token);
+  if (CONTAINS_PARENS_REGEX.test(token)) return false;
+  if (GENERIC_SLASH_WORD_REGEX.test(token)) return false;
+  if (token.startsWith('.') && !token.startsWith('./') && !token.startsWith('../')) {
+    return false;
+  }
+  if (DOT_TOKEN_REGEX.test(token)) return false;
+  if (DOT_METHOD_CALL_REGEX.test(token)) return false;
+  if (KNOWN_METHOD_SUFFIX_REGEX.test(token)) return false;
+  if (token.includes('/')) {
+    const segments = token.split('/').filter(Boolean);
+    if (segments.length < 2) return false;
+    return PATH_SEGMENT_ALLOWED_CHARS_REGEX.test(token);
+  }
+  return FILELIKE_EXTENSION_REGEX.test(token);
 }
 
 function isDistinctiveSymbol(token: string): boolean {
   if (token.length < 5) return false;
   if (token.endsWith('()')) return true;
   if (token.includes('_')) return true;
-  return /[A-Z].*[A-Z]/.test(token);
+  return UPPER_CAMELISH_REGEX.test(token);
 }
 
 function classifyToken(token: string): ClaimKind {
   if (token.includes(' ') || token.includes('\n')) return 'skip';
   if (isPathToken(token)) return 'path';
-  if (!/^[A-Za-z_][A-Za-z0-9_]*\(\)?$/.test(token)) return 'skip';
+  if (!SYMBOL_TOKEN_REGEX.test(token)) return 'skip';
   if (CLAIM_DENYLIST.has(token.replace(/\(\)$/, ''))) return 'skip';
   return 'symbol';
 }
@@ -84,7 +128,7 @@ export function extractClaims(content: string): ExtractedClaim[] {
   const body = stripFrontmatterAndCodeBlocks(content);
   const seen = new Set<string>();
   const claims: ExtractedClaim[] = [];
-  for (const match of body.matchAll(/`([^`\n]+)`/g)) {
+  for (const match of body.matchAll(BACKTICK_TOKEN_REGEX)) {
     const token = (match[1] ?? '').trim();
     if (token && !seen.has(token)) {
       seen.add(token);
@@ -133,11 +177,12 @@ function listCodeFiles(root: string): string[] {
         continue;
       }
       if (st.isDirectory()) {
+        if (SKIP_DIRS.has(entry)) continue;
         stack.push(abs);
         continue;
       }
       const ext = extname(abs);
-      if (ext === '.ts' || ext === '.tsx') out.push(abs);
+      if (SEARCHABLE_EXTENSIONS.has(ext)) out.push(abs);
     }
   }
   return out;
@@ -147,7 +192,7 @@ function tokenizeKeywords(text: string): Set<string> {
   return new Set(
     text
       .toLowerCase()
-      .replace(/[^a-z0-9\s]/g, ' ')
+      .replace(NON_ALNUM_SPACE_REGEX, ' ')
       .split(/\s+/)
       .filter(part => part.length >= 4),
   );
@@ -181,8 +226,7 @@ function buildSymbolPresenceMap(symbols: Set<string>, projectRoot: string): Map<
   for (const symbol of symbols) map.set(symbol, false);
   if (symbols.size === 0) return map;
 
-  const codeRoot = join(projectRoot, 'packages');
-  const files = listCodeFiles(codeRoot);
+  const files = listCodeFiles(projectRoot);
   for (const file of files) {
     let text = '';
     try {
@@ -203,6 +247,11 @@ function buildSymbolPresenceMap(symbols: Set<string>, projectRoot: string): Map<
 
 function isTestPath(path: string): boolean {
   return path.includes('__tests__/') || path.endsWith('.test.ts') || path.endsWith('.spec.ts');
+}
+
+function shouldFingerprintPath(path: string): boolean {
+  const ext = extname(path).toLowerCase();
+  return ext === '.ts' || ext === '.tsx';
 }
 
 export function detectDrift(
@@ -260,7 +309,7 @@ export function detectDrift(
           loadBearingMisses.push(`Missing path: ${claim.token}`);
           continue;
         }
-        if (!isTestPath(claim.token) && (claim.token.endsWith('.ts') || claim.token.endsWith('.tsx'))) {
+        if (!isTestPath(claim.token) && shouldFingerprintPath(claim.token)) {
           const fingerprint = extractFileFingerprint(absPath);
           currentFingerprints[claim.token] = fingerprint;
           const stored = loadStoredFingerprint(props, claim.token);

--- a/packages/myco/src/agent/skill-drift.ts
+++ b/packages/myco/src/agent/skill-drift.ts
@@ -1,0 +1,336 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { extname, join, resolve } from 'node:path';
+
+export interface SkillDriftInput {
+  id: string;
+  name: string;
+  description: string;
+  path: string;
+  properties: string;
+}
+
+export interface SkillFileFingerprint {
+  exports: string[];
+}
+
+type ClaimKind = 'path' | 'symbol' | 'skip';
+
+export interface ExtractedClaim {
+  token: string;
+  kind: ClaimKind;
+}
+
+export interface SkillDriftReport {
+  skillId: string;
+  name: string;
+  severity: 'none' | 'minor' | 'major' | 'critical';
+  confidence: 'high' | 'medium' | 'low';
+  notes: string;
+  loadBearingMisses: string[];
+  inconclusive: string[];
+  growth: string[];
+  currentFingerprints: Record<string, SkillFileFingerprint>;
+}
+
+export interface SkillDriftResult {
+  verifiedAt: number;
+  reports: SkillDriftReport[];
+  totalMissing: number;
+  totalInconclusive: number;
+  totalGrowth: number;
+}
+
+const CLAIM_DENYLIST = new Set([
+  'AbortController',
+  'Promise',
+  'fetch',
+  'Config',
+  'Error',
+  'Map',
+  'Set',
+  'Object',
+  'Array',
+]);
+
+function stripFrontmatterAndCodeBlocks(content: string): string {
+  const body = content.replace(/^---[\s\S]*?---\n/, '');
+  return body
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/~~~[\s\S]*?~~~/g, '');
+}
+
+function isPathToken(token: string): boolean {
+  return token.includes('/')
+    || token.startsWith('.')
+    || /\.(ts|tsx|js|jsx|mjs|cjs|json|yaml|yml|md|sql)$/.test(token);
+}
+
+function isDistinctiveSymbol(token: string): boolean {
+  if (token.length < 5) return false;
+  if (token.endsWith('()')) return true;
+  if (token.includes('_')) return true;
+  return /[A-Z].*[A-Z]/.test(token);
+}
+
+function classifyToken(token: string): ClaimKind {
+  if (token.includes(' ') || token.includes('\n')) return 'skip';
+  if (isPathToken(token)) return 'path';
+  if (!/^[A-Za-z_][A-Za-z0-9_]*\(\)?$/.test(token)) return 'skip';
+  if (CLAIM_DENYLIST.has(token.replace(/\(\)$/, ''))) return 'skip';
+  return 'symbol';
+}
+
+export function extractClaims(content: string): ExtractedClaim[] {
+  const body = stripFrontmatterAndCodeBlocks(content);
+  const seen = new Set<string>();
+  const claims: ExtractedClaim[] = [];
+  for (const match of body.matchAll(/`([^`\n]+)`/g)) {
+    const token = (match[1] ?? '').trim();
+    if (token && !seen.has(token)) {
+      seen.add(token);
+      claims.push({ token, kind: classifyToken(token) });
+    }
+  }
+  return claims;
+}
+
+export function extractFileFingerprint(absPath: string): SkillFileFingerprint {
+  const text = readFileSync(absPath, 'utf-8');
+  const exports = new Set<string>();
+  const patterns = [
+    /^\s*export\s+(?:async\s+)?function\s+([A-Za-z_][A-Za-z0-9_]*)/gm,
+    /^\s*export\s+class\s+([A-Za-z_][A-Za-z0-9_]*)/gm,
+    /^\s*export\s+const\s+([A-Za-z_][A-Za-z0-9_]*)/gm,
+    /^\s*export\s+interface\s+([A-Za-z_][A-Za-z0-9_]*)/gm,
+    /^\s*export\s+type\s+([A-Za-z_][A-Za-z0-9_]*)/gm,
+  ];
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      if (match[1]) exports.add(match[1]);
+    }
+  }
+  return { exports: [...exports].sort() };
+}
+
+function listCodeFiles(root: string): string[] {
+  const out: string[] = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    if (!dir) continue;
+    let entries: string[] = [];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const abs = join(dir, entry);
+      let st;
+      try {
+        st = statSync(abs);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) {
+        stack.push(abs);
+        continue;
+      }
+      const ext = extname(abs);
+      if (ext === '.ts' || ext === '.tsx') out.push(abs);
+    }
+  }
+  return out;
+}
+
+function tokenizeKeywords(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .split(/\s+/)
+      .filter(part => part.length >= 4),
+  );
+}
+
+function parseProperties(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw || '{}');
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function loadStoredFingerprint(
+  properties: Record<string, unknown>,
+  path: string,
+): SkillFileFingerprint | null {
+  const fingerprints = properties.file_fingerprints;
+  if (!fingerprints || typeof fingerprints !== 'object') return null;
+  const row = (fingerprints as Record<string, unknown>)[path];
+  if (!row || typeof row !== 'object') return null;
+  const exports = (row as { exports?: unknown[] }).exports;
+  if (!Array.isArray(exports)) return null;
+  const asStrings = exports.filter(v => typeof v === 'string') as string[];
+  return { exports: asStrings };
+}
+
+function buildSymbolPresenceMap(symbols: Set<string>, projectRoot: string): Map<string, boolean> {
+  const map = new Map<string, boolean>();
+  for (const symbol of symbols) map.set(symbol, false);
+  if (symbols.size === 0) return map;
+
+  const codeRoot = join(projectRoot, 'packages');
+  const files = listCodeFiles(codeRoot);
+  for (const file of files) {
+    let text = '';
+    try {
+      text = readFileSync(file, 'utf-8');
+    } catch {
+      continue;
+    }
+    for (const symbol of symbols) {
+      if (map.get(symbol)) continue;
+      const escaped = symbol.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\(\\\)$/, '(?:\\(\\))?');
+      const re = new RegExp(`\\b${escaped}\\b`);
+      if (re.test(text)) map.set(symbol, true);
+    }
+  }
+
+  return map;
+}
+
+function isTestPath(path: string): boolean {
+  return path.includes('__tests__/') || path.endsWith('.test.ts') || path.endsWith('.spec.ts');
+}
+
+export function detectDrift(
+  skills: SkillDriftInput[],
+  projectRoot: string,
+  verifiedAt: number,
+): SkillDriftResult {
+  const skillClaims = new Map<string, ExtractedClaim[]>();
+  const skillContents = new Map<string, string>();
+  const allSymbols = new Set<string>();
+
+  for (const skill of skills) {
+    const absPath = resolve(projectRoot, skill.path);
+    let content = '';
+    try {
+      content = readFileSync(absPath, 'utf-8');
+    } catch {
+      content = '';
+    }
+    skillContents.set(skill.id, content);
+    const claims = extractClaims(content);
+    skillClaims.set(skill.id, claims);
+    for (const claim of claims) {
+      const normalized = claim.token.replace(/\(\)$/, '');
+      if (claim.kind === 'symbol' && isDistinctiveSymbol(normalized)) {
+        allSymbols.add(normalized);
+      }
+    }
+  }
+
+  const symbolPresence = buildSymbolPresenceMap(allSymbols, projectRoot);
+
+  const reports: SkillDriftReport[] = [];
+  let totalMissing = 0;
+  let totalInconclusive = 0;
+  let totalGrowth = 0;
+
+  for (const skill of skills) {
+    const props = parseProperties(skill.properties);
+    const claims = skillClaims.get(skill.id) ?? [];
+    const loadBearingMisses: string[] = [];
+    const inconclusive: string[] = [];
+    const growth: string[] = [];
+    const currentFingerprints: Record<string, SkillFileFingerprint> = {};
+    const headings = (skillContents.get(skill.id) ?? '')
+      .split('\n')
+      .filter(line => line.startsWith('## '))
+      .map(line => line.slice(3));
+    const keywords = tokenizeKeywords(`${skill.description} ${headings.join(' ')}`);
+
+    for (const claim of claims) {
+      if (claim.kind === 'path') {
+        const absPath = resolve(projectRoot, claim.token);
+        if (!existsSync(absPath)) {
+          loadBearingMisses.push(`Missing path: ${claim.token}`);
+          continue;
+        }
+        if (!isTestPath(claim.token) && (claim.token.endsWith('.ts') || claim.token.endsWith('.tsx'))) {
+          const fingerprint = extractFileFingerprint(absPath);
+          currentFingerprints[claim.token] = fingerprint;
+          const stored = loadStoredFingerprint(props, claim.token);
+          if (stored) {
+            const previous = new Set(stored.exports);
+            const added = fingerprint.exports.filter(exp => !previous.has(exp));
+            if (added.length > 0) {
+              const significant = added.length >= 2 || added.some(exp => keywords.has(exp.toLowerCase()));
+              if (significant) growth.push(`${claim.token}: ${added.join(', ')}`);
+            }
+          }
+        }
+        continue;
+      }
+
+      if (claim.kind === 'symbol') {
+        const normalized = claim.token.replace(/\(\)$/, '');
+        if (!isDistinctiveSymbol(normalized)) {
+          inconclusive.push(`Inconclusive symbol: ${claim.token}`);
+          continue;
+        }
+        if (!symbolPresence.get(normalized)) {
+          loadBearingMisses.push(`Missing symbol: ${normalized}`);
+        }
+      }
+    }
+
+    const verifiedCount = claims.length - loadBearingMisses.length - inconclusive.length;
+    const confidence = claims.length === 0
+      ? 'low'
+      : (verifiedCount / claims.length >= 0.8 ? 'high' : verifiedCount / claims.length >= 0.5 ? 'medium' : 'low');
+
+    const severity: SkillDriftReport['severity'] = loadBearingMisses.length >= 3
+      ? 'critical'
+      : loadBearingMisses.length >= 1
+        ? 'major'
+        : growth.length > 0
+          ? 'minor'
+          : inconclusive.length > 0
+            ? 'minor'
+            : 'none';
+
+    totalMissing += loadBearingMisses.length;
+    totalInconclusive += inconclusive.length;
+    totalGrowth += growth.length;
+
+    reports.push({
+      skillId: skill.id,
+      name: skill.name,
+      severity,
+      confidence,
+      notes: loadBearingMisses.length > 0
+        ? `Missing load-bearing claims: ${loadBearingMisses.length}`
+        : growth.length > 0
+          ? `Detected ${growth.length} growth signal(s)`
+          : inconclusive.length > 0
+            ? `Detected ${inconclusive.length} inconclusive claim(s)`
+            : 'No drift detected',
+      loadBearingMisses,
+      inconclusive,
+      growth,
+      currentFingerprints,
+    });
+  }
+
+  return {
+    verifiedAt,
+    reports,
+    totalMissing,
+    totalInconclusive,
+    totalGrowth,
+  };
+}

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -301,6 +301,7 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
       agentId: run.agent_id,
       task: run.task ?? undefined,
       instruction: run.instruction ?? undefined,
+      dryRun: run.dry_run,
       resumeRunId: run.id,
       resumeMode: mode ?? 'manual',
       embeddingManager,

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -191,7 +191,7 @@ export async function reconcileExistingDaemon(
   logger: DaemonLogger,
 ): Promise<'ok' | 'step-aside'> {
   const daemonJsonPath = path.join(vaultDir, 'daemon.json');
-  let info: { pid?: number; port?: number };
+  let info: { pid?: number; port?: number; command?: string | null };
   let mtimeMs: number;
   try {
     if (!fs.existsSync(daemonJsonPath)) return 'ok';
@@ -225,10 +225,16 @@ export async function reconcileExistingDaemon(
       });
       if (res.ok) {
         const data = await res.json() as { myco?: boolean; version?: string };
-        if (data.myco && data.version === getPluginVersion()) {
+        const existingCommand = info.command ?? null;
+        const currentCommand = process.argv[1] ?? null;
+        const runtimeMismatch = Boolean(existingCommand && currentCommand && existingCommand !== currentCommand);
+        if (data.myco && (data.version === getPluginVersion() || runtimeMismatch)) {
           logger.info(LOG_KINDS.DAEMON_START, 'Sibling daemon already healthy — stepping aside', {
             existing_pid: info.pid,
             existing_port: info.port,
+            existing_command: existingCommand,
+            current_command: currentCommand,
+            runtime_mismatch: runtimeMismatch,
           });
           return 'step-aside';
         }

--- a/packages/myco/src/daemon/server.ts
+++ b/packages/myco/src/daemon/server.ts
@@ -321,6 +321,7 @@ export class DaemonServer {
     const info = {
       pid: process.pid,
       port: this.port,
+      command: process.argv[1] ?? null,
       started: new Date().toISOString(),
       sessions: [] as string[],
     };

--- a/tests/agent/instruction-builders.test.ts
+++ b/tests/agent/instruction-builders.test.ts
@@ -6,6 +6,9 @@
  * content assembly.
  */
 
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
 
 // Mock embedding before imports
@@ -30,6 +33,7 @@ import {
   CORTEX_INSTRUCTIONS_TASK,
   getSkillSurveyEligibility,
   isInstructionRequiredTask,
+  selectOutlierPairs,
   SKILL_GENERATE_TASK,
   SKILL_EVOLVE_TASK,
 } from '@myco/agent/instruction-builders.js';
@@ -165,10 +169,10 @@ describe('buildSkillEvolveInstruction', () => {
 
   it('returns skip message when no skills exist', async () => {
     const result = await buildSkillEvolveInstruction();
-    expect(result).toContain('No skills need assessment');
+    expect(result).toBeUndefined();
   });
 
-  it('returns skip message when no new spores since watermark', async () => {
+  it('returns undefined when no new spores since watermark', async () => {
     const now = epochSeconds();
     // Watermark is in the future — no spores can be newer
     createSkillWithWatermark('no-spores-skill', now + 1000);
@@ -176,7 +180,7 @@ describe('buildSkillEvolveInstruction', () => {
     createSpore(now - 100);
 
     const result = await buildSkillEvolveInstruction();
-    expect(result).toContain('No skills need assessment');
+    expect(result).toBeUndefined();
   });
 
   it('includes skill when new spores exist since watermark', async () => {
@@ -201,7 +205,7 @@ describe('buildSkillEvolveInstruction', () => {
     createSpore(now - 100);
 
     const result = await buildSkillEvolveInstruction();
-    expect(result).toContain('No skills need assessment');
+    expect(result).toBeUndefined();
   });
 
   it('respects max_skills_per_run param', async () => {
@@ -355,6 +359,76 @@ describe('buildSkillEvolveInstruction', () => {
     expect(uiIds[0]).toBe(uiSporeId);
     expect(provider.embedQuery).toHaveBeenCalled();
     expect(provider.searchVectors).toHaveBeenCalled();
+  });
+
+  it('returns undefined when all signals are zero with projectRoot', async () => {
+    const now = epochSeconds();
+    createSkillWithWatermark('steady-skill', now + 1000, 0, 'Steady skill');
+
+    const root = mkdtempSync(join(tmpdir(), 'myco-evolve-'));
+    mkdirSync(join(root, '.agents', 'skills', 'steady-skill'), { recursive: true });
+    writeFileSync(
+      join(root, '.agents', 'skills', 'steady-skill', 'SKILL.md'),
+      '# Steady\n## Scope\nNo code refs.\n## Procedure\nNo changes.\n',
+    );
+
+    const result = await buildSkillEvolveInstruction({}, root);
+    expect(result).toBeUndefined();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('includes drift report when growth-only signal is present', async () => {
+    const now = epochSeconds();
+    const skillId = createSkillWithWatermark('growth-skill', now + 1000, 0, 'helpers skill');
+
+    const db = getDatabase();
+    db.prepare('UPDATE skill_records SET properties = ? WHERE id = ?').run(JSON.stringify({
+      knowledge_watermark: now + 1000,
+      file_fingerprints: {
+        'packages/myco/src/helpers.ts': { exports: ['ExistingSymbol'] },
+      },
+    }), skillId);
+
+    const root = mkdtempSync(join(tmpdir(), 'myco-evolve-'));
+    mkdirSync(join(root, '.agents', 'skills', 'growth-skill'), { recursive: true });
+    mkdirSync(join(root, 'packages', 'myco', 'src'), { recursive: true });
+    writeFileSync(
+      join(root, '.agents', 'skills', 'growth-skill', 'SKILL.md'),
+      '# Growth\n## Scope\nUse `packages/myco/src/helpers.ts`.\n## Procedure\nKeep updated.\n',
+    );
+    writeFileSync(
+      join(root, 'packages', 'myco', 'src', 'helpers.ts'),
+      'export const ExistingSymbol = 1;\nexport const AddedOne = 2;\nexport const AddedTwo = 3;\n',
+    );
+
+    const result = await buildSkillEvolveInstruction({}, root);
+    expect(result).toContain('Pre-computed Drift Report');
+    expect(result).toContain('growth=');
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe('selectOutlierPairs', () => {
+  it('selects high outliers from distribution', () => {
+    const pairs = [
+      { idA: 'a', idB: 'b', similarity: 0.32 },
+      { idA: 'a', idB: 'c', similarity: 0.35 },
+      { idA: 'a', idB: 'd', similarity: 0.37 },
+      { idA: 'a', idB: 'e', similarity: 0.39 },
+      { idA: 'a', idB: 'f', similarity: 0.41 },
+      { idA: 'a', idB: 'g', similarity: 0.43 },
+      { idA: 'a', idB: 'h', similarity: 0.45 },
+      { idA: 'a', idB: 'i', similarity: 0.48 },
+      { idA: 'a', idB: 'j', similarity: 0.91 },
+      { idA: 'a', idB: 'k', similarity: 0.89 },
+    ];
+    const selected = selectOutlierPairs(pairs, { kSigma: 2, minSamples: 10 });
+    expect(selected.map(p => p.similarity)).toEqual([0.91]);
+  });
+
+  it('returns empty when under minimum sample size', () => {
+    const selected = selectOutlierPairs([{ idA: 'a', idB: 'b', similarity: 0.99 }], { kSigma: 2, minSamples: 10 });
+    expect(selected).toEqual([]);
   });
 });
 

--- a/tests/agent/skill-drift.test.ts
+++ b/tests/agent/skill-drift.test.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import { detectDrift, extractClaims, extractFileFingerprint } from '@myco/agent/skill-drift.js';
+
+describe('skill-drift helpers', () => {
+  it('extractClaims strips fenced code and frontmatter', () => {
+    const claims = extractClaims(`---
+name: test
+---
+# Title
+Use \`packages/myco/src/foo.ts\` and \`GoodSymbol\`.
+\`\`\`ts
+const x = \`ignored-token\`;
+\`\`\`
+`);
+    expect(claims.map(c => c.token)).toEqual(['packages/myco/src/foo.ts', 'GoodSymbol']);
+  });
+
+  it('extractFileFingerprint reads exported symbols', () => {
+    const root = mkdtempSync(join(tmpdir(), 'myco-drift-'));
+    const file = join(root, 'sample.ts');
+    writeFileSync(file, 'export const ONE = 1;\nexport function Two() {}\nexport type Three = string;\n');
+    const fp = extractFileFingerprint(file);
+    expect(fp.exports).toEqual(['ONE', 'Three', 'Two']);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('detectDrift reports missing paths/symbols and growth', () => {
+    const root = mkdtempSync(join(tmpdir(), 'myco-drift-'));
+    mkdirSync(join(root, 'packages', 'myco', 'src'), { recursive: true });
+    mkdirSync(join(root, '.agents', 'skills', 'example'), { recursive: true });
+
+    writeFileSync(
+      join(root, 'packages', 'myco', 'src', 'helpers.ts'),
+      'export const ExistingSymbol = 1;\nexport const AddedOne = 2;\nexport const AddedTwo = 3;\n',
+    );
+    writeFileSync(
+      join(root, '.agents', 'skills', 'example', 'SKILL.md'),
+      '# Skill\nUse `packages/myco/src/helpers.ts` and `ExistingSymbol` and `MissingSymbol`.\nAlso `packages/myco/src/missing.ts`.\n',
+    );
+
+    const result = detectDrift([
+      {
+        id: 'skill-1',
+        name: 'example',
+        description: 'helpers and symbols',
+        path: '.agents/skills/example/SKILL.md',
+        properties: JSON.stringify({
+          file_fingerprints: {
+            'packages/myco/src/helpers.ts': { exports: ['ExistingSymbol'] },
+          },
+        }),
+      },
+    ], root, 123);
+
+    expect(result.totalMissing).toBeGreaterThanOrEqual(1);
+    expect(result.totalGrowth).toBeGreaterThanOrEqual(1);
+    expect(result.reports[0].growth.join(' ')).toContain('AddedOne');
+    expect(result.reports[0].currentFingerprints['packages/myco/src/helpers.ts']).toBeTruthy();
+    rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/tests/daemon/api/agent-runs-dry-run.test.ts
+++ b/tests/daemon/api/agent-runs-dry-run.test.ts
@@ -131,6 +131,32 @@ describe('agent-runs API dry-run + write-intents', () => {
     });
   });
 
+  describe('handleResumeRun — dry-run preservation', () => {
+    it('preserves dryRun=true when resuming a resumable failed run', async () => {
+      insertRun({
+        id: 'run-resume-dry',
+        agent_id: 'myco-agent',
+        status: 'failed',
+        resumable: 1,
+        dryRun: true,
+        task: 'skill-evolve',
+        instruction: 'resume this run',
+      });
+
+      const { handleResumeRun } = makeHandlers();
+      const res = await handleResumeRun(makeRequest({
+        params: { id: 'run-resume-dry' },
+        body: {},
+      }));
+
+      expect((res.body as { ok: boolean }).ok).toBe(true);
+      expect(runAgentSpy).toHaveBeenCalledTimes(1);
+      const [, opts] = runAgentSpy.mock.calls[0] as [string, { dryRun?: boolean; resumeRunId?: string }];
+      expect(opts.resumeRunId).toBe('run-resume-dry');
+      expect(opts.dryRun).toBe(true);
+    });
+  });
+
   describe('handleGetRun — serializes reasoning_level + execution_overrides', () => {
     it('surfaces reasoning_level and parsed execution_overrides from the row', async () => {
       insertRun({

--- a/tests/daemon/reconcile-existing-daemon.test.ts
+++ b/tests/daemon/reconcile-existing-daemon.test.ts
@@ -106,6 +106,21 @@ describe('reconcileExistingDaemon', () => {
     );
   });
 
+  it('steps aside when daemon is healthy but command differs (runtime mismatch)', async () => {
+    await withHealthServer(
+      { status: 200, body: { myco: true, version: '0.0.0-different' } },
+      async (port) => {
+        fs.writeFileSync(
+          path.join(vaultDir, 'daemon.json'),
+          JSON.stringify({ pid: siblingPid, port, command: '/tmp/bun-myco' }),
+        );
+        const result = await reconcileExistingDaemon(vaultDir, makeLogger(vaultDir));
+        expect(result).toBe('step-aside');
+        expect(fs.existsSync(path.join(vaultDir, 'daemon.json'))).toBe(true);
+      },
+    );
+  });
+
   it('takes over (ok) when daemon.json is older than the grace window', async () => {
     await withHealthServer(
       { status: 200, body: { myco: true, version: getPluginVersion() } },


### PR DESCRIPTION
## Summary
- Reduce `skill-evolve` no-work and dry-run overhead by removing the verify phase, adding mechanical drift triage (`skill-drift.ts`), and tightening phase/output budgets in `skill-evolve.yaml`.
- Preserve dry-run semantics on resume by propagating `dryRun` through `POST /api/agent/runs/:id/resume`, with regression coverage to prevent resumed dry runs from applying writes.
- Harden daemon lifecycle behavior for mixed-runtime/worktree environments by recording daemon command provenance and stepping aside when a healthy daemon is already running from a different command/runtime.

## Test plan
- [x] `npm test -- tests/agent/skill-drift.test.ts tests/agent/instruction-builders.test.ts`
- [x] `npm test -- tests/daemon/api/agent-runs-dry-run.test.ts`
- [x] `npm test -- tests/daemon/reconcile-existing-daemon.test.ts`
- [x] `make build` (latest run in this branch)
- [x] Manual dry run validation via daemon UI (`ca7074a0-a1e0-4ebf-9878-7ab1c045417e`) confirming dry-run act phase reports skip/no applied writes

Made with [Cursor](https://cursor.com)