### PR TITLE
feat(canopy): Phase 1 Track C — observability & aggregation

### DIFF
--- a/packages/myco/src/canopy/aggregate.ts
+++ b/packages/myco/src/canopy/aggregate.ts
@@ -1,0 +1,64 @@
+/**
+ * Per-turn Canopy aggregation entry point.
+ *
+ * Run at each Stop boundary: aggregate the persisted activity rows for the
+ * session into a row-level summary on the `sessions` table. The capture
+ * buffer remains authoritative for raw events; this is a derived view.
+ *
+ * Designed for fire-and-forget invocation — the function never throws on
+ * read paths, returning `null` instead so the caller (typically the daemon
+ * Stop processor) doesn't take the whole stop pipeline down on a corrupt
+ * row or a transient SQLite error.
+ */
+
+import type { Database } from 'bun:sqlite';
+import { getDatabase } from '@myco/db/client.js';
+import { aggregateSessionCanopy, type CanopySessionAggregate } from '@myco/db/queries/canopy.js';
+
+/**
+ * Compute the per-session Canopy aggregate and UPDATE it onto the
+ * sessions row. Returns the aggregate it wrote (handy for logging /
+ * tests), or `null` if the underlying query failed.
+ *
+ * Column order in the UPDATE matches `CANOPY_SESSION_COLUMNS` in
+ * schema-ddl.ts. If those names change, the queries module's startup
+ * guard fires first.
+ */
+export function materializeCanopyAggregates(
+  sessionId: string,
+  db?: Database | null,
+): CanopySessionAggregate | null {
+  const handle = db ?? getDatabase();
+  let agg: CanopySessionAggregate;
+  try {
+    agg = aggregateSessionCanopy(handle, sessionId);
+  } catch {
+    // Read failure shouldn't block the Stop pipeline. Caller logs.
+    return null;
+  }
+
+  try {
+    handle.prepare(`
+      UPDATE sessions SET
+        canopy_injections_offered     = ?,
+        canopy_injection_total_tokens = ?,
+        canopy_skips_after_injection  = ?,
+        canopy_reads_after_injection  = ?,
+        canopy_tokens_saved           = ?,
+        canopy_redundant_reads        = ?
+      WHERE id = ?
+    `).run(
+      agg.injections_offered,
+      agg.injection_total_tokens,
+      agg.skips_after_injection,
+      agg.reads_after_injection,
+      agg.tokens_saved,
+      agg.redundant_reads,
+      sessionId,
+    );
+  } catch {
+    return null;
+  }
+
+  return agg;
+}

--- a/packages/myco/src/daemon/api/canopy-read.ts
+++ b/packages/myco/src/daemon/api/canopy-read.ts
@@ -1,0 +1,210 @@
+/**
+ * Read-side daemon HTTP endpoints for the Canopy UI.
+ *
+ * Three endpoints:
+ *   GET /api/sessions/:id/canopy
+ *     → per-session aggregate from the sessions row + the per-Read tool-call
+ *       list with canopy_injection_tokens.
+ *
+ *   GET /api/sessions/:id/canopy/tool-calls/:tcId/blob
+ *     → replays the injection blob the agent saw at PreToolUse time.
+ *       Regenerates by looking up the canopy_entries row for the activity's
+ *       file_path. Stable as long as the file's mechanical anatomy hasn't
+ *       changed since the call ran. Returns the raw blob string under
+ *       `blob`; UI renders verbatim for full transparency.
+ *
+ *   GET /api/canopy/rollup?since=&until=
+ *     → cross-session aggregate: total tokens saved, average per session,
+ *       skip ratio. Optional epoch-seconds time bounds.
+ *
+ * The blob endpoint depends on Track B's compose helper. Because Track B
+ * lands in parallel, the import is dynamic and tolerated as missing — the
+ * endpoint surfaces a clear `compose_unavailable` reason instead of 500'ing
+ * when the helper isn't on main yet. Once Track B merges the import
+ * resolves naturally and the fallback path goes cold.
+ */
+
+import type { RouteHandler, RouteResponse } from '../router.js';
+import { getSession } from '@myco/db/queries/sessions.js';
+import {
+  listCanopyReads,
+  getCanopyToolCallContext,
+  rollupCanopy,
+} from '@myco/db/queries/canopy.js';
+import type { CanopyEntry } from '@myco/db/schema.js';
+import { getDatabase } from '@myco/db/client.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function notFound(reason: string): RouteResponse {
+  return { status: 404, body: { error: 'not_found', reason } };
+}
+
+function badRequest(reason: string): RouteResponse {
+  return { status: 400, body: { error: 'bad_request', reason } };
+}
+
+function parseEpochSeconds(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function findCanopyEntry(projectId: string, path: string): CanopyEntry | null {
+  const row = getDatabase()
+    .prepare('SELECT * FROM canopy_entries WHERE project_id = ? AND path = ?')
+    .get(projectId, path) as CanopyEntry | undefined;
+  return row ?? null;
+}
+
+/**
+ * Try to load Track B's composeBlob helper. Returns null when the module
+ * is unavailable (Track B not merged yet) so callers can degrade
+ * gracefully instead of throwing. Cached after first lookup.
+ */
+let composeBlobLoader: Promise<((entry: CanopyEntry) => string) | null> | null = null;
+
+function loadComposeBlob(): Promise<((entry: CanopyEntry) => string) | null> {
+  if (composeBlobLoader) return composeBlobLoader;
+  composeBlobLoader = (async () => {
+    try {
+      const mod = (await import('@myco/canopy/inject/compose.js' as string)) as {
+        composeBlob?: (entry: CanopyEntry) => string;
+      };
+      return typeof mod.composeBlob === 'function' ? mod.composeBlob : null;
+    } catch {
+      return null;
+    }
+  })();
+  return composeBlobLoader;
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+export const handleGetSessionCanopy: RouteHandler = async (req) => {
+  const sessionId = req.params.id;
+  if (!sessionId) return badRequest('missing_session_id');
+
+  const session = getSession(sessionId);
+  if (!session) return notFound('session');
+
+  const reads = listCanopyReads(null, sessionId);
+
+  // Pull aggregates from the row directly (materialized at last Stop). For
+  // pre-feature sessions every column is NULL — the UI hides the tile in
+  // that case (see Track D Task D.1).
+  const aggregate = {
+    injections_offered: session.canopy_injections_offered,
+    injection_total_tokens: session.canopy_injection_total_tokens,
+    skips_after_injection: session.canopy_skips_after_injection,
+    reads_after_injection: session.canopy_reads_after_injection,
+    tokens_saved: session.canopy_tokens_saved,
+    redundant_reads: session.canopy_redundant_reads,
+  };
+
+  return {
+    body: {
+      session_id: sessionId,
+      aggregate,
+      reads,
+    },
+  };
+};
+
+export const handleGetCanopyToolCallBlob: RouteHandler = async (req) => {
+  const sessionId = req.params.id;
+  const tcIdRaw = req.params.tcId;
+  if (!sessionId || !tcIdRaw) return badRequest('missing_param');
+  const tcId = Number(tcIdRaw);
+  if (!Number.isFinite(tcId)) return badRequest('invalid_tc_id');
+
+  const ctx = getCanopyToolCallContext(null, sessionId, tcId);
+  if (!ctx) return notFound('tool_call');
+
+  if (!ctx.project_id) {
+    return {
+      body: {
+        session_id: sessionId,
+        activity_id: ctx.activity_id,
+        file_path: ctx.file_path,
+        injection_tokens: ctx.injection_tokens,
+        blob: null,
+        reason: 'no_project_root',
+      },
+    };
+  }
+
+  const entry = findCanopyEntry(ctx.project_id, ctx.file_path);
+  if (!entry) {
+    return {
+      body: {
+        session_id: sessionId,
+        activity_id: ctx.activity_id,
+        file_path: ctx.file_path,
+        injection_tokens: ctx.injection_tokens,
+        blob: null,
+        reason: 'entry_missing',
+      },
+    };
+  }
+
+  const composeBlob = await loadComposeBlob();
+  if (!composeBlob) {
+    return {
+      body: {
+        session_id: sessionId,
+        activity_id: ctx.activity_id,
+        file_path: ctx.file_path,
+        injection_tokens: ctx.injection_tokens,
+        blob: null,
+        reason: 'compose_unavailable',
+      },
+    };
+  }
+
+  return {
+    body: {
+      session_id: sessionId,
+      activity_id: ctx.activity_id,
+      file_path: ctx.file_path,
+      injection_tokens: ctx.injection_tokens,
+      blob: composeBlob(entry),
+      reason: null,
+    },
+  };
+};
+
+export const handleGetCanopyRollup: RouteHandler = async (req) => {
+  const since = parseEpochSeconds(req.query.since);
+  const until = parseEpochSeconds(req.query.until);
+
+  const rollup = rollupCanopy(null, { since, until });
+  return { body: rollup };
+};
+
+// ---------------------------------------------------------------------------
+// Wire-in helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Register the read-side Canopy routes on a Router-like server. Mirrors
+ * the pattern used by other daemon/api/*.ts wirings.
+ *
+ * Track B's canopy-inject endpoints register separately via their own
+ * file; the two registrations are non-overlapping so order doesn't matter.
+ */
+export function registerCanopyReadRoutes(server: {
+  registerRoute(method: string, pattern: string, handler: RouteHandler): void;
+}): void {
+  server.registerRoute('GET', '/api/sessions/:id/canopy', handleGetSessionCanopy);
+  server.registerRoute(
+    'GET',
+    '/api/sessions/:id/canopy/tool-calls/:tcId/blob',
+    handleGetCanopyToolCallBlob,
+  );
+  server.registerRoute('GET', '/api/canopy/rollup', handleGetCanopyRollup);
+}

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -75,6 +75,7 @@ import { createSessionContextHandler, createPromptContextHandler, createResumeCo
 import { createCortexHandlers } from './api/cortex.js';
 import { handleGetFeed } from './api/feed.js';
 import { handleListSymbionts } from './api/symbionts.js';
+import { registerCanopyReadRoutes } from './api/canopy-read.js';
 import {
   handleGetEmbeddingStatus,
   handleEmbeddingDetails,
@@ -827,6 +828,9 @@ export async function main(): Promise<void> {
   server.registerRoute('GET', '/api/batches/:id/activities', handleGetBatchActivities);
   server.registerRoute('GET', '/api/sessions/:id/attachments', handleGetSessionAttachments);
   server.registerRoute('GET', '/api/sessions/:id/plans', handleGetSessionPlans);
+
+  // --- Canopy read-side API routes (Track C of Phase 1) ---
+  registerCanopyReadRoutes(server);
 
   // --- Skill lifecycle API routes ---
   server.registerRoute('GET', '/api/skill-candidates', handleListCandidates);

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -45,6 +45,7 @@ import type { RouteHandler } from './router.js';
 import type { RegisteredSession } from './lifecycle.js';
 import { cleanupAfterSessionCascade } from './jobs/session-cleanup.js';
 import type { PlanWatchConfig } from './plan-capture.js';
+import { materializeCanopyAggregates } from '@myco/canopy/aggregate.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -527,6 +528,12 @@ export function createStopProcessor(deps: StopProcessorDeps): {
       source: turnSource,
       title: existingSession?.title ?? sessionTitleCache.get(sessionId) ?? '(untitled)',
     });
+
+    // Materialize Canopy aggregates onto the sessions row. Pure SQL over
+    // already-persisted activities — safe to run after every Stop. Internal
+    // failure is swallowed by materializeCanopyAggregates so it never blocks
+    // the rest of the Stop pipeline.
+    materializeCanopyAggregates(sessionId);
   }
 
   const handleStopRoute: RouteHandler = async (req) => {

--- a/packages/myco/src/db/queries/canopy.ts
+++ b/packages/myco/src/db/queries/canopy.ts
@@ -1,0 +1,374 @@
+/**
+ * Canopy aggregation queries.
+ *
+ * Computes per-session injection outcomes from the persisted `activities`
+ * (tool-call) rows. Run at each Stop boundary; the result is materialized
+ * onto the `sessions` row by `materializeCanopyAggregates`.
+ *
+ * The aggregation is a pure SQL self-join — no in-memory state, no
+ * correlator. The capture buffer remains authoritative for raw events.
+ */
+
+import type { Database } from 'bun:sqlite';
+import { getDatabase } from '@myco/db/client.js';
+import { CANOPY_SESSION_COLUMNS, CANOPY_ACTIVITY_COLUMN } from '@myco/db/schema-ddl.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Session-level Canopy aggregate computed by `aggregateSessionCanopy`. Field
+ * order mirrors `CANOPY_SESSION_COLUMNS` so the UPDATE in
+ * `materializeCanopyAggregates` reads cleanly.
+ */
+export interface CanopySessionAggregate {
+  /** Number of Read tool-calls where Canopy offered an injection. */
+  injections_offered: number;
+  /** Sum of injection token costs across all offered injections. */
+  injection_total_tokens: number;
+  /** Injections followed by no later Read of the same path within this session. */
+  skips_after_injection: number;
+  /** Injections where the agent went on to Read the same path anyway (full file). */
+  reads_after_injection: number;
+  /**
+   * Net tokens saved =
+   *   Σ(file_tokens − injection_tokens)        over skips
+   * − Σ(injection_tokens)                       over reads-after-injection.
+   *
+   * `file_tokens` is sourced from `canopy_entries.token_estimate` joined on
+   * (project_id, path). When an injection's path is missing from
+   * `canopy_entries` (deleted, race), the contribution is 0 — conservative.
+   */
+  tokens_saved: number;
+  /** Count of (session, path) pairs read more than once in the session. */
+  redundant_reads: number;
+}
+
+// ---------------------------------------------------------------------------
+// Column-name guards
+// ---------------------------------------------------------------------------
+
+// The aggregation SQL hardcodes column names. Cross-check against the
+// schema-ddl exports so a column rename triggers a compile error here, not a
+// silent NULL aggregate at runtime.
+const CANOPY_ACTIVITY_TOKEN_COLUMN = CANOPY_ACTIVITY_COLUMN[0];
+const CANOPY_SESSION_COLUMN_NAMES = CANOPY_SESSION_COLUMNS.map(([name]) => name);
+
+const EXPECTED_SESSION_COLUMNS = [
+  'canopy_injections_offered',
+  'canopy_injection_total_tokens',
+  'canopy_skips_after_injection',
+  'canopy_reads_after_injection',
+  'canopy_tokens_saved',
+  'canopy_redundant_reads',
+] as const;
+
+if (CANOPY_ACTIVITY_TOKEN_COLUMN !== 'canopy_injection_tokens') {
+  throw new Error(
+    `Canopy aggregation expects canopy_injection_tokens; schema-ddl exports ${CANOPY_ACTIVITY_TOKEN_COLUMN}`,
+  );
+}
+
+for (const name of EXPECTED_SESSION_COLUMNS) {
+  if (!CANOPY_SESSION_COLUMN_NAMES.includes(name)) {
+    throw new Error(`Canopy aggregation expects sessions.${name}; not present in schema-ddl`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SQL
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregation SQL.
+ *
+ * `reads`            — every Read tool-call for the session, with the path
+ *                      resolved from JSON tool_input.
+ * `skip_resolution`  — for each Read with an injection, decide whether a
+ *                      *later* Read of the same path also exists in this
+ *                      session. If not, it's a skip.
+ *
+ * `LEFT JOIN canopy_entries` brings in the file's token estimate so the
+ * tokens-saved arithmetic can run without a second round-trip. Joining on
+ * `(project_id, path)` requires the project_id; we resolve it from the
+ * sessions row's project_root since canopy_entries keys on project_id but
+ * the sessions table tracks project_root. The join falls back to NULL when
+ * there's no match (file not yet scanned, or excluded).
+ *
+ * The reads_after_injection branch *spends* injection tokens (negative
+ * savings) since we paid the injection cost and then read the file anyway.
+ * Skips *save* (file_tokens − injection_tokens).
+ */
+const AGGREGATE_SQL = `
+WITH session_root AS (
+  SELECT project_root AS project_id
+  FROM sessions
+  WHERE id = ?
+),
+reads AS (
+  SELECT
+    a.id                       AS tc_id,
+    json_extract(a.tool_input, '$.file_path') AS path,
+    a.canopy_injection_tokens  AS injection_tokens,
+    CASE WHEN a.canopy_injection_tokens IS NOT NULL THEN 1 ELSE 0 END AS had_injection,
+    a.timestamp                AS ts
+  FROM activities a
+  WHERE a.session_id = ?
+    AND a.tool_name = 'Read'
+),
+skip_resolution AS (
+  SELECT
+    r.tc_id,
+    r.path,
+    r.injection_tokens,
+    r.had_injection,
+    CASE
+      WHEN r.had_injection = 1
+       AND NOT EXISTS (
+         SELECT 1 FROM activities a2
+         WHERE a2.session_id = ?
+           AND a2.tool_name = 'Read'
+           AND a2.id != r.tc_id
+           AND a2.timestamp >= r.ts
+           AND json_extract(a2.tool_input, '$.file_path') = r.path
+       )
+      THEN 1 ELSE 0
+    END AS skipped
+  FROM reads r
+),
+tokens AS (
+  SELECT
+    sr.tc_id,
+    sr.path,
+    sr.injection_tokens,
+    sr.had_injection,
+    sr.skipped,
+    ce.token_estimate AS file_tokens
+  FROM skip_resolution sr
+  LEFT JOIN canopy_entries ce
+    ON ce.project_id = (SELECT project_id FROM session_root)
+   AND ce.path = sr.path
+),
+redundant AS (
+  SELECT COUNT(*) AS redundant_reads
+  FROM (
+    SELECT path
+    FROM reads
+    WHERE path IS NOT NULL
+    GROUP BY path
+    HAVING COUNT(*) > 1
+  )
+)
+SELECT
+  COALESCE(SUM(t.had_injection), 0)                                              AS injections_offered,
+  COALESCE(SUM(CASE WHEN t.had_injection = 1 THEN t.injection_tokens END), 0)    AS injection_total_tokens,
+  COALESCE(SUM(CASE WHEN t.skipped = 1 THEN 1 ELSE 0 END), 0)                    AS skips_after_injection,
+  COALESCE(SUM(CASE WHEN t.had_injection = 1 AND t.skipped = 0 THEN 1 ELSE 0 END), 0) AS reads_after_injection,
+  COALESCE(
+    SUM(
+      CASE
+        WHEN t.skipped = 1
+          THEN COALESCE(t.file_tokens, 0) - COALESCE(t.injection_tokens, 0)
+        WHEN t.had_injection = 1 AND t.skipped = 0
+          THEN -COALESCE(t.injection_tokens, 0)
+        ELSE 0
+      END
+    ),
+    0
+  )                                                                              AS tokens_saved,
+  (SELECT redundant_reads FROM redundant)                                         AS redundant_reads
+FROM tokens t
+`;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the per-session Canopy aggregate from persisted activity rows.
+ *
+ * Pure SQL — no in-memory state, no correlator. Safe to call repeatedly
+ * (e.g. once per Stop boundary): later calls overwrite earlier results.
+ *
+ * @param db - Optional Database handle. Defaults to the process-wide
+ *             `getDatabase()` (matches the rest of the queries module).
+ *             Pass an explicit handle for tests or when a non-default DB
+ *             is in use.
+ * @param sessionId - Session whose aggregates to compute.
+ */
+export function aggregateSessionCanopy(
+  db: Database | null,
+  sessionId: string,
+): CanopySessionAggregate {
+  const handle = db ?? getDatabase();
+  const row = handle.prepare(AGGREGATE_SQL).get(sessionId, sessionId, sessionId) as
+    | {
+        injections_offered: number | null;
+        injection_total_tokens: number | null;
+        skips_after_injection: number | null;
+        reads_after_injection: number | null;
+        tokens_saved: number | null;
+        redundant_reads: number | null;
+      }
+    | undefined;
+
+  return {
+    injections_offered: Number(row?.injections_offered ?? 0),
+    injection_total_tokens: Number(row?.injection_total_tokens ?? 0),
+    skips_after_injection: Number(row?.skips_after_injection ?? 0),
+    reads_after_injection: Number(row?.reads_after_injection ?? 0),
+    tokens_saved: Number(row?.tokens_saved ?? 0),
+    redundant_reads: Number(row?.redundant_reads ?? 0),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cross-session rollup
+// ---------------------------------------------------------------------------
+
+export interface CanopyRollup {
+  sessions_with_data: number;
+  total_tokens_saved: number;
+  avg_tokens_saved_per_session: number;
+  total_injections_offered: number;
+  total_skips_after_injection: number;
+  /** skips / injections, or 0 when no injections offered. */
+  skip_ratio: number;
+}
+
+export interface CanopyRollupOptions {
+  /** Inclusive lower bound on session.started_at (epoch seconds). */
+  since?: number;
+  /** Inclusive upper bound on session.started_at (epoch seconds). */
+  until?: number;
+}
+
+/**
+ * Cross-session Canopy rollup for the all-sessions UI surface. Only sessions
+ * with non-NULL `canopy_injections_offered` contribute (pre-feature sessions
+ * and disabled-injection sessions are excluded).
+ */
+export function rollupCanopy(
+  db: Database | null,
+  opts: CanopyRollupOptions = {},
+): CanopyRollup {
+  const handle = db ?? getDatabase();
+  const clauses: string[] = ['canopy_injections_offered IS NOT NULL'];
+  const params: number[] = [];
+  if (opts.since !== undefined) {
+    clauses.push('started_at >= ?');
+    params.push(opts.since);
+  }
+  if (opts.until !== undefined) {
+    clauses.push('started_at <= ?');
+    params.push(opts.until);
+  }
+
+  const sql = `
+    SELECT
+      COUNT(*)                                          AS sessions_with_data,
+      COALESCE(SUM(canopy_tokens_saved), 0)             AS total_tokens_saved,
+      COALESCE(SUM(canopy_injections_offered), 0)       AS total_injections_offered,
+      COALESCE(SUM(canopy_skips_after_injection), 0)    AS total_skips_after_injection
+    FROM sessions
+    WHERE ${clauses.join(' AND ')}
+  `;
+  const row = handle.prepare(sql).get(...params) as {
+    sessions_with_data: number | null;
+    total_tokens_saved: number | null;
+    total_injections_offered: number | null;
+    total_skips_after_injection: number | null;
+  } | undefined;
+
+  const sessions = Number(row?.sessions_with_data ?? 0);
+  const tokens = Number(row?.total_tokens_saved ?? 0);
+  const injections = Number(row?.total_injections_offered ?? 0);
+  const skips = Number(row?.total_skips_after_injection ?? 0);
+
+  return {
+    sessions_with_data: sessions,
+    total_tokens_saved: tokens,
+    avg_tokens_saved_per_session: sessions > 0 ? tokens / sessions : 0,
+    total_injections_offered: injections,
+    total_skips_after_injection: skips,
+    skip_ratio: injections > 0 ? skips / injections : 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-session Read activities (with canopy column) for the UI
+// ---------------------------------------------------------------------------
+
+export interface CanopyReadRow {
+  id: number;
+  timestamp: number;
+  file_path: string | null;
+  canopy_injection_tokens: number | null;
+}
+
+/**
+ * Read tool-calls for a session, ordered by timestamp. Used by the
+ * `/sessions/:id/canopy` endpoint to render per-tool-call indicators.
+ */
+export function listCanopyReads(db: Database | null, sessionId: string): CanopyReadRow[] {
+  const handle = db ?? getDatabase();
+  return handle
+    .prepare(
+      `
+        SELECT
+          id,
+          timestamp,
+          json_extract(tool_input, '$.file_path') AS file_path,
+          canopy_injection_tokens
+        FROM activities
+        WHERE session_id = ?
+          AND tool_name = 'Read'
+        ORDER BY timestamp ASC, id ASC
+      `,
+    )
+    .all(sessionId) as CanopyReadRow[];
+}
+
+/**
+ * Look up the canopy_entries row that backs a specific tool-call's path, so
+ * the read endpoint can replay the injection blob. Returns null if the
+ * tool-call doesn't exist, isn't a Read, has no file_path in tool_input, or
+ * the canopy_entries row is missing (deleted/excluded since the call ran).
+ */
+export interface CanopyToolCallContext {
+  activity_id: number;
+  session_id: string;
+  file_path: string;
+  injection_tokens: number | null;
+  /** project_id used to look up canopy_entries — sessions.project_root. */
+  project_id: string | null;
+}
+
+export function getCanopyToolCallContext(
+  db: Database | null,
+  sessionId: string,
+  activityId: number,
+): CanopyToolCallContext | null {
+  const handle = db ?? getDatabase();
+  const row = handle
+    .prepare(
+      `
+        SELECT
+          a.id                                       AS activity_id,
+          a.session_id                               AS session_id,
+          json_extract(a.tool_input, '$.file_path')  AS file_path,
+          a.canopy_injection_tokens                  AS injection_tokens,
+          s.project_root                             AS project_id
+        FROM activities a
+        LEFT JOIN sessions s ON s.id = a.session_id
+        WHERE a.id = ?
+          AND a.session_id = ?
+          AND a.tool_name = 'Read'
+      `,
+    )
+    .get(activityId, sessionId) as CanopyToolCallContext | undefined;
+
+  if (!row || !row.file_path) return null;
+  return row;
+}

--- a/tests/canopy/aggregate/aggregate-session.test.ts
+++ b/tests/canopy/aggregate/aggregate-session.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Tests for the per-session Canopy aggregation SQL.
+ *
+ * Each scenario seeds an in-memory SQLite vault with:
+ *   - a sessions row with project_root pointing at a fixture project_id
+ *   - activities rows representing Read tool-calls (with/without injection)
+ *   - canopy_entries rows providing the file_tokens for the LEFT JOIN
+ *
+ * Then asserts the aggregate matches hand-computed values.
+ *
+ * Coverage matrix (per plan Task C.1):
+ *   - all-skip
+ *   - all-read (read-anyway)
+ *   - mixed (skip + read-anyway)
+ *   - no-injection (pre-feature / disabled)
+ *   - redundant reads (same path read >1 time)
+ *   - tool-calls of other types are ignored
+ *   - missing canopy_entries row is conservative (file_tokens=0)
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'bun:test';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
+import { getDatabase } from '@myco/db/client.js';
+import { upsertSession } from '@myco/db/queries/sessions.js';
+import { aggregateSessionCanopy, rollupCanopy } from '@myco/db/queries/canopy.js';
+
+const PROJECT_ID = '/repo/myco';
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+interface SeedActivity {
+  /** Tool name; defaults to 'Read'. */
+  tool_name?: string;
+  file_path: string | null;
+  injection_tokens?: number | null;
+  /** Relative timestamp offset (seconds); seed ordering matches insertion order. */
+  ts?: number;
+}
+
+interface SeedCanopyEntry {
+  path: string;
+  token_estimate: number;
+}
+
+function seedSession(sessionId: string) {
+  const now = epochNow();
+  upsertSession({
+    id: sessionId,
+    agent: 'claude-code',
+    started_at: now,
+    created_at: now,
+    project_root: PROJECT_ID,
+  });
+}
+
+function seedActivities(sessionId: string, activities: SeedActivity[]) {
+  const db = getDatabase();
+  const base = epochNow();
+  const insert = db.prepare(`
+    INSERT INTO activities (
+      session_id, tool_name, tool_input, file_path,
+      timestamp, processed, created_at, canopy_injection_tokens
+    ) VALUES (?, ?, ?, ?, ?, 0, ?, ?)
+  `);
+  activities.forEach((a, i) => {
+    const path = a.file_path;
+    const toolInput = path === null ? null : JSON.stringify({ file_path: path });
+    insert.run(
+      sessionId,
+      a.tool_name ?? 'Read',
+      toolInput,
+      path,
+      base + (a.ts ?? i),
+      base + (a.ts ?? i),
+      a.injection_tokens ?? null,
+    );
+  });
+}
+
+function seedCanopyEntries(entries: SeedCanopyEntry[]) {
+  const db = getDatabase();
+  const insert = db.prepare(`
+    INSERT INTO canopy_entries (
+      project_id, machine_id, path, content_hash, size_bytes, token_estimate,
+      line_count, language, exports_json, imports_json, top_comment,
+      mechanical_updated_at, llm_description, llm_updated_at
+    ) VALUES (?, 'local', ?, 'hash', 0, ?, 0, 'typescript', NULL, NULL, NULL, ?, NULL, NULL)
+  `);
+  const now = epochNow();
+  for (const e of entries) {
+    insert.run(PROJECT_ID, e.path, e.token_estimate, now);
+  }
+}
+
+describe('aggregateSessionCanopy', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    // canopy_entries isn't in the shared cleanup list — wipe manually.
+    getDatabase().prepare('DELETE FROM canopy_entries').run();
+  });
+
+  it('returns zeros for a session with no Read activities', () => {
+    const sessionId = 'sess-empty';
+    seedSession(sessionId);
+
+    const agg = aggregateSessionCanopy(null, sessionId);
+
+    expect(agg).toEqual({
+      injections_offered: 0,
+      injection_total_tokens: 0,
+      skips_after_injection: 0,
+      reads_after_injection: 0,
+      tokens_saved: 0,
+      redundant_reads: 0,
+    });
+  });
+
+  it('counts only Read activities', () => {
+    const sessionId = 'sess-non-read';
+    seedSession(sessionId);
+    seedCanopyEntries([{ path: 'a.ts', token_estimate: 1000 }]);
+    seedActivities(sessionId, [
+      { tool_name: 'Edit', file_path: 'a.ts', injection_tokens: 80 },
+      { tool_name: 'Bash', file_path: null, injection_tokens: null },
+    ]);
+
+    const agg = aggregateSessionCanopy(null, sessionId);
+
+    expect(agg.injections_offered).toBe(0);
+    expect(agg.injection_total_tokens).toBe(0);
+    expect(agg.tokens_saved).toBe(0);
+  });
+
+  it('all-skip: every injection saves (file_tokens - injection_tokens)', () => {
+    const sessionId = 'sess-all-skip';
+    seedSession(sessionId);
+    seedCanopyEntries([
+      { path: 'a.ts', token_estimate: 1000 },
+      { path: 'b.ts', token_estimate: 2000 },
+    ]);
+    seedActivities(sessionId, [
+      { file_path: 'a.ts', injection_tokens: 80 },
+      { file_path: 'b.ts', injection_tokens: 90 },
+    ]);
+
+    const agg = aggregateSessionCanopy(null, sessionId);
+
+    expect(agg.injections_offered).toBe(2);
+    expect(agg.injection_total_tokens).toBe(170);
+    expect(agg.skips_after_injection).toBe(2);
+    expect(agg.reads_after_injection).toBe(0);
+    // (1000-80) + (2000-90) = 2830
+    expect(agg.tokens_saved).toBe(2830);
+    expect(agg.redundant_reads).toBe(0);
+  });
+
+  it('all-read (read-anyway): every injection costs injection_tokens', () => {
+    const sessionId = 'sess-all-read';
+    seedSession(sessionId);
+    seedCanopyEntries([{ path: 'a.ts', token_estimate: 1000 }]);
+    // First Read carries the injection; the second is the agent reading anyway.
+    seedActivities(sessionId, [
+      { file_path: 'a.ts', injection_tokens: 80, ts: 1 },
+      { file_path: 'a.ts', injection_tokens: null, ts: 2 },
+    ]);
+
+    const agg = aggregateSessionCanopy(null, sessionId);
+
+    expect(agg.injections_offered).toBe(1);
+    expect(agg.injection_total_tokens).toBe(80);
+    expect(agg.skips_after_injection).toBe(0);
+    expect(agg.reads_after_injection).toBe(1);
+    expect(agg.tokens_saved).toBe(-80);
+    // Same path read twice → 1 redundant pair.
+    expect(agg.redundant_reads).toBe(1);
+  });
+
+  it('mixed: skip on one path, read-anyway on another', () => {
+    const sessionId = 'sess-mixed';
+    seedSession(sessionId);
+    seedCanopyEntries([
+      { path: 'skipped.ts', token_estimate: 1500 },
+      { path: 'read.ts', token_estimate: 2000 },
+    ]);
+    seedActivities(sessionId, [
+      { file_path: 'skipped.ts', injection_tokens: 100, ts: 1 },
+      { file_path: 'read.ts',    injection_tokens: 90,  ts: 2 },
+      { file_path: 'read.ts',    injection_tokens: null, ts: 3 },
+    ]);
+
+    const agg = aggregateSessionCanopy(null, sessionId);
+
+    expect(agg.injections_offered).toBe(2);
+    expect(agg.injection_total_tokens).toBe(190);
+    expect(agg.skips_after_injection).toBe(1);
+    expect(agg.reads_after_injection).toBe(1);
+    // Skip: (1500 - 100) = 1400. Read-anyway: -90. Net = 1310.
+    expect(agg.tokens_saved).toBe(1310);
+    // 'read.ts' appears twice → 1 redundant pair; 'skipped.ts' only once.
+    expect(agg.redundant_reads).toBe(1);
+  });
+
+  it('no-injection: pre-feature or disabled session → all aggregates are zero', () => {
+    const sessionId = 'sess-no-inject';
+    seedSession(sessionId);
+    seedCanopyEntries([{ path: 'a.ts', token_estimate: 1000 }]);
+    seedActivities(sessionId, [
+      { file_path: 'a.ts', injection_tokens: null },
+      { file_path: 'b.ts', injection_tokens: null },
+    ]);
+
+    const agg = aggregateSessionCanopy(null, sessionId);
+
+    expect(agg.injections_offered).toBe(0);
+    expect(agg.injection_total_tokens).toBe(0);
+    expect(agg.skips_after_injection).toBe(0);
+    expect(agg.reads_after_injection).toBe(0);
+    expect(agg.tokens_saved).toBe(0);
+    expect(agg.redundant_reads).toBe(0);
+  });
+
+  it('counts redundant reads independently of injection state', () => {
+    const sessionId = 'sess-redundant';
+    seedSession(sessionId);
+    seedActivities(sessionId, [
+      { file_path: 'a.ts', injection_tokens: null, ts: 1 },
+      { file_path: 'a.ts', injection_tokens: null, ts: 2 },
+      { file_path: 'a.ts', injection_tokens: null, ts: 3 },
+      { file_path: 'b.ts', injection_tokens: null, ts: 4 },
+    ]);
+
+    const agg = aggregateSessionCanopy(null, sessionId);
+
+    // 'a.ts' appears 3 times → 1 redundant *pair* (group counted once).
+    // 'b.ts' once → not redundant. The metric is "files read more than once."
+    expect(agg.redundant_reads).toBe(1);
+  });
+
+  it('falls back to 0 file_tokens when canopy_entries row is missing', () => {
+    const sessionId = 'sess-missing-entry';
+    seedSession(sessionId);
+    // No canopy_entries seeded.
+    seedActivities(sessionId, [
+      { file_path: 'unknown.ts', injection_tokens: 50 },
+    ]);
+
+    const agg = aggregateSessionCanopy(null, sessionId);
+
+    expect(agg.injections_offered).toBe(1);
+    // Skip credit = (file_tokens 0) - (injection 50) = -50; conservative.
+    expect(agg.skips_after_injection).toBe(1);
+    expect(agg.tokens_saved).toBe(-50);
+  });
+
+  it('does not count later Reads of a different path as the same-path Read', () => {
+    const sessionId = 'sess-different-paths';
+    seedSession(sessionId);
+    seedCanopyEntries([{ path: 'a.ts', token_estimate: 1000 }]);
+    seedActivities(sessionId, [
+      { file_path: 'a.ts', injection_tokens: 80, ts: 1 },
+      { file_path: 'b.ts', injection_tokens: null, ts: 2 },
+    ]);
+
+    const agg = aggregateSessionCanopy(null, sessionId);
+    // a.ts's injection counts as a skip (no later Read of a.ts).
+    expect(agg.skips_after_injection).toBe(1);
+    expect(agg.reads_after_injection).toBe(0);
+    expect(agg.tokens_saved).toBe(920); // 1000 - 80
+  });
+});
+
+describe('rollupCanopy', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    getDatabase().prepare('DELETE FROM canopy_entries').run();
+  });
+
+  it('returns zero rollup with no sessions', () => {
+    const r = rollupCanopy(null);
+    expect(r.sessions_with_data).toBe(0);
+    expect(r.total_tokens_saved).toBe(0);
+    expect(r.avg_tokens_saved_per_session).toBe(0);
+    expect(r.skip_ratio).toBe(0);
+  });
+
+  it('aggregates only sessions with canopy_injections_offered IS NOT NULL', () => {
+    const db = getDatabase();
+    const now = epochNow();
+    upsertSession({ id: 's1', agent: 'claude-code', started_at: now, created_at: now });
+    upsertSession({ id: 's2', agent: 'claude-code', started_at: now, created_at: now });
+    upsertSession({ id: 's3', agent: 'claude-code', started_at: now, created_at: now });
+    // s1 — pre-feature, all NULL (excluded)
+    // s2 — feature on, with data
+    db.prepare(`
+      UPDATE sessions SET
+        canopy_injections_offered = 5,
+        canopy_injection_total_tokens = 400,
+        canopy_skips_after_injection = 4,
+        canopy_reads_after_injection = 1,
+        canopy_tokens_saved = 1000,
+        canopy_redundant_reads = 0
+      WHERE id = ?
+    `).run('s2');
+    // s3 — feature on, with data
+    db.prepare(`
+      UPDATE sessions SET
+        canopy_injections_offered = 3,
+        canopy_injection_total_tokens = 200,
+        canopy_skips_after_injection = 1,
+        canopy_reads_after_injection = 2,
+        canopy_tokens_saved = 500,
+        canopy_redundant_reads = 0
+      WHERE id = ?
+    `).run('s3');
+
+    const r = rollupCanopy(null);
+    expect(r.sessions_with_data).toBe(2);
+    expect(r.total_tokens_saved).toBe(1500);
+    expect(r.avg_tokens_saved_per_session).toBe(750);
+    expect(r.total_injections_offered).toBe(8);
+    expect(r.total_skips_after_injection).toBe(5);
+    expect(r.skip_ratio).toBeCloseTo(5 / 8, 5);
+  });
+
+  it('respects since/until time bounds', () => {
+    const db = getDatabase();
+    upsertSession({ id: 'old', agent: 'claude-code', started_at: 100, created_at: 100 });
+    upsertSession({ id: 'new', agent: 'claude-code', started_at: 200, created_at: 200 });
+    db.prepare(`
+      UPDATE sessions SET canopy_injections_offered = 1, canopy_skips_after_injection = 1,
+        canopy_injection_total_tokens = 0, canopy_reads_after_injection = 0,
+        canopy_tokens_saved = 100, canopy_redundant_reads = 0
+      WHERE id = ?
+    `).run('old');
+    db.prepare(`
+      UPDATE sessions SET canopy_injections_offered = 1, canopy_skips_after_injection = 1,
+        canopy_injection_total_tokens = 0, canopy_reads_after_injection = 0,
+        canopy_tokens_saved = 200, canopy_redundant_reads = 0
+      WHERE id = ?
+    `).run('new');
+
+    const fresh = rollupCanopy(null, { since: 150 });
+    expect(fresh.sessions_with_data).toBe(1);
+    expect(fresh.total_tokens_saved).toBe(200);
+
+    const stale = rollupCanopy(null, { until: 150 });
+    expect(stale.sessions_with_data).toBe(1);
+    expect(stale.total_tokens_saved).toBe(100);
+  });
+});

--- a/tests/canopy/aggregate/api.test.ts
+++ b/tests/canopy/aggregate/api.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for the read-side Canopy daemon HTTP handlers.
+ *
+ * Each handler is a pure function over a RouteRequest, so we can call them
+ * directly without spinning up the HTTP server.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'bun:test';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
+import { getDatabase } from '@myco/db/client.js';
+import { upsertSession } from '@myco/db/queries/sessions.js';
+import { materializeCanopyAggregates } from '@myco/canopy/aggregate.js';
+import {
+  handleGetSessionCanopy,
+  handleGetCanopyToolCallBlob,
+  handleGetCanopyRollup,
+} from '@myco/daemon/api/canopy-read.js';
+import type { RouteRequest } from '@myco/daemon/router.js';
+
+const PROJECT_ID = '/repo/myco';
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+function makeReq(opts: {
+  params?: Record<string, string>;
+  query?: Record<string, string>;
+  body?: unknown;
+} = {}): RouteRequest {
+  return {
+    body: opts.body ?? null,
+    query: opts.query ?? {},
+    params: opts.params ?? {},
+    pathname: '/test',
+  };
+}
+
+function seedSession(sessionId: string) {
+  const now = epochNow();
+  upsertSession({
+    id: sessionId,
+    agent: 'claude-code',
+    started_at: now,
+    created_at: now,
+    project_root: PROJECT_ID,
+  });
+}
+
+function seedRead(
+  sessionId: string,
+  filePath: string,
+  injectionTokens: number | null,
+  ts: number,
+): number {
+  const result = getDatabase()
+    .prepare(`
+      INSERT INTO activities (
+        session_id, tool_name, tool_input, file_path, timestamp,
+        processed, created_at, canopy_injection_tokens
+      ) VALUES (?, 'Read', ?, ?, ?, 0, ?, ?)
+    `)
+    .run(sessionId, JSON.stringify({ file_path: filePath }), filePath, ts, ts, injectionTokens);
+  return Number(result.lastInsertRowid);
+}
+
+function seedCanopyEntry(path: string, tokens: number) {
+  const now = epochNow();
+  getDatabase()
+    .prepare(`
+      INSERT INTO canopy_entries (
+        project_id, machine_id, path, content_hash, size_bytes, token_estimate,
+        line_count, language, exports_json, imports_json, top_comment,
+        mechanical_updated_at, llm_description, llm_updated_at
+      ) VALUES (?, 'local', ?, 'h', 0, ?, 0, 'typescript', '["foo"]', '[]', NULL, ?, NULL, NULL)
+    `)
+    .run(PROJECT_ID, path, tokens, now);
+}
+
+describe('handleGetSessionCanopy', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    getDatabase().prepare('DELETE FROM canopy_entries').run();
+  });
+
+  it('returns 404 when the session does not exist', async () => {
+    const res = await handleGetSessionCanopy(makeReq({ params: { id: 'missing' } }));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns aggregate + reads for a session with data', async () => {
+    const sessionId = 'sess-api-1';
+    seedSession(sessionId);
+    seedCanopyEntry('a.ts', 1000);
+    seedRead(sessionId, 'a.ts', 80, epochNow());
+    materializeCanopyAggregates(sessionId);
+
+    const res = await handleGetSessionCanopy(makeReq({ params: { id: sessionId } }));
+    expect(res.status ?? 200).toBe(200);
+    const body = res.body as Record<string, unknown>;
+    expect(body.session_id).toBe(sessionId);
+    const agg = body.aggregate as Record<string, number | null>;
+    expect(agg.injections_offered).toBe(1);
+    expect(agg.tokens_saved).toBe(920);
+    const reads = body.reads as Array<Record<string, unknown>>;
+    expect(reads.length).toBe(1);
+    expect(reads[0].file_path).toBe('a.ts');
+    expect(reads[0].canopy_injection_tokens).toBe(80);
+  });
+
+  it('returns NULL aggregate for a pre-feature session', async () => {
+    const sessionId = 'sess-api-prefeature';
+    seedSession(sessionId);
+    // Don't materialize → all canopy columns stay NULL.
+
+    const res = await handleGetSessionCanopy(makeReq({ params: { id: sessionId } }));
+    const body = res.body as Record<string, unknown>;
+    const agg = body.aggregate as Record<string, number | null>;
+    expect(agg.injections_offered).toBeNull();
+    expect(agg.tokens_saved).toBeNull();
+  });
+});
+
+describe('handleGetCanopyToolCallBlob', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    getDatabase().prepare('DELETE FROM canopy_entries').run();
+  });
+
+  it('returns 404 when the tool-call does not belong to the session', async () => {
+    const sessionId = 'sess-api-blob-1';
+    seedSession(sessionId);
+    const res = await handleGetCanopyToolCallBlob(makeReq({
+      params: { id: sessionId, tcId: '99999' },
+    }));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 on a non-numeric tcId', async () => {
+    const res = await handleGetCanopyToolCallBlob(makeReq({
+      params: { id: 'whatever', tcId: 'not-a-number' },
+    }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns reason="entry_missing" when the canopy_entries row is gone', async () => {
+    const sessionId = 'sess-api-blob-2';
+    seedSession(sessionId);
+    const tcId = seedRead(sessionId, 'gone.ts', 80, epochNow());
+
+    const res = await handleGetCanopyToolCallBlob(makeReq({
+      params: { id: sessionId, tcId: String(tcId) },
+    }));
+    const body = res.body as Record<string, unknown>;
+    expect(body.blob).toBeNull();
+    expect(body.reason).toBe('entry_missing');
+    expect(body.file_path).toBe('gone.ts');
+    expect(body.injection_tokens).toBe(80);
+  });
+
+  it('returns reason="compose_unavailable" when the canopy_entries row exists but Track B compose is not loaded', async () => {
+    // Track B's compose module isn't on this branch, so the dynamic import
+    // resolves null and the handler degrades cleanly.
+    const sessionId = 'sess-api-blob-3';
+    seedSession(sessionId);
+    seedCanopyEntry('present.ts', 800);
+    const tcId = seedRead(sessionId, 'present.ts', 70, epochNow());
+
+    const res = await handleGetCanopyToolCallBlob(makeReq({
+      params: { id: sessionId, tcId: String(tcId) },
+    }));
+    const body = res.body as Record<string, unknown>;
+    expect(body.file_path).toBe('present.ts');
+    // On this branch (Track B not merged) the helper is unavailable, so
+    // the API surfaces the reason rather than a blob. Once Track B lands
+    // and exports composeBlob, this will start returning a string.
+    expect(body.reason).toBe('compose_unavailable');
+    expect(body.blob).toBeNull();
+  });
+});
+
+describe('handleGetCanopyRollup', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    getDatabase().prepare('DELETE FROM canopy_entries').run();
+  });
+
+  it('returns the cross-session rollup', async () => {
+    const db = getDatabase();
+    const now = epochNow();
+    upsertSession({ id: 's1', agent: 'claude-code', started_at: now, created_at: now });
+    db.prepare(`
+      UPDATE sessions SET
+        canopy_injections_offered = 4,
+        canopy_injection_total_tokens = 300,
+        canopy_skips_after_injection = 3,
+        canopy_reads_after_injection = 1,
+        canopy_tokens_saved = 1200,
+        canopy_redundant_reads = 0
+      WHERE id = ?
+    `).run('s1');
+
+    const res = await handleGetCanopyRollup(makeReq());
+    const body = res.body as Record<string, number>;
+    expect(body.sessions_with_data).toBe(1);
+    expect(body.total_tokens_saved).toBe(1200);
+    expect(body.skip_ratio).toBeCloseTo(0.75, 5);
+  });
+
+  it('parses since/until query params', async () => {
+    const db = getDatabase();
+    upsertSession({ id: 'old', agent: 'claude-code', started_at: 100, created_at: 100 });
+    upsertSession({ id: 'new', agent: 'claude-code', started_at: 500, created_at: 500 });
+    db.prepare(`
+      UPDATE sessions SET canopy_injections_offered = 1, canopy_skips_after_injection = 1,
+        canopy_injection_total_tokens = 0, canopy_reads_after_injection = 0,
+        canopy_tokens_saved = 50, canopy_redundant_reads = 0
+      WHERE id = ?
+    `).run('old');
+    db.prepare(`
+      UPDATE sessions SET canopy_injections_offered = 1, canopy_skips_after_injection = 1,
+        canopy_injection_total_tokens = 0, canopy_reads_after_injection = 0,
+        canopy_tokens_saved = 90, canopy_redundant_reads = 0
+      WHERE id = ?
+    `).run('new');
+
+    const res = await handleGetCanopyRollup(makeReq({ query: { since: '300' } }));
+    const body = res.body as Record<string, number>;
+    expect(body.sessions_with_data).toBe(1);
+    expect(body.total_tokens_saved).toBe(90);
+  });
+});

--- a/tests/canopy/aggregate/materialize.test.ts
+++ b/tests/canopy/aggregate/materialize.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for materializeCanopyAggregates: runs the aggregation and writes
+ * the result onto the sessions row.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'bun:test';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
+import { getDatabase } from '@myco/db/client.js';
+import { upsertSession, getSession } from '@myco/db/queries/sessions.js';
+import { materializeCanopyAggregates } from '@myco/canopy/aggregate.js';
+
+const PROJECT_ID = '/repo/myco';
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+function seedSession(sessionId: string) {
+  const now = epochNow();
+  upsertSession({
+    id: sessionId,
+    agent: 'claude-code',
+    started_at: now,
+    created_at: now,
+    project_root: PROJECT_ID,
+  });
+}
+
+function seedRead(sessionId: string, filePath: string, injectionTokens: number | null, ts: number) {
+  getDatabase()
+    .prepare(`
+      INSERT INTO activities (
+        session_id, tool_name, tool_input, file_path, timestamp,
+        processed, created_at, canopy_injection_tokens
+      ) VALUES (?, 'Read', ?, ?, ?, 0, ?, ?)
+    `)
+    .run(sessionId, JSON.stringify({ file_path: filePath }), filePath, ts, ts, injectionTokens);
+}
+
+function seedCanopyEntry(path: string, tokens: number) {
+  const now = epochNow();
+  getDatabase()
+    .prepare(`
+      INSERT INTO canopy_entries (
+        project_id, machine_id, path, content_hash, size_bytes, token_estimate,
+        line_count, language, exports_json, imports_json, top_comment,
+        mechanical_updated_at, llm_description, llm_updated_at
+      ) VALUES (?, 'local', ?, 'h', 0, ?, 0, 'typescript', NULL, NULL, NULL, ?, NULL, NULL)
+    `)
+    .run(PROJECT_ID, path, tokens, now);
+}
+
+describe('materializeCanopyAggregates', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    getDatabase().prepare('DELETE FROM canopy_entries').run();
+  });
+
+  it('writes the aggregate onto the sessions row', () => {
+    const sessionId = 'sess-mat-1';
+    seedSession(sessionId);
+    seedCanopyEntry('a.ts', 1000);
+    seedRead(sessionId, 'a.ts', 80, epochNow());
+
+    const result = materializeCanopyAggregates(sessionId);
+
+    expect(result).not.toBeNull();
+    expect(result!.injections_offered).toBe(1);
+    expect(result!.skips_after_injection).toBe(1);
+    expect(result!.tokens_saved).toBe(920);
+
+    const session = getSession(sessionId);
+    expect(session).toBeDefined();
+    expect(session!.canopy_injections_offered).toBe(1);
+    expect(session!.canopy_injection_total_tokens).toBe(80);
+    expect(session!.canopy_skips_after_injection).toBe(1);
+    expect(session!.canopy_reads_after_injection).toBe(0);
+    expect(session!.canopy_tokens_saved).toBe(920);
+    expect(session!.canopy_redundant_reads).toBe(0);
+  });
+
+  it('overwrites prior values on subsequent calls (per-turn re-materialization)', () => {
+    const sessionId = 'sess-mat-2';
+    seedSession(sessionId);
+    seedCanopyEntry('a.ts', 500);
+    const t = epochNow();
+    seedRead(sessionId, 'a.ts', 50, t);
+
+    materializeCanopyAggregates(sessionId);
+    let session = getSession(sessionId);
+    expect(session!.canopy_skips_after_injection).toBe(1);
+
+    // Add a later same-path Read → previous skip becomes a read-after-injection.
+    seedRead(sessionId, 'a.ts', null, t + 10);
+    materializeCanopyAggregates(sessionId);
+    session = getSession(sessionId);
+    expect(session!.canopy_skips_after_injection).toBe(0);
+    expect(session!.canopy_reads_after_injection).toBe(1);
+    expect(session!.canopy_tokens_saved).toBe(-50);
+    expect(session!.canopy_redundant_reads).toBe(1);
+  });
+
+  it('writes zeros for a session with no Read activities', () => {
+    const sessionId = 'sess-mat-empty';
+    seedSession(sessionId);
+
+    const result = materializeCanopyAggregates(sessionId);
+    expect(result).not.toBeNull();
+    expect(result!.injections_offered).toBe(0);
+
+    const session = getSession(sessionId);
+    expect(session!.canopy_injections_offered).toBe(0);
+    expect(session!.canopy_injection_total_tokens).toBe(0);
+    expect(session!.canopy_tokens_saved).toBe(0);
+  });
+
+  it('is a no-op for a session that does not exist (no row to update)', () => {
+    // No exception, returns the zero aggregate.
+    const result = materializeCanopyAggregates('nonexistent-session');
+    expect(result).not.toBeNull();
+    expect(result!.injections_offered).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Lands Track C of the Canopy Phase 1 parallel implementation: per-session
aggregation of injection outcomes plus three read-side daemon endpoints
the UI track can consume.

- **`db/queries/canopy.ts`** — `aggregateSessionCanopy(db, sessionId)` runs
  the CTE-based aggregation (`reads` → `skip_resolution` → `tokens` join to
  `canopy_entries.token_estimate`). Plus `rollupCanopy()` for cross-session
  totals and `listCanopyReads` / `getCanopyToolCallContext` for the
  read-side endpoints. Column names are validated against
  `CANOPY_SESSION_COLUMNS` / `CANOPY_ACTIVITY_COLUMN` exports at module
  load so a future schema rename surfaces as a startup failure rather
  than a silent NULL aggregate.

- **`canopy/aggregate.ts`** — `materializeCanopyAggregates(sessionId, db?)`
  runs the aggregation and UPDATEs the resulting columns onto the
  sessions row. Internal failure is swallowed so it never blocks the
  rest of the Stop pipeline.

- **`daemon/stop-processing.ts`** — single call to
  `materializeCanopyAggregates` at the end of `processStopEvent`. See
  deviation note below.

- **`daemon/api/canopy-read.ts`** — three GET endpoints:
  - `GET /api/sessions/:id/canopy` — aggregate + per-Read tool-call rows.
  - `GET /api/sessions/:id/canopy/tool-calls/:tcId/blob` — replays the
    injection blob via Track B's `composeBlob`. Tolerated as missing
    until Track B lands; surfaces `reason="compose_unavailable"` instead
    of 500'ing.
  - `GET /api/canopy/rollup` — cross-session totals with optional
    `since`/`until` epoch-second bounds.
  Wired through `registerCanopyReadRoutes(server)` in `daemon/main.ts`.

## Tests

36 canopy tests pass (3 new files, 25 new aggregate-track tests + 11
pre-existing canopy utility tests).

```
$ bun test tests/canopy/aggregate
 25 pass / 0 fail / 96 expect() calls
$ bun test tests/canopy
 36 pass / 0 fail / 124 expect() calls
$ npx tsc --noEmit
(clean)
```

Coverage: all-skip, all-read (read-anyway), mixed, no-injection,
redundant-reads, non-Read-tools-ignored, missing-canopy-entry
conservative fallback, same-vs-different-path skip resolution, rollup
empty/with-data, since/until bounds, all three API handlers including
the Track-B-not-yet-merged degradation path.

Sample SQL output (mixed scenario from `aggregate-session.test.ts`):

| metric | value |
| --- | --- |
| `injections_offered` | 2 |
| `injection_total_tokens` | 190 |
| `skips_after_injection` | 1 |
| `reads_after_injection` | 1 |
| `tokens_saved` | 1310 |
| `redundant_reads` | 1 |

Pre-existing baseline failures (1183 fail across the full suite) are
test-infra pollution unrelated to this PR; my tests pass standalone and
the +25 delta in the full-suite count corresponds 1:1 with the new
aggregate-track tests.

## Deviation from plan

The plan text says to wire materialization into `hooks/stop.ts` ("ONE
surgical line"), but the hook process never opens the vault DB — all
DB writes during Stop already happen inside the daemon's
`stop-processing.ts`. The single line lands there instead.
Functionally equivalent, architecturally correct; no other Track
touches `stop-processing.ts` so the exclusivity contract still holds.

## Test plan

- [ ] `bun test tests/canopy/aggregate` — 25/25 pass
- [ ] `bun test tests/canopy` — 36/36 pass
- [ ] `npx tsc --noEmit` clean
- [ ] Phase 2 Lead dogfoods: confirm a fresh Claude Code session
      populates `canopy_*` columns on the sessions row at each Stop
- [ ] Once Track B's compose helper is on main, verify the
      blob-replay endpoint returns a non-null `blob` instead of
      `compose_unavailable`

## Follow-ups

- Track B integration: once `@myco/canopy/inject/compose.js` lands,
  `loadComposeBlob()` will pick it up automatically. No edits needed
  here.
- Track D integration: the three endpoints expose exactly the shape
  Track D's components need (per the plan). A follow-up could add a
  TanStack-Query hook wrapper alongside `useSession*` hooks if it
  turns out useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)