### PR TITLE
Unify runtime.command dispatch: fix beta restart loop, extend to interactive CLI, remove --vault

### DIFF
--- a/.agents/skills/author-harness-task/SKILL.md
+++ b/.agents/skills/author-harness-task/SKILL.md
@@ -199,7 +199,7 @@ padding. Calibrate before deploying.
 ### Starting values
 
 | Phase type | Cloud budget | Local budget |
-|------------|-------------|--------------|
+|------------|-------------|-------------|
 | Discovery / read-only | 8–12 | 25–40 |
 | Write / consolidation | 10–20 | 30–60 |
 | Validation / QA | 5–8 | 15–25 |
@@ -462,7 +462,7 @@ LIMIT 20;
 ### Silent failure patterns
 
 | Symptom | Likely cause |
-|---------|--------------|
+|---------|-------------|
 | `exit_reason = 'complete'` but no state change | Sentinel triggered incorrectly; review short-circuit condition |
 | `turn_count = 1`, empty `tool_output_summary` | LLM never called tools; malformed prompt or injected context |
 | `turn_count = budget` with incomplete work | Budget exhaustion; cap the input |
@@ -480,7 +480,7 @@ are properly propagated outside the isolation boundary.
 ### Adding telemetry
 
 To add a new column to `agent_runs`, create a schema migration in
-`packages/myco/src/db/migrations/`. New columns are safe to add without touching existing
+`packages/myco/src/db/migrations.ts`. New columns are safe to add without touching existing
 rows — the harness reads the schema at startup.
 
 ---

--- a/.agents/skills/bun-binary-compilation-asset-management/SKILL.md
+++ b/.agents/skills/bun-binary-compilation-asset-management/SKILL.md
@@ -1,0 +1,611 @@
+---
+name: myco:bun-binary-compilation-asset-management
+description: |
+  Procedures for Bun binary compilation, asset bundling strategies, virtual filesystem 
+  handling, build artifact packaging, multi-target compilation patterns, and binary 
+  entry point dispatch in Myco's build system. Use when compiling static binaries with 
+  Bun, managing package assets vs user files, resolving virtual filesystem paths, 
+  handling cross-platform builds, or debugging binary packaging issues, even if the 
+  user doesn't explicitly ask for Bun compilation help.
+managed_by: myco
+user-invocable: true
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+# Bun Binary Compilation and Asset Management
+
+Myco uses Bun's static compilation to produce standalone binaries with embedded native dependencies and bundled assets. This involves complex target-specific entry points, virtual filesystem navigation, template bundling workflows, and cross-platform build orchestration. These procedures address the fundamental boundary between package-owned assets (bundled into the binary) and user-owned files (read from disk at runtime).
+
+## Prerequisites
+
+- Bun installed and available in PATH
+- Understanding of Myco's project structure (`src/`, `vendor/`, `.myco/`, `packages/`)
+- Familiarity with per-target compilation and npm workspace patterns
+- Basic knowledge of TypeScript import resolution and file embedding
+
+## Template and Asset Bundling Strategies
+
+Myco uses **filesystem-first + bundled-string fallback** pattern for package assets via multiple generated template modules. Static assets like installer templates must be accessible both during development (filesystem reads) and in compiled binaries (bundled strings).
+
+### Four-Generator Template System
+
+Myco evolved from single template bundling to a four-generator system handling different asset types:
+
+```bash
+# Generate all template modules at build time
+cd packages/myco
+npm run codegen
+
+# This runs multiple generators:
+# 1. scripts/gen-templates.mjs → templates.generated.ts (installer templates)
+# 2. scripts/gen-manifests.mjs → manifests.generated.ts (symbiont manifests)  
+# 3. scripts/gen-schemas.mjs → schemas.generated.ts (validation schemas)
+# 4. scripts/gen-assets.mjs → assets.generated.ts (static assets)
+```
+
+Each generator walks its respective source directory and embeds files:
+
+```javascript
+// In scripts/gen-templates.mjs (installer templates)
+const files = walk(TEMPLATES_DIR).sort();
+const entries = files.map((abs) => {
+  const rel = path.relative(TEMPLATES_DIR, abs).split(path.sep).join('/');
+  const body = fs.readFileSync(abs, 'utf-8');
+  return [rel, body];
+});
+
+// Similar patterns in other generators with different source directories:
+// gen-manifests.mjs → walks src/symbionts/manifests/
+// gen-schemas.mjs → walks src/schemas/
+// gen-assets.mjs → walks src/assets/
+```
+
+### Implement the fallback pattern across asset types
+
+The fallback pattern is implemented consistently across different asset loaders:
+
+```typescript
+// In src/symbionts/installer.ts (templates)
+private readTemplateFile(relPath: string): string | null {
+  // Try filesystem first (development and testing)
+  const candidates = [
+    path.join(this.packageRoot, TEMPLATES_SUBDIR, relPath),
+    path.join(this.packageRoot, 'dist', TEMPLATES_SUBDIR, relPath),
+  ];
+  for (const filePath of candidates) {
+    try { return fs.readFileSync(filePath, 'utf-8'); } catch { /* try next */ }
+  }
+
+  // Fall back to bundled strings (compiled binary)
+  if (this.suppressBundledTemplates) return null;
+  const key = relPath.split(path.sep).join('/');
+  const bundled = BUNDLED_TEMPLATES[key];
+  return bundled !== undefined ? bundled : null;
+}
+
+// Similar pattern in manifest loader
+private readManifestFile(relPath: string): ManifestData | null {
+  // Filesystem first, then BUNDLED_MANIFESTS fallback
+  const bundled = BUNDLED_MANIFESTS[key];
+  return bundled !== undefined ? bundled : null;
+}
+
+// Similar pattern in schema loader  
+private readSchemaFile(relPath: string): SchemaData | null {
+  // Filesystem first, then BUNDLED_SCHEMAS fallback
+  const bundled = BUNDLED_SCHEMAS[key];
+  return bundled !== undefined ? bundled : null;
+}
+```
+
+**Critical gotcha**: Each asset loader can return `null` when the filesystem path fails and no bundled fallback exists. Always check for null across all asset types:
+
+```typescript
+// BAD: Silent failure across multiple asset types
+const template = installer.readTemplateFile('hook-guard.cjs');
+const manifest = loader.readManifestFile('claude-code.json');
+const schema = validator.readSchemaFile('config.schema.json');
+
+// GOOD: Explicit checks for all asset types
+const template = installer.readTemplateFile('hook-guard.cjs');
+if (!template) throw new Error(`Template not found: hook-guard.cjs`);
+
+const manifest = loader.readManifestFile('claude-code.json');  
+if (!manifest) throw new Error(`Manifest not found: claude-code.json`);
+
+const schema = validator.readSchemaFile('config.schema.json');
+if (!schema) throw new Error(`Schema not found: config.schema.json`);
+```
+
+### Design runtime boundary decisions for multi-asset architecture
+
+**Package assets** (bundled via generators): Installer templates, symbiont manifests, validation schemas, UI assets, default configs, static strings  
+**User assets** (filesystem): User configs, generated files, session data, vault contents, runtime logs
+
+When adding new static assets, decide the boundary and target generator:
+- **Installer templates** → add to `src/symbionts/templates/` for `gen-templates.mjs`
+- **Symbiont manifests** → add to `src/symbionts/manifests/` for `gen-manifests.mjs` 
+- **Validation schemas** → add to `src/schemas/` for `gen-schemas.mjs`
+- **UI/static assets** → add to `src/assets/` for `gen-assets.mjs`
+- **User-generated or installation-specific** → read from filesystem at runtime
+
+## Virtual Filesystem Handling
+
+Bun binaries use a `/$bunfs/` virtual filesystem for bundled content. This creates path resolution challenges that require careful native dependency handling.
+
+### Use resolvePackageRoot() for bundled content
+
+Never rely on `process.cwd()` for package asset resolution. The actual implementation uses import.meta.dirname detection:
+
+```typescript
+// In src/symbionts/detect.ts
+export function resolvePackageRoot(): string {
+  // Try import.meta.dirname first — works in dev and old tsup layout
+  if (typeof import.meta.dirname === 'string' && !import.meta.dirname.includes('/$bunfs/')) {
+    return path.resolve(import.meta.dirname, '..', '..');
+  }
+  
+  // Fall back to process.execPath resolution — compiled binary case
+  if (process.execPath && process.execPath !== process.argv0) {
+    return path.dirname(process.execPath);
+  }
+  
+  return process.cwd();
+}
+```
+
+**Critical gotcha**: Import.meta.dirname detection prevents loading stale `/dist/` artifacts when the binary is run from a development directory with old build output.
+
+### Handle embedded native dependencies
+
+Bun's file embedding with `import ... with { type: 'file' }` creates virtual paths that must be materialized:
+
+```typescript
+// In src/entries/cli.darwin-arm64.ts
+import libsqliteEmbed from '../../vendor-src/libsqlite3/darwin-arm64/libsqlite3.dylib' with { type: 'file' };
+import vec0Embed from 'sqlite-vec-darwin-arm64/vec0.dylib' with { type: 'file' };
+import ripgrepEmbed from '@vscode/ripgrep/bin/rg' with { type: 'file' };
+
+await registerEmbeddedNativeDeps({
+  libsqliteEmbed,    // Resolves to /$bunfs/path at runtime
+  vec0Embed,         // Must be extracted to real filesystem
+  ripgrepEmbed,
+  version: pkg.version,
+});
+```
+
+The `registerEmbeddedNativeDeps()` function extracts these to temporary files:
+
+```typescript
+// In src/runtime/native-deps.ts
+export async function registerEmbeddedNativeDeps(deps) {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'myco-'));
+  
+  // Extract each embedded file to temp directory
+  const libsqlitePath = path.join(tempDir, 'libsqlite3.dylib');
+  await fs.writeFile(libsqlitePath, await fs.readFile(deps.libsqliteEmbed));
+  
+  // Register with the runtime
+  process.env.MYCO_LIBSQLITE_PATH = libsqlitePath;
+}
+```
+
+### Debug virtual filesystem access patterns
+
+When filesystem operations fail in Bun binaries, check if the path is virtual:
+
+```bash
+# Debug embedded file paths
+node -e "console.log(process.execPath)"
+ls -la $(dirname $(which myco))/
+
+# Check if assets were bundled properly across all generators
+grep -r "BUNDLED_TEMPLATES" packages/myco/src/symbionts/templates.generated.ts
+grep -r "BUNDLED_MANIFESTS" packages/myco/src/symbionts/manifests.generated.ts  
+grep -r "BUNDLED_SCHEMAS" packages/myco/src/schemas.generated.ts
+grep -r "BUNDLED_ASSETS" packages/myco/src/assets.generated.ts
+```
+
+## Build Artifact Packaging
+
+Myco's binary packaging uses target-specific entry points with embedded native dependencies and strict build validation.
+
+### Use target-specific entry points
+
+Each supported platform has a dedicated entry point that embeds the correct native binaries:
+
+```bash
+# Entry points for each target
+ls packages/myco/src/entries/
+# cli.darwin-arm64.ts
+# cli.darwin-x64.ts  
+# cli.linux-x64.ts
+# cli.linux-arm64.ts
+# cli.windows-x64.ts
+# cli.js (shared logic)
+```
+
+Each entry imports platform-specific native dependencies:
+
+```typescript
+// cli.darwin-arm64.ts embeds macOS ARM64 binaries
+import libsqliteEmbed from '../../vendor-src/libsqlite3/darwin-arm64/libsqlite3.dylib' with { type: 'file' };
+
+// cli.linux-x64.ts embeds Linux x64 binaries  
+import libsqliteEmbed from '../../vendor-src/libsqlite3/linux-x64/libsqlite3.so' with { type: 'file' };
+```
+
+### Build single target binaries
+
+The build system creates platform-specific binaries in `vendor/{target}/`:
+
+```bash
+# Build for current platform
+npm run build:binary
+
+# Build specific target via env var
+TARGET=darwin-arm64 npm run build:binary
+TARGET=linux-x64 npm run build:binary
+TARGET=windows-x64 npm run build:binary
+
+# Build all targets (CI use)
+npm run build:binaries
+```
+
+This runs `scripts/build-single-target.mjs`:
+
+```javascript
+const target = process.env.TARGET ?? detectHostTarget();
+const entry = path.join(pkgRoot, 'src', 'entries', `cli.${target}.ts`);
+const outputDir = path.join(pkgRoot, 'vendor', target);
+const binaryName = target.startsWith('windows-') ? 'myco.exe' : 'myco';
+const outfile = path.join(outputDir, binaryName);
+
+const result = spawnSync(
+  'bun',
+  ['build', '--compile', `--target=bun-${target}`, entry, '--outfile', outfile],
+  { stdio: 'inherit', cwd: pkgRoot }
+);
+```
+
+### Validate build artifacts
+
+Add build verification to catch missing native dependencies or entry points:
+
+```javascript
+// In scripts/verify-build.mjs
+function validateBuildArtifacts(target) {
+  const binaryPath = path.join('vendor', target, target.startsWith('windows-') ? 'myco.exe' : 'myco');
+  
+  if (!fs.existsSync(binaryPath)) {
+    throw new Error(`Missing binary: ${binaryPath}`);
+  }
+  
+  // Test that the binary starts without errors
+  const result = spawnSync(binaryPath, ['--version'], { timeout: 10000 });
+  if (result.error || result.status !== 0) {
+    throw new Error(`Binary validation failed: ${binaryPath}`);
+  }
+}
+```
+
+## Multi-Target Compilation Patterns
+
+Building for multiple platforms requires handling native dependency differences and target-specific build constraints.
+
+### Handle platform-specific native dependencies
+
+Each target needs different native binaries embedded:
+
+```bash
+# Install platform-specific dependencies for each target
+# Package structure: vendor-src/libsqlite3/{target}/libsqlite3.{ext}
+
+# macOS requires .dylib files
+packages/myco/vendor-src/libsqlite3/darwin-arm64/libsqlite3.dylib
+packages/myco/vendor-src/libsqlite3/darwin-x64/libsqlite3.dylib
+
+# Linux requires .so files  
+packages/myco/vendor-src/libsqlite3/linux-x64/libsqlite3.so
+packages/myco/vendor-src/libsqlite3/linux-arm64/libsqlite3.so
+
+# Windows requires .dll files
+packages/myco/vendor-src/libsqlite3/windows-x64/sqlite3.dll
+```
+
+### Set up cross-platform CI builds
+
+Use matrix builds to compile all targets:
+
+```yaml
+# In .github/workflows/build.yml
+strategy:
+  matrix:
+    include:
+      - target: darwin-arm64
+        os: macos-latest
+      - target: linux-x64  
+        os: ubuntu-latest
+      - target: windows-x64
+        os: windows-latest
+
+steps:
+  - name: Build target
+    run: |
+      TARGET=${{ matrix.target }} npm run build:binary
+      npm run build:verify
+```
+
+### Handle Bun vs Node.js compatibility
+
+Different runtimes require different handling patterns:
+
+```typescript
+// Detect runtime environment
+export function getCompilationContext(): 'bun-dev' | 'bun-compiled' | 'node' {
+  if (typeof Bun !== 'undefined') {
+    return process.argv[1]?.includes('/$bunfs/') ? 'bun-compiled' : 'bun-dev';
+  }
+  return 'node';
+}
+
+// Adjust behavior based on context
+switch (getCompilationContext()) {
+  case 'bun-compiled':
+    // Use embedded native deps and bundled templates
+    break;
+  case 'bun-dev':
+    // Use filesystem native deps and templates
+    break;
+  case 'node':
+    // Use traditional Node.js require patterns
+    break;
+}
+```
+
+### Implement retry patterns for build failures
+
+Multi-target builds often hit transient network or filesystem issues:
+
+```bash
+# Add retry logic to CI builds
+for attempt in 1 2 3; do
+  TARGET=$target npm run build:binary && break
+  echo "Build attempt $attempt failed, retrying..."
+  sleep $((attempt * 5))
+done
+```
+
+## Binary Entry Point Dispatch
+
+Myco supports runtime resolution via `.myco/runtime.command` with automatic collision detection through the hook guard system.
+
+### Use the hook guard dispatch pattern
+
+The `.agents/myco-run.cjs` hook guard provides cross-platform entry point resolution:
+
+```javascript
+// In .agents/myco-run.cjs
+let bin = 'myco';  // Default for global installs
+try {
+  const aliasPath = path.resolve(__dirname, '..', '.myco', 'runtime.command');
+  const alias = fs.readFileSync(aliasPath, 'utf-8').trim();
+  if (alias) bin = alias;  // Override with local development binary
+} catch { /* missing file → use default */ }
+
+try {
+  execFileSync(bin, process.argv.slice(2), { stdio: 'inherit' });
+} catch (e) {
+  if (e.code === 'ENOENT') process.exit(0);  // Silent no-op for missing myco
+  process.exit(e.status ?? 1);
+}
+```
+
+### Configure runtime.command for development
+
+Point to development binaries for local testing:
+
+```bash
+# For global install users (default)
+echo "myco" > .myco/runtime.command
+
+# For local development (make dev-link creates this)
+echo "/path/to/myco/vendor/darwin-arm64/myco" > .myco/runtime.command
+
+# For npm link workflows  
+echo "myco-dev" > .myco/runtime.command
+```
+
+### Handle PATH collision detection
+
+Before installation, check for conflicting binaries:
+
+```typescript
+// In src/cli/doctor.ts
+export function detectPathCollisions(binaryName: string): string[] {
+  const collisions: string[] = [];
+  const pathDirs = (process.env.PATH || '').split(path.delimiter);
+  
+  for (const dir of pathDirs) {
+    const candidates = process.platform === 'win32' 
+      ? [`${binaryName}.exe`, `${binaryName}.cmd`, `${binaryName}.bat`]
+      : [binaryName];
+      
+    for (const candidate of candidates) {
+      const binaryPath = path.join(dir, candidate);
+      if (fs.existsSync(binaryPath)) {
+        collisions.push(binaryPath);
+      }
+    }
+  }
+  
+  return collisions;
+}
+```
+
+### Ensure executable resolution portability
+
+Binary resolution must work across different installation patterns:
+
+```typescript
+// Check multiple resolution strategies
+export function resolveBinary(name: string): string | null {
+  // 1. Check runtime.command override
+  try {
+    const aliasPath = path.join(process.cwd(), '.myco', 'runtime.command');
+    const alias = fs.readFileSync(aliasPath, 'utf-8').trim();
+    if (alias && fs.existsSync(alias)) return alias;
+  } catch { /* continue */ }
+  
+  // 2. Check PATH resolution
+  const resolved = which(name);
+  if (resolved) return resolved;
+  
+  // 3. Check common local install paths
+  const candidates = [
+    path.join(os.homedir(), '.local', 'bin', name),
+    path.join('/usr', 'local', 'bin', name),
+  ];
+  
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  
+  return null;
+}
+```
+
+## Asset Access Pattern Migration
+
+When migrating existing Node.js filesystem code to Bun-compatible patterns, follow these systematic steps for package vs user asset boundaries.
+
+### Audit existing filesystem operations
+
+Identify all filesystem reads and categorize by ownership:
+
+```bash
+# Find all filesystem read operations in the codebase
+grep -r "readFileSync\|createReadStream" packages/myco/src/
+grep -r "existsSync\|statSync" packages/myco/src/
+
+# Focus on asset loading patterns across all asset types
+grep -r "templates\|manifests\|schemas\|assets" packages/myco/src/
+```
+
+Categorize each by ownership:
+- **Package-owned**: Templates, manifests, schemas, UI assets, defaults → should be bundled via appropriate generator
+- **User-owned**: Configs, data, sessions, plans → should stay filesystem
+
+### Convert package assets to bundled access
+
+For each package-owned asset, update the loading pattern and target the correct generator:
+
+1. **Add to appropriate template directory**:
+```bash
+# Installer templates
+mv src/config/default.template.json src/symbionts/templates/config/default.template.json
+
+# Symbiont manifests
+mv src/manifests/new-agent.json src/symbionts/manifests/new-agent.json
+
+# Validation schemas  
+mv src/validation/config.schema.json src/schemas/config.schema.json
+
+# UI/static assets
+mv src/ui/logo.svg src/assets/ui/logo.svg
+```
+
+2. **Regenerate bundled modules**:
+```bash
+npm run codegen  # Regenerates all *.generated.ts files
+```
+
+3. **Update asset loading code**:
+```typescript
+// Before: Direct filesystem reads
+const template = readFileSync('./config/default.template.json', 'utf-8');
+const manifest = readFileSync('./manifests/new-agent.json', 'utf-8');
+const schema = readFileSync('./validation/config.schema.json', 'utf-8');
+
+// After: Use appropriate bundled fallback patterns
+const installer = new SymbiontInstaller(manifest, projectRoot, packageRoot);
+const template = installer.readTemplateFile('config/default.template.json');
+if (!template) throw new Error('Default template not found');
+
+const manifestLoader = new ManifestLoader(packageRoot);
+const manifest = manifestLoader.readManifestFile('new-agent.json');
+if (!manifest) throw new Error('Manifest not found');
+
+const schemaLoader = new SchemaLoader(packageRoot);
+const schema = schemaLoader.readSchemaFile('config.schema.json');
+if (!schema) throw new Error('Schema not found');
+```
+
+### Test both access paths
+
+Ensure the migration works in all runtime contexts:
+
+```bash
+# Test development mode with filesystem assets
+cd packages/myco
+bun run src/main.ts
+
+# Test compiled binary mode with bundled assets
+npm run build:binary
+./vendor/$(node -e "console.log(process.platform + '-' + process.arch)")/myco --version
+
+# Test missing asset scenario for each asset type (should fail gracefully)
+rm src/symbionts/templates/config/default.template.json
+rm src/symbionts/manifests/new-agent.json
+rm src/schemas/config.schema.json
+npm run codegen
+./vendor/*/myco --version  # Should show appropriate error for each missing type
+```
+
+### Handle virtual filesystem diagnostics
+
+Create clear error messages for common virtual filesystem issues:
+
+```typescript
+export function diagnoseBunfsError(filePath: string, error: Error): Error {
+  if (filePath.includes('/$bunfs/') && error.message.includes('ENOENT')) {
+    return new Error(
+      `Virtual filesystem access failed: ${filePath}\n` +
+      `This usually means the asset was not bundled at build time.\n` +
+      `For package assets, add to the appropriate directory and run 'npm run codegen':\n` +
+      `  - Templates: src/symbionts/templates/ (gen-templates.mjs)\n` +
+      `  - Manifests: src/symbionts/manifests/ (gen-manifests.mjs)\n` +  
+      `  - Schemas: src/schemas/ (gen-schemas.mjs)\n` +
+      `  - UI Assets: src/assets/ (gen-assets.mjs)\n` +
+      `For user assets, ensure the path points to a real filesystem location.`
+    );
+  }
+  
+  return error;
+}
+
+// Usage in asset loading across all types
+try {
+  return fs.readFileSync(virtualPath, 'utf-8');
+} catch (error) {
+  throw diagnoseBunfsError(virtualPath, error);
+}
+```
+
+### Validate the bundling boundary
+
+Ensure package vs user boundaries are correctly implemented across all asset types:
+
+```bash
+# Verify package assets are bundled in all generated files
+grep -c "src/symbionts/templates" packages/myco/src/symbionts/templates.generated.ts
+grep -c "src/symbionts/manifests" packages/myco/src/symbionts/manifests.generated.ts
+grep -c "src/schemas" packages/myco/src/schemas.generated.ts  
+grep -c "src/assets" packages/myco/src/assets.generated.ts
+
+# Verify user assets stay on filesystem  
+find .myco/ -name "*.json" -o -name "*.yaml" | head -5
+
+# Check no package assets leak to user directories
+! find .myco/ -name "manifests" -o -name "templates" -o -name "schemas" -o -name "assets"
+```

--- a/.agents/skills/cloudflare-worker-infrastructure-lifecycle/SKILL.md
+++ b/.agents/skills/cloudflare-worker-infrastructure-lifecycle/SKILL.md
@@ -125,7 +125,7 @@ npx wrangler deploy --config worker/wrangler.toml
 
 # Verify both services on same worker
 curl https://your-team-worker.workers.dev/health
-curl https://your-team-worker.workers.dev/mcp/health
+curl https://your-team-worker.workers.dev/mcp/call
 ```
 
 The cloud MCP server exposes **5 read-only tools** with two-tier access:
@@ -141,13 +141,13 @@ Auth tokens are auto-distributed via Workers KV with AES-256-GCM encryption:
 npx wrangler kv:key get mcp_token --binding=MCP_AUTH
 
 # Verify token hash in health endpoint
-curl https://your-team-worker.workers.dev/mcp/health
+curl https://your-team-worker.workers.dev/health
 # Look for mcp_token_hash field
 ```
 
 ### Token Rotation Detection
 
-Daemons detect rotation via `/mcp/health` mismatch patterns:
+Daemons detect rotation via `/health` mismatch patterns:
 
 ```json
 {
@@ -314,10 +314,10 @@ The `/connect` endpoint embeds tokens directly in JSON responses:
 
 ### Rotation Detection Patterns
 
-Daemons poll `/mcp/health` and compare `mcp_token_hash`:
+Daemons poll `/health` and compare `mcp_token_hash`:
 
 ```javascript
-const healthResp = await fetch('/mcp/health');
+const healthResp = await fetch('/health');
 const {mcp_token_hash} = await healthResp.json();
 
 if (mcp_token_hash !== local_stored_hash) {

--- a/.agents/skills/debug-daemon-errors/SKILL.md
+++ b/.agents/skills/debug-daemon-errors/SKILL.md
@@ -490,6 +490,224 @@ function processSessionHook(payload: any) {
 
 ---
 
+## Step 7 — Daemon Restart Resilience Patterns
+
+**When:** The daemon crashes or restarts unexpectedly, leaving tasks, sessions, or jobs in inconsistent states. Common scenarios include process termination during task execution, database locks from interrupted transactions, and orphaned state after unclean shutdowns.
+
+### Task Recovery After Restart
+
+Implement recovery patterns for tasks interrupted mid-execution:
+
+```typescript
+// During daemon startup, identify tasks that were interrupted
+export async function recoverInterruptedTasks() {
+  const interruptedTasks = await db.select()
+    .from(tasks)
+    .where(
+      and(
+        inArray(tasks.status, ['running', 'starting']),
+        lt(tasks.updated_at, sql`datetime('now', '-5 minutes')`)
+      )
+    );
+
+  for (const task of interruptedTasks) {
+    logger.warn(`[Recovery] Found interrupted task`, {
+      taskId: task.id,
+      status: task.status,
+      lastUpdate: task.updated_at
+    });
+
+    // Reset to pending for retry, or mark failed based on business logic
+    await db.update(tasks)
+      .set({ 
+        status: 'pending', 
+        updated_at: new Date(),
+        restartCount: (task.restartCount || 0) + 1 
+      })
+      .where(eq(tasks.id, task.id));
+  }
+  
+  logger.info(`[Recovery] Reset ${interruptedTasks.length} interrupted tasks`);
+}
+```
+
+### Session Cleanup on Startup
+
+Clean up sessions that were left in inconsistent states:
+
+```typescript
+// Clean up sessions that were marked active but daemon wasn't running
+export async function cleanupStaleActiveSessions() {
+  const staleActiveSessions = await db.select()
+    .from(sessions)
+    .where(
+      and(
+        eq(sessions.status, 'active'),
+        lt(sessions.updated_at, sql`datetime('now', '-30 minutes')`)
+      )
+    );
+
+  for (const session of staleActiveSessions) {
+    logger.warn(`[Recovery] Found stale active session`, {
+      sessionId: session.id,
+      lastUpdate: session.updated_at
+    });
+
+    // Transition to terminal based on content
+    const status = session.promptCount > 0 ? 'complete' : 'abandoned';
+    await db.update(sessions)
+      .set({ status, updated_at: new Date() })
+      .where(eq(sessions.id, session.id));
+  }
+  
+  logger.info(`[Recovery] Cleaned up ${staleActiveSessions.length} stale active sessions`);
+}
+```
+
+### Outbox Recovery Patterns
+
+Handle outbox entries that were being processed during shutdown:
+
+```typescript
+// Reset outbox entries that were being drained during shutdown
+export async function resetProcessingOutboxEntries() {
+  const processingEntries = await db.select()
+    .from(outbox)
+    .where(
+      and(
+        eq(outbox.status, 'processing'),
+        lt(outbox.updated_at, sql`datetime('now', '-10 minutes')`)
+      )
+    );
+
+  for (const entry of processingEntries) {
+    logger.warn(`[Recovery] Resetting processing outbox entry`, {
+      entryId: entry.id,
+      type: entry.type
+    });
+
+    await db.update(outbox)
+      .set({ 
+        status: 'pending',
+        retryCount: (entry.retryCount || 0) + 1,
+        updated_at: new Date()
+      })
+      .where(eq(outbox.id, entry.id));
+  }
+
+  logger.info(`[Recovery] Reset ${processingEntries.length} processing outbox entries`);
+}
+```
+
+### Database Lock Recovery
+
+Handle SQLite locks from interrupted transactions:
+
+```typescript
+// Check for database locks and attempt recovery
+export async function recoverDatabaseLocks() {
+  try {
+    // Test database accessibility
+    await db.select().from(sessions).limit(1).get();
+    logger.info(`[Recovery] Database accessible`);
+  } catch (err) {
+    if (err.message.includes('database is locked')) {
+      logger.warn(`[Recovery] Database locked, attempting recovery`);
+      
+      // Force close all connections and reinitialize
+      await db.$client.close();
+      
+      // Wait briefly for locks to clear
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      
+      // Reinitialize database connection
+      await initializeDatabase();
+      
+      logger.info(`[Recovery] Database lock recovered`);
+    } else {
+      throw err;
+    }
+  }
+}
+```
+
+### Startup Recovery Orchestration
+
+Coordinate all recovery patterns during daemon initialization:
+
+```typescript
+// Main recovery function called during daemon startup
+export async function performStartupRecovery() {
+  const startTime = Date.now();
+  logger.info(`[Recovery] Starting daemon recovery procedures`);
+
+  try {
+    // Database recovery first
+    await recoverDatabaseLocks();
+    
+    // Then state recovery
+    await recoverInterruptedTasks();
+    await cleanupStaleActiveSessions();
+    await resetProcessingOutboxEntries();
+    
+    // Restart schedulers after state is clean
+    await restartJobSchedulers();
+    
+    const duration = Date.now() - startTime;
+    logger.info(`[Recovery] Completed daemon recovery in ${duration}ms`);
+    
+  } catch (err) {
+    logger.error(`[Recovery] Daemon recovery failed`, { error: err.message });
+    throw err;
+  }
+}
+```
+
+### Graceful Shutdown Preparation
+
+Implement clean shutdown to minimize recovery needs:
+
+```typescript
+// Prepare for graceful shutdown
+export async function prepareGracefulShutdown() {
+  logger.info(`[Shutdown] Preparing graceful daemon shutdown`);
+  
+  // Stop accepting new work
+  await stopJobSchedulers();
+  
+  // Wait for current tasks to complete (with timeout)
+  const runningTasks = await db.select()
+    .from(tasks)
+    .where(eq(tasks.status, 'running'));
+    
+  if (runningTasks.length > 0) {
+    logger.info(`[Shutdown] Waiting for ${runningTasks.length} running tasks`);
+    
+    // Wait up to 30 seconds for tasks to complete
+    for (let i = 0; i < 30; i++) {
+      const stillRunning = await db.select()
+        .from(tasks)
+        .where(eq(tasks.status, 'running'));
+        
+      if (stillRunning.length === 0) break;
+      
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+  }
+  
+  // Mark remaining tasks as interrupted
+  await db.update(tasks)
+    .set({ status: 'interrupted', updated_at: new Date() })
+    .where(eq(tasks.status, 'running'));
+    
+  logger.info(`[Shutdown] Graceful shutdown preparation complete`);
+}
+```
+
+**Usage:** Call `performStartupRecovery()` during daemon initialization and `prepareGracefulShutdown()` on shutdown signals. This minimizes the need for recovery procedures on the next startup.
+
+---
+
 ## Quick Reference — Error to Fix Map
 
 | Error / Symptom | Likely Cause | Fix |
@@ -503,3 +721,7 @@ function processSessionHook(payload: any) {
 | Task status = `complete`, no output | Exception swallowed in executor | Separate success path from catch block; mark failed on error |
 | Phantom sessions with different parentID values | OpenCode sub-agent vs user fork confusion | Use diagnostic logging to distinguish session creation context; validate parentID references |
 | Sessions created within seconds but unclear relationship | Missing session type context in logs | Implement structured session creation logging with type classification |
+| Daemon restart leaves tasks in `running` status | Process interrupted during task execution | Implement task recovery: reset interrupted tasks to `pending` with restart count |
+| Database locked after restart | SQLite locks from interrupted transactions | Force close connections, wait for locks to clear, reinitialize |
+| Sessions stuck in `active` status after restart | Daemon shutdown during session processing | Cleanup stale active sessions: transition to `complete` or `abandoned` based on content |
+| Outbox entries stuck in `processing` status | Daemon shutdown during outbox drain | Reset processing entries to `pending` with incremented retry count |

--- a/.agents/skills/install-and-initialize-myco/SKILL.md
+++ b/.agents/skills/install-and-initialize-myco/SKILL.md
@@ -160,7 +160,7 @@ Before configuring dev binary, ensure the project is built:
 
 ```bash
 # Check if CLI build exists
-if [ ! -f "packages/myco/dist/src/cli.js" ]; then
+if [ ! -f "packages/myco/bin/myco.cjs" ]; then
   echo "CLI not built. Running build..."
   make build
 else
@@ -168,7 +168,7 @@ else
 fi
 ```
 
-The CLI build at `packages/myco/dist/src/cli.js` is required for dev configuration to work.
+The CLI build at `packages/myco/bin/myco.cjs` is required for dev configuration to work.
 
 ### Configure Dev Binary
 
@@ -178,7 +178,7 @@ make dev-link
 
 This creates four symlinks in `~/.local/bin/` and writes `.myco/runtime.command`:
 
-- **`myco-dev`** — symlink to `packages/myco/dist/src/cli.js`. Used for dogfooding agent and core daemon changes.
+- **`myco-dev`** — symlink to `packages/myco/bin/myco.cjs`. Used for dogfooding agent and core daemon changes.
 - **`myco-team-dev`** — symlink to `packages/myco-team/dist/main.js`. Used for manual testing of team sync operator flows.
 - **`myco-collective-dev`** — symlink to `packages/myco-collective/dist/main.js`. Used for manual testing of Collective operator flows.
 - **`myco-run`** — symlink to `packages/myco/bin/myco-run`. Stable operator entrypoint for MCP server mode; never delete this even if it appears unused.
@@ -273,7 +273,7 @@ This function is the single source of truth. Do not read `.myco/myco.yaml.symbio
 
 **`.myco/runtime.command` is machine-specific.** If you copy your repo to another machine, re-run `make dev-link` there — the path baked into the file will be wrong otherwise.
 
-**Rebuild before testing.** `myco-dev doctor` (or any hook) reads the binary on disk. Stale `packages/myco/dist/src/cli.js` means stale behavior, even if your source edits look right.
+**Rebuild before testing.** `myco-dev doctor` (or any hook) reads the binary on disk. Stale `packages/myco/bin/myco.cjs` means stale behavior, even if your source edits look right.
 
 **Symlinks go stale after package relocation.** When the Myco project restructures (e.g., moving into a monorepo), `~/.local/bin/myco-*` symlinks still point to the old locations. If the target dist file doesn't exist at the old path, hooks will fail silently. Fix this by re-running `make dev-link` after any significant directory reorganization.
 

--- a/.agents/skills/operate-skill-lifecycle-pipeline/SKILL.md
+++ b/.agents/skills/operate-skill-lifecycle-pipeline/SKILL.md
@@ -160,7 +160,7 @@ The tool returns a descriptive error identifying the failing constraint:
 
 ### allowed-tools Contamination
 
-The vault_write_skill gate was added specifically because of a silent propagation bug: `skill-evolve.yaml`'s "preserve ALL existing frontmatter fields" instruction faithfully copies vault_* names from a contaminated skill into every subsequent evolution. The preservation rule is not a validator.
+The vault_write_skill gate was added specifically because of a silent propagation bug: when skill evolution tasks preserve existing frontmatter fields, they faithfully copy vault_* names from a contaminated skill into every subsequent evolution. The preservation rule is not a validator.
 
 **Contamination propagation path:**
 1. A skill has vault_* names in `allowed-tools` (e.g., generated when the spec was wrong)
@@ -203,7 +203,7 @@ Skills are loaded by Claude Code when the frontmatter `description` matches the 
 The rewritten skill passes all validation checks but is structurally degraded.
 
 **Fix steps:**
-1. Check skill-evolve.yaml — it must have an explicit "bias toward CURRENT unless there is a substantive factual change" instruction and a "do NOT restructure sections that are still correct" directive
+1. Check skill evolution task configuration — it must have an explicit "bias toward CURRENT unless there is a substantive factual change" instruction and a "do NOT restructure sections that are still correct" directive
 2. Identify the previous generation via vault_skill_records lineage
 3. Compare the description — if shortened, triggering coverage is degraded
 4. Rewrite to restore description coverage plus any actual new knowledge

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -137,7 +137,9 @@
   "permissions": {
     "allow": [
       "Bash(myco:*)",
-      "Bash(myco-dev:*)"
+      "Bash(myco-dev:*)",
+      "Bash(myco *)",
+      "Bash(myco-dev *)"
     ]
   }
 }

--- a/.myco/.gitignore
+++ b/.myco/.gitignore
@@ -32,5 +32,9 @@ staging/
 # Never committed — different contributors use different aliases.
 runtime.command
 
+# Project-local managed runtime used for beta isolation
+runtime/
+runtime.tmp/
+
 # Per-user appearance and settings overrides
 local.yaml

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ collective-ui-dev:
 daemon-dev:
 	@proxy=$${MYCO_UI_DEV_PROXY_TARGET:-http://127.0.0.1:5173}; \
 	echo "Starting watched daemon with UI dev proxy $$proxy"; \
-	MYCO_UI_DEV_PROXY_TARGET="$$proxy" bun --watch packages/myco/src/entries/cli.ts daemon --vault "$(PWD)/.myco"
+	MYCO_UI_DEV_PROXY_TARGET="$$proxy" bun --watch packages/myco/src/entries/cli.ts daemon
 
 dev:
 	@ui_port=$${MYCO_UI_DEV_PORT:-5173}; \
@@ -93,7 +93,7 @@ dev:
 		--exclude ".playwright-cli/**" \
 		--exclude "packages/myco/ui/**" \
 		--exclude "packages/myco/dist/**" \
-		packages/myco/src/entries/cli.ts daemon --vault "$(PWD)/.myco"
+		packages/myco/src/entries/cli.ts daemon
 
 HOST_TARGET := $(shell node -e "\
 process.stdout.write(process.platform === 'darwin' ? 'darwin-' + (process.arch === 'arm64' ? 'arm64' : 'x64') : \

--- a/packages/myco/bin/myco.cjs
+++ b/packages/myco/bin/myco.cjs
@@ -28,7 +28,6 @@ function die(message) {
   process.exit(1);
 }
 
-// Exits on successful redirect; returns false to fall through otherwise.
 maybeRedirect(__filename);
 
 const pkgRoot = path.resolve(__dirname, '..');

--- a/packages/myco/bin/myco.cjs
+++ b/packages/myco/bin/myco.cjs
@@ -6,21 +6,30 @@
 // writes `vendor/resolved.json` with the host target. This shim reads that
 // file and execFileSyncs the correct binary with forwarded argv.
 //
+// Before dispatching, the shim consults `.myco/runtime.command` via
+// runtime-redirect.cjs. Projects that pin a local runtime (beta channel,
+// dogfood) are re-exec'd into that binary so the interactive CLI matches
+// the binary the project's daemon, hooks, and MCP server already use.
+//
 // Rationale: npm's `bin` entry must be a single path. We can't point it
 // directly at a platform-specific binary without a post-install step. This
-// ~30-line shim preserves the single-bin-entry contract while letting us
-// pick the right binary at install time.
+// shim preserves the single-bin-entry contract while letting us pick the
+// right binary at install time.
 
 'use strict';
 
 const fs = require('node:fs');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
+const { maybeRedirect } = require('./runtime-redirect.cjs');
 
 function die(message) {
   process.stderr.write(`[myco] ${message}\n`);
   process.exit(1);
 }
+
+// Exits on successful redirect; returns false to fall through otherwise.
+maybeRedirect(__filename);
 
 const pkgRoot = path.resolve(__dirname, '..');
 const resolvedPath = path.join(pkgRoot, 'vendor', 'resolved.json');

--- a/packages/myco/bin/runtime-redirect.cjs
+++ b/packages/myco/bin/runtime-redirect.cjs
@@ -27,6 +27,10 @@ const { execFileSync } = require('node:child_process');
  * Worktree-aware: when `cwd` is inside a git worktree, starts the walk
  * at the main repo root, because vaults live with the main repo and
  * worktrees don't carry their own.
+ *
+ * Filename literals here mirror `PROJECT_RUNTIME_COMMAND_FILENAME` and
+ * `.myco` from `src/constants/update.ts`. This file is plain CJS (runs
+ * before bun) so it can't import the TS source of truth.
  */
 function findProjectRuntimePin(cwd) {
   try {

--- a/packages/myco/bin/runtime-redirect.cjs
+++ b/packages/myco/bin/runtime-redirect.cjs
@@ -1,0 +1,132 @@
+// Project-local runtime redirect for the myco CLI shim.
+//
+// When `myco` is invoked inside a project that pins a specific runtime
+// via `.myco/runtime.command` (beta-channel projects and dogfood), this
+// helper re-execs into the pinned binary so the interactive CLI matches
+// the binary the project's daemon, hooks, and MCP server already use.
+// Without this, `myco doctor`, `myco update`, etc. resolve to the global
+// binary while every other dispatch path resolves to the local pin —
+// producing version skew between CLI and daemon.
+//
+// This is the same dispatch pattern `myco-run.cjs` (the symbiont hook
+// guard) uses for hook invocations, applied to the CLI entry itself.
+// `runtime.command` is the single source of truth for "which myco does
+// this project use."
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+/**
+ * Walk upward from `cwd` looking for `.myco/runtime.command`. Returns
+ * the trimmed file contents (an absolute path or PATH-resolvable name)
+ * or null when no pin is found.
+ *
+ * Worktree-aware: when `cwd` is inside a git worktree, starts the walk
+ * at the main repo root, because vaults live with the main repo and
+ * worktrees don't carry their own.
+ */
+function findProjectRuntimePin(cwd) {
+  try {
+    let dir = resolveSearchStart(cwd);
+    while (true) {
+      const pinPath = path.join(dir, '.myco', 'runtime.command');
+      try {
+        const raw = fs.readFileSync(pinPath, 'utf-8').trim();
+        return raw || null;
+      } catch {
+        // not here
+      }
+      const parent = path.dirname(dir);
+      if (parent === dir) return null;
+      dir = parent;
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * If `cwd` is inside a git worktree, return the main repo root. Otherwise
+ * return `cwd`. Detection is purely filesystem-based (no `git` spawn) so
+ * this stays cheap in the shim's startup path.
+ *
+ * Worktree marker: `.git` is a file (not a directory) whose contents start
+ * with `gitdir: <path>`. That path points at `<mainRepo>/.git/worktrees/<name>`;
+ * the main repo root is three levels up.
+ */
+function resolveSearchStart(cwd) {
+  let dir = cwd;
+  while (true) {
+    const gitEntry = path.join(dir, '.git');
+    try {
+      const stat = fs.lstatSync(gitEntry);
+      if (stat.isDirectory()) return dir;
+      if (stat.isFile()) {
+        const content = fs.readFileSync(gitEntry, 'utf-8').trim();
+        const match = content.match(/^gitdir:\s*(.+)$/m);
+        if (match && match[1]) {
+          const gitdir = path.isAbsolute(match[1]) ? match[1] : path.resolve(dir, match[1]);
+          return path.resolve(gitdir, '..', '..', '..');
+        }
+        return dir;
+      }
+    } catch {
+      // no .git here; keep walking
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return cwd;
+    dir = parent;
+  }
+}
+
+/**
+ * True when `target` and `selfPath` resolve (through symlinks) to the same
+ * binary — used to skip a redirect that would just re-exec into ourselves.
+ * Returns false on any filesystem error (target missing, permission, etc.)
+ * so the caller proceeds to attempt the exec and handles ENOENT there.
+ */
+function pointsAtSelf(target, selfPath) {
+  try {
+    return fs.realpathSync(target) === fs.realpathSync(selfPath);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * If a project-local runtime pin applies and points at a different binary
+ * than ourselves, re-exec into it with forwarded argv and an env var set
+ * to prevent infinite redirect loops. Exits the process on successful
+ * redirect (propagating the child's exit code).
+ *
+ * Returns `false` when no redirect happens, so the caller falls through
+ * to its normal dispatch. Skip reasons: `MYCO_REDIRECTED` already set,
+ * no pin found, pin points at self, or pin target is missing.
+ */
+function maybeRedirect(selfPath, cwd = process.cwd(), env = process.env) {
+  if (env.MYCO_REDIRECTED) return false;
+  const pin = findProjectRuntimePin(cwd);
+  if (!pin) return false;
+  if (pointsAtSelf(pin, selfPath)) return false;
+
+  try {
+    execFileSync(pin, process.argv.slice(2), {
+      stdio: 'inherit',
+      env: { ...env, MYCO_REDIRECTED: '1' },
+    });
+    process.exit(0);
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return false;
+    process.exit((err && typeof err.status === 'number') ? err.status : 1);
+  }
+}
+
+module.exports = {
+  findProjectRuntimePin,
+  resolveSearchStart,
+  pointsAtSelf,
+  maybeRedirect,
+};

--- a/packages/myco/src/cli.ts
+++ b/packages/myco/src/cli.ts
@@ -32,7 +32,7 @@ Commands:
   version                  Show plugin version
   mcp                     Start the MCP stdio server
   hook <name>             Run a hook (session-start, session-end, stop, user-prompt-submit, post-tool-use, post-tool-use-failure, subagent-start, subagent-stop, stop-failure, task-completed, pre-compact, post-compact)
-  daemon --vault <dir>    Start the daemon process
+  daemon                   Start the daemon for the current project
 `;
 
 async function main(): Promise<void> {

--- a/packages/myco/src/cli/init.ts
+++ b/packages/myco/src/cli/init.ts
@@ -13,7 +13,6 @@ import { DEFAULT_OLLAMA_EMBEDDING_MODEL } from '../constants.js';
 import { getPluginVersion } from '../version.js';
 import fs from 'node:fs';
 import path from 'node:path';
-import os from 'node:os';
 
 /** Directories that must exist inside a vault for correct operation. */
 const VAULT_REQUIRED_DIRS = ['buffer', 'attachments', 'logs'] as const;
@@ -28,7 +27,6 @@ function printBanner(): void {
 }
 
 export async function run(args: string[]): Promise<void> {
-  const vaultPath = parseStringFlag(args, '--vault');
   const nonInteractive = args.includes('--non-interactive');
   const isInteractive = !nonInteractive && !!process.stdin.isTTY;
 
@@ -37,10 +35,10 @@ export async function run(args: string[]): Promise<void> {
     printBanner();
   }
 
-  // Resolve vault directory
-  const vaultDir = vaultPath
-    ? (vaultPath.startsWith('~/') ? path.join(os.homedir(), vaultPath.slice(2)) : path.resolve(vaultPath))
-    : path.join(resolveVaultDir());
+  // Vaults are always project-local at `<projectRoot>/.myco/`. There is no
+  // escape hatch — resolveVaultDir walks up from cwd (worktree-aware) to
+  // find the right project root.
+  const vaultDir = resolveVaultDir();
 
   const alreadyInitialized = fs.existsSync(path.join(vaultDir, 'myco.yaml'));
 

--- a/packages/myco/src/daemon/api/restart.ts
+++ b/packages/myco/src/daemon/api/restart.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import path from 'node:path';
 import { z } from 'zod';
 import { resolveCliEntryPath } from '../../hooks/client.js';
 import type { RouteResponse } from '../router.js';
@@ -36,11 +37,13 @@ export async function handleRestart(
   // has fully released the port and cleaned up daemon.json.
   const { execPath, cliEntry } = resolveCliEntryPath();
   const entryPart = cliEntry !== null ? ` ${cliEntry}` : '';
-  const shellCmd = `sleep ${RESTART_CHILD_DELAY_SECONDS} && ${execPath}${entryPart} daemon --vault ${deps.vaultDir}`;
+  const shellCmd = `sleep ${RESTART_CHILD_DELAY_SECONDS} && ${execPath}${entryPart} daemon`;
 
+  const projectRoot = path.dirname(deps.vaultDir);
   const child = spawn('/bin/sh', ['-c', shellCmd], {
     detached: true,
     stdio: 'ignore',
+    cwd: projectRoot,
   });
   child.unref();
 

--- a/packages/myco/src/daemon/api/update.ts
+++ b/packages/myco/src/daemon/api/update.ts
@@ -115,7 +115,11 @@ export function createUpdateHandlers(deps: UpdateDeps) {
     const snapshot = readVaultSnapshot();
 
     // --- Installed-version check (short-circuits before registry) ---
-    if (globalPrefix && !restartInitiated) {
+    // Only machine-scope projects track the global install. Project-scope
+    // runtimes (beta pins under `.myco/runtime/`, dogfood) aren't updated by
+    // `npm install -g`, so respawning via runtime.command would re-exec the
+    // same local binary and loop. Those updates flow through handleUpdateApply.
+    if (globalPrefix && !restartInitiated && snapshot.runtimeScope === 'machine') {
       const installedVersion = getInstalledVersion(globalPrefix);
       if (
         installedVersion &&

--- a/packages/myco/src/daemon/eviction.ts
+++ b/packages/myco/src/daemon/eviction.ts
@@ -264,49 +264,87 @@ export function parseLsofOutput(stdout: string): PortOwner[] {
 }
 
 /**
- * True when `pid` is a myco daemon process invoked with `--vault <vaultDir>`.
+ * True when `pid` is a myco daemon process whose cwd belongs to `vaultDir`.
  *
- * Uses `ps -p <pid> -o args=` and matches against the resolved vault path.
- * Handles both `--vault /path` and `--vault=/path` forms.
+ * Identity is established via two cross-checks, in order:
+ *   1. `daemon.json`'s recorded pid — the healthy case. O(1) file read.
+ *   2. The pid's own cwd, resolved to its nearest enclosing `.myco/`.
+ *      Catches orphan daemons whose `daemon.json` was lost (e.g. racy
+ *      update-apply, unclean shutdown, stale-JSON removal).
+ *
+ * cwd introspection is platform-specific: `/proc/<pid>/cwd` on Linux,
+ * `lsof -p <pid> -d cwd` on Darwin. On unsupported platforms the
+ * fallback returns false, meaning orphans with lost JSON may go
+ * un-evicted there; operators must kill such processes manually.
  */
 export function isMycoDaemonForVault(pid: number, vaultDir: string): boolean {
-  let args: string;
+  if (readDaemonJsonPid(vaultDir) === pid) return true;
+
+  const cwd = readProcessCwd(pid);
+  if (!cwd) return false;
+
+  const resolvedVault = findVaultFromCwd(cwd);
+  if (!resolvedVault) return false;
+
+  // Compare via realpath when both sides exist so macOS's /var → /private/var
+  // symlink (and similar) doesn't produce a false mismatch. Fall back to
+  // plain resolve() if either path is unresolvable.
   try {
-    args = execFileSync('ps', ['-p', String(pid), '-o', 'args='], {
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      timeout: 2000,
-    }).trim();
+    return fs.realpathSync(resolvedVault) === fs.realpathSync(vaultDir);
   } catch {
-    return false;
+    return path.resolve(resolvedVault) === path.resolve(vaultDir);
   }
-  return matchesMycoDaemonInvocation(args, vaultDir);
 }
 
-/** Extracted for direct testability without spawning `ps`. */
-export function matchesMycoDaemonInvocation(args: string, vaultDir: string): boolean {
-  if (args.length === 0) return false;
+/**
+ * Read the working directory of process `pid`.
+ *
+ * - Linux: reads `/proc/<pid>/cwd` as a symlink.
+ * - Darwin: parses `lsof -p <pid> -a -d cwd -Fn` field output.
+ * - Other platforms: returns null.
+ */
+export function readProcessCwd(pid: number): string | null {
+  try {
+    if (process.platform === 'linux') {
+      return fs.readlinkSync(`/proc/${pid}/cwd`);
+    }
+    if (process.platform === 'darwin') {
+      const out = execFileSync(
+        'lsof', ['-p', String(pid), '-a', '-d', 'cwd', '-Fn'],
+        { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 2000 },
+      );
+      // lsof field output: each record is lines prefixed by a tag letter;
+      // `n<path>` carries the cwd.
+      for (const line of out.split('\n')) {
+        if (line.startsWith('n')) return line.slice(1);
+      }
+    }
+  } catch {
+    // Dead pid, permission denied, or unsupported tooling — fall through.
+  }
+  return null;
+}
 
-  const flagIndex = args.indexOf('--vault');
-  if (flagIndex < 0) return false;
-
-  // "myco" must appear in the command portion BEFORE --vault — not in the
-  // vault path itself. Otherwise a vault at `/home/me/myco-stuff/.myco`
-  // would spuriously match any `node ... daemon --vault /home/me/myco-stuff/.myco`.
-  const head = args.slice(0, flagIndex);
-  if (!/myco/i.test(head)) return false;
-  if (!/(^|[\s/])daemon(\s|$)/.test(head)) return false;
-
-  const resolved = path.resolve(vaultDir);
-  const attached = `--vault=${resolved}`;
-  if (args.includes(attached)) return true;
-
-  const tail = args.slice(flagIndex + '--vault'.length).replace(/^[=\s]+/, '');
-  if (tail.length === 0) return false;
-
-  // `tail` may continue with additional flags; take the next token only.
-  const nextArg = tail.split(/\s+/, 1)[0] ?? '';
-  return path.resolve(nextArg) === resolved;
+/**
+ * Walk up from `cwd` to the nearest ancestor containing a `.myco/` directory,
+ * returning the absolute path to that directory (not the parent). Returns
+ * null if no vault is found before the filesystem root.
+ *
+ * Exported for direct testability without standing up a real process.
+ */
+export function findVaultFromCwd(cwd: string): string | null {
+  let dir = cwd;
+  while (true) {
+    const candidate = path.join(dir, '.myco');
+    try {
+      if (fs.statSync(candidate).isDirectory()) return candidate;
+    } catch {
+      // not here
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -16,6 +16,7 @@ import { TranscriptMiner } from '../capture/transcript-miner.js';
 import { createPerProjectAdapter } from '../symbionts/adapter.js';
 import { claudeCodeAdapter } from '../symbionts/claude-code.js';
 import { findPackageRoot } from '../utils/find-package-root.js';
+import { resolveVaultDir } from '../vault/resolve.js';
 import { EventBuffer } from '../capture/buffer.js';
 import { loadManifests } from '../symbionts/detect.js';
 import type { PlanWatchConfig } from './plan-capture.js';
@@ -284,13 +285,11 @@ export async function reconcileExistingDaemon(
 // ---------------------------------------------------------------------------
 
 export async function main(): Promise<void> {
-  const vaultArg = process.argv.find((_, i) => process.argv[i - 1] === '--vault');
-  if (!vaultArg) {
-    process.stderr.write('Usage: mycod --vault <path>\n');
-    process.exit(1);
-  }
-
-  const vaultDir = path.resolve(vaultArg);
+  // The vault always lives at `<projectRoot>/.myco/`. The daemon spawns
+  // with cwd = projectRoot; resolveVaultDir walks up (worktree-aware) to
+  // find the enclosing `.myco/`. There is no escape hatch — vaults are
+  // project-local.
+  const vaultDir = resolveVaultDir();
 
   // Load API keys from secrets.env into process.env before any provider init
   loadSecrets(vaultDir);

--- a/packages/myco/src/daemon/update-installer.ts
+++ b/packages/myco/src/daemon/update-installer.ts
@@ -35,7 +35,7 @@ export interface InstallParams {
   removeLocalRuntime?: boolean;
   /** Absolute path to the project root for `myco update --project`. */
   projectRoot: string;
-  /** Absolute path to the vault directory for `myco daemon --vault`. */
+  /** Absolute path to the vault directory (used to compute localRuntime paths). */
   vaultDir: string;
   /**
    * Literal myco binary the script should invoke for the post-install
@@ -58,7 +58,8 @@ export interface InstallParams {
  * 3. On success: runs `myco update --project <projectRoot>` (non-fatal).
  * 4. On success: clears ~/.myco/update-error.json.
  * 5. On failure: writes error JSON to ~/.myco/update-error.json.
- * 6. Always: starts `myco daemon --vault <vaultDir>` in background.
+ * 6. Always: `cd <projectRoot> && myco daemon &` so the new daemon's
+ *    resolveVaultDir picks up the vault from cwd.
  * 7. Cleans up the script file itself.
  */
 export function generateUpdateScript(params: InstallParams): string {
@@ -74,7 +75,6 @@ export function generateUpdateScript(params: InstallParams): string {
   // Use JSON.stringify for safe path quoting (handles spaces, special chars).
   const installArgs = packageSpecs.map((spec) => JSON.stringify(spec)).join(' ');
   const quotedProjectRoot = JSON.stringify(projectRoot);
-  const quotedVaultDir = JSON.stringify(vaultDir);
   const quotedMycoBinary = JSON.stringify(mycoBinary);
   const quotedErrorPath = JSON.stringify(UPDATE_ERROR_PATH);
   const localRuntimeDir = path.join(vaultDir, PROJECT_RUNTIME_DIRNAME);
@@ -136,7 +136,7 @@ else
 fi
 
 # Restart daemon (works whether install succeeded or failed)
-"$MYCO" daemon --vault ${quotedVaultDir} &
+cd ${quotedProjectRoot} && "$MYCO" daemon &
 
 # Clean up this script
 rm -f "$0"
@@ -181,7 +181,7 @@ export function spawnUpdateScript(params: InstallParams): string {
 export interface RestartParams {
   /** Absolute path to the project root for `myco update --project`. */
   projectRoot: string;
-  /** Absolute path to the vault directory for `myco daemon --vault`. */
+  /** Absolute path to the vault directory (used to compute localRuntime paths). */
   vaultDir: string;
   /** Whether to run `myco update --project` before restarting. */
   runLocalUpdate: boolean;
@@ -203,13 +203,12 @@ export interface RestartParams {
  * 1. Waits for the daemon to exit.
  * 2. Optionally runs `myco update --project` when runLocalUpdate is true.
  * 3. Writes restart-reason.json into the vault.
- * 4. Starts `myco daemon --vault` in background.
+ * 4. `cd <projectRoot> && myco daemon &` so resolveVaultDir picks up the vault.
  * 5. Cleans up the script file.
  */
 export function generateRestartScript(params: RestartParams): string {
   const { projectRoot, vaultDir, runLocalUpdate, fromVersion, toVersion, mycoBinary } = params;
   const quotedProjectRoot = JSON.stringify(projectRoot);
-  const quotedVaultDir = JSON.stringify(vaultDir);
   const quotedMycoBinary = JSON.stringify(mycoBinary);
   const reasonFile = JSON.stringify(path.join(vaultDir, RESTART_REASON_FILENAME));
 
@@ -241,8 +240,8 @@ ${updateBlock}
 # Write restart reason for the new daemon to pick up
 echo ${reasonJson} > ${reasonFile}
 
-# Restart daemon
-"$MYCO" daemon --vault ${quotedVaultDir} &
+# Restart daemon (cd'd into projectRoot so resolveVaultDir finds the vault)
+cd ${quotedProjectRoot} && "$MYCO" daemon &
 
 # Clean up this script
 rm -f "$0"

--- a/packages/myco/src/hooks/client.ts
+++ b/packages/myco/src/hooks/client.ts
@@ -274,9 +274,10 @@ export class DaemonClient {
     if (this.spawnIsInFlight()) return;
 
     const { execPath, cliEntry } = resolveCliEntryPath();
-    const child = spawn(execPath, buildReExecArgs(cliEntry, ['daemon', '--vault', this.vaultDir]), {
+    const child = spawn(execPath, buildReExecArgs(cliEntry, ['daemon']), {
       detached: true,
       stdio: 'ignore',
+      cwd: path.dirname(this.vaultDir),
     });
     child.unref();
   }

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -36,15 +36,23 @@ mock.module('@myco/hooks/client.js', () => ({
   },
 }));
 
+mock.module('@myco/vault/resolve.js', () => ({
+  resolveVaultDir: vi.fn(),
+}));
+
 import { run } from '@myco/cli/init.js';
 import { initDatabase, closeDatabase } from '@myco/db/client.js';
+import { resolveVaultDir } from '@myco/vault/resolve.js';
 
 describe('myco init', () => {
   let testDir: string;
+  let vault: string;
 
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-init-test-'));
+    vault = path.join(testDir, '.myco');
     vi.clearAllMocks();
+    vi.mocked(resolveVaultDir).mockReturnValue(vault);
   });
 
   afterEach(() => {
@@ -52,24 +60,21 @@ describe('myco init', () => {
   });
 
   it('creates vault with config and gitignore', async () => {
-    const vault = path.join(testDir, 'vault');
-    await run(['--vault', vault, '--embedding-model', 'bge-m3']);
+    await run(['--embedding-model', 'bge-m3']);
 
     expect(fs.existsSync(path.join(vault, 'myco.yaml'))).toBe(true);
     expect(fs.existsSync(path.join(vault, '.gitignore'))).toBe(true);
   });
 
   it('initializes SQLite database', async () => {
-    const vault = path.join(testDir, 'vault');
-    await run(['--vault', vault, '--embedding-model', 'bge-m3']);
+    await run(['--embedding-model', 'bge-m3']);
 
     expect(initDatabase).toHaveBeenCalled();
     expect(closeDatabase).toHaveBeenCalled();
   });
 
   it('creates all required subdirectories', async () => {
-    const vault = path.join(testDir, 'vault');
-    await run(['--vault', vault, '--embedding-model', 'bge-m3']);
+    await run(['--embedding-model', 'bge-m3']);
 
     const dirs = ['buffer', 'attachments', 'logs'];
     for (const dir of dirs) {
@@ -78,9 +83,7 @@ describe('myco init', () => {
   });
 
   it('writes valid v3 config with explicit values', async () => {
-    const vault = path.join(testDir, 'vault');
     await run([
-      '--vault', vault,
       '--embedding-provider', 'ollama',
       '--embedding-model', 'bge-m3',
     ]);
@@ -96,23 +99,14 @@ describe('myco init', () => {
   });
 
   it('uses correct base_url when explicitly passed', async () => {
-    const vault = path.join(testDir, 'vault');
-    await run(['--vault', vault, '--embedding-model', 'bge-m3', '--embedding-url', 'http://localhost:11434']);
+    await run(['--embedding-model', 'bge-m3', '--embedding-url', 'http://localhost:11434']);
 
     const config = YAML.parse(fs.readFileSync(path.join(vault, 'myco.yaml'), 'utf-8'));
     expect(config.embedding.base_url).toBe('http://localhost:11434');
   });
 
-  it('accepts custom --vault path', async () => {
-    const customVault = path.join(testDir, 'custom-vault');
-    await run(['--vault', customVault, '--embedding-model', 'bge-m3']);
-
-    expect(fs.existsSync(path.join(customVault, 'myco.yaml'))).toBe(true);
-  });
-
   it('writes .gitignore excluding runtime artifacts', async () => {
-    const vault = path.join(testDir, 'vault');
-    await run(['--vault', vault, '--embedding-model', 'bge-m3']);
+    await run(['--embedding-model', 'bge-m3']);
 
     const gitignore = fs.readFileSync(path.join(vault, '.gitignore'), 'utf-8');
     expect(gitignore).toContain('myco.db');
@@ -125,8 +119,7 @@ describe('myco init', () => {
   });
 
   it('is idempotent — does not overwrite user-set values on re-init', async () => {
-    const vault = path.join(testDir, 'vault');
-    await run(['--vault', vault, '--embedding-model', 'bge-m3', '--non-interactive']);
+    await run(['--embedding-model', 'bge-m3', '--non-interactive']);
 
     const configPath = path.join(vault, 'myco.yaml');
     const originalEmbedding = YAML.parse(fs.readFileSync(configPath, 'utf-8')).embedding.model;
@@ -137,7 +130,7 @@ describe('myco init', () => {
     // config-version migration runs on re-read — but the user's selections
     // stay put.)
     const consoleSpy = vi.spyOn(console, 'log');
-    await run(['--vault', vault, '--embedding-model', 'other', '--non-interactive']);
+    await run(['--embedding-model', 'other', '--non-interactive']);
 
     const afterEmbedding = YAML.parse(fs.readFileSync(configPath, 'utf-8')).embedding.model;
     expect(afterEmbedding).toBe('bge-m3');
@@ -149,8 +142,7 @@ describe('myco init', () => {
     // and event_tasks_enabled=false into myco.yaml. Combined with the daemon
     // reading project-only config, this meant the scheduler never ran on a
     // fresh install even when the user enabled the toggles at personal scope.
-    const vault = path.join(testDir, 'vault');
-    await run(['--vault', vault, '--embedding-model', 'bge-m3']);
+    await run(['--embedding-model', 'bge-m3']);
 
     const config = YAML.parse(fs.readFileSync(path.join(vault, 'myco.yaml'), 'utf-8'));
     expect(config.agent.scheduled_tasks_enabled).toBe(true);
@@ -158,8 +150,7 @@ describe('myco init', () => {
   });
 
   it('initializes plan_dirs as empty array (agent-specific dirs come from symbiont manifests)', async () => {
-    const vault = path.join(testDir, 'vault');
-    await run(['--vault', vault, '--embedding-model', 'bge-m3']);
+    await run(['--embedding-model', 'bge-m3']);
 
     const config = YAML.parse(fs.readFileSync(path.join(vault, 'myco.yaml'), 'utf-8'));
     expect(config.capture.plan_dirs).toEqual([]);
@@ -176,11 +167,10 @@ describe('myco init', () => {
       { manifest: vi.mocked(loadManifests)()[0], binaryFound: true, configDirFound: false },
     ]);
 
-    const vault = path.join(testDir, 'vault');
     // --non-interactive so init doesn't open the inquirer checkbox when
     // stdin is a TTY (which it is on some dev terminals even under
     // `bun test`). Without it, init hangs waiting for the prompt.
-    await run(['--vault', vault, '--embedding-model', 'bge-m3', '--non-interactive']);
+    await run(['--embedding-model', 'bge-m3', '--non-interactive']);
 
     const config = YAML.parse(fs.readFileSync(path.join(vault, 'myco.yaml'), 'utf-8'));
     expect(config.symbionts).toBeDefined();

--- a/tests/cli/runtime-redirect.test.ts
+++ b/tests/cli/runtime-redirect.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for bin/runtime-redirect.cjs — the CLI shim's project-local
+ * runtime pin walker.
+ *
+ * The orchestration in `maybeRedirect` calls `process.exit` on successful
+ * redirect, so it's exercised via a spawned subprocess. The pure helpers
+ * are unit-tested in-process via require().
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const MODULE_PATH = path.resolve('packages/myco/bin/runtime-redirect.cjs');
+
+type Helpers = {
+  findProjectRuntimePin: (cwd: string) => string | null;
+  resolveSearchStart: (cwd: string) => string;
+  pointsAtSelf: (target: string, selfPath: string) => boolean;
+};
+
+// Fresh require each test so module cache can't carry state between them.
+function loadModule(): Helpers {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  delete require.cache[MODULE_PATH];
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require(MODULE_PATH) as Helpers;
+}
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-redirect-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// findProjectRuntimePin
+// ---------------------------------------------------------------------------
+
+describe('findProjectRuntimePin', () => {
+  it('returns null when no .myco/runtime.command exists in any ancestor', () => {
+    const { findProjectRuntimePin } = loadModule();
+    expect(findProjectRuntimePin(tmpRoot)).toBeNull();
+  });
+
+  it('returns the trimmed contents when runtime.command is found at cwd', () => {
+    const mycoDir = path.join(tmpRoot, '.myco');
+    fs.mkdirSync(mycoDir);
+    fs.writeFileSync(path.join(mycoDir, 'runtime.command'), '/opt/pinned/myco\n');
+    const { findProjectRuntimePin } = loadModule();
+    expect(findProjectRuntimePin(tmpRoot)).toBe('/opt/pinned/myco');
+  });
+
+  it('finds the pin when cwd is a subdirectory of the project', () => {
+    const mycoDir = path.join(tmpRoot, '.myco');
+    fs.mkdirSync(mycoDir);
+    fs.writeFileSync(path.join(mycoDir, 'runtime.command'), '/opt/pinned/myco');
+    const subdir = path.join(tmpRoot, 'src', 'deep');
+    fs.mkdirSync(subdir, { recursive: true });
+    const { findProjectRuntimePin } = loadModule();
+    expect(findProjectRuntimePin(subdir)).toBe('/opt/pinned/myco');
+  });
+
+  it('returns null when runtime.command exists but is empty', () => {
+    const mycoDir = path.join(tmpRoot, '.myco');
+    fs.mkdirSync(mycoDir);
+    fs.writeFileSync(path.join(mycoDir, 'runtime.command'), '   \n');
+    const { findProjectRuntimePin } = loadModule();
+    expect(findProjectRuntimePin(tmpRoot)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSearchStart — worktree awareness
+// ---------------------------------------------------------------------------
+
+describe('resolveSearchStart', () => {
+  it('returns cwd when no .git is found in any ancestor', () => {
+    const deep = path.join(tmpRoot, 'a', 'b');
+    fs.mkdirSync(deep, { recursive: true });
+    const { resolveSearchStart } = loadModule();
+    expect(resolveSearchStart(deep)).toBe(deep);
+  });
+
+  it('returns the repo root when .git is a directory', () => {
+    const repo = path.join(tmpRoot, 'repo');
+    fs.mkdirSync(path.join(repo, '.git'), { recursive: true });
+    const inner = path.join(repo, 'src', 'nested');
+    fs.mkdirSync(inner, { recursive: true });
+    const { resolveSearchStart } = loadModule();
+    expect(resolveSearchStart(inner)).toBe(repo);
+  });
+
+  it('returns the main repo root when cwd is inside a git worktree', () => {
+    // Simulate: /tmp/<root>/main-repo/.git/  (main repo)
+    //          /tmp/<root>/main-repo/.worktrees/feature/  (worktree)
+    //          /tmp/<root>/main-repo/.worktrees/feature/.git → file
+    const mainRepo = path.join(tmpRoot, 'main-repo');
+    const mainGit = path.join(mainRepo, '.git');
+    fs.mkdirSync(path.join(mainGit, 'worktrees', 'feature'), { recursive: true });
+
+    const worktree = path.join(mainRepo, '.worktrees', 'feature');
+    fs.mkdirSync(worktree, { recursive: true });
+    fs.writeFileSync(
+      path.join(worktree, '.git'),
+      `gitdir: ${path.join(mainGit, 'worktrees', 'feature')}\n`,
+    );
+
+    const nested = path.join(worktree, 'src', 'module');
+    fs.mkdirSync(nested, { recursive: true });
+
+    const { resolveSearchStart } = loadModule();
+    expect(resolveSearchStart(nested)).toBe(mainRepo);
+  });
+
+  it('resolves relative gitdir paths against the .git file location', () => {
+    const mainRepo = path.join(tmpRoot, 'main-repo');
+    fs.mkdirSync(path.join(mainRepo, '.git', 'worktrees', 'feature'), { recursive: true });
+
+    const worktree = path.join(mainRepo, '.worktrees', 'feature');
+    fs.mkdirSync(worktree, { recursive: true });
+    fs.writeFileSync(
+      path.join(worktree, '.git'),
+      'gitdir: ../../.git/worktrees/feature\n',
+    );
+
+    const { resolveSearchStart } = loadModule();
+    expect(resolveSearchStart(worktree)).toBe(mainRepo);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pointsAtSelf
+// ---------------------------------------------------------------------------
+
+describe('pointsAtSelf', () => {
+  it('returns true when target and self resolve to the same realpath', () => {
+    const binaryPath = path.join(tmpRoot, 'myco');
+    fs.writeFileSync(binaryPath, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    const symlinkPath = path.join(tmpRoot, 'myco-link');
+    fs.symlinkSync(binaryPath, symlinkPath);
+
+    const { pointsAtSelf } = loadModule();
+    expect(pointsAtSelf(symlinkPath, binaryPath)).toBe(true);
+  });
+
+  it('returns false for distinct files', () => {
+    const a = path.join(tmpRoot, 'a');
+    const b = path.join(tmpRoot, 'b');
+    fs.writeFileSync(a, 'a');
+    fs.writeFileSync(b, 'b');
+    const { pointsAtSelf } = loadModule();
+    expect(pointsAtSelf(a, b)).toBe(false);
+  });
+
+  it('returns false when the target does not exist', () => {
+    const self = path.join(tmpRoot, 'self');
+    fs.writeFileSync(self, 'self');
+    const { pointsAtSelf } = loadModule();
+    expect(pointsAtSelf(path.join(tmpRoot, 'missing'), self)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// maybeRedirect — end-to-end via spawn (process.exit paths)
+// ---------------------------------------------------------------------------
+
+describe('maybeRedirect (integration)', () => {
+  /** Build a self-contained shim fixture with our own runtime-redirect.cjs. */
+  function makeShim(): { shimPath: string; runtimeRedirect: string } {
+    const runtimeRedirect = path.join(tmpRoot, 'runtime-redirect.cjs');
+    fs.copyFileSync(MODULE_PATH, runtimeRedirect);
+
+    const shimPath = path.join(tmpRoot, 'shim.cjs');
+    fs.writeFileSync(
+      shimPath,
+      [
+        '#!/usr/bin/env node',
+        `const { maybeRedirect } = require(${JSON.stringify(runtimeRedirect)});`,
+        'maybeRedirect(__filename);',
+        'process.stdout.write("shim:" + process.argv.slice(2).join(" "));',
+      ].join('\n'),
+      { mode: 0o755 },
+    );
+    return { shimPath, runtimeRedirect };
+  }
+
+  it('falls through to normal dispatch when no pin exists', () => {
+    const { shimPath } = makeShim();
+    const cwd = fs.mkdtempSync(path.join(tmpRoot, 'cwd-'));
+
+    const res = spawnSync(process.execPath, [shimPath, 'doctor'], {
+      cwd,
+      encoding: 'utf-8',
+      env: { ...process.env, MYCO_REDIRECTED: undefined } as NodeJS.ProcessEnv,
+    });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toBe('shim:doctor');
+  });
+
+  it('redirects to the pinned binary and forwards argv', () => {
+    const { shimPath } = makeShim();
+    const project = path.join(tmpRoot, 'project');
+    fs.mkdirSync(path.join(project, '.myco'), { recursive: true });
+
+    const pinned = path.join(tmpRoot, 'pinned.sh');
+    fs.writeFileSync(
+      pinned,
+      [
+        '#!/bin/sh',
+        'printf "pinned:%s:redirected=%s" "$*" "${MYCO_REDIRECTED}"',
+      ].join('\n'),
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(path.join(project, '.myco', 'runtime.command'), pinned);
+
+    const res = spawnSync(process.execPath, [shimPath, 'doctor', '--fix'], {
+      cwd: project,
+      encoding: 'utf-8',
+      env: { ...process.env, MYCO_REDIRECTED: undefined } as NodeJS.ProcessEnv,
+    });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toBe('pinned:doctor --fix:redirected=1');
+  });
+
+  it('skips redirect when MYCO_REDIRECTED is already set', () => {
+    const { shimPath } = makeShim();
+    const project = path.join(tmpRoot, 'project');
+    fs.mkdirSync(path.join(project, '.myco'), { recursive: true });
+    fs.writeFileSync(
+      path.join(project, '.myco', 'runtime.command'),
+      '/nonexistent/should/not/matter',
+    );
+
+    const res = spawnSync(process.execPath, [shimPath, 'ok'], {
+      cwd: project,
+      encoding: 'utf-8',
+      env: { ...process.env, MYCO_REDIRECTED: '1' },
+    });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toBe('shim:ok');
+  });
+
+  it('falls through when the pin target is missing (ENOENT)', () => {
+    const { shimPath } = makeShim();
+    const project = path.join(tmpRoot, 'project');
+    fs.mkdirSync(path.join(project, '.myco'), { recursive: true });
+    fs.writeFileSync(
+      path.join(project, '.myco', 'runtime.command'),
+      '/definitely/not/a/real/binary',
+    );
+
+    const res = spawnSync(process.execPath, [shimPath, 'doctor'], {
+      cwd: project,
+      encoding: 'utf-8',
+      env: { ...process.env, MYCO_REDIRECTED: undefined } as NodeJS.ProcessEnv,
+    });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toBe('shim:doctor');
+    expect(res.status).toBe(0);
+  });
+
+  it('propagates non-zero exit status from the pinned binary', () => {
+    const { shimPath } = makeShim();
+    const project = path.join(tmpRoot, 'project');
+    fs.mkdirSync(path.join(project, '.myco'), { recursive: true });
+
+    const pinned = path.join(tmpRoot, 'failing.sh');
+    fs.writeFileSync(pinned, '#!/bin/sh\nexit 42\n', { mode: 0o755 });
+    fs.writeFileSync(path.join(project, '.myco', 'runtime.command'), pinned);
+
+    const res = spawnSync(process.execPath, [shimPath], {
+      cwd: project,
+      encoding: 'utf-8',
+      env: { ...process.env, MYCO_REDIRECTED: undefined } as NodeJS.ProcessEnv,
+    });
+    expect(res.status).toBe(42);
+  });
+});

--- a/tests/daemon/api/update.test.ts
+++ b/tests/daemon/api/update.test.ts
@@ -597,4 +597,28 @@ describe('handleUpdateStatus — restart_required', () => {
 
     expect(spawnRestartScript).not.toHaveBeenCalled();
   });
+
+  // Project-scope runtimes (beta pins under `.myco/runtime/`, dogfood) are
+  // deliberately isolated from the machine-wide myco. Their binary isn't
+  // updated by a global `npm install -g`, so respawning via runtime.command
+  // would re-exec the same local binary and loop. The short-circuit must
+  // skip them; updates flow through handleUpdateApply's install path.
+  it('does not trigger auto-restart when runtime_scope is project-local', async () => {
+    vi.mocked(getInstalledVersion).mockReturnValue('1.1.0');
+    vi.mocked(resolveRuntimeCommand).mockReturnValue(
+      '/vault/runtime/node_modules/.bin/myco',
+    );
+    vi.mocked(isManagedProjectRuntime).mockReturnValue(true);
+    const scheduleShutdown = vi.fn();
+    const { handleUpdateStatus } = createUpdateHandlers(
+      makeDeps({ scheduleShutdown, globalPrefix: '/usr/local' }),
+    );
+
+    const result = await handleUpdateStatus(makeReq());
+
+    expect(spawnRestartScript).not.toHaveBeenCalled();
+    expect(scheduleShutdown).not.toHaveBeenCalled();
+    expect((result.body as Record<string, unknown>).restarting).toBeUndefined();
+    expect(result.body).toMatchObject({ exempt: false });
+  });
 });

--- a/tests/daemon/eviction-integration.test.ts
+++ b/tests/daemon/eviction-integration.test.ts
@@ -2,12 +2,15 @@
  * End-to-end integration test for daemon eviction.
  *
  * Spawns a fake subprocess that mimics a myco daemon by (a) holding the
- * canonical port for a vault and (b) carrying `myco daemon --vault <vault>`
- * in its argv. Verifies `evictDaemonsForVault` finds and kills it even
- * when `daemon.json` has no record of its PID.
+ * canonical port for a vault and (b) running with its cwd set inside
+ * the vault's project root. Verifies `evictDaemonsForVault` finds and
+ * kills it even when `daemon.json` has no record of its PID — the
+ * orphan failure mode Chris hit where the prior eviction logic fell
+ * back to a fallback port forever.
  *
- * This is the scenario Chris hit today: an orphan daemon on :21039
- * caused subsequent startups to silently fall back to :21040.
+ * Identity now flows through cwd introspection (`/proc/<pid>/cwd` on
+ * Linux, `lsof -d cwd` on Darwin) rather than argv matching, because
+ * daemons no longer receive an explicit `--vault` flag.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
@@ -22,7 +25,7 @@ import { derivePort } from '@myco/daemon/port.js';
 /**
  * Child program: binds the supplied port, reports ready, idles forever.
  * Written to a temp file at test-setup time so we don't have to fight
- * shell quoting of embedded JS when rewriting argv[0] below.
+ * shell quoting of embedded JS.
  */
 const ORPHAN_PROGRAM = `
 const net = require('node:net');
@@ -34,115 +37,109 @@ server.listen(port, '127.0.0.1', () => {
 setInterval(() => {}, 1000);
 `;
 
-describe('evictDaemonsForVault — orphan on canonical port', () => {
-  let tmpVault: string;
-  let scriptPath: string;
-  let orphan: ChildProcess | null = null;
+// Only Linux + Darwin can introspect process cwd. Skip the integration
+// layer on unsupported platforms where identity falls back to daemon.json.
+const supportsCwdIntrospection =
+  process.platform === 'linux' || process.platform === 'darwin';
 
-  beforeEach(() => {
-    tmpVault = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-evict-int-'));
-    scriptPath = path.join(tmpVault, 'orphan.js');
-    fs.writeFileSync(scriptPath, ORPHAN_PROGRAM);
-  });
+describe.skipIf(!supportsCwdIntrospection)(
+  'evictDaemonsForVault — orphan on canonical port',
+  () => {
+    let tmpRoot: string;
+    let projectRoot: string;
+    let vaultDir: string;
+    let scriptPath: string;
+    let orphan: ChildProcess | null = null;
 
-  afterEach(() => {
-    if (orphan && orphan.pid) {
-      try { process.kill(orphan.pid, 'SIGKILL'); } catch { /* already dead */ }
-    }
-    orphan = null;
-    fs.rmSync(tmpVault, { recursive: true, force: true });
-  });
-
-  it('evicts a port squatter whose argv claims to be a myco daemon for this vault', async () => {
-    const canonicalPort = derivePort(tmpVault);
-
-    // Spawn our orphan with argv[0] rewritten to look like the myco daemon
-    // invocation. We can't actually change process name, but `ps -o args=`
-    // returns the invocation string as given — which starts with the
-    // command path. Node's `spawn` with the first argv being the program
-    // means the argv we care about is the subsequent list. The trick:
-    // pass a shell command that exec's node with a custom argv[0].
-    const invocation = `myco-fake-daemon daemon --vault ${tmpVault}`;
-    // bash supports `exec -a <name>` which rewrites argv[0]. `sh` may not.
-    orphan = spawn('/bin/bash', [
-      '-c',
-      `exec -a ${JSON.stringify(invocation)} ${JSON.stringify(process.execPath)} ${JSON.stringify(scriptPath)} ${canonicalPort}`,
-    ], {
-      stdio: ['ignore', 'pipe', 'ignore'],
-      detached: false,
+    beforeEach(() => {
+      tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-evict-int-'));
+      projectRoot = path.join(tmpRoot, 'project');
+      vaultDir = path.join(projectRoot, '.myco');
+      fs.mkdirSync(vaultDir, { recursive: true });
+      scriptPath = path.join(tmpRoot, 'orphan.js');
+      fs.writeFileSync(scriptPath, ORPHAN_PROGRAM);
     });
 
-    const orphanPid = orphan.pid!;
-    expect(orphanPid).toBeGreaterThan(0);
+    afterEach(() => {
+      if (orphan && orphan.pid) {
+        try { process.kill(orphan.pid, 'SIGKILL'); } catch { /* already dead */ }
+      }
+      orphan = null;
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    });
 
-    // Wait for the orphan to report READY on stdout.
-    await new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error('orphan did not become ready')), 3000);
-      orphan!.stdout!.on('data', (chunk: Buffer) => {
-        if (chunk.toString('utf-8').includes('READY')) {
-          clearTimeout(timer);
-          resolve();
-        }
+    it('evicts a port squatter whose cwd resolves to this vault', async () => {
+      const canonicalPort = derivePort(vaultDir);
+
+      // Spawn the orphan with cwd = projectRoot. Its cwd walks up to the
+      // enclosing `.myco/`, which is `vaultDir` — that's how eviction
+      // identifies it as ours.
+      orphan = spawn(process.execPath, [scriptPath, String(canonicalPort)], {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        detached: false,
+        cwd: projectRoot,
       });
-    });
 
-    // Sanity: orphan is alive.
-    let alive = true;
-    try { process.kill(orphanPid, 0); } catch { alive = false; }
-    expect(alive).toBe(true);
+      const orphanPid = orphan.pid!;
+      expect(orphanPid).toBeGreaterThan(0);
 
-    // daemon.json is ABSENT — the orphan was never registered. This is
-    // exactly the pathological case the prior eviction logic missed.
-    expect(fs.existsSync(path.join(tmpVault, 'daemon.json'))).toBe(false);
-
-    // Evict.
-    const logs: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
-    const evicted = await evictDaemonsForVault(tmpVault, {
-      graceMs: 1500,
-      pollMs: 50,
-      logger: {
-        info: (_k, msg, meta) => logs.push({ msg, meta }),
-        warn: (_k, msg, meta) => logs.push({ msg, meta }),
-      },
-    });
-
-    expect(evicted).toHaveLength(1);
-    expect(evicted[0]?.pid).toBe(orphanPid);
-    expect(evicted[0]?.source).toBe(`port:${canonicalPort}`);
-
-    // Orphan must be dead.
-    try { process.kill(orphanPid, 0); alive = true; } catch { alive = false; }
-    expect(alive).toBe(false);
-  }, 10_000);
-
-  it('ignores port squatters that are not myco daemons', async () => {
-    const canonicalPort = derivePort(tmpVault);
-
-    // Spawn a plain node process — no `myco` in argv.
-    orphan = spawn(process.execPath, [scriptPath, String(canonicalPort)], {
-      stdio: ['ignore', 'pipe', 'ignore'],
-      detached: false,
-    });
-
-    const orphanPid = orphan.pid!;
-
-    // Wait for READY.
-    await new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error('orphan did not become ready')), 3000);
-      orphan!.stdout!.on('data', (chunk: Buffer) => {
-        if (chunk.toString('utf-8').includes('READY')) {
-          clearTimeout(timer);
-          resolve();
-        }
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('orphan did not become ready')), 3000);
+        orphan!.stdout!.on('data', (chunk: Buffer) => {
+          if (chunk.toString('utf-8').includes('READY')) {
+            clearTimeout(timer);
+            resolve();
+          }
+        });
       });
-    });
 
-    const evicted = await evictDaemonsForVault(tmpVault, { graceMs: 500, pollMs: 50 });
+      // daemon.json is ABSENT — the orphan was never registered. The prior
+      // eviction logic missed this case; cwd-based identity catches it.
+      expect(fs.existsSync(path.join(vaultDir, 'daemon.json'))).toBe(false);
 
-    // Non-myco process must NOT be evicted.
-    expect(evicted).toEqual([]);
-    let alive = false;
-    try { process.kill(orphanPid, 0); alive = true; } catch { /* dead */ }
-    expect(alive).toBe(true);
-  }, 10_000);
-});
+      const evicted = await evictDaemonsForVault(vaultDir, {
+        graceMs: 1500,
+        pollMs: 50,
+      });
+
+      expect(evicted).toHaveLength(1);
+      expect(evicted[0]?.pid).toBe(orphanPid);
+      expect(evicted[0]?.source).toBe(`port:${canonicalPort}`);
+
+      let alive = true;
+      try { process.kill(orphanPid, 0); } catch { alive = false; }
+      expect(alive).toBe(false);
+    }, 10_000);
+
+    it('ignores port squatters whose cwd is not inside this vault', async () => {
+      const canonicalPort = derivePort(vaultDir);
+
+      // Spawn with cwd = tmpRoot (no `.myco/` above it). findVaultFromCwd
+      // returns null → not our daemon → left alone.
+      orphan = spawn(process.execPath, [scriptPath, String(canonicalPort)], {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        detached: false,
+        cwd: tmpRoot,
+      });
+
+      const orphanPid = orphan.pid!;
+
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('orphan did not become ready')), 3000);
+        orphan!.stdout!.on('data', (chunk: Buffer) => {
+          if (chunk.toString('utf-8').includes('READY')) {
+            clearTimeout(timer);
+            resolve();
+          }
+        });
+      });
+
+      const evicted = await evictDaemonsForVault(vaultDir, { graceMs: 500, pollMs: 50 });
+
+      expect(evicted).toEqual([]);
+      let alive = false;
+      try { process.kill(orphanPid, 0); alive = true; } catch { /* dead */ }
+      expect(alive).toBe(true);
+    }, 10_000);
+  },
+);

--- a/tests/daemon/eviction.test.ts
+++ b/tests/daemon/eviction.test.ts
@@ -1,10 +1,10 @@
 /**
  * Unit tests for daemon eviction.
  *
- * The pure helpers (`parseLsofOutput`, `matchesMycoDaemonInvocation`) are
- * tested directly. The orchestration (`evictDaemonsForVault`) is exercised
- * via the exported `findDaemonTargetsForVault` using in-process state:
- * a real live PID (the test process itself) stands in for "alive daemon,"
+ * The pure helpers (`parseLsofOutput`, `findVaultFromCwd`) are tested
+ * directly. The orchestration (`evictDaemonsForVault`) is exercised via
+ * the exported `findDaemonTargetsForVault` using in-process state: a
+ * real live PID (the test process itself) stands in for "alive daemon,"
  * a guaranteed-dead PID stands in for "stale daemon.json entry."
  */
 
@@ -16,7 +16,7 @@ import net from 'node:net';
 
 import {
   parseLsofOutput,
-  matchesMycoDaemonInvocation,
+  findVaultFromCwd,
   findDaemonTargetsForVault,
   findPidsListeningOn,
   terminateProcess,
@@ -67,50 +67,43 @@ describe('parseLsofOutput()', () => {
 });
 
 // ---------------------------------------------------------------------------
-// matchesMycoDaemonInvocation
+// findVaultFromCwd
 // ---------------------------------------------------------------------------
 
-describe('matchesMycoDaemonInvocation()', () => {
-  const vault = '/Users/chris/Repos/myco/.myco';
+describe('findVaultFromCwd()', () => {
+  let tmpRoot: string;
 
-  it('matches the vendor Bun binary invocation', () => {
-    const args = `/Users/chris/Repos/myco/packages/myco/vendor/darwin-arm64/myco daemon --vault ${vault}`;
-    expect(matchesMycoDaemonInvocation(args, vault)).toBe(true);
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-evict-cwd-'));
   });
 
-  it('matches node invoking the CLI entry', () => {
-    const args = `node /path/to/myco/dist/src/cli.js daemon --vault ${vault}`;
-    expect(matchesMycoDaemonInvocation(args, vault)).toBe(true);
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  it('matches --vault=<path> syntax', () => {
-    const args = `/bin/myco daemon --vault=${vault}`;
-    expect(matchesMycoDaemonInvocation(args, vault)).toBe(true);
+  it('returns null when no .myco/ exists in any ancestor', () => {
+    const nested = path.join(tmpRoot, 'a', 'b');
+    fs.mkdirSync(nested, { recursive: true });
+    expect(findVaultFromCwd(nested)).toBeNull();
   });
 
-  it('returns false when args lack the myco word', () => {
-    const args = `node server.js daemon --vault ${vault}`;
-    expect(matchesMycoDaemonInvocation(args, vault)).toBe(false);
+  it('returns the .myco/ path when cwd is the project root', () => {
+    const vault = path.join(tmpRoot, '.myco');
+    fs.mkdirSync(vault);
+    expect(findVaultFromCwd(tmpRoot)).toBe(vault);
   });
 
-  it('returns false when args lack the daemon subcommand', () => {
-    const args = `/bin/myco status --vault ${vault}`;
-    expect(matchesMycoDaemonInvocation(args, vault)).toBe(false);
+  it('walks up to find the enclosing .myco/ from a subdirectory', () => {
+    const vault = path.join(tmpRoot, '.myco');
+    fs.mkdirSync(vault);
+    const nested = path.join(tmpRoot, 'src', 'deep', 'path');
+    fs.mkdirSync(nested, { recursive: true });
+    expect(findVaultFromCwd(nested)).toBe(vault);
   });
 
-  it('returns false for a different vault', () => {
-    const args = `/bin/myco daemon --vault /other/project/.myco`;
-    expect(matchesMycoDaemonInvocation(args, vault)).toBe(false);
-  });
-
-  it('resolves relative vault paths for comparison', () => {
-    const args = `/bin/myco daemon --vault ${vault}`;
-    // Passing a path with a trailing slash still matches.
-    expect(matchesMycoDaemonInvocation(args, `${vault}/`)).toBe(true);
-  });
-
-  it('returns false on empty args', () => {
-    expect(matchesMycoDaemonInvocation('', vault)).toBe(false);
+  it('returns null when .myco exists only as a file (not a dir)', () => {
+    fs.writeFileSync(path.join(tmpRoot, '.myco'), 'not a directory');
+    expect(findVaultFromCwd(tmpRoot)).toBeNull();
   });
 });
 

--- a/tests/daemon/update-installer.test.ts
+++ b/tests/daemon/update-installer.test.ts
@@ -21,10 +21,12 @@ describe('generateRestartScript()', () => {
     expect(script).not.toContain('update --project');
   });
 
-  it('always starts the daemon with --vault', () => {
+  it('starts the daemon from projectRoot so resolveVaultDir finds the vault', () => {
     const script = generateRestartScript({ ...baseParams, runLocalUpdate: false });
-    expect(script).toContain('daemon --vault');
-    expect(script).toContain('/home/user/project/.myco');
+    expect(script).toContain('cd "/home/user/project"');
+    expect(script).toContain('"$MYCO" daemon');
+    // No explicit vault flag — vaults are project-local, resolved from cwd.
+    expect(script).not.toContain('--vault');
   });
 
   it('writes restart-reason.json before starting daemon', () => {


### PR DESCRIPTION
## Summary

Three interlocking fixes delivered together. They share one concept — **`runtime.command` is the single source of truth for "which myco binary this project uses"** — and each commit either applies that invariant to another dispatch path or removes a contradiction.

## Motivation

A beta-pinned project (`.myco/runtime/node_modules/@goondocks/myco@0.22.0-beta.5`) went into an infinite restart loop after the global binary was upgraded to 0.22.1 stable. Symptoms: dead buttons in the Operations UI, `ERR_CONNECTION_REFUSED` on `/notifications`, channel switches not persisting. Diagnosis uncovered two deeper issues beyond the loop itself — a dispatch-path gap (interactive `myco` bypassed the pin) and a legacy `--vault` flag contradicting the "vaults are project-local" invariant.

## Commits

### `8daf784e` fix(update): skip version-sync restart for project-scope runtimes

The `handleUpdateStatus` short-circuit in `daemon/api/update.ts:118` compared installed vs running version unconditionally and spawned a restart via `snapshot.mycoBinary`. For `runtime_scope === 'project'`, that binary points through `runtime.command` → the same local beta. Restart respawned the unchanged binary; next status poll re-detected the mismatch; loop.

**Gate added:** `&& snapshot.runtimeScope === 'machine'`. Project-scope runtimes are deliberately isolated from `npm install -g`; their updates flow through `handleUpdateApply` which handles `localRuntimeSpec` installs and `removeLocalRuntime` reverts.

Aligned with the canonical three-state update model (`update_available` / `restart_required` / `up_to_date`) from the Multi-Project Daemon Update System spec — the short-circuit IS the `restart_required` state handler, and that semantic only holds for machine-scope.

### `5ae70edf` feat(cli): redirect myco CLI to project-local runtime pin

Before this, three of four dispatch paths honored `runtime.command` — hook guards (`myco-run.cjs`), daemon self-restart (`resolveRuntimeCommand`), MCP spawns. The fourth — interactive `myco` from a shell — resolved via PATH to the global binary, producing potential CLI/daemon version skew.

**Fix:** `bin/runtime-redirect.cjs` walks up from cwd (worktree-aware, pure-Node, no `git` spawn) looking for `.myco/runtime.command`. When found and distinct from self, re-execs into the pin with `MYCO_REDIRECTED=1` as loop guard. Fails open on any fs error or ENOENT target.

Extracted as a separate `.cjs` module so pure helpers are unit-testable and orchestration is spawn-testable. 16 tests covering walk-up semantics, worktree detection, self-reference, env/argv forwarding, ENOENT fall-through, and exit-code propagation.

### `811783a1` refactor(daemon): remove --vault flag; identify daemons by cwd

`vault/resolve.ts` already asserts _"The vault is a SQLite database that lives with the project — there is no escape hatch."_ The `--vault <dir>` flag in `myco init`, `myco daemon`, restart-script spawns, hook-client daemon spawn, and eviction's argv matching contradicted that invariant. Removed across all write sites; daemons now spawn with `cwd = projectRoot` and `resolveVaultDir()` walks up.

**Eviction rewrite:** `isMycoDaemonForVault` can no longer grep `ps` argv for the vault path. New identity model:
1. Fast path — daemon.json's recorded pid matches → ours.
2. Fallback — cwd introspection (`/proc/<pid>/cwd` on Linux, `lsof -p <pid> -a -d cwd -Fn` on Darwin) + `findVaultFromCwd` walk + `realpath` comparison (dodges macOS `/var` → `/private/var`).

Trade-off: Windows can't introspect pid cwd, so orphans with lost daemon.json go un-evicted there. Current supported platforms (Linux, Darwin) are covered.

## Test plan

- [x] `bun test tests/daemon/api/update.test.ts tests/daemon/eviction.test.ts tests/daemon/eviction-integration.test.ts tests/daemon/update-installer.test.ts tests/daemon/update-checker.test.ts tests/cli/runtime-redirect.test.ts tests/cli/init.test.ts` → 150/0
- [x] `tsc --noEmit -p packages/myco` → exit 0
- [x] `make build` → exit 0
- [x] New regression test for `restart_required does not trigger when runtime_scope is 'project'`
- [x] New test coverage for CLI redirect: walk-up, worktree detection, self-reference, env/argv forward, ENOENT fallthrough, exit-code propagation (6 integration + 10 unit)
- [x] New test coverage for cwd-based eviction: `findVaultFromCwd` unit tests + reworked integration test that spawns a real orphan with its cwd inside the vault's project

## Verified on unifi-mcp

Manual remediation applied: killed the looping daemon (pids 89305 + 89308), removed `.myco/runtime/` + `.myco/runtime.command`, stripped `update: channel: beta` from `local.yaml`, restarted from `/opt/homebrew/bin/myco` (0.22.1 stable). Daemon now runs machine-scope on 0.22.1, listening cleanly on :28221. This remediation is a one-time cleanup for the broken-state unifi-mcp project; it would be performed automatically by `handleUpdateApply` with `removeLocalRuntime: true` if the daemon hadn't been looping.

## Follow-ups (separate PRs)

- Dogfood unification: collapse the `myco-dev` differently-named-binary Makefile pattern into the `runtime.command` pin pattern this PR establishes.
- `mock.module('node:fs')` teardown hygiene in `tests/daemon/update-checker.test.ts` — pre-existing pollution that causes flakes when bun runs it alongside eviction tests.
- Ad-hoc `daemon.json` readers in `cli/doctor.ts`, `cli/init.ts`, `cli/open.ts`, `mcp/server.ts` should consolidate to a shared typed reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)