### PR TITLE
feat(daemon): self-mutation discipline — atomic + reconciler + intent

### DIFF
--- a/packages/myco-shared/src/process.ts
+++ b/packages/myco-shared/src/process.ts
@@ -2,12 +2,30 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
+/**
+ * Liveness check via the null signal.
+ *
+ * `process.kill(pid, 0)` succeeds when the kernel has a process for `pid` AND
+ * the caller has permission to signal it. The OS distinguishes the two
+ * failure modes via `errno`:
+ *
+ *   - `ESRCH` — no such process. The pid is genuinely dead.
+ *   - `EPERM` — the process exists but the caller cannot signal it (a
+ *     different uid owns it). For our purposes the pid is ALIVE; we just
+ *     can't talk to it.
+ *
+ * Conflating EPERM with "dead" is unsafe in the reconcileExistingDaemon
+ * polling ladder — it would unlink daemon.json out from under a live daemon
+ * owned by another user (self-mutation-discipline tenet violation). Any
+ * other unexpected error is treated conservatively as "alive" to err away
+ * from orphaning state.
+ */
 export function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
-    return false;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code !== 'ESRCH';
   }
 }
 

--- a/packages/myco/src/cli/restart.ts
+++ b/packages/myco/src/cli/restart.ts
@@ -1,43 +1,22 @@
 import { resolveDaemonServiceState } from '../daemon/service-state.js';
 import { mergeIntent } from '../daemon/intent.js';
 import { DaemonClient } from '../hooks/client.js';
+import { serviceLabel, serviceVariantForState } from '../service/labels.js';
 
-/** How long the CLI waits for the supervisor-driven respawn before giving up. */
 const RESTART_CONVERGE_DEADLINE_MS = 15_000;
-/** Poll interval while waiting for a new pid to appear on the canonical port. */
 const RESTART_POLL_INTERVAL_MS = 500;
 
-/**
- * `myco restart` is the first command migrated to the intent +
- * reconciliation model. The CLI no longer shuts down or kills the
- * daemon itself. Instead:
- *
- *   1. Write `[restart]` into intent.toml (atomic).
- *   2. Exit.
- *   3. The daemon's continuous `reconcileSelf` PowerManager tick
- *      observes the intent on its next iteration, clears the section
- *      (so a respawn loop doesn't reapply it), and triggers a
- *      supervisor-side restart (`launchctl kickstart -k` on macOS,
- *      `systemctl --user restart` on Linux).
- *   4. The supervisor SIGTERMs the daemon and respawns it. A fresh
- *      daemon.json appears on startup.
- *
- * The CLI polls `getInfoAsync()` — which falls back to `/health` on
- * the canonical port when daemon.json is missing — and waits for a
- * new pid to surface. During the gap between SIGTERM and respawn,
- * `getInfoAsync()` returns null; the loop treats that as "still
- * restarting", not failure.
- */
 export async function run(_args: string[], vaultDir: string): Promise<void> {
   const daemonService = resolveDaemonServiceState(vaultDir);
   const client = new DaemonClient(vaultDir);
   const before = await client.getInfoAsync();
 
   if (!before) {
-    console.error('No daemon found on the canonical port and no state file present.');
+    const label = serviceLabel(serviceVariantForState(daemonService));
     const supervisorHint = process.platform === 'darwin'
-      ? `  launchctl list | grep ${daemonService.scope === 'global' ? 'co.goondocks.myco' : 'co.goondocks.myco-dev'}`
-      : `  systemctl --user status myco.service`;
+      ? `  launchctl list | grep ${label}`
+      : `  systemctl --user status ${label}.service`;
+    console.error('No daemon found on the canonical port and no state file present.');
     console.error('If the daemon should be running, check the supervisor:');
     console.error(supervisorHint);
     process.exit(1);
@@ -49,11 +28,8 @@ export async function run(_args: string[], vaultDir: string): Promise<void> {
   console.log(`Restart requested for daemon ${before.pid} on port ${before.port}.`);
   console.log('Waiting for the reconciler to converge...');
 
-  // The reconciler ticks at PowerManager cadence; the supervisor
-  // SIGTERMs and respawns. A new pid on the canonical port (or on
-  // daemon.json after the fresh daemon's startup write) signals
-  // convergence. A null result during the gap is expected — keep
-  // polling until the deadline.
+  // A null poll result during the SIGTERM→respawn gap is expected;
+  // keep polling until a new pid surfaces or the deadline elapses.
   const deadline = Date.now() + RESTART_CONVERGE_DEADLINE_MS;
   const previousPid = before.pid;
   while (Date.now() < deadline) {

--- a/packages/myco/src/cli/restart.ts
+++ b/packages/myco/src/cli/restart.ts
@@ -1,25 +1,74 @@
+import { resolveDaemonServiceState } from '../daemon/service-state.js';
+import { mergeIntent } from '../daemon/intent.js';
+import { DaemonClient } from '../hooks/client.js';
+
+/** How long the CLI waits for the supervisor-driven respawn before giving up. */
+const RESTART_CONVERGE_DEADLINE_MS = 15_000;
+/** Poll interval while waiting for a new pid to appear on the canonical port. */
+const RESTART_POLL_INTERVAL_MS = 500;
+
+/**
+ * `myco restart` is the first command migrated to the intent +
+ * reconciliation model. The CLI no longer shuts down or kills the
+ * daemon itself. Instead:
+ *
+ *   1. Write `[restart]` into intent.toml (atomic).
+ *   2. Exit.
+ *   3. The daemon's continuous `reconcileSelf` PowerManager tick
+ *      observes the intent on its next iteration, clears the section
+ *      (so a respawn loop doesn't reapply it), and triggers a
+ *      supervisor-side restart (`launchctl kickstart -k` on macOS,
+ *      `systemctl --user restart` on Linux).
+ *   4. The supervisor SIGTERMs the daemon and respawns it. A fresh
+ *      daemon.json appears on startup.
+ *
+ * The CLI polls `getInfoAsync()` — which falls back to `/health` on
+ * the canonical port when daemon.json is missing — and waits for a
+ * new pid to surface. During the gap between SIGTERM and respawn,
+ * `getInfoAsync()` returns null; the loop treats that as "still
+ * restarting", not failure.
+ */
 export async function run(_args: string[], vaultDir: string): Promise<void> {
-  const { DaemonClient } = await import('../hooks/client.js');
+  const daemonService = resolveDaemonServiceState(vaultDir);
   const client = new DaemonClient(vaultDir);
-  const previous = client.getInfo();
+  const before = await client.getInfoAsync();
 
-  console.log('Waiting for health check...');
-  const healthy = await client.restart({ checkStale: false });
-  if (!healthy) {
-    console.error('Daemon failed to become healthy');
-    return;
+  if (!before) {
+    console.error('No daemon found on the canonical port and no state file present.');
+    const supervisorHint = process.platform === 'darwin'
+      ? `  launchctl list | grep ${daemonService.scope === 'global' ? 'co.goondocks.myco' : 'co.goondocks.myco-dev'}`
+      : `  systemctl --user status myco.service`;
+    console.error('If the daemon should be running, check the supervisor:');
+    console.error(supervisorHint);
+    process.exit(1);
   }
 
-  const info = client.getInfo();
-  if (previous?.pid) {
-    console.log(`Stopped daemon ${previous.pid}`);
-  } else {
-    console.log('No existing daemon to stop');
+  mergeIntent(daemonService, {
+    restart: { requested_at: new Date().toISOString(), reason: 'cli' },
+  });
+  console.log(`Restart requested for daemon ${before.pid} on port ${before.port}.`);
+  console.log('Waiting for the reconciler to converge...');
+
+  // The reconciler ticks at PowerManager cadence; the supervisor
+  // SIGTERMs and respawns. A new pid on the canonical port (or on
+  // daemon.json after the fresh daemon's startup write) signals
+  // convergence. A null result during the gap is expected — keep
+  // polling until the deadline.
+  const deadline = Date.now() + RESTART_CONVERGE_DEADLINE_MS;
+  const previousPid = before.pid;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, RESTART_POLL_INTERVAL_MS));
+    const now = await client.getInfoAsync();
+    if (now && now.pid !== previousPid) {
+      console.log(`Stopped daemon ${previousPid}`);
+      console.log(`Daemon healthy on port ${now.port} (pid ${now.pid})`);
+      console.log(`Dashboard: http://localhost:${now.port}/`);
+      return;
+    }
   }
-  if (info) {
-    console.log(`Daemon healthy on port ${info.port}`);
-    console.log(`Dashboard: http://localhost:${info.port}/`);
-  } else {
-    console.log('Daemon healthy');
-  }
+  console.error(
+    `Reconciler did not converge within ${RESTART_CONVERGE_DEADLINE_MS / 1000}s. `
+    + 'The intent file remains; the daemon will pick it up on the next tick.',
+  );
+  process.exit(1);
 }

--- a/packages/myco/src/cli/update.ts
+++ b/packages/myco/src/cli/update.ts
@@ -7,9 +7,11 @@ import { withInferredReleaseProvenanceDefaults } from '../release-provenance/def
 import { getPluginVersion } from '../version.js';
 import { UPDATE_STAMP_FILENAME } from '../constants/update.js';
 import { DAEMON_CLIENT_TIMEOUT_MS } from '../constants.js';
-import { readDaemonPort } from '../daemon/service-state.js';
+import { readDaemonPort, readDaemonState, resolveDaemonServiceState } from '../daemon/service-state.js';
 import { listGroves, listRegisteredProjects } from '../grove/registry.js';
 import { loadProjectManifest } from '../config/project-manifest.js';
+import { mergeIntent, clearIntentSection, readIntent } from '../daemon/intent.js';
+import { DaemonClient } from '../hooks/client.js';
 import {
   activateProjectMigration,
   activationMarkerPath,
@@ -31,14 +33,36 @@ Regenerate managed Myco project files and migrate legacy config to the
 current Machine/Grove/Project config tiers.
 
 Options:
-  --project <path>  Project root to update
-  --all-projects    Update every registered project served by this binary
-  -h, --help        Show this help
+  --project <path>           Project root to update
+  --all-projects             Update every registered project served by this binary
+  --target-version <ver>     Request the daemon install @goondocks/myco@<ver>
+                             via the intent + reconciliation pipeline
+  --cancel-update            Clear a pending [update] intent without installing
+  -h, --help                 Show this help
 `;
 
 export async function run(args: string[]): Promise<void> {
   if (args.includes('--help') || args.includes('-h')) {
     process.stdout.write(USAGE);
+    return;
+  }
+
+  // `--target-version <v>` writes a binary-update intent for the daemon's
+  // reconciler to pick up. Distinct from the project-config-sync path
+  // (the rest of this command). Doesn't touch project files.
+  const targetVersionIdx = args.indexOf('--target-version');
+  if (targetVersionIdx !== -1) {
+    const target = args[targetVersionIdx + 1];
+    if (!target) {
+      console.error('--target-version requires a version argument');
+      process.exit(1);
+    }
+    await runUpdateIntent(target);
+    return;
+  }
+
+  if (args.includes('--cancel-update')) {
+    await runCancelUpdate();
     return;
   }
 
@@ -321,6 +345,65 @@ async function runAllProjects(): Promise<void> {
     console.error(`  - ${target.groveSlug}/${target.projectName}: ${error instanceof Error ? error.message : String(error)}`);
   }
   process.exit(1);
+}
+
+/**
+ * Write a `[update]` intent under `<stateDir>/intent.toml` and exit.
+ *
+ * Parallel to `myco restart`: the CLI does not call the installer
+ * directly. Instead it writes intent and lets the daemon's
+ * `reconcileSelf` PowerManager tick observe it and invoke
+ * `spawnUpdateScript`. On install failure, the intent is retained so
+ * the next reconcile tick retries — see `self-reconcile.ts`.
+ *
+ * The current daemon's running version is read via `DaemonClient`. When
+ * the daemon is already at the requested version, no intent is written.
+ */
+async function runUpdateIntent(targetVersion: string): Promise<void> {
+  const vaultDir = resolveVaultDir();
+  const daemonService = resolveDaemonServiceState(vaultDir);
+  const client = new DaemonClient(vaultDir);
+  const reachable = await client.getInfoAsync();
+
+  if (!reachable) {
+    console.error('No daemon found. Start the daemon before running `myco update --target-version`.');
+    process.exit(1);
+  }
+
+  // `getInfoAsync` returns the daemon's pid/port but not version (the
+  // `/health` fallback intentionally omits it). For the same-version
+  // short-circuit we consult daemon.json — written by the live daemon's
+  // self-reconcile tick, includes the version field.
+  const state = readDaemonState(daemonService.statePath);
+  if (state?.version === targetVersion) {
+    console.log(`Daemon already at version ${targetVersion}. Nothing to do.`);
+    return;
+  }
+
+  mergeIntent(daemonService, {
+    update: { target_version: targetVersion, requested_at: new Date().toISOString() },
+  });
+  console.log(
+    `Update to ${targetVersion} requested. The daemon will apply it on the next reconcile tick.`,
+  );
+  console.log(`Tail ~/.myco/update-error.json if the update fails.`);
+  console.log(`Run \`myco update --cancel-update\` to withdraw before it lands.`);
+}
+
+/**
+ * Clear a pending `[update]` intent. Idempotent — succeeds even when
+ * no intent is present.
+ */
+async function runCancelUpdate(): Promise<void> {
+  const vaultDir = resolveVaultDir();
+  const daemonService = resolveDaemonServiceState(vaultDir);
+  const intent = readIntent(daemonService);
+  if (!intent.update) {
+    console.log('No pending update intent.');
+    return;
+  }
+  clearIntentSection(daemonService, 'update');
+  console.log(`Cleared pending update intent (target was ${intent.update.target_version}).`);
 }
 
 async function httpMcpEndpointMissing(vaultDir: string): Promise<boolean> {

--- a/packages/myco/src/config/loader.ts
+++ b/packages/myco/src/config/loader.ts
@@ -16,6 +16,7 @@ import {
 import { runMigrations, CURRENT_MIGRATION_VERSION } from './migrations.js';
 import { deepMerge } from '../utils/deep-merge.js';
 import { getAtPath, setAtPath, unsetAtPath } from '../utils/dot-path.js';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import {
   resolveGlobalConfigPath,
   resolveGroveConfigPath,
@@ -144,7 +145,7 @@ export function saveMachineConfig(config: MachineConfig, mycoHome = resolveMycoH
   const validated = MachineConfigSchema.parse(config);
   const filePath = resolveGlobalConfigPath(mycoHome);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, YAML.stringify(validated), 'utf-8');
+  atomicWriteFileSync(filePath, YAML.stringify(validated), 'utf-8');
   machineConfigCache.delete(filePath);
   invalidateMergedConfigCache();
 }
@@ -171,7 +172,7 @@ export function saveGroveConfig(
   const validated = GroveConfigSchema.parse(config);
   const filePath = resolveGroveConfigPath(groveId, mycoHome);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, YAML.stringify(validated), 'utf-8');
+  atomicWriteFileSync(filePath, YAML.stringify(validated), 'utf-8');
   groveConfigCache.delete(filePath);
   invalidateMergedConfigCache();
 }
@@ -413,7 +414,7 @@ function loadConfigInternal(vaultDir: string, options: LoadConfigOptions = {}): 
     // Zod-parsed full `config` — so the project file stays free of
     // Grove/Machine-tier fields and unrelated defaults. The returned
     // `config` still has every field defaulted for runtime consumers.
-    fs.writeFileSync(configPath, YAML.stringify(parsed), 'utf-8');
+    atomicWriteFileSync(configPath, YAML.stringify(parsed), 'utf-8');
   }
 
   return { config, parsed };
@@ -435,7 +436,7 @@ export function saveConfig(vaultDir: string, config: MycoConfig): void {
 
   const configPath = path.join(vaultDir, CONFIG_FILENAME);
   fs.mkdirSync(vaultDir, { recursive: true });
-  fs.writeFileSync(configPath, YAML.stringify(projectOnly), 'utf-8');
+  atomicWriteFileSync(configPath, YAML.stringify(projectOnly), 'utf-8');
   invalidateMergedConfigCache(vaultDir);
 }
 
@@ -517,7 +518,7 @@ export function loadLocalConfig(vaultDir: string): Partial<MycoConfig> {
   // which would otherwise stamp legacy files with `config_version` for
   // no semantic reason.
   if (before !== after) {
-    fs.writeFileSync(filePath, after, 'utf-8');
+    atomicWriteFileSync(filePath, after, 'utf-8');
   }
 
   return doc as Partial<MycoConfig>;
@@ -672,7 +673,7 @@ function writeLocalYamlIfChanged<T>(vaultDir: string, current: T, next: T): T {
   if (existingYaml === nextYaml) return next;
 
   fs.mkdirSync(vaultDir, { recursive: true });
-  fs.writeFileSync(localConfigPath(vaultDir), nextYaml, 'utf-8');
+  atomicWriteFileSync(localConfigPath(vaultDir), nextYaml, 'utf-8');
   invalidateMergedConfigCache(vaultDir);
   return next;
 }

--- a/packages/myco/src/config/secrets.ts
+++ b/packages/myco/src/config/secrets.ts
@@ -16,6 +16,7 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 
 const SECRETS_FILE = 'secrets.env';
 const SECRETS_FILE_MODE = 0o600;
@@ -171,9 +172,13 @@ function ensureSecretsDirSecure(vaultDir: string): void {
 }
 
 function writeSecretsFile(secretsPath: string, content: string): void {
-  fs.writeFileSync(secretsPath, content, { encoding: 'utf-8', mode: SECRETS_FILE_MODE });
-  // writeFileSync only applies the mode when creating the file. If it
-  // already existed, force the tightening explicitly.
+  // Atomic write protects against torn writes; the helper doesn't accept
+  // a mode argument today (Task 2's scope), so we chmod immediately
+  // after the rename. The rename->chmod window is bounded to the same
+  // synchronous call site, matching the prior writeFileSync+chmod
+  // sequence on the same path.
+  atomicWriteFileSync(secretsPath, content, 'utf-8');
+  // TODO: Task 2 — pass mode 0o600 to atomicWriteFileSync
   try {
     fs.chmodSync(secretsPath, SECRETS_FILE_MODE);
   } catch {

--- a/packages/myco/src/config/secrets.ts
+++ b/packages/myco/src/config/secrets.ts
@@ -172,16 +172,8 @@ function ensureSecretsDirSecure(vaultDir: string): void {
 }
 
 function writeSecretsFile(secretsPath: string, content: string): void {
-  // Atomic write protects against torn writes; the helper doesn't accept
-  // a mode argument today (Task 2's scope), so we chmod immediately
-  // after the rename. The rename->chmod window is bounded to the same
-  // synchronous call site, matching the prior writeFileSync+chmod
-  // sequence on the same path.
-  atomicWriteFileSync(secretsPath, content, 'utf-8');
-  // TODO: Task 2 — pass mode 0o600 to atomicWriteFileSync
-  try {
-    fs.chmodSync(secretsPath, SECRETS_FILE_MODE);
-  } catch {
-    // Best-effort.
-  }
+  // Atomic write protects against torn writes; the mode-aware helper
+  // applies 0o600 to the tempfile before rename so the final path is
+  // never briefly readable at the default umask.
+  atomicWriteFileSync(secretsPath, content, { encoding: 'utf-8', mode: SECRETS_FILE_MODE });
 }

--- a/packages/myco/src/constants.ts
+++ b/packages/myco/src/constants.ts
@@ -139,6 +139,19 @@ export const DAEMON_EVICT_TIMEOUT_MS = 3000;
 /** Poll interval when waiting for an evicted daemon to die (ms). */
 export const DAEMON_EVICT_POLL_MS = 100;
 
+/** reconcileExistingDaemon: grace period between SIGTERM and SIGKILL when
+ *  taking over from a stale/unhealthy/version-mismatched predecessor (ms).
+ *  Closes the orphan-zombie window — daemon.json must not be unlinked until
+ *  the recorded pid is confirmed dead. Self-mutation-discipline tenet. */
+export const RECONCILE_SIGTERM_GRACE_MS = 2000;
+/** reconcileExistingDaemon: grace period after SIGKILL before giving up and
+ *  stepping aside (ms). A pid that survives this window is unkillable from
+ *  user space; we refuse to remove daemon.json and return 'step-aside'. */
+export const RECONCILE_SIGKILL_GRACE_MS = 500;
+/** reconcileExistingDaemon: poll interval while waiting for the predecessor
+ *  pid to exit (ms). */
+export const RECONCILE_POLL_MS = 50;
+
 // --- Slug limits ---
 /** Max length for slugified artifact IDs. */
 

--- a/packages/myco/src/constants/power-jobs.ts
+++ b/packages/myco/src/constants/power-jobs.ts
@@ -13,6 +13,7 @@ export const POWER_JOB_NAMES = {
   STAGING_GC: 'staging-gc',
   CANOPY_BACKGROUND_SCAN: 'canopy-background-scan',
   RELEASE_PROVENANCE_RECONCILE: 'release-provenance-reconcile',
+  SELF_RECONCILE: 'self-reconcile',
 } as const;
 
 export type PowerJobName = (typeof POWER_JOB_NAMES)[keyof typeof POWER_JOB_NAMES];

--- a/packages/myco/src/daemon/intent.ts
+++ b/packages/myco/src/daemon/intent.ts
@@ -36,7 +36,7 @@ export function readIntent(daemonService: DaemonServiceState): Intent {
 }
 
 export function writeIntent(daemonService: DaemonServiceState, intent: Intent): void {
-  atomicWriteFileSync(intentPath(daemonService), stringify(intent as never));
+  atomicWriteFileSync(intentPath(daemonService), stringify(intent as Record<string, unknown>));
 }
 
 export function mergeIntent(daemonService: DaemonServiceState, patch: Intent): void {

--- a/packages/myco/src/daemon/intent.ts
+++ b/packages/myco/src/daemon/intent.ts
@@ -1,0 +1,55 @@
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse, stringify } from 'smol-toml';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
+import type { DaemonServiceState } from './service-state.js';
+
+export interface RestartIntent {
+  requested_at: string; // ISO8601
+  reason?: string;
+}
+
+export interface UpdateIntent {
+  target_version: string;
+  requested_at: string;
+}
+
+export interface Intent {
+  restart?: RestartIntent;
+  update?: UpdateIntent;
+}
+
+function intentPath(daemonService: DaemonServiceState): string {
+  return join(daemonService.stateDir, 'intent.toml');
+}
+
+export function readIntent(daemonService: DaemonServiceState): Intent {
+  const p = intentPath(daemonService);
+  if (!existsSync(p)) return {};
+  try {
+    return parse(readFileSync(p, 'utf-8')) as Intent;
+  } catch {
+    // Malformed intent file — treat as empty. The next writer
+    // overwrites; no other behavior depends on its prior contents.
+    return {};
+  }
+}
+
+export function writeIntent(daemonService: DaemonServiceState, intent: Intent): void {
+  atomicWriteFileSync(intentPath(daemonService), stringify(intent as never));
+}
+
+export function mergeIntent(daemonService: DaemonServiceState, patch: Intent): void {
+  const current = readIntent(daemonService);
+  writeIntent(daemonService, { ...current, ...patch });
+}
+
+export function clearIntentSection(daemonService: DaemonServiceState, section: keyof Intent): void {
+  const current = readIntent(daemonService);
+  delete current[section];
+  if (Object.keys(current).length === 0) {
+    try { unlinkSync(intentPath(daemonService)); } catch { /* already gone */ }
+    return;
+  }
+  writeIntent(daemonService, current);
+}

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -1774,6 +1774,8 @@ export async function main(): Promise<void> {
       scheduledTaskKicker.kick('canopy-describe', { groveId, projectId }),
     daemonVaultDir: bootstrapVaultDir,
     daemonStateDir: daemonService.stateDir,
+    daemonService,
+    server,
   });
   teamSync.registerFlushJob(powerManager, runtimeCache);
 

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -203,7 +203,11 @@ import type { MycoConfig } from '@myco/config/schema.js';
 import {
   DAEMON_HEALTH_CHECK_TIMEOUT_MS,
   DAEMON_STALE_GRACE_PERIOD_MS,
+  RECONCILE_POLL_MS,
+  RECONCILE_SIGKILL_GRACE_MS,
+  RECONCILE_SIGTERM_GRACE_MS,
 } from '../constants.js';
+import { isProcessAlive, waitForProcessExit } from '@goondocks/myco-shared';
 import { getPluginVersion } from '../version.js';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -236,6 +240,22 @@ export async function isHealthyMycoSibling(port: number): Promise<boolean> {
 // ---------------------------------------------------------------------------
 
 /**
+ * Test-only seam for reconcileExistingDaemon. Production callers pass nothing
+ * and the defaults route to `process.kill`, `isProcessAlive`, and the
+ * production constants. Tests inject short grace windows and synthetic
+ * kill/aliveness so they can exercise the SIGTERM → SIGKILL → step-aside
+ * ladder without spawning a truly unkillable process (which user-space can't
+ * produce on macOS/Linux anyway).
+ */
+export interface ReconcileDeps {
+  kill?: (pid: number, signal: NodeJS.Signals | 0) => void;
+  isProcessAlive?: (pid: number) => boolean;
+  sigtermGraceMs?: number;
+  sigkillGraceMs?: number;
+  pollMs?: number;
+}
+
+/**
  * Reconcile with any existing daemon for this vault before starting a new one.
  *
  * - If no daemon.json or the recorded pid is dead → 'ok' (take over).
@@ -243,13 +263,27 @@ export async function isHealthyMycoSibling(port: number): Promise<boolean> {
  *   version → 'step-aside' (a sibling just started; don't kill it). The caller
  *   exits cleanly. This is what stops the concurrent-spawn cascade where each
  *   new process SIGTERMs the last one standing.
- * - Otherwise (stale, unhealthy, or version-mismatch) → SIGTERM the old
- *   daemon, unlink daemon.json, return 'ok' to proceed.
+ * - Otherwise (stale, unhealthy, or version-mismatch) → SIGTERM, poll for
+ *   exit, escalate to SIGKILL if needed, and only `removeDaemonState` once
+ *   the pid is confirmed dead. If the pid survives both signals, log an
+ *   error and return 'step-aside' WITHOUT unlinking — leaving the file in
+ *   place is structurally safer than orphaning a live daemon.
+ *
+ * Cleanup ownership inversion: this function is the SOLE production path
+ * that may remove daemon.json. `stop()` and `killDaemon()` no longer unlink.
+ * Self-mutation-discipline tenet: pid alive ⇔ daemon.json exists.
  */
 export async function reconcileExistingDaemon(
   daemonService: DaemonServiceState,
   logger: DaemonLogger,
+  deps: ReconcileDeps = {},
 ): Promise<'ok' | 'step-aside'> {
+  const kill = deps.kill ?? ((pid, sig) => process.kill(pid, sig));
+  const alive = deps.isProcessAlive ?? isProcessAlive;
+  const sigtermGraceMs = deps.sigtermGraceMs ?? RECONCILE_SIGTERM_GRACE_MS;
+  const sigkillGraceMs = deps.sigkillGraceMs ?? RECONCILE_SIGKILL_GRACE_MS;
+  const pollMs = deps.pollMs ?? RECONCILE_POLL_MS;
+
   const daemonJsonPath = daemonService.statePath;
   let info: { pid?: number; port?: number; command?: string | null };
   let mtimeMs: number;
@@ -266,10 +300,9 @@ export async function reconcileExistingDaemon(
   if (!info.pid) return 'ok';
   if (info.pid === process.pid) return 'ok';
 
-  // Is the recorded process actually alive?
-  try {
-    process.kill(info.pid, 0);
-  } catch {
+  // Is the recorded process actually alive? Use the dependency-injected
+  // probe so tests can simulate "still alive after SIGKILL".
+  if (!alive(info.pid)) {
     // Dead — clean up and take over.
     removeDaemonState(daemonJsonPath);
     return 'ok';
@@ -313,13 +346,60 @@ export async function reconcileExistingDaemon(
     } catch { /* health probe failed — fall through and replace */ }
   }
 
-  // Stale, unhealthy, or version mismatch: take over.
+  // Stale, unhealthy, or version mismatch: take over. We MUST confirm the
+  // predecessor pid is dead before unlinking daemon.json — otherwise a
+  // wedged shutdown leaves a live daemon with no discoverable state file
+  // (the orphan-zombie failure mode the tenet prohibits).
   try {
-    process.kill(info.pid, 'SIGTERM');
-    logger.info(LOG_KINDS.DAEMON_START, 'Killed stale daemon', { pid: info.pid });
+    kill(info.pid, 'SIGTERM');
+    logger.info(LOG_KINDS.DAEMON_RECONCILE, 'SIGTERM sent to stale daemon', { pid: info.pid });
+  } catch { /* already dead between alive() and kill() */ }
+
+  if (await waitForExit(info.pid, alive, sigtermGraceMs, pollMs)) {
+    removeDaemonState(daemonJsonPath);
+    return 'ok';
+  }
+
+  logger.warn(LOG_KINDS.DAEMON_RECONCILE, 'Predecessor ignored SIGTERM — escalating to SIGKILL', {
+    pid: info.pid,
+    grace_ms: sigtermGraceMs,
+  });
+  try {
+    kill(info.pid, 'SIGKILL');
   } catch { /* already dead */ }
-  removeDaemonState(daemonJsonPath);
-  return 'ok';
+
+  if (await waitForExit(info.pid, alive, sigkillGraceMs, pollMs)) {
+    removeDaemonState(daemonJsonPath);
+    return 'ok';
+  }
+
+  // Pid survived SIGKILL. user-space cannot kill it. Refusing to remove
+  // daemon.json is the safe move — the file still describes a live daemon,
+  // and stepping aside hands control back to the supervisor (launchd /
+  // systemd) without binding our own port on top of the live predecessor.
+  logger.error(
+    LOG_KINDS.DAEMON_RECONCILE,
+    `Refusing to remove daemon.json: prior daemon pid ${info.pid} is unkillable`,
+    { pid: info.pid, sigterm_grace_ms: sigtermGraceMs, sigkill_grace_ms: sigkillGraceMs },
+  );
+  return 'step-aside';
+}
+
+async function waitForExit(
+  pid: number,
+  alive: (pid: number) => boolean,
+  timeoutMs: number,
+  pollMs: number,
+): Promise<boolean> {
+  if (alive === isProcessAlive) {
+    return waitForProcessExit(pid, timeoutMs, pollMs);
+  }
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!alive(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  return !alive(pid);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -1776,6 +1776,12 @@ export async function main(): Promise<void> {
     daemonStateDir: daemonService.stateDir,
     daemonService,
     server,
+    projectRoot,
+    scheduleShutdown: () => {
+      setTimeout(() => {
+        process.kill(process.pid, 'SIGTERM');
+      }, RESTART_RESPONSE_FLUSH_MS);
+    },
   });
   teamSync.registerFlushJob(powerManager, runtimeCache);
 

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -168,6 +168,7 @@ import { PowerManager } from './power.js';
 import { EventLoopLagProbe } from './event-loop-lag.js';
 import { InflightRunRegistry } from './inflight-runs.js';
 import { registerPowerJobs } from './power-jobs.js';
+import { registerSelfReconcileJob } from './self-reconcile-wiring.js';
 import {
   handleUserPrompt, handleToolUse, handleStopBatches, handleToolFailure,
   handleSubagentStart, handleSubagentStop, handleStopFailure,
@@ -239,14 +240,7 @@ export async function isHealthyMycoSibling(port: number): Promise<boolean> {
 // Stale daemon cleanup
 // ---------------------------------------------------------------------------
 
-/**
- * Test-only seam for reconcileExistingDaemon. Production callers pass nothing
- * and the defaults route to `process.kill`, `isProcessAlive`, and the
- * production constants. Tests inject short grace windows and synthetic
- * kill/aliveness so they can exercise the SIGTERM → SIGKILL → step-aside
- * ladder without spawning a truly unkillable process (which user-space can't
- * produce on macOS/Linux anyway).
- */
+/** Test seam for reconcileExistingDaemon: production callers pass nothing. */
 export interface ReconcileDeps {
   kill?: (pid: number, signal: NodeJS.Signals | 0) => void;
   isProcessAlive?: (pid: number) => boolean;
@@ -1774,8 +1768,11 @@ export async function main(): Promise<void> {
       scheduledTaskKicker.kick('canopy-describe', { groveId, projectId }),
     daemonVaultDir: bootstrapVaultDir,
     daemonStateDir: daemonService.stateDir,
+  });
+  registerSelfReconcileJob(powerManager, logger, {
     daemonService,
     server,
+    daemonVaultDir: bootstrapVaultDir,
     projectRoot,
     scheduleShutdown: () => {
       setTimeout(() => {

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process';
 import type { DaemonLogger, Logger } from './logger.js';
 import type { PowerManager } from './power.js';
 import type { EmbeddingManager } from './embedding/manager.js';
@@ -5,6 +6,7 @@ import type { SessionRegistry } from './lifecycle.js';
 import type { DaemonServer } from './server.js';
 import type { DaemonServiceState } from './service-state.js';
 import { reconcileSelf } from './self-reconcile.js';
+import { serviceLabel, serviceVariantForState } from '../service/labels.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import { loadMergedConfig } from '@myco/config/loader.js';
 import { DatabaseMaintenanceManager } from './database/manager.js';
@@ -227,6 +229,57 @@ function makeTotalPendingProbe(deps: PowerJobDeps): () => number {
   };
 }
 
+/**
+ * Fork a detached child that asks the platform service supervisor to
+ * SIGTERM-and-respawn this daemon. The child is unref'd so it survives
+ * the SIGTERM that lands on us moments later.
+ *
+ * macOS:  `launchctl kickstart -k gui/<uid>/<label>` — KeepAlive-driven
+ *         respawn under the user's launchd domain.
+ * Linux:  `systemctl --user restart <label>.service` — the standard
+ *         systemd user-unit restart.
+ *
+ * Other platforms fall through with a warn log; the intent file has
+ * already been cleared so we don't loop.
+ *
+ * The service label is resolved via `serviceLabel(variant)` derived
+ * from the daemon's own service-state — NEVER hardcoded — so the
+ * dogfood (`co.goondocks.myco-dev`) and production
+ * (`co.goondocks.myco`) variants both route correctly.
+ */
+function requestSupervisorRestart(deps: PowerJobDeps): void {
+  const variant = serviceVariantForState(deps.daemonService);
+  const label = serviceLabel(variant);
+  if (process.platform === 'darwin') {
+    const uid = typeof process.getuid === 'function' ? process.getuid() : null;
+    if (uid === null) {
+      deps.logger.warn(
+        LOG_KINDS.DAEMON_RECONCILE,
+        'Supervisor restart skipped: process.getuid unavailable',
+        { platform: process.platform, label },
+      );
+      return;
+    }
+    spawn('launchctl', ['kickstart', '-k', `gui/${uid}/${label}`], {
+      detached: true,
+      stdio: 'ignore',
+    }).unref();
+    return;
+  }
+  if (process.platform === 'linux') {
+    spawn('systemctl', ['--user', 'restart', `${label}.service`], {
+      detached: true,
+      stdio: 'ignore',
+    }).unref();
+    return;
+  }
+  deps.logger.warn(
+    LOG_KINDS.DAEMON_RECONCILE,
+    'Supervisor restart not implemented on this platform',
+    { platform: process.platform, label },
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Registration
 // ---------------------------------------------------------------------------
@@ -356,6 +409,7 @@ export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps
         daemonService: deps.daemonService,
         currentState: () => deps.server.currentDaemonState(),
         logger,
+        requestSupervisorRestart: () => requestSupervisorRestart(deps),
       });
     },
   });

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -1,17 +1,7 @@
-import { spawn } from 'node:child_process';
 import type { DaemonLogger, Logger } from './logger.js';
 import type { PowerManager } from './power.js';
 import type { EmbeddingManager } from './embedding/manager.js';
 import type { SessionRegistry } from './lifecycle.js';
-import type { DaemonServer } from './server.js';
-import type { DaemonServiceState } from './service-state.js';
-import { reconcileSelf } from './self-reconcile.js';
-import { serviceLabel, serviceVariantForState } from '../service/labels.js';
-import { spawnUpdateScript } from './update-installer.js';
-import { resolveMycoBinary } from './update-checker.js';
-import { detectServiceManagedLabel } from './api/restart.js';
-import { getServiceManager } from '../service/manager.js';
-import { NPM_PACKAGE_NAME } from '../constants/update.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import { loadMergedConfig } from '@myco/config/loader.js';
 import { DatabaseMaintenanceManager } from './database/manager.js';
@@ -94,29 +84,6 @@ export interface PowerJobDeps {
   mycoHome?: string;
   /** The current daemon's service dir; passed through to `forEachGrove` to enforce the served-by boundary. */
   daemonStateDir: string;
-  /**
-   * The current daemon's resolved service state. Needed by the
-   * `self-reconcile` job so it can re-write daemon.json at the
-   * canonical path for this variant (dogfood vs production).
-   */
-  daemonService: DaemonServiceState;
-  /**
-   * Live server handle. The `self-reconcile` job calls
-   * `server.currentDaemonState()` on each tick to project the
-   * in-memory truth back into the state file.
-   */
-  server: DaemonServer;
-  /**
-   * Project root the daemon was launched against. Baked into update
-   * scripts so the post-install respawn happens in the right cwd.
-   */
-  projectRoot: string;
-  /**
-   * Schedules an in-process shutdown after the detached update script
-   * has been written and spawned. The update script waits a few
-   * seconds for this shutdown before running `npm install -g …`.
-   */
-  scheduleShutdown: () => void;
   onCanopyMassAdd?: (groveId: string, projectId: GroveProjectId) => void;
 }
 
@@ -245,100 +212,6 @@ function makeTotalPendingProbe(deps: PowerJobDeps): () => number {
   };
 }
 
-/**
- * Fork a detached child that asks the platform service supervisor to
- * SIGTERM-and-respawn this daemon. The child is unref'd so it survives
- * the SIGTERM that lands on us moments later.
- *
- * macOS:  `launchctl kickstart -k gui/<uid>/<label>` — KeepAlive-driven
- *         respawn under the user's launchd domain.
- * Linux:  `systemctl --user restart <label>.service` — the standard
- *         systemd user-unit restart.
- *
- * Other platforms fall through with a warn log; the intent file has
- * already been cleared so we don't loop.
- *
- * The service label is resolved via `serviceLabel(variant)` derived
- * from the daemon's own service-state — NEVER hardcoded — so the
- * dogfood (`co.goondocks.myco-dev`) and production
- * (`co.goondocks.myco`) variants both route correctly.
- */
-function requestSupervisorRestart(deps: PowerJobDeps): void {
-  const variant = serviceVariantForState(deps.daemonService);
-  const label = serviceLabel(variant);
-  if (process.platform === 'darwin') {
-    const uid = typeof process.getuid === 'function' ? process.getuid() : null;
-    if (uid === null) {
-      deps.logger.warn(
-        LOG_KINDS.DAEMON_RECONCILE,
-        'Supervisor restart skipped: process.getuid unavailable',
-        { platform: process.platform, label },
-      );
-      return;
-    }
-    spawn('launchctl', ['kickstart', '-k', `gui/${uid}/${label}`], {
-      detached: true,
-      stdio: 'ignore',
-    }).unref();
-    return;
-  }
-  if (process.platform === 'linux') {
-    spawn('systemctl', ['--user', 'restart', `${label}.service`], {
-      detached: true,
-      stdio: 'ignore',
-    }).unref();
-    return;
-  }
-  deps.logger.warn(
-    LOG_KINDS.DAEMON_RECONCILE,
-    'Supervisor restart not implemented on this platform',
-    { platform: process.platform, label },
-  );
-}
-
-/**
- * Resolve the platform-native restart shell command for the
- * service-managed daemon, or undefined when this process isn't
- * service-managed. Mirrors the helper used inside
- * `createUpdateHandlers` — both flows must agree on what the
- * supervisor is so the post-install respawn lands on the same path.
- */
-async function resolveServiceRestartCommandForInstall(): Promise<string | undefined> {
-  const serviceManager = getServiceManager();
-  const label = await detectServiceManagedLabel(serviceManager);
-  if (!label) return undefined;
-  try {
-    return serviceManager.restartShellCommand(label);
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Generate-and-spawn the detached update script that installs
- * `@goondocks/myco@<target>` globally and respawns the daemon.
- *
- * This is the `installUpdate` impl for `reconcileSelf`. Wraps
- * `spawnUpdateScript` so the reconciler doesn't need to know about
- * package specs or the runtime-command pin.
- *
- * Schedules an in-process shutdown after the script is on disk so
- * the script's `sleep N && npm install` step lands while the daemon
- * is gone — matching the existing `/api/update/apply` behavior.
- */
-async function installUpdateToVersion(deps: PowerJobDeps, targetVersion: string): Promise<void> {
-  const mycoBinary = resolveMycoBinary();
-  const serviceRestartCommand = await resolveServiceRestartCommandForInstall();
-  spawnUpdateScript({
-    packageSpecs: [`${NPM_PACKAGE_NAME}@${targetVersion}`],
-    projectRoot: deps.projectRoot,
-    vaultDir: deps.daemonVaultDir,
-    mycoBinary,
-    serviceRestartCommand,
-  });
-  deps.scheduleShutdown();
-}
-
 // ---------------------------------------------------------------------------
 // Registration
 // ---------------------------------------------------------------------------
@@ -454,25 +327,6 @@ export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps
 
   const fanOutGroves = (jobName: PowerJobName, body: (scope: GroveScope) => Promise<void>) =>
     () => forEachGrove(cache, logger, body, { mycoHome, daemonStateDir, jobName }).then(() => undefined);
-
-  // Continuously re-assert daemon.json against the live process state.
-  // Excludes 'deep_sleep' deliberately: at that point the daemon is
-  // essentially stopped and we don't want filesystem writes contending
-  // with system sleep. Runs first so even when later jobs starve a
-  // tick, the invariant tick still fires.
-  powerManager.register({
-    name: POWER_JOB_NAMES.SELF_RECONCILE,
-    runIn: ['active', 'idle', 'sleep'],
-    fn: async () => {
-      await reconcileSelf({
-        daemonService: deps.daemonService,
-        currentState: () => deps.server.currentDaemonState(),
-        logger,
-        requestSupervisorRestart: () => requestSupervisorRestart(deps),
-        installUpdate: (target: string) => installUpdateToVersion(deps, target),
-      });
-    },
-  });
 
   // Every tick processes one batch per Grove that has pending work; a Grove
   // with N records drains in N / batch ticks while peers drain in parallel.

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -7,6 +7,11 @@ import type { DaemonServer } from './server.js';
 import type { DaemonServiceState } from './service-state.js';
 import { reconcileSelf } from './self-reconcile.js';
 import { serviceLabel, serviceVariantForState } from '../service/labels.js';
+import { spawnUpdateScript } from './update-installer.js';
+import { resolveMycoBinary } from './update-checker.js';
+import { detectServiceManagedLabel } from './api/restart.js';
+import { getServiceManager } from '../service/manager.js';
+import { NPM_PACKAGE_NAME } from '../constants/update.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import { loadMergedConfig } from '@myco/config/loader.js';
 import { DatabaseMaintenanceManager } from './database/manager.js';
@@ -101,6 +106,17 @@ export interface PowerJobDeps {
    * in-memory truth back into the state file.
    */
   server: DaemonServer;
+  /**
+   * Project root the daemon was launched against. Baked into update
+   * scripts so the post-install respawn happens in the right cwd.
+   */
+  projectRoot: string;
+  /**
+   * Schedules an in-process shutdown after the detached update script
+   * has been written and spawned. The update script waits a few
+   * seconds for this shutdown before running `npm install -g …`.
+   */
+  scheduleShutdown: () => void;
   onCanopyMassAdd?: (groveId: string, projectId: GroveProjectId) => void;
 }
 
@@ -280,6 +296,49 @@ function requestSupervisorRestart(deps: PowerJobDeps): void {
   );
 }
 
+/**
+ * Resolve the platform-native restart shell command for the
+ * service-managed daemon, or undefined when this process isn't
+ * service-managed. Mirrors the helper used inside
+ * `createUpdateHandlers` — both flows must agree on what the
+ * supervisor is so the post-install respawn lands on the same path.
+ */
+async function resolveServiceRestartCommandForInstall(): Promise<string | undefined> {
+  const serviceManager = getServiceManager();
+  const label = await detectServiceManagedLabel(serviceManager);
+  if (!label) return undefined;
+  try {
+    return serviceManager.restartShellCommand(label);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Generate-and-spawn the detached update script that installs
+ * `@goondocks/myco@<target>` globally and respawns the daemon.
+ *
+ * This is the `installUpdate` impl for `reconcileSelf`. Wraps
+ * `spawnUpdateScript` so the reconciler doesn't need to know about
+ * package specs or the runtime-command pin.
+ *
+ * Schedules an in-process shutdown after the script is on disk so
+ * the script's `sleep N && npm install` step lands while the daemon
+ * is gone — matching the existing `/api/update/apply` behavior.
+ */
+async function installUpdateToVersion(deps: PowerJobDeps, targetVersion: string): Promise<void> {
+  const mycoBinary = resolveMycoBinary();
+  const serviceRestartCommand = await resolveServiceRestartCommandForInstall();
+  spawnUpdateScript({
+    packageSpecs: [`${NPM_PACKAGE_NAME}@${targetVersion}`],
+    projectRoot: deps.projectRoot,
+    vaultDir: deps.daemonVaultDir,
+    mycoBinary,
+    serviceRestartCommand,
+  });
+  deps.scheduleShutdown();
+}
+
 // ---------------------------------------------------------------------------
 // Registration
 // ---------------------------------------------------------------------------
@@ -405,11 +464,12 @@ export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps
     name: POWER_JOB_NAMES.SELF_RECONCILE,
     runIn: ['active', 'idle', 'sleep'],
     fn: async () => {
-      reconcileSelf({
+      await reconcileSelf({
         daemonService: deps.daemonService,
         currentState: () => deps.server.currentDaemonState(),
         logger,
         requestSupervisorRestart: () => requestSupervisorRestart(deps),
+        installUpdate: (target: string) => installUpdateToVersion(deps, target),
       });
     },
   });

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -2,6 +2,9 @@ import type { DaemonLogger, Logger } from './logger.js';
 import type { PowerManager } from './power.js';
 import type { EmbeddingManager } from './embedding/manager.js';
 import type { SessionRegistry } from './lifecycle.js';
+import type { DaemonServer } from './server.js';
+import type { DaemonServiceState } from './service-state.js';
+import { reconcileSelf } from './self-reconcile.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import { loadMergedConfig } from '@myco/config/loader.js';
 import { DatabaseMaintenanceManager } from './database/manager.js';
@@ -84,6 +87,18 @@ export interface PowerJobDeps {
   mycoHome?: string;
   /** The current daemon's service dir; passed through to `forEachGrove` to enforce the served-by boundary. */
   daemonStateDir: string;
+  /**
+   * The current daemon's resolved service state. Needed by the
+   * `self-reconcile` job so it can re-write daemon.json at the
+   * canonical path for this variant (dogfood vs production).
+   */
+  daemonService: DaemonServiceState;
+  /**
+   * Live server handle. The `self-reconcile` job calls
+   * `server.currentDaemonState()` on each tick to project the
+   * in-memory truth back into the state file.
+   */
+  server: DaemonServer;
   onCanopyMassAdd?: (groveId: string, projectId: GroveProjectId) => void;
 }
 
@@ -327,6 +342,23 @@ export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps
 
   const fanOutGroves = (jobName: PowerJobName, body: (scope: GroveScope) => Promise<void>) =>
     () => forEachGrove(cache, logger, body, { mycoHome, daemonStateDir, jobName }).then(() => undefined);
+
+  // Continuously re-assert daemon.json against the live process state.
+  // Excludes 'deep_sleep' deliberately: at that point the daemon is
+  // essentially stopped and we don't want filesystem writes contending
+  // with system sleep. Runs first so even when later jobs starve a
+  // tick, the invariant tick still fires.
+  powerManager.register({
+    name: POWER_JOB_NAMES.SELF_RECONCILE,
+    runIn: ['active', 'idle', 'sleep'],
+    fn: async () => {
+      reconcileSelf({
+        daemonService: deps.daemonService,
+        currentState: () => deps.server.currentDaemonState(),
+        logger,
+      });
+    },
+  });
 
   // Every tick processes one batch per Grove that has pending work; a Grove
   // with N records drains in N / batch ticks while peers drain in parallel.

--- a/packages/myco/src/daemon/self-reconcile-wiring.ts
+++ b/packages/myco/src/daemon/self-reconcile-wiring.ts
@@ -1,0 +1,99 @@
+import type { DaemonLogger } from './logger.js';
+import type { PowerManager } from './power.js';
+import type { DaemonServer } from './server.js';
+import type { DaemonServiceState } from './service-state.js';
+import { reconcileSelf } from './self-reconcile.js';
+import { serviceLabel, serviceVariantForState } from '../service/labels.js';
+import { spawnUpdateScript } from './update-installer.js';
+import { resolveMycoBinary } from './update-checker.js';
+import { detectServiceManagedLabel } from './api/restart.js';
+import { getServiceManager } from '../service/manager.js';
+import { NPM_PACKAGE_NAME } from '../constants/update.js';
+import { errorMessage } from '@myco/utils/error-message.js';
+import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+import { POWER_JOB_NAMES } from '@myco/constants/power-jobs.js';
+
+export interface SelfReconcileWiringDeps {
+  daemonService: DaemonServiceState;
+  /** Live server handle. `server.currentDaemonState()` projects in-memory truth back into daemon.json each tick. */
+  server: DaemonServer;
+  daemonVaultDir: string;
+  /** Project root the daemon was launched against; baked into update scripts for the post-install respawn. */
+  projectRoot: string;
+  /** In-process shutdown so the update script's `sleep && npm install` lands while the daemon is gone. */
+  scheduleShutdown: () => void;
+}
+
+/**
+ * Registers the SELF_RECONCILE PowerManager job. Runs first so the
+ * `pid alive ⇔ daemon.json exists` invariant tick still fires even if
+ * later jobs starve the tick budget. Excludes deep_sleep — the daemon
+ * is essentially stopped there and we don't want filesystem writes
+ * contending with system sleep.
+ */
+export function registerSelfReconcileJob(
+  powerManager: PowerManager,
+  logger: DaemonLogger,
+  deps: SelfReconcileWiringDeps,
+): void {
+  powerManager.register({
+    name: POWER_JOB_NAMES.SELF_RECONCILE,
+    runIn: ['active', 'idle', 'sleep'],
+    fn: async () => {
+      await reconcileSelf({
+        daemonService: deps.daemonService,
+        currentState: () => deps.server.currentDaemonState(),
+        logger,
+        requestSupervisorRestart: () => requestSupervisorRestart(logger, deps.daemonService),
+        installUpdate: (target: string) => installUpdateToVersion(deps, target),
+      });
+    },
+  });
+}
+
+/** Fire-and-forget supervisor restart via `ServiceManager.restart(label)`. */
+function requestSupervisorRestart(logger: DaemonLogger, daemonService: DaemonServiceState): void {
+  const label = serviceLabel(serviceVariantForState(daemonService));
+  const serviceManager = getServiceManager();
+  if (!serviceManager.supported) {
+    logger.warn(
+      LOG_KINDS.DAEMON_RECONCILE,
+      'Supervisor restart not implemented on this platform',
+      { platform: process.platform, label },
+    );
+    return;
+  }
+  serviceManager.restart(label).catch((err: unknown) => {
+    logger.error(
+      LOG_KINDS.DAEMON_RECONCILE,
+      'Supervisor restart failed',
+      { platform: process.platform, label, error: errorMessage(err) },
+    );
+  });
+}
+
+// Restart shell command the post-install script invokes after npm install.
+// Mirrors createUpdateHandlers — both flows must agree on the supervisor
+// so the post-install respawn lands on the same path.
+async function resolveServiceRestartCommandForInstall(): Promise<string | undefined> {
+  const serviceManager = getServiceManager();
+  const label = await detectServiceManagedLabel(serviceManager);
+  if (!label) return undefined;
+  try { return serviceManager.restartShellCommand(label); } catch { return undefined; }
+}
+
+async function installUpdateToVersion(
+  deps: SelfReconcileWiringDeps,
+  targetVersion: string,
+): Promise<void> {
+  const mycoBinary = resolveMycoBinary();
+  const serviceRestartCommand = await resolveServiceRestartCommandForInstall();
+  spawnUpdateScript({
+    packageSpecs: [`${NPM_PACKAGE_NAME}@${targetVersion}`],
+    projectRoot: deps.projectRoot,
+    vaultDir: deps.daemonVaultDir,
+    mycoBinary,
+    serviceRestartCommand,
+  });
+  deps.scheduleShutdown();
+}

--- a/packages/myco/src/daemon/self-reconcile.ts
+++ b/packages/myco/src/daemon/self-reconcile.ts
@@ -19,6 +19,20 @@ export interface ReconcileSelfDeps {
    * or `systemctl --user restart` via `power-jobs.ts`.
    */
   requestSupervisorRestart?: () => void;
+  /**
+   * Invoked when an update intent is observed for a version OTHER than
+   * the currently running daemon's version. Optional so unit tests can
+   * omit it. In production this delegates to `spawnUpdateScript` via
+   * `power-jobs.ts`.
+   *
+   * Pattern asymmetry vs `requestSupervisorRestart`: this runs BEFORE
+   * the intent section is cleared. On success the section is cleared
+   * (we're done). On failure the section is RETAINED so the next
+   * reconcile tick retries — installs are flaky (network, npm) and
+   * should be auto-resilient. The user-facing failure surface is
+   * `update-error.json`, written by the existing installer.
+   */
+  installUpdate?: (targetVersion: string) => Promise<void>;
 }
 
 /**
@@ -34,13 +48,17 @@ export interface ReconcileSelfDeps {
  * re-write only refreshes mtime, which keeps the freshness window
  * `reconcileExistingDaemon` consults for siblings accurate.
  *
- * Also consumes the intent file (`intent.toml`) — any `[restart]`
- * section is cleared and the supervisor restart is requested. The
- * clear-before-act ordering is load-bearing: if the supervisor
- * respawns us with the intent still present, the next tick would
- * read it again and trigger an infinite restart loop.
+ * Also consumes the intent file (`intent.toml`):
+ *   - `[restart]`: clear BEFORE invoking the supervisor restart, then
+ *     fan out via `requestSupervisorRestart`. The clear-before-act
+ *     ordering is load-bearing — a respawn with the intent still
+ *     present would trigger an infinite restart loop.
+ *   - `[update]`: invoke `installUpdate` THEN clear on success.
+ *     Retain on failure so the next tick can retry. If the target
+ *     version already matches the running daemon, clear without
+ *     invoking the installer.
  */
-export function reconcileSelf(deps: ReconcileSelfDeps): void {
+export async function reconcileSelf(deps: ReconcileSelfDeps): Promise<void> {
   const expected = deps.currentState();
   const observed = readDaemonState(deps.daemonService.statePath);
   if (observed && observed.pid === expected.pid && observed.port === expected.port) {
@@ -82,5 +100,41 @@ export function reconcileSelf(deps: ReconcileSelfDeps): void {
     // respawn could read the same intent again.
     clearIntentSection(deps.daemonService, 'restart');
     deps.requestSupervisorRestart?.();
+  }
+
+  if (intent.update) {
+    const current = deps.currentState().version;
+    if (intent.update.target_version === current) {
+      // Already at the requested version — the daemon was likely
+      // restarted into the target binary but the intent file wasn't
+      // cleared. Clean up so we don't re-evaluate forever.
+      deps.logger.info(
+        LOG_KINDS.DAEMON_RECONCILE,
+        'Update intent target matches current version; clearing',
+        { target_version: intent.update.target_version, current_version: current ?? null },
+      );
+      clearIntentSection(deps.daemonService, 'update');
+    } else if (deps.installUpdate) {
+      deps.logger.info(LOG_KINDS.DAEMON_RECONCILE, 'Update intent observed', {
+        target_version: intent.update.target_version,
+        current_version: current ?? null,
+      });
+      try {
+        await deps.installUpdate(intent.update.target_version);
+        // Clear AFTER success — installs can fail (network, npm); the
+        // retained intent lets the next tick retry without re-issuing
+        // the CLI command.
+        clearIntentSection(deps.daemonService, 'update');
+      } catch (err) {
+        deps.logger.error(
+          LOG_KINDS.DAEMON_RECONCILE,
+          'Update failed; intent retained for retry',
+          {
+            target_version: intent.update.target_version,
+            err: String(err),
+          },
+        );
+      }
+    }
   }
 }

--- a/packages/myco/src/daemon/self-reconcile.ts
+++ b/packages/myco/src/daemon/self-reconcile.ts
@@ -12,65 +12,24 @@ export interface ReconcileSelfDeps {
   daemonService: DaemonServiceState;
   currentState: () => DaemonState;
   logger: DaemonLogger;
-  /**
-   * Invoked when a restart intent is observed and after the intent
-   * section has been cleared. Optional so unit tests can omit it (or
-   * pass a spy). In production this fans out to `launchctl kickstart`
-   * or `systemctl --user restart` via `power-jobs.ts`.
-   */
   requestSupervisorRestart?: () => void;
-  /**
-   * Invoked when an update intent is observed for a version OTHER than
-   * the currently running daemon's version. Optional so unit tests can
-   * omit it. In production this delegates to `spawnUpdateScript` via
-   * `power-jobs.ts`.
-   *
-   * Pattern asymmetry vs `requestSupervisorRestart`: this runs BEFORE
-   * the intent section is cleared. On success the section is cleared
-   * (we're done). On failure the section is RETAINED so the next
-   * reconcile tick retries — installs are flaky (network, npm) and
-   * should be auto-resilient. The user-facing failure surface is
-   * `update-error.json`, written by the existing installer.
-   */
   installUpdate?: (targetVersion: string) => Promise<void>;
 }
 
 /**
- * Continuously-enforced invariant: if THIS process is alive and serving
- * on its variant's canonical port, daemon.json for that variant must
- * exist and accurately describe this process. Called from the
- * PowerManager reconcile tick (every active/idle/sleep tick) so the
- * `pid alive ⇔ daemon.json exists` invariant is no longer just a
- * startup guarantee — anything that nukes the file externally is
- * re-asserted within one tick.
- *
- * Idempotent: when the file already matches expected state, the
- * re-write only refreshes mtime, which keeps the freshness window
- * `reconcileExistingDaemon` consults for siblings accurate.
- *
- * Also consumes the intent file (`intent.toml`):
- *   - `[restart]`: clear BEFORE invoking the supervisor restart, then
- *     fan out via `requestSupervisorRestart`. The clear-before-act
- *     ordering is load-bearing — a respawn with the intent still
- *     present would trigger an infinite restart loop.
- *   - `[update]`: invoke `installUpdate` THEN clear on success.
- *     Retain on failure so the next tick can retry. If the target
- *     version already matches the running daemon, clear without
- *     invoking the installer.
+ * Continuously enforces `pid alive ⇔ daemon.json exists` and drains
+ * intent.toml. Two intent kinds with deliberately asymmetric clear
+ * semantics:
+ *   - `[restart]`: clear BEFORE invoking — load-bearing. A respawn
+ *     that observes the intent before it's cleared would trigger an
+ *     infinite restart loop.
+ *   - `[update]`: clear ONLY on installer success. Retain on failure
+ *     so the next tick retries (installs are flaky).
  */
 export async function reconcileSelf(deps: ReconcileSelfDeps): Promise<void> {
   const expected = deps.currentState();
   const observed = readDaemonState(deps.daemonService.statePath);
-  if (observed && observed.pid === expected.pid && observed.port === expected.port) {
-    // File is correct in shape; refresh atime/mtime via re-write so the
-    // freshness window stays open for sibling reconciliation paths
-    // that read mtime to decide whether the file is fresh enough to
-    // trust.
-    writeDaemonState(deps.daemonService.statePath, expected);
-  } else {
-    // File missing or pointing elsewhere. The live process IS the source
-    // of truth; the file is its projection. Re-write authoritatively and
-    // log the discrepancy so externally-induced drift is visible.
+  if (!observed || observed.pid !== expected.pid || observed.port !== expected.port) {
     deps.logger.info(LOG_KINDS.DAEMON_RECONCILE, 'Re-asserting daemon.json from live state', {
       had_file: observed !== null,
       state_path: deps.daemonService.statePath,
@@ -79,25 +38,18 @@ export async function reconcileSelf(deps: ReconcileSelfDeps): Promise<void> {
       expected_port: expected.port,
       observed_port: observed?.port ?? null,
     });
-    writeDaemonState(deps.daemonService.statePath, expected);
   }
+  // Always re-write to refresh mtime; siblings consult mtime via
+  // DAEMON_STALE_GRACE_PERIOD_MS to decide whether the file is fresh.
+  writeDaemonState(deps.daemonService.statePath, expected);
 
-  // Intent consumption. Read whatever sections are present and act on
-  // each. The file is small and read-once per tick; no caching needed.
   const intent = readIntent(deps.daemonService);
   if (intent.restart) {
     deps.logger.info(
       LOG_KINDS.DAEMON_RECONCILE,
       'Restart intent observed; initiating supervisor restart',
-      {
-        requested_at: intent.restart.requested_at,
-        reason: intent.restart.reason ?? null,
-      },
+      { requested_at: intent.restart.requested_at, reason: intent.restart.reason ?? null },
     );
-    // Clear the section BEFORE triggering restart so a respawn loop
-    // doesn't reapply the same intent. The supervisor SIGTERMs us
-    // synchronously-ish; if we cleared after triggering, a fast
-    // respawn could read the same intent again.
     clearIntentSection(deps.daemonService, 'restart');
     deps.requestSupervisorRestart?.();
   }
@@ -105,9 +57,6 @@ export async function reconcileSelf(deps: ReconcileSelfDeps): Promise<void> {
   if (intent.update) {
     const current = deps.currentState().version;
     if (intent.update.target_version === current) {
-      // Already at the requested version — the daemon was likely
-      // restarted into the target binary but the intent file wasn't
-      // cleared. Clean up so we don't re-evaluate forever.
       deps.logger.info(
         LOG_KINDS.DAEMON_RECONCILE,
         'Update intent target matches current version; clearing',
@@ -121,18 +70,12 @@ export async function reconcileSelf(deps: ReconcileSelfDeps): Promise<void> {
       });
       try {
         await deps.installUpdate(intent.update.target_version);
-        // Clear AFTER success — installs can fail (network, npm); the
-        // retained intent lets the next tick retry without re-issuing
-        // the CLI command.
         clearIntentSection(deps.daemonService, 'update');
       } catch (err) {
         deps.logger.error(
           LOG_KINDS.DAEMON_RECONCILE,
           'Update failed; intent retained for retry',
-          {
-            target_version: intent.update.target_version,
-            err: String(err),
-          },
+          { target_version: intent.update.target_version, err: String(err) },
         );
       }
     }

--- a/packages/myco/src/daemon/self-reconcile.ts
+++ b/packages/myco/src/daemon/self-reconcile.ts
@@ -1,0 +1,52 @@
+import type { DaemonLogger } from './logger.js';
+import { LOG_KINDS } from '../constants/log-kinds.js';
+import {
+  readDaemonState,
+  writeDaemonState,
+  type DaemonServiceState,
+  type DaemonState,
+} from './service-state.js';
+
+export interface ReconcileSelfDeps {
+  daemonService: DaemonServiceState;
+  currentState: () => DaemonState;
+  logger: DaemonLogger;
+}
+
+/**
+ * Continuously-enforced invariant: if THIS process is alive and serving
+ * on its variant's canonical port, daemon.json for that variant must
+ * exist and accurately describe this process. Called from the
+ * PowerManager reconcile tick (every active/idle/sleep tick) so the
+ * `pid alive ⇔ daemon.json exists` invariant is no longer just a
+ * startup guarantee — anything that nukes the file externally is
+ * re-asserted within one tick.
+ *
+ * Idempotent: when the file already matches expected state, the
+ * re-write only refreshes mtime, which keeps the freshness window
+ * `reconcileExistingDaemon` consults for siblings accurate.
+ */
+export function reconcileSelf(deps: ReconcileSelfDeps): void {
+  const expected = deps.currentState();
+  const observed = readDaemonState(deps.daemonService.statePath);
+  if (observed && observed.pid === expected.pid && observed.port === expected.port) {
+    // File is correct in shape; refresh atime/mtime via re-write so the
+    // freshness window stays open for sibling reconciliation paths
+    // that read mtime to decide whether the file is fresh enough to
+    // trust.
+    writeDaemonState(deps.daemonService.statePath, expected);
+    return;
+  }
+  // File missing or pointing elsewhere. The live process IS the source
+  // of truth; the file is its projection. Re-write authoritatively and
+  // log the discrepancy so externally-induced drift is visible.
+  deps.logger.info(LOG_KINDS.DAEMON_RECONCILE, 'Re-asserting daemon.json from live state', {
+    had_file: observed !== null,
+    state_path: deps.daemonService.statePath,
+    expected_pid: expected.pid,
+    observed_pid: observed?.pid ?? null,
+    expected_port: expected.port,
+    observed_port: observed?.port ?? null,
+  });
+  writeDaemonState(deps.daemonService.statePath, expected);
+}

--- a/packages/myco/src/daemon/self-reconcile.ts
+++ b/packages/myco/src/daemon/self-reconcile.ts
@@ -6,11 +6,19 @@ import {
   type DaemonServiceState,
   type DaemonState,
 } from './service-state.js';
+import { readIntent, clearIntentSection } from './intent.js';
 
 export interface ReconcileSelfDeps {
   daemonService: DaemonServiceState;
   currentState: () => DaemonState;
   logger: DaemonLogger;
+  /**
+   * Invoked when a restart intent is observed and after the intent
+   * section has been cleared. Optional so unit tests can omit it (or
+   * pass a spy). In production this fans out to `launchctl kickstart`
+   * or `systemctl --user restart` via `power-jobs.ts`.
+   */
+  requestSupervisorRestart?: () => void;
 }
 
 /**
@@ -25,6 +33,12 @@ export interface ReconcileSelfDeps {
  * Idempotent: when the file already matches expected state, the
  * re-write only refreshes mtime, which keeps the freshness window
  * `reconcileExistingDaemon` consults for siblings accurate.
+ *
+ * Also consumes the intent file (`intent.toml`) — any `[restart]`
+ * section is cleared and the supervisor restart is requested. The
+ * clear-before-act ordering is load-bearing: if the supervisor
+ * respawns us with the intent still present, the next tick would
+ * read it again and trigger an infinite restart loop.
  */
 export function reconcileSelf(deps: ReconcileSelfDeps): void {
   const expected = deps.currentState();
@@ -35,18 +49,38 @@ export function reconcileSelf(deps: ReconcileSelfDeps): void {
     // that read mtime to decide whether the file is fresh enough to
     // trust.
     writeDaemonState(deps.daemonService.statePath, expected);
-    return;
+  } else {
+    // File missing or pointing elsewhere. The live process IS the source
+    // of truth; the file is its projection. Re-write authoritatively and
+    // log the discrepancy so externally-induced drift is visible.
+    deps.logger.info(LOG_KINDS.DAEMON_RECONCILE, 'Re-asserting daemon.json from live state', {
+      had_file: observed !== null,
+      state_path: deps.daemonService.statePath,
+      expected_pid: expected.pid,
+      observed_pid: observed?.pid ?? null,
+      expected_port: expected.port,
+      observed_port: observed?.port ?? null,
+    });
+    writeDaemonState(deps.daemonService.statePath, expected);
   }
-  // File missing or pointing elsewhere. The live process IS the source
-  // of truth; the file is its projection. Re-write authoritatively and
-  // log the discrepancy so externally-induced drift is visible.
-  deps.logger.info(LOG_KINDS.DAEMON_RECONCILE, 'Re-asserting daemon.json from live state', {
-    had_file: observed !== null,
-    state_path: deps.daemonService.statePath,
-    expected_pid: expected.pid,
-    observed_pid: observed?.pid ?? null,
-    expected_port: expected.port,
-    observed_port: observed?.port ?? null,
-  });
-  writeDaemonState(deps.daemonService.statePath, expected);
+
+  // Intent consumption. Read whatever sections are present and act on
+  // each. The file is small and read-once per tick; no caching needed.
+  const intent = readIntent(deps.daemonService);
+  if (intent.restart) {
+    deps.logger.info(
+      LOG_KINDS.DAEMON_RECONCILE,
+      'Restart intent observed; initiating supervisor restart',
+      {
+        requested_at: intent.restart.requested_at,
+        reason: intent.restart.reason ?? null,
+      },
+    );
+    // Clear the section BEFORE triggering restart so a respawn loop
+    // doesn't reapply the same intent. The supervisor SIGTERMs us
+    // synchronously-ish; if we cleared after triggering, a fast
+    // respawn could read the same intent again.
+    clearIntentSection(deps.daemonService, 'restart');
+    deps.requestSupervisorRestart?.();
+  }
 }

--- a/packages/myco/src/daemon/server.ts
+++ b/packages/myco/src/daemon/server.ts
@@ -91,14 +91,8 @@ export class DaemonServer {
    * that didn't inherit the env) can recover it.
    */
   private authToken: string;
-  /**
-   * ISO timestamp of the moment listen() resolved (this daemon's
-   * effective birth). Captured once so `currentDaemonState()` can
-   * return a stable `started` value across reconcile ticks; without
-   * this the re-asserted file would have a fresh `started` every
-   * tick and downstream consumers that compare uptime against the
-   * recorded value would see jitter.
-   */
+  // Captured once at listen() so currentDaemonState() returns a stable
+  // `started` across reconcile re-writes (otherwise uptime jitters).
   private startedAt: string | null = null;
   /**
    * Cache of post-injection dashboard HTML, keyed by source file path.
@@ -184,14 +178,7 @@ export class DaemonServer {
   }
 
   async stop(): Promise<void> {
-    // Cleanup ownership inversion: we do NOT call removeDaemonJson() here.
-    // If we unlinked first and gracefullyCloseHttpServer then hung (wedged
-    // background loop, deadlocked shutdown handler, etc.), we would leave a
-    // live process with no discoverable state file — the orphan-zombie
-    // failure mode the self-mutation-discipline tenet prohibits. Cleanup of
-    // daemon.json is owned by the successor process's reconcileExistingDaemon
-    // path, which only removes the file after confirming the recorded pid is
-    // actually dead.
+    // No daemon.json unlink — see reconcileExistingDaemon for cleanup ownership.
     if (!this.server) {
       this.closeRequestDatabases();
       return;

--- a/packages/myco/src/daemon/server.ts
+++ b/packages/myco/src/daemon/server.ts
@@ -17,7 +17,7 @@ import {
 } from '../tools/request-context.js';
 import { isProjectPaused } from '../grove/registry.js';
 import { pausedErrorResponse } from './api/error-envelope.js';
-import { readDaemonState, removeDaemonState, writeDaemonState } from './service-state.js';
+import { readDaemonState, writeDaemonState } from './service-state.js';
 import { vaultDbPath, withDatabase, type Database } from '../db/client.js';
 import { GroveRuntimeCache } from './grove-runtime-cache.js';
 
@@ -154,7 +154,14 @@ export class DaemonServer {
   }
 
   async stop(): Promise<void> {
-    this.removeDaemonJson();
+    // Cleanup ownership inversion: we do NOT call removeDaemonJson() here.
+    // If we unlinked first and gracefullyCloseHttpServer then hung (wedged
+    // background loop, deadlocked shutdown handler, etc.), we would leave a
+    // live process with no discoverable state file — the orphan-zombie
+    // failure mode the self-mutation-discipline tenet prohibits. Cleanup of
+    // daemon.json is owned by the successor process's reconcileExistingDaemon
+    // path, which only removes the file after confirming the recorded pid is
+    // actually dead.
     if (!this.server) {
       this.closeRequestDatabases();
       return;
@@ -532,10 +539,6 @@ export class DaemonServer {
       auth_token: this.authToken,
     };
     writeDaemonState(this.daemonStatePath, info);
-  }
-
-  private removeDaemonJson(): void {
-    removeDaemonState(this.daemonStatePath, process.pid);
   }
 }
 

--- a/packages/myco/src/daemon/server.ts
+++ b/packages/myco/src/daemon/server.ts
@@ -17,7 +17,7 @@ import {
 } from '../tools/request-context.js';
 import { isProjectPaused } from '../grove/registry.js';
 import { pausedErrorResponse } from './api/error-envelope.js';
-import { readDaemonState, writeDaemonState } from './service-state.js';
+import { readDaemonState, writeDaemonState, type DaemonState } from './service-state.js';
 import { vaultDbPath, withDatabase, type Database } from '../db/client.js';
 import { GroveRuntimeCache } from './grove-runtime-cache.js';
 
@@ -92,6 +92,15 @@ export class DaemonServer {
    */
   private authToken: string;
   /**
+   * ISO timestamp of the moment listen() resolved (this daemon's
+   * effective birth). Captured once so `currentDaemonState()` can
+   * return a stable `started` value across reconcile ticks; without
+   * this the re-asserted file would have a fresh `started` every
+   * tick and downstream consumers that compare uptime against the
+   * recorded value would see jitter.
+   */
+  private startedAt: string | null = null;
+  /**
    * Cache of post-injection dashboard HTML, keyed by source file path.
    * The token is fixed for the daemon's lifetime and the built HTML is
    * immutable, so reading + injecting on every request is wasted work.
@@ -121,6 +130,26 @@ export class DaemonServer {
     return this.authToken;
   }
 
+  /**
+   * Live snapshot of what daemon.json *should* contain for this
+   * process. Used by `reconcileSelf` to re-assert the state file
+   * against the in-memory truth on every PowerManager tick. The
+   * `started` field reflects when this daemon began listening, not
+   * when the snapshot was taken, so the file's `started` is stable
+   * across re-assertions.
+   */
+  currentDaemonState(): DaemonState {
+    return {
+      pid: process.pid,
+      port: this.port,
+      command: process.execPath,
+      started: this.startedAt ?? new Date().toISOString(),
+      sessions: [],
+      version: this.version,
+      auth_token: this.authToken,
+    };
+  }
+
   registerRoute(method: string, routePath: string, handler: RouteHandler): void {
     this.router.add(method, routePath, handler);
   }
@@ -146,6 +175,7 @@ export class DaemonServer {
       this.server.listen(port, '127.0.0.1', HTTP_LISTEN_BACKLOG, () => {
         const addr = this.server!.address() as { port: number };
         this.port = addr.port;
+        this.startedAt = new Date().toISOString();
         this.writeDaemonJson();
         this.logger.info(LOG_KINDS.DAEMON_PORT, 'Server started', { port: this.port, dashboard: `http://localhost:${this.port}/` });
         resolve();
@@ -529,16 +559,7 @@ export class DaemonServer {
   }
 
   private writeDaemonJson(): void {
-    const info = {
-      pid: process.pid,
-      port: this.port,
-      command: process.execPath,
-      started: new Date().toISOString(),
-      sessions: [] as string[],
-      version: this.version,
-      auth_token: this.authToken,
-    };
-    writeDaemonState(this.daemonStatePath, info);
+    writeDaemonState(this.daemonStatePath, this.currentDaemonState());
   }
 }
 

--- a/packages/myco/src/daemon/service-state.ts
+++ b/packages/myco/src/daemon/service-state.ts
@@ -7,6 +7,7 @@ import {
   resolveServiceDir,
 } from '@myco/grove/paths.js';
 import type { MycoRequestContext } from '@myco/tools/request-context.js';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { derivePort } from './port.js';
 
 export class GroveBindingRequiredError extends Error {
@@ -113,15 +114,12 @@ export function readDaemonPort(vaultDir: string, options: ResolveDaemonServiceSt
 
 export function writeDaemonState(statePath: string, state: DaemonState): void {
   fs.mkdirSync(path.dirname(statePath), { recursive: true });
-  // 0o600 because daemon.json now carries the daemon-issued bearer
-  // token (G4); leaking it would let other local users redirect
-  // context-switching requests at any registered Grove.
-  fs.writeFileSync(statePath, JSON.stringify(state, null, 2), { mode: 0o600 });
-  try {
-    fs.chmodSync(statePath, 0o600);
-  } catch {
-    // Best-effort; non-POSIX filesystems and read-only mounts.
-  }
+  // 0o600 because daemon.json carries the daemon-issued bearer token
+  // (G4); leaking it would let other local users redirect
+  // context-switching requests at any registered Grove. The atomic
+  // helper applies the mode to the tempfile before rename so the final
+  // path is never briefly readable at the default umask.
+  atomicWriteFileSync(statePath, JSON.stringify(state, null, 2), { mode: 0o600 });
 }
 
 export function removeDaemonState(statePath: string, ownerPid?: number): void {

--- a/packages/myco/src/grove/claim.ts
+++ b/packages/myco/src/grove/claim.ts
@@ -775,12 +775,20 @@ export function releaseClaimedGrove(
       writeManifest(open.manifestPath, manifest);
     }
 
+    // Archive phase: the rename relocates the manifest itself. Checkpoint
+    // first so a crash mid-rename leaves the manifest flagged 'archived';
+    // resume below completes the rename even when 'archived' is already set
+    // (handles the "checkpointed but didn't rename" crash window).
+    const archiveRoot = groveArchiveDir(backupsRoot, grove.slug);
+    const archiveTarget = path.join(archiveRoot, path.basename(open.claimRoot));
     if (manifest.release_phase !== 'archived') {
-      const archiveRoot = groveArchiveDir(backupsRoot, grove.slug);
       fs.mkdirSync(archiveRoot, { recursive: true });
-      const archiveTarget = path.join(archiveRoot, path.basename(open.claimRoot));
       manifest = { ...manifest, release_phase: 'archived' };
       writeManifest(open.manifestPath, manifest);
+    }
+
+    if (fs.existsSync(open.claimRoot)) {
+      fs.mkdirSync(archiveRoot, { recursive: true });
       try {
         fs.renameSync(open.claimRoot, archiveTarget);
       } catch (err) {
@@ -790,24 +798,16 @@ export function releaseClaimedGrove(
           throw err;
         }
       }
-      const cutoffMs = Date.now() - ARCHIVE_RETENTION_DAYS * 86_400_000;
-      pruneArchivesOlderThan(archiveRoot, cutoffMs);
-
-      const refreshed = loadGroveRecord(grove.id, mycoHome) ?? grove;
-      return {
-        grove: refreshed,
-        manifest,
-        manifest_path: path.join(archiveTarget, MANIFEST_FILENAME),
-        archive_dir: archiveTarget,
-      };
     }
+    const cutoffMs = Date.now() - ARCHIVE_RETENTION_DAYS * 86_400_000;
+    pruneArchivesOlderThan(archiveRoot, cutoffMs);
 
     const refreshed = loadGroveRecord(grove.id, mycoHome) ?? grove;
     return {
       grove: refreshed,
       manifest,
-      manifest_path: open.manifestPath,
-      archive_dir: open.claimRoot,
+      manifest_path: path.join(archiveTarget, MANIFEST_FILENAME),
+      archive_dir: archiveTarget,
     };
   } finally {
     for (const { groveId: gid, projectId: pid } of pausedProjects) {

--- a/packages/myco/src/hooks/client.ts
+++ b/packages/myco/src/hooks/client.ts
@@ -25,7 +25,6 @@ import {
 import {
   daemonStateMtimeMs,
   readDaemonState,
-  removeDaemonState,
   resolveDaemonServiceState,
   type DaemonServiceState,
 } from '../daemon/service-state.js';
@@ -366,13 +365,22 @@ export class DaemonClient {
 
   /**
    * Kill the running daemon process.
+   *
+   * Cleanup ownership inversion: we never unlink daemon.json here. If we did,
+   * a wedged daemon that hangs on SIGTERM would be left running with no
+   * discoverable state file — the orphan-zombie failure that motivates the
+   * self-mutation-discipline tenet. Cleanup is owned exclusively by the
+   * successor process's `reconcileExistingDaemon` path, which only removes
+   * daemon.json after confirming the recorded pid is actually dead.
    */
   private killDaemon(info: DaemonInfo | null): void {
+    if (!info) return;
     try {
-      if (!info) return;
       process.kill(info.pid, 'SIGTERM');
-    } catch { /* already dead */ }
-    removeDaemonState(this.daemonService.statePath);
+    } catch {
+      // Already dead — the successor's reconcileExistingDaemon will clean
+      // up the stale state file. We never unlink here.
+    }
   }
 
   /**
@@ -451,9 +459,11 @@ export class DaemonClient {
     const prevPid = prevInfo?.pid;
     const prevPort = prevInfo?.port;
 
-    // Initiate the bounce. killDaemon issues SIGTERM and clears daemon.json;
-    // spawnDaemon (or the service supervisor's KeepAlive) brings a fresh
-    // daemon up.
+    // Initiate the bounce. killDaemon issues SIGTERM but never unlinks
+    // daemon.json — the successor's reconcileExistingDaemon owns state-file
+    // cleanup once the recorded pid is confirmed dead. spawnDaemon (or the
+    // service supervisor's KeepAlive) brings a fresh daemon up, which
+    // overwrites daemon.json with its own pid as part of normal startup.
     this.killDaemon(prevInfo);
     // Kick the spawn / supervisor start without blocking on retry delays —
     // the unified poll loop below is the single source of truth for the

--- a/packages/myco/src/hooks/client.ts
+++ b/packages/myco/src/hooks/client.ts
@@ -28,10 +28,10 @@ import {
   resolveDaemonServiceState,
   type DaemonServiceState,
 } from '../daemon/service-state.js';
-import { SERVICE_DEV_DIRNAME } from '../grove/paths.js';
 import { findInstalledServiceLabel } from '../daemon/api/restart.js';
 import { getServiceManager } from '../service/manager.js';
-import type { ServiceManager, ServiceVariant } from '../service/types.js';
+import { serviceVariantForState } from '../service/labels.js';
+import type { ServiceManager } from '../service/types.js';
 
 export interface DaemonInfo {
   pid: number;
@@ -130,10 +130,6 @@ function defaultIsPortBound(port: number, pid: number): boolean {
   } catch {
     return false;
   }
-}
-
-function serviceVariantForState(state: DaemonServiceState): ServiceVariant {
-  return path.basename(state.stateDir) === SERVICE_DEV_DIRNAME ? 'dev' : 'prod';
 }
 
 /**

--- a/packages/myco/src/hooks/client.ts
+++ b/packages/myco/src/hooks/client.ts
@@ -420,6 +420,45 @@ export class DaemonClient {
     return this.readDaemonJson();
   }
 
+  /**
+   * Async sibling of `getInfo()` that falls back to a `/health` probe
+   * on the canonical port when daemon.json is missing or stale. The
+   * sync `getInfo()` returns null in that case, which loses sight of a
+   * healthy daemon any time the state file is externally nuked between
+   * its write and the daemon's next self-reconcile tick.
+   *
+   * The reconstructed `DaemonInfo` omits `auth_token` because /health
+   * deliberately doesn't expose it. Callers that need the bearer
+   * (context-switching requests) must wait for the daemon's next
+   * self-reconcile tick to re-write daemon.json.
+   */
+  async getInfoAsync(): Promise<DaemonInfo | null> {
+    const direct = this.readDaemonJson();
+    if (direct) return direct;
+    return this.discoverViaHealth();
+  }
+
+  /**
+   * Probe `/health` on the variant's canonical port. Used as a
+   * last-resort discovery path when daemon.json is missing. Returns
+   * null on any failure — a missing or non-Myco response is
+   * indistinguishable from "no daemon" for caller purposes.
+   */
+  private async discoverViaHealth(): Promise<DaemonInfo | null> {
+    const port = this.daemonService.canonicalPort;
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/health`, {
+        signal: AbortSignal.timeout(DAEMON_HEALTH_CHECK_TIMEOUT_MS),
+      });
+      if (!res.ok) return null;
+      const data = await res.json() as { myco?: boolean; version?: string; pid?: number };
+      if (data.myco !== true || typeof data.pid !== 'number') return null;
+      return { pid: data.pid, port };
+    } catch {
+      return null;
+    }
+  }
+
   private requestHeaders(headers?: Record<string, string>): Record<string, string> | undefined {
     if (Object.keys(this.defaultHeaders).length === 0) return headers;
     return { ...this.defaultHeaders, ...(headers ?? {}) };

--- a/packages/myco/src/hooks/client.ts
+++ b/packages/myco/src/hooks/client.ts
@@ -359,24 +359,13 @@ export class DaemonClient {
     }
   }
 
-  /**
-   * Kill the running daemon process.
-   *
-   * Cleanup ownership inversion: we never unlink daemon.json here. If we did,
-   * a wedged daemon that hangs on SIGTERM would be left running with no
-   * discoverable state file — the orphan-zombie failure that motivates the
-   * self-mutation-discipline tenet. Cleanup is owned exclusively by the
-   * successor process's `reconcileExistingDaemon` path, which only removes
-   * daemon.json after confirming the recorded pid is actually dead.
-   */
+  // SIGTERM only. Never unlinks daemon.json — see reconcileExistingDaemon
+  // for the cleanup-ownership-inversion rationale (the canonical comment).
   private killDaemon(info: DaemonInfo | null): void {
     if (!info) return;
     try {
       process.kill(info.pid, 'SIGTERM');
-    } catch {
-      // Already dead — the successor's reconcileExistingDaemon will clean
-      // up the stale state file. We never unlink here.
-    }
+    } catch { /* already dead */ }
   }
 
   /**

--- a/packages/myco/src/service/labels.ts
+++ b/packages/myco/src/service/labels.ts
@@ -1,5 +1,7 @@
+import path from 'node:path';
 import type { ServiceVariant } from './types.js';
 import { isDevServiceMode, SERVICE_DIRNAME, SERVICE_DEV_DIRNAME } from '../grove/paths.js';
+import type { DaemonServiceState } from '../daemon/service-state.js';
 
 /** Stable launchd/systemd label for the production daemon. */
 export const SERVICE_LABEL_PROD = 'co.goondocks.myco';
@@ -17,4 +19,13 @@ export function detectInstallVariant(): ServiceVariant {
 
 export function serviceVariantToDirName(variant: ServiceVariant): typeof SERVICE_DIRNAME | typeof SERVICE_DEV_DIRNAME {
   return variant === 'dev' ? SERVICE_DEV_DIRNAME : SERVICE_DIRNAME;
+}
+
+/**
+ * Derive the service variant ('dev' | 'prod') from a resolved
+ * `DaemonServiceState`. The variant is encoded in the state dir name:
+ * `service-dev/` for contributor dogfood, `service/` for production.
+ */
+export function serviceVariantForState(state: DaemonServiceState): ServiceVariant {
+  return path.basename(state.stateDir) === SERVICE_DEV_DIRNAME ? 'dev' : 'prod';
 }

--- a/packages/myco/src/service/launchd.ts
+++ b/packages/myco/src/service/launchd.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { renderLaunchdPlist } from './launchd-plist.js';
 import type { ServiceManager, ServiceSpec, ServiceStatus } from './types.js';
 
@@ -69,7 +70,7 @@ export class LaunchdServiceManager implements ServiceManager {
     fs.mkdirSync(this.agentsDir, { recursive: true });
     fs.mkdirSync(path.dirname(spec.stdoutPath), { recursive: true });
     fs.mkdirSync(path.dirname(spec.stderrPath), { recursive: true });
-    fs.writeFileSync(plistPath, rendered);
+    atomicWriteFileSync(plistPath, rendered);
 
     await this.runner.run(['bootstrap', `gui/${this.uid}`, plistPath]);
     await this.runner.run(['enable', this.domainTarget(spec.label)]);

--- a/packages/myco/src/service/systemd.ts
+++ b/packages/myco/src/service/systemd.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { renderSystemdUnit } from './systemd-unit.js';
 import type { ServiceManager, ServiceSpec, ServiceStatus } from './types.js';
 
@@ -55,7 +56,7 @@ export class SystemdUserServiceManager implements ServiceManager {
     fs.mkdirSync(this.unitDir, { recursive: true });
     fs.mkdirSync(path.dirname(spec.stdoutPath), { recursive: true });
     fs.mkdirSync(path.dirname(spec.stderrPath), { recursive: true });
-    fs.writeFileSync(unitPath, rendered);
+    atomicWriteFileSync(unitPath, rendered);
 
     await this.runner.run(['--user', 'daemon-reload']);
     await this.runner.run(['--user', 'enable', `${spec.label}.service`]);

--- a/packages/myco/src/utils/atomic-write.ts
+++ b/packages/myco/src/utils/atomic-write.ts
@@ -1,21 +1,68 @@
 import fs from 'node:fs';
 
+export interface AtomicWriteOptions {
+  encoding?: BufferEncoding;
+  /**
+   * POSIX file mode (e.g. 0o600) to apply to the tempfile before it is
+   * renamed into place. Without this, the tempfile is briefly visible at
+   * the default umask (typically 0o644) — a leak window for files that
+   * carry secrets (daemon bearer token, API keys). When set, the
+   * tempfile is created with the mode AND chmod'd before rename to
+   * defeat umask masking on the create call.
+   */
+  mode?: number;
+}
+
 /**
  * Write a file via temp+rename so readers either see the prior valid
  * contents or the new contents — never a torn write. Required for any
  * file that backs a recoverable on-disk state machine (registry,
  * markers, manifests).
+ *
+ * The third argument is either a `BufferEncoding` string (legacy form,
+ * equivalent to `{ encoding }`) or an options object. Mode preservation
+ * (`{ mode }`) is opt-in because most callers don't need owner-only
+ * permissions and would pay a redundant chmodSync syscall.
  */
 export function atomicWriteFileSync(
   filePath: string,
   contents: string | Buffer,
-  encoding: BufferEncoding = 'utf-8',
+  encodingOrOptions: BufferEncoding | AtomicWriteOptions = 'utf-8',
 ): void {
+  const options: AtomicWriteOptions = typeof encodingOrOptions === 'string'
+    ? { encoding: encodingOrOptions }
+    : encodingOrOptions;
+  const encoding: BufferEncoding = options.encoding ?? 'utf-8';
+  const { mode } = options;
+
   const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
   if (typeof contents === 'string') {
-    fs.writeFileSync(tmp, contents, encoding);
+    fs.writeFileSync(tmp, contents, mode !== undefined ? { encoding, mode } : encoding);
   } else {
-    fs.writeFileSync(tmp, contents);
+    fs.writeFileSync(tmp, contents, mode !== undefined ? { mode } : undefined);
   }
-  fs.renameSync(tmp, filePath);
+  if (mode !== undefined) {
+    try {
+      // Defeat umask: writeFileSync's `mode` is masked by the process
+      // umask on create. An explicit chmod on the tempfile guarantees
+      // the mode lands before rename exposes the final path.
+      fs.chmodSync(tmp, mode);
+    } catch {
+      // Best-effort; non-POSIX filesystems (Windows) ignore POSIX modes.
+    }
+  }
+  try {
+    fs.renameSync(tmp, filePath);
+  } catch (err) {
+    // Rename failed (cross-device, EBUSY on Windows, ENOSPC, etc.).
+    // Clean up the tempfile rather than leaving stale — possibly
+    // secret-bearing — data at a predictable `.tmp-<pid>-<ts>` path
+    // for a future read by the same user to harvest.
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      // Best-effort; a Windows EBUSY on rename may also block unlink.
+    }
+    throw err;
+  }
 }

--- a/tests/cli/restart-intent.test.ts
+++ b/tests/cli/restart-intent.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { vi } from '../helpers/vi-shim.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { parse as parseToml } from 'smol-toml';
+
+// Stub the DaemonClient: getInfoAsync is the only call the CLI makes
+// before deciding whether to write the intent. The shared mutable
+// state lets each test control "what does the CLI see for the
+// current daemon" and "what does the CLI see during the polling
+// loop". Without this, the real DaemonClient would try to read a
+// non-existent daemon.json and hit the 37s spawn/retry path the
+// vault memory warns about.
+const { fakeDaemon } = vi.hoisted(() => {
+  const fakeDaemon: {
+    before: { pid: number; port: number } | null;
+    pollResponses: ({ pid: number; port: number } | null)[];
+  } = {
+    before: null,
+    pollResponses: [],
+  };
+  return { fakeDaemon };
+});
+
+mock.module('@myco/hooks/client.js', () => ({
+  DaemonClient: class {
+    constructor(_vaultDir: string) {}
+    async getInfoAsync() {
+      // First call serves `before`; subsequent calls drain
+      // `pollResponses`. When the queue is empty the loop sees null
+      // (treated as "still restarting") until the deadline.
+      if (this._beforeServed === false) {
+        this._beforeServed = true;
+        return fakeDaemon.before;
+      }
+      return fakeDaemon.pollResponses.shift() ?? null;
+    }
+    private _beforeServed = false;
+  },
+}));
+
+// Pin MYCO_HOME inside the test temp dir so resolveDaemonServiceState
+// drops intent.toml under our fixture instead of ~/.myco.
+import { run } from '@myco/cli/restart.js';
+
+describe('myco restart writes intent', () => {
+  let testDir: string;
+  let vault: string;
+  let serviceDir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-restart-intent-'));
+    vault = path.join(testDir, '.myco');
+    fs.mkdirSync(vault, { recursive: true });
+
+    originalHome = process.env.MYCO_HOME;
+    process.env.MYCO_HOME = path.join(testDir, '.home');
+    serviceDir = path.join(process.env.MYCO_HOME, 'service');
+    fs.mkdirSync(serviceDir, { recursive: true });
+
+    fakeDaemon.before = null;
+    fakeDaemon.pollResponses = [];
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.MYCO_HOME;
+    else process.env.MYCO_HOME = originalHome;
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('writes a [restart] section to intent.toml and converges on a new pid', async () => {
+    fakeDaemon.before = { pid: 11111, port: 20915 };
+    // First poll: still old pid (shouldn't happen, but defensive).
+    // Second poll: new pid → CLI returns.
+    fakeDaemon.pollResponses = [
+      null, // gap during SIGTERM/respawn
+      { pid: 22222, port: 20915 },
+    ];
+
+    await run([], vault);
+
+    const intentPath = path.join(serviceDir, 'intent.toml');
+    expect(fs.existsSync(intentPath)).toBe(true);
+    const parsed = parseToml(fs.readFileSync(intentPath, 'utf-8')) as {
+      restart?: { requested_at: string; reason?: string };
+    };
+    expect(parsed.restart).toBeDefined();
+    expect(parsed.restart!.reason).toBe('cli');
+    // ISO8601 timestamp shape
+    expect(parsed.restart!.requested_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('does NOT write intent when no daemon is discovered', async () => {
+    fakeDaemon.before = null;
+    fakeDaemon.pollResponses = [];
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+      throw new Error('__exit__');
+    }) as never);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(run([], vault)).rejects.toThrow('__exit__');
+
+    const intentPath = path.join(serviceDir, 'intent.toml');
+    expect(fs.existsSync(intentPath)).toBe(false);
+
+    exitSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it('treats null poll responses as "still restarting" (no early exit)', async () => {
+    fakeDaemon.before = { pid: 11111, port: 20915 };
+    // Several nulls in a row, then convergence — proves the loop
+    // doesn't bail on the first null.
+    fakeDaemon.pollResponses = [
+      null,
+      null,
+      null,
+      { pid: 33333, port: 20915 },
+    ];
+
+    await run([], vault);
+
+    const intentPath = path.join(serviceDir, 'intent.toml');
+    expect(fs.existsSync(intentPath)).toBe(true);
+  });
+});

--- a/tests/cli/update-intent.test.ts
+++ b/tests/cli/update-intent.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { vi } from '../helpers/vi-shim.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { parse as parseToml } from 'smol-toml';
+
+// Stub DaemonClient.getInfoAsync — the only call --target-version makes
+// before deciding whether to write an intent. Without this the real
+// client would try to bring up a daemon against the temp vault dir.
+const { fakeDaemon } = vi.hoisted(() => {
+  const fakeDaemon: { info: { pid: number; port: number } | null } = {
+    info: null,
+  };
+  return { fakeDaemon };
+});
+
+mock.module('@myco/hooks/client.js', () => ({
+  DaemonClient: class {
+    constructor(_vaultDir: string) {}
+    async getInfoAsync() { return fakeDaemon.info; }
+  },
+}));
+
+function writeDaemonJson(serviceDir: string, version: string) {
+  fs.writeFileSync(
+    path.join(serviceDir, 'daemon.json'),
+    JSON.stringify({ pid: 12345, port: 20915, version, started: new Date().toISOString() }),
+  );
+}
+
+import { run } from '@myco/cli/update.js';
+
+describe('myco update --target-version writes intent', () => {
+  let testDir: string;
+  let vault: string;
+  let serviceDir: string;
+  let originalHome: string | undefined;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-update-intent-'));
+    vault = path.join(testDir, '.myco');
+    fs.mkdirSync(vault, { recursive: true });
+    // resolveVaultDir() climbs from cwd looking for .myco/. Setting cwd
+    // into testDir lets it pick up our fixture vault without forcing
+    // every call site to thread an explicit vaultDir.
+    originalCwd = process.cwd();
+    process.chdir(testDir);
+    // Seed myco.yaml so resolveVaultDir's existence check passes.
+    fs.writeFileSync(path.join(vault, 'myco.yaml'), 'engine: claude\n');
+
+    originalHome = process.env.MYCO_HOME;
+    process.env.MYCO_HOME = path.join(testDir, '.home');
+    serviceDir = path.join(process.env.MYCO_HOME, 'service');
+    fs.mkdirSync(serviceDir, { recursive: true });
+
+    fakeDaemon.info = null;
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (originalHome === undefined) delete process.env.MYCO_HOME;
+    else process.env.MYCO_HOME = originalHome;
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('writes a [update] section with target_version when daemon is on a different version', async () => {
+    fakeDaemon.info = { pid: 12345, port: 20915 };
+    writeDaemonJson(serviceDir, '0.27.10');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await run(['--target-version', '0.27.99']);
+
+    const intentPath = path.join(serviceDir, 'intent.toml');
+    expect(fs.existsSync(intentPath)).toBe(true);
+    const parsed = parseToml(fs.readFileSync(intentPath, 'utf-8')) as {
+      update?: { target_version: string; requested_at: string };
+    };
+    expect(parsed.update).toBeDefined();
+    expect(parsed.update!.target_version).toBe('0.27.99');
+    expect(parsed.update!.requested_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    logSpy.mockRestore();
+  });
+
+  it('prints "already at version" and writes no intent when daemon matches target', async () => {
+    fakeDaemon.info = { pid: 12345, port: 20915 };
+    writeDaemonJson(serviceDir, '0.27.10');
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(' '));
+    });
+
+    await run(['--target-version', '0.27.10']);
+
+    const intentPath = path.join(serviceDir, 'intent.toml');
+    expect(fs.existsSync(intentPath)).toBe(false);
+    expect(logs.some((l) => l.toLowerCase().includes('already'))).toBe(true);
+    logSpy.mockRestore();
+  });
+
+  it('exits non-zero when no daemon is discovered', async () => {
+    fakeDaemon.info = null;
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+      throw new Error('__exit__');
+    }) as never);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(run(['--target-version', '0.27.99'])).rejects.toThrow('__exit__');
+
+    const intentPath = path.join(serviceDir, 'intent.toml');
+    expect(fs.existsSync(intentPath)).toBe(false);
+
+    exitSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it('exits non-zero when --target-version has no argument', async () => {
+    fakeDaemon.info = { pid: 12345, port: 20915 };
+    writeDaemonJson(serviceDir, '0.27.10');
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+      throw new Error('__exit__');
+    }) as never);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(run(['--target-version'])).rejects.toThrow('__exit__');
+
+    exitSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it('--cancel-update clears a pending update intent', async () => {
+    // Seed an existing update intent.
+    const intentPath = path.join(serviceDir, 'intent.toml');
+    fs.writeFileSync(
+      intentPath,
+      'update = { target_version = "0.27.99", requested_at = "2026-05-16T00:00:00Z" }\n',
+    );
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await run(['--cancel-update']);
+
+    expect(fs.existsSync(intentPath)).toBe(false);
+    logSpy.mockRestore();
+  });
+
+  it('--cancel-update is idempotent when no intent exists', async () => {
+    const logs: string[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(' '));
+    });
+
+    await run(['--cancel-update']);
+    expect(logs.some((l) => l.toLowerCase().includes('no pending'))).toBe(true);
+    logSpy.mockRestore();
+  });
+});

--- a/tests/config/atomic-writes.test.ts
+++ b/tests/config/atomic-writes.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect, spyOn } from 'bun:test';
-import fs, { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import fs, { existsSync, mkdtempSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { atomicWriteFileSync } from '../../packages/myco/src/utils/atomic-write.js';
 import { saveConfig } from '../../packages/myco/src/config/loader.js';
 import { MycoConfigSchema } from '../../packages/myco/src/config/schema.js';
 
@@ -43,5 +44,89 @@ describe('config atomic writes', () => {
     saveConfig(dir, validConfig);
     const content = readFileSync(join(dir, 'myco.yaml'), 'utf-8');
     expect(content).toContain('version: 3');
+  });
+});
+
+describe('atomicWriteFileSync mode option', () => {
+  test('applies mode to the tempfile before rename (chmod before rename)', () => {
+    // Defense against umask: even if writeFileSync's mode is masked by the
+    // process umask on create, the explicit chmodSync on the tempfile must
+    // land the requested mode before the rename exposes the final path.
+    const dir = mkdtempSync(join(tmpdir(), 'myco-atomic-mode-'));
+    const finalPath = join(dir, 'secrets.env');
+
+    const chmodSpy = spyOn(fs, 'chmodSync');
+    const renameSpy = spyOn(fs, 'renameSync');
+    try {
+      atomicWriteFileSync(finalPath, 'TOKEN=abc\n', { mode: 0o600 });
+
+      // chmodSync must fire on the tempfile (not the final path) and must
+      // be called before renameSync — the whole point of the helper.
+      expect(chmodSpy).toHaveBeenCalled();
+      const chmodCall = chmodSpy.mock.calls[0] as [string, number];
+      expect(chmodCall[0].startsWith(`${finalPath}.tmp-`)).toBe(true);
+      expect(chmodCall[1]).toBe(0o600);
+
+      expect(renameSpy).toHaveBeenCalledTimes(1);
+      const renameCall = renameSpy.mock.calls[0] as [string, string];
+      expect(renameCall[0].startsWith(`${finalPath}.tmp-`)).toBe(true);
+      expect(renameCall[1]).toBe(finalPath);
+    } finally {
+      chmodSpy.mockRestore();
+      renameSpy.mockRestore();
+    }
+
+    // And the landed file is actually 0o600 (POSIX-only assertion).
+    if (process.platform !== 'win32') {
+      const mode = statSync(finalPath).mode & 0o777;
+      expect(mode).toBe(0o600);
+    }
+  });
+
+  test('legacy encoding-string form still works', () => {
+    // Existing callers pass 'utf-8' as the third arg. The union signature
+    // must keep them working without any mode side-effect.
+    const dir = mkdtempSync(join(tmpdir(), 'myco-atomic-legacy-'));
+    const finalPath = join(dir, 'plain.txt');
+    const chmodSpy = spyOn(fs, 'chmodSync');
+    try {
+      atomicWriteFileSync(finalPath, 'hello', 'utf-8');
+      // No mode requested → no chmod on the tempfile.
+      const tempChmods = chmodSpy.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && (c[0] as string).startsWith(`${finalPath}.tmp-`),
+      );
+      expect(tempChmods.length).toBe(0);
+    } finally {
+      chmodSpy.mockRestore();
+    }
+    expect(readFileSync(finalPath, 'utf-8')).toBe('hello');
+  });
+
+  test('cleans up the tempfile when renameSync throws', () => {
+    // If rename fails (cross-device, EBUSY, ENOSPC), the tempfile must
+    // not be left behind — it would otherwise sit at a predictable
+    // `.tmp-<pid>-<ts>` path carrying secret bytes (auth tokens,
+    // API keys) that a future read by the same user could harvest.
+    const dir = mkdtempSync(join(tmpdir(), 'myco-atomic-rename-fail-'));
+    const finalPath = join(dir, 'secrets.env');
+    const fakeError = new Error('EXDEV: cross-device link not permitted');
+    const renameSpy = spyOn(fs, 'renameSync').mockImplementation(() => {
+      throw fakeError;
+    });
+    try {
+      expect(() =>
+        atomicWriteFileSync(finalPath, 'TOKEN=abc\n', { mode: 0o600 }),
+      ).toThrow(fakeError);
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    // Final path never landed.
+    expect(existsSync(finalPath)).toBe(false);
+    // And no tempfile lingers — the catch block unlinked it.
+    const leftover = readdirSync(dir).filter((name) =>
+      name.startsWith('secrets.env.tmp-'),
+    );
+    expect(leftover).toEqual([]);
   });
 });

--- a/tests/config/atomic-writes.test.ts
+++ b/tests/config/atomic-writes.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect, spyOn } from 'bun:test';
+import fs, { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { saveConfig } from '../../packages/myco/src/config/loader.js';
+import { MycoConfigSchema } from '../../packages/myco/src/config/schema.js';
+
+// Smallest valid config: schema requires `version: 3`; every other field
+// is defaulted. We re-parse through the schema so the test data tracks
+// whatever defaults the schema adds today, instead of hard-coding them.
+const validConfig = MycoConfigSchema.parse({ version: 3 });
+
+describe('config atomic writes', () => {
+  test('saveConfig writes atomically via temp + rename', () => {
+    // Non-vacuous regression check: if anyone reverts a converted call
+    // site to a direct writeFileSync, renameSync won't be called and
+    // this test fails. The temp-path naming is the atomic-write helper's
+    // contract — we assert the shape so a refactor that breaks it
+    // (e.g. dropping the unique suffix) also trips this test.
+    const dir = mkdtempSync(join(tmpdir(), 'myco-atomic-'));
+    const finalPath = join(dir, 'myco.yaml');
+    const spy = spyOn(fs, 'renameSync');
+    try {
+      saveConfig(dir, validConfig);
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [tmpPath, target] = spy.mock.calls[0] as [string, string];
+      expect(target).toBe(finalPath);
+      expect(tmpPath.startsWith(`${finalPath}.tmp-`)).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+
+    // And the final file must contain the written content — i.e. the
+    // rename actually landed, not just that it was called.
+    const after = readFileSync(finalPath, 'utf-8');
+    expect(after).toContain('version: 3');
+  });
+
+  test('saveConfig with sibling tempfile present is idempotent', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'myco-atomic-'));
+    // Stale tempfile from a prior interrupted write.
+    writeFileSync(join(dir, 'myco.yaml.tmp-stale'), 'garbage');
+    saveConfig(dir, validConfig);
+    const content = readFileSync(join(dir, 'myco.yaml'), 'utf-8');
+    expect(content).toContain('version: 3');
+  });
+});

--- a/tests/daemon/intent.test.ts
+++ b/tests/daemon/intent.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect, spyOn } from 'bun:test';
+import fs, { mkdtempSync, existsSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  readIntent,
+  writeIntent,
+  mergeIntent,
+  clearIntentSection,
+} from '../../packages/myco/src/daemon/intent.js';
+import type { DaemonServiceState } from '../../packages/myco/src/daemon/service-state.js';
+
+function svc(dir: string): DaemonServiceState {
+  return { stateDir: dir, statePath: join(dir, 'daemon.json'), canonicalPort: 20915, scope: 'global' };
+}
+
+describe('intent', () => {
+  test('round-trips restart intent', () => {
+    const d = mkdtempSync(join(tmpdir(), 'myco-intent-'));
+    writeIntent(svc(d), { restart: { requested_at: '2026-05-16T19:30:00Z', reason: 'user' } });
+    expect(readIntent(svc(d)).restart?.reason).toBe('user');
+  });
+
+  test('merge preserves unrelated sections', () => {
+    const d = mkdtempSync(join(tmpdir(), 'myco-intent-'));
+    writeIntent(svc(d), { update: { target_version: '0.27.11', requested_at: 'x' } });
+    mergeIntent(svc(d), { restart: { requested_at: 'y' } });
+    const i = readIntent(svc(d));
+    expect(i.update?.target_version).toBe('0.27.11');
+    expect(i.restart?.requested_at).toBe('y');
+  });
+
+  test('clearIntentSection removes file when empty', () => {
+    const d = mkdtempSync(join(tmpdir(), 'myco-intent-'));
+    writeIntent(svc(d), { restart: { requested_at: 'x' } });
+    clearIntentSection(svc(d), 'restart');
+    expect(readIntent(svc(d))).toEqual({});
+    expect(existsSync(join(d, 'intent.toml'))).toBe(false);
+  });
+
+  test('clearIntentSection keeps file when other sections remain', () => {
+    const d = mkdtempSync(join(tmpdir(), 'myco-intent-'));
+    writeIntent(svc(d), {
+      restart: { requested_at: 'x' },
+      update: { target_version: '0.27.11', requested_at: 'y' },
+    });
+    clearIntentSection(svc(d), 'restart');
+    const i = readIntent(svc(d));
+    expect(i.restart).toBeUndefined();
+    expect(i.update?.target_version).toBe('0.27.11');
+  });
+
+  test('readIntent returns empty object when file does not exist', () => {
+    const d = mkdtempSync(join(tmpdir(), 'myco-intent-'));
+    expect(readIntent(svc(d))).toEqual({});
+  });
+
+  test('readIntent tolerates malformed TOML by returning empty object', () => {
+    const d = mkdtempSync(join(tmpdir(), 'myco-intent-'));
+    writeFileSync(join(d, 'intent.toml'), '!!! not valid toml !!!');
+    expect(readIntent(svc(d))).toEqual({});
+  });
+
+  test('writeIntent is atomic — spies on renameSync', () => {
+    const d = mkdtempSync(join(tmpdir(), 'myco-intent-'));
+    const spy = spyOn(fs, 'renameSync');
+    try {
+      writeIntent(svc(d), { restart: { requested_at: 'x' } });
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/tests/daemon/reconcile-existing-daemon.test.ts
+++ b/tests/daemon/reconcile-existing-daemon.test.ts
@@ -72,8 +72,10 @@ describe('reconcileExistingDaemon', () => {
   });
 
   afterEach(async () => {
-    sibling.kill('SIGKILL');
-    await new Promise<void>((resolve) => sibling.once('exit', () => resolve()));
+    if (sibling.exitCode === null && sibling.signalCode === null) {
+      sibling.kill('SIGKILL');
+      await new Promise<void>((resolve) => sibling.once('exit', () => resolve()));
+    }
     try { fs.unlinkSync(daemonService(vaultDir).statePath); } catch { /* gone */ }
     fs.rmSync(vaultDir, { recursive: true, force: true });
   });
@@ -197,6 +199,85 @@ describe('reconcileExistingDaemon', () => {
     const result = await reconcileExistingDaemon(svc, makeLogger(vaultDir));
     expect(result).toBe('ok');
     expect(fs.existsSync(svc.statePath)).toBe(false);
+  });
+
+  it('escalates to SIGKILL when SIGTERM is ignored, then unlinks once dead', async () => {
+    // Spawn a child that swallows SIGTERM but exits on SIGKILL. The reconcile
+    // SIGTERM phase will time out, escalate to SIGKILL, and only then unlink
+    // daemon.json — proving the orphan-zombie window is closed.
+    sibling.kill('SIGKILL');
+    await new Promise<void>((resolve) => sibling.once('exit', () => resolve()));
+    sibling = spawn(process.execPath, [
+      '-e',
+      "process.on('SIGTERM',()=>{});process.stdout.write('ready\\n');setInterval(()=>{},1000)",
+    ], { stdio: ['ignore', 'pipe', 'ignore'] });
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('child did not signal ready')), 2_000);
+      sibling.stdout!.once('data', (chunk: Buffer) => {
+        if (chunk.toString().includes('ready')) {
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+    });
+    if (!sibling.pid) throw new Error('child failed to spawn');
+    siblingPid = sibling.pid;
+
+    const svc = daemonService(vaultDir);
+    fs.mkdirSync(path.dirname(svc.statePath), { recursive: true });
+    fs.writeFileSync(
+      svc.statePath,
+      // pid + bogus port so the health probe fails fast → takeover branch.
+      JSON.stringify({ pid: siblingPid, port: 1 }),
+    );
+
+    const result = await reconcileExistingDaemon(
+      svc,
+      makeLogger(vaultDir),
+      // Short grace windows so the test stays under a second; production
+      // defaults are 2s/500ms.
+      { sigtermGraceMs: 200, sigkillGraceMs: 500, pollMs: 25 },
+    );
+
+    expect(result).toBe('ok');
+    expect(fs.existsSync(svc.statePath)).toBe(false);
+    await new Promise<void>((resolve) => {
+      if (sibling.exitCode !== null || sibling.signalCode !== null) return resolve();
+      sibling.once('exit', () => resolve());
+    });
+    let alive = false;
+    try { process.kill(siblingPid, 0); alive = true; } catch { /* dead */ }
+    expect(alive).toBe(false);
+  });
+
+  it('steps aside and preserves daemon.json when pid survives SIGKILL', async () => {
+    // user-space can't truly produce an unkillable process — inject a fake
+    // `isProcessAlive` that always returns true and a no-op `kill`. The real
+    // sibling is just there to satisfy the "pid !== process.pid" guard;
+    // reconcile never touches it because we own the kill/alive seams.
+    const svc = daemonService(vaultDir);
+    fs.mkdirSync(path.dirname(svc.statePath), { recursive: true });
+    fs.writeFileSync(
+      svc.statePath,
+      JSON.stringify({ pid: siblingPid, port: 1 }),
+    );
+
+    const killCalls: Array<{ pid: number; signal: NodeJS.Signals | 0 }> = [];
+    const result = await reconcileExistingDaemon(svc, makeLogger(vaultDir), {
+      kill: (pid, signal) => { killCalls.push({ pid, signal }); },
+      isProcessAlive: () => true,
+      sigtermGraceMs: 50,
+      sigkillGraceMs: 50,
+      pollMs: 10,
+    });
+
+    expect(result).toBe('step-aside');
+    // daemon.json must survive — the (notionally still-live) predecessor
+    // owns it. Removing the file would orphan a live daemon.
+    expect(fs.existsSync(svc.statePath)).toBe(true);
+    // Both signals must have been attempted before stepping aside.
+    expect(killCalls.map((c) => c.signal)).toEqual(['SIGTERM', 'SIGKILL']);
+    expect(killCalls.every((c) => c.pid === siblingPid)).toBe(true);
   });
 });
 

--- a/tests/daemon/self-reconcile.test.ts
+++ b/tests/daemon/self-reconcile.test.ts
@@ -43,15 +43,29 @@ function makeState(): DaemonState {
   };
 }
 
+function makeErrorLogger(): DaemonLogger & {
+  calls: { kind: string; message: string; level: 'info' | 'error' }[];
+} {
+  const calls: { kind: string; message: string; level: 'info' | 'error' }[] = [];
+  const logger = {
+    calls,
+    debug() {},
+    info(kind: string, message: string) { calls.push({ kind, message, level: 'info' }); },
+    warn() {},
+    error(kind: string, message: string) { calls.push({ kind, message, level: 'error' }); },
+  } as unknown as DaemonLogger & { calls: typeof calls };
+  return logger;
+}
+
 describe('reconcileSelf', () => {
-  test('writes daemon.json when the file is missing', () => {
+  test('writes daemon.json when the file is missing', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'myco-recon-missing-'));
     const daemonService = makeDaemonService(dir);
     const state = makeState();
     const logger = makeLogger();
 
     expect(existsSync(daemonService.statePath)).toBe(false);
-    reconcileSelf({ daemonService, currentState: () => state, logger });
+    await reconcileSelf({ daemonService, currentState: () => state, logger });
     expect(existsSync(daemonService.statePath)).toBe(true);
 
     const parsed = JSON.parse(readFileSync(daemonService.statePath, 'utf-8'));
@@ -62,19 +76,19 @@ describe('reconcileSelf', () => {
     expect(logger.calls.some((c) => c.kind === 'daemon.reconcile')).toBe(true);
   });
 
-  test('re-writes daemon.json after it has been deleted', () => {
+  test('re-writes daemon.json after it has been deleted', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'myco-recon-deleted-'));
     const daemonService = makeDaemonService(dir);
     const state = makeState();
     const logger = makeLogger();
 
-    reconcileSelf({ daemonService, currentState: () => state, logger });
+    await reconcileSelf({ daemonService, currentState: () => state, logger });
     expect(existsSync(daemonService.statePath)).toBe(true);
 
     unlinkSync(daemonService.statePath);
     expect(existsSync(daemonService.statePath)).toBe(false);
 
-    reconcileSelf({ daemonService, currentState: () => state, logger });
+    await reconcileSelf({ daemonService, currentState: () => state, logger });
     expect(existsSync(daemonService.statePath)).toBe(true);
     const parsed = JSON.parse(readFileSync(daemonService.statePath, 'utf-8'));
     expect(parsed.pid).toBe(process.pid);
@@ -86,14 +100,14 @@ describe('reconcileSelf', () => {
     const state = makeState();
     const logger = makeLogger();
 
-    reconcileSelf({ daemonService, currentState: () => state, logger });
+    await reconcileSelf({ daemonService, currentState: () => state, logger });
     const mtime1 = statSync(daemonService.statePath).mtimeMs;
 
     // Give the filesystem mtime granularity headroom; HFS+ and some
     // network FS only resolve to whole seconds.
     await new Promise((r) => setTimeout(r, 1100));
 
-    reconcileSelf({ daemonService, currentState: () => state, logger });
+    await reconcileSelf({ daemonService, currentState: () => state, logger });
     const mtime2 = statSync(daemonService.statePath).mtimeMs;
     expect(mtime2).toBeGreaterThan(mtime1);
 
@@ -103,7 +117,7 @@ describe('reconcileSelf', () => {
     expect(discrepancyLogs.length).toBeLessThanOrEqual(1);
   });
 
-  test('consumes restart intent and invokes supervisor restart', () => {
+  test('consumes restart intent and invokes supervisor restart', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'myco-recon-intent-'));
     const daemonService = makeDaemonService(dir);
     const state = makeState();
@@ -115,7 +129,7 @@ describe('reconcileSelf', () => {
     expect(existsSync(join(dir, 'intent.toml'))).toBe(true);
 
     let restartCalls = 0;
-    reconcileSelf({
+    await reconcileSelf({
       daemonService,
       currentState: () => state,
       logger,
@@ -128,7 +142,7 @@ describe('reconcileSelf', () => {
     expect(logger.calls.some((c) => c.message.includes('Restart intent observed'))).toBe(true);
   });
 
-  test('clears restart intent BEFORE invoking supervisor restart', () => {
+  test('clears restart intent BEFORE invoking supervisor restart', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'myco-recon-intent-order-'));
     const daemonService = makeDaemonService(dir);
     const state = makeState();
@@ -143,7 +157,7 @@ describe('reconcileSelf', () => {
     // time we throw — otherwise a respawn loop would re-trigger the
     // same restart on the next tick.
     let intentClearedAtThrowTime: boolean | null = null;
-    expect(() =>
+    await expect(
       reconcileSelf({
         daemonService,
         currentState: () => state,
@@ -153,19 +167,19 @@ describe('reconcileSelf', () => {
           throw new Error('supervisor failed');
         },
       }),
-    ).toThrow('supervisor failed');
+    ).rejects.toThrow('supervisor failed');
 
     expect(intentClearedAtThrowTime).toBe(true);
   });
 
-  test('does nothing when intent.toml is absent', () => {
+  test('does nothing when intent.toml is absent', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'myco-recon-no-intent-'));
     const daemonService = makeDaemonService(dir);
     const state = makeState();
     const logger = makeLogger();
 
     let restartCalls = 0;
-    reconcileSelf({
+    await reconcileSelf({
       daemonService,
       currentState: () => state,
       logger,
@@ -175,7 +189,7 @@ describe('reconcileSelf', () => {
     expect(restartCalls).toBe(0);
   });
 
-  test('ignores a malformed intent.toml without throwing', () => {
+  test('ignores a malformed intent.toml without throwing', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'myco-recon-bad-intent-'));
     const daemonService = makeDaemonService(dir);
     const state = makeState();
@@ -184,18 +198,18 @@ describe('reconcileSelf', () => {
     writeFileSync(join(dir, 'intent.toml'), 'this is not = valid = toml = at all');
 
     let restartCalls = 0;
-    expect(() =>
+    await expect(
       reconcileSelf({
         daemonService,
         currentState: () => state,
         logger,
         requestSupervisorRestart: () => { restartCalls += 1; },
       }),
-    ).not.toThrow();
+    ).resolves.toBeUndefined();
     expect(restartCalls).toBe(0);
   });
 
-  test('does not require requestSupervisorRestart dep (clears intent and continues)', () => {
+  test('does not require requestSupervisorRestart dep (clears intent and continues)', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'myco-recon-no-spy-'));
     const daemonService = makeDaemonService(dir);
     const state = makeState();
@@ -205,12 +219,12 @@ describe('reconcileSelf', () => {
       restart: { requested_at: new Date().toISOString(), reason: 'test' },
     });
 
-    expect(() => reconcileSelf({ daemonService, currentState: () => state, logger })).not.toThrow();
+    await expect(reconcileSelf({ daemonService, currentState: () => state, logger })).resolves.toBeUndefined();
     // Intent still gets cleared even without the supervisor dep.
     expect(existsSync(join(dir, 'intent.toml'))).toBe(false);
   });
 
-  test('overwrites daemon.json when it points to a different pid', () => {
+  test('overwrites daemon.json when it points to a different pid', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'myco-recon-foreign-'));
     const daemonService = makeDaemonService(dir);
     const state = makeState();
@@ -218,14 +232,112 @@ describe('reconcileSelf', () => {
 
     // Seed with foreign pid (some other process claimed the file).
     const foreign: DaemonState = { ...state, pid: state.pid + 99999 };
-    reconcileSelf({ daemonService, currentState: () => foreign, logger });
+    await reconcileSelf({ daemonService, currentState: () => foreign, logger });
     const foreignWrite = JSON.parse(readFileSync(daemonService.statePath, 'utf-8'));
     expect(foreignWrite.pid).toBe(foreign.pid);
 
     // Reconcile under our identity; we must re-assert.
-    reconcileSelf({ daemonService, currentState: () => state, logger });
+    await reconcileSelf({ daemonService, currentState: () => state, logger });
     const final = JSON.parse(readFileSync(daemonService.statePath, 'utf-8'));
     expect(final.pid).toBe(state.pid);
     expect(logger.calls.some((c) => c.message.includes('Re-asserting'))).toBe(true);
+  });
+});
+
+describe('reconcileSelf update intent', () => {
+  test('invokes installUpdate and clears intent on success', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'myco-recon-update-ok-'));
+    const daemonService = makeDaemonService(dir);
+    const state = makeState();
+    const logger = makeLogger();
+
+    mergeIntent(daemonService, {
+      update: { target_version: '0.27.99', requested_at: new Date().toISOString() },
+    });
+    expect(existsSync(join(dir, 'intent.toml'))).toBe(true);
+
+    let installerCalls: string[] = [];
+    await reconcileSelf({
+      daemonService,
+      currentState: () => state,
+      logger,
+      installUpdate: async (target) => { installerCalls.push(target); },
+    });
+
+    expect(installerCalls).toEqual(['0.27.99']);
+    expect(existsSync(join(dir, 'intent.toml'))).toBe(false);
+    expect(logger.calls.some((c) => c.message.includes('Update intent observed'))).toBe(true);
+  });
+
+  test('RETAINS update intent and logs error when installer throws', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'myco-recon-update-fail-'));
+    const daemonService = makeDaemonService(dir);
+    const state = makeState();
+    const logger = makeErrorLogger();
+
+    mergeIntent(daemonService, {
+      update: { target_version: '0.27.99', requested_at: new Date().toISOString() },
+    });
+
+    let installerCalls = 0;
+    await reconcileSelf({
+      daemonService,
+      currentState: () => state,
+      logger,
+      installUpdate: async () => {
+        installerCalls += 1;
+        throw new Error('npm install failed');
+      },
+    });
+
+    expect(installerCalls).toBe(1);
+    // Intent file MUST still be present so the next tick retries.
+    expect(existsSync(join(dir, 'intent.toml'))).toBe(true);
+    expect(
+      logger.calls.some(
+        (c) => c.level === 'error' && c.message.includes('Update failed; intent retained'),
+      ),
+    ).toBe(true);
+  });
+
+  test('clears update intent when target matches current version (no install)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'myco-recon-update-noop-'));
+    const daemonService = makeDaemonService(dir);
+    const state: DaemonState = { ...makeState(), version: '0.27.10' };
+    const logger = makeLogger();
+
+    mergeIntent(daemonService, {
+      update: { target_version: '0.27.10', requested_at: new Date().toISOString() },
+    });
+
+    let installerCalls = 0;
+    await reconcileSelf({
+      daemonService,
+      currentState: () => state,
+      logger,
+      installUpdate: async () => { installerCalls += 1; },
+    });
+
+    expect(installerCalls).toBe(0);
+    expect(existsSync(join(dir, 'intent.toml'))).toBe(false);
+  });
+
+  test('does nothing when installUpdate dep is omitted', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'myco-recon-update-no-dep-'));
+    const daemonService = makeDaemonService(dir);
+    const state = makeState();
+    const logger = makeLogger();
+
+    mergeIntent(daemonService, {
+      update: { target_version: '0.27.99', requested_at: new Date().toISOString() },
+    });
+
+    await expect(
+      reconcileSelf({ daemonService, currentState: () => state, logger }),
+    ).resolves.toBeUndefined();
+
+    // Intent is retained when no installer dep is wired (parallel to
+    // the failure case — preserves retry semantics for tests/dev modes).
+    expect(existsSync(join(dir, 'intent.toml'))).toBe(true);
   });
 });

--- a/tests/daemon/self-reconcile.test.ts
+++ b/tests/daemon/self-reconcile.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, statSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { reconcileSelf } from '../../packages/myco/src/daemon/self-reconcile.js';
+import type {
+  DaemonServiceState,
+  DaemonState,
+} from '../../packages/myco/src/daemon/service-state.js';
+import type { DaemonLogger } from '../../packages/myco/src/daemon/logger.js';
+
+function makeLogger(): DaemonLogger & { calls: { kind: string; message: string }[] } {
+  const calls: { kind: string; message: string }[] = [];
+  const logger = {
+    calls,
+    debug() {},
+    info(kind: string, message: string) { calls.push({ kind, message }); },
+    warn() {},
+    error() {},
+  } as unknown as DaemonLogger & { calls: { kind: string; message: string }[] };
+  return logger;
+}
+
+function makeDaemonService(dir: string): DaemonServiceState {
+  return {
+    scope: 'global',
+    stateDir: dir,
+    statePath: join(dir, 'daemon.json'),
+    canonicalPort: 20915,
+  };
+}
+
+function makeState(): DaemonState {
+  return {
+    pid: process.pid,
+    port: 20915,
+    command: process.execPath,
+    started: new Date().toISOString(),
+    sessions: [],
+    version: '0.27.10',
+    auth_token: 'tok-deadbeef',
+  };
+}
+
+describe('reconcileSelf', () => {
+  test('writes daemon.json when the file is missing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'myco-recon-missing-'));
+    const daemonService = makeDaemonService(dir);
+    const state = makeState();
+    const logger = makeLogger();
+
+    expect(existsSync(daemonService.statePath)).toBe(false);
+    reconcileSelf({ daemonService, currentState: () => state, logger });
+    expect(existsSync(daemonService.statePath)).toBe(true);
+
+    const parsed = JSON.parse(readFileSync(daemonService.statePath, 'utf-8'));
+    expect(parsed.pid).toBe(state.pid);
+    expect(parsed.port).toBe(state.port);
+    expect(parsed.auth_token).toBe(state.auth_token);
+    // Missing file => the discrepancy path logs the re-assertion.
+    expect(logger.calls.some((c) => c.kind === 'daemon.reconcile')).toBe(true);
+  });
+
+  test('re-writes daemon.json after it has been deleted', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'myco-recon-deleted-'));
+    const daemonService = makeDaemonService(dir);
+    const state = makeState();
+    const logger = makeLogger();
+
+    reconcileSelf({ daemonService, currentState: () => state, logger });
+    expect(existsSync(daemonService.statePath)).toBe(true);
+
+    unlinkSync(daemonService.statePath);
+    expect(existsSync(daemonService.statePath)).toBe(false);
+
+    reconcileSelf({ daemonService, currentState: () => state, logger });
+    expect(existsSync(daemonService.statePath)).toBe(true);
+    const parsed = JSON.parse(readFileSync(daemonService.statePath, 'utf-8'));
+    expect(parsed.pid).toBe(process.pid);
+  });
+
+  test('refreshes mtime when state matches expected', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'myco-recon-mtime-'));
+    const daemonService = makeDaemonService(dir);
+    const state = makeState();
+    const logger = makeLogger();
+
+    reconcileSelf({ daemonService, currentState: () => state, logger });
+    const mtime1 = statSync(daemonService.statePath).mtimeMs;
+
+    // Give the filesystem mtime granularity headroom; HFS+ and some
+    // network FS only resolve to whole seconds.
+    await new Promise((r) => setTimeout(r, 1100));
+
+    reconcileSelf({ daemonService, currentState: () => state, logger });
+    const mtime2 = statSync(daemonService.statePath).mtimeMs;
+    expect(mtime2).toBeGreaterThan(mtime1);
+
+    // No discrepancy means no daemon.reconcile log entries beyond
+    // (potentially) the first write.
+    const discrepancyLogs = logger.calls.filter((c) => c.kind === 'daemon.reconcile');
+    expect(discrepancyLogs.length).toBeLessThanOrEqual(1);
+  });
+
+  test('overwrites daemon.json when it points to a different pid', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'myco-recon-foreign-'));
+    const daemonService = makeDaemonService(dir);
+    const state = makeState();
+    const logger = makeLogger();
+
+    // Seed with foreign pid (some other process claimed the file).
+    const foreign: DaemonState = { ...state, pid: state.pid + 99999 };
+    reconcileSelf({ daemonService, currentState: () => foreign, logger });
+    const foreignWrite = JSON.parse(readFileSync(daemonService.statePath, 'utf-8'));
+    expect(foreignWrite.pid).toBe(foreign.pid);
+
+    // Reconcile under our identity; we must re-assert.
+    reconcileSelf({ daemonService, currentState: () => state, logger });
+    const final = JSON.parse(readFileSync(daemonService.statePath, 'utf-8'));
+    expect(final.pid).toBe(state.pid);
+    expect(logger.calls.some((c) => c.message.includes('Re-asserting'))).toBe(true);
+  });
+});

--- a/tests/daemon/self-reconcile.test.ts
+++ b/tests/daemon/self-reconcile.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect } from 'bun:test';
-import { existsSync, mkdtempSync, readFileSync, statSync, unlinkSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { reconcileSelf } from '../../packages/myco/src/daemon/self-reconcile.js';
+import { mergeIntent } from '../../packages/myco/src/daemon/intent.js';
 import type {
   DaemonServiceState,
   DaemonState,
@@ -100,6 +101,113 @@ describe('reconcileSelf', () => {
     // (potentially) the first write.
     const discrepancyLogs = logger.calls.filter((c) => c.kind === 'daemon.reconcile');
     expect(discrepancyLogs.length).toBeLessThanOrEqual(1);
+  });
+
+  test('consumes restart intent and invokes supervisor restart', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'myco-recon-intent-'));
+    const daemonService = makeDaemonService(dir);
+    const state = makeState();
+    const logger = makeLogger();
+
+    mergeIntent(daemonService, {
+      restart: { requested_at: new Date().toISOString(), reason: 'test' },
+    });
+    expect(existsSync(join(dir, 'intent.toml'))).toBe(true);
+
+    let restartCalls = 0;
+    reconcileSelf({
+      daemonService,
+      currentState: () => state,
+      logger,
+      requestSupervisorRestart: () => { restartCalls += 1; },
+    });
+
+    expect(restartCalls).toBe(1);
+    // clearIntentSection removes the file when no sections remain.
+    expect(existsSync(join(dir, 'intent.toml'))).toBe(false);
+    expect(logger.calls.some((c) => c.message.includes('Restart intent observed'))).toBe(true);
+  });
+
+  test('clears restart intent BEFORE invoking supervisor restart', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'myco-recon-intent-order-'));
+    const daemonService = makeDaemonService(dir);
+    const state = makeState();
+    const logger = makeLogger();
+
+    mergeIntent(daemonService, {
+      restart: { requested_at: new Date().toISOString(), reason: 'test' },
+    });
+
+    // Throwing inside requestSupervisorRestart simulates a supervisor
+    // invocation failure. The intent MUST already be cleared by the
+    // time we throw — otherwise a respawn loop would re-trigger the
+    // same restart on the next tick.
+    let intentClearedAtThrowTime: boolean | null = null;
+    expect(() =>
+      reconcileSelf({
+        daemonService,
+        currentState: () => state,
+        logger,
+        requestSupervisorRestart: () => {
+          intentClearedAtThrowTime = !existsSync(join(dir, 'intent.toml'));
+          throw new Error('supervisor failed');
+        },
+      }),
+    ).toThrow('supervisor failed');
+
+    expect(intentClearedAtThrowTime).toBe(true);
+  });
+
+  test('does nothing when intent.toml is absent', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'myco-recon-no-intent-'));
+    const daemonService = makeDaemonService(dir);
+    const state = makeState();
+    const logger = makeLogger();
+
+    let restartCalls = 0;
+    reconcileSelf({
+      daemonService,
+      currentState: () => state,
+      logger,
+      requestSupervisorRestart: () => { restartCalls += 1; },
+    });
+
+    expect(restartCalls).toBe(0);
+  });
+
+  test('ignores a malformed intent.toml without throwing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'myco-recon-bad-intent-'));
+    const daemonService = makeDaemonService(dir);
+    const state = makeState();
+    const logger = makeLogger();
+
+    writeFileSync(join(dir, 'intent.toml'), 'this is not = valid = toml = at all');
+
+    let restartCalls = 0;
+    expect(() =>
+      reconcileSelf({
+        daemonService,
+        currentState: () => state,
+        logger,
+        requestSupervisorRestart: () => { restartCalls += 1; },
+      }),
+    ).not.toThrow();
+    expect(restartCalls).toBe(0);
+  });
+
+  test('does not require requestSupervisorRestart dep (clears intent and continues)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'myco-recon-no-spy-'));
+    const daemonService = makeDaemonService(dir);
+    const state = makeState();
+    const logger = makeLogger();
+
+    mergeIntent(daemonService, {
+      restart: { requested_at: new Date().toISOString(), reason: 'test' },
+    });
+
+    expect(() => reconcileSelf({ daemonService, currentState: () => state, logger })).not.toThrow();
+    // Intent still gets cleared even without the supervisor dep.
+    expect(existsSync(join(dir, 'intent.toml'))).toBe(false);
   });
 
   test('overwrites daemon.json when it points to a different pid', () => {

--- a/tests/daemon/server.test.ts
+++ b/tests/daemon/server.test.ts
@@ -415,15 +415,25 @@ describe('DaemonServer', () => {
     }
   });
 
-  it('cleans up daemon.json on stop', async () => {
+  it('leaves daemon.json in place on stop — successor owns cleanup', async () => {
+    // Cleanup ownership inversion (self-mutation-discipline tenet): stop()
+    // never unlinks daemon.json. If it did, a wedged shutdown would leave a
+    // live process with no discoverable state file. Cleanup is owned by the
+    // successor process's reconcileExistingDaemon path, which removes the
+    // file only after confirming the recorded pid is dead.
     const server = new DaemonServer({ vaultDir, logger });
     await server.start();
+    const jsonPath = path.join(vaultDir, 'daemon.json');
+    expect(fs.existsSync(jsonPath)).toBe(true);
     await server.stop();
 
-    expect(fs.existsSync(path.join(vaultDir, 'daemon.json'))).toBe(false);
+    expect(fs.existsSync(jsonPath)).toBe(true);
   });
 
   it('does not delete daemon.json on stop if another daemon has taken over', async () => {
+    // Same invariant: stop() never unlinks. This test additionally checks
+    // the successor-overwritten-state shape so a regression that re-introduced
+    // a pid-guarded delete in stop() would still be caught.
     const server = new DaemonServer({ vaultDir, logger });
     await server.start();
 

--- a/tests/daemon/state-file-invariant.test.ts
+++ b/tests/daemon/state-file-invariant.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Canonical tenet test: self-mutation-discipline state-file invariant.
+ *
+ * The contract proven here, across the daemon lifecycle operation class:
+ *
+ *   At any observable moment, `pid alive ⇔ daemon.json exists`.
+ *
+ * Plus the two intent-file sub-invariants that complete the tenet:
+ *
+ *   - Restart intent: clear-BEFORE-act. The intent section must be
+ *     removed before the supervisor restart is requested, otherwise a
+ *     fast respawn re-reads the same intent and loops forever.
+ *   - Update intent: clear-AFTER-success. The intent section is removed
+ *     only when the installer succeeds; on failure the section is
+ *     retained so the next reconcile tick retries.
+ *
+ * This file is the SINGLE place a future reader should land to see the
+ * tenet proven end-to-end across operations. Per-operation tests cover
+ * specific paths in depth — they are referenced here, not duplicated:
+ *
+ *   - `tests/daemon/reconcile-existing-daemon.test.ts`
+ *       Takeover/step-aside matrix, SIGTERM→SIGKILL escalation+poll,
+ *       step-aside when pid survives SIGKILL, stale grace window.
+ *   - `tests/daemon/self-reconcile.test.ts`
+ *       Heartbeat re-asserts daemon.json after external deletion;
+ *       clear-before-act restart contract; retain-on-fail update
+ *       contract.
+ *   - `tests/hooks/client-kill-no-orphan.test.ts`
+ *       killDaemon does NOT unlink daemon.json when the recorded pid is
+ *       still alive — cleanup is owned by the successor's reconcile.
+ *   - `tests/daemon/intent.test.ts`
+ *       Atomic writes and merge/clear semantics for intent.toml.
+ *
+ * Net-new in this file: cross-cutting round trips that touch more than
+ * one primitive in a single test, plus scenarios the per-operation
+ * suites do not exercise (notably simultaneous restart + update intent).
+ *
+ * See `docs/superpowers/plans/2026-05-16-self-mutation-discipline.md`.
+ */
+import { describe, test, expect } from 'bun:test';
+import { spawn, type ChildProcess } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { reconcileExistingDaemon } from '../../packages/myco/src/daemon/main.js';
+import { reconcileSelf } from '../../packages/myco/src/daemon/self-reconcile.js';
+import {
+  mergeIntent,
+  readIntent,
+} from '../../packages/myco/src/daemon/intent.js';
+import { DaemonLogger } from '../../packages/myco/src/daemon/logger.js';
+import type {
+  DaemonServiceState,
+  DaemonState,
+} from '../../packages/myco/src/daemon/service-state.js';
+import type { DaemonLogger as DaemonLoggerType } from '../../packages/myco/src/daemon/logger.js';
+
+function makeService(dir: string, canonicalPort = 20915): DaemonServiceState {
+  const stateDir = join(dir, 'service');
+  mkdirSync(stateDir, { recursive: true });
+  return {
+    scope: 'global',
+    stateDir,
+    statePath: join(stateDir, 'daemon.json'),
+    canonicalPort,
+  };
+}
+
+function makeLogger(dir: string): DaemonLoggerType {
+  return new DaemonLogger(join(dir, 'logs'), { level: 'info' });
+}
+
+function makeState(overrides: Partial<DaemonState> = {}): DaemonState {
+  return {
+    pid: process.pid,
+    port: 20915,
+    command: process.execPath,
+    started: new Date().toISOString(),
+    sessions: [],
+    version: '0.27.10',
+    auth_token: 'tok-tenet',
+    ...overrides,
+  };
+}
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('self-mutation-discipline invariants', () => {
+  test('round-trip: dead predecessor + stale daemon.json → reconcile cleans, invariant restored', async () => {
+    // Cross-cutting integration: simulate a predecessor that exited
+    // without removing daemon.json (the new contract — successor owns
+    // cleanup). The invariant is violated at the start (file exists,
+    // pid dead). reconcileExistingDaemon must restore it.
+    const dir = mkdtempSync(join(tmpdir(), 'myco-tenet-roundtrip-'));
+    const svc = makeService(dir);
+
+    // Spawn and immediately reap a child to get a guaranteed-dead pid.
+    const dead = spawn(process.execPath, ['-e', 'process.exit(0)'], { stdio: 'ignore' });
+    await new Promise<void>((resolve) => dead.once('exit', () => resolve()));
+    const deadPid = dead.pid!;
+    expect(pidAlive(deadPid)).toBe(false);
+
+    writeFileSync(svc.statePath, JSON.stringify({ pid: deadPid, port: 12345 }));
+    expect(existsSync(svc.statePath)).toBe(true); // invariant violated
+
+    const result = await reconcileExistingDaemon(svc, makeLogger(dir));
+
+    expect(result).toBe('ok');
+    // INVARIANT RESTORED: pid not alive AND state file gone.
+    expect(pidAlive(deadPid)).toBe(false);
+    expect(existsSync(svc.statePath)).toBe(false);
+  });
+
+  test('simultaneous restart + update intent — both sections processed in one tick, file fully cleared', async () => {
+    // Net-new scenario not covered elsewhere: a user could plausibly
+    // queue both intents (e.g. `myco restart` then `myco update`
+    // before the daemon has ticked). The reconcile loop must process
+    // both deterministically and leave intent.toml fully cleaned when
+    // both succeed — otherwise a partial state at next tick could
+    // produce surprising behavior (re-restart, re-update).
+    const dir = mkdtempSync(join(tmpdir(), 'myco-tenet-both-intents-'));
+    const svc = makeService(dir);
+    const logger = makeLogger(dir);
+    const state = makeState();
+
+    mergeIntent(svc, {
+      restart: { requested_at: new Date().toISOString(), reason: 'tenet-both' },
+      update: { target_version: '0.27.99', requested_at: new Date().toISOString() },
+    });
+    const intentFile = join(svc.stateDir, 'intent.toml');
+    expect(existsSync(intentFile)).toBe(true);
+
+    const events: string[] = [];
+    await reconcileSelf({
+      daemonService: svc,
+      currentState: () => state,
+      logger,
+      requestSupervisorRestart: () => events.push('restart'),
+      installUpdate: async (target) => { events.push(`update:${target}`); },
+    });
+
+    // Both intents were invoked, restart first (it's processed before
+    // update in reconcileSelf; this locks the ordering in).
+    expect(events).toEqual(['restart', 'update:0.27.99']);
+    // INVARIANT: intent.toml fully gone after both clears.
+    expect(existsSync(intentFile)).toBe(false);
+    // INVARIANT: daemon.json present and pointing at us.
+    expect(existsSync(svc.statePath)).toBe(true);
+    const written = JSON.parse(readFileSync(svc.statePath, 'utf-8'));
+    expect(written.pid).toBe(state.pid);
+  });
+
+  test('simultaneous restart + update where update FAILS — restart still fires, update intent retained', async () => {
+    // Net-new corollary: even when one intent's action fails, the
+    // other's must still complete, and only the failed intent's
+    // section is retained. This proves the two intent sections are
+    // independent and that failure containment works.
+    const dir = mkdtempSync(join(tmpdir(), 'myco-tenet-update-fail-'));
+    const svc = makeService(dir);
+    const state = makeState();
+    // Use the silent test logger shape from self-reconcile.test.ts —
+    // the real DaemonLogger writes to disk, which is fine, but we
+    // need to avoid the error being treated as a test failure.
+    const logger: DaemonLoggerType = {
+      debug() {},
+      info() {},
+      warn() {},
+      error() {},
+    } as unknown as DaemonLoggerType;
+
+    mergeIntent(svc, {
+      restart: { requested_at: new Date().toISOString(), reason: 'tenet-partial-fail' },
+      update: { target_version: '0.27.99', requested_at: new Date().toISOString() },
+    });
+
+    let restartCalls = 0;
+    let updateCalls = 0;
+    await reconcileSelf({
+      daemonService: svc,
+      currentState: () => state,
+      logger,
+      requestSupervisorRestart: () => { restartCalls += 1; },
+      installUpdate: async () => {
+        updateCalls += 1;
+        throw new Error('npm registry unreachable');
+      },
+    });
+
+    // Restart fired, update attempted.
+    expect(restartCalls).toBe(1);
+    expect(updateCalls).toBe(1);
+
+    // INVARIANT: restart section cleared (it succeeded), update
+    // section retained (it failed) — proves clear-before-act for
+    // restart and retain-on-fail for update operate independently.
+    const intent = readIntent(svc);
+    expect(intent.restart).toBeUndefined();
+    expect(intent.update?.target_version).toBe('0.27.99');
+    // File still exists because update section remains.
+    expect(existsSync(join(svc.stateDir, 'intent.toml'))).toBe(true);
+  });
+
+  test('pid-reuse defense: stale daemon.json pointing at a recycled pid → takeover without orphaning the stranger', async () => {
+    // The literal invariant `pid alive ⇔ daemon.json exists` would be
+    // fooled if the OS recycled the recorded pid for an unrelated
+    // process between the predecessor's exit and the successor's
+    // startup. Two defenses combine:
+    //   1. Freshness window — mtime older than
+    //      DAEMON_STALE_GRACE_PERIOD_MS denies the step-aside path.
+    //   2. Health probe — even within the window, a non-myco process
+    //      on the recorded port fails the /health check.
+    // Together they force the successor through the eviction path,
+    // where the kill+poll ladder decides cleanup. This test stands a
+    // real child process in for the "recycled-pid stranger" and
+    // injects test-only kill/alive seams so we drive the ladder
+    // without actually signalling the (innocent) stranger.
+    const dir = mkdtempSync(join(tmpdir(), 'myco-tenet-pid-reuse-'));
+    const svc = makeService(dir);
+
+    const stranger: ChildProcess = spawn(
+      process.execPath,
+      ['-e', 'setInterval(()=>{},60000)'],
+      { stdio: 'ignore' },
+    );
+    await new Promise<void>((resolve) => stranger.once('spawn', () => resolve()));
+    const strangerPid = stranger.pid!;
+    try {
+      writeFileSync(
+        svc.statePath,
+        JSON.stringify({ pid: strangerPid, port: 1 /* health probe fails */ }),
+      );
+      // Backdate mtime well past the 60s grace — represents a stale
+      // file whose pid was recycled by the OS during the interim.
+      const ancient = (Date.now() - 10 * 60 * 1000) / 1000;
+      utimesSync(svc.statePath, ancient, ancient);
+
+      // Drive the eviction ladder deterministically:
+      //   - `isProcessAlive` claims alive on first call (so we enter
+      //     the kill path), then dead (so SIGTERM's waitForExit
+      //     reports success and we unlink). This models the recycled
+      //     pid being released by the OS during the brief eviction
+      //     window without actually killing the stranger child.
+      //   - `kill` is a no-op — we never want to SIGTERM the stranger.
+      const aliveSequence = [true, false];
+      const result = await reconcileExistingDaemon(svc, makeLogger(dir), {
+        kill: () => { /* swallow — do not signal the stranger */ },
+        isProcessAlive: () => aliveSequence.shift() ?? false,
+        sigtermGraceMs: 100,
+        sigkillGraceMs: 100,
+        pollMs: 10,
+      });
+
+      // INVARIANTS:
+      //   - State file removed (no orphan pointing at the wrong pid).
+      //   - Result is 'ok' — we took over rather than stepping aside
+      //     into a non-myco predecessor.
+      //   - Stranger untouched: pid-reuse defense must not collateral-
+      //     damage unrelated processes.
+      expect(result).toBe('ok');
+      expect(existsSync(svc.statePath)).toBe(false);
+      expect(pidAlive(strangerPid)).toBe(true);
+    } finally {
+      stranger.kill('SIGKILL');
+      await new Promise<void>((resolve) => {
+        if (stranger.exitCode !== null || stranger.signalCode !== null) return resolve();
+        stranger.once('exit', () => resolve());
+      });
+    }
+  });
+});

--- a/tests/daemon/update-checker.test.ts
+++ b/tests/daemon/update-checker.test.ts
@@ -34,6 +34,9 @@ const fsMocks = {
   writeFileSync: mock(() => undefined),
   mkdirSync: mock(() => undefined),
   unlinkSync: mock(() => undefined),
+  // atomicWriteFileSync writes to a temp path then renames. The release
+  // channel writer flows through that helper now.
+  renameSync: mock(() => undefined),
 };
 mock.module('node:fs', () => ({
   default: fsMocks,
@@ -270,10 +273,16 @@ describe('project release channel helpers', () => {
 
     writeProjectReleaseChannel('/vault/.myco', 'beta');
 
+    // Atomic write: content goes to a sibling tempfile, then renames over
+    // the final path. Assert against both legs of the dance.
     expect(fs.writeFileSync).toHaveBeenCalledWith(
-      '/vault/.myco/local.yaml',
+      expect.stringMatching(/^\/vault\/\.myco\/local\.yaml\.tmp-/),
       expect.stringContaining('channel: beta'),
       'utf-8',
+    );
+    expect(fs.renameSync).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/vault\/\.myco\/local\.yaml\.tmp-/),
+      '/vault/.myco/local.yaml',
     );
   });
 
@@ -283,9 +292,13 @@ describe('project release channel helpers', () => {
     writeProjectReleaseChannel('/vault/.myco', 'stable');
 
     expect(fs.writeFileSync).toHaveBeenCalledWith(
-      '/vault/.myco/local.yaml',
+      expect.stringMatching(/^\/vault\/\.myco\/local\.yaml\.tmp-/),
       '{}\n',
       'utf-8',
+    );
+    expect(fs.renameSync).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/vault\/\.myco\/local\.yaml\.tmp-/),
+      '/vault/.myco/local.yaml',
     );
   });
 

--- a/tests/grove/claim-resume.test.ts
+++ b/tests/grove/claim-resume.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tenet conformance: every phase transition in claim/release is resumable.
+ * For each phase, we stage a claim manifest stuck at that phase and verify
+ * that re-running claim or release converges to the same terminal state
+ * a clean run would produce.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  type ClaimManifest,
+  claimGroveForDogfood,
+  releaseClaimedGrove,
+} from '@myco/grove/claim.js';
+import {
+  resolveGroveDbPath,
+  resolveBackupsRoot,
+} from '@myco/grove/paths.js';
+import {
+  clearGroveRegistryCaches,
+  createGrove,
+  loadGroveRecord,
+  setGroveServedBy,
+} from '@myco/grove/registry.js';
+
+let home: string;
+let backupsRoot: string;
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-claim-resume-'));
+  backupsRoot = path.join(home, 'backups');
+  clearGroveRegistryCaches();
+});
+
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+  clearGroveRegistryCaches();
+});
+
+function seedGrove(name: string) {
+  const grove = createGrove(name, home);
+  // Write a fake SQLite-looking byte sequence at the Grove DB path so the
+  // snapshot copy fallback succeeds (VACUUM INTO falls back to copyFileSync
+  // when the file isn't a real DB).
+  const dbPath = resolveGroveDbPath(grove.id, home);
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  fs.writeFileSync(dbPath, 'not-a-real-sqlite-file');
+  return grove;
+}
+
+function readManifest(manifestPath: string): ClaimManifest {
+  return JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as ClaimManifest;
+}
+
+describe('claim/release resumability (tenet conformance)', () => {
+  it('claim is idempotent: re-running after success is a no-op', () => {
+    const grove = seedGrove('Resume One');
+
+    const first = claimGroveForDogfood(grove.id, home, { backupsRoot });
+    expect(first.manifest.claim_phase).toBe('flipped');
+    expect(loadGroveRecord(grove.id, home)?.served_by).toBe('service-dev');
+
+    const second = claimGroveForDogfood(grove.id, home, { backupsRoot });
+    expect(second.manifest_path).toBe(first.manifest_path);
+    expect(second.manifest.claim_phase).toBe('flipped');
+    expect(loadGroveRecord(grove.id, home)?.served_by).toBe('service-dev');
+  });
+
+  it('claim resumes when interrupted between snapshot and flip (claim_phase=claimed)', () => {
+    const grove = seedGrove('Resume Two');
+
+    // Run claim then rewind state to simulate crash after snapshot but
+    // before served_by flip — manifest at 'claimed', served_by still
+    // 'service'.
+    const first = claimGroveForDogfood(grove.id, home, { backupsRoot });
+    setGroveServedBy(grove.id, 'service', home);
+    const rewound: ClaimManifest = { ...first.manifest, claim_phase: 'claimed' };
+    fs.writeFileSync(first.manifest_path, JSON.stringify(rewound, null, 2));
+
+    const resumed = claimGroveForDogfood(grove.id, home, { backupsRoot });
+    expect(resumed.manifest.claim_phase).toBe('flipped');
+    expect(loadGroveRecord(grove.id, home)?.served_by).toBe('service-dev');
+  });
+
+  it('release is idempotent: re-running after success is a no-op', () => {
+    const grove = seedGrove('Resume Three');
+    claimGroveForDogfood(grove.id, home, { backupsRoot });
+
+    const first = releaseClaimedGrove(grove.id, home, { backupsRoot });
+    expect(first.manifest.release_phase).toBe('archived');
+    expect(loadGroveRecord(grove.id, home)?.served_by).toBe('service');
+
+    // Re-running release after a clean completion: the active claim dir
+    // has been renamed under archive/, so findOpenClaim returns null and
+    // a fresh release call throws "Nothing to release."
+    expect(() => releaseClaimedGrove(grove.id, home, { backupsRoot })).toThrow(/Nothing to release/);
+  });
+
+  it('release resumes from each phase', () => {
+    type Phase = 'restored' | 'registry-restored' | 'flipped' | 'archived';
+    const phases: Phase[] = ['restored', 'registry-restored', 'flipped'];
+
+    for (const phase of phases) {
+      // Fresh Grove per phase since release archives the prior claim dir.
+      const slug = `phase-${phase}`.replace(/-/g, '_');
+      const grove = seedGrove(`Phase ${phase}`);
+      claimGroveForDogfood(grove.id, home, { backupsRoot });
+
+      const claimsDir = path.join(
+        resolveBackupsRoot(backupsRoot),
+        'claims',
+        grove.slug,
+      );
+      const claimRoots = fs.readdirSync(claimsDir).filter((n) => n !== 'archive');
+      expect(claimRoots.length).toBe(1);
+      const manifestPath = path.join(claimsDir, claimRoots[0], 'claim.json');
+      const baseline = readManifest(manifestPath);
+
+      // Stage the manifest at the target phase. Don't simulate partial
+      // work — we only verify that the resume code path correctly skips
+      // already-completed phases and finishes the rest.
+      const staged: ClaimManifest = {
+        ...baseline,
+        release_phase: phase,
+        release_owner_op: baseline.release_owner_op
+          ?? `grove-release-${grove.slug}-staged`,
+      };
+      // For phases >= 'flipped', also flip served_by back since that phase's
+      // work has logically happened.
+      if (phase === 'flipped') {
+        setGroveServedBy(grove.id, baseline.original_served_by, home);
+      }
+      fs.writeFileSync(manifestPath, JSON.stringify(staged, null, 2));
+
+      const result = releaseClaimedGrove(grove.id, home, { backupsRoot });
+      expect(result.manifest.release_phase).toBe('archived');
+      expect(loadGroveRecord(grove.id, home)?.served_by).toBe('service');
+
+      // After successful archive, the claim dir should be in archive/, not
+      // active claims dir.
+      const remaining = fs.existsSync(claimsDir)
+        ? fs.readdirSync(claimsDir).filter((n) => n !== 'archive')
+        : [];
+      expect(remaining.length).toBe(0);
+      expect(slug).toBeTruthy(); // suppress unused warning
+    }
+  });
+
+  it('archive phase resumes when checkpoint was written but rename did not happen', () => {
+    // Regression: the archive phase writes the 'archived' checkpoint
+    // before renaming the claim dir. If a crash lands between checkpoint
+    // and rename, the active claim dir is still in place — re-running
+    // release must complete the rename instead of leaving the dir
+    // stranded with an 'archived' flag.
+    const grove = seedGrove('Resume Archive');
+    claimGroveForDogfood(grove.id, home, { backupsRoot });
+
+    const claimsDir = path.join(
+      resolveBackupsRoot(backupsRoot),
+      'claims',
+      grove.slug,
+    );
+    const claimRoots = fs.readdirSync(claimsDir).filter((n) => n !== 'archive');
+    const claimRoot = path.join(claimsDir, claimRoots[0]);
+    const manifestPath = path.join(claimRoot, 'claim.json');
+    const baseline = readManifest(manifestPath);
+
+    // Simulate: prior release ran restore, registry-restore, served_by flip,
+    // wrote 'archived' checkpoint, then crashed before rename.
+    setGroveServedBy(grove.id, baseline.original_served_by, home);
+    const stranded: ClaimManifest = {
+      ...baseline,
+      release_phase: 'archived',
+      release_owner_op: `grove-release-${grove.slug}-staged`,
+    };
+    fs.writeFileSync(manifestPath, JSON.stringify(stranded, null, 2));
+
+    const result = releaseClaimedGrove(grove.id, home, { backupsRoot });
+    expect(result.manifest.release_phase).toBe('archived');
+    expect(result.archive_dir).toContain(`${path.sep}archive${path.sep}`);
+    expect(fs.existsSync(claimRoot)).toBe(false);
+    expect(fs.existsSync(result.archive_dir)).toBe(true);
+  });
+});

--- a/tests/hooks/client-kill-no-orphan.test.ts
+++ b/tests/hooks/client-kill-no-orphan.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, writeFileSync, mkdtempSync, mkdirSync, rmSync, unlinkSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { DaemonClient } from '@myco/hooks/client';
+import { resolveServiceDaemonStatePath } from '@myco/grove/paths';
+import { ensureProjectManifest } from '@myco/config/project-manifest';
+
+/**
+ * Cleanup ownership inversion: killDaemon must NOT unlink daemon.json when the
+ * recorded pid is still alive. This protects against the orphan-zombie failure
+ * mode where SIGTERM is sent, the target hangs in shutdown, and the state file
+ * gets deleted regardless — leaving a live daemon with no discoverable handoff
+ * file. Cleanup of daemon.json is owned exclusively by the successor process's
+ * reconcileExistingDaemon path.
+ */
+describe('killDaemon cleanup ownership', () => {
+  let vaultDir: string;
+  let previousMycoHome: string | undefined;
+  let statePath: string;
+  let child: ChildProcess | null = null;
+
+  beforeEach(() => {
+    process.env.MYCO_NO_AUTO_SPAWN = '1';
+    vaultDir = mkdtempSync(join(tmpdir(), 'myco-orphan-'));
+    previousMycoHome = process.env.MYCO_HOME;
+    process.env.MYCO_HOME = join(vaultDir, 'home');
+    ensureProjectManifest(vaultDir, { projectName: 'orphan-test' });
+    statePath = resolveServiceDaemonStatePath();
+    mkdirSync(dirname(statePath), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (child) {
+      try { child.kill('SIGKILL'); } catch { /* already gone */ }
+      child = null;
+    }
+    try { unlinkSync(statePath); } catch { /* gone */ }
+    rmSync(vaultDir, { recursive: true, force: true });
+    delete process.env.MYCO_NO_AUTO_SPAWN;
+    if (previousMycoHome === undefined) delete process.env.MYCO_HOME;
+    else process.env.MYCO_HOME = previousMycoHome;
+  });
+
+  it('does not unlink state file when target ignores SIGTERM and stays alive', async () => {
+    // Spawn a long-lived child that ignores SIGTERM — simulates a wedged daemon.
+    // The child writes "ready" to stdout once the SIGTERM handler is attached,
+    // so we can wait for it before sending SIGTERM (avoids a race where the
+    // signal arrives before the handler is installed and the default action
+    // kills the child).
+    child = spawn('node', [
+      '-e',
+      "process.on('SIGTERM',()=>{});process.stdout.write('ready\\n');setInterval(()=>{},1000)",
+    ], { detached: false, stdio: ['ignore', 'pipe', 'ignore'] });
+    const childPid = child.pid!;
+    expect(typeof childPid).toBe('number');
+
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('child did not signal ready')), 2_000);
+      child!.stdout!.once('data', (chunk: Buffer) => {
+        if (chunk.toString().includes('ready')) {
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+    });
+
+    writeFileSync(
+      statePath,
+      JSON.stringify({
+        pid: childPid,
+        port: 20915,
+        started: new Date().toISOString(),
+        version: '0.27.10',
+        auth_token: 'test',
+      }),
+    );
+
+    const client = new DaemonClient(vaultDir);
+    (client as unknown as { killDaemon: (info: { pid: number }) => void }).killDaemon({ pid: childPid });
+
+    // Give a moment for any async unlink to settle.
+    await new Promise((r) => setTimeout(r, 100));
+
+    // INVARIANT: process still alive ⇒ state file must still exist.
+    expect(() => process.kill(childPid, 0)).not.toThrow();
+    expect(existsSync(statePath)).toBe(true);
+  });
+});

--- a/tests/hooks/client-restart-stuck.test.ts
+++ b/tests/hooks/client-restart-stuck.test.ts
@@ -88,9 +88,11 @@ describe('DaemonClient.restart — stuck-shutdown recovery', () => {
       pollIntervalMs: 10,
     };
 
-    // killDaemon clears daemon.json before our poll loop runs — reinstate it
-    // so isHealthy can resolve the port. In production launchd writes a fresh
-    // daemon.json when it respawns.
+    // Simulate the supervisor writing a fresh daemon.json shortly after
+    // respawn. killDaemon itself no longer unlinks state (cleanup ownership
+    // inversion — the successor owns that), but in production launchd
+    // overwrites daemon.json with the new pid when it brings a fresh daemon
+    // up. We mimic that here so isHealthy can resolve the port.
     setTimeout(() => {
       fs.writeFileSync(statePath, JSON.stringify({ pid: FAKE_PID, port: healthPort }));
     }, 5);

--- a/tests/myco-shared/process.test.ts
+++ b/tests/myco-shared/process.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, spyOn } from 'bun:test';
+import { isProcessAlive } from '@goondocks/myco-shared';
+
+/**
+ * `isProcessAlive` is the load-bearing primitive behind the
+ * reconcileExistingDaemon polling ladder. The ladder decides whether to
+ * unlink daemon.json based on this function's return value. Conflating the
+ * three `process.kill(pid, 0)` outcomes is a self-mutation-discipline tenet
+ * violation:
+ *
+ *   - succeeds        → ALIVE
+ *   - throws ESRCH    → DEAD
+ *   - throws EPERM    → ALIVE (process exists, caller can't signal it)
+ *   - any other error → ALIVE (conservative; err away from orphaning state)
+ */
+describe('isProcessAlive', () => {
+  it('returns true for the current process', () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  it('returns false when process.kill throws ESRCH (process genuinely dead)', () => {
+    const spy = spyOn(process, 'kill').mockImplementation(() => {
+      const err = new Error('ESRCH') as NodeJS.ErrnoException;
+      err.code = 'ESRCH';
+      throw err;
+    });
+    try {
+      expect(isProcessAlive(99999)).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('returns true when process.kill throws EPERM (process exists but inaccessible)', () => {
+    const spy = spyOn(process, 'kill').mockImplementation(() => {
+      const err = new Error('EPERM') as NodeJS.ErrnoException;
+      err.code = 'EPERM';
+      throw err;
+    });
+    try {
+      expect(isProcessAlive(99999)).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('returns true for any unexpected error (conservative)', () => {
+    const spy = spyOn(process, 'kill').mockImplementation(() => {
+      throw new Error('something unexpected');
+    });
+    try {
+      expect(isProcessAlive(99999)).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/tests/service/launchd.test.ts
+++ b/tests/service/launchd.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeEach } from 'bun:test';
+import { describe, expect, test, beforeEach, spyOn } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -148,6 +148,34 @@ describe('LaunchdServiceManager', () => {
     expect(mgr.restartShellCommand('co.goondocks.myco-dev')).toBe(
       'launchctl kickstart -k gui/501/co.goondocks.myco-dev',
     );
+  });
+
+  test('install writes plist atomically via tempfile + rename', async () => {
+    // Regression guard: a torn write of the plist would let `launchctl
+    // bootstrap` register a structurally broken service. The write path
+    // must go through atomicWriteFileSync (tempfile + rename), not a
+    // direct writeFileSync to the final path.
+    const s = spec(home);
+    const plistPath = path.join(agentsDir, `${s.label}.plist`);
+    const writeSpy = spyOn(fs, 'writeFileSync');
+    const renameSpy = spyOn(fs, 'renameSync');
+    try {
+      await mgr.install(s);
+      const renamedToPlist = renameSpy.mock.calls.find(
+        (call) => call[1] === plistPath,
+      );
+      expect(renamedToPlist).toBeDefined();
+      const tmpSrc = renamedToPlist![0] as string;
+      expect(tmpSrc.startsWith(`${plistPath}.tmp-`)).toBe(true);
+      // The plist write itself targets the tempfile, never the final path.
+      const directPlistWrite = writeSpy.mock.calls.find(
+        (call) => call[0] === plistPath,
+      );
+      expect(directPlistWrite).toBeUndefined();
+    } finally {
+      writeSpy.mockRestore();
+      renameSpy.mockRestore();
+    }
   });
 
   test('isInstalled returns true after install, false after uninstall', async () => {


### PR DESCRIPTION
## Summary

Closes a class of bugs where Myco's own normal operations could corrupt its state, config, or process integrity. The trigger was a live dogfood failure: the production daemon was alive and serving on its port, but `daemon.json` was missing on disk because `stop()` unlinked the state file *before* `gracefullyCloseHttpServer` resolved — and the close hung. Every `myco restart` and `myco update` then reported "no daemon" against a daemon that was right there.

Tenet (captured as Myco spore `architecture-8edf2d03`): **no normal Myco operation may leave Myco's process, state, configuration, or data in an inconsistent or unrecoverable state under any failure mode**. Operations that mutate operational state must do so transactionally via *intent + reconciliation*: callers express what should be true, and a single owning actor converges actual state toward intent atomically. Direct destructive mutation by callers is structurally disallowed.

Three structural changes act together to enforce this:

1. **Atomic writes for every state mutation.** Daemon state, secrets, plists, every YAML config writer now goes through `atomicWriteFileSync` (tempfile + rename, with `{ mode }` option for 0o600 paths and rename-failure cleanup to avoid leaking secret-bearing tempfiles).

2. **Cleanup ownership inversion.** `stop()` and `killDaemon` no longer unlink `daemon.json`. The successor's `reconcileExistingDaemon` is the only path that removes it, and only after `SIGTERM → poll → SIGKILL → poll → step-aside` confirms the prior pid is dead. The `isProcessAlive` primitive in `@goondocks/myco-shared` was hardened so EPERM (alive but inaccessible) is treated as alive, not dead.

3. **Intent + reconciliation for restart and update.** `myco restart` and `myco update --target-version <v>` write `<stateDir>/intent.toml` and exit. The daemon's PowerManager runs a `self-reconcile` job every tick that re-asserts `daemon.json` from in-memory state (converting startup-only guarantee to continuously-enforced) and consumes intent sections. Restart clears the section BEFORE invoking the supervisor (no respawn loops). Update clears AFTER installer success; retains on failure for retry. CLI gets `DaemonClient.getInfoAsync()` — when `daemon.json` is missing, probes `/health` on the canonical port instead of misreporting "no daemon."

Plan: `docs/superpowers/plans/2026-05-16-self-mutation-discipline.md` (gitignored working spec).
Tenet spore: `architecture-8edf2d03`.

## Commit map

```
64733d5b fix(config): atomic writes for myco.yaml, machine config, secrets
f4728812 fix(daemon): atomic mode-preserving writes for daemon.json and secrets
c2843afd fix(service): atomic plist write for launchd install
def0b38c fix(daemon): cleanup ownership inversion — successor owns state-file removal
68ba6a26 feat(daemon): continuous self-reconcile + CLI fallback discovery
abe47ce5 feat(daemon): intent file primitive for transactional operations
1f0b4f5f feat(restart): intent + reconciliation
10bced9a feat(update): intent + reconciliation
020d12b5 test(daemon): canonical state-file invariant suite
f8416154 fix(grove): tenet-conformance for claim/release state machine
9af59cfb refactor: simplify self-mutation discipline per review
```

## Test plan

- [x] Full suite green: `npm test` → 4688 + 178 pass, 0 fail.
- [x] `make build` clean.
- [x] Canonical tenet test: `tests/daemon/state-file-invariant.test.ts` — 4 cross-cutting scenarios (round-trip cleanup, simultaneous restart+update intents, partial-failure independence, PID-reuse defense).
- [x] Per-operation invariant coverage: `tests/daemon/reconcile-existing-daemon.test.ts` (SIGTERM→SIGKILL→step-aside ladder), `tests/daemon/self-reconcile.test.ts` (continuous re-assertion + intent consumption + clear-before-act proof), `tests/hooks/client-kill-no-orphan.test.ts` (killDaemon doesn't orphan), `tests/grove/claim-resume.test.ts` (phased state machine resumes from each interrupted phase, including the archive-rename-resume regression found during audit).
- [x] Atomic-write coverage: `tests/config/atomic-writes.test.ts` (tempfile+rename, mode preservation, rename-failure cleanup).
- [x] CLI flow coverage: `tests/cli/restart-intent.test.ts`, `tests/cli/update-intent.test.ts`.

### Dogfood checklist (post-merge, runs on real install)

After merging and `npm install -g packages/myco` from the worktree:

- [ ] From a non-myco project (e.g. `~/Repos/unifi-network-rules`), run `myco restart` — prod daemon respawns cleanly, new pid in `~/.myco/service/daemon.json` within a few seconds.
- [ ] `myco update --target-version 0.27.10` — reports "already at version" and writes no intent file.
- [ ] `~/.myco/service/daemon.json` exists after restart with current pid+port; file mode is 0600.
- [ ] `kill -STOP $(jq -r .pid ~/.myco/service/daemon.json)` for 30s then `-CONT` — `reconcileSelf` re-asserts `daemon.json` after `CONT`; nothing orphans.
- [ ] Move `~/.myco/service/daemon.json` aside; `myco status` discovers the daemon via `/health` fallback; next reconcile tick re-creates the file.

Universal recovery: `launchctl kickstart -k gui/$(id -u)/co.goondocks.myco`.

## Known follow-ups (out of scope, captured for later)

- `daemon/api/update.ts` UI-driven apply path still calls `spawnUpdateScript` directly (doesn't route through intent). Pre-existing; concurrency guard would prevent UI-and-reconciler-tick races.
- Supervisor respawn has no backoff if a predecessor is genuinely unkillable. Acceptable today.
- `myco update --target-version` could split into a separate `myco install <v>` subcommand for surface clarity. Implementer flagged; deliberately deferred to keep this PR scoped to the tenet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)