### PR TITLE
feat(canopy): Phase 1 Track D — session detail tile, tool-call indicator, list rollup

### DIFF
--- a/packages/myco/ui/src/components/sessions/ActivityList.tsx
+++ b/packages/myco/ui/src/components/sessions/ActivityList.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { CheckCircle2, XCircle, ChevronDown, ChevronRight } from 'lucide-react';
 import { useBatchActivities, type ActivityRow } from '../../hooks/use-sessions';
 import { formatDurationMs as formatDuration } from '../../lib/format';
+import { CanopyToolCallIndicator } from './CanopyToolCallIndicator';
 import { cn } from '../../lib/cn';
 
 /* ---------- Constants ---------- */
@@ -41,6 +42,7 @@ function ActivityItem({ activity }: { activity: ActivityRow }) {
           </span>
         )}
         <span className="shrink-0 ml-auto" />
+        <CanopyToolCallIndicator sessionId={activity.session_id} activity={activity} />
         <span className="shrink-0 font-mono text-xs text-on-surface-variant">
           {formatDuration(activity.duration_ms)}
         </span>

--- a/packages/myco/ui/src/components/sessions/CanopyEfficiencyTile.tsx
+++ b/packages/myco/ui/src/components/sessions/CanopyEfficiencyTile.tsx
@@ -1,0 +1,174 @@
+import { Surface } from '../ui/surface';
+import { SectionHeader } from '../ui/section-header';
+import {
+  useSessionCanopy,
+  isCanopyAggregateEmpty,
+  type SessionCanopyAggregate,
+} from '../../hooks/use-canopy';
+import { cn } from '../../lib/cn';
+
+/* ---------- Constants ---------- */
+
+/**
+ * Local-format thresholds. Matches the loose convention used by other tiles
+ * (no shared formatter library). Negative net-saved values are rendered with
+ * a minus sign so users see when injection cost exceeded gain — honest, not
+ * hidden.
+ */
+const KILO = 1_000;
+const MEGA = 1_000_000;
+
+/* ---------- Helpers ---------- */
+
+/**
+ * Compact integer formatter: `9999 → 9,999`, `12500 → 12.5k`, `1500000 → 1.5M`.
+ * Sign-preserving: `-1234 → -1,234`. Used for the prominent token count.
+ */
+function formatTokens(n: number): string {
+  const sign = n < 0 ? '-' : '';
+  const abs = Math.abs(n);
+  if (abs >= MEGA) return `${sign}${(abs / MEGA).toFixed(1)}M`;
+  if (abs >= KILO * 10) return `${sign}${Math.round(abs / KILO)}k`;
+  if (abs >= KILO) return `${sign}${(abs / KILO).toFixed(1)}k`;
+  return `${sign}${abs.toLocaleString()}`;
+}
+
+/** Pure plain-integer formatter for sub-stat counts. */
+function formatCount(n: number | null): string {
+  return n === null ? '—' : n.toLocaleString();
+}
+
+/* ---------- Sub-components ---------- */
+
+/** Single label/value row in the sub-stats stack. */
+function SubStat({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div
+      className="flex items-baseline justify-between gap-3 py-1.5 border-b border-[var(--ghost-border)] last:border-0"
+      title={hint}
+    >
+      <span className="font-mono text-[10px] uppercase tracking-wider text-outline">
+        {label}
+      </span>
+      <span className="font-mono text-xs text-on-surface">{value}</span>
+    </div>
+  );
+}
+
+/* ---------- Component ---------- */
+
+export interface CanopyEfficiencyTileProps {
+  sessionId: string;
+  /**
+   * Test/storybook seam: inject an aggregate directly to bypass the network
+   * fetch. When provided, the component skips the hook and renders the
+   * supplied row exactly as the live hook would. `null` means "no data" and
+   * triggers the same hide-gracefully path as a 404 response.
+   */
+  fixture?: SessionCanopyAggregate | null;
+  className?: string;
+}
+
+/**
+ * Token-efficiency tile for the session detail page.
+ *
+ * Hides itself entirely when:
+ *  - the API returns `null` (404 — no Canopy row, pre-feature session, or
+ *    Track C endpoint not yet shipped),
+ *  - or every aggregate column is `null` (row exists but no outcomes were
+ *    captured, e.g. injection disabled in the active scope).
+ *
+ * No "N/A" placeholder — the design calls for graceful hiding so the
+ * surrounding stat-tile row stays clean for sessions that pre-date the
+ * feature. When data is present, surface the net savings prominently and
+ * back it with the structural sub-stats users need to audit the math.
+ */
+export function CanopyEfficiencyTile({
+  sessionId,
+  fixture,
+  className,
+}: CanopyEfficiencyTileProps) {
+  // Always call the hook to keep React's hook order stable. When `fixture` is
+  // explicitly supplied (including `null`), we ignore the hook's data and
+  // render directly from the fixture. The hook is still cheap because the
+  // query key is unique per session and React Query dedupes.
+  const { data: fetched, isLoading } = useSessionCanopy(sessionId);
+  const fixtureProvided = fixture !== undefined;
+  const data = fixtureProvided ? fixture : fetched ?? null;
+
+  // Loading: stay invisible. The tile is non-essential and a flash of empty
+  // state is worse than a delayed reveal.
+  if (!fixtureProvided && isLoading) return null;
+
+  // Hide-gracefully gate.
+  if (isCanopyAggregateEmpty(data)) return null;
+
+  // After the empty-gate, every nullable field is treated as 0 for arithmetic
+  // — but the sub-stat row still renders the em-dash for fields that came
+  // back as `null`, preserving the distinction between "no data" and "zero".
+  const tokensSaved = data!.canopy_tokens_saved ?? 0;
+  const offered = data!.canopy_injections_offered;
+  const skips = data!.canopy_skips_after_injection;
+  const reads = data!.canopy_reads_after_injection;
+  const redundant = data!.canopy_redundant_reads;
+  const totalTokens = data!.canopy_injection_total_tokens;
+
+  return (
+    <Surface
+      level="low"
+      className={cn(
+        'p-4 overflow-hidden rounded-lg border-t-2 border-t-sage',
+        'border border-outline-variant/10',
+        className,
+      )}
+      data-testid="canopy-efficiency-tile"
+    >
+      <SectionHeader className="mb-3">Token efficiency</SectionHeader>
+
+      <div className="mb-4">
+        <p
+          className={cn(
+            'font-serif text-3xl font-bold tracking-tight',
+            tokensSaved >= 0 ? 'text-sage' : 'text-terracotta',
+          )}
+          aria-label={`${formatTokens(tokensSaved)} net tokens saved`}
+        >
+          {formatTokens(tokensSaved)}
+        </p>
+        <p className="font-mono text-[10px] uppercase tracking-wider text-outline mt-1">
+          net tokens {tokensSaved >= 0 ? 'saved' : 'spent'}
+        </p>
+      </div>
+
+      <div className="space-y-0">
+        <SubStat
+          label="Injections offered"
+          value={formatCount(offered)}
+          hint="PreToolUse Read events where Canopy injected anatomy."
+        />
+        <SubStat
+          label="Skipped after injection"
+          value={formatCount(skips)}
+          hint="Files the agent did not Read after seeing the injected blob."
+        />
+        <SubStat
+          label="Read anyway"
+          value={formatCount(reads)}
+          hint="Files the agent Read in full after the injection."
+        />
+        <SubStat
+          label="Injection cost"
+          value={totalTokens === null ? '—' : `${formatTokens(totalTokens)} tok`}
+          hint="Sum of tokens spent on Canopy injections this session."
+        />
+        {redundant !== null && redundant > 0 && (
+          <SubStat
+            label="Redundant reads"
+            value={formatCount(redundant)}
+            hint="Files Read more than once in this session (informational)."
+          />
+        )}
+      </div>
+    </Surface>
+  );
+}

--- a/packages/myco/ui/src/components/sessions/CanopySessionListRollupTile.tsx
+++ b/packages/myco/ui/src/components/sessions/CanopySessionListRollupTile.tsx
@@ -1,0 +1,145 @@
+import { Surface } from '../ui/surface';
+import { SectionHeader } from '../ui/section-header';
+import {
+  useCanopyRollup,
+  isCanopyRollupEmpty,
+  type CanopyRollup,
+} from '../../hooks/use-canopy';
+import { cn } from '../../lib/cn';
+
+/* ---------- Constants ---------- */
+
+const KILO = 1_000;
+const MEGA = 1_000_000;
+
+/* ---------- Helpers ---------- */
+
+/** Compact, sign-preserving integer formatter. */
+function formatTokens(n: number): string {
+  const sign = n < 0 ? '-' : '';
+  const abs = Math.abs(n);
+  if (abs >= MEGA) return `${sign}${(abs / MEGA).toFixed(1)}M`;
+  if (abs >= KILO * 10) return `${sign}${Math.round(abs / KILO)}k`;
+  if (abs >= KILO) return `${sign}${(abs / KILO).toFixed(1)}k`;
+  return `${sign}${abs.toLocaleString()}`;
+}
+
+/** Render a ratio as a percent like "62%". Returns "—" for null inputs. */
+function formatRatio(r: number | null): string {
+  if (r === null) return '—';
+  return `${Math.round(r * 100)}%`;
+}
+
+/* ---------- Sub-components ---------- */
+
+/**
+ * One stat in the rollup tile's three-column row. Visual weight is split
+ * across the three: same typographic level, no accent variation. The
+ * primary "tokens saved" gets a bold serif treatment to draw the eye.
+ */
+function RollupStat({
+  label,
+  value,
+  primary,
+  hint,
+}: {
+  label: string;
+  value: string;
+  primary?: boolean;
+  hint?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1" title={hint}>
+      <span className="font-mono text-[10px] uppercase tracking-wider text-outline">
+        {label}
+      </span>
+      <span
+        className={cn(
+          primary
+            ? 'font-serif text-2xl font-bold text-sage tracking-tight'
+            : 'font-serif text-xl font-medium text-on-surface',
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+/* ---------- Component ---------- */
+
+export interface CanopySessionListRollupTileProps {
+  /**
+   * Test/storybook seam — same pattern as the per-session tile. Pass `null`
+   * to exercise the hide-gracefully path.
+   */
+  fixture?: CanopyRollup | null;
+  className?: string;
+}
+
+/**
+ * Lifetime Canopy rollup tile for the session list surface.
+ *
+ * Mirrors the hide-gracefully posture of the per-session tile: returns
+ * `null` whenever the rollup endpoint 404s OR every numeric field is null
+ * (no Canopy data yet on this machine). Otherwise renders three stats —
+ * total tokens saved, average per session, and injection effectiveness
+ * (skips / injections offered) — in a single tonal card.
+ */
+export function CanopySessionListRollupTile({
+  fixture,
+  className,
+}: CanopySessionListRollupTileProps) {
+  const { data: fetched, isLoading } = useCanopyRollup();
+  const fixtureProvided = fixture !== undefined;
+  const data = fixtureProvided ? fixture : fetched ?? null;
+
+  if (!fixtureProvided && isLoading) return null;
+  if (isCanopyRollupEmpty(data)) return null;
+
+  // Past the empty gate — null fields collapse to 0 for arithmetic.
+  const totalSaved = data!.total_tokens_saved ?? 0;
+  const avgPerSession = data!.avg_tokens_saved_per_session;
+  const ratio = data!.injection_effectiveness_ratio;
+  const sessionsCount = data!.sessions_with_canopy;
+
+  return (
+    <Surface
+      level="low"
+      className={cn(
+        'p-4 overflow-hidden rounded-lg border-t-2 border-t-sage',
+        'border border-outline-variant/10',
+        className,
+      )}
+      data-testid="canopy-rollup-tile"
+    >
+      <div className="flex items-baseline justify-between mb-3">
+        <SectionHeader>Canopy efficiency · lifetime</SectionHeader>
+        {sessionsCount !== null && sessionsCount > 0 && (
+          <span className="font-mono text-[10px] text-outline">
+            across {sessionsCount.toLocaleString()} session{sessionsCount === 1 ? '' : 's'}
+          </span>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <RollupStat
+          label="Tokens saved"
+          value={formatTokens(totalSaved)}
+          primary
+          hint="Net tokens saved by Canopy injections across every captured session."
+        />
+        <RollupStat
+          label="Avg per session"
+          value={avgPerSession === null ? '—' : `${formatTokens(Math.round(avgPerSession))} tok`}
+          hint="Mean tokens saved per session that had at least one Canopy injection."
+        />
+        <RollupStat
+          label="Injection effectiveness"
+          value={formatRatio(ratio)}
+          hint="Share of injections where the agent skipped the full Read."
+        />
+      </div>
+    </Surface>
+  );
+}

--- a/packages/myco/ui/src/components/sessions/CanopyToolCallIndicator.tsx
+++ b/packages/myco/ui/src/components/sessions/CanopyToolCallIndicator.tsx
@@ -1,0 +1,148 @@
+import { useState } from 'react';
+import { Sprout, ArrowRight, FileX } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+import { useCanopyInjectionBlob } from '../../hooks/use-canopy';
+import type { ActivityRow } from '../../hooks/use-sessions';
+import { cn } from '../../lib/cn';
+
+/* ---------- Constants ---------- */
+
+/** Tool names where we show the indicator. Per spec: only Read. */
+const READ_TOOL_NAMES = new Set(['Read', 'read']);
+
+/* ---------- Helpers ---------- */
+
+/**
+ * Decides whether a tool-call row qualifies for a Canopy indicator. Two
+ * gates: the tool must be a Read, and the row must carry a non-null
+ * `canopy_injection_tokens` value (the column is null on every non-Read row
+ * and on Read rows where Canopy didn't inject — targeted reads, small
+ * files, unknown files, disabled scope).
+ */
+function qualifies(activity: { tool_name: string; canopy_injection_tokens: number | null }): boolean {
+  if (activity.canopy_injection_tokens === null) return false;
+  return READ_TOOL_NAMES.has(activity.tool_name);
+}
+
+/* ---------- Sub-components ---------- */
+
+/**
+ * Modal body that lazy-loads the verbatim injection blob via React Query.
+ * Rendered inside <Dialog open> so the fetch only fires when the user opens
+ * the popover — keeps the timeline lightweight by default.
+ */
+function BlobPanel({ sessionId, toolCallId }: { sessionId: string; toolCallId: number }) {
+  const { data, isLoading, isError, error } = useCanopyInjectionBlob(sessionId, toolCallId);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <div className="h-3 w-3/4 animate-pulse rounded bg-surface-container-high" />
+        <div className="h-3 w-2/3 animate-pulse rounded bg-surface-container-high" />
+        <div className="h-3 w-1/2 animate-pulse rounded bg-surface-container-high" />
+      </div>
+    );
+  }
+
+  if (isError || data === null) {
+    return (
+      <div className="flex items-center gap-2 text-on-surface-variant">
+        <FileX className="h-4 w-4" />
+        <span className="font-sans text-sm">
+          {error instanceof Error
+            ? error.message
+            : 'No injection blob available — Track C may not have shipped this endpoint yet.'}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <pre
+      className="font-mono text-xs whitespace-pre-wrap break-words bg-surface-container-lowest rounded-md p-3 text-on-surface overflow-x-auto"
+      data-testid="canopy-blob-text"
+    >
+      {`[canopy] ${data.path} — ${data.tokenEstimate} tok, ${data.lineCount} lines`}
+      {data.exports.length > 0 && `\n  exports: ${data.exports.join(', ')}`}
+      {data.imports.length > 0 && `\n  imports: ${data.imports.join(', ')}`}
+      {data.summary && `\n  summary: "${data.summary}"`}
+      {!data.summary && data.top && `\n  top: "${data.top}"`}
+      {`\n[meta] File anatomy from Myco. If exports + top line already answer your question, skipping the full read may be appropriate.`}
+    </pre>
+  );
+}
+
+/* ---------- Component ---------- */
+
+export interface CanopyToolCallIndicatorProps {
+  sessionId: string;
+  /**
+   * Activity row for this tool call. The component reads `tool_name`,
+   * `canopy_injection_tokens`, and `id`; it does not modify the row.
+   */
+  activity: ActivityRow;
+}
+
+/**
+ * Compact inline indicator for the Canopy injection on a Read tool-call
+ * row. Renders nothing for non-Read tools or for Read rows without an
+ * injection — the column being NULL is the universal "no indicator" signal.
+ *
+ * Click opens a transparency popover with the verbatim blob Cortex sent the
+ * agent. The blob fetch is lazy (only fires on open).
+ */
+export function CanopyToolCallIndicator({ sessionId, activity }: CanopyToolCallIndicatorProps) {
+  const [open, setOpen] = useState(false);
+
+  if (!qualifies(activity)) return null;
+
+  // Type-narrow: qualifies() guarantees this is non-null.
+  const tokens = activity.canopy_injection_tokens as number;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={(e) => {
+          // Tool-call rows are clickable themselves (they expand/collapse).
+          // Stop propagation so opening the blob popover doesn't also toggle
+          // the row's expand state.
+          e.stopPropagation();
+          setOpen(true);
+        }}
+        className={cn(
+          'inline-flex items-center gap-1 px-1.5 py-0.5 rounded',
+          'font-mono text-[10px] text-sage',
+          'bg-sage/10 hover:bg-sage/20 transition-colors cursor-pointer',
+          'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-sage/40',
+        )}
+        title={`Canopy injected ${tokens} tokens of file anatomy. Click to view the blob sent to the agent.`}
+        aria-label={`Canopy injection: ${tokens} tokens`}
+        data-testid="canopy-tool-call-indicator"
+      >
+        <Sprout className="h-3 w-3" aria-hidden="true" />
+        <span>{tokens} tok</span>
+        <ArrowRight className="h-2.5 w-2.5 opacity-60" aria-hidden="true" />
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Canopy injection blob</DialogTitle>
+            <DialogDescription>
+              The verbatim file-anatomy snippet Cortex sent the agent before this Read.
+              Transparency is the default — what you see here is exactly what the model saw.
+            </DialogDescription>
+          </DialogHeader>
+          <BlobPanel sessionId={sessionId} toolCallId={activity.id} />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/packages/myco/ui/src/components/sessions/SessionDetail.tsx
+++ b/packages/myco/ui/src/components/sessions/SessionDetail.tsx
@@ -12,6 +12,7 @@ import { useSymbionts, buildResumeCommand } from '../../hooks/use-symbionts';
 import { useTriggerRun } from '../../hooks/use-agent';
 import { BatchTimeline } from './BatchTimeline';
 import { SessionPlans } from './SessionPlans';
+import { CanopyEfficiencyTile } from './CanopyEfficiencyTile';
 import { StatusBadge } from './status-helpers';
 import { formatTimeAgo, formatDuration as formatDurationSec, shortSession } from '../../lib/format';
 import { cn } from '../../lib/cn';
@@ -267,6 +268,9 @@ export function SessionDetail({ id }: SessionDetailProps) {
         <StatCard label="Tool Calls" value={String(session.tool_count)} accent="sage" />
         <StatCard label="Plans" value={String(plans?.length ?? 0)} accent="outline" />
       </div>
+
+      {/* Canopy token efficiency — hides itself when no data */}
+      <CanopyEfficiencyTile sessionId={id} />
 
       {/* Metadata details (collapsible-style row) */}
       <Surface level="low" className="p-4 overflow-hidden">

--- a/packages/myco/ui/src/components/sessions/SessionList.tsx
+++ b/packages/myco/ui/src/components/sessions/SessionList.tsx
@@ -12,6 +12,7 @@ import { useListFilters, FILTER_ALL } from '../../hooks/use-list-filters';
 import { DEFAULT_PAGE_SIZE } from '../../lib/constants';
 import { shortSession } from '../../lib/format';
 import { StatusBadge } from './status-helpers';
+import { CanopySessionListRollupTile } from './CanopySessionListRollupTile';
 import { cn } from '../../lib/cn';
 import { useMemo, useState } from 'react';
 
@@ -255,6 +256,11 @@ export function SessionList() {
         title="Session Archive"
         subtitle={isLoading ? 'Loading...' : `${total} session${total !== 1 ? 's' : ''} captured`}
       />
+
+      {/* Canopy rollup — hides itself when no data */}
+      <div className="mb-4">
+        <CanopySessionListRollupTile />
+      </div>
 
       {toolbar}
 

--- a/packages/myco/ui/src/hooks/use-canopy.ts
+++ b/packages/myco/ui/src/hooks/use-canopy.ts
@@ -1,0 +1,174 @@
+import { useQuery } from '@tanstack/react-query';
+import { ApiError, fetchJson } from '../lib/api';
+
+/* ---------- Constants ---------- */
+
+/** Cache TTL for the per-session Canopy aggregate (60 seconds). */
+const SESSION_CANOPY_STALE_TIME = 60_000;
+
+/** Cache TTL for the lifetime Canopy rollup (5 minutes — moves slowly). */
+const ROLLUP_STALE_TIME = 300_000;
+
+/** Cache TTL for an injection-blob fetch (effectively immutable per tool-call). */
+const BLOB_STALE_TIME = 3_600_000;
+
+/* ---------- Types ---------- */
+
+/**
+ * Per-session Canopy aggregates returned by `GET /sessions/:id/canopy`.
+ *
+ * Mirrors the canopy_* columns on the session row (Phase 0 schema).
+ * All numeric fields are nullable to cover pre-feature sessions, sessions
+ * where the feature is disabled in the active scope, and sessions whose
+ * Stop hook hasn't materialized aggregates yet.
+ */
+export interface SessionCanopyAggregate {
+  canopy_injections_offered: number | null;
+  canopy_injection_total_tokens: number | null;
+  canopy_skips_after_injection: number | null;
+  canopy_reads_after_injection: number | null;
+  canopy_tokens_saved: number | null;
+  canopy_redundant_reads: number | null;
+}
+
+/**
+ * Lifetime Canopy rollup returned by `GET /canopy/rollup`.
+ *
+ * Aggregated across all sessions on this machine. NULLs indicate "no data
+ * yet" — the rollup endpoint may also return an entirely null payload for a
+ * fresh project, in which case the consumer should hide the rollup tile.
+ */
+export interface CanopyRollup {
+  total_tokens_saved: number | null;
+  sessions_with_canopy: number | null;
+  avg_tokens_saved_per_session: number | null;
+  total_injections_offered: number | null;
+  total_skips_after_injection: number | null;
+  injection_effectiveness_ratio: number | null;
+}
+
+/**
+ * Verbatim injection blob persisted with a tool-call row. The shape is the
+ * structural payload Cortex composed at PreToolUse — `summary` is populated
+ * only when a Tier 2 `llm_description` was available.
+ */
+export interface CanopyInjectionBlob {
+  path: string;
+  tokenEstimate: number;
+  lineCount: number;
+  exports: string[];
+  imports: string[];
+  top: string | null;
+  summary: string | null;
+}
+
+/* ---------- Helpers ---------- */
+
+/**
+ * Treat 404 as "no data" rather than an error. Used for endpoints Track C
+ * may not have shipped yet, plus pre-feature sessions where no row exists.
+ * Re-throws every other error so React Query can surface real failures.
+ */
+async function fetchJsonOrNullOn404<T>(path: string, signal?: AbortSignal): Promise<T | null> {
+  try {
+    return await fetchJson<T>(path, { signal });
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * True when every numeric field in the aggregate is null. The session detail
+ * tile uses this as its hide-gracefully signal: pre-feature sessions and
+ * sessions captured under disabled-injection scope both produce all-null
+ * payloads (the row exists but has no Canopy outcomes to report).
+ */
+export function isCanopyAggregateEmpty(agg: SessionCanopyAggregate | null | undefined): boolean {
+  if (!agg) return true;
+  return (
+    agg.canopy_injections_offered === null
+    && agg.canopy_injection_total_tokens === null
+    && agg.canopy_skips_after_injection === null
+    && agg.canopy_reads_after_injection === null
+    && agg.canopy_tokens_saved === null
+    && agg.canopy_redundant_reads === null
+  );
+}
+
+/** Same hide-gracefully test for the lifetime rollup. */
+export function isCanopyRollupEmpty(rollup: CanopyRollup | null | undefined): boolean {
+  if (!rollup) return true;
+  return (
+    rollup.total_tokens_saved === null
+    && rollup.sessions_with_canopy === null
+    && rollup.avg_tokens_saved_per_session === null
+    && rollup.total_injections_offered === null
+    && rollup.total_skips_after_injection === null
+    && rollup.injection_effectiveness_ratio === null
+  );
+}
+
+/* ---------- Hooks ---------- */
+
+/**
+ * Fetches per-session Canopy aggregates. Returns `null` (not an error) when
+ * the endpoint 404s, so callers can hide the tile entirely without branching
+ * on the error path. Track C's `/sessions/:id/canopy` route may not exist on
+ * every branch — graceful 404 handling lets the UI ship ahead of the API.
+ */
+export function useSessionCanopy(sessionId: string | undefined) {
+  return useQuery<SessionCanopyAggregate | null>({
+    queryKey: ['session-canopy', sessionId],
+    queryFn: ({ signal }) =>
+      fetchJsonOrNullOn404<SessionCanopyAggregate>(`/sessions/${sessionId}/canopy`, signal),
+    enabled: sessionId !== undefined,
+    staleTime: SESSION_CANOPY_STALE_TIME,
+    // Don't retry 404s — they're a "no data" answer, not a transient failure.
+    retry: (failureCount, err) => {
+      if (err instanceof ApiError && err.status === 404) return false;
+      return failureCount < 2;
+    },
+  });
+}
+
+/** Fetches the lifetime Canopy rollup for the all-sessions surface. */
+export function useCanopyRollup() {
+  return useQuery<CanopyRollup | null>({
+    queryKey: ['canopy-rollup'],
+    queryFn: ({ signal }) =>
+      fetchJsonOrNullOn404<CanopyRollup>('/canopy/rollup', signal),
+    staleTime: ROLLUP_STALE_TIME,
+    retry: (failureCount, err) => {
+      if (err instanceof ApiError && err.status === 404) return false;
+      return failureCount < 2;
+    },
+  });
+}
+
+/**
+ * Fetches the verbatim injection blob persisted with a tool-call row.
+ * Lazy — only runs when both ids are defined (the indicator passes
+ * `undefined` until the user opens its popover).
+ */
+export function useCanopyInjectionBlob(
+  sessionId: string | undefined,
+  toolCallId: number | undefined,
+) {
+  return useQuery<CanopyInjectionBlob | null>({
+    queryKey: ['canopy-tool-call-blob', sessionId, toolCallId],
+    queryFn: ({ signal }) =>
+      fetchJsonOrNullOn404<CanopyInjectionBlob>(
+        `/sessions/${sessionId}/canopy/tool-calls/${toolCallId}/blob`,
+        signal,
+      ),
+    enabled: sessionId !== undefined && toolCallId !== undefined,
+    staleTime: BLOB_STALE_TIME,
+    retry: (failureCount, err) => {
+      if (err instanceof ApiError && err.status === 404) return false;
+      return failureCount < 2;
+    },
+  });
+}

--- a/tests/ui/canopy-efficiency-tile.test.tsx
+++ b/tests/ui/canopy-efficiency-tile.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'bun:test';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CanopyEfficiencyTile } from '../../packages/myco/ui/src/components/sessions/CanopyEfficiencyTile';
+import type { SessionCanopyAggregate } from '../../packages/myco/ui/src/hooks/use-canopy';
+
+/* ---------- Helpers ---------- */
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function renderTile(fixture: SessionCanopyAggregate | null) {
+  const client = makeQueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <CanopyEfficiencyTile sessionId="sess-1" fixture={fixture} />
+    </QueryClientProvider>,
+  );
+}
+
+const POPULATED: SessionCanopyAggregate = {
+  canopy_injections_offered: 12,
+  canopy_injection_total_tokens: 720,
+  canopy_skips_after_injection: 8,
+  canopy_reads_after_injection: 4,
+  canopy_tokens_saved: 4_320,
+  canopy_redundant_reads: 1,
+};
+
+const ALL_NULL: SessionCanopyAggregate = {
+  canopy_injections_offered: null,
+  canopy_injection_total_tokens: null,
+  canopy_skips_after_injection: null,
+  canopy_reads_after_injection: null,
+  canopy_tokens_saved: null,
+  canopy_redundant_reads: null,
+};
+
+const NEGATIVE: SessionCanopyAggregate = {
+  canopy_injections_offered: 5,
+  canopy_injection_total_tokens: 400,
+  canopy_skips_after_injection: 0,
+  canopy_reads_after_injection: 5,
+  canopy_tokens_saved: -400,
+  canopy_redundant_reads: 0,
+};
+
+/* ---------- Tests ---------- */
+
+describe('CanopyEfficiencyTile', () => {
+  it('renders the tile with populated data', () => {
+    renderTile(POPULATED);
+
+    expect(screen.getByTestId('canopy-efficiency-tile')).toBeInTheDocument();
+    expect(screen.getByText(/token efficiency/i)).toBeInTheDocument();
+    // Compact-formatted prominent number (4_320 → "4.3k").
+    expect(screen.getByText(/4\.3k/)).toBeInTheDocument();
+    expect(screen.getByText(/net tokens saved/i)).toBeInTheDocument();
+    // Sub-stats render their values.
+    expect(screen.getByText('12')).toBeInTheDocument(); // injections offered
+    expect(screen.getByText('8')).toBeInTheDocument();  // skipped
+    expect(screen.getByText('4')).toBeInTheDocument();  // read anyway
+  });
+
+  it('hides itself entirely when fixture is null', () => {
+    const { container } = renderTile(null);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId('canopy-efficiency-tile')).not.toBeInTheDocument();
+  });
+
+  it('hides itself entirely when every column is null', () => {
+    const { container } = renderTile(ALL_NULL);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId('canopy-efficiency-tile')).not.toBeInTheDocument();
+  });
+
+  it('shows a negative net-spend when injection cost exceeds gain', () => {
+    renderTile(NEGATIVE);
+
+    expect(screen.getByTestId('canopy-efficiency-tile')).toBeInTheDocument();
+    // -400 fits below the kilo threshold so it formats as a comma-grouped int.
+    expect(screen.getByText(/-400/)).toBeInTheDocument();
+    expect(screen.getByText(/net tokens spent/i)).toBeInTheDocument();
+  });
+
+  it('omits the redundant-reads row when count is zero', () => {
+    renderTile({ ...POPULATED, canopy_redundant_reads: 0 });
+    expect(screen.queryByText(/redundant reads/i)).not.toBeInTheDocument();
+  });
+});

--- a/tests/ui/canopy-session-list-rollup-tile.test.tsx
+++ b/tests/ui/canopy-session-list-rollup-tile.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'bun:test';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CanopySessionListRollupTile } from '../../packages/myco/ui/src/components/sessions/CanopySessionListRollupTile';
+import type { CanopyRollup } from '../../packages/myco/ui/src/hooks/use-canopy';
+
+/* ---------- Helpers ---------- */
+
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function renderTile(fixture: CanopyRollup | null) {
+  const client = makeQueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <CanopySessionListRollupTile fixture={fixture} />
+    </QueryClientProvider>,
+  );
+}
+
+const POPULATED: CanopyRollup = {
+  total_tokens_saved: 24_500,
+  sessions_with_canopy: 17,
+  avg_tokens_saved_per_session: 1_441,
+  total_injections_offered: 60,
+  total_skips_after_injection: 38,
+  injection_effectiveness_ratio: 0.633,
+};
+
+const ALL_NULL: CanopyRollup = {
+  total_tokens_saved: null,
+  sessions_with_canopy: null,
+  avg_tokens_saved_per_session: null,
+  total_injections_offered: null,
+  total_skips_after_injection: null,
+  injection_effectiveness_ratio: null,
+};
+
+/* ---------- Tests ---------- */
+
+describe('CanopySessionListRollupTile', () => {
+  it('renders the rollup with populated data', () => {
+    renderTile(POPULATED);
+
+    expect(screen.getByTestId('canopy-rollup-tile')).toBeInTheDocument();
+    expect(screen.getByText(/Canopy efficiency · lifetime/i)).toBeInTheDocument();
+    // Compact-formatted values appear.
+    expect(screen.getByText(/25k|24\.5k/)).toBeInTheDocument(); // total saved
+    expect(screen.getByText(/63%/)).toBeInTheDocument(); // ratio
+    expect(screen.getByText(/across 17 sessions/i)).toBeInTheDocument();
+  });
+
+  it('hides itself entirely when fixture is null', () => {
+    const { container } = renderTile(null);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId('canopy-rollup-tile')).not.toBeInTheDocument();
+  });
+
+  it('hides itself entirely when every column is null', () => {
+    const { container } = renderTile(ALL_NULL);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders em-dashes for partial-null payloads instead of falsy 0', () => {
+    renderTile({
+      ...POPULATED,
+      avg_tokens_saved_per_session: null,
+      injection_effectiveness_ratio: null,
+    });
+    // The "average per session" and "injection effectiveness" stats fall
+    // back to em-dashes — better than rendering "0 tok" / "0%" which would
+    // imply Canopy ran and produced no benefit.
+    const dashes = screen.getAllByText(/—/);
+    expect(dashes.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/tests/ui/canopy-tool-call-indicator.test.tsx
+++ b/tests/ui/canopy-tool-call-indicator.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'bun:test';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CanopyToolCallIndicator } from '../../packages/myco/ui/src/components/sessions/CanopyToolCallIndicator';
+import type { ActivityRow } from '../../packages/myco/ui/src/hooks/use-sessions';
+
+/* ---------- Helpers ---------- */
+
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function renderIndicator(activity: ActivityRow) {
+  const client = makeQueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <CanopyToolCallIndicator sessionId="sess-1" activity={activity} />
+    </QueryClientProvider>,
+  );
+}
+
+const baseActivity: ActivityRow = {
+  id: 42,
+  session_id: 'sess-1',
+  prompt_batch_id: 1,
+  tool_name: 'Read',
+  tool_input: '{"path":"src/foo.ts"}',
+  tool_output_summary: null,
+  file_path: 'src/foo.ts',
+  files_affected: null,
+  duration_ms: 12,
+  success: 1,
+  error_message: null,
+  timestamp: 100,
+  processed: 1,
+  content_hash: null,
+  created_at: 100,
+};
+
+/* ---------- Tests ---------- */
+
+describe('CanopyToolCallIndicator', () => {
+  it('renders the badge for a Read tool with non-null injection tokens', () => {
+    renderIndicator({ ...baseActivity, canopy_injection_tokens: 60 });
+
+    const badge = screen.getByTestId('canopy-tool-call-indicator');
+    expect(badge).toBeInTheDocument();
+    expect(badge.textContent).toContain('60');
+    expect(badge.textContent).toContain('tok');
+  });
+
+  it('renders nothing when canopy_injection_tokens is null', () => {
+    const { container } = renderIndicator({ ...baseActivity, canopy_injection_tokens: null });
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId('canopy-tool-call-indicator')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing for a non-Read tool even when injection tokens are populated', () => {
+    // Defensive: the column should always be NULL for non-Read tools, but
+    // the component must guard regardless so a stale row never produces a
+    // misleading indicator on the wrong tool.
+    const { container } = renderIndicator({
+      ...baseActivity,
+      tool_name: 'Bash',
+      canopy_injection_tokens: 60,
+    });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('lower-cases read alias also qualifies', () => {
+    renderIndicator({ ...baseActivity, tool_name: 'read', canopy_injection_tokens: 75 });
+    expect(screen.getByTestId('canopy-tool-call-indicator')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 / Track D of the Canopy code-intelligence rollout. Adds the three UI surfaces that render the per-Read injection numbers Tracks B/C populate.

- **D.1 — `CanopyEfficiencyTile`** — per-session token-efficiency tile on the session detail page. Fetches `GET /sessions/:id/canopy`, renders net tokens saved as the prominent figure plus injections-offered / skips / reads-anyway / cost / redundant-reads sub-stats. Hides itself when the API 404s or every column is null.
- **D.2 — `CanopyToolCallIndicator`** — compact sage badge on Read tool-call rows. Renders nothing on non-Read tools or rows where `canopy_injection_tokens` is NULL. Click opens a transparency dialog that fetches `GET /sessions/:id/canopy/tool-calls/:tcId/blob` and shows the verbatim Cortex blob the agent saw. Single additive insertion in `ActivityList.tsx` — no row restructuring.
- **D.3 — `CanopySessionListRollupTile`** — lifetime aggregate tile on the session list. Fetches `GET /canopy/rollup` and shows total tokens saved, average per session, and injection effectiveness ratio. Same hide-gracefully posture so a fresh project renders nothing.

All three components use the project's Tactile Research design language (sage accent, surface tokens, serif headings, font-mono for code/path, no borders besides the standard tonal-card top accent).

The data hooks live in `packages/myco/ui/src/hooks/use-canopy.ts`. Each hook treats HTTP 404 as "no data" rather than an error, so the UI is safe to ship ahead of Track C's endpoints — when the API isn't there yet, the tiles simply hide.

## Test plan

- [x] `cd packages/myco && npx tsc --noEmit` clean
- [x] `npx tsc --noEmit` (root) clean
- [x] `npm run build:ui` builds (1,387 kB minified, no errors)
- [x] `MYCO_TEST_PROFILE=fast node scripts/run-bun-tests.mjs` — full suite passes (3132 + 36 = 3168 total; +13 new tests across 3 new files)
  - 5 tests for `CanopyEfficiencyTile` (with-data, null fixture hides, all-null hides, negative net-spend, redundant-reads omitted at zero)
  - 4 tests for `CanopyToolCallIndicator` (renders for Read+tokens, hidden when tokens null, hidden for non-Read tools, lower-case `read` alias)
  - 4 tests for `CanopySessionListRollupTile` (with-data, null fixture hides, all-null hides, partial-null em-dashes)
- [ ] Visual check once Track C ships — currently fixture-only

## Notes

- Files owned exclusively by Track D were touched: three new components, one new hook file, one new test file each. Boundary edits to `SessionDetail.tsx`, `ActivityList.tsx`, and `SessionList.tsx` are single additive insertions per the plan's "no restructuring" rule.
- No new runtime deps. Reuses `@tanstack/react-query`, the existing `Surface` / `SectionHeader` / `Dialog` primitives, and `lucide-react` icons already in the bundle.
- Each hook's 404-graceful behavior is what lets Track D ship before Track C's endpoints exist. Once the endpoints land, no UI changes are required — the tiles simply start rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)