### PR TITLE
Vector search: in-KNN vec0 partition/metadata filtering (fix filtered-search over-truncation)

### DIFF
--- a/.agents/skills/capture-pipeline-durability/SKILL.md
+++ b/.agents/skills/capture-pipeline-durability/SKILL.md
@@ -125,7 +125,7 @@ timeout 5s curl -H "X-Myco-Context: project:test,grove:test" \
 
 ## Procedure 3: Implementing Recovery Patterns with Decoupled Self-Reconcile
 
-**For capture-critical hooks, always use `capturePost()` instead of raw `DaemonClient.post()`:**
+**For capture-critical hooks, always use `capturePost()` instead of raw `post()`:**
 
 ```typescript
 // ❌ Fragile - no managed service recovery
@@ -135,7 +135,7 @@ await client.post('/events', {
 });
 
 // ✅ Resilient - triggers service restart on failure
-await capturePost('/events', {
+await client.capturePost('/events', {
   kind: 'prompt',
   data: promptData
 });
@@ -146,22 +146,22 @@ await capturePost('/events', {
 - Prompt submit (`/events` with `prompt` kind)
 - Tool use (`/events` with `tool_use` kind)
 - Generic event send (`/events` with other kinds)
-- Session stop (`/events` with `stop` kind)
+- Session stop (`/events/stop`)
 
 **Non-capture hooks keep ordinary `post()`:**
 - Health checks, context switches, stats reads
 - These get basic `spawnDaemon()` recovery, appropriate for unmanaged daemons
 
 **Self-Reconcile Architecture (v0.27.17+):**
-Self-reconciliation is now decoupled from PowerManager scheduling and runs on a dedicated interval:
+Self-reconciliation is now decoupled from PowerManager scheduling. It is started via `startSelfReconcileLoop` in `packages/myco/src/daemon/self-reconcile-wiring.ts` on a dedicated interval:
 
 ```typescript
-// Self-reconcile runs independently every N minutes
-setInterval(async () => {
-  // Compare buffer state to database state
-  // Recover any orphaned sessions or incomplete batches
-  await daemon.selfReconcile();
-}, SELF_RECONCILE_INTERVAL);  // No longer co-scheduled with PowerManager
+// packages/myco/src/daemon/self-reconcile-wiring.ts
+const SELF_RECONCILE_INTERVAL_MS = 30_000;
+
+// started in daemon main.ts:
+const selfReconcileLoop = startSelfReconcileLoop(logger, { ... });
+// runs every SELF_RECONCILE_INTERVAL_MS — not co-scheduled with PowerManager
 ```
 
 **Key differences from previous pattern:**
@@ -172,13 +172,7 @@ setInterval(async () => {
 
 **Implementation in `packages/myco/src/hooks/client.ts`:**
 
-```typescript
-async function capturePost(endpoint: string, data: any) {
-  return DaemonClient.post(endpoint, data, {
-    recoverDaemonOnFailure: true
-  });
-}
-```
+`DaemonClient.capturePost()` wraps `postWithRecovery` with `{ captureCritical: true }`, which triggers service manager restart (not just `spawnDaemon()`) when the managed daemon is alive but wedged.
 
 **Key pattern:** For managed services (launchd/systemd), `spawnDaemon()` is ineffective on a live-but-stuck daemon. Recovery must go through `ServiceManager.restart()` with coalescing to prevent restart storms.
 
@@ -382,16 +376,14 @@ Double-fire hooks are **normal and expected**. Symbionts and agents consume hook
 ### Solution Pattern (Post-v0.27.17)
 ```typescript
 // Shared fingerprint in packages/myco/src/capture/dedup.ts
-// 10-second dedup window
-// Both live dispatcher and buffer reconciler use same key
+// Dedup window defined by EVENT_DEDUP_WINDOW_MS
+// Both live dispatcher (event-dispatch.ts) and reconciliation.ts use same key
 
-const fingerprint = eventDedupKey(event); // 10s window built-in
-if (isProcessedRecently(fingerprint)) {
-  return { status: 'duplicate', reason: 'within-window' };
-}
+const key = eventDedupKey(event); // stable fingerprint for dedup
+// Both dispatch and reconcile paths check this key against a seen-set
 ```
 
-**Test coverage:** See `tests/daemon/reconciliation-dedup.test.ts` for regression tests covering session 019e2bc0.
+**Test coverage:** See `tests/capture/dedup.test.ts` for regression tests covering the dedup key contract.
 
 ## Cross-Cutting Gotchas
 
@@ -408,7 +400,7 @@ if (isProcessedRecently(fingerprint)) {
 
 **Three-tier daemon.lock discovery:** The three-tier pattern allows daemon.lock to be discovered from explicit paths, grove directories, or global machine scan. Understand which tier applies to your setup when debugging location mismatches.
 
-**Self-reconcile is independent:** Self-reconciliation no longer depends on PowerManager scheduling. It runs continuously on its own interval, even when PowerManager tasks are suspended.
+**Self-reconcile is independent:** Self-reconciliation no longer depends on PowerManager scheduling. It runs continuously on its own interval (`SELF_RECONCILE_INTERVAL_MS = 30_000`), even when PowerManager tasks are suspended.
 
 **Silent Failure Patterns:**
 - **Multiple simultaneous bugs:** The May 15 incident had three independent failures. Fix one layer, then re-test the full pipeline.

--- a/.agents/skills/daemon-process-lifecycle-management/SKILL.md
+++ b/.agents/skills/daemon-process-lifecycle-management/SKILL.md
@@ -349,3 +349,7 @@ async function selfUpdateWithServiceCoordination(): Promise<void> {
 ### MYCO_SERVICE_VARIANT Must Be Set in the Service Plist, Not at Runtime
 
 **Startup ordering gotcha**: `MYCO_SERVICE_VARIANT` is read once at process startup by `resolveBootstrapVaultDirOrPhantom()` to determine whether the daemon runs as global (phantom-anchored) or project-local. Setting or unsetting it after the process starts has no effect. Configure it in the launchd plist `EnvironmentVariables` key before the service loads; do not set it dynamically in CLI wrappers that exec into the daemon.
+
+### PowerManager Serial Tick Starvation
+
+**Architectural gotcha** (`packages/myco/src/daemon/power.ts`): `PowerManager` runs all eligible jobs **serially** — each job is awaited before the next starts. The effective tick period is therefore `base_interval + Σ(job durations)`, not just `base_interval`. A single long-running job delays every subsequent job registered for that tick, including embedding and canopy scans. When adding a new `PowerJob`, account for this: long jobs starve later jobs. If a job's runtime is unbounded or variable, monitor `event_loop_lag_during_ms` in power job log entries to detect runaway jobs early. The `preventsDeepSleep` guard can gate a job but does not make it run concurrently.

--- a/.agents/skills/debug-daemon-errors/SKILL.md
+++ b/.agents/skills/debug-daemon-errors/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob
 
 # Debug Production Daemon Errors
 
-The Myco daemon is a long-running process that hosts multiple subsystems: a PowerManager job scheduler, SQLite-backed state, an outbox drain loop, session lifecycle tracking, and a phased task executor. Bugs in each subsystem have distinct failure signatures and require different surgical fixes. This skill teaches you how to identify which subsystem is implicated, trace to the root cause, apply a minimal fix, and prevent regression.
+The Myco daemon is a long-running process that hosts multiple subsystems: a JobRunner-based scheduler, SQLite-backed state, an outbox drain loop, session lifecycle tracking, and a phased task executor. Bugs in each subsystem have distinct failure signatures and require different surgical fixes. This skill teaches you how to identify which subsystem is implicated, trace to the root cause, apply a minimal fix, and prevent regression.
 
 ## Prerequisites
 
@@ -32,7 +32,7 @@ cat ~/.myco/daemon.log | tail -200
 
 Look for the **first anomalous line**, not just the error message. Record:
 - The timestamp of the first unexpected event
-- The subsystem prefix in the log line (e.g., `[PowerManager]`, `[Outbox]`, `[Session]`, `[Executor]`)
+- The subsystem prefix in the log line (e.g., `[JobRunner]`, `[Outbox]`, `[Session]`, `[Executor]`)
 - Whether the error is a hard crash, a silent return, or a loop
 
 **Pitfall:** Don't jump to fixing based on the exception message alone. `FOREIGN KEY constraint failed` looks like a schema bug but is almost always a deletion order problem.
@@ -45,7 +45,7 @@ Each daemon subsystem has a distinct failure signature:
 
 | Subsystem | Failure Signature |
 |-----------|-------------------|
-| **PowerManager** | A registered job stops firing after initial runs; scheduler log goes quiet |
+| **JobRunner/Scheduler** | A registered job stops firing; wrong `kind` field causes two-lane starvation, or `runIn` states don't match current power state |
 | **SQLite FK cascade** | `FOREIGN KEY constraint failed` on delete; orphaned child rows after parent deletion |
 | **Outbox drain** | Drain runs on every tick but the same records never leave; loop visible in logs |
 | **Session lifecycle** | Two sessions created for one conversation; session ID missing mid-run |
@@ -60,15 +60,21 @@ Each daemon subsystem has a distinct failure signature:
 
 ## Step 3 — Trace the Root Cause (Subsystem Playbooks)
 
-### PowerManager — Scheduler Starvation
+### JobRunner — Job Starvation (Two-Lane Scheduler)
 
-**Trace:** Check whether `scheduleNextRun` is called after inserting new work.
+**Trace:** Check the job's `kind` field. The JobRunner implements two-lane fair scheduling separating `'drain'` (time-sensitive: embedding, outbox) and `'housekeeping'` (background maintenance) jobs. When both lanes are contended, each is capped at `concurrency-1` slots. A job registered with the wrong `kind` may lose slots it needs, or a housekeeping job can appear to stall when drain jobs are busy.
 
-**Fix pattern:**
+**Fix pattern:** Set `kind: 'drain'` for time-sensitive jobs; `kind: 'housekeeping'` for background maintenance:
 ```typescript
-await db.insert(workTable).values(newWork);
-scheduler.wake(); // ensure this exists in every insert path
+runner.register({
+  name: POWER_JOB_NAMES.YOUR_JOB,
+  kind: 'drain',       // ensures fair-share slot even when housekeeping is running
+  runIn: ['active', 'idle', 'sleep'],
+  fn: yourJobFn,
+});
 ```
+
+Also verify `runIn` includes all power states where the job should fire — a job registered only for `['active']` won't run in `'idle'` or `'sleep'` states.
 
 ### SQLite FK Cascade — Wrong Deletion Order
 
@@ -405,7 +411,7 @@ All mutations require mandatory reason parameters with structured logging (kind=
 When troubleshooting daemon restart failures, consult this table of the four independent daemon state sources:
 
 | State Source | Location | Authority | Consistency Guarantee | Failure Mode |
-|--------------|----------|-----------|----------------------|--------------|
+|--------------|----------|-----------|----------------------|--------------| 
 | **daemon.json** | ~/.myco/daemon.json | Daemon self (intent-based) | Atomic write via temp-file rename; ownerPid prevents third-contender race | Stale PID; malformed JSON; third-contender deletion race |
 | **Process list** | /proc/[pid]/stat (Unix) or tasklist (Windows) | OS kernel | Real-time; immediate on kill | Race: process exits between check and reconciliation |
 | **Port claim** | Port 20915 (TCP socket) | OS kernel | Atomic on listen(); owner identifies PID | Port stuck in TIME_WAIT after unclean shutdown; EADDRINUSE false positive |
@@ -422,7 +428,7 @@ When daemon.json exists but daemon won't start, check these four sources in orde
 | Error / Symptom | Likely Cause | Fix |
 |----------------|--------------|-----|
 | `FOREIGN KEY constraint failed` on delete | Wrong deletion order | Delete children before parents |
-| Job registered but never fires | Scheduler not woken after insert | Call `scheduler.wake()` after inserting work |
+| Job registered but never fires | Wrong `kind` for two-lane scheduler, or `runIn` excludes current power state | Set `kind: 'drain'` for time-sensitive jobs; verify `runIn` includes relevant power states |
 | Two sessions for one conversation | No duplicate guard on session insert | Check for existing session ID before insert |
 | Sessions vanish mid-run, no explicit error | `findDeadSessionIds()` too aggressive | Set `DEAD_SESSION_MAX_PROMPTS = 0`; add `status != 'active'` filter |
 | Task shows "process aborted by user" without user action | Phase timeout, next phase runs under dead AbortController | Create fresh `AbortController` for each phase |

--- a/.agents/skills/power-management-scheduled-tasks/SKILL.md
+++ b/.agents/skills/power-management-scheduled-tasks/SKILL.md
@@ -16,13 +16,13 @@ Comprehensive procedures for authoring, configuring, and maintaining Myco's Powe
 
 ### Registering New PowerManager Jobs
 
-PowerManager jobs are registered through the `registerPowerJobs()` function in `packages/myco/src/daemon/main.ts`:
+PowerManager jobs are registered through `registerPowerJobs()` in `packages/myco/src/daemon/power-jobs.ts`. The function signature takes a `JobRunner` instance (not `PowerManager`):
 
 ```typescript
 import { registerPowerJobs } from './power-jobs.js';
 
 // Register all power-managed jobs during daemon startup
-const powerJobs = registerPowerJobs(powerManager, {
+const powerJobs = registerPowerJobs(jobRunner, {
   registry,
   logger,
   liveConfig,
@@ -37,16 +37,17 @@ const powerJobs = registerPowerJobs(powerManager, {
 
 ### Implementing New PowerManager Jobs
 
-Add new job implementations to `packages/myco/src/daemon/power-jobs.ts` within the `registerPowerJobs()` function:
+Add new job implementations to `packages/myco/src/daemon/power-jobs.ts` within the `registerPowerJobs()` function using the `JobRunner` API. The `kind` field controls two-lane fair scheduling — `'drain'` for time-sensitive jobs (embedding drain, outbox), `'housekeeping'` for background maintenance:
 
 ```typescript
-export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps): PowerJobsResult {
+export function registerPowerJobs(runner: JobRunner, deps: PowerJobDeps): PowerJobsResult {
   // Register existing jobs (embedding-reconcile, session-maintenance, etc.)
   
   // Add your new job
-  powerManager.register({
+  runner.register({
     name: POWER_JOB_NAMES.YOUR_NEW_JOB,
     runIn: ['active', 'idle', 'sleep'], // States where job can run
+    kind: 'housekeeping', // 'housekeeping' (maintenance) or 'drain' (time-sensitive)
     fn: () => yourNewJobImplementation(deps)
   });
   
@@ -57,7 +58,7 @@ export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps
 
 ### Grove-Scoped Iteration Pattern
 
-Use the `forEachGrove` primitive for jobs that need to iterate across all Groves:
+Use the `forEachGrove` primitive from `packages/myco/src/daemon/scope-iteration.ts` for jobs that need to iterate across all Groves:
 
 ```typescript
 import { forEachGrove } from './scope-iteration.js';
@@ -89,26 +90,32 @@ await forEachGrove(cache, logger, async (scope) => {
 
 ### Task Scheduler Implementation
 
-The task scheduler in `packages/myco/src/daemon/task-scheduling.ts` implements per-project scheduled task dispatch:
+Scheduled tasks are registered via `registerScheduledTasks()` in `packages/myco/src/daemon/task-scheduling.ts`. It takes a `JobRunner` and returns a `ScheduledJobKicker`:
 
 ```typescript
-import type { ScheduledJobContext, ScheduledJobKicker } from './task-scheduler.js';
-import { buildScheduledJobs } from './task-scheduler.js';
+import { registerScheduledTasks } from './task-scheduling.js';
 
-// Build scheduled jobs from agent task registry
-const scheduledJobs = buildScheduledJobs(loadedTasks, config);
-
-// Initialize per-project context and kicker
-const scheduledJobContext = new ScheduledJobContext(config, powerStateTracker);
-const scheduledJobKicker = new ScheduledJobKicker();
+// Register all scheduled tasks with the JobRunner during daemon startup
+const scheduledTaskKicker = await registerScheduledTasks(jobRunner, {
+  definitionsDir,
+  vaultDir,
+  logger,
+  cache: runtimeCache,
+  mycoHome,
+  daemonStateDir,
+  machineId,
+  projectStateTracker,
+});
 ```
+
+Internally, `registerScheduledTasks` uses `buildScheduledJobs` from `packages/myco/src/daemon/task-scheduler.ts` to register each agent task as a `JobRunner` job. The `ScheduledJobKicker` interface is returned for manual kicks (e.g., `kick('canopy-describe', { groveId, projectId })`).
 
 ### Understanding Scheduler Dispatch Patterns
 
 The task scheduler implements:
 
-- **Per-project dispatch**: Each project gets independent task throttling and execution via `ScheduledJobContext`
-- **Broadcast snapshot semantics**: Kick sets captured once per cycle via `ScheduledJobKicker`, preventing thundering herd
+- **Per-project dispatch**: Each project gets independent task throttling and execution
+- **Broadcast snapshot semantics**: Kick sets captured once per cycle, preventing thundering herd
 - **Idempotent kicks**: Multiple kicks to same project in one cycle execute only once
 
 ### Configuring Agent Task Parameters
@@ -349,9 +356,10 @@ await Promise.all(grovePromises);
 
 ### Fair-Share Scheduler Coordination
 
-The `ScheduledJobContext` and `ScheduledJobKicker` prevent resource contention through:
+The `JobRunner` prevents resource contention through two-lane fair scheduling:
 
-- **Per-project running flags**: Prevents concurrent task execution per project via `ProjectTaskLastRunMap`
+- **Two-lane scheduling**: `kind: 'drain'` (time-sensitive: embedding, outbox) and `kind: 'housekeeping'` (background maintenance). When both lanes have work, neither holds more than `concurrency-1` slots — each lane is always guaranteed at least one slot.
+- **Per-project running flags**: Prevents concurrent task execution per project
 - **Independent throttle timers**: Each project maintains separate `lastRun` timestamp using binding_id
 - **Broadcast semantics**: Multiple events for same project coalesce into single dispatch via kick deduplication
 
@@ -382,10 +390,10 @@ return cache.withPinned(grove.databasePath, async () => {
 
 Only record activity at the two designated points (session registration and user prompt dispatch). Additional recording points create false warmth signals and skew power state transitions.
 
-### PowerManager Job Registration vs Task Scheduler
+### Power Job Registration vs Task Scheduler
 
-- **PowerManager jobs**: Background maintenance tasks (embedding-reconcile, session-maintenance) registered via `registerPowerJobs()`
-- **Scheduled tasks**: Agent tasks (skill-survey, vault-evolve) dispatched via `ScheduledJobContext`/`ScheduledJobKicker`
+- **Power jobs** (`packages/myco/src/daemon/power-jobs.ts`, `registerPowerJobs(runner, deps)`): Background and drain jobs registered directly with `runner.register({..., kind: 'housekeeping' | 'drain'})`. Two-lane fair scheduling ensures drain jobs (time-sensitive) are never starved by housekeeping jobs.
+- **Scheduled tasks** (`packages/myco/src/daemon/task-scheduling.ts`, `registerScheduledTasks(runner, deps)`): Agent tasks (skill-survey, vault-evolve) dispatched per-project with throttling via `run_in` intervals.
 
 These are separate systems with different lifecycle patterns and configuration mechanisms.
 

--- a/.agents/skills/safe-config-updates/SKILL.md
+++ b/.agents/skills/safe-config-updates/SKILL.md
@@ -189,7 +189,7 @@ Myco's three-tier scoped configuration enables machine-global defaults, grove-le
 - **Project tier** (`myco.yaml`) — committed team-shared settings that affect how the team collaborates
 - **Personal tier** (`.myco/local.yaml`) — gitignored per-machine overrides for individual developer preferences
 
-The daemon uses `loadConfig()` to deep-merge these files with `arrayStrategy: 'replace'` where higher-tier values win (personal → project → grove → machine). This allows individuals to override team settings locally, teams to override grove settings for specific projects, and groves to override machine defaults, all without changing the lower-tier configuration.
+The daemon uses `loadMergedConfig()` which calls `pruneToTier(raw, tier)` for each tier before merging. `pruneToTier` is the **primary enforcement mechanism** — it uses `SCOPE_REGISTRY` from `packages/myco/src/config/scope.ts` to keep only leaf paths whose `home` or `overridableBy` tiers allow them. Deep-merge follows with `arrayStrategy: 'replace'` where higher-tier (personal) values win.
 
 ### Grove architecture coordination patterns
 
@@ -211,22 +211,24 @@ When adding any new user-configurable behavior, follow these steps to determine 
 - **Project tier**: Team collaboration settings specific to this project (task configs, team sync)
 - **Personal tier**: Individual developer experience preferences (UI themes, notification settings, daemon operational settings)
 
-**Step 2: Reference the classification matrix**
-Use these established patterns as precedent:
+**Step 2: Consult the scope registry**
+The canonical tier assignment for every config field lives in `SCOPE_REGISTRY` in `packages/myco/src/config/scope.ts`. This registry is the single source of truth — it drives `pruneToTier()` enforcement during config loading and the UI scope indicators. Look up the closest parent path in the registry to find precedent for similar fields.
 
-*Personal Settings (11 fields):* Per-machine preferences that do not affect team collaboration
+Use these established patterns as representative examples (verify against the live registry for current state):
+
+*Personal Settings:* Per-machine preferences that do not affect team collaboration
 - Daemon operational settings (`daemon.port`, `daemon.log_level`)
 - UI personalization (`appearance.theme`, `appearance.font_size`, `appearance.dark_mode`, `appearance.density`)
 - Notification preferences (`notifications.*`)
 - Maintenance automation (`maintenance.auto_optimize`)
 
-*Project Settings (6 fields):* Shared team configuration affecting workflow behavior
+*Project Settings:* Shared team configuration affecting workflow behavior
 - Symbiont manifest (`symbionts.*`)
 - Agent operational limits (`agent.timeout`, `agent.context_window`)
 - Vault data policies (`vault.retention_days`, `vault.max_sessions`)
 - Team sync enablement (`sync.enabled`)
 
-*Grove Settings (5 fields):* Multi-project coordination within a grove (NEW in PR #353)
+*Grove Settings:* Multi-project coordination within a grove
 - Agent provider and model selection (`agent.provider`, `agent.model`)
 - Agent harness configuration (`agent.harness`)
 - Task configuration overlays (`agent.tasks.*`)
@@ -237,37 +239,33 @@ Use these established patterns as precedent:
 - Machine-level authentication
 - Global logging and diagnostics
 
-**Step 3: Document your decision**
+**Step 3: Add the field to SCOPE_REGISTRY and the Zod schema**
+New fields must be registered in `SCOPE_REGISTRY` in `packages/myco/src/config/scope.ts` with the correct `home` tier and `overridableBy` array. The scope-registry sync test will fail if a schema leaf is not covered, so ratify against the Zod tier schemas in `packages/myco/src/config/schema.ts`.
+
+**Step 4: Document your decision**
 Add the new field to the appropriate tier in comments and update any scope defaults matrices in the UI layer.
 
 ### Handle Legacy Config Fields During Tier Migration
 
-When architectural changes move fields between tiers (e.g., PR #353 migrated agent.provider to Grove tier), use the `PROJECT_TIER_LEGACY_FIELDS` pattern in `packages/myco/src/config/schema.ts` to strip fields from outdated locations:
+When architectural changes move fields between tiers, two mechanisms cooperate:
 
-```typescript
-// In schema.ts
-export const PROJECT_TIER_LEGACY_FIELDS = [
-  'agent.provider',  // moved to Grove tier in PR #353
-  'agent.model',     // moved to Grove tier in PR #353
-  'embedding.provider', // moved to Grove tier in PR #353
-];
+**Primary enforcement — `pruneToTier()`**: The loader calls `pruneToTier(raw, tier)` for every tier in `loadMergedConfig`. This uses `SCOPE_REGISTRY` to silently drop any fields that don't belong to the given tier — so once a field's `home` tier is updated in the registry, misplaced values in other tiers are automatically ignored at load time.
 
-// During config load, filter legacy fields from Project tier
-if (projectConfig) {
-  for (const legacyPath of PROJECT_TIER_LEGACY_FIELDS) {
-    deepDeleteByPath(projectConfig, legacyPath);
-  }
-}
-```
+**Legacy strip — `PROJECT_TIER_LEGACY_FIELDS`**: For fields that historically lived in the wrong tier and need to be actively removed from committed `myco.yaml` files (not just ignored), add them to `PROJECT_TIER_LEGACY_FIELDS` in `packages/myco/src/config/schema.ts`. The loader's `stripLegacyProjectFields()` function iterates this list and calls `unsetAtPath()` to physically remove them from the YAML document, preventing stale fields from cluttering project configs.
 
-This silent-strip pattern ensures that when developers pull code with the tier reorganization, old fields in `myco.yaml` do not interfere with new grove-tier values, preventing silent shadowing of grove defaults.
+**When to use each:**
+- New field at correct tier from day one → just add to `SCOPE_REGISTRY`; `pruneToTier` enforces it automatically
+- Field moved from project → grove tier → add to `SCOPE_REGISTRY` with new home; also add to `PROJECT_TIER_LEGACY_FIELDS` so the old project-tier value gets stripped from `myco.yaml` on next load
+- Field removed entirely → add to `PROJECT_TIER_LEGACY_FIELDS` to clean up existing configs; no registry entry needed
+
+This silent-strip pattern ensures that when developers pull code with a tier reorganization, old fields in `myco.yaml` do not interfere with new grove-tier values, preventing silent shadowing of grove defaults.
 
 ### Two-Layer Config Migration Procedures
 
 When migrating existing projects to a new config architecture, use a two-layer approach:
 
 **Layer 1: Client-side silent strip**
-The client removes legacy fields during `loadConfig()` before merging. This protects against old project-tier fields shadowing new grove-tier defaults.
+The client removes legacy fields during `loadConfig()` before merging via `stripLegacyProjectFields()`. This protects against old project-tier fields shadowing new grove-tier defaults.
 
 **Layer 2: Daemon-side reconciliation**
 On next daemon startup after the migration-aware code is deployed, the daemon detects legacy fields in `myco.yaml` and offers a migration guide. This allows teams to understand what changed without breaking existing setups.
@@ -299,7 +297,17 @@ const TasksSchema = z.object({
 });
 ```
 
-**Step 2: Verify the scoped config endpoint handles your field**
+**Step 2: Register the field in SCOPE_REGISTRY**
+Add the new field to `SCOPE_REGISTRY` in `packages/myco/src/config/scope.ts` with correct `home` and `overridableBy`:
+
+```typescript
+// In scope.ts SCOPE_REGISTRY
+'your.new.field': { home: 'grove', overridableBy: ['local'] },
+```
+
+The scope-registry sync test will fail if this entry is missing, so add it before running tests.
+
+**Step 3: Verify the scoped config endpoint handles your field**
 The endpoint at `packages/myco/src/daemon/api/config.ts` handles partial patch merging with validation via `handlePutScopedConfig`:
 
 ```typescript
@@ -309,7 +317,7 @@ The endpoint at `packages/myco/src/daemon/api/config.ts` handles partial patch m
 
 Your new field should automatically work through this endpoint once added to the schema.
 
-**Step 3: Add field to scope defaults matrix (for UI)**
+**Step 4: Add field to scope defaults matrix (for UI)**
 If your field will appear in the daemon UI, update the scope defaults in the appropriate Settings component:
 
 ```typescript
@@ -322,7 +330,7 @@ const scopeDefaults = {
 };
 ```
 
-**Step 4: Handle restart-required fields (if applicable)**
+**Step 5: Handle restart-required fields (if applicable)**
 If the field requires daemon restart rather than live-reload, add it to the restart-required pattern in the UI:
 
 ```typescript
@@ -441,7 +449,9 @@ This pattern keeps side-effects deterministic and avoids the complexity of subpr
 
 **Config tier migration false positives:** During drift analysis, config property paths like `myco.yaml` and `backup.dir` are configuration property references, not missing file paths. Verify that core config safety functions remain present in the loader module before assuming drift.
 
-**Legacy field shadowing:** When using PROJECT_TIER_LEGACY_FIELDS to silent-strip old fields, ensure the silent-strip happens BEFORE tier merging. If legacy project-tier `agent.provider` exists alongside new grove-tier `agent.provider`, the legacy field will shadow the grove value until it's removed.
+**Legacy field shadowing:** When adding to PROJECT_TIER_LEGACY_FIELDS for migration, ensure the strip happens at load time before tier merging. If a legacy project-tier `agent.provider` exists alongside a new grove-tier `agent.provider`, the legacy field will shadow the grove value until it's stripped.
+
+**SCOPE_REGISTRY sync test:** A scope-registry sync test enforces that every Zod schema leaf has a registry entry. After adding a new config field to the schema, always add it to `SCOPE_REGISTRY` in `packages/myco/src/config/scope.ts` — or the test will fail loudly.
 
 **loadMergedConfig groveId resolution:** `loadMergedConfig(vaultDir, { groveId })` automatically resolves and merges grove-tier configuration from `~/.myco/groves/<groveId>/grove.yaml` when groveId is provided. When groveId is not provided, it auto-resolves from `loadProjectManifest(vaultDir)` to detect the project's grove association. If groveId is undefined and the project manifest contains no grove association, grove-tier settings are skipped.
 
@@ -455,11 +465,11 @@ This pattern keeps side-effects deterministic and avoids the complexity of subpr
 - [ ] Settings page only sets fields it owns — no pass-through of other pages' sections
 - [ ] Modern settings UI uses ScopedField components or patch endpoints directly
 - [ ] If touching daemon-behavior fields, reload signal is sent
-- [ ] New scoped config fields have correct tier classification (Machine/Grove/Project/Personal)
+- [ ] New scoped config fields added to both Zod schema AND `SCOPE_REGISTRY` in `packages/myco/src/config/scope.ts`
 - [ ] Config reactions follow closure factory pattern and idempotency constraints
 - [ ] Config toggle side-effects use managed blocks and in-process reconciliation
 - [ ] Grove architecture compatibility considered for multi-project coordination
 - [ ] Three-tier merge precedence understood and documented
 - [ ] Config tier migration compatibility verified for grove coordination features
-- [ ] Legacy field handling verified if tier restructuring involved
+- [ ] Legacy field handling: use `PROJECT_TIER_LEGACY_FIELDS` in schema.ts for fields that need physical removal from project YAML; `pruneToTier` auto-enforces scope for everything else
 - [ ] Manual verification: inspect `myco.yaml` after a test save to confirm no data loss

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,8 @@ Myco captures project memory in a local vault and serves it back through context
 - Prefer extending existing patterns over one-off patches.
 - Prefer established architectural patterns like Vertical Slice Architecture, CLEAN architecture, CQRS, Dependency Injection, etc. when they are appropriate.
 - Keep code DRY. Extract helpers or shared patterns when they remove real duplication.
+- One implementation per operation across surfaces. UI, MCP/symbiont tools, and CLI MUST share the same underlying code path for the same operation; a user and a symbiont doing the same thing MUST get the same result. Divergent implementations for one operation are a bug.
+- Never swallow errors. Do not turn a failure into an empty or default result (e.g. `return []` when a call fails); propagate or surface it. Silent failure hides real problems — cross-tenant rejections, auth failures, lost connectivity — behind "no data".
 - Preserve clear domain ownership. Do not blur module boundaries without a reason. Callout and fix when you see this happening.
 - Avoid magic literals for meaningful values. Use named constants or an existing shared pattern.
 - Keep comments lean. Add comments only when they clarify non-obvious code; DO NOT use comments to preserve task history, decisions, PR context, or conversational state.

--- a/packages/myco/src/daemon/embedding/sqlite-vec-store.ts
+++ b/packages/myco/src/daemon/embedding/sqlite-vec-store.ts
@@ -13,6 +13,12 @@ import type { Statement } from 'bun:sqlite';
 import { getVec0Path, resolveDevNativeDeps } from '../../runtime/native-deps.js';
 import { EMBEDDING_DIMENSIONS } from '@myco/db/schema.js';
 import {
+  VECTOR_PARTITION_KEYS,
+  VECTOR_COLUMN_KEYS,
+  VECTOR_INDEXED_KEYS,
+  FILTERABLE_DOMAIN_KEYS,
+} from '@myco/semantic-search-filters.js';
+import {
   EMBEDDABLE_NAMESPACES,
   type DomainMetadata,
   type EmbeddableNamespace,
@@ -41,30 +47,61 @@ const DEFAULT_META_PROVIDER = 'unknown';
 /** Fallback content hash when metadata omits it. */
 const DEFAULT_META_CONTENT_HASH = '';
 
-/** Metadata columns safe to filter on in search queries (prevents SQL injection via key names). */
+/** `embedding_metadata` columns (NOT domain_metadata keys) filterable post-KNN. */
 const FILTERABLE_COLUMNS = new Set(['model', 'provider', 'namespace']);
-const FILTERABLE_DOMAIN_METADATA_KEYS = new Set([
-  'status',
-  'session_id',
-  'observation_type',
-  'project_root',
-  'name',
-  'source_path',
-  'created_at',
-  'project_id',
-  'path',
-  'language',
-  'release_state',
-  'release_confidence',
-  'release_basis_kind',
-  'release_checked_at',
-]);
 const FILTER_SUFFIX_TO_OPERATOR: Record<string, string> = {
   _gte: '>=',
   _lte: '<=',
   _gt: '>',
   _lt: '<',
 };
+
+/**
+ * The vec0 column layout is DERIVED from the single filterable-key registry in
+ * `semantic-search-filters.ts` — partition keys + the in-KNN metadata columns —
+ * so the filterable-key set is defined in exactly one place. Promoting a key to
+ * a column lets the KNN filter on it IN the traversal (curing the
+ * over-truncation bug, where post-KNN filtering with a small `k` silently
+ * dropped matching rows). Per the registry's contract, every promoted column is
+ * TEXT, equality-filtered, and embed-stable; range keys (`created_at`),
+ * patched-in-place keys (`release_*`), and long-string keys stay post-KNN.
+ */
+const VEC0_PARTITION_KEYS: readonly string[] = VECTOR_PARTITION_KEYS;
+const VEC0_COLUMN_KEYS: readonly string[] = VECTOR_COLUMN_KEYS;
+
+/**
+ * Sentinel for a missing partition/column value. vec0 columns cannot be NULL
+ * (sqlite-vec rejects NULL binds). Every promoted column is TEXT and
+ * equality-only, so `''` is correct: it never equals a real value, so a record
+ * missing the field is excluded by a filter on it — matching both the
+ * pre-existing `project_id IS NULL` row scope and `matchesSemanticSearchFilters`
+ * (which excludes `undefined`). Range keys are never columns, so the sentinel
+ * never participates in a comparison.
+ */
+const VEC0_MISSING = '';
+
+/** Over-fetch multiplier when a post-KNN (json_extract) filter must run after the KNN. */
+const POST_KNN_OVERFETCH_FACTOR = 8;
+/**
+ * Upper bound on fail-loud re-query widening: when a post-KNN filtered search
+ * under-fills AND the candidate pool was fully consumed, `search` widens `k`
+ * and re-queries up to this factor before accepting a short result — so a
+ * selective long-string filter cannot silently return too few rows.
+ */
+const POST_KNN_MAX_OVERFETCH_FACTOR = 64;
+
+/**
+ * Schema version for `vectors.db`, tracked via `PRAGMA user_version`.
+ *
+ * v1: vec0 tables gained the `project_id` partition key + the short metadata
+ * columns so filtering happens inside the KNN. Existing tables (v0) have only
+ * `(record_id, embedding)`, which `CREATE … IF NOT EXISTS` cannot upgrade —
+ * vec0 has no `ALTER TABLE`. The migration recreates each table with the new
+ * layout, copying the stored vectors and backfilling the columns from
+ * `embedding_metadata.domain_metadata`. No re-embedding: vectors are read out
+ * of the old table and re-inserted, so the migration is fast and provider-free.
+ */
+const VEC_STORE_SCHEMA_VERSION = 1;
 
 /**
  * Convert cosine *distance* (0 = identical, 2 = opposite) to a similarity
@@ -108,12 +145,97 @@ const HUBNESS_TABLE = `
     PRIMARY KEY (namespace, record_id)
   )`;
 
-/** Build the DDL for a single vec0 virtual table. */
-function vecTableDDL(namespace: EmbeddableNamespace): string {
-  return `CREATE VIRTUAL TABLE IF NOT EXISTS vec_${namespace} USING vec0(
+/** vec0 table name for a namespace. */
+const vecTable = (namespace: EmbeddableNamespace): string => `vec_${namespace}`;
+/** Temp table used during a v0→v1 migration of a namespace. */
+const vecMigratingTable = (namespace: EmbeddableNamespace): string => `vec_${namespace}__migrating`;
+
+/** Build the DDL for a vec0 virtual table under the given name. */
+function vecTableDDL(tableName: string): string {
+  // Column order sqlite-vec expects (confirmed on 0.1.9): primary key,
+  // partition key(s), the vector, then metadata columns. All promoted columns
+  // are TEXT (see the registry contract).
+  const partitionCols = VEC0_PARTITION_KEYS.map((k) => `    ${k} TEXT partition key`).join(',\n');
+  const metaCols = VEC0_COLUMN_KEYS.map((k) => `    ${k} TEXT`).join(',\n');
+  return `CREATE VIRTUAL TABLE IF NOT EXISTS ${tableName} USING vec0(
     record_id TEXT PRIMARY KEY,
-    embedding float[${EMBEDDING_DIMENSIONS}] distance_metric=cosine
+${partitionCols},
+    embedding float[${EMBEDDING_DIMENSIONS}] distance_metric=cosine,
+${metaCols}
   )`;
+}
+
+/** Ordered `INSERT INTO vec_<ns>` column list: id, partitions, vector, columns. */
+function vecInsertColumns(): string[] {
+  return ['record_id', ...VEC0_PARTITION_KEYS, 'embedding', ...VEC0_COLUMN_KEYS];
+}
+
+/**
+ * `SELECT` clause that reads a v0 vec table joined to `embedding_metadata` and
+ * projects each partition/metadata column out of `domain_metadata` — in
+ * `vecInsertColumns()` order. `CAST(... AS TEXT)` + `COALESCE(..., '')` make
+ * the projection total and correctly-typed (mirrors `vecColumnValues`), so the
+ * migration is a pure in-engine `INSERT … SELECT` with no JS round-trip.
+ */
+function vecBackfillSelect(namespace: EmbeddableNamespace): string {
+  const fromMetadata = (key: string): string =>
+    `COALESCE(CAST(json_extract(em.domain_metadata, '$.${key}') AS TEXT), '')`;
+  const selectExprs = [
+    'v.record_id',
+    ...VEC0_PARTITION_KEYS.map(fromMetadata),
+    'v.embedding',
+    ...VEC0_COLUMN_KEYS.map(fromMetadata),
+  ];
+  return `SELECT ${selectExprs.join(', ')}
+          FROM ${vecTable(namespace)} v
+          LEFT JOIN embedding_metadata em
+            ON em.namespace = '${namespace}' AND em.record_id = v.record_id`;
+}
+
+/**
+ * Project a record's `domain_metadata` onto its vec0 column values, returning
+ * the partition values and metadata-column values separately so the caller can
+ * interleave the embedding between them (per `vecInsertColumns` order).
+ *
+ * Every value is coerced to a string (all promoted columns are TEXT — coercion
+ * means a mistyped field can't throw at the vec0 bind boundary) and a missing
+ * value binds {@link VEC0_MISSING}.
+ */
+function vecColumnValues(domainMetadata: Record<string, unknown> | undefined): {
+  partitionValues: string[];
+  columnValues: string[];
+} {
+  const dm = domainMetadata ?? {};
+  const coerce = (key: string): string => {
+    const v = dm[key];
+    return v === undefined || v === null ? VEC0_MISSING : String(v);
+  };
+  return {
+    partitionValues: VEC0_PARTITION_KEYS.map(coerce),
+    columnValues: VEC0_COLUMN_KEYS.map(coerce),
+  };
+}
+
+/** Map a hydrated search row (vec join + embedding_metadata) to a result. */
+function toSearchResult(
+  row: Record<string, unknown>,
+  namespace: EmbeddableNamespace,
+  similarity: number,
+): VectorSearchResult {
+  return {
+    id: row.record_id as string,
+    namespace,
+    similarity,
+    metadata: {
+      model: row.model,
+      provider: row.provider,
+      content_hash: row.content_hash,
+      embedded_at: row.embedded_at,
+      ...(row.dist_mean != null ? { neighbor_mean: row.dist_mean } : {}),
+      ...(row.dist_std != null ? { neighbor_std: row.dist_std } : {}),
+      ...(row.domain_metadata ? JSON.parse(row.domain_metadata as string) : {}),
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -129,6 +251,8 @@ export class SqliteVecVectorStore implements VectorStore {
   private upsertMetaStmt!: Statement;
   private deleteMetaStmt!: Statement;
   private searchStmts = new Map<string, Statement>();
+  /** Cache of filtered/candidate-count prepared statements, keyed by SQL text. */
+  private filteredStmtCache = new Map<string, Statement>();
   private statsCountStmt!: Statement;
   private statsModelsStmt!: Statement;
   private staleIdsStmt!: Statement;
@@ -153,9 +277,87 @@ export class SqliteVecVectorStore implements VectorStore {
     this.db.exec(METADATA_TABLE);
     this.db.exec(METADATA_MODEL_INDEX);
     this.db.exec(HUBNESS_TABLE);
+    // Upgrade any pre-existing v0 vec tables BEFORE the IF NOT EXISTS creates
+    // below (which can't alter an existing table). Reads domain_metadata, so it
+    // must run after embedding_metadata exists.
+    this.migrateVecTables();
     for (const ns of EMBEDDABLE_NAMESPACES) {
-      this.db.exec(vecTableDDL(ns));
+      this.db.exec(vecTableDDL(vecTable(ns)));
     }
+  }
+
+  /**
+   * Bring `vectors.db` up to {@link VEC_STORE_SCHEMA_VERSION}. No-op when the
+   * store is already current (including fresh databases, whose tables are
+   * created new-schema by `createSchema`). See {@link VEC_STORE_SCHEMA_VERSION}.
+   */
+  private migrateVecTables(): void {
+    const { user_version: version } = this.db
+      .query('PRAGMA user_version')
+      .get() as { user_version: number };
+    if (version >= VEC_STORE_SCHEMA_VERSION) return;
+
+    // Drop any temp table left by an interrupted prior run. The original vec
+    // table (if it still exists) is the authority; a half-built temp is stale.
+    for (const ns of EMBEDDABLE_NAMESPACES) {
+      this.db.run(`DROP TABLE IF EXISTS ${vecMigratingTable(ns)}`);
+    }
+    for (const ns of EMBEDDABLE_NAMESPACES) {
+      this.migrateVecTableToV1(ns);
+    }
+    this.db.run(`PRAGMA user_version = ${VEC_STORE_SCHEMA_VERSION}`);
+  }
+
+  /**
+   * Recreate one v0 vec table with the v1 layout — vectors copied and the
+   * partition/metadata columns backfilled from `embedding_metadata` — entirely
+   * in the engine via `INSERT … SELECT` (no JS materialization, no per-row
+   * queries). No-op when the table is missing (createSchema makes it v1) or
+   * already v1.
+   *
+   * Atomicity without `ALTER … RENAME` (which vec0 lacks): build the migrated
+   * copy in a temp table while the original stays intact, verify the row count
+   * matches before dropping the original, then rebuild the original name from
+   * the verified copy inside a transaction. A crash before the count check
+   * leaves the original untouched (retried next start); the vectors are also
+   * re-embeddable via `myco rebuild` as a backstop.
+   */
+  private migrateVecTableToV1(ns: EmbeddableNamespace): void {
+    const existing = this.db
+      .query(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?`)
+      .get(vecTable(ns)) as { sql: string } | undefined;
+    if (!existing) return; // missing — will be created new-schema
+    if (existing.sql.includes('partition key')) return; // already v1
+
+    const tmp = vecMigratingTable(ns);
+    const cols = vecInsertColumns().join(', ');
+
+    // 1. Build the migrated copy from the still-intact original.
+    this.db.exec(vecTableDDL(tmp));
+    this.db.run(`INSERT INTO ${tmp}(${cols}) ${vecBackfillSelect(ns)}`);
+
+    // 2. Verify completeness BEFORE destroying the original. A short copy means
+    //    a bad backfill — fail loud, keep the original, don't bump the version.
+    const count = (table: string): number =>
+      (this.db.query(`SELECT COUNT(*) AS n FROM ${table}`).get() as { n: number }).n;
+    const srcCount = count(vecTable(ns));
+    const migCount = count(tmp);
+    if (migCount !== srcCount) {
+      this.db.run(`DROP TABLE IF EXISTS ${tmp}`);
+      throw new Error(
+        `vec migration ${vecTable(ns)}: copied ${migCount}/${srcCount} rows; aborting `
+        + 'with the original intact (re-embed via `myco rebuild` if this persists)',
+      );
+    }
+
+    // 3. Swap: rebuild the original name from the verified copy, then drop temp.
+    const swap = this.db.transaction(() => {
+      this.db.run(`DROP TABLE ${vecTable(ns)}`);
+      this.db.exec(vecTableDDL(vecTable(ns)));
+      this.db.run(`INSERT INTO ${vecTable(ns)}(${cols}) SELECT ${cols} FROM ${tmp}`);
+      this.db.run(`DROP TABLE ${tmp}`);
+    });
+    swap();
   }
 
   private prepareStatements(): void {
@@ -201,9 +403,12 @@ export class SqliteVecVectorStore implements VectorStore {
         ns,
         this.db.prepare(`DELETE FROM vec_${ns} WHERE record_id = ?`)
       );
+      const insertCols = vecInsertColumns();
       this.insertVecStmts.set(
         ns,
-        this.db.prepare(`INSERT INTO vec_${ns}(record_id, embedding) VALUES (?, ?)`)
+        this.db.prepare(
+          `INSERT INTO vec_${ns}(${insertCols.join(', ')}) VALUES (${insertCols.map(() => '?').join(', ')})`,
+        )
       );
       this.searchStmts.set(
         ns,
@@ -238,11 +443,16 @@ export class SqliteVecVectorStore implements VectorStore {
     const ns = namespace as EmbeddableNamespace;
 
     const vec = new Float32Array(embedding);
+    // Project partition + metadata columns from domain_metadata so the KNN can
+    // filter on them in-traversal (see the filterable-key registry).
+    const { partitionValues, columnValues } = vecColumnValues(
+      metadata?.['domain_metadata'] as Record<string, unknown> | undefined,
+    );
 
     const txn = this.db.transaction(() => {
       // Delete-then-insert for vec0 (INSERT OR REPLACE not fully supported)
       this.deleteVecStmts.get(ns)!.run(id);
-      this.insertVecStmts.get(ns)!.run(id, vec);
+      this.insertVecStmts.get(ns)!.run(id, ...partitionValues, vec, ...columnValues);
 
       // Upsert metadata. bun:sqlite requires the @-prefix in binding keys to
       // match @name placeholders in the SQL (better-sqlite3 accepted either).
@@ -347,45 +557,66 @@ export class SqliteVecVectorStore implements VectorStore {
     const results: VectorSearchResult[] = [];
 
     for (const ns of targets) {
-      let rows: Array<Record<string, unknown>>;
-
-      if (hasFilters) {
-        // Build a filtered query that JOINs with embedding_metadata
-        const { sql, params } = this.buildFilteredSearchQuery(
-          ns,
-          options!.filters!,
-          limit,
-        );
-        const stmt = this.db.prepare(sql);
-        rows = stmt.all(queryVec, limit, ...params) as Array<Record<string, unknown>>;
-      } else {
-        rows = this.searchStmts.get(ns)!.all(queryVec, limit) as Array<Record<string, unknown>>;
-      }
+      const rows = hasFilters
+        ? this.filteredKnn(ns, options!.filters!, limit, queryVec)
+        : (this.searchStmts.get(ns)!.all(queryVec, limit) as Array<Record<string, unknown>>);
 
       for (const row of rows) {
         const similarity = cosineDistanceToSimilarity(row.distance as number);
-        if (similarity >= threshold) {
-          results.push({
-            id: row.record_id as string,
-            namespace: ns,
-            similarity,
-            metadata: {
-              model: row.model,
-              provider: row.provider,
-              content_hash: row.content_hash,
-              embedded_at: row.embedded_at,
-              ...(row.dist_mean != null ? { neighbor_mean: row.dist_mean } : {}),
-              ...(row.dist_std != null ? { neighbor_std: row.dist_std } : {}),
-              ...(row.domain_metadata ? JSON.parse(row.domain_metadata as string) : {}),
-            },
-          });
-        }
+        if (similarity >= threshold) results.push(toSearchResult(row, ns, similarity));
       }
     }
 
     // Sort by similarity DESC across all namespaces, then truncate to limit
     results.sort((a, b) => b.similarity - a.similarity);
     return results.slice(0, limit);
+  }
+
+  /**
+   * Run a filtered KNN. In-KNN filters (partition + metadata columns) narrow
+   * the traversal; post-KNN filters (`json_extract` over `domain_metadata`)
+   * run on the joined rows afterward. When post-KNN filters are present the
+   * candidate pool is over-fetched; and if it still under-fills `limit` while
+   * the KNN pool remains CAPPED (a `COUNT(*)` of candidates equals `k`, so more
+   * matches may lie deeper), `k` is widened and the query re-run — up to
+   * {@link POST_KNN_MAX_OVERFETCH_FACTOR}× — so a selective post-KNN filter
+   * cannot silently return fewer rows than exist. Widening stops as soon as the
+   * candidate pool is exhausted (`< k`), which is the true "fewer than limit"
+   * answer.
+   */
+  private filteredKnn(
+    ns: EmbeddableNamespace,
+    filters: Record<string, unknown>,
+    limit: number,
+    queryVec: Float32Array,
+  ): Array<Record<string, unknown>> {
+    const build = this.buildFilteredSearchQuery(ns, filters);
+    const run = (k: number) =>
+      this.prepareCached(build.sql).all(queryVec, k, ...build.knnParams, ...build.postParams) as Array<Record<string, unknown>>;
+
+    if (!build.hasPostFilter) return run(limit); // in-KNN-only: top-k IS top-k-of-matching
+
+    const maxK = limit * POST_KNN_MAX_OVERFETCH_FACTOR;
+    let k = limit * POST_KNN_OVERFETCH_FACTOR;
+    let rows = run(k);
+    while (rows.length < limit && k < maxK) {
+      const { n } = this.prepareCached(build.candidateSql).get(queryVec, k, ...build.knnParams) as { n: number };
+      if (n < k) break; // candidate pool exhausted — this IS the full match set
+      k = Math.min(k * 2, maxK);
+      rows = run(k);
+    }
+    return rows;
+  }
+
+  /** Prepared-statement cache for filtered/candidate queries, keyed by SQL text
+   *  (the SQL is deterministic per filter-key shape; `k` and values are binds). */
+  private prepareCached(sql: string): Statement {
+    let stmt = this.filteredStmtCache.get(sql);
+    if (!stmt) {
+      stmt = this.db.prepare(sql);
+      this.filteredStmtCache.set(sql, stmt);
+    }
+    return stmt;
   }
 
   stats(options: { namespace?: string; projectId?: string | null } = {}): VectorStoreStats {
@@ -599,51 +830,76 @@ export class SqliteVecVectorStore implements VectorStore {
   }
 
   /**
-   * Build a filtered KNN query that JOINs vec results with embedding_metadata.
-   * Filters are applied as WHERE conditions on the metadata table.
+   * Build the SQL for a filtered KNN. Filters route via the registry:
+   *
+   *   - **In-KNN** — equality on a promoted partition/metadata column. Applied
+   *     inside the KNN CTE on the vec0 table, so the traversal returns the
+   *     top-`k` OF MATCHING rows (the over-truncation cure). Range ops fall
+   *     through to post-KNN: promoted columns are equality-only, and
+   *     `json_extract` gives the correct NULL semantics for ranges that the
+   *     `''` sentinel would not.
+   *   - **Post-KNN** — every other recognized domain key (ranges, patched, and
+   *     long-string keys), applied as `json_extract` conditions on the joined
+   *     `embedding_metadata` after the KNN. The caller over-fetches `k` (and
+   *     widens on under-fill) so these can't silently truncate.
+   *
+   * `k` is bound by the caller (a `?`), so one prepared statement serves every
+   * over-fetch width. Returns the main query, a candidate-count query (the KNN
+   * pool size at `k`, used to detect a capped pool for fail-loud widening), and
+   * the param lists for each.
    */
   private buildFilteredSearchQuery(
     namespace: EmbeddableNamespace,
     filters: Record<string, unknown>,
-    _limit: number,
-  ): { sql: string; params: unknown[] } {
-    const conditions: string[] = [];
-    const params: unknown[] = [];
+  ): {
+    sql: string;
+    candidateSql: string;
+    knnParams: unknown[];
+    postParams: unknown[];
+    hasPostFilter: boolean;
+  } {
+    const knnConditions: string[] = [];
+    const knnParams: unknown[] = [];
+    const postConditions: string[] = [];
+    const postParams: unknown[] = [];
 
     for (const [key, value] of Object.entries(filters)) {
-      if (FILTERABLE_COLUMNS.has(key)) {
-        conditions.push(`em.${key} = ?`);
-        params.push(value);
-        continue;
-      }
-
-      let metadataKey = key;
+      // Range suffixes (_gte/_lte/…) map to comparison operators on the base key.
+      let baseKey = key;
       let operator = '=';
       for (const [suffix, sqlOperator] of Object.entries(FILTER_SUFFIX_TO_OPERATOR)) {
         if (key.endsWith(suffix)) {
-          metadataKey = key.slice(0, -suffix.length);
+          baseKey = key.slice(0, -suffix.length);
           operator = sqlOperator;
           break;
         }
       }
 
-      if (FILTERABLE_DOMAIN_METADATA_KEYS.has(metadataKey)) {
-        conditions.push(`json_extract(em.domain_metadata, '$.${metadataKey}') ${operator} ?`);
-        params.push(value);
+      if (operator === '=' && VECTOR_INDEXED_KEYS.has(baseKey)) {
+        knnConditions.push(`${baseKey} = ?`);
+        knnParams.push(value);
+      } else if (FILTERABLE_COLUMNS.has(key)) {
+        // `embedding_metadata` columns (model/provider/namespace) — post-KNN.
+        postConditions.push(`em.${key} = ?`);
+        postParams.push(value);
+      } else if (FILTERABLE_DOMAIN_KEYS.has(baseKey)) {
+        postConditions.push(`json_extract(em.domain_metadata, '$.${baseKey}') ${operator} ?`);
+        postParams.push(value);
       }
     }
 
-    const whereClause =
-      conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const knnWhere = knnConditions.length > 0 ? `AND ${knnConditions.join(' AND ')}` : '';
+    const postWhere = postConditions.length > 0 ? `WHERE ${postConditions.join(' AND ')}` : '';
+    const knnCte = `
+      SELECT record_id, distance
+      FROM vec_${namespace}
+      WHERE embedding MATCH ?
+        AND k = ?
+        ${knnWhere}
+      ORDER BY distance`;
 
     const sql = `
-      WITH knn AS (
-        SELECT record_id, distance
-        FROM vec_${namespace}
-        WHERE embedding MATCH ?
-          AND k = ?
-        ORDER BY distance
-      )
+      WITH knn AS (${knnCte})
       SELECT knn.record_id, knn.distance,
              em.model, em.provider, em.content_hash, em.embedded_at, em.domain_metadata,
              hs.dist_mean, hs.dist_std
@@ -652,9 +908,10 @@ export class SqliteVecVectorStore implements VectorStore {
         ON em.namespace = '${namespace}' AND em.record_id = knn.record_id
       LEFT JOIN hubness_stats hs
         ON hs.namespace = '${namespace}' AND hs.record_id = knn.record_id
-      ${whereClause}
+      ${postWhere}
     `;
+    const candidateSql = `SELECT COUNT(*) AS n FROM (${knnCte})`;
 
-    return { sql, params };
+    return { sql, candidateSql, knnParams, postParams, hasPostFilter: postConditions.length > 0 };
   }
 }

--- a/packages/myco/src/semantic-search-filters.ts
+++ b/packages/myco/src/semantic-search-filters.ts
@@ -1,5 +1,81 @@
 import type { EmbeddingMetadata } from '@myco/daemon/embedding/types.js';
 
+/**
+ * Single source of truth for how each filterable `domain_metadata` key is
+ * applied in the vector store. The sqlite-vec store derives its vec0 schema,
+ * its upsert column projection, and its KNN query routing from this one
+ * registry — so the filterable-key set is defined once, here, alongside the
+ * post-fetch matcher (`matchesSemanticSearchFilters`) that must agree with it.
+ *
+ *   - `'partition'` → a vec0 partition key. Equality-only; the tenancy scope.
+ *   - `'column'`    → a vec0 metadata column (TEXT), filtered INSIDE the KNN so
+ *                     a small `k` still returns the top-k OF MATCHING rows.
+ *                     ONLY for keys that are (a) equality-filtered, (b) short
+ *                     (<12 chars — sqlite-vec's efficient bound), and (c)
+ *                     STABLE for the vector's lifetime: set at embed, and any
+ *                     change re-embeds or removes the vector (so the column can
+ *                     never go stale). Missing binds the `''` sentinel, which
+ *                     is correct for equality (`'' ≠ any real value`) but WRONG
+ *                     for comparisons — which is exactly why range keys are
+ *                     never columns.
+ *   - `'postKnn'`   → filtered AFTER the KNN via `json_extract` on the live
+ *                     `domain_metadata` JSON (over an over-fetched candidate
+ *                     pool). Required for: RANGE/nullable keys (`created_at` —
+ *                     SQL NULL is the correct "missing" contract, no sentinel
+ *                     collision); keys PATCHED in place after embed
+ *                     (`release_state`/`release_confidence` via
+ *                     `patchDomainMetadata` — a column would go stale); and
+ *                     LONG-STRING keys (sqlite-vec metadata columns are
+ *                     inefficient past ~12 chars).
+ *
+ * Invariant: a key is in exactly one strategy, and every key here is a
+ * `domain_metadata` field. Promoting a key to `'column'` requires it satisfy
+ * (a)+(b)+(c) above; when in doubt, `'postKnn'` is always correct (just slower).
+ */
+export type VectorFilterStrategy = 'partition' | 'column' | 'postKnn';
+
+export interface FilterableKeySpec {
+  /** `domain_metadata` key; also the vec0 column/partition name when promoted. */
+  readonly key: string;
+  readonly strategy: VectorFilterStrategy;
+}
+
+export const FILTERABLE_KEY_REGISTRY: readonly FilterableKeySpec[] = [
+  { key: 'project_id', strategy: 'partition' },
+  // In-KNN columns — equality-only, short, embed-stable.
+  { key: 'observation_type', strategy: 'column' },
+  { key: 'status', strategy: 'column' },
+  { key: 'language', strategy: 'column' },
+  // Post-KNN — ranges, patched-in-place, and long strings.
+  { key: 'created_at', strategy: 'postKnn' },
+  { key: 'release_state', strategy: 'postKnn' },
+  { key: 'release_confidence', strategy: 'postKnn' },
+  { key: 'release_basis_kind', strategy: 'postKnn' },
+  { key: 'release_checked_at', strategy: 'postKnn' },
+  { key: 'session_id', strategy: 'postKnn' },
+  { key: 'project_root', strategy: 'postKnn' },
+  { key: 'name', strategy: 'postKnn' },
+  { key: 'source_path', strategy: 'postKnn' },
+  { key: 'path', strategy: 'postKnn' },
+];
+
+const keysWithStrategy = (s: VectorFilterStrategy): string[] =>
+  FILTERABLE_KEY_REGISTRY.filter((k) => k.strategy === s).map((k) => k.key);
+
+/** vec0 partition-key column names (currently just `project_id`). */
+export const VECTOR_PARTITION_KEYS: readonly string[] = keysWithStrategy('partition');
+/** vec0 metadata-column names, filtered in-KNN. */
+export const VECTOR_COLUMN_KEYS: readonly string[] = keysWithStrategy('column');
+/** Keys promoted to vec0 (partition + column) — filterable inside the KNN. */
+export const VECTOR_INDEXED_KEYS: ReadonlySet<string> = new Set([
+  ...VECTOR_PARTITION_KEYS,
+  ...VECTOR_COLUMN_KEYS,
+]);
+/** Every recognized filterable `domain_metadata` key. */
+export const FILTERABLE_DOMAIN_KEYS: ReadonlySet<string> = new Set(
+  FILTERABLE_KEY_REGISTRY.map((k) => k.key),
+);
+
 export interface SemanticSearchFilters {
   status?: string;
   session_id?: string;

--- a/tests/daemon/embedding/sqlite-vec-store-filter.test.ts
+++ b/tests/daemon/embedding/sqlite-vec-store-filter.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { SqliteVecVectorStore } from '@myco/daemon/embedding/sqlite-vec-store';
+import { EMBEDDING_DIMENSIONS } from '@myco/db/schema';
+
+const DIMS = EMBEDDING_DIMENSIONS;
+const unit = (axis: number): number[] => { const v = new Array(DIMS).fill(0); v[axis] = 1; return v; };
+// Mostly along axis 0 (close to unit(0)) but farther than unit(0) itself.
+const near0 = (eps: number): number[] => { const v = new Array(DIMS).fill(0); v[0] = Math.sqrt(1 - eps * eps); v[1] = eps; return v; };
+const meta = (domain: Record<string, unknown>) => ({ model: 'm', provider: 'p', content_hash: 'h', embedded_at: 1, domain_metadata: domain });
+
+describe('SqliteVecVectorStore filtered search', () => {
+  let store: SqliteVecVectorStore;
+  beforeEach(() => { store = new SqliteVecVectorStore(); });
+  afterEach(() => { store.close(); });
+
+  it('applies observation_type filter INSIDE the knn (small limit still returns matches)', () => {
+    store.upsert('spores', 'a-decision', unit(0), meta({ project_id: 'proj_a', observation_type: 'decision' }));
+    store.upsert('spores', 'b-wisdom', near0(0.2), meta({ project_id: 'proj_a', observation_type: 'wisdom' }));
+    store.upsert('spores', 'c-wisdom-far', unit(5), meta({ project_id: 'proj_a', observation_type: 'wisdom' }));
+    const res = store.search(unit(0), { namespace: 'spores', limit: 1, threshold: -1, filters: { observation_type: 'wisdom' } });
+    expect(res.map((r) => r.id)).toEqual(['b-wisdom']);
+  });
+
+  it('scopes by project_id partition key', () => {
+    store.upsert('spores', 'a', unit(0), meta({ project_id: 'proj_a', observation_type: 'wisdom' }));
+    store.upsert('spores', 'b', near0(0.1), meta({ project_id: 'proj_b', observation_type: 'wisdom' }));
+    const res = store.search(unit(0), { namespace: 'spores', limit: 10, threshold: -1, filters: { project_id: 'proj_a' } });
+    expect(res.map((r) => r.id)).toEqual(['a']);
+  });
+
+  it('combines partition + metadata filter in one knn', () => {
+    store.upsert('spores', 'a-dec', unit(0), meta({ project_id: 'proj_a', observation_type: 'decision' }));
+    store.upsert('spores', 'b-wis', near0(0.2), meta({ project_id: 'proj_a', observation_type: 'wisdom' }));
+    store.upsert('spores', 'c-wis-other', unit(0), meta({ project_id: 'proj_b', observation_type: 'wisdom' }));
+    const res = store.search(unit(0), { namespace: 'spores', limit: 1, threshold: -1, filters: { project_id: 'proj_a', observation_type: 'wisdom' } });
+    expect(res.map((r) => r.id)).toEqual(['b-wis']);
+  });
+
+  it('long-string filter (session_id) falls back to post-KNN over-fetch and still matches', () => {
+    store.upsert('spores', 'a-dec', unit(0), meta({ project_id: 'proj_a', observation_type: 'decision', session_id: 'sess_x' }));
+    store.upsert('spores', 'b-wis', near0(0.2), meta({ project_id: 'proj_a', observation_type: 'wisdom', session_id: 'sess_y' }));
+    const res = store.search(unit(0), { namespace: 'spores', limit: 5, threshold: -1, filters: { session_id: 'sess_y' } });
+    expect(res.map((r) => r.id)).toEqual(['b-wis']);
+  });
+
+  it('null-partition records are excluded by a project filter but returned unfiltered', () => {
+    store.upsert('spores', 'g-global', unit(0), meta({ observation_type: 'wisdom' }));
+    store.upsert('spores', 'p-scoped', near0(0.1), meta({ project_id: 'proj_a', observation_type: 'wisdom' }));
+    const scoped = store.search(unit(0), { namespace: 'spores', limit: 10, threshold: -1, filters: { project_id: 'proj_a' } });
+    expect(scoped.map((r) => r.id)).toEqual(['p-scoped']);
+    const all = store.search(unit(0), { namespace: 'spores', limit: 10, threshold: -1 });
+    expect(all.map((r) => r.id).sort()).toEqual(['g-global', 'p-scoped']);
+  });
+
+  it('created_at range filter (post-KNN) excludes undated rows on an upper bound', () => {
+    // created_at is post-KNN: json_extract NULL semantics, so a row with NO
+    // created_at must NOT match created_at_lte (the sentinel-collision bug).
+    store.upsert('spores', 'old', unit(0), meta({ project_id: 'proj_a', created_at: 100 }));
+    store.upsert('spores', 'new', near0(0.2), meta({ project_id: 'proj_a', created_at: 5000 }));
+    store.upsert('spores', 'undated', near0(0.3), meta({ project_id: 'proj_a' }));
+    const gte = store.search(unit(0), { namespace: 'spores', limit: 10, threshold: -1, filters: { created_at_gte: 1000 } });
+    expect(gte.map((r) => r.id)).toEqual(['new']);
+    const lte = store.search(unit(0), { namespace: 'spores', limit: 10, threshold: -1, filters: { created_at_lte: 1000 } });
+    expect(lte.map((r) => r.id).sort()).toEqual(['old']); // NOT 'undated'
+  });
+
+  it('fail-loud over-fetch: a post-KNN match ranked beyond the initial pool is still returned', () => {
+    // limit 1 → initial over-fetch k = 8. Eight non-matching rows rank nearer
+    // than the single matching one (rank ~9), so the initial pool misses it;
+    // the widen loop must surface it instead of silently returning [].
+    for (let i = 0; i < 8; i++) {
+      const v = new Array<number>(DIMS).fill(0);
+      v[0] = 1; v[1] = 0.01 * (i + 1); // near — ranks 1..8
+      store.upsert('spores', `near-${i}`, v, meta({ project_id: 'proj_a', session_id: 'other' }));
+    }
+    const far = new Array<number>(DIMS).fill(0);
+    far[0] = 1; far[1] = 0.5; // rank ~9
+    store.upsert('spores', 'target', far, meta({ project_id: 'proj_a', session_id: 'target' }));
+
+    const res = store.search(unit(0), { namespace: 'spores', limit: 1, threshold: -1, filters: { session_id: 'target' } });
+    expect(res.map((r) => r.id)).toEqual(['target']);
+  });
+});

--- a/tests/daemon/embedding/sqlite-vec-store-migration.test.ts
+++ b/tests/daemon/embedding/sqlite-vec-store-migration.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getVec0Path, resolveDevNativeDeps } from '@myco/runtime/native-deps.js';
+import { SqliteVecVectorStore } from '@myco/daemon/embedding/sqlite-vec-store';
+import { EMBEDDING_DIMENSIONS } from '@myco/db/schema';
+
+const DIMS = EMBEDDING_DIMENSIONS;
+const unit = (axis: number): number[] => { const v = new Array(DIMS).fill(0); v[axis] = 1; return v; };
+
+describe('SqliteVecVectorStore v0 -> v1 migration', () => {
+  let tmpDir: string | undefined;
+  let store: SqliteVecVectorStore | undefined;
+
+  afterEach(() => {
+    store?.close();
+    store = undefined;
+    if (tmpDir && fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  });
+
+  it('upgrades an old (record_id, embedding) table — vectors preserved, columns backfilled, no re-embed', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-vecmig-'));
+    const dbPath = path.join(tmpDir, 'vectors.db');
+
+    // --- Build a v0 database by hand: old vec0 layout (no partition/metadata
+    //     columns) + the embedding_metadata domain_metadata the backfill reads.
+    resolveDevNativeDeps();
+    const old = new Database(dbPath);
+    old.loadExtension(getVec0Path());
+    old.run(`CREATE VIRTUAL TABLE vec_spores USING vec0(record_id TEXT PRIMARY KEY, embedding float[${DIMS}] distance_metric=cosine)`);
+    old.run(`CREATE TABLE embedding_metadata (
+      namespace TEXT NOT NULL, record_id TEXT NOT NULL, model TEXT NOT NULL, provider TEXT NOT NULL,
+      dimensions INTEGER NOT NULL, content_hash TEXT NOT NULL, embedded_at INTEGER NOT NULL,
+      domain_metadata TEXT, PRIMARY KEY (namespace, record_id))`);
+    const insVec = old.prepare('INSERT INTO vec_spores(record_id, embedding) VALUES (?, ?)');
+    const insMeta = old.prepare(
+      `INSERT INTO embedding_metadata(namespace, record_id, model, provider, dimensions, content_hash, embedded_at, domain_metadata)
+       VALUES ('spores', ?, 'm', 'p', ${DIMS}, 'h', 1, ?)`,
+    );
+    insVec.run('a-decision', new Float32Array(unit(0)));
+    insMeta.run('a-decision', JSON.stringify({ project_id: 'proj_a', observation_type: 'decision' }));
+    insVec.run('b-wisdom', new Float32Array(unit(1)));
+    insMeta.run('b-wisdom', JSON.stringify({ project_id: 'proj_a', observation_type: 'wisdom' }));
+    expect((old.query('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(0);
+    old.close();
+
+    // --- Opening through the store triggers the migration.
+    store = new SqliteVecVectorStore(dbPath);
+
+    // Schema upgraded: version bumped and the table now carries the partition key.
+    const check = new Database(dbPath, { readonly: true });
+    check.loadExtension(getVec0Path());
+    expect((check.query('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(1);
+    const ddl = (check.query(`SELECT sql FROM sqlite_master WHERE name = 'vec_spores'`).get() as { sql: string }).sql;
+    expect(ddl).toContain('partition key');
+    check.close();
+
+    // Vectors preserved (no re-embed): unfiltered search returns both, with the
+    // ORIGINAL geometry — querying along axis 1 ranks b (the axis-1 vector) first.
+    const all = store.search(unit(1), { namespace: 'spores', limit: 10, threshold: -1 });
+    expect(all.map((r) => r.id).sort()).toEqual(['a-decision', 'b-wisdom']);
+    expect(all[0].id).toBe('b-wisdom');
+
+    // Backfilled columns work in-KNN: nearest is the decision row, but a
+    // limit-1 wisdom filter still returns b — proving the column was populated.
+    const filtered = store.search(unit(0), { namespace: 'spores', limit: 1, threshold: -1, filters: { observation_type: 'wisdom' } });
+    expect(filtered.map((r) => r.id)).toEqual(['b-wisdom']);
+  });
+
+  it('is a no-op on a fresh (already-v1) database', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-vecfresh-'));
+    const dbPath = path.join(tmpDir, 'vectors.db');
+    store = new SqliteVecVectorStore(dbPath); // fresh → created v1
+    const check = new Database(dbPath, { readonly: true });
+    check.loadExtension(getVec0Path());
+    expect((check.query('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(1);
+    check.close();
+  });
+});

--- a/tests/semantic-search-filters.test.ts
+++ b/tests/semantic-search-filters.test.ts
@@ -1,5 +1,34 @@
 import { describe, expect, it } from 'bun:test';
-import { matchesSemanticSearchFilters } from '@myco/semantic-search-filters.js';
+import {
+  matchesSemanticSearchFilters,
+  FILTERABLE_KEY_REGISTRY,
+  VECTOR_PARTITION_KEYS,
+  VECTOR_COLUMN_KEYS,
+  VECTOR_INDEXED_KEYS,
+  FILTERABLE_DOMAIN_KEYS,
+} from '@myco/semantic-search-filters.js';
+
+describe('filterable-key registry invariants', () => {
+  it('has no duplicate keys', () => {
+    const keys = FILTERABLE_KEY_REGISTRY.map((k) => k.key);
+    expect(keys.length).toBe(new Set(keys).size);
+  });
+
+  it('indexed keys (partition + column) are the union, and a subset of all filterable keys', () => {
+    expect([...VECTOR_INDEXED_KEYS].sort()).toEqual([...VECTOR_PARTITION_KEYS, ...VECTOR_COLUMN_KEYS].sort());
+    for (const k of VECTOR_INDEXED_KEYS) expect(FILTERABLE_DOMAIN_KEYS.has(k)).toBe(true);
+  });
+
+  it('the store supports exactly one partition key (tenancy)', () => {
+    expect(VECTOR_PARTITION_KEYS.length).toBe(1);
+  });
+
+  it('every registry key has a single recognized strategy', () => {
+    for (const spec of FILTERABLE_KEY_REGISTRY) {
+      expect(['partition', 'column', 'postKnn']).toContain(spec.strategy);
+    }
+  });
+});
 
 describe('matchesSemanticSearchFilters', () => {
   it('matches equality filters against embedding metadata', () => {


### PR DESCRIPTION
## Summary

Filtered semantic search (by `observation_type`, `status`, `language`, `project_id`, etc.) could silently return too few or zero results. Root cause: the store ran the KNN with `k = limit` and applied filters **after**, so any matching row ranked below position-k was dropped — the "looks like no results" failure that's bitten search across every surface.

This reworks the sqlite-vec store to filter **inside** the KNN, driven by a single source of truth so every consumer behaves identically.

### Core change
- **`semantic-search-filters.ts`**: new `FILTERABLE_KEY_REGISTRY` — the one place that declares, per filterable `domain_metadata` key, how it's applied:
  - `partition` → vec0 partition key (`project_id` — the tenancy scope)
  - `column` → vec0 metadata column, filtered **in-KNN** (equality-only, short, embed-stable: `observation_type`, `status`, `language`)
  - `postKnn` → filtered after an over-fetched candidate pool (ranges, patched-in-place, long strings: `created_at`, `release_*`, `session_id`, …)
- **`sqlite-vec-store.ts`**: derives its vec0 schema, upsert projection, and KNN routing from that registry. In-KNN filters run at `k = limit`; post-KNN filters over-fetch (8×) and widen (up to 64×) while the candidate pool is saturated, so a match ranked beyond the initial pool is still surfaced (fail-loud, not silently dropped).
- **One path, all surfaces**: UI, the `myco_search` MCP/CLI tool, per-prompt injection, harness read-tools, semantic-shortlist, and canopy all go through this store — no per-surface logic, so they now behave consistently.

### Migration (no re-embed)
- Auto v0→v1: rebuilds the vec table via `INSERT…SELECT` (vectors copied as-is), backfills the new partition/metadata columns from existing `embedding_metadata.domain_metadata`, row-count-verifies before the swap, bumps `PRAGMA user_version`. Existing embeddings are preserved — **no re-embedding**.

### AGENTS.md
- Codified the two rules this work surfaced: **one implementation per operation across surfaces** and **never swallow errors** (a swallowed cross-grove rejection is exactly how the empty-result symptom hid).

### Also included
- `9e6ed29d` (authored by Chris): skill-doc refresh documenting the PowerManager→JobRunner architecture — routine skill-doc cargo, unrelated to the search change.

## Test plan
- Full `npm test` suite: **5,866 pass, 0 fail** (node + jsdom phases).
- New tests: in-KNN filter over-truncation cure, partition scoping, combined partition+column, post-KNN long-string fallback, null-partition exclusion, `created_at` upper-bound excludes undated rows, fail-loud over-fetch (rank-9 match with limit 1 still returned); v0→v1 migration preserves vectors + backfills columns; registry invariants.
- Dogfood: dogfood grove migrated to `user_version=1`; live `myco_search` confirmed (`observation_type=wisdom limit=4` → 4 matches, previously dropped). Prod groves auto-migrate on next prod-daemon restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)