### PR TITLE
Canopy: scope describe-backlog counts to serviceable projects

### DIFF
--- a/.agents/skills/feature-branch-worktree-squash-merge-delivery/SKILL.md
+++ b/.agents/skills/feature-branch-worktree-squash-merge-delivery/SKILL.md
@@ -46,15 +46,15 @@ cd ../myco-branch-name
 
 **Critical**: use a sibling directory (e.g., `../myco-branch-name`), **not a subdirectory inside the repo**. Nested worktrees confuse Myco's CWD detection and create phantom sessions.
 
-### Step 2b: Bootstrap Myco hooks in the worktree
+### Step 2b: Pin the worktree to its dev binary
 
 ```bash
-myco-dev init --worktree   # or `myco init --worktree` when working from a released CLI
+make dev-link-worktree
 ```
 
-This materializes `.claude/settings.json`, `.agents/myco-run.cjs`, and `.myco/runtime.command` inside the worktree. Those files are gitignored and untracked — `git worktree add` only checks out tracked files, so without this step the worktree's capture stack is silent and the daemon never sees the work happening here. Symbiont enablement is inherited from the main repo's merged config, so no prompts; vault reads still resolve through the shared `<main>/.myco`.
+This writes a `.myco/runtime.command` file that pins this worktree to the freshly-built local binary (not the shared `~/.local/bin/myco-dev` symlink). All hooks, MCP calls, and CLI invocations in this worktree then dispatch to the worktree build. The file is gitignored, so it's never committed. When you're done (Step 6), run `make dev-unlink-worktree` to remove the pin.
 
-Skip this step ONLY when you have deliberately decided the worktree should not capture (rare; the default is to bootstrap).
+Skip this step ONLY when you deliberately want the worktree to fall back to the global binary.
 
 ### Step 3: Implement with incremental commits
 
@@ -160,7 +160,7 @@ This commit will be squashed into the feature commit in Step 6.
 make build
 ```
 
-This executes `tsc` + `vitest` + `tsup` + `vite` in sequence. **Do NOT use `npm run build`** — it runs only the bundler, silently skipping type checks and tests. `make build` is the gate before squash. Never proceed until it passes cleanly.
+This runs lint + fast unit tests + bundler (`tsc` + `vitest` fast profile + `tsup` + `vite`). Integration, smoke, and daemon tests are excluded from the default profile — they run in CI on every PR. **Do NOT use `npm run build`** — it runs only the bundler, silently skipping type checks and tests. For pre-release confidence when tagging a release, use `make build-all` instead. `make build` is the standard gate before squash. Never proceed until it passes cleanly.
 
 ### Step 6: Squash all commits, delete worktree, push
 
@@ -170,6 +170,9 @@ Run from inside the worktree directory (`../myco-branch-name`):
 # Squash all implementation + simplify commits into one
 git reset --soft $(git merge-base HEAD main)
 git commit -m "feat: <single clear description of the feature>"
+
+# Remove the dev binary pin
+make dev-unlink-worktree
 
 # Delete the worktree before pushing
 git worktree remove ../myco-branch-name
@@ -216,7 +219,7 @@ The single squashed commit becomes the PR commit.
 
 ### Standard Quality and Build Gotchas
 
-- **`npm run build` silently ships broken packages** — only `make build` runs the full `tsc` + `vitest` + `tsup` + `vite` chain
+- **`npm run build` silently ships broken packages** — only `make build` runs lint + fast unit tests + `tsc` + `tsup` + `vite`; for the full test sweep including integration/smoke, use `make build-all`
 - **Sibling directory, not subdirectory** — always use `../myco-branch-name`; nested worktrees cause CWD detection misattribution
 - **`/simplify` before squash, not after** — simplification belongs in the final squashed commit, not a follow-up cleanup PR
 - **Delete the worktree before pushing** — `git worktree remove` must precede `git push`; lingering worktrees confuse subsequent Claude Code sessions

--- a/.agents/skills/safe-config-updates/SKILL.md
+++ b/.agents/skills/safe-config-updates/SKILL.md
@@ -254,10 +254,12 @@ When architectural changes move fields between tiers, two mechanisms cooperate:
 
 **Legacy strip — `PROJECT_TIER_LEGACY_FIELDS`**: For fields that historically lived in the wrong tier and need to be actively removed from committed `myco.yaml` files (not just ignored), add them to `PROJECT_TIER_LEGACY_FIELDS` in `packages/myco/src/config/schema.ts`. The loader's `stripLegacyProjectFields()` function iterates this list and calls `unsetAtPath()` to physically remove them from the YAML document, preventing stale fields from cluttering project configs.
 
+**`GROVE_PROMOTED_FIELDS` — Grove-tier conditional stripping**: `GROVE_PROMOTED_FIELDS` (also exported from `packages/myco/src/config/schema.ts`) is a companion array listing the subset of fields that belong specifically to Grove tier — embedding settings, agent provider, agent harness, agent model, and agent scheduling fields. See the array definition in schema.ts for the current list. This array is spread into `PROJECT_TIER_LEGACY_FIELDS`, but with a critical conditional: `stripLegacyProjectFields()` only strips these fields when the project is Grove-bound (`hasGrove: true`). If no Grove exists yet, the values are retained in `myco.yaml` so they aren't lost. Once the project binds to a Grove, `myco update` lifts the values to Grove tier and then strips them from the project YAML.
+
 **When to use each:**
 - New field at correct tier from day one → just add to `SCOPE_REGISTRY`; `pruneToTier` enforces it automatically
-- Field moved from project → grove tier → add to `SCOPE_REGISTRY` with new home; also add to `PROJECT_TIER_LEGACY_FIELDS` so the old project-tier value gets stripped from `myco.yaml` on next load
-- Field removed entirely → add to `PROJECT_TIER_LEGACY_FIELDS` to clean up existing configs; no registry entry needed
+- Field moved from project → grove tier → add to `SCOPE_REGISTRY` with new home; also add to `GROVE_PROMOTED_FIELDS` (and by extension `PROJECT_TIER_LEGACY_FIELDS`) so the old project-tier value gets stripped from `myco.yaml` once Grove is bound
+- Field removed entirely → add to `PROJECT_TIER_LEGACY_FIELDS` directly to clean up existing configs; no registry entry needed
 
 This silent-strip pattern ensures that when developers pull code with a tier reorganization, old fields in `myco.yaml` do not interfere with new grove-tier values, preventing silent shadowing of grove defaults.
 
@@ -332,15 +334,7 @@ const scopeDefaults = {
 ```
 
 **Step 5: Handle restart-required fields (if applicable)**
-If the field requires daemon restart rather than live-reload, add it to the restart-required pattern in the UI:
-
-```typescript
-const RESTART_REQUIRED_PATHS = [
-  'daemon.port',
-  'daemon.log_level',
-  'new_field_requiring_restart'
-];
-```
+If the field requires daemon restart rather than live-reload, document it in the settings UI and ensure the save handler sends the appropriate IPC restart signal alongside the config write.
 
 ---
 
@@ -413,12 +407,14 @@ generated content here
 ```
 
 **Step 3: In-process reconciliation**
-Trigger reconciliation via SymbiontInstaller after config save - NOT CLI subprocess:
+Trigger reconciliation via the symbiont reconciler after config save — NOT a CLI subprocess:
 
 ```typescript
+import { reconcileConfiguredSymbionts } from '../symbionts/reconcile.js';
+
 // In config write handler
 if (newConfig.enable_new_feature !== oldConfig.enable_new_feature) {
-  await SymbiontInstaller.reconcileFeatureBlocks();
+  reconcileConfiguredSymbionts(projectRoot, vaultDir);
 }
 ```
 
@@ -450,7 +446,7 @@ This pattern keeps side-effects deterministic and avoids the complexity of subpr
 
 **Config tier migration false positives:** During drift analysis, config property paths like `myco.yaml` and `backup.dir` are configuration property references, not missing file paths. Verify that core config safety functions remain present in the loader module before assuming drift.
 
-**Legacy field shadowing:** When adding to PROJECT_TIER_LEGACY_FIELDS for migration, ensure the strip happens at load time before tier merging. If a legacy project-tier `agent.provider` exists alongside a new grove-tier `agent.provider`, the legacy field will shadow the grove value until it's stripped.
+**Legacy field shadowing:** When adding to PROJECT_TIER_LEGACY_FIELDS for migration, ensure the strip happens at load time before tier merging. If a legacy project-tier `agent.provider` exists alongside a new grove-tier `agent.provider`, the legacy field will shadow the grove value until it's stripped. Note: fields in `GROVE_PROMOTED_FIELDS` are only stripped when the project is Grove-bound (`hasGrove: true`) — they remain in `myco.yaml` until a Grove is available to receive the migrated value.
 
 **SCOPE_REGISTRY sync test:** A scope-registry sync test enforces that every Zod schema leaf has a registry entry. After adding a new config field to the schema, always add it to `SCOPE_REGISTRY` in `packages/myco/src/config/scope.ts` — or the test will fail loudly.
 
@@ -474,11 +470,12 @@ This pattern keeps side-effects deterministic and avoids the complexity of subpr
 - [ ] If touching daemon-behavior fields, reload signal is sent
 - [ ] New scoped config fields added to both Zod schema AND `SCOPE_REGISTRY` in `packages/myco/src/config/scope.ts`
 - [ ] Config reactions follow closure factory pattern and idempotency constraints
-- [ ] Config toggle side-effects use managed blocks and in-process reconciliation
+- [ ] Config toggle side-effects use managed blocks and in-process reconciliation via `reconcileConfiguredSymbionts` from `packages/myco/src/symbionts/reconcile.ts`
 - [ ] Grove architecture compatibility considered for multi-project coordination
 - [ ] Three-tier merge precedence understood and documented
 - [ ] Config tier migration compatibility verified for grove coordination features
-- [ ] Legacy field handling: use `PROJECT_TIER_LEGACY_FIELDS` in schema.ts for fields that need physical removal from project YAML; `pruneToTier` auto-enforces scope for everything else
+- [ ] Legacy field handling: use `PROJECT_TIER_LEGACY_FIELDS` (or `GROVE_PROMOTED_FIELDS` for Grove-tier fields) in schema.ts for fields that need physical removal from project YAML; `pruneToTier` auto-enforces scope for everything else
+- [ ] GROVE_PROMOTED_FIELDS entries only stripped when project is Grove-bound — retained in myco.yaml until Grove exists
 - [ ] Scoped-clear operations pass `{ pruneEmptyParents: true }` to `unsetAtPath()` to avoid empty-map residue
 - [ ] Capability-gated features use `capabilityEnabled(config, capId)` from `packages/myco/src/config/capabilities.ts`, not direct config reads
 - [ ] Manual verification: inspect `myco.yaml` after a test save to confirm no data loss

--- a/.agents/skills/three-tier-config-architecture/SKILL.md
+++ b/.agents/skills/three-tier-config-architecture/SKILL.md
@@ -163,9 +163,9 @@ const merged  = deepMergeConfig(stage2, pruneToTier(localRaw, 'local'));
 
 Myco uses a **promote-before-strip** two-layer automatic migration model for scope boundary evolution. Legacy fields are promoted (recognized) before being stripped (removed), ensuring zero data loss during migrations.
 
-**Layer 1: PROJECT_TIER_LEGACY_FIELDS Silent Recognition**
+**Layer 1: PROJECT_TIER_LEGACY_FIELDS and GROVE_PROMOTED_FIELDS**
 
-`PROJECT_TIER_LEGACY_FIELDS` in `packages/myco/src/config/schema.ts` lists the dot-path segments of fields that have been moved out of project tier. The internal `stripLegacyProjectFields` helper in `packages/myco/src/config/loader.ts` reads this list and silently removes those fields when writing project config. When `loadMergedConfig()` encounters them, `pruneToTier(..., 'project')` drops them — they are not included in the merged result:
+`PROJECT_TIER_LEGACY_FIELDS` in `packages/myco/src/config/schema.ts` lists the dot-path segments of all fields that have been moved out of project tier. The internal `stripLegacyProjectFields` helper in `packages/myco/src/config/loader.ts` reads this list and silently removes those fields when writing project config. When `loadMergedConfig()` encounters them, `pruneToTier(..., 'project')` drops them — they are not included in the merged result:
 
 ```typescript
 // packages/myco/src/config/schema.ts
@@ -174,10 +174,12 @@ export const PROJECT_TIER_LEGACY_FIELDS: ReadonlyArray<readonly string[]> = [
   ['embedding', 'run_in_deep_sleep'],
   ['agent', 'scheduled_tasks_active_window_days'],
   ['appearance'],
-  // ... and others
+  // ... and others, including all of GROVE_PROMOTED_FIELDS via spread
 ];
 // pruneToTier(projectRaw, 'project') drops all of these automatically.
 ```
+
+`GROVE_PROMOTED_FIELDS` (also exported from `packages/myco/src/config/schema.ts`) is the companion subset listing fields that belong specifically to Grove tier — embedding settings, agent provider, harness, model, and scheduling fields. See the array definition in schema.ts for the current list. This array is spread into `PROJECT_TIER_LEGACY_FIELDS`, but with a **critical conditional**: `stripLegacyProjectFields()` only strips `GROVE_PROMOTED_FIELDS` entries when the project is Grove-bound (`hasGrove: true`). If the project has no Grove yet, these values are retained in the project config so they aren't silently lost. Once a Grove is bound, the values are available to migrate. Fields in `PROJECT_TIER_LEGACY_FIELDS` that are NOT in `GROVE_PROMOTED_FIELDS` (machine/personal tier moves) are always stripped unconditionally.
 
 **Layer 2: Atomic `myco update` Lift**
 
@@ -195,7 +197,7 @@ Running `myco update` performs an atomic, value-preserving migration: legacy pro
 
 When moving a field from one tier to another:
 
-1. Add the old path to `PROJECT_TIER_LEGACY_FIELDS` (or the equivalent for other tier moves) so the promote-before-strip mechanism recognizes it
+1. Add the old path to `PROJECT_TIER_LEGACY_FIELDS` (or `GROVE_PROMOTED_FIELDS` if it's a Grove-tier field) so the promote-before-strip mechanism recognizes it
 2. Update `SCOPE_REGISTRY` in `packages/myco/src/config/scope.ts` to assign the new home tier and `overridableBy` list
 3. Add the new path to the appropriate tier Zod schema in `packages/myco/src/config/schema.ts`
 4. Write a migration function that reads legacy values and writes them to the new tier via `updateGroveConfig()` / `updateConfig()` / `saveMachineConfig()`
@@ -234,6 +236,8 @@ Before running a scope boundary migration in production:
 
 - **Promote-before-strip pattern**: The two-layer automatic migration model PROMOTES (recognizes) legacy project-tier fields in Layer 1 before STRIPPING (removing) them in Layer 2. This ensures zero data loss. Never skip the promotion phase or attempt direct removal without atomic lift validation.
 
+- **GROVE_PROMOTED_FIELDS conditional stripping**: Fields in `GROVE_PROMOTED_FIELDS` (the Grove-tier subset of `PROJECT_TIER_LEGACY_FIELDS`) are only stripped from project config when the project is Grove-bound. An unbound project retains these values so they survive until a Grove is available to receive them. Do not manually strip these fields from the project config without first ensuring the values are captured in Grove config.
+
 - **Legacy project ID migration**: When migrating from legacy project identifiers, preserve configuration continuity by mapping legacy values to binding_id-based storage before removing legacy entries.
 
 - **Grove identity coordination**: Project configuration changes may affect Grove-level settings inheritance. Always consider the Grove/project relationship when modifying project-scoped configuration patterns. Changes at Grove tier affect all projects unless overridden at project scope.
@@ -252,4 +256,4 @@ Before running a scope boundary migration in production:
 
 - **No-Grove gotcha — project-scope-only read paths**: Code paths that read project-scoped configuration without Grove context cannot access Grove-tier settings. This is intentional for security. If you need Grove settings in a project-only context, pass Grove context explicitly or redesignate the setting as project-scoped.
 
-- **liveConfig is not per-grove**: In `packages/myco/src/daemon/power-jobs.ts`, `liveConfig` is typed as `{ current: MycoConfig }` — a mutable container holding the daemon's boot-grove merged config. It updates on config-change events but is NOT per-project. When daemon jobs iterate multiple groves or projects, always call `loadMergedConfig({ projectPath })` for each project to get the correct grove-specific merged config. Reading from the shared `liveConfig` container in a multi-grove iteration applies the boot grove's config to all other projects.
+- **liveConfig is not per-grove**: In `packages/myco/src/daemon/power-jobs.ts`, `liveConfig` is typed as `{ current: MycoConfig }` — a mutable container holding the daemon's boot-grove merged config. It updates on config-change events but is NOT per-project. When daemon jobs iterate multiple groves or projects, always call `loadMergedConfig({ projectPath })` for each project to get the correct grove-specific merged config. Reading from the shared `liveConfig` container in a multi-grove iteration applies the boot grove's config to all other projects — a pattern confirmed to cause production failures where backup operations resolved to the wrong grove, causing a successful "Backup Now" to appear absent on the next read.

--- a/packages/myco/src/canopy/describe-backlog.ts
+++ b/packages/myco/src/canopy/describe-backlog.ts
@@ -20,15 +20,51 @@ import {
   type CanopyDescribeBacklog,
 } from '@myco/db/queries/canopy.js';
 import type { ProjectScope } from '@myco/grove/ids.js';
+import { resolveMycoHome } from '@myco/grove/paths.js';
+import { listRegisteredProjects, loadGroveRecord } from '@myco/grove/registry.js';
 
-export interface CanopyDescribeBacklogReader {
-  read(scope: ProjectScope): CanopyDescribeBacklog;
+export interface CanopyDescribeBacklogContext {
+  /** Grove the request is bound to; consulted for grove-wide reads. */
+  groveId?: string | null;
 }
 
-export function createCanopyDescribeBacklogReader(): CanopyDescribeBacklogReader {
+export interface CanopyDescribeBacklogReader {
+  read(scope: ProjectScope, context?: CanopyDescribeBacklogContext): CanopyDescribeBacklog;
+}
+
+export interface CanopyDescribeBacklogReaderOptions {
+  mycoHome?: string;
+}
+
+export function createCanopyDescribeBacklogReader(
+  options: CanopyDescribeBacklogReaderOptions = {},
+): CanopyDescribeBacklogReader {
   return {
-    read(scope) {
-      return getCanopyDescribeBacklog(getDatabase(), scope);
+    read(scope, context) {
+      const projectIds = scope.kind === 'all'
+        ? serviceableProjectIds(context?.groveId ?? null, options.mycoHome)
+        : null;
+      return getCanopyDescribeBacklog(
+        getDatabase(),
+        scope,
+        projectIds ? { projectIds } : {},
+      );
     },
   };
+}
+
+// Grove-wide backlog counts must reflect work the scribe can actually
+// service: active registered projects only. Rows left behind by deleted
+// projects (pre-cascade orphans) or held by archived projects would
+// otherwise inflate the dashboard with work no scheduled run will drain.
+// When the grove record can't be loaded the registry is unavailable, so
+// fall back to the unrestricted count rather than report a false zero.
+function serviceableProjectIds(
+  groveId: string | null,
+  mycoHome?: string,
+): string[] | null {
+  if (!groveId) return null;
+  const home = mycoHome ?? resolveMycoHome();
+  if (!loadGroveRecord(groveId, home)) return null;
+  return listRegisteredProjects(groveId, home).map((project) => project.project_id);
 }

--- a/packages/myco/src/daemon/api/embedding.ts
+++ b/packages/myco/src/daemon/api/embedding.ts
@@ -249,7 +249,7 @@ export function createEmbeddingDetailsHandler(deps: EmbeddingDetailsDeps): Route
     return withDatabase(runtime.db, () =>
       handleEmbeddingDetails(runtime.manager, {
         projectId,
-        canopyDescribe: deps.canopyDescribeBacklog.read(scope),
+        canopyDescribe: deps.canopyDescribeBacklog.read(scope, { groveId: ctx.groveId ?? null }),
       }),
     );
   };

--- a/packages/myco/src/db/queries/canopy.ts
+++ b/packages/myco/src/db/queries/canopy.ts
@@ -423,6 +423,15 @@ export interface CanopyDescribeBacklog {
   stale: number;
 }
 
+export interface CanopyDescribeBacklogOptions {
+  /**
+   * Restrict the count to these project ids. Grove-wide callers pass the
+   * active registered projects so rows from deleted or archived projects
+   * (which no scribe run will ever service) don't inflate the backlog.
+   */
+  projectIds?: readonly string[];
+}
+
 /**
  * Count the upstream Canopy scribe backlog. This is deliberately separate
  * from embedding queue depth: changed files keep their old vector until the
@@ -431,15 +440,21 @@ export interface CanopyDescribeBacklog {
 export function getCanopyDescribeBacklog(
   db: Database,
   scope: ProjectScope,
+  options: CanopyDescribeBacklogOptions = {},
 ): CanopyDescribeBacklog {
   const { sql: projectSql, params } = projectScopeClause(scope);
+  let restrictSql = '';
+  if (options.projectIds) {
+    restrictSql = ' AND project_id IN (SELECT value FROM json_each(?))';
+    params.push(JSON.stringify(options.projectIds));
+  }
   const row = db.prepare(
     `SELECT
        SUM(CASE WHEN llm_updated_at IS NULL OR llm_updated_at < mechanical_updated_at THEN 1 ELSE 0 END) AS pending,
        SUM(CASE WHEN llm_updated_at IS NULL THEN 1 ELSE 0 END) AS undescribed,
        SUM(CASE WHEN llm_updated_at IS NOT NULL AND llm_updated_at < mechanical_updated_at THEN 1 ELSE 0 END) AS stale
        FROM canopy_entries
-      WHERE 1 = 1${projectSql}`,
+      WHERE 1 = 1${projectSql}${restrictSql}`,
   ).get(...params) as { pending: number | null; undescribed: number | null; stale: number | null } | undefined;
   return {
     pending: Number(row?.pending ?? 0),

--- a/tests/canopy/describe-backlog.test.ts
+++ b/tests/canopy/describe-backlog.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { Database } from 'bun:sqlite';
+import { withDatabase } from '@myco/db/client';
+import { CANOPY_ENTRIES_TABLE } from '@myco/db/schema-ddl';
+import { ALL_PROJECTS_SCOPE, projectScope } from '@myco/grove/ids';
+import {
+  archiveProjectInGrove,
+  clearGroveRegistryCaches,
+  createGrove,
+  registerProjectInGrove,
+} from '@myco/grove/registry';
+import { createCanopyDescribeBacklogReader } from '@myco/canopy/describe-backlog';
+
+let home: string;
+let db: Database;
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-describe-backlog-'));
+  clearGroveRegistryCaches();
+  db = new Database(':memory:');
+  db.prepare(CANOPY_ENTRIES_TABLE).run();
+});
+
+afterEach(() => {
+  db.close();
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+function insertUndescribedEntry(projectId: string, filePath: string): void {
+  db.prepare(
+    `INSERT INTO canopy_entries (
+      project_id, path, content_hash, size_bytes, token_estimate,
+      line_count, mechanical_updated_at, llm_description, llm_updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(projectId, filePath, `hash-${filePath}`, 10, 5, 1, 200, null, null);
+}
+
+describe('canopy describe backlog reader', () => {
+  it('grove-wide reads count only active registered projects', () => {
+    const grove = createGrove('Test Grove', home);
+    registerProjectInGrove(grove.id, {
+      projectId: 'proj_active',
+      projectName: 'active',
+      projectRoot: '/tmp/active',
+      bindingId: 'gbind_active',
+    }, home);
+    registerProjectInGrove(grove.id, {
+      projectId: 'proj_archived',
+      projectName: 'archived',
+      projectRoot: '/tmp/archived',
+      bindingId: 'gbind_archived',
+    }, home);
+    archiveProjectInGrove(grove.id, 'proj_archived', home);
+
+    insertUndescribedEntry('proj_active', 'a.ts');
+    insertUndescribedEntry('proj_active', 'b.ts');
+    insertUndescribedEntry('proj_archived', 'c.ts');
+    insertUndescribedEntry('proj_deleted_orphan', 'd.ts');
+
+    const reader = createCanopyDescribeBacklogReader({ mycoHome: home });
+    const backlog = withDatabase(db, () =>
+      reader.read(ALL_PROJECTS_SCOPE, { groveId: grove.id }),
+    );
+
+    expect(backlog).toEqual({ pending: 2, undescribed: 2, stale: 0 });
+  });
+
+  it('falls back to the unrestricted count when the grove record is unknown', () => {
+    insertUndescribedEntry('proj_anything', 'a.ts');
+
+    const reader = createCanopyDescribeBacklogReader({ mycoHome: home });
+    const backlog = withDatabase(db, () =>
+      reader.read(ALL_PROJECTS_SCOPE, { groveId: 'grove_missing' }),
+    );
+
+    expect(backlog.undescribed).toBe(1);
+  });
+
+  it('project-scoped reads stay unrestricted by the registry', () => {
+    insertUndescribedEntry('proj_unregistered', 'a.ts');
+
+    const reader = createCanopyDescribeBacklogReader({ mycoHome: home });
+    const backlog = withDatabase(db, () =>
+      reader.read(projectScope('proj_unregistered'), { groveId: null }),
+    );
+
+    expect(backlog.undescribed).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

The grove-scoped Operations page showed **Canopy Scribe 7,619 pending** while every active project was fully described. The backlog counter (`getCanopyDescribeBacklog`) counted every `canopy_entries` row in the Grove DB, but the scribe and its wake probe only service active registered projects (`listRegisteredProjects()` in `task-scheduling.ts`). The gap was unserviceable work the dashboard reported as permanent backlog:

- 6,616 rows from a deleted project (deregistered before the `GROVE_PROJECT_SCOPED_TABLES` delete cascade existed, leaving orphan rows)
- 818 rows from an archived project (skipped by the scribe, kept for unarchive)

Both removal paths (`deleteProjectPermanently`, grove move) already cascade `canopy_entries`, so new orphans can't be created — but the counter still surfaced pre-cascade residue and archived projects as work no scheduled run will ever drain.

## Fix

Grove-wide (`'all'`-scope) backlog reads now restrict to active registered project ids:

- `getCanopyDescribeBacklog` accepts an optional `projectIds` restriction (`json_each` IN-clause), keeping the SQL layer registry-agnostic.
- `createCanopyDescribeBacklogReader` resolves active registered projects for the request's grove and passes them through. When the grove record can't be loaded, it falls back to the unrestricted count — unrestricted truth beats a false zero.
- Project-scoped reads are unchanged (an explicitly requested project is counted as-is).

Verified against the prod Grove: phantom backlog gone, real backlog (active project that hasn't opted into the describe schedule) still visible.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Fable 5 via [Claude Code](https://claude.com/claude-code)