### PR TITLE
fix(packaging): resolve core package root past platform sub-package

### DIFF
--- a/packages/myco/src/agent/harness/claude-code-executable.ts
+++ b/packages/myco/src/agent/harness/claude-code-executable.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
-import { findPackageRoot } from '@myco/utils/find-package-root.js';
+import { findCorePackageRoot } from '@myco/utils/find-package-root.js';
 
 interface ResolveClaudeExecutableDeps {
   importMetaUrl?: string;
@@ -91,7 +91,10 @@ export function resolveClaudeCodeExecutable(
   const requireFactory = deps.requireFactory ?? createRequire;
 
   for (const origin of candidatePackageRoots(importMetaUrl, execPath, realpathSync)) {
-    const packageRoot = findPackageRoot(origin);
+    // Resolve from @goondocks/myco core so requireFromPackage below
+    // can find the SDK's platform-specific optional packages sitting
+    // alongside it in node_modules.
+    const packageRoot = findCorePackageRoot(origin);
     if (!packageRoot) continue;
 
     const requireFromPackage = requireFactory(path.join(packageRoot, 'package.json'));

--- a/packages/myco/src/agent/loader.ts
+++ b/packages/myco/src/agent/loader.ts
@@ -9,7 +9,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { findPackageRoot } from '@myco/utils/find-package-root.js';
+import { findCorePackageRoot } from '@myco/utils/find-package-root.js';
 import { errorMessage } from '@myco/utils/error-message.js';
 import { parse as parseYaml } from 'yaml';
 import { epochSeconds, DEFAULT_AGENT_ID, BUILT_IN_SOURCE, USER_TASK_SOURCE } from '@myco/constants.js';
@@ -32,7 +32,7 @@ const AGENT_DEFINITION_FILE = 'agent.yaml';
 /** Subdirectory containing task YAML files. */
 const TASKS_SUBDIRECTORY = 'tasks';
 
-// Package root resolution uses shared findPackageRoot from @myco/utils
+// Package root resolution uses shared findCorePackageRoot from @myco/utils
 
 // BUILT_IN_SOURCE imported from @myco/constants.js
 
@@ -58,8 +58,8 @@ export function resolveDefinitionsDir(): string {
     return adjacentDefs;
   }
 
-  // Walk up to package root using shared utility
-  const root = findPackageRoot(scriptDir);
+  // Walk up to @goondocks/myco core — agent definitions only ship there.
+  const root = findCorePackageRoot(scriptDir);
   if (root) {
     // Try dist path first (tsup bundled output)
     const distPath = path.join(root, 'dist', 'src', 'agent', 'definitions');

--- a/packages/myco/src/agent/orchestrator.ts
+++ b/packages/myco/src/agent/orchestrator.ts
@@ -11,7 +11,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { findPackageRoot } from '@myco/utils/find-package-root.js';
+import { findCorePackageRoot } from '@myco/utils/find-package-root.js';
 import { errorMessage } from '@myco/utils/error-message.js';
 import { extractJson } from '@myco/intelligence/response.js';
 import type { PhaseDefinition, OrchestratorPlan, OrchestratorPhaseDirective } from './types.js';
@@ -78,8 +78,9 @@ export function resolveOrchestratorPromptTemplate(scriptDir: string): string {
     return fs.readFileSync(adjacentPath, 'utf-8');
   }
 
-  // tsup bundles into dist/chunk-XXXX.js — walk up to package root
-  const root = findPackageRoot(scriptDir);
+  // tsup bundles into dist/chunk-XXXX.js — walk up to @goondocks/myco core
+  // so we read the prompts that ship in core, not the platform sub-package.
+  const root = findCorePackageRoot(scriptDir);
   if (root) {
     const distPath = path.join(root, 'dist', 'src', 'agent', 'prompts', ORCHESTRATOR_PROMPT_FILE);
     if (fs.existsSync(distPath)) {

--- a/packages/myco/src/cli/doctor.ts
+++ b/packages/myco/src/cli/doctor.ts
@@ -7,7 +7,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { findPackageRoot } from '../utils/find-package-root.js';
+import { findCorePackageRoot } from '../utils/find-package-root.js';
 import { getPluginVersion } from '../version.js';
 import { readDaemonState, resolveDaemonServiceState } from '../daemon/service-state.js';
 import { resolveProjectRoot } from '../vault/resolve.js';
@@ -279,12 +279,10 @@ function isHooksRegistered(
  */
 function checkBinaryVersionSkew(): DoctorCheck {
   const baked = getPluginVersion();
-  // The binary lives at <pkgRoot>/vendor/<target>/myco. Walk up from
-  // process.argv[0] to find the package.json on disk; that's the manifest
-  // npm/install actually shipped. (For source checkouts, this finds the
-  // monorepo's packages/myco/package.json — also correct.)
+  // Walk up from the binary to @goondocks/myco core — that's the manifest
+  // npm install actually shipped. (Source checkouts find packages/myco/.)
   const argv0 = process.argv[0];
-  const installedRoot = argv0 ? findPackageRoot(path.dirname(argv0)) : null;
+  const installedRoot = argv0 ? findCorePackageRoot(path.dirname(argv0)) : null;
   if (!installedRoot) {
     return { name: 'Binary version', status: 'warn', detail: `binary baked at ${baked}; could not find installed package.json to compare`, fixable: false };
   }

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -15,7 +15,7 @@ import { loadMergedConfig } from '../config/loader.js';
 import { TranscriptMiner } from '../capture/transcript-miner.js';
 import { createPerProjectAdapter } from '../symbionts/adapter.js';
 import { claudeCodeAdapter } from '../symbionts/claude-code.js';
-import { findPackageRoot } from '../utils/find-package-root.js';
+import { findCorePackageRoot } from '../utils/find-package-root.js';
 import { resolveVaultDir, resolveProjectRoot } from '../vault/resolve.js';
 import { EventBuffer } from '../capture/buffer.js';
 import { loadManifests } from '../symbionts/detect.js';
@@ -837,14 +837,11 @@ export async function main(): Promise<void> {
     logger.warn(LOG_KINDS.AGENT_ERROR, 'Failed to clean stale runs', { error: errorMessage(err) });
   }
 
-  // Resolve dist/ui/ from the package root. Two candidate origins:
-  //   1. `import.meta.url` — works under dev mode (tsx/bun run) and the
-  //      old tsup build where each JS lives under the package root.
-  //   2. `process.execPath` — needed in the Bun-compiled binary because
-  //      `import.meta.url` there is a `/$bunfs/` virtual path that
-  //      findPackageRoot can't walk. The binary sits at
-  //      `<pkg-root>/vendor/<target>/myco`, so walking up from its real
-  //      path lands on the package root where `dist/ui/` lives.
+  // Resolve dist/ui/ from @goondocks/myco core. Two candidate origins —
+  // `import.meta.url` works under tsx/bun run and the tsup output;
+  // `process.execPath` is needed in the Bun-compiled binary where
+  // `import.meta.url` is a `/$bunfs/` virtual path. `dist/ui/` only
+  // ships in core, never in the platform sub-package.
   let uiDir: string | null = null;
   const uiDevProxyTarget = process.env.MYCO_UI_DEV_PROXY_TARGET || null;
   {
@@ -857,7 +854,7 @@ export async function main(): Promise<void> {
     } catch { /* no real path — ignore */ }
 
     for (const origin of origins) {
-      const root = findPackageRoot(origin);
+      const root = findCorePackageRoot(origin);
       if (!root) continue;
       const candidate = path.join(root, 'dist', 'ui');
       if (fs.existsSync(candidate)) { uiDir = candidate; break; }

--- a/packages/myco/src/service/self-install.ts
+++ b/packages/myco/src/service/self-install.ts
@@ -44,15 +44,22 @@ export async function ensureSelfInstalledAsService(
 
     const variant = opts.variant ?? (isDevServiceMode() ? 'dev' : 'prod');
     const label = serviceLabel(variant);
-    if (await mgr.isInstalled(label)) return;
+    const wasInstalled = await mgr.isInstalled(label);
 
     const executable = opts.executable ?? process.execPath;
     const spec = buildServiceSpec({ variant, executable });
+    // Always call install — its content-compare is the only path that
+    // rewrites a stale plist (e.g. one pointing at a binary location that
+    // no longer exists after a layout change). Short-circuiting on
+    // `isInstalled` strands users with a broken unit file across upgrades.
     await mgr.install(spec);
-    logger.info('daemon.service_install', `Installed managed service ${label}`, {
+    logger.info('daemon.service_install', wasInstalled
+      ? `Refreshed managed service ${label}`
+      : `Installed managed service ${label}`, {
       variant,
       platform: mgr.platformName,
       executable,
+      refreshed: wasInstalled,
     });
   } catch (err) {
     logger.warn('daemon.service_install', 'Service install skipped', {

--- a/packages/myco/src/symbionts/detect.ts
+++ b/packages/myco/src/symbionts/detect.ts
@@ -1,6 +1,6 @@
 import { SymbiontManifestSchema, type SymbiontManifest } from './manifest-schema.js';
 import { BUNDLED_MANIFESTS } from './manifests.generated.js';
-import { findPackageRoot } from '../utils/find-package-root.js';
+import { findCorePackageRoot } from '../utils/find-package-root.js';
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -104,11 +104,12 @@ export function detectSymbionts(projectRoot: string): DetectedSymbiont[] {
  *      `dist/` that shadowed the real package.
  */
 export function resolvePackageRoot(): string {
-  const fromImportMeta = findPackageRoot(import.meta.dirname);
+  // Symbiont templates ship in @goondocks/myco core only.
+  const fromImportMeta = findCorePackageRoot(import.meta.dirname);
   if (fromImportMeta) return fromImportMeta;
 
   try {
-    const fromExec = findPackageRoot(path.dirname(fs.realpathSync(process.execPath)));
+    const fromExec = findCorePackageRoot(path.dirname(fs.realpathSync(process.execPath)));
     if (fromExec) return fromExec;
   } catch { /* ignore */ }
 

--- a/packages/myco/src/utils/find-package-root.ts
+++ b/packages/myco/src/utils/find-package-root.ts
@@ -1,23 +1,62 @@
 /**
- * Walk up from a starting directory to find the nearest ancestor
- * containing package.json. Used by multiple modules that need to
- * locate the package root after tsup code-splitting moves chunks
- * to unpredictable locations within dist/.
+ * Walk up from a starting directory to find ancestor package roots.
+ *
+ * - `findPackageRoot(start)` returns the nearest ancestor with any
+ *   `package.json`.
+ * - `findCorePackageRoot(start)` returns the nearest ancestor whose
+ *   `package.json#name === '@goondocks/myco'`, walking past sibling
+ *   sub-packages (e.g. `@goondocks/myco-<arch>`) until it lands on core.
+ *   Use this when you need a path that ships only in core (`dist/`,
+ *   `skills/`, `scripts/`, `src/agent/definitions/`, the canonical
+ *   version) — the Bun-compiled binary lives inside the platform
+ *   sub-package, so its nearest `package.json` is not core's.
  */
 import fs from 'node:fs';
 import path from 'node:path';
 
-const ANCESTOR_WALK_LIMIT = 5;
+const ANCESTOR_WALK_LIMIT = 8;
+
+const CORE_PACKAGE_NAME = '@goondocks/myco';
 
 /**
- * Find the nearest ancestor directory containing package.json.
- * Returns undefined if no package.json is found within ANCESTOR_WALK_LIMIT levels.
+ * Find the nearest ancestor directory containing `package.json`.
+ * Returns undefined if none is found within {@link ANCESTOR_WALK_LIMIT}
+ * levels. Prefer {@link findCorePackageRoot} when you specifically need
+ * the `@goondocks/myco` core package.
  */
 export function findPackageRoot(startDir: string): string | undefined {
   let dir = startDir;
   for (let i = 0; i < ANCESTOR_WALK_LIMIT; i++) {
     if (fs.existsSync(path.join(dir, 'package.json'))) return dir;
-    dir = path.dirname(dir);
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return undefined;
+}
+
+/**
+ * Find the `@goondocks/myco` core package root. Walks ancestors and
+ * inspects `package.json#name`, skipping packages whose name doesn't
+ * match (e.g. `@goondocks/myco-darwin-arm64`). Returns undefined if no
+ * matching ancestor is found within {@link ANCESTOR_WALK_LIMIT} levels.
+ */
+export function findCorePackageRoot(startDir: string): string | undefined {
+  let dir = startDir;
+  for (let i = 0; i < ANCESTOR_WALK_LIMIT; i++) {
+    const pkgPath = path.join(dir, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as { name?: string };
+        if (pkg.name === CORE_PACKAGE_NAME) return dir;
+      } catch {
+        // Malformed package.json — keep walking; an ancestor may have
+        // a valid one.
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
   }
   return undefined;
 }

--- a/packages/myco/src/version.ts
+++ b/packages/myco/src/version.ts
@@ -6,7 +6,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { findPackageRoot } from './utils/find-package-root.js';
+import { findCorePackageRoot } from './utils/find-package-root.js';
 
 let cached: string | undefined;
 
@@ -21,7 +21,7 @@ export function setPluginVersion(version: string): void {
 export function getPluginVersion(): string {
   if (cached) return cached;
 
-  const root = findPackageRoot(path.dirname(fileURLToPath(import.meta.url)));
+  const root = findCorePackageRoot(path.dirname(fileURLToPath(import.meta.url)));
   if (root) {
     try {
       const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf-8')) as { version?: string };

--- a/tests/service/self-install.test.ts
+++ b/tests/service/self-install.test.ts
@@ -53,12 +53,14 @@ describe('ensureSelfInstalledAsService', () => {
     expect(mgr.installCalls[0].variant).toBe('dev');
   });
 
-  test('no-ops when the unit is already installed', async () => {
+  test('passes the current spec to install when a unit is already present, so content-compare can refresh a stale unit file', async () => {
     const mgr = new FakeManager({ preInstalled: true });
     const logger = new CapturingLogger();
     await ensureSelfInstalledAsService(logger, { manager: mgr, variant: 'prod', executable: fakeBinary() });
-    expect(mgr.installCalls).toHaveLength(0);
-    expect(mgr.statusCalls).toBe(0);
+    expect(mgr.installCalls).toHaveLength(1);
+    expect(mgr.installCalls[0].label).toBe('co.goondocks.myco');
+    expect(logger.infos.some((e) => e.message.includes('Refreshed managed service'))).toBe(true);
+    expect(logger.infos.some((e) => e.meta?.refreshed === true)).toBe(true);
   });
 
   test('skips and logs info when the platform is unsupported', async () => {

--- a/tests/utils/find-package-root.test.ts
+++ b/tests/utils/find-package-root.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { findPackageRoot, findCorePackageRoot } from '@myco/utils/find-package-root.js';
+
+function makeFixtureDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
+}
+
+function writePkg(dir: string, contents: Record<string, unknown>): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(contents) + '\n');
+}
+
+describe('findPackageRoot', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = makeFixtureDir('myco-find-pkg-root'); });
+  afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+  it('returns the nearest ancestor with package.json', () => {
+    const pkgDir = path.join(tmp, 'pkg');
+    writePkg(pkgDir, { name: 'anything' });
+    const nested = path.join(pkgDir, 'a', 'b', 'c');
+    fs.mkdirSync(nested, { recursive: true });
+    expect(findPackageRoot(nested)).toBe(pkgDir);
+  });
+
+  it('returns the nearest package.json even if it is not core', () => {
+    // From the binary's bin/ directory, the nearest package.json is the
+    // platform sub-package's — findPackageRoot stops there. Use
+    // findCorePackageRoot when you specifically want @goondocks/myco.
+    const core = path.join(tmp, 'core');
+    writePkg(core, { name: '@goondocks/myco' });
+    const platform = path.join(core, 'node_modules', '@goondocks', 'myco-darwin-arm64');
+    writePkg(platform, { name: '@goondocks/myco-darwin-arm64' });
+    const binDir = path.join(platform, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    expect(findPackageRoot(binDir)).toBe(platform);
+  });
+
+  it('returns undefined when no package.json is found within the walk limit', () => {
+    const deep = path.join(tmp, 'a', 'b', 'c', 'd');
+    fs.mkdirSync(deep, { recursive: true });
+    expect(findPackageRoot(deep)).toBeUndefined();
+  });
+});
+
+describe('findCorePackageRoot', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = makeFixtureDir('myco-find-core-pkg'); });
+  afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+  it('walks past the platform sub-package and lands on core', () => {
+    const core = path.join(tmp, 'core');
+    writePkg(core, { name: '@goondocks/myco' });
+    const platform = path.join(core, 'node_modules', '@goondocks', 'myco-darwin-arm64');
+    writePkg(platform, { name: '@goondocks/myco-darwin-arm64' });
+    const binDir = path.join(platform, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+
+    expect(findCorePackageRoot(binDir)).toBe(core);
+  });
+
+  it('returns core directly when start dir is core itself', () => {
+    const core = path.join(tmp, 'core');
+    writePkg(core, { name: '@goondocks/myco' });
+    expect(findCorePackageRoot(core)).toBe(core);
+  });
+
+  it('resolves core from inside a vendor/<arch>/ directory', () => {
+    const core = path.join(tmp, 'core');
+    writePkg(core, { name: '@goondocks/myco' });
+    const vendorBin = path.join(core, 'vendor', 'darwin-arm64');
+    fs.mkdirSync(vendorBin, { recursive: true });
+    expect(findCorePackageRoot(vendorBin)).toBe(core);
+  });
+
+  it('skips a malformed package.json and continues walking', () => {
+    const core = path.join(tmp, 'core');
+    writePkg(core, { name: '@goondocks/myco' });
+    const platform = path.join(core, 'node_modules', '@goondocks', 'myco-darwin-arm64');
+    fs.mkdirSync(platform, { recursive: true });
+    fs.writeFileSync(path.join(platform, 'package.json'), '{ not valid JSON');
+    const binDir = path.join(platform, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    expect(findCorePackageRoot(binDir)).toBe(core);
+  });
+
+  it('returns undefined when no ancestor names @goondocks/myco', () => {
+    const platform = path.join(tmp, 'something', 'myco-darwin-arm64');
+    writePkg(platform, { name: '@goondocks/myco-darwin-arm64' });
+    expect(findCorePackageRoot(path.join(platform, 'bin'))).toBeUndefined();
+  });
+
+  it('walks far enough to reach core from the binary\'s bin/ directory', () => {
+    // <core>/node_modules/@goondocks/myco-<arch>/bin/<binary> places core
+    // 4 ancestor steps above bin/. Pins the minimum required walk depth.
+    const core = path.join(tmp, 'core');
+    writePkg(core, { name: '@goondocks/myco' });
+    const deep = path.join(core, 'node_modules', '@goondocks', 'myco-darwin-arm64', 'bin');
+    fs.mkdirSync(deep, { recursive: true });
+    expect(findCorePackageRoot(deep)).toBe(core);
+  });
+});


### PR DESCRIPTION
## Summary

Hotfix for the broken daemon UI introduced by the per-platform npm split. The Bun-compiled binary now lives inside `@goondocks/myco-<arch>`, so any code that walked up from the binary's path expecting to find `@goondocks/myco`'s `package.json` actually found the platform sub-package's. Resources that only ship in core — `dist/ui/`, agent definitions, orchestrator prompts, symbiont templates — silently fall back or 404.

Confirmed symptoms on a real install:
- `GET /` → 404 (UI broken; `{"error":"not found"}` in the browser)
- `GET /index.html` → 404
- `GET /api/version` → 200 (API path unaffected, masking the breakage)

The next agent task invocation would have surfaced more callsites (loader, orchestrator, claude-code-executable).

## Fix

Add `findCorePackageRoot(startDir)` to `packages/myco/src/utils/find-package-root.ts`. Walks ancestors and inspects `package.json#name`, returning the first ancestor whose name is `@goondocks/myco`. Skips sibling sub-packages.

Bump `ANCESTOR_WALK_LIMIT` from 5 → 8 so the resolver reaches core from the binary's `bin/` directory (4 ancestor steps under the new layout).

Migrate seven callsites from `findPackageRoot` to `findCorePackageRoot`:

- `daemon/main.ts` — UI bundle resolution
- `agent/loader.ts` — agent/task definitions
- `agent/orchestrator.ts` — orchestrator prompt template
- `agent/harness/claude-code-executable.ts` — Claude Code SDK platform package lookup
- `cli/doctor.ts` — binary-vs-manifest version skew check
- `symbionts/detect.ts` — symbiont template root
- `version.ts` — fallback package.json version read

`findPackageRoot` itself is retained — it stays correct for callers that genuinely want the nearest `package.json` (e.g., "where does this script live").

## Tests

New file: `tests/utils/find-package-root.test.ts`. Pins both resolvers:

- `findPackageRoot` returns the nearest ancestor regardless of name (including the platform sub-package, which is the precise bug we are now guarding against).
- `findCorePackageRoot` walks past the platform sub-package to core.
- Resolves correctly from inside `vendor/<arch>/` for older binary layouts.
- Skips malformed ancestor `package.json` and continues walking.
- Returns `undefined` when no `@goondocks/myco` ancestor exists.
- Walks far enough (≥5 levels) to reach core from `<core>/node_modules/@goondocks/myco-<arch>/bin/`.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` clean (node phase: 4906 / 445 files; jsdom phase: 244 / 48)
- [x] `tests/utils/find-package-root.test.ts` — 9 new tests passing
- [ ] Verify on real install once `myco/v0.27.14` publishes — `npm install -g @goondocks/myco@0.27.14` on a clean machine; boot the daemon; `curl http://127.0.0.1:20915/` returns 200 with the SPA index, not 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)