### PR TITLE
build(runner): runner diagnostics — STARTING / STILL RUNNING / FINISHED on every phase

### DIFF
--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -8,6 +8,30 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+// ---------------------------------------------------------------------------
+// Watchdog diagnostics
+// ---------------------------------------------------------------------------
+// Hangs in CI used to be opaque: the runner emitted a single
+// `=== bun test (label) ===` line at phase start and then sat silent until
+// either the subprocess exited or GitHub Actions killed the job. Recovering
+// "which test was running when it hung" meant scrolling through thousands
+// of log lines, often impossible mid-run.
+//
+// These constants drive a per-phase quiet-line detector. Every `INTERVAL`
+// ms the runner checks how long it's been since the subprocess last wrote
+// a non-empty line. If that quiet window exceeds `QUIET_MS`, the runner
+// emits a structured `[run-bun-tests] STILL RUNNING …` line with the
+// elapsed time AND the last non-empty line the subprocess produced —
+// which is usually the test name Bun was about to or just started running.
+// That single grepable line is enough to identify the hanger without
+// re-reading the full log.
+//
+// Override via env vars to tighten/relax for local debugging:
+//   MYCO_RUNNER_QUIET_MS — quiet threshold before a heartbeat is emitted
+//   MYCO_RUNNER_HEARTBEAT_INTERVAL_MS — how often to check
+const WATCHDOG_QUIET_MS = Number(process.env.MYCO_RUNNER_QUIET_MS ?? 30000);
+const WATCHDOG_INTERVAL_MS = Number(process.env.MYCO_RUNNER_HEARTBEAT_INTERVAL_MS ?? 10000);
+
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 const FAST_EXCLUDES = [
@@ -679,7 +703,7 @@ function resetReportDir() {
   fs.mkdirSync(REPORT_DIR, { recursive: true });
 }
 
-function runPhase(label, extraArgs, bunfig, { isolate }) {
+async function runPhase(label, extraArgs, bunfig, { isolate }) {
   if (extraArgs === null || extraArgs.length === 0) return 0;
   // `BUN_CONFIG_FILE` is not observed by `bun test` for the bunfig; the only
   // reliable way to swap configs is to move the file on disk for the
@@ -709,7 +733,7 @@ function runPhase(label, extraArgs, bunfig, { isolate }) {
       `--reporter-outfile=${reportFile}`,
       ...extraArgs,
     ];
-    const status = runWithTee('bun', args, teeFile);
+    const status = await runWithTeeAndHeartbeat('bun', args, teeFile, label);
     return status;
   } finally {
     if (restored) {
@@ -795,6 +819,101 @@ function runWithTee(command, args, teeFile) {
     env: process.env,
   });
   return result.status ?? 1;
+}
+
+/**
+ * Async variant of `runWithTee` with a quiet-line watchdog. Pipes child
+ * stdout/stderr through Node so we can:
+ *   - tee to the terminal (preserves live progress in CI logs)
+ *   - tee to the per-phase log file (preserves the existing artifact)
+ *   - track the last non-empty line and timestamp
+ *
+ * Every `WATCHDOG_INTERVAL_MS` we check whether the child has produced
+ * output recently. If `WATCHDOG_QUIET_MS` has passed since the last
+ * non-empty line, we emit a heartbeat that includes that last line —
+ * which is usually a Bun test name. This makes hangs grepable: after
+ * the run, `grep STILL RUNNING <log>` points straight at the file/test
+ * that was stuck.
+ *
+ * Behavior is otherwise identical to `runWithTee` — same shell command,
+ * same pipefail handling, same exit-code semantics.
+ */
+async function runWithTeeAndHeartbeat(command, args, teeFile, label) {
+  const escaped = args.map((a) => `'${String(a).replace(/'/g, `'\\''`)}'`).join(' ');
+  const shellCmd = `set -o pipefail; ${command} ${escaped}`;
+  const startMs = Date.now();
+  process.stderr.write(`[run-bun-tests] STARTING ${label}\n`);
+
+  return new Promise((resolve) => {
+    const child = spawn('/bin/bash', ['-c', shellCmd], {
+      cwd: REPO,
+      env: process.env,
+      stdio: ['inherit', 'pipe', 'pipe'],
+    });
+
+    let lastNonEmptyLine = '';
+    let lastOutputMs = Date.now();
+    // Buffer partial lines across chunks so we attribute the last
+    // non-empty line correctly even when chunks arrive mid-line.
+    let stdoutTail = '';
+    let stderrTail = '';
+
+    function ingest(chunk, stream, tailRef) {
+      const text = chunk.toString();
+      // Mirror to terminal verbatim — preserves ANSI/formatting for
+      // anyone watching the live log.
+      stream.write(text);
+      // Mirror to the log file. Sync append: chunks are small, sync
+      // I/O here matches the prior runWithTee behavior (shell tee was
+      // also sync per write).
+      try { fs.appendFileSync(teeFile, text); } catch { /* best-effort */ }
+      // Track the last non-empty line for the watchdog heartbeat.
+      const combined = tailRef.value + text;
+      const lines = combined.split(/\r?\n/);
+      tailRef.value = lines.pop() ?? '';
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed) {
+          lastNonEmptyLine = trimmed;
+          lastOutputMs = Date.now();
+        }
+      }
+    }
+    const stdoutRef = { value: stdoutTail };
+    const stderrRef = { value: stderrTail };
+    child.stdout.on('data', (c) => ingest(c, process.stdout, stdoutRef));
+    child.stderr.on('data', (c) => ingest(c, process.stderr, stderrRef));
+
+    const watchdog = setInterval(() => {
+      const sinceLastOutput = Date.now() - lastOutputMs;
+      if (sinceLastOutput >= WATCHDOG_QUIET_MS) {
+        const totalElapsed = Date.now() - startMs;
+        const msg = `[run-bun-tests] STILL RUNNING ${label} — ${totalElapsed}ms elapsed, ${sinceLastOutput}ms since last output; last line: ${lastNonEmptyLine || '(none)'}\n`;
+        process.stderr.write(msg);
+        try { fs.appendFileSync(teeFile, msg); } catch { /* best-effort */ }
+      }
+    }, WATCHDOG_INTERVAL_MS);
+    // Don't keep the event loop alive purely for the heartbeat — the
+    // child's pipes are the load-bearing references that hold the
+    // process open.
+    watchdog.unref?.();
+
+    child.on('error', (err) => {
+      clearInterval(watchdog);
+      process.stderr.write(`[run-bun-tests] FAILED TO SPAWN ${label}: ${err?.message ?? err}\n`);
+      resolve(1);
+    });
+
+    child.on('close', (code) => {
+      clearInterval(watchdog);
+      const totalMs = Date.now() - startMs;
+      const tail = lastNonEmptyLine ? ` (last line: ${lastNonEmptyLine})` : '';
+      const completion = `[run-bun-tests] FINISHED ${label} in ${totalMs}ms (exit ${code ?? 1})${tail}\n`;
+      process.stderr.write(completion);
+      try { fs.appendFileSync(teeFile, completion); } catch { /* best-effort */ }
+      resolve(code ?? 1);
+    });
+  });
 }
 
 function decodeXmlEntities(input) {
@@ -976,7 +1095,7 @@ resetReportDir();
 
 let nonDomStatus = 0;
 for (const phase of nonDomPhases) {
-  const status = runPhase(phase.label, phase.args, path.join(REPO, 'bunfig.toml'), { isolate: phase.isolate });
+  const status = await runPhase(phase.label, phase.args, path.join(REPO, 'bunfig.toml'), { isolate: phase.isolate });
   nonDomStatus ||= status;
   phaseReports.push({
     label: phase.label,
@@ -988,7 +1107,7 @@ for (const phase of nonDomPhases) {
 let domStatus = 0;
 if (dom !== null) {
   stripDuplicateReact();
-  domStatus = runPhase(
+  domStatus = await runPhase(
     'jsdom',
     dom,
     path.join(REPO, 'bunfig.dom.toml'),


### PR DESCRIPTION
## TL;DR

Stop guessing which test is hanging in CI. The test runner now emits structured `STARTING / STILL RUNNING / FINISHED` markers around every phase, including a `STILL RUNNING <label> — <elapsed>ms; last line: <text>` heartbeat every 10s once a subprocess has been quiet for 30s.

Diagnostics-only. No tests change, no skips added, no timeouts modified. `make build` passes.

This is **PR A** of the CI Test Flake Investigation plan (`bda17b1ae319a9b0` / `docs/superpowers/specs/2026-05-28-ci-test-flake-investigation.md`), which Chris greenlit immediately after PR #380 merged because *"I'm sick of guessing"*.

## Problem

Today when `npm test` hangs in CI, the only visible signal is a `=== bun test (label) ===` line that fired ~10 min earlier. Which specific test file or `it()` is stuck — invisible. `gh run view --log` refuses to stream from in-progress jobs, so the data isn't even retrievable until GitHub Actions kills the job. Net effect: every hang costs ~10–25 min of staring at a stalled GH UI before we can cancel and triage.

PR #380's two consecutive hangs (one before the `instrumented-fetch` fix, one after) were both diagnosed via screenshot-scrolling of frozen test output — exactly the failure mode this PR closes.

## What changes

- New `runWithTeeAndHeartbeat` replaces synchronous `spawnSync` with async `spawn`. Pipes child stdout/stderr through Node so the runner can see every chunk in real time.
- Identical tee behavior to the prior shell-pipefail-then-tee path: same terminal output, same on-disk log artifacts under `target/test-reports/`, same exit-code semantics.
- A `setInterval` heartbeat (every `WATCHDOG_INTERVAL_MS`, default 10s) checks `Date.now() - lastNonEmptyLineMs`. If quiet > `WATCHDOG_QUIET_MS` (default 30s), emits:
  ```
  [run-bun-tests] STILL RUNNING <label> — Nms elapsed, Mms since last output; last line: <text>
  ```
  to stderr AND the per-phase `.log` artifact. The "last line" is typically a Bun-printed test name — so after a hang, one `grep STILL RUNNING` points straight at the stuck test.
- `STARTING <label>` and `FINISHED <label> in Nms (exit C)` markers bracket every phase.
- `runPhase` and the top-level loop are now `async` — top-level await works fine in the ESM script.

Override thresholds via env vars for local debugging:
```
MYCO_RUNNER_QUIET_MS=10000 MYCO_RUNNER_HEARTBEAT_INTERVAL_MS=5000 npm test -- <files>
```

## Validation

- `make build` passes (exit 0).
- Aggressive thresholds force-trigger the heartbeat:
  ```
  $ MYCO_RUNNER_QUIET_MS=100 MYCO_RUNNER_HEARTBEAT_INTERVAL_MS=50 npm test -- tests/utils/instrumented-fetch.test.ts
  [run-bun-tests] STARTING node env
  [run-bun-tests] STILL RUNNING node env — 156ms elapsed, 151ms since last output; last line: bun test v1.3.14 (0d9b296a)
  [run-bun-tests] FINISHED node env in 243ms (exit 0) (last line: Ran 6 tests across 1 file. [236.00ms])
  ```

## Test plan

- [ ] CI green on this PR (the runner change applies to its own CI run — meta-validation).
- [ ] Next PR that hits a hang shows a `STILL RUNNING ... last line: <test name>` line in the log, pointing at the stuck test.
- [ ] Watch for any regression in artifact contents under `target/test-reports/` — should be byte-equivalent to before plus the new bracket markers.

## Follow-ups (later PRs per the plan)

- **PR B** — catalog flake-prone files using these diagnostics across N CI runs against main.
- **PR C(N)** — per logical group, triage: HARDEN (timeout bump for timer-sensitive), REWRITE (`vi.useFakeTimers`), QUARANTINE to nightly-only workflow with auto-issue-file on persistent failure.
- **PR D** — doctrine in a skill, authoring checklist for new integration tests, alerting wiring via the actionable-notifications platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)