### PR TITLE
fix(daemon): route /api/config* through the per-request project vault

### DIFF
--- a/.agents/skills/daemon-process-lifecycle-management/SKILL.md
+++ b/.agents/skills/daemon-process-lifecycle-management/SKILL.md
@@ -388,6 +388,74 @@ When multiple global daemons detected:
 
 ## Procedure E: Health Checking and Recovery
 
+### Liveness vs Readiness Probe Split
+
+**Critical architecture**: Formalize daemon health checking into two distinct endpoints following Kubernetes liveness/readiness probe pattern:
+
+```typescript
+// 1. /health — Raw Liveness Probe
+app.get('/health', (req, res) => {
+  // Returns immediately with process-level liveness signal
+  // No routed request, no DB scoping, no context validation
+  res.json({
+    status: 'alive',
+    version: process.env.npm_package_version,
+    pid: process.pid,
+    uptime: process.uptime(),
+    timestamp: Date.now()
+  });
+});
+
+// 2. /ready — Routed Readiness Probe  
+app.get('/ready', async (req, res) => {
+  // Full readiness check with request context validation
+  try {
+    // Validate request context propagation
+    const groveId = req.headers['x-grove-id'] || 'default';
+    
+    // Test database connectivity
+    await validateDatabaseConnection(groveId);
+    
+    // Test grove coordination
+    await validateGroveCoordination(groveId);
+    
+    // Test critical services
+    await validateCriticalServices(groveId);
+    
+    res.json({
+      status: 'ready',
+      grove: groveId,
+      checks: {
+        database: 'ok',
+        groveCoordination: 'ok', 
+        criticalServices: 'ok'
+      },
+      timestamp: Date.now()
+    });
+  } catch (error) {
+    res.status(503).json({
+      status: 'not_ready',
+      error: error.message,
+      timestamp: Date.now()
+    });
+  }
+});
+```
+
+**Liveness probe characteristics:**
+- Fast response (< 100ms typical)
+- Process-level health only
+- No external dependencies
+- No database queries
+- No grove coordination
+
+**Readiness probe characteristics:**
+- Context-aware validation
+- Database connectivity check
+- Grove coordination validation
+- Full service stack verification
+- May fail while process is alive
+
 ### Session Freshness Check with Tool-Use Activity Detection
 
 **Critical fix**: Session freshness checks must account for tool-use activity during long agentic turns:
@@ -431,28 +499,39 @@ async function isSessionFresh(sessionId: string): Promise<boolean> {
 
 **Fix pattern**: Always include tool-use activity timestamps in session freshness calculations to properly handle long agentic turns.
 
-### Global Daemon Health Validation
+### Dual-Probe Health Validation
 
 ```bash
-# Global daemon HTTP health check
+# Liveness check — fast process health
 DAEMON_PORT=$(jq -r '.port' ~/.myco/daemon.json)
 if curl -f -s "http://localhost:$DAEMON_PORT/health" >/dev/null; then
-  echo "Global daemon healthy"
+  echo "Daemon process alive"
 else
-  echo "Global daemon unhealthy - triggering recovery"
+  echo "Daemon process dead - triggering restart"
+  myco daemon restart
+fi
+
+# Readiness check — full service validation
+GROVE_ID="default"
+if curl -f -s -H "x-grove-id: $GROVE_ID" "http://localhost:$DAEMON_PORT/ready" >/dev/null; then
+  echo "Daemon ready for requests"
+else
+  echo "Daemon not ready - investigating service issues"
+  # Continue with detailed diagnostics
 fi
 ```
 
 ### Grove-Aware Recovery Workflows
 
 **Global daemon recovery workflow:**
-1. **Attempt global health ping** with reasonable timeout
-2. **Check global process existence** if health ping fails
-3. **Validate global port binding** if process exists
-4. **Check for Hub process interference** and migrate if needed
-5. **Coordinate grove notification** before eviction
-6. **Evict and restart global daemon** if unresponsive
-7. **Re-establish grove connections** after restart
+1. **Attempt liveness ping** (`/health`) with reasonable timeout
+2. **Attempt readiness ping** (`/ready`) with grove context
+3. **Check global process existence** if liveness ping fails
+4. **Validate global port binding** if process exists
+5. **Check for Hub process interference** and migrate if needed
+6. **Coordinate grove notification** before eviction
+7. **Evict and restart global daemon** if unresponsive
+8. **Re-establish grove connections** after restart
 
 ### Grove Responsiveness Monitoring
 
@@ -660,6 +739,33 @@ else
   echo "Hub migration not complete - preserving Hub artifacts"
 fi
 ```
+
+### Liveness vs Readiness Probe Usage
+
+**Probe selection gotcha**: Choose the appropriate probe for each use case:
+
+```bash
+# Wrong - using readiness probe for process restart decisions
+if ! curl -s "http://localhost:$PORT/ready"; then
+  myco daemon restart  # May restart healthy process with temporary readiness issues
+fi
+
+# Right - use liveness probe for restart decisions
+if ! curl -s "http://localhost:$PORT/health"; then
+  myco daemon restart  # Only restart when process is actually dead
+fi
+
+# Right - use readiness probe for load balancing and request routing
+if curl -s "http://localhost:$PORT/ready"; then
+  # Safe to route requests to this daemon
+  route_requests_to_daemon
+fi
+```
+
+**Probe timing gotchas**:
+- Liveness probes should timeout quickly (< 5 seconds) to detect process death
+- Readiness probes can timeout longer (10-30 seconds) for thorough validation
+- Never use readiness failure as sole trigger for process restart
 
 ### Grove Ownership and Multi-Environment Coordination
 

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ docs/superpowers/specs/
 docs/superpowers/plans/
 docs/design/
 docs/plans/
+docs/superpowers/handoffs/
 .wrangler/

--- a/.myco/myco.yaml
+++ b/.myco/myco.yaml
@@ -10,6 +10,7 @@ capture:
     - docs/superpowers/plans/
     - docs/design/
     - docs/plans
+    - docs/superpowers/handoffs
   ignore_plan_dirs_in_git: true
   artifact_extensions:
     - .md

--- a/packages/myco/src/config/loader.ts
+++ b/packages/myco/src/config/loader.ts
@@ -449,16 +449,6 @@ export function updateConfig(
   return updated;
 }
 
-export function updateBackupConfig(
-  vaultDir: string,
-  backup: Partial<BackupConfig>,
-): MycoConfig {
-  return updateConfig(vaultDir, (config) => ({
-    ...config,
-    backup: { ...config.backup, ...backup },
-  }));
-}
-
 /**
  * Extract the set of enabled symbiont names from config.
  * Returns null when the `symbionts` section is absent (pre-existing installs),

--- a/packages/myco/src/daemon/api/backup.ts
+++ b/packages/myco/src/daemon/api/backup.ts
@@ -339,33 +339,43 @@ export function createBackupHandlers(deps: BackupDeps) {
 // ---------------------------------------------------------------------------
 
 export interface BackupConfigDeps {
-  vaultDir: string;
-  /** Boot-time Grove id; used to compute the default-dir hint. */
+  /** Bootstrap fallback used only when a request arrives with no context. */
+  bootstrapVaultDir: string;
+  /** Boot-time Grove id; used to compute the default-dir hint when unset. */
   bootGroveId: string | null;
   mycoHome?: string;
 }
 
 /**
  * Create handlers for GET/PUT /api/backup/config.
+ *
+ * The vault dir is resolved per-request from `req.requestContext.projectVaultDir`
+ * so each project's backup setting is read/written against its own
+ * `myco.yaml`. `bootstrapVaultDir` is only used when no request context is
+ * bound (legacy / non-daemon callers).
  */
 export function createBackupConfigHandlers(deps: BackupConfigDeps) {
-  const { vaultDir } = deps;
   const mycoHome = deps.mycoHome ?? resolveMycoHome();
 
-  function defaultDirForGrove(grove: GroveRecord | null): string {
+  function defaultDirForGrove(grove: GroveRecord | null, vaultDir: string): string {
     if (grove) return path.resolve(resolveGroveDir(grove.id, mycoHome), 'backups');
     return path.resolve(vaultDir, 'backups');
   }
 
+  function vaultDirForRequest(req: RouteRequest): string {
+    return req.requestContext?.projectVaultDir ?? deps.bootstrapVaultDir;
+  }
+
   /** GET /api/backup/config — read the configured backup directory (merged). */
   async function handleGetBackupConfig(req: RouteRequest): Promise<RouteResponse> {
+    const vaultDir = vaultDirForRequest(req);
     const groveId = req.requestContext?.groveId ?? deps.bootGroveId;
     const cfg = loadMergedConfig(vaultDir, { groveId, mycoHome });
     const grove = groveId ? loadGroveRecord(groveId, mycoHome) : null;
     return {
       body: {
         dir: cfg.backup.dir ?? null,
-        default_dir: defaultDirForGrove(grove),
+        default_dir: defaultDirForGrove(grove, vaultDir),
       },
     };
   }
@@ -373,7 +383,7 @@ export function createBackupConfigHandlers(deps: BackupConfigDeps) {
   /** PUT /api/backup/config — update the backup directory setting. */
   async function handlePutBackupConfig(req: RouteRequest): Promise<RouteResponse> {
     const { dir } = req.body as { dir?: string | null };
-    updateBackupConfig(vaultDir, { dir: dir || undefined });
+    updateBackupConfig(vaultDirForRequest(req), { dir: dir || undefined });
     return { body: { dir: dir || null } };
   }
 

--- a/packages/myco/src/daemon/api/backup.ts
+++ b/packages/myco/src/daemon/api/backup.ts
@@ -20,7 +20,8 @@ import {
   restorePreview,
   restoreBackup,
 } from '../backup.js';
-import { loadMergedConfig, updateBackupConfig } from '../../config/loader.js';
+import { loadMergedConfig, loadGroveConfig, saveGroveConfig } from '../../config/loader.js';
+import { GroveConfigSchema } from '../../config/schema.js';
 import { loadGroveRecord, listGroves, type GroveRecord } from '../../grove/registry.js';
 import { resolveGroveDir, resolveGroveDbPath, resolveMycoHome } from '../../grove/paths.js';
 import type { GroveRuntimeCache } from '../grove-runtime-cache.js';
@@ -380,10 +381,27 @@ export function createBackupConfigHandlers(deps: BackupConfigDeps) {
     };
   }
 
-  /** PUT /api/backup/config — update the backup directory setting. */
+  /**
+   * PUT /api/backup/config — update the backup directory setting.
+   *
+   * `backup` lives at Grove tier (see `GroveConfigSchema`) — one backup
+   * policy per Grove. Project myco.yaml writes for `backup.*` are
+   * silently stripped by `PROJECT_TIER_LEGACY_FIELDS` on the next load,
+   * so the API must persist to `~/.myco/groves/<id>/grove.yaml` to
+   * survive a daemon restart.
+   */
   async function handlePutBackupConfig(req: RouteRequest): Promise<RouteResponse> {
+    const groveId = req.requestContext?.groveId ?? deps.bootGroveId;
+    if (!groveId) {
+      return { status: 404, body: { error: 'no_grove_in_context' } };
+    }
     const { dir } = req.body as { dir?: string | null };
-    updateBackupConfig(vaultDirForRequest(req), { dir: dir || undefined });
+    const current = loadGroveConfig(groveId);
+    const next = GroveConfigSchema.parse({
+      ...current,
+      backup: { ...current.backup, dir: dir || undefined },
+    });
+    saveGroveConfig(groveId, next);
     return { body: { dir: dir || null } };
   }
 

--- a/packages/myco/src/daemon/api/register-config-routes.ts
+++ b/packages/myco/src/daemon/api/register-config-routes.ts
@@ -1,0 +1,85 @@
+/**
+ * Route registration for the four `/api/config*` endpoints.
+ *
+ * Extracted from `main.ts` so route-wiring is independently testable:
+ * tests can register these against any object that implements
+ * `registerRoute(method, path, handler)` and assert that the per-request
+ * `requestContext.projectVaultDir` is threaded through. Previously the
+ * routes were inlined in `main.ts` and the only assertion available was
+ * at the handler level — which couldn't catch a wiring regression that
+ * fed `bootstrapVaultDir` into a Grove-aware handler.
+ */
+
+import {
+  handleGetConfig,
+  handleGetMergedConfig,
+  handleGetLocalConfig,
+  handlePutScopedConfig,
+} from './config.js';
+import type { RouteRequest } from '../router.js';
+
+export interface ConfigRouteServer {
+  registerRoute(
+    method: string,
+    routePath: string,
+    handler: (req: RouteRequest) => Promise<unknown>,
+  ): void;
+}
+
+export interface ConfigRouteDeps {
+  /** Fallback vault dir when a request arrives without a `requestContext`. */
+  bootstrapVaultDir: string;
+  /** Fallback Grove id when a request arrives without one. */
+  bootGroveId: string | null;
+  /**
+   * Optional side-effect hook fired after a successful PUT /api/config/scoped.
+   * Receives the resolved per-request scope (vaultDir + groveId) so reactions,
+   * notifications, and cache invalidations can target the project that was
+   * actually written.
+   */
+  onScopedWrite?: (params: {
+    request: RouteRequest;
+    body: { scope: 'project' | 'local'; patch?: unknown; clear?: string[] };
+    vaultDir: string;
+    groveId: string | null;
+  }) => Promise<void> | void;
+}
+
+export function registerConfigRoutes(
+  server: ConfigRouteServer,
+  deps: ConfigRouteDeps,
+): void {
+  const vaultDirFor = (req: RouteRequest): string =>
+    req.requestContext?.projectVaultDir ?? deps.bootstrapVaultDir;
+  const groveIdFor = (req: RouteRequest): string | null =>
+    req.requestContext?.groveId ?? deps.bootGroveId;
+
+  server.registerRoute('GET', '/api/config', async (req) =>
+    handleGetConfig(vaultDirFor(req)));
+
+  server.registerRoute('GET', '/api/config/merged', async (req) =>
+    handleGetMergedConfig(vaultDirFor(req), { groveId: groveIdFor(req) }));
+
+  server.registerRoute('GET', '/api/config/local', async (req) =>
+    handleGetLocalConfig(vaultDirFor(req)));
+
+  server.registerRoute('PUT', '/api/config/scoped', async (req) => {
+    const vaultDir = vaultDirFor(req);
+    const result = await handlePutScopedConfig(vaultDir, req.body);
+    const status = (result as { status?: number }).status;
+    if ((!status || status < 400) && deps.onScopedWrite) {
+      const body = req.body as {
+        scope: 'project' | 'local';
+        patch?: unknown;
+        clear?: string[];
+      };
+      await deps.onScopedWrite({
+        request: req,
+        body,
+        vaultDir,
+        groveId: groveIdFor(req),
+      });
+    }
+    return result;
+  });
+}

--- a/packages/myco/src/daemon/api/team-connect.ts
+++ b/packages/myco/src/daemon/api/team-connect.ts
@@ -1084,10 +1084,13 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
       version: result.version,
     });
 
-    // Re-read myco.yaml (the subprocess updated team.worker_url) and
-    // reinitialize the client from the fresh merged config rather than
-    // the subprocess's result shape.
-    const freshConfig = loadMergedConfig(vaultDir);
+    // Re-read merged config (the subprocess updated team.worker_url in
+    // the Grove-tier config) and reinitialize the client from the fresh
+    // merged config rather than the subprocess's result shape. Passing
+    // `groveId` ensures the Grove-tier `team` block is included.
+    const freshConfig = loadMergedConfig(vaultDir, {
+      groveId: req.requestContext?.groveId ?? null,
+    });
     const workerUrl = result.worker_url ?? freshConfig.team.worker_url;
     if (workerUrl) {
       updateTeamConnectionConfig(vaultDir, req.requestContext, {

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -907,7 +907,8 @@ export async function main(): Promise<void> {
     registerInflightRun: (p) => inflightRuns.register(p),
   });
 
-  server.registerRoute('GET', '/api/config', async () => handleGetConfig(bootstrapVaultDir));
+  server.registerRoute('GET', '/api/config', async (req) =>
+    handleGetConfig(req.requestContext?.projectVaultDir ?? bootstrapVaultDir));
   server.registerRoute('GET', '/api/symbionts', async () => handleListSymbionts(bootstrapVaultDir));
   server.registerRoute('GET', '/api/cortex/instructions', cortexHandlers.handleGetInstructions);
   server.registerRoute('POST', '/api/cortex/instructions/refresh', cortexHandlers.handleRefreshInstructions);
@@ -915,8 +916,12 @@ export async function main(): Promise<void> {
   server.registerRoute('GET', '/api/cortex/prompt-builder/:runId', cortexHandlers.handleGetPromptResult);
 
   server.registerRoute('GET', '/api/config/merged', async (req) =>
-    handleGetMergedConfig(bootstrapVaultDir, { groveId: req.requestContext?.groveId ?? null }));
-  server.registerRoute('GET', '/api/config/local', async () => handleGetLocalConfig(bootstrapVaultDir));
+    handleGetMergedConfig(
+      req.requestContext?.projectVaultDir ?? bootstrapVaultDir,
+      { groveId: req.requestContext?.groveId ?? null },
+    ));
+  server.registerRoute('GET', '/api/config/local', async (req) =>
+    handleGetLocalConfig(req.requestContext?.projectVaultDir ?? bootstrapVaultDir));
 
   // Pre-compute symbiont plan dirs for the config endpoint (manifests don't change at runtime)
   const symbiontPlanDirsByAgent: Record<string, string[]> = {};
@@ -988,12 +993,15 @@ export async function main(): Promise<void> {
     await syncScheduledTasks();
   });
 
-  async function applyConfigWriteReactions(touchedPaths: string[]) {
-    const reactionContext = loadReactionContext(bootstrapVaultDir, logger, {
-      groveId: dataPaths.requestContext.groveId,
+  async function applyConfigWriteReactions(
+    touchedPaths: string[],
+    scope: { vaultDir: string; groveId: string | null },
+  ) {
+    const reactionContext = loadReactionContext(scope.vaultDir, logger, {
+      groveId: scope.groveId,
     });
     if (!reactionContext) {
-      configHash = computeConfigHash(bootstrapVaultDir);
+      configHash = computeConfigHash(scope.vaultDir);
       return null;
     }
     await reactions.fire(touchedPaths, reactionContext);
@@ -1001,14 +1009,19 @@ export async function main(): Promise<void> {
   }
 
   server.registerRoute('PUT', '/api/config/scoped', async (req) => {
-    const result = await handlePutScopedConfig(bootstrapVaultDir, req.body);
+    const requestVaultDir = req.requestContext?.projectVaultDir ?? bootstrapVaultDir;
+    const requestGroveId = req.requestContext?.groveId ?? dataPaths.requestContext.groveId;
+    const result = await handlePutScopedConfig(requestVaultDir, req.body);
     if (!result.status || result.status < 400) {
       const body = req.body as { scope: 'project' | 'local'; patch?: unknown; clear?: string[] };
       const touchedPaths = computeTouchedPaths(body.patch, body.clear);
-      const reactionContext = await applyConfigWriteReactions(touchedPaths);
+      const reactionContext = await applyConfigWriteReactions(
+        touchedPaths,
+        { vaultDir: requestVaultDir, groveId: requestGroveId },
+      );
       if (reactionContext) {
         const summary = buildScopedConfigSaveNotification(body.scope, touchedPaths);
-        notify(bootstrapVaultDir, {
+        notify(requestVaultDir, {
           domain: 'settings',
           type: 'settings.saved',
           title: summary.title,
@@ -1017,7 +1030,7 @@ export async function main(): Promise<void> {
           metadata: summary.metadata,
         }, reactionContext);
       } else {
-        configHash = computeConfigHash(bootstrapVaultDir);
+        configHash = computeConfigHash(requestVaultDir);
       }
     }
     return result;
@@ -1035,7 +1048,10 @@ export async function main(): Promise<void> {
       req.body,
     );
     if ((!response.status || response.status < 400) && touchedPaths.length > 0) {
-      await applyConfigWriteReactions(touchedPaths);
+      await applyConfigWriteReactions(touchedPaths, {
+        vaultDir: req.requestContext?.projectVaultDir ?? bootstrapVaultDir,
+        groveId: req.requestContext?.groveId ?? dataPaths.requestContext.groveId,
+      });
     }
     return response;
   });
@@ -1050,7 +1066,10 @@ export async function main(): Promise<void> {
   server.registerRoute('PUT', '/api/machine-config', async (req) => {
     const { response, touchedPaths } = await handlePutMachineConfig(req.body);
     if ((!response.status || response.status < 400) && touchedPaths.length > 0) {
-      await applyConfigWriteReactions(touchedPaths);
+      await applyConfigWriteReactions(touchedPaths, {
+        vaultDir: req.requestContext?.projectVaultDir ?? bootstrapVaultDir,
+        groveId: req.requestContext?.groveId ?? dataPaths.requestContext.groveId,
+      });
     }
     return response;
   });
@@ -1308,7 +1327,10 @@ export async function main(): Promise<void> {
   server.registerRoute('PUT', '/api/agent/tasks/:id/config', async (req) => {
     const result = await handleUpdateTaskConfig(req, bootstrapVaultDir);
     if (!result.status || result.status < 400) {
-      await applyConfigWriteReactions([`agent.tasks.${req.params.id}`]);
+      await applyConfigWriteReactions([`agent.tasks.${req.params.id}`], {
+        vaultDir: bootstrapVaultDir,
+        groveId: dataPaths.requestContext.groveId,
+      });
     }
     return result;
   });
@@ -1377,7 +1399,10 @@ export async function main(): Promise<void> {
   server.registerRoute('PUT', '/api/backup/config', async (req) => {
     const result = await backupConfigHandlers.handlePutBackupConfig(req);
     if (!result.status || result.status < 400) {
-      await applyConfigWriteReactions(['backup.dir']);
+      await applyConfigWriteReactions(['backup.dir'], {
+        vaultDir: bootstrapVaultDir,
+        groveId: dataPaths.requestContext.groveId,
+      });
     }
     return result;
   });
@@ -1411,7 +1436,10 @@ export async function main(): Promise<void> {
   server.registerRoute('POST', '/api/team/connect', async (req) => {
     const result = await teamHandlers.handleConnect(req);
     if (!result.status || result.status < 400) {
-      await applyConfigWriteReactions(['team.enabled', 'team.worker_url']);
+      await applyConfigWriteReactions(['team.enabled', 'team.worker_url'], {
+        vaultDir: bootstrapVaultDir,
+        groveId: req.requestContext?.groveId ?? dataPaths.requestContext.groveId,
+      });
       await teamSync.reconcileClient(req.requestContext);
     }
     return result;
@@ -1419,7 +1447,10 @@ export async function main(): Promise<void> {
   server.registerRoute('POST', '/api/team/disconnect', async (req) => {
     const result = await teamHandlers.handleDisconnect(req);
     if (!result.status || result.status < 400) {
-      await applyConfigWriteReactions(['team.enabled', 'team.worker_url']);
+      await applyConfigWriteReactions(['team.enabled', 'team.worker_url'], {
+        vaultDir: bootstrapVaultDir,
+        groveId: req.requestContext?.groveId ?? dataPaths.requestContext.groveId,
+      });
       await teamSync.reconcileClient(req.requestContext);
     }
     return result;

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -21,16 +21,13 @@ import { EventBuffer } from '../capture/buffer.js';
 import { loadManifests } from '../symbionts/detect.js';
 import type { PlanWatchConfig } from './plan-capture.js';
 import {
-  handleGetConfig,
-  handleGetMergedConfig,
-  handleGetLocalConfig,
-  handlePutScopedConfig,
   handleGetGroveConfig,
   handlePutGroveConfig,
   handleGetMachineConfig,
   handlePutMachineConfig,
   createPlanDirHandlers,
 } from './api/config.js';
+import { registerConfigRoutes } from './api/register-config-routes.js';
 import { handleLogSearch, handleLogStream, handleLogDetail, createLogIngestionHandler } from './api/log-explorer.js';
 import { handleRestart } from './api/restart.js';
 import { createUpdateHandlers } from './api/update.js';
@@ -907,21 +904,11 @@ export async function main(): Promise<void> {
     registerInflightRun: (p) => inflightRuns.register(p),
   });
 
-  server.registerRoute('GET', '/api/config', async (req) =>
-    handleGetConfig(req.requestContext?.projectVaultDir ?? bootstrapVaultDir));
   server.registerRoute('GET', '/api/symbionts', async () => handleListSymbionts(bootstrapVaultDir));
   server.registerRoute('GET', '/api/cortex/instructions', cortexHandlers.handleGetInstructions);
   server.registerRoute('POST', '/api/cortex/instructions/refresh', cortexHandlers.handleRefreshInstructions);
   server.registerRoute('POST', '/api/cortex/prompt-builder', cortexHandlers.handleBuildPrompt);
   server.registerRoute('GET', '/api/cortex/prompt-builder/:runId', cortexHandlers.handleGetPromptResult);
-
-  server.registerRoute('GET', '/api/config/merged', async (req) =>
-    handleGetMergedConfig(
-      req.requestContext?.projectVaultDir ?? bootstrapVaultDir,
-      { groveId: req.requestContext?.groveId ?? null },
-    ));
-  server.registerRoute('GET', '/api/config/local', async (req) =>
-    handleGetLocalConfig(req.requestContext?.projectVaultDir ?? bootstrapVaultDir));
 
   // Pre-compute symbiont plan dirs for the config endpoint (manifests don't change at runtime)
   const symbiontPlanDirsByAgent: Record<string, string[]> = {};
@@ -1008,20 +995,18 @@ export async function main(): Promise<void> {
     return reactionContext;
   }
 
-  server.registerRoute('PUT', '/api/config/scoped', async (req) => {
-    const requestVaultDir = req.requestContext?.projectVaultDir ?? bootstrapVaultDir;
-    const requestGroveId = req.requestContext?.groveId ?? dataPaths.requestContext.groveId;
-    const result = await handlePutScopedConfig(requestVaultDir, req.body);
-    if (!result.status || result.status < 400) {
-      const body = req.body as { scope: 'project' | 'local'; patch?: unknown; clear?: string[] };
+  registerConfigRoutes(server, {
+    bootstrapVaultDir,
+    bootGroveId: dataPaths.requestContext.groveId ?? null,
+    onScopedWrite: async ({ body, vaultDir, groveId }) => {
       const touchedPaths = computeTouchedPaths(body.patch, body.clear);
-      const reactionContext = await applyConfigWriteReactions(
-        touchedPaths,
-        { vaultDir: requestVaultDir, groveId: requestGroveId },
-      );
+      const reactionContext = await applyConfigWriteReactions(touchedPaths, {
+        vaultDir,
+        groveId,
+      });
       if (reactionContext) {
         const summary = buildScopedConfigSaveNotification(body.scope, touchedPaths);
-        notify(requestVaultDir, {
+        notify(vaultDir, {
           domain: 'settings',
           type: 'settings.saved',
           title: summary.title,
@@ -1030,10 +1015,9 @@ export async function main(): Promise<void> {
           metadata: summary.metadata,
         }, reactionContext);
       } else {
-        configHash = computeConfigHash(requestVaultDir);
+        configHash = computeConfigHash(vaultDir);
       }
-    }
-    return result;
+    },
   });
 
   // Grove-tier config (~/.myco/groves/<id>/grove.yaml) — separate tier
@@ -1292,44 +1276,46 @@ export async function main(): Promise<void> {
   server.registerRoute('GET', '/api/digest/revisions', digestRevisionHandlers.handleList);
   server.registerRoute('POST', '/api/digest/revisions/:id/restore', digestRevisionHandlers.handleRestore);
 
-  server.registerRoute('GET', '/api/agent/tasks', async (req) => handleListTasks(req, bootstrapVaultDir));
-  server.registerRoute('GET', '/api/agent/tasks/:id', async (req) => handleGetTask(req, bootstrapVaultDir));
-  server.registerRoute('GET', '/api/agent/tasks/:id/yaml', async (req) => handleGetTaskYaml(req, bootstrapVaultDir));
+  const taskVaultDir = (req: RouteRequest) => req.requestContext?.projectVaultDir ?? bootstrapVaultDir;
+  server.registerRoute('GET', '/api/agent/tasks', async (req) => handleListTasks(req, taskVaultDir(req)));
+  server.registerRoute('GET', '/api/agent/tasks/:id', async (req) => handleGetTask(req, taskVaultDir(req)));
+  server.registerRoute('GET', '/api/agent/tasks/:id/yaml', async (req) => handleGetTaskYaml(req, taskVaultDir(req)));
   server.registerRoute('PUT', '/api/agent/tasks/:id', async (req) => {
-    const result = await handleUpdateTask(req, bootstrapVaultDir);
+    const result = await handleUpdateTask(req, taskVaultDir(req));
     if (!result.status || result.status < 400) {
       await syncScheduledTasks();
     }
     return result;
   });
   server.registerRoute('POST', '/api/agent/tasks', async (req) => {
-    const result = await handleCreateTask(req, bootstrapVaultDir);
+    const result = await handleCreateTask(req, taskVaultDir(req));
     if (!result.status || result.status < 400) {
       await syncScheduledTasks();
     }
     return result;
   });
   server.registerRoute('POST', '/api/agent/tasks/:id/copy', async (req) => {
-    const result = await handleCopyTask(req, bootstrapVaultDir);
+    const result = await handleCopyTask(req, taskVaultDir(req));
     if (!result.status || result.status < 400) {
       await syncScheduledTasks();
     }
     return result;
   });
   server.registerRoute('DELETE', '/api/agent/tasks/:id', async (req) => {
-    const result = await handleDeleteTask(req, bootstrapVaultDir);
+    const result = await handleDeleteTask(req, taskVaultDir(req));
     if (!result.status || result.status < 400) {
       await syncScheduledTasks();
     }
     return result;
   });
-  server.registerRoute('GET', '/api/agent/tasks/:id/config', async (req) => handleGetTaskConfig(req, bootstrapVaultDir));
+  server.registerRoute('GET', '/api/agent/tasks/:id/config', async (req) => handleGetTaskConfig(req, taskVaultDir(req)));
   server.registerRoute('PUT', '/api/agent/tasks/:id/config', async (req) => {
-    const result = await handleUpdateTaskConfig(req, bootstrapVaultDir);
+    const requestVaultDir = taskVaultDir(req);
+    const result = await handleUpdateTaskConfig(req, requestVaultDir);
     if (!result.status || result.status < 400) {
       await applyConfigWriteReactions([`agent.tasks.${req.params.id}`], {
-        vaultDir: bootstrapVaultDir,
-        groveId: dataPaths.requestContext.groveId,
+        vaultDir: requestVaultDir,
+        groveId: req.requestContext?.groveId ?? dataPaths.requestContext.groveId,
       });
     }
     return result;
@@ -1392,7 +1378,7 @@ export async function main(): Promise<void> {
   server.registerRoute('POST', '/api/restore', backupHandlers.handleRestore);
 
   const backupConfigHandlers = createBackupConfigHandlers({
-    vaultDir: bootstrapVaultDir,
+    bootstrapVaultDir,
     bootGroveId: dataPaths.requestContext.groveId ?? null,
   });
   server.registerRoute('GET', '/api/backup/config', backupConfigHandlers.handleGetBackupConfig);
@@ -1400,8 +1386,8 @@ export async function main(): Promise<void> {
     const result = await backupConfigHandlers.handlePutBackupConfig(req);
     if (!result.status || result.status < 400) {
       await applyConfigWriteReactions(['backup.dir'], {
-        vaultDir: bootstrapVaultDir,
-        groveId: dataPaths.requestContext.groveId,
+        vaultDir: req.requestContext?.projectVaultDir ?? bootstrapVaultDir,
+        groveId: req.requestContext?.groveId ?? dataPaths.requestContext.groveId,
       });
     }
     return result;

--- a/tests/daemon/api/backup-config-grove-tier.test.ts
+++ b/tests/daemon/api/backup-config-grove-tier.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Regression: `PUT /api/backup/config` must persist `backup.dir` at Grove
+ * tier (`~/.myco/groves/<id>/grove.yaml`), not at project tier
+ * (`<project>/.myco/myco.yaml`).
+ *
+ * `backup` lives in `GroveConfigSchema` and is listed in
+ * `PROJECT_TIER_LEGACY_FIELDS`, which means any project-tier write is
+ * silently stripped on the next load. The previous implementation routed
+ * writes through `updateBackupConfig(vaultDir, ...)` and lost the value
+ * after a restart. This test fixes the API path on disk: the write must
+ * land in grove.yaml and survive a fresh `loadGroveConfig`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import YAML from 'yaml';
+import { createBackupConfigHandlers } from '@myco/daemon/api/backup';
+import { loadGroveConfig } from '@myco/config/loader';
+import { resolveGroveConfigPath, resolveGroveDir } from '@myco/grove/paths';
+import {
+  ensureGroveExistsLocally,
+  registerProjectInGrove,
+} from '@myco/grove/registry';
+import { ensureProjectManifest } from '@myco/config/project-manifest';
+import { resolveLegacyRequestContext } from '@myco/tools/request-context';
+import type { RouteRequest } from '@myco/daemon/router';
+
+describe('PUT /api/backup/config — persists at Grove tier', () => {
+  let mycoHome: string;
+  let groveId: string;
+  let vaultDir: string;
+  let projectId: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    originalHome = process.env.MYCO_HOME;
+    mycoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-bk-home-'));
+    process.env.MYCO_HOME = mycoHome;
+
+    groveId = 'grove_aaaa1111bbbb2222cccc3333dddd4444';
+    ensureGroveExistsLocally(groveId, { name: 'Test', slug: 'test' }, mycoHome);
+
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-bk-proj-'));
+    vaultDir = path.join(projectRoot, '.myco');
+    fs.mkdirSync(vaultDir, { recursive: true });
+    // Seed a minimal myco.yaml so loadMergedConfig (used by GET) finds a project tier.
+    fs.writeFileSync(
+      path.join(vaultDir, 'myco.yaml'),
+      'version: 3\nembedding:\n  provider: ollama\n  model: bge-m3\n',
+    );
+    const manifest = ensureProjectManifest(vaultDir, { projectName: 'bk-test' });
+    projectId = manifest.project.id;
+    registerProjectInGrove(groveId, {
+      projectId,
+      projectName: 'bk-test',
+      projectRoot,
+      bindingId: 'gbind_aaaa1111bbbb2222cccc3333dddd4444',
+    }, mycoHome);
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.MYCO_HOME;
+    else process.env.MYCO_HOME = originalHome;
+    fs.rmSync(mycoHome, { recursive: true, force: true });
+    fs.rmSync(path.dirname(vaultDir), { recursive: true, force: true });
+  });
+
+  function makeRequest(body: unknown): RouteRequest {
+    return {
+      params: {},
+      query: {},
+      body,
+      requestContext: resolveLegacyRequestContext(vaultDir, {
+        projectId: projectId as `proj_${string}`,
+        groveId,
+        machineId: 'test-machine',
+      }),
+    } as RouteRequest;
+  }
+
+  it('writes backup.dir to grove.yaml, not project myco.yaml', async () => {
+    const handlers = createBackupConfigHandlers({
+      bootstrapVaultDir: vaultDir,
+      bootGroveId: null,
+      mycoHome,
+    });
+    const res = await handlers.handlePutBackupConfig(makeRequest({ dir: '/var/test-backups' }));
+    expect(res.status).toBeUndefined();
+    expect((res.body as { dir: string }).dir).toBe('/var/test-backups');
+
+    const groveYaml = resolveGroveConfigPath(groveId, mycoHome);
+    expect(fs.existsSync(groveYaml)).toBe(true);
+    const written = YAML.parse(fs.readFileSync(groveYaml, 'utf-8')) as Record<string, unknown>;
+    expect((written.backup as { dir?: string })?.dir).toBe('/var/test-backups');
+
+    // Critically: project myco.yaml has not gained a backup block (it
+    // would be stripped on load anyway, but the write must not touch it).
+    const projectYaml = path.join(vaultDir, 'myco.yaml');
+    if (fs.existsSync(projectYaml)) {
+      const projectDoc = YAML.parse(fs.readFileSync(projectYaml, 'utf-8'));
+      expect(projectDoc?.backup).toBeUndefined();
+    }
+  });
+
+  it('survives a fresh loadGroveConfig after restart simulation', async () => {
+    const handlers = createBackupConfigHandlers({
+      bootstrapVaultDir: vaultDir,
+      bootGroveId: null,
+      mycoHome,
+    });
+    await handlers.handlePutBackupConfig(makeRequest({ dir: '~/persistent-backups' }));
+
+    // Simulate a daemon restart by reading Grove config fresh from disk.
+    const groveConfig = loadGroveConfig(groveId, mycoHome);
+    expect(groveConfig.backup.dir).toBe('~/persistent-backups');
+  });
+
+  it('GET reflects the Grove-tier value after a write', async () => {
+    const handlers = createBackupConfigHandlers({
+      bootstrapVaultDir: vaultDir,
+      bootGroveId: null,
+      mycoHome,
+    });
+    await handlers.handlePutBackupConfig(makeRequest({ dir: '/var/grove-backups' }));
+
+    const res = await handlers.handleGetBackupConfig(makeRequest({}));
+    expect((res.body as { dir: string | null }).dir).toBe('/var/grove-backups');
+    expect((res.body as { default_dir: string }).default_dir)
+      .toBe(path.resolve(resolveGroveDir(groveId, mycoHome), 'backups'));
+  });
+
+  it('returns 404 when no Grove is bound to the request', async () => {
+    const handlers = createBackupConfigHandlers({
+      bootstrapVaultDir: vaultDir,
+      bootGroveId: null,
+      mycoHome,
+    });
+    const legacyReq = {
+      params: {},
+      query: {},
+      body: { dir: '/x' },
+      requestContext: resolveLegacyRequestContext(vaultDir, {
+        projectId: projectId as `proj_${string}`,
+        groveId: null,
+        machineId: 'test-machine',
+      }),
+    } as RouteRequest;
+    const res = await handlers.handlePutBackupConfig(legacyReq);
+    expect(res.status).toBe(404);
+    expect((res.body as { error: string }).error).toBe('no_grove_in_context');
+  });
+});

--- a/tests/daemon/api/config-routes-per-request-vault.test.ts
+++ b/tests/daemon/api/config-routes-per-request-vault.test.ts
@@ -9,14 +9,9 @@
  * release_provenance and every other project-tier field bled across
  * projects, and saves silently overwrote the bootstrap project's file.
  *
- * This test mirrors the route closure shape used in main.ts and asserts:
- *   - GET /api/config/merged returns the requested project's values, not
- *     bootstrap's.
- *   - GET /api/config/local returns the requested project's overlay.
- *   - PUT /api/config/scoped writes into the requested project's vault
- *     and leaves the other project's `myco.yaml` untouched.
- *
- * If anyone reverts the routing to `bootstrapVaultDir`, these tests fail.
+ * This test exercises `registerConfigRoutes` — the helper the daemon
+ * uses to register the four routes — through a fake server, so a future
+ * regression that re-hard-wires `bootstrapVaultDir` fails here.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
@@ -24,30 +19,53 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import {
-  handleGetMergedConfig,
-  handleGetLocalConfig,
-  handlePutScopedConfig,
-} from '@myco/daemon/api/config';
+  registerConfigRoutes,
+  type ConfigRouteServer,
+} from '@myco/daemon/api/register-config-routes';
+import type { RouteRequest } from '@myco/daemon/router';
 
 interface FakeReq {
   requestContext?: { projectVaultDir?: string; groveId?: string | null };
   body?: unknown;
 }
 
-// Mirrors the route closures in packages/myco/src/daemon/main.ts.
-// Keeping them inline (rather than importing from main.ts) avoids
-// pulling in the daemon's bootstrap singletons. If main.ts route
-// wiring changes shape, update these mirrors too.
-function makeRoutes(bootstrapVaultDir: string) {
+interface RegisteredRoute {
+  method: string;
+  path: string;
+  handler: (req: RouteRequest) => Promise<unknown>;
+}
+
+function makeFakeServer() {
+  const routes: RegisteredRoute[] = [];
+  const server: ConfigRouteServer = {
+    registerRoute(method, routePath, handler) {
+      routes.push({ method, path: routePath, handler });
+    },
+  };
+  function call(method: string, routePath: string, req: FakeReq) {
+    const route = routes.find((r) => r.method === method && r.path === routePath);
+    if (!route) throw new Error(`No route registered for ${method} ${routePath}`);
+    return route.handler(req as unknown as RouteRequest);
+  }
+  return { server, call };
+}
+
+function makeRoutes(bootstrapVaultDir: string, onScopedWrite?: (params: {
+  request: RouteRequest;
+  body: { scope: 'project' | 'local'; patch?: unknown; clear?: string[] };
+  vaultDir: string;
+  groveId: string | null;
+}) => void | Promise<void>) {
+  const fake = makeFakeServer();
+  registerConfigRoutes(fake.server, {
+    bootstrapVaultDir,
+    bootGroveId: null,
+    onScopedWrite,
+  });
   return {
-    mergedGet: (req: FakeReq) =>
-      handleGetMergedConfig(req.requestContext?.projectVaultDir ?? bootstrapVaultDir, {
-        groveId: req.requestContext?.groveId ?? null,
-      }),
-    localGet: (req: FakeReq) =>
-      handleGetLocalConfig(req.requestContext?.projectVaultDir ?? bootstrapVaultDir),
-    scopedPut: (req: FakeReq) =>
-      handlePutScopedConfig(req.requestContext?.projectVaultDir ?? bootstrapVaultDir, req.body),
+    mergedGet: (req: FakeReq) => fake.call('GET', '/api/config/merged', req),
+    localGet: (req: FakeReq) => fake.call('GET', '/api/config/local', req),
+    scopedPut: (req: FakeReq) => fake.call('PUT', '/api/config/scoped', req),
   };
 }
 
@@ -68,7 +86,7 @@ release_provenance:
   );
 }
 
-describe('config HTTP routes — per-request projectVaultDir wiring', () => {
+describe('registerConfigRoutes — per-request projectVaultDir wiring', () => {
   let projectA: string;
   let projectB: string;
   let bootstrap: string;
@@ -130,6 +148,34 @@ describe('config HTTP routes — per-request projectVaultDir wiring', () => {
     expect(aAfter).toBe(aBefore);
     expect(bAfter).toContain('refs/tags/v99');
     expect(bAfter).not.toContain('refs/tags/network/v*');
+  });
+
+  it('PUT /api/config/scoped fires onScopedWrite with the request-scoped vault + grove', async () => {
+    const writes: Array<{ vaultDir: string; groveId: string | null }> = [];
+    const fake = makeFakeServer();
+    registerConfigRoutes(fake.server, {
+      bootstrapVaultDir: bootstrap,
+      bootGroveId: 'grove_boot',
+      onScopedWrite: ({ vaultDir, groveId }) => { writes.push({ vaultDir, groveId }); },
+    });
+    await fake.call('PUT', '/api/config/scoped', {
+      requestContext: { projectVaultDir: projectB, groveId: 'grove_b' },
+      body: {
+        scope: 'project',
+        patch: { release_provenance: { production_refs: ['refs/tags/v9'] } },
+      },
+    });
+    // Also confirm fallback to bootstrap+bootGrove when no request context.
+    await fake.call('PUT', '/api/config/scoped', {
+      body: {
+        scope: 'project',
+        patch: { release_provenance: { production_refs: ['refs/tags/v10'] } },
+      },
+    });
+    expect(writes).toEqual([
+      { vaultDir: projectB, groveId: 'grove_b' },
+      { vaultDir: bootstrap, groveId: 'grove_boot' },
+    ]);
   });
 
   it('PUT /api/config/scoped at scope=local writes the requested project local.yaml', async () => {

--- a/tests/daemon/api/config-routes-per-request-vault.test.ts
+++ b/tests/daemon/api/config-routes-per-request-vault.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Regression: config HTTP routes must respect the request's
+ * `requestContext.projectVaultDir`, not the daemon's bootstrap vault.
+ *
+ * Before the fix, `main.ts` registered the four `/api/config(...)*` routes
+ * with `bootstrapVaultDir` hard-wired. A Grove daemon serving multiple
+ * projects ended up reading and writing only the bootstrap project's
+ * `myco.yaml` regardless of which project the dashboard was viewing —
+ * release_provenance and every other project-tier field bled across
+ * projects, and saves silently overwrote the bootstrap project's file.
+ *
+ * This test mirrors the route closure shape used in main.ts and asserts:
+ *   - GET /api/config/merged returns the requested project's values, not
+ *     bootstrap's.
+ *   - GET /api/config/local returns the requested project's overlay.
+ *   - PUT /api/config/scoped writes into the requested project's vault
+ *     and leaves the other project's `myco.yaml` untouched.
+ *
+ * If anyone reverts the routing to `bootstrapVaultDir`, these tests fail.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  handleGetMergedConfig,
+  handleGetLocalConfig,
+  handlePutScopedConfig,
+} from '@myco/daemon/api/config';
+
+interface FakeReq {
+  requestContext?: { projectVaultDir?: string; groveId?: string | null };
+  body?: unknown;
+}
+
+// Mirrors the route closures in packages/myco/src/daemon/main.ts.
+// Keeping them inline (rather than importing from main.ts) avoids
+// pulling in the daemon's bootstrap singletons. If main.ts route
+// wiring changes shape, update these mirrors too.
+function makeRoutes(bootstrapVaultDir: string) {
+  return {
+    mergedGet: (req: FakeReq) =>
+      handleGetMergedConfig(req.requestContext?.projectVaultDir ?? bootstrapVaultDir, {
+        groveId: req.requestContext?.groveId ?? null,
+      }),
+    localGet: (req: FakeReq) =>
+      handleGetLocalConfig(req.requestContext?.projectVaultDir ?? bootstrapVaultDir),
+    scopedPut: (req: FakeReq) =>
+      handlePutScopedConfig(req.requestContext?.projectVaultDir ?? bootstrapVaultDir, req.body),
+  };
+}
+
+function seedProject(dir: string, productionRef: string, githubRepo: string) {
+  fs.writeFileSync(
+    path.join(dir, 'myco.yaml'),
+    `version: 3
+embedding:
+  provider: ollama
+  model: bge-m3
+release_provenance:
+  enabled: true
+  production_refs:
+    - ${productionRef}
+  github:
+    repo: ${githubRepo}
+`,
+  );
+}
+
+describe('config HTTP routes — per-request projectVaultDir wiring', () => {
+  let projectA: string;
+  let projectB: string;
+  let bootstrap: string;
+  let routes: ReturnType<typeof makeRoutes>;
+
+  beforeEach(() => {
+    projectA = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-route-A-'));
+    projectB = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-route-B-'));
+    bootstrap = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-route-boot-'));
+    seedProject(projectA, 'refs/tags/network/v*', 'sirkirby/unifi-mcp');
+    seedProject(projectB, 'refs/tags/v*', 'goondocks-co/collagen-advocacy');
+    seedProject(bootstrap, 'refs/tags/bootstrap/v*', 'org/bootstrap');
+    routes = makeRoutes(bootstrap);
+  });
+
+  afterEach(() => {
+    for (const dir of [projectA, projectB, bootstrap]) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('GET /api/config/merged returns the requested project, not bootstrap', async () => {
+    const a = await routes.mergedGet({ requestContext: { projectVaultDir: projectA } });
+    const b = await routes.mergedGet({ requestContext: { projectVaultDir: projectB } });
+    expect((a.body as any).release_provenance.production_refs).toEqual(['refs/tags/network/v*']);
+    expect((a.body as any).release_provenance.github.repo).toBe('sirkirby/unifi-mcp');
+    expect((b.body as any).release_provenance.production_refs).toEqual(['refs/tags/v*']);
+    expect((b.body as any).release_provenance.github.repo).toBe('goondocks-co/collagen-advocacy');
+  });
+
+  it('GET /api/config/merged falls back to bootstrap when no request context', async () => {
+    const res = await routes.mergedGet({});
+    expect((res.body as any).release_provenance.production_refs).toEqual(['refs/tags/bootstrap/v*']);
+  });
+
+  it('GET /api/config/local returns the requested project overlay', async () => {
+    // Seed a local overlay only in project B.
+    fs.writeFileSync(
+      path.join(projectB, 'local.yaml'),
+      'release_provenance:\n  enabled: false\n',
+    );
+    const a = await routes.localGet({ requestContext: { projectVaultDir: projectA } });
+    const b = await routes.localGet({ requestContext: { projectVaultDir: projectB } });
+    expect((a.body as any).release_provenance?.enabled).toBeUndefined();
+    expect((b.body as any).release_provenance.enabled).toBe(false);
+  });
+
+  it('PUT /api/config/scoped writes to the requested project and leaves the other untouched', async () => {
+    const aBefore = fs.readFileSync(path.join(projectA, 'myco.yaml'), 'utf-8');
+    await routes.scopedPut({
+      requestContext: { projectVaultDir: projectB },
+      body: {
+        scope: 'project',
+        patch: { release_provenance: { production_refs: ['refs/tags/v99'] } },
+      },
+    });
+    const aAfter = fs.readFileSync(path.join(projectA, 'myco.yaml'), 'utf-8');
+    const bAfter = fs.readFileSync(path.join(projectB, 'myco.yaml'), 'utf-8');
+    expect(aAfter).toBe(aBefore);
+    expect(bAfter).toContain('refs/tags/v99');
+    expect(bAfter).not.toContain('refs/tags/network/v*');
+  });
+
+  it('PUT /api/config/scoped at scope=local writes the requested project local.yaml', async () => {
+    await routes.scopedPut({
+      requestContext: { projectVaultDir: projectB },
+      body: {
+        scope: 'local',
+        patch: { release_provenance: { enabled: false } },
+      },
+    });
+    expect(fs.existsSync(path.join(projectA, 'local.yaml'))).toBe(false);
+    const bLocal = fs.readFileSync(path.join(projectB, 'local.yaml'), 'utf-8');
+    expect(bLocal).toContain('enabled: false');
+  });
+});


### PR DESCRIPTION
## Summary

The `/api/config*` HTTP routes were hard-wired to `bootstrapVaultDir` — the project the daemon first attached to at startup. On a Grove daemon serving multiple projects, every project's Settings page ended up reading and writing the **bootstrap project's** `myco.yaml`. User-visible symptom: release-provenance, agent toggles, and every other project-tier field appeared identical across projects, and any UI save silently overwrote the bootstrap project.

The comment at `main.ts:391-412` already warned: `bootstrapVaultDir` "is a *transitional* concept" and "do NOT use this value as a stand-in for the request-scoped vault." Multiple route handlers did exactly that.

### Code changes

**Primary fix — `/api/config*` routes** (commit 1)

- Extracted the four `/api/config*` route registrations into `packages/myco/src/daemon/api/register-config-routes.ts`, exporting `registerConfigRoutes(server, deps)`. `main.ts` calls it once with an `onScopedWrite` callback that runs reactions, notifications, and configHash refresh against the **request scope**.
- `applyConfigWriteReactions` now takes a `{vaultDir, groveId}` scope so it targets the project that was actually written.

**Other bootstrap-bound writers** (commit 2)

- `handle{List,Get,GetYaml,Update,Create,Copy,Delete}Task` and `:id/config` now bind to `req.requestContext.projectVaultDir`. Saving an agent task config from a non-bootstrap project no longer leaks into the bootstrap project's yaml.
- `createBackupConfigHandlers` resolves the vault per request.
- `team-connect.ts`: persistence already routed correctly via `resolveTeamConnectionStore(groveId)`. The one remaining smell — `loadMergedConfig(vaultDir)` re-read after a worker upgrade — now passes `groveId` from the request so the Grove-tier `team` block is included.

**Backup config persistence — surfaced during smoke test** (commit 3)

`backup` lives in `GroveConfigSchema` and is in `PROJECT_TIER_LEGACY_FIELDS`, so any project-tier write gets stripped on next load. `PUT /api/backup/config` previously wrote via `updateBackupConfig(vaultDir, …)` and silently lost the value on every daemon restart — broken before this PR, same broken under the fix. Persistence now goes through `loadGroveConfig` + `saveGroveConfig` so writes land in `~/.myco/groves/<id>/grove.yaml` and survive. Returns 404 when no Grove is bound. The unused `updateBackupConfig` helper is removed.

### Tests

`tests/daemon/api/config-routes-per-request-vault.test.ts` exercises `registerConfigRoutes` through a fake `ConfigRouteServer`:

- Two seeded project vaults with distinct `release_provenance` values; each GET returns its own.
- PUT against project B does not mutate project A's `myco.yaml`.
- `onScopedWrite` fires with the per-request `vaultDir` + `groveId`, falling back to bootstrap when no context is supplied.

`tests/daemon/api/backup-config-grove-tier.test.ts` exercises the backup write path:

- PUT lands in `~/.myco/groves/<id>/grove.yaml`, not in project myco.yaml.
- Value survives a fresh `loadGroveConfig` (restart simulation).
- GET reflects the post-write Grove state.
- Unbound-Grove request returns 404.

Full suite: 4731 node + 178 jsdom, 0 fail.

### Live smoke test

Built the dev binary, restarted the dogfood daemon (port 19344), seeded a second project in the dogfood Grove, and exercised real HTTP requests with project headers:

- `GET /api/config/merged` per project returned each project's own `production_refs` / `github.repo` / `theme` / `scheduled_tasks_enabled`. No bleed.
- `PUT /api/config/scoped` (scope=project) against the smoke project wrote `refs/tags/SMOKE-WROTE-THIS/v*` to the smoke yaml; myco.yaml hash unchanged.
- `PUT /api/config/scoped` (scope=local) against the myco project wrote a `theme=plum` local override; smoke yaml hash unchanged, smoke `local.yaml` never created.
- `PUT /api/agent/tasks/canopy-describe/config` (maxTurns=99) against the smoke project landed only in the smoke yaml.
- `PUT /api/backup/config` against the myco project updated `~/.myco/groves/<id>/grove.yaml`; project myco.yaml stayed clean; `GET /api/backup/config` echoed the new value; the original `~/myco_backups/myco` value was restored post-smoke.

### Data impact

Audited every project's `myco.yaml` and `local.yaml` against git: **no data damage.** Each project's yaml was seeded with project-correct defaults at init; non-bootstrap projects' files predate the bug or match HEAD; the bootstrap project's yaml is clean against HEAD. The bug was loud (wrong UI display) but quiet (no writes corrupted other projects, because users mostly looked rather than saved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)