### PR TITLE
config: enforce tier semantics on every write surface (RC-3)

### DIFF
--- a/packages/myco/src/cli/config.ts
+++ b/packages/myco/src/cli/config.ts
@@ -1,7 +1,14 @@
 import fs from 'node:fs';
-import { loadConfig, updateConfig } from '../config/loader.js';
+import {
+  loadConfig,
+  updateConfig,
+  updateTierConfigRaw,
+  TierConfigUnreadableError,
+} from '../config/loader.js';
+import { scopePolicyForPath, type ScopeEntry } from '../config/scope.js';
+import { loadProjectManifest } from '../config/project-manifest.js';
 import { withValue } from '../config/updates.js';
-import { getAtPath } from '../utils/dot-path.js';
+import { getAtPath, setAtPath } from '../utils/dot-path.js';
 import { resolveDaemonServiceState } from '../daemon/service-state.js';
 
 export async function run(args: string[], vaultDir: string): Promise<void> {
@@ -41,9 +48,44 @@ function configGet(dotPath: string, vaultDir: string): void {
 function configSet(dotPath: string, rawValue: string, vaultDir: string): void {
   const value = parseValue(rawValue);
 
+  // Scope-aware dispatch: write the value into the tier file that owns the
+  // path so it actually takes effect (a wrong-tier write is pruned at merge
+  // time and silently vanishes).
+  let policy: ScopeEntry;
   try {
-    updateConfig(vaultDir, (config) => withValue(config, dotPath, value));
+    policy = scopePolicyForPath(dotPath);
+  } catch {
+    console.error(`Unknown config setting: ${dotPath}`);
+    process.exit(1);
+    return;
+  }
+
+  try {
+    if (policy.home === 'machine') {
+      updateTierConfigRaw({ kind: 'machine' }, (rawDoc) => {
+        setAtPath(rawDoc, dotPath, value);
+        return rawDoc;
+      });
+    } else if (policy.home === 'grove') {
+      const groveId = loadProjectManifest(vaultDir)?.grove?.id ?? null;
+      if (groveId) {
+        updateTierConfigRaw({ kind: 'grove', groveId }, (rawDoc) => {
+          setAtPath(rawDoc, dotPath, value);
+          return rawDoc;
+        });
+      } else {
+        // Unbound project: myco.yaml retains grove-tier values until a
+        // Grove binds, then the loader lifts them into grove config.
+        updateConfig(vaultDir, (config) => withValue(config, dotPath, value));
+      }
+    } else {
+      updateConfig(vaultDir, (config) => withValue(config, dotPath, value));
+    }
   } catch (err) {
+    if (err instanceof TierConfigUnreadableError) {
+      console.error(err.message);
+      process.exit(1);
+    }
     if (err instanceof Error && 'issues' in err) {
       const issues = (err as { issues: Array<{ path: (string | number)[]; message: string }> }).issues;
       console.error('Validation error:');

--- a/packages/myco/src/config/loader.ts
+++ b/packages/myco/src/config/loader.ts
@@ -1,13 +1,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import YAML from 'yaml';
+import { z } from 'zod';
 import {
   MycoConfigSchema,
   MachineConfigSchema,
   GroveConfigSchema,
   ProjectConfigSchema,
   PROJECT_TIER_LEGACY_FIELDS,
-  GROVE_PROMOTED_FIELDS,
+  GROVE_TIER_FIELDS,
   type MycoConfig,
   type MachineConfig,
   type GroveConfig,
@@ -16,6 +17,8 @@ import {
 } from './schema.js';
 import { runMigrations, CURRENT_MIGRATION_VERSION } from './migrations.js';
 import { pruneToTier } from './scope.js';
+import { CAPABILITIES } from './capabilities.js';
+import { enumerateLeafPaths } from './leaf-paths.js';
 import { stripDefaultSections } from './sparse.js';
 import { deepMerge } from '../utils/deep-merge.js';
 import { getAtPath, setAtPath, unsetAtPath } from '../utils/dot-path.js';
@@ -59,19 +62,6 @@ function stripLegacyProjectFields(
   // Grove-tier fields can only be safely stripped when there's a Grove
   // to migrate them into. Otherwise they stay until the project gets
   // bound to a Grove.
-  const GROVE_TIER_FIELDS: ReadonlyArray<readonly string[]> = [
-    ['daemon', 'stale_session_threshold_ms'],
-    ['backup'],
-    ['maintenance'],
-    ['embedding', 'run_in_deep_sleep'],
-    ['agent', 'scheduled_tasks_active_window_days'],
-    ['appearance'],
-    ['team'],
-    ...GROVE_PROMOTED_FIELDS,
-    // 2026-06: skills.* is Grove-tier; only strip once a Grove is bound so
-    // the value can be migrated rather than dropped.
-    ['skills'],
-  ];
   const groveTierKeys = new Set(GROVE_TIER_FIELDS.map((seg) => seg.join('.')));
 
   let stripped = false;
@@ -95,6 +85,71 @@ interface CachedTierConfig<T> {
 const machineConfigCache = new Map<string, CachedTierConfig<MachineConfig>>();
 const groveConfigCache = new Map<string, CachedTierConfig<GroveConfig>>();
 
+// ---------------------------------------------------------------------------
+// Tier parse-failure registry — loud, deduped, observable
+// ---------------------------------------------------------------------------
+//
+// A tier file that exists but can't be honored (corrupt YAML, non-mapping
+// root, genuine Zod value violations) silently reverts that tier to defaults.
+// Every such failure is logged to stderr (deduped per file+reason per
+// process) and reported to an optional listener so the daemon can surface a
+// notification. The loader must NOT import the notification layer itself —
+// notify() loads merged config, which would recurse straight back here.
+
+const tierParseFailures = new Map<string, string>();
+let tierParseFailureListener: ((filePath: string, reason: string) => void) | null = null;
+
+export function setTierParseFailureListener(
+  fn: ((filePath: string, reason: string) => void) | null,
+): void {
+  tierParseFailureListener = fn;
+  // Replay failures recorded before registration: tier files are read during
+  // daemon boot (config load) before the daemon wires its listener, and the
+  // dedupe map would otherwise swallow the very incident the listener exists
+  // to surface (a file already corrupt at startup). A file deleted since the
+  // failure no longer needs surfacing — drop its record instead.
+  if (fn) {
+    for (const [filePath, reason] of tierParseFailures) {
+      if (!fs.existsSync(filePath)) {
+        tierParseFailures.delete(filePath);
+        continue;
+      }
+      fn(filePath, reason);
+    }
+  }
+}
+
+function recordTierParseFailure(filePath: string, reason: string): void {
+  if (tierParseFailures.get(filePath) === reason) return;
+  tierParseFailures.set(filePath, reason);
+  process.stderr.write(`[myco config] Failed to honor ${filePath}: ${reason}\n`);
+  tierParseFailureListener?.(filePath, reason);
+}
+
+/**
+ * Remove every `unrecognized_keys` path reported by a Zod error from `doc`.
+ * Returns true when at least one key was removed. Used to salvage tier files
+ * that carry unknown keys (e.g. written by a newer Myco version): known
+ * values are honored instead of silently reverting the whole tier to
+ * defaults.
+ */
+function stripUnrecognizedKeys(doc: Record<string, unknown>, error: z.ZodError): boolean {
+  let stripped = false;
+  for (const issue of error.issues) {
+    if (issue.code !== 'unrecognized_keys') continue;
+    for (const key of issue.keys) {
+      if (unsetAtPath(doc, [...issue.path.map(String), key])) stripped = true;
+    }
+  }
+  return stripped;
+}
+
+function zodReason(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+    .join('; ');
+}
+
 function readTierConfig<T>(
   filePath: string,
   cache: Map<string, CachedTierConfig<T>>,
@@ -109,6 +164,11 @@ function readTierConfig<T>(
     return cached.config;
   }
   let result: T;
+  let failedThisRead = false;
+  const fail = (reason: string): void => {
+    failedThisRead = true;
+    recordTierParseFailure(filePath, reason);
+  };
   if (!stat) {
     result = parseEmpty();
   } else {
@@ -120,22 +180,43 @@ function readTierConfig<T>(
       try {
         parsed = YAML.parse(raw);
       } catch (err) {
-        process.stderr.write(`[myco config] Failed to parse ${filePath}: ${(err as Error).message}\n`);
+        fail(`invalid YAML — ${(err as Error).message}`);
         result = parseEmpty();
         cache.set(filePath, { mtimeMs: stat.mtimeMs, size: stat.size, config: result });
         return result;
       }
       if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        fail('root must be a YAML mapping');
         result = parseEmpty();
       } else {
         try {
           result = parseDoc(parsed);
-        } catch {
+        } catch (err) {
+          // Salvage: unknown keys (strict tier schemas) must not revert the
+          // whole tier to defaults — strip them and honor the known values.
+          // Only genuine value violations fall back to defaults, loudly.
           result = parseEmpty();
+          if (err instanceof z.ZodError) {
+            const salvaged = structuredClone(parsed) as Record<string, unknown>;
+            if (stripUnrecognizedKeys(salvaged, err)) {
+              try {
+                result = parseDoc(salvaged);
+              } catch (err2) {
+                fail(err2 instanceof z.ZodError ? zodReason(err2) : (err2 as Error).message);
+              }
+            } else {
+              fail(zodReason(err));
+            }
+          } else {
+            fail((err as Error).message);
+          }
         }
       }
     }
   }
+  // A clean read clears the failure record so a later re-corruption of the
+  // same file (even with an identical reason) notifies again.
+  if (!failedThisRead) tierParseFailures.delete(filePath);
   cache.set(filePath, { mtimeMs: stat?.mtimeMs ?? null, size: stat?.size ?? null, config: result });
   return result;
 }
@@ -189,16 +270,23 @@ export function saveGroveConfig(
 /**
  * Load → transform → save in one call, matching the `updateConfig` pattern
  * for the project tier. Returns the saved (Zod-validated) GroveConfig.
+ *
+ * The transform receives the Zod-defaulted parsed view; its result is
+ * deep-merged onto the RAW on-disk doc so unknown keys survive the write.
+ * Deep-merge cannot DELETE keys — callers that need wholesale subtree
+ * replacement (e.g. agent.tasks, where task updates remove keys) should use
+ * `updateTierConfigRaw` directly with `setAtPath` (verbatim subtree set).
  */
 export function updateGroveConfig(
   groveId: string,
   transform: (current: GroveConfig) => GroveConfig,
   opts?: { mycoHome?: string },
 ): GroveConfig {
-  const current = loadGroveConfig(groveId, opts?.mycoHome);
-  const next = transform(current);
-  saveGroveConfig(groveId, next, opts?.mycoHome);
-  return next;
+  return updateTierConfigRaw({ kind: 'grove', groveId }, (raw) => {
+    const current = loadGroveConfig(groveId, opts?.mycoHome);
+    const next = transform(current);
+    return deepMergeConfig(raw, next as unknown as Record<string, unknown>);
+  }, opts);
 }
 
 function readRawYamlDoc(filePath: string): Record<string, unknown> {
@@ -214,6 +302,109 @@ function readRawYamlDoc(filePath: string): Record<string, unknown> {
     // Fall through; corrupt YAML is treated as empty.
   }
   return {};
+}
+
+// ---------------------------------------------------------------------------
+// Shared raw-merge tier writer — machine + grove
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when a tier file exists, is non-empty, and cannot be parsed as a
+ * YAML mapping. Write paths must refuse to proceed (the lenient read path
+ * would treat the doc as empty and the subsequent write would wipe the
+ * file); API callers surface it as a 422.
+ */
+export class TierConfigUnreadableError extends Error {
+  constructor(public readonly filePath: string, reason: string) {
+    super(`On-disk config at ${filePath} is invalid — fix or remove it (${reason})`);
+    this.name = 'TierConfigUnreadableError';
+  }
+}
+
+/** Strict variant of `readRawYamlDoc`: corrupt content throws instead of `{}`. */
+function readRawYamlDocStrict(filePath: string): Record<string, unknown> {
+  if (!fs.existsSync(filePath)) return {};
+  const raw = fs.readFileSync(filePath, 'utf-8').trim();
+  if (!raw) return {};
+  let parsed: unknown;
+  try {
+    parsed = YAML.parse(raw);
+  } catch (err) {
+    throw new TierConfigUnreadableError(filePath, `invalid YAML — ${(err as Error).message}`);
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new TierConfigUnreadableError(filePath, 'root must be a YAML mapping');
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * Validate a raw tier doc with unknown keys TOLERATED: parse a deep-cloned
+ * copy with `unrecognized_keys` stripped. A pass means the raw doc (unknown
+ * keys preserved) is safe to persist; genuine value violations rethrow the
+ * ZodError for the caller to surface.
+ */
+function parseTierDocTolerant<T>(parse: (doc: unknown) => T, rawDoc: Record<string, unknown>): T {
+  try {
+    return parse(rawDoc);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      const stripped = structuredClone(rawDoc);
+      if (stripUnrecognizedKeys(stripped, err)) {
+        return parse(stripped);
+      }
+    }
+    throw err;
+  }
+}
+
+export type TierWriteTarget = { kind: 'machine' } | { kind: 'grove'; groveId: string };
+
+export function updateTierConfigRaw(
+  target: { kind: 'machine' },
+  mutate: (rawDoc: Record<string, unknown>) => Record<string, unknown> | void,
+  opts?: { mycoHome?: string },
+): MachineConfig;
+export function updateTierConfigRaw(
+  target: { kind: 'grove'; groveId: string },
+  mutate: (rawDoc: Record<string, unknown>) => Record<string, unknown> | void,
+  opts?: { mycoHome?: string },
+): GroveConfig;
+export function updateTierConfigRaw(
+  target: TierWriteTarget,
+  mutate: (rawDoc: Record<string, unknown>) => Record<string, unknown> | void,
+  opts?: { mycoHome?: string },
+): MachineConfig | GroveConfig;
+/**
+ * Canonical write path for machine/grove tier files. Reads the RAW on-disk
+ * doc (throwing `TierConfigUnreadableError` rather than wiping a corrupt
+ * file), applies `mutate`, validates tolerantly (unknown keys preserved on
+ * disk; value violations throw ZodError), persists atomically, and
+ * invalidates the tier + merged caches. Returns the Zod-parsed full view —
+ * the shape API responses and the UI's PUT-response cache expect.
+ */
+export function updateTierConfigRaw(
+  target: TierWriteTarget,
+  mutate: (rawDoc: Record<string, unknown>) => Record<string, unknown> | void,
+  opts?: { mycoHome?: string },
+): MachineConfig | GroveConfig {
+  const mycoHome = opts?.mycoHome ?? resolveMycoHome();
+  const filePath = target.kind === 'machine'
+    ? resolveGlobalConfigPath(mycoHome)
+    : resolveGroveConfigPath(target.groveId, mycoHome);
+
+  const rawDoc = readRawYamlDocStrict(filePath);
+  const nextRaw = mutate(rawDoc) ?? rawDoc;
+  const parsedView = target.kind === 'machine'
+    ? parseTierDocTolerant((doc) => MachineConfigSchema.parse(doc), nextRaw)
+    : parseTierDocTolerant((doc) => GroveConfigSchema.parse(doc), nextRaw);
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  atomicWriteFileSync(filePath, YAML.stringify(nextRaw), 'utf-8');
+  if (target.kind === 'machine') machineConfigCache.delete(filePath);
+  else groveConfigCache.delete(filePath);
+  invalidateMergedConfigCache();
+  return parsedView;
 }
 
 /**
@@ -236,40 +427,87 @@ const MACHINE_RELOCATE_FIELDS: ReadonlyArray<readonly [readonly string[], readon
 ];
 
 /**
- * Relocate legacy machine-tier residue (capture/notifications/daemon log fields)
- * out of a project's parsed doc and into machine config, mirroring the exact
- * `moveMachine` semantics from `migrateLegacyProjectFields`: move only when the
- * source has a value AND the machine config has no explicit value for that path
- * (so a newer machine value is never clobbered). Idempotent. Reads the RAW
- * target YAML (no Zod defaults) so defaults don't block or trigger a move.
+ * Machine-tier relocation pairs handled on the SAVE path: every entry of
+ * `MACHINE_RELOCATE_FIELDS` plus the legacy `update.channel` →
+ * `daemon.update_channel` lift.
+ */
+const SAVE_PATH_MACHINE_RELOCATE_FIELDS: ReadonlyArray<readonly [readonly string[], readonly string[]]> = [
+  ...MACHINE_RELOCATE_FIELDS,
+  [['update', 'channel'], ['daemon', 'update_channel']],
+];
+
+/**
+ * Relocate machine-tier values (capture/notifications/daemon log fields,
+ * legacy update.channel) out of a project save and into machine config —
+ * LEAF-WISE, deep-merged into the raw machine doc. Block-level writes would
+ * wipe machine-explicit leaves (e.g. `capture.transcript_paths`) whenever a
+ * project section relocates over an existing machine section.
+ *
+ * Per-leaf rule: relocate when the leaf is on-disk residue in myco.yaml OR
+ * its value differs from the schema default. When the machine doc already
+ * has that exact leaf, the no-clobber stands UNLESS the caller-set value
+ * differs from default — the caller wins at leaf granularity, so an
+ * explicit `updateConfig` write of a machine-homed leaf actually lands.
  *
  * Returns true when a write to machine config occurred.
  */
 function relocateMachineFieldsFromProject(
-  parsed: Record<string, unknown>,
+  validated: Record<string, unknown>,
+  onDiskRaw: Record<string, unknown>,
+  defaults: Record<string, unknown>,
   mycoHome: string,
 ): boolean {
   const machinePath = resolveGlobalConfigPath(mycoHome);
   const machineRaw = readRawYamlDoc(machinePath);
   let machineDirty = false;
 
-  for (const [sourcePath, targetPath] of MACHINE_RELOCATE_FIELDS) {
-    const value = getAtPath(parsed, sourcePath);
+  for (const [sourcePath, targetPath] of SAVE_PATH_MACHINE_RELOCATE_FIELDS) {
+    const value = getAtPath(validated, sourcePath);
     if (value === undefined) continue;
-    if (getAtPath(machineRaw, targetPath) !== undefined) continue; // explicit value already
-    setAtPath(machineRaw, targetPath, value);
-    machineDirty = true;
+
+    // Enumerate leaves of section values; scalar/array sources are a single leaf.
+    const leafSuffixes = (value !== null && typeof value === 'object' && !Array.isArray(value))
+      ? enumerateLeafPaths(value).map((leaf) => leaf.split('.'))
+      : [[]];
+
+    for (const suffix of leafSuffixes) {
+      const fullSource = [...sourcePath, ...suffix];
+      const fullTarget = [...targetPath, ...suffix];
+      const leafValue = getAtPath(validated, fullSource);
+      if (leafValue === undefined) continue;
+      const defaultValue = getAtPath(defaults, fullSource);
+      const differsFromDefault = YAML.stringify(leafValue) !== YAML.stringify(defaultValue);
+      const onDiskValue = getAtPath(onDiskRaw, fullSource);
+      const onDisk = onDiskValue !== undefined;
+      if (!onDisk && !differsFromDefault) continue; // defaults aren't meaningful
+      if (getAtPath(machineRaw, fullTarget) !== undefined) {
+        // A leaf may overwrite an explicit machine value only when the caller
+        // changed it in THIS save (differs from the project file's pre-save
+        // state). Unchanged on-disk residue never clobbers a machine value —
+        // the machine value is the newer intent; the residue is simply
+        // dropped from the project file by the schema strip.
+        const callerChanged = YAML.stringify(leafValue) !== YAML.stringify(onDiskValue);
+        if (!callerChanged) continue;
+      }
+      setAtPath(machineRaw, fullTarget, leafValue);
+      machineDirty = true;
+    }
   }
 
   if (machineDirty) {
     try {
-      const validated = MachineConfigSchema.parse(machineRaw);
-      saveMachineConfig(validated, mycoHome);
-      return true;
+      // Tolerant validation, then persist the RAW doc — unknown keys in the
+      // machine file survive the relocation instead of being wiped.
+      parseTierDocTolerant((doc) => MachineConfigSchema.parse(doc), machineRaw);
     } catch {
-      // Defensive: leave the field in place rather than corrupt machine storage.
+      // Defensive: never corrupt machine storage from a project save.
       return false;
     }
+    fs.mkdirSync(path.dirname(machinePath), { recursive: true });
+    atomicWriteFileSync(machinePath, YAML.stringify(machineRaw), 'utf-8');
+    machineConfigCache.delete(machinePath);
+    invalidateMergedConfigCache();
+    return true;
   }
   return false;
 }
@@ -306,15 +544,13 @@ function migrateLegacyProjectFields(
       groveDirty = true;
     };
 
-    tryMove(['daemon', 'stale_session_threshold_ms'], ['daemon', 'stale_session_threshold_ms']);
-    tryMove(['backup'], ['backup']);
-    tryMove(['maintenance'], ['maintenance']);
-    tryMove(['embedding', 'run_in_deep_sleep'], ['embedding', 'run_in_deep_sleep']);
-    tryMove(['agent', 'scheduled_tasks_active_window_days'], ['agent', 'scheduled_tasks_active_window_days']);
-    tryMove(['appearance'], ['appearance']);
-    tryMove(['team'], ['team']);
-    // 2026-06 settings-scope correction: skills.* → Grove tier.
-    tryMove(['skills'], ['skills']);
+    // Every Grove-tier field that can appear in a legacy project myco.yaml
+    // (source path === target path for all entries). Derived from the shared
+    // GROVE_TIER_FIELDS export so the lift list can't drift from the strip
+    // list — Grove-bind lifts retained values instead of wiping them.
+    for (const segments of GROVE_TIER_FIELDS) {
+      tryMove(segments, segments);
+    }
 
     if (groveDirty) {
       try {
@@ -562,52 +798,56 @@ export function saveConfig(vaultDir: string, config: MycoConfig): void {
   const onDiskRaw = readRawYamlDoc(configPath);
   const defaults = MycoConfigSchema.parse({ version: 3 });
 
-  // Machine-tier `capture`/`notifications` are dropped by ProjectConfigSchema's
-  // strip. The load-path migration (migrateLegacyProjectFields, gated by
-  // migrateTiers=true) relocates them to machine config — but updateConfig →
-  // loadConfig runs WITHOUT migrateTiers, so an un-migrated project's
-  // capture/notifications can reach saveConfig still living in myco.yaml. Were
-  // we to only strip them here, the values would be lost: not kept (project),
-  // not relocated (the migration never ran). Relocate them on the save path too,
-  // mirroring migrateLegacyProjectFields' moveMachine semantics (move only
-  // legacy residue; never clobber a newer machine value; idempotent) so NO
-  // capture/notifications value is ever lost on save.
-  //
-  // Only relocate a value that is MEANINGFUL — present on disk in myco.yaml
-  // (legacy residue) OR a non-default value the caller just set. Otherwise the
-  // always-defaulted `validated` block would pollute machine config with a
-  // defaults block on every clean save (mirrors the sparse-doc semantics).
-  const machineResidue: Record<string, unknown> = {};
-  for (const key of ['capture', 'notifications'] as const) {
-    const onDisk = getAtPath(onDiskRaw, [key]) !== undefined;
-    const isDefault = YAML.stringify(validated[key]) === YAML.stringify(defaults[key]);
-    if (onDisk || !isDefault) {
-      machineResidue[key] = validated[key];
-    }
-  }
-  if (Object.keys(machineResidue).length > 0) {
-    relocateMachineFieldsFromProject(machineResidue, resolveMycoHome());
-  }
+  // Machine-tier fields (capture/notifications/daemon log fields/legacy
+  // update.channel) are dropped by ProjectConfigSchema's strip. The load-path
+  // migration (migrateLegacyProjectFields, gated by migrateTiers=true)
+  // relocates them to machine config — but updateConfig → loadConfig runs
+  // WITHOUT migrateTiers, so an un-migrated project's machine-tier values can
+  // reach saveConfig still living in myco.yaml. Were we to only strip them
+  // here, the values would be lost: not kept (project), not relocated (the
+  // migration never ran). Relocate them on the save path too — leaf-wise, so
+  // a relocated section never wipes machine-explicit leaves, and only for
+  // MEANINGFUL leaves (on-disk residue OR non-default caller values) so clean
+  // saves don't pollute machine config with defaults blocks.
+  relocateMachineFieldsFromProject(
+    validated as unknown as Record<string, unknown>,
+    onDiskRaw,
+    defaults as unknown as Record<string, unknown>,
+    resolveMycoHome(),
+  );
 
-  // Grove-tier `skills` is dropped by ProjectConfigSchema's strip, but that's
-  // only safe once a Grove is bound (the load-path migration relocates it to
+  // Grove-tier fields are dropped by ProjectConfigSchema's strip, but that's
+  // only safe once a Grove is bound (the load-path migration relocates them to
   // grove config then). On an UNBOUND project there's no Grove to migrate
-  // into, so dropping it here would lose a user-set value entirely — neither
+  // into, so dropping them here would lose user-set values entirely — neither
   // kept (project) nor migrated (grove). Mirror the load-path deferral
-  // (stripLegacyProjectFields skips skills when !hasGrove): keep the skills
-  // block in myco.yaml until a Grove is bound. The next Grove-bound load runs
-  // migrateLegacyProjectFields to lift + strip it.
+  // (stripLegacyProjectFields skips grove-tier fields when !hasGrove): retain
+  // every meaningful GROVE_TIER_FIELDS value in myco.yaml until a Grove is
+  // bound. The next Grove-bound load runs migrateLegacyProjectFields to
+  // lift + strip them.
   //
-  // Re-attach only when skills is meaningful — either already persisted on
-  // disk OR carrying a non-default value the caller just set — so clean
-  // projects aren't polluted with a grove-tier defaults block (mirrors the
-  // sparse-doc semantics: defaults never get written to myco.yaml).
+  // Meaningful = already persisted on disk OR carrying a non-default value
+  // the caller just set — so clean projects aren't polluted with grove-tier
+  // defaults blocks (mirrors the sparse-doc semantics: defaults never get
+  // written to myco.yaml). Sub-path entries compare at the LEAF, not the
+  // section, so stripDefaultSections below doesn't end up keeping
+  // default-valued sparse leaves inside an otherwise non-default section.
   const groveId = loadProjectManifest(vaultDir)?.grove?.id ?? null;
   if (groveId === null) {
-    const onDisk = getAtPath(onDiskRaw, ['skills']) !== undefined;
-    const isDefault = YAML.stringify(validated.skills) === YAML.stringify(defaults.skills);
-    if (onDisk || !isDefault) {
-      setAtPath(projectOnly, ['skills'], validated.skills);
+    for (const segments of GROVE_TIER_FIELDS) {
+      const value = getAtPath(validated as unknown as Record<string, unknown>, segments);
+      if (value === undefined) continue; // cleared/optional — nothing to retain
+      const defaultValue = getAtPath(defaults as unknown as Record<string, unknown>, segments);
+      const onDisk = getAtPath(onDiskRaw, segments) !== undefined;
+      // Explicit both-undefined guard: YAML.stringify(undefined) returns
+      // undefined, which would make two absent values compare "equal" only
+      // by accident — state it directly instead.
+      const differsFromDefault = defaultValue === undefined
+        ? true
+        : YAML.stringify(value) !== YAML.stringify(defaultValue);
+      if (onDisk || differsFromDefault) {
+        setAtPath(projectOnly, segments, value);
+      }
     }
   }
 
@@ -705,6 +945,25 @@ export function loadLocalConfig(vaultDir: string): Partial<MycoConfig> {
   return doc as Partial<MycoConfig>;
 }
 
+/**
+ * True when the personal overlay file EXISTS, is non-empty, and cannot be
+ * honored (YAML parse failure or a non-mapping root). Deliberately separate
+ * from `loadLocalConfig`, whose `{}`-on-malformed return contract is pinned
+ * by callers — this classifier lets `loadMergedConfig` fail closed without
+ * changing that contract. A missing or empty file is NOT unreadable.
+ */
+function isLocalOverlayUnreadable(filePath: string): boolean {
+  if (!fs.existsSync(filePath)) return false;
+  const raw = fs.readFileSync(filePath, 'utf-8').trim();
+  if (!raw) return false;
+  try {
+    const parsed: unknown = YAML.parse(raw);
+    return !parsed || typeof parsed !== 'object' || Array.isArray(parsed);
+  } catch {
+    return true;
+  }
+}
+
 export function migrateLegacyLocalAppearanceToGrove(
   vaultDir: string,
   groveId: string | null,
@@ -796,7 +1055,13 @@ export function invalidateMergedConfigCache(vaultDir?: string): void {
     mergedConfigCache.clear();
     return;
   }
-  mergedConfigCache.delete(vaultDir);
+  // Entries are keyed `${vaultDir}::${groveId ?? ''}` — drop every Grove
+  // variant for this vault.
+  for (const key of mergedConfigCache.keys()) {
+    if (key === vaultDir || key.startsWith(`${vaultDir}::`)) {
+      mergedConfigCache.delete(key);
+    }
+  }
 }
 
 export interface LoadMergedConfigOptions {
@@ -868,6 +1133,25 @@ export function loadMergedConfig(vaultDir: string, options: LoadMergedConfigOpti
   const stage1 = deepMergeConfig(pruneToTier(machineRaw, 'machine'), pruneToTier(groveRaw, 'grove'));
   const stage2 = deepMergeConfig(stage1, pruneToTier(projectRaw, 'project'));
   const stage3 = deepMergeConfig(stage2, pruneToTier(local as Record<string, unknown>, 'local'));
+
+  // Fail closed when the personal overlay exists but can't be honored.
+  // local.yaml is where capability OFF-gates live (capture-only projects);
+  // loadLocalConfig returns {} for a corrupt file, which would silently
+  // re-enable every capability (`capabilityEnabled` is `!== false`). Force
+  // every capability master gate off until the file is fixed or removed.
+  if (isLocalOverlayUnreadable(localPath)) {
+    for (const capability of Object.values(CAPABILITIES)) {
+      setAtPath(stage3, capability.masterGate.split('.'), false);
+    }
+    recordTierParseFailure(
+      localPath,
+      'personal overlay is unreadable — all capabilities forced off until it is fixed or removed',
+    );
+  } else {
+    // A readable overlay clears the failure record so re-corruption notifies.
+    tierParseFailures.delete(localPath);
+  }
+
   const result = MycoConfigSchema.parse(stage3);
 
   // Re-stat after load — loadConfig may have written a migrated file back.

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -662,6 +662,28 @@ export const GROVE_PROMOTED_FIELDS: ReadonlyArray<readonly string[]> = [
   ['agent', 'cold_project_threshold_days'],
 ];
 
+/**
+ * Grove-tier field paths that may appear in a project myco.yaml as legacy
+ * residue. They can only be safely stripped from the project file when a
+ * Grove is bound (so the value migrates instead of vanishing); on UNBOUND
+ * projects both the load and save paths retain them in myco.yaml. Shared by
+ * `stripLegacyProjectFields`, `migrateLegacyProjectFields`, and `saveConfig`
+ * so all three move/retain the exact same set.
+ */
+export const GROVE_TIER_FIELDS: ReadonlyArray<readonly string[]> = [
+  ['daemon', 'stale_session_threshold_ms'],
+  ['backup'],
+  ['maintenance'],
+  ['embedding', 'run_in_deep_sleep'],
+  ['agent', 'scheduled_tasks_active_window_days'],
+  ['appearance'],
+  ['team'],
+  ...GROVE_PROMOTED_FIELDS,
+  // 2026-06: skills.* is Grove-tier; only strip once a Grove is bound so
+  // the value can be migrated rather than dropped.
+  ['skills'],
+];
+
 /** Field paths the loader silently strips from project myco.yaml on load. */
 export const PROJECT_TIER_LEGACY_FIELDS: ReadonlyArray<readonly string[]> = [
   ['daemon', 'port'],

--- a/packages/myco/src/config/scope.ts
+++ b/packages/myco/src/config/scope.ts
@@ -97,13 +97,24 @@ export function tierAllowsPath(tier: Tier, path: string): boolean {
   return e.home === tier || e.overridableBy.includes(tier);
 }
 
+/** Unknown paths already warned about — one stderr line per path per process. */
+const warnedUnknownPaths = new Set<string>();
+
 /** Return a copy of `raw` keeping only leaf paths this tier may contribute.
- *  Sparse: no defaults injected; unknown paths are dropped. */
+ *  Sparse: no defaults injected; unknown paths are dropped (fail-closed),
+ *  with a one-time stderr warning per path so the drop is observable. */
 export function pruneToTier(raw: Record<string, unknown>, tier: Tier): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const leaf of enumerateLeafPaths(raw)) {
     let allowed = false;
-    try { allowed = tierAllowsPath(tier, leaf); } catch { allowed = false; }
+    try {
+      allowed = tierAllowsPath(tier, leaf);
+    } catch {
+      if (!warnedUnknownPaths.has(leaf)) {
+        warnedUnknownPaths.add(leaf);
+        process.stderr.write(`[myco config] Unknown config path "${leaf}" has no scope registry entry; dropping it from the ${tier} tier\n`);
+      }
+    }
     if (!allowed) continue;
     const parts = leaf.split('.');
     let src: any = raw, dst: any = out;

--- a/packages/myco/src/daemon/api/agent-tasks.ts
+++ b/packages/myco/src/daemon/api/agent-tasks.ts
@@ -25,7 +25,8 @@ import {
 } from '@myco/agent/registry.js';
 import { resolveDefinitionsDir } from '@myco/agent/loader.js';
 import { USER_TASK_SOURCE } from '@myco/constants.js';
-import { loadMergedConfig, updateConfig, loadGroveConfig, saveGroveConfig } from '../../config/loader.js';
+import { z } from 'zod';
+import { loadMergedConfig, updateConfig, loadGroveConfig, updateTierConfigRaw, TierConfigUnreadableError } from '../../config/loader.js';
 import {
   capabilityEnabled,
   effectiveTaskScheduleEnabled,
@@ -33,6 +34,8 @@ import {
 } from '../../config/capabilities.js';
 import { withTaskConfig } from '../../config/updates.js';
 import type { TaskConfigUpdate } from '../../config/updates.js';
+import { setAtPath, unsetAtPath } from '../../utils/dot-path.js';
+import type { TaskProviderOverride } from '../../config/schema.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 
 // ---------------------------------------------------------------------------
@@ -362,25 +365,49 @@ export async function handleUpdateTaskConfig(
   }
 
   if (groveId) {
-    let updatedTasks;
+    let updatedTask: TaskProviderOverride | undefined;
     try {
       const groveConfig = loadGroveConfig(groveId);
       const updated = withTaskConfig(groveConfig, taskId, body);
-      updatedTasks = updated.agent.tasks;
-      saveGroveConfig(groveId, {
-        ...groveConfig,
-        agent: { ...groveConfig.agent, tasks: updatedTasks },
+      updatedTask = updated.agent.tasks?.[taskId];
+      // Verbatim subtree replace of THIS task only via setAtPath/unsetAtPath:
+      // task updates DELETE keys (null fields, emptied entries), so a deep
+      // merge would resurrect them from the raw doc — while replacing the
+      // whole agent.tasks map would rewrite sibling tasks from the Zod view,
+      // dropping any raw content (e.g. fields from a newer build) they carry.
+      updateTierConfigRaw({ kind: 'grove', groveId }, (rawDoc) => {
+        if (updatedTask === undefined) {
+          unsetAtPath(rawDoc, ['agent', 'tasks', taskId], { pruneEmptyParents: true });
+        } else {
+          setAtPath(rawDoc, ['agent', 'tasks', taskId], updatedTask);
+        }
+        return rawDoc;
       });
     } catch (err) {
+      if (err instanceof TierConfigUnreadableError) {
+        return {
+          status: 422,
+          body: {
+            error: 'tier_config_unreadable',
+            message: 'The on-disk grove config is invalid — fix or remove it before writing.',
+            file: err.filePath,
+          },
+        };
+      }
+      if (err instanceof z.ZodError) {
+        return { status: 422, body: { error: 'validation_failed', issues: err.issues } };
+      }
       return { status: HTTP_BAD_REQUEST, body: { error: (err as Error).message } };
     }
     return {
       status: HTTP_OK,
-      body: { taskId, config: updatedTasks?.[taskId] ?? null },
+      body: { taskId, config: updatedTask ?? null },
     };
   }
 
-  // No Grove bound — fall back to project-tier myco.yaml write.
+  // No Grove bound — write agent.tasks at project tier via updateConfig.
+  // saveConfig retains grove-tier values in myco.yaml while the project is
+  // unbound, and the next Grove-bound load lifts them into grove config.
   let updated;
   try {
     updated = updateConfig(vaultDir, (config) =>

--- a/packages/myco/src/daemon/api/backup.ts
+++ b/packages/myco/src/daemon/api/backup.ts
@@ -27,8 +27,9 @@ import {
 import { restoreViaChild } from '@myco/backup/restore-runner.js';
 import { RestoreJobRegistry } from '@myco/backup/restore-jobs.js';
 import type { RestoreResult } from '@myco/backup/engine.js';
-import { loadMergedConfig, loadGroveConfig, saveGroveConfig } from '../../config/loader.js';
-import { GroveConfigSchema } from '../../config/schema.js';
+import { z } from 'zod';
+import { loadMergedConfig, updateTierConfigRaw, TierConfigUnreadableError } from '../../config/loader.js';
+import { setAtPath, unsetAtPath } from '../../utils/dot-path.js';
 import { loadGroveRecord, listGroves, type GroveRecord } from '../../grove/registry.js';
 import { resolveGroveDir, resolveGroveDbPath, resolveMycoHome, currentDaemonVariant } from '../../grove/paths.js';
 import type { GroveRuntimeCache } from '../grove-runtime-cache.js';
@@ -357,12 +358,28 @@ export function createBackupConfigHandlers(deps: BackupConfigDeps) {
       return { status: 404, body: { error: 'no_grove_in_context' } };
     }
     const { dir } = req.body as { dir?: string | null };
-    const current = loadGroveConfig(groveId);
-    const next = GroveConfigSchema.parse({
-      ...current,
-      backup: { ...current.backup, dir: dir || undefined },
-    });
-    saveGroveConfig(groveId, next);
+    try {
+      updateTierConfigRaw({ kind: 'grove', groveId }, (rawDoc) => {
+        if (dir) setAtPath(rawDoc, ['backup', 'dir'], dir);
+        else unsetAtPath(rawDoc, ['backup', 'dir'], { pruneEmptyParents: true });
+        return rawDoc;
+      }, { mycoHome });
+    } catch (err) {
+      if (err instanceof TierConfigUnreadableError) {
+        return {
+          status: 422,
+          body: {
+            error: 'tier_config_unreadable',
+            message: 'The on-disk grove config is invalid — fix or remove it before writing.',
+            file: err.filePath,
+          },
+        };
+      }
+      if (err instanceof z.ZodError) {
+        return { status: 422, body: { error: 'validation_failed', issues: err.issues } };
+      }
+      throw err;
+    }
     return { body: { dir: dir || null } };
   }
 

--- a/packages/myco/src/daemon/api/config.ts
+++ b/packages/myco/src/daemon/api/config.ts
@@ -5,21 +5,21 @@ import {
   loadMergedConfig,
   loadLocalConfig,
   loadGroveConfig,
-  saveGroveConfig,
   loadMachineConfig,
-  saveMachineConfig,
   deepMergeConfig,
   migrateLegacyLocalAppearanceToGrove,
+  updateTierConfigRaw,
+  TierConfigUnreadableError,
+  type TierWriteTarget,
 } from '../../config/loader.js';
 import { z } from 'zod';
 import {
   MycoConfigSchema,
-  GroveConfigSchema,
-  MachineConfigSchema,
   type MycoConfig,
   type GroveConfig,
   type MachineConfig,
 } from '../../config/schema.js';
+import { tierAllowsPath, type Tier } from '../../config/scope.js';
 import { getAtPath, setAtPath, unsetAtPath } from '../../utils/dot-path.js';
 import { enumerateLeafPaths } from '../config-reactions/touched-paths.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
@@ -96,6 +96,40 @@ function pathsOverlap(a: string, b: string): boolean {
 }
 
 /**
+ * Registry-driven write gate, shared by the scoped and tier PUT handlers.
+ * Returns the subset of `paths` the given tier may NOT write: paths whose
+ * scope registry entry names a different home with no override for this
+ * tier, plus paths the registry doesn't know at all (scopePolicyForPath
+ * throws → fail closed). Callers reject the write with a 400 listing them.
+ *
+ * Only value-INTRODUCING paths (patch leaves + addToList) are gated; clears
+ * and removeFromList stay exempt so stale wrong-tier residue remains
+ * deletable through the same API that created it.
+ */
+function scopeViolations(tier: Tier, paths: string[]): string[] {
+  const offending: string[] = [];
+  for (const p of paths) {
+    try {
+      if (!tierAllowsPath(tier, p)) offending.push(p);
+    } catch {
+      offending.push(p);
+    }
+  }
+  return offending;
+}
+
+function scopeViolationResponse(tier: Tier, paths: string[]): RouteResponse {
+  return {
+    status: 400,
+    body: {
+      error: 'scope_violation',
+      message: `These config paths are not writable at the ${tier} scope`,
+      paths,
+    },
+  };
+}
+
+/**
  * PUT /api/config/scoped — atomic patch + clear + list-delta against project or local config.
  *
  * Request body:
@@ -114,7 +148,7 @@ export async function handlePutScopedConfig(vaultDir: string, body: unknown): Pr
   if (!isScopedConfigScope(payload.scope)) {
     return { status: 400, body: { error: 'scope must be project or local' } };
   }
-  const scope = payload.scope;
+  const scope = payload.scope as 'project' | 'local';
   const patch = payload.patch ?? {};
   const clearListOrError = validateClearList(payload.clear);
   if (Array.isArray(clearListOrError) === false) return clearListOrError;
@@ -140,24 +174,16 @@ export async function handlePutScopedConfig(vaultDir: string, body: unknown): Pr
   if (overlap.length > 0) {
     return { status: 400, body: { error: 'patch_clear_overlap', keys: overlap } };
   }
-  // List-delta ops write config paths too, so they pass through the same
-  // path-based scope guards as patch/clear — a list-delta targeting
-  // appearance.* gets the specific 400 below, not a generic validation_failed.
-  const listOpPaths = [...addOpsOrError, ...removeOpsOrError].map((op) => op.path);
-  const appearancePaths = [
-    ...patchLeaves.filter((leaf) => pathsOverlap(leaf, 'appearance')),
-    ...clearList.filter((clearPath) => pathsOverlap(clearPath, 'appearance')),
-    ...listOpPaths.filter((opPath) => pathsOverlap(opPath, 'appearance')),
-  ];
-  if (appearancePaths.length > 0) {
-    return {
-      status: 400,
-      body: {
-        error: 'appearance_is_grove_scoped',
-        message: 'appearance settings must be written through Grove config',
-        keys: appearancePaths,
-      },
-    };
+  // Registry-driven scope gate: value-introducing writes (patch + addToList)
+  // against a path this scope doesn't own get a 400 instead of the old
+  // 200-then-vanish (pruneToTier silently dropped them at merge time).
+  // Clears and removeFromList stay exempt so stale residue is deletable.
+  const violations = scopeViolations(scope, [
+    ...patchLeaves,
+    ...addOpsOrError.map((op) => op.path),
+  ]);
+  if (violations.length > 0) {
+    return scopeViolationResponse(scope, violations);
   }
 
   if (scope === 'local') {
@@ -292,6 +318,9 @@ function applyListDeltas(
 
   for (const op of removeOps) {
     const existing = getAtPath(working, op.path);
+    // Nothing at the path → nothing to remove. Skip the write so an exempt
+    // removeFromList of an absent path can't plant an empty array as residue.
+    if (existing === undefined) continue;
     const arr = Array.isArray(existing) ? existing : [];
     setAtPath(working, op.path, arr.filter((v) => !op.values.includes(v)));
     touchedPaths.push(op.path);
@@ -301,9 +330,13 @@ function applyListDeltas(
 }
 
 interface TierPutOptions<TConfig> {
-  load: () => TConfig;
-  save: (validated: TConfig) => void;
-  validate: (merged: unknown) => TConfig;
+  /** Tier name for the registry-driven scope gate. */
+  tier: Tier;
+  /** Write target routed through `updateTierConfigRaw`. */
+  target: TierWriteTarget;
+  /** Zod-defaulted view — list-delta results are computed against this so
+   *  schema-default array members aren't lost on sparse files. */
+  loadView: () => TConfig;
   /** Optional patch sanitizer — strip fields the user can't write to this tier. */
   sanitizePatch?: (patch: Record<string, unknown>) => Record<string, unknown>;
   /**
@@ -316,10 +349,12 @@ interface TierPutOptions<TConfig> {
 }
 
 /**
- * Shared PUT handler for tier config files (Grove, Machine). Loads
- * current, applies sanitized patch and any list-delta ops, validates,
- * persists, returns the canonical post-merge value plus touched leaf
- * paths so the caller can fire `applyConfigWriteReactions`.
+ * Shared PUT handler for tier config files (Grove, Machine). Applies the
+ * sanitized patch and any list-delta ops through `updateTierConfigRaw` — the
+ * RAW on-disk doc is mutated and persisted, so unknown keys survive the
+ * write and a corrupt file is refused (422) instead of being wiped. Returns
+ * the canonical Zod-parsed full config plus touched leaf paths so the
+ * caller can fire `applyConfigWriteReactions`.
  *
  * Request body may contain any combination of:
  *   patch          — deep-merged into the current config
@@ -351,14 +386,14 @@ async function handlePutTierConfig<TConfig>(
     : (incoming as Record<string, unknown>);
   // Drop list-delta ops targeting protected paths, mirroring how
   // `sanitizePatch` strips the same field from `patch`.
-  const addOpsOrError = options.isProtectedPath
+  const addOps = options.isProtectedPath
     ? addOpsRaw.filter((op) => !options.isProtectedPath!(op.path))
     : addOpsRaw;
-  const removeOpsOrError = options.isProtectedPath
+  const removeOps = options.isProtectedPath
     ? removeOpsRaw.filter((op) => !options.isProtectedPath!(op.path))
     : removeOpsRaw;
   const patchLeaves = enumerateLeafPaths(patch);
-  const hasListOps = addOpsOrError.length > 0 || removeOpsOrError.length > 0;
+  const hasListOps = addOps.length > 0 || removeOps.length > 0;
 
   if (patchLeaves.length === 0 && !hasListOps) {
     return {
@@ -367,21 +402,53 @@ async function handlePutTierConfig<TConfig>(
     };
   }
 
+  // Registry-driven scope gate — same contract as the scoped handler:
+  // value-introducing writes (patch + addToList) for paths this tier
+  // doesn't own are rejected; removeFromList stays exempt.
+  const violations = scopeViolations(options.tier, [
+    ...patchLeaves,
+    ...addOps.map((op) => op.path),
+  ]);
+  if (violations.length > 0) {
+    return { response: scopeViolationResponse(options.tier, violations), touchedPaths: [] };
+  }
+
   try {
-    const current = options.load();
-    let working = deepMergeConfig(
-      current as Record<string, unknown>,
-      patch as Record<string, unknown>,
-    ) as Record<string, unknown>;
-    const listTouched = applyListDeltas(working, addOpsOrError, removeOpsOrError);
-    const validated = options.validate(working);
-    options.save(validated);
-    const allTouched = [...patchLeaves, ...listTouched];
-    return { response: { body: validated }, touchedPaths: allTouched };
+    // Compute list-delta results against the Zod-DEFAULTED view so members
+    // that only exist as schema defaults on a sparse file survive the op,
+    // then write the FULL resulting array into the raw doc.
+    const working = deepMergeConfig(
+      structuredClone(options.loadView()) as Record<string, unknown>,
+      patch,
+    );
+    const listTouched = applyListDeltas(working, addOps, removeOps);
+
+    const validated = updateTierConfigRaw(options.target, (rawDoc) => {
+      const next = deepMergeConfig(rawDoc, patch);
+      for (const opPath of listTouched) {
+        setAtPath(next, opPath, getAtPath(working, opPath));
+      }
+      return next;
+    }) as TConfig;
+
+    return { response: { body: validated }, touchedPaths: [...patchLeaves, ...listTouched] };
   } catch (err) {
+    if (err instanceof TierConfigUnreadableError) {
+      return {
+        response: {
+          status: 422,
+          body: {
+            error: 'tier_config_unreadable',
+            message: 'The on-disk config file is invalid — fix or remove it before writing.',
+            file: err.filePath,
+          },
+        },
+        touchedPaths: [],
+      };
+    }
     if (err instanceof z.ZodError) {
       return {
-        response: { status: 400, body: { error: 'validation_failed', issues: err.issues } },
+        response: { status: 422, body: { error: 'validation_failed', issues: err.issues } },
         touchedPaths: [],
       };
     }
@@ -404,9 +471,9 @@ export async function handlePutGroveConfig(
     };
   }
   return handlePutTierConfig<GroveConfig>(body, {
-    load: () => loadGroveConfig(groveId),
-    save: (validated) => saveGroveConfig(groveId, validated),
-    validate: (merged) => GroveConfigSchema.parse(merged) as GroveConfig,
+    tier: 'grove',
+    target: { kind: 'grove', groveId },
+    loadView: () => loadGroveConfig(groveId),
   });
 }
 
@@ -429,9 +496,9 @@ export async function handlePutMachineConfig(
   body: unknown,
 ): Promise<{ response: RouteResponse; touchedPaths: string[] }> {
   return handlePutTierConfig<MachineConfig>(body, {
-    load: () => loadMachineConfig(),
-    save: (validated) => saveMachineConfig(validated),
-    validate: (merged) => MachineConfigSchema.parse(merged) as MachineConfig,
+    tier: 'machine',
+    target: { kind: 'machine' },
+    loadView: () => loadMachineConfig(),
     sanitizePatch: (patch) => {
       const { grove: _grove, ...rest } = patch;
       return rest;

--- a/packages/myco/src/daemon/api/update.ts
+++ b/packages/myco/src/daemon/api/update.ts
@@ -26,6 +26,7 @@ import {
   resolveRuntimeCommand,
   isManagedMachineRuntime,
 } from '../update-checker.js';
+import { TierConfigUnreadableError } from '../../config/loader.js';
 import { spawnUpdateScript, spawnRestartScript } from '../update-installer.js';
 import * as updateInProgress from '../update-in-progress.js';
 import { RELEASE_CHANNELS } from '../../constants/update.js';
@@ -392,7 +393,21 @@ export function createUpdateHandlers(deps: UpdateDeps) {
     const { channel } = parsed.data;
     const config = readUpdateConfig();
 
-    writeProjectReleaseChannel(vaultDir, channel);
+    try {
+      writeProjectReleaseChannel(vaultDir, channel);
+    } catch (err) {
+      if (err instanceof TierConfigUnreadableError) {
+        return {
+          status: 422,
+          body: {
+            error: 'tier_config_unreadable',
+            message: 'The on-disk machine config is invalid — fix or remove it before changing the channel.',
+            file: err.filePath,
+          },
+        };
+      }
+      throw err;
+    }
     clearCachedCheck();
 
     const snapshot = readVaultSnapshot();

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -10,7 +10,7 @@ import { DaemonServer } from './server.js';
 import type { RouteRequest } from './router.js';
 import { SessionRegistry } from './lifecycle.js';
 import { DaemonLogger, type Logger } from './logger.js';
-import { loadMergedConfig } from '../config/loader.js';
+import { loadMergedConfig, setTierParseFailureListener } from '../config/loader.js';
 import { TranscriptMiner } from '../capture/transcript-miner.js';
 import { createPerProjectAdapter } from '../symbionts/adapter.js';
 import { claudeCodeAdapter } from '../symbionts/claude-code.js';
@@ -1357,6 +1357,20 @@ export async function main(): Promise<void> {
 
   reactions.on(['agent.tasks'], async () => {
     await syncScheduledTasks();
+  });
+
+  // Tier config files that exist but can't be honored (corrupt YAML, value
+  // violations, unreadable personal overlay) silently revert their tier to
+  // defaults — surface each one as a settings notification. The loader
+  // dedupes per file+reason and notify()'s 5-minute window absorbs repeats.
+  setTierParseFailureListener((filePath, reason) => {
+    notify(bootstrapVaultDir, {
+      domain: 'settings',
+      type: 'settings.config_unreadable',
+      title: 'Config file could not be honored',
+      message: `${filePath}: ${reason}`,
+      metadata: { filePath, reason },
+    }, liveConfig.current, { scope: 'daemon' });
   });
 
   async function applyConfigWriteReactions(

--- a/packages/myco/src/daemon/update-checker.ts
+++ b/packages/myco/src/daemon/update-checker.ts
@@ -21,7 +21,8 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import YAML from 'yaml';
 import semver from 'semver';
-import { loadMachineConfig, saveMachineConfig } from '../config/loader.js';
+import { loadMachineConfig, updateTierConfigRaw } from '../config/loader.js';
+import { setAtPath } from '../utils/dot-path.js';
 
 import {
   NPM_REGISTRY_BASE_URL,
@@ -319,10 +320,9 @@ export function readProjectReleaseChannel(_vaultDir?: string): ReleaseChannel {
  * `vaultDir` parameter is retained for call-site compatibility only.
  */
 export function writeProjectReleaseChannel(_vaultDir: string | undefined, channel: ReleaseChannel): void {
-  const machine = loadMachineConfig();
-  saveMachineConfig({
-    ...machine,
-    daemon: { ...machine.daemon, update_channel: channel },
+  updateTierConfigRaw({ kind: 'machine' }, (rawDoc) => {
+    setAtPath(rawDoc, ['daemon', 'update_channel'], channel);
+    return rawDoc;
   });
 }
 

--- a/packages/myco/src/notifications/domains.ts
+++ b/packages/myco/src/notifications/domains.ts
@@ -62,6 +62,7 @@ export function registerBuiltinDomains(): void {
     label: 'Settings',
     types: [
       { id: 'settings.saved', label: 'Settings saved', defaultMode: 'banner', defaultLevel: 'success' },
+      { id: 'settings.config_unreadable', label: 'Config file unreadable', defaultMode: 'banner', defaultLevel: 'error' },
     ],
   });
 }

--- a/packages/myco/ui/src/hooks/use-scoped-config.ts
+++ b/packages/myco/ui/src/hooks/use-scoped-config.ts
@@ -35,9 +35,6 @@ const NOTIFICATIONS_KEY = ['notifications'] as const;
  * - `setField` writes a single field into the chosen scope by constructing
  *   a nested patch that matches the dotted path.
  * - `resetField` clears a local override so the project value shines through.
- * - `promoteField` copies the current effective value into the project
- *   config, then clears the local override — equivalent to "this was working
- *   for me, make it the team default."
  *
  * Returned callbacks are stable across re-renders (data is read through refs)
  * so consumers don't have their `useCallback` deps thrash on every refetch.
@@ -156,15 +153,6 @@ export function useScopedConfigForSelection(selection: ProjectSelection | null) 
     invalidateLocal();
   }, [contextHeaders, invalidateLocal]);
 
-  const promoteField = useCallback(async (path: ConfigPath): Promise<void> => {
-    const value = getAtPath((mergedRef.current ?? {}) as Record<string, unknown>, path);
-    const patch: Record<string, unknown> = {};
-    setAtPath(patch, path, value);
-    await writeScopedConfig('project', patch, undefined, contextHeaders);
-    await clearLocalConfigKeys([path], contextHeaders);
-    invalidateLocal();
-  }, [contextHeaders, invalidateLocal]);
-
   const isLocalOverride = useCallback(
     (path: ConfigPath): boolean =>
       getAtPath((localRef.current ?? {}) as Record<string, unknown>, path) !== undefined,
@@ -232,7 +220,6 @@ export function useScopedConfigForSelection(selection: ProjectSelection | null) 
     setFields,
     resetField,
     resetFields,
-    promoteField,
     addToConfigList,
     removeFromConfigList,
   };

--- a/packages/myco/ui/src/lib/config-paths.ts
+++ b/packages/myco/ui/src/lib/config-paths.ts
@@ -5,7 +5,7 @@ import type { MycoConfig } from '../hooks/use-config';
  *
  * `DotPaths<T>` is the union of all valid dotted paths into `T`. Used to
  * constrain the `path` prop on `<ScopedField>` and the `path` argument on
- * `useScopedConfig().setField()` / `resetField()` / `promoteField()` so a
+ * `useScopedConfig().setField()` / `resetField()` so a
  * typo at the call site is a compile error.
  *
  * `PathValue<T, P>` walks a dotted path and yields the leaf type — letting

--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -714,21 +714,69 @@ describe('Settings-scope correction (2026-06) — tier migration', () => {
     expect(merged.notifications.default_mode).toBe('banner');
   });
 
-  it('saveConfig does not clobber a newer explicit machine capture value (Fix #1 idempotence)', () => {
-    // The user already set capture explicitly in machine config. A later
-    // un-migrated project save must NOT overwrite that newer machine value —
-    // saveConfig's relocation mirrors moveMachine's "skip if target present".
+  it('saveConfig machine relocation is leaf-wise: unchanged residue never clobbers an explicit machine leaf', () => {
+    // RC-3 semantics: relocation merges LEAF-WISE into the machine doc, and a
+    // leaf may overwrite an explicit machine value only when the caller
+    // changed it in this save. Stale on-disk residue in myco.yaml is dropped
+    // by the schema strip, not relocated over the machine's newer value.
     fs.mkdirSync(path.dirname(machinePath()), { recursive: true });
-    fs.writeFileSync(machinePath(), 'capture:\n  buffer_max_events: 111\n');
+    fs.writeFileSync(
+      machinePath(),
+      'capture:\n  buffer_max_events: 111\n  transcript_paths:\n    - /machine/explicit\n',
+    );
     writeProject(tmpDir, 'version: 3\ncapture:\n  buffer_max_events: 999\n');
     const config = loadConfig(tmpDir);
 
     saveConfig(tmpDir, config);
 
-    // The explicit machine value wins; the stale project value is NOT moved over it.
+    const machineRaw = readYaml(machinePath());
+    // Unchanged residue does not clobber the machine's explicit value.
+    expect((machineRaw.capture as Record<string, unknown>).buffer_max_events).toBe(111);
+    // The machine-explicit sibling leaf survives — no block-level overwrite.
+    expect((machineRaw.capture as Record<string, unknown>).transcript_paths).toEqual(['/machine/explicit']);
+    // … and capture is still stripped from myco.yaml.
+    const persisted = readYaml(path.join(tmpDir, 'myco.yaml'));
+    expect(persisted.capture).toBeUndefined();
+  });
+
+  it('saveConfig machine relocation: a caller-changed leaf lands on machine config, siblings survive', () => {
+    // A deliberate updateConfig write of a machine-homed leaf must actually
+    // land (caller wins at leaf granularity), while machine-explicit sibling
+    // leaves are never wiped by a section-level write.
+    fs.mkdirSync(path.dirname(machinePath()), { recursive: true });
+    fs.writeFileSync(
+      machinePath(),
+      'capture:\n  buffer_max_events: 111\n  transcript_paths:\n    - /machine/explicit\n',
+    );
+    writeProject(tmpDir, 'version: 3\n');
+
+    updateConfig(tmpDir, (config) => ({
+      ...config,
+      capture: { ...config.capture, buffer_max_events: 999 },
+    }));
+
+    const machineRaw = readYaml(machinePath());
+    // The caller-set value wins at its leaf.
+    expect((machineRaw.capture as Record<string, unknown>).buffer_max_events).toBe(999);
+    // The machine-explicit sibling leaf survives.
+    expect((machineRaw.capture as Record<string, unknown>).transcript_paths).toEqual(['/machine/explicit']);
+    const persisted = readYaml(path.join(tmpDir, 'myco.yaml'));
+    expect(persisted.capture).toBeUndefined();
+  });
+
+  it('saveConfig relocation never clobbers an explicit machine leaf with a default-valued one', () => {
+    // A default-valued leaf is not "meaningful" — it must neither relocate
+    // over an explicit machine value nor pollute the machine doc.
+    fs.mkdirSync(path.dirname(machinePath()), { recursive: true });
+    fs.writeFileSync(machinePath(), 'capture:\n  buffer_max_events: 111\n');
+    // 500 is the schema default for buffer_max_events.
+    writeProject(tmpDir, 'version: 3\ncapture:\n  buffer_max_events: 500\n');
+    const config = loadConfig(tmpDir);
+
+    saveConfig(tmpDir, config);
+
     const machineRaw = readYaml(machinePath());
     expect((machineRaw.capture as Record<string, unknown>).buffer_max_events).toBe(111);
-    // … and it's still stripped from myco.yaml.
     const persisted = readYaml(path.join(tmpDir, 'myco.yaml'));
     expect(persisted.capture).toBeUndefined();
   });

--- a/tests/config/rc3-config-tier-write-safety.test.ts
+++ b/tests/config/rc3-config-tier-write-safety.test.ts
@@ -1,0 +1,411 @@
+/**
+ * RC-3 — Config tier write safety regression tests.
+ *
+ * Ports the five verified repros:
+ *   rc3a — saveConfig destroyed grove-tier values on UNBOUND projects
+ *   rc3b — wrong-tier writes returned 200 then vanished at merge time
+ *   rc3c — an unknown key default-reverted a strict tier file; the next PUT
+ *          wiped it
+ *   rc3d — corrupt local.yaml re-enabled every capability (OFF-gates lost)
+ *   rc3e — invalidateMergedConfigCache(vaultDir) was a structural no-op
+ *          against `${vaultDir}::${groveId}` keys
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import YAML from 'yaml';
+import {
+  loadConfig,
+  updateConfig,
+  loadMergedConfig,
+  invalidateMergedConfigCache,
+  loadMachineConfig,
+  setTierParseFailureListener,
+} from '@myco/config/loader';
+import { CURRENT_MIGRATION_VERSION } from '@myco/config/migrations';
+import { clearProjectManifestCache } from '@myco/config/project-manifest';
+import { CAPABILITIES, capabilityEnabled } from '@myco/config/capabilities';
+import type { CapabilityId } from '@myco/config/scope';
+import { getAtPath } from '@myco/utils/dot-path';
+import {
+  handlePutScopedConfig,
+  handlePutMachineConfig,
+  handleGetMachineConfig,
+} from '@myco/daemon/api/config';
+import { handleUpdateTaskConfig } from '@myco/daemon/api/agent-tasks';
+import type { RouteRequest } from '@myco/daemon/router';
+import type { MachineConfig } from '@myco/config/schema';
+import { sandboxMycoHome } from '../helpers/myco-home-sandbox';
+
+describe('RC-3 — config tier write safety', () => {
+  let sandbox: ReturnType<typeof sandboxMycoHome>;
+  let mycoHome: string;
+  let vaultDir: string;
+  const groveId = 'grove_' + 'd'.repeat(32);
+
+  function configPath(): string {
+    return path.join(vaultDir, 'myco.yaml');
+  }
+  function localPath(): string {
+    return path.join(vaultDir, 'local.yaml');
+  }
+  function machinePath(): string {
+    return path.join(mycoHome, 'config.yaml');
+  }
+  function grovePath(): string {
+    return path.join(mycoHome, 'groves', groveId, 'grove.yaml');
+  }
+  function writeProject(yaml: string): void {
+    fs.writeFileSync(configPath(), yaml);
+  }
+  function readYaml(p: string): Record<string, unknown> {
+    return (YAML.parse(fs.readFileSync(p, 'utf-8')) ?? {}) as Record<string, unknown>;
+  }
+  function bindGrove(): void {
+    // Minimal project.toml that loadProjectManifest can resolve a grove.id from.
+    fs.writeFileSync(
+      path.join(vaultDir, 'project.toml'),
+      `[project]\nid = "proj_${'e'.repeat(32)}"\nname = "rc3-test"\n\n[grove]\nid = "${groveId}"\nslug = "rc3-grove"\nmode = "local"\n`,
+    );
+    clearProjectManifestCache();
+  }
+
+  beforeEach(() => {
+    sandbox = sandboxMycoHome('myco-rc3-home-');
+    mycoHome = sandbox.mycoHome;
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-rc3-vault-'));
+    invalidateMergedConfigCache();
+    clearProjectManifestCache();
+  });
+
+  afterEach(() => {
+    setTierParseFailureListener(null);
+    sandbox.restore();
+    fs.rmSync(vaultDir, { recursive: true, force: true });
+    invalidateMergedConfigCache();
+    clearProjectManifestCache();
+  });
+
+  // -------------------------------------------------------------------------
+  // rc3a — unbound retention + Grove-bind lift
+  // -------------------------------------------------------------------------
+
+  it('rc3a: unbound project retains user-set grove-tier values across an unrelated updateConfig', () => {
+    writeProject([
+      'version: 3',
+      'team:',
+      '  enabled: true',
+      '  team_id: team-rc3',
+      'backup:',
+      '  dir: /tmp/rc3-backups',
+      'agent:',
+      '  model: claude-opus-4-6',
+      '  tasks:',
+      '    vault-evolve:',
+      '      maxTurns: 7',
+      'release_provenance:',
+      '  enabled: true',
+      '',
+    ].join('\n'));
+
+    // One unrelated project-tier write must not destroy grove-tier values.
+    updateConfig(vaultDir, (config) => ({
+      ...config,
+      release_provenance: { ...config.release_provenance, enabled: false },
+    }));
+
+    const persisted = readYaml(configPath());
+    expect((persisted.team as Record<string, unknown>).enabled).toBe(true);
+    expect((persisted.team as Record<string, unknown>).team_id).toBe('team-rc3');
+    expect((persisted.backup as Record<string, unknown>).dir).toBe('/tmp/rc3-backups');
+    expect(getAtPath(persisted, 'agent.model')).toBe('claude-opus-4-6');
+    expect(getAtPath(persisted, 'agent.tasks.vault-evolve.maxTurns')).toBe(7);
+    expect(getAtPath(persisted, 'release_provenance.enabled')).toBe(false);
+  });
+
+  it('rc3a: binding a Grove lifts the retained values into grove.yaml and strips them from myco.yaml', () => {
+    writeProject([
+      'version: 3',
+      'team:',
+      '  enabled: true',
+      '  team_id: team-rc3',
+      'backup:',
+      '  dir: /tmp/rc3-backups',
+      'agent:',
+      '  model: claude-opus-4-6',
+      '  tasks:',
+      '    vault-evolve:',
+      '      maxTurns: 7',
+      '',
+    ].join('\n'));
+    // Retention round-trip first (unbound).
+    updateConfig(vaultDir, (config) => config);
+
+    bindGrove();
+    // The merged load resolves groveId from the manifest and runs migrateTiers.
+    loadMergedConfig(vaultDir, { mycoHome });
+
+    const grove = readYaml(grovePath());
+    expect(getAtPath(grove, 'team.enabled')).toBe(true);
+    expect(getAtPath(grove, 'team.team_id')).toBe('team-rc3');
+    expect(getAtPath(grove, 'backup.dir')).toBe('/tmp/rc3-backups');
+    expect(getAtPath(grove, 'agent.model')).toBe('claude-opus-4-6');
+    expect(getAtPath(grove, 'agent.tasks.vault-evolve.maxTurns')).toBe(7);
+
+    const persisted = readYaml(configPath());
+    expect(persisted.team).toBeUndefined();
+    expect(persisted.backup).toBeUndefined();
+    expect(persisted.agent).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // rc3b — write surfaces consult the scope registry
+  // -------------------------------------------------------------------------
+
+  it('rc3b: wrong-tier scoped patches are rejected with a 400 listing the paths', async () => {
+    writeProject('version: 3\n');
+
+    // Grove-homed path at project scope.
+    const project = await handlePutScopedConfig(vaultDir, {
+      scope: 'project',
+      patch: { team: { enabled: true } },
+    });
+    expect(project.status).toBe(400);
+    expect((project.body as Record<string, unknown>).error).toBe('scope_violation');
+    expect((project.body as Record<string, unknown>).paths).toEqual(['team.enabled']);
+
+    // Non-overridable (grove-locked) path at local scope.
+    const local = await handlePutScopedConfig(vaultDir, {
+      scope: 'local',
+      patch: { embedding: { model: 'nomic-embed-text' } },
+    });
+    expect(local.status).toBe(400);
+    expect((local.body as Record<string, unknown>).error).toBe('scope_violation');
+    expect((local.body as Record<string, unknown>).paths).toEqual(['embedding.model']);
+  });
+
+  it('rc3b: clears of the same wrong-tier paths stay exempt (residue remains deletable)', async () => {
+    writeProject('version: 3\nteam:\n  enabled: true\n');
+    fs.writeFileSync(localPath(), 'embedding:\n  model: stale-model\n');
+
+    const clearProject = await handlePutScopedConfig(vaultDir, {
+      scope: 'project',
+      clear: ['team.enabled'],
+    });
+    expect(clearProject.status).toBeUndefined();
+
+    const clearLocal = await handlePutScopedConfig(vaultDir, {
+      scope: 'local',
+      clear: ['embedding.model'],
+    });
+    expect(clearLocal.status).toBeUndefined();
+    const localRaw = readYaml(localPath());
+    // The leaf is gone (an empty parent object may remain — clears don't
+    // prune parents on the local path).
+    expect(getAtPath(localRaw, 'embedding.model')).toBeUndefined();
+  });
+
+  it('rc3b: tier PUTs reject patches for paths the tier does not own', async () => {
+    const res = await handlePutMachineConfig({
+      patch: { team: { enabled: true } },
+    });
+    expect(res.response.status).toBe(400);
+    expect((res.response.body as Record<string, unknown>).error).toBe('scope_violation');
+    expect((res.response.body as Record<string, unknown>).paths).toEqual(['team.enabled']);
+  });
+
+  it('rc3b: agent-tasks no-Grove fallback persists agent.tasks in myco.yaml', async () => {
+    writeProject('version: 3\n');
+    const req = {
+      params: { id: 'vault-evolve' },
+      query: {},
+      body: { maxTurns: 9 },
+    } as unknown as RouteRequest;
+
+    const res = await handleUpdateTaskConfig(req, vaultDir, null);
+    expect(res.status).toBe(200);
+
+    const persisted = readYaml(configPath());
+    expect(getAtPath(persisted, 'agent.tasks.vault-evolve.maxTurns')).toBe(9);
+    // Retain-until-Grove-bind: the value persists in myco.yaml (where the
+    // scope-aware merge deliberately ignores grove-homed strays); rc3a
+    // covers the lift that makes it effective once a Grove binds.
+  });
+
+  // -------------------------------------------------------------------------
+  // rc3c — strict tier files: salvage unknown keys, refuse corrupt writes
+  // -------------------------------------------------------------------------
+
+  it('rc3c: an unknown key in machine config is salvaged (known values honored, not defaults)', () => {
+    fs.mkdirSync(path.dirname(machinePath()), { recursive: true });
+    fs.writeFileSync(machinePath(), 'daemon:\n  log_level: debug\nfuture_key: 1\n');
+
+    const machine = loadMachineConfig();
+    expect(machine.daemon.log_level).toBe('debug');
+  });
+
+  it('rc3c: a machine PUT preserves the unknown key on disk and does not destroy values', async () => {
+    fs.mkdirSync(path.dirname(machinePath()), { recursive: true });
+    fs.writeFileSync(machinePath(), 'daemon:\n  log_level: debug\nfuture_key: 1\n');
+
+    const res = await handlePutMachineConfig({
+      patch: { daemon: { log_retention_days: 60 } },
+    });
+    expect(res.response.status).toBeUndefined();
+    expect((res.response.body as MachineConfig).daemon.log_retention_days).toBe(60);
+
+    const raw = readYaml(machinePath());
+    expect(raw.future_key).toBe(1);
+    expect(getAtPath(raw, 'daemon.log_level')).toBe('debug');
+    expect(getAtPath(raw, 'daemon.log_retention_days')).toBe(60);
+  });
+
+  it('rc3c: a corrupt machine file makes the PUT 422 and leaves the file untouched', async () => {
+    const corrupt = 'daemon: [unterminated\n';
+    fs.mkdirSync(path.dirname(machinePath()), { recursive: true });
+    fs.writeFileSync(machinePath(), corrupt);
+
+    const res = await handlePutMachineConfig({
+      patch: { daemon: { log_retention_days: 60 } },
+    });
+    expect(res.response.status).toBe(422);
+    expect((res.response.body as Record<string, unknown>).error).toBe('tier_config_unreadable');
+    expect(fs.readFileSync(machinePath(), 'utf-8')).toBe(corrupt);
+  });
+
+  // -------------------------------------------------------------------------
+  // rc3d — corrupt local.yaml fails closed on capabilities
+  // -------------------------------------------------------------------------
+
+  it('rc3d: a corrupt local.yaml forces every capability master gate off', () => {
+    writeProject('version: 3\n');
+    // Capture-only project shape: every master gate explicitly off in
+    // local.yaml — then the file gets corrupted.
+    fs.writeFileSync(localPath(), [
+      'cortex:',
+      '  enabled: false',
+      'skills:',
+      '  enabled: false',
+      'vault_evolution:',
+      '  enabled: false',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(localPath(), '{ broken: yaml');
+
+    const failures: Array<{ filePath: string; reason: string }> = [];
+    setTierParseFailureListener((filePath, reason) => failures.push({ filePath, reason }));
+
+    const merged = loadMergedConfig(vaultDir, { groveId: null, mycoHome });
+    for (const id of Object.keys(CAPABILITIES) as CapabilityId[]) {
+      expect(getAtPath(merged, CAPABILITIES[id].masterGate)).toBe(false);
+      expect(capabilityEnabled(merged, id)).toBe(false);
+    }
+    expect(failures.some((f) => f.filePath === localPath())).toBe(true);
+  });
+
+  it('rc3d: a scalar-root local.yaml also fails closed; an empty one stays a no-op', () => {
+    writeProject('version: 3\n');
+    fs.writeFileSync(localPath(), 'sage');
+    const merged = loadMergedConfig(vaultDir, { groveId: null, mycoHome });
+    for (const id of Object.keys(CAPABILITIES) as CapabilityId[]) {
+      expect(capabilityEnabled(merged, id)).toBe(false);
+    }
+
+    // Empty file: capabilities stay default-on.
+    fs.writeFileSync(localPath(), '');
+    invalidateMergedConfigCache();
+    const mergedEmpty = loadMergedConfig(vaultDir, { groveId: null, mycoHome });
+    for (const id of Object.keys(CAPABILITIES) as CapabilityId[]) {
+      expect(capabilityEnabled(mergedEmpty, id)).toBe(true);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // rc3e — per-vault merged-cache invalidation
+  // -------------------------------------------------------------------------
+
+  it('rc3e: invalidateMergedConfigCache(vaultDir) drops the grove-keyed entry (frozen-fingerprint A→B)', () => {
+    const FIXED = new Date(1_700_000_000_000);
+    const yamlA = `version: 3\nconfig_version: ${CURRENT_MIGRATION_VERSION}\nrelease_provenance:\n  production_refs:\n    - refs/tags/aaa\n`;
+    const yamlB = yamlA.replace('refs/tags/aaa', 'refs/tags/bbb');
+    expect(yamlA.length).toBe(yamlB.length); // same size — fingerprint can't see the change
+
+    writeProject(yamlA);
+    fs.utimesSync(configPath(), FIXED, FIXED);
+    const first = loadMergedConfig(vaultDir, { groveId: null, mycoHome });
+    expect(first.release_provenance.production_refs).toEqual(['refs/tags/aaa']);
+
+    writeProject(yamlB);
+    fs.utimesSync(configPath(), FIXED, FIXED);
+    // Setup sanity: the frozen mtime+size really does serve the stale entry.
+    const stale = loadMergedConfig(vaultDir, { groveId: null, mycoHome });
+    expect(stale.release_provenance.production_refs).toEqual(['refs/tags/aaa']);
+
+    invalidateMergedConfigCache(vaultDir);
+    const fresh = loadMergedConfig(vaultDir, { groveId: null, mycoHome });
+    expect(fresh.release_provenance.production_refs).toEqual(['refs/tags/bbb']);
+  });
+
+  // -------------------------------------------------------------------------
+  // List-delta against sparse tier files
+  // -------------------------------------------------------------------------
+
+  it('list-delta on a sparse machine file keeps schema-default array members', async () => {
+    // No machine file at all — capture.artifact_extensions exists only as
+    // the schema default ['.md']. The op must compute against the defaulted
+    // view and write the FULL resulting array.
+    const res = await handlePutMachineConfig({
+      addToList: [{ path: 'capture.artifact_extensions', values: ['.py'] }],
+    });
+    expect(res.response.status).toBeUndefined();
+
+    const raw = readYaml(machinePath());
+    expect(getAtPath(raw, 'capture.artifact_extensions')).toEqual(['.md', '.py']);
+    const view = await handleGetMachineConfig();
+    expect((view.body as { config: MachineConfig }).config.capture.artifact_extensions)
+      .toEqual(['.md', '.py']);
+  });
+});
+
+describe('RC-3: tier-parse-failure listener replay (boot ordering)', () => {
+  let sandbox: ReturnType<typeof sandboxMycoHome>;
+
+  beforeEach(() => {
+    sandbox = sandboxMycoHome('myco-rc3-listener-');
+  });
+
+  afterEach(() => {
+    setTierParseFailureListener(null);
+    sandbox.restore();
+  });
+
+  function machineFile(): string {
+    return path.join(sandbox.mycoHome, 'config.yaml');
+  }
+
+  it('replays failures recorded before the listener registers, and re-notifies after fix-then-recorrupt', () => {
+    // The daemon loads config at boot BEFORE wiring its listener; a file
+    // already corrupt at startup must still produce a notification.
+    fs.mkdirSync(path.dirname(machineFile()), { recursive: true });
+    fs.writeFileSync(machineFile(), ':\nnot yaml: [\n');
+    loadMachineConfig(sandbox.mycoHome);
+
+    // Filter to this test's file: earlier tests in this process may have
+    // recorded failures for their own (still-existing) sandbox files.
+    const seen: Array<{ filePath: string; reason: string }> = [];
+    setTierParseFailureListener((filePath, reason) => {
+      if (filePath === machineFile()) seen.push({ filePath, reason });
+    });
+    expect(seen.length).toBe(1);
+
+    // A clean read clears the record…
+    fs.writeFileSync(machineFile(), 'daemon:\n  log_level: debug\n');
+    loadMachineConfig(sandbox.mycoHome);
+
+    // …so re-corrupting the SAME file with the SAME failure shape notifies again.
+    fs.writeFileSync(machineFile(), ':\nnot yaml: [\n');
+    loadMachineConfig(sandbox.mycoHome);
+    expect(seen.length).toBe(2);
+  });
+});

--- a/tests/config/tier-dispatch.test.ts
+++ b/tests/config/tier-dispatch.test.ts
@@ -116,28 +116,32 @@ describe('Tier dispatch', () => {
     expect(groveDoc.daemon.update_channel).toBeUndefined();
   });
 
-  it('saveConfig strips Grove/Machine tier fields out of the project file (ProjectConfigSchema)', () => {
-    // Seed a sparse-but-valid project file so loadConfig succeeds.
+  it('saveConfig retains caller-set Grove-tier fields in myco.yaml while the project is UNBOUND', () => {
+    // Seed a sparse-but-valid project file so loadConfig succeeds. No
+    // project.toml → no Grove binding. RC-3 semantics: Grove-tier values on
+    // an unbound project are RETAINED in myco.yaml — there is no Grove file
+    // to migrate them into, so dropping them would silently destroy them.
+    // The next Grove-bound load lifts them into grove config and strips them.
     const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-project-'));
     try {
       const seedYaml = 'version: 3\n';
       fs.writeFileSync(path.join(projectDir, 'myco.yaml'), seedYaml, 'utf-8');
 
       const config = loadConfig(projectDir);
-      // Hand back a "full" MycoConfig with stray tier-foreign fields.
-      // saveConfig should drop them before persisting myco.yaml.
       saveConfig(projectDir, {
         ...config,
-        // Grove tier — should NOT survive into project file.
+        // Grove tier — retained until a Grove binds. Unknown keys
+        // (retention_days, github_repo, …) are still stripped by the schema.
         backup: { dir: '/tmp/bad', retention_days: 30 },
         team: { enabled: true, github_repo: 'acme/x', branch: 'main', api_token: 'secret' },
         appearance: { theme: 'plum', mode: 'light', font: 'jetbrains-mono', density: 'compact' },
       } as MycoConfig);
 
       const persisted = YAML.parse(fs.readFileSync(path.join(projectDir, 'myco.yaml'), 'utf-8'));
-      expect(persisted.backup).toBeUndefined();
-      expect(persisted.team).toBeUndefined();
-      expect(persisted.appearance).toBeUndefined();
+      expect(persisted.backup?.dir).toBe('/tmp/bad');
+      expect(persisted.team?.enabled).toBe(true);
+      expect(persisted.appearance?.theme).toBe('plum');
+      // Machine-tier + legacy fields still never survive in the project file.
       expect(persisted.daemon).toBeUndefined();
       expect(persisted.update).toBeUndefined();
       // Project-tier shape preserved.

--- a/tests/daemon/api/config-list-ops.test.ts
+++ b/tests/daemon/api/config-list-ops.test.ts
@@ -124,8 +124,10 @@ describe('machine config addToList / removeFromList', () => {
     const res = await handlePutMachineConfig({
       addToList: [{ path: 'capture.ignore.paths', values: [42 as unknown as string] }],
     });
-    // MachineConfigSchema requires string[] — Zod should reject non-string entries
-    expect(res.response.status).toBe(400);
+    // MachineConfigSchema requires string[] — Zod rejects non-string entries.
+    // Value violations on tier PUTs are 422s (RC-3: 400 stays reserved for
+    // malformed requests and scope violations).
+    expect(res.response.status).toBe(422);
     expect((res.response.body as any).error).toBe('validation_failed');
   });
 

--- a/tests/daemon/api/config-routes-per-request-vault.test.ts
+++ b/tests/daemon/api/config-routes-per-request-vault.test.ts
@@ -179,11 +179,14 @@ describe('registerConfigRoutes — per-request projectVaultDir wiring', () => {
   });
 
   it('PUT /api/config/scoped at scope=local writes the requested project local.yaml', async () => {
+    // cortex.* is project-homed with a Personal override (scope registry),
+    // so it's a legitimate local-scope write. (release_provenance.* is
+    // project-locked and now rejected by the scope gate.)
     await routes.scopedPut({
       requestContext: { projectVaultDir: projectB },
       body: {
         scope: 'local',
-        patch: { release_provenance: { enabled: false } },
+        patch: { cortex: { enabled: false } },
       },
     });
     expect(fs.existsSync(path.join(projectA, 'local.yaml'))).toBe(false);

--- a/tests/daemon/api/config-scope.test.ts
+++ b/tests/daemon/api/config-scope.test.ts
@@ -60,9 +60,11 @@ describe('scoped config HTTP handlers', () => {
   });
 
   it('PUT /scoped scope=project with invalid patch returns 400 validation_failed', async () => {
+    // release_provenance.* is project-homed (passes the scope gate), so an
+    // invalid value exercises the Zod validation path.
     const res = await handlePutScopedConfig(tmpDir, {
       scope: 'project',
-      patch: { notifications: { enabled: 'nope' } },
+      patch: { release_provenance: { enabled: 'nope' } },
     });
     expect(res.status).toBe(400);
     expect((res.body as any).error).toBe('validation_failed');
@@ -79,15 +81,17 @@ describe('scoped config HTTP handlers', () => {
       patch: { appearance: { theme: 'moss' } },
     });
     expect(local.status).toBe(400);
-    expect((local.body as any).error).toBe('appearance_is_grove_scoped');
+    expect((local.body as any).error).toBe('scope_violation');
+    expect((local.body as any).paths).toEqual(['appearance.theme']);
     expect(project.status).toBe(400);
-    expect((project.body as any).error).toBe('appearance_is_grove_scoped');
+    expect((project.body as any).error).toBe('scope_violation');
+    expect((project.body as any).paths).toEqual(['appearance.theme']);
   });
 
-  it('PUT /scoped list-delta targeting appearance.* gets the same Grove-scoped 400', async () => {
-    // A list-delta is a new way to write config paths; it must pass through
-    // the same path-based scope guard as patch/clear — so an op targeting
-    // appearance.* returns the specific error, not a generic validation_failed.
+  it('PUT /scoped addToList targeting appearance.* gets the same scope-gate 400; removeFromList stays exempt', async () => {
+    // addToList introduces values, so it passes through the same registry
+    // gate as patch. removeFromList only deletes — it stays exempt so stale
+    // wrong-tier residue remains removable.
     const add = await handlePutScopedConfig(tmpDir, {
       scope: 'local',
       addToList: [{ path: 'appearance.accents', values: ['moss'] }],
@@ -97,9 +101,9 @@ describe('scoped config HTTP handlers', () => {
       removeFromList: [{ path: 'appearance.accents', values: ['moss'] }],
     });
     expect(add.status).toBe(400);
-    expect((add.body as any).error).toBe('appearance_is_grove_scoped');
-    expect(remove.status).toBe(400);
-    expect((remove.body as any).error).toBe('appearance_is_grove_scoped');
+    expect((add.body as any).error).toBe('scope_violation');
+    expect((add.body as any).paths).toEqual(['appearance.accents']);
+    expect(remove.status).toBeUndefined();
   });
 
   it('PUT /grove-config writes appearance for the current Grove', async () => {
@@ -172,16 +176,18 @@ describe('scoped config HTTP handlers', () => {
   it('PUT /scoped applies patch and clear atomically', async () => {
     // Seed a local agent.provider override.
     await handlePutScopedConfig(tmpDir, { scope: 'local', patch: { agent: { provider: { type: 'anthropic' } } } });
-    // Atomic: clear agent.provider AND set scheduled_tasks_enabled=false
+    // Atomic: clear agent.provider AND set agent.model. (agent.model is
+    // local-overridable via the `agent` registry block;
+    // agent.scheduled_tasks_enabled is Grove-locked and now scope-gated.)
     const res = await handlePutScopedConfig(tmpDir, {
       scope: 'local',
-      patch: { agent: { scheduled_tasks_enabled: false } },
+      patch: { agent: { model: 'claude-haiku-4-5' } },
       clear: ['agent.provider'],
     });
     expect(res.status).toBeUndefined();
     const local = await handleGetLocalConfig(tmpDir);
     expect((local.body as any).agent?.provider).toBeUndefined();
-    expect((local.body as any).agent?.scheduled_tasks_enabled).toBe(false);
+    expect((local.body as any).agent?.model).toBe('claude-haiku-4-5');
   });
 
   it('PUT /scoped rejects 400 when patch and clear overlap', async () => {
@@ -232,12 +238,26 @@ describe('scoped config HTTP handlers', () => {
   });
 
   it('PUT /scoped rejects invalid local overlays before writing local.yaml', async () => {
+    // notifications.* is local-overridable (passes the scope gate), so the
+    // bogus value exercises the merged-validation path. (daemon.log_level is
+    // machine-locked and now rejected earlier, by the scope gate.)
     const res = await handlePutScopedConfig(tmpDir, {
       scope: 'local',
-      patch: { daemon: { log_level: 'verbose' } },
+      patch: { notifications: { default_mode: 'verbose' } },
     });
     expect(res.status).toBe(400);
     expect((res.body as any).error).toBe('validation_failed');
+    expect(fs.existsSync(path.join(tmpDir, 'local.yaml'))).toBe(false);
+  });
+
+  it('PUT /scoped rejects wrong-tier patches with a 400 listing the paths', async () => {
+    const res = await handlePutScopedConfig(tmpDir, {
+      scope: 'local',
+      patch: { daemon: { log_level: 'debug' } },
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as any).error).toBe('scope_violation');
+    expect((res.body as any).paths).toEqual(['daemon.log_level']);
     expect(fs.existsSync(path.join(tmpDir, 'local.yaml'))).toBe(false);
   });
 


### PR DESCRIPTION
## What

Fixes the config-tier data-loss cluster from the 2026-06-10 bug hunt (RC-3: three P1s + two P2s, **all five reproduced** under hermetic MYCO_HOME). One root cause: tier semantics were enforced on the **load** path only (`pruneToTier`, deferred grove-tier strips for unbound projects) while every write surface re-implemented fragments of it — so writes silently destroyed user values.

The reproduced failures this closes:
- Any unrelated `updateConfig` call on an **unbound** project destroyed user-set `team`/`backup`/`maintenance`/`appearance`/`embedding.*`/`agent.*` from myco.yaml (stripped, relocated nowhere).
- Wrong-tier writes returned 200 then vanished at merge time — including an in-repo caller (`agent-tasks` no-Grove fallback) that was a complete silent no-op.
- One unknown key in `~/.myco/config.yaml` (e.g. written by a newer build before a channel downgrade) silently default-reverted the whole machine tier, and the next PUT **permanently wiped the file** — including `capture.transcript_paths` (the recurring "capture went dark" vector), `update_channel`, and `machine_id`.
- A corrupt `.myco/local.yaml` (where capability OFF-gates live) silently re-enabled **every** capability → unbounded LLM spend.
- `invalidateMergedConfigCache(vaultDir)` was a structural no-op (key mismatch).

## How

- **One tier table, every surface**: `GROVE_TIER_FIELDS` is now exported from `schema.ts` and shared by strip (load), retain (save), and lift (Grove-bind migration). `saveConfig` retains every entry while unbound, leaf-wise.
- **Shared raw-merge tier writer** (`updateTierConfigRaw`): preserves unknown keys on disk (forward compat), refuses corrupt on-disk docs with 422 instead of wiping them with defaults, computes list deltas against the Zod-defaulted view, returns the parsed full view. Routed through it: machine/grove PUTs, backup PUT, the update-channel writer, `updateGroveConfig`, and agent-tasks (per-task verbatim subtree so sibling tasks keep raw content).
- **Registry gates**: `handlePutScopedConfig`/`handlePutTierConfig` reject wrong-tier patch/addToList leaves with 400 + the offending paths (clears/removeFromList stay exempt so residue remains deletable). CLI `config set` routes by registry home. Every ScopedField/manifest write path was checked against the registry — no UI surface is affected by the new gates.
- **Salvage instead of default-revert**: `readTierConfig` strips `unrecognized_keys` and honors known values; only genuine value violations fall back to defaults, loudly. Failures feed a listener the daemon wires to a `settings.config_unreadable` notification — with **replay on registration** (boot reads happen before the daemon wires the listener) and clean-read clearing so fix-then-recorrupt re-notifies.
- **Fail-closed capabilities**: an unreadable `local.yaml` forces every capability master gate off in the merged view (genuinely-unset leaves keep today's fail-open contract).

## ⚠️ Two decisions for review

1. **Lift-then-strip on Grove bind.** Previously `GROVE_PROMOTED_FIELDS` (agent.*/embedding.*) were stripped from myco.yaml on Grove bind **without lifting** (the v1.0.3 "wipe on upgrade" decision). With unbound retention, that strip-only behavior becomes delayed destruction, so the migration now lifts all retained values into `grove.yaml` before stripping. Rationale: the one-time anti-shadowing wipe already ran in prod; for values a user sets on an unbound project, data preservation wins, and lift-then-strip achieves the same no-shadowing end state.
2. **Caller-changed-wins machine relocation.** A project-tier save can overwrite an explicit machine-config leaf only when the caller changed that leaf in *this* save (differs from myco.yaml's pre-save on-disk state). Unchanged residue never clobbers a newer machine value — it is dropped by the schema strip. Known residual edge: resetting a machine-homed leaf *to its schema default* via project-tier `updateConfig` cannot overwrite an explicit machine value (the CLI now routes machine paths directly, so this is a narrow corner).

## Tests

`tests/config/rc3-config-tier-write-safety.test.ts` ports all five repros as hermetic regression tests (sandboxed MYCO_HOME) plus the scope gates, salvage, 422 refusal, listener replay, and the cache fix. Five pre-existing tests updated where they pinned the buggy behavior (each is a deliberate semantic change: unbound retention, 400→422 on tier value violations, removeFromList exemption, leaf-wise relocation).

Full suite green: all 85 phase JUnit artifacts report `failures="0"`, every phase exited 0; tsc clean. No schema or `SYNC_PROTOCOL_VERSION` impact (config files only).

Deferred (noted from the adversarial diff review, no data risk): no-op tier writes still rewrite the file and clear the merged cache; unbound retention materializes full sections into myco.yaml (VCS noise); salvage can't strip unknown keys nested inside arrays (degrades loudly to defaults/422).

Pipeline: independently reviewed plan (7 must-fixes folded) → implementation → adversarial diff review (1 must-fix: listener boot-ordering replay; 2 consistency items) → all fixed and regression-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)