### PR TITLE
feat(team-sync): replace SQLite outbox with Cloudflare Queues

### DIFF
--- a/packages/myco-team/src/cli.ts
+++ b/packages/myco-team/src/cli.ts
@@ -404,12 +404,16 @@ function ensureQueue(queueName: string): void {
     wrangler(['queues', 'create', queueName]);
   } catch (err) {
     const errMsg = (err as Error).message;
-    // Wrangler reports collisions in a few different shapes depending on
-    // version; treat any "already exists" variant as success.
+    // Wrangler reports collisions in several shapes depending on version
+    // and the underlying CF API response. The current 4.x + Queues API
+    // returns "is already taken" with code 11009; older variants used
+    // "already exists" / "duplicate". Treat any of them as success so
+    // re-running install/upgrade is idempotent.
     if (
       errMsg.includes('already exists')
+      || errMsg.includes('is already taken')
       || errMsg.includes('duplicate')
-      || errMsg.includes('queue with this name already exists')
+      || errMsg.includes('11009')
     ) {
       return;
     }

--- a/packages/myco-team/src/cli.ts
+++ b/packages/myco-team/src/cli.ts
@@ -101,6 +101,15 @@ const TOML_KV_PLACEHOLDER_REGEX = /<YOUR_KV_NAMESPACE_ID>/g;
 /** Regex to extract the KV namespace ID from an existing wrangler.toml. */
 const TOML_KV_ID_REGEX = /\[\[kv_namespaces\]\][\s\S]*?id\s*=\s*"([0-9a-f]+)"/;
 
+/** Regex to match wrangler.toml sync queue placeholder. */
+const TOML_SYNC_QUEUE_PLACEHOLDER_REGEX = /<YOUR_SYNC_QUEUE_NAME>/g;
+
+/** Regex to match wrangler.toml sync DLQ placeholder. */
+const TOML_SYNC_DLQ_PLACEHOLDER_REGEX = /<YOUR_SYNC_DLQ_NAME>/g;
+
+/** Regex to extract the bound sync queue name from an existing wrangler.toml producer block. */
+const TOML_SYNC_QUEUE_NAME_REGEX = /\[\[queues\.producers\]\][\s\S]*?queue\s*=\s*"([^"]+)"/;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -345,6 +354,16 @@ function locateWorkerSource(): string {
   throw new Error(`Cannot find ${WORKER_SOURCE_DIR} — are you running from the myco-team package?`);
 }
 
+/** Compute the sync queue name for this project. */
+function syncQueueName(name: string): string {
+  return `${name}-sync`;
+}
+
+/** Compute the sync dead-letter queue name for this project. */
+function syncDlqName(name: string): string {
+  return `${name}-sync-dlq`;
+}
+
 /**
  * Copy worker source to the vault deployment directory and patch wrangler.toml
  * with actual D1 database ID and resource names.
@@ -365,12 +384,37 @@ function prepareDeployDir(vaultDir: string, d1Id: string, kvId: string): string 
         (toml) => toml.replace(TOML_DB_NAME_REGEX, `database_name = "${name}"`),
         (toml) => toml.replace(TOML_INDEX_NAME_REGEX, `index_name = "${name}-vectors"`),
         (toml) => toml.replace(TOML_KV_PLACEHOLDER_REGEX, kvId),
+        (toml) => toml.replace(TOML_SYNC_QUEUE_PLACEHOLDER_REGEX, syncQueueName(name)),
+        (toml) => toml.replace(TOML_SYNC_DLQ_PLACEHOLDER_REGEX, syncDlqName(name)),
         (toml) => toml.replace(TOML_TEAM_PACKAGE_VERSION_REGEX, `MYCO_TEAM_PACKAGE_VERSION = "${getTeamPackageVersion()}"`),
         (toml) => toml.replace(TOML_MYCO_SCHEMA_VERSION_REGEX, `MYCO_SCHEMA_VERSION = "${getMycoSchemaVersion()}"`),
       ],
     }],
     installDepsTimeoutMs: WRANGLER_COMMAND_TIMEOUT_MS * 3,
   });
+}
+
+/**
+ * Ensure a Cloudflare Queue exists for this project. Idempotent — treats
+ * "already exists" as success. Queues are bound by name in wrangler.toml,
+ * so no ID lookup is needed.
+ */
+function ensureQueue(queueName: string): void {
+  try {
+    wrangler(['queues', 'create', queueName]);
+  } catch (err) {
+    const errMsg = (err as Error).message;
+    // Wrangler reports collisions in a few different shapes depending on
+    // version; treat any "already exists" variant as success.
+    if (
+      errMsg.includes('already exists')
+      || errMsg.includes('duplicate')
+      || errMsg.includes('queue with this name already exists')
+    ) {
+      return;
+    }
+    throw err;
+  }
 }
 
 /** Ensure a KV namespace exists for this project. Returns the namespace ID. */
@@ -498,10 +542,21 @@ export async function teamInit(vaultDir: string): Promise<void> {
     process.exit(1);
   }
 
-  // 6. Generate API key
+  // 6. Create Cloudflare Queues for sync + dead-letter (idempotent)
+  console.log('Creating sync queues...');
+  try {
+    ensureQueue(syncQueueName(name));
+    ensureQueue(syncDlqName(name));
+    console.log(`Sync queues ready: ${syncQueueName(name)}, ${syncDlqName(name)}\n`);
+  } catch (err) {
+    console.error(`Failed to create sync queues: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  // 7. Generate API key
   const apiKey = crypto.randomBytes(API_KEY_BYTES).toString('hex');
 
-  // 7. Prepare deployment directory
+  // 8. Prepare deployment directory
   console.log('Preparing worker deployment...');
   const deployDir = prepareDeployDir(vaultDir, d1Id, kvId);
 
@@ -639,6 +694,15 @@ export function upgradeWorker(vaultDir: string): UpgradeResult {
     }
   }
 
+  // Sync queues may not exist on pre-queues deployments — create idempotently.
+  // ensureQueue is a no-op when the queue is already provisioned.
+  try {
+    ensureQueue(syncQueueName(workerName));
+    ensureQueue(syncDlqName(workerName));
+  } catch (err) {
+    return { success: false, error: `Failed to provision sync queues: ${(err as Error).message}` };
+  }
+
   try {
     stageDeploymentDir({
       sourceDir: locateWorkerSource(),
@@ -651,6 +715,8 @@ export function upgradeWorker(vaultDir: string): UpgradeResult {
           (toml) => toml.replace(TOML_DB_NAME_REGEX, `database_name = "${dbNameMatch?.[1] ?? workerName}"`),
           (toml) => toml.replace(TOML_INDEX_NAME_REGEX, `index_name = "${indexNameMatch?.[1] ?? `${workerName}-vectors`}"`),
           (toml) => toml.replace(TOML_KV_PLACEHOLDER_REGEX, kvId),
+          (toml) => toml.replace(TOML_SYNC_QUEUE_PLACEHOLDER_REGEX, syncQueueName(workerName)),
+          (toml) => toml.replace(TOML_SYNC_DLQ_PLACEHOLDER_REGEX, syncDlqName(workerName)),
           (toml) => toml.replace(TOML_TEAM_PACKAGE_VERSION_REGEX, `MYCO_TEAM_PACKAGE_VERSION = "${getTeamPackageVersion()}"`),
           (toml) => toml.replace(TOML_MYCO_SCHEMA_VERSION_REGEX, `MYCO_SCHEMA_VERSION = "${getMycoSchemaVersion()}"`),
         ],
@@ -824,6 +890,18 @@ export async function teamDestroy(vaultDir: string): Promise<void> {
     }
   } catch (error) {
     errors.push(`kv delete failed: ${(error as Error).message}`);
+  }
+
+  // Delete sync queues. Missing queues (older deployments) yield a not-found
+  // error from wrangler, which we swallow.
+  for (const queueName of [syncQueueName(config.worker_name), syncDlqName(config.worker_name)]) {
+    try {
+      wrangler(['queues', 'delete', queueName]);
+    } catch (error) {
+      const errMsg = (error as Error).message;
+      if (errMsg.includes('not found') || errMsg.includes('does not exist') || errMsg.includes('no queue')) continue;
+      errors.push(`queue ${queueName} delete failed: ${errMsg}`);
+    }
   }
 
   if (errors.length > 0) {

--- a/packages/myco-team/worker/src/index.ts
+++ b/packages/myco-team/worker/src/index.ts
@@ -26,6 +26,12 @@ export interface Env {
   MYCO_TEAM_API_KEY: string;
   SYNC_PROTOCOL_VERSION: string;
   MYCO_SECRETS: KVNamespace;
+  /**
+   * Producer binding for the project's sync queue. Bound at deploy time via
+   * the wrangler.toml [[queues.producers]] block; queue name is project-scoped
+   * (`myco-team-<hash>-sync`) and provisioned by `myco-team init`.
+   */
+  SYNC_QUEUE: Queue<SyncRecord>;
   MYCO_TEAM_PACKAGE_VERSION?: string;
   MYCO_SCHEMA_VERSION?: string;
 }
@@ -410,10 +416,16 @@ async function handleConnect(request: Request, env: Env): Promise<Response> {
   });
 }
 
-async function handleSync(request: Request, env: Env): Promise<Response> {
+/**
+ * Producer endpoint — receives a SyncPayload and fans the records out into
+ * the project's sync queue. The queue consumer (defined in this Worker's
+ * `queue()` handler) is what actually writes to D1 and Vectorize. This
+ * decoupling lets Cloudflare handle batching, retries, and dead-lettering;
+ * the daemon's local outbox shrinks to a thin offline buffer.
+ */
+async function handleEnqueue(request: Request, env: Env): Promise<Response> {
   const body = (await request.json()) as SyncPayload;
 
-  // Version check
   const serverVersion = parseInt(env.SYNC_PROTOCOL_VERSION, 10);
   if (body.sync_protocol_version !== serverVersion) {
     return errorResponse(
@@ -423,79 +435,134 @@ async function handleSync(request: Request, env: Env): Promise<Response> {
   }
 
   if (!Array.isArray(body.records) || body.records.length === 0) {
-    return jsonResponse({ synced: 0, skipped: 0, errors: [] });
+    return jsonResponse({ accepted: 0 });
   }
 
-  let synced = 0;
-  let skipped = 0;
-  const errors: Array<{ id: string; table: string; error: string }> = [];
-
-  // Collect embedding tasks so they can be parallelized after DB writes
-  const embeddingTasks: Array<() => Promise<void>> = [];
-
+  // Validate table names up-front so the daemon can't poison the queue with
+  // payloads the consumer would always reject. Unknown tables are reported in
+  // the response so the daemon surfaces them during its flush.
+  const acceptedRecords: SyncRecord[] = [];
+  const rejected: Array<{ id: string; table: string; error: string }> = [];
   for (const record of body.records) {
-    try {
-      if (!SYNCED_TABLES.includes(record.table)) {
-        errors.push({ id: record.id, table: record.table, error: `Unknown table: ${record.table}` });
-        continue;
-      }
-
-      if (record.operation === 'delete') {
-        await handleDelete(env, record);
-        synced++;
-        continue;
-      }
-
-      // Check content_hash — skip if unchanged
-      if (record.content_hash) {
-        const existing = await env.MYCO_TEAM_DB.prepare(
-          `SELECT content_hash FROM ${record.table} WHERE id = ? AND machine_id = ?`,
-        )
-          .bind(record.id, record.machine_id)
-          .first<{ content_hash: string | null }>();
-
-        if (existing?.content_hash === record.content_hash) {
-          skipped++;
-          continue;
-        }
-      }
-
-      // INSERT OR REPLACE into D1
-      const { sql, values } = buildInsertParts(record.table, record.data, record.id, record.machine_id);
-      await env.MYCO_TEAM_DB.prepare(sql).bind(...values).run();
-
-      // Queue embedding if the table has embeddable content
-      const embeddableField = EMBEDDABLE_TABLES[record.table];
-      if (embeddableField) {
-        const textContent = record.data[embeddableField] as string | undefined;
-        if (textContent) {
-          const { table, id, machine_id } = record;
-          if (table === 'spores' && record.data.status !== 'active') {
-            embeddingTasks.push(() => deleteVector(env, table, id, machine_id));
-          } else {
-            embeddingTasks.push(() => embedAndUpsert(env, table, id, machine_id, textContent, buildVectorMetadata(table, record.data)));
-          }
-        }
-      }
-
-      synced++;
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      errors.push({ id: record.id, table: record.table, error: message });
+    if (!SYNCED_TABLES.includes(record.table)) {
+      rejected.push({ id: record.id, table: record.table, error: `Unknown table: ${record.table}` });
+      continue;
     }
+    acceptedRecords.push(record);
   }
 
-  // Run all embedding tasks in parallel
-  if (embeddingTasks.length > 0) {
-    await Promise.allSettled(embeddingTasks.map((t) => t()));
+  if (acceptedRecords.length > 0) {
+    // sendBatch caps at 100 messages or 256KB per call — the daemon batches
+    // its flush in 100-message chunks, so a single sendBatch covers a tick.
+    await env.SYNC_QUEUE.sendBatch(acceptedRecords.map((record) => ({ body: record })));
   }
 
-  // Update node last_seen
+  // Update node last_seen — proxies the previous /sync semantics so existing
+  // collective heartbeats keep working without waiting on queue drain.
   await env.MYCO_TEAM_DB.prepare('UPDATE nodes SET last_seen = ? WHERE machine_id = ?')
     .bind(epochSeconds(), body.machine_id)
     .run();
 
-  return jsonResponse({ synced, skipped, errors });
+  return jsonResponse({ accepted: acceptedRecords.length, rejected });
+}
+
+/**
+ * Apply one sync record to D1. Returns whether the write was skipped (no-op
+ * because the content_hash matched) and an optional embedding task that the
+ * caller should run after committing the D1 batch.
+ *
+ * Throws on D1 error so the queue runtime treats the message as failed and
+ * applies its retry policy. The DLQ catches messages that keep failing past
+ * the configured max_retries.
+ */
+async function writeRecordToD1(
+  env: Env,
+  record: SyncRecord,
+): Promise<{ skipped: boolean; embedTask?: () => Promise<void> }> {
+  if (record.operation === 'delete') {
+    await handleDelete(env, record);
+    return { skipped: false };
+  }
+
+  if (record.content_hash) {
+    const existing = await env.MYCO_TEAM_DB.prepare(
+      `SELECT content_hash FROM ${record.table} WHERE id = ? AND machine_id = ?`,
+    )
+      .bind(record.id, record.machine_id)
+      .first<{ content_hash: string | null }>();
+    if (existing?.content_hash === record.content_hash) {
+      return { skipped: true };
+    }
+  }
+
+  const { sql, values } = buildInsertParts(record.table, record.data, record.id, record.machine_id);
+  await env.MYCO_TEAM_DB.prepare(sql).bind(...values).run();
+
+  const embeddableField = EMBEDDABLE_TABLES[record.table];
+  if (!embeddableField) return { skipped: false };
+
+  const textContent = record.data[embeddableField] as string | undefined;
+  if (!textContent) return { skipped: false };
+
+  const { table, id, machine_id } = record;
+  if (table === 'spores' && record.data.status !== 'active') {
+    return { skipped: false, embedTask: () => deleteVector(env, table, id, machine_id) };
+  }
+  return {
+    skipped: false,
+    embedTask: () =>
+      embedAndUpsert(env, table, id, machine_id, textContent, buildVectorMetadata(table, record.data)),
+  };
+}
+
+/**
+ * Sync-queue consumer. Receives a batch of SyncRecord messages, applies each
+ * one to D1, and runs any embedding work after the D1 batch settles. Per-
+ * message ack/retry: a single broken message does not block its batch-mates,
+ * and CF Queues handles backoff + DLQ routing once `max_retries` is hit.
+ */
+async function handleSyncBatch(batch: MessageBatch<SyncRecord>, env: Env): Promise<void> {
+  if (!schemaInitialized) {
+    await initD1Schema(env.MYCO_TEAM_DB);
+    schemaInitialized = true;
+  }
+
+  const embeddingTasks: Array<() => Promise<void>> = [];
+  for (const message of batch.messages) {
+    try {
+      const result = await writeRecordToD1(env, message.body);
+      if (result.embedTask) embeddingTasks.push(result.embedTask);
+      message.ack();
+    } catch (err) {
+      // Throwing in the consumer function would fail the entire batch.
+      // Per-message retry confines the failure to this record so siblings
+      // still progress; CF will DLQ the message once max_retries is hit.
+      const reason = err instanceof Error ? err.message : String(err);
+      console.error(`team-sync.queue.write_failed ${message.body.table}/${message.body.id}: ${reason}`);
+      message.retry();
+    }
+  }
+
+  // Embedding failures are non-fatal — Vectorize is a best-effort companion
+  // index and a missed upsert is recoverable via /vectors/reindex. We still
+  // run them in parallel for throughput.
+  if (embeddingTasks.length > 0) {
+    await Promise.allSettled(embeddingTasks.map((task) => task()));
+  }
+}
+
+/**
+ * Dead-letter consumer. Logs each failed message so operators can see the
+ * tail-end record id and table without leaving the Worker logs view; the
+ * daemon UI's Outbox tab (PR2) provides the structured replay/discard path.
+ */
+async function handleDlqBatch(batch: MessageBatch<SyncRecord>, _env: Env): Promise<void> {
+  for (const message of batch.messages) {
+    console.error(
+      `team-sync.dlq received ${message.body.table}/${message.body.id} machine=${message.body.machine_id}`,
+    );
+    message.ack();
+  }
 }
 
 async function handleDelete(env: Env, record: SyncRecord): Promise<void> {
@@ -963,8 +1030,8 @@ export default {
       if (method === 'POST' && path === '/connect') {
         return await handleConnect(request, env);
       }
-      if (method === 'POST' && path === '/sync') {
-        return await handleSync(request, env);
+      if (method === 'POST' && path === '/enqueue') {
+        return await handleEnqueue(request, env);
       }
       if (method === 'GET' && path === '/search') {
         return await handleSearch(request, env);
@@ -1015,4 +1082,17 @@ export default {
     await syncCollectiveSettings(env);
     await sendCollectiveHeartbeat(env);
   },
-} satisfies ExportedHandler<Env>;
+  /**
+   * Queue consumer entry point. Cloudflare invokes this with a MessageBatch
+   * for whichever consumer matched in wrangler.toml; we discriminate by
+   * `batch.queue` name. The DLQ path is the same Worker by design — keeping
+   * one Worker means one deploy and shared types/helpers.
+   */
+  async queue(batch: MessageBatch<SyncRecord>, env: Env, _ctx: ExecutionContext): Promise<void> {
+    if (batch.queue.endsWith('-sync-dlq')) {
+      await handleDlqBatch(batch, env);
+      return;
+    }
+    await handleSyncBatch(batch, env);
+  },
+} satisfies ExportedHandler<Env, SyncRecord>;

--- a/packages/myco-team/worker/src/index.ts
+++ b/packages/myco-team/worker/src/index.ts
@@ -32,6 +32,10 @@ export interface Env {
    * (`myco-team-<hash>-sync`) and provisioned by `myco-team init`.
    */
   SYNC_QUEUE: Queue<SyncRecord>;
+  /** Name of the project's main sync queue — bound from wrangler.toml [vars]. */
+  SYNC_QUEUE_NAME: string;
+  /** Name of the project's dead-letter queue — bound from wrangler.toml [vars]. */
+  SYNC_DLQ_NAME: string;
   MYCO_TEAM_PACKAGE_VERSION?: string;
   MYCO_SCHEMA_VERSION?: string;
 }
@@ -61,6 +65,8 @@ const SYNCED_TABLES = [
   'skill_records',
   'skill_usage',
 ] as const;
+
+const SYNCED_TABLES_SET = new Set<string>(SYNCED_TABLES);
 
 type SyncedTable = (typeof SYNCED_TABLES)[number];
 
@@ -444,7 +450,7 @@ async function handleEnqueue(request: Request, env: Env): Promise<Response> {
   const acceptedRecords: SyncRecord[] = [];
   const rejected: Array<{ id: string; table: string; error: string }> = [];
   for (const record of body.records) {
-    if (!SYNCED_TABLES.includes(record.table)) {
+    if (!SYNCED_TABLES_SET.has(record.table)) {
       rejected.push({ id: record.id, table: record.table, error: `Unknown table: ${record.table}` });
       continue;
     }
@@ -1084,15 +1090,20 @@ export default {
   },
   /**
    * Queue consumer entry point. Cloudflare invokes this with a MessageBatch
-   * for whichever consumer matched in wrangler.toml; we discriminate by
-   * `batch.queue` name. The DLQ path is the same Worker by design — keeping
-   * one Worker means one deploy and shared types/helpers.
+   * for whichever consumer matched in wrangler.toml. Discriminate by exact
+   * queue name from the env binding so unrelated future queues on this
+   * Worker can't be silently routed to the sync handler.
    */
   async queue(batch: MessageBatch<SyncRecord>, env: Env, _ctx: ExecutionContext): Promise<void> {
-    if (batch.queue.endsWith('-sync-dlq')) {
+    if (batch.queue === env.SYNC_DLQ_NAME) {
       await handleDlqBatch(batch, env);
       return;
     }
-    await handleSyncBatch(batch, env);
+    if (batch.queue === env.SYNC_QUEUE_NAME) {
+      await handleSyncBatch(batch, env);
+      return;
+    }
+    console.error(`team-sync.queue.unknown queue=${batch.queue}; ack-and-drop`);
+    for (const message of batch.messages) message.ack();
   },
 } satisfies ExportedHandler<Env, SyncRecord>;

--- a/packages/myco-team/worker/wrangler.toml
+++ b/packages/myco-team/worker/wrangler.toml
@@ -31,5 +31,29 @@ id = "<YOUR_KV_NAMESPACE_ID>"
 [ai]
 binding = "AI"
 
+# Sync queue — producer binding for /api/team/enqueue.
+# Queue name is project-scoped; provisioning fills <YOUR_SYNC_QUEUE_NAME>.
+[[queues.producers]]
+binding = "SYNC_QUEUE"
+queue = "<YOUR_SYNC_QUEUE_NAME>"
+
+# Sync queue consumer — receives MessageBatch<SyncPayload>, writes to D1.
+# Failures retry with exponential backoff up to max_retries, then route to
+# the project's DLQ. Batch tuning kept conservative; revisit after
+# operating data lands.
+[[queues.consumers]]
+queue = "<YOUR_SYNC_QUEUE_NAME>"
+max_batch_size = 100
+max_batch_timeout = 5
+max_retries = 10
+dead_letter_queue = "<YOUR_SYNC_DLQ_NAME>"
+
+# Dead-letter consumer — logs failed messages for operator visibility.
+# No automatic recovery; the daemon UI's Outbox tab surfaces replay/discard.
+[[queues.consumers]]
+queue = "<YOUR_SYNC_DLQ_NAME>"
+max_batch_size = 10
+max_batch_timeout = 30
+
 [triggers]
 crons = ["*/5 * * * *"]

--- a/packages/myco-team/worker/wrangler.toml
+++ b/packages/myco-team/worker/wrangler.toml
@@ -10,6 +10,10 @@ compatibility_flags = [ "nodejs_compat", "global_fetch_strictly_public" ]
 SYNC_PROTOCOL_VERSION = "1"
 MYCO_TEAM_PACKAGE_VERSION = "<MYCO_TEAM_PACKAGE_VERSION>"
 MYCO_SCHEMA_VERSION = "<MYCO_SCHEMA_VERSION>"
+# Mirror the queue names into env vars so the queue() handler can route on
+# equality (batch.queue === env.SYNC_QUEUE_NAME) instead of suffix-matching.
+SYNC_QUEUE_NAME = "<YOUR_SYNC_QUEUE_NAME>"
+SYNC_DLQ_NAME = "<YOUR_SYNC_DLQ_NAME>"
 
 # D1 database — fill database_id after `wrangler d1 create myco-team`
 [[d1_databases]]

--- a/packages/myco/src/constants/log-kinds.ts
+++ b/packages/myco/src/constants/log-kinds.ts
@@ -112,8 +112,7 @@ export const LOG_KINDS = {
   TEAM_SYNC_START: 'team-sync.start',
   TEAM_SYNC_COMPLETE: 'team-sync.complete',
   TEAM_SYNC_ERROR: 'team-sync.error',
-  TEAM_SYNC_RETRY: 'team-sync.retry',
-  TEAM_SYNC_DEAD_LETTER: 'team-sync.dead-letter',
+  TEAM_SYNC_REJECTED: 'team-sync.rejected',
 } as const;
 
 export type LogKind = (typeof LOG_KINDS)[keyof typeof LOG_KINDS];

--- a/packages/myco/src/daemon/api/team-connect.ts
+++ b/packages/myco/src/daemon/api/team-connect.ts
@@ -12,7 +12,7 @@ import { promisify } from 'node:util';
 import { updateTeamConfig, loadMergedConfig } from '@myco/config/loader.js';
 import { resolveProjectRoot } from '@myco/vault/resolve.js';
 import { writeSecret, readSecrets } from '@myco/config/secrets.js';
-import { countPending, countDeadLettered, backfillUnsynced, retryDeadLettered } from '@myco/db/queries/team-outbox.js';
+import { countPending, backfillUnsynced } from '@myco/db/queries/team-outbox.js';
 import { readJsonConfig, resolveVaultConfigPath } from '@myco-deploy/index.js';
 import { getInstalledVersion } from '../update-checker.js';
 import { TEAM_PACKAGE_NAME } from '@myco/constants/update.js';
@@ -216,15 +216,13 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
     }
 
     let pendingCount = 0;
-    let deadLetterCount = 0;
     try {
       pendingCount = countPending();
-      deadLetterCount = countDeadLettered();
     } catch (err) {
       // DB may not have the table yet — log so we don't silently report
       // "0 pending" when the team-outbox queries are actually broken.
       const detail = errorMessage(err);
-      logger.warn('team-sync.outbox.count-failed', 'team-outbox counts unavailable', { error: detail });
+      logger.warn('team-sync.outbox.count-failed', 'team-outbox count unavailable', { error: detail });
     }
 
     let collectiveStatus: Awaited<ReturnType<TeamSyncClient['getCollectiveStatus']>> | null = null;
@@ -270,7 +268,6 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
         healthy,
         health_error: healthError,
         pending_sync_count: pendingCount,
-        dead_letter_count: deadLetterCount,
         machine_id: machineId,
         package_version: getPluginVersion(),
         local_team_package_version: localTeamPackageVersion,
@@ -307,12 +304,6 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
   async function handleBackfill(_req: RouteRequest): Promise<RouteResponse> {
     const count = backfillUnsynced(machineId);
     return { body: { enqueued: count } };
-  }
-
-  /** POST /api/team/retry-failed — move dead-lettered outbox rows back to pending. */
-  async function handleRetryFailed(_req: RouteRequest): Promise<RouteResponse> {
-    const count = retryDeadLettered();
-    return { body: { retried: count } };
   }
 
   /**
@@ -460,5 +451,5 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
     }
   }
 
-  return { handleConnect, handleDisconnect, handleStatus, handleBackfill, handleRetryFailed, handleUpgradeWorker, handleRotateMcpToken };
+  return { handleConnect, handleDisconnect, handleStatus, handleBackfill, handleUpgradeWorker, handleRotateMcpToken };
 }

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -1104,7 +1104,6 @@ export async function main(): Promise<void> {
   });
   server.registerRoute('GET', '/api/team/status', teamHandlers.handleStatus);
   server.registerRoute('POST', '/api/team/backfill', teamHandlers.handleBackfill);
-  server.registerRoute('POST', '/api/team/retry-failed', teamHandlers.handleRetryFailed);
   server.registerRoute('POST', '/api/team/upgrade-worker', teamHandlers.handleUpgradeWorker);
   server.registerRoute('POST', '/api/team/rotate-mcp-token', teamHandlers.handleRotateMcpToken);
 

--- a/packages/myco/src/daemon/team-sync-init.ts
+++ b/packages/myco/src/daemon/team-sync-init.ts
@@ -120,13 +120,8 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
     setTeamClient: (client) => { teamClient = client; },
     reconcileClient,
     registerFlushJob: (powerManager) => {
-      // Always register the flush job; gate at run time so toggling
-      // team.enabled in Settings takes effect without a daemon restart.
-      //
-      // With queues, this loop's only job is to hand outbox rows off to the
-      // worker's /enqueue endpoint. Once the worker accepts a payload it
-      // owns delivery via Cloudflare Queues — backoff, retries, and the
-      // DLQ are queue-runtime concerns, not daemon concerns.
+      // Registered unconditionally; team.enabled is checked at run time so
+      // Settings toggles take effect without a daemon restart.
       powerManager.register({
         name: 'team-sync-flush',
         runIn: ['active', 'idle', 'sleep'],
@@ -144,26 +139,30 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
             const result = await client.enqueueBatch(pending);
             const now = epochSeconds();
 
-            // Validation rejections (unknown table, etc.) are permanent —
-            // they will never succeed, so discard rather than re-buffer.
+            // Partition pending rows by the worker's per-record outcome in
+            // a single pass. Rejections are validation failures (unknown
+            // table, etc.) and will never succeed, so they're discarded
+            // outright — re-buffering would grow the outbox forever.
             const rejectedIds = new Set(result.rejected.map((e) => e.id));
-            const rejectedOutboxIds = pending
-              .filter((r) => rejectedIds.has(String(r.row_id)))
-              .map((r) => r.id);
+            const rejectedOutboxIds: number[] = [];
+            const handedOff: typeof pending = [];
+            for (const row of pending) {
+              if (rejectedIds.has(String(row.row_id))) {
+                rejectedOutboxIds.push(row.id);
+              } else {
+                handedOff.push(row);
+              }
+            }
+
             if (rejectedOutboxIds.length > 0) {
-              logger.warn(LOG_KINDS.TEAM_SYNC_RETRY, `Discarding ${rejectedOutboxIds.length} rejected records`, {
+              logger.warn(LOG_KINDS.TEAM_SYNC_REJECTED, `Discarding ${rejectedOutboxIds.length} rejected records`, {
                 rejected: result.rejected.slice(0, 5),
               });
               discardRows(rejectedOutboxIds);
             }
 
-            // Everything else was handed off to the queue. Mark sent on
-            // local outbox + source rows. If the queue consumer later
-            // dead-letters one of these, the DLQ surface (PR2) is where
-            // operators see and resolve it.
-            const handedOff = pending.filter((r) => !rejectedIds.has(String(r.row_id)));
-            const handedOffIds = handedOff.map((r) => r.id);
-            if (handedOffIds.length > 0) {
+            if (handedOff.length > 0) {
+              const handedOffIds = handedOff.map((r) => r.id);
               markSent(handedOffIds, now);
               markSourceRowsSynced(handedOff, now);
             }
@@ -175,9 +174,8 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
               total: pending.length,
             });
           } catch (err) {
-            // Network/server failure: leave pending — next tick retries.
-            // No counter to increment; if the worker is down, every tick
-            // tries again until it comes back.
+            // Network/server failure: leave pending for the next tick. No
+            // per-row counter — if the worker is down, every tick retries.
             logger.error(LOG_KINDS.TEAM_SYNC_ERROR, 'Outbox flush failed', { error: (err as Error).message });
           }
         },

--- a/packages/myco/src/daemon/team-sync-init.ts
+++ b/packages/myco/src/daemon/team-sync-init.ts
@@ -17,7 +17,7 @@ import {
   markSourceRowsSynced,
   pruneOld,
   backfillUnsynced,
-  incrementRetryCount,
+  discardRows,
   countPending,
 } from '@myco/db/queries/team-outbox.js';
 import {
@@ -122,12 +122,11 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
     registerFlushJob: (powerManager) => {
       // Always register the flush job; gate at run time so toggling
       // team.enabled in Settings takes effect without a daemon restart.
-      const logDeadLettered = (ids: number[]) => {
-        if (ids.length > 0) {
-          logger.error(LOG_KINDS.TEAM_SYNC_DEAD_LETTER, `Dead-lettered ${ids.length} records after max retries`, { ids });
-        }
-      };
-
+      //
+      // With queues, this loop's only job is to hand outbox rows off to the
+      // worker's /enqueue endpoint. Once the worker accepts a payload it
+      // owns delivery via Cloudflare Queues — backoff, retries, and the
+      // DLQ are queue-runtime concerns, not daemon concerns.
       powerManager.register({
         name: 'team-sync-flush',
         runIn: ['active', 'idle', 'sleep'],
@@ -142,49 +141,43 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
 
           try {
             logger.info(LOG_KINDS.TEAM_SYNC_START, 'Flushing outbox', { count: pending.length });
-            const result = await client.pushBatch(pending);
+            const result = await client.enqueueBatch(pending);
             const now = epochSeconds();
 
-            // Mark successfully synced records as sent
-            const failedIds = new Set(result.errors.map((e) => e.id));
-            const sentRecords = pending.filter((r) => !failedIds.has(String(r.row_id)));
-            const sentIds = sentRecords.map((r) => r.id);
-            if (sentIds.length > 0) {
-              markSent(sentIds, now);
-              markSourceRowsSynced(sentRecords, now);
+            // Validation rejections (unknown table, etc.) are permanent —
+            // they will never succeed, so discard rather than re-buffer.
+            const rejectedIds = new Set(result.rejected.map((e) => e.id));
+            const rejectedOutboxIds = pending
+              .filter((r) => rejectedIds.has(String(r.row_id)))
+              .map((r) => r.id);
+            if (rejectedOutboxIds.length > 0) {
+              logger.warn(LOG_KINDS.TEAM_SYNC_RETRY, `Discarding ${rejectedOutboxIds.length} rejected records`, {
+                rejected: result.rejected.slice(0, 5),
+              });
+              discardRows(rejectedOutboxIds);
             }
 
-            // Increment retry count on per-record failures
-            if (result.errors.length > 0) {
-              const failedOutboxIds = pending
-                .filter((r) => failedIds.has(String(r.row_id)))
-                .map((r) => r.id);
-              const deadLettered = incrementRetryCount(failedOutboxIds, now);
-
-              logger.warn(LOG_KINDS.TEAM_SYNC_RETRY, `Retrying ${failedOutboxIds.length} records`, {
-                errors: result.errors.slice(0, 5),
-              });
-
-              logDeadLettered(deadLettered);
+            // Everything else was handed off to the queue. Mark sent on
+            // local outbox + source rows. If the queue consumer later
+            // dead-letters one of these, the DLQ surface (PR2) is where
+            // operators see and resolve it.
+            const handedOff = pending.filter((r) => !rejectedIds.has(String(r.row_id)));
+            const handedOffIds = handedOff.map((r) => r.id);
+            if (handedOffIds.length > 0) {
+              markSent(handedOffIds, now);
+              markSourceRowsSynced(handedOff, now);
             }
 
             pruneOld();
             logger.info(LOG_KINDS.TEAM_SYNC_COMPLETE, 'Outbox flush complete', {
-              synced: result.synced, skipped: result.skipped, errors: result.errors.length, total: pending.length,
+              accepted: result.accepted,
+              rejected: result.rejected.length,
+              total: pending.length,
             });
           } catch (err) {
-            // Batch-level failure: increment retry count on all records
-            try {
-              const now = epochSeconds();
-              const allIds = pending.map((r) => r.id);
-              const deadLettered = incrementRetryCount(allIds, now);
-
-              logger.warn(LOG_KINDS.TEAM_SYNC_RETRY, `Batch failed, retrying ${allIds.length} records`, {
-                error: (err as Error).message,
-              });
-
-              logDeadLettered(deadLettered);
-            } catch { /* best-effort retry tracking */ }
+            // Network/server failure: leave pending — next tick retries.
+            // No counter to increment; if the worker is down, every tick
+            // tries again until it comes back.
             logger.error(LOG_KINDS.TEAM_SYNC_ERROR, 'Outbox flush failed', { error: (err as Error).message });
           }
         },

--- a/packages/myco/src/daemon/team-sync.ts
+++ b/packages/myco/src/daemon/team-sync.ts
@@ -98,6 +98,19 @@ export interface TeamCollectiveSettingsResponse {
   last_sync: number | null;
 }
 
+/** Per-record validation failure returned by the worker's /enqueue. */
+export interface RecordRejection {
+  id: string;
+  table: string;
+  error: string;
+}
+
+/** Worker /enqueue response shape. */
+export interface EnqueueBatchResponse {
+  accepted: number;
+  rejected: RecordRejection[];
+}
+
 // ---------------------------------------------------------------------------
 // Client
 // ---------------------------------------------------------------------------
@@ -157,10 +170,7 @@ export class TeamSyncClient {
    * @returns counts and per-record rejections (validation failures only —
    *   downstream queue failures land in the DLQ, not in this response).
    */
-  async enqueueBatch(records: OutboxRow[]): Promise<{
-    accepted: number;
-    rejected: Array<{ id: string; table: string; error: string }>;
-  }> {
+  async enqueueBatch(records: OutboxRow[]): Promise<EnqueueBatchResponse> {
     const res = await this.request('POST', '/enqueue', {
       machine_id: this.machineId,
       sync_protocol_version: this.syncProtocolVersion,
@@ -176,7 +186,7 @@ export class TeamSyncClient {
         };
       }),
     }, { timeoutMs: TEAM_SYNC_TIMEOUT_MS });
-    const body = res as { accepted?: number; rejected?: Array<{ id: string; table: string; error: string }> };
+    const body = res as Partial<EnqueueBatchResponse>;
     return {
       accepted: body.accepted ?? 0,
       rejected: body.rejected ?? [],

--- a/packages/myco/src/daemon/team-sync.ts
+++ b/packages/myco/src/daemon/team-sync.ts
@@ -146,12 +146,22 @@ export class TeamSyncClient {
   }
 
   /**
-   * Push a batch of outbox records to the team worker.
+   * Hand a batch of outbox records off to the team worker's sync queue.
    *
-   * @returns the number of records accepted by the worker.
+   * The worker validates table names up-front and fans the rest into
+   * Cloudflare Queues; the queue consumer (also part of the worker) does
+   * the actual D1 + Vectorize writes. Daemon-side retry semantics shrink
+   * to "did the handoff succeed?" — once the worker accepts the payload,
+   * Cloudflare's queue runtime owns delivery, retries, and DLQ.
+   *
+   * @returns counts and per-record rejections (validation failures only —
+   *   downstream queue failures land in the DLQ, not in this response).
    */
-  async pushBatch(records: OutboxRow[]): Promise<{ synced: number; skipped: number; errors: Array<{ id: string; table: string; error: string }> }> {
-    const res = await this.request('POST', '/sync', {
+  async enqueueBatch(records: OutboxRow[]): Promise<{
+    accepted: number;
+    rejected: Array<{ id: string; table: string; error: string }>;
+  }> {
+    const res = await this.request('POST', '/enqueue', {
       machine_id: this.machineId,
       sync_protocol_version: this.syncProtocolVersion,
       records: records.map((r) => {
@@ -166,7 +176,11 @@ export class TeamSyncClient {
         };
       }),
     }, { timeoutMs: TEAM_SYNC_TIMEOUT_MS });
-    return res as { synced: number; skipped: number; errors: Array<{ id: string; table: string; error: string }> };
+    const body = res as { accepted?: number; rejected?: Array<{ id: string; table: string; error: string }> };
+    return {
+      accepted: body.accepted ?? 0,
+      rejected: body.rejected ?? [],
+    };
   }
 
   /**

--- a/packages/myco/src/db/migrations.ts
+++ b/packages/myco/src/db/migrations.ts
@@ -70,6 +70,7 @@ export const MIGRATIONS: Migration[] = [
   { version: 27, migrate: (db) => migrateV26ToV27(db) },
   { version: 28, migrate: (db) => migrateV27ToV28(db) },
   { version: 29, migrate: (db) => migrateV28ToV29(db) },
+  { version: 30, migrate: (db) => migrateV29ToV30(db) },
 ];
 
 // ---------------------------------------------------------------------------
@@ -1669,6 +1670,51 @@ function migrateV28ToV29(db: Database): void {
        VALUES (?, ?)
        ON CONFLICT (version) DO NOTHING`,
     ).run(29, epochSeconds());
+    db.prepare('COMMIT').run();
+  } catch (err) {
+    db.prepare('ROLLBACK').run();
+    throw err;
+  }
+}
+
+/**
+ * Version 30 retires the daemon-side dead-letter machinery now that team
+ * sync routes through Cloudflare Queues. The queue runtime owns retry +
+ * DLQ semantics; the daemon's outbox shrinks to a thin offline buffer.
+ *
+ * Steps (in order, inside one transaction):
+ *  1. Discard any rows that the old code had marked dead-lettered. Their
+ *     payloads were rejected by the worker before the queue path existed
+ *     (typically because they carried local-only columns the worker D1
+ *     never had a place for). The source rows still exist locally; if
+ *     they need to reach the team they'll re-enqueue via backfill on
+ *     next daemon startup with the sanitize fix from PR1 in place.
+ *  2. Drop `retry_count` and `last_attempt_at` columns. SQLite ≥ 3.35
+ *     supports DROP COLUMN; we guard with PRAGMA so re-running on an
+ *     already-migrated DB is a no-op.
+ */
+function migrateV29ToV30(db: Database): void {
+  db.prepare('BEGIN').run();
+  try {
+    const cols = getTableColumnSet(db, 'team_outbox');
+
+    if (cols.has('retry_count')) {
+      // Pre-queue dead-lettered rows have stale payloads — delete rather
+      // than re-enqueue. Backfill will re-create them with sanitized
+      // payloads if the source rows are still unsynced.
+      db.prepare(`DELETE FROM team_outbox WHERE sent_at IS NULL AND retry_count >= 10`).run();
+      db.prepare('ALTER TABLE team_outbox DROP COLUMN retry_count').run();
+    }
+
+    if (cols.has('last_attempt_at')) {
+      db.prepare('ALTER TABLE team_outbox DROP COLUMN last_attempt_at').run();
+    }
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at)
+       VALUES (?, ?)
+       ON CONFLICT (version) DO NOTHING`,
+    ).run(30, epochSeconds());
     db.prepare('COMMIT').run();
   } catch (err) {
     db.prepare('ROLLBACK').run();

--- a/packages/myco/src/db/migrations.ts
+++ b/packages/myco/src/db/migrations.ts
@@ -1690,8 +1690,14 @@ function migrateV28ToV29(db: Database): void {
  *     they need to reach the team they'll re-enqueue via backfill on
  *     next daemon startup with the sanitize fix from PR1 in place.
  *  2. Drop `retry_count` and `last_attempt_at` columns. SQLite ≥ 3.35
- *     supports DROP COLUMN; we guard with PRAGMA so re-running on an
- *     already-migrated DB is a no-op.
+ *     supports DROP COLUMN; we guard via PRAGMA so re-running is a no-op.
+ *
+ * Cost note: SQLite DROP COLUMN rewrites the table internally. Two
+ * consecutive drops mean two rewrites. On the dogfood vault (~840
+ * outbox rows) this is sub-second; on a hypothetical heavy vault with
+ * 100k+ rows it would take a few seconds but still bounded. If that
+ * ever becomes a problem the fix is to collapse into a single
+ * CREATE/INSERT/DROP/RENAME rebuild.
  */
 function migrateV29ToV30(db: Database): void {
   db.prepare('BEGIN').run();

--- a/packages/myco/src/db/queries/team-outbox.ts
+++ b/packages/myco/src/db/queries/team-outbox.ts
@@ -1,8 +1,10 @@
 /**
  * Team outbox CRUD query helpers.
  *
- * The outbox pattern: write paths enqueue records here when team sync is enabled.
- * The sync client flushes pending records in batches to the Cloudflare Worker.
+ * The outbox is a thin local buffer for the daemon → team Worker hop.
+ * Cloudflare Queues handle retries, exponential backoff, and dead-lettering
+ * once a record reaches the worker; the outbox just remembers what we still
+ * need to hand off when the Worker is reachable.
  *
  * All functions obtain the SQLite instance internally via `getDatabase()`.
  * Queries use positional `?` placeholders throughout (better-sqlite3).
@@ -20,9 +22,6 @@ const BURST_BATCH_SIZE = 200;
 
 /** Age in seconds after which sent records are pruned (24 hours). */
 const SENT_PRUNE_AGE_SECONDS = 86_400;
-
-/** Max retry attempts before a record is dead-lettered. */
-export const MAX_OUTBOX_RETRIES = 10;
 
 /** Milliseconds-per-second multiplier for epoch math. */
 const MS_PER_SECOND = 1000;
@@ -81,8 +80,6 @@ export interface OutboxRow {
   machine_id: string;
   created_at: number;
   sent_at: number | null;
-  retry_count: number;
-  last_attempt_at: number | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -98,8 +95,6 @@ const OUTBOX_COLUMNS = [
   'machine_id',
   'created_at',
   'sent_at',
-  'retry_count',
-  'last_attempt_at',
 ] as const;
 
 const SELECT_COLUMNS = OUTBOX_COLUMNS.join(', ');
@@ -119,8 +114,6 @@ function toOutboxRow(row: Record<string, unknown>): OutboxRow {
     machine_id: row.machine_id as string,
     created_at: row.created_at as number,
     sent_at: (row.sent_at as number) ?? null,
-    retry_count: (row.retry_count as number) ?? 0,
-    last_attempt_at: (row.last_attempt_at as number) ?? null,
   };
 }
 
@@ -168,7 +161,7 @@ export function syncRow(
  *
  * Inserted with `sent_at = NULL` (pending). Rejects attempts to enqueue
  * tables listed in `LOCAL_ONLY_OUTBOX_TABLES` so private per-machine data
- * can never leak into team sync via a stray call site. Finding #58.
+ * can never leak into team sync via a stray call site.
  */
 export function enqueueOutbox(data: OutboxInsert): OutboxRow {
   if (LOCAL_ONLY_OUTBOX_TABLES.has(data.table_name)) {
@@ -199,30 +192,22 @@ export function enqueueOutbox(data: OutboxInsert): OutboxRow {
   );
 }
 
-/**
- * List pending outbox records (oldest-first).
- *
- * Uses burst sizing: fetches BURST_BATCH_SIZE rows and returns them all.
- * If fewer than BURST_THRESHOLD rows come back, callers get a normal-size
- * batch; if more, the full burst. This avoids a separate COUNT query.
- */
+/** List pending outbox records (oldest-first). */
 export function listPending(limit?: number): OutboxRow[] {
   const db = getDatabase();
 
   const rows = db.prepare(
     `SELECT ${SELECT_COLUMNS}
      FROM team_outbox
-     WHERE sent_at IS NULL AND retry_count < ?
+     WHERE sent_at IS NULL
      ORDER BY created_at ASC
      LIMIT ?`,
-  ).all(MAX_OUTBOX_RETRIES, limit ?? BURST_BATCH_SIZE) as Record<string, unknown>[];
+  ).all(limit ?? BURST_BATCH_SIZE) as Record<string, unknown>[];
 
   return rows.map(toOutboxRow);
 }
 
-/**
- * Mark outbox records as sent by setting sent_at.
- */
+/** Mark outbox records as sent by setting sent_at. */
 export function markSent(ids: number[], sentAt: number): void {
   if (ids.length === 0) return;
 
@@ -237,77 +222,19 @@ export function markSent(ids: number[], sentAt: number): void {
 }
 
 /**
- * Reset sent_at to NULL for records that need to be retried.
- *
- * This allows the sync client to re-enqueue specific records for retry.
+ * Discard outbox rows that the worker rejected at validation time
+ * (e.g. unknown table). These will never succeed; retrying them is
+ * pointless and they would otherwise grow the buffer indefinitely.
  */
-export function markForRetry(ids: number[]): void {
+export function discardRows(ids: number[]): void {
   if (ids.length === 0) return;
 
   const db = getDatabase();
   const placeholders = ids.map(() => '?').join(', ');
 
   db.prepare(
-    `UPDATE team_outbox
-     SET sent_at = NULL
-     WHERE id IN (${placeholders})`,
+    `DELETE FROM team_outbox WHERE id IN (${placeholders})`,
   ).run(...ids);
-}
-
-/**
- * Increment retry_count and set last_attempt_at for failed outbox records.
- *
- * @returns IDs of records that have now reached MAX_OUTBOX_RETRIES (newly dead-lettered).
- */
-export function incrementRetryCount(ids: number[], attemptAt: number): number[] {
-  if (ids.length === 0) return [];
-
-  const db = getDatabase();
-  const placeholders = ids.map(() => '?').join(', ');
-
-  db.prepare(
-    `UPDATE team_outbox
-     SET retry_count = retry_count + 1, last_attempt_at = ?
-     WHERE id IN (${placeholders})`,
-  ).run(attemptAt, ...ids);
-
-  // Return IDs that just hit the threshold
-  const deadLettered = db.prepare(
-    `SELECT id FROM team_outbox
-     WHERE id IN (${placeholders}) AND retry_count >= ?`,
-  ).all(...ids, MAX_OUTBOX_RETRIES) as Array<{ id: number }>;
-
-  return deadLettered.map((r) => r.id);
-}
-
-/**
- * Reset all dead-lettered records back to pending for retry.
- *
- * @returns the number of records reset.
- */
-export function retryDeadLettered(): number {
-  const db = getDatabase();
-
-  const info = db.prepare(
-    `UPDATE team_outbox
-     SET retry_count = 0, last_attempt_at = NULL
-     WHERE sent_at IS NULL AND retry_count >= ?`,
-  ).run(MAX_OUTBOX_RETRIES);
-
-  return info.changes;
-}
-
-/**
- * Count dead-lettered outbox records (exceeded max retries, never sent).
- */
-export function countDeadLettered(): number {
-  const db = getDatabase();
-
-  const row = db.prepare(
-    `SELECT COUNT(*) as count FROM team_outbox WHERE sent_at IS NULL AND retry_count >= ?`,
-  ).get(MAX_OUTBOX_RETRIES) as { count: number };
-
-  return row.count;
 }
 
 /**
@@ -329,15 +256,13 @@ export function pruneOld(): number {
   return info.changes;
 }
 
-/**
- * Count pending (unsent) outbox records.
- */
+/** Count pending (unsent) outbox records. */
 export function countPending(): number {
   const db = getDatabase();
 
   const row = db.prepare(
-    `SELECT COUNT(*) as count FROM team_outbox WHERE sent_at IS NULL AND retry_count < ?`,
-  ).get(MAX_OUTBOX_RETRIES) as { count: number };
+    `SELECT COUNT(*) as count FROM team_outbox WHERE sent_at IS NULL`,
+  ).get() as { count: number };
 
   return row.count;
 }
@@ -372,6 +297,11 @@ const BACKFILL_TABLE_SET = new Set<string>(BACKFILL_TABLES);
  * corresponding source rows. This closes the re-enqueue loop: once
  * synced_at is non-NULL, `backfillUnsynced` skips the row even after
  * the outbox entry is pruned.
+ *
+ * Note: with queues, `synced_at` records that the daemon handed the row
+ * off to the worker — not that the queue consumer wrote it to D1. A
+ * record that ends up in the DLQ will still show synced_at on the local
+ * side; the DLQ surface (PR2) is where operators see and resolve those.
  */
 export function markSourceRowsSynced(records: OutboxRow[], syncedAt: number): void {
   const db = getDatabase();
@@ -433,7 +363,7 @@ export function backfillUnsynced(machineId: string): number {
       for (const row of batchRows) {
         // Strip local-only columns before serializing — backfill must follow
         // the same contract as syncRow(), or restart-driven re-enqueues will
-        // ship columns the worker D1 has no place for and dead-letter them.
+        // ship columns the worker D1 has no place for.
         stmt.run(table, String(row.id), JSON.stringify(sanitizeSyncPayload(table, row)), machineId, now);
       }
     });

--- a/packages/myco/src/db/schema.ts
+++ b/packages/myco/src/db/schema.ts
@@ -19,7 +19,7 @@ import { TABLE_DDLS, FTS_TABLES, SECONDARY_INDEXES } from './schema-ddl.js';
 import { MIGRATIONS } from './migrations.js';
 
 /** Current schema version -- fresh start for the SQLite era. */
-export const SCHEMA_VERSION = 29;
+export const SCHEMA_VERSION = 30;
 
 // Re-export for backwards compat (other modules import from schema.ts)
 export { DEFAULT_MACHINE_ID };

--- a/packages/myco/ui/src/hooks/use-team.ts
+++ b/packages/myco/ui/src/hooks/use-team.ts
@@ -10,7 +10,6 @@ export interface TeamStatusResponse {
   healthy: boolean;
   health_error?: string;
   pending_sync_count: number;
-  dead_letter_count: number;
   local_team_package_version: string | null;
   cached_team_package_version: string | null;
   deployed_worker_version: string | null;

--- a/packages/myco/ui/src/pages/Team.tsx
+++ b/packages/myco/ui/src/pages/Team.tsx
@@ -164,8 +164,6 @@ function ConnectedStatus({ status }: { status: TeamStatusResponse }) {
   const [syncMessage, setSyncMessage] = useState<string | null>(null);
   const [upgrading, setUpgrading] = useState(false);
   const [upgradeMessage, setUpgradeMessage] = useState<string | null>(null);
-  const [retrying, setRetrying] = useState(false);
-  const [retryMessage, setRetryMessage] = useState<string | null>(null);
   const [showMcpSnippet, setShowMcpSnippet] = useState(false);
   const [showRotateConfirm, setShowRotateConfirm] = useState(false);
   const [rotating, setRotating] = useState(false);
@@ -226,24 +224,6 @@ function ConnectedStatus({ status }: { status: TeamStatusResponse }) {
     }
   }, [queryClient]);
 
-  const handleRetryFailed = useCallback(async () => {
-    setRetrying(true);
-    setRetryMessage(null);
-    try {
-      const res = await postJson<{ retried: number }>('/team/retry-failed');
-      setRetryMessage(
-        res.retried > 0
-          ? `Re-queued ${res.retried} record${res.retried > 1 ? 's' : ''} for sync.`
-          : 'No failed records to retry.',
-      );
-      queryClient.invalidateQueries({ queryKey: ['team-status'] });
-    } catch {
-      setRetryMessage('Retry failed.');
-    } finally {
-      setRetrying(false);
-    }
-  }, [queryClient]);
-
   return (
     <div className="space-y-4">
       {/* Worker update banner */}
@@ -291,8 +271,7 @@ function ConnectedStatus({ status }: { status: TeamStatusResponse }) {
         <StatCard
           label="Pending sync"
           value={String(status.pending_sync_count)}
-          accent={status.dead_letter_count > 0 ? 'terracotta' : 'outline'}
-          sublabel={status.dead_letter_count > 0 ? `${status.dead_letter_count} failed` : undefined}
+          accent={status.pending_sync_count > 0 ? 'sage' : 'outline'}
           href="/logs?component=team-sync"
         />
         <StatCard
@@ -476,25 +455,6 @@ function ConnectedStatus({ status }: { status: TeamStatusResponse }) {
         </p>
         {syncMessage && (
           <p className="text-sm text-primary">{syncMessage}</p>
-        )}
-        {status.dead_letter_count > 0 && (
-          <div className="flex items-center justify-between pt-2 border-t border-outline-variant/10">
-            <p className="text-xs text-on-surface-variant">
-              <span className="text-tertiary font-medium">{status.dead_letter_count} failed</span> record{status.dead_letter_count > 1 ? 's' : ''} — exceeded max retries.{' '}
-              <Link to="/logs?component=team-sync&level=error" className="underline hover:text-on-surface">View logs</Link>
-            </p>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleRetryFailed}
-              disabled={retrying}
-            >
-              {retrying ? 'Retrying...' : 'Retry Failed'}
-            </Button>
-          </div>
-        )}
-        {retryMessage && (
-          <p className="text-xs text-primary">{retryMessage}</p>
         )}
       </Surface>
 

--- a/tests/cli/team-upgrade.test.ts
+++ b/tests/cli/team-upgrade.test.ts
@@ -259,6 +259,26 @@ Resource location: remote
     expect(patchedToml).toContain('id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"');
   });
 
+  it('treats existing queues as a successful upgrade (CF "is already taken")', async () => {
+    // KV exists; wrangler queues create reports the collision shape we hit
+    // live ("is already taken", error code 11009). ensureQueue must swallow
+    // both shapes so re-running upgrade is idempotent.
+    const tomlWithKv = LEGACY_TOML + '\n[[kv_namespaces]]\nbinding = "MYCO_SECRETS"\nid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\n';
+    fs.writeFileSync(path.join(deployDir, 'wrangler.toml'), tomlWithKv, 'utf-8');
+
+    execHandlers.push(
+      () => new Error("Queue name 'myco-team-abc12345-sync' is already taken. [code: 11009]"),
+      () => new Error("Queue name 'myco-team-abc12345-sync-dlq' is already taken. [code: 11009]"),
+      () => '',
+      () => '',
+      () => 'https://myco-team-abc12345.test.workers.dev\n',
+    );
+
+    const { upgradeWorker } = await importTeamCli();
+    const result = upgradeWorker(vaultDir);
+    expect(result.success).toBe(true);
+  });
+
   it('returns error when KV provisioning fails', async () => {
     execHandlers.push(() => new Error('Cloudflare API: authentication failed'));
 

--- a/tests/cli/team-upgrade.test.ts
+++ b/tests/cli/team-upgrade.test.ts
@@ -164,6 +164,8 @@ Resource location: remote
 
     execHandlers.push(
       () => wranglerKvCreateOutput,
+      () => '', // wrangler queues create <sync>
+      () => '', // wrangler queues create <dlq>
       () => '',
       () => '',
       () => 'https://myco-team-abc12345.test.workers.dev\n',
@@ -178,6 +180,14 @@ Resource location: remote
     expect(execCalls[0]).toMatchObject({
       command: 'wrangler',
       args: ['kv', 'namespace', 'create', 'myco-team-abc12345-secrets'],
+    });
+    expect(execCalls[1]).toMatchObject({
+      command: 'wrangler',
+      args: ['queues', 'create', 'myco-team-abc12345-sync'],
+    });
+    expect(execCalls[2]).toMatchObject({
+      command: 'wrangler',
+      args: ['queues', 'create', 'myco-team-abc12345-sync-dlq'],
     });
 
     const npmCall = execCalls.find((c) => c.command === 'npm' && c.args[0] === 'install');
@@ -203,6 +213,8 @@ Resource location: remote
     execHandlers.push(
       () => new Error('A namespace with the same title already exists'),
       () => listOutput,
+      () => '', // wrangler queues create <sync>
+      () => '', // wrangler queues create <dlq>
       () => '',
       () => '',
       () => 'https://myco-team-abc12345.test.workers.dev\n',
@@ -222,8 +234,10 @@ Resource location: remote
     const tomlWithKv = LEGACY_TOML + '\n[[kv_namespaces]]\nbinding = "MYCO_SECRETS"\nid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\n';
     fs.writeFileSync(path.join(deployDir, 'wrangler.toml'), tomlWithKv, 'utf-8');
 
-    // Only npm install + secret put + deploy should run; NO kv namespace create
+    // KV is preserved (no create); queue creates still run; then npm install, secret put, deploy
     execHandlers.push(
+      () => '', // wrangler queues create <sync>
+      () => '', // wrangler queues create <dlq>
       () => '',
       () => '',
       () => 'https://myco-team-abc12345.test.workers.dev\n',
@@ -259,6 +273,8 @@ Resource location: remote
   it('returns error when npm install fails', async () => {
     execHandlers.push(
       () => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n',
+      () => '', // wrangler queues create <sync>
+      () => '', // wrangler queues create <dlq>
       () => new Error('npm ERR! ENOENT package.json'),
     );
 
@@ -272,6 +288,8 @@ Resource location: remote
   it('runs npm install in the deploy dir before wrangler deploy', async () => {
     execHandlers.push(
       () => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n',
+      () => '', // wrangler queues create <sync>
+      () => '', // wrangler queues create <dlq>
       () => '',
       () => '',
       () => 'https://myco-team-abc12345.test.workers.dev\n',
@@ -291,6 +309,8 @@ Resource location: remote
   it('teamUpgrade does not trigger remote vector reindex by default', async () => {
     execHandlers.push(
       () => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n',
+      () => '', // wrangler queues create <sync>
+      () => '', // wrangler queues create <dlq>
       () => '',
       () => '',
       () => 'https://myco-team-abc12345.test.workers.dev\n',
@@ -307,6 +327,8 @@ Resource location: remote
   it('teamUpgrade triggers remote vector reindex when explicitly requested', async () => {
     execHandlers.push(
       () => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n',
+      () => '', // wrangler queues create <sync>
+      () => '', // wrangler queues create <dlq>
       () => '',
       () => '',
       () => 'https://myco-team-abc12345.test.workers.dev\n',
@@ -327,6 +349,8 @@ Resource location: remote
   it('retries remote vector reindex when the new route is not ready immediately after deploy', async () => {
     execHandlers.push(
       () => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n',
+      () => '', // wrangler queues create <sync>
+      () => '', // wrangler queues create <dlq>
       () => '',
       () => '',
       () => 'https://myco-team-abc12345.test.workers.dev\n',
@@ -349,6 +373,8 @@ Resource location: remote
   it('retries remote vector reindex when a batch request times out', async () => {
     execHandlers.push(
       () => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n',
+      () => '', // wrangler queues create <sync>
+      () => '', // wrangler queues create <dlq>
       () => '',
       () => '',
       () => 'https://myco-team-abc12345.test.workers.dev\n',

--- a/tests/cli/team-upgrade.test.ts
+++ b/tests/cli/team-upgrade.test.ts
@@ -152,6 +152,28 @@ describe('upgradeWorker', () => {
     vi.unstubAllGlobals();
   });
 
+  /**
+   * Push the trailing 5 handlers every happy-path upgrade test needs after
+   * its KV-mode prefix: queues create sync, queues create dlq, npm install,
+   * wrangler secret put, wrangler deploy. Override individual stages by
+   * passing them in `overrides`.
+   */
+  function pushUpgradeTailHandlers(overrides: {
+    queueSync?: () => string | Error;
+    queueDlq?: () => string | Error;
+    npmInstall?: () => string | Error;
+    secretPut?: () => string | Error;
+    deploy?: () => string | Error;
+  } = {}): void {
+    execHandlers.push(
+      overrides.queueSync ?? (() => ''),
+      overrides.queueDlq ?? (() => ''),
+      overrides.npmInstall ?? (() => ''),
+      overrides.secretPut ?? (() => ''),
+      overrides.deploy ?? (() => 'https://myco-team-abc12345.test.workers.dev\n'),
+    );
+  }
+
   it('provisions a KV namespace on existing deployments that lack one', async () => {
     // Simulate wrangler's actual output format: a JSON config snippet with "id": "..."
     // Real-world observation: KV IDs can be 31 hex chars, not always 32.
@@ -162,14 +184,8 @@ Resource location: remote
 { "kv_namespaces": [ { "binding": "myco_team_abc12345_secrets", "id": "7cc069cb32b4438b29079cca4714056" } ] }
 `;
 
-    execHandlers.push(
-      () => wranglerKvCreateOutput,
-      () => '', // wrangler queues create <sync>
-      () => '', // wrangler queues create <dlq>
-      () => '',
-      () => '',
-      () => 'https://myco-team-abc12345.test.workers.dev\n',
-    );
+    execHandlers.push(() => wranglerKvCreateOutput);
+    pushUpgradeTailHandlers();
 
     const { upgradeWorker } = await importTeamCli();
     const result = upgradeWorker(vaultDir);
@@ -213,12 +229,8 @@ Resource location: remote
     execHandlers.push(
       () => new Error('A namespace with the same title already exists'),
       () => listOutput,
-      () => '', // wrangler queues create <sync>
-      () => '', // wrangler queues create <dlq>
-      () => '',
-      () => '',
-      () => 'https://myco-team-abc12345.test.workers.dev\n',
     );
+    pushUpgradeTailHandlers();
 
     const { upgradeWorker } = await importTeamCli();
     const result = upgradeWorker(vaultDir);
@@ -235,13 +247,7 @@ Resource location: remote
     fs.writeFileSync(path.join(deployDir, 'wrangler.toml'), tomlWithKv, 'utf-8');
 
     // KV is preserved (no create); queue creates still run; then npm install, secret put, deploy
-    execHandlers.push(
-      () => '', // wrangler queues create <sync>
-      () => '', // wrangler queues create <dlq>
-      () => '',
-      () => '',
-      () => 'https://myco-team-abc12345.test.workers.dev\n',
-    );
+    pushUpgradeTailHandlers();
 
     const { upgradeWorker } = await importTeamCli();
     const result = upgradeWorker(vaultDir);
@@ -266,13 +272,10 @@ Resource location: remote
     const tomlWithKv = LEGACY_TOML + '\n[[kv_namespaces]]\nbinding = "MYCO_SECRETS"\nid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\n';
     fs.writeFileSync(path.join(deployDir, 'wrangler.toml'), tomlWithKv, 'utf-8');
 
-    execHandlers.push(
-      () => new Error("Queue name 'myco-team-abc12345-sync' is already taken. [code: 11009]"),
-      () => new Error("Queue name 'myco-team-abc12345-sync-dlq' is already taken. [code: 11009]"),
-      () => '',
-      () => '',
-      () => 'https://myco-team-abc12345.test.workers.dev\n',
-    );
+    pushUpgradeTailHandlers({
+      queueSync: () => new Error("Queue name 'myco-team-abc12345-sync' is already taken. [code: 11009]"),
+      queueDlq: () => new Error("Queue name 'myco-team-abc12345-sync-dlq' is already taken. [code: 11009]"),
+    });
 
     const { upgradeWorker } = await importTeamCli();
     const result = upgradeWorker(vaultDir);
@@ -291,12 +294,10 @@ Resource location: remote
   });
 
   it('returns error when npm install fails', async () => {
-    execHandlers.push(
-      () => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n',
-      () => '', // wrangler queues create <sync>
-      () => '', // wrangler queues create <dlq>
-      () => new Error('npm ERR! ENOENT package.json'),
-    );
+    execHandlers.push(() => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n');
+    pushUpgradeTailHandlers({
+      npmInstall: () => new Error('npm ERR! ENOENT package.json'),
+    });
 
     const { upgradeWorker } = await importTeamCli();
     const result = upgradeWorker(vaultDir);
@@ -306,14 +307,8 @@ Resource location: remote
   });
 
   it('runs npm install in the deploy dir before wrangler deploy', async () => {
-    execHandlers.push(
-      () => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n',
-      () => '', // wrangler queues create <sync>
-      () => '', // wrangler queues create <dlq>
-      () => '',
-      () => '',
-      () => 'https://myco-team-abc12345.test.workers.dev\n',
-    );
+    execHandlers.push(() => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n');
+    pushUpgradeTailHandlers();
 
     const { upgradeWorker } = await importTeamCli();
     upgradeWorker(vaultDir);
@@ -327,14 +322,8 @@ Resource location: remote
   });
 
   it('teamUpgrade does not trigger remote vector reindex by default', async () => {
-    execHandlers.push(
-      () => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n',
-      () => '', // wrangler queues create <sync>
-      () => '', // wrangler queues create <dlq>
-      () => '',
-      () => '',
-      () => 'https://myco-team-abc12345.test.workers.dev\n',
-    );
+    execHandlers.push(() => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n');
+    pushUpgradeTailHandlers();
 
     const { teamUpgrade } = await importTeamCli();
     await teamUpgrade(vaultDir);
@@ -345,14 +334,8 @@ Resource location: remote
   });
 
   it('teamUpgrade triggers remote vector reindex when explicitly requested', async () => {
-    execHandlers.push(
-      () => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n',
-      () => '', // wrangler queues create <sync>
-      () => '', // wrangler queues create <dlq>
-      () => '',
-      () => '',
-      () => 'https://myco-team-abc12345.test.workers.dev\n',
-    );
+    execHandlers.push(() => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n');
+    pushUpgradeTailHandlers();
 
     const { teamUpgrade } = await importTeamCli();
     await teamUpgrade(vaultDir, { reindexVectors: true });
@@ -367,14 +350,8 @@ Resource location: remote
   });
 
   it('retries remote vector reindex when the new route is not ready immediately after deploy', async () => {
-    execHandlers.push(
-      () => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n',
-      () => '', // wrangler queues create <sync>
-      () => '', // wrangler queues create <dlq>
-      () => '',
-      () => '',
-      () => 'https://myco-team-abc12345.test.workers.dev\n',
-    );
+    execHandlers.push(() => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n');
+    pushUpgradeTailHandlers();
 
     const fetchMock = vi.mocked(fetch);
     fetchMock
@@ -391,14 +368,8 @@ Resource location: remote
   });
 
   it('retries remote vector reindex when a batch request times out', async () => {
-    execHandlers.push(
-      () => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n',
-      () => '', // wrangler queues create <sync>
-      () => '', // wrangler queues create <dlq>
-      () => '',
-      () => '',
-      () => 'https://myco-team-abc12345.test.workers.dev\n',
-    );
+    execHandlers.push(() => '{ "kv_namespaces": [ { "binding": "x", "id": "0123456789abcdef0123456789abcdef" } ] }\n');
+    pushUpgradeTailHandlers();
 
     const fetchMock = vi.mocked(fetch);
     fetchMock

--- a/tests/daemon/team-sync-init.test.ts
+++ b/tests/daemon/team-sync-init.test.ts
@@ -22,14 +22,14 @@ mock.module('@myco/db/queries/team-outbox.js', () => ({
   markSourceRowsSynced: vi.fn(),
   pruneOld: vi.fn(),
   backfillUnsynced: backfillUnsyncedMock,
-  incrementRetryCount: vi.fn(() => []),
+  discardRows: vi.fn(),
   countPending: vi.fn(() => 0),
 }));
 
 mock.module('@myco/daemon/team-sync.js', () => ({
   TeamSyncClient: class {
     connect = connectMock;
-    pushBatch = vi.fn();
+    enqueueBatch = vi.fn();
     getCollectiveStatus = vi.fn();
     getMcpToken = vi.fn(() => null);
     getMcpEndpoint = vi.fn(() => null);

--- a/tests/daemon/team-sync.test.ts
+++ b/tests/daemon/team-sync.test.ts
@@ -133,31 +133,32 @@ describe('TeamSyncClient', () => {
     });
   });
 
-  describe('pushBatch', () => {
-    it('POSTs records to /sync', async () => {
+  describe('enqueueBatch', () => {
+    it('POSTs records to /enqueue', async () => {
       const mockFetch = createMockFetch({
-        '/sync': { status: 200, body: { accepted: 2 } },
+        '/enqueue': { status: 200, body: { accepted: 2, rejected: [] } },
       });
 
       const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
       const records = [makeOutboxRow({ id: 1 }), makeOutboxRow({ id: 2 })];
 
-      const result = await client.pushBatch(records);
+      const result = await client.enqueueBatch(records);
       expect(result.accepted).toBe(2);
+      expect(result.rejected).toEqual([]);
     });
 
     it('includes machine_id and sync_protocol_version', async () => {
       let capturedBody: unknown;
       const mockFetch = vi.fn(async (url: string, init: RequestInit) => {
         capturedBody = JSON.parse(init.body as string);
-        return new Response(JSON.stringify({ accepted: 1 }), {
+        return new Response(JSON.stringify({ accepted: 1, rejected: [] }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         });
       }) as unknown as typeof globalThis.fetch;
 
       const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
-      await client.pushBatch([makeOutboxRow()]);
+      await client.enqueueBatch([makeOutboxRow()]);
 
       const body = capturedBody as { machine_id: string; sync_protocol_version: number; records: unknown[] };
       expect(body.machine_id).toBe('test_abc123');
@@ -165,13 +166,28 @@ describe('TeamSyncClient', () => {
       expect(body.records).toHaveLength(1);
     });
 
-    it('throws on sync error', async () => {
+    it('throws on enqueue error', async () => {
       const mockFetch = createMockFetch({
-        '/sync': { status: 409, body: { error: 'version_mismatch' } },
+        '/enqueue': { status: 409, body: { error: 'version_mismatch' } },
       });
 
       const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
-      await expect(client.pushBatch([makeOutboxRow()])).rejects.toThrow(/failed: 409/);
+      await expect(client.enqueueBatch([makeOutboxRow()])).rejects.toThrow(/failed: 409/);
+    });
+
+    it('returns per-record validation rejections', async () => {
+      const mockFetch = createMockFetch({
+        '/enqueue': {
+          status: 200,
+          body: { accepted: 1, rejected: [{ id: 'r2', table: 'unknown_table', error: 'Unknown table: unknown_table' }] },
+        },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      const result = await client.enqueueBatch([makeOutboxRow({ id: 1 }), makeOutboxRow({ id: 2 })]);
+      expect(result.accepted).toBe(1);
+      expect(result.rejected).toHaveLength(1);
+      expect(result.rejected[0].error).toContain('Unknown table');
     });
   });
 

--- a/tests/db/canopy-embedded-migration.test.ts
+++ b/tests/db/canopy-embedded-migration.test.ts
@@ -32,8 +32,8 @@ describe('canopy_entries.embedded migration v26', () => {
     expect(cols.filter((c) => c.name === 'embedded')).toHaveLength(1);
   });
 
-  it('SCHEMA_VERSION is 29', () => {
-    expect(SCHEMA_VERSION).toBe(29);
+  it('SCHEMA_VERSION is 30', () => {
+    expect(SCHEMA_VERSION).toBe(30);
   });
 
   it('migrateV25ToV26 is a no-op when column already exists', () => {

--- a/tests/db/canopy-maps-migration.test.ts
+++ b/tests/db/canopy-maps-migration.test.ts
@@ -27,8 +27,8 @@ describe('canopy_maps migration v27', () => {
     expect(c?.dflt_value).toBe('0');
   });
 
-  it('SCHEMA_VERSION is 29', () => {
-    expect(SCHEMA_VERSION).toBe(29);
+  it('SCHEMA_VERSION is 30', () => {
+    expect(SCHEMA_VERSION).toBe(30);
   });
 
   it('idempotent re-apply', () => {

--- a/tests/db/queries/team-outbox.test.ts
+++ b/tests/db/queries/team-outbox.test.ts
@@ -9,13 +9,10 @@ import {
   enqueueOutbox,
   listPending,
   markSent,
-  markForRetry,
   pruneOld,
   countPending,
-  incrementRetryCount,
-  countDeadLettered,
+  discardRows,
   sanitizeSyncPayload,
-  MAX_OUTBOX_RETRIES,
 } from '@myco/db/queries/team-outbox.js';
 import type { OutboxInsert } from '@myco/db/queries/team-outbox.js';
 
@@ -205,32 +202,25 @@ describe('team outbox query helpers', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // markForRetry
+  // discardRows
   // ---------------------------------------------------------------------------
 
-  describe('markForRetry', () => {
-    it('resets sent_at to NULL for re-processing', () => {
-      const row = enqueueOutbox(makeOutbox());
-      markSent([row.id], epochNow());
+  describe('discardRows', () => {
+    it('deletes the matching rows outright (used for worker-rejected payloads)', () => {
+      const a = enqueueOutbox(makeOutbox());
+      const b = enqueueOutbox(makeOutbox());
 
-      // Verify it's marked as sent
-      expect(listPending()).toHaveLength(0);
+      discardRows([a.id]);
 
-      // Mark for retry
-      markForRetry([row.id]);
-
-      // Now it should be pending again
       const pending = listPending();
       expect(pending).toHaveLength(1);
-      expect(pending[0].id).toBe(row.id);
+      expect(pending[0].id).toBe(b.id);
     });
 
-    it('does nothing for empty ids array', () => {
-      const row = enqueueOutbox(makeOutbox());
-      markSent([row.id], epochNow());
-      markForRetry([]);
-
-      expect(listPending()).toHaveLength(0);
+    it('is a no-op for empty ids', () => {
+      enqueueOutbox(makeOutbox());
+      discardRows([]);
+      expect(listPending()).toHaveLength(1);
     });
   });
 
@@ -297,101 +287,6 @@ describe('team outbox query helpers', () => {
 
       enqueueOutbox(makeOutbox());
       expect(countPending()).toBe(2);
-    });
-
-    it('excludes dead-lettered records', () => {
-      const row = enqueueOutbox(makeOutbox());
-      // Push retry count to max
-      for (let i = 0; i < MAX_OUTBOX_RETRIES; i++) {
-        incrementRetryCount([row.id], epochNow());
-      }
-
-      expect(countPending()).toBe(0);
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // incrementRetryCount
-  // ---------------------------------------------------------------------------
-
-  describe('incrementRetryCount', () => {
-    it('increments retry_count and sets last_attempt_at', () => {
-      const row = enqueueOutbox(makeOutbox());
-      const now = epochNow();
-
-      incrementRetryCount([row.id], now);
-
-      const pending = listPending();
-      expect(pending).toHaveLength(1);
-      expect(pending[0].retry_count).toBe(1);
-      expect(pending[0].last_attempt_at).toBe(now);
-    });
-
-    it('returns empty when no records reach max retries', () => {
-      const row = enqueueOutbox(makeOutbox());
-      const deadLettered = incrementRetryCount([row.id], epochNow());
-
-      expect(deadLettered).toEqual([]);
-    });
-
-    it('returns ids of newly dead-lettered records', () => {
-      const row = enqueueOutbox(makeOutbox());
-      // Increment to one below max
-      for (let i = 0; i < MAX_OUTBOX_RETRIES - 1; i++) {
-        incrementRetryCount([row.id], epochNow());
-      }
-
-      // This push should dead-letter it
-      const deadLettered = incrementRetryCount([row.id], epochNow());
-      expect(deadLettered).toEqual([row.id]);
-    });
-
-    it('does nothing for empty ids array', () => {
-      enqueueOutbox(makeOutbox());
-      const deadLettered = incrementRetryCount([], epochNow());
-
-      expect(deadLettered).toEqual([]);
-      expect(listPending()).toHaveLength(1);
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // dead-lettering (listPending / countDeadLettered)
-  // ---------------------------------------------------------------------------
-
-  describe('dead-lettering', () => {
-    it('listPending excludes records at max retries', () => {
-      const row = enqueueOutbox(makeOutbox());
-      for (let i = 0; i < MAX_OUTBOX_RETRIES; i++) {
-        incrementRetryCount([row.id], epochNow());
-      }
-
-      expect(listPending()).toHaveLength(0);
-    });
-
-    it('countDeadLettered counts records at max retries', () => {
-      expect(countDeadLettered()).toBe(0);
-
-      const row = enqueueOutbox(makeOutbox());
-      for (let i = 0; i < MAX_OUTBOX_RETRIES; i++) {
-        incrementRetryCount([row.id], epochNow());
-      }
-
-      expect(countDeadLettered()).toBe(1);
-    });
-
-    it('dead-lettered records are not returned by listPending but counted by countDeadLettered', () => {
-      const good = enqueueOutbox(makeOutbox());
-      const bad = enqueueOutbox(makeOutbox());
-
-      for (let i = 0; i < MAX_OUTBOX_RETRIES; i++) {
-        incrementRetryCount([bad.id], epochNow());
-      }
-
-      expect(listPending()).toHaveLength(1);
-      expect(listPending()[0].id).toBe(good.id);
-      expect(countPending()).toBe(1);
-      expect(countDeadLettered()).toBe(1);
     });
   });
 });

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -47,7 +47,7 @@ describe('Database schema', () => {
 
   describe('constants', () => {
     it('exports SCHEMA_VERSION as a positive integer', () => {
-      expect(SCHEMA_VERSION).toBe(29);
+      expect(SCHEMA_VERSION).toBe(30);
       expect(Number.isInteger(SCHEMA_VERSION)).toBe(true);
     });
 
@@ -1336,16 +1336,16 @@ describe('Database schema', () => {
         expect(() => runMigration(db, 19)).not.toThrow();
       });
 
-      it('full v13 -> v25 chain reaches SCHEMA_VERSION and is replay-safe', () => {
+      it('full v13 -> v30 chain reaches SCHEMA_VERSION and is replay-safe', () => {
         buildV13Db(db);
-        for (const v of [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]) runMigration(db, v);
+        for (const v of [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]) runMigration(db, v);
 
         const row = db.prepare(
           `SELECT MAX(version) AS v FROM schema_version`,
         ).get() as { v: number };
         expect(row.v).toBe(SCHEMA_VERSION);
 
-        for (const v of [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]) {
+        for (const v of [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]) {
           expect(() => runMigration(db, v), `v${v} replay`).not.toThrow();
         }
       });


### PR DESCRIPTION
## Summary

Big-bang cutover of team sync from the hand-rolled SQLite outbox + dead-letter machinery to managed Cloudflare Queues. The daemon's outbox shrinks to a thin offline buffer for the daemon→Worker hop; once the Worker accepts a payload, Cloudflare's queue runtime owns delivery, retries with exponential backoff up to `max_retries=10`, and dead-lettering.

This is a follow-on to PR1 (tool-surface realignment, #202). It carries the spike outcome documented in the Myco vault — "validate Cloudflare Queues as a viable replacement for the custom outbox retry/dead-letter system." Spike concluded "ship it"; this PR is the result.

**Branch is already deployed and running live on the dogfood vault.** Worker `myco-team-974bc350` is queue-aware; daemon is on schema v30; the 88 stale dead-letter rows on this vault were cleared by the v30 migration. Verified end-to-end: synthetic spore traversed daemon → `/enqueue` → CF Queue → consumer → D1 → cleanup in ~7s.

### What's in scope
- **Worker**: `/enqueue` producer endpoint replaces `/sync`. Per-record validation rejections returned in `{accepted, rejected}`. `queue()` consumer with per-message `ack`/`retry`. DLQ consumer logs only (operator UX is PR2). Queue + DLQ names bound via `wrangler.toml [vars]` for explicit-equality routing.
- **Provisioning IaC**: `myco-team init` and `upgrade` provision both queues idempotently; `prepareDeployDir` substitutes the new placeholders; `teamDestroy` cleans them up. Queue names follow the existing per-project hash convention (`myco-team-<hash>-sync` / `-sync-dlq`).
- **Daemon**: schema v30 drops `retry_count` + `last_attempt_at` and clears any pre-fix dead-letter rows. `team-outbox.ts` shrinks to a thin offline buffer (no per-row retry counter). `TeamSyncClient.enqueueBatch` posts to `/enqueue`. Flush loop partitions accepted/rejected in one pass; `markSent` for handed-off, `discardRows` for validation rejections.
- **UI**: dead-letter banner + "Retry Failed" button removed (the action no longer exists in this architecture). PR2 will rebuild the operator surface against the CF queue + DLQ APIs.
- **Tests**: ~30 fail/pass churn — dead-letter test suites culled, `enqueueBatch` shape covered, `pushUpgradeTailHandlers` helper introduced for fixture maintenance, schema v30 migration covered.

### What's deferred (PR2)
The simplify pass on this branch surfaced three efficiency items that need the consumer hot path touched. Recorded in the PR2 plan and will land there:
- Per-table `db.batch()` coalescing in `handleSyncBatch` (today: ~200 sequential D1 round-trips per 100-msg batch).
- Move `nodes.last_seen` UPDATE off the `/enqueue` hot path into the scheduled heartbeat.
- `OutboxRow.payload` typing — parse-once in `toOutboxRow` rather than the current string-of-JSON with defensive parse.

PR2 also carries the original Team page UX work (3-tab chrome, queue-stats / DLQ proxy endpoints, operator replay/discard actions).

## Test plan
- [x] `npm run lint` (tsc + worker tsc) clean
- [x] `npm run test` — 3724 pass / 0 fail (node) + 67 pass / 0 fail (jsdom)
- [x] Dogfood worker re-deployed; queues `myco-team-974bc350-sync` + `-sync-dlq` show producer=1 / consumer=1
- [x] Live e2e: synthetic spore enqueue → D1-visible in ~7s
- [x] Live e2e: pre-existing 88 dead-letter rows deleted by v30 migration on daemon restart
- [x] Live e2e: post-restart flush logged `Outbox flush complete | {"accepted":13,"rejected":0,"total":13}` against the new shape
- [x] Soak overnight on dogfood before merging (Chris)
- [x] Merge with squash; PR2 opens against fresh main

🤖 Generated with [Claude Code](https://claude.com/claude-code)