### PR TITLE
Eliminate the phantom bootstrap project from the tenancy data plane

### DIFF
--- a/packages/myco/src/agent/context-queries.ts
+++ b/packages/myco/src/agent/context-queries.ts
@@ -19,6 +19,7 @@ import {
 } from './tools/read-projections.js';
 import {
   projectScopeFromRequestContext,
+  requireProjectId,
   type MycoRequestContext,
 } from '@myco/grove/request-context.js';
 import type { ProjectScope } from '@myco/grove/ids.js';
@@ -71,7 +72,7 @@ export async function executeContextQueries(
   }
 
   const scope = projectScopeFromRequestContext(requestContext);
-  const projectId = requestContext!.projectId;
+  const projectId = requireProjectId(requestContext!, 'agent context query');
 
   // Execute all queries in parallel — they hit independent DB tables.
   const settled = await Promise.allSettled(

--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -18,7 +18,7 @@ import { setState } from '@myco/db/queries/agent-state.js';
 import { listReports } from '@myco/db/queries/reports.js';
 import { writeCanopyMap } from '@myco/canopy/map/store.js';
 import { getMachineId } from '@myco/machine-id.js';
-import { projectScopeFromRequestContext, rowProjectIdFromRequestContext } from '@myco/grove/request-context.js';
+import { projectScopeFromRequestContext, requireProjectId, rowProjectIdFromRequestContext } from '@myco/grove/request-context.js';
 import { getDefaultTask } from '@myco/db/queries/tasks.js';
 import {
   insertRun,
@@ -325,7 +325,7 @@ export async function runAgent(
   }
 
   const systemPrompt = loadSystemPrompt(definitionsDir, config.systemPromptPath);
-  const vaultContext = buildVaultContext(agentId, options!.requestContext!.projectId);
+  const vaultContext = buildVaultContext(agentId, requireProjectId(options!.requestContext!, 'agent run'));
 
   // Resolve Ollama context variants across task + phase scopes. Applies
   // DEFAULT_OLLAMA_CONTEXT_LENGTH when no value is set, and reconciles
@@ -806,7 +806,7 @@ function finalizeCanopyMap(args: {
   if (!args.requestContext) {
     throw new Error('canopy-map writer requires a Grove request context — none supplied');
   }
-  const projectId = args.requestContext.projectId;
+  const projectId = requireProjectId(args.requestContext, 'canopy-map writer');
   const machineId = args.requestContext.machineId;
   writeCanopyMap({
     project_id: projectId,

--- a/packages/myco/src/agent/instruction-builders.ts
+++ b/packages/myco/src/agent/instruction-builders.ts
@@ -26,6 +26,7 @@ import { getMachineId } from '@myco/machine-id.js';
 import type { AgentTeamStatusPort } from '@myco/agent/runtime/ports.js';
 import {
   projectScopeFromRequestContext,
+  requireProjectId,
   type MycoRequestContext,
 } from '@myco/grove/request-context.js';
 import type { ProjectScope } from '@myco/grove/ids.js';
@@ -896,7 +897,7 @@ export async function gatherCanopyMapContext(
   config?: MycoConfig,
 ): Promise<CanopyMapGatherContext | CanopyMapGatherSkip> {
   const vaultDir = `${projectRoot.replace(/\/$/, '')}/.myco`;
-  const projectId = resolveRequestContextForVault(vaultDir).projectId;
+  const projectId = requireProjectId(resolveRequestContextForVault(vaultDir), 'canopy map instruction');
 
   // Gate 1: canopy injection master switch. The schedule fires whenever the
   // task is enabled, so the gate must absorb the disabled-canopy case here.

--- a/packages/myco/src/agent/skill-survey-prepare.ts
+++ b/packages/myco/src/agent/skill-survey-prepare.ts
@@ -9,6 +9,7 @@ import { countSpores, listSpores } from '@myco/db/queries/spores.js';
 import type { ProjectScope } from '@myco/grove/ids.js';
 import {
   projectScopeFromRequestContext,
+  requireProjectId,
   type MycoRequestContext,
 } from '@myco/grove/request-context.js';
 import {
@@ -330,7 +331,7 @@ export function getSkillSurveyEligibility(
   options: { ignoreWatermark?: boolean } = {},
 ): SkillSurveyEligibility {
   const scope = projectScopeFromRequestContext(requestContext);
-  const projectId = requestContext!.projectId;
+  const projectId = requireProjectId(requestContext!, 'skill survey');
   const queueWork = listSurveyQueueReconciliationCandidates(scope, {
     includeDeferred: options.ignoreWatermark === true,
     onlyUnreconciled: false,
@@ -390,7 +391,7 @@ export function buildSkillSurveyPreparation(
   options: { ignoreWatermark?: boolean } = {},
 ): SkillSurveyPreparation {
   const scope = projectScopeFromRequestContext(requestContext);
-  const projectId = requestContext!.projectId;
+  const projectId = requireProjectId(requestContext!, 'skill survey');
   const ignoreWatermark = options.ignoreWatermark === true;
   const eligibility = getSkillSurveyEligibility(agentId, requestContext, options);
 

--- a/packages/myco/src/agent/tools/read-tools.ts
+++ b/packages/myco/src/agent/tools/read-tools.ts
@@ -36,6 +36,7 @@ import { errorMessage } from '@myco/utils/error-message.js';
 import { hasSemanticSearchFilters, matchesSemanticSearchFilters } from '@myco/semantic-search-filters.js';
 import { listGraphEdges } from '@myco/db/queries/graph-edges.js';
 import { searchCanopy } from '@myco/canopy/search.js';
+import { requireProjectId } from '@myco/grove/request-context.js';
 import { projectScopeFromVaultToolDeps, textResult, type VaultToolDeps } from './types.js';
 import {
   projectBatchForAgent,
@@ -509,7 +510,7 @@ export function createReadTools(deps: VaultToolDeps) {
     'Get all state key-value pairs for the current agent.',
     {},
     async () => {
-      const states = getStatesForAgent(agentId, requestContext!.projectId);
+      const states = getStatesForAgent(agentId, requireProjectId(requestContext!, 'agent state read'));
       return textResult(states);
     },
     { annotations: { readOnlyHint: true } },

--- a/packages/myco/src/agent/tools/write-tools.ts
+++ b/packages/myco/src/agent/tools/write-tools.ts
@@ -16,6 +16,7 @@ import { OBSERVATION_TYPES } from '../../vault/types.js';
 import { markBatchProcessed } from '@myco/db/queries/batches.js';
 import { createSporeLineage } from '@myco/db/queries/lineage.js';
 import { assertGroveProjectId } from '@myco/grove/ids.js';
+import { requireProjectId } from '@myco/grove/request-context.js';
 import { insertResolutionEvent } from '@myco/db/queries/resolution-events.js';
 import { upsertDigestExtract, listDigestExtracts } from '@myco/db/queries/digest-extracts.js';
 import { textResult, dryRunResult, projectScopeFromVaultToolDeps, rowProjectIdFromVaultToolDeps, type VaultToolDeps } from './types.js';
@@ -187,7 +188,7 @@ export function createWriteTools(deps: VaultToolDeps) {
     },
     async (args) => {
       const now = epochSeconds();
-      const state = setState(agentId, requestContext!.projectId, args.key, args.value, now);
+      const state = setState(agentId, requireProjectId(requestContext!, 'agent state write'), args.key, args.value, now);
 
       return textResult(state);
     },

--- a/packages/myco/src/context/cortex-brief.ts
+++ b/packages/myco/src/context/cortex-brief.ts
@@ -27,6 +27,7 @@ import { readCanopyMap } from '@myco/canopy/map/store.js';
 import { getMachineId } from '@myco/machine-id.js';
 import {
   projectScopeFromRequestContext,
+  requireProjectId,
   type MycoRequestContext,
 } from '@myco/grove/request-context.js';
 import type { ProjectScope } from '@myco/grove/ids.js';
@@ -344,7 +345,7 @@ export async function buildCortexInstructionsInput(
   if (!requestContext) {
     throw new Error('buildCortexInstructionsInput requires a Grove request context — none supplied');
   }
-  const projectId = requestContext.projectId;
+  const projectId = requireProjectId(requestContext, 'cortex brief');
   const scope = projectScopeFromRequestContext(requestContext);
   // Request context carries the machine id when the caller knows it
   // (tests, /sessions/register paths, MCP requests). Fall back to the

--- a/packages/myco/src/daemon/api/canopy-inject.ts
+++ b/packages/myco/src/daemon/api/canopy-inject.ts
@@ -22,7 +22,7 @@
 
 import path from 'node:path';
 import { z } from 'zod';
-import { filesystemRootFromRequestContext } from '../../grove/request-context.js';
+import { filesystemRootFromRequestContext, requireProjectId } from '../../grove/request-context.js';
 import type { MycoConfig } from '../../config/schema.js';
 import type { CanopyEntry } from '../../db/schema.js';
 import type { Database } from '../../db/client.js';
@@ -107,7 +107,7 @@ export function createCanopyInjectHandler(deps: CanopyInjectDeps) {
       return { body };
     }
     const projectRoot = filesystemRootFromRequestContext(ctx);
-    const projectId = ctx.projectId;
+    const projectId = requireProjectId(ctx, 'canopy inject');
     const config = deps.liveConfig.current.cortex.canopy;
 
     const capabilityOn = symbiontHasCapability(agent, 'preToolUseInjection');

--- a/packages/myco/src/daemon/api/canopy-inject.ts
+++ b/packages/myco/src/daemon/api/canopy-inject.ts
@@ -22,7 +22,7 @@
 
 import path from 'node:path';
 import { z } from 'zod';
-import { filesystemRootFromRequestContext, requireProjectId } from '../../grove/request-context.js';
+import { filesystemRootFromRequestContext, rowProjectIdFromRequestContext } from '../../grove/request-context.js';
 import type { MycoConfig } from '../../config/schema.js';
 import type { CanopyEntry } from '../../db/schema.js';
 import type { Database } from '../../db/client.js';
@@ -96,18 +96,16 @@ export function createCanopyInjectHandler(deps: CanopyInjectDeps) {
     const { sessionId, agent, toolInput } = parsed.data;
     const filePath = typeof toolInput.file_path === 'string' ? toolInput.file_path : undefined;
 
-    // Tenancy comes from the caller's request context — never from the
-    // daemon's bootstrap-anchor vault. A request without a resolved context
-    // has no project to look canopy rows up against; degrade to the same
-    // safe no-injection response the rest of the handler uses rather than
-    // synthesizing tenancy from the anchor (the cross-tenant leak class).
+    // Canopy lookups are scoped to the caller's resolved project. With no
+    // request context or no resolved project, degrade to the same safe
+    // no-injection response the rest of the handler returns.
     const ctx = req.requestContext;
-    if (!ctx) {
+    const projectId = ctx ? rowProjectIdFromRequestContext(ctx) : undefined;
+    if (!ctx || typeof projectId !== 'string') {
       const body: InjectResponseBody = { inject: false, reason: 'unknown_file' };
       return { body };
     }
     const projectRoot = filesystemRootFromRequestContext(ctx);
-    const projectId = requireProjectId(ctx, 'canopy inject');
     const config = deps.liveConfig.current.cortex.canopy;
 
     const capabilityOn = symbiontHasCapability(agent, 'preToolUseInjection');

--- a/packages/myco/src/daemon/api/search.ts
+++ b/packages/myco/src/daemon/api/search.ts
@@ -120,6 +120,11 @@ async function handleSearchWithDatabase(
     // the canopy_entries row instead of vector metadata. Local-only — canopy
     // is per-machine and not synced to team, so no team-client merge here.
     if (type === 'canopy') {
+      // Canopy is project-scoped: with no resolved project there is nothing to
+      // search, so return empty.
+      if (typeof projectId !== 'string') {
+        return { body: { mode: 'semantic', results: [] } };
+      }
       const canopyResults = await searchCanopy(embeddingManager, {
         query,
         limit,

--- a/packages/myco/src/daemon/api/sessions.ts
+++ b/packages/myco/src/daemon/api/sessions.ts
@@ -257,7 +257,13 @@ export function createSessionMutationHandlers(deps: SessionMutationDeps) {
       }, scope);
     }
 
-    await triggerTitleSummary(sessionId, { vaultDir, resolveEmbeddingManager, liveConfig, logger });
+    await triggerTitleSummary(sessionId, {
+      vaultDir,
+      resolveEmbeddingManager,
+      liveConfig,
+      logger,
+      requestContext: req.requestContext,
+    });
 
     logger.info(LOG_KINDS.API_SESSION_COMPLETE, 'Session manually completed', {
       session_id: sessionId,

--- a/packages/myco/src/daemon/cortex.ts
+++ b/packages/myco/src/daemon/cortex.ts
@@ -33,7 +33,7 @@ import { getCortexInstructions } from '@myco/db/queries/cortex-instructions.js';
 import { listReports, type ReportRow } from '@myco/db/queries/reports.js';
 import { getLatestRunId, getRun } from '@myco/db/queries/runs.js';
 import { tryParseJson } from '@myco/utils/json.js';
-import type { MycoRequestContext } from '@myco/grove/request-context.js';
+import { requireProjectId, type MycoRequestContext } from '@myco/grove/request-context.js';
 import { listSymbiontInfos, type SymbiontInfo } from './api/symbionts.js';
 import type { EmbeddingManager } from './embedding/manager.js';
 import type { DaemonLogger } from './logger.js';
@@ -231,7 +231,7 @@ export async function buildCortexPrompt(
   const delivery = resolveInstructionDelivery(config.cortex, targetSymbiont);
   const scope: import('@myco/grove/ids.js').ProjectScope = {
     kind: 'project',
-    id: requestContext.projectId,
+    id: requireProjectId(requestContext, 'cortex instructions'),
   };
   const instructions = delivery.inlineInstructions
     ? getCortexInstructions(DEFAULT_AGENT_ID, scope)
@@ -380,7 +380,7 @@ export async function triggerCortexInstructions(
       embeddingManager,
       requestContext,
     });
-    const runId = getLatestRunId(DEFAULT_AGENT_ID, CORTEX_INSTRUCTIONS_TASK, { kind: 'project', id: requestContext.projectId });
+    const runId = getLatestRunId(DEFAULT_AGENT_ID, CORTEX_INSTRUCTIONS_TASK, { kind: 'project', id: requireProjectId(requestContext, 'cortex instructions') });
 
     const tracked = resultPromise.catch((err) => {
       logger.warn(LOG_KINDS.AGENT_ERROR, 'Cortex instructions task failed', {

--- a/packages/myco/src/daemon/data-paths.ts
+++ b/packages/myco/src/daemon/data-paths.ts
@@ -1,5 +1,9 @@
 import path from 'node:path';
-import { type MycoRequestContext, requestContextFromEnvironment } from '@myco/grove/request-context.js';
+import {
+  type MycoRequestContext,
+  requestContextFromEnvironment,
+  daemonGlobalRequestContext,
+} from '@myco/grove/request-context.js';
 import {
   GROVE_VECTORS_FILENAME,
   resolveGroveVectorsPath,
@@ -47,8 +51,15 @@ export function resolveVectorsPathForRequestContext(requestContext: MycoRequestC
 export function resolveDaemonDataPaths(
   vaultDir: string,
   env: Record<string, string | undefined> = process.env,
+  options: { daemonGlobal?: boolean } = {},
 ): DaemonDataPaths {
-  const requestContext = requestContextFromEnvironment(env, vaultDir);
+  // The global multi-tenant daemon's anchor has NO project (it serves every
+  // tenant per request). Its context is the daemon-global shape (projectId
+  // null) — never a fabricated phantom project id. A variant-less ad-hoc
+  // `myco daemon` bound to a real project vault still resolves that project.
+  const requestContext = options.daemonGlobal
+    ? daemonGlobalRequestContext(vaultDir)
+    : requestContextFromEnvironment(env, vaultDir);
   return {
     requestContext,
     databasePath: requestContext.databasePath,

--- a/packages/myco/src/daemon/data-paths.ts
+++ b/packages/myco/src/daemon/data-paths.ts
@@ -53,10 +53,8 @@ export function resolveDaemonDataPaths(
   env: Record<string, string | undefined> = process.env,
   options: { daemonGlobal?: boolean } = {},
 ): DaemonDataPaths {
-  // The global multi-tenant daemon's anchor has NO project (it serves every
-  // tenant per request). Its context is the daemon-global shape (projectId
-  // null) — never a fabricated phantom project id. A variant-less ad-hoc
-  // `myco daemon` bound to a real project vault still resolves that project.
+  // daemonGlobal uses the project-less anchor context; otherwise resolve the
+  // vault's project from env.
   const requestContext = options.daemonGlobal
     ? daemonGlobalRequestContext(vaultDir)
     : requestContextFromEnvironment(env, vaultDir);

--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -39,6 +39,7 @@ import {
   filesystemRootFromRequestContext,
   projectScopeFromRequestContext,
   rowProjectIdFromRequestContext,
+  type MycoRequestContext,
 } from '@myco/grove/request-context.js';
 import { resolveProjectRoot } from '@myco/vault/resolve.js';
 import { getDatabase } from '@myco/db/client.js';
@@ -88,6 +89,7 @@ export interface EventDispatchDeps {
   planWatchConfig: PlanWatchConfig; // object reference — mutated in place for hot-reload
   triggerTitleSummary: (
     sessionId: string,
+    requestContext: MycoRequestContext | undefined,
     trigger?: { evaluateBoundary: true; promptOrigin: PromptBatchOrigin },
   ) => Promise<void>;
   /**
@@ -501,7 +503,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
 
         // Boundary policy (origin filter + N-th human-batch crossing) lives
         // inside the trigger; the dispatcher just hands it the event's origin.
-        triggerTitleSummary(event.session_id, { evaluateBoundary: true, promptOrigin });
+        triggerTitleSummary(event.session_id, req.requestContext, { evaluateBoundary: true, promptOrigin });
 
         // A new human prompt is a turn boundary: the PRIOR turn definitively
         // ended, and its response is now complete in the transcript. Converge

--- a/packages/myco/src/daemon/log-entry-insert.ts
+++ b/packages/myco/src/daemon/log-entry-insert.ts
@@ -1,0 +1,72 @@
+/**
+ * The single seam that maps a logger `LogEntry` (or a parsed JSONL buffer
+ * line) to a `LogEntryInsert`. Both the live persist path (the daemon
+ * logger's persistFn) and the buffer-replay path (`reconcileLogBuffer`)
+ * resolve a log row's `project_id` here, so there is exactly one rule for it.
+ *
+ * The rule: a daemon log row carries the entry's own explicit `project_id`
+ * when it has one, else the daemon's resolved fallback. The fallback is NULL
+ * for the groveless daemon anchor — daemon-owned rows belong to the
+ * `project_id IS NULL` (`GLOBAL_SCOPE`) partition, NEVER the phantom
+ * `_unbound-bootstrap` project id. Callers compute the fallback via
+ * `rowProjectIdFromRequestContext(...)`, which yields NULL for a groveless
+ * context, so the phantom id can never reach the data plane through logging.
+ */
+
+import type { LogEntryInsert } from '@myco/db/queries/logs.js';
+import { assertGroveProjectId, type GroveProjectId } from '@myco/grove/ids.js';
+import { kindToComponent } from '@myco/constants/log-kinds.js';
+
+/**
+ * Resolve the `project_id` a daemon log row should carry: the entry's own
+ * explicit id when present (validated as a real Grove project id), otherwise
+ * the daemon's resolved fallback (NULL for the groveless anchor).
+ */
+export function resolveLogRowProjectId(
+  entryProjectId: unknown,
+  fallbackProjectId: GroveProjectId | null,
+): GroveProjectId | null {
+  return typeof entryProjectId === 'string'
+    ? assertGroveProjectId(entryProjectId)
+    : fallbackProjectId;
+}
+
+/**
+ * Map a logger entry (or a parsed JSONL buffer line) to a `LogEntryInsert`.
+ * Defensive about `kind`/`component` so a malformed or partial buffered line
+ * still replays. `project_id` and `session_id` are lifted to their own
+ * columns and excluded from the JSON `data` blob.
+ */
+export function logEntryToInsert(
+  entry: Record<string, unknown>,
+  fallbackProjectId: GroveProjectId | null,
+): LogEntryInsert {
+  const {
+    timestamp,
+    level,
+    kind,
+    component,
+    message,
+    project_id: entryProjectId,
+    session_id: entrySessionId,
+    ...data
+  } = entry;
+
+  const resolvedKind = typeof kind === 'string' && kind.length > 0
+    ? kind
+    : `${typeof component === 'string' && component.length > 0 ? component : 'unknown'}.unknown`;
+  const resolvedComponent = typeof component === 'string' && component.length > 0
+    ? component
+    : kindToComponent(resolvedKind);
+
+  return {
+    timestamp: String(timestamp),
+    level: String(level),
+    kind: resolvedKind,
+    component: resolvedComponent,
+    message: typeof message === 'string' ? message : String(message ?? ''),
+    data: Object.keys(data).length > 0 ? JSON.stringify(data) : null,
+    session_id: typeof entrySessionId === 'string' ? entrySessionId : null,
+    project_id: resolveLogRowProjectId(entryProjectId, fallbackProjectId),
+  };
+}

--- a/packages/myco/src/daemon/log-entry-insert.ts
+++ b/packages/myco/src/daemon/log-entry-insert.ts
@@ -1,16 +1,9 @@
 /**
- * The single seam that maps a logger `LogEntry` (or a parsed JSONL buffer
- * line) to a `LogEntryInsert`. Both the live persist path (the daemon
- * logger's persistFn) and the buffer-replay path (`reconcileLogBuffer`)
- * resolve a log row's `project_id` here, so there is exactly one rule for it.
- *
- * The rule: a daemon log row carries the entry's own explicit `project_id`
- * when it has one, else the daemon's resolved fallback. The fallback is NULL
- * for the groveless daemon anchor — daemon-owned rows belong to the
- * `project_id IS NULL` (`GLOBAL_SCOPE`) partition, NEVER the phantom
- * `_unbound-bootstrap` project id. Callers compute the fallback via
- * `rowProjectIdFromRequestContext(...)`, which yields NULL for a groveless
- * context, so the phantom id can never reach the data plane through logging.
+ * Maps a logger `LogEntry` (or a parsed JSONL buffer line) to a
+ * `LogEntryInsert`. The live persist path and the buffer-replay path
+ * (`reconcileLogBuffer`) both resolve a log row's `project_id` here: the
+ * entry's own explicit `project_id` when present, else the caller-supplied
+ * fallback (NULL for a groveless context).
  */
 
 import type { LogEntryInsert } from '@myco/db/queries/logs.js';

--- a/packages/myco/src/daemon/log-reconcile.ts
+++ b/packages/myco/src/daemon/log-reconcile.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { insertLogEntry } from '@myco/db/queries/logs.js';
-import { kindToComponent } from '@myco/constants/log-kinds.js';
+import { logEntryToInsert } from './log-entry-insert.js';
 import type { GroveProjectId } from '@myco/grove/ids.js';
 
 /**
@@ -11,7 +11,7 @@ import type { GroveProjectId } from '@myco/grove/ids.js';
 export function reconcileLogBuffer(
   logDir: string,
   sinceTimestamp: string,
-  projectId: GroveProjectId,
+  fallbackProjectId: GroveProjectId | null,
 ): number {
   let replayed = 0;
 
@@ -31,17 +31,7 @@ export function reconcileLogBuffer(
       try {
         const entry = JSON.parse(line);
         if (entry.timestamp > sinceTimestamp) {
-          const { timestamp, level, kind, component, message, ...rest } = entry;
-          insertLogEntry({
-            timestamp,
-            level,
-            kind: kind ?? `${component ?? 'unknown'}.unknown`,
-            component: component ?? kindToComponent(kind ?? 'unknown'),
-            message,
-            data: Object.keys(rest).length > 0 ? JSON.stringify(rest) : null,
-            session_id: rest.session_id ?? null,
-            project_id: projectId,
-          });
+          insertLogEntry(logEntryToInsert(entry, fallbackProjectId));
           replayed++;
         }
       } catch {

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -196,7 +196,7 @@ import { createConfigReactionRegistry, computeTouchedPaths, loadReactionContext 
 import { createPlanWatchReaction } from './plan-watch-reaction.js';
 import { resolveDaemonDataPaths, resolveVectorsPathForRequestContext } from './data-paths.js';
 import { type GroveProjectId } from '../grove/ids.js';
-import { rowProjectIdFromRequestContext, type MycoRequestContext } from '../grove/request-context.js';
+import { rowProjectIdFromRequestContext, requireProjectId, type MycoRequestContext } from '../grove/request-context.js';
 import {
   daemonStateMtimeMs,
   readDaemonState,
@@ -600,10 +600,16 @@ export async function main(): Promise<void> {
     // no Groves yet), fall through to fresh derivation via getMachineId.
   }
   const machineId = getMachineId();
-  const dataPaths = resolveDaemonDataPaths(bootstrapVaultDir, {
-    ...process.env,
-    MYCO_MACHINE_ID: machineId,
-  });
+  const dataPaths = resolveDaemonDataPaths(
+    bootstrapVaultDir,
+    {
+      ...process.env,
+      MYCO_MACHINE_ID: machineId,
+    },
+    // Phantom boot = the global daemon's project-less anchor. Use the
+    // daemon-global context (projectId null), never a fabricated project id.
+    { daemonGlobal: bootstrapIsPhantom },
+  );
 
   // Relocate any legacy project-vault `secrets.env` into machine secrets
   // BEFORE loading. The provider-secrets dashboard no longer reads the
@@ -1174,7 +1180,7 @@ export async function main(): Promise<void> {
     logger,
     liveConfig,
     vaultDir: bootstrapVaultDir,
-    projectId: dataPaths.requestContext.projectId,
+    projectId: rowProjectIdFromRequestContext(dataPaths.requestContext) ?? null,
     machineId,
     planTags: symbiontPlanTags,
     planWatchConfig,
@@ -1529,7 +1535,10 @@ export async function main(): Promise<void> {
 
   // --- Canopy read-side API routes ---
   registerCanopyReadRoutes(server, {
-    resolveProjectId: (req) => req.requestContext?.projectId ?? dataPaths.requestContext.projectId,
+    // No project context (e.g. a global-page request) → empty string, which
+    // matches no project row and yields the empty-canopy envelope. Never the
+    // daemon anchor (which has no project anyway).
+    resolveProjectId: (req) => req.requestContext?.projectId ?? '',
     resolveMachineId: (req) => req.requestContext?.machineId ?? getMachineId(),
     runCanopyMapTask: async ({ task, params }) => {
       // Mirror the dispatch shape used by /api/agent/run (see
@@ -1552,8 +1561,16 @@ export async function main(): Promise<void> {
       const { DEFAULT_AGENT_ID } = await import('../constants.js');
 
       const mycoConfig = liveConfig.current;
-      const projectRoot = dataPaths.requestContext.projectRoot;
       const requestContext = dataPaths.requestContext;
+      // Canopy regenerate is project-owned. The global daemon's anchor has no
+      // project (projectId null); dispatching under it would record a
+      // NULL-project agent run (RC-4). Refuse rather than mis-scope. A
+      // variant-less ad-hoc daemon bound to a real project still proceeds.
+      if (rowProjectIdFromRequestContext(requestContext) == null) {
+        return { skipped: true, reason: 'canopy-map regenerate requires a project-scoped daemon context' };
+      }
+      const projectId = requireProjectId(requestContext, 'canopy-map regenerate');
+      const projectRoot = requestContext.projectRoot;
       const built = await buildCanopyMapInstructionDetailed(params, projectRoot, mycoConfig);
 
       if (built.kind === 'skip') {
@@ -1573,7 +1590,7 @@ export async function main(): Promise<void> {
 
       // runAgent inserts the agent_runs row synchronously before its first
       // await. Capture the id before letting the promise run unsupervised.
-      const runId = getLatestRunId(DEFAULT_AGENT_ID, task, { kind: 'project', id: requestContext.projectId });
+      const runId = getLatestRunId(DEFAULT_AGENT_ID, task, { kind: 'project', id: projectId });
 
       // Fire-and-forget — caller already has the run id; we don't block
       // the HTTP response on the LLM round-trip. Errors are logged so
@@ -1596,8 +1613,14 @@ export async function main(): Promise<void> {
       const { DEFAULT_AGENT_ID } = await import('../constants.js');
 
       const mycoConfig = liveConfig.current;
-      const projectRoot = dataPaths.requestContext.projectRoot;
       const requestContext = dataPaths.requestContext;
+      // Project-owned run; refuse under the project-less daemon anchor rather
+      // than record a NULL-project run (RC-4).
+      if (rowProjectIdFromRequestContext(requestContext) == null) {
+        throw new Error('canopy-describe regenerate requires a project-scoped daemon context');
+      }
+      const projectId = requireProjectId(requestContext, 'canopy-describe regenerate');
+      const projectRoot = requestContext.projectRoot;
       const built = await buildTaskInstruction(
         task,
         params,
@@ -1620,7 +1643,7 @@ export async function main(): Promise<void> {
         logger,
       });
 
-      const runId = getLatestRunId(DEFAULT_AGENT_ID, task, { kind: 'project', id: requestContext.projectId });
+      const runId = getLatestRunId(DEFAULT_AGENT_ID, task, { kind: 'project', id: projectId });
 
       resultPromise.catch((err) => {
         logger.error(LOG_KINDS.AGENT_ERROR, 'canopy-describe redescribe threw', {

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -1952,12 +1952,21 @@ export async function main(): Promise<void> {
 
   // --- Search, activity feed, and embedding status ---
 
-  server.registerRoute('GET', '/api/search', createSearchHandler({
+  // Tenant-scoped read: an unresolved/synthesized (daemon-anchor) context is
+  // rejected with a typed 400 tenancy-violation rather than silently scoped to
+  // GLOBAL_SCOPE and returning an empty result set — the failure shape that
+  // looked like "no search results". The UI always carries caller tenancy
+  // (grove+project headers from the active selection); only genuinely
+  // context-less callers (e.g. a cwd=/ CLI launch) are rejected, which is the
+  // intended fail-loud. Reuses the same `tenantRoute` seam as every other
+  // tenant-scoped route.
+  const searchHandler = createSearchHandler({
     embeddingManager,
     resolveEmbeddingManager: (requestContext) => getEmbeddingRuntime(requestContext).manager,
     getTeamClient: (requestContext) => teamSync.getTeamClient(requestContext),
     machineId,
-  }));
+  });
+  server.registerRoute('GET', '/api/search', tenantRoute({ machineId, logger }, (req) => searchHandler(req)));
   server.registerRoute('GET', '/api/activity', handleGetFeed);
   const embeddingStatusHandler = createEmbeddingStatusHandler({
     resolveRequestRuntime: getRequestEmbeddingRuntime,

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -1532,8 +1532,11 @@ export async function main(): Promise<void> {
 
   // --- Canopy read-side API routes ---
   registerCanopyReadRoutes(server, {
-    // Empty string when no project context; matches no project row.
-    resolveProjectId: (req) => req.requestContext?.projectId ?? '',
+    resolveProjectId: (req) => {
+      const ctx = req.requestContext;
+      if (!ctx) throw new Error('canopy read requires a resolved request context');
+      return requireProjectId(ctx, 'canopy read');
+    },
     resolveMachineId: (req) => req.requestContext?.machineId ?? getMachineId(),
     runCanopyMapTask: async ({ task, params }) => {
       // Mirror the dispatch shape used by /api/agent/run (see

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -1966,15 +1966,16 @@ export async function main(): Promise<void> {
 
   // --- Search, activity feed, and embedding status ---
 
-  // tenantRoute rejects an unresolved/synthesized context with a 400
-  // tenancy-violation; only caller-supplied tenancy reaches the handler.
+  // Dual-mode read: a caller-supplied context scopes to its project; a
+  // context-less request scopes to GLOBAL_SCOPE and returns no project rows.
+  // Fail-loud on unresolved tenancy is enforced in the tools layer, not here.
   const searchHandler = createSearchHandler({
     embeddingManager,
     resolveEmbeddingManager: (requestContext) => getEmbeddingRuntime(requestContext).manager,
     getTeamClient: (requestContext) => teamSync.getTeamClient(requestContext),
     machineId,
   });
-  server.registerRoute('GET', '/api/search', tenantRoute({ machineId, logger }, (req) => searchHandler(req)));
+  server.registerRoute('GET', '/api/search', searchHandler);
   server.registerRoute('GET', '/api/activity', handleGetFeed);
   const embeddingStatusHandler = createEmbeddingStatusHandler({
     resolveRequestRuntime: getRequestEmbeddingRuntime,

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -884,7 +884,7 @@ export async function main(): Promise<void> {
   // project_id when present, else this daemon fallback (NULL for a groveless
   // anchor). logEntryToInsert maps a log entry to a row for both this live
   // path and buffer replay.
-  const daemonLogProjectId = rowProjectIdFromRequestContext(dataPaths.requestContext) ?? null;
+  const daemonLogProjectId = rowProjectIdFromRequestContext(dataPaths.requestContext);
   logger.setPersistFn((entry) => {
     insertLogEntry(logEntryToInsert(entry, daemonLogProjectId));
   });
@@ -1177,7 +1177,7 @@ export async function main(): Promise<void> {
     logger,
     liveConfig,
     vaultDir: bootstrapVaultDir,
-    projectId: rowProjectIdFromRequestContext(dataPaths.requestContext) ?? null,
+    projectId: rowProjectIdFromRequestContext(dataPaths.requestContext),
     machineId,
     planTags: symbiontPlanTags,
     planWatchConfig,
@@ -1560,11 +1560,10 @@ export async function main(): Promise<void> {
 
       const mycoConfig = liveConfig.current;
       const requestContext = dataPaths.requestContext;
-      // Skip when the daemon context has no resolved project.
-      if (rowProjectIdFromRequestContext(requestContext) == null) {
+      const projectId = rowProjectIdFromRequestContext(requestContext);
+      if (projectId == null) {
         return { skipped: true, reason: 'canopy-map regenerate requires a project-scoped daemon context' };
       }
-      const projectId = requireProjectId(requestContext, 'canopy-map regenerate');
       const projectRoot = requestContext.projectRoot;
       const built = await buildCanopyMapInstructionDetailed(params, projectRoot, mycoConfig);
 
@@ -1609,11 +1608,10 @@ export async function main(): Promise<void> {
 
       const mycoConfig = liveConfig.current;
       const requestContext = dataPaths.requestContext;
-      // Fail when the daemon context has no resolved project.
-      if (rowProjectIdFromRequestContext(requestContext) == null) {
+      const projectId = rowProjectIdFromRequestContext(requestContext);
+      if (projectId == null) {
         throw new Error('canopy-describe regenerate requires a project-scoped daemon context');
       }
-      const projectId = requireProjectId(requestContext, 'canopy-describe regenerate');
       const projectRoot = requestContext.projectRoot;
       const built = await buildTaskInstruction(
         task,

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -606,8 +606,7 @@ export async function main(): Promise<void> {
       ...process.env,
       MYCO_MACHINE_ID: machineId,
     },
-    // Phantom boot = the global daemon's project-less anchor. Use the
-    // daemon-global context (projectId null), never a fabricated project id.
+    // Phantom boot uses the project-less daemon-global context (projectId null).
     { daemonGlobal: bootstrapIsPhantom },
   );
 
@@ -881,12 +880,10 @@ export async function main(): Promise<void> {
   // --- Team context ---
   initTeamContext(machineId);
 
-  // Wire logger to SQLite persistence. Daemon-owned log rows belong to the
-  // NULL / GLOBAL_SCOPE partition: the groveless daemon anchor resolves to
-  // NULL here (never the phantom `_unbound-bootstrap` project id). A real
-  // project id only rides in when an entry carries an explicit one or the
-  // daemon is grove-bound. `logEntryToInsert` is the single seam both this
-  // live path and the buffer-replay path resolve project_id through.
+  // Wire logger to SQLite persistence. Log rows take the entry's explicit
+  // project_id when present, else this daemon fallback (NULL for a groveless
+  // anchor). logEntryToInsert maps a log entry to a row for both this live
+  // path and buffer replay.
   const daemonLogProjectId = rowProjectIdFromRequestContext(dataPaths.requestContext) ?? null;
   logger.setPersistFn((entry) => {
     insertLogEntry(logEntryToInsert(entry, daemonLogProjectId));
@@ -1535,9 +1532,7 @@ export async function main(): Promise<void> {
 
   // --- Canopy read-side API routes ---
   registerCanopyReadRoutes(server, {
-    // No project context (e.g. a global-page request) → empty string, which
-    // matches no project row and yields the empty-canopy envelope. Never the
-    // daemon anchor (which has no project anyway).
+    // Empty string when no project context; matches no project row.
     resolveProjectId: (req) => req.requestContext?.projectId ?? '',
     resolveMachineId: (req) => req.requestContext?.machineId ?? getMachineId(),
     runCanopyMapTask: async ({ task, params }) => {
@@ -1562,10 +1557,7 @@ export async function main(): Promise<void> {
 
       const mycoConfig = liveConfig.current;
       const requestContext = dataPaths.requestContext;
-      // Canopy regenerate is project-owned. The global daemon's anchor has no
-      // project (projectId null); dispatching under it would record a
-      // NULL-project agent run (RC-4). Refuse rather than mis-scope. A
-      // variant-less ad-hoc daemon bound to a real project still proceeds.
+      // Skip when the daemon context has no resolved project.
       if (rowProjectIdFromRequestContext(requestContext) == null) {
         return { skipped: true, reason: 'canopy-map regenerate requires a project-scoped daemon context' };
       }
@@ -1614,8 +1606,7 @@ export async function main(): Promise<void> {
 
       const mycoConfig = liveConfig.current;
       const requestContext = dataPaths.requestContext;
-      // Project-owned run; refuse under the project-less daemon anchor rather
-      // than record a NULL-project run (RC-4).
+      // Fail when the daemon context has no resolved project.
       if (rowProjectIdFromRequestContext(requestContext) == null) {
         throw new Error('canopy-describe regenerate requires a project-scoped daemon context');
       }
@@ -1975,14 +1966,8 @@ export async function main(): Promise<void> {
 
   // --- Search, activity feed, and embedding status ---
 
-  // Tenant-scoped read: an unresolved/synthesized (daemon-anchor) context is
-  // rejected with a typed 400 tenancy-violation rather than silently scoped to
-  // GLOBAL_SCOPE and returning an empty result set — the failure shape that
-  // looked like "no search results". The UI always carries caller tenancy
-  // (grove+project headers from the active selection); only genuinely
-  // context-less callers (e.g. a cwd=/ CLI launch) are rejected, which is the
-  // intended fail-loud. Reuses the same `tenantRoute` seam as every other
-  // tenant-scoped route.
+  // tenantRoute rejects an unresolved/synthesized context with a 400
+  // tenancy-violation; only caller-supplied tenancy reaches the handler.
   const searchHandler = createSearchHandler({
     embeddingManager,
     resolveEmbeddingManager: (requestContext) => getEmbeddingRuntime(requestContext).manager,

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -159,6 +159,7 @@ import { createAgentRunHandlers } from './api/agent-runs.js';
 import { createDigestRevisionHandlers } from './api/digest-revisions.js';
 import { createAttachmentHandler } from './api/attachments.js';
 import { reconcileLogBuffer } from './log-reconcile.js';
+import { logEntryToInsert } from './log-entry-insert.js';
 import { markRunningRunsInterrupted } from '../db/queries/runs.js';
 import {
   POWER_IDLE_THRESHOLD_MS,
@@ -194,7 +195,7 @@ import { createLiveReconcile } from './live-reconcile.js';
 import { createConfigReactionRegistry, computeTouchedPaths, loadReactionContext } from './config-reactions/index.js';
 import { createPlanWatchReaction } from './plan-watch-reaction.js';
 import { resolveDaemonDataPaths, resolveVectorsPathForRequestContext } from './data-paths.js';
-import { assertGroveProjectId, type GroveProjectId } from '../grove/ids.js';
+import { type GroveProjectId } from '../grove/ids.js';
 import { rowProjectIdFromRequestContext, type MycoRequestContext } from '../grove/request-context.js';
 import {
   daemonStateMtimeMs,
@@ -474,7 +475,7 @@ async function waitForExit(
 // Main
 // ---------------------------------------------------------------------------
 
-function loggerForProject(logger: Logger, projectId: GroveProjectId): Logger {
+function loggerForProject(logger: Logger, projectId: GroveProjectId | null): Logger {
   const addProject = (data?: Record<string, unknown>) => ({
     ...data,
     project_id: typeof data?.project_id === 'string' ? data.project_id : projectId,
@@ -874,26 +875,15 @@ export async function main(): Promise<void> {
   // --- Team context ---
   initTeamContext(machineId);
 
-  // Wire logger to SQLite persistence. Every log row is scoped to the
-  // daemon's resolved Grove project id — there is no NULL fallback.
-  const daemonProjectId = dataPaths.requestContext.projectId;
+  // Wire logger to SQLite persistence. Daemon-owned log rows belong to the
+  // NULL / GLOBAL_SCOPE partition: the groveless daemon anchor resolves to
+  // NULL here (never the phantom `_unbound-bootstrap` project id). A real
+  // project id only rides in when an entry carries an explicit one or the
+  // daemon is grove-bound. `logEntryToInsert` is the single seam both this
+  // live path and the buffer-replay path resolve project_id through.
+  const daemonLogProjectId = rowProjectIdFromRequestContext(dataPaths.requestContext) ?? null;
   logger.setPersistFn((entry) => {
-    const { timestamp, level, kind, component, message, ...rest } = entry;
-    const {
-      project_id: entryProjectId,
-      session_id: entrySessionId,
-      ...data
-    } = rest;
-    insertLogEntry({
-      timestamp,
-      level,
-      kind,
-      component,
-      message,
-      data: Object.keys(data).length > 0 ? JSON.stringify(data) : null,
-      session_id: (entrySessionId as string | undefined) ?? null,
-      project_id: typeof entryProjectId === 'string' ? assertGroveProjectId(entryProjectId) : daemonProjectId,
-    });
+    insertLogEntry(logEntryToInsert(entry, daemonLogProjectId));
   });
 
   // Reconcile log entries missed while daemon was down
@@ -903,7 +893,7 @@ export async function main(): Promise<void> {
       requestContext: dataPaths.requestContext,
       env: process.env,
     });
-    const replayedCount = reconcileLogBuffer(logDir, lastLogTimestamp, daemonProjectId);
+    const replayedCount = reconcileLogBuffer(logDir, lastLogTimestamp, daemonLogProjectId);
     if (replayedCount > 0) {
       logger.info(LOG_KINDS.DAEMON_RECONCILE, `Replayed ${replayedCount} log entries from buffer`, { replayed: replayedCount });
     }
@@ -920,7 +910,7 @@ export async function main(): Promise<void> {
   const databaseManagerForRequest = (req: RouteRequest) => new DatabaseMaintenanceManager(
     req.requestContext?.databasePath ?? dataPaths.databasePath,
     req.requestContext?.projectVaultDir ?? bootstrapVaultDir,
-    loggerForProject(logger, req.requestContext?.projectId ?? dataPaths.requestContext.projectId),
+    loggerForProject(logger, rowProjectIdFromRequestContext(req.requestContext) ?? daemonLogProjectId),
   );
   const runtimeCache = new GroveRuntimeCache();
   const databaseHandlers = createDatabaseMaintenanceHandlers({

--- a/packages/myco/src/daemon/server.ts
+++ b/packages/myco/src/daemon/server.ts
@@ -327,10 +327,11 @@ export class DaemonServer {
         // `projects.toml`; while set, every writer for that project must
         // be refused. Reads stay open so the UI can still surface "this
         // project is paused (reason)".
-        if (isWriteMethod(req.method) && requestContext.groveId) {
-          const paused = isProjectPaused(requestContext.projectId);
+        if (isWriteMethod(req.method) && requestContext.groveId && requestContext.projectId) {
+          const projectId = requestContext.projectId;
+          const paused = isProjectPaused(projectId);
           if (paused.paused) {
-            const response = pausedErrorResponse(requestContext.projectId, paused);
+            const response = pausedErrorResponse(projectId, paused);
             res.writeHead(response.status, { 'Content-Type': 'application/json', ...versionHeader });
             res.end(JSON.stringify(response.body));
             return;

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -137,7 +137,11 @@ export function createStopProcessor(deps: StopProcessorDeps): {
   handleStopRoute: RouteHandler;
   clearSession: (sessionId: string) => void;
   getActiveProcessing: () => Promise<void> | null;
-  triggerTitleSummary: (sessionId: string) => Promise<void>;
+  triggerTitleSummary: (
+    sessionId: string,
+    requestContext: MycoRequestContext | undefined,
+    trigger?: { evaluateBoundary: true; promptOrigin: PromptBatchOrigin },
+  ) => Promise<void>;
 } {
   const {
     registry,
@@ -187,9 +191,14 @@ export function createStopProcessor(deps: StopProcessorDeps): {
 
   const triggerTitleSummary = (
     sessionId: string,
+    requestContext: MycoRequestContext | undefined,
     trigger?: { evaluateBoundary: true; promptOrigin: PromptBatchOrigin },
   ) =>
-    sharedTriggerTitleSummary(sessionId, { vaultDir, resolveEmbeddingManager, liveConfig, logger }, trigger);
+    sharedTriggerTitleSummary(
+      sessionId,
+      { vaultDir, resolveEmbeddingManager, liveConfig, logger, requestContext },
+      trigger,
+    );
 
   function cleanupInvalidCapturedSession(sessionId: string): boolean {
     registry.unregister(sessionId);
@@ -229,6 +238,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     requestFilesystemRoot: string,
     requestMachineId: string,
     requestProductionRef: string | null,
+    requestContext: MycoRequestContext | undefined,
     hookTranscriptPath?: string,
     lastAssistantMessage?: string,
     phases: readonly ('response' | 'transcript')[] = ['response', 'transcript'],
@@ -570,7 +580,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     // Trigger title/summary if the session still needs one. Runs on
     // response phase for early visibility; idempotent if called again.
     if (runResponsePhase && !hasTitle) {
-      triggerTitleSummary(sessionId);
+      triggerTitleSummary(sessionId, requestContext);
     }
 
     // Write images to attachments — decoupled from transcript turn indices.
@@ -774,6 +784,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
       requestFilesystemRoot,
       requestMachineId,
       requestProductionRef,
+      req.requestContext,
       normalizedTranscriptPath,
       normalizedAssistantMessage,
       phases,

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -235,8 +235,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     sessionId: string,
     user: string | undefined,
     sessionMeta: RegisteredSession | undefined,
-    requestProjectId: GroveProjectId | null,
-    requestRowProjectId: string | null,
+    requestRowProjectId: GroveProjectId | null,
     requestProjectRoot: string,
     requestFilesystemRoot: string,
     requestMachineId: string,
@@ -458,8 +457,8 @@ export function createStopProcessor(deps: StopProcessorDeps): {
             .map((t) => [t.prompt ?? '', t.aiResponse ?? ''].join(' '))
             .join('\n');
         }
-        if (transcriptText && requestProjectId) {
-          detectSkillUsage(sessionId, transcriptText, requestProjectId);
+        if (transcriptText && requestRowProjectId) {
+          detectSkillUsage(sessionId, transcriptText, requestRowProjectId);
         }
       } catch {
         // Best-effort — don't block reconciliation
@@ -616,14 +615,14 @@ export function createStopProcessor(deps: StopProcessorDeps): {
         } catch { /* fallback to index-based */ }
       }
 
-      if (requestProjectId) {
+      if (requestRowProjectId) {
         captureBatchImages({
           sessionId,
           promptBatchId: resolvedBatchId,
           promptNumber: resolvedPromptNumber,
           images: turn.images,
           logger,
-          projectId: requestProjectId,
+          projectId: requestRowProjectId,
         });
       }
     }
@@ -672,9 +671,11 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     const phases = explicitPhases && explicitPhases.length > 0
       ? explicitPhases
       : (['response', 'transcript'] as const);
-    const requestProjectId = req.requestContext?.projectId ?? defaultProjectId;
+    // Single project scope for the whole stop cycle: a context-less event
+    // (no grove) falls back to the daemon default; otherwise the Grove-gated
+    // row scope drives session, batch, and capture writes alike.
     const requestScope = rowProjectIdFromRequestContext(req.requestContext);
-    const requestRowProjectId = requestScope === undefined ? requestProjectId : requestScope;
+    const requestRowProjectId = requestScope === undefined ? defaultProjectId : requestScope;
     const requestProjectRoot = req.requestContext?.projectRoot ?? resolveProjectRoot(vaultDir);
     const requestFilesystemRoot = req.requestContext
       ? filesystemRootFromRequestContext(req.requestContext)
@@ -783,7 +784,6 @@ export function createStopProcessor(deps: StopProcessorDeps): {
       sessionId,
       user,
       sessionMeta,
-      requestProjectId,
       requestRowProjectId,
       requestProjectRoot,
       requestFilesystemRoot,

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -77,11 +77,8 @@ export interface StopProcessorDeps {
   liveConfig: { current: MycoConfig };
   vaultDir: string;
   /**
-   * Daemon-resolved Grove project id used as the fallback when a stop event
-   * carries no caller project. NULL for the global daemon's project-less
-   * anchor (real stop events always carry a grove-bound context, so this
-   * fallback is a dead-in-practice safety net — and NULL is safer than the
-   * old phantom id it replaced).
+   * Fallback Grove project id used when a stop event carries no caller
+   * project. NULL for the global daemon's project-less anchor.
    */
   projectId: GroveProjectId | null;
   machineId?: string;

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -76,8 +76,14 @@ export interface StopProcessorDeps {
   logger: DaemonLogger;
   liveConfig: { current: MycoConfig };
   vaultDir: string;
-  /** Daemon-resolved Grove project id used for every per-session insert. */
-  projectId: GroveProjectId;
+  /**
+   * Daemon-resolved Grove project id used as the fallback when a stop event
+   * carries no caller project. NULL for the global daemon's project-less
+   * anchor (real stop events always carry a grove-bound context, so this
+   * fallback is a dead-in-practice safety net — and NULL is safer than the
+   * old phantom id it replaced).
+   */
+  projectId: GroveProjectId | null;
   machineId?: string;
   /** Plan tag names to extract from transcript responses. Merged from all symbiont manifests. */
   planTags: string[];
@@ -232,7 +238,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     sessionId: string,
     user: string | undefined,
     sessionMeta: RegisteredSession | undefined,
-    requestProjectId: GroveProjectId,
+    requestProjectId: GroveProjectId | null,
     requestRowProjectId: string | null,
     requestProjectRoot: string,
     requestFilesystemRoot: string,
@@ -455,7 +461,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
             .map((t) => [t.prompt ?? '', t.aiResponse ?? ''].join(' '))
             .join('\n');
         }
-        if (transcriptText) {
+        if (transcriptText && requestProjectId) {
           detectSkillUsage(sessionId, transcriptText, requestProjectId);
         }
       } catch {
@@ -613,14 +619,16 @@ export function createStopProcessor(deps: StopProcessorDeps): {
         } catch { /* fallback to index-based */ }
       }
 
-      captureBatchImages({
-        sessionId,
-        promptBatchId: resolvedBatchId,
-        promptNumber: resolvedPromptNumber,
-        images: turn.images,
-        logger,
-        projectId: requestProjectId,
-      });
+      if (requestProjectId) {
+        captureBatchImages({
+          sessionId,
+          promptBatchId: resolvedBatchId,
+          promptNumber: resolvedPromptNumber,
+          images: turn.images,
+          logger,
+          projectId: requestProjectId,
+        });
+      }
     }
 
     // Final-state markers run on transcript phase only. For single-phase

--- a/packages/myco/src/daemon/trigger-title-summary.ts
+++ b/packages/myco/src/daemon/trigger-title-summary.ts
@@ -69,22 +69,10 @@ export async function triggerTitleSummary(
 ): Promise<void> {
   const { vaultDir, resolveEmbeddingManager, liveConfig, logger } = deps;
 
-  // Resolve the request context BEFORE the config gates so the gates read the
-  // REQUEST grove's merged config — not the daemon's bootstrap-home liveConfig.
-  // `summary_batch_interval` / `event_tasks_enabled` are grove-tier (PR #394),
-  // so gating on liveConfig would gate a tenant op on the wrong grove.
-  //
-  // The caller (Stop pipeline, /events boundary, manual Complete-Session)
-  // threads its own grove-bound request context. We deliberately do NOT fall
-  // back to deriving a context from `vaultDir` here: the daemon's vaultDir is
-  // the bootstrap anchor, whose phantom `project.toml` yields a GROVELESS
-  // context (rowProjectIdFromRequestContext === null). Dispatching under it
-  // recorded the title-summary agent run with project_id NULL (RC-4) — a
-  // project-owned run mis-attributed to no project. We refuse such runs below.
+  // Config gates are grove-tier, so resolve config from the caller's
+  // grove-bound context. resolveTenantConfig falls back to liveConfig when no
+  // tenant context resolves.
   const requestContext = deps.requestContext;
-
-  // Legacy non-Grove vaults (requestContext undefined) fall back to liveConfig;
-  // resolveTenantConfig returns the fallback when no tenant context resolves.
   const config = resolveTenantConfig(requestContext, liveConfig.current, { logger });
 
   if (config.agent.summary_batch_interval <= 0) return;
@@ -96,12 +84,9 @@ export async function triggerTitleSummary(
     if (humanCount <= 0 || humanCount % config.agent.summary_batch_interval !== 0) return;
   }
 
-  // Refuse to record a project-owned run we cannot attribute to a real
-  // project. A title-summary run is inherently project-scoped; recording it
-  // under project_id NULL (the groveless/anchor shape) corrupts per-project
-  // run history and cost accounting. Resolve a real project or skip loudly —
-  // never write NULL. (rowProjectIdFromRequestContext is null/undefined for an
-  // absent or groveless context, the real project id for a grove-bound one.)
+  // Skip when the context has no resolved project. rowProjectIdFromRequestContext
+  // is null/undefined for an absent or groveless context, the project id for a
+  // grove-bound one.
   if (rowProjectIdFromRequestContext(requestContext) == null) {
     logger.warn(LOG_KINDS.AGENT_ERROR, 'Skipping title-summary: unresolved project tenancy for session', {
       session_id: sessionId,

--- a/packages/myco/src/daemon/trigger-title-summary.ts
+++ b/packages/myco/src/daemon/trigger-title-summary.ts
@@ -12,7 +12,7 @@ import type { DaemonLogger } from './logger.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import {
-  tryResolveRequestContextForVault,
+  rowProjectIdFromRequestContext,
   type MycoRequestContext,
 } from '@myco/grove/request-context.js';
 import { resolveTenantConfig } from './request-config.js';
@@ -74,20 +74,14 @@ export async function triggerTitleSummary(
   // `summary_batch_interval` / `event_tasks_enabled` are grove-tier (PR #394),
   // so gating on liveConfig would gate a tenant op on the wrong grove.
   //
-  // runAgent calls projectScopeFromRequestContext, which throws when no
-  // context is supplied. The Stop pipeline used to pass no context here
-  // and every title-summary task failed with that exact error. Supply the
-  // caller's context if we got one; otherwise resolve from vaultDir with
-  // the sessionId as an override so the task gets project-scoped reads.
-  let requestContext = deps.requestContext;
-  if (!requestContext) {
-    const resolved = tryResolveRequestContextForVault(vaultDir, { sessionId });
-    if (resolved.kind === 'grove') {
-      requestContext = resolved.context;
-    }
-    // Legacy non-Grove vaults fall through with requestContext undefined;
-    // runAgent will surface the underlying error via its own try/catch.
-  }
+  // The caller (Stop pipeline, /events boundary, manual Complete-Session)
+  // threads its own grove-bound request context. We deliberately do NOT fall
+  // back to deriving a context from `vaultDir` here: the daemon's vaultDir is
+  // the bootstrap anchor, whose phantom `project.toml` yields a GROVELESS
+  // context (rowProjectIdFromRequestContext === null). Dispatching under it
+  // recorded the title-summary agent run with project_id NULL (RC-4) — a
+  // project-owned run mis-attributed to no project. We refuse such runs below.
+  const requestContext = deps.requestContext;
 
   // Legacy non-Grove vaults (requestContext undefined) fall back to liveConfig;
   // resolveTenantConfig returns the fallback when no tenant context resolves.
@@ -100,6 +94,19 @@ export async function triggerTitleSummary(
     if (trigger.promptOrigin !== PROMPT_BATCH_ORIGIN.HUMAN) return;
     const humanCount = countBatchesBySession(sessionId, { origins: [PROMPT_BATCH_ORIGIN.HUMAN] });
     if (humanCount <= 0 || humanCount % config.agent.summary_batch_interval !== 0) return;
+  }
+
+  // Refuse to record a project-owned run we cannot attribute to a real
+  // project. A title-summary run is inherently project-scoped; recording it
+  // under project_id NULL (the groveless/anchor shape) corrupts per-project
+  // run history and cost accounting. Resolve a real project or skip loudly —
+  // never write NULL. (rowProjectIdFromRequestContext is null/undefined for an
+  // absent or groveless context, the real project id for a grove-bound one.)
+  if (rowProjectIdFromRequestContext(requestContext) == null) {
+    logger.warn(LOG_KINDS.AGENT_ERROR, 'Skipping title-summary: unresolved project tenancy for session', {
+      session_id: sessionId,
+    });
+    return;
   }
 
   try {

--- a/packages/myco/src/db/queries/logs.ts
+++ b/packages/myco/src/db/queries/logs.ts
@@ -35,11 +35,7 @@ export interface LogEntryInsert {
   session_id: string | null;
   /**
    * Branded Grove project id this log line belongs to, or NULL for a
-   * daemon-owned row (the `project_id IS NULL` / `GLOBAL_SCOPE` partition —
-   * startup/maintenance logs from the groveless daemon anchor). A real
-   * project id only rides in when the entry carries an explicit one or the
-   * daemon is grove-bound. Passing a bare `string` is still a type error by
-   * design; the phantom bootstrap id must never be stamped here.
+   * daemon-owned row. Passing a bare `string` is a type error.
    */
   project_id: GroveProjectId | null;
 }

--- a/packages/myco/src/db/queries/logs.ts
+++ b/packages/myco/src/db/queries/logs.ts
@@ -34,11 +34,14 @@ export interface LogEntryInsert {
   data: string | null;
   session_id: string | null;
   /**
-   * Branded Grove project id this log line belongs to. Required so the
-   * row joins correctly under Grove's per-project scope; passing a bare
-   * `string` here is a type error by design.
+   * Branded Grove project id this log line belongs to, or NULL for a
+   * daemon-owned row (the `project_id IS NULL` / `GLOBAL_SCOPE` partition —
+   * startup/maintenance logs from the groveless daemon anchor). A real
+   * project id only rides in when the entry carries an explicit one or the
+   * daemon is grove-bound. Passing a bare `string` is still a type error by
+   * design; the phantom bootstrap id must never be stamped here.
    */
-  project_id: GroveProjectId;
+  project_id: GroveProjectId | null;
 }
 
 /** Row shape returned from log_entries queries (all columns). */

--- a/packages/myco/src/grove/request-context.ts
+++ b/packages/myco/src/grove/request-context.ts
@@ -163,7 +163,16 @@ export interface MycoRequestContext {
    * registration) stay on `projectRoot`.
    */
   callerRoot: string | null;
-  projectId: GroveProjectId;
+  /**
+   * The bound Grove project id, or NULL for the daemon-global anchor — the
+   * global multi-tenant daemon has no "current project" (it serves every
+   * tenant per-request), so its own context carries no project. Every
+   * caller/registered context has a real id; only the daemon's startup anchor
+   * is null. Readers that need row tenancy go through
+   * `rowProjectIdFromRequestContext` (null for the anchor); direct readers
+   * must handle the null anchor explicitly rather than stamping a value.
+   */
+  projectId: GroveProjectId | null;
   groveId: string | null;
   machineId: string;
   sessionId: string | null;
@@ -600,6 +609,55 @@ function tryBuildVaultFallback(
 }
 
 /**
+ * Build the daemon-global request context for the global multi-tenant daemon's
+ * startup anchor. The daemon has no "current project" — it serves every tenant
+ * per request — so its own context carries NO project tenancy: `projectId` and
+ * `groveId` are both null. `rowProjectIdFromRequestContext` resolves this to
+ * NULL (daemon-owned) and `projectScopeFromRequestContext` to GLOBAL_SCOPE.
+ *
+ * This replaces the old phantom `_unbound-bootstrap` `project.toml` id, which
+ * fabricated a real-looking `proj_<hex>` that could masquerade as a tenant in
+ * the data plane. There is no fabricated project id anymore.
+ */
+export function daemonGlobalRequestContext(
+  vaultDir: string,
+  overrides: { machineId?: string; sessionId?: string | null } = {},
+): MycoRequestContext {
+  return {
+    projectRoot: resolveProjectRoot(vaultDir),
+    callerRoot: null,
+    projectId: null,
+    groveId: null,
+    machineId: overrides.machineId ?? getMachineId(),
+    sessionId: overrides.sessionId ?? null,
+    projectVaultDir: vaultDir,
+    databasePath: vaultDbPath(vaultDir),
+    source: 'legacy-vault',
+    tenancySource: 'synthesized',
+  };
+}
+
+/**
+ * Assert that a context carries a real Grove project id and return it. Use at
+ * sites only ever reached by caller/registered (grove-bound) contexts — an
+ * agent run, a tenant-route handler — where a null project means the
+ * daemon-global anchor leaked somewhere it must not. Throws rather than
+ * silently stamping a wrong or absent project.
+ */
+export function requireProjectId(
+  context: MycoRequestContext,
+  what = 'operation',
+): GroveProjectId {
+  if (context.projectId == null) {
+    throw new Error(
+      `${what} requires a resolved Grove project, but the request context has none `
+      + '(the daemon-global anchor must not reach this path).',
+    );
+  }
+  return context.projectId;
+}
+
+/**
  * Translate a transport-level request context into the project_id predicate
  * expected by first-generation Grove-aware row helpers.
  *
@@ -642,7 +700,7 @@ export function projectScopeFromRequestContext(
   // rows to an unauthorized request. Only a caller-asserted, Grove-bound
   // context may bind to a specific project scope; everything else resolves to
   // GLOBAL_SCOPE (`project_id IS NULL`), which returns zero cross-project rows.
-  return isProjectScopedTenancy(context) && context.groveId
+  return isProjectScopedTenancy(context) && context.groveId && context.projectId
     ? projectScope(context.projectId)
     : GLOBAL_SCOPE;
 }

--- a/packages/myco/src/grove/request-context.ts
+++ b/packages/myco/src/grove/request-context.ts
@@ -163,15 +163,7 @@ export interface MycoRequestContext {
    * registration) stay on `projectRoot`.
    */
   callerRoot: string | null;
-  /**
-   * The bound Grove project id, or NULL for the daemon-global anchor — the
-   * global multi-tenant daemon has no "current project" (it serves every
-   * tenant per-request), so its own context carries no project. Every
-   * caller/registered context has a real id; only the daemon's startup anchor
-   * is null. Readers that need row tenancy go through
-   * `rowProjectIdFromRequestContext` (null for the anchor); direct readers
-   * must handle the null anchor explicitly rather than stamping a value.
-   */
+  /** The bound Grove project id, or NULL for the project-less daemon anchor. */
   projectId: GroveProjectId | null;
   groveId: string | null;
   machineId: string;
@@ -275,10 +267,7 @@ export function requestContextFromHttpHeaders(
   enforceContextSwitchAuth(headers, options.expectedAuthToken ?? null);
 
   const callerRoot = normalizeCallerRoot(readHeader(headers, REQUEST_CONTEXT_HEADERS.callerRoot));
-  // Daemon path: tolerate the project-less anchor vault (no manifest) by
-  // resolving the daemon-global context rather than throwing — context-less
-  // requests (notification banner) must succeed at GLOBAL_SCOPE. Caller
-  // headers below still override to a real project.
+  // Base context; caller headers below override to a real project.
   const { context: fallback, manifest } = buildVaultFallbackOrGlobal(fallbackVaultDir, { callerRoot });
   const explicit: ExplicitContextInput = {
     projectRoot: readHeader(headers, REQUEST_CONTEXT_HEADERS.projectRoot),
@@ -333,8 +322,7 @@ export function requestContextFromTenancyIds(
   },
 ): MycoRequestContext {
   enforceUrlTenancyAuth(options.headers, options.expectedAuthToken);
-  // Daemon path: tolerate the project-less anchor vault; the URL (Grove,
-  // project) ids below override to the real project.
+  // Base context; the URL (Grove, project) ids below override to the project.
   const { context: fallback } = buildVaultFallbackOrGlobal(fallbackVaultDir);
   const explicit: ExplicitContextInput = {
     groveId: ids.groveId,
@@ -574,14 +562,10 @@ function buildVaultFallback(
 }
 
 /**
- * Daemon per-request variant of `buildVaultFallback`: when the fallback vault
- * is the project-less `_unbound-bootstrap` anchor (no manifest), return the
- * daemon-global context instead of throwing. The global daemon's own vault has
- * no project, so a context-less request (e.g. the notification banner) must
- * resolve to GLOBAL_SCOPE, not 500. Real project vaults still resolve to their
- * project. Used only by the daemon transport paths (header / URL-param); the
- * CLI/env path keeps the throwing `buildVaultFallback` so an unregistered
- * project still gets the friendly "commit Myco config" error.
+ * Like `buildVaultFallback` but returns the daemon-global context instead of
+ * throwing when the vault has no manifest. Resolves a real project vault to its
+ * project and the project-less anchor vault to the daemon-global context. Used
+ * by the daemon transport paths (header / URL-param).
  */
 function buildVaultFallbackOrGlobal(
   vaultDir: string,
@@ -640,15 +624,10 @@ function tryBuildVaultFallback(
 }
 
 /**
- * Build the daemon-global request context for the global multi-tenant daemon's
- * startup anchor. The daemon has no "current project" — it serves every tenant
- * per request — so its own context carries NO project tenancy: `projectId` and
- * `groveId` are both null. `rowProjectIdFromRequestContext` resolves this to
- * NULL (daemon-owned) and `projectScopeFromRequestContext` to GLOBAL_SCOPE.
- *
- * This replaces the old phantom `_unbound-bootstrap` `project.toml` id, which
- * fabricated a real-looking `proj_<hex>` that could masquerade as a tenant in
- * the data plane. There is no fabricated project id anymore.
+ * Builds the project-less request context for the global daemon's startup
+ * anchor: `projectId` and `groveId` are both null, so
+ * `rowProjectIdFromRequestContext` resolves to NULL and
+ * `projectScopeFromRequestContext` to GLOBAL_SCOPE.
  */
 export function daemonGlobalRequestContext(
   vaultDir: string,
@@ -669,11 +648,9 @@ export function daemonGlobalRequestContext(
 }
 
 /**
- * Assert that a context carries a real Grove project id and return it. Use at
- * sites only ever reached by caller/registered (grove-bound) contexts — an
- * agent run, a tenant-route handler — where a null project means the
- * daemon-global anchor leaked somewhere it must not. Throws rather than
- * silently stamping a wrong or absent project.
+ * Returns the context's Grove project id, or throws when it is null. Use at
+ * sites reached only by caller/registered (grove-bound) contexts — an agent
+ * run, a tenant-route handler.
  */
 export function requireProjectId(
   context: MycoRequestContext,

--- a/packages/myco/src/grove/request-context.ts
+++ b/packages/myco/src/grove/request-context.ts
@@ -583,6 +583,32 @@ function buildVaultFallbackOrGlobal(
 }
 
 /**
+ * Build a request context synthesized from a daemon-owned vault directory
+ * (not caller-supplied tenancy). `projectId` is the vault's manifest project
+ * for a Grove-bound vault, or null for the global daemon's project-less
+ * startup anchor. Explicit-header/env branches override `tenancySource` to
+ * 'caller'.
+ */
+function synthesizedVaultContext(
+  vaultDir: string,
+  projectId: GroveProjectId | null,
+  overrides: { machineId?: string; sessionId?: string | null; callerRoot?: string | null } = {},
+): MycoRequestContext {
+  return {
+    projectRoot: resolveProjectRoot(vaultDir),
+    callerRoot: overrides.callerRoot ?? null,
+    projectId,
+    groveId: null,
+    machineId: overrides.machineId ?? getMachineId(),
+    sessionId: overrides.sessionId ?? null,
+    projectVaultDir: vaultDir,
+    databasePath: vaultDbPath(vaultDir),
+    source: 'legacy-vault',
+    tenancySource: 'synthesized',
+  };
+}
+
+/**
  * Internal: soft-fail variant of `buildVaultFallback`. Returns a
  * discriminated union so call sites can branch on legacy state
  * instead of catching exceptions. `kind: 'grove'` carries the
@@ -602,23 +628,9 @@ function tryBuildVaultFallback(
       reason: `No Grove project id available for vault ${vaultDir}. Open the dashboard and commit Myco config to this project from the Symbionts page.`,
     };
   }
-  const projectRoot = resolveProjectRoot(vaultDir);
   return {
     kind: 'grove',
-    context: {
-      projectRoot,
-      callerRoot: overrides.callerRoot ?? null,
-      projectId: assertGroveProjectId(manifest.project.id),
-      groveId: null,
-      machineId: overrides.machineId ?? getMachineId(),
-      sessionId: overrides.sessionId ?? null,
-      projectVaultDir: vaultDir,
-      databasePath: vaultDbPath(vaultDir),
-      source: 'legacy-vault',
-      // Built from the daemon's fallback vault, not caller-supplied
-      // tenancy. Explicit-header/env branches override this to 'caller'.
-      tenancySource: 'synthesized',
-    },
+    context: synthesizedVaultContext(vaultDir, assertGroveProjectId(manifest.project.id), overrides),
     manifest,
   };
 }
@@ -633,18 +645,7 @@ export function daemonGlobalRequestContext(
   vaultDir: string,
   overrides: { machineId?: string; sessionId?: string | null } = {},
 ): MycoRequestContext {
-  return {
-    projectRoot: resolveProjectRoot(vaultDir),
-    callerRoot: null,
-    projectId: null,
-    groveId: null,
-    machineId: overrides.machineId ?? getMachineId(),
-    sessionId: overrides.sessionId ?? null,
-    projectVaultDir: vaultDir,
-    databasePath: vaultDbPath(vaultDir),
-    source: 'legacy-vault',
-    tenancySource: 'synthesized',
-  };
+  return synthesizedVaultContext(vaultDir, null, overrides);
 }
 
 /**
@@ -674,6 +675,12 @@ export function requireProjectId(
  * NULL rows because pre-Grove vault data has no project_id. Once a Grove id
  * is present, the resolved project id becomes mandatory row scope.
  */
+export function rowProjectIdFromRequestContext(
+  context: MycoRequestContext,
+): GroveProjectId | null;
+export function rowProjectIdFromRequestContext(
+  context: MycoRequestContext | undefined,
+): GroveProjectId | null | undefined;
 export function rowProjectIdFromRequestContext(
   context?: MycoRequestContext,
 ): GroveProjectId | null | undefined {

--- a/packages/myco/src/grove/request-context.ts
+++ b/packages/myco/src/grove/request-context.ts
@@ -275,7 +275,11 @@ export function requestContextFromHttpHeaders(
   enforceContextSwitchAuth(headers, options.expectedAuthToken ?? null);
 
   const callerRoot = normalizeCallerRoot(readHeader(headers, REQUEST_CONTEXT_HEADERS.callerRoot));
-  const { context: fallback, manifest } = buildVaultFallback(fallbackVaultDir, { callerRoot });
+  // Daemon path: tolerate the project-less anchor vault (no manifest) by
+  // resolving the daemon-global context rather than throwing — context-less
+  // requests (notification banner) must succeed at GLOBAL_SCOPE. Caller
+  // headers below still override to a real project.
+  const { context: fallback, manifest } = buildVaultFallbackOrGlobal(fallbackVaultDir, { callerRoot });
   const explicit: ExplicitContextInput = {
     projectRoot: readHeader(headers, REQUEST_CONTEXT_HEADERS.projectRoot),
     projectId: readHeader(headers, REQUEST_CONTEXT_HEADERS.projectId),
@@ -329,7 +333,9 @@ export function requestContextFromTenancyIds(
   },
 ): MycoRequestContext {
   enforceUrlTenancyAuth(options.headers, options.expectedAuthToken);
-  const { context: fallback } = buildVaultFallback(fallbackVaultDir);
+  // Daemon path: tolerate the project-less anchor vault; the URL (Grove,
+  // project) ids below override to the real project.
+  const { context: fallback } = buildVaultFallbackOrGlobal(fallbackVaultDir);
   const explicit: ExplicitContextInput = {
     groveId: ids.groveId,
     projectId: ids.projectId,
@@ -565,6 +571,31 @@ function buildVaultFallback(
     throw new Error(result.reason);
   }
   return { context: result.context, manifest: result.manifest };
+}
+
+/**
+ * Daemon per-request variant of `buildVaultFallback`: when the fallback vault
+ * is the project-less `_unbound-bootstrap` anchor (no manifest), return the
+ * daemon-global context instead of throwing. The global daemon's own vault has
+ * no project, so a context-less request (e.g. the notification banner) must
+ * resolve to GLOBAL_SCOPE, not 500. Real project vaults still resolve to their
+ * project. Used only by the daemon transport paths (header / URL-param); the
+ * CLI/env path keeps the throwing `buildVaultFallback` so an unregistered
+ * project still gets the friendly "commit Myco config" error.
+ */
+function buildVaultFallbackOrGlobal(
+  vaultDir: string,
+  overrides: { machineId?: string; sessionId?: string | null; callerRoot?: string | null } = {},
+): { context: MycoRequestContext; manifest: ProjectManifest | null } {
+  const result = tryBuildVaultFallback(vaultDir, overrides);
+  if (result.kind === 'grove') {
+    return { context: result.context, manifest: result.manifest };
+  }
+  const context = daemonGlobalRequestContext(vaultDir, {
+    machineId: overrides.machineId,
+    sessionId: overrides.sessionId,
+  });
+  return { context: { ...context, callerRoot: overrides.callerRoot ?? null }, manifest: null };
 }
 
 /**

--- a/packages/myco/src/tools/call-context.ts
+++ b/packages/myco/src/tools/call-context.ts
@@ -28,6 +28,7 @@ import path from 'node:path';
 import { ToolError } from './error.js';
 import {
   REQUEST_CONTEXT_HEADERS,
+  requireProjectId,
   type MycoRequestContext,
 } from '@myco/grove/request-context.js';
 import {
@@ -136,7 +137,7 @@ export function resolveCallContext(
     // If that project isn't registered in the target Grove, we still
     // pivot the database — row-scope filters will simply return zero
     // matches, which is the honest answer.
-    resolvedProjectId = baseContext.projectId;
+    resolvedProjectId = requireProjectId(baseContext, 'caller tenancy');
     resolvedProjectRoot = baseContext.projectRoot;
   }
 

--- a/packages/myco/src/tools/cortex.ts
+++ b/packages/myco/src/tools/cortex.ts
@@ -194,7 +194,7 @@ function resolveCanopyEntry(
   if (requestContext && input.id) {
     const parsed = parseCanopyRecordId(input.id);
     if (!parsed) return null;
-    if (parsed.projectId !== requestContext.projectId) {
+    if (parsed.projectId !== requireProjectId(requestContext, 'cortex tool')) {
       return { error: 'Canopy entry is outside the current project context' };
     }
     return parsed;

--- a/packages/myco/src/tools/cortex.ts
+++ b/packages/myco/src/tools/cortex.ts
@@ -6,7 +6,7 @@ import { parseCanopyRecordId } from '@myco/canopy/hydrate.js';
 import { readCanopyEntry } from '@myco/canopy/read-service.js';
 import type { DaemonClient } from '@myco/hooks/client.js';
 import { handleCanopyMap, type CanopyMapResult } from './canopy-map.js';
-import { requestContextHeaders, type MycoRequestContext } from '@myco/grove/request-context.js';
+import { requestContextHeaders, requireProjectId, type MycoRequestContext } from '@myco/grove/request-context.js';
 import { buildEndpoint } from './shared.js';
 import type { ToolFailure } from './error.js';
 
@@ -189,7 +189,7 @@ function resolveCanopyEntry(
   requestContext?: MycoRequestContext,
 ): ResolvedCanopyEntry | { error: string } | null {
   if (requestContext && input.path) {
-    return { projectId: requestContext.projectId, path: input.path };
+    return { projectId: requireProjectId(requestContext, 'cortex tool'), path: input.path };
   }
   if (requestContext && input.id) {
     const parsed = parseCanopyRecordId(input.id);

--- a/packages/myco/src/tools/index.ts
+++ b/packages/myco/src/tools/index.ts
@@ -4,7 +4,7 @@ import type { DaemonClient } from '@myco/hooks/client.js';
 import type { Database } from '@myco/db/client.js';
 import { ToolError } from './error.js';
 import { isCollectiveEnabled } from './shared.js';
-import { isCallerTenancy, type MycoRequestContext } from '@myco/grove/request-context.js';
+import { isCallerTenancy, requireProjectId, type MycoRequestContext } from '@myco/grove/request-context.js';
 import {
   readPivot,
   resolveCallContext,
@@ -423,7 +423,7 @@ export function createMycoTools(vaultDir: string, client: DaemonClient, options:
     // see plan session:3216054f...:key:myco-tool-call-tracking-per-session.
     try {
       return await runWithRequestDatabase(context, async () => {
-        const projectId = context.projectId;
+        const projectId = requireProjectId(context, 'cortex canopy map');
         const machineId = context.machineId;
         const sessionId = context.sessionId;
         const result = await handleCortexCanopyMap({ projectId, machineId });

--- a/packages/myco/src/tools/search.ts
+++ b/packages/myco/src/tools/search.ts
@@ -13,6 +13,7 @@ import type {
 } from '@myco/db/queries/release-provenance.js';
 import { normalizeSearchResults, type NormalizedSearchResult } from '@myco/search-results.js';
 import { requestContextHeaders, type MycoRequestContext } from '@myco/grove/request-context.js';
+import { ToolError, extractErrorMessage } from './error.js';
 import { buildEndpoint } from './shared.js';
 
 // ---------------------------------------------------------------------------
@@ -71,7 +72,15 @@ export async function handleMycoSearch(
   const result = requestContext
     ? await client.get(endpoint, { headers: requestContextHeaders(requestContext) })
     : await client.get(endpoint);
-  if (!result.ok || !result.data?.results) return [];
+  // Fail loud on a daemon error (tenancy rejection, 5xx, timeout). Disguising
+  // it as an empty result set is how a tenancy/connectivity failure looked
+  // like "no search results". A genuine empty match set still returns [].
+  if (!result.ok) {
+    throw new ToolError(
+      'tool_call_failed',
+      extractErrorMessage(result.data, 'Search request failed'),
+    );
+  }
 
-  return normalizeSearchResults(result.data.results);
+  return normalizeSearchResults(result.data?.results ?? []);
 }

--- a/packages/myco/src/tools/search.ts
+++ b/packages/myco/src/tools/search.ts
@@ -72,9 +72,7 @@ export async function handleMycoSearch(
   const result = requestContext
     ? await client.get(endpoint, { headers: requestContextHeaders(requestContext) })
     : await client.get(endpoint);
-  // Fail loud on a daemon error (tenancy rejection, 5xx, timeout). Disguising
-  // it as an empty result set is how a tenancy/connectivity failure looked
-  // like "no search results". A genuine empty match set still returns [].
+  // Throw on a daemon error; a genuine empty match set returns [].
   if (!result.ok) {
     throw new ToolError(
       'tool_call_failed',

--- a/packages/myco/src/vault/bootstrap.ts
+++ b/packages/myco/src/vault/bootstrap.ts
@@ -8,7 +8,6 @@ import {
   SERVICE_DEV_DIRNAME,
 } from '../grove/paths.js';
 import { listGroves, getDefaultGroveId, listRegisteredProjects, loadGroveRecord } from '../grove/registry.js';
-import { createProjectId } from '../grove/ids.js';
 
 /**
  * Resolve the bootstrap vault directory for daemon startup.
@@ -129,29 +128,33 @@ export function resolveBootstrapVaultDirOrPhantom(cwd: string = process.cwd()): 
   if (resolved) return { vaultDir: resolved, isPhantom: false };
   const phantom = resolvePhantomBootstrapVaultDir();
   fs.mkdirSync(phantom, { recursive: true });
-  ensurePhantomProjectManifest(phantom);
+  // The phantom dir is pure filesystem scaffolding (machine id, secrets, log
+  // dir, a config-empty myco.yaml). We deliberately do NOT mint a `[project]
+  // id` — the daemon's anchor is the project-less daemon-global context
+  // (`resolveDaemonDataPaths({ daemonGlobal: true })`). Fabricating a
+  // real-looking `proj_<hex>` here was the phantom-tenancy bug: an id that
+  // masqueraded as a tenant in the data plane. Also remove any stale manifest
+  // an older daemon build left behind so no fabricated id survives an upgrade.
+  removeStalePhantomProjectManifest(phantom);
   ensurePhantomMycoYaml(phantom);
   return { vaultDir: phantom, isPhantom: true };
 }
 
 /**
- * Write a minimal `project.toml` into the phantom vault so the daemon's
- * manifest-aware paths (`loadProjectManifest`, `requestContextFromEnvironment`)
- * have a non-null shape to work against. The id is a real Grove-era
- * project id (`proj_<32hex>`) so it satisfies `assertGroveProjectId`, but
- * the manifest has no `grove` block — the daemon's `assertGroveBound`
- * path is skipped in phantom mode, so the unbound state is intentional.
- *
- * Persisted across boots so the phantom id stays stable; the daemon
- * restarts to a real vault as soon as the first project registers via
- * the hook-driven auto-Grove-create flow.
+ * Remove any stale `project.toml` a previous daemon build minted in the
+ * phantom vault. The global daemon no longer fabricates a project id for its
+ * anchor — it uses the project-less daemon-global context — so a leftover
+ * `_unbound-bootstrap/project.toml` carrying a `proj_<hex>` id (which could be
+ * read as tenancy) is deleted on boot. Best-effort: absence is the goal, and
+ * the daemon-global anchor ignores the manifest regardless.
  */
-function ensurePhantomProjectManifest(phantomVaultDir: string): void {
+function removeStalePhantomProjectManifest(phantomVaultDir: string): void {
   const manifestPath = path.join(phantomVaultDir, PROJECT_MANIFEST_FILENAME);
-  if (fs.existsSync(manifestPath)) return;
-  const projectId = createProjectId();
-  const body = `[project]\nid = "${projectId}"\nname = "myco-bootstrap"\n`;
-  fs.writeFileSync(manifestPath, body, { mode: 0o600 });
+  try {
+    fs.rmSync(manifestPath, { force: true });
+  } catch {
+    // Non-fatal — the daemon-global anchor does not read this manifest.
+  }
 }
 
 /**

--- a/packages/myco/src/vault/bootstrap.ts
+++ b/packages/myco/src/vault/bootstrap.ts
@@ -128,32 +128,24 @@ export function resolveBootstrapVaultDirOrPhantom(cwd: string = process.cwd()): 
   if (resolved) return { vaultDir: resolved, isPhantom: false };
   const phantom = resolvePhantomBootstrapVaultDir();
   fs.mkdirSync(phantom, { recursive: true });
-  // The phantom dir is pure filesystem scaffolding (machine id, secrets, log
-  // dir, a config-empty myco.yaml). We deliberately do NOT mint a `[project]
-  // id` — the daemon's anchor is the project-less daemon-global context
-  // (`resolveDaemonDataPaths({ daemonGlobal: true })`). Fabricating a
-  // real-looking `proj_<hex>` here was the phantom-tenancy bug: an id that
-  // masqueraded as a tenant in the data plane. Also remove any stale manifest
-  // an older daemon build left behind so no fabricated id survives an upgrade.
+  // The phantom dir holds machine id, secrets, log dir, and a config-empty
+  // myco.yaml — no `[project] id`. Remove any stale manifest an older build
+  // left behind.
   removeStalePhantomProjectManifest(phantom);
   ensurePhantomMycoYaml(phantom);
   return { vaultDir: phantom, isPhantom: true };
 }
 
 /**
- * Remove any stale `project.toml` a previous daemon build minted in the
- * phantom vault. The global daemon no longer fabricates a project id for its
- * anchor — it uses the project-less daemon-global context — so a leftover
- * `_unbound-bootstrap/project.toml` carrying a `proj_<hex>` id (which could be
- * read as tenancy) is deleted on boot. Best-effort: absence is the goal, and
- * the daemon-global anchor ignores the manifest regardless.
+ * Delete any `project.toml` a previous daemon build wrote into the phantom
+ * vault. Best-effort.
  */
 function removeStalePhantomProjectManifest(phantomVaultDir: string): void {
   const manifestPath = path.join(phantomVaultDir, PROJECT_MANIFEST_FILENAME);
   try {
     fs.rmSync(manifestPath, { force: true });
   } catch {
-    // Non-fatal — the daemon-global anchor does not read this manifest.
+    // Best-effort.
   }
 }
 

--- a/tests/canopy/inject/codex-pre-post-link.test.ts
+++ b/tests/canopy/inject/codex-pre-post-link.test.ts
@@ -58,7 +58,7 @@ function ctx(): MycoRequestContext {
     projectRoot: tmpVault,
     callerRoot: null,
     projectId: assertGroveProjectId(tmpProjectId),
-    groveId: null,
+    groveId: 'grove_test',
     machineId: 'local',
     sessionId: null,
     projectVaultDir: path.join(tmpVault, '.myco'),

--- a/tests/canopy/inject/end-to-end.test.ts
+++ b/tests/canopy/inject/end-to-end.test.ts
@@ -69,7 +69,7 @@ beforeEach(async () => {
     projectRoot: tmpVault,
     callerRoot: null,
     projectId: assertGroveProjectId(tmpProjectId),
-    groveId: null,
+    groveId: 'grove_test',
     machineId: 'local',
     sessionId: null,
     projectVaultDir: path.join(tmpVault, '.myco'),

--- a/tests/canopy/inject/endpoint.test.ts
+++ b/tests/canopy/inject/endpoint.test.ts
@@ -80,7 +80,7 @@ function ctx(overrides: Partial<MycoRequestContext> = {}): MycoRequestContext {
     projectRoot: tmpVault,
     callerRoot: null,
     projectId: assertGroveProjectId(tmpProjectId),
-    groveId: null,
+    groveId: 'grove_test',
     machineId: 'local',
     sessionId: null,
     projectVaultDir: path.join(tmpVault, '.myco'),
@@ -280,7 +280,7 @@ describe('POST /canopy/inject — handler', () => {
         projectRoot: tmpVault,
         callerRoot: worktreeRoot,
         projectId: assertGroveProjectId(tmpProjectId),
-        groveId: null,
+        groveId: 'grove_test',
         machineId: 'local',
         sessionId: 's-worktree',
         projectVaultDir: path.join(tmpVault, '.myco'),
@@ -407,5 +407,18 @@ describe('POST /canopy/inject — handler', () => {
     const body = res.body as { blob: string };
     expect(body.blob).toContain('summary: "A test file used for integration coverage."');
     expect(body.blob).toContain('File summary from Myco');
+  });
+
+  it('degrades to no-injection for a request that resolves no project', async () => {
+    seed(tmpProjectId, [{ path: 'src/big.ts', size: 4096, exports: ['foo'] }]);
+    const handler = createCanopyInjectHandler({
+      liveConfig: { current: makeConfig() },
+      getDatabase,
+    });
+    const res = await handler({
+      requestContext: ctx({ groveId: null }),
+      body: { sessionId: 's-no-project', agent: 'claude-code', toolInput: { file_path: 'src/big.ts' } },
+    });
+    expect(res.body).toEqual({ inject: false, reason: 'unknown_file' });
   });
 });

--- a/tests/daemon/api/models.test.ts
+++ b/tests/daemon/api/models.test.ts
@@ -6,9 +6,8 @@ import { OPENAI_API_KEY_ENV } from '@myco/providers/env.js';
 const originalFetch = global.fetch;
 const fetchMock = vi.fn();
 global.fetch = fetchMock as unknown as typeof fetch;
-// Restore the real global.fetch at file end so this module-scope override does
-// not leak into sibling test files sharing the process (NO_ISOLATE groups) —
-// a mock'd fetch returning undefined was silently failing pause-enforcement.
+// Restore global.fetch at file end so this override does not leak into sibling
+// test files sharing the process.
 afterAll(() => { global.fetch = originalFetch; });
 
 describe('handleGetModels', () => {

--- a/tests/daemon/api/models.test.ts
+++ b/tests/daemon/api/models.test.ts
@@ -1,10 +1,15 @@
-import { afterEach, describe, expect, it } from 'bun:test';
+import { afterAll, afterEach, describe, expect, it } from 'bun:test';
 import { vi } from '../../helpers/vi-shim.js';
 import { handleGetModels } from '@myco/daemon/api/models.js';
 import { OPENAI_API_KEY_ENV } from '@myco/providers/env.js';
 
+const originalFetch = global.fetch;
 const fetchMock = vi.fn();
 global.fetch = fetchMock as unknown as typeof fetch;
+// Restore the real global.fetch at file end so this module-scope override does
+// not leak into sibling test files sharing the process (NO_ISOLATE groups) —
+// a mock'd fetch returning undefined was silently failing pause-enforcement.
+afterAll(() => { global.fetch = originalFetch; });
 
 describe('handleGetModels', () => {
   afterEach(() => {

--- a/tests/daemon/api/providers-ssrf.test.ts
+++ b/tests/daemon/api/providers-ssrf.test.ts
@@ -5,14 +5,18 @@
  * daemon's stored bearer key is never sent to an attacker-controlled host.
  * `openai-compatible` / `ollama` / `lmstudio` remain user-configurable.
  */
-import { describe, it, expect, afterEach, mock } from 'bun:test';
+import { describe, it, expect, afterAll, afterEach, mock } from 'bun:test';
 import { vi } from '../../helpers/vi-shim.js';
 import { handleTestProvider } from '@myco/daemon/api/providers';
 import { handleGetModels } from '@myco/daemon/api/models';
 import { OPENAI_API_KEY_ENV, OPENROUTER_API_KEY_ENV } from '@myco/providers/env.js';
 
+const originalFetch = global.fetch;
 const fetchMock = vi.fn();
 global.fetch = fetchMock as unknown as typeof fetch;
+// Restore the real global.fetch at file end so this module-scope override does
+// not leak into sibling test files sharing the process (NO_ISOLATE groups).
+afterAll(() => { global.fetch = originalFetch; });
 
 mock.module('@myco/intelligence/ollama.js', () => ({
   OllamaBackend: class {

--- a/tests/daemon/api/providers-ssrf.test.ts
+++ b/tests/daemon/api/providers-ssrf.test.ts
@@ -14,8 +14,8 @@ import { OPENAI_API_KEY_ENV, OPENROUTER_API_KEY_ENV } from '@myco/providers/env.
 const originalFetch = global.fetch;
 const fetchMock = vi.fn();
 global.fetch = fetchMock as unknown as typeof fetch;
-// Restore the real global.fetch at file end so this module-scope override does
-// not leak into sibling test files sharing the process (NO_ISOLATE groups).
+// Restore global.fetch at file end so this override does not leak into sibling
+// test files sharing the process.
 afterAll(() => { global.fetch = originalFetch; });
 
 mock.module('@myco/intelligence/ollama.js', () => ({

--- a/tests/daemon/api/search-canopy.test.ts
+++ b/tests/daemon/api/search-canopy.test.ts
@@ -17,8 +17,14 @@ import { createSearchHandler } from '@myco/daemon/api/search.js';
 import type { EmbeddingManager } from '@myco/daemon/embedding/manager.js';
 import type { RouteRequest } from '@myco/daemon/router.js';
 
-import { TEST_REQUEST_CONTEXT } from '../../helpers/request-context';
+import { makeTestRequestContext } from '../../helpers/request-context';
+import type { MycoRequestContext } from '@myco/grove/request-context.js';
 const epochNow = () => Math.floor(Date.now() / 1000);
+
+// Canopy is project-scoped: a real MCP/CLI caller searches its own Grove. A
+// Grove-bound context resolves a non-null row project id, so the handler runs
+// the canopy search.
+const GROVE_BOUND_CONTEXT = makeTestRequestContext({ groveId: 'grove_test' });
 
 function seedCanopyRow(opts: {
   project_id: string;
@@ -41,11 +47,14 @@ function seedCanopyRow(opts: {
   });
 }
 
-function makeRequest(query: Record<string, string>): RouteRequest {
+function makeRequest(
+  query: Record<string, string>,
+  context: MycoRequestContext = GROVE_BOUND_CONTEXT,
+): RouteRequest {
   // Search handler opens a per-request DB from requestContext.databasePath.
   // The test relies on the singleton via setupTestDb(); blank the path so
   // openRequestDatabase falls back to getDatabase().
-  const ctx = { ...TEST_REQUEST_CONTEXT, databasePath: '' };
+  const ctx = { ...context, databasePath: '' };
   return { body: {}, query, params: {}, pathname: '/api/search', requestContext: ctx } as RouteRequest;
 }
 
@@ -142,5 +151,24 @@ describe('GET /api/search type=canopy', () => {
     const res = await handler(makeRequest({ q: 'x', type: 'canopy' }));
     expect(res.body?.results).toEqual([]);
     expect(res.body?.provider_unavailable).toBe(true);
+  });
+
+  it('returns empty without touching the vector store for a request that resolves no project', async () => {
+    seedCanopyRow({ project_id: 'p', path: 'auth/login.ts', description: 'login flow handler' });
+
+    let searchVectorsCalled = false;
+    const embeddingManager = fakeEmbeddingManager({
+      searchVectors: ((..._args: unknown[]) => {
+        searchVectorsCalled = true;
+        return [];
+      }) as EmbeddingManager['searchVectors'],
+    });
+
+    const handler = createSearchHandler({ embeddingManager });
+    const groveless = makeTestRequestContext({ groveId: null, tenancySource: 'synthesized' });
+    const res = await handler(makeRequest({ q: 'auth', type: 'canopy' }, groveless));
+
+    expect(res.body?.results).toEqual([]);
+    expect(searchVectorsCalled).toBe(false);
   });
 });

--- a/tests/daemon/bootstrap-rebind.test.ts
+++ b/tests/daemon/bootstrap-rebind.test.ts
@@ -216,20 +216,16 @@ describe('no phantom leak after rebind', () => {
     }
   });
 
-  test('phantom dir still exists on disk post-rebind (intentional) but is not surfaced by the resolver', () => {
-    // This locks in the design choice from bootstrap.ts:130-141:
-    // "Persisted across boots so the phantom id stays stable; the
-    // daemon restarts to a real vault as soon as the first project
-    // registers." We do NOT delete the phantom dir after rebind — but
-    // the resolver must stop returning it.
+  test('phantom dir still exists on disk post-rebind (intentional) but carries no project id', () => {
+    // The phantom scratch dir persists (machine id, secrets, myco.yaml) but
+    // NEVER carries a fabricated project id — the daemon's anchor is the
+    // project-less daemon-global context. The resolver must also stop
+    // surfacing the phantom dir once a real project registers.
     const phantomPath = resolvePhantomBootstrapVaultDir(tmpHome);
     // Force materialization of the phantom dir.
     resolveBootstrapVaultDirOrPhantom(tmpCwd);
     expect(fs.existsSync(phantomPath)).toBe(true);
-    const phantomManifestBefore = fs.readFileSync(
-      path.join(phantomPath, 'project.toml'),
-      'utf-8',
-    );
+    expect(fs.existsSync(path.join(phantomPath, 'project.toml'))).toBe(false);
 
     // Rebind.
     const groveId = 'grove_44444444444444444444444444444444';
@@ -242,16 +238,10 @@ describe('no phantom leak after rebind', () => {
       const after = resolveBootstrapVaultDirOrPhantom(tmpCwd);
       expect(after.vaultDir).not.toBe(phantomPath);
 
-      // Phantom artifacts still exist on disk — the rebind does NOT
-      // clean them. The next greenfield daemon (e.g. after `myco
-      // remove` strips all projects) would reuse the same synthetic
-      // project id, which is the documented design.
+      // Phantom scratch dir still exists on disk (the rebind does NOT clean
+      // it) but still carries no project id — no fabricated tenancy survives.
       expect(fs.existsSync(phantomPath)).toBe(true);
-      const phantomManifestAfter = fs.readFileSync(
-        path.join(phantomPath, 'project.toml'),
-        'utf-8',
-      );
-      expect(phantomManifestAfter).toBe(phantomManifestBefore);
+      expect(fs.existsSync(path.join(phantomPath, 'project.toml'))).toBe(false);
     } finally {
       fs.rmSync(projRoot, { recursive: true, force: true });
     }
@@ -462,14 +452,19 @@ describe('global daemon phantom bootstrap resolves home-scoped service/log/data 
       // The would-be anchor project root is never the boot vault.
       expect(boot.vaultDir).not.toBe(path.join(projRoot, '.myco'));
 
-      // The boot DB resolves under the phantom home — not the project.
-      const dataPaths = resolveDaemonDataPaths(boot.vaultDir, {
-        MYCO_HOME: tmpHome,
-        MYCO_MACHINE_ID: 'machine-test',
-      });
+      // The boot DB resolves under the phantom home — not the project. The
+      // daemon passes { daemonGlobal: isPhantom } so the anchor context is the
+      // project-less daemon-global shape (mirrors daemon/main.ts).
+      const dataPaths = resolveDaemonDataPaths(
+        boot.vaultDir,
+        { MYCO_HOME: tmpHome, MYCO_MACHINE_ID: 'machine-test' },
+        { daemonGlobal: boot.isPhantom },
+      );
       expect(dataPaths.databasePath.startsWith(boot.vaultDir)).toBe(true);
       expect(dataPaths.databasePath.startsWith(projRoot)).toBe(false);
-      // Phantom manifest carries a project id but no Grove binding.
+      // The daemon-global anchor carries NO project and NO Grove binding —
+      // no fabricated phantom project id.
+      expect(dataPaths.requestContext.projectId).toBeNull();
       expect(dataPaths.requestContext.groveId).toBeNull();
     } finally {
       delete process.env.MYCO_SERVICE_VARIANT;

--- a/tests/daemon/daemon-global-anchor.test.ts
+++ b/tests/daemon/daemon-global-anchor.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The global multi-tenant daemon's startup anchor carries NO project — it
+ * serves every tenant per request. These tests pin the elimination of the
+ * phantom `_unbound-bootstrap` project: the anchor context is project-less
+ * (projectId null) and no fabricated `proj_<hex>` id is ever derivable from
+ * the phantom vault.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  daemonGlobalRequestContext,
+  rowProjectIdFromRequestContext,
+  projectScopeFromRequestContext,
+} from '@myco/grove/request-context.js';
+import {
+  resolveBootstrapVaultDirOrPhantom,
+  resolvePhantomBootstrapVaultDir,
+} from '@myco/vault/bootstrap.js';
+
+describe('daemon-global anchor context', () => {
+  it('carries no project or grove', () => {
+    const ctx = daemonGlobalRequestContext('/tmp/_unbound-bootstrap');
+    expect(ctx.projectId).toBeNull();
+    expect(ctx.groveId).toBeNull();
+  });
+
+  it('resolves to NULL row tenancy and GLOBAL_SCOPE (daemon-owned, never the phantom id)', () => {
+    const ctx = daemonGlobalRequestContext('/tmp/_unbound-bootstrap');
+    expect(rowProjectIdFromRequestContext(ctx)).toBeNull();
+    expect(projectScopeFromRequestContext(ctx)).toEqual({ kind: 'global' });
+  });
+});
+
+describe('phantom bootstrap mints no project id', () => {
+  let tmpHome: string;
+  let prevHome: string | undefined;
+  let prevVariant: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-phantom-home-'));
+    prevHome = process.env.MYCO_HOME;
+    prevVariant = process.env.MYCO_SERVICE_VARIANT;
+    process.env.MYCO_HOME = tmpHome;
+    // A service variant forces the project-less phantom boot path.
+    process.env.MYCO_SERVICE_VARIANT = 'service';
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.MYCO_HOME;
+    else process.env.MYCO_HOME = prevHome;
+    if (prevVariant === undefined) delete process.env.MYCO_SERVICE_VARIANT;
+    else process.env.MYCO_SERVICE_VARIANT = prevVariant;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('does not write a project.toml into _unbound-bootstrap', () => {
+    const { vaultDir, isPhantom } = resolveBootstrapVaultDirOrPhantom();
+    expect(isPhantom).toBe(true);
+    expect(fs.existsSync(path.join(vaultDir, 'project.toml'))).toBe(false);
+  });
+
+  it('removes a stale project.toml a prior daemon build minted (no proj_ survives upgrade)', () => {
+    const phantom = resolvePhantomBootstrapVaultDir(tmpHome);
+    fs.mkdirSync(phantom, { recursive: true });
+    const stale = path.join(phantom, 'project.toml');
+    fs.writeFileSync(
+      stale,
+      '[project]\nid = "proj_deadbeefdeadbeefdeadbeefdeadbeef"\nname = "myco-bootstrap"\n',
+    );
+
+    resolveBootstrapVaultDirOrPhantom();
+
+    expect(fs.existsSync(stale)).toBe(false);
+  });
+});

--- a/tests/daemon/daemon-global-anchor.test.ts
+++ b/tests/daemon/daemon-global-anchor.test.ts
@@ -35,11 +35,8 @@ describe('daemon-global anchor context', () => {
   });
 
   it('a context-less daemon request against the project-less anchor resolves daemon-global, not throw', () => {
-    // Regression: the daemon synthesizes a per-request fallback from its own
-    // (now manifest-less) `_unbound-bootstrap` vault. With no caller headers it
-    // must produce the daemon-global context (GLOBAL_SCOPE) rather than throw
-    // "No Grove project id available" — e.g. the notification banner polls
-    // every page with no project context.
+    // A manifest-less vault with no caller headers resolves to the
+    // daemon-global context (GLOBAL_SCOPE), not a throw.
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-anchor-vault-'));
     try {
       const ctx = requestContextFromHttpHeaders({}, dir);

--- a/tests/daemon/daemon-global-anchor.test.ts
+++ b/tests/daemon/daemon-global-anchor.test.ts
@@ -14,6 +14,7 @@ import {
   daemonGlobalRequestContext,
   rowProjectIdFromRequestContext,
   projectScopeFromRequestContext,
+  requestContextFromHttpHeaders,
 } from '@myco/grove/request-context.js';
 import {
   resolveBootstrapVaultDirOrPhantom,
@@ -31,6 +32,23 @@ describe('daemon-global anchor context', () => {
     const ctx = daemonGlobalRequestContext('/tmp/_unbound-bootstrap');
     expect(rowProjectIdFromRequestContext(ctx)).toBeNull();
     expect(projectScopeFromRequestContext(ctx)).toEqual({ kind: 'global' });
+  });
+
+  it('a context-less daemon request against the project-less anchor resolves daemon-global, not throw', () => {
+    // Regression: the daemon synthesizes a per-request fallback from its own
+    // (now manifest-less) `_unbound-bootstrap` vault. With no caller headers it
+    // must produce the daemon-global context (GLOBAL_SCOPE) rather than throw
+    // "No Grove project id available" — e.g. the notification banner polls
+    // every page with no project context.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-anchor-vault-'));
+    try {
+      const ctx = requestContextFromHttpHeaders({}, dir);
+      expect(ctx.projectId).toBeNull();
+      expect(ctx.groveId).toBeNull();
+      expect(projectScopeFromRequestContext(ctx)).toEqual({ kind: 'global' });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/daemon/log-entry-insert.test.ts
+++ b/tests/daemon/log-entry-insert.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for the shared LogEntry -> LogEntryInsert mapping seam.
+ *
+ * This is the single place both the live persist path (main.ts logger
+ * persistFn) and the buffer-replay path (log-reconcile.ts) resolve a daemon
+ * log row's project_id. The invariant it enforces: a daemon-owned log row
+ * carries the daemon's resolved fallback project id — which is NULL for the
+ * groveless daemon anchor — and NEVER the phantom `_unbound-bootstrap`
+ * project id. An explicit per-entry project_id always wins over the fallback.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { logEntryToInsert } from '@myco/daemon/log-entry-insert.js';
+import { assertGroveProjectId } from '@myco/grove/ids.js';
+
+// A real, registered Grove project id (32 hex after the prefix).
+const REAL_PROJECT_ID = assertGroveProjectId('proj_11111111111111111111111111111111');
+// The phantom `myco-bootstrap` id from `_unbound-bootstrap/project.toml`. It
+// must never appear on a daemon log row.
+const PHANTOM_PROJECT_ID = 'proj_a28e8a32e8b7727cfd19f22223b482c5';
+
+function entry(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    timestamp: '2026-06-04T00:00:00.000Z',
+    level: 'info',
+    kind: 'daemon.start',
+    component: 'daemon',
+    message: 'Daemon started',
+    ...overrides,
+  };
+}
+
+describe('logEntryToInsert', () => {
+  it('maps a daemon-anchor log (null fallback) to project_id IS NULL', () => {
+    const insert = logEntryToInsert(entry(), null);
+    expect(insert.project_id).toBeNull();
+  });
+
+  it('never substitutes a phantom id for a groveless daemon anchor', () => {
+    const insert = logEntryToInsert(entry(), null);
+    expect(insert.project_id).not.toBe(PHANTOM_PROJECT_ID);
+  });
+
+  it('preserves an explicit per-entry project_id over the fallback', () => {
+    const insert = logEntryToInsert(entry({ project_id: REAL_PROJECT_ID }), null);
+    expect(insert.project_id).toBe(REAL_PROJECT_ID);
+  });
+
+  it('uses the fallback project id when the daemon is grove-bound', () => {
+    const insert = logEntryToInsert(entry(), REAL_PROJECT_ID);
+    expect(insert.project_id).toBe(REAL_PROJECT_ID);
+  });
+
+  it('throws on a malformed string project_id rather than writing junk', () => {
+    expect(() => logEntryToInsert(entry({ project_id: 'not-a-project-id' }), null)).toThrow();
+  });
+
+  it('carries through the core columns', () => {
+    const insert = logEntryToInsert(entry({ session_id: 'sess-abc' }), null);
+    expect(insert.timestamp).toBe('2026-06-04T00:00:00.000Z');
+    expect(insert.level).toBe('info');
+    expect(insert.kind).toBe('daemon.start');
+    expect(insert.component).toBe('daemon');
+    expect(insert.message).toBe('Daemon started');
+    expect(insert.session_id).toBe('sess-abc');
+  });
+
+  it('puts extra fields in data but excludes project_id and session_id', () => {
+    const insert = logEntryToInsert(
+      entry({ session_id: 'sess-abc', project_id: REAL_PROJECT_ID, foo: 'bar' }),
+      null,
+    );
+    expect(insert.data).toBe('{"foo":"bar"}');
+  });
+
+  it('returns null data when no extra fields are present', () => {
+    const insert = logEntryToInsert(entry(), null);
+    expect(insert.data).toBeNull();
+  });
+
+  it('defensively derives kind/component for a malformed buffered line', () => {
+    // Buffer replay parses arbitrary JSONL; an old/partial line may lack kind.
+    const insert = logEntryToInsert(
+      { timestamp: '2026-06-04T00:00:00.000Z', level: 'warn', message: 'x', component: 'session' },
+      null,
+    );
+    expect(insert.kind).toBe('session.unknown');
+    expect(insert.component).toBe('session');
+  });
+});

--- a/tests/daemon/trigger-title-summary.test.ts
+++ b/tests/daemon/trigger-title-summary.test.ts
@@ -82,10 +82,8 @@ describe('triggerTitleSummary live-config gating', () => {
   });
 
   it('refuses to dispatch (never records a NULL-project run) when the context has no grove', async () => {
-    // RC-4: a groveless context resolves rowProjectIdFromRequestContext to
-    // NULL, which previously recorded the title-summary agent run under
-    // project_id NULL. The trigger must refuse and log rather than dispatch a
-    // run it cannot attribute to a real project.
+    // A groveless context resolves rowProjectIdFromRequestContext to NULL; the
+    // trigger refuses and logs rather than dispatch.
     const logger = makeLogger();
     let resolverCalled = false;
     await triggerTitleSummary('sess-1', {

--- a/tests/daemon/trigger-title-summary.test.ts
+++ b/tests/daemon/trigger-title-summary.test.ts
@@ -32,6 +32,9 @@ describe('triggerTitleSummary live-config gating', () => {
       resolveEmbeddingManager: () => makeEmbeddingManagerStub() as never,
       liveConfig,
       logger: makeLogger() as never,
+      // Grove-bound caller context so the trigger proceeds past the gate
+      // instead of refusing on unresolved tenancy.
+      requestContext: { projectId: 'proj_x', groveId: 'grove_x' } as never,
     };
 
     // Disabled state: trigger returns immediately without touching the
@@ -76,5 +79,37 @@ describe('triggerTitleSummary live-config gating', () => {
       logger: logger as never,
     })).resolves.toBeUndefined();
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('refuses to dispatch (never records a NULL-project run) when the context has no grove', async () => {
+    // RC-4: a groveless context resolves rowProjectIdFromRequestContext to
+    // NULL, which previously recorded the title-summary agent run under
+    // project_id NULL. The trigger must refuse and log rather than dispatch a
+    // run it cannot attribute to a real project.
+    const logger = makeLogger();
+    let resolverCalled = false;
+    await triggerTitleSummary('sess-1', {
+      vaultDir: '/tmp/ignored',
+      resolveEmbeddingManager: () => { resolverCalled = true; return makeEmbeddingManagerStub() as never; },
+      liveConfig: { current: makeConfig({ event_tasks_enabled: true, summary_batch_interval: 5 }) },
+      logger: logger as never,
+      // groveId null -> rowProjectIdFromRequestContext === null (the leak shape).
+      requestContext: { projectId: 'proj_x', groveId: null } as never,
+    } as never);
+    expect(resolverCalled).toBe(false); // never reached the dispatch path
+    expect(logger.warn).toHaveBeenCalled(); // refusal is logged, not silent
+  });
+
+  it('also refuses when no request context is supplied at all', async () => {
+    const logger = makeLogger();
+    let resolverCalled = false;
+    await triggerTitleSummary('sess-1', {
+      vaultDir: '/tmp/ignored',
+      resolveEmbeddingManager: () => { resolverCalled = true; return makeEmbeddingManagerStub() as never; },
+      liveConfig: { current: makeConfig({ event_tasks_enabled: true, summary_batch_interval: 5 }) },
+      logger: logger as never,
+    });
+    expect(resolverCalled).toBe(false);
+    expect(logger.warn).toHaveBeenCalled();
   });
 });

--- a/tests/mcp/tools/search.test.ts
+++ b/tests/mcp/tools/search.test.ts
@@ -62,9 +62,6 @@ describe('myco_search', () => {
   });
 
   it('throws on daemon failure instead of silently returning empty', async () => {
-    // A daemon error (tenancy rejection, 500, timeout) must NOT be disguised
-    // as "no results" — that is how a tenancy/connectivity failure looked like
-    // an empty search and burned hours of debugging.
     const client = mockClient(null, false);
     await expect(handleMycoSearch({ query: 'test' }, client)).rejects.toThrow();
   });

--- a/tests/mcp/tools/search.test.ts
+++ b/tests/mcp/tools/search.test.ts
@@ -61,9 +61,25 @@ describe('myco_search', () => {
     }]);
   });
 
-  it('returns empty on daemon failure', async () => {
+  it('throws on daemon failure instead of silently returning empty', async () => {
+    // A daemon error (tenancy rejection, 500, timeout) must NOT be disguised
+    // as "no results" — that is how a tenancy/connectivity failure looked like
+    // an empty search and burned hours of debugging.
     const client = mockClient(null, false);
-    const results = await handleMycoSearch({ query: 'test' }, client);
+    await expect(handleMycoSearch({ query: 'test' }, client)).rejects.toThrow();
+  });
+
+  it('surfaces the daemon error message on a tenancy violation', async () => {
+    const client = mockClient(
+      { error: { code: 'tenancy-violation', message: 'Rejected request with invalid tenancy' } },
+      false,
+    );
+    await expect(handleMycoSearch({ query: 'test' }, client)).rejects.toThrow(/tenancy/i);
+  });
+
+  it('still returns [] for a genuine empty result set (ok, no matches)', async () => {
+    const client = mockClient({ mode: 'semantic', results: [] }, true);
+    const results = await handleMycoSearch({ query: 'no-such-thing' }, client);
     expect(results).toEqual([]);
   });
 });

--- a/tests/tools/request-context.test.ts
+++ b/tests/tools/request-context.test.ts
@@ -246,12 +246,17 @@ describe('tool request context', () => {
     });
   }, 15000);
 
-  it('throws when neither headers nor a Grove manifest provide a project id', () => {
+  it('resolves the daemon-global context (no project) when neither headers nor a manifest provide one', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-no-grove-'));
     try {
       const vaultDir = path.join(tmp, '.myco');
       fs.mkdirSync(vaultDir, { recursive: true });
-      expect(() => requestContextFromHttpHeaders({}, vaultDir)).toThrow(/No Grove project id available/);
+      // The daemon's per-request fallback must NOT throw for the project-less
+      // anchor — a context-less request resolves to the daemon-global context
+      // (GLOBAL_SCOPE), not 500. (The notification banner polls every page.)
+      const resolved = requestContextFromHttpHeaders({}, vaultDir);
+      expect(resolved.projectId).toBeNull();
+      expect(resolved.groveId).toBeNull();
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/tests/vault/bootstrap.test.ts
+++ b/tests/vault/bootstrap.test.ts
@@ -98,12 +98,12 @@ describe('resolveBootstrapVaultDir', () => {
     // Dir is created so callers (machine-id, logger) can write into it
     // immediately.
     expect(fs.existsSync(result.vaultDir)).toBe(true);
-    // Manifest is materialized so loadProjectManifest / request-context
-    // resolution don't blow up against a vault-less dir.
+    // No project.toml is minted: the daemon's anchor is the project-less
+    // daemon-global context, never a fabricated `proj_<hex>` id. (Regression
+    // for the phantom-tenancy elimination — see daemon-global-anchor.test.ts.)
     const manifestPath = path.join(result.vaultDir, 'project.toml');
-    expect(fs.existsSync(manifestPath)).toBe(true);
-    expect(fs.readFileSync(manifestPath, 'utf-8')).toMatch(/^\[project\]\nid = "proj_[0-9a-f]{32}"/);
-    // myco.yaml is materialized so loadConfigInternal doesn't throw
+    expect(fs.existsSync(manifestPath)).toBe(false);
+    // myco.yaml is still materialized so loadConfigInternal doesn't throw
     // "myco.yaml not found" on the first loadMergedConfig call —
     // greenfield smoke caught this gap before the fix-up.
     const configPath = path.join(result.vaultDir, 'myco.yaml');
@@ -111,12 +111,12 @@ describe('resolveBootstrapVaultDir', () => {
     expect(fs.readFileSync(configPath, 'utf-8')).toBe('version: 3\n');
   });
 
-  test('phantom helper is idempotent — manifest id persists across calls', () => {
+  test('phantom helper never materializes a project id (no proj_ in the scratch dir)', () => {
     const first = resolveBootstrapVaultDirOrPhantom(tmpCwd);
-    const firstBody = fs.readFileSync(path.join(first.vaultDir, 'project.toml'), 'utf-8');
+    expect(fs.existsSync(path.join(first.vaultDir, 'project.toml'))).toBe(false);
+    // Idempotent: a second call still leaves no project.toml.
     const second = resolveBootstrapVaultDirOrPhantom(tmpCwd);
-    const secondBody = fs.readFileSync(path.join(second.vaultDir, 'project.toml'), 'utf-8');
-    expect(secondBody).toBe(firstBody);
+    expect(fs.existsSync(path.join(second.vaultDir, 'project.toml'))).toBe(false);
   });
 
   test('phantom helper passes through real vault when one resolves', () => {


### PR DESCRIPTION
## Summary

Eliminates the phantom bootstrap project (`proj_a28e8a32…`, "myco-bootstrap") from the tenancy data plane and follows up with the `/code-review high` findings on the same surface.

The global daemon used to mint a fabricated `proj_<hex>` for its startup anchor vault and write it onto daemon-owned rows (logs, agent_runs). That phantom id leaked into the data plane and mis-scoped rows. This branch makes the daemon anchor **project-less** (`projectId: null` → `rowProjectIdFromRequestContext` resolves to NULL / `GLOBAL_SCOPE`), so the phantom id is gone by construction.

## Phantom elimination

- **Daemon log rows** use NULL scope for the groveless anchor, never the phantom id.
- **Search** fails loud on unresolved tenancy in the tools layer instead of silently returning empty.
- **Title-summary runs** resolve the session's real project or refuse — never run NULL-scoped.
- **Daemon-spawned project-owned runs** resolve the real project.
- The phantom project **mint is removed**; a stale `project.toml` minted by a prior build is cleaned on boot.
- Daemon transport paths serve context-less requests against the project-less anchor (no 500) via `buildVaultFallbackOrGlobal`.
- Dogfood-verified on the dev daemon; data migration run on the dogfood grove (phantom rows = 0, NULL agent_runs = 0, FTS integrity ok). Production cleanup is a separate post-release step (prod runs a different binary).

## Code-review cleanup (`/code-review high`, grouped by root cause)

- **G1 — `/api/search` dual-mode:** unwrapped from `tenantRoute` so a context-less read returns empty results instead of 400 (dashboard GlobalSearch fires before a project is selected); canopy branch returns empty when no project resolves rather than searching every project.
- **G2 — consistent project resolution:** three canopy surfaces routed through shared helpers — read CRUD routes fail loud (`requireProjectId`), the inject endpoint degrades gracefully (`rowProjectIdFromRequestContext`), the cortex id branch matches its path branch. The `''` sentinel is gone.
- **G3 — one scope value through the stop cycle:** session, batch, and capture writes now share a single Grove-gated project id, so a groveless context can't produce divergent row scopes.
- **G4 — de-dup / cleanup:** one `synthesizedVaultContext` builder for the anchor + fallback shapes; `rowProjectIdFromRequestContext` overloaded so a defined context returns `GroveProjectId | null` (dead `?? null` removed); the two canopy-regenerate guards collapsed.

One finding (reorder the title-summary null-skip before `resolveTenantConfig`) was evaluated and intentionally **not** changed — `resolveTenantConfig` already short-circuits for groveless contexts, and the warn must stay after the boundary check so it fires only when a title would actually be generated.

## Testing

Full suite green (node + jsdom): **5885 pass, 0 fail**, no `(fail)` lines, no non-zero JUnit `failures`. Dogfood smoke verified on the dev daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
