### PR TITLE
ui(phase-7): Block 2 — Sessions filter bar + v7 row/header re-skin

### DIFF
--- a/packages/myco/ui/src/components/sessions/SessionDetail.tsx
+++ b/packages/myco/ui/src/components/sessions/SessionDetail.tsx
@@ -4,7 +4,7 @@ import { ArrowLeft, AlertCircle, Loader2, Sparkles, Check, Trash2, CheckCircle2 
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { Surface } from '../ui/surface';
-import { StatCard } from '../ui/stat-card';
+import { MetricCard } from '../ui/metric-card';
 import { SectionHeader } from '../ui/section-header';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { useSession, useDeleteSession, useSessionImpact, useSessionPlans, useCompleteSession } from '../../hooks/use-sessions';
@@ -180,7 +180,7 @@ export function SessionDetail({ id }: SessionDetailProps) {
       {/* Header */}
       <div className="space-y-2">
         <div className="flex items-center gap-3 flex-wrap">
-          <h1 className="font-serif text-2xl font-normal text-on-surface tracking-wide">
+          <h1 className="myco-display-lg text-on-surface m-0">
             {session.title ?? shortSession(session.id)}
           </h1>
           <StatusBadge status={session.status} />
@@ -268,13 +268,14 @@ export function SessionDetail({ id }: SessionDetailProps) {
         </div>
       </div>
 
-      {/* Key stats (compact row). Canopy tile renders for every session
-          (including non-Claude / pre-feature) with zeros where data is
-          absent — fits the four-column row regardless of agent. */}
+      {/* Key stats (compact row). Canopy tile keeps its bespoke chrome — it
+          aggregates efficiency, not a single metric, and gets re-skinned
+          alongside the broader Canopy work. The other three move to the v7
+          MetricCard treatment per Phase 7 T14. */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <StatCard label="Prompts" value={String(session.prompt_count)} accent="sage" />
-        <StatCard label="Tool Calls" value={String(session.tool_count)} accent="sage" />
-        <StatCard label="Plans" value={String(plans?.length ?? 0)} accent="outline" />
+        <MetricCard label="Prompts" value={String(session.prompt_count)} tone="sage" />
+        <MetricCard label="Tool Calls" value={String(session.tool_count)} tone="sage" />
+        <MetricCard label="Plans" value={String(plans?.length ?? 0)} />
         <CanopyEfficiencyTile sessionId={id} />
       </div>
 

--- a/packages/myco/ui/src/components/sessions/SessionList.tsx
+++ b/packages/myco/ui/src/components/sessions/SessionList.tsx
@@ -2,35 +2,23 @@ import { useNavigate } from 'react-router-dom';
 import { AlertCircle, GitBranch, MessageSquare, Trash2 } from 'lucide-react';
 import { Surface } from '../ui/surface';
 import { ConfirmDialog } from '../ui/confirm-dialog';
-import { ListToolbar, type FilterDefinition } from '../ui/list-toolbar';
 import { Pagination } from '../ui/pagination';
 import { StatusDot, type StatusTone } from '../ui/status-dot';
 import { Sparkline } from '../ui/sparkline';
 import { useSessions, useDeleteSession, useSessionImpact, type SessionSummary } from '../../hooks/use-sessions';
 import { useSymbionts } from '../../hooks/use-symbionts';
-import { useListFilters, FILTER_ALL } from '../../hooks/use-list-filters';
 import { DEFAULT_PAGE_SIZE } from '../../lib/constants';
 import { shortSession, formatEpochAgo } from '../../lib/format';
 import { ReleaseStateDot } from '../release-state/ReleaseStateBadge';
 import { sectionRows } from '../../lib/section-rows';
 import { cn } from '../../lib/cn';
-import { forwardRef, useEffect, useMemo, useRef, useState } from 'react';
+import { forwardRef, useEffect, useMemo, useRef, useState, type RefObject } from 'react';
 import { useListKeyboardNav } from '../../hooks/use-list-keyboard-nav';
 
 /* ---------- Constants ---------- */
 
 /** Number of skeleton rows to show during loading. */
 const SKELETON_ROW_COUNT = 5;
-
-const STATUS_FILTER: FilterDefinition = {
-  key: 'status',
-  label: 'Status',
-  options: [
-    { value: FILTER_ALL, label: 'All statuses' },
-    { value: 'active', label: 'Active' },
-    { value: 'completed', label: 'Completed' },
-  ],
-};
 
 /* ---------- Helpers ---------- */
 
@@ -65,11 +53,16 @@ const SessionCardRow = forwardRef<HTMLDivElement, {
       data-selected={isSelected || undefined}
       data-cursor={isCursor || undefined}
       className={cn(
-        'group relative border-b border-outline-variant/20 last:border-0 px-4 py-3 cursor-pointer transition-all duration-150',
-        'hover:bg-surface-container-high/50 hover:shadow-[inset_3px_0_0_var(--primary)]',
-        'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40',
-        isSelected && 'bg-surface-container-high shadow-[inset_3px_0_0_var(--primary)]',
-        isCursor && !isSelected && 'bg-surface-container/40 ring-2 ring-inset ring-primary/30',
+        // v7 myco-grove-active-row treatment: ghost-border separators, soft
+        // surface-container hover, sage left-stripe + tinted background on
+        // active. Cursor (keyboard-focused but not selected) gets a softer
+        // ring so j/k feedback stays visible without competing with the
+        // selected row's accent.
+        'group relative border-b border-[var(--ghost-border)] last:border-b-0 px-4 py-3 cursor-pointer transition-colors duration-100',
+        'hover:bg-surface-container',
+        'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-sage/40',
+        isSelected && 'bg-sage/[0.08] shadow-[inset_2px_0_0_var(--sage)]',
+        isCursor && !isSelected && 'bg-surface-container/60 ring-1 ring-inset ring-sage/30',
       )}
       onClick={onClick}
       onKeyDown={(e) => {
@@ -111,7 +104,7 @@ const SessionCardRow = forwardRef<HTMLDivElement, {
                 e.stopPropagation();
               }
             }}
-            className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-1 rounded hover:bg-tertiary/10 hover:text-tertiary transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-tertiary/40"
+            className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 p-1 rounded hover:bg-terracotta/10 hover:text-terracotta transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-terracotta/40"
             aria-label={`Delete session ${sessionLabel}`}
             title="Delete session"
           >
@@ -138,7 +131,7 @@ const SessionCardRow = forwardRef<HTMLDivElement, {
 
 function SkeletonCardRow() {
   return (
-    <div className="border-b border-outline-variant/20 px-4 py-3">
+    <div className="border-b border-[var(--ghost-border)] last:border-b-0 px-4 py-3">
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-start gap-2 min-w-0 flex-1">
           <div className="mt-1.5 h-1.5 w-1.5 rounded-full bg-surface-container-high animate-pulse shrink-0" />
@@ -160,35 +153,33 @@ export interface SessionListProps {
   /** When set, the row with this session id renders as active. Also seeds the
    * keyboard-nav cursor so j/k continues from the selection. */
   selectedId?: string;
+  /** Debounced search string from the page-level filter bar. */
+  search?: string;
+  /** Active filter values from the page-level filter bar (undefined = all). */
+  statusFilter?: string;
+  agentFilter?: string;
+  /** Pagination state (owned by the page so it resets when filters change). */
+  offset: number;
+  onOffsetChange: (offset: number) => void;
+  /** Search-input ref from the page filter bar — passed to keyboard nav so
+   * the `/` shortcut focuses the page-level input. */
+  filterInputRef?: RefObject<HTMLInputElement | null>;
 }
 
-export function SessionList({ selectedId }: SessionListProps = {}) {
+export function SessionList({
+  selectedId,
+  search,
+  statusFilter,
+  agentFilter,
+  offset,
+  onOffsetChange,
+  filterInputRef,
+}: SessionListProps) {
   const navigate = useNavigate();
-  const filterInputRef = useRef<HTMLInputElement>(null);
-  const { searchInput, debouncedSearch, filterValues, offset, setOffset, handleSearchChange, handleFilterChange, activeFilter } = useListFilters({
-    initialFilters: { status: FILTER_ALL, agent: FILTER_ALL },
-  });
   const [deleteTarget, setDeleteTarget] = useState<SessionSummary | null>(null);
   const deleteSession = useDeleteSession();
   const { data: impact } = useSessionImpact(deleteTarget?.id ?? null);
   const { data: symbiontsData } = useSymbionts();
-
-  // Build the Symbiont filter from whichever symbionts this project has
-  // enabled. The filter key stays `agent` because that's what the backend
-  // sessions query expects, but the label and options reflect the project's
-  // actual configuration rather than a hardcoded list.
-  const sessionFilters = useMemo<FilterDefinition[]>(() => {
-    const enabledSymbionts = (symbiontsData?.symbionts ?? []).filter((s) => s.enabled);
-    const symbiontFilter: FilterDefinition = {
-      key: 'agent',
-      label: 'Symbiont',
-      options: [
-        { value: FILTER_ALL, label: 'All symbionts' },
-        ...enabledSymbionts.map((s) => ({ value: s.name, label: s.displayName })),
-      ],
-    };
-    return [STATUS_FILTER, symbiontFilter];
-  }, [symbiontsData]);
 
   // Lookup from the DB-stored agent name (e.g. 'claude-code') to the
   // manifest display name. Falls back to the raw name for sessions whose
@@ -204,15 +195,12 @@ export function SessionList({ selectedId }: SessionListProps = {}) {
     };
   }, [symbiontsData]);
 
-  const activeStatus = activeFilter('status');
-  const activeAgent = activeFilter('agent');
-
   const { data, isLoading, isError, error } = useSessions({
     limit: DEFAULT_PAGE_SIZE,
     offset,
-    status: activeStatus,
-    agent: activeAgent,
-    search: debouncedSearch,
+    status: statusFilter,
+    agent: agentFilter,
+    search,
   });
 
   function handleDeleteConfirm() {
@@ -248,18 +236,6 @@ export function SessionList({ selectedId }: SessionListProps = {}) {
     filterInputRef,
   });
 
-  const toolbar = (
-    <ListToolbar
-      searchPlaceholder="Search sessions..."
-      searchValue={searchInput}
-      onSearchChange={handleSearchChange}
-      filters={sessionFilters}
-      filterValues={filterValues}
-      onFilterChange={handleFilterChange}
-      inputRef={filterInputRef}
-    />
-  );
-
   // Page-local sums: aggregates reflect the visible page only. The sessions
   // query doesn't expose project-scoped totals for prompts/active-status
   // separately, so we sum what's loaded. TOTAL comes from the paginated
@@ -268,12 +244,10 @@ export function SessionList({ selectedId }: SessionListProps = {}) {
   const promptsTotal = sessions.reduce((sum, s) => sum + (s.prompt_count ?? 0), 0);
 
   const totalsHeader = (
-    <div className="px-4 py-3 border-b border-outline-variant/20">
+    <div className="px-4 py-3 border-b border-[var(--ghost-border)]">
       <div className="flex items-baseline justify-between gap-2 mb-2">
-        <h2 className="font-mono text-[10px] uppercase tracking-wider text-on-surface-variant">
-          Sessions
-        </h2>
-        <span className="font-serif italic text-sm text-on-surface">Archive</span>
+        <h2 className="myco-eyebrow-sm">Sessions</h2>
+        <span className="myco-display-sm text-on-surface">Archive</span>
       </div>
       <div className="font-mono text-[11px] text-on-surface-variant inline-flex items-center gap-1.5">
         <span><strong className="text-on-surface font-semibold">{total.toLocaleString()}</strong> TOTAL</span>
@@ -287,10 +261,9 @@ export function SessionList({ selectedId }: SessionListProps = {}) {
 
   if (isError) {
     return (
-      <div className="p-4">
+      <div>
         {totalsHeader}
-        {toolbar}
-        <div className="flex h-40 flex-col items-center justify-center gap-2 text-tertiary mt-4">
+        <div className="flex h-40 flex-col items-center justify-center gap-2 text-terracotta mt-4">
           <AlertCircle className="h-5 w-5" />
           <span className="font-sans text-sm">Failed to load sessions</span>
           <span className="font-sans text-xs text-on-surface-variant">
@@ -302,10 +275,8 @@ export function SessionList({ selectedId }: SessionListProps = {}) {
   }
 
   return (
-    <div className="p-4">
+    <div>
       {totalsHeader}
-
-      {toolbar}
 
       {isLoading ? (
         <Surface level="low" className="rounded-md overflow-hidden mt-4">
@@ -319,11 +290,11 @@ export function SessionList({ selectedId }: SessionListProps = {}) {
         <div className="flex h-40 flex-col items-center justify-center gap-2 text-on-surface-variant mt-4">
           <MessageSquare className="h-8 w-8 opacity-30" />
           <span className="font-sans text-sm">
-            {total === 0 && !debouncedSearch && !activeStatus && !activeAgent
+            {total === 0 && !search && !statusFilter && !agentFilter
               ? 'No sessions yet'
               : 'No matching sessions'}
           </span>
-          {total === 0 && !debouncedSearch && !activeStatus && !activeAgent && (
+          {total === 0 && !search && !statusFilter && !agentFilter && (
             <span className="font-sans text-xs">Sessions appear here as you work with your agent</span>
           )}
         </div>
@@ -333,7 +304,7 @@ export function SessionList({ selectedId }: SessionListProps = {}) {
             {...nav.containerProps}
             role="list"
             aria-label="Session archive"
-            className="outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40"
+            className="outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-sage/40"
           >
             {(() => {
               const sections = sectionRows(sessions, {
@@ -349,12 +320,10 @@ export function SessionList({ selectedId }: SessionListProps = {}) {
                 <div key={section.label}>
                   <div
                     role="separator"
-                    className="flex items-center justify-between px-4 py-2 border-b border-outline-variant/20 bg-surface-container/30"
+                    className="flex items-center justify-between px-4 py-2 border-b border-[var(--ghost-border)] bg-surface-container/40"
                   >
-                    <span className="font-mono text-[10px] uppercase tracking-wider text-on-surface-variant">
-                      {section.label}
-                    </span>
-                    <span className="font-mono text-[10px] text-on-surface-variant">
+                    <span className="myco-eyebrow-sm">{section.label}</span>
+                    <span className="font-mono text-[10px] text-outline">
                       {section.rows.length}
                     </span>
                   </div>
@@ -384,7 +353,7 @@ export function SessionList({ selectedId }: SessionListProps = {}) {
         total={total}
         offset={offset}
         limit={DEFAULT_PAGE_SIZE}
-        onPageChange={setOffset}
+        onPageChange={onOffsetChange}
       />
 
       <ConfirmDialog
@@ -392,7 +361,7 @@ export function SessionList({ selectedId }: SessionListProps = {}) {
         onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}
         title="Delete Session"
         description="This will permanently remove this session and all related data. This action cannot be undone."
-        icon={<Trash2 className="h-4 w-4 text-tertiary" />}
+        icon={<Trash2 className="h-4 w-4 text-terracotta" />}
         meta={deleteTarget ? [
           { label: 'ID', value: shortSession(deleteTarget.id) },
           { label: 'Title', value: deleteTarget.title || shortSession(deleteTarget.id) },

--- a/packages/myco/ui/src/pages/Sessions.tsx
+++ b/packages/myco/ui/src/pages/Sessions.tsx
@@ -1,27 +1,99 @@
+import { useMemo, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { MasterDetailSplit } from '../components/ui/master-detail-split';
 import { EmptyDetailHint } from '../components/ui/empty-detail-hint';
+import { ListFilterBar, type FilterDefinition } from '../components/ui/list-filter-bar';
 import { SessionList } from '../components/sessions/SessionList';
 import { SessionDetail } from '../components/sessions/SessionDetail';
+import { useSymbionts } from '../hooks/use-symbionts';
+import { useListFilters, FILTER_ALL } from '../hooks/use-list-filters';
+
+const STATUS_FILTER: FilterDefinition = {
+  key: 'status',
+  label: 'Status',
+  options: [
+    { value: FILTER_ALL, label: 'All statuses' },
+    { value: 'active', label: 'Active' },
+    { value: 'completed', label: 'Completed' },
+  ],
+};
 
 export default function Sessions() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const filterInputRef = useRef<HTMLInputElement>(null);
+
+  const {
+    searchInput,
+    debouncedSearch,
+    filterValues,
+    offset,
+    setOffset,
+    handleSearchChange,
+    handleFilterChange,
+    activeFilter,
+  } = useListFilters({
+    initialFilters: { status: FILTER_ALL, agent: FILTER_ALL },
+  });
+
+  const { data: symbiontsData } = useSymbionts();
+
+  // Symbiont filter options are derived from whichever symbionts the project
+  // has enabled. The filter key stays `agent` because the sessions backend
+  // expects it, but the label + options reflect the project's actual config.
+  const sessionFilters = useMemo<FilterDefinition[]>(() => {
+    const enabledSymbionts = (symbiontsData?.symbionts ?? []).filter((s) => s.enabled);
+    const symbiontFilter: FilterDefinition = {
+      key: 'agent',
+      label: 'Symbiont',
+      options: [
+        { value: FILTER_ALL, label: 'All symbionts' },
+        ...enabledSymbionts.map((s) => ({ value: s.name, label: s.displayName })),
+      ],
+    };
+    return [STATUS_FILTER, symbiontFilter];
+  }, [symbiontsData]);
+
+  const activeStatus = activeFilter('status');
+  const activeAgent = activeFilter('agent');
 
   return (
-    <MasterDetailSplit
-      hasSelection={!!id}
-      onCloseMobileDetail={() => navigate('..')}
-      masterAriaLabel="Sessions"
-      detailAriaLabel="Session details"
-      master={<SessionList selectedId={id} />}
-      detail={
-        id ? (
-          <SessionDetail id={id} />
-        ) : (
-          <EmptyDetailHint message="Select a session to see its details." />
-        )
-      }
-    />
+    <div className="flex flex-col h-full gap-4 p-4">
+      <ListFilterBar
+        searchPlaceholder="Search sessions..."
+        searchValue={searchInput}
+        onSearchChange={handleSearchChange}
+        filters={sessionFilters}
+        filterValues={filterValues}
+        onFilterChange={handleFilterChange}
+        inputRef={filterInputRef}
+      />
+      <div className="flex-1 min-h-0">
+        <MasterDetailSplit
+          hasSelection={!!id}
+          onCloseMobileDetail={() => navigate('..')}
+          masterAriaLabel="Sessions"
+          detailAriaLabel="Session details"
+          master={
+            <SessionList
+              selectedId={id}
+              search={debouncedSearch}
+              statusFilter={activeStatus}
+              agentFilter={activeAgent}
+              offset={offset}
+              onOffsetChange={setOffset}
+              filterInputRef={filterInputRef}
+            />
+          }
+          detail={
+            id ? (
+              <SessionDetail id={id} />
+            ) : (
+              <EmptyDetailHint message="Select a session to see its details." />
+            )
+          }
+        />
+      </div>
+    </div>
   );
 }

--- a/tests/ui/sessions-filter-bar.test.tsx
+++ b/tests/ui/sessions-filter-bar.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+/**
+ * Phase 7 Block 2 T15 — Sessions page-level filter bar contract.
+ *
+ * Asserts the filter chrome was correctly lifted out of `<SessionList>` and
+ * now lives at the page level (above MasterDetailSplit), so the master pane
+ * reclaims its full width and the search/filter wiring drives the underlying
+ * `useSessions` query.
+ *
+ * Why we stub <ListFilterBar>: pulling Radix Select through bun's
+ * isolated jsdom render trips an "Invalid hook call" — captured as a Block 1
+ * spore. This test mocks the primitive to a plain `<input>` wrapper so we can
+ * still assert structural placement + search wiring deterministically. The
+ * primitive's tone/filter rendering is covered by component-level tests; the
+ * full Radix interaction will get exercised in dogfood + real-browser CI when
+ * the dev UI loads the page.
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const sessionsQueryMock = mock<(opts: Record<string, unknown>) => void>(() => {});
+
+mock.module('../../packages/myco/ui/src/components/ui/list-filter-bar', () => {
+  return {
+    ListFilterBar: ({
+      searchValue,
+      onSearchChange,
+      filters,
+      searchPlaceholder,
+    }: {
+      searchValue: string;
+      onSearchChange: (v: string) => void;
+      filters?: Array<{ key: string; label: string }>;
+      searchPlaceholder?: string;
+    }) => (
+      <div data-testid="list-filter-bar" data-filter-count={filters?.length ?? 0}>
+        <input
+          data-testid="list-filter-bar-search"
+          placeholder={searchPlaceholder}
+          value={searchValue}
+          onChange={(e) => onSearchChange(e.target.value)}
+        />
+        {filters?.map((f) => (
+          <span key={f.key} data-testid={`filter-${f.key}`}>
+            {f.label}
+          </span>
+        ))}
+      </div>
+    ),
+  };
+});
+
+// Sessions hook fixture — records what query options it was called with so
+// the test can assert wiring without a real network round-trip. The debounced
+// search will eventually arrive on a follow-up render.
+mock.module('../../packages/myco/ui/src/hooks/use-sessions', () => ({
+  useSessions: (opts: Record<string, unknown>) => {
+    sessionsQueryMock(opts);
+    return { data: { sessions: [], total: 0 }, isLoading: false, isError: false };
+  },
+  useDeleteSession: () => ({ mutate: () => {}, isPending: false, isSuccess: false }),
+  useSessionImpact: () => ({ data: undefined }),
+}));
+
+mock.module('../../packages/myco/ui/src/hooks/use-symbionts', () => ({
+  useSymbionts: () => ({
+    data: {
+      symbionts: [
+        { name: 'claude-code', displayName: 'Claude Code', enabled: true },
+        { name: 'cursor', displayName: 'Cursor', enabled: true },
+      ],
+    },
+  }),
+}));
+
+// Force the debounced value through immediately so the test can drive the
+// search wiring without sleeping.
+mock.module('../../packages/myco/ui/src/hooks/use-debounce', () => ({
+  useDebounce: (v: string) => v,
+}));
+
+// Import the page AFTER the mocks so it sees the stubbed modules.
+import Sessions from '../../packages/myco/ui/src/pages/Sessions';
+
+function renderPage(initial: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initial]}>
+        <Routes>
+          <Route path="/sessions" element={<Sessions />} />
+          <Route path="/sessions/:id" element={<Sessions />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('Sessions page-level filter bar (T12)', () => {
+  it('renders <ListFilterBar> outside the master/detail split', async () => {
+    const { container } = renderPage('/sessions');
+    await waitFor(() => expect(screen.getByTestId('list-filter-bar')).toBeTruthy());
+    const filterBar = container.querySelector('[data-testid="list-filter-bar"]') as HTMLElement;
+    const masterDetail = container.querySelector('[role="region"][aria-label="Sessions"]')
+      ?? container.querySelector('[aria-label="Sessions"]');
+    expect(filterBar).toBeTruthy();
+    expect(masterDetail).toBeTruthy();
+    // Structural contract: the filter bar must NOT be a descendant of the
+    // master pane — the whole point of T12 is to lift it out so the master
+    // pane reclaims its width.
+    expect(masterDetail!.contains(filterBar)).toBe(false);
+  });
+
+  it('passes status + symbiont filters into the bar', async () => {
+    renderPage('/sessions');
+    await waitFor(() => expect(screen.getByTestId('list-filter-bar')).toBeTruthy());
+    const bar = screen.getByTestId('list-filter-bar');
+    expect(bar.getAttribute('data-filter-count')).toBe('2');
+    expect(screen.getByTestId('filter-status').textContent).toBe('Status');
+    expect(screen.getByTestId('filter-agent').textContent).toBe('Symbiont');
+  });
+
+  it('threads search input through to useSessions as the `search` query option', async () => {
+    renderPage('/sessions');
+    await waitFor(() => expect(screen.getByTestId('list-filter-bar-search')).toBeTruthy());
+    const input = screen.getByTestId('list-filter-bar-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'onboarding' } });
+    await waitFor(() => {
+      const calls = sessionsQueryMock.mock.calls;
+      // Latest call should have search === 'onboarding'
+      const latest = calls[calls.length - 1]?.[0] as Record<string, unknown> | undefined;
+      expect(latest?.search).toBe('onboarding');
+    });
+  });
+});


### PR DESCRIPTION
Block 2 of the Phase 7 UI evolution
([plan](https://github.com/goondocks-co/myco) id `67b54f3d6dcda98f`).
Stacks on Block 1 (#337) primitives. Sessions filter chrome moves out of
the narrow master pane to the page level; row + header chrome adopts the
v7 visual treatment.

## Summary

- **T12 — Filters lifted to page level.** `pages/Sessions.tsx` now owns
  `useListFilters`, the symbiont-filter computation, and renders
  `<ListFilterBar>` above `MasterDetailSplit`. The master pane reclaims
  its full width.
- **T13 — Row re-skin.** `SessionList` rows adopt the v7
  `.myco-grove-active-row` treatment: ghost-border separators, soft
  `bg-surface-container` hover, sage left-stripe + tinted background on
  the selected row, softer sage ring on the keyboard cursor.
- **T14 — Header re-skin.** `SessionDetail` title switches to
  `myco-display-lg`; the 3 single-metric tiles (Prompts / Tool Calls /
  Plans) move from `<StatCard>` to `<MetricCard>`. The 4th slot keeps
  `<CanopyEfficiencyTile>` — dropping it would lose shipped
  functionality for a less-useful Spore count.
- **T15 — Contract test.** `tests/ui/sessions-filter-bar.test.tsx`
  asserts the filter bar mounts outside the master pane and the search
  input wires into `useSessions`. Stubs `<ListFilterBar>` to a plain
  input so the test doesn't render Radix Select (per Block 1 spore on
  bun + jsdom + Radix).

## Tests

- `npm test`: **220 pass / 0 fail** (Block 1: 217 → Block 2: +3 from
  sessions-filter-bar).

## Out-of-scope notes

- The keyboard `/` shortcut still focuses the search input — the ref
  threads page → bar → input.
- Pagination state moves with the filter bar's session lifecycle (still
  in `useListFilters`); filter changes reset offset to 0 as before.
- The CanopyEfficiencyTile keeps its bespoke chrome; it composes more
  than a single metric and gets re-skinned alongside Cortex work later
  in Phase 7 if time allows, or punts to Phase 8.

Plan: `67b54f3d6dcda98f`. Branch base: `main` @ `046e49e1` (post-#337).

🤖 Generated with [Claude Code](https://claude.com/claude-code)