### PR TITLE
feat(cli): MYCO_DEBUG_REDIRECT traces shim redirect decisions on stderr

### DIFF
--- a/packages/myco/bin/myco.cjs
+++ b/packages/myco/bin/myco.cjs
@@ -10,6 +10,7 @@
 // runtime-redirect.cjs. Projects that pin a local runtime (beta channel,
 // dogfood) are re-exec'd into that binary so the interactive CLI matches
 // the binary the project's daemon, hooks, and MCP server already use.
+// Set `MYCO_DEBUG_REDIRECT=1` to trace redirect decisions on stderr.
 //
 // Rationale: npm's `bin` entry must be a single path. We can't point it
 // directly at a platform-specific binary without a post-install step. This

--- a/packages/myco/bin/runtime-redirect.cjs
+++ b/packages/myco/bin/runtime-redirect.cjs
@@ -109,13 +109,32 @@ function pointsAtSelf(target, selfPath) {
  * Returns `false` when no redirect happens, so the caller falls through
  * to its normal dispatch. Skip reasons: `MYCO_REDIRECTED` already set,
  * no pin found, pin points at self, or pin target is missing.
+ *
+ * When `MYCO_DEBUG_REDIRECT` is set in env, each redirect and each skip
+ * emits a single-line trace to stderr — useful when `which myco` reports
+ * one binary but `myco --version` seems to run a different one.
  */
 function maybeRedirect(selfPath, cwd = process.cwd(), env = process.env) {
-  if (env.MYCO_REDIRECTED) return false;
-  const pin = findProjectRuntimePin(cwd);
-  if (!pin) return false;
-  if (pointsAtSelf(pin, selfPath)) return false;
+  const debug = Boolean(env.MYCO_DEBUG_REDIRECT);
+  const trace = (msg) => {
+    if (debug) process.stderr.write(`[myco] redirect: ${msg}\n`);
+  };
 
+  if (env.MYCO_REDIRECTED) {
+    trace('skip (MYCO_REDIRECTED already set)');
+    return false;
+  }
+  const pin = findProjectRuntimePin(cwd);
+  if (!pin) {
+    trace('skip (no .myco/runtime.command pin found)');
+    return false;
+  }
+  if (pointsAtSelf(pin, selfPath)) {
+    trace(`skip (pin points at self: ${pin})`);
+    return false;
+  }
+
+  trace(`${selfPath} → ${pin}`);
   try {
     execFileSync(pin, process.argv.slice(2), {
       stdio: 'inherit',
@@ -123,7 +142,10 @@ function maybeRedirect(selfPath, cwd = process.cwd(), env = process.env) {
     });
     process.exit(0);
   } catch (err) {
-    if (err && err.code === 'ENOENT') return false;
+    if (err && err.code === 'ENOENT') {
+      trace(`fallback to normal dispatch (pin target missing: ${pin})`);
+      return false;
+    }
     process.exit((err && typeof err.status === 'number') ? err.status : 1);
   }
 }

--- a/tests/cli/runtime-redirect.test.ts
+++ b/tests/cli/runtime-redirect.test.ts
@@ -282,4 +282,68 @@ describe('maybeRedirect (integration)', () => {
     });
     expect(res.status).toBe(42);
   });
+
+  it('stays silent on stderr by default when redirecting', () => {
+    const { shimPath } = makeShim();
+    const project = path.join(tmpRoot, 'project');
+    fs.mkdirSync(path.join(project, '.myco'), { recursive: true });
+    const pinned = path.join(tmpRoot, 'silent-pinned.sh');
+    fs.writeFileSync(pinned, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    fs.writeFileSync(path.join(project, '.myco', 'runtime.command'), pinned);
+
+    const res = spawnSync(process.execPath, [shimPath], {
+      cwd: project,
+      encoding: 'utf-8',
+      env: { ...process.env, MYCO_REDIRECTED: undefined, MYCO_DEBUG_REDIRECT: undefined } as NodeJS.ProcessEnv,
+    });
+    expect(res.status).toBe(0);
+    expect(res.stderr).toBe('');
+  });
+
+  it('traces the redirect to stderr when MYCO_DEBUG_REDIRECT is set', () => {
+    const { shimPath } = makeShim();
+    const project = path.join(tmpRoot, 'project');
+    fs.mkdirSync(path.join(project, '.myco'), { recursive: true });
+    const pinned = path.join(tmpRoot, 'traced-pinned.sh');
+    fs.writeFileSync(pinned, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    fs.writeFileSync(path.join(project, '.myco', 'runtime.command'), pinned);
+
+    const res = spawnSync(process.execPath, [shimPath], {
+      cwd: project,
+      encoding: 'utf-8',
+      env: { ...process.env, MYCO_REDIRECTED: undefined, MYCO_DEBUG_REDIRECT: '1' },
+    });
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain('[myco] redirect:');
+    expect(res.stderr).toContain(shimPath);
+    expect(res.stderr).toContain(pinned);
+  });
+
+  it('traces the skip reason when MYCO_DEBUG_REDIRECT is set and no pin exists', () => {
+    const { shimPath } = makeShim();
+    const cwd = fs.mkdtempSync(path.join(tmpRoot, 'nopin-'));
+
+    const res = spawnSync(process.execPath, [shimPath], {
+      cwd,
+      encoding: 'utf-8',
+      env: { ...process.env, MYCO_REDIRECTED: undefined, MYCO_DEBUG_REDIRECT: '1' },
+    });
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain('[myco] redirect: skip (no .myco/runtime.command pin found)');
+  });
+
+  it('traces the skip reason when MYCO_REDIRECTED is already set', () => {
+    const { shimPath } = makeShim();
+    const project = path.join(tmpRoot, 'project');
+    fs.mkdirSync(path.join(project, '.myco'), { recursive: true });
+    fs.writeFileSync(path.join(project, '.myco', 'runtime.command'), '/unused');
+
+    const res = spawnSync(process.execPath, [shimPath], {
+      cwd: project,
+      encoding: 'utf-8',
+      env: { ...process.env, MYCO_REDIRECTED: '1', MYCO_DEBUG_REDIRECT: '1' },
+    });
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain('[myco] redirect: skip (MYCO_REDIRECTED already set)');
+  });
 });


### PR DESCRIPTION
## Summary

The CLI shim's runtime.command redirect (from PR #156) is silent by design. That's a feature for everyday use but a pain for debugging: \`which myco\` says one thing, \`myco --version\` reports another, and the only way to understand why was to read the shim's source.

This PR adds an opt-in diagnostic: set \`MYCO_DEBUG_REDIRECT=1\` and the shim writes a single-line trace to stderr for each decision it makes.

## What it looks like

\`\`\`
$ MYCO_DEBUG_REDIRECT=1 myco --version
[myco] redirect: /opt/homebrew/bin/myco → /Users/x/.local/bin/myco-dev
0.22.2

$ cd /tmp && MYCO_DEBUG_REDIRECT=1 myco --version
[myco] redirect: skip (no .myco/runtime.command pin found)
0.22.2

$ MYCO_REDIRECTED=1 MYCO_DEBUG_REDIRECT=1 myco --version
[myco] redirect: skip (MYCO_REDIRECTED already set)
0.22.2
\`\`\`

All five decision branches emit a trace line:
- redirect happening (with self-path → pin-path)
- skip: MYCO_REDIRECTED already set (we're the redirected-into child)
- skip: no .myco/runtime.command pin found in any ancestor
- skip: pin points at self (realpath match)
- fallback to normal dispatch: pin target missing on disk (ENOENT)

## Default behavior unchanged

Silent by default — no output on stderr unless \`MYCO_DEBUG_REDIRECT\` is set. There's a new regression test asserting that.

## Test plan

- [x] \`bun test tests/cli/runtime-redirect.test.ts\` — 20/20 (4 new tests covering: silent by default, redirect trace shape, no-pin skip trace, already-redirected skip trace)
- [x] \`tsc --noEmit -p packages/myco\` — exit 0

## Context

Surfaced as a quality-of-life follow-up during the 0.22.1 → 0.22.2 transition where the unifi-mcp daemon ended up serving from \`myco-dev\` because its parent daemon inherited the wrong cwd and the shim redirected based on that cwd. At the time, there was no way to tell from outside the process that the redirect had happened. This flag fixes that for future debugging sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)