### PR TITLE
daemon: yield seam + Claude SDK and release-provenance yields to keep main loop responsive

### DIFF
--- a/packages/myco/src/agent/harness/claude.ts
+++ b/packages/myco/src/agent/harness/claude.ts
@@ -117,6 +117,9 @@ async function consumeClaudeMessageStream(
     for await (const message of messageStream) {
       if (message.type === 'assistant') {
         assistantMessages += 1;
+        // Yield to libuv so the daemon's HTTP listener and lag probe
+        // don't starve during high-message-count runs.
+        await new Promise<void>((resolve) => setImmediate(resolve));
         continue;
       }
       if (message.type === 'result') {
@@ -130,6 +133,7 @@ async function consumeClaudeMessageStream(
           finalText = message.result;
         }
       }
+      await new Promise<void>((resolve) => setImmediate(resolve));
     }
   } catch (err) {
     if (turnsUsed > 0 || inputTokens > 0 || outputTokens > 0) {

--- a/packages/myco/src/agent/runner-host.ts
+++ b/packages/myco/src/agent/runner-host.ts
@@ -1,0 +1,39 @@
+/**
+ * Agent run dispatcher — the seam where the main thread hands a run off
+ * to whichever execution backend is in force.
+ *
+ * Phase 1 (this commit) ships only the inline backend — every call goes
+ * straight to `runAgent` in the calling process. The shim's value is
+ * the indirection itself: every caller routes through `dispatchAgentRun`
+ * instead of importing `runAgent` directly, so a future commit can
+ * introduce a worker backend behind `agent.execution_isolation`
+ * without re-touching every call site.
+ *
+ * Why this exists: the daemon-loop hardening PR enforced HTTP/event-loop
+ * responsiveness by adding `setImmediate` yields in the agent path. That
+ * works but is fragile — every new sync hot path on the agent code
+ * surface has to remember to yield. Moving agent execution into a
+ * `node:worker_threads` worker enforces the property by architecture
+ * instead of by discipline. The dispatcher is the integration seam for
+ * that future change. See plan `66f6da5b3ca2ed9f`.
+ */
+
+import { runAgent } from './executor.js';
+import type { RunOptions, AgentRunResult } from './types.js';
+
+/**
+ * Dispatch an agent run. Drop-in replacement for `runAgent` — same
+ * signature, same return shape. Internally chooses the configured
+ * execution backend (today: always inline).
+ *
+ * Callers MUST go through this rather than importing `runAgent`
+ * directly. Tests that drive the executor in isolation are the one
+ * exception — they can still import `runAgent` from `./executor.js`
+ * since they care about the inline semantics specifically.
+ */
+export async function dispatchAgentRun(
+  vaultDir: string,
+  options?: RunOptions,
+): Promise<AgentRunResult> {
+  return runAgent(vaultDir, options);
+}

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -192,8 +192,8 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
       }
     }
 
-    const { runAgent } = await import('@myco/agent/executor.js');
-    const resultPromise = runAgent(vaultDir, {
+    const { dispatchAgentRun } = await import('@myco/agent/runner-host.js');
+    const resultPromise = dispatchAgentRun(vaultDir, {
       task,
       instruction,
       agentId,
@@ -309,8 +309,8 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
     }
 
     const { mode } = ResumeRunBody.parse(req.body ?? {});
-    const { runAgent } = await import('@myco/agent/executor.js');
-    const resultPromise = runAgent(vaultDir, {
+    const { dispatchAgentRun } = await import('@myco/agent/runner-host.js');
+    const resultPromise = dispatchAgentRun(vaultDir, {
       agentId: run.agent_id,
       task: run.task ?? undefined,
       instruction: run.instruction ?? undefined,

--- a/packages/myco/src/daemon/cortex.ts
+++ b/packages/myco/src/daemon/cortex.ts
@@ -18,7 +18,7 @@
  * the orchestration layer: deciding which symbiont is targeted, what
  * instructions go inline, and how the agent run is launched + tracked.
  */
-import { runAgent } from '@myco/agent/executor.js';
+import { dispatchAgentRun } from '@myco/agent/runner-host.js';
 import { hasConfiguredProvider } from '@myco/agent/config-resolver.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import { DEFAULT_AGENT_ID } from '@myco/constants.js';
@@ -73,11 +73,13 @@ export interface TriggerCortexInstructionsDeps {
   /** Optional registry that tracks the fire-and-forget run so daemon shutdown can await it. */
   registerInflightRun?: (promise: Promise<unknown>) => void;
   /**
-   * Dynamic import seam for the agent executor. Defaults to the real import
+   * Dynamic import seam for the agent runner. Defaults to the real import
    * so tests can force the module-unavailable branch without monkey-patching
-   * the module system.
+   * the module system. Renamed from `loadExecutor` when the runner-host
+   * shim landed — production now routes through `dispatchAgentRun` rather
+   * than calling `runAgent` directly, so the seam loads `runner-host`.
    */
-  loadExecutor?: () => Promise<typeof import('../agent/executor.js')>;
+  loadRunner?: () => Promise<typeof import('../agent/runner-host.js')>;
 }
 
 export interface CortexInstructionsSnapshot {
@@ -217,7 +219,7 @@ export async function buildCortexPrompt(
       : '## Current Cortex session-start instructions\nOmit them from the prompt because this symbiont receives session-start injection.\n',
   ].join('\n');
 
-  const resultPromise = runAgent(vaultDir, {
+  const resultPromise = dispatchAgentRun(vaultDir, {
     task: CORTEX_PROMPT_BUILDER_TASK,
     agentId: DEFAULT_AGENT_ID,
     instruction: builderInstruction,
@@ -282,7 +284,7 @@ export async function triggerCortexInstructions(
   deps: TriggerCortexInstructionsDeps,
 ): Promise<TriggerCortexInstructionsResult> {
   const { vaultDir, embeddingManager, liveConfig, logger, getTeamClient } = deps;
-  const loadExecutor = deps.loadExecutor ?? (() => import('../agent/executor.js'));
+  const loadRunner = deps.loadRunner ?? (() => import('../agent/runner-host.js'));
   const config = liveConfig.current;
 
   if (config.agent.event_tasks_enabled === false) {
@@ -292,9 +294,9 @@ export async function triggerCortexInstructions(
     return { started: false, reason: 'provider-not-configured' };
   }
 
-  let runAgentFn: typeof import('../agent/executor.js').runAgent;
+  let dispatchFn: typeof import('../agent/runner-host.js').dispatchAgentRun;
   try {
-    ({ runAgent: runAgentFn } = await loadExecutor());
+    ({ dispatchAgentRun: dispatchFn } = await loadRunner());
   } catch (err) {
     logger.warn(LOG_KINDS.AGENT_ERROR, 'cortex-instructions: agent module unavailable', {
       error: String(err),
@@ -309,7 +311,7 @@ export async function triggerCortexInstructions(
   try {
     const requestContext = resolveRequestContextForVault(vaultDir);
     const built = await buildCortexInstructionsInput(config, vaultDir, getTeamClient, requestContext);
-    const resultPromise = runAgentFn(vaultDir, {
+    const resultPromise = dispatchFn(vaultDir, {
       task: CORTEX_INSTRUCTIONS_TASK,
       agentId: DEFAULT_AGENT_ID,
       instruction: built.instruction,

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -1147,7 +1147,7 @@ export async function main(): Promise<void> {
       // + fs_read) and then finalizeCanopyMap crashes because
       // runContext.canopy_map_inputs_hash is unset.
       const { buildCanopyMapInstructionDetailed } = await import('../agent/instruction-builders.js');
-      const { runAgent } = await import('../agent/executor.js');
+      const { dispatchAgentRun } = await import('../agent/runner-host.js');
       const { getLatestRunId } = await import('../db/queries/runs.js');
       const { DEFAULT_AGENT_ID } = await import('../constants.js');
 
@@ -1160,7 +1160,7 @@ export async function main(): Promise<void> {
         return { skipped: true, reason: built.reason };
       }
 
-      const resultPromise = runAgent(bootstrapVaultDir, {
+      const resultPromise = dispatchAgentRun(bootstrapVaultDir, {
         task,
         instruction: built.instruction,
         runContext: built.context,
@@ -1191,7 +1191,7 @@ export async function main(): Promise<void> {
       // runCanopyMapTask above. Map-phase source.args uses
       // params.canopy_entry_path to filter to that one entry.
       const { buildTaskInstruction } = await import('../agent/instruction-builders.js');
-      const { runAgent } = await import('../agent/executor.js');
+      const { dispatchAgentRun } = await import('../agent/runner-host.js');
       const { getLatestRunId } = await import('../db/queries/runs.js');
       const { DEFAULT_AGENT_ID } = await import('../constants.js');
 
@@ -1209,7 +1209,7 @@ export async function main(): Promise<void> {
         requestContext,
       );
 
-      const resultPromise = runAgent(bootstrapVaultDir, {
+      const resultPromise = dispatchAgentRun(bootstrapVaultDir, {
         task,
         instruction: built?.instruction,
         runContext: built?.context,

--- a/packages/myco/src/daemon/task-scheduling.ts
+++ b/packages/myco/src/daemon/task-scheduling.ts
@@ -22,7 +22,7 @@ import { getLastCompletedRunsForProject } from '@myco/db/queries/project-activit
 import { withDatabase } from '@myco/db/client.js';
 import { getLatestResumableRunForTask } from '@myco/db/queries/runs.js';
 import { countToolCallsByRun } from '@myco/db/queries/turns.js';
-import { runAgent } from '@myco/agent/executor.js';
+import { dispatchAgentRun } from '@myco/agent/runner-host.js';
 import { loadAllTasks } from '@myco/agent/registry.js';
 import { notify } from '@myco/notifications/notify.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
@@ -214,7 +214,7 @@ export async function registerScheduledTasks(
       : getLatestResumableRunForTask(DEFAULT_AGENT_ID, taskName, readScope);
 
     if (resumableRun) {
-      const resumed = await runAgent(projectVaultDir, {
+      const resumed = await dispatchAgentRun(projectVaultDir, {
         agentId: DEFAULT_AGENT_ID,
         task: taskName,
         resumeRunId: resumableRun.id,
@@ -254,7 +254,7 @@ export async function registerScheduledTasks(
       return;
     }
 
-    const result = await runAgent(projectVaultDir, {
+    const result = await dispatchAgentRun(projectVaultDir, {
       task: taskName,
       instruction: built?.instruction,
       runContext: built?.context,

--- a/packages/myco/src/daemon/trigger-title-summary.ts
+++ b/packages/myco/src/daemon/trigger-title-summary.ts
@@ -71,8 +71,8 @@ export async function triggerTitleSummary(
   }
 
   try {
-    const { runAgent } = await import('../agent/executor.js');
-    runAgent(vaultDir, {
+    const { dispatchAgentRun } = await import('../agent/runner-host.js');
+    dispatchAgentRun(vaultDir, {
       task: 'title-summary',
       instruction: `Process session ${sessionId} only`,
       embeddingManager,

--- a/packages/myco/src/release-provenance/reconcile.ts
+++ b/packages/myco/src/release-provenance/reconcile.ts
@@ -135,15 +135,18 @@ function targetFor(row: GitProvenanceRow): ReleaseTarget | null {
   }
 }
 
-function checkRefs(projectRoot: string, headSha: string, refs: readonly string[]): RefCheck[] {
-  return refs.map((ref) => {
+async function checkRefs(projectRoot: string, headSha: string, refs: readonly string[]): Promise<RefCheck[]> {
+  const results: RefCheck[] = [];
+  for (const ref of refs) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
     const result = runGit(projectRoot, ['merge-base', '--is-ancestor', headSha, ref]);
-    return {
+    results.push({
       ref,
       ok: result.ok,
       ...(result.ok || result.status === 1 ? {} : { error: result.error }),
-    };
-  });
+    });
+  }
+  return results;
 }
 
 function boundedChecks(checks: RefCheck[]): RefCheck[] {
@@ -165,11 +168,11 @@ function parseCapturedPatchIds(row: GitProvenanceRow): CapturedPatchId[] {
   }
 }
 
-function capturedPatchCandidates(
+async function capturedPatchCandidates(
   row: GitProvenanceRow,
   projectRoot: string,
   refs: readonly string[],
-): CapturedPatchId[] {
+): Promise<CapturedPatchId[]> {
   const byKey = new Map<string, CapturedPatchId>();
   for (const patch of parseCapturedPatchIds(row)) {
     if (!patch.patch_id) continue;
@@ -178,6 +181,7 @@ function capturedPatchCandidates(
 
   if (row.head_sha) {
     for (const ref of refs) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
       const baseSha = mergeBase(projectRoot, row.head_sha, ref);
       if (!baseSha) continue;
       const patchId = patchIdForRange(projectRoot, baseSha, row.head_sha);
@@ -196,13 +200,13 @@ function capturedPatchCandidates(
   return [...byKey.values()];
 }
 
-function findPatchMatch(
+async function findPatchMatch(
   projectRoot: string,
   row: GitProvenanceRow,
   refs: readonly string[],
   cache: PatchIdCache,
-): { matches: PatchMatch[]; errors: RefCheck[] } {
-  const patches = capturedPatchCandidates(row, projectRoot, refs);
+): Promise<{ matches: PatchMatch[]; errors: RefCheck[] }> {
+  const patches = await capturedPatchCandidates(row, projectRoot, refs);
   const wanted = new Map<string, CapturedPatchId>();
   for (const patch of patches) {
     if (patch.patch_id) wanted.set(patch.patch_id, patch);
@@ -213,13 +217,19 @@ function findPatchMatch(
   const errors: RefCheck[] = [];
 
   for (const ref of refs) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
     const revList = runGit(projectRoot, ['rev-list', `--max-count=${PATCH_SCAN_MAX_COMMITS}`, ref]);
     if (!revList.ok) {
       errors.push({ ref, ok: false, error: revList.error });
       continue;
     }
+    let commitsSinceYield = 0;
     for (const commitSha of revList.stdout.split('\n')) {
       if (!commitSha) continue;
+      if (++commitsSinceYield >= 32) {
+        commitsSinceYield = 0;
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
       const patchId = cache.patchIdForCommit(projectRoot, commitSha);
       if (!patchId) continue;
       const captured = wanted.get(patchId);
@@ -276,12 +286,12 @@ function selectRefsForRow(
   };
 }
 
-function classify(
+async function classify(
   row: GitProvenanceRow,
   input: ReconcileReleaseProvenanceInput,
   cache: PatchIdCache,
   prSquash: PullRequestSquashEvidence | null,
-): Classification {
+): Promise<Classification> {
   const baseEvidence = {
     provenance_id: row.id,
     capture_point: row.capture_point,
@@ -319,7 +329,7 @@ function classify(
   }
 
   // Direct ancestry against production refs (highest confidence).
-  const productionChecks = checkRefs(input.projectRoot, row.head_sha, productionRefs);
+  const productionChecks = await checkRefs(input.projectRoot, row.head_sha, productionRefs);
   const released = productionChecks.find((check) => check.ok);
   if (released) {
     return buildClassification(
@@ -330,7 +340,7 @@ function classify(
   }
 
   // Patch-id equivalence against production refs (squash-merge case).
-  const productionPatchMatch = findPatchMatch(input.projectRoot, row, productionRefs, cache);
+  const productionPatchMatch = await findPatchMatch(input.projectRoot, row, productionRefs, cache);
   const releasedByPatch = productionPatchMatch.matches[0];
   if (releasedByPatch) {
     return buildClassification(
@@ -353,7 +363,7 @@ function classify(
   // has a different SHA. Re-check ancestry against the squash commit before
   // falling through to integration refs.
   if (prSquash) {
-    const squashAncestry = checkRefs(input.projectRoot, prSquash.merge_commit_sha, productionRefs);
+    const squashAncestry = await checkRefs(input.projectRoot, prSquash.merge_commit_sha, productionRefs);
     const releasedBySquash = squashAncestry.find((check) => check.ok);
     if (releasedBySquash) {
       return buildClassification(
@@ -370,7 +380,7 @@ function classify(
   }
 
   // Same checks against integration refs (merged but not released).
-  const integrationChecks = checkRefs(input.projectRoot, row.head_sha, integrationRefs);
+  const integrationChecks = await checkRefs(input.projectRoot, row.head_sha, integrationRefs);
   const merged = integrationChecks.find((check) => check.ok);
   if (merged) {
     return buildClassification(
@@ -380,7 +390,7 @@ function classify(
     );
   }
 
-  const integrationPatchMatch = findPatchMatch(input.projectRoot, row, integrationRefs, cache);
+  const integrationPatchMatch = await findPatchMatch(input.projectRoot, row, integrationRefs, cache);
   const mergedByPatch = integrationPatchMatch.matches[0];
   if (mergedByPatch) {
     return buildClassification(
@@ -476,6 +486,7 @@ export async function reconcileReleaseProvenance(
   let failed = 0;
 
   for (const row of rows) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
     const target = targetFor(row);
     if (!target) {
       skipped++;
@@ -490,7 +501,7 @@ export async function reconcileReleaseProvenance(
 
     try {
       const prSquash = await resolvePullRequestSquash(row, reconcilerInput, githubBudget);
-      const result = classify(row, reconcilerInput, cache, prSquash);
+      const result = await classify(row, reconcilerInput, cache, prSquash);
       const projectId = input.projectId ?? row.project_id;
       const identityKey = buildReleaseStateIdentityKey({
         project_id: projectId,
@@ -542,6 +553,7 @@ export async function reconcileReleaseProvenance(
         scope: input.scope,
       });
       for (const record of derived) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
         upsertReleaseState({
           project_id: projectId,
           machine_id: input.machineId ?? row.machine_id,

--- a/tests/daemon/cortex.test.ts
+++ b/tests/daemon/cortex.test.ts
@@ -154,9 +154,9 @@ describe('triggerCortexInstructions', () => {
     );
   });
 
-  it('returns agent-module-unavailable when loadExecutor throws (module-not-found path)', async () => {
+  it('returns agent-module-unavailable when loadRunner throws (module-not-found path)', async () => {
     const logger = makeLogger();
-    const loadExecutor = vi.fn(async () => {
+    const loadRunner = vi.fn(async () => {
       throw new Error("Cannot find module '../agent/executor.js'");
     });
 
@@ -165,13 +165,13 @@ describe('triggerCortexInstructions', () => {
       embeddingManager: makeEmbeddingManagerStub() as never,
       liveConfig: { current: makeConfig() },
       logger: logger as never,
-      loadExecutor: loadExecutor as never,
+      loadRunner: loadRunner as never,
     });
 
     expect(result.started).toBe(false);
     expect(result.reason).toBe('agent-module-unavailable');
     expect(result.error).toContain('Cannot find module');
-    expect(loadExecutor).toHaveBeenCalledTimes(1);
+    expect(loadRunner).toHaveBeenCalledTimes(1);
     expect(buildCortexInstructionsInput).not.toHaveBeenCalled();
     expect(runAgent).not.toHaveBeenCalled();
     expect(logger.warn).toHaveBeenCalledWith(
@@ -181,10 +181,10 @@ describe('triggerCortexInstructions', () => {
     );
   });
 
-  it('uses the default loadExecutor (real dynamic import) when the seam is not injected', async () => {
+  it('uses the default loadRunner (real dynamic import) when the seam is not injected', async () => {
     // Happy path already mocks @myco/agent/executor.js at the vi.mock level;
     // this assertion confirms the default code path is still exercised when
-    // no loadExecutor override is passed (sanity check that the seam is
+    // no loadRunner override is passed (sanity check that the seam is
     // opt-in and backward-compatible).
     const logger = makeLogger();
 


### PR DESCRIPTION
## Summary

PR #275 hardened the daemon main loop with a lag probe, instrumented `fetch`, and `setImmediate` yields in the OpenAI Agents harness. Live dogfooding then surfaced **two more wedges of the same shape** that PR #275 didn't cover:

1. **Claude SDK harness** — `consumeClaudeMessageStream`'s `for await` loop drained SDK messages back-to-back as microtasks. A multi-thousand-turn agent run starved libuv between turns. Symptom: `/health` unresponsive while a Claude-backed agent ran.
2. **release-provenance reconcile** — `reconcileReleaseProvenance` scans up to 500 git provenance rows per power tick. Each row fans out into hundreds of sync `runGit` shellouts via `checkRefs` / `findPatchMatch` / `capturedPatchCandidates` / `cache.patchIdForCommit`. In dogfood, a 326-row scan wedged the daemon main loop for **199 seconds**.

This PR fixes both with the same pattern PR #275 used for the OpenAI Agents harness: `setImmediate` yields at hot-loop boundaries.

## What changed

- **`agent/runner-host.ts`** — refactor-only seam. All 6 call sites now route through `dispatchAgentRun` instead of importing `runAgent` directly. Currently a pass-through; preserves the option of pulling agent execution out of the main process later without re-touching every caller.
- **`agent/harness/claude.ts`** — yield after every SDK message (assistant + result + unknown subtypes).
- **`release-provenance/reconcile.ts`** — `checkRefs`, `capturedPatchCandidates`, `findPatchMatch`, and `classify` become async with yields between refs, between rows, and every 32 commits inside the patch-id scan. Both callers (`maintenance.ts`, `power-jobs.ts`) already awaited `reconcileReleaseProvenance`, so the public signature is unchanged.

## What this is NOT

The branch started as a worker_threads / child_process isolation experiment. That approach didn't fix the wedge — turning agent execution into a subprocess still wedged the main loop because the wedge cause was on the main thread, not in agent execution. Profiling with macOS `sample` pointed at the loops fixed here. The isolation code is gone from this branch; only the `runner-host` seam survives in case we want to revisit isolation later.

## Verification

5-minute `/health` smoke probe (300 probes, 1s interval) after the fix:

| Metric | Before fix | After fix |
|---|---|---|
| Successful probes | 229 / 300 | **300 / 300** |
| Max latency | ~199,000 ms | **902 ms** |
| Avg latency | — | 54 ms |
| `lag.spike` entries | many | **zero** |

`release-provenance.reconcile` completed a full 326-row scan during the smoke window with zero failed probes.

## Test plan

- [x] `npm test` — 4692 + 125 tests, 0 fails
- [x] Build single-target binary and restart daemon
- [x] 5-min `/health` smoke probe (300 / 300 ok, max 902 ms)
- [x] Confirm `release-provenance.reconcile` runs to completion during the window
- [x] Confirm no `lag.spike` entries in daemon log

🤖 Generated with [Claude Code](https://claude.com/claude-code)