### PR TITLE
feat(request-context): callerRoot field for worktree-local plan capture

### DIFF
--- a/packages/myco-team/src/cli.ts
+++ b/packages/myco-team/src/cli.ts
@@ -331,6 +331,7 @@ function resolveTeamRequestContext(vaultDir: string): MycoRequestContext {
     return {
       projectRoot: registeredRoot,
       projectId: assertGroveProjectId(projectId),
+      callerRoot: null,
       groveId: registered.grove.id,
       machineId,
       sessionId,
@@ -351,6 +352,7 @@ function resolveTeamRequestContext(vaultDir: string): MycoRequestContext {
       const registeredRoot = path.resolve(registered.project.root);
       return {
         projectRoot: registeredRoot,
+        callerRoot: null,
         projectId: assertGroveProjectId(registered.project.project_id),
         groveId: registered.grove.id,
         machineId,
@@ -373,6 +375,7 @@ function resolveTeamRequestContext(vaultDir: string): MycoRequestContext {
   }
   return {
     projectRoot: fallbackProjectRoot,
+    callerRoot: null,
     projectId: assertGroveProjectId(fallbackProjectId),
     groveId: null,
     machineId,

--- a/packages/myco/src/daemon/scope-iteration.ts
+++ b/packages/myco/src/daemon/scope-iteration.ts
@@ -348,6 +348,7 @@ function buildRegisteredProjectScope(input: {
   const projectId = assertGroveProjectId(input.project.project_id);
   const requestContext: MycoRequestContext = {
     projectRoot,
+    callerRoot: null,
     projectId,
     groveId: input.grove.id,
     machineId: input.machineId,

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -253,6 +253,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     requestProjectId: GroveProjectId,
     requestRowProjectId: string | null,
     requestProjectRoot: string,
+    requestCallerRoot: string | null,
     requestMachineId: string,
     requestProductionRef: string | null,
     hookTranscriptPath?: string,
@@ -483,8 +484,13 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     const sessionStopMs = Date.now();
     const sessionBatches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
 
+    // Caller-local: when the Stop request originates in a worktree, anchor
+    // the watch dirs and plan source paths at the worktree cwd so files
+    // written there are seen and stored as portable relative paths. Falls
+    // back to the daemon-boot registered root when no callerRoot is set.
+    const planCaptureRoot = requestCallerRoot ?? planWatchConfig.projectRoot;
     for (const watchDir of planWatchConfig.watchDirs) {
-      const absoluteWatchDir = resolvePlanWatchDir(watchDir, planWatchConfig.projectRoot);
+      const absoluteWatchDir = resolvePlanWatchDir(watchDir, planCaptureRoot);
       if (!fs.existsSync(absoluteWatchDir)) continue;
 
       const planFiles = collectPlanFiles(absoluteWatchDir, planWatchConfig.extensions);
@@ -508,7 +514,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
           );
           capturePlan({
             sourcePath: planFile,
-            projectRoot: planWatchConfig.projectRoot,
+            projectRoot: planCaptureRoot,
             projectId: requestRowProjectId,
             content,
             sessionId,
@@ -599,6 +605,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     const requestScope = rowProjectIdFromRequestContext(req.requestContext);
     const requestRowProjectId = requestScope === undefined ? requestProjectId : requestScope;
     const requestProjectRoot = req.requestContext?.projectRoot ?? resolveProjectRoot(vaultDir);
+    const requestCallerRoot = req.requestContext?.callerRoot ?? null;
     const requestMachineId = req.requestContext?.machineId ?? machineId;
     const requestProductionRef = primaryProductionRef(configForRequest(req));
 
@@ -678,6 +685,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
       requestProjectId,
       requestRowProjectId,
       requestProjectRoot,
+      requestCallerRoot,
       requestMachineId,
       requestProductionRef,
       normalizedTranscriptPath,

--- a/packages/myco/src/daemon/team-sync-init.ts
+++ b/packages/myco/src/daemon/team-sync-init.ts
@@ -227,6 +227,7 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
   function groveSyncContext(groveId: string, databasePath: string, projectVaultDir: string): MycoRequestContext {
     return {
       projectRoot: projectVaultDir,
+      callerRoot: null,
       // Cast — never read by team-sync code paths. Documented above.
       projectId: '' as MycoRequestContext['projectId'],
       groveId,

--- a/packages/myco/src/tools/call-context.ts
+++ b/packages/myco/src/tools/call-context.ts
@@ -142,6 +142,9 @@ export function resolveCallContext(
 
   return {
     projectRoot: resolvedProjectRoot,
+    // Preserve the caller's cwd across the pivot — switching Grove or
+    // pivoting project_id doesn't change "where the user is right now".
+    callerRoot: baseContext.callerRoot,
     projectId: resolvedProjectId,
     groveId: grove.id,
     machineId: baseContext.machineId,

--- a/packages/myco/src/tools/plans.ts
+++ b/packages/myco/src/tools/plans.ts
@@ -94,7 +94,10 @@ export async function handleMycoPlans(
       title: input.title,
       status: input.status,
       tags: input.tags,
-      projectRoot: context.projectRoot,
+      // Caller-local: source path keys must anchor to where the user is
+      // (worktree cwd) so the same plan file produces the same logical_key
+      // from any tree. Falls back to projectRoot when no callerRoot is set.
+      projectRoot: context.callerRoot ?? context.projectRoot,
       requestContext: context,
     });
 

--- a/packages/myco/src/tools/request-context.ts
+++ b/packages/myco/src/tools/request-context.ts
@@ -20,6 +20,17 @@ export const REQUEST_CONTEXT_HEADERS = {
   groveId: 'x-myco-grove-id',
   machineId: 'x-myco-machine-id',
   sessionId: 'x-myco-session-id',
+  /**
+   * Caller's actual cwd (per-request, free-form). Distinct from
+   * `x-myco-project-root` which is the canonical/registered project
+   * root and validated against the Grove registry. `callerRoot`
+   * represents "where the user is right now" — typically a git
+   * worktree path that differs from the registered main tree — and
+   * is preserved through resolution untouched. Filesystem ops that
+   * should follow the caller (plan watch dirs, plan source path
+   * keys) read `context.callerRoot ?? context.projectRoot`.
+   */
+  callerRoot: 'x-myco-caller-root',
 } as const;
 
 export const REQUEST_CONTEXT_ENV = {
@@ -28,6 +39,7 @@ export const REQUEST_CONTEXT_ENV = {
   groveId: 'MYCO_GROVE_ID',
   machineId: 'MYCO_MACHINE_ID',
   sessionId: 'MYCO_SESSION_ID',
+  callerRoot: 'MYCO_CALLER_ROOT',
 } as const;
 
 /**
@@ -84,6 +96,17 @@ export type RequestContextSource = 'explicit' | 'headers' | 'legacy-vault';
 
 export interface MycoRequestContext {
   projectRoot: string;
+  /**
+   * Caller's actual cwd, populated from `x-myco-caller-root` (or
+   * `MYCO_CALLER_ROOT`) and preserved untouched through registry
+   * resolution. Null when no caller-root was supplied. Readers that
+   * need "where the user is right now" — plan watch dirs, plan
+   * source path keys, hook artifact discovery — use
+   * `context.callerRoot ?? context.projectRoot`. Readers that need
+   * canonical project identity (vault dir, db path, Grove
+   * registration) stay on `projectRoot`.
+   */
+  callerRoot: string | null;
   projectId: GroveProjectId;
   groveId: string | null;
   machineId: string;
@@ -100,6 +123,7 @@ export function isGroveScoped(context: MycoRequestContext | undefined | null): b
 
 export interface LegacyRequestContextOptions {
   projectRoot?: string;
+  callerRoot?: string | null;
   projectId?: GroveProjectId;
   groveId?: string | null;
   machineId?: string;
@@ -129,6 +153,7 @@ export function resolveLegacyRequestContext(
   const projectRoot = options.projectRoot ?? resolveProjectRoot(vaultDir);
   return {
     projectRoot,
+    callerRoot: options.callerRoot ?? null,
     projectId: assertGroveProjectId(options.projectId),
     groveId: options.groveId ?? null,
     machineId: options.machineId ?? process.env.MYCO_MACHINE_ID ?? getMachineId(vaultDir),
@@ -142,6 +167,7 @@ export function resolveLegacyRequestContext(
 export function requestContextHeaders(context: MycoRequestContext): Record<string, string> {
   return compactHeaders({
     [REQUEST_CONTEXT_HEADERS.projectRoot]: context.projectRoot,
+    [REQUEST_CONTEXT_HEADERS.callerRoot]: context.callerRoot,
     [REQUEST_CONTEXT_HEADERS.projectId]: context.projectId,
     [REQUEST_CONTEXT_HEADERS.groveId]: context.groveId,
     [REQUEST_CONTEXT_HEADERS.machineId]: context.machineId,
@@ -159,7 +185,8 @@ export function requestContextFromHttpHeaders(
   // trigger a manifest read — failure mode is "unauthorized" full stop.
   enforceContextSwitchAuth(headers, options.expectedAuthToken ?? null);
 
-  const { context: fallback, manifest } = buildVaultFallback(fallbackVaultDir);
+  const callerRoot = normalizeCallerRoot(readHeader(headers, REQUEST_CONTEXT_HEADERS.callerRoot));
+  const { context: fallback, manifest } = buildVaultFallback(fallbackVaultDir, { callerRoot });
   const explicit: ExplicitContextInput = {
     projectRoot: readHeader(headers, REQUEST_CONTEXT_HEADERS.projectRoot),
     projectId: readHeader(headers, REQUEST_CONTEXT_HEADERS.projectId),
@@ -232,7 +259,8 @@ export function requestContextFromEnvironment(
 ): MycoRequestContext {
   const machineId = readEnv(env, REQUEST_CONTEXT_ENV.machineId);
   const sessionId = readEnv(env, REQUEST_CONTEXT_ENV.sessionId);
-  const { context: fallback, manifest } = buildVaultFallback(fallbackVaultDir, { machineId, sessionId });
+  const callerRoot = normalizeCallerRoot(readEnv(env, REQUEST_CONTEXT_ENV.callerRoot));
+  const { context: fallback, manifest } = buildVaultFallback(fallbackVaultDir, { machineId, sessionId, callerRoot });
   const hasExplicitProjectContext = [
     REQUEST_CONTEXT_ENV.projectRoot,
     REQUEST_CONTEXT_ENV.projectId,
@@ -326,7 +354,7 @@ export function tryResolveRequestContextForVault(
  */
 function buildVaultFallback(
   vaultDir: string,
-  overrides: { machineId?: string; sessionId?: string | null } = {},
+  overrides: { machineId?: string; sessionId?: string | null; callerRoot?: string | null } = {},
 ): { context: MycoRequestContext; manifest: ProjectManifest | null } {
   const result = tryBuildVaultFallback(vaultDir, overrides);
   if (result.kind === 'legacy') {
@@ -345,7 +373,7 @@ function buildVaultFallback(
  */
 function tryBuildVaultFallback(
   vaultDir: string,
-  overrides: { machineId?: string; sessionId?: string | null } = {},
+  overrides: { machineId?: string; sessionId?: string | null; callerRoot?: string | null } = {},
 ): { kind: 'grove'; context: MycoRequestContext; manifest: ProjectManifest } | { kind: 'legacy'; vaultDir: string; reason: string } {
   const manifest = readManifest(vaultDir);
   if (!manifest?.project?.id) {
@@ -360,6 +388,7 @@ function tryBuildVaultFallback(
     kind: 'grove',
     context: {
       projectRoot,
+      callerRoot: overrides.callerRoot ?? null,
       projectId: assertGroveProjectId(manifest.project.id),
       groveId: null,
       machineId: overrides.machineId ?? getMachineId(vaultDir),
@@ -597,6 +626,17 @@ function readManifest(projectVaultDir: string): ProjectManifest | null {
   // that field from this loader rather than calling `loadProjectLocalManifest`
   // directly so the legacy-vault and post-migration code paths stay unified.
   return loadProjectManifest(projectVaultDir);
+}
+
+/**
+ * Resolve a caller-root value (header or env) to an absolute path,
+ * or null when the caller did not supply one. Centralized so the
+ * HTTP and env entry points apply the same `path.resolve` normalization
+ * — readers downstream get a value that is always absolute when present.
+ */
+function normalizeCallerRoot(raw: string | undefined): string | null {
+  if (!raw) return null;
+  return path.resolve(raw);
 }
 
 function readHeader(headers: IncomingHttpHeaders, name: string): string | undefined {

--- a/tests/daemon/stop-processing.test.ts
+++ b/tests/daemon/stop-processing.test.ts
@@ -525,4 +525,70 @@ describe('createStopProcessor session capture rules', () => {
     fs.rmSync(projectRoot, { recursive: true, force: true });
   });
 
+  it('reconciles a worktree-local plan-dir write using requestContext.callerRoot', async () => {
+    const sessionId = 'claude-plan-reconcile-worktree';
+    const now = epochNow();
+    // planWatchConfig.projectRoot is set at daemon boot from the registered
+    // (main-tree) root. A Stop request from a worktree carries callerRoot
+    // pointing at the worktree; the handler must anchor watch dirs there
+    // or the worktree-local plan file is never seen.
+    const registeredRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-main-tree-'));
+    const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-worktree-'));
+    const transcriptPath = path.join(worktreeRoot, `${sessionId}.jsonl`);
+    const specDir = path.join(worktreeRoot, 'docs/superpowers/specs');
+    const specPath = path.join(specDir, 'worktree-spec.md');
+    fs.mkdirSync(specDir, { recursive: true });
+    fs.writeFileSync(transcriptPath, '', 'utf-8');
+    fs.writeFileSync(specPath, '# Worktree Spec\n\nWritten in a worktree.', 'utf-8');
+
+    upsertSession({
+      id: sessionId,
+      agent: 'claude-code',
+      status: 'active',
+      started_at: now - 60,
+      created_at: now - 60,
+    });
+
+    const stopProcessor = makeStopProcessor(vaultDir, {
+      planWatchConfig: {
+        watchDirs: ['docs/superpowers/specs'],
+        // Registered main-tree root — the watcher resolves dirs here by
+        // default, which would miss the worktree write.
+        projectRoot: registeredRoot,
+        extensions: ['.md'],
+      },
+    });
+
+    const res = await stopProcessor.handleStopRoute({
+      body: {
+        session_id: sessionId,
+        agent: 'claude-code',
+        transcript_path: transcriptPath,
+        last_assistant_message: 'done',
+      },
+      requestContext: {
+        projectRoot: registeredRoot,
+        callerRoot: worktreeRoot,
+        projectId: 'proj_worktree000000000000000000000',
+        groveId: 'grove-worktree',
+        machineId: 'machine-w',
+        sessionId: null,
+        projectVaultDir: registeredRoot,
+        databasePath: vaultDir,
+        source: 'headers',
+      },
+    } as never);
+
+    expect(res.body).toEqual({ ok: true });
+    await stopProcessor.getActiveProcessing();
+
+    const plans = listPlansBySession(sessionId, ALL_PROJECTS_SCOPE);
+    expect(plans).toHaveLength(1);
+    expect(plans[0].title).toBe('Worktree Spec');
+    expect(plans[0].source_path).toBe('docs/superpowers/specs/worktree-spec.md');
+
+    fs.rmSync(registeredRoot, { recursive: true, force: true });
+    fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  });
+
 });

--- a/tests/mcp/tools/save-plan.test.ts
+++ b/tests/mcp/tools/save-plan.test.ts
@@ -191,6 +191,29 @@ describe('myco_plans op: save (in-process)', () => {
     ]);
   });
 
+  it('normalizes the source_path against the caller cwd so worktrees produce a portable logical_key', async () => {
+    seedSession('sess-worktree', 'proj_cccccccccccccccccccccccccccccccc');
+    const worktreeRoot = '/workspace/worktrees/feature-x';
+    const context = resolveLegacyRequestContext(vaultDir, {
+      projectRoot: '/workspace/project-c',
+      callerRoot: worktreeRoot,
+      projectId: 'proj_cccccccccccccccccccccccccccccccc',
+      groveId: 'grove-c',
+      machineId: 'machine-c',
+      source: 'explicit',
+    });
+
+    const result = await handleMycoPlans({
+      op: 'save',
+      session_id: 'sess-worktree',
+      content: '# Worktree Plan',
+      source_path: `${worktreeRoot}/docs/plans/sprint.md`,
+    }, mockClient(), context) as PlanSaveSuccess;
+
+    expect(result.logical_key).toBe('path:docs/plans/sprint.md');
+    expect(result.source_path).toBe('docs/plans/sprint.md');
+  });
+
   it('rejects op:save when both source_path and plan_key are passed', async () => {
     seedSession('sess-1');
 

--- a/tests/tools/request-context.test.ts
+++ b/tests/tools/request-context.test.ts
@@ -263,6 +263,73 @@ describe('tool request context', () => {
     expect(rowProjectIdFromRequestContext(grove)).toBe(projectId);
   });
 
+  describe('callerRoot — caller cwd for worktree-local filesystem ops', () => {
+    it('preserves callerRoot from MYCO_CALLER_ROOT env var through Grove resolution', () => {
+      withRegisteredProject(({ projectRoot, vaultDir, groveId, projectId }) => {
+        const worktreeRoot = path.join(projectRoot, '..', 'worktrees', 'feature-x');
+        const resolved = requestContextFromEnvironment({
+          [REQUEST_CONTEXT_ENV.projectId]: projectId,
+          [REQUEST_CONTEXT_ENV.groveId]: groveId,
+          [REQUEST_CONTEXT_ENV.callerRoot]: worktreeRoot,
+        }, vaultDir);
+
+        expect(resolved.projectRoot).toBe(projectRoot);
+        expect(resolved.callerRoot).toBe(path.resolve(worktreeRoot));
+      });
+    });
+
+    it('preserves callerRoot from x-myco-caller-root HTTP header through Grove resolution', () => {
+      withRegisteredProject(({ projectRoot, vaultDir, groveId, projectId }) => {
+        const worktreeRoot = path.join(projectRoot, '..', 'worktrees', 'feature-x');
+        const resolved = requestContextFromHttpHeaders({
+          [REQUEST_CONTEXT_HEADERS.projectId]: projectId,
+          [REQUEST_CONTEXT_HEADERS.groveId]: groveId,
+          [REQUEST_CONTEXT_HEADERS.callerRoot]: worktreeRoot,
+        }, vaultDir);
+
+        expect(resolved.projectRoot).toBe(projectRoot);
+        expect(resolved.callerRoot).toBe(path.resolve(worktreeRoot));
+      });
+    });
+
+    it('leaves callerRoot null when no caller-root header or env is present', () => {
+      withRegisteredProject(({ vaultDir, groveId, projectId }) => {
+        const fromEnv = requestContextFromEnvironment({
+          [REQUEST_CONTEXT_ENV.projectId]: projectId,
+          [REQUEST_CONTEXT_ENV.groveId]: groveId,
+        }, vaultDir);
+        const fromHeaders = requestContextFromHttpHeaders({
+          [REQUEST_CONTEXT_HEADERS.projectId]: projectId,
+          [REQUEST_CONTEXT_HEADERS.groveId]: groveId,
+        }, vaultDir);
+
+        expect(fromEnv.callerRoot).toBeNull();
+        expect(fromHeaders.callerRoot).toBeNull();
+      });
+    });
+
+    it('round-trips callerRoot through requestContextHeaders', () => {
+      const projectId = assertGroveProjectId(createProjectId());
+      const context = resolveLegacyRequestContext(path.join('/tmp', 'project', '.myco'), {
+        projectId,
+        callerRoot: path.join('/tmp', 'worktrees', 'feature-y'),
+      });
+
+      const headers = requestContextHeaders(context);
+
+      expect(headers[REQUEST_CONTEXT_HEADERS.callerRoot]).toBe(path.join('/tmp', 'worktrees', 'feature-y'));
+    });
+
+    it('does not emit x-myco-caller-root when callerRoot is null', () => {
+      const projectId = assertGroveProjectId(createProjectId());
+      const context = resolveLegacyRequestContext(path.join('/tmp', 'project', '.myco'), { projectId });
+
+      const headers = requestContextHeaders(context);
+
+      expect(headers[REQUEST_CONTEXT_HEADERS.callerRoot]).toBeUndefined();
+    });
+  });
+
   it('rejects a path-string project id at the brand boundary', () => {
     expect(() => resolveLegacyRequestContext(path.join('/tmp', 'p', '.myco'), {
       // @ts-expect-error — exercising the runtime brand check on bad input


### PR DESCRIPTION
## Summary

Plans written from a git worktree were silently dropped: the daemon's plan watcher and the MCP plan-save path both anchored at the registered (main-tree) project root, so worktree-local plan dirs resolved to a path the daemon never looked at, and MCP-saved plans got machine-specific absolute logical keys instead of portable relative ones. Same root cause as PR #270 (stdio bridge bearer token) and the three earlier failure modes captured in wisdom spore `spore_663f4df836f820d27a1e4795d1e2d60a` — the resolver overwrites the inbound caller cwd with the registered project root, discarding it.

Fix the class by adding a sibling field that preserves the caller's cwd through resolution, then migrating the two plan-capture call sites that need it.

### Architectural change (commit 1)

\`MycoRequestContext\` now carries:
- \`projectRoot\` — registered, canonical, project identity. Drives vault dirs, db paths, Grove registration. **Unchanged.**
- \`callerRoot: string | null\` — caller's actual cwd, populated from \`x-myco-caller-root\` / \`MYCO_CALLER_ROOT\`, preserved untouched through registry resolution. Null when the caller did not supply one.

The existing \`x-myco-project-root\` header stays strict (identity / spoofing guard). The new \`x-myco-caller-root\` is free-form and never feeds the Grove registry lookup — it represents "where the user is right now."

### Migration (commit 2)

Two call sites in the plan-capture surface migrated to consume \`context.callerRoot ?? context.projectRoot\`:
- \`packages/myco/src/tools/plans.ts\` — \`myco_plans op:save\` normalizes the source path against the caller cwd so the logical key is portable (\`path:docs/plans/foo.md\` from main or worktree).
- \`packages/myco/src/daemon/stop-processing.ts\` — \`processStopEvent\` accepts a new \`requestCallerRoot\` argument; the watch-dir resolver and \`capturePlan\` consume it. The daemon-boot \`planWatchConfig.projectRoot\` is the fallback for non-worktree callers.

Both fall back to \`projectRoot\` when no \`callerRoot\` is set, preserving existing behavior.

### What's intentionally untouched

The 23 identity readers stay on \`projectRoot\` (vault paths, Grove registration, team-sync, persisted session rows). Canopy scanning also stays on \`projectRoot\` — entries are project-identity keyed and must not diverge across worktrees of the same project.

## Test plan

- [x] \`tests/tools/request-context.test.ts\` — \`callerRoot\` round-trip through env, header, and \`requestContextHeaders\` emission, plus null-default behavior
- [x] \`tests/mcp/tools/save-plan.test.ts\` — worktree-rooted source_path normalizes to portable relative logical_key
- [x] \`tests/daemon/stop-processing.test.ts\` — Stop request with \`requestContext.callerRoot\` reconciles a worktree-local plan file the registered-root watcher would have missed
- [x] Full \`npm test\` green (4639 + 91 = 4730 passing, 0 failing) including the 4 new tests from this branch and post-rebase pickup of PR #271's service-restart fix
- [x] Typecheck clean (\`tsc --noEmit\`) — the new required interface field caught three internal-stub construction sites which were patched to set \`callerRoot: null\`

## Related

- Wisdom spore \`spore_663f4df836f820d27a1e4795d1e2d60a\` (Worktree Binary Path Safety) — supersedes once merged. The pattern this PR introduces should turn the next worktree-bleed bug from a new PR into a one-field decision at the call site.
- PR #270 — same bug class (stdio bridge auth); confirmed the pattern was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)