### PR TITLE
fix(ui): render steering-turn responses in the session view

### DIFF
--- a/packages/myco/ui/src/components/sessions/SteeringChildCard.tsx
+++ b/packages/myco/ui/src/components/sessions/SteeringChildCard.tsx
@@ -1,4 +1,6 @@
+import { Bot } from 'lucide-react';
 import type { BatchRow } from '../../hooks/use-sessions';
+import { MarkdownContent } from '../ui/markdown-content';
 import { ActivityList } from './ActivityList';
 import { formatTimestamp } from './batch-timeline-helpers';
 
@@ -31,6 +33,17 @@ export function SteeringChildCard({ child }: SteeringChildCardProps) {
       </p>
       {child.activity_count > 0 && (
         <ActivityList batchId={child.id} activityCount={child.activity_count} />
+      )}
+      {child.response_summary && (
+        <div className="mt-3">
+          <div className="flex items-center gap-1.5 mb-1.5">
+            <Bot className="h-3 w-3 text-primary/60" />
+            <span className="font-sans text-[10px] font-medium uppercase tracking-widest text-on-surface-variant">
+              Response
+            </span>
+          </div>
+          <MarkdownContent content={child.response_summary} />
+        </div>
       )}
     </div>
   );

--- a/tests/ui/steering-child-card.test.tsx
+++ b/tests/ui/steering-child-card.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { SteeringChildCard } from '../../packages/myco/ui/src/components/sessions/SteeringChildCard';
+import type { BatchRow } from '../../packages/myco/ui/src/hooks/use-sessions';
+
+function makeChild(overrides: Partial<BatchRow> = {}): BatchRow {
+  return {
+    id: 3,
+    session_id: 'sess-test',
+    prompt_number: 3,
+    user_prompt: 'i can already see one issue',
+    response_summary: null,
+    classification: null,
+    started_at: 1780326031,
+    ended_at: 1780326527,
+    status: 'completed',
+    activity_count: 0, // 0 → ActivityList (which fetches) is not rendered
+    processed: 1,
+    content_hash: null,
+    created_at: 1780326031,
+    parent_prompt_batch_id: 2,
+    kind: 'steering',
+    origin: 'human',
+    ...overrides,
+  };
+}
+
+describe('SteeringChildCard', () => {
+  it('renders the steering prompt', () => {
+    render(<SteeringChildCard child={makeChild()} />);
+    expect(screen.getByText('i can already see one issue')).toBeDefined();
+  });
+
+  it('renders the steering turn response when captured', () => {
+    render(<SteeringChildCard child={makeChild({ response_summary: 'I can see it clearly in your screenshot' })} />);
+    expect(screen.getByText('Response')).toBeDefined();
+    expect(screen.getByText(/I can see it clearly in your screenshot/)).toBeDefined();
+  });
+
+  it('omits the Response block when the child has no response', () => {
+    render(<SteeringChildCard child={makeChild({ response_summary: null })} />);
+    expect(screen.queryByText('Response')).toBeNull();
+  });
+});


### PR DESCRIPTION
Second of the two PRs (rebased on #391). Fixes the reported "responses stop being captured after I steer."

## Root cause: display, not capture

`SteeringChildCard` rendered the steering prompt and its tool calls but had **no element for `response_summary`** — so a steering turn's response, though fully captured, never displayed. The parent `PromptBatchCard` shows only the parent's response, so a steering turn read as "responses stopped after I interjected." Yesterday's #390 (capture-pipeline convergence) couldn't touch this — wrong layer.

Capture was provably complete: for the live repro, the transcript's 16 assistant text blocks (11,882 chars) in the steering window all landed in the DB (batch 2 = 1,153 + batch 3 = 10,757 = 11,910 chars).

## Change

- `SteeringChildCard` now renders a Response block (mirroring the parent's: Bot icon + "Response" label + `MarkdownContent`) when `child.response_summary` is present.
- jsdom regression test (`tests/ui/steering-child-card.test.tsx`): response shown when present, omitted when absent, prompt always shown.

Display-only; capture pipeline untouched. UI build clean, jsdom + full suite green.

Spore: `bug_fix-13a639fc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)