### PR TITLE
Hooks: probe daemon liveness before capture recovery restarts the service

### DIFF
--- a/packages/myco/src/constants.ts
+++ b/packages/myco/src/constants.ts
@@ -122,6 +122,13 @@ export const DAEMON_RESTART_HEALTH_DEADLINE_MS = 30_000;
 /** Minimum interval between hook-triggered capture recovery restarts. */
 export const DAEMON_CAPTURE_RECOVERY_COALESCE_MS = 30_000;
 
+/** Liveness probe attempts before a capture failure may restart the
+ *  service, and the pause between attempts. The retry window must ride
+ *  out a daemon event-loop stall longer than the capture request
+ *  timeout (observed: multi-second stalls during Grove auto-backups). */
+export const DAEMON_RECOVERY_PROBE_ATTEMPTS = 3;
+export const DAEMON_RECOVERY_PROBE_DELAY_MS = 750;
+
 /** Per-poll interval during the restart health-watch loop (ms). */
 export const DAEMON_RESTART_POLL_INTERVAL_MS = 500;
 

--- a/packages/myco/src/hooks/client.ts
+++ b/packages/myco/src/hooks/client.ts
@@ -6,6 +6,8 @@ import {
   DAEMON_CAPTURE_RECOVERY_COALESCE_MS,
   DAEMON_HEALTH_CHECK_TIMEOUT_MS,
   DAEMON_HEALTH_RETRY_DELAYS,
+  DAEMON_RECOVERY_PROBE_ATTEMPTS,
+  DAEMON_RECOVERY_PROBE_DELAY_MS,
   DAEMON_RESTART_HEALTH_DEADLINE_MS,
   DAEMON_RESTART_POLL_INTERVAL_MS,
   DAEMON_SPAWN_COALESCE_MS,
@@ -642,6 +644,8 @@ export class DaemonClient {
       return;
     }
 
+    if (await this.daemonConfirmedAlive()) return;
+
     if (this.captureRecoveryRecentlyRequested()) return;
 
     try {
@@ -656,6 +660,33 @@ export class DaemonClient {
     }
 
     await this.spawnDaemon();
+  }
+
+  /**
+   * A single failed capture request is not proof the daemon is down.
+   * Two healthy-daemon shapes reach the recovery path: a `daemon.json`
+   * briefly carrying a foreign pid/port (another process clobbered it;
+   * the daemon's self-reconciler heals it within one tick), and an
+   * event-loop stall that outlives the capture request timeout. Probe
+   * every discovery tier — the state file, the lifecycle lock, and the
+   * canonical port — with retries before concluding the service needs a
+   * restart. Restarting a healthy daemon costs every live session its
+   * capture continuity, so this errs toward "alive"; a genuinely dead
+   * daemon fails each probe with an immediate connection refusal, so
+   * the added recovery latency is just the inter-attempt pauses.
+   */
+  private async daemonConfirmedAlive(): Promise<boolean> {
+    for (let attempt = 0; attempt < DAEMON_RECOVERY_PROBE_ATTEMPTS; attempt++) {
+      if (attempt > 0) {
+        await new Promise((r) => setTimeout(r, DAEMON_RECOVERY_PROBE_DELAY_MS));
+      }
+      const direct = this.readDaemonJson();
+      if (direct && await this.isHealthy(direct)) return true;
+      const lock = this.readDaemonInfoFromLock();
+      if (lock && lock.port !== direct?.port && await this.isHealthy(lock)) return true;
+      if (await this.discoverViaHealth()) return true;
+    }
+    return false;
   }
 
   private captureRecoveryRecentlyRequested(): boolean {

--- a/tests/hooks/client-capture-recovery.test.ts
+++ b/tests/hooks/client-capture-recovery.test.ts
@@ -1,0 +1,121 @@
+/**
+ * DaemonClient capture-critical recovery — liveness probe before restart.
+ *
+ * A failed capture POST used to restart the owning service unconditionally
+ * (after the 30s coalesce marker). Two healthy-daemon shapes reach that
+ * path: a daemon.json briefly carrying a foreign pid/port (clobbered by
+ * another process; the daemon's self-reconciler heals it within a tick),
+ * and an event-loop stall longer than the capture request timeout. The
+ * client must confirm the daemon is unreachable on every discovery tier
+ * before it asks the supervisor to restart a production daemon.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DaemonClient } from '@myco/hooks/client';
+import { ensureProjectManifest } from '@myco/config/project-manifest';
+import {
+  resolveMycoHome,
+  resolveServiceDaemonStatePath,
+  resolveServiceDir,
+} from '@myco/grove/paths';
+import { listenEphemeral, closeServer } from '../helpers/net.js';
+import { FakeServiceManager } from '../helpers/fake-service-manager.js';
+
+let vaultDir: string;
+let mycoHome: string;
+let serviceDir: string;
+let lockPath: string;
+let statePath: string;
+let markerPath: string;
+let previousHome: string | undefined;
+let previousNoAutoSpawn: string | undefined;
+
+beforeEach(() => {
+  previousHome = process.env.MYCO_HOME;
+  previousNoAutoSpawn = process.env.MYCO_NO_AUTO_SPAWN;
+  process.env.MYCO_NO_AUTO_SPAWN = '1';
+  vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-capture-recovery-'));
+  mycoHome = path.join(vaultDir, 'home');
+  fs.mkdirSync(mycoHome, { recursive: true });
+  process.env.MYCO_HOME = mycoHome;
+  ensureProjectManifest(vaultDir, { projectName: 'capture-recovery-test' });
+  serviceDir = resolveServiceDir(resolveMycoHome());
+  fs.mkdirSync(serviceDir, { recursive: true });
+  lockPath = path.join(serviceDir, 'daemon.lock');
+  statePath = resolveServiceDaemonStatePath(mycoHome);
+  markerPath = path.join(serviceDir, 'capture-recovery.json');
+});
+
+afterEach(() => {
+  fs.rmSync(vaultDir, { recursive: true, force: true });
+  if (previousHome === undefined) delete process.env.MYCO_HOME;
+  else process.env.MYCO_HOME = previousHome;
+  if (previousNoAutoSpawn === undefined) delete process.env.MYCO_NO_AUTO_SPAWN;
+  else process.env.MYCO_NO_AUTO_SPAWN = previousNoAutoSpawn;
+});
+
+// Port 1 is never listening — connects fail with an immediate refusal, the
+// same shape a hook sees when daemon.json carries a foreign port.
+function writePoisonedState(): void {
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(statePath, JSON.stringify({ pid: process.pid, port: 1 }));
+}
+
+function writeLock(holder: { pid: number; port: number }): void {
+  fs.writeFileSync(
+    lockPath,
+    JSON.stringify({
+      pid: holder.pid,
+      startedAt: Math.floor(Date.now() / 1000),
+      command: 'mock daemon',
+      port: holder.port,
+    }, null, 2) + '\n',
+  );
+}
+
+describe('DaemonClient capture-critical recovery', () => {
+  it('does not restart the service when the daemon is reachable via the lock tier', async () => {
+    const { server, port } = await listenEphemeral((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ myco: true, pid: process.pid }));
+    });
+    try {
+      writePoisonedState();
+      writeLock({ pid: process.pid, port });
+
+      const mgr = new FakeServiceManager({ preInstalled: true });
+      const client = new DaemonClient(vaultDir, { serviceManager: mgr });
+      const result = await client.capturePost('/events', { type: 'user_prompt', session_id: 's' });
+
+      // The poisoned port made the request itself fail...
+      expect(result.ok).toBe(false);
+      // ...but the daemon answered the liveness probe, so no restart and
+      // no recovery marker.
+      expect(mgr.restartCalls).toEqual([]);
+      expect(fs.existsSync(markerPath)).toBe(false);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('restarts the installed service once every probe confirms the daemon is unreachable, coalescing repeats', async () => {
+    writePoisonedState();
+    // No lock, nothing on the canonical port: the daemon is genuinely gone.
+
+    const mgr = new FakeServiceManager({ preInstalled: true });
+    const client = new DaemonClient(vaultDir, { serviceManager: mgr });
+
+    const first = await client.capturePost('/events', { type: 'user_prompt', session_id: 's' });
+    expect(first.ok).toBe(false);
+    expect(mgr.restartCalls.length).toBe(1);
+    expect(fs.existsSync(markerPath)).toBe(true);
+
+    // A second failure inside the coalesce window must not restart again.
+    const second = await client.capturePost('/events', { type: 'user_prompt', session_id: 's' });
+    expect(second.ok).toBe(false);
+    expect(mgr.restartCalls.length).toBe(1);
+  }, 20_000);
+});


### PR DESCRIPTION
## Problem

When a capture-critical hook POST fails, `recoverAfterRequestFailure` restarted the owning service (`launchctl kickstart -k`) with no check that the daemon was actually down — only a 30s coalesce marker stood between one failed fetch and a production restart. Two healthy-daemon situations reach that path:

- `daemon.json` briefly carrying a foreign pid/port — another process clobbered it (see goondocks-co/myco#464), and the daemon's self-reconciler heals it within one 30s tick. Hooks reading the poisoned file in that window fetched a dead port and concluded the daemon was wedged.
- An event-loop stall longer than the 2s capture timeout — the daemon's own logs show 1.9–6.1s stalls during Grove auto-backups and embedding batches, several of which line up with same-second SIGTERMs.

Net effect: dozens of unnecessary production restarts over the past two weeks, across all symbionts.

## Fix

Before restarting, capture recovery now confirms the daemon is unreachable on **every** discovery tier — the state file, the lifecycle lock, and the canonical derived port — across 3 attempts spaced 750ms apart (sized to ride out observed stall durations). Only when all probes fail does it fall through to the existing coalesce-marker + supervisor-restart path, which is unchanged.

The probe errs toward "alive": restarting a healthy daemon costs every live session its capture continuity, while a genuinely dead daemon fails each probe with an immediate connection refusal — so real outage recovery only gains the inter-attempt pauses (~1.5s).

Tests cover both sides: a daemon reachable only via the lock tier (poisoned `daemon.json`) produces no restart and no recovery marker; a fully unreachable daemon produces exactly one supervisor restart with repeats coalesced.

Companion to goondocks-co/myco#464, which stops the test suite from poisoning the state file in the first place.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Fable 5 via [Claude Code](https://claude.com/claude-code)