### PR TITLE
fix(ui): unblock vite dev by stopping the @myco/utils/json cross-boundary import (closes #294)

### DIFF
--- a/packages/myco/ui/src/components/agent/AuditTrail.tsx
+++ b/packages/myco/ui/src/components/agent/AuditTrail.tsx
@@ -4,7 +4,7 @@ import { useAgentTurns, useAgentRunAudit } from '../../hooks/use-agent';
 import { Badge } from '../ui/badge';
 import { Surface } from '../ui/surface';
 import { cn } from '../../lib/cn';
-import { tryParseJson } from '@myco/utils/json';
+import { tryParseJson } from '../../lib/json';
 import type { PhaseAuditEntry, TurnRow } from '../../hooks/use-agent';
 import { formatCost, formatTokens } from './helpers';
 import { MS_PER_SECOND } from '../../lib/constants';

--- a/packages/myco/ui/src/components/agent/RunDetail.tsx
+++ b/packages/myco/ui/src/components/agent/RunDetail.tsx
@@ -26,7 +26,7 @@ import { formatCost, formatTokens, formatDuration, resolveTaskName } from './hel
 import { PhaseTimeline, type PhaseResult } from './PhaseTimeline';
 import type { CostResolution } from '@myco/agent/cost/types';
 import type { HarnessTokenBudget } from '@myco/agent/types';
-import { tryParseJson } from '@myco/utils/json';
+import { tryParseJson } from '../../lib/json';
 
 /* ---------- Helpers ---------- */
 

--- a/packages/myco/ui/src/components/agent/comparison-helpers.ts
+++ b/packages/myco/ui/src/components/agent/comparison-helpers.ts
@@ -5,7 +5,7 @@
  * spinning up a React renderer (the component itself has no RTL harness).
  */
 
-import { tryParseJson } from '@myco/utils/json';
+import { tryParseJson } from '../../lib/json';
 import type { RunCompareSummary } from '../../hooks/use-agent';
 import { extractSharedInputs, type SharedInputKey } from './shared-inputs';
 

--- a/packages/myco/ui/src/lib/json.ts
+++ b/packages/myco/ui/src/lib/json.ts
@@ -1,0 +1,24 @@
+/**
+ * Pure JSON-parsing helper for the UI bundle. Browser-safe — no Node
+ * imports — so `vite dev` can resolve it without falling back to the
+ * Node-only `@myco/utils/json` re-export (which transitively pulls in
+ * `fs` via `@goondocks/myco-shared`).
+ *
+ * See issue #294 and the follow-up issue for the broader UI/daemon
+ * boundary work; this fix targets just the one cross-boundary import
+ * that breaks `vite dev` today.
+ */
+
+export function tryParseJson<T>(raw: unknown, validator: (value: unknown) => value is T): T | null;
+export function tryParseJson(raw: unknown): unknown;
+export function tryParseJson<T>(raw: unknown, validator?: (value: unknown) => value is T): T | unknown | null {
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!validator) return parsed;
+  return validator(parsed) ? parsed : null;
+}


### PR DESCRIPTION
## Summary

Closes #294 — the tactical part. Three UI components imported \`tryParseJson\` from \`@myco/utils/json\`, which is a one-line re-export from \`@goondocks/myco-shared\`. That package is 100% Node-only (every file imports \`fs\` / \`path\` / \`child_process\`), so \`vite dev\` fails to resolve it for the browser bundle and the inner loop breaks.

The function itself is pure (string → object). Moving a 12-line copy into the UI's own \`lib/\` eliminates the cross-boundary import; \`vite dev\` now starts clean.

The strategic part — the broader UI/daemon boundary the leak revealed — is filed as **#303**.

## Why not the issue's recommended fix (split \`@goondocks/myco-shared\`)

The issue suggested splitting the package into \`myco-shared\` (browser-safe) + \`myco-shared-node\`. That's symptom-patching:

- \`@goondocks/myco-shared\` has **zero** browser-safe code today. Every file imports a Node built-in. Renaming the package wouldn't change anything about this import chain.
- The actual leak is the UI reaching into a daemon package for one tiny helper. Fixing that at the use site is the smaller, correct change.
- The broader pattern — UI imports ~14 distinct \`@myco/*\` paths into daemon code — is the architectural problem behind the class of bug. That's #303.

## Change

- New `packages/myco/ui/src/lib/json.ts` — 12-line pure \`tryParseJson\`, browser-safe, no Node imports.
- Three callsites switched from \`@myco/utils/json\` to \`../../lib/json\`:
  - `packages/myco/ui/src/components/agent/comparison-helpers.ts`
  - `packages/myco/ui/src/components/agent/AuditTrail.tsx`
  - `packages/myco/ui/src/components/agent/RunDetail.tsx`

`@myco/utils/json` (and `@goondocks/myco-shared`) are unchanged — daemon-side imports continue to use them.

## Verification

- `npx vite build` → \`✓ built in 417ms\` (no externalize warnings)
- `npx vite dev` → \`VITE v8.0.12 ready in 145 ms\` (clean startup; was previously throwing \`Module \"fs\" has been externalized\` per the issue)
- `npm test` → 4815 passing across both phases (no test removed or added; behavior unchanged at runtime)

## Follow-up

- **#303 — enforce a UI ↔ daemon module boundary** — filed to capture the architectural work. It includes the audit data (14 cross-boundary imports today) and proposes a tsconfig/ESLint enforcement so the next time someone adds a Node import to a UI-imported module, the failure surfaces at build time rather than as a confusing \`vite dev\` externalize warning weeks later.

## Test plan

- [x] \`npx vite build\` clean
- [x] \`npx vite dev\` starts without externalize warnings
- [x] \`npm test\` green (4815 passing)
- [ ] Manual: run \`vite dev\` in any worktree of this branch, edit one of the three touched components, confirm HMR roundtrips without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)