### PR TITLE
deps: batch follow-up Dependabot npm updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.168",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.169",
         "@anthropic-ai/sdk": "^0.102.0",
         "@inquirer/prompts": "^8.5.2",
         "@modelcontextprotocol/sdk": "^1.28.0",
@@ -19,7 +19,7 @@
         "chokidar": "^5.0.0",
         "gray-matter": "^4.0.3",
         "openai": "^6.42.0",
-        "semver": "^7.8.2",
+        "semver": "^7.8.3",
         "yaml": "^2.9.0",
         "zod": "^4.4.3"
       },
@@ -55,22 +55,22 @@
       "license": "MIT"
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.168.tgz",
-      "integrity": "sha512-C7n9uS1fsAt9lFKw/ovsFNAlPI7UXE2uPQbOzzKLpDNjfFR5spthALhV49b01PtYWEzTo3W3OJfgCv6wooXtYg==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.169.tgz",
+      "integrity": "sha512-pzsd0BBnlfHwAUfKouSNwDLcCxGDq+lbPZTsIdiNSLw+AQw7mjxPxqnFwd4YH7qw+E3XhlotuihCm01XzcybPQ==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.168",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.168",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.168",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.168",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.168",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.168",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.168",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.168"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.169",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.169",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.169",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.169",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.169",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.169",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.169",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.169"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -79,9 +79,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.168.tgz",
-      "integrity": "sha512-tvFGCGVX9tesGBzfpK008nRmv91pd3ToapDpJbjdwiFSLGWT9n+dc/qurwgxgv9VwWRvV8nWTc3zLRSFI8Lf2g==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.169.tgz",
+      "integrity": "sha512-5PJU3wqfvJUrgUF3H7iroxAGDyliKmq5q8kK+glERf8YZgmPeDMvQL4mGSB0Vf9RgBWS01dCen93TIsN0O8NPQ==",
       "cpu": [
         "arm64"
       ],
@@ -92,9 +92,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.168.tgz",
-      "integrity": "sha512-J5dZUCrwjz4+gY2dAds2rMDWWSdcMl9jEDpZIzKNCx0f0KlJfE1C7/+stOJaBv6tGj8d/mmzcfBCeNBS1KScgA==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.169.tgz",
+      "integrity": "sha512-1Hzt0QYG7N/ExfPbN/C92YRc3BoDnyQMJpuWLVyI/r0NmKV/se/cZbIygbvQXs2ywoXOB/EyNj/hkVHaC1G22g==",
       "cpu": [
         "x64"
       ],
@@ -105,9 +105,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.168.tgz",
-      "integrity": "sha512-K9fltcI0VJBr21z4t0iJ4aArFtiS9UwhmMGkxl1jAIM0jatGqiHHbbk+qaCB04va3U6vaflukgtmbpogSB36yQ==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.169.tgz",
+      "integrity": "sha512-J0tyM4t5qxc2/xilsfHqcJv+fyEDhX66Nv+CMXq4mRbquZmMHhbZbh8ryb+BnKYXUeqKX3uoU/J+7K6/fjcY4g==",
       "cpu": [
         "arm64"
       ],
@@ -121,9 +121,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.168.tgz",
-      "integrity": "sha512-uOFtBJjntrYkXlHPRK+cTx1pCc37XxGQ/kN3KBK/KoIDcIrmU8DcX2WUw5IJHJqpG2Qjb7gZ5xAbcw3WTmduwQ==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.169.tgz",
+      "integrity": "sha512-xkmyNdU6f7HXXzgR6IZym7x41bjL3rjGrXf5PAmx9PjdThy476+TrpO1evKUza1zlVmUj4tj/jYKQsV4ER7QFw==",
       "cpu": [
         "arm64"
       ],
@@ -137,9 +137,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.168.tgz",
-      "integrity": "sha512-0Fw4ICZopwKbqNQo64HqkpJw5cqxOxFOV/w8GCS2hDsJ+0aogmK/B78t4iV6rFHIkC076Nm5UH14FP1eOIJ3OA==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.169.tgz",
+      "integrity": "sha512-ktEPBwzXZagt0cntfRLlvNL0sAplt2HOCbR5iBvq2IV5dLvbEOiBjZQArIcSAN7CTQUFqkZs9HzQMdKe5QPwuQ==",
       "cpu": [
         "x64"
       ],
@@ -153,9 +153,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.168.tgz",
-      "integrity": "sha512-JwYD7oxYlIVYDFhgj+QVHgWbJUVGMXsiecB6WQ5VS5u4OqUorivJPFYPaP469otMj4HFtkDupESB+7Zp4jMmUw==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.169.tgz",
+      "integrity": "sha512-Me8VW91pCKgkct/y1isjKNVt+ZPMPhHk3C7O078UO1bakHD6kuPiMtugcCsg4jmmmuuywXQIQUESRbcf0GluUg==",
       "cpu": [
         "x64"
       ],
@@ -169,9 +169,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.168.tgz",
-      "integrity": "sha512-NREaLXAxl23pEzoU7bmX6u8MibAYEY2t8XP5xtj/vMO6UwxFjT3YgGsTuQcnFP+1qsjWaOBCia2ZQnqI68Y0Ng==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.169.tgz",
+      "integrity": "sha512-HL9ecP82A/H8aC896Q7ETyl+nLFkMzBHfO0yvK7Lhxbi98CEpqXn3BADTAc5pEgzkO+r18+CDmZdgjTFMvGoTw==",
       "cpu": [
         "arm64"
       ],
@@ -182,9 +182,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.168",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.168.tgz",
-      "integrity": "sha512-Ha3eivz2Wm4y3BR+Xpn/r+CBM8ARC6knYDLbjLqH/DxjKahr6WB60xQkBD1U6wchT6w7zfIQqQGbucuUOTTuew==",
+      "version": "0.3.169",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.169.tgz",
+      "integrity": "sha512-34pBbiKe7FNsY8LHuuTmKujmYko/cBOrKJpk9H+MOot+dSfB/FmIHq9USL17otNal5Droq9lqpezAWPBPv3lAQ==",
       "cpu": [
         "x64"
       ],
@@ -5783,9 +5783,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7519,14 +7519,14 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.168",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.169",
         "@anthropic-ai/sdk": "^0.102.0",
         "@inquirer/prompts": "^8.5.2",
         "@modelcontextprotocol/sdk": "^1.28.0",
         "@openai/agents": "^0.11.5",
         "chokidar": "^5.0.0",
         "gray-matter": "^4.0.3",
-        "semver": "^7.8.2",
+        "semver": "^7.8.3",
         "shell-quote": "^1.8.4",
         "smol-toml": "^1.6.1",
         "yaml": "^2.8.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/goondocks-co/myco.git"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.168",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.169",
     "@anthropic-ai/sdk": "^0.102.0",
     "@inquirer/prompts": "^8.5.2",
     "@modelcontextprotocol/sdk": "^1.28.0",
@@ -35,7 +35,7 @@
     "chokidar": "^5.0.0",
     "gray-matter": "^4.0.3",
     "openai": "^6.42.0",
-    "semver": "^7.8.2",
+    "semver": "^7.8.3",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },

--- a/packages/myco-collective/worker/package-lock.json
+++ b/packages/myco-collective/worker/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.3.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "agents": "^0.14.5",
+        "agents": "^0.15.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260608.1",
+        "@cloudflare/workers-types": "^4.20260609.1",
         "typescript": "^6.0.3",
         "wrangler": "^4.98.0"
       }
@@ -606,9 +606,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260608.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260608.1.tgz",
-      "integrity": "sha512-Yz90KXPZBB9K/AhsnLaA321s5+i5ZpWZRFbcGx9dWjyknQJXPAS1pK5CJSFEedwY6zoEr1cf2SkpBATL1idsWA==",
+      "version": "4.20260609.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260609.1.tgz",
+      "integrity": "sha512-krGHtwSApCFBjTe1NTx/TFQ0P5i/bHGQOqCPnCLssb8rOKaAG4JkPFJZsossr0z/ZTMnpP2Tid5jWju+/i0hCA==",
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -2286,9 +2286,9 @@
       }
     },
     "node_modules/agents": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/agents/-/agents-0.14.5.tgz",
-      "integrity": "sha512-xKZDaAU5vaLw5vNlGzt20vCwAe74hWcufuc5a4LeVh9/uOoPFILpgCTyOdTtvEs2eMBy3KyyAIbailsBOGECaw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.15.0.tgz",
+      "integrity": "sha512-bLBPQ802tsxNMdNZCuujasbqM7Oiw+6FEdHKjtXuElX+QLvVzy17Cdygcx0BZyC7C9cqZ8Nr3T2LI/X/hDXxXQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-proposal-decorators": "^7.29.7",

--- a/packages/myco-collective/worker/package.json
+++ b/packages/myco-collective/worker/package.json
@@ -10,13 +10,13 @@
     "check": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260608.1",
+    "@cloudflare/workers-types": "^4.20260609.1",
     "typescript": "^6.0.3",
     "wrangler": "^4.98.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "agents": "^0.14.5",
+    "agents": "^0.15.0",
     "zod": "^4.4.3"
   }
 }

--- a/packages/myco-team/worker/package-lock.json
+++ b/packages/myco-team/worker/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.3.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "agents": "^0.14.5",
+        "agents": "^0.15.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260608.1",
+        "@cloudflare/workers-types": "^4.20260609.1",
         "typescript": "^6.0.3",
         "wrangler": "^4.98.0"
       }
@@ -606,9 +606,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260608.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260608.1.tgz",
-      "integrity": "sha512-Yz90KXPZBB9K/AhsnLaA321s5+i5ZpWZRFbcGx9dWjyknQJXPAS1pK5CJSFEedwY6zoEr1cf2SkpBATL1idsWA==",
+      "version": "4.20260609.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260609.1.tgz",
+      "integrity": "sha512-krGHtwSApCFBjTe1NTx/TFQ0P5i/bHGQOqCPnCLssb8rOKaAG4JkPFJZsossr0z/ZTMnpP2Tid5jWju+/i0hCA==",
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -2286,9 +2286,9 @@
       }
     },
     "node_modules/agents": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/agents/-/agents-0.14.5.tgz",
-      "integrity": "sha512-xKZDaAU5vaLw5vNlGzt20vCwAe74hWcufuc5a4LeVh9/uOoPFILpgCTyOdTtvEs2eMBy3KyyAIbailsBOGECaw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.15.0.tgz",
+      "integrity": "sha512-bLBPQ802tsxNMdNZCuujasbqM7Oiw+6FEdHKjtXuElX+QLvVzy17Cdygcx0BZyC7C9cqZ8Nr3T2LI/X/hDXxXQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-proposal-decorators": "^7.29.7",

--- a/packages/myco-team/worker/package.json
+++ b/packages/myco-team/worker/package.json
@@ -10,13 +10,13 @@
     "check": "tsc --noEmit"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260608.1",
+    "@cloudflare/workers-types": "^4.20260609.1",
     "typescript": "^6.0.3",
     "wrangler": "^4.98.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "agents": "^0.14.5",
+    "agents": "^0.15.0",
     "zod": "^4.4.3"
   }
 }

--- a/packages/myco/package.json
+++ b/packages/myco/package.json
@@ -59,14 +59,14 @@
     "directory": "packages/myco"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.168",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.169",
     "@anthropic-ai/sdk": "^0.102.0",
     "@inquirer/prompts": "^8.5.2",
     "@modelcontextprotocol/sdk": "^1.28.0",
     "@openai/agents": "^0.11.5",
     "chokidar": "^5.0.0",
     "gray-matter": "^4.0.3",
-    "semver": "^7.8.2",
+    "semver": "^7.8.3",
     "shell-quote": "^1.8.4",
     "smol-toml": "^1.6.1",
     "yaml": "^2.8.4",


### PR DESCRIPTION
## Summary

Batches the Dependabot PRs that remained open after #461 merged. These are fresh follow-up bumps beyond the versions included in #461:

- #436 semver 7.8.2 -> 7.8.3
- #437 @cloudflare/workers-types 4.20260608.1 -> 4.20260609.1 in packages/myco-collective/worker
- #438 @cloudflare/workers-types 4.20260608.1 -> 4.20260609.1 in packages/myco-team/worker
- #442 agents 0.14.5 -> 0.15.0 in packages/myco-collective/worker
- #451 agents 0.14.5 -> 0.15.0 in packages/myco-team/worker
- #452 @anthropic-ai/claude-agent-sdk 0.3.168 -> 0.3.169

Note: #438's standalone Dependabot CI was red, but the same target version passes in this combined branch locally.

## Verification

- Lockfile audit for every target package/version: passed
- npm ci
- npm ci --prefix packages/myco-team/worker
- npm ci --prefix packages/myco-collective/worker
- make build
- npm test