### PR TITLE
fix(release): install @vscode/ripgrep platform subpackage per target

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -184,47 +184,25 @@ jobs:
           SQLITE_VEC_VERSION="$(node -p "JSON.parse(require('node:fs').readFileSync('./node_modules/sqlite-vec/package.json', 'utf8')).version")"
           npm install "sqlite-vec-${TARGET}@${SQLITE_VEC_VERSION}" --no-save --ignore-scripts --force
 
-      # @vscode/ripgrep's postinstall only downloads the host-matching
-      # binary, so for cross-compile we fetch the target-specific release
-      # from microsoft/ripgrep-prebuilt directly (VERSION matches the
-      # constant in node_modules/@vscode/ripgrep/lib/postinstall.js).
-      - name: Install target-specific ripgrep binary
+      # @vscode/ripgrep 1.18+ ships the binary inside platform-specific
+      # subpackages (declared as optionalDependencies on the umbrella
+      # `@vscode/ripgrep`). npm ci on a single host only resolves the
+      # host-matching subpackage, so force-install the target's subpackage
+      # at the same pinned version. Mirrors the sqlite-vec step above.
+      # Safe: TARGET is bound from matrix.target, not user input; the
+      # case/esac restricts RG_PLATFORM to a known set before use.
+      - name: Install @vscode/ripgrep target subpackage
         env:
           TARGET: ${{ matrix.target }}
         run: |
-          RG_VERSION="v15.0.1"
           case "$TARGET" in
-            darwin-arm64) RG_TRIPLE="aarch64-apple-darwin" ;;
-            darwin-x64)   RG_TRIPLE="x86_64-apple-darwin" ;;
-            linux-x64)    RG_TRIPLE="x86_64-unknown-linux-musl" ;;
-            linux-arm64)  RG_TRIPLE="aarch64-unknown-linux-musl" ;;
-            windows-x64)  RG_TRIPLE="x86_64-pc-windows-msvc" ;;
+            windows-x64)  RG_PLATFORM="win32-x64" ;;
+            darwin-arm64|darwin-x64|linux-x64|linux-arm64) RG_PLATFORM="$TARGET" ;;
             *) echo "unknown target: $TARGET" >&2; exit 1 ;;
           esac
-          RG_BIN_DIR="node_modules/@vscode/ripgrep/bin"
-          mkdir -p "$RG_BIN_DIR"
-          STAGE="$(mktemp -d)"
-          if [ "$TARGET" = "windows-x64" ]; then
-            ARCHIVE="ripgrep-${RG_VERSION}-${RG_TRIPLE}.zip"
-            curl --fail --silent --show-error --location \
-              -o "${STAGE}/${ARCHIVE}" \
-              "https://github.com/microsoft/ripgrep-prebuilt/releases/download/${RG_VERSION}/${ARCHIVE}"
-            unzip -q "${STAGE}/${ARCHIVE}" -d "${STAGE}"
-            mv "${STAGE}/rg.exe" "${RG_BIN_DIR}/rg.exe"
-            # The per-target entry imports '@vscode/ripgrep/bin/rg' — file
-            # content is what matters; extension is irrelevant to Bun's
-            # file-embed. Mirror the Windows binary to both names.
-            cp "${RG_BIN_DIR}/rg.exe" "${RG_BIN_DIR}/rg"
-          else
-            ARCHIVE="ripgrep-${RG_VERSION}-${RG_TRIPLE}.tar.gz"
-            curl --fail --silent --show-error --location \
-              -o "${STAGE}/${ARCHIVE}" \
-              "https://github.com/microsoft/ripgrep-prebuilt/releases/download/${RG_VERSION}/${ARCHIVE}"
-            tar -xzf "${STAGE}/${ARCHIVE}" -C "${STAGE}"
-            mv "${STAGE}/rg" "${RG_BIN_DIR}/rg"
-            chmod +x "${RG_BIN_DIR}/rg"
-          fi
-          ls -lh "${RG_BIN_DIR}"
+          RG_VERSION="$(node -p "JSON.parse(require('node:fs').readFileSync('./node_modules/@vscode/ripgrep/package.json', 'utf8')).version")"
+          npm install "@vscode/ripgrep-${RG_PLATFORM}@${RG_VERSION}" --no-save --ignore-scripts --force
+          ls -lh "node_modules/@vscode/ripgrep-${RG_PLATFORM}/bin/"
 
       - name: Download libsqlite3 artifact
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## What broke

The release for the merged dep-bumps PR failed at the cross-compile matrix: 4 of 5 jobs errored with

\`\`\`
error: Could not resolve: \"@vscode/ripgrep-<platform>/bin/rg\". Maybe you need to \"bun install\"?
\`\`\`

(See [run 25697050667](https://github.com/goondocks-co/myco/actions/runs/25697050667).)

## Root cause

The 1.18 migration changed every \`cli.<platform>.ts\` entry to import from \`@vscode/ripgrep-<platform>/bin/rg\` (the platform subpackage), but \`publish.yml\` still staged the binary at the old \`@vscode/ripgrep/bin/rg\` path by downloading it from \`microsoft/ripgrep-prebuilt\`. \`linux-x64\` happened to succeed only because the Ubuntu runner's \`npm ci\` auto-installs the host-matching optional dep.

## Fix

Replace the 35-line \"download + extract from GitHub releases\" step with a 13-line \`npm install @vscode/ripgrep-<platform>@<version> --no-save --ignore-scripts --force\` — exactly the same shape as the \`sqlite-vec\` step a few lines above. The 1.18 subpackages ship the binary directly on npm, so the GitHub-download dance is no longer needed.

Net wins beyond unblocking the release:
- One fewer external download per matrix job (5 fewer per release).
- No version drift risk — version comes from the resolved \`@vscode/ripgrep\` instead of a hardcoded \`RG_VERSION=\"v15.0.1\"\`.
- Platform name mapping is just one special case (\`windows-x64\` → \`win32-x64\`); all other targets match directly.

## Test plan

- [ ] Re-tag (or trigger the release workflow manually) and confirm all 5 cross-compile jobs succeed.
- [ ] Confirm the resulting binary still contains a working embedded \`rg\` — same smoke test as PR #260 (canopy search / skill-generation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)