### PR TITLE
ui(phase-7): Block 5 — Skills TileTabs + ListFilterBar + SkillDetail re-skin

### DIFF
--- a/packages/myco/ui/src/components/skills/CandidateList.tsx
+++ b/packages/myco/ui/src/components/skills/CandidateList.tsx
@@ -5,7 +5,7 @@ import { Badge } from '../ui/badge';
 import { Surface } from '../ui/surface';
 import { Button } from '../ui/button';
 import { MarkdownContent } from '../ui/markdown-content';
-import { ListToolbar, type FilterDefinition } from '../ui/list-toolbar';
+import { ListFilterBar, type FilterDefinition } from '../ui/list-filter-bar';
 import { Pagination } from '../ui/pagination';
 import { useSkillCandidates, useUpdateCandidate, type SkillCandidate } from '../../hooks/use-skills';
 import { useListFilters, FILTER_ALL } from '../../hooks/use-list-filters';
@@ -350,8 +350,8 @@ export function CandidateList() {
   }
 
   const toolbar = (
-    <ListToolbar
-      searchPlaceholder="Search candidates..."
+    <ListFilterBar
+      searchPlaceholder="Search candidates by title or rationale..."
       searchValue={searchInput}
       onSearchChange={handleSearchChange}
       filters={CANDIDATE_FILTERS}

--- a/packages/myco/ui/src/components/skills/SkillDetail.tsx
+++ b/packages/myco/ui/src/components/skills/SkillDetail.tsx
@@ -3,7 +3,8 @@ import { ArrowLeft, AlertCircle, Trash2 } from 'lucide-react';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { Surface } from '../ui/surface';
-import { StatCard } from '../ui/stat-card';
+import { MetricCard } from '../ui/metric-card';
+import { Eyebrow } from '../ui/eyebrow';
 import { SectionHeader } from '../ui/section-header';
 import { MarkdownContent } from '../ui/markdown-content';
 import { ConfirmDialog } from '../ui/confirm-dialog';
@@ -108,10 +109,11 @@ export function SkillDetail({ skillName, onBack }: SkillDetailProps) {
       </div>
 
       {/* Header card */}
-      <Surface level="low" className="p-4 space-y-3">
+      <Surface level="low" accent="sage" className="p-5 space-y-3">
         <div className="flex flex-wrap items-start gap-3">
           <div className="flex-1 space-y-1 min-w-0">
-            <h1 className="font-serif text-lg text-on-surface">
+            <Eyebrow tone="sage">Skill · {skill.name}</Eyebrow>
+            <h1 className="myco-display-md text-on-surface m-0">
               {skill.display_name}
             </h1>
             {skill.description && (
@@ -140,23 +142,23 @@ export function SkillDetail({ skillName, onBack }: SkillDetailProps) {
         </div>
       </Surface>
 
-      {/* Stat cards */}
+      {/* Metric tiles */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <StatCard
+        <MetricCard
           label="Generation"
           value={`v${skill.generation}`}
-          accent="sage"
+          tone="sage"
+          mono
         />
-        <StatCard
+        <MetricCard
           label="Usage"
           value={`${skill.usage_total ?? skill.usage_count ?? 0}`}
-          sublabel="sessions"
-          accent="ochre"
+          sub="sessions"
+          tone="ochre"
         />
-        <StatCard
+        <MetricCard
           label="Sources"
           value={`${sourceCount}`}
-          accent="outline"
         />
       </div>
 

--- a/packages/myco/ui/src/components/skills/SkillList.tsx
+++ b/packages/myco/ui/src/components/skills/SkillList.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 import { AlertCircle, BookOpen } from 'lucide-react';
 import { Badge } from '../ui/badge';
 import { Surface } from '../ui/surface';
-import { ListToolbar, type FilterDefinition } from '../ui/list-toolbar';
+import { ListFilterBar, type FilterDefinition } from '../ui/list-filter-bar';
 import { Pagination } from '../ui/pagination';
 import { useSkillRecords, type SkillRecord } from '../../hooks/use-skills';
 import { useListFilters, FILTER_ALL } from '../../hooks/use-list-filters';
@@ -147,13 +147,14 @@ export function SkillList({ onSelectSkill }: { onSelectSkill: (name: string) => 
     : records;
 
   const toolbar = (
-    <ListToolbar
-      searchPlaceholder="Search skills..."
+    <ListFilterBar
+      searchPlaceholder="Search skills by name, slug, or description..."
       searchValue={searchInput}
       onSearchChange={handleSearchChange}
       filters={SKILL_FILTERS}
       filterValues={filterValues}
       onFilterChange={handleFilterChange}
+      count={total > 0 ? `${total} ${total === 1 ? 'skill' : 'skills'}` : undefined}
     />
   );
 

--- a/packages/myco/ui/src/pages/Skills.tsx
+++ b/packages/myco/ui/src/pages/Skills.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { HelpCircle, ExternalLink } from 'lucide-react';
 import { PageHeader } from '../components/ui/page-header';
-import type { Tab } from '../components/ui/tab-switcher';
+import { TileTabs } from '../components/ui/tile-tabs';
 import { Badge } from '../components/ui/badge';
 import { Button } from '../components/ui/button';
 import {
@@ -27,8 +27,8 @@ const PARAM_SKILL = 'skill';
 
 const VALID_TABS = new Set<SkillsTab>(['candidates', 'skills']);
 
-function readUrlState(): { tab: SkillsTab; skill?: string } {
-  const params = new URLSearchParams(window.location.search);
+function readUrlState(search: string): { tab: SkillsTab; skill?: string } {
+  const params = new URLSearchParams(search);
   const rawTab = params.get(PARAM_TAB);
   const tab: SkillsTab =
     rawTab && VALID_TABS.has(rawTab as SkillsTab) ? (rawTab as SkillsTab) : 'skills';
@@ -49,10 +49,10 @@ function writeUrlState(tab: SkillsTab, skill?: string): void {
 
 /* ---------- Tab definitions ---------- */
 
-const TABS: Tab[] = [
-  { id: 'skills', label: 'Skills' },
-  { id: 'candidates', label: 'Candidates' },
-];
+const TABS = [
+  { id: 'skills', label: 'Skills', description: 'promoted records' },
+  { id: 'candidates', label: 'Candidates', description: 'approval queue' },
+] as const;
 
 /* ---------- Help Dialog ---------- */
 
@@ -133,7 +133,7 @@ function SkillsHelpDialog() {
 
 export default function Skills() {
   const location = useLocation();
-  const initial = readUrlState();
+  const initial = readUrlState(location.search);
   const [tab, setTab] = useState<SkillsTab>(initial.tab);
   const [selectedSkill, setSelectedSkill] = useState<string | undefined>(initial.skill);
 
@@ -148,7 +148,7 @@ export default function Skills() {
   }, [tab, selectedSkill]);
 
   useEffect(() => {
-    const state = readUrlState();
+    const state = readUrlState(location.search);
     setTab(state.tab);
     setSelectedSkill(state.skill);
   }, [location.search, location.key]);
@@ -165,13 +165,10 @@ export default function Skills() {
   }, []);
 
   return (
-    <div className="p-6 space-y-4">
+    <div className="p-6 space-y-6">
       <PageHeader
         title="Skills"
         subtitle="Discovered skill candidates and promoted skill records"
-        tabs={TABS}
-        activeTab={tab}
-        onTabChange={switchTab}
         actions={
           <div className="flex items-center gap-2">
             {pendingCount > 0 && <Badge variant="secondary">{pendingCount} pending</Badge>}
@@ -179,6 +176,13 @@ export default function Skills() {
             <SkillsHelpDialog />
           </div>
         }
+      />
+
+      <TileTabs
+        tabs={TABS.map((t) => ({ id: t.id, label: t.label, description: t.description }))}
+        activeTab={tab}
+        onTabChange={switchTab}
+        columns={2}
       />
 
       {/* Candidates tab */}

--- a/tests/ui/skills-tabs.test.tsx
+++ b/tests/ui/skills-tabs.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+
+/**
+ * Phase 7 Block 5 T26 — Skills page TileTabs + ListFilterBar contract.
+ *
+ * Renders Skills with the candidate / record hooks mocked and asserts:
+ *   1. The page-level TileTabs renders Skills + Candidates with descriptions.
+ *   2. Active state honors `?tab=…`.
+ *   3. The SkillList (Skills tab default) renders a ListFilterBar at page
+ *      level via our stubbed implementation; the search input is wired to
+ *      the underlying record query.
+ *   4. The CandidateList (Candidates tab) also surfaces a ListFilterBar.
+ *
+ * Same stubbing pattern as cortex-tabs / sessions-filter-bar to avoid
+ * Radix Select rendering in the bun + jsdom env (Block 1 spore).
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const recordsQueryMock = mock<(opts: Record<string, unknown>) => void>(() => {});
+
+mock.module('../../packages/myco/ui/src/components/ui/list-filter-bar', () => ({
+  ListFilterBar: ({
+    searchValue,
+    onSearchChange,
+    filters,
+    searchPlaceholder,
+  }: {
+    searchValue: string;
+    onSearchChange: (v: string) => void;
+    filters?: Array<{ key: string; label: string }>;
+    searchPlaceholder?: string;
+  }) => (
+    <div data-testid="list-filter-bar" data-filter-count={filters?.length ?? 0}>
+      <input
+        data-testid="list-filter-bar-search"
+        placeholder={searchPlaceholder}
+        value={searchValue}
+        onChange={(e) => onSearchChange(e.target.value)}
+      />
+    </div>
+  ),
+}));
+
+mock.module('../../packages/myco/ui/src/hooks/use-skills', () => ({
+  useSkillRecords: (opts: Record<string, unknown>) => {
+    recordsQueryMock(opts);
+    return {
+      data: {
+        records: [
+          {
+            id: 'sk1',
+            name: 'phase-7-ui-evolution',
+            display_name: 'Phase 7 UI evolution',
+            description: 'discipline',
+            status: 'active',
+            generation: 1,
+            candidate_id: null,
+            source_ids: '[]',
+            path: '.agents/skills/phase-7-ui-evolution.md',
+            usage_count: 12,
+            last_used_at: null,
+            created_at: 1779000000,
+            updated_at: 1779099900,
+            properties: null,
+          },
+        ],
+        total: 1,
+      },
+      isLoading: false,
+      isError: false,
+    };
+  },
+  useSkillCandidates: () => ({
+    data: { candidates: [], total: 0 },
+    isLoading: false,
+    isError: false,
+  }),
+  useUpdateCandidate: () => ({ mutate: () => {}, isPending: false }),
+  useDeleteSkillRecord: () => ({ mutate: () => {}, isPending: false }),
+  useSkillRecord: () => ({ data: null, isPending: false, isError: false }),
+}));
+
+mock.module('../../packages/myco/ui/src/hooks/use-debounce', () => ({
+  useDebounce: (v: string) => v,
+}));
+
+import Skills from '../../packages/myco/ui/src/pages/Skills';
+
+function renderPage(initial: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initial]}>
+        <Routes>
+          <Route path="/skills" element={<Skills />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('Skills page TileTabs (T23)', () => {
+  it('renders the Skills + Candidates tabs with descriptions', () => {
+    renderPage('/skills');
+    const tabs = screen.getAllByRole('tab');
+    const labels = tabs.map((t) => t.textContent ?? '');
+    expect(labels.some((l) => l.includes('Skills'))).toBe(true);
+    expect(labels.some((l) => l.includes('Candidates'))).toBe(true);
+    expect(labels.some((l) => l.includes('promoted records'))).toBe(true);
+    expect(labels.some((l) => l.includes('approval queue'))).toBe(true);
+  });
+
+  it('marks Skills active by default', () => {
+    renderPage('/skills');
+    const active = screen.getByRole('tab', { selected: true });
+    expect(active.textContent).toContain('Skills');
+  });
+
+  it('marks Candidates active when ?tab=candidates', () => {
+    renderPage('/skills?tab=candidates');
+    const active = screen.getByRole('tab', { selected: true });
+    expect(active.textContent).toContain('Candidates');
+  });
+});
+
+describe('Skills page ListFilterBar (T24)', () => {
+  it('renders ListFilterBar on the Skills tab', () => {
+    renderPage('/skills');
+    expect(screen.getByTestId('list-filter-bar')).toBeTruthy();
+  });
+
+  it('threads search input through to useSkillRecords', () => {
+    renderPage('/skills');
+    const input = screen.getByTestId('list-filter-bar-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'phase' } });
+    // Local search filtering is client-side in SkillList — the query
+    // call still fires with the active filter values, and the local
+    // filter applies on top. We assert the input wiring (re-renders with
+    // new value) rather than the underlying query string.
+    expect(input.value).toBe('phase');
+  });
+
+  it('renders ListFilterBar on the Candidates tab as well', () => {
+    renderPage('/skills?tab=candidates');
+    expect(screen.getByTestId('list-filter-bar')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Block 5 of the Phase 7 UI evolution
([plan](https://github.com/goondocks-co/myco) id `67b54f3d6dcda98f`).
Stacks on Block 1 primitives, Block 2 ListFilterBar pattern, and Block 4
TileTabs work. Skills page joins the v7 tab + filter chrome system.

## Summary

- **T23 — `<TileTabs columns={2}>` for Skills + Candidates** with v7
  descriptors ("promoted records" / "approval queue"). Pending vs active
  state encoded in the tab pattern.
- **T23 (bonus fix)** — `readUrlState` now takes search from
  `useLocation()` instead of `window.location.search`. The previous
  implementation silently broke under `MemoryRouter` (and was fragile
  for any future router-state-only navigation). Surfaced by T26's tab
  assertion.
- **T24 — `<ListFilterBar>`** replaces `<ListToolbar>` in both
  SkillList and CandidateList. Page-level placement; SkillList adds a
  result count.
- **T25 — SkillDetail re-skin.** Header card adopts
  `<Surface accent="sage">` + `<Eyebrow tone="sage">` +
  `myco-display-md` italic title. 3 `<StatCard>` tiles swap to
  `<MetricCard>` with tone variants.
- **T26 — `tests/ui/skills-tabs.test.tsx`** covers both TileTabs +
  ListFilterBar on both tabs, 6 assertions.

Out-of-scope: no `category` filter (no real schema field); CandidateList
card chrome unchanged beyond the toolbar swap (the per-card chrome is
already domain-specific and doesn't have a clean Panel-pattern fit).

## Live smoke (delivered separately as screenshots)

- /skills renders 2 TileTabs at top with descriptors, ListFilterBar at
  910px page width, 28 real skill records load.
- Click into a row → SkillDetail shows the Eyebrow + serif italic title
  + 3 MetricCards (Generation = v1, Usage = 0, Sources = 1).
- 0 console errors.

## Tests

- `npm test`: **4881 node + 238 jsdom pass / 0 fail** (+6 jsdom from
  `skills-tabs.test.tsx`). One flake retry on an unrelated 5s-deadline
  backup test.

Plan: `67b54f3d6dcda98f`. Branch base: `main` @ `29fd6d6a` (post-#341).

🤖 Generated with [Claude Code](https://claude.com/claude-code)