### PR TITLE
Route project funding through GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,15 +1,3 @@
-# These are supported funding model platforms
-
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-polar: # Replace with a single Polar username
-buy_me_a_coffee: sirkirby
-thanks_dev: # Replace with a single thanks.dev username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+github: goondocks-co
+custom:
+  - "https://github.com/goondocks-co/myco/blob/main/FUNDING.md"

--- a/FUNDING.md
+++ b/FUNDING.md
@@ -1,0 +1,32 @@
+# Sponsor Myco
+
+Myco is open-source infrastructure for AI-assisted software teams. It captures development sessions, turns them into shared project knowledge, and gives coding agents the context they need to work with the codebase instead of starting cold.
+
+If Myco saves your team time, sponsorship helps keep the project moving.
+
+## What Sponsorship Funds
+
+Sponsorship supports the recurring work needed to keep Myco useful and reliable:
+
+- Maintaining the local service, dashboard, MCP server, and symbiont integrations.
+- Testing Myco against real coding-agent workflows as those agents change.
+- Improving Grove backup, restore, Team Sync, and cloud-agent access.
+- Running AI-assisted development, review, smoke testing, release notes, and documentation work.
+- Keeping the knowledge pipeline current so spores, wisdom, digests, Canopy, and skills continue to evolve with projects.
+
+## Sponsor
+
+GitHub Sponsors is the funding path for Myco:
+
+- [Sponsor Myco through Goondocks](https://github.com/sponsors/goondocks-co?metadata_project=myco)
+
+## Project Boundaries
+
+Sponsorship supports ongoing maintenance, but it does not change Myco's open-source boundaries:
+
+- Myco remains open source.
+- Core features are not paywalled.
+- Sponsors do not bypass review, safety checks, or data-protection expectations.
+- Priorities still follow user impact, project sustainability, and maintainability.
+
+Thank you for helping sustain the project.

--- a/FUNDING.md
+++ b/FUNDING.md
@@ -1,28 +1,35 @@
-# Sponsor Myco
+# Sponsor Myco and Goondocks Open Source
 
-Myco is open-source infrastructure for AI-assisted software teams. It captures development sessions, turns them into shared project knowledge, and gives coding agents the context they need to work with the codebase instead of starting cold.
+Hi, I'm Chris Kirby. Goondocks Consulting is my independent software practice, and it is where I build and maintain open source tools for practical AI-assisted development, developer workflows, infrastructure, and automation.
 
-If Myco saves your team time, sponsorship helps keep the project moving.
+My current focus is Myco, an open source project intelligence system for AI-assisted software teams. Myco helps coding agents and teams preserve the project knowledge that normally lives in human heads: decisions, gotchas, workflows, codebase context, and the tribal knowledge needed to keep real software moving.
+
+I also maintain tools across the UniFi, Home Assistant, and automation ecosystem, including projects that make networks, homelabs, and agent workflows easier to operate safely.
+
+If Myco or another Goondocks project saves your team time, sponsorship helps keep the work moving.
 
 ## What Sponsorship Funds
 
-Sponsorship supports the recurring work needed to keep Myco useful and reliable:
+Sponsorship supports the recurring work needed to keep these projects useful and reliable:
 
 - Maintaining the local service, dashboard, MCP server, and symbiont integrations.
 - Testing Myco against real coding-agent workflows as those agents change.
 - Improving Grove backup, restore, Team Sync, and cloud-agent access.
 - Running AI-assisted development, review, smoke testing, release notes, and documentation work.
+- Testing live integrations across UniFi, Home Assistant, and automation workflows.
 - Keeping the knowledge pipeline current so spores, wisdom, digests, Canopy, and skills continue to evolve with projects.
 
 ## Sponsor
 
-GitHub Sponsors is the funding path for Myco:
+GitHub Sponsors is the funding path for Myco and Goondocks open source:
 
 - [Sponsor Myco through Goondocks](https://github.com/sponsors/goondocks-co?metadata_project=myco)
 
 ## Project Boundaries
 
-Sponsorship supports ongoing maintenance, but it does not change Myco's open-source boundaries:
+Goondocks is a business, but this sponsorship page is not a sales funnel. It is a practical way to support independent open source work if Myco or another Goondocks project saves you time, improves your workflow, or helps your team build better software.
+
+Sponsorship supports ongoing maintenance, but it does not change the open-source boundaries:
 
 - Myco remains open source.
 - Core features are not paywalled.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="https://github.com/goondocks-co/myco/actions/workflows/publish.yml"><img src="https://github.com/goondocks-co/myco/actions/workflows/publish.yml/badge.svg" alt="Release"></a>
   <a href="https://www.npmjs.com/package/@goondocks/myco"><img src="https://img.shields.io/npm/v/@goondocks/myco?label=npm&color=22c55e" alt="npm"></a>
   <a href="https://github.com/goondocks-co/myco/blob/main/LICENSE"><img src="https://img.shields.io/github/license/goondocks-co/myco?color=22c55e" alt="License"></a>
+  <a href="https://github.com/sponsors/goondocks-co"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-22c55e" alt="Sponsor Myco"></a>
   <img src="https://img.shields.io/badge/node-%3E%3D22-22c55e" alt="Node 22+">
   <img src="https://img.shields.io/badge/agents-Claude%20Code%20%7C%20Cursor%20%7C%20Codex%20%7C%20VS%20Code%20%7C%20Antigravity%20%7C%20Windsurf%20%7C%20OpenCode%20%7C%20Pi-22c55e" alt="Claude Code | Cursor | Codex | VS Code | Antigravity | Windsurf | OpenCode | Pi">
 </p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -85,6 +85,7 @@
       <a href="#team">Team sync</a>
       <a href="#agents">Agents</a>
       <a href="#docs">Docs</a>
+      <a href="#sponsor">Sponsor</a>
     </div>
     <div class="nav-right">
       <a class="github-pill" href="https://github.com/goondocks-co/myco" target="_blank" rel="noopener">
@@ -738,6 +739,23 @@
   </div>
 </section>
 
+<!-- =================== SPONSOR =================== -->
+<section class="band sponsor-band" id="sponsor">
+  <div class="wrap">
+    <div class="sponsor-row">
+      <div class="sponsor-copy">
+        <span class="eyebrow">Sponsor</span>
+        <h2 class="sec-title">Support independent <em>agent infrastructure</em>.</h2>
+        <p class="sec-lede">Myco is independent open source from Goondocks Consulting. Sponsorship helps fund maintenance, real workflow testing, documentation, release work, and the intelligence pipeline that keeps project knowledge evolving.</p>
+      </div>
+      <div class="sponsor-actions">
+        <a class="btn btn-primary btn-lg" href="https://github.com/sponsors/goondocks-co?metadata_project=myco" target="_blank" rel="noopener">Sponsor on GitHub<span class="chev">→</span></a>
+        <a class="btn btn-outline btn-lg" href="https://github.com/goondocks-co/myco/blob/main/FUNDING.md" target="_blank" rel="noopener">What funding supports</a>
+      </div>
+    </div>
+  </div>
+</section>
+
 <!-- =================== CTA =================== -->
 <section class="cta-band">
   <div class="cta-band-bg"></div>
@@ -781,6 +799,7 @@
       <div class="footer-col">
         <h5>Community</h5>
         <a href="https://github.com/goondocks-co/myco" target="_blank" rel="noopener">GitHub ↗</a>
+        <a href="https://github.com/sponsors/goondocks-co?metadata_project=myco" target="_blank" rel="noopener">Sponsor</a>
         <a href="https://github.com/goondocks-co/myco/issues" target="_blank" rel="noopener">Issues</a>
         <a href="https://github.com/goondocks-co/myco/blob/main/LICENSE" target="_blank" rel="noopener">Apache 2.0 license</a>
       </div>

--- a/docs/site.css
+++ b/docs/site.css
@@ -1425,6 +1425,34 @@ section.band + section.band { padding-top: 0; }
 .doc-card:hover .go::after { transform: translateX(3px); }
 
 /* ----------------------------------------------------------------------------
+   Sponsor band
+   ---------------------------------------------------------------------------- */
+
+.sponsor-band {
+  padding: 72px 0;
+  border-top: 1px solid var(--outline-variant);
+}
+.sponsor-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 48px;
+}
+.sponsor-copy .sec-title {
+  margin-top: 16px;
+  font-size: 36px;
+}
+.sponsor-copy .sec-lede {
+  max-width: 720px;
+}
+.sponsor-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+/* ----------------------------------------------------------------------------
    CTA band
    ---------------------------------------------------------------------------- */
 
@@ -1627,6 +1655,8 @@ section.band + section.band { padding-top: 0; }
   .lifecycle-line { display: none; }
   .lifecycle-payoff { grid-template-columns: 1fr; }
   .docs-grid { grid-template-columns: repeat(2, 1fr); }
+  .sponsor-row { grid-template-columns: 1fr; align-items: start; }
+  .sponsor-actions { justify-content: flex-start; }
   .agents-grid { grid-template-columns: repeat(3, 1fr); }
   .features { grid-template-columns: 1fr; }
 }


### PR DESCRIPTION
## Summary
- Replace the Buy Me a Coffee funding entry with GitHub Sponsors for `goondocks-co`.
- Add a repo-local `FUNDING.md` explaining what Myco and Goondocks open-source sponsorship supports.
- Add a GitHub Sponsors badge to the README.
- Add a restrained Sponsor path to the docs site: nav link, bottom-page sponsor section, and footer link.

## Validation
- `git diff --check`
- Parsed `.github/FUNDING.yml` with Ruby YAML and verified the GitHub Sponsors and custom funding targets.
- Parsed `docs/index.html` with Python `HTMLParser`.
- Smoked `docs/index.html#sponsor` through the Codex browser against a local static server.
- Confirmed no Buy Me a Coffee funding entry remains.
