### PR TITLE
feat(canopy): Phase 0 foundation (schema + types + settings + utilities)

### DIFF
--- a/packages/myco/src/canopy/exclude.ts
+++ b/packages/myco/src/canopy/exclude.ts
@@ -1,15 +1,6 @@
-/**
- * Minimal glob matcher for Canopy exclude patterns. We intentionally do not
- * pull in `minimatch` — the default pattern set only uses three shapes:
- *   1. Bare segment  e.g. `node_modules`, `.git`, `dist`
- *      → matches if any path segment equals the pattern
- *   2. `**\/<name>`    e.g. `**\/package-lock.json`
- *      → matches if the basename equals <name>
- *   3. `**\/<glob>`    e.g. `**\/*.lock`
- *      → matches if the basename matches the glob (* and ? supported)
- *
- * Anything more exotic should be added here with an accompanying test case.
- */
+// Minimal glob matcher for Canopy exclude patterns. We avoid the minimatch dep
+// because the default pattern set only needs three shapes: bare segment,
+// `**/<basename>`, and `**/<glob>` against the basename.
 
 function globToRegex(pattern: string): RegExp {
   const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');

--- a/packages/myco/src/canopy/exclude.ts
+++ b/packages/myco/src/canopy/exclude.ts
@@ -1,0 +1,48 @@
+/**
+ * Minimal glob matcher for Canopy exclude patterns. We intentionally do not
+ * pull in `minimatch` — the default pattern set only uses three shapes:
+ *   1. Bare segment  e.g. `node_modules`, `.git`, `dist`
+ *      → matches if any path segment equals the pattern
+ *   2. `**\/<name>`    e.g. `**\/package-lock.json`
+ *      → matches if the basename equals <name>
+ *   3. `**\/<glob>`    e.g. `**\/*.lock`
+ *      → matches if the basename matches the glob (* and ? supported)
+ *
+ * Anything more exotic should be added here with an accompanying test case.
+ */
+
+function globToRegex(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  const body = escaped.replace(/\*/g, '.*').replace(/\?/g, '.');
+  return new RegExp(`^${body}$`);
+}
+
+function matchesBasename(relPath: string, basenameGlob: string): boolean {
+  const base = relPath.split('/').pop() ?? relPath;
+  if (!basenameGlob.includes('*') && !basenameGlob.includes('?')) {
+    return base === basenameGlob;
+  }
+  return globToRegex(basenameGlob).test(base);
+}
+
+function matchesAnySegment(relPath: string, segment: string): boolean {
+  return relPath.split('/').some((part) => part === segment);
+}
+
+export function isExcluded(relPath: string, patterns: string[]): boolean {
+  const normalized = relPath.replace(/\\/g, '/');
+  for (const raw of patterns) {
+    const p = raw.replace(/\\/g, '/');
+    if (p.startsWith('**/')) {
+      if (matchesBasename(normalized, p.slice(3))) return true;
+      continue;
+    }
+    if (!p.includes('/') && !p.includes('*') && !p.includes('?')) {
+      if (matchesAnySegment(normalized, p)) return true;
+      continue;
+    }
+    // Fallback: treat as path-shape glob anchored at start.
+    if (globToRegex(p).test(normalized)) return true;
+  }
+  return false;
+}

--- a/packages/myco/src/canopy/exclude.ts
+++ b/packages/myco/src/canopy/exclude.ts
@@ -8,32 +8,60 @@ function globToRegex(pattern: string): RegExp {
   return new RegExp(`^${body}$`);
 }
 
-function matchesBasename(relPath: string, basenameGlob: string): boolean {
-  const base = relPath.split('/').pop() ?? relPath;
-  if (!basenameGlob.includes('*') && !basenameGlob.includes('?')) {
-    return base === basenameGlob;
+type CompiledPattern =
+  | { kind: 'segment'; value: string }
+  | { kind: 'basename-literal'; value: string }
+  | { kind: 'basename-glob'; regex: RegExp }
+  | { kind: 'path-glob'; regex: RegExp };
+
+function compile(raw: string): CompiledPattern {
+  const p = raw.replace(/\\/g, '/');
+  if (p.startsWith('**/')) {
+    const base = p.slice(3);
+    if (!base.includes('*') && !base.includes('?')) {
+      return { kind: 'basename-literal', value: base };
+    }
+    return { kind: 'basename-glob', regex: globToRegex(base) };
   }
-  return globToRegex(basenameGlob).test(base);
+  if (!p.includes('/') && !p.includes('*') && !p.includes('?')) {
+    return { kind: 'segment', value: p };
+  }
+  return { kind: 'path-glob', regex: globToRegex(p) };
 }
 
-function matchesAnySegment(relPath: string, segment: string): boolean {
-  return relPath.split('/').some((part) => part === segment);
+/**
+ * Build a matcher closure that compiles each pattern once. Hot-path callers
+ * (the scanner walks ~10k files × ~10 patterns) should reuse a single matcher
+ * across the walk so regex construction and pattern classification happen at
+ * setup, not per-file.
+ */
+export function createExcludeMatcher(patterns: string[]): (relPath: string) => boolean {
+  const compiled = patterns.map(compile);
+  return (relPath) => {
+    const normalized = relPath.replace(/\\/g, '/');
+    const segments = normalized.split('/');
+    const basename = segments[segments.length - 1] ?? normalized;
+    for (const c of compiled) {
+      switch (c.kind) {
+        case 'segment':
+          if (segments.includes(c.value)) return true;
+          break;
+        case 'basename-literal':
+          if (basename === c.value) return true;
+          break;
+        case 'basename-glob':
+          if (c.regex.test(basename)) return true;
+          break;
+        case 'path-glob':
+          if (c.regex.test(normalized)) return true;
+          break;
+      }
+    }
+    return false;
+  };
 }
 
+/** One-shot check; for repeated calls prefer `createExcludeMatcher`. */
 export function isExcluded(relPath: string, patterns: string[]): boolean {
-  const normalized = relPath.replace(/\\/g, '/');
-  for (const raw of patterns) {
-    const p = raw.replace(/\\/g, '/');
-    if (p.startsWith('**/')) {
-      if (matchesBasename(normalized, p.slice(3))) return true;
-      continue;
-    }
-    if (!p.includes('/') && !p.includes('*') && !p.includes('?')) {
-      if (matchesAnySegment(normalized, p)) return true;
-      continue;
-    }
-    // Fallback: treat as path-shape glob anchored at start.
-    if (globToRegex(p).test(normalized)) return true;
-  }
-  return false;
+  return createExcludeMatcher(patterns)(relPath);
 }

--- a/packages/myco/src/canopy/hash.ts
+++ b/packages/myco/src/canopy/hash.ts
@@ -1,0 +1,17 @@
+import { createHash } from 'node:crypto';
+
+/** SHA-256 hex digest of a buffer. Used as the content_hash for scanner entries. */
+export function sha256Hex(buf: Buffer | string): string {
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+/**
+ * Mechanical token estimate: one token per ~4 characters. Stable across
+ * languages; deliberately ignores tokenizer-specific boundaries because we
+ * want a cheap, deterministic heuristic that survives re-scans unchanged
+ * when content is unchanged.
+ */
+export function estimateTokens(text: string): number {
+  if (text.length === 0) return 0;
+  return Math.ceil(text.length / 4);
+}

--- a/packages/myco/src/canopy/hash.ts
+++ b/packages/myco/src/canopy/hash.ts
@@ -1,17 +1,7 @@
 import { createHash } from 'node:crypto';
+import { CONTENT_HASH_ALGORITHM } from '@myco/constants.js';
 
-/** SHA-256 hex digest of a buffer. Used as the content_hash for scanner entries. */
+/** SHA-256 hex digest of a buffer or string. */
 export function sha256Hex(buf: Buffer | string): string {
-  return createHash('sha256').update(buf).digest('hex');
-}
-
-/**
- * Mechanical token estimate: one token per ~4 characters. Stable across
- * languages; deliberately ignores tokenizer-specific boundaries because we
- * want a cheap, deterministic heuristic that survives re-scans unchanged
- * when content is unchanged.
- */
-export function estimateTokens(text: string): number {
-  if (text.length === 0) return 0;
-  return Math.ceil(text.length / 4);
+  return createHash(CONTENT_HASH_ALGORITHM).update(buf).digest('hex');
 }

--- a/packages/myco/src/canopy/index.ts
+++ b/packages/myco/src/canopy/index.ts
@@ -1,0 +1,3 @@
+export * from './types.js';
+export * from './hash.js';
+export * from './exclude.js';

--- a/packages/myco/src/canopy/index.ts
+++ b/packages/myco/src/canopy/index.ts
@@ -1,3 +1,0 @@
-export * from './types.js';
-export * from './hash.js';
-export * from './exclude.js';

--- a/packages/myco/src/canopy/types.ts
+++ b/packages/myco/src/canopy/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared Canopy types. Row-shape (`CanopyEntry`) lives in db/schema.ts
+ * because that's where the other row types are published.
+ */
+
+export interface CanopyParserInput {
+  /** Repo-relative path (forward-slash). */
+  path: string;
+  /** UTF-8 file contents. */
+  content: string;
+  sizeBytes: number;
+  lineCount: number;
+}
+
+export interface CanopyParserOutput {
+  language: string | null;
+  exports: string[];
+  imports: string[];
+  topComment: string | null;
+}
+
+export type CanopyParser = (input: CanopyParserInput) => CanopyParserOutput;
+
+export interface CanopyScanResult {
+  scanned: number;
+  added: number;
+  updated: number;
+  removed: number;
+  errored: number;
+  durationMs: number;
+}
+
+/**
+ * Injection-time blob shape. Composed by Track B from a persisted
+ * CanopyEntry; `summary` is populated from `llm_description` when present.
+ */
+export interface CanopyBlob {
+  path: string;
+  tokenEstimate: number;
+  lineCount: number;
+  exports: string[];
+  imports: string[];
+  top: string | null;
+  summary: string | null;
+}

--- a/packages/myco/src/cli.ts
+++ b/packages/myco/src/cli.ts
@@ -30,7 +30,7 @@ Commands:
   restart                  Restart the daemon
   version                  Show plugin version
   mcp                     Start the MCP stdio server
-  hook <name>             Run a hook (session-start, session-end, stop, user-prompt-submit, post-tool-use, post-tool-use-failure, subagent-start, subagent-stop, stop-failure, task-completed, pre-compact, post-compact)
+  hook <name>             Run a hook (session-start, session-end, stop, user-prompt-submit, pre-tool-use, post-tool-use, post-tool-use-failure, subagent-start, subagent-stop, stop-failure, task-completed, pre-compact, post-compact)
   daemon                   Start the daemon for the current project
 `;
 
@@ -56,6 +56,7 @@ async function main(): Promise<void> {
       'session-end': () => import('./hooks/session-end.js'),
       'stop': () => import('./hooks/stop.js'),
       'user-prompt-submit': () => import('./hooks/user-prompt-submit.js'),
+      'pre-tool-use': () => import('./hooks/pre-tool-use.js'),
       'post-tool-use': () => import('./hooks/post-tool-use.js'),
       'post-tool-use-failure': () => import('./hooks/post-tool-use-failure.js'),
       'subagent-start': () => import('./hooks/subagent-start.js'),

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -181,6 +181,65 @@ const SymbiontEntrySchema = z.object({
   enabled: z.boolean().default(true),
 });
 
+/**
+ * Canopy — the project-local data plane for code intelligence.
+ * Controls collection (scanning, exclusion, refresh cadence). Separate from
+ * what Cortex does with the collected data (see CortexSchema below).
+ */
+const CanopyRefreshSchema = z.object({
+  /** Whether the PowerManager-scheduled background rescan runs at all. */
+  background_enabled: z.boolean().default(true),
+  /** Human-readable period consumed by PowerManager's duration parser. */
+  background_period: z.string().default('1h'),
+});
+
+const CanopyExcludeSchema = z.object({
+  /** Glob/segment patterns skipped during scans. */
+  patterns: z.array(z.string()).default([
+    'node_modules', '.git', 'dist', 'build', '.next', '.turbo',
+    '**/*.lock', '**/package-lock.json', '**/pnpm-lock.yaml', '**/yarn.lock',
+  ]),
+});
+
+const CanopySchema = z.object({
+  refresh: CanopyRefreshSchema.default(() => CanopyRefreshSchema.parse({})),
+  exclude: CanopyExcludeSchema.default(() => CanopyExcludeSchema.parse({})),
+});
+
+/**
+ * Cortex controls — what Cortex does with collected data.
+ * Nested because the scoped-settings surface groups consumer-side
+ * configuration separately from the data plane.
+ */
+const CortexCanopyInjectionSchema = z.object({
+  /** Master switch for PreToolUse Canopy injection on Read. */
+  enabled: z.boolean().default(true),
+  /** Minimum size_bytes before injection is offered. */
+  size_threshold: z.number().int().default(800),
+});
+
+const CortexCanopyLlmSchema = z.object({
+  /** Enable the Tier 2 `canopy-describe` task. Default off — opt in. */
+  enabled: z.boolean().default(false),
+  /** Reasoning tier hint passed to the provider selector. */
+  reasoning_tier: z.enum(['low', 'medium', 'high']).default('low'),
+  /** Prompt ref resolved under packages/myco/src/prompts/. */
+  prompt_ref: z.string().default('canopy-describe'),
+  /** Hard cap on post-processed description length. */
+  max_description_chars: z.number().int().default(180),
+  /** Retry budget before leaving llm_description NULL. */
+  max_attempts: z.number().int().default(2),
+});
+
+const CortexCanopySchema = z.object({
+  injection: CortexCanopyInjectionSchema.default(() => CortexCanopyInjectionSchema.parse({})),
+  llm: CortexCanopyLlmSchema.default(() => CortexCanopyLlmSchema.parse({})),
+});
+
+const CortexSchema = z.object({
+  canopy: CortexCanopySchema.default(() => CortexCanopySchema.parse({})),
+});
+
 export {
   APPEARANCE_THEMES,
   APPEARANCE_MODES,
@@ -228,6 +287,8 @@ export const MycoConfigSchema = z.preprocess(
     team: TeamSchema.default(() => TeamSchema.parse({})),
     skills: SkillsSchema.default(() => SkillsSchema.parse({})),
     notifications: NotificationsSchema.default(() => NotificationsSchema.parse({})),
+    canopy: CanopySchema.default(() => CanopySchema.parse({})),
+    cortex: CortexSchema.default(() => CortexSchema.parse({})),
     appearance: AppearanceConfigSchema,
     symbionts: z.record(z.string(), SymbiontEntrySchema).optional(),
   }),
@@ -244,4 +305,6 @@ export type HubConfig = z.infer<typeof HubSchema>;
 export type TeamConfig = z.infer<typeof TeamSchema>;
 export type SkillsConfig = z.infer<typeof SkillsSchema>;
 export type NotificationsConfig = z.infer<typeof NotificationsSchema>;
+export type CanopyConfig = z.infer<typeof CanopySchema>;
+export type CortexConfig = z.infer<typeof CortexSchema>;
 export type SymbiontEntry = z.infer<typeof SymbiontEntrySchema>;

--- a/packages/myco/src/db/migrations.ts
+++ b/packages/myco/src/db/migrations.ts
@@ -22,6 +22,9 @@ import {
   CORTEX_INSTRUCTIONS_TABLE,
   MIGRATION_TASKS_TABLE,
   CANOPY_ENTRIES_TABLE,
+  CANOPY_SESSION_COLUMNS,
+  CANOPY_ACTIVITY_COLUMN,
+  CANOPY_INDEX_DDLS,
 } from './schema-ddl.js';
 import {
   buildPlanId,
@@ -1377,34 +1380,25 @@ function migrateV23ToV24(db: Database): void {
  * All new columns on existing tables are nullable; pre-feature rows stay NULL.
  */
 function migrateV24ToV25(db: Database): void {
+  const existingSessions = getTableColumnSet(db, 'sessions');
+  const sessionPending = CANOPY_SESSION_COLUMNS.filter(([name]) => !existingSessions.has(name));
+
+  const existingActivities = getTableColumnSet(db, 'activities');
+  const [activityName, activityDecl] = CANOPY_ACTIVITY_COLUMN;
+  const activityPending = !existingActivities.has(activityName);
+
   db.prepare('BEGIN').run();
   try {
     db.prepare(CANOPY_ENTRIES_TABLE).run();
 
-    if (tableExists(db, 'sessions')) {
-      const sessionCols = getTableColumnSet(db, 'sessions');
-      const sessionAdds: Array<[string, string]> = [
-        ['canopy_injections_offered', 'ALTER TABLE sessions ADD COLUMN canopy_injections_offered INTEGER'],
-        ['canopy_injection_total_tokens', 'ALTER TABLE sessions ADD COLUMN canopy_injection_total_tokens INTEGER'],
-        ['canopy_skips_after_injection', 'ALTER TABLE sessions ADD COLUMN canopy_skips_after_injection INTEGER'],
-        ['canopy_reads_after_injection', 'ALTER TABLE sessions ADD COLUMN canopy_reads_after_injection INTEGER'],
-        ['canopy_tokens_saved', 'ALTER TABLE sessions ADD COLUMN canopy_tokens_saved INTEGER'],
-        ['canopy_redundant_reads', 'ALTER TABLE sessions ADD COLUMN canopy_redundant_reads INTEGER'],
-      ];
-      for (const [col, stmt] of sessionAdds) {
-        if (!sessionCols.has(col)) db.prepare(stmt).run();
-      }
+    for (const [name, decl] of sessionPending) {
+      db.prepare(`ALTER TABLE sessions ADD COLUMN ${name} ${decl}`).run();
+    }
+    if (activityPending) {
+      db.prepare(`ALTER TABLE activities ADD COLUMN ${activityName} ${activityDecl}`).run();
     }
 
-    if (tableExists(db, 'activities')) {
-      const activitiesCols = getTableColumnSet(db, 'activities');
-      if (!activitiesCols.has('canopy_injection_tokens')) {
-        db.prepare('ALTER TABLE activities ADD COLUMN canopy_injection_tokens INTEGER').run();
-      }
-    }
-
-    db.prepare('CREATE INDEX IF NOT EXISTS idx_canopy_hash ON canopy_entries (project_id, content_hash)').run();
-    db.prepare('CREATE INDEX IF NOT EXISTS idx_canopy_updated ON canopy_entries (project_id, mechanical_updated_at)').run();
+    for (const ddl of CANOPY_INDEX_DDLS) db.prepare(ddl).run();
 
     db.prepare(
       `INSERT INTO schema_version (version, applied_at)

--- a/packages/myco/src/db/migrations.ts
+++ b/packages/myco/src/db/migrations.ts
@@ -21,6 +21,7 @@ import {
   DIGEST_EXTRACT_REVISIONS_TABLE,
   CORTEX_INSTRUCTIONS_TABLE,
   MIGRATION_TASKS_TABLE,
+  CANOPY_ENTRIES_TABLE,
 } from './schema-ddl.js';
 import {
   buildPlanId,
@@ -60,6 +61,7 @@ export const MIGRATIONS: Migration[] = [
   { version: 22, migrate: (db) => migrateV21ToV22(db) },
   { version: 23, migrate: (db) => migrateV22ToV23(db) },
   { version: 24, migrate: (db) => migrateV23ToV24(db) },
+  { version: 25, migrate: (db) => migrateV24ToV25(db) },
 ];
 
 // ---------------------------------------------------------------------------
@@ -1357,6 +1359,58 @@ function migrateV23ToV24(db: Database): void {
        VALUES (?, ?)
        ON CONFLICT (version) DO NOTHING`,
     ).run(24, epochSeconds());
+
+    db.prepare('COMMIT').run();
+  } catch (err) {
+    db.prepare('ROLLBACK').run();
+    throw err;
+  }
+}
+
+/**
+ * Version 25 lands the Canopy code-intelligence layer:
+ *   - new `canopy_entries` table (project-scoped source file index)
+ *   - `activities.canopy_injection_tokens` — per-Read injection cost, NULL otherwise
+ *   - six aggregate columns on `sessions` for per-session injection outcomes
+ *   - two indexes on canopy_entries (content_hash lookup, mechanical_updated_at scan)
+ *
+ * All new columns on existing tables are nullable; pre-feature rows stay NULL.
+ */
+function migrateV24ToV25(db: Database): void {
+  db.prepare('BEGIN').run();
+  try {
+    db.prepare(CANOPY_ENTRIES_TABLE).run();
+
+    if (tableExists(db, 'sessions')) {
+      const sessionCols = getTableColumnSet(db, 'sessions');
+      const sessionAdds: Array<[string, string]> = [
+        ['canopy_injections_offered', 'ALTER TABLE sessions ADD COLUMN canopy_injections_offered INTEGER'],
+        ['canopy_injection_total_tokens', 'ALTER TABLE sessions ADD COLUMN canopy_injection_total_tokens INTEGER'],
+        ['canopy_skips_after_injection', 'ALTER TABLE sessions ADD COLUMN canopy_skips_after_injection INTEGER'],
+        ['canopy_reads_after_injection', 'ALTER TABLE sessions ADD COLUMN canopy_reads_after_injection INTEGER'],
+        ['canopy_tokens_saved', 'ALTER TABLE sessions ADD COLUMN canopy_tokens_saved INTEGER'],
+        ['canopy_redundant_reads', 'ALTER TABLE sessions ADD COLUMN canopy_redundant_reads INTEGER'],
+      ];
+      for (const [col, stmt] of sessionAdds) {
+        if (!sessionCols.has(col)) db.prepare(stmt).run();
+      }
+    }
+
+    if (tableExists(db, 'activities')) {
+      const activitiesCols = getTableColumnSet(db, 'activities');
+      if (!activitiesCols.has('canopy_injection_tokens')) {
+        db.prepare('ALTER TABLE activities ADD COLUMN canopy_injection_tokens INTEGER').run();
+      }
+    }
+
+    db.prepare('CREATE INDEX IF NOT EXISTS idx_canopy_hash ON canopy_entries (project_id, content_hash)').run();
+    db.prepare('CREATE INDEX IF NOT EXISTS idx_canopy_updated ON canopy_entries (project_id, mechanical_updated_at)').run();
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at)
+       VALUES (?, ?)
+       ON CONFLICT (version) DO NOTHING`,
+    ).run(25, epochSeconds());
 
     db.prepare('COMMIT').run();
   } catch (err) {

--- a/packages/myco/src/db/queries/activities.ts
+++ b/packages/myco/src/db/queries/activities.ts
@@ -59,6 +59,7 @@ export interface ActivityRow {
   processed: number;
   content_hash: string | null;
   created_at: number;
+  canopy_injection_tokens: number | null;
 }
 
 /** Filter options for `listActivities`. */
@@ -88,6 +89,7 @@ const ACTIVITY_COLUMNS = [
   'processed',
   'content_hash',
   'created_at',
+  'canopy_injection_tokens',
 ] as const;
 
 const SELECT_COLUMNS = ACTIVITY_COLUMNS.join(', ');
@@ -114,6 +116,7 @@ function toActivityRow(row: Record<string, unknown>): ActivityRow {
     processed: row.processed as number,
     content_hash: (row.content_hash as string) ?? null,
     created_at: row.created_at as number,
+    canopy_injection_tokens: (row.canopy_injection_tokens as number) ?? null,
   };
 }
 

--- a/packages/myco/src/db/queries/sessions.ts
+++ b/packages/myco/src/db/queries/sessions.ts
@@ -81,6 +81,12 @@ export interface SessionRow {
   created_at: number;
   machine_id: string;
   synced_at: number | null;
+  canopy_injections_offered: number | null;
+  canopy_injection_total_tokens: number | null;
+  canopy_skips_after_injection: number | null;
+  canopy_reads_after_injection: number | null;
+  canopy_tokens_saved: number | null;
+  canopy_redundant_reads: number | null;
 }
 
 /** Updatable fields for `updateSession`. */
@@ -151,6 +157,12 @@ const SESSION_COLUMNS = [
   'created_at',
   'machine_id',
   'synced_at',
+  'canopy_injections_offered',
+  'canopy_injection_total_tokens',
+  'canopy_skips_after_injection',
+  'canopy_reads_after_injection',
+  'canopy_tokens_saved',
+  'canopy_redundant_reads',
 ] as const;
 
 const SELECT_COLUMNS = SESSION_COLUMNS.join(', ');
@@ -187,6 +199,12 @@ function toSessionRow(row: Record<string, unknown>): SessionRow {
     created_at: row.created_at as number,
     machine_id: (row.machine_id as string) ?? 'local',
     synced_at: (row.synced_at as number) ?? null,
+    canopy_injections_offered: (row.canopy_injections_offered as number) ?? null,
+    canopy_injection_total_tokens: (row.canopy_injection_total_tokens as number) ?? null,
+    canopy_skips_after_injection: (row.canopy_skips_after_injection as number) ?? null,
+    canopy_reads_after_injection: (row.canopy_reads_after_injection as number) ?? null,
+    canopy_tokens_saved: (row.canopy_tokens_saved as number) ?? null,
+    canopy_redundant_reads: (row.canopy_redundant_reads as number) ?? null,
   };
 }
 

--- a/packages/myco/src/db/schema-ddl.ts
+++ b/packages/myco/src/db/schema-ddl.ts
@@ -47,7 +47,13 @@ const SESSIONS_TABLE = `
     created_at             INTEGER NOT NULL,
     embedded               INTEGER DEFAULT 0,
     machine_id             TEXT NOT NULL DEFAULT 'local',
-    synced_at              INTEGER
+    synced_at              INTEGER,
+    canopy_injections_offered      INTEGER,
+    canopy_injection_total_tokens  INTEGER,
+    canopy_skips_after_injection   INTEGER,
+    canopy_reads_after_injection   INTEGER,
+    canopy_tokens_saved            INTEGER,
+    canopy_redundant_reads         INTEGER
   )`;
 
 const PROMPT_BATCHES_TABLE = `
@@ -87,7 +93,8 @@ const ACTIVITIES_TABLE = `
     timestamp            INTEGER NOT NULL,
     processed            INTEGER DEFAULT 0,
     content_hash         TEXT UNIQUE,
-    created_at           INTEGER NOT NULL
+    created_at           INTEGER NOT NULL,
+    canopy_injection_tokens INTEGER
   )`;
 
 const PLANS_TABLE = `
@@ -511,6 +518,25 @@ export const DIGEST_EXTRACT_REVISIONS_TABLE = `
     created_at          INTEGER NOT NULL
   )`;
 
+export const CANOPY_ENTRIES_TABLE = `
+  CREATE TABLE IF NOT EXISTS canopy_entries (
+    project_id             TEXT    NOT NULL,
+    machine_id             TEXT    NOT NULL DEFAULT 'local',
+    path                   TEXT    NOT NULL,
+    content_hash           TEXT    NOT NULL,
+    size_bytes             INTEGER NOT NULL,
+    token_estimate         INTEGER NOT NULL,
+    line_count             INTEGER NOT NULL,
+    language               TEXT,
+    exports_json           TEXT,
+    imports_json           TEXT,
+    top_comment            TEXT,
+    mechanical_updated_at  INTEGER NOT NULL,
+    llm_description        TEXT,
+    llm_updated_at         INTEGER,
+    PRIMARY KEY (project_id, path)
+  ) WITHOUT ROWID`;
+
 // -- FTS5 Virtual Tables ----------------------------------------------------
 
 export const FTS_TABLES = [
@@ -707,6 +733,10 @@ export const SECONDARY_INDEXES = [
   'CREATE INDEX IF NOT EXISTS idx_write_intents_run_id ON agent_run_write_intents (run_id)',
   'CREATE INDEX IF NOT EXISTS idx_write_intents_run_id_tool ON agent_run_write_intents (run_id, tool_name)',
   'CREATE INDEX IF NOT EXISTS idx_digest_revisions_agent_tier ON digest_extract_revisions (agent_id, tier, created_at DESC)',
+
+  // Canopy
+  'CREATE INDEX IF NOT EXISTS idx_canopy_hash ON canopy_entries (project_id, content_hash)',
+  'CREATE INDEX IF NOT EXISTS idx_canopy_updated ON canopy_entries (project_id, mechanical_updated_at)',
 ];
 
 // -- Ordered table creation -------------------------------------------------
@@ -751,4 +781,6 @@ export const TABLE_DDLS = [
   // Eval harness layer
   AGENT_RUN_WRITE_INTENTS_TABLE,
   DIGEST_EXTRACT_REVISIONS_TABLE,
+  // Canopy layer
+  CANOPY_ENTRIES_TABLE,
 ];

--- a/packages/myco/src/db/schema-ddl.ts
+++ b/packages/myco/src/db/schema-ddl.ts
@@ -537,6 +537,31 @@ export const CANOPY_ENTRIES_TABLE = `
     PRIMARY KEY (project_id, path)
   ) WITHOUT ROWID`;
 
+/**
+ * Canopy aggregate column names + decls on the `sessions` table. Shared by
+ * `SESSIONS_TABLE` (initial create), `migrateV24ToV25` (ALTER on existing
+ * vaults), and the query-layer column lists / row interface.
+ */
+export const CANOPY_SESSION_COLUMNS: ReadonlyArray<readonly [string, string]> = [
+  ['canopy_injections_offered', 'INTEGER'],
+  ['canopy_injection_total_tokens', 'INTEGER'],
+  ['canopy_skips_after_injection', 'INTEGER'],
+  ['canopy_reads_after_injection', 'INTEGER'],
+  ['canopy_tokens_saved', 'INTEGER'],
+  ['canopy_redundant_reads', 'INTEGER'],
+];
+
+/** Canopy column on the `activities` (tool-call) table. */
+export const CANOPY_ACTIVITY_COLUMN: readonly [string, string] = [
+  'canopy_injection_tokens',
+  'INTEGER',
+];
+
+export const CANOPY_INDEX_DDLS: readonly string[] = [
+  'CREATE INDEX IF NOT EXISTS idx_canopy_hash ON canopy_entries (project_id, content_hash)',
+  'CREATE INDEX IF NOT EXISTS idx_canopy_updated ON canopy_entries (project_id, mechanical_updated_at)',
+];
+
 // -- FTS5 Virtual Tables ----------------------------------------------------
 
 export const FTS_TABLES = [
@@ -735,8 +760,7 @@ export const SECONDARY_INDEXES = [
   'CREATE INDEX IF NOT EXISTS idx_digest_revisions_agent_tier ON digest_extract_revisions (agent_id, tier, created_at DESC)',
 
   // Canopy
-  'CREATE INDEX IF NOT EXISTS idx_canopy_hash ON canopy_entries (project_id, content_hash)',
-  'CREATE INDEX IF NOT EXISTS idx_canopy_updated ON canopy_entries (project_id, mechanical_updated_at)',
+  ...CANOPY_INDEX_DDLS,
 ];
 
 // -- Ordered table creation -------------------------------------------------

--- a/packages/myco/src/db/schema.ts
+++ b/packages/myco/src/db/schema.ts
@@ -27,6 +27,30 @@ export { DEFAULT_MACHINE_ID };
 /** Embedding vector dimensions (bge-m3 default). */
 export const EMBEDDING_DIMENSIONS = 1024;
 
+/**
+ * Row shape for the `canopy_entries` table — project-scoped source file index
+ * that backs Canopy code intelligence. Mechanical fields (hash, size, token
+ * estimate, language, exports, imports, top_comment) are maintained by the
+ * scanner. `llm_description` is an optional override populated by the Tier 2
+ * `canopy-describe` task.
+ */
+export interface CanopyEntry {
+  project_id: string;
+  machine_id: string;
+  path: string;
+  content_hash: string;
+  size_bytes: number;
+  token_estimate: number;
+  line_count: number;
+  language: string | null;
+  exports_json: string | null; // JSON array
+  imports_json: string | null; // JSON array
+  top_comment: string | null;
+  mechanical_updated_at: number; // epoch seconds
+  llm_description: string | null;
+  llm_updated_at: number | null;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/packages/myco/src/db/schema.ts
+++ b/packages/myco/src/db/schema.ts
@@ -19,7 +19,7 @@ import { TABLE_DDLS, FTS_TABLES, SECONDARY_INDEXES } from './schema-ddl.js';
 import { MIGRATIONS } from './migrations.js';
 
 /** Current schema version -- fresh start for the SQLite era. */
-export const SCHEMA_VERSION = 24;
+export const SCHEMA_VERSION = 25;
 
 // Re-export for backwards compat (other modules import from schema.ts)
 export { DEFAULT_MACHINE_ID };

--- a/packages/myco/src/hooks/pre-tool-use.ts
+++ b/packages/myco/src/hooks/pre-tool-use.ts
@@ -1,6 +1,2 @@
-// Stub — real implementation lands in Track B (Canopy injection).
-// Phase 0 registers this so the CLI dispatcher doesn't throw on the hook
-// name once symbiont hook templates begin registering PreToolUse.
-export async function main(): Promise<void> {
-  // No-op by default. Track B replaces this with the injection handler.
-}
+// Stub; injection handler lands in Track B.
+export async function main(): Promise<void> {}

--- a/packages/myco/src/hooks/pre-tool-use.ts
+++ b/packages/myco/src/hooks/pre-tool-use.ts
@@ -1,0 +1,6 @@
+// Stub — real implementation lands in Track B (Canopy injection).
+// Phase 0 registers this so the CLI dispatcher doesn't throw on the hook
+// name once symbiont hook templates begin registering PreToolUse.
+export async function main(): Promise<void> {
+  // No-op by default. Track B replaces this with the injection handler.
+}

--- a/tests/canopy/exclude.test.ts
+++ b/tests/canopy/exclude.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'bun:test';
 import { isExcluded } from '@myco/canopy/exclude';
+import { MycoConfigSchema } from '@myco/config/schema';
 
-const DEFAULT_PATTERNS = [
-  'node_modules', '.git', 'dist', 'build', '.next', '.turbo',
-  '**/*.lock', '**/package-lock.json', '**/pnpm-lock.yaml', '**/yarn.lock',
-];
+// Source the default pattern list from the live schema so this test fails if
+// the defaults drift, instead of silently exercising a stale copy.
+const DEFAULT_PATTERNS = MycoConfigSchema.parse({ version: 3 }).canopy.exclude.patterns;
 
 describe('isExcluded (default patterns)', () => {
   it('excludes node_modules at any depth', () => {

--- a/tests/canopy/exclude.test.ts
+++ b/tests/canopy/exclude.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'bun:test';
+import { isExcluded } from '@myco/canopy/exclude';
+
+const DEFAULT_PATTERNS = [
+  'node_modules', '.git', 'dist', 'build', '.next', '.turbo',
+  '**/*.lock', '**/package-lock.json', '**/pnpm-lock.yaml', '**/yarn.lock',
+];
+
+describe('isExcluded (default patterns)', () => {
+  it('excludes node_modules at any depth', () => {
+    expect(isExcluded('node_modules/foo/index.js', DEFAULT_PATTERNS)).toBe(true);
+    expect(isExcluded('packages/a/node_modules/foo/index.js', DEFAULT_PATTERNS)).toBe(true);
+  });
+
+  it('excludes .git and build output dirs', () => {
+    expect(isExcluded('.git/HEAD', DEFAULT_PATTERNS)).toBe(true);
+    expect(isExcluded('dist/app.js', DEFAULT_PATTERNS)).toBe(true);
+    expect(isExcluded('build/index.html', DEFAULT_PATTERNS)).toBe(true);
+    expect(isExcluded('.next/cache/foo', DEFAULT_PATTERNS)).toBe(true);
+    expect(isExcluded('.turbo/daemon.log', DEFAULT_PATTERNS)).toBe(true);
+  });
+
+  it('excludes lockfiles by basename at any depth', () => {
+    expect(isExcluded('package-lock.json', DEFAULT_PATTERNS)).toBe(true);
+    expect(isExcluded('packages/a/package-lock.json', DEFAULT_PATTERNS)).toBe(true);
+    expect(isExcluded('yarn.lock', DEFAULT_PATTERNS)).toBe(true);
+    expect(isExcluded('apps/web/pnpm-lock.yaml', DEFAULT_PATTERNS)).toBe(true);
+    expect(isExcluded('vendor/foo.lock', DEFAULT_PATTERNS)).toBe(true);
+  });
+
+  it('allows normal source files', () => {
+    expect(isExcluded('src/index.ts', DEFAULT_PATTERNS)).toBe(false);
+    expect(isExcluded('packages/myco/src/db/schema.ts', DEFAULT_PATTERNS)).toBe(false);
+    expect(isExcluded('README.md', DEFAULT_PATTERNS)).toBe(false);
+    expect(isExcluded('docs/design.md', DEFAULT_PATTERNS)).toBe(false);
+  });
+
+  it('does NOT mistake segment substrings for matches', () => {
+    // `node_modules` is a full segment pattern — `node_modules_legacy` must not match.
+    expect(isExcluded('node_modules_legacy/foo.js', DEFAULT_PATTERNS)).toBe(false);
+    // `build` as a segment — `rebuild.ts` must not match.
+    expect(isExcluded('src/rebuild.ts', DEFAULT_PATTERNS)).toBe(false);
+  });
+
+  it('normalizes backslash paths (windows-ish)', () => {
+    expect(isExcluded('packages\\a\\node_modules\\foo.js', DEFAULT_PATTERNS)).toBe(true);
+  });
+
+  it('returns false for empty pattern list', () => {
+    expect(isExcluded('node_modules/foo.js', [])).toBe(false);
+  });
+});

--- a/tests/canopy/exclude.test.ts
+++ b/tests/canopy/exclude.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { isExcluded } from '@myco/canopy/exclude';
+import { createExcludeMatcher, isExcluded } from '@myco/canopy/exclude';
 import { MycoConfigSchema } from '@myco/config/schema';
 
 // Source the default pattern list from the live schema so this test fails if
@@ -48,5 +48,15 @@ describe('isExcluded (default patterns)', () => {
 
   it('returns false for empty pattern list', () => {
     expect(isExcluded('node_modules/foo.js', [])).toBe(false);
+  });
+});
+
+describe('createExcludeMatcher', () => {
+  it('reuses compiled patterns across calls and matches each shape correctly', () => {
+    const matcher = createExcludeMatcher(DEFAULT_PATTERNS);
+    expect(matcher('node_modules/foo/index.js')).toBe(true);    // segment
+    expect(matcher('packages/a/package-lock.json')).toBe(true); // basename-literal
+    expect(matcher('vendor/foo.lock')).toBe(true);              // basename-glob
+    expect(matcher('src/index.ts')).toBe(false);
   });
 });

--- a/tests/canopy/hash.test.ts
+++ b/tests/canopy/hash.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { sha256Hex, estimateTokens } from '@myco/canopy/hash';
+import { sha256Hex } from '@myco/canopy/hash';
 
 describe('sha256Hex', () => {
   it('is deterministic for identical input', () => {
@@ -12,24 +12,6 @@ describe('sha256Hex', () => {
   });
 
   it('returns a 64-char hex string', () => {
-    const h = sha256Hex('anything');
-    expect(h).toMatch(/^[0-9a-f]{64}$/);
-  });
-});
-
-describe('estimateTokens', () => {
-  it('returns 0 for empty input', () => {
-    expect(estimateTokens('')).toBe(0);
-  });
-
-  it('uses a 4-char-per-token heuristic with ceiling', () => {
-    expect(estimateTokens('abcd')).toBe(1);
-    expect(estimateTokens('abcde')).toBe(2);
-    expect(estimateTokens('a'.repeat(400))).toBe(100);
-  });
-
-  it('is stable across re-scans for identical content', () => {
-    const text = 'export function foo() { return 42; }';
-    expect(estimateTokens(text)).toBe(estimateTokens(text));
+    expect(sha256Hex('anything')).toMatch(/^[0-9a-f]{64}$/);
   });
 });

--- a/tests/canopy/hash.test.ts
+++ b/tests/canopy/hash.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'bun:test';
+import { sha256Hex, estimateTokens } from '@myco/canopy/hash';
+
+describe('sha256Hex', () => {
+  it('is deterministic for identical input', () => {
+    expect(sha256Hex('hello')).toBe(sha256Hex('hello'));
+    expect(sha256Hex(Buffer.from('hello'))).toBe(sha256Hex('hello'));
+  });
+
+  it('differs for different content', () => {
+    expect(sha256Hex('hello')).not.toBe(sha256Hex('Hello'));
+  });
+
+  it('returns a 64-char hex string', () => {
+    const h = sha256Hex('anything');
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('estimateTokens', () => {
+  it('returns 0 for empty input', () => {
+    expect(estimateTokens('')).toBe(0);
+  });
+
+  it('uses a 4-char-per-token heuristic with ceiling', () => {
+    expect(estimateTokens('abcd')).toBe(1);
+    expect(estimateTokens('abcde')).toBe(2);
+    expect(estimateTokens('a'.repeat(400))).toBe(100);
+  });
+
+  it('is stable across re-scans for identical content', () => {
+    const text = 'export function foo() { return 42; }';
+    expect(estimateTokens(text)).toBe(estimateTokens(text));
+  });
+});

--- a/tests/config/canopy-schema.test.ts
+++ b/tests/config/canopy-schema.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'bun:test';
+import { MycoConfigSchema } from '@myco/config/schema';
+
+describe('Canopy config defaults', () => {
+  const minimal = { version: 3 };
+
+  it('applies canopy collection defaults', () => {
+    const cfg = MycoConfigSchema.parse(minimal);
+    expect(cfg.canopy.refresh.background_enabled).toBe(true);
+    expect(cfg.canopy.refresh.background_period).toBe('1h');
+    expect(cfg.canopy.exclude.patterns).toContain('node_modules');
+    expect(cfg.canopy.exclude.patterns).toContain('.git');
+    expect(cfg.canopy.exclude.patterns).toContain('**/package-lock.json');
+  });
+
+  it('applies cortex.canopy injection defaults', () => {
+    const cfg = MycoConfigSchema.parse(minimal);
+    expect(cfg.cortex.canopy.injection.enabled).toBe(true);
+    expect(cfg.cortex.canopy.injection.size_threshold).toBe(800);
+  });
+
+  it('applies cortex.canopy LLM defaults — off by default, low tier', () => {
+    const cfg = MycoConfigSchema.parse(minimal);
+    expect(cfg.cortex.canopy.llm.enabled).toBe(false);
+    expect(cfg.cortex.canopy.llm.reasoning_tier).toBe('low');
+    expect(cfg.cortex.canopy.llm.prompt_ref).toBe('canopy-describe');
+    expect(cfg.cortex.canopy.llm.max_description_chars).toBe(180);
+    expect(cfg.cortex.canopy.llm.max_attempts).toBe(2);
+  });
+
+  it('accepts partial overrides and merges with defaults', () => {
+    const cfg = MycoConfigSchema.parse({
+      version: 3,
+      canopy: { refresh: { background_period: '30m' } },
+      cortex: { canopy: { injection: { enabled: false } } },
+    });
+    expect(cfg.canopy.refresh.background_period).toBe('30m');
+    expect(cfg.canopy.refresh.background_enabled).toBe(true); // preserved default
+    expect(cfg.cortex.canopy.injection.enabled).toBe(false);
+    expect(cfg.cortex.canopy.injection.size_threshold).toBe(800); // preserved default
+  });
+
+  it('rejects invalid reasoning_tier', () => {
+    const result = MycoConfigSchema.safeParse({
+      version: 3,
+      cortex: { canopy: { llm: { reasoning_tier: 'extreme' } } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-integer size_threshold', () => {
+    const result = MycoConfigSchema.safeParse({
+      version: 3,
+      cortex: { canopy: { injection: { size_threshold: 1.5 } } },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -47,7 +47,7 @@ describe('Database schema', () => {
 
   describe('constants', () => {
     it('exports SCHEMA_VERSION as a positive integer', () => {
-      expect(SCHEMA_VERSION).toBe(24);
+      expect(SCHEMA_VERSION).toBe(25);
       expect(Number.isInteger(SCHEMA_VERSION)).toBe(true);
     });
 
@@ -1329,16 +1329,16 @@ describe('Database schema', () => {
         expect(() => runMigration(db, 19)).not.toThrow();
       });
 
-      it('full v13 -> v24 chain reaches SCHEMA_VERSION and is replay-safe', () => {
+      it('full v13 -> v25 chain reaches SCHEMA_VERSION and is replay-safe', () => {
         buildV13Db(db);
-        for (const v of [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]) runMigration(db, v);
+        for (const v of [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]) runMigration(db, v);
 
         const row = db.prepare(
           `SELECT MAX(version) AS v FROM schema_version`,
         ).get() as { v: number };
         expect(row.v).toBe(SCHEMA_VERSION);
 
-        for (const v of [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]) {
+        for (const v of [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]) {
           expect(() => runMigration(db, v), `v${v} replay`).not.toThrow();
         }
       });
@@ -1564,6 +1564,121 @@ describe('Database schema', () => {
         expect(tableExists(db, 'agent_run_evaluations')).toBe(false);
         expect(getColumnNames(db, 'agent_runs')).not.toContain('evaluation_id');
         expect(() => runMigration(db, 24)).not.toThrow();
+      });
+    });
+
+    describe('v24 to v25: canopy code-intelligence layer', () => {
+      function runMigration(target: Database, version: number) {
+        const m = MIGRATIONS.find((mm) => mm.version === version);
+        expect(m, `migration v${version} registered`).toBeDefined();
+        m!.migrate(target, 'local');
+      }
+
+      /** Bring the vault to v24-shape: run createSchema, then drop the canopy
+       *  artifacts v25 is responsible for adding, and stamp the version back
+       *  to 24 so the v25 migration step re-runs. */
+      function setupAtV24(target: Database): void {
+        createSchema(target);
+        target.prepare(`DELETE FROM schema_version WHERE version = ?`).run(SCHEMA_VERSION);
+        target.prepare(
+          `INSERT INTO schema_version (version, applied_at)
+           VALUES (24, 1000)
+           ON CONFLICT (version) DO NOTHING`,
+        ).run();
+        target.prepare(`DROP INDEX IF EXISTS idx_canopy_hash`).run();
+        target.prepare(`DROP INDEX IF EXISTS idx_canopy_updated`).run();
+        target.prepare(`DROP TABLE IF EXISTS canopy_entries`).run();
+        for (const col of [
+          'canopy_injections_offered',
+          'canopy_injection_total_tokens',
+          'canopy_skips_after_injection',
+          'canopy_reads_after_injection',
+          'canopy_tokens_saved',
+          'canopy_redundant_reads',
+        ]) {
+          try {
+            target.prepare(`ALTER TABLE sessions DROP COLUMN ${col}`).run();
+          } catch {
+            // Column absent — acceptable.
+          }
+        }
+        try {
+          target.prepare(`ALTER TABLE activities DROP COLUMN canopy_injection_tokens`).run();
+        } catch {
+          // Column absent — acceptable.
+        }
+      }
+
+      it('creates canopy_entries, indexes, and aggregate/tool-call columns', () => {
+        setupAtV24(db);
+        expect(tableExists(db, 'canopy_entries')).toBe(false);
+        expect(getColumnNames(db, 'sessions')).not.toContain('canopy_tokens_saved');
+        expect(getColumnNames(db, 'activities')).not.toContain('canopy_injection_tokens');
+
+        runMigration(db, 25);
+
+        expect(tableExists(db, 'canopy_entries')).toBe(true);
+        const canopyCols = getColumnNames(db, 'canopy_entries');
+        for (const col of [
+          'project_id', 'machine_id', 'path', 'content_hash', 'size_bytes',
+          'token_estimate', 'line_count', 'language', 'exports_json', 'imports_json',
+          'top_comment', 'mechanical_updated_at', 'llm_description', 'llm_updated_at',
+        ]) {
+          expect(canopyCols).toContain(col);
+        }
+
+        expect(indexExists(db, 'idx_canopy_hash')).toBe(true);
+        expect(indexExists(db, 'idx_canopy_updated')).toBe(true);
+
+        const sessionCols = getColumnNames(db, 'sessions');
+        for (const col of [
+          'canopy_injections_offered',
+          'canopy_injection_total_tokens',
+          'canopy_skips_after_injection',
+          'canopy_reads_after_injection',
+          'canopy_tokens_saved',
+          'canopy_redundant_reads',
+        ]) {
+          expect(sessionCols).toContain(col);
+        }
+
+        expect(getColumnNames(db, 'activities')).toContain('canopy_injection_tokens');
+      });
+
+      it('new columns are nullable — rows insert cleanly with NULLs', () => {
+        setupAtV24(db);
+        runMigration(db, 25);
+
+        db.prepare(
+          `INSERT INTO sessions (id, agent, started_at, created_at)
+           VALUES ('ses-null', 'claude-code', 1000, 1000)`,
+        ).run();
+        const row = db.prepare(
+          `SELECT canopy_tokens_saved, canopy_injections_offered FROM sessions WHERE id = 'ses-null'`,
+        ).get() as { canopy_tokens_saved: number | null; canopy_injections_offered: number | null };
+        expect(row.canopy_tokens_saved).toBeNull();
+        expect(row.canopy_injections_offered).toBeNull();
+      });
+
+      it('records schema_version row 25 after migration', () => {
+        setupAtV24(db);
+        runMigration(db, 25);
+        const row = db.prepare(`SELECT version FROM schema_version WHERE version = 25`).get() as
+          | { version: number }
+          | undefined;
+        expect(row?.version).toBe(25);
+      });
+
+      it('is idempotent — running twice does not throw', () => {
+        setupAtV24(db);
+        runMigration(db, 25);
+        expect(() => runMigration(db, 25)).not.toThrow();
+      });
+
+      it('is safe when artifacts already exist (fresh-install v25 replay)', () => {
+        createSchema(db);
+        expect(tableExists(db, 'canopy_entries')).toBe(true);
+        expect(() => runMigration(db, 25)).not.toThrow();
       });
     });
   });

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -1187,6 +1187,13 @@ describe('Database schema', () => {
              started_at INTEGER NOT NULL,
              created_at INTEGER NOT NULL
            )`,
+          `CREATE TABLE activities (
+             id          INTEGER PRIMARY KEY AUTOINCREMENT,
+             session_id  TEXT NOT NULL REFERENCES sessions(id),
+             tool_name   TEXT NOT NULL,
+             timestamp   INTEGER NOT NULL,
+             created_at  INTEGER NOT NULL
+           )`,
           `CREATE TABLE agent_runs (
              id             TEXT PRIMARY KEY,
              agent_id       TEXT NOT NULL,


### PR DESCRIPTION
## Summary

Phase 0 of the Canopy code-intelligence layer — foundation only. Everything below is shared contract that the four Phase 1 tracks (Scanner / Injection / Observability / UI) need to branch off in parallel without conflicting.

**Zero feature behavior changes ship in this PR.** No scanner runs, no PreToolUse injection, no UI rendering — the hook handler is a no-op stub. The only observable change is that the vault schema is now at v25 with new tables/columns ready for Phase 1 to populate.

### What lands

- **Schema v25 migration** (`db/schema-ddl.ts`, `db/migrations.ts`)
  - New `canopy_entries` table — project+path PK, WITHOUT ROWID, mechanical scanner fields + optional `llm_description` override
  - 6 nullable aggregate columns on `sessions` for per-session injection outcomes
  - 1 nullable column on `activities` (`canopy_injection_tokens`) for per-Read injection cost
  - 2 indexes: `(project_id, content_hash)` and `(project_id, mechanical_updated_at)`
  - Backfill-safe: all new columns nullable, fresh-install + chain-replay both tested
- **Shared row types** (`db/schema.ts`, `db/queries/{sessions,activities}.ts`) — `CanopyEntry`, extended `SessionRow`/`ActivityRow`, normalizers updated
- **Scoped Zod settings** (`config/schema.ts`) — `canopy.refresh`, `canopy.exclude`, `cortex.canopy.injection`, `cortex.canopy.llm` with full defaults; LLM disabled by default, low reasoning tier, 180-char description cap
- **Shared utilities** (`canopy/{hash,exclude,types}.ts`) — `sha256Hex` (uses existing `CONTENT_HASH_ALGORITHM` constant), `createExcludeMatcher` (pre-compiles patterns once for scanner reuse), shared parser interfaces, no new runtime deps
- **Hook dispatcher slot** (`cli.ts`, `hooks/pre-tool-use.ts`) — `pre-tool-use` registered as a no-op stub; Track B replaces with the real injection handler

### What does **not** land here (intentional)

- Scanner / parsers / refresh jobs → Phase 1 Track A
- PreToolUse injection handler / blob composer / intent filter → Phase 1 Track B
- Per-turn aggregation SQL / read-side daemon endpoints → Phase 1 Track C
- React tiles / tool-call indicators / settings UI → Phase 1 Track D + Phase 3
- `canopy-describe` LLM task → Phase 3

### Tests

- 5 new migration tests (`tests/db/schema.test.ts`) — fresh-install, idempotency, chain-replay, NULL preservation, version stamp
- 6 new config defaults tests (`tests/config/canopy-schema.test.ts`) — section defaults, partial overrides, validation rejection
- 8 new utility tests (`tests/canopy/{hash,exclude}.test.ts`) — hash determinism, all three pattern shapes, matcher reuse, drift-resistant via live-schema import

Full suite: **3155 pass, 0 fail.** TypeScript + worker lint clean.

### Quality review

`/simplify` review pass merged into the branch (commit `f976adaa`):
- Removed duplicate `estimateTokens` (already in `@myco/constants`)
- Switched to `CONTENT_HASH_ALGORITHM` constant instead of hardcoded `'sha256'`
- Migration now uses the codebase's idiomatic `[name, decl]` tuple pattern (matches v12, v13, v22)
- Extracted `CANOPY_SESSION_COLUMNS` / `CANOPY_ACTIVITY_COLUMN` / `CANOPY_INDEX_DDLS` so DDL, migration, and `SECONDARY_INDEXES` share one source of truth
- Pre-compiled exclude matcher (`createExcludeMatcher`) for Phase 1 scanner hot-path reuse
- Trimmed narrative/diff-pointing comments
- Deleted speculative `canopy/index.ts` barrel (no consumers)

### Smoke test (live vault)

Verified post-restart against a real vault:
- `schema_version = 25`
- `canopy_entries` table with correct shape; insert/select/delete round-trips cleanly
- 144 pre-existing sessions intact, new aggregate columns NULL as expected
- `myco doctor` all green
- `myco hook pre-tool-use` exits 0
- `GET /api/config` returns full `canopy.*` and `cortex.canopy.*` defaults

### Phase 1 unlock

Once this lands on `main`, Phase 1 worktrees can branch:
- `feat/canopy-scanner` (Track A)
- `feat/canopy-injection` (Track B)
- `feat/canopy-observability` (Track C)
- `feat/canopy-ui` (Track D)

File ownership map and integration-conflict resolution rules are documented in `docs/superpowers/plans/2026-04-24-canopy-implementation.md`.

## Test plan

- [x] `npm run test` (fast profile) — 3155 pass / 0 fail
- [x] `npx tsc --noEmit` clean across `packages/myco`
- [x] `npm run check:workers` clean for both team and collective workers
- [x] Migration runs cleanly on a real v24 vault (144 sessions preserved)
- [x] Migration is idempotent on re-run
- [x] `myco doctor` reports all-green post-migration
- [x] `GET /api/config` exposes `canopy.*` + `cortex.canopy.*` with correct defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)