### PR TITLE
Fix plan over-association: authorship-gated capture + v55→v56 cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Myco captures project memory in a local vault and serves it back through context
 - Keep comments lean. Add comments only when they clarify non-obvious code; DO NOT use comments to preserve task history, decisions, PR context, or conversational state.
 - Prefer explicit configuration and user choice over heuristic detection when both are viable.
 - When in doubt, ask whether the rule belongs here or should live in Myco context instead.
+- Test critical paths, not edge cases, tests to prevent regressions, not to verify correctness.
 
 ## Quality Gates
 

--- a/packages/myco/src/daemon/plan-capture.ts
+++ b/packages/myco/src/daemon/plan-capture.ts
@@ -145,6 +145,67 @@ export function isPlanWriteEvent(
 }
 
 /**
+ * The subset of a recorded activity needed to decide plan authorship.
+ * Structurally compatible with `ActivityRow` from the activities query module.
+ */
+export interface PlanWriteActivity {
+  tool_name: string;
+  file_path: string | null;
+  prompt_batch_id: number | null;
+  timestamp: number;
+}
+
+/** A plan file a session authored, with the batch of its latest authoring write. */
+export interface AuthoredPlanWrite {
+  /**
+   * Plan file path exactly as recorded on the authoring activity. The form
+   * (absolute / relative / `./`-prefixed) is whatever the symbiont emitted;
+   * downstream `capturePlan` canonicalizes it via `normalizePlanSourcePath`.
+   */
+  filePath: string;
+  /** Prompt batch of the most-recent authoring write, for attribution. */
+  promptBatchId: number | null;
+}
+
+/**
+ * Select the plan files a session authored, from its recorded file activities.
+ *
+ * This is the retroactive half of the plan-capture authorship pattern: the live
+ * `event-dispatch` path captures a plan when a write *event* fires; this reuses
+ * the SAME `isPlanWriteEvent` predicate against already-recorded activities so a
+ * stop-time reconcile can recover authored plans the live path missed — WITHOUT
+ * the old mtime-window heuristic that claimed files a session never wrote.
+ *
+ * Authorship, not temporal proximity, is the association signal. A file is only
+ * returned when this session has a plan-dir write activity for it. Per file, the
+ * latest write wins (its `prompt_batch_id` is the attribution), so repeated
+ * edits collapse to one capture. Symbiont-agnostic by construction — tool-name
+ * and path-key variance is handled inside `isPlanWriteEvent`.
+ */
+export function selectAuthoredPlanWrites(
+  activities: readonly PlanWriteActivity[],
+  config: PlanWatchConfig,
+): AuthoredPlanWrite[] {
+  const latestByFile = new Map<string, { write: AuthoredPlanWrite; timestamp: number }>();
+  for (const activity of activities) {
+    const planFile = isPlanWriteEvent(
+      activity.tool_name,
+      { file_path: activity.file_path ?? undefined },
+      config,
+    );
+    if (!planFile) continue;
+    const existing = latestByFile.get(planFile);
+    if (!existing || activity.timestamp >= existing.timestamp) {
+      latestByFile.set(planFile, {
+        write: { filePath: planFile, promptBatchId: activity.prompt_batch_id },
+        timestamp: activity.timestamp,
+      });
+    }
+  }
+  return Array.from(latestByFile.values(), (entry) => entry.write);
+}
+
+/**
  * Extract a plan title from markdown content.
  *
  * Looks for the first top-level heading (# Title). If none is found,

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -19,7 +19,7 @@ import {
   extractTaggedPlans,
   capturePlan,
   captureTaggedPlan,
-  resolvePlanWatchDir,
+  selectAuthoredPlanWrites,
 } from './plan-capture.js';
 import {
   getLatestBatch,
@@ -35,6 +35,7 @@ import {
   type PromptBatchOrigin,
 } from '@myco/db/queries/batches.js';
 import { deleteSessionCascade, getSession, updateSession } from '@myco/db/queries/sessions.js';
+import { listSessionFileActivities } from '@myco/db/queries/activities.js';
 import { detectSkillUsage, SKILL_USAGE_DETECTION_ENABLED } from './skill-usage.js';
 import { epochSeconds, LOG_MESSAGE_PREVIEW_CHARS } from '@myco/constants.js';
 import { TITLE_PREVIEW_CHARS } from './event-handlers.js';
@@ -83,56 +84,6 @@ export interface StopProcessorDeps {
   planWatchConfig: PlanWatchConfig;
 }
 
-const MILLISECONDS_PER_SECOND = 1000;
-
-function isEligiblePlanExtension(filePath: string, extensions?: string[]): boolean {
-  if (!extensions || extensions.length === 0) return true;
-  const extension = path.extname(filePath).toLowerCase();
-  return extensions.includes(extension);
-}
-
-function collectPlanFiles(rootDir: string, extensions?: string[]): string[] {
-  const files: string[] = [];
-  const stack = [rootDir];
-
-  while (stack.length > 0) {
-    const currentDir = stack.pop();
-    if (!currentDir) continue;
-
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(currentDir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-
-    for (const entry of entries) {
-      const absolutePath = path.join(currentDir, entry.name);
-      if (entry.isDirectory()) {
-        stack.push(absolutePath);
-        continue;
-      }
-      if (entry.isFile() && isEligiblePlanExtension(absolutePath, extensions)) {
-        files.push(absolutePath);
-      }
-    }
-  }
-
-  return files;
-}
-
-function resolvePromptBatchIdForPlanWrite(
-  batches: BatchRow[],
-  modifiedAtSeconds: number,
-): number | undefined {
-  for (let index = batches.length - 1; index >= 0; index--) {
-    const startedAt = batches[index].started_at;
-    if (startedAt !== null && startedAt <= modifiedAtSeconds) {
-      return batches[index].id;
-    }
-  }
-  return undefined;
-}
 
 // ---------------------------------------------------------------------------
 // Exported pure utility
@@ -463,7 +414,6 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     // actual row counts the readers care about). If transcript-mining
     // detects missing batches, the right response is to INSERT those
     // batches via reenrich, which bumps the cache as a side effect.
-    const currentSession = getSession(sessionId, ALL_PROJECTS_SCOPE);
     const updateFields: Record<string, unknown> = {};
     // Only stamp transcript_path when this event actually carries one.
     // Multi-phase symbionts (Windsurf) fire the response phase with no
@@ -562,58 +512,53 @@ export function createStopProcessor(deps: StopProcessorDeps): {
       }
     }
 
-    const sessionStartedAt = currentSession?.started_at
-      ?? (sessionMeta?.started_at
-        ? Math.floor(new Date(sessionMeta.started_at).getTime() / MILLISECONDS_PER_SECOND)
-        : epochSeconds());
-    // File mtime on APFS has sub-millisecond precision but Date.now() rounds
-    // to whole ms. A plan file written in the same ms as the Stop event can
-    // end up with mtimeMs > Date.now() by a fraction. Quantize mtime to
-    // integer ms so the boundary check is stable across filesystems.
-    const sessionStopMs = Date.now();
-    const sessionBatches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
-
     const planCaptureRoot = requestFilesystemRoot;
-    // Plan-file reconciliation gated on transcript phase so two-phase
-    // symbionts don't double-scan the watch dirs per turn.
-    if (runTranscriptPhase) for (const watchDir of planWatchConfig.watchDirs) {
-      const absoluteWatchDir = resolvePlanWatchDir(watchDir, planCaptureRoot);
-      if (!fs.existsSync(absoluteWatchDir)) continue;
-
-      const planFiles = collectPlanFiles(absoluteWatchDir, planWatchConfig.extensions);
-      for (const planFile of planFiles) {
-        let stats: fs.Stats;
+    // Plan reconciliation backstop — AUTHORSHIP-DRIVEN, gated on transcript
+    // phase so two-phase symbionts don't double-scan per turn.
+    //
+    // Association is by authorship, never by file mtime. We capture only the
+    // plans THIS session actually wrote, recovered from its own recorded write
+    // activities via the same `isPlanWriteEvent` predicate the live path uses
+    // (see `selectAuthoredPlanWrites`). This still recovers plans the live
+    // capture missed (e.g. a global-daemon projectRoot mismatch) but WITHOUT
+    // the old mtime-window scan, which claimed every plan file merely *touched*
+    // during the session's lifetime regardless of author — duplicating a plan
+    // into every concurrently-open session and letting the stale copies diverge.
+    if (runTranscriptPhase) {
+      const captureWatchConfig: PlanWatchConfig = {
+        watchDirs: planWatchConfig.watchDirs,
+        projectRoot: planCaptureRoot,
+        extensions: planWatchConfig.extensions,
+      };
+      const fileActivities = listSessionFileActivities(sessionId, ALL_PROJECTS_SCOPE);
+      for (const authored of selectAuthoredPlanWrites(fileActivities, captureWatchConfig)) {
+        const planFile = path.isAbsolute(authored.filePath)
+          ? authored.filePath
+          : path.resolve(planCaptureRoot, authored.filePath);
+        let content: string;
         try {
-          stats = fs.statSync(planFile);
+          content = fs.readFileSync(planFile, 'utf-8');
         } catch {
+          // The authored plan file was removed or moved after the write —
+          // nothing on disk to reconcile.
           continue;
         }
-        const mtimeMs = Math.floor(stats.mtimeMs);
-        if (mtimeMs < sessionStartedAt * MILLISECONDS_PER_SECOND || mtimeMs > sessionStopMs) {
-          continue;
-        }
-
         try {
-          const content = fs.readFileSync(planFile, 'utf-8');
-          const promptBatchId = resolvePromptBatchIdForPlanWrite(
-            sessionBatches,
-            Math.floor(stats.mtimeMs / MILLISECONDS_PER_SECOND),
-          );
           capturePlan({
             sourcePath: planFile,
             projectRoot: planCaptureRoot,
             projectId: requestRowProjectId,
             content,
             sessionId,
-            promptBatchId,
+            promptBatchId: authored.promptBatchId,
             logger,
           });
-          logger.info(LOG_KINDS.CAPTURE_PLAN, 'Plan reconciled from configured plan dir', {
+          logger.info(LOG_KINDS.CAPTURE_PLAN, 'Plan reconciled from authoring activity', {
             session_id: sessionId,
             source_path: planFile,
           });
         } catch (err) {
-          logger.warn(LOG_KINDS.CAPTURE_PLAN, 'Failed to reconcile plan from configured plan dir', {
+          logger.warn(LOG_KINDS.CAPTURE_PLAN, 'Failed to reconcile authored plan', {
             session_id: sessionId,
             source_path: planFile,
             error: (err as Error).message,

--- a/packages/myco/src/db/migrations.ts
+++ b/packages/myco/src/db/migrations.ts
@@ -6,6 +6,7 @@
  * iterate over instead of hand-coding version checks.
  */
 
+import path from 'node:path';
 import type { Database } from 'bun:sqlite';
 import { epochSeconds, DEFAULT_MACHINE_ID } from '@myco/constants.js';
 import { CANDIDATE_STATUS } from '@myco/constants/skill-candidate-status.js';
@@ -117,6 +118,7 @@ export const MIGRATIONS: Migration[] = [
   { version: 53, migrate: (db) => migrateV52ToV53(db) },
   { version: 54, migrate: (db) => migrateV53ToV54(db) },
   { version: 55, migrate: (db) => migrateV54ToV55(db) },
+  { version: 56, migrate: (db, machineId) => migrateV55ToV56(db, machineId) },
 ];
 
 // ---------------------------------------------------------------------------
@@ -3387,6 +3389,110 @@ function migrateV54ToV55(db: Database): void {
     db.prepare(
       `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`,
     ).run(55, epochSeconds());
+    db.prepare('COMMIT').run();
+  } catch (err) {
+    db.prepare('ROLLBACK').run();
+    throw err;
+  }
+}
+
+/**
+ * v55 → v56: retire mtime-over-claimed plan associations.
+ *
+ * The stop-time plan reconcile historically claimed every plan file whose mtime
+ * fell within a session's lifetime, regardless of authorship. With several
+ * agents running concurrently, that duplicated a single plan into every open
+ * session as a `session:<sid>:file:<path>` row — diverging, stale copies. The
+ * live capture pattern is now authorship-gated (a recorded Write/Edit/Create
+ * activity on the file); this applies the same definition retroactively to
+ * remove the phantom duplicates already persisted.
+ *
+ * Rules (data-preservation safe — never delete the last copy):
+ *   - Candidates: file-backed, session-scoped rows only (`session:%:file:%`,
+ *     excluding `transcript:` tag plans, which are genuine per-session artifacts).
+ *   - LOCAL rows only (`machine_id = thisMachine`). `activities` are machine-local
+ *     and never sync, so a row synced in from another machine would look
+ *     unauthored here; evaluating it could falsely delete a genuine plan. Each
+ *     machine cleans its own rows on its own v56 run.
+ *   - A candidate is *authored* when its session has a write-tool activity on the
+ *     same (canonicalized) file path.
+ *   - A non-authored candidate is deleted ONLY when another row for the same
+ *     (project, canonical path) IS authored. Groups with no authored row are
+ *     left untouched.
+ *
+ * `plans` carries an AFTER DELETE team-sync trigger, so deletes also enqueue
+ * tombstones for any row that had been synced out.
+ */
+function migrateV55ToV56(db: Database, machineId: string): void {
+  db.prepare('BEGIN').run();
+  try {
+    if (tableExists(db, 'plans') && tableExists(db, 'activities')) {
+      // Cross-symbiont file-write tool names, FROZEN at v56. Do NOT import the
+      // live FILE_WRITE_TOOLS set — a historical migration must not change
+      // behavior when that set evolves. Mirrors plan-capture.ts at this revision.
+      const WRITE_TOOLS = ['Write', 'Edit', 'Create', 'write', 'edit', 'patch', 'create'] as const;
+
+      // Canonicalize a stored path so a symbiont's `./`-prefixed or backslash
+      // form matches the normalized `source_path` that capture writes.
+      const canonical = (value: string): string =>
+        path.posix.normalize(value.replace(/\\/g, '/')).replace(/^\.\//, '');
+
+      const candidates = db.prepare(
+        `SELECT id, project_id, session_id, source_path
+           FROM plans
+          WHERE logical_key LIKE 'session:%:file:%'
+            AND source_path IS NOT NULL
+            AND source_path NOT LIKE 'transcript:%'
+            AND machine_id = ?`,
+      ).all(machineId) as Array<{
+        id: string;
+        project_id: string | null;
+        session_id: string | null;
+        source_path: string;
+      }>;
+
+      const writePathsBySession = new Map<string, Set<string>>();
+      const writeActivityStmt = db.prepare(
+        `SELECT file_path FROM activities
+          WHERE session_id = ?
+            AND file_path IS NOT NULL
+            AND tool_name IN (${WRITE_TOOLS.map(() => '?').join(', ')})`,
+      );
+      const authoredPathsFor = (sessionId: string): Set<string> => {
+        const cached = writePathsBySession.get(sessionId);
+        if (cached) return cached;
+        const set = new Set<string>();
+        const rows = writeActivityStmt.all(sessionId, ...WRITE_TOOLS) as Array<{ file_path: string }>;
+        for (const row of rows) set.add(canonical(row.file_path));
+        writePathsBySession.set(sessionId, set);
+        return set;
+      };
+      const isAuthored = (candidate: { session_id: string | null; source_path: string }): boolean =>
+        candidate.session_id !== null
+        && authoredPathsFor(candidate.session_id).has(canonical(candidate.source_path));
+
+      // Group by (project, canonical path). A non-authored row is removable only
+      // when a sibling row in the same group IS authored.
+      const groups = new Map<string, typeof candidates>();
+      for (const candidate of candidates) {
+        const key = `${candidate.project_id ?? ''} ${canonical(candidate.source_path)}`;
+        const bucket = groups.get(key) ?? [];
+        bucket.push(candidate);
+        groups.set(key, bucket);
+      }
+
+      const deleteStmt = db.prepare(`DELETE FROM plans WHERE id = ?`);
+      for (const bucket of groups.values()) {
+        if (!bucket.some(isAuthored)) continue;
+        for (const candidate of bucket) {
+          if (!isAuthored(candidate)) deleteStmt.run(candidate.id);
+        }
+      }
+    }
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`,
+    ).run(56, epochSeconds());
     db.prepare('COMMIT').run();
   } catch (err) {
     db.prepare('ROLLBACK').run();

--- a/packages/myco/src/db/queries/activities.ts
+++ b/packages/myco/src/db/queries/activities.ts
@@ -338,6 +338,37 @@ export function listActivities(
 }
 
 /**
+ * List a session's file-touching activities (every row with a non-null
+ * `file_path`), ordered by timestamp ASC.
+ *
+ * This is the authorship-evidence feed for plan capture: which files a session
+ * actually wrote. The caller decides which of these are *plan* writes via the
+ * shared `isPlanWriteEvent` predicate (single source of truth for plan-write
+ * detection across every symbiont), so this query intentionally does NOT filter
+ * by tool name. Unbounded by design — one session's file activity set is small,
+ * and a `LIMIT` could silently drop an authoring write and resurrect the
+ * over-association bug.
+ */
+export function listSessionFileActivities(
+  sessionId: string,
+  scope: ProjectScope,
+): ActivityRow[] {
+  const db = getDatabase();
+  const conditions = ['session_id = ?', 'file_path IS NOT NULL'];
+  const params: unknown[] = [sessionId];
+  appendProjectCondition(conditions, params, scope);
+
+  const rows = db.prepare(
+    `SELECT ${SELECT_COLUMNS}
+     FROM activities
+     WHERE ${conditions.join(' AND ')}
+     ORDER BY timestamp ASC`,
+  ).all(...params) as Record<string, unknown>[];
+
+  return rows.map(toActivityRow);
+}
+
+/**
  * List all activities for a specific batch, ordered by timestamp ASC.
  */
 export function listActivitiesByBatch(

--- a/packages/myco/src/db/schema.ts
+++ b/packages/myco/src/db/schema.ts
@@ -20,7 +20,7 @@ import { TABLE_DDLS, FTS_TABLES, SECONDARY_INDEXES, TEAM_DELETE_TRIGGERS } from 
 import { MIGRATIONS } from './migrations.js';
 
 /** Current schema version -- fresh start for the SQLite era. */
-export const SCHEMA_VERSION = 55;
+export const SCHEMA_VERSION = 56;
 
 // Re-export for backwards compat (other modules import from schema.ts)
 export { DEFAULT_MACHINE_ID };

--- a/tests/daemon/plan-capture.test.ts
+++ b/tests/daemon/plan-capture.test.ts
@@ -25,7 +25,9 @@ import {
   persistPlan,
   resolvePlanWatchDir,
   extractTaggedPlans,
+  selectAuthoredPlanWrites,
   type PlanWatchConfig,
+  type PlanWriteActivity,
 } from '@myco/daemon/plan-capture.js';
 import { buildPathPlanLogicalKey, buildFilePlanLogicalKey } from '@myco/plans/identity.js';
 import type { Logger } from '@myco/daemon/logger.js';
@@ -751,5 +753,94 @@ describe('extractTaggedPlans', () => {
     expect(results).toHaveLength(2);
     expect(results[0].content).toBe('# Original Plan');
     expect(results[1].content).toBe('# Revised Plan');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectAuthoredPlanWrites — authorship-from-activities (the regression guard)
+// ---------------------------------------------------------------------------
+
+describe('selectAuthoredPlanWrites', () => {
+  const config: PlanWatchConfig = {
+    watchDirs: ['docs/plans'],
+    projectRoot: '/home/user/proj',
+    extensions: ['.md'],
+  };
+
+  const act = (over: Partial<PlanWriteActivity>): PlanWriteActivity => ({
+    tool_name: 'Write',
+    file_path: 'docs/plans/sprint.md',
+    prompt_batch_id: 1,
+    timestamp: 100,
+    ...over,
+  });
+
+  it('selects a plan-dir write activity as authorship', () => {
+    const result = selectAuthoredPlanWrites([act({})], config);
+    expect(result).toEqual([{ filePath: 'docs/plans/sprint.md', promptBatchId: 1 }]);
+  });
+
+  it('ignores writes outside any plan directory', () => {
+    const result = selectAuthoredPlanWrites(
+      [act({ file_path: 'src/index.ts' })],
+      config,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('ignores non-write tools even when targeting a plan file (Read is not authorship)', () => {
+    const result = selectAuthoredPlanWrites([act({ tool_name: 'Read' })], config);
+    expect(result).toEqual([]);
+  });
+
+  it('ignores activities with no file_path', () => {
+    const result = selectAuthoredPlanWrites([act({ file_path: null })], config);
+    expect(result).toEqual([]);
+  });
+
+  it('dedupes repeated edits of one file, keeping the latest write batch', () => {
+    const result = selectAuthoredPlanWrites(
+      [
+        act({ prompt_batch_id: 1, timestamp: 100 }),
+        act({ tool_name: 'Edit', prompt_batch_id: 2, timestamp: 200 }),
+        act({ tool_name: 'Edit', prompt_batch_id: 3, timestamp: 300 }),
+      ],
+      config,
+    );
+    expect(result).toEqual([{ filePath: 'docs/plans/sprint.md', promptBatchId: 3 }]);
+  });
+
+  it('returns one entry per distinct authored plan file', () => {
+    const result = selectAuthoredPlanWrites(
+      [
+        act({ file_path: 'docs/plans/a.md', prompt_batch_id: 1 }),
+        act({ file_path: 'docs/plans/b.md', prompt_batch_id: 2 }),
+      ],
+      config,
+    );
+    expect(result).toHaveLength(2);
+    expect(result.map((w) => w.filePath).sort()).toEqual(['docs/plans/a.md', 'docs/plans/b.md']);
+  });
+
+  it('honors the extension filter (non-.md plan-dir writes are not plans)', () => {
+    const result = selectAuthoredPlanWrites(
+      [act({ file_path: 'docs/plans/notes.txt' })],
+      config,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('detects authorship across symbionts (lowercase write tools, raw absolute paths)', () => {
+    // opencode emits lowercase tool names; a symbiont may record an absolute path.
+    const result = selectAuthoredPlanWrites(
+      [
+        act({ tool_name: 'write', file_path: '/home/user/proj/docs/plans/x.md', prompt_batch_id: 7 }),
+        act({ tool_name: 'patch', file_path: '/home/user/proj/docs/plans/x.md', prompt_batch_id: 8, timestamp: 250 }),
+      ],
+      config,
+    );
+    expect(result).toEqual([
+      { filePath: '/home/user/proj/docs/plans/x.md', promptBatchId: 8 },
+    ]);
   });
 });

--- a/tests/daemon/stop-processing.test.ts
+++ b/tests/daemon/stop-processing.test.ts
@@ -8,10 +8,33 @@ import { createStopProcessor } from '@myco/daemon/stop-processing.js';
 import { SessionRegistry } from '@myco/daemon/lifecycle.js';
 import { getSession, upsertSession } from '@myco/db/queries/sessions.js';
 import { insertBatch, listBatchesBySession } from '@myco/db/queries/batches.js';
+import { insertActivity } from '@myco/db/queries/activities.js';
 import { listPlansBySession } from '@myco/db/queries/plans.js';
 import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
 
 const epochNow = () => Math.floor(Date.now() / 1000);
+
+/**
+ * Record an authoring write activity — the authorship evidence the stop-time
+ * plan backstop now requires. `relPath` is relative to the capture root, matching
+ * the form `handleToolUse` stores via `relativizeToolPath`.
+ */
+function recordPlanWrite(
+  sessionId: string,
+  promptBatchId: number,
+  relPath: string,
+  ts: number,
+  toolName = 'Write',
+): void {
+  insertActivity({
+    session_id: sessionId,
+    prompt_batch_id: promptBatchId,
+    tool_name: toolName,
+    file_path: relPath,
+    timestamp: ts,
+    created_at: ts,
+  });
+}
 
 function writeCodexSubagentTranscript(sessionId: string): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-codex-subagent-'));
@@ -477,7 +500,7 @@ describe('createStopProcessor session capture rules', () => {
     expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(0);
   });
 
-  it('reconciles a plan-dir file written outside the fast-path tool gate', async () => {
+  it('reconciles a plan-dir file the live fast-path missed, from its write activity', async () => {
     const sessionId = 'claude-plan-reconcile-001';
     const now = epochNow();
     const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-plan-reconcile-'));
@@ -495,6 +518,18 @@ describe('createStopProcessor session capture rules', () => {
       started_at: now - 60,
       created_at: now - 60,
     });
+    // The agent's Write tool fired (activity recorded) but the live plan
+    // fast-path didn't capture it — the stop backstop must recover it from
+    // the recorded authorship.
+    const batch = insertBatch({
+      session_id: sessionId,
+      prompt_number: 1,
+      user_prompt: 'Write the spec',
+      started_at: now - 50,
+      created_at: now - 50,
+      status: 'completed',
+    });
+    recordPlanWrite(sessionId, batch.id, 'docs/superpowers/specs/reconciled.md', now - 45);
 
     const stopProcessor = makeStopProcessor(vaultDir, {
       planWatchConfig: {
@@ -524,7 +559,7 @@ describe('createStopProcessor session capture rules', () => {
     fs.rmSync(projectRoot, { recursive: true, force: true });
   });
 
-  it('reconciliation assigns the batch that matches the file mtime instead of the latest batch', async () => {
+  it('attributes the captured plan to the batch its authoring write belongs to, not the latest batch', async () => {
     const sessionId = 'claude-plan-reconcile-002';
     const now = epochNow();
     const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-plan-batch-'));
@@ -558,7 +593,9 @@ describe('createStopProcessor session capture rules', () => {
       created_at: now - 10,
       status: 'active',
     });
-    fs.utimesSync(specPath, new Date((now - 60) * 1000), new Date((now - 60) * 1000));
+    // The authoring write happened in the FIRST batch; a later batch exists but
+    // did not touch the file. Attribution must follow the write, not recency.
+    recordPlanWrite(sessionId, firstBatch.id, 'docs/superpowers/specs/batch-mapped.md', now - 80);
 
     const stopProcessor = makeStopProcessor(vaultDir, {
       planWatchConfig: {
@@ -610,6 +647,17 @@ describe('createStopProcessor session capture rules', () => {
       started_at: now - 60,
       created_at: now - 60,
     });
+    // Authorship evidence: the write activity's file_path is relativized to the
+    // worktree (caller) root, matching what the backstop anchors against.
+    const batch = insertBatch({
+      session_id: sessionId,
+      prompt_number: 1,
+      user_prompt: 'Write the worktree spec',
+      started_at: now - 50,
+      created_at: now - 50,
+      status: 'completed',
+    });
+    recordPlanWrite(sessionId, batch.id, 'docs/superpowers/specs/worktree-spec.md', now - 45);
 
     const stopProcessor = makeStopProcessor(vaultDir, {
       planWatchConfig: {
@@ -651,6 +699,128 @@ describe('createStopProcessor session capture rules', () => {
 
     fs.rmSync(registeredRoot, { recursive: true, force: true });
     fs.rmSync(worktreeRoot, { recursive: true, force: true });
+  });
+
+  it('does NOT claim a plan file the stopping session never wrote (no authoring activity)', async () => {
+    // Regression for the mtime-window over-claim: a plan file present in a watch
+    // dir during a session's lifetime must NOT be attributed to that session
+    // unless it actually authored it. The session below has an open batch but
+    // never wrote the file — so no plan row may be created for it.
+    const sessionId = 'claude-plan-no-authorship';
+    const now = epochNow();
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-plan-noauthor-'));
+    const transcriptPath = path.join(projectRoot, `${sessionId}.jsonl`);
+    const specDir = path.join(projectRoot, 'docs/superpowers/specs');
+    const specPath = path.join(specDir, 'foreign.md');
+    fs.mkdirSync(specDir, { recursive: true });
+    fs.writeFileSync(transcriptPath, '', 'utf-8');
+    fs.writeFileSync(specPath, '# Foreign Plan\n\nWritten by someone else.', 'utf-8');
+
+    upsertSession({
+      id: sessionId,
+      agent: 'claude-code',
+      status: 'active',
+      started_at: now - 60,
+      created_at: now - 60,
+    });
+    const batch = insertBatch({
+      session_id: sessionId,
+      prompt_number: 1,
+      user_prompt: 'Unrelated work',
+      started_at: now - 50,
+      created_at: now - 50,
+      status: 'active',
+    });
+    // The session only READ the plan file — reading is not authorship.
+    recordPlanWrite(sessionId, batch.id, 'docs/superpowers/specs/foreign.md', now - 40, 'Read');
+
+    const stopProcessor = makeStopProcessor(vaultDir, {
+      planWatchConfig: {
+        watchDirs: ['docs/superpowers/specs'],
+        projectRoot,
+        extensions: ['.md'],
+      },
+    });
+
+    const res = await stopProcessor.handleStopRoute({
+      body: {
+        session_id: sessionId,
+        agent: 'claude-code',
+        transcript_path: transcriptPath,
+        last_assistant_message: 'done',
+      },
+    } as never);
+
+    expect(res.body).toEqual({ ok: true });
+    await stopProcessor.getActiveProcessing();
+
+    expect(listPlansBySession(sessionId, ALL_PROJECTS_SCOPE)).toHaveLength(0);
+
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('two concurrent sessions over one plan file associate only the authoring session', async () => {
+    // The core bug: with several agents running at once, a single plan file used
+    // to be duplicated into every concurrently-open session by mtime. Now only
+    // the session whose write activity targets the file is associated.
+    const now = epochNow();
+    const authorId = 'claude-plan-concurrent-author';
+    const bystanderId = 'claude-plan-concurrent-bystander';
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-plan-concurrent-'));
+    const specDir = path.join(projectRoot, 'docs/superpowers/specs');
+    const specPath = path.join(specDir, 'shared.md');
+    fs.mkdirSync(specDir, { recursive: true });
+    fs.writeFileSync(specPath, '# Shared Plan\n\nAuthored by exactly one session.', 'utf-8');
+
+    for (const id of [authorId, bystanderId]) {
+      const transcriptPath = path.join(projectRoot, `${id}.jsonl`);
+      fs.writeFileSync(transcriptPath, '', 'utf-8');
+      upsertSession({
+        id,
+        agent: 'claude-code',
+        status: 'active',
+        started_at: now - 60,
+        created_at: now - 60,
+      });
+      const batch = insertBatch({
+        session_id: id,
+        prompt_number: 1,
+        user_prompt: 'work',
+        started_at: now - 50,
+        created_at: now - 50,
+        status: 'active',
+      });
+      // Only the author actually wrote the shared plan file.
+      if (id === authorId) {
+        recordPlanWrite(id, batch.id, 'docs/superpowers/specs/shared.md', now - 45);
+      }
+    }
+
+    const stopProcessor = makeStopProcessor(vaultDir, {
+      planWatchConfig: {
+        watchDirs: ['docs/superpowers/specs'],
+        projectRoot,
+        extensions: ['.md'],
+      },
+    });
+
+    for (const id of [authorId, bystanderId]) {
+      const res = await stopProcessor.handleStopRoute({
+        body: {
+          session_id: id,
+          agent: 'claude-code',
+          transcript_path: path.join(projectRoot, `${id}.jsonl`),
+          last_assistant_message: 'done',
+        },
+      } as never);
+      expect(res.body).toEqual({ ok: true });
+      await stopProcessor.getActiveProcessing();
+    }
+
+    expect(listPlansBySession(authorId, ALL_PROJECTS_SCOPE)).toHaveLength(1);
+    expect(listPlansBySession(bystanderId, ALL_PROJECTS_SCOPE)).toHaveLength(0);
+
+    fs.rmSync(projectRoot, { recursive: true, force: true });
   });
 
   // Regression for /code-review finding C1: a Stop event declaring only

--- a/tests/db/migrate-v54-to-v55-activities-fts.test.ts
+++ b/tests/db/migrate-v54-to-v55-activities-fts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { Database } from 'bun:sqlite';
-import { createSchema } from '@myco/db/schema.js';
+import { createSchema, SCHEMA_VERSION } from '@myco/db/schema.js';
 
 const now = 1_780_346_900;
 
@@ -51,10 +51,16 @@ describe('migration v54 -> v55: activities_fts triggers', () => {
     ).get() as { n: number };
     expect(match.n).toBe(1);
 
+    // createSchema runs the full migration chain, so the terminal version is
+    // the current SCHEMA_VERSION; assert the v55 step ran on its own.
+    const v55Applied = db.prepare(
+      `SELECT COUNT(*) AS n FROM schema_version WHERE version = 55`,
+    ).get() as { n: number };
+    expect(v55Applied.n).toBe(1);
     const version = db.prepare(
       `SELECT MAX(version) AS version FROM schema_version`,
     ).get() as { version: number };
-    expect(version.version).toBe(55);
+    expect(version.version).toBe(SCHEMA_VERSION);
     db.close();
   });
 });

--- a/tests/db/migrate-v55-to-v56-plan-authorship.test.ts
+++ b/tests/db/migrate-v55-to-v56-plan-authorship.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { createSchema } from '@myco/db/schema.js';
+
+const now = 1_780_600_000;
+const LOCAL = 'test-machine';
+const PROJECT = 'proj_test1';
+
+function seedSession(db: Database, id: string, machineId = LOCAL): void {
+  db.prepare(
+    `INSERT INTO sessions (id, agent, started_at, created_at, machine_id, project_id)
+     VALUES (?, 'claude-code', ?, ?, ?, ?)`,
+  ).run(id, now, now, machineId, PROJECT);
+}
+
+function seedBatch(db: Database, sessionId: string): number {
+  const info = db.prepare(
+    `INSERT INTO prompt_batches (session_id, prompt_number, started_at, created_at, status)
+     VALUES (?, 1, ?, ?, 'active')`,
+  ).run(sessionId, now, now);
+  return Number(info.lastInsertRowid);
+}
+
+function seedActivity(
+  db: Database,
+  sessionId: string,
+  batchId: number,
+  toolName: string,
+  filePath: string,
+): void {
+  db.prepare(
+    `INSERT INTO activities (session_id, prompt_batch_id, tool_name, file_path, timestamp, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(sessionId, batchId, toolName, filePath, now, now);
+}
+
+function seedPlan(
+  db: Database,
+  opts: {
+    id: string;
+    sessionId: string;
+    sourcePath: string;
+    machineId?: string;
+    logicalKey?: string;
+    content?: string;
+  },
+): void {
+  const logicalKey = opts.logicalKey ?? `session:${opts.sessionId}:file:${opts.sourcePath}`;
+  db.prepare(
+    `INSERT INTO plans (id, project_id, logical_key, status, source_path, session_id, machine_id, created_at, content)
+     VALUES (?, ?, ?, 'active', ?, ?, ?, ?, ?)`,
+  ).run(
+    opts.id,
+    PROJECT,
+    logicalKey,
+    opts.sourcePath,
+    opts.sessionId,
+    opts.machineId ?? LOCAL,
+    now,
+    opts.content ?? '# Plan\n\nbody',
+  );
+}
+
+function planExists(db: Database, id: string): boolean {
+  return (db.prepare(`SELECT COUNT(*) AS n FROM plans WHERE id = ?`).get(id) as { n: number }).n === 1;
+}
+
+function seedV55Db(): Database {
+  const db = new Database(':memory:');
+  createSchema(db, LOCAL);
+  db.prepare('DELETE FROM schema_version').run();
+  db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (55, ?)').run(now);
+
+  // --- Group: shared.md — one genuine author + one mtime phantom -------------
+  seedSession(db, 'author');
+  seedActivity(db, 'author', seedBatch(db, 'author'), 'Write', 'docs/plans/shared.md');
+  seedPlan(db, { id: 'p-author-shared', sessionId: 'author', sourcePath: 'docs/plans/shared.md' });
+
+  seedSession(db, 'phantom');
+  // phantom only READ the file — reading is not authorship.
+  seedActivity(db, 'phantom', seedBatch(db, 'phantom'), 'Read', 'docs/plans/shared.md');
+  seedPlan(db, { id: 'p-phantom-shared', sessionId: 'phantom', sourcePath: 'docs/plans/shared.md' });
+
+  // --- Group: multi.md — two genuine authors (both kept) ---------------------
+  seedSession(db, 'authorC');
+  seedActivity(db, 'authorC', seedBatch(db, 'authorC'), 'Edit', 'docs/plans/multi.md');
+  seedPlan(db, { id: 'p-c-multi', sessionId: 'authorC', sourcePath: 'docs/plans/multi.md' });
+
+  seedSession(db, 'authorD');
+  seedActivity(db, 'authorD', seedBatch(db, 'authorD'), 'write', 'docs/plans/multi.md');
+  seedPlan(db, { id: 'p-d-multi', sessionId: 'authorD', sourcePath: 'docs/plans/multi.md' });
+
+  // --- Group: orphan.md — no authorship anywhere (last copy preserved) -------
+  seedSession(db, 'orphan');
+  seedPlan(db, { id: 'p-orphan', sessionId: 'orphan', sourcePath: 'docs/plans/orphan.md' });
+
+  // --- Group: canon.md — author recorded a `./`-prefixed path ----------------
+  // Proves canonicalization: the activity path form differs from source_path,
+  // yet authorship must still be recognized (symbiont-agnostic matching).
+  seedSession(db, 'canonAuthor');
+  seedActivity(db, 'canonAuthor', seedBatch(db, 'canonAuthor'), 'Write', './docs/plans/canon.md');
+  seedPlan(db, { id: 'p-canon-author', sessionId: 'canonAuthor', sourcePath: 'docs/plans/canon.md' });
+
+  seedSession(db, 'canonPhantom');
+  seedPlan(db, { id: 'p-canon-phantom', sessionId: 'canonPhantom', sourcePath: 'docs/plans/canon.md' });
+
+  // --- Non-local row — activities for its session live on another machine -----
+  seedSession(db, 'remote', 'other-machine');
+  seedPlan(db, {
+    id: 'p-remote',
+    sessionId: 'remote',
+    sourcePath: 'docs/plans/remote.md',
+    machineId: 'other-machine',
+  });
+
+  // --- Transcript tag plan — genuine per-session artifact, never a candidate -
+  seedPlan(db, {
+    id: 'p-tag',
+    sessionId: 'author',
+    sourcePath: 'transcript:proposed_plan',
+    logicalKey: 'session:author:tag:proposed_plan',
+  });
+
+  return db;
+}
+
+describe('migration v55 -> v56: authorship-gated plan cleanup', () => {
+  it('removes only mtime-phantom plan rows and preserves genuine, last-copy, non-local, and tag rows', () => {
+    const db = seedV55Db();
+
+    createSchema(db, LOCAL);
+
+    // Phantom rows shadowed by a genuine author are removed.
+    expect(planExists(db, 'p-phantom-shared')).toBe(false);
+    expect(planExists(db, 'p-canon-phantom')).toBe(false);
+
+    // Genuine authors are preserved (including both of a multi-author file).
+    expect(planExists(db, 'p-author-shared')).toBe(true);
+    expect(planExists(db, 'p-c-multi')).toBe(true);
+    expect(planExists(db, 'p-d-multi')).toBe(true);
+
+    // Canonicalization: the `./`-prefixed write still counts as authorship.
+    expect(planExists(db, 'p-canon-author')).toBe(true);
+
+    // Never delete the last copy when no row in the group is authored.
+    expect(planExists(db, 'p-orphan')).toBe(true);
+
+    // Non-local rows are untouched (their activities are not local).
+    expect(planExists(db, 'p-remote')).toBe(true);
+
+    // Transcript tag plans are not candidates.
+    expect(planExists(db, 'p-tag')).toBe(true);
+
+    const version = db.prepare(`SELECT MAX(version) AS version FROM schema_version`).get() as {
+      version: number;
+    };
+    expect(version.version).toBe(56);
+    db.close();
+  });
+
+  it('enqueues a team-sync tombstone for each deleted plan row when team sync is enabled', () => {
+    const db = seedV55Db();
+    // plans carries an AFTER DELETE team-sync trigger gated on team_sync_state.
+    db.prepare(
+      `INSERT INTO team_sync_state (rowid_guard, enabled) VALUES (1, 1)
+         ON CONFLICT (rowid_guard) DO UPDATE SET enabled = 1`,
+    ).run();
+
+    createSchema(db, LOCAL);
+
+    // The two phantom deletes (p-phantom-shared, p-canon-phantom) journal a
+    // tombstone so machines that already pulled the row drop it too.
+    const tombstones = db.prepare(
+      `SELECT COUNT(*) AS n FROM team_outbox WHERE table_name = 'plans' AND operation = 'delete'`,
+    ).get() as { n: number };
+    expect(tombstones.n).toBe(2);
+    db.close();
+  });
+});

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -48,7 +48,7 @@ describe('Database schema', () => {
 
   describe('constants', () => {
     it('exports SCHEMA_VERSION as a positive integer', () => {
-      expect(SCHEMA_VERSION).toBe(55);
+      expect(SCHEMA_VERSION).toBe(56);
       expect(Number.isInteger(SCHEMA_VERSION)).toBe(true);
     });
 


### PR DESCRIPTION
## Problem

Plans were being duplicated into every concurrently-open session. The stop-time plan reconcile (`daemon/stop-processing.ts`) claimed every plan file whose **mtime** fell within a session's lifetime, with **no authorship check**. With several agents running at once, one plan file landed in multiple session windows and was written as a separate `session:<sid>:file:<path>` row per session; the copies diverged and went stale (e.g. a long-lived PowerManager session that never touched a file ended up owning a frozen snapshot of it).

This is a session-attribution + data-integrity **regression** — the original capture required authorship. It is **not** a cross-tenant leak; all duplication is within one project/Grove. Session-scoped plan identity (the deliberate v53→v54 rekey) is intentional and is **kept**; the defect was the mtime heuristic.

## Fix

Restore authorship as a first-class part of the capture pattern, shared across three touchpoints by the existing `isPlanWriteEvent` predicate — symbiont-agnostic (it already covers every agent's write-tool names and `file_path`/`path`/`filePath` shapes):

- **Live path** (`event-dispatch.ts`) — unchanged. The tool write event *is* the authorship act.
- **Backstop rewritten** (`stop-processing.ts`) — `selectAuthoredPlanWrites` derives the plans a session authored from its own recorded write **activities** (new `listSessionFileActivities` query), dedupes per file keeping the latest write's batch. No mtime scan; removed the now-dead `collectPlanFiles`/`resolvePromptBatchIdForPlanWrite` helpers.
- **Cleanup migration v55→v56** — removes phantom non-authored duplicate rows, but only when a sibling row for the same `(project, canonical path)` is authored — **never the last copy**. Scoped to local `machine_id` (activities are machine-local and never sync, so a synced-in row would falsely look unauthored). Canonicalizes both stored path forms so matching is symbiont-agnostic.

## Verification

- Full `npm test` + `tsc --noEmit`: green. New tests: `selectAuthoredPlanWrites` units; stop-processing concurrent-session and no-authorship regression locks; full v55→v56 migration coverage (phantom removed; genuine, multi-author, last-copy, non-local, and transcript-tag rows preserved; `./`-prefix canonicalization; tombstone-when-enabled).
- **Dogfooded on the dev release + daemon:** the migration took the Dogfood Grove from 167 → 137 session-file plan rows (30 phantoms removed, **0 files lost**; survivors are genuine authors — `tenant-scope-integrity.md` collapsed 4→1 onto its 24-write author, the stale PowerManager phantom is gone). A live test on the deployed daemon confirmed a plan write is attributed only to its author, and a concurrent bystander session (opened before the write) gets **no** copy. Production Groves were untouched (the dev daemon only serves the Dogfood Grove).

🤖 Generated with [Claude Code](https://claude.com/claude-code)