### PR TITLE
Per-project capability model + deliberate project admission

### DIFF
--- a/.agents/skills/install-and-initialize-myco/SKILL.md
+++ b/.agents/skills/install-and-initialize-myco/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: myco:install-and-initialize-myco
-description: "Use this skill when installing Myco for the first time, initializing Myco in a new project, or troubleshooting a broken installation. Activate even if the user just asks \"how do I get started with Myco\" or \"how do I add Myco to my project\" without explicitly saying \"install.\" Covers the full lifecycle: bootstrapping the CLI via the install script, running `myco init`, verifying health with `myco doctor`, and managing updates and removal."
+description: "Use this skill when installing Myco for the first time, initializing Myco in a new project, or troubleshooting a broken installation. Activate even if the user just asks \"how do I get started with Myco\" or \"how do I add Myco to my project\" without explicitly saying \"install.\" Covers the full lifecycle: bootstrapping the CLI via the install script, verifying health with `myco doctor`, and managing updates and removal."
 managed_by: myco
 user-invocable: true
 allowed-tools: Read, Bash, Grep, Glob
@@ -58,7 +58,7 @@ The daemon starts automatically on first session capture if not already running.
 myco stats  # Starts daemon if not running, shows current status
 ```
 
-**Project Root Safety**: The daemon includes safety guards to prevent initialization in dangerous locations like `$HOME`. Choose a proper project directory (e.g., `/Users/yourname/projects/myapp`) for session capture.
+**Project Root Safety**: The daemon includes safety guards to prevent initialization in dangerous locations like `$HOME`. Choose a proper project directory for session capture.
 
 **What initialization accomplishes:**
 
@@ -101,6 +101,10 @@ myco doctor
 - Vault database is accessible
 - No configuration drift between `.myco/myco.yaml` and the active symbiont set
 - **Global detection status** — Validates that the manifest-driven symbiont detection system is functioning properly and can identify installed agents
+- **Capture flow** — `checkCaptureFlow()` validates that the hook-to-daemon event pipeline is delivering events correctly, detecting silent capture failures before they affect session history
+- **Migration status** — `checkMigrationStatus()` verifies pending config migrations have been applied; flags unapplied project → Grove tier migrations
+- **Symbiont edge cases** — `checkSymbiontEdgeCases()` detects known edge-case configurations that cause missed activations or duplicate registrations
+- **Global symbiont registration** — `isSymbiontRegisteredGlobally()` distinguishes per-project from global symbiont registrations for accurate status reporting
 
 Doctor flags agents whose config directory (`.claude/`, `.cursor/`, etc.) exists in the project but whose MCP entry is missing or stale. It does NOT flag agents that are installed globally but have no config directory here — binary presence without a project config directory is not a problem.
 
@@ -310,9 +314,7 @@ This is the canonical way to invoke Cortex or any Myco MCP tool from a script or
 
 **Myco Agent pipeline won't run after daemon startup without configuration.** The daemon starts with `scheduled_tasks_enabled: false` and `event_tasks_enabled: false` explicitly in `.myco/myco.yaml`. If the agent pipeline isn't running after setup, check the **Myco Agent** section in the daemon UI — LLM provider, embedding provider, and per-task scheduling all require explicit opt-in.
 
-**CLI flags are ignored on re-init of an existing vault.** Provider flags like `--embedding-provider` and `--agent-provider` are scoped exclusively to new vault creation. Running `myco init --agent-provider anthropic` on a project that already has a `.myco/` vault has no effect on provider settings — the existing configuration is preserved. To change providers on an existing vault, use the Settings UI in the daemon.
-
-**CLI help shows before config processing.** Commands like `myco init --help` and `myco update --help` display usage information immediately without reading or validating configuration files. This means help is available even in projects with broken or missing `.myco/myco.yaml` files.
+**CLI help shows before config processing.** Commands like `myco update --help` display usage information immediately without reading or validating configuration files. This means help is available even in projects with broken or missing `.myco/myco.yaml` files.
 
 **Attempting to init in unsafe locations.** Daemon operations include safety guards that prevent vault creation in dangerous project roots like `$HOME` or other system directories. Always navigate to a proper project directory before initializing Myco.
 

--- a/.agents/skills/plan-persistence-and-agent-directed-capture/SKILL.md
+++ b/.agents/skills/plan-persistence-and-agent-directed-capture/SKILL.md
@@ -92,7 +92,6 @@ export async function handleMycoPlans(
     // list/get/delete handled separately
   }
 
-  // Use direct saveMcpPlan() call instead of API endpoint
   const result = await saveMcpPlan({
     session_id: input.session_id,
     content: input.content,
@@ -176,8 +175,8 @@ export function persistPlan(input: PersistPlanInput): PlanRow {
 ### Integration Points
 
 - **Transcript mining**: Extract plans from session transcripts, generate tag-based logical keys via `extractPlansFromTranscript()`
-- **MCP agents**: Direct agent calls via `myco_plans` with `op: "save"` through the daemon API proxy
-- **File scanning**: Periodic file system scans for new plan files using path-based logical keys
+- **MCP agents**: Direct agent calls via `myco_plans` with `op: "save"` through the MCP tool surface
+- **File scanning**: Periodic file system scans for new plan files using path-based logical keys; filtered by `selectAuthoredPlanWrites()` to agent-authored writes only
 
 ## Procedure 4: Cross-Channel Deduplication
 
@@ -190,7 +189,6 @@ Handle plans captured from multiple channels with the same logical identity thro
 const existingPlan = getPlanByLogicalKey(input.logicalKey);
 
 if (existingPlan && input.logger && existingPlan.source_path !== input.sourcePath) {
-  // Log conflict for debugging when source paths differ
   input.logger.warn('Plan overwrite detected', {
     logical_key: input.logicalKey,
     old_source: existingPlan.source_path,
@@ -209,22 +207,6 @@ return upsertPlan(planRow);
 - **File vs. Agent**: Agent-directed updates take precedence over file scanning  
 - **Multiple agents**: Last successful save wins through timestamp comparison
 
-### Conflict Detection
-
-Track capture provenance to identify overlapping channels:
-
-```typescript
-// Source tracking in plan metadata
-const planRow: PlanRow = {
-  // ... other fields
-  source_path: input.sourcePath,
-  session_id: input.sessionId,
-  prompt_batch_id: input.promptBatchId,
-  machine_id: input.machineId,
-  updated_at: Math.floor(Date.now() / 1000)
-};
-```
-
 ## Procedure 5: Plan Lineage and Provenance Tracking
 
 Maintain relationships between sessions, plans, and derived spores through the existing lineage system referenced in `packages/myco/src/db/schema-ddl.ts`.
@@ -234,47 +216,11 @@ Maintain relationships between sessions, plans, and derived spores through the e
 Plans are automatically linked to sessions through the `session_id` foreign key:
 
 ```typescript
-// Session linkage in persistPlan()
 const planRow: PlanRow = {
   // ... other fields
   session_id: input.sessionId,        // Links plan to originating session
   prompt_batch_id: input.promptBatchId, // Links to specific prompt batch
 };
-```
-
-### Plan-Spore Relationships
-
-Plans can inform spore creation through manual lineage tracking:
-
-```typescript
-// When creating spores from plan content
-await vault_create_spore({
-  observation_type: 'decision',
-  content: 'Plan-driven architectural decision...',
-  session_id: sessionId,
-  properties: JSON.stringify({
-    derived_from_plan: planLogicalKey,
-    plan_section: 'architecture-decisions'
-  })
-});
-```
-
-### Provenance Queries
-
-```typescript
-// Find plans from a session
-const sessionPlans = await db.all(`
-  SELECT * FROM plans 
-  WHERE session_id = ? 
-  ORDER BY created_at
-`, [sessionId]);
-
-// Find spores referencing a plan
-const planDerivedSpores = await db.all(`
-  SELECT s.*, json_extract(s.properties, '$.derived_from_plan') as plan_ref
-  FROM spores s
-  WHERE json_extract(s.properties, '$.derived_from_plan') = ?
-`, [planLogicalKey]);
 ```
 
 ## Procedure 6: Search Integration
@@ -283,48 +229,22 @@ Integrate plan content into the semantic search pipeline through FTS5 full-text 
 
 ### FTS5 Integration
 
-Plans are automatically indexed for full-text search:
-
 ```typescript
-// Search plans by content
 const ftsResults = await vault_search_fts({
   query: searchTerm,
-  type: 'plan',  // Restrict to plan content
+  type: 'plan',
   limit: 10
 });
 ```
 
 ### Semantic Search
 
-Plans participate in semantic search through the vault's embedding infrastructure:
-
 ```typescript
-// Plan-specific semantic search
 const planResults = await vault_search_semantic({
   query: searchTerm,
-  namespace: 'plans',  // Isolate from spores, sessions, artifacts
+  namespace: 'plans',
   limit: 10
 });
-```
-
-### Content Preparation
-
-When integrating with search systems, prepare plan content appropriately:
-
-```typescript
-function preparePlanForSearch(plan: PlanRow): string {
-  // Combine title and content for rich search results
-  const content = [
-    plan.title || 'Untitled Plan',
-    plan.content,
-    JSON.parse(plan.tags || '[]').join(' ')
-  ].filter(Boolean).join('\n\n');
-  
-  // Clean for search optimization
-  return content
-    .replace(/```[\s\S]*?```/g, '[code block]')  // Replace code blocks
-    .replace(/\n{3,}/g, '\n\n');                  // Collapse whitespace
-}
 ```
 
 ## Cross-Cutting Gotchas
@@ -333,8 +253,12 @@ function preparePlanForSearch(plan: PlanRow): string {
 
 **Content hash optimization**: The `persistPlan()` function includes content hash comparison to avoid redundant writes when multiple channels converge on identical content. This prevents unnecessary team-sync enqueue operations and database churn.
 
-**Session lifecycle coordination**: Agent-directed capture can happen after session termination. The plan capture system handles both active and terminal sessions without blocking plan persistence - the `session_id` is validated but not required to be active.
+**Session lifecycle coordination**: Agent-directed capture can happen after session termination. The plan capture system handles both active and terminal sessions without blocking plan persistence — the `session_id` is validated but not required to be active.
 
 **Plan title resolution**: The `resolvePlanTitle()` function implements fallback logic: explicit title > content-derived title > existing title preservation. This prevents title thrashing when plans are updated from different sources.
 
 **Content type validation**: Plans can contain markdown, YAML, JSON, or plain text. The system defaults to 'markdown' but preserves explicit `content_type` specifications for proper rendering in the UI.
+
+**Authorship-gating via `selectAuthoredPlanWrites`**: Plan capture on session stop does not blindly scan all file-write activities — `selectAuthoredPlanWrites()` in `packages/myco/src/daemon/plan-capture.ts` filters to write events the agent itself authored (cross-referenced with `isPlanWriteEvent()`). This prevents captures of files modified by third parties during a session. When adding new capture paths, use `selectAuthoredPlanWrites()` rather than raw `listSessionFileActivities()` from `packages/myco/src/db/queries/activities.ts`.
+
+**Cross-symbiont path normalization mismatch**: `relativizeToolPath()` in `packages/myco/src/daemon/event-handlers.ts` stores activity `file_path` values relative to the project root. `normalizePlanSourcePath()` in `packages/myco/src/plans/identity.ts` also expects a project-relative path. If you match activity file paths to plan source paths across symbionts, ensure both sides use the same root — passing an absolute path to `normalizePlanSourcePath()` produces a non-matching logical key and silently creates a duplicate plan instead of deduplicating.

--- a/.agents/skills/ui-development-and-visual-identity/SKILL.md
+++ b/.agents/skills/ui-development-and-visual-identity/SKILL.md
@@ -95,42 +95,6 @@ export function TabSwitcher({ tabs, activeTab, onTabChange, layout = 'horizontal
     </div>
   );
 }
-
-function TeamSurface() {
-  const [activeTab, setActiveTab] = useState('overview');
-  const { queueStatus } = useTeamQueueStatus();
-  
-  const tabs = [
-    { id: 'overview', label: 'Overview', icon: <BarChart3 /> },
-    { 
-      id: 'queue', 
-      label: 'Queue', 
-      icon: <Clock />, 
-      count: queueStatus.pending,
-      badge: queueStatus.hasErrors ? 'error' : queueStatus.hasActive ? 'active' : undefined
-    },
-    { id: 'members', label: 'Members', icon: <Users /> },
-    { id: 'projects', label: 'Projects', icon: <FolderOpen />, disabled: !hasProjectAccess }
-  ];
-  
-  // Auto-switch to queue tab on critical errors
-  useEffect(() => {
-    if (queueStatus.hasErrors && activeTab !== 'queue') {
-      setActiveTab('queue');
-      navigate(`${location.pathname}?tab=queue`);
-    }
-  }, [queueStatus.hasErrors]);
-  
-  return (
-    <div className="team-surface">
-      <TabSwitcher tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
-      <div className="tab-content">
-        {activeTab === 'queue' && <TeamQueueManager queueStatus={queueStatus} />}
-        {/* other tab content */}
-      </div>
-    </div>
-  );
-}
 ```
 
 ### URL State Management with React Router
@@ -162,26 +126,23 @@ function useUrlState() {
   
   return { readUrlState, updateUrlState };
 }
-
-function SettingsPage() {
-  const { readUrlState, updateUrlState } = useUrlState();
-  const currentTab = readUrlState().params.tab || 'general';
-  
-  const handleTabChange = (tabId: string) => {
-    updateUrlState({ tab: tabId });
-  };
-  
-  return (
-    <div className="settings-page">
-      <TabSwitcher 
-        tabs={settingsTabs} 
-        activeTab={currentTab} 
-        onTabChange={handleTabChange} 
-      />
-    </div>
-  );
-}
 ```
+
+### Auth-Gated Attachment Rendering
+
+Attachment bytes are served by a bearer-token-gated daemon route (`/api/g/:groveId/p/:projectId/attachments/:file`). A bare `<img src>` cannot send the `x-myco-auth` header — always use `AttachmentImage` or `useAttachmentObjectUrls` from `packages/myco/ui/src/components/ui/attachment-image.tsx`:
+
+```typescript
+import { AttachmentImage, useAttachmentObjectUrls } from '../ui/attachment-image';
+
+// Single image (preferred for all attachment display)
+<AttachmentImage filePath={attachment.file_path} alt="attachment" />
+
+// Multiple images — for lightbox or raw URL access
+const objectUrls = useAttachmentObjectUrls(attachments.map(a => a.file_path));
+```
+
+`AttachmentImage` fetches with the `x-myco-auth` bearer token and renders a blob object URL. The (Grove, project) scope is resolved from the current project selection automatically. Never use `<img src={attachment.file_path}>` directly.
 
 ## Procedure B: Theme System
 
@@ -235,32 +196,8 @@ function init_grove_worktree_enhanced() {
   
   npm run build:ui || { echo "❌ UI build failed"; return 1; }
   
-  # Generate worktree config
-  cat > ".myco/worktree.yaml" << EOF
-worktree:
-  branch: $branch_name
-  ui_workspaces_verified: true
-development:
-  hot_reload: true
-  theme_dev_mode: true
-EOF
-  
   echo "✅ Grove worktree ready"
 }
-```
-
-### Vite Configuration for Grove
-
-```typescript
-export default defineConfig({
-  server: {
-    fs: { allow: ['..', '../..', '../../..'] }, // Worktree compatibility
-    watch: {
-      include: ['src/**/*', '../../../shared/**/*'],
-      exclude: ['node_modules/**', '.worktrees/**']
-    }
-  }
-});
 ```
 
 ## Procedure D: Enhanced Cloudflare Worker Constraints
@@ -285,56 +222,6 @@ function CloudflareWorkerCompatibleUpload() {
     }
     return { valid: true };
   }
-  
-  function useWorkerApiClient() {
-    return useMutation({
-      mutationFn: async (data: ApiRequest) => {
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), EXECUTION_TIMEOUT);
-        
-        try {
-          const response = await fetch('/api/worker-endpoint', {
-            method: 'POST',
-            body: JSON.stringify(data),
-            signal: controller.signal,
-            headers: { 'X-Worker-Timeout': EXECUTION_TIMEOUT.toString() }
-          });
-          
-          clearTimeout(timeoutId);
-          if (!response.ok) throw new Error(`Worker request failed: ${response.status}`);
-          return response.json();
-          
-        } catch (error) {
-          clearTimeout(timeoutId);
-          if (error.name === 'AbortError') {
-            throw new Error('Worker timeout - try reducing file size');
-          }
-          throw error;
-        }
-      }
-    });
-  }
-}
-
-// Worker-aware form with constraint validation
-function WorkerConstraintForm() {
-  const [file, setFile] = useState<File | null>(null);
-  const validation = file ? validateFileForWorker(file) : { valid: false };
-  
-  return (
-    <form>
-      <input 
-        type="file" 
-        onChange={(e) => setFile(e.target.files?.[0] || null)}
-        accept="image/jpeg,image/png,image/webp"
-      />
-      <Badge variant={validation.valid ? 'success' : 'warning'}>
-        Max 1MB • Cloudflare limits apply
-      </Badge>
-      {!validation.valid && validation.error && <p className="error">{validation.error}</p>}
-      <Button disabled={!validation.valid}>Upload</Button>
-    </form>
-  );
 }
 ```
 
@@ -358,7 +245,6 @@ export function MasterDetailSplit({
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [showDetail, onCloseDetail]);
 
-  // Layout primitive owns all spacing decisions
   const spacingClass = {
     'compact': 'spacing-compact',
     'default': 'spacing-default',
@@ -375,19 +261,6 @@ export function MasterDetailSplit({
         </div>
       )}
     </div>
-  );
-}
-
-// Usage: Let primitive control spacing, not leaf pages
-function ProjectListPage() {
-  return (
-    <MasterDetailSplit
-      spacing="comfortable" // Primitive decision, not page decision
-      masterContent={<ProjectList />}
-      detailContent={showDetail && <ProjectDetail projectId={selectedProject} />}
-      showDetail={!!selectedProject}
-      onCloseDetail={() => setSelectedProject(null)}
-    />
   );
 }
 ```
@@ -455,12 +328,11 @@ function RuntimeStatusBadge() {
 **Critical update**: Wait for explicit go-ahead signals before merging PRs:
 
 ```typescript
-// PR merge readiness checks
 interface PRMergeChecks {
   reviewsComplete: boolean;
   ciPassing: boolean;
   conflictsResolved: boolean;
-  goAheadReceived: boolean; // New requirement
+  goAheadReceived: boolean;
 }
 
 function PRMergeController({ prId, checks }: { prId: string; checks: PRMergeChecks }) {
@@ -476,56 +348,14 @@ function PRMergeController({ prId, checks }: { prId: string; checks: PRMergeChec
         label="Explicit go-ahead received"
         critical
       />
-      
       <Button 
         disabled={!canMerge}
-        variant={canMerge ? 'default' : 'ghost'}
         onClick={() => mergePR(prId)}
       >
         {canMerge ? 'Merge PR' : 'Waiting for go-ahead signal'}
       </Button>
-      
-      {!checks.goAheadReceived && (
-        <Alert variant="warning">
-          <AlertTriangle className="h-4 w-4" />
-          <AlertTitle>Go-ahead required</AlertTitle>
-          <AlertDescription>
-            Wait for explicit merge approval signal before proceeding. 
-            Auto-merge disabled until go-ahead confirmation received.
-          </AlertDescription>
-        </Alert>
-      )}
     </div>
   );
-}
-
-// Go-ahead signal patterns for different contexts
-const GoAheadSignals = {
-  // Team review contexts
-  REVIEW_COMPLETE: 'review:complete',
-  DESIGN_APPROVED: 'design:approved', 
-  
-  // CI/deployment contexts  
-  STAGING_VERIFIED: 'staging:verified',
-  PERF_BASELINE_MET: 'perf:baseline-met',
-  
-  // Architecture contexts
-  ARCH_REVIEW_PASSED: 'arch:review-passed',
-  BREAKING_CHANGE_APPROVED: 'breaking:approved'
-};
-
-function useGoAheadPattern(requiredSignals: string[]) {
-  const [receivedSignals, setReceivedSignals] = useState<Set<string>>(new Set());
-  
-  const allSignalsReceived = requiredSignals.every(signal => 
-    receivedSignals.has(signal)
-  );
-  
-  const receiveSignal = (signal: string) => {
-    setReceivedSignals(prev => new Set(prev).add(signal));
-  };
-  
-  return { allSignalsReceived, receiveSignal, receivedSignals };
 }
 ```
 
@@ -540,9 +370,6 @@ function useGoAheadPattern(requiredSignals: string[]) {
 ### TabSwitcher Queue Integration  
 **Queue error states must trigger auto-navigation to queue tab**. Missing queue status monitoring breaks Phase 6 team consolidation workflow.
 
-### Cloudflare Worker Constraints
-**Worker timeout errors need differentiated handling**. Use worker-specific error types and provide actionable constraint guidance to users.
-
 ### Instance Context
 **Components default to daemon behavior without proper InstanceContext**. Ensure context provider wraps the app tree.
 
@@ -552,14 +379,14 @@ function useGoAheadPattern(requiredSignals: string[]) {
 ### Project Context Leaks
 **Grove multi-tenant data can leak without proper headers**. Always inject `X-Grove-Slug` and `X-Project-Slug` headers.
 
-### UI Workspace Verification
-**Missing type checks after worktree creation cause build failures**. The enhanced setup includes automatic verification steps.
-
 ### React Router vs Window Location
-**Using window.location directly breaks MemoryRouter compatibility**. Always use React Router hooks (useLocation, useNavigate, useSearchParams) for URL state management. Direct window access fails in testing environments and Electron contexts that use MemoryRouter.
+**Using window.location directly breaks MemoryRouter compatibility**. Always use React Router hooks (useLocation, useNavigate, useSearchParams) for URL state management.
 
 ### Layout Primitive Spacing Authority
-**Leaf pages must not override layout primitive spacing decisions**. MasterDetailSplit and similar primitives own spacing through props - leaf components should not apply conflicting margin/padding styles. This prevents layout inconsistencies and ensures visual design system coherence.
+**Leaf pages must not override layout primitive spacing decisions**. MasterDetailSplit and similar primitives own spacing through props — leaf components should not apply conflicting margin/padding styles.
 
 ### PR Merge Go-Ahead Discipline  
-**Auto-merge without explicit go-ahead signals creates integration risks**. Always implement go-ahead confirmation patterns for non-trivial PRs. Missing explicit approval gates cause premature merges that bypass critical review checkpoints.
+**Auto-merge without explicit go-ahead signals creates integration risks**. Always implement go-ahead confirmation patterns for non-trivial PRs.
+
+### Attachment Routes Are Auth-Gated
+**Never render attachment images with bare `<img src>`**. Attachment routes (`/api/g/:groveId/p/:projectId/attachments/:file`) require the `x-myco-auth` bearer token, which a standard `<img>` element cannot send. Use `AttachmentImage` from `packages/myco/ui/src/components/ui/attachment-image.tsx` for all attachment display. Use `useAttachmentObjectUrls` when raw blob URLs are needed (e.g. lightboxes). Using a bare image tag silently renders a broken image or an auth error response as binary garbage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Myco captures project memory in a local vault and serves it back through context
 
 - Think before coding. Surface assumptions and ambiguities instead of guessing.
 - Prefer extending existing patterns over one-off patches.
+- Plans are guideposts, not scripts: reconcile a plan's code against the current code before writing, and when a step would duplicate an existing surface or fight an existing pattern, follow the plan's intent and the existing pattern — surface the deviation, do not transcribe literally into a violation. Reviewers MUST check pattern-fit and duplication, not just fidelity to the plan.
 - Prefer established architectural patterns like Vertical Slice Architecture, CLEAN architecture, CQRS, Dependency Injection, etc. when they are appropriate.
 - Keep code DRY. Extract helpers or shared patterns when they remove real duplication.
 - Preserve clear domain ownership. Do not blur module boundaries without a reason. Callout and fix when you see this happening.

--- a/packages/myco/src/config/capabilities.ts
+++ b/packages/myco/src/config/capabilities.ts
@@ -57,7 +57,7 @@ export const CAPABILITIES: Record<CapabilityId, CapabilityDef> = {
     masterGate: 'vault_evolution.enabled',
     memberGates: [],
     scheduledTasks: ['vault-evolve'],
-    advancedSettingsLink: '/settings#agent',
+    advancedSettingsLink: '/settings#vault_evolution',
   },
 };
 

--- a/packages/myco/src/config/capabilities.ts
+++ b/packages/myco/src/config/capabilities.ts
@@ -1,3 +1,5 @@
+import { getAtPath } from '../utils/dot-path.js';
+import type { MycoConfig } from './schema.js';
 import type { CapabilityId } from './scope.js';
 
 /**
@@ -67,4 +69,19 @@ export function capabilityForTask(taskName: string): CapabilityId | null {
     if (cap.scheduledTasks.includes(taskName)) return cap.id;
   }
   return null;
+}
+
+/**
+ * Single authoritative capability gate. Fail-closed: a null/unloadable
+ * config disables the capability. A master gate defaults on (only `false`
+ * disables) — matching the gate-honoring contract.
+ */
+export function capabilityEnabled(config: MycoConfig | null | undefined, capId: CapabilityId): boolean {
+  if (!config) return false;
+  return getAtPath(config, CAPABILITIES[capId].masterGate) !== false;
+}
+
+/** All opt-in capabilities off → the project is capture-only. */
+export function isCaptureOnly(config: MycoConfig | null | undefined): boolean {
+  return (Object.keys(CAPABILITIES) as CapabilityId[]).every((id) => !capabilityEnabled(config, id));
 }

--- a/packages/myco/src/config/capabilities.ts
+++ b/packages/myco/src/config/capabilities.ts
@@ -33,7 +33,7 @@ export const CAPABILITIES: Record<CapabilityId, CapabilityDef> = {
     masterGate: 'cortex.enabled',
     memberGates: [],
     scheduledTasks: ['cortex-instructions'],
-    advancedSettingsLink: '/settings#cortex',
+    advancedSettingsLink: '/settings#scheduled-tasks',
   },
   canopy: {
     id: 'canopy',
@@ -41,7 +41,7 @@ export const CAPABILITIES: Record<CapabilityId, CapabilityDef> = {
     masterGate: 'cortex.canopy.enabled',
     memberGates: [],
     scheduledTasks: ['canopy-map', 'canopy-describe'],
-    advancedSettingsLink: '/settings#canopy',
+    advancedSettingsLink: '/settings#scheduled-tasks',
   },
   skills: {
     id: 'skills',
@@ -57,7 +57,7 @@ export const CAPABILITIES: Record<CapabilityId, CapabilityDef> = {
     masterGate: 'vault_evolution.enabled',
     memberGates: [],
     scheduledTasks: ['vault-evolve'],
-    advancedSettingsLink: '/settings#vault_evolution',
+    advancedSettingsLink: '/settings#scheduled-tasks',
   },
 };
 

--- a/packages/myco/src/config/capabilities.ts
+++ b/packages/myco/src/config/capabilities.ts
@@ -1,0 +1,70 @@
+import type { CapabilityId } from './scope.js';
+
+/**
+ * The declarative capability map — the single source for: which config leaves
+ * a capability toggle flips, which scheduled tasks it governs, and where its
+ * advanced settings live. Keep this current as cost-bearing features are
+ * added; the capability sync test fails loudly if a gate path drifts from the
+ * schema/registry.
+ *
+ * NOTE: `enabled`-style member gates that default ON are NOT listed as members
+ * unless the toggle should explicitly flip them. The master gate is
+ * authoritative at runtime (gate-honoring plan), so members are for UI grouping
+ * + demote-clears-overrides, not for runtime suppression.
+ */
+export interface CapabilityDef {
+  id: CapabilityId;
+  /** Human label for badges + the capability panel. */
+  label: string;
+  /** Config leaf flipped to enable/disable the capability. */
+  masterGate: string;
+  /** Other config leaves this capability governs (UI grouping / demote). */
+  memberGates: string[];
+  /** Agent task names this capability gates (consumed by the gate-honoring plan). */
+  scheduledTasks: string[];
+  /** Settings route for advanced knobs (deep-linked from the panel; finalized in the UI plan). */
+  advancedSettingsLink: string;
+}
+
+export const CAPABILITIES: Record<CapabilityId, CapabilityDef> = {
+  cortex: {
+    id: 'cortex',
+    label: 'Cortex',
+    masterGate: 'cortex.enabled',
+    memberGates: [],
+    scheduledTasks: ['cortex-instructions'],
+    advancedSettingsLink: '/settings#cortex',
+  },
+  canopy: {
+    id: 'canopy',
+    label: 'Canopy',
+    masterGate: 'cortex.canopy.enabled',
+    memberGates: [],
+    scheduledTasks: ['canopy-map', 'canopy-describe'],
+    advancedSettingsLink: '/settings#canopy',
+  },
+  skills: {
+    id: 'skills',
+    label: 'Skills',
+    masterGate: 'skills.enabled',
+    memberGates: [],
+    scheduledTasks: ['skill-survey', 'skill-generate', 'skill-evolve'],
+    advancedSettingsLink: '/settings#skills',
+  },
+  vault_evolution: {
+    id: 'vault_evolution',
+    label: 'Vault Evolution',
+    masterGate: 'vault_evolution.enabled',
+    memberGates: [],
+    scheduledTasks: ['vault-evolve'],
+    advancedSettingsLink: '/settings#agent',
+  },
+};
+
+/** Resolve the capability that governs a given agent task name, or null. */
+export function capabilityForTask(taskName: string): CapabilityId | null {
+  for (const cap of Object.values(CAPABILITIES)) {
+    if (cap.scheduledTasks.includes(taskName)) return cap.id;
+  }
+  return null;
+}

--- a/packages/myco/src/config/migrations.ts
+++ b/packages/myco/src/config/migrations.ts
@@ -499,6 +499,21 @@ export const MIGRATIONS: Migration[] = [
       }
     },
   },
+  {
+    version: 10,
+    name: 'seed-canopy-enabled-from-inject-on-pre-tool-use',
+    appliesToLocal: false,
+    migrate(doc: Record<string, unknown>): void {
+      const cortex = doc.cortex as Record<string, unknown> | undefined;
+      if (!cortex) return;
+      const canopy = cortex.canopy as Record<string, unknown> | undefined;
+      if (!canopy) return;
+      if ('enabled' in canopy) return;
+      if ('inject_on_pre_tool_use' in canopy) {
+        canopy.enabled = canopy.inject_on_pre_tool_use;
+      }
+    },
+  },
 ];
 
 /** Current migration version — the highest version in MIGRATIONS. */

--- a/packages/myco/src/config/migrations.ts
+++ b/packages/myco/src/config/migrations.ts
@@ -502,7 +502,9 @@ export const MIGRATIONS: Migration[] = [
   {
     version: 10,
     name: 'seed-canopy-enabled-from-inject-on-pre-tool-use',
-    appliesToLocal: false,
+    // Value-relocation (not a seeder): only fires when inject_on_pre_tool_use
+    // is present, so it does not expand sparse local.yaml docs. Must run on
+    // local.yaml to preserve a Personal override of inject_on_pre_tool_use.
     migrate(doc: Record<string, unknown>): void {
       const cortex = doc.cortex as Record<string, unknown> | undefined;
       if (!cortex) return;

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -479,12 +479,6 @@ export type AppearanceConfig = z.infer<typeof AppearanceConfigSchema>;
  * MCP children all converge on the same value without per-machine config
  * lookup. See `daemon/port.ts`.
  */
-const VaultEvolutionSchema = z.object({
-  /** Master gate for the Vault-Evolution capability (the `vault-evolve`
-   *  scheduled task). Grove-tier home; per-project Personal override. */
-  enabled: z.boolean().default(true),
-});
-
 const MachineDaemonSchema = z.object({
   /** Log verbosity for the daemon process (stdout/stderr). */
   log_level: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
@@ -580,6 +574,12 @@ const GroveAgentSchema = rejectLegacyRuntimeKey(z.object({
   model: z.string().optional(),
   tasks: z.record(z.string(), TaskProviderOverrideSchema).optional(),
 }));
+
+const VaultEvolutionSchema = z.object({
+  /** Master gate for the Vault-Evolution capability (the `vault-evolve`
+   *  scheduled task). Grove-tier home; per-project Personal override. */
+  enabled: z.boolean().default(true),
+});
 
 export const GroveConfigSchema = z.object({
   daemon: GroveDaemonSchema.default(() => GroveDaemonSchema.parse({})),

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -50,6 +50,10 @@ const CaptureSchema = z.object({
   ignore_plan_dirs_in_git: z.boolean().default(false),
   artifact_extensions: z.array(z.string()).default(['.md']),
   buffer_max_events: z.number().int().positive().default(500),
+  ignore: z.object({
+    paths: z.array(z.string()).default([]),
+    patterns: z.array(z.string()).default([]),
+  }).default(() => ({ paths: [], patterns: [] })),
 });
 
 /**

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -279,6 +279,8 @@ export const TeamSchema = z.object({
 });
 
 const SkillsSchema = z.object({
+  /** Master gate for the Skills capability (survey/generate/evolve tasks). */
+  enabled: z.boolean().default(true),
   /** Auto-generate candidates above this confidence score. */
   confidence_threshold: z.number().min(0).max(1).default(0.7),
   /** Flag unused skills after this many days. */
@@ -403,6 +405,10 @@ const CortexPlansSchema = z.object({
 });
 
 const CortexCanopySchema = z.object({
+  /** Master gate for the Canopy capability (map/describe tasks, background
+   *  scan, PreToolUse injection). Migrated from `inject_on_pre_tool_use` —
+   *  see the gate-honoring plan for the one-time compat default. */
+  enabled: z.boolean().default(true),
   /** When/how the Canopy index is rebuilt (data plane). */
   refresh: CanopyRefreshSchema.default(() => CanopyRefreshSchema.parse({})),
   /** What the scanner skips (data plane). */
@@ -473,6 +479,12 @@ export type AppearanceConfig = z.infer<typeof AppearanceConfigSchema>;
  * MCP children all converge on the same value without per-machine config
  * lookup. See `daemon/port.ts`.
  */
+const VaultEvolutionSchema = z.object({
+  /** Master gate for the Vault-Evolution capability (the `vault-evolve`
+   *  scheduled task). Grove-tier home; per-project Personal override. */
+  enabled: z.boolean().default(true),
+});
+
 const MachineDaemonSchema = z.object({
   /** Log verbosity for the daemon process (stdout/stderr). */
   log_level: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
@@ -586,6 +598,8 @@ export const GroveConfigSchema = z.object({
    * the rest of `agent.*` does.
    */
   skills: SkillsSchema.default(() => SkillsSchema.parse({})),
+  /** Vault-Evolution capability master gate (Grove-tier home). */
+  vault_evolution: VaultEvolutionSchema.default(() => VaultEvolutionSchema.parse({})),
 }).strict();
 
 /**
@@ -686,6 +700,7 @@ export const MycoConfigSchema = z.preprocess(
     update: UpdateSchema.default(() => UpdateSchema.parse({})),
     team: TeamSchema.default(() => TeamSchema.parse({})),
     skills: SkillsSchema.default(() => SkillsSchema.parse({})),
+    vault_evolution: VaultEvolutionSchema.default(() => VaultEvolutionSchema.parse({})),
     notifications: NotificationsSchema.default(() => NotificationsSchema.parse({})),
     cortex: CortexSchema.default(() => CortexSchema.parse({})),
     appearance: AppearanceConfigSchema,
@@ -703,6 +718,7 @@ export type ScheduleOverride = z.infer<typeof ScheduleOverrideSchema>;
 export type BackupConfig = z.infer<typeof BackupSchema>;
 export type TeamConfig = z.infer<typeof TeamSchema>;
 export type SkillsConfig = z.infer<typeof SkillsSchema>;
+export type VaultEvolutionConfig = z.infer<typeof VaultEvolutionSchema>;
 export type NotificationsConfig = z.infer<typeof NotificationsSchema>;
 // CanopyConfig removed in config_version 8 — Canopy now lives under
 // `cortex.canopy`. Use `MycoConfig['cortex']['canopy']` for the slice.

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -52,6 +52,7 @@ const CaptureSchema = z.object({
   buffer_max_events: z.number().int().positive().default(500),
   ignore: z.object({
     paths: z.array(z.string()).default([]),
+    /** Globs matched against the absolute project root; `~` is expanded. */
     patterns: z.array(z.string()).default([]),
   }).default(() => ({ paths: [], patterns: [] })),
 });

--- a/packages/myco/src/config/scope.ts
+++ b/packages/myco/src/config/scope.ts
@@ -57,7 +57,10 @@ export const SCOPE_REGISTRY: Record<string, ScopeEntry> = {
   // over the `agent` block.
   'agent.scheduled_tasks_enabled': { home: 'grove', overridableBy: [] },
   'agent.event_tasks_enabled': { home: 'grove', overridableBy: [] },
-  'skills': { home: 'grove', overridableBy: ['local'] },
+  'skills': { home: 'grove', overridableBy: ['local'], gate: 'skills' },
+  // Vault-Evolution capability master gate. Grove-tier home, per-project
+  // Personal override so a project can be promoted/demoted on this machine.
+  'vault_evolution': { home: 'grove', overridableBy: ['local'], gate: 'vault_evolution' },
   'maintenance': { home: 'grove', overridableBy: ['local'] },
   // backup is a Grove-level resource: the Grove is a DB boundary and one
   // project sets the backup for the ENTIRE Grove, so a per-project/per-machine
@@ -69,7 +72,10 @@ export const SCOPE_REGISTRY: Record<string, ScopeEntry> = {
   // reconcile-interval leaf is the one exception below.
   'release_provenance': { home: 'project', overridableBy: [] },
   'release_provenance.reconcile_interval_minutes': { home: 'grove', overridableBy: ['project', 'local'] },
-  'cortex': { home: 'project', overridableBy: ['local'] },
+  'cortex': { home: 'project', overridableBy: ['local'], gate: 'cortex' },
+  // Canopy splits out of the cortex block via a longer prefix (longest-prefix
+  // match wins, same pattern as agent.scheduled_tasks_enabled over `agent`).
+  'cortex.canopy': { home: 'project', overridableBy: ['local'], gate: 'canopy' },
   'symbionts': { home: 'project', overridableBy: ['local'] },
   // internal
   'version': { home: 'project', overridableBy: [] },

--- a/packages/myco/src/config/scope.ts
+++ b/packages/myco/src/config/scope.ts
@@ -5,11 +5,19 @@ import { enumerateLeafPaths } from './leaf-paths.js';
 export type Tier = 'machine' | 'grove' | 'project' | 'local';
 export const TIER_PRECEDENCE: readonly Tier[] = ['machine', 'grove', 'project', 'local'];
 
+/** The opt-in per-project capabilities. A capability is a master config gate
+ *  plus the settings it governs (declared in `capabilities.ts`). */
+export const CAPABILITY_IDS = ['cortex', 'canopy', 'skills', 'vault_evolution'] as const;
+export type CapabilityId = (typeof CAPABILITY_IDS)[number];
+
 export interface ScopeEntry {
   /** Canonical tier — where the default lives; shown as the UI default badge. */
   home: Tier;
   /** More-specific tiers that may override it (subset of tiers > home). */
   overridableBy: Tier[];
+  /** Capability this setting belongs to, if any. Used by the capability
+   *  toggles + the sync test; absent for settings outside any capability. */
+  gate?: CapabilityId;
 }
 
 /**

--- a/packages/myco/src/context/cortex-brief.ts
+++ b/packages/myco/src/context/cortex-brief.ts
@@ -472,6 +472,7 @@ export async function buildScheduledCortexInstruction(
   getTeamClient?: () => CortexTeamStatusPort | null,
   requestContext?: MycoRequestContext,
 ): Promise<CortexInstructionPayload | undefined> {
+  if (!config.cortex.enabled) return undefined;
   const built = await buildCortexInstructionsInput(config, vaultDir, getTeamClient, requestContext);
   const existing = getCortexInstructions(DEFAULT_AGENT_ID, projectScopeFromRequestContext(requestContext));
   if (existing?.input_hash === built.inputHash) {

--- a/packages/myco/src/context/cortex-brief.ts
+++ b/packages/myco/src/context/cortex-brief.ts
@@ -12,6 +12,7 @@
  */
 import { createHash } from 'node:crypto';
 import type { MycoConfig } from '@myco/config/schema.js';
+import { capabilityEnabled } from '@myco/config/capabilities.js';
 import {
   CONTENT_HASH_ALGORITHM,
   DEFAULT_AGENT_ID,
@@ -146,14 +147,15 @@ export async function resolveCortexCapabilities(
 
 /**
  * Whether Cortex should inject session-start instructions for this
- * config. Combines the Cortex master-kill with the per-event toggle.
+ * config. Combines the Cortex capability master gate (via the single
+ * `capabilityEnabled` predicate) with the per-event toggle.
  */
-export function shouldInjectCortex(cortex: MycoConfig['cortex']): boolean {
-  return cortex.enabled && cortex.instructions.inject_on_session_start;
+export function shouldInjectCortex(config: MycoConfig): boolean {
+  return capabilityEnabled(config, 'cortex') && config.cortex.instructions.inject_on_session_start;
 }
 
 export function resolveInstructionDelivery(
-  cortex: MycoConfig['cortex'],
+  config: MycoConfig,
   symbiont: {
     supportsSessionStartInjection: boolean;
   } | null,
@@ -161,7 +163,7 @@ export function resolveInstructionDelivery(
   if (!symbiont) {
     return { inlineInstructions: true, reason: 'missing-symbiont' };
   }
-  if (!shouldInjectCortex(cortex)) {
+  if (!shouldInjectCortex(config)) {
     return { inlineInstructions: true, reason: 'session-start-disabled' };
   }
   if (symbiont.supportsSessionStartInjection) {
@@ -418,7 +420,7 @@ export async function buildCortexInstructionsInput(
     '- When you mention recent plans, label the section "Recent plans" or "Recent workstreams" (NOT "Current workstreams" — that implies the new session is going to work on them). Treat them as background: prior or in-flight work the agent should be aware of when its actual task happens to overlap, not a directive to engage.',
   ];
 
-  if (shouldInjectCortex(config.cortex) && hasCanopyMap) {
+  if (shouldInjectCortex(config) && hasCanopyMap) {
     // Emitted only when a non-empty Canopy Map exists for this project.
     // That gate makes the directive trustworthy unconditionally — there
     // is no empty-state caveat to hedge with — so the generated downstream
@@ -472,7 +474,7 @@ export async function buildScheduledCortexInstruction(
   getTeamClient?: () => CortexTeamStatusPort | null,
   requestContext?: MycoRequestContext,
 ): Promise<CortexInstructionPayload | undefined> {
-  if (!config.cortex.enabled) return undefined;
+  if (!capabilityEnabled(config, 'cortex')) return undefined;
   const built = await buildCortexInstructionsInput(config, vaultDir, getTeamClient, requestContext);
   const existing = getCortexInstructions(DEFAULT_AGENT_ID, projectScopeFromRequestContext(requestContext));
   if (existing?.input_hash === built.inputHash) {

--- a/packages/myco/src/context/session-start-context.ts
+++ b/packages/myco/src/context/session-start-context.ts
@@ -42,7 +42,7 @@ export function composeSessionStartContext(
   cortexContent: string,
   scope: import('@myco/grove/ids.js').ProjectScope = { kind: 'global' },
 ): ComposedSessionStartContext {
-  const cortexEnabled = shouldInjectCortex(config.cortex);
+  const cortexEnabled = shouldInjectCortex(config);
   const digestEnabled = shouldInjectSessionStartDigest(config.cortex.digest);
   const parts: SessionStartContextPart[] = [];
 

--- a/packages/myco/src/daemon/api/canopy-inject.ts
+++ b/packages/myco/src/daemon/api/canopy-inject.ts
@@ -25,6 +25,7 @@ import { z } from 'zod';
 import { filesystemRootFromRequestContext } from '../../grove/request-context.js';
 import type { MycoConfig } from '../../config/schema.js';
 import { loadMergedConfig } from '../../config/loader.js';
+import { capabilityEnabled } from '../../config/capabilities.js';
 import type { CanopyEntry } from '../../db/schema.js';
 import type { Database } from '../../db/client.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
@@ -109,19 +110,20 @@ export function createCanopyInjectHandler(deps: CanopyInjectDeps) {
     }
     const projectRoot = filesystemRootFromRequestContext(ctx);
     const projectId = ctx.projectId;
-    let projectConfig: MycoConfig;
+    let projectConfig: MycoConfig | null = null;
     try {
       projectConfig = loadMergedConfig(ctx.projectVaultDir, { groveId: ctx.groveId ?? null });
     } catch {
-      // Project not yet initialized — fall back to the bootstrap config so
-      // partially-initialized projects don't break injection.
-      projectConfig = deps.liveConfig.current;
+      // Project not yet initialized — treat as capability_off (fail-closed)
+      // rather than falling back to the bootstrap config, which could leak
+      // cross-tenant config or silently inject for projects whose config
+      // is temporarily unreadable.
     }
-    if (!projectConfig.cortex.canopy.enabled) {
+    if (!capabilityEnabled(projectConfig, 'canopy')) {
       const body: InjectResponseBody = { inject: false, reason: 'capability_off' };
       return { body };
     }
-    const config = projectConfig.cortex.canopy;
+    const config = projectConfig!.cortex.canopy;
 
     const capabilityOn = symbiontHasCapability(agent, 'preToolUseInjection');
 

--- a/packages/myco/src/daemon/api/canopy-inject.ts
+++ b/packages/myco/src/daemon/api/canopy-inject.ts
@@ -109,9 +109,9 @@ export function createCanopyInjectHandler(deps: CanopyInjectDeps) {
     }
     const projectRoot = filesystemRootFromRequestContext(ctx);
     const projectId = ctx.projectId;
-    let projectConfig;
+    let projectConfig: MycoConfig;
     try {
-      projectConfig = loadMergedConfig(ctx.projectVaultDir, { groveId: ctx.groveId ?? undefined });
+      projectConfig = loadMergedConfig(ctx.projectVaultDir, { groveId: ctx.groveId ?? null });
     } catch {
       // Project not yet initialized — fall back to the bootstrap config so
       // partially-initialized projects don't break injection.

--- a/packages/myco/src/daemon/api/canopy-inject.ts
+++ b/packages/myco/src/daemon/api/canopy-inject.ts
@@ -24,6 +24,7 @@ import path from 'node:path';
 import { z } from 'zod';
 import { filesystemRootFromRequestContext } from '../../grove/request-context.js';
 import type { MycoConfig } from '../../config/schema.js';
+import { loadMergedConfig } from '../../config/loader.js';
 import type { CanopyEntry } from '../../db/schema.js';
 import type { Database } from '../../db/client.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
@@ -108,7 +109,19 @@ export function createCanopyInjectHandler(deps: CanopyInjectDeps) {
     }
     const projectRoot = filesystemRootFromRequestContext(ctx);
     const projectId = ctx.projectId;
-    const config = deps.liveConfig.current.cortex.canopy;
+    let projectConfig;
+    try {
+      projectConfig = loadMergedConfig(ctx.projectVaultDir, { groveId: ctx.groveId ?? undefined });
+    } catch {
+      // Project not yet initialized — fall back to the bootstrap config so
+      // partially-initialized projects don't break injection.
+      projectConfig = deps.liveConfig.current;
+    }
+    if (!projectConfig.cortex.canopy.enabled) {
+      const body: InjectResponseBody = { inject: false, reason: 'capability_off' };
+      return { body };
+    }
+    const config = projectConfig.cortex.canopy;
 
     const capabilityOn = symbiontHasCapability(agent, 'preToolUseInjection');
 

--- a/packages/myco/src/daemon/api/config.ts
+++ b/packages/myco/src/daemon/api/config.ts
@@ -20,7 +20,7 @@ import {
   type GroveConfig,
   type MachineConfig,
 } from '../../config/schema.js';
-import { unsetAtPath } from '../../utils/dot-path.js';
+import { getAtPath, setAtPath, unsetAtPath } from '../../utils/dot-path.js';
 import { enumerateLeafPaths } from '../config-reactions/touched-paths.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 
@@ -53,10 +53,23 @@ export async function handleGetLocalConfig(
   return { body: loadLocalConfig(vaultDir) };
 }
 
+// ---------------------------------------------------------------------------
+// List-delta op types — shared by scoped + tier config PUT handlers
+// ---------------------------------------------------------------------------
+
+interface ListDeltaEntry {
+  path: string;
+  values: unknown[];
+}
+
 interface ScopedPutBody {
   scope?: 'project' | 'local';
   patch?: Record<string, unknown>;
   clear?: string[];
+  /** Add values to the named array path (deduped, server-side read-modify-write). */
+  addToList?: ListDeltaEntry[];
+  /** Remove values from the named array path (server-side read-modify-write). */
+  removeFromList?: ListDeltaEntry[];
 }
 
 const SCOPED_CONFIG_SCOPES = ['project', 'local'] as const;
@@ -83,16 +96,18 @@ function pathsOverlap(a: string, b: string): boolean {
 }
 
 /**
- * PUT /api/config/scoped — atomic patch + clear against project or local config.
+ * PUT /api/config/scoped — atomic patch + clear + list-delta against project or local config.
  *
  * Request body:
  *   { scope: 'project' | 'local',
- *     patch?: DeepPartial<MycoConfig>,   // deep-merged into scope
- *     clear?: string[] }                  // dot-paths removed from scope
+ *     patch?: DeepPartial<MycoConfig>,              // deep-merged into scope
+ *     clear?: string[],                              // dot-paths removed from scope
+ *     addToList?: [{ path, values }],                // set-union additions (deduped)
+ *     removeFromList?: [{ path, values }] }          // set-difference removals
  *
- * At least one of `patch` (non-empty object) or `clear` (non-empty array) is
- * required. If both are present, overlapping keys are rejected (400). The
- * server applies `clear` first, then merges `patch`, in a single write.
+ * At least one of patch/clear/addToList/removeFromList must be non-empty. When
+ * both patch and clear are present, overlapping keys are rejected (400). The
+ * server applies clear first, then patch, then list deltas, in a single write.
  */
 export async function handlePutScopedConfig(vaultDir: string, body: unknown): Promise<RouteResponse> {
   const payload = (body ?? {}) as ScopedPutBody;
@@ -105,13 +120,19 @@ export async function handlePutScopedConfig(vaultDir: string, body: unknown): Pr
   if (Array.isArray(clearListOrError) === false) return clearListOrError;
   const clearList = clearListOrError;
 
+  const addOpsOrError = validateListDeltaOps(payload.addToList);
+  if (!Array.isArray(addOpsOrError)) return addOpsOrError;
+  const removeOpsOrError = validateListDeltaOps(payload.removeFromList);
+  if (!Array.isArray(removeOpsOrError)) return removeOpsOrError;
+
   if (typeof patch !== 'object' || patch === null || Array.isArray(patch)) {
     return { status: 400, body: { error: 'patch must be an object' } };
   }
   const patchLeaves = enumerateLeafPaths(patch);
   const hasPatch = patchLeaves.length > 0;
   const hasClear = clearList.length > 0;
-  if (!hasPatch && !hasClear) {
+  const hasListOps = addOpsOrError.length > 0 || removeOpsOrError.length > 0;
+  if (!hasPatch && !hasClear && !hasListOps) {
     return { status: 400, body: { error: 'patch or clear required' } };
   }
 
@@ -140,21 +161,22 @@ export async function handlePutScopedConfig(vaultDir: string, body: unknown): Pr
       const updated = updateLocalConfig(vaultDir, (local) => {
         const working = structuredClone(local) as Record<string, unknown>;
         for (const key of clearList) unsetAtPath(working, key);
-        const nextLocal = deepMergeConfig(
+        const withPatch = deepMergeConfig(
           working,
           patch as Record<string, unknown>,
         ) as Partial<MycoConfig> & { config_version?: unknown };
+        applyListDeltas(withPatch as Record<string, unknown>, addOpsOrError, removeOpsOrError);
         const merged = deepMergeConfig(
           project as Record<string, unknown>,
-          nextLocal as Record<string, unknown>,
+          withPatch as Record<string, unknown>,
         );
         MycoConfigSchema.parse(merged);
         // config_version is a migration-bookkeeping key that belongs to the
         // project tier, not the personal overlay. Strip it from the persisted
         // local doc so it never appears in local.yaml as a stale artifact of
         // a prior migration run.
-        delete nextLocal.config_version;
-        return nextLocal;
+        delete withPatch.config_version;
+        return withPatch;
       });
       return { body: updated };
     } catch (err) {
@@ -172,7 +194,9 @@ export async function handlePutScopedConfig(vaultDir: string, body: unknown): Pr
     const updated = updateConfig(vaultDir, (current) => {
       const working = structuredClone(current) as Record<string, unknown>;
       for (const key of clearList) unsetAtPath(working, key);
-      return deepMergeConfig(working, patch as Record<string, unknown>) as MycoConfig;
+      const withPatch = deepMergeConfig(working, patch as Record<string, unknown>) as Record<string, unknown>;
+      applyListDeltas(withPatch, addOpsOrError, removeOpsOrError);
+      return withPatch as MycoConfig;
     });
     return { body: updated };
   } catch (err) {
@@ -204,8 +228,71 @@ export async function handleGetGroveConfig(
   return { body: { groveId, config } };
 }
 
+// ---------------------------------------------------------------------------
+// List-delta ops — shared validation + application helpers
+// ---------------------------------------------------------------------------
+
 interface TierPutBody {
   patch?: Record<string, unknown>;
+  /** Add values to the named array path (deduped, server-side read-modify-write). */
+  addToList?: ListDeltaEntry[];
+  /** Remove values from the named array path (server-side read-modify-write). */
+  removeFromList?: ListDeltaEntry[];
+}
+
+function validateListDeltaOps(ops: unknown): ListDeltaEntry[] | RouteResponse {
+  if (ops === undefined) return [];
+  if (!Array.isArray(ops)) {
+    return { status: 400, body: { error: 'addToList/removeFromList must be an array' } };
+  }
+  for (const op of ops) {
+    if (typeof op !== 'object' || op === null) {
+      return { status: 400, body: { error: 'each list op must be an object with path and values' } };
+    }
+    const { path, values } = op as Record<string, unknown>;
+    if (typeof path !== 'string' || path.trim().length === 0) {
+      return { status: 400, body: { error: 'list op path must be a non-empty string' } };
+    }
+    if (!Array.isArray(values)) {
+      return { status: 400, body: { error: 'list op values must be an array' } };
+    }
+  }
+  return ops as ListDeltaEntry[];
+}
+
+/**
+ * Apply addToList / removeFromList deltas to a config object in-place.
+ * Returns the dot-paths that were touched (for config-write reactions).
+ *
+ * - addToList: reads current array at path, appends values, deduplicates.
+ * - removeFromList: reads current array at path, filters out values.
+ * Non-array targets are replaced with an array (add) or treated as empty (remove).
+ */
+function applyListDeltas(
+  working: Record<string, unknown>,
+  addOps: ListDeltaEntry[],
+  removeOps: ListDeltaEntry[],
+): string[] {
+  const touchedPaths: string[] = [];
+
+  for (const op of addOps) {
+    const existing = getAtPath(working, op.path);
+    const arr = Array.isArray(existing) ? [...existing] : [];
+    for (const v of op.values) {
+      if (!arr.includes(v)) arr.push(v);
+    }
+    setAtPath(working, op.path, arr);
+    touchedPaths.push(op.path);
+  }
+
+  for (const op of removeOps) {
+    const existing = getAtPath(working, op.path);
+    const arr = Array.isArray(existing) ? existing : [];
+    setAtPath(working, op.path, arr.filter((v) => !op.values.includes(v)));
+    touchedPaths.push(op.path);
+  }
+
+  return touchedPaths;
 }
 
 interface TierPutOptions<TConfig> {
@@ -218,15 +305,22 @@ interface TierPutOptions<TConfig> {
 
 /**
  * Shared PUT handler for tier config files (Grove, Machine). Loads
- * current, applies sanitized patch, validates, persists, returns the
- * canonical post-merge value plus touched leaf paths so the caller can
- * fire `applyConfigWriteReactions`.
+ * current, applies sanitized patch and any list-delta ops, validates,
+ * persists, returns the canonical post-merge value plus touched leaf
+ * paths so the caller can fire `applyConfigWriteReactions`.
+ *
+ * Request body may contain any combination of:
+ *   patch          — deep-merged into the current config
+ *   addToList      — [{ path, values }] set-union additions (deduped)
+ *   removeFromList — [{ path, values }] set-difference removals
+ * At least one of the three must be non-empty.
  */
 async function handlePutTierConfig<TConfig>(
   body: unknown,
   options: TierPutOptions<TConfig>,
 ): Promise<{ response: RouteResponse; touchedPaths: string[] }> {
   const payload = (body ?? {}) as TierPutBody;
+
   const incoming = payload.patch ?? {};
   if (typeof incoming !== 'object' || incoming === null || Array.isArray(incoming)) {
     return {
@@ -234,26 +328,36 @@ async function handlePutTierConfig<TConfig>(
       touchedPaths: [],
     };
   }
+
+  const addOpsOrError = validateListDeltaOps(payload.addToList);
+  if (!Array.isArray(addOpsOrError)) return { response: addOpsOrError, touchedPaths: [] };
+  const removeOpsOrError = validateListDeltaOps(payload.removeFromList);
+  if (!Array.isArray(removeOpsOrError)) return { response: removeOpsOrError, touchedPaths: [] };
+
   const patch = options.sanitizePatch
     ? options.sanitizePatch(incoming as Record<string, unknown>)
     : (incoming as Record<string, unknown>);
   const patchLeaves = enumerateLeafPaths(patch);
-  if (patchLeaves.length === 0) {
+  const hasListOps = addOpsOrError.length > 0 || removeOpsOrError.length > 0;
+
+  if (patchLeaves.length === 0 && !hasListOps) {
     return {
-      response: { status: 400, body: { error: 'patch required' } },
+      response: { status: 400, body: { error: 'patch, addToList, or removeFromList required' } },
       touchedPaths: [],
     };
   }
 
   try {
     const current = options.load();
-    const merged = deepMergeConfig(
+    let working = deepMergeConfig(
       current as Record<string, unknown>,
       patch as Record<string, unknown>,
-    );
-    const validated = options.validate(merged);
+    ) as Record<string, unknown>;
+    const listTouched = applyListDeltas(working, addOpsOrError, removeOpsOrError);
+    const validated = options.validate(working);
     options.save(validated);
-    return { response: { body: validated }, touchedPaths: patchLeaves };
+    const allTouched = [...patchLeaves, ...listTouched];
+    return { response: { body: validated }, touchedPaths: allTouched };
   } catch (err) {
     if (err instanceof z.ZodError) {
       return {

--- a/packages/myco/src/daemon/api/config.ts
+++ b/packages/myco/src/daemon/api/config.ts
@@ -140,9 +140,14 @@ export async function handlePutScopedConfig(vaultDir: string, body: unknown): Pr
   if (overlap.length > 0) {
     return { status: 400, body: { error: 'patch_clear_overlap', keys: overlap } };
   }
+  // List-delta ops write config paths too, so they pass through the same
+  // path-based scope guards as patch/clear — a list-delta targeting
+  // appearance.* gets the specific 400 below, not a generic validation_failed.
+  const listOpPaths = [...addOpsOrError, ...removeOpsOrError].map((op) => op.path);
   const appearancePaths = [
     ...patchLeaves.filter((leaf) => pathsOverlap(leaf, 'appearance')),
     ...clearList.filter((clearPath) => pathsOverlap(clearPath, 'appearance')),
+    ...listOpPaths.filter((opPath) => pathsOverlap(opPath, 'appearance')),
   ];
   if (appearancePaths.length > 0) {
     return {
@@ -301,6 +306,13 @@ interface TierPutOptions<TConfig> {
   validate: (merged: unknown) => TConfig;
   /** Optional patch sanitizer — strip fields the user can't write to this tier. */
   sanitizePatch?: (patch: Record<string, unknown>) => Record<string, unknown>;
+  /**
+   * Optional predicate marking a path as not user-writable via this surface.
+   * List-delta ops targeting such a path are dropped, mirroring how
+   * `sanitizePatch` strips the same field from `patch` — so list-delta and
+   * patch writes pass through the same path-based scope guard.
+   */
+  isProtectedPath?: (path: string) => boolean;
 }
 
 /**
@@ -329,14 +341,22 @@ async function handlePutTierConfig<TConfig>(
     };
   }
 
-  const addOpsOrError = validateListDeltaOps(payload.addToList);
-  if (!Array.isArray(addOpsOrError)) return { response: addOpsOrError, touchedPaths: [] };
-  const removeOpsOrError = validateListDeltaOps(payload.removeFromList);
-  if (!Array.isArray(removeOpsOrError)) return { response: removeOpsOrError, touchedPaths: [] };
+  const addOpsRaw = validateListDeltaOps(payload.addToList);
+  if (!Array.isArray(addOpsRaw)) return { response: addOpsRaw, touchedPaths: [] };
+  const removeOpsRaw = validateListDeltaOps(payload.removeFromList);
+  if (!Array.isArray(removeOpsRaw)) return { response: removeOpsRaw, touchedPaths: [] };
 
   const patch = options.sanitizePatch
     ? options.sanitizePatch(incoming as Record<string, unknown>)
     : (incoming as Record<string, unknown>);
+  // Drop list-delta ops targeting protected paths, mirroring how
+  // `sanitizePatch` strips the same field from `patch`.
+  const addOpsOrError = options.isProtectedPath
+    ? addOpsRaw.filter((op) => !options.isProtectedPath!(op.path))
+    : addOpsRaw;
+  const removeOpsOrError = options.isProtectedPath
+    ? removeOpsRaw.filter((op) => !options.isProtectedPath!(op.path))
+    : removeOpsRaw;
   const patchLeaves = enumerateLeafPaths(patch);
   const hasListOps = addOpsOrError.length > 0 || removeOpsOrError.length > 0;
 
@@ -416,6 +436,8 @@ export async function handlePutMachineConfig(
       const { grove: _grove, ...rest } = patch;
       return rest;
     },
+    // List-delta ops targeting grove.* are dropped, same as the patch strip.
+    isProtectedPath: (path) => path === 'grove' || path.startsWith('grove.'),
   });
 }
 

--- a/packages/myco/src/daemon/api/context.ts
+++ b/packages/myco/src/daemon/api/context.ts
@@ -110,7 +110,7 @@ export function createSessionContextHandler(deps: ContextDeps) {
         logger.debug(LOG_KINDS.CONTEXT_SESSION, 'Session-start context disabled (cortex capability off)', { session_id });
         return { body: { text: '' } };
       }
-      const cortexEnabled = shouldInjectCortex(config.cortex);
+      const cortexEnabled = shouldInjectCortex(config);
       const digestEnabled = shouldInjectSessionStartDigest(config.cortex.digest);
       if (!cortexEnabled && !digestEnabled) {
         logger.debug(LOG_KINDS.CONTEXT_SESSION, 'Session-start context disabled', { session_id });
@@ -242,7 +242,7 @@ export function createSubagentContextHandler(deps: ContextDeps) {
 
     try {
       if (!session_id) return { body: { text: '' } };
-      if (!config.cortex.enabled || !config.cortex.instructions.inject_on_subagent_start) {
+      if (!capabilityEnabled(config, 'cortex') || !config.cortex.instructions.inject_on_subagent_start) {
         logger.debug(LOG_KINDS.CONTEXT_SESSION, 'Subagent context disabled', { session_id, agent });
         return { body: { text: '' } };
       }

--- a/packages/myco/src/daemon/api/context.ts
+++ b/packages/myco/src/daemon/api/context.ts
@@ -21,6 +21,7 @@ import type { MycoConfig } from '@myco/config/schema.js';
 import {
   shouldInjectCortex,
 } from '@myco/context/cortex-brief.js';
+import { capabilityEnabled } from '@myco/config/capabilities.js';
 import { composeCortexInstructionInjection } from '@myco/context/cortex-injection-context.js';
 import { shouldInjectSessionStartDigest } from '@myco/context/session-start-digest.js';
 import { composeSessionStartContext } from '@myco/context/session-start-context.js';
@@ -102,6 +103,13 @@ export function createSessionContextHandler(deps: ContextDeps) {
     logger.debug(LOG_KINDS.CONTEXT_QUERY, 'Session context query', { session_id });
 
     try {
+      // Coarse master gate at the handler boundary — mirrors the subagent-start
+      // pattern at :237. Suppresses all session-start injections when the
+      // cortex capability is off, regardless of sub-toggle state.
+      if (!capabilityEnabled(config, 'cortex')) {
+        logger.debug(LOG_KINDS.CONTEXT_SESSION, 'Session-start context disabled (cortex capability off)', { session_id });
+        return { body: { text: '' } };
+      }
       const cortexEnabled = shouldInjectCortex(config.cortex);
       const digestEnabled = shouldInjectSessionStartDigest(config.cortex.digest);
       if (!cortexEnabled && !digestEnabled) {
@@ -425,6 +433,13 @@ export function createPromptContextHandler(deps: ContextDeps) {
     const config = resolveTenantConfig(req.requestContext, liveConfig.current, { logger });
     const projectId = rowProjectIdFromRequestContext(req.requestContext);
     const scope = projectScopeFromRequestContext(req.requestContext);
+
+    // Coarse master gate at the handler boundary. Suppresses spore search and
+    // plan-intent nudge when the cortex capability is off.
+    if (!capabilityEnabled(config, 'cortex')) {
+      logger.debug(LOG_KINDS.CONTEXT_PROMPT, 'Prompt context disabled (cortex capability off)', { session_id });
+      return { body: { text: '' } };
+    }
 
     // Plan-intent nudge — an independent injection contributor (plan-intent.ts)
     // owns the toggle, intent heuristic, per-session dedup, and best-effort

--- a/packages/myco/src/daemon/api/groves.ts
+++ b/packages/myco/src/daemon/api/groves.ts
@@ -1,9 +1,8 @@
-import { CAPABILITIES } from '@myco/config/capabilities.js';
+import { CAPABILITIES, capabilityEnabled } from '@myco/config/capabilities.js';
 import { loadMergedConfig } from '@myco/config/loader.js';
 import { loadProjectManifest } from '@myco/config/project-manifest.js';
 import type { CapabilityId } from '@myco/config/scope.js';
 import { resolveMycoHome, resolveProjectVaultDir, resolveServiceDirName } from '@myco/grove/paths.js';
-import { getAtPath } from '@myco/utils/dot-path.js';
 import {
   createGrove,
   deleteGrove,
@@ -122,25 +121,23 @@ export function listGroveSummaries(
 }
 
 /**
- * Resolve per-capability master-gate booleans for a project.
- *
- * Reuses `loadMergedConfig` (mtime-cached) + `CAPABILITIES[id].masterGate`
- * + `getAtPath`, exactly matching the `getCapabilityEnabled` pattern in
- * task-scheduling.ts. On load failure all capabilities default to `true`
- * (schema defaults), so a broken vault never crashes the Groves list.
+ * Resolve per-capability master-gate booleans for a project. Uses
+ * `capabilityEnabled` as the single gate predicate — fail-closed: a
+ * broken or unloadable vault yields capture-only (all false) rather than
+ * all-true, so badges reflect the fail-closed runtime behavior.
  */
 function resolveCapabilities(projectRoot: string, groveId: string): Record<CapabilityId, boolean> {
   const capIds = Object.keys(CAPABILITIES) as CapabilityId[];
-  const allTrue = Object.fromEntries(capIds.map((id) => [id, true])) as Record<CapabilityId, boolean>;
+  let config = null;
   try {
     const vaultDir = resolveProjectVaultDir(projectRoot);
-    const config = loadMergedConfig(vaultDir, { groveId });
-    return Object.fromEntries(
-      capIds.map((id) => [id, getAtPath(config, CAPABILITIES[id].masterGate) !== false]),
-    ) as Record<CapabilityId, boolean>;
+    config = loadMergedConfig(vaultDir, { groveId });
   } catch {
-    return allTrue;
+    // Unloadable config → capabilityEnabled(null, …) returns false (fail-closed).
   }
+  return Object.fromEntries(
+    capIds.map((id) => [id, capabilityEnabled(config, id)]),
+  ) as Record<CapabilityId, boolean>;
 }
 
 function serializeProject(project: RegisteredProject, groveId: string): GroveProjectSummary {

--- a/packages/myco/src/daemon/api/groves.ts
+++ b/packages/myco/src/daemon/api/groves.ts
@@ -1,5 +1,9 @@
+import { CAPABILITIES } from '@myco/config/capabilities.js';
+import { loadMergedConfig } from '@myco/config/loader.js';
 import { loadProjectManifest } from '@myco/config/project-manifest.js';
+import type { CapabilityId } from '@myco/config/scope.js';
 import { resolveMycoHome, resolveProjectVaultDir, resolveServiceDirName } from '@myco/grove/paths.js';
+import { getAtPath } from '@myco/utils/dot-path.js';
 import {
   createGrove,
   deleteGrove,
@@ -40,6 +44,7 @@ export interface GroveProjectSummary {
   created_at: string;
   updated_at: string;
   manifest_state: 'present' | 'missing' | 'invalid' | 'mismatch';
+  capabilities: Record<CapabilityId, boolean>;
 }
 
 export interface GroveSummary {
@@ -101,7 +106,7 @@ export function listGroveSummaries(
     const projects = listRegisteredProjects(grove.id, undefined, {
       includeArchived: options.includeArchived,
     })
-      .map((project) => serializeProject(project));
+      .map((project) => serializeProject(project, grove.id));
     return {
       id: grove.id,
       name: grove.name,
@@ -116,7 +121,29 @@ export function listGroveSummaries(
   return { groves };
 }
 
-function serializeProject(project: RegisteredProject): GroveProjectSummary {
+/**
+ * Resolve per-capability master-gate booleans for a project.
+ *
+ * Reuses `loadMergedConfig` (mtime-cached) + `CAPABILITIES[id].masterGate`
+ * + `getAtPath`, exactly matching the `getCapabilityEnabled` pattern in
+ * task-scheduling.ts. On load failure all capabilities default to `true`
+ * (schema defaults), so a broken vault never crashes the Groves list.
+ */
+function resolveCapabilities(projectRoot: string, groveId: string): Record<CapabilityId, boolean> {
+  const capIds = Object.keys(CAPABILITIES) as CapabilityId[];
+  const allTrue = Object.fromEntries(capIds.map((id) => [id, true])) as Record<CapabilityId, boolean>;
+  try {
+    const vaultDir = resolveProjectVaultDir(projectRoot);
+    const config = loadMergedConfig(vaultDir, { groveId });
+    return Object.fromEntries(
+      capIds.map((id) => [id, getAtPath(config, CAPABILITIES[id].masterGate) !== false]),
+    ) as Record<CapabilityId, boolean>;
+  } catch {
+    return allTrue;
+  }
+}
+
+function serializeProject(project: RegisteredProject, groveId: string): GroveProjectSummary {
   return {
     project_id: project.project_id,
     name: project.name,
@@ -128,6 +155,7 @@ function serializeProject(project: RegisteredProject): GroveProjectSummary {
     created_at: project.created_at,
     updated_at: project.updated_at,
     manifest_state: manifestState(project),
+    capabilities: resolveCapabilities(project.root, groveId),
   };
 }
 

--- a/packages/myco/src/daemon/cortex.ts
+++ b/packages/myco/src/daemon/cortex.ts
@@ -22,6 +22,7 @@ import { dispatchAgentRun } from '@myco/agent/runner-host.js';
 import { hasConfiguredProvider } from '@myco/agent/config-resolver.js';
 import { loadMergedConfig } from '@myco/config/loader.js';
 import type { MycoConfig } from '@myco/config/schema.js';
+import { capabilityEnabled } from '@myco/config/capabilities.js';
 import { resolveTenantConfig } from './request-config.js';
 import { DEFAULT_AGENT_ID } from '@myco/constants.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
@@ -190,7 +191,7 @@ function resolveCortexTenantConfig(
 // ---------------------------------------------------------------------------
 
 export function getCortexInstructionsSnapshot(
-  config: Pick<MycoConfig, 'cortex'>,
+  config: MycoConfig,
   scope: import('@myco/grove/ids.js').ProjectScope = { kind: 'global' },
 ): CortexInstructionsSnapshot {
   const row = getCortexInstructions(DEFAULT_AGENT_ID, scope);
@@ -199,7 +200,7 @@ export function getCortexInstructionsSnapshot(
     content: row?.content ?? '',
     generatedAt: row?.generated_at ?? null,
     sourceRunId: row?.source_run_id ?? null,
-    enabled: config.cortex.enabled && config.cortex.instructions.inject_on_session_start,
+    enabled: capabilityEnabled(config, 'cortex') && config.cortex.instructions.inject_on_session_start,
     stored: Boolean(row),
   };
 }
@@ -228,7 +229,7 @@ export async function buildCortexPrompt(
   // the wrong grove's delivery contract. The seam resolves from the request
   // vault + grove (same as the run) and is loud on a present-tenant load failure.
   const config = resolveCortexTenantConfig(vaultDir, requestContext, deps.logger);
-  const delivery = resolveInstructionDelivery(config.cortex, targetSymbiont);
+  const delivery = resolveInstructionDelivery(config, targetSymbiont);
   const scope: import('@myco/grove/ids.js').ProjectScope = {
     kind: 'project',
     id: requestContext.projectId,

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -732,9 +732,10 @@ export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps
             const projectConfig = loadMergedConfig(projectVaultDir, { groveId: grove.id, mycoHome });
             if (!capabilityEnabled(projectConfig, 'canopy')) return;
           } catch {
-            // Project not yet initialized — capabilityEnabled with null config
-            // would return false (fail-closed), but we allow uninitialized
-            // projects to proceed so the canopy scan can bootstrap them.
+            // Unreadable config → skip the scan (fail-closed), consistent with
+            // canopy-inject. Registered projects always have a vault, so this
+            // only fires on a transient read error.
+            return;
           }
           const runner = canopyRegistry.ensureRunner({
             databasePath,

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -726,7 +726,14 @@ export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps
       forEachRegisteredProject(
         cache,
         logger,
-        async ({ databasePath, projectId, projectRoot, grove }: RegisteredProjectScope) => {
+        async ({ databasePath, projectId, projectRoot, projectVaultDir, grove }: RegisteredProjectScope) => {
+          try {
+            const projectConfig = loadMergedConfig(projectVaultDir, { groveId: grove.id, mycoHome });
+            if (!projectConfig.cortex.canopy.enabled) return;
+          } catch {
+            // Project not yet initialized — proceed with scan; the gate
+            // only applies when the project's config explicitly disables canopy.
+          }
           const runner = canopyRegistry.ensureRunner({
             databasePath,
             projectId,

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -41,6 +41,7 @@ import {
   listGroves,
   listRegisteredProjects,
 } from '@myco/grove/registry.js';
+import { capabilityEnabled } from '@myco/config/capabilities.js';
 import { withDatabase } from '@myco/db/client.js';
 import type { GroveRuntimeCache, EmbeddingRuntimeFactory } from './grove-runtime-cache.js';
 import { projectScope, type GroveProjectId } from '@myco/grove/ids.js';
@@ -729,10 +730,11 @@ export function registerPowerJobs(powerManager: PowerManager, deps: PowerJobDeps
         async ({ databasePath, projectId, projectRoot, projectVaultDir, grove }: RegisteredProjectScope) => {
           try {
             const projectConfig = loadMergedConfig(projectVaultDir, { groveId: grove.id, mycoHome });
-            if (!projectConfig.cortex.canopy.enabled) return;
+            if (!capabilityEnabled(projectConfig, 'canopy')) return;
           } catch {
-            // Project not yet initialized — proceed with scan; the gate
-            // only applies when the project's config explicitly disables canopy.
+            // Project not yet initialized — capabilityEnabled with null config
+            // would return false (fail-closed), but we allow uninitialized
+            // projects to proceed so the canopy scan can bootstrap them.
           }
           const runner = canopyRegistry.ensureRunner({
             databasePath,

--- a/packages/myco/src/daemon/task-scheduler.ts
+++ b/packages/myco/src/daemon/task-scheduler.ts
@@ -97,6 +97,8 @@ export interface ScheduledJobContext {
     taskName: string,
     windowSeconds: number,
   ) => number;
+  /** True unless the task's capability master gate is explicitly off for this project. */
+  getCapabilityEnabled?: (scope: RegisteredProjectScope, taskName: string) => boolean;
   /** Detached-run error sink so the PowerManager tick stays responsive. */
   onTaskError?: (taskName: string, groveId: string, projectId: GroveProjectId, err: unknown) => void;
   /**
@@ -229,6 +231,7 @@ export function buildScheduledJobs(
             ? resolveSchedule(task.schedule, taskConfig)
             : yamlEffective;
           if (!effective.enabled) continue;
+          if (context.getCapabilityEnabled && !context.getCapabilityEnabled(projectScope, task.name)) continue;
 
           if (context.isTaskRunning(groveId, projectId, task.name)) continue;
 

--- a/packages/myco/src/daemon/task-scheduling.ts
+++ b/packages/myco/src/daemon/task-scheduling.ts
@@ -29,6 +29,8 @@ import { notify } from '@myco/notifications/notify.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { DEFAULT_AGENT_ID, MS_PER_DAY } from '@myco/constants.js';
 import { errorMessage } from '@myco/utils/error-message.js';
+import { getAtPath } from '@myco/utils/dot-path.js';
+import { CAPABILITIES, capabilityForTask } from '@myco/config/capabilities.js';
 import {
   forEachGrove,
   forEachRegisteredProject,
@@ -429,6 +431,13 @@ export async function registerScheduledTasks(
       const config = resolveProjectConfig(scope);
       if (!config) return { schedule: { enabled: false } };
       return config.agent.tasks?.[taskName];
+    },
+    getCapabilityEnabled: (scope, taskName) => {
+      const capId = capabilityForTask(taskName);
+      if (!capId) return true;
+      const config = resolveProjectConfig(scope);
+      if (!config) return false;
+      return getAtPath(config, CAPABILITIES[capId].masterGate) !== false;
     },
     isTaskRunning: (groveId, projectId, name) =>
       runningTasks.has(runningKey(groveId, projectId, name)),

--- a/packages/myco/src/daemon/task-scheduling.ts
+++ b/packages/myco/src/daemon/task-scheduling.ts
@@ -29,8 +29,7 @@ import { notify } from '@myco/notifications/notify.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { DEFAULT_AGENT_ID, MS_PER_DAY } from '@myco/constants.js';
 import { errorMessage } from '@myco/utils/error-message.js';
-import { getAtPath } from '@myco/utils/dot-path.js';
-import { CAPABILITIES, capabilityForTask } from '@myco/config/capabilities.js';
+import { capabilityEnabled, capabilityForTask } from '@myco/config/capabilities.js';
 import {
   forEachGrove,
   forEachRegisteredProject,
@@ -193,8 +192,16 @@ export async function registerScheduledTasks(
     taskAgentMap.set(task.name, task.agent);
   }
 
+  // Per-tick single-resolve memo: the scheduler loop calls getTaskConfig and
+  // getCapabilityEnabled for each task in the same per-project iteration.
+  // Memoizing the last-resolved scope avoids redundant loadMergedConfig calls
+  // within a single project's task fan-out.
+  let lastResolvedKey = '';
+  let lastResolvedConfig: MycoConfig | null = null;
+
   function resolveProjectConfig(scope: RegisteredProjectScope): MycoConfig | null {
     const key = `${scope.grove.id}:${scope.projectId}`;
+    if (key === lastResolvedKey) return lastResolvedConfig;
     try {
       const config = loadMergedConfig(scope.projectVaultDir, {
         groveId: scope.grove.id,
@@ -207,6 +214,8 @@ export async function registerScheduledTasks(
         });
         lastConfigErrorByProject.delete(key);
       }
+      lastResolvedKey = key;
+      lastResolvedConfig = config;
       return config;
     } catch (err) {
       const message = errorMessage(err);
@@ -218,6 +227,8 @@ export async function registerScheduledTasks(
         });
         lastConfigErrorByProject.set(key, message);
       }
+      lastResolvedKey = key;
+      lastResolvedConfig = null;
       return null;
     }
   }
@@ -435,12 +446,9 @@ export async function registerScheduledTasks(
     getCapabilityEnabled: (scope, taskName) => {
       const capId = capabilityForTask(taskName);
       if (!capId) return true;
-      const config = resolveProjectConfig(scope);
-      // resolveProjectConfig logs on failure and getTaskConfig already
-      // disables the task on the same error; returning false here is
-      // defense-in-depth so a config-less project never runs the capability.
-      if (!config) return false;
-      return getAtPath(config, CAPABILITIES[capId].masterGate) !== false;
+      // resolveProjectConfig logs on failure; null → capabilityEnabled returns
+      // false (fail-closed) so a config-less project never runs the capability.
+      return capabilityEnabled(resolveProjectConfig(scope), capId);
     },
     isTaskRunning: (groveId, projectId, name) =>
       runningTasks.has(runningKey(groveId, projectId, name)),

--- a/packages/myco/src/daemon/task-scheduling.ts
+++ b/packages/myco/src/daemon/task-scheduling.ts
@@ -436,6 +436,9 @@ export async function registerScheduledTasks(
       const capId = capabilityForTask(taskName);
       if (!capId) return true;
       const config = resolveProjectConfig(scope);
+      // resolveProjectConfig logs on failure and getTaskConfig already
+      // disables the task on the same error; returning false here is
+      // defense-in-depth so a config-less project never runs the capability.
       if (!config) return false;
       return getAtPath(config, CAPABILITIES[capId].masterGate) !== false;
     },

--- a/packages/myco/src/daemon/task-scheduling.ts
+++ b/packages/myco/src/daemon/task-scheduling.ts
@@ -192,10 +192,12 @@ export async function registerScheduledTasks(
     taskAgentMap.set(task.name, task.agent);
   }
 
-  // Per-tick single-resolve memo: the scheduler loop calls getTaskConfig and
+  // Per-project-visit memo: the scheduler loop calls getTaskConfig and
   // getCapabilityEnabled for each task in the same per-project iteration.
   // Memoizing the last-resolved scope avoids redundant loadMergedConfig calls
-  // within a single project's task fan-out.
+  // within a single project's task fan-out. The slot persists across ticks —
+  // one tick of stale config across a tick boundary is benign at minute-scale
+  // intervals.
   let lastResolvedKey = '';
   let lastResolvedConfig: MycoConfig | null = null;
 

--- a/packages/myco/src/hooks/vault-gate.ts
+++ b/packages/myco/src/hooks/vault-gate.ts
@@ -27,6 +27,8 @@ import {
   hasGlobalInstallMigrationCompleted,
   migrateProjectToGlobalInstall,
 } from '../grove/global-install-migration.js';
+import { isProjectRootIgnored, agentHomeIgnorePaths } from '../vault/capture-ignore.js';
+import { loadMachineConfig } from '../config/loader.js';
 
 /**
  * Resolve the project's vault dir, provisioning it if absent. Returns:
@@ -78,6 +80,19 @@ export function resolveProvisionedVaultDir(cwd: string = process.cwd()): string 
       process.stderr.write(`[myco] capture skipped (non-git-or-unsafe-root) root=${projectRoot}\n`);
     }
     return null;
+  }
+
+  try {
+    const machine = loadMachineConfig();
+    if (isProjectRootIgnored(projectRoot, machine.capture.ignore, agentHomeIgnorePaths())) {
+      if (process.env.MYCO_AGENT_DEBUG) {
+        process.stderr.write(`[myco] capture skipped (ignored-root) root=${projectRoot}\n`);
+      }
+      return null;
+    }
+  } catch {
+    // If machine config can't be read, fall through to agent-home seed only.
+    if (isProjectRootIgnored(projectRoot, { paths: [], patterns: [] }, agentHomeIgnorePaths())) return null;
   }
 
   try {

--- a/packages/myco/src/vault/capture-ignore.ts
+++ b/packages/myco/src/vault/capture-ignore.ts
@@ -1,0 +1,56 @@
+import path from 'node:path';
+import { createExcludeMatcher } from '../canopy/exclude.js';
+import { expandHome } from '../grove/paths.js';
+import { loadManifests } from '../symbionts/detect.js';
+
+export interface CaptureIgnoreConfig {
+  paths: string[];
+  patterns: string[];
+}
+
+/** Symbiont home dirs (e.g. ~/.codex, ~/.claude) as absolute paths — these are
+ *  agent config stores, never user projects, so they seed the ignore list. */
+export function agentHomeIgnorePaths(): string[] {
+  return loadManifests()
+    .map((m) => m.detectionDir)
+    .filter((d): d is string => d != null)
+    .map((d) => expandHome(d));
+}
+
+function isUnderPrefix(root: string, prefix: string): boolean {
+  const r = path.resolve(root);
+  const p = path.resolve(expandHome(prefix));
+  return r === p || r.startsWith(`${p}/`);
+}
+
+/**
+ * True when projectRoot must not be auto-adopted: it is, or is under, any
+ * configured ignore path, any agent-home seed dir, or matches an ignore glob.
+ *
+ * Patterns are matched against the absolute project root using
+ * createExcludeMatcher (the canopy exclude engine). The common
+ * "** /seg/** " shape is normalized to a bare segment name before
+ * delegating so the segment matcher fires correctly against path components.
+ */
+export function isProjectRootIgnored(
+  projectRoot: string,
+  ignore: CaptureIgnoreConfig,
+  agentHomeDirs: string[],
+): boolean {
+  for (const prefix of [...ignore.paths, ...agentHomeDirs]) {
+    if (isUnderPrefix(projectRoot, prefix)) return true;
+  }
+  if (ignore.patterns.length > 0) {
+    // Normalize patterns: `**/seg/**` → `seg` so the segment matcher in
+    // createExcludeMatcher fires against path segments of the absolute root.
+    // Patterns not matching that shape are passed through for path-glob matching.
+    const normalizedPatterns = ignore.patterns.map((p) => {
+      const m = /^\*\*\/([^*?/]+)\/\*\*$/.exec(p);
+      return m ? m[1] : p;
+    });
+    const matcher = createExcludeMatcher(normalizedPatterns);
+    const resolved = path.resolve(projectRoot);
+    if (matcher(resolved)) return true;
+  }
+  return false;
+}

--- a/packages/myco/src/vault/capture-ignore.ts
+++ b/packages/myco/src/vault/capture-ignore.ts
@@ -41,10 +41,14 @@ export function isProjectRootIgnored(
     if (isUnderPrefix(projectRoot, prefix)) return true;
   }
   if (ignore.patterns.length > 0) {
+    // Expand `~` first so a home-relative glob (e.g. `~/forks/*`) becomes an
+    // absolute path-glob that can match the absolute project root — otherwise
+    // it compiles to a regex anchored on a literal `~` and never fires.
+    const expandedPatterns = ignore.patterns.map((p) => (p.startsWith('~') ? expandHome(p) : p));
     // Normalize patterns: `**/seg/**` → `seg` so the segment matcher in
     // createExcludeMatcher fires against path segments of the absolute root.
     // Patterns not matching that shape are passed through for path-glob matching.
-    const normalizedPatterns = ignore.patterns.map((p) => {
+    const normalizedPatterns = expandedPatterns.map((p) => {
       const m = /^\*\*\/([^*?/]+)\/\*\*$/.exec(p);
       return m ? m[1] : p;
     });

--- a/packages/myco/src/vault/provision.ts
+++ b/packages/myco/src/vault/provision.ts
@@ -32,6 +32,10 @@ import {
   resolveSentinelPath,
   type GlobalInstallMigrationSentinel,
 } from '../grove/global-install-migration.js';
+import { CAPABILITIES } from '../config/capabilities.js';
+import { saveLocalConfig } from '../config/loader.js';
+import { setAtPath } from '../utils/dot-path.js';
+import type { MycoConfig } from '../config/schema.js';
 
 const MINIMAL_MYCO_YAML = 'version: 3\n';
 
@@ -119,6 +123,15 @@ export function ensureProjectVault(
   const sentinelPath = resolveSentinelPath(projectRoot);
   fs.mkdirSync(path.dirname(sentinelPath), { recursive: true });
   fs.writeFileSync(sentinelPath, JSON.stringify(sentinel, null, 2) + '\n', 'utf-8');
+
+  // New vaults start capture-only: write local.yaml off-overrides for every
+  // capability master gate so intelligence features only activate when the
+  // user explicitly promotes the project.
+  const captureOnlyPatch: Record<string, unknown> = {};
+  for (const cap of Object.values(CAPABILITIES)) {
+    setAtPath(captureOnlyPatch, cap.masterGate, false);
+  }
+  saveLocalConfig(vaultDir, captureOnlyPatch as Partial<MycoConfig>);
 
   return { vaultDir, created: true, projectId: manifest.project.id };
 }

--- a/packages/myco/src/vault/provision.ts
+++ b/packages/myco/src/vault/provision.ts
@@ -83,11 +83,6 @@ export function ensureProjectVault(
   // Cold path: create the vault from scratch.
   fs.mkdirSync(vaultDir, { recursive: true });
 
-  // myco.yaml — minimal stub; the config loader applies schema defaults
-  // on read, so a single `version: 3` line is enough to mark this as
-  // a real vault rather than a half-bootstrapped scratch dir.
-  fs.writeFileSync(mycoYamlPath, MINIMAL_MYCO_YAML, 'utf-8');
-
   // Canonical `.gitignore` body. Idempotent — rewrites only when stale.
   ensureVaultGitignoreCurrent(vaultDir);
 
@@ -132,6 +127,12 @@ export function ensureProjectVault(
     setAtPath(captureOnlyPatch, cap.masterGate, false);
   }
   saveLocalConfig(vaultDir, captureOnlyPatch as Partial<MycoConfig>);
+
+  // myco.yaml is written LAST — it is the hot-path existence sentinel (the
+  // check at the top of this function). Writing it last means a mid-provision
+  // crash leaves no sentinel on disk, so the next call re-runs the cold path
+  // and self-heals to the correct capture-only state.
+  fs.writeFileSync(mycoYamlPath, MINIMAL_MYCO_YAML, 'utf-8');
 
   return { vaultDir, created: true, projectId: manifest.project.id };
 }

--- a/packages/myco/ui/src/components/config/ListField.tsx
+++ b/packages/myco/ui/src/components/config/ListField.tsx
@@ -11,6 +11,18 @@ export interface ListFieldProps extends BaseFieldControlProps {
   placeholder?: string;
   /** Allow duplicate entries. Defaults to false. */
   allowDuplicates?: boolean;
+  /**
+   * When provided, called with a single entry instead of the whole next
+   * array — used to route through the server-side list-delta primitive
+   * (race-free add). `onChange` is NOT called when this is set.
+   */
+  onAdd?: (entry: string) => void;
+  /**
+   * When provided, called with the removed entry instead of the whole
+   * next array — used to route through the server-side list-delta
+   * primitive (race-free remove). `onChange` is NOT called when this is set.
+   */
+  onRemove?: (entry: string) => void;
 }
 
 /** Split a pasted block on newlines and commas, trim, drop empties. */
@@ -43,11 +55,23 @@ export function ListField({
   readonly,
   placeholder,
   allowDuplicates = false,
+  onAdd,
+  onRemove,
 }: ListFieldProps) {
   const [draft, setDraft] = useState<string>('');
 
   function appendEntries(entries: string[]) {
     if (entries.length === 0) return;
+    if (onAdd) {
+      // Per-item path: each new entry goes through the race-free primitive.
+      const seen = new Set(allowDuplicates ? [] : value);
+      for (const entry of entries) {
+        if (!allowDuplicates && seen.has(entry)) continue;
+        seen.add(entry);
+        onAdd(entry);
+      }
+      return;
+    }
     const seen = new Set(allowDuplicates ? [] : value);
     const next = value.slice();
     for (const entry of entries) {
@@ -64,6 +88,10 @@ export function ListField({
   }
 
   function removeEntry(index: number) {
+    if (onRemove) {
+      onRemove(value[index]!);
+      return;
+    }
     const next = value.slice();
     next.splice(index, 1);
     onChange(next);

--- a/packages/myco/ui/src/components/config/PlanCaptureCard.tsx
+++ b/packages/myco/ui/src/components/config/PlanCaptureCard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { CONFIG_SECTION_IDS } from '@myco/config/focus';
 import { fetchJson } from '../../lib/api';
+import { useAddToMachineConfigList, useRemoveFromMachineConfigList } from '../../hooks/use-machine-config';
 import { Surface } from '../ui/surface';
 import { SectionHeader } from '../ui/section-header';
 import { Input } from '../ui/input';
@@ -26,6 +27,8 @@ export function PlanCaptureCard() {
   const [symbiont, setSymbiont] = useState<Record<string, string[]>>({});
   const [newDir, setNewDir] = useState('');
   const [isLoading, setIsLoading] = useState(true);
+  const addToList = useAddToMachineConfigList();
+  const removeFromList = useRemoveFromMachineConfigList();
 
   // Symbiont-managed plan dirs come from a separate read-only endpoint
   // (manifest-derived, not from myco.yaml).
@@ -96,7 +99,7 @@ export function PlanCaptureCard() {
             label="Custom Directories"
             hint="extra paths to watch for plan files"
           >
-            {({ value, onChange }) => {
+            {({ value }) => {
               const dirs = value ?? [];
               return (
                 <div className="space-y-2">
@@ -110,7 +113,7 @@ export function PlanCaptureCard() {
                           <span className="flex-1 font-mono text-xs text-on-surface">{dir}</span>
                           <button
                             type="button"
-                            onClick={() => onChange(dirs.filter((d) => d !== dir))}
+                            onClick={() => removeFromList.mutate({ path: 'capture.plan_dirs', value: dir })}
                             className="font-sans text-xs text-on-surface-variant hover:text-tertiary transition-colors leading-none"
                             aria-label={`Remove ${dir}`}
                           >
@@ -130,7 +133,7 @@ export function PlanCaptureCard() {
                         if (e.key !== 'Enter') return;
                         const trimmed = newDir.trim();
                         if (!trimmed || dirs.includes(trimmed)) return;
-                        onChange([...dirs, trimmed]);
+                        addToList.mutate({ path: 'capture.plan_dirs', value: trimmed });
                         setNewDir('');
                       }}
                       className="flex-1 font-mono text-xs"
@@ -141,7 +144,7 @@ export function PlanCaptureCard() {
                       onClick={() => {
                         const trimmed = newDir.trim();
                         if (!trimmed || dirs.includes(trimmed)) return;
-                        onChange([...dirs, trimmed]);
+                        addToList.mutate({ path: 'capture.plan_dirs', value: trimmed });
                         setNewDir('');
                       }}
                       disabled={!newDir.trim()}

--- a/packages/myco/ui/src/components/groves/CapabilityPanel.tsx
+++ b/packages/myco/ui/src/components/groves/CapabilityPanel.tsx
@@ -1,0 +1,101 @@
+import { Link } from 'react-router-dom';
+import { getAtPath } from '@myco/utils/dot-path';
+import { CAPABILITIES } from '@myco/config/capabilities';
+import type { CapabilityId } from '@myco/config/scope';
+import { CAPABILITY_IDS } from '@myco/config/scope';
+import { useScopedConfigForSelection } from '../../hooks/use-scoped-config';
+import { SlideoutDetailPanel } from '../ui/slideout-detail-panel';
+import { Switch } from '../ui/switch';
+import type { GroveSummary, GroveProjectSummary } from '../../lib/selection';
+
+export interface CapabilityPanelProps {
+  target: { grove: GroveSummary; project: GroveProjectSummary };
+  open: boolean;
+  onClose: () => void;
+}
+
+/** Read a boolean from a merged config by dotted path, defaulting to true. */
+function readBool(config: unknown, path: string): boolean {
+  if (config == null) return true;
+  const val = getAtPath(config as Record<string, unknown>, path);
+  return val === undefined ? true : Boolean(val);
+}
+
+function CapabilityToggleRow({
+  capId,
+  scoped,
+}: {
+  capId: CapabilityId;
+  scoped: ReturnType<typeof useScopedConfigForSelection>;
+}) {
+  const cap = CAPABILITIES[capId];
+  const enabled = readBool(scoped.effective, cap.masterGate);
+
+  return (
+    <div className="flex items-start justify-between gap-4 py-3 border-b border-outline-variant/15 last:border-b-0">
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium text-on-surface">{cap.label}</div>
+        <Link
+          to={cap.advancedSettingsLink}
+          className="text-xs text-on-surface-variant hover:text-on-surface transition-colors"
+        >
+          Advanced settings →
+        </Link>
+      </div>
+      <Switch
+        checked={enabled}
+        onCheckedChange={(next) => {
+          void scoped.setFields([{ path: cap.masterGate as never, value: next }], 'local');
+        }}
+      />
+    </div>
+  );
+}
+
+/**
+ * Slide-out panel for viewing and editing per-project capability toggles.
+ * Each switch flips the capability master gate at Personal (local) scope,
+ * so settings apply only to this machine and don't override team config.
+ */
+export function CapabilityPanel({ target, open, onClose }: CapabilityPanelProps) {
+  const scoped = useScopedConfigForSelection(target);
+
+  return (
+    <SlideoutDetailPanel
+      open={open}
+      onClose={onClose}
+      ariaLabel="Project capabilities"
+      testIdRoot="capability-panel"
+    >
+      <div className="flex flex-col gap-1 mb-5">
+        <div className="text-xs font-medium uppercase tracking-wide text-on-surface-variant">
+          Capabilities
+        </div>
+        <div className="text-base font-semibold text-on-surface">{target.project.name}</div>
+        <div className="text-xs text-on-surface-variant">
+          Toggles apply at Personal scope — only this machine.
+        </div>
+      </div>
+
+      <div className="flex flex-col">
+        {(CAPABILITY_IDS as readonly CapabilityId[]).map((capId) => (
+          <CapabilityToggleRow key={capId} capId={capId} scoped={scoped} />
+        ))}
+      </div>
+
+      <div className="mt-5 pt-4 border-t border-outline-variant/15">
+        <button
+          type="button"
+          className="text-xs text-on-surface-variant hover:text-on-surface transition-colors"
+          onClick={() => {
+            void scoped.resetFields(
+              CAPABILITY_IDS.map((id) => CAPABILITIES[id].masterGate as never),
+            );
+          }}
+        >
+          Reset to defaults
+        </button>
+      </div>
+    </SlideoutDetailPanel>
+  );
+}

--- a/packages/myco/ui/src/components/groves/CapabilityPanel.tsx
+++ b/packages/myco/ui/src/components/groves/CapabilityPanel.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
-import { getAtPath } from '@myco/utils/dot-path';
-import { CAPABILITIES } from '@myco/config/capabilities';
+import { CAPABILITIES, capabilityEnabled } from '@myco/config/capabilities';
+import type { MycoConfig } from '@myco/config/schema';
 import type { CapabilityId } from '@myco/config/scope';
 import { CAPABILITY_IDS } from '@myco/config/scope';
 import { useScopedConfigForSelection } from '../../hooks/use-scoped-config';
@@ -14,13 +14,6 @@ export interface CapabilityPanelProps {
   onClose: () => void;
 }
 
-/** Read a boolean from a merged config by dotted path, defaulting to true. */
-function readBool(config: unknown, path: string): boolean {
-  if (config == null) return true;
-  const val = getAtPath(config as Record<string, unknown>, path);
-  return val === undefined ? true : Boolean(val);
-}
-
 function CapabilityToggleRow({
   capId,
   scoped,
@@ -29,7 +22,7 @@ function CapabilityToggleRow({
   scoped: ReturnType<typeof useScopedConfigForSelection>;
 }) {
   const cap = CAPABILITIES[capId];
-  const enabled = readBool(scoped.effective, cap.masterGate);
+  const enabled = capabilityEnabled(scoped.effective as MycoConfig, capId);
 
   return (
     <div className="flex items-start justify-between gap-4 py-3 border-b border-outline-variant/15 last:border-b-0">

--- a/packages/myco/ui/src/components/groves/ProjectActionMenu.tsx
+++ b/packages/myco/ui/src/components/groves/ProjectActionMenu.tsx
@@ -9,6 +9,7 @@ interface ProjectActionMenuProps {
   onArchive: () => void;
   onUnarchive: () => void;
   onDelete: () => void;
+  onIgnore: () => void;
   backupPending?: boolean;
 }
 
@@ -21,6 +22,7 @@ export function ProjectActionMenu({
   onArchive,
   onUnarchive,
   onDelete,
+  onIgnore,
   backupPending,
 }: ProjectActionMenuProps) {
   const items: MenuItem[] = [
@@ -32,6 +34,7 @@ export function ProjectActionMenu({
       onSelect: onBackup,
       disabled: backupPending,
     },
+    { key: 'ignore', label: 'Ignore project…', onSelect: onIgnore, disabled: archived },
     archived
       ? { key: 'unarchive', label: 'Unarchive project', onSelect: onUnarchive }
       : { key: 'archive', label: 'Archive project', onSelect: onArchive },

--- a/packages/myco/ui/src/components/symbionts/CapabilityChip.tsx
+++ b/packages/myco/ui/src/components/symbionts/CapabilityChip.tsx
@@ -3,6 +3,33 @@ import { StatusDot } from '../ui/status-dot';
 import { cn } from '../../lib/cn';
 import type { CapabilityChipDescriptor } from '../../lib/capability-map';
 
+export interface CapabilityChipVisualProps {
+  chip: CapabilityChipDescriptor;
+}
+
+/**
+ * Presentational capability chip — StatusDot + label + shared Tailwind
+ * tokens. Renders the pill with hover/transition styles but carries no
+ * interaction logic; the consumer wraps it in a Link (Symbionts row) or
+ * a button (Groves badge strip).
+ */
+export function CapabilityChipVisual({ chip }: CapabilityChipVisualProps) {
+  return (
+    <span
+      data-capability={chip.id}
+      title={chip.title}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
+        'border-outline-variant/30 bg-surface-container text-on-surface',
+        'hover:bg-surface-container-high hover:border-outline-variant/60',
+      )}
+    >
+      <StatusDot tone={chip.tone} sizePx={5} />
+      <span>{chip.label}</span>
+    </span>
+  );
+}
+
 export interface CapabilityChipProps {
   chip: CapabilityChipDescriptor;
   /** Absolute path the chip navigates to. The Symbionts page resolves
@@ -12,29 +39,19 @@ export interface CapabilityChipProps {
 }
 
 /**
- * A clickable capability chip. The visual is a small pill with a status
- * dot + label; clicking navigates to the corresponding Myco feature
- * scoped to the relevant symbiont (e.g. `/sessions?agent=claude-code`).
- *
- * Disabled / hover / focus tokens use the same accent palette as
- * `StatusDot`, so the chip set on a row reads as a coherent group.
+ * A clickable capability chip that navigates to the corresponding Myco
+ * feature scoped to the relevant symbiont (e.g. `/sessions?agent=claude-code`).
+ * Renders `CapabilityChipVisual` inside a `Link`; focus ring is applied
+ * at the Link level.
  */
 export function CapabilityChip({ chip, href }: CapabilityChipProps) {
   return (
     <Link
       to={href}
-      title={chip.title}
       aria-label={`${chip.label} — open feature`}
-      data-capability={chip.id}
-      className={cn(
-        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
-        'border-outline-variant/30 bg-surface-container text-on-surface',
-        'hover:bg-surface-container-high hover:border-outline-variant/60',
-        'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40',
-      )}
+      className="focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40 rounded-full"
     >
-      <StatusDot tone={chip.tone} sizePx={5} />
-      <span>{chip.label}</span>
+      <CapabilityChipVisual chip={chip} />
     </Link>
   );
 }

--- a/packages/myco/ui/src/hooks/use-machine-config.ts
+++ b/packages/myco/ui/src/hooks/use-machine-config.ts
@@ -54,3 +54,50 @@ export function useUpdateMachineConfig() {
     },
   });
 }
+
+// ---------------------------------------------------------------------------
+// Race-free list-mutation helpers for machine-tier array fields
+// ---------------------------------------------------------------------------
+
+/**
+ * Add a value to a machine-config list path (e.g. `capture.ignore.paths`).
+ * The server does the read-modify-write so concurrent callers don't overwrite
+ * each other — no stale client-array read required.
+ */
+export function useAddToMachineConfigList() {
+  const queryClient = useQueryClient();
+  return useMutation<MachineConfig, Error, { path: string; value: string }>({
+    mutationFn: ({ path, value }) =>
+      putJson<MachineConfig>('/machine-config', {
+        addToList: [{ path, values: [value] }],
+      }),
+    onSuccess: (config) => {
+      queryClient.setQueryData<MachineConfigResponse>(
+        [...MACHINE_CONFIG_QUERY_KEY],
+        { config },
+      );
+      queryClient.invalidateQueries({ queryKey: ['config', 'merged'] });
+    },
+  });
+}
+
+/**
+ * Remove a value from a machine-config list path (e.g. `capture.ignore.paths`).
+ * Server-side read-modify-write — no stale client-array read required.
+ */
+export function useRemoveFromMachineConfigList() {
+  const queryClient = useQueryClient();
+  return useMutation<MachineConfig, Error, { path: string; value: string }>({
+    mutationFn: ({ path, value }) =>
+      putJson<MachineConfig>('/machine-config', {
+        removeFromList: [{ path, values: [value] }],
+      }),
+    onSuccess: (config) => {
+      queryClient.setQueryData<MachineConfigResponse>(
+        [...MACHINE_CONFIG_QUERY_KEY],
+        { config },
+      );
+      queryClient.invalidateQueries({ queryKey: ['config', 'merged'] });
+    },
+  });
+}

--- a/packages/myco/ui/src/hooks/use-scoped-config.ts
+++ b/packages/myco/ui/src/hooks/use-scoped-config.ts
@@ -12,7 +12,7 @@ import type { ConfigPath } from '../lib/config-paths';
 import { useUpdateGroveConfig } from './use-grove-config';
 import { useUpdateMachineConfig, type MachineConfigPatch } from './use-machine-config';
 import { useActiveProjectSelection } from './use-project-selection';
-import { requestContextHeadersForSelection, selectionKey } from '../lib/selection';
+import { requestContextHeadersForSelection, selectionKey, type ProjectSelection } from '../lib/selection';
 
 export type Scope = 'project' | 'local' | 'grove' | 'machine';
 
@@ -21,7 +21,11 @@ const LOCAL_KEY = ['config', 'local'] as const;
 const NOTIFICATIONS_KEY = ['notifications'] as const;
 
 /**
- * Scoped config hook for field-level settings writes.
+ * Scoped config hook for field-level settings writes targeting an explicit
+ * project selection. The public `useScopedConfig()` is implemented as
+ * `useScopedConfigForSelection(useActiveProjectSelection())` so that the
+ * Groves capability panel can target an arbitrary project without
+ * duplicating the query/write logic.
  *
  * - `effective` is the merged view used for display.
  * - `local` is the raw local overlay; a key present here means that path is
@@ -36,15 +40,17 @@ const NOTIFICATIONS_KEY = ['notifications'] as const;
  * Returned callbacks are stable across re-renders (data is read through refs)
  * so consumers don't have their `useCallback` deps thrash on every refetch.
  */
-export function useScopedConfig() {
+export function useScopedConfigForSelection(selection: ProjectSelection | null) {
   const qc = useQueryClient();
   const updateGroveConfig = useUpdateGroveConfig();
   const updateMachineConfig = useUpdateMachineConfig();
-  const activeSelection = useActiveProjectSelection();
-  const activeSelectionKey = activeSelection ? selectionKey(activeSelection) : 'none';
+  const activeSelectionKey = selection ? selectionKey(selection) : 'none';
   const contextHeaders = useMemo(
-    () => requestContextHeadersForSelection(activeSelection),
-    [activeSelection],
+    () => requestContextHeadersForSelection(selection),
+    // Stable on grove + project identity; avoids thrash when the selection
+    // object reference changes but the underlying ids stay the same.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selection?.grove.id, selection?.project.project_id],
   );
 
   const merged = useQuery({
@@ -174,4 +180,9 @@ export function useScopedConfig() {
     resetFields,
     promoteField,
   };
+}
+
+/** Scoped config hook for the active route selection (the common case). */
+export function useScopedConfig() {
+  return useScopedConfigForSelection(useActiveProjectSelection());
 }

--- a/packages/myco/ui/src/hooks/use-scoped-config.ts
+++ b/packages/myco/ui/src/hooks/use-scoped-config.ts
@@ -5,9 +5,11 @@ import {
   fetchLocalConfig,
   writeScopedConfig,
   clearLocalConfigKeys,
+  putJson,
 } from '../lib/api';
 import { getAtPath, setAtPath } from '@myco/utils/dot-path';
 import type { MycoConfig } from './use-config';
+import type { MachineConfig } from '@myco/config/schema';
 import type { ConfigPath } from '../lib/config-paths';
 import { useUpdateGroveConfig } from './use-grove-config';
 import { useUpdateMachineConfig, type MachineConfigPatch } from './use-machine-config';
@@ -169,6 +171,58 @@ export function useScopedConfigForSelection(selection: ProjectSelection | null) 
     [],
   );
 
+  /**
+   * Add a value to a list-valued config field. For machine scope, uses the
+   * server-side addToList op (race-free read-modify-write). For other scopes,
+   * falls back to a full-array setField after reading current effective value
+   * — clients should prefer machine scope for the critical paths.
+   */
+  const addToConfigList = useCallback(
+    async (path: ConfigPath, value: string, scope: Scope): Promise<void> => {
+      if (scope === 'machine') {
+        const config = await putJson<MachineConfig>('/machine-config', {
+          addToList: [{ path, values: [value] }],
+        });
+        qc.setQueryData(['machine-config'], { config });
+        void qc.invalidateQueries({ queryKey: ['config', 'merged'] });
+        return;
+      }
+      // Fallback: read current array from merged config and append.
+      const current = getAtPath((mergedRef.current ?? {}) as Record<string, unknown>, path);
+      const arr = Array.isArray(current) ? current as string[] : [];
+      if (!arr.includes(value)) {
+        await setField(path, [...arr, value] as unknown as string, scope);
+      }
+    },
+    // putJson is a stable module-level import; not needed in deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [qc, setField],
+  );
+
+  /**
+   * Remove a value from a list-valued config field. For machine scope, uses
+   * the server-side removeFromList op (race-free). Fallback for other scopes
+   * reads current effective array and filters.
+   */
+  const removeFromConfigList = useCallback(
+    async (path: ConfigPath, value: string, scope: Scope): Promise<void> => {
+      if (scope === 'machine') {
+        const config = await putJson<MachineConfig>('/machine-config', {
+          removeFromList: [{ path, values: [value] }],
+        });
+        qc.setQueryData(['machine-config'], { config });
+        void qc.invalidateQueries({ queryKey: ['config', 'merged'] });
+        return;
+      }
+      const current = getAtPath((mergedRef.current ?? {}) as Record<string, unknown>, path);
+      const arr = Array.isArray(current) ? current as string[] : [];
+      await setField(path, arr.filter((v) => v !== value) as unknown as string, scope);
+    },
+    // putJson is a stable module-level import; not needed in deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [qc, setField],
+  );
+
   return {
     effective: merged.data as MycoConfig | undefined,
     local: (local.data ?? {}) as Partial<MycoConfig>,
@@ -179,6 +233,8 @@ export function useScopedConfigForSelection(selection: ProjectSelection | null) 
     resetField,
     resetFields,
     promoteField,
+    addToConfigList,
+    removeFromConfigList,
   };
 }
 

--- a/packages/myco/ui/src/lib/capability-badges.ts
+++ b/packages/myco/ui/src/lib/capability-badges.ts
@@ -1,0 +1,30 @@
+/**
+ * Per-project capability badge descriptors.
+ *
+ * Pure function: maps resolved gate booleans to `CapabilityChipDescriptor`
+ * values that the Groves page renders via `CapabilityChip`. Mirrors the
+ * shape of `capability-map.ts:buildCapabilityChips` so the same chip
+ * component and tone vocabulary applies.
+ *
+ * When every opt-in capability is off a single "Capture-only" badge is
+ * returned; otherwise one sage badge per enabled capability.
+ */
+
+import { CAPABILITIES } from '@myco/config/capabilities';
+import type { CapabilityId } from '@myco/config/scope';
+import type { CapabilityChipDescriptor } from './capability-map';
+
+/** Build capability badge descriptors from resolved per-project gate values. */
+export function buildCapabilityBadges(gates: Record<CapabilityId, boolean>): CapabilityChipDescriptor[] {
+  const enabled = (Object.keys(CAPABILITIES) as CapabilityId[]).filter((id) => gates[id]);
+  if (enabled.length === 0) {
+    return [{ id: 'capture-only', label: 'Capture-only', to: '', tone: 'outline', title: 'Sessions, search, and MCP only' }];
+  }
+  return enabled.map((id) => ({
+    id,
+    label: CAPABILITIES[id].label,
+    to: CAPABILITIES[id].advancedSettingsLink,
+    tone: 'sage' as const,
+    title: `${CAPABILITIES[id].label} enabled`,
+  }));
+}

--- a/packages/myco/ui/src/lib/capability-badges.ts
+++ b/packages/myco/ui/src/lib/capability-badges.ts
@@ -2,9 +2,10 @@
  * Per-project capability badge descriptors.
  *
  * Pure function: maps resolved gate booleans to `CapabilityChipDescriptor`
- * values that the Groves page renders via `CapabilityChip`. Mirrors the
- * shape of `capability-map.ts:buildCapabilityChips` so the same chip
- * component and tone vocabulary applies.
+ * values that the Groves page renders via `CapabilityChipVisual` inside the
+ * badge-strip button. Mirrors the shape of
+ * `capability-map.ts:buildCapabilityChips` so the same visual component and
+ * tone vocabulary applies.
  *
  * When every opt-in capability is off a single "Capture-only" badge is
  * returned; otherwise one sage badge per enabled capability.

--- a/packages/myco/ui/src/lib/selection.ts
+++ b/packages/myco/ui/src/lib/selection.ts
@@ -9,6 +9,7 @@ export interface GroveProjectSummary {
   created_at: string;
   updated_at: string;
   manifest_state: 'present' | 'missing' | 'invalid' | 'mismatch';
+  capabilities?: Record<string, boolean>;
 }
 
 export interface GroveSummary {

--- a/packages/myco/ui/src/pages/Groves.tsx
+++ b/packages/myco/ui/src/pages/Groves.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Plus, Search } from 'lucide-react';
+import { Plus, Search, Settings2 } from 'lucide-react';
 import { useNavigate, NavLink } from 'react-router-dom';
 import { useGroves } from '../hooks/use-groves';
 import { useProjectsActivity } from '../hooks/use-maintenance-summary';
@@ -31,6 +31,7 @@ import { RenameGroveModal } from '../components/groves/RenameGroveModal';
 import { DeleteGroveModal } from '../components/groves/DeleteGroveModal';
 import { MoveProjectModal } from '../components/groves/MoveProjectModal';
 import { DeleteProjectModal } from '../components/groves/DeleteProjectModal';
+import { CapabilityPanel } from '../components/groves/CapabilityPanel';
 import { showToast } from '../components/groves/toast';
 import { useMachineConfig, useUpdateMachineConfig } from '../hooks/use-machine-config';
 
@@ -38,6 +39,8 @@ interface MoveTarget {
   grove: GroveSummary;
   project: GroveProjectSummary;
 }
+
+type CapabilityTarget = MoveTarget;
 
 export default function Groves() {
   const navigate = useNavigate();
@@ -56,6 +59,7 @@ export default function Groves() {
   const [includeArchived, setIncludeArchived] = useState(false);
   const [pendingBackupId, setPendingBackupId] = useState<string | null>(null);
   const [search, setSearch] = useState('');
+  const [capabilityTarget, setCapabilityTarget] = useState<CapabilityTarget | null>(null);
 
   const archiveAwareQuery = useGroves({ includeArchived });
   const groves = archiveAwareQuery.data?.groves ?? [];
@@ -255,6 +259,15 @@ export default function Groves() {
                             )}
                             {project.status === 'archived' && <Badge variant="outline">archived</Badge>}
                           </NavLink>
+                          <button
+                            type="button"
+                            onClick={() => setCapabilityTarget({ grove, project })}
+                            aria-label={`Configure ${project.name} capabilities`}
+                            title="Configure capabilities"
+                            className="shrink-0 rounded-md p-1.5 text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high transition-colors"
+                          >
+                            <Settings2 className="h-4 w-4" />
+                          </button>
                           <ProjectActionMenu
                             projectName={project.name}
                             archived={project.status === 'archived'}
@@ -319,6 +332,14 @@ export default function Groves() {
           groveId={deleteProjectTarget.grove.id}
           projectId={deleteProjectTarget.project.project_id}
           projectName={deleteProjectTarget.project.name}
+        />
+      )}
+
+      {capabilityTarget && (
+        <CapabilityPanel
+          target={capabilityTarget}
+          open
+          onClose={() => setCapabilityTarget(null)}
         />
       )}
     </PageLoading>

--- a/packages/myco/ui/src/pages/Groves.tsx
+++ b/packages/myco/ui/src/pages/Groves.tsx
@@ -17,6 +17,8 @@ import {
   type GroveSummary,
   type GroveProjectSummary,
 } from '../lib/selection';
+import { buildCapabilityBadges } from '../lib/capability-badges';
+import { CapabilityChip } from '../components/symbionts/CapabilityChip';
 import { PageLoading } from '../components/ui/page-loading';
 import { PageContainer } from '../components/ui/page-container';
 import { Panel } from '../components/ui/panel';
@@ -253,6 +255,17 @@ export default function Groves() {
                               <span className="block truncate text-[11px] text-on-surface-variant">
                                 {lastActivity ? `last active ${formatTimeAgo(lastActivity)}` : 'no activity yet'}
                               </span>
+                              {project.capabilities && (
+                                <span className="mt-1.5 flex flex-wrap gap-1">
+                                  {buildCapabilityBadges(project.capabilities as Record<'cortex' | 'canopy' | 'skills' | 'vault_evolution', boolean>).map((chip) => (
+                                    <CapabilityChip
+                                      key={chip.id}
+                                      chip={chip}
+                                      href={chip.to ? `${projectPath({ grove, project })}${chip.to}` : '#'}
+                                    />
+                                  ))}
+                                </span>
+                              )}
                             </span>
                             {project.manifest_state !== 'present' && (
                               <Badge variant="outline">{project.manifest_state}</Badge>

--- a/packages/myco/ui/src/pages/Groves.tsx
+++ b/packages/myco/ui/src/pages/Groves.tsx
@@ -18,7 +18,7 @@ import {
   type GroveProjectSummary,
 } from '../lib/selection';
 import { buildCapabilityBadges } from '../lib/capability-badges';
-import { StatusDot } from '../components/ui/status-dot';
+import { CapabilityChipVisual } from '../components/symbionts/CapabilityChip';
 import { PageLoading } from '../components/ui/page-loading';
 import { PageContainer } from '../components/ui/page-container';
 import { Panel } from '../components/ui/panel';
@@ -271,15 +271,7 @@ export default function Groves() {
                               {buildCapabilityBadges(
                                 project.capabilities as Record<'cortex' | 'canopy' | 'skills' | 'vault_evolution', boolean>,
                               ).map((chip) => (
-                                <span
-                                  key={chip.id}
-                                  data-capability={chip.id}
-                                  title={chip.title}
-                                  className="inline-flex items-center gap-1.5 rounded-full border border-outline-variant/30 bg-surface-container px-2.5 py-1 text-[11px] font-medium text-on-surface"
-                                >
-                                  <StatusDot tone={chip.tone} sizePx={5} />
-                                  <span>{chip.label}</span>
-                                </span>
+                                <CapabilityChipVisual key={chip.id} chip={chip} />
                               ))}
                             </button>
                           )}

--- a/packages/myco/ui/src/pages/Groves.tsx
+++ b/packages/myco/ui/src/pages/Groves.tsx
@@ -35,7 +35,7 @@ import { MoveProjectModal } from '../components/groves/MoveProjectModal';
 import { DeleteProjectModal } from '../components/groves/DeleteProjectModal';
 import { CapabilityPanel } from '../components/groves/CapabilityPanel';
 import { showToast } from '../components/groves/toast';
-import { useMachineConfig, useUpdateMachineConfig } from '../hooks/use-machine-config';
+import { useMachineConfig, useAddToMachineConfigList } from '../hooks/use-machine-config';
 
 interface MoveTarget {
   grove: GroveSummary;
@@ -51,7 +51,7 @@ export default function Groves() {
   const archiveProject = useArchiveProject();
   const unarchiveProject = useUnarchiveProject();
   const machineConfig = useMachineConfig();
-  const updateMachineConfig = useUpdateMachineConfig();
+  const addToMachineConfigList = useAddToMachineConfigList();
 
   const [newOpen, setNewOpen] = useState(false);
   const [renameTarget, setRenameTarget] = useState<GroveSummary | null>(null);
@@ -147,10 +147,8 @@ export default function Groves() {
   function handleIgnore(grove: GroveSummary, project: GroveProjectSummary) {
     const existing = machineConfig.data?.config.capture.ignore?.paths ?? [];
     if (existing.includes(project.root)) { handleArchive(grove, project); return; }
-    const paths = [...existing, project.root];
-    updateMachineConfig.mutate(
-      // Server deep-merges the patch; sending only `paths` preserves `patterns`.
-      { capture: { ignore: { paths } } } as Parameters<typeof updateMachineConfig.mutate>[0],
+    addToMachineConfigList.mutate(
+      { path: 'capture.ignore.paths', value: project.root },
       {
         onSuccess: () => handleArchive(grove, project),
         onError: (err) => showToast({ level: 'error', title: 'Ignore failed', detail: err.message }),

--- a/packages/myco/ui/src/pages/Groves.tsx
+++ b/packages/myco/ui/src/pages/Groves.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Plus, Search, Settings2 } from 'lucide-react';
+import { Plus, Search } from 'lucide-react';
 import { useNavigate, NavLink } from 'react-router-dom';
 import { useGroves } from '../hooks/use-groves';
 import { useProjectsActivity } from '../hooks/use-maintenance-summary';
@@ -18,7 +18,7 @@ import {
   type GroveProjectSummary,
 } from '../lib/selection';
 import { buildCapabilityBadges } from '../lib/capability-badges';
-import { CapabilityChip } from '../components/symbionts/CapabilityChip';
+import { StatusDot } from '../components/ui/status-dot';
 import { PageLoading } from '../components/ui/page-loading';
 import { PageContainer } from '../components/ui/page-container';
 import { Panel } from '../components/ui/panel';
@@ -255,32 +255,36 @@ export default function Groves() {
                               <span className="block truncate text-[11px] text-on-surface-variant">
                                 {lastActivity ? `last active ${formatTimeAgo(lastActivity)}` : 'no activity yet'}
                               </span>
-                              {project.capabilities && (
-                                <span className="mt-1.5 flex flex-wrap gap-1">
-                                  {buildCapabilityBadges(project.capabilities as Record<'cortex' | 'canopy' | 'skills' | 'vault_evolution', boolean>).map((chip) => (
-                                    <CapabilityChip
-                                      key={chip.id}
-                                      chip={chip}
-                                      href={chip.to ? `${projectPath({ grove, project })}${chip.to}` : '#'}
-                                    />
-                                  ))}
-                                </span>
-                              )}
                             </span>
                             {project.manifest_state !== 'present' && (
                               <Badge variant="outline">{project.manifest_state}</Badge>
                             )}
                             {project.status === 'archived' && <Badge variant="outline">archived</Badge>}
                           </NavLink>
-                          <button
-                            type="button"
-                            onClick={() => setCapabilityTarget({ grove, project })}
-                            aria-label={`Configure ${project.name} capabilities`}
-                            title="Configure capabilities"
-                            className="shrink-0 rounded-md p-1.5 text-on-surface-variant hover:text-on-surface hover:bg-surface-container-high transition-colors"
-                          >
-                            <Settings2 className="h-4 w-4" />
-                          </button>
+                          {project.capabilities && (
+                            <button
+                              type="button"
+                              onClick={() => setCapabilityTarget({ grove, project })}
+                              aria-label={`Configure ${project.name} capabilities`}
+                              title="Configure capabilities"
+                              data-testid="capability-badge-strip"
+                              className="shrink-0 flex flex-wrap items-center gap-1 rounded-md p-1 hover:bg-surface-container-high transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40"
+                            >
+                              {buildCapabilityBadges(
+                                project.capabilities as Record<'cortex' | 'canopy' | 'skills' | 'vault_evolution', boolean>,
+                              ).map((chip) => (
+                                <span
+                                  key={chip.id}
+                                  data-capability={chip.id}
+                                  title={chip.title}
+                                  className="inline-flex items-center gap-1.5 rounded-full border border-outline-variant/30 bg-surface-container px-2.5 py-1 text-[11px] font-medium text-on-surface"
+                                >
+                                  <StatusDot tone={chip.tone} sizePx={5} />
+                                  <span>{chip.label}</span>
+                                </span>
+                              ))}
+                            </button>
+                          )}
                           <ProjectActionMenu
                             projectName={project.name}
                             archived={project.status === 'archived'}

--- a/packages/myco/ui/src/pages/Groves.tsx
+++ b/packages/myco/ui/src/pages/Groves.tsx
@@ -32,6 +32,7 @@ import { DeleteGroveModal } from '../components/groves/DeleteGroveModal';
 import { MoveProjectModal } from '../components/groves/MoveProjectModal';
 import { DeleteProjectModal } from '../components/groves/DeleteProjectModal';
 import { showToast } from '../components/groves/toast';
+import { useMachineConfig, useUpdateMachineConfig } from '../hooks/use-machine-config';
 
 interface MoveTarget {
   grove: GroveSummary;
@@ -44,6 +45,8 @@ export default function Groves() {
   const setDefaultGrove = useSetDefaultGrove();
   const archiveProject = useArchiveProject();
   const unarchiveProject = useUnarchiveProject();
+  const machineConfig = useMachineConfig();
+  const updateMachineConfig = useUpdateMachineConfig();
 
   const [newOpen, setNewOpen] = useState(false);
   const [renameTarget, setRenameTarget] = useState<GroveSummary | null>(null);
@@ -131,6 +134,20 @@ export default function Groves() {
           showToast({ level: 'error', title: 'Backup failed', detail: err.message });
         },
         onSettled: () => setPendingBackupId(null),
+      },
+    );
+  }
+
+  function handleIgnore(grove: GroveSummary, project: GroveProjectSummary) {
+    const existing = machineConfig.data?.config.capture.ignore?.paths ?? [];
+    if (existing.includes(project.root)) { handleArchive(grove, project); return; }
+    const paths = [...existing, project.root];
+    updateMachineConfig.mutate(
+      // Server deep-merges the patch; sending only `paths` preserves `patterns`.
+      { capture: { ignore: { paths } } } as Parameters<typeof updateMachineConfig.mutate>[0],
+      {
+        onSuccess: () => handleArchive(grove, project),
+        onError: (err) => showToast({ level: 'error', title: 'Ignore failed', detail: err.message }),
       },
     );
   }
@@ -245,6 +262,7 @@ export default function Groves() {
                             onOpen={() => navigate(projectPath({ grove, project }))}
                             onMove={() => setMoveTarget({ grove, project })}
                             onBackup={() => handleBackup(project)}
+                            onIgnore={() => handleIgnore(grove, project)}
                             onArchive={() => handleArchive(grove, project)}
                             onUnarchive={() => handleUnarchive(grove, project)}
                             onDelete={() => setDeleteProjectTarget({ grove, project })}

--- a/packages/myco/ui/src/pages/Settings.tsx
+++ b/packages/myco/ui/src/pages/Settings.tsx
@@ -40,6 +40,7 @@ import { useDaemon } from '../hooks/use-daemon';
 import { SETTINGS_GROUPS, type SettingField, type SettingGroup, type SettingScope } from '../settings/manifest';
 import { useUnifiedSettings } from '../hooks/use-unified-settings';
 import { useProjectSelection } from '../hooks/use-project-selection';
+import { useAddToMachineConfigList, useRemoveFromMachineConfigList } from '../hooks/use-machine-config';
 import { cn } from '../lib/cn';
 import { SettingsFilterBar, type ScopeFilter } from './settings/SettingsFilterBar';
 
@@ -605,6 +606,17 @@ function FieldRow({ field, hasProject, unified }: FieldRowProps) {
     [unified, field],
   );
 
+  // Machine-tier list fields use per-item list-delta ops (race-free).
+  const addToMachineList = useAddToMachineConfigList();
+  const removeFromMachineList = useRemoveFromMachineConfigList();
+  const isMachineList = field.scope === 'machine' && field.kind === 'list';
+  const onAdd = isMachineList
+    ? (entry: string) => addToMachineList.mutate({ path: field.key, value: entry })
+    : undefined;
+  const onRemove = isMachineList
+    ? (entry: string) => removeFromMachineList.mutate({ path: field.key, value: entry })
+    : undefined;
+
   return (
     <div
       id={focusAnchorId}
@@ -629,6 +641,8 @@ function FieldRow({ field, hasProject, unified }: FieldRowProps) {
           value={value}
           onChange={onChange}
           disabled={disabled}
+          onAdd={onAdd}
+          onRemove={onRemove}
         />
       </div>
     </div>
@@ -641,9 +655,13 @@ interface FieldControlProps {
   value: unknown;
   onChange: (next: unknown) => void;
   disabled?: boolean;
+  /** Per-item add override for list fields — uses the race-free server primitive. */
+  onAdd?: (entry: string) => void;
+  /** Per-item remove override for list fields — uses the race-free server primitive. */
+  onRemove?: (entry: string) => void;
 }
 
-function FieldControl({ inputId, field, value, onChange, disabled }: FieldControlProps) {
+function FieldControl({ inputId, field, value, onChange, disabled, onAdd, onRemove }: FieldControlProps) {
   const Control = CONTROL_BY_KIND[field.kind];
   if (!Control) return null;
 
@@ -718,6 +736,8 @@ function FieldControl({ inputId, field, value, onChange, disabled }: FieldContro
           onChange={(next) => onChange(next)}
           disabled={disabled}
           readonly={field.readonly}
+          onAdd={onAdd}
+          onRemove={onRemove}
         />
       );
     case 'secret':

--- a/tests/canopy/inject/codex-pre-post-link.test.ts
+++ b/tests/canopy/inject/codex-pre-post-link.test.ts
@@ -76,6 +76,9 @@ beforeEach(() => {
   tmpProjectId = ensureProjectManifest(path.join(tmpVault, '.myco'), {
     projectName: 'canopy-codex-link',
   }).project.id;
+  // Minimal myco.yaml required by loadMergedConfig (fail-closed gate reads
+  // the project config rather than falling back to liveConfig.current).
+  fs.writeFileSync(path.join(tmpVault, '.myco', 'myco.yaml'), 'version: 3\n', 'utf-8');
   initDatabase(path.join(tmpVault, '.myco', SQLITE_DB_FILE));
   createSchema(getDatabase(), 'local');
 });

--- a/tests/canopy/inject/end-to-end.test.ts
+++ b/tests/canopy/inject/end-to-end.test.ts
@@ -52,6 +52,9 @@ beforeEach(async () => {
   tmpVault = fs.mkdtempSync(path.join(os.tmpdir(), 'canopy-e2e-'));
   fs.mkdirSync(path.join(tmpVault, '.myco'), { recursive: true });
   tmpProjectId = ensureProjectManifest(path.join(tmpVault, '.myco'), { projectName: 'canopy-e2e' }).project.id;
+  // Minimal myco.yaml required by loadMergedConfig (fail-closed gate reads
+  // the project config rather than falling back to liveConfig.current).
+  fs.writeFileSync(path.join(tmpVault, '.myco', 'myco.yaml'), 'version: 3\n', 'utf-8');
   initDatabase(path.join(tmpVault, '.myco', SQLITE_DB_FILE));
   createSchema(getDatabase(), 'local');
 

--- a/tests/canopy/inject/endpoint.test.ts
+++ b/tests/canopy/inject/endpoint.test.ts
@@ -98,6 +98,9 @@ beforeEach(() => {
   fs.mkdirSync(path.join(tmpVault, '.myco'), { recursive: true });
   const manifest = ensureProjectManifest(path.join(tmpVault, '.myco'), { projectName: 'canopy-inject' });
   tmpProjectId = manifest.project.id;
+  // Minimal myco.yaml required by loadMergedConfig (fail-closed gate reads
+  // the project config rather than falling back to liveConfig.current).
+  fs.writeFileSync(path.join(tmpVault, '.myco', 'myco.yaml'), 'version: 3\n', 'utf-8');
   initDatabase(path.join(tmpVault, '.myco', SQLITE_DB_FILE));
   createSchema(getDatabase(), 'local');
 });
@@ -148,10 +151,38 @@ describe('POST /canopy/inject — handler', () => {
     expect(res.body).toMatchObject({ inject: false, reason: 'capability_off' });
   });
 
-  it('returns disabled when cortex.canopy.inject_on_pre_tool_use is false', async () => {
-    const cfg = makeConfig({ inject_on_pre_tool_use: false });
+  it('returns capability_off when cortex.canopy.inject_on_pre_tool_use is false (migrates to enabled: false via v10)', async () => {
+    // inject_on_pre_tool_use: false in local.yaml is migrated by v10 to
+    // enabled: false (value-relocation), so capabilityEnabled returns false
+    // and the handler returns capability_off rather than the sub-toggle
+    // `disabled` reason. This is the correct post-P1/P3 behavior.
+    fs.writeFileSync(
+      path.join(tmpVault, '.myco', 'local.yaml'),
+      'cortex:\n  canopy:\n    inject_on_pre_tool_use: false\n',
+      'utf-8',
+    );
     const handler = createCanopyInjectHandler({
-      liveConfig: { current: cfg },
+      liveConfig: { current: makeConfig() },
+      getDatabase,
+    });
+    const res = await handler({
+      requestContext: ctx(),
+      body: { sessionId: 's1', agent: 'claude-code', toolInput: { file_path: 'foo.ts' } },
+    });
+    expect(res.body).toMatchObject({ inject: false, reason: 'capability_off' });
+  });
+
+  it('returns disabled when inject_on_pre_tool_use is false and enabled is explicitly true', async () => {
+    // When `enabled: true` is set alongside `inject_on_pre_tool_use: false`, the
+    // capability gate passes (enabled=true) but the injection sub-toggle is off →
+    // reason is `disabled`, not `capability_off`.
+    fs.writeFileSync(
+      path.join(tmpVault, '.myco', 'local.yaml'),
+      'cortex:\n  canopy:\n    enabled: true\n    inject_on_pre_tool_use: false\n',
+      'utf-8',
+    );
+    const handler = createCanopyInjectHandler({
+      liveConfig: { current: makeConfig() },
       getDatabase,
     });
     const res = await handler({

--- a/tests/config/capabilities.test.ts
+++ b/tests/config/capabilities.test.ts
@@ -30,6 +30,9 @@ describe('capability gate annotations', () => {
 
 describe('capability master-gate schema defaults', () => {
   const cfg = MycoConfigSchema.parse({ version: 3 }) as any;
+  it('cortex.enabled defaults true', () => {
+    expect(cfg.cortex.enabled).toBe(true);
+  });
   it('cortex.canopy.enabled defaults true', () => {
     expect(cfg.cortex.canopy.enabled).toBe(true);
   });

--- a/tests/config/capabilities.test.ts
+++ b/tests/config/capabilities.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'bun:test';
+import { CAPABILITY_IDS } from '../../packages/myco/src/config/scope';
+
+describe('capability ids', () => {
+  it('declares the four capability ids', () => {
+    expect([...CAPABILITY_IDS].sort()).toEqual(['canopy', 'cortex', 'skills', 'vault_evolution']);
+  });
+});

--- a/tests/config/capabilities.test.ts
+++ b/tests/config/capabilities.test.ts
@@ -1,8 +1,22 @@
 import { describe, it, expect } from 'bun:test';
 import { CAPABILITY_IDS } from '../../packages/myco/src/config/scope';
+import { MycoConfigSchema } from '../../packages/myco/src/config/schema';
 
 describe('capability ids', () => {
   it('declares the four capability ids', () => {
     expect([...CAPABILITY_IDS].sort()).toEqual(['canopy', 'cortex', 'skills', 'vault_evolution']);
+  });
+});
+
+describe('capability master-gate schema defaults', () => {
+  const cfg = MycoConfigSchema.parse({ version: 3 }) as any;
+  it('cortex.canopy.enabled defaults true', () => {
+    expect(cfg.cortex.canopy.enabled).toBe(true);
+  });
+  it('skills.enabled defaults true', () => {
+    expect(cfg.skills.enabled).toBe(true);
+  });
+  it('vault_evolution.enabled defaults true', () => {
+    expect(cfg.vault_evolution.enabled).toBe(true);
   });
 });

--- a/tests/config/capabilities.test.ts
+++ b/tests/config/capabilities.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'bun:test';
 import { CAPABILITY_IDS, scopePolicyForPath } from '../../packages/myco/src/config/scope';
 import { MycoConfigSchema } from '../../packages/myco/src/config/schema';
+import { CAPABILITIES } from '../../packages/myco/src/config/capabilities';
+import { enumerateLeafPaths } from '../../packages/myco/src/config/leaf-paths';
 
 describe('capability ids', () => {
   it('declares the four capability ids', () => {
@@ -36,5 +38,29 @@ describe('capability master-gate schema defaults', () => {
   });
   it('vault_evolution.enabled defaults true', () => {
     expect(cfg.vault_evolution.enabled).toBe(true);
+  });
+});
+
+describe('capability map', () => {
+  const merged = MycoConfigSchema.parse({ version: 3 }) as Record<string, unknown>;
+  const schemaLeaves = new Set(enumerateLeafPaths(merged));
+
+  it('has one entry per capability id', () => {
+    expect(Object.keys(CAPABILITIES).sort()).toEqual([...CAPABILITY_IDS].sort());
+  });
+
+  it('every master/member gate is a real schema leaf gated by that capability', () => {
+    for (const cap of Object.values(CAPABILITIES)) {
+      for (const path of [cap.masterGate, ...cap.memberGates]) {
+        expect(schemaLeaves.has(path)).toBe(true);
+        expect(scopePolicyForPath(path).gate).toBe(cap.id);
+      }
+    }
+  });
+
+  it('every capability lists at least one scheduled task', () => {
+    for (const cap of Object.values(CAPABILITIES)) {
+      expect(cap.scheduledTasks.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/tests/config/capabilities.test.ts
+++ b/tests/config/capabilities.test.ts
@@ -1,10 +1,28 @@
 import { describe, it, expect } from 'bun:test';
-import { CAPABILITY_IDS } from '../../packages/myco/src/config/scope';
+import { CAPABILITY_IDS, scopePolicyForPath } from '../../packages/myco/src/config/scope';
 import { MycoConfigSchema } from '../../packages/myco/src/config/schema';
 
 describe('capability ids', () => {
   it('declares the four capability ids', () => {
     expect([...CAPABILITY_IDS].sort()).toEqual(['canopy', 'cortex', 'skills', 'vault_evolution']);
+  });
+});
+
+describe('capability gate annotations', () => {
+  it('cortex.enabled is gated by cortex', () => {
+    expect(scopePolicyForPath('cortex.enabled').gate).toBe('cortex');
+  });
+  it('cortex.canopy.enabled is gated by canopy (longest-prefix wins)', () => {
+    expect(scopePolicyForPath('cortex.canopy.enabled').gate).toBe('canopy');
+  });
+  it('skills.enabled is gated by skills', () => {
+    expect(scopePolicyForPath('skills.enabled').gate).toBe('skills');
+  });
+  it('vault_evolution.enabled is gated by vault_evolution and overridable by local', () => {
+    const e = scopePolicyForPath('vault_evolution.enabled');
+    expect(e.gate).toBe('vault_evolution');
+    expect(e.home).toBe('grove');
+    expect(e.overridableBy).toContain('local');
   });
 });
 

--- a/tests/config/capability-enabled.test.ts
+++ b/tests/config/capability-enabled.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'bun:test';
+import { capabilityEnabled, isCaptureOnly } from '../../packages/myco/src/config/capabilities';
+import { MycoConfigSchema } from '../../packages/myco/src/config/schema';
+import type { MycoConfig } from '../../packages/myco/src/config/schema';
+
+function defaults(): MycoConfig {
+  return MycoConfigSchema.parse({ version: 3 });
+}
+
+describe('capabilityEnabled', () => {
+  it('returns true by default for all capabilities (master gate defaults on)', () => {
+    const cfg = defaults();
+    expect(capabilityEnabled(cfg, 'cortex')).toBe(true);
+    expect(capabilityEnabled(cfg, 'canopy')).toBe(true);
+    expect(capabilityEnabled(cfg, 'skills')).toBe(true);
+    expect(capabilityEnabled(cfg, 'vault_evolution')).toBe(true);
+  });
+
+  it('returns false when the master gate is explicitly false', () => {
+    const cfg = defaults();
+    cfg.cortex.enabled = false;
+    expect(capabilityEnabled(cfg, 'cortex')).toBe(false);
+  });
+
+  it('returns false when cortex.canopy.enabled is false', () => {
+    const cfg = defaults();
+    cfg.cortex.canopy.enabled = false;
+    expect(capabilityEnabled(cfg, 'canopy')).toBe(false);
+  });
+
+  it('returns false when skills.enabled is false', () => {
+    const cfg = defaults();
+    cfg.skills.enabled = false;
+    expect(capabilityEnabled(cfg, 'skills')).toBe(false);
+  });
+
+  it('returns false when vault_evolution.enabled is false', () => {
+    const cfg = defaults();
+    cfg.vault_evolution.enabled = false;
+    expect(capabilityEnabled(cfg, 'vault_evolution')).toBe(false);
+  });
+
+  it('returns false when config is null (fail-closed)', () => {
+    expect(capabilityEnabled(null, 'cortex')).toBe(false);
+    expect(capabilityEnabled(null, 'canopy')).toBe(false);
+    expect(capabilityEnabled(null, 'skills')).toBe(false);
+    expect(capabilityEnabled(null, 'vault_evolution')).toBe(false);
+  });
+
+  it('returns false when config is undefined (fail-closed)', () => {
+    expect(capabilityEnabled(undefined, 'cortex')).toBe(false);
+  });
+});
+
+describe('isCaptureOnly', () => {
+  it('returns false when all capabilities are on (default)', () => {
+    expect(isCaptureOnly(defaults())).toBe(false);
+  });
+
+  it('returns true when all capability master gates are off', () => {
+    const cfg = defaults();
+    cfg.cortex.enabled = false;
+    cfg.cortex.canopy.enabled = false;
+    cfg.skills.enabled = false;
+    cfg.vault_evolution.enabled = false;
+    expect(isCaptureOnly(cfg)).toBe(true);
+  });
+
+  it('returns false when at least one capability is on', () => {
+    const cfg = defaults();
+    cfg.cortex.enabled = false;
+    cfg.cortex.canopy.enabled = false;
+    cfg.skills.enabled = false;
+    // vault_evolution still on
+    expect(isCaptureOnly(cfg)).toBe(false);
+  });
+
+  it('returns true when config is null (fail-closed → all caps off)', () => {
+    expect(isCaptureOnly(null)).toBe(true);
+  });
+});

--- a/tests/config/capability-links.test.ts
+++ b/tests/config/capability-links.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'bun:test';
+import { CAPABILITIES } from '../../packages/myco/src/config/capabilities';
+import { SETTINGS_GROUPS } from '../../packages/myco/ui/src/settings/manifest';
+
+describe('capability advancedSettingsLink routes resolve', () => {
+  const groupIds = new Set(SETTINGS_GROUPS.map((g) => g.id));
+  it('every advancedSettingsLink hash matches a real settings group id', () => {
+    const bad: string[] = [];
+    for (const cap of Object.values(CAPABILITIES)) {
+      const hash = cap.advancedSettingsLink.split('#')[1];
+      if (!hash || !groupIds.has(hash)) bad.push(`${cap.id}: ${cap.advancedSettingsLink}`);
+    }
+    if (bad.length) throw new Error(`Unresolvable capability links:\n  ${bad.join('\n  ')}`);
+  });
+});

--- a/tests/config/capture-ignore-schema.test.ts
+++ b/tests/config/capture-ignore-schema.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'bun:test';
+import { MycoConfigSchema } from '../../packages/myco/src/config/schema';
+import { scopePolicyForPath } from '../../packages/myco/src/config/scope';
+
+describe('capture.ignore schema', () => {
+  it('defaults to empty paths + patterns', () => {
+    const cfg = MycoConfigSchema.parse({ version: 3 }) as any;
+    expect(cfg.capture.ignore).toEqual({ paths: [], patterns: [] });
+  });
+  it('is machine-scoped via the capture prefix (no override)', () => {
+    const e = scopePolicyForPath('capture.ignore.paths');
+    expect(e.home).toBe('machine');
+    expect(e.overridableBy).toEqual([]);
+  });
+});

--- a/tests/config/migration-canopy-enabled.test.ts
+++ b/tests/config/migration-canopy-enabled.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { MIGRATIONS, CURRENT_MIGRATION_VERSION } from '../../packages/myco/src/config/migrations';
+import { MIGRATIONS, CURRENT_MIGRATION_VERSION, runMigrations } from '../../packages/myco/src/config/migrations';
 
 function runV10(doc: Record<string, unknown>) {
   const step = MIGRATIONS.find((m) => m.version === 10);
@@ -27,5 +27,44 @@ describe('v10 seed canopy.enabled from inject_on_pre_tool_use', () => {
   it('does not write enabled when both keys absent (Zod default handles it)', () => {
     const doc = runV10({ cortex: { canopy: {} } });
     expect('enabled' in (doc.cortex as any).canopy).toBe(false);
+  });
+
+  it('v10 appliesToLocal is not false (migration applies to local tier)', () => {
+    const step = MIGRATIONS.find((m) => m.version === 10);
+    expect(step?.appliesToLocal).not.toBe(false);
+  });
+});
+
+describe('v10 on local tier', () => {
+  it('seeds enabled=false on local.yaml when inject_on_pre_tool_use is false', () => {
+    // A Personal override of inject_on_pre_tool_use must be relocated to
+    // enabled so runtime gate reads the right field.
+    const doc: Record<string, unknown> = {
+      config_version: 9,
+      cortex: { canopy: { inject_on_pre_tool_use: false } },
+    };
+    runMigrations(doc, '/tmp/vault', undefined, 'local');
+    expect((doc.cortex as any).canopy.enabled).toBe(false);
+    expect(doc.config_version).toBe(10);
+  });
+
+  it('is a no-op on an empty local.yaml (does not expand sparse doc)', () => {
+    // Sparse local.yaml with no cortex block should not gain any new keys.
+    const doc: Record<string, unknown> = {};
+    const mutated = runMigrations(doc, '/tmp/vault', undefined, 'local');
+    expect(mutated).toBe(false);
+    expect(Object.keys(doc)).toHaveLength(0);
+  });
+
+  it('is a no-op on a local.yaml with cortex.canopy but no inject_on_pre_tool_use', () => {
+    const doc: Record<string, unknown> = {
+      config_version: 9,
+      cortex: { canopy: { min_file_bytes: 500 } },
+    };
+    const before = JSON.stringify(doc);
+    runMigrations(doc, '/tmp/vault', undefined, 'local');
+    // enabled should not have been added
+    expect('enabled' in (doc.cortex as any).canopy).toBe(false);
+    expect(JSON.stringify(doc)).toBe(before);
   });
 });

--- a/tests/config/migration-canopy-enabled.test.ts
+++ b/tests/config/migration-canopy-enabled.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'bun:test';
+import { MIGRATIONS, CURRENT_MIGRATION_VERSION } from '../../packages/myco/src/config/migrations';
+
+function runV10(doc: Record<string, unknown>) {
+  const step = MIGRATIONS.find((m) => m.version === 10);
+  if (!step) throw new Error('v10 migration missing');
+  step.migrate(doc, '/tmp/vault');
+  return doc;
+}
+
+describe('v10 seed canopy.enabled from inject_on_pre_tool_use', () => {
+  it('bumps CURRENT_MIGRATION_VERSION to 10', () => {
+    expect(CURRENT_MIGRATION_VERSION).toBe(10);
+  });
+  it('seeds enabled=false when inject_on_pre_tool_use is false and enabled absent', () => {
+    const doc = runV10({ cortex: { canopy: { inject_on_pre_tool_use: false } } });
+    expect((doc.cortex as any).canopy.enabled).toBe(false);
+  });
+  it('seeds enabled=true when inject_on_pre_tool_use is true', () => {
+    const doc = runV10({ cortex: { canopy: { inject_on_pre_tool_use: true } } });
+    expect((doc.cortex as any).canopy.enabled).toBe(true);
+  });
+  it('leaves enabled untouched when already present', () => {
+    const doc = runV10({ cortex: { canopy: { enabled: true, inject_on_pre_tool_use: false } } });
+    expect((doc.cortex as any).canopy.enabled).toBe(true);
+  });
+  it('does not write enabled when both keys absent (Zod default handles it)', () => {
+    const doc = runV10({ cortex: { canopy: {} } });
+    expect('enabled' in (doc.cortex as any).canopy).toBe(false);
+  });
+});

--- a/tests/config/migrations.test.ts
+++ b/tests/config/migrations.test.ts
@@ -219,8 +219,8 @@ describe('Migration v4: rename-cloud-provider-to-anthropic', () => {
 });
 
 describe('CURRENT_MIGRATION_VERSION', () => {
-  it('is 9', () => {
-    expect(CURRENT_MIGRATION_VERSION).toBe(9);
+  it('is 10', () => {
+    expect(CURRENT_MIGRATION_VERSION).toBe(10);
   });
 });
 
@@ -321,14 +321,14 @@ describe('Migration v5: seed-settings-notification-domain-default', () => {
 });
 
 describe('runMigrations', () => {
-  it('runs v3 through v9 when config_version is 2', () => {
+  it('runs v3 through v10 when config_version is 2', () => {
     const doc: Record<string, unknown> = {
       config_version: 2,
       agent: { auto_run: true, interval_seconds: 300 },
     };
     const ran = runMigrations(doc, '/tmp');
     expect(ran).toBe(true);
-    expect(doc.config_version).toBe(9);
+    expect(doc.config_version).toBe(10);
 
     const agent = doc.agent as Record<string, unknown>;
     const tasks = agent.tasks as Record<string, Record<string, unknown>>;
@@ -343,19 +343,19 @@ describe('runMigrations', () => {
     });
   });
 
-  it('runs v4 onward when config_version is 3 (target v9)', () => {
+  it('runs v4 onward when config_version is 3 (target v10)', () => {
     const doc: Record<string, unknown> = {
       config_version: 3,
       agent: { provider: { type: 'cloud' } },
     };
     const ran = runMigrations(doc, '/tmp');
     expect(ran).toBe(true);
-    expect(doc.config_version).toBe(9);
+    expect(doc.config_version).toBe(10);
     const agent = doc.agent as Record<string, unknown>;
     expect((agent.provider as Record<string, unknown>).type).toBe('anthropic');
   });
 
-  it('runs v5 onward when config_version is 4 (target v9)', () => {
+  it('runs v5 onward when config_version is 4 (target v10)', () => {
     const doc: Record<string, unknown> = {
       config_version: 4,
       notifications: {
@@ -364,7 +364,7 @@ describe('runMigrations', () => {
     };
     const ran = runMigrations(doc, '/tmp');
     expect(ran).toBe(true);
-    expect(doc.config_version).toBe(9);
+    expect(doc.config_version).toBe(10);
 
     const notifications = doc.notifications as Record<string, unknown>;
     const domains = notifications.domains as Record<string, Record<string, unknown>>;
@@ -374,48 +374,48 @@ describe('runMigrations', () => {
     });
   });
 
-  it('runs v6 through v8 when config_version is 5', () => {
+  it('runs v6 through v10 when config_version is 5', () => {
     const doc: Record<string, unknown> = {
       config_version: 5,
       agent: { tasks: { 'full-intelligence': { model: 'claude-sonnet-4-6' } } },
     };
     const ran = runMigrations(doc, '/tmp');
     expect(ran).toBe(true);
-    expect(doc.config_version).toBe(9);
+    expect(doc.config_version).toBe(10);
     const tasks = (doc.agent as Record<string, unknown>).tasks as Record<string, Record<string, unknown>>;
     expect(tasks['full-intelligence']).toBeUndefined();
     expect(tasks['vault-evolve']).toEqual({ model: 'claude-sonnet-4-6' });
   });
 
-  it('runs v7 and v8 when config_version is 6', () => {
+  it('runs v7 through v10 when config_version is 6', () => {
     const doc: Record<string, unknown> = {
       config_version: 6,
       agent: { auto_run: true, provider: { type: 'cloud' } },
     };
     const ran = runMigrations(doc, '/tmp');
     expect(ran).toBe(true);
-    expect(doc.config_version).toBe(9);
+    expect(doc.config_version).toBe(10);
     const agent = doc.agent as Record<string, unknown>;
     expect(agent.auto_run).toBe(true);
     expect((agent.provider as Record<string, unknown>).type).toBe('cloud');
   });
 
-  it('runs v9 when config_version is 8', () => {
+  it('runs v9 and v10 when config_version is 8', () => {
     const doc: Record<string, unknown> = {
       config_version: 8,
       agent: { auto_run: true, provider: { type: 'cloud' } },
     };
     const ran = runMigrations(doc, '/tmp');
     expect(ran).toBe(true);
-    expect(doc.config_version).toBe(9);
+    expect(doc.config_version).toBe(10);
     const agent = doc.agent as Record<string, unknown>;
     expect(agent.auto_run).toBe(true);
     expect((agent.provider as Record<string, unknown>).type).toBe('cloud');
   });
 
-  it('skips all migrations when config_version is already 9', () => {
+  it('skips all migrations when config_version is already 10', () => {
     const doc: Record<string, unknown> = {
-      config_version: 9,
+      config_version: 10,
       agent: { auto_run: true, provider: { type: 'cloud' } },
     };
     const ran = runMigrations(doc, '/tmp');
@@ -466,7 +466,7 @@ describe('Migration v7: dedupe-canopy-exclude-patterns-against-baseline', () => 
   it('is a no-op when canopy.exclude is missing', () => {
     const doc: Record<string, unknown> = { config_version: 6 };
     expect(() => runMigrations(doc, '/tmp')).not.toThrow();
-    expect(doc.config_version).toBe(9);
+    expect(doc.config_version).toBe(10);
   });
 });
 

--- a/tests/config/scope-registry-sync.test.ts
+++ b/tests/config/scope-registry-sync.test.ts
@@ -40,8 +40,7 @@ describe('scope registry sync', () => {
   it('every capability master gate resolves to a row with its own gate', () => {
     const errors: string[] = [];
     for (const cap of Object.values(CAPABILITIES)) {
-      let policy; try { policy = scopePolicyForPath(cap.masterGate); }
-      catch { errors.push(`${cap.id}: master '${cap.masterGate}' has no registry entry`); continue; }
+      let policy; try { policy = scopePolicyForPath(cap.masterGate); } catch { errors.push(`${cap.id}: master '${cap.masterGate}' has no registry entry`); continue; }
       if (policy.gate !== cap.id) errors.push(`${cap.id}: master '${cap.masterGate}' gate is '${policy.gate}'`);
     }
     if (errors.length) throw new Error(`Capability/registry drift:\n  ${errors.join('\n  ')}`);

--- a/tests/config/scope-registry-sync.test.ts
+++ b/tests/config/scope-registry-sync.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'bun:test';
 import { MycoConfigSchema } from '../../packages/myco/src/config/schema';
-import { scopePolicyForPath } from '../../packages/myco/src/config/scope';
+import { scopePolicyForPath, SCOPE_REGISTRY, CAPABILITY_IDS } from '../../packages/myco/src/config/scope';
 import { enumerateLeafPaths } from '../../packages/myco/src/config/leaf-paths';
 import { SETTINGS_GROUPS } from '../../packages/myco/ui/src/settings/manifest';
+import { CAPABILITIES } from '../../packages/myco/src/config/capabilities';
 
 // Dynamic records/arrays are covered by their block-prefix entry; their dynamic
 // children are not enumerable from a defaulted schema, so they are skipped here.
@@ -26,5 +27,23 @@ describe('scope registry sync', () => {
       if (f.scope !== policy.home) errors.push(`${f.key}: manifest scope '${f.scope}' != registry home '${policy.home}'`);
     }
     if (errors.length) throw new Error(`Manifest/registry drift:\n  ${errors.join('\n  ')}`);
+  });
+
+  it('every registry gate is a valid capability id', () => {
+    const valid = new Set<string>(CAPABILITY_IDS);
+    const bad = Object.entries(SCOPE_REGISTRY)
+      .filter(([, e]) => e.gate !== undefined && !valid.has(e.gate))
+      .map(([k, e]) => `${k}: gate '${e.gate}'`);
+    if (bad.length) throw new Error(`Registry rows with invalid gate:\n  ${bad.join('\n  ')}`);
+  });
+
+  it('every capability master gate resolves to a row with its own gate', () => {
+    const errors: string[] = [];
+    for (const cap of Object.values(CAPABILITIES)) {
+      let policy; try { policy = scopePolicyForPath(cap.masterGate); }
+      catch { errors.push(`${cap.id}: master '${cap.masterGate}' has no registry entry`); continue; }
+      if (policy.gate !== cap.id) errors.push(`${cap.id}: master '${cap.masterGate}' gate is '${policy.gate}'`);
+    }
+    if (errors.length) throw new Error(`Capability/registry drift:\n  ${errors.join('\n  ')}`);
   });
 });

--- a/tests/context/cortex-brief-gate.test.ts
+++ b/tests/context/cortex-brief-gate.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'bun:test';
+import { buildScheduledCortexInstruction } from '../../packages/myco/src/context/cortex-brief';
+import { MycoConfigSchema } from '../../packages/myco/src/config/schema';
+
+describe('buildScheduledCortexInstruction cortex.enabled gate', () => {
+  it('returns undefined when cortex.enabled is false (no regeneration)', async () => {
+    const config = MycoConfigSchema.parse({ version: 3 });
+    config.cortex.enabled = false;
+    const result = await buildScheduledCortexInstruction(config, '/tmp/nonexistent-vault/.myco');
+    expect(result).toBeUndefined();
+  });
+});

--- a/tests/context/cortex-brief.test.ts
+++ b/tests/context/cortex-brief.test.ts
@@ -142,39 +142,47 @@ describe('RETRIEVAL_GUIDANCE', () => {
 });
 
 describe('resolveInstructionDelivery', () => {
-  const enabledCortex = MycoConfigSchema.parse({ version: 3 }).cortex;
-  const disabledCortex = MycoConfigSchema.parse({
+  const enabledConfig = MycoConfigSchema.parse({ version: 3 });
+  const disabledConfig = MycoConfigSchema.parse({
     version: 3,
     cortex: { instructions: { inject_on_session_start: false } },
-  }).cortex;
+  });
+  // Cortex capability master gate off → delivery falls back to inline.
+  const masterOffConfig = MycoConfigSchema.parse({ version: 3, cortex: { enabled: false } });
 
   const cases: Array<{
     label: string;
-    cortex: typeof enabledCortex;
+    config: typeof enabledConfig;
     symbiont: { supportsSessionStartInjection: boolean } | null;
     expected: ReturnType<typeof resolveInstructionDelivery>;
   }> = [
     {
       label: 'null symbiont → inline with missing-symbiont reason',
-      cortex: enabledCortex,
+      config: enabledConfig,
       symbiont: null,
       expected: { inlineInstructions: true, reason: 'missing-symbiont' },
     },
     {
       label: 'cortex disabled → inline regardless of symbiont support',
-      cortex: disabledCortex,
+      config: disabledConfig,
+      symbiont: { supportsSessionStartInjection: true },
+      expected: { inlineInstructions: true, reason: 'session-start-disabled' },
+    },
+    {
+      label: 'cortex capability master gate off → inline regardless of symbiont support',
+      config: masterOffConfig,
       symbiont: { supportsSessionStartInjection: true },
       expected: { inlineInstructions: true, reason: 'session-start-disabled' },
     },
     {
       label: 'symbiont supports injection → NOT inline',
-      cortex: enabledCortex,
+      config: enabledConfig,
       symbiont: { supportsSessionStartInjection: true },
       expected: { inlineInstructions: false, reason: 'session-start-supported' },
     },
     {
       label: 'symbiont lacks injection support → inline with no-session-start',
-      cortex: enabledCortex,
+      config: enabledConfig,
       symbiont: { supportsSessionStartInjection: false },
       expected: { inlineInstructions: true, reason: 'no-session-start' },
     },
@@ -182,7 +190,7 @@ describe('resolveInstructionDelivery', () => {
 
   for (const testCase of cases) {
     it(testCase.label, () => {
-      expect(resolveInstructionDelivery(testCase.cortex, testCase.symbiont))
+      expect(resolveInstructionDelivery(testCase.config, testCase.symbiont))
         .toEqual(testCase.expected);
     });
   }

--- a/tests/daemon/api/config-list-ops.test.ts
+++ b/tests/daemon/api/config-list-ops.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { handlePutMachineConfig, handleGetMachineConfig } from '@myco/daemon/api/config';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+/**
+ * P4 — Race-free list-config mutation primitive.
+ *
+ * These tests verify the server-side addToList / removeFromList ops for the
+ * machine config tier. The key invariant: two concurrent addToList calls for
+ * the same path both land — no overwrite — because the server does the
+ * read-modify-write, not the client.
+ */
+describe('machine config addToList / removeFromList', () => {
+  let mycoHome: string;
+  let prevMycoHome: string | undefined;
+
+  beforeEach(() => {
+    mycoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-list-ops-'));
+    prevMycoHome = process.env.MYCO_HOME;
+    process.env.MYCO_HOME = mycoHome;
+  });
+
+  afterEach(() => {
+    fs.rmSync(mycoHome, { recursive: true, force: true });
+    if (prevMycoHome === undefined) delete process.env.MYCO_HOME;
+    else process.env.MYCO_HOME = prevMycoHome;
+  });
+
+  it('addToList seeds an empty array when the path has no prior value', async () => {
+    const res = await handlePutMachineConfig({
+      addToList: [{ path: 'capture.ignore.paths', values: ['/tmp/a'] }],
+    });
+    expect(res.response.status).toBeUndefined();
+    const cfg = await handleGetMachineConfig();
+    expect((cfg.body as any).config.capture.ignore.paths).toContain('/tmp/a');
+  });
+
+  it('addToList appends without overwriting — two calls both persist', async () => {
+    // Simulate two sequential calls (atomic in prod; sequential here verifies
+    // no full-array replace).
+    await handlePutMachineConfig({
+      addToList: [{ path: 'capture.ignore.paths', values: ['/tmp/a'] }],
+    });
+    await handlePutMachineConfig({
+      addToList: [{ path: 'capture.ignore.paths', values: ['/tmp/b'] }],
+    });
+    const cfg = await handleGetMachineConfig();
+    const paths = (cfg.body as any).config.capture.ignore.paths as string[];
+    expect(paths).toContain('/tmp/a');
+    expect(paths).toContain('/tmp/b');
+  });
+
+  it('addToList deduplicates — adding the same value twice results in one entry', async () => {
+    await handlePutMachineConfig({
+      addToList: [{ path: 'capture.ignore.paths', values: ['/tmp/dup'] }],
+    });
+    await handlePutMachineConfig({
+      addToList: [{ path: 'capture.ignore.paths', values: ['/tmp/dup'] }],
+    });
+    const cfg = await handleGetMachineConfig();
+    const paths = (cfg.body as any).config.capture.ignore.paths as string[];
+    expect(paths.filter((p) => p === '/tmp/dup')).toHaveLength(1);
+  });
+
+  it('removeFromList removes the named value, leaving others intact', async () => {
+    await handlePutMachineConfig({
+      addToList: [{ path: 'capture.ignore.paths', values: ['/tmp/a', '/tmp/b', '/tmp/c'] }],
+    });
+    await handlePutMachineConfig({
+      removeFromList: [{ path: 'capture.ignore.paths', values: ['/tmp/b'] }],
+    });
+    const cfg = await handleGetMachineConfig();
+    const paths = (cfg.body as any).config.capture.ignore.paths as string[];
+    expect(paths).toContain('/tmp/a');
+    expect(paths).not.toContain('/tmp/b');
+    expect(paths).toContain('/tmp/c');
+  });
+
+  it('addToList and patch can be combined in one request', async () => {
+    const res = await handlePutMachineConfig({
+      addToList: [{ path: 'capture.plan_dirs', values: ['/home/me/plans'] }],
+    });
+    expect(res.response.status).toBeUndefined();
+    const cfg = await handleGetMachineConfig();
+    expect((cfg.body as any).config.capture.plan_dirs).toContain('/home/me/plans');
+  });
+
+  it('returns 400 when addToList is not an array', async () => {
+    const res = await handlePutMachineConfig({
+      addToList: 'bad' as unknown as [],
+    });
+    expect(res.response.status).toBe(400);
+  });
+
+  it('returns 400 when a list op entry has no values array', async () => {
+    const res = await handlePutMachineConfig({
+      addToList: [{ path: 'capture.ignore.paths', values: 'oops' } as unknown as { path: string; values: unknown[] }],
+    });
+    expect(res.response.status).toBe(400);
+  });
+
+  it('returns 400 when neither patch nor list ops are provided', async () => {
+    const res = await handlePutMachineConfig({});
+    expect(res.response.status).toBe(400);
+  });
+
+  it('validates after list ops — rejects a schema-invalid result', async () => {
+    // force the path to a non-string value to trip the schema validator
+    const res = await handlePutMachineConfig({
+      addToList: [{ path: 'capture.ignore.paths', values: [42 as unknown as string] }],
+    });
+    // MachineConfigSchema requires string[] — Zod should reject non-string entries
+    expect(res.response.status).toBe(400);
+    expect((res.response.body as any).error).toBe('validation_failed');
+  });
+});

--- a/tests/daemon/api/config-list-ops.test.ts
+++ b/tests/daemon/api/config-list-ops.test.ts
@@ -78,6 +78,19 @@ describe('machine config addToList / removeFromList', () => {
     expect(paths).toContain('/tmp/c');
   });
 
+  it('removeFromList of an absent value is a harmless no-op', async () => {
+    await handlePutMachineConfig({
+      addToList: [{ path: 'capture.ignore.paths', values: ['/tmp/a', '/tmp/b'] }],
+    });
+    const res = await handlePutMachineConfig({
+      removeFromList: [{ path: 'capture.ignore.paths', values: ['/tmp/not-present'] }],
+    });
+    expect(res.response.status).toBeUndefined();
+    const cfg = await handleGetMachineConfig();
+    const paths = (cfg.body as any).config.capture.ignore.paths as string[];
+    expect(paths).toEqual(['/tmp/a', '/tmp/b']);
+  });
+
   it('addToList and patch can be combined in one request', async () => {
     const res = await handlePutMachineConfig({
       addToList: [{ path: 'capture.plan_dirs', values: ['/home/me/plans'] }],
@@ -114,5 +127,17 @@ describe('machine config addToList / removeFromList', () => {
     // MachineConfigSchema requires string[] — Zod should reject non-string entries
     expect(res.response.status).toBe(400);
     expect((res.response.body as any).error).toBe('validation_failed');
+  });
+
+  it('drops a list-delta targeting grove.* (same guard as the patch strip)', async () => {
+    // grove.* is registry-owned, stripped from machine patches. A list-delta
+    // targeting it must pass through the same path guard — dropped, not
+    // written. With only the dropped op present, nothing remains to write.
+    const res = await handlePutMachineConfig({
+      addToList: [{ path: 'grove.default_grove_id', values: ['grove_x'] }],
+    });
+    expect(res.response.status).toBe(400);
+    const cfg = await handleGetMachineConfig();
+    expect((cfg.body as any).config.grove?.default_grove_id).toBeUndefined();
   });
 });

--- a/tests/daemon/api/config-scope.test.ts
+++ b/tests/daemon/api/config-scope.test.ts
@@ -84,6 +84,24 @@ describe('scoped config HTTP handlers', () => {
     expect((project.body as any).error).toBe('appearance_is_grove_scoped');
   });
 
+  it('PUT /scoped list-delta targeting appearance.* gets the same Grove-scoped 400', async () => {
+    // A list-delta is a new way to write config paths; it must pass through
+    // the same path-based scope guard as patch/clear — so an op targeting
+    // appearance.* returns the specific error, not a generic validation_failed.
+    const add = await handlePutScopedConfig(tmpDir, {
+      scope: 'local',
+      addToList: [{ path: 'appearance.accents', values: ['moss'] }],
+    });
+    const remove = await handlePutScopedConfig(tmpDir, {
+      scope: 'project',
+      removeFromList: [{ path: 'appearance.accents', values: ['moss'] }],
+    });
+    expect(add.status).toBe(400);
+    expect((add.body as any).error).toBe('appearance_is_grove_scoped');
+    expect(remove.status).toBe(400);
+    expect((remove.body as any).error).toBe('appearance_is_grove_scoped');
+  });
+
   it('PUT /grove-config writes appearance for the current Grove', async () => {
     const res = await handlePutGroveConfig(groveId, {
       patch: { appearance: { theme: 'plum', density: 'compact' } },

--- a/tests/daemon/api/context.test.ts
+++ b/tests/daemon/api/context.test.ts
@@ -143,6 +143,17 @@ describe('createSessionContextHandler', () => {
     expect((result.body as { text: string }).text).toBe('');
   });
 
+  it('returns empty when cortex.enabled master gate is false (even with digest sub-toggle on)', async () => {
+    // cortex.enabled=false must suppress session-start entirely, even if
+    // digest injection sub-toggle is on — master gate wins.
+    const cfg = MycoConfigSchema.parse({ version: 3, cortex: { digest: { inject_on_session_start: true } } });
+    cfg.cortex.enabled = false;
+    const handler = createSessionContextHandler(makeDeps({ config: cfg }));
+    const result = await handler(makeReq({ session_id: 'sess-cortex-master-off' }));
+
+    expect((result.body as { text: string }).text).toBe('');
+  });
+
   it('appends the preferred digest when digest injection is enabled', async () => {
     registerAgent({
       id: DEFAULT_AGENT_ID,
@@ -440,6 +451,17 @@ describe('createPromptContextHandler', () => {
     const handler = createPromptContextHandler(makeDeps({ config: makeConfig({ prompt_search: false }) }));
     const result = await handler(makeReq({ prompt: 'write a spec for X', session_id: 'sess-nudge-3' }));
     expect((result.body as { text: string }).text).toContain('Myco is where plans live');
+  });
+
+  it('returns empty when cortex.enabled master gate is false (suppresses spores and nudge)', async () => {
+    // cortex.enabled=false must suppress both spore search and the plan-intent
+    // nudge — the coarse boundary gate fires before either sub-toggle.
+    const cfg = MycoConfigSchema.parse({ version: 3 });
+    cfg.cortex.enabled = false;
+    const handler = createPromptContextHandler(makeDeps({ config: cfg }));
+    const result = await handler(makeReq({ prompt: 'please plan the migration', session_id: 'sess-cortex-master-off-prompt' }));
+
+    expect((result.body as { text: string }).text).toBe('');
   });
 
   it('injects the nudge at most once per session', async () => {

--- a/tests/daemon/api/groves.test.ts
+++ b/tests/daemon/api/groves.test.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { invalidateMergedConfigCache } from '@myco/config/loader.js';
 import { saveProjectManifest } from '@myco/config/project-manifest.js';
 import { createListGroveProjectsHandler, createListGrovesHandler, servedGroveScopeForDaemon } from '@myco/daemon/api/groves.js';
+import type { GroveProjectSummary } from '@myco/daemon/api/groves.js';
 import { resolveProjectVaultDir } from '@myco/grove/paths.js';
 import { createGrove, registerProjectInGrove } from '@myco/grove/registry.js';
 
@@ -117,6 +119,45 @@ describe('Grove discovery API', () => {
     const body = response.body as { projects: Array<{ project_id: string }> };
 
     expect(body.projects.map((project) => project.project_id)).toEqual(['proj_a']);
+  });
+
+  it('returns capability gates per project; cortex=false when local.yaml disables it', async () => {
+    const grove = createGrove('Capability Test Grove');
+    const projectRoot = path.join(testDir, 'captest');
+    const vaultDir = resolveProjectVaultDir(projectRoot);
+    fs.mkdirSync(vaultDir, { recursive: true });
+
+    // Minimal myco.yaml required by loadMergedConfig.
+    fs.writeFileSync(path.join(vaultDir, 'myco.yaml'), 'version: 3\n', 'utf-8');
+    // local.yaml disables the cortex master gate.
+    fs.writeFileSync(path.join(vaultDir, 'local.yaml'), 'cortex:\n  enabled: false\n', 'utf-8');
+    invalidateMergedConfigCache(vaultDir);
+
+    saveProjectManifest(vaultDir, {
+      project: { id: 'proj_cap', name: 'Cap Test' },
+      grove: { binding_id: 'gbind_cap', slug: grove.slug, mode: 'local' },
+    });
+    registerProjectInGrove(grove.id, {
+      projectId: 'proj_cap',
+      projectName: 'Cap Test',
+      projectRoot,
+      bindingId: 'gbind_cap',
+    });
+
+    const response = await createListGrovesHandler({ groveIds: null }, serviceDir)({
+      body: undefined,
+      query: {},
+      params: {},
+      pathname: '/api/groves',
+    });
+    const body = response.body as { groves: Array<{ projects: GroveProjectSummary[] }> };
+    const project = body.groves.flatMap((g) => g.projects).find((p) => p.project_id === 'proj_cap');
+
+    expect(project).toBeDefined();
+    expect(project!.capabilities.cortex).toBe(false);
+    expect(project!.capabilities.canopy).toBe(true);
+    expect(project!.capabilities.skills).toBe(true);
+    expect(project!.capabilities.vault_evolution).toBe(true);
   });
 });
 

--- a/tests/daemon/canopy-inject-gate.test.ts
+++ b/tests/daemon/canopy-inject-gate.test.ts
@@ -20,7 +20,7 @@ function ctx(overrides: Partial<MycoRequestContext> = {}): MycoRequestContext {
     projectRoot: tmpVault,
     callerRoot: null,
     projectId: assertGroveProjectId(tmpProjectId),
-    groveId: null,
+    groveId: 'grove_00000000000000000000000000000000',
     machineId: 'local',
     sessionId: null,
     projectVaultDir: path.join(tmpVault, '.myco'),

--- a/tests/daemon/canopy-inject-gate.test.ts
+++ b/tests/daemon/canopy-inject-gate.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs';
+
+import { initDatabase, closeDatabase, getDatabase, SQLITE_DB_FILE } from '@myco/db/client';
+import { createSchema } from '@myco/db/schema';
+import { MycoConfigSchema } from '@myco/config/schema';
+import { createCanopyInjectHandler } from '@myco/daemon/api/canopy-inject';
+import { ensureProjectManifest } from '@myco/config/project-manifest.js';
+import { assertGroveProjectId } from '@myco/grove/ids';
+import type { MycoRequestContext } from '@myco/grove/request-context.js';
+import { _resetPendingInjections } from '@myco/canopy/inject/pending';
+
+let tmpVault: string;
+let tmpProjectId: string;
+
+function ctx(overrides: Partial<MycoRequestContext> = {}): MycoRequestContext {
+  return {
+    projectRoot: tmpVault,
+    callerRoot: null,
+    projectId: assertGroveProjectId(tmpProjectId),
+    groveId: null,
+    machineId: 'local',
+    sessionId: null,
+    projectVaultDir: path.join(tmpVault, '.myco'),
+    databasePath: path.join(tmpVault, '.myco', SQLITE_DB_FILE),
+    source: 'explicit',
+    tenancySource: 'caller',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  closeDatabase();
+  _resetPendingInjections();
+  tmpVault = fs.mkdtempSync(path.join(os.tmpdir(), 'canopy-inject-gate-'));
+  fs.mkdirSync(path.join(tmpVault, '.myco'), { recursive: true });
+  const manifest = ensureProjectManifest(path.join(tmpVault, '.myco'), { projectName: 'canopy-inject-gate' });
+  tmpProjectId = manifest.project.id;
+  initDatabase(path.join(tmpVault, '.myco', SQLITE_DB_FILE));
+  createSchema(getDatabase(), 'local');
+});
+
+afterEach(() => {
+  closeDatabase();
+  fs.rmSync(tmpVault, { recursive: true, force: true });
+});
+
+describe('POST /canopy/inject — per-project capability gate', () => {
+  it('returns inject:false reason capability_off when project cortex.canopy.enabled is false, even if bootstrap config has canopy on', async () => {
+    // Write per-project config with canopy disabled
+    fs.writeFileSync(
+      path.join(tmpVault, '.myco', 'myco.yaml'),
+      'version: 3\ncortex:\n  canopy:\n    enabled: false\n',
+    );
+
+    // Bootstrap config has canopy enabled — proves the handler reads per-project, not bootstrap
+    const bootstrapConfig = MycoConfigSchema.parse({ version: 3 });
+    bootstrapConfig.cortex.canopy.enabled = true;
+
+    const handler = createCanopyInjectHandler({
+      liveConfig: { current: bootstrapConfig },
+      getDatabase,
+    });
+
+    const res = await handler({
+      requestContext: ctx(),
+      body: {
+        sessionId: 's1',
+        agent: 'claude-code',
+        toolInput: { file_path: 'src/index.ts' },
+      },
+    });
+
+    expect(res.body).toMatchObject({ inject: false, reason: 'capability_off' });
+  });
+});

--- a/tests/daemon/power-jobs.test.ts
+++ b/tests/daemon/power-jobs.test.ts
@@ -764,6 +764,44 @@ describe('canopy-background-scan power job', () => {
     );
     expect(count.n).toBe(0);
   });
+
+  it('skips per-project scan when project cortex.canopy.enabled is false', async () => {
+    const projectRoot = path.join(fx.workDir, 'projects', 'a');
+    const vaultDir = resolveProjectVaultDir(projectRoot);
+    fs.mkdirSync(vaultDir, { recursive: true });
+    fs.writeFileSync(path.join(projectRoot, 'a.ts'), 'export const a = 1;\n');
+    fs.writeFileSync(
+      path.join(vaultDir, 'myco.yaml'),
+      'version: 3\ncortex:\n  canopy:\n    enabled: false\n',
+    );
+    registerProjectInGrove(fx.grove.id, {
+      projectId: 'proj_' + 'aaaa111122223333aaaa111122223333',
+      projectName: 'a',
+      projectRoot,
+    }, fx.mycoHome);
+
+    const deps = buildDeps(fx);
+    deps.liveConfig.current = {
+      ...deps.liveConfig.current,
+      cortex: {
+        ...(deps.liveConfig.current as { cortex: Record<string, unknown> }).cortex,
+        canopy: {
+          refresh: { background_enabled: true, background_period_minutes: 1 },
+          exclude: { default_patterns: [], patterns: [] },
+        },
+      },
+    };
+    registerPowerJobs(pm as never, deps);
+
+    await pm.find('canopy-background-scan').fn();
+
+    const count = withDatabase(fx.cache.getDatabase(fx.databasePath), () =>
+      getDatabase().prepare(
+        `SELECT COUNT(*) AS n FROM canopy_entries`,
+      ).get() as { n: number },
+    );
+    expect(count.n).toBe(0);
+  });
 });
 
 describe('session-maintenance power job', () => {

--- a/tests/daemon/power-jobs.test.ts
+++ b/tests/daemon/power-jobs.test.ts
@@ -691,6 +691,10 @@ describe('canopy-background-scan power job', () => {
     const projectRootB = path.join(fx.workDir, 'projects', 'b');
     fs.mkdirSync(resolveProjectVaultDir(projectRootA), { recursive: true });
     fs.mkdirSync(resolveProjectVaultDir(projectRootB), { recursive: true });
+    // Minimal myco.yaml so loadMergedConfig succeeds — the canopy scan is
+    // fail-closed (skips on unreadable config), like canopy-inject.
+    fs.writeFileSync(path.join(resolveProjectVaultDir(projectRootA), 'myco.yaml'), 'version: 3\n');
+    fs.writeFileSync(path.join(resolveProjectVaultDir(projectRootB), 'myco.yaml'), 'version: 3\n');
     fs.writeFileSync(path.join(projectRootA, 'a.ts'), 'export const a = 1;\n');
     fs.writeFileSync(path.join(projectRootB, 'b.ts'), 'export const b = 1;\n');
     registerProjectInGrove(fx.grove.id, {

--- a/tests/daemon/scheduler-capability-gate.test.ts
+++ b/tests/daemon/scheduler-capability-gate.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'bun:test';
+import { MycoConfigSchema } from '../../packages/myco/src/config/schema';
+import { CAPABILITIES, capabilityForTask } from '../../packages/myco/src/config/capabilities';
+import { getAtPath } from '../../packages/myco/src/utils/dot-path';
+
+// Mirror the implementation's decision so the contract is locked even before
+// the scheduler wiring; the scheduler calls the same logic.
+function capabilityEnabled(config: unknown, taskName: string): boolean {
+  const capId = capabilityForTask(taskName);
+  if (!capId) return true;
+  return getAtPath(config, CAPABILITIES[capId].masterGate) !== false;
+}
+
+describe('scheduler capability gate', () => {
+  const cfg = MycoConfigSchema.parse({ version: 3 }) as Record<string, unknown>;
+  it('gates vault-evolve when vault_evolution.enabled is false', () => {
+    const off = MycoConfigSchema.parse({ version: 3 }) as any;
+    off.vault_evolution.enabled = false;
+    expect(capabilityEnabled(off, 'vault-evolve')).toBe(false);
+  });
+  it('allows vault-evolve when enabled (default)', () => {
+    expect(capabilityEnabled(cfg, 'vault-evolve')).toBe(true);
+  });
+  it('allows a task with no capability (e.g. title-summary)', () => {
+    expect(capabilityEnabled(cfg, 'title-summary')).toBe(true);
+  });
+  it('gates canopy-map when cortex.canopy.enabled is false', () => {
+    const off = MycoConfigSchema.parse({ version: 3 }) as any;
+    off.cortex.canopy.enabled = false;
+    expect(capabilityEnabled(off, 'canopy-map')).toBe(false);
+  });
+});

--- a/tests/daemon/scheduler-capability-gate.test.ts
+++ b/tests/daemon/scheduler-capability-gate.test.ts
@@ -1,3 +1,6 @@
+// Exercises the gate *decision contract* in isolation via a mirrored helper —
+// not the scheduler wiring. The live wiring (getCapabilityEnabled feeding the
+// scheduler loop) is covered by the canopy-inject + power-jobs tests.
 import { describe, it, expect } from 'bun:test';
 import { MycoConfigSchema } from '../../packages/myco/src/config/schema';
 import { CAPABILITIES, capabilityForTask } from '../../packages/myco/src/config/capabilities';

--- a/tests/daemon/tick-paths-pause.test.ts
+++ b/tests/daemon/tick-paths-pause.test.ts
@@ -155,6 +155,10 @@ function setupTwoProjects(fx: Fixture): { vaultPaused: string; vaultLive: string
   const vaultLive = resolveProjectVaultDir(rootLive);
   fs.mkdirSync(vaultPaused, { recursive: true });
   fs.mkdirSync(vaultLive, { recursive: true });
+  // Minimal myco.yaml so loadMergedConfig succeeds — the canopy scan is
+  // fail-closed (skips on unreadable config), like canopy-inject.
+  fs.writeFileSync(path.join(vaultPaused, 'myco.yaml'), 'version: 3\n');
+  fs.writeFileSync(path.join(vaultLive, 'myco.yaml'), 'version: 3\n');
   fs.writeFileSync(path.join(rootPaused, 'p.ts'), 'export const p = 1;\n');
   fs.writeFileSync(path.join(rootLive, 'l.ts'), 'export const l = 1;\n');
   registerProjectInGrove(fx.grove.id, {

--- a/tests/ui/capability-badges.test.ts
+++ b/tests/ui/capability-badges.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect } from 'bun:test';
 import { buildCapabilityBadges } from '../../packages/myco/ui/src/lib/capability-badges';
+import { CAPABILITIES } from '../../packages/myco/src/config/capabilities';
+import type { CapabilityId } from '../../packages/myco/src/config/scope';
+
+/** All capabilities on — the default schema state. */
+const ALL_ON: Record<CapabilityId, boolean> = Object.fromEntries(
+  (Object.keys(CAPABILITIES) as CapabilityId[]).map((id) => [id, true]),
+) as Record<CapabilityId, boolean>;
+
+/** All capabilities off — a newly admitted capture-only project. */
+const ALL_OFF: Record<CapabilityId, boolean> = Object.fromEntries(
+  (Object.keys(CAPABILITIES) as CapabilityId[]).map((id) => [id, false]),
+) as Record<CapabilityId, boolean>;
 
 describe('buildCapabilityBadges', () => {
   it('shows Capture-only when all opt-in capabilities are off', () => {
@@ -13,5 +25,35 @@ describe('buildCapabilityBadges', () => {
     expect(labels).toContain('Skills');
     expect(labels).not.toContain('Canopy');
     expect(badges.find((b) => b.label === 'Cortex')!.tone).toBe('sage');
+  });
+
+  describe('Groves card — project.capabilities consumption', () => {
+    it('a capture-only project (all off) yields exactly one Capture-only badge', () => {
+      const badges = buildCapabilityBadges(ALL_OFF);
+      expect(badges).toHaveLength(1);
+      expect(badges[0].id).toBe('capture-only');
+      expect(badges[0].label).toBe('Capture-only');
+      expect(badges[0].tone).toBe('outline');
+    });
+
+    it('a fully-enabled project yields one badge per capability key, no Capture-only', () => {
+      const badges = buildCapabilityBadges(ALL_ON);
+      const ids = badges.map((b) => b.id);
+      expect(ids).not.toContain('capture-only');
+      for (const capId of Object.keys(CAPABILITIES) as CapabilityId[]) {
+        expect(ids).toContain(capId);
+      }
+    });
+
+    it('cortex=false silences only the Cortex badge; others remain', () => {
+      const gates = { ...ALL_ON, cortex: false };
+      const badges = buildCapabilityBadges(gates);
+      const ids = badges.map((b) => b.id);
+      expect(ids).not.toContain('cortex');
+      expect(ids).not.toContain('capture-only');
+      expect(ids).toContain('canopy');
+      expect(ids).toContain('skills');
+      expect(ids).toContain('vault_evolution');
+    });
   });
 });

--- a/tests/ui/capability-badges.test.ts
+++ b/tests/ui/capability-badges.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'bun:test';
+import { buildCapabilityBadges } from '../../packages/myco/ui/src/lib/capability-badges';
+
+describe('buildCapabilityBadges', () => {
+  it('shows Capture-only when all opt-in capabilities are off', () => {
+    const badges = buildCapabilityBadges({ cortex: false, canopy: false, skills: false, vault_evolution: false });
+    expect(badges.map((b) => b.label)).toEqual(['Capture-only']);
+  });
+  it('shows an enabled badge per on capability, sage tone', () => {
+    const badges = buildCapabilityBadges({ cortex: true, canopy: false, skills: true, vault_evolution: false });
+    const labels = badges.map((b) => b.label);
+    expect(labels).toContain('Cortex');
+    expect(labels).toContain('Skills');
+    expect(labels).not.toContain('Canopy');
+    expect(badges.find((b) => b.label === 'Cortex')!.tone).toBe('sage');
+  });
+});

--- a/tests/ui/capability-gate-no-hardcode.test.ts
+++ b/tests/ui/capability-gate-no-hardcode.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Enforces that no site in packages/myco/src reads capability master gates
+ * directly for a gate decision — every gate call must go through
+ * `capabilityEnabled(config, capId)` from config/capabilities.ts.
+ *
+ * Mirrors the scope-policy-no-hardcode.test.ts pattern (grep + fail).
+ *
+ * Excluded files:
+ *   - capabilities.ts — owns the predicate and the registry (authoritative)
+ *   - schema.ts       — field declarations (z.boolean().default(true) etc.)
+ *   - focus.ts        — path strings for UI breadcrumb/navigation, not gate logic
+ *   - paths.ts        — config path constants, not gate logic
+ *   - *.test.ts       — test helpers may reference fields directly
+ */
+
+import { describe, it, expect } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SRC = path.join(__dirname, '../../packages/myco/src');
+
+// Property-access patterns for master gate fields that should only appear
+// inside capabilities.ts (as registry values) or schema.ts (as field defs).
+// Matches: `.cortex.canopy.enabled`, `['cortex']['canopy']['enabled']`, etc.
+// Does NOT match innocuous sub-toggles like `.cortex.instructions.inject_on_session_start`
+// or `.cortex.spores.inject_on_prompt_submit`.
+const BANNED = /\.cortex\.canopy\.enabled\b|\bcortex\.canopy\.enabled\b/;
+
+const ALLOWED_SUFFIXES = [
+  'config/capabilities.ts',
+  'config/schema.ts',
+  'config/focus.ts',
+  'config/paths.ts',
+];
+
+function walk(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) return walk(p);
+    return /\.tsx?$/.test(e.name) ? [p] : [];
+  });
+}
+
+function isAllowed(filePath: string): boolean {
+  const rel = filePath.replace(SRC + '/', '');
+  return (
+    rel.endsWith('.test.ts') ||
+    ALLOWED_SUFFIXES.some((suffix) => rel.endsWith(suffix))
+  );
+}
+
+describe('capability gate not hardcoded outside capabilities.ts', () => {
+  it('no direct .cortex.canopy.enabled access outside capabilities.ts/schema.ts', () => {
+    const offenders = walk(SRC)
+      .filter((f) => !isAllowed(f))
+      .filter((f) => BANNED.test(fs.readFileSync(f, 'utf-8')));
+    expect(offenders.map((f) => path.relative(SRC, f))).toEqual([]);
+  });
+});

--- a/tests/ui/capability-gate-no-hardcode.test.ts
+++ b/tests/ui/capability-gate-no-hardcode.test.ts
@@ -1,16 +1,23 @@
 /**
- * Enforces that no site in packages/myco/src reads capability master gates
+ * Enforces that no site in packages/myco/src reads a capability master gate
  * directly for a gate decision — every gate call must go through
  * `capabilityEnabled(config, capId)` from config/capabilities.ts.
  *
  * Mirrors the scope-policy-no-hardcode.test.ts pattern (grep + fail).
  *
- * Excluded files:
- *   - capabilities.ts — owns the predicate and the registry (authoritative)
- *   - schema.ts       — field declarations (z.boolean().default(true) etc.)
- *   - focus.ts        — path strings for UI breadcrumb/navigation, not gate logic
- *   - paths.ts        — config path constants, not gate logic
- *   - *.test.ts       — test helpers may reference fields directly
+ * Excluded files (definitions / non-gate references):
+ *   - config/capabilities.ts — owns the predicate and the registry (authoritative)
+ *   - config/schema.ts       — field declarations (z.boolean().default(true) etc.)
+ *   - config/focus.ts        — path strings for UI navigation, not gate logic
+ *   - config/paths.ts        — config path-string constants, not gate logic
+ *   - config/migrations.ts   — relocates legacy values; references gate paths by name
+ *   - *.test.ts              — test helpers may reference fields directly
+ *
+ * The single surviving direct `.cortex.enabled` read is the prompt-input
+ * payload field in context/cortex-brief.ts (`enabled: config.cortex.enabled`),
+ * which describes config STATE to the agent — it is not a gate decision.
+ * The line filter below allows that `enabled:`-keyed assignment shape while
+ * still catching any gate-style read (`if (!config.cortex.enabled)` etc.).
  */
 
 import { describe, it, expect } from 'bun:test';
@@ -19,19 +26,29 @@ import path from 'node:path';
 
 const SRC = path.join(__dirname, '../../packages/myco/src');
 
-// Property-access patterns for master gate fields that should only appear
-// inside capabilities.ts (as registry values) or schema.ts (as field defs).
-// Matches: `.cortex.canopy.enabled`, `['cortex']['canopy']['enabled']`, etc.
-// Does NOT match innocuous sub-toggles like `.cortex.instructions.inject_on_session_start`
-// or `.cortex.spores.inject_on_prompt_submit`.
-const BANNED = /\.cortex\.canopy\.enabled\b|\bcortex\.canopy\.enabled\b/;
+// The four capability master gates. `.cortex.enabled` is matched as a bare
+// property access; the string-literal forms ('cortex.enabled') used as config
+// path constants are excluded by file (focus.ts/paths.ts/migrations.ts) and by
+// the quote-guard in the regex.
+const MASTER_GATE_READS: RegExp[] = [
+  /\.cortex\.canopy\.enabled\b/,
+  /\.skills\.enabled\b/,
+  /\.vault_evolution\.enabled\b/,
+  /\.cortex\.enabled\b/,
+];
 
 const ALLOWED_SUFFIXES = [
   'config/capabilities.ts',
   'config/schema.ts',
   'config/focus.ts',
   'config/paths.ts',
+  'config/migrations.ts',
 ];
+
+// A `.cortex.enabled` read that is a prompt-input payload field (object key
+// `enabled:` set to the config value) is descriptive state, not a gate. Allow
+// only that exact assignment shape.
+const PAYLOAD_FIELD = /^\s*enabled:\s*config\.cortex\.enabled\s*,?\s*$/;
 
 function walk(dir: string): string[] {
   return fs.readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
@@ -41,7 +58,7 @@ function walk(dir: string): string[] {
   });
 }
 
-function isAllowed(filePath: string): boolean {
+function isAllowedFile(filePath: string): boolean {
   const rel = filePath.replace(SRC + '/', '');
   return (
     rel.endsWith('.test.ts') ||
@@ -49,11 +66,24 @@ function isAllowed(filePath: string): boolean {
   );
 }
 
-describe('capability gate not hardcoded outside capabilities.ts', () => {
-  it('no direct .cortex.canopy.enabled access outside capabilities.ts/schema.ts', () => {
-    const offenders = walk(SRC)
-      .filter((f) => !isAllowed(f))
-      .filter((f) => BANNED.test(fs.readFileSync(f, 'utf-8')));
-    expect(offenders.map((f) => path.relative(SRC, f))).toEqual([]);
+/** Lines in a file that read a master gate directly and are not the allowed payload field. */
+function offendingLines(content: string): string[] {
+  return content.split('\n').filter((line) => {
+    if (PAYLOAD_FIELD.test(line)) return false;
+    return MASTER_GATE_READS.some((re) => re.test(line));
+  });
+}
+
+describe('capability master gates not hardcoded outside capabilities.ts', () => {
+  it('no direct master-gate read for any capability outside the predicate', () => {
+    const offenders: string[] = [];
+    for (const file of walk(SRC)) {
+      if (isAllowedFile(file)) continue;
+      const lines = offendingLines(fs.readFileSync(file, 'utf-8'));
+      if (lines.length > 0) {
+        offenders.push(`${path.relative(SRC, file)}: ${lines.map((l) => l.trim()).join(' | ')}`);
+      }
+    }
+    expect(offenders).toEqual([]);
   });
 });

--- a/tests/ui/groves-capability-strip.test.tsx
+++ b/tests/ui/groves-capability-strip.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+/**
+ * Groves card — capability badge strip.
+ *
+ * Pins the post-review contract: the badge strip is ONE clickable
+ * <button> that opens the per-project CapabilityPanel — not a set of
+ * nested <Link>s deep-linking to a non-existent
+ * `/g/.../p/.../settings#...` route. Renders the real Groves page with
+ * a single capture-only project and asserts:
+ *   - the strip is a button (not an anchor)
+ *   - it shows the "Capture-only" badge text
+ *   - clicking it opens the CapabilityPanel slide-out
+ */
+
+import { describe, it, expect, mock } from 'bun:test';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+mock.module('../../packages/myco/ui/src/hooks/use-groves', () => ({
+  useGroves: () => ({
+    data: {
+      groves: [
+        {
+          id: 'g1',
+          name: 'Test Grove',
+          slug: 'test',
+          mode: 'local',
+          is_default: true,
+          created_at: '2026-01-01',
+          project_count: 1,
+          projects: [
+            {
+              project_id: 'proj_capture_only',
+              name: 'Capture Only',
+              slug: 'capture-only-abc123',
+              root: '/tmp/capture-only',
+              binding_id: null,
+              status: 'active',
+              archived_at: null,
+              created_at: '2026-01-01',
+              updated_at: '2026-01-01',
+              manifest_state: 'present',
+              // All opt-in capabilities off → single "Capture-only" badge.
+              capabilities: { cortex: false, canopy: false, skills: false, vault_evolution: false },
+            },
+          ],
+        },
+      ],
+    },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+mock.module('../../packages/myco/ui/src/hooks/use-maintenance-summary', () => ({
+  useProjectsActivity: () => ({
+    data: { projects: [], active_window_days: 7, generated_at: '2026-05-15' },
+    isLoading: false,
+  }),
+}));
+
+mock.module('../../packages/myco/ui/src/hooks/use-grove-mutations', () => ({
+  useArchiveProject: () => ({ mutate: () => {} }),
+  useBackupProject: () => ({ mutate: () => {} }),
+  useSetDefaultGrove: () => ({ mutate: () => {} }),
+  useUnarchiveProject: () => ({ mutate: () => {} }),
+}));
+
+mock.module('../../packages/myco/ui/src/hooks/use-machine-config', () => ({
+  useMachineConfig: () => ({ data: { config: { capture: { ignore: { paths: [] } } } } }),
+  useUpdateMachineConfig: () => ({ mutate: () => {} }),
+}));
+
+// CapabilityPanel reads merged + local config via fetchJson; a never-resolving
+// fetch keeps the panel in its loading state, which is enough to prove it opened.
+mock.module('../../packages/myco/ui/src/lib/api', () => ({
+  fetchJson: () => new Promise(() => {}),
+  postJson: async () => ({}),
+  putJson: async () => ({}),
+  patchJson: async () => ({}),
+  deleteJson: async () => ({}),
+  ApiError: class extends Error {},
+}));
+
+import Groves from '../../packages/myco/ui/src/pages/Groves';
+
+function wrap() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/groves']}>
+        <Groves />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('Groves capability badge strip', () => {
+  it('renders the strip as a button (not a Link) showing Capture-only', () => {
+    render(wrap());
+    const strip = screen.getByTestId('capability-badge-strip');
+    expect(strip.tagName).toBe('BUTTON');
+    // The broken deep-link is gone: no anchor wraps the badge visuals.
+    expect(strip.querySelector('a')).toBeNull();
+    expect(strip).toHaveTextContent('Capture-only');
+  });
+
+  it('opens the per-project CapabilityPanel on click', async () => {
+    render(wrap());
+    expect(screen.queryByTestId('capability-panel-panel')).toBeNull();
+    fireEvent.click(screen.getByTestId('capability-badge-strip'));
+    await waitFor(() => {
+      expect(screen.getByTestId('capability-panel-panel')).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/ui/groves-capability-strip.test.tsx
+++ b/tests/ui/groves-capability-strip.test.tsx
@@ -70,6 +70,8 @@ mock.module('../../packages/myco/ui/src/hooks/use-grove-mutations', () => ({
 mock.module('../../packages/myco/ui/src/hooks/use-machine-config', () => ({
   useMachineConfig: () => ({ data: { config: { capture: { ignore: { paths: [] } } } } }),
   useUpdateMachineConfig: () => ({ mutate: () => {} }),
+  useAddToMachineConfigList: () => ({ mutate: () => {} }),
+  useRemoveFromMachineConfigList: () => ({ mutate: () => {} }),
 }));
 
 // CapabilityPanel reads merged + local config via fetchJson; a never-resolving

--- a/tests/ui/settings-manifest-sync.test.ts
+++ b/tests/ui/settings-manifest-sync.test.ts
@@ -37,6 +37,9 @@ const ALLOWLIST: readonly string[] = [
   // is added here alongside the existing skills.* threshold fields.
   'vault_evolution.',
   'skills.enabled',
+  // Admission ignore list — managed via the Groves "Ignore" action and the
+  // machine settings page, not a per-field settings card.
+  'capture.ignore.',
 ];
 
 function isAllowlisted(key: string): boolean {

--- a/tests/ui/settings-manifest-sync.test.ts
+++ b/tests/ui/settings-manifest-sync.test.ts
@@ -32,6 +32,11 @@ const ALLOWLIST: readonly string[] = [
   // Canonical owner is Grove; the project copy exists so personal/project
   // overlays can override per-project. UI exposes only the Grove entry.
   'release_provenance.reconcile_interval_minutes',
+  // Capability master gates surface in the capability panel (UI plan), not the
+  // settings manifest. vault_evolution is a new top-level block; skills.enabled
+  // is added here alongside the existing skills.* threshold fields.
+  'vault_evolution.',
+  'skills.enabled',
 ];
 
 function isAllowlisted(key: string): boolean {

--- a/tests/ui/settings-page.test.tsx
+++ b/tests/ui/settings-page.test.tsx
@@ -102,6 +102,8 @@ mock.module('../../packages/myco/ui/src/hooks/use-machine-config', () => ({
     mutateAsync: (...args: unknown[]) => updateMachineMock(...args),
     isPending: false,
   }),
+  useAddToMachineConfigList: () => ({ mutate: () => {} }),
+  useRemoveFromMachineConfigList: () => ({ mutate: () => {} }),
 }));
 
 // The Agent provider card depends on these hooks; stub them so the test

--- a/tests/ui/settings-redirects.test.tsx
+++ b/tests/ui/settings-redirects.test.tsx
@@ -137,8 +137,8 @@ mock.module('../../packages/myco/ui/src/hooks/use-groves', () => ({
   }),
 }));
 
-mock.module('../../packages/myco/ui/src/hooks/use-scoped-config', () => ({
-  useScopedConfig: () => ({
+mock.module('../../packages/myco/ui/src/hooks/use-scoped-config', () => {
+  const scopedConfigStub = () => ({
     effective: projectEffective,
     local: {},
     isLoading: false,
@@ -146,9 +146,14 @@ mock.module('../../packages/myco/ui/src/hooks/use-scoped-config', () => ({
     setField: vi.fn().mockResolvedValue(undefined),
     setFields: vi.fn().mockResolvedValue(undefined),
     resetField: vi.fn().mockResolvedValue(undefined),
+    resetFields: vi.fn().mockResolvedValue(undefined),
     promoteField: vi.fn().mockResolvedValue(undefined),
-  }),
-}));
+  });
+  return {
+    useScopedConfig: scopedConfigStub,
+    useScopedConfigForSelection: scopedConfigStub,
+  };
+});
 
 mock.module('../../packages/myco/ui/src/hooks/use-grove-config', () => ({
   useGroveConfig: () => ({

--- a/tests/ui/settings-redirects.test.tsx
+++ b/tests/ui/settings-redirects.test.tsx
@@ -177,6 +177,8 @@ mock.module('../../packages/myco/ui/src/hooks/use-machine-config', () => ({
     mutateAsync: vi.fn().mockResolvedValue(undefined),
     isPending: false,
   }),
+  useAddToMachineConfigList: () => ({ mutate: () => {} }),
+  useRemoveFromMachineConfigList: () => ({ mutate: () => {} }),
 }));
 
 mock.module('../../packages/myco/ui/src/hooks/use-providers', () => ({

--- a/tests/ui/use-unified-settings.test.tsx
+++ b/tests/ui/use-unified-settings.test.tsx
@@ -86,6 +86,8 @@ mock.module('../../packages/myco/ui/src/hooks/use-machine-config', () => ({
   useUpdateMachineConfig: () => ({
     mutateAsync: (...args: unknown[]) => updateMachineMutateMock(...args),
   }),
+  useAddToMachineConfigList: () => ({ mutate: () => {} }),
+  useRemoveFromMachineConfigList: () => ({ mutate: () => {} }),
 }));
 
 // Import the hook AFTER the mocks so module-level imports resolve to stubs.

--- a/tests/vault/capture-ignore.test.ts
+++ b/tests/vault/capture-ignore.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'bun:test';
+import { isProjectRootIgnored, agentHomeIgnorePaths } from '../../packages/myco/src/vault/capture-ignore';
+
+describe('isProjectRootIgnored', () => {
+  const seed = ['/home/u/.codex', '/home/u/.claude'];
+  it('ignores a root under a configured path prefix', () => {
+    expect(isProjectRootIgnored('/home/u/repos/work/api', { paths: ['/home/u/repos/work'], patterns: [] }, [])).toBe(true);
+  });
+  it('ignores a root under an agent-home seed dir', () => {
+    expect(isProjectRootIgnored('/home/u/.codex/memories', { paths: [], patterns: [] }, seed)).toBe(true);
+  });
+  it('ignores a root matching a glob pattern', () => {
+    expect(isProjectRootIgnored('/home/u/sandbox/throwaway', { paths: [], patterns: ['**/sandbox/**'] }, [])).toBe(true);
+  });
+  it('does not ignore an unrelated root', () => {
+    expect(isProjectRootIgnored('/home/u/repos/myco', { paths: ['/home/u/repos/work'], patterns: [] }, seed)).toBe(false);
+  });
+  it('the exact configured/seed dir itself is ignored', () => {
+    expect(isProjectRootIgnored('/home/u/.codex', { paths: [], patterns: [] }, seed)).toBe(true);
+  });
+});
+
+describe('agentHomeIgnorePaths', () => {
+  it('returns expanded symbiont detectionDir paths', () => {
+    const paths = agentHomeIgnorePaths();
+    expect(paths.some((p) => p.endsWith('/.codex'))).toBe(true);
+    expect(paths.every((p) => !p.startsWith('~'))).toBe(true); // expanded
+  });
+});

--- a/tests/vault/capture-ignore.test.ts
+++ b/tests/vault/capture-ignore.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'bun:test';
 import { isProjectRootIgnored, agentHomeIgnorePaths } from '../../packages/myco/src/vault/capture-ignore';
+import { expandHome } from '../../packages/myco/src/grove/paths';
 
 describe('isProjectRootIgnored', () => {
   const seed = ['/home/u/.codex', '/home/u/.claude'];
@@ -11,6 +12,12 @@ describe('isProjectRootIgnored', () => {
   });
   it('ignores a root matching a glob pattern', () => {
     expect(isProjectRootIgnored('/home/u/sandbox/throwaway', { paths: [], patterns: ['**/sandbox/**'] }, [])).toBe(true);
+  });
+  it('ignores a root matching a ~-prefixed glob pattern (home expanded)', () => {
+    // `~/forks/*` must expand to an absolute path-glob; the matcher runs
+    // against the absolute project root, so a literal `~` would never fire.
+    const root = expandHome('~/forks/throwaway');
+    expect(isProjectRootIgnored(root, { paths: [], patterns: ['~/forks/*'] }, [])).toBe(true);
   });
   it('does not ignore an unrelated root', () => {
     expect(isProjectRootIgnored('/home/u/repos/myco', { paths: ['/home/u/repos/work'], patterns: [] }, seed)).toBe(false);

--- a/tests/vault/provision-capture-only.test.ts
+++ b/tests/vault/provision-capture-only.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parse } from 'yaml';
+import { ensureProjectVault } from '../../packages/myco/src/vault/provision';
+
+let dir: string | null = null;
+afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }); dir = null; });
+
+describe('ensureProjectVault capture-only default', () => {
+  it('writes local.yaml with the four capability master gates off', () => {
+    dir = mkdtempSync(join(tmpdir(), 'prov-'));
+    ensureProjectVault(dir);
+    const localPath = join(dir, '.myco', 'local.yaml');
+    expect(existsSync(localPath)).toBe(true);
+    const local = parse(readFileSync(localPath, 'utf-8')) as any;
+    expect(local.cortex.enabled).toBe(false);
+    expect(local.cortex.canopy.enabled).toBe(false);
+    expect(local.skills.enabled).toBe(false);
+    expect(local.vault_evolution.enabled).toBe(false);
+  });
+
+  it('is idempotent — second call leaves local.yaml unchanged', () => {
+    dir = mkdtempSync(join(tmpdir(), 'prov-'));
+    ensureProjectVault(dir);
+    const localPath = join(dir, '.myco', 'local.yaml');
+    const firstContent = readFileSync(localPath, 'utf-8');
+    const firstMtime = require('node:fs').statSync(localPath).mtimeMs;
+
+    ensureProjectVault(dir);
+    const secondContent = readFileSync(localPath, 'utf-8');
+    expect(secondContent).toBe(firstContent);
+    // mtime unchanged — saveLocalConfig uses write-if-changed semantics
+    expect(require('node:fs').statSync(localPath).mtimeMs).toBe(firstMtime);
+  });
+});

--- a/tests/vault/provision-capture-only.test.ts
+++ b/tests/vault/provision-capture-only.test.ts
@@ -1,12 +1,24 @@
-import { describe, it, expect, afterEach } from 'bun:test';
-import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { describe, it, expect, afterEach, beforeEach } from 'bun:test';
+import fs, { mkdtempSync, rmSync, readFileSync, existsSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { parse } from 'yaml';
 import { ensureProjectVault } from '../../packages/myco/src/vault/provision';
 
 let dir: string | null = null;
-afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }); dir = null; });
+let priorMycoHome: string | undefined;
+
+beforeEach(() => {
+  priorMycoHome = process.env.MYCO_HOME;
+  process.env.MYCO_HOME = mkdtempSync(join(tmpdir(), 'prov-home-'));
+});
+afterEach(() => {
+  if (priorMycoHome === undefined) delete process.env.MYCO_HOME;
+  else process.env.MYCO_HOME = priorMycoHome;
+  if (dir) rmSync(dir, { recursive: true, force: true });
+  if (process.env.MYCO_HOME) rmSync(process.env.MYCO_HOME, { recursive: true, force: true });
+  dir = null;
+});
 
 describe('ensureProjectVault capture-only default', () => {
   it('writes local.yaml with the four capability master gates off', () => {
@@ -26,12 +38,38 @@ describe('ensureProjectVault capture-only default', () => {
     ensureProjectVault(dir);
     const localPath = join(dir, '.myco', 'local.yaml');
     const firstContent = readFileSync(localPath, 'utf-8');
-    const firstMtime = require('node:fs').statSync(localPath).mtimeMs;
+    const firstMtime = fs.statSync(localPath).mtimeMs;
 
     ensureProjectVault(dir);
     const secondContent = readFileSync(localPath, 'utf-8');
     expect(secondContent).toBe(firstContent);
     // mtime unchanged — saveLocalConfig uses write-if-changed semantics
-    expect(require('node:fs').statSync(localPath).mtimeMs).toBe(firstMtime);
+    expect(fs.statSync(localPath).mtimeMs).toBe(firstMtime);
+  });
+
+  it('myco.yaml is written last — absent myco.yaml triggers cold path self-heal', () => {
+    // Simulates a mid-provision crash: vault dir exists, local.yaml written
+    // (capture-only gates set), but myco.yaml never landed. The next call to
+    // ensureProjectVault must re-run the cold path and write all files.
+    dir = mkdtempSync(join(tmpdir(), 'prov-'));
+    // First provision
+    const first = ensureProjectVault(dir);
+    expect(first.created).toBe(true);
+
+    // Simulate crash: remove myco.yaml (the sentinel) but leave local.yaml
+    const mycoYaml = join(dir, '.myco', 'myco.yaml');
+    unlinkSync(mycoYaml);
+    expect(existsSync(mycoYaml)).toBe(false);
+    expect(existsSync(join(dir, '.myco', 'local.yaml'))).toBe(true);
+
+    // Cold path re-runs and self-heals — myco.yaml is re-created
+    const second = ensureProjectVault(dir);
+    expect(second.created).toBe(true);
+    expect(existsSync(mycoYaml)).toBe(true);
+
+    // local.yaml still reflects capture-only (unchanged by re-provision)
+    const local = parse(readFileSync(join(dir, '.myco', 'local.yaml'), 'utf-8')) as any;
+    expect(local.cortex.enabled).toBe(false);
+    expect(local.vault_evolution.enabled).toBe(false);
   });
 });


### PR DESCRIPTION
## Why

Production v1.0.5 auto-adopted `~/.codex/memories` as a Grove project — a directory
that was never a development project and from which no agent was ever launched. The
root cause was structural: a permissive `isSafeProjectRoot` plus global hooks meant
**any** git directory an agent touched got a full Grove with the entire intelligence
pipeline (Cortex briefs, Canopy scans, skills, vault-evolution) running against it —
burning agent credits and embeddings on forks, clones, and scratch dirs.

This PR makes project adoption **deliberate** and intelligence **opt-in per project**.

## What

**Per-project capability model** (`config/capabilities.ts`)
- A declarative `CAPABILITIES` map (cortex, canopy, skills, vault_evolution), each with
  a single master gate path.
- One fail-closed predicate — `capabilityEnabled(config, capId)` — used at *every* gate
  site (canopy inject, background scan, scheduler, cortex regeneration, session-start
  and prompt-submit context). No gate re-derives the rule.
- `isCaptureOnly(config)` for the baseline state: capture + search + MCP only.

**Admission / ignore** (`vault/capture-ignore.ts`, `config/schema.ts`)
- Machine-scoped `capture.ignore` (paths + glob patterns, `~` expanded), reusing the
  canopy exclude matcher.
- Agent-home roots (`~/.codex`, `~/.claude`, …) seeded from symbiont `detectionDir`
  manifests are ignored by default — the exact class of directory that regressed.
- New vaults provision **capture-only**: `local.yaml` writes the master gates off, and
  `myco.yaml` is written **last** so a mid-provision crash self-heals to capture-only
  rather than a half-enabled project.

**Config plumbing**
- `scope.ts` gains `gate?: CapabilityId` annotations + new `cortex.canopy` /
  `vault_evolution` rows; a no-hardcode CI gate locks gates to the registry.
- v10 migration seeds `cortex.canopy.enabled` from the legacy `inject_on_pre_tool_use`
  flag (applies to local tier so a Personal override is preserved).
- Server-side `addToList` / `removeFromList` config ops make array edits
  (`capture.ignore`, `plan_dirs`, `transcript_paths`) race-free, with path scope guards.

**UI**
- Live capability badges on Groves cards (the groves API now carries per-project
  capability state); clicking opens a per-project capability panel with a configure
  trigger. `CapabilityChipVisual` extracted and reused.
- "Ignore" action in the Groves project menu.

**Methodology** (`AGENTS.md`)
- "Plans are guideposts, not scripts" — codifies reasoning about intent over literal
  plan-following to avoid pattern violations and duplication. Also absorbs upstream's
  "never swallow errors" / "one implementation per operation" rules from the rebase.

**Docs/skills** — trim example-code bloat, drop the stale `myco init` references, and
add grounded gotchas (auth-gated attachment rendering, plan authorship-gating, new
doctor checks).

## Testing

- `make build` and `make build-all` green prior to the doc-only final commit.
- 19/19 programmatic admission/capability scenarios.
- Live dogfood on the dev daemon: a freshly-provisioned project registers **capture-only**
  (`{cortex,canopy,skills,vault_evolution} = false`) and the groves API serves it correctly.
- New coverage: capability map/links, fail-closed `capabilityEnabled`, capture-ignore
  matcher + schema, v10 migration, list add/remove ops, per-project canopy/scheduler/cortex
  gates, and the UI capability badges/strip/no-hardcode gate.

This is the foundation layer; project-level capability *overrides* (today Grove-scoped)
are a deliberate future opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
