### PR TITLE
ui(phase-7): Block 7 — Grove vault MetricCards, MemberAvatar, Operations TileTabs

### DIFF
--- a/packages/myco/ui/src/components/grove/GroveVaultSummary.tsx
+++ b/packages/myco/ui/src/components/grove/GroveVaultSummary.tsx
@@ -1,8 +1,8 @@
 import { Cpu } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { Surface } from '../ui/surface';
-import { SectionHeader } from '../ui/section-header';
-import { StatCard } from '../ui/stat-card';
+import { Eyebrow } from '../ui/eyebrow';
+import { MetricCard } from '../ui/metric-card';
 import { useEmbeddingDetails } from '../../hooks/use-embedding-details';
 import { useDatabaseDetails } from '../../hooks/use-database-details';
 import { formatBytes } from '../../lib/format';
@@ -18,35 +18,41 @@ export function GroveVaultSummary({ groveSlug }: Props) {
   const totalPending = emb ? Object.values(emb.pending).reduce((a, b) => a + b, 0) : 0;
 
   return (
-    <Surface level="low" className="rounded-lg p-5 space-y-3">
+    <Surface level="low" accent="sage" className="rounded-lg p-5 space-y-3">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Cpu className="h-4 w-4 text-primary" />
-          <SectionHeader>Vault</SectionHeader>
+          <Cpu className="h-4 w-4 text-sage" />
+          <div className="space-y-0.5">
+            <Eyebrow tone="sage">Grove</Eyebrow>
+            <h3 className="myco-display-sm text-on-surface m-0">Vault</h3>
+          </div>
         </div>
         <Link
           to={`/g/${groveSlug}/operations`}
-          className="text-xs text-primary hover:text-primary/80"
+          className="text-xs text-sage hover:text-sage/80"
         >
           Manage in Operations →
         </Link>
       </div>
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <StatCard label="Vectors" value={emb ? String(emb.total) : '—'} accent="sage" />
-        <StatCard
+        <MetricCard label="Vectors" value={emb ? String(emb.total) : '—'} tone="sage" mono />
+        <MetricCard
           label="Pending"
           value={String(totalPending)}
-          accent={totalPending > 0 ? 'ochre' : 'outline'}
+          tone={totalPending > 0 ? 'ochre' : 'default'}
+          mono
         />
-        <StatCard
+        <MetricCard
           label="DB size"
           value={db ? formatBytes(db.file.size_bytes) : '—'}
-          accent="sage"
+          tone="sage"
+          mono
         />
-        <StatCard
+        <MetricCard
           label="Fragmentation"
           value={db ? `${db.file.fragmentation_pct.toFixed(1)}%` : '—'}
-          accent={db && db.file.fragmentation_pct > 25 ? 'ochre' : 'outline'}
+          tone={db && db.file.fragmentation_pct > 25 ? 'ochre' : 'default'}
+          mono
         />
       </div>
     </Surface>

--- a/packages/myco/ui/src/pages/Operations.tsx
+++ b/packages/myco/ui/src/pages/Operations.tsx
@@ -2,17 +2,17 @@ import { useState, useCallback } from 'react';
 import { RefreshCw } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { PageHeader } from '../components/ui/page-header';
+import { TileTabs } from '../components/ui/tile-tabs';
 import { Button } from '../components/ui/button';
 import { EmbeddingTab } from '../components/operations/EmbeddingTab';
 import { DatabaseTab } from '../components/operations/DatabaseTab';
-import type { Tab } from '../components/ui/tab-switcher';
 
 type ActiveTab = 'embedding' | 'database';
 
-const OPERATIONS_TABS: Tab[] = [
-  { id: 'embedding', label: 'Embedding' },
-  { id: 'database', label: 'Database' },
-];
+const OPERATIONS_TABS = [
+  { id: 'embedding', label: 'Embedding', description: 'queues + namespaces' },
+  { id: 'database', label: 'Database', description: 'file health + maintenance' },
+] as const;
 
 const VALID_TABS = new Set<ActiveTab>(['embedding', 'database']);
 
@@ -54,19 +54,22 @@ export default function Operations() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="px-6 pt-6">
+      <div className="px-6 pt-6 space-y-6">
         <PageHeader
           title="Operations"
           subtitle={TAB_SUBTITLES[activeTab]}
-          tabs={OPERATIONS_TABS}
-          activeTab={activeTab}
-          onTabChange={handleTabChange}
           actions={
             <Button variant="ghost" size="sm" onClick={handleRefresh}>
               <RefreshCw size={14} />
               Refresh
             </Button>
           }
+        />
+        <TileTabs
+          tabs={OPERATIONS_TABS.map((t) => ({ id: t.id, label: t.label, description: t.description }))}
+          activeTab={activeTab}
+          onTabChange={handleTabChange}
+          columns={2}
         />
       </div>
 

--- a/packages/myco/ui/src/pages/Team/MembersTab.tsx
+++ b/packages/myco/ui/src/pages/Team/MembersTab.tsx
@@ -3,10 +3,7 @@ import { useTeamStatus } from '../../hooks/use-team';
 import { Surface } from '../../components/ui/surface';
 import { SectionHeader } from '../../components/ui/section-header';
 import { Badge } from '../../components/ui/badge';
-
-function initials(name: string): string {
-  return name.split(/\s+/).slice(0, 2).map((p) => p[0] ?? '').join('').toUpperCase() || '?';
-}
+import { MemberAvatar } from '../../components/ui/member-avatar';
 
 function timeAgo(at: number | null): string {
   if (!at) return 'never';
@@ -21,10 +18,8 @@ function timeAgo(at: number | null): string {
 
 function MemberRow({ m, isSelf }: { m: TeamMember; isSelf: boolean }) {
   return (
-    <li className="flex items-center gap-3 py-3 border-b border-outline-variant/10 last:border-b-0">
-      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-medium text-primary">
-        {initials(m.user)}
-      </div>
+    <li className="flex items-center gap-3 py-3 border-b border-[var(--ghost-border)] last:border-b-0">
+      <MemberAvatar name={m.user} size={36} />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <span className="truncate text-sm text-on-surface">{m.user}</span>


### PR DESCRIPTION
Block 7 of the Phase 7 UI evolution
([plan](https://github.com/goondocks-co/myco) id `67b54f3d6dcda98f`).
Surgical re-skin of three shipped surfaces. Two T33 sub-tasks deferred
to Phase 8 — surfaced honestly in the commit body.

## Summary

- **T30 — `<GroveVaultSummary>`** swaps 4 `<StatCard>` tiles for
  `<MetricCard>` (sage/ochre/mono variants), Surface gains
  `accent="sage"` + Eyebrow + serif italic "Vault" title.
- **T31 — `<MembersTab>`** replaces the bespoke `bg-primary/10` initials
  circle with `<MemberAvatar>` (sage-dim → ochre gradient + mono
  uppercase initials). Row border switches to ghost-border.
- **T32 — `<Operations>`** swaps `PageHeader.tabs` for page-level
  `<TileTabs columns={2}>` with descriptors ("queues + namespaces" /
  "file health + maintenance").

## Deferred to Phase 8 (called out in commit body)

- **T33 FilterBar migration.** Mechanical swap to `<ListFilterBar>`
  (Select-based) broke `tests/ui/settings-page.test.tsx::"scope filter
  narrows visible groups"` which clicks `getByRole('button', { name:
  /^Machine/ })`. The button-row UX (with per-scope count badges) is
  worth preserving, and the Radix Select alternative would need a
  jsdom interaction pattern we haven't proven out. Punch-list item.
- **T31 StepCircle wiring.** No existing numbered-step pattern in
  `NotConnectedView` to swap into — requires a small design shift
  (rendering steps as `<ol>` with `<StepCircle>` markers) rather than
  a chrome swap.

## Live smoke (delivered separately as screenshots)

- /grove*: vault summary card shows sage top-stripe + Eyebrow + serif
  "Vault" + 4 MetricCard tiles with tones.
- /team?tab=members: MemberAvatar renders sage-dim→ochre gradient
  with "SI" initials for the local machine.
- /operations: 2 TileTabs with descriptors, Embedding active.
- /settings: existing FilterBar still works (no behavior change).
- 0 console errors on all four.

## Tests

- `npm test`: **4882 node + 244 jsdom pass / 0 fail**. The earlier
  T33-attempt run caught a Settings test regression — the discipline
  is working as intended (caught + reverted before merge).

Plan: `67b54f3d6dcda98f`. Branch base: `main` @ `3a6a92d6` (post-#343).

🤖 Generated with [Claude Code](https://claude.com/claude-code)