### PR TITLE
tests: capture-pipeline end-to-end integration (phase 3 of suite audit)

### DIFF
--- a/tests/integration/capture-pipeline-e2e.test.ts
+++ b/tests/integration/capture-pipeline-e2e.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Capture-pipeline end-to-end integration test.
+ *
+ * Drives the real `createEventDispatcher` through a multi-event session and
+ * asserts the full DB shape after — sessions row, prompt_batches with
+ * sequential prompt_numbers, activities linked to the open batch.
+ *
+ * This is the first canary integration test in Phase 3 of the suite audit
+ * (see #295 / #296 for context). It complements the function-level tests
+ * in `tests/daemon/capture.test.ts` (which call `handleUserPrompt` /
+ * `handleToolUse` directly) and `tests/daemon/event-dispatch.test.ts`
+ * (which exercise individual dispatcher decision branches) by covering
+ * what neither does: a single continuous lifecycle running through the
+ * dispatcher's wrapping layers — dedup window, auto-registration,
+ * request-context resolution, the `ensureSessionRowExists` defensive
+ * layer (added in #284), DB persistence — and asserting that the rows
+ * land correctly across multiple turns.
+ *
+ * If this fails, the capture pipeline is silently dropping work. That's
+ * the bug shape that shipped in #278, #280, #284, #285, #286 — the test
+ * exists to fail loudly the next time anything in this chain regresses,
+ * instead of letting it leak to a user.
+ *
+ * Stop processing (`POST /events/stop`) lives in a separate processor
+ * with heavier deps (transcriptMiner, embeddingManager) and is covered
+ * by its own future integration test; this file stays focused on the
+ * `/events` dispatcher path.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
+import { TEST_REQUEST_CONTEXT } from '../helpers/request-context';
+import { createEventDispatcher } from '@myco/daemon/event-dispatch.js';
+import { SessionRegistry } from '@myco/daemon/lifecycle.js';
+import { PowerManager } from '@myco/daemon/power.js';
+import { DaemonLogger } from '@myco/daemon/logger.js';
+import { getSession } from '@myco/db/queries/sessions.js';
+import { listBatchesBySession } from '@myco/db/queries/batches.js';
+import { listActivities, countActivities } from '@myco/db/queries/activities.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+
+function makeDispatcher() {
+  const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-capture-e2e-log-'));
+  const vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-capture-e2e-vault-'));
+  const logger = new DaemonLogger(logDir, { level: 'warn' });
+  const registry = new SessionRegistry({ gracePeriod: 1, onEmpty: () => {} });
+  const powerManager = new PowerManager({
+    idleThresholdMs: 60_000,
+    sleepThresholdMs: 120_000,
+    deepSleepThresholdMs: 180_000,
+    activeIntervalMs: 60_000,
+    sleepIntervalMs: 60_000,
+    logger,
+  });
+  const sessionBuffers = new Map();
+
+  const handler = createEventDispatcher({
+    registry,
+    sessionBuffers,
+    powerManager,
+    logger,
+    machineId: 'local',
+    liveConfig: {
+      current: {
+        agent: { summary_batch_interval: 20 },
+        canopy: { exclude: { patterns: [] } },
+      } as never,
+    },
+    vaultDir,
+    reconcileSession: () => {},
+    planWatchConfig: { watchDirs: [], projectRoot: vaultDir },
+    triggerTitleSummary: async () => {},
+  });
+
+  return { handler, registry, sessionBuffers };
+}
+
+function post(handler: ReturnType<typeof makeDispatcher>['handler'], body: Record<string, unknown>) {
+  return handler({
+    requestContext: TEST_REQUEST_CONTEXT,
+    body,
+    query: {},
+    params: {},
+    pathname: '/events',
+  });
+}
+
+describe('capture pipeline — end-to-end through dispatcher', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => { cleanTestDb(); });
+
+  it('persists a two-batch session — sessions row, batches with prompt_numbers, activities linked', async () => {
+    const { handler } = makeDispatcher();
+    const sessionId = 'capture-e2e-001';
+    const agent = 'claude-code';
+
+    // Turn 1 — user prompt arrives for a never-registered session. The
+    // dispatcher's `ensureSessionRowExists` defensive layer (#284) is what
+    // makes this safe; if that regresses, no session row exists when the
+    // batch insert hits the FK and the whole turn vanishes.
+    const r1 = await post(handler, {
+      type: 'user_prompt',
+      session_id: sessionId,
+      agent,
+      prompt: 'Write a hello world program',
+      transcript_path: '/tmp/fake-transcript.jsonl',
+    });
+    expect(r1.body).toMatchObject({ ok: true });
+
+    let session = getSession(sessionId, ALL_PROJECTS_SCOPE);
+    expect(session).not.toBeNull();
+    expect(session!.id).toBe(sessionId);
+
+    // Two tool uses inside turn 1 — both should attach to the open batch.
+    await post(handler, {
+      type: 'tool_use',
+      session_id: sessionId,
+      agent,
+      tool_name: 'Write',
+      tool_input: { file_path: '/tmp/hello.ts', content: 'console.log("hi")' },
+    });
+    await post(handler, {
+      type: 'tool_use',
+      session_id: sessionId,
+      agent,
+      tool_name: 'Bash',
+      tool_input: { command: 'bun /tmp/hello.ts' },
+    });
+
+    // Turn 2 — a new user prompt opens a new batch with prompt_number=2.
+    await post(handler, {
+      type: 'user_prompt',
+      session_id: sessionId,
+      agent,
+      prompt: 'Now add a test for it',
+      transcript_path: '/tmp/fake-transcript.jsonl',
+    });
+
+    // One tool use inside turn 2.
+    await post(handler, {
+      type: 'tool_use',
+      session_id: sessionId,
+      agent,
+      tool_name: 'Write',
+      tool_input: { file_path: '/tmp/hello.test.ts', content: 'expect(1).toBe(1)' },
+    });
+
+    // --- Verify session ---
+    session = getSession(sessionId, ALL_PROJECTS_SCOPE);
+    expect(session).not.toBeNull();
+    expect(session!.status).toBe('active');
+    expect(session!.ended_at).toBeNull();
+
+    // --- Verify batches ---
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches.length).toBe(2);
+    const [batch1, batch2] = batches;
+
+    expect(batch1.prompt_number).toBe(1);
+    expect(batch1.user_prompt).toBe('Write a hello world program');
+
+    expect(batch2.prompt_number).toBe(2);
+    expect(batch2.user_prompt).toBe('Now add a test for it');
+
+    // --- Verify activities ---
+    const activities = listActivities({ session_id: sessionId, scope: ALL_PROJECTS_SCOPE });
+    expect(activities.length).toBe(3);
+
+    // First two activities belong to batch 1, in order.
+    expect(activities[0].prompt_batch_id).toBe(batch1.id);
+    expect(activities[0].tool_name).toBe('Write');
+    expect(activities[0].file_path).toBe('/tmp/hello.ts');
+
+    expect(activities[1].prompt_batch_id).toBe(batch1.id);
+    expect(activities[1].tool_name).toBe('Bash');
+
+    // Third activity belongs to batch 2.
+    expect(activities[2].prompt_batch_id).toBe(batch2.id);
+    expect(activities[2].tool_name).toBe('Write');
+    expect(activities[2].file_path).toBe('/tmp/hello.test.ts');
+
+    expect(countActivities(sessionId, ALL_PROJECTS_SCOPE)).toBe(3);
+  });
+
+  it('drops duplicate user_prompt within the dedup window without creating a second batch', async () => {
+    const { handler } = makeDispatcher();
+    const sessionId = 'capture-e2e-dedup-001';
+    const agent = 'claude-code';
+    const event = {
+      type: 'user_prompt',
+      session_id: sessionId,
+      agent,
+      prompt: 'identical prompt that should only persist once',
+      transcript_path: '/tmp/fake-transcript.jsonl',
+    };
+
+    await post(handler, event);
+    await post(handler, event);
+    await post(handler, event);
+
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches.length).toBe(1);
+    expect(batches[0].prompt_number).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

First integration test in Phase 3 of the test-suite audit (follow-up to #295, #296). Drives a multi-event session through the real \`createEventDispatcher\` and asserts the full DB shape after — sessions row, prompt_batches with sequential prompt_numbers, activities linked to the open batch.

## Why this, instead of more unit tests

The recent capture-pipeline regressions (#278, #280, #284, #285, #286) all **escaped** the existing function-level tests. They were all cross-layer: a route arrived, the dispatcher's wrapping layers (auto-registration → dedup → defensive FK protection → DB persist) interacted incorrectly, and work was silently dropped. No single-unit test catches that — by definition, those tests don't cross layers.

\`tests/daemon/capture.test.ts\` (1,110 lines) tests the bare handlers (\`handleUserPrompt\`, \`handleToolUse\`) directly. \`tests/daemon/event-dispatch.test.ts\` (407 lines) tests individual dispatcher decision branches (orphan drops, dedup edges, drift defence). Neither covers a continuous multi-turn lifecycle that exercises the dispatcher's full wrapping chain plus the resulting DB state.

This file does. If the chain breaks at any layer, this fails loudly instead of leaking to a user.

## What's covered

Two tests, ~31ms total runtime:

1. **\`persists a two-batch session\`** — two user_prompt turns with tool_use events between, asserts both batches have sequential \`prompt_number\`s, activities link to the correct open batch, session row exists with status=active. Specifically exercises the \`ensureSessionRowExists\` defensive layer added in #284 (event arrives for a never-formally-registered session; the dispatcher must still create the session row before the batch insert hits the FK).
2. **\`drops duplicate user_prompt within the dedup window\`** — asserts that three identical posts result in exactly one batch in the DB (not just the dispatcher response shape, which existing tests already cover).

## What's *not* covered (deferred)

- \`POST /events/stop\` (heavier deps — transcriptMiner, embeddingManager — gets its own integration test in a follow-up).
- HTTP round-trip (no real \`DaemonServer.listen()\`). Worth adding once we have a port-allocation strategy that doesn't introduce flake — currently the dispatcher is called directly, exactly like the existing unit tests in \`event-dispatch.test.ts\` but driving the full lifecycle.

These are explicit next steps, not gaps to be filled silently.

## Suite metrics

- Before: 4,797 tests across 453 files
- After: 4,799 tests across 454 files
- Runtime: +31ms

## Phase 3 next steps

This is one of five planned integration tests targeting recent bug shapes:

| Test | Catches |
|---|---|
| ✅ capture-pipeline (this PR) | #278, #284 class — silent capture loss |
| ⏳ multi-tenancy invariant | #235, #280 class — cross-Grove data leak |
| ⏳ MCP bridge round-trip | #270, #286, #288 class — stdio bridge / token / observability |
| ⏳ V7 visual regression | #283, #293 class — UI rendering drift |
| ⏳ worktree harness | #290, #294 class — bootstrap / packaging in worktrees |

## Test plan

- [x] \`npm test\` green (4799 passing, 0 failing)
- [x] New test runs in ~31ms
- [ ] Watch over the next several merges: if a capture regression escapes despite this test, the failure shape tells us what additional integration coverage to add

🤖 Generated with [Claude Code](https://claude.com/claude-code)