### PR TITLE
daemon: log every /mcp tool dispatch (closes #288)

### DIFF
--- a/packages/myco/src/constants/log-kinds.ts
+++ b/packages/myco/src/constants/log-kinds.ts
@@ -109,6 +109,8 @@ export const LOG_KINDS = {
 
   // MCP
   MCP_EVENT: 'mcp.event',
+  MCP_CALL: 'mcp.call',
+  MCP_LIST: 'mcp.list',
 
   // Log retention
   LOG_RETENTION: 'log.retention',

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -1336,6 +1336,7 @@ export async function main(): Promise<void> {
     resolveDatabase: (databasePath) => databasePath === dataPaths.databasePath
       ? db
       : runtimeCache.getDatabase(databasePath),
+    logger,
   }));
 
   // --- Backup routes ---

--- a/packages/myco/src/mcp/http.ts
+++ b/packages/myco/src/mcp/http.ts
@@ -8,6 +8,7 @@ import {
   tryResolveRequestContextForVault,
 } from '../tools/request-context.js';
 import { createMcpProtocolServer } from './server.js';
+import type { Logger } from '../daemon/logger.js';
 
 export type StreamableMcpHttpHandler = (
   req: http.IncomingMessage,
@@ -18,6 +19,12 @@ export interface StreamableMcpHttpHandlerOptions {
   client?: DaemonClient;
   /** Reuse the daemon's runtime cache so tool calls don't open per-call DB handles. */
   resolveDatabase?: (databasePath: string) => Database;
+  /**
+   * Optional structured logger. When provided, the protocol server logs
+   * each /mcp tool dispatch (start, success, error) — closes the
+   * observability gap from issue #288.
+   */
+  logger?: Logger;
 }
 
 /**
@@ -76,7 +83,10 @@ export function createStreamableMcpHttpHandler(
       requestContext,
       resolveDatabase: options.resolveDatabase,
     });
-    const server = createMcpProtocolServer(tools);
+    const server = createMcpProtocolServer(tools, {
+      logger: options.logger,
+      sessionId: requestContext.sessionId ?? null,
+    });
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
     });

--- a/packages/myco/src/mcp/server.ts
+++ b/packages/myco/src/mcp/server.ts
@@ -3,21 +3,67 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprot
 import { getPluginVersion } from '../version.js';
 import { TOOL_CORTEX, type ToolDefinition } from '../tools/definitions.js';
 import { type MycoTools } from '../tools/index.js';
+import { LOG_KINDS } from '../constants/log-kinds.js';
+import type { Logger } from '../daemon/logger.js';
 
-export function createMcpProtocolServer(tools: MycoTools): Server {
+export interface McpProtocolServerOptions {
+  /**
+   * Optional structured logger. When provided, every CallTool dispatch
+   * leaves at least one info-level entry (success) or warn-level entry
+   * (error). Mirrors the `hooks.*` log shape so the same investigation
+   * procedure works for /events and /mcp. See issue #288.
+   */
+  logger?: Logger;
+  /** Session id from the request context, surfaced in log payloads. */
+  sessionId?: string | null;
+}
+
+export function createMcpProtocolServer(tools: MycoTools, options: McpProtocolServerOptions = {}): Server {
+  const { logger, sessionId } = options;
   const server = new Server(
     { name: 'myco', version: getPluginVersion() },
     { capabilities: { tools: {} } },
   );
 
-  server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: await tools.listTools() as ToolDefinition[],
-  }));
+  server.setRequestHandler(ListToolsRequestSchema, async (_request, extra) => {
+    const listed = (await tools.listTools()) as ToolDefinition[];
+    logger?.debug(LOG_KINDS.MCP_LIST, 'MCP tools listed', {
+      tool_count: listed.length,
+      session_id: sessionId ?? undefined,
+      request_id: extra?.requestId,
+    });
+    return { tools: listed };
+  });
 
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     const { name, arguments: args = {} } = request.params;
-    const result = await tools.callTool(name, args);
-    return { content: [{ type: 'text', text: serializeToolResult(name, result) }] };
+    logger?.info(LOG_KINDS.MCP_CALL, 'MCP tool call received', {
+      tool_name: name,
+      session_id: sessionId ?? undefined,
+      request_id: extra?.requestId,
+    });
+    try {
+      const result = await tools.callTool(name, args);
+      logger?.info(LOG_KINDS.MCP_CALL, 'MCP tool call completed', {
+        tool_name: name,
+        session_id: sessionId ?? undefined,
+        request_id: extra?.requestId,
+        status: 'ok',
+      });
+      return { content: [{ type: 'text', text: serializeToolResult(name, result) }] };
+    } catch (err) {
+      const error = err as Error;
+      logger?.warn(LOG_KINDS.MCP_CALL, 'MCP tool call failed', {
+        tool_name: name,
+        session_id: sessionId ?? undefined,
+        request_id: extra?.requestId,
+        status: 'error',
+        error_class: error?.name ?? 'Error',
+        // First line only — keep grep-friendly. Full stack stays out of the log.
+        error_message: (error?.message ?? String(err)).split('\n', 1)[0],
+      });
+      throw err;
+    }
   });
 
   return server;

--- a/tests/mcp/observability.test.ts
+++ b/tests/mcp/observability.test.ts
@@ -1,0 +1,140 @@
+/**
+ * MCP daemon-side observability tests.
+ *
+ * Closes #288 — every /mcp tool dispatch must leave at least one log
+ * entry, so `grep mcp <daemon.log>` is no longer empty after the agent
+ * calls a tool. Mirrors the existing `hooks.*` log shape.
+ *
+ * Drives the real `createMcpProtocolServer` (no transport, no HTTP)
+ * with a tiny in-memory logger and a tiny in-memory tool surface that
+ * lets us trigger both happy and error paths deterministically.
+ */
+
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { Logger } from '@myco/daemon/logger.js';
+import { createMcpProtocolServer } from '@myco/mcp/server.js';
+import type { MycoTools } from '@myco/tools/index.js';
+
+interface CapturedLogEntry {
+  level: 'debug' | 'info' | 'warn' | 'error';
+  kind: string;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+function makeRecordingLogger(): { logger: Logger; entries: CapturedLogEntry[] } {
+  const entries: CapturedLogEntry[] = [];
+  const push = (level: CapturedLogEntry['level']) => (kind: string, message: string, data?: Record<string, unknown>) => {
+    entries.push({ level, kind, message, data });
+  };
+  return {
+    entries,
+    logger: { debug: push('debug'), info: push('info'), warn: push('warn'), error: push('error') },
+  };
+}
+
+function makeFakeTools(overrides: Partial<MycoTools> = {}): MycoTools {
+  return {
+    listTools: async () => [
+      { name: 'fake_tool', description: 'fake', inputSchema: { type: 'object' } },
+    ],
+    callTool: async (name: string) => {
+      if (name === 'fake_tool') return { ok: true };
+      throw new Error('unknown tool');
+    },
+    ...overrides,
+  } as unknown as MycoTools;
+}
+
+async function connectAndCall(tools: MycoTools, loggerOpts: { logger: Logger; sessionId?: string }) {
+  const server = createMcpProtocolServer(tools, loggerOpts);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await client.connect(clientTransport);
+  return { client, server };
+}
+
+describe('MCP server observability (#288)', () => {
+  let recording: ReturnType<typeof makeRecordingLogger>;
+
+  beforeEach(() => {
+    recording = makeRecordingLogger();
+  });
+
+  it('logs an info entry on successful tool dispatch', async () => {
+    const { client } = await connectAndCall(makeFakeTools(), {
+      logger: recording.logger,
+      sessionId: 'sess-test-1',
+    });
+
+    await client.callTool({ name: 'fake_tool', arguments: {} });
+
+    const calls = recording.entries.filter((e) => e.kind === 'mcp.call');
+    expect(calls.length).toBeGreaterThanOrEqual(2); // received + completed
+
+    const received = calls.find((e) => e.message === 'MCP tool call received');
+    expect(received?.level).toBe('info');
+    expect(received?.data).toMatchObject({ tool_name: 'fake_tool', session_id: 'sess-test-1' });
+
+    const completed = calls.find((e) => e.message === 'MCP tool call completed');
+    expect(completed?.level).toBe('info');
+    expect(completed?.data).toMatchObject({
+      tool_name: 'fake_tool',
+      session_id: 'sess-test-1',
+      status: 'ok',
+    });
+
+    await client.close();
+  });
+
+  it('logs a warn entry on tool error with error class + first line of message', async () => {
+    const throwingTools = makeFakeTools({
+      callTool: async () => { throw new TypeError('first line\nsecond line should not appear'); },
+    });
+    const { client } = await connectAndCall(throwingTools, {
+      logger: recording.logger,
+      sessionId: 'sess-test-2',
+    });
+
+    // The SDK surfaces the throw as a JSON-RPC error; the call from the
+    // client will reject — that's expected and not what we're testing.
+    await client.callTool({ name: 'anything', arguments: {} }).catch(() => undefined);
+
+    const errorEntry = recording.entries.find((e) => e.level === 'warn' && e.kind === 'mcp.call');
+    expect(errorEntry).toBeDefined();
+    expect(errorEntry?.data).toMatchObject({
+      tool_name: 'anything',
+      session_id: 'sess-test-2',
+      status: 'error',
+      error_class: 'TypeError',
+      error_message: 'first line',
+    });
+    expect((errorEntry?.data?.error_message as string).includes('\n')).toBe(false);
+
+    await client.close();
+  });
+
+  it('logs listTools at debug level (lower verbosity than dispatches)', async () => {
+    const { client } = await connectAndCall(makeFakeTools(), { logger: recording.logger });
+
+    await client.listTools();
+
+    const listEntries = recording.entries.filter((e) => e.kind === 'mcp.list');
+    expect(listEntries.length).toBe(1);
+    expect(listEntries[0].level).toBe('debug');
+    expect(listEntries[0].data).toMatchObject({ tool_count: 1 });
+
+    await client.close();
+  });
+
+  it('runs without a logger (observability is opt-in, not required)', async () => {
+    // No logger supplied — must not throw, must still serve tool calls.
+    const { client } = await connectAndCall(makeFakeTools(), { logger: undefined as unknown as Logger });
+    const result = await client.callTool({ name: 'fake_tool', arguments: {} });
+    expect(result).toBeDefined();
+    await client.close();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #288. Adds info-level log entries for every MCP tool dispatch so `grep mcp <daemon.log>` is no longer empty after an agent calls a tool — mirrors the existing `hooks.*` shape for `/events`.

## Before / after

**Before:** An agent calls a Myco tool, the daemon handles it, `daemon.log` shows zero entries for the call. A hung or errored tool gets debugged via process trees and buffer mtimes because the daemon side is silent.

**After:** Every CallTool dispatch leaves at least one info-level entry on success, or warn-level on error. The error log carries the error class plus the first line of the error message — grep-friendly, no full stack pollution.

## Wire

| File | Change |
|---|---|
| `constants/log-kinds.ts` | `MCP_CALL: 'mcp.call'` (info) and `MCP_LIST: 'mcp.list'` (debug) |
| `mcp/server.ts` | `createMcpProtocolServer` now takes `{ logger?, sessionId? }`; CallToolRequestSchema handler is wrapped with start/success/error logs |
| `mcp/http.ts` | `createStreamableMcpHttpHandler` options gain `logger`; threaded through |
| `daemon/main.ts` | `/mcp` route registration passes the daemon `logger` |
| `tests/mcp/observability.test.ts` | drives the real protocol server through an in-memory transport, asserts both happy and error path log shapes |

## Log shape

Matches `hooks.*` for tool surfaces:

\`\`\`
info  mcp.call  "MCP tool call received"    { tool_name, session_id, request_id }
info  mcp.call  "MCP tool call completed"   { tool_name, session_id, request_id, status: 'ok' }
warn  mcp.call  "MCP tool call failed"      { tool_name, session_id, request_id, status: 'error', error_class, error_message }
\`\`\`

`mcp.list` (tool listings) is at debug — high-cardinality and not what \"why did my tool call vanish\" investigations look at.

## Non-goals

- Full request/response tracing (verbose; out of scope per issue).
- Trace ID propagation across hook → MCP boundaries (separate ergonomics question).

## Suite metrics

- Before: 4,811 tests
- After: 4,815 tests (+4 new in `tests/mcp/observability.test.ts`)
- Status: green on full `npm test`

## Test plan

- [x] `npm test` green
- [x] Observability test asserts both happy and error log shapes against a real `createMcpProtocolServer` + in-memory transport
- [ ] Manual smoke after daemon restart: run a Myco MCP tool from any agent, `grep mcp.call ~/.myco/service/logs/daemon.log` returns the call

🤖 Generated with [Claude Code](https://claude.com/claude-code)