### PR TITLE
fix(team-ui): full-width chrome, dedupe pending sync, slow Outbox polling

### DIFF
--- a/packages/myco/ui/src/hooks/use-team.ts
+++ b/packages/myco/ui/src/hooks/use-team.ts
@@ -1,3 +1,4 @@
+import { keepPreviousData } from '@tanstack/react-query';
 import { usePowerQuery } from './use-power-query';
 import { fetchJson } from '../lib/api';
 import { POLL_INTERVALS } from '../lib/constants';
@@ -84,12 +85,17 @@ export function isTokenMissing(value: unknown): value is CfApiTokenMissing {
 }
 
 export function useTeamQueueStats(enabled: boolean) {
+  // Polled slowly because the live values (depth, oldest_msg_age_s) are
+  // stubbed until the GraphQL Analytics wiring lands; the data effectively
+  // doesn't change. keepPreviousData prevents the UI from flashing the
+  // empty state on refetch.
   return usePowerQuery<QueueStatsResponse | CfApiTokenMissing>({
     queryKey: ['team-queue-stats'],
     queryFn: ({ signal }) => fetchJson<QueueStatsResponse | CfApiTokenMissing>('/team/queue-stats', { signal }),
-    refetchInterval: POLL_INTERVALS.STATS,
+    refetchInterval: POLL_INTERVALS.UPDATE,
     pollCategory: 'standard',
     enabled,
+    placeholderData: keepPreviousData,
   });
 }
 
@@ -97,8 +103,9 @@ export function useTeamDlq(enabled: boolean) {
   return usePowerQuery<DlqListResponse | CfApiTokenMissing>({
     queryKey: ['team-dlq'],
     queryFn: ({ signal }) => fetchJson<DlqListResponse | CfApiTokenMissing>('/team/dlq', { signal }),
-    refetchInterval: POLL_INTERVALS.STATS,
+    refetchInterval: POLL_INTERVALS.UPDATE,
     pollCategory: 'standard',
     enabled,
+    placeholderData: keepPreviousData,
   });
 }

--- a/packages/myco/ui/src/pages/Team.tsx
+++ b/packages/myco/ui/src/pages/Team.tsx
@@ -301,18 +301,12 @@ function StatusTab({ status }: { status: TeamStatusResponse }) {
         </Surface>
       )}
 
-      {/* Status overview */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      {/* Status overview — sync queue counters live on the Outbox tab. */}
+      <div className="grid grid-cols-3 gap-3">
         <StatCard
           label="Status"
           value={status.healthy ? 'Connected' : 'Unhealthy'}
           accent={status.healthy ? 'sage' : 'terracotta'}
-        />
-        <StatCard
-          label="Pending sync"
-          value={String(status.pending_sync_count)}
-          accent={status.pending_sync_count > 0 ? 'sage' : 'outline'}
-          href="/logs?component=team-sync"
         />
         <StatCard
           label="Protocol"
@@ -879,64 +873,68 @@ export default function Team() {
   const isConnected = status?.enabled && status?.worker_url;
 
   return (
-    <div className="p-6 max-w-4xl">
-      <PageHeader
-        title="Team"
-        subtitle={isConnected && status ? TAB_SUBTITLES[activeTab] : 'Share knowledge across machines with team sync'}
-        tabs={isConnected ? TEAM_TABS : undefined}
-        activeTab={isConnected ? activeTab : undefined}
-        onTabChange={isConnected ? handleTabChange : undefined}
-      />
+    <div className="flex h-full flex-col">
+      <div className="px-6 pt-6">
+        <PageHeader
+          title="Team"
+          subtitle={isConnected && status ? TAB_SUBTITLES[activeTab] : 'Share knowledge across machines with team sync'}
+          tabs={isConnected ? TEAM_TABS : undefined}
+          activeTab={isConnected ? activeTab : undefined}
+          onTabChange={isConnected ? handleTabChange : undefined}
+        />
+      </div>
 
-      {isConnected && status ? (
-        <>
-          {activeTab === 'status' && <StatusTab status={status} />}
-          {activeTab === 'outbox' && <OutboxTab status={status} />}
-          {activeTab === 'synced' && <SyncedTab status={status} />}
-        </>
-      ) : (
-        <div className="space-y-4">
-          {/* Setup guide */}
-          <Surface level="low" ghostBorder className="p-6 space-y-4">
-            <SectionHeader>Getting Started</SectionHeader>
-            <p className="text-sm text-on-surface-variant">
-              Team sync lets multiple machines share captured knowledge through a Cloudflare Worker.
-              One team member provisions the infrastructure, then shares the connection details.
-            </p>
-
-            <div className="space-y-3">
-              <div>
-                <p className="text-sm font-medium text-on-surface mb-1">1. Install prerequisites</p>
-                <code className="block font-mono text-xs bg-surface-container rounded px-3 py-2 text-on-surface-variant">
-                  npm install -g @goondocks/myco-team wrangler && wrangler login
-                </code>
-              </div>
-
-              <div>
-                <p className="text-sm font-medium text-on-surface mb-1">2. Provision the team</p>
-                <code className="block font-mono text-xs bg-surface-container rounded px-3 py-2 text-on-surface-variant">
-                  myco-team install
-                </code>
-                <p className="text-xs text-on-surface-variant mt-1">
-                  Creates a D1 database, Vectorize index, and deploys the sync worker.
-                  Outputs a Worker URL and API key to share with teammates.
+      <div className="flex-1 overflow-auto">
+        <div className="px-6 pb-6">
+          {isConnected && status ? (
+            <>
+              {activeTab === 'status' && <StatusTab status={status} />}
+              {activeTab === 'outbox' && <OutboxTab status={status} />}
+              {activeTab === 'synced' && <SyncedTab status={status} />}
+            </>
+          ) : (
+            <div className="space-y-4">
+              <Surface level="low" ghostBorder className="p-6 space-y-4">
+                <SectionHeader>Getting Started</SectionHeader>
+                <p className="text-sm text-on-surface-variant">
+                  Team sync lets multiple machines share captured knowledge through a Cloudflare Worker.
+                  One team member provisions the infrastructure, then shares the connection details.
                 </p>
-              </div>
 
-              <div>
-                <p className="text-sm font-medium text-on-surface mb-1">3. Connect</p>
-                <p className="text-xs text-on-surface-variant">
-                  Paste the Worker URL and API key below, or if you ran <code className="font-mono">myco-team install</code>,
-                  you're already connected.
-                </p>
-              </div>
+                <div className="space-y-3">
+                  <div>
+                    <p className="text-sm font-medium text-on-surface mb-1">1. Install prerequisites</p>
+                    <code className="block font-mono text-xs bg-surface-container rounded px-3 py-2 text-on-surface-variant">
+                      npm install -g @goondocks/myco-team wrangler && wrangler login
+                    </code>
+                  </div>
+
+                  <div>
+                    <p className="text-sm font-medium text-on-surface mb-1">2. Provision the team</p>
+                    <code className="block font-mono text-xs bg-surface-container rounded px-3 py-2 text-on-surface-variant">
+                      myco-team install
+                    </code>
+                    <p className="text-xs text-on-surface-variant mt-1">
+                      Creates a D1 database, Vectorize index, and deploys the sync worker.
+                      Outputs a Worker URL and API key to share with teammates.
+                    </p>
+                  </div>
+
+                  <div>
+                    <p className="text-sm font-medium text-on-surface mb-1">3. Connect</p>
+                    <p className="text-xs text-on-surface-variant">
+                      Paste the Worker URL and API key below, or if you ran <code className="font-mono">myco-team install</code>,
+                      you're already connected.
+                    </p>
+                  </div>
+                </div>
+              </Surface>
+
+              <ConnectForm onConnected={() => queryClient.invalidateQueries({ queryKey: ['team-status'] })} />
             </div>
-          </Surface>
-
-          {/* Connect form */}
-          <ConnectForm onConnected={() => queryClient.invalidateQueries({ queryKey: ['team-status'] })} />
+          )}
         </div>
-      )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Three manual-test findings on the Team page after #205 landed:

1. **Width / chrome alignment.** The Team page used `p-6 max-w-4xl`; peer pages (Operations, Settings, Cortex) use a flex-column layout with separate header (`px-6 pt-6`) and body (`flex-1 overflow-auto` + `px-6 pb-6`) padding, no max-width. Now mirrors the Operations pattern — fills the same width and the tabs feel cohesive with the rest of the dashboard.

2. **Pending sync shown twice.** StatusTab still carried a "Pending sync" StatCard from the pre-tab layout; OutboxTab now also surfaces it (it's the local-hand-off counter, which belongs there). Dropped the StatusTab copy and shifted the remaining Status / Protocol / Schema cards from a 4-column grid to a 3-column grid so the row stays balanced.

3. **Outbox tab refetch jitter.** `/queue-stats` and `/dlq` were polling at `POLL_INTERVALS.STATS` (10s) each, with no placeholderData, so every 10s the UI flashed back through the loading shape before re-rendering. `/queue-stats` has stubbed values today (depth=0 until GraphQL Analytics lands), so 10s polling is wasted work; `/dlq` does change but a 30× lower cadence is fine for a manual operator surface. Bumped both to `POLL_INTERVALS.UPDATE` (5min) and added `placeholderData: keepPreviousData` so refetches keep the existing render until new data lands.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run test` — 3791 pass, 0 fail
- [x] Daemon rebuilt + restarted on dogfood; UI smoke-tested
- [x] Confirm tabs feel right at native width

🤖 Generated with [Claude Code](https://claude.com/claude-code)