### PR TITLE
Fix/cli launch context tenancy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ Myco captures project memory in a local vault and serves it back through context
 ## Non-Negotiable Rules
 
 - Think before coding. Surface assumptions and ambiguities instead of guessing.
+- Verify before asserting state. Before claiming which project/grove/daemon/database something belongs to — or that two of them share state — run the command that proves it and report only what the output shows. A URL slug, an injected memory, or a helper run in isolation is a hypothesis, not proof; label it as such until checked.
+- Never build a claim on an unverified claim. If a step was a guess, verify it before it becomes the premise for the next conclusion.
 - Prefer extending existing patterns over one-off patches.
 - Prefer established architectural patterns like Vertical Slice Architecture, CLEAN architecture, CQRS, Dependency Injection, etc. when they are appropriate.
 - Keep code DRY. Extract helpers or shared patterns when they remove real duplication.

--- a/packages/myco/src/cli/search.ts
+++ b/packages/myco/src/cli/search.ts
@@ -45,7 +45,12 @@ export async function run(args: string[], vaultDir: string): Promise<void> {
 
   const cleanup = await initVaultDb(vaultDir);
   try {
-    const requestContext = requestContextFromEnvironment(process.env, vaultDir);
+    // Launch-context tenancy (see cli/tool.ts): resolve THIS project's caller
+    // scope from the cwd-derived vault. Without it a Grove-bound project
+    // resolves to GLOBAL_SCOPE and silently returns only NULL-project rows.
+    const requestContext = requestContextFromEnvironment(process.env, vaultDir, {
+      launchContextTenancy: true,
+    });
     const scope = projectScopeFromRequestContext(requestContext);
     const results = fullTextSearch(query, { limit: CLI_SEARCH_LIMIT, scope });
 

--- a/packages/myco/src/cli/tool.ts
+++ b/packages/myco/src/cli/tool.ts
@@ -55,7 +55,14 @@ export async function run(args: string[], vaultDir: string): Promise<void> {
     try {
       const input = parseInput(parsed.input ?? '{}');
       const { createMycoTools } = await import('@myco/tools/index.js');
-      const requestContext = requestContextFromEnvironment(process.env, vaultDir);
+      // Launch-context tenancy: `vaultDir` was resolved by walking up from the
+      // caller's cwd to this project's `.myco`, so a registered Grove-bound
+      // manifest here is the caller asserting THIS project — accepted by the
+      // tenancy guard without any env from the agent or user. Falls back to
+      // 'synthesized' (→ rejected) for an unregistered/unbound launch context.
+      const requestContext = requestContextFromEnvironment(process.env, vaultDir, {
+        launchContextTenancy: true,
+      });
       const tools = createMycoTools(vaultDir, new DaemonClient(vaultDir), { requestContext });
       const result = await tools.callTool(tool, input);
       await writeEnvelope({ ok: true, tool, result });

--- a/packages/myco/src/grove/request-context.ts
+++ b/packages/myco/src/grove/request-context.ts
@@ -416,9 +416,38 @@ function timingSafeStringEqual(a: string, b: string): boolean {
   return mismatch === 0;
 }
 
+export interface EnvRequestContextOptions {
+  /**
+   * Treat a REGISTRY-VALIDATED manifest resolved from `fallbackVaultDir` as
+   * caller-determined tenancy (`tenancySource: 'caller'`) instead of the
+   * default `'synthesized'`, when the environment carries no explicit
+   * project/grove identity.
+   *
+   * Set this ONLY from launch-context entry points whose `fallbackVaultDir` is
+   * the caller's OWN cwd-resolved project vault — the `myco` CLI tool runtime
+   * and direct-DB CLI reads, which resolve the vault by walking up from
+   * `process.cwd()` to the git/`.myco` root. Running `myco` inside a
+   * registered, Grove-bound project IS the caller asserting "act on THIS
+   * project" — the same assertion `tenancySourceFromExplicit` already honors
+   * for a caller-supplied projectRoot/projectId/groveId. The agent and the user
+   * supply nothing; the launch directory is the signal.
+   *
+   * It is NOT a synthesis from the daemon's bootstrap-anchor vault: resolution
+   * still runs through `findRegisteredProject` (a Grove-registry lookup), so an
+   * unregistered or unbound launch context resolves nothing and stays the
+   * `'synthesized'` fallback (→ rejected by the tenancy guard). The anchor can
+   * never masquerade as caller tenancy.
+   *
+   * The daemon's bootstrap-anchor path derivation (`resolveDaemonDataPaths`)
+   * MUST NOT set this — it passes the anchor vault and consumes only paths.
+   */
+  launchContextTenancy?: boolean;
+}
+
 export function requestContextFromEnvironment(
   env: Record<string, string | undefined>,
   fallbackVaultDir: string,
+  options: EnvRequestContextOptions = {},
 ): MycoRequestContext {
   const machineId = readEnv(env, REQUEST_CONTEXT_ENV.machineId);
   const sessionId = readEnv(env, REQUEST_CONTEXT_ENV.sessionId);
@@ -431,7 +460,8 @@ export function requestContextFromEnvironment(
   ].some((key) => readEnv(env, key) !== undefined);
 
   if (!hasExplicitProjectContext) {
-    return resolveManifestRequestContext(fallback, 'explicit', manifest) ?? fallback;
+    const manifestTenancy: TenancySource = options.launchContextTenancy ? 'caller' : 'synthesized';
+    return resolveManifestRequestContext(fallback, 'explicit', manifest, manifestTenancy) ?? fallback;
   }
 
   const explicit: ExplicitContextInput = {
@@ -630,6 +660,16 @@ function resolveManifestRequestContext(
   fallback: MycoRequestContext,
   source: RequestContextSource,
   cachedManifest?: ProjectManifest | null,
+  // Provenance to stamp on a successfully registry-validated manifest
+  // resolution. Defaults to 'synthesized': for the daemon's no-header /
+  // bootstrap-anchor fallback paths, a manifest resolved from the SERVER's
+  // own vault is the daemon's assertion, not the caller's. Launch-context
+  // entry points (the `myco` CLI, which resolves its vault by walking up from
+  // the caller's cwd) pass 'caller' so a project the caller is physically
+  // inside is honored as caller-supplied tenancy. Resolution still runs through
+  // `findRegisteredProject` either way, so an unregistered/unbound vault never
+  // reaches this stamp — the anchor cannot masquerade as caller tenancy.
+  tenancySource: TenancySource = 'synthesized',
 ): MycoRequestContext | null {
   const manifest = cachedManifest ?? readManifest(fallback.projectVaultDir);
   if (!manifest?.grove?.binding_id) return null;
@@ -642,9 +682,7 @@ function resolveManifestRequestContext(
   return buildRegisteredRequestContext({
     fallback,
     source,
-    // Resolved from the daemon's anchor-vault manifest, not from
-    // caller-supplied project/grove identity — tenancy stays synthesized.
-    tenancySource: 'synthesized',
+    tenancySource,
     projectRoot: registered.project.root,
     projectId: assertGroveProjectId(registered.project.project_id),
     groveId: registered.grove.id,

--- a/tests/tools/request-context.test.ts
+++ b/tests/tools/request-context.test.ts
@@ -574,6 +574,51 @@ describe('tool request context', () => {
       });
     });
 
+    // Launch-context tenancy: a `myco` CLI invocation resolves its vault by
+    // walking up from cwd to the project's `.myco`. When that vault is a
+    // REGISTERED, Grove-bound project, the launch context IS the caller
+    // asserting "act on THIS project" — opted-in callers (cli/tool, cli/search)
+    // get 'caller', so the in-process tenancy guard accepts the call without
+    // the agent or the user supplying any env. This is NOT anchor synthesis:
+    // resolution still validates against the Grove registry.
+    it('tags env context as caller from a registered launch context when opted in (no explicit env)', () => {
+      withRegisteredProject(({ vaultDir, groveId, projectId }) => {
+        const resolved = requestContextFromEnvironment({}, vaultDir, { launchContextTenancy: true });
+
+        expect(resolved.projectId).toBe(projectId);
+        expect(resolved.groveId).toBe(groveId);
+        expect(resolved.tenancySource).toBe('caller');
+      });
+    });
+
+    // The anti-anchor guarantee: opting in does NOT let an unregistered /
+    // unbound launch context (or the daemon's bootstrap anchor) masquerade as
+    // caller tenancy. With no registry row + no Grove binding, the manifest
+    // resolves nothing and the context stays the 'synthesized' fallback —
+    // which the tenancy guard then rejects.
+    it('stays synthesized for launch-context opt-in when the project is NOT registered (no anchor masquerade)', () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-unregistered-launch-'));
+      const previousHome = process.env.MYCO_HOME;
+      try {
+        process.env.MYCO_HOME = path.join(tmp, 'home');
+        const vaultDir = path.join(tmp, 'project', '.myco');
+        fs.mkdirSync(vaultDir, { recursive: true });
+        // A project id but NO Grove binding and NO registry row.
+        saveProjectManifest(vaultDir, {
+          project: { id: assertGroveProjectId(createProjectId()), name: 'Unregistered' },
+        });
+
+        const resolved = requestContextFromEnvironment({}, vaultDir, { launchContextTenancy: true });
+
+        expect(resolved.groveId).toBeNull();
+        expect(resolved.tenancySource).toBe('synthesized');
+      } finally {
+        if (previousHome === undefined) delete process.env.MYCO_HOME;
+        else process.env.MYCO_HOME = previousHome;
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
     it('survives transport: a caller context re-parsed from its headers stays caller', () => {
       withRegisteredProject(({ projectRoot, vaultDir, groveId, projectId }) => {
         const explicit = resolveLegacyRequestContext(vaultDir, {


### PR DESCRIPTION
The multi-tenant guard requireCallerTenancy (PR #420/#421) rejects any
in-process tool call whose tenancySource is not 'caller'. The `myco tool
call` and `myco search` CLI paths build their context via
requestContextFromEnvironment, which — with no MYCO_PROJECT_ID/MYCO_GROVE_ID
in the environment — resolved the local project manifest but hardcoded
tenancySource 'synthesized', so the guard rejected it. Symbionts that fell
back to the CLI got legacy_vault and gave up; `myco search` silently scoped
to GLOBAL and returned wrong results for Grove-bound projects.

Add opt-in EnvRequestContextOptions.launchContextTenancy and thread a
tenancySource parameter into resolveManifestRequestContext (default
'synthesized'). When the vault is resolved from the caller's own cwd
(resolveVaultDir's git-root walk) AND validates against the Grove registry,
stamp 'caller' — the launch directory is the caller asserting "act on THIS
project", with nothing required from the agent or user.

This is not anchor synthesis: resolution still runs through
findRegisteredProject, so an unregistered or unbound launch context resolves
nothing and stays 'synthesized' (rejected). The bootstrap anchor can never
masquerade as caller tenancy. cli/tool.ts and cli/search.ts opt in; the
daemon's bootstrap-anchor path derivation (resolveDaemonDataPaths) does not.
The served_by daemon boundary is untouched.

Verified: bare `myco tool call myco_cortex {op:canopy_map}` from the project
root and from a deep subdirectory both succeed with no env; from /tmp it
still rejects. Full suite green; tests/meta/no-anchor-as-tenancy.test.ts and
tests/tools/caller-tenancy.test.ts stay green.

## Summary

This pull request improves how project tenancy is determined and tagged in Myco CLI tools, ensuring that when a CLI command is launched from within a registered project, the system reliably recognizes and honors the caller's project context. This prevents accidental fallback to global or synthesized tenancy, reducing silent errors and improving security. The changes also add comprehensive tests and clearer documentation around tenancy resolution.

**Improvements to tenancy detection and tagging:**

* The `requestContextFromEnvironment` function now accepts a `launchContextTenancy` option, allowing CLI entry points (like `cli/tool.ts` and `cli/search.ts`) to explicitly signal that the caller's current directory should be treated as the asserted project context if it is registered and Grove-bound. [[1]](diffhunk://#diff-df5b56c2164e5feef8e67627adca66be1c8a1fa5689b7422b1700d6107d416b1R419-R450) [[2]](diffhunk://#diff-df5b56c2164e5feef8e67627adca66be1c8a1fa5689b7422b1700d6107d416b1L434-R464) [[3]](diffhunk://#diff-df5b56c2164e5feef8e67627adca66be1c8a1fa5689b7422b1700d6107d416b1R663-R672) [[4]](diffhunk://#diff-df5b56c2164e5feef8e67627adca66be1c8a1fa5689b7422b1700d6107d416b1L645-R685) [[5]](diffhunk://#diff-a5448fc8d426a3f35bded61bc1e13bb46c3d6d83a7be20e016063dc665b7a3e2L48-R53) [[6]](diffhunk://#diff-76d690a75c38f8a3310537b01ddf5c65df955de6963e7dc4f65afdb9d803d5c6L58-R65)

**Testing and validation:**

* New tests ensure that a registered, Grove-bound project directory is correctly tagged as `tenancySource: 'caller'` when opted in, and that unregistered or unbound directories cannot masquerade as valid caller tenancy.

**Documentation and agent rules:**

* The agent rules in `AGENTS.md` are updated to emphasize verifying claims about project/grove/daemon/database state by actually running commands, and to avoid building on unverified assumptions.

## Related Issues

- Closes #
- Related #

## Change Type

- [x] Bug fix
- [ ] Enhancement / new feature
- [ ] Refactor / code quality
- [x] Documentation
- [ ] CI / workflow

## Validation

```bash
make check    # lint + 266 tests
```

## Checklist

- [ ] `make check` passes locally
- [ ] Tests added or updated where behavior changed
- [ ] Docs updated for user-visible changes
- [ ] No magic literals introduced (named constants in `src/constants.ts`)
