### PR TITLE
daemon: keep main loop responsive (lag probe + instrumented fetch + fast shutdown + service-install safety)

### DIFF
--- a/packages/myco/src/agent/harness/openai-local-mcp.ts
+++ b/packages/myco/src/agent/harness/openai-local-mcp.ts
@@ -62,6 +62,13 @@ class LocalVaultMcpServer implements MCPServer {
       throw new Error(`Unknown MCP tool: ${toolName}`);
     }
     const result = await tool.handler(args ?? {});
+    // Vault tools invoke synchronous bun:sqlite work — a chatty agent doing
+    // dozens of tool calls per turn would queue all of them as immediate
+    // microtask resolutions, starving libuv timers (PowerManager tick) and
+    // the daemon HTTP poll phase. Hand control back to libuv between tool
+    // dispatches so `/health` and scheduled jobs keep getting scheduling
+    // slots even during a hot tool-call burst.
+    await new Promise<void>((resolve) => setImmediate(resolve));
     return result.content;
   }
 

--- a/packages/myco/src/agent/harness/openai.ts
+++ b/packages/myco/src/agent/harness/openai.ts
@@ -34,6 +34,7 @@ import {
 } from '@myco/intelligence/local-openai-backends.js';
 import { DEFAULT_OPENAI_URL, DEFAULT_OPENROUTER_URL } from '@myco/agent/provider.js';
 import { errorMessage } from '@myco/utils/error-message.js';
+import { createInstrumentedFetch } from '@myco/utils/instrumented-fetch.js';
 
 const OPENAI_COMPATIBLE_PLACEHOLDER_API_KEY = 'myco-local-openai-compatible';
 const OPENAI_API_PATH = '/v1';
@@ -252,11 +253,39 @@ async function prepareLocalProviderExecution(
   };
 }
 
+/**
+ * Outbound LLM fetch instrumentation for the OpenAI Agents harness.
+ *
+ * Owns the cross-provider protection that's missing from the SDK out of
+ * the box: bounded response-headers timeout, no-progress watchdog (any
+ * stream that drops below the idle threshold gets aborted with a stable
+ * `fetch.stall` log entry), and `setImmediate` yields between body chunks
+ * so a high-rate streamed response never starves libuv timers or the
+ * daemon's HTTP listener. See `utils/instrumented-fetch.ts` for the full
+ * contract.
+ *
+ * Defaults are chosen for local-provider tolerance — LMStudio / Ollama
+ * on cold first-byte and big context loads can take a while — but still
+ * tight enough that a wedged stream dies in tens of seconds, not the
+ * SDK's default 600s.
+ */
+const harnessFetch = createInstrumentedFetch({
+  component: 'agent.openai-harness',
+  // 90s of silence allowed before headers — covers cold model warm-up on
+  // a local backend at high context.
+  responseHeadersTimeoutMs: 90_000,
+  // 45s between body chunks before we treat the stream as wedged. A
+  // healthy local model emits chunks well under a second apart even when
+  // it's reasoning; 45s is several orders of magnitude above that.
+  idleTimeoutMs: 45_000,
+});
+
 function createProvider(provider: ProviderConfig | undefined): OpenAIProvider {
   const { apiKey, baseURL } = resolveOpenAIClientConfig(provider);
   const client = new OpenAI({
     apiKey,
     ...(baseURL ? { baseURL } : {}),
+    fetch: harnessFetch,
   });
 
   return new OpenAIProvider({

--- a/packages/myco/src/agent/phase-loop.ts
+++ b/packages/myco/src/agent/phase-loop.ts
@@ -678,6 +678,14 @@ export async function executePhasedQuery(
     if (shouldStop) {
       break;
     }
+
+    // Hand control back to libuv between waves. Each wave settles via
+    // `Promise.allSettled` (microtasks only) and then writes a
+    // checkpoint via sync bun:sqlite — back-to-back waves with no yield
+    // can keep the timer/poll phases starved long enough for
+    // PowerManager ticks and the `/health` listener to miss their
+    // scheduling windows.
+    await new Promise<void>((resolve) => setImmediate(resolve));
   }
 
   const usage = aggregateUsage(phaseResults.map((phase) => phase.usage));

--- a/packages/myco/src/cli/service.ts
+++ b/packages/myco/src/cli/service.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { getServiceManager } from '../service/manager.js';
-import { buildServiceSpec } from '../service/spec-builder.js';
+import { buildServiceSpec, looksLikeDevBuildExecutable } from '../service/spec-builder.js';
 import { serviceLabel, serviceVariantToDirName } from '../service/labels.js';
 import type { ServiceVariant } from '../service/types.js';
 import { resolveMycoHome, DAEMON_STATE_FILENAME } from '../grove/paths.js';
@@ -58,6 +58,38 @@ function readRecordedDaemonCommand(variant: ServiceVariant): string | null {
   }
 }
 
+/**
+ * Hard fence: a dev-build binary must never manage the *prod* service.
+ *
+ * Why this exists: even when the dev binary resolves the correct
+ * executable for the prod plist (via daemon.json), `mgr.install`
+ * rewrites the plist whenever the rendered content drifts (e.g. when
+ * the running binary adds new plist keys like SoftResourceLimits), and
+ * the bootout/bootstrap cycle SIGTERMs the running prod daemon
+ * mid-flight. The dev binary also has no business uninstalling /
+ * restarting / stopping the prod service. Block every mutating verb at
+ * the CLI boundary so an accidental `myco service install` (no `--dev`)
+ * from a developer shell can never disturb prod.
+ *
+ * Returns a refusal message when the action should be blocked, or null
+ * when the action is safe to proceed. Exported for unit tests.
+ */
+export function assertSafeServiceMutation(
+  parsed: ParsedServiceArgs,
+  execPath: string,
+): string | null {
+  const mutating: ReadonlySet<ServiceAction> = new Set(['install', 'uninstall', 'start', 'stop', 'restart']);
+  if (parsed.variant !== 'prod') return null;
+  if (!mutating.has(parsed.action)) return null;
+  if (!looksLikeDevBuildExecutable(execPath)) return null;
+  return (
+    `Refusing to ${parsed.action} the *prod* service from a dev-build binary (${execPath}). ` +
+    `The prod service must be managed by the globally installed myco. ` +
+    `Use \`myco service ${parsed.action} --dev\` for the dogfood service, or run this command from the installed binary ` +
+    `(e.g. /opt/homebrew/lib/node_modules/@goondocks/myco/vendor/<arch>/myco).`
+  );
+}
+
 export async function run(args: string[], _vaultDir: string): Promise<void> {
   const parsed = parseServiceArgs(args);
   const mgr = getServiceManager();
@@ -68,6 +100,12 @@ export async function run(args: string[], _vaultDir: string): Promise<void> {
   }
 
   const label = serviceLabel(parsed.variant);
+
+  const refusal = assertSafeServiceMutation(parsed, process.execPath);
+  if (refusal) {
+    console.error(refusal);
+    process.exit(1);
+  }
 
   switch (parsed.action) {
     case 'install': {

--- a/packages/myco/src/constants/log-kinds.ts
+++ b/packages/myco/src/constants/log-kinds.ts
@@ -78,6 +78,15 @@ export const LOG_KINDS = {
   DAEMON_MIGRATION: 'daemon.migration',
   DAEMON_PORT: 'daemon.port',
   DAEMON_RECONCILE: 'daemon.reconcile',
+  DAEMON_LAG: 'daemon.lag',
+
+  // Provider-level fetch instrumentation (cross-runtime: anything that
+  // routes outbound LLM/embedding requests through `instrumentedFetch`).
+  FETCH_START: 'fetch.start',
+  FETCH_COMPLETE: 'fetch.complete',
+  FETCH_TIMEOUT: 'fetch.timeout',
+  FETCH_STALL: 'fetch.stall',
+  FETCH_ABORT: 'fetch.abort',
 
   // Server (HTTP)
   SERVER_REQUEST: 'server.request',

--- a/packages/myco/src/daemon/event-loop-lag.ts
+++ b/packages/myco/src/daemon/event-loop-lag.ts
@@ -1,0 +1,114 @@
+/**
+ * Always-on probe that measures event-loop responsiveness.
+ *
+ * Schedules a chained `setTimeout` at a fixed sample interval and records
+ * how much the actual fire time drifts past the expected one. Drift above
+ * the warn threshold means the loop was occupied by sync work (or a
+ * microtask cascade) for that duration — the diagnostic signal we lacked
+ * during the canopy-describe / LMStudio over-pressure hang where the
+ * daemon went silent without any error.
+ *
+ * Cross-provider by construction: this lives at the daemon level, so any
+ * blocker (sync bun:sqlite call, JSON.parse on a multi-MB buffer, a
+ * misbehaving SDK aggregator) shows up in the same log stream with the
+ * same kind. Operators grep for `daemon.lag` and see every stall.
+ *
+ * Implementation note: chained `setTimeout` is preferred over
+ * `setInterval`. setInterval's callback fires "as soon as possible" after
+ * the interval, which masks lag; chained setTimeout measures the gap
+ * directly.
+ */
+
+import type { Logger } from './logger.js';
+import { LOG_KINDS } from '../constants/log-kinds.js';
+
+export interface EventLoopLagProbeOptions {
+  /** How often to measure. Defaults to 250ms — small enough to catch a
+   *  half-second pin, large enough not to itself contribute to lag. */
+  sampleIntervalMs?: number;
+  /** Minimum drift in ms above which a warning is emitted. The probe
+   *  records every sample internally; only those exceeding this threshold
+   *  hit the log. */
+  warnThresholdMs?: number;
+  /** Optional clock override for tests. */
+  now?: () => number;
+}
+
+export const DEFAULT_SAMPLE_INTERVAL_MS = 250;
+export const DEFAULT_WARN_THRESHOLD_MS = 500;
+
+export class EventLoopLagProbe {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private lastTick: number = 0;
+  private running = false;
+  private readonly sampleIntervalMs: number;
+  private readonly warnThresholdMs: number;
+  private readonly now: () => number;
+  /** Peak lag observed since `start()` — surfaced via `getStats()` so the
+   *  daemon /stats endpoint or a test can read it without parsing logs. */
+  private peakLagMs = 0;
+  /** Number of samples that exceeded the warn threshold. */
+  private stallCount = 0;
+
+  constructor(private readonly logger: Logger, options: EventLoopLagProbeOptions = {}) {
+    this.sampleIntervalMs = options.sampleIntervalMs ?? DEFAULT_SAMPLE_INTERVAL_MS;
+    this.warnThresholdMs = options.warnThresholdMs ?? DEFAULT_WARN_THRESHOLD_MS;
+    this.now = options.now ?? Date.now;
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    this.lastTick = this.now();
+    this.schedule();
+  }
+
+  stop(): void {
+    this.running = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  getStats(): { peakLagMs: number; stallCount: number } {
+    return { peakLagMs: this.peakLagMs, stallCount: this.stallCount };
+  }
+
+  /** Test-only: reset counters between probe runs. */
+  resetStats(): void {
+    this.peakLagMs = 0;
+    this.stallCount = 0;
+  }
+
+  private schedule(): void {
+    if (!this.running) return;
+    this.timer = setTimeout(() => this.tick(), this.sampleIntervalMs);
+    // unref so the probe doesn't keep the process alive on its own.
+    this.timer.unref?.();
+  }
+
+  private tick(): void {
+    if (!this.running) return;
+    const now = this.now();
+    const observed = now - this.lastTick;
+    const lag = observed - this.sampleIntervalMs;
+    this.lastTick = now;
+
+    if (lag > this.peakLagMs) this.peakLagMs = lag;
+    if (lag >= this.warnThresholdMs) {
+      this.stallCount += 1;
+      this.logger.warn(
+        LOG_KINDS.DAEMON_LAG,
+        `Event-loop lag ${lag}ms exceeds threshold ${this.warnThresholdMs}ms`,
+        {
+          lagMs: lag,
+          sampleIntervalMs: this.sampleIntervalMs,
+          warnThresholdMs: this.warnThresholdMs,
+        },
+      );
+    }
+
+    this.schedule();
+  }
+}

--- a/packages/myco/src/daemon/event-loop-lag.ts
+++ b/packages/myco/src/daemon/event-loop-lag.ts
@@ -13,10 +13,20 @@
  * misbehaving SDK aggregator) shows up in the same log stream with the
  * same kind. Operators grep for `daemon.lag` and see every stall.
  *
- * Implementation note: chained `setTimeout` is preferred over
+ * Implementation note 1: chained `setTimeout` is preferred over
  * `setInterval`. setInterval's callback fires "as soon as possible" after
  * the interval, which masks lag; chained setTimeout measures the gap
  * directly.
+ *
+ * Implementation note 2: measurements use `performance.now()` rather than
+ * `Date.now()`. On macOS (laptop lid close / display sleep) and other
+ * platforms with system suspend, `Date.now()` keeps advancing during
+ * sleep while `setTimeout` (driven by libuv's monotonic clock) pauses.
+ * That mismatch would surface as a multi-minute fake "lag" reading the
+ * first time the laptop woke up. `performance.now()` is monotonic and
+ * pauses with the timer, so sleep events are invisible to the probe and
+ * only real loop pinning is reported. Live dogfood proof: probe reported
+ * 275 sec and 329 sec "lags" until this clock fix landed.
  */
 
 import type { Logger } from './logger.js';
@@ -30,7 +40,10 @@ export interface EventLoopLagProbeOptions {
    *  records every sample internally; only those exceeding this threshold
    *  hit the log. */
   warnThresholdMs?: number;
-  /** Optional clock override for tests. */
+  /** Optional clock override for tests. Production uses
+   *  `performance.now()` — monotonic and pauses during system sleep,
+   *  unlike `Date.now()` which would mis-classify multi-minute sleep
+   *  gaps as event-loop pins. */
   now?: () => number;
 }
 
@@ -53,7 +66,7 @@ export class EventLoopLagProbe {
   constructor(private readonly logger: Logger, options: EventLoopLagProbeOptions = {}) {
     this.sampleIntervalMs = options.sampleIntervalMs ?? DEFAULT_SAMPLE_INTERVAL_MS;
     this.warnThresholdMs = options.warnThresholdMs ?? DEFAULT_WARN_THRESHOLD_MS;
-    this.now = options.now ?? Date.now;
+    this.now = options.now ?? (() => performance.now());
   }
 
   start(): void {

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -168,6 +168,7 @@ import { RESTART_REASON_FILENAME } from '../constants/update.js';
 import { buildScopedConfigSaveNotification } from '../config/focus.js';
 import { notify } from '../notifications/notify.js';
 import { PowerManager } from './power.js';
+import { EventLoopLagProbe } from './event-loop-lag.js';
 import { InflightRunRegistry } from './inflight-runs.js';
 import { registerPowerJobs } from './power-jobs.js';
 import {
@@ -762,6 +763,12 @@ export async function main(): Promise<void> {
     sleepIntervalMs: POWER_SLEEP_INTERVAL_MS,
     logger,
   });
+
+  // Always-on diagnostic for event-loop pinning. Catches stalls regardless
+  // of cause (sync bun:sqlite, multi-MB JSON.parse, microtask cascade in a
+  // streaming SDK aggregator). Stopped during shutdown alongside the
+  // PowerManager.
+  const eventLoopLagProbe = new EventLoopLagProbe(logger);
 
   // Per-project power state. Pre-Grove, each project ran in its own
   // daemon with its own PowerManager. With one global daemon hosting
@@ -1741,6 +1748,7 @@ export async function main(): Promise<void> {
   }
 
   powerManager.start();
+  eventLoopLagProbe.start();
 
   // --- Shutdown ---
 
@@ -1763,6 +1771,7 @@ export async function main(): Promise<void> {
   const runShutdown = async (signal: string) => {
     logger.info(LOG_KINDS.DAEMON_START, `${signal} received`);
     powerManager.stop();
+    eventLoopLagProbe.stop();
     // Wait for any active stop processing to finish before shutting down
     const activeStopProcessing = stopProcessor.getActiveProcessing();
     if (activeStopProcessing) {

--- a/packages/myco/src/daemon/server.ts
+++ b/packages/myco/src/daemon/server.ts
@@ -22,6 +22,11 @@ import { vaultDbPath, withDatabase, type Database } from '../db/client.js';
 import { GroveRuntimeCache } from './grove-runtime-cache.js';
 
 const DEFAULT_STATUS = 200;
+/** How long we wait after `closeIdleConnections()` before force-yanking
+ *  any sockets that still haven't closed. Long enough for an in-flight
+ *  request to finish its response, short enough that a stale UI
+ *  keep-alive doesn't make restart look broken. */
+const SERVER_STOP_FORCE_CLOSE_GRACE_MS = 2_000;
 
 export interface DaemonServerConfig {
   vaultDir: string;
@@ -121,19 +126,16 @@ export class DaemonServer {
   }
 
   async stop(): Promise<void> {
-    return new Promise((resolve) => {
-      this.removeDaemonJson();
-      if (this.server) {
-        this.server.close(() => {
-          this.closeRequestDatabases();
-          this.logger.info(LOG_KINDS.DAEMON_START, 'Server stopped');
-          resolve();
-        });
-      } else {
-        this.closeRequestDatabases();
-        resolve();
-      }
+    this.removeDaemonJson();
+    if (!this.server) {
+      this.closeRequestDatabases();
+      return;
+    }
+    await gracefullyCloseHttpServer(this.server, {
+      gracePeriodMs: SERVER_STOP_FORCE_CLOSE_GRACE_MS,
     });
+    this.closeRequestDatabases();
+    this.logger.info(LOG_KINDS.DAEMON_START, 'Server stopped');
   }
 
   private registerDefaultRoutes(): void {
@@ -643,4 +645,59 @@ function isLoopbackOrigin(origin: string, port: number): boolean {
     origin === `http://127.0.0.1:${portStr}` ||
     origin === `http://localhost:${portStr}`
   );
+}
+
+/**
+ * Force a Node HTTP server through a fast, deterministic shutdown.
+ *
+ * `http.Server.close()` only stops accepting *new* connections — it
+ * waits for every existing connection to disconnect on its own before
+ * invoking its callback. UI keep-alives, MCP HTTP clients, and
+ * WebSocket upgrades happily hold sockets open for ~90s after we asked
+ * them to leave, which makes every daemon restart look broken (old
+ * daemon still holding the port, new daemon unable to bind).
+ *
+ *   1. `closeIdleConnections()` drops sockets that aren't mid-request
+ *      immediately (Node 18.2+).
+ *   2. A short grace window lets an in-flight request finish its
+ *      response cycle.
+ *   3. `closeAllConnections()` yanks anything still holding a socket —
+ *      WebSocket upgrades, long-poll clients, anything that wouldn't
+ *      otherwise notice we said goodbye.
+ *
+ * After that, the `close()` callback fires immediately because the
+ * sockets are gone. Exported so the regression test can exercise the
+ * timing property without standing up a full `DaemonServer`.
+ */
+export function gracefullyCloseHttpServer(
+  server: http.Server,
+  options: { gracePeriodMs: number },
+): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    server.closeIdleConnections();
+    // `server.close(cb)` invokes its callback only after every existing
+    // socket has finished. With bun's HTTP runtime that callback is not
+    // reliably fired even after `closeAllConnections()` has destroyed
+    // the sockets, so we don't depend on it: we drive completion from
+    // the operations we control. The callback path is still wired so
+    // we resolve on the fast path (no force-close needed) when the
+    // runtime does fire it.
+    server.close(finish);
+    const forceClose = setTimeout(() => {
+      server.closeAllConnections();
+      // closeAllConnections returns synchronously after destroying
+      // every socket — the server has now stopped accepting new
+      // connections (close() was called above) and severed every
+      // existing one. Anything still waiting on the close() callback
+      // is the runtime, not real work; resolve and move on.
+      finish();
+    }, options.gracePeriodMs);
+    forceClose.unref?.();
+  });
 }

--- a/packages/myco/src/daemon/server.ts
+++ b/packages/myco/src/daemon/server.ts
@@ -28,6 +28,28 @@ const DEFAULT_STATUS = 200;
  *  keep-alive doesn't make restart look broken. */
 const SERVER_STOP_FORCE_CLOSE_GRACE_MS = 2_000;
 
+/**
+ * Protective limits applied to the daemon's HTTP server. Node's defaults
+ * are tuned for public-internet clients (long keep-alive, slow-loris
+ * tolerance, no cap on per-socket request count). On loopback we can be
+ * much tighter — every legitimate client is on the same machine. Without
+ * these, a misbehaving client (or even a stress test from a developer
+ * shell) can pile up sockets in CLOSE_WAIT until the daemon's fd table
+ * is exhausted and `accept()` starts returning EMFILE.
+ */
+const HTTP_KEEP_ALIVE_TIMEOUT_MS = 5_000;
+const HTTP_HEADERS_TIMEOUT_MS = 10_000;
+/** Cap how many requests reuse a single keep-alive socket before we
+ *  force a close. Without this, a single client can hold one fd open
+ *  forever no matter how many requests it sends. */
+const HTTP_MAX_REQUESTS_PER_SOCKET = 1_000;
+/** Explicit TCP listen backlog. Node defaults to 511, which the macOS
+ *  kernel further caps at `kern.ipc.somaxconn` (often 128). 4096 keeps
+ *  the kernel's SYN queue deep enough that a burst of concurrent
+ *  loopback connections doesn't get rejected during the brief window
+ *  the daemon takes to call `accept()` on each. */
+const HTTP_LISTEN_BACKLOG = 4_096;
+
 export interface DaemonServerConfig {
   vaultDir: string;
   logger: DaemonLogger;
@@ -115,7 +137,13 @@ export class DaemonServer {
       });
       this.server.on('error', reject);
 
-      this.server.listen(port, '127.0.0.1', () => {
+      // Tighten Node's default HTTP server limits — see the helper
+      // docstring for the load-bearing reasoning. Defaults let a single
+      // misbehaving client camp on sockets long enough to exhaust the
+      // daemon's fd table.
+      applyDaemonHttpServerLimits(this.server);
+
+      this.server.listen(port, '127.0.0.1', HTTP_LISTEN_BACKLOG, () => {
         const addr = this.server!.address() as { port: number };
         this.port = addr.port;
         this.writeDaemonJson();
@@ -646,6 +674,37 @@ function isLoopbackOrigin(origin: string, port: number): boolean {
     origin === `http://localhost:${portStr}`
   );
 }
+
+/**
+ * Apply the daemon's protective HTTP server limits.
+ *
+ * Node's HTTP server defaults are tuned for serving public-internet
+ * clients — long keep-alive, generous slow-loris tolerance, no cap on
+ * how many requests reuse a single socket. The daemon listens only on
+ * loopback, so every legitimate client is on the same machine and we
+ * can be much tighter.
+ *
+ * The motivating incident: 250 concurrent `curl` probes against
+ * `/health` filled the kernel's accept queue and the daemon's fd table
+ * (launchd capped at 256 NOFILE) faster than the server could drain
+ * them. Once the fd table was full, `accept()` returned EMFILE and the
+ * SYN queue overflowed — new clients couldn't even complete the TCP
+ * handshake. With these limits in place, idle keep-alives are reaped
+ * every 5s, slow-header attackers drop after 10s, and one client can't
+ * monopolize a socket past `HTTP_MAX_REQUESTS_PER_SOCKET` reuses.
+ *
+ * Exported so the regression test can verify the limits are applied
+ * without standing up a full `DaemonServer`.
+ */
+export function applyDaemonHttpServerLimits(server: http.Server): void {
+  server.keepAliveTimeout = HTTP_KEEP_ALIVE_TIMEOUT_MS;
+  server.headersTimeout = HTTP_HEADERS_TIMEOUT_MS;
+  server.maxRequestsPerSocket = HTTP_MAX_REQUESTS_PER_SOCKET;
+}
+
+/** TCP listen backlog used by the daemon. Exported so service installers
+ *  / consumers that bind their own listener can match it. */
+export const DAEMON_HTTP_LISTEN_BACKLOG = HTTP_LISTEN_BACKLOG;
 
 /**
  * Force a Node HTTP server through a fast, deterministic shutdown.

--- a/packages/myco/src/intelligence/lm-studio.ts
+++ b/packages/myco/src/intelligence/lm-studio.ts
@@ -1,5 +1,20 @@
 import type { LlmProvider, EmbeddingProvider, LlmResponse, EmbeddingResponse, LlmRequestOptions } from './llm.js';
 import { LLM_REQUEST_TIMEOUT_MS, EMBEDDING_REQUEST_TIMEOUT_MS, DAEMON_CLIENT_TIMEOUT_MS } from '../constants.js';
+import { createInstrumentedFetch } from '../utils/instrumented-fetch.js';
+
+/**
+ * Module-level instrumented fetch for every LMStudio request — adds the
+ * no-progress watchdog and per-chunk loop yields on top of the existing
+ * `AbortSignal.timeout(...)` wall-clock cap. The previous wall-clock
+ * timeout protects only the *total* duration; the watchdog catches
+ * "stream drips one byte every 30 minutes" and any sync work inside
+ * undici's chunk delivery is interleaved with `setImmediate`.
+ */
+const lmStudioFetch = createInstrumentedFetch({
+  component: 'intelligence.lm-studio',
+  responseHeadersTimeoutMs: 60_000,
+  idleTimeoutMs: 30_000,
+});
 
 interface LmStudioConfig {
   model?: string;
@@ -92,7 +107,7 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
       body.reasoning = opts!.reasoning;
     }
 
-    let response = await fetch(`${this.baseUrl}${ENDPOINT_CHAT}`, {
+    let response = await lmStudioFetch(`${this.baseUrl}${ENDPOINT_CHAT}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -107,7 +122,7 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
       if (sendReasoning && /does not support reasoning|"param"\s*:\s*"reasoning"/.test(errorBody)) {
         this.reasoningUnsupported = true;
         delete body.reasoning;
-        response = await fetch(`${this.baseUrl}${ENDPOINT_CHAT}`, {
+        response = await lmStudioFetch(`${this.baseUrl}${ENDPOINT_CHAT}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),
@@ -141,7 +156,7 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
    * (The native API doesn't have an embedding endpoint — OpenAI-compat is fine here.)
    */
   async embed(text: string): Promise<EmbeddingResponse> {
-    const response = await fetch(`${this.baseUrl}${ENDPOINT_EMBEDDINGS}`, {
+    const response = await lmStudioFetch(`${this.baseUrl}${ENDPOINT_EMBEDDINGS}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -204,7 +219,7 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
       body.offload_kv_cache_to_gpu = true;
     }
 
-    const response = await fetch(`${this.baseUrl}${ENDPOINT_MODELS_LOAD}`, {
+    const response = await lmStudioFetch(`${this.baseUrl}${ENDPOINT_MODELS_LOAD}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -233,7 +248,7 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
    */
   private async getLoadedInstances(): Promise<NativeLoadedInstance[]> {
     try {
-      const response = await fetch(`${this.baseUrl}${ENDPOINT_MODELS_NATIVE}`, {
+      const response = await lmStudioFetch(`${this.baseUrl}${ENDPOINT_MODELS_NATIVE}`, {
         signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
       });
       if (!response.ok) return [];
@@ -248,7 +263,7 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
 
   async isAvailable(): Promise<boolean> {
     try {
-      const response = await fetch(`${this.baseUrl}${ENDPOINT_MODELS_LIST}`, {
+      const response = await lmStudioFetch(`${this.baseUrl}${ENDPOINT_MODELS_LIST}`, {
         signal: AbortSignal.timeout(DAEMON_CLIENT_TIMEOUT_MS),
       });
       return response.ok;
@@ -260,7 +275,7 @@ export class LmStudioBackend implements LlmProvider, EmbeddingProvider {
   /** List available models on this LM Studio instance. */
   async listModels(timeoutMs?: number): Promise<string[]> {
     try {
-      const response = await fetch(`${this.baseUrl}${ENDPOINT_MODELS_LIST}`, {
+      const response = await lmStudioFetch(`${this.baseUrl}${ENDPOINT_MODELS_LIST}`, {
         signal: AbortSignal.timeout(timeoutMs ?? DAEMON_CLIENT_TIMEOUT_MS),
       });
       const data = await response.json() as { data: Array<{ id: string }> };

--- a/packages/myco/src/service/launchd-plist.ts
+++ b/packages/myco/src/service/launchd-plist.ts
@@ -12,6 +12,17 @@ function tag(name: string, value: string): string {
   return `<${name}>${value}</${name}>`;
 }
 
+/**
+ * launchd inherits the user session's `maxfiles` limit (typically 256 on
+ * macOS), which is far too low for a daemon serving HTTP plus N
+ * SQLite handles plus log streams. A burst of ~250 concurrent connections
+ * exhausted the fd table in dogfood and started returning EMFILE on
+ * `accept()`. SoftResourceLimits / HardResourceLimits inside the plist
+ * raise the daemon's per-process cap independent of whatever the user
+ * session is configured for.
+ */
+const LAUNCHD_NUMBER_OF_FILES = 65_535;
+
 export function renderLaunchdPlist(spec: ServiceSpec): string {
   const programArgs = [spec.executable, ...spec.args]
     .map((a) => `    ${tag('string', escapeXml(a))}`)
@@ -24,6 +35,18 @@ export function renderLaunchdPlist(spec: ServiceSpec): string {
   const keepAlive = spec.keepAlive
     ? `  <key>KeepAlive</key>\n  <true/>\n  <key>ThrottleInterval</key>\n  ${tag('integer', String(spec.throttleSeconds))}\n`
     : '';
+
+  const resourceLimits =
+    `  <key>SoftResourceLimits</key>\n` +
+    `  <dict>\n` +
+    `    <key>NumberOfFiles</key>\n` +
+    `    ${tag('integer', String(LAUNCHD_NUMBER_OF_FILES))}\n` +
+    `  </dict>\n` +
+    `  <key>HardResourceLimits</key>\n` +
+    `  <dict>\n` +
+    `    <key>NumberOfFiles</key>\n` +
+    `    ${tag('integer', String(LAUNCHD_NUMBER_OF_FILES))}\n` +
+    `  </dict>\n`;
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -47,7 +70,7 @@ ${envEntries}
   ${tag('string', escapeXml(spec.stderrPath))}
   <key>RunAtLoad</key>
   ${spec.runAtLoad ? '<true/>' : '<false/>'}
-${keepAlive}</dict>
+${keepAlive}${resourceLimits}</dict>
 </plist>
 `;
 }

--- a/packages/myco/src/service/spec-builder.ts
+++ b/packages/myco/src/service/spec-builder.ts
@@ -12,6 +12,30 @@ export interface BuildSpecOptions {
   mycoHome?: string;
 }
 
+/**
+ * Detect a dev-build executable path — anything inside a checkout's
+ * `packages/<pkg>/vendor/<arch>/myco` tree.
+ *
+ * Used as a guard in `buildServiceSpec` (and the prod-only callsite
+ * fence below) to refuse installing a dev-build binary as the *prod*
+ * service. Live dogfood proof of why this matters: the prod plist was
+ * once overwritten with a dev-build path, after which launchd
+ * re-spawned the dev binary as the prod service — running unreleased
+ * code against the prod Grove with no operator visibility into the
+ * substitution. Catching the substitution at build-spec time makes the
+ * failure mode unreachable regardless of which caller initiated the
+ * install (`myco service install`, `ensureSelfInstalledAsService`, a
+ * future auto-update flow, etc.).
+ *
+ * Detection is intentionally a literal path match — we want to catch
+ * the path *as it will be written into the plist*, before any realpath
+ * resolution could flatten it. We also realpath the executable below
+ * so a symlink pointing into a vendor tree can't bypass the check.
+ */
+export function looksLikeDevBuildExecutable(executable: string): boolean {
+  return /\/packages\/[^/]+\/vendor\//.test(executable);
+}
+
 export function buildServiceSpec(opts: BuildSpecOptions): ServiceSpec {
   const mycoHome = opts.mycoHome ?? resolveMycoHome();
   const executable = path.resolve(opts.executable);
@@ -32,6 +56,23 @@ export function buildServiceSpec(opts: BuildSpecOptions): ServiceSpec {
       + `Service install requires a standalone daemon binary (e.g. ~/.local/bin/myco or the vendored binary at packages/myco/vendor/<arch>/myco). `
       + `Start the daemon at least once with \`myco daemon\` so it records its own binary path in daemon.json, then retry.`,
     );
+  }
+  // Dev-build guard: the *prod* service must never run a dev-build
+  // binary. We check both the literal path and its realpath so a
+  // symlink whose target lives under a vendor tree still fails.
+  if (opts.variant === 'prod') {
+    const candidatePaths = [executable];
+    try { candidatePaths.push(fs.realpathSync(executable)); } catch { /* ignore */ }
+    const offender = candidatePaths.find(looksLikeDevBuildExecutable);
+    if (offender) {
+      throw new Error(
+        `Refusing to install the *prod* service with a dev-build executable: ${offender}. `
+        + `Dev-build binaries (any path under packages/<pkg>/vendor/) belong to the *dev* service variant only. `
+        + `If you meant to install the dogfood daemon, pass \`--dev\`. `
+        + `If you intended to install the production daemon, point at the globally installed binary `
+        + `(e.g. /opt/homebrew/lib/node_modules/@goondocks/myco/vendor/<arch>/myco) instead.`,
+      );
+    }
   }
 
   const serviceDirName = opts.variant === 'dev' ? SERVICE_DEV_DIRNAME : SERVICE_DIRNAME;

--- a/packages/myco/src/service/systemd-unit.ts
+++ b/packages/myco/src/service/systemd-unit.ts
@@ -4,6 +4,16 @@ function shellEscape(value: string): string {
   return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 }
 
+/**
+ * systemd's default `LimitNOFILE` for user services is 1024 on most
+ * distros — fine for a typical CLI tool, but the daemon serves HTTP +
+ * N SQLite handles + log streams, and a burst of concurrent connections
+ * can exhaust the cap. Raise it explicitly so the unit file is the
+ * source of truth instead of inheriting whatever the distro chose. See
+ * the matching `SoftResourceLimits.NumberOfFiles` in launchd-plist.ts.
+ */
+const SYSTEMD_LIMIT_NOFILE = 65_535;
+
 export function renderSystemdUnit(spec: ServiceSpec): string {
   const execLine = [spec.executable, ...spec.args].join(' ');
   const envLines = Object.entries(spec.env)
@@ -26,6 +36,7 @@ StandardOutput=append:${spec.stdoutPath}
 StandardError=append:${spec.stderrPath}
 Restart=${restart}
 RestartSec=${spec.throttleSeconds}
+LimitNOFILE=${SYSTEMD_LIMIT_NOFILE}
 
 [Install]
 ${wantedBy ? `WantedBy=${wantedBy}` : ''}

--- a/packages/myco/src/utils/instrumented-fetch.ts
+++ b/packages/myco/src/utils/instrumented-fetch.ts
@@ -1,0 +1,441 @@
+/**
+ * Cross-provider fetch wrapper with bounded headers timeout, no-progress
+ * (idle) watchdog, structured chunk logging, and per-chunk event-loop
+ * yields.
+ *
+ * Purpose: any outbound LLM / embedding HTTP call routed through this
+ * factory gets the same protections, regardless of which provider SDK
+ * issued it. The acute failure that motivated this — canopy-describe
+ * over-pressuring gpt-oss-20b via LMStudio and pinning the daemon's main
+ * loop for >60 seconds with no `/health` response — would have been
+ * killed at the idle-timeout boundary and logged with a stable kind
+ * (`fetch.stall`) operators can grep on.
+ *
+ * The body wrap also serves as a forcing function for event-loop yields:
+ * `setImmediate` between every chunk hands control back to libuv so timer
+ * callbacks (PowerManager tick, idle-probe sampling) and incoming TCP
+ * connections (`/health`) get scheduling time even when the upstream is
+ * dripping chunks in tight bursts.
+ *
+ * Wiring: factory function — each provider configures its own thresholds
+ * (e.g., a chat completion is allowed a longer idle window than an
+ * embedding call). The returned function is type-compatible with the
+ * global `fetch`.
+ */
+
+import crypto from 'node:crypto';
+import { LOG_KINDS } from '../constants/log-kinds.js';
+import type { Logger } from '../daemon/logger.js';
+
+/** A logger surface the wrapper actually uses — kept narrow so callers
+ *  can pass any compatible object (full DaemonLogger, a mock, or null). */
+export interface InstrumentedFetchLogger {
+  debug?: Logger['debug'];
+  warn?: Logger['warn'];
+}
+
+export interface InstrumentedFetchOptions {
+  /** Component label included on every log entry so operators can tell
+   *  whether the stall was an agent run vs. an embedding job vs. a
+   *  control-plane call. */
+  component: string;
+  /** Logger to emit structured events on. If undefined, instrumentation is
+   *  silent but the timeouts and yields still apply. */
+  logger?: InstrumentedFetchLogger;
+  /** Cap on how long we wait for response headers (the network round-trip
+   *  to the upstream). Defaults to 60s. */
+  responseHeadersTimeoutMs?: number;
+  /** Cap on the gap between consecutive body chunks. Defaults to 30s. A
+   *  stuck stream that never closes still triggers this even if the
+   *  caller's wall-clock budget is much longer. */
+  idleTimeoutMs?: number;
+  /** Hard ceiling on total request time. Defaults to undefined — relies on
+   *  the caller's signal + idleTimeoutMs. Set this when a provider should
+   *  never be allowed to occupy a connection beyond N seconds regardless
+   *  of activity. */
+  totalTimeoutMs?: number;
+  /** Whether to insert `await new Promise(r => setImmediate(r))` between
+   *  chunks while draining the body. Defaults to true — this is the
+   *  loop-yield property that keeps `/health` responsive during a large
+   *  streamed response. Disable only in tests that need deterministic
+   *  back-to-back chunks. */
+  yieldBetweenChunks?: boolean;
+  /** Optional clock override (tests). */
+  now?: () => number;
+}
+
+export const DEFAULT_RESPONSE_HEADERS_TIMEOUT_MS = 60_000;
+export const DEFAULT_IDLE_TIMEOUT_MS = 30_000;
+
+interface ResolvedOptions {
+  component: string;
+  logger: InstrumentedFetchLogger | undefined;
+  responseHeadersTimeoutMs: number;
+  idleTimeoutMs: number;
+  totalTimeoutMs: number | undefined;
+  yieldBetweenChunks: boolean;
+  now: () => number;
+}
+
+function resolveOptions(options: InstrumentedFetchOptions): ResolvedOptions {
+  return {
+    component: options.component,
+    logger: options.logger,
+    responseHeadersTimeoutMs:
+      options.responseHeadersTimeoutMs ?? DEFAULT_RESPONSE_HEADERS_TIMEOUT_MS,
+    idleTimeoutMs: options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS,
+    totalTimeoutMs: options.totalTimeoutMs,
+    yieldBetweenChunks: options.yieldBetweenChunks ?? true,
+    now: options.now ?? Date.now,
+  };
+}
+
+/**
+ * Combine multiple AbortSignals into one. Node 20.3+ exposes
+ * `AbortSignal.any` natively; we fall back to a manual implementation for
+ * older runtimes to keep the wrapper portable. Either way the returned
+ * signal aborts as soon as any input does and propagates the original
+ * `reason`.
+ */
+function anySignal(signals: AbortSignal[]): AbortSignal {
+  const native = (AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal }).any;
+  if (typeof native === 'function') {
+    return native.call(AbortSignal, signals);
+  }
+  const controller = new AbortController();
+  const handlers: Array<() => void> = [];
+  for (const sig of signals) {
+    if (sig.aborted) {
+      controller.abort(sig.reason);
+      return controller.signal;
+    }
+    const handler = () => {
+      if (!controller.signal.aborted) {
+        controller.abort(sig.reason);
+      }
+      for (const h of handlers) h();
+    };
+    handlers.push(() => sig.removeEventListener('abort', handler));
+    sig.addEventListener('abort', handler, { once: true });
+  }
+  return controller.signal;
+}
+
+class FetchStallError extends Error {
+  constructor(public readonly kind: 'response-headers-timeout' | 'idle-timeout' | 'total-timeout', message: string) {
+    super(message);
+    this.name = 'FetchStallError';
+  }
+}
+
+/**
+ * Callable fetch type — what every consumer in this codebase (OpenAI
+ * client, LmStudioBackend, embedding providers) actually wants. We do not
+ * widen this to `typeof fetch` because that includes static fields like
+ * `fetch.preconnect` that the global declares but no SDK consumes.
+ */
+export type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Create a `fetch`-compatible function with the configured instrumentation
+ * baked in. Reuse the returned function across many requests; per-call
+ * customization comes from the standard `init.signal` parameter, which we
+ * compose with our internal abort sources.
+ */
+export function createInstrumentedFetch(options: InstrumentedFetchOptions): FetchLike {
+  const resolved = resolveOptions(options);
+  return async function instrumentedFetch(input: RequestInfo | URL, init: RequestInit = {}): Promise<Response> {
+    return instrumentedFetchImpl(input, init, resolved);
+  };
+}
+
+/** Module-default instance, suitable for ad-hoc imports where the caller
+ *  doesn't need per-component log routing or custom thresholds. */
+export const instrumentedFetch: FetchLike = createInstrumentedFetch({
+  component: 'default',
+});
+
+async function instrumentedFetchImpl(
+  input: RequestInfo | URL,
+  init: RequestInit,
+  options: ResolvedOptions,
+): Promise<Response> {
+  const requestId = crypto.randomUUID();
+  const url = extractUrl(input);
+  const method = (init.method ?? (typeof input === 'object' && 'method' in (input as Request) ? (input as Request).method : 'GET') ?? 'GET').toUpperCase();
+  const callerSignal = init.signal ?? undefined;
+
+  const startedAt = options.now();
+  const headersAbort = new AbortController();
+  const idleAbort = new AbortController();
+  const totalAbort = new AbortController();
+
+  const signalsToCompose: AbortSignal[] = [headersAbort.signal, idleAbort.signal, totalAbort.signal];
+  if (callerSignal) signalsToCompose.push(callerSignal);
+  const composed = anySignal(signalsToCompose);
+
+  const headersTimer = setTimeout(() => {
+    headersAbort.abort(new FetchStallError(
+      'response-headers-timeout',
+      `No response headers after ${options.responseHeadersTimeoutMs}ms`,
+    ));
+  }, options.responseHeadersTimeoutMs);
+  headersTimer.unref?.();
+
+  let totalTimer: ReturnType<typeof setTimeout> | undefined;
+  if (options.totalTimeoutMs !== undefined) {
+    totalTimer = setTimeout(() => {
+      totalAbort.abort(new FetchStallError(
+        'total-timeout',
+        `Request exceeded total budget of ${options.totalTimeoutMs}ms`,
+      ));
+    }, options.totalTimeoutMs);
+    totalTimer.unref?.();
+  }
+
+  options.logger?.debug?.(LOG_KINDS.FETCH_START, `${options.component}: ${method} ${redactUrl(url)}`, {
+    component: options.component,
+    requestId,
+    method,
+    url: redactUrl(url),
+    responseHeadersTimeoutMs: options.responseHeadersTimeoutMs,
+    idleTimeoutMs: options.idleTimeoutMs,
+    totalTimeoutMs: options.totalTimeoutMs ?? null,
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(input, { ...init, signal: composed });
+  } catch (err) {
+    clearTimeout(headersTimer);
+    if (totalTimer) clearTimeout(totalTimer);
+    const stall = classifyStallReason(err, headersAbort.signal, idleAbort.signal, totalAbort.signal, callerSignal);
+    if (stall) {
+      options.logger?.warn?.(stallToLogKind(stall.kind), `${options.component}: ${stall.kind} ${redactUrl(url)}`, {
+        component: options.component,
+        requestId,
+        url: redactUrl(url),
+        method,
+        elapsedMs: options.now() - startedAt,
+        reason: stall.message,
+      });
+      throw stall;
+    }
+    throw err;
+  }
+
+  clearTimeout(headersTimer);
+
+  if (!response.body) {
+    if (totalTimer) clearTimeout(totalTimer);
+    options.logger?.debug?.(LOG_KINDS.FETCH_COMPLETE, `${options.component}: ${method} ${redactUrl(url)} ${response.status}`, {
+      component: options.component,
+      requestId,
+      method,
+      url: redactUrl(url),
+      status: response.status,
+      elapsedMs: options.now() - startedAt,
+      chunkCount: 0,
+      totalBytes: 0,
+    });
+    return response;
+  }
+
+  const wrappedBody = wrapBodyWithIdleWatchdog({
+    body: response.body,
+    idleAbort,
+    callerSignal: composed,
+    options,
+    onSettled: () => {
+      if (totalTimer) clearTimeout(totalTimer);
+    },
+    onComplete: (stats) => {
+      options.logger?.debug?.(LOG_KINDS.FETCH_COMPLETE, `${options.component}: ${method} ${redactUrl(url)} ${response.status}`, {
+        component: options.component,
+        requestId,
+        method,
+        url: redactUrl(url),
+        status: response.status,
+        elapsedMs: options.now() - startedAt,
+        chunkCount: stats.chunkCount,
+        totalBytes: stats.totalBytes,
+      });
+    },
+    onAbort: (reason) => {
+      const stall = classifyStallReason(reason, headersAbort.signal, idleAbort.signal, totalAbort.signal, callerSignal);
+      options.logger?.warn?.(
+        stall ? stallToLogKind(stall.kind) : LOG_KINDS.FETCH_ABORT,
+        `${options.component}: stream aborted ${redactUrl(url)}`,
+        {
+          component: options.component,
+          requestId,
+          url: redactUrl(url),
+          method,
+          elapsedMs: options.now() - startedAt,
+          reason: stall?.message ?? errorReason(reason),
+        },
+      );
+    },
+  });
+
+  return new Response(wrappedBody, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
+interface BodyWrapStats {
+  chunkCount: number;
+  totalBytes: number;
+}
+
+interface WrapBodyArgs {
+  body: ReadableStream<Uint8Array>;
+  idleAbort: AbortController;
+  callerSignal: AbortSignal;
+  options: ResolvedOptions;
+  onSettled: () => void;
+  onComplete: (stats: BodyWrapStats) => void;
+  onAbort: (reason: unknown) => void;
+}
+
+function wrapBodyWithIdleWatchdog(args: WrapBodyArgs): ReadableStream<Uint8Array> {
+  const { body, idleAbort, callerSignal, options, onSettled, onComplete, onAbort } = args;
+
+  let lastChunkAt = options.now();
+  let watchdog: ReturnType<typeof setTimeout> | null = null;
+  let chunkCount = 0;
+  let totalBytes = 0;
+
+  const armWatchdog = () => {
+    if (watchdog) clearTimeout(watchdog);
+    watchdog = setTimeout(() => {
+      const sinceLastMs = options.now() - lastChunkAt;
+      if (sinceLastMs >= options.idleTimeoutMs) {
+        idleAbort.abort(new FetchStallError(
+          'idle-timeout',
+          `No chunk received in ${sinceLastMs}ms (threshold ${options.idleTimeoutMs}ms)`,
+        ));
+      }
+    }, options.idleTimeoutMs);
+    watchdog.unref?.();
+  };
+
+  const disarmWatchdog = () => {
+    if (watchdog) {
+      clearTimeout(watchdog);
+      watchdog = null;
+    }
+  };
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const reader = body.getReader();
+      // Forward any abort source (idle watchdog, total-timeout, caller
+      // signal) to the inner reader. Without this, `reader.read()` blocks
+      // indefinitely while the upstream sends nothing, even after our
+      // own watchdog has set `idleAbort` — the reader doesn't observe
+      // signals on its own. Cancelling the reader causes the pending
+      // read promise to reject with the supplied reason.
+      const cancelOnAbort = () => {
+        try { void reader.cancel(callerSignal.reason); } catch { /* ignore */ }
+      };
+      if (callerSignal.aborted) {
+        cancelOnAbort();
+      } else {
+        callerSignal.addEventListener('abort', cancelOnAbort, { once: true });
+      }
+
+      armWatchdog();
+      try {
+        while (true) {
+          if (callerSignal.aborted) {
+            throw callerSignal.reason ?? new Error('Aborted');
+          }
+          const { done, value } = await reader.read();
+          if (callerSignal.aborted) {
+            // Reader was cancelled mid-read. The read may return
+            // `{ done: true }` quietly when cancelled — turn that into a
+            // surfaced abort so the caller learns *why* the stream ended.
+            throw callerSignal.reason ?? new Error('Aborted');
+          }
+          if (done) break;
+          chunkCount += 1;
+          totalBytes += value.byteLength;
+          lastChunkAt = options.now();
+          armWatchdog();
+          controller.enqueue(value);
+          if (options.yieldBetweenChunks) {
+            await new Promise((resolve) => setImmediate(resolve));
+          }
+        }
+        controller.close();
+        disarmWatchdog();
+        callerSignal.removeEventListener('abort', cancelOnAbort);
+        onSettled();
+        onComplete({ chunkCount, totalBytes });
+      } catch (err) {
+        disarmWatchdog();
+        callerSignal.removeEventListener('abort', cancelOnAbort);
+        onSettled();
+        onAbort(err);
+        try { controller.error(err); } catch { /* already errored */ }
+        try { reader.releaseLock(); } catch { /* ignore */ }
+        try { await body.cancel(err); } catch { /* ignore */ }
+      }
+    },
+    cancel(reason) {
+      disarmWatchdog();
+      onSettled();
+      return body.cancel(reason);
+    },
+  });
+}
+
+function stallToLogKind(
+  kind: FetchStallError['kind'],
+): typeof LOG_KINDS.FETCH_STALL | typeof LOG_KINDS.FETCH_TIMEOUT {
+  return kind === 'idle-timeout' ? LOG_KINDS.FETCH_STALL : LOG_KINDS.FETCH_TIMEOUT;
+}
+
+function classifyStallReason(
+  err: unknown,
+  headersSignal: AbortSignal,
+  idleSignal: AbortSignal,
+  totalSignal: AbortSignal,
+  callerSignal: AbortSignal | undefined,
+): FetchStallError | undefined {
+  if (err instanceof FetchStallError) return err;
+  if (idleSignal.aborted && idleSignal.reason instanceof FetchStallError) return idleSignal.reason;
+  if (headersSignal.aborted && headersSignal.reason instanceof FetchStallError) return headersSignal.reason;
+  if (totalSignal.aborted && totalSignal.reason instanceof FetchStallError) return totalSignal.reason;
+  if (callerSignal?.aborted) return undefined;
+  return undefined;
+}
+
+function errorReason(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  try { return JSON.stringify(err); } catch { return '(unserializable)'; }
+}
+
+function extractUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return (input as Request).url;
+}
+
+/** Strip query params from URLs in logs. Provider URLs can carry tokens in
+ *  query strings — never let those land in the log file. */
+function redactUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    u.search = '';
+    return u.href;
+  } catch {
+    return url.split('?')[0] ?? url;
+  }
+}
+
+export { FetchStallError };

--- a/packages/myco/src/vault/bootstrap.ts
+++ b/packages/myco/src/vault/bootstrap.ts
@@ -14,28 +14,56 @@ import { serviceVariantToDirName } from '../service/labels.js';
  * Resolve the bootstrap vault directory for daemon startup.
  *
  * Priority:
- *  1. The cwd-walking `resolveVaultDir()` result, IF its parent contains a
- *     `project.toml`. This preserves existing behavior for daemons spawned
- *     from a project directory (lazy spawn via `ensureRunning`).
- *  2. The first registered project in a Grove matching the current service
- *     variant (`MYCO_SERVICE_VARIANT` env var). Dev variant scans for a
- *     Grove with `served_by = "service-dev"`; prod variant (or unset) uses
- *     the default Grove from the registry.
+ *  1. **When `MYCO_SERVICE_VARIANT` is set** (i.e. the daemon is under a
+ *     service supervisor — launchd, systemd — with a known variant), use
+ *     the variant-aware registry path **first**. The cwd at spawn time is
+ *     irrelevant: we already know which Grove this daemon serves.
+ *
+ *     This guards against a previously-observed failure: a lazy-spawn
+ *     triggered by a hook or MCP tool whose cwd is inside an unrelated
+ *     project would bootstrap the daemon to that project's vault — even
+ *     if that project's Grove is served by a *different* variant. The
+ *     dashboard then refuses every request with "Cross-Grove access is
+ *     forbidden" (API 500). Before this guard, the only thing that hid
+ *     the race was the daemon's 87-second shutdown latency; once that
+ *     was fixed, the wrong-cwd respawn won the port consistently.
+ *
+ *  2. The cwd-walking `resolveVaultDir()` result, IF its parent contains
+ *     a `project.toml`. Preserves the existing behavior for variant-less
+ *     ad-hoc invocations (lazy spawn via `ensureRunning`, `myco daemon`
+ *     run by hand from a project directory).
+ *
+ *  3. The first registered project in a Grove matching the current
+ *     service variant. Dev variant scans for a Grove with
+ *     `served_by = "service-dev"`; prod variant (or unset) uses the
+ *     default Grove from the registry.
  *
  * Throws if neither path yields a vault dir (no enclosing project AND no
  * Grove with at least one registered project). The error message instructs
  * the user to run `myco init` from a project directory.
  */
 export function resolveBootstrapVaultDir(cwd: string = process.cwd()): string {
+  const variant = process.env.MYCO_SERVICE_VARIANT?.trim();
   const cwdVault = resolveVaultDir(cwd);
+
+  // Variant-pinned daemons trust their variant, not their cwd.
+  if (variant) {
+    const fromRegistry = firstProjectVaultFromRegistry();
+    if (fromRegistry) return fromRegistry;
+    throw new Error(
+      `Daemon bootstrap failed (variant="${variant}"): no projects registered in a Grove served_by="${variant === 'dev' ? SERVICE_DEV_DIRNAME : SERVICE_DIRNAME}". `
+      + `Run \`myco init\` from a project directory first.`,
+    );
+  }
+
+  // Variant-less: original cwd-walk-first behavior.
   if (hasProjectManifest(cwdVault)) return cwdVault;
 
   const fromRegistry = firstProjectVaultFromRegistry();
   if (fromRegistry) return fromRegistry;
 
-  const variant = process.env.MYCO_SERVICE_VARIANT?.trim() || 'prod';
   throw new Error(
-    `Daemon bootstrap failed: no enclosing project at ${cwdVault}, and no projects registered in a Grove served_by="${variant === 'dev' ? SERVICE_DEV_DIRNAME : SERVICE_DIRNAME}". `
+    `Daemon bootstrap failed: no enclosing project at ${cwdVault}, and no projects registered in the default Grove (served_by="${SERVICE_DIRNAME}"). `
     + `Run \`myco init\` from a project directory first.`,
   );
 }

--- a/tests/cli/service.test.ts
+++ b/tests/cli/service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { parseServiceArgs } from '../../packages/myco/src/cli/service';
+import { parseServiceArgs, assertSafeServiceMutation } from '../../packages/myco/src/cli/service';
 
 describe('parseServiceArgs', () => {
   test('install (no flags) → variant=prod', () => {
@@ -32,5 +32,38 @@ describe('parseServiceArgs', () => {
 
   test('rejects missing action', () => {
     expect(() => parseServiceArgs([])).toThrow(/usage/i);
+  });
+});
+
+// Regression: the dev daemon was once allowed to manage the prod plist,
+// which produced a multi-minute prod outage when the dev binary's plist
+// format diverged from the installed prod binary's. The fence below
+// makes that path unreachable at the CLI boundary.
+describe('assertSafeServiceMutation (prod-from-dev-binary fence)', () => {
+  const devBuildPath = '/Users/dev/repos/myco/packages/myco/vendor/darwin-arm64/myco';
+  const globalPath = '/opt/homebrew/lib/node_modules/@goondocks/myco/vendor/darwin-arm64/myco';
+
+  test('refuses every mutating verb against prod when run from a dev-build binary', () => {
+    for (const action of ['install', 'uninstall', 'start', 'stop', 'restart'] as const) {
+      const refusal = assertSafeServiceMutation({ action, variant: 'prod' }, devBuildPath);
+      expect(refusal).not.toBeNull();
+      expect(refusal!).toMatch(/Refusing to .* the \*prod\* service from a dev-build binary/);
+    }
+  });
+
+  test('allows status against prod even from a dev-build binary (read-only)', () => {
+    expect(assertSafeServiceMutation({ action: 'status', variant: 'prod' }, devBuildPath)).toBeNull();
+  });
+
+  test('allows all actions against dev variant from a dev-build binary', () => {
+    for (const action of ['install', 'uninstall', 'start', 'stop', 'restart', 'status'] as const) {
+      expect(assertSafeServiceMutation({ action, variant: 'dev' }, devBuildPath)).toBeNull();
+    }
+  });
+
+  test('allows all actions against prod variant from the globally installed binary', () => {
+    for (const action of ['install', 'uninstall', 'start', 'stop', 'restart', 'status'] as const) {
+      expect(assertSafeServiceMutation({ action, variant: 'prod' }, globalPath)).toBeNull();
+    }
   });
 });

--- a/tests/daemon/agent-loop-responsiveness.test.ts
+++ b/tests/daemon/agent-loop-responsiveness.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Regression test: a stuck/slow streaming upstream consumed by the
+ * instrumented fetch wrapper does not pin the event loop. `/health`
+ * remains responsive throughout — the property a worker_threads
+ * isolation would also guarantee, but here enforced via the wrapper's
+ * per-chunk `setImmediate` yields plus the no-progress watchdog.
+ *
+ * Reproduces (in miniature) the failure mode that motivated the work:
+ * canopy-describe drove gpt-oss-20b via LMStudio, the response stream
+ * misbehaved, and the daemon's HTTP listener stopped accepting
+ * connections for >60s. With the wrapper + yields in place, /health
+ * answers in milliseconds even while many chunks are flowing.
+ */
+
+import { describe, it, expect, afterEach } from 'bun:test';
+import http from 'node:http';
+import { vi } from '../helpers/vi-shim.js';
+import { createInstrumentedFetch } from '@myco/utils/instrumented-fetch.js';
+import { EventLoopLagProbe } from '@myco/daemon/event-loop-lag.js';
+
+interface RunningServer {
+  port: number;
+  close: () => Promise<void>;
+}
+
+async function startHealthServer(): Promise<RunningServer> {
+  // Mirror the daemon's raw-route fast path: a tiny GET /health handler
+  // that does no DB work, no AsyncLocalStorage, just answers JSON.
+  const server = http.createServer((req, res) => {
+    if (req.method === 'GET' && req.url === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, ts: Date.now() }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address() as { port: number };
+  return {
+    port: address.port,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+async function timedHealthCheck(port: number): Promise<number> {
+  const start = Date.now();
+  const res = await fetch(`http://127.0.0.1:${port}/health`);
+  await res.text();
+  return Date.now() - start;
+}
+
+function buildSlowChunkStream(opts: {
+  chunkCount: number;
+  chunkSizeBytes: number;
+  intraChunkDelayMs: number;
+}): ReadableStream<Uint8Array> {
+  const payload = new Uint8Array(opts.chunkSizeBytes).fill(0x78); // 'x'
+  return new ReadableStream({
+    async start(controller) {
+      for (let i = 0; i < opts.chunkCount; i += 1) {
+        controller.enqueue(payload);
+        if (opts.intraChunkDelayMs > 0) {
+          await new Promise((r) => setTimeout(r, opts.intraChunkDelayMs));
+        }
+      }
+      controller.close();
+    },
+  });
+}
+
+describe('agent loop responsiveness regression', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('keeps /health latency low while a slow stream is being consumed', async () => {
+    const server = await startHealthServer();
+    // Capture the original loopback-capable fetch BEFORE stubbing the
+    // global one, so /health probes don't get routed through the
+    // upstream-simulating stub below.
+    const realFetch = globalThis.fetch.bind(globalThis);
+    try {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+          const urlStr = typeof url === 'string' ? url : url.toString();
+          if (urlStr.includes('/api/echo')) {
+            return new Response(
+              buildSlowChunkStream({ chunkCount: 60, chunkSizeBytes: 4096, intraChunkDelayMs: 8 }),
+              { status: 200 },
+            );
+          }
+          return realFetch(url, init);
+        }),
+      );
+
+      const instrumented = createInstrumentedFetch({
+        component: 'test.regression',
+        responseHeadersTimeoutMs: 5_000,
+        idleTimeoutMs: 5_000,
+      });
+
+      let consumeDone = false;
+      const consumeStream = (async () => {
+        const response = await instrumented('http://upstream.test/api/echo');
+        await response.text();
+      })().finally(() => {
+        consumeDone = true;
+      });
+
+      const latencies: number[] = [];
+      const probeTask = (async () => {
+        while (!consumeDone) {
+          try {
+            const url = `http://127.0.0.1:${server.port}/health`;
+            const start = Date.now();
+            const res = await realFetch(url);
+            await res.text();
+            latencies.push(Date.now() - start);
+          } catch {
+            break;
+          }
+          await new Promise((r) => setTimeout(r, 25));
+        }
+      })();
+
+      await consumeStream;
+      await probeTask;
+
+      expect(latencies.length).toBeGreaterThan(5);
+      const max = Math.max(...latencies);
+      expect(max).toBeLessThan(200);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('lag probe records a stall when consumption is artificially synchronous', async () => {
+    const logs: Array<{ kind: string; data?: Record<string, unknown> }> = [];
+    const logger: any = {
+      debug: () => {},
+      info: () => {},
+      warn: (kind: string, _msg: string, data?: Record<string, unknown>) => {
+        logs.push({ kind, data });
+      },
+      error: () => {},
+    };
+    const probe = new EventLoopLagProbe(logger, {
+      sampleIntervalMs: 30,
+      warnThresholdMs: 120,
+    });
+    probe.start();
+    await new Promise((r) => setTimeout(r, 60));
+    // Synchronous busy-wait — what a stalled sync bun:sqlite call would
+    // do to the loop. The probe must see and report this.
+    const deadline = Date.now() + 250;
+    while (Date.now() < deadline) { /* spin */ }
+    await new Promise((r) => setTimeout(r, 100));
+    probe.stop();
+
+    const stalls = logs.filter((l) => l.kind === 'daemon.lag');
+    expect(stalls.length).toBeGreaterThanOrEqual(1);
+    expect(probe.getStats().peakLagMs).toBeGreaterThanOrEqual(120);
+  });
+});

--- a/tests/daemon/event-loop-lag.test.ts
+++ b/tests/daemon/event-loop-lag.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'bun:test';
+import { EventLoopLagProbe } from '@myco/daemon/event-loop-lag.js';
+import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+
+interface LogCall {
+  level: 'warn' | 'debug' | 'info' | 'error';
+  kind: string;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+function captureLogger(): { logs: LogCall[]; logger: any } {
+  const logs: LogCall[] = [];
+  const push = (level: LogCall['level']) =>
+    (kind: string, message: string, data?: Record<string, unknown>) => {
+      logs.push({ level, kind, message, data });
+    };
+  return {
+    logs,
+    logger: {
+      debug: push('debug'),
+      info: push('info'),
+      warn: push('warn'),
+      error: push('error'),
+    },
+  };
+}
+
+function blockSync(ms: number): void {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    // busy-wait — synchronously holds the event loop the way a sync
+    // bun:sqlite query or a JSON.parse on a large buffer would.
+  }
+}
+
+const FAST_INTERVAL = 25;
+const ABOVE_INTERVAL = FAST_INTERVAL + 10;
+
+describe('EventLoopLagProbe', () => {
+  it('does not emit when the loop is responsive', async () => {
+    const { logs, logger } = captureLogger();
+    const probe = new EventLoopLagProbe(logger, {
+      sampleIntervalMs: FAST_INTERVAL,
+      warnThresholdMs: 200,
+    });
+    probe.start();
+    await new Promise((r) => setTimeout(r, FAST_INTERVAL * 5));
+    probe.stop();
+
+    const lagWarns = logs.filter((entry) => entry.kind === LOG_KINDS.DAEMON_LAG);
+    expect(lagWarns.length).toBe(0);
+  });
+
+  it('emits a warning when the loop is blocked past the threshold', async () => {
+    const { logs, logger } = captureLogger();
+    const probe = new EventLoopLagProbe(logger, {
+      sampleIntervalMs: FAST_INTERVAL,
+      warnThresholdMs: 100,
+    });
+    probe.start();
+
+    // Let the probe take one clean sample, then pin the loop for ~300ms.
+    await new Promise((r) => setTimeout(r, ABOVE_INTERVAL));
+    blockSync(300);
+    await new Promise((r) => setTimeout(r, FAST_INTERVAL * 3));
+    probe.stop();
+
+    const lagWarns = logs.filter((entry) => entry.kind === LOG_KINDS.DAEMON_LAG);
+    expect(lagWarns.length).toBeGreaterThanOrEqual(1);
+    const observedLag = lagWarns[0].data?.lagMs as number;
+    expect(observedLag).toBeGreaterThanOrEqual(100);
+    expect(probe.getStats().peakLagMs).toBeGreaterThanOrEqual(observedLag);
+    expect(probe.getStats().stallCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('stop() halts further samples', async () => {
+    const { logs, logger } = captureLogger();
+    const probe = new EventLoopLagProbe(logger, {
+      sampleIntervalMs: FAST_INTERVAL,
+      warnThresholdMs: 50,
+    });
+    probe.start();
+    await new Promise((r) => setTimeout(r, ABOVE_INTERVAL));
+    probe.stop();
+    const lagWarnsAtStop = logs.filter((entry) => entry.kind === LOG_KINDS.DAEMON_LAG).length;
+
+    // Block well past the threshold; if stop() worked, no further warns fire.
+    blockSync(200);
+    await new Promise((r) => setTimeout(r, FAST_INTERVAL * 3));
+
+    const lagWarnsAfter = logs.filter((entry) => entry.kind === LOG_KINDS.DAEMON_LAG).length;
+    expect(lagWarnsAfter).toBe(lagWarnsAtStop);
+  });
+});

--- a/tests/daemon/graceful-shutdown.test.ts
+++ b/tests/daemon/graceful-shutdown.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression test: `http.Server.close()` blocks on any open connection
+ * until the *client* disconnects — keep-alives and WebSocket upgrades
+ * can hold a Node HTTP server open for ~90s after we asked it to stop.
+ * Live dogfood reproduction: every dev daemon restart appeared
+ * "broken" for ~87s because the old daemon's HTTP server was waiting
+ * on UI keep-alives + MCP bridge sockets to time out from the client
+ * side.
+ *
+ * `gracefullyCloseHttpServer` forces the issue: drop idle keep-alives
+ * immediately, then yank anything still hanging on after the grace
+ * window. This test pins both behaviors with real sockets so a
+ * regression on either step (e.g. dropping the closeAllConnections
+ * call, or relying on a long grace) shows up in CI.
+ */
+
+import { describe, it, expect, afterEach } from 'bun:test';
+import http from 'node:http';
+import { gracefullyCloseHttpServer } from '@myco/daemon/server.js';
+
+interface RunningServer {
+  port: number;
+  server: http.Server;
+  hung?: HungSignal;
+}
+
+interface HungSignal {
+  arrived: Promise<void>;
+}
+
+async function startServer(): Promise<RunningServer & { hung: HungSignal }> {
+  let signalArrived!: () => void;
+  const arrived = new Promise<void>((resolve) => {
+    signalArrived = resolve;
+  });
+
+  const server = http.createServer((req, res) => {
+    if (req.url === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+    if (req.url === '/long-poll') {
+      // Hold the response open until the client disconnects. Models
+      // an SSE / long-poll endpoint that the old daemon's UI uses.
+      // Signal the test as soon as the server has the request in hand
+      // so we don't race on `setTimeout`-based settling.
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      signalArrived();
+      // Never write more; never end. Force-close should still kill it.
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  // Default keep-alive timeout is 5s. Bump up so the OS doesn't help us
+  // by closing keep-alives on its own — we want to prove the fast-
+  // shutdown helper is doing the work.
+  server.keepAliveTimeout = 60_000;
+  server.headersTimeout = 65_000;
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address() as { port: number };
+  return { server, port: address.port, hung: { arrived } };
+}
+
+describe('gracefullyCloseHttpServer', () => {
+  let running: RunningServer | null = null;
+
+  afterEach(async () => {
+    if (running && running.server.listening) {
+      await new Promise<void>((resolve) => running!.server.close(() => resolve()));
+    }
+    running = null;
+  });
+
+  it('resolves quickly with no open connections', async () => {
+    running = await startServer();
+    const start = Date.now();
+    await gracefullyCloseHttpServer(running.server, { gracePeriodMs: 1_000 });
+    expect(Date.now() - start).toBeLessThan(500);
+    expect(running.server.listening).toBe(false);
+  });
+
+  it('drops idle keep-alives without waiting for them to time out', async () => {
+    running = await startServer();
+    // Open a keep-alive socket and complete one request so the
+    // connection lingers as idle keep-alive.
+    const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
+    await new Promise<void>((resolve, reject) => {
+      const req = http.request(
+        { host: '127.0.0.1', port: running!.port, path: '/health', agent },
+        (res) => {
+          res.on('data', () => {});
+          res.on('end', resolve);
+          res.on('error', reject);
+        },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+
+    const start = Date.now();
+    await gracefullyCloseHttpServer(running.server, { gracePeriodMs: 1_000 });
+    const elapsed = Date.now() - start;
+    agent.destroy();
+    // Without closeIdleConnections this would wait for the agent's
+    // keep-alive timeout (default 5s, raised to 60s above).
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it('force-closes hung connections after the grace window', async () => {
+    running = await startServer();
+    const agent = new http.Agent({ keepAlive: true });
+    // Fire-and-forget request to /long-poll — the server-side handler
+    // never calls `res.end()`. We do NOT await any client-side
+    // completion event: we wait on the server's `hung.arrived` signal
+    // (resolved inside the request handler) so we know the connection
+    // is registered with the server before we ask it to shut down.
+    const req = http.request({
+      host: '127.0.0.1',
+      port: running.port,
+      path: '/long-poll',
+      agent,
+    });
+    req.on('error', () => { /* expected when the socket is force-closed */ });
+    req.end();
+    await running.hung!.arrived;
+
+    const start = Date.now();
+    await gracefullyCloseHttpServer(running.server, { gracePeriodMs: 200 });
+    const elapsed = Date.now() - start;
+    agent.destroy();
+    // close() must complete just after the force-close grace window —
+    // not wait indefinitely for the dangling /long-poll socket.
+    expect(elapsed).toBeGreaterThanOrEqual(200);
+    expect(elapsed).toBeLessThan(1_500);
+  });
+});

--- a/tests/daemon/http-server-limits.test.ts
+++ b/tests/daemon/http-server-limits.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Regression test: the daemon's HTTP server stays responsive under a
+ * burst of concurrent localhost connections. Without protective
+ * limits + an explicit listen backlog, Node's defaults let 250+
+ * concurrent `/health` probes pile up CLOSE_WAIT sockets faster than
+ * the daemon could drain — exhausting the launchd-capped fd table
+ * (256 NOFILE on macOS) and triggering EMFILE on `accept()`. New
+ * clients then couldn't even complete the TCP handshake (SYN_SENT).
+ *
+ * The smoke we ran on the live dev daemon caught this exact failure
+ * mode at 250 connections. With `applyDaemonHttpServerLimits` + the
+ * explicit listen backlog from `DAEMON_HTTP_LISTEN_BACKLOG`, the
+ * server now drains bursts cleanly.
+ *
+ * What this test does NOT cover: the launchd `SoftResourceLimits` /
+ * systemd `LimitNOFILE` raises (those live in the plist/unit
+ * generators and are covered by tests/service/*). This file proves
+ * the Node-level config side of the fix.
+ */
+
+import { describe, expect, test, afterEach } from 'bun:test';
+import http from 'node:http';
+import {
+  applyDaemonHttpServerLimits,
+  DAEMON_HTTP_LISTEN_BACKLOG,
+} from '@myco/daemon/server.js';
+
+interface RunningServer {
+  port: number;
+  server: http.Server;
+}
+
+async function startServer(): Promise<RunningServer> {
+  const server = http.createServer((req, res) => {
+    if (req.url === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  applyDaemonHttpServerLimits(server);
+  await new Promise<void>((resolve) =>
+    server.listen(0, '127.0.0.1', DAEMON_HTTP_LISTEN_BACKLOG, resolve),
+  );
+  const address = server.address() as { port: number };
+  return { server, port: address.port };
+}
+
+describe('applyDaemonHttpServerLimits', () => {
+  let running: RunningServer | null = null;
+
+  afterEach(async () => {
+    if (running && running.server.listening) {
+      running.server.closeAllConnections?.();
+      await new Promise<void>((resolve) => running!.server.close(() => resolve()));
+    }
+    running = null;
+  });
+
+  test('sets a short keep-alive timeout', async () => {
+    running = await startServer();
+    expect(running.server.keepAliveTimeout).toBeLessThanOrEqual(5_000);
+  });
+
+  test('sets a tight headers timeout (well below the 60s Node default)', async () => {
+    running = await startServer();
+    expect(running.server.headersTimeout).toBeLessThanOrEqual(10_000);
+  });
+
+  test('caps maxRequestsPerSocket so one client cannot monopolize a socket forever', async () => {
+    running = await startServer();
+    const cap = running.server.maxRequestsPerSocket ?? 0;
+    expect(cap).toBeGreaterThan(0);
+    expect(cap).toBeLessThan(Number.MAX_SAFE_INTEGER);
+  });
+
+  test('explicit listen backlog is high enough for a localhost burst', () => {
+    // 4096 is well above macOS's typical `kern.ipc.somaxconn` cap (often
+    // 128) — so even when the kernel applies its own cap, we're at least
+    // requesting more than Node's silent default.
+    expect(DAEMON_HTTP_LISTEN_BACKLOG).toBeGreaterThanOrEqual(1024);
+  });
+
+  test('drains a burst of 200 concurrent /health probes without errors', async () => {
+    running = await startServer();
+    const url = `http://127.0.0.1:${running.port}/health`;
+    const start = Date.now();
+    const results = await Promise.allSettled(
+      Array.from({ length: 200 }, async () => {
+        const res = await fetch(url);
+        // body must be consumed for the socket to release in keep-alive
+        // mode — uncomsumed bodies leave the connection hot.
+        await res.text();
+        return res.status;
+      }),
+    );
+    const elapsed = Date.now() - start;
+    const fulfilled = results.filter((r) => r.status === 'fulfilled') as Array<PromiseFulfilledResult<number>>;
+    const rejected = results.filter((r) => r.status === 'rejected');
+
+    expect(rejected.length).toBe(0);
+    expect(fulfilled.length).toBe(200);
+    expect(fulfilled.every((r) => r.value === 200)).toBe(true);
+    // 200 sub-millisecond responses on loopback should resolve in well
+    // under a second, even on a busy CI box.
+    expect(elapsed).toBeLessThan(5_000);
+  });
+});

--- a/tests/service/launchd-plist.test.ts
+++ b/tests/service/launchd-plist.test.ts
@@ -61,4 +61,20 @@ describe('renderLaunchdPlist', () => {
     const plist = renderLaunchdPlist({ ...baseSpec, keepAlive: false });
     expect(plist).not.toContain('<key>KeepAlive</key>');
   });
+
+  test('raises NumberOfFiles past the launchd-session default of 256', () => {
+    // launchd inherits the user session's `maxfiles` ceiling, which on
+    // macOS is typically 256. A burst of concurrent HTTP connections
+    // hits that ceiling and starts returning EMFILE on accept(). The
+    // plist must override it on both Soft and Hard limits so the
+    // daemon's fd table actually opens up.
+    const plist = renderLaunchdPlist(baseSpec);
+    expect(plist).toContain('<key>SoftResourceLimits</key>');
+    expect(plist).toContain('<key>HardResourceLimits</key>');
+    expect(plist).toContain('<key>NumberOfFiles</key>');
+    // The exact value isn't load-bearing, but it must be well above 256.
+    const match = plist.match(/<key>NumberOfFiles<\/key>\s*<integer>(\d+)<\/integer>/);
+    expect(match).not.toBeNull();
+    expect(Number(match![1])).toBeGreaterThan(10_000);
+  });
 });

--- a/tests/service/spec-builder.test.ts
+++ b/tests/service/spec-builder.test.ts
@@ -76,4 +76,78 @@ describe('buildServiceSpec', () => {
       expect(() => buildServiceSpec({ variant: 'prod', mycoHome: home, executable: exe })).toThrow(/script-runner|standalone daemon binary/);
     }
   });
+
+  // Regression: the prod plist was once written with a dev-build path,
+  // after which launchd spawned the dev binary as the prod service —
+  // running unreleased code against the prod Grove. The guard must
+  // refuse the substitution regardless of which caller invoked us.
+  test('refuses prod variant when executable is a dev-build path', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-home-'));
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-repo-'));
+    const vendorDir = path.join(repoRoot, 'packages', 'myco', 'vendor', 'darwin-arm64');
+    fs.mkdirSync(vendorDir, { recursive: true });
+    const devBin = path.join(vendorDir, 'myco');
+    fs.writeFileSync(devBin, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+
+    expect(() => buildServiceSpec({
+      variant: 'prod',
+      mycoHome: home,
+      executable: devBin,
+    })).toThrow(/dev-build executable|packages\/<pkg>\/vendor/);
+  });
+
+  test('allows dev variant with a dev-build path (the legitimate dogfood case)', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-home-'));
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-repo-'));
+    const vendorDir = path.join(repoRoot, 'packages', 'myco', 'vendor', 'darwin-arm64');
+    fs.mkdirSync(vendorDir, { recursive: true });
+    const devBin = path.join(vendorDir, 'myco');
+    fs.writeFileSync(devBin, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+
+    const spec = buildServiceSpec({
+      variant: 'dev',
+      mycoHome: home,
+      executable: devBin,
+    });
+    expect(spec.executable).toBe(devBin);
+    expect(spec.variant).toBe('dev');
+  });
+
+  test('prod refuses a symlink whose realpath resolves into a vendor tree', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-home-'));
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-repo-'));
+    const vendorDir = path.join(repoRoot, 'packages', 'myco', 'vendor', 'darwin-arm64');
+    fs.mkdirSync(vendorDir, { recursive: true });
+    const realBin = path.join(vendorDir, 'myco');
+    fs.writeFileSync(realBin, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+
+    // The user installs via a symlink that lives outside vendor/.
+    const linkDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-link-'));
+    const link = path.join(linkDir, 'myco');
+    fs.symlinkSync(realBin, link);
+
+    expect(() => buildServiceSpec({
+      variant: 'prod',
+      mycoHome: home,
+      executable: link,
+    })).toThrow(/dev-build executable/);
+  });
+
+  test('prod allows a normal globally-installed path (npm-style)', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-home-'));
+    // Simulate a global install layout: no 'packages/<pkg>/vendor/' segment.
+    const globalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-global-'));
+    const vendorDir = path.join(globalDir, 'node_modules', '@goondocks', 'myco', 'vendor', 'darwin-arm64');
+    fs.mkdirSync(vendorDir, { recursive: true });
+    const bin = path.join(vendorDir, 'myco');
+    fs.writeFileSync(bin, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+
+    const spec = buildServiceSpec({
+      variant: 'prod',
+      mycoHome: home,
+      executable: bin,
+    });
+    expect(spec.variant).toBe('prod');
+    expect(spec.executable).toBe(bin);
+  });
 });

--- a/tests/service/systemd-unit.test.ts
+++ b/tests/service/systemd-unit.test.ts
@@ -56,4 +56,14 @@ describe('renderSystemdUnit', () => {
     const unit = renderSystemdUnit(baseSpec);
     expect(unit).toContain('WantedBy=default.target');
   });
+
+  test('raises LimitNOFILE past the systemd-default of 1024', () => {
+    // Most systemd distros default user-service `LimitNOFILE` to 1024.
+    // The daemon's HTTP server + SQLite handles + log streams blow past
+    // that under load. The unit file must override it.
+    const unit = renderSystemdUnit(baseSpec);
+    const match = unit.match(/^LimitNOFILE=(\d+)/m);
+    expect(match).not.toBeNull();
+    expect(Number(match![1])).toBeGreaterThan(10_000);
+  });
 });

--- a/tests/utils/instrumented-fetch.test.ts
+++ b/tests/utils/instrumented-fetch.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { vi } from '../helpers/vi-shim.js';
+import {
+  createInstrumentedFetch,
+  FetchStallError,
+} from '@myco/utils/instrumented-fetch.js';
+import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+
+interface LogCall {
+  level: 'warn' | 'debug' | 'info' | 'error';
+  kind: string;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+function captureLogger(): { logs: LogCall[]; logger: any } {
+  const logs: LogCall[] = [];
+  const push = (level: LogCall['level']) =>
+    (kind: string, message: string, data?: Record<string, unknown>) => {
+      logs.push({ level, kind, message, data });
+    };
+  return {
+    logs,
+    logger: {
+      debug: push('debug'),
+      info: push('info'),
+      warn: push('warn'),
+      error: push('error'),
+    },
+  };
+}
+
+function buildChunkedResponse(chunks: Uint8Array[], status = 200): Response {
+  const body = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, { status });
+}
+
+function buildStallingHeadersResponse(): Promise<Response> {
+  // Never resolves; the wrapper's response-headers timeout must catch it.
+  return new Promise(() => {});
+}
+
+function buildIdleStreamResponse(idleAfterChunkMs: number): Response {
+  const body = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      controller.enqueue(new TextEncoder().encode('first'));
+      // Then go silent — never closes, never enqueues. The wrapper's
+      // idle watchdog must abort.
+      await new Promise((r) => setTimeout(r, idleAfterChunkMs));
+    },
+  });
+  return new Response(body, { status: 200 });
+}
+
+describe('createInstrumentedFetch', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('logs start + complete with chunk stats on a normal response', async () => {
+    const { logs, logger } = captureLogger();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        buildChunkedResponse([
+          new TextEncoder().encode('hello '),
+          new TextEncoder().encode('world'),
+        ]),
+      ),
+    );
+
+    const fetchFn = createInstrumentedFetch({ component: 'test.basic', logger });
+    const response = await fetchFn('http://example.test/api/echo');
+    const text = await response.text();
+    expect(text).toBe('hello world');
+
+    const starts = logs.filter((l) => l.kind === LOG_KINDS.FETCH_START);
+    const completes = logs.filter((l) => l.kind === LOG_KINDS.FETCH_COMPLETE);
+    expect(starts.length).toBe(1);
+    expect(completes.length).toBe(1);
+    expect(completes[0].data?.chunkCount).toBe(2);
+    expect(completes[0].data?.totalBytes).toBe(11);
+    expect(completes[0].data?.status).toBe(200);
+  });
+
+  it('aborts with FetchStallError when response headers never arrive', async () => {
+    const { logs, logger } = captureLogger();
+    vi.stubGlobal('fetch', vi.fn(async (_input: unknown, init?: RequestInit) =>
+      new Promise<Response>((_, reject) => {
+        // Honor the composed AbortSignal so the underlying fetch
+        // rejects when the wrapper aborts — what real undici does.
+        init?.signal?.addEventListener('abort', () => {
+          reject(init.signal!.reason);
+        });
+      }),
+    ));
+
+    const fetchFn = createInstrumentedFetch({
+      component: 'test.headers',
+      logger,
+      responseHeadersTimeoutMs: 50,
+    });
+
+    let caught: unknown;
+    try {
+      await fetchFn('http://example.test/api/slow');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FetchStallError);
+    expect((caught as FetchStallError).kind).toBe('response-headers-timeout');
+
+    const timeoutLogs = logs.filter((l) => l.kind === LOG_KINDS.FETCH_TIMEOUT);
+    expect(timeoutLogs.length).toBe(1);
+  });
+
+  it('aborts mid-stream when chunks stop arriving past idleTimeoutMs', async () => {
+    const { logs, logger } = captureLogger();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => buildIdleStreamResponse(5_000)),
+    );
+
+    const fetchFn = createInstrumentedFetch({
+      component: 'test.idle',
+      logger,
+      idleTimeoutMs: 60,
+    });
+    const response = await fetchFn('http://example.test/api/drip');
+
+    let caught: unknown;
+    try {
+      await response.text();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FetchStallError);
+    expect((caught as FetchStallError).kind).toBe('idle-timeout');
+
+    const stalls = logs.filter((l) => l.kind === LOG_KINDS.FETCH_STALL);
+    expect(stalls.length).toBe(1);
+  });
+
+  it('honors the caller-supplied AbortSignal without misclassifying as stall', async () => {
+    const { logs, logger } = captureLogger();
+    vi.stubGlobal('fetch', vi.fn(async (_input: unknown, init?: RequestInit) =>
+      new Promise<Response>((_, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(init.signal!.reason);
+        });
+      }),
+    ));
+
+    const fetchFn = createInstrumentedFetch({ component: 'test.caller-abort', logger });
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(new Error('caller aborted')), 30);
+
+    let caught: unknown;
+    try {
+      await fetchFn('http://example.test/api/x', { signal: controller.signal });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).not.toBeInstanceOf(FetchStallError);
+
+    // No spurious stall/timeout warns when the caller aborted.
+    const wronglyClassified = logs.filter(
+      (l) => l.kind === LOG_KINDS.FETCH_STALL || l.kind === LOG_KINDS.FETCH_TIMEOUT,
+    );
+    expect(wronglyClassified.length).toBe(0);
+  });
+
+  it('reports per-chunk stats matching what the wrapper observed', async () => {
+    const { logs, logger } = captureLogger();
+    const chunkCount = 8;
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (let i = 0; i < chunkCount; i += 1) {
+            controller.enqueue(new TextEncoder().encode('xxx'));
+          }
+          controller.close();
+        },
+      });
+      return new Response(body, { status: 200 });
+    }));
+
+    const fetchFn = createInstrumentedFetch({ component: 'test.stats', logger });
+    const response = await fetchFn('http://example.test/api/burst');
+    await response.text();
+
+    const completes = logs.filter((l) => l.kind === LOG_KINDS.FETCH_COMPLETE);
+    expect(completes.length).toBe(1);
+    expect(completes[0].data?.chunkCount).toBe(chunkCount);
+    expect(completes[0].data?.totalBytes).toBe(chunkCount * 3);
+  });
+});

--- a/tests/vault/bootstrap.test.ts
+++ b/tests/vault/bootstrap.test.ts
@@ -138,4 +138,50 @@ describe('resolveBootstrapVaultDir', () => {
       delete process.env.MYCO_SERVICE_VARIANT;
     }
   });
+
+  test('variant-pinned dev daemon ignores cwd inside a prod-grove project', () => {
+    // The regression: a hook running inside /Users/x/unifi-mcp lazy-spawns
+    // the dev daemon. cwd-walk would resolve to unifi-mcp's vault, but
+    // unifi-mcp belongs to the prod Grove. The dashboard then refuses
+    // every cross-Grove request. The fix: when the variant env is set,
+    // the cwd is ignored — the variant pins us to its own Grove.
+    const prodGrove = 'grove_ffffffffffffffffffffffffffffffff';
+    const devGrove = 'grove_99999999999999999999999999999999';
+    const prodRoot = makeProject('prod-cwd');
+    const devRoot = makeProject('dev-target');
+    writeRegistry(prodGrove);
+    writeGroveToml(prodGrove, 'service');
+    writeGroveToml(devGrove, 'service-dev');
+    writeProjectsToml(prodGrove, [{ id: 'proj_prod', root: prodRoot }]);
+    writeProjectsToml(devGrove, [{ id: 'proj_dev', root: devRoot }]);
+
+    process.env.MYCO_SERVICE_VARIANT = 'dev';
+    try {
+      // cwd is inside the prod-grove project — but we are the dev daemon.
+      expect(resolveBootstrapVaultDir(prodRoot)).toBe(path.join(devRoot, '.myco'));
+    } finally {
+      delete process.env.MYCO_SERVICE_VARIANT;
+    }
+  });
+
+  test('variant-pinned prod daemon ignores cwd inside a dev-grove project', () => {
+    // Symmetric: the prod daemon shouldn't be hijacked by a cwd that
+    // happens to fall inside the dogfood project either.
+    const prodGrove = 'grove_88888888888888888888888888888888';
+    const devGrove = 'grove_77777777777777777777777777777777';
+    const prodRoot = makeProject('prod-target');
+    const devRoot = makeProject('dev-cwd');
+    writeRegistry(prodGrove);
+    writeGroveToml(prodGrove, 'service');
+    writeGroveToml(devGrove, 'service-dev');
+    writeProjectsToml(prodGrove, [{ id: 'proj_prod', root: prodRoot }]);
+    writeProjectsToml(devGrove, [{ id: 'proj_dev', root: devRoot }]);
+
+    process.env.MYCO_SERVICE_VARIANT = 'prod';
+    try {
+      expect(resolveBootstrapVaultDir(devRoot)).toBe(path.join(prodRoot, '.myco'));
+    } finally {
+      delete process.env.MYCO_SERVICE_VARIANT;
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Six commits, all motivated by a live dogfood failure: an over-pressured canopy-describe run pinned the daemon's main event loop for >60 seconds, with `/health` returning HTTP 000 and `power.tick` silent. Every commit traces to a finding from smoke-testing the previous one on the live dev daemon.

## What changed

| Commit | Theme | Key shapes |
|---|---|---|
| `8864520f` | Loop responsiveness | Always-on `EventLoopLagProbe` (chained setTimeout, `performance.now()`). Cross-provider `createInstrumentedFetch`: bounded response-headers timeout, no-progress idle watchdog (cancels the inner reader on abort — bun's `reader.read()` doesn't observe AbortSignals), per-chunk `setImmediate` yields, structured `fetch.start`/`fetch.complete`/`fetch.timeout`/`fetch.stall`/`fetch.abort` logs with redacted URLs + chunk stats. Wired into OpenAI Agents harness (90s/45s) and `LmStudioBackend` (60s/30s). Yield points in `phase-loop.ts` between waves and `openai-local-mcp.ts callTool`. |
| `0c93a496` | Fast shutdown | `gracefullyCloseHttpServer` helper: `closeIdleConnections()` immediately, force-close grace window (2s), resolve on whichever signal fires first (bun's `close()` callback isn't reliable after `closeAllConnections`). Restart wall-clock: 87s → ~4ms. |
| `99699245` | Honest lag probe | `performance.now()` instead of `Date.now()` so macOS lid-close / display-sleep doesn't surface as multi-minute false "lag". Live dogfood proof: probe reported 275s and 329s "lags" until this fix. |
| `7ab36f4b` | Localhost bursts work | Service installers (launchd plist + systemd unit) raise `NumberOfFiles` / `LimitNOFILE` past the 256 / 1024 distro defaults. HTTP server gets `keepAliveTimeout=5s`, `headersTimeout=10s`, `maxRequestsPerSocket=1000`, and explicit `4096` listen backlog. 5000 concurrent `/health` probes → p99 24ms, 0 failures. |
| `fb995473` | Variant integrity | `resolveBootstrapVaultDir` skips cwd-walk when `MYCO_SERVICE_VARIANT` is set. Stops a dev daemon spawned from a prod-grove cwd from bootstrapping to the wrong vault. (Pre-existing race, unmasked by the fast-shutdown fix.) |
| `9fdffc72` | Prod-clobber fence | Two-layer defense: `buildServiceSpec` refuses prod variant with dev-build executables (matches `packages/<pkg>/vendor/`, follows realpath). CLI fence refuses every mutating verb against prod from a dev-build binary. `status` (read-only) still allowed. |

## Live smoke test results (dev daemon)

| Property | Result |
|---|---|
| `/health` p99 under 5000-concurrent burst | **24ms** (max 37ms, 0 failures) |
| 1000-concurrent burst p99 | **12ms** (max 16ms, 0 failures) |
| Daemon restart wall-clock | **~4ms shutdown** (was 87s) |
| Lag probe false-positive rate | **0** (vs. 4 multi-minute false reports before the clock fix) |
| Mid-burst daemon swap survivability | Zero failed requests during a forced PID swap mid-storm |
| Prod-clobber fence | `service install` from dev binary refused, exit 1, prod plist shasum unchanged |

## What this PR deliberately does NOT include

- **Worker-thread isolation of agent execution.** This PR enforces responsiveness via discipline (`setImmediate` yields + always-on lag probe). The structural answer — physically isolating agent runs in a `node:worker_threads` worker with its own SQLite handle and message-pass log routing — is captured as a separate follow-up plan (saved in Myco as `66f6da5b3ca2ed9f`). Bigger design space, deserves its own PR.
- **Forensic investigation into the original prod-plist clobber** at 22:48 UTC during dogfood. With the fence in `9fdffc72` it's no longer reachable; understanding the original trigger is now a non-blocking organizational exercise.
- **Backporting the HTTP server limits / fast shutdown to the running prod 0.27.6 daemon.** That requires a release cut. Until then, the prod daemon (homebrew install) still has the original architectural issues. Worth flagging in the release notes when this lands.

## Test plan

- [x] `npm test` — 4692 node + 125 jsdom, all passing
- [x] Live smoke on dev daemon: 250 → 1000 → 5000 concurrent `/health`, all 100% success
- [x] Live smoke: dashboard endpoint `/api/config/local` returns 200 with correct config after bootstrap fix
- [x] Live smoke: `service install` from dev binary refused, prod plist unchanged (shasum-verified)
- [x] Live smoke: lag probe is silent during idle, fires on real sync blocks
- [x] Live smoke: fast shutdown completes mid-burst with zero failed requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)