### PR TITLE
fix(update): close the dogfood restart-loop gap in #156's version-sync gate

### DIFF
--- a/packages/myco/src/daemon/api/update.ts
+++ b/packages/myco/src/daemon/api/update.ts
@@ -115,11 +115,17 @@ export function createUpdateHandlers(deps: UpdateDeps) {
     const snapshot = readVaultSnapshot();
 
     // --- Installed-version check (short-circuits before registry) ---
-    // Only machine-scope projects track the global install. Project-scope
-    // runtimes (beta pins under `.myco/runtime/`, dogfood) aren't updated by
-    // `npm install -g`, so respawning via runtime.command would re-exec the
-    // same local binary and loop. Those updates flow through handleUpdateApply.
-    if (globalPrefix && !restartInitiated && snapshot.runtimeScope === 'machine') {
+    // Only run this when there is NO `runtime.command` pin at all. A pin
+    // means the daemon is locked to a specific binary (beta runtimes under
+    // `.myco/runtime/`, dogfood symlinks like ~/.local/bin/myco-dev, any
+    // other user-set pin). `npm install -g` never touches those binaries,
+    // so respawning via the pin re-execs the same binary and loops. This
+    // gate is on `runtimeCommand === null` rather than the older
+    // `runtimeScope === 'machine'` check because the scope label lumped
+    // "no pin" and "pin outside .myco/runtime/" together — the latter still
+    // has the loop problem. Pinned-runtime updates flow through
+    // handleUpdateApply's install path.
+    if (globalPrefix && !restartInitiated && snapshot.runtimeCommand === null) {
       const installedVersion = getInstalledVersion(globalPrefix);
       if (
         installedVersion &&

--- a/tests/daemon/api/update.test.ts
+++ b/tests/daemon/api/update.test.ts
@@ -598,17 +598,44 @@ describe('handleUpdateStatus — restart_required', () => {
     expect(spawnRestartScript).not.toHaveBeenCalled();
   });
 
-  // Project-scope runtimes (beta pins under `.myco/runtime/`, dogfood) are
-  // deliberately isolated from the machine-wide myco. Their binary isn't
-  // updated by a global `npm install -g`, so respawning via runtime.command
-  // would re-exec the same local binary and loop. The short-circuit must
-  // skip them; updates flow through handleUpdateApply's install path.
-  it('does not trigger auto-restart when runtime_scope is project-local', async () => {
+  // Any runtime.command pin isolates the daemon from the global install.
+  // The short-circuit must skip whenever a pin is set, regardless of where
+  // the pin points. Two representative cases:
+  //
+  //   1. Pin under `.myco/runtime/` — beta-channel project-local install.
+  //   2. Pin outside `.myco/runtime/` — dogfood `~/.local/bin/myco-dev`
+  //      symlinked to a locally-built repo binary.
+  //
+  // Before this fix, only case 1 was gated (via the `runtimeScope`
+  // label), leaving dogfood daemons in a restart loop whenever the
+  // globally-installed version outran the pinned binary.
+  it('does not trigger auto-restart when runtime.command pins a project-local beta runtime', async () => {
     vi.mocked(getInstalledVersion).mockReturnValue('1.1.0');
     vi.mocked(resolveRuntimeCommand).mockReturnValue(
       '/vault/runtime/node_modules/.bin/myco',
     );
     vi.mocked(isManagedProjectRuntime).mockReturnValue(true);
+    const scheduleShutdown = vi.fn();
+    const { handleUpdateStatus } = createUpdateHandlers(
+      makeDeps({ scheduleShutdown, globalPrefix: '/usr/local' }),
+    );
+
+    const result = await handleUpdateStatus(makeReq());
+
+    expect(spawnRestartScript).not.toHaveBeenCalled();
+    expect(scheduleShutdown).not.toHaveBeenCalled();
+    expect((result.body as Record<string, unknown>).restarting).toBeUndefined();
+    expect(result.body).toMatchObject({ exempt: false });
+  });
+
+  it('does not trigger auto-restart when runtime.command pins a dogfood binary outside .myco/runtime/', async () => {
+    vi.mocked(getInstalledVersion).mockReturnValue('1.1.0');
+    // Dogfood layout: ~/.local/bin/myco-dev symlinked to the repo's built
+    // vendor binary. `isManagedProjectRuntime` returns false (not under
+    // `.myco/runtime/node_modules/`), but the daemon is still pinned —
+    // restart would respawn the same binary and loop.
+    vi.mocked(resolveRuntimeCommand).mockReturnValue('/Users/x/.local/bin/myco-dev');
+    vi.mocked(isManagedProjectRuntime).mockReturnValue(false);
     const scheduleShutdown = vi.fn();
     const { handleUpdateStatus } = createUpdateHandlers(
       makeDeps({ scheduleShutdown, globalPrefix: '/usr/local' }),


### PR DESCRIPTION
## Summary

Follow-up to PR #156. The gate I added there stopped the restart loop for *beta-pinned* projects (runtime.command pointing under \`.myco/runtime/\`) but left **dogfood** projects — where runtime.command points *outside* that directory (e.g., \`~/.local/bin/myco-dev\` → repo vendor binary) — still in the loop.

## Symptom (observed on main)

Dogfood myco repo:
- Running daemon: 0.22.1 (locally built myco-dev)
- Global install: 0.22.2 (just released)
- UI notifications: repeated "Updated to v0.22.2 — Restarted to pick up the latest version"
- Daemon log: \`Version sync restart detected, from 0.22.1, to 0.22.2\` firing every 1-2 minutes, plus "Sibling daemon already healthy — stepping aside" as the loop races itself

## Why #156 missed it

\`snapshot.runtimeScope\` maps to \`'project'\` only when \`isManagedProjectRuntime()\` returns true — i.e., when runtime.command points *inside* \`.myco/runtime/node_modules/\`. Dogfood's \`~/.local/bin/myco-dev\` doesn't match that pattern, so it lands in \`'machine'\` alongside "no pin at all."

But the two cases behave very differently under the version-sync short-circuit:

| Pin state | Restart binary | Safe to sync? |
|---|---|---|
| \`runtime.command\` missing | \`'myco'\` via PATH → new global | ✅ |
| Pin under \`.myco/runtime/\` | Pinned beta binary | ❌ loops |
| Pin outside \`.myco/runtime/\` (dogfood, user-set) | Whatever the pin points at | ❌ loops |

#156 caught row 2 but not row 3.

## Fix

Change the gate from \`snapshot.runtimeScope === 'machine'\` to \`snapshot.runtimeCommand === null\`. The semantic becomes "short-circuit only when there is no pin at all." Covers all three cases correctly and is robust to future pinning schemes.

Added a second regression test alongside the existing one: \`does not trigger auto-restart when runtime.command pins a dogfood binary outside .myco/runtime/\` — mocks \`isManagedProjectRuntime\` to return \`false\` while setting \`resolveRuntimeCommand\` to a dogfood-style path, and asserts no restart spawns.

## Test plan

- [x] \`bun test tests/daemon/api/update.test.ts\` — 30/30 (1 new case)
- [x] \`tsc --noEmit -p packages/myco\` — exit 0

## Deployment note

After merge and release, first visit to the dogfood project's Operations page will trigger one final "version sync" restart as the old 0.22.1 daemon reads the new logic — wait, no: the fix only affects the *new* daemon's gate decision. The old 0.22.1 daemon will keep looping until it's manually killed OR the user runs \`make dev-link\` to rebuild myco-dev at the new version. Post-fix, rebuilt dogfood daemons on the fixed version won't loop regardless of global/repo version skew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)