### PR TITLE
daemon: enforce session-row exists before any in-memory registry update

### DIFF
--- a/packages/myco/src/daemon/api/session-lifecycle.ts
+++ b/packages/myco/src/daemon/api/session-lifecycle.ts
@@ -20,7 +20,8 @@ import type { EventBuffer } from '@myco/capture/buffer.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import { loadMergedConfig } from '@myco/config/loader.js';
 import { cleanStaleBuffers } from '@myco/capture/buffer.js';
-import { upsertSession, closeSession, updateSession } from '@myco/db/queries/sessions.js';
+import { closeSession, updateSession } from '@myco/db/queries/sessions.js';
+import { ensureSession } from '../session-lifecycle.js';
 import { notify } from '@myco/notifications/notify.js';
 import { epochSeconds, STALE_BUFFER_MAX_AGE_MS } from '@myco/constants.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
@@ -136,27 +137,30 @@ export function createSessionLifecycleHandlers(deps: SessionLifecycleDeps) {
     }
     const { session_id, agent, branch, started_at } = RegisterBody.parse(req.body);
     const resolvedStartedAt = started_at ?? new Date().toISOString();
-    registry.register(session_id, { started_at: resolvedStartedAt, branch });
-    server.updateDaemonJsonSessions(registry.sessions);
-
-    // Upsert session in SQLite — always reset to active on register
-    const now = epochSeconds();
-    const startedEpoch = Math.floor(new Date(resolvedStartedAt).getTime() / 1000);
     const projectId = rowProjectIdFromRequestContext(req.requestContext);
     const projectRoot = req.requestContext?.projectRoot ?? resolveProjectRoot(vaultDir);
     const requestMachineId = req.requestContext?.machineId ?? machineId;
-    upsertSession({
-      id: session_id,
-      project_id: projectId,
+    // Persist + register through the single lifecycle helper. Pre-fix this
+    // call site registered in memory FIRST and upserted second, which
+    // poisoned the registry whenever the DB persist later threw.
+    ensureSession({
+      sessionId: session_id,
       agent: agent ?? 'claude-code',
-      user: null,
-      project_root: projectRoot,
-      branch: branch ?? null,
-      started_at: startedEpoch,
-      created_at: now,
-      status: 'active',
-      machine_id: requestMachineId,
+      projectId,
+      projectRoot,
+      machineId: requestMachineId,
+      startedAt: resolvedStartedAt,
+      registry,
+      logger,
+      source: 'api',
     });
+    // `branch` is only carried on this API path (hooks discover it via
+    // git provenance separately). Apply it as a follow-up update so the
+    // ensureSession contract stays minimal.
+    if (branch) {
+      updateSession(session_id, { branch }, projectScopeFromRequestContext(req.requestContext));
+    }
+    server.updateDaemonJsonSessions(registry.sessions);
     // Clear ended_at if session was previously completed (reload scenario)
     updateSession(session_id, { ended_at: null, status: 'active' }, projectScopeFromRequestContext(req.requestContext));
 

--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -44,7 +44,8 @@ import {
 import { resolveProjectRoot } from '@myco/vault/resolve.js';
 import { getDatabase } from '@myco/db/client.js';
 import { getLatestBatch } from '@myco/db/queries/batches.js';
-import { getSession, upsertSession, updateSession, reactivateSessionIfCompleted } from '@myco/db/queries/sessions.js';
+import { getSession, updateSession, reactivateSessionIfCompleted } from '@myco/db/queries/sessions.js';
+import { ensureSession } from './session-lifecycle.js';
 import { captureBatchImages, type CapturedImage } from './capture-images.js';
 import { DEFAULT_SYMBIONT_NAME, epochSeconds, LOG_PROMPT_PREVIEW_CHARS } from '@myco/constants.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
@@ -294,23 +295,21 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
           return { body: { ok: true, ignored: decision.reason ?? 'rule' } };
         }
 
-        registry.register(event.session_id, { started_at: event.timestamp });
-        logger.debug(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Auto-registered session from event', { session_id: event.session_id });
-
-        // Ensure SQLite session exists — explicitly set status='active' so
-        // resumed sessions (previously 'completed') get reopened.
-        const now = epochSeconds();
-        const startedEpoch = Math.floor(new Date(event.timestamp).getTime() / 1000);
-        upsertSession({
-          id: event.session_id,
-          project_id: requestProjectId,
-          agent: (event as Record<string, unknown>).agent as string ?? DEFAULT_SYMBIONT_NAME,
-          project_root: requestProjectRoot,
-          status: 'active',
-          started_at: startedEpoch,
-          created_at: now,
-          machine_id: requestMachineId,
+        // Persist + register through the single lifecycle helper. ordering
+        // matters: DB row first, then in-memory registry. See
+        // `session-lifecycle.ts` for the invariant rationale.
+        ensureSession({
+          sessionId: event.session_id,
+          agent: ((event as Record<string, unknown>).agent as string) ?? DEFAULT_SYMBIONT_NAME,
+          projectId: requestProjectId,
+          projectRoot: requestProjectRoot,
+          machineId: requestMachineId,
+          startedAt: event.timestamp,
+          registry,
+          logger,
+          source: event.type === 'user_prompt' ? 'user_prompt' : 'tool_use',
         });
+        logger.debug(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Auto-registered session from event', { session_id: event.session_id });
         const autoRegisterScope = projectScopeFromRequestContext(req.requestContext);
         deferGitProvenance(
           {

--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -45,7 +45,7 @@ import { resolveProjectRoot } from '@myco/vault/resolve.js';
 import { getDatabase } from '@myco/db/client.js';
 import { getLatestBatch } from '@myco/db/queries/batches.js';
 import { getSession, updateSession, reactivateSessionIfCompleted } from '@myco/db/queries/sessions.js';
-import { ensureSession } from './session-lifecycle.js';
+import { ensureSession, ensureSessionRowExists } from './session-lifecycle.js';
 import { captureBatchImages, type CapturedImage } from './capture-images.js';
 import { DEFAULT_SYMBIONT_NAME, epochSeconds, LOG_PROMPT_PREVIEW_CHARS } from '@myco/constants.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
@@ -381,6 +381,22 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
           });
         }
         try {
+          // Defensive layer: the registry-gated auto-register above is an
+          // optimization, not the contract. The contract is that a
+          // sessions.id row must exist by the time we open a prompt_batch.
+          // If anything upstream missed (e.g. an event arrived before
+          // session-start, or a future refactor breaks the gate), this
+          // recovers via an INSERT-IF-MISSING + WARN log so the bug
+          // surfaces instead of cascading into FK violations downstream.
+          ensureSessionRowExists({
+            sessionId: event.session_id,
+            agent: ((event as Record<string, unknown>).agent as string) ?? undefined,
+            projectId: requestProjectId,
+            projectRoot: requestProjectRoot,
+            machineId: requestMachineId,
+            logger,
+            source: 'user_prompt',
+          });
           const kind = typeof event.kind === 'string' ? event.kind : 'initial';
           const { batchId, promptNumber } = handleUserPrompt(event.session_id, promptText || undefined, { kind });
           userPromptBatchId = batchId;
@@ -487,6 +503,18 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
         });
       }
       try {
+        // Defensive: same belt-and-suspenders pattern as the user_prompt
+        // branch above. activities.session_id is FK-constrained, so the
+        // sessions.id row must exist by here.
+        ensureSessionRowExists({
+          sessionId: event.session_id,
+          agent: typeof event.agent === 'string' ? event.agent : undefined,
+          projectId: requestProjectId,
+          projectRoot: requestProjectRoot,
+          machineId: requestMachineId,
+          logger,
+          source: 'tool_use',
+        });
         handleToolUse(
           event.session_id,
           typeof event.agent === 'string' ? event.agent : DEFAULT_SYMBIONT_NAME,

--- a/packages/myco/src/daemon/session-lifecycle.ts
+++ b/packages/myco/src/daemon/session-lifecycle.ts
@@ -67,7 +67,7 @@
  *     logged at ERROR level, and the throw propagates so the HTTP layer
  *     returns 500. We never fabricate success for a failed persist.
  */
-import type { Logger } from '@myco/log/logger.js';
+import type { Logger } from './logger.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { epochSeconds, DEFAULT_SYMBIONT_NAME } from '@myco/constants.js';
 import { upsertSession, getSession } from '@myco/db/queries/sessions.js';

--- a/packages/myco/src/daemon/session-lifecycle.ts
+++ b/packages/myco/src/daemon/session-lifecycle.ts
@@ -1,0 +1,99 @@
+/**
+ * Single source of truth for registering a session with the daemon.
+ *
+ * Background — the bug this exists to prevent:
+ * Before this helper, two separate paths could add a session to the
+ * in-memory `SessionRegistry`:
+ *   1. `event-dispatch.ts` on user_prompt — also called `upsertSession()`
+ *      so the DB row existed.
+ *   2. `stop-processing.ts` on stop — registered in memory but did NOT
+ *      call `upsertSession()`.
+ *
+ * When Codex's first event after a daemon restart was a Stop, path (2)
+ * left the registry holding a session_id with no matching `sessions` row.
+ * The very next prompt then took path (1)'s early-return branch (because
+ * the registry already had the session), skipped its upsert, and tried to
+ * insert a `prompt_batches` row whose FK referenced a session that didn't
+ * exist. Every downstream write failed with `FOREIGN KEY constraint
+ * failed` for the rest of the session's life.
+ *
+ * The invariant — "session in registry ⇒ session row exists in DB" — was
+ * implicit. It now has a name and one enforced entry point. Anything that
+ * mutates the registry must go through `ensureSession`. Tests assert
+ * direct `registry.register` calls don't appear outside this file.
+ *
+ * Failure semantics:
+ *   - DB persistence is attempted first; the registry is updated only on
+ *     success. If the DB upsert throws (cross-grove rejection, locked
+ *     database, schema constraint), the registry is NOT poisoned with a
+ *     ghost entry, and the error is logged at ERROR level so it surfaces
+ *     in `myco logs` immediately.
+ *   - The error is then re-thrown so the calling route returns 500 and
+ *     the hook caller can retry rather than silently dropping events.
+ */
+import type { Logger } from '@myco/log/logger.js';
+import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+import { epochSeconds } from '@myco/constants.js';
+import { upsertSession } from '@myco/db/queries/sessions.js';
+import type { SessionRegistry } from './lifecycle.js';
+
+export interface EnsureSessionParams {
+  sessionId: string;
+  agent: string;
+  projectId?: string | null;
+  projectRoot?: string | null;
+  machineId: string;
+  /** ISO 8601 timestamp from the inbound event; falls back to `now`. */
+  startedAt?: string;
+  registry: SessionRegistry;
+  logger: Logger;
+  /**
+   * Tag identifying which code path invoked this — included in logs so
+   * post-mortem analysis can tell whether the session was first seen via
+   * a Prompt, a Stop, a session-start hook, or a manual API call.
+   */
+  source: 'user_prompt' | 'stop' | 'session_start' | 'tool_use' | 'api' | 'backfill';
+}
+
+/**
+ * Persist the session row, then add it to the in-memory registry.
+ *
+ * Idempotent: subsequent calls for the same `sessionId` re-upsert (which
+ * is a no-op when the row already exists) and re-`register` (which is a
+ * no-op when the registry already has the id).
+ *
+ * Throws on DB failure after logging — callers should let the throw
+ * propagate so the HTTP layer returns 500 rather than fabricating success.
+ */
+export function ensureSession(params: EnsureSessionParams): void {
+  const startedEpoch = params.startedAt
+    ? Math.floor(new Date(params.startedAt).getTime() / 1000)
+    : epochSeconds();
+  const now = epochSeconds();
+
+  try {
+    upsertSession({
+      id: params.sessionId,
+      project_id: params.projectId ?? null,
+      agent: params.agent,
+      project_root: params.projectRoot ?? null,
+      status: 'active',
+      started_at: startedEpoch,
+      created_at: now,
+      machine_id: params.machineId,
+    });
+  } catch (err) {
+    params.logger.error(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'ensureSession: failed to persist session row', {
+      session_id: params.sessionId,
+      source: params.source,
+      project_id: params.projectId ?? null,
+      machine_id: params.machineId,
+      error: (err as Error).message,
+    });
+    throw err;
+  }
+
+  params.registry.register(params.sessionId, {
+    started_at: params.startedAt ?? new Date().toISOString(),
+  });
+}

--- a/packages/myco/src/daemon/session-lifecycle.ts
+++ b/packages/myco/src/daemon/session-lifecycle.ts
@@ -1,40 +1,77 @@
 /**
- * Single source of truth for registering a session with the daemon.
+ * Session-lifecycle invariants.
  *
- * Background — the bug this exists to prevent:
- * Before this helper, two separate paths could add a session to the
- * in-memory `SessionRegistry`:
- *   1. `event-dispatch.ts` on user_prompt — also called `upsertSession()`
- *      so the DB row existed.
- *   2. `stop-processing.ts` on stop — registered in memory but did NOT
- *      call `upsertSession()`.
+ * # Source-of-truth ordering (read this if you're tempted to gate writes on
+ * # `registry.getSession()`)
  *
- * When Codex's first event after a daemon restart was a Stop, path (2)
- * left the registry holding a session_id with no matching `sessions` row.
- * The very next prompt then took path (1)'s early-return branch (because
- * the registry already had the session), skipped its upsert, and tried to
- * insert a `prompt_batches` row whose FK referenced a session that didn't
- * exist. Every downstream write failed with `FOREIGN KEY constraint
- * failed` for the rest of the session's life.
+ * Inbound events + the SQLite DB are the **only** sources of truth for
+ * capture data. The on-disk event buffer is the durability fallback that
+ * survives daemon restarts. The in-memory `SessionRegistry` is a **cache**
+ * — useful for cheap "is this session active in this daemon's runtime"
+ * checks, but it must **never** gate a side effect that would otherwise
+ * persist data.
  *
- * The invariant — "session in registry ⇒ session row exists in DB" — was
- * implicit. It now has a name and one enforced entry point. Anything that
- * mutates the registry must go through `ensureSession`. Tests assert
- * direct `registry.register` calls don't appear outside this file.
+ * Concretely:
+ *
+ *   1. **DB is the source of truth.** Every FK-dependent write
+ *      (prompt_batches, activities, etc.) requires its `sessions.id`
+ *      parent to exist. That row must be persisted **before** the write
+ *      attempts the FK.
+ *   2. **Registry is an optimization.** It can be wrong (stale entries,
+ *      missing entries after restart, missing entries after a failed
+ *      upsert). A cache miss should never cause data loss; a cache hit
+ *      should never be the reason a persist step is skipped.
+ *   3. **Buffer is the durability fallback.** Events persist to disk
+ *      before any in-memory state changes, so a daemon crash mid-event
+ *      doesn't drop the inbound payload.
+ *
+ * # Why this file exists
+ *
+ * Pre-fix, two separate paths could add a session to the registry:
+ *
+ *   - `event-dispatch.ts` on user_prompt / tool_use — also called
+ *     `upsertSession()`, so the DB row existed.
+ *   - `stop-processing.ts` on Stop — registered in memory but did **not**
+ *     call `upsertSession()`.
+ *
+ * When Codex's first event after a daemon restart was a Stop (its normal
+ * pattern between sub-invocations), path 2 left the registry holding a
+ * `session_id` with no matching `sessions` row. The very next prompt took
+ * path 1's "skip-because-registry-has-it" early-return branch, skipped
+ * its upsert, and tried to insert a `prompt_batches` row whose FK
+ * referenced a session that didn't exist. Every downstream insert failed
+ * with `FOREIGN KEY constraint failed` for the rest of the session's
+ * life.
+ *
+ * That bug was the symptom. The real problem was the implicit invariant
+ * "session in registry ⇒ session row exists in DB" — load-bearing on
+ * developer memory across multiple files with no compiler check.
+ *
+ * # Contract
+ *
+ * - `ensureSession()` — explicit lifecycle event (start / Stop /
+ *   /sessions/register API call). Upserts the row with full metadata,
+ *   then caches in the registry. Errors loudly and re-throws.
+ * - `ensureSessionRowExists()` — defensive, idempotent INSERT-IF-MISSING
+ *   meant to be called at the top of every event handler **before** any
+ *   FK-dependent write. Cheap (PK lookup), safe (writes nothing when the
+ *   row exists), and does NOT trust the registry. The whole point of
+ *   this function is that "the cache says we know about this session" is
+ *   not allowed to skip the persist step.
  *
  * Failure semantics:
  *   - DB persistence is attempted first; the registry is updated only on
- *     success. If the DB upsert throws (cross-grove rejection, locked
- *     database, schema constraint), the registry is NOT poisoned with a
- *     ghost entry, and the error is logged at ERROR level so it surfaces
- *     in `myco logs` immediately.
- *   - The error is then re-thrown so the calling route returns 500 and
- *     the hook caller can retry rather than silently dropping events.
+ *     success.
+ *   - If the DB write throws (cross-grove rejection, locked database,
+ *     schema constraint), the registry is NOT poisoned, the error is
+ *     logged at ERROR level, and the throw propagates so the HTTP layer
+ *     returns 500. We never fabricate success for a failed persist.
  */
 import type { Logger } from '@myco/log/logger.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
-import { epochSeconds } from '@myco/constants.js';
-import { upsertSession } from '@myco/db/queries/sessions.js';
+import { epochSeconds, DEFAULT_SYMBIONT_NAME } from '@myco/constants.js';
+import { upsertSession, getSession } from '@myco/db/queries/sessions.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
 import type { SessionRegistry } from './lifecycle.js';
 
 export interface EnsureSessionParams {
@@ -96,4 +133,76 @@ export function ensureSession(params: EnsureSessionParams): void {
   params.registry.register(params.sessionId, {
     started_at: params.startedAt ?? new Date().toISOString(),
   });
+}
+
+export interface EnsureSessionRowExistsParams {
+  sessionId: string;
+  /** Best-effort agent label, used only when we have to create the row. */
+  agent?: string;
+  projectId?: string | null;
+  projectRoot?: string | null;
+  machineId: string;
+  logger: Logger;
+  /**
+   * Where in the pipeline this defensive ensure was called from — surfaces
+   * in the WARN log so post-mortems can tell which upstream handler missed
+   * its responsibility.
+   */
+  source: 'user_prompt' | 'tool_use' | 'activity' | 'batch';
+}
+
+/**
+ * Defensive idempotent "make sure the sessions.id row exists" check.
+ *
+ * Call this at the top of every event handler **before** any FK-dependent
+ * insert. It does not trust the in-memory registry: the whole point is
+ * that "cache says we know about this session" is not allowed to skip the
+ * persist step. A cheap PK lookup decides whether to no-op (row already
+ * persisted upstream — the happy path) or to create a minimal row (row
+ * was missing despite cache claim — log a WARN so the upstream gap
+ * surfaces, then keep the FK insert from failing).
+ *
+ * This pairs with `ensureSession()`: the explicit lifecycle path
+ * (session_start / Stop / API register) should run first and supply rich
+ * metadata. This function is the belt-and-suspenders layer in case any
+ * future code path forgets.
+ *
+ * Returns `true` if the row was just created (an upstream miss was just
+ * recovered), `false` if it already existed (the common case).
+ */
+export function ensureSessionRowExists(params: EnsureSessionRowExistsParams): boolean {
+  // PK lookup — cheap, returns null if the row is missing.
+  const existing = getSession(params.sessionId, ALL_PROJECTS_SCOPE);
+  if (existing) return false;
+
+  // The row is missing. Upstream auto-register didn't run (or threw). Log
+  // loudly so the gap doesn't repeat silently, then persist a minimal
+  // row so the immediately-following FK-dependent insert can proceed.
+  params.logger.warn(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'ensureSessionRowExists: row missing despite event arrival — defensive insert', {
+    session_id: params.sessionId,
+    source: params.source,
+    project_id: params.projectId ?? null,
+  });
+
+  const now = epochSeconds();
+  try {
+    upsertSession({
+      id: params.sessionId,
+      project_id: params.projectId ?? null,
+      agent: params.agent ?? DEFAULT_SYMBIONT_NAME,
+      project_root: params.projectRoot ?? null,
+      status: 'active',
+      started_at: now,
+      created_at: now,
+      machine_id: params.machineId,
+    });
+  } catch (err) {
+    params.logger.error(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'ensureSessionRowExists: defensive insert failed', {
+      session_id: params.sessionId,
+      source: params.source,
+      error: (err as Error).message,
+    });
+    throw err;
+  }
+  return true;
 }

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -36,6 +36,7 @@ import { detectSkillUsage, SKILL_USAGE_DETECTION_ENABLED } from './skill-usage.j
 import { epochSeconds, LOG_MESSAGE_PREVIEW_CHARS } from '@myco/constants.js';
 import { TITLE_PREVIEW_CHARS } from './event-handlers.js';
 import { SessionRegistry } from './lifecycle.js';
+import { ensureSession } from './session-lifecycle.js';
 import { EventBuffer } from '@myco/capture/buffer.js';
 import { DaemonLogger } from './logger.js';
 import type { MycoConfig } from '@myco/config/schema.js';
@@ -651,12 +652,40 @@ export function createStopProcessor(deps: StopProcessorDeps): {
       return { body: { ok: true, ignored: 'ephemeral-sub-invocation' } };
     }
 
-    // Ensure session is registered (handles daemon restarts mid-session)
+    // Ensure session is registered (handles daemon restarts mid-session
+    // AND the Codex-style case where the very first event we see for a
+    // session is a Stop, not a user_prompt). Pre-fix, this path only
+    // updated the in-memory registry — the missing DB row produced silent
+    // FK cascades in every subsequent prompt_batch/activity insert. Go
+    // through the lifecycle helper so the row exists by construction.
     if (!existingSessionMeta) {
-      registry.register(sessionId, { started_at: new Date().toISOString() });
-      logger.debug(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, dbSession
-        ? 'Rehydrated registry from DB on stop event'
-        : 'Auto-registered session from stop event', { session_id: sessionId });
+      if (dbSession) {
+        // Cheap rehydrate path: row already exists, just cache it.
+        registry.register(sessionId, { started_at: new Date().toISOString() });
+        logger.debug(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Rehydrated registry from DB on stop event', {
+          session_id: sessionId,
+        });
+      } else {
+        // First-sight session — Stop is its registration event. Persist
+        // the row before adding to the registry so future prompt/tool
+        // events find an existing sessions.id when they reference it via
+        // FK. `agent` is best-effort: hook events for Codex / Claude
+        // include it; older transcripts may not.
+        ensureSession({
+          sessionId,
+          agent: agent ?? 'claude-code',
+          projectId: requestRowProjectId ?? null,
+          projectRoot: requestProjectRoot,
+          machineId: requestMachineId,
+          startedAt: new Date().toISOString(),
+          registry,
+          logger,
+          source: 'stop',
+        });
+        logger.debug(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Auto-registered session from stop event', {
+          session_id: sessionId,
+        });
+      }
     }
     const sessionMeta = existingSessionMeta ?? registry.getSession(sessionId);
     logger.info(LOG_KINDS.HOOKS_STOP, 'Stop received', {

--- a/tests/daemon/event-dispatch.test.ts
+++ b/tests/daemon/event-dispatch.test.ts
@@ -262,6 +262,55 @@ describe('createEventDispatcher', () => {
     });
   });
 
+  describe('cache-vs-DB drift defence', () => {
+    // Pinned regression: the principle is that in-memory registry is a
+    // cache, not a source of truth. Even if the cache lies and claims we
+    // know about a session that has no DB row, the FK-dependent insert
+    // path (prompt_batches, activities) must self-heal rather than fail.
+    // This is what `ensureSessionRowExists()` enforces — the test makes
+    // sure no future refactor strips that defense.
+    it('inserts a sessions row when the registry claims a session that has no DB row (defence layer)', async () => {
+      const { handler, registry, logger, vaultDir } = makeHandler();
+      const sessionId = 'cache-lies-defense-001';
+
+      // Simulate the exact pre-fix bug scenario: registry has the session
+      // (e.g., a Stop handler upstream added it without persisting), but
+      // no row exists in the sessions table. Pre-defense, the very next
+      // user_prompt would skip auto-register (cache hit), call
+      // handleUserPrompt(), and crash with FOREIGN KEY constraint failed.
+      registry.register(sessionId, { started_at: new Date().toISOString() });
+      expect(getSession(sessionId, ALL_PROJECTS_SCOPE)).toBeNull();
+
+      const res = await handler({
+        requestContext: TEST_REQUEST_CONTEXT,
+        body: {
+          type: 'user_prompt',
+          session_id: sessionId,
+          agent: 'codex',
+          prompt: 'recovered prompt after cache-vs-DB drift',
+        },
+        query: {},
+        params: {},
+        pathname: '/events',
+      });
+
+      // The dispatcher must succeed end-to-end.
+      expect(res.body).toMatchObject({ ok: true });
+
+      // Defense in depth: sessions row now exists (created by
+      // ensureSessionRowExists during the FK-dependent path).
+      const row = getSession(sessionId, ALL_PROJECTS_SCOPE);
+      expect(row).toBeDefined();
+      expect(row).not.toBeNull();
+
+      // The prompt_batch landed (the original failure mode).
+      expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE }).length).toBeGreaterThan(0);
+
+      logger.close();
+      fs.rmSync(vaultDir, { recursive: true, force: true });
+    });
+  });
+
   describe('event-dedup window', () => {
     it('suppresses identical user_prompt POSTs that arrive within the dedup window', async () => {
       const { handler, logger, vaultDir } = makeHandler();

--- a/tests/daemon/stop-processing.test.ts
+++ b/tests/daemon/stop-processing.test.ts
@@ -157,6 +157,68 @@ describe('createStopProcessor session capture rules', () => {
     expect(childAfter.response_summary).toBeNull();
   });
 
+  // Regression: post-restart Codex pattern. The daemon's in-memory
+  // SessionRegistry is empty after a restart. The FIRST event for a
+  // live session is typically a Stop (Codex emits Stops between
+  // sub-invocations). Pre-fix, the Stop handler added the session to
+  // the registry without persisting a sessions.id row; the next
+  // user_prompt then bypassed its own DB-insert path (because the
+  // registry already had the session_id) and tried to insert a
+  // prompt_batches row whose FK referenced a session that didn't
+  // exist. Every subsequent capture failed with
+  // `FOREIGN KEY constraint failed` until the user noticed the gap.
+  //
+  // The session MUST exist in the sessions table after handleStopRoute
+  // returns — without it, all FK-dependent inserts (prompt_batches,
+  // activities) silently drop on the floor and data is lost.
+  it('persists a sessions.id row when Stop is the first-seen event after daemon restart', async () => {
+    const sessionId = 'codex-stop-first-after-restart-001';
+    // Provide a transcript so the ephemeral-sub-invocation guard
+    // doesn't drop the event. Empty turns are fine — this test
+    // verifies the registration path, not transcript mining.
+    const transcriptPath = (() => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-stop-first-'));
+      const file = path.join(dir, `rollout-${sessionId}.jsonl`);
+      fs.writeFileSync(
+        file,
+        `${JSON.stringify({ type: 'session_meta', payload: { id: sessionId } })}\n`,
+      );
+      return file;
+    })();
+
+    // Empty registry and empty DB — simulate the post-restart state.
+    expect(getSession(sessionId, ALL_PROJECTS_SCOPE)).toBeFalsy();
+
+    const stopProcessor = makeStopProcessor(vaultDir);
+    await stopProcessor.handleStopRoute({
+      body: {
+        session_id: sessionId,
+        agent: 'codex',
+        transcript_path: transcriptPath,
+        last_assistant_message: 'ok',
+      },
+    } as never);
+
+    // Invariant: registry-in-memory implies sessions-row-in-DB.
+    // Pre-fix this lookup returned undefined and the test would fail.
+    const row = getSession(sessionId, ALL_PROJECTS_SCOPE);
+    expect(row).toBeDefined();
+    expect(row?.agent).toBe('codex');
+    expect(row?.status).toBe('active');
+
+    // Sanity: a subsequent FK-dependent insert succeeds now that the
+    // sessions row exists. Pre-fix this threw FOREIGN KEY constraint failed.
+    expect(() => {
+      insertBatch({
+        session_id: sessionId,
+        prompt_number: 1,
+        user_prompt: 'follow-up prompt after the restart-Stop',
+        started_at: epochNow(),
+        created_at: epochNow(),
+      });
+    }).not.toThrow();
+  });
+
   // Regression: Cursor's stop payload doesn't carry `last_assistant_message`
   // and its transcript is rewritten per turn (always turn_count=1). The
   // primary capture path must fall back to the last parsed turn's aiResponse


### PR DESCRIPTION
## Why this matters

Data collection is Myco's core promise — every regression here erodes trust. Today every capture write on the prod daemon silently failed with `FOREIGN KEY constraint failed` for new sessions, losing every prompt batch and tool-use activity until a backfill.

## Root cause

The invariant **"session in in-memory `SessionRegistry` implies a row in the `sessions` table"** was implicit. Two paths could add a session to the registry:

1. [`event-dispatch.ts`](packages/myco/src/daemon/event-dispatch.ts) on `user_prompt` / `tool_use` — also called `upsertSession`, so the DB row existed.
2. [`stop-processing.ts`](packages/myco/src/daemon/stop-processing.ts) on `Stop` — registered in memory but did **NOT** call `upsertSession`.

When Codex's first event after a daemon restart was a Stop (its normal pattern between sub-invocations), path (2) left the registry holding a `session_id` with no matching `sessions` row. The next prompt then took path (1)'s early-return branch — because the registry already had the session — skipped its own upsert, and tried to insert a `prompt_batches` row whose FK referenced a session that didn't exist. **Every downstream insert failed for the rest of the session's life.**

A related but subtler problem in [`api/session-lifecycle.ts`](packages/myco/src/daemon/api/session-lifecycle.ts)'s `/sessions/register` handler: `registry.register` first, then `upsertSession`. A DB failure poisoned the registry with a ghost entry.

## Fix

New helper [`packages/myco/src/daemon/session-lifecycle.ts`](packages/myco/src/daemon/session-lifecycle.ts) owns the invariant by construction:

```ts
ensureSession(params) {
  upsertSession(...);                  // 1. persist first
  registry.register(params.sessionId)  // 2. cache second, only on success
}
```

- DB failure logs at **ERROR** (was silent) and re-throws so the HTTP layer returns 500 — never fabricating success.
- All three call sites now route through `ensureSession`. The rehydrate-from-DB branches keep direct `registry.register` calls because those paths already verified the DB row exists.

## Regression test

`tests/daemon/stop-processing.test.ts` adds the **Stop-first-after-restart** scenario. Verified it **fails** against the pre-fix `stop-processing.ts` (1 fail) and **passes** after the fix.

## Today's lost data

Recovered for the in-flight Codex session by:
1. Inserting the missing `sessions` row directly into the Default grove DB.
2. Firing a Stop replay with `transcript_path` to the prod daemon.

Result: **17 prompt_batches + 55 activities** populated for session `019e2bc0-…` from the on-disk transcript at `~/.codex/sessions/2026/05/15/…jsonl`. Other affected sessions follow the same recipe — Codex and Claude both keep authoritative transcripts on disk; nothing was truly lost.

## Test plan

- [x] `npm test`: 4729 + 209 pass, 0 fail.
- [x] New regression test fails against pre-fix code, passes after.
- [x] Dev daemon rebuilt + restarted; healthy.
- [x] Manual backfill replay confirmed prompt_batches/activities land.

## Outstanding

- **Homebrew install** is still at v0.27.8 with the bug. Hooks for projects whose `runtime.command` resolves to `/opt/homebrew/bin/myco` will still hit this on the next "first event after restart is a Stop" scenario, until v0.27.9 ships with this fix.
- **Broader integration coverage** of the full hook → daemon → DB pipeline is a follow-up; this PR's test covers the specific failure mode but doesn't yet guard the whole capture path against the next category of silent-data-loss bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)