### PR TITLE
fix(capture): converge response attribution at turn boundaries

### DIFF
--- a/packages/myco/src/daemon/api/session-lifecycle.ts
+++ b/packages/myco/src/daemon/api/session-lifecycle.ts
@@ -20,7 +20,7 @@ import type { EventBuffer } from '@myco/capture/buffer.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import { loadMergedConfig } from '@myco/config/loader.js';
 import { cleanStaleBuffers } from '@myco/capture/buffer.js';
-import { closeSession, updateSession } from '@myco/db/queries/sessions.js';
+import { closeSession, updateSession, getSession } from '@myco/db/queries/sessions.js';
 import { ensureSession, ENSURE_SESSION_SOURCE } from '../session-lifecycle.js';
 import { notify } from '@myco/notifications/notify.js';
 import { epochSeconds, STALE_BUFFER_MAX_AGE_MS } from '@myco/constants.js';
@@ -28,7 +28,7 @@ import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { projectScopeFromRequestContext, rowProjectIdFromRequestContext } from '@myco/tools/request-context.js';
 import { errorMessage } from '@myco/utils/error-message.js';
 import type { CanopyJobsRegistry } from '../jobs/canopy-scan.js';
-import { assertGroveProjectId, isGroveEraId } from '@myco/grove/ids.js';
+import { assertGroveProjectId, isGroveEraId, ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
 import type { ProjectPowerStateTracker } from '../project-power-state.js';
 import { deferGitProvenance } from '@myco/release-provenance/capture.js';
 import { primaryProductionRef } from '@myco/release-provenance/config.js';
@@ -55,6 +55,15 @@ export interface SessionLifecycleDeps {
   sessionBuffers: Map<string, EventBuffer>;
   reconciler: { reconcileSession: (sessionId: string) => void; clearSession: (sessionId: string) => void };
   stopProcessor: { clearSession: (sessionId: string) => void };
+  /**
+   * The authoritative "converge DB to transcript" operation, shared with the
+   * Stop and live-reconcile paths. Run at SessionEnd so the FINAL turn's
+   * response is attributed even when that turn produced no trailing tool event
+   * and fired no clean per-turn Stop (interrupt + /exit, force-quit). Without
+   * this, a response sitting complete in the transcript is never lifted into
+   * `response_summary` — the steering/final-summary capture gap.
+   */
+  transcriptMiner: { reconcileAndAttributeResponses: (sessionId: string, input: { agent: string; transcriptPath: string }) => unknown };
   server: DaemonServer;
   powerManager: PowerManager;
   machineId: string;
@@ -92,6 +101,7 @@ export function createSessionLifecycleHandlers(deps: SessionLifecycleDeps) {
     sessionBuffers,
     reconciler,
     stopProcessor,
+    transcriptMiner,
     server,
     powerManager,
     machineId,
@@ -248,6 +258,29 @@ export function createSessionLifecycleHandlers(deps: SessionLifecycleDeps) {
     // We do NOT delete THIS session's buffer — session reload reuses the same ID.
     const bufferDir = `${vaultDir}/buffer`;
     cleanStaleBuffers(bufferDir, STALE_BUFFER_MAX_AGE_MS, session_id);
+
+    // Final convergence at the authoritative turn boundary. The per-turn Stop
+    // hook converges each COMPLETED turn, but a turn interrupted mid-response
+    // (the user steers/aborts, then the session ends) fires no clean Stop — so
+    // its response, though already complete in the transcript, was never
+    // attributed. SessionEnd is the last boundary at which we can lift it.
+    // Best-effort and idempotent: re-running over an already-attributed
+    // transcript is a no-op. Runs BEFORE closeSession so the converged rows are
+    // in place when the session is marked ended.
+    try {
+      const ending = getSession(session_id, ALL_PROJECTS_SCOPE);
+      if (ending?.agent && ending.transcript_path) {
+        transcriptMiner.reconcileAndAttributeResponses(session_id, {
+          agent: ending.agent,
+          transcriptPath: ending.transcript_path,
+        });
+      }
+    } catch (err) {
+      logger.warn(LOG_KINDS.LIFECYCLE_UNREGISTER, 'SessionEnd transcript convergence failed', {
+        session_id, error: errorMessage(err),
+      });
+    }
+
     // Close the session in SQLite — this is the authoritative end-of-session.
     // The Stop hook fires per-turn and does NOT close the session.
     closeSession(session_id, epochSeconds());

--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -508,6 +508,19 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
         // Boundary policy (origin filter + N-th human-batch crossing) lives
         // inside the trigger; the dispatcher just hands it the event's origin.
         triggerTitleSummary(event.session_id, { evaluateBoundary: true, promptOrigin });
+
+        // A new human prompt is a turn boundary: the PRIOR turn definitively
+        // ended, and its response is now complete in the transcript. Converge
+        // it here so a turn whose tail was text-only (a final summary with no
+        // trailing tool call — e.g. after a steering prompt) is attributed
+        // without waiting for a tool event that never comes. Tool events remain
+        // a mid-turn liveness optimization, not the correctness mechanism. Same
+        // throttled unit of work the tool path uses; deferred off the hot path.
+        if (liveReconcile && typeof event.transcript_path === 'string' && event.transcript_path) {
+          const reconcileAgent = typeof event.agent === 'string' ? event.agent : DEFAULT_SYMBIONT_NAME;
+          const reconcileTranscript = event.transcript_path;
+          setTimeout(() => liveReconcile(event.session_id, reconcileAgent, reconcileTranscript), 0);
+        }
       } catch (err) {
         logger.warn(LOG_KINDS.CAPTURE_BATCH, 'Failed to open batch', { session_id: event.session_id, error: (err as Error).message });
       }

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -1161,7 +1161,7 @@ export async function main(): Promise<void> {
   // The deps object is mutated after registerPowerJobs so the canopy delta
   // runner becomes visible to SessionStart triggers.
   const sessionLifecycleDeps = {
-    registry, sessionBuffers, reconciler, stopProcessor,
+    registry, sessionBuffers, reconciler, stopProcessor, transcriptMiner,
     server, powerManager, machineId, logger, liveConfig, vaultDir: bootstrapVaultDir,
     projectStateTracker,
   };

--- a/tests/daemon/event-dispatch.test.ts
+++ b/tests/daemon/event-dispatch.test.ts
@@ -15,7 +15,7 @@ import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
 import { listGitProvenance } from '@myco/db/queries/release-provenance.js';
 
 import { TEST_REQUEST_CONTEXT } from '../helpers/request-context';
-function makeHandler() {
+function makeHandler(opts: { liveReconcile?: (sessionId: string, agent: string, transcriptPath: string) => void } = {}) {
   const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-event-dispatch-'));
   const logger = new DaemonLogger(logDir, { level: 'debug' });
   const registry = new SessionRegistry({ gracePeriod: 1, onEmpty: () => {} });
@@ -44,6 +44,7 @@ function makeHandler() {
     reconcileSession: () => {},
     planWatchConfig: { watchDirs: [], projectRoot: vaultDir },
     triggerTitleSummary: async () => {},
+    liveReconcile: opts.liveReconcile,
   });
 
   return { handler, registry, sessionBuffers, logger, vaultDir };
@@ -172,6 +173,31 @@ describe('createEventDispatcher', () => {
     expect(plans[0].prompt_batch_id).toBe(batches[0].id);
     expect(plans[0].source_path).toBe('transcript:ultraplan');
     expect(plans[0].content).toContain('Add dry-run harness');
+
+    logger.close();
+    fs.rmSync(vaultDir, { recursive: true, force: true });
+    fs.rmSync(transcriptDir, { recursive: true, force: true });
+  });
+
+  it('converges the prior turn on the next-prompt boundary (liveReconcile fires on user_prompt)', async () => {
+    const calls: Array<{ sessionId: string; agent: string; transcriptPath: string }> = [];
+    const { handler, logger, vaultDir } = makeHandler({
+      liveReconcile: (sessionId, agent, transcriptPath) => calls.push({ sessionId, agent, transcriptPath }),
+    });
+    const sessionId = 'claude-next-prompt-boundary-001';
+    const transcriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-next-prompt-'));
+    const transcriptPath = path.join(transcriptDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(transcriptPath, '');
+
+    await handler({
+      requestContext: TEST_REQUEST_CONTEXT,
+      body: { type: 'user_prompt', session_id: sessionId, agent: 'claude-code', transcript_path: transcriptPath, prompt: 'next prompt' },
+      query: {}, params: {}, pathname: '/events',
+    });
+
+    // The trigger is deferred off the hot path with setTimeout(0); flush it.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(calls).toEqual([{ sessionId, agent: 'claude-code', transcriptPath }]);
 
     logger.close();
     fs.rmSync(vaultDir, { recursive: true, force: true });

--- a/tests/daemon/session-lifecycle-convergence.test.ts
+++ b/tests/daemon/session-lifecycle-convergence.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { vi } from '../helpers/vi-shim.js';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
+import { createSessionLifecycleHandlers } from '@myco/daemon/api/session-lifecycle.js';
+import { SessionRegistry } from '@myco/daemon/lifecycle.js';
+import { upsertSession, getSession } from '@myco/db/queries/sessions.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+
+const nowSec = () => Math.floor(Date.now() / 1000);
+
+function makeHandlers(vaultDir: string, miner: { reconcileAndAttributeResponses: ReturnType<typeof vi.fn> }) {
+  return createSessionLifecycleHandlers({
+    registry: new SessionRegistry({ gracePeriod: 1, onEmpty: () => {} }),
+    sessionBuffers: new Map(),
+    reconciler: { reconcileSession: vi.fn(), clearSession: vi.fn() },
+    stopProcessor: { clearSession: vi.fn() },
+    transcriptMiner: miner,
+    server: { updateDaemonJsonSessions: vi.fn() },
+    powerManager: { recordActivity: vi.fn() },
+    machineId: 'test-machine',
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    liveConfig: { current: { agent: { event_tasks_enabled: false }, notifications: { enabled: false } } },
+    vaultDir,
+  } as never);
+}
+
+function req(session_id: string) {
+  return { body: { session_id }, requestContext: undefined } as never;
+}
+
+describe('SessionEnd transcript convergence (handleUnregister)', () => {
+  let vaultDir: string;
+  beforeAll(() => setupTestDb());
+  afterAll(() => teardownTestDb());
+  beforeEach(() => {
+    cleanTestDb();
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-session-end-'));
+  });
+
+  it('runs the authoritative convergence with the session agent + transcript_path on session end', async () => {
+    const transcriptPath = path.join(vaultDir, 'transcript.jsonl');
+    fs.writeFileSync(transcriptPath, '');
+    upsertSession({
+      id: 'sess-end-1',
+      agent: 'claude-code',
+      status: 'active',
+      started_at: nowSec(),
+      created_at: nowSec(),
+      transcript_path: transcriptPath,
+    });
+    const reconcile = vi.fn();
+    const { handleUnregister } = makeHandlers(vaultDir, { reconcileAndAttributeResponses: reconcile });
+
+    await handleUnregister(req('sess-end-1'));
+
+    // The final turn's response must be attributed at the session boundary —
+    // even when no trailing tool event / clean per-turn Stop occurred.
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(reconcile).toHaveBeenCalledWith('sess-end-1', {
+      agent: 'claude-code',
+      transcriptPath,
+    });
+    // Convergence runs BEFORE the session is closed.
+    const session = getSession('sess-end-1', ALL_PROJECTS_SCOPE)!;
+    expect(session.status).toBe('completed');
+  });
+
+  it('skips convergence when the session never recorded a transcript_path', async () => {
+    upsertSession({
+      id: 'sess-end-2',
+      agent: 'claude-code',
+      status: 'active',
+      started_at: nowSec(),
+      created_at: nowSec(),
+    });
+    const reconcile = vi.fn();
+    const { handleUnregister } = makeHandlers(vaultDir, { reconcileAndAttributeResponses: reconcile });
+
+    await handleUnregister(req('sess-end-2'));
+
+    expect(reconcile).not.toHaveBeenCalled();
+    expect(getSession('sess-end-2', ALL_PROJECTS_SCOPE)!.status).toBe('completed');
+  });
+
+  it('still closes the session when convergence throws (best-effort)', async () => {
+    const transcriptPath = path.join(vaultDir, 't2.jsonl');
+    fs.writeFileSync(transcriptPath, '');
+    upsertSession({
+      id: 'sess-end-3', agent: 'claude-code', status: 'active',
+      started_at: nowSec(), created_at: nowSec(), transcript_path: transcriptPath,
+    });
+    const reconcile = vi.fn(() => { throw new Error('boom'); });
+    const { handleUnregister } = makeHandlers(vaultDir, { reconcileAndAttributeResponses: reconcile });
+
+    await handleUnregister(req('sess-end-3'));
+
+    expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(getSession('sess-end-3', ALL_PROJECTS_SCOPE)!.status).toBe('completed');
+  });
+});


### PR DESCRIPTION
## The bug

After a steering prompt, the steering batch's `response_summary` often stayed empty during the turn — and in cases where the turn ended without a clean Stop (interrupt + `/exit`, force-quit), it was **permanently NULL** even though the response sat complete in the transcript. Reported as "no more in-stream responses are captured nor the final AI summary" after steering.

(The scary all-time "~66% of steering batches empty" number is dominated by **legacy pre-#384 data** — system task-notifications captured as `steering` before origin classification existed. Post-#384 steering attribution is ~90–100% at the per-turn Stop. This PR closes the residual gap.)

## Root cause — the pattern flaw

The transcript is the source of truth and already holds the complete response; `prompt_batches.response_summary` is a **projection** of it. But the projection was only refreshed on **incidental proxy events**:

- a `tool_use` firing (throttled live reconcile — `event-dispatch.ts`)
- a clean per-turn `Stop` (`stop-processing.ts`)

Those proxies usually coincide with "a response was produced" but are not that fact. When a response tail isn't followed by a proxy — a **text-only final summary** (no trailing tool call) or an **unclean exit** — the projection silently, sometimes permanently, lags a source that already has the data. Capture was *push-on-incidental-event* when it must be *converge-to-source*.

Diagnosis was confirmed empirically: the parser extracts the steering response correctly, `populateBatchResponses` attributes it correctly (the batch `matched=true`), yet the DB was NULL — and re-running the convergence op filled it instantly. **The attributor was always correct; it just never ran on the final transcript.**

## The fix — converge at every turn boundary

The authoritative converge-to-transcript op (`TranscriptMiner.reconcileAndAttributeResponses`) already existed and was correct. This PR invokes it on the two **missing** turn boundaries:

| Boundary | Before | After |
|---|---|---|
| tool events (mid-turn) | reconciled | unchanged — now *liveness only* |
| per-turn Stop | reconciled | unchanged |
| **next human prompt** (`user_prompt`) | nothing | **converges the prior turn** |
| **session end** (`handleUnregister`) | closed, no attribution | **converges before close** — keystone |

Tool-event reconcile is no longer load-bearing for correctness.

## Files

- `daemon/api/session-lifecycle.ts` — SessionEnd convergence before `closeSession` (threads `transcriptMiner`, best-effort, idempotent).
- `daemon/event-dispatch.ts` — next-prompt boundary triggers the same throttled `liveReconcile`.
- `daemon/main.ts` — wires `transcriptMiner` into the session-lifecycle deps.

## Verification

- Typecheck clean; **full canonical suite green** (56 groups, exit 0).
- New tests: `tests/daemon/session-lifecycle-convergence.test.ts` (SessionEnd convergence wiring + guards), plus a next-prompt-boundary case in `tests/daemon/event-dispatch.test.ts`.
- **Live-verified** on the dogfood daemon: a steering turn with a text-only tail, absent from the DB until `/sessions/unregister`, was created and attributed (`kind=steering`, response filled) by the SessionEnd convergence — the only event between absent and attributed.

## Follow-ups (intentionally not in this PR)

1. **Hard-kill backstop**: `reEnrichSessionFromTranscript` still fills only the last batch positionally; switch it to `populateBatchResponses` so sessions that never fire SessionEnd (SIGKILL) fully converge on the next daemon-startup reconcile. (Touches the "does not overwrite existing response_summary" contract.)
2. **Interrupt-marker completeness**: Claude Code emits both `[Request interrupted by user for tool use]` and the bare `[Request interrupted by user]`; only the long form is recognized, so the bare variant becomes a junk `steering` batch. (Manifest regen required.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)