### PR TITLE
fix(mcp): attach daemon bearer token in stdio bridge

### DIFF
--- a/packages/myco/src/hooks/client.ts
+++ b/packages/myco/src/hooks/client.ts
@@ -35,6 +35,15 @@ import type { ServiceManager } from '../service/types.js';
 export interface DaemonInfo {
   pid: number;
   port: number;
+  /**
+   * Daemon-issued bearer token (G4). Present when the daemon writes
+   * `daemon.json` with an `auth_token`; absent for pre-G4 state files.
+   * Out-of-band callers (e.g. the stdio MCP bridge) that build their
+   * own HTTP transport must attach this as `x-myco-auth` whenever
+   * they send context-switching headers, or the daemon's gate rejects
+   * the request with `UnauthorizedRequestContextError`.
+   */
+  auth_token?: string;
 }
 
 /**

--- a/packages/myco/src/mcp/stdio-bridge.ts
+++ b/packages/myco/src/mcp/stdio-bridge.ts
@@ -20,7 +20,11 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { resolveVaultDir } from '../vault/resolve.js';
 import { DaemonClient } from '../hooks/client.js';
-import { requestContextFromEnvironment, requestContextHeaders } from '../tools/request-context.js';
+import {
+  REQUEST_CONTEXT_AUTH_HEADER,
+  requestContextFromEnvironment,
+  requestContextHeaders,
+} from '../tools/request-context.js';
 
 const STDIO_BRIDGE_TAG = '[myco stdio-bridge]';
 
@@ -40,13 +44,17 @@ export async function main(): Promise<void> {
     process.exit(1);
   }
 
+  // G4: context-switching headers (project/grove ids) must be paired with
+  // the daemon-issued bearer token. The host (e.g. claude-code) spawns this
+  // bridge with a clean env, so MYCO_DAEMON_AUTH is unset — recover the
+  // token from daemon.json via `info.auth_token`.
+  const headers: Record<string, string> = {
+    ...requestContextHeaders(requestContextFromEnvironment(process.env, vaultDir)),
+    ...(info.auth_token ? { [REQUEST_CONTEXT_AUTH_HEADER]: info.auth_token } : {}),
+  };
   const upstream = new StreamableHTTPClientTransport(
     new URL(`http://127.0.0.1:${info.port}/mcp`),
-    {
-      requestInit: {
-        headers: requestContextHeaders(requestContextFromEnvironment(process.env, vaultDir)),
-      },
-    },
+    { requestInit: { headers } },
   );
   const downstream = new StdioServerTransport();
 

--- a/tests/mcp/stdio-bridge-auth.test.ts
+++ b/tests/mcp/stdio-bridge-auth.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { createStreamableMcpHttpHandler } from '@myco/mcp/http.js';
+import type { DaemonClient } from '@myco/hooks/client.js';
+import {
+  REQUEST_CONTEXT_AUTH_ENV,
+  REQUEST_CONTEXT_ENV,
+} from '@myco/tools/request-context.js';
+import { saveProjectManifest } from '@myco/config/project-manifest.js';
+import { createGrove, registerProjectInGrove } from '@myco/grove/registry.js';
+import { resolveDaemonServiceState, writeDaemonState } from '@myco/daemon/service-state.js';
+import { vi } from '../helpers/vi-shim.js';
+
+const servers: http.Server[] = [];
+const tmpDirs: string[] = [];
+let savedEnv: Record<string, string | undefined> = {};
+
+afterEach(async () => {
+  await Promise.all(servers.map((server) => new Promise<void>((resolve) => server.close(() => resolve()))));
+  servers.length = 0;
+  for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+  tmpDirs.length = 0;
+  for (const [key, prior] of Object.entries(savedEnv)) {
+    if (prior === undefined) delete process.env[key];
+    else process.env[key] = prior;
+  }
+  savedEnv = {};
+});
+
+function saveEnv(...keys: string[]): void {
+  for (const key of keys) savedEnv[key] = process.env[key];
+}
+
+function mockClient(): DaemonClient {
+  return {
+    get: vi.fn(async () => ({ ok: true, data: {} })),
+    post: vi.fn().mockResolvedValue({ ok: true, data: {} }),
+    put: vi.fn().mockResolvedValue({ ok: true, data: {} }),
+    delete: vi.fn().mockResolvedValue({ ok: true, data: {} }),
+  } as unknown as DaemonClient;
+}
+
+/**
+ * Stub daemon mirroring the real daemon's raw-route wrapping: the /mcp
+ * handler throws on auth failure, which the daemon's request handler
+ * converts into the `-32603 Internal server error` JSON-RPC envelope the
+ * bug report observed. Tests assert the bridge clears the gate, so they
+ * never need to observe the unauthorized branch directly.
+ */
+async function startDaemonStub(
+  vaultDir: string,
+  mcpHandler: (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>,
+  authToken: string,
+): Promise<void> {
+  const server = http.createServer((req, res) => {
+    if (req.url === '/mcp') {
+      void mcpHandler(req, res).catch((err: Error) => {
+        if (res.headersSent) return;
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          jsonrpc: '2.0',
+          error: { code: -32603, message: 'Internal server error', data: err.message },
+          id: null,
+        }));
+      });
+      return;
+    }
+    if (req.url === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ myco: true }));
+      return;
+    }
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not_found' }));
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+  const address = server.address() as { port: number };
+  const daemonService = resolveDaemonServiceState(vaultDir, { env: process.env });
+  writeDaemonState(daemonService.statePath, {
+    pid: process.pid,
+    port: address.port,
+    auth_token: authToken,
+  });
+}
+
+function childEnv(strip: string[], extra: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (typeof value === 'string' && !strip.includes(key)) env[key] = value;
+  }
+  env.MYCO_NO_AUTO_SPAWN = '1';
+  Object.assign(env, extra);
+  return env;
+}
+
+describe('MCP stdio bridge auth', () => {
+  it('forwards the daemon-issued bearer token so context-switching requests pass the gate', async () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-stdio-auth-'));
+    tmpDirs.push(projectRoot);
+    saveEnv('MYCO_HOME', REQUEST_CONTEXT_AUTH_ENV);
+    const home = path.join(projectRoot, '.myco-home');
+    process.env.MYCO_HOME = home;
+    const vaultDir = path.join(projectRoot, '.myco');
+    fs.mkdirSync(vaultDir, { recursive: true });
+    fs.writeFileSync(path.join(vaultDir, 'myco.yaml'), 'version: 3\nconfig_version: 0\n', 'utf-8');
+    const grove = createGrove('Work', home);
+    saveProjectManifest(vaultDir, {
+      project: { id: 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', name: 'Project A' },
+      grove: { binding_id: 'gbind-a', slug: grove.slug, mode: 'local' },
+    });
+    registerProjectInGrove(grove.id, {
+      projectId: 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      projectName: 'Project A',
+      projectRoot,
+      bindingId: 'gbind-a',
+    }, home);
+
+    const authToken = 'test-bearer-9f3a';
+    // The /mcp handler runs in this (test) process and reads
+    // MYCO_DAEMON_AUTH from its own env to enable the gate.
+    process.env[REQUEST_CONTEXT_AUTH_ENV] = authToken;
+    const mcpHandler = createStreamableMcpHttpHandler(vaultDir, { client: mockClient() });
+    await startDaemonStub(vaultDir, mcpHandler, authToken);
+
+    const stdioClient = new Client({ name: 'myco-stdio-auth-test', version: '1.0.0' });
+    const stdioTransport = new StdioClientTransport({
+      command: process.execPath,
+      args: [path.resolve('packages/myco/src/cli.ts'), 'mcp'],
+      cwd: projectRoot,
+      // Strip MYCO_DAEMON_AUTH from the child env so the bridge MUST recover
+      // the token from daemon.json. Without this strip the env would leak the
+      // bearer to a separate code path and mask the bridge-side defect.
+      env: childEnv([REQUEST_CONTEXT_AUTH_ENV], {
+        [REQUEST_CONTEXT_ENV.projectRoot]: projectRoot,
+        [REQUEST_CONTEXT_ENV.projectId]: 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        [REQUEST_CONTEXT_ENV.groveId]: grove.id,
+        [REQUEST_CONTEXT_ENV.machineId]: 'machine-a',
+        [REQUEST_CONTEXT_ENV.sessionId]: 'sess-a',
+        MYCO_HOME: home,
+      }),
+      stderr: 'pipe',
+    });
+
+    try {
+      await stdioClient.connect(stdioTransport);
+      const list = await stdioClient.listTools();
+      expect(list.tools.length).toBeGreaterThan(0);
+    } finally {
+      await stdioClient.close().catch(() => undefined);
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

The stdio MCP bridge built its own upstream transport bypassing \`DaemonClient\`'s auth-header path, so context-switching headers (project/grove ids) reached the daemon without the required \`x-myco-auth\` bearer. Hosts that spawn the bridge with a clean env — notably Claude Code launched from a git worktree, where the resolved project id differs from the daemon's bootstrap context — were rejected by the G4 auth gate with \`-32603 Internal server error\`. The main checkout silently dodged this because its headers matched the daemon's default vault and the gate stayed inert.

- Recover the token from \`daemon.json\` via \`info.auth_token\` and merge it into the upstream transport's request headers in \`packages/myco/src/mcp/stdio-bridge.ts\`.
- Add \`auth_token?\` to \`DaemonInfo\` in \`packages/myco/src/hooks/client.ts\` so the value is typed at the boundary (the underlying \`DaemonState\` already carried it).
- New regression test \`tests/mcp/stdio-bridge-auth.test.ts\` spawns the real bridge as a child process against a stub daemon with the auth gate enforced; the child env has \`MYCO_DAEMON_AUTH\` stripped so the bridge MUST recover the token from \`daemon.json\`.

Supersedes spore \`gotcha-0f135fd2\`.

## Test plan

- [x] New test fails (30s timeout, gate rejects) before the patch
- [x] New test passes (~7s) after the patch
- [x] Existing \`tests/mcp/transport-parity.test.ts\` still passes
- [x] Full \`npm test\` green (4628 + 91 = 4719 passing)
- [x] Manual probe against live dev daemon (port 19344) — without \`x-myco-auth\`: \`Context-switching headers require the daemon-issued bearer token\`; with \`x-myco-auth\`: gate passes (probe failure then comes from Grove lookup, confirming the auth boundary is the only difference)
- [x] Main-checkout case preserved — fix is conditional on \`info.auth_token\` and the daemon only invokes the gate under context-switching headers, so the non-switching path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)