### PR TITLE
cleanup(team): retire bundled `myco team init/upgrade` CLI; fix UI instructions

### DIFF
--- a/.agents/skills/setup-cloudflare-team-sync/SKILL.md
+++ b/.agents/skills/setup-cloudflare-team-sync/SKILL.md
@@ -2,7 +2,7 @@
 name: myco:setup-cloudflare-team-sync
 description: >-
   Use this skill when setting up or debugging Myco team sync on Cloudflare.
-  It applies to `myco team init`, the Team page in the daemon UI, Worker
+  It applies to `myco-team install`, the Team page in the daemon UI, Worker
   deployment, Wrangler setup, machine identity, cross-machine vault sync, and
   failure modes like pending outbox drains, missing remote records, or
   embeddings not appearing on another machine. It also covers the outbox
@@ -20,6 +20,7 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob
 - Cloudflare account (free tier covers typical Myco volumes)
 - wrangler CLI installed: `npm install -g wrangler`
 - Authenticated with Cloudflare: `wrangler login`
+- `@goondocks/myco-team` installed globally: `npm install -g @goondocks/myco-team`
 - Myco installed and daemon running (starts automatically on session start)
 - Node.js ≥22
 
@@ -40,22 +41,16 @@ The local `.myco/` vault is always the source of truth. The Cloudflare layer is 
 One team member runs this once from the project directory. It provisions the D1 database, Vectorize index, KV namespace, generates an API key, and deploys the Cloudflare Worker — all in one command.
 
 ```bash
-myco team init
-```
-
-Alternatively, if you installed the standalone team CLI (`npm install -g @goondocks/myco-team`):
-
-```bash
 myco-team install
 ```
 
-Both call the same function. The command is **idempotent** — if D1 or Vectorize already exist, it detects and reuses them.
+The command is **idempotent** — if D1 or Vectorize already exist, it detects and reuses them.
 
 On completion, the command outputs a **Worker URL** and **API key**. Share these with teammates.
 
 ### 2. Verify secrets
 
-After `myco team init`, two secrets are stored in `.myco/secrets.env`:
+After `myco-team install`, two secrets are stored in `.myco/secrets.env`:
 
 ```
 MYCO_TEAM_API_KEY=<hex-api-key>
@@ -130,7 +125,7 @@ If fewer records appear on Machine B than were pushed from Machine A, D1 batch w
 
 ### wrangler ≥4.77: `d1 create` output format changed
 
-**Symptom:** `myco team init` fails with `Could not parse D1 database ID from wrangler output`.
+**Symptom:** `myco-team install` fails with `Could not parse D1 database ID from wrangler output`.
 
 **Fix:** `myco update`. The updated parser handles both the legacy plain-string and new JSON binding block formats, and falls back to `wrangler d1 list --json`.
 
@@ -150,7 +145,7 @@ Two machines sharing the same `machine_id` will have colliding sync records in D
 
 ### wrangler.toml bindings out of sync after manual edits
 
-If `database_name` or `index_name` in `wrangler.toml` was manually edited, the Worker may bind to different resources than expected — producing a silent data split. Use `myco team upgrade` (or `myco-team upgrade`) to re-stage the deployment directory from the canonical source, which patches all bindings correctly.
+If `database_name` or `index_name` in `wrangler.toml` was manually edited, the Worker may bind to different resources than expected — producing a silent data split. Use `myco-team upgrade` to re-stage the deployment directory from the canonical source, which patches all bindings correctly.
 
 ## Implementation: The `team_outbox` Table (schema v9)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,8 +123,8 @@ See [docs/lifecycle.md](docs/lifecycle.md) for the full lifecycle with diagrams.
 
 Three packages are published to [npmjs.org](https://www.npmjs.com/) under the `@goondocks` scope:
 
-- [`@goondocks/myco`](https://www.npmjs.com/package/@goondocks/myco) — main CLI, daemon, hooks, dashboard, and built-in `myco team init` / `myco team upgrade` flow
-- [`@goondocks/myco-team`](https://www.npmjs.com/package/@goondocks/myco-team) — standalone team-sync operator CLI (`myco-team`)
+- [`@goondocks/myco`](https://www.npmjs.com/package/@goondocks/myco) — main CLI, daemon, hooks, and dashboard
+- [`@goondocks/myco-team`](https://www.npmjs.com/package/@goondocks/myco-team) — team-sync operator CLI (`myco-team install` / `upgrade` / `status` / etc.)
 - [`@goondocks/myco-collective`](https://www.npmjs.com/package/@goondocks/myco-collective) — standalone Collective operator CLI (`myco-collective`)
 
 `@goondocks/myco-deploy` under `packages/` is private — it holds the shared Cloudflare deploy helpers the two operator CLIs depend on.

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Existing users still upgrade the main product the same way:
 npm update -g @goondocks/myco
 ```
 
-That remains the only package most users need. It updates the local CLI, daemon, hooks, dashboard, and the built-in `myco team init` / `myco team upgrade` flow.
+That remains the only package most users need for the local CLI, daemon, hooks, and dashboard.
 
-If you also installed the optional standalone operator packages, the Operations page now detects and applies updates for those installed Myco packages too. You only need to drop to npm for the initial install.
+If you also installed the optional operator packages, the Operations page detects and applies updates for them too. You only need to drop to npm for the initial install.
 
-Two new packages are optional operator surfaces:
+Two separate packages are the operator surfaces for team and collective administration:
 
-- `@goondocks/myco-team` — direct team-worker administration from the terminal
+- `@goondocks/myco-team` — provision and manage team sync (required for team features)
 - `@goondocks/myco-collective` — deploy and manage a Myco Collective
 
 Each project also has a **Stable**/**Beta** toggle on its Operations page for early access to upcoming releases. Channel selection is per-project, so trying a Beta in one project does not affect your other projects. See [Stable and Beta channels](docs/lifecycle.md#stable-and-beta-channels).
@@ -128,13 +128,14 @@ See the [Symbiont docs](docs/symbionts.md) for detailed setup information per ag
 
 ### Team sync
 
-Share knowledge across machines and team members with one command:
+Share knowledge across machines and team members. One team member installs the `@goondocks/myco-team` package and provisions the infrastructure:
 
 ```bash
-myco team init    # Provisions Cloudflare D1 + Vectorize + KV + Worker
+npm install -g @goondocks/myco-team
+myco-team install    # Provisions Cloudflare D1 + Vectorize + KV + Worker
 ```
 
-Share the output URL and API key with teammates — they connect from the Team page in the dashboard. Once connected, knowledge syncs automatically: new spores, session summaries, plans, and graph edges push to the team store in the background. Search queries fan out to both local and cloud databases, merging results by relevance score.
+Share the output URL and API key with teammates — they connect from the Team page in the dashboard without needing the `myco-team` package themselves. Once connected, knowledge syncs automatically: new spores, session summaries, plans, and graph edges push to the team store in the background. Search queries fan out to both local and cloud databases, merging results by relevance score.
 
 Local databases remain the source of truth. The cloud store is a queryable mirror — no data is pulled back down. Each record carries a machine identity for attribution.
 

--- a/docs/cloud-mcp.md
+++ b/docs/cloud-mcp.md
@@ -36,7 +36,7 @@ Five read-only tools. The Cloud MCP surface is deliberately narrower than the lo
 
 ## Setting it up
 
-If you've already run `myco team init`, the Cloud MCP server is deployed automatically the next time you click **Update Worker** in the Team page. New team deployments get it out of the box.
+If you've already run `myco-team install`, the Cloud MCP server is deployed automatically the next time you click **Update Worker** in the Team page. New team deployments get it out of the box.
 
 ## Finding your endpoint
 

--- a/docs/collective.md
+++ b/docs/collective.md
@@ -50,10 +50,10 @@ After install, open the deployed worker URL in your browser. The admin UI gives 
 
 Each project needs team sync first.
 
-From the project itself:
+From the project itself (after installing `@goondocks/myco-team`):
 
 ```bash
-myco team init
+myco-team install
 ```
 
 Then add that team worker to the Collective:
@@ -78,11 +78,11 @@ If you already use Myco locally, your normal upgrade path does not change:
 npm update -g @goondocks/myco
 ```
 
-That updates the main Myco CLI, daemon, hooks, dashboard, and the built-in `myco team init` / `myco team upgrade` flow. Most users do not need to install anything else.
+That updates the main Myco CLI, daemon, hooks, and dashboard. Users who are only *connecting* to an existing team don't need anything else.
 
 ### Team operators
 
-Install the standalone team CLI only if you want direct worker administration commands from the terminal:
+Anyone provisioning or administering a team worker needs the team operator CLI:
 
 ```bash
 npm install -g @goondocks/myco-team
@@ -90,10 +90,11 @@ npm install -g @goondocks/myco-team
 
 That adds:
 
-- `myco-team install` — provision team sync (same as `myco team init`)
+- `myco-team install` — provision team sync (D1 + Vectorize + KV + Worker)
 - `myco-team upgrade` — redeploy the worker
 - `myco-team status` — show worker info and credentials
 - `myco-team rotate-tokens` — rotate API key and/or MCP token
+- `myco-team reindex-vectors` — rebuild the Vectorize index
 - `myco-team destroy` — tear down all Cloudflare resources
 
 ### Collective operators

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -95,7 +95,7 @@ If you also installed one of the optional standalone operator CLIs, the Operatio
 - `npm update -g @goondocks/myco-team`
 - `npm update -g @goondocks/myco-collective`
 
-Most users do not need those extra packages. The main `@goondocks/myco` install still covers normal local use, the dashboard, and the built-in `myco team init` / `myco team upgrade` flow.
+Users who are only consuming Myco locally don't need those extra packages. Team operators install `@goondocks/myco-team` for provisioning and worker administration; Collective operators install `@goondocks/myco-collective`.
 
 ### What other projects do
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -192,10 +192,11 @@ npm install -g @goondocks/myco-team
 
 Use it for:
 
-- `myco-team install` — provision team sync (same as `myco team init`)
+- `myco-team install` — provision team sync
 - `myco-team upgrade` — redeploy the worker
 - `myco-team status` — show worker info and credentials
 - `myco-team rotate-tokens` — rotate API key and/or MCP token
+- `myco-team reindex-vectors` — rebuild the Vectorize index
 - `myco-team destroy` — tear down all Cloudflare resources
 
 ### Collective CLI

--- a/docs/team-sync.md
+++ b/docs/team-sync.md
@@ -18,32 +18,24 @@ Local databases remain the source of truth — the cloud store is a queryable mi
 
 ### 1. Install Wrangler
 
-The Cloudflare CLI is required for provisioning.
+Install Wrangler and the team operator CLI. Only the person provisioning the team needs `@goondocks/myco-team` — teammates who are just connecting don't.
 
 ```bash
-npm install -g wrangler
+npm install -g wrangler @goondocks/myco-team
 wrangler login
 ```
-
-The built-in `myco team init` command continues to work from the main `@goondocks/myco` install. You do not need a second package just to enable team sync.
 
 ### 2. Create the team
 
 One team member runs this once. It provisions the Cloudflare infrastructure and deploys the sync Worker.
 
 ```bash
-myco team init
+myco-team install
 ```
 
 The command outputs a **Worker URL** and **API key**. Share these with teammates through your preferred out-of-band channel.
 
-If you want direct worker administration commands from the terminal, install the optional standalone CLI:
-
-```bash
-npm install -g @goondocks/myco-team
-```
-
-That adds `myco-team install` (same as `myco team init`), `myco-team upgrade`, `myco-team status`, `myco-team rotate-tokens`, and `myco-team destroy`.
+The full `myco-team` CLI surface: `install`, `upgrade`, `status`, `rotate-tokens`, `reindex-vectors`, `destroy`.
 
 ### 3. Connect teammates
 
@@ -105,22 +97,20 @@ Backups include all knowledge tables but exclude logs, tool call activities, and
 
 ### Upgrade
 
-Any team member with Wrangler access can update the Worker to match their installed Myco version:
+Any team member with Wrangler and `@goondocks/myco-team` installed can update the Worker to match their installed Myco version:
 
 ```bash
-myco team upgrade
+myco-team upgrade
 ```
 
-Or click **Update Worker** on the Team page when an update is available. The upgrade handles new infrastructure (like the KV namespace added for Cloud MCP), installs new runtime dependencies, and redeploys.
+Or click **Update Worker** on the Team page when an update is available (this runs the upgrade through the daemon, no local `myco-team` install required). The upgrade handles new infrastructure (like the KV namespace added for Cloud MCP), installs new runtime dependencies, and redeploys.
 
-If you use the standalone team CLI, the Operations page now detects and applies its package update when that CLI is installed on the same machine. Manual npm updates still work if you want them:
+The Operations page detects and applies package updates to `@goondocks/myco-team` when that CLI is installed on the same machine. Manual npm updates still work:
 
 ```bash
 npm update -g @goondocks/myco-team
 myco-team upgrade
 ```
-
-If you only use the built-in team commands, `npm update -g @goondocks/myco` remains your upgrade path.
 
 ### Architecture
 

--- a/packages/myco-team/README.md
+++ b/packages/myco-team/README.md
@@ -2,13 +2,13 @@
 
 `@goondocks/myco-team` manages a Myco Team Sync deployment from the terminal.
 
-Install it when you want the standalone operator CLI:
+Install it to provision or administer a team worker:
 
 ```bash
 npm install -g @goondocks/myco-team
 ```
 
-Most Myco users do not need this package. The main `@goondocks/myco` package already includes the built-in `myco team init` and `myco team upgrade` flow.
+Team operators need this package; teammates who only *connect* to an existing team worker through the daemon UI do not.
 
 ## What you can do
 

--- a/packages/myco-team/src/cli.ts
+++ b/packages/myco-team/src/cli.ts
@@ -1,8 +1,14 @@
 /**
  * CLI team commands — provision and manage Cloudflare team sync infrastructure.
  *
- * `myco team init`    — Provision D1 database, Vectorize index, deploy worker.
- * `myco team upgrade` — Redeploy worker with updated source.
+ * Exposed via the standalone `myco-team` binary (see `main.ts`):
+ *   `myco-team install` — Provision D1 database, Vectorize index, deploy worker.
+ *   `myco-team upgrade` — Redeploy worker with updated source.
+ *
+ * The daemon's `POST /api/team/upgrade-worker` handler also imports
+ * `upgradeWorker` from this module at build time (via the tsconfig `@myco-team/*`
+ * path alias) so the UI's "Update Worker" button works without requiring the
+ * user to have `myco-team` on PATH.
  */
 
 import crypto from 'node:crypto';
@@ -596,7 +602,7 @@ export interface UpgradeResult {
 export function upgradeWorker(vaultDir: string): UpgradeResult {
   const config = loadConfig(vaultDir);
   if (!config.team.worker_url) {
-    return { success: false, error: 'No team sync configured. Run: myco team init' };
+    return { success: false, error: 'No team sync configured. Run: myco-team install' };
   }
 
   migrateLegacyDeployDir(vaultDir);
@@ -604,14 +610,14 @@ export function upgradeWorker(vaultDir: string): UpgradeResult {
   const tomlPath = path.join(deployDir, 'wrangler.toml');
 
   if (!fs.existsSync(tomlPath)) {
-    return { success: false, error: 'No deployment directory found. Run: myco team init' };
+    return { success: false, error: 'No deployment directory found. Run: myco-team install' };
   }
 
   // Read ALL existing resource identifiers from current wrangler.toml.
   const existingToml = fs.readFileSync(tomlPath, 'utf-8');
   const d1Match = existingToml.match(TOML_DB_ID_REGEX);
   if (!d1Match || d1Match[1] === '<YOUR_D1_DATABASE_ID>') {
-    return { success: false, error: 'Cannot determine D1 database ID from existing deployment. Run: myco team init' };
+    return { success: false, error: 'Cannot determine D1 database ID from existing deployment. Run: myco-team install' };
   }
   const d1Id = d1Match[1];
 

--- a/packages/myco/src/cli.ts
+++ b/packages/myco/src/cli.ts
@@ -25,7 +25,6 @@ Commands:
   setup-digest [options]   Configure digest and capture settings
   agent [options]          Run the intelligence agent
   task <subcommand>        Manage agent task definitions
-  team <init|upgrade>      Provision or upgrade team sync infrastructure
   doctor [--fix]          Check vault health and repair issues
   open                     Open the dashboard in your browser
   restart                  Restart the daemon
@@ -108,14 +107,6 @@ async function main(): Promise<void> {
       return (await import('./cli/agent-run.js')).run(args, vaultDir);
     }
     case 'task': return (await import('./cli/agent-tasks.js')).run(args, vaultDir);
-    case 'team': {
-      const sub = args[0];
-      if (sub === 'init') return (await import('./cli/team.js')).teamInit(vaultDir);
-      if (sub === 'upgrade') return (await import('./cli/team.js')).teamUpgrade(vaultDir);
-      console.error('Usage: myco team <init|upgrade>');
-      process.exit(1);
-      break;
-    }
     case 'open': return (await import('./cli/open.js')).run(args, vaultDir);
     case 'restart': return (await import('./cli/restart.js')).run(args, vaultDir);
     case 'logs': return (await import('./cli/logs.js')).run(args, vaultDir);

--- a/packages/myco/src/cli/team.ts
+++ b/packages/myco/src/cli/team.ts
@@ -1,7 +1,13 @@
+// Thin re-export of the myco-team bundle surface that the daemon depends on.
+//
+// NB: `myco team init` / `myco team upgrade` were retired in favor of the
+// standalone `myco-team` binary (`npm install -g @goondocks/myco-team`). The
+// only remaining bundled consumer is the daemon's POST /api/team/upgrade-worker
+// handler, which needs in-process access to `upgradeWorker` so that the
+// one-click Worker upgrade from the UI works without requiring the user to
+// have `myco-team` on their PATH. See `daemon/api/team-connect.ts`.
 export {
   getTeamPackageVersion,
-  teamInit,
-  teamUpgrade,
   upgradeWorker,
   type UpgradeResult,
 } from '@myco-team/cli';

--- a/packages/myco/ui/src/pages/Team.tsx
+++ b/packages/myco/ui/src/pages/Team.tsx
@@ -590,16 +590,16 @@ export default function Team() {
 
             <div className="space-y-3">
               <div>
-                <p className="text-sm font-medium text-on-surface mb-1">1. Install Wrangler</p>
+                <p className="text-sm font-medium text-on-surface mb-1">1. Install prerequisites</p>
                 <code className="block font-mono text-xs bg-surface-container rounded px-3 py-2 text-on-surface-variant">
-                  npm install -g wrangler && wrangler login
+                  npm install -g @goondocks/myco-team wrangler && wrangler login
                 </code>
               </div>
 
               <div>
                 <p className="text-sm font-medium text-on-surface mb-1">2. Provision the team</p>
                 <code className="block font-mono text-xs bg-surface-container rounded px-3 py-2 text-on-surface-variant">
-                  myco team init
+                  myco-team install
                 </code>
                 <p className="text-xs text-on-surface-variant mt-1">
                   Creates a D1 database, Vectorize index, and deploys the sync worker.
@@ -610,7 +610,7 @@ export default function Team() {
               <div>
                 <p className="text-sm font-medium text-on-surface mb-1">3. Connect</p>
                 <p className="text-xs text-on-surface-variant">
-                  Paste the Worker URL and API key below, or if you ran <code className="font-mono">myco team init</code>,
+                  Paste the Worker URL and API key below, or if you ran <code className="font-mono">myco-team install</code>,
                   you're already connected.
                 </p>
               </div>

--- a/tests/cli/team-upgrade.test.ts
+++ b/tests/cli/team-upgrade.test.ts
@@ -87,7 +87,7 @@ describe('upgradeWorker', () => {
   let tempHomeDir: string;
   let previousHome: string | undefined;
 
-  async function importTeamCli(): Promise<typeof import('@myco/cli/team.js')> {
+  async function importTeamCli(): Promise<typeof import('@myco-team/cli')> {
     // Pre-import the real module before registering the mock, so the factory
     // doesn't recurse into the eclipsed registry entry.
     const deployActual = await import('@myco-deploy/index.js');
@@ -95,7 +95,7 @@ describe('upgradeWorker', () => {
       ...deployActual,
       resolveHomeConfigPath: (configDir: string, fileName: string) => path.join(tempHomeDir, configDir, fileName),
     }));
-    return import('@myco/cli/team.js');
+    return import('@myco-team/cli');
   }
 
   beforeEach(async () => {


### PR DESCRIPTION
## Summary

Two code paths were delivering the same team-sync provisioning UX: the **bundled** `myco team init` / `myco team upgrade` subcommands (inside the `@goondocks/myco` binary, via a tsconfig path alias that pulled `@myco-team/cli` into the bundle at build time), and the **standalone** `myco-team install` / `myco-team upgrade` binary (`@goondocks/myco-team`). The canonical path is the standalone. The bundled path is retired here.

The UI Team page was also documenting the retired command (`myco team init`) — users following the in-app instructions would hit a command that's about to disappear. Fixed.

## Changes

### Code
- `packages/myco/src/cli.ts` — drop the `team` case and usage line.
- `packages/myco/src/cli/team.ts` — trim to just the two symbols the daemon's `POST /api/team/upgrade-worker` handler still needs (`upgradeWorker`, `getTeamPackageVersion`). Comment explains why. See follow-up question below.
- `packages/myco-team/src/cli.ts` — update the three user-facing error messages that told users to "Run: myco team init" to point at `myco-team install`.
- `packages/myco/ui/src/pages/Team.tsx` — prepend `@goondocks/myco-team` to the prerequisite install step and replace `myco team init` → `myco-team install` in the provisioning and connect blocks.

### Tests
- `tests/cli/team-upgrade.test.ts` — import `teamUpgrade`/`upgradeWorker` from `@myco-team/cli` directly (they test myco-team's function, not myco's CLI surface).

### Docs
- `README.md`, `CONTRIBUTING.md`, `docs/team-sync.md`, `docs/collective.md`, `docs/quickstart.md`, `docs/lifecycle.md`, `docs/cloud-mcp.md` — replace the retired command and remove the "built-in flow" language.
- `packages/myco-team/README.md` — reframe from "install only if you want the standalone CLI" to "install if you're a team operator."
- `.agents/skills/setup-cloudflare-team-sync/SKILL.md` — update the skill description, prerequisites, and steps.

## Test plan

- [x] `bun test tests/cli/team-upgrade.test.ts` — 10/10
- [x] `bunx tsc --noEmit -p packages/myco` — exit 0
- [x] `make build` — exit 0 (full gate: lint + tests + bun compile + UI builds)

## Open design question (deferred to follow-up)

`POST /api/team/upgrade-worker` in the daemon still uses the bundled `upgradeWorker` import via `@myco-team/*` tsconfig path alias. This keeps the "Update Worker" button in the UI working without requiring the user to have `myco-team` on PATH. Two options for eventually removing this last dependency:

1. **Shell out to `myco-team upgrade` from the daemon handler.** Cleaner architectural boundary. Requires the user to have `myco-team` installed globally. Error surface changes (subprocess errors vs JS errors). Natural alignment with the rest of the provisioning UX which now also requires the standalone CLI.
2. **Leave the bundled import.** Accepts the dependency for UX convenience. Documents that this one path is intentional.

No change either way in this PR — just noting the remaining seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)