### PR TITLE
capture: dedup buffer replays + stderr trace on every hook fallback

### DIFF
--- a/packages/myco/src/capture/dedup.ts
+++ b/packages/myco/src/capture/dedup.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared event-deduplication helper.
+ *
+ * Two distinct paths can deliver "the same physical hook event" more than
+ * once:
+ *
+ *   1. **Live dispatch path** (`event-dispatch.ts`) — hook fires multiple
+ *      times (Codex's user_prompt hook is observed firing twice within 30ms;
+ *      retry storms after a wedged-then-recovered daemon; two symbionts
+ *      watching the same project). The dispatcher's in-memory dedup cache
+ *      catches these and returns `ignored: 'duplicate'`.
+ *
+ *   2. **Buffer replay path** (`reconciliation.ts`) — the hook CLI writes
+ *      the event to the buffer file whenever the daemon returns
+ *      `ignored: 'duplicate'` (so reconcile can replay if the dedup was
+ *      wrong). Without this helper, the replay re-inserts the duplicate as
+ *      a fresh prompt_batch — the original dedup decision evaporates.
+ *
+ * Both paths must use the SAME fingerprint, or the buffer replay will
+ * resurrect events the live path correctly rejected. This module is the
+ * single source of truth for that fingerprint.
+ */
+
+/** How long after the first occurrence we still treat a repeat as a duplicate. */
+export const EVENT_DEDUP_WINDOW_MS = 10_000;
+
+const PROMPT_FINGERPRINT_CHARS = 256;
+const TOOL_INPUT_FINGERPRINT_CHARS = 256;
+
+/**
+ * Compute a content fingerprint key for an inbound capture event.
+ *
+ * The key combines `session_id` + `type` with payload fields that vary by
+ * event shape (prompt text, tool name, tool input, task / agent ids). For
+ * any given physical hook event, the key is stable across the live dispatch
+ * path and the buffer replay path — that's what lets reconcile suppress
+ * replays of events the live dispatcher already rejected.
+ *
+ * Slicing to 256 chars on free-text fields keeps the key bounded for long
+ * prompts and large tool inputs while still being collision-resistant in
+ * practice (two genuinely-different prompts that share their first 256 chars
+ * are extraordinarily rare in capture traffic).
+ */
+export function eventDedupKey(
+  event: { type: string; session_id: string } & Record<string, unknown>,
+): string {
+  const parts: string[] = [
+    event.type,
+    typeof event.prompt === 'string' ? event.prompt.slice(0, PROMPT_FINGERPRINT_CHARS) : '',
+    typeof event.tool_name === 'string' ? event.tool_name : '',
+    typeof event.tool_input === 'object'
+      ? JSON.stringify(event.tool_input).slice(0, TOOL_INPUT_FINGERPRINT_CHARS)
+      : String(event.tool_input ?? '').slice(0, TOOL_INPUT_FINGERPRINT_CHARS),
+    typeof event.task_id === 'string' ? event.task_id : '',
+    typeof event.agent_id === 'string' ? event.agent_id : '',
+  ];
+  return `${event.session_id}\0${parts.join('\0')}`;
+}
+
+/**
+ * Parse an event timestamp string to milliseconds. Returns `null` when the
+ * field is missing or unparseable, letting callers decide how to treat
+ * timestamp-less events (typically: skip dedup, treat as unique).
+ */
+export function eventTimestampMs(event: Record<string, unknown>): number | null {
+  const ts = event.timestamp;
+  if (typeof ts !== 'string') return null;
+  const ms = Date.parse(ts);
+  return Number.isFinite(ms) ? ms : null;
+}

--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -51,6 +51,7 @@ import { DEFAULT_SYMBIONT_NAME, epochSeconds, LOG_PROMPT_PREVIEW_CHARS } from '@
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { loadManifests } from '@myco/symbionts/detect.js';
 import { gateEventByCaptureRules } from './capture-gating.js';
+import { eventDedupKey, EVENT_DEDUP_WINDOW_MS } from '@myco/capture/dedup.js';
 import { assertGroveProjectId, isGroveEraId } from '@myco/grove/ids.js';
 import type { ProjectPowerStateTracker } from './project-power-state.js';
 import { deferGitProvenance } from '@myco/release-provenance/capture.js';
@@ -95,16 +96,15 @@ export interface EventDispatchDeps {
 // revisited; FIFO eviction via Map ordering is sufficient.
 const DROP_DECISION_CACHE_MAX = 1024;
 
-// Suppress identical /events POSTs that arrive within this window. Hook
-// scripts can re-fire the same event when the daemon was previously slow
-// or briefly unavailable (Claude Code retries, multi-symbiont overlap),
-// and the inserts at handleUserPrompt / insertActivityWithBatch have no
-// natural idempotency. A 10-second window catches retry storms without
-// suppressing legitimate same-text turns (a human typing "y" twice in a
-// row pauses far longer than 10s; auto-tooling that legitimately needs
-// to re-send identical events at sub-10s cadence should set a fresh
-// `timestamp` on each attempt, which makes the dedup key differ).
-const EVENT_DEDUP_WINDOW_MS = 10_000;
+// Suppress identical /events POSTs that arrive within `EVENT_DEDUP_WINDOW_MS`.
+// Hook scripts can re-fire the same event when the daemon was previously
+// slow or briefly unavailable (Claude Code retries, multi-symbiont overlap,
+// Codex's user_prompt-submit hook observed firing twice within ~30ms), and
+// the inserts at handleUserPrompt / insertActivityWithBatch have no natural
+// idempotency. A 10-second window catches retry storms without suppressing
+// legitimate same-text turns. The window value and fingerprint live in
+// `@myco/capture/dedup.js` so the buffer reconciler can apply the same key
+// when replaying events the live path already rejected.
 const EVENT_DEDUP_CACHE_MAX = 4096;
 
 export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
@@ -138,23 +138,11 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
   }
 
   // FIFO dedup cache for event idempotency. Key includes session_id, type,
-  // and a content fingerprint so the cache can distinguish "same prompt
-  // sent twice" from "same hook type for two different prompts."
+  // and a content fingerprint (see `@myco/capture/dedup.js`) so the cache
+  // can distinguish "same prompt sent twice" from "same hook type for two
+  // different prompts." Shared with the buffer reconciler so duplicates the
+  // live path correctly rejected don't resurrect on replay.
   const recentEvents = new Map<string, number>();
-  function eventDedupKey(event: { type: string; session_id: string } & Record<string, unknown>): string {
-    // Cheap content fingerprint: type + first 256 chars of any natural
-    // payload field. Different event shapes use different fields; combine
-    // them so the same physical hook event always hashes the same way.
-    const parts = [
-      event.type,
-      typeof event.prompt === 'string' ? event.prompt.slice(0, 256) : '',
-      typeof event.tool_name === 'string' ? event.tool_name : '',
-      typeof event.tool_input === 'object' ? JSON.stringify(event.tool_input).slice(0, 256) : String(event.tool_input ?? '').slice(0, 256),
-      typeof event.task_id === 'string' ? event.task_id : '',
-      typeof event.agent_id === 'string' ? event.agent_id : '',
-    ];
-    return `${event.session_id}\0${parts.join('\0')}`;
-  }
   function isDuplicateEvent(event: { type: string; session_id: string } & Record<string, unknown>, nowMs: number): boolean {
     const key = eventDedupKey(event);
     const lastSeenMs = recentEvents.get(key);
@@ -244,7 +232,11 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
     // the same project, can deliver the same physical event multiple times
     // within seconds; the downstream insert paths are not idempotent.
     if (isDuplicateEvent(event, Date.now())) {
-      logger.debug(LOG_KINDS.HOOKS_EVENT, 'Event suppressed as duplicate within dedup window', {
+      // Promoted from debug to info so `grep hooks.event` in the default
+      // daemon log surfaces the volume of in-flight duplicate-fire patterns
+      // (Codex's double-fire, Claude retries, multi-symbiont overlap) — a
+      // class of bug we keep re-discovering only by manual buffer inspection.
+      logger.info(LOG_KINDS.HOOKS_EVENT, 'Event suppressed as duplicate within dedup window', {
         type: event.type, session_id: event.session_id,
       });
       return { body: { ok: true, ignored: 'duplicate' } };

--- a/packages/myco/src/daemon/reconciliation.ts
+++ b/packages/myco/src/daemon/reconciliation.ts
@@ -20,6 +20,7 @@ import { STALE_BUFFER_MAX_AGE_MS, DEFAULT_SYMBIONT_NAME } from '@myco/constants.
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import type { DaemonLogger } from './logger.js';
 import { isSystemMessage, handleUserPrompt, handleToolUse, handleToolFailure } from './event-handlers.js';
+import { eventDedupKey, eventTimestampMs, EVENT_DEDUP_WINDOW_MS } from '@myco/capture/dedup.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -205,15 +206,40 @@ export function createReconciler({ bufferDir, logger, projectRoot }: ReconcilerD
       return;
     }
 
-    // Replay full event stream from the divergence point
+    // Replay full event stream from the divergence point. Two guards apply
+    // before each event hits replayEvent:
+    //
+    //   1. Type filter (REPLAYABLE_EVENT_TYPES).
+    //   2. Content+window dedup that mirrors the live dispatcher
+    //      (`event-dispatch.ts`). The hook CLI writes to the buffer file
+    //      whenever the daemon returns `ignored: 'duplicate'` (see
+    //      `hooks/send-event.ts`), so without this guard the replay path
+    //      re-inserts events the live path already rejected. Both paths
+    //      now use the same key from `@myco/capture/dedup.js`.
     const eventsToReplay = allEvents.slice(replayStartIndex).filter(
       (e) => REPLAYABLE_EVENT_TYPES.has(String(e.type)),
     );
 
     let promptsRecovered = 0;
     let activitiesRecovered = 0;
+    let duplicatesSuppressed = 0;
+    const seenKeys = new Map<string, number>();
 
     for (const event of eventsToReplay) {
+      const eventWithSession = {
+        ...event,
+        type: String(event.type),
+        session_id: sessionId,
+      } as Record<string, unknown> & { type: string; session_id: string };
+      const key = eventDedupKey(eventWithSession);
+      const ts = eventTimestampMs(event) ?? Date.now();
+      const lastSeen = seenKeys.get(key);
+      if (lastSeen !== undefined && ts - lastSeen < EVENT_DEDUP_WINDOW_MS) {
+        duplicatesSuppressed++;
+        continue;
+      }
+      seenKeys.set(key, ts);
+
       try {
         const result = replayEvent(sessionId, event);
         if (result === 'prompt') promptsRecovered++;
@@ -226,11 +252,12 @@ export function createReconciler({ bufferDir, logger, projectRoot }: ReconcilerD
       }
     }
 
-    if (promptsRecovered > 0 || activitiesRecovered > 0) {
+    if (promptsRecovered > 0 || activitiesRecovered > 0 || duplicatesSuppressed > 0) {
       logger.info(LOG_KINDS.LIFECYCLE_RECONCILE, 'Buffer reconciliation complete', {
         session_id: sessionId,
         prompts_recovered: promptsRecovered,
         activities_recovered: activitiesRecovered,
+        duplicates_suppressed: duplicatesSuppressed,
       });
     }
   }

--- a/packages/myco/src/hooks/post-tool-use.ts
+++ b/packages/myco/src/hooks/post-tool-use.ts
@@ -1,4 +1,5 @@
 import { createHookDaemonClient } from './client.js';
+import { classifyBufferFallback } from './send-event.js';
 import { readHookInput } from './input.js';
 import { EventBuffer } from '../capture/buffer.js';
 import { resolveVaultDir } from '../vault/resolve.js';
@@ -41,6 +42,12 @@ export async function main() {
         output_preview: typeof input.toolOutput === 'string' ? input.toolOutput.slice(0, TOOL_OUTPUT_PREVIEW_CHARS) : undefined,
         transcript_path: input.transcriptPath,
       });
+      // Mirror the observability contract from send-event.ts and
+      // user-prompt-submit.ts — every buffer-fallback path leaves a stderr
+      // trace classifying the reason.
+      process.stderr.write(
+        `[myco] post-tool-use buffered (${classifyBufferFallback(result)}) session=${sessionId}\n`,
+      );
     }
   } catch (error) {
     process.stderr.write(`[myco] post-tool-use error: ${(error as Error).message}\n`);

--- a/packages/myco/src/hooks/send-event.ts
+++ b/packages/myco/src/hooks/send-event.ts
@@ -9,6 +9,32 @@ import { writeHookResponse } from './response.js';
 import fs from 'node:fs';
 import path from 'node:path';
 
+/**
+ * Classify why a hook is falling back to a buffer write. Surfaces in stderr
+ * so a "session not captured" investigation can answer "did the hook reach
+ * the daemon at all?" without inspecting buffer-file byte counts. Matches
+ * the failure modes in `DaemonClient.capturePost`.
+ *
+ * Exported so the two hook handlers with their own buffer-write logic
+ * (`user-prompt-submit.ts`, `post-tool-use.ts`) classify the same way as
+ * sendEvent — one observability surface across every capture hook.
+ */
+export function classifyBufferFallback(result: { ok: boolean; data?: unknown }): string {
+  if (result.ok) {
+    if (isIgnoredEventResponse(result.data)) {
+      const ignored = (result.data as { ignored?: unknown } | undefined)?.ignored;
+      return `daemon-ignored:${typeof ignored === 'string' ? ignored : 'unknown'}`;
+    }
+    return 'unknown';
+  }
+  // transport failure (fetch threw, daemon.json missing, recovery path)
+  // OR non-2xx HTTP response (`result.data` may be the parsed error envelope)
+  if (result.data !== undefined) {
+    return 'http-error';
+  }
+  return 'transport-failure';
+}
+
 export async function sendEvent(
   hookName: string,
   buildEvent: (input: NormalizedHookInput) => Record<string, unknown>,
@@ -39,6 +65,15 @@ export async function sendEvent(
     if (!result.ok || isIgnoredEventResponse(result.data)) {
       const buffer = new EventBuffer(path.join(VAULT_DIR, 'buffer'), sessionId);
       buffer.append(eventWithContext);
+      // Stderr log so "session not captured" investigations can see the
+      // buffer-fallback path firing — previously this was completely silent,
+      // which is exactly how the prod-daemon stop-responding-after-restart
+      // class of bug went undiagnosed for hours at a time. The agent
+      // captures hook stderr (or surfaces it in its log), so this is the
+      // shortest path to observability without a daemon round-trip.
+      process.stderr.write(
+        `[myco] ${hookName} buffered (${classifyBufferFallback(result)}) session=${sessionId}\n`,
+      );
     }
   } catch (error) {
     process.stderr.write(`[myco] ${hookName} error: ${(error as Error).message}\n`);

--- a/packages/myco/src/hooks/user-prompt-submit.ts
+++ b/packages/myco/src/hooks/user-prompt-submit.ts
@@ -1,4 +1,5 @@
 import { createHookDaemonClient, isIgnoredEventResponse } from './client.js';
+import { classifyBufferFallback } from './send-event.js';
 import { readHookInput } from './input.js';
 import { evaluateUserPromptRules } from './capture-rules.js';
 import { readTranscriptMeta } from './transcript-meta.js';
@@ -56,10 +57,16 @@ export async function main() {
     });
 
     // Buffer on transport failure OR server-side `ignored` so the event is
-    // recoverable by reconcileBufferBatches on the next daemon start.
+    // recoverable by reconcileBufferBatches on the next daemon start. Log
+    // to stderr with the reason — every buffer-fallback path needs a trace
+    // so "session not captured" investigations can rule out the hook layer
+    // without comparing buffer-file mtimes against transcript mtimes.
     if (!eventResult.ok || isIgnoredEventResponse(eventResult.data)) {
       const buffer = new EventBuffer(path.join(VAULT_DIR, 'buffer'), sessionId);
       buffer.append({ type: 'user_prompt', prompt, transcript_path: input.transcriptPath });
+      process.stderr.write(
+        `[myco] user-prompt-submit buffered (${classifyBufferFallback(eventResult)}) session=${sessionId}\n`,
+      );
     }
 
     const contextResult = await client.post('/context/prompt', {

--- a/tests/capture/dedup.test.ts
+++ b/tests/capture/dedup.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  eventDedupKey,
+  eventTimestampMs,
+  EVENT_DEDUP_WINDOW_MS,
+} from '@myco/capture/dedup.js';
+
+describe('eventDedupKey', () => {
+  it('produces identical keys for two physically-identical events', () => {
+    const e1 = {
+      type: 'user_prompt',
+      session_id: 'sess-1',
+      prompt: 'Help me debug this',
+    };
+    const e2 = { ...e1 };
+    expect(eventDedupKey(e1)).toBe(eventDedupKey(e2));
+  });
+
+  it('distinguishes events of the same type with different content', () => {
+    const a = { type: 'user_prompt', session_id: 's', prompt: 'apple' };
+    const b = { type: 'user_prompt', session_id: 's', prompt: 'banana' };
+    expect(eventDedupKey(a)).not.toBe(eventDedupKey(b));
+  });
+
+  it('distinguishes the same prompt across different sessions', () => {
+    const a = { type: 'user_prompt', session_id: 's-a', prompt: 'p' };
+    const b = { type: 'user_prompt', session_id: 's-b', prompt: 'p' };
+    expect(eventDedupKey(a)).not.toBe(eventDedupKey(b));
+  });
+
+  it('treats tool_use events with identical tool_input as the same key', () => {
+    const a = {
+      type: 'tool_use',
+      session_id: 's',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls', description: 'list' },
+    };
+    const b = {
+      type: 'tool_use',
+      session_id: 's',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls', description: 'list' },
+    };
+    expect(eventDedupKey(a)).toBe(eventDedupKey(b));
+  });
+
+  it('truncates long prompts at 256 chars — guards against unbounded key growth', () => {
+    const a = { type: 'user_prompt', session_id: 's', prompt: 'x'.repeat(500) };
+    const b = { type: 'user_prompt', session_id: 's', prompt: 'x'.repeat(800) };
+    // Both truncated to 256 'x's → same fingerprint.
+    expect(eventDedupKey(a)).toBe(eventDedupKey(b));
+  });
+});
+
+describe('eventTimestampMs', () => {
+  it('parses ISO timestamps to milliseconds', () => {
+    expect(eventTimestampMs({ timestamp: '2026-05-15T15:55:07.594Z' })).toBe(
+      Date.parse('2026-05-15T15:55:07.594Z'),
+    );
+  });
+
+  it('returns null when the timestamp field is missing', () => {
+    expect(eventTimestampMs({})).toBeNull();
+  });
+
+  it('returns null for an unparseable timestamp', () => {
+    expect(eventTimestampMs({ timestamp: 'not-a-date' })).toBeNull();
+  });
+});
+
+describe('EVENT_DEDUP_WINDOW_MS', () => {
+  it('is the shared 10-second window', () => {
+    // Pinning the value so live dispatch + buffer reconcile stay in lockstep.
+    // Changing the window is a deliberate architectural decision, not a
+    // local tweak.
+    expect(EVENT_DEDUP_WINDOW_MS).toBe(10_000);
+  });
+});

--- a/tests/daemon/reconciliation-dedup.test.ts
+++ b/tests/daemon/reconciliation-dedup.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'bun:test';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
+import { seedSession } from '../helpers/sessions.js';
+import { createReconciler } from '@myco/daemon/reconciliation.js';
+import { listBatchesBySession } from '@myco/db/queries/batches.js';
+import { countActivities } from '@myco/db/queries/activities.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const silentLogger = {
+  debug: () => {}, info: () => {}, warn: () => {}, error: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;
+
+describe('Buffer reconciliation — duplicate suppression', () => {
+  let tmpDir: string;
+  let bufferDir: string;
+
+  beforeAll(() => { setupTestDb(); });
+  afterAll(teardownTestDb);
+
+  beforeEach(() => {
+    cleanTestDb();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reconcile-dedup-'));
+    bufferDir = path.join(tmpDir, 'buffer');
+    fs.mkdirSync(bufferDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // The exact failure mode from session 019e2bc0 on 2026-05-15: Codex's
+  // user_prompt hook fires twice ~3ms apart. The live dispatcher dedups the
+  // second one and returns `ignored: 'duplicate'`. The hook CLI sees `ignored`
+  // and writes the duplicate to the buffer file "for replay". Without this
+  // guard, buffer reconciliation then re-inserts it and the session ends up
+  // with two prompt_batches for the same physical prompt (prompt_numbers 47
+  // AND 48 in the bug). The duplicates must be suppressed at the replay
+  // boundary too.
+  it('suppresses duplicate user_prompt events in the buffer (Codex double-fire)', () => {
+    const sessionId = 'codex-dup-001';
+    seedSession({ id: sessionId, agent: 'codex' });
+
+    const promptText = 'Yes the script is a good idea';
+    const bufferPath = path.join(bufferDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(bufferPath,
+      JSON.stringify({ type: 'user_prompt', prompt: promptText, timestamp: '2026-05-15T15:55:07.594Z' }) + '\n' +
+      JSON.stringify({ type: 'user_prompt', prompt: promptText, timestamp: '2026-05-15T15:55:07.597Z' }) + '\n',
+    );
+
+    const reconciler = createReconciler({ bufferDir, logger: silentLogger, projectRoot: process.cwd() });
+    reconciler.reconcileSession(sessionId);
+
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches).toHaveLength(1);
+    expect(batches[0].user_prompt).toBe(promptText);
+  });
+
+  it('suppresses duplicate tool_use events with identical tool_input', () => {
+    const sessionId = 'codex-tool-dup-001';
+    seedSession({ id: sessionId, agent: 'codex' });
+
+    const toolEvent = {
+      type: 'tool_use',
+      tool_name: 'Bash',
+      tool_input: { command: 'pwd', description: 'cwd' },
+    };
+    const bufferPath = path.join(bufferDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(bufferPath,
+      // Prompt opens a batch so tool_use has a parent.
+      JSON.stringify({ type: 'user_prompt', prompt: 'do the thing', timestamp: '2026-05-15T15:55:00.000Z' }) + '\n' +
+      JSON.stringify({ ...toolEvent, timestamp: '2026-05-15T15:55:01.000Z' }) + '\n' +
+      JSON.stringify({ ...toolEvent, timestamp: '2026-05-15T15:55:01.020Z' }) + '\n' +
+      JSON.stringify({ ...toolEvent, timestamp: '2026-05-15T15:55:01.040Z' }) + '\n',
+    );
+
+    const reconciler = createReconciler({ bufferDir, logger: silentLogger, projectRoot: process.cwd() });
+    reconciler.reconcileSession(sessionId);
+
+    expect(countActivities(sessionId, ALL_PROJECTS_SCOPE)).toBe(1);
+  });
+
+  // The 10-second window protects against retry storms (which are sub-second
+  // bursts) — it must not suppress legitimate same-text turns that pause for
+  // a real user think-time between firings.
+  it('lets a repeated prompt through if it arrives outside the 10s dedup window', () => {
+    const sessionId = 'codex-window-001';
+    seedSession({ id: sessionId, agent: 'codex' });
+
+    const bufferPath = path.join(bufferDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(bufferPath,
+      JSON.stringify({ type: 'user_prompt', prompt: 'continue', timestamp: '2026-05-15T15:00:00.000Z' }) + '\n' +
+      // 15s later — outside the window, treat as a fresh turn.
+      JSON.stringify({ type: 'user_prompt', prompt: 'continue', timestamp: '2026-05-15T15:00:15.000Z' }) + '\n',
+    );
+
+    const reconciler = createReconciler({ bufferDir, logger: silentLogger, projectRoot: process.cwd() });
+    reconciler.reconcileSession(sessionId);
+
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches.length).toBe(2);
+  });
+});

--- a/tests/hooks/send-event-stderr.test.ts
+++ b/tests/hooks/send-event-stderr.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+/**
+ * Regression: hook buffer-fallback used to be completely silent. A "session
+ * not captured" investigation had to compare buffer-file mtimes against
+ * transcript mtimes to discover that the hook had been writing to the
+ * buffer for hours without ever reaching the daemon — exactly the failure
+ * mode that hid the prod-daemon stop-responding bug for the entire morning
+ * of 2026-05-15. Every fallback path must now leave a stderr trace so the
+ * agent's log (or the user's terminal) captures it without a buffer-byte
+ * audit.
+ */
+describe('hook send-event stderr observability', () => {
+  function setupProject(): { projectRoot: string; vaultDir: string; transcriptPath: string } {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-send-event-stderr-'));
+    const vaultDir = path.join(projectRoot, '.myco');
+    const transcriptPath = path.join(projectRoot, 'transcript.jsonl');
+    fs.mkdirSync(vaultDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(vaultDir, 'project.toml'),
+      '[project]\nid = "proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\nname = "send-event-stderr"\n',
+      'utf-8',
+    );
+    fs.writeFileSync(path.join(vaultDir, 'myco.yaml'), 'version: 3\nconfig_version: 0\n', 'utf-8');
+    fs.writeFileSync(transcriptPath, '{}\n', 'utf-8');
+    return { projectRoot, vaultDir, transcriptPath };
+  }
+
+  it('logs to stderr when buffering a tool_use on transport failure (daemon unreachable)', () => {
+    const { projectRoot, vaultDir, transcriptPath } = setupProject();
+
+    try {
+      // No daemon.json + MYCO_NO_AUTO_SPAWN=1 means capturePost short-circuits
+      // to ok=false without an HTTP error envelope — the "transport-failure"
+      // branch in classifyBufferFallback.
+      const result = spawnSync(
+        process.execPath,
+        [path.resolve('packages/myco/src/cli.ts'), 'hook', 'post-tool-use', '--symbiont', 'codex'],
+        {
+          cwd: projectRoot,
+          env: { ...process.env, MYCO_NO_AUTO_SPAWN: '1' },
+          input: JSON.stringify({
+            session_id: 'sess-stderr-transport',
+            transcript_path: transcriptPath,
+            tool_name: 'Bash',
+            tool_input: { command: 'pwd' },
+            tool_output: 'ok',
+          }),
+          encoding: 'utf-8',
+        },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain('[myco] post-tool-use buffered');
+      expect(result.stderr).toContain('session=sess-stderr-transport');
+      // Reason classification: no daemon.json → result.ok=false, result.data=undefined.
+      expect(result.stderr).toContain('transport-failure');
+
+      // And the buffer should still have the event (the durability path is unchanged).
+      const bufferPath = path.join(vaultDir, 'buffer', 'sess-stderr-transport.jsonl');
+      expect(fs.existsSync(bufferPath)).toBe(true);
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two intertwined capture bugs surfaced on 2026-05-15 by Codex session `019e2bc0`:

- **Duplicate prompt_batches from Codex double-fire.** Codex's UserPromptSubmit hook fires twice ~3ms apart. The live dispatcher correctly suppresses the second one (returns `ignored: 'duplicate'`), but the hook CLI then buffers the rejected event "for replay". The buffer reconciler had no dedup guard → re-inserts → every prompt produced two `prompt_batches` rows.
- **Silent buffer-fallback in the hook CLI.** Transport failures, HTTP errors, and daemon-side `ignored` responses all wrote to the buffer with zero stderr trace. "Session not captured" turned into a hand-investigation comparing buffer-file mtimes to transcript-file mtimes — the same architectural opacity that hid the prod-daemon stop-responding-after-restart bug all morning.

## Changes

- New `@myco/capture/dedup.js` — single source of truth for the fingerprint (`session_id + type + prompt[0:256] + tool_name + tool_input[0:256] + task_id + agent_id`) and the 10-second window. Live dispatcher and buffer reconciler both use it.
- `reconcileSession()` applies the dedup guard before replaying. `duplicates_suppressed` is now in the reconciliation-complete log so the volume is observable.
- Every hook buffer-fallback writes `[myco] <hook> buffered (<reason>) session=<id>` to stderr. Reasons: `transport-failure`, `http-error`, `daemon-ignored:<reason>` — classified through a shared `classifyBufferFallback` helper so the three independent buffer-write sites (`send-event.ts`, `user-prompt-submit.ts`, `post-tool-use.ts`) stay consistent.
- Daemon `Event suppressed as duplicate within dedup window` log promoted from debug → info. The volume is the signal that a symbiont is double-firing; hiding it at debug is how Codex's double-fire went unnoticed.

## Test plan

- [x] `tests/capture/dedup.test.ts` — fingerprint stability and the 10s-window constant
- [x] `tests/daemon/reconciliation-dedup.test.ts` — reproduces the 019e2bc0 3ms-apart double-fire and asserts exactly one prompt_batch lands; plus an outside-window case proving legitimate same-text turns still pass; plus a tool_use triple-fire test
- [x] `tests/hooks/send-event-stderr.test.ts` — runs the post-tool-use hook with no daemon and asserts the stderr `buffered (transport-failure)` trace fires
- [x] Full suite: 4743 node + 209 jsdom = 4952 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)