### PR TITLE
ui(phase-7): Block 6 — Mycelium + Agent TileTabs, RunList v7 chrome, RunDetail MetricCards

### DIFF
--- a/packages/myco/ui/src/components/agent/RunDetail.tsx
+++ b/packages/myco/ui/src/components/agent/RunDetail.tsx
@@ -3,7 +3,7 @@ import { ArrowLeft, AlertCircle, Loader2, ChevronDown, ChevronRight, RotateCcw }
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { Surface } from '../ui/surface';
-import { StatCard } from '../ui/stat-card';
+import { MetricCard } from '../ui/metric-card';
 import { MarkdownContent } from '../ui/markdown-content';
 import { RefreshIndicator } from '../ui/refresh-indicator';
 import { POLL_INTERVALS, MS_PER_SECOND } from '../../lib/constants';
@@ -462,14 +462,14 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
         )}
       </div>
 
-      {/* Stat cards */}
+      {/* Metric tiles */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4">
-        <StatCard label="Status" value={capitalize(run.status)} accent="sage" />
-        <StatCard label="Task" value={resolveTaskName(run.task, tasksList)} accent="outline" />
-        <StatCard label="Started" value={formatEpochRelative(run.started_at)} accent="outline" />
-        <StatCard label="Duration" value={formatDuration(run.started_at, run.completed_at)} accent="outline" />
-        <StatCard label="Tokens" value={formatTokens(run.tokens_used)} accent="ochre" />
-        <StatCard label={costCardLabel} value={formatCost(run.cost_usd, run.cost_source)} accent="ochre" />
+        <MetricCard label="Status" value={capitalize(run.status)} tone="sage" />
+        <MetricCard label="Task" value={resolveTaskName(run.task, tasksList)} mono />
+        <MetricCard label="Started" value={formatEpochRelative(run.started_at)} mono />
+        <MetricCard label="Duration" value={formatDuration(run.started_at, run.completed_at)} mono />
+        <MetricCard label="Tokens" value={formatTokens(run.tokens_used)} tone="ochre" mono />
+        <MetricCard label={costCardLabel} value={formatCost(run.cost_usd, run.cost_source)} tone="ochre" mono />
       </div>
 
       <div className="flex items-center gap-3 flex-wrap">

--- a/packages/myco/ui/src/components/agent/RunList.tsx
+++ b/packages/myco/ui/src/components/agent/RunList.tsx
@@ -120,11 +120,14 @@ const RunRailRow = memo(forwardRef<HTMLDivElement, RunRailRowProps>(function Run
       data-selected={isActive || undefined}
       data-cursor={isCursor || undefined}
       className={cn(
-        'group relative border-b border-outline-variant/20 last:border-0 px-4 py-3 cursor-pointer transition-all duration-150',
-        'hover:bg-surface-container-high/50 hover:shadow-[inset_3px_0_0_var(--primary)]',
-        'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40',
-        isActive && 'bg-surface-container-high shadow-[inset_3px_0_0_var(--primary)]',
-        isCursor && !isActive && 'bg-surface-container/40 ring-2 ring-inset ring-primary/30',
+        // v7 row treatment — matches Sessions Block 2 (.myco-grove-active-row pattern):
+        // ghost-border separators, soft surface-container hover, sage left-stripe
+        // + tinted background on the active row.
+        'group relative border-b border-[var(--ghost-border)] last:border-b-0 px-4 py-3 cursor-pointer transition-colors duration-100',
+        'hover:bg-surface-container',
+        'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-sage/40',
+        isActive && 'bg-sage/[0.08] shadow-[inset_2px_0_0_var(--sage)]',
+        isCursor && !isActive && 'bg-surface-container/60 ring-1 ring-inset ring-sage/30',
       )}
       onClick={onClick}
       onKeyDown={(e) => {

--- a/packages/myco/ui/src/pages/Agent.tsx
+++ b/packages/myco/ui/src/pages/Agent.tsx
@@ -6,7 +6,7 @@ import { PageHeader } from '../components/ui/page-header';
 import { Surface } from '../components/ui/surface';
 import { MasterDetailSplit } from '../components/ui/master-detail-split';
 import { EmptyDetailHint } from '../components/ui/empty-detail-hint';
-import type { Tab } from '../components/ui/tab-switcher';
+import { TileTabs } from '../components/ui/tile-tabs';
 import { RunList } from '../components/agent/RunList';
 import { RunDetail } from '../components/agent/RunDetail';
 import { RunTaskDialog } from '../components/agent/RunTaskDialog';
@@ -87,12 +87,12 @@ function buildUrlState({ tab, taskId, compareRunIds }: BuildUrlArgs): URLSearchP
 
 /* ---------- Tab definitions ---------- */
 
-const TABS: Tab[] = [
-  { id: 'runs', label: 'Runs' },
-  { id: 'tasks', label: 'Tasks' },
-  { id: 'comparisons', label: 'Comparisons' },
-  { id: 'config', label: 'Config' },
-];
+const TABS = [
+  { id: 'runs', label: 'Runs', description: 'execution log' },
+  { id: 'tasks', label: 'Tasks', description: 'task library' },
+  { id: 'comparisons', label: 'Comparisons', description: 'side-by-side' },
+  { id: 'config', label: 'Config', description: 'agent settings' },
+] as const;
 
 /* ---------- Component ---------- */
 
@@ -225,14 +225,17 @@ export default function Agent() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="shrink-0 p-6 pb-0">
+      <div className="shrink-0 p-6 pb-0 space-y-6">
         <PageHeader
           title="Agent"
           subtitle="Intelligence runs, task configuration, and operational settings"
-          tabs={TABS}
+          actions={pageAction}
+        />
+        <TileTabs
+          tabs={TABS.map((t) => ({ id: t.id, label: t.label, description: t.description }))}
           activeTab={tab}
           onTabChange={switchTab}
-          actions={pageAction}
+          columns={4}
         />
       </div>
 

--- a/packages/myco/ui/src/pages/Mycelium.tsx
+++ b/packages/myco/ui/src/pages/Mycelium.tsx
@@ -5,13 +5,13 @@ import { Inspector } from '../components/mycelium/Inspector';
 import { SporeList } from '../components/mycelium/SporeList';
 import { SporeDetail } from '../components/mycelium/SporeDetail';
 import { PageHeader } from '../components/ui/page-header';
+import { TileTabs } from '../components/ui/tile-tabs';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
 import { useFullGraph, useGraph, useGraphSeeds } from '../hooks/use-spores';
 import { Network, Target, Info, Search } from 'lucide-react';
 import type { GraphNode } from '../hooks/use-graph-canvas';
 import type { SporeSummary } from '../hooks/use-spores';
-import type { Tab } from '../components/ui/tab-switcher';
 import { cn } from '../lib/cn';
 import { formatGraphLabel } from '../lib/graph-labels';
 
@@ -33,11 +33,11 @@ type UiGraphEdge = { source_id: string; target_id: string; label: string; weight
 type ActiveTab = 'graph' | 'spores';
 type ViewMode = 'global' | 'focus';
 
-/** Tab definitions for the PageHeader TabSwitcher. */
-const MYCELIUM_TABS: Tab[] = [
-  { id: 'graph', label: 'Graph' },
-  { id: 'spores', label: 'Spores' },
-];
+/** Tab definitions for the page-level TileTabs control. */
+const MYCELIUM_TABS = [
+  { id: 'graph', label: 'Graph', description: 'connection map' },
+  { id: 'spores', label: 'Spores', description: 'captured knowledge' },
+] as const;
 
 /* ---------- URL state helpers ---------- */
 
@@ -458,13 +458,17 @@ export default function Mycelium() {
   }
 
   return (
-    <div className="p-6 space-y-4">
+    <div className="p-6 space-y-6">
       <PageHeader
         title="Mycelium"
         subtitle="Derived intelligence — spores, entity graph, and synthesized context."
-        tabs={MYCELIUM_TABS}
+      />
+
+      <TileTabs
+        tabs={MYCELIUM_TABS.map((t) => ({ id: t.id, label: t.label, description: t.description }))}
         activeTab={activeTab}
         onTabChange={(tabId) => handleTabChange(tabId as ActiveTab)}
+        columns={2}
       />
 
       {/* Tab content */}

--- a/tests/ui/agent-tabs.test.tsx
+++ b/tests/ui/agent-tabs.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+/**
+ * Phase 7 Block 6 T29 — Agent page-level TileTabs contract.
+ *
+ * Asserts the four Agent tabs (Runs / Tasks / Comparisons / Config) render
+ * via TileTabs, active state honors the URL, and the tab labels carry
+ * their v7 descriptors.
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Stub data hooks so Agent renders without network.
+mock.module('../../packages/myco/ui/src/hooks/use-agent', () => ({
+  useAgentRuns: () => ({ data: { runs: [], total: 0, offset: 0, limit: 20 }, isLoading: false, isFetching: false, refetch: () => {} }),
+  useAgentRun: () => ({ data: null, isLoading: false, isError: false }),
+  useAgentReports: () => ({ data: { reports: [] }, isLoading: false }),
+  useAgentTurns: () => ({ data: [], isLoading: false }),
+  useAgentTasks: () => ({ data: { tasks: [] }, isLoading: false }),
+  useTask: () => ({ data: null, isLoading: false }),
+  useCreateTask: () => ({ mutate: () => {}, isPending: false }),
+  useCopyTask: () => ({ mutate: () => {}, isPending: false }),
+  useDeleteTask: () => ({ mutate: () => {}, isPending: false }),
+  useTaskYaml: () => ({ data: null, isLoading: false }),
+  useUpdateTask: () => ({ mutate: () => {}, isPending: false }),
+  useTriggerRun: () => ({ mutate: () => {}, isPending: false }),
+  useResumeRun: () => ({ mutate: () => {}, isPending: false }),
+  useRunsByIds: () => ({ runs: [], isLoading: false, isError: false, errors: [] }),
+}));
+
+// Stub child components that pull additional hooks not relevant to the tab
+// chrome contract.
+mock.module('../../packages/myco/ui/src/components/agent/RunList', () => ({
+  RunList: () => <div data-testid="run-list" />,
+}));
+mock.module('../../packages/myco/ui/src/components/agent/TaskList', () => ({
+  TaskList: () => <div data-testid="task-list" />,
+}));
+mock.module('../../packages/myco/ui/src/components/agent/AgentConfig', () => ({
+  AgentConfig: () => <div data-testid="agent-config" />,
+}));
+mock.module('../../packages/myco/ui/src/components/agent/RunTaskDialog', () => ({
+  RunTaskDialog: () => null,
+}));
+
+import Agent from '../../packages/myco/ui/src/pages/Agent';
+
+function renderPage(initial: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initial]}>
+        <Routes>
+          <Route path="/agent" element={<Agent />} />
+          <Route path="/agent/:id" element={<Agent />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('Agent page TileTabs (T28)', () => {
+  it('renders all four Agent tabs with descriptors', () => {
+    renderPage('/agent');
+    const labels = screen.getAllByRole('tab').map((t) => t.textContent ?? '');
+    expect(labels.some((l) => l.includes('Runs'))).toBe(true);
+    expect(labels.some((l) => l.includes('Tasks'))).toBe(true);
+    expect(labels.some((l) => l.includes('Comparisons'))).toBe(true);
+    expect(labels.some((l) => l.includes('Config'))).toBe(true);
+    expect(labels.some((l) => l.includes('execution log'))).toBe(true);
+    expect(labels.some((l) => l.includes('agent settings'))).toBe(true);
+  });
+
+  it('marks Runs active by default', () => {
+    renderPage('/agent');
+    const active = screen.getByRole('tab', { selected: true });
+    expect(active.textContent).toContain('Runs');
+    expect(screen.getByTestId('run-list')).toBeTruthy();
+  });
+
+  it('marks Tasks active when ?tab=tasks', () => {
+    renderPage('/agent?tab=tasks');
+    const active = screen.getByRole('tab', { selected: true });
+    expect(active.textContent).toContain('Tasks');
+    expect(screen.getByTestId('task-list')).toBeTruthy();
+  });
+
+  it('marks Config active when ?tab=config', () => {
+    renderPage('/agent?tab=config');
+    const active = screen.getByRole('tab', { selected: true });
+    expect(active.textContent).toContain('Config');
+    expect(screen.getByTestId('agent-config')).toBeTruthy();
+  });
+});

--- a/tests/ui/mycelium-tabs.test.tsx
+++ b/tests/ui/mycelium-tabs.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+/**
+ * Phase 7 Block 6 T29 — Mycelium page-level TileTabs contract.
+ *
+ * Asserts the two Mycelium tabs (Graph / Spores) render via TileTabs with
+ * v7 descriptors and active state tracks the URL.
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Stub the heavy GraphTab / Spore components so we focus only on tab chrome.
+mock.module('../../packages/myco/ui/src/components/mycelium/GraphCanvas', () => ({
+  GraphCanvas: () => <div data-testid="graph-canvas" />,
+}));
+mock.module('../../packages/myco/ui/src/components/mycelium/Inspector', () => ({
+  Inspector: () => null,
+}));
+mock.module('../../packages/myco/ui/src/components/mycelium/SporeList', () => ({
+  SporeList: () => <div data-testid="spore-list" />,
+}));
+mock.module('../../packages/myco/ui/src/components/mycelium/SporeDetail', () => ({
+  SporeDetail: () => <div data-testid="spore-detail" />,
+}));
+
+mock.module('../../packages/myco/ui/src/hooks/use-spores', () => ({
+  useFullGraph: () => ({ data: { nodes: [], edges: [] }, isLoading: false }),
+  useGraph: () => ({ data: null, isLoading: false }),
+  useGraphSeeds: () => ({ data: { recommended_id: null, seeds: [] }, isLoading: false }),
+}));
+
+import Mycelium from '../../packages/myco/ui/src/pages/Mycelium';
+
+function renderPage(initial: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initial]}>
+        <Routes>
+          <Route path="/mycelium" element={<Mycelium />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('Mycelium page TileTabs (T27)', () => {
+  it('renders Graph + Spores tabs with descriptors', () => {
+    renderPage('/mycelium');
+    const labels = screen.getAllByRole('tab').map((t) => t.textContent ?? '');
+    expect(labels.some((l) => l.includes('Graph'))).toBe(true);
+    expect(labels.some((l) => l.includes('Spores'))).toBe(true);
+    expect(labels.some((l) => l.includes('connection map'))).toBe(true);
+    expect(labels.some((l) => l.includes('captured knowledge'))).toBe(true);
+  });
+
+  it('marks Graph active by default', () => {
+    renderPage('/mycelium');
+    const active = screen.getByRole('tab', { selected: true });
+    expect(active.textContent).toContain('Graph');
+  });
+});


### PR DESCRIPTION
Block 6 of the Phase 7 UI evolution
([plan](https://github.com/goondocks-co/myco) id `67b54f3d6dcda98f`).
Mycelium and Agent join the v7 tab system; agent run rows + detail
header adopt the Block 2 SessionList chrome + MetricCard treatment.

## Summary

- **T27 — Mycelium `<TileTabs columns={2}>`** (Graph · connection map /
  Spores · captured knowledge).
- **T28 — Agent `<TileTabs columns={4}>`** (Runs · execution log /
  Tasks · task library / Comparisons · side-by-side / Config · agent
  settings).
- **T28 — RunList rows** adopt the v7 `.myco-grove-active-row`
  treatment from Block 2 (ghost-border, sage stripe + tinted bg on
  active, sage ring on cursor).
- **T28 — RunDetail header** swaps 6 `<StatCard>` tiles for
  `<MetricCard>` with mono variants for operational fields (Task /
  Started / Duration / Tokens / Cost). Status keeps the italic serif
  default.
- **T29 — `tests/ui/mycelium-tabs.test.tsx` + `agent-tabs.test.tsx`**
  cover both tab nav contracts (6 assertions total).

## Live smoke (delivered separately as screenshots)

- /agent: 4 TileTabs with descriptors, Runs active, RunList rows show
  v7 chrome, RunDetail header has 6 MetricCard tiles.
- /mycelium: 2 TileTabs with descriptors, Graph active, real graph
  canvas renders.
- 0 console errors.

## Tests

- `npm test`: **4881 node + 244 jsdom pass / 0 fail** (+6 jsdom from
  the two tab nav tests). Green first try, no flakes.

Plan: `67b54f3d6dcda98f`. Branch base: `main` @ `8f024b1c` (post-#342).

🤖 Generated with [Claude Code](https://claude.com/claude-code)