### PR TITLE
Tests: hermetic MYCO_HOME — stop poisoning prod's daemon.json

### DIFF
--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -5,8 +5,26 @@
 
 import { spawnSync, spawn } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+// ---------------------------------------------------------------------------
+// Hermetic MYCO_HOME
+// ---------------------------------------------------------------------------
+// Tests must never touch the real ~/.myco. An unsandboxed write to
+// ~/.myco/service/daemon.json points every capture hook on the machine at a
+// dead port, and the hooks' capture-critical recovery then restarts the
+// production daemon. Every test process spawned by this runner inherits a
+// per-run sandbox home instead. An explicitly-set MYCO_HOME is honored so a
+// debugging run can still target a fixture home.
+if (!process.env.MYCO_HOME) {
+  const sandboxMycoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-test-home-'));
+  process.env.MYCO_HOME = sandboxMycoHome;
+  process.on('exit', () => {
+    try { fs.rmSync(sandboxMycoHome, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Watchdog diagnostics

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -6,6 +6,7 @@ import YAML from 'yaml';
 import { run } from '@myco/cli/config';
 import { MycoConfigSchema } from '@myco/config/schema';
 import { resolveServiceDaemonStatePath } from '@myco/grove/paths';
+import { sandboxMycoHome } from '../helpers/myco-home-sandbox.js';
 
 const VALID_CONFIG = {
   version: 3,
@@ -35,9 +36,14 @@ describe('myco config', () => {
   let logged: string[];
   let errors: string[];
   let exitCode: number | undefined;
+  let sandbox: ReturnType<typeof sandboxMycoHome>;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-config-test-'));
+    // The daemon-restart-notice tests write and unlink a daemon.json via
+    // resolveServiceDaemonStatePath(); the sandbox keeps that away from
+    // the machine's real ~/.myco.
+    sandbox = sandboxMycoHome('myco-config-home-');
     logged = [];
     errors = [];
     exitCode = undefined;
@@ -60,6 +66,7 @@ describe('myco config', () => {
     console.error = originalError;
     process.exit = (globalThis as Record<string, unknown>).__originalExit as typeof process.exit;
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    sandbox.restore();
   });
 
   describe('config get', () => {

--- a/tests/helpers/myco-home-sandbox.ts
+++ b/tests/helpers/myco-home-sandbox.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Point MYCO_HOME at a fresh temp dir so a test can exercise real
+ * path-resolution code (daemon.json fixtures, service dirs, grove
+ * registries) without ever touching the machine's ~/.myco — a real
+ * daemon.json write there points capture hooks at a dead port and gets
+ * the production daemon restarted. Call restore() in afterEach; it
+ * reinstates the prior env value and removes the sandbox dir.
+ */
+export function sandboxMycoHome(prefix = 'myco-home-sandbox-'): {
+  mycoHome: string;
+  restore: () => void;
+} {
+  const previous = process.env.MYCO_HOME;
+  const mycoHome = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  process.env.MYCO_HOME = mycoHome;
+  return {
+    mycoHome,
+    restore() {
+      if (previous === undefined) delete process.env.MYCO_HOME;
+      else process.env.MYCO_HOME = previous;
+      fs.rmSync(mycoHome, { recursive: true, force: true });
+    },
+  };
+}

--- a/tests/mcp/tools/plans.test.ts
+++ b/tests/mcp/tools/plans.test.ts
@@ -28,6 +28,7 @@ import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import { ensureProjectManifest } from '@myco/config/project-manifest.js';
 import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
 import { makeTestRequestContext } from '../../helpers/request-context.js';
+import { sandboxMycoHome } from '../../helpers/myco-home-sandbox.js';
 import { listGraphEdges } from '@myco/db/queries/graph-edges.js';
 import { DEFAULT_AGENT_ID } from '@myco/constants.js';
 
@@ -271,8 +272,13 @@ describe('myco_plans op: delete (integration against real HTTP router)', () => {
   let logger: DaemonLogger;
   let client: DaemonClient;
   let now: number;
+  let sandbox: ReturnType<typeof sandboxMycoHome>;
 
   beforeAll(async () => {
+    // The daemon.json fixture below must land in a sandbox home, never the
+    // machine's real ~/.myco where it would point live capture hooks at
+    // this test server's ephemeral port.
+    sandbox = sandboxMycoHome('myco-plans-delete-home-');
     vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-plans-delete-'));
     ensureProjectManifest(vaultDir, { projectName: 'plans-delete-test' });
     fs.mkdirSync(path.join(vaultDir, 'logs'), { recursive: true });
@@ -315,6 +321,7 @@ describe('myco_plans op: delete (integration against real HTTP router)', () => {
     try { fs.unlinkSync(resolveServiceDaemonStatePath()); } catch { /* gone */ }
     teardownTestDb();
     fs.rmSync(vaultDir, { recursive: true, force: true });
+    sandbox.restore();
   });
 
   beforeEach(() => {

--- a/tests/services/stats.test.ts
+++ b/tests/services/stats.test.ts
@@ -17,6 +17,7 @@ import { ALL_PROJECTS_SCOPE, projectScope, type GroveProjectId } from '@myco/gro
 import { markEmbedded } from '@myco/db/queries/embeddings.js';
 import { gatherStats } from '@myco/services/stats.js';
 import { resolveServiceDaemonStatePath } from '@myco/grove/paths.js';
+import { sandboxMycoHome } from '../helpers/myco-home-sandbox.js';
 
 const AGENT_ID = 'stats-agent';
 
@@ -33,11 +34,16 @@ function insertArtifact(id: string, content: string | null, createdAt: number): 
 describe('gatherStats', () => {
   let tempDir: string;
   let vaultDir: string;
+  let sandbox: ReturnType<typeof sandboxMycoHome>;
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-stats-'));
     vaultDir = path.join(tempDir, '.myco');
     fs.mkdirSync(vaultDir, { recursive: true });
+    // The daemon-metadata assertions below write a fixture daemon.json via
+    // resolveServiceDaemonStatePath(); the sandbox keeps it out of the
+    // machine's real ~/.myco.
+    sandbox = sandboxMycoHome('myco-stats-home-');
 
     saveConfig(vaultDir, MycoConfigSchema.parse({
       version: 3,
@@ -52,6 +58,7 @@ describe('gatherStats', () => {
   });
 
   afterEach(() => {
+    sandbox.restore();
     closeDatabase();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Problem

The production daemon has been restarting chronically (dozens of times over the past two weeks, across all symbionts). Forensics on the daemon's reconcile log found **1,319 `Re-asserting daemon.json` events and 481 foreign pid/port overwrites in 16 days**, each burst aligned with test-suite runs. The chain:

1. A test writes a fixture `daemon.json` via argless `resolveServiceDaemonStatePath()` — which resolves the machine's **real** `~/.myco/service/daemon.json` (`tests/services/stats.test.ts` wrote `port: 19200`; `tests/mcp/tools/plans.test.ts` wrote its test server's ephemeral port; `tests/cli/config.test.ts` wrote `{}` and even unlinked the real file in cleanup).
2. Any symbiont's capture hook reads the poisoned state file, fetches the dead port, and fails.
3. The hook's capture-critical recovery concludes the daemon is wedged and runs `launchctl kickstart -k` — restarting a perfectly healthy production daemon.

Reproduced deterministically: a file watcher on the real `daemon.json` caught the overwrite during `npm test -- tests/services/`.

## Fix

Two layers, so the class is closed rather than the instances:

- **Runner-level sandbox**: `run-bun-tests.mjs` defaults `MYCO_HOME` to a per-run temp dir for every spawned test process (cleaned on exit). No test reachable through `npm test` can touch the real `~/.myco`, including future ones. An explicitly-set `MYCO_HOME` is honored for debugging against a fixture home.
- **Per-file hermeticity** for the three proven offenders via a shared `sandboxMycoHome()` helper (`tests/helpers/myco-home-sandbox.ts`), so raw `bun test` invocations that bypass the runner are safe too.

Verified: full suite green, and a `daemon.json` watcher during the entire run observed only the production daemon's own heartbeat writes — zero foreign writes.

A companion PR hardens the hook-side recovery so a single failed fetch can no longer restart a healthy daemon.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Fable 5 via [Claude Code](https://claude.com/claude-code)