### PR TITLE
feat(canopy): Phase 1 Track A — scanner & collection

### DIFF
--- a/packages/myco/src/canopy/parsers/fallback.ts
+++ b/packages/myco/src/canopy/parsers/fallback.ts
@@ -1,0 +1,26 @@
+import type { CanopyParser, CanopyParserInput, CanopyParserOutput } from '../types.js';
+
+const TOP_COMMENT_MAX = 200;
+
+/**
+ * Universal mechanical baseline used when no language-specific parser applies
+ * or when a language parser fails. Returns enough structure that the row is
+ * still useful (path/hash/size/lines arrive from the scanner).
+ */
+export const fallbackParser: CanopyParser = (input: CanopyParserInput): CanopyParserOutput => {
+  const firstLine = firstNonEmptyLine(input.content);
+  return {
+    language: null,
+    exports: [],
+    imports: [],
+    topComment: firstLine ? firstLine.slice(0, TOP_COMMENT_MAX) : null,
+  };
+};
+
+function firstNonEmptyLine(content: string): string | null {
+  for (const raw of content.split(/\r?\n/)) {
+    const trimmed = raw.trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  return null;
+}

--- a/packages/myco/src/canopy/parsers/markdown.ts
+++ b/packages/myco/src/canopy/parsers/markdown.ts
@@ -1,8 +1,31 @@
-import type { CanopyParser } from '../types.js';
-import { fallbackParser } from './fallback.js';
+import type { CanopyParser, CanopyParserInput, CanopyParserOutput } from '../types.js';
 
-// Real implementation lands in Task A.3.
-export const markdownParser: CanopyParser = (input) => ({
-  ...fallbackParser(input),
-  language: 'markdown',
-});
+const TOP_COMMENT_MAX = 240;
+
+/**
+ * Mechanical parser for `.md` / `.markdown`. Pulls the first H1 (or the
+ * first non-empty line if no H1 is present) into topComment, and appends a
+ * compact heading-count summary so the row carries some shape.
+ */
+export const markdownParser: CanopyParser = (input: CanopyParserInput): CanopyParserOutput => {
+  const lines = input.content.split(/\r?\n/);
+  let h1: string | null = null;
+  let h2 = 0;
+  let h3 = 0;
+  let firstNonEmpty: string | null = null;
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (line.length === 0) continue;
+    if (firstNonEmpty === null) firstNonEmpty = line;
+    if (h1 === null && line.startsWith('# ')) h1 = line.slice(2).trim();
+    else if (line.startsWith('## ')) h2++;
+    else if (line.startsWith('### ')) h3++;
+  }
+
+  const head = h1 ?? firstNonEmpty;
+  const headings = h2 + h3 > 0 ? ` [h2:${h2} h3:${h3}]` : '';
+  const top = head ? `${head}${headings}`.slice(0, TOP_COMMENT_MAX) : null;
+
+  return { language: 'markdown', exports: [], imports: [], topComment: top };
+};

--- a/packages/myco/src/canopy/parsers/markdown.ts
+++ b/packages/myco/src/canopy/parsers/markdown.ts
@@ -1,0 +1,8 @@
+import type { CanopyParser } from '../types.js';
+import { fallbackParser } from './fallback.js';
+
+// Real implementation lands in Task A.3.
+export const markdownParser: CanopyParser = (input) => ({
+  ...fallbackParser(input),
+  language: 'markdown',
+});

--- a/packages/myco/src/canopy/parsers/python.ts
+++ b/packages/myco/src/canopy/parsers/python.ts
@@ -1,8 +1,72 @@
-import type { CanopyParser } from '../types.js';
-import { fallbackParser } from './fallback.js';
+import type { CanopyParser, CanopyParserInput, CanopyParserOutput } from '../types.js';
 
-// Real implementation lands in Task A.3.
-export const pythonParser: CanopyParser = (input) => ({
-  ...fallbackParser(input),
-  language: 'python',
-});
+const TOP_COMMENT_MAX = 240;
+
+/**
+ * Mechanical regex parser for `.py` files. Captures the module-level
+ * docstring (triple-quoted at column zero, possibly preceded by shebang or
+ * blank lines), top-level `def`/`class` names, and `import`/`from` modules.
+ */
+export const pythonParser: CanopyParser = (input: CanopyParserInput): CanopyParserOutput => {
+  return {
+    language: 'python',
+    exports: extractDefsAndClasses(input.content),
+    imports: extractImports(input.content),
+    topComment: extractDocstring(input.content),
+  };
+};
+
+function extractDocstring(content: string): string | null {
+  // Skip leading shebang, encoding cookie, and blank lines.
+  let idx = 0;
+  while (idx < content.length) {
+    const nl = content.indexOf('\n', idx);
+    const line = (nl === -1 ? content.slice(idx) : content.slice(idx, nl)).trimEnd();
+    const stripped = line.trim();
+    if (stripped === '' || stripped.startsWith('#')) {
+      if (nl === -1) return null;
+      idx = nl + 1;
+      continue;
+    }
+    break;
+  }
+  const head = content.slice(idx);
+  const m = head.match(/^([ru]?)("""|''')([\s\S]*?)\2/i);
+  if (!m) return null;
+  const body = m[3].trim().replace(/\s+/g, ' ');
+  return body.length === 0 ? null : body.slice(0, TOP_COMMENT_MAX);
+}
+
+function extractDefsAndClasses(content: string): string[] {
+  const out: string[] = [];
+  for (const line of content.split(/\r?\n/)) {
+    // Top-level only — no leading whitespace.
+    const m = line.match(/^(?:async\s+)?def\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/);
+    if (m) {
+      out.push(m[1]);
+      continue;
+    }
+    const c = line.match(/^class\s+([A-Za-z_][A-Za-z0-9_]*)/);
+    if (c) out.push(c[1]);
+  }
+  return out;
+}
+
+function extractImports(content: string): string[] {
+  const set = new Set<string>();
+  for (const line of content.split(/\r?\n/)) {
+    const f = line.match(/^from\s+([.\w]+)\s+import\b/);
+    if (f) {
+      set.add(f[1]);
+      continue;
+    }
+    const i = line.match(/^import\s+(.+?)(?:\s+as\s+\w+)?\s*$/);
+    if (i) {
+      for (const part of i[1].split(',')) {
+        const name = part.trim().split(/\s+/)[0];
+        if (name) set.add(name);
+      }
+    }
+  }
+  return [...set];
+}

--- a/packages/myco/src/canopy/parsers/python.ts
+++ b/packages/myco/src/canopy/parsers/python.ts
@@ -1,0 +1,8 @@
+import type { CanopyParser } from '../types.js';
+import { fallbackParser } from './fallback.js';
+
+// Real implementation lands in Task A.3.
+export const pythonParser: CanopyParser = (input) => ({
+  ...fallbackParser(input),
+  language: 'python',
+});

--- a/packages/myco/src/canopy/parsers/registry.ts
+++ b/packages/myco/src/canopy/parsers/registry.ts
@@ -1,0 +1,23 @@
+import type { CanopyParser } from '../types.js';
+import { typescriptParser } from './typescript.js';
+import { pythonParser } from './python.js';
+import { markdownParser } from './markdown.js';
+import { yamlJsonParser } from './yaml-json.js';
+import { sqlParser } from './sql.js';
+import { fallbackParser } from './fallback.js';
+
+const TS_RE = /\.(?:tsx|ts|jsx|js|mjs|cjs|mts|cts)$/i;
+const PY_RE = /\.py$/i;
+const MD_RE = /\.(?:md|markdown)$/i;
+const YJ_RE = /\.(?:yaml|yml|json)$/i;
+const SQL_RE = /\.sql$/i;
+
+/** Dispatch a path to the right mechanical parser. Extension-driven only. */
+export function parserFor(path: string): CanopyParser {
+  if (TS_RE.test(path)) return typescriptParser;
+  if (PY_RE.test(path)) return pythonParser;
+  if (MD_RE.test(path)) return markdownParser;
+  if (YJ_RE.test(path)) return yamlJsonParser;
+  if (SQL_RE.test(path)) return sqlParser;
+  return fallbackParser;
+}

--- a/packages/myco/src/canopy/parsers/sql.ts
+++ b/packages/myco/src/canopy/parsers/sql.ts
@@ -1,0 +1,8 @@
+import type { CanopyParser } from '../types.js';
+import { fallbackParser } from './fallback.js';
+
+// Real implementation lands in Task A.3.
+export const sqlParser: CanopyParser = (input) => ({
+  ...fallbackParser(input),
+  language: 'sql',
+});

--- a/packages/myco/src/canopy/parsers/sql.ts
+++ b/packages/myco/src/canopy/parsers/sql.ts
@@ -1,8 +1,41 @@
-import type { CanopyParser } from '../types.js';
-import { fallbackParser } from './fallback.js';
+import type { CanopyParser, CanopyParserInput, CanopyParserOutput } from '../types.js';
 
-// Real implementation lands in Task A.3.
-export const sqlParser: CanopyParser = (input) => ({
-  ...fallbackParser(input),
-  language: 'sql',
-});
+/**
+ * Mechanical parser for `.sql`. Scans for top-level DDL/DML statement kinds
+ * and emits affected object identifiers as `exports`. Strips line and block
+ * comments first so commented-out statements don't show up.
+ */
+export const sqlParser: CanopyParser = (input: CanopyParserInput): CanopyParserOutput => {
+  const cleaned = stripComments(input.content);
+  const exports: string[] = [];
+
+  for (const m of cleaned.matchAll(/\bCREATE\s+(?:TEMP(?:ORARY)?\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([\w."`]+)/gi)) {
+    exports.push(`table:${unquote(m[1])}`);
+  }
+  for (const m of cleaned.matchAll(/\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?([\w."`]+)/gi)) {
+    exports.push(`index:${unquote(m[1])}`);
+  }
+  for (const m of cleaned.matchAll(/\bCREATE\s+VIEW\s+(?:IF\s+NOT\s+EXISTS\s+)?([\w."`]+)/gi)) {
+    exports.push(`view:${unquote(m[1])}`);
+  }
+  for (const m of cleaned.matchAll(/\bCREATE\s+TRIGGER\s+(?:IF\s+NOT\s+EXISTS\s+)?([\w."`]+)/gi)) {
+    exports.push(`trigger:${unquote(m[1])}`);
+  }
+  for (const m of cleaned.matchAll(/\bALTER\s+TABLE\s+([\w."`]+)/gi)) {
+    exports.push(`alter:${unquote(m[1])}`);
+  }
+
+  return { language: 'sql', exports, imports: [], topComment: null };
+};
+
+function stripComments(s: string): string {
+  return s
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .split(/\r?\n/)
+    .map((line) => line.replace(/--.*$/, ''))
+    .join('\n');
+}
+
+function unquote(s: string): string {
+  return s.replace(/^["`]|["`]$/g, '');
+}

--- a/packages/myco/src/canopy/parsers/typescript.ts
+++ b/packages/myco/src/canopy/parsers/typescript.ts
@@ -1,9 +1,172 @@
-import type { CanopyParser } from '../types.js';
-import { fallbackParser } from './fallback.js';
+import ts from 'typescript';
+import type { CanopyParser, CanopyParserInput, CanopyParserOutput } from '../types.js';
 
-// Real implementation lands in Task A.2; the registry references this slot
-// from A.1 onward, so a no-op delegate keeps the surface stable.
-export const typescriptParser: CanopyParser = (input) => ({
-  ...fallbackParser(input),
-  language: 'typescript',
-});
+const TOP_COMMENT_MAX = 240;
+
+/**
+ * Mechanical parser for `.ts/.tsx/.js/.jsx/.mjs/.cjs/.mts/.cts` files.
+ *
+ * Walks a non-typechecked SourceFile to extract named exports, import module
+ * specifiers, and the leading JSDoc/banner comment. Defensive against parse
+ * errors: any throw in the AST path falls back to a minimal result with a
+ * first-line topComment so the row is still useful.
+ */
+export const typescriptParser: CanopyParser = (input: CanopyParserInput): CanopyParserOutput => {
+  try {
+    return parse(input);
+  } catch {
+    return {
+      language: 'typescript',
+      exports: [],
+      imports: [],
+      topComment: firstNonEmptyLine(input.content),
+    };
+  }
+};
+
+function parse(input: CanopyParserInput): CanopyParserOutput {
+  const scriptKind = pickScriptKind(input.path);
+  const source = ts.createSourceFile(
+    input.path,
+    input.content,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    scriptKind,
+  );
+
+  const exports = new Set<string>();
+  const imports = new Set<string>();
+
+  for (const stmt of source.statements) {
+    collectExports(stmt, exports);
+    collectImports(stmt, imports);
+  }
+
+  return {
+    language: 'typescript',
+    exports: [...exports],
+    imports: [...imports],
+    topComment: extractTopComment(input.content) ?? firstNonEmptyLine(input.content),
+  };
+}
+
+function pickScriptKind(path: string): ts.ScriptKind {
+  const lower = path.toLowerCase();
+  if (lower.endsWith('.tsx')) return ts.ScriptKind.TSX;
+  if (lower.endsWith('.jsx')) return ts.ScriptKind.JSX;
+  if (lower.endsWith('.js') || lower.endsWith('.mjs') || lower.endsWith('.cjs')) return ts.ScriptKind.JS;
+  return ts.ScriptKind.TS;
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  // Cast to any-shaped accessor to avoid the ts.canHaveModifiers type narrowing
+  // on the broad ts.Statement union; the property is read defensively.
+  const modifiers = (node as { modifiers?: readonly ts.ModifierLike[] }).modifiers;
+  if (!modifiers) return false;
+  return modifiers.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+}
+
+function collectExports(stmt: ts.Statement, out: Set<string>): void {
+  // export { a, b } from '...'  /  export { a, b }
+  if (ts.isExportDeclaration(stmt)) {
+    if (stmt.exportClause && ts.isNamedExports(stmt.exportClause)) {
+      for (const el of stmt.exportClause.elements) out.add(el.name.text);
+    } else if (stmt.moduleSpecifier && !stmt.exportClause) {
+      // export * from '...'  -- record the module as the export marker
+      out.add(`* from ${stripQuotes(stmt.moduleSpecifier.getText())}`);
+    }
+    return;
+  }
+
+  // export = ...  /  export default ...
+  if (ts.isExportAssignment(stmt)) {
+    out.add(stmt.isExportEquals ? 'export=' : 'default');
+    return;
+  }
+
+  if (!hasExportModifier(stmt)) return;
+
+  if (ts.isFunctionDeclaration(stmt) && stmt.name) out.add(stmt.name.text);
+  else if (ts.isClassDeclaration(stmt) && stmt.name) out.add(stmt.name.text);
+  else if (ts.isInterfaceDeclaration(stmt)) out.add(stmt.name.text);
+  else if (ts.isTypeAliasDeclaration(stmt)) out.add(stmt.name.text);
+  else if (ts.isEnumDeclaration(stmt)) out.add(stmt.name.text);
+  else if (ts.isModuleDeclaration(stmt) && stmt.name && ts.isIdentifier(stmt.name)) {
+    out.add(stmt.name.text);
+  } else if (ts.isVariableStatement(stmt)) {
+    for (const decl of stmt.declarationList.declarations) {
+      collectBindingNames(decl.name, out);
+    }
+  }
+}
+
+function collectBindingNames(name: ts.BindingName, out: Set<string>): void {
+  if (ts.isIdentifier(name)) {
+    out.add(name.text);
+    return;
+  }
+  for (const el of name.elements) {
+    if (ts.isOmittedExpression(el)) continue;
+    collectBindingNames(el.name, out);
+  }
+}
+
+function collectImports(stmt: ts.Statement, out: Set<string>): void {
+  if (ts.isImportDeclaration(stmt)) {
+    out.add(stripQuotes(stmt.moduleSpecifier.getText()));
+    return;
+  }
+  // import x = require('...')
+  if (ts.isImportEqualsDeclaration(stmt) && ts.isExternalModuleReference(stmt.moduleReference)) {
+    out.add(stripQuotes(stmt.moduleReference.expression.getText()));
+  }
+}
+
+function stripQuotes(s: string): string {
+  return s.replace(/^['"`]|['"`]$/g, '');
+}
+
+function extractTopComment(content: string): string | null {
+  const ranges = ts.getLeadingCommentRanges(content, 0);
+  if (!ranges || ranges.length === 0) return null;
+  // Block comments stand alone; consecutive line comments form a banner so
+  // gather the run of SingleLineCommentTrivia entries that touch the start.
+  const first = ranges[0];
+  if (first.kind === ts.SyntaxKind.MultiLineCommentTrivia) {
+    return cleanComment(content.slice(first.pos, first.end));
+  }
+  const lineGroup: ts.CommentRange[] = [];
+  for (const r of ranges) {
+    if (r.kind !== ts.SyntaxKind.SingleLineCommentTrivia) break;
+    lineGroup.push(r);
+  }
+  const raw = lineGroup.map((r) => content.slice(r.pos, r.end)).join('\n');
+  return cleanComment(raw);
+}
+
+function cleanComment(raw: string): string {
+  let s = raw;
+  if (s.startsWith('/**') || s.startsWith('/*')) {
+    s = s.replace(/^\/\*+/, '').replace(/\*+\/$/, '');
+  } else if (s.startsWith('//')) {
+    s = s
+      .split(/\r?\n/)
+      .map((line) => line.replace(/^\s*\/\/\s?/, ''))
+      .join(' ');
+  }
+  s = s
+    .split(/\r?\n/)
+    .map((line) => line.replace(/^\s*\*\s?/, ''))
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return s.slice(0, TOP_COMMENT_MAX);
+}
+
+function firstNonEmptyLine(content: string): string | null {
+  for (const raw of content.split(/\r?\n/)) {
+    const trimmed = raw.trim();
+    if (trimmed.length > 0) return trimmed.slice(0, TOP_COMMENT_MAX);
+  }
+  return null;
+}

--- a/packages/myco/src/canopy/parsers/typescript.ts
+++ b/packages/myco/src/canopy/parsers/typescript.ts
@@ -1,0 +1,9 @@
+import type { CanopyParser } from '../types.js';
+import { fallbackParser } from './fallback.js';
+
+// Real implementation lands in Task A.2; the registry references this slot
+// from A.1 onward, so a no-op delegate keeps the surface stable.
+export const typescriptParser: CanopyParser = (input) => ({
+  ...fallbackParser(input),
+  language: 'typescript',
+});

--- a/packages/myco/src/canopy/parsers/yaml-json.ts
+++ b/packages/myco/src/canopy/parsers/yaml-json.ts
@@ -1,0 +1,8 @@
+import type { CanopyParser } from '../types.js';
+import { fallbackParser } from './fallback.js';
+
+// Real implementation lands in Task A.3.
+export const yamlJsonParser: CanopyParser = (input) => ({
+  ...fallbackParser(input),
+  language: input.path.endsWith('.json') ? 'json' : 'yaml',
+});

--- a/packages/myco/src/canopy/parsers/yaml-json.ts
+++ b/packages/myco/src/canopy/parsers/yaml-json.ts
@@ -1,8 +1,42 @@
-import type { CanopyParser } from '../types.js';
-import { fallbackParser } from './fallback.js';
+import type { CanopyParser, CanopyParserInput, CanopyParserOutput } from '../types.js';
 
-// Real implementation lands in Task A.3.
-export const yamlJsonParser: CanopyParser = (input) => ({
-  ...fallbackParser(input),
-  language: input.path.endsWith('.json') ? 'json' : 'yaml',
-});
+/**
+ * Mechanical parser for `.yaml` / `.yml` / `.json`.
+ *
+ * For JSON we attempt a real parse and emit object keys as `exports`;
+ * arrays become `[array]` and primitives become `[primitive]` so the row
+ * still has a recognisable shape. For YAML we collect column-zero
+ * `key:` tokens — naïve but stable across the common cases (config files,
+ * package metadata, GitHub Actions workflows).
+ */
+export const yamlJsonParser: CanopyParser = (input: CanopyParserInput): CanopyParserOutput => {
+  const isJson = /\.json$/i.test(input.path);
+  const language = isJson ? 'json' : 'yaml';
+  const exports = isJson ? jsonTopKeys(input.content) : yamlTopKeys(input.content);
+  return { language, exports, imports: [], topComment: null };
+};
+
+function jsonTopKeys(content: string): string[] {
+  try {
+    const parsed = JSON.parse(content);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return Object.keys(parsed);
+    }
+    if (Array.isArray(parsed)) return ['[array]'];
+    return ['[primitive]'];
+  } catch {
+    return [];
+  }
+}
+
+function yamlTopKeys(content: string): string[] {
+  const seen = new Set<string>();
+  for (const raw of content.split(/\r?\n/)) {
+    if (raw.startsWith('---') || raw.startsWith('...')) continue;
+    if (raw.startsWith('#')) continue;
+    // Column-zero `key:` (no leading whitespace, no list dash).
+    const m = raw.match(/^([A-Za-z_][\w.-]*)\s*:(?:\s|$)/);
+    if (m) seen.add(m[1]);
+  }
+  return [...seen];
+}

--- a/packages/myco/src/canopy/scanner/delta-scan.ts
+++ b/packages/myco/src/canopy/scanner/delta-scan.ts
@@ -1,0 +1,99 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createExcludeMatcher } from '../exclude.js';
+import { walkProject } from './walk.js';
+import { scanFile, DEFAULT_MAX_FILE_BYTES } from './scan-file.js';
+import {
+  upsertCanopyEntry,
+  deleteMissingEntries,
+  listExistingHashes,
+} from './upsert.js';
+import { epochSeconds } from '@myco/constants.js';
+import type { Database } from 'bun:sqlite';
+import type { CanopyScanResult } from '../types.js';
+
+export interface DeltaScanOptions {
+  db: Database;
+  projectId: string;
+  machineId: string;
+  projectRoot: string;
+  excludePatterns: string[];
+  maxBytes?: number;
+}
+
+/**
+ * Incremental scan: walk every file but skip the parse/hash step when the
+ * stored size matches the current stat. This is the cheap path used by
+ * SessionStart and the periodic background job — typical idle repos finish
+ * in well under a second after the initial populate.
+ *
+ * Trade-off: relying on size as a same-content shortcut can miss content
+ * changes that happen to preserve byte length. The next full scan
+ * (`scan-project`) reconciles those rare cases; the periodic background
+ * scan can also be configured to run a full pass occasionally.
+ */
+export function deltaScan(opts: DeltaScanOptions): CanopyScanResult {
+  const start = Date.now();
+  const now = epochSeconds();
+  const isExcluded = createExcludeMatcher(opts.excludePatterns);
+  const existing = listExistingHashes(opts.db, opts.projectId);
+  const visited = new Set<string>();
+  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_FILE_BYTES;
+
+  let scanned = 0;
+  let added = 0;
+  let updated = 0;
+  let errored = 0;
+
+  for (const relPath of walkProject({ projectRoot: opts.projectRoot, isExcluded })) {
+    scanned++;
+    const prior = existing.get(relPath);
+
+    if (prior) {
+      // Cheap stat check: same size means same content with overwhelming
+      // probability and matches what `git status` does at the same step.
+      try {
+        const stat = fs.statSync(path.join(opts.projectRoot, relPath));
+        if (stat.size === prior.size_bytes && stat.size <= maxBytes) {
+          visited.add(relPath);
+          continue;
+        }
+      } catch {
+        errored++;
+        continue;
+      }
+    }
+
+    const result = scanFile({
+      projectId: opts.projectId,
+      machineId: opts.machineId,
+      projectRoot: opts.projectRoot,
+      relPath,
+      now,
+      maxBytes,
+    });
+    if (!result.ok) {
+      if (result.reason === 'read_error') errored++;
+      continue;
+    }
+    visited.add(relPath);
+    if (prior && result.entry.content_hash === prior.content_hash) {
+      // Bytes changed but hash matches (rare — e.g. mtime touch); skip the
+      // upsert so `mechanical_updated_at` isn't churned uselessly.
+      continue;
+    }
+    upsertCanopyEntry(opts.db, result.entry);
+    if (prior) updated++;
+    else added++;
+  }
+
+  const removed = deleteMissingEntries(opts.db, opts.projectId, visited);
+  return {
+    scanned,
+    added,
+    updated,
+    removed,
+    errored,
+    durationMs: Date.now() - start,
+  };
+}

--- a/packages/myco/src/canopy/scanner/handle-tool-use.ts
+++ b/packages/myco/src/canopy/scanner/handle-tool-use.ts
@@ -1,0 +1,73 @@
+import { rescanSingle } from './rescan-single.js';
+import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+import type { Database } from 'bun:sqlite';
+import type { DaemonLogger } from '../../daemon/logger.js';
+
+/**
+ * Tool names whose tool_use events warrant a single-file rescan. Kept in
+ * sync with the symbiont-adapter file-mutation vocabulary so a new tool
+ * (e.g. `MultiEdit`) can join the list in one place.
+ */
+const FILE_MUTATING_TOOLS: ReadonlySet<string> = new Set([
+  'Write',
+  'Edit',
+  'MultiEdit',
+  'NotebookEdit',
+]);
+
+export interface HandleToolUseOptions {
+  db: Database;
+  logger: DaemonLogger;
+  machineId: string;
+  projectRoot: string;
+  projectId: string;
+  toolName: string;
+  toolInput: unknown;
+}
+
+/**
+ * Bridge from the daemon's `tool_use` event dispatcher into the canopy
+ * scanner. Synchronous and best-effort: any failure is logged at warn and
+ * swallowed so capture-pipeline traffic is never blocked by canopy.
+ */
+export function handleCanopyToolUse(opts: HandleToolUseOptions): void {
+  if (!FILE_MUTATING_TOOLS.has(opts.toolName)) return;
+  const filePath = extractPath(opts.toolInput);
+  if (!filePath) return;
+  try {
+    const result = rescanSingle({
+      db: opts.db,
+      projectId: opts.projectId,
+      machineId: opts.machineId,
+      projectRoot: opts.projectRoot,
+      filePath,
+    });
+    if (result.ok) {
+      opts.logger.debug(LOG_KINDS.CANOPY_RESCAN, 'Canopy single-file rescan', {
+        action: result.action,
+        path: result.relPath,
+        tool: opts.toolName,
+      });
+    }
+  } catch (err) {
+    opts.logger.warn(LOG_KINDS.CANOPY_ERROR, 'Canopy rescan failed', {
+      error: (err as Error).message,
+      tool: opts.toolName,
+      path: filePath,
+    });
+  }
+}
+
+function extractPath(toolInput: unknown): string | null {
+  if (!toolInput || typeof toolInput !== 'object') return null;
+  const o = toolInput as Record<string, unknown>;
+  // Claude Code variants — normalised across Read/Write/Edit toolschemas.
+  for (const key of ['file_path', 'path', 'filePath', 'notebook_path']) {
+    const v = o[key];
+    if (typeof v === 'string' && v.length > 0) return v;
+  }
+  return null;
+}
+
+/** Exported for tests that want to assert the trigger list contents. */
+export const FILE_MUTATING_TOOLS_LIST: readonly string[] = [...FILE_MUTATING_TOOLS];

--- a/packages/myco/src/canopy/scanner/rescan-single.ts
+++ b/packages/myco/src/canopy/scanner/rescan-single.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { scanFile } from './scan-file.js';
+import { upsertCanopyEntry, deleteCanopyEntry } from './upsert.js';
+import { epochSeconds } from '@myco/constants.js';
+import type { Database } from 'bun:sqlite';
+
+export interface RescanSingleOptions {
+  db: Database;
+  projectId: string;
+  machineId: string;
+  projectRoot: string;
+  /** Repo-relative or absolute path; absolute is normalised against projectRoot. */
+  filePath: string;
+  maxBytes?: number;
+}
+
+export type RescanSingleResult =
+  | { ok: true; action: 'upserted' | 'deleted'; relPath: string }
+  | { ok: false; reason: 'outside_project' | 'skipped'; relPath: string };
+
+/**
+ * Re-scan a single file in response to a Write/Edit/Delete tool event.
+ * Cheap and idempotent — one stat, at most one read, one upsert. The path
+ * is normalised against the project root so absolute paths from tool inputs
+ * resolve identically to relative ones, and paths outside the project are
+ * rejected so we never index files we don't own.
+ */
+export function rescanSingle(opts: RescanSingleOptions): RescanSingleResult {
+  const rel = relativise(opts.projectRoot, opts.filePath);
+  if (rel === null) return { ok: false, reason: 'outside_project', relPath: opts.filePath };
+
+  if (!fs.existsSync(path.join(opts.projectRoot, rel))) {
+    deleteCanopyEntry(opts.db, opts.projectId, rel);
+    return { ok: true, action: 'deleted', relPath: rel };
+  }
+
+  const result = scanFile({
+    projectId: opts.projectId,
+    machineId: opts.machineId,
+    projectRoot: opts.projectRoot,
+    relPath: rel,
+    now: epochSeconds(),
+    maxBytes: opts.maxBytes,
+  });
+  if (!result.ok) return { ok: false, reason: 'skipped', relPath: rel };
+
+  upsertCanopyEntry(opts.db, result.entry);
+  return { ok: true, action: 'upserted', relPath: rel };
+}
+
+function relativise(projectRoot: string, filePath: string): string | null {
+  const abs = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(projectRoot, filePath);
+  const rootAbs = path.resolve(projectRoot);
+  const rel = path.relative(rootAbs, abs);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
+  return rel.split(path.sep).join('/');
+}

--- a/packages/myco/src/canopy/scanner/scan-file.ts
+++ b/packages/myco/src/canopy/scanner/scan-file.ts
@@ -1,0 +1,113 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { sha256Hex } from '../hash.js';
+import { estimateTokens } from '@myco/constants.js';
+import { parserFor } from '../parsers/registry.js';
+import type { CanopyEntry } from '../../db/schema.js';
+
+/** Files larger than this are skipped (mechanical heuristic). */
+export const DEFAULT_MAX_FILE_BYTES = 2 * 1024 * 1024; // 2 MiB
+
+/** Bytes inspected for the binary-content sniff. */
+const BINARY_SNIFF_BYTES = 8 * 1024;
+
+/** Reason a file was rejected; null when scanFile produced an entry. */
+export type ScanRejection = 'too_large' | 'binary' | 'symlink' | 'missing' | 'read_error';
+
+export interface ScanFileOptions {
+  projectId: string;
+  machineId: string;
+  projectRoot: string;
+  /** Repo-relative, forward-slash. */
+  relPath: string;
+  now: number; // epoch seconds
+  maxBytes?: number;
+}
+
+export interface ScanFileSuccess {
+  ok: true;
+  entry: CanopyEntry;
+}
+
+export interface ScanFileSkip {
+  ok: false;
+  reason: ScanRejection;
+}
+
+export type ScanFileResult = ScanFileSuccess | ScanFileSkip;
+
+/**
+ * Read one file and produce a CanopyEntry — pure aside from the read.
+ * Skips binary content, symlinks, and files exceeding `maxBytes`.
+ */
+export function scanFile(opts: ScanFileOptions): ScanFileResult {
+  const abs = path.join(opts.projectRoot, opts.relPath);
+  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_FILE_BYTES;
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(abs);
+  } catch {
+    return { ok: false, reason: 'missing' };
+  }
+  if (stat.isSymbolicLink()) return { ok: false, reason: 'symlink' };
+  if (!stat.isFile()) return { ok: false, reason: 'missing' };
+  if (stat.size > maxBytes) return { ok: false, reason: 'too_large' };
+
+  let buf: Buffer;
+  try {
+    buf = fs.readFileSync(abs);
+  } catch {
+    return { ok: false, reason: 'read_error' };
+  }
+  if (looksBinary(buf)) return { ok: false, reason: 'binary' };
+
+  const content = buf.toString('utf8');
+  const lineCount = countLines(content);
+  const parser = parserFor(opts.relPath);
+  const parsed = parser({
+    path: opts.relPath,
+    content,
+    sizeBytes: buf.length,
+    lineCount,
+  });
+
+  const entry: CanopyEntry = {
+    project_id: opts.projectId,
+    machine_id: opts.machineId,
+    path: opts.relPath,
+    content_hash: sha256Hex(buf),
+    size_bytes: buf.length,
+    token_estimate: estimateTokens(content),
+    line_count: lineCount,
+    language: parsed.language,
+    exports_json: parsed.exports.length > 0 ? JSON.stringify(parsed.exports) : null,
+    imports_json: parsed.imports.length > 0 ? JSON.stringify(parsed.imports) : null,
+    top_comment: parsed.topComment,
+    mechanical_updated_at: opts.now,
+    llm_description: null,
+    llm_updated_at: null,
+  };
+
+  return { ok: true, entry };
+}
+
+/** A NUL byte in the leading prefix is a robust binary signal. */
+function looksBinary(buf: Buffer): boolean {
+  const len = Math.min(buf.length, BINARY_SNIFF_BYTES);
+  for (let i = 0; i < len; i++) {
+    if (buf[i] === 0) return true;
+  }
+  return false;
+}
+
+function countLines(content: string): number {
+  if (content.length === 0) return 0;
+  let n = 1;
+  for (let i = 0; i < content.length; i++) {
+    if (content.charCodeAt(i) === 10) n++;
+  }
+  // Trailing newline shouldn't count as an extra blank line.
+  if (content.charCodeAt(content.length - 1) === 10) n--;
+  return n;
+}

--- a/packages/myco/src/canopy/scanner/scan-project.ts
+++ b/packages/myco/src/canopy/scanner/scan-project.ts
@@ -1,0 +1,72 @@
+import { createExcludeMatcher } from '../exclude.js';
+import { walkProject } from './walk.js';
+import { scanFile, DEFAULT_MAX_FILE_BYTES } from './scan-file.js';
+import { upsertCanopyEntry, deleteMissingEntries } from './upsert.js';
+import { epochSeconds } from '@myco/constants.js';
+import type { Database } from 'bun:sqlite';
+import type { CanopyScanResult } from '../types.js';
+
+export interface ScanProjectOptions {
+  db: Database;
+  projectId: string;
+  machineId: string;
+  projectRoot: string;
+  excludePatterns: string[];
+  maxBytes?: number;
+}
+
+/**
+ * Full project scan: walk every non-excluded file, parse and upsert each
+ * row, then tombstone rows whose paths no longer exist on disk. Deterministic
+ * given identical input — `now` is sampled once at entry.
+ */
+export function scanProject(opts: ScanProjectOptions): CanopyScanResult {
+  const start = Date.now();
+  const now = epochSeconds();
+  const isExcluded = createExcludeMatcher(opts.excludePatterns);
+  const visited = new Set<string>();
+  let scanned = 0;
+  let added = 0; // populated below from changes-tracking
+  let updated = 0;
+  let errored = 0;
+
+  // To distinguish add from update without an extra SELECT per row, sample
+  // existing paths once up-front. The cost is one bounded query at start;
+  // every subsequent decision is an O(1) Set check.
+  const existing = new Set<string>(
+    (opts.db.prepare(
+      'SELECT path FROM canopy_entries WHERE project_id = ?',
+    ).all(opts.projectId) as { path: string }[]).map((r) => r.path),
+  );
+
+  for (const relPath of walkProject({ projectRoot: opts.projectRoot, isExcluded })) {
+    scanned++;
+    const result = scanFile({
+      projectId: opts.projectId,
+      machineId: opts.machineId,
+      projectRoot: opts.projectRoot,
+      relPath,
+      now,
+      maxBytes: opts.maxBytes ?? DEFAULT_MAX_FILE_BYTES,
+    });
+    if (!result.ok) {
+      // Skips for binary/too-large/symlink are expected and not errors.
+      if (result.reason === 'read_error') errored++;
+      continue;
+    }
+    visited.add(relPath);
+    upsertCanopyEntry(opts.db, result.entry);
+    if (existing.has(relPath)) updated++;
+    else added++;
+  }
+
+  const removed = deleteMissingEntries(opts.db, opts.projectId, visited);
+  return {
+    scanned,
+    added,
+    updated,
+    removed,
+    errored,
+    durationMs: Date.now() - start,
+  };
+}

--- a/packages/myco/src/canopy/scanner/upsert.ts
+++ b/packages/myco/src/canopy/scanner/upsert.ts
@@ -1,0 +1,111 @@
+import type { Database } from 'bun:sqlite';
+import type { CanopyEntry } from '../../db/schema.js';
+
+const COLUMNS = [
+  'project_id',
+  'machine_id',
+  'path',
+  'content_hash',
+  'size_bytes',
+  'token_estimate',
+  'line_count',
+  'language',
+  'exports_json',
+  'imports_json',
+  'top_comment',
+  'mechanical_updated_at',
+  'llm_description',
+  'llm_updated_at',
+] as const;
+
+const PLACEHOLDERS = COLUMNS.map(() => '?').join(', ');
+const COL_LIST = COLUMNS.join(', ');
+
+/**
+ * Upsert a single CanopyEntry. Mechanical columns overwrite on conflict.
+ * `llm_description` and `llm_updated_at` are deliberately untouched here so
+ * a Tier 2 description survives subsequent mechanical rescans; the
+ * `canopy-describe` task is the only writer of those columns.
+ */
+export function upsertCanopyEntry(db: Database, entry: CanopyEntry): void {
+  db.prepare(
+    `INSERT INTO canopy_entries (${COL_LIST})
+     VALUES (${PLACEHOLDERS})
+     ON CONFLICT (project_id, path) DO UPDATE SET
+       machine_id            = EXCLUDED.machine_id,
+       content_hash          = EXCLUDED.content_hash,
+       size_bytes            = EXCLUDED.size_bytes,
+       token_estimate        = EXCLUDED.token_estimate,
+       line_count            = EXCLUDED.line_count,
+       language              = EXCLUDED.language,
+       exports_json          = EXCLUDED.exports_json,
+       imports_json          = EXCLUDED.imports_json,
+       top_comment           = EXCLUDED.top_comment,
+       mechanical_updated_at = EXCLUDED.mechanical_updated_at`,
+  ).run(
+    entry.project_id,
+    entry.machine_id,
+    entry.path,
+    entry.content_hash,
+    entry.size_bytes,
+    entry.token_estimate,
+    entry.line_count,
+    entry.language,
+    entry.exports_json,
+    entry.imports_json,
+    entry.top_comment,
+    entry.mechanical_updated_at,
+    entry.llm_description,
+    entry.llm_updated_at,
+  );
+}
+
+/**
+ * Delete rows whose path is not in the provided set, scoped by project.
+ * Used by the full scan to tombstone files removed since the last walk. The
+ * MVP deletes outright (per plan); a soft-delete column can be added later
+ * if a downstream consumer needs lineage.
+ */
+export function deleteMissingEntries(
+  db: Database,
+  projectId: string,
+  visitedPaths: ReadonlySet<string>,
+): number {
+  if (visitedPaths.size === 0) {
+    return db.prepare('DELETE FROM canopy_entries WHERE project_id = ?').run(projectId).changes;
+  }
+  db.exec('DROP TABLE IF EXISTS _canopy_visited');
+  db.exec('CREATE TEMP TABLE _canopy_visited (path TEXT PRIMARY KEY)');
+  const insert = db.prepare('INSERT OR IGNORE INTO _canopy_visited (path) VALUES (?)');
+  for (const p of visitedPaths) insert.run(p);
+  const info = db.prepare(
+    `DELETE FROM canopy_entries
+       WHERE project_id = ?
+         AND path NOT IN (SELECT path FROM _canopy_visited)`,
+  ).run(projectId);
+  db.exec('DROP TABLE IF EXISTS _canopy_visited');
+  return info.changes;
+}
+
+export interface ExistingHashRow {
+  path: string;
+  content_hash: string;
+  size_bytes: number;
+}
+
+/** Snapshot of project rows used by the delta scan to skip unchanged files. */
+export function listExistingHashes(db: Database, projectId: string): Map<string, ExistingHashRow> {
+  const rows = db.prepare(
+    'SELECT path, content_hash, size_bytes FROM canopy_entries WHERE project_id = ?',
+  ).all(projectId) as ExistingHashRow[];
+  const out = new Map<string, ExistingHashRow>();
+  for (const r of rows) out.set(r.path, r);
+  return out;
+}
+
+/** Delete a single row by (project_id, path). Used by rescan-single on file removal. */
+export function deleteCanopyEntry(db: Database, projectId: string, relPath: string): number {
+  return db.prepare(
+    'DELETE FROM canopy_entries WHERE project_id = ? AND path = ?',
+  ).run(projectId, relPath).changes;
+}

--- a/packages/myco/src/canopy/scanner/walk.ts
+++ b/packages/myco/src/canopy/scanner/walk.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface WalkOptions {
+  /** Absolute path to walk. */
+  projectRoot: string;
+  /** Returns true when a relative path should be excluded. Compiled once per scan. */
+  isExcluded: (relPath: string) => boolean;
+}
+
+/**
+ * Recursive file walk yielding repo-relative, forward-slash paths.
+ *
+ * Both directory and file paths are tested against `isExcluded`; excluded
+ * directories prune the walk so we never descend into `node_modules` etc.
+ * Symlinks are skipped silently. Filesystem errors on a single entry are
+ * swallowed so one missing or unreadable directory doesn't fail the whole
+ * scan; the caller logs in aggregate.
+ */
+export function* walkProject(opts: WalkOptions): Generator<string> {
+  const stack: string[] = ['']; // empty string represents projectRoot itself
+  while (stack.length > 0) {
+    const relDir = stack.pop()!;
+    const absDir = relDir === '' ? opts.projectRoot : path.join(opts.projectRoot, relDir);
+
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(absDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const e of entries) {
+      const relChild = relDir === '' ? e.name : `${relDir}/${e.name}`;
+      // Symlinks are skipped without inspecting their target.
+      if (e.isSymbolicLink()) continue;
+
+      if (e.isDirectory()) {
+        if (opts.isExcluded(relChild)) continue;
+        stack.push(relChild);
+        continue;
+      }
+      if (!e.isFile()) continue;
+      if (opts.isExcluded(relChild)) continue;
+      yield relChild;
+    }
+  }
+}

--- a/packages/myco/src/constants/log-kinds.ts
+++ b/packages/myco/src/constants/log-kinds.ts
@@ -88,6 +88,11 @@ export const LOG_KINDS = {
   MAINTENANCE_EMBEDDING: 'maintenance.embedding',
   MAINTENANCE_STAGING_GC: 'maintenance.staging-gc',
 
+  // Canopy code intelligence
+  CANOPY_SCAN: 'canopy.scan',
+  CANOPY_RESCAN: 'canopy.rescan',
+  CANOPY_ERROR: 'canopy.error',
+
   // API operations
   API_SESSION_DELETE: 'api.session-delete',
   API_SESSION_COMPLETE: 'api.session-complete',

--- a/packages/myco/src/daemon/api/session-lifecycle.ts
+++ b/packages/myco/src/daemon/api/session-lifecycle.ts
@@ -54,6 +54,13 @@ export interface SessionLifecycleDeps {
   // respect the change without a daemon restart.
   liveConfig: { current: MycoConfig };
   vaultDir: string;
+  /**
+   * Holder for the canopy delta runner. Populated after register-power-jobs
+   * has run; the register handler triggers a fire-and-forget delta scan on
+   * each SessionStart so the index stays current with on-disk changes that
+   * happened between sessions.
+   */
+  canopyDelta?: { run: () => Promise<void> };
 }
 
 // ---------------------------------------------------------------------------
@@ -73,6 +80,9 @@ export function createSessionLifecycleHandlers(deps: SessionLifecycleDeps) {
     liveConfig,
     vaultDir,
   } = deps;
+  // Read through `deps` on every register call so the holder set after
+  // registerPowerJobs becomes visible to subsequent SessionStart events.
+  const canopyDeltaHolder = (): { run: () => Promise<void> } | undefined => deps.canopyDelta;
 
   /** POST /sessions/register */
   async function handleRegister(req: { body: unknown }): Promise<RouteResponse> {
@@ -112,6 +122,17 @@ export function createSessionLifecycleHandlers(deps: SessionLifecycleDeps) {
       link: `/sessions/${session_id}`,
       metadata: { sessionId: session_id, agent: agent ?? 'claude-code', branch },
     }, liveConfig.current);
+
+    // Fire-and-forget canopy delta refresh. The runner debounces internally,
+    // so multiple registers (re-attaches, fast switches) collapse cleanly.
+    const delta = canopyDeltaHolder();
+    if (delta) {
+      delta.run().catch((err) => {
+        logger.warn(LOG_KINDS.LIFECYCLE_REGISTER, 'Canopy delta scan failed on register', {
+          error: (err as Error).message,
+        });
+      });
+    }
 
     return { body: { ok: true, sessions: registry.sessions } };
   }

--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -33,6 +33,8 @@ import {
   handleTaskCompleted,
   handleCompact,
 } from './event-handlers.js';
+import { handleCanopyToolUse } from '@myco/canopy/scanner/handle-tool-use.js';
+import { getDatabase } from '@myco/db/client.js';
 import { getLatestBatch } from '@myco/db/queries/batches.js';
 import { getSession, upsertSession, reactivateSessionIfCompleted } from '@myco/db/queries/sessions.js';
 import { captureBatchImages, type CapturedImage } from './capture-images.js';
@@ -358,6 +360,18 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
       } catch (err) {
         logger.warn(LOG_KINDS.CAPTURE_ACTIVITY, 'Failed to record activity', { session_id: event.session_id, error: (err as Error).message });
       }
+      // Canopy: rescan the touched file synchronously after activity capture.
+      // Best-effort; handleCanopyToolUse swallows its own errors so the
+      // capture pipeline is never blocked.
+      handleCanopyToolUse({
+        db: getDatabase(),
+        logger,
+        machineId,
+        projectRoot,
+        projectId: projectRoot,
+        toolName,
+        toolInput: event.tool_input,
+      });
     }
 
     if (event.type === 'tool_failure') {

--- a/packages/myco/src/daemon/jobs/canopy-background-scan.ts
+++ b/packages/myco/src/daemon/jobs/canopy-background-scan.ts
@@ -1,0 +1,69 @@
+import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+import { MS_PER_SECOND } from '@myco/constants.js';
+import type { CanopyDeltaScanRunner } from './canopy-delta-scan.js';
+import type { MycoConfig } from '@myco/config/schema.js';
+import type { DaemonLogger } from '../logger.js';
+
+const SECONDS_PER_MINUTE = 60;
+const SECONDS_PER_HOUR = 3600;
+const SECONDS_PER_DAY = 86_400;
+
+export interface BackgroundScanContext {
+  liveConfig: { current: MycoConfig };
+  delta: CanopyDeltaScanRunner;
+  logger: DaemonLogger;
+}
+
+/**
+ * Periodic background driver: every PowerManager tick checks whether the
+ * configured background period has elapsed since the last delta run, and
+ * triggers one if so. The delta runner already debounces, so even if this
+ * fires too eagerly the actual scan is gated.
+ */
+export class CanopyBackgroundScan {
+  private lastDispatchedAt = Number.NEGATIVE_INFINITY;
+
+  constructor(private readonly ctx: BackgroundScanContext) {}
+
+  /** PowerManager job entry point. */
+  async tick(): Promise<void> {
+    const cfg = this.ctx.liveConfig.current.canopy.refresh;
+    if (!cfg.background_enabled) return;
+    const periodSeconds = parseDuration(cfg.background_period);
+    if (periodSeconds <= 0) return;
+    const now = Date.now();
+    if (now - this.lastDispatchedAt < periodSeconds * MS_PER_SECOND) return;
+    this.lastDispatchedAt = now;
+    try {
+      await this.ctx.delta.run(now);
+    } catch (err) {
+      this.ctx.logger.error(LOG_KINDS.CANOPY_ERROR, 'Canopy background scan dispatch failed', {
+        error: (err as Error).message,
+      });
+    }
+  }
+}
+
+/**
+ * Parse a humanised duration of the form `<n><unit>` where unit is one of
+ * `s | m | h | d`. Falls back to seconds when no unit is present. Returns 0
+ * for inputs that fail to parse so callers can treat that as "disabled."
+ */
+export function parseDuration(input: string): number {
+  const m = input.trim().match(/^(\d+(?:\.\d+)?)\s*([smhd]?)$/i);
+  if (!m) return 0;
+  const value = Number.parseFloat(m[1]);
+  if (!Number.isFinite(value) || value < 0) return 0;
+  switch (m[2].toLowerCase()) {
+    case 'm':
+      return Math.round(value * SECONDS_PER_MINUTE);
+    case 'h':
+      return Math.round(value * SECONDS_PER_HOUR);
+    case 'd':
+      return Math.round(value * SECONDS_PER_DAY);
+    case 's':
+    case '':
+    default:
+      return Math.round(value);
+  }
+}

--- a/packages/myco/src/daemon/jobs/canopy-delta-scan.ts
+++ b/packages/myco/src/daemon/jobs/canopy-delta-scan.ts
@@ -1,0 +1,59 @@
+import { deltaScan } from '@myco/canopy/scanner/delta-scan.js';
+import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+import type { CanopyJobContext } from './canopy-scan.js';
+
+/** Coalesce delta-scan triggers fired within this window into one run. */
+export const CANOPY_DELTA_DEBOUNCE_MS = 30_000;
+
+/**
+ * Process-local debouncer for the delta scan. Multiple session-start hooks
+ * landing within 30 s collapse to a single walk; the unused triggers are
+ * dropped silently because the work they would do has already been done.
+ */
+export class CanopyDeltaScanRunner {
+  // Sentinel so the first call always proceeds regardless of injected clock.
+  private lastRunAt = Number.NEGATIVE_INFINITY;
+  private inFlight: Promise<void> | null = null;
+
+  constructor(private readonly ctx: CanopyJobContext) {}
+
+  /**
+   * Run a delta scan unless one ran within the debounce window or one is
+   * already in flight. Both gates are necessary: the time gate handles the
+   * "two session-start hooks back-to-back" case; the in-flight gate handles
+   * the "background tick fires while session-start is still running" case.
+   *
+   * The supplied `now` is also used to stamp `lastRunAt` so a single
+   * monotonic clock source drives both reads and writes — important for
+   * tests that inject a deterministic clock.
+   */
+  async run(now: number = Date.now()): Promise<void> {
+    if (this.inFlight) return this.inFlight;
+    if (now - this.lastRunAt < CANOPY_DELTA_DEBOUNCE_MS) return;
+    this.inFlight = this.execute().finally(() => {
+      this.lastRunAt = now;
+      this.inFlight = null;
+    });
+    return this.inFlight;
+  }
+
+  private async execute(): Promise<void> {
+    const patterns = this.ctx.liveConfig.current.canopy.exclude.patterns;
+    try {
+      const result = deltaScan({
+        db: this.ctx.db,
+        projectId: this.ctx.projectId,
+        machineId: this.ctx.machineId,
+        projectRoot: this.ctx.projectRoot,
+        excludePatterns: patterns,
+      });
+      this.ctx.logger.info(LOG_KINDS.CANOPY_SCAN, 'Canopy delta scan complete', {
+        ...result,
+      });
+    } catch (err) {
+      this.ctx.logger.error(LOG_KINDS.CANOPY_ERROR, 'Canopy delta scan failed', {
+        error: (err as Error).message,
+      });
+    }
+  }
+}

--- a/packages/myco/src/daemon/jobs/canopy-scan.ts
+++ b/packages/myco/src/daemon/jobs/canopy-scan.ts
@@ -1,0 +1,80 @@
+import type { Database } from 'bun:sqlite';
+import type { DaemonLogger } from '../logger.js';
+import type { MycoConfig } from '@myco/config/schema.js';
+import type { PowerManager } from '../power.js';
+import { scanProject } from '@myco/canopy/scanner/scan-project.js';
+import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+import { CanopyDeltaScanRunner } from './canopy-delta-scan.js';
+import { CanopyBackgroundScan } from './canopy-background-scan.js';
+
+export interface CanopyJobContext {
+  db: Database;
+  logger: DaemonLogger;
+  machineId: string;
+  projectRoot: string;
+  /** Stable identifier for the canopy project_id column. */
+  projectId: string;
+  liveConfig: { current: MycoConfig };
+}
+
+/**
+ * One-shot full project scan. Used for initial populate on first daemon boot
+ * after the feature lands and as a manual rescue if the index drifts. Logs
+ * the result; the caller decides whether to retry.
+ */
+export interface CanopyJobsRegistration {
+  /** The shared delta runner — also exposed so the SessionStart hook bridge can trigger it. */
+  delta: CanopyDeltaScanRunner;
+  /** Manual full-scan trigger (used for the initial populate after first install). */
+  runFullScan: () => Promise<void>;
+}
+
+/**
+ * Register the three canopy jobs with PowerManager and return handles for
+ * the SessionStart bridge and the initial-populate path.
+ */
+export function registerCanopyJobs(
+  powerManager: PowerManager,
+  ctx: CanopyJobContext,
+): CanopyJobsRegistration {
+  const delta = new CanopyDeltaScanRunner(ctx);
+  const background = new CanopyBackgroundScan({
+    liveConfig: ctx.liveConfig,
+    delta,
+    logger: ctx.logger,
+  });
+
+  // Background driver: runs whenever PowerManager ticks in any non-deep state.
+  // The driver itself enforces the configured period; PowerManager just
+  // gives it a heartbeat.
+  powerManager.register({
+    name: 'canopy-background-scan',
+    runIn: ['active', 'idle', 'sleep'],
+    fn: () => background.tick(),
+  });
+
+  return {
+    delta,
+    runFullScan: () => runCanopyScan(ctx),
+  };
+}
+
+export async function runCanopyScan(ctx: CanopyJobContext): Promise<void> {
+  const patterns = ctx.liveConfig.current.canopy.exclude.patterns;
+  try {
+    const result = scanProject({
+      db: ctx.db,
+      projectId: ctx.projectId,
+      machineId: ctx.machineId,
+      projectRoot: ctx.projectRoot,
+      excludePatterns: patterns,
+    });
+    ctx.logger.info(LOG_KINDS.CANOPY_SCAN, 'Canopy full scan complete', {
+      ...result,
+    });
+  } catch (err) {
+    ctx.logger.error(LOG_KINDS.CANOPY_ERROR, 'Canopy full scan failed', {
+      error: (err as Error).message,
+    });
+  }
+}

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -614,10 +614,13 @@ export async function main(): Promise<void> {
   });
 
   // --- Session routes ---
-  const sessionLifecycle = createSessionLifecycleHandlers({
+  // The deps object is mutated after registerPowerJobs so the canopy delta
+  // runner becomes visible to SessionStart triggers.
+  const sessionLifecycleDeps = {
     registry, sessionBuffers, reconciler, stopProcessor,
     server, powerManager, machineId, logger, liveConfig, vaultDir,
-  });
+  };
+  const sessionLifecycle = createSessionLifecycleHandlers(sessionLifecycleDeps);
   server.registerRoute('POST', '/sessions/register', sessionLifecycle.handleRegister);
   server.registerRoute('POST', '/sessions/unregister', sessionLifecycle.handleUnregister);
 
@@ -1090,7 +1093,7 @@ export async function main(): Promise<void> {
   });
 
   // --- Register power-managed jobs ---
-  registerPowerJobs(powerManager, {
+  const powerJobs = registerPowerJobs(powerManager, {
     embeddingManager,
     registry,
     logger,
@@ -1098,9 +1101,23 @@ export async function main(): Promise<void> {
     db,
     machineId,
     vaultDir,
+    projectRoot,
     databaseManager,
   });
   teamSync.registerFlushJob(powerManager);
+
+  // Wire the canopy delta runner into the session-register path so each
+  // SessionStart triggers a fire-and-forget refresh. The runner debounces.
+  (sessionLifecycleDeps as { canopyDelta?: { run: () => Promise<void> } }).canopyDelta = powerJobs.canopy.delta;
+
+  // Initial canopy populate runs in the background — does not block boot.
+  // The delta scan handles steady-state refresh; this fire-and-forget call
+  // covers the first run on a fresh install where the table is empty.
+  powerJobs.canopy.runFullScan().catch((err) => {
+    logger.warn(LOG_KINDS.CANOPY_ERROR, 'Initial canopy populate failed', {
+      error: (err as Error).message,
+    });
+  });
 
   // -- Dynamic task scheduling --
   await registerScheduledTasks(powerManager, {

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -14,6 +14,7 @@ import type { SessionRegistry } from './lifecycle.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import type { DatabaseMaintenanceManager } from './database/manager.js';
 import { runSessionMaintenance } from './jobs/session-maintenance.js';
+import { registerCanopyJobs, type CanopyJobsRegistration } from './jobs/canopy-scan.js';
 import { createBackup } from './backup.js';
 import { resolveBackupDir } from './api/backup.js';
 import { deleteOldLogs } from '@myco/db/queries/logs.js';
@@ -45,15 +46,22 @@ export interface PowerJobDeps {
   db: Database;
   machineId: string;
   vaultDir: string;
+  /** Repo root used for canopy scans and any project-rooted job. */
+  projectRoot: string;
   databaseManager: DatabaseMaintenanceManager;
+}
+
+export interface PowerJobsResult {
+  /** Handles for jobs whose runtime is exposed beyond PowerManager (e.g. delta scan from SessionStart). */
+  canopy: CanopyJobsRegistration;
 }
 
 // ---------------------------------------------------------------------------
 // Registration
 // ---------------------------------------------------------------------------
 
-export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps): void {
-  const { embeddingManager, registry, logger, liveConfig, db, machineId, vaultDir, databaseManager } = deps;
+export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps): PowerJobsResult {
+  const { embeddingManager, registry, logger, liveConfig, db, machineId, vaultDir, projectRoot, databaseManager } = deps;
 
   let reconcileRunning = false;
   powerManager.register({
@@ -152,4 +160,18 @@ export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps
       });
     },
   });
+
+  // Canopy code intelligence: project_id is the absolute project root —
+  // stable on this machine, no extra plumbing required for the local-only
+  // table.
+  const canopy = registerCanopyJobs(powerManager, {
+    db,
+    logger,
+    machineId,
+    projectRoot,
+    projectId: projectRoot,
+    liveConfig,
+  });
+
+  return { canopy };
 }

--- a/tests/canopy/parsers/fallback.test.ts
+++ b/tests/canopy/parsers/fallback.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'bun:test';
+import { fallbackParser } from '@myco/canopy/parsers/fallback';
+
+function input(content: string, path = 'unknown.bin') {
+  return { path, content, sizeBytes: Buffer.byteLength(content), lineCount: content.split(/\r?\n/).length };
+}
+
+describe('fallbackParser', () => {
+  it('returns null language and empty exports/imports', () => {
+    const out = fallbackParser(input('hello'));
+    expect(out.language).toBeNull();
+    expect(out.exports).toEqual([]);
+    expect(out.imports).toEqual([]);
+  });
+
+  it('uses the first non-empty line as topComment, trimmed', () => {
+    const out = fallbackParser(input('\n\n   first line   \nsecond\n'));
+    expect(out.topComment).toBe('first line');
+  });
+
+  it('truncates very long first lines to 200 chars', () => {
+    const long = 'x'.repeat(500);
+    const out = fallbackParser(input(long));
+    expect(out.topComment?.length).toBe(200);
+  });
+
+  it('returns null topComment for entirely empty content', () => {
+    const out = fallbackParser(input(''));
+    expect(out.topComment).toBeNull();
+  });
+});

--- a/tests/canopy/parsers/markdown.test.ts
+++ b/tests/canopy/parsers/markdown.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'bun:test';
+import { markdownParser } from '@myco/canopy/parsers/markdown';
+
+function input(content: string, path = 'README.md') {
+  return { path, content, sizeBytes: Buffer.byteLength(content), lineCount: content.split(/\r?\n/).length };
+}
+
+describe('markdownParser', () => {
+  it('uses the first H1 as topComment', () => {
+    const out = markdownParser(input(`# Hello world\n\nbody\n## sub\n## sub2\n`));
+    expect(out.language).toBe('markdown');
+    expect(out.topComment).toContain('Hello world');
+    expect(out.topComment).toContain('h2:2');
+  });
+
+  it('falls back to the first non-empty line when there is no H1', () => {
+    const out = markdownParser(input(`\n\nplain first line\n## sub\n`));
+    expect(out.topComment).toContain('plain first line');
+  });
+
+  it('returns no exports or imports', () => {
+    const out = markdownParser(input(`# a\n\n## b\n`));
+    expect(out.exports).toEqual([]);
+    expect(out.imports).toEqual([]);
+  });
+
+  it('omits the heading-count suffix when only an H1 is present', () => {
+    const out = markdownParser(input(`# Solo\n\ntext only\n`));
+    expect(out.topComment).toBe('Solo');
+  });
+
+  it('returns null topComment for an empty file', () => {
+    const out = markdownParser(input(''));
+    expect(out.topComment).toBeNull();
+  });
+});

--- a/tests/canopy/parsers/python.test.ts
+++ b/tests/canopy/parsers/python.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'bun:test';
+import { pythonParser } from '@myco/canopy/parsers/python';
+
+function input(content: string, path = 'sample.py') {
+  return { path, content, sizeBytes: Buffer.byteLength(content), lineCount: content.split(/\r?\n/).length };
+}
+
+describe('pythonParser', () => {
+  it('extracts module docstring as topComment', () => {
+    const out = pythonParser(input(`"""Top of module.\n\nMore details.\n"""\n\nimport os\n`));
+    expect(out.language).toBe('python');
+    expect(out.topComment).toContain('Top of module');
+  });
+
+  it('skips shebang and encoding cookie before docstring', () => {
+    const out = pythonParser(input(`#!/usr/bin/env python\n# -*- coding: utf-8 -*-\n\n"""The actual docstring."""\n`));
+    expect(out.topComment).toBe('The actual docstring.');
+  });
+
+  it('returns null topComment when there is no docstring', () => {
+    const out = pythonParser(input(`import os\n\ndef foo(): pass\n`));
+    expect(out.topComment).toBeNull();
+  });
+
+  it('extracts top-level def and class names', () => {
+    const out = pythonParser(input(`
+def alpha():
+    pass
+
+class Beta:
+    def gamma(self): pass
+
+async def delta(): pass
+`));
+    expect(out.exports.sort()).toEqual(['Beta', 'alpha', 'delta']);
+  });
+
+  it('extracts imports for both forms', () => {
+    const out = pythonParser(input(`
+import os
+import sys, json
+from collections import OrderedDict
+from .relative import thing
+`));
+    expect(out.imports).toContain('os');
+    expect(out.imports).toContain('sys');
+    expect(out.imports).toContain('json');
+    expect(out.imports).toContain('collections');
+    expect(out.imports).toContain('.relative');
+  });
+
+  it('does not include nested defs as exports', () => {
+    const out = pythonParser(input(`
+def outer():
+    def inner(): pass
+`));
+    expect(out.exports).toEqual(['outer']);
+  });
+});

--- a/tests/canopy/parsers/registry.test.ts
+++ b/tests/canopy/parsers/registry.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'bun:test';
+import { parserFor } from '@myco/canopy/parsers/registry';
+import { typescriptParser } from '@myco/canopy/parsers/typescript';
+import { pythonParser } from '@myco/canopy/parsers/python';
+import { markdownParser } from '@myco/canopy/parsers/markdown';
+import { yamlJsonParser } from '@myco/canopy/parsers/yaml-json';
+import { sqlParser } from '@myco/canopy/parsers/sql';
+import { fallbackParser } from '@myco/canopy/parsers/fallback';
+
+describe('parserFor', () => {
+  it('routes TypeScript / JavaScript variants to the typescript parser', () => {
+    for (const p of ['a.ts', 'b.tsx', 'c.js', 'd.jsx', 'e.mjs', 'f.cjs', 'g.mts', 'h.cts']) {
+      expect(parserFor(p)).toBe(typescriptParser);
+    }
+  });
+
+  it('routes .py to the python parser', () => {
+    expect(parserFor('foo/bar.py')).toBe(pythonParser);
+  });
+
+  it('routes markdown variants to the markdown parser', () => {
+    expect(parserFor('README.md')).toBe(markdownParser);
+    expect(parserFor('docs/x.markdown')).toBe(markdownParser);
+  });
+
+  it('routes yaml/yml/json to the yaml-json parser', () => {
+    for (const p of ['a.yaml', 'b.yml', 'c.json']) {
+      expect(parserFor(p)).toBe(yamlJsonParser);
+    }
+  });
+
+  it('routes .sql to the sql parser', () => {
+    expect(parserFor('migrations/v1.sql')).toBe(sqlParser);
+  });
+
+  it('falls back for unknown extensions and extensionless files', () => {
+    expect(parserFor('Makefile')).toBe(fallbackParser);
+    expect(parserFor('foo.unknown')).toBe(fallbackParser);
+    expect(parserFor('binary.bin')).toBe(fallbackParser);
+  });
+
+  it('matches case-insensitively', () => {
+    expect(parserFor('Foo.TS')).toBe(typescriptParser);
+    expect(parserFor('NOTES.MD')).toBe(markdownParser);
+  });
+});

--- a/tests/canopy/parsers/sql.test.ts
+++ b/tests/canopy/parsers/sql.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'bun:test';
+import { sqlParser } from '@myco/canopy/parsers/sql';
+
+function input(content: string, path = 'a.sql') {
+  return { path, content, sizeBytes: Buffer.byteLength(content), lineCount: content.split(/\r?\n/).length };
+}
+
+describe('sqlParser', () => {
+  it('emits CREATE TABLE / INDEX / VIEW / TRIGGER targets', () => {
+    const out = sqlParser(input(`
+      CREATE TABLE IF NOT EXISTS users (id INTEGER);
+      CREATE UNIQUE INDEX users_email ON users (email);
+      CREATE VIEW recent AS SELECT * FROM users;
+      CREATE TRIGGER bump AFTER INSERT ON users BEGIN END;
+    `));
+    expect(out.language).toBe('sql');
+    expect(out.exports).toContain('table:users');
+    expect(out.exports).toContain('index:users_email');
+    expect(out.exports).toContain('view:recent');
+    expect(out.exports).toContain('trigger:bump');
+  });
+
+  it('emits ALTER TABLE targets', () => {
+    const out = sqlParser(input(`ALTER TABLE users ADD COLUMN created_at INTEGER;`));
+    expect(out.exports).toContain('alter:users');
+  });
+
+  it('ignores commented-out statements (line and block)', () => {
+    const out = sqlParser(input(`
+      -- CREATE TABLE ghost (id INTEGER);
+      /* CREATE TABLE phantom (id INTEGER); */
+      CREATE TABLE real (id INTEGER);
+    `));
+    expect(out.exports).toContain('table:real');
+    expect(out.exports).not.toContain('table:ghost');
+    expect(out.exports).not.toContain('table:phantom');
+  });
+
+  it('strips quote/backtick wrappers on identifiers', () => {
+    const out = sqlParser(input(`CREATE TABLE "Quoted" (id INT);\nCREATE TABLE \`backtick\` (id INT);`));
+    expect(out.exports).toContain('table:Quoted');
+    expect(out.exports).toContain('table:backtick');
+  });
+});

--- a/tests/canopy/parsers/typescript.test.ts
+++ b/tests/canopy/parsers/typescript.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'bun:test';
+import { typescriptParser } from '@myco/canopy/parsers/typescript';
+
+function input(content: string, path = 'src/sample.ts') {
+  return { path, content, sizeBytes: Buffer.byteLength(content), lineCount: content.split(/\r?\n/).length };
+}
+
+describe('typescriptParser', () => {
+  it('extracts named function/class/const exports', () => {
+    const out = typescriptParser(input(`
+      export function foo() {}
+      export class Bar {}
+      export const baz = 1, qux = 2;
+    `));
+    expect(out.language).toBe('typescript');
+    expect(out.exports.sort()).toEqual(['Bar', 'baz', 'foo', 'qux']);
+  });
+
+  it('extracts type-only and interface exports', () => {
+    const out = typescriptParser(input(`
+      export interface Foo {}
+      export type Bar = number;
+      export enum Color { Red }
+    `));
+    expect(out.exports.sort()).toEqual(['Bar', 'Color', 'Foo']);
+  });
+
+  it('extracts re-exports and named export lists', () => {
+    const out = typescriptParser(input(`
+      export { a, b } from './neighbor';
+      export * from './deep';
+    `));
+    expect(out.exports).toContain('a');
+    expect(out.exports).toContain('b');
+    expect(out.exports.some((e) => e.startsWith('* from '))).toBe(true);
+  });
+
+  it('records default exports with the "default" sentinel', () => {
+    const out = typescriptParser(input(`
+      const x = 1;
+      export default x;
+    `));
+    expect(out.exports).toContain('default');
+  });
+
+  it('extracts import module specifiers', () => {
+    const out = typescriptParser(input(`
+      import foo from 'foo';
+      import { bar } from './bar.js';
+      import * as ns from "node:path";
+    `));
+    expect(out.imports.sort()).toEqual(['./bar.js', 'foo', 'node:path']);
+  });
+
+  it('extracts a leading JSDoc as topComment, stripped of markers', () => {
+    const out = typescriptParser(input(`/**
+ * Top-level documentation.
+ * Continued on a second line.
+ */
+export const x = 1;
+`));
+    expect(out.topComment).toContain('Top-level documentation');
+    expect(out.topComment).not.toContain('*');
+    expect(out.topComment).not.toContain('/');
+  });
+
+  it('extracts a leading // banner comment as topComment', () => {
+    const out = typescriptParser(input(`// Banner line one\n// Banner line two\nexport const y = 2;\n`));
+    expect(out.topComment).toBe('Banner line one Banner line two');
+  });
+
+  it('returns a graceful result on syntactically malformed input', () => {
+    const out = typescriptParser(input('export const = ;\nfunction foo( {\n'));
+    expect(out.language).toBe('typescript');
+    expect(Array.isArray(out.exports)).toBe(true);
+    expect(Array.isArray(out.imports)).toBe(true);
+  });
+
+  it('handles destructured exports', () => {
+    const out = typescriptParser(input(`export const { a, b } = obj;`));
+    expect(out.exports.sort()).toEqual(['a', 'b']);
+  });
+
+  it('parses TSX without choking on JSX', () => {
+    const out = typescriptParser(
+      input(`import { x } from './x';\nexport const C = () => <div>{x}</div>;\n`, 'a.tsx'),
+    );
+    expect(out.exports).toContain('C');
+    expect(out.imports).toContain('./x');
+  });
+});

--- a/tests/canopy/parsers/yaml-json.test.ts
+++ b/tests/canopy/parsers/yaml-json.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'bun:test';
+import { yamlJsonParser } from '@myco/canopy/parsers/yaml-json';
+
+function input(content: string, path: string) {
+  return { path, content, sizeBytes: Buffer.byteLength(content), lineCount: content.split(/\r?\n/).length };
+}
+
+describe('yamlJsonParser', () => {
+  it('emits JSON top-level object keys as exports', () => {
+    const out = yamlJsonParser(input(`{"name":"x","version":"1","scripts":{}}`, 'package.json'));
+    expect(out.language).toBe('json');
+    expect(out.exports.sort()).toEqual(['name', 'scripts', 'version']);
+  });
+
+  it('marks JSON arrays and primitives explicitly', () => {
+    expect(yamlJsonParser(input(`[1,2,3]`, 'a.json')).exports).toEqual(['[array]']);
+    expect(yamlJsonParser(input(`42`, 'a.json')).exports).toEqual(['[primitive]']);
+  });
+
+  it('returns empty exports for malformed JSON', () => {
+    expect(yamlJsonParser(input(`{not: json,}`, 'a.json')).exports).toEqual([]);
+  });
+
+  it('emits column-zero YAML keys', () => {
+    const out = yamlJsonParser(input(`name: foo\nversion: 1.0\nscripts:\n  build: tsc\n`, 'config.yaml'));
+    expect(out.language).toBe('yaml');
+    expect(out.exports.sort()).toEqual(['name', 'scripts', 'version']);
+  });
+
+  it('ignores YAML document markers and comments', () => {
+    const out = yamlJsonParser(input(`---\n# comment\nkey: val\n...\n`, 'a.yml'));
+    expect(out.exports).toEqual(['key']);
+  });
+});

--- a/tests/canopy/scanner/jobs.test.ts
+++ b/tests/canopy/scanner/jobs.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initDatabase, closeDatabase, getDatabase } from '@myco/db/client';
+import { createSchema } from '@myco/db/schema';
+import { MycoConfigSchema } from '@myco/config/schema';
+import { runCanopyScan } from '@myco/daemon/jobs/canopy-scan';
+import {
+  CanopyDeltaScanRunner,
+  CANOPY_DELTA_DEBOUNCE_MS,
+} from '@myco/daemon/jobs/canopy-delta-scan';
+import {
+  CanopyBackgroundScan,
+  parseDuration,
+} from '@myco/daemon/jobs/canopy-background-scan';
+
+function buildLogger() {
+  const calls: Array<{ level: string; kind: string; msg: string; meta?: unknown }> = [];
+  const logger = {
+    info: (kind: string, msg: string, meta?: unknown) => calls.push({ level: 'info', kind, msg, meta }),
+    warn: (kind: string, msg: string, meta?: unknown) => calls.push({ level: 'warn', kind, msg, meta }),
+    error: (kind: string, msg: string, meta?: unknown) => calls.push({ level: 'error', kind, msg, meta }),
+    debug: (kind: string, msg: string, meta?: unknown) => calls.push({ level: 'debug', kind, msg, meta }),
+  };
+  // The real DaemonLogger has more methods — the jobs only use info/warn/error.
+  return { logger: logger as unknown as import('@myco/daemon/logger').DaemonLogger, calls };
+}
+
+let tmp: string;
+let projectRoot: string;
+const liveConfig = { current: MycoConfigSchema.parse({ version: 3 }) };
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-canopy-jobs-'));
+  projectRoot = path.join(tmp, 'project');
+  fs.mkdirSync(projectRoot, { recursive: true });
+  initDatabase(path.join(tmp, 'myco.db'));
+  createSchema(getDatabase());
+});
+
+afterEach(() => {
+  closeDatabase();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function write(rel: string, content: string) {
+  const abs = path.join(projectRoot, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+}
+
+describe('runCanopyScan', () => {
+  it('logs CANOPY_SCAN on success', async () => {
+    write('a.ts', 'export const a = 1;\n');
+    const { logger, calls } = buildLogger();
+    await runCanopyScan({
+      db: getDatabase(),
+      logger,
+      machineId: 'local',
+      projectRoot,
+      projectId: projectRoot,
+      liveConfig,
+    });
+    expect(calls.some((c) => c.kind === 'canopy.scan' && c.level === 'info')).toBe(true);
+  });
+});
+
+describe('CanopyDeltaScanRunner', () => {
+  it('debounces back-to-back triggers within the window', async () => {
+    write('a.ts', 'export const a = 1;\n');
+    const { logger, calls } = buildLogger();
+    const runner = new CanopyDeltaScanRunner({
+      db: getDatabase(),
+      logger,
+      machineId: 'local',
+      projectRoot,
+      projectId: projectRoot,
+      liveConfig,
+    });
+    await runner.run(1_000);
+    await runner.run(1_000 + CANOPY_DELTA_DEBOUNCE_MS - 1);
+    const runs = calls.filter((c) => c.kind === 'canopy.scan').length;
+    expect(runs).toBe(1);
+  });
+
+  it('runs again after the debounce window elapses', async () => {
+    write('a.ts', 'export const a = 1;\n');
+    const { logger, calls } = buildLogger();
+    const runner = new CanopyDeltaScanRunner({
+      db: getDatabase(),
+      logger,
+      machineId: 'local',
+      projectRoot,
+      projectId: projectRoot,
+      liveConfig,
+    });
+    await runner.run(1_000);
+    await runner.run(1_000 + CANOPY_DELTA_DEBOUNCE_MS + 1);
+    const runs = calls.filter((c) => c.kind === 'canopy.scan').length;
+    expect(runs).toBe(2);
+  });
+});
+
+describe('CanopyBackgroundScan', () => {
+  it('respects the configured period', async () => {
+    let runs = 0;
+    const fakeDelta = { run: async () => { runs++; } };
+    const cfg = { current: MycoConfigSchema.parse({
+      version: 3,
+      canopy: { refresh: { background_period: '60s' } },
+    }) };
+    const { logger } = buildLogger();
+    const bg = new CanopyBackgroundScan({ liveConfig: cfg, delta: fakeDelta as unknown as CanopyDeltaScanRunner, logger });
+    await bg.tick();
+    await bg.tick(); // immediately — should be skipped by the period gate
+    expect(runs).toBe(1);
+  });
+
+  it('skips entirely when background_enabled is false', async () => {
+    let runs = 0;
+    const fakeDelta = { run: async () => { runs++; } };
+    const cfg = { current: MycoConfigSchema.parse({
+      version: 3,
+      canopy: { refresh: { background_enabled: false } },
+    }) };
+    const { logger } = buildLogger();
+    const bg = new CanopyBackgroundScan({ liveConfig: cfg, delta: fakeDelta as unknown as CanopyDeltaScanRunner, logger });
+    await bg.tick();
+    expect(runs).toBe(0);
+  });
+});
+
+describe('parseDuration', () => {
+  it('parses the standard humanised forms', () => {
+    expect(parseDuration('30s')).toBe(30);
+    expect(parseDuration('5m')).toBe(300);
+    expect(parseDuration('1h')).toBe(3600);
+    expect(parseDuration('1d')).toBe(86_400);
+  });
+
+  it('treats a bare number as seconds', () => {
+    expect(parseDuration('45')).toBe(45);
+  });
+
+  it('returns 0 for unparseable input', () => {
+    expect(parseDuration('forever')).toBe(0);
+    expect(parseDuration('')).toBe(0);
+  });
+});

--- a/tests/canopy/scanner/rescan-single.test.ts
+++ b/tests/canopy/scanner/rescan-single.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initDatabase, closeDatabase, getDatabase } from '@myco/db/client';
+import { createSchema } from '@myco/db/schema';
+import { rescanSingle } from '@myco/canopy/scanner/rescan-single';
+import { handleCanopyToolUse, FILE_MUTATING_TOOLS_LIST } from '@myco/canopy/scanner/handle-tool-use';
+import type { DaemonLogger } from '@myco/daemon/logger';
+
+const PROJECT_ID_PREFIX = 'p';
+
+let tmp: string;
+let projectRoot: string;
+let projectId: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-rescan-'));
+  projectRoot = path.join(tmp, 'project');
+  fs.mkdirSync(projectRoot, { recursive: true });
+  projectId = projectRoot;
+  initDatabase(path.join(tmp, 'myco.db'));
+  createSchema(getDatabase());
+});
+
+afterEach(() => {
+  closeDatabase();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function write(rel: string, content: string) {
+  const abs = path.join(projectRoot, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+}
+
+function rowExists(rel: string): boolean {
+  return Boolean(getDatabase().prepare(
+    'SELECT 1 FROM canopy_entries WHERE project_id = ? AND path = ?',
+  ).get(projectId, rel));
+}
+
+describe('rescanSingle', () => {
+  it('upserts the row for an existing file', () => {
+    write('src/a.ts', 'export const x = 1;\n');
+    const r = rescanSingle({
+      db: getDatabase(),
+      projectId,
+      machineId: 'local',
+      projectRoot,
+      filePath: 'src/a.ts',
+    });
+    expect(r).toEqual({ ok: true, action: 'upserted', relPath: 'src/a.ts' });
+    expect(rowExists('src/a.ts')).toBe(true);
+  });
+
+  it('deletes the row when the file is gone', () => {
+    write('src/a.ts', 'export const x = 1;\n');
+    rescanSingle({ db: getDatabase(), projectId, machineId: 'local', projectRoot, filePath: 'src/a.ts' });
+    fs.unlinkSync(path.join(projectRoot, 'src/a.ts'));
+    const r = rescanSingle({
+      db: getDatabase(), projectId, machineId: 'local', projectRoot, filePath: 'src/a.ts',
+    });
+    expect(r).toEqual({ ok: true, action: 'deleted', relPath: 'src/a.ts' });
+    expect(rowExists('src/a.ts')).toBe(false);
+  });
+
+  it('rejects paths outside the project root', () => {
+    const r = rescanSingle({
+      db: getDatabase(), projectId, machineId: 'local', projectRoot,
+      filePath: path.join(tmp, 'outside.ts'),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('outside_project');
+  });
+
+  it('accepts absolute paths inside the project root', () => {
+    write('src/b.ts', 'export const y = 1;\n');
+    const r = rescanSingle({
+      db: getDatabase(), projectId, machineId: 'local', projectRoot,
+      filePath: path.join(projectRoot, 'src/b.ts'),
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.relPath).toBe('src/b.ts');
+  });
+});
+
+describe('handleCanopyToolUse', () => {
+  function makeLogger() {
+    const calls: Array<{ level: string; kind: string }> = [];
+    const logger = {
+      info: (kind: string) => calls.push({ level: 'info', kind }),
+      warn: (kind: string) => calls.push({ level: 'warn', kind }),
+      error: (kind: string) => calls.push({ level: 'error', kind }),
+      debug: (kind: string) => calls.push({ level: 'debug', kind }),
+    } as unknown as DaemonLogger;
+    return { logger, calls };
+  }
+
+  it('triggers a rescan for Write tool events', () => {
+    write('src/a.ts', 'export const x = 1;\n');
+    const { logger, calls } = makeLogger();
+    handleCanopyToolUse({
+      db: getDatabase(),
+      logger, machineId: 'local', projectRoot, projectId,
+      toolName: 'Write',
+      toolInput: { file_path: path.join(projectRoot, 'src/a.ts') },
+    });
+    expect(rowExists('src/a.ts')).toBe(true);
+    expect(calls.some((c) => c.kind === 'canopy.rescan')).toBe(true);
+  });
+
+  it('ignores tool events outside the file-mutating set', () => {
+    const { logger, calls } = makeLogger();
+    handleCanopyToolUse({
+      db: getDatabase(),
+      logger, machineId: 'local', projectRoot, projectId,
+      toolName: 'Read',
+      toolInput: { file_path: 'src/a.ts' },
+    });
+    expect(calls.length).toBe(0);
+  });
+
+  it('exposes the trigger list', () => {
+    expect(FILE_MUTATING_TOOLS_LIST).toContain('Write');
+    expect(FILE_MUTATING_TOOLS_LIST).toContain('Edit');
+  });
+});

--- a/tests/canopy/scanner/scan-file.test.ts
+++ b/tests/canopy/scanner/scan-file.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { scanFile } from '@myco/canopy/scanner/scan-file';
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-scan-file-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function write(relPath: string, content: string | Buffer) {
+  const abs = path.join(tmp, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+}
+
+const baseOpts = () => ({
+  projectId: 'p1',
+  machineId: 'local',
+  projectRoot: tmp,
+  now: 1_700_000_000,
+});
+
+describe('scanFile', () => {
+  it('produces a CanopyEntry for a small TypeScript file', () => {
+    write('src/a.ts', 'export const x = 1;\n');
+    const r = scanFile({ ...baseOpts(), relPath: 'src/a.ts' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.entry.path).toBe('src/a.ts');
+    expect(r.entry.language).toBe('typescript');
+    expect(r.entry.size_bytes).toBeGreaterThan(0);
+    expect(r.entry.line_count).toBe(1);
+    expect(r.entry.content_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.parse(r.entry.exports_json!)).toContain('x');
+    expect(r.entry.mechanical_updated_at).toBe(1_700_000_000);
+    expect(r.entry.llm_description).toBeNull();
+  });
+
+  it('skips files larger than maxBytes', () => {
+    write('big.ts', 'x'.repeat(100));
+    const r = scanFile({ ...baseOpts(), relPath: 'big.ts', maxBytes: 50 });
+    expect(r).toEqual({ ok: false, reason: 'too_large' });
+  });
+
+  it('skips binary content (NUL byte in prefix)', () => {
+    write('blob.bin', Buffer.from([0x68, 0x00, 0x65]));
+    const r = scanFile({ ...baseOpts(), relPath: 'blob.bin' });
+    expect(r).toEqual({ ok: false, reason: 'binary' });
+  });
+
+  it('skips symlinks', () => {
+    write('real.txt', 'hello\n');
+    fs.symlinkSync(path.join(tmp, 'real.txt'), path.join(tmp, 'link.txt'));
+    const r = scanFile({ ...baseOpts(), relPath: 'link.txt' });
+    expect(r).toEqual({ ok: false, reason: 'symlink' });
+  });
+
+  it('reports missing files as missing', () => {
+    const r = scanFile({ ...baseOpts(), relPath: 'nope.ts' });
+    expect(r).toEqual({ ok: false, reason: 'missing' });
+  });
+
+  it('emits null exports_json/imports_json when arrays are empty', () => {
+    write('notes.md', '# hello\n');
+    const r = scanFile({ ...baseOpts(), relPath: 'notes.md' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.entry.exports_json).toBeNull();
+    expect(r.entry.imports_json).toBeNull();
+    expect(r.entry.top_comment).toContain('hello');
+  });
+});

--- a/tests/canopy/scanner/scan-project.test.ts
+++ b/tests/canopy/scanner/scan-project.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initDatabase, closeDatabase, getDatabase } from '@myco/db/client';
+import { createSchema } from '@myco/db/schema';
+import { scanProject } from '@myco/canopy/scanner/scan-project';
+import { deltaScan } from '@myco/canopy/scanner/delta-scan';
+import { MycoConfigSchema } from '@myco/config/schema';
+
+const PROJECT_ID = 'test-project';
+const DEFAULT_PATTERNS = MycoConfigSchema.parse({ version: 3 }).canopy.exclude.patterns;
+
+let tmp: string;
+let projectRoot: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-scan-proj-'));
+  projectRoot = path.join(tmp, 'project');
+  fs.mkdirSync(projectRoot, { recursive: true });
+  dbPath = path.join(tmp, 'myco.db');
+  const db = initDatabase(dbPath);
+  createSchema(db);
+});
+
+afterEach(() => {
+  closeDatabase();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function write(relPath: string, content: string) {
+  const abs = path.join(projectRoot, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+}
+
+function rowCount(): number {
+  const db = getDatabase();
+  return (db.prepare('SELECT COUNT(*) AS n FROM canopy_entries WHERE project_id = ?').get(PROJECT_ID) as { n: number }).n;
+}
+
+const baseOpts = () => ({
+  db: getDatabase(),
+  projectId: PROJECT_ID,
+  machineId: 'local',
+  projectRoot,
+  excludePatterns: DEFAULT_PATTERNS,
+});
+
+describe('scanProject', () => {
+  it('populates rows for non-excluded files and respects default exclusions', () => {
+    write('src/a.ts', 'export const a = 1;\n');
+    write('src/b.ts', 'export const b = 2;\n');
+    write('node_modules/ignored.ts', 'export const x = 1;\n');
+    write('.git/HEAD', 'ref: refs/heads/main\n');
+    write('package-lock.json', '{}');
+    write('README.md', '# hello\n');
+
+    const result = scanProject(baseOpts());
+    expect(result.scanned).toBeGreaterThanOrEqual(3);
+    expect(rowCount()).toBe(3);
+    expect(result.added).toBe(3);
+    expect(result.removed).toBe(0);
+  });
+
+  it('tombstones rows whose files have been deleted', () => {
+    write('src/a.ts', 'export const a = 1;\n');
+    write('src/b.ts', 'export const b = 2;\n');
+    scanProject(baseOpts());
+    expect(rowCount()).toBe(2);
+
+    fs.unlinkSync(path.join(projectRoot, 'src/b.ts'));
+    const result = scanProject(baseOpts());
+    expect(result.removed).toBe(1);
+    expect(rowCount()).toBe(1);
+  });
+
+  it('upsert is idempotent across repeated full scans', () => {
+    write('src/a.ts', 'export const a = 1;\n');
+    scanProject(baseOpts());
+    const first = rowCount();
+    scanProject(baseOpts());
+    expect(rowCount()).toBe(first);
+  });
+});
+
+describe('deltaScan', () => {
+  it('skips unchanged files (no upsert) but still returns scan counts', () => {
+    write('src/a.ts', 'export const a = 1;\n');
+    scanProject(baseOpts());
+    const initial = (getDatabase().prepare(
+      'SELECT mechanical_updated_at FROM canopy_entries WHERE project_id = ? AND path = ?',
+    ).get(PROJECT_ID, 'src/a.ts') as { mechanical_updated_at: number }).mechanical_updated_at;
+
+    // Run the delta with a forced "now" by sleeping a moment to ensure
+    // epochSeconds advances; the assertion below proves the row was NOT
+    // re-upserted because the size and hash matched.
+    const result = deltaScan(baseOpts());
+    const after = (getDatabase().prepare(
+      'SELECT mechanical_updated_at FROM canopy_entries WHERE project_id = ? AND path = ?',
+    ).get(PROJECT_ID, 'src/a.ts') as { mechanical_updated_at: number }).mechanical_updated_at;
+    expect(after).toBe(initial);
+    expect(result.scanned).toBeGreaterThan(0);
+    expect(result.added).toBe(0);
+    expect(result.updated).toBe(0);
+  });
+
+  it('detects new and modified files and tombstones deletions', () => {
+    write('src/a.ts', 'export const a = 1;\n');
+    write('src/d.ts', 'export const d = 4;\n');
+    scanProject(baseOpts());
+
+    // Modify a (size grows), add c, delete d.
+    write('src/a.ts', 'export const a = 1;\nexport const b = 2;\n');
+    write('src/c.ts', 'export const c = 3;\n');
+    fs.unlinkSync(path.join(projectRoot, 'src/d.ts'));
+
+    const r = deltaScan(baseOpts());
+    expect(r.added).toBe(1); // src/c.ts
+    expect(r.updated).toBe(1); // src/a.ts changed size
+    expect(r.removed).toBe(1); // src/d.ts deleted
+    expect(rowCount()).toBe(2);
+  });
+});

--- a/tests/canopy/scanner/walk.test.ts
+++ b/tests/canopy/scanner/walk.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { walkProject } from '@myco/canopy/scanner/walk';
+import { createExcludeMatcher } from '@myco/canopy/exclude';
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-walk-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function write(rel: string, content = '') {
+  const abs = path.join(tmp, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+}
+
+describe('walkProject', () => {
+  it('yields files but not directories, with forward-slash relative paths', () => {
+    write('a.ts');
+    write('src/b.ts');
+    write('src/nested/c.ts');
+    const results = [...walkProject({ projectRoot: tmp, isExcluded: () => false })].sort();
+    expect(results).toEqual(['a.ts', 'src/b.ts', 'src/nested/c.ts']);
+  });
+
+  it('prunes excluded directories without descending into them', () => {
+    write('keep/a.ts');
+    write('node_modules/foo/index.js');
+    const isExcluded = createExcludeMatcher(['node_modules']);
+    const results = [...walkProject({ projectRoot: tmp, isExcluded })];
+    expect(results).toContain('keep/a.ts');
+    expect(results.every((p) => !p.startsWith('node_modules/'))).toBe(true);
+  });
+
+  it('skips symlinks silently', () => {
+    write('real.txt', 'x');
+    fs.symlinkSync(path.join(tmp, 'real.txt'), path.join(tmp, 'link.txt'));
+    const results = [...walkProject({ projectRoot: tmp, isExcluded: () => false })].sort();
+    expect(results).toContain('real.txt');
+    expect(results).not.toContain('link.txt');
+  });
+
+  it('tolerates a missing/unreadable subtree without throwing', () => {
+    write('a.ts');
+    // No directory at "ghost/" — walkProject only traverses what exists, so
+    // this just confirms an empty-prefix walk completes cleanly.
+    const results = [...walkProject({ projectRoot: tmp, isExcluded: () => false })];
+    expect(results).toEqual(['a.ts']);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 Track A of the Canopy code intelligence rollout — populates `canopy_entries` from disk so Cortex (Track B) and the observability layer (Track C) can read against real data.

- **Parsers** for TypeScript/JS, Python, Markdown, YAML/JSON, SQL, plus a universal fallback. TypeScript uses the existing `typescript` package; the rest are mechanical regex.
- **Scanner core**: `scanFile`, `walkProject`, `scanProject`, `deltaScan`, `rescanSingle`. The exclude matcher is compiled once per scan; `mechanical_updated_at` is preserved when bytes are unchanged.
- **PowerManager jobs**: initial full populate on boot, debounced delta scan triggered by SessionStart, periodic background scan honoring `canopy.refresh.background_period` and `…background_enabled`.
- **Single-file rescan** on Write/Edit/MultiEdit/NotebookEdit tool events from the daemon's existing `tool_use` dispatcher. Best-effort; canopy errors never block the capture pipeline.

## Files added (new, owned by Track A)

- `packages/myco/src/canopy/parsers/{registry,fallback,typescript,python,markdown,yaml-json,sql}.ts`
- `packages/myco/src/canopy/scanner/{scan-file,walk,upsert,scan-project,delta-scan,rescan-single,handle-tool-use}.ts`
- `packages/myco/src/daemon/jobs/{canopy-scan,canopy-delta-scan,canopy-background-scan}.ts`
- `tests/canopy/{parsers,scanner}/**` — 82 tests across 14 files

## Files modified (additive, integration)

- `packages/myco/src/constants/log-kinds.ts` — three new `CANOPY_*` log kinds.
- `packages/myco/src/daemon/power-jobs.ts` — adds `projectRoot` to `PowerJobDeps`, returns canopy registration.
- `packages/myco/src/daemon/main.ts` — passes `projectRoot`, kicks off initial populate, wires the delta runner into the session-register handler.
- `packages/myco/src/daemon/api/session-lifecycle.ts` — fires the canopy delta runner after register; fire-and-forget, debounced inside the runner.
- `packages/myco/src/daemon/event-dispatch.ts` — single-line dispatch into `handleCanopyToolUse` after activity capture.

## Deviations from the plan

- **A.6** (edit `hooks/session-start.ts`): the same effect is implemented at the daemon side via `session-lifecycle.ts` so the hook stays thin (per AGENTS.md "Hooks must stay thin and delegate to the daemon"). The session-start hook already calls `/sessions/register`; the daemon now triggers the delta runner there.
- The daemon `/canopy/inject` API surface mentioned in plan B.7 is **not** in this PR — that's Track B's responsibility per the file-ownership map.
- `project_id` is set to the absolute project root path. Stable on this machine, no extra plumbing required for the local-only table; can switch to a derived hash later without a schema change.

## Test results

- `bun test tests/canopy/parsers tests/canopy/scanner` — **82 pass / 0 fail / 174 assertions**.
- `MYCO_TEST_PROFILE=fast node scripts/run-bun-tests.mjs` — **3203 pass / 0 fail** + 23/23 DOM tests.
- `npm run lint` (which is `tsc --noEmit`) — clean.

## Dogfood (Task A.8)

Run against this worktree (1168 files):

- **Full scan**: 1127 added, 0 errors, **428 ms**.
- **Delta scan** (no changes): scanned 1168, 0 modifications, **12 ms**.
- **Language histogram**: typescript 888, markdown 84, fallback 63, json 59, yaml 33.
- Sample rows look right: TypeScript exports/imports parsed correctly, top JSDoc comments stripped of markers, `templates.generated.ts` correctly emits `BUNDLED_TEMPLATES`, etc.

Both well inside the plan's targets (full < 10 s, delta < 2 s).

## Test plan

- [ ] `bun test tests/canopy/parsers tests/canopy/scanner` is green.
- [ ] `MYCO_TEST_PROFILE=fast node scripts/run-bun-tests.mjs` is green.
- [ ] `npm run lint` is clean.
- [ ] Spot-check a fresh daemon run: `canopy_entries` populates, delta scan fires on SessionStart, `tool_use` Write events refresh single rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)