### PR TITLE
fix(daemon): drop daemon.port override — derivePort is the only source

### DIFF
--- a/packages/myco/src/config/focus.ts
+++ b/packages/myco/src/config/focus.ts
@@ -168,7 +168,6 @@ const EXACT_FIELD_LABELS: Record<string, string> = {
   'notifications.system_notifications': 'Browser Notifications',
   'capture.ignore_plan_dirs_in_git': 'Ignore Custom Plan Dirs In Git',
   'capture.plan_dirs': 'Custom Directories',
-  'daemon.port': 'Daemon Port',
   'daemon.log_level': 'Log Level',
   'daemon.log_retention_days': 'Log Retention (days)',
   [AGENT_PATHS.scheduledTasksEnabled]: 'Scheduled Tasks',

--- a/packages/myco/src/config/loader.ts
+++ b/packages/myco/src/config/loader.ts
@@ -339,11 +339,11 @@ function loadConfigInternal(vaultDir: string, options: LoadConfigOptions = {}): 
       parsed.embedding = embeddingConfig;
     }
 
-    // Keep daemon.port and daemon.log_level, drop grace_period and max_log_size
+    // Keep daemon.log_level; drop port (machine-derived now), grace_period, max_log_size
     const daemon = parsed.daemon as Record<string, unknown> | undefined;
     if (daemon) {
-      const { port, log_level } = daemon;
-      parsed.daemon = { port: port ?? null, log_level: log_level ?? 'info' };
+      const { log_level } = daemon;
+      parsed.daemon = { log_level: log_level ?? 'info' };
     }
 
     // Keep capture basics, drop token-related fields; migrate artifact_watch → plan_dirs

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -32,7 +32,6 @@ const EmbeddingProviderSchema = z.object({
 });
 
 const DaemonSchema = z.object({
-  port: z.number().int().min(1024).max(65535).nullable().default(null),
   log_level: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
   log_retention_days: z.number().int().min(1).max(365).default(30),
   /**
@@ -371,12 +370,15 @@ export type AppearanceConfig = z.infer<typeof AppearanceConfigSchema>;
 // Resolution order on read: machine → grove → project → personal (highest).
 
 /**
- * Machine tier — one daemon process per machine, one log policy, one port.
+ * Machine tier — one daemon process per machine, one log policy.
  * Stored in `~/.myco/config.yaml`. Sparse — every field has a default.
+ *
+ * The daemon's listening port is NOT configurable: it's deterministically
+ * derived from the service path via `derivePort` so launchers, hooks, and
+ * MCP children all converge on the same value without per-machine config
+ * lookup. See `daemon/port.ts`.
  */
 const MachineDaemonSchema = z.object({
-  /** Port the global daemon listens on. Null = pick an available port. */
-  port: z.number().int().min(1024).max(65535).nullable().default(null),
   /** Log verbosity for the daemon process (stdout/stderr). */
   log_level: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
   /**
@@ -398,10 +400,21 @@ const MachineDaemonSchema = z.object({
 // validation so existing installs keep parsing — the registry value
 // is migrated to the new file the first time `getDefaultGroveId`
 // runs after upgrade.
+//
+// `daemon.port` was a pre-Grove machine-level override of the daemon
+// port. Post-Grove the canonical port is always `derivePort` of the
+// service path; the override silently broke port resolution for users
+// whose stale value didn't match the canonical. Strip it here so old
+// `~/.myco/config.yaml` files keep parsing under strict mode while the
+// runtime ignores the dead field.
 export const MachineConfigSchema = z.preprocess((raw) => {
   if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
-    const { grove: _legacy, ...rest } = raw as Record<string, unknown>;
-    return rest;
+    const { grove: _legacy, daemon, ...rest } = raw as Record<string, unknown>;
+    if (daemon && typeof daemon === 'object' && !Array.isArray(daemon)) {
+      const { port: _deadPort, ...daemonRest } = daemon as Record<string, unknown>;
+      return { ...rest, daemon: daemonRest };
+    }
+    return { ...rest, ...(daemon !== undefined ? { daemon } : {}) };
   }
   return raw;
 }, z.object({

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -1521,18 +1521,15 @@ export async function main(): Promise<void> {
 
   // --- Start server ---
   //
-  // The port is authoritative: Grove-bound projects use the per-user global
-  // service port; legacy projects keep the explicit `daemon.port` override in
-  // myco.yaml or the deterministic hash of the vault path.
-  // No silent fallback — if the port is unavailable after eviction, either a
-  // concurrent sibling won the race (step aside) or something unrelated is
-  // squatting (fail loudly). Ghost daemons on surprise ports come from
-  // silent fallback, so we don't do that.
+  // The canonical port is the single source of truth: derivePort(serviceDir)
+  // for grove-bound projects, derivePort(vaultDir) for the rare legacy case.
+  // No config override and no silent fallback — if the port is unavailable
+  // after eviction, either a concurrent sibling won the race (step aside)
+  // or something unrelated is squatting (fail loudly). Ghost daemons on
+  // surprise ports come from fallbacks, so we don't have any.
 
   await server.evictExistingDaemon();
-  const canonicalPort = dataPaths.usingGrove
-    ? daemonService.canonicalPort
-    : config.daemon.port ?? daemonService.canonicalPort;
+  const canonicalPort = daemonService.canonicalPort;
 
   try {
     await server.start(canonicalPort);
@@ -1549,7 +1546,7 @@ export async function main(): Promise<void> {
 
     logger.error(LOG_KINDS.DAEMON_PORT, 'Canonical port is held by another process — cannot start', {
       port: canonicalPort,
-      hint: `Run \`lsof -iTCP:${canonicalPort}\` to identify the owner, then either kill it or override daemon.port in myco.yaml`,
+      hint: `Run \`lsof -iTCP:${canonicalPort}\` to identify the owner and stop it.`,
     });
     process.stderr.write(
       `Myco daemon cannot bind port ${canonicalPort} (held by another process). ` +

--- a/packages/myco/src/daemon/port.ts
+++ b/packages/myco/src/daemon/port.ts
@@ -6,11 +6,11 @@ export const PORT_RANGE_SIZE = 10000;
 /**
  * Derive a deterministic port from a vault path.
  *
- * The port is the authoritative binding target for a daemon — either this
- * derived value, or an explicit override in `myco.yaml` under `daemon.port`.
- * Startup never silently falls back to a different port; if the canonical
- * port is unavailable, the daemon either steps aside (sibling wins) or
- * fails loudly (unrelated squatter).
+ * The single authoritative source of truth for the daemon's binding port.
+ * No config override; no fallback. Launchers, hooks, MCP children, and the
+ * daemon itself all derive the same value from the service path so they
+ * converge without per-machine config lookup. Startup either binds the
+ * canonical port or fails loudly (squatter) / steps aside (sibling).
  */
 export function derivePort(vaultPath: string): number {
   const hash = createHash('md5').update(vaultPath).digest();

--- a/packages/myco/src/symbionts/installer.ts
+++ b/packages/myco/src/symbionts/installer.ts
@@ -5,12 +5,7 @@ import { findTomlSectionEnd, buildTomlMcpSection, upsertTomlSection, removeTomlS
 import { deepMergeSettings, deepRemoveSettings } from './settings-merge.js';
 import { readJsonFile, writeJsonFile, writeOrDeleteJsonFile } from './json-helpers.js';
 import { ensureAgentsMd, ensureSymlink, isMycoHookGroup } from './install-helpers.js';
-import {
-  loadMergedConfig,
-  loadMachineConfig,
-  saveMachineConfig,
-} from '../config/loader.js';
-import { derivePort } from '../daemon/port.js';
+import { loadMergedConfig } from '../config/loader.js';
 import { resolveDaemonServiceState } from '../daemon/service-state.js';
 import { BUNDLED_TEMPLATES } from './templates.generated.js';
 
@@ -1046,23 +1041,7 @@ export class SymbiontInstaller {
 
   private resolveDaemonPort(): number {
     const vaultDir = path.join(this.projectRoot, '.myco');
-    const daemonService = resolveDaemonServiceState(vaultDir, { env: process.env });
-    if (daemonService.scope === 'global') return daemonService.canonicalPort;
-
-    // Daemon port is machine-tier (one daemon per machine).
-    // Persist+read from `~/.myco/config.yaml`, NOT project myco.yaml.
-    try {
-      const machine = loadMachineConfig();
-      if (machine.daemon.port !== null) return machine.daemon.port;
-      const port = derivePort(vaultDir);
-      saveMachineConfig({
-        ...machine,
-        daemon: { ...machine.daemon, port },
-      });
-      return port;
-    } catch {
-      return derivePort(vaultDir);
-    }
+    return resolveDaemonServiceState(vaultDir, { env: process.env }).canonicalPort;
   }
 
   /**

--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -97,7 +97,9 @@ digest:
     // Opt into the three-tier strip so we can assert the moved Machine fields.
     loadConfig(tmpDir, { migrateTiers: true });
     const machineYaml = fs.readFileSync(path.join(mycoHomeDir, 'config.yaml'), 'utf-8');
-    expect(machineYaml).toContain('port: 7432');
+    // daemon.port is no longer migrated — the canonical port is derived
+    // from the service path; the v2 override is silently dropped.
+    expect(machineYaml).not.toContain('port:');
     expect(machineYaml).toContain('log_level: debug');
     const reloaded = loadConfig(tmpDir);
     expect(reloaded.version).toBe(3);

--- a/tests/config/schema.test.ts
+++ b/tests/config/schema.test.ts
@@ -48,7 +48,6 @@ describe('MycoConfigSchema v3', () => {
     const config = MycoConfigSchema.parse(minimal);
     expect(config.capture.buffer_max_events).toBe(500);
     expect(config.daemon.log_level).toBe('info');
-    expect(config.daemon.port).toBeNull();
     expect(config.notifications.default_mode).toBe('summary');
   });
 

--- a/tests/config/tier-dispatch.test.ts
+++ b/tests/config/tier-dispatch.test.ts
@@ -44,7 +44,7 @@ describe('Tier dispatch', () => {
   it('saveMachineConfig writes ~/.myco/config.yaml', () => {
     saveMachineConfig({
       ...loadMachineConfig(),
-      daemon: { port: 9999, log_level: 'debug', log_retention_days: 14, update_channel: 'stable' },
+      daemon: { log_level: 'debug', log_retention_days: 14, update_channel: 'stable' },
     });
 
     const expected = resolveGlobalConfigPath();
@@ -52,14 +52,14 @@ describe('Tier dispatch', () => {
     expect(fs.existsSync(expected)).toBe(true);
 
     const written = YAML.parse(fs.readFileSync(expected, 'utf-8'));
-    expect(written.daemon.port).toBe(9999);
     expect(written.daemon.log_level).toBe('debug');
+    expect(written.daemon.log_retention_days).toBe(14);
   });
 
   it('saveMachineConfig does NOT write to a Grove config file', () => {
     saveMachineConfig({
       ...loadMachineConfig(),
-      daemon: { port: 8888, log_level: 'info', log_retention_days: 7, update_channel: 'stable' },
+      daemon: { log_level: 'info', log_retention_days: 7, update_channel: 'stable' },
     });
 
     const grovePath = resolveGroveConfigPath('grove_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
@@ -95,24 +95,25 @@ describe('Tier dispatch', () => {
     }
   });
 
-  it('save{Machine,Grove}Config write to distinct files for the same field name', () => {
+  it('save{Machine,Grove}Config write to distinct files for distinct daemon fields', () => {
     saveMachineConfig({
       ...loadMachineConfig(),
-      daemon: { port: 7777, log_level: 'info', log_retention_days: 7, update_channel: 'stable' },
+      // Machine tier owns daemon.log_level / log_retention_days / update_channel.
+      daemon: { log_level: 'info', log_retention_days: 7, update_channel: 'beta' },
     });
     saveGroveConfig('grove_3333333333333333333333333333aaaa', {
       ...loadGroveConfig('grove_3333333333333333333333333333aaaa'),
-      // Grove tier owns daemon.stale_session_threshold_ms
+      // Grove tier owns daemon.stale_session_threshold_ms.
       daemon: { stale_session_threshold_ms: 60_000 },
     });
 
     const machineDoc = YAML.parse(fs.readFileSync(resolveGlobalConfigPath(), 'utf-8'));
     const groveDoc = YAML.parse(fs.readFileSync(resolveGroveConfigPath('grove_3333333333333333333333333333aaaa'), 'utf-8'));
 
-    expect(machineDoc.daemon.port).toBe(7777);
+    expect(machineDoc.daemon.update_channel).toBe('beta');
     expect(machineDoc.daemon.stale_session_threshold_ms).toBeUndefined();
     expect(groveDoc.daemon.stale_session_threshold_ms).toBe(60_000);
-    expect(groveDoc.daemon.port).toBeUndefined();
+    expect(groveDoc.daemon.update_channel).toBeUndefined();
   });
 
   it('saveConfig strips Grove/Machine tier fields out of the project file (ProjectConfigSchema)', () => {
@@ -147,7 +148,7 @@ describe('Tier dispatch', () => {
   it('loadMachineConfig and loadGroveConfig read from their own tier files only', () => {
     saveMachineConfig({
       ...loadMachineConfig(),
-      daemon: { port: 6666, log_level: 'info', log_retention_days: 7, update_channel: 'beta' },
+      daemon: { log_level: 'info', log_retention_days: 7, update_channel: 'beta' },
     });
     saveGroveConfig('grove_4444444444444444444444444444aaaa', {
       ...loadGroveConfig('grove_4444444444444444444444444444aaaa'),
@@ -157,8 +158,8 @@ describe('Tier dispatch', () => {
     const machine = loadMachineConfig();
     const grove = loadGroveConfig('grove_4444444444444444444444444444aaaa');
 
-    expect(machine.daemon.port).toBe(6666);
     expect(machine.daemon.update_channel).toBe('beta');
+    expect(machine.daemon.log_retention_days).toBe(7);
     expect(grove.backup?.dir).toBe('/tmp/readback');
   });
 });

--- a/tests/symbionts/installer.test.ts
+++ b/tests/symbionts/installer.test.ts
@@ -1050,9 +1050,11 @@ describe('installMcp (TOML)', () => {
     expect(content).not.toContain('[mcp_servers.myco.env]');
   });
 
-  it('uses daemon.port from machine config when installing Codex MCP URL', () => {
-    // Daemon port is machine-tier (one daemon per machine); seed
-    // ~/.myco/config.yaml rather than the project's myco.yaml.
+  it('ignores any stale daemon.port in machine config (canonical port is derived)', () => {
+    // Pre-0.25.3 installs may have a stale `daemon.port` field in
+    // ~/.myco/config.yaml left over from the deprecated machine override.
+    // The installer must ignore it and use the derived canonical port so
+    // launchers, hooks, and the daemon all converge on the same value.
     const mycoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-installer-home-'));
     process.env.MYCO_HOME = mycoHome;
     fs.writeFileSync(path.join(mycoHome, 'config.yaml'), [
@@ -1074,13 +1076,15 @@ describe('installMcp (TOML)', () => {
     const installer = new SymbiontInstaller(CODEX_MANIFEST, projectRoot, packageRoot);
     installer.installMcp();
 
+    const expectedPort = derivePort(path.join(projectRoot, '.myco'));
     const content = fs.readFileSync(path.join(projectRoot, '.codex/config.toml'), 'utf-8');
-    expect(content).toContain('url = "http://127.0.0.1:21039/mcp"');
+    expect(content).toContain(`url = "http://127.0.0.1:${expectedPort}/mcp"`);
+    expect(content).not.toContain('21039');
   });
 
-  it('persists a stable daemon.port to machine config before installing Codex MCP URL when omitted', () => {
-    // Sandbox MYCO_HOME so we don't pollute the user's real
-    // ~/.myco/config.yaml when the installer persists the derived port.
+  it('uses derivePort(vaultDir) for Codex MCP URL on a legacy (non-grove) project', () => {
+    // Sandbox MYCO_HOME so we don't read or write the user's real
+    // ~/.myco/config.yaml during this test.
     const mycoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-installer-home-'));
     process.env.MYCO_HOME = mycoHome;
 
@@ -1093,9 +1097,7 @@ describe('installMcp (TOML)', () => {
 
     const expectedPort = derivePort(path.join(projectRoot, '.myco'));
     const codexConfig = fs.readFileSync(path.join(projectRoot, '.codex/config.toml'), 'utf-8');
-    const machineConfig = fs.readFileSync(path.join(mycoHome, 'config.yaml'), 'utf-8');
     expect(codexConfig).toContain(`url = "http://127.0.0.1:${expectedPort}/mcp"`);
-    expect(machineConfig).toContain(`port: ${expectedPort}`);
   });
 
   it('uses the global daemon port for Grove-bound project MCP URLs', () => {


### PR DESCRIPTION
## Summary

Fixes the silent-port-hijack you hit on the unifi-mcp dashboard after upgrading to 0.25.2: the daemon bound to a stale `daemon.port: 27307` override in `~/.myco/config.yaml` instead of the canonical 20915, leaving the dashboard URL pointing at a dead port and `__MYCO_AUTH__` unreachable.

Per the principle you laid out — *one, only one, authoritative truth for how to find the port* — this PR removes the override entirely. Post-Grove, `derivePort(serviceDir)` is the only thing anyone consults. Launchers, hook guard, MCP children, daemon respawn, and the daemon process itself all recompute the same value with no config lookup.

## What changes

| Layer | Before | After |
|---|---|---|
| `MachineDaemonSchema.port` | nullable number, default null | **removed** |
| Legacy project `DaemonSchema.port` | nullable number, default null | **removed** |
| `MachineConfigSchema` preprocess | strips legacy `grove` field only | also strips dead `daemon.port` |
| v2 → v3 project migration | carries `daemon.port` forward | drops it |
| `daemon/main.ts` startup | `dataPaths.usingGrove ? canonicalPort : config.daemon.port ?? canonicalPort` | `daemonService.canonicalPort`, period |
| `SymbiontInstaller.resolveDaemonPort` | reads/writes `~/.myco/config.yaml` daemon.port | returns `daemonService.canonicalPort` directly |
| Settings UI focus map | `'daemon.port': 'Daemon Port'` | removed |

## Why the override existed and why it goes

Pre-Grove, each project had its own daemon and the port could collide with other apps; an explicit override was useful. The 0.25.0 Grove migration moved daemons to one-per-machine on a per-user `~/.myco/service/` path. From that point on, the canonical `derivePort` value was both unique on the machine and known by every launcher; the override served only to drift silently. Users who installed Myco pre-Grove still carry the dead field — the schema preprocess strips it on read.

## Migration

- Existing `~/.myco/config.yaml` files with a `daemon.port` field continue to parse (preprocess strips it before strict validation).
- The runtime ignores any value that was there.
- v2 → v3 project migrations drop the field instead of carrying it forward.
- No user action required.

## Test plan

- [x] `make build` clean — 4152 non-DOM + 71 DOM tests, 0 fail.
- [x] Targeted tests updated:
  - `tests/config/schema.test.ts` — drop the `daemon.port` default expectation.
  - `tests/config/loader.test.ts` — v2 migration test asserts `port:` is NOT present in the migrated machine config.
  - `tests/config/tier-dispatch.test.ts` — three tests rewritten to use surviving fields (`log_retention_days`, `update_channel`).
  - `tests/symbionts/installer.test.ts` — replaced "respects machine override" with "ignores stale machine override and uses derivePort."
- [x] Post-merge: install via `npm i -g @goondocks/myco@0.25.3`, restart daemon — should bind canonical 20915 (or whatever `derivePort('~/.myco/service/')` returns) regardless of any leftover `daemon.port` line in `~/.myco/config.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)