### PR TITLE
feat(daemon): activity→batch invariant + per-job lag attribution

### DIFF
--- a/.agents/skills/debug-daemon-errors/SKILL.md
+++ b/.agents/skills/debug-daemon-errors/SKILL.md
@@ -54,6 +54,7 @@ Each daemon subsystem has a distinct failure signature:
 | **Executor (phased tasks)** | Task status transitions to `complete` or `failed` silently; no error thrown |
 | **Timeout cascade failure** | Task shows *"process aborted by user"* when no user action occurred |
 | **Self-mutation discipline** | Daemon corrupts its own state during normal operations; daemon.json becomes invalid after restart |
+| **Daemon restart/reconciliation** | PID conflicts, EPERM errors, MCP bridge indefinite reconnect loops |
 
 ---
 
@@ -159,7 +160,126 @@ try {
 
 ---
 
-## Step 4 — Write the Regression Test First
+## Step 4 — Daemon Restart and PID Reconciliation Failures
+
+### EPERM Livelock in reconcileExistingDaemon
+
+**Problem:** When daemon restart encounters an existing daemon.json with a stale PID, `reconcileExistingDaemon` can enter an EPERM livelock where repeated `process.kill(pid, 0)` calls fail with EPERM but the function keeps retrying without resolution.
+
+**Root cause:** The kill-probe doesn't distinguish between "process doesn't exist" (ESRCH, safe to proceed) and "process exists but we can't signal it" (EPERM, uncertain state).
+
+**Fix pattern:** Treat EPERM as "uncertain" and escalate to user decision rather than looping:
+```typescript
+export async function reconcileExistingDaemon(existingRecord: DaemonRecord): Promise<'cleared' | 'escalate'> {
+  try {
+    // Probe with kill signal 0 (no-op probe)
+    process.kill(existingRecord.pid, 0);
+    // If we get here, process exists and we can signal it
+    logger.info(`Found existing daemon process ${existingRecord.pid}, attempting clean shutdown`);
+    process.kill(existingRecord.pid, 'SIGTERM');
+    await waitForProcessExit(existingRecord.pid, { timeoutMs: 10000 });
+    return 'cleared';
+  } catch (err) {
+    if (err.code === 'ESRCH') {
+      // Process doesn't exist, safe to clear the record
+      logger.info(`Daemon record points to non-existent process ${existingRecord.pid}, clearing stale record`);
+      return 'cleared';
+    } else if (err.code === 'EPERM') {
+      // Process may exist but we can't signal it - escalate to user
+      logger.warn(`Cannot signal existing daemon process ${existingRecord.pid} (EPERM). Manual intervention required.`);
+      console.error(`Existing daemon process ${existingRecord.pid} is running but not accessible.`);
+      console.error(`Please manually stop the process or run: sudo kill ${existingRecord.pid}`);
+      return 'escalate';
+    } else {
+      throw err; // Unexpected error
+    }
+  }
+}
+```
+
+### Daemon Restart Failure Mode 4 — MCP Bridge Indefinite Reconnect
+
+**Problem:** During daemon restart, if the MCP bridge connection fails to establish cleanly, it can enter an indefinite reconnect loop where the daemon appears to start successfully but the bridge never becomes functional.
+
+**Diagnosis patterns:**
+```bash
+# Look for these log patterns indicating Mode 4 failure:
+grep -A 5 -B 5 "MCP bridge.*reconnect" ~/.myco/daemon.log
+grep "bridge.*timeout\|bridge.*failed" ~/.myco/daemon.log | tail -20
+```
+
+**Typical Mode 4 signature:**
+```
+[MCP] Bridge connection attempt 1 failed: connect ECONNREFUSED 127.0.0.1:3456
+[MCP] Bridge connection attempt 2 failed: connect ECONNREFUSED 127.0.0.1:3456
+[MCP] Bridge connection attempt 3 failed: connect ECONNREFUSED 127.0.0.1:3456
+[MCP] Bridge reconnect exponential backoff, next attempt in 8000ms
+[MCP] Bridge connection attempt 4 failed: connect ECONNREFUSED 127.0.0.1:3456
+```
+
+**Resolution procedure:**
+```typescript
+export async function resolveMcpBridgeLoopMode4() {
+  // Step 1: Stop daemon cleanly to break the reconnect loop
+  await stopDaemonProcess({ force: false, timeoutMs: 15000 });
+  
+  // Step 2: Clean any stale MCP bridge state
+  await cleanupMcpBridgeState();
+  
+  // Step 3: Restart with bridge connection verification
+  const startResult = await startDaemonWithBridgeVerification();
+  
+  if (!startResult.bridgeHealthy) {
+    throw new Error('Daemon started but MCP bridge failed verification. Check daemon port conflicts.');
+  }
+  
+  return startResult;
+}
+
+async function startDaemonWithBridgeVerification(): Promise<{ pid: number; bridgeHealthy: boolean }> {
+  const daemon = await startDaemonProcess();
+  
+  // Wait for bridge to establish or timeout
+  const bridgeHealthy = await waitForMcpBridgeReady({
+    timeoutMs: 10000,
+    healthCheckInterval: 500
+  });
+  
+  return { pid: daemon.pid, bridgeHealthy };
+}
+
+async function waitForMcpBridgeReady({ timeoutMs, healthCheckInterval }: { timeoutMs: number; healthCheckInterval: number }): Promise<boolean> {
+  const startTime = Date.now();
+  
+  while (Date.now() - startTime < timeoutMs) {
+    try {
+      // Test bridge connectivity with a minimal request
+      const response = await fetch('http://127.0.0.1:3456/mcp/health', { 
+        timeout: 2000,
+        headers: { 'X-Bridge-Health-Check': '1' }
+      });
+      
+      if (response.ok) {
+        logger.info('[MCP] Bridge health check passed');
+        return true;
+      }
+    } catch (err) {
+      // Bridge not ready yet, continue waiting
+    }
+    
+    await new Promise(resolve => setTimeout(resolve, healthCheckInterval));
+  }
+  
+  logger.warn('[MCP] Bridge health check timed out');
+  return false;
+}
+```
+
+**Prevention:** Always verify MCP bridge health after daemon restart before declaring the restart successful.
+
+---
+
+## Step 5 — Write the Regression Test First
 
 Write a test that fails with the current code. This confirms you've identified the root cause.
 
@@ -169,7 +289,7 @@ Tests for daemon subsystems live in:
 
 ---
 
-## Step 5 — Apply the Fix and Verify
+## Step 6 — Apply the Fix and Verify
 
 1. Apply the minimal surgical fix
 2. Run the targeted test first: confirm it goes green
@@ -180,7 +300,7 @@ Tests for daemon subsystems live in:
 
 ---
 
-## Step 6 — Diagnostic Logging for Session Type Disambiguation
+## Step 7 — Diagnostic Logging for Session Type Disambiguation
 
 **When:** Investigating phantom sessions or parent-child session relationships.
 
@@ -224,7 +344,7 @@ function processSessionHook(payload: any) {
 
 ---
 
-## Step 7 — Daemon Restart Resilience Patterns
+## Step 8 — Daemon Restart Resilience Patterns
 
 **When:** Daemon crashes or restarts unexpectedly, leaving tasks/sessions in inconsistent states.
 
@@ -278,7 +398,7 @@ export async function cleanupStaleActiveSessions() {
 
 ---
 
-## Step 8 — Self-Mutation Discipline: Intent + Reconciliation Patterns
+## Step 9 — Self-Mutation Discipline: Intent + Reconciliation Patterns
 
 **When:** Daemon operations that modify Myco's own state, configuration, or process identity create inconsistencies.
 
@@ -462,3 +582,5 @@ export class DaemonSupervisor {
 | "No daemon" false positive during restart | Race condition in daemon.json lifecycle | Apply intent + reconciliation: supervisor manages daemon.json |
 | Daemon state corruption after config updates | Non-atomic configuration changes with no rollback | Use intent + reconciliation for config updates with validation |
 | Process identity drift after daemon updates | Self-mutation during update process | Supervisor-owned lifecycle: external supervisor manages updates |
+| EPERM livelock during daemon restart | `reconcileExistingDaemon` loops on permission error | Distinguish ESRCH from EPERM; escalate EPERM to user intervention |
+| MCP bridge indefinite reconnect loop | Mode 4 restart failure - bridge never establishes | Stop daemon, clean bridge state, restart with bridge health verification |

--- a/.agents/skills/ui-development-and-visual-identity/SKILL.md
+++ b/.agents/skills/ui-development-and-visual-identity/SKILL.md
@@ -9,83 +9,43 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob
 
 # UI Development and Visual Identity System
 
-Myco's UI spans multiple contexts (daemon, collective, marketing) that must maintain family cohesion while providing visual distinction. The system uses a 6-theme architecture with dynamic configuration, React component patterns optimized for multi-instance coordination, and integrated build tooling.
+Myco's UI spans multiple contexts (daemon, collective, marketing) with 6-theme architecture and multi-instance coordination.
 
 ## Prerequisites
 
-- Myco project with `.myco/` vault directory
+- Myco project with `.myco/` vault directory  
 - Node.js environment with npm workspaces
 - Access to `packages/myco/ui/` and related UI directories
-- Understanding of Myco's config overlay pattern (`.myco/local.yaml` over `.myco/myco.yaml`)
 
-## Procedure A: React Component Architecture Patterns
+## Procedure A: React Component Architecture
 
 ### Multi-Instance Component Design
 
-Design components that work across daemon, collective, and marketing contexts:
-
 ```typescript
-// Use context providers for instance-aware behavior
 const InstanceContext = createContext<'daemon' | 'collective' | 'marketing'>();
 
 function NavigationComponent() {
   const instance = useContext(InstanceContext);
-  const baseClasses = "nav-component";
   const instanceClasses = instance === 'collective' ? 'nav-collective' : 'nav-daemon';
-  
-  return <nav className={`${baseClasses} ${instanceClasses}`}>
-    {/* Instance-specific navigation items */}
-  </nav>;
+  return <nav className={`nav-component ${instanceClasses}`}>{/* content */}</nav>;
 }
 ```
 
-### Component Composition Strategy
-
-Build reusable primitives that compose into domain-specific components:
-
-```
-Base Components (packages/myco/ui/src/components/)
-├── Button, Input, Card, Modal
-└── Theme-aware, instance-agnostic
-
-Domain Components (packages/myco/ui/src/components/domains/)
-├── settings/, dashboard/, auth/
-└── Composed from base, domain-specific logic
-
-Pages (packages/myco/ui/src/pages/)
-├── Settings, Dashboard, Cortex
-└── Uses domain components, adds layout context
-```
-
-### Grove Multi-Project UI Switcher
-
-Implement Slack/Linear-style project switcher for Grove multi-tenant navigation:
+### Grove Project Switcher
 
 ```typescript
 function ProjectSwitcher() {
   const { groveSlug, projectSlug } = useParams();
   const { projects } = useGroveProjects(groveSlug);
-  const navigate = useNavigate();
-  
-  function switchProject(newProjectSlug: string) {
-    navigate(`/g/${groveSlug}/p/${newProjectSlug}/`);
-  }
   
   return (
     <DropdownMenu>
       <DropdownTrigger>
-        <Button variant="ghost" className="project-switcher">
-          {projectSlug} <ChevronDown />
-        </Button>
+        <Button variant="ghost">{projectSlug} <ChevronDown /></Button>
       </DropdownTrigger>
       <DropdownContent>
         {projects.map(project => (
-          <DropdownItem 
-            key={project.slug}
-            onClick={() => switchProject(project.slug)}
-            className={project.slug === projectSlug ? 'active' : ''}
-          >
-            <ProjectIcon project={project} />
+          <DropdownItem key={project.slug} onClick={() => navigate(`/g/${groveSlug}/p/${project.slug}/`)}>
             {project.displayName}
           </DropdownItem>
         ))}
@@ -95,342 +55,257 @@ function ProjectSwitcher() {
 }
 ```
 
-### Request Context Headers for Grove
+### Enhanced TabSwitcher for Phase 6 Team Consolidation
 
-Inject project context into API requests for multi-tenant safety:
-
-```typescript
-function useGroveApiClient() {
-  const { groveSlug, projectSlug } = useGroveContext();
-  
-  const apiClient = useMemo(() => {
-    const client = axios.create({
-      baseURL: '/api/v1',
-      headers: { 'X-Grove-Slug': groveSlug, 'X-Project-Slug': projectSlug }
-    });
-    return client;
-  }, [groveSlug, projectSlug]);
-  
-  return apiClient;
-}
-```
-
-### TabSwitcher Component for Team Consolidation
-
-**Critical Phase 6 update**: Implement unified tabbed interface for team surface consolidation:
+**Critical update**: Queue-aware TabSwitcher with error state handling:
 
 ```typescript
 interface TabSwitcherProps {
-  tabs: Array<{ id: string; label: string; icon?: React.ReactNode; count?: number }>;
+  tabs: Array<{ 
+    id: string; 
+    label: string; 
+    icon?: React.ReactNode; 
+    count?: number;
+    badge?: 'active' | 'pending' | 'error';
+    disabled?: boolean;
+  }>;
   activeTab: string;
   onTabChange: (tabId: string) => void;
-  className?: string;
+  layout?: 'horizontal' | 'vertical';
 }
 
-export function TabSwitcher({ tabs, activeTab, onTabChange, className }: TabSwitcherProps) {
+export function TabSwitcher({ tabs, activeTab, onTabChange, layout = 'horizontal' }: TabSwitcherProps) {
   return (
-    <div className={`tab-switcher ${className || ''}`} role="tablist">
+    <div className={`tab-switcher tab-switcher-${layout}`} role="tablist">
       {tabs.map(tab => (
         <button
           key={tab.id}
           role="tab"
           aria-selected={tab.id === activeTab}
-          className={`tab-button ${tab.id === activeTab ? 'active' : ''}`}
-          onClick={() => onTabChange(tab.id)}
+          disabled={tab.disabled}
+          className={`tab-button ${tab.id === activeTab ? 'active' : ''} ${tab.badge ? `badge-${tab.badge}` : ''}`}
+          onClick={() => !tab.disabled && onTabChange(tab.id)}
         >
           {tab.icon && <span className="tab-icon">{tab.icon}</span>}
           <span className="tab-label">{tab.label}</span>
-          {tab.count !== undefined && (
-            <span className="tab-count">{tab.count}</span>
-          )}
+          {tab.count !== undefined && <span className="tab-count">{tab.count}</span>}
+          {tab.badge && <span className={`tab-badge tab-badge-${tab.badge}`} />}
         </button>
       ))}
     </div>
   );
 }
 
-// Team consolidation usage - replaces separate status/sync components
 function TeamSurface() {
   const [activeTab, setActiveTab] = useState('overview');
-  const location = useLocation();
+  const { queueStatus } = useTeamQueueStatus();
   
   const tabs = [
     { id: 'overview', label: 'Overview', icon: <BarChart3 /> },
-    { id: 'members', label: 'Members', icon: <Users />, count: memberCount },
-    { id: 'projects', label: 'Projects', icon: <FolderOpen />, count: projectCount },
-    { id: 'activity', label: 'Activity', icon: <Activity /> }
+    { 
+      id: 'queue', 
+      label: 'Queue', 
+      icon: <Clock />, 
+      count: queueStatus.pending,
+      badge: queueStatus.hasErrors ? 'error' : queueStatus.hasActive ? 'active' : undefined
+    },
+    { id: 'members', label: 'Members', icon: <Users /> },
+    { id: 'projects', label: 'Projects', icon: <FolderOpen />, disabled: !hasProjectAccess }
   ];
   
-  // Sync tab state with URL
+  // Auto-switch to queue tab on critical errors
   useEffect(() => {
-    const urlTab = new URLSearchParams(location.search).get('tab');
-    if (urlTab && tabs.find(t => t.id === urlTab)) {
-      setActiveTab(urlTab);
+    if (queueStatus.hasErrors && activeTab !== 'queue') {
+      setActiveTab('queue');
+      navigate(`${location.pathname}?tab=queue`);
     }
-  }, [location.search]);
+  }, [queueStatus.hasErrors]);
   
   return (
     <div className="team-surface">
-      <TabSwitcher 
-        tabs={tabs}
-        activeTab={activeTab}
-        onTabChange={(tabId) => {
-          setActiveTab(tabId);
-          navigate(`${location.pathname}?tab=${tabId}`);
-        }}
-      />
+      <TabSwitcher tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
       <div className="tab-content">
-        {activeTab === 'overview' && <TeamOverview />}
-        {activeTab === 'members' && <TeamMembers />}
-        {activeTab === 'projects' && <TeamProjects />}
-        {activeTab === 'activity' && <TeamActivity />}
+        {activeTab === 'queue' && <TeamQueueManager queueStatus={queueStatus} />}
+        {/* other tab content */}
       </div>
     </div>
   );
 }
 ```
 
-### Machine-Scoped Runtime Status Badges
-
-Implement sidebar badges to display DEV/BETA runtime status:
-
-```typescript
-function RuntimeStatusBadge() {
-  const { runtimeOrigin } = useDaemonStats();
-  
-  if (!runtimeOrigin || runtimeOrigin === 'stable') {
-    return null; // No badge for stable/production runtime
-  }
-  
-  const badgeConfig = {
-    dev: { label: 'DEV', className: 'runtime-badge-dev', color: 'amber' },
-    beta: { label: 'BETA', className: 'runtime-badge-beta', color: 'blue' }
-  };
-  
-  const config = badgeConfig[runtimeOrigin as keyof typeof badgeConfig];
-  
-  return <Badge variant="outline" className={`runtime-status-badge ${config.className}`}>{config.label}</Badge>;
-}
-
-function useDaemonStats() {
-  return useQuery({
-    queryKey: ['daemon-stats'],
-    queryFn: async () => {
-      const response = await fetch('/api/stats');
-      if (!response.ok) throw new Error('Failed to fetch daemon stats');
-      return response.json() as { runtimeOrigin: 'dev' | 'beta' | 'stable'; version: string; uptime: number; };
-    },
-    refetchInterval: 30000
-  });
-}
-```
-
-## Procedure B: Theme System Implementation and Extension
+## Procedure B: Theme System
 
 ### Core Theme Architecture
 
-The 6-theme system uses CSS custom properties with color coordination:
-
 ```css
-/* Base theme structure in packages/myco/ui/src/themes/ */
 :root[data-theme="sage"] {
-  --primary: #abcfb8;           /* Primary brand color */
-  --on-primary: #163627;        /* Text on primary */
-  --primary-container: #7b9e89; /* Container variant */
-  --on-primary-container: #143525;
-  
-  --secondary: #edbf7f;         /* Supporting accent */
-  --on-secondary: #442b00;
-  --secondary-container: #60410b;
-  
-  --tertiary: #ffb4a1;          /* Third accent level */
-  --on-tertiary: #5d1806;
-  --tertiary-container: #df7a60;
+  --primary: #abcfb8;
+  --on-primary: #163627;
+  --secondary: #edbf7f;
+  --tertiary: #ffb4a1;
 }
 ```
 
 ### Adding New Themes
 
-1. **Create theme definition file**: `touch packages/myco/ui/src/themes/ocean.css`
-2. **Define color palette**: CSS custom properties with ocean color scheme
-3. **Register in theme configuration**: Update `packages/myco/src/config/appearance-values.ts` APPEARANCE_THEMES array
-4. **Add CSS import**: Update `packages/myco/ui/src/index.css` with new theme import
+1. Create `packages/myco/ui/src/themes/new-theme.css`
+2. Define CSS custom properties
+3. Register in `packages/myco/src/config/appearance-values.ts`
+4. Import in `packages/myco/ui/src/index.css`
 
-### Reserved Color Coordination
+## Procedure C: Enhanced Grove Worktree Architecture
 
-**Ochre is reserved for Collective instances** to maintain visual distinction:
-- Daemon instances: Use any of the 6 main themes
-- Collective instances: Always use ochre accent colors
-- Marketing site: Typically sage or theme-neutral
-
-## Procedure C: Multi-Instance Visual Identity Coordination
-
-### Dynamic Tab Title Generation
-
-Generate distinct browser tab titles that identify both project and instance type:
-
-```typescript
-function generateDynamicTitle(projectConfig: MycoConfig): string {
-  const projectName = projectConfig.project?.name || 'Myco Project';
-  const instanceType = 'Daemon'; // or 'Collective', 'Marketing'
-  return `${projectName} | Myco ${instanceType}`;
-}
-
-// Update document title
-document.title = generateDynamicTitle(config);
-```
-
-### Family Cohesion vs Instance Recognition
-
-Balance unified Myco identity with practical tab distinction:
-
-**Family cohesion**: Consistent typography, shared component design language, common interaction patterns
-**Instance recognition**: Theme-based color distinction, dynamic tab titles, instance-specific favicon variants, contextual navigation differences
-
-## Procedure D: Frontend Build Integration
-
-### Vite Asset Pipeline Integration
-
-Configure Vite for monorepo structure with theme asset coordination:
-
-```typescript
-export default defineConfig({
-  build: {
-    lib: { entry: 'src/index.ts', formats: ['es', 'cjs'] },
-    rollupOptions: { external: ['react', 'react-dom'], output: { globals: { react: 'React', 'react-dom': 'ReactDOM' } } }
-  },
-  css: { preprocessorOptions: { scss: { additionalData: `@import "src/themes/variables.scss";` } } }
-});
-```
-
-### Worktree Build Environment Setup
-
-**Critical Grove architecture**: Git worktrees require independent UI workspace installation and clean multi-worktree setup:
+**Critical Grove improvement**: Streamlined worktree setup with UI workspace verification:
 
 ```bash
-# Automated Grove worktree setup for Phase 6 development
-function init_myco_worktree() {
+function init_grove_worktree_enhanced() {
   local branch_name="$1"
   local worktree_path=".worktrees/$branch_name"
   
-  # Create and enter worktree
+  echo "🌱 Creating Grove worktree: $branch_name"
   git worktree add "$worktree_path" "$branch_name"
   cd "$worktree_path"
   
-  # Install root dependencies
-  npm install
+  # Install with parallel UI workspaces
+  npm install --include-workspace-root
   
-  # Install nested UI workspaces separately (critical for Grove)
-  for ui_workspace in packages/myco/ui packages/myco-hub/ui; do
-    if [ -d "$ui_workspace" ]; then
-      echo "Installing $ui_workspace..."
-      (cd "$ui_workspace" && npm install)
-    fi
+  echo "🎨 Installing UI workspaces in parallel..."
+  for workspace in packages/myco/ui packages/myco-hub/ui; do
+    [ -d "$workspace" ] && (cd "$workspace" && npm install) &
+  done
+  wait
+  
+  # Verify UI workspace integrity
+  echo "🔍 Verifying UI workspaces..."
+  for workspace in packages/myco/ui packages/myco-hub/ui; do
+    [ -d "$workspace" ] && (cd "$workspace" && npm run type-check) || {
+      echo "❌ Type check failed in $workspace"; return 1
+    }
   done
   
-  # Build UI components
-  npm run build:ui
+  npm run build:ui || { echo "❌ UI build failed"; return 1; }
   
-  echo "Grove worktree $branch_name ready for Phase 6 development"
+  # Generate worktree config
+  cat > ".myco/worktree.yaml" << EOF
+worktree:
+  branch: $branch_name
+  ui_workspaces_verified: true
+development:
+  hot_reload: true
+  theme_dev_mode: true
+EOF
+  
+  echo "✅ Grove worktree ready"
 }
 ```
 
-**Critical gotcha**: Each `packages/*/ui` workspace needs its own `npm install` run in worktrees.
-
-**Phase 6 worktree benefits**: Clean isolation for Grove + Team rebuild, independent dependency resolution, parallel development workflow, easier branch switching without stale node_modules.
-
-## Procedure E: Appearance Controls and User Preferences
-
-### Configuration Overlay Pattern
-
-Store appearance preferences in `.myco/local.yaml` for personal overrides:
-
-```yaml
-appearance:
-  theme: "terracotta"
-  font_size: "large"
-  dark_mode: true
-  density: "compact"
-```
-
-### Appearance Control Implementation
+### Vite Configuration for Grove
 
 ```typescript
-interface AppearanceConfig {
-  theme: 'sage' | 'moss' | 'terracotta' | 'dusk' | 'plum' | 'slate';
-  fontSize: 'small' | 'medium' | 'large';
-  darkMode: boolean;
-  density: 'compact' | 'comfortable' | 'spacious';
-}
-
-function useAppearanceConfig(): [AppearanceConfig, (config: Partial<AppearanceConfig>) => void] {
-  // Read from .myco/local.yaml, fall back to defaults
-  // Write updates to .myco/local.yaml via updateLocalConfig()
-}
-```
-
-## Procedure F: Component Development Lifecycle
-
-### Adding New UI Components
-
-Follow the established pattern for settings page components:
-
-1. **Create component file**: `touch packages/myco/ui/src/components/settings/NewSettingControl.tsx`
-2. **Implement with appearance awareness**: Use theme-aware classes and appearance config hooks
-3. **Test across themes**: Verify component works correctly with all 6 themes
-4. **Add Playwright tests**: Test component behavior and visual state
-
-### Playwright Testing Patterns for Visual State
-
-Write Playwright tests that verify visual state across themes and configurations:
-
-```typescript
-test('theme picker updates appearance correctly', async ({ page }) => {
-  await page.goto('/settings');
-  
-  for (const theme of ['sage', 'moss', 'terracotta']) {
-    await page.selectOption('[data-testid="theme-picker"]', theme);
-    const primaryColor = await page.evaluate(() => 
-      getComputedStyle(document.documentElement).getPropertyValue('--primary')
-    );
-    expect(primaryColor).toMatch(EXPECTED_THEME_COLORS[theme]);
+export default defineConfig({
+  server: {
+    fs: { allow: ['..', '../..', '../../..'] }, // Worktree compatibility
+    watch: {
+      include: ['src/**/*', '../../../shared/**/*'],
+      exclude: ['node_modules/**', '.worktrees/**']
+    }
   }
 });
 ```
 
-## Procedure G: Master-Detail Layout Architecture
+## Procedure D: Enhanced Cloudflare Worker Constraints
 
-### MasterDetailSplit Component Implementation
-
-Implement responsive master-detail layout with keyboard navigation:
+**Critical constraint updates**: Comprehensive worker limitations with UI adaptations:
 
 ```typescript
-interface MasterDetailSplitProps {
-  masterContent: React.ReactNode;
-  detailContent: React.ReactNode;
-  showDetail: boolean;
-  onCloseDetail: () => void;
-  className?: string;
+function CloudflareWorkerCompatibleUpload() {
+  const MAX_FILE_SIZE = 1024 * 1024; // 1MB limit
+  const EXECUTION_TIMEOUT = 9000; // 9s timeout
+  const SUPPORTED_FORMATS = ['image/jpeg', 'image/png', 'image/webp'];
+  
+  function validateFileForWorker(file: File) {
+    if (file.size > MAX_FILE_SIZE) {
+      return { 
+        valid: false, 
+        error: `File ${(file.size/1024/1024).toFixed(2)}MB exceeds 1MB worker limit` 
+      };
+    }
+    if (!SUPPORTED_FORMATS.includes(file.type)) {
+      return { valid: false, error: `Format ${file.type} not supported in worker` };
+    }
+    return { valid: true };
+  }
+  
+  function useWorkerApiClient() {
+    return useMutation({
+      mutationFn: async (data: ApiRequest) => {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), EXECUTION_TIMEOUT);
+        
+        try {
+          const response = await fetch('/api/worker-endpoint', {
+            method: 'POST',
+            body: JSON.stringify(data),
+            signal: controller.signal,
+            headers: { 'X-Worker-Timeout': EXECUTION_TIMEOUT.toString() }
+          });
+          
+          clearTimeout(timeoutId);
+          if (!response.ok) throw new Error(`Worker request failed: ${response.status}`);
+          return response.json();
+          
+        } catch (error) {
+          clearTimeout(timeoutId);
+          if (error.name === 'AbortError') {
+            throw new Error('Worker timeout - try reducing file size');
+          }
+          throw error;
+        }
+      }
+    });
+  }
 }
 
-export function MasterDetailSplit({ masterContent, detailContent, showDetail, onCloseDetail, className }: MasterDetailSplitProps) {
+// Worker-aware form with constraint validation
+function WorkerConstraintForm() {
+  const [file, setFile] = useState<File | null>(null);
+  const validation = file ? validateFileForWorker(file) : { valid: false };
+  
+  return (
+    <form>
+      <input 
+        type="file" 
+        onChange={(e) => setFile(e.target.files?.[0] || null)}
+        accept="image/jpeg,image/png,image/webp"
+      />
+      <Badge variant={validation.valid ? 'success' : 'warning'}>
+        Max 1MB • Cloudflare limits apply
+      </Badge>
+      {!validation.valid && validation.error && <p className="error">{validation.error}</p>}
+      <Button disabled={!validation.valid}>Upload</Button>
+    </form>
+  );
+}
+```
+
+## Procedure E: Master-Detail Layout
+
+```typescript
+export function MasterDetailSplit({ masterContent, detailContent, showDetail, onCloseDetail }) {
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === 'Escape' && showDetail) {
-        onCloseDetail();
-      }
+      if (event.key === 'Escape' && showDetail) onCloseDetail();
     }
-
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [showDetail, onCloseDetail]);
 
   return (
-    <div className={`master-detail-split ${showDetail ? 'detail-open' : ''} ${className || ''}`}>
+    <div className={`master-detail-split ${showDetail ? 'detail-open' : ''}`}>
       <div className="master-panel">{masterContent}</div>
       {showDetail && (
         <div className="detail-panel">
-          <button className="close-detail-btn" onClick={onCloseDetail} aria-label="Close detail view">×</button>
+          <button onClick={onCloseDetail}>×</button>
           {detailContent}
         </div>
       )}
@@ -439,245 +314,86 @@ export function MasterDetailSplit({ masterContent, detailContent, showDetail, on
 }
 ```
 
-### Responsive Master-Detail CSS
-
-Define CSS patterns for responsive master-detail behavior:
-
-```css
-.master-detail-split {
-  display: grid;
-  height: 100%;
-  grid-template-columns: 1fr;
-  transition: grid-template-columns 0.2s ease-in-out;
-}
-
-.master-detail-split.detail-open { grid-template-columns: 350px 1fr; }
-.master-panel { overflow: auto; border-right: 1px solid var(--border-color); }
-.detail-panel { position: relative; overflow: auto; background: var(--surface-container); }
-
-@media (max-width: 768px) {
-  .master-detail-split.detail-open { grid-template-columns: 0 1fr; }
-  .master-panel { overflow: hidden; }
-}
-```
-
-## Procedure H: Operations Surface URL Routing
-
-### Scope-Encoded URL Structure
-
-Implement hierarchical URL routing that encodes scope context for proper multi-tenant operations:
+## Procedure F: Settings Registry
 
 ```typescript
-// URL structure: /operations/:scope/:category/:operationId?
-// Examples: /operations/machine/daemons/daemon-123, /operations/grove/projects/grove-abc/proj-xyz
-
-export function OperationsRouter() {
-  return (
-    <Routes>
-      <Route path="/operations" element={<OperationsLayout />}>
-        <Route index element={<OperationsOverview />} />
-        <Route path=":scope" element={<OperationsScopeView />}>
-          <Route path=":category" element={<OperationsCategoryView />}>
-            <Route path="*" element={<OperationDetailView />} />
-          </Route>
-        </Route>
-      </Route>
-    </Routes>
-  );
-}
-
-function OperationsLayout() {
-  const { scope, category } = useParams();
-  const location = useLocation();
-  
-  const scopeContext = useMemo(() => {
-    const pathSegments = location.pathname.split('/').filter(Boolean);
-    const operationsIndex = pathSegments.indexOf('operations');
-    
-    if (operationsIndex === -1 || pathSegments.length < 3) return null;
-    
-    const scopeType = pathSegments[operationsIndex + 1];
-    const category = pathSegments[operationsIndex + 2];
-    
-    // Parse scope-specific identifiers
-    if (scopeType === 'grove' && pathSegments.length >= 5) {
-      return {
-        scope: 'grove',
-        groveSlug: pathSegments[operationsIndex + 3],
-        projectSlug: pathSegments[operationsIndex + 4]
-      };
-    }
-    
-    return { scope: scopeType, category };
-  }, [location.pathname]);
-  
-  return (
-    <div className="operations-layout">
-      <Breadcrumbs crumbs={buildBreadcrumbs(scopeContext)} />
-      <ScopeContextProvider context={scopeContext}>
-        <Outlet />
-      </ScopeContextProvider>
-    </div>
-  );
-}
-```
-
-## Procedure I: Unified Settings Registry
-
-### Zod-Validated Settings Architecture
-
-Implement centralized settings registry with Zod schema validation:
-
-```typescript
-import { z } from 'zod';
-
-interface SettingDefinition<T = any> {
+interface SettingDefinition<T> {
   key: string;
   label: string;
-  description?: string;
   schema: z.ZodType<T>;
   scope: 'machine' | 'grove' | 'project';
   section: string;
   defaultValue: T;
-  hidden?: boolean;
-  deprecated?: { since: string; message: string };
 }
 
 class SettingsRegistry {
   private settings = new Map<string, SettingDefinition>();
-  private sections = new Set<string>();
   
   register<T>(setting: SettingDefinition<T>) {
-    if (!setting.key || !setting.label || !setting.schema) {
-      throw new Error(`Invalid setting definition: ${setting.key}`);
-    }
-    
     this.settings.set(setting.key, setting);
-    this.sections.add(setting.section);
   }
   
-  validate<T>(key: string, value: unknown): T | ValidationError {
+  validate<T>(key: string, value: unknown): T {
     const setting = this.settings.get(key);
-    if (!setting) throw new Error(`Unknown setting: ${key}`);
-    
-    const result = setting.schema.safeParse(value);
-    if (!result.success) return new ValidationError(key, result.error.errors);
-    
+    const result = setting?.schema.safeParse(value);
+    if (!result?.success) throw new Error(`Validation failed: ${key}`);
     return result.data;
   }
 }
-
-export const settingsRegistry = new SettingsRegistry();
-
-// Example registrations
-settingsRegistry.register({
-  key: 'daemon.port', label: 'Daemon Port', description: 'TCP port for the Myco daemon to listen on',
-  schema: z.number().int().min(1024).max(65535), scope: 'machine', section: 'daemon', defaultValue: 3456
-});
-
-settingsRegistry.register({
-  key: 'appearance.theme', label: 'UI Theme', description: 'Visual theme for the Myco interface',
-  schema: z.enum(['sage', 'moss', 'terracotta', 'dusk', 'plum', 'slate']), scope: 'project', section: 'appearance', defaultValue: 'sage'
-});
 ```
 
-## Procedure J: Cloudflare API Constraint Adaptations
-
-### Worker Environment Limitations
-
-**Critical constraint**: Cloudflare Workers have strict API limitations affecting UI design decisions:
+## Procedure G: Appearance Controls
 
 ```typescript
-// Adapt UI patterns for Cloudflare Worker constraints
-function WorkerCompatibleImageUpload() {
-  // CONSTRAINT: Limited file size and processing time
-  const MAX_FILE_SIZE = 1024 * 1024; // 1MB limit for worker processing
-  const SUPPORTED_FORMATS = ['image/jpeg', 'image/png', 'image/webp'];
-  
-  function handleFileUpload(file: File) {
-    if (file.size > MAX_FILE_SIZE) {
-      throw new Error('File too large for Cloudflare Worker processing');
-    }
-    
-    if (!SUPPORTED_FORMATS.includes(file.type)) {
-      throw new Error('Unsupported format for worker environment');
-    }
-    
-    // Process with worker-compatible approach
-    return processImageInWorker(file);
-  }
+interface AppearanceConfig {
+  theme: 'sage' | 'moss' | 'terracotta' | 'dusk' | 'plum' | 'slate';
+  fontSize: 'small' | 'medium' | 'large';
+  darkMode: boolean;
 }
 
-// API call patterns adapted for worker constraints
-function useWorkerApi() {
-  return useMutation({
-    mutationFn: async (data: ApiRequest) => {
-      // CONSTRAINT: 10 second execution limit
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 9000); // 9s timeout
-      
-      try {
-        const response = await fetch('/api/worker-endpoint', {
-          method: 'POST',
-          body: JSON.stringify(data),
-          signal: controller.signal,
-          headers: { 'Content-Type': 'application/json' }
-        });
-        
-        clearTimeout(timeoutId);
-        return response.json();
-      } catch (error) {
-        clearTimeout(timeoutId);
-        if (error.name === 'AbortError') {
-          throw new Error('Request timed out due to Cloudflare Worker constraints');
-        }
-        throw error;
-      }
-    }
-  });
+function useAppearanceConfig(): [AppearanceConfig, (config: Partial<AppearanceConfig>) => void] {
+  // Read from .myco/local.yaml, write updates
 }
 ```
 
-**UI design adaptations**: Smaller file upload limits, simplified processing workflows, timeout-aware user feedback, progressive enhancement for worker limitations.
+## Procedure H: Runtime Status Badges
+
+```typescript
+function RuntimeStatusBadge() {
+  const { runtimeOrigin } = useDaemonStats();
+  
+  if (!runtimeOrigin || runtimeOrigin === 'stable') return null;
+  
+  const config = runtimeOrigin === 'dev' 
+    ? { label: 'DEV', className: 'runtime-badge-dev' }
+    : { label: 'BETA', className: 'runtime-badge-beta' };
+  
+  return <Badge variant="outline" className={config.className}>{config.label}</Badge>;
+}
+```
 
 ## Cross-Cutting Gotchas
 
-### Theme Development Cache Issues
+### Theme Development
+**Browser caches CSS aggressively**. Always hard refresh (Cmd+Shift+R) when developing themes.
 
-**Browser aggressively caches CSS files**. Always hard refresh (Cmd+Shift+R / Ctrl+Shift+R) when developing themes or you'll see stale styles.
+### Grove Worktree Dependencies
+**Each Grove worktree needs independent UI workspace `npm install`**. The enhanced setup handles this automatically with parallel installation and verification.
 
-### CSS Custom Property Inheritance
+### TabSwitcher Queue Integration  
+**Queue error states must trigger auto-navigation to queue tab**. Missing queue status monitoring breaks Phase 6 team consolidation workflow.
 
-**Theme variables are set on `:root` but can be overridden at component level**. Check the cascade when debugging color issues.
+### Cloudflare Worker Constraints
+**Worker timeout errors need differentiated handling**. Use worker-specific error types and provide actionable constraint guidance to users.
 
-### Instance Context Lost
+### Instance Context
+**Components default to daemon behavior without proper InstanceContext**. Ensure context provider wraps the app tree.
 
-**When components don't receive instance context, they default to daemon behavior**. Ensure InstanceContext provider wraps the entire app tree.
+### Master-Detail State
+**URL params must drive state, not component state**. Missing URL sync breaks browser history.
 
-### Worktree Nested UI Install Required
+### Project Context Leaks
+**Grove multi-tenant data can leak without proper headers**. Always inject `X-Grove-Slug` and `X-Project-Slug` headers.
 
-**New Grove worktrees need `npm install` inside each nested UI workspace** (`packages/*/ui/`) — root install doesn't cover them, leading to build failures during Phase 6 development.
-
-### Grove Project Context Loss
-
-**Without proper context headers and query cache scoping, data can leak between projects**. Always inject `X-Grove-Slug` and `X-Project-Slug` headers and scope cache keys by project.
-
-### Runtime Status Badge Missing
-
-**If runtime badges don't appear, verify `/api/stats` endpoint returns `runtimeOrigin` field** and hook is properly polling. DEV builds should show badges, stable should not.
-
-### Master-Detail State Sync
-
-**URL params must drive master-detail state, not vice versa**. Component state that doesn't reflect in the URL breaks browser history and deep linking.
-
-### TabSwitcher State Persistence
-
-**Tab state should sync with URL query parameters for proper browser history**. Don't rely on component state alone for active tab tracking from Phase 6 consolidation.
-
-### Phase 6 Worktree Dependencies
-
-**Phase 6 Grove worktree setup must install dependencies independently in each UI workspace**. Missing nested installs cause build failures during Grove + Team rebuild development.
-
-### Cloudflare Worker UI Constraints
-
-**Cloudflare Worker API limitations require UI adaptations**: reduced file upload limits, timeout-aware processing, worker-compatible data formats, graceful degradation when worker APIs fail.
+### UI Workspace Verification
+**Missing type checks after worktree creation cause build failures**. The enhanced setup includes automatic verification steps.

--- a/packages/myco/src/daemon/api/sessions.ts
+++ b/packages/myco/src/daemon/api/sessions.ts
@@ -158,10 +158,14 @@ export interface SessionMutationDeps {
   vaultDir: string;
   logger: DaemonLogger;
   liveConfig: { current: MycoConfig };
+  /** Cleared on DELETE so a re-created session with the same id is not
+   *  short-circuited by the per-lifetime reconciliation cache. Mirrors
+   *  the unregister path in session-lifecycle.ts. */
+  reconciler: { clearSession(sessionId: string): void };
 }
 
 export function createSessionMutationHandlers(deps: SessionMutationDeps) {
-  const { embeddingManager, vaultDir, logger, liveConfig } = deps;
+  const { embeddingManager, vaultDir, logger, liveConfig, reconciler } = deps;
 
   /** DELETE /api/sessions/:id — cascade delete with post-transaction cleanup. */
   async function handleDeleteSession(req: RouteRequest): Promise<RouteResponse> {
@@ -171,7 +175,12 @@ export function createSessionMutationHandlers(deps: SessionMutationDeps) {
     const result = deleteSessionCascade(sessionId);
     if (!result.deleted) return { status: 404, body: { error: 'Session not found' } };
 
-    // Post-transaction cleanup (fire-and-forget)
+    // Clear the per-lifetime reconciliation cache so a re-registration
+    // with the same session id replays its buffer cleanly.
+    reconciler.clearSession(sessionId);
+
+    // Fire-and-forget cleanup: embeddings, vault files, attachments,
+    // and the session's buffer journal.
     cleanupAfterSessionCascade(sessionId, result, embeddingManager, vaultDir).catch(() => {});
 
     logger.info(LOG_KINDS.API_SESSION_DELETE, 'Session cascade deleted', {

--- a/packages/myco/src/daemon/event-handlers.ts
+++ b/packages/myco/src/daemon/event-handlers.ts
@@ -82,6 +82,26 @@ export interface UserPromptOptions {
 }
 
 /**
+ * Open a synthetic `kind='recovered'` batch when no batch is currently
+ * open for the session. Callers that produce an activity but don't
+ * manage their own batch lifecycle invoke this first so the FK on
+ * `activities.prompt_batch_id` (NOT NULL) is satisfied.
+ */
+export function ensureOpenBatch(sessionId: string): void {
+  if (findOpenParentBatch(sessionId)) return;
+  const now = epochSeconds();
+  insertBatchStateless({
+    session_id: sessionId,
+    user_prompt: '(implicit batch — capture recovered)',
+    started_at: now,
+    created_at: now,
+    machine_id: getTeamMachineId(),
+    kind: BATCH_KIND.RECOVERED,
+    parent_prompt_batch_id: null,
+  });
+}
+
+/**
  * Handle a UserPromptSubmit event.
  *
  * For initial prompts: closes open batches, opens a new initial batch.
@@ -141,10 +161,9 @@ export function handleUserPrompt(
 }
 
 /**
- * Handle a PostToolUse event: insert activity with inline batch linkage.
- *
- * Fully stateless — the batch ID is resolved via an inline subquery in
- * `insertActivityWithBatch`, so no in-memory state is needed.
+ * Handle a PostToolUse event: ensure a batch is open (opening a
+ * synthetic recovery batch if necessary) and insert the activity
+ * linked to it.
  */
 export function handleToolUse(
   sessionId: string,
@@ -155,6 +174,8 @@ export function handleToolUse(
   projectRoot: string,
 ): void {
   const now = epochSeconds();
+
+  ensureOpenBatch(sessionId);
 
   const filePath = extractToolFilePath(agent, toolName, toolInput);
   const activityFilePath = filePath ? relativizeToolPath(filePath, projectRoot) : null;
@@ -183,7 +204,6 @@ export function handleToolUse(
     canopy_injection_tokens: injectionTokens,
   });
 
-  // Increment batch activity count if linked to a batch
   if (activity.prompt_batch_id !== null) {
     incrementActivityCount(activity.prompt_batch_id);
   }
@@ -222,6 +242,8 @@ export function handleToolFailure(
   const now = epochSeconds();
   const filePath = extractToolFilePath(agent, toolName, toolInput);
 
+  ensureOpenBatch(sessionId);
+
   const activity = insertActivityWithBatch({
     session_id: sessionId,
     tool_name: toolName,
@@ -248,6 +270,7 @@ export function handleSubagentStart(
   agentType: string | undefined,
 ): void {
   const now = epochSeconds();
+  ensureOpenBatch(sessionId);
   insertActivityWithBatch({
     session_id: sessionId,
     tool_name: 'subagent_start',
@@ -267,6 +290,7 @@ export function handleSubagentStop(
   lastAssistantMessage: string | undefined,
 ): void {
   const now = epochSeconds();
+  ensureOpenBatch(sessionId);
   insertActivityWithBatch({
     session_id: sessionId,
     tool_name: 'subagent_stop',
@@ -286,6 +310,7 @@ export function handleStopFailure(
   errorDetails: string | undefined,
 ): void {
   const now = epochSeconds();
+  ensureOpenBatch(sessionId);
   insertActivityWithBatch({
     session_id: sessionId,
     tool_name: 'stop_failure',
@@ -307,6 +332,7 @@ export function handleTaskCompleted(
   taskDescription: string | undefined,
 ): void {
   const now = epochSeconds();
+  ensureOpenBatch(sessionId);
   insertActivityWithBatch({
     session_id: sessionId,
     tool_name: 'task_completed',
@@ -327,6 +353,7 @@ export function handleCompact(
   compactSummary: string | undefined,
 ): void {
   const now = epochSeconds();
+  ensureOpenBatch(sessionId);
   insertActivityWithBatch({
     session_id: sessionId,
     tool_name: `${phase}_compact`,

--- a/packages/myco/src/daemon/event-loop-lag.ts
+++ b/packages/myco/src/daemon/event-loop-lag.ts
@@ -62,6 +62,8 @@ export class EventLoopLagProbe {
   private peakLagMs = 0;
   /** Number of samples that exceeded the warn threshold. */
   private stallCount = 0;
+  /** Per-tick subscribers, invoked synchronously inside tick(). */
+  private listeners = new Set<(lagMs: number) => void>();
 
   constructor(private readonly logger: Logger, options: EventLoopLagProbeOptions = {}) {
     this.sampleIntervalMs = options.sampleIntervalMs ?? DEFAULT_SAMPLE_INTERVAL_MS;
@@ -94,6 +96,18 @@ export class EventLoopLagProbe {
     this.stallCount = 0;
   }
 
+  /** Subscribe to per-tick lag values. Returns an unsubscribe function.
+   *
+   *  Listeners are invoked synchronously inside the probe's tick. Keep
+   *  them cheap — exceptions are caught and logged but the listener is
+   *  not removed, so a buggy subscriber will keep firing. */
+  addTickListener(fn: (lagMs: number) => void): () => void {
+    this.listeners.add(fn);
+    return () => {
+      this.listeners.delete(fn);
+    };
+  }
+
   private schedule(): void {
     if (!this.running) return;
     this.timer = setTimeout(() => this.tick(), this.sampleIntervalMs);
@@ -109,6 +123,17 @@ export class EventLoopLagProbe {
     this.lastTick = now;
 
     if (lag > this.peakLagMs) this.peakLagMs = lag;
+    for (const fn of this.listeners) {
+      try {
+        fn(lag);
+      } catch (err) {
+        this.logger.warn(
+          LOG_KINDS.DAEMON_LAG,
+          'Event-loop lag tick listener threw',
+          { error: (err as Error).message },
+        );
+      }
+    }
     if (lag >= this.warnThresholdMs) {
       this.stallCount += 1;
       this.logger.warn(

--- a/packages/myco/src/daemon/jobs/session-cleanup.ts
+++ b/packages/myco/src/daemon/jobs/session-cleanup.ts
@@ -48,4 +48,8 @@ export async function cleanupAfterSessionCascade(
   for (const filePath of result.deletedAttachmentPaths) {
     try { await unlink(filePath); } catch { /* best-effort */ }
   }
+
+  // Buffer journal file. Removed alongside DB cascade so a same-id
+  // reload doesn't resurrect stale events through reconciliation.
+  try { await unlink(`${vaultDir}/buffer/${sessionId}.jsonl`); } catch { /* best-effort */ }
 }

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -867,6 +867,13 @@ export async function main(): Promise<void> {
     logger.debug(LOG_KINDS.DAEMON_START, 'Static UI directory found', { path: uiDir });
   }
 
+  // Always-on diagnostic for event-loop pinning. Catches stalls regardless
+  // of cause (sync bun:sqlite, multi-MB JSON.parse, microtask cascade in a
+  // streaming SDK aggregator). Stopped during shutdown alongside the
+  // PowerManager. Constructed before PowerManager so PowerManager can wire
+  // it in for per-job lag attribution.
+  const eventLoopLagProbe = new EventLoopLagProbe(logger);
+
   const powerManager = new PowerManager({
     idleThresholdMs: POWER_IDLE_THRESHOLD_MS,
     sleepThresholdMs: POWER_SLEEP_THRESHOLD_MS,
@@ -874,13 +881,8 @@ export async function main(): Promise<void> {
     activeIntervalMs: POWER_ACTIVE_INTERVAL_MS,
     sleepIntervalMs: POWER_SLEEP_INTERVAL_MS,
     logger,
+    lagProbe: eventLoopLagProbe,
   });
-
-  // Always-on diagnostic for event-loop pinning. Catches stalls regardless
-  // of cause (sync bun:sqlite, multi-MB JSON.parse, microtask cascade in a
-  // streaming SDK aggregator). Stopped during shutdown alongside the
-  // PowerManager.
-  const eventLoopLagProbe = new EventLoopLagProbe(logger);
 
   // Per-project power state. Pre-Grove, each project ran in its own
   // daemon with its own PowerManager. With one global daemon hosting
@@ -1247,7 +1249,7 @@ export async function main(): Promise<void> {
 
   const teamFallbackDeps = { getTeamClient: () => teamSync.getTeamClient(), machineId };
   server.registerRoute('GET', '/api/sessions/:id', createGetSessionHandler(teamFallbackDeps));
-  const sessionMutations = createSessionMutationHandlers({ embeddingManager, vaultDir: bootstrapVaultDir, logger, liveConfig });
+  const sessionMutations = createSessionMutationHandlers({ embeddingManager, vaultDir: bootstrapVaultDir, logger, liveConfig, reconciler });
   server.registerRoute('GET', '/api/sessions/:id/impact', sessionMutations.handleGetSessionImpact);
   server.registerRoute('POST', '/api/sessions/:id/complete', sessionMutations.handleCompleteSession);
   server.registerRoute('DELETE', '/api/sessions/:id', sessionMutations.handleDeleteSession);

--- a/packages/myco/src/daemon/power.ts
+++ b/packages/myco/src/daemon/power.ts
@@ -1,4 +1,5 @@
 import type { DaemonLogger } from './logger.js';
+import type { EventLoopLagProbe } from './event-loop-lag.js';
 import { LOG_KINDS } from '../constants/log-kinds.js';
 
 export type PowerState = 'active' | 'idle' | 'sleep' | 'deep_sleep';
@@ -18,6 +19,10 @@ export interface PowerManagerConfig {
   activeIntervalMs: number;
   sleepIntervalMs: number;
   logger: DaemonLogger;
+  /** Optional. When provided, every job invocation emits a `power.job`
+   *  log entry annotated with the peak event-loop lag observed during
+   *  the job's runtime. */
+  lagProbe?: EventLoopLagProbe;
 }
 
 export class PowerManager {
@@ -144,15 +149,42 @@ export class PowerManager {
     });
 
     for (const job of eligible) {
-      try {
-        await job.fn();
-      } catch (err) {
-        this.logger.error(LOG_KINDS.POWER_JOB_ERROR, `Job "${job.name}" failed`, {
-          error: (err as Error).message,
-        });
-      }
+      await this.runJob(job);
     }
 
     this.scheduleNextTick();
+  }
+
+  private async runJob(job: PowerJob): Promise<void> {
+    const probe = this.config.lagProbe;
+    const startMs = performance.now();
+    let peakLagDuringMs = 0;
+    const unsubscribe = probe?.addTickListener((lag) => {
+      if (lag > peakLagDuringMs) peakLagDuringMs = lag;
+    });
+    let errored: Error | null = null;
+    try {
+      await job.fn();
+    } catch (err) {
+      errored = err as Error;
+    }
+    // Yield once to libuv's timer phase so any probe tick deferred by a
+    // sync-heavy job fires and reaches the listener before unsubscribe.
+    if (probe) {
+      await new Promise<void>((r) => setTimeout(r, 0));
+    }
+    unsubscribe?.();
+    const durationMs = performance.now() - startMs;
+    this.logger.info(LOG_KINDS.POWER_JOB, 'Power job completed', {
+      job_name: job.name,
+      duration_ms: durationMs,
+      event_loop_lag_during_ms: probe ? peakLagDuringMs : null,
+      status: errored ? 'error' : 'ok',
+    });
+    if (errored) {
+      this.logger.error(LOG_KINDS.POWER_JOB_ERROR, `Job "${job.name}" failed`, {
+        error: errored.message,
+      });
+    }
   }
 }

--- a/packages/myco/src/daemon/reconciliation.ts
+++ b/packages/myco/src/daemon/reconciliation.ts
@@ -139,7 +139,6 @@ export function createReconciler({ bufferDir, logger, projectRoot }: ReconcilerD
    */
   function reconcileSession(sessionId: string): void {
     if (reconciledSessions.has(sessionId)) return;
-    reconciledSessions.add(sessionId);
 
     // Read buffer file directly — avoid EventBuffer constructor which reads
     // the file to compute a count we don't need.
@@ -148,17 +147,23 @@ export function createReconciler({ bufferDir, logger, projectRoot }: ReconcilerD
     try {
       content = fs.readFileSync(bufferPath, 'utf-8').trim();
     } catch {
-      return; // Buffer file doesn't exist or is unreadable
+      // Buffer file absent. Return WITHOUT marking reconciled so a later
+      // call after the buffer appears can replay it.
+      return;
     }
     if (!content) return;
 
-    // Buffer files outlive session rows — sessions may have been manually
-    // deleted or cleaned up by the session cleanup job. Skip reconciliation
-    // for sessions that no longer exist rather than resurrecting them.
+    // Session row absent (deleted, or not yet created by an /events
+    // POST). Return WITHOUT marking reconciled — if the row later
+    // appears, the next call must be free to replay.
     if (!getSession(sessionId, ALL_PROJECTS_SCOPE)) {
-      logger.debug(LOG_KINDS.LIFECYCLE_RECONCILE, 'Skipping reconciliation for deleted session', { session_id: sessionId });
+      logger.debug(LOG_KINDS.LIFECYCLE_RECONCILE, 'Skipping reconciliation — session row absent', { session_id: sessionId });
       return;
     }
+
+    // Both preconditions hold; mark reconciled so the startup loop and
+    // a later /events auto-register don't replay it twice.
+    reconciledSessions.add(sessionId);
 
     const allEvents: Array<Record<string, unknown>> = content.split('\n').map((line) => JSON.parse(line));
 

--- a/packages/myco/src/db/migrations.ts
+++ b/packages/myco/src/db/migrations.ts
@@ -98,6 +98,7 @@ export const MIGRATIONS: Migration[] = [
   { version: 40, migrate: (db) => migrateV39ToV40(db) },
   { version: 41, migrate: (db) => migrateV40ToV41(db) },
   { version: 42, migrate: (db) => migrateV41ToV42(db) },
+  { version: 43, migrate: (db) => migrateV42ToV43(db) },
 ];
 
 // ---------------------------------------------------------------------------
@@ -2593,5 +2594,121 @@ function migrateV41ToV42(db: Database): void {
   } catch (err) {
     db.prepare('ROLLBACK').run();
     throw err;
+  }
+}
+
+/**
+ * Version 43 enforces NOT NULL on `activities.prompt_batch_id`.
+ *
+ *  1. For each session with one or more orphan activities
+ *     (`prompt_batch_id IS NULL`), insert one synthetic
+ *     `kind='recovered'` batch and UPDATE those activities to point
+ *     at it. The Sessions UI renders `'recovered'` batches distinctly.
+ *  2. Recreate the `activities` table with NOT NULL on `prompt_batch_id`
+ *     via the recreate-and-swap pattern (SQLite has no ALTER COLUMN),
+ *     with foreign_keys OFF during the swap.
+ */
+function migrateV42ToV43(db: Database): void {
+  const foreignKeys = readPragmaNumber(db, 'foreign_keys');
+  setPragmaBoolean(db, 'foreign_keys', 0);
+
+  db.prepare('BEGIN').run();
+  try {
+    // 1. Backfill orphans per session.
+    const orphanSessions = db.prepare(
+      'SELECT DISTINCT session_id FROM activities WHERE prompt_batch_id IS NULL',
+    ).all() as Array<{ session_id: string }>;
+
+    const insertRecoveryBatch = db.prepare(
+      `INSERT INTO prompt_batches
+         (project_id, session_id, kind, prompt_number, user_prompt,
+          started_at, ended_at, status, processed, created_at,
+          machine_id, origin)
+       VALUES (?, ?, 'recovered', 0, '(recovered — pre-invariant orphans)',
+               ?, ?, 'completed', 0, ?, 'local', 'system')`,
+    );
+    const orphanRange = db.prepare(
+      `SELECT MIN(timestamp) AS started_at,
+              MAX(timestamp) AS ended_at
+         FROM activities
+        WHERE session_id = ? AND prompt_batch_id IS NULL`,
+    );
+    const sessionProject = db.prepare(
+      'SELECT project_id FROM sessions WHERE id = ?',
+    );
+    const relinkOrphans = db.prepare(
+      `UPDATE activities
+          SET prompt_batch_id = ?
+        WHERE session_id = ? AND prompt_batch_id IS NULL`,
+    );
+    const nowSec = epochSeconds();
+    for (const { session_id } of orphanSessions) {
+      const range = orphanRange.get(session_id) as { started_at: number | null; ended_at: number | null };
+      const session = sessionProject.get(session_id) as { project_id: string | null } | undefined;
+      const result = insertRecoveryBatch.run(
+        session?.project_id ?? null,
+        session_id,
+        range.started_at ?? nowSec,
+        range.ended_at ?? nowSec,
+        nowSec,
+      );
+      relinkOrphans.run(Number(result.lastInsertRowid), session_id);
+    }
+
+    // 2. Recreate activities with NOT NULL prompt_batch_id. Activities_fts
+    //    is keyed by rowid (= activities.id); preserving ids through the
+    //    swap keeps FTS row matches intact. reapplyCurrentSchemaDdl()
+    //    after migrations reinstalls secondary indexes via IF NOT EXISTS.
+    db.exec(`
+      CREATE TABLE activities_v43 (
+        id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+        project_id           TEXT,
+        session_id           TEXT NOT NULL REFERENCES sessions(id),
+        prompt_batch_id      INTEGER NOT NULL REFERENCES prompt_batches(id),
+        tool_name            TEXT NOT NULL,
+        tool_input           TEXT,
+        tool_output_summary  TEXT,
+        file_path            TEXT,
+        files_affected       TEXT,
+        duration_ms          INTEGER,
+        success              INTEGER DEFAULT 1,
+        error_message        TEXT,
+        timestamp            INTEGER NOT NULL,
+        processed            INTEGER DEFAULT 0,
+        content_hash         TEXT,
+        created_at           INTEGER NOT NULL,
+        canopy_injection_tokens INTEGER
+      )
+    `);
+    db.exec(`
+      INSERT INTO activities_v43
+        (id, project_id, session_id, prompt_batch_id, tool_name, tool_input,
+         tool_output_summary, file_path, files_affected, duration_ms, success,
+         error_message, timestamp, processed, content_hash, created_at,
+         canopy_injection_tokens)
+      SELECT id, project_id, session_id, prompt_batch_id, tool_name, tool_input,
+             tool_output_summary, file_path, files_affected, duration_ms, success,
+             error_message, timestamp, processed, content_hash, created_at,
+             canopy_injection_tokens
+        FROM activities
+    `);
+    db.exec('DROP TABLE activities');
+    db.exec('ALTER TABLE activities_v43 RENAME TO activities');
+    // sqlite_sequence is metadata. After the swap, AUTOINCREMENT tracking
+    // points at name='activities_v43'. Re-key so future INSERTs continue
+    // past the highest preserved id.
+    db.exec("UPDATE sqlite_sequence SET name='activities' WHERE name='activities_v43'");
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at)
+       VALUES (?, ?)
+       ON CONFLICT (version) DO NOTHING`,
+    ).run(43, epochSeconds());
+    db.prepare('COMMIT').run();
+  } catch (err) {
+    db.prepare('ROLLBACK').run();
+    throw err;
+  } finally {
+    setPragmaBoolean(db, 'foreign_keys', foreignKeys);
   }
 }

--- a/packages/myco/src/db/queries/batches.ts
+++ b/packages/myco/src/db/queries/batches.ts
@@ -51,6 +51,10 @@ export const BATCH_KIND = {
   INITIAL: 'initial',
   STEERING: 'steering',
   INTERRUPT: 'interrupt',
+  /** Synthetic batch opened when an activity arrives without a
+   *  preceding user prompt. Required for the activities FK; rendered
+   *  distinctly in the UI. */
+  RECOVERED: 'recovered',
 } as const;
 
 export type BatchKind = typeof BATCH_KIND[keyof typeof BATCH_KIND];

--- a/packages/myco/src/db/schema-ddl.ts
+++ b/packages/myco/src/db/schema-ddl.ts
@@ -140,7 +140,7 @@ export const ACTIVITIES_TABLE = `
     id                   INTEGER PRIMARY KEY AUTOINCREMENT,
     project_id           TEXT,
     session_id           TEXT NOT NULL REFERENCES sessions(id),
-    prompt_batch_id      INTEGER REFERENCES prompt_batches(id),
+    prompt_batch_id      INTEGER NOT NULL REFERENCES prompt_batches(id),
     tool_name            TEXT NOT NULL,
     tool_input           TEXT,
     tool_output_summary  TEXT,

--- a/packages/myco/src/db/schema.ts
+++ b/packages/myco/src/db/schema.ts
@@ -20,7 +20,7 @@ import { TABLE_DDLS, FTS_TABLES, SECONDARY_INDEXES } from './schema-ddl.js';
 import { MIGRATIONS } from './migrations.js';
 
 /** Current schema version -- fresh start for the SQLite era. */
-export const SCHEMA_VERSION = 42;
+export const SCHEMA_VERSION = 43;
 
 // Re-export for backwards compat (other modules import from schema.ts)
 export { DEFAULT_MACHINE_ID };

--- a/packages/myco/ui/src/components/sessions/PromptBatchCard.tsx
+++ b/packages/myco/ui/src/components/sessions/PromptBatchCard.tsx
@@ -60,7 +60,12 @@ export function PromptBatchCard({ batch, batchAttachments, steeringChildren, def
       </div>
 
       {/* Card content */}
-      <Surface level="low" className="flex-1 overflow-hidden rounded-md max-w-full border border-outline-variant/10 mb-2">
+      <Surface level="low" className={cn(
+        'flex-1 overflow-hidden rounded-md max-w-full border border-outline-variant/10 mb-2',
+        // Synthetic recovery batches render faded + dashed so the
+        // timeline shows they are reconstructed, not real prompts.
+        batch.kind === 'recovered' && 'opacity-60 border-dashed',
+      )}>
         {/* Collapsible header */}
         <button
           type="button"
@@ -80,7 +85,7 @@ export function PromptBatchCard({ batch, batchAttachments, steeringChildren, def
           <div className="flex-1 min-w-0 overflow-hidden">
             <div className="flex items-baseline justify-between gap-2 mb-0.5">
               <span className="font-sans text-[10px] font-medium uppercase tracking-widest text-on-surface-variant shrink-0">
-                Prompt
+                {batch.kind === 'recovered' ? 'Recovered' : 'Prompt'}
               </span>
               {batch.activity_count > 0 && (
                 <span className="font-mono text-[10px] text-on-surface-variant/70 shrink-0">

--- a/tests/canopy/aggregate/aggregate-session.test.ts
+++ b/tests/canopy/aggregate/aggregate-session.test.ts
@@ -64,17 +64,26 @@ function seedSession(sessionId: string) {
 function seedActivities(sessionId: string, activities: SeedActivity[]) {
   const db = getDatabase();
   const base = epochNow();
+  // v43 invariant: activities.prompt_batch_id is NOT NULL. Open a batch
+  // for the session and reuse its id for every seeded activity.
+  const batchInsert = db.prepare(`
+    INSERT INTO prompt_batches (session_id, prompt_number, started_at, created_at, status)
+    VALUES (?, 1, ?, ?, 'active')
+  `).run(sessionId, base, base);
+  const batchId = Number(batchInsert.lastInsertRowid);
+
   const insert = db.prepare(`
     INSERT INTO activities (
-      session_id, tool_name, tool_input, file_path,
+      session_id, prompt_batch_id, tool_name, tool_input, file_path,
       timestamp, processed, created_at, canopy_injection_tokens
-    ) VALUES (?, ?, ?, ?, ?, 0, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)
   `);
   activities.forEach((a, i) => {
     const path = a.file_path;
     const toolInput = path === null ? null : JSON.stringify({ file_path: path });
     insert.run(
       sessionId,
+      batchId,
       a.tool_name ?? 'Read',
       toolInput,
       path,

--- a/tests/canopy/aggregate/api.test.ts
+++ b/tests/canopy/aggregate/api.test.ts
@@ -54,14 +54,25 @@ function seedRead(
   injectionTokens: number | null,
   ts: number,
 ): number {
-  const result = getDatabase()
-    .prepare(`
-      INSERT INTO activities (
-        session_id, project_id, tool_name, tool_input, file_path, timestamp,
-        processed, created_at, canopy_injection_tokens
-      ) VALUES (?, ?, 'Read', ?, ?, ?, 0, ?, ?)
-    `)
-    .run(sessionId, PROJECT_ID, JSON.stringify({ file_path: filePath }), filePath, ts, ts, injectionTokens);
+  // v43 invariant: activities.prompt_batch_id is NOT NULL. Reuse the
+  // session's batch (open one if absent).
+  const db = getDatabase();
+  let batchId = (db.prepare(
+    'SELECT id FROM prompt_batches WHERE session_id = ? ORDER BY id LIMIT 1',
+  ).get(sessionId) as { id: number } | undefined)?.id;
+  if (batchId === undefined) {
+    const result = db.prepare(
+      `INSERT INTO prompt_batches (session_id, project_id, prompt_number, started_at, created_at, status)
+       VALUES (?, ?, 1, ?, ?, 'active')`,
+    ).run(sessionId, PROJECT_ID, ts, ts);
+    batchId = Number(result.lastInsertRowid);
+  }
+  const result = db.prepare(`
+    INSERT INTO activities (
+      session_id, project_id, prompt_batch_id, tool_name, tool_input, file_path, timestamp,
+      processed, created_at, canopy_injection_tokens
+    ) VALUES (?, ?, ?, 'Read', ?, ?, ?, 0, ?, ?)
+  `).run(sessionId, PROJECT_ID, batchId, JSON.stringify({ file_path: filePath }), filePath, ts, ts, injectionTokens);
   return Number(result.lastInsertRowid);
 }
 

--- a/tests/canopy/aggregate/materialize.test.ts
+++ b/tests/canopy/aggregate/materialize.test.ts
@@ -28,14 +28,25 @@ function seedSession(sessionId: string) {
 }
 
 function seedRead(sessionId: string, filePath: string, injectionTokens: number | null, ts: number) {
-  getDatabase()
-    .prepare(`
-      INSERT INTO activities (
-        session_id, tool_name, tool_input, file_path, timestamp,
-        processed, created_at, canopy_injection_tokens
-      ) VALUES (?, 'Read', ?, ?, ?, 0, ?, ?)
-    `)
-    .run(sessionId, JSON.stringify({ file_path: filePath }), filePath, ts, ts, injectionTokens);
+  // v43 invariant: activities.prompt_batch_id is NOT NULL. Open or reuse
+  // a batch for the session before inserting the activity.
+  const db = getDatabase();
+  let batchId = (db.prepare(
+    'SELECT id FROM prompt_batches WHERE session_id = ? ORDER BY id LIMIT 1',
+  ).get(sessionId) as { id: number } | undefined)?.id;
+  if (batchId === undefined) {
+    const result = db.prepare(
+      `INSERT INTO prompt_batches (session_id, prompt_number, started_at, created_at, status)
+       VALUES (?, 1, ?, ?, 'active')`,
+    ).run(sessionId, ts, ts);
+    batchId = Number(result.lastInsertRowid);
+  }
+  db.prepare(`
+    INSERT INTO activities (
+      session_id, prompt_batch_id, tool_name, tool_input, file_path, timestamp,
+      processed, created_at, canopy_injection_tokens
+    ) VALUES (?, ?, 'Read', ?, ?, ?, 0, ?, ?)
+  `).run(sessionId, batchId, JSON.stringify({ file_path: filePath }), filePath, ts, ts, injectionTokens);
 }
 
 function seedCanopyEntry(path: string, tokens: number) {

--- a/tests/daemon/api/sessions.test.ts
+++ b/tests/daemon/api/sessions.test.ts
@@ -143,6 +143,7 @@ describe('handleCompleteSession', () => {
       vaultDir: tmpDir,
       logger: makeLogger() as never,
       liveConfig: liveConfig as never,
+      reconciler: { clearSession: vi.fn() },
     });
   }
 
@@ -226,6 +227,7 @@ describe('handleDeletePlan', () => {
       vaultDir: tmpDir,
       logger: makeLogger() as never,
       liveConfig: { current: { agent: { event_tasks_enabled: false } } } as never,
+      reconciler: { clearSession: vi.fn() },
     });
   }
 
@@ -319,6 +321,7 @@ describe('handleDeletePlan — machine_id ownership', () => {
       vaultDir: tmpDir,
       logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
       liveConfig: { current: { agent: { event_tasks_enabled: false } } } as never,
+      reconciler: { clearSession: vi.fn() },
     });
   }
 

--- a/tests/daemon/capture.test.ts
+++ b/tests/daemon/capture.test.ts
@@ -151,13 +151,19 @@ describe('daemon capture flow', () => {
       created_at: now,
     });
 
-    // Tool use without a prior user prompt — should still record activity
+    // Tool use without a prior user prompt — handler opens an implicit
+    // 'recovered' batch so the activity has a parent.
     handleToolUse(sessionId, 'claude-code', 'Read', { file_path: '/tmp/file.ts' }, 'contents', TEST_PROJECT_ROOT);
 
     const activities = listActivities({ session_id: sessionId, scope: ALL_PROJECTS_SCOPE });
     expect(activities.length).toBe(1);
-    expect(activities[0].prompt_batch_id).toBeNull();
+    expect(activities[0].prompt_batch_id).not.toBeNull();
     expect(activities[0].tool_name).toBe('Read');
+
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches.length).toBe(1);
+    expect(batches[0].kind).toBe('recovered');
+    expect(activities[0].prompt_batch_id).toBe(batches[0].id);
   });
 
   it('extracts file_path from camelCase filePath tool input', async () => {
@@ -454,21 +460,25 @@ describe('stateless DB functions', () => {
       expect(activity.file_path).toBe('/tmp/test.ts');
     });
 
-    it('sets prompt_batch_id to NULL when no open batch exists', async () => {
+    it('rejects insert when no open batch exists (NOT NULL FK enforced)', async () => {
       const sessionId = 'test-activity-batch-002';
       const now = epochNow();
 
       upsertSession({ id: sessionId, agent: 'claude-code', started_at: now, created_at: now });
 
-      // No batch created — activity should have NULL batch
-      const activity = insertActivityWithBatch({
-        session_id: sessionId,
-        tool_name: 'Read',
-        timestamp: now,
-        created_at: now,
-      });
-
-      expect(activity.prompt_batch_id).toBeNull();
+      // Schema v43 enforces activities.prompt_batch_id NOT NULL. The inline
+      // subquery in insertActivityWithBatch resolves to NULL when no batch
+      // is open, so the INSERT fails the constraint. This is the safety
+      // net — `handleToolUse` is responsible for opening a recovery batch
+      // before this path runs.
+      expect(() =>
+        insertActivityWithBatch({
+          session_id: sessionId,
+          tool_name: 'Read',
+          timestamp: now,
+          created_at: now,
+        }),
+      ).toThrow();
     });
 
     it('links to the most recent open batch when multiple exist', async () => {
@@ -492,7 +502,7 @@ describe('stateless DB functions', () => {
       expect(activity.prompt_batch_id).toBe(batch2.id);
     });
 
-    it('does not link to closed batches', async () => {
+    it('does not link to closed batches — rejects insert under v43 invariant', async () => {
       const sessionId = 'test-activity-batch-004';
       const now = epochNow();
 
@@ -502,15 +512,18 @@ describe('stateless DB functions', () => {
       insertBatchStateless({ session_id: sessionId, user_prompt: 'closed', created_at: now });
       closeOpenBatches(sessionId, now + 1);
 
-      // Activity should have NULL batch since only closed batches exist
-      const activity = insertActivityWithBatch({
-        session_id: sessionId,
-        tool_name: 'Read',
-        timestamp: now + 2,
-        created_at: now + 2,
-      });
-
-      expect(activity.prompt_batch_id).toBeNull();
+      // Only closed batches exist → inline subquery returns no row → NULL
+      // → fails NOT NULL constraint. Insertion at this level is rejected;
+      // the runtime caller (handleToolUse) is expected to open a fresh
+      // recovery batch first.
+      expect(() =>
+        insertActivityWithBatch({
+          session_id: sessionId,
+          tool_name: 'Read',
+          timestamp: now + 2,
+          created_at: now + 2,
+        }),
+      ).toThrow();
     });
 
     it('accepts canopy_injection_tokens in the same INSERT (no follow-up UPDATE needed)', async () => {
@@ -518,6 +531,7 @@ describe('stateless DB functions', () => {
       const now = epochNow();
 
       upsertSession({ id: sessionId, agent: 'claude-code', started_at: now, created_at: now });
+      insertBatchStateless({ session_id: sessionId, user_prompt: 'p', created_at: now });
 
       const activity = insertActivityWithBatch({
         session_id: sessionId,
@@ -537,6 +551,7 @@ describe('stateless DB functions', () => {
       const now = epochNow();
 
       upsertSession({ id: sessionId, agent: 'claude-code', started_at: now, created_at: now });
+      insertBatchStateless({ session_id: sessionId, user_prompt: 'p', created_at: now });
 
       const activity = insertActivityWithBatch({
         session_id: sessionId,
@@ -649,37 +664,40 @@ describe('daemon-restart resilience', () => {
     expect(activities[1].prompt_batch_id).toBe(postBatch.id);
   });
 
-  it('activity before any post-restart batch gets NULL batch', async () => {
+  it('activity before any post-restart batch is captured via implicit recovery batch (v43 invariant)', async () => {
     const sessionId = 'test-restart-orphan-001';
     const now = epochNow();
 
     upsertSession({ id: sessionId, agent: 'claude-code', started_at: now, created_at: now });
 
     // Pre-restart: open batch, close it
-    insertBatchStateless({ session_id: sessionId, user_prompt: 'pre', created_at: now });
+    const preBatch = insertBatchStateless({ session_id: sessionId, user_prompt: 'pre', created_at: now });
     closeOpenBatches(sessionId, now + 1);
 
     // ---- RESTART ----
 
-    // Tool use before the first post-restart prompt — no open batch
-    const orphanActivity = insertActivityWithBatch({
-      session_id: sessionId,
-      tool_name: 'Read',
-      file_path: '/tmp/context.ts',
-      timestamp: now + 2,
-      created_at: now + 2,
-    });
-    expect(orphanActivity.prompt_batch_id).toBeNull();
+    // Tool use before the first post-restart prompt. Under v43 + the
+    // handleToolUse defense, this opens an implicit recovery batch
+    // rather than orphaning the activity.
+    handleToolUse(sessionId, 'claude-code', 'Read', { file_path: '/tmp/context.ts' }, 'contents', TEST_PROJECT_ROOT);
 
-    // Now open a new batch — subsequent activities link correctly
+    const batchesMid = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batchesMid.length).toBe(2);
+    const recovered = batchesMid.find((b) => b.kind === 'recovered');
+    expect(recovered).toBeDefined();
+
+    const activitiesMid = listActivities({ session_id: sessionId, scope: ALL_PROJECTS_SCOPE });
+    expect(activitiesMid.length).toBe(1);
+    expect(activitiesMid[0].prompt_batch_id).toBe(recovered!.id);
+
+    // Now open a new real batch — subsequent activities link correctly to it.
     const postBatch = insertBatchStateless({ session_id: sessionId, user_prompt: 'post', created_at: now + 3 });
-    const linkedActivity = insertActivityWithBatch({
-      session_id: sessionId,
-      tool_name: 'Write',
-      timestamp: now + 4,
-      created_at: now + 4,
-    });
-    expect(linkedActivity.prompt_batch_id).toBe(postBatch.id);
+    handleToolUse(sessionId, 'claude-code', 'Write', {}, 'ok', TEST_PROJECT_ROOT);
+    const finalActivities = listActivities({ session_id: sessionId, scope: ALL_PROJECTS_SCOPE });
+    expect(finalActivities.length).toBe(2);
+    expect(finalActivities[1].prompt_batch_id).toBe(postBatch.id);
+    // Reference the pre-restart batch so the linter doesn't flag the binding.
+    expect(preBatch.id).toBeGreaterThan(0);
   });
 
   it('multiple restarts maintain correct numbering', async () => {
@@ -804,7 +822,9 @@ describe('new event type handlers', () => {
       expect(activities[0].tool_name).toBe('subagent_start');
       expect(activities[0].tool_input).toContain('agent-123');
       expect(activities[0].tool_input).toContain('researcher');
-      expect(activities[0].prompt_batch_id).toBeNull();
+      // Under schema v43, prompt_batch_id is NOT NULL. The handler opens
+      // an implicit recovery batch when none is found.
+      expect(activities[0].prompt_batch_id).not.toBeNull();
     });
   });
 

--- a/tests/daemon/event-loop-lag.test.ts
+++ b/tests/daemon/event-loop-lag.test.ts
@@ -74,6 +74,56 @@ describe('EventLoopLagProbe', () => {
     expect(probe.getStats().stallCount).toBeGreaterThanOrEqual(1);
   });
 
+  it('addTickListener delivers per-tick lag values and supports unsubscribe', async () => {
+    const { logger } = captureLogger();
+    const probe = new EventLoopLagProbe(logger, {
+      sampleIntervalMs: FAST_INTERVAL,
+      warnThresholdMs: 50,
+    });
+    const observed: number[] = [];
+    const unsubscribe = probe.addTickListener((lag) => observed.push(lag));
+
+    probe.start();
+    await new Promise((r) => setTimeout(r, FAST_INTERVAL * 4));
+    expect(observed.length).toBeGreaterThanOrEqual(2);
+
+    const seenAtUnsubscribe = observed.length;
+    unsubscribe();
+    await new Promise((r) => setTimeout(r, FAST_INTERVAL * 3));
+    probe.stop();
+
+    // After unsubscribe the listener is not called again.
+    expect(observed.length).toBe(seenAtUnsubscribe);
+  });
+
+  it('addTickListener: a throwing listener does not crash the probe or block other listeners', async () => {
+    const { logs, logger } = captureLogger();
+    const probe = new EventLoopLagProbe(logger, {
+      sampleIntervalMs: FAST_INTERVAL,
+      warnThresholdMs: 50,
+    });
+    let goodCount = 0;
+    probe.addTickListener(() => {
+      throw new Error('boom');
+    });
+    probe.addTickListener(() => {
+      goodCount++;
+    });
+
+    probe.start();
+    await new Promise((r) => setTimeout(r, FAST_INTERVAL * 4));
+    probe.stop();
+
+    expect(goodCount).toBeGreaterThanOrEqual(2);
+    const listenerWarns = logs.filter(
+      (entry) =>
+        entry.kind === LOG_KINDS.DAEMON_LAG &&
+        entry.level === 'warn' &&
+        entry.message?.includes('listener threw'),
+    );
+    expect(listenerWarns.length).toBeGreaterThanOrEqual(2);
+  });
+
   it('stop() halts further samples', async () => {
     const { logs, logger } = captureLogger();
     const probe = new EventLoopLagProbe(logger, {

--- a/tests/daemon/jobs/session-cleanup.test.ts
+++ b/tests/daemon/jobs/session-cleanup.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { vi } from '../../helpers/vi-shim.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { cleanupAfterSessionCascade } from '@myco/daemon/jobs/session-cleanup.js';
+import type { DeleteCascadeResult } from '@myco/db/queries/sessions.js';
+
+// Stub that satisfies the slice of EmbeddingManager cleanupAfterSessionCascade
+// reaches into. The real one is heavier and unrelated to what we're testing.
+function makeEmbeddingStub() {
+  return { onRemoved: vi.fn() } as unknown as Parameters<typeof cleanupAfterSessionCascade>[2];
+}
+
+function emptyResult(): DeleteCascadeResult {
+  return {
+    deleted: true,
+    counts: {} as never,
+    deletedSporeIds: [],
+    deletedAttachmentPaths: [],
+  } as unknown as DeleteCascadeResult;
+}
+
+describe('cleanupAfterSessionCascade — buffer journal unlink', () => {
+  let vaultDir: string;
+  let bufferDir: string;
+
+  beforeEach(() => {
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cleanup-cascade-'));
+    bufferDir = path.join(vaultDir, 'buffer');
+    fs.mkdirSync(bufferDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(vaultDir, { recursive: true, force: true });
+  });
+
+  // Cascade-delete is the user's explicit "this session is gone" intent,
+  // so the buffer journal is removed alongside the DB rows. Leaving it
+  // behind lets a same-id reload resurrect stale events at reconcile.
+  it('unlinks <vaultDir>/buffer/<sessionId>.jsonl when present', async () => {
+    const sessionId = 'cascade-buf-001';
+    const bufferPath = path.join(bufferDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(bufferPath, '{"type":"user_prompt","prompt":"hi","timestamp":"2026-05-18T00:00:00Z"}\n');
+    expect(fs.existsSync(bufferPath)).toBe(true);
+
+    await cleanupAfterSessionCascade(sessionId, emptyResult(), makeEmbeddingStub(), vaultDir);
+
+    expect(fs.existsSync(bufferPath)).toBe(false);
+  });
+
+  it('is a no-op when no buffer file exists (best-effort)', async () => {
+    const sessionId = 'cascade-buf-002';
+    // No buffer file written. Should not throw.
+    await expect(
+      cleanupAfterSessionCascade(sessionId, emptyResult(), makeEmbeddingStub(), vaultDir),
+    ).resolves.toBeUndefined();
+  });
+
+  it('leaves other sessions\' buffer files untouched', async () => {
+    const targetId = 'cascade-buf-003';
+    const survivorId = 'survivor-buf-004';
+    const targetPath = path.join(bufferDir, `${targetId}.jsonl`);
+    const survivorPath = path.join(bufferDir, `${survivorId}.jsonl`);
+    fs.writeFileSync(targetPath, '{"type":"user_prompt","prompt":"x","timestamp":"2026-05-18T00:00:00Z"}\n');
+    fs.writeFileSync(survivorPath, '{"type":"user_prompt","prompt":"y","timestamp":"2026-05-18T00:00:00Z"}\n');
+
+    await cleanupAfterSessionCascade(targetId, emptyResult(), makeEmbeddingStub(), vaultDir);
+
+    expect(fs.existsSync(targetPath)).toBe(false);
+    expect(fs.existsSync(survivorPath)).toBe(true);
+  });
+});

--- a/tests/daemon/power.test.ts
+++ b/tests/daemon/power.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { vi } from '../helpers/vi-shim.js';
 import { PowerManager, type PowerState } from '@myco/daemon/power.js';
+import { EventLoopLagProbe } from '@myco/daemon/event-loop-lag.js';
+import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 
 describe('PowerManager', () => {
   let pm: PowerManager;
@@ -189,5 +191,143 @@ describe('PowerManager', () => {
       'embedding-reconcile',
       'scheduled:new-task',
     ]);
+  });
+});
+
+// Real-timer suite — exercises per-job timing/lag instrumentation against a
+// live EventLoopLagProbe. Cannot run under fake timers because the probe is
+// driven by real setTimeout for clock-fidelity reasons documented on
+// `event-loop-lag.ts`.
+describe('PowerManager: per-job timing instrumentation', () => {
+  interface LogCall {
+    level: 'info' | 'warn' | 'error' | 'debug';
+    kind: string;
+    message: string;
+    data?: Record<string, unknown>;
+  }
+
+  function captureLogger(): { logs: LogCall[]; logger: any } {
+    const logs: LogCall[] = [];
+    const push = (level: LogCall['level']) =>
+      (kind: string, message: string, data?: Record<string, unknown>) => {
+        logs.push({ level, kind, message, data });
+      };
+    return {
+      logs,
+      logger: {
+        debug: push('debug'),
+        info: push('info'),
+        warn: push('warn'),
+        error: push('error'),
+      },
+    };
+  }
+
+  function blockSync(ms: number): void {
+    const deadline = Date.now() + ms;
+    while (Date.now() < deadline) { /* busy-wait */ }
+  }
+
+  it('emits a power.job log entry with duration and lag attribution for each job', async () => {
+    const { logs, logger } = captureLogger();
+    const probe = new EventLoopLagProbe(logger, { sampleIntervalMs: 25, warnThresholdMs: 1_000_000 });
+    probe.start();
+    try {
+      const pm = new PowerManager({
+        idleThresholdMs: 60_000,
+        sleepThresholdMs: 120_000,
+        deepSleepThresholdMs: 180_000,
+        activeIntervalMs: 50,
+        sleepIntervalMs: 1000,
+        logger,
+        lagProbe: probe,
+      });
+
+      pm.register({
+        name: 'fast-job',
+        runIn: ['active'],
+        fn: async () => { /* no-op */ },
+      });
+      pm.register({
+        name: 'slow-job',
+        runIn: ['active'],
+        fn: async () => { blockSync(120); },
+      });
+
+      pm.start();
+      // Let one tick complete (≥ 50ms active interval + job runtime).
+      await new Promise((r) => setTimeout(r, 300));
+      pm.stop();
+
+      const jobLogs = logs.filter((e) => e.kind === LOG_KINDS.POWER_JOB);
+      const fast = jobLogs.find((e) => e.data?.job_name === 'fast-job');
+      const slow = jobLogs.find((e) => e.data?.job_name === 'slow-job');
+      expect(fast).toBeDefined();
+      expect(slow).toBeDefined();
+      expect((slow!.data?.duration_ms as number)).toBeGreaterThanOrEqual(100);
+      expect((fast!.data?.duration_ms as number)).toBeLessThan(50);
+      expect(fast!.data?.status).toBe('ok');
+      expect(slow!.data?.status).toBe('ok');
+      // lag-during is attributable when a probe is provided (may be 0 if no
+      // tick happened to fire inside the fast job — the slow job pins the
+      // loop long enough that at least one tick fires during it).
+      expect(slow!.data?.event_loop_lag_during_ms).toBeGreaterThanOrEqual(50);
+    } finally {
+      probe.stop();
+    }
+  });
+
+  it('emits power.job with status=error and still logs power.job-error when the job throws', async () => {
+    const { logs, logger } = captureLogger();
+    const probe = new EventLoopLagProbe(logger, { sampleIntervalMs: 25, warnThresholdMs: 1_000_000 });
+    probe.start();
+    try {
+      const pm = new PowerManager({
+        idleThresholdMs: 60_000,
+        sleepThresholdMs: 120_000,
+        deepSleepThresholdMs: 180_000,
+        activeIntervalMs: 50,
+        sleepIntervalMs: 1000,
+        logger,
+        lagProbe: probe,
+      });
+      pm.register({
+        name: 'broken-job',
+        runIn: ['active'],
+        fn: async () => { throw new Error('boom'); },
+      });
+
+      pm.start();
+      await new Promise((r) => setTimeout(r, 200));
+      pm.stop();
+
+      const jobLog = logs.find((e) => e.kind === LOG_KINDS.POWER_JOB);
+      expect(jobLog?.data?.status).toBe('error');
+      const errLog = logs.find((e) => e.kind === LOG_KINDS.POWER_JOB_ERROR);
+      expect(errLog).toBeDefined();
+      expect(errLog?.data?.error).toBe('boom');
+    } finally {
+      probe.stop();
+    }
+  });
+
+  it('reports event_loop_lag_during_ms = null when no lag probe is configured', async () => {
+    const { logs, logger } = captureLogger();
+    const pm = new PowerManager({
+      idleThresholdMs: 60_000,
+      sleepThresholdMs: 120_000,
+      deepSleepThresholdMs: 180_000,
+      activeIntervalMs: 50,
+      sleepIntervalMs: 1000,
+      logger,
+    });
+    pm.register({ name: 'no-probe-job', runIn: ['active'], fn: async () => {} });
+    pm.start();
+    await new Promise((r) => setTimeout(r, 150));
+    pm.stop();
+
+    const jobLog = logs.find((e) => e.kind === LOG_KINDS.POWER_JOB);
+    expect(jobLog).toBeDefined();
+    expect(jobLog?.data?.event_loop_lag_during_ms).toBeNull();
   });
 });

--- a/tests/daemon/reconciliation-cache-poisoning.test.ts
+++ b/tests/daemon/reconciliation-cache-poisoning.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'bun:test';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
+import { seedSession } from '../helpers/sessions.js';
+import { createReconciler } from '@myco/daemon/reconciliation.js';
+import { listBatchesBySession } from '@myco/db/queries/batches.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const silentLogger = {
+  debug: () => {}, info: () => {}, warn: () => {}, error: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;
+
+// reconcileSession bails when the session row is absent (deleted, or
+// not yet created). The bail must NOT mark the session reconciled — a
+// later call after the row appears has to replay the buffer cleanly.
+
+describe('Buffer reconciliation — cache poisoning protection', () => {
+  let tmpDir: string;
+  let bufferDir: string;
+
+  beforeAll(() => { setupTestDb(); });
+  afterAll(teardownTestDb);
+
+  beforeEach(() => {
+    cleanTestDb();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reconcile-cache-'));
+    bufferDir = path.join(tmpDir, 'buffer');
+    fs.mkdirSync(bufferDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('a bailout for a missing session row does NOT mark the session reconciled — a later call after the row appears completes the replay', () => {
+    const sessionId = 'cache-poison-001';
+    const promptText = 'investigate the wedge';
+    const bufferPath = path.join(bufferDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(bufferPath,
+      JSON.stringify({ type: 'user_prompt', prompt: promptText, timestamp: '2026-05-18T17:37:20.907Z' }) + '\n',
+    );
+
+    const reconciler = createReconciler({ bufferDir, logger: silentLogger, projectRoot: process.cwd() });
+
+    // First call: session row not present yet. Reconciler must bail and
+    // must NOT poison the cache.
+    reconciler.reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(0);
+
+    // Simulate the /events auto-register path: the session row appears.
+    seedSession({ id: sessionId, agent: 'claude-code' });
+
+    // Second call: the row now exists, the buffer is still on disk. The
+    // reconciler must replay and open the batch.
+    reconciler.reconcileSession(sessionId);
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches).toHaveLength(1);
+    expect(batches[0].user_prompt).toBe(promptText);
+  });
+
+  it('a missing buffer file does NOT poison the cache either — a later call after the buffer is written replays it', () => {
+    const sessionId = 'cache-poison-002';
+    seedSession({ id: sessionId, agent: 'claude-code' });
+
+    const reconciler = createReconciler({ bufferDir, logger: silentLogger, projectRoot: process.cwd() });
+
+    // No buffer file on disk yet — reconciler should silently no-op.
+    reconciler.reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(0);
+
+    // Now the buffer is written (e.g. a hook fires and the daemon was hot
+    // enough that the buffer was created but not yet drained).
+    const promptText = 'follow-up question';
+    fs.writeFileSync(path.join(bufferDir, `${sessionId}.jsonl`),
+      JSON.stringify({ type: 'user_prompt', prompt: promptText, timestamp: '2026-05-18T17:42:49.644Z' }) + '\n',
+    );
+
+    reconciler.reconcileSession(sessionId);
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches).toHaveLength(1);
+    expect(batches[0].user_prompt).toBe(promptText);
+  });
+
+  it('a successful reconcile still marks the session — a second call is a no-op (existing per-lifetime guard preserved)', () => {
+    const sessionId = 'cache-poison-003';
+    seedSession({ id: sessionId, agent: 'claude-code' });
+
+    const promptText = 'first prompt';
+    fs.writeFileSync(path.join(bufferDir, `${sessionId}.jsonl`),
+      JSON.stringify({ type: 'user_prompt', prompt: promptText, timestamp: '2026-05-18T17:37:20.907Z' }) + '\n',
+    );
+
+    const reconciler = createReconciler({ bufferDir, logger: silentLogger, projectRoot: process.cwd() });
+
+    reconciler.reconcileSession(sessionId);
+    const batchesAfterFirst = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batchesAfterFirst).toHaveLength(1);
+
+    // Append a second event to the buffer. The cache is now marked, so a
+    // second reconcileSession must skip without re-replaying — this is
+    // the existing once-per-lifetime guarantee. If it ever re-replayed,
+    // we'd get duplicate batches.
+    fs.appendFileSync(path.join(bufferDir, `${sessionId}.jsonl`),
+      JSON.stringify({ type: 'user_prompt', prompt: 'second prompt', timestamp: '2026-05-18T17:42:00.000Z' }) + '\n',
+    );
+    reconciler.reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(1);
+  });
+});

--- a/tests/daemon/stale-session-sweep.test.ts
+++ b/tests/daemon/stale-session-sweep.test.ts
@@ -35,19 +35,31 @@ function seedSession(id: string, opts: {
 
   const db = getDatabase();
 
+  let batchId: number | null = null;
   if (opts.batchStartedAt !== undefined) {
-    db.prepare(
+    const result = db.prepare(
       `INSERT INTO prompt_batches (session_id, prompt_number, started_at, created_at, status)
        VALUES (?, 1, ?, ?, 'active')`,
     ).run(id, opts.batchStartedAt, now);
+    batchId = Number(result.lastInsertRowid);
   }
 
   if (opts.activityTimestamp !== undefined) {
+    // v43 invariant: activities.prompt_batch_id is NOT NULL. If the test
+    // didn't ask for a real batch, attach the activity to a synthetic
+    // recovery batch (mirrors what handleToolUse does in production).
+    if (batchId === null) {
+      const result = db.prepare(
+        `INSERT INTO prompt_batches (session_id, prompt_number, started_at, created_at, status, kind, user_prompt, origin)
+         VALUES (?, 0, ?, ?, 'completed', 'recovered', '(implicit batch — capture recovered)', 'system')`,
+      ).run(id, opts.activityTimestamp, now);
+      batchId = Number(result.lastInsertRowid);
+    }
     db.prepare(
       `INSERT INTO activities
-         (session_id, tool_name, timestamp, created_at)
-       VALUES (?, 'Bash', ?, ?)`,
-    ).run(id, opts.activityTimestamp, now);
+         (session_id, prompt_batch_id, tool_name, timestamp, created_at)
+       VALUES (?, ?, 'Bash', ?, ?)`,
+    ).run(id, batchId, opts.activityTimestamp, now);
   }
 }
 

--- a/tests/db/migrate-v42-skill-candidate-quality.test.ts
+++ b/tests/db/migrate-v42-skill-candidate-quality.test.ts
@@ -80,8 +80,8 @@ describe('migrateV41ToV42 skill candidate quality metadata', () => {
     closeDatabase();
   });
 
-  it('SCHEMA_VERSION is 42', () => {
-    expect(SCHEMA_VERSION).toBe(42);
+  it('SCHEMA_VERSION reflects the latest migration', () => {
+    expect(SCHEMA_VERSION).toBeGreaterThanOrEqual(42);
   });
 
   it('is registered in MIGRATIONS at version 42', () => {

--- a/tests/db/migrate-v43-activity-not-null.test.ts
+++ b/tests/db/migrate-v43-activity-not-null.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Verifies the v43 migration: NOT NULL on `activities.prompt_batch_id`
+ * plus backfill of pre-invariant orphans to synthetic kind='recovered'
+ * batches.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { Database } from 'bun:sqlite';
+import { initDatabase, closeDatabase, getDatabase } from '@myco/db/client.js';
+import { createSchema, SCHEMA_VERSION } from '@myco/db/schema.js';
+import { epochSeconds } from '@myco/constants.js';
+
+// Stage a database at "post-v42 with the v43 NOT NULL reverted." Concretely:
+// run createSchema() once to install all current DDL, recreate the
+// activities table without the NOT NULL on prompt_batch_id (mirroring the
+// pre-fix shape that produced orphans in the wild), then rewind
+// schema_version to 42 so the v43 migration applies on the next call.
+function seedV42Database(dbPath: string): void {
+  const db = new Database(dbPath);
+  createSchema(db as never);
+  db.exec(`
+    CREATE TABLE activities_legacy (
+      id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+      project_id           TEXT,
+      session_id           TEXT NOT NULL REFERENCES sessions(id),
+      prompt_batch_id      INTEGER REFERENCES prompt_batches(id),
+      tool_name            TEXT NOT NULL,
+      tool_input           TEXT,
+      tool_output_summary  TEXT,
+      file_path            TEXT,
+      files_affected       TEXT,
+      duration_ms          INTEGER,
+      success              INTEGER DEFAULT 1,
+      error_message        TEXT,
+      timestamp            INTEGER NOT NULL,
+      processed            INTEGER DEFAULT 0,
+      content_hash         TEXT,
+      created_at           INTEGER NOT NULL,
+      canopy_injection_tokens INTEGER
+    )
+  `);
+  db.exec(`INSERT INTO activities_legacy SELECT * FROM activities`);
+  db.exec('DROP TABLE activities');
+  db.exec('ALTER TABLE activities_legacy RENAME TO activities');
+  db.exec('DELETE FROM schema_version');
+  db.prepare(
+    'INSERT INTO schema_version (version, applied_at) VALUES (42, ?)',
+  ).run(epochSeconds());
+  db.close();
+}
+
+describe('migrateV42ToV43 — activity NOT NULL + recovery batch backfill', () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-v43-'));
+    dbPath = path.join(tmpDir, 'myco.db');
+    seedV42Database(dbPath);
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('backfills orphan activities to a per-session synthetic recovery batch', () => {
+    const seed = new Database(dbPath);
+    const now = epochSeconds();
+    seed.exec(`INSERT INTO sessions (id, agent, started_at, created_at) VALUES ('sess-A', 'claude-code', ${now}, ${now})`);
+    seed.exec(`INSERT INTO sessions (id, agent, started_at, created_at) VALUES ('sess-B', 'codex', ${now}, ${now})`);
+    seed.exec(`INSERT INTO sessions (id, agent, started_at, created_at) VALUES ('sess-clean', 'claude-code', ${now}, ${now})`);
+    seed.exec(`INSERT INTO activities (session_id, tool_name, timestamp, created_at) VALUES ('sess-A', 'Read', ${now}, ${now})`);
+    seed.exec(`INSERT INTO activities (session_id, tool_name, timestamp, created_at) VALUES ('sess-A', 'Bash', ${now + 1}, ${now + 1})`);
+    seed.exec(`INSERT INTO activities (session_id, tool_name, timestamp, created_at) VALUES ('sess-B', 'Write', ${now + 2}, ${now + 2})`);
+    const batchResult = seed.prepare(
+      `INSERT INTO prompt_batches (session_id, prompt_number, user_prompt, started_at, created_at, status)
+       VALUES ('sess-clean', 1, 'real prompt', ?, ?, 'active')`,
+    ).run(now, now);
+    const cleanBatchId = Number(batchResult.lastInsertRowid);
+    seed.prepare(
+      `INSERT INTO activities (session_id, prompt_batch_id, tool_name, timestamp, created_at)
+       VALUES ('sess-clean', ?, 'Edit', ?, ?)`,
+    ).run(cleanBatchId, now, now);
+    seed.close();
+
+    initDatabase(dbPath);
+    createSchema(getDatabase() as never);
+
+    const db = new Database(dbPath, { readonly: true });
+
+    const recoveryBatches = db.prepare(
+      "SELECT session_id, user_prompt, kind FROM prompt_batches WHERE kind = 'recovered'",
+    ).all() as Array<{ session_id: string; user_prompt: string; kind: string }>;
+    expect(recoveryBatches).toHaveLength(2);
+    const sessions = new Set(recoveryBatches.map((r) => r.session_id));
+    expect(sessions.has('sess-A')).toBe(true);
+    expect(sessions.has('sess-B')).toBe(true);
+    expect(sessions.has('sess-clean')).toBe(false);
+
+    const remainingNull = (db.prepare(
+      'SELECT count(*) AS n FROM activities WHERE prompt_batch_id IS NULL',
+    ).get() as { n: number }).n;
+    expect(remainingNull).toBe(0);
+
+    const sessARecovery = db.prepare("SELECT id FROM prompt_batches WHERE session_id = 'sess-A' AND kind = 'recovered'").get() as { id: number };
+    const sessBRecovery = db.prepare("SELECT id FROM prompt_batches WHERE session_id = 'sess-B' AND kind = 'recovered'").get() as { id: number };
+    const sessAActs = db.prepare("SELECT prompt_batch_id FROM activities WHERE session_id = 'sess-A'").all() as Array<{ prompt_batch_id: number }>;
+    expect(sessAActs.every((a) => a.prompt_batch_id === sessARecovery.id)).toBe(true);
+    const sessBActs = db.prepare("SELECT prompt_batch_id FROM activities WHERE session_id = 'sess-B'").all() as Array<{ prompt_batch_id: number }>;
+    expect(sessBActs.every((a) => a.prompt_batch_id === sessBRecovery.id)).toBe(true);
+    const cleanAct = db.prepare("SELECT prompt_batch_id FROM activities WHERE session_id = 'sess-clean'").get() as { prompt_batch_id: number };
+    expect(cleanAct.prompt_batch_id).toBe(cleanBatchId);
+
+    const version = (db.prepare('SELECT MAX(version) AS v FROM schema_version').get() as { v: number }).v;
+    expect(version).toBe(SCHEMA_VERSION);
+    db.close();
+  });
+
+  it('rejects new activity inserts without a non-NULL prompt_batch_id', () => {
+    initDatabase(dbPath);
+    createSchema(getDatabase() as never);
+
+    const db = new Database(dbPath);
+    db.exec(`INSERT INTO sessions (id, agent, started_at, created_at) VALUES ('sess-X', 'claude-code', ${epochSeconds()}, ${epochSeconds()})`);
+    expect(() => {
+      db.exec(`INSERT INTO activities (session_id, tool_name, timestamp, created_at) VALUES ('sess-X', 'Read', ${epochSeconds()}, ${epochSeconds()})`);
+    }).toThrow();
+    db.close();
+  });
+
+  it('is idempotent — re-running createSchema does not create a second recovery batch', () => {
+    const seed = new Database(dbPath);
+    const now = epochSeconds();
+    seed.exec(`INSERT INTO sessions (id, agent, started_at, created_at) VALUES ('sess-idem', 'claude-code', ${now}, ${now})`);
+    seed.exec(`INSERT INTO activities (session_id, tool_name, timestamp, created_at) VALUES ('sess-idem', 'Read', ${now}, ${now})`);
+    seed.close();
+
+    initDatabase(dbPath);
+    createSchema(getDatabase() as never);
+
+    const db1 = new Database(dbPath, { readonly: true });
+    const firstRun = (db1.prepare("SELECT count(*) AS n FROM prompt_batches WHERE kind = 'recovered'").get() as { n: number }).n;
+    db1.close();
+    expect(firstRun).toBe(1);
+
+    createSchema(getDatabase() as never);
+
+    const db2 = new Database(dbPath, { readonly: true });
+    const secondRun = (db2.prepare("SELECT count(*) AS n FROM prompt_batches WHERE kind = 'recovered'").get() as { n: number }).n;
+    db2.close();
+    expect(secondRun).toBe(1);
+  });
+});

--- a/tests/db/queries/activities.test.ts
+++ b/tests/db/queries/activities.test.ts
@@ -5,7 +5,7 @@
  * exercises the query function, and tears down the database.
  */
 
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'bun:test';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'bun:test';
 import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import { insertBatch } from '@myco/db/queries/batches.js';
@@ -46,7 +46,9 @@ function makeBatch(sessionId: string, overrides: Partial<BatchInsert> = {}): Bat
   };
 }
 
-/** Factory for minimal valid activity data. */
+/** Factory for minimal valid activity data. Tests that need a specific
+ *  batch override this; otherwise the surrounding describe binds
+ *  `defaultBatchId` (set in beforeEach) for the activity FK. */
 function makeActivity(
   sessionId: string,
   overrides: Partial<ActivityInsert> = {},
@@ -57,9 +59,15 @@ function makeActivity(
     tool_name: 'Read',
     timestamp: now,
     created_at: now,
+    prompt_batch_id: defaultBatchIdOrNull(),
     ...overrides,
   };
 }
+
+// Lazy lookup so the helper compiles before the describe block runs.
+let _defaultBatchId: number | null = null;
+function setDefaultBatchId(id: number | null) { _defaultBatchId = id; }
+function defaultBatchIdOrNull() { return _defaultBatchId; }
 
 describe('activity query helpers', () => {
   let sessionId: string;
@@ -72,7 +80,13 @@ describe('activity query helpers', () => {
     const session = makeSession();
     upsertSession(session);
     sessionId = session.id;
+
+    // v43 invariant: activities.prompt_batch_id is NOT NULL. Tests that
+    // don't explicitly set a batch_id receive this default via makeActivity().
+    const batch = insertBatch(makeBatch(sessionId));
+    setDefaultBatchId(batch.id);
   });
+  afterEach(() => { setDefaultBatchId(null); });
 
   // ---------------------------------------------------------------------------
   // insertActivity
@@ -131,6 +145,7 @@ describe('activity query helpers', () => {
     it('derives project_id from the session for stateless inserts', () => {
       const scopedSession = makeSession({ id: 'sess-project-a', project_id: 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' });
       upsertSession(scopedSession);
+      insertBatch(makeBatch(scopedSession.id));
 
       const row = insertActivityWithBatch(makeActivity(scopedSession.id));
 

--- a/tests/db/queries/search.test.ts
+++ b/tests/db/queries/search.test.ts
@@ -52,7 +52,9 @@ function makeBatch(sessionId: string, overrides: Partial<BatchInsert> = {}): Bat
   };
 }
 
-/** Factory for minimal valid activity data (requires a session_id). */
+/** Factory for minimal valid activity data (requires a session_id). The
+ *  surrounding describe sets a default batch_id via setDefaultBatchId
+ *  so activities satisfy the v43 NOT NULL FK. */
 function makeActivity(sessionId: string, overrides: Partial<ActivityInsert> = {}): ActivityInsert {
   const now = epochNow();
   return {
@@ -60,9 +62,13 @@ function makeActivity(sessionId: string, overrides: Partial<ActivityInsert> = {}
     tool_name: 'Bash',
     timestamp: now,
     created_at: now,
+    prompt_batch_id: _defaultBatchId,
     ...overrides,
   };
 }
+
+let _defaultBatchId: number | null = null;
+function setDefaultBatchId(id: number | null) { _defaultBatchId = id; }
 
 // ---------------------------------------------------------------------------
 // Test suite
@@ -79,6 +85,10 @@ describe('fullTextSearch', () => {
     const session = makeSession();
     upsertSession(session);
     sessionId = session.id;
+
+    // v43 invariant: activities.prompt_batch_id is NOT NULL.
+    const defaultBatch = insertBatch(makeBatch(sessionId, { prompt_number: 0 }));
+    setDefaultBatchId(defaultBatch.id);
   });
 
   it('finds matching prompt batches by keyword in user_prompt', () => {

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -48,7 +48,7 @@ describe('Database schema', () => {
 
   describe('constants', () => {
     it('exports SCHEMA_VERSION as a positive integer', () => {
-      expect(SCHEMA_VERSION).toBe(42);
+      expect(SCHEMA_VERSION).toBe(43);
       expect(Number.isInteger(SCHEMA_VERSION)).toBe(true);
     });
 
@@ -1554,14 +1554,15 @@ describe('Database schema', () => {
           `INSERT INTO sessions (id, agent, started_at, created_at, content_hash, title)
            VALUES ('sess-a', 'test', 1000, 1000, 'session-hash', 'searchabletitle')`,
         ).run();
-        db.prepare(
+        const batchInsert = db.prepare(
           `INSERT INTO prompt_batches (session_id, user_prompt, created_at, content_hash)
            VALUES ('sess-a', 'searchable prompt', 1000, 'batch-hash')`,
         ).run();
+        const batchId = Number(batchInsert.lastInsertRowid);
         db.prepare(
-          `INSERT INTO activities (session_id, tool_name, timestamp, created_at, content_hash)
-           VALUES ('sess-a', 'Read', 1000, 1000, 'activity-hash')`,
-        ).run();
+          `INSERT INTO activities (session_id, prompt_batch_id, tool_name, timestamp, created_at, content_hash)
+           VALUES ('sess-a', ?, 'Read', 1000, 1000, 'activity-hash')`,
+        ).run(batchId);
         db.prepare(
           `INSERT INTO spores (id, agent_id, observation_type, content, content_hash, created_at)
            VALUES ('spore-a', 'agent-test', 'discovery', 'searchable spore', 'spore-hash', 1000)`,

--- a/tests/integration/capture-pipeline-e2e.test.ts
+++ b/tests/integration/capture-pipeline-e2e.test.ts
@@ -241,3 +241,148 @@ describe('capture pipeline — end-to-end through dispatcher', () => {
     expect(batches.map((b) => b.user_prompt)).toEqual(prompts);
   });
 });
+
+// Mid-session daemon restart with the agent still alive. Asserts that
+// the buffer JSONL is drained at startup, every activity ends up with
+// a non-NULL prompt_batch_id, and synthetic recovery batches carry the
+// 'recovered' kind.
+import { createReconciler } from '@myco/daemon/reconciliation.js';
+
+function makeDispatcherWithRealReconciler(opts: { bufferDir: string; vaultDir?: string }) {
+  const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-capture-e2e-log-'));
+  // Default vaultDir = parent of bufferDir, so the dispatcher's internal
+  // EventBuffer writes to the same directory the reconciler reads from.
+  const vaultDir = opts.vaultDir ?? path.dirname(opts.bufferDir);
+  const logger = new DaemonLogger(logDir, { level: 'warn' });
+  const registry = new SessionRegistry({ gracePeriod: 1, onEmpty: () => {} });
+  const powerManager = new PowerManager({
+    idleThresholdMs: 60_000,
+    sleepThresholdMs: 120_000,
+    deepSleepThresholdMs: 180_000,
+    activeIntervalMs: 60_000,
+    sleepIntervalMs: 60_000,
+    logger,
+  });
+  const sessionBuffers = new Map();
+  const reconciler = createReconciler({ bufferDir: opts.bufferDir, logger: logger as never, projectRoot: process.cwd() });
+
+  const handler = createEventDispatcher({
+    registry,
+    sessionBuffers,
+    powerManager,
+    logger,
+    machineId: 'local',
+    liveConfig: {
+      current: {
+        agent: { summary_batch_interval: 20 },
+        canopy: { exclude: { patterns: [] } },
+      } as never,
+    },
+    vaultDir,
+    reconcileSession: reconciler.reconcileSession,
+    planWatchConfig: { watchDirs: [], projectRoot: vaultDir },
+    triggerTitleSummary: async () => {},
+  });
+
+  return { handler, registry, sessionBuffers, reconciler, vaultDir };
+}
+
+describe('capture pipeline — mid-session restart replay', () => {
+  let tmpBuffer: string;
+
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    // Shared vault root across the two simulated daemons so the dispatcher's
+    // internal EventBuffer writes are visible to the reconciler at restart.
+    // bufferDir is the conventional <vaultRoot>/buffer subdir.
+    const vaultRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-replay-vault-'));
+    fs.mkdirSync(path.join(vaultRoot, 'buffer'), { recursive: true });
+    tmpBuffer = path.join(vaultRoot, 'buffer');
+    (globalThis as Record<string, unknown>).__replayVaultRoot = vaultRoot;
+  });
+
+  it('mid-session daemon restart with no SessionStart re-fire does not lose buffer events or orphan activities', async () => {
+    const sessionId = 'replay-incident-001';
+    const agent = 'claude-code';
+    const vaultRoot = (globalThis as Record<string, unknown>).__replayVaultRoot as string;
+    const bufferPath = path.join(tmpBuffer, `${sessionId}.jsonl`);
+    const appendBuffer = (event: Record<string, unknown>) => {
+      fs.appendFileSync(bufferPath, JSON.stringify(event) + '\n');
+    };
+
+    // ── Phase A: original daemon. Dispatcher's internal EventBuffer
+    //    writes to <vaultRoot>/buffer/, the same dir Phase B's reconciler
+    //    reads — exactly mirroring production layout. ──
+    const a = makeDispatcherWithRealReconciler({ bufferDir: tmpBuffer, vaultDir: vaultRoot });
+    const transcriptPath = '/tmp/fake-transcript.jsonl';
+    await post(a.handler, { type: 'user_prompt', session_id: sessionId, agent, prompt: 'investigate the wedge', transcript_path: transcriptPath });
+    await post(a.handler, { type: 'tool_use', session_id: sessionId, agent, tool_name: 'Read', tool_input: { file_path: '/x.ts' }, transcript_path: transcriptPath });
+    await post(a.handler, { type: 'tool_use', session_id: sessionId, agent, tool_name: 'Bash', tool_input: { command: 'ls' }, transcript_path: transcriptPath });
+
+    // Simulate the wedge — daemon stops responding. Production hooks keep
+    // writing the buffer JSONL even when the POST fails, so events arrive
+    // in the journal but not the DB. Append directly to mirror that.
+    appendBuffer({ type: 'user_prompt', prompt: 'second wedge prompt', timestamp: '2026-05-18T17:42:49.644Z' });
+    appendBuffer({ type: 'tool_use', tool_name: 'Edit', tool_input: { file_path: '/y.ts' }, timestamp: '2026-05-18T17:43:00.000Z' });
+
+    // ── Phase B: daemon restart. New dispatcher, new reconciler. The
+    //    agent is still alive; it does NOT re-register the session. ──
+    const b = makeDispatcherWithRealReconciler({ bufferDir: tmpBuffer, vaultDir: vaultRoot });
+
+    // Startup reconciliation must drain the buffer file and replay the
+    // events the live path missed during the wedge. With the cache-
+    // poisoning fix, this works even though the session row still exists.
+    b.reconciler.runStartupReconciliation();
+
+    // Post-restart, the agent sends a fresh tool_use FOLLOWING the
+    // (wedge-buffered) "second wedge prompt." If everything is intact:
+    //   - the buffered prompt now exists as batch #2
+    //   - the buffered tool_use now exists as activity attached to it
+    //   - the post-restart tool_use also attaches to batch #2 (the open one)
+    await post(b.handler, { type: 'tool_use', session_id: sessionId, agent, tool_name: 'Write', tool_input: { file_path: '/z.ts' }, transcript_path: '/tmp/fake-transcript.jsonl' });
+
+    // ── Assertions ──
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches.length).toBeGreaterThanOrEqual(2);
+    expect(batches[0].user_prompt).toBe('investigate the wedge');
+    expect(batches[1].user_prompt).toBe('second wedge prompt');
+
+    // Crucially: every activity has a non-NULL prompt_batch_id.
+    const activities = listActivities({ session_id: sessionId, scope: ALL_PROJECTS_SCOPE });
+    expect(activities.length).toBeGreaterThanOrEqual(4);
+    for (const a of activities) {
+      expect(a.prompt_batch_id).not.toBeNull();
+    }
+  });
+
+  it('agent-side tool_use arrives with no preceding user_prompt — handler opens an implicit recovery batch instead of orphaning', async () => {
+    const sessionId = 'replay-recovery-001';
+    const agent = 'claude-code';
+    const { handler } = makeDispatcherWithRealReconciler({ bufferDir: tmpBuffer });
+
+    // No user_prompt — directly a tool_use. transcript_path is required
+    // by the auto-registration gate (capture rules); with it set, the
+    // session row gets created and handleToolUse runs. The runtime
+    // defense in handleToolUse opens an implicit recovery batch so the
+    // activity has a parent even when no real prompt has arrived yet.
+    const res = await post(handler, {
+      type: 'tool_use',
+      session_id: sessionId,
+      agent,
+      tool_name: 'Read',
+      tool_input: { file_path: '/a.ts' },
+      transcript_path: '/tmp/fake-transcript.jsonl',
+    });
+    expect(res.body).toMatchObject({ ok: true });
+
+    const allBatches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(allBatches.length).toBeGreaterThanOrEqual(1);
+    const recovered = allBatches.find((b) => b.kind === 'recovered');
+    expect(recovered).toBeDefined();
+    const activities = listActivities({ session_id: sessionId, scope: ALL_PROJECTS_SCOPE });
+    expect(activities.length).toBe(1);
+    expect(activities[0].prompt_batch_id).toBe(recovered!.id);
+  });
+});


### PR DESCRIPTION
## Summary

Closes a class of capture-loss bugs by making the activity → prompt_batch relationship a structural invariant instead of a code convention, and adds per-PowerManager-job timing so the next event-loop wedge can be attributed without a forensic dig.

### Schema (v43)
- `activities.prompt_batch_id` is now **NOT NULL**.
- Migration backfills orphan rows: one synthetic `kind='recovered'` batch per affected session, relinks the orphans, idempotent. On the Myco dogfood Grove this surfaced 67 sessions with orphan activities; all relinked, zero NULL rows remain.

### Runtime
- `reconcileSession` no longer poisons its per-lifetime cache on a bailout. Missing buffer or missing session row returns *without* marking reconciled, so a later call after the preconditions hold can replay.
- Every activity-producing handler (`handleToolUse`, `handleToolFailure`, `handleSubagentStart`, `handleSubagentStop`, `handleStopFailure`, `handleTaskCompleted`, `handleCompact`) routes through a shared `ensureOpenBatch` helper that opens a recovery batch when none is open.
- `handleDeleteSession` clears the reconciler cache and unlinks the session's buffer journal alongside the DB cascade.

### Observability
- `EventLoopLagProbe` exposes `addTickListener` for per-window attribution.
- `PowerManager` wraps every job and emits a `power.job` log entry with `job_name`, `duration_ms`, `event_loop_lag_during_ms`, and `status`. Already useful — first minute of post-rebuild dev daemon caught `scheduled:tasks` pinning the loop for 3.5s.

### UI
- Sessions UI renders `kind='recovered'` batches faded + dashed with the header label "Recovered" so reconstructed turns are visually distinguishable.

## Test plan

- [x] `make check` clean (typecheck + lint + tests).
- [x] `make build` clean (full bundle).
- [x] Full suite: 4907 (node) + 244 (jsdom) = 5151 passing, 0 failing.
- [x] 6 new function-level tests for the new invariants (cache poisoning, buffer cleanup, v43 migration backfill + NOT NULL + idempotency, power.job emission + lag attribution + error case, tick-listener behavior).
- [x] 1 new end-to-end integration test: mid-session daemon restart with the agent still alive, asserts buffer drainage + no orphan activities.
- [x] Existing tests updated where they codified the prior NULL-allowed behavior.
- [x] Live smoke test on dogfood Grove: v43 migration applied, 67 sessions backfilled, daemon boots clean, `power.job` entries emitting with all four expected fields.
- [x] Squash on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)