### PR TITLE
Add myco-handoff packaged skill

### DIFF
--- a/.agents/skills/cost-optimization-performance-telemetry/SKILL.md
+++ b/.agents/skills/cost-optimization-performance-telemetry/SKILL.md
@@ -154,6 +154,13 @@ Optimize task cadence and resource allocation patterns across grove boundaries.
    - Add session state validation before expensive operations with grove coordination
    - Validate grove coordination state before cross-grove operations
 
+5. **Understand JobRunner drain bounded-slice contracts**:
+   - Background jobs migrated from PowerManager to `JobRunner` (`packages/myco/src/daemon/job-runner.ts`)
+   - Each `RunnerJob` declares an optional `DrainSpec` with a `slice` count (base items per tick) and `softDeadlineMs` (default 2000ms) to bound work per tick
+   - **Serial tick starvation**: Long-running jobs (e.g., release-provenance reconciler averaging 348s) block all subsequent jobs in the serial tick loop — do not schedule expensive jobs at short intervals without bounded drain specs
+   - **Per-job dispatch tracking**: `JobRunner` maintains a `lastDispatched` map keyed by job name; each job tracks its own cadence independently rather than sharing a global state
+   - **Deep-sleep hold from `HoldSpec`**: Jobs with a `HoldSpec` use a `pending()` function to signal non-empty queues; non-zero `pending()` prevents the daemon from entering deep sleep (`allowDeepSleepHold` defaults true)
+
 ## Procedure D: SDK Execution Telemetry & Monitoring
 
 Implement comprehensive cost and performance tracking with grove attribution and improved accuracy.
@@ -199,6 +206,12 @@ Implement comprehensive cost and performance tracking with grove attribution and
    - **Tool consolidation effectiveness measurement**: Track performance improvements from tool usage optimization
    - **System batch origin filtering**: Exclude system-generated batches (~11% telemetry noise) from cost attribution
    - **Origin filtering implementation**: Check batch origin field before counting in cost models
+
+6. **Monitor embedding provider health accurately**:
+   - `isAvailable()` on local providers (Ollama, LM Studio) can return false-positive `true` when a brew stub is installed but the service is not actually running
+   - Multiple search consumers (`packages/myco/src/intelligence/embed-query.ts` and semantic search routes) behave inconsistently when the provider is down: some retry, some silently skip, some return empty results
+   - Embedding status endpoints may report available regardless of actual provider connectivity — always verify via an explicit provider health probe before trusting the status field
+   - **Observability gap**: Treat `isAvailable()` as a necessary-but-not-sufficient check; supplement with an actual embedding probe for health dashboards
 
 ## Procedure E: Agent Harness Cost Control Patterns
 
@@ -352,7 +365,7 @@ Optimize test execution and build performance to reduce development cycle costs 
    # Group related test files into domain-scoped Bun processes
    ./scripts/run-bun-tests.mjs --domain agent-harness
    ./scripts/run-bun-tests.mjs --domain daemon-core
-   
+
    # Avoid expensive per-file isolation for related tests
    # Balance: test independence vs execution speed
    ```
@@ -419,3 +432,5 @@ Optimize test execution and build performance to reduce development cycle costs 
 - **Test isolation boundaries are performance-critical** — Measured-isolation provides 20% performance improvement over naive per-file isolation; domain-scoped processes balance safety and speed
 - **Build profile selection impacts development velocity** — Performance profiles exclude flaky tests for speed; comprehensive profiles include everything for thorough validation
 - **Tool call telemetry accuracy matters** — Undercounting tool calls leads to incorrect budget allocation; ensure telemetry captures all tool emissions accurately
+- **JobRunner drain starvation is real** — A single slow job (e.g., release-provenance reconciler averaging 348s) blocks all other jobs in the serial tick loop; always declare a `DrainSpec` with bounded `slice` and `softDeadlineMs` on expensive jobs to limit per-tick work
+- **`isAvailable()` on local embedding providers is not reliable alone** — Brew-stub installations return `true` without a running service; probe actual connectivity before treating the embedding provider as up

--- a/.agents/skills/worktree-aware-request-context/SKILL.md
+++ b/.agents/skills/worktree-aware-request-context/SKILL.md
@@ -22,7 +22,7 @@ MycoRequestContext separates project identity from caller locality through dual 
 - Understanding of MycoRequestContext structure and flow
 - Familiarity with Grove registration and project identity concepts
 - Knowledge of worktree patterns and potential bleed scenarios
-- Access to `packages/myco/src/tools/request-context.ts` and related request handling code
+- Access to `packages/myco/src/grove/request-context.ts` and related request handling code
 - Understand that context-switching headers require daemon authentication tokens
 
 ## Procedure A: Implement callerRoot vs projectRoot Separation
@@ -35,9 +35,17 @@ When designing or modifying request context handling:
      projectRoot: string;      // Canonical, registered project identity
      callerRoot: string | null; // Caller's actual cwd, preserved untouched
      projectId: string;        // Sole identity for DB operations
+     tenancySource: TenancySource; // How this context was established
      // ... other fields
    }
    ```
+
+   **TenancySource tri-value model** (defined in `packages/myco/src/grove/request-context.ts`):
+   - `'caller'` — context established by an authenticated caller (e.g., `launchContextTenancy: true` in CLI launch options, or explicit context-switching headers)
+   - `'synthesized'` — context built internally by the daemon without caller authentication
+   - `'daemon'` — context resolved from the Grove registry by the daemon itself
+
+   Use `isCallerTenancy(context)` to check if the context originated from an authenticated caller request.
 
 2. **Populate callerRoot from headers/environment**:
    - Read from `x-myco-caller-root` header or `MYCO_CALLER_ROOT` environment variable
@@ -66,6 +74,10 @@ For each filesystem operation, determine the correct root using this decision tr
    - Persistent session rows and team-sync keys
    - Background scans and daemon maintenance
    - **Always use**: `context.projectRoot`
+
+   **Dual-helper pattern for DB project ID**:
+   - `rowProjectIdFromRequestContext(context)` — returns `null` when no project is bound; safe for optional project scoping (e.g., observability tools where project context is optional)
+   - `requireProjectId(context, label)` — throws with a descriptive label if no project is bound; use when a project is mandatory for the operation (e.g., saving plans, cortex lookups)
 
 2. **Caller-local operations** (must follow user's actual cwd):
    - Plan watch directories and file monitoring operations
@@ -129,7 +141,7 @@ export function requestContextFromHttpHeaders(
 ): TryRequestContextResult {
   const authHeader = headers['authorization'];
   const daemonToken = authHeader?.replace(/^Bearer\s+/, '');
-  
+
   if (!daemonToken) {
     return {
       ok: false,
@@ -139,17 +151,8 @@ export function requestContextFromHttpHeaders(
     };
   }
 
-  // Verify token against daemon.json
-  const isValid = verifyDaemonAuthToken(daemonToken);
-  if (!isValid) {
-    return {
-      ok: false,
-      error: new UnauthorizedRequestContextError('Invalid or expired authentication token')
-    };
-  }
-
-  // Token valid; proceed with context parsing
-  return tryParseContextHeaders(headers);
+  // Token present; packages/myco/src/grove/request-context.ts validates
+  // it against daemon.json and extracts context from remaining headers.
 }
 ```
 
@@ -187,21 +190,7 @@ const headers = {
 const response = await fetch('/api/vault', { headers });
 ```
 
-**Token Rotation**: Daemon auth tokens rotate on each daemon restart. Clients reading tokens from disk must refresh on 401 responses:
-
-```typescript
-async function withAuthRefresh(request: () => Promise<Response>) {
-  let response = await request();
-  
-  if (response.status === 401) {
-    // Token may be stale; refresh and retry
-    const newToken = readDaemonAuthTokenFromDisk();
-    // Update headers and retry...
-  }
-  
-  return response;
-}
-```
+**Token Rotation**: Daemon auth tokens rotate on each daemon restart. On 401 responses, refresh the token by re-reading `~/.myco/daemon.json` and retry the request. Daemon tokens rotate on each restart so stale tokens are expected in long-running clients.
 
 ### Authorization Boundaries
 
@@ -266,3 +255,7 @@ When adding new filesystem operations:
 **No silent 401 buffering**: In Pi extensions and MCP clients, catching 401 responses and buffering them to disk for later retry is a debugging nightmare. Instead, fail fast with explicit error messages. Store tokens correctly at startup and refresh on daemon restart.
 
 **Machine-scoped tokens cannot be shared**: Daemon auth tokens in `~/.myco/daemon.json` are tied to the machine's daemon process. Do not bake them into CI/CD configs or shared environments. Each machine needs its own daemon and token lifecycle.
+
+**`buildVaultFallbackOrGlobal` is the internal fallback builder**: When explicit context headers are absent, `buildVaultFallbackOrGlobal` in `packages/myco/src/grove/request-context.ts` constructs a synthesized context from a vault directory. It is an internal function — do not call it from tool handlers or external code; use the exported `requestContextFromHttpHeaders` or CLI launch options instead.
+
+**`rowProjectIdFromRequestContext` vs `requireProjectId` — choose deliberately**: Use `rowProjectIdFromRequestContext` only when project context is genuinely optional (e.g., a telemetry call that degrades gracefully with no project). Use `requireProjectId` everywhere a missing project would produce corrupt or misrouted data. The label argument appears in error messages, so make it descriptive.

--- a/packages/myco/skills/myco-handoff/SKILL.md
+++ b/packages/myco/skills/myco-handoff/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: myco-handoff
+description: >-
+  Use when handing a coding session off to a new session or another symbiont —
+  "hand this off", "prepare a handoff", "continue this in a new session", "pick
+  up where I left off", "pass this to another agent", or when context is heavy /
+  running low and the work will continue elsewhere, or work has drifted out of
+  scope and should restart fresh. PREPARE compresses the current session's
+  intention (why we're here, what we're doing, gotchas, dead ends, decisions)
+  into a ≤1500-token digest saved on a Myco plan. RECEIVE takes a plan ID,
+  rehydrates the context, loads the suggested skills, marks the referenced plans
+  in progress, and resumes the work.
+allowed-tools: Read, Bash, Grep, Glob
+user-invocable: true
+argument-hint: prepare [plan-id] | receive <plan-id>
+---
+
+# Myco Handoff
+
+Carry a session's working **intention** to another session cleanly. The
+codebase shows *what* exists and the plan shows *what's next* — this skill
+captures the *why* and *how we got here* that neither stores, compresses it to
+≤1500 tokens, and rides it on a Myco plan (the cross-symbiont shared vehicle).
+
+One skill, two modes.
+
+## Routing
+
+- `prepare [plan-id]` → build a handoff. The optional `plan-id` targets an
+  existing plan to attach the handoff to. → follow `references/preparing.md`.
+- `receive <plan-id>` → consume a handoff. → follow `references/receiving.md`.
+- **No argument** → infer from context: if you are mid-work with something to
+  hand off, PREPARE; if you were just given a plan ID to continue, RECEIVE.
+- **Unsure** → ask the user. Do not guess.
+
+## The handoff block
+
+The handoff is a single delimited block inside a plan's content, so RECEIVE can
+locate it and PREPARE can replace it idempotently (re-preparing replaces the
+block — a plan never accumulates stale handoffs):
+
+```markdown
+<!-- myco-handoff:start -->
+## Handoff — <YYYY-MM-DD>
+- **Source session:** <session-id>
+- **Referenced plans:** <plan-id>, <plan-id>
+- **Suggested skills:** myco, <skill>, <skill>
+
+### Digest
+<≤1500-token intention-focused narrative>
+<!-- myco-handoff:end -->
+```
+
+## Tooling
+
+Drive Myco via the ambient MCP tools (`myco_plans`, `myco_sessions`,
+`myco_cortex`, `myco_search`). On a host without MCP, fall back to
+`myco tool call <tool> --json --input '{...}'` via Bash. Load suggested skills
+with the `Skill` tool. Your current session ID is injected at session start
+(look for the `Session::` line); if you cannot find it, ask the user.

--- a/packages/myco/skills/myco-handoff/references/preparing.md
+++ b/packages/myco/skills/myco-handoff/references/preparing.md
@@ -1,0 +1,98 @@
+# Preparing a Handoff
+
+Goal: compress this session's intention into a ≤1500-token digest and persist it
+on a Myco plan, with the source session ID, referenced plan IDs, and suggested
+skills, then hand the user the exact line to resume in their next session.
+
+## 1. Resolve the target plan
+
+In priority order:
+
+1. **Explicit `[plan-id]` argument** — use it as the target.
+2. **An existing plan tied to this session** — `myco_plans({"op":"list","session":"<session-id>"})`.
+   If exactly one relevant plan comes back, target it. If several, ask the user
+   which (or whether to create a new one).
+3. **Otherwise** — create a new dedicated handoff plan (Step 4b).
+
+## 2. Author the ≤1500-token digest
+
+Self-compress your **live working context** — this is a manual compaction. Focus
+on **intention**, the part Myco doesn't already store:
+
+- **How we got here / what we're doing & why** — the goal and the path to it.
+- **Gotchas hit** — surprises about how something actually behaves.
+- **Dead ends** — approaches ruled out, and why.
+- **Decisions + rationale** — choices made and the reasoning.
+
+**Defer to the plan.** State, next-steps, and open-questions usually already live
+in the plan — do not duplicate them in the digest. Carry them in the digest
+**only** when you are creating a *new dedicated handoff plan* (there is no work
+plan to hold them).
+
+**Stay within ≤1500 tokens** (~1100 words). Prefer dense prose over exhaustive
+detail; the receiver can pull more via `myco_search` / `myco_cortex`.
+
+**Secret nudge:** don't inline secrets, keys, or PII — reference them by location
+(e.g. "API key in `.myco/secrets.env`").
+
+## 3. Choose suggested skills
+
+Decide which skills the receiver will need to resume well. Always include `myco`.
+Add domain skills relevant to the work (e.g. a debugging or subsystem skill).
+List them by name.
+
+## 4. Persist the handoff block
+
+Assemble the block:
+
+```markdown
+<!-- myco-handoff:start -->
+## Handoff — <today's date YYYY-MM-DD>
+- **Source session:** <this session id>
+- **Referenced plans:** <plan-id>, <plan-id>
+- **Suggested skills:** myco, <skill>, <skill>
+
+### Digest
+<the digest from step 2>
+<!-- myco-handoff:end -->
+```
+
+### 4a. Append/replace onto an existing plan (idempotent)
+
+1. Read current content: `myco_plans({"op":"get","id":"<plan-id>"})`.
+2. If a `<!-- myco-handoff:start -->…<!-- myco-handoff:end -->` block already
+   exists, **replace** it with the new block. Otherwise append the new block to
+   the end. Leave all other plan content untouched.
+3. Save: `myco_plans({"op":"save","id":"<plan-id>","content":"<full updated content>"})`.
+   (Updating by `id` preserves the plan's existing status.)
+
+### 4b. Create a new dedicated handoff plan
+
+```json
+myco_plans({
+  "op":"save",
+  "session_id":"<this session id>",
+  "title":"Handoff: <short topic>",
+  "status":"active",
+  "tags":["handoff"],
+  "content":"<the handoff block>"
+})
+```
+
+The `save` response returns the new plan `id` — capture it for Step 5.
+
+## 5. Return the resume instruction to the user
+
+Tell the user the plan ID and the **exact line** to run next session, plus a
+one-line summary of what was captured. For example:
+
+> Handoff saved to plan `<plan-id>`. In your next session, run:
+> `/myco-handoff receive <plan-id>`
+> It carries: <one-line summary of the digest + referenced plans + suggested skills>.
+
+## CLI fallback (no MCP)
+
+```bash
+myco tool call myco_plans --json --input '{"op":"list","session":"<session-id>"}'
+myco tool call myco_plans --json --input '{"op":"save","id":"<plan-id>","content":"..."}'
+```

--- a/packages/myco/skills/myco-handoff/references/preparing.md
+++ b/packages/myco/skills/myco-handoff/references/preparing.md
@@ -68,10 +68,16 @@ Assemble the block:
 
 ### 4b. Create a new dedicated handoff plan
 
+A new, non-file-backed plan **requires `plan_key`** (its stable identity; pass
+`plan_key` OR `source_path`, never both). Use a `plan_key` like
+`handoff-<short-slug>` — re-running `prepare` with the same `session_id` +
+`plan_key` then updates the same plan (idempotent) instead of creating a second.
+
 ```json
 myco_plans({
   "op":"save",
   "session_id":"<this session id>",
+  "plan_key":"handoff-<short-slug>",
   "title":"Handoff: <short topic>",
   "status":"active",
   "tags":["handoff"],

--- a/packages/myco/skills/myco-handoff/references/receiving.md
+++ b/packages/myco/skills/myco-handoff/references/receiving.md
@@ -1,0 +1,54 @@
+# Receiving a Handoff
+
+Goal: given a plan ID, rehydrate a fresh session from a prepared handoff and
+resume the work.
+
+## 1. Read and parse the handoff
+
+`myco_plans({"op":"get","id":"<plan-id>"})` → in the returned `content`, find the
+block between `<!-- myco-handoff:start -->` and `<!-- myco-handoff:end -->`.
+Parse out:
+
+- **Source session** (id)
+- **Referenced plans** (ids)
+- **Suggested skills** (names)
+- **Digest** (the narrative)
+
+If no handoff block is present, tell the user the plan has no handoff and stop.
+
+## 2. Load the suggested skills
+
+For each suggested skill, invoke it with the `Skill` tool. If a skill is not
+available in this symbiont, note it and continue — do not fail the handoff over
+a missing optional skill.
+
+## 3. Mark referenced plans in progress
+
+For each referenced work plan:
+`myco_plans({"op":"save","id":"<plan-id>","status":"in_progress"})`.
+
+If this *is* a dedicated handoff plan (the plan you received is itself the work
+plan, tagged `handoff`), mark **it** `in_progress`.
+
+## 4. Optional — pull broader context
+
+Only when you need richer/broader context than the digest gives:
+
+- `myco_cortex({"op":"digest","tier":5000})` — high-fidelity project memory.
+- `myco_search({"query":"<topic from the digest>"})` — related spores/plans;
+  follow each result's `retrieve` hint to read the owning entity.
+
+Skip this for a narrow, well-scoped resume.
+
+## 5. Summarize the landing and resume
+
+Tell the user, in a few lines: where the prior session left off (from the
+digest), which skills you loaded, which plan(s) you marked `in_progress`, and the
+concrete next step you're about to take. Then continue the work.
+
+## CLI fallback (no MCP)
+
+```bash
+myco tool call myco_plans --json --input '{"op":"get","id":"<plan-id>"}'
+myco tool call myco_plans --json --input '{"op":"save","id":"<plan-id>","status":"in_progress"}'
+```

--- a/packages/myco/src/plans/save-mcp.ts
+++ b/packages/myco/src/plans/save-mcp.ts
@@ -77,7 +77,7 @@ export function saveMcpPlan(input: SaveMcpPlanInput): SaveMcpPlanResult {
       logicalKey: existingPlan.logical_key,
       sourcePath: existingPlan.source_path,
       promptBatchId: openBatch?.id ?? existingPlan.prompt_batch_id,
-      title: input.title,
+      title: input.title ?? (input.content === undefined ? existingPlan.title : undefined),
       status: input.status,
       tags: input.tags,
     });

--- a/tests/mcp/tools/save-plan.test.ts
+++ b/tests/mcp/tools/save-plan.test.ts
@@ -134,6 +134,42 @@ describe('myco_plans op: save (in-process)', () => {
     expect(row?.logical_key).toBe(existing.logical_key);
   });
 
+  it('preserves an existing title on status-only updates by id', async () => {
+    seedSession('sess-1');
+    const existing = upsertPlan({
+      id: 'handoff-plan',
+      logical_key: 'session:sess-1:key:handoff',
+      title: 'Handoff: myco-handoff skill',
+      content: [
+        '<!-- myco-handoff:start -->',
+        '## Handoff - 2026-06-05',
+        '',
+        '### Digest',
+        'Resume context.',
+        '<!-- myco-handoff:end -->',
+      ].join('\n'),
+      tags: 'handoff',
+      status: 'active',
+      session_id: 'sess-1',
+      created_at: 1700000000,
+      machine_id: 'local',
+    });
+
+    const result = await handleMycoPlans({
+      op: 'save',
+      id: existing.id,
+      status: 'in_progress',
+    }, mockClient(), vaultDir) as PlanSaveSuccess;
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe('in_progress');
+    expect(result.title).toBe('Handoff: myco-handoff skill');
+
+    const row = getPlan(existing.id, ALL_PROJECTS_SCOPE);
+    expect(row?.status).toBe('in_progress');
+    expect(row?.title).toBe('Handoff: myco-handoff skill');
+  });
+
   it('returns Plan not found when updating an unknown id', async () => {
     const result = await handleMycoPlans({
       op: 'save',


### PR DESCRIPTION
## Summary

Adds the packaged `myco-handoff` skill for explicit session handoff workflows:

- `prepare [plan-id]` compresses live session intent into a delimited handoff block on a Myco plan.
- `receive <plan-id>` reads the block, loads suggested skills, marks referenced plans in progress, and resumes work.
- The skill ships under `packages/myco/skills/myco-handoff/`, so it follows the same package discovery and symlink install path as `myco` and `myco-rules`.

The dogfood receive test also exposed and fixes a `myco_plans op:save` bug where status-only updates could clear an explicit plan title when the plan content did not contain a top-level `#` heading.

## Details

- Adds `packages/myco/skills/myco-handoff/SKILL.md` plus `references/preparing.md` and `references/receiving.md`.
- Documents the handoff block contract, dedicated plan creation with `plan_key`, idempotent append/replace behavior, and receive-side plan status transitions.
- Preserves `existingPlan.title` when `myco_plans op:save` updates by id without new `content` or explicit `title`.
- Adds regression coverage for title preservation on status-only plan updates.

## Validation

- `npm test -- tests/mcp/tools/save-plan.test.ts`
- `npm test -- tests/symbionts/installer.test.ts`
- `make build`
- `npm pack --workspace @goondocks/myco --dry-run --json` confirmed `skills/myco-handoff/**` is included in the package payload.
- Built-binary smoke against handoff plan `13d64d1100c7fd49`: status-only updates preserved the title and left status as `in_progress`.

## Notes

Two unrelated `.agents/skills/...` files were already dirty locally and are not included in this PR.
