### PR TITLE
feat(ui): Phase 2 — split-view + v6 row cards on Sessions and Runs

### DIFF
--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -8,6 +8,7 @@
 import { z } from 'zod';
 import { resolveProjectRoot } from '@myco/vault/resolve.js';
 import { listRuns, countRuns, getRun, getLatestRunId } from '@myco/db/queries/runs.js';
+import { getRunActivityBuckets, getRunBranches } from '@myco/db/queries/activity-buckets.js';
 import { listReports } from '@myco/db/queries/reports.js';
 import { listTurnsByRun } from '@myco/db/queries/turns.js';
 import { listWriteIntents, countWriteIntents, countWriteIntentsByTool } from '@myco/db/queries/write-intents.js';
@@ -266,8 +267,22 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
     const filterOpts = { scope, agent_id: agentId, status, task, search };
     const runs = listRuns({ ...filterOpts, limit, offset });
     const total = countRuns(filterOpts);
+    const runIds = runs.map((r) => r.id);
+    const activityBuckets = getRunActivityBuckets(runIds);
+    const branches = getRunBranches(runIds);
 
-    return { body: { runs: runs.map((run) => serializeRun(run, { logger })), total, offset, limit } };
+    return {
+      body: {
+        runs: runs.map((run) => serializeRun(run, {
+          logger,
+          activityBuckets: activityBuckets.get(run.id) ?? [],
+          branch: branches.get(run.id) ?? null,
+        })),
+        total,
+        offset,
+        limit,
+      },
+    };
   }
 
   /**
@@ -286,12 +301,16 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
     }
     const byTool = countWriteIntentsByTool(run.id, scope);
     const total = Object.values(byTool).reduce((acc, n) => acc + n, 0);
+    const activityBuckets = getRunActivityBuckets([run.id]);
+    const branches = getRunBranches([run.id]);
     return {
       body: {
         run: serializeRun(run, {
           writeIntents: { total, by_tool: byTool },
           duration_ms: runDurationMs(run),
           logger,
+          activityBuckets: activityBuckets.get(run.id) ?? [],
+          branch: branches.get(run.id) ?? null,
         }),
       },
     };

--- a/packages/myco/src/daemon/api/run-serializer.ts
+++ b/packages/myco/src/daemon/api/run-serializer.ts
@@ -108,6 +108,19 @@ export interface SerializeRunOptions {
    * sites that don't have a logger can still serialize rows.
    */
   logger?: DaemonLogger;
+  /**
+   * Length-`BUCKET_COUNT` activity sparkline for the v6 rail cards. Each
+   * entry counts `agent_turns` rows for that run in a 1-minute bucket over
+   * the recent window. Omit (or pass undefined) to skip — MCP / legacy
+   * call sites that don't need it stay slim.
+   */
+  activityBuckets?: number[];
+  /**
+   * Git branch the run was started on, resolved from the run's session via
+   * the most recent release-provenance capture. Null when no provenance is
+   * available. Omit entirely to skip the field on the wire.
+   */
+  branch?: string | null;
 }
 
 /**
@@ -123,6 +136,8 @@ export function serializeRun(run: RunRow, opts: SerializeRunOptions = {}) {
     writeIntents,
     duration_ms,
     logger,
+    activityBuckets,
+    branch,
   } = opts;
 
   const base = {
@@ -171,5 +186,7 @@ export function serializeRun(run: RunRow, opts: SerializeRunOptions = {}) {
       ? { write_intents: writeIntents }
       : {}),
     ...(duration_ms !== undefined ? { duration_ms } : {}),
+    ...(activityBuckets !== undefined ? { activity_buckets: activityBuckets } : {}),
+    ...('branch' in opts ? { branch: branch ?? null } : {}),
   };
 }

--- a/packages/myco/src/daemon/api/sessions.ts
+++ b/packages/myco/src/daemon/api/sessions.ts
@@ -3,6 +3,7 @@ import { listBatchesBySession, countBatchesBySession, getBatchById, PROMPT_BATCH
 import { listActivitiesByBatch, countActivities } from '@myco/db/queries/activities.js';
 import { listAttachmentsBySession } from '@myco/db/queries/attachments.js';
 import { deletePlan, getPlan, listPlansBySession } from '@myco/db/queries/plans.js';
+import { getSessionActivityBuckets } from '@myco/db/queries/activity-buckets.js';
 import { getTeamMachineId } from '@myco/daemon/team-context.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { epochSeconds } from '@myco/constants.js';
@@ -36,6 +37,7 @@ export async function handleListSessions(req: RouteRequest): Promise<RouteRespon
 
   const rawSessions = listSessions({ ...filterOpts, limit, offset });
   const states = releaseStateAnnotationMap('sessions', rawSessions.map((s) => s.id), scope);
+  const activityBuckets = getSessionActivityBuckets(rawSessions.map((s) => s.id));
   const sessions = rawSessions.map((s) => ({
     id: s.id,
     date: new Date(s.started_at * 1000).toISOString().slice(0, 10),
@@ -46,6 +48,8 @@ export async function handleListSessions(req: RouteRequest): Promise<RouteRespon
     tool_count: s.tool_count,
     started_at: s.started_at,
     ended_at: s.ended_at,
+    branch: s.branch,
+    activity_buckets: activityBuckets.get(s.id) ?? [],
     ...releaseStateField(states.get(s.id)),
   }));
   const total = countSessions(filterOpts);

--- a/packages/myco/src/db/queries/activity-buckets.ts
+++ b/packages/myco/src/db/queries/activity-buckets.ts
@@ -1,0 +1,193 @@
+/**
+ * Activity-bucket helpers for the session/run rail cards.
+ *
+ * Each list row in the v6 design shows a mini sparkline of recent activity.
+ * The wire payload is a fixed-length array of integers — one count per
+ * 1-minute bucket over the last `BUCKET_COUNT` minutes, newest bucket last.
+ *
+ * The naive shape is one subquery per session × 8 buckets. For lists of
+ * 50–200 rows that's 400–1600 round-trips per page load. We instead issue a
+ * single ranged SELECT covering every visible id, then bucket in JS. The DB
+ * touches each row once; the bucketing is O(rows) and runs at near-memory
+ * speed.
+ */
+
+import { getDatabase } from '@myco/db/client.js';
+import { epochSeconds } from '@myco/constants.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Number of 1-minute buckets returned per row. Matches the v6 sparkline width. */
+export const BUCKET_COUNT = 8;
+
+/** Width of each bucket, in seconds. */
+const BUCKET_WIDTH_SECONDS = 60;
+
+/** Total window width, in seconds (BUCKET_COUNT × BUCKET_WIDTH). */
+const WINDOW_SECONDS = BUCKET_COUNT * BUCKET_WIDTH_SECONDS;
+
+/** Wire shape: integers, newest bucket last (index BUCKET_COUNT-1 is the most recent minute). */
+export type ActivityBuckets = number[];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function emptyBuckets(): ActivityBuckets {
+  return new Array(BUCKET_COUNT).fill(0) as number[];
+}
+
+/**
+ * Build the buckets map from a flat (id, started_at) result set.
+ *
+ * Buckets are anchored at `nowSeconds`: index 0 covers
+ * `[now - WINDOW_SECONDS, now - WINDOW_SECONDS + 60)` and the last index
+ * covers `[now - 60, now)`. A row outside the window is silently dropped.
+ */
+function bucketByIdFromRows(
+  rows: Array<{ id: string; started_at: number }>,
+  ids: readonly string[],
+  nowSeconds: number,
+): Map<string, ActivityBuckets> {
+  const map = new Map<string, ActivityBuckets>();
+  for (const id of ids) map.set(id, emptyBuckets());
+
+  const windowStart = nowSeconds - WINDOW_SECONDS;
+  for (const row of rows) {
+    const buckets = map.get(row.id);
+    if (!buckets) continue;
+    const offset = row.started_at - windowStart;
+    if (offset < 0 || offset >= WINDOW_SECONDS) continue;
+    const idx = Math.floor(offset / BUCKET_WIDTH_SECONDS);
+    if (idx < 0 || idx >= BUCKET_COUNT) continue;
+    buckets[idx] += 1;
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Public API — sessions
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute per-session activity buckets for a list of session ids.
+ *
+ * "Activity" for a session is a captured prompt_batch. Returns a map keyed
+ * by session id; every input id appears in the map (with all-zero buckets
+ * when the session has no recent activity).
+ *
+ * An empty input list short-circuits without hitting the database.
+ */
+export function getSessionActivityBuckets(
+  sessionIds: readonly string[],
+  options: { nowSeconds?: number } = {},
+): Map<string, ActivityBuckets> {
+  const now = options.nowSeconds ?? epochSeconds();
+  if (sessionIds.length === 0) return new Map();
+
+  const db = getDatabase();
+  const placeholders = sessionIds.map(() => '?').join(', ');
+  const windowStart = now - WINDOW_SECONDS;
+  const rows = db
+    .prepare(
+      `SELECT session_id AS id, started_at
+         FROM prompt_batches
+        WHERE session_id IN (${placeholders})
+          AND started_at IS NOT NULL
+          AND started_at >= ?
+          AND started_at < ?`,
+    )
+    .all(...sessionIds, windowStart, now) as Array<{ id: string; started_at: number }>;
+
+  return bucketByIdFromRows(rows, sessionIds, now);
+}
+
+// ---------------------------------------------------------------------------
+// Public API — runs
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute per-run activity buckets for a list of run ids.
+ *
+ * "Activity" for an agent run is a recorded `agent_turns` row — each turn
+ * represents one tool call the agent made, which is the closest analog to
+ * the prompt-batch granularity used for sessions.
+ *
+ * Same contract as `getSessionActivityBuckets`: every input id appears in
+ * the returned map.
+ */
+export function getRunActivityBuckets(
+  runIds: readonly string[],
+  options: { nowSeconds?: number } = {},
+): Map<string, ActivityBuckets> {
+  const now = options.nowSeconds ?? epochSeconds();
+  if (runIds.length === 0) return new Map();
+
+  const db = getDatabase();
+  const placeholders = runIds.map(() => '?').join(', ');
+  const windowStart = now - WINDOW_SECONDS;
+  const rows = db
+    .prepare(
+      `SELECT run_id AS id, started_at
+         FROM agent_turns
+        WHERE run_id IN (${placeholders})
+          AND started_at IS NOT NULL
+          AND started_at >= ?
+          AND started_at < ?`,
+    )
+    .all(...runIds, windowStart, now) as Array<{ id: string; started_at: number }>;
+
+  return bucketByIdFromRows(rows, runIds, now);
+}
+
+// ---------------------------------------------------------------------------
+// Public API — run branch lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the most recent captured git branch for each run.
+ *
+ * Runs themselves don't store branch — release-provenance captures it per
+ * session/prompt_batch. We follow each run's `session_ref` to its session
+ * and read the most-recent provenance row's `branch`. A run without a
+ * session_ref, or a session with no captured provenance, maps to `null`.
+ *
+ * The query joins `agent_runs → sessions → knowledge_git_provenance` so we
+ * pick up the right row even when the session_ref string and a sessions.id
+ * shape differ (the join enforces the FK relationship).
+ */
+export function getRunBranches(runIds: readonly string[]): Map<string, string | null> {
+  const result = new Map<string, string | null>();
+  for (const id of runIds) result.set(id, null);
+  if (runIds.length === 0) return result;
+
+  const db = getDatabase();
+  const placeholders = runIds.map(() => '?').join(', ');
+  // For each run, prefer the latest provenance row attached to its session;
+  // we group by run_id and take MAX(captured_at). The outer SELECT projects
+  // the branch attached to that captured_at via a self-join on (session_id,
+  // captured_at) — safe because (session_id, captured_at) is effectively
+  // unique within a session's capture stream.
+  const rows = db
+    .prepare(
+      `SELECT r.id AS run_id, p.branch AS branch
+         FROM agent_runs r
+         JOIN sessions s ON s.id = r.session_ref
+         JOIN knowledge_git_provenance p
+           ON p.session_id = s.id
+          AND p.captured_at = (
+            SELECT MAX(captured_at)
+              FROM knowledge_git_provenance
+             WHERE session_id = s.id
+          )
+        WHERE r.id IN (${placeholders})`,
+    )
+    .all(...runIds) as Array<{ run_id: string; branch: string | null }>;
+
+  for (const row of rows) {
+    result.set(row.run_id, row.branch ?? null);
+  }
+  return result;
+}

--- a/packages/myco/ui/src/App.tsx
+++ b/packages/myco/ui/src/App.tsx
@@ -51,6 +51,7 @@ export default function App() {
         <Route path="cortex" element={<Cortex />} />
         <Route path="mycelium" element={<Mycelium />} />
         <Route path="agent" element={<Agent />} />
+        <Route path="agent/:id" element={<Agent />} />
         <Route path="skills" element={<Skills />} />
         <Route path="settings" element={<Settings />} />
         {/* Legacy project-scoped /operations → Grove-scoped /dashboard. */}
@@ -82,6 +83,7 @@ export default function App() {
       <Route path="/cortex" element={<LegacyProjectRedirect suffix="/cortex" />} />
       <Route path="/mycelium" element={<LegacyProjectRedirect suffix="/mycelium" />} />
       <Route path="/agent" element={<LegacyProjectRedirect suffix="/agent" />} />
+      <Route path="/agent/:id" element={<LegacyProjectRedirect suffixFromPath />} />
       <Route path="/skills" element={<LegacyProjectRedirect suffix="/skills" />} />
       <Route path="/settings" element={<LegacyProjectRedirect suffix="/settings" />} />
       <Route path="/operations" element={<LegacyGroveRedirect suffix="/dashboard" />} />

--- a/packages/myco/ui/src/components/agent/MetricCard.tsx
+++ b/packages/myco/ui/src/components/agent/MetricCard.tsx
@@ -30,7 +30,7 @@ export function MetricCard({ label, value, sparklineData, children, className }:
         {children}
       </div>
       {sparklineData && sparklineData.length >= 2 && (
-        <Sparkline data={sparklineData} width={160} height={28} className="mt-1 opacity-80" />
+        <Sparkline data={sparklineData} widthPx={160} heightPx={28} className="mt-1 opacity-80" />
       )}
     </div>
   );

--- a/packages/myco/ui/src/components/agent/RunDetail.tsx
+++ b/packages/myco/ui/src/components/agent/RunDetail.tsx
@@ -677,7 +677,7 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
       </div>
 
       {/* Stat cards */}
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4">
         <StatCard label="Status" value={capitalize(run.status)} accent="sage" />
         <StatCard label="Task" value={resolveTaskName(run.task, tasksList)} accent="outline" />
         <StatCard label="Started" value={formatEpochRelative(run.started_at)} accent="outline" />
@@ -720,7 +720,7 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
 
       {/* Model / Provider info */}
       {(run.harness || run.provider || run.model) && (
-        <div className="flex items-center gap-4 px-1">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 px-1">
           {run.harness && (
             <span className="font-sans text-xs text-on-surface-variant">
               Harness: <span className="font-mono text-on-surface">{run.harness}</span>
@@ -749,7 +749,7 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
           <h2 className="font-sans text-sm font-medium text-on-surface-variant uppercase tracking-wide">
             Cost Diagnostics
           </h2>
-          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-3">
             <StatTile label="Input" value={formatTokens(parsedCost?.breakdown.inputTokens ?? parsedUsage?.run?.inputTokens ?? null)} />
             <StatTile label="Cached Input" value={formatTokens(parsedCost?.breakdown.cachedInputTokens ?? parsedUsage?.run?.cachedTokens ?? null)} />
             <StatTile label="Uncached Input" value={formatTokens(parsedCost?.breakdown.uncachedInputTokens ?? null)} />
@@ -768,7 +768,7 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
           <h2 className="font-sans text-sm font-medium text-on-surface-variant uppercase tracking-wide">
             Token Budget
           </h2>
-          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-3">
             <StatTile label="Context Window" value={formatTokens(parsedUsage.runBudget.contextWindowTokens)} />
             <StatTile label="Peak Request" value={formatTokens(parsedUsage.runBudget.peakRequestTotalTokens)} />
             <StatTile label="Peak Input" value={formatTokens(parsedUsage.runBudget.peakRequestInputTokens)} />
@@ -776,7 +776,7 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
             <StatTile label="Budget Used" value={parsedUsage.runBudget.utilizationPercent != null ? `${parsedUsage.runBudget.utilizationPercent}%` : '\u2014'} />
             <StatTile label="Headroom" value={formatTokens(parsedUsage.runBudget.headroomTokens)} />
           </div>
-          <div className="flex items-center gap-3 px-1">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 px-1">
             <span className="font-sans text-xs text-on-surface-variant">
               Budget status: <span className="font-mono text-on-surface">{parsedUsage.runBudget.status}</span>
             </span>

--- a/packages/myco/ui/src/components/agent/RunList.tsx
+++ b/packages/myco/ui/src/components/agent/RunList.tsx
@@ -1,17 +1,19 @@
 import { forwardRef, memo, useCallback, useMemo, useRef, useState } from 'react';
-import { Bot, AlertCircle, Play, RotateCcw } from 'lucide-react';
+import { Bot, AlertCircle, GitBranch, Play, RotateCcw } from 'lucide-react';
 import { Button } from '../ui/button';
 import { CompareBar } from '../ui/compare-bar';
 import { ListToolbar, type FilterDefinition } from '../ui/list-toolbar';
 import { Pagination } from '../ui/pagination';
+import { Sparkline } from '../ui/sparkline';
+import { StatusDot, type StatusTone } from '../ui/status-dot';
 import { useAgentRuns, useAgentTasks, type RunRow } from '../../hooks/use-agent';
 import { RunTaskDialog } from './RunTaskDialog';
 import { useListFilters, FILTER_ALL } from '../../hooks/use-list-filters';
 import { useListKeyboardNav } from '../../hooks/use-list-keyboard-nav';
 import { DEFAULT_PAGE_SIZE } from '../../lib/constants';
 import { cn } from '../../lib/cn';
-import { formatEpochRelative, capitalize } from '../../lib/format';
-import { statusBadgeVariant, formatCost, formatTokens, formatDuration, UNKNOWN_TASK_LABEL } from './helpers';
+import { formatEpochAgo, capitalize } from '../../lib/format';
+import { statusBadgeVariant, formatDuration, UNKNOWN_TASK_LABEL } from './helpers';
 
 /* ---------- Constants ---------- */
 
@@ -22,6 +24,15 @@ const RUN_STATUS_OPTIONS = [
   { value: 'failed', label: 'Failed' },
   { value: 'cancelled', label: 'Cancelled' },
 ];
+
+/* ---------- Helpers ---------- */
+
+function statusTone(status: string): StatusTone {
+  if (status === 'running') return 'sage';
+  if (status === 'completed') return 'outline';
+  if (status === 'failed' || status === 'cancelled') return 'terracotta';
+  return 'ochre';
+}
 
 /* ---------- Sub-components ---------- */
 
@@ -82,13 +93,33 @@ const RunRailRow = memo(forwardRef<HTMLDivElement, RunRailRowProps>(function Run
   const onClick = useCallback(() => onSelectRun(run.id), [onSelectRun, run.id]);
   const taskLabel = run.task ? taskNameMap.get(run.task) ?? run.task : UNKNOWN_TASK_LABEL;
 
+  // Meta segments built conditionally so missing fields drop out entirely
+  // rather than rendering em-dash placeholders that read as broken state.
+  // started_at already appears in the top-right; the meta line carries
+  // duration, tokens, and cost only.
+  const metaSegments: string[] = [];
+  if (run.started_at !== null && run.completed_at !== null) {
+    metaSegments.push(formatDuration(run.started_at, run.completed_at));
+  }
+  if (run.tokens_used !== null && run.tokens_used > 0) {
+    metaSegments.push(`${run.tokens_used.toLocaleString()} tok`);
+  }
+  if (
+    run.cost_source !== 'unavailable' &&
+    run.cost_usd !== null &&
+    run.cost_usd > 0
+  ) {
+    const prefix = run.cost_source === 'estimated' ? '~' : '';
+    metaSegments.push(`${prefix}$${run.cost_usd.toFixed(4)}`);
+  }
+
   return (
     <div
       ref={ref}
       data-selected={isActive || undefined}
       data-cursor={isCursor || undefined}
       className={cn(
-        'group border-b border-outline-variant/20 last:border-0 px-4 py-3 cursor-pointer transition-all duration-150',
+        'group relative border-b border-outline-variant/20 last:border-0 px-4 py-3 cursor-pointer transition-all duration-150',
         'hover:bg-surface-container-high/50 hover:shadow-[inset_3px_0_0_var(--primary)]',
         'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40',
         isActive && 'bg-surface-container-high shadow-[inset_3px_0_0_var(--primary)]',
@@ -106,84 +137,90 @@ const RunRailRow = memo(forwardRef<HTMLDivElement, RunRailRowProps>(function Run
       aria-selected={isActive}
       aria-label={`Agent run: ${taskLabel}, status ${run.status}`}
     >
-      <div className="flex items-start gap-3">
-        {/* Compare checkbox */}
-        <div
-          className="pt-1 shrink-0"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <input
-            type="checkbox"
-            aria-label={`Select run ${run.id.slice(0, 8)}`}
-            checked={selected}
-            onChange={() => onToggleSelected(run.id)}
+      {/* Top row: checkbox + status dot + title on the left, time + sparkline + actions on the right */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-2 min-w-0 flex-1">
+          {/* Compare checkbox */}
+          <div
+            className="pt-1 shrink-0"
             onClick={(e) => e.stopPropagation()}
-            className="h-4 w-4 rounded accent-primary cursor-pointer"
-          />
-        </div>
-
-        <Bot className="h-4 w-4 shrink-0 text-on-surface-variant mt-0.5" />
-
-        {/* Main content */}
-        <div className="flex-1 min-w-0 space-y-1.5">
-          {/* Top line: task label + flags */}
-          <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-on-surface truncate">
-              {taskLabel}
-            </span>
-            {run.dry_run && (
-              <span
-                className="inline-flex items-center rounded-xs bg-secondary/15 px-1.5 py-0.5 font-sans text-[10px] uppercase tracking-wide text-secondary shrink-0"
-                title="Dry run — writes were intercepted, no vault mutations"
-              >
-                Dry
-              </span>
-            )}
-          </div>
-
-          {/* Status line */}
-          <div className="flex items-center gap-2">
-            <RunStatusBadge status={run.status} />
-            {run.resumable && run.status === 'failed' && (
-              <span className="font-sans text-[10px] uppercase tracking-wide text-secondary">resumable</span>
-            )}
-            {run.cost_source === 'estimated' && (
-              <span className="font-sans text-[10px] uppercase tracking-wide text-secondary">est</span>
-            )}
-          </div>
-
-          {/* Meta line: started · duration · tokens · cost */}
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-on-surface-variant font-mono">
-            <span>{formatEpochRelative(run.started_at)}</span>
-            <span aria-hidden="true">·</span>
-            <span>{formatDuration(run.started_at, run.completed_at)}</span>
-            <span aria-hidden="true">·</span>
-            <span>{formatTokens(run.tokens_used)} tok</span>
-            <span aria-hidden="true">·</span>
-            <span>{formatCost(run.cost_usd, run.cost_source)}</span>
-          </div>
-        </div>
-
-        {/* Rerun action */}
-        <div
-          className="shrink-0"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <Button
-            size="icon"
-            variant="ghost"
-            className="h-7 w-7 text-on-surface-variant hover:text-on-surface opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
-            onClick={(e) => {
-              e.stopPropagation();
-              onRerun(run);
-            }}
-            title="Rerun with same settings"
-            aria-label={`Rerun ${run.id.slice(0, 8)} with same settings`}
           >
-            <RotateCcw className="h-3.5 w-3.5" />
-          </Button>
+            <input
+              type="checkbox"
+              aria-label={`Select run ${run.id.slice(0, 8)}`}
+              checked={selected}
+              onChange={() => onToggleSelected(run.id)}
+              onClick={(e) => e.stopPropagation()}
+              className="h-4 w-4 rounded accent-primary cursor-pointer"
+            />
+          </div>
+          <StatusDot
+            tone={statusTone(run.status)}
+            pulse={run.status === 'running'}
+            className="mt-1.5 shrink-0"
+          />
+          <h3 className="font-serif italic text-sm text-on-surface truncate leading-snug">
+            {taskLabel}
+          </h3>
+          {run.dry_run && (
+            <span
+              className="inline-flex items-center rounded-xs bg-secondary/15 px-1.5 py-0.5 font-sans text-[10px] uppercase tracking-wide text-secondary shrink-0"
+              title="Dry run — writes were intercepted, no vault mutations"
+            >
+              Dry
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {run.started_at !== null && (
+            <span className="font-mono text-[10px] text-on-surface-variant whitespace-nowrap">
+              {formatEpochAgo(run.started_at)}
+            </span>
+          )}
+          <Sparkline data={run.activity_buckets ?? []} widthPx={48} heightPx={14} />
+          <div onClick={(e) => e.stopPropagation()}>
+            <Button
+              size="icon"
+              variant="ghost"
+              className="h-7 w-7 text-on-surface-variant hover:text-on-surface opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRerun(run);
+              }}
+              title="Rerun with same settings"
+              aria-label={`Rerun ${run.id.slice(0, 8)} with same settings`}
+            >
+              <RotateCcw className="h-3.5 w-3.5" />
+            </Button>
+          </div>
         </div>
       </div>
+
+      {/* Status line: badge + flags */}
+      <div className="mt-1.5 ml-11 flex items-center gap-2">
+        <RunStatusBadge status={run.status} />
+        {run.resumable && run.status === 'failed' && (
+          <span className="font-sans text-[10px] uppercase tracking-wide text-secondary">resumable</span>
+        )}
+        {run.cost_source === 'estimated' && (
+          <span className="font-sans text-[10px] uppercase tracking-wide text-secondary">est</span>
+        )}
+      </div>
+
+      {/* Meta line: only rendered segments that have data, joined with · */}
+      {metaSegments.length > 0 && (
+        <div className="mt-1 ml-11 font-mono text-[11px] text-on-surface-variant truncate">
+          {metaSegments.join(' · ')}
+        </div>
+      )}
+
+      {/* Branch line: rendered only when a branch was captured */}
+      {run.branch && (
+        <div className="mt-0.5 ml-11 inline-flex items-center gap-1 font-mono text-[10px] italic text-on-surface-variant">
+          <GitBranch className="h-2.5 w-2.5" />
+          {run.branch}
+        </div>
+      )}
     </div>
   );
 }));

--- a/packages/myco/ui/src/components/agent/RunList.tsx
+++ b/packages/myco/ui/src/components/agent/RunList.tsx
@@ -1,11 +1,13 @@
-import { memo, useCallback, useMemo, useState } from 'react';
-import { Bot, AlertCircle, GitCompare, Play, RotateCcw, X } from 'lucide-react';
+import { forwardRef, memo, useCallback, useMemo, useRef, useState } from 'react';
+import { Bot, AlertCircle, Play, RotateCcw } from 'lucide-react';
 import { Button } from '../ui/button';
+import { CompareBar } from '../ui/compare-bar';
 import { ListToolbar, type FilterDefinition } from '../ui/list-toolbar';
 import { Pagination } from '../ui/pagination';
 import { useAgentRuns, useAgentTasks, type RunRow } from '../../hooks/use-agent';
 import { RunTaskDialog } from './RunTaskDialog';
 import { useListFilters, FILTER_ALL } from '../../hooks/use-list-filters';
+import { useListKeyboardNav } from '../../hooks/use-list-keyboard-nav';
 import { DEFAULT_PAGE_SIZE } from '../../lib/constants';
 import { cn } from '../../lib/cn';
 import { formatEpochRelative, capitalize } from '../../lib/format';
@@ -40,25 +42,22 @@ function RunStatusBadge({ status }: { status: string }) {
   );
 }
 
-function SkeletonRow() {
+function SkeletonRailRow() {
   return (
-    <tr className="border-b border-outline-variant/20">
-      <td className="px-4 py-3">
-        <div className="h-4 w-4 animate-pulse rounded bg-surface-container" />
-      </td>
-      {[200, 80, 100, 80, 80, 80].map((w, i) => (
-        <td key={i} className="px-4 py-3">
-          <div className={cn('h-4 animate-pulse rounded bg-surface-container')} style={{ width: w }} />
-        </td>
-      ))}
-      <td className="px-2 py-3 w-10">
-        <div className="h-4 w-4 animate-pulse rounded bg-surface-container" />
-      </td>
-    </tr>
+    <div className="border-b border-outline-variant/20 px-4 py-3">
+      <div className="flex items-center gap-3">
+        <div className="h-4 w-4 animate-pulse rounded bg-surface-container shrink-0" />
+        <div className="h-4 w-4 animate-pulse rounded bg-surface-container shrink-0" />
+        <div className="flex-1 space-y-2">
+          <div className="h-4 w-2/3 animate-pulse rounded bg-surface-container" />
+          <div className="h-3 w-1/2 animate-pulse rounded bg-surface-container" />
+        </div>
+      </div>
+    </div>
   );
 }
 
-interface RunRowItemProps {
+interface RunRailRowProps {
   run: RunRow;
   /** Called with the run id so callers don't allocate a new closure per row. */
   onSelectRun: (id: string) => void;
@@ -66,22 +65,35 @@ interface RunRowItemProps {
   selected: boolean;
   onToggleSelected: (id: string) => void;
   onRerun: (run: RunRow) => void;
+  isActive: boolean;
+  isCursor: boolean;
 }
 
-const RunRowItem = memo(function RunRowItem({
+const RunRailRow = memo(forwardRef<HTMLDivElement, RunRailRowProps>(function RunRailRow({
   run,
   onSelectRun,
   taskNameMap,
   selected,
   onToggleSelected,
   onRerun,
-}: RunRowItemProps) {
+  isActive,
+  isCursor,
+}, ref) {
   const onClick = useCallback(() => onSelectRun(run.id), [onSelectRun, run.id]);
   const taskLabel = run.task ? taskNameMap.get(run.task) ?? run.task : UNKNOWN_TASK_LABEL;
 
   return (
-    <tr
-      className="border-b border-outline-variant/20 last:border-0 hover:bg-surface-container-high/50 cursor-pointer transition-all duration-150 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40 hover:shadow-[inset_3px_0_0_var(--primary)]"
+    <div
+      ref={ref}
+      data-selected={isActive || undefined}
+      data-cursor={isCursor || undefined}
+      className={cn(
+        'group border-b border-outline-variant/20 last:border-0 px-4 py-3 cursor-pointer transition-all duration-150',
+        'hover:bg-surface-container-high/50 hover:shadow-[inset_3px_0_0_var(--primary)]',
+        'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40',
+        isActive && 'bg-surface-container-high shadow-[inset_3px_0_0_var(--primary)]',
+        isCursor && !isActive && 'bg-surface-container/40 ring-2 ring-inset ring-primary/30',
+      )}
       onClick={onClick}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
@@ -91,101 +103,105 @@ const RunRowItem = memo(function RunRowItem({
       }}
       tabIndex={0}
       role="row"
+      aria-selected={isActive}
       aria-label={`Agent run: ${taskLabel}, status ${run.status}`}
     >
-      <td
-        className="px-4 py-3"
-        onClick={(e) => {
-          // Stop row-click from firing when clicking the checkbox or its <td>.
-          e.stopPropagation();
-        }}
-      >
-        <input
-          type="checkbox"
-          aria-label={`Select run ${run.id.slice(0, 8)}`}
-          checked={selected}
-          onChange={() => onToggleSelected(run.id)}
+      <div className="flex items-start gap-3">
+        {/* Compare checkbox */}
+        <div
+          className="pt-1 shrink-0"
           onClick={(e) => e.stopPropagation()}
-          className="h-4 w-4 rounded accent-primary cursor-pointer"
-        />
-      </td>
-      <td className="px-4 py-3">
-        <div className="flex items-center gap-2">
-          <Bot className="h-3.5 w-3.5 shrink-0 text-on-surface-variant" />
-          <span className="text-sm font-medium text-on-surface truncate max-w-xs">
-            {taskLabel}
-          </span>
-          {run.dry_run && (
-            <span
-              className="inline-flex items-center rounded-xs bg-secondary/15 px-1.5 py-0.5 font-sans text-[10px] uppercase tracking-wide text-secondary"
-              title="Dry run — writes were intercepted, no vault mutations"
-            >
-              Dry
-            </span>
-          )}
-        </div>
-      </td>
-      <td className="px-4 py-3">
-        <div className="flex items-center gap-2">
-          <RunStatusBadge status={run.status} />
-          {run.resumable && run.status === 'failed' && (
-            <span className="font-sans text-[10px] uppercase tracking-wide text-secondary">resumable</span>
-          )}
-        </div>
-      </td>
-      <td className="px-4 py-3 text-xs text-on-surface-variant font-mono">
-        {formatEpochRelative(run.started_at)}
-      </td>
-      <td className="px-4 py-3 text-xs text-on-surface-variant font-mono">
-        {formatDuration(run.started_at, run.completed_at)}
-      </td>
-      <td className="px-4 py-3 text-xs text-on-surface-variant font-mono">
-        {formatTokens(run.tokens_used)}
-      </td>
-      <td className="px-4 py-3 text-xs text-on-surface-variant font-mono">
-        <div className="flex items-center gap-2">
-          <span>{formatCost(run.cost_usd, run.cost_source)}</span>
-          {run.cost_source === 'estimated' && (
-            <span className="font-sans text-[10px] uppercase tracking-wide text-secondary">est</span>
-          )}
-        </div>
-      </td>
-      <td
-        className="px-2 py-3 w-10"
-        onClick={(e) => {
-          // Stop row-click from firing — rerun opens a confirmation dialog,
-          // not the run detail.
-          e.stopPropagation();
-        }}
-      >
-        <Button
-          size="icon"
-          variant="ghost"
-          className="h-7 w-7 text-on-surface-variant hover:text-on-surface"
-          onClick={(e) => {
-            e.stopPropagation();
-            onRerun(run);
-          }}
-          title="Rerun with same settings"
-          aria-label={`Rerun ${run.id.slice(0, 8)} with same settings`}
         >
-          <RotateCcw className="h-3.5 w-3.5" />
-        </Button>
-      </td>
-    </tr>
+          <input
+            type="checkbox"
+            aria-label={`Select run ${run.id.slice(0, 8)}`}
+            checked={selected}
+            onChange={() => onToggleSelected(run.id)}
+            onClick={(e) => e.stopPropagation()}
+            className="h-4 w-4 rounded accent-primary cursor-pointer"
+          />
+        </div>
+
+        <Bot className="h-4 w-4 shrink-0 text-on-surface-variant mt-0.5" />
+
+        {/* Main content */}
+        <div className="flex-1 min-w-0 space-y-1.5">
+          {/* Top line: task label + flags */}
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-on-surface truncate">
+              {taskLabel}
+            </span>
+            {run.dry_run && (
+              <span
+                className="inline-flex items-center rounded-xs bg-secondary/15 px-1.5 py-0.5 font-sans text-[10px] uppercase tracking-wide text-secondary shrink-0"
+                title="Dry run — writes were intercepted, no vault mutations"
+              >
+                Dry
+              </span>
+            )}
+          </div>
+
+          {/* Status line */}
+          <div className="flex items-center gap-2">
+            <RunStatusBadge status={run.status} />
+            {run.resumable && run.status === 'failed' && (
+              <span className="font-sans text-[10px] uppercase tracking-wide text-secondary">resumable</span>
+            )}
+            {run.cost_source === 'estimated' && (
+              <span className="font-sans text-[10px] uppercase tracking-wide text-secondary">est</span>
+            )}
+          </div>
+
+          {/* Meta line: started · duration · tokens · cost */}
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-on-surface-variant font-mono">
+            <span>{formatEpochRelative(run.started_at)}</span>
+            <span aria-hidden="true">·</span>
+            <span>{formatDuration(run.started_at, run.completed_at)}</span>
+            <span aria-hidden="true">·</span>
+            <span>{formatTokens(run.tokens_used)} tok</span>
+            <span aria-hidden="true">·</span>
+            <span>{formatCost(run.cost_usd, run.cost_source)}</span>
+          </div>
+        </div>
+
+        {/* Rerun action */}
+        <div
+          className="shrink-0"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-7 w-7 text-on-surface-variant hover:text-on-surface opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRerun(run);
+            }}
+            title="Rerun with same settings"
+            aria-label={`Rerun ${run.id.slice(0, 8)} with same settings`}
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+    </div>
   );
-});
+}));
 
 /* ---------- Component ---------- */
 
 export interface RunListProps {
+  /** When set, the row with this run id renders as active. Also seeds the
+   *  keyboard-nav cursor so j/k continues from the selection. */
+  selectedId?: string;
   onSelectRun: (id: string) => void;
   onTriggerRun: () => void;
   /** Navigates to an ad-hoc comparison over the selected run ids. */
   onCompareRuns: (ids: string[]) => void;
 }
 
-export function RunList({ onSelectRun, onTriggerRun, onCompareRuns }: RunListProps) {
+export function RunList({ selectedId, onSelectRun, onTriggerRun, onCompareRuns }: RunListProps) {
+  const filterInputRef = useRef<HTMLInputElement>(null);
   const { searchInput, debouncedSearch, filterValues, offset, setOffset, handleSearchChange, handleFilterChange, activeFilter } = useListFilters({
     initialFilters: { status: FILTER_ALL, task: FILTER_ALL },
   });
@@ -247,6 +263,14 @@ export function RunList({ onSelectRun, onTriggerRun, onCompareRuns }: RunListPro
   const runs = data?.runs ?? [];
   const total = data?.total ?? 0;
 
+  const nav = useListKeyboardNav({
+    items: runs,
+    getId: (r) => r.id,
+    selectedId,
+    onActivate: (id) => onSelectRun(id),
+    filterInputRef,
+  });
+
   const toolbar = (
     <ListToolbar
       searchPlaceholder="Search runs..."
@@ -255,31 +279,13 @@ export function RunList({ onSelectRun, onTriggerRun, onCompareRuns }: RunListPro
       filters={filters}
       filterValues={filterValues}
       onFilterChange={handleFilterChange}
+      inputRef={filterInputRef}
     />
-  );
-
-  const tableHeader = (
-    <thead>
-      <tr className="border-b border-outline-variant/20 bg-surface-container/50">
-        <th className="px-4 py-3 text-left text-xs font-medium text-on-surface-variant uppercase tracking-widest font-sans w-10" aria-label="Select">
-          <span className="sr-only">Select</span>
-        </th>
-        <th className="px-4 py-3 text-left text-xs font-medium text-on-surface-variant uppercase tracking-widest font-sans">Task</th>
-        <th className="px-4 py-3 text-left text-xs font-medium text-on-surface-variant uppercase tracking-widest font-sans">Status</th>
-        <th className="px-4 py-3 text-left text-xs font-medium text-on-surface-variant uppercase tracking-widest font-sans">Started</th>
-        <th className="px-4 py-3 text-left text-xs font-medium text-on-surface-variant uppercase tracking-widest font-sans">Duration</th>
-        <th className="px-4 py-3 text-left text-xs font-medium text-on-surface-variant uppercase tracking-widest font-sans">Tokens</th>
-        <th className="px-4 py-3 text-left text-xs font-medium text-on-surface-variant uppercase tracking-widest font-sans">Cost</th>
-        <th className="px-2 py-3 w-10" aria-label="Rerun">
-          <span className="sr-only">Rerun</span>
-        </th>
-      </tr>
-    </thead>
   );
 
   if (isError) {
     return (
-      <div className="space-y-4">
+      <div className="p-4 space-y-4">
         {toolbar}
         <div className="flex h-40 flex-col items-center justify-center gap-2 text-tertiary">
           <AlertCircle className="h-5 w-5" />
@@ -293,17 +299,12 @@ export function RunList({ onSelectRun, onTriggerRun, onCompareRuns }: RunListPro
   }
 
   return (
-    <div className="space-y-4">
+    <div className="p-4 space-y-4">
       {toolbar}
 
       {isLoading ? (
         <div className="rounded-md bg-surface-container-low overflow-hidden">
-          <table className="w-full">
-            {tableHeader}
-            <tbody>
-              {[1, 2, 3].map((i) => <SkeletonRow key={i} />)}
-            </tbody>
-          </table>
+          {[1, 2, 3].map((i) => <SkeletonRailRow key={i} />)}
         </div>
       ) : runs.length === 0 ? (
         <div className="flex h-48 flex-col items-center justify-center gap-3 rounded-md bg-surface-container-low text-on-surface-variant">
@@ -326,23 +327,26 @@ export function RunList({ onSelectRun, onTriggerRun, onCompareRuns }: RunListPro
           )}
         </div>
       ) : (
-        <div className="rounded-md bg-surface-container-low overflow-hidden">
-          <table className="w-full" aria-label="Agent runs">
-            {tableHeader}
-            <tbody>
-              {runs.map((run) => (
-                <RunRowItem
-                  key={run.id}
-                  run={run}
-                  taskNameMap={taskNameMap}
-                  selected={selected.has(run.id)}
-                  onToggleSelected={toggleSelected}
-                  onSelectRun={onSelectRun}
-                  onRerun={setRerunSource}
-                />
-              ))}
-            </tbody>
-          </table>
+        <div
+          {...nav.containerProps}
+          role="group"
+          aria-label="Agent run list keyboard navigation"
+          className="rounded-md bg-surface-container-low overflow-hidden outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40"
+        >
+          {runs.map((run, idx) => (
+            <RunRailRow
+              key={run.id}
+              ref={nav.setRowRef(idx)}
+              run={run}
+              taskNameMap={taskNameMap}
+              selected={selected.has(run.id)}
+              onToggleSelected={toggleSelected}
+              onSelectRun={onSelectRun}
+              onRerun={setRerunSource}
+              isActive={selectedId === run.id}
+              isCursor={nav.cursorIndex === idx}
+            />
+          ))}
         </div>
       )}
 
@@ -353,36 +357,11 @@ export function RunList({ onSelectRun, onTriggerRun, onCompareRuns }: RunListPro
         onPageChange={setOffset}
       />
 
-      {selected.size > 0 && (
-        <div
-          role="region"
-          aria-label="Run selection"
-          className="fixed bottom-6 left-1/2 -translate-x-1/2 z-40 flex items-center gap-3 rounded-full bg-surface-container-high px-4 py-2 shadow-lg border border-outline-variant/30"
-        >
-          <span className="font-sans text-sm text-on-surface">
-            {selected.size} selected
-          </span>
-          <Button
-            size="sm"
-            variant="default"
-            className="gap-2"
-            disabled={selected.size < 2}
-            onClick={() => onCompareRuns([...selected])}
-          >
-            <GitCompare className="h-3.5 w-3.5" />
-            Compare {selected.size} {selected.size === 1 ? 'run' : 'runs'}
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            className="gap-2 text-on-surface-variant"
-            onClick={clearSelection}
-          >
-            <X className="h-3.5 w-3.5" />
-            Clear selection
-          </Button>
-        </div>
-      )}
+      <CompareBar
+        selectedCount={selected.size}
+        onClear={clearSelection}
+        onCompare={() => onCompareRuns([...selected])}
+      />
 
       {/* "Rerun with same settings" dialog — opens pre-filled from rerunSource.
           Conditionally mounted so the dialog's hook subscriptions

--- a/packages/myco/ui/src/components/agent/RunList.tsx
+++ b/packages/myco/ui/src/components/agent/RunList.tsx
@@ -13,6 +13,7 @@ import { useListKeyboardNav } from '../../hooks/use-list-keyboard-nav';
 import { DEFAULT_PAGE_SIZE } from '../../lib/constants';
 import { cn } from '../../lib/cn';
 import { formatEpochAgo, capitalize } from '../../lib/format';
+import { sectionRows } from '../../lib/section-rows';
 import { statusBadgeVariant, formatDuration, UNKNOWN_TASK_LABEL } from './helpers';
 
 /* ---------- Constants ---------- */
@@ -370,20 +371,49 @@ export function RunList({ selectedId, onSelectRun, onTriggerRun, onCompareRuns }
           aria-label="Agent run list keyboard navigation"
           className="rounded-md bg-surface-container-low overflow-hidden outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40"
         >
-          {runs.map((run, idx) => (
-            <RunRailRow
-              key={run.id}
-              ref={nav.setRowRef(idx)}
-              run={run}
-              taskNameMap={taskNameMap}
-              selected={selected.has(run.id)}
-              onToggleSelected={toggleSelected}
-              onSelectRun={onSelectRun}
-              onRerun={setRerunSource}
-              isActive={selectedId === run.id}
-              isCursor={nav.cursorIndex === idx}
-            />
-          ))}
+          {(() => {
+            const sections = sectionRows(runs, {
+              isActive: (r) => r.status === 'running',
+              startedAtEpochSec: (r) => r.started_at,
+            });
+            // Keyboard nav was wired with items=runs (flat array). The
+            // setRowRef/cursorIndex indices must match positions in that
+            // flat array, NOT positions within their section — so j/k
+            // crosses section boundaries seamlessly.
+            let flatIdx = 0;
+            return sections.map((section) => (
+              <div key={section.label}>
+                <div
+                  role="separator"
+                  className="flex items-center justify-between px-4 py-2 border-b border-outline-variant/20 bg-surface-container/30"
+                >
+                  <span className="font-mono text-[10px] uppercase tracking-wider text-on-surface-variant">
+                    {section.label}
+                  </span>
+                  <span className="font-mono text-[10px] text-on-surface-variant">
+                    {section.rows.length}
+                  </span>
+                </div>
+                {section.rows.map((run) => {
+                  const idx = flatIdx++;
+                  return (
+                    <RunRailRow
+                      key={run.id}
+                      ref={nav.setRowRef(idx)}
+                      run={run}
+                      taskNameMap={taskNameMap}
+                      selected={selected.has(run.id)}
+                      onToggleSelected={toggleSelected}
+                      onSelectRun={onSelectRun}
+                      onRerun={setRerunSource}
+                      isActive={selectedId === run.id}
+                      isCursor={nav.cursorIndex === idx}
+                    />
+                  );
+                })}
+              </div>
+            ));
+          })()}
         </div>
       )}
 

--- a/packages/myco/ui/src/components/agent/RunList.tsx
+++ b/packages/myco/ui/src/components/agent/RunList.tsx
@@ -309,6 +309,32 @@ export function RunList({ selectedId, onSelectRun, onTriggerRun, onCompareRuns }
     filterInputRef,
   });
 
+  // Page-local sums: aggregates reflect the visible page only. RunRow has
+  // no per-run tool-call count (turn-level data lives in `agent_turns`,
+  // which is not loaded with the run list). TOKENS is the closest aggregate
+  // available without an N+1 fetch — TOTAL comes from the paginated query
+  // response (server-wide for the current filter).
+  const runningCount = runs.filter((r) => r.status === 'running').length;
+  const tokensTotal = runs.reduce((sum, r) => sum + (r.tokens_used ?? 0), 0);
+
+  const totalsHeader = (
+    <div className="px-4 py-3 border-b border-outline-variant/20">
+      <div className="flex items-baseline justify-between gap-2 mb-2">
+        <h2 className="font-mono text-[10px] uppercase tracking-wider text-on-surface-variant">
+          Runs
+        </h2>
+        <span className="font-serif italic text-sm text-on-surface">History</span>
+      </div>
+      <div className="font-mono text-[11px] text-on-surface-variant inline-flex items-center gap-1.5">
+        <span><strong className="text-on-surface font-semibold">{total.toLocaleString()}</strong> TOTAL</span>
+        <span aria-hidden>·</span>
+        <span><strong className="text-on-surface font-semibold">{runningCount.toLocaleString()}</strong> RUNNING</span>
+        <span aria-hidden>·</span>
+        <span><strong className="text-on-surface font-semibold">{tokensTotal.toLocaleString()}</strong> TOKENS</span>
+      </div>
+    </div>
+  );
+
   const toolbar = (
     <ListToolbar
       searchPlaceholder="Search runs..."
@@ -324,6 +350,7 @@ export function RunList({ selectedId, onSelectRun, onTriggerRun, onCompareRuns }
   if (isError) {
     return (
       <div className="p-4 space-y-4">
+        {totalsHeader}
         {toolbar}
         <div className="flex h-40 flex-col items-center justify-center gap-2 text-tertiary">
           <AlertCircle className="h-5 w-5" />
@@ -338,6 +365,7 @@ export function RunList({ selectedId, onSelectRun, onTriggerRun, onCompareRuns }
 
   return (
     <div className="p-4 space-y-4">
+      {totalsHeader}
       {toolbar}
 
       {isLoading ? (

--- a/packages/myco/ui/src/components/sessions/SessionList.tsx
+++ b/packages/myco/ui/src/components/sessions/SessionList.tsx
@@ -1,17 +1,17 @@
 import { useNavigate } from 'react-router-dom';
-import { AlertCircle, MessageSquare, Trash2 } from 'lucide-react';
-import { Badge } from '../ui/badge';
+import { AlertCircle, GitBranch, MessageSquare, Trash2 } from 'lucide-react';
 import { Surface } from '../ui/surface';
 import { PageHeader } from '../ui/page-header';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { ListToolbar, type FilterDefinition } from '../ui/list-toolbar';
 import { Pagination } from '../ui/pagination';
+import { StatusDot, type StatusTone } from '../ui/status-dot';
+import { Sparkline } from '../ui/sparkline';
 import { useSessions, useDeleteSession, useSessionImpact, type SessionSummary } from '../../hooks/use-sessions';
 import { useSymbionts } from '../../hooks/use-symbionts';
 import { useListFilters, FILTER_ALL } from '../../hooks/use-list-filters';
 import { DEFAULT_PAGE_SIZE } from '../../lib/constants';
-import { shortSession } from '../../lib/format';
-import { StatusBadge } from './status-helpers';
+import { shortSession, formatEpochAgo } from '../../lib/format';
 import { ReleaseStateDot } from '../release-state/ReleaseStateBadge';
 import { cn } from '../../lib/cn';
 import { forwardRef, useMemo, useRef, useState } from 'react';
@@ -21,9 +21,6 @@ import { useListKeyboardNav } from '../../hooks/use-list-keyboard-nav';
 
 /** Number of skeleton rows to show during loading. */
 const SKELETON_ROW_COUNT = 5;
-
-/** Characters shown from session ID in table column. */
-const SESSION_ID_COLUMN_LENGTH = 12;
 
 const STATUS_FILTER: FilterDefinition = {
   key: 'status',
@@ -35,16 +32,24 @@ const STATUS_FILTER: FilterDefinition = {
   ],
 };
 
+/* ---------- Helpers ---------- */
+
+function statusTone(status: string): StatusTone {
+  if (status === 'active') return 'sage';
+  if (status === 'completed') return 'outline';
+  return 'ochre';
+}
+
 /* ---------- Sub-components ---------- */
 
-const SessionTableRow = forwardRef<HTMLTableRowElement, {
+const SessionCardRow = forwardRef<HTMLDivElement, {
   session: SessionSummary;
   symbiontDisplayName: string;
   isSelected: boolean;
   isCursor: boolean;
   onClick: () => void;
   onDelete: () => void;
-}>(function SessionTableRow({
+}>(function SessionCardRow({
   session,
   symbiontDisplayName,
   isSelected,
@@ -55,12 +60,14 @@ const SessionTableRow = forwardRef<HTMLTableRowElement, {
   const sessionLabel = session.title || shortSession(session.id);
 
   return (
-    <tr
+    <div
       ref={ref}
       data-selected={isSelected || undefined}
       data-cursor={isCursor || undefined}
       className={cn(
-        'border-b border-[var(--ghost-border)] last:border-0 hover:bg-surface-container/60 cursor-pointer transition-all duration-150 group focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40 hover:shadow-[inset_3px_0_0_var(--primary)]',
+        'group relative border-b border-outline-variant/20 last:border-0 px-4 py-3 cursor-pointer transition-all duration-150',
+        'hover:bg-surface-container-high/50 hover:shadow-[inset_3px_0_0_var(--primary)]',
+        'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40',
         isSelected && 'bg-surface-container-high shadow-[inset_3px_0_0_var(--primary)]',
         isCursor && !isSelected && 'bg-surface-container/40 ring-2 ring-inset ring-primary/30',
       )}
@@ -76,50 +83,24 @@ const SessionTableRow = forwardRef<HTMLTableRowElement, {
       aria-selected={isSelected}
       aria-label={`Session: ${sessionLabel}`}
     >
-      {/* Session ID */}
-      <td className="px-4 py-3">
-        <span className="font-mono text-xs text-on-surface-variant">
-          {session.id.slice(0, SESSION_ID_COLUMN_LENGTH)}
-        </span>
-      </td>
-
-      {/* Title */}
-      <td className="px-4 py-3">
-        <span className="font-sans text-sm font-medium text-on-surface truncate block max-w-xs">
-          {sessionLabel}
-        </span>
-      </td>
-
-      {/* Symbiont */}
-      <td className="px-4 py-3">
-        <Badge variant="outline" className="font-mono text-[10px] px-1.5 py-0">
-          {symbiontDisplayName}
-        </Badge>
-      </td>
-
-      {/* Status */}
-      <td className="px-4 py-3">
-        <StatusBadge status={session.status} />
-      </td>
-
-      {/* Release */}
-      <td className="px-4 py-3 text-center">
-        <ReleaseStateDot annotation={session.release_state} className="mx-auto" />
-      </td>
-
-      {/* Turns */}
-      <td className="px-4 py-3 text-center">
-        <span className="font-mono text-xs text-on-surface-variant">
-          {session.prompt_count}
-        </span>
-      </td>
-
-      {/* Last Activity */}
-      <td className="px-4 py-3">
-        <div className="flex items-center justify-between gap-2">
-          <span className="font-mono text-xs text-on-surface-variant">
-            {session.date}
+      {/* Top row: status + title on the left, time + sparkline + actions on the right */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-2 min-w-0 flex-1">
+          <StatusDot
+            tone={statusTone(session.status)}
+            pulse={session.status === 'active'}
+            className="mt-1.5 shrink-0"
+          />
+          <h3 className="font-serif italic text-sm text-on-surface truncate leading-snug">
+            {sessionLabel}
+          </h3>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <ReleaseStateDot annotation={session.release_state} />
+          <span className="font-mono text-[10px] text-on-surface-variant whitespace-nowrap">
+            {formatEpochAgo(session.started_at)}
           </span>
+          <Sparkline data={session.activity_buckets} widthPx={48} heightPx={14} />
           <button
             onClick={(e) => {
               e.stopPropagation();
@@ -130,38 +111,46 @@ const SessionTableRow = forwardRef<HTMLTableRowElement, {
                 e.stopPropagation();
               }
             }}
-            className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-1 rounded hover:bg-tertiary/10 hover:text-tertiary transition-all shrink-0 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-tertiary/40"
+            className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-1 rounded hover:bg-tertiary/10 hover:text-tertiary transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-tertiary/40"
             aria-label={`Delete session ${sessionLabel}`}
             title="Delete session"
           >
             <Trash2 className="h-3.5 w-3.5" />
           </button>
         </div>
-      </td>
-    </tr>
+      </div>
+
+      {/* Meta line: agent · symbiont · prompts · tools */}
+      <div className="mt-1.5 ml-5 font-mono text-[11px] text-on-surface-variant truncate">
+        {session.agent} · {symbiontDisplayName} · {session.prompt_count}p · {session.tool_count}t
+      </div>
+
+      {/* Branch line: rendered only when a branch was captured */}
+      {session.branch && (
+        <div className="mt-0.5 ml-5 inline-flex items-center gap-1 font-mono text-[10px] italic text-on-surface-variant">
+          <GitBranch className="h-2.5 w-2.5" />
+          {session.branch}
+        </div>
+      )}
+    </div>
   );
 });
 
-function SkeletonTableRow() {
+function SkeletonCardRow() {
   return (
-    <tr className="border-b border-[var(--ghost-border)]">
-      <td className="px-4 py-3"><div className="h-3 w-20 rounded bg-surface-container-high animate-pulse" /></td>
-      <td className="px-4 py-3"><div className="h-3 w-40 rounded bg-surface-container-high animate-pulse" /></td>
-      <td className="px-4 py-3"><div className="h-3 w-16 rounded bg-surface-container-high animate-pulse" /></td>
-      <td className="px-4 py-3"><div className="h-3 w-16 rounded bg-surface-container-high animate-pulse" /></td>
-      <td className="px-4 py-3 text-center"><div className="h-2.5 w-2.5 rounded-full bg-surface-container-high animate-pulse mx-auto" /></td>
-      <td className="px-4 py-3"><div className="h-3 w-8 rounded bg-surface-container-high animate-pulse mx-auto" /></td>
-      <td className="px-4 py-3"><div className="h-3 w-20 rounded bg-surface-container-high animate-pulse" /></td>
-    </tr>
-  );
-}
-
-/** Column header with consistent styling. */
-function ColHeader({ children, className }: { children: React.ReactNode; className?: string }) {
-  return (
-    <th className={cn('px-4 py-3 text-left font-sans text-[10px] font-medium uppercase tracking-widest text-on-surface-variant', className)}>
-      {children}
-    </th>
+    <div className="border-b border-outline-variant/20 px-4 py-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-2 min-w-0 flex-1">
+          <div className="mt-1.5 h-1.5 w-1.5 rounded-full bg-surface-container-high animate-pulse shrink-0" />
+          <div className="h-3 w-48 rounded bg-surface-container-high animate-pulse" />
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <div className="h-3 w-10 rounded bg-surface-container-high animate-pulse" />
+          <div className="h-3 w-12 rounded bg-surface-container-high animate-pulse" />
+        </div>
+      </div>
+      <div className="mt-1.5 ml-5 h-2.5 w-40 rounded bg-surface-container-high animate-pulse" />
+    </div>
   );
 }
 
@@ -256,20 +245,6 @@ export function SessionList({ selectedId }: SessionListProps = {}) {
     />
   );
 
-  const tableHead = (
-    <thead>
-      <tr className="border-b border-[var(--ghost-border)] bg-surface-container/50">
-        <ColHeader>Session ID</ColHeader>
-        <ColHeader>Title</ColHeader>
-        <ColHeader>Symbiont</ColHeader>
-        <ColHeader>Status</ColHeader>
-        <ColHeader className="w-16 text-center">Release</ColHeader>
-        <ColHeader className="text-center">Turns</ColHeader>
-        <ColHeader>Date</ColHeader>
-      </tr>
-    </thead>
-  );
-
   if (isError) {
     return (
       <div className="p-4">
@@ -297,14 +272,11 @@ export function SessionList({ selectedId }: SessionListProps = {}) {
 
       {isLoading ? (
         <Surface level="low" className="rounded-md overflow-hidden mt-4">
-          <table className="w-full">
-            {tableHead}
-            <tbody>
-              {Array.from({ length: SKELETON_ROW_COUNT }).map((_, i) => (
-                <SkeletonTableRow key={i} />
-              ))}
-            </tbody>
-          </table>
+          <div role="list" aria-label="Session archive loading">
+            {Array.from({ length: SKELETON_ROW_COUNT }).map((_, i) => (
+              <SkeletonCardRow key={i} />
+            ))}
+          </div>
         </Surface>
       ) : sessions.length === 0 ? (
         <div className="flex h-40 flex-col items-center justify-center gap-2 text-on-surface-variant mt-4">
@@ -322,27 +294,22 @@ export function SessionList({ selectedId }: SessionListProps = {}) {
         <Surface level="low" className="rounded-md overflow-hidden mt-4">
           <div
             {...nav.containerProps}
-            role="group"
-            aria-label="Session list keyboard navigation"
+            role="list"
+            aria-label="Session archive"
             className="outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40"
           >
-            <table className="w-full" aria-label="Session archive">
-              {tableHead}
-              <tbody>
-                {sessions.map((session, idx) => (
-                  <SessionTableRow
-                    key={session.id}
-                    ref={nav.setRowRef(idx)}
-                    session={session}
-                    symbiontDisplayName={symbiontDisplayName(session.agent)}
-                    isSelected={selectedId === session.id}
-                    isCursor={nav.cursorIndex === idx}
-                    onClick={() => navigate(`/sessions/${session.id}`)}
-                    onDelete={() => setDeleteTarget(session)}
-                  />
-                ))}
-              </tbody>
-            </table>
+            {sessions.map((session, idx) => (
+              <SessionCardRow
+                key={session.id}
+                ref={nav.setRowRef(idx)}
+                session={session}
+                symbiontDisplayName={symbiontDisplayName(session.agent)}
+                isSelected={selectedId === session.id}
+                isCursor={nav.cursorIndex === idx}
+                onClick={() => navigate(`/sessions/${session.id}`)}
+                onDelete={() => setDeleteTarget(session)}
+              />
+            ))}
           </div>
         </Surface>
       )}

--- a/packages/myco/ui/src/components/sessions/SessionList.tsx
+++ b/packages/myco/ui/src/components/sessions/SessionList.tsx
@@ -14,7 +14,8 @@ import { shortSession } from '../../lib/format';
 import { StatusBadge } from './status-helpers';
 import { ReleaseStateDot } from '../release-state/ReleaseStateBadge';
 import { cn } from '../../lib/cn';
-import { useMemo, useState } from 'react';
+import { forwardRef, useMemo, useRef, useState } from 'react';
+import { useListKeyboardNav } from '../../hooks/use-list-keyboard-nav';
 
 /* ---------- Constants ---------- */
 
@@ -36,22 +37,33 @@ const STATUS_FILTER: FilterDefinition = {
 
 /* ---------- Sub-components ---------- */
 
-function SessionTableRow({
-  session,
-  symbiontDisplayName,
-  onClick,
-  onDelete,
-}: {
+const SessionTableRow = forwardRef<HTMLTableRowElement, {
   session: SessionSummary;
   symbiontDisplayName: string;
+  isSelected: boolean;
+  isCursor: boolean;
   onClick: () => void;
   onDelete: () => void;
-}) {
+}>(function SessionTableRow({
+  session,
+  symbiontDisplayName,
+  isSelected,
+  isCursor,
+  onClick,
+  onDelete,
+}, ref) {
   const sessionLabel = session.title || shortSession(session.id);
 
   return (
     <tr
-      className="border-b border-[var(--ghost-border)] last:border-0 hover:bg-surface-container/60 cursor-pointer transition-all duration-150 group focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40 hover:shadow-[inset_3px_0_0_var(--primary)]"
+      ref={ref}
+      data-selected={isSelected || undefined}
+      data-cursor={isCursor || undefined}
+      className={cn(
+        'border-b border-[var(--ghost-border)] last:border-0 hover:bg-surface-container/60 cursor-pointer transition-all duration-150 group focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40 hover:shadow-[inset_3px_0_0_var(--primary)]',
+        isSelected && 'bg-surface-container-high shadow-[inset_3px_0_0_var(--primary)]',
+        isCursor && !isSelected && 'bg-surface-container/40 ring-2 ring-inset ring-primary/30',
+      )}
       onClick={onClick}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
@@ -61,6 +73,7 @@ function SessionTableRow({
       }}
       tabIndex={0}
       role="row"
+      aria-selected={isSelected}
       aria-label={`Session: ${sessionLabel}`}
     >
       {/* Session ID */}
@@ -127,7 +140,7 @@ function SessionTableRow({
       </td>
     </tr>
   );
-}
+});
 
 function SkeletonTableRow() {
   return (
@@ -154,8 +167,15 @@ function ColHeader({ children, className }: { children: React.ReactNode; classNa
 
 /* ---------- Component ---------- */
 
-export function SessionList() {
+export interface SessionListProps {
+  /** When set, the row with this session id renders as active. Also seeds the
+   * keyboard-nav cursor so j/k continues from the selection. */
+  selectedId?: string;
+}
+
+export function SessionList({ selectedId }: SessionListProps = {}) {
   const navigate = useNavigate();
+  const filterInputRef = useRef<HTMLInputElement>(null);
   const { searchInput, debouncedSearch, filterValues, offset, setOffset, handleSearchChange, handleFilterChange, activeFilter } = useListFilters({
     initialFilters: { status: FILTER_ALL, agent: FILTER_ALL },
   });
@@ -216,6 +236,14 @@ export function SessionList() {
   const sessions = data?.sessions ?? [];
   const total = data?.total ?? 0;
 
+  const nav = useListKeyboardNav({
+    items: sessions,
+    getId: (s) => s.id,
+    selectedId,
+    onActivate: (id) => navigate(`/sessions/${id}`),
+    filterInputRef,
+  });
+
   const toolbar = (
     <ListToolbar
       searchPlaceholder="Search sessions..."
@@ -224,6 +252,7 @@ export function SessionList() {
       filters={sessionFilters}
       filterValues={filterValues}
       onFilterChange={handleFilterChange}
+      inputRef={filterInputRef}
     />
   );
 
@@ -243,7 +272,7 @@ export function SessionList() {
 
   if (isError) {
     return (
-      <div>
+      <div className="p-4">
         <PageHeader title="Session Archive" />
         {toolbar}
         <div className="flex h-40 flex-col items-center justify-center gap-2 text-tertiary mt-4">
@@ -258,7 +287,7 @@ export function SessionList() {
   }
 
   return (
-    <div>
+    <div className="p-4">
       <PageHeader
         title="Session Archive"
         subtitle={isLoading ? 'Loading...' : `${total} session${total !== 1 ? 's' : ''} captured`}
@@ -291,20 +320,30 @@ export function SessionList() {
         </div>
       ) : (
         <Surface level="low" className="rounded-md overflow-hidden mt-4">
-          <table className="w-full" aria-label="Session archive">
-            {tableHead}
-            <tbody>
-              {sessions.map((session) => (
-                <SessionTableRow
-                  key={session.id}
-                  session={session}
-                  symbiontDisplayName={symbiontDisplayName(session.agent)}
-                  onClick={() => navigate(`/sessions/${session.id}`)}
-                  onDelete={() => setDeleteTarget(session)}
-                />
-              ))}
-            </tbody>
-          </table>
+          <div
+            {...nav.containerProps}
+            role="group"
+            aria-label="Session list keyboard navigation"
+            className="outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40"
+          >
+            <table className="w-full" aria-label="Session archive">
+              {tableHead}
+              <tbody>
+                {sessions.map((session, idx) => (
+                  <SessionTableRow
+                    key={session.id}
+                    ref={nav.setRowRef(idx)}
+                    session={session}
+                    symbiontDisplayName={symbiontDisplayName(session.agent)}
+                    isSelected={selectedId === session.id}
+                    isCursor={nav.cursorIndex === idx}
+                    onClick={() => navigate(`/sessions/${session.id}`)}
+                    onDelete={() => setDeleteTarget(session)}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
         </Surface>
       )}
 

--- a/packages/myco/ui/src/components/sessions/SessionList.tsx
+++ b/packages/myco/ui/src/components/sessions/SessionList.tsx
@@ -1,7 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { AlertCircle, GitBranch, MessageSquare, Trash2 } from 'lucide-react';
 import { Surface } from '../ui/surface';
-import { PageHeader } from '../ui/page-header';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { ListToolbar, type FilterDefinition } from '../ui/list-toolbar';
 import { Pagination } from '../ui/pagination';
@@ -246,10 +245,35 @@ export function SessionList({ selectedId }: SessionListProps = {}) {
     />
   );
 
+  // Page-local sums: aggregates reflect the visible page only. The sessions
+  // query doesn't expose project-scoped totals for prompts/active-status
+  // separately, so we sum what's loaded. TOTAL comes from the paginated
+  // query response (server-wide for the current filter).
+  const activeCount = sessions.filter((s) => s.status === 'active').length;
+  const promptsTotal = sessions.reduce((sum, s) => sum + (s.prompt_count ?? 0), 0);
+
+  const totalsHeader = (
+    <div className="px-4 py-3 border-b border-outline-variant/20">
+      <div className="flex items-baseline justify-between gap-2 mb-2">
+        <h2 className="font-mono text-[10px] uppercase tracking-wider text-on-surface-variant">
+          Sessions
+        </h2>
+        <span className="font-serif italic text-sm text-on-surface">Archive</span>
+      </div>
+      <div className="font-mono text-[11px] text-on-surface-variant inline-flex items-center gap-1.5">
+        <span><strong className="text-on-surface font-semibold">{total.toLocaleString()}</strong> TOTAL</span>
+        <span aria-hidden>·</span>
+        <span><strong className="text-on-surface font-semibold">{activeCount.toLocaleString()}</strong> ACTIVE</span>
+        <span aria-hidden>·</span>
+        <span><strong className="text-on-surface font-semibold">{promptsTotal.toLocaleString()}</strong> PROMPTS</span>
+      </div>
+    </div>
+  );
+
   if (isError) {
     return (
       <div className="p-4">
-        <PageHeader title="Session Archive" />
+        {totalsHeader}
         {toolbar}
         <div className="flex h-40 flex-col items-center justify-center gap-2 text-tertiary mt-4">
           <AlertCircle className="h-5 w-5" />
@@ -264,10 +288,7 @@ export function SessionList({ selectedId }: SessionListProps = {}) {
 
   return (
     <div className="p-4">
-      <PageHeader
-        title="Session Archive"
-        subtitle={isLoading ? 'Loading...' : `${total} session${total !== 1 ? 's' : ''} captured`}
-      />
+      {totalsHeader}
 
       {toolbar}
 

--- a/packages/myco/ui/src/components/sessions/SessionList.tsx
+++ b/packages/myco/ui/src/components/sessions/SessionList.tsx
@@ -13,6 +13,7 @@ import { useListFilters, FILTER_ALL } from '../../hooks/use-list-filters';
 import { DEFAULT_PAGE_SIZE } from '../../lib/constants';
 import { shortSession, formatEpochAgo } from '../../lib/format';
 import { ReleaseStateDot } from '../release-state/ReleaseStateBadge';
+import { sectionRows } from '../../lib/section-rows';
 import { cn } from '../../lib/cn';
 import { forwardRef, useMemo, useRef, useState } from 'react';
 import { useListKeyboardNav } from '../../hooks/use-list-keyboard-nav';
@@ -298,18 +299,47 @@ export function SessionList({ selectedId }: SessionListProps = {}) {
             aria-label="Session archive"
             className="outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40"
           >
-            {sessions.map((session, idx) => (
-              <SessionCardRow
-                key={session.id}
-                ref={nav.setRowRef(idx)}
-                session={session}
-                symbiontDisplayName={symbiontDisplayName(session.agent)}
-                isSelected={selectedId === session.id}
-                isCursor={nav.cursorIndex === idx}
-                onClick={() => navigate(`/sessions/${session.id}`)}
-                onDelete={() => setDeleteTarget(session)}
-              />
-            ))}
+            {(() => {
+              const sections = sectionRows(sessions, {
+                isActive: (s) => s.status === 'active',
+                startedAtEpochSec: (s) => s.started_at,
+              });
+              // Keyboard nav was wired with items=sessions (flat array). The
+              // setRowRef/cursorIndex indices must match positions in that
+              // flat array, NOT positions within their section — so j/k
+              // crosses section boundaries seamlessly.
+              let flatIdx = 0;
+              return sections.map((section) => (
+                <div key={section.label}>
+                  <div
+                    role="separator"
+                    className="flex items-center justify-between px-4 py-2 border-b border-outline-variant/20 bg-surface-container/30"
+                  >
+                    <span className="font-mono text-[10px] uppercase tracking-wider text-on-surface-variant">
+                      {section.label}
+                    </span>
+                    <span className="font-mono text-[10px] text-on-surface-variant">
+                      {section.rows.length}
+                    </span>
+                  </div>
+                  {section.rows.map((session) => {
+                    const idx = flatIdx++;
+                    return (
+                      <SessionCardRow
+                        key={session.id}
+                        ref={nav.setRowRef(idx)}
+                        session={session}
+                        symbiontDisplayName={symbiontDisplayName(session.agent)}
+                        isSelected={selectedId === session.id}
+                        isCursor={nav.cursorIndex === idx}
+                        onClick={() => navigate(`/sessions/${session.id}`)}
+                        onDelete={() => setDeleteTarget(session)}
+                      />
+                    );
+                  })}
+                </div>
+              ));
+            })()}
           </div>
         </Surface>
       )}

--- a/packages/myco/ui/src/components/ui/compare-bar.tsx
+++ b/packages/myco/ui/src/components/ui/compare-bar.tsx
@@ -1,0 +1,65 @@
+import { GitCompare, X } from 'lucide-react';
+import { Button } from './button';
+import { cn } from '../../lib/cn';
+
+export interface CompareBarProps {
+  selectedCount: number;
+  onClear: () => void;
+  onCompare: () => void;
+  /** Defaults to 2. Primary action is disabled when count < this. */
+  minSelected?: number;
+  /** Defaults to "Compare". */
+  primaryLabel?: string;
+  /** Defaults to "run". Used to render "Compare 1 run". */
+  nounSingular?: string;
+  /** Defaults to "runs". Used to render "Compare 3 runs". */
+  nounPlural?: string;
+  className?: string;
+}
+
+export function CompareBar({
+  selectedCount,
+  onClear,
+  onCompare,
+  minSelected = 2,
+  primaryLabel = 'Compare',
+  nounSingular = 'run',
+  nounPlural = 'runs',
+  className,
+}: CompareBarProps) {
+  if (selectedCount === 0) return null;
+  const noun = selectedCount === 1 ? nounSingular : nounPlural;
+  return (
+    <div
+      role="region"
+      aria-label="Selection actions"
+      className={cn(
+        'fixed bottom-6 left-1/2 -translate-x-1/2 z-40 flex items-center gap-3 rounded-full bg-surface-container-high px-4 py-2 shadow-lg border border-outline-variant/30',
+        className,
+      )}
+    >
+      <span className="font-sans text-sm text-on-surface">
+        {selectedCount} selected
+      </span>
+      <Button
+        size="sm"
+        variant="default"
+        className="gap-2"
+        disabled={selectedCount < minSelected}
+        onClick={onCompare}
+      >
+        <GitCompare className="h-3.5 w-3.5" />
+        {primaryLabel} {selectedCount} {noun}
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        className="gap-2 text-on-surface-variant"
+        onClick={onClear}
+      >
+        <X className="h-3.5 w-3.5" />
+        Clear selection
+      </Button>
+    </div>
+  );
+}

--- a/packages/myco/ui/src/components/ui/empty-detail-hint.tsx
+++ b/packages/myco/ui/src/components/ui/empty-detail-hint.tsx
@@ -1,0 +1,20 @@
+import { cn } from '../../lib/cn';
+
+export interface EmptyDetailHintProps {
+  /** Message shown to the user, e.g. "Select a session" */
+  message: string;
+  className?: string;
+}
+
+export function EmptyDetailHint({ message, className }: EmptyDetailHintProps) {
+  return (
+    <div
+      className={cn(
+        'flex h-full w-full items-center justify-center text-on-surface-variant',
+        className,
+      )}
+    >
+      <span className="font-sans text-sm">{message}</span>
+    </div>
+  );
+}

--- a/packages/myco/ui/src/components/ui/filter-pill.tsx
+++ b/packages/myco/ui/src/components/ui/filter-pill.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { Filter } from 'lucide-react';
+import { cn } from '../../lib/cn';
+
+export interface FilterPillProps {
+  /** Number of filters currently active. When > 0, a count badge appears. */
+  activeCount: number;
+  /** Content rendered inside the popover when open (filter form, checkboxes, etc.). */
+  children: ReactNode;
+  /** Optional label override. Defaults to "Filter". */
+  label?: string;
+  className?: string;
+}
+
+export function FilterPill({ activeCount, children, label = 'Filter', className }: FilterPillProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    const onClick = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('mousedown', onClick);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('mousedown', onClick);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className={cn('relative inline-flex', className)}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        className={cn(
+          'inline-flex items-center gap-2 rounded-full border border-outline-variant/30 bg-surface-container-high px-3 py-1.5 text-xs text-on-surface hover:bg-surface-container transition-colors',
+          activeCount > 0 && 'border-primary/40',
+        )}
+      >
+        <Filter className="h-3 w-3" />
+        <span>{label}</span>
+        {activeCount > 0 && (
+          <span
+            aria-label={`${activeCount} active filter${activeCount === 1 ? '' : 's'}`}
+            className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-on-primary"
+          >
+            {activeCount}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          aria-label={`${label} options`}
+          className="absolute right-0 top-full z-30 mt-2 min-w-[240px] rounded-md border border-outline-variant/30 bg-surface-container-high shadow-lg p-3"
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/myco/ui/src/components/ui/list-toolbar.tsx
+++ b/packages/myco/ui/src/components/ui/list-toolbar.tsx
@@ -1,3 +1,4 @@
+import { type RefObject } from 'react';
 import { Search } from 'lucide-react';
 import { Input } from './input';
 import { Surface } from './surface';
@@ -22,6 +23,8 @@ export interface ListToolbarProps {
   filters?: FilterDefinition[];
   filterValues?: Record<string, string>;
   onFilterChange?: (key: string, value: string) => void;
+  /** Forwarded to the underlying search input so callers can programmatically focus it (e.g. `/` keyboard shortcut). */
+  inputRef?: RefObject<HTMLInputElement | null>;
 }
 
 export function ListToolbar({
@@ -31,11 +34,13 @@ export function ListToolbar({
   filters = [],
   filterValues = {},
   onFilterChange,
+  inputRef,
 }: ListToolbarProps) {
   return (
     <Surface level="bright" className="flex items-center gap-3 px-4 py-2 rounded-md">
       <Search className="h-3.5 w-3.5 text-on-surface-variant shrink-0" />
       <Input
+        ref={inputRef}
         placeholder={searchPlaceholder}
         value={searchValue}
         onChange={(e) => onSearchChange(e.target.value)}

--- a/packages/myco/ui/src/components/ui/master-detail-split.tsx
+++ b/packages/myco/ui/src/components/ui/master-detail-split.tsx
@@ -1,0 +1,88 @@
+import { type ReactNode } from 'react';
+import { ChevronLeft } from 'lucide-react';
+import { useMediaQuery } from '../../hooks/use-media-query';
+import { cn } from '../../lib/cn';
+
+const DESKTOP_BREAKPOINT = '(min-width: 768px)';
+const DEFAULT_RAIL_MIN = 240;
+const DEFAULT_RAIL_MAX = 360;
+
+export interface MasterDetailSplitProps {
+  master: ReactNode;
+  detail: ReactNode;
+  hasSelection: boolean;
+  onCloseMobileDetail?: () => void;
+  railMinWidthPx?: number;
+  railMaxWidthPx?: number;
+  className?: string;
+  /** Accessible label for the master/rail landmark. Defaults to "List". */
+  masterAriaLabel?: string;
+  /** Accessible label for the detail landmark. Defaults to "Details". */
+  detailAriaLabel?: string;
+}
+
+export function MasterDetailSplit({
+  master,
+  detail,
+  hasSelection,
+  onCloseMobileDetail,
+  railMinWidthPx = DEFAULT_RAIL_MIN,
+  railMaxWidthPx = DEFAULT_RAIL_MAX,
+  className,
+  masterAriaLabel = 'List',
+  detailAriaLabel = 'Details',
+}: MasterDetailSplitProps) {
+  const isDesktop = useMediaQuery(DESKTOP_BREAKPOINT);
+
+  if (!isDesktop) {
+    if (hasSelection) {
+      return (
+        <section
+          role="region"
+          aria-label={detailAriaLabel}
+          className={cn('flex h-full w-full flex-col', className)}
+        >
+          {onCloseMobileDetail && (
+            <button
+              type="button"
+              onClick={onCloseMobileDetail}
+              className="sticky top-0 z-10 flex items-center gap-1 border-b border-outline-variant/20 bg-surface-container px-3 py-2 text-sm text-on-surface-variant hover:bg-surface-container-high"
+            >
+              <ChevronLeft className="h-4 w-4" />
+              <span>Back</span>
+            </button>
+          )}
+          <div className="flex-1 overflow-y-auto">{detail}</div>
+        </section>
+      );
+    }
+    return (
+      <section
+        role="region"
+        aria-label={masterAriaLabel}
+        className={cn('h-full w-full overflow-y-auto', className)}
+      >
+        {master}
+      </section>
+    );
+  }
+
+  return (
+    <div className={cn('flex h-full w-full', className)}>
+      <aside
+        aria-label={masterAriaLabel}
+        className="flex-shrink-0 overflow-y-auto border-r border-outline-variant/20"
+        style={{
+          minWidth: railMinWidthPx,
+          maxWidth: railMaxWidthPx,
+          width: `clamp(${railMinWidthPx}px, 30vw, ${railMaxWidthPx}px)`,
+        }}
+      >
+        {master}
+      </aside>
+      <section aria-label={detailAriaLabel} className="flex-1 overflow-y-auto">
+        {detail}
+      </section>
+    </div>
+  );
+}

--- a/packages/myco/ui/src/components/ui/sparkline.tsx
+++ b/packages/myco/ui/src/components/ui/sparkline.tsx
@@ -1,49 +1,66 @@
-interface SparklineProps {
+import { cn } from '../../lib/cn';
+
+export interface SparklineProps {
+  /** Bucket values; bar heights scale to max(data). Render order: index 0 left, last index right. */
   data: number[];
-  width?: number;
-  height?: number;
+  /** Width in px. Defaults to 56. */
+  widthPx?: number;
+  /** Height in px. Defaults to 16. */
+  heightPx?: number;
+  /** Tailwind color class for the bars. Defaults to 'fill-primary/60'. */
+  barClassName?: string;
+  /** Optional accessible label. Defaults to "Activity sparkline". */
+  ariaLabel?: string;
   className?: string;
 }
 
-export function Sparkline({ data, width = 120, height = 40, className }: SparklineProps) {
-  if (data.length < 2) return null;
-
-  const min = Math.min(...data);
-  const max = Math.max(...data);
-  const range = max - min || 1;
-
-  const points = data.map((value, i) => ({
-    x: (i / (data.length - 1)) * width,
-    y: height - ((value - min) / range) * height,
-  }));
-
-  let pathD = `M ${points[0]!.x} ${points[0]!.y}`;
-  for (let i = 0; i < points.length - 1; i++) {
-    const p0 = points[Math.max(0, i - 1)]!;
-    const p1 = points[i]!;
-    const p2 = points[i + 1]!;
-    const p3 = points[Math.min(points.length - 1, i + 2)]!;
-
-    const cp1x = p1.x + (p2.x - p0.x) / 6;
-    const cp1y = p1.y + (p2.y - p0.y) / 6;
-    const cp2x = p2.x - (p3.x - p1.x) / 6;
-    const cp2y = p2.y - (p3.y - p1.y) / 6;
-
-    pathD += ` C ${cp1x} ${cp1y}, ${cp2x} ${cp2y}, ${p2.x} ${p2.y}`;
+export function Sparkline({
+  data,
+  widthPx = 56,
+  heightPx = 16,
+  barClassName = 'fill-primary/60',
+  ariaLabel = 'Activity sparkline',
+  className,
+}: SparklineProps) {
+  const n = data.length;
+  if (n === 0) {
+    return (
+      <svg
+        role="img"
+        aria-label={ariaLabel}
+        width={widthPx}
+        height={heightPx}
+        className={cn('inline-block', className)}
+      />
+    );
   }
-
-  const fillD = `${pathD} L ${width} ${height} L 0 ${height} Z`;
-
+  const max = Math.max(...data, 1);
+  const gap = 1;
+  const barWidth = Math.max(1, (widthPx - gap * (n - 1)) / n);
   return (
-    <svg width={width} height={height} className={className} viewBox={`0 0 ${width} ${height}`}>
-      <defs>
-        <linearGradient id="sparkline-fill" x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor="var(--primary)" stopOpacity="0.2" />
-          <stop offset="100%" stopColor="var(--primary)" stopOpacity="0" />
-        </linearGradient>
-      </defs>
-      <path d={fillD} fill="url(#sparkline-fill)" />
-      <path d={pathD} fill="none" stroke="var(--primary)" strokeWidth="1.5" strokeOpacity="0.8" />
+    <svg
+      role="img"
+      aria-label={ariaLabel}
+      width={widthPx}
+      height={heightPx}
+      className={cn('inline-block', className)}
+    >
+      {data.map((v, i) => {
+        const h = max === 0 ? 0 : Math.round((v / max) * heightPx);
+        const x = i * (barWidth + gap);
+        const y = heightPx - h;
+        return (
+          <rect
+            key={i}
+            x={x}
+            y={y}
+            width={barWidth}
+            height={h}
+            className={barClassName}
+            rx={0.5}
+          />
+        );
+      })}
     </svg>
   );
 }

--- a/packages/myco/ui/src/components/ui/stat-card.tsx
+++ b/packages/myco/ui/src/components/ui/stat-card.tsx
@@ -52,7 +52,7 @@ export function StatCard({ label, value, sublabel, accent, sparklineData, classN
           {value}
         </p>
         {sparklineData && sparklineData.length >= 2 && (
-          <Sparkline data={sparklineData} width={80} height={28} className="opacity-60" />
+          <Sparkline data={sparklineData} widthPx={80} heightPx={28} className="opacity-60" />
         )}
       </div>
       {sublabel && (

--- a/packages/myco/ui/src/hooks/use-agent.ts
+++ b/packages/myco/ui/src/hooks/use-agent.ts
@@ -115,6 +115,20 @@ export interface RunRow {
     costUsd?: number;
     costSource?: 'actual' | 'estimated' | 'unavailable';
   }>;
+  /**
+   * Recent-activity sparkline data — one `agent_turns` count per 1-minute
+   * bucket over the recent window, newest bucket last. Length matches
+   * `BUCKET_COUNT` on the server. Empty array when the run has no activity
+   * in the window. Optional because legacy/serialized rows may omit it.
+   */
+  activity_buckets?: number[];
+  /**
+   * Git branch resolved from the run's session via the most recent
+   * release-provenance capture. Null when no provenance was recorded for
+   * the linked session, or when the run has no session_ref. Optional —
+   * MCP / legacy serializers may omit the field entirely.
+   */
+  branch?: string | null;
 }
 
 export interface RunsResponse {

--- a/packages/myco/ui/src/hooks/use-list-keyboard-nav.ts
+++ b/packages/myco/ui/src/hooks/use-list-keyboard-nav.ts
@@ -1,0 +1,115 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type RefObject,
+} from 'react';
+
+export interface UseListKeyboardNavOptions<T> {
+  items: T[];
+  getId: (item: T) => string;
+  selectedId?: string;
+  onActivate: (id: string) => void;
+  filterInputRef?: RefObject<HTMLInputElement | null>;
+  enabled?: boolean;
+}
+
+export interface UseListKeyboardNavResult {
+  cursorIndex: number;
+  setRowRef: (idx: number) => (el: HTMLElement | null) => void;
+  containerProps: {
+    tabIndex: 0;
+    onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => void;
+  };
+}
+
+function hasNoModifier(e: KeyboardEvent<HTMLDivElement>): boolean {
+  return !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey;
+}
+
+export function useListKeyboardNav<T>({
+  items,
+  getId,
+  selectedId,
+  onActivate,
+  filterInputRef,
+  enabled = true,
+}: UseListKeyboardNavOptions<T>): UseListKeyboardNavResult {
+  const getIdRef = useRef(getId);
+  getIdRef.current = getId;
+
+  const [cursorIndex, setCursorIndex] = useState(() => {
+    if (!selectedId) return 0;
+    const idx = items.findIndex((it) => getId(it) === selectedId);
+    return idx >= 0 ? idx : 0;
+  });
+  const rowRefs = useRef<Array<HTMLElement | null>>([]);
+  const lastSyncedSelectedId = useRef<string | undefined>(selectedId);
+
+  useEffect(() => {
+    if (lastSyncedSelectedId.current === selectedId) return;
+    lastSyncedSelectedId.current = selectedId;
+    if (!selectedId) return;
+    const idx = items.findIndex((it) => getIdRef.current(it) === selectedId);
+    if (idx >= 0) setCursorIndex(idx);
+  }, [selectedId, items]);
+
+  useEffect(() => {
+    if (cursorIndex >= items.length) {
+      setCursorIndex(Math.max(0, items.length - 1));
+    }
+    if (rowRefs.current.length > items.length) {
+      rowRefs.current.length = items.length;
+    }
+  }, [items.length, cursorIndex]);
+
+  useEffect(() => {
+    const el = rowRefs.current[cursorIndex];
+    if (el && typeof el.scrollIntoView === 'function') {
+      el.scrollIntoView({ block: 'nearest' });
+    }
+  }, [cursorIndex]);
+
+  const setRowRef = useCallback(
+    (idx: number) => (el: HTMLElement | null) => {
+      rowRefs.current[idx] = el;
+    },
+    [],
+  );
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (!enabled) return;
+      if (e.key === '/' && hasNoModifier(e) && filterInputRef?.current) {
+        e.preventDefault();
+        filterInputRef.current.focus();
+        return;
+      }
+      if (!hasNoModifier(e)) return;
+      if (e.key === 'j' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        setCursorIndex((c) => Math.min(items.length - 1, c + 1));
+        return;
+      }
+      if (e.key === 'k' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        setCursorIndex((c) => Math.max(0, c - 1));
+        return;
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const it = items[cursorIndex];
+        if (it) onActivate(getId(it));
+      }
+    },
+    [enabled, items, cursorIndex, onActivate, getId, filterInputRef],
+  );
+
+  return {
+    cursorIndex,
+    setRowRef,
+    containerProps: { tabIndex: 0, onKeyDown },
+  };
+}

--- a/packages/myco/ui/src/hooks/use-media-query.ts
+++ b/packages/myco/ui/src/hooks/use-media-query.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia(query).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mql = window.matchMedia(query);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    setMatches(mql.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, [query]);
+
+  return matches;
+}

--- a/packages/myco/ui/src/hooks/use-sessions.ts
+++ b/packages/myco/ui/src/hooks/use-sessions.ts
@@ -50,6 +50,14 @@ export interface SessionSummary {
   started_at: number;
   ended_at: number | null;
   release_state?: SessionReleaseState;
+  /**
+   * Recent-activity sparkline data — one prompt_batch count per 1-minute
+   * bucket over the recent window, newest bucket last. Empty array when
+   * the session has no activity in the window.
+   */
+  activity_buckets: number[];
+  /** Git branch captured for this session, or null when no provenance was recorded. */
+  branch: string | null;
 }
 
 /** Full session row returned by the detail endpoint. */

--- a/packages/myco/ui/src/lib/section-rows.ts
+++ b/packages/myco/ui/src/lib/section-rows.ts
@@ -1,0 +1,77 @@
+/**
+ * Bucket rail rows into time-window sections (ACTIVE / TODAY / YESTERDAY /
+ * EARLIER) for the v6 mock's section-header rendering. Pure helper, shared
+ * by the Sessions and Runs rails.
+ */
+
+export type SectionLabel = 'ACTIVE' | 'TODAY' | 'YESTERDAY' | 'EARLIER';
+
+export interface SectionedRows<T> {
+  label: SectionLabel;
+  rows: T[];
+}
+
+export interface SectionRowsOptions<T> {
+  /** Returns true when the row counts as active (status === 'active' / 'running'). */
+  isActive: (row: T) => boolean;
+  /**
+   * Epoch seconds when the row was started; used for date-bucketing non-active
+   * rows. Return null/undefined to bucket the row as EARLIER.
+   */
+  startedAtEpochSec: (row: T) => number | null | undefined;
+  /** Override "now" (epoch seconds) for testability. Defaults to Date.now() / 1000. */
+  nowEpochSec?: number;
+}
+
+const SECTION_ORDER: readonly SectionLabel[] = ['ACTIVE', 'TODAY', 'YESTERDAY', 'EARLIER'];
+
+/**
+ * Bucket rows into time-window sections, preserving each section's internal
+ * order. Returned sections are always in display order; sections with zero
+ * rows are omitted.
+ */
+export function sectionRows<T>(
+  rows: readonly T[],
+  options: SectionRowsOptions<T>,
+): Array<SectionedRows<T>> {
+  const { isActive, startedAtEpochSec, nowEpochSec } = options;
+
+  const nowSec = nowEpochSec ?? Math.floor(Date.now() / 1000);
+  const nowDate = new Date(nowSec * 1000);
+  const startOfToday = new Date(nowDate.getFullYear(), nowDate.getMonth(), nowDate.getDate()).getTime() / 1000;
+  const startOfYesterday = startOfToday - 24 * 60 * 60;
+
+  const buckets: Record<SectionLabel, T[]> = {
+    ACTIVE: [],
+    TODAY: [],
+    YESTERDAY: [],
+    EARLIER: [],
+  };
+
+  for (const row of rows) {
+    if (isActive(row)) {
+      buckets.ACTIVE.push(row);
+      continue;
+    }
+    const started = startedAtEpochSec(row);
+    if (started === null || started === undefined) {
+      buckets.EARLIER.push(row);
+      continue;
+    }
+    if (started >= startOfToday) {
+      buckets.TODAY.push(row);
+    } else if (started >= startOfYesterday) {
+      buckets.YESTERDAY.push(row);
+    } else {
+      buckets.EARLIER.push(row);
+    }
+  }
+
+  const sections: Array<SectionedRows<T>> = [];
+  for (const label of SECTION_ORDER) {
+    if (buckets[label].length > 0) {
+      sections.push({ label, rows: buckets[label] });
+    }
+  }
+  return sections;
+}

--- a/packages/myco/ui/src/pages/Agent.tsx
+++ b/packages/myco/ui/src/pages/Agent.tsx
@@ -130,7 +130,7 @@ export default function Agent() {
   const { id: selectedRunId } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const location = useLocation();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const urlState = useMemo(() => readUrlState(searchParams), [searchParams]);
   // When a run is selected via the path (/agent/:id), force the Runs tab —
   // a path-selected run only makes sense in the Runs view. Tab in ?tab= is
@@ -138,36 +138,6 @@ export default function Agent() {
   const tab: AgentTab = selectedRunId ? 'runs' : urlState.tab;
   const { taskId: selectedTaskId, compareRunIds } = urlState;
   const [triggerOpen, setTriggerOpen] = useState(false);
-
-  // Canonicalize `?tab=evaluations` bookmarks on mount so future navigation
-  // uses the new name.
-  useEffect(() => {
-    const rawTab = searchParams.get(PARAM_TAB);
-    if (rawTab && TAB_REDIRECTS[rawTab]) {
-      const nextTab = TAB_REDIRECTS[rawTab];
-      const next = new URLSearchParams(searchParams);
-      if (nextTab === 'runs') next.delete(PARAM_TAB);
-      else next.set(PARAM_TAB, nextTab);
-      setSearchParams(next, { replace: true });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // Migrate legacy `?run=<id>` bookmarks to `/agent/<id>` path selection.
-  // Mount-only canonicalization, same pattern as the ?tab=evaluations redirect.
-  useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    const legacyRunId = params.get('run');
-    if (legacyRunId && !selectedRunId) {
-      params.delete('run');
-      const search = params.toString();
-      navigate(
-        `${agentBasePath}/${legacyRunId}${search ? `?${search}` : ''}`,
-        { replace: true },
-      );
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   /** Base path of the Agent page (`/g/<grove>/p/<project>/agent`), with any
    *  trailing `/<runId>` stripped. Used to build sibling URLs for tab/comparison
@@ -181,6 +151,39 @@ export default function Agent() {
     }
     return location.pathname;
   }, [location.pathname, selectedRunId]);
+
+  // mount-only canonicalization for legacy URL shapes:
+  //   - `?run=<id>` -> path-based `/agent/<id>` selection
+  //   - `?tab=evaluations` (and other legacy tab ids) -> current tab id
+  // Resolved together so a URL like `/agent?run=<id>&tab=evaluations`
+  // applies both transforms atomically in a single replace.
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const legacyRunId = params.get('run');
+    const rawTab = params.get(PARAM_TAB);
+    const redirectedTab = rawTab ? TAB_REDIRECTS[rawTab] : undefined;
+
+    let nextPath = location.pathname;
+    let mutated = false;
+
+    if (legacyRunId && !selectedRunId) {
+      params.delete('run');
+      nextPath = `${agentBasePath}/${legacyRunId}`;
+      mutated = true;
+    }
+
+    if (redirectedTab) {
+      if (redirectedTab === 'runs') params.delete(PARAM_TAB);
+      else params.set(PARAM_TAB, redirectedTab);
+      mutated = true;
+    }
+
+    if (mutated) {
+      const search = params.toString();
+      navigate(`${nextPath}${search ? `?${search}` : ''}`, { replace: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   /** Navigate to the agent page with the given tab state, dropping any
    *  path-selected run id. */

--- a/packages/myco/ui/src/pages/Agent.tsx
+++ b/packages/myco/ui/src/pages/Agent.tsx
@@ -1,9 +1,11 @@
 import { useState, useCallback, useMemo, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useParams, useNavigate, useLocation } from 'react-router-dom';
 import { Play } from 'lucide-react';
 import { Button } from '../components/ui/button';
 import { PageHeader } from '../components/ui/page-header';
 import { Surface } from '../components/ui/surface';
+import { MasterDetailSplit } from '../components/ui/master-detail-split';
+import { EmptyDetailHint } from '../components/ui/empty-detail-hint';
 import type { Tab } from '../components/ui/tab-switcher';
 import { RunList } from '../components/agent/RunList';
 import { RunDetail } from '../components/agent/RunDetail';
@@ -20,7 +22,6 @@ type AgentTab = 'runs' | 'tasks' | 'config' | 'comparisons';
 
 /** URL search param keys for persistent navigation state. */
 const PARAM_TAB = 'tab';
-const PARAM_RUN = 'run';
 const PARAM_TASK = 'task';
 const PARAM_RUNS = 'runs';
 
@@ -38,7 +39,6 @@ const TAB_REDIRECTS: Record<string, AgentTab> = {
 
 interface UrlState {
   tab: AgentTab;
-  runId?: string;
   taskId?: string;
   /** Ad-hoc comparison run ids (parsed from `runs=id1,id2,...`). */
   compareRunIds?: string[];
@@ -50,7 +50,8 @@ function parseRunIds(raw: string | null): string[] | undefined {
   return ids.length > 0 ? ids : undefined;
 }
 
-/** Read initial state from URL search params. */
+/** Read tab + non-run-id state from URL search params. The selected run id
+ *  lives in the path (`/agent/:id`), not search params. */
 function readUrlState(params: URLSearchParams): UrlState {
   const rawTab = params.get(PARAM_TAB);
   let tab: AgentTab = 'runs';
@@ -63,7 +64,6 @@ function readUrlState(params: URLSearchParams): UrlState {
   }
   return {
     tab,
-    runId: params.get(PARAM_RUN) ?? undefined,
     taskId: params.get(PARAM_TASK) ?? undefined,
     compareRunIds: parseRunIds(params.get(PARAM_RUNS)),
   };
@@ -71,15 +71,13 @@ function readUrlState(params: URLSearchParams): UrlState {
 
 interface BuildUrlArgs {
   tab: AgentTab;
-  runId?: string;
   taskId?: string;
   compareRunIds?: string[];
 }
 
-function buildUrlState({ tab, runId, taskId, compareRunIds }: BuildUrlArgs): URLSearchParams {
+function buildUrlState({ tab, taskId, compareRunIds }: BuildUrlArgs): URLSearchParams {
   const params = new URLSearchParams();
   if (tab !== 'runs') params.set(PARAM_TAB, tab);
-  if (runId) params.set(PARAM_RUN, runId);
   if (taskId) params.set(PARAM_TASK, taskId);
   if (compareRunIds && compareRunIds.length > 0) {
     params.set(PARAM_RUNS, compareRunIds.join(','));
@@ -129,9 +127,16 @@ function AdHocComparison({
 }
 
 export default function Agent() {
+  const { id: selectedRunId } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const urlState = useMemo(() => readUrlState(searchParams), [searchParams]);
-  const { tab, runId: selectedRunId, taskId: selectedTaskId, compareRunIds } = urlState;
+  // When a run is selected via the path (/agent/:id), force the Runs tab —
+  // a path-selected run only makes sense in the Runs view. Tab in ?tab= is
+  // ignored in that case.
+  const tab: AgentTab = selectedRunId ? 'runs' : urlState.tab;
+  const { taskId: selectedTaskId, compareRunIds } = urlState;
   const [triggerOpen, setTriggerOpen] = useState(false);
 
   // Canonicalize `?tab=evaluations` bookmarks on mount so future navigation
@@ -148,19 +153,56 @@ export default function Agent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Migrate legacy `?run=<id>` bookmarks to `/agent/<id>` path selection.
+  // Mount-only canonicalization, same pattern as the ?tab=evaluations redirect.
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const legacyRunId = params.get('run');
+    if (legacyRunId && !selectedRunId) {
+      params.delete('run');
+      const search = params.toString();
+      navigate(
+        `${agentBasePath}/${legacyRunId}${search ? `?${search}` : ''}`,
+        { replace: true },
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  /** Base path of the Agent page (`/g/<grove>/p/<project>/agent`), with any
+   *  trailing `/<runId>` stripped. Used to build sibling URLs for tab/comparison
+   *  navigation that must drop the path-selected run. */
+  const agentBasePath = useMemo(() => {
+    if (selectedRunId) {
+      const suffix = `/${selectedRunId}`;
+      if (location.pathname.endsWith(suffix)) {
+        return location.pathname.slice(0, -suffix.length);
+      }
+    }
+    return location.pathname;
+  }, [location.pathname, selectedRunId]);
+
+  /** Navigate to the agent page with the given tab state, dropping any
+   *  path-selected run id. */
   const navigateState = useCallback((
     nextTab: AgentTab,
-    nextRunId?: string,
     nextTaskId?: string,
     nextCompareRunIds?: string[],
   ) => {
-    setSearchParams(buildUrlState({
+    const params = buildUrlState({
       tab: nextTab,
-      runId: nextRunId,
       taskId: nextTaskId,
       compareRunIds: nextCompareRunIds,
-    }));
-  }, [setSearchParams]);
+    });
+    const search = params.toString();
+    navigate(search ? `${agentBasePath}?${search}` : agentBasePath);
+  }, [agentBasePath, navigate]);
+
+  /** Select a run by navigating to the path-based `/agent/<id>` URL. Clears
+   *  any tab/comparison query state. */
+  const selectRun = useCallback((runId: string) => {
+    navigate(`${agentBasePath}/${runId}`);
+  }, [agentBasePath, navigate]);
 
   const switchTab = useCallback((id: string) => {
     const t = id as AgentTab;
@@ -179,81 +221,101 @@ export default function Agent() {
   }
 
   return (
-    <div className="p-6 space-y-4">
-      <PageHeader
-        title="Agent"
-        subtitle="Intelligence runs, task configuration, and operational settings"
-        tabs={TABS}
-        activeTab={tab}
-        onTabChange={switchTab}
-        actions={pageAction}
-      />
+    <div className="flex h-full flex-col">
+      <div className="shrink-0 p-6 pb-0">
+        <PageHeader
+          title="Agent"
+          subtitle="Intelligence runs, task configuration, and operational settings"
+          tabs={TABS}
+          activeTab={tab}
+          onTabChange={switchTab}
+          actions={pageAction}
+        />
+      </div>
 
-      {/* Runs tab */}
+      {/* Runs tab — master/detail split */}
       {tab === 'runs' && (
-        selectedRunId ? (
-          <RunDetail runId={selectedRunId} onBack={() => navigateState('runs')} />
-        ) : (
-          <RunList
-            onSelectRun={(id) => navigateState('runs', id)}
-            onTriggerRun={() => setTriggerOpen(true)}
-            onCompareRuns={(ids) =>
-              navigateState('comparisons', undefined, undefined, ids)
+        <div className="flex-1 min-h-0 mt-4">
+          <MasterDetailSplit
+            hasSelection={!!selectedRunId}
+            onCloseMobileDetail={() => navigate(agentBasePath)}
+            masterAriaLabel="Agent runs"
+            detailAriaLabel="Run details"
+            master={
+              <RunList
+                selectedId={selectedRunId}
+                onSelectRun={selectRun}
+                onTriggerRun={() => setTriggerOpen(true)}
+                onCompareRuns={(ids) => navigateState('comparisons', undefined, ids)}
+              />
+            }
+            detail={
+              selectedRunId ? (
+                <RunDetail runId={selectedRunId} onBack={() => navigate(agentBasePath)} />
+              ) : (
+                <EmptyDetailHint message="Select a run to see its details." />
+              )
             }
           />
-        )
+        </div>
       )}
 
       {/* Tasks tab */}
       {tab === 'tasks' && (
-        selectedTaskId ? (
-          <TaskDetail
-            taskId={selectedTaskId}
-            onBack={() => navigateState('tasks')}
-            onNavigate={(taskId) => navigateState('tasks', undefined, taskId)}
-            onRunTriggered={(runId) => {
-              navigateState('runs', runId);
-            }}
-          />
-        ) : (
-          <TaskList onSelect={(taskId) => navigateState('tasks', undefined, taskId)} />
-        )
+        <div className="p-6 pt-4 space-y-4">
+          {selectedTaskId ? (
+            <TaskDetail
+              taskId={selectedTaskId}
+              onBack={() => navigateState('tasks')}
+              onNavigate={(taskId) => navigateState('tasks', taskId)}
+              onRunTriggered={(runId) => { if (runId) selectRun(runId); }}
+            />
+          ) : (
+            <TaskList onSelect={(taskId) => navigateState('tasks', taskId)} />
+          )}
+        </div>
       )}
 
       {/* Comparisons tab — ad-hoc run comparison or empty-state prompt */}
       {tab === 'comparisons' && (
-        compareRunIds && compareRunIds.length > 0 ? (
-          <AdHocComparison
-            runIds={compareRunIds}
-            onBack={() => navigateState('comparisons')}
-            onOpenRun={(runId) => navigateState('runs', runId)}
-          />
-        ) : (
-          <Surface level="low" className="p-8 text-center space-y-2">
-            <h2 className="font-serif text-lg text-on-surface">Compare selected runs</h2>
-            <p className="font-sans text-sm text-on-surface-variant">
-              Select two or more runs in the Runs tab and use "Compare selected"
-              to see them side by side here.
-            </p>
-            <Button
-              variant="outline"
-              size="sm"
-              className="mt-2"
-              onClick={() => navigateState('runs')}
-            >
-              Go to Runs
-            </Button>
-          </Surface>
-        )
+        <div className="p-6 pt-4 space-y-4">
+          {compareRunIds && compareRunIds.length > 0 ? (
+            <AdHocComparison
+              runIds={compareRunIds}
+              onBack={() => navigateState('comparisons')}
+              onOpenRun={(runId) => selectRun(runId)}
+            />
+          ) : (
+            <Surface level="low" className="p-8 text-center space-y-2">
+              <h2 className="font-serif text-lg text-on-surface">Compare selected runs</h2>
+              <p className="font-sans text-sm text-on-surface-variant">
+                Select two or more runs in the Runs tab and use "Compare selected"
+                to see them side by side here.
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-2"
+                onClick={() => navigateState('runs')}
+              >
+                Go to Runs
+              </Button>
+            </Surface>
+          )}
+        </div>
       )}
 
       {/* Config tab */}
-      {tab === 'config' && <AgentConfig />}
+      {tab === 'config' && (
+        <div className="p-6 pt-4 space-y-4">
+          <AgentConfig />
+        </div>
+      )}
 
       <RunTaskDialog
         open={triggerOpen}
         onOpenChange={setTriggerOpen}
-        onTriggered={(runId) => navigateState('runs', runId)}
+        onTriggered={(runId) => { if (runId) selectRun(runId); }}
       />
     </div>
   );

--- a/packages/myco/ui/src/pages/Sessions.tsx
+++ b/packages/myco/ui/src/pages/Sessions.tsx
@@ -1,15 +1,27 @@
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
+import { MasterDetailSplit } from '../components/ui/master-detail-split';
+import { EmptyDetailHint } from '../components/ui/empty-detail-hint';
 import { SessionList } from '../components/sessions/SessionList';
 import { SessionDetail } from '../components/sessions/SessionDetail';
 
 export default function Sessions() {
   const { id } = useParams<{ id: string }>();
-
-  if (id) return <SessionDetail id={id} />;
+  const navigate = useNavigate();
 
   return (
-    <div className="p-6">
-      <SessionList />
-    </div>
+    <MasterDetailSplit
+      hasSelection={!!id}
+      onCloseMobileDetail={() => navigate('..')}
+      masterAriaLabel="Sessions"
+      detailAriaLabel="Session details"
+      master={<SessionList selectedId={id} />}
+      detail={
+        id ? (
+          <SessionDetail id={id} />
+        ) : (
+          <EmptyDetailHint message="Select a session to see its details." />
+        )
+      }
+    />
   );
 }

--- a/tests/daemon/api/sessions.test.ts
+++ b/tests/daemon/api/sessions.test.ts
@@ -77,6 +77,28 @@ describe('session API request context scoping', () => {
     expect(body.total).toBe(1);
   });
 
+  it('returns activity_buckets and branch on every list row', async () => {
+    const now = epochNow();
+    upsertSession({
+      id: 'sess-bucketed',
+      project_id: 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      agent: 'test-agent',
+      branch: 'feat/test-branch',
+      started_at: now,
+      created_at: now,
+    });
+
+    const res = await handleListSessions(makeRequest({
+      requestContext: requestContext(tmpDir, 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+    }));
+
+    const body = res.body as { sessions: Array<{ id: string; branch: string | null; activity_buckets: number[] }> };
+    expect(body.sessions).toHaveLength(1);
+    expect(body.sessions[0].branch).toBe('feat/test-branch');
+    expect(body.sessions[0].activity_buckets).toHaveLength(8);
+    expect(body.sessions[0].activity_buckets.every((n) => n === 0)).toBe(true);
+  });
+
   it('does not return a session from a different project context', async () => {
     const now = epochNow();
     upsertSession({ id: 'sess-other', project_id: 'proj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', agent: 'test-agent', started_at: now, created_at: now });

--- a/tests/db/queries/activity-buckets.test.ts
+++ b/tests/db/queries/activity-buckets.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for the v6-rail-card activity-bucket helpers.
+ *
+ * The helpers compute the per-row sparkline data (8 × 1-minute buckets,
+ * newest last) used by `GET /api/sessions` and `GET /api/agent/runs`.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'bun:test';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
+import { upsertSession } from '@myco/db/queries/sessions.js';
+import { insertBatch } from '@myco/db/queries/batches.js';
+import { insertRun } from '@myco/db/queries/runs.js';
+import { insertTurn } from '@myco/db/queries/turns.js';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { insertGitProvenance } from '@myco/db/queries/release-provenance.js';
+import {
+  BUCKET_COUNT,
+  getSessionActivityBuckets,
+  getRunActivityBuckets,
+  getRunBranches,
+} from '@myco/db/queries/activity-buckets.js';
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+describe('activity-bucket helpers', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => { cleanTestDb(); });
+
+  describe('getSessionActivityBuckets', () => {
+    it('returns an empty map when given no ids', () => {
+      const result = getSessionActivityBuckets([]);
+      expect(result.size).toBe(0);
+    });
+
+    it('returns zero-filled buckets for sessions with no activity', () => {
+      const now = epochNow();
+      upsertSession({ id: 'sess-quiet', agent: 'claude-code', started_at: now, created_at: now });
+
+      const result = getSessionActivityBuckets(['sess-quiet'], { nowSeconds: now });
+      const buckets = result.get('sess-quiet');
+      expect(buckets).toBeDefined();
+      expect(buckets!).toHaveLength(BUCKET_COUNT);
+      expect(buckets!.every((c) => c === 0)).toBe(true);
+    });
+
+    it('bucketizes prompt_batches into the correct 1-minute slot', () => {
+      const now = epochNow();
+      upsertSession({ id: 'sess-a', agent: 'claude-code', started_at: now - 600, created_at: now - 600 });
+
+      // Two batches in the most-recent bucket (within last 60s).
+      insertBatch({ session_id: 'sess-a', started_at: now - 10, created_at: now - 10 });
+      insertBatch({ session_id: 'sess-a', started_at: now - 50, created_at: now - 50 });
+      // One batch in the second-most-recent bucket (60–120s ago).
+      insertBatch({ session_id: 'sess-a', started_at: now - 90, created_at: now - 90 });
+      // Outside the 8-minute window — should not be counted.
+      insertBatch({ session_id: 'sess-a', started_at: now - 600, created_at: now - 600 });
+
+      const result = getSessionActivityBuckets(['sess-a'], { nowSeconds: now });
+      const buckets = result.get('sess-a')!;
+      expect(buckets).toHaveLength(BUCKET_COUNT);
+      // Newest bucket (index BUCKET_COUNT-1) should hold the two recent batches.
+      expect(buckets[BUCKET_COUNT - 1]).toBe(2);
+      // Second-newest bucket should hold the one mid-window batch.
+      expect(buckets[BUCKET_COUNT - 2]).toBe(1);
+      // Sum equals captured-in-window batches (older one excluded).
+      expect(buckets.reduce((a, b) => a + b, 0)).toBe(3);
+    });
+
+    it('isolates activity per session', () => {
+      const now = epochNow();
+      upsertSession({ id: 'sess-a', agent: 'claude-code', started_at: now - 200, created_at: now - 200 });
+      upsertSession({ id: 'sess-b', agent: 'claude-code', started_at: now - 200, created_at: now - 200 });
+
+      insertBatch({ session_id: 'sess-a', started_at: now - 5, created_at: now - 5 });
+      insertBatch({ session_id: 'sess-b', started_at: now - 70, created_at: now - 70 });
+
+      const result = getSessionActivityBuckets(['sess-a', 'sess-b'], { nowSeconds: now });
+      expect(result.get('sess-a')![BUCKET_COUNT - 1]).toBe(1);
+      expect(result.get('sess-b')![BUCKET_COUNT - 2]).toBe(1);
+      // Cross-leakage check: each session sees only its own counts.
+      expect(result.get('sess-a')!.reduce((a, b) => a + b, 0)).toBe(1);
+      expect(result.get('sess-b')!.reduce((a, b) => a + b, 0)).toBe(1);
+    });
+  });
+
+  describe('getRunActivityBuckets', () => {
+    it('returns zero buckets for a run with no turns', () => {
+      const now = epochNow();
+      registerAgent({ id: 'agent-buckets', name: 'Bucket Test', created_at: now });
+      const run = insertRun({ id: 'run-quiet', agent_id: 'agent-buckets' });
+
+      const result = getRunActivityBuckets([run.id], { nowSeconds: now });
+      const buckets = result.get(run.id)!;
+      expect(buckets).toHaveLength(BUCKET_COUNT);
+      expect(buckets.every((c) => c === 0)).toBe(true);
+    });
+
+    it('bucketizes agent_turns into 1-minute slots', () => {
+      const now = epochNow();
+      registerAgent({ id: 'agent-buckets', name: 'Bucket Test', created_at: now });
+      const run = insertRun({ id: 'run-a', agent_id: 'agent-buckets' });
+
+      insertTurn({
+        run_id: run.id,
+        agent_id: 'agent-buckets',
+        turn_number: 1,
+        tool_name: 'read',
+        started_at: now - 5,
+      });
+      insertTurn({
+        run_id: run.id,
+        agent_id: 'agent-buckets',
+        turn_number: 2,
+        tool_name: 'edit',
+        started_at: now - 30,
+      });
+      insertTurn({
+        run_id: run.id,
+        agent_id: 'agent-buckets',
+        turn_number: 3,
+        tool_name: 'bash',
+        started_at: now - 130,
+      });
+
+      const result = getRunActivityBuckets([run.id], { nowSeconds: now });
+      const buckets = result.get(run.id)!;
+      expect(buckets[BUCKET_COUNT - 1]).toBe(2);
+      expect(buckets[BUCKET_COUNT - 3]).toBe(1);
+    });
+  });
+
+  describe('getRunBranches', () => {
+    it('returns null branches when run has no session_ref', () => {
+      const now = epochNow();
+      registerAgent({ id: 'agent-branch', name: 'Branch Test', created_at: now });
+      const run = insertRun({ id: 'run-no-session', agent_id: 'agent-branch' });
+
+      const result = getRunBranches([run.id]);
+      expect(result.get(run.id)).toBeNull();
+    });
+
+    it('resolves branch from the most-recent provenance row for the linked session', () => {
+      const now = epochNow();
+      registerAgent({ id: 'agent-branch', name: 'Branch Test', created_at: now });
+      upsertSession({ id: 'sess-branch', agent: 'claude-code', started_at: now, created_at: now });
+      const run = insertRun({ id: 'run-with-session', agent_id: 'agent-branch', session_ref: 'sess-branch' });
+
+      insertGitProvenance({
+        project_id: null,
+        machine_id: 'local',
+        session_id: 'sess-branch',
+        prompt_batch_id: null,
+        capture_point: 'session_start',
+        captured_at: now - 100,
+        project_root: '/p',
+        branch: 'old-branch',
+        head_sha: null,
+        upstream_ref: null,
+        upstream_sha: null,
+        production_ref: null,
+        production_sha: null,
+        is_dirty: 0,
+        staged_count: 0,
+        unstaged_count: 0,
+        untracked_count: 0,
+        changed_paths_json: '[]',
+        tracked_blob_hashes_json: '[]',
+        patch_ids_json: '[]',
+        status_hash: 'h-old',
+        evidence_json: '{}',
+        error: null,
+        created_at: now - 100,
+      });
+      insertGitProvenance({
+        project_id: null,
+        machine_id: 'local',
+        session_id: 'sess-branch',
+        prompt_batch_id: null,
+        capture_point: 'prompt_batch_start',
+        captured_at: now - 10,
+        project_root: '/p',
+        branch: 'feat/new-branch',
+        head_sha: null,
+        upstream_ref: null,
+        upstream_sha: null,
+        production_ref: null,
+        production_sha: null,
+        is_dirty: 0,
+        staged_count: 0,
+        unstaged_count: 0,
+        untracked_count: 0,
+        changed_paths_json: '[]',
+        tracked_blob_hashes_json: '[]',
+        patch_ids_json: '[]',
+        status_hash: 'h-new',
+        evidence_json: '{}',
+        error: null,
+        created_at: now - 10,
+      });
+
+      const result = getRunBranches([run.id]);
+      expect(result.get(run.id)).toBe('feat/new-branch');
+    });
+  });
+});

--- a/tests/ui/agent-page.test.tsx
+++ b/tests/ui/agent-page.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, mock } from 'bun:test';
+import { render } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Stub the heavy child components so the test can focus on the mount-time
+// redirect logic in Agent.tsx without instantiating real queries or
+// pulling in their transitive dependency graph.
+mock.module('../../packages/myco/ui/src/components/agent/RunList', () => ({
+  RunList: () => null,
+}));
+mock.module('../../packages/myco/ui/src/components/agent/RunDetail', () => ({
+  RunDetail: () => null,
+}));
+mock.module('../../packages/myco/ui/src/components/agent/RunTaskDialog', () => ({
+  RunTaskDialog: () => null,
+}));
+mock.module('../../packages/myco/ui/src/components/agent/TaskList', () => ({
+  TaskList: () => null,
+}));
+mock.module('../../packages/myco/ui/src/components/agent/TaskDetail', () => ({
+  TaskDetail: () => null,
+}));
+mock.module('../../packages/myco/ui/src/components/agent/AgentConfig', () => ({
+  AgentConfig: () => null,
+}));
+mock.module('../../packages/myco/ui/src/components/agent/ComparisonView', () => ({
+  ComparisonView: () => null,
+}));
+mock.module('../../packages/myco/ui/src/hooks/use-agent', () => ({
+  useRunsByIds: () => ({ runs: [], isLoading: false, isError: false, errors: [] }),
+}));
+
+// useMediaQuery (used inside MasterDetailSplit) reaches for matchMedia
+// which jsdom doesn't ship by default.
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: () => ({
+      matches: false,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+const { default: Agent } = await import('../../packages/myco/ui/src/pages/Agent');
+
+function LocationProbe({ onChange }: { onChange: (loc: string) => void }) {
+  const loc = useLocation();
+  onChange(`${loc.pathname}${loc.search}`);
+  return null;
+}
+
+function renderAgent(initialEntry: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  let lastLocation = initialEntry;
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <QueryClientProvider client={client}>
+        <Routes>
+          <Route path="/agent" element={<Agent />} />
+          <Route path="/agent/:id" element={<Agent />} />
+        </Routes>
+        <LocationProbe onChange={(l) => { lastLocation = l; }} />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+  return () => lastLocation;
+}
+
+describe('Agent mount-time URL canonicalization', () => {
+  it('migrates ?run=<id>&tab=evaluations to /agent/<id>?tab=comparisons atomically', () => {
+    const getLocation = renderAgent('/agent?run=abc&tab=evaluations');
+    expect(getLocation()).toBe('/agent/abc?tab=comparisons');
+  });
+
+  it('migrates ?run=<id> alone to /agent/<id>', () => {
+    const getLocation = renderAgent('/agent?run=abc');
+    expect(getLocation()).toBe('/agent/abc');
+  });
+
+  it('canonicalizes ?tab=evaluations alone to ?tab=comparisons', () => {
+    const getLocation = renderAgent('/agent?tab=evaluations');
+    expect(getLocation()).toBe('/agent?tab=comparisons');
+  });
+});

--- a/tests/ui/compare-bar.test.tsx
+++ b/tests/ui/compare-bar.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, mock } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { CompareBar } from '../../packages/myco/ui/src/components/ui/compare-bar';
+
+describe('CompareBar', () => {
+  it('renders count and primary label', () => {
+    render(<CompareBar selectedCount={3} onClear={() => {}} onCompare={() => {}} />);
+    expect(screen.getByText(/3 selected/i)).toBeDefined();
+    expect(screen.getByRole('button', { name: /compare 3 runs/i })).toBeDefined();
+  });
+
+  it('singular noun when count is 1', () => {
+    render(<CompareBar selectedCount={1} onClear={() => {}} onCompare={() => {}} />);
+    expect(screen.getByRole('button', { name: /compare 1 run$/i })).toBeDefined();
+  });
+
+  it('disables Compare when count < minSelected (default 2)', () => {
+    render(<CompareBar selectedCount={1} onClear={() => {}} onCompare={() => {}} />);
+    const btn = screen.getByRole('button', { name: /compare/i });
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('enables Compare when count >= minSelected', () => {
+    render(<CompareBar selectedCount={2} onClear={() => {}} onCompare={() => {}} />);
+    const btn = screen.getByRole('button', { name: /compare/i });
+    expect((btn as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('fires callbacks on click', () => {
+    const onClear = mock(() => {});
+    const onCompare = mock(() => {});
+    render(<CompareBar selectedCount={3} onClear={onClear} onCompare={onCompare} />);
+    screen.getByRole('button', { name: /compare/i }).click();
+    screen.getByRole('button', { name: /clear selection/i }).click();
+    expect(onCompare).toHaveBeenCalledTimes(1);
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses custom primaryLabel + noun pluralization', () => {
+    render(
+      <CompareBar
+        selectedCount={2}
+        onClear={() => {}}
+        onCompare={() => {}}
+        primaryLabel="Diff"
+        nounSingular="session"
+        nounPlural="sessions"
+      />,
+    );
+    expect(screen.getByRole('button', { name: /diff 2 sessions/i })).toBeDefined();
+  });
+});

--- a/tests/ui/filter-pill.test.tsx
+++ b/tests/ui/filter-pill.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, mock } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { FilterPill } from '../../packages/myco/ui/src/components/ui/filter-pill';
+
+describe('FilterPill', () => {
+  it('renders the trigger with default label', () => {
+    render(<FilterPill activeCount={0}>options</FilterPill>);
+    expect(screen.getByRole('button', { name: /filter/i })).toBeDefined();
+  });
+
+  it('hides popover content initially', () => {
+    render(<FilterPill activeCount={0}><div>options</div></FilterPill>);
+    expect(screen.queryByText('options')).toBeNull();
+  });
+
+  it('opens popover on click and shows children', () => {
+    render(<FilterPill activeCount={0}><div>options</div></FilterPill>);
+    fireEvent.click(screen.getByRole('button', { name: /filter/i }));
+    expect(screen.getByText('options')).toBeDefined();
+  });
+
+  it('closes on Escape', () => {
+    render(<FilterPill activeCount={0}><div>options</div></FilterPill>);
+    fireEvent.click(screen.getByRole('button', { name: /filter/i }));
+    expect(screen.getByText('options')).toBeDefined();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByText('options')).toBeNull();
+  });
+
+  it('shows active count badge when activeCount > 0', () => {
+    render(<FilterPill activeCount={3}>options</FilterPill>);
+    expect(screen.getByLabelText(/3 active filters/i)).toBeDefined();
+  });
+
+  it('hides active count badge at zero', () => {
+    render(<FilterPill activeCount={0}>options</FilterPill>);
+    expect(screen.queryByLabelText(/active filter/i)).toBeNull();
+  });
+
+  it('supports a custom label', () => {
+    render(<FilterPill activeCount={0} label="Refine">options</FilterPill>);
+    expect(screen.getByRole('button', { name: /refine/i })).toBeDefined();
+  });
+});

--- a/tests/ui/master-detail-split.test.tsx
+++ b/tests/ui/master-detail-split.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MasterDetailSplit } from '../../packages/myco/ui/src/components/ui/master-detail-split';
+
+type Listener = (e: MediaQueryListEvent) => void;
+
+function installMatchMedia(matches: boolean) {
+  const listeners = new Set<Listener>();
+  // @ts-expect-error — test scaffold
+  globalThis.window.matchMedia = mock((q: string) => ({
+    matches,
+    media: q,
+    onchange: null,
+    addEventListener: (_t: 'change', l: Listener) => listeners.add(l),
+    removeEventListener: (_t: 'change', l: Listener) => listeners.delete(l),
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => true,
+  }));
+}
+
+afterEach(() => {
+  // jsdom defines window.matchMedia as non-configurable once assigned, so
+  // reset rather than delete.
+  // @ts-expect-error — test scaffold
+  globalThis.window.matchMedia = undefined;
+});
+
+describe('MasterDetailSplit', () => {
+  it('renders both panes on desktop (matchMedia true)', () => {
+    installMatchMedia(true);
+    render(
+      <MasterDetailSplit
+        hasSelection={false}
+        master={<div data-testid="m">master</div>}
+        detail={<div data-testid="d">detail</div>}
+      />,
+    );
+    expect(screen.getByTestId('m')).toBeDefined();
+    expect(screen.getByTestId('d')).toBeDefined();
+  });
+
+  it('renders only master on mobile when no selection', () => {
+    installMatchMedia(false);
+    render(
+      <MasterDetailSplit
+        hasSelection={false}
+        master={<div data-testid="m">master</div>}
+        detail={<div data-testid="d">detail</div>}
+      />,
+    );
+    expect(screen.getByTestId('m')).toBeDefined();
+    expect(screen.queryByTestId('d')).toBeNull();
+  });
+
+  it('renders only detail on mobile when hasSelection', () => {
+    installMatchMedia(false);
+    render(
+      <MasterDetailSplit
+        hasSelection
+        master={<div data-testid="m">master</div>}
+        detail={<div data-testid="d">detail</div>}
+      />,
+    );
+    expect(screen.queryByTestId('m')).toBeNull();
+    expect(screen.getByTestId('d')).toBeDefined();
+  });
+
+  it('renders back-link header on mobile when onCloseMobileDetail provided', () => {
+    installMatchMedia(false);
+    const onClose = mock(() => {});
+    render(
+      <MasterDetailSplit
+        hasSelection
+        onCloseMobileDetail={onClose}
+        master={<div>master</div>}
+        detail={<div>detail</div>}
+      />,
+    );
+    const back = screen.getByRole('button', { name: /back/i });
+    fireEvent.click(back);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits back-link when onCloseMobileDetail is not provided', () => {
+    installMatchMedia(false);
+    render(
+      <MasterDetailSplit
+        hasSelection
+        master={<div>master</div>}
+        detail={<div>detail</div>}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: /back/i })).toBeNull();
+  });
+});

--- a/tests/ui/section-rows.test.ts
+++ b/tests/ui/section-rows.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'bun:test';
+import { sectionRows } from '../../packages/myco/ui/src/lib/section-rows';
+
+// Fixed local-time anchor: 2026-05-14T15:00:00 in whichever timezone the
+// tests run. The helper buckets by local calendar day, so we derive the
+// boundaries from the same anchor to keep the tests timezone-independent.
+const NOW = new Date(2026, 4, 14, 15, 0, 0); // May 14 2026, 15:00 local
+const NOW_SEC = Math.floor(NOW.getTime() / 1000);
+
+const startOfToday = new Date(2026, 4, 14, 0, 0, 0);
+const startOfYesterday = new Date(2026, 4, 13, 0, 0, 0);
+const startOfDayBeforeYesterday = new Date(2026, 4, 12, 0, 0, 0);
+
+const TODAY_SEC = Math.floor(startOfToday.getTime() / 1000) + 60 * 60; // 01:00 today
+const YESTERDAY_SEC = Math.floor(startOfYesterday.getTime() / 1000) + 60 * 60; // 01:00 yesterday
+const EARLIER_SEC = Math.floor(startOfDayBeforeYesterday.getTime() / 1000) - 60; // a minute before yesterday's midnight
+
+interface Row {
+  id: string;
+  status: 'active' | 'completed';
+  started_at: number | null;
+}
+
+const isActive = (r: Row) => r.status === 'active';
+const startedAtEpochSec = (r: Row) => r.started_at;
+
+describe('sectionRows', () => {
+  it('returns only ACTIVE section when all rows are active', () => {
+    const rows: Row[] = [
+      { id: 'a', status: 'active', started_at: EARLIER_SEC },
+      { id: 'b', status: 'active', started_at: TODAY_SEC },
+    ];
+    const sections = sectionRows(rows, { isActive, startedAtEpochSec, nowEpochSec: NOW_SEC });
+    expect(sections).toHaveLength(1);
+    expect(sections[0].label).toBe('ACTIVE');
+    expect(sections[0].rows.map((r) => r.id)).toEqual(['a', 'b']);
+  });
+
+  it('returns sections in display order and omits empty ones', () => {
+    const rows: Row[] = [
+      { id: 'active1', status: 'active', started_at: TODAY_SEC },
+      { id: 'today1', status: 'completed', started_at: TODAY_SEC },
+      { id: 'earlier1', status: 'completed', started_at: EARLIER_SEC },
+    ];
+    const sections = sectionRows(rows, { isActive, startedAtEpochSec, nowEpochSec: NOW_SEC });
+    // No YESTERDAY rows — that section should be omitted entirely.
+    expect(sections.map((s) => s.label)).toEqual(['ACTIVE', 'TODAY', 'EARLIER']);
+    expect(sections[0].rows.map((r) => r.id)).toEqual(['active1']);
+    expect(sections[1].rows.map((r) => r.id)).toEqual(['today1']);
+    expect(sections[2].rows.map((r) => r.id)).toEqual(['earlier1']);
+  });
+
+  it('preserves the original order of rows within each section', () => {
+    const rows: Row[] = [
+      { id: 't1', status: 'completed', started_at: TODAY_SEC + 100 },
+      { id: 't2', status: 'completed', started_at: TODAY_SEC + 50 },
+      { id: 't3', status: 'completed', started_at: TODAY_SEC + 10 },
+    ];
+    const sections = sectionRows(rows, { isActive, startedAtEpochSec, nowEpochSec: NOW_SEC });
+    expect(sections).toHaveLength(1);
+    expect(sections[0].label).toBe('TODAY');
+    expect(sections[0].rows.map((r) => r.id)).toEqual(['t1', 't2', 't3']);
+  });
+
+  it('buckets non-active rows with null started_at into EARLIER', () => {
+    const rows: Row[] = [
+      { id: 'orphan', status: 'completed', started_at: null },
+      { id: 'today', status: 'completed', started_at: TODAY_SEC },
+    ];
+    const sections = sectionRows(rows, { isActive, startedAtEpochSec, nowEpochSec: NOW_SEC });
+    expect(sections.map((s) => s.label)).toEqual(['TODAY', 'EARLIER']);
+    expect(sections[1].rows.map((r) => r.id)).toEqual(['orphan']);
+  });
+
+  it('honors nowEpochSec for deterministic today/yesterday boundaries', () => {
+    const rows: Row[] = [
+      { id: 'today', status: 'completed', started_at: TODAY_SEC },
+      { id: 'yesterday', status: 'completed', started_at: YESTERDAY_SEC },
+      { id: 'earlier', status: 'completed', started_at: EARLIER_SEC },
+    ];
+    const sections = sectionRows(rows, { isActive, startedAtEpochSec, nowEpochSec: NOW_SEC });
+    expect(sections.map((s) => s.label)).toEqual(['TODAY', 'YESTERDAY', 'EARLIER']);
+    expect(sections[0].rows.map((r) => r.id)).toEqual(['today']);
+    expect(sections[1].rows.map((r) => r.id)).toEqual(['yesterday']);
+    expect(sections[2].rows.map((r) => r.id)).toEqual(['earlier']);
+
+    // Shift "now" forward by one day: yesterday's row should now be EARLIER.
+    const tomorrowNow = NOW_SEC + 24 * 60 * 60;
+    const shifted = sectionRows(rows, { isActive, startedAtEpochSec, nowEpochSec: tomorrowNow });
+    const byLabel = new Map(shifted.map((s) => [s.label, s.rows.map((r) => r.id)]));
+    expect(byLabel.get('TODAY')).toBeUndefined();
+    expect(byLabel.get('YESTERDAY')).toEqual(['today']);
+    expect(byLabel.get('EARLIER')).toEqual(['yesterday', 'earlier']);
+  });
+});

--- a/tests/ui/sparkline.test.tsx
+++ b/tests/ui/sparkline.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect } from 'bun:test';
+import { render } from '@testing-library/react';
+import { Sparkline } from '../../packages/myco/ui/src/components/ui/sparkline';
+
+describe('Sparkline', () => {
+  it('renders an svg with width/height defaults', () => {
+    const { container } = render(<Sparkline data={[1, 2, 3]} />);
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute('width')).toBe('56');
+    expect(svg?.getAttribute('height')).toBe('16');
+  });
+
+  it('renders one <rect> per data point', () => {
+    const { container } = render(<Sparkline data={[1, 2, 3, 4]} />);
+    expect(container.querySelectorAll('rect').length).toBe(4);
+  });
+
+  it('scales bar heights to the max value', () => {
+    const { container } = render(<Sparkline data={[1, 4]} heightPx={16} />);
+    const rects = container.querySelectorAll('rect');
+    expect(rects[0]?.getAttribute('height')).toBe('4');
+    expect(rects[1]?.getAttribute('height')).toBe('16');
+  });
+
+  it('renders an empty svg for empty data', () => {
+    const { container } = render(<Sparkline data={[]} />);
+    expect(container.querySelector('svg')).not.toBeNull();
+    expect(container.querySelectorAll('rect').length).toBe(0);
+  });
+
+  it('renders all-zero bars with zero height for all-zero data', () => {
+    const { container } = render(<Sparkline data={[0, 0, 0]} />);
+    const rects = container.querySelectorAll('rect');
+    expect(rects.length).toBe(3);
+    rects.forEach((r) => expect(r.getAttribute('height')).toBe('0'));
+  });
+
+  it('honors widthPx / heightPx overrides', () => {
+    const { container } = render(<Sparkline data={[1]} widthPx={100} heightPx={24} />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('width')).toBe('100');
+    expect(svg?.getAttribute('height')).toBe('24');
+  });
+});

--- a/tests/ui/use-list-keyboard-nav.test.tsx
+++ b/tests/ui/use-list-keyboard-nav.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, mock } from 'bun:test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useRef } from 'react';
+import { useListKeyboardNav } from '../../packages/myco/ui/src/hooks/use-list-keyboard-nav';
+
+interface Row { id: string; label: string }
+const ITEMS: Row[] = [
+  { id: 'a', label: 'Alpha' },
+  { id: 'b', label: 'Bravo' },
+  { id: 'c', label: 'Charlie' },
+];
+
+function Harness({
+  selectedId,
+  onActivate,
+}: {
+  selectedId?: string;
+  onActivate: (id: string) => void;
+}) {
+  const filterRef = useRef<HTMLInputElement>(null);
+  const nav = useListKeyboardNav({
+    items: ITEMS,
+    getId: (r) => r.id,
+    selectedId,
+    onActivate,
+    filterInputRef: filterRef,
+  });
+  return (
+    <div>
+      <input ref={filterRef} data-testid="filter" />
+      <div data-testid="list" {...nav.containerProps}>
+        {ITEMS.map((row, i) => (
+          <div
+            key={row.id}
+            ref={nav.setRowRef(i)}
+            data-testid={`row-${row.id}`}
+            data-cursor={nav.cursorIndex === i ? 'true' : 'false'}
+          >
+            {row.label}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+describe('useListKeyboardNav', () => {
+  it('initializes cursor at selectedId index', () => {
+    render(<Harness selectedId="b" onActivate={() => {}} />);
+    expect(screen.getByTestId('row-b').dataset.cursor).toBe('true');
+  });
+
+  it('initializes cursor at 0 when selectedId is undefined', () => {
+    render(<Harness onActivate={() => {}} />);
+    expect(screen.getByTestId('row-a').dataset.cursor).toBe('true');
+  });
+
+  it('j / ArrowDown moves cursor forward', () => {
+    render(<Harness onActivate={() => {}} />);
+    const list = screen.getByTestId('list');
+    fireEvent.keyDown(list, { key: 'j' });
+    expect(screen.getByTestId('row-b').dataset.cursor).toBe('true');
+    fireEvent.keyDown(list, { key: 'ArrowDown' });
+    expect(screen.getByTestId('row-c').dataset.cursor).toBe('true');
+  });
+
+  it('k / ArrowUp moves cursor back', () => {
+    render(<Harness selectedId="c" onActivate={() => {}} />);
+    const list = screen.getByTestId('list');
+    fireEvent.keyDown(list, { key: 'k' });
+    expect(screen.getByTestId('row-b').dataset.cursor).toBe('true');
+    fireEvent.keyDown(list, { key: 'ArrowUp' });
+    expect(screen.getByTestId('row-a').dataset.cursor).toBe('true');
+  });
+
+  it('clamps at boundaries', () => {
+    render(<Harness onActivate={() => {}} />);
+    const list = screen.getByTestId('list');
+    fireEvent.keyDown(list, { key: 'k' });
+    expect(screen.getByTestId('row-a').dataset.cursor).toBe('true');
+    fireEvent.keyDown(list, { key: 'j' });
+    fireEvent.keyDown(list, { key: 'j' });
+    fireEvent.keyDown(list, { key: 'j' });
+    fireEvent.keyDown(list, { key: 'j' });
+    expect(screen.getByTestId('row-c').dataset.cursor).toBe('true');
+  });
+
+  it('Enter calls onActivate with current row id', () => {
+    const onActivate = mock(() => {});
+    render(<Harness onActivate={onActivate} />);
+    const list = screen.getByTestId('list');
+    fireEvent.keyDown(list, { key: 'j' });
+    fireEvent.keyDown(list, { key: 'Enter' });
+    expect(onActivate).toHaveBeenCalledTimes(1);
+    expect(onActivate.mock.calls[0]?.[0]).toBe('b');
+  });
+
+  it('/ focuses the filter input', () => {
+    render(<Harness onActivate={() => {}} />);
+    const list = screen.getByTestId('list');
+    fireEvent.keyDown(list, { key: '/' });
+    expect(document.activeElement).toBe(screen.getByTestId('filter'));
+  });
+
+  it('ignores capital J/K (shift modifier)', () => {
+    render(<Harness onActivate={() => {}} />);
+    const list = screen.getByTestId('list');
+    fireEvent.keyDown(list, { key: 'J', shiftKey: true });
+    expect(screen.getByTestId('row-a').dataset.cursor).toBe('true');
+  });
+
+  it('ignores keys with meta/ctrl/alt modifiers', () => {
+    render(<Harness onActivate={() => {}} />);
+    const list = screen.getByTestId('list');
+    fireEvent.keyDown(list, { key: 'j', metaKey: true });
+    fireEvent.keyDown(list, { key: 'j', ctrlKey: true });
+    fireEvent.keyDown(list, { key: 'j', altKey: true });
+    expect(screen.getByTestId('row-a').dataset.cursor).toBe('true');
+  });
+
+  it('resyncs cursor when selectedId changes externally', () => {
+    const { rerender } = render(<Harness selectedId="a" onActivate={() => {}} />);
+    expect(screen.getByTestId('row-a').dataset.cursor).toBe('true');
+    rerender(<Harness selectedId="c" onActivate={() => {}} />);
+    expect(screen.getByTestId('row-c').dataset.cursor).toBe('true');
+  });
+});

--- a/tests/ui/use-media-query.test.tsx
+++ b/tests/ui/use-media-query.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { renderHook, act } from '@testing-library/react';
+import { useMediaQuery } from '../../packages/myco/ui/src/hooks/use-media-query';
+
+type Listener = (e: MediaQueryListEvent) => void;
+
+function installMatchMedia(initialMatches: boolean) {
+  const listeners = new Set<Listener>();
+  const mql = {
+    matches: initialMatches,
+    media: '',
+    onchange: null,
+    addEventListener: (_type: 'change', listener: Listener) => listeners.add(listener),
+    removeEventListener: (_type: 'change', listener: Listener) => listeners.delete(listener),
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => true,
+  };
+  // @ts-expect-error — test scaffold
+  globalThis.window.matchMedia = mock((q: string) => ({ ...mql, media: q }));
+  return {
+    fire(matches: boolean) {
+      mql.matches = matches;
+      for (const l of listeners) l({ matches } as MediaQueryListEvent);
+    },
+    listenerCount: () => listeners.size,
+  };
+}
+
+afterEach(() => {
+  // jsdom defines window.matchMedia as non-configurable once assigned, so
+  // reset rather than delete.
+  // @ts-expect-error — test scaffold
+  globalThis.window.matchMedia = undefined;
+});
+
+describe('useMediaQuery', () => {
+  it('returns the initial match value', () => {
+    installMatchMedia(true);
+    const { result } = renderHook(() => useMediaQuery('(min-width: 768px)'));
+    expect(result.current).toBe(true);
+  });
+
+  it('updates when the matchMedia listener fires', () => {
+    const ctl = installMatchMedia(false);
+    const { result } = renderHook(() => useMediaQuery('(min-width: 768px)'));
+    expect(result.current).toBe(false);
+    act(() => { ctl.fire(true); });
+    expect(result.current).toBe(true);
+  });
+
+  it('unsubscribes on unmount', () => {
+    const ctl = installMatchMedia(true);
+    const { unmount } = renderHook(() => useMediaQuery('(min-width: 768px)'));
+    expect(ctl.listenerCount()).toBe(1);
+    unmount();
+    expect(ctl.listenerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the Myco UI evolution. Migrates Sessions and Runs to a side-by-side master-rail + detail-pane layout, then redesigns the rail rows to match the v6 design mock (italic display-font titles, sparklines, time-window section grouping, totals header). RunDetail re-flows for the narrower detail-pane width. ~14 commits across primitives, hooks, page rewires, and a polish pass.

Builds on Phase 1 (PR #274) and the daemon-event-loop fixes from PRs #275 and #276 (rebased in).

## What changed

**New primitives**
- \`MasterDetailSplit\` — desktop side-by-side; mobile collapses to either-or based on URL selection
- \`CompareBar\` — extracted from RunList's inline pill, parametric on noun/label
- \`Sparkline\` — small SVG-based vertical-bar chart for rail-card activity
- \`FilterPill\` — popover-based filter trigger
- \`EmptyDetailHint\` — placeholder for the detail pane when nothing is selected
- \`useMediaQuery\`, \`useListKeyboardNav\` — supporting hooks

**Page rewires**
- \`pages/Sessions.tsx\` — route-based switching → \`MasterDetailSplit\` with path-based selection (\`/sessions/<id>\`)
- \`pages/Agent.tsx\` — table view → \`MasterDetailSplit\`; \`?run=<id>\` query param replaced by \`/agent/<id>\` path; mount-time legacy redirect preserves bookmarks; tab + run redirects merged atomically to avoid the canonicalization race a per-task review caught
- \`App.tsx\` — adds \`agent/:id\` route and legacy redirect mirror

**Row redesign (v6 match)**
- Both \`SessionList\` and \`RunList\` render vertical card rows: status dot (pulsing when active) + italic display-font title + time-ago + sparkline on the top line; meta line (agent · symbiont · prompts/tools); optional branch line
- Time-window section headers: \`ACTIVE · TODAY · YESTERDAY · EARLIER\` — empty sections omitted
- Top-of-rail totals strip: \`N TOTAL · M ACTIVE · K PROMPTS\` for Sessions; \`N TOTAL · M RUNNING · K TOKENS\` for Runs (\`TOKENS\` instead of \`TOOL CALLS\` because per-run tool counts aren't on the list summary and computing them would be N+1)
- Single-row \`aria-selected\` invariant (cursor and URL-selection are distinct visual states)
- \`j\`/\`k\`/\`Enter\`/\`/\` keyboard nav from \`useListKeyboardNav\` (with cursor → URL resync after a per-task review caught the missing effect)

**Backend augments**
- \`SessionSummary\` + \`RunRow\` now carry \`activity_buckets: number[]\` (length-8 prompt-batch counts per minute over last 8 minutes) and \`branch: string | null\` (from release-provenance)
- One batched query per page (not 8N subqueries) via the new \`activity-buckets.ts\` helper

**RunDetail responsive layout**
- Layout-only refactor of \`RunDetail.tsx\`'s grids: \`grid-cols-N\` → \`grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-N\`; flex strips get \`flex-wrap\`. No content or logic changes. Fixes the "smashed" look reported during smoke testing.

**Phase 1 surfaces unchanged**
- Topbar, Canopy entry slideout, Logs overlay, RunDetail RefreshIndicator, polling cadence — all preserved.

## Test posture

- Full suite: **4686 pass / 0 fail** (node phase) + **165 pass / 0 fail** (jsdom phase)
- New tests: 8 backend activity-buckets, 6 Sparkline, 7 FilterPill, 5 section-rows, plus the existing Phase 2 primitives' tests
- TypeScript clean for touched files

## Latent bug fixes incidentally included

- \`TaskDetail.onRunTriggered\` previously passed \`runId\` to a \`taskId\` slot in the URL builder (a pre-existing bug); the Task 5 refactor incidentally fixed it
- Mount-time tab + run-id redirect race on Agent.tsx: a per-task reviewer caught that two separate \`useEffect\`s with \`replace: true\` would clobber each other on combined URLs; merged into one atomic effect

## Notes

- Vite dev in worktrees is still blocked by a \`@goondocks/myco-shared\` browser-incompatible export — orthogonal to this PR, worth a separate fix
- Daemon binary serves the UI it was compiled against, so the freshly-built \`dist/ui\` only takes effect after \`make build\`. Smoke testing happens locally; no production behavior change

## Test plan
- [x] \`npm test\` green across both node + jsdom phases
- [x] Branch rebased onto latest \`main\` (4677 + 165 tests pass post-rebase)
- [x] TypeScript clean for all touched files
- [ ] Local smoke after \`make build\` + daemon restart: walk Sessions rail → click a session → click another → press j/k → press / → resize to mobile + back; same for Agent; verify RunDetail no longer looks smashed; check Phase 1 surfaces (Topbar, Canopy slideout, Logs overlay) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)