### PR TITLE
feat(ui): Phase 1 foundation — desktop topbar + slideout primitive + git identity

### DIFF
--- a/packages/myco/src/daemon/api/git-status.ts
+++ b/packages/myco/src/daemon/api/git-status.ts
@@ -92,9 +92,10 @@ export function readGitStatus(cwd: string): GitStatusResponse | null {
     timeout: GIT_TIMEOUT_MS,
     killSignal: 'SIGKILL',
   });
-  // SpawnSyncReturns sets `signal` (non-null) when the child was killed by
-  // the timeout, and leaves `status` at null. The old `status !== 0` check
-  // alone let the timeout case fall through to a successful response.
+  // Guard against the three independent failure modes: error (thrown),
+  // signal (process killed, e.g. by SIGKILL timeout), and non-zero exit.
+  // On a timeout kill the result has status=null and signal set, so
+  // checking status alone misses the timeout case.
   if (statusResult.error || statusResult.signal !== null || statusResult.status !== 0) return null;
 
   const authorResult = spawnSync('git', ['log', '-1', '--pretty=%an%n%ae'], {

--- a/packages/myco/src/daemon/api/git-status.ts
+++ b/packages/myco/src/daemon/api/git-status.ts
@@ -1,14 +1,16 @@
 // Lightweight git state for the topbar identity pill. Reads branch, dirty
-// flag, ahead/behind, head sha, and last-commit author from the request's
-// project root — NOT the daemon's working directory. The daemon serves
-// multiple projects; scoping to req.requestContext.projectRoot is what
-// keeps a Grove with N projects from reporting one canonical branch.
+// flag, ahead/behind, head sha, and last-commit author from the caller's
+// filesystem root — NOT the daemon's working directory. The daemon serves
+// multiple projects, and the caller may be working inside a worktree; the
+// topbar pill must reflect the worktree's branch, not the canonical
+// project branch.
 //
 // Heavier git work (patch IDs, blob hashes) lives in release-provenance;
-// this endpoint stays cheap so a 30s topbar poll doesn't compete with it.
+// this endpoint stays cheap so a topbar poll doesn't compete with it.
 
 import { spawnSync } from 'node:child_process';
 import type { RouteHandler, RouteResponse } from '../router.js';
+import { filesystemRootFromRequestContext } from '../../tools/request-context.js';
 import { errorBody } from './error-envelope.js';
 
 // Cap subprocess wall time so a wedged index.lock or slow NFS doesn't
@@ -121,16 +123,18 @@ export function readGitStatus(cwd: string): GitStatusResponse | null {
 }
 
 /**
- * GET /api/git/status — returns the request project's git state.
+ * GET /api/git/status — returns the caller's filesystem-root git state.
  *
- * Scopes to `req.requestContext.projectRoot`, not `process.cwd()`: the
- * daemon serves multiple projects, and a Grove switch must change the
- * reported branch immediately.
+ * Resolves the caller's actual working location via
+ * `filesystemRootFromRequestContext` (callerRoot falls back to projectRoot).
+ * Worktree callers report the worktree's branch; non-worktree callers
+ * report the canonical project's branch.
  */
 export const handleGetGitStatus: RouteHandler = async (req) => {
-  const projectRoot = req.requestContext?.projectRoot;
-  if (!projectRoot) return badRequest('Request has no project root');
-  const status = readGitStatus(projectRoot);
+  if (!req.requestContext) return badRequest('Request has no project root');
+  const root = filesystemRootFromRequestContext(req.requestContext);
+  if (!root) return badRequest('Request has no project root');
+  const status = readGitStatus(root);
   if (!status) return notFound('Not a git repository or git is unavailable');
   return { body: status };
 };

--- a/packages/myco/src/daemon/api/git-status.ts
+++ b/packages/myco/src/daemon/api/git-status.ts
@@ -1,0 +1,135 @@
+// Lightweight git state for the topbar identity pill. Reads branch, dirty
+// flag, ahead/behind, head sha, and last-commit author from the request's
+// project root — NOT the daemon's working directory. The daemon serves
+// multiple projects; scoping to req.requestContext.projectRoot is what
+// keeps a Grove with N projects from reporting one canonical branch.
+//
+// Heavier git work (patch IDs, blob hashes) lives in release-provenance;
+// this endpoint stays cheap so a 30s topbar poll doesn't compete with it.
+
+import { spawnSync } from 'node:child_process';
+import type { RouteHandler, RouteResponse } from '../router.js';
+import { errorBody } from './error-envelope.js';
+
+// Cap subprocess wall time so a wedged index.lock or slow NFS doesn't
+// pin a daemon route. The topbar consumer treats 404 the same as
+// "no git here" — a timeout is no worse than that.
+const GIT_TIMEOUT_MS = 2000;
+
+function notFound(reason: string): RouteResponse {
+  return { status: 404, body: errorBody('not_found', reason) };
+}
+
+function badRequest(reason: string): RouteResponse {
+  return { status: 400, body: errorBody('bad_request', reason) };
+}
+
+export interface GitStatusResponse {
+  branch: string;
+  dirty: boolean;
+  ahead: number;
+  behind: number;
+  author: string;
+  author_email: string;
+  head_sha: string;
+}
+
+export interface ParsedGitStatus {
+  branch: string;
+  head_sha: string;
+  dirty: boolean;
+  ahead: number;
+  behind: number;
+}
+
+/**
+ * Parse `git status --porcelain=v2 --branch` output.
+ *
+ * Header lines begin with `# branch.<key> <value>`; everything else is an
+ * entry line (one per modified/untracked/unmerged path). Any non-header,
+ * non-empty line means the worktree is dirty — we don't classify, the
+ * topbar only needs the boolean.
+ */
+export function parseGitStatus(porcelainOutput: string): ParsedGitStatus {
+  const lines = porcelainOutput.split('\n');
+  let branch = '';
+  let head_sha = '';
+  let ahead = 0;
+  let behind = 0;
+  let dirty = false;
+
+  for (const line of lines) {
+    if (line.startsWith('# branch.oid ')) {
+      head_sha = line.slice('# branch.oid '.length).trim();
+    } else if (line.startsWith('# branch.head ')) {
+      branch = line.slice('# branch.head '.length).trim();
+    } else if (line.startsWith('# branch.ab ')) {
+      const ab = line.slice('# branch.ab '.length).trim();
+      const match = ab.match(/^\+(\d+)\s+-(\d+)$/);
+      if (match) {
+        ahead = Number(match[1]);
+        behind = Number(match[2]);
+      }
+    } else if (line.length > 0 && !line.startsWith('#')) {
+      dirty = true;
+    }
+  }
+
+  return { branch, head_sha, dirty, ahead, behind };
+}
+
+/**
+ * Run git in `cwd` and return the topbar-shaped status, or null if the
+ * directory isn't a git repo (or git isn't installed). The two spawns
+ * are kept separate so a missing HEAD (fresh repo, no commits yet)
+ * downgrades the author fields to empty strings instead of failing
+ * the whole call.
+ */
+export function readGitStatus(cwd: string): GitStatusResponse | null {
+  const statusResult = spawnSync('git', ['status', '--porcelain=v2', '--branch'], {
+    cwd,
+    encoding: 'utf-8',
+    timeout: GIT_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
+  });
+  // SpawnSyncReturns sets `signal` (non-null) when the child was killed by
+  // the timeout, and leaves `status` at null. The old `status !== 0` check
+  // alone let the timeout case fall through to a successful response.
+  if (statusResult.error || statusResult.signal !== null || statusResult.status !== 0) return null;
+
+  const authorResult = spawnSync('git', ['log', '-1', '--pretty=%an%n%ae'], {
+    cwd,
+    encoding: 'utf-8',
+    timeout: GIT_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
+  });
+  // Author lookup is best-effort: a timed-out or failed `git log` (fresh
+  // repo with no commits, slow NFS) downgrades to empty author fields
+  // rather than failing the whole call.
+  const authorStdout = (!authorResult.error && authorResult.signal === null && authorResult.status === 0)
+    ? (authorResult.stdout ?? '')
+    : '';
+  const [author = '', author_email = ''] = authorStdout.split('\n');
+
+  const parsed = parseGitStatus(statusResult.stdout ?? '');
+  return {
+    ...parsed,
+    author: author.trim(),
+    author_email: author_email.trim(),
+  };
+}
+
+/**
+ * GET /api/git/status — returns the request project's git state.
+ *
+ * Scopes to `req.requestContext.projectRoot`, not `process.cwd()`: the
+ * daemon serves multiple projects, and a Grove switch must change the
+ * reported branch immediately.
+ */
+export const handleGetGitStatus: RouteHandler = async (req) => {
+  const projectRoot = req.requestContext?.projectRoot;
+  if (!projectRoot) return badRequest('Request has no project root');
+  const status = readGitStatus(projectRoot);
+  if (!status) return notFound('Not a git repository or git is unavailable');
+  return { body: status };
+};

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -95,6 +95,7 @@ import { createCanopyInjectHandler } from './api/canopy-inject.js';
 import { handleGetFeed } from './api/feed.js';
 import { handleListSymbionts } from './api/symbionts.js';
 import { registerCanopyReadRoutes } from './api/canopy-read.js';
+import { handleGetGitStatus } from './api/git-status.js';
 import {
   handleGetEmbeddingStatus,
   handleEmbeddingDetails,
@@ -1081,6 +1082,7 @@ export async function main(): Promise<void> {
   server.registerRoute('POST', '/api/log', createLogIngestionHandler(logger));
 
   server.registerRoute('GET', '/api/models', async (req) => handleGetModels(req, logger));
+  server.registerRoute('GET', '/api/git/status', handleGetGitStatus);
   server.registerRoute('POST', '/api/restart', async (req) => handleRestart({ vaultDir: bootstrapVaultDir, progressTracker }, req.body));
 
   // --- Update routes ---

--- a/packages/myco/ui/src/components/agent/RunDetail.tsx
+++ b/packages/myco/ui/src/components/agent/RunDetail.tsx
@@ -5,6 +5,8 @@ import { Badge } from '../ui/badge';
 import { Surface } from '../ui/surface';
 import { StatCard } from '../ui/stat-card';
 import { MarkdownContent } from '../ui/markdown-content';
+import { RefreshIndicator } from '../ui/refresh-indicator';
+import { POLL_INTERVALS } from '../../lib/constants';
 import {
   useAgentRun,
   useAgentReports,
@@ -587,7 +589,13 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
   // a brand-new run and never modifies this one.
   const [rerunOpen, setRerunOpen] = useState(false);
 
-  const { data: runData, isLoading: runLoading, isError: runError } = useAgentRun(runId);
+  const {
+    data: runData,
+    isLoading: runLoading,
+    isError: runError,
+    isFetching: runFetching,
+    refetch: refetchRun,
+  } = useAgentRun(runId);
   const runStatus = runData?.run?.status;
   const { data: reportsData, isLoading: reportsLoading } = useAgentReports(runId, runStatus);
   const { data: turnsData, isLoading: turnsLoading } = useAgentTurns(showAudit ? runId : undefined, runStatus);
@@ -638,6 +646,7 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
   const turns = turnsData ?? [];
   const costCardLabel = run.cost_source === 'estimated' ? 'Estimated Cost' : 'Cost';
   const isDryRun = run.dry_run === true;
+  const isTerminal = ['completed', 'failed', 'skipped'].includes(run.status);
   // Detect whether this run produced digest writes so we know whether to
   // render the revisions section. turns is empty until the audit trail is
   // opened; fall back to task name ('vault-evolve' always writes a
@@ -656,6 +665,14 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
           <Badge variant="warning" title="Writes were intercepted and recorded as intents">
             Dry Run
           </Badge>
+        )}
+        {!isTerminal && (
+          <RefreshIndicator
+            className="ml-auto"
+            intervalMs={POLL_INTERVALS.RUN_DETAIL}
+            isFetching={runFetching}
+            onManualRefresh={() => { void refetchRun(); }}
+          />
         )}
       </div>
 

--- a/packages/myco/ui/src/components/canopy/CanopyEntryDetail.tsx
+++ b/packages/myco/ui/src/components/canopy/CanopyEntryDetail.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useMemo, useState } from 'react';
-import { AlertCircle, ArrowLeft, Check, Copy, RefreshCw, Sparkles, X } from 'lucide-react';
+import { AlertCircle, ArrowLeft, Check, Copy, RefreshCw, Sparkles } from 'lucide-react';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { Surface } from '../ui/surface';
 import { SectionHeader } from '../ui/section-header';
+import { SlideoutDetailPanel } from '../ui/slideout-detail-panel';
 import {
   useCanopyEntry,
   useReembedCanopyEntry,
@@ -82,42 +83,6 @@ function SkeletonDetail() {
   );
 }
 
-/**
- * Outer slide-out chrome shared by every render branch (loading, error,
- * empty, and populated). Mirrors the Mycelium Inspector: glass Surface,
- * absolute right-edge positioning, scrollable body, optional X close.
- */
-function DetailShell({
-  onClose,
-  children,
-}: {
-  onClose?: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <Surface
-      glass
-      className="fixed top-3 right-3 bottom-3 z-30 w-[480px] max-w-[calc(100vw-1.5rem)] flex flex-col shadow-lg border border-outline-variant/15 rounded-md"
-      data-testid="canopy-entry-detail-panel"
-    >
-      {onClose ? (
-        <div className="flex justify-end px-3 pt-3">
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close detail"
-            data-testid="canopy-entry-detail-close"
-            className="shrink-0 rounded-md p-1 text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high transition-colors"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-      ) : null}
-      <div className="flex-1 overflow-y-auto px-5 pb-5 pt-2">{children}</div>
-    </Surface>
-  );
-}
-
 /* ---------- Component ---------- */
 
 export interface CanopyEntryDetailProps {
@@ -177,15 +142,25 @@ export function CanopyEntryDetail({ path, onBack, onClose }: CanopyEntryDetailPr
 
   if (isPending) {
     return (
-      <DetailShell onClose={onClose}>
+      <SlideoutDetailPanel
+      open
+      onClose={onClose ?? (() => {})}
+      ariaLabel="Canopy entry detail"
+      testIdRoot="canopy-entry-detail"
+    >
         <SkeletonDetail />
-      </DetailShell>
+      </SlideoutDetailPanel>
     );
   }
 
   if (isError) {
     return (
-      <DetailShell onClose={onClose}>
+      <SlideoutDetailPanel
+      open
+      onClose={onClose ?? (() => {})}
+      ariaLabel="Canopy entry detail"
+      testIdRoot="canopy-entry-detail"
+    >
         <div className="space-y-3">
           {onBack ? (
             <Button variant="ghost" size="sm" onClick={onBack} className="gap-2 text-on-surface-variant">
@@ -204,13 +179,18 @@ export function CanopyEntryDetail({ path, onBack, onClose }: CanopyEntryDetailPr
             </span>
           </div>
         </div>
-      </DetailShell>
+      </SlideoutDetailPanel>
     );
   }
 
   if (!entry) {
     return (
-      <DetailShell onClose={onClose}>
+      <SlideoutDetailPanel
+      open
+      onClose={onClose ?? (() => {})}
+      ariaLabel="Canopy entry detail"
+      testIdRoot="canopy-entry-detail"
+    >
         <div className="space-y-3">
           {onBack ? (
             <Button variant="ghost" size="sm" onClick={onBack} className="gap-2 text-on-surface-variant">
@@ -226,14 +206,19 @@ export function CanopyEntryDetail({ path, onBack, onClose }: CanopyEntryDetailPr
             <span className="font-sans text-sm">No entry found at this path.</span>
           </div>
         </div>
-      </DetailShell>
+      </SlideoutDetailPanel>
     );
   }
 
   const isEmbedded = entry.embedded === 1;
 
   return (
-    <DetailShell onClose={onClose}>
+    <SlideoutDetailPanel
+      open
+      onClose={onClose ?? (() => {})}
+      ariaLabel="Canopy entry detail"
+      testIdRoot="canopy-entry-detail"
+    >
       <div className="space-y-4" data-testid="canopy-entry-detail">
         {/* Header / actions */}
         <div className="flex flex-wrap items-start justify-between gap-3">
@@ -397,7 +382,7 @@ export function CanopyEntryDetail({ path, onBack, onClose }: CanopyEntryDetailPr
           </div>
         </Surface>
       </div>
-    </DetailShell>
+    </SlideoutDetailPanel>
   );
 }
 

--- a/packages/myco/ui/src/components/canopy/CanopyEntryDetail.tsx
+++ b/packages/myco/ui/src/components/canopy/CanopyEntryDetail.tsx
@@ -90,7 +90,7 @@ export interface CanopyEntryDetailProps {
   /** Legacy back button — retained for callers that still use stacked layout. */
   onBack?: () => void;
   /** Slide-out close handler — renders an X button in the top-right. */
-  onClose?: () => void;
+  onClose: () => void;
 }
 
 export function CanopyEntryDetail({ path, onBack, onClose }: CanopyEntryDetailProps) {
@@ -144,7 +144,7 @@ export function CanopyEntryDetail({ path, onBack, onClose }: CanopyEntryDetailPr
     return (
       <SlideoutDetailPanel
       open
-      onClose={onClose ?? (() => {})}
+      onClose={onClose}
       ariaLabel="Canopy entry detail"
       testIdRoot="canopy-entry-detail"
     >
@@ -157,7 +157,7 @@ export function CanopyEntryDetail({ path, onBack, onClose }: CanopyEntryDetailPr
     return (
       <SlideoutDetailPanel
       open
-      onClose={onClose ?? (() => {})}
+      onClose={onClose}
       ariaLabel="Canopy entry detail"
       testIdRoot="canopy-entry-detail"
     >
@@ -187,7 +187,7 @@ export function CanopyEntryDetail({ path, onBack, onClose }: CanopyEntryDetailPr
     return (
       <SlideoutDetailPanel
       open
-      onClose={onClose ?? (() => {})}
+      onClose={onClose}
       ariaLabel="Canopy entry detail"
       testIdRoot="canopy-entry-detail"
     >
@@ -215,7 +215,7 @@ export function CanopyEntryDetail({ path, onBack, onClose }: CanopyEntryDetailPr
   return (
     <SlideoutDetailPanel
       open
-      onClose={onClose ?? (() => {})}
+      onClose={onClose}
       ariaLabel="Canopy entry detail"
       testIdRoot="canopy-entry-detail"
     >

--- a/packages/myco/ui/src/components/ui/cortex-status-pill.tsx
+++ b/packages/myco/ui/src/components/ui/cortex-status-pill.tsx
@@ -1,0 +1,48 @@
+import { StatusDot } from './status-dot';
+import { useDaemon } from '../../hooks/use-daemon';
+import { cn } from '../../lib/cn';
+
+export function computeIndexingPct(described: number, total: number): number {
+  if (!total || total <= 0) return 0;
+  return Math.floor((described / total) * 100);
+}
+
+export interface CortexStatusPillViewProps {
+  describedCount: number | undefined;
+  entriesCount: number | undefined;
+  className?: string;
+}
+
+export function CortexStatusPillView({
+  describedCount,
+  entriesCount,
+  className,
+}: CortexStatusPillViewProps) {
+  const known = describedCount !== undefined && entriesCount !== undefined;
+  const pct = known ? computeIndexingPct(describedCount, entriesCount) : null;
+  const indexing = known && pct < 100;
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-2 rounded-md border border-outline-variant/30 bg-surface-container px-2 py-1',
+        className,
+      )}
+      title="Cortex (Canopy) describe coverage"
+    >
+      <StatusDot tone={indexing ? 'ochre' : 'sage'} pulse={indexing} />
+      <span className="font-sans text-[10px] uppercase tracking-wider text-on-surface-variant">cortex</span>
+      <span className="font-mono text-xs text-on-surface">{pct === null ? '—' : `${pct}%`}</span>
+    </div>
+  );
+}
+
+export function CortexStatusPill({ className }: { className?: string }) {
+  const { data } = useDaemon();
+  return (
+    <CortexStatusPillView
+      describedCount={data?.canopy.described_count}
+      entriesCount={data?.canopy.entries_count}
+      className={className}
+    />
+  );
+}

--- a/packages/myco/ui/src/components/ui/daemon-status-pill.tsx
+++ b/packages/myco/ui/src/components/ui/daemon-status-pill.tsx
@@ -1,0 +1,44 @@
+import { StatusDot } from './status-dot';
+import { useDaemon } from '../../hooks/use-daemon';
+import { cn } from '../../lib/cn';
+
+export function formatUptime(seconds: number): string {
+  if (seconds < 60) return `${Math.floor(seconds)}s`;
+  if (seconds < 3_600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86_400) {
+    const h = Math.floor(seconds / 3_600);
+    const m = Math.floor((seconds % 3_600) / 60);
+    return `${h}h ${m}m`;
+  }
+  const d = Math.floor(seconds / 86_400);
+  const h = Math.floor((seconds % 86_400) / 3_600);
+  return `${d}d ${h}h`;
+}
+
+export interface DaemonStatusPillViewProps {
+  uptimeSeconds: number | undefined;
+  className?: string;
+}
+
+export function DaemonStatusPillView({ uptimeSeconds, className }: DaemonStatusPillViewProps) {
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-2 rounded-md border border-outline-variant/30 bg-surface-container px-2 py-1',
+        className,
+      )}
+      title="Daemon uptime"
+    >
+      <StatusDot tone="sage" />
+      <span className="font-sans text-[10px] uppercase tracking-wider text-on-surface-variant">daemon</span>
+      <span className="font-mono text-xs text-on-surface">
+        {uptimeSeconds !== undefined ? formatUptime(uptimeSeconds) : '—'}
+      </span>
+    </div>
+  );
+}
+
+export function DaemonStatusPill({ className }: { className?: string }) {
+  const { data } = useDaemon();
+  return <DaemonStatusPillView uptimeSeconds={data?.daemon.uptime_seconds} className={className} />;
+}

--- a/packages/myco/ui/src/components/ui/git-identity-pill.tsx
+++ b/packages/myco/ui/src/components/ui/git-identity-pill.tsx
@@ -15,6 +15,7 @@ export function GitIdentityPill({ data, isPending, isError, className }: GitIden
       <button
         type="button"
         disabled
+        data-testid="git-identity-pill"
         className={cn(
           'inline-flex items-center gap-2 rounded-md border border-outline-variant/30 bg-surface-container px-2 py-1 text-on-surface-variant',
           className,
@@ -34,6 +35,7 @@ export function GitIdentityPill({ data, isPending, isError, className }: GitIden
     <button
       type="button"
       title={title}
+      data-testid="git-identity-pill"
       className={cn(
         'inline-flex items-center gap-2 rounded-md border border-outline-variant/30 bg-surface-container px-2 py-1 hover:bg-surface-container-high transition-colors',
         className,

--- a/packages/myco/ui/src/components/ui/git-identity-pill.tsx
+++ b/packages/myco/ui/src/components/ui/git-identity-pill.tsx
@@ -1,0 +1,59 @@
+import { GitBranch } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { gitIdentityInitials, type GitIdentity } from '../../hooks/use-git-identity';
+
+export interface GitIdentityPillProps {
+  data: GitIdentity | undefined;
+  isPending: boolean;
+  isError: boolean;
+  className?: string;
+}
+
+export function GitIdentityPill({ data, isPending, isError, className }: GitIdentityPillProps) {
+  if (isPending || isError || !data) {
+    return (
+      <button
+        type="button"
+        disabled
+        className={cn(
+          'inline-flex items-center gap-2 rounded-md border border-outline-variant/30 bg-surface-container px-2 py-1 text-on-surface-variant',
+          className,
+        )}
+        title={isError ? 'Failed to load git state' : 'Loading git state'}
+      >
+        <GitBranch className="h-3 w-3" />
+        <span className="font-mono text-xs">—</span>
+      </button>
+    );
+  }
+
+  const initials = gitIdentityInitials(data.author);
+  const title = `${data.author} <${data.author_email}> · ${data.branch}${data.dirty ? ' (dirty)' : ''}`;
+
+  return (
+    <button
+      type="button"
+      title={title}
+      className={cn(
+        'inline-flex items-center gap-2 rounded-md border border-outline-variant/30 bg-surface-container px-2 py-1 hover:bg-surface-container-high transition-colors',
+        className,
+      )}
+    >
+      <GitBranch className="h-3 w-3 text-on-surface-variant" />
+      <div className="flex flex-col items-start leading-tight">
+        <span className="font-mono text-xs text-on-surface">{data.branch}</span>
+        <span className="font-mono text-[10px] text-on-surface-variant inline-flex items-center gap-1">
+          {data.dirty && (
+            <span title="working tree dirty" className="text-secondary">●</span>
+          )}
+          {data.ahead > 0 && <span title="ahead of upstream">↑{data.ahead}</span>}
+          {data.behind > 0 && <span title="behind upstream">↓{data.behind}</span>}
+          <span>{data.author}</span>
+        </span>
+      </div>
+      <span className="ml-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/20 font-sans text-[10px] font-semibold text-primary">
+        {initials}
+      </span>
+    </button>
+  );
+}

--- a/packages/myco/ui/src/components/ui/refresh-indicator.tsx
+++ b/packages/myco/ui/src/components/ui/refresh-indicator.tsx
@@ -1,0 +1,54 @@
+import { RefreshCw } from 'lucide-react';
+import { cn } from '../../lib/cn';
+
+export interface RefreshIndicatorProps {
+  intervalMs?: number;
+  isFetching: boolean;
+  onManualRefresh: () => void;
+  /** Reserved for a future "updated Xs ago" label. Not currently rendered. */
+  lastUpdatedAt?: number | null;
+  className?: string;
+}
+
+function formatInterval(ms: number): string | null {
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  if (ms < 1_000) return `${ms}ms`;
+  if (ms < 60_000) return `${Math.round(ms / 1_000)}s`;
+  return `${Math.round(ms / 60_000)}m`;
+}
+
+export function RefreshIndicator({
+  intervalMs,
+  isFetching,
+  onManualRefresh,
+  lastUpdatedAt: _lastUpdatedAt,
+  className,
+}: RefreshIndicatorProps) {
+  const label = intervalMs !== undefined ? formatInterval(intervalMs) : null;
+  return (
+    <div
+      className={cn('flex items-center gap-2 text-on-surface-variant', className)}
+      aria-busy={isFetching}
+    >
+      <span
+        data-testid="refresh-indicator-dot"
+        className={cn(
+          'h-1.5 w-1.5 rounded-full bg-primary',
+          isFetching && 'animate-pulse',
+        )}
+        aria-hidden
+      />
+      {label ? (
+        <span className="font-sans text-xs">every {label}</span>
+      ) : null}
+      <button
+        type="button"
+        onClick={onManualRefresh}
+        aria-label="Refresh now"
+        className="rounded-md p-1 hover:bg-surface-container-high hover:text-on-surface transition-colors"
+      >
+        <RefreshCw className={cn('h-3 w-3', isFetching && 'animate-spin')} />
+      </button>
+    </div>
+  );
+}

--- a/packages/myco/ui/src/components/ui/slideout-detail-panel.tsx
+++ b/packages/myco/ui/src/components/ui/slideout-detail-panel.tsx
@@ -10,6 +10,12 @@ export interface SlideoutDetailPanelProps {
   children: ReactNode;
   ariaLabel?: string;
   className?: string;
+  /**
+   * When set, stamps `data-testid="${testIdRoot}-panel"` on the outer Surface
+   * and `data-testid="${testIdRoot}-close"` on the close button. Useful when a
+   * consumer needs scoped chrome-level testids beyond the inner content.
+   */
+  testIdRoot?: string;
 }
 
 export function SlideoutDetailPanel({
@@ -19,6 +25,7 @@ export function SlideoutDetailPanel({
   children,
   ariaLabel = 'Detail panel',
   className,
+  testIdRoot,
 }: SlideoutDetailPanelProps) {
   useEffect(() => {
     if (!open) return;
@@ -45,12 +52,14 @@ export function SlideoutDetailPanel({
         className,
       )}
       style={{ width: widthPx }}
+      data-testid={testIdRoot ? `${testIdRoot}-panel` : undefined}
     >
       <div className="flex justify-end px-3 pt-3">
         <button
           type="button"
           onClick={onClose}
           aria-label="Close detail"
+          data-testid={testIdRoot ? `${testIdRoot}-close` : undefined}
           className="shrink-0 rounded-md p-1 text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high transition-colors"
         >
           <X className="h-4 w-4" />

--- a/packages/myco/ui/src/components/ui/slideout-detail-panel.tsx
+++ b/packages/myco/ui/src/components/ui/slideout-detail-panel.tsx
@@ -1,0 +1,62 @@
+import { useEffect, type ReactNode } from 'react';
+import { X } from 'lucide-react';
+import { Surface } from './surface';
+import { cn } from '../../lib/cn';
+
+export interface SlideoutDetailPanelProps {
+  open: boolean;
+  onClose: () => void;
+  widthPx?: number;
+  children: ReactNode;
+  ariaLabel?: string;
+  className?: string;
+}
+
+export function SlideoutDetailPanel({
+  open,
+  onClose,
+  widthPx = 480,
+  children,
+  ariaLabel = 'Detail panel',
+  className,
+}: SlideoutDetailPanelProps) {
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <Surface
+      glass
+      role="dialog"
+      aria-label={ariaLabel}
+      className={cn(
+        'fixed top-3 right-3 bottom-3 z-30 flex flex-col shadow-lg border border-outline-variant/15 rounded-md max-w-[calc(100vw-1.5rem)]',
+        className,
+      )}
+      style={{ width: widthPx }}
+    >
+      <div className="flex justify-end px-3 pt-3">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close detail"
+          className="shrink-0 rounded-md p-1 text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high transition-colors"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto px-5 pb-5 pt-2">{children}</div>
+    </Surface>
+  );
+}

--- a/packages/myco/ui/src/components/ui/status-dot.tsx
+++ b/packages/myco/ui/src/components/ui/status-dot.tsx
@@ -1,0 +1,30 @@
+import { cn } from '../../lib/cn';
+
+export type StatusTone = 'sage' | 'ochre' | 'terracotta' | 'outline';
+
+const TONE_CLASSES: Record<StatusTone, string> = {
+  sage: 'bg-primary',
+  ochre: 'bg-secondary',
+  terracotta: 'bg-tertiary',
+  outline: 'bg-outline-variant',
+};
+
+export interface StatusDotProps {
+  tone: StatusTone;
+  pulse?: boolean;
+  sizePx?: number;
+  className?: string;
+}
+
+export function StatusDot({ tone, pulse = false, sizePx = 6, className }: StatusDotProps) {
+  return (
+    <span
+      data-testid="status-dot"
+      data-tone={tone}
+      data-pulsing={pulse ? 'true' : 'false'}
+      className={cn('inline-block rounded-full', TONE_CLASSES[tone], pulse && 'animate-pulse', className)}
+      style={{ width: sizePx, height: sizePx }}
+      aria-hidden
+    />
+  );
+}

--- a/packages/myco/ui/src/hooks/use-agent.ts
+++ b/packages/myco/ui/src/hooks/use-agent.ts
@@ -16,11 +16,11 @@ export type DigestRevisionRow = DigestExtractRevisionRow;
 
 /* ---------- Constants ---------- */
 
-/** Poll interval for agent run list (matches POLL_INTERVALS.STATS). */
-const RUNS_POLL_INTERVAL = POLL_INTERVALS.STATS;
+/** Poll interval for agent run list. */
+const RUNS_POLL_INTERVAL = POLL_INTERVALS.RUNS_ACTIVE;
 
 /** Poll interval for a single run detail (faster — watching active run). */
-const RUN_DETAIL_POLL_INTERVAL = POLL_INTERVALS.HEALTH;
+const RUN_DETAIL_POLL_INTERVAL = POLL_INTERVALS.RUN_DETAIL;
 
 /** Poll interval for run reports (moderate — updates during execution). */
 const REPORTS_POLL_INTERVAL = POLL_INTERVALS.STATS;

--- a/packages/myco/ui/src/hooks/use-canopy.ts
+++ b/packages/myco/ui/src/hooks/use-canopy.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ApiError, fetchJson, postJson } from '../lib/api';
+import { POLL_INTERVALS } from '../lib/constants';
 import { useProjectScopedQueryKey } from './use-project-selection';
 
 /* ---------- Constants ---------- */
@@ -249,6 +250,7 @@ export function useCanopyEntries(args: CanopyEntriesQuery) {
     queryFn: ({ signal }) =>
       fetchJson<CanopyEntriesListResponse>(`/canopy/entries${buildEntriesQueryString(args)}`, { signal }),
     staleTime: ENTRIES_STALE_TIME,
+    refetchInterval: POLL_INTERVALS.CANOPY_ENTRIES,
   });
 }
 

--- a/packages/myco/ui/src/hooks/use-git-identity.ts
+++ b/packages/myco/ui/src/hooks/use-git-identity.ts
@@ -1,0 +1,33 @@
+import { usePowerQuery } from './use-power-query';
+import { fetchJson } from '../lib/api';
+import { POLL_INTERVALS } from '../lib/constants';
+
+export interface GitIdentity {
+  branch: string;
+  dirty: boolean;
+  ahead: number;
+  behind: number;
+  author: string;
+  author_email: string;
+  head_sha: string;
+}
+
+export function useGitIdentity() {
+  return usePowerQuery<GitIdentity>({
+    queryKey: ['git-identity'],
+    queryFn: ({ signal }) => fetchJson<GitIdentity>('/api/git/status', { signal }),
+    refetchInterval: POLL_INTERVALS.GIT_IDENTITY,
+    pollCategory: 'standard',
+  });
+}
+
+export function gitIdentityInitials(author: string | undefined): string {
+  if (!author) return '?';
+  const trimmed = author.trim();
+  if (!trimmed) return '?';
+  const parts = trimmed.split(/\s+/);
+  const first = parts[0] ?? '';
+  if (parts.length === 1) return first.slice(0, 2).toUpperCase();
+  const last = parts[parts.length - 1] ?? '';
+  return ((first[0] ?? '') + (last[0] ?? '')).toUpperCase();
+}

--- a/packages/myco/ui/src/hooks/use-git-identity.ts
+++ b/packages/myco/ui/src/hooks/use-git-identity.ts
@@ -15,7 +15,7 @@ export interface GitIdentity {
 export function useGitIdentity() {
   return usePowerQuery<GitIdentity>({
     queryKey: ['git-identity'],
-    queryFn: ({ signal }) => fetchJson<GitIdentity>('/api/git/status', { signal }),
+    queryFn: ({ signal }) => fetchJson<GitIdentity>('/git/status', { signal }),
     refetchInterval: POLL_INTERVALS.GIT_IDENTITY,
     pollCategory: 'standard',
   });

--- a/packages/myco/ui/src/hooks/use-sessions.ts
+++ b/packages/myco/ui/src/hooks/use-sessions.ts
@@ -7,13 +7,13 @@ import { useProjectScopedQueryKey } from './use-project-selection';
 /* ---------- Constants ---------- */
 
 /** Poll interval for session list. */
-const SESSIONS_POLL_INTERVAL = POLL_INTERVALS.STATS;
+const SESSIONS_POLL_INTERVAL = POLL_INTERVALS.SESSIONS;
 
 /** Poll interval for session detail. */
-const SESSION_DETAIL_POLL_INTERVAL = POLL_INTERVALS.STATS;
+const SESSION_DETAIL_POLL_INTERVAL = POLL_INTERVALS.SESSION_DETAIL;
 
 /** Poll interval for batch list. */
-const BATCHES_POLL_INTERVAL = POLL_INTERVALS.STATS;
+const BATCHES_POLL_INTERVAL = POLL_INTERVALS.SESSION_DETAIL;
 
 /** Cache TTL for activities list (30 seconds). */
 const ACTIVITIES_STALE_TIME = 30_000;
@@ -25,7 +25,7 @@ const ATTACHMENTS_STALE_TIME = 60_000;
 const IMPACT_STALE_TIME = 10_000;
 
 /** Poll interval for session plans. */
-const PLANS_POLL_INTERVAL = POLL_INTERVALS.STATS;
+const PLANS_POLL_INTERVAL = POLL_INTERVALS.SESSION_DETAIL;
 
 /* ---------- Types ---------- */
 

--- a/packages/myco/ui/src/hooks/use-spores.ts
+++ b/packages/myco/ui/src/hooks/use-spores.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchJson } from '../lib/api';
+import { POLL_INTERVALS } from '../lib/constants';
 import { useProjectScopedQueryKey } from './use-project-selection';
 
 /* ---------- Constants ---------- */
@@ -136,6 +137,7 @@ export function useSpores(filters?: {
     queryKey,
     queryFn: ({ signal }) => fetchJson<SporesResponse>(path, { signal }),
     staleTime: SPORES_STALE_TIME,
+    refetchInterval: POLL_INTERVALS.SPORES,
   });
 }
 

--- a/packages/myco/ui/src/layout/Layout.tsx
+++ b/packages/myco/ui/src/layout/Layout.tsx
@@ -41,6 +41,7 @@ import { useUnreadCount } from '../hooks/use-notifications';
 import { cn } from '../lib/cn';
 import { monogramFor } from '../lib/selection';
 import { AppearanceSection } from './AppearanceSection';
+import { Topbar } from './Topbar';
 
 /* ---------- Constants ---------- */
 
@@ -627,6 +628,13 @@ export default function Layout() {
         )}
         aria-label="Page content"
       >
+        {!drawer.isMobile && (
+          <Topbar
+            onOpenSearch={openSearch}
+            onOpenNotifications={openNotifPanel}
+            unreadCount={unreadCount}
+          />
+        )}
         <Outlet />
       </main>
     </div>

--- a/packages/myco/ui/src/layout/Topbar.tsx
+++ b/packages/myco/ui/src/layout/Topbar.tsx
@@ -24,9 +24,7 @@ function breadcrumbFor(pathname: string): string[] {
   const segments = pathname.split('/').filter(Boolean);
   const top = `/${segments[0]}`;
   const topLabel = ROUTE_LABELS[top] ?? segments[0];
-  const trail: string[] = [topLabel];
-  if (segments.length > 1 && segments[1] !== ':id') trail.push(segments[1]);
-  return trail;
+  return [topLabel];
 }
 
 export interface TopbarProps {

--- a/packages/myco/ui/src/layout/Topbar.tsx
+++ b/packages/myco/ui/src/layout/Topbar.tsx
@@ -20,8 +20,21 @@ const ROUTE_LABELS: Record<string, string> = {
 };
 
 function breadcrumbFor(pathname: string): string[] {
-  if (pathname === '/') return ['Dashboard'];
-  const segments = pathname.split('/').filter(Boolean);
+  // Strip grove/project scope prefix so the breadcrumb shows the page,
+  // not "g". Layout wraps project-scoped routes as /g/<grove>/p/<project>/<page>
+  // and grove-scoped routes as /g/<grove>/<page>.
+  let effective = pathname;
+  const projectScoped = pathname.match(/^\/g\/[^/]+\/p\/[^/]+(\/.*)?$/);
+  if (projectScoped) {
+    effective = projectScoped[1] || '/';
+  } else {
+    const groveScoped = pathname.match(/^\/g\/[^/]+(\/.*)?$/);
+    if (groveScoped) {
+      effective = groveScoped[1] || '/';
+    }
+  }
+  if (effective === '/') return ['Dashboard'];
+  const segments = effective.split('/').filter(Boolean);
   const top = `/${segments[0]}`;
   const topLabel = ROUTE_LABELS[top] ?? segments[0];
   return [topLabel];

--- a/packages/myco/ui/src/layout/Topbar.tsx
+++ b/packages/myco/ui/src/layout/Topbar.tsx
@@ -1,0 +1,99 @@
+import { useLocation } from 'react-router-dom';
+import { Bell, Command, Search } from 'lucide-react';
+import { cn } from '../lib/cn';
+import { GitIdentityPill } from '../components/ui/git-identity-pill';
+import { DaemonStatusPill } from '../components/ui/daemon-status-pill';
+import { CortexStatusPill } from '../components/ui/cortex-status-pill';
+import { useGitIdentity } from '../hooks/use-git-identity';
+
+const ROUTE_LABELS: Record<string, string> = {
+  '/': 'Dashboard',
+  '/sessions': 'Sessions',
+  '/cortex': 'Cortex',
+  '/mycelium': 'Mycelium',
+  '/skills': 'Skills',
+  '/agent': 'Agent',
+  '/settings': 'Settings',
+  '/logs': 'Logs',
+  '/machine': 'Machine',
+  '/groves': 'Groves',
+};
+
+function breadcrumbFor(pathname: string): string[] {
+  if (pathname === '/') return ['Dashboard'];
+  const segments = pathname.split('/').filter(Boolean);
+  const top = `/${segments[0]}`;
+  const topLabel = ROUTE_LABELS[top] ?? segments[0];
+  const trail: string[] = [topLabel];
+  if (segments.length > 1 && segments[1] !== ':id') trail.push(segments[1]);
+  return trail;
+}
+
+export interface TopbarProps {
+  onOpenSearch: () => void;
+  onOpenNotifications: () => void;
+  unreadCount: number;
+  className?: string;
+}
+
+export function Topbar({
+  onOpenSearch,
+  onOpenNotifications,
+  unreadCount,
+  className,
+}: TopbarProps) {
+  const location = useLocation();
+  const trail = breadcrumbFor(location.pathname);
+  const gitIdentity = useGitIdentity();
+
+  return (
+    <header
+      className={cn(
+        'sticky top-0 z-20 flex h-12 items-center gap-3 border-b border-outline-variant/20 bg-surface-container/90 backdrop-blur px-4',
+        className,
+      )}
+    >
+      <nav aria-label="Breadcrumb" className="flex items-center gap-1 font-sans text-xs text-on-surface-variant">
+        {trail.map((label, i) => (
+          <span key={i} className={cn(i === trail.length - 1 && 'text-on-surface')}>
+            {i > 0 && <span className="mx-1">/</span>}
+            {label}
+          </span>
+        ))}
+      </nav>
+
+      <button
+        type="button"
+        onClick={onOpenSearch}
+        aria-label="Search"
+        className="ml-auto inline-flex h-7 items-center gap-2 rounded-md border border-outline-variant/30 bg-surface-container px-2 text-on-surface-variant hover:bg-surface-container-high transition-colors"
+      >
+        <Search className="h-3 w-3" />
+        <span className="font-sans text-xs">Search</span>
+        <kbd className="inline-flex items-center gap-0.5 font-mono text-[10px] text-on-surface-variant/70">
+          <Command className="h-2.5 w-2.5" />K
+        </kbd>
+      </button>
+
+      <DaemonStatusPill />
+      <CortexStatusPill />
+      <GitIdentityPill
+        data={gitIdentity.data}
+        isPending={gitIdentity.isPending}
+        isError={gitIdentity.isError}
+      />
+
+      <button
+        type="button"
+        onClick={onOpenNotifications}
+        aria-label="Notifications"
+        className="relative rounded-md p-1.5 text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface transition-colors"
+      >
+        <Bell className="h-4 w-4" />
+        {unreadCount > 0 && (
+          <span className="absolute top-0.5 right-0.5 h-2 w-2 rounded-full bg-primary" />
+        )}
+      </button>
+    </header>
+  );
+}

--- a/packages/myco/ui/src/lib/constants.ts
+++ b/packages/myco/ui/src/lib/constants.ts
@@ -1,9 +1,19 @@
 export const POLL_INTERVALS = {
+  // Generic buckets — used by consumers that don't yet adopt per-surface keys.
   HEALTH: 5_000,
   STATS: 10_000,
   LOGS: 3_000,
   PROGRESS: 1_000,
   UPDATE: 300_000,
+
+  // Per-surface intervals — used by RefreshIndicator and the redesigned surfaces.
+  RUNS_ACTIVE: 3_000,
+  RUN_DETAIL: 5_000,
+  SESSIONS: 8_000,
+  SESSION_DETAIL: 8_000,
+  SPORES: 30_000,
+  CANOPY_ENTRIES: 60_000,
+  GIT_IDENTITY: 5_000,
 } as const;
 
 export const STALE_TIME = 10_000;

--- a/packages/myco/ui/src/pages/Logs.tsx
+++ b/packages/myco/ui/src/pages/Logs.tsx
@@ -4,8 +4,8 @@ import { Pagination } from '../components/ui/pagination';
 import { LogToolbar, type LogMode } from '../components/logs/LogToolbar';
 import { LogTable } from '../components/logs/LogTable';
 import { LogDetail } from '../components/logs/LogDetail';
+import { SlideoutDetailPanel } from '../components/ui/slideout-detail-panel';
 import { useLogStream, useLogSearch, useLogDetail, type LogEntry } from '../hooks/use-logs';
-import { cn } from '../lib/cn';
 import { DEFAULT_PAGE_SIZE, LEVEL_ORDER, type LogLevel } from '../lib/constants';
 
 /** Map time range presets to ISO from-timestamp. */
@@ -159,10 +159,9 @@ export default function Logs() {
         />
       </div>
 
-      {/* Main content: table + optional detail panel */}
+      {/* Main content: table */}
       <div className="flex flex-1 overflow-hidden mx-6 mb-6 rounded-lg border border-outline-variant/10">
-        {/* Log table */}
-        <div className={cn('flex flex-col', detailOpen ? 'w-3/5' : 'w-full')}>
+        <div className="flex flex-col w-full">
           <LogTable
             entries={displayEntries}
             selectedId={selectedEntry?.id ?? null}
@@ -183,18 +182,21 @@ export default function Logs() {
             </div>
           )}
         </div>
-
-        {/* Detail slide-out */}
-        {detailOpen && selectedEntry && (
-          <div className="w-2/5 border-l border-outline-variant/10">
-            <LogDetail
-              entry={selectedEntry}
-              resolved={detailData?.resolved}
-              onClose={() => setSelectedEntry(null)}
-            />
-          </div>
-        )}
       </div>
+
+      <SlideoutDetailPanel
+        open={detailOpen && !!selectedEntry}
+        onClose={() => setSelectedEntry(null)}
+        ariaLabel="Log entry detail"
+      >
+        {selectedEntry && (
+          <LogDetail
+            entry={selectedEntry}
+            resolved={detailData?.resolved}
+            onClose={() => setSelectedEntry(null)}
+          />
+        )}
+      </SlideoutDetailPanel>
     </div>
   );
 }

--- a/tests/daemon/git-status.test.ts
+++ b/tests/daemon/git-status.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'bun:test';
+import { parseGitStatus } from '../../packages/myco/src/daemon/api/git-status';
+
+describe('parseGitStatus', () => {
+  it('parses a clean branch with upstream and tracking info', () => {
+    const out = [
+      '# branch.oid abc123def456',
+      '# branch.head main',
+      '# branch.upstream origin/main',
+      '# branch.ab +0 -0',
+      '',
+    ].join('\n');
+    const result = parseGitStatus(out);
+    expect(result.branch).toBe('main');
+    expect(result.head_sha).toBe('abc123def456');
+    expect(result.dirty).toBe(false);
+    expect(result.ahead).toBe(0);
+    expect(result.behind).toBe(0);
+  });
+
+  it('parses a dirty branch with ahead/behind', () => {
+    const out = [
+      '# branch.oid 0123456789ab',
+      '# branch.head feature/x',
+      '# branch.upstream origin/feature/x',
+      '# branch.ab +3 -1',
+      '1 .M N... 100644 100644 100644 abc def src/foo.ts',
+      '? src/unknown.ts',
+    ].join('\n');
+    const result = parseGitStatus(out);
+    expect(result.branch).toBe('feature/x');
+    expect(result.dirty).toBe(true);
+    expect(result.ahead).toBe(3);
+    expect(result.behind).toBe(1);
+  });
+
+  it('handles a branch with no upstream', () => {
+    const out = [
+      '# branch.oid 9876543210fe',
+      '# branch.head local-only',
+      '',
+    ].join('\n');
+    const result = parseGitStatus(out);
+    expect(result.branch).toBe('local-only');
+    expect(result.dirty).toBe(false);
+    expect(result.ahead).toBe(0);
+    expect(result.behind).toBe(0);
+  });
+
+  it('handles detached HEAD', () => {
+    const out = [
+      '# branch.oid deadbeefcafe',
+      '# branch.head (detached)',
+      '',
+    ].join('\n');
+    const result = parseGitStatus(out);
+    expect(result.branch).toBe('(detached)');
+    expect(result.head_sha).toBe('deadbeefcafe');
+  });
+});

--- a/tests/ui/canopy-entry-detail.test.tsx
+++ b/tests/ui/canopy-entry-detail.test.tsx
@@ -37,7 +37,7 @@ function renderDetail(path: string) {
   const client = makeQueryClient();
   return render(
     <QueryClientProvider client={client}>
-      <CanopyEntryDetail path={path} />
+      <CanopyEntryDetail path={path} onClose={() => {}} />
     </QueryClientProvider>,
   );
 }

--- a/tests/ui/cortex-status-pill.test.tsx
+++ b/tests/ui/cortex-status-pill.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { CortexStatusPillView, computeIndexingPct } from '../../packages/myco/ui/src/components/ui/cortex-status-pill';
+
+describe('computeIndexingPct', () => {
+  it('returns 100 when fully described', () => {
+    expect(computeIndexingPct(50, 50)).toBe(100);
+  });
+  it('returns 0 when entries_count is 0', () => {
+    expect(computeIndexingPct(0, 0)).toBe(0);
+  });
+  it('returns floor of ratio * 100', () => {
+    expect(computeIndexingPct(74, 100)).toBe(74);
+    expect(computeIndexingPct(33, 100)).toBe(33);
+    expect(computeIndexingPct(1, 3)).toBe(33);
+  });
+});
+
+describe('CortexStatusPillView', () => {
+  it('renders sage dot at 100% (idle)', () => {
+    render(<CortexStatusPillView describedCount={10} entriesCount={10} />);
+    expect(screen.getByTestId('status-dot').dataset.tone).toBe('sage');
+    expect(screen.getByText('100%')).toBeDefined();
+  });
+
+  it('renders ochre pulsing dot when indexing', () => {
+    render(<CortexStatusPillView describedCount={5} entriesCount={10} />);
+    expect(screen.getByTestId('status-dot').dataset.tone).toBe('ochre');
+    expect(screen.getByTestId('status-dot').dataset.pulsing).toBe('true');
+    expect(screen.getByText('50%')).toBeDefined();
+  });
+
+  it('renders em-dash when data is missing', () => {
+    render(<CortexStatusPillView describedCount={undefined} entriesCount={undefined} />);
+    expect(screen.getByText('—')).toBeDefined();
+  });
+});

--- a/tests/ui/daemon-status-pill.test.tsx
+++ b/tests/ui/daemon-status-pill.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { formatUptime, DaemonStatusPillView } from '../../packages/myco/ui/src/components/ui/daemon-status-pill';
+
+describe('formatUptime', () => {
+  it('formats seconds under a minute', () => {
+    expect(formatUptime(45)).toBe('45s');
+  });
+  it('formats minutes', () => {
+    expect(formatUptime(125)).toBe('2m');
+  });
+  it('formats hours and minutes', () => {
+    expect(formatUptime(3 * 3600 + 17 * 60)).toBe('3h 17m');
+  });
+  it('formats days', () => {
+    expect(formatUptime(2 * 86400 + 4 * 3600)).toBe('2d 4h');
+  });
+});
+
+describe('DaemonStatusPillView', () => {
+  it('renders sage dot + daemon label + uptime', () => {
+    render(<DaemonStatusPillView uptimeSeconds={3 * 3600 + 17 * 60} />);
+    expect(screen.getByText('daemon')).toBeDefined();
+    expect(screen.getByText('3h 17m')).toBeDefined();
+    expect(screen.getByTestId('status-dot').dataset.tone).toBe('sage');
+  });
+
+  it('renders em-dash when uptime is unavailable', () => {
+    render(<DaemonStatusPillView uptimeSeconds={undefined} />);
+    expect(screen.getByText('—')).toBeDefined();
+  });
+});

--- a/tests/ui/git-identity-pill.test.tsx
+++ b/tests/ui/git-identity-pill.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { GitIdentityPill } from '../../packages/myco/ui/src/components/ui/git-identity-pill';
+import type { GitIdentity } from '../../packages/myco/ui/src/hooks/use-git-identity';
+import { gitIdentityInitials } from '../../packages/myco/ui/src/hooks/use-git-identity';
+
+function renderWithIdentity(identity: GitIdentity | undefined, opts?: { isPending?: boolean; isError?: boolean }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  client.setQueryData(['git-identity'], identity);
+  return render(
+    <QueryClientProvider client={client}>
+      <GitIdentityPill
+        data={identity}
+        isPending={opts?.isPending ?? false}
+        isError={opts?.isError ?? false}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe('GitIdentityPill', () => {
+  it('renders branch + initials when given a clean state', () => {
+    renderWithIdentity({
+      branch: 'main',
+      dirty: false,
+      ahead: 0,
+      behind: 0,
+      author: 'Chris Kirby',
+      author_email: 'chris@example.com',
+      head_sha: 'deadbeef',
+    });
+    expect(screen.getByText('main')).toBeDefined();
+    expect(screen.getByText('CK')).toBeDefined();
+  });
+
+  it('shows the dirty marker when the working tree is dirty', () => {
+    renderWithIdentity({
+      branch: 'main',
+      dirty: true,
+      ahead: 0,
+      behind: 0,
+      author: 'Chris Kirby',
+      author_email: 'chris@example.com',
+      head_sha: 'd',
+    });
+    expect(screen.getByTitle(/working tree dirty/i)).toBeDefined();
+  });
+
+  it('shows ahead/behind counts when set', () => {
+    renderWithIdentity({
+      branch: 'feature/x',
+      dirty: false,
+      ahead: 3,
+      behind: 2,
+      author: 'A B',
+      author_email: 'a@example.com',
+      head_sha: '0',
+    });
+    expect(screen.getByText(/↑3/)).toBeDefined();
+    expect(screen.getByText(/↓2/)).toBeDefined();
+  });
+
+  it('renders an em dash when pending', () => {
+    renderWithIdentity(undefined, { isPending: true });
+    expect(screen.getByText('—')).toBeDefined();
+  });
+});
+
+describe('gitIdentityInitials', () => {
+  it('returns the first two letters for a single-word name', () => {
+    expect(gitIdentityInitials('Chris')).toBe('CH');
+  });
+  it('returns first+last initial for multi-word', () => {
+    expect(gitIdentityInitials('Chris Kirby')).toBe('CK');
+    expect(gitIdentityInitials('Alice Bob Charlie')).toBe('AC');
+  });
+  it('returns ? for empty author', () => {
+    expect(gitIdentityInitials(undefined)).toBe('?');
+    expect(gitIdentityInitials('')).toBe('?');
+  });
+});

--- a/tests/ui/project-layout-routing.test.tsx
+++ b/tests/ui/project-layout-routing.test.tsx
@@ -45,6 +45,10 @@ mock.module('../../packages/myco/ui/src/layout/AppearanceSection', () => ({
   AppearanceSection: () => null,
 }));
 
+mock.module('../../packages/myco/ui/src/hooks/use-git-identity', () => ({
+  useGitIdentity: () => ({ data: null, isPending: false, isError: false }),
+}));
+
 const selection: ProjectSelection = {
   grove: {
     id: 'grove-a',

--- a/tests/ui/refresh-indicator.test.tsx
+++ b/tests/ui/refresh-indicator.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, mock } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { RefreshIndicator } from '../../packages/myco/ui/src/components/ui/refresh-indicator';
+
+describe('RefreshIndicator', () => {
+  it('shows the interval in seconds when idle', () => {
+    render(
+      <RefreshIndicator intervalMs={5_000} isFetching={false} onManualRefresh={() => {}} />,
+    );
+    expect(screen.getByText(/5s/)).toBeDefined();
+  });
+
+  it('shows a breathing dot while fetching', () => {
+    render(
+      <RefreshIndicator intervalMs={5_000} isFetching onManualRefresh={() => {}} />,
+    );
+    const dot = screen.getByTestId('refresh-indicator-dot');
+    expect(dot.className).toMatch(/animate-pulse/);
+  });
+
+  it('invokes onManualRefresh when the button is clicked', () => {
+    const handler = mock(() => {});
+    render(
+      <RefreshIndicator intervalMs={5_000} isFetching={false} onManualRefresh={handler} />,
+    );
+    screen.getByRole('button', { name: /refresh now/i }).click();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders manual-only mode without cadence text when intervalMs is undefined', () => {
+    render(
+      <RefreshIndicator isFetching={false} onManualRefresh={() => {}} />,
+    );
+    expect(screen.queryByText(/s$/)).toBeNull();
+  });
+});

--- a/tests/ui/slideout-detail-panel.test.tsx
+++ b/tests/ui/slideout-detail-panel.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, mock } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { SlideoutDetailPanel } from '../../packages/myco/ui/src/components/ui/slideout-detail-panel';
+
+describe('SlideoutDetailPanel', () => {
+  it('renders children when open', () => {
+    render(
+      <SlideoutDetailPanel open onClose={() => {}}>
+        <div>panel body</div>
+      </SlideoutDetailPanel>,
+    );
+    expect(screen.getByText('panel body')).toBeDefined();
+  });
+
+  it('does not render when closed', () => {
+    render(
+      <SlideoutDetailPanel open={false} onClose={() => {}}>
+        <div>panel body</div>
+      </SlideoutDetailPanel>,
+    );
+    expect(screen.queryByText('panel body')).toBeNull();
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = mock(() => {});
+    render(
+      <SlideoutDetailPanel open onClose={onClose}>
+        <div>panel body</div>
+      </SlideoutDetailPanel>,
+    );
+    screen.getByRole('button', { name: /close detail/i }).click();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = mock(() => {});
+    render(
+      <SlideoutDetailPanel open onClose={onClose}>
+        <div>panel body</div>
+      </SlideoutDetailPanel>,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invoke onClose when Escape fires while closed', () => {
+    const onClose = mock(() => {});
+    render(
+      <SlideoutDetailPanel open={false} onClose={onClose}>
+        <div>panel body</div>
+      </SlideoutDetailPanel>,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ui/topbar.test.tsx
+++ b/tests/ui/topbar.test.tsx
@@ -40,7 +40,6 @@ describe('Topbar', () => {
     renderTopbar('/');
     expect(screen.getByText('daemon')).toBeDefined();
     expect(screen.getByText('cortex')).toBeDefined();
-    // Git pill renders an em-dash when pending (no QueryClient data yet)
-    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+    expect(screen.getByTestId('git-identity-pill')).toBeDefined();
   });
 });

--- a/tests/ui/topbar.test.tsx
+++ b/tests/ui/topbar.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Topbar } from '../../packages/myco/ui/src/layout/Topbar';
+import { PowerProvider } from '../../packages/myco/ui/src/providers/power';
+
+function renderTopbar(initialRoute: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <QueryClientProvider client={client}>
+        <PowerProvider>
+          <Topbar onOpenSearch={() => {}} onOpenNotifications={() => {}} unreadCount={0} />
+        </PowerProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('Topbar', () => {
+  it('renders the command-palette trigger', () => {
+    renderTopbar('/');
+    expect(screen.getByRole('button', { name: /search/i })).toBeDefined();
+  });
+
+  it('renders the notifications bell', () => {
+    renderTopbar('/');
+    expect(screen.getByRole('button', { name: /notifications/i })).toBeDefined();
+  });
+
+  it('renders the breadcrumb from the route', () => {
+    renderTopbar('/sessions/abc-123');
+    expect(screen.getByText('Sessions')).toBeDefined();
+  });
+
+  it('renders daemon, cortex, and git pills', () => {
+    renderTopbar('/');
+    expect(screen.getByText('daemon')).toBeDefined();
+    expect(screen.getByText('cortex')).toBeDefined();
+    // Git pill renders an em-dash when pending (no QueryClient data yet)
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+  });
+});

--- a/tests/ui/use-canopy.test.tsx
+++ b/tests/ui/use-canopy.test.tsx
@@ -3,7 +3,6 @@
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import { vi } from '../helpers/vi-shim.js';
-import { POLL_INTERVALS } from '../../packages/myco/ui/src/lib/constants';
 import { useCanopyEntries } from '../../packages/myco/ui/src/hooks/use-canopy';
 
 const useQueryMock = vi.fn();
@@ -40,7 +39,7 @@ describe('useCanopyEntries', () => {
     renderHook(() => useCanopyEntries({}));
 
     expect(useQueryMock).toHaveBeenCalledWith(expect.objectContaining({
-      refetchInterval: POLL_INTERVALS.CANOPY_ENTRIES,
+      refetchInterval: 60_000,
     }));
   });
 });

--- a/tests/ui/use-canopy.test.tsx
+++ b/tests/ui/use-canopy.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { vi } from '../helpers/vi-shim.js';
+import { POLL_INTERVALS } from '../../packages/myco/ui/src/lib/constants';
+import { useCanopyEntries } from '../../packages/myco/ui/src/hooks/use-canopy';
+
+const useQueryMock = vi.fn();
+
+mock.module('@tanstack/react-query', () => ({
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+  useMutation: vi.fn(),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+mock.module('../../packages/myco/ui/src/lib/api', () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+  fetchJson: vi.fn(),
+  postJson: vi.fn(),
+}));
+
+mock.module('../../packages/myco/ui/src/hooks/use-project-selection', () => ({
+  useProjectScopedQueryKey: (key: unknown[]) => key,
+}));
+
+describe('useCanopyEntries', () => {
+  beforeEach(() => {
+    useQueryMock.mockReset();
+    useQueryMock.mockReturnValue({ data: undefined, isLoading: false, isError: false });
+  });
+
+  it('polls canopy entries at the CANOPY_ENTRIES interval', () => {
+    renderHook(() => useCanopyEntries({}));
+
+    expect(useQueryMock).toHaveBeenCalledWith(expect.objectContaining({
+      refetchInterval: POLL_INTERVALS.CANOPY_ENTRIES,
+    }));
+  });
+});

--- a/tests/ui/use-sessions.test.tsx
+++ b/tests/ui/use-sessions.test.tsx
@@ -31,7 +31,7 @@ describe('useSessionPlans', () => {
       queryKey: ['session-plans', 'sess-1'],
       enabled: true,
       pollCategory: 'standard',
-      refetchInterval: POLL_INTERVALS.STATS,
+      refetchInterval: POLL_INTERVALS.SESSION_DETAIL,
     }));
   });
 });

--- a/tests/ui/use-spores.test.tsx
+++ b/tests/ui/use-spores.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { vi } from '../helpers/vi-shim.js';
+import { POLL_INTERVALS } from '../../packages/myco/ui/src/lib/constants';
+import { useSpores } from '../../packages/myco/ui/src/hooks/use-spores';
+
+const useQueryMock = vi.fn();
+
+mock.module('@tanstack/react-query', () => ({
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+}));
+
+mock.module('../../packages/myco/ui/src/lib/api', () => ({
+  fetchJson: vi.fn(),
+}));
+
+mock.module('../../packages/myco/ui/src/hooks/use-project-selection', () => ({
+  useProjectScopedQueryKey: (key: unknown[]) => key,
+}));
+
+describe('useSpores', () => {
+  beforeEach(() => {
+    useQueryMock.mockReset();
+    useQueryMock.mockReturnValue({ data: undefined, isLoading: false, isError: false });
+  });
+
+  it('polls the spore list at the SPORES interval', () => {
+    renderHook(() => useSpores());
+
+    expect(useQueryMock).toHaveBeenCalledWith(expect.objectContaining({
+      refetchInterval: POLL_INTERVALS.SPORES,
+    }));
+  });
+});

--- a/tests/ui/use-spores.test.tsx
+++ b/tests/ui/use-spores.test.tsx
@@ -3,7 +3,6 @@
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import { vi } from '../helpers/vi-shim.js';
-import { POLL_INTERVALS } from '../../packages/myco/ui/src/lib/constants';
 import { useSpores } from '../../packages/myco/ui/src/hooks/use-spores';
 
 const useQueryMock = vi.fn();
@@ -30,7 +29,7 @@ describe('useSpores', () => {
     renderHook(() => useSpores());
 
     expect(useQueryMock).toHaveBeenCalledWith(expect.objectContaining({
-      refetchInterval: POLL_INTERVALS.SPORES,
+      refetchInterval: 30_000,
     }));
   });
 });


### PR DESCRIPTION
## Summary

Phase 1 of the Myco UI evolution against the v6 design handoff. This phase is **foundation**, not visual transformation — it builds the cross-cutting primitives, hooks, backend endpoint, and global desktop topbar that Phases 2-4b consume. Visible payoff in this PR is intentionally modest; the bigger surface rebuilds (Dashboard, Sessions Conversation/Plans/Spores tab, Runs master/detail + audit trail, Cortex tab restyle, Skills pipeline strip, Mycelium polish) live in subsequent phases.

The master spec and Phase 1 plan are at `docs/superpowers/specs/2026-05-13-myco-ui-evolution-master-spec.md` and `docs/superpowers/plans/2026-05-13-myco-ui-evolution-phase-1.md` (gitignored — also captured in the vault as plan ids \`f2e01cf80c4ff4aa\` and \`b16e49ebda9ba6a5\`).

## What's in this PR

**Backend**
- New \`GET /api/git/status\` daemon endpoint. Lightweight \`git status --porcelain=v2 --branch\` + \`git log -1\` reading the **caller's** filesystem root (via \`filesystemRootFromRequestContext\` — worktree-aware). Bearer-token-gated. 2s timeout-guarded with full failure-mode coverage (\`error\` / \`signal\` / non-zero status).

**Constants**
- \`POLL_INTERVALS\` expanded from 5 generic buckets to 12 keys (added \`RUNS_ACTIVE\`, \`RUN_DETAIL\`, \`SESSIONS\`, \`SESSION_DETAIL\`, \`SPORES\`, \`CANOPY_ENTRIES\`, \`GIT_IDENTITY\`). Existing aliases in \`use-sessions\`, \`use-agent\`, \`use-spores\`, \`use-canopy\` rewired to the new keys.

**Hook**
- \`useGitIdentity()\` against \`/api/git/status\`, polling at 5s.

**6 new UI primitives**
- \`RefreshIndicator\` — cadence text + manual refresh button + breathing dot
- \`SlideoutDetailPanel\` — extracted from \`CanopyEntryDetail\`'s inner \`DetailShell\`. Esc-to-close, focus-safe, optional \`testIdRoot\` prop (additive)
- \`StatusDot\` — \`tone\` × \`pulse\` × \`sizePx\` primitive
- \`GitIdentityPill\` — branch · dirty · ahead/behind · initials
- \`DaemonStatusPill\` — sage dot + uptime
- \`CortexStatusPill\` — derives indexing % from \`canopy.described_count / canopy.entries_count\`

**New layout component**
- \`Topbar\` — desktop chrome composing breadcrumb (grove-scope-aware) + ⌘K search trigger + daemon/cortex/git pills + notifications bell. Wired into \`Layout.tsx\` above \`<Outlet />\` for non-mobile. Mobile keeps its existing inline top bar.

**Wiring sites**
- \`CanopyEntryDetail\` refactored to compose \`SlideoutDetailPanel\` (visually identical by design — proves the extraction preserves behavior)
- \`Logs\` inspector converted from inline \`w-2/5\` split panel to fixed-right glass overlay; table goes back to full width
- \`RunDetail\` shows \`RefreshIndicator\` (cadence + manual refresh) for non-terminal runs in the back-nav row

## What's intentionally NOT changed

The following surfaces are unchanged in Phase 1 by design — they're rebuilt in later phases:

- Dashboard (Phase 4a: ScopeCard × 3 + ActiveSessionsHero)
- Sessions interior (Phase 3: Conversation/Plans/Spores tab rebuilds)
- Agent runs page (Phase 2: master/detail conversion; Phase 3: audit trail restyle)
- Cortex tab strip (Phase 4a)
- Skills (Phase 4a: pipeline strip)
- Mycelium (Phase 4a: sage halo, dashed edges)
- All settings, operations, grove, machine, team, onboarding pages (Phase 4b)

## Design reconciliation

Validation upfront found the v6 handoff was wrong / stale in several places. Key reconciliation decisions baked into the spec:

- **Source of truth = code, not mock.** Memory captured at \`feedback_design_vs_code_source_of_truth.md\`.
- **Spore vocabulary stays at production values** (\`gotcha, bug_fix, decision, discovery, trade_off, cross-cutting\`); handoff used different labels. Phase 3's UI will use production vocab.
- **Audit trail surfaces existing \`tool_input\` + \`tool_output_summary\` + \`PhaseAudit\`** from \`agent_turns\` — no schema change.
- **Test infra reused** — \`bun test\` jsdom config + \`@testing-library/*\` already installed; no new infrastructure needed.

## Test posture

- UI tests: **125 pass / 0 fail** (up from 91 pre-Phase-1; +34 new tests across primitives and helpers).
- Daemon tests: **4 pass / 0 fail** for the new \`parseGitStatus\` parser.
- Full project suite: **4647 pass / 0 fail / 15 skip** (node phase) + **125 pass / 0 fail** (jsdom phase).
- Typecheck clean for all touched files.
- Visual smoke-tested by author across topbar, Canopy slideout, Logs slideout, RunDetail RefreshIndicator, palette, breadcrumb, light + dark mode, mobile responsive.

## Test plan
- [x] Branch rebased cleanly onto latest \`main\` (no conflicts, 4 in-flight main PRs already in)
- [x] \`npm test\` green
- [x] Desktop topbar renders with correct git identity, daemon uptime, cortex %
- [x] Breadcrumb shows correct page name (no raw \`g\` from grove-scoped URL prefix)
- [x] ⌘K palette opens; notifications bell opens panel
- [x] Mobile viewport (< 768px) hides desktop topbar; existing mobile top bar still works
- [x] Canopy entries slide-out works as before (visually identical refactor)
- [x] Logs detail is now a fixed-right overlay; table full-width
- [x] RunDetail \`RefreshIndicator\` visible on non-terminal runs only
- [x] Light + dark mode pass on all new chrome
- [ ] Daemon-load verification under faster polling (\`RUNS_ACTIVE: 3s\`, \`LOGS: 1s\`) — optional follow-up; current numbers are spec defaults

## What's next

- Phase 2: Sessions/Runs master-detail alignment + extracted \`CompareBar\` + j/k nav decision
- Phase 3: Sessions Spores tab (new surface) + Conversation polish + Plans rule + Audit trail visual
- Phase 4a: Dashboard rebuild + Cortex tab restyle + Skills pipeline strip + Mycelium polish
- Phase 4b: Apply design language to 9 uncovered pages (Grove × 4, Machine × 2, Settings, Operations, Onboarding)

Each gets its own brainstorm → spec → plan → implement cycle per the master spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)