### PR TITLE
fix: clean grove move data

### DIFF
--- a/packages/myco/src/grove/move.ts
+++ b/packages/myco/src/grove/move.ts
@@ -19,6 +19,7 @@ import path from 'node:path';
 import type { Database } from 'bun:sqlite';
 import { GROVE_PROJECT_SCOPED_TABLES } from '@myco/db/schema-ddl.js';
 import { openDatabase } from '@myco/db/client.js';
+import { EMBEDDABLE_TABLES } from '@myco/db/queries/embeddings.js';
 import {
   saveProjectManifest,
   saveProjectLocalManifest,
@@ -255,8 +256,10 @@ export function moveProjectBetweenGroves(
     // `openDatabase` only creates an empty file; restoreBackup needs the
     // schema present before its INSERT OR IGNORE statements run.
     ensureGroveDatabase(targetGroveId, mycoHome);
-    withDb(targetDbPath, (targetDb) => {
+    withDbs(sourceDbPath, targetDbPath, (sourceDb, targetDb) => {
+      copyAgents(sourceDb, targetDb);
       restoreBackup(targetDb, snapshotPath);
+      resetTargetEmbeddingFlags(targetDb, projectId);
     });
     marker = { ...marker, phase: 'restored' };
     writeMarker(markerPath, marker);
@@ -326,7 +329,7 @@ export function moveProjectBetweenGroves(
 
   if (orderOf(marker.phase) <= orderOf('committed')) {
     withDb(sourceDbPath, (sourceDb) => {
-      deleteProjectRows(sourceDb, projectId);
+      deleteProjectRows(sourceDb, projectIdsForCleanup(sourceDb, projectId, projectRoot));
     });
     marker = { ...marker, phase: 'cleaned' };
     writeMarker(markerPath, marker);
@@ -449,6 +452,69 @@ function withDb<T>(dbPath: string, fn: (db: Database) => T): T {
   }
 }
 
+function withDbs<T>(
+  firstDbPath: string,
+  secondDbPath: string,
+  fn: (firstDb: Database, secondDb: Database) => T,
+): T {
+  fs.mkdirSync(path.dirname(firstDbPath), { recursive: true });
+  fs.mkdirSync(path.dirname(secondDbPath), { recursive: true });
+  const firstDb = openDatabase(firstDbPath);
+  const secondDb = openDatabase(secondDbPath);
+  try {
+    return fn(firstDb, secondDb);
+  } finally {
+    secondDb.close();
+    firstDb.close();
+  }
+}
+
+function copyAgents(sourceDb: Database, targetDb: Database): void {
+  const agents = sourceDb.prepare(
+    `SELECT
+       id, name, provider, model, system_prompt_hash, config,
+       source, system_prompt, max_turns, timeout_seconds, tool_access,
+       enabled, created_at, updated_at
+     FROM agents
+     ORDER BY created_at ASC, id ASC`,
+  ).all() as Array<Record<string, unknown>>;
+  if (agents.length === 0) return;
+
+  const insert = targetDb.prepare(
+    `INSERT OR IGNORE INTO agents (
+       id, name, provider, model, system_prompt_hash, config,
+       source, system_prompt, max_turns, timeout_seconds, tool_access,
+       enabled, created_at, updated_at
+     ) VALUES (
+       ?, ?, ?, ?, ?, ?,
+       ?, ?, ?, ?, ?,
+       ?, ?, ?
+     )`,
+  );
+
+  const tx = targetDb.transaction(() => {
+    for (const row of agents) {
+      insert.run(
+        row.id,
+        row.name,
+        row.provider,
+        row.model,
+        row.system_prompt_hash,
+        row.config,
+        row.source ?? 'built-in',
+        row.system_prompt,
+        row.max_turns,
+        row.timeout_seconds,
+        row.tool_access,
+        row.enabled ?? 1,
+        row.created_at,
+        row.updated_at,
+      );
+    }
+  });
+  tx();
+}
+
 function countProjectRows(db: Database, projectId: string): Record<string, number> {
   const counts: Record<string, number> = {};
   for (const table of MOVE_SCOPED_TABLES) {
@@ -464,13 +530,54 @@ function countProjectRows(db: Database, projectId: string): Record<string, numbe
   return counts;
 }
 
-function deleteProjectRows(db: Database, projectId: string): void {
+function resetTargetEmbeddingFlags(db: Database, projectId: string): void {
+  const tx = db.transaction(() => {
+    for (const table of EMBEDDABLE_TABLES) {
+      try {
+        db.prepare(`UPDATE ${table} SET embedded = 0 WHERE project_id = ?`).run(projectId);
+      } catch {
+        // Older schemas may not have every embeddable table; skip.
+      }
+    }
+  });
+  tx();
+}
+
+function projectIdsForCleanup(
+  db: Database,
+  projectId: string,
+  projectRoot: string,
+): string[] {
+  const ids = new Set<string>([projectId]);
+  try {
+    const rows = db.prepare(
+      `SELECT DISTINCT project_id
+       FROM sessions
+       WHERE project_root = ?
+         AND project_id IS NOT NULL
+         AND project_id <> ''`,
+    ).all(projectRoot) as Array<{ project_id: string }>;
+    for (const row of rows) {
+      if (typeof row.project_id === 'string') ids.add(row.project_id);
+    }
+  } catch {
+    // Older schemas may not have project_root/project_id; fall back to the
+    // project id from the active registry entry.
+  }
+  return [...ids];
+}
+
+function deleteProjectRows(db: Database, projectIds: string[]): void {
+  const uniqueProjectIds = [...new Set(projectIds)].filter((id) => id.length > 0);
+  if (uniqueProjectIds.length === 0) return;
+
   db.run('PRAGMA foreign_keys = OFF');
   try {
     const tx = db.transaction(() => {
       for (const table of MOVE_SCOPED_TABLES) {
         try {
-          db.prepare(`DELETE FROM ${table} WHERE project_id = ?`).run(projectId);
+          const stmt = db.prepare(`DELETE FROM ${table} WHERE project_id = ?`);
+          for (const id of uniqueProjectIds) stmt.run(id);
         } catch {
           // Table may not exist on a brand-new target Grove DB; skip.
         }
@@ -482,7 +589,8 @@ function deleteProjectRows(db: Database, projectId: string): void {
       // them from source explicitly here — the moved project must leave
       // no orphans behind.
       try {
-        db.prepare(`DELETE FROM entity_mentions WHERE project_id = ?`).run(projectId);
+        const stmt = db.prepare(`DELETE FROM entity_mentions WHERE project_id = ?`);
+        for (const id of uniqueProjectIds) stmt.run(id);
       } catch {
         // Table may not exist on older schemas; skip.
       }

--- a/tests/grove/move.test.ts
+++ b/tests/grove/move.test.ts
@@ -77,7 +77,7 @@ function seedAgent(groveId: string): void {
   });
 }
 
-function seedProjectRows(groveId: string, projectId: string): void {
+function seedProjectRows(groveId: string, projectId: string, root = projectRoot): void {
   withGroveDb(groveId, (db) => {
     db.prepare(
       `INSERT INTO sessions (
@@ -87,7 +87,7 @@ function seedProjectRows(groveId: string, projectId: string): void {
     ).run(
       `sess-${projectId}-1`,
       'claude-code',
-      projectRoot,
+      root,
       'main',
       200,
       'completed',
@@ -144,6 +144,26 @@ function countRows(groveId: string, table: string, projectId: string): number {
       `SELECT COUNT(*) AS n FROM ${table} WHERE project_id = ?`,
     ).get(projectId) as { n: number };
     return row.n;
+  });
+}
+
+function countAllRows(groveId: string, table: string): number {
+  return withGroveDb(groveId, (db) => {
+    const row = db.prepare(`SELECT COUNT(*) AS n FROM ${table}`).get() as { n: number };
+    return row.n;
+  });
+}
+
+function foreignKeyViolations(groveId: string): unknown[] {
+  return withGroveDb(groveId, (db) => db.prepare('PRAGMA foreign_key_check').all());
+}
+
+function embeddedValue(groveId: string, table: string, id: string): number {
+  return withGroveDb(groveId, (db) => {
+    const row = db.prepare(`SELECT embedded FROM ${table} WHERE id = ?`).get(id) as {
+      embedded: number;
+    };
+    return row.embedded;
   });
 }
 
@@ -253,6 +273,42 @@ describe('moveProjectBetweenGroves', () => {
     expect(countRows(target.id, 'plans', projectId)).toBe(1);
     expect(countRows(target.id, 'spores', projectId)).toBe(1);
     expect(countRows(source.id, 'sessions', projectId)).toBe(0);
+    expect(countAllRows(target.id, 'agents')).toBe(1);
+    expect(foreignKeyViolations(target.id)).toEqual([]);
+    expect(embeddedValue(target.id, 'sessions', `sess-${projectId}-1`)).toBe(0);
+    expect(embeddedValue(target.id, 'plans', `plan-${projectId}-1`)).toBe(0);
+    expect(embeddedValue(target.id, 'spores', `spore-${projectId}-1`)).toBe(0);
+  });
+
+  it('cleans stale source rows for the same project root after a successful move', () => {
+    const source = createGrove('Source', mycoHome);
+    const target = createGrove('Target', mycoHome);
+    ensureGroveDb(source.id);
+    ensureGroveDb(target.id);
+    seedAgent(source.id);
+    seedAgent(target.id);
+
+    const currentProjectId = createProjectId();
+    const staleProjectId = createProjectId();
+    const unrelatedProjectId = createProjectId();
+    registerProjectInGrove(source.id, {
+      projectId: currentProjectId,
+      projectName: 'Demo',
+      projectRoot,
+    }, mycoHome);
+    seedProjectRows(source.id, currentProjectId);
+    seedProjectRows(source.id, staleProjectId);
+    seedProjectRows(source.id, unrelatedProjectId, path.join(tmpDir, 'other-project'));
+
+    moveProjectBetweenGroves(source.id, target.id, currentProjectId, mycoHome, { snapshotsRoot });
+
+    expect(countRows(target.id, 'sessions', currentProjectId)).toBe(1);
+    expect(countRows(source.id, 'sessions', currentProjectId)).toBe(0);
+    expect(countRows(source.id, 'spores', currentProjectId)).toBe(0);
+    expect(countRows(source.id, 'sessions', staleProjectId)).toBe(0);
+    expect(countRows(source.id, 'spores', staleProjectId)).toBe(0);
+    expect(countRows(source.id, 'sessions', unrelatedProjectId)).toBe(1);
+    expect(countRows(source.id, 'spores', unrelatedProjectId)).toBe(1);
   });
 
   it('throws when source and target Grove ids are the same', () => {


### PR DESCRIPTION
## Summary

Fixes Grove project moves so moving into a never-activated Grove preserves referential integrity and leaves the source Grove clean.

## Root cause

The move path restored only project-scoped backup rows into the target Grove. Grove-global `agents` rows were not copied first, so moved rows could reference missing agents in a fresh target Grove. The cleanup phase also deleted only the current project id, which left stale same-root rows under older project ids in the source Grove. Finally, moved rows retained `embedded=1` even though `vectors.db` is not moved.

## Changes

- Copy source `agents` rows into the target before restoring project-scoped data.
- Reset moved target rows' `embedded` flags so embeddings are rebuilt in the target Grove.
- Expand source cleanup to include stale project ids discovered from the same `sessions.project_root`.
- Add regression tests for fresh target Grove integrity, embedding reset, and stale same-root cleanup.

## Production repair performed

Backed up the affected production DBs to `/Users/chris/.myco/backups/manual-grove-move-cleanup-20260518-115312`, then repaired the `OSS` move of `ten-second-tom`:

- Inserted missing target Grove agents.
- Cleared target embedded flags for moved rows.
- Deleted stale same-root rows from Default.
- Removed 118 stale source vector metadata/vector rows.
- Rebuilt affected source FTS indexes.

Post-repair validation: API shows `ten-second-tom` only in `OSS`, both affected SQLite DBs pass `integrity_check`, both have zero FK violations, Default has no scoped leftovers for the current or stale project id, and Default vector metadata has no leftovers for those ids.

## Verification

- Isolated disposable-DB smoke test for Grove move repair behavior.
- `bun test tests/grove/move.test.ts`
- `npm run lint -w @goondocks/myco`
