### PR TITLE
Isolate the bootstrap anchor vault per service variant

### DIFF
--- a/packages/myco/src/vault/bootstrap.ts
+++ b/packages/myco/src/vault/bootstrap.ts
@@ -107,8 +107,17 @@ export function resolveBootstrapVaultDir(cwd: string = process.cwd()): string | 
  * the registry watcher then triggers a daemon restart so the next
  * boot finds the project through `firstProjectVaultFromRegistry()`.
  */
+const PHANTOM_BOOTSTRAP_DIRNAME = '_unbound-bootstrap';
+
 export function resolvePhantomBootstrapVaultDir(mycoHome = resolveMycoHome()): string {
-  return path.join(mycoHome, '_unbound-bootstrap');
+  // Per-variant scratch vault: the dev daemon (service-dev) and the prod
+  // daemon (service) anchor to separate dirs, so one daemon's boot-time
+  // manifest cleanup never mutates the vault the other is running against.
+  const variant = daemonVariantFromEnvValue(process.env.MYCO_SERVICE_VARIANT);
+  const dirname = variant === SERVICE_DEV_DIRNAME
+    ? `${PHANTOM_BOOTSTRAP_DIRNAME}-dev`
+    : PHANTOM_BOOTSTRAP_DIRNAME;
+  return path.join(mycoHome, dirname);
 }
 
 /**

--- a/tests/vault/bootstrap.test.ts
+++ b/tests/vault/bootstrap.test.ts
@@ -354,3 +354,46 @@ describe('resolveBootstrapVaultDir', () => {
     }
   });
 });
+
+describe('resolvePhantomBootstrapVaultDir — per-variant isolation', () => {
+  let savedVariant: string | undefined;
+
+  beforeEach(() => {
+    setUpTmpHome();
+    savedVariant = process.env.MYCO_SERVICE_VARIANT;
+  });
+
+  afterEach(() => {
+    tearDownTmpHome();
+    if (savedVariant === undefined) delete process.env.MYCO_SERVICE_VARIANT;
+    else process.env.MYCO_SERVICE_VARIANT = savedVariant;
+  });
+
+  test('prod variant anchors to _unbound-bootstrap', () => {
+    process.env.MYCO_SERVICE_VARIANT = 'service';
+    expect(resolvePhantomBootstrapVaultDir(tmpHome)).toBe(path.join(tmpHome, '_unbound-bootstrap'));
+  });
+
+  test('dev variant anchors to a separate _unbound-bootstrap-dev', () => {
+    process.env.MYCO_SERVICE_VARIANT = 'service-dev';
+    expect(resolvePhantomBootstrapVaultDir(tmpHome)).toBe(path.join(tmpHome, '_unbound-bootstrap-dev'));
+  });
+
+  test('dev alias resolves to the same dev anchor', () => {
+    process.env.MYCO_SERVICE_VARIANT = 'dev';
+    expect(resolvePhantomBootstrapVaultDir(tmpHome)).toBe(path.join(tmpHome, '_unbound-bootstrap-dev'));
+  });
+
+  test('variant-less daemon uses the prod anchor', () => {
+    delete process.env.MYCO_SERVICE_VARIANT;
+    expect(resolvePhantomBootstrapVaultDir(tmpHome)).toBe(path.join(tmpHome, '_unbound-bootstrap'));
+  });
+
+  test('dev and prod anchors never collide', () => {
+    process.env.MYCO_SERVICE_VARIANT = 'service';
+    const prod = resolvePhantomBootstrapVaultDir(tmpHome);
+    process.env.MYCO_SERVICE_VARIANT = 'service-dev';
+    const dev = resolvePhantomBootstrapVaultDir(tmpHome);
+    expect(prod).not.toBe(dev);
+  });
+});


### PR DESCRIPTION
## Summary

Isolates the daemon-global bootstrap anchor vault per service variant so a dev daemon and a prod daemon can never contend over the same scratch vault — closing the cross-version contamination class behind a live prod incident.

## The bug

The dev daemon (`service-dev`) and prod daemon (`service`) both anchored to one shared scratch vault at `~/.myco/_unbound-bootstrap`. A daemon booting on a newer build runs a boot-time manifest cleanup (`removeStalePhantomProjectManifest`) that mutates that shared vault. When the dev daemon booted on the phantom-elimination build, it deleted the `project.toml` that the still-running older prod daemon depended on — every prod endpoint then 500'd with `No Grove project id available for vault …/_unbound-bootstrap` and the dashboard showed "no groves" (no data lost; pure context-resolution failure).

## The fix

`resolvePhantomBootstrapVaultDir` now resolves per variant:

- `service-dev` → `~/.myco/_unbound-bootstrap-dev`
- `service` (and variant-less) → `~/.myco/_unbound-bootstrap` (unchanged — no prod migration)

One caller; prod path is untouched. The two daemons can no longer share or mutate each other's anchor regardless of version skew.

## Testing

- 5 new unit tests pin the split (prod/dev/dev-alias/variant-less paths + a never-collide assertion).
- Full suite green: **5902 pass, 0 fail**.
- **Dogfood-verified live:** rebuilt + restarted the dev daemon — it now anchors to its own `_unbound-bootstrap-dev`, and the prod daemon stayed healthy (`/api/groves` 200, 2 groves) through the restart that previously broke it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
