### PR TITLE
fix: isolate prod and dev service restarts

### DIFF
--- a/.agents/skills/debug-daemon-errors/SKILL.md
+++ b/.agents/skills/debug-daemon-errors/SKILL.md
@@ -107,6 +107,67 @@ await db.transaction(async (tx) => {
 
 **Pitfall:** If there are multiple levels of FK nesting (grandchild → child → parent), delete from the leaf up. Draw the dependency tree before writing the delete sequence.
 
+#### deleteSessionCascade — Complex FK Cascade Patterns
+
+The `deleteSessionCascade` function in `packages/myco/src/db/queries/sessions.ts` demonstrates the most complex FK cascade scenario in Myco. This function has encountered three different FK bugs due to its deep dependency tree and recurring extension pattern.
+
+**Design Contract:** `deleteSessionCascade` must delete a session and ALL related data across 9+ tables with complex FK dependencies. The function returns counts for each deleted table type for verification.
+
+**Correct Delete Order:**
+```typescript
+// Fixed FK-respecting delete order:
+// activities → attachments → plans → skill_usage → resolution_events → graph_edges → spores → prompt_batches → sessions
+```
+
+**Historical FK Bugs:**
+
+1. **Original Bug**: Deleted `prompt_batches` before `spores`, causing FK constraint violations because `spores.prompt_batch_id` references `prompt_batches.id`
+2. **Extension Bug**: Release provenance feature added new FK tables (`release_artifacts`, `release_commits`) that weren't included in the cascade delete
+3. **Test Gap**: Existing regression test used `createSpore` helper that omitted `promptBatchId`, so spores had no FK links to test
+
+**Recurring Extension Pattern:** Each time a new feature adds tables with session FKs, `deleteSessionCascade` must be updated or silent FK failures occur in production. The function serves as a "FK canary" — when session deletion starts failing, it indicates missing cascade delete entries.
+
+**Implementation Pattern:**
+```typescript
+export function deleteSessionCascade(sessionId: string): CascadeDeleteCounts {
+  return db.transaction((tx) => {
+    // Delete in FK dependency order - children first
+    const activities = tx.delete(activitiesTable).where(eq(activitiesTable.sessionId, sessionId));
+    const attachments = tx.delete(attachmentsTable).where(eq(attachmentsTable.sessionId, sessionId));
+    const plans = tx.delete(plansTable).where(eq(plansTable.sessionId, sessionId));
+    const skillUsage = tx.delete(skillUsageTable).where(eq(skillUsageTable.sessionId, sessionId));
+    const resolutionEvents = tx.delete(resolutionEventsTable).where(eq(resolutionEventsTable.sessionId, sessionId));
+    const graphEdges = tx.delete(graphEdgesTable).where(eq(graphEdgesTable.sessionId, sessionId));
+    const spores = tx.delete(sporesTable).where(eq(sporesTable.sessionId, sessionId));
+    const promptBatches = tx.delete(promptBatchesTable).where(eq(promptBatchesTable.sessionId, sessionId));
+    const sessions = tx.delete(sessionsTable).where(eq(sessionsTable.id, sessionId));
+
+    return { activities, attachments, plans, skillUsage, resolutionEvents, graphEdges, spores, promptBatches, sessions };
+  });
+}
+```
+
+**Extension Checklist:** When adding tables with session FKs:
+1. Add the new table delete to `deleteSessionCascade` in correct FK order
+2. Update the return type to include the new table count
+3. Add regression test that creates FK links to verify cascade delete works
+4. Test in isolation before deploying to avoid production FK failures
+
+**Debugging FK Cascade Failures:**
+```bash
+# Check for missing table deletions in deleteSessionCascade
+sqlite3 .myco/myco.db "
+SELECT sql FROM sqlite_master 
+WHERE sql LIKE '%REFERENCES%session%' 
+AND type='table';"
+
+# Verify FK constraints in logs
+grep -rn "FOREIGN KEY constraint failed" ~/.myco/daemon.log
+
+# Check session maintenance job for cascade delete usage
+grep -rn "deleteSessionCascade" packages/myco/src/daemon/jobs/
+```
+
 ### Grove Import/Migration FK Violations
 
 Grove import operations commonly trigger FK constraint violations when importing data with cross-references. The patterns above apply, but Grove import has additional considerations:
@@ -716,6 +777,7 @@ export async function performStartupRecovery() {
 | Error / Symptom | Likely Cause | Fix |
 |----------------|--------------|-----|
 | `FOREIGN KEY constraint failed` on delete | Wrong deletion order | Delete children before parents |
+| `deleteSessionCascade` FK constraint failed | Missing table in cascade delete OR wrong delete order | Add missing tables to cascade delete; use correct order: activities → attachments → plans → skill_usage → resolution_events → graph_edges → spores → prompt_batches → sessions |
 | Job registered but never fires | Scheduler not woken after insert | Call `scheduler.wake()` after inserting work |
 | Outbox drain loops without progress | Missing `approved_at` guard | Guard status transitions to set value only once |
 | Two sessions for one conversation | No duplicate guard on session insert | Check for existing session ID before insert |

--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,1 +1,2 @@
 scheduled_tasks.lock
+worktrees/

--- a/packages/myco/src/daemon/api/restart.ts
+++ b/packages/myco/src/daemon/api/restart.ts
@@ -55,12 +55,15 @@ export function buildRestartShellCommand(
  *  current status. Process-agnostic — used by client-side surfaces
  *  (DaemonClient.spawnDaemon) that only need to know "is there a service
  *  supervisor that owns the daemon for our variant" without checking PID. */
+const SERVICE_VARIANTS: ServiceVariant[] = ['dev', 'prod'];
+
 export async function findInstalledServiceLabel(
   mgr: ServiceManager,
+  variant?: ServiceVariant,
 ): Promise<{ label: string; status: ServiceStatus } | null> {
   if (!mgr.supported) return null;
-  for (const variant of ['dev', 'prod'] as ServiceVariant[]) {
-    const label = serviceLabel(variant);
+  for (const candidate of variant ? [variant] : SERVICE_VARIANTS) {
+    const label = serviceLabel(candidate);
     const installed = await mgr.isInstalled(label).catch(() => false);
     if (!installed) continue;
     const status = await mgr.status(label).catch(() => null);
@@ -83,9 +86,11 @@ export async function detectServiceManagedLabel(
   mgr: ServiceManager,
   myPid: number = process.pid,
 ): Promise<string | null> {
-  const found = await findInstalledServiceLabel(mgr);
-  if (!found) return null;
-  return found.status.running && found.status.pid === myPid ? found.label : null;
+  for (const variant of SERVICE_VARIANTS) {
+    const found = await findInstalledServiceLabel(mgr, variant);
+    if (found?.status.running && found.status.pid === myPid) return found.label;
+  }
+  return null;
 }
 
 export async function handleRestart(

--- a/packages/myco/src/hooks/client.ts
+++ b/packages/myco/src/hooks/client.ts
@@ -28,9 +28,10 @@ import {
   resolveDaemonServiceState,
   type DaemonServiceState,
 } from '../daemon/service-state.js';
+import { SERVICE_DEV_DIRNAME } from '../grove/paths.js';
 import { findInstalledServiceLabel } from '../daemon/api/restart.js';
 import { getServiceManager } from '../service/manager.js';
-import type { ServiceManager } from '../service/types.js';
+import type { ServiceManager, ServiceVariant } from '../service/types.js';
 
 export interface DaemonInfo {
   pid: number;
@@ -125,6 +126,10 @@ function defaultIsPortBound(port: number, pid: number): boolean {
   } catch {
     return false;
   }
+}
+
+function serviceVariantForState(state: DaemonServiceState): ServiceVariant {
+  return path.basename(state.stateDir) === SERVICE_DEV_DIRNAME ? 'dev' : 'prod';
 }
 
 /**
@@ -458,7 +463,7 @@ export class DaemonClient {
     // the /restart and update-flow bypasses fixed earlier in this branch.
     try {
       const mgr = this.serviceManager ?? getServiceManager();
-      const installed = await findInstalledServiceLabel(mgr);
+      const installed = await findInstalledServiceLabel(mgr, serviceVariantForState(this.daemonService));
       if (installed) {
         if (!installed.status.running) {
           // Supervisor knows about the service but isn't running it (cold

--- a/tests/daemon/api/restart.test.ts
+++ b/tests/daemon/api/restart.test.ts
@@ -36,7 +36,7 @@ function restoreProcessKill() {
   (process as any).kill = realKill;
 }
 
-import { buildRestartShellCommand, findInstalledServiceLabel, handleRestart, type RestartHandlerDeps } from '@myco/daemon/api/restart.js';
+import { buildRestartShellCommand, detectServiceManagedLabel, findInstalledServiceLabel, handleRestart, type RestartHandlerDeps } from '@myco/daemon/api/restart.js';
 import { ProgressTracker } from '@myco/daemon/api/progress.js';
 import { FakeServiceManager } from '../../helpers/fake-service-manager';
 
@@ -113,6 +113,26 @@ describe('findInstalledServiceLabel', () => {
     const found = await findInstalledServiceLabel(mgr);
     expect(found?.label).toBe('co.goondocks.myco');
   });
+
+  test('variant filter returns prod even when dev is installed first', async () => {
+    const mgr = new FakeServiceManager();
+    mgr.installed.add('co.goondocks.myco-dev');
+    mgr.statuses.set('co.goondocks.myco-dev', { installed: true, running: true, pid: 1111, lastExitCode: 0, unitPath: '/dev.plist' });
+    mgr.installed.add('co.goondocks.myco');
+    mgr.statuses.set('co.goondocks.myco', { installed: true, running: false, pid: null, lastExitCode: 78, unitPath: '/prod.plist' });
+    const found = await findInstalledServiceLabel(mgr, 'prod');
+    expect(found?.label).toBe('co.goondocks.myco');
+    expect(found?.status.running).toBe(false);
+  });
+
+  test('detectServiceManagedLabel scans past non-matching dev service', async () => {
+    const mgr = new FakeServiceManager();
+    mgr.installed.add('co.goondocks.myco-dev');
+    mgr.statuses.set('co.goondocks.myco-dev', { installed: true, running: true, pid: process.pid + 999, lastExitCode: 0, unitPath: '/dev.plist' });
+    mgr.installed.add('co.goondocks.myco');
+    mgr.statuses.set('co.goondocks.myco', { installed: true, running: true, pid: process.pid, lastExitCode: 0, unitPath: '/prod.plist' });
+    await expect(detectServiceManagedLabel(mgr, process.pid)).resolves.toBe('co.goondocks.myco');
+  });
 });
 
 describe('handleRestart', () => {
@@ -141,6 +161,20 @@ describe('handleRestart', () => {
     const mgr = new FakeServiceManager();
     mgr.installed.add('co.goondocks.myco');
     mgr.statuses.set('co.goondocks.myco', { installed: true, running: true, pid: process.pid, lastExitCode: 0, unitPath: '/x' });
+    const deps = makeDeps({ serviceManager: mgr });
+    const res = await handleRestart(deps, {});
+    expect(res.body).toMatchObject({ status: 'restarting' });
+    const shellCmd = (spawnCalls[0].args[1] ?? '');
+    expect(shellCmd).toContain('service restart');
+    expect(shellCmd).not.toContain('--dev');
+  });
+
+  test('service-managed prod with dev service also running: still routes to prod restart', async () => {
+    const mgr = new FakeServiceManager();
+    mgr.installed.add('co.goondocks.myco-dev');
+    mgr.statuses.set('co.goondocks.myco-dev', { installed: true, running: true, pid: process.pid + 999, lastExitCode: 0, unitPath: '/dev' });
+    mgr.installed.add('co.goondocks.myco');
+    mgr.statuses.set('co.goondocks.myco', { installed: true, running: true, pid: process.pid, lastExitCode: 0, unitPath: '/prod' });
     const deps = makeDeps({ serviceManager: mgr });
     const res = await handleRestart(deps, {});
     expect(res.body).toMatchObject({ status: 'restarting' });

--- a/tests/hooks/client-spawn-coalesce.test.ts
+++ b/tests/hooks/client-spawn-coalesce.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { DAEMON_SPAWN_COALESCE_MS } from '@myco/constants';
-import { resolveServiceDaemonStatePath } from '@myco/grove/paths';
+import { resolveServiceDaemonStatePath, setDevServiceMode } from '@myco/grove/paths';
 import * as childProcessActual__ns from 'node:child_process';
 import { FakeServiceManager, noServiceManager } from '../helpers/fake-service-manager';
 
@@ -49,6 +49,7 @@ describe('DaemonClient.spawnDaemon — coalesce guard', () => {
   });
 
   afterEach(() => {
+    setDevServiceMode(false);
     try { fs.unlinkSync(statePath); } catch { /* gone */ }
     fs.rmSync(vaultDir, { recursive: true, force: true });
   });
@@ -152,6 +153,7 @@ describe('DaemonClient.spawnDaemon — service-aware deferral', () => {
   let statePath: string;
 
   beforeEach(() => {
+    setDevServiceMode(false);
     vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-svc-defer-'));
     statePath = resolveServiceDaemonStatePath();
     fs.mkdirSync(path.dirname(statePath), { recursive: true });
@@ -160,6 +162,7 @@ describe('DaemonClient.spawnDaemon — service-aware deferral', () => {
   });
 
   afterEach(() => {
+    setDevServiceMode(false);
     try { fs.unlinkSync(statePath); } catch { /* gone */ }
     fs.rmSync(vaultDir, { recursive: true, force: true });
   });
@@ -200,9 +203,25 @@ describe('DaemonClient.spawnDaemon — service-aware deferral', () => {
     mgr.statuses.set('co.goondocks.myco-dev', {
       installed: true, running: false, pid: null, lastExitCode: null, unitPath: '/x.plist',
     });
+    setDevServiceMode(true);
     await new DaemonClient(vaultDir, { serviceManager: mgr }).spawnDaemon();
     expect(spawnMock).not.toHaveBeenCalled();
     expect(mgr.startCalls).toEqual(['co.goondocks.myco-dev']);
+  });
+
+  it('prod client ignores installed dev service and starts prod service', async () => {
+    const mgr = new FakeServiceManager();
+    mgr.installed.add('co.goondocks.myco-dev');
+    mgr.statuses.set('co.goondocks.myco-dev', {
+      installed: true, running: true, pid: 1111, lastExitCode: 0, unitPath: '/dev.plist',
+    });
+    mgr.installed.add('co.goondocks.myco');
+    mgr.statuses.set('co.goondocks.myco', {
+      installed: true, running: false, pid: null, lastExitCode: 78, unitPath: '/prod.plist',
+    });
+    await new DaemonClient(vaultDir, { serviceManager: mgr }).spawnDaemon();
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(mgr.startCalls).toEqual(['co.goondocks.myco']);
   });
 
   it('unsupported platform: falls back to legacy raw spawn', async () => {


### PR DESCRIPTION
## Summary

Fixes a production/dogfood service boundary leak in daemon restart and auto-spawn paths.

Production clients were using a process-agnostic service lookup that checked the dev service before the prod service. On a dogfood machine with `co.goondocks.myco-dev` running and `co.goondocks.myco` stopped, `myco restart` from a production project could see the dev service, assume a supervisor was already handling startup, and skip starting the prod service. The health check then polled the prod daemon port and failed because nothing was listening.

This changes service lookup to be variant-aware for client startup, and changes service-managed restart detection to match the running daemon PID against both variants instead of trusting the first installed service.

## Changes

- Let `findInstalledServiceLabel` accept an optional service variant filter.
- Make `DaemonClient.spawnDaemon` select `prod` vs `dev` from its resolved daemon service state.
- Make restart service-managed detection scan both service variants for the current daemon PID.
- Add regression coverage for prod clients when the dev service is also installed/running.

## Verification

- `bun test tests/hooks/client-spawn-coalesce.test.ts tests/daemon/api/restart.test.ts`
- `make build`
- Restored and verified production launchd service locally:
  - `myco service status` reports `co.goondocks.myco` running.
  - `curl http://localhost:20915/health` reports `version: "0.27.5"`.