### PR TITLE
0.22.0 release gate: eviction unification + revert semantics + capture fix

### DIFF
--- a/.agents/skills/install-and-initialize-myco/SKILL.md
+++ b/.agents/skills/install-and-initialize-myco/SKILL.md
@@ -150,9 +150,25 @@ When developing Myco itself, you need the project's hooks and daemon to invoke y
 
 ### Prerequisites for Dev Setup
 
-- The project is built: `packages/myco/dist/src/cli.js` must exist. Run `make build` first if it doesn't.
-- You are in the repository root (`/Users/chris/Repos/myco` or equivalent).
-- The globally-installed `myco` is already working (used as the fallback when `.myco/runtime.command` is absent).
+- Node.js installed (Myco requires Node.js ≥ 18)
+- You are in the repository root (`/Users/chris/Repos/myco` or equivalent)
+- The globally-installed `myco` is already working (used as the fallback when `.myco/runtime.command` is absent)
+
+### Verify Build Status
+
+Before configuring dev binary, ensure the project is built:
+
+```bash
+# Check if CLI build exists
+if [ ! -f "packages/myco/dist/src/cli.js" ]; then
+  echo "CLI not built. Running build..."
+  make build
+else
+  echo "CLI build found."
+fi
+```
+
+The CLI build at `packages/myco/dist/src/cli.js` is required for dev configuration to work.
 
 ### Configure Dev Binary
 

--- a/.agents/skills/vault-schema-extension/SKILL.md
+++ b/.agents/skills/vault-schema-extension/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob
 
 # Vault Schema and Data Layer Extension
 
-Myco stores all project intelligence in a local SQLite file (`.myco/myco.db`) and mirrors the schema to Cloudflare D1 for team sync. Every new feature that persists data requires a versioned migration block, a query module, and — depending on the feature — an FTS5 index and D1 alignment. Schema versions progress monotonically (v6→v7→v8→v9→…); each version is a self-contained, idempotent block in the migration runner.
+Myco stores all project intelligence in a local SQLite file (`.myco/myco.db`) and mirrors the schema to Cloudflare D1 for team sync. Every new feature that persists data requires a versioned migration block, query functions, and — depending on the feature — an FTS5 index and D1 alignment. Schema versions progress monotonically (v6→v7→v8→v9→…); each version is a self-contained, idempotent block in the migration runner.
 
 ## Prerequisites
 
@@ -19,7 +19,7 @@ Myco stores all project intelligence in a local SQLite file (`.myco/myco.db`) an
 
 ## Procedure A: Adding a New Table
 
-Follow these steps in order. Skipping the query module or constants update leaves the data layer incomplete.
+Follow these steps in order. Skipping the query functions or constants update leaves the data layer incomplete.
 
 ### 1. Write the migration block
 
@@ -52,9 +52,9 @@ Key rules:
 - Use `INTEGER NOT NULL DEFAULT (unixepoch())` for timestamps — store Unix epoch seconds, not ISO strings.
 - Use `TEXT PRIMARY KEY` with a UUID for entity tables; use `INTEGER PRIMARY KEY AUTOINCREMENT` only for pure log/event tables where an ordered surrogate is the point.
 
-### 2. Create the query module
+### 2. Create the query functions
 
-Create `packages/myco/src/db/queries/my-new-table.ts`:
+Add query functions directly in the appropriate module or create a dedicated query module as needed:
 
 ```typescript
 import type { Database } from 'better-sqlite3';
@@ -88,18 +88,19 @@ export function getMyNewTableBySession(
 }
 ```
 
-Re-export from the barrel file (`packages/myco/src/db/queries/index.ts`). All SQL lives in `packages/myco/src/db/queries/` — never inline SQL strings in MCP handlers or business logic.
+All SQL lives in the appropriate query modules — never inline SQL strings in MCP handlers or business logic.
 
 ### 3. Update schema constants
 
-Open `packages/myco/src/config/constants.ts` and check each relevant set:
+Open `packages/myco/src/db/schema-ddl.ts` and update the relevant constants:
 
 | Constant | Add the table if… |
 |---|---|
-| `VAULT_GITIGNORE_TABLES` | Table rows should not appear in gitignore-excluded export |
-| `BACKUP_EXCLUDED_TABLES` | Table holds transient/cache data not worth backing up |
-| `SEARCHABLE_TABLES` | Table is FTS5-indexed and surfaced via `vault_search_fts` |
-| `MCP_READABLE_TABLES` | Table is exposed to the cloud MCP read surface |
+| `TABLE_DDLS` | Always add new table DDL definition |
+| `FTS_TABLES` | Table is FTS5-indexed and searchable |
+| `SECONDARY_INDEXES` | Table has custom indexes beyond primary key |
+
+Review the schema-ddl.ts file to identify other table registration constants that may apply to your new table. Look for patterns like how existing tables (sessions, spores, etc.) are registered and follow the same registration approach.
 
 Find all places a similar table name appears to avoid missing any registration point:
 
@@ -131,7 +132,7 @@ Rules:
 - **Never add `NOT NULL` without a `DEFAULT`** — existing rows fail the constraint on open.
 - **Backfill in the same version block**, before bumping `user_version`. This keeps the migration atomic: either both the schema change and the backfill succeed, or the whole block retries.
 - **One conceptual change per version block** — keep each version atomic and describable in a single sentence.
-- Update the query module's INSERT and SELECT statements and the TypeScript row interface to include the new column.
+- Update the query functions' INSERT and SELECT statements and the TypeScript row interface to include the new column.
 
 ### What never to do
 
@@ -145,7 +146,7 @@ Cloudflare D1 mirrors the local SQLite schema for team sync. Its critical behavi
 
 ### Maintaining the D1 migration file
 
-Keep a parallel migration file in the Workers project (e.g., `packages/myco-team/migrations/0009_add_my_new_table.sql`):
+Keep a parallel migration file in the Workers project (e.g., in the team package migrations directory):
 
 ```sql
 -- 0009_add_my_new_table.sql
@@ -540,13 +541,7 @@ packages/myco/
   src/
     db/
       migrations.ts            # All versioned migration blocks, in order
-      queries/
-        index.ts               # Barrel re-export of all query modules
-        sessions.ts            # One file per logical domain
-        spores.ts
-        my-new-table.ts        # New query module
-    config/
-      constants.ts             # VAULT_GITIGNORE_TABLES and other shared sets
+      schema-ddl.ts            # Table DDL definitions and constants
 packages/myco-team/
   migrations/                  # Parallel D1 SQL migration files
     0009_add_my_new_table.sql
@@ -559,6 +554,7 @@ packages/myco-team/
 - **D1 ALTER TABLE is lazy** — the column does not exist on D1 until the first post-deploy request triggers migration. Guard reads against new columns until you know migration has run.
 - **FTS triggers must use `IF NOT EXISTS`** — duplicate triggers corrupt the index silently.
 - **Never post-filter in JS what SQL can filter** — use `json_each` for dynamic ID sets, JOIN for related data, and keyset cursors for pagination.
-- **All SQL lives in `packages/myco/src/db/queries/`** — no inline SQL in MCP handlers or business logic. This keeps it grep-able, testable, and refactorable.
-- **Scan `packages/myco/src/config/constants.ts` after every new table** — missing a registration in `SEARCHABLE_TABLES` or `MCP_READABLE_TABLES` silently limits the feature surface.
+- **All SQL lives in the appropriate query modules** — no inline SQL in MCP handlers or business logic. This keeps it grep-able, testable, and refactorable.
+- **Scan `packages/myco/src/db/schema-ddl.ts` after every new table** — missing a registration in `TABLE_DDLS` or `FTS_TABLES` silently limits the feature surface.
+- **Review schema-ddl.ts for table registration constants after every new table** — missing registrations in various table arrays silently limits the feature surface.
 - **Migration test functions for complex transformations** — include test helpers like `resolveV20PlanIdentityCollisionsForTest` for migrations that involve data conflicts or complex transformations.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -272,29 +272,21 @@ jobs:
         run: npm ci --prefix packages/myco/ui
       - name: Install myco-collective UI deps
         run: npm ci --prefix packages/myco-collective/ui
-      - name: Install myco-team worker deps
+      - name: Install worker deps
         run: |
-          for attempt in 1 2 3; do
-            if npm ci --prefix packages/myco-team/worker; then
-              exit 0
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              exit 1
-            fi
-            echo "myco-team worker npm ci failed on attempt $attempt; retrying..." >&2
-            sleep 5
-          done
-      - name: Install myco-collective worker deps
-        run: |
-          for attempt in 1 2 3; do
-            if npm ci --prefix packages/myco-collective/worker; then
-              exit 0
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              exit 1
-            fi
-            echo "myco-collective worker npm ci failed on attempt $attempt; retrying..." >&2
-            sleep 5
+          set -eu
+          for workspace in packages/myco-team/worker packages/myco-collective/worker; do
+            for attempt in 1 2 3; do
+              if npm ci --prefix "$workspace"; then
+                break
+              fi
+              if [ "$attempt" -eq 3 ]; then
+                echo "$workspace npm ci failed after 3 attempts" >&2
+                exit 1
+              fi
+              echo "$workspace npm ci failed on attempt $attempt; retrying..." >&2
+              sleep 5
+            done
           done
 
       - name: Sync target package versions from tag

--- a/packages/myco/src/agent/runtime/claude-code-executable.ts
+++ b/packages/myco/src/agent/runtime/claude-code-executable.ts
@@ -71,9 +71,19 @@ function candidatePackageRoots(
  * installed Myco package root on disk, not by hardcoding an absolute binary
  * path per machine.
  */
+let cachedResolution: { value: string | undefined } | undefined;
+
 export function resolveClaudeCodeExecutable(
   deps: ResolveClaudeExecutableDeps = {},
 ): string | undefined {
+  const hasInjectedDeps =
+    deps.importMetaUrl !== undefined ||
+    deps.execPath !== undefined ||
+    deps.realpathSync !== undefined ||
+    deps.existsSync !== undefined ||
+    deps.requireFactory !== undefined;
+  if (!hasInjectedDeps && cachedResolution) return cachedResolution.value;
+
   const importMetaUrl = deps.importMetaUrl ?? import.meta.url;
   const execPath = deps.execPath ?? process.execPath;
   const realpathSync = deps.realpathSync ?? fs.realpathSync;
@@ -89,12 +99,16 @@ export function resolveClaudeCodeExecutable(
       try {
         const packageJsonPath = requireFromPackage.resolve(`${optionalPackage}/package.json`);
         const executablePath = path.join(path.dirname(packageJsonPath), claudeExecutableName());
-        if (existsSync(executablePath)) return executablePath;
+        if (existsSync(executablePath)) {
+          if (!hasInjectedDeps) cachedResolution = { value: executablePath };
+          return executablePath;
+        }
       } catch {
         // Try the next platform candidate or package-root origin.
       }
     }
   }
 
+  if (!hasInjectedDeps) cachedResolution = { value: undefined };
   return undefined;
 }

--- a/packages/myco/src/capture/prompt-kind.ts
+++ b/packages/myco/src/capture/prompt-kind.ts
@@ -44,6 +44,24 @@ export function extractUserPromptRecords(
   return walkTranscript(config, agent, events, transcriptPath).records;
 }
 
+/**
+ * Like {@link extractUserPromptRecords} but also returns the raw text of
+ * prompts that a capture.rules `drop` decision suppressed. Reconcile uses the
+ * dropped list to distinguish a DB batch with no transcript peer (real drift,
+ * worth warning about) from one whose transcript peer the walker intentionally
+ * dropped (e.g., Claude Code's <command-message> dispatch envelope).
+ */
+export function extractUserPromptRecordsWithDrops(
+  agent: string,
+  events: ReadonlyArray<Record<string, unknown>>,
+  transcriptPath?: string,
+): { records: UserPromptRecord[]; droppedText: string[] } {
+  const config = HOOK_CONFIG[agent]?.capturePrompts;
+  if (!config) return { records: [], droppedText: [] };
+  const result = walkTranscript(config, agent, events, transcriptPath);
+  return { records: result.records, droppedText: result.droppedText };
+}
+
 /** Classify a hypothetical next prompt given current transcript state + text. */
 export function classifyNextPromptKind(
   agent: string | undefined,
@@ -64,6 +82,8 @@ export function classifyNextPromptKind(
 
 interface WalkResult {
   records: UserPromptRecord[];
+  /** Raw text of prompts that a `drop` rule suppressed; used by reconcile to silence false stranded-batch warnings. */
+  droppedText: string[];
   priorTurnEnded: boolean;
 }
 
@@ -80,6 +100,7 @@ function walkTranscript(
 ): WalkResult {
   const seenDedupe = new Set<string>();
   const records: UserPromptRecord[] = [];
+  const droppedText: string[] = [];
   let priorTurnEnded = true;
 
   // Each reset-boundary with `changeOn` remembers its last seen value so
@@ -113,7 +134,10 @@ function walkTranscript(
       agent,
       { prompt: rawText, transcriptPath: transcriptPath ?? '<transcript-walker>' },
     );
-    if (decision.action === 'drop') continue;
+    if (decision.action === 'drop') {
+      droppedText.push(rawText);
+      continue;
+    }
     const text = decision.action === 'rewrite' ? decision.prompt : rawText;
 
     const kind = config.interruptMarker && text.startsWith(config.interruptMarker)
@@ -126,7 +150,7 @@ function walkTranscript(
     priorTurnEnded = false;
   }
 
-  return { records, priorTurnEnded };
+  return { records, droppedText, priorTurnEnded };
 }
 
 function findMatchingShape(

--- a/packages/myco/src/capture/transcript-miner.ts
+++ b/packages/myco/src/capture/transcript-miner.ts
@@ -11,7 +11,7 @@ import {
   BATCH_KIND,
   type BatchRow,
 } from '../db/queries/batches.js';
-import { extractUserPromptRecords, type UserPromptRecord } from './prompt-kind.js';
+import { extractUserPromptRecordsWithDrops, type UserPromptRecord } from './prompt-kind.js';
 import { epochSeconds, DEFAULT_AGENT_ID } from '@myco/constants.js';
 import { createBatchLineage } from '../db/queries/lineage.js';
 import { getTeamMachineId } from '../daemon/team-context.js';
@@ -164,7 +164,7 @@ export class TranscriptMiner {
       // statSync failure falls through to parseAllEvents, which handles it.
     }
 
-    const records = extractUserPromptRecords(
+    const { records, droppedText } = extractUserPromptRecordsWithDrops(
       input.agent,
       this.parseAllEvents(input.transcriptPath),
       input.transcriptPath,
@@ -219,7 +219,15 @@ export class TranscriptMiner {
       if (effectiveKind === BATCH_KIND.INITIAL) currentParentId = created.id;
     }
 
-    const stranded = buckets.remaining().length;
+    // Each capture.rules `drop` decision suppresses a transcript prompt the
+    // live hook path already captured, so one DB batch is structurally
+    // "stranded by design" per drop. Subtract those from the stranded count
+    // before warning — otherwise every slash-command dispatch logs a false
+    // signal. Prefix matching isn't viable here: the dropped transcript text
+    // (e.g., `<command-message>...`) has a different prefix than the
+    // hook-stored batch text (`/<name> <args>`), which is the whole reason we
+    // drop the transcript peer in the first place.
+    const stranded = Math.max(0, buckets.remaining().length - droppedText.length);
     if (stranded > 0) {
       errors.push(`${stranded} DB batch(es) had no matching transcript prompt`);
     }

--- a/packages/myco/src/cli/restart.ts
+++ b/packages/myco/src/cli/restart.ts
@@ -1,40 +1,45 @@
-import { isProcessAlive } from './shared.js';
+import { evictDaemonsForVault } from '../daemon/eviction.js';
 import fs from 'node:fs';
 import path from 'node:path';
 
 export async function run(_args: string[], vaultDir: string): Promise<void> {
-  const daemonPath = path.join(vaultDir, 'daemon.json');
-
-  // Kill existing daemon if running
-  if (fs.existsSync(daemonPath)) {
-    try {
-      const daemon = JSON.parse(fs.readFileSync(daemonPath, 'utf-8'));
-      if (isProcessAlive(daemon.pid)) {
-        process.kill(daemon.pid, 'SIGTERM');
-        console.log(`Stopped daemon (pid ${daemon.pid})`);
-      } else {
-        console.log(`Daemon pid ${daemon.pid} was already dead`);
-      }
-    } catch { /* ignore */ }
-    try { fs.unlinkSync(daemonPath); } catch { /* already gone */ }
+  // Evict every daemon for this vault — handles both the PID in daemon.json
+  // and orphans holding the canonical port without JSON registration. Waits
+  // for SIGTERM → (optional SIGKILL) → process exit before returning so the
+  // subsequent spawn can bind the canonical port cleanly.
+  const evicted = await evictDaemonsForVault(vaultDir, {
+    logger: {
+      info: (_kind, msg, meta) => console.log(formatLog(msg, meta)),
+      warn: (_kind, msg, meta) => console.warn(formatLog(msg, meta)),
+    },
+  });
+  if (evicted.length > 0) {
+    console.log(`Stopped ${evicted.length} daemon(s): ${evicted.map((e) => e.pid).join(', ')}`);
+  } else {
+    console.log('No existing daemon to stop');
   }
 
-  // Spawn and wait for health using the shared client
-  // (handles CLAUDE_PLUGIN_ROOT + CURSOR_PLUGIN_ROOT resolution)
   const { DaemonClient } = await import('../hooks/client.js');
   const client = new DaemonClient(vaultDir);
 
   console.log('Waiting for health check...');
   const healthy = await client.ensureRunning();
-  if (healthy) {
-    try {
-      const info = JSON.parse(fs.readFileSync(daemonPath, 'utf-8'));
-      console.log(`Daemon healthy on port ${info.port}`);
-      console.log(`Dashboard: http://localhost:${info.port}/`);
-    } catch {
-      console.log('Daemon healthy');
-    }
-  } else {
+  if (!healthy) {
     console.error('Daemon failed to become healthy');
+    return;
   }
+
+  const daemonPath = path.join(vaultDir, 'daemon.json');
+  try {
+    const info = JSON.parse(fs.readFileSync(daemonPath, 'utf-8'));
+    console.log(`Daemon healthy on port ${info.port}`);
+    console.log(`Dashboard: http://localhost:${info.port}/`);
+  } catch {
+    console.log('Daemon healthy');
+  }
+}
+
+function formatLog(message: string, meta?: Record<string, unknown>): string {
+  if (!meta || Object.keys(meta).length === 0) return message;
+  return `${message} ${JSON.stringify(meta)}`;
 }

--- a/packages/myco/src/cli/shared.ts
+++ b/packages/myco/src/cli/shared.ts
@@ -8,6 +8,11 @@ import { DaemonClient } from '../hooks/client.js';
 import { initDatabase, closeDatabase, vaultDbPath } from '../db/client.js';
 import { SymbiontInstaller } from '../symbionts/installer.js';
 import type { SymbiontManifest } from '../symbionts/manifest-schema.js';
+import {
+  PROJECT_RUNTIME_DIRNAME,
+  PROJECT_RUNTIME_TMP_DIRNAME,
+  PROJECT_RUNTIME_COMMAND_FILENAME,
+} from '../constants/update.js';
 
 export { parseStringFlag, parseIntFlag } from '../logs/format.js';
 
@@ -89,11 +94,11 @@ staging/
 # the hook guard invokes. Default (file absent) is \`myco\`; \`make dev-link\`
 # writes \`myco-dev\`; users can hand-edit for PATH conflicts or pinning.
 # Never committed — different contributors use different aliases.
-runtime.command
+${PROJECT_RUNTIME_COMMAND_FILENAME}
 
 # Project-local managed runtime used for beta isolation
-runtime/
-runtime.tmp/
+${PROJECT_RUNTIME_DIRNAME}/
+${PROJECT_RUNTIME_TMP_DIRNAME}/
 
 # Per-user appearance and settings overrides
 local.yaml

--- a/packages/myco/src/cli/shared.ts
+++ b/packages/myco/src/cli/shared.ts
@@ -93,7 +93,7 @@ runtime.command
 
 # Project-local managed runtime used for beta isolation
 runtime/
-runtime.prev/
+runtime.tmp/
 
 # Per-user appearance and settings overrides
 local.yaml

--- a/packages/myco/src/constants/update.ts
+++ b/packages/myco/src/constants/update.ts
@@ -19,6 +19,9 @@ export const UPDATE_ERROR_PATH = path.join(MYCO_GLOBAL_DIR, 'update-error.json')
 /** Project-local managed runtime directory under the vault. */
 export const PROJECT_RUNTIME_DIRNAME = 'runtime';
 
+/** Filename for the per-project runtime command alias (lives inside vault .myco/). */
+export const PROJECT_RUNTIME_COMMAND_FILENAME = 'runtime.command';
+
 /** Filename for the version stamp written by `myco update` (lives inside vault .myco/). */
 export const UPDATE_STAMP_FILENAME = 'last-update-version';
 

--- a/packages/myco/src/constants/update.ts
+++ b/packages/myco/src/constants/update.ts
@@ -19,6 +19,16 @@ export const UPDATE_ERROR_PATH = path.join(MYCO_GLOBAL_DIR, 'update-error.json')
 /** Project-local managed runtime directory under the vault. */
 export const PROJECT_RUNTIME_DIRNAME = 'runtime';
 
+/**
+ * Staging directory used during atomic swap on update.
+ *
+ * `npm install --prefix <runtime.tmp>` runs first; on success the staging
+ * dir is `mv`d into place over the old `runtime/`. Derived from
+ * {@link PROJECT_RUNTIME_DIRNAME} so a rename of the runtime dir can't
+ * silently drift from the gitignore or the installer script.
+ */
+export const PROJECT_RUNTIME_TMP_DIRNAME = `${PROJECT_RUNTIME_DIRNAME}.tmp`;
+
 /** Filename for the per-project runtime command alias (lives inside vault .myco/). */
 export const PROJECT_RUNTIME_COMMAND_FILENAME = 'runtime.command';
 

--- a/packages/myco/src/daemon/api/update.ts
+++ b/packages/myco/src/daemon/api/update.ts
@@ -70,13 +70,22 @@ const ChannelBodySchema = z.object({
  */
 export function createUpdateHandlers(deps: UpdateDeps) {
   const { vaultDir, projectRoot, currentVersion, scheduleShutdown, globalPrefix } = deps;
-  const resolveManagedMycoBinary = () => resolveRuntimeCommand(vaultDir) ?? resolveMycoBinary();
-  const getRuntimeCommand = () => resolveRuntimeCommand(vaultDir);
-  const getDesiredChannel = () => readProjectReleaseChannel(vaultDir);
-  const getRuntimeScope = () => {
-    const runtimeCommand = getRuntimeCommand();
-    return runtimeCommand !== null && isManagedProjectRuntime(runtimeCommand) ? 'project' : 'machine';
-  };
+
+  /**
+   * Per-request snapshot of everything derived from vault state on disk.
+   * Reads each source once per handler invocation; handlers pass the
+   * snapshot into all downstream helpers instead of re-reading.
+   */
+  function readVaultSnapshot() {
+    const runtimeCommand = resolveRuntimeCommand(vaultDir);
+    const desiredChannel = readProjectReleaseChannel(vaultDir);
+    const runtimeScope: 'project' | 'machine' =
+      runtimeCommand !== null && isManagedProjectRuntime(runtimeCommand, vaultDir)
+        ? 'project'
+        : 'machine';
+    const mycoBinary = runtimeCommand ?? resolveMycoBinary();
+    return { runtimeCommand, desiredChannel, runtimeScope, mycoBinary };
+  }
 
   /** Prevents multiple restart scripts from racing during the shutdown window. */
   let restartInitiated = false;
@@ -103,6 +112,8 @@ export function createUpdateHandlers(deps: UpdateDeps) {
       return { body: { exempt: true, running_version: currentVersion } };
     }
 
+    const snapshot = readVaultSnapshot();
+
     // --- Installed-version check (short-circuits before registry) ---
     if (globalPrefix && !restartInitiated) {
       const installedVersion = getInstalledVersion(globalPrefix);
@@ -118,7 +129,7 @@ export function createUpdateHandlers(deps: UpdateDeps) {
           projectRoot, vaultDir, runLocalUpdate,
           fromVersion: currentVersion,
           toVersion: installedVersion,
-          mycoBinary: resolveManagedMycoBinary(),
+          mycoBinary: snapshot.mycoBinary,
         });
         scheduleShutdown();
         return {
@@ -133,13 +144,18 @@ export function createUpdateHandlers(deps: UpdateDeps) {
     }
 
     // --- Normal registry check flow (unchanged) ---
-    const desiredChannel = getDesiredChannel();
     const config = readUpdateConfig();
     const cache = readCachedCheck();
 
     if (isCacheStale(cache, config.check_interval_hours)) {
       // Fire-and-forget — don't block the response on the registry fetch.
-      checkForUpdate(currentVersion, globalPrefix, getRuntimeCommand(), desiredChannel).catch(() => {});
+      checkForUpdate(
+        currentVersion,
+        globalPrefix,
+        snapshot.runtimeCommand,
+        snapshot.desiredChannel,
+        vaultDir,
+      ).catch(() => {});
     }
 
     // Pass pre-read config and cache to avoid reading the files a second time.
@@ -148,8 +164,9 @@ export function createUpdateHandlers(deps: UpdateDeps) {
       cache,
       config,
       globalPrefix,
-      getRuntimeCommand(),
-      desiredChannel,
+      snapshot.runtimeCommand,
+      snapshot.desiredChannel,
+      vaultDir,
     );
     if (!status) {
       // No cache yet — return minimal response; background check will populate it.
@@ -157,13 +174,14 @@ export function createUpdateHandlers(deps: UpdateDeps) {
         body: {
           exempt: false,
           update_available: false,
+          revert_available: false,
           running_version: currentVersion,
           latest_version: currentVersion,
           latest_stable: currentVersion,
           latest_beta: null,
-          channel: desiredChannel,
+          channel: snapshot.desiredChannel,
           channel_scope: 'project',
-          runtime_scope: getRuntimeScope(),
+          runtime_scope: snapshot.runtimeScope,
           check_interval_hours: config.check_interval_hours,
           last_check: '',
           error: null,
@@ -187,11 +205,13 @@ export function createUpdateHandlers(deps: UpdateDeps) {
       };
     }
 
+    const snapshot = readVaultSnapshot();
     const result = await checkForUpdate(
       currentVersion,
       globalPrefix,
-      getRuntimeCommand(),
-      getDesiredChannel(),
+      snapshot.runtimeCommand,
+      snapshot.desiredChannel,
+      vaultDir,
     );
     return { body: { exempt: false, ...result } };
   }
@@ -206,32 +226,60 @@ export function createUpdateHandlers(deps: UpdateDeps) {
       return { status: 400, body: { error: 'update_exempt' } };
     }
 
-    const runtimeCommand = getRuntimeCommand();
+    const snapshot = readVaultSnapshot();
     const status = statusFromCache(
       currentVersion,
       undefined,
       undefined,
       globalPrefix,
-      runtimeCommand,
-      getDesiredChannel(),
+      snapshot.runtimeCommand,
+      snapshot.desiredChannel,
+      vaultDir,
     );
-    const packageSpecs = (status?.packages ?? [])
-      .filter((pkg) => pkg.installed && pkg.update_available && pkg.latest_version)
-      .map((pkg) => `${pkg.package_name}@${pkg.latest_version}`);
-    const removeLocalRuntime =
-      status?.channel === 'stable'
-      && runtimeCommand !== null
-      && isManagedProjectRuntime(runtimeCommand);
-    if (!status || (packageSpecs.length === 0 && !removeLocalRuntime)) {
+    if (!status) {
       return { status: 400, body: { error: 'no_update_available' } };
     }
 
-    const localRuntimeSpec = status.channel === 'beta'
-      ? packageSpecs.find((spec) => spec.startsWith('@goondocks/myco@'))
+    const mycoPackage = status.packages.find((pkg) => pkg.id === 'myco');
+    const mycoPackageSpec = mycoPackage?.latest_version
+      ? `${mycoPackage.package_name}@${mycoPackage.latest_version}`
       : undefined;
+
+    // Specs to `npm install -g` — covers both forward updates and revert
+    // flows. For a revert, we reinstall the stable target globally so the
+    // machine runtime is at the correct version before we drop the
+    // project-local runtime.
+    const installSpecs = status.packages
+      .filter(
+        (pkg) => pkg.installed && (pkg.update_available || pkg.revert_available) && pkg.latest_version,
+      )
+      .map((pkg) => `${pkg.package_name}@${pkg.latest_version}`);
+
+    // Reverting a project-local beta back to the machine-wide stable install.
+    const removeLocalRuntime =
+      status.channel === 'stable' && snapshot.runtimeScope === 'project';
+
+    // Entering beta on a project that's still on the machine runtime means we
+    // need to install a project-local myco — even when the machine install is
+    // already at the beta target version and `update_available` is false.
+    const enteringBetaLocalRuntime =
+      status.channel === 'beta' && snapshot.runtimeScope === 'machine';
+
+    const localRuntimeSpec = (() => {
+      if (enteringBetaLocalRuntime) return mycoPackageSpec;
+      if (status.channel === 'beta') {
+        return installSpecs.find((spec) => spec.startsWith('@goondocks/myco@'));
+      }
+      return undefined;
+    })();
+
+    if (installSpecs.length === 0 && !removeLocalRuntime && !localRuntimeSpec) {
+      return { status: 400, body: { error: 'no_update_available' } };
+    }
+
     const globalPackageSpecs = localRuntimeSpec
-      ? packageSpecs.filter((spec) => spec !== localRuntimeSpec)
-      : packageSpecs;
+      ? installSpecs.filter((spec) => spec !== localRuntimeSpec)
+      : installSpecs;
 
     spawnUpdateScript({
       packageSpecs: globalPackageSpecs,
@@ -239,15 +287,19 @@ export function createUpdateHandlers(deps: UpdateDeps) {
       removeLocalRuntime,
       projectRoot,
       vaultDir,
-      mycoBinary: resolveManagedMycoBinary(),
+      mycoBinary: snapshot.mycoBinary,
     });
     scheduleShutdown();
+
+    const reportedPackages = localRuntimeSpec && !installSpecs.includes(localRuntimeSpec)
+      ? [...installSpecs, localRuntimeSpec]
+      : installSpecs;
 
     return {
       body: {
         status: 'applying',
         version: status.latest_version,
-        packages: packageSpecs,
+        packages: reportedPackages,
       },
     };
   }
@@ -269,26 +321,29 @@ export function createUpdateHandlers(deps: UpdateDeps) {
     writeProjectReleaseChannel(vaultDir, channel);
     clearCachedCheck();
 
+    const snapshot = readVaultSnapshot();
     const channelStatus = statusFromCache(
       currentVersion,
       undefined,
       undefined,
       globalPrefix,
-      getRuntimeCommand(),
+      snapshot.runtimeCommand,
       channel,
+      vaultDir,
     );
     if (!channelStatus) {
       return {
         body: {
           exempt: false,
           update_available: false,
+          revert_available: false,
           running_version: currentVersion,
           latest_version: currentVersion,
           latest_stable: currentVersion,
           latest_beta: null,
           channel,
           channel_scope: 'project',
-          runtime_scope: getRuntimeScope(),
+          runtime_scope: snapshot.runtimeScope,
           check_interval_hours: config.check_interval_hours,
           last_check: '',
           error: null,

--- a/packages/myco/src/daemon/eviction.ts
+++ b/packages/myco/src/daemon/eviction.ts
@@ -1,0 +1,341 @@
+/**
+ * Unified daemon-eviction helpers.
+ *
+ * One source of truth for "find every myco daemon running for this vault and
+ * make them go away so we can take the canonical port." Callers:
+ *   - `server.evictExistingDaemon` (daemon startup)
+ *   - `cli/restart.ts` (user-triggered restart)
+ *
+ * The prior eviction logic looked only at the PID recorded in `daemon.json`.
+ * That missed two real failure modes:
+ *   - An orphan daemon holding the canonical port whose JSON registration got
+ *     lost (racing update-apply, unclean shutdown, stale-JSON SIGTERM that
+ *     the target process ignored).
+ *   - A "current" daemon that fell back to `canonical+1` because an orphan was
+ *     squatting the canonical port; subsequent restarts keep using the wrong
+ *     port forever because daemon.json points at the fallback.
+ *
+ * This module scans a small port range around the canonical port (which was
+ * the fallback-retry range before we dropped silent fallback) to catch any
+ * historical fallback-bound myco daemons, identifies them via `ps` argv
+ * matching, and evicts them all.
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { derivePort } from './port.js';
+import {
+  DAEMON_EVICT_POLL_MS,
+  DAEMON_EVICT_TIMEOUT_MS,
+} from '../constants.js';
+
+/** How many ports above the canonical to scan for stale daemons. */
+const EVICT_PORT_SCAN_RANGE = 10;
+
+/** Minimal logger shape so this module works for both daemon and CLI callers. */
+export interface EvictionLogger {
+  info: (event: string, message: string, meta?: Record<string, unknown>) => void;
+  warn: (event: string, message: string, meta?: Record<string, unknown>) => void;
+}
+
+export interface EvictOptions {
+  /** Grace period between SIGTERM and SIGKILL (ms). Default: {@link DAEMON_EVICT_TIMEOUT_MS}. */
+  graceMs?: number;
+  /** Poll interval while waiting for process exit (ms). Default: {@link DAEMON_EVICT_POLL_MS}. */
+  pollMs?: number;
+  /** Optional logger. Falls back to silent when omitted. */
+  logger?: EvictionLogger;
+}
+
+/** Source that surfaced a PID — useful for logs and tests. */
+export type PidSource = 'daemon.json' | `port:${number}`;
+
+export interface EvictionTarget {
+  pid: number;
+  source: PidSource;
+}
+
+const LOG_KIND = 'daemon.eviction';
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Evict every myco daemon running for `vaultDir`.
+ *
+ * Looks at both the PID in `daemon.json` and any myco daemon holding a port
+ * in the canonical range derived from `vaultDir`. SIGTERMs with a grace
+ * period, escalates to SIGKILL, then waits for the process to exit.
+ *
+ * Safe to call before the caller has bound its own port (the current process
+ * is excluded from the kill list).
+ */
+export async function evictDaemonsForVault(
+  vaultDir: string,
+  opts: EvictOptions = {},
+): Promise<EvictionTarget[]> {
+  const logger = opts.logger;
+  const graceMs = opts.graceMs ?? DAEMON_EVICT_TIMEOUT_MS;
+  const pollMs = opts.pollMs ?? DAEMON_EVICT_POLL_MS;
+  const canonicalPort = derivePort(vaultDir);
+
+  const targets = findDaemonTargetsForVault(vaultDir, canonicalPort);
+  if (targets.length === 0) return [];
+
+  logger?.info(LOG_KIND, 'Evicting daemons for vault', {
+    vault: vaultDir,
+    canonical_port: canonicalPort,
+    targets: targets.map((t) => ({ pid: t.pid, source: t.source })),
+  });
+
+  await Promise.all(
+    targets.map((t) => terminateProcess(t.pid, { graceMs, pollMs, logger })),
+  );
+
+  // Best-effort: unlink daemon.json if it still points at one of the evicted
+  // PIDs. Leaving it can cause subsequent startups to "step aside" from a
+  // process we just killed.
+  cleanStaleDaemonJson(vaultDir, targets.map((t) => t.pid));
+
+  return targets;
+}
+
+/**
+ * Return the union of (daemon.json PID, canonical-port squatters) for a vault.
+ *
+ * Filtered to myco daemons only, deduplicated, and excluding the current
+ * process. Port squatters that are NOT myco daemons for this vault are
+ * ignored — we don't want to kill an unrelated service just because it
+ * grabbed our preferred port.
+ */
+export function findDaemonTargetsForVault(
+  vaultDir: string,
+  canonicalPort: number,
+): EvictionTarget[] {
+  const seen = new Map<number, EvictionTarget>();
+
+  const jsonPid = readDaemonJsonPid(vaultDir);
+  if (jsonPid !== undefined && jsonPid !== process.pid && isProcessAlive(jsonPid)) {
+    seen.set(jsonPid, { pid: jsonPid, source: 'daemon.json' });
+  }
+
+  const portsToScan = rangeInclusive(canonicalPort, canonicalPort + EVICT_PORT_SCAN_RANGE - 1)
+    .filter((p) => p <= 65535);
+  const squatters = findPidsListeningOn(portsToScan);
+  for (const { port, pid } of squatters) {
+    if (pid === process.pid) continue;
+    if (seen.has(pid)) continue;
+    if (!isMycoDaemonForVault(pid, vaultDir)) continue;
+    seen.set(pid, { pid, source: `port:${port}` });
+  }
+
+  return [...seen.values()];
+}
+
+// ---------------------------------------------------------------------------
+// Process termination
+// ---------------------------------------------------------------------------
+
+interface TerminateOpts {
+  graceMs: number;
+  pollMs: number;
+  logger?: EvictionLogger;
+}
+
+/** SIGTERM → poll → SIGKILL → verify. Resolves when the process is gone. */
+export async function terminateProcess(pid: number, opts: TerminateOpts): Promise<void> {
+  const { graceMs, pollMs, logger } = opts;
+
+  if (!isProcessAlive(pid)) return;
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch {
+    return; // already dead between isAlive and kill
+  }
+
+  if (await waitForProcessExit(pid, graceMs, pollMs)) return;
+
+  logger?.warn(LOG_KIND, 'Daemon did not exit after SIGTERM, escalating to SIGKILL', {
+    pid,
+    grace_ms: graceMs,
+  });
+
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    return; // died during the escalation window
+  }
+
+  // Short verify window — the kernel normally reaps promptly after SIGKILL.
+  if (await waitForProcessExit(pid, pollMs * 5, pollMs)) return;
+
+  logger?.warn(LOG_KIND, 'Daemon still alive after SIGKILL', { pid });
+}
+
+/** Poll `process.kill(pid, 0)` until it throws (dead) or the deadline passes. */
+async function waitForProcessExit(pid: number, timeoutMs: number, pollMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return true;
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  return !isProcessAlive(pid);
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+function readDaemonJsonPid(vaultDir: string): number | undefined {
+  try {
+    const jsonPath = path.join(vaultDir, 'daemon.json');
+    const raw = fs.readFileSync(jsonPath, 'utf-8');
+    const info = JSON.parse(raw) as { pid?: unknown };
+    return typeof info.pid === 'number' ? info.pid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+interface PortOwner {
+  port: number;
+  pid: number;
+}
+
+/**
+ * Return PIDs currently LISTENing on any of the given ports, via `lsof`.
+ *
+ * Shelling out to `lsof` is a deliberate choice: Node's net APIs only report
+ * whether a port is bindable, not who owns it. `lsof` is present on both
+ * Darwin and Linux; the Bun single-file binary can invoke it the same way.
+ */
+export function findPidsListeningOn(ports: number[]): PortOwner[] {
+  if (ports.length === 0) return [];
+  const range = formatPortRange(ports);
+
+  let stdout: string;
+  try {
+    stdout = execFileSync(
+      'lsof',
+      ['-iTCP:' + range, '-sTCP:LISTEN', '-nP', '-F', 'pn'],
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 2000 },
+    );
+  } catch {
+    // `lsof` exits non-zero when nothing matches — treat as "no squatters".
+    return [];
+  }
+
+  return parseLsofOutput(stdout);
+}
+
+/**
+ * Parse the `-F pn` field-formatted output of `lsof`. Each record starts with
+ * `p<pid>`; subsequent `n` lines give the name (e.g. `127.0.0.1:21039`) which
+ * we parse to extract the listening port.
+ */
+export function parseLsofOutput(stdout: string): PortOwner[] {
+  const owners: PortOwner[] = [];
+  let currentPid: number | undefined;
+  for (const line of stdout.split('\n')) {
+    if (line.startsWith('p')) {
+      const pid = Number(line.slice(1));
+      currentPid = Number.isFinite(pid) ? pid : undefined;
+    } else if (line.startsWith('n') && currentPid !== undefined) {
+      const match = line.match(/:(\d+)$/);
+      if (!match?.[1]) continue;
+      const port = Number(match[1]);
+      if (!Number.isFinite(port)) continue;
+      owners.push({ port, pid: currentPid });
+    }
+  }
+  return owners;
+}
+
+/**
+ * True when `pid` is a myco daemon process invoked with `--vault <vaultDir>`.
+ *
+ * Uses `ps -p <pid> -o args=` and matches against the resolved vault path.
+ * Handles both `--vault /path` and `--vault=/path` forms.
+ */
+export function isMycoDaemonForVault(pid: number, vaultDir: string): boolean {
+  let args: string;
+  try {
+    args = execFileSync('ps', ['-p', String(pid), '-o', 'args='], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+    }).trim();
+  } catch {
+    return false;
+  }
+  return matchesMycoDaemonInvocation(args, vaultDir);
+}
+
+/** Extracted for direct testability without spawning `ps`. */
+export function matchesMycoDaemonInvocation(args: string, vaultDir: string): boolean {
+  if (args.length === 0) return false;
+
+  const flagIndex = args.indexOf('--vault');
+  if (flagIndex < 0) return false;
+
+  // "myco" must appear in the command portion BEFORE --vault — not in the
+  // vault path itself. Otherwise a vault at `/home/me/myco-stuff/.myco`
+  // would spuriously match any `node ... daemon --vault /home/me/myco-stuff/.myco`.
+  const head = args.slice(0, flagIndex);
+  if (!/myco/i.test(head)) return false;
+  if (!/(^|[\s/])daemon(\s|$)/.test(head)) return false;
+
+  const resolved = path.resolve(vaultDir);
+  const attached = `--vault=${resolved}`;
+  if (args.includes(attached)) return true;
+
+  const tail = args.slice(flagIndex + '--vault'.length).replace(/^[=\s]+/, '');
+  if (tail.length === 0) return false;
+
+  // `tail` may continue with additional flags; take the next token only.
+  const nextArg = tail.split(/\s+/, 1)[0] ?? '';
+  return path.resolve(nextArg) === resolved;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function rangeInclusive(lo: number, hi: number): number[] {
+  const out: number[] = [];
+  for (let p = lo; p <= hi; p++) out.push(p);
+  return out;
+}
+
+function formatPortRange(ports: number[]): string {
+  const sorted = [...new Set(ports)].sort((a, b) => a - b);
+  const first = sorted[0];
+  const last = sorted[sorted.length - 1];
+  if (first === undefined || last === undefined) return '';
+  return first === last ? `${first}` : `${first}-${last}`;
+}
+
+function cleanStaleDaemonJson(vaultDir: string, evictedPids: number[]): void {
+  try {
+    const jsonPath = path.join(vaultDir, 'daemon.json');
+    const raw = fs.readFileSync(jsonPath, 'utf-8');
+    const info = JSON.parse(raw) as { pid?: unknown };
+    if (typeof info.pid === 'number' && evictedPids.includes(info.pid)) {
+      fs.unlinkSync(jsonPath);
+    }
+  } catch {
+    // daemon.json already absent or a sibling wrote a new one — leave it.
+  }
+}

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -10,8 +10,8 @@
 import { DaemonServer } from './server.js';
 import { SessionRegistry } from './lifecycle.js';
 import { DaemonLogger } from './logger.js';
-import { loadMergedConfig, updateConfig } from '../config/loader.js';
-import { resolvePort } from './port.js';
+import { loadMergedConfig } from '../config/loader.js';
+import { derivePort } from './port.js';
 import { TranscriptMiner } from '../capture/transcript-miner.js';
 import { createPerProjectAdapter } from '../symbionts/adapter.js';
 import { claudeCodeAdapter } from '../symbionts/claude-code.js';
@@ -171,6 +171,28 @@ import os from 'node:os';
 import path from 'node:path';
 
 // ---------------------------------------------------------------------------
+// Sibling probe
+// ---------------------------------------------------------------------------
+
+/**
+ * True when `127.0.0.1:<port>/health` responds with a myco daemon heartbeat.
+ * Used during startup to distinguish a concurrent sibling (step-aside
+ * candidate) from an unrelated port squatter.
+ */
+export async function isHealthyMycoSibling(port: number): Promise<boolean> {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/health`, {
+      signal: AbortSignal.timeout(DAEMON_HEALTH_CHECK_TIMEOUT_MS),
+    });
+    if (!res.ok) return false;
+    const data = await res.json() as { myco?: boolean };
+    return data.myco === true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Stale daemon cleanup
 // ---------------------------------------------------------------------------
 
@@ -213,11 +235,18 @@ export async function reconcileExistingDaemon(
     return 'ok';
   }
 
-  // Alive. If it's recent AND healthy AND the same version, step aside rather
-  // than racing it. Without this guard, two concurrent spawns kill each other
-  // in sequence and the surviving PID is whichever one ran last.
+  // Alive. If it's recent AND healthy AND the same version AND on the
+  // canonical port, step aside rather than racing it. Without this guard,
+  // two concurrent spawns kill each other in sequence and the surviving PID
+  // is whichever one ran last.
+  //
+  // The canonical-port check is load-bearing: if the sibling fell back to
+  // `canonical+1` because an orphan was squatting the canonical port, we
+  // must NOT step aside — we need to proceed through eviction, kill the
+  // orphan, and bind the canonical port ourselves.
   const recent = Date.now() - mtimeMs < DAEMON_STALE_GRACE_PERIOD_MS;
-  if (recent && typeof info.port === 'number') {
+  const canonicalPort = derivePort(vaultDir);
+  if (recent && typeof info.port === 'number' && info.port === canonicalPort) {
     try {
       const res = await fetch(`http://127.0.0.1:${info.port}/health`, {
         signal: AbortSignal.timeout(DAEMON_HEALTH_CHECK_TIMEOUT_MS),
@@ -983,13 +1012,40 @@ export async function main(): Promise<void> {
   server.registerRoute('GET', '/api/notifications/unread-count', async () => handleUnreadCount());
 
   // --- Start server ---
+  //
+  // The port is authoritative: either the explicit `daemon.port` override in
+  // myco.yaml or the deterministic hash of the vault path via `derivePort`.
+  // No silent fallback — if the port is unavailable after eviction, either a
+  // concurrent sibling won the race (step aside) or something unrelated is
+  // squatting (fail loudly). Ghost daemons on surprise ports come from
+  // silent fallback, so we don't do that.
 
   await server.evictExistingDaemon();
-  const resolvedPort = await resolvePort(config.daemon.port, vaultDir);
-  if (resolvedPort === 0) {
-    logger.warn(LOG_KINDS.DAEMON_PORT, 'All preferred ports occupied, using ephemeral port');
+  const canonicalPort = config.daemon.port ?? derivePort(vaultDir);
+
+  try {
+    await server.start(canonicalPort);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code !== 'EADDRINUSE') throw err;
+
+    if (await isHealthyMycoSibling(canonicalPort)) {
+      logger.info(LOG_KINDS.DAEMON_START, 'Sibling claimed canonical port during startup — stepping aside', {
+        port: canonicalPort,
+      });
+      process.exit(0);
+    }
+
+    logger.error(LOG_KINDS.DAEMON_PORT, 'Canonical port is held by another process — cannot start', {
+      port: canonicalPort,
+      hint: `Run \`lsof -iTCP:${canonicalPort}\` to identify the owner, then either kill it or override daemon.port in myco.yaml`,
+    });
+    process.stderr.write(
+      `Myco daemon cannot bind port ${canonicalPort} (held by another process). ` +
+        `Run \`lsof -iTCP:${canonicalPort}\` to investigate.\n`,
+    );
+    process.exit(1);
   }
-  await server.start(resolvedPort);
   logger.info(LOG_KINDS.DAEMON_READY, 'Daemon ready', { vault: vaultDir, port: server.port });
 
   // Pre-warm modules that are dynamically imported from daemon hot paths.
@@ -1013,19 +1069,6 @@ export async function main(): Promise<void> {
       error: (err as Error).message,
     });
   });
-
-  // Persist the resolved port to config if it was auto-derived
-  if (config.daemon.port === null && resolvedPort !== 0) {
-    try {
-      updateConfig(vaultDir, (c) => ({
-        ...c,
-        daemon: { ...c.daemon, port: resolvedPort },
-      }));
-      logger.info(LOG_KINDS.DAEMON_CONFIG, 'Persisted auto-derived port to myco.yaml', { port: resolvedPort });
-    } catch (err) {
-      logger.warn(LOG_KINDS.DAEMON_CONFIG, 'Failed to persist auto-derived port', { error: (err as Error).message });
-    }
-  }
 
   // --- Register power-managed jobs ---
   registerPowerJobs(powerManager, {

--- a/packages/myco/src/daemon/port.ts
+++ b/packages/myco/src/daemon/port.ts
@@ -1,41 +1,19 @@
 import { createHash } from 'node:crypto';
-import net from 'node:net';
 
 export const PORT_RANGE_START = 19200;
 export const PORT_RANGE_SIZE = 10000;
-const PORT_RETRY_COUNT = 10;
 
-/** Derive a deterministic port from a vault path. */
+/**
+ * Derive a deterministic port from a vault path.
+ *
+ * The port is the authoritative binding target for a daemon — either this
+ * derived value, or an explicit override in `myco.yaml` under `daemon.port`.
+ * Startup never silently falls back to a different port; if the canonical
+ * port is unavailable, the daemon either steps aside (sibling wins) or
+ * fails loudly (unrelated squatter).
+ */
 export function derivePort(vaultPath: string): number {
   const hash = createHash('md5').update(vaultPath).digest();
   const num = hash.readUInt16LE(0);
   return PORT_RANGE_START + (num % PORT_RANGE_SIZE);
-}
-
-/** Resolve the port to bind: try config port, derive from path, or fall back to ephemeral. */
-export async function resolvePort(
-  configPort: number | null,
-  vaultPath: string,
-): Promise<number> {
-  const basePort = configPort ?? derivePort(vaultPath);
-
-  for (let offset = 0; offset < PORT_RETRY_COUNT; offset++) {
-    const candidate = basePort + offset;
-    if (candidate > 65535) break;
-    if (await isPortAvailable(candidate)) return candidate;
-  }
-
-  // All candidates taken — fall back to ephemeral
-  return 0;
-}
-
-function isPortAvailable(port: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const server = net.createServer();
-    server.once('error', () => resolve(false));
-    server.once('listening', () => {
-      server.close(() => resolve(true));
-    });
-    server.listen(port, '127.0.0.1');
-  });
 }

--- a/packages/myco/src/daemon/server.ts
+++ b/packages/myco/src/daemon/server.ts
@@ -6,7 +6,7 @@ import type { DaemonLogger } from './logger.js';
 import { getPluginVersion } from '../version.js';
 import { Router, type RouteHandler } from './router.js';
 import { resolveStaticFile } from './static.js';
-import { DAEMON_EVICT_TIMEOUT_MS, DAEMON_EVICT_POLL_MS } from '../constants.js';
+import { evictDaemonsForVault } from './eviction.js';
 import { LOG_KINDS } from '../constants/log-kinds.js';
 
 const DEFAULT_STATUS = 200;
@@ -280,41 +280,14 @@ export class DaemonServer {
   /**
    * Kill any existing daemon for this vault before taking over.
    * Prevents orphaned daemons when spawned from worktrees or plugin upgrades.
-   * Must be called BEFORE resolvePort() so the old daemon releases the port.
+   * Must be called BEFORE `server.start()` so the old daemon releases the
+   * canonical port.
+   *
+   * Delegates to `evictDaemonsForVault`, which also handles orphans that
+   * hold the canonical port but aren't recorded in daemon.json.
    */
   async evictExistingDaemon(): Promise<void> {
-    const jsonPath = path.join(this.vaultDir, 'daemon.json');
-    let existingPid: number | undefined;
-    try {
-      const content = fs.readFileSync(jsonPath, 'utf-8');
-      const info = JSON.parse(content);
-      if (typeof info.pid === 'number' && info.pid !== process.pid) {
-        existingPid = info.pid;
-      }
-    } catch { /* no daemon.json or invalid — nothing to evict */ }
-
-    if (!existingPid) return;
-
-    // Check if the process is alive
-    try { process.kill(existingPid, 0); } catch { return; /* already dead */ }
-
-    this.logger.info(LOG_KINDS.DAEMON_START, 'Evicting existing daemon', { pid: existingPid });
-    try { process.kill(existingPid, 'SIGTERM'); } catch { return; }
-
-    // Give SIGTERM a grace period, then escalate to SIGKILL to guarantee port release
-    const deadline = Date.now() + DAEMON_EVICT_TIMEOUT_MS;
-    while (Date.now() < deadline) {
-      await new Promise((r) => setTimeout(r, DAEMON_EVICT_POLL_MS));
-      try { process.kill(existingPid, 0); } catch { return; /* dead */ }
-    }
-
-    this.logger.warn(LOG_KINDS.DAEMON_START, 'Evicted daemon did not exit in time, sending SIGKILL', { pid: existingPid });
-    try { process.kill(existingPid, 'SIGKILL'); } catch { return; }
-
-    // Verify SIGKILL took effect
-    await new Promise((r) => setTimeout(r, DAEMON_EVICT_POLL_MS));
-    try { process.kill(existingPid, 0); } catch { return; /* dead */ }
-    this.logger.warn(LOG_KINDS.DAEMON_START, 'Evicted daemon still alive after SIGKILL', { pid: existingPid });
+    await evictDaemonsForVault(this.vaultDir, { logger: this.logger });
   }
 
   private writeDaemonJson(): void {

--- a/packages/myco/src/daemon/update-checker.ts
+++ b/packages/myco/src/daemon/update-checker.ts
@@ -29,6 +29,7 @@ import {
   UPDATE_PACKAGES,
   MYCO_GLOBAL_DIR,
   PROJECT_RUNTIME_DIRNAME,
+  PROJECT_RUNTIME_COMMAND_FILENAME,
   UPDATE_CHECK_CACHE_PATH,
   UPDATE_CONFIG_PATH,
   UPDATE_ERROR_PATH,
@@ -74,12 +75,21 @@ export interface PackageCheckResult {
   latest_version: string | null;
   latest_stable: string | null;
   latest_beta: string | null;
+  /** True when the target version is strictly greater than what's installed. */
   update_available: boolean;
+  /**
+   * True when the project is pinned to a managed beta runtime and the stable
+   * target is lower than the running version — set only on the `myco` package
+   * during a revert-to-stable flow. Mutually exclusive with `update_available`.
+   */
+  revert_available: boolean;
 }
 
 /** Result returned to callers of checkForUpdate / statusFromCache */
 export interface CheckResult {
   update_available: boolean;
+  /** True when any package has `revert_available` set. */
+  revert_available: boolean;
   running_version: string;
   latest_version: string;
   latest_stable: string;
@@ -151,24 +161,62 @@ export function resolveMycoBinary(): string {
 
 export function resolveRuntimeCommand(vaultDir: string): string | null {
   try {
-    const raw = fs.readFileSync(path.join(vaultDir, 'runtime.command'), 'utf-8').trim();
+    const raw = fs.readFileSync(path.join(vaultDir, PROJECT_RUNTIME_COMMAND_FILENAME), 'utf-8').trim();
     return raw || null;
   } catch {
     return null;
   }
 }
 
-export function isManagedProjectRuntime(cliEntry: string): boolean {
+/**
+ * True when `cliEntry` points inside the project-local managed runtime.
+ *
+ * When `vaultDir` is known, prefer `startsWith` against the exact managed
+ * runtime path — this is robust to `.myco` being relocated via
+ * `MYCO_VAULT_DIR`. The path-less form falls back to a substring match,
+ * used only in contexts where vaultDir is unavailable.
+ */
+export function isManagedProjectRuntime(cliEntry: string, vaultDir?: string): boolean {
   const normalized = cliEntry.split(path.sep).join('/');
+  if (vaultDir !== undefined) {
+    const managedPrefix = `${vaultDir.split(path.sep).join('/')}/${PROJECT_RUNTIME_DIRNAME}/node_modules/`;
+    return normalized.startsWith(managedPrefix);
+  }
   return normalized.includes(`/.myco/${PROJECT_RUNTIME_DIRNAME}/node_modules/`);
+}
+
+/**
+ * Classify how the current project dispatches the `myco` binary.
+ *
+ * - `'project'` — a managed project-local runtime exists under the vault
+ *   (`.myco/runtime/`), pointed at by `.myco/runtime.command`.
+ * - `'machine'` — no project-local runtime; fall back to the machine-
+ *   installed myco via PATH or its absolute path.
+ *
+ * Single source of truth for the "where does this project's myco live"
+ * question. Prefer this over reading `runtime.command` directly.
+ */
+export function getRuntimeScope(vaultDir: string): 'project' | 'machine' {
+  const runtimeCommand = resolveRuntimeCommand(vaultDir);
+  return runtimeCommand !== null && isManagedProjectRuntime(runtimeCommand, vaultDir)
+    ? 'project'
+    : 'machine';
 }
 
 export function readProjectReleaseChannel(vaultDir: string): ReleaseChannel {
   const local = loadLocalConfig(vaultDir);
-  const channel = local.update?.channel;
-  return RELEASE_CHANNELS.includes(channel as ReleaseChannel)
-    ? channel as ReleaseChannel
-    : DEFAULT_RELEASE_CHANNEL;
+  const projectChannel = local.update?.channel;
+  if (RELEASE_CHANNELS.includes(projectChannel as ReleaseChannel)) {
+    return projectChannel as ReleaseChannel;
+  }
+
+  // Migration fallback: before 0.22, the channel lived in the machine-global
+  // ~/.myco/update.yaml. Honor that preference when this project has not
+  // explicitly set one, so existing beta users don't silently fall back to
+  // stable after upgrading. Per-project opt-out via the Operations UI writes
+  // to local.yaml and shadows this fallback.
+  const legacyChannel = readUpdateConfig().channel;
+  return RELEASE_CHANNELS.includes(legacyChannel) ? legacyChannel : DEFAULT_RELEASE_CHANNEL;
 }
 
 export function writeProjectReleaseChannel(vaultDir: string, channel: ReleaseChannel): void {
@@ -450,24 +498,30 @@ function buildPackageResults(
   channel: ReleaseChannel,
   globalPrefix: string | null,
   runtimeCommand: string | null = null,
+  vaultDir?: string,
 ): PackageCheckResult[] {
   const installedVersions = buildInstalledPackageVersions(globalPrefix, currentVersion);
   const isManagedStableRevert =
     channel === 'stable'
     && runtimeCommand !== null
-    && isManagedProjectRuntime(runtimeCommand);
+    && isManagedProjectRuntime(runtimeCommand, vaultDir);
 
   return UPDATE_PACKAGES.map((pkg) => {
     const cached = cache.packages[pkg.id];
     const installedVersion = installedVersions[pkg.id];
     const latestVersion = cached ? resolveTargetVersionFromCache(cached, channel) : null;
-    const updateAvailable = pkg.id === 'myco' && isManagedStableRevert
-      ? latestVersion !== null && latestVersion !== currentVersion
-      : installedVersion !== null &&
-        latestVersion !== null &&
-        semver.valid(installedVersion) !== null &&
-        semver.valid(latestVersion) !== null &&
-        semver.gt(latestVersion, installedVersion);
+    const updateAvailable =
+      installedVersion !== null &&
+      latestVersion !== null &&
+      semver.valid(installedVersion) !== null &&
+      semver.valid(latestVersion) !== null &&
+      semver.gt(latestVersion, installedVersion);
+    const revertAvailable =
+      pkg.id === 'myco' &&
+      isManagedStableRevert &&
+      latestVersion !== null &&
+      latestVersion !== currentVersion &&
+      !updateAvailable;
 
     return {
       id: pkg.id,
@@ -479,6 +533,7 @@ function buildPackageResults(
       latest_stable: cached?.latest_stable ?? null,
       latest_beta: cached?.latest_beta ?? null,
       update_available: updateAvailable,
+      revert_available: revertAvailable,
     };
   });
 }
@@ -495,19 +550,23 @@ function buildCheckResult(
   error: string | null,
   globalPrefix: string | null,
   runtimeCommand: string | null = null,
+  vaultDir?: string,
 ): CheckResult {
-  const packages = buildPackageResults(currentVersion, cache, channel, globalPrefix, runtimeCommand);
+  const packages = buildPackageResults(currentVersion, cache, channel, globalPrefix, runtimeCommand, vaultDir);
   const primaryPackage = packages.find((pkg) => pkg.id === 'myco');
   const targetVersion = primaryPackage?.latest_version ?? currentVersion;
   const latestStable = primaryPackage?.latest_stable ?? currentVersion;
   const latestBeta = primaryPackage?.latest_beta ?? null;
   const updateAvailable = packages.some((pkg) => pkg.installed && pkg.update_available);
-  const runtimeScope = runtimeCommand !== null && isManagedProjectRuntime(runtimeCommand)
-    ? 'project'
-    : 'machine';
+  const revertAvailable = packages.some((pkg) => pkg.revert_available);
+  const runtimeScope: 'project' | 'machine' =
+    runtimeCommand !== null && isManagedProjectRuntime(runtimeCommand, vaultDir)
+      ? 'project'
+      : 'machine';
 
   return {
     update_available: updateAvailable,
+    revert_available: revertAvailable,
     running_version: currentVersion,
     latest_version: targetVersion,
     latest_stable: latestStable,
@@ -576,6 +635,7 @@ export async function checkForUpdate(
   globalPrefix: string | null = null,
   runtimeCommand: string | null = null,
   channelOverride?: ReleaseChannel,
+  vaultDir?: string,
 ): Promise<CheckResult> {
   const config = readUpdateConfig();
   const existingCache = readCachedCheck();
@@ -632,13 +692,17 @@ export async function checkForUpdate(
     const fetchError = fetchErrors[0] ?? 'registry fetch failed';
     return {
       update_available: false,
+      revert_available: false,
       running_version: currentVersion,
       latest_version: currentVersion,
       latest_stable: currentVersion,
       latest_beta: null,
       channel: effectiveChannel,
       channel_scope: 'project',
-      runtime_scope: runtimeCommand !== null && isManagedProjectRuntime(runtimeCommand) ? 'project' : 'machine',
+      runtime_scope:
+        runtimeCommand !== null && isManagedProjectRuntime(runtimeCommand, vaultDir)
+          ? 'project'
+          : 'machine',
       check_interval_hours: config.check_interval_hours,
       last_check: new Date().toISOString(),
       error: fetchError,
@@ -648,6 +712,7 @@ export async function checkForUpdate(
         effectiveChannel,
         globalPrefix,
         runtimeCommand,
+        vaultDir,
       ),
     };
   }
@@ -674,6 +739,7 @@ export async function checkForUpdate(
     error,
     globalPrefix,
     runtimeCommand,
+    vaultDir,
   );
 }
 
@@ -691,6 +757,7 @@ export function statusFromCache(
   globalPrefix: string | null = null,
   runtimeCommand: string | null = null,
   channelOverride?: ReleaseChannel,
+  vaultDir?: string,
 ): CheckResult | null {
   const resolvedCache = cache !== undefined ? cache : readCachedCheck();
   if (resolvedCache === null) return null;
@@ -705,5 +772,6 @@ export function statusFromCache(
     null,
     globalPrefix,
     runtimeCommand,
+    vaultDir,
   );
 }

--- a/packages/myco/src/daemon/update-installer.ts
+++ b/packages/myco/src/daemon/update-installer.ts
@@ -14,6 +14,7 @@ import { spawn } from 'node:child_process';
 import {
   MYCO_GLOBAL_DIR,
   PROJECT_RUNTIME_DIRNAME,
+  PROJECT_RUNTIME_COMMAND_FILENAME,
   UPDATE_ERROR_PATH,
   UPDATE_SCRIPT_DELAY_SECONDS,
   RESTART_REASON_FILENAME,
@@ -77,7 +78,7 @@ export function generateUpdateScript(params: InstallParams): string {
   const quotedErrorPath = JSON.stringify(UPDATE_ERROR_PATH);
   const localRuntimeDir = path.join(vaultDir, PROJECT_RUNTIME_DIRNAME);
   const localRuntimeTmpDir = `${localRuntimeDir}.tmp`;
-  const localRuntimeCommandPath = path.join(vaultDir, 'runtime.command');
+  const localRuntimeCommandPath = path.join(vaultDir, PROJECT_RUNTIME_COMMAND_FILENAME);
   const localRuntimeMyco = path.join(localRuntimeDir, 'node_modules', '.bin', 'myco');
   const quotedLocalRuntimeSpec = localRuntimeSpec ? JSON.stringify(localRuntimeSpec) : null;
   const quotedLocalRuntimeDir = JSON.stringify(localRuntimeDir);

--- a/packages/myco/src/daemon/update-installer.ts
+++ b/packages/myco/src/daemon/update-installer.ts
@@ -14,6 +14,7 @@ import { spawn } from 'node:child_process';
 import {
   MYCO_GLOBAL_DIR,
   PROJECT_RUNTIME_DIRNAME,
+  PROJECT_RUNTIME_TMP_DIRNAME,
   PROJECT_RUNTIME_COMMAND_FILENAME,
   UPDATE_ERROR_PATH,
   UPDATE_SCRIPT_DELAY_SECONDS,
@@ -77,7 +78,7 @@ export function generateUpdateScript(params: InstallParams): string {
   const quotedMycoBinary = JSON.stringify(mycoBinary);
   const quotedErrorPath = JSON.stringify(UPDATE_ERROR_PATH);
   const localRuntimeDir = path.join(vaultDir, PROJECT_RUNTIME_DIRNAME);
-  const localRuntimeTmpDir = `${localRuntimeDir}.tmp`;
+  const localRuntimeTmpDir = path.join(vaultDir, PROJECT_RUNTIME_TMP_DIRNAME);
   const localRuntimeCommandPath = path.join(vaultDir, PROJECT_RUNTIME_COMMAND_FILENAME);
   const localRuntimeMyco = path.join(localRuntimeDir, 'node_modules', '.bin', 'myco');
   const quotedLocalRuntimeSpec = localRuntimeSpec ? JSON.stringify(localRuntimeSpec) : null;

--- a/packages/myco/src/hooks/hook-config.generated.ts
+++ b/packages/myco/src/hooks/hook-config.generated.ts
@@ -54,7 +54,19 @@ export const HOOK_CONFIG: Readonly<Record<string, HookConfigEntry>> = {
         }
       ],
       "interruptMarker": "[Request interrupted by user for tool use]"
-    }
+    },
+    "captureRules": [
+      {
+        "event": "user_prompt",
+        "scope": "this_agent",
+        "when": {
+          "prompt_starts_with": "<command-message>"
+        },
+        "action": "drop",
+        "reason": "claude-code-slash-command-dispatch",
+        "trim": true
+      }
+    ]
   },
   "codex": {
     "capturePrompts": {

--- a/packages/myco/src/symbionts/manifests.generated.ts
+++ b/packages/myco/src/symbionts/manifests.generated.ts
@@ -34,7 +34,18 @@ export const BUNDLED_MANIFESTS: readonly SymbiontManifest[] = [
       "planTags": [
         "ultraplan"
       ],
-      "rules": [],
+      "rules": [
+        {
+          "event": "user_prompt",
+          "scope": "this_agent",
+          "when": {
+            "prompt_starts_with": "<command-message>"
+          },
+          "action": "drop",
+          "reason": "claude-code-slash-command-dispatch",
+          "trim": true
+        }
+      ],
       "prompts": {
         "shapes": [
           {

--- a/packages/myco/src/symbionts/manifests/claude-code.yaml
+++ b/packages/myco/src/symbionts/manifests/claude-code.yaml
@@ -20,6 +20,36 @@ capture:
     # Ultraplan sends the approved cloud plan back to the terminal by injecting
     # it into the next user prompt as <ultraplan>...</ultraplan>.
     - ultraplan
+  rules:
+    # Slash-command dispatch envelope filter (structural).
+    #
+    # When the user runs `/name args`, Claude Code fires UserPromptSubmit with
+    # the raw `/name args` text — the hook captures it and stores it in a
+    # prompt_batch (buffer-backed if the daemon is down). The transcript then
+    # logs the dispatch as a pair of user entries sharing one promptId:
+    #   1. <command-message>name</command-message>
+    #      <command-name>/name</command-name>
+    #      <command-args>args</command-args>
+    #   2. the expanded command body (the rendered .claude/commands/<name>.md).
+    #
+    # Without this rule, transcript mining at Stop emits the XML-wrapped text
+    # as a record, reconcile can't match its prefix to the hook-stored
+    # `/name args` batch, and a duplicate batch is inserted. Dropping the
+    # wrapper entry also suppresses the expanded body via shape-level
+    # dedupeBy: promptId, so zero transcript records are emitted for the
+    # dispatch. The live hook capture is authoritative.
+    #
+    # The `<command-message>` prefix is Claude-synthesized — it only appears
+    # on real slash-command dispatches (prompts whose first token is a
+    # recognized `/name`). Plain prompts, mid-sentence `/` mentions, and
+    # queued_command attachments (which carry raw `/name args` text, not the
+    # XML envelope) are unaffected.
+    - event: user_prompt
+      scope: this_agent
+      when:
+        prompt_starts_with: "<command-message>"
+      action: drop
+      reason: claude-code-slash-command-dispatch
   prompts:
     shapes:
       # Standard user prompts. message.content is either a plain string or an

--- a/packages/myco/ui/src/components/operations/UpdateCard.tsx
+++ b/packages/myco/ui/src/components/operations/UpdateCard.tsx
@@ -136,6 +136,8 @@ export function UpdateCard() {
   const isChecking = checkMutation.isPending;
   const isApplying = applyState === 'applying' || applyState === 'restarting';
   const updateAvailable = status.update_available === true;
+  const revertAvailable = status.revert_available === true;
+  const actionAvailable = updateAvailable || revertAvailable;
   const activeChannel = status.channel ?? 'stable';
   const installedPackages = (status.packages ?? []).filter((pkg) => pkg.installed);
   const pendingPackages = installedPackages.filter((pkg) => pkg.update_available);
@@ -168,7 +170,7 @@ export function UpdateCard() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <ArrowUpCircle
-            className={cn('h-4 w-4', updateAvailable ? 'text-secondary' : 'text-primary')}
+            className={cn('h-4 w-4', actionAvailable ? 'text-secondary' : 'text-primary')}
           />
           <SectionHeader>Updates</SectionHeader>
         </div>
@@ -182,7 +184,7 @@ export function UpdateCard() {
 
       {/* Status row */}
       <div className="flex items-center gap-3 flex-wrap">
-        {updateAvailable ? (
+        {actionAvailable ? (
           <Button
             variant="default"
             size="sm"
@@ -192,12 +194,14 @@ export function UpdateCard() {
             {isApplying ? (
               <>
                 <RefreshCw className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                {applyState === 'restarting' ? 'Restarting…' : 'Updating…'}
+                {applyState === 'restarting' ? 'Restarting…' : (revertAvailable && !updateAvailable ? 'Reverting…' : 'Updating…')}
               </>
             ) : (
               <>
                 <ArrowUpCircle className="mr-1.5 h-3.5 w-3.5" />
-                {pendingCount > 1 ? `Update ${pendingCount} Packages & Restart` : 'Update & Restart'}
+                {revertAvailable && !updateAvailable
+                  ? 'Revert to Stable & Restart'
+                  : pendingCount > 1 ? `Update ${pendingCount} Packages & Restart` : 'Update & Restart'}
               </>
             )}
           </Button>
@@ -241,23 +245,26 @@ export function UpdateCard() {
 
       {installedPackages.length > 0 && (
         <div className="space-y-2">
-          {installedPackages.map((pkg) => (
-            <div
-              key={pkg.id}
-              className="flex items-center justify-between gap-3 rounded-md border border-outline/20 px-3 py-2"
-            >
-              <div className="min-w-0">
-                <div className="font-sans text-sm text-on-surface">{pkg.display_name}</div>
-                <div className="font-mono text-xs text-on-surface-variant">
-                  {pkg.installed_version ?? 'not installed'}
-                  {pkg.update_available && pkg.latest_version ? ` → ${pkg.latest_version}` : ''}
+          {installedPackages.map((pkg) => {
+            const showRevert = pkg.revert_available && !pkg.update_available;
+            return (
+              <div
+                key={pkg.id}
+                className="flex items-center justify-between gap-3 rounded-md border border-outline/20 px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <div className="font-sans text-sm text-on-surface">{pkg.display_name}</div>
+                  <div className="font-mono text-xs text-on-surface-variant">
+                    {pkg.installed_version ?? 'not installed'}
+                    {(pkg.update_available || showRevert) && pkg.latest_version ? ` → ${pkg.latest_version}` : ''}
+                  </div>
                 </div>
+                <Badge variant={pkg.update_available || showRevert ? 'warning' : 'secondary'}>
+                  {pkg.update_available ? 'Update available' : showRevert ? 'Revert pending' : 'Installed'}
+                </Badge>
               </div>
-              <Badge variant={pkg.update_available ? 'warning' : 'secondary'}>
-                {pkg.update_available ? 'Update available' : 'Installed'}
-              </Badge>
-            </div>
-          ))}
+            );
+          })}
           <p className="font-sans text-xs text-on-surface-variant">
             {runtimeSummary}
           </p>

--- a/packages/myco/ui/src/hooks/use-update-status.ts
+++ b/packages/myco/ui/src/hooks/use-update-status.ts
@@ -15,12 +15,14 @@ export interface UpdatePackageStatus {
   latest_stable: string | null;
   latest_beta: string | null;
   update_available: boolean;
+  revert_available?: boolean;
 }
 
 export interface UpdateStatus {
   exempt: boolean;
   running_version: string;
   update_available?: boolean;
+  revert_available?: boolean;
   latest_version?: string;
   latest_stable?: string;
   latest_beta?: string | null;

--- a/scripts/smoke-update-flow.ts
+++ b/scripts/smoke-update-flow.ts
@@ -1,0 +1,241 @@
+/**
+ * Smoke harness for the 0.22.0 update apply flow.
+ *
+ * Exercises `generateUpdateScript` with the exact params produced by
+ * `handleUpdateApply` across four scenarios. Prints the resulting shell
+ * script for each case so the decision logic can be eyeballed without
+ * cutting a real release or mutating the dev machine's npm install.
+ *
+ * Not a test — it hits the real `generateUpdateScript`, not a mock. Run
+ * with: `bun scripts/smoke-update-flow.ts`
+ *
+ * Scenarios:
+ *   1. Normal update on stable — user on 1.0.0, latest 1.1.0, machine-scoped
+ *   2. Stable → Beta opt-in, version gap — user on 1.0.0, latest beta 1.1.0-beta.1
+ *   3. Stable → Beta opt-in, matching global — user on 1.1.0, latest beta 1.1.0-beta.1
+ *      (this is the case that used to silently 400 before the beta opt-in fix)
+ *   4. Beta → Stable revert — user on 1.1.0-beta.1, stable 1.1.0, runtime-scoped
+ */
+
+import { generateUpdateScript } from '../packages/myco/src/daemon/update-installer.js';
+import type { PackageCheckResult, CheckResult } from '../packages/myco/src/daemon/update-checker.js';
+import { NPM_PACKAGE_NAME } from '../packages/myco/src/constants/update.js';
+
+type RuntimeScope = 'project' | 'machine';
+
+interface Scenario {
+  label: string;
+  description: string;
+  status: CheckResult;
+  runtimeScope: RuntimeScope;
+  mycoBinary: string;
+}
+
+// Mirror of the decision logic in `handleUpdateApply`. Kept in sync by hand —
+// the apply handler test suite verifies the same cases against the real
+// handler; this harness exists for human inspection of the generated bash.
+interface ApplyPlan {
+  updateSpecs: string[];
+  localRuntimeSpec: string | undefined;
+  removeLocalRuntime: boolean;
+  globalPackageSpecs: string[];
+}
+
+function computeApplyPlan(status: CheckResult, runtimeScope: RuntimeScope): ApplyPlan {
+  const mycoPackage = status.packages.find((p) => p.id === 'myco');
+  const mycoPackageSpec = mycoPackage?.latest_version
+    ? `${mycoPackage.package_name}@${mycoPackage.latest_version}`
+    : undefined;
+
+  const updateSpecs = status.packages
+    .filter((p) => p.installed && (p.update_available || p.revert_available) && p.latest_version)
+    .map((p) => `${p.package_name}@${p.latest_version}`);
+
+  const removeLocalRuntime = status.channel === 'stable' && runtimeScope === 'project';
+  const enteringBetaLocalRuntime = status.channel === 'beta' && runtimeScope === 'machine';
+
+  const localRuntimeSpec = enteringBetaLocalRuntime
+    ? mycoPackageSpec
+    : status.channel === 'beta'
+      ? updateSpecs.find((s) => s.startsWith(`${NPM_PACKAGE_NAME}@`))
+      : undefined;
+
+  const globalPackageSpecs = localRuntimeSpec
+    ? updateSpecs.filter((s) => s !== localRuntimeSpec)
+    : updateSpecs;
+
+  return { updateSpecs, localRuntimeSpec, removeLocalRuntime, globalPackageSpecs };
+}
+
+function makeMycoPackage(overrides: Partial<PackageCheckResult> = {}): PackageCheckResult {
+  return {
+    id: 'myco',
+    display_name: 'Myco',
+    package_name: NPM_PACKAGE_NAME,
+    installed: true,
+    installed_version: '1.0.0',
+    latest_version: '1.1.0',
+    latest_stable: '1.1.0',
+    latest_beta: null,
+    update_available: true,
+    revert_available: false,
+    ...overrides,
+  };
+}
+
+function makeStatus(overrides: Partial<CheckResult> = {}): CheckResult {
+  return {
+    update_available: true,
+    revert_available: false,
+    running_version: '1.0.0',
+    latest_version: '1.1.0',
+    latest_stable: '1.1.0',
+    latest_beta: null,
+    channel: 'stable',
+    channel_scope: 'project',
+    runtime_scope: 'machine',
+    check_interval_hours: 6,
+    last_check: new Date().toISOString(),
+    error: null,
+    packages: [makeMycoPackage()],
+    ...overrides,
+  };
+}
+
+const scenarios: Scenario[] = [
+  {
+    label: '1. Normal update on stable (machine-scoped)',
+    description:
+      'User on 1.0.0, latest stable 1.1.0. Expect: global npm install only; no project-local runtime, no removal.',
+    status: makeStatus(),
+    runtimeScope: 'machine',
+    mycoBinary: 'myco',
+  },
+  {
+    label: '2. Stable → Beta opt-in, version gap',
+    description:
+      'User on 1.0.0 global stable, latest beta 1.1.0-beta.1. Expect: project-local runtime install at beta; no global install.',
+    status: makeStatus({
+      channel: 'beta',
+      latest_version: '1.1.0-beta.1',
+      latest_stable: '1.0.0',
+      latest_beta: '1.1.0-beta.1',
+      packages: [
+        makeMycoPackage({
+          installed_version: '1.0.0',
+          latest_version: '1.1.0-beta.1',
+          latest_stable: '1.0.0',
+          latest_beta: '1.1.0-beta.1',
+        }),
+      ],
+    }),
+    runtimeScope: 'machine',
+    mycoBinary: 'myco',
+  },
+  {
+    label: '3. Stable → Beta opt-in, matching global (the fixed case)',
+    description:
+      'User on 1.1.0 global stable; latest beta also 1.1.0 (e.g., stable caught up). Before the fix this returned 400; now expect: project-local runtime install at 1.1.0; no global install.',
+    status: makeStatus({
+      channel: 'beta',
+      update_available: false,
+      revert_available: false,
+      running_version: '1.1.0',
+      latest_version: '1.1.0',
+      packages: [
+        makeMycoPackage({
+          installed_version: '1.1.0',
+          latest_version: '1.1.0',
+          update_available: false,
+          revert_available: false,
+        }),
+      ],
+    }),
+    runtimeScope: 'machine',
+    mycoBinary: 'myco',
+  },
+  {
+    label: '4. Beta → Stable revert (project-scoped)',
+    description:
+      'User on 1.1.0-beta.1 via project-local runtime; latest stable 1.0.0. Expect: global install at stable (revert_available=true path) + remove local runtime.',
+    status: makeStatus({
+      channel: 'stable',
+      update_available: false,
+      revert_available: true,
+      running_version: '1.1.0-beta.1',
+      latest_version: '1.0.0',
+      latest_stable: '1.0.0',
+      latest_beta: '1.1.0-beta.1',
+      packages: [
+        makeMycoPackage({
+          installed_version: '1.1.0-beta.1',
+          latest_version: '1.0.0',
+          latest_stable: '1.0.0',
+          latest_beta: '1.1.0-beta.1',
+          update_available: false,
+          revert_available: true,
+        }),
+      ],
+    }),
+    runtimeScope: 'project',
+    mycoBinary: '/project/.myco/runtime/node_modules/.bin/myco',
+  },
+];
+
+const projectRoot = '/example/project';
+const vaultDir = '/example/project/.myco';
+
+function renderScenario(s: Scenario): void {
+  console.log('═'.repeat(78));
+  console.log(s.label);
+  console.log('─'.repeat(78));
+  console.log(s.description);
+  console.log();
+
+  const plan = computeApplyPlan(s.status, s.runtimeScope);
+  console.log('Apply plan:');
+  console.log(`  globalPackageSpecs:  ${JSON.stringify(plan.globalPackageSpecs)}`);
+  console.log(`  localRuntimeSpec:    ${JSON.stringify(plan.localRuntimeSpec ?? null)}`);
+  console.log(`  removeLocalRuntime:  ${plan.removeLocalRuntime}`);
+  console.log();
+
+  if (
+    plan.globalPackageSpecs.length === 0 &&
+    plan.localRuntimeSpec === undefined &&
+    !plan.removeLocalRuntime
+  ) {
+    console.log('↪ Apply would return 400 no_update_available (no action computed).\n');
+    return;
+  }
+
+  const script = generateUpdateScript({
+    packageSpecs: plan.globalPackageSpecs,
+    localRuntimeSpec: plan.localRuntimeSpec,
+    removeLocalRuntime: plan.removeLocalRuntime,
+    projectRoot,
+    vaultDir,
+    mycoBinary: s.mycoBinary,
+  });
+
+  console.log('Generated shell script:');
+  console.log(
+    script
+      .split('\n')
+      .map((line) => `  │ ${line}`)
+      .join('\n'),
+  );
+  console.log();
+}
+
+console.log();
+console.log('Myco update-apply smoke harness');
+console.log(`vaultDir=${vaultDir}`);
+console.log(`projectRoot=${projectRoot}`);
+console.log();
+
+for (const s of scenarios) {
+  renderScenario(s);
+}
+
+console.log('═'.repeat(78));
+console.log('Smoke complete. Compare each plan against the scenario description.');

--- a/tests/capture/prompt-kind.test.ts
+++ b/tests/capture/prompt-kind.test.ts
@@ -96,6 +96,73 @@ describe('walkClaudeCode content shape handling', () => {
   });
 });
 
+describe('walkClaudeCode slash-command dispatch drop rule', () => {
+  // When the user runs `/name args`, Claude Code logs two user entries
+  // sharing one promptId: the XML-wrapped dispatch envelope and the
+  // expanded command body. UserPromptSubmit already captured `/name args`
+  // via the hook path, so both transcript entries are redundant and — if
+  // left alone — cause reconcileBatchKinds to insert a phantom second
+  // batch because the XML prefix doesn't match the hook-stored prefix.
+  //
+  // The manifest carries a `prompt_starts_with: "<command-message>"` drop
+  // rule. Paired with `dedupeBy: promptId`, dropping the wrapper also
+  // suppresses the expanded body.
+  it('drops both transcript entries for a slash-command dispatch', () => {
+    const events = [
+      {
+        type: 'user',
+        promptId: 'p1',
+        message: {
+          role: 'user',
+          content:
+            '<command-message>simplify</command-message>\n'
+            + '<command-name>/simplify</command-name>\n'
+            + '<command-args>review the diff</command-args>',
+        },
+      },
+      {
+        type: 'user',
+        promptId: 'p1',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: '# Simplify: Code Review and Cleanup\n...' }],
+        },
+      },
+    ];
+    expect(extractUserPromptKinds('claude-code', events)).toEqual([]);
+  });
+
+  it('leaves a plain user prompt untouched when no dispatch envelope is present', () => {
+    const events = [
+      {
+        type: 'user',
+        promptId: 'p1',
+        message: { role: 'user', content: 'please review the diff' },
+      },
+    ];
+    expect(extractUserPromptKinds('claude-code', events)).toEqual(['initial']);
+  });
+
+  it('does not drop a queued_command carrying raw slash-command text', () => {
+    // The Esc→queue UI writes queued slash commands as plain `/name args`
+    // in attachment.prompt, not the XML envelope. The drop rule keys on
+    // the envelope prefix, so queued commands are unaffected.
+    const events = [
+      {
+        type: 'user',
+        promptId: 'p1',
+        message: { role: 'user', content: 'open turn' },
+      },
+      {
+        type: 'attachment',
+        uuid: 'att-1',
+        attachment: { type: 'queued_command', prompt: '/simplify after this' },
+      },
+    ];
+    expect(extractUserPromptKinds('claude-code', events)).toEqual(['initial', 'steering']);
+  });
+});
+
 describe('walkClaudeCode queued_command shape (Phase 4)', () => {
   // Claude Code's Esc→queue UI writes mid-turn prompts as
   //   type:"attachment", attachment:{type:"queued_command", prompt:"..."}

--- a/tests/capture/transcript-miner-reconcile.test.ts
+++ b/tests/capture/transcript-miner-reconcile.test.ts
@@ -248,6 +248,59 @@ describe('TranscriptMiner.reconcileBatchKinds', () => {
     expect(result.errors.some((e) => /stranded|no matching transcript prompt/.test(e))).toBe(true);
   });
 
+  // Regression: Claude Code's slash-command dispatch writes a pair of user
+  // entries sharing one promptId — the <command-message> XML envelope and the
+  // expanded command body. UserPromptSubmit already captured `/<name> <args>`
+  // via the hook path, so both transcript entries are redundant. Before the
+  // claude-code.yaml drop rule, the walker emitted the XML-wrapped text as a
+  // record, reconcile couldn't match its prefix to the hook-stored batch, and
+  // a phantom second batch was inserted (bug showed two side-by-side prompts
+  // in the UI — the raw `/simplify …` form and the XML form).
+  it('does not duplicate a slash-command batch captured via the hook', () => {
+    handleUserPrompt(
+      's-reconcile',
+      '/simplify Okay. We have a lot of releases on Main which were designed to test the new beta on the bun binary',
+      { kind: 'initial' },
+    );
+
+    const events = [
+      // Dispatch envelope — dropped by the manifest rule.
+      {
+        type: 'user',
+        promptId: 'slash-1',
+        message: {
+          role: 'user',
+          content:
+            '<command-message>simplify</command-message>\n'
+            + '<command-name>/simplify</command-name>\n'
+            + '<command-args>Okay. We have a lot of releases on Main which were designed to test the new beta on the bun binary</command-args>',
+        },
+      },
+      // Expanded command body — suppressed via shape-level promptId dedupe.
+      {
+        type: 'user',
+        promptId: 'slash-1',
+        message: { role: 'user', content: [{ type: 'text', text: '# Simplify: Code Review and Cleanup\n...' }] },
+      },
+      { type: 'assistant', message: { stop_reason: 'end_turn' } },
+    ];
+    fs.writeFileSync(transcriptPath, events.map((e) => JSON.stringify(e)).join('\n') + '\n');
+
+    const miner = new TranscriptMiner();
+    const result = miner.reconcileBatchKinds('s-reconcile', {
+      agent: 'claude-code',
+      transcriptPath,
+    });
+
+    expect(result.inserted).toBe(0);
+    expect(result.errors).toEqual([]);
+
+    const after = listBatchesBySession('s-reconcile');
+    expect(after).toHaveLength(1);
+    expect(after[0].user_prompt).toContain('/simplify Okay.');
+    expect(after[0].user_prompt).not.toContain('<command-message>');
+  });
+
   it('inserts batches when the transcript has prompts and the DB has none', () => {
     // Cold reconcile — daemon missed every hook, the transcript is all we have.
     const events = [

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -121,7 +121,7 @@ describe('myco init', () => {
     expect(gitignore).toContain('logs/');
     expect(gitignore).toContain('attachments/');
     expect(gitignore).toContain('runtime/');
-    expect(gitignore).toContain('runtime.prev/');
+    expect(gitignore).toContain('runtime.tmp/');
   });
 
   it('is idempotent — does not overwrite user-set values on re-init', async () => {

--- a/tests/daemon/api/update.test.ts
+++ b/tests/daemon/api/update.test.ts
@@ -177,7 +177,7 @@ describe('handleUpdateStatus', () => {
     // Response returned immediately (does not await checkForUpdate)
     expect(result.body).toMatchObject({ exempt: false });
     // Background check was triggered
-    expect(checkForUpdate).toHaveBeenCalledWith('1.0.0', undefined, null, 'stable');
+    expect(checkForUpdate).toHaveBeenCalledWith('1.0.0', undefined, null, 'stable', '/vault');
   });
 
   it('returns exempt:false in body when not exempt', async () => {
@@ -234,7 +234,7 @@ describe('handleUpdateCheck', () => {
 
     const result = await handleUpdateCheck(makeReq());
 
-    expect(checkForUpdate).toHaveBeenCalledWith('1.0.0', undefined, null, 'stable');
+    expect(checkForUpdate).toHaveBeenCalledWith('1.0.0', undefined, null, 'stable', '/vault');
     expect(result.body).toMatchObject({ exempt: false, update_available: true });
   });
 
@@ -357,12 +357,16 @@ describe('handleUpdateApply', () => {
       running_version: '1.1.0-beta.1',
       latest_version: '1.0.0',
       latest_stable: '1.0.0',
+      update_available: false,
+      revert_available: true,
       packages: [
         {
           ...UPDATE_AVAILABLE_STATUS.packages[0],
           installed_version: '1.1.0-beta.1',
           latest_version: '1.0.0',
           latest_stable: '1.0.0',
+          update_available: false,
+          revert_available: true,
         },
       ],
     });
@@ -380,6 +384,45 @@ describe('handleUpdateApply', () => {
       projectRoot: '/project',
       vaultDir: '/vault',
       mycoBinary: '/project/.myco/runtime/node_modules/.bin/myco',
+    });
+  });
+
+  it('installs a project-local beta runtime even when the machine install matches the target', async () => {
+    // User is on stable, opts into beta for this project. Global myco is already
+    // at the version beta channel resolves to — update_available is false but
+    // we still need to create the project-local runtime.
+    vi.mocked(statusFromCache).mockReturnValue({
+      ...UPDATE_AVAILABLE_STATUS,
+      channel: 'beta',
+      update_available: false,
+      revert_available: false,
+      running_version: '1.0.0',
+      latest_version: '1.0.0',
+      packages: [
+        {
+          ...UPDATE_AVAILABLE_STATUS.packages[0],
+          installed_version: '1.0.0',
+          latest_version: '1.0.0',
+          update_available: false,
+          revert_available: false,
+        },
+      ],
+    });
+    vi.mocked(resolveRuntimeCommand).mockReturnValue(null);
+    vi.mocked(isManagedProjectRuntime).mockReturnValue(false);
+
+    const { handleUpdateApply } = createUpdateHandlers(makeDeps());
+
+    const result = await handleUpdateApply(makeReq());
+
+    expect(result.status).toBeUndefined();
+    expect(spawnUpdateScript).toHaveBeenCalledWith({
+      packageSpecs: [],
+      localRuntimeSpec: '@goondocks/myco@1.0.0',
+      removeLocalRuntime: false,
+      projectRoot: '/project',
+      vaultDir: '/vault',
+      mycoBinary: 'myco',
     });
   });
 });

--- a/tests/daemon/eviction-integration.test.ts
+++ b/tests/daemon/eviction-integration.test.ts
@@ -1,0 +1,148 @@
+/**
+ * End-to-end integration test for daemon eviction.
+ *
+ * Spawns a fake subprocess that mimics a myco daemon by (a) holding the
+ * canonical port for a vault and (b) carrying `myco daemon --vault <vault>`
+ * in its argv. Verifies `evictDaemonsForVault` finds and kills it even
+ * when `daemon.json` has no record of its PID.
+ *
+ * This is the scenario Chris hit today: an orphan daemon on :21039
+ * caused subsequent startups to silently fall back to :21040.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { spawn, type ChildProcess } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { evictDaemonsForVault } from '@myco/daemon/eviction.js';
+import { derivePort } from '@myco/daemon/port.js';
+
+/**
+ * Child program: binds the supplied port, reports ready, idles forever.
+ * Written to a temp file at test-setup time so we don't have to fight
+ * shell quoting of embedded JS when rewriting argv[0] below.
+ */
+const ORPHAN_PROGRAM = `
+const net = require('node:net');
+const server = net.createServer();
+const port = Number(process.argv[2]);
+server.listen(port, '127.0.0.1', () => {
+  process.stdout.write('READY\\n');
+});
+setInterval(() => {}, 1000);
+`;
+
+describe('evictDaemonsForVault — orphan on canonical port', () => {
+  let tmpVault: string;
+  let scriptPath: string;
+  let orphan: ChildProcess | null = null;
+
+  beforeEach(() => {
+    tmpVault = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-evict-int-'));
+    scriptPath = path.join(tmpVault, 'orphan.js');
+    fs.writeFileSync(scriptPath, ORPHAN_PROGRAM);
+  });
+
+  afterEach(() => {
+    if (orphan && orphan.pid) {
+      try { process.kill(orphan.pid, 'SIGKILL'); } catch { /* already dead */ }
+    }
+    orphan = null;
+    fs.rmSync(tmpVault, { recursive: true, force: true });
+  });
+
+  it('evicts a port squatter whose argv claims to be a myco daemon for this vault', async () => {
+    const canonicalPort = derivePort(tmpVault);
+
+    // Spawn our orphan with argv[0] rewritten to look like the myco daemon
+    // invocation. We can't actually change process name, but `ps -o args=`
+    // returns the invocation string as given — which starts with the
+    // command path. Node's `spawn` with the first argv being the program
+    // means the argv we care about is the subsequent list. The trick:
+    // pass a shell command that exec's node with a custom argv[0].
+    const invocation = `myco-fake-daemon daemon --vault ${tmpVault}`;
+    // bash supports `exec -a <name>` which rewrites argv[0]. `sh` may not.
+    orphan = spawn('/bin/bash', [
+      '-c',
+      `exec -a ${JSON.stringify(invocation)} ${JSON.stringify(process.execPath)} ${JSON.stringify(scriptPath)} ${canonicalPort}`,
+    ], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      detached: false,
+    });
+
+    const orphanPid = orphan.pid!;
+    expect(orphanPid).toBeGreaterThan(0);
+
+    // Wait for the orphan to report READY on stdout.
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('orphan did not become ready')), 3000);
+      orphan!.stdout!.on('data', (chunk: Buffer) => {
+        if (chunk.toString('utf-8').includes('READY')) {
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+    });
+
+    // Sanity: orphan is alive.
+    let alive = true;
+    try { process.kill(orphanPid, 0); } catch { alive = false; }
+    expect(alive).toBe(true);
+
+    // daemon.json is ABSENT — the orphan was never registered. This is
+    // exactly the pathological case the prior eviction logic missed.
+    expect(fs.existsSync(path.join(tmpVault, 'daemon.json'))).toBe(false);
+
+    // Evict.
+    const logs: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const evicted = await evictDaemonsForVault(tmpVault, {
+      graceMs: 1500,
+      pollMs: 50,
+      logger: {
+        info: (_k, msg, meta) => logs.push({ msg, meta }),
+        warn: (_k, msg, meta) => logs.push({ msg, meta }),
+      },
+    });
+
+    expect(evicted).toHaveLength(1);
+    expect(evicted[0]?.pid).toBe(orphanPid);
+    expect(evicted[0]?.source).toBe(`port:${canonicalPort}`);
+
+    // Orphan must be dead.
+    try { process.kill(orphanPid, 0); alive = true; } catch { alive = false; }
+    expect(alive).toBe(false);
+  }, 10_000);
+
+  it('ignores port squatters that are not myco daemons', async () => {
+    const canonicalPort = derivePort(tmpVault);
+
+    // Spawn a plain node process — no `myco` in argv.
+    orphan = spawn(process.execPath, [scriptPath, String(canonicalPort)], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      detached: false,
+    });
+
+    const orphanPid = orphan.pid!;
+
+    // Wait for READY.
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('orphan did not become ready')), 3000);
+      orphan!.stdout!.on('data', (chunk: Buffer) => {
+        if (chunk.toString('utf-8').includes('READY')) {
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+    });
+
+    const evicted = await evictDaemonsForVault(tmpVault, { graceMs: 500, pollMs: 50 });
+
+    // Non-myco process must NOT be evicted.
+    expect(evicted).toEqual([]);
+    let alive = false;
+    try { process.kill(orphanPid, 0); alive = true; } catch { /* dead */ }
+    expect(alive).toBe(true);
+  }, 10_000);
+});

--- a/tests/daemon/eviction.test.ts
+++ b/tests/daemon/eviction.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Unit tests for daemon eviction.
+ *
+ * The pure helpers (`parseLsofOutput`, `matchesMycoDaemonInvocation`) are
+ * tested directly. The orchestration (`evictDaemonsForVault`) is exercised
+ * via the exported `findDaemonTargetsForVault` using in-process state:
+ * a real live PID (the test process itself) stands in for "alive daemon,"
+ * a guaranteed-dead PID stands in for "stale daemon.json entry."
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import net from 'node:net';
+
+import {
+  parseLsofOutput,
+  matchesMycoDaemonInvocation,
+  findDaemonTargetsForVault,
+  findPidsListeningOn,
+  terminateProcess,
+  isMycoDaemonForVault,
+} from '@myco/daemon/eviction.js';
+import { derivePort } from '@myco/daemon/port.js';
+
+// ---------------------------------------------------------------------------
+// parseLsofOutput
+// ---------------------------------------------------------------------------
+
+describe('parseLsofOutput()', () => {
+  it('parses a single p/n record pair', () => {
+    const out = ['p1234', 'n127.0.0.1:21039'].join('\n');
+    expect(parseLsofOutput(out)).toEqual([{ pid: 1234, port: 21039 }]);
+  });
+
+  it('parses multiple records', () => {
+    const out = [
+      'p1234',
+      'n127.0.0.1:21039',
+      'p5678',
+      'n127.0.0.1:21040',
+    ].join('\n');
+    expect(parseLsofOutput(out)).toEqual([
+      { pid: 1234, port: 21039 },
+      { pid: 5678, port: 21040 },
+    ]);
+  });
+
+  it('ignores records without a port suffix', () => {
+    const out = ['p1234', 'nSOME_UNRELATED_NAME'].join('\n');
+    expect(parseLsofOutput(out)).toEqual([]);
+  });
+
+  it('returns empty for empty input', () => {
+    expect(parseLsofOutput('')).toEqual([]);
+  });
+
+  it('pairs an n-line with its most recent p-line', () => {
+    const out = [
+      'p1000',
+      'p2000',
+      'n127.0.0.1:9000',
+    ].join('\n');
+    expect(parseLsofOutput(out)).toEqual([{ pid: 2000, port: 9000 }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchesMycoDaemonInvocation
+// ---------------------------------------------------------------------------
+
+describe('matchesMycoDaemonInvocation()', () => {
+  const vault = '/Users/chris/Repos/myco/.myco';
+
+  it('matches the vendor Bun binary invocation', () => {
+    const args = `/Users/chris/Repos/myco/packages/myco/vendor/darwin-arm64/myco daemon --vault ${vault}`;
+    expect(matchesMycoDaemonInvocation(args, vault)).toBe(true);
+  });
+
+  it('matches node invoking the CLI entry', () => {
+    const args = `node /path/to/myco/dist/src/cli.js daemon --vault ${vault}`;
+    expect(matchesMycoDaemonInvocation(args, vault)).toBe(true);
+  });
+
+  it('matches --vault=<path> syntax', () => {
+    const args = `/bin/myco daemon --vault=${vault}`;
+    expect(matchesMycoDaemonInvocation(args, vault)).toBe(true);
+  });
+
+  it('returns false when args lack the myco word', () => {
+    const args = `node server.js daemon --vault ${vault}`;
+    expect(matchesMycoDaemonInvocation(args, vault)).toBe(false);
+  });
+
+  it('returns false when args lack the daemon subcommand', () => {
+    const args = `/bin/myco status --vault ${vault}`;
+    expect(matchesMycoDaemonInvocation(args, vault)).toBe(false);
+  });
+
+  it('returns false for a different vault', () => {
+    const args = `/bin/myco daemon --vault /other/project/.myco`;
+    expect(matchesMycoDaemonInvocation(args, vault)).toBe(false);
+  });
+
+  it('resolves relative vault paths for comparison', () => {
+    const args = `/bin/myco daemon --vault ${vault}`;
+    // Passing a path with a trailing slash still matches.
+    expect(matchesMycoDaemonInvocation(args, `${vault}/`)).toBe(true);
+  });
+
+  it('returns false on empty args', () => {
+    expect(matchesMycoDaemonInvocation('', vault)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findPidsListeningOn — touches the real system
+// ---------------------------------------------------------------------------
+
+describe('findPidsListeningOn()', () => {
+  it('returns empty when no ports are requested', () => {
+    expect(findPidsListeningOn([])).toEqual([]);
+  });
+
+  it('finds a real listener and reports the current pid', async () => {
+    const server = net.createServer();
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+    const addr = server.address() as { port: number };
+
+    try {
+      const owners = findPidsListeningOn([addr.port]);
+      const mine = owners.find((o) => o.pid === process.pid);
+      expect(mine).toBeDefined();
+      expect(mine?.port).toBe(addr.port);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isMycoDaemonForVault — touches `ps`
+// ---------------------------------------------------------------------------
+
+describe('isMycoDaemonForVault()', () => {
+  it('returns false for the current test process (not a myco daemon)', () => {
+    expect(isMycoDaemonForVault(process.pid, '/any/vault')).toBe(false);
+  });
+
+  it('returns false for a dead PID', () => {
+    expect(isMycoDaemonForVault(999_999_999, '/any/vault')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findDaemonTargetsForVault
+// ---------------------------------------------------------------------------
+
+describe('findDaemonTargetsForVault()', () => {
+  let tmpVault: string;
+
+  beforeEach(() => {
+    tmpVault = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-evict-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpVault, { recursive: true, force: true });
+  });
+
+  it('returns no targets when daemon.json is absent and no port squatter', () => {
+    // Use a port derived from a fake path guaranteed not to be squatted.
+    const canonicalPort = derivePort(tmpVault);
+    expect(findDaemonTargetsForVault(tmpVault, canonicalPort)).toEqual([]);
+  });
+
+  it('ignores daemon.json entries for dead PIDs', () => {
+    const deadPid = 999_999_999;
+    fs.writeFileSync(
+      path.join(tmpVault, 'daemon.json'),
+      JSON.stringify({ pid: deadPid, port: 30000 }),
+    );
+    expect(findDaemonTargetsForVault(tmpVault, 30000)).toEqual([]);
+  });
+
+  it('excludes the current process from the kill list', () => {
+    fs.writeFileSync(
+      path.join(tmpVault, 'daemon.json'),
+      JSON.stringify({ pid: process.pid, port: 30000 }),
+    );
+    expect(findDaemonTargetsForVault(tmpVault, 30000)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// terminateProcess — real subprocess
+// ---------------------------------------------------------------------------
+
+describe('terminateProcess()', () => {
+  it('is a no-op for a dead pid', async () => {
+    await terminateProcess(999_999_999, { graceMs: 100, pollMs: 25 });
+    // No throw — success.
+  });
+
+  it('SIGTERMs a live subprocess that responds to signals', async () => {
+    const { spawn } = await import('node:child_process');
+    // A trivial Node subprocess that idles until killed.
+    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000);'], {
+      stdio: 'ignore',
+      detached: false,
+    });
+
+    // Give the child a moment to become process-visible.
+    await new Promise((r) => setTimeout(r, 100));
+
+    await terminateProcess(child.pid!, { graceMs: 1000, pollMs: 50 });
+
+    // process.kill(pid, 0) should now throw (dead).
+    let alive = true;
+    try { process.kill(child.pid!, 0); } catch { alive = false; }
+    expect(alive).toBe(false);
+  });
+
+  it('escalates to SIGKILL when SIGTERM is ignored', async () => {
+    const { spawn } = await import('node:child_process');
+    // Subprocess that traps SIGTERM and stays alive.
+    const child = spawn(process.execPath, [
+      '-e',
+      "process.on('SIGTERM', () => {});\nsetInterval(() => {}, 1000);",
+    ], {
+      stdio: 'ignore',
+      detached: false,
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const logs: Array<{ level: string; msg: string }> = [];
+    await terminateProcess(child.pid!, {
+      graceMs: 250,
+      pollMs: 25,
+      logger: {
+        info: (_k, msg) => logs.push({ level: 'info', msg }),
+        warn: (_k, msg) => logs.push({ level: 'warn', msg }),
+      },
+    });
+
+    let alive = true;
+    try { process.kill(child.pid!, 0); } catch { alive = false; }
+    expect(alive).toBe(false);
+    expect(logs.some((l) => l.level === 'warn' && l.msg.includes('SIGKILL'))).toBe(true);
+  });
+});

--- a/tests/daemon/reconcile-existing-daemon.test.ts
+++ b/tests/daemon/reconcile-existing-daemon.test.ts
@@ -4,9 +4,10 @@ import os from 'node:os';
 import path from 'node:path';
 import http from 'node:http';
 import { spawn, type ChildProcess } from 'node:child_process';
-import { reconcileExistingDaemon } from '@myco/daemon/main';
+import { reconcileExistingDaemon, isHealthyMycoSibling } from '@myco/daemon/main';
 import { DaemonLogger } from '@myco/daemon/logger';
 import { getPluginVersion } from '@myco/version';
+import { derivePort } from '@myco/daemon/port';
 
 // Prevents the concurrent-spawn cascade we observed in production, where
 // every newly-spawned daemon unconditionally SIGTERM'd whatever pid was in
@@ -22,15 +23,16 @@ function makeLogger(vaultDir: string): DaemonLogger {
 async function withHealthServer<T>(
   response: { status: number; body: unknown },
   fn: (port: number) => Promise<T>,
+  port = 0,
 ): Promise<T> {
   const server = http.createServer((_req, res) => {
     res.writeHead(response.status, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify(response.body));
   });
-  await new Promise<void>((r) => server.listen(0, '127.0.0.1', () => r()));
-  const port = (server.address() as { port: number }).port;
+  await new Promise<void>((r) => server.listen(port, '127.0.0.1', () => r()));
+  const boundPort = (server.address() as { port: number }).port;
   try {
-    return await fn(port);
+    return await fn(boundPort);
   } finally {
     await new Promise<void>((r) => server.close(() => r()));
   }
@@ -75,7 +77,7 @@ describe('reconcileExistingDaemon', () => {
     expect(fs.existsSync(path.join(vaultDir, 'daemon.json'))).toBe(false);
   });
 
-  it('steps aside when recorded daemon is recent, healthy, and same version', async () => {
+  it('steps aside when recorded daemon is recent, healthy, same version, and on canonical port', async () => {
     await withHealthServer(
       { status: 200, body: { myco: true, version: getPluginVersion() } },
       async (port) => {
@@ -88,6 +90,26 @@ describe('reconcileExistingDaemon', () => {
         // daemon.json must survive — the sibling we stepped aside for owns it.
         expect(fs.existsSync(path.join(vaultDir, 'daemon.json'))).toBe(true);
       },
+      derivePort(vaultDir),
+    );
+  });
+
+  it('takes over (ok) when recorded daemon is healthy but NOT on the canonical port', async () => {
+    // An orphan squatting the canonical port forced the sibling to fall back
+    // to a non-canonical port. We must NOT step aside — we need to proceed
+    // through eviction so the canonical port is reclaimed.
+    await withHealthServer(
+      { status: 200, body: { myco: true, version: getPluginVersion() } },
+      async (port) => {
+        fs.writeFileSync(
+          path.join(vaultDir, 'daemon.json'),
+          JSON.stringify({ pid: siblingPid, port }),
+        );
+        const result = await reconcileExistingDaemon(vaultDir, makeLogger(vaultDir));
+        expect(result).toBe('ok');
+      },
+      // Explicitly NOT the canonical port — let the OS pick any ephemeral port.
+      0,
     );
   });
 
@@ -118,6 +140,7 @@ describe('reconcileExistingDaemon', () => {
         expect(result).toBe('step-aside');
         expect(fs.existsSync(path.join(vaultDir, 'daemon.json'))).toBe(true);
       },
+      derivePort(vaultDir),
     );
   });
 
@@ -147,5 +170,43 @@ describe('reconcileExistingDaemon', () => {
     const result = await reconcileExistingDaemon(vaultDir, makeLogger(vaultDir));
     expect(result).toBe('ok');
     expect(fs.existsSync(path.join(vaultDir, 'daemon.json'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isHealthyMycoSibling — late-race detector
+// ---------------------------------------------------------------------------
+
+describe('isHealthyMycoSibling', () => {
+  it('returns true when the port answers /health with myco:true', async () => {
+    await withHealthServer(
+      { status: 200, body: { myco: true, version: '1.0.0' } },
+      async (port) => {
+        expect(await isHealthyMycoSibling(port)).toBe(true);
+      },
+    );
+  });
+
+  it('returns false when /health is non-2xx', async () => {
+    await withHealthServer(
+      { status: 500, body: { error: 'boom' } },
+      async (port) => {
+        expect(await isHealthyMycoSibling(port)).toBe(false);
+      },
+    );
+  });
+
+  it('returns false when /health responds without myco:true', async () => {
+    await withHealthServer(
+      { status: 200, body: { some: 'other service' } },
+      async (port) => {
+        expect(await isHealthyMycoSibling(port)).toBe(false);
+      },
+    );
+  });
+
+  it('returns false when the port is not listening', async () => {
+    // Port 1 refuses connections under normal userspace permissions.
+    expect(await isHealthyMycoSibling(1)).toBe(false);
   });
 });

--- a/tests/daemon/update-checker.test.ts
+++ b/tests/daemon/update-checker.test.ts
@@ -64,6 +64,8 @@ import {
   getDevBuildCliEntry,
   resolveMycoBinary,
   resolveRuntimeCommand,
+  isManagedProjectRuntime,
+  getRuntimeScope,
   readProjectReleaseChannel,
   writeProjectReleaseChannel,
   readUpdateConfig,
@@ -221,6 +223,51 @@ describe('resolveRuntimeCommand()', () => {
   });
 });
 
+describe('isManagedProjectRuntime()', () => {
+  it('matches a managed runtime path inside a standard .myco vault', () => {
+    expect(
+      isManagedProjectRuntime('/Users/me/proj/.myco/runtime/node_modules/.bin/myco'),
+    ).toBe(true);
+  });
+
+  it('returns false for a machine-installed myco binary', () => {
+    expect(isManagedProjectRuntime('/opt/homebrew/bin/myco')).toBe(false);
+  });
+
+  it('uses startsWith against the vaultDir when supplied', () => {
+    const vaultDir = '/tmp/relocated-vault';
+    const entry = `${vaultDir}/runtime/node_modules/.bin/myco`;
+    expect(isManagedProjectRuntime(entry, vaultDir)).toBe(true);
+  });
+
+  it('rejects entries outside the supplied vaultDir even when the substring appears', () => {
+    // Without vaultDir, a misleading path could falsely match the substring
+    // form. With vaultDir, we anchor to the real prefix.
+    const entry = '/other/.myco/runtime/node_modules/.bin/myco';
+    expect(isManagedProjectRuntime(entry, '/my/.myco')).toBe(false);
+  });
+});
+
+describe('getRuntimeScope()', () => {
+  it('returns `machine` when no runtime.command exists', () => {
+    mockNoFiles();
+    expect(getRuntimeScope('/vault/.myco')).toBe('machine');
+  });
+
+  it('returns `project` when runtime.command points at the managed runtime', () => {
+    mockFileContent(
+      '/vault/.myco/runtime.command',
+      '/vault/.myco/runtime/node_modules/.bin/myco\n',
+    );
+    expect(getRuntimeScope('/vault/.myco')).toBe('project');
+  });
+
+  it('returns `machine` when runtime.command points outside the managed runtime', () => {
+    mockFileContent('/vault/.myco/runtime.command', 'myco-dev\n');
+    expect(getRuntimeScope('/vault/.myco')).toBe('machine');
+  });
+});
+
 describe('project release channel helpers', () => {
   it('defaults to stable when local.yaml has no update override', () => {
     mockNoFiles();
@@ -254,6 +301,29 @@ describe('project release channel helpers', () => {
       '{}\n',
       'utf-8',
     );
+  });
+
+  it('migrates legacy machine-global beta preference when project has no override', () => {
+    // Pre-0.22 users had channel in the global update.yaml. Honor it so they
+    // don't silently fall back to stable after upgrading. Project-local
+    // local.yaml shadows this when explicitly set.
+    mockFileContent(UPDATE_CONFIG_PATH, 'channel: beta\ncheck_interval_hours: 6\n');
+
+    expect(readProjectReleaseChannel('/vault/.myco')).toBe('beta');
+  });
+
+  it('prefers project-local channel over legacy machine-global channel', () => {
+    const localPath = '/vault/.myco/local.yaml';
+    vi.mocked(fs.existsSync).mockImplementation((p) => p === localPath || p === UPDATE_CONFIG_PATH);
+    vi.mocked(fs.readFileSync).mockImplementation((p) => {
+      if (p === localPath) return 'update:\n  channel: stable\n';
+      if (p === UPDATE_CONFIG_PATH) return 'channel: beta\ncheck_interval_hours: 6\n';
+      const err: NodeJS.ErrnoException = new Error(`ENOENT: ${String(p)}`);
+      err.code = 'ENOENT';
+      throw err;
+    });
+
+    expect(readProjectReleaseChannel('/vault/.myco')).toBe('stable');
   });
 });
 
@@ -619,9 +689,12 @@ describe('statusFromCache()', () => {
       '/opt/homebrew',
       '/Users/chris/Repos/unifi-mcp/.myco/runtime/node_modules/.bin/myco',
     );
-    expect(result!.update_available).toBe(true);
+    // Revert to a lower stable version is a revert, not an update.
+    expect(result!.update_available).toBe(false);
+    expect(result!.revert_available).toBe(true);
     expect(result!.latest_version).toBe('1.0.0');
-    expect(result!.packages[0]?.update_available).toBe(true);
+    expect(result!.packages[0]?.update_available).toBe(false);
+    expect(result!.packages[0]?.revert_available).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Final quality pass and correctness work between `myco/v0.21.2` and `myco/v0.22.0`. The four beta cycles validated the Bun binary migration and project-local beta runtime; this PR closes out the review findings and hardens the daemon lifecycle before we promote to stable.

## Commits

- **`fix(capture): drop Claude Code slash-command dispatch envelope…`** — Claude Code writes two redundant user transcript entries for every `/command` invocation (XML envelope + expanded body). Before this fix, reconcile inserted a phantom duplicate batch because the XML prefix didn't match the hook-stored `/name args` prefix. New `capture.rules` drop keyed on `<command-message>`, with the walker normalizing the dropped envelope to the hook-stored form so reconcile can consume the matching batch.
- **`chore(skills): incorporate evolved skill updates`** — `install-and-initialize-myco` (Node version prereq + explicit build verification step) and `vault-schema-extension` (add `src/db/schema-ddl.ts` location to the schema-constants procedure).
- **`feat: 0.22.0 release gate — revert semantics, beta opt-in, quality pass`** — the meat of the review findings:
  - `revert_available` field decouples revert from update semantics. UpdateCard now shows "Revert to Stable & Restart" with a "Revert pending" badge instead of rendering a downgrade as "Update available".
  - Beta opt-in no longer silently 400s when the machine install already matches the beta target; the project-local runtime is created regardless of version delta so the "switching to Beta installs a project-local runtime" contract holds.
  - Legacy machine-global `channel: beta` preference is honored as a fallback in `readProjectReleaseChannel`, so pre-0.22 beta users don't silently revert to stable on upgrade.
  - `resolveClaudeCodeExecutable` memoizes at module level (agent hot path).
  - `api/update.ts` handlers read the vault snapshot once per invocation via `readVaultSnapshot` (was re-reading `runtime.command` 3–4× per request).
  - `PROJECT_RUNTIME_COMMAND_FILENAME` constant replaces three inline string literals.
  - `cli/shared.ts` gitignore now ignores `runtime.tmp/` (what the installer writes), not the stale `runtime.prev/`.
  - `publish.yml` collapses two near-identical worker npm-ci retry blocks into one shell matrix loop.
- **`feat(daemon): unified eviction + authoritative canonical port`** — addresses the "I keep ending up on port 21040" class of bugs:
  - New `daemon/eviction.ts` module. One entry point `evictDaemonsForVault` used by both daemon startup and CLI restart. Scans both `daemon.json` and the canonical port range via `lsof`, identifies myco daemons by `ps` argv match, SIGTERMs with grace → SIGKILLs if ignored → verifies exit.
  - `resolvePort` deleted. Port is authoritative (derivePort + optional `daemon.port` override); no silent fallback. On `EADDRINUSE` the daemon either steps aside (concurrent sibling won, confirmed via `/health`) or fails loudly (unrelated squatter) with a stderr hint.
  - `reconcileExistingDaemon` step-aside now requires the sibling to be on the canonical port — previously a sibling on `canonical+1` would perpetuate wrong-port state across restarts.
  - `cli/restart.ts` no longer fire-and-forgets SIGTERM; it waits for process exit before respawning, guaranteeing the new daemon binds the canonical port cleanly.
  - Removed the block that persisted the derived port back into `myco.yaml` — duplicate authority that drifted when the vault moved.
- **`chore(scripts): add update-apply smoke harness`** — `scripts/smoke-update-flow.ts` renders the shell script generated by the apply handler across four scenarios (normal update, stable→beta with gap, stable→beta matching global, beta→stable revert). Pure inspection, no mutation; useful before cutting future betas.

## Test plan

- [x] Typecheck: clean
- [x] `MYCO_TEST_PROFILE=fast bun scripts/run-bun-tests.mjs` — 3064 backend + 23 UI tests pass (up from 3030 backend before this PR)
- [x] New tests added:
  - `tests/capture/prompt-kind.test.ts` + `tests/capture/transcript-miner-reconcile.test.ts` — slash-command dispatch drop + hook-batch matching regression
  - `tests/daemon/eviction.test.ts` — 23 unit tests (parseLsofOutput, matchesMycoDaemonInvocation, findPidsListeningOn against a real listener, findDaemonTargetsForVault, terminateProcess SIGTERM + SIGKILL escalation)
  - `tests/daemon/eviction-integration.test.ts` — spawns a subprocess with rewritten `argv[0]` holding the canonical port with no `daemon.json`, verifies eviction finds and kills it. Also verifies non-myco squatters are left alone.
  - `tests/daemon/reconcile-existing-daemon.test.ts` — canonical-port step-aside requirement + 4 `isHealthyMycoSibling` cases
  - `tests/daemon/api/update.test.ts` — new beta opt-in (matching global) + stable-revert cases
  - `tests/daemon/update-checker.test.ts` — legacy channel migration cases + `revert_available` semantics
- [x] Smoke harness run (`bun scripts/smoke-update-flow.ts`) — all 4 scenarios produce the expected shell script shape
- [x] Live verify: `myco-dev restart` after `make build` binds canonical `:21039` cleanly (previously fell back to `:21040` due to concurrent-spawn race)

## Release plan

After merge, cut `myco/v0.22.0-beta.5` to validate the `publish.yml` worker-deps consolidation and eyeball the new revert UI on a real registry artifact. If clean, promote to `myco/v0.22.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)