### PR TITLE
fix: harden daemon capture readiness

### DIFF
--- a/packages/myco/src/cli/init.ts
+++ b/packages/myco/src/cli/init.ts
@@ -20,6 +20,20 @@ import path from 'node:path';
 /** Directories that must exist inside a vault for correct operation. */
 const VAULT_REQUIRED_DIRS = ['buffer', 'attachments', 'logs', 'migration', 'tasks'] as const;
 
+const USAGE = `Usage: myco init [options]
+
+Initialize or reconcile Myco for the current project.
+
+Options:
+  --project <path>                 Project root to initialize
+  --grove <name|id>                Grove to bind this project to
+  --non-interactive                Run without prompts
+  --embedding-provider <provider>  Embedding provider for new vaults
+  --embedding-model <model>        Embedding model for new vaults
+  --embedding-url <url>            Embedding base URL for new vaults
+  -h, --help                       Show this help
+`;
+
 function printBanner(): void {
   const version = getPluginVersion();
   console.log('');
@@ -30,6 +44,11 @@ function printBanner(): void {
 }
 
 export async function run(args: string[]): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(USAGE);
+    return;
+  }
+
   const nonInteractive = args.includes('--non-interactive');
   const isInteractive = !nonInteractive && !!process.stdin.isTTY;
 

--- a/packages/myco/src/cli/update.ts
+++ b/packages/myco/src/cli/update.ts
@@ -25,7 +25,23 @@ import path from 'node:path';
 // gated by the `migration_tasks` ledger so they run exactly once per
 // vault regardless of update invocations.
 
+const USAGE = `Usage: myco update [options]
+
+Regenerate managed Myco project files and migrate legacy config to the
+current Machine/Grove/Project config tiers.
+
+Options:
+  --project <path>  Project root to update
+  --all-projects    Update every registered project served by this binary
+  -h, --help        Show this help
+`;
+
 export async function run(args: string[]): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(USAGE);
+    return;
+  }
+
   if (args.includes('--all-projects')) {
     await runAllProjects();
     return;
@@ -63,6 +79,7 @@ async function runForProject(projectRoot: string | undefined): Promise<void> {
   // .myco/myco.db but no project.toml Grove binding. Lift it into the
   // machine's default Grove before the rest of update operates on it.
   ensureGroveActivation(vaultDir, resolvedProjectRoot);
+  const groveId = loadProjectManifest(vaultDir)?.grove?.id ?? null;
 
   const stampPath = path.join(vaultDir, UPDATE_STAMP_FILENAME);
   const currentVersion = getPluginVersion();
@@ -89,7 +106,7 @@ async function runForProject(projectRoot: string | undefined): Promise<void> {
   const allManifests = loadManifests();
   const pkgRoot = resolvePackageRoot();
 
-  const config = loadConfig(vaultDir);
+  const config = loadConfig(vaultDir, { groveId, migrateTiers: true });
   const withReleaseDefaults = withInferredReleaseProvenanceDefaults(config, resolvedProjectRoot);
   if (withReleaseDefaults !== config) {
     updateConfig(vaultDir, () => withReleaseDefaults);

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -17,7 +17,7 @@ function rejectLegacyRuntimeKey<T extends z.ZodTypeAny>(schema: T) {
   }).pipe(schema);
 }
 
-const EmbeddingProviderSchema = z.object({
+const EmbeddingProviderBaseSchema = z.object({
   provider: z.enum(['ollama', 'openai-compatible', 'openrouter', 'openai']).default('ollama'),
   model: z.string().default('bge-m3'),
   base_url: z.string().url().optional(),
@@ -29,6 +29,10 @@ const EmbeddingProviderSchema = z.object({
    * draining when the machine sits idle long enough to deep-sleep.
    */
   run_in_deep_sleep: z.boolean().default(true),
+});
+const EmbeddingProviderSchema = EmbeddingProviderBaseSchema;
+const ProjectEmbeddingProviderSchema = EmbeddingProviderBaseSchema.omit({
+  run_in_deep_sleep: true,
 });
 
 const DaemonSchema = z.object({
@@ -154,7 +158,7 @@ const TaskProviderOverrideSchema = rejectLegacyRuntimeKey(z.object({
 // (Legacy `context.*` and root `canopy.*` blocks unified into `cortex.*`
 // in config_version 8. See migrations.ts:migrateV7ToV8.)
 
-const AgentSchema = rejectLegacyRuntimeKey(z.object({
+const AgentBaseSchema = z.object({
   /** Number of batches between event-driven summary triggers (0 to disable). */
   summary_batch_interval: z.number().int().min(0).default(5),
   /** Global toggle for PowerManager-scheduled agent tasks. */
@@ -183,6 +187,10 @@ const AgentSchema = rejectLegacyRuntimeKey(z.object({
   model: z.string().optional(),
   /** Per-task overrides keyed by task name. */
   tasks: z.record(z.string(), TaskProviderOverrideSchema).optional(),
+});
+const AgentSchema = rejectLegacyRuntimeKey(AgentBaseSchema);
+const ProjectAgentSchema = rejectLegacyRuntimeKey(AgentBaseSchema.omit({
+  scheduled_tasks_active_window_days: true,
 }));
 
 const BackupRetentionSchema = z.object({
@@ -525,10 +533,10 @@ export const GroveConfigSchema = z.object({
 export const ProjectConfigSchema = z.object({
   version: z.literal(3),
   config_version: z.number().int().nonnegative().default(0),
-  embedding: EmbeddingProviderSchema.default(() => EmbeddingProviderSchema.parse({})),
+  embedding: ProjectEmbeddingProviderSchema.default(() => ProjectEmbeddingProviderSchema.parse({})),
   capture: CaptureSchema.default(() => CaptureSchema.parse({})),
   release_provenance: ReleaseProvenanceSchema.default(() => ReleaseProvenanceSchema.parse({})),
-  agent: AgentSchema.default(() => AgentSchema.parse({})),
+  agent: ProjectAgentSchema.default(() => ProjectAgentSchema.parse({})),
   skills: SkillsSchema.default(() => SkillsSchema.parse({})),
   notifications: NotificationsSchema.default(() => NotificationsSchema.parse({})),
   cortex: CortexSchema.default(() => CortexSchema.parse({})),

--- a/packages/myco/src/constants.ts
+++ b/packages/myco/src/constants.ts
@@ -110,6 +110,8 @@ export const DAEMON_HEALTH_RETRY_DELAYS = [100, 200, 400, 800, 1500];
  *  triggering shutdown. Long enough to cover a fresh `npm install`-paced cold
  *  boot, short enough that genuine wedge states surface to the user. */
 export const DAEMON_RESTART_HEALTH_DEADLINE_MS = 30_000;
+/** Minimum interval between hook-triggered capture recovery restarts. */
+export const DAEMON_CAPTURE_RECOVERY_COALESCE_MS = 30_000;
 
 /** Per-poll interval during the restart health-watch loop (ms). */
 export const DAEMON_RESTART_POLL_INTERVAL_MS = 500;

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -34,6 +34,7 @@ import {
   resolveMycoHome,
   resolveProjectVaultDir,
   resolveGroveDbPath,
+  resolveServiceDirName,
 } from '@myco/grove/paths.js';
 import {
   pauseAwareShouldVisit,
@@ -171,8 +172,9 @@ function makeTotalPendingProbe(deps: PowerJobDeps): () => number {
   return () => {
     if (cache && Date.now() < cache.expiresAt) return cache.total;
     const mycoHome = deps.mycoHome ?? resolveMycoHome();
+    const servedBy = resolveServiceDirName(deps.daemonStateDir, mycoHome);
     let total = 0;
-    for (const grove of listGroves(mycoHome)) {
+    for (const grove of listGroves(mycoHome, { servedBy })) {
       try {
         const databasePath = resolveGroveDbPath(grove.id, mycoHome);
         const entry = deps.cache.getEmbeddingRuntime(databasePath, deps.embeddingRuntimeFactory);

--- a/packages/myco/src/daemon/server.ts
+++ b/packages/myco/src/daemon/server.ts
@@ -210,6 +210,19 @@ export class DaemonServer {
       res.writeHead(200, { 'Content-Type': 'application/json', ...versionHeader });
       res.end(JSON.stringify({ version: this.version }));
     });
+
+    // Readiness deliberately uses the normal route pipeline. /health answers
+    // "is the process alive?"; /ready answers "can routed daemon requests
+    // make it through request-context resolution and DB scoping?"
+    this.registerRoute('GET', '/ready', async () => ({
+      body: {
+        myco: true,
+        ready: true,
+        version: this.version,
+        pid: process.pid,
+        uptime: process.uptime(),
+      },
+    }));
   }
 
   private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
@@ -322,7 +335,7 @@ export class DaemonServer {
       return;
     }
 
-    if (pathname.startsWith('/api/') || pathname === '/health') {
+    if (isDaemonControlPath(pathname)) {
       res.writeHead(404, { 'Content-Type': 'application/json', 'X-Myco-Api-Version': this.version });
       res.end(JSON.stringify({ error: 'not found' }));
       return;
@@ -375,7 +388,7 @@ export class DaemonServer {
     if (!this.uiDevProxyTarget || !req.url) return false;
 
     const pathname = new URL(req.url, 'http://localhost').pathname;
-    if (pathname.startsWith('/api/') || pathname === '/health') return false;
+    if (isDaemonControlPath(pathname)) return false;
 
     try {
       const targetUrl = new URL(req.url, this.uiDevProxyTarget).toString();
@@ -438,7 +451,7 @@ export class DaemonServer {
     }
 
     const pathname = new URL(req.url, 'http://localhost').pathname;
-    if (pathname.startsWith('/api/') || pathname === '/health') {
+    if (isDaemonControlPath(pathname)) {
       socket.destroy();
       return;
     }
@@ -705,6 +718,10 @@ export function applyDaemonHttpServerLimits(server: http.Server): void {
 /** TCP listen backlog used by the daemon. Exported so service installers
  *  / consumers that bind their own listener can match it. */
 export const DAEMON_HTTP_LISTEN_BACKLOG = HTTP_LISTEN_BACKLOG;
+
+function isDaemonControlPath(pathname: string): boolean {
+  return pathname.startsWith('/api/') || pathname === '/health' || pathname === '/ready';
+}
 
 /**
  * Force a Node HTTP server through a fast, deterministic shutdown.

--- a/packages/myco/src/hooks/client.ts
+++ b/packages/myco/src/hooks/client.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { spawn } from 'node:child_process';
 import {
   DAEMON_CLIENT_TIMEOUT_MS,
+  DAEMON_CAPTURE_RECOVERY_COALESCE_MS,
   DAEMON_HEALTH_CHECK_TIMEOUT_MS,
   DAEMON_HEALTH_RETRY_DELAYS,
   DAEMON_RESTART_HEALTH_DEADLINE_MS,
@@ -85,6 +86,10 @@ interface ClientResult {
 interface ClientOptions {
   timeoutMs?: number;
   headers?: Record<string, string>;
+}
+
+interface RequestFailureRecovery {
+  captureCritical?: boolean;
 }
 
 interface DaemonClientOptions {
@@ -183,6 +188,24 @@ export class DaemonClient {
   }
 
   async post(endpoint: string, body: unknown, options?: ClientOptions): Promise<ClientResult> {
+    return this.postWithRecovery(endpoint, body, options);
+  }
+
+  /**
+   * POST for capture-critical hook writes. If transport times out or the
+   * daemon socket fails, recover the owning service instead of only spawning:
+   * a managed daemon can still be "running" while routed ingestion is wedged.
+   */
+  async capturePost(endpoint: string, body: unknown, options?: ClientOptions): Promise<ClientResult> {
+    return this.postWithRecovery(endpoint, body, options, { captureCritical: true });
+  }
+
+  private async postWithRecovery(
+    endpoint: string,
+    body: unknown,
+    options?: ClientOptions,
+    recovery?: RequestFailureRecovery,
+  ): Promise<ClientResult> {
     const info = this.readDaemonJson();
     if (!info) {
       this.spawnDaemon();
@@ -200,7 +223,7 @@ export class DaemonClient {
       const data = await res.json();
       return { ok: true, data };
     } catch {
-      this.spawnDaemon();
+      await this.recoverAfterRequestFailure(recovery);
       return { ok: false };
     }
   }
@@ -223,7 +246,7 @@ export class DaemonClient {
       const data = await res.json();
       return { ok: true, data };
     } catch {
-      this.spawnDaemon();
+      await this.recoverAfterRequestFailure();
       return { ok: false };
     }
   }
@@ -244,7 +267,7 @@ export class DaemonClient {
       const data = await res.json();
       return { ok: true, data };
     } catch {
-      this.spawnDaemon();
+      await this.recoverAfterRequestFailure();
       return { ok: false };
     }
   }
@@ -274,7 +297,7 @@ export class DaemonClient {
       const data = await res.json();
       return { ok: true, data };
     } catch {
-      this.spawnDaemon();
+      await this.recoverAfterRequestFailure();
       return { ok: false };
     }
   }
@@ -290,6 +313,23 @@ export class DaemonClient {
       if (!res.ok) return false;
       const data = await res.json() as HealthResponse;
       return data.myco === true;
+    } catch {
+      return false;
+    }
+  }
+
+  async isReady(cachedInfo?: DaemonInfo | null): Promise<boolean> {
+    try {
+      const info = cachedInfo ?? this.readDaemonJson();
+      if (!info) return false;
+
+      const res = await fetch(`http://127.0.0.1:${info.port}/ready`, {
+        headers: this.requestHeaders(),
+        signal: AbortSignal.timeout(DAEMON_HEALTH_CHECK_TIMEOUT_MS),
+      });
+      if (!res.ok) return false;
+      const data = await res.json() as { ready?: boolean };
+      return data.ready === true;
     } catch {
       return false;
     }
@@ -504,6 +544,41 @@ export class DaemonClient {
 
   private readDaemonJson(): DaemonInfo | null {
     return readDaemonState(this.daemonService.statePath);
+  }
+
+  private async recoverAfterRequestFailure(recovery?: RequestFailureRecovery): Promise<void> {
+    if (!recovery?.captureCritical) {
+      await this.spawnDaemon();
+      return;
+    }
+
+    if (this.captureRecoveryRecentlyRequested()) return;
+
+    try {
+      const mgr = this.serviceManager ?? getServiceManager();
+      const installed = await findInstalledServiceLabel(mgr, serviceVariantForState(this.daemonService));
+      if (installed) {
+        await mgr.restart(installed.label).catch(() => { /* best-effort */ });
+        return;
+      }
+    } catch {
+      // Fall through to legacy spawn recovery.
+    }
+
+    await this.spawnDaemon();
+  }
+
+  private captureRecoveryRecentlyRequested(): boolean {
+    try {
+      const markerPath = path.join(this.daemonService.stateDir, 'capture-recovery.json');
+      const stat = fs.existsSync(markerPath) ? fs.statSync(markerPath) : null;
+      if (stat && Date.now() - stat.mtimeMs < DAEMON_CAPTURE_RECOVERY_COALESCE_MS) return true;
+      fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+      fs.writeFileSync(markerPath, JSON.stringify({ requested_at: new Date().toISOString() }));
+    } catch {
+      return false;
+    }
+    return false;
   }
 }
 

--- a/packages/myco/src/hooks/post-tool-use.ts
+++ b/packages/myco/src/hooks/post-tool-use.ts
@@ -20,11 +20,9 @@ export async function main() {
 
     const client = createHookDaemonClient(VAULT_DIR, { sessionId });
 
-    // DaemonClient auto-spawns on missing daemon.json or fetch failure,
-    // coalesced within DAEMON_SPAWN_COALESCE_MS so frequent PostToolUse
-    // firings don't fork extra daemons. This call still buffers on live
-    // failure; reconcile replays on the next successful start.
-    const result = await client.post('/events', {
+    // Capture writes use service-aware recovery on transport failure, then
+    // still buffer locally so reconcile can replay on the next successful start.
+    const result = await client.capturePost('/events', {
       type: 'tool_use',
       tool_name: input.toolName,
       tool_input: input.toolInput,

--- a/packages/myco/src/hooks/send-event.ts
+++ b/packages/myco/src/hooks/send-event.ts
@@ -30,7 +30,10 @@ export async function sendEvent(
     };
 
     const client = createHookDaemonClient(VAULT_DIR, { sessionId });
-    const result = await client.post('/events', { ...eventWithContext, session_id: sessionId, agent: symbiont });
+    const result = await client.capturePost(
+      '/events',
+      { ...eventWithContext, session_id: sessionId, agent: symbiont },
+    );
 
     // Buffer on transport failure OR server-side `ignored` so reconcile can replay it.
     if (!result.ok || isIgnoredEventResponse(result.data)) {

--- a/packages/myco/src/hooks/session-start.ts
+++ b/packages/myco/src/hooks/session-start.ts
@@ -45,7 +45,7 @@ export async function main() {
     } catch { /* not a git repo */ }
 
     const [, contextResult] = await Promise.all([
-      client.post('/sessions/register', {
+      client.capturePost('/sessions/register', {
         session_id: sessionId,
         agent: symbiont,
         branch,

--- a/packages/myco/src/hooks/stop.ts
+++ b/packages/myco/src/hooks/stop.ts
@@ -22,7 +22,7 @@ export async function main() {
     // Pass transcript_path and last_assistant_message from the active agent.
     // These are provided by the hook system and eliminate the need to
     // scan directories or mine the transcript for the AI response.
-    await client.post('/events/stop', {
+    await client.capturePost('/events/stop', {
       session_id: input.sessionId,
       agent: input.agent,
       transcript_path: input.transcriptPath,

--- a/packages/myco/src/hooks/user-prompt-submit.ts
+++ b/packages/myco/src/hooks/user-prompt-submit.ts
@@ -47,7 +47,7 @@ export async function main() {
     }
 
     // Kind classification happens on the daemon; Stop-time reconciler repairs it.
-    const eventResult = await client.post('/events', {
+    const eventResult = await client.capturePost('/events', {
       type: 'user_prompt',
       prompt,
       session_id: sessionId,

--- a/packages/myco/src/symbionts/canopy-read-tools.ts
+++ b/packages/myco/src/symbionts/canopy-read-tools.ts
@@ -117,7 +117,12 @@ function resolveShellArg(
   // (pipes, redirects, subshells, globs, command chains all surface here).
   // A bare `$` string token comes from a subshell expansion like `$(...)`
   // whose `(`/`)` arrive as operator objects — treat that as not-simple too.
-  const tokens = shellParse(raw);
+  let tokens: ReturnType<typeof shellParse>;
+  try {
+    tokens = shellParse(raw);
+  } catch {
+    return null;
+  }
   if (tokens.length === 0) return null;
   for (const tok of tokens) {
     if (typeof tok !== 'string') return null;

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -80,6 +80,17 @@ describe('myco init', () => {
     fs.rmSync(testDir, { recursive: true, force: true });
   });
 
+  it('prints help without initializing or updating a project', async () => {
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await run(['--help']);
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('Usage: myco init'));
+    expect(fs.existsSync(vault)).toBe(false);
+    expect(openDatabase).not.toHaveBeenCalled();
+    stdoutSpy.mockRestore();
+  });
+
   it('creates vault with config and gitignore', async () => {
     await run(['--embedding-model', 'bge-m3']);
 

--- a/tests/cli/update.test.ts
+++ b/tests/cli/update.test.ts
@@ -51,10 +51,15 @@ mock.module('@myco/cli/shared.js', () => ({
 describe('myco update', () => {
   let testDir: string;
   let vaultDir: string;
+  let mycoHome: string;
+  let previousMycoHome: string | undefined;
 
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-update-test-'));
     vaultDir = path.join(testDir, '.myco');
+    mycoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-update-home-'));
+    previousMycoHome = process.env.MYCO_HOME;
+    process.env.MYCO_HOME = mycoHome;
     fs.mkdirSync(vaultDir, { recursive: true });
     vi.clearAllMocks();
     ensureRunningMock.mockResolvedValue(true);
@@ -64,6 +69,24 @@ describe('myco update', () => {
 
   afterEach(() => {
     fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(mycoHome, { recursive: true, force: true });
+    if (previousMycoHome === undefined) {
+      delete process.env.MYCO_HOME;
+    } else {
+      process.env.MYCO_HOME = previousMycoHome;
+    }
+  });
+
+  it('prints help without touching project files', async () => {
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const { run } = await import('@myco/cli/update.js');
+
+    await run(['--help']);
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('Usage: myco update'));
+    expect(fs.existsSync(path.join(vaultDir, 'myco.yaml'))).toBe(false);
+    expect(ensureRunningMock).not.toHaveBeenCalled();
+    stdoutSpy.mockRestore();
   });
 
   it('updates only enabled symbionts from config', async () => {
@@ -242,6 +265,47 @@ describe('myco update', () => {
     await run(['--project', testDir]);
 
     expect(ensureRunningMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('moves legacy project config fields into Grove config during update', async () => {
+    const groveId = 'grove_00000000000000000000000000000001';
+    const projectId = 'proj_00000000000000000000000000000001';
+    fs.writeFileSync(path.join(vaultDir, 'project.toml'), [
+      '[project]',
+      `id = "${projectId}"`,
+      'name = "test-project"',
+      '',
+      '[grove]',
+      `id = "${groveId}"`,
+      'name = "Default"',
+      'slug = "default"',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(path.join(vaultDir, 'myco.yaml'), YAML.stringify({
+      version: 3,
+      config_version: 0,
+      embedding: {
+        provider: 'ollama',
+        model: 'bge-m3',
+        run_in_deep_sleep: false,
+      },
+      agent: {
+        scheduled_tasks_active_window_days: 3,
+      },
+      symbionts: { 'claude-code': { enabled: true } },
+    }));
+    fs.mkdirSync(path.join(testDir, '.claude'), { recursive: true });
+
+    const { run } = await import('@myco/cli/update.js');
+    await run(['--project', testDir]);
+
+    const projectYaml = fs.readFileSync(path.join(vaultDir, 'myco.yaml'), 'utf-8');
+    expect(projectYaml).not.toContain('run_in_deep_sleep');
+    expect(projectYaml).not.toContain('scheduled_tasks_active_window_days');
+
+    const groveYaml = fs.readFileSync(path.join(mycoHome, 'groves', groveId, 'grove.yaml'), 'utf-8');
+    expect(groveYaml).toContain('run_in_deep_sleep: false');
+    expect(groveYaml).toContain('scheduled_tasks_active_window_days: 3');
   });
 
   describe('--all-projects', () => {

--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -170,10 +170,24 @@ intelligence:
     const loaded = loadConfig(tmpDir);
     expect(loaded.embedding.provider).toBe('ollama');
   });
+
+  it('does not serialize Grove-tier defaults into project config', () => {
+    const config = loadConfig(writeMinimalProject(tmpDir));
+
+    saveConfig(tmpDir, config);
+
+    const written = fs.readFileSync(path.join(tmpDir, 'myco.yaml'), 'utf-8');
+    expect(written).not.toContain('run_in_deep_sleep');
+    expect(written).not.toContain('scheduled_tasks_active_window_days');
+  });
 });
 
 function writeProject(dir: string, yaml: string) {
   fs.writeFileSync(path.join(dir, 'myco.yaml'), yaml);
+}
+function writeMinimalProject(dir: string) {
+  fs.writeFileSync(path.join(dir, 'myco.yaml'), 'version: 3\n');
+  return dir;
 }
 function writeLocal(dir: string, yaml: string) {
   // Tests treat `dir` as the vault directory (matches resolveVaultDir's `.myco/` convention).

--- a/tests/daemon/power-jobs.test.ts
+++ b/tests/daemon/power-jobs.test.ts
@@ -376,6 +376,29 @@ describe('embedding-reconcile power job', () => {
     expect(job.preventsDeepSleep?.()).toBe(false);
   });
 
+  it('preventsDeepSleep ignores pending work in Groves served by a different daemon', () => {
+    const devGrove = createGrove('Dogfood', fx.mycoHome, { servedBy: 'service-dev' });
+    ensureGroveDatabase(devGrove.id, fx.mycoHome);
+    const devDatabasePath = resolveGroveDbPath(devGrove.id, fx.mycoHome);
+
+    const managers = new Map<string, { totalPendingCount: () => number; reconcile: ReturnType<typeof vi.fn> }>([
+      [fx.databasePath, { totalPendingCount: () => 0, reconcile: vi.fn(async () => ({ embedded: 0, stale_reembedded: 0, orphans_cleaned: 0, duration_ms: 0 })) }],
+      [devDatabasePath, { totalPendingCount: () => 5, reconcile: vi.fn(async () => ({ embedded: 0, stale_reembedded: 0, orphans_cleaned: 0, duration_ms: 0 })) }],
+    ]);
+    const factory: EmbeddingRuntimeFactory = (_db, dbPath) => ({
+      vectorStore: { close() {} } as never,
+      embeddingManager: managers.get(dbPath)! as never,
+    });
+    fx.cache.getEmbeddingRuntime(devDatabasePath, factory);
+
+    const deps = buildDeps(fx);
+    deps.embeddingRuntimeFactory = factory;
+    registerPowerJobs(pm as never, deps);
+
+    const job = pm.find('embedding-reconcile');
+    expect(job.preventsDeepSleep?.()).toBe(false);
+  });
+
   it('preventsDeepSleep returns false when toggle is off, even with pending work', () => {
     fx.cleanup();
     fx = setupGrove({ pendingCount: 50 });

--- a/tests/daemon/server.test.ts
+++ b/tests/daemon/server.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { DaemonServer } from '@myco/daemon/server';
 import { DaemonLogger } from '@myco/daemon/logger';
-import { requestContextHeaders, resolveLegacyRequestContext, REQUEST_CONTEXT_AUTH_HEADER } from '@myco/tools/request-context';
+import { requestContextHeaders, resolveLegacyRequestContext, REQUEST_CONTEXT_AUTH_HEADER, REQUEST_CONTEXT_HEADERS } from '@myco/tools/request-context';
 import { ensureProjectManifest, saveProjectManifest } from '@myco/config/project-manifest';
 import { resolveGroveDbPath, resolveProjectVaultDir } from '@myco/grove/paths';
 import { createGrove, registerProjectInGrove } from '@myco/grove/registry';
@@ -183,6 +183,38 @@ describe('DaemonServer', () => {
       const body = await res.json();
       expect(body.myco).toBe(true);
       expect(body.version).toBeTruthy();
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('/ready reports routed request readiness', async () => {
+    const server = new DaemonServer({ vaultDir, logger });
+    await server.start();
+    try {
+      const res = await fetch(`http://127.0.0.1:${server.port}/ready`);
+      expect(res.status).toBe(200);
+      const body = await res.json() as { myco?: boolean; ready?: boolean; version?: string; pid?: number };
+      expect(body.myco).toBe(true);
+      expect(body.ready).toBe(true);
+      expect(body.version).toBeTruthy();
+      expect(body.pid).toBe(process.pid);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('/ready uses request-context auth instead of raw liveness bypass', async () => {
+    const server = new DaemonServer({ vaultDir, logger });
+    await server.start();
+    try {
+      const res = await fetch(`http://127.0.0.1:${server.port}/ready`, {
+        headers: {
+          [REQUEST_CONTEXT_HEADERS.groveId]: 'grove_does_not_exist',
+          [REQUEST_CONTEXT_HEADERS.projectId]: 'proj_does_not_exist',
+        },
+      });
+      expect(res.status).toBe(401);
     } finally {
       await server.stop();
     }

--- a/tests/hooks/client.test.ts
+++ b/tests/hooks/client.test.ts
@@ -4,6 +4,8 @@ import { REQUEST_CONTEXT_ENV, REQUEST_CONTEXT_HEADERS, resolveLegacyRequestConte
 import { ensureProjectManifest, saveProjectManifest } from '@myco/config/project-manifest';
 import { resolveProjectVaultDir, resolveServiceDaemonStatePath } from '@myco/grove/paths';
 import { createGrove, registerProjectInGrove } from '@myco/grove/registry';
+import { serviceLabel } from '@myco/service/labels';
+import { FakeServiceManager } from '../helpers/fake-service-manager';
 import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -14,6 +16,7 @@ describe('DaemonClient', () => {
   let mockServer: http.Server;
   let mockPort: number;
   let globalStatePath: string;
+  let previousMycoHome: string | undefined;
 
   beforeEach(async () => {
     // Suppress the fire-and-forget spawnDaemon side effect that post/get/put/
@@ -21,12 +24,17 @@ describe('DaemonClient', () => {
     // request-level result; the spawn path has its own unit coverage.
     process.env.MYCO_NO_AUTO_SPAWN = '1';
     vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-client-'));
+    previousMycoHome = process.env.MYCO_HOME;
+    process.env.MYCO_HOME = path.join(vaultDir, 'home');
     ensureProjectManifest(vaultDir, { projectName: 'client-test' });
 
     mockServer = http.createServer((req, res) => {
       if (req.url === '/health') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ myco: true, pid: process.pid }));
+      } else if (req.url === '/ready') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ myco: true, ready: true, pid: process.pid }));
       } else {
         let body = '';
         req.on('data', (c: string) => { body += c; });
@@ -56,6 +64,8 @@ describe('DaemonClient', () => {
     fs.rmSync(vaultDir, { recursive: true, force: true });
     try { fs.unlinkSync(globalStatePath); } catch { /* gone */ }
     delete process.env.MYCO_NO_AUTO_SPAWN;
+    if (previousMycoHome === undefined) delete process.env.MYCO_HOME;
+    else process.env.MYCO_HOME = previousMycoHome;
     delete process.env[REQUEST_CONTEXT_ENV.projectRoot];
     delete process.env[REQUEST_CONTEXT_ENV.projectId];
     delete process.env[REQUEST_CONTEXT_ENV.groveId];
@@ -69,6 +79,12 @@ describe('DaemonClient', () => {
     const result = await client.post('/events', { type: 'test' });
     expect(result.ok).toBe(true);
     expect(result.data.received.type).toBe('test');
+  });
+
+  it('checks routed readiness separately from raw health', async () => {
+    const client = new DaemonClient(vaultDir);
+    await expect(client.isHealthy()).resolves.toBe(true);
+    await expect(client.isReady()).resolves.toBe(true);
   });
 
   it('forwards constructor request context headers to daemon requests', async () => {
@@ -166,6 +182,44 @@ describe('DaemonClient', () => {
     const client = new DaemonClient(vaultDir);
     const result = await client.post('/events', { type: 'test' });
     expect(result.ok).toBe(false);
+  });
+
+  it('restarts the managed service when a capture-critical post fails', async () => {
+    await new Promise<void>((r) => mockServer.close(() => r()));
+
+    const mgr = new FakeServiceManager({ preInstalled: serviceLabel('prod') });
+    mgr.statuses.set(serviceLabel('prod'), {
+      installed: true,
+      running: true,
+      pid: process.pid,
+      lastExitCode: 0,
+      unitPath: '/fake/co.goondocks.myco.plist',
+    });
+    const client = new DaemonClient(vaultDir, { serviceManager: mgr });
+
+    const result = await client.capturePost('/events', { type: 'test' });
+
+    expect(result.ok).toBe(false);
+    expect(mgr.restartCalls).toEqual([serviceLabel('prod')]);
+  });
+
+  it('coalesces repeated capture recovery restarts', async () => {
+    await new Promise<void>((r) => mockServer.close(() => r()));
+
+    const mgr = new FakeServiceManager({ preInstalled: serviceLabel('prod') });
+    mgr.statuses.set(serviceLabel('prod'), {
+      installed: true,
+      running: true,
+      pid: process.pid,
+      lastExitCode: 0,
+      unitPath: '/fake/co.goondocks.myco.plist',
+    });
+    const client = new DaemonClient(vaultDir, { serviceManager: mgr });
+
+    await client.capturePost('/events', { type: 'first' });
+    await client.capturePost('/events', { type: 'second' });
+
+    expect(mgr.restartCalls).toEqual([serviceLabel('prod')]);
   });
 });
 

--- a/tests/symbionts/canopy-read-tools.test.ts
+++ b/tests/symbionts/canopy-read-tools.test.ts
@@ -140,6 +140,9 @@ describe('resolveCanopyReadTool — shell-arg variant', () => {
     expect(resolveCanopyReadTool(codexManifest, 'Bash', { command: 'cat $(echo src/x.ts)' })).toBeNull();
     expect(resolveCanopyReadTool(codexManifest, 'Bash', { command: 'cat src/*.ts' })).toBeNull();
   });
+  it('returns null when shell parsing rejects complex command syntax', () => {
+    expect(resolveCanopyReadTool(codexManifest, 'Bash', { command: 'node -e "console.log(${JSON.stringify({ ok: true })})"' })).toBeNull();
+  });
   it('returns null when command has no positional argument', () => {
     expect(resolveCanopyReadTool(codexManifest, 'Bash', { command: 'cat' })).toBeNull();
     expect(resolveCanopyReadTool(codexManifest, 'Bash', { command: 'cat -n' })).toBeNull();


### PR DESCRIPTION
## Summary
- add daemon readiness semantics for capture-critical hook traffic and keep /health as liveness
- recover capture posts through restart/coalesced buffering when the daemon cannot process requests
- keep prod/dev Grove ownership separated in scheduled embedding work
- make CLI help paths side-effect free and make update run config tier migration into Grove scope
- tolerate shell parser failures in Canopy read-tool detection without dropping capture

## Verification
- bun test tests/cli/init.test.ts tests/cli/update.test.ts tests/config/loader.test.ts
- bun test tests/symbionts/canopy-read-tools.test.ts
- bun test tests/daemon/power-jobs.test.ts tests/hooks/client.test.ts tests/daemon/server.test.ts
- make build
- myco-dev restart
- myco-dev init --help
- myco-dev update --help
- myco-dev update
- curl -fsS http://127.0.0.1:19344/ready