### PR TITLE
fix(canopy): resolve worktree paths for statistics

### DIFF
--- a/packages/myco/src/daemon/api/canopy-inject.ts
+++ b/packages/myco/src/daemon/api/canopy-inject.ts
@@ -22,11 +22,11 @@
 
 import path from 'node:path';
 import { z } from 'zod';
-import { resolveRequestContextForVault } from '../../tools/request-context.js';
+import { filesystemRootFromRequestContext, resolveRequestContextForVault } from '../../tools/request-context.js';
 import type { MycoConfig } from '../../config/schema.js';
 import type { CanopyEntry } from '../../db/schema.js';
 import type { Database } from '../../db/client.js';
-import type { RouteResponse } from '../router.js';
+import type { RouteRequest, RouteResponse } from '../router.js';
 import { errorBody } from './error-envelope.js';
 import { composeBlob, blobTokenCost } from '../../canopy/inject/compose.js';
 import { decide, type IntentDecision, type NoInjectionReason } from '../../canopy/inject/filter.js';
@@ -85,7 +85,7 @@ export function relativizeForLookup(filePath: string, projectRoot: string): stri
 }
 
 export function createCanopyInjectHandler(deps: CanopyInjectDeps) {
-  return async function handleCanopyInject(req: { body: unknown }): Promise<RouteResponse> {
+  return async function handleCanopyInject(req: Pick<RouteRequest, 'body' | 'requestContext'>): Promise<RouteResponse> {
     const parsed = InjectBody.safeParse(req.body);
     if (!parsed.success) {
       return {
@@ -96,8 +96,8 @@ export function createCanopyInjectHandler(deps: CanopyInjectDeps) {
     const { sessionId, agent, toolInput } = parsed.data;
     const filePath = typeof toolInput.file_path === 'string' ? toolInput.file_path : undefined;
 
-    const ctx = resolveRequestContextForVault(deps.vaultDir);
-    const projectRoot = ctx.projectRoot;
+    const ctx = req.requestContext ?? resolveRequestContextForVault(deps.vaultDir);
+    const projectRoot = filesystemRootFromRequestContext(ctx);
     const projectId = ctx.projectId;
     const config = deps.liveConfig.current.cortex.canopy;
 

--- a/packages/myco/src/daemon/api/canopy-read.ts
+++ b/packages/myco/src/daemon/api/canopy-read.ts
@@ -78,8 +78,10 @@ export const handleGetCanopyToolCallBlob: RouteHandler = async (req) => {
   // today. If the file's mechanical anatomy has advanced since the call,
   // the popover shows the current blob, not a stale snapshot — design
   // choice per the spec, and the same path the agent would now see.
-  if (!ctx.project_id) return notFound('project_root_missing');
-  const lookupPath = relativizeForLookup(ctx.file_path, ctx.project_id);
+  if (!ctx.project_id) return notFound('project_id_missing');
+  const lookupPath = ctx.project_root
+    ? relativizeForLookup(ctx.file_path, ctx.project_root)
+    : ctx.file_path;
   const entry = findCanopyEntry(ctx.project_id, lookupPath);
   if (!entry) return notFound('entry_missing');
 

--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -35,7 +35,12 @@ import {
   handleCompact,
 } from './event-handlers.js';
 import { handleCanopyToolUse } from '@myco/canopy/scanner/handle-tool-use.js';
-import { resolveRequestContextForVault } from '@myco/tools/request-context.js';
+import {
+  filesystemRootFromRequestContext,
+  projectScopeFromRequestContext,
+  resolveRequestContextForVault,
+  rowProjectIdFromRequestContext,
+} from '@myco/tools/request-context.js';
 import { resolveProjectRoot } from '@myco/vault/resolve.js';
 import { getDatabase } from '@myco/db/client.js';
 import { getLatestBatch } from '@myco/db/queries/batches.js';
@@ -45,7 +50,6 @@ import { DEFAULT_SYMBIONT_NAME, epochSeconds, LOG_PROMPT_PREVIEW_CHARS } from '@
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { loadManifests } from '@myco/symbionts/detect.js';
 import { gateEventByCaptureRules } from './capture-gating.js';
-import { projectScopeFromRequestContext, rowProjectIdFromRequestContext } from '@myco/tools/request-context.js';
 import { assertGroveProjectId, isGroveEraId } from '@myco/grove/ids.js';
 import type { ProjectPowerStateTracker } from './project-power-state.js';
 import { deferGitProvenance } from '@myco/release-provenance/capture.js';
@@ -227,6 +231,9 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
     let userPromptBatchId: number | undefined;
     const requestProjectId = rowProjectIdFromRequestContext(req.requestContext);
     const requestProjectRoot = req.requestContext?.projectRoot ?? projectRoot;
+    const requestFilesystemRoot = req.requestContext
+      ? filesystemRootFromRequestContext(req.requestContext)
+      : requestProjectRoot;
     const requestMachineId = req.requestContext?.machineId ?? machineId;
 
     logger.debug(LOG_KINDS.HOOKS_EVENT, 'Event received', { type: event.type, session_id: event.session_id });
@@ -487,7 +494,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
           toolName,
           event.tool_input,
           typeof event.output_preview === 'string' ? event.output_preview : undefined,
-          requestProjectRoot,
+          requestFilesystemRoot,
         );
       } catch (err) {
         logger.warn(LOG_KINDS.CAPTURE_ACTIVITY, 'Failed to record activity', { session_id: event.session_id, error: (err as Error).message });
@@ -500,7 +507,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
             db: getDatabase(),
             logger,
             machineId: requestMachineId,
-            projectRoot: requestProjectRoot,
+            projectRoot: requestFilesystemRoot,
             projectId: (req.requestContext ?? resolveRequestContextForVault(vaultDir)).projectId,
             toolName,
             toolInput: event.tool_input,

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -48,7 +48,7 @@ import type { RegisteredSession } from './lifecycle.js';
 import { cleanupAfterSessionCascade } from './jobs/session-cleanup.js';
 import type { PlanWatchConfig } from './plan-capture.js';
 import { materializeCanopyAggregates } from '@myco/canopy/aggregate.js';
-import { rowProjectIdFromRequestContext } from '@myco/tools/request-context.js';
+import { filesystemRootFromRequestContext, rowProjectIdFromRequestContext } from '@myco/tools/request-context.js';
 import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
 import { resolveProjectRoot } from '@myco/vault/resolve.js';
 import { deferGitProvenance } from '@myco/release-provenance/capture.js';
@@ -253,7 +253,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     requestProjectId: GroveProjectId,
     requestRowProjectId: string | null,
     requestProjectRoot: string,
-    requestCallerRoot: string | null,
+    requestFilesystemRoot: string,
     requestMachineId: string,
     requestProductionRef: string | null,
     hookTranscriptPath?: string,
@@ -484,11 +484,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     const sessionStopMs = Date.now();
     const sessionBatches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
 
-    // Caller-local: when the Stop request originates in a worktree, anchor
-    // the watch dirs and plan source paths at the worktree cwd so files
-    // written there are seen and stored as portable relative paths. Falls
-    // back to the daemon-boot registered root when no callerRoot is set.
-    const planCaptureRoot = requestCallerRoot ?? planWatchConfig.projectRoot;
+    const planCaptureRoot = requestFilesystemRoot;
     for (const watchDir of planWatchConfig.watchDirs) {
       const absoluteWatchDir = resolvePlanWatchDir(watchDir, planCaptureRoot);
       if (!fs.existsSync(absoluteWatchDir)) continue;
@@ -605,7 +601,9 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     const requestScope = rowProjectIdFromRequestContext(req.requestContext);
     const requestRowProjectId = requestScope === undefined ? requestProjectId : requestScope;
     const requestProjectRoot = req.requestContext?.projectRoot ?? resolveProjectRoot(vaultDir);
-    const requestCallerRoot = req.requestContext?.callerRoot ?? null;
+    const requestFilesystemRoot = req.requestContext
+      ? filesystemRootFromRequestContext(req.requestContext)
+      : planWatchConfig.projectRoot;
     const requestMachineId = req.requestContext?.machineId ?? machineId;
     const requestProductionRef = primaryProductionRef(configForRequest(req));
 
@@ -685,7 +683,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
       requestProjectId,
       requestRowProjectId,
       requestProjectRoot,
-      requestCallerRoot,
+      requestFilesystemRoot,
       requestMachineId,
       requestProductionRef,
       normalizedTranscriptPath,

--- a/packages/myco/src/db/queries/canopy.ts
+++ b/packages/myco/src/db/queries/canopy.ts
@@ -93,18 +93,18 @@ for (const name of EXPECTED_SESSION_COLUMNS) {
  *
  * `LEFT JOIN canopy_entries` brings in the file's token estimate so the
  * tokens-saved arithmetic can run without a second round-trip. Joining on
- * `(project_id, path)` requires the project_id; we resolve it from the
- * sessions row's project_root since canopy_entries keys on project_id but
- * the sessions table tracks project_root. The join falls back to NULL when
- * there's no match (file not yet scanned, or excluded).
+ * `(project_id, path)` requires sessions.project_id. Absolute paths are
+ * canonicalized against sessions.project_root, while already-normalized
+ * activity file paths pass through unchanged. The join falls back to NULL
+ * when there's no match (file not yet scanned, or excluded).
  *
  * The reads_after_injection branch *spends* injection tokens (negative
  * savings) since we paid the injection cost and then read the file anyway.
  * Skips *save* (file_tokens − injection_tokens).
  */
 const AGGREGATE_SQL = `
-WITH session_root AS (
-  SELECT project_root AS project_id
+WITH session_ctx AS (
+  SELECT project_id, project_root
   FROM sessions
   WHERE id = ?
 ),
@@ -112,9 +112,9 @@ raw_reads AS (
   SELECT
     a.id                       AS tc_id,
     COALESCE(
+      a.file_path,
       json_extract(a.tool_input, '$.file_path'),
-      json_extract(a.tool_input, '$.filePath'),
-      a.file_path
+      json_extract(a.tool_input, '$.filePath')
     ) AS raw_path,
     a.canopy_injection_tokens  AS injection_tokens,
     CASE WHEN a.canopy_injection_tokens IS NOT NULL THEN 1 ELSE 0 END AS had_injection,
@@ -128,9 +128,9 @@ reads AS (
     rr.tc_id,
     CASE
       WHEN rr.raw_path IS NOT NULL
-       AND (SELECT project_id FROM session_root) IS NOT NULL
-       AND rr.raw_path LIKE (SELECT project_id FROM session_root) || '/%'
-      THEN substr(rr.raw_path, length((SELECT project_id FROM session_root)) + 2)
+       AND (SELECT project_root FROM session_ctx) IS NOT NULL
+       AND rr.raw_path LIKE (SELECT project_root FROM session_ctx) || '/%'
+      THEN substr(rr.raw_path, length((SELECT project_root FROM session_ctx)) + 2)
       ELSE rr.raw_path
     END AS path,
     rr.injection_tokens,
@@ -168,7 +168,7 @@ tokens AS (
     ce.token_estimate AS file_tokens
   FROM skip_resolution sr
   LEFT JOIN canopy_entries ce
-    ON ce.project_id = (SELECT project_id FROM session_root)
+    ON ce.project_id = (SELECT project_id FROM session_ctx)
    AND ce.path = sr.path
 ),
 redundant AS (
@@ -448,7 +448,7 @@ export function listCanopyReads(db: Database | null, sessionId: string): CanopyR
         SELECT
           id,
           timestamp,
-          COALESCE(json_extract(tool_input, '$.file_path'), json_extract(tool_input, '$.filePath'), file_path) AS file_path,
+          COALESCE(file_path, json_extract(tool_input, '$.file_path'), json_extract(tool_input, '$.filePath')) AS file_path,
           canopy_injection_tokens
         FROM activities
         WHERE session_id = ?
@@ -470,8 +470,10 @@ export interface CanopyToolCallContext {
   session_id: string;
   file_path: string;
   injection_tokens: number | null;
-  /** project_id used to look up canopy_entries — sessions.project_root. */
+  /** project_id used to look up canopy_entries. */
   project_id: string | null;
+  /** project root used only to canonicalize absolute filesystem paths. */
+  project_root: string | null;
 }
 
 export function getCanopyToolCallContext(
@@ -494,9 +496,10 @@ export function getCanopyToolCallContext(
         SELECT
           a.id                                       AS activity_id,
           a.session_id                               AS session_id,
-          COALESCE(json_extract(a.tool_input, '$.file_path'), json_extract(a.tool_input, '$.filePath'), a.file_path) AS file_path,
+          COALESCE(a.file_path, json_extract(a.tool_input, '$.file_path'), json_extract(a.tool_input, '$.filePath')) AS file_path,
           a.canopy_injection_tokens                  AS injection_tokens,
-          s.project_root                             AS project_id
+          s.project_id                               AS project_id,
+          s.project_root                             AS project_root
         FROM activities a
         LEFT JOIN sessions s ON s.id = a.session_id
         WHERE a.id = ?

--- a/packages/myco/src/hooks/client.ts
+++ b/packages/myco/src/hooks/client.ts
@@ -513,6 +513,7 @@ export function requestContextForHook(
 ): MycoRequestContext {
   const env: Record<string, string | undefined> = { ...process.env };
   if (input.sessionId) env[REQUEST_CONTEXT_ENV.sessionId] = input.sessionId;
+  env[REQUEST_CONTEXT_ENV.callerRoot] ??= process.cwd();
   return requestContextFromEnvironment(env, vaultDir);
 }
 

--- a/packages/myco/src/tools/plans.ts
+++ b/packages/myco/src/tools/plans.ts
@@ -9,7 +9,12 @@
 import type { DaemonClient } from '@myco/hooks/client.js';
 import { saveMcpPlan } from '@myco/plans/save-mcp.js';
 import { listPlansForMcp } from '@myco/plans/list-for-mcp.js';
-import { requestContextHeaders, resolveRequestContextForVault, type MycoRequestContext } from './request-context.js';
+import {
+  filesystemRootFromRequestContext,
+  requestContextHeaders,
+  resolveRequestContextForVault,
+  type MycoRequestContext,
+} from './request-context.js';
 import { extractErrorMessage, type ToolFailure } from './error.js';
 
 // ---------------------------------------------------------------------------
@@ -94,10 +99,7 @@ export async function handleMycoPlans(
       title: input.title,
       status: input.status,
       tags: input.tags,
-      // Caller-local: source path keys must anchor to where the user is
-      // (worktree cwd) so the same plan file produces the same logical_key
-      // from any tree. Falls back to projectRoot when no callerRoot is set.
-      projectRoot: context.callerRoot ?? context.projectRoot,
+      projectRoot: filesystemRootFromRequestContext(context),
       requestContext: context,
     });
 

--- a/packages/myco/src/tools/request-context.ts
+++ b/packages/myco/src/tools/request-context.ts
@@ -28,7 +28,7 @@ export const REQUEST_CONTEXT_HEADERS = {
    * worktree path that differs from the registered main tree — and
    * is preserved through resolution untouched. Filesystem ops that
    * should follow the caller (plan watch dirs, plan source path
-   * keys) read `context.callerRoot ?? context.projectRoot`.
+   * keys, live Canopy tool paths) use `filesystemRootFromRequestContext`.
    */
   callerRoot: 'x-myco-caller-root',
 } as const;
@@ -102,7 +102,7 @@ export interface MycoRequestContext {
    * resolution. Null when no caller-root was supplied. Readers that
    * need "where the user is right now" — plan watch dirs, plan
    * source path keys, hook artifact discovery — use
-   * `context.callerRoot ?? context.projectRoot`. Readers that need
+   * `filesystemRootFromRequestContext`. Readers that need
    * canonical project identity (vault dir, db path, Grove
    * registration) stay on `projectRoot`.
    */
@@ -119,6 +119,21 @@ export interface MycoRequestContext {
 /** True iff the request is bound to a Grove (vs a legacy project-local vault). */
 export function isGroveScoped(context: MycoRequestContext | undefined | null): boolean {
   return Boolean(context?.groveId);
+}
+
+/**
+ * Filesystem anchor for live, caller-originated paths.
+ *
+ * Use this when interpreting paths that came from a hook, MCP tool call, or
+ * current user action: the caller may be in a git worktree whose filesystem
+ * root differs from the registered project root. Do not use this for durable
+ * project identity, Grove registration, database selection, or background
+ * sweeps; those stay anchored to `context.projectRoot`.
+ */
+export function filesystemRootFromRequestContext(
+  context: Pick<MycoRequestContext, 'callerRoot' | 'projectRoot'>,
+): string {
+  return context.callerRoot ?? context.projectRoot;
 }
 
 export interface LegacyRequestContextOptions {

--- a/tests/canopy/aggregate/aggregate-session.test.ts
+++ b/tests/canopy/aggregate/aggregate-session.test.ts
@@ -2,7 +2,7 @@
  * Tests for the per-session Canopy aggregation SQL.
  *
  * Each scenario seeds an in-memory SQLite vault with:
- *   - a sessions row with project_root pointing at a fixture project_id
+ *   - a sessions row with project_id pointing at the fixture Canopy project
  *   - activities rows representing Read tool-calls (with/without injection)
  *   - canopy_entries rows providing the file_tokens for the LEFT JOIN
  *
@@ -30,7 +30,8 @@ import {
 } from '@myco/db/queries/canopy.js';
 import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
 
-const PROJECT_ID = '/repo/myco';
+const PROJECT_ID = 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const PROJECT_ROOT = '/repo/myco';
 
 const epochNow = () => Math.floor(Date.now() / 1000);
 
@@ -55,7 +56,8 @@ function seedSession(sessionId: string) {
     agent: 'claude-code',
     started_at: now,
     created_at: now,
-    project_root: PROJECT_ID,
+    project_id: PROJECT_ID,
+    project_root: PROJECT_ROOT,
   });
 }
 
@@ -338,8 +340,25 @@ describe('aggregateSessionCanopy', () => {
     seedSession(sessionId);
     seedCanopyEntries([{ path: 'src/a.ts', token_estimate: 1000 }]);
     seedActivities(sessionId, [
-      { file_path: `${PROJECT_ID}/src/a.ts`, injection_tokens: 80, ts: 1 },
+      { file_path: `${PROJECT_ROOT}/src/a.ts`, injection_tokens: 80, ts: 1 },
     ]);
+
+    const agg = aggregateSessionCanopy(null, sessionId);
+
+    expect(agg.skips_after_injection).toBe(1);
+    expect(agg.tokens_saved).toBe(920);
+  });
+
+  it('prefers normalized activity file_path over raw absolute tool_input path', () => {
+    const sessionId = 'sess-normalized-path';
+    seedSession(sessionId);
+    seedCanopyEntries([{ path: 'src/a.ts', token_estimate: 1000 }]);
+    seedActivities(sessionId, [
+      { file_path: 'src/a.ts', injection_tokens: 80, ts: 1 },
+    ]);
+    getDatabase()
+      .prepare(`UPDATE activities SET tool_input = ? WHERE session_id = ?`)
+      .run(JSON.stringify({ file_path: '/tmp/worktrees/feature/src/a.ts' }), sessionId);
 
     const agg = aggregateSessionCanopy(null, sessionId);
 

--- a/tests/canopy/aggregate/api.test.ts
+++ b/tests/canopy/aggregate/api.test.ts
@@ -16,9 +16,10 @@ import {
   handleGetCanopyRollup,
 } from '@myco/daemon/api/canopy-read.js';
 import type { RouteRequest } from '@myco/daemon/router.js';
-import { TEST_REQUEST_CONTEXT } from '../../helpers/request-context';
+import { makeTestRequestContext } from '../../helpers/request-context';
 
-const PROJECT_ID = '/repo/myco';
+const PROJECT_ID = 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const PROJECT_ROOT = '/repo/myco';
 const epochNow = () => Math.floor(Date.now() / 1000);
 
 function makeReq(opts: {
@@ -31,7 +32,7 @@ function makeReq(opts: {
     query: opts.query ?? {},
     params: opts.params ?? {},
     pathname: '/test',
-    requestContext: TEST_REQUEST_CONTEXT,
+    requestContext: makeTestRequestContext({ projectId: PROJECT_ID, groveId: 'grove_test' }),
   };
 }
 
@@ -42,7 +43,8 @@ function seedSession(sessionId: string) {
     agent: 'claude-code',
     started_at: now,
     created_at: now,
-    project_root: PROJECT_ID,
+    project_id: PROJECT_ID,
+    project_root: PROJECT_ROOT,
   });
 }
 
@@ -55,11 +57,11 @@ function seedRead(
   const result = getDatabase()
     .prepare(`
       INSERT INTO activities (
-        session_id, tool_name, tool_input, file_path, timestamp,
+        session_id, project_id, tool_name, tool_input, file_path, timestamp,
         processed, created_at, canopy_injection_tokens
-      ) VALUES (?, 'Read', ?, ?, ?, 0, ?, ?)
+      ) VALUES (?, ?, 'Read', ?, ?, ?, 0, ?, ?)
     `)
-    .run(sessionId, JSON.stringify({ file_path: filePath }), filePath, ts, ts, injectionTokens);
+    .run(sessionId, PROJECT_ID, JSON.stringify({ file_path: filePath }), filePath, ts, ts, injectionTokens);
   return Number(result.lastInsertRowid);
 }
 
@@ -169,7 +171,7 @@ describe('handleGetCanopyToolCallBlob', () => {
     const sessionId = 'sess-api-blob-absolute';
     seedSession(sessionId);
     seedCanopyEntry('present.ts', 800);
-    const tcId = seedRead(sessionId, `${PROJECT_ID}/present.ts`, 70, epochNow());
+    const tcId = seedRead(sessionId, `${PROJECT_ROOT}/present.ts`, 70, epochNow());
 
     const res = await handleGetCanopyToolCallBlob(makeReq({
       params: { id: sessionId, tcId: String(tcId) },
@@ -212,7 +214,7 @@ describe('handleGetCanopyRollup', () => {
   it('returns the cross-session rollup', async () => {
     const db = getDatabase();
     const now = epochNow();
-    upsertSession({ id: 's1', agent: 'claude-code', started_at: now, created_at: now });
+    upsertSession({ id: 's1', agent: 'claude-code', started_at: now, created_at: now, project_id: PROJECT_ID, project_root: PROJECT_ROOT });
     db.prepare(`
       UPDATE sessions SET
         canopy_injections_offered = 4,
@@ -236,8 +238,8 @@ describe('handleGetCanopyRollup', () => {
 
   it('parses since/until query params', async () => {
     const db = getDatabase();
-    upsertSession({ id: 'old', agent: 'claude-code', started_at: 100, created_at: 100 });
-    upsertSession({ id: 'new', agent: 'claude-code', started_at: 500, created_at: 500 });
+    upsertSession({ id: 'old', agent: 'claude-code', started_at: 100, created_at: 100, project_id: PROJECT_ID, project_root: PROJECT_ROOT });
+    upsertSession({ id: 'new', agent: 'claude-code', started_at: 500, created_at: 500, project_id: PROJECT_ID, project_root: PROJECT_ROOT });
     db.prepare(`
       UPDATE sessions SET canopy_injections_offered = 1, canopy_skips_after_injection = 1,
         canopy_injection_total_tokens = 0, canopy_reads_after_injection = 0,

--- a/tests/canopy/aggregate/materialize.test.ts
+++ b/tests/canopy/aggregate/materialize.test.ts
@@ -10,7 +10,8 @@ import { upsertSession, getSession } from '@myco/db/queries/sessions.js';
 import { materializeCanopyAggregates } from '@myco/canopy/aggregate.js';
 import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
 
-const PROJECT_ID = '/repo/myco';
+const PROJECT_ID = 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const PROJECT_ROOT = '/repo/myco';
 
 const epochNow = () => Math.floor(Date.now() / 1000);
 
@@ -21,7 +22,8 @@ function seedSession(sessionId: string) {
     agent: 'claude-code',
     started_at: now,
     created_at: now,
-    project_root: PROJECT_ID,
+    project_id: PROJECT_ID,
+    project_root: PROJECT_ROOT,
   });
 }
 

--- a/tests/canopy/inject/endpoint.test.ts
+++ b/tests/canopy/inject/endpoint.test.ts
@@ -8,6 +8,7 @@ import { createSchema } from '@myco/db/schema';
 import { MycoConfigSchema, type MycoConfig } from '@myco/config/schema';
 import { createCanopyInjectHandler } from '@myco/daemon/api/canopy-inject';
 import { ensureProjectManifest } from '@myco/config/project-manifest.js';
+import { assertGroveProjectId } from '@myco/grove/ids';
 import {
   _resetPendingInjections,
   consumePendingInjection,
@@ -240,6 +241,39 @@ describe('POST /canopy/inject — handler', () => {
     expect(res.body).toMatchObject({ inject: true, path: 'src/big.ts' });
     const body = res.body as { injectionTokens: number };
     expect(consumePendingInjection('s1', absPath)).toBe(body.injectionTokens);
+  });
+
+  it('uses requestContext.callerRoot to canonicalize worktree absolute paths', async () => {
+    const worktreeRoot = path.join(os.tmpdir(), 'myco-worktree-canopy');
+    seed(tmpProjectId, [{ path: 'src/worktree.ts', size: 4096 }]);
+    const handler = createCanopyInjectHandler({
+      liveConfig: { current: makeConfig() },
+      vaultDir: path.join(tmpVault, '.myco'),
+      getDatabase,
+    });
+    const absoluteWorktreePath = path.join(worktreeRoot, 'src/worktree.ts');
+    const res = await handler({
+      requestContext: {
+        projectRoot: tmpVault,
+        callerRoot: worktreeRoot,
+        projectId: assertGroveProjectId(tmpProjectId),
+        groveId: null,
+        machineId: 'local',
+        sessionId: 's-worktree',
+        projectVaultDir: path.join(tmpVault, '.myco'),
+        databasePath: path.join(tmpVault, '.myco', SQLITE_DB_FILE),
+        source: 'explicit',
+      },
+      body: {
+        sessionId: 's-worktree',
+        agent: 'claude-code',
+        toolInput: { file_path: absoluteWorktreePath },
+      },
+    });
+
+    expect(res.body).toMatchObject({ inject: true, path: 'src/worktree.ts' });
+    const body = res.body as { injectionTokens: number };
+    expect(consumePendingInjection('s-worktree', absoluteWorktreePath)).toBe(body.injectionTokens);
   });
 
   it('uses summary [meta] line when llm_description is populated', async () => {

--- a/tests/hooks/client.test.ts
+++ b/tests/hooks/client.test.ts
@@ -61,6 +61,7 @@ describe('DaemonClient', () => {
     delete process.env[REQUEST_CONTEXT_ENV.groveId];
     delete process.env[REQUEST_CONTEXT_ENV.machineId];
     delete process.env[REQUEST_CONTEXT_ENV.sessionId];
+    delete process.env[REQUEST_CONTEXT_ENV.callerRoot];
   });
 
   it('posts to daemon and returns data', async () => {
@@ -142,6 +143,7 @@ describe('DaemonClient', () => {
       expect(result.data.headers[REQUEST_CONTEXT_HEADERS.groveId]).toBe(grove.id);
       expect(result.data.headers[REQUEST_CONTEXT_HEADERS.machineId]).toBe('machine-a');
       expect(result.data.headers[REQUEST_CONTEXT_HEADERS.sessionId]).toBe('sess-hook');
+      expect(result.data.headers[REQUEST_CONTEXT_HEADERS.callerRoot]).toBe(process.cwd());
     } finally {
       if (previousHome === undefined) delete process.env.MYCO_HOME;
       else process.env.MYCO_HOME = previousHome;

--- a/tests/tools/request-context.test.ts
+++ b/tests/tools/request-context.test.ts
@@ -11,6 +11,7 @@ import {
   REQUEST_CONTEXT_ENV,
   REQUEST_CONTEXT_HEADERS,
   UnauthorizedRequestContextError,
+  filesystemRootFromRequestContext,
   requestContextFromEnvironment,
   requestContextFromHttpHeaders,
   requestContextHeaders,
@@ -327,6 +328,31 @@ describe('tool request context', () => {
       const headers = requestContextHeaders(context);
 
       expect(headers[REQUEST_CONTEXT_HEADERS.callerRoot]).toBeUndefined();
+    });
+
+    it('uses projectRoot as the live filesystem root when callerRoot is absent', () => {
+      const projectId = assertGroveProjectId(createProjectId());
+      const projectRoot = path.join('/tmp', 'project');
+      const context = resolveLegacyRequestContext(path.join(projectRoot, '.myco'), {
+        projectId,
+        projectRoot,
+      });
+
+      expect(filesystemRootFromRequestContext(context)).toBe(path.resolve(projectRoot));
+    });
+
+    it('uses callerRoot as the live filesystem root without changing registered projectRoot', () => {
+      const projectId = assertGroveProjectId(createProjectId());
+      const projectRoot = path.join('/tmp', 'project');
+      const worktreeRoot = path.join('/tmp', 'worktrees', 'feature-y');
+      const context = resolveLegacyRequestContext(path.join(projectRoot, '.myco'), {
+        projectId,
+        projectRoot,
+        callerRoot: worktreeRoot,
+      });
+
+      expect(context.projectRoot).toBe(path.resolve(projectRoot));
+      expect(filesystemRootFromRequestContext(context)).toBe(worktreeRoot);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes Canopy statistics and injection for Claude Code sessions running from git worktrees while preserving the root-checkout Codex path that already worked. The key distinction is now explicit: `projectRoot` remains the registered Grove project identity, while `callerRoot` is the per-request filesystem root used for live hook paths.

## Changes

- Add `filesystemRootFromRequestContext()` as the shared pattern for code that needs the caller's filesystem root.
- Thread caller-root-aware path normalization through Canopy pre-tool injection, post-tool activity capture, stop-time plan reconciliation, and MCP plan saves.
- Correct Canopy read aggregation to join by durable `project_id` while canonicalizing absolute tool paths against the session filesystem root.
- Cover root and worktree scenarios in request-context, hook, Canopy injection, and aggregate statistics tests.

## Validation

- `git diff --check`
- `make check`
- `make build`
- `myco-dev restart`
- Live smoke against the restarted dev daemon and built hook binary:
  - root Codex PreToolUse returned Canopy context for `packages/myco/src/symbionts/templates.generated.ts`
  - worktree-style Claude Code PreToolUse returned the same normalized Canopy path
  - matching post-tool hook events wrote stats rows for both smoke sessions with `canopy_injection_tokens = 87`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)