### PR TITLE
Harden capability admission and task schedule governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Agents can still use their own memory and tools. Myco adds shared project contex
 
 A local web dashboard provides configuration and operations management. Manage Groves and projects, configure providers, approve skill candidates, trigger intelligence and digest cycles, monitor service health, and view live logs.
 
+Use the [Grove Management guide](docs/groves.md) to decide when to create additional Groves, move or archive projects, and toggle per-project capabilities such as Cortex, Canopy, Skills, and Vault Evolution.
+
 <p align="center">
   <img src="packages/myco/assets/myco-dashboard.png" alt="Myco Dashboard" width="100%">
 </p>

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -136,7 +136,7 @@ agent:
         intervalSeconds: 600         # Every 10 min when candidates might exist
 ```
 
-For capture-only projects, leave the project capability toggles off. Myco still captures sessions, keeps search available, and maintains session titles, while heavier intelligence work such as Vault Evolution, Canopy mapping, and skill lifecycle tasks stays off. Canopy context injection follows the Canopy capability for each project.
+For capture-only projects, leave the project capability toggles off. Myco still captures sessions and keeps search available, while heavier intelligence work such as Vault Evolution, Canopy mapping, and skill lifecycle tasks stays off. Canopy context injection follows the Canopy capability for each project. See [Grove Management](groves.md) for the user-facing guide to project capabilities.
 
 Tasks only run when Myco is active or recently active. Background work pauses when the developer has stepped away.
 

--- a/docs/agent-harness.md
+++ b/docs/agent-harness.md
@@ -136,7 +136,7 @@ agent:
         intervalSeconds: 600         # Every 10 min when candidates might exist
 ```
 
-The two master switches (`scheduled_tasks_enabled` and `event_tasks_enabled`) silence intelligence work without editing per-task config — flip them off when you want Myco to capture only, without processing.
+For capture-only projects, leave the project capability toggles off. Myco still captures sessions, keeps search available, and maintains session titles, while heavier intelligence work such as Vault Evolution, Canopy mapping, and skill lifecycle tasks stays off. Canopy context injection follows the Canopy capability for each project.
 
 Tasks only run when Myco is active or recently active. Background work pauses when the developer has stepped away.
 

--- a/docs/groves.md
+++ b/docs/groves.md
@@ -1,0 +1,117 @@
+# Grove Management
+
+A **Grove** is the local home for one or more projects. It gives related projects a shared vault, shared provider settings, shared backups, and optional team sync while still letting each project keep its own identity.
+
+Most users start with the default Grove Myco creates during install. Create more Groves when you want to separate workstreams, clients, experiments, or teams.
+
+## When to Use More Than One Grove
+
+Keep projects in the same Grove when they should share project knowledge, provider setup, backups, and team sync membership. This is common for a monorepo, a product plus companion tooling, or several repos that one team works on together.
+
+Use separate Groves when projects should stay independent. Good reasons include client separation, personal versus work projects, risky experiments, or projects that should not appear in the same team sync connection.
+
+The Grove boundary matters because search, embeddings, backups, and team sync are organized around it.
+
+## How Projects Join a Grove
+
+After install, Myco creates a default Grove. The first time you use a supported coding agent from a git repository, Myco registers that project into the default Grove and starts capture.
+
+Projects only register from git repositories. If you work in a folder that is not a git repo, Myco leaves it alone.
+
+To share a project identity with teammates, commit `.myco/project.toml`. Myco creates this file automatically and tracks it in git. Teammates who clone the repo can land in the same project identity while keeping their own local Grove data and settings.
+
+## Manage Groves in the Dashboard
+
+Open the dashboard:
+
+```bash
+myco open
+```
+
+Use the **Groves** page to:
+
+- Create a new Grove
+- Rename a Grove
+- Set the default Grove
+- Move a project to another Grove
+- Back up a project
+- Archive or unarchive a project
+- Ignore a project so Myco stops bringing it back automatically
+- Delete a project after confirmation
+- Delete an empty Grove
+
+The **Grove** dashboard shows the selected Grove's projects, recent activity, vault health, backups, and nearby Groves.
+
+## Project Capabilities
+
+Each project can run as capture-only or enable deeper intelligence features. On the **Groves** page, each project row shows capability badges. Click the badges to open the project capability panel.
+
+The available capabilities are:
+
+| Capability | What it enables |
+| --- | --- |
+| **Cortex** | Project briefings and generated instructions that help connected agents start with the right context. |
+| **Canopy** | Codebase awareness, file summaries, project maps, and supported pre-read context. |
+| **Skills** | Skill candidate discovery, skill generation, and skill evolution. |
+| **Vault Evolution** | The main background intelligence pass that processes captured sessions into spores, summaries, wisdom, and digests. |
+
+When all four capabilities are off, the project is **Capture-only**. Myco still records sessions, keeps them searchable, and exposes the project through local tools, while the heavier background intelligence work stays quiet.
+
+Capability toggles on the Groves page apply at **Personal** scope. They affect this machine only. This lets you pause heavier intelligence work locally without changing the team's shared project defaults.
+
+## Scheduling and Capabilities
+
+Scheduled tasks follow project capabilities. If a capability is off, tasks governed by that capability do not run even if their individual schedule is enabled.
+
+For example:
+
+- Turning off **Vault Evolution** stops the scheduled `vault-evolve` task.
+- Turning off **Canopy** stops scheduled Canopy map and description refreshes.
+- Turning off **Skills** stops skill survey, generation, and evolution tasks.
+- Turning off **Cortex** stops scheduled Cortex instruction refresh.
+
+You can still tune individual task schedules from the **Agent** page. The task page shows the effective schedule state so you can see whether a task is active or held off by a project capability.
+
+## Capture-only Projects
+
+Capture-only is useful when you want Myco to remember sessions without spending tokens or local compute on deeper processing. Use it for:
+
+- Repos you visit occasionally
+- Experiments you do not want in the intelligence pipeline yet
+- Projects where you only want search and session history
+- Temporary worktrees or scratch projects
+
+You can promote a capture-only project later by opening its capability panel and enabling the features you want.
+
+## Moving and Archiving Projects
+
+Move a project when it belongs with a different set of Grove settings or a different team sync connection. Myco keeps the project identity intact and shows the project under the target Grove after the move.
+
+Archive a project when you want it out of the active list but may need it later. Archived projects can be shown and unarchived from the Groves page.
+
+Ignore a project when you want Myco to stop automatically bringing it back after removal or cleanup.
+
+## Backups and Deletes
+
+Backups are Grove-scoped. You can run a project backup from the Groves page, and Myco runs local backups automatically during idle periods when backups are enabled.
+
+Deleting a project is destructive and requires confirmation. When backups are enabled, Myco creates a fresh backup before destructive project deletion.
+
+## Team Sync
+
+Team Sync connects a Grove to a cloud mirror so teammates and cloud agents can query shared Grove knowledge. Local Grove data remains the source of truth.
+
+Use the **Team** page to join or manage a Team Sync connection. See [Team Sync](team-sync.md) for the full setup guide.
+
+## Troubleshooting
+
+If a project does not appear in the Groves page, start a supported coding agent from that git repository and run a normal session. Myco registers projects when supported agents work inside them.
+
+If a project appears when you expected it to stay removed, archive or ignore it from the Groves page.
+
+If scheduled work is not running, check both places:
+
+- The project capability badges on the **Groves** page
+- The task schedule on the **Agent** page
+
+Run `myco doctor` when the dashboard, service, or provider setup looks unhealthy.

--- a/docs/index.html
+++ b/docs/index.html
@@ -693,6 +693,12 @@
         <p>What gets captured, how the local service behaves, and what to do when something needs attention.</p>
         <span class="go">Read guide</span>
       </a>
+      <a class="doc-card" href="groves.md">
+        <span class="kind">Projects</span>
+        <h4>Grove management</h4>
+        <p>Organize projects into Groves, move or archive projects, and choose which intelligence capabilities each project runs.</p>
+        <span class="go">Read guide</span>
+      </a>
       <a class="doc-card" href="skills.md">
         <span class="kind">Skills</span>
         <h4>Skill auto-curation</h4>
@@ -792,6 +798,7 @@
       <div class="footer-col">
         <h5>Docs</h5>
         <a href="quickstart.md">Quickstart</a>
+        <a href="groves.md">Groves</a>
         <a href="skills.md">Skills</a>
         <a href="agent-harness.md">Agent harness</a>
         <a href="agent-tools.md">MCP tools</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -17,6 +17,7 @@ The supported path for the current release is macOS. Linux and Windows packages 
 - [Skills](https://myco.sh/skills.md): How accumulated project knowledge becomes reviewed workflows that connected agents can follow.
 - [Symbionts](https://myco.sh/symbionts.md): How Myco connects to supported coding agents while preserving each agent's native workflow.
 - [Canopy](https://myco.sh/canopy.md): Codebase awareness that helps agents understand files and architecture before they read deeply.
+- [Grove management](https://myco.sh/groves.md): How users organize projects into Groves, move/archive projects, and control per-project capabilities.
 - [Agent tools](https://myco.sh/agent-tools.md): MCP tools and slash-command skills available to connected agents.
 - [Agent harness](https://myco.sh/agent-harness.md): Background intelligence work that extracts spores, summaries, digests, and evolving skills.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -114,12 +114,14 @@ You can also open the dashboard directly at [http://localhost:20915/](http://loc
 The dashboard lets you:
 
 - **Configure** intelligence providers, per-task model assignments, and embedding settings
-- **Manage** Groves, projects, archive/unarchive, and destructive delete with confirmation
+- **Manage** Groves, projects, archive/unarchive, project capability toggles, and destructive delete with confirmation
 - **Run operations** like intelligence agent runs, index rebuilds, and manual digest cycles
 - **Monitor** service health, background activity, and system stats
 - **View logs** in real-time with level filtering
 
 The Settings page shows where each setting applies. Changes take effect automatically, and the dashboard prompts for a restart only when one is required.
+
+See [Grove Management](groves.md) for the guide to Groves, project movement, capture-only projects, and capability toggles.
 
 ## MCP tools
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -26,6 +26,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://myco.sh/groves.md</loc>
+    <lastmod>2026-06-06</lastmod>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://myco.sh/team-sync.md</loc>
     <lastmod>2026-05-28</lastmod>
     <priority>0.8</priority>

--- a/packages/myco/src/config/capabilities.ts
+++ b/packages/myco/src/config/capabilities.ts
@@ -71,6 +71,10 @@ export function capabilityForTask(taskName: string): CapabilityId | null {
   return null;
 }
 
+export function governingCapability(taskName: string): CapabilityId | null {
+  return capabilityForTask(taskName);
+}
+
 /**
  * Single authoritative capability gate. Fail-closed: a null/unloadable
  * config disables the capability. A master gate defaults on (only `false`
@@ -79,6 +83,25 @@ export function capabilityForTask(taskName: string): CapabilityId | null {
 export function capabilityEnabled(config: MycoConfig | null | undefined, capId: CapabilityId): boolean {
   if (!config) return false;
   return getAtPath(config, CAPABILITIES[capId].masterGate) !== false;
+}
+
+/**
+ * Single authority for scheduled-task effective enablement: a task runs only
+ * when its governing capability is on and its schedule resolves enabled via
+ * the same override-nullish-coalescing semantics as the scheduler
+ * (`override ?? YAML default`). Callers pass the task definition's YAML
+ * default so this module stays independent of task loading.
+ */
+export function effectiveTaskScheduleEnabled(
+  config: MycoConfig | null | undefined,
+  taskName: string,
+  yamlScheduleEnabled: boolean,
+): boolean {
+  if (!config) return false;
+  const capId = capabilityForTask(taskName);
+  if (capId && !capabilityEnabled(config, capId)) return false;
+  const override = config.agent.tasks?.[taskName]?.schedule?.enabled;
+  return override ?? yamlScheduleEnabled;
 }
 
 /** All opt-in capabilities off → the project is capture-only. */

--- a/packages/myco/src/config/loader.ts
+++ b/packages/myco/src/config/loader.ts
@@ -16,6 +16,7 @@ import {
 } from './schema.js';
 import { runMigrations, CURRENT_MIGRATION_VERSION } from './migrations.js';
 import { pruneToTier } from './scope.js';
+import { stripDefaultSections } from './sparse.js';
 import { deepMerge } from '../utils/deep-merge.js';
 import { getAtPath, setAtPath, unsetAtPath } from '../utils/dot-path.js';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
@@ -611,7 +612,12 @@ export function saveConfig(vaultDir: string, config: MycoConfig): void {
   }
 
   fs.mkdirSync(vaultDir, { recursive: true });
-  atomicWriteFileSync(configPath, YAML.stringify(projectOnly), 'utf-8');
+  // Keep project config sparse. Capability gates are fail-open on unset, so
+  // stripping a wholly-default `cortex` section is behaviorally identical to
+  // leaving its default `enabled: true` materialized; revisit if that contract
+  // ever becomes fail-closed.
+  const sparseProject = stripDefaultSections(projectOnly, defaults, ['version', 'config_version']);
+  atomicWriteFileSync(configPath, YAML.stringify(sparseProject), 'utf-8');
   invalidateMergedConfigCache(vaultDir);
 }
 

--- a/packages/myco/src/config/sparse.ts
+++ b/packages/myco/src/config/sparse.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Goondocks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import YAML from 'yaml';
+
+/**
+ * Drop top-level sections whose serialized value equals the schema default,
+ * while preserving required bookkeeping scalars such as `version`.
+ *
+ * This is deliberately section-granular: if any nested value in a section is
+ * non-default, the whole section remains intact.
+ */
+export function stripDefaultSections<T extends Record<string, unknown>>(
+  value: T,
+  defaults: Record<string, unknown>,
+  keep: ReadonlyArray<string>,
+): Partial<T> {
+  const out: Record<string, unknown> = {};
+  for (const key of keep) {
+    if (value[key] !== undefined) out[key] = value[key];
+  }
+
+  for (const [key, section] of Object.entries(value)) {
+    if (keep.includes(key)) continue;
+    if (YAML.stringify(section) !== YAML.stringify(defaults[key])) {
+      out[key] = section;
+    }
+  }
+
+  return out as Partial<T>;
+}

--- a/packages/myco/src/daemon/api/agent-tasks.ts
+++ b/packages/myco/src/daemon/api/agent-tasks.ts
@@ -26,6 +26,11 @@ import {
 import { resolveDefinitionsDir } from '@myco/agent/loader.js';
 import { USER_TASK_SOURCE } from '@myco/constants.js';
 import { loadMergedConfig, updateConfig, loadGroveConfig, saveGroveConfig } from '../../config/loader.js';
+import {
+  capabilityEnabled,
+  effectiveTaskScheduleEnabled,
+  governingCapability,
+} from '../../config/capabilities.js';
 import { withTaskConfig } from '../../config/updates.js';
 import type { TaskConfigUpdate } from '../../config/updates.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
@@ -305,9 +310,31 @@ export async function handleGetTaskConfig(
   vaultDir: string,
 ): Promise<RouteResponse> {
   const taskId = req.params.id;
+  const definitionsDir = resolveDefinitionsDir();
+  const allTasks = loadAllTasks(definitionsDir, vaultDir);
+  const task = allTasks.get(taskId);
+  if (!task) {
+    return { status: HTTP_NOT_FOUND, body: { error: 'task_not_found', name: taskId } };
+  }
+
   const config = loadMergedConfig(vaultDir, { groveId: req.requestContext?.groveId ?? null });
   const taskConfig = config.agent.tasks?.[taskId] ?? null;
-  return { status: HTTP_OK, body: { taskId, config: taskConfig } };
+  const capability = governingCapability(taskId);
+  const yamlScheduleEnabled = task.schedule?.enabled ?? false;
+  return {
+    status: HTTP_OK,
+    body: {
+      taskId,
+      config: taskConfig,
+      capability,
+      capabilityEnabled: capability ? capabilityEnabled(config, capability) : true,
+      effectiveScheduleEnabled: effectiveTaskScheduleEnabled(
+        config,
+        taskId,
+        yamlScheduleEnabled,
+      ),
+    },
+  };
 }
 
 /**

--- a/packages/myco/src/daemon/task-scheduler.ts
+++ b/packages/myco/src/daemon/task-scheduler.ts
@@ -80,6 +80,11 @@ export interface ScheduledJobContext {
     scope: RegisteredProjectScope,
     taskName: string,
   ) => { schedule?: Partial<TaskSchedule> } | undefined;
+  getTaskScheduleEnabled?: (
+    scope: RegisteredProjectScope,
+    taskName: string,
+    yamlScheduleEnabled: boolean,
+  ) => boolean;
   /** Pre-condition checks scoped to a project. */
   preConditions: Record<string, (scope: RegisteredProjectScope) => boolean>;
   /** Backlog count functions keyed by accelerator name. */
@@ -97,8 +102,6 @@ export interface ScheduledJobContext {
     taskName: string,
     windowSeconds: number,
   ) => number;
-  /** True unless the task's capability master gate is explicitly off for this project. */
-  getCapabilityEnabled?: (scope: RegisteredProjectScope, taskName: string) => boolean;
   /** Detached-run error sink so the PowerManager tick stays responsive. */
   onTaskError?: (taskName: string, groveId: string, projectId: GroveProjectId, err: unknown) => void;
   /**
@@ -238,8 +241,10 @@ export function buildScheduledJobs(
           const effective = task.schedule
             ? resolveSchedule(task.schedule, taskConfig)
             : yamlEffective;
-          if (!effective.enabled) continue;
-          if (context.getCapabilityEnabled && !context.getCapabilityEnabled(projectScope, task.name)) continue;
+          const enabled = context.getTaskScheduleEnabled
+            ? context.getTaskScheduleEnabled(projectScope, task.name, yamlEffective.enabled)
+            : effective.enabled;
+          if (!enabled) continue;
 
           if (context.isTaskRunning(groveId, projectId, task.name)) continue;
 

--- a/packages/myco/src/daemon/task-scheduling.ts
+++ b/packages/myco/src/daemon/task-scheduling.ts
@@ -29,7 +29,7 @@ import { notify } from '@myco/notifications/notify.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { DEFAULT_AGENT_ID, MS_PER_DAY } from '@myco/constants.js';
 import { errorMessage } from '@myco/utils/error-message.js';
-import { capabilityEnabled, capabilityForTask } from '@myco/config/capabilities.js';
+import { effectiveTaskScheduleEnabled } from '@myco/config/capabilities.js';
 import {
   forEachGrove,
   forEachRegisteredProject,
@@ -83,7 +83,7 @@ export function makeTotalCanopyPendingProbe(deps: CanopyPendingProbeDeps): () =>
           groveId: grove.id,
           mycoHome,
         });
-        if (config.agent.tasks?.['canopy-describe']?.schedule?.enabled !== true) continue;
+        if (!effectiveTaskScheduleEnabled(config, 'canopy-describe', false)) continue;
         grovePending += countPendingCanopyDescribe(null, project.project_id, CANOPY_PROBE_COUNT_CAP);
         if (grovePending > 0) break;
       }
@@ -241,7 +241,7 @@ export async function registerScheduledTasks(
   }
 
   // Per-project-visit memo: the scheduler loop calls getTaskConfig and
-  // getCapabilityEnabled for each task in the same per-project iteration.
+  // getTaskScheduleEnabled for each task in the same per-project iteration.
   // Memoizing the last-resolved scope avoids redundant loadMergedConfig calls
   // within a single project's task fan-out. The slot persists across ticks —
   // one tick of stale config across a tick boundary is benign at minute-scale
@@ -493,13 +493,8 @@ export async function registerScheduledTasks(
       if (!config) return { schedule: { enabled: false } };
       return config.agent.tasks?.[taskName];
     },
-    getCapabilityEnabled: (scope, taskName) => {
-      const capId = capabilityForTask(taskName);
-      if (!capId) return true;
-      // resolveProjectConfig logs on failure; null → capabilityEnabled returns
-      // false (fail-closed) so a config-less project never runs the capability.
-      return capabilityEnabled(resolveProjectConfig(scope), capId);
-    },
+    getTaskScheduleEnabled: (scope, taskName, yamlScheduleEnabled) =>
+      effectiveTaskScheduleEnabled(resolveProjectConfig(scope), taskName, yamlScheduleEnabled),
     isTaskRunning: (groveId, projectId, name) =>
       runningTasks.has(runningKey(groveId, projectId, name)),
     setTaskRunning: (groveId, projectId, name, running) => {

--- a/packages/myco/src/grove/project-lifecycle.ts
+++ b/packages/myco/src/grove/project-lifecycle.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import type { Database } from 'bun:sqlite';
@@ -13,7 +12,6 @@ import {
   resolveGroveDir,
   resolveGroveDbPath,
   resolveMycoHome,
-  resolveProjectVaultDir,
 } from './paths.js';
 import {
   archiveProjectInGrove,
@@ -24,6 +22,7 @@ import {
   type RegisteredProject,
 } from './registry.js';
 import { ensureProjectVault } from '../vault/provision.js';
+import { ProjectVault } from '../vault/project-vault.js';
 
 export interface ProjectLifecycleResult {
   grove_id: string;
@@ -117,7 +116,7 @@ export function deleteProjectPermanently(
 }
 
 export function removeProjectVault(projectRoot: string): void {
-  fs.rmSync(resolveProjectVaultDir(projectRoot), { recursive: true, force: true });
+  ProjectVault.atRoot(projectRoot).removeManagedProjectFiles();
 }
 
 function tryRemoveProjectVault(projectRoot: string, action: 'archive' | 'delete', projectId: string): void {

--- a/packages/myco/src/grove/project-lifecycle.ts
+++ b/packages/myco/src/grove/project-lifecycle.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import type { Database } from 'bun:sqlite';
@@ -12,6 +13,7 @@ import {
   resolveGroveDir,
   resolveGroveDbPath,
   resolveMycoHome,
+  resolveProjectVaultDir,
 } from './paths.js';
 import {
   archiveProjectInGrove,
@@ -21,6 +23,7 @@ import {
   unarchiveProjectInGrove,
   type RegisteredProject,
 } from './registry.js';
+import { ensureProjectVault } from '../vault/provision.js';
 
 export interface ProjectLifecycleResult {
   grove_id: string;
@@ -44,6 +47,7 @@ export function archiveProject(
   mycoHome = resolveMycoHome(),
 ): ProjectLifecycleResult {
   const project = archiveProjectInGrove(groveId, projectId, mycoHome);
+  tryRemoveProjectVault(project.root, 'archive', project.project_id);
   return lifecycleResult(groveId, project);
 }
 
@@ -53,6 +57,13 @@ export function unarchiveProject(
   mycoHome = resolveMycoHome(),
 ): ProjectLifecycleResult {
   const project = unarchiveProjectInGrove(groveId, projectId, mycoHome);
+  try {
+    ensureProjectVault(project.root, { projectName: project.name, force: true });
+  } catch (err) {
+    process.stderr.write(
+      `[myco] project unarchive could not re-provision project vault project_id=${project.project_id}: ${(err as Error).message}\n`,
+    );
+  }
   return lifecycleResult(groveId, project);
 }
 
@@ -92,6 +103,7 @@ export function deleteProjectPermanently(
     // tombstone enqueue is needed (it would double-journal).
     deleteProjectRows(db, project.project_id);
     deregisterProjectInGrove(groveId, project.project_id, mycoHome);
+    tryRemoveProjectVault(project.root, 'delete', project.project_id);
     return {
       grove_id: groveId,
       project_id: project.project_id,
@@ -101,6 +113,20 @@ export function deleteProjectPermanently(
     };
   } finally {
     db.close();
+  }
+}
+
+export function removeProjectVault(projectRoot: string): void {
+  fs.rmSync(resolveProjectVaultDir(projectRoot), { recursive: true, force: true });
+}
+
+function tryRemoveProjectVault(projectRoot: string, action: 'archive' | 'delete', projectId: string): void {
+  try {
+    removeProjectVault(projectRoot);
+  } catch (err) {
+    process.stderr.write(
+      `[myco] project ${action} could not remove project vault project_id=${projectId}: ${(err as Error).message}\n`,
+    );
   }
 }
 

--- a/packages/myco/src/grove/registry.ts
+++ b/packages/myco/src/grove/registry.ts
@@ -678,6 +678,15 @@ export function findProjectByRoot(
   return null;
 }
 
+export function projectLifecycleForRoot(
+  projectRoot: string,
+  mycoHome = resolveMycoHome(),
+): 'active' | 'archived' | 'unregistered' {
+  const found = findProjectByRoot(projectRoot, mycoHome, { includeArchived: true });
+  if (!found) return 'unregistered';
+  return found.project.status === 'archived' ? 'archived' : 'active';
+}
+
 export function findRegisteredProjectByBinding(
   bindingId: string,
   mycoHome = resolveMycoHome(),

--- a/packages/myco/src/hooks/vault-gate.ts
+++ b/packages/myco/src/hooks/vault-gate.ts
@@ -27,8 +27,44 @@ import {
   hasGlobalInstallMigrationCompleted,
   migrateProjectToGlobalInstall,
 } from '../grove/global-install-migration.js';
+import { projectLifecycleForRoot } from '../grove/registry.js';
 import { isProjectRootIgnored, agentHomeIgnorePaths } from '../vault/capture-ignore.js';
 import { loadMachineConfig } from '../config/loader.js';
+
+const lifecycleMemo = new Map<string, 'active' | 'archived' | 'unregistered'>();
+
+function lifecycleForRootMemo(projectRoot: string): 'active' | 'archived' | 'unregistered' {
+  const key = path.resolve(projectRoot);
+  const cached = lifecycleMemo.get(key);
+  if (cached) return cached;
+  // Hook processes are short-lived, so process-lifetime memoization avoids
+  // duplicate Grove registry reads without creating meaningful stale state.
+  const lifecycle = projectLifecycleForRoot(projectRoot);
+  lifecycleMemo.set(key, lifecycle);
+  return lifecycle;
+}
+
+function isCaptureGateClosed(projectRoot: string): boolean {
+  try {
+    const machine = loadMachineConfig();
+    if (isProjectRootIgnored(projectRoot, machine.capture.ignore, agentHomeIgnorePaths())) {
+      if (process.env.MYCO_AGENT_DEBUG) {
+        process.stderr.write(`[myco] capture skipped (ignored-root) root=${projectRoot}\n`);
+      }
+      return true;
+    }
+  } catch {
+    if (isProjectRootIgnored(projectRoot, { paths: [], patterns: [] }, agentHomeIgnorePaths())) return true;
+  }
+
+  if (lifecycleForRootMemo(projectRoot) === 'archived') {
+    if (process.env.MYCO_AGENT_DEBUG) {
+      process.stderr.write(`[myco] capture skipped (archived-root) root=${projectRoot}\n`);
+    }
+    return true;
+  }
+  return false;
+}
 
 /**
  * Resolve the project's vault dir, provisioning it if absent. Returns:
@@ -53,6 +89,15 @@ export function resolveProvisionedVaultDir(cwd: string = process.cwd()): string 
   const projectRoot = resolveProjectRoot(vaultDir);
 
   if (fs.existsSync(mycoYamlPath)) {
+    if (isCaptureGateClosed(projectRoot)) return null;
+    if (lifecycleForRootMemo(projectRoot) === 'unregistered') {
+      try { ensureProjectVault(projectRoot, { force: true }); }
+      catch {
+        // Re-seeding is best-effort on the hot path; capture can still proceed
+        // with the existing vault and the provisioning-failed trace remains
+        // reserved for cold-path creation failures.
+      }
+    }
     // Vault exists. Check the global-install sentinel; if absent, this
     // project is legacy — its `.myco/` predates the global-install
     // model and still carries project-scope hook installs that need to
@@ -82,18 +127,7 @@ export function resolveProvisionedVaultDir(cwd: string = process.cwd()): string 
     return null;
   }
 
-  try {
-    const machine = loadMachineConfig();
-    if (isProjectRootIgnored(projectRoot, machine.capture.ignore, agentHomeIgnorePaths())) {
-      if (process.env.MYCO_AGENT_DEBUG) {
-        process.stderr.write(`[myco] capture skipped (ignored-root) root=${projectRoot}\n`);
-      }
-      return null;
-    }
-  } catch {
-    // If machine config can't be read, fall through to agent-home seed only.
-    if (isProjectRootIgnored(projectRoot, { paths: [], patterns: [] }, agentHomeIgnorePaths())) return null;
-  }
+  if (isCaptureGateClosed(projectRoot)) return null;
 
   try {
     ensureProjectVault(projectRoot);

--- a/packages/myco/src/vault/project-vault.ts
+++ b/packages/myco/src/vault/project-vault.ts
@@ -214,6 +214,20 @@ export class ProjectVault {
     });
   }
 
+  /**
+   * Remove every project-local file this capability owns. Used by project
+   * archive/delete lifecycle paths so ghost readmission cannot leave a
+   * launcher behind that recreates `.myco/` outside the admission flow.
+   */
+  removeManagedProjectFiles(): void {
+    removeProjectLaunchers(this.projectRoot, {
+      legacy: true,
+      active: true,
+      runtimeCommand: true,
+    });
+    fs.rmSync(this.vaultDir, { recursive: true, force: true });
+  }
+
   // -------------------------------------------------------------------
   // Lower-level operations (used by the registry / activation / move /
   // claim paths that already construct a manifest in flight)

--- a/packages/myco/src/vault/provision.ts
+++ b/packages/myco/src/vault/provision.ts
@@ -45,6 +45,12 @@ export interface EnsureProjectVaultOptions {
    * Symbiont metadata may pass a richer label when one is available.
    */
   projectName?: string;
+  /**
+   * Existing vaults normally return without mutating config. `force` re-applies
+   * the capture-only gate overrides for re-admission paths that intentionally
+   * treat a leftover vault as fresh.
+   */
+  force?: boolean;
 }
 
 export interface EnsureProjectVaultResult {
@@ -77,6 +83,7 @@ export function ensureProjectVault(
   if (fs.existsSync(mycoYamlPath)) {
     const projectName = options.projectName ?? path.basename(projectRoot);
     const manifest = ensureProjectManifest(vaultDir, { projectName });
+    if (options.force) reseedCaptureOnly(vaultDir);
     return { vaultDir, created: false, projectId: manifest.project.id };
   }
 
@@ -122,11 +129,7 @@ export function ensureProjectVault(
   // New vaults start capture-only: write local.yaml off-overrides for every
   // capability master gate so intelligence features only activate when the
   // user explicitly promotes the project.
-  const captureOnlyPatch: Record<string, unknown> = {};
-  for (const cap of Object.values(CAPABILITIES)) {
-    setAtPath(captureOnlyPatch, cap.masterGate, false);
-  }
-  saveLocalConfig(vaultDir, captureOnlyPatch as Partial<MycoConfig>);
+  reseedCaptureOnly(vaultDir);
 
   // myco.yaml is written LAST — it is the hot-path existence sentinel (the
   // check at the top of this function). Writing it last means a mid-provision
@@ -135,6 +138,14 @@ export function ensureProjectVault(
   fs.writeFileSync(mycoYamlPath, MINIMAL_MYCO_YAML, 'utf-8');
 
   return { vaultDir, created: true, projectId: manifest.project.id };
+}
+
+export function reseedCaptureOnly(vaultDir: string): void {
+  const captureOnlyPatch: Record<string, unknown> = {};
+  for (const cap of Object.values(CAPABILITIES)) {
+    setAtPath(captureOnlyPatch, cap.masterGate, false);
+  }
+  saveLocalConfig(vaultDir, captureOnlyPatch as Partial<MycoConfig>);
 }
 
 function bornGlobalPassId(): string {

--- a/packages/myco/ui/src/components/agent/TaskProviderConfig.tsx
+++ b/packages/myco/ui/src/components/agent/TaskProviderConfig.tsx
@@ -191,8 +191,13 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
     defaults?.timeoutSeconds,
   ]);
 
-  // Effective schedule values: user override merged over YAML defaults
-  const effectiveScheduleEnabled = scheduleOverride.enabled ?? schedule?.enabled ?? false;
+  // Draft schedule values: user override merged over YAML defaults.
+  const draftScheduleEnabled = scheduleOverride.enabled ?? schedule?.enabled ?? false;
+  const scheduleCapabilityDisabled = taskConfigData?.capability != null
+    && taskConfigData.capabilityEnabled === false;
+  const effectiveScheduleEnabled = scheduleCapabilityDisabled
+    ? false
+    : draftScheduleEnabled;
   const effectiveRunIn = scheduleOverride.runIn ?? schedule?.runIn ?? [];
   function handleProviderChange(type: string) {
     handleDraftProviderChange(type);
@@ -484,7 +489,9 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
               variant={effectiveScheduleEnabled ? 'secondary' : 'outline'}
               className="text-[10px] px-1.5 py-0"
             >
-              {effectiveScheduleEnabled ? 'active' : 'off'}
+              {scheduleCapabilityDisabled
+                ? 'governed off'
+                : (effectiveScheduleEnabled ? 'active' : 'off')}
             </Badge>
           </div>
 
@@ -498,6 +505,7 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
             </div>
             <Switch
               checked={effectiveScheduleEnabled}
+              disabled={scheduleCapabilityDisabled}
               onCheckedChange={(checked) => {
                 setScheduleOverride((prev) => ({ ...prev, enabled: checked }));
               }}

--- a/packages/myco/ui/src/components/agent/TaskProviderConfig.tsx
+++ b/packages/myco/ui/src/components/agent/TaskProviderConfig.tsx
@@ -191,13 +191,20 @@ export function TaskProviderConfig({ taskId, phases, defaults, schedule, params 
     defaults?.timeoutSeconds,
   ]);
 
-  // Draft schedule values: user override merged over YAML defaults.
+  // Server effective state is authoritative; only layer an unsaved local
+  // toggle draft over it while the user is editing.
   const draftScheduleEnabled = scheduleOverride.enabled ?? schedule?.enabled ?? false;
+  const savedScheduleEnabled = savedTaskSnapshot.scheduleOverride.enabled;
+  const hasScheduleEnabledDraft = scheduleOverride.enabled !== savedScheduleEnabled;
   const scheduleCapabilityDisabled = taskConfigData?.capability != null
     && taskConfigData.capabilityEnabled === false;
   const effectiveScheduleEnabled = scheduleCapabilityDisabled
     ? false
-    : draftScheduleEnabled;
+    : (
+      hasScheduleEnabledDraft
+        ? draftScheduleEnabled
+        : (taskConfigData?.effectiveScheduleEnabled ?? draftScheduleEnabled)
+    );
   const effectiveRunIn = scheduleOverride.runIn ?? schedule?.runIn ?? [];
   function handleProviderChange(type: string) {
     handleDraftProviderChange(type);

--- a/packages/myco/ui/src/hooks/use-providers.ts
+++ b/packages/myco/ui/src/hooks/use-providers.ts
@@ -268,6 +268,9 @@ export function draftToProviderConfig(draft: ProviderDraft): ProviderConfig | un
 export interface TaskConfigResponse {
   taskId: string;
   config: TaskConfigOverride | null;
+  capability: string | null;
+  capabilityEnabled: boolean;
+  effectiveScheduleEnabled: boolean;
 }
 
 export interface TestProviderResponse {

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -122,10 +122,10 @@ describe('myco config', () => {
 
     it('creates intermediate objects along dot-path', async () => {
       writeConfig(tmpDir);
-      await run(['set', 'release_provenance.github.max_lookups_per_run', '20'], tmpDir);
+      await run(['set', 'release_provenance.github.max_lookups_per_run', '21'], tmpDir);
       const config = readConfig(tmpDir);
       const rp = config.release_provenance as Record<string, unknown>;
-      expect((rp.github as Record<string, unknown>).max_lookups_per_run).toBe(20);
+      expect((rp.github as Record<string, unknown>).max_lookups_per_run).toBe(21);
     });
 
     it('exits 1 on Zod validation failure', async () => {

--- a/tests/config/capability-effective-enablement.test.ts
+++ b/tests/config/capability-effective-enablement.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Goondocks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { MycoConfigSchema } from '../../packages/myco/src/config/schema';
+import {
+  effectiveTaskScheduleEnabled,
+  governingCapability,
+} from '../../packages/myco/src/config/capabilities';
+
+function cfg(input: Record<string, unknown>) {
+  return MycoConfigSchema.parse({ version: 3, ...input });
+}
+
+describe('governingCapability', () => {
+  it('maps governed tasks', () => {
+    expect(governingCapability('vault-evolve')).toBe('vault_evolution');
+    expect(governingCapability('canopy-describe')).toBe('canopy');
+    expect(governingCapability('title-summary')).toBeNull();
+  });
+});
+
+describe('effectiveTaskScheduleEnabled', () => {
+  it('returns false when the governing capability is off even if the task schedule is on', () => {
+    expect(
+      effectiveTaskScheduleEnabled(
+        cfg({ vault_evolution: { enabled: false } }),
+        'vault-evolve',
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it('uses the YAML default when capability is on and no override is set', () => {
+    expect(
+      effectiveTaskScheduleEnabled(
+        cfg({ vault_evolution: { enabled: true } }),
+        'vault-evolve',
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it('preserves default-off tasks when no override is set', () => {
+    expect(effectiveTaskScheduleEnabled(cfg({}), 'canopy-describe', false)).toBe(false);
+  });
+
+  it('lets an explicit override enable a default-off task when capability is on', () => {
+    expect(
+      effectiveTaskScheduleEnabled(
+        cfg({
+          agent: {
+            tasks: {
+              'canopy-describe': { schedule: { enabled: true } },
+            },
+          },
+        }),
+        'canopy-describe',
+        false,
+      ),
+    ).toBe(true);
+  });
+
+  it('fails closed on missing config', () => {
+    expect(effectiveTaskScheduleEnabled(null, 'vault-evolve', true)).toBe(false);
+  });
+});

--- a/tests/config/capability-governance-coverage.test.ts
+++ b/tests/config/capability-governance-coverage.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Goondocks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { MycoConfigSchema } from '../../packages/myco/src/config/schema';
+import {
+  CAPABILITIES,
+  effectiveTaskScheduleEnabled,
+  governingCapability,
+} from '../../packages/myco/src/config/capabilities';
+import { setAtPath } from '../../packages/myco/src/utils/dot-path';
+
+describe('capability scheduled-task governance coverage', () => {
+  it('disables every governed scheduled task when its capability master gate is off', () => {
+    for (const capability of Object.values(CAPABILITIES)) {
+      const rawConfig: Record<string, unknown> = { version: 3 };
+      setAtPath(rawConfig, capability.masterGate, false);
+      const config = MycoConfigSchema.parse(rawConfig);
+
+      for (const taskName of capability.scheduledTasks) {
+        expect(governingCapability(taskName)).toBe(capability.id);
+        expect(effectiveTaskScheduleEnabled(config, taskName, true)).toBe(false);
+      }
+    }
+  });
+});

--- a/tests/config/save-config-sparse.test.ts
+++ b/tests/config/save-config-sparse.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Goondocks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import YAML from 'yaml';
+
+import {
+  loadConfig,
+  saveConfig,
+  updateConfig,
+} from '../../packages/myco/src/config/loader';
+import { MycoConfigSchema } from '../../packages/myco/src/config/schema';
+
+let rootDir: string | null = null;
+
+afterEach(() => {
+  if (rootDir) fs.rmSync(rootDir, { recursive: true, force: true });
+  rootDir = null;
+});
+
+function makeVault(): string {
+  rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-save-sparse-'));
+  const vaultDir = path.join(rootDir, '.myco');
+  fs.mkdirSync(vaultDir, { recursive: true });
+  fs.writeFileSync(path.join(vaultDir, 'myco.yaml'), 'version: 3\n');
+  return vaultDir;
+}
+
+function readProjectYaml(vaultDir: string): Record<string, unknown> {
+  return YAML.parse(fs.readFileSync(path.join(vaultDir, 'myco.yaml'), 'utf-8')) as Record<string, unknown>;
+}
+
+describe('saveConfig sparsity', () => {
+  it('does not materialize default project sections, and still reloads', () => {
+    const vaultDir = makeVault();
+
+    updateConfig(vaultDir, (config) => ({
+      ...config,
+      release_provenance: {
+        ...config.release_provenance,
+        integration_refs: ['main'],
+      },
+    }));
+
+    const raw = readProjectYaml(vaultDir);
+    expect(raw.version).toBe(3);
+    expect(raw.cortex).toBeUndefined();
+    expect(raw.symbionts).toBeUndefined();
+    expect((raw.release_provenance as Record<string, unknown>).integration_refs).toEqual(['main']);
+
+    const reloaded = loadConfig(vaultDir);
+    expect(reloaded.version).toBe(3);
+    expect(reloaded.release_provenance.integration_refs).toEqual(['main']);
+  });
+
+  it('preserves config_version when present', () => {
+    const vaultDir = makeVault();
+    const config = MycoConfigSchema.parse({
+      version: 3,
+      config_version: 7,
+      release_provenance: { integration_refs: ['release'] },
+    });
+
+    saveConfig(vaultDir, config);
+
+    const raw = readProjectYaml(vaultDir);
+    expect(raw.version).toBe(3);
+    expect(raw.config_version).toBe(7);
+  });
+});

--- a/tests/daemon/api/agent-tasks.test.ts
+++ b/tests/daemon/api/agent-tasks.test.ts
@@ -20,18 +20,34 @@ import {
   handleCreateTask,
   handleCopyTask,
   handleDeleteTask,
+  handleGetTaskConfig,
 } from '@myco/daemon/api/agent-tasks.js';
+import { invalidateMergedConfigCache } from '@myco/config/loader.js';
+import { createGrove, clearGroveRegistryCaches } from '@myco/grove/registry.js';
+import { resolveGroveConfigPath } from '@myco/grove/paths.js';
 import { TEST_REQUEST_CONTEXT } from '../../helpers/request-context';
 import type { RouteRequest } from '@myco/daemon/router.js';
 
 let vaultDir: string;
+let mycoHome: string;
+let previousMycoHome: string | undefined;
 
 beforeEach(() => {
   vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-api-tasks-'));
+  mycoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-api-tasks-home-'));
+  previousMycoHome = process.env.MYCO_HOME;
+  process.env.MYCO_HOME = mycoHome;
+  clearGroveRegistryCaches();
+  invalidateMergedConfigCache();
 });
 
 afterEach(() => {
+  if (previousMycoHome === undefined) delete process.env.MYCO_HOME;
+  else process.env.MYCO_HOME = previousMycoHome;
+  clearGroveRegistryCaches();
+  invalidateMergedConfigCache();
   fs.rmSync(vaultDir, { recursive: true, force: true });
+  fs.rmSync(mycoHome, { recursive: true, force: true });
 });
 
 function makeReq(overrides: Partial<RouteRequest> = {}): RouteRequest {
@@ -157,5 +173,47 @@ describe('handleDeleteTask', () => {
     );
     expect(res.status).toBe(404);
     expect((res.body as { error: string }).error).toBe('task_not_found');
+  });
+});
+
+describe('handleGetTaskConfig', () => {
+  it('reports capability governance and effective schedule enablement', async () => {
+    const grove = createGrove('Agent Tasks', mycoHome);
+    const groveConfigPath = resolveGroveConfigPath(grove.id, mycoHome);
+    fs.mkdirSync(path.dirname(groveConfigPath), { recursive: true });
+    fs.writeFileSync(
+      groveConfigPath,
+      [
+        'version: 3',
+        'vault_evolution:',
+        '  enabled: false',
+        'agent:',
+        '  tasks:',
+        '    vault-evolve:',
+        '      schedule:',
+        '        enabled: true',
+        '',
+      ].join('\n'),
+    );
+    fs.mkdirSync(vaultDir, { recursive: true });
+    fs.writeFileSync(path.join(vaultDir, 'myco.yaml'), 'version: 3\n');
+    invalidateMergedConfigCache();
+
+    const res = await handleGetTaskConfig(
+      makeReq({
+        params: { id: 'vault-evolve' },
+        requestContext: { ...TEST_REQUEST_CONTEXT, groveId: grove.id },
+      }),
+      vaultDir,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      taskId: 'vault-evolve',
+      capability: 'vault_evolution',
+      capabilityEnabled: false,
+      effectiveScheduleEnabled: false,
+      config: { schedule: { enabled: true } },
+    });
   });
 });

--- a/tests/daemon/canopy-pending-probe.test.ts
+++ b/tests/daemon/canopy-pending-probe.test.ts
@@ -198,6 +198,23 @@ describe('makeTotalCanopyPendingProbe', () => {
     expect(makeProbe(fx)()).toBe(0);
   });
 
+  it('returns 0 when canopy capability is off even if canopy-describe is enabled', () => {
+    fx.setCanopyDescribeEnabled(true);
+    fs.writeFileSync(
+      path.join(resolveProjectVaultDir(fx.projectRoot), 'myco.yaml'),
+      'version: 3\ncortex:\n  canopy:\n    enabled: false\n',
+      'utf-8',
+    );
+    invalidateMergedConfigCache();
+    insertPendingEntry(fx);
+    expect(makeProbe(fx)()).toBe(0);
+  });
+
+  it('returns 0 when capability is on but canopy-describe override is unset', () => {
+    insertPendingEntry(fx);
+    expect(makeProbe(fx)()).toBe(0);
+  });
+
   it('returns 0 after pending entries are removed and the cache expires', () => {
     fx.setCanopyDescribeEnabled(true);
     insertPendingEntry(fx);

--- a/tests/daemon/task-scheduler.test.ts
+++ b/tests/daemon/task-scheduler.test.ts
@@ -54,6 +54,7 @@ interface FakeContextOptions {
   getProjectPowerState?: ScheduledJobContext['getProjectPowerState'];
   getRecentTaskRunCount?: ScheduledJobContext['getRecentTaskRunCount'];
   getTaskConfig?: ScheduledJobContext['getTaskConfig'];
+  getTaskScheduleEnabled?: ScheduledJobContext['getTaskScheduleEnabled'];
 }
 
 function makeContext(opts: FakeContextOptions = {}): ScheduledJobContext {
@@ -73,6 +74,7 @@ function makeContext(opts: FakeContextOptions = {}): ScheduledJobContext {
     getProjectPowerState: opts.getProjectPowerState ?? (() => 'idle'),
     getRecentTaskRunCount: opts.getRecentTaskRunCount,
     getTaskConfig: opts.getTaskConfig ?? (() => undefined),
+    getTaskScheduleEnabled: opts.getTaskScheduleEnabled,
   };
 }
 
@@ -163,6 +165,24 @@ describe('buildScheduledJobs (collapsed fan-out)', () => {
     const ctx = makeContext({
       projects: [fakeScope(PROJECT_A)],
       getTaskConfig: () => undefined,
+      runTask,
+    });
+    const { jobs } = buildScheduledJobs(tasks, ctx);
+
+    await jobs[0].fn();
+    await new Promise((r) => setImmediate(r));
+    expect(runTask).not.toHaveBeenCalled();
+  });
+
+  it('routes the dispatch enablement decision through the effective schedule seam', async () => {
+    const tasks = [
+      makeTask('vault-evolve', { enabled: true, intervalSeconds: 120, runIn: ['idle'] }),
+    ];
+    const runTask = vi.fn().mockResolvedValue(undefined);
+    const ctx = makeContext({
+      projects: [fakeScope(PROJECT_A)],
+      getTaskConfig: () => ({ schedule: { enabled: true } }),
+      getTaskScheduleEnabled: () => false,
       runTask,
     });
     const { jobs } = buildScheduledJobs(tasks, ctx);

--- a/tests/grove/lifecycle-cleanup.test.ts
+++ b/tests/grove/lifecycle-cleanup.test.ts
@@ -72,6 +72,25 @@ describe('removeProjectVault', () => {
     expect(fs.existsSync(vault)).toBe(false);
   });
 
+  it('removes project-local launchers and runtime pin through the vault capability', () => {
+    const vault = resolveProjectVaultDir(projectRoot);
+    const agentsDir = path.join(projectRoot, '.agents');
+    fs.mkdirSync(vault, { recursive: true });
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.writeFileSync(path.join(vault, 'myco.yaml'), 'version: 3\n');
+    fs.writeFileSync(path.join(vault, 'runtime.command'), '/tmp/myco-dev\n');
+    fs.writeFileSync(path.join(agentsDir, 'myco-run.cjs'), '// launcher\n');
+    fs.writeFileSync(path.join(agentsDir, 'myco-cli.cjs'), '// cli\n');
+    fs.writeFileSync(path.join(agentsDir, 'myco-hook.cjs'), '// legacy\n');
+
+    removeProjectVault(projectRoot);
+
+    expect(fs.existsSync(vault)).toBe(false);
+    expect(fs.existsSync(path.join(agentsDir, 'myco-run.cjs'))).toBe(false);
+    expect(fs.existsSync(path.join(agentsDir, 'myco-cli.cjs'))).toBe(false);
+    expect(fs.existsSync(path.join(agentsDir, 'myco-hook.cjs'))).toBe(false);
+  });
+
   it('is a no-op when .myco is already absent', () => {
     expect(() => removeProjectVault(projectRoot)).not.toThrow();
   });

--- a/tests/grove/lifecycle-cleanup.test.ts
+++ b/tests/grove/lifecycle-cleanup.test.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 Goondocks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import YAML from 'yaml';
+import { createSchema } from '@myco/db/schema.js';
+import { openDatabase } from '@myco/db/client.js';
+import {
+  archiveProject,
+  deleteProjectPermanently,
+  removeProjectVault,
+  unarchiveProject,
+} from '@myco/grove/project-lifecycle.js';
+import {
+  clearGroveRegistryCaches,
+  createGrove,
+  listRegisteredProjects,
+  registerProjectInGrove,
+} from '@myco/grove/registry.js';
+import { createProjectId } from '@myco/grove/ids.js';
+import { resolveGroveDbPath, resolveProjectVaultDir } from '@myco/grove/paths.js';
+import { resetMachineIdCache } from '@myco/machine-id.js';
+
+let tmpDir: string;
+let mycoHome: string;
+let projectRoot: string;
+let priorMycoHome: string | undefined;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-lifecycle-cleanup-'));
+  mycoHome = path.join(tmpDir, 'home');
+  projectRoot = path.join(tmpDir, 'project');
+  priorMycoHome = process.env.MYCO_HOME;
+  process.env.MYCO_HOME = mycoHome;
+  fs.mkdirSync(projectRoot, { recursive: true });
+  resetMachineIdCache();
+  clearGroveRegistryCaches();
+});
+
+afterEach(() => {
+  if (priorMycoHome === undefined) delete process.env.MYCO_HOME;
+  else process.env.MYCO_HOME = priorMycoHome;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  resetMachineIdCache();
+  clearGroveRegistryCaches();
+});
+
+describe('removeProjectVault', () => {
+  it('removes the on-disk .myco directory', () => {
+    const vault = resolveProjectVaultDir(projectRoot);
+    fs.mkdirSync(vault, { recursive: true });
+    fs.writeFileSync(path.join(vault, 'myco.yaml'), 'version: 3\n');
+
+    removeProjectVault(projectRoot);
+
+    expect(fs.existsSync(vault)).toBe(false);
+  });
+
+  it('is a no-op when .myco is already absent', () => {
+    expect(() => removeProjectVault(projectRoot)).not.toThrow();
+  });
+});
+
+describe('project lifecycle cleanup', () => {
+  it('archive removes the project-local vault without deleting Grove data', () => {
+    const { grove, projectId } = registerProjectWithVault();
+    const groveDbPath = resolveGroveDbPath(grove.id, mycoHome);
+    fs.mkdirSync(path.dirname(groveDbPath), { recursive: true });
+    const db = openDatabase(groveDbPath);
+    try {
+      createSchema(db);
+      db.prepare(
+        `INSERT INTO sessions (
+           id, agent, project_root, branch, started_at, status, created_at,
+           embedded, machine_id, project_id
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        'sess_lifecycle_cleanup',
+        'codex',
+        projectRoot,
+        'main',
+        100,
+        'active',
+        100,
+        0,
+        'test-machine',
+        projectId,
+      );
+    } finally {
+      db.close();
+    }
+
+    archiveProject(grove.id, projectId, mycoHome);
+
+    expect(fs.existsSync(resolveProjectVaultDir(projectRoot))).toBe(false);
+    expect(fs.existsSync(groveDbPath)).toBe(true);
+    const verifyDb = openDatabase(groveDbPath);
+    try {
+      const row = verifyDb.prepare('SELECT COUNT(*) AS n FROM sessions WHERE project_id = ?')
+        .get(projectId) as { n: number };
+      expect(row.n).toBe(1);
+    } finally {
+      verifyDb.close();
+    }
+    expect(listRegisteredProjects(grove.id, mycoHome)).toEqual([]);
+    expect(listRegisteredProjects(grove.id, mycoHome, { includeArchived: true })[0]?.status)
+      .toBe('archived');
+  });
+
+  it('permanent delete removes the project-local vault after deregistration', () => {
+    const { grove, projectId } = registerProjectWithVault();
+
+    const result = deleteProjectPermanently(grove.id, projectId, mycoHome);
+
+    expect(result.project_id).toBe(projectId);
+    expect(fs.existsSync(resolveProjectVaultDir(projectRoot))).toBe(false);
+    expect(listRegisteredProjects(grove.id, mycoHome, { includeArchived: true })).toEqual([]);
+  });
+
+  it('unarchive re-provisions a fresh capture-only vault', () => {
+    const { grove, projectId } = registerProjectWithVault({
+      localConfig: { cortex: { enabled: true } },
+    });
+
+    archiveProject(grove.id, projectId, mycoHome);
+    expect(fs.existsSync(resolveProjectVaultDir(projectRoot))).toBe(false);
+
+    unarchiveProject(grove.id, projectId, mycoHome);
+
+    const localRaw = YAML.parse(
+      fs.readFileSync(path.join(resolveProjectVaultDir(projectRoot), 'local.yaml'), 'utf-8'),
+    ) as Record<string, any>;
+    expect(localRaw.cortex?.enabled).toBe(false);
+    expect(localRaw.cortex?.canopy?.enabled).toBe(false);
+    expect(localRaw.skills?.enabled).toBe(false);
+    expect(localRaw.vault_evolution?.enabled).toBe(false);
+  });
+});
+
+function registerProjectWithVault(options: { localConfig?: Record<string, unknown> } = {}) {
+  const grove = createGrove('Work', mycoHome);
+  const projectId = createProjectId();
+  registerProjectInGrove(grove.id, {
+    projectId,
+    projectName: 'project',
+    projectRoot,
+    bindingId: 'gbind_lifecycle_cleanup',
+  }, mycoHome);
+  const vault = resolveProjectVaultDir(projectRoot);
+  fs.mkdirSync(vault, { recursive: true });
+  fs.writeFileSync(path.join(vault, 'myco.yaml'), 'version: 3\n');
+  if (options.localConfig) {
+    fs.writeFileSync(path.join(vault, 'local.yaml'), YAML.stringify(options.localConfig), 'utf-8');
+  }
+  return { grove, projectId };
+}

--- a/tests/hooks/vault-gate-readmit.test.ts
+++ b/tests/hooks/vault-gate-readmit.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Goondocks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import YAML from 'yaml';
+import { resolveProvisionedVaultDir } from '@myco/hooks/vault-gate.js';
+import {
+  archiveProjectInGrove,
+  clearGroveRegistryCaches,
+  createGrove,
+  registerProjectInGrove,
+} from '@myco/grove/registry.js';
+import { createProjectId } from '@myco/grove/ids.js';
+import { resolveProjectVaultDir } from '@myco/grove/paths.js';
+
+let tmpDir: string;
+let mycoHome: string;
+let projectRoot: string;
+let priorMycoHome: string | undefined;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-vault-gate-readmit-'));
+  mycoHome = path.join(tmpDir, 'home');
+  projectRoot = path.join(tmpDir, 'project');
+  priorMycoHome = process.env.MYCO_HOME;
+  process.env.MYCO_HOME = mycoHome;
+  fs.mkdirSync(projectRoot, { recursive: true });
+  execFileSync('git', ['init'], { cwd: projectRoot, stdio: 'pipe' });
+  seedLeftoverVault({ cortex: { enabled: true } });
+  clearGroveRegistryCaches();
+});
+
+afterEach(() => {
+  if (priorMycoHome === undefined) delete process.env.MYCO_HOME;
+  else process.env.MYCO_HOME = priorMycoHome;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  clearGroveRegistryCaches();
+});
+
+describe('resolveProvisionedVaultDir re-admission gate', () => {
+  it('returns null on the hot path when the root is ignored', () => {
+    fs.mkdirSync(mycoHome, { recursive: true });
+    fs.writeFileSync(
+      path.join(mycoHome, 'config.yaml'),
+      YAML.stringify({ capture: { ignore: { paths: [projectRoot] } } }),
+      'utf-8',
+    );
+
+    expect(resolveProvisionedVaultDir(projectRoot)).toBeNull();
+  });
+
+  it('returns null on the hot path when the root is archived', () => {
+    const grove = createGrove('Work', mycoHome);
+    const projectId = createProjectId();
+    registerProjectInGrove(grove.id, {
+      projectId,
+      projectName: 'project',
+      projectRoot,
+    }, mycoHome);
+    archiveProjectInGrove(grove.id, projectId, mycoHome);
+
+    expect(resolveProvisionedVaultDir(projectRoot)).toBeNull();
+  });
+
+  it('re-seeds capture-only for an unregistered root with a leftover vault', () => {
+    const vaultDir = resolveProvisionedVaultDir(projectRoot);
+
+    expect(vaultDir).toBe(resolveProjectVaultDir(projectRoot));
+    const localRaw = YAML.parse(
+      fs.readFileSync(path.join(resolveProjectVaultDir(projectRoot), 'local.yaml'), 'utf-8'),
+    ) as Record<string, any>;
+    expect(localRaw.cortex?.enabled).toBe(false);
+    expect(localRaw.cortex?.canopy?.enabled).toBe(false);
+    expect(localRaw.skills?.enabled).toBe(false);
+    expect(localRaw.vault_evolution?.enabled).toBe(false);
+  });
+});
+
+function seedLeftoverVault(localConfig: Record<string, unknown>): void {
+  const vault = resolveProjectVaultDir(projectRoot);
+  fs.mkdirSync(vault, { recursive: true });
+  fs.writeFileSync(path.join(vault, 'myco.yaml'), 'version: 3\n');
+  fs.writeFileSync(path.join(vault, 'local.yaml'), YAML.stringify(localConfig), 'utf-8');
+}

--- a/tests/ui/task-provider-config-governance.test.tsx
+++ b/tests/ui/task-provider-config-governance.test.tsx
@@ -19,6 +19,7 @@ import { describe, expect, it, mock } from 'bun:test';
 import { render, screen } from '@testing-library/react';
 
 let capabilityEnabled = false;
+let serverEffectiveScheduleEnabled = false;
 
 const taskConfig = { schedule: { enabled: true } };
 const providerDraft = {
@@ -42,7 +43,7 @@ const taskConfigResponse = {
     return capabilityEnabled;
   },
   get effectiveScheduleEnabled() {
-    return capabilityEnabled;
+    return serverEffectiveScheduleEnabled;
   },
 };
 const taskConfigQueryResult = { data: taskConfigResponse };
@@ -114,6 +115,7 @@ function renderScheduledTask() {
 describe('TaskProviderConfig capability governance', () => {
   it('disables schedule controls when the governing capability is off', () => {
     capabilityEnabled = false;
+    serverEffectiveScheduleEnabled = false;
 
     renderScheduledTask();
 
@@ -125,11 +127,23 @@ describe('TaskProviderConfig capability governance', () => {
 
   it('keeps schedule controls editable when the governing capability is on', () => {
     capabilityEnabled = true;
+    serverEffectiveScheduleEnabled = true;
 
     renderScheduledTask();
 
     expect(screen.getByText('active')).toBeInTheDocument();
     expect(screen.getByRole('switch')).not.toBeDisabled();
     expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('uses the API effective schedule state when no local draft is pending', () => {
+    capabilityEnabled = true;
+    serverEffectiveScheduleEnabled = false;
+
+    renderScheduledTask();
+
+    expect(screen.getByText('off')).toBeInTheDocument();
+    expect(screen.getByRole('switch')).not.toBeDisabled();
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false');
   });
 });

--- a/tests/ui/task-provider-config-governance.test.tsx
+++ b/tests/ui/task-provider-config-governance.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+/*
+ * Copyright 2026 Goondocks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+
+let capabilityEnabled = false;
+
+const taskConfig = { schedule: { enabled: true } };
+const providerDraft = {
+  harness: 'claude-sdk',
+  type: 'openai',
+  localBackend: undefined,
+  model: '',
+  reasoningLow: '',
+  reasoningDefault: '',
+  reasoningHigh: '',
+  baseUrl: '',
+  contextLength: '',
+};
+const providersData = { providers: [] };
+const modelsData = { models: [] };
+const taskConfigResponse = {
+  taskId: 'vault-evolve',
+  config: taskConfig,
+  capability: 'vault_evolution',
+  get capabilityEnabled() {
+    return capabilityEnabled;
+  },
+  get effectiveScheduleEnabled() {
+    return capabilityEnabled;
+  },
+};
+const taskConfigQueryResult = { data: taskConfigResponse };
+
+mock.module('../../packages/myco/ui/src/hooks/use-providers', () => ({
+  defaultBaseUrlForProvider: () => '',
+  maybeInferHarnessFromProviderType: () => 'claude-sdk',
+  REASONING_LEVELS: ['low', 'default', 'high'],
+  useProviders: () => ({ data: providersData, isPending: false }),
+  useTaskConfig: () => taskConfigQueryResult,
+  useTestProvider: () => ({
+    isPending: false,
+    isSuccess: false,
+    data: undefined,
+    mutate: () => {},
+    reset: () => {},
+  }),
+  useUpdateTaskConfig: () => ({
+    isPending: false,
+    mutate: () => {},
+  }),
+}));
+
+mock.module('../../packages/myco/ui/src/hooks/use-models', () => ({
+  useModels: () => ({ data: modelsData }),
+}));
+
+mock.module('../../packages/myco/ui/src/hooks/use-provider-config-draft', () => ({
+  draftToNormalizedProviderConfig: () => ({ type: 'openai' }),
+  providerDraftFromSource: () => providerDraft,
+  useProviderConfigDraft: () => ({
+    draft: providerDraft,
+    isDirty: false,
+    commitDraft: () => {},
+    handleHarnessChange: () => {},
+    handleProviderChange: () => {},
+    handleModelChange: () => {},
+    handleLocalBackendChange: () => {},
+    handleReasoningChange: () => {},
+    handleBaseUrlChange: () => {},
+    handleContextLengthChange: () => {},
+  }),
+}));
+
+mock.module('../../packages/myco/ui/src/components/providers/ProviderModelSelector', () => ({
+  ProviderModelSelector: () => <div data-testid="provider-model-selector" />,
+}));
+
+mock.module('../../packages/myco/ui/src/components/providers/AdvancedModelPin', () => ({
+  AdvancedModelPin: () => <div data-testid="advanced-model-pin" />,
+}));
+
+mock.module('../../packages/myco/ui/src/components/providers/ReasoningProfiles', () => ({
+  ReasoningProfiles: () => <div data-testid="reasoning-profiles" />,
+}));
+
+import { TaskProviderConfig } from '../../packages/myco/ui/src/components/agent/TaskProviderConfig';
+
+function renderScheduledTask() {
+  return render(
+    <TaskProviderConfig
+      taskId="vault-evolve"
+      defaults={{ harness: 'claude-sdk', providerType: 'openai' }}
+      schedule={{ enabled: true, intervalSeconds: 300, runIn: ['active'] }}
+    />,
+  );
+}
+
+describe('TaskProviderConfig capability governance', () => {
+  it('disables schedule controls when the governing capability is off', () => {
+    capabilityEnabled = false;
+
+    renderScheduledTask();
+
+    expect(screen.getByText('governed off')).toBeInTheDocument();
+    expect(screen.getByRole('switch')).toBeDisabled();
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false');
+    expect(screen.queryByLabelText('Run every (seconds)')).toBeNull();
+  });
+
+  it('keeps schedule controls editable when the governing capability is on', () => {
+    capabilityEnabled = true;
+
+    renderScheduledTask();
+
+    expect(screen.getByText('active')).toBeInTheDocument();
+    expect(screen.getByRole('switch')).not.toBeDisabled();
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+  });
+});


### PR DESCRIPTION
## Summary

- Harden capture-only project re-admission so ignored/archived projects do not silently reappear, and route project-vault cleanup through `ProjectVault` instead of direct filesystem deletion.
- Add a capability-based effective task enablement resolver and route scheduler/UI task config state through that single source of truth.
- Preserve sparse project config writes so setting one field does not materialize defaults or drift scoped config ownership.
- Add a dedicated user-facing Grove Management guide covering Grove boundaries, project movement, capture-only projects, and per-project capability toggles.

## Why

This branch closes the bypass class that showed up in review: lifecycle cleanup was deleting `.myco/` directly, outside the owning `ProjectVault` capability. It also keeps scheduled task governance grounded in the effective capability resolver rather than local UI recomputation or scheduler-specific checks.

The new Grove capability controls also need user documentation. Existing docs mentioned Groves across Quickstart, Symbionts, and the intelligence pipeline, but there was no single guide for how users should organize projects or understand Cortex, Canopy, Skills, and Vault Evolution toggles.

## Validation

- `make build` from the rebased worktree.
- `make build` again from the root checkout on `feat/capability-admission-hardening`.
- `myco-dev restart` succeeded; dev daemon is running from `/Users/chris/Repos/myco/packages/myco-darwin-arm64/bin/myco` on port `19344`.
- API smoke: `/api/agent/tasks/vault-evolve/config` returned `capability: vault_evolution`, `capabilityEnabled: true`, `effectiveScheduleEnabled: true`.
- Browser smoke via `playwright-cli`: dashboard loaded, top bar showed `feat/capability-admission-hardening` and daemon `v0.18.1-284-ge8b63f39`; Agent -> Tasks -> Vault Evolve showed Scheduling active and Auto-run checked.
- Docs sanity: `git diff --check`; verified `docs/groves.md` is linked from README, Quickstart, homepage docs grid/footer, `llms.txt`, and `sitemap.xml`.