### PR TITLE
fix(daemon): close cross-project data leaks (multi-tenancy invariant)

### DIFF
--- a/packages/myco/src/daemon/api/attachments.ts
+++ b/packages/myco/src/daemon/api/attachments.ts
@@ -8,6 +8,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { getAttachmentByFilePath } from '@myco/db/queries/attachments.js';
+import { projectScopeFromRequestContext } from '@myco/tools/request-context.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 
 // ---------------------------------------------------------------------------
@@ -46,8 +47,12 @@ export function createAttachmentHandler(deps: AttachmentDeps) {
       return { status: 400, body: { error: 'invalid_filename' } };
     }
 
-    // Try DB first (new path)
-    const att = getAttachmentByFilePath(filename);
+    // Try DB first (new path). Scope MUST come from request context — the
+    // attachments table holds rows for every project in the same Grove DB
+    // and an unscoped lookup would return a sibling project's bytes when
+    // a caller knows or guesses the file_path.
+    const scope = projectScopeFromRequestContext(req.requestContext);
+    const att = getAttachmentByFilePath(filename, scope);
     if (att?.data) {
       const contentType = att.media_type ?? 'application/octet-stream';
       return { status: 200, headers: { 'Content-Type': contentType }, body: att.data };

--- a/packages/myco/src/daemon/api/canopy-read.ts
+++ b/packages/myco/src/daemon/api/canopy-read.ts
@@ -66,7 +66,11 @@ export const handleGetCanopyToolCallBlob: RouteHandler = async (req) => {
   const tcId = Number(tcIdRaw);
   if (!Number.isFinite(tcId)) return badRequest('invalid_tc_id');
 
-  const ctx = getCanopyToolCallContext(null, sessionId, tcId);
+  // Scope MUST come from request context: the previous null-scope read joined
+  // activities → sessions across the entire Grove DB and let a caller fetch
+  // a sibling project's source-code blob given only a session id + tcId.
+  const scope = projectScopeFromRequestContext(req.requestContext);
+  const ctx = getCanopyToolCallContext(scope, sessionId, tcId);
   if (!ctx) return notFound('tool_call');
 
   // The blob is regenerated from the canopy_entries row at request time so
@@ -86,7 +90,10 @@ export const handleGetCanopyRollup: RouteHandler = async (req) => {
   const since = parseEpochSeconds(req.query.since);
   const until = parseEpochSeconds(req.query.until);
 
-  const r = rollupCanopy(null, { since, until });
+  // Scope MUST come from the request context: an unscoped rollup aggregates
+  // sessions across every project in the Grove DB.
+  const scope = projectScopeFromRequestContext(req.requestContext);
+  const r = rollupCanopy(scope, { since, until });
   // Reshape for the UI (see CanopyRollup in use-canopy.ts). Field renames +
   // two derived metrics that are cheaper to compute here than in React.
   const sessionsWithCanopy = r.sessions_with_data ?? 0;

--- a/packages/myco/src/daemon/api/feed.ts
+++ b/packages/myco/src/daemon/api/feed.ts
@@ -1,5 +1,6 @@
 import { getActivityFeed } from '@myco/db/queries/feed.js';
 import { FEED_DEFAULT_LIMIT } from '@myco/constants.js';
+import { projectScopeFromRequestContext } from '@myco/tools/request-context.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 
 // ---------------------------------------------------------------------------
@@ -8,6 +9,12 @@ import type { RouteRequest, RouteResponse } from '../router.js';
 
 export async function handleGetFeed(req: RouteRequest): Promise<RouteResponse> {
   const limit = Number(req.query.limit) || FEED_DEFAULT_LIMIT;
-  const feed = getActivityFeed(limit);
+  // Project scope MUST be applied: sessions/agent_runs/spores all carry
+  // project_id post-Grove; an unscoped read leaks rows across projects in
+  // the same Grove DB. `projectScopeFromRequestContext` throws on an
+  // absent context — that's intentional, every API request to a Grove DB
+  // must arrive with a resolved project context.
+  const scope = projectScopeFromRequestContext(req.requestContext);
+  const feed = getActivityFeed(scope, limit);
   return { body: feed };
 }

--- a/packages/myco/src/db/queries/attachments.ts
+++ b/packages/myco/src/db/queries/attachments.ts
@@ -7,6 +7,7 @@
 
 import { getDatabase } from '@myco/db/client.js';
 import type { GroveProjectId } from '@myco/grove/ids.js';
+import { projectScopeClause, type ProjectScope } from './project-scope.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -202,16 +203,27 @@ export function listAttachmentsBySession(sessionId: string): AttachmentListRow[]
 }
 
 /**
- * Find an attachment by its file_path.
+ * Find an attachment by its file_path within the given project scope.
  *
- * @returns the first matching attachment row, or null if none exists.
+ * Scope is required: post-Grove the `attachments` table holds rows for
+ * every project in the same Grove DB. Without a project filter a caller
+ * who knows or guesses a sibling project's file_path can fetch its bytes.
+ * Filenames are usually content-hash-derived (bounded exploit surface)
+ * but defense-in-depth requires the filter regardless. Pass
+ * `ALL_PROJECTS_SCOPE` only when an admin/aggregation read is intended.
+ *
+ * @returns the first matching attachment row in scope, or null if none exists.
  */
-export function getAttachmentByFilePath(filePath: string): AttachmentRow | null {
+export function getAttachmentByFilePath(
+  filePath: string,
+  scope: ProjectScope,
+): AttachmentRow | null {
   const db = getDatabase();
+  const scopeClause = projectScopeClause(scope);
 
   const row = db.prepare(
-    `SELECT ${SELECT_COLUMNS} FROM attachments WHERE file_path = ? LIMIT 1`,
-  ).get(filePath) as Record<string, unknown> | undefined;
+    `SELECT ${SELECT_COLUMNS} FROM attachments WHERE file_path = ?${scopeClause.sql} LIMIT 1`,
+  ).get(filePath, ...scopeClause.params) as Record<string, unknown> | undefined;
 
   return row ? toAttachmentRow(row) : null;
 }

--- a/packages/myco/src/db/queries/canopy.ts
+++ b/packages/myco/src/db/queries/canopy.ts
@@ -12,6 +12,7 @@
 import type { Database } from 'bun:sqlite';
 import { getDatabase } from '@myco/db/client.js';
 import { CANOPY_SESSION_COLUMNS, CANOPY_ACTIVITY_COLUMN } from '@myco/db/schema-ddl.js';
+import { projectScopeClause, type ProjectScope } from './project-scope.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -267,14 +268,27 @@ export interface CanopyRollupOptions {
  * Cross-session Canopy rollup for the all-sessions UI surface. Only sessions
  * with non-NULL `canopy_injections_offered` contribute (pre-feature sessions
  * and disabled-injection sessions are excluded).
+ *
+ * Scope MUST be applied: post-Grove the `sessions` table holds rows for
+ * every project in the same Grove DB. An unscoped rollup leaks aggregate
+ * metrics across project boundaries. Pass `ALL_PROJECTS_SCOPE` only when
+ * a cross-project Grove-wide aggregate is genuinely intended.
  */
 export function rollupCanopy(
-  db: Database | null,
+  scope: ProjectScope,
   opts: CanopyRollupOptions = {},
+  db: Database | null = null,
 ): CanopyRollup {
   const handle = db ?? getDatabase();
   const clauses: string[] = ['canopy_injections_offered IS NOT NULL'];
-  const params: number[] = [];
+  const params: unknown[] = [];
+  const scopeClause = projectScopeClause(scope);
+  if (scopeClause.sql) {
+    // scopeClause.sql starts with " AND "; strip the leading " AND " since
+    // we're appending to a clauses array that's joined with ' AND '.
+    clauses.push(scopeClause.sql.replace(/^ AND /, ''));
+    params.push(...scopeClause.params);
+  }
   if (opts.since !== undefined) {
     clauses.push('started_at >= ?');
     params.push(opts.since);
@@ -435,11 +449,13 @@ export interface CanopyToolCallContext {
 }
 
 export function getCanopyToolCallContext(
-  db: Database | null,
+  scope: ProjectScope,
   sessionId: string,
   activityId: number,
+  db: Database | null = null,
 ): CanopyToolCallContext | null {
   const handle = db ?? getDatabase();
+  const scopeClause = projectScopeClause(scope, 'a');
   const row = handle
     .prepare(
       `
@@ -455,9 +471,10 @@ export function getCanopyToolCallContext(
           AND a.session_id = ?
           AND a.tool_name = 'Read'
           AND a.canopy_injection_tokens IS NOT NULL
+          ${scopeClause.sql}
       `,
     )
-    .get(activityId, sessionId) as CanopyToolCallContext | undefined;
+    .get(activityId, sessionId, ...scopeClause.params) as CanopyToolCallContext | undefined;
 
   if (!row || !row.file_path) return null;
   return row;

--- a/packages/myco/src/db/queries/entities.ts
+++ b/packages/myco/src/db/queries/entities.ts
@@ -8,7 +8,7 @@
 import { getDatabase } from '@myco/db/client.js';
 import { getTeamMachineId } from '@myco/daemon/team-context.js';
 import { syncRow } from '@myco/db/queries/team-outbox.js';
-import { appendProjectCondition, type ProjectScope } from '@myco/db/queries/project-scope.js';
+import { appendProjectCondition, projectScopeClause, type ProjectScope } from '@myco/db/queries/project-scope.js';
 import type { GroveProjectId } from '@myco/grove/ids.js';
 
 // ---------------------------------------------------------------------------
@@ -190,16 +190,21 @@ export function insertEntity(data: EntityInsert): EntityRow {
 }
 
 /**
- * Retrieve a single entity by id.
+ * Retrieve a single entity by id, scoped to a project.
  *
- * @returns the entity row, or null if not found.
+ * Scope is required for parity with `listEntities` and to prevent silent
+ * cross-project reads when this is consumed by an API handler. Pass
+ * `ALL_PROJECTS_SCOPE` only when an admin/aggregation read is intended.
+ *
+ * @returns the entity row in scope, or null if not found.
  */
-export function getEntity(id: string): EntityRow | null {
+export function getEntity(id: string, scope: ProjectScope): EntityRow | null {
   const db = getDatabase();
+  const scopeClause = projectScopeClause(scope);
 
   const row = db.prepare(
-    `SELECT ${SELECT_COLUMNS} FROM entities WHERE id = ?`,
-  ).get(id) as Record<string, unknown> | undefined;
+    `SELECT ${SELECT_COLUMNS} FROM entities WHERE id = ?${scopeClause.sql}`,
+  ).get(id, ...scopeClause.params) as Record<string, unknown> | undefined;
 
   if (!row) return null;
   return toEntityRow(row);

--- a/packages/myco/src/db/queries/feed.ts
+++ b/packages/myco/src/db/queries/feed.ts
@@ -4,12 +4,16 @@
  * Uses UNION ALL to merge per-table subqueries, then a final ORDER BY + LIMIT
  * to produce a cross-table timeline ordered by timestamp descending.
  *
- * All functions obtain the SQLite instance internally via `getDatabase()`.
- * Queries use positional `?` placeholders throughout (better-sqlite3).
+ * Every branch filters on `project_id` via the supplied `ProjectScope`.
+ * Post-Grove, all three tables hold rows from multiple projects in the
+ * same Grove DB; an unfiltered read leaks data across project boundaries.
+ * Callers must pass the scope from `projectScopeFromRequestContext` (or
+ * explicitly opt into `ALL_PROJECTS_SCOPE` for cross-project admin views).
  */
 
-import { getDatabase } from '@myco/db/client.js';
+import { getDatabase, type Database } from '@myco/db/client.js';
 import { FEED_DEFAULT_LIMIT } from '@myco/constants.js';
+import { projectScopeClause, type ProjectScope } from './project-scope.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -28,8 +32,8 @@ export interface FeedEntry {
 // ---------------------------------------------------------------------------
 
 /**
- * Return the most recent activity across sessions, agent runs, and spores,
- * merged into a single timeline sorted by timestamp descending.
+ * Return the most recent activity across sessions, agent runs, and spores
+ * within `scope`, merged into a single timeline sorted by timestamp descending.
  *
  * Each branch contributes up to `limit` candidates; the final result is
  * also capped at `limit`.
@@ -38,17 +42,19 @@ export interface FeedEntry {
  * parenthesized subqueries the way PostgreSQL does. Instead, each branch
  * is wrapped as a subquery (SELECT ... ORDER BY ... LIMIT ?) to achieve
  * the same effect.
- *
- * @param limit - max entries to return (defaults to FEED_DEFAULT_LIMIT)
  */
-export function getActivityFeed(limit: number = FEED_DEFAULT_LIMIT): FeedEntry[] {
-  const db = getDatabase();
+export function getActivityFeed(
+  scope: ProjectScope,
+  limit: number = FEED_DEFAULT_LIMIT,
+  db: Database = getDatabase(),
+): FeedEntry[] {
+  const clause = projectScopeClause(scope);
 
   const rows = db.prepare(`
     SELECT * FROM (
       SELECT 'session' as type, id, COALESCE(title, 'Session ' || substr(id, 1, 8)) as summary,
               COALESCE(ended_at, started_at) as timestamp
-       FROM sessions ORDER BY started_at DESC LIMIT ?
+       FROM sessions WHERE 1 = 1${clause.sql} ORDER BY started_at DESC LIMIT ?
     )
 
     UNION ALL
@@ -56,7 +62,7 @@ export function getActivityFeed(limit: number = FEED_DEFAULT_LIMIT): FeedEntry[]
     SELECT * FROM (
       SELECT 'agent_run' as type, id, task || ' — ' || status as summary,
               COALESCE(completed_at, started_at) as timestamp
-       FROM agent_runs ORDER BY started_at DESC LIMIT ?
+       FROM agent_runs WHERE 1 = 1${clause.sql} ORDER BY started_at DESC LIMIT ?
     )
 
     UNION ALL
@@ -64,11 +70,16 @@ export function getActivityFeed(limit: number = FEED_DEFAULT_LIMIT): FeedEntry[]
     SELECT * FROM (
       SELECT 'spore' as type, id, observation_type || ': ' || substr(content, 1, 80) as summary,
               created_at as timestamp
-       FROM spores WHERE status = 'active' ORDER BY created_at DESC LIMIT ?
+       FROM spores WHERE status = 'active'${clause.sql} ORDER BY created_at DESC LIMIT ?
     )
 
     ORDER BY timestamp DESC LIMIT ?
-  `).all(limit, limit, limit, limit) as FeedEntry[];
+  `).all(
+    ...clause.params, limit,
+    ...clause.params, limit,
+    ...clause.params, limit,
+    limit,
+  ) as FeedEntry[];
 
   return rows;
 }

--- a/packages/myco/ui/src/hooks/use-activity.ts
+++ b/packages/myco/ui/src/hooks/use-activity.ts
@@ -1,6 +1,7 @@
 import { usePowerQuery } from './use-power-query';
 import { fetchJson } from '../lib/api';
 import { POLL_INTERVALS } from '../lib/constants';
+import { useProjectScopedQueryKey } from './use-project-selection';
 
 export interface ActivityEvent {
   type: string;
@@ -10,8 +11,12 @@ export interface ActivityEvent {
 }
 
 export function useActivity(limit = 20) {
+  // Cache key MUST include the active project selection — otherwise
+  // react-query reuses the same cache entry across project switches and
+  // shows stale cross-project activity until the next refetch tick.
+  const queryKey = useProjectScopedQueryKey(['activity', limit]);
   return usePowerQuery<ActivityEvent[]>({
-    queryKey: ['activity', limit],
+    queryKey,
     queryFn: ({ signal }) =>
       fetchJson<ActivityEvent[]>(`/activity?limit=${limit}`, { signal }),
     refetchInterval: POLL_INTERVALS.STATS,

--- a/tests/canopy/aggregate/aggregate-session.test.ts
+++ b/tests/canopy/aggregate/aggregate-session.test.ts
@@ -23,6 +23,7 @@ import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import { getDatabase } from '@myco/db/client.js';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import { aggregateSessionCanopy, rollupCanopy } from '@myco/db/queries/canopy.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
 
 const PROJECT_ID = '/repo/myco';
 
@@ -310,7 +311,7 @@ describe('rollupCanopy', () => {
   });
 
   it('returns zero rollup with no sessions', () => {
-    const r = rollupCanopy(null);
+    const r = rollupCanopy(ALL_PROJECTS_SCOPE);
     expect(r.sessions_with_data).toBe(0);
     expect(r.total_tokens_saved).toBe(0);
     expect(r.avg_tokens_saved_per_session).toBe(0);
@@ -347,7 +348,7 @@ describe('rollupCanopy', () => {
       WHERE id = ?
     `).run('s3');
 
-    const r = rollupCanopy(null);
+    const r = rollupCanopy(ALL_PROJECTS_SCOPE);
     expect(r.sessions_with_data).toBe(2);
     expect(r.total_tokens_saved).toBe(1500);
     expect(r.avg_tokens_saved_per_session).toBe(750);
@@ -373,11 +374,11 @@ describe('rollupCanopy', () => {
       WHERE id = ?
     `).run('new');
 
-    const fresh = rollupCanopy(null, { since: 150 });
+    const fresh = rollupCanopy(ALL_PROJECTS_SCOPE, { since: 150 });
     expect(fresh.sessions_with_data).toBe(1);
     expect(fresh.total_tokens_saved).toBe(200);
 
-    const stale = rollupCanopy(null, { until: 150 });
+    const stale = rollupCanopy(ALL_PROJECTS_SCOPE, { until: 150 });
     expect(stale.sessions_with_data).toBe(1);
     expect(stale.total_tokens_saved).toBe(100);
   });

--- a/tests/db/queries/attachments.test.ts
+++ b/tests/db/queries/attachments.test.ts
@@ -14,6 +14,7 @@ import {
   getAttachmentByFilePath,
   type AttachmentListRow,
 } from '@myco/db/queries/attachments.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
 
 describe('attachment queries', () => {
   beforeAll(() => { setupTestDb(); });
@@ -164,7 +165,7 @@ describe('attachment queries', () => {
         created_at: now,
       });
 
-      const row = getAttachmentByFilePath('attachments/screenshot.png');
+      const row = getAttachmentByFilePath('attachments/screenshot.png', ALL_PROJECTS_SCOPE);
       expect(row).not.toBeNull();
       expect(row!.id).toBe('att-1');
       expect(row!.file_path).toBe('attachments/screenshot.png');
@@ -172,7 +173,7 @@ describe('attachment queries', () => {
     });
 
     it('returns null for a non-existent file_path', async () => {
-      const row = getAttachmentByFilePath('attachments/does-not-exist.png');
+      const row = getAttachmentByFilePath('attachments/does-not-exist.png', ALL_PROJECTS_SCOPE);
       expect(row).toBeNull();
     });
 
@@ -195,11 +196,11 @@ describe('attachment queries', () => {
         created_at: now,
       });
 
-      const row = getAttachmentByFilePath('attachments/a.png');
+      const row = getAttachmentByFilePath('attachments/a.png', ALL_PROJECTS_SCOPE);
       expect(row).not.toBeNull();
       expect(row!.id).toBe('att-1');
 
-      const row2 = getAttachmentByFilePath('attachments/b.png');
+      const row2 = getAttachmentByFilePath('attachments/b.png', ALL_PROJECTS_SCOPE);
       expect(row2).not.toBeNull();
       expect(row2!.id).toBe('att-2');
     });

--- a/tests/db/queries/feed.test.ts
+++ b/tests/db/queries/feed.test.ts
@@ -12,6 +12,7 @@ import { registerAgent } from '@myco/db/queries/agents.js';
 import { insertRun } from '@myco/db/queries/runs.js';
 import { insertSpore } from '@myco/db/queries/spores.js';
 import { getActivityFeed } from '@myco/db/queries/feed.js';
+import { ALL_PROJECTS_SCOPE, assertGroveProjectId, projectScope } from '@myco/grove/ids.js';
 
 /** Epoch seconds helper. */
 const epochNow = () => Math.floor(Date.now() / 1000);
@@ -37,7 +38,7 @@ describe('getActivityFeed', () => {
   // ---------------------------------------------------------------------------
 
   it('returns empty array when no data exists', async () => {
-    const feed = getActivityFeed();
+    const feed = getActivityFeed(ALL_PROJECTS_SCOPE);
     expect(feed).toEqual([]);
   });
 
@@ -76,7 +77,7 @@ describe('getActivityFeed', () => {
       created_at: base + 10,
     });
 
-    const feed = getActivityFeed();
+    const feed = getActivityFeed(ALL_PROJECTS_SCOPE);
 
     expect(feed).toHaveLength(3);
 
@@ -116,7 +117,7 @@ describe('getActivityFeed', () => {
       title: null,
     });
 
-    const feed = getActivityFeed();
+    const feed = getActivityFeed(ALL_PROJECTS_SCOPE);
     expect(feed).toHaveLength(1);
     expect(feed[0].summary).toBe('Session abcdefgh');
   });
@@ -137,7 +138,7 @@ describe('getActivityFeed', () => {
       created_at: now,
     });
 
-    const feed = getActivityFeed();
+    const feed = getActivityFeed(ALL_PROJECTS_SCOPE);
     expect(feed).toHaveLength(1);
     // summary = "decision: " + LEFT(content, 80) = "decision: " + 80 A's
     expect(feed[0].summary).toBe('decision: ' + 'A'.repeat(80));
@@ -168,7 +169,7 @@ describe('getActivityFeed', () => {
       status: 'superseded',
     });
 
-    const feed = getActivityFeed();
+    const feed = getActivityFeed(ALL_PROJECTS_SCOPE);
     expect(feed).toHaveLength(1);
     expect(feed[0].id).toBe('spore-active');
   });
@@ -190,7 +191,7 @@ describe('getActivityFeed', () => {
       });
     }
 
-    const feed = getActivityFeed(3);
+    const feed = getActivityFeed(ALL_PROJECTS_SCOPE, 3);
     expect(feed).toHaveLength(3);
   });
 
@@ -207,7 +208,7 @@ describe('getActivityFeed', () => {
       });
     }
 
-    const feed = getActivityFeed();
+    const feed = getActivityFeed(ALL_PROJECTS_SCOPE);
     expect(feed).toHaveLength(50);
   });
 
@@ -227,7 +228,7 @@ describe('getActivityFeed', () => {
       completed_at: now + 100,
     });
 
-    const feed = getActivityFeed();
+    const feed = getActivityFeed(ALL_PROJECTS_SCOPE);
     expect(feed).toHaveLength(1);
     expect(feed[0].timestamp).toBe(now + 100);
   });
@@ -248,8 +249,62 @@ describe('getActivityFeed', () => {
       created_at: now,
     });
 
-    const feed = getActivityFeed();
+    const feed = getActivityFeed(ALL_PROJECTS_SCOPE);
     expect(feed).toHaveLength(1);
     expect(feed[0].type).toBe('spore');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Multi-tenancy — project scope MUST filter rows by project_id
+  // ---------------------------------------------------------------------------
+
+  it('returns only rows belonging to the scoped project (no cross-project leak)', async () => {
+    const now = epochNow();
+    const projectA = assertGroveProjectId('proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    const projectB = assertGroveProjectId('proj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+
+    upsertSession({
+      id: 'sess-A', agent: 'claude-code', started_at: now + 30, created_at: now + 30, title: 'A session',
+      project_id: projectA,
+    });
+    upsertSession({
+      id: 'sess-B', agent: 'claude-code', started_at: now + 31, created_at: now + 31, title: 'B session',
+      project_id: projectB,
+    });
+
+    insertRun({
+      id: 'run-A', agent_id: TEST_AGENT_ID, task: 'a-task', status: 'completed',
+      started_at: now + 20, completed_at: now + 20, project_id: projectA,
+    });
+    insertRun({
+      id: 'run-B', agent_id: TEST_AGENT_ID, task: 'b-task', status: 'completed',
+      started_at: now + 21, completed_at: now + 21, project_id: projectB,
+    });
+
+    insertSpore({
+      id: 'spore-A', agent_id: TEST_AGENT_ID, observation_type: 'gotcha',
+      content: 'A finding', created_at: now + 10, project_id: projectA,
+    });
+    insertSpore({
+      id: 'spore-B', agent_id: TEST_AGENT_ID, observation_type: 'gotcha',
+      content: 'B finding', created_at: now + 11, project_id: projectB,
+    });
+
+    const feedA = getActivityFeed(projectScope(projectA));
+    expect(feedA).toHaveLength(3);
+    for (const entry of feedA) {
+      expect(entry.id.endsWith('-A')).toBe(true);
+    }
+
+    const feedB = getActivityFeed(projectScope(projectB));
+    expect(feedB).toHaveLength(3);
+    for (const entry of feedB) {
+      expect(entry.id.endsWith('-B')).toBe(true);
+    }
+
+    // ALL_PROJECTS_SCOPE deliberately leaks for admin views — confirm it
+    // sees both sets so consumers can rely on the explicit-opt-in semantics.
+    const feedAll = getActivityFeed(ALL_PROJECTS_SCOPE);
+    expect(feedAll).toHaveLength(6);
   });
 });


### PR DESCRIPTION
## Summary

Closes 5 multi-tenancy data leaks: three CRITICAL UI-visible cross-project leaks, one HIGH defense-in-depth gap, one LOW latent footgun. Triggered by Chris's report that the Recent Activity feed showed myco-dogfood data when viewing the unifi-mcp project. Audit found four more sites with the same shape.

## The bug class

Post-Grove every Grove DB holds rows from multiple projects. Any query against project-scoped tables (`sessions`, `agent_runs`, `spores`, `canopy_entries`, `attachments`, `entities`, …) MUST filter by `project_id` or explicitly opt into `ALL_PROJECTS_SCOPE`. The infrastructure exists:

- `projectScopeFromRequestContext(context)` returns the strict `ProjectScope` type
- `projectScopeClause(scope)` produces the SQL fragment + params
- `ALL_PROJECTS_SCOPE` is the explicit opt-in for Grove-wide reads

Some handlers were calling underlying queries with `null`/no scope, defaulting to "no filter".

## Findings & fixes

| # | Severity | Endpoint | Leak surface | Fix |
|---|---|---|---|---|
| 1 | CRITICAL | `/api/activity` | Recent Activity feed shows other projects' sessions/runs/spores | `getActivityFeed(scope, limit)`; UI cache key now project-scoped |
| 2 | CRITICAL | `/api/canopy/rollup` | "All sessions" Canopy tile aggregates across Grove | `rollupCanopy(scope, opts, db?)` |
| 3 | CRITICAL | `/api/sessions/:id/canopy/tool-calls/:tcId/blob` | Caller knowing a sibling project's session+activity ids could fetch its source-code blob | `getCanopyToolCallContext(scope, …)` |
| 4 | HIGH | `/api/attachments/:filename` | Defense-in-depth — content-hash filenames bound the practical surface, but no scope filter at all | `getAttachmentByFilePath(filePath, scope)` |
| 5 | LOW | `getEntity(id)` (no live caller) | Latent footgun for next consumer | scope param added for parity with `listEntities` |

## Pattern

Every fix follows the `services/stats.ts` gold standard: handler reads `req.requestContext` → `projectScopeFromRequestContext` → strict `ProjectScope` → query appends `projectScopeClause(scope).sql`/params. No silent defaults; no nullable scope; explicit `ALL_PROJECTS_SCOPE` for genuine cross-project reads.

## Sites audited and verified safe

`daemon/api/sessions.ts`, `agent-runs.ts`, `skills.ts`, `notifications.ts`, `mycelium.ts`, `digest-revisions.ts`, `cortex.ts`, `search.ts`, `session-lifecycle.ts`, `log-explorer.ts`, `context.ts`, `team-connect.ts`, `canopy-inject.ts`, `handleGetSessionCanopy`, `services/stats.ts`. All thread scope through correctly. The audit also distinguished genuinely Grove-wide handlers (`projects-activity.ts`, `maintenance.ts`) from leaks; those stay as-is.

## Test plan

- [x] `make build` clean — 4165 + 71 tests, 0 fail.
- [x] New: `tests/db/queries/feed.test.ts` proves project-A and project-B data don't leak across `getActivityFeed(projectScope(...))` and that `ALL_PROJECTS_SCOPE` deliberately sees both sets.
- [x] Existing tests updated to pass `ALL_PROJECTS_SCOPE` where genuinely Grove-wide (`tests/canopy/aggregate/aggregate-session.test.ts:rollupCanopy`, `tests/db/queries/attachments.test.ts:getAttachmentByFilePath`).
- [ ] Post-merge: switch projects in the dashboard, confirm Recent Activity reflects the active project; switch back, confirm cache invalidates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)