### PR TITLE
Close open batches on session completion (chokepoint); fix CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,9 @@ npm install
 myco init
 ```
 
-For dogfooding, the vault lives at `~/.myco/vaults/myco/` (configured in `.claude/settings.json`).
+For dogfooding, the vault lives in the project-local `.myco/` directory — Myco vaults are always project-local, never global.
 
-### 4. Verify
+### 3. Verify
 
 ```bash
 myco doctor    # Health check

--- a/packages/myco/src/daemon/api/sessions.ts
+++ b/packages/myco/src/daemon/api/sessions.ts
@@ -1,4 +1,4 @@
-import { getSession, listSessions, countSessions, deleteSessionCascade, getSessionImpact, updateSession } from '@myco/db/queries/sessions.js';
+import { getSession, listSessions, countSessions, deleteSessionCascade, getSessionImpact, closeSession } from '@myco/db/queries/sessions.js';
 import { listBatchesBySession, countBatchesBySession, countBatchesBySessions, getBatchById, PROMPT_BATCH_ORIGIN, type PromptBatchOrigin } from '@myco/db/queries/batches.js';
 import { listActivitiesByBatch, countActivities, countActivitiesBySessions } from '@myco/db/queries/activities.js';
 import { listAttachmentsBySession } from '@myco/db/queries/attachments.js';
@@ -251,10 +251,10 @@ export function createSessionMutationHandlers(deps: SessionMutationDeps) {
 
     const wasActive = session.status === 'active';
     if (wasActive) {
-      updateSession(sessionId, {
-        status: 'completed',
-        ended_at: session.ended_at ?? epochSeconds(),
-      }, scope);
+      // Route through the completion chokepoint so the manual-complete path
+      // also closes open batches (no perpetually-open turn) — scope already
+      // verified via getSession above.
+      closeSession(sessionId, session.ended_at ?? epochSeconds());
     }
 
     await triggerTitleSummary(sessionId, {

--- a/packages/myco/src/daemon/jobs/session-maintenance.ts
+++ b/packages/myco/src/daemon/jobs/session-maintenance.ts
@@ -9,7 +9,7 @@
  */
 
 import { getDatabase } from '@myco/db/client.js';
-import { deleteSessionCascade } from '@myco/db/queries/sessions.js';
+import { closeSession, deleteSessionCascade } from '@myco/db/queries/sessions.js';
 import {
   epochSeconds,
   MS_PER_SECOND,
@@ -48,27 +48,39 @@ export function completeStaleActiveSessions(
   thresholdSeconds: number = STALE_SESSION_THRESHOLD_MS / MS_PER_SECOND,
 ): number {
   const db = getDatabase();
-  const cutoff = epochSeconds() - thresholdSeconds;
+  const now = epochSeconds();
+  const cutoff = now - thresholdSeconds;
 
-  const info = db.prepare(
-    `UPDATE sessions
-     SET status = 'completed', ended_at = COALESCE(ended_at, ?)
-     WHERE status = 'active'
-       AND COALESCE(
-         (SELECT MAX(touch) FROM (
-           SELECT MAX(pb.started_at) AS touch
-             FROM prompt_batches pb
-            WHERE pb.session_id = sessions.id
-           UNION ALL
-           SELECT MAX(a.timestamp) AS touch
-             FROM activities a
-            WHERE a.session_id = sessions.id
-         )),
-         sessions.started_at
-       ) < ?`,
-  ).run(epochSeconds(), cutoff);
+  // Select first (rather than a bulk UPDATE) so we have the swept session ids
+  // and can close each one's still-open batch in the same pass.
+  const staleIds = db.prepare(
+    `SELECT id FROM sessions
+      WHERE status = 'active'
+        AND COALESCE(
+          (SELECT MAX(touch) FROM (
+            SELECT MAX(pb.started_at) AS touch
+              FROM prompt_batches pb
+             WHERE pb.session_id = sessions.id
+            UNION ALL
+            SELECT MAX(a.timestamp) AS touch
+              FROM activities a
+             WHERE a.session_id = sessions.id
+          )),
+          sessions.started_at
+        ) < ?`,
+  ).all(cutoff).map((r) => (r as { id: string }).id);
 
-  return info.changes;
+  if (staleIds.length === 0) return 0;
+
+  // closeSession is the completion chokepoint — it flips status, stamps
+  // ended_at, closes any still-open batch (so a session swept without a final
+  // Stop doesn't keep a perpetually-open turn), and enqueues the session for
+  // team sync. Done per-id in one transaction.
+  db.transaction(() => {
+    for (const id of staleIds) closeSession(id, now);
+  })();
+
+  return staleIds.length;
 }
 
 /**

--- a/packages/myco/src/db/queries/sessions.ts
+++ b/packages/myco/src/db/queries/sessions.ts
@@ -8,6 +8,7 @@
 import { getDatabase, changesSince, type Database } from '@myco/db/client.js';
 import { getTeamMachineId } from '@myco/team/context.js';
 import { syncRow } from '@myco/db/queries/team-outbox.js';
+import { closeOpenBatches } from '@myco/db/queries/batches.js';
 import { appendProjectCondition, projectScopeClause, type ProjectScope } from '@myco/db/queries/project-scope.js';
 
 // ---------------------------------------------------------------------------
@@ -528,7 +529,15 @@ export function updateSession(
 }
 
 /**
- * Close a session — set status to 'completed' and record the end time.
+ * Close a session — set status to 'completed', record the end time, and close
+ * any still-open prompt batches.
+ *
+ * This is the single completion chokepoint: every path that completes a session
+ * (SessionEnd, the manual API, the stale-session sweep) routes through here, so
+ * the invariant "a completed session has no open turns" holds structurally.
+ * Without the batch close, a session ended without a final Stop (e.g. a
+ * plan-mode→execution run that never returned end_turn) keeps its last turn
+ * open indefinitely.
  *
  * @returns the updated row, or null if the session does not exist.
  */
@@ -543,6 +552,8 @@ export function closeSession(
      SET status = ?, ended_at = ?
      WHERE id = ?`,
   ).run(STATUS_COMPLETED, endedAt, id);
+
+  closeOpenBatches(id, endedAt);
 
   const closed = getSession(id, { kind: 'all' });
 

--- a/tests/daemon/jobs/session-maintenance.test.ts
+++ b/tests/daemon/jobs/session-maintenance.test.ts
@@ -136,6 +136,33 @@ describe('completeStaleActiveSessions', () => {
     expect(session?.ended_at).not.toBeNull();
     expect(session?.ended_at).toBeGreaterThanOrEqual(before);
   });
+
+  const openBatchCount = (sessionId: string): number =>
+    (getDatabase()
+      .prepare(`SELECT COUNT(*) AS n FROM prompt_batches WHERE session_id = ? AND ended_at IS NULL`)
+      .get(sessionId) as { n: number }).n;
+
+  it('closes the open batch when sweeping a stale session', () => {
+    // A plan-mode→execution run that never returns end_turn leaves its last
+    // turn open forever (no Stop closed it). When the sweep finally completes
+    // the idle session, that batch must close too — otherwise the session
+    // shows a perpetually-open turn.
+    const staleTime = epochNow() - STALE_THRESHOLD_S - 1;
+    seedSession('stale-open-batch', { status: 'active', batchStartedAt: staleTime });
+    expect(openBatchCount('stale-open-batch')).toBe(1);
+
+    completeStaleActiveSessions();
+
+    expect(openBatchCount('stale-open-batch')).toBe(0);
+  });
+
+  it('leaves open batches of a fresh (non-swept) session untouched', () => {
+    seedSession('fresh-open-batch', { status: 'active', batchStartedAt: epochNow() });
+
+    completeStaleActiveSessions();
+
+    expect(openBatchCount('fresh-open-batch')).toBe(1);
+  });
 });
 
 describe('findDeadSessionIds', () => {

--- a/tests/db/queries/sessions.test.ts
+++ b/tests/db/queries/sessions.test.ts
@@ -149,6 +149,27 @@ describe('session query helpers', () => {
       const result = closeSession('nope', epochNow());
       expect(result).toBeNull();
     });
+
+    it('closes the session\'s still-open batches (completion chokepoint invariant)', () => {
+      // A completed session must not retain open turns. Completing the session
+      // is the single point that owns batch-closing, so every completion path
+      // (SessionEnd, manual API, stale sweep) inherits it.
+      const data = makeSession();
+      upsertSession(data);
+      const db = getDatabase();
+      db.prepare(
+        `INSERT INTO prompt_batches (session_id, prompt_number, started_at, created_at, status)
+         VALUES (?, 1, ?, ?, 'active')`,
+      ).run(data.id, epochNow(), epochNow());
+      const openCount = (): number =>
+        (db.prepare(`SELECT COUNT(*) AS n FROM prompt_batches WHERE session_id = ? AND ended_at IS NULL`)
+          .get(data.id) as { n: number }).n;
+      expect(openCount()).toBe(1);
+
+      closeSession(data.id, epochNow());
+
+      expect(openCount()).toBe(0);
+    });
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`closeSession` is now the single session-completion chokepoint: it closes any still-open prompt batches in addition to flipping status and enqueuing team sync. The stale-session sweep and the manual `/complete` API both route through it (SessionEnd already did).

So a session ended without a final `Stop` — e.g. a plan-mode→execution run that never returns `end_turn` — no longer shows a perpetually-open turn. This also closes the same open-batch gap that previously affected the SessionEnd and manual-complete paths, making **"a completed session has no open turns"** a structural invariant.

Plus two **CONTRIBUTING.md** quality fixes (vault location → project-local `.myco/`; step numbering 1,2,4 → 1,2,3), authored while dogfooding.

## Why

A long plan-mode→execution session (real example: 280 tool activities over 24h) that never returns `end_turn` left its batch open forever — the session "looked dead" in the dashboard. The three completion paths each owned a different subset of "complete a session" (status flip vs batch close); consolidating on `closeSession` makes them consistent. The sweep now SELECTs stale ids then closes each via `closeSession` in one transaction (replacing a hand-rolled UPDATE that skipped batch-close and team sync).

## Note on the branch name

The branch name (`…exitplanmode-capture`) reflects an earlier direction — a live ExitPlanMode plan-capture. A real dogfood session proved Claude Code's PostToolUse hook sends an **empty `tool_input` for ExitPlanMode** (the plan lives only in the transcript), so that capture could never fire; it was reverted as dead code before this commit. Native plan-mode plans already capture reliably via the existing file-write path (`~/.claude/plans/`). Branch name kept for continuity.

## Testing

- `make build` + full `npm test` green (76/76 phases, 0 failures).
- New tests: `closeSession` closes open batches; sweep closes the swept session's batch; fresh sessions untouched.
- Verified live on the rebuilt dev daemon: a real plan-mode session captured plan + execution + doc edits correctly, and the completion path closes the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)