### PR TITLE
review-prep: address P0/P1 findings from three-bucket release review

### DIFF
--- a/packages/myco-team/worker/src/cf-api.ts
+++ b/packages/myco-team/worker/src/cf-api.ts
@@ -14,9 +14,15 @@ export const CF_API_TOKEN_KV = 'cf_queues_api_token';
 export const CF_ACCOUNT_ID_KV = 'cf_account_id';
 
 export interface QueueStats {
-  /** Approximate number of messages currently in the queue. */
-  depth: number;
-  /** Age (epoch seconds) of the oldest in-queue message, or null if empty. */
+  /**
+   * Approximate number of messages currently in the queue.
+   * `null` means the metric is not available — today every value is null
+   * because CF Queues exposes backlog metrics only via GraphQL Analytics
+   * (separate API not yet wired). The UI renders "—" rather than "0" so
+   * an empty stat doesn't masquerade as a healthy zero.
+   */
+  depth: number | null;
+  /** Age (epoch seconds) of the oldest in-queue message, or null if unknown. */
   oldest_msg_age_s: number | null;
 }
 
@@ -104,10 +110,11 @@ async function fetchQueueStatsForQueue(
   if (!queue) {
     throw new Error(`CF queue not found: ${queueName}`);
   }
-  // Backlog stats live behind a separate GraphQL endpoint; for the v1 of
-  // this surface we return depth=0 when unavailable. The PR2 plan tracks
-  // wiring full GraphQL-driven stats as a later refinement.
-  return { depth: 0, oldest_msg_age_s: null };
+  // Backlog stats live behind the CF Queues GraphQL Analytics endpoint
+  // which isn't wired yet. Return null/null so the UI clearly distinguishes
+  // "stat not yet available" from "queue is empty" — emitting `0` here
+  // would silently lie when a queue is actually backed up.
+  return { depth: null, oldest_msg_age_s: null };
 }
 
 /**
@@ -128,7 +135,11 @@ export async function pullDlqMessages(
   const res = await fetch(url, {
     method: 'POST',
     headers: { Authorization: `Bearer ${creds.token}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ batch_size: batchSize, visibility_timeout_ms: 30_000 }),
+    // Visibility timeout is human-paced: an operator inspects the DLQ row
+    // and decides whether to retry/discard, possibly after a coffee break.
+    // 5 min is long enough to not surprise the user; CF max is 12h if we
+    // ever need to support batch operator review.
+    body: JSON.stringify({ batch_size: batchSize, visibility_timeout_ms: 5 * 60 * 1000 }),
   });
   if (!res.ok) {
     throw new Error(`CF queues pull failed: ${res.status} ${await res.text()}`);
@@ -188,26 +199,50 @@ export async function discardDlqMessages(
   }
 }
 
-const queueIdCache = new Map<string, string>();
+/**
+ * TTL'd queue-id cache with single-flight dedup.
+ *
+ * - 10-minute TTL so a recreated queue (e.g. after destroy + reinstall)
+ *   eventually heals without a Worker redeploy.
+ * - In-flight Promise dedup so concurrent DLQ requests on a cold isolate
+ *   share a single CF API call instead of racing.
+ * - Callers can invoke `invalidateQueueIdCache(queueName)` on a 404 from
+ *   any downstream API to force a refetch on the next call.
+ */
+const QUEUE_ID_CACHE_TTL_MS = 10 * 60 * 1000;
+const queueIdCache = new Map<string, { id: string; expires_at: number }>();
+const queueIdInFlight = new Map<string, Promise<string>>();
+
+export function invalidateQueueIdCache(queueName: string): void {
+  queueIdCache.delete(queueName);
+  queueIdInFlight.delete(queueName);
+}
 
 async function resolveQueueId(
   creds: { token: string; accountId: string },
   queueName: string,
 ): Promise<string> {
   const cached = queueIdCache.get(queueName);
-  if (cached) return cached;
-  const url = `https://api.cloudflare.com/client/v4/accounts/${creds.accountId}/queues?name=${encodeURIComponent(queueName)}`;
-  const res = await fetch(url, {
-    headers: { Authorization: `Bearer ${creds.token}`, 'Content-Type': 'application/json' },
-  });
-  if (!res.ok) {
-    throw new Error(`CF queues list failed: ${res.status} ${await res.text()}`);
-  }
-  const body = await res.json() as { result?: Array<{ queue_id?: string }> };
-  const id = body.result?.[0]?.queue_id;
-  if (!id) {
-    throw new Error(`CF queue not found: ${queueName}`);
-  }
-  queueIdCache.set(queueName, id);
-  return id;
+  if (cached && cached.expires_at > Date.now()) return cached.id;
+
+  const inFlight = queueIdInFlight.get(queueName);
+  if (inFlight) return inFlight;
+
+  const fetchPromise = (async () => {
+    const url = `https://api.cloudflare.com/client/v4/accounts/${creds.accountId}/queues?name=${encodeURIComponent(queueName)}`;
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${creds.token}`, 'Content-Type': 'application/json' },
+    });
+    if (!res.ok) {
+      throw new Error(`CF queues list failed: ${res.status} ${await res.text()}`);
+    }
+    const body = await res.json() as { result?: Array<{ queue_id?: string }> };
+    const id = body.result?.[0]?.queue_id;
+    if (!id) throw new Error(`CF queue not found: ${queueName}`);
+    queueIdCache.set(queueName, { id, expires_at: Date.now() + QUEUE_ID_CACHE_TTL_MS });
+    return id;
+  })().finally(() => queueIdInFlight.delete(queueName));
+
+  queueIdInFlight.set(queueName, fetchPromise);
+  return fetchPromise;
 }

--- a/packages/myco-team/worker/src/mcp/result-shape.ts
+++ b/packages/myco-team/worker/src/mcp/result-shape.ts
@@ -2,12 +2,25 @@ import type { HydratedResult } from '../search-helpers';
 
 type RetrieveHint = { tool: string; input: Record<string, unknown> };
 
+/**
+ * Table-name → canonical entity-type mapping. Mirrors the core
+ * `normalizeResultType` mapping in `packages/myco/src/search-results.ts`
+ * so a worker-side hint and a daemon-side hint produce the same result.
+ *
+ * `agent_runs` and `canopy_*` entries are present even though those tables
+ * aren't synced to D1 today — keeping the mapping complete prevents silent
+ * drift if a future sync expansion does start surfacing them.
+ */
 const TABLE_TO_ENTITY: Record<string, string> = {
   plans: 'plan',
   sessions: 'session',
   spores: 'spore',
   skill_records: 'skill',
   skills: 'skill',
+  agent_runs: 'agent_run',
+  runs: 'agent_run',
+  canopy_entries: 'canopy_entry',
+  canopy_file: 'canopy_entry',
 };
 
 const ENTITY_TO_TOOL: Record<string, string> = {
@@ -15,6 +28,8 @@ const ENTITY_TO_TOOL: Record<string, string> = {
   session: 'myco_sessions',
   spore: 'myco_spores',
   skill: 'myco_skills',
+  agent_run: 'myco_agent',
+  canopy_entry: 'myco_cortex',
 };
 
 export interface CloudSearchResult {
@@ -31,7 +46,7 @@ export interface CloudSearchResult {
 
 export function toCloudSearchResult(result: HydratedResult): CloudSearchResult {
   const type = normalizeEntityType(result.type);
-  const retrieve = retrieveHint(type, result.id, result.machine_id);
+  const retrieve = retrieveHint(type, result.id, result.machine_id, result.data);
   return {
     id: result.id,
     machine_id: result.machine_id,
@@ -49,9 +64,30 @@ export function normalizeEntityType(table: string): string {
   return TABLE_TO_ENTITY[table] ?? table;
 }
 
-function retrieveHint(type: string, id: string, machineId: string): RetrieveHint | undefined {
+function retrieveHint(
+  type: string,
+  id: string,
+  machineId: string,
+  data: Record<string, unknown>,
+): RetrieveHint | undefined {
   const tool = ENTITY_TO_TOOL[type];
   if (!tool) return undefined;
+  if (type === 'agent_run') {
+    return { tool, input: { op: 'run', id } };
+  }
+  if (type === 'canopy_entry') {
+    const projectId = typeof data.project_id === 'string' ? data.project_id : undefined;
+    const path = typeof data.path === 'string' ? data.path : undefined;
+    return {
+      tool,
+      input: {
+        op: 'canopy_entry',
+        id,
+        ...(projectId ? { project_id: projectId } : {}),
+        ...(path ? { path } : {}),
+      },
+    };
+  }
   return { tool, input: { op: 'get', id, machine_id: machineId } };
 }
 
@@ -71,4 +107,9 @@ function previewFor(data: Record<string, unknown>): string {
 
 export function textJson(value: unknown) {
   return { content: [{ type: 'text' as const, text: JSON.stringify(value) }] };
+}
+
+/** Standard error envelope for worker tool handlers. */
+export function textJsonError(error: string) {
+  return textJson({ ok: false, error });
 }

--- a/packages/myco-team/worker/src/mcp/server.ts
+++ b/packages/myco-team/worker/src/mcp/server.ts
@@ -8,6 +8,17 @@ import { handleSessions } from './tools/sessions';
 import { handleSkills } from './tools/skills';
 import { handleSpores } from './tools/spores';
 
+/**
+ * MCP tool surface for the team Cloudflare Worker.
+ *
+ * Mirrors the core daemon's read tools (search, cortex, plans, sessions,
+ * skills, spores). `myco_agent` is intentionally absent: agent run history
+ * is per-machine and `agent_runs` is not in the synced-tables list, so a
+ * worker-side handler would always return empty results. If a future
+ * release starts syncing `agent_runs` to D1, also register `myco_agent`
+ * here and update `result-shape.ts` callers — the entity→tool mapping
+ * already covers it.
+ */
 export function createMcpServerInstance(env: Env): McpServer {
   const server = new McpServer({ name: 'myco', version: '1.0.0' });
 
@@ -25,12 +36,12 @@ export function createMcpServerInstance(env: Env): McpServer {
   }, async (args) => handleSearch(args, env));
 
   server.tool('myco_cortex', 'Retrieve Cortex project intelligence. This team surface currently supports op="digest". Three tiers: 1500 (executive), 5000 (deep onboarding), 10000 (comprehensive).', {
-    op: z.enum(['digest']).default('digest').optional().describe('Operation; only digest is available on the team worker surface'),
+    op: z.enum(['digest']).default('digest').describe('Operation; only digest is available on the team worker surface'),
     tier: z.number().optional().describe('Digest depth: 1500, 5000 (default), or 10000'),
   }, async (args) => handleContext(args, env));
 
   server.tool('myco_plans', 'List or retrieve synced plans. op="list" returns summaries; op="get" returns one full plan by id and optional machine_id from search retrieve hints.', {
-    op: z.enum(['list', 'get']).default('list').optional().describe('Operation; cloud plans are read-only'),
+    op: z.enum(['list', 'get']).default('list').describe('Operation; cloud plans are read-only'),
     id: z.string().optional().describe('Plan id for op="get"'),
     machine_id: z.string().optional().describe('Machine id from a search retrieve hint for disambiguation'),
     status: z.string().optional().describe('Filter by plan status'),
@@ -39,7 +50,7 @@ export function createMcpServerInstance(env: Env): McpServer {
   }, async (args) => handlePlans(args, env));
 
   server.tool('myco_sessions', 'List or retrieve synced coding sessions. Useful for recent activity, work by branch or agent.', {
-    op: z.enum(['list', 'get']).default('list').optional().describe('Operation; cloud sessions are read-only'),
+    op: z.enum(['list', 'get']).default('list').describe('Operation; cloud sessions are read-only'),
     id: z.string().optional().describe('Session id for op="get"'),
     machine_id: z.string().optional().describe('Machine id from a search retrieve hint for disambiguation'),
     limit: z.number().min(1).max(100).default(20).optional().describe('Maximum sessions'),
@@ -50,7 +61,7 @@ export function createMcpServerInstance(env: Env): McpServer {
   }, async (args) => handleSessions(args, env));
 
   server.tool('myco_skills', 'List or retrieve synced project skills — reusable patterns extracted from project knowledge.', {
-    op: z.enum(['list', 'get']).default('list').optional().describe('Operation; cloud skills are read-only'),
+    op: z.enum(['list', 'get']).default('list').describe('Operation; cloud skills are read-only'),
     id: z.string().optional().describe('Skill id or name for op="get"'),
     machine_id: z.string().optional().describe('Machine id from a search retrieve hint for disambiguation'),
     status: z.string().optional().describe('Filter: active, stale, retired'),
@@ -58,7 +69,7 @@ export function createMcpServerInstance(env: Env): McpServer {
   }, async (args) => handleSkills(args, env));
 
   server.tool('myco_spores', 'List or retrieve synced spores. op="list" filters durable observations; op="get" returns one full spore by id and optional machine_id from search retrieve hints. Cloud spores are read-only.', {
-    op: z.enum(['list', 'get']).default('list').optional().describe('Operation; cloud spores are read-only'),
+    op: z.enum(['list', 'get']).default('list').describe('Operation; cloud spores are read-only'),
     id: z.string().optional().describe('Spore id for op="get"'),
     machine_id: z.string().optional().describe('Machine id from a search retrieve hint for disambiguation'),
     status: z.string().optional().describe('Filter by spore status'),

--- a/packages/myco/src/agent/config-resolver.ts
+++ b/packages/myco/src/agent/config-resolver.ts
@@ -23,6 +23,7 @@ import { loadAllTasks } from './registry.js';
 import { loadMergedConfig } from '@myco/config/loader.js';
 import type { MycoConfig, PhaseOverride, TaskProviderOverride } from '@myco/config/schema.js';
 import type { ProviderConfig, EffectiveConfig, HarnessId } from './types.js';
+import { HARNESS_CLAUDE_SDK } from './types.js';
 import { inferHarnessFromProviderType } from './provider-harness.js';
 
 /**
@@ -170,7 +171,7 @@ export function resolveRunConfig(
   let phaseProviderOverrides: Record<string, { provider?: ProviderConfig; model?: string; maxTurns?: number }> = {};
   let taskParams: Record<string, string | number | boolean> | undefined;
   let harness: HarnessId = config.execution?.harness
-    ?? 'claude-sdk';
+    ?? HARNESS_CLAUDE_SDK;
   try {
     const mycoConfig = loadMergedConfig(vaultDir);
 
@@ -183,7 +184,7 @@ export function resolveRunConfig(
       ?? inferHarnessFromProviderType(globalProvider?.type)
       ?? config.execution?.harness
       ?? inferHarnessFromProviderType(config.execution?.provider?.type)
-      ?? 'claude-sdk';
+      ?? HARNESS_CLAUDE_SDK;
 
     if (taskConfig?.provider) {
       taskProviderOverride = toProviderConfig(taskConfig.provider);

--- a/packages/myco/src/agent/executor-state.ts
+++ b/packages/myco/src/agent/executor-state.ts
@@ -8,6 +8,7 @@ import type {
   RuntimeTokenBudget,
   RuntimeUsage,
 } from './types.js';
+import { HARNESS_CLAUDE_SDK } from './types.js';
 
 export interface PhaseCheckpoint {
   name: string;
@@ -49,7 +50,7 @@ export function abortReasonMessage(abortController?: AbortController): string | 
 
 export function parseCheckpointState(raw: string | null | undefined): RunCheckpointState {
   if (!raw) {
-    return { schemaVersion: 2, harness: 'claude-sdk', phases: {} };
+    return { schemaVersion: 2, harness: HARNESS_CLAUDE_SDK, phases: {} };
   }
   try {
     const parsed = JSON.parse(raw) as Partial<RunCheckpointState> & { harness?: HarnessId };
@@ -59,7 +60,7 @@ export function parseCheckpointState(raw: string | null | undefined): RunCheckpo
     };
     return {
       schemaVersion: 2,
-      harness: parsed.harness ?? parsed.harness ?? 'claude-sdk',
+      harness: parsed.harness ?? parsed.harness ?? HARNESS_CLAUDE_SDK,
       provider: parsed.provider,
       providerConfig: parsed.providerConfig,
       model: parsed.model,
@@ -69,7 +70,7 @@ export function parseCheckpointState(raw: string | null | undefined): RunCheckpo
       phases: parsed.phases ?? {},
     };
   } catch {
-    return { schemaVersion: 2, harness: 'claude-sdk', phases: {} };
+    return { schemaVersion: 2, harness: HARNESS_CLAUDE_SDK, phases: {} };
   }
 }
 

--- a/packages/myco/src/agent/harness/claude.ts
+++ b/packages/myco/src/agent/harness/claude.ts
@@ -204,144 +204,170 @@ export class ClaudeSdkHarness implements AgentHarness {
   }
 
   async execute(input: HarnessExecuteInput): Promise<HarnessExecuteResult> {
-    const toolServer = buildToolServer(input);
-    const baseEnv = buildPhaseEnv(input.provider);
-    const env = {
-      ...(baseEnv ?? process.env),
-      MYCO_AGENT_SESSION: '1',
-      // Isolate from the user's Claude Code plugin registry — see
-      // `getIsolatedPluginCacheDir()` docs above. Only honored when the
-      // user hasn't explicitly overridden the cache dir themselves.
-      CLAUDE_CODE_PLUGIN_CACHE_DIR:
-        process.env.CLAUDE_CODE_PLUGIN_CACHE_DIR ?? getIsolatedPluginCacheDir(),
-    };
-
-    // Debug-level record of the per-request tool surface. Filtered out
-    // unless daemon.log_level is set to 'debug' — when it is, operators
-    // can grep the log viewer for `agent.harness.request` to see what
-    // tools each phase actually sent, which is how you catch a plugin
-    // leak before it blows up a real run with a 400 tool-schema error.
-    if (input.logger) {
-      const mcpToolNames = input.toolSurface.toolNames
-        ?? (toolServer ? ['<full-vault-surface>'] : []);
-      input.logger.debug('agent.harness.request', 'Agent harness request', {
-        runId: input.toolSurface.runId,
-        agentId: input.toolSurface.agentId,
-        model: input.model,
-        mcpToolCount: mcpToolNames.length,
-        mcpTools: mcpToolNames,
-        pluginCacheDir: env.CLAUDE_CODE_PLUGIN_CACHE_DIR,
-        sessionRef: input.sessionRef ?? null,
-      });
-    }
-
-    const claudeCodeExecutable = resolveClaudeCodeExecutable();
-    const localProvider = isLocalProvider(input.provider);
-
-    // Always pass `strictMcpConfig: true`, even when the phase wants no
-    // MCP tools (e.g., the orchestrator planner with `toolNames: []`).
-    // Without strict mode, the SDK falls back to loading every MCP server
-    // the user has configured in ~/.claude/mcp.json, ~/.claude.json, and
-    // every installed plugin — 130+ unrelated tools leak into the agent's
-    // tool surface, inflating context and occasionally triggering API
-    // schema rejections (Anthropic's 400 on top-level oneOf/allOf/anyOf).
-    //
-    // `settingSources: []` completes the isolation: the SDK's plugin-sync
-    // path reads `enabledPlugins` from `~/.claude/settings.json` / project
-    // settings and syncs them into our "isolated" plugin cache dir,
-    // re-introducing every developer plugin we meant to exclude. Per the
-    // SDK docs: "When omitted or empty, no filesystem settings are
-    // loaded (SDK isolation mode)."
-    const messageStream: AsyncIterable<SDKMessage> = query({
+    const setup = pickClaudeSetup(input);
+    const prepared = prepareClaudeRun(setup);
+    logClaudeRequest('agent.harness.request', 'Agent harness request', setup, prepared, {
+      sessionRef: input.sessionRef,
+    });
+    const drained = await runClaudeQuery(setup, prepared, {
       prompt: input.prompt,
-      options: {
-        model: input.model,
-        systemPrompt: input.systemPrompt,
-        tools: [],
-        mcpServers: toolServer ? { [MCP_SERVER_NAME]: toolServer } : {},
-        strictMcpConfig: true,
-        settingSources: [],
-        maxTurns: input.maxTurns,
-        permissionMode: 'bypassPermissions',
-        allowDangerouslySkipPermissions: true,
-        persistSession: true,
-        env,
-        ...suppressEffortLeakForLocalProvider(input.provider),
-        ...(claudeCodeExecutable ? { pathToClaudeCodeExecutable: claudeCodeExecutable } : {}),
-        ...(input.sessionRef ? { sessionId: input.sessionRef } : {}),
-        ...(input.abortController ? { abortController: input.abortController } : {}),
-      },
-    });
-
-    const drained = await consumeClaudeMessageStream(messageStream, {
-      localProvider,
+      maxTurns: input.maxTurns,
       sessionRef: input.sessionRef,
+      persistSession: true,
+      abortController: input.abortController,
     });
-
-    return {
-      ...drained,
-      sessionRef: input.sessionRef,
-    };
+    return { ...drained, sessionRef: input.sessionRef };
   }
 
   async openScope(setup: HarnessScopeSetup): Promise<HarnessScope> {
-    const toolServer = buildToolServer({ toolSurface: setup.toolSurface });
-    const claudeCodeExecutable = resolveClaudeCodeExecutable();
-    const baseEnv = buildPhaseEnv(setup.provider);
-    const env = {
-      ...(baseEnv ?? process.env),
-      MYCO_AGENT_SESSION: '1',
-      CLAUDE_CODE_PLUGIN_CACHE_DIR:
-        process.env.CLAUDE_CODE_PLUGIN_CACHE_DIR ?? getIsolatedPluginCacheDir(),
-    };
-    const localProvider = isLocalProvider(setup.provider);
-
-    if (setup.logger) {
-      const mcpToolNames = setup.toolSurface.toolNames
-        ?? (toolServer ? ['<full-vault-surface>'] : []);
-      setup.logger.debug('agent.harness.scope-open', 'Claude SDK scope opened', {
-        runId: setup.toolSurface.runId,
-        agentId: setup.toolSurface.agentId,
-        model: setup.model,
-        mcpToolCount: mcpToolNames.length,
-        mcpTools: mcpToolNames,
-      });
-    }
+    const prepared = prepareClaudeRun(setup);
+    logClaudeRequest('agent.harness.scope-open', 'Claude SDK scope opened', setup, prepared);
 
     let closed = false;
-
     return {
       async run(input: HarnessScopeRunInput): Promise<HarnessExecuteResult> {
         if (closed) throw new Error('ClaudeSdkHarness: scope.run() called after close()');
-
-        const messageStream: AsyncIterable<SDKMessage> = query({
+        return runClaudeQuery(setup, prepared, {
           prompt: input.prompt,
-          options: {
-            model: setup.model,
-            systemPrompt: setup.systemPrompt,
-            tools: [],
-            mcpServers: toolServer ? { [MCP_SERVER_NAME]: toolServer } : {},
-            strictMcpConfig: true,
-            settingSources: [],
-            maxTurns: input.maxTurns,
-            permissionMode: 'bypassPermissions',
-            allowDangerouslySkipPermissions: true,
-            persistSession: false,
-            env,
-            ...suppressEffortLeakForLocalProvider(setup.provider),
-            ...(claudeCodeExecutable ? { pathToClaudeCodeExecutable: claudeCodeExecutable } : {}),
-            ...(input.abortController ? { abortController: input.abortController } : {}),
-          },
+          maxTurns: input.maxTurns,
+          persistSession: false,
+          abortController: input.abortController,
         });
-
-        return consumeClaudeMessageStream(messageStream, { localProvider });
       },
       async close(): Promise<void> {
         // The Claude SDK MCP server is in-process — no async resource to
         // release. Just gate further run() calls.
-        if (closed) return;
         closed = true;
       },
     };
   }
+}
+
+/**
+ * Per-setup state both `execute` and `openScope` need: the in-process MCP
+ * tool server, the merged env, the resolved Claude Code executable path,
+ * and the `localProvider` flag. Computed once per `execute` call (or once
+ * per scope, reused across N scope.run calls).
+ */
+interface PreparedClaudeRun {
+  toolServer: ReturnType<typeof buildToolServer>;
+  env: Record<string, string | undefined>;
+  claudeCodeExecutable: string | undefined;
+  localProvider: boolean;
+}
+
+interface ClaudeRunOptions {
+  prompt: string;
+  maxTurns?: number;
+  sessionRef?: string;
+  persistSession: boolean;
+  abortController?: AbortController;
+}
+
+/** Narrow an ExecuteInput down to the setup-only fields shared with HarnessScopeSetup. */
+function pickClaudeSetup(input: HarnessExecuteInput): HarnessScopeSetup {
+  return {
+    systemPrompt: input.systemPrompt,
+    model: input.model,
+    provider: input.provider,
+    toolSurface: input.toolSurface,
+    logger: input.logger,
+  };
+}
+
+function prepareClaudeRun(setup: HarnessScopeSetup): PreparedClaudeRun {
+  const toolServer = buildToolServer({ toolSurface: setup.toolSurface });
+  const baseEnv = buildPhaseEnv(setup.provider);
+  const env = {
+    ...(baseEnv ?? process.env),
+    MYCO_AGENT_SESSION: '1',
+    // Isolate from the user's Claude Code plugin registry — see
+    // `getIsolatedPluginCacheDir()` docs. Only honored when the user hasn't
+    // overridden the cache dir themselves.
+    CLAUDE_CODE_PLUGIN_CACHE_DIR:
+      process.env.CLAUDE_CODE_PLUGIN_CACHE_DIR ?? getIsolatedPluginCacheDir(),
+  };
+  return {
+    toolServer,
+    env,
+    claudeCodeExecutable: resolveClaudeCodeExecutable(),
+    localProvider: isLocalProvider(setup.provider),
+  };
+}
+
+/**
+ * Debug-level record of the per-request tool surface. Filtered out unless
+ * daemon.log_level is 'debug' — when it is, operators can grep the log
+ * viewer for `agent.harness.request` to see what tools each phase actually
+ * sent, which is how you catch a plugin leak before it blows up a real run
+ * with a 400 tool-schema error.
+ */
+function logClaudeRequest(
+  kind: string,
+  message: string,
+  setup: HarnessScopeSetup,
+  prepared: PreparedClaudeRun,
+  extra: { sessionRef?: string } = {},
+): void {
+  if (!setup.logger) return;
+  const mcpToolNames = setup.toolSurface.toolNames
+    ?? (prepared.toolServer ? ['<full-vault-surface>'] : []);
+  setup.logger.debug(kind, message, {
+    runId: setup.toolSurface.runId,
+    agentId: setup.toolSurface.agentId,
+    model: setup.model,
+    mcpToolCount: mcpToolNames.length,
+    mcpTools: mcpToolNames,
+    pluginCacheDir: prepared.env.CLAUDE_CODE_PLUGIN_CACHE_DIR,
+    ...(extra.sessionRef !== undefined ? { sessionRef: extra.sessionRef ?? null } : {}),
+  });
+}
+
+/**
+ * Run a single Claude SDK query against the prepared setup.
+ *
+ * Always passes `strictMcpConfig: true`, even when the phase wants no
+ * MCP tools (e.g., the orchestrator planner with `toolNames: []`).
+ * Without strict mode, the SDK falls back to loading every MCP server
+ * the user has configured in ~/.claude/mcp.json, ~/.claude.json, and
+ * every installed plugin — 130+ unrelated tools leak into the agent's
+ * tool surface, inflating context and occasionally triggering API
+ * schema rejections (Anthropic's 400 on top-level oneOf/allOf/anyOf).
+ *
+ * `settingSources: []` completes the isolation: the SDK's plugin-sync
+ * path reads `enabledPlugins` from settings.json and syncs them into our
+ * isolated plugin cache dir, re-introducing every developer plugin we
+ * meant to exclude. Per the SDK docs: "When omitted or empty, no
+ * filesystem settings are loaded (SDK isolation mode)."
+ */
+async function runClaudeQuery(
+  setup: HarnessScopeSetup,
+  prepared: PreparedClaudeRun,
+  options: ClaudeRunOptions,
+): Promise<HarnessExecuteResult> {
+  const messageStream: AsyncIterable<SDKMessage> = query({
+    prompt: options.prompt,
+    options: {
+      model: setup.model,
+      systemPrompt: setup.systemPrompt,
+      tools: [],
+      mcpServers: prepared.toolServer ? { [MCP_SERVER_NAME]: prepared.toolServer } : {},
+      strictMcpConfig: true,
+      settingSources: [],
+      maxTurns: options.maxTurns,
+      permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
+      persistSession: options.persistSession,
+      env: prepared.env,
+      ...suppressEffortLeakForLocalProvider(setup.provider),
+      ...(prepared.claudeCodeExecutable ? { pathToClaudeCodeExecutable: prepared.claudeCodeExecutable } : {}),
+      ...(options.sessionRef ? { sessionId: options.sessionRef } : {}),
+      ...(options.abortController ? { abortController: options.abortController } : {}),
+    },
+  });
+
+  return consumeClaudeMessageStream(messageStream, {
+    localProvider: prepared.localProvider,
+    sessionRef: options.sessionRef,
+  });
 }

--- a/packages/myco/src/agent/harness/claude.ts
+++ b/packages/myco/src/agent/harness/claude.ts
@@ -12,6 +12,7 @@ import type {
   HarnessScopeSetup,
 } from './types.js';
 import { HarnessExecutionError } from './types.js';
+import { HARNESS_CLAUDE_SDK } from '@myco/agent/types.js';
 import {
   createMaterializedVaultToolServer,
   createScopedVaultToolServer,
@@ -182,7 +183,7 @@ function buildToolServer(input: { toolSurface: HarnessExecuteInput['toolSurface'
 }
 
 export class ClaudeSdkHarness implements AgentHarness {
-  readonly id = 'claude-sdk' as const;
+  readonly id = HARNESS_CLAUDE_SDK;
 
   supports(capability: HarnessCapability): boolean {
     return capability === 'supportsSessionResume' || capability === 'supportsMcp';

--- a/packages/myco/src/agent/harness/index.ts
+++ b/packages/myco/src/agent/harness/index.ts
@@ -1,7 +1,7 @@
 import { ClaudeSdkHarness } from './claude.js';
 import { OpenAIAgentsHarness } from './openai.js';
 import type { AgentHarness } from './types.js';
-import type { HarnessId } from '@myco/agent/types.js';
+import { HARNESS_CLAUDE_SDK, HARNESS_OPENAI_AGENTS, type HarnessId } from '@myco/agent/types.js';
 
 export * from './types.js';
 
@@ -29,5 +29,5 @@ export function listAgentHarnessIds(): HarnessId[] {
   return [...HARNESS_REGISTRY.keys()];
 }
 
-registerAgentHarness('claude-sdk', () => new ClaudeSdkHarness());
-registerAgentHarness('openai-agents', () => new OpenAIAgentsHarness());
+registerAgentHarness(HARNESS_CLAUDE_SDK, () => new ClaudeSdkHarness());
+registerAgentHarness(HARNESS_OPENAI_AGENTS, () => new OpenAIAgentsHarness());

--- a/packages/myco/src/agent/harness/openai.ts
+++ b/packages/myco/src/agent/harness/openai.ts
@@ -19,6 +19,7 @@ import {
 } from './types.js';
 import { createLocalVaultMcpServer } from './openai-local-mcp.js';
 import type { ProviderConfig, RuntimeUsage } from '@myco/agent/types.js';
+import { HARNESS_OPENAI_AGENTS } from '@myco/agent/types.js';
 import { DEFAULT_LOCAL_AGENT_CONTEXT_WINDOW_TOKENS } from '@myco/agent/context-windows.js';
 import { ensureOllamaContextVariant } from '@myco/agent/ollama-context.js';
 import { OPENAI_API_KEY_ENV } from '@myco/cli/providers/openai-embeddings.js';
@@ -320,7 +321,7 @@ async function runOpenAIAgent(
 }
 
 export class OpenAIAgentsHarness implements AgentHarness {
-  readonly id = 'openai-agents' as const;
+  readonly id = HARNESS_OPENAI_AGENTS;
 
   supports(capability: HarnessCapability): boolean {
     return capability === 'supportsSessionResume' || capability === 'supportsMcp';

--- a/packages/myco/src/agent/harness/openai.ts
+++ b/packages/myco/src/agent/harness/openai.ts
@@ -335,52 +335,33 @@ export class OpenAIAgentsHarness implements AgentHarness {
   }
 
   async execute(input: HarnessExecuteInput): Promise<HarnessExecuteResult> {
-    const preparedExecution = await prepareLocalProviderExecution(input.provider, input.model);
-    const mcpServer = createLocalVaultMcpServer(input.toolSurface);
-    await mcpServer.connect();
-
+    const setup: HarnessScopeSetup = {
+      systemPrompt: input.systemPrompt,
+      model: input.model,
+      provider: input.provider,
+      toolSurface: input.toolSurface,
+      logger: input.logger,
+    };
+    const prepared = await prepareOpenAIRun(setup);
     try {
-      const agent = new Agent({
-        name: 'myco-agent',
-        instructions: input.systemPrompt ?? 'You are the Myco agent harness.',
-        model: preparedExecution.model,
-        mcpServers: [mcpServer],
-      });
-      const runner = new Runner({
-        modelProvider: createProvider(preparedExecution.provider),
-      });
-      return await runOpenAIAgent(runner, agent, input.prompt, {
+      return await runOpenAIAgent(prepared.runner, prepared.agent, input.prompt, {
         maxTurns: input.maxTurns,
         sessionRef: input.sessionRef ?? crypto.randomUUID(),
         sessionData: Array.isArray(input.sessionData) ? (input.sessionData as AgentInputItem[]) : [],
         abortController: input.abortController,
       });
     } finally {
-      await mcpServer.close();
+      await prepared.mcpServer.close();
     }
   }
 
   async openScope(setup: HarnessScopeSetup): Promise<HarnessScope> {
-    const preparedExecution = await prepareLocalProviderExecution(setup.provider, setup.model);
-    const mcpServer = createLocalVaultMcpServer(setup.toolSurface);
-    await mcpServer.connect();
-
-    const agent = new Agent({
-      name: 'myco-agent',
-      instructions: setup.systemPrompt ?? 'You are the Myco agent harness.',
-      model: preparedExecution.model,
-      mcpServers: [mcpServer],
-    });
-    const runner = new Runner({
-      modelProvider: createProvider(preparedExecution.provider),
-    });
-
+    const prepared = await prepareOpenAIRun(setup);
     let closed = false;
-
     return {
       async run(input: HarnessScopeRunInput): Promise<HarnessExecuteResult> {
         if (closed) throw new Error('OpenAIAgentsHarness: scope.run() called after close()');
-        return runOpenAIAgent(runner, agent, input.prompt, {
+        return runOpenAIAgent(prepared.runner, prepared.agent, input.prompt, {
           maxTurns: input.maxTurns,
           sessionRef: crypto.randomUUID(),
           sessionData: [],
@@ -390,10 +371,36 @@ export class OpenAIAgentsHarness implements AgentHarness {
       async close(): Promise<void> {
         if (closed) return;
         closed = true;
-        await mcpServer.close();
+        await prepared.mcpServer.close();
       },
     };
   }
+}
+
+/**
+ * Build the per-setup SDK machinery: connect the MCP server, construct
+ * the Agent + Runner pair. Both `execute` (single-shot, runs once and
+ * closes) and `openScope` (long-lived, scope.run() called N times) share
+ * this — they only diverge in resource lifetime.
+ */
+async function prepareOpenAIRun(setup: HarnessScopeSetup): Promise<{
+  agent: Agent;
+  runner: Runner;
+  mcpServer: ReturnType<typeof createLocalVaultMcpServer>;
+}> {
+  const preparedExecution = await prepareLocalProviderExecution(setup.provider, setup.model);
+  const mcpServer = createLocalVaultMcpServer(setup.toolSurface);
+  await mcpServer.connect();
+  const agent = new Agent({
+    name: 'myco-agent',
+    instructions: setup.systemPrompt ?? 'You are the Myco agent harness.',
+    model: preparedExecution.model,
+    mcpServers: [mcpServer],
+  });
+  const runner = new Runner({
+    modelProvider: createProvider(preparedExecution.provider),
+  });
+  return { agent, runner, mcpServer };
 }
 
 /**

--- a/packages/myco/src/agent/loader.ts
+++ b/packages/myco/src/agent/loader.ts
@@ -18,6 +18,7 @@ import { registerAgent } from '@myco/db/queries/agents.js';
 import { upsertTask } from '@myco/db/queries/tasks.js';
 import type { AgentRow } from '@myco/db/queries/agents.js';
 import type { AgentDefinition, AgentTask, EffectiveConfig } from './types.js';
+import { HARNESS_CLAUDE_SDK } from './types.js';
 import { AgentDefinitionSchema, AgentTaskSchema } from './schemas.js';
 import { BUNDLED_AGENT_DEFINITION, BUNDLED_AGENT_PROMPTS, BUNDLED_AGENT_TASKS } from './definitions.generated.js';
 
@@ -204,7 +205,7 @@ export function resolveEffectiveConfig(
   agentOverrides?: AgentRow | null,
   taskOverrides?: AgentTask,
 ): EffectiveConfig {
-  let harness = taskOverrides?.execution?.harness ?? 'claude-sdk';
+  let harness = taskOverrides?.execution?.harness ?? HARNESS_CLAUDE_SDK;
   // Start with definition defaults
   let model = definition.model;
   let reasoningLevel = taskOverrides?.reasoningLevel;

--- a/packages/myco/src/agent/provider-harness.ts
+++ b/packages/myco/src/agent/provider-harness.ts
@@ -1,4 +1,5 @@
 import type { ProviderType, HarnessId } from './types.js';
+import { HARNESS_CLAUDE_SDK, HARNESS_OPENAI_AGENTS } from './types.js';
 import {
   DEFAULT_COMPATIBLE_CONTEXT_WINDOW_TOKENS,
   DEFAULT_FRONTIER_CONTEXT_WINDOW_TOKENS,
@@ -22,33 +23,33 @@ export interface ProviderMetadata {
 
 export const PROVIDER_METADATA_BY_TYPE: Record<ProviderType, ProviderMetadata> = {
   anthropic: {
-    harness: 'claude-sdk',
-    supportedHarnesses: ['claude-sdk'],
+    harness: HARNESS_CLAUDE_SDK,
+    supportedHarnesses: [HARNESS_CLAUDE_SDK],
     defaultContextWindowTokens: DEFAULT_FRONTIER_CONTEXT_WINDOW_TOKENS,
   },
   ollama: {
-    harness: 'claude-sdk',
-    supportedHarnesses: ['claude-sdk', 'openai-agents'],
+    harness: HARNESS_CLAUDE_SDK,
+    supportedHarnesses: [HARNESS_CLAUDE_SDK, HARNESS_OPENAI_AGENTS],
     defaultContextWindowTokens: DEFAULT_LOCAL_AGENT_CONTEXT_WINDOW_TOKENS,
   },
   lmstudio: {
-    harness: 'claude-sdk',
-    supportedHarnesses: ['claude-sdk', 'openai-agents'],
+    harness: HARNESS_CLAUDE_SDK,
+    supportedHarnesses: [HARNESS_CLAUDE_SDK, HARNESS_OPENAI_AGENTS],
     defaultContextWindowTokens: DEFAULT_LOCAL_AGENT_CONTEXT_WINDOW_TOKENS,
   },
   openai: {
-    harness: 'openai-agents',
-    supportedHarnesses: ['openai-agents'],
+    harness: HARNESS_OPENAI_AGENTS,
+    supportedHarnesses: [HARNESS_OPENAI_AGENTS],
     defaultContextWindowTokens: DEFAULT_FRONTIER_CONTEXT_WINDOW_TOKENS,
   },
   openrouter: {
-    harness: 'openai-agents',
-    supportedHarnesses: ['openai-agents'],
+    harness: HARNESS_OPENAI_AGENTS,
+    supportedHarnesses: [HARNESS_OPENAI_AGENTS],
     defaultContextWindowTokens: DEFAULT_FRONTIER_CONTEXT_WINDOW_TOKENS,
   },
   'openai-compatible': {
-    harness: 'openai-agents',
-    supportedHarnesses: ['openai-agents'],
+    harness: HARNESS_OPENAI_AGENTS,
+    supportedHarnesses: [HARNESS_OPENAI_AGENTS],
     defaultContextWindowTokens: DEFAULT_COMPATIBLE_CONTEXT_WINDOW_TOKENS,
   },
 };

--- a/packages/myco/src/agent/types.ts
+++ b/packages/myco/src/agent/types.ts
@@ -162,7 +162,16 @@ export interface ContextQuery {
   required: boolean;
 }
 
-export type BuiltinHarnessId = 'claude-sdk' | 'openai-agents';
+/**
+ * Canonical identifiers for the two built-in agent harnesses. Use these
+ * constants instead of literal strings — every cross-file dispatch table,
+ * config migration, provider→harness map, and test fixture should import
+ * from here so a future rename happens in one place.
+ */
+export const HARNESS_CLAUDE_SDK = 'claude-sdk' as const;
+export const HARNESS_OPENAI_AGENTS = 'openai-agents' as const;
+export const BUILTIN_HARNESS_IDS = [HARNESS_CLAUDE_SDK, HARNESS_OPENAI_AGENTS] as const;
+export type BuiltinHarnessId = typeof BUILTIN_HARNESS_IDS[number];
 export type HarnessId = string;
 export type ReasoningLevel = 'low' | 'default' | 'high';
 

--- a/packages/myco/src/config/migrations.ts
+++ b/packages/myco/src/config/migrations.ts
@@ -13,6 +13,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { HARNESS_CLAUDE_SDK, HARNESS_OPENAI_AGENTS } from '@myco/agent/types.js';
 
 export interface Migration {
   version: number;
@@ -426,11 +427,11 @@ export const MIGRATIONS: Migration[] = [
           case 'openai':
           case 'openrouter':
           case 'openai-compatible':
-            return 'openai-agents';
+            return HARNESS_OPENAI_AGENTS;
           case 'anthropic':
           case 'ollama':
           case 'lmstudio':
-            return 'claude-sdk';
+            return HARNESS_CLAUDE_SDK;
           default:
             return undefined;
         }

--- a/packages/myco/src/daemon/api/providers.ts
+++ b/packages/myco/src/daemon/api/providers.ts
@@ -25,7 +25,7 @@ import {
 } from './models.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 import type { DaemonLogger } from '../logger.js';
-import { PROVIDER_TYPES, type HarnessId, type ProviderType } from '@myco/agent/types.js';
+import { PROVIDER_TYPES, HARNESS_CLAUDE_SDK, HARNESS_OPENAI_AGENTS, type HarnessId, type ProviderType } from '@myco/agent/types.js';
 import { DEFAULT_OPENAI_URL, DEFAULT_OPENROUTER_URL } from '@myco/agent/provider.js';
 import { getSupportedHarnessesForProviderType } from '@myco/agent/provider-harness.js';
 import { errorMessage } from '@myco/utils/error-message.js';
@@ -81,7 +81,7 @@ export async function handleGetProviders(logger?: DaemonLogger): Promise<RouteRe
     extras: Omit<ProviderInfo, 'type' | 'harness' | 'availableHarnesses'>,
   ): ProviderInfo => ({
     type,
-    harness: getSupportedHarnessesForProviderType(type)[0] ?? 'claude-sdk',
+    harness: getSupportedHarnessesForProviderType(type)[0] ?? HARNESS_CLAUDE_SDK,
     availableHarnesses: getSupportedHarnessesForProviderType(type),
     ...extras,
   });
@@ -209,7 +209,7 @@ async function detectLocalProviderInfo(
   const supported = getSupportedHarnessesForProviderType(type);
   return {
     type,
-    harness: type === 'openai-compatible' ? 'openai-agents' : 'claude-sdk',
+    harness: type === 'openai-compatible' ? HARNESS_OPENAI_AGENTS : HARNESS_CLAUDE_SDK,
     availableHarnesses: supported,
     available: status.available,
     baseUrl: defaultBaseUrl,
@@ -230,7 +230,7 @@ async function detectAnthropic(logger?: DaemonLogger): Promise<ProviderInfo> {
   if (anthropicModelsCache && now - anthropicModelsCache.ts < ANTHROPIC_MODELS_CACHE_TTL_MS) {
     return {
       type: 'anthropic',
-      harness: 'claude-sdk',
+      harness: HARNESS_CLAUDE_SDK,
       availableHarnesses: getSupportedHarnessesForProviderType('anthropic'),
       available: true,
       models: anthropicModelsCache.models,
@@ -261,7 +261,7 @@ async function detectAnthropic(logger?: DaemonLogger): Promise<ProviderInfo> {
   anthropicModelsCache = { ts: now, models };
   return {
     type: 'anthropic',
-    harness: 'claude-sdk',
+    harness: HARNESS_CLAUDE_SDK,
     availableHarnesses: getSupportedHarnessesForProviderType('anthropic'),
     available: true,
     models,
@@ -292,7 +292,7 @@ async function detectRemoteProviderInfo(
 
   return {
     type,
-    harness: 'openai-agents',
+    harness: HARNESS_OPENAI_AGENTS,
     availableHarnesses: getSupportedHarnessesForProviderType(type),
     available,
     authConfigured,

--- a/packages/myco/src/daemon/api/team-connect.ts
+++ b/packages/myco/src/daemon/api/team-connect.ts
@@ -12,7 +12,13 @@ import { promisify } from 'node:util';
 import { updateTeamConfig, loadMergedConfig } from '@myco/config/loader.js';
 import { resolveProjectRoot } from '@myco/vault/resolve.js';
 import { writeSecret, readSecrets } from '@myco/config/secrets.js';
-import { countPending, backfillUnsynced } from '@myco/db/queries/team-outbox.js';
+import {
+  countPending,
+  backfillUnsynced,
+  LOCAL_ONLY_OUTBOX_TABLES,
+  LOCAL_ONLY_SYNC_COLUMNS,
+  LOCAL_ONLY_RATIONALES,
+} from '@myco/db/queries/team-outbox.js';
 import { readJsonConfig, resolveVaultConfigPath } from '@myco-deploy/index.js';
 import { getInstalledVersion } from '../update-checker.js';
 import { TEAM_PACKAGE_NAME } from '@myco/constants/update.js';
@@ -296,8 +302,34 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
         sync_protocol_version: SYNC_PROTOCOL_VERSION,
         mcp_token: client?.getMcpToken() ?? null,
         mcp_endpoint: client?.getMcpEndpoint() ?? null,
+        local_only_disclosures: buildLocalOnlyDisclosures(),
       },
     };
+  }
+
+  /**
+   * Snapshot the local-only sync policy for the UI's "What stays local"
+   * disclosure on the Synced data tab. Derived from the canonical
+   * LOCAL_ONLY_OUTBOX_TABLES + LOCAL_ONLY_SYNC_COLUMNS + LOCAL_ONLY_RATIONALES
+   * exports so the UI can never drift from the enforcement.
+   */
+  function buildLocalOnlyDisclosures(): Array<{ table: string; columns: string[]; rationale: string }> {
+    const disclosures: Array<{ table: string; columns: string[]; rationale: string }> = [];
+    for (const table of LOCAL_ONLY_OUTBOX_TABLES) {
+      disclosures.push({
+        table,
+        columns: ['(entire table)'],
+        rationale: LOCAL_ONLY_RATIONALES[table] ?? 'Local-only by policy.',
+      });
+    }
+    for (const [table, columns] of Object.entries(LOCAL_ONLY_SYNC_COLUMNS)) {
+      disclosures.push({
+        table,
+        columns: [...columns],
+        rationale: LOCAL_ONLY_RATIONALES[table] ?? 'Local-only columns by policy.',
+      });
+    }
+    return disclosures;
   }
 
   /** POST /api/team/backfill — enqueue all unsynced rows to the outbox. */

--- a/packages/myco/src/daemon/server.ts
+++ b/packages/myco/src/daemon/server.ts
@@ -166,6 +166,11 @@ export class DaemonServer {
         res.writeHead(status, headers);
         res.end(JSON.stringify(result.body));
       } catch (error) {
+        if (error instanceof RequestBodyTooLarge) {
+          res.writeHead(413, { 'Content-Type': 'application/json', ...versionHeader });
+          res.end(JSON.stringify({ error: 'request_body_too_large', limit_bytes: MAX_REQUEST_BODY_BYTES }));
+          return;
+        }
         this.logger.error(LOG_KINDS.SERVER_ERROR, 'Request handler error', {
           path: req.url,
           error: (error as Error).message,
@@ -352,13 +357,38 @@ export class DaemonServer {
   }
 }
 
+/**
+ * Hard cap on request body size. The daemon binds 127.0.0.1 only and is
+ * gated by loopback CSRF, so this is defense-in-depth rather than a
+ * security boundary — but unbounded reads from a misbehaving local
+ * client (or a swap-thrashed hung browser) could OOM the daemon.
+ * 8 MB is well above the largest legitimate API request shape.
+ */
+const MAX_REQUEST_BODY_BYTES = 8 * 1024 * 1024;
+
+class RequestBodyTooLarge extends Error {
+  constructor() { super('Request body exceeds maximum size'); }
+}
+
 function readBody(req: http.IncomingMessage): Promise<unknown> {
   return new Promise((resolve, reject) => {
-    let data = '';
-    req.on('data', (chunk: string) => { data += chunk; });
+    const chunks: Buffer[] = [];
+    let total = 0;
+    req.on('data', (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > MAX_REQUEST_BODY_BYTES) {
+        reject(new RequestBodyTooLarge());
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
     req.on('end', () => {
-      try { resolve(data ? JSON.parse(data) : {}); }
-      catch (e) { reject(e); }
+      if (total > MAX_REQUEST_BODY_BYTES) return;
+      try {
+        const text = Buffer.concat(chunks).toString('utf-8');
+        resolve(text ? JSON.parse(text) : {});
+      } catch (e) { reject(e); }
     });
     req.on('error', reject);
   });

--- a/packages/myco/src/daemon/team-sync.ts
+++ b/packages/myco/src/daemon/team-sync.ts
@@ -314,15 +314,23 @@ export class TeamSyncClient {
     return res as T;
   }
 
-  /** Fetch queue + DLQ depth/age stats. Returns null if the worker has no
-   *  CF API token configured yet (UI prompts the operator to set one). */
+  /**
+   * Fetch queue + DLQ depth/age stats. Returns the
+   * `cf_api_token_not_configured` discriminator when the worker has no CF
+   * API token yet — the UI uses that to surface the token-config form.
+   * Pass-through 412 keeps the body accessible instead of throwing.
+   */
   async getQueueStats(): Promise<QueueStatsResponse | { error: 'cf_api_token_not_configured' }> {
-    return await this.request('GET', '/queue-stats') as QueueStatsResponse | { error: 'cf_api_token_not_configured' };
+    return await this.request('GET', '/queue-stats', undefined, {
+      passthroughStatuses: [412],
+    }) as QueueStatsResponse | { error: 'cf_api_token_not_configured' };
   }
 
   /** List a page of DLQ messages. */
   async listDlq(limit = 50): Promise<DlqListResponse | { error: 'cf_api_token_not_configured' }> {
-    return await this.request('GET', `/dlq?limit=${limit}`) as DlqListResponse | { error: 'cf_api_token_not_configured' };
+    return await this.request('GET', `/dlq?limit=${limit}`, undefined, {
+      passthroughStatuses: [412],
+    }) as DlqListResponse | { error: 'cf_api_token_not_configured' };
   }
 
   /** Re-publish DLQ messages back onto the main queue. */
@@ -403,7 +411,7 @@ export class TeamSyncClient {
     method: string,
     path: string,
     body?: unknown,
-    options: { timeoutMs?: number } = {},
+    options: { timeoutMs?: number; passthroughStatuses?: number[] } = {},
   ): Promise<unknown> {
     const timeoutMs = options.timeoutMs ?? TEAM_REQUEST_TIMEOUT_MS;
     const controller = new AbortController();
@@ -417,7 +425,10 @@ export class TeamSyncClient {
         signal: controller.signal,
       });
 
-      if (!res.ok) {
+      // passthroughStatuses are surfaces where the worker's body is the
+      // discriminated response shape (e.g. 412 cf_api_token_not_configured)
+      // and the caller wants to inspect it rather than catch a throw.
+      if (!res.ok && !options.passthroughStatuses?.includes(res.status)) {
         const text = await res.text().catch(() => '');
         throw new Error(`Team sync request ${method} ${path} failed: ${res.status} ${text}`);
       }

--- a/packages/myco/src/db/queries/team-outbox.ts
+++ b/packages/myco/src/db/queries/team-outbox.ts
@@ -43,7 +43,7 @@ export const LOCAL_ONLY_OUTBOX_TABLES = new Set<string>([
   'cortex_instructions',
 ]);
 
-const LOCAL_ONLY_SYNC_COLUMNS: Record<string, readonly string[]> = {
+export const LOCAL_ONLY_SYNC_COLUMNS: Record<string, readonly string[]> = {
   sessions: [
     'embedded',
     'canopy_injections_offered',
@@ -54,6 +54,17 @@ const LOCAL_ONLY_SYNC_COLUMNS: Record<string, readonly string[]> = {
     'canopy_redundant_reads',
     'canopy_map_tool_calls',
   ],
+};
+
+/**
+ * Human-readable rationale for each local-only table/column group. The Team
+ * page UI surfaces this so operators can see why their data isn't
+ * appearing on a teammate's machine. Co-located with the policy itself so
+ * the disclosure can't drift from the enforcement.
+ */
+export const LOCAL_ONLY_RATIONALES: Record<string, string> = {
+  cortex_instructions: 'Per-machine operating guidance generated from local digest substrate; never synced to the team.',
+  sessions: 'Local-only behavioural counters: embedding state and Canopy injection telemetry stay on the originating machine.',
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/myco/src/tools/index.ts
+++ b/packages/myco/src/tools/index.ts
@@ -263,40 +263,58 @@ export function createMycoTools(vaultDir: string, client: DaemonClient, options:
 
   async function dispatchCortex(input: ToolInput, start: number): Promise<unknown> {
     const op = input.op ?? 'digest';
-    const {
-      handleCortexCanopyEntry,
-      handleCortexCanopyMap,
-      handleCortexDigest,
-      handleCortexInstructions,
-    } = await import('./cortex.js');
+    const cortex = await import('./cortex.js');
 
     switch (op) {
       case 'digest': {
-        const result = await handleCortexDigest(input as unknown as Parameters<typeof handleCortexDigest>[0], client);
+        const result = await cortex.handleCortexDigest(input as unknown as Parameters<typeof cortex.handleCortexDigest>[0], client);
         logActivity(TOOL_CORTEX, { op, tier: result.tier, fallback: result.fallback, duration_ms: Date.now() - start });
         return result;
       }
       case 'instructions': {
-        const result = await handleCortexInstructions(client);
+        const result = await cortex.handleCortexInstructions(client);
         logActivity(TOOL_CORTEX, { op, duration_ms: Date.now() - start });
         return result;
       }
       case 'canopy_entry':
+        return await dispatchCanopyEntry(input, start, cortex.handleCortexCanopyEntry);
       case 'canopy_map':
-        break;
+        return await dispatchCanopyMap(input, start, cortex.handleCortexCanopyMap);
       default:
         throw new ToolError('invalid_input', `Unknown op '${String(op)}' for tool ${TOOL_CORTEX}`);
     }
+  }
 
+  /**
+   * Both Canopy ops need vault DB init before reading. When the DB isn't
+   * available we return the empty-map sentinel so callers see a typed
+   * "no data yet" payload rather than a hard error.
+   */
+  async function ensureCanopyDb(): Promise<{ ready: true } | { ready: false; emptyResult: unknown }> {
+    if (await ensureDb()) return { ready: true };
     const { emptyCanopyMap } = await import('./canopy-map.js');
-    if (!(await ensureDb())) {
-      return emptyCanopyMap('Vault database is not available; Canopy data cannot be read right now.');
-    }
-    if (op === 'canopy_entry') {
-      const result = await handleCortexCanopyEntry(input as unknown as Parameters<typeof handleCortexCanopyEntry>[0]);
-      logActivity(TOOL_CORTEX, { op, id: input.id, project_id: input.project_id, path: input.path, duration_ms: Date.now() - start });
-      return result;
-    }
+    return { ready: false, emptyResult: emptyCanopyMap('Vault database is not available; Canopy data cannot be read right now.') };
+  }
+
+  async function dispatchCanopyEntry(
+    input: ToolInput,
+    start: number,
+    handleCortexCanopyEntry: typeof import('./cortex.js')['handleCortexCanopyEntry'],
+  ): Promise<unknown> {
+    const guard = await ensureCanopyDb();
+    if (!guard.ready) return guard.emptyResult;
+    const result = await handleCortexCanopyEntry(input as unknown as Parameters<typeof handleCortexCanopyEntry>[0]);
+    logActivity(TOOL_CORTEX, { op: 'canopy_entry', id: input.id, project_id: input.project_id, path: input.path, duration_ms: Date.now() - start });
+    return result;
+  }
+
+  async function dispatchCanopyMap(
+    input: ToolInput,
+    start: number,
+    handleCortexCanopyMap: typeof import('./cortex.js')['handleCortexCanopyMap'],
+  ): Promise<unknown> {
+    const guard = await ensureCanopyDb();
+    if (!guard.ready) return guard.emptyResult;
 
     const { resolveCanopyProjectId } = await import('@myco/canopy/identity.js');
     const { getMachineId } = await import('@myco/daemon/machine-id.js');
@@ -309,7 +327,7 @@ export function createMycoTools(vaultDir: string, client: DaemonClient, options:
       try { incrementCanopyMapToolCalls(sessionId); } catch { /* counter is best-effort */ }
     }
     logActivity(TOOL_CORTEX, {
-      op,
+      op: 'canopy_map',
       is_empty: (result as { is_empty?: boolean }).is_empty === true,
       token_estimate: (result as { token_estimate?: number }).token_estimate,
       session_id: sessionId,

--- a/packages/myco/ui/src/hooks/use-team.ts
+++ b/packages/myco/ui/src/hooks/use-team.ts
@@ -35,6 +35,14 @@ export interface TeamStatusResponse {
   sync_protocol_version: number;
   mcp_token: string | null;
   mcp_endpoint: string | null;
+  local_only_disclosures: LocalOnlyDisclosure[];
+}
+
+/** Server-canonical "what stays local" disclosure surfaced on the Team page. */
+export interface LocalOnlyDisclosure {
+  table: string;
+  columns: string[];
+  rationale: string;
 }
 
 export function useTeamStatus() {
@@ -51,7 +59,8 @@ export function useTeamStatus() {
 // ---------------------------------------------------------------------------
 
 export interface QueueStats {
-  depth: number;
+  /** null until CF Queues GraphQL Analytics is wired; UI renders "—". */
+  depth: number | null;
   oldest_msg_age_s: number | null;
 }
 

--- a/packages/myco/ui/src/pages/Team.tsx
+++ b/packages/myco/ui/src/pages/Team.tsx
@@ -732,11 +732,11 @@ function OutboxTab({ status }: { status: TeamStatusResponse }) {
               <p className="text-xs text-on-surface-variant">Loading…</p>
             ) : (
               <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-                <StatCard label="Main depth" value={String(main?.depth ?? '—')} accent="outline" />
+                <StatCard label="Main depth" value={main?.depth == null ? '—' : String(main.depth)} accent="outline" />
                 <StatCard label="Main oldest" value={formatAge(main?.oldest_msg_age_s ?? null)} accent="outline" />
                 <StatCard
                   label="DLQ depth"
-                  value={String(dlqStats?.depth ?? dlqMessages.length)}
+                  value={dlqStats?.depth == null ? String(dlqMessages.length) : String(dlqStats.depth)}
                   accent={(dlqStats?.depth ?? dlqMessages.length) > 0 ? 'terracotta' : 'outline'}
                 />
                 <StatCard label="DLQ oldest" value={formatAge(dlqStats?.oldest_msg_age_s ?? null)} accent="outline" />
@@ -776,35 +776,8 @@ function OutboxTab({ status }: { status: TeamStatusResponse }) {
 
 /* ---------- SyncedTab ---------- */
 
-interface LocalOnlyDisclosure {
-  table: string;
-  columns: string[];
-  rationale: string;
-}
-
-const LOCAL_ONLY_DISCLOSURES: LocalOnlyDisclosure[] = [
-  {
-    table: 'cortex_instructions',
-    columns: ['(entire table)'],
-    rationale: 'Per-machine operating guidance generated from local digest substrate; never synced to the team.',
-  },
-  {
-    table: 'sessions',
-    columns: [
-      'embedded',
-      'canopy_injections_offered',
-      'canopy_injection_total_tokens',
-      'canopy_skips_after_injection',
-      'canopy_reads_after_injection',
-      'canopy_tokens_saved',
-      'canopy_redundant_reads',
-      'canopy_map_tool_calls',
-    ],
-    rationale: 'Local-only behavioural counters: embedding state and Canopy injection telemetry stay on the originating machine.',
-  },
-];
-
 function SyncedTab({ status }: { status: TeamStatusResponse }) {
+  const disclosures = status.local_only_disclosures ?? [];
   return (
     <div className="space-y-4">
       <Surface level="low" ghostBorder className="p-5 space-y-3">
@@ -826,7 +799,7 @@ function SyncedTab({ status }: { status: TeamStatusResponse }) {
           These tables and columns are intentionally excluded from team sync. Read this if you're surprised that something doesn't appear on a teammate's machine.
         </p>
         <div className="space-y-3">
-          {LOCAL_ONLY_DISCLOSURES.map((d) => (
+          {disclosures.map((d) => (
             <div key={d.table} className="space-y-1">
               <div className="flex items-center gap-2">
                 <code className="text-sm text-on-surface font-mono">{d.table}</code>


### PR DESCRIPTION
## Summary

Comprehensive code-quality pass since `myco/v0.23.3`. Three review agents (reuse / quality / efficiency lenses) audited the post-tag work in three buckets: tools refactor (#199–#201), tool-surface realignment (#202), and team-sync queue cutover trilogy (#203/#205/#206). Aggregated **2 P0s + 11 P1s + 2 substantial refactors**; this PR lands all of them plus a bug found during post-refactor smoke testing.

## Commits

### `2c235e3e` — review-prep batch (10 fixes)

**P0 — schema drift / source-of-truth**
- `worker/src/mcp/server.ts`: document why `myco_agent` is intentionally absent from the team worker (per-machine data, not synced to D1).
- `daemon/api/team-connect.ts`: derive the Team page "What stays local" disclosures from `LOCAL_ONLY_OUTBOX_TABLES` + `LOCAL_ONLY_SYNC_COLUMNS` + a new `LOCAL_ONLY_RATIONALES` map. Surfaced via `/team/status`; UI consumes `status.local_only_disclosures`. Eliminates the hand-copied list in `Team.tsx` that would have silently drifted.

**P1 — worker hygiene**
- `result-shape.ts`: `ENTITY_TO_TOOL` gains `agent_run` + `canopy_entry`; retrieve-hint shapes match core `search-results.ts`.
- `mcp/server.ts`: drop redundant `.default().optional()` pairs across every tool's op field.
- `result-shape.ts`: new `textJsonError` helper for the `{ok:false, error}` envelope.

**P1 — daemon HTTP server**
- `server.ts`: 8 MB cap on `readBody` with 413 response. Buffer chunks instead of string-concat.

**P1 — queue surface honesty**
- `cf-api.ts`: `QueueStats.depth` is now `number | null`; GraphQL-Analytics-only fields return null instead of 0 so the UI distinguishes "stat not available" from "queue is empty".
- `Team.tsx`: render "—" when depth is null.
- `cf-api.ts`: DLQ visibility timeout 30s → 5 min (operator-paced, not consumer-paced).
- `cf-api.ts`: `queueIdCache` gains 10-min TTL + in-flight Promise dedup; exports `invalidateQueueIdCache` for 404 recovery.

**P1 — harness ID constants**
- `agent/types.ts`: `HARNESS_CLAUDE_SDK` + `HARNESS_OPENAI_AGENTS` exported `as const`. `BUILTIN_HARNESS_IDS` array + `BuiltinHarnessId` type derived from the constants.
- 8 files migrated to the constants: provider-harness, executor-state, loader, config-resolver, harness/{claude,openai,index}, daemon/api/providers, config/migrations.

### `f0ab53ba` — dispatchCortex restructure + harness dedup

**`dispatchCortex` (`tools/index.ts`)** — switch handles every op explicitly. Canopy ops delegate to named helpers (`dispatchCanopyEntry`, `dispatchCanopyMap`) that share an `ensureCanopyDb()` guard returning `{ ready: true } | { ready: false; emptyResult }`. Eliminates the prior switch-with-fall-through where two ops broke out and the post-switch block branched on `op` a second time.

**Claude SDK harness (`harness/claude.ts`)** — `execute` and `openScope.run` no longer rebuild env, toolServer, executable path, query options, or logger emission twice. New private helpers:
- `pickClaudeSetup(input)` narrows `ExecuteInput` to setup-only fields shared with `HarnessScopeSetup`.
- `prepareClaudeRun(setup)` returns `{ toolServer, env, claudeCodeExecutable, localProvider }` once.
- `runClaudeQuery(setup, prepared, options)` drives both paths via a single SDK invocation.
- `logClaudeRequest(...)` shares debug log emission with a kind discriminator.

**OpenAI Agents harness (`harness/openai.ts`)** — `prepareOpenAIRun(setup)` returns `{ agent, runner, mcpServer }` shared between `execute` (closes mcpServer in `finally`) and `openScope` (defers close until operator-initiated).

### `aed10e8a` — 412 passthrough fix found during smoke

The worker correctly returns `412 {error:'cf_api_token_not_configured'}` when the operator hasn't set up a CF API token, but `TeamSyncClient.request()` unconditionally threw on non-2xx — so the structured body never reached the UI's `isTokenMissing` discriminator. The Outbox tab's first-run token-config form would have been silently unreachable.

Added `passthroughStatuses` option to `request()`. `getQueueStats` + `listDlq` opt into `[412]` so the discriminated body flows through.

## What's deferred

Two P2-and-below items from the review remain as TODOs for the upcoming larger refactor:
- `markSourceRowsSynced` semantics — a record that ends up in the DLQ keeps `synced_at` non-NULL locally, so corrupt payloads can't re-enqueue via backfill until operator-discard wires back to clearing `synced_at`.
- `/queue-stats` returning live depth — needs CF Queues GraphQL Analytics wiring (separate API not yet integrated).

## Test plan
- [x] `npm run lint` (tsc + worker tsc) clean
- [x] `npm run test` — 3724 / 0 (node) + 67 / 0 (jsdom)
- [x] Daemon rebuilt + restarted on dogfood; Team page tabs render correctly
- [x] Worker redeployed; `/queue-stats` + `/dlq` return 412 cleanly when token missing
- [x] Cortex dispatch smoke (digest, canopy_map, unknown op) all behave correctly via tool call
- [x] Provider list + agent runs return harness IDs from the new constants
- [x] Live e2e: enqueue → CF Queue → coalesced consumer → D1 in ~6s; delete-op path also works
- [x] Daemon flush via `/enqueue` logs the new shape: `{accepted:N, rejected:0, total:N}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)