### PR TITLE
fix(daemon): harden init + canopy + title-summary against bad project roots (0.26.7)

### DIFF
--- a/packages/myco/src/canopy/scanner/delta-scan.ts
+++ b/packages/myco/src/canopy/scanner/delta-scan.ts
@@ -52,7 +52,12 @@ export function deltaScan(opts: DeltaScanOptions): CanopyScanResult {
   let updated = 0;
   let errored = 0;
 
-  for (const relPath of walkProject({ projectRoot: opts.projectRoot, isExcluded })) {
+  let limitHit: { kind: 'maxFiles' | 'maxDepth'; value: number } | null = null;
+  for (const relPath of walkProject({
+    projectRoot: opts.projectRoot,
+    isExcluded,
+    onLimitHit: (kind, value) => { limitHit ??= { kind, value }; },
+  })) {
     scanned++;
     const prior = existing.get(relPath);
 
@@ -94,7 +99,12 @@ export function deltaScan(opts: DeltaScanOptions): CanopyScanResult {
     else added++;
   }
 
-  const removed = deleteMissingEntries(opts.db, opts.projectId, visited);
+  // When the walk capped at maxFiles, skip `deleteMissingEntries` — `visited`
+  // is incomplete, so a tombstone pass would wrongly delete entries that
+  // simply weren't visited this round.
+  const removed = limitHit
+    ? 0
+    : deleteMissingEntries(opts.db, opts.projectId, visited);
   return {
     scanned,
     added,
@@ -102,5 +112,6 @@ export function deltaScan(opts: DeltaScanOptions): CanopyScanResult {
     removed,
     errored,
     durationMs: Date.now() - start,
+    limitHit: limitHit ?? undefined,
   };
 }

--- a/packages/myco/src/canopy/scanner/scan-project.ts
+++ b/packages/myco/src/canopy/scanner/scan-project.ts
@@ -43,7 +43,12 @@ export function scanProject(opts: ScanProjectOptions): CanopyScanResult {
   // re-queue it for canopy-describe even though nothing actually changed.
   const existing = listExistingHashes(opts.db, opts.projectId);
 
-  for (const relPath of walkProject({ projectRoot: opts.projectRoot, isExcluded })) {
+  let limitHit: { kind: 'maxFiles' | 'maxDepth'; value: number } | null = null;
+  for (const relPath of walkProject({
+    projectRoot: opts.projectRoot,
+    isExcluded,
+    onLimitHit: (kind, value) => { limitHit ??= { kind, value }; },
+  })) {
     scanned++;
     const result = scanFile({
       projectId: opts.projectId,
@@ -68,7 +73,13 @@ export function scanProject(opts: ScanProjectOptions): CanopyScanResult {
     else added++;
   }
 
-  const removed = deleteMissingEntries(opts.db, opts.projectId, visited);
+  // When the walk capped at maxFiles, skip `deleteMissingEntries` — `visited`
+  // is incomplete, and a tombstone pass would wrongly delete entries that
+  // simply weren't visited this round. The next scan with a corrected
+  // exclude set (or a fixed project root) catches them properly.
+  const removed = limitHit
+    ? 0
+    : deleteMissingEntries(opts.db, opts.projectId, visited);
   return {
     scanned,
     added,
@@ -76,5 +87,6 @@ export function scanProject(opts: ScanProjectOptions): CanopyScanResult {
     removed,
     errored,
     durationMs: Date.now() - start,
+    limitHit: limitHit ?? undefined,
   };
 }

--- a/packages/myco/src/canopy/scanner/walk.ts
+++ b/packages/myco/src/canopy/scanner/walk.ts
@@ -11,7 +11,29 @@ export interface WalkOptions {
    * a single-purpose matcher can ignore it.
    */
   isExcluded: (relPath: string, isDir?: boolean) => boolean;
+  /**
+   * Hard cap on how many file paths the walker yields per call. Prevents
+   * a misconfigured project root (e.g., $HOME accidentally registered as
+   * a project) from blocking the event loop on a multi-million-file
+   * traversal. Default 50,000. Set to `Infinity` to disable.
+   *
+   * When the cap is reached, an `onLimitHit` callback fires (if provided)
+   * and the generator stops. The caller is responsible for logging.
+   */
+  maxFiles?: number;
+  /**
+   * Hard cap on directory descent depth. Prevents pathological symlink
+   * loops (we already skip symlinks, but defense in depth) and runaway
+   * deep trees from blocking the walk. Default 24. Set to `Infinity`
+   * to disable.
+   */
+  maxDepth?: number;
+  /** Called once when `maxFiles` or `maxDepth` is hit, for caller logging. */
+  onLimitHit?: (kind: 'maxFiles' | 'maxDepth', value: number) => void;
 }
+
+const DEFAULT_MAX_FILES = 50_000;
+const DEFAULT_MAX_DEPTH = 24;
 
 /**
  * Recursive file walk yielding repo-relative, forward-slash paths.
@@ -23,9 +45,14 @@ export interface WalkOptions {
  * scan; the caller logs in aggregate.
  */
 export function* walkProject(opts: WalkOptions): Generator<string> {
-  const stack: string[] = ['']; // empty string represents projectRoot itself
+  const maxFiles = opts.maxFiles ?? DEFAULT_MAX_FILES;
+  const maxDepth = opts.maxDepth ?? DEFAULT_MAX_DEPTH;
+  // Stack carries (relDir, depth). Empty string represents projectRoot itself.
+  const stack: Array<{ relDir: string; depth: number }> = [{ relDir: '', depth: 0 }];
+  let yielded = 0;
+  let hitDepthLimit = false;
   while (stack.length > 0) {
-    const relDir = stack.pop()!;
+    const { relDir, depth } = stack.pop()!;
     const absDir = relDir === '' ? opts.projectRoot : path.join(opts.projectRoot, relDir);
 
     let entries: fs.Dirent[];
@@ -45,12 +72,24 @@ export function* walkProject(opts: WalkOptions): Generator<string> {
 
       if (e.isDirectory()) {
         if (opts.isExcluded(relChild, true)) continue;
-        stack.push(relChild);
+        if (depth + 1 > maxDepth) {
+          if (!hitDepthLimit) {
+            hitDepthLimit = true;
+            opts.onLimitHit?.('maxDepth', maxDepth);
+          }
+          continue;
+        }
+        stack.push({ relDir: relChild, depth: depth + 1 });
         continue;
       }
       if (!e.isFile()) continue;
       if (opts.isExcluded(relChild, false)) continue;
       yield relChild;
+      yielded++;
+      if (yielded >= maxFiles) {
+        opts.onLimitHit?.('maxFiles', maxFiles);
+        return;
+      }
     }
   }
 }

--- a/packages/myco/src/canopy/types.ts
+++ b/packages/myco/src/canopy/types.ts
@@ -28,4 +28,10 @@ export interface CanopyScanResult {
   removed: number;
   errored: number;
   durationMs: number;
+  /**
+   * Set when the walker stopped early because it hit the `maxFiles` or
+   * `maxDepth` cap. Callers should log a warning naming the project so
+   * an operator can investigate (typically a too-broad project root).
+   */
+  limitHit?: { kind: 'maxFiles' | 'maxDepth'; value: number };
 }

--- a/packages/myco/src/cli/init.ts
+++ b/packages/myco/src/cli/init.ts
@@ -1,6 +1,6 @@
 import { initDatabase, vaultDbPath, closeDatabase } from '../db/client.js';
 import { createSchema } from '../db/schema.js';
-import { resolveVaultDir, resolveProjectRoot } from '../vault/resolve.js';
+import { resolveVaultDir, resolveProjectRoot, assertSafeProjectRoot, UnsafeProjectRootError } from '../vault/resolve.js';
 import { ensureProjectManifest, loadProjectManifest, type ProjectManifest } from '../config/project-manifest.js';
 import { resolveProjectVaultDir } from '../grove/paths.js';
 import { ensureGroveDatabase } from '../grove/database.js';
@@ -46,6 +46,20 @@ export async function run(args: string[]): Promise<void> {
   const explicitProjectRoot = projectArg ? path.resolve(projectArg) : undefined;
   const vaultDir = explicitProjectRoot ? resolveProjectVaultDir(explicitProjectRoot) : resolveVaultDir();
   const projectRoot = explicitProjectRoot ?? resolveProjectRoot(vaultDir);
+
+  // Refuse to register obviously-too-broad project roots ($HOME, /,
+  // /Users/<user>, etc.) before we touch the registry. A bad root here
+  // cascades into canopy-scan event-loop wedges and a poisoned project
+  // entry that's hard to clean up after the fact.
+  try {
+    assertSafeProjectRoot(projectRoot);
+  } catch (err) {
+    if (err instanceof UnsafeProjectRootError) {
+      console.error(`\nmyco init: ${err.message}\n`);
+      process.exit(1);
+    }
+    throw err;
+  }
 
   const alreadyInitialized = fs.existsSync(path.join(vaultDir, 'myco.yaml'));
 

--- a/packages/myco/src/daemon/jobs/canopy-scan.ts
+++ b/packages/myco/src/daemon/jobs/canopy-scan.ts
@@ -28,9 +28,31 @@ import type { MycoConfig } from '@myco/config/schema.js';
 import type { PowerManager } from '../power.js';
 import { scanProject } from '@myco/canopy/scanner/scan-project.js';
 import { deltaScan } from '@myco/canopy/scanner/delta-scan.js';
+import type { CanopyScanResult } from '@myco/canopy/types.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { POWER_JOB_NAMES } from '@myco/constants/power-jobs.js';
 import type { GroveProjectId } from '@myco/grove/ids.js';
+
+/**
+ * Surface a one-line warning when the walker tripped a safety cap. The
+ * scanner already returns partial data — operators need a clear signal
+ * that the project root is likely misconfigured (typically $HOME or `/`)
+ * so they can investigate instead of trusting the truncated counts.
+ */
+function logScanLimitHit(
+  logger: DaemonLogger,
+  projectId: string,
+  projectRoot: string,
+  limitHit: CanopyScanResult['limitHit'],
+): void {
+  if (!limitHit) return;
+  logger.warn(LOG_KINDS.CANOPY_SCAN, 'Canopy scan stopped at safety cap — project root may be too broad', {
+    project_id: projectId,
+    project_root: projectRoot,
+    limit_kind: limitHit.kind,
+    limit_value: limitHit.value,
+  });
+}
 
 /**
  * Threshold above which a scan's `added` count counts as a "mass re-add"
@@ -141,6 +163,7 @@ export class CanopyDeltaScanRunner {
         ...result,
         project_id: this.identity.projectId,
       });
+      logScanLimitHit(this.shared.logger, this.identity.projectId, this.identity.projectRoot, result.limitHit);
       // Mass-add detection: a delta scan that re-adds many rows means
       // either initial populate just landed or something earlier wiped
       // rows that have now been restored. New rows have NULL
@@ -321,6 +344,7 @@ export class CanopyJobsRegistry {
         ...result,
         project_id: identity.projectId,
       });
+      logScanLimitHit(this.shared.logger, identity.projectId, identity.projectRoot, result.limitHit);
       if (result.added > DELTA_SCAN_MASS_ADD_KICK_THRESHOLD) {
         this.shared.onCanopyMassAdd?.(identity.groveId, identity.projectId);
       }

--- a/packages/myco/src/daemon/trigger-title-summary.ts
+++ b/packages/myco/src/daemon/trigger-title-summary.ts
@@ -11,6 +11,10 @@ import type { EmbeddingManager } from './embedding/manager.js';
 import type { DaemonLogger } from './logger.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+import {
+  tryResolveRequestContextForVault,
+  type MycoRequestContext,
+} from '@myco/tools/request-context.js';
 
 export interface TriggerTitleSummaryDeps {
   vaultDir: string;
@@ -20,6 +24,14 @@ export interface TriggerTitleSummaryDeps {
   // without a daemon restart.
   liveConfig: { current: MycoConfig };
   logger: DaemonLogger;
+  /**
+   * Caller-supplied request context. The title-summary task runs through
+   * `runAgent`, which threads context into `projectScopeFromRequestContext`
+   * for project-scoped reads/writes. When omitted, we fall back to deriving
+   * a context from `vaultDir` so the task doesn't crash on the first call
+   * — see the catch in the body for the legacy-vault case.
+   */
+  requestContext?: MycoRequestContext;
 }
 
 /**
@@ -43,6 +55,21 @@ export async function triggerTitleSummary(
   if (config.agent.summary_batch_interval <= 0) return;
   if (config.agent.event_tasks_enabled === false) return;
 
+  // runAgent calls projectScopeFromRequestContext, which throws when no
+  // context is supplied. The Stop pipeline used to pass no context here
+  // and every title-summary task failed with that exact error. Supply the
+  // caller's context if we got one; otherwise resolve from vaultDir with
+  // the sessionId as an override so the task gets project-scoped reads.
+  let requestContext = deps.requestContext;
+  if (!requestContext) {
+    const resolved = tryResolveRequestContextForVault(vaultDir, { sessionId });
+    if (resolved.kind === 'grove') {
+      requestContext = resolved.context;
+    }
+    // Legacy non-Grove vaults fall through with requestContext undefined;
+    // runAgent will surface the underlying error via its own try/catch.
+  }
+
   try {
     const { runAgent } = await import('../agent/executor.js');
     runAgent(vaultDir, {
@@ -50,6 +77,7 @@ export async function triggerTitleSummary(
       instruction: `Process session ${sessionId} only`,
       embeddingManager,
       logger,
+      requestContext,
     }).catch((err) => {
       logger.warn(LOG_KINDS.AGENT_ERROR, 'Title-summary task failed', {
         session_id: sessionId,

--- a/packages/myco/src/grove/registry.ts
+++ b/packages/myco/src/grove/registry.ts
@@ -23,6 +23,7 @@ import {
   findRegisteredProjectByBinding as findRegisteredProjectByBindingResolve,
   type RegistryResolvedProject,
 } from './registry-resolve.js';
+import { assertSafeProjectRoot } from '../vault/resolve.js';
 
 export type DaemonVariant = 'service' | 'service-dev';
 
@@ -348,6 +349,11 @@ export function registerProjectInGrove(
 ): RegisteredProject {
   const grove = loadGroveRecord(groveId, mycoHome);
   if (!grove) throw new Error(`Unknown Grove: ${groveId}`);
+
+  // Defense in depth: even if a CLI / MCP caller skipped the same check,
+  // refuse to register $HOME / `/` / a likely-home-dir as a project root.
+  // See `assertSafeProjectRoot` for the rationale.
+  assertSafeProjectRoot(input.projectRoot);
 
   const root = path.resolve(input.projectRoot);
   const now = new Date().toISOString();

--- a/packages/myco/src/vault/resolve.ts
+++ b/packages/myco/src/vault/resolve.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import os from 'node:os';
 import { execFileSync } from 'node:child_process';
 
 /**
@@ -24,6 +25,65 @@ export function resolveVaultDir(cwd: string = process.cwd()): string {
  */
 export function resolveProjectRoot(vaultDir: string): string {
   return path.dirname(vaultDir);
+}
+
+/**
+ * Refuse to treat dangerously-broad paths as a project root.
+ *
+ * A project root is meant to be a single repo or workspace directory. When
+ * `myco init` (or any other registration site) is handed `$HOME`, `/`, or
+ * a direct child of `/Users` / `/home` / `/root`, the user almost certainly
+ * ran the command from the wrong cwd. Letting it through registers a
+ * "project" that owns the entire home directory — which then poisons
+ * downstream tools like the canopy scanner, which try to walk every file
+ * under the project root.
+ *
+ * Throws `UnsafeProjectRootError` with a message that explains both what
+ * was rejected and the likely fix. Call from every project-creation entry
+ * point: `myco init`, MCP register tools, and `registerProjectInGrove`
+ * (defense in depth).
+ */
+export class UnsafeProjectRootError extends Error {
+  constructor(public readonly projectRoot: string, public readonly reason: string) {
+    super(
+      `Refusing to use ${projectRoot} as a project root: ${reason}. ` +
+      `Run \`myco init\` from inside a specific project directory ` +
+      `(e.g., a checked-out git repo), not from your home directory or filesystem root.`,
+    );
+    this.name = 'UnsafeProjectRootError';
+  }
+}
+
+// Paths that are themselves well-known user home directories, even when
+// they don't match the calling user's $HOME. Caught by an exact match.
+const KNOWN_HOME_DIRS = new Set(['/root', '/var/root']);
+// Parent dirs whose direct children are conventionally a user's home
+// (e.g., `/Users/anyone` on macOS, `/home/anyone` on Linux). A path one
+// segment below any of these is rejected.
+const HOME_PARENT_DIRS = new Set(['/Users', '/home', '/root', '/var/root']);
+
+export function assertSafeProjectRoot(projectRoot: string): void {
+  const resolved = path.resolve(projectRoot);
+
+  if (resolved === os.homedir()) {
+    throw new UnsafeProjectRootError(resolved, "this is the user's home directory ($HOME)");
+  }
+
+  if (resolved === path.parse(resolved).root) {
+    throw new UnsafeProjectRootError(resolved, 'this is the filesystem root');
+  }
+
+  if (KNOWN_HOME_DIRS.has(resolved)) {
+    throw new UnsafeProjectRootError(resolved, 'this is a well-known user home directory');
+  }
+
+  const parent = path.dirname(resolved);
+  if (HOME_PARENT_DIRS.has(parent)) {
+    throw new UnsafeProjectRootError(
+      resolved,
+      `this looks like a user home directory (direct child of ${parent})`,
+    );
+  }
 }
 
 /**

--- a/tests/canopy/scanner/walk.test.ts
+++ b/tests/canopy/scanner/walk.test.ts
@@ -59,4 +59,49 @@ describe('walkProject', () => {
     const missing = path.join(tmp, 'missing-root');
     expect(() => [...walkProject({ projectRoot: missing, isExcluded: () => false })]).toThrow(/Cannot read project root/);
   });
+
+  it('caps yield at maxFiles and fires onLimitHit', () => {
+    for (let i = 0; i < 50; i++) write(`f${i}.ts`);
+    const limits: Array<{ kind: string; value: number }> = [];
+    const results = [...walkProject({
+      projectRoot: tmp,
+      isExcluded: () => false,
+      maxFiles: 10,
+      onLimitHit: (kind, value) => limits.push({ kind, value }),
+    })];
+    expect(results.length).toBe(10);
+    expect(limits).toEqual([{ kind: 'maxFiles', value: 10 }]);
+  });
+
+  it('caps directory descent at maxDepth and fires onLimitHit', () => {
+    // Build /tmp/a/b/c/d/leaf.ts → depth 4
+    write('a/b/c/d/leaf.ts');
+    write('a/top.ts');
+    const limits: Array<{ kind: string; value: number }> = [];
+    const results = [...walkProject({
+      projectRoot: tmp,
+      isExcluded: () => false,
+      maxDepth: 2,
+      onLimitHit: (kind, value) => limits.push({ kind, value }),
+    })].sort();
+    // a/top.ts is at depth 1 → kept. a/b/c/d/leaf.ts at depth 4 → pruned.
+    expect(results).toContain('a/top.ts');
+    expect(results.every((p) => !p.includes('/c/'))).toBe(true);
+    expect(limits.some((l) => l.kind === 'maxDepth' && l.value === 2)).toBe(true);
+  });
+
+  it('does not call onLimitHit when caps are not reached', () => {
+    write('a.ts');
+    write('b.ts');
+    const limits: Array<{ kind: string; value: number }> = [];
+    const results = [...walkProject({
+      projectRoot: tmp,
+      isExcluded: () => false,
+      maxFiles: 100,
+      maxDepth: 100,
+      onLimitHit: (kind, value) => limits.push({ kind, value }),
+    })];
+    expect(results.length).toBe(2);
+    expect(limits).toEqual([]);
+  });
 });

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -44,9 +44,19 @@ mock.module('@myco/hooks/client.js', () => ({
   },
 }));
 
+class UnsafeProjectRootError extends Error {
+  constructor(public readonly projectRoot: string, public readonly reason: string) {
+    super(`unsafe: ${reason}`);
+  }
+}
 mock.module('@myco/vault/resolve.js', () => ({
   resolveVaultDir: vi.fn(),
   resolveProjectRoot: vi.fn((vaultDir: string) => path.dirname(vaultDir)),
+  // Test vaults sit in /tmp/myco-init-*, which the real guard would
+  // accept — stub the assertion as a no-op so we don't have to thread
+  // safe-path fixtures through every test case.
+  assertSafeProjectRoot: vi.fn(),
+  UnsafeProjectRootError,
 }));
 
 import { run } from '@myco/cli/init.js';

--- a/tests/cli/remove.test.ts
+++ b/tests/cli/remove.test.ts
@@ -25,9 +25,19 @@ mock.module('@myco/symbionts/installer.js', () => {
 });
 
 let testVaultDir = '';
+class UnsafeProjectRootError extends Error {
+  constructor(public readonly projectRoot: string, public readonly reason: string) {
+    super(`unsafe: ${reason}`);
+  }
+}
 mock.module('@myco/vault/resolve.js', () => ({
   resolveVaultDir: vi.fn(() => testVaultDir),
   resolveProjectRoot: vi.fn((vaultDir: string) => path.dirname(vaultDir)),
+  // Tests run with synthetic /tmp project roots that are always safe — the
+  // real guard would let them through too. Stub as a no-op so cli paths
+  // that import this module don't fail at import time.
+  assertSafeProjectRoot: vi.fn(),
+  UnsafeProjectRootError,
 }));
 
 describe('myco remove --symbiont', () => {

--- a/tests/vault/safe-project-root.test.ts
+++ b/tests/vault/safe-project-root.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'bun:test';
+import os from 'node:os';
+import path from 'node:path';
+import { assertSafeProjectRoot, UnsafeProjectRootError } from '@myco/vault/resolve';
+
+describe('assertSafeProjectRoot', () => {
+  it('rejects $HOME', () => {
+    expect(() => assertSafeProjectRoot(os.homedir())).toThrow(UnsafeProjectRootError);
+    try {
+      assertSafeProjectRoot(os.homedir());
+    } catch (err) {
+      expect((err as UnsafeProjectRootError).reason).toMatch(/home directory/);
+    }
+  });
+
+  it('rejects the filesystem root', () => {
+    const root = path.parse(os.homedir()).root; // '/' on POSIX, 'C:\\' on Windows
+    expect(() => assertSafeProjectRoot(root)).toThrow(UnsafeProjectRootError);
+  });
+
+  it('rejects a direct child of /Users (likely a user home)', () => {
+    expect(() => assertSafeProjectRoot('/Users/notARealUser')).toThrow(UnsafeProjectRootError);
+  });
+
+  it('rejects a direct child of /home', () => {
+    expect(() => assertSafeProjectRoot('/home/someuser')).toThrow(UnsafeProjectRootError);
+  });
+
+  it('rejects /root and /var/root', () => {
+    expect(() => assertSafeProjectRoot('/root')).toThrow();
+    // /var/root is a direct child of /var, not the home parent set — but
+    // /var/root itself is the macOS root user's home. Confirm the parent
+    // check catches direct children of /var/root specifically.
+    expect(() => assertSafeProjectRoot('/var/root/something')).toThrow();
+  });
+
+  it('accepts a normal nested project path', () => {
+    expect(() => assertSafeProjectRoot('/Users/anyone/Repos/some-project')).not.toThrow();
+    expect(() => assertSafeProjectRoot('/tmp/myco-test-fixture')).not.toThrow();
+  });
+
+  it('resolves relative paths before checking', () => {
+    // path.resolve('.') === process.cwd(); when cwd happens to BE $HOME this
+    // would catch the issue. Here we test the resolve step normalizes.
+    const expanded = path.resolve(os.homedir(), '..', path.basename(os.homedir()));
+    expect(expanded).toBe(os.homedir());
+    expect(() => assertSafeProjectRoot(expanded)).toThrow(UnsafeProjectRootError);
+  });
+});


### PR DESCRIPTION
## Summary

Three independent fixes for the bug chain that broke session capture on `2026-05-11`. A stray `myco init` run from `$HOME` registered a project rooted at the user's whole home directory, and the canopy scanner walking that tree wedged the daemon's event loop. While recovering, a separate `triggerTitleSummary` bug fired on every Stop event.

- **`myco init` rejects `$HOME`, `/`, `/root`, `/var/root`, and direct children of `/Users` / `/home` / `/root` / `/var/root`** — exits with code 1 and an actionable error. Same guard applied inside `registerProjectInGrove()` (defense in depth so MCP tools or other third-party callers can't bypass the CLI).
- **Canopy walker bounds traversal at `maxFiles=50_000` / `maxDepth=24`** — even with a bad root, the daemon stays responsive. `scanProject` / `deltaScan` skip the tombstone pass when capped (truncated visit set would falsely delete real entries). Daemon caller logs a `warn` naming the project + which cap fired.
- **`triggerTitleSummary` derives a fallback `requestContext`** — fixes the `projectScopeFromRequestContext requires a MycoRequestContext` error that fired on every Stop.

Two related bugs are deferred to their own PRs because they need better repros than what we have today:
- `reconcileSession` amplification — observed but the existing divergence guard *should* prevent it; need a clean local repro before patching.
- `myco --version` reports stale binary version after upgrade — that's a packaging-level issue in `select-binary.mjs` / per-platform subpackage publish, not a CLI patch.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `make build` clean (tsc + vitest + tsup + vite)
- [x] **Smoke 1 (init guard):** `myco init --project $HOME` → exit 1 with the new error message
- [x] **Smoke 2 (init guard):** `myco init --project /Users/notARealUser` → exit 1, "direct child of /Users" message
- [x] **Smoke 3 (init guard):** `myco init --project /tmp/myco-smoke-real` → succeeds, registers normally
- [x] Daemon stays healthy through the smoke-test sequence
- [x] **Unit: `walkProject` bounds** — caps yield at `maxFiles`, fires `onLimitHit`, prunes at `maxDepth`, no callback when caps not reached
- [x] **Unit: `assertSafeProjectRoot`** — rejects `$HOME`, `/`, `/root`, `/var/root`, parent-of-Users/home/root paths; accepts normal nested project paths; resolves relative paths before checking
- [x] **Test mock fixups** for `tests/cli/init.test.ts` and `tests/cli/remove.test.ts` so existing suites still pass with the new exports

The integration smoke for `triggerTitleSummary` is left to post-merge dogfood — running an isolated daemon against a synthetic Grove tripped the (correctly-working) cross-Grove guard, so the proper test is post-deploy on a real session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)