### PR TITLE
grove: enforce served_by ownership at every on-demand seam (RC-5)

### DIFF
--- a/packages/myco/src/daemon/api/backup.ts
+++ b/packages/myco/src/daemon/api/backup.ts
@@ -30,7 +30,7 @@ import type { RestoreResult } from '@myco/backup/engine.js';
 import { z } from 'zod';
 import { loadMergedConfig, updateTierConfigRaw, TierConfigUnreadableError } from '../../config/loader.js';
 import { setAtPath, unsetAtPath } from '../../utils/dot-path.js';
-import { loadGroveRecord, listGroves, type GroveRecord } from '../../grove/registry.js';
+import { assertOwnedGrove, loadGroveRecord, listGroves, type GroveRecord } from '../../grove/registry.js';
 import { resolveGroveDir, resolveGroveDbPath, resolveMycoHome, currentDaemonVariant } from '../../grove/paths.js';
 import type { GroveRuntimeCache } from '../grove-runtime-cache.js';
 import path from 'node:path';
@@ -170,9 +170,11 @@ export function createBackupHandlers(deps: BackupDeps) {
       });
     }
 
-    // scope.kind === 'grove'
-    const grove = loadGroveRecord(scope.grove_id, mycoHome);
-    if (!grove) return { status: 404, body: { error: 'grove_not_found' } };
+    // scope.kind === 'grove'. Body-scope grove ids arrive outside the
+    // request-context funnel, so existence and served_by ownership gate
+    // here before the backup opens the Grove DB; throws propagate to the
+    // transport (403 foreign_grove / 404 grove_not_found).
+    const grove = assertOwnedGrove(scope.grove_id, mycoHome);
     const key = `backup:${actionScopeKey(scope)}`;
     return inflight.run(key, async (): Promise<RouteResponse> => {
       const result = performBackupForGrove(grove);

--- a/packages/myco/src/daemon/api/database.ts
+++ b/packages/myco/src/daemon/api/database.ts
@@ -5,7 +5,7 @@ import {
   resolveGroveDir,
   resolveMycoHome,
 } from '@myco/grove/paths.js';
-import { loadGroveRecord } from '@myco/grove/registry.js';
+import { assertOwnedGrove } from '@myco/grove/registry.js';
 import type { GroveRuntimeCache } from '../grove-runtime-cache.js';
 import type { Logger } from '../logger.js';
 import { DatabaseMaintenanceManager } from '../database/manager.js';
@@ -67,11 +67,15 @@ export function createDatabaseMaintenanceHandlers(deps: DatabaseMaintenanceRoute
     groveId: string,
     run: (manager: DatabaseMaintenanceManager) => Promise<T>,
   ): Promise<PerGroveResultBase & T> {
-    const grove = loadGroveRecord(groveId, mycoHome);
-    const slug = grove?.slug ?? groveId;
+    // Body-scope grove ids arrive outside the request-context funnel, so
+    // existence and served_by ownership gate here — BEFORE the cache
+    // opens (and schema-migrates) the Grove DB. An unknown id must not
+    // create groves/<id>/ as a side effect; throws propagate to the
+    // transport (403 foreign_grove / 404 grove_not_found).
+    const grove = assertOwnedGrove(groveId, mycoHome);
     const dbPath = resolveGroveDbPath(groveId, mycoHome);
     const db = deps.cache.getDatabase(dbPath);
-    return wrapPerGroveResult(groveId, slug, () =>
+    return wrapPerGroveResult(groveId, grove.slug, () =>
       deps.cache.withPinned(dbPath, async () =>
         withDatabase(db, async () => run(buildManagerForGrove(groveId))),
       ),

--- a/packages/myco/src/daemon/api/embedding.ts
+++ b/packages/myco/src/daemon/api/embedding.ts
@@ -14,7 +14,7 @@ import {
   resolveGroveDbPath,
   resolveMycoHome,
 } from '@myco/grove/paths.js';
-import { loadGroveRecord } from '@myco/grove/registry.js';
+import { assertOwnedGrove, loadGroveRecord } from '@myco/grove/registry.js';
 import type { GroveRuntimeCache, EmbeddingRuntimeFactory } from '../grove-runtime-cache.js';
 import type { Logger } from '../logger.js';
 import { forEachGrove } from '../scope-iteration.js';
@@ -338,9 +338,14 @@ export function createEmbeddingActionHandlers(deps: EmbeddingActionDeps): {
     groveId: string,
     run: (manager: EmbeddingManager, db: Database) => Promise<T> | T,
   ): Promise<PerGroveResultBase & T> {
-    const grove = loadGroveRecord(groveId, mycoHome);
-    const slug = grove?.slug ?? groveId;
-    return wrapPerGroveResult(groveId, slug, async () => {
+    // Body-scope grove ids arrive outside the request-context funnel, so
+    // existence and served_by ownership gate here — BEFORE
+    // wrapPerGroveResult (which would swallow the refusal into a result
+    // row) and before the cache opens the Grove DB and builds an
+    // embedding runtime on it. Throws propagate to the transport
+    // (403 foreign_grove / 404 grove_not_found).
+    const grove = assertOwnedGrove(groveId, mycoHome);
+    return wrapPerGroveResult(groveId, grove.slug, async () => {
       const { manager, db, databasePath } = buildManagerForGrove(groveId);
       return deps.cache.withPinned(databasePath, async () =>
         withDatabase(db, async () => run(manager, db)),

--- a/packages/myco/src/daemon/api/maintenance.ts
+++ b/packages/myco/src/daemon/api/maintenance.ts
@@ -18,7 +18,7 @@ import {
   resolveProjectVaultDir,
 } from '@myco/grove/paths.js';
 import {
-  loadGroveRecord,
+  assertOwnedGrove,
   listRegisteredProjects,
   type GroveRecord,
 } from '@myco/grove/registry.js';
@@ -383,8 +383,12 @@ export function createMaintenanceHandlers(deps: MaintenanceHandlersDeps) {
 
   async function handleGroveMaintenance(req: RouteRequest): Promise<RouteResponse> {
     const groveId = req.params.id;
-    const grove = loadGroveRecord(groveId, mycoHome);
-    if (!grove) return { status: 404, body: { error: 'grove_not_found' } };
+    // URL :id arrives outside the request-context funnel, so existence
+    // and served_by ownership gate here — BEFORE the cache opens (and
+    // schema-migrates) the Grove DB, and outside the summary try/catch
+    // below so the refusal isn't swallowed into an error summary. Throws
+    // propagate to the transport (403 foreign_grove / 404 grove_not_found).
+    const grove = assertOwnedGrove(groveId, mycoHome);
 
     const databasePath = resolveGroveDbPath(grove.id, mycoHome);
     const groveHome = resolveGroveDir(grove.id, mycoHome);

--- a/packages/myco/src/daemon/server.ts
+++ b/packages/myco/src/daemon/server.ts
@@ -10,6 +10,7 @@ import { resolveStaticFile } from './static.js';
 import { evictDaemonsForVault } from './eviction.js';
 import { LOG_KINDS } from '../constants/log-kinds.js';
 import {
+  ForeignGroveError,
   REQUEST_CONTEXT_AUTH_ENV,
   UnauthorizedRequestContextError,
   UnknownRequestContextError,
@@ -17,7 +18,7 @@ import {
   requestContextFromTenancyIds,
   type MycoRequestContext,
 } from '../grove/request-context.js';
-import { isProjectPaused } from '../grove/registry.js';
+import { isProjectPaused, UnknownGroveError } from '../grove/registry.js';
 import { pausedErrorResponse } from './api/error-envelope.js';
 import { type DaemonState } from './service-state.js';
 import {
@@ -378,6 +379,37 @@ export class DaemonServer {
           res.end(JSON.stringify({ error: 'unknown_tenancy', message: error.message }));
           return;
         }
+        if (error instanceof ForeignGroveError) {
+          // The request resolved to a Grove served by the other daemon
+          // variant. Refuse before any handler (or DB open) runs —
+          // `myco grove claim` is the supported cross-daemon path.
+          // Logged at warn: hook clients swallow 403s silently, so this
+          // line is the only daemon-side trace during a claim window.
+          this.logger.warn(LOG_KINDS.SERVER_ERROR, 'Refused request for foreign-served Grove', {
+            path: req.url,
+            grove_id: error.groveId,
+            served_by: error.servedBy,
+          });
+          res.writeHead(403, { 'Content-Type': 'application/json', ...versionHeader });
+          res.end(JSON.stringify({
+            error: 'foreign_grove',
+            message: error.message,
+            grove_id: error.groveId,
+            served_by: error.servedBy,
+          }));
+          return;
+        }
+        if (error instanceof UnknownGroveError) {
+          // A caller-named Grove id (body scope / URL :id) with no record
+          // on this machine: 404 before any groves/<id>/ path is created.
+          res.writeHead(404, { 'Content-Type': 'application/json', ...versionHeader });
+          res.end(JSON.stringify({
+            error: 'grove_not_found',
+            message: error.message,
+            grove_id: error.groveId,
+          }));
+          return;
+        }
         this.logger.error(LOG_KINDS.SERVER_ERROR, 'Request handler error', {
           path: req.url,
           error: (error as Error).message,
@@ -501,11 +533,14 @@ export class DaemonServer {
       return requestContextFromTenancyIds(
         { groveId: params.groveId, projectId: params.projectId },
         this.vaultDir,
-        { headers, expectedAuthToken: this.authToken },
+        { headers, expectedAuthToken: this.authToken, enforceGroveOwnership: true },
       );
     }
     return requestContextFromHttpHeaders(headers, this.vaultDir, {
       expectedAuthToken: this.authToken,
+      // Inbound daemon resolution: a request must never resolve to (and
+      // then open) a Grove served by the other daemon variant.
+      enforceGroveOwnership: true,
     });
   }
 

--- a/packages/myco/src/grove/registry.ts
+++ b/packages/myco/src/grove/registry.ts
@@ -8,6 +8,7 @@ import { createMtimeCache } from '@myco/utils/mtime-cache.js';
 import { createGroveId, createProjectId, isGroveEraId } from './ids.js';
 import { assertSafeProjectRoot, isSafeProjectRoot } from '../vault/resolve.js';
 import {
+  currentDaemonVariant,
   pathsEquivalent,
   resolveGlobalConfigPath,
   resolveGroveDir,
@@ -222,6 +223,73 @@ export function loadGroveRecord(groveId: string, mycoHome = resolveMycoHome()): 
   // rejects malformed ids before any path is constructed.
   if (!isGroveEraId(groveId, 'grove')) return null;
   return groveRecordCache.get(resolveGroveMetadataPath(groveId, mycoHome));
+}
+
+/**
+ * True when this process's daemon variant owns the Grove. Reads always
+ * normalize `served_by` to `'service' | 'service-dev'` (legacy records
+ * without the field read as `'service'`), so plain equality is the whole
+ * ownership predicate. On-demand seams — tool-call Grove pivots and the
+ * daemon's inbound request resolution — gate cross-Grove access through
+ * this before any database is opened or schema-migrated.
+ */
+export function groveServedByThisDaemon(
+  grove: Pick<GroveRecord, 'served_by'>,
+  variant: DaemonVariant = currentDaemonVariant(),
+): boolean {
+  return grove.served_by === variant;
+}
+
+/**
+ * A request resolved to a Grove that is served by the other daemon
+ * variant. Thrown by daemon-side request resolution when Grove-ownership
+ * enforcement is enabled; transports translate it into a 403
+ * `foreign_grove` error so the caller never reaches a database the
+ * daemon does not own. Crossing the boundary deliberately is what
+ * `myco grove claim` is for.
+ */
+export class ForeignGroveError extends Error {
+  constructor(
+    public readonly groveId: string,
+    public readonly servedBy: DaemonVariant,
+  ) {
+    super(
+      `Grove ${groveId} is served by another daemon (${servedBy}); `
+      + 'claim it first (myco grove claim)',
+    );
+    this.name = 'ForeignGroveError';
+  }
+}
+
+/**
+ * A caller named a Grove id that has no record on this machine. Thrown by
+ * {@link assertOwnedGrove} so unknown (or junk) ids are refused before any
+ * path under `groves/<id>/` is materialized; the daemon transport maps it
+ * to a 404 `grove_not_found`.
+ */
+export class UnknownGroveError extends Error {
+  constructor(public readonly groveId: string) {
+    super(`Unknown Grove: ${groveId}`);
+    this.name = 'UnknownGroveError';
+  }
+}
+
+/**
+ * Existence + ownership gate for caller-named Grove ids that arrive
+ * OUTSIDE the request-context funnel (body `ActionScope.grove_id`, URL
+ * `:id` params). Throws {@link UnknownGroveError} when no record exists —
+ * so an unknown id can never create `groves/<id>/` as a side effect of a
+ * DB open — and {@link ForeignGroveError} when the Grove is served by the
+ * other daemon variant. Call it BEFORE any `cache.getDatabase` /
+ * `resolveGroveDbPath` on the named Grove.
+ */
+export function assertOwnedGrove(groveId: string, mycoHome = resolveMycoHome()): GroveRecord {
+  const grove = loadGroveRecord(groveId, mycoHome);
+  if (!grove) throw new UnknownGroveError(groveId);
+  if (!groveServedByThisDaemon(grove)) {
+    throw new ForeignGroveError(grove.id, grove.served_by);
+  }
+  return grove;
 }
 
 export interface CreateGroveOptions {

--- a/packages/myco/src/grove/request-context.ts
+++ b/packages/myco/src/grove/request-context.ts
@@ -11,8 +11,19 @@ import {
   type ProjectScope,
 } from '@myco/grove/ids.js';
 import { resolveGroveDbPath, resolveMycoHome, resolveProjectVaultDir } from '@myco/grove/paths.js';
-import { findRegisteredProject, loadGroveRecord } from '@myco/grove/registry.js';
+import {
+  findRegisteredProject,
+  ForeignGroveError,
+  groveServedByThisDaemon,
+  loadGroveRecord,
+  type GroveRecord,
+} from '@myco/grove/registry.js';
 import { resolveProjectRoot } from '@myco/vault/resolve.js';
+
+// Transports that resolve inbound requests catch this alongside the
+// resolver's own error types; re-exported so they import one module for
+// the full request-resolution error surface.
+export { ForeignGroveError };
 
 export const REQUEST_CONTEXT_HEADERS = {
   projectRoot: 'x-myco-project-root',
@@ -104,6 +115,18 @@ export interface RequestContextAuthOptions {
    * with non-daemon callers (e.g. unit tests).
    */
   expectedAuthToken?: string | null;
+  /**
+   * Enforce `grove.toml served_by` ownership on the Grove this request
+   * resolves to: when the Grove is served by the other daemon variant
+   * (per `currentDaemonVariant()`), throw {@link ForeignGroveError}
+   * instead of returning a context whose `databasePath` points into a
+   * foreign Grove. Opt-in, set ONLY where the daemon resolves inbound
+   * requests (the HTTP API and `/mcp` transports). The same resolver
+   * also runs client-side — hooks, the stdio bridge, the CLI — where a
+   * throw would be swallowed and silently drop capture headers, so the
+   * default keeps today's non-throwing behavior.
+   */
+  enforceGroveOwnership?: boolean;
 }
 
 export type RequestContextSource = 'explicit' | 'headers' | 'legacy-vault' | 'url';
@@ -266,6 +289,7 @@ export function requestContextFromHttpHeaders(
   // trigger a manifest read — failure mode is "unauthorized" full stop.
   enforceContextSwitchAuth(headers, options.expectedAuthToken ?? null);
 
+  const enforceGroveOwnership = options.enforceGroveOwnership === true;
   const callerRoot = normalizeCallerRoot(readHeader(headers, REQUEST_CONTEXT_HEADERS.callerRoot));
   // Base context; caller headers below override to a real project.
   const { context: fallback, manifest } = buildVaultFallbackOrGlobal(fallbackVaultDir, { callerRoot });
@@ -283,13 +307,15 @@ export function requestContextFromHttpHeaders(
     // headers the auth gate guards), not on incidental projectRoot/machine/
     // session headers. Auth has already been enforced above.
     const tenancySource = tenancySourceFromExplicit(explicit);
-    if (explicit.groveId) return resolveRegisteredRequestContext(explicit, fallback, 'headers', tenancySource);
-    const manifestContext = resolveManifestHeaderRequestContext(explicit, fallback, 'headers', tenancySource);
+    if (explicit.groveId) {
+      return resolveRegisteredRequestContext(explicit, fallback, 'headers', tenancySource, enforceGroveOwnership);
+    }
+    const manifestContext = resolveManifestHeaderRequestContext(explicit, fallback, 'headers', tenancySource, enforceGroveOwnership);
     if (manifestContext) return manifestContext;
     return resolveLegacyHeaderRequestContext(explicit, fallback, tenancySource);
   }
 
-  return resolveManifestRequestContext(fallback, 'headers', manifest) ?? fallback;
+  return resolveManifestRequestContext(fallback, 'headers', manifest, 'synthesized', enforceGroveOwnership) ?? fallback;
 }
 
 /**
@@ -316,7 +342,7 @@ export function requestContextFromHttpHeaders(
 export function requestContextFromTenancyIds(
   ids: { groveId: string; projectId: string },
   fallbackVaultDir: string,
-  options: { headers: IncomingHttpHeaders; expectedAuthToken: string | null } = {
+  options: { headers: IncomingHttpHeaders; expectedAuthToken: string | null; enforceGroveOwnership?: boolean } = {
     headers: {},
     expectedAuthToken: null,
   },
@@ -329,7 +355,13 @@ export function requestContextFromTenancyIds(
     projectId: ids.projectId,
     sessionId: null,
   };
-  return resolveRegisteredRequestContext(explicit, fallback, 'url', tenancySourceFromExplicit(explicit));
+  return resolveRegisteredRequestContext(
+    explicit,
+    fallback,
+    'url',
+    tenancySourceFromExplicit(explicit),
+    options.enforceGroveOwnership === true,
+  );
 }
 
 /**
@@ -474,7 +506,11 @@ export function requestContextFromEnvironment(
     machineId,
     sessionId,
   };
-  return resolveRegisteredRequestContext(explicit, fallback, 'explicit', tenancySourceFromExplicit(explicit));
+  // Client-side resolution (hooks, stdio bridge, CLI): never enforce
+  // Grove ownership here — a throw would be swallowed by the hook
+  // client's catch and silently drop capture headers. The daemon
+  // enforces ownership when it resolves the inbound request.
+  return resolveRegisteredRequestContext(explicit, fallback, 'explicit', tenancySourceFromExplicit(explicit), false);
 }
 
 /**
@@ -743,6 +779,7 @@ function resolveManifestRequestContext(
   // `findRegisteredProject` either way, so an unregistered/unbound vault never
   // reaches this stamp — the anchor cannot masquerade as caller tenancy.
   tenancySource: TenancySource = 'synthesized',
+  enforceGroveOwnership = false,
 ): MycoRequestContext | null {
   const manifest = cachedManifest ?? readManifest(fallback.projectVaultDir);
   if (!manifest?.grove?.binding_id) return null;
@@ -756,9 +793,10 @@ function resolveManifestRequestContext(
     fallback,
     source,
     tenancySource,
+    enforceGroveOwnership,
     projectRoot: registered.project.root,
     projectId: assertGroveProjectId(registered.project.project_id),
-    groveId: registered.grove.id,
+    grove: registered.grove,
     machineId: fallback.machineId,
     sessionId: fallback.sessionId,
     manifest,
@@ -770,6 +808,7 @@ function resolveManifestHeaderRequestContext(
   fallback: MycoRequestContext,
   source: RequestContextSource,
   tenancySource: TenancySource,
+  enforceGroveOwnership: boolean,
 ): MycoRequestContext | null {
   const inputProjectRoot = input.projectRoot ? path.resolve(input.projectRoot) : null;
   if (!inputProjectRoot && !input.projectId) return null;
@@ -797,9 +836,10 @@ function resolveManifestHeaderRequestContext(
     fallback,
     source,
     tenancySource,
+    enforceGroveOwnership,
     projectRoot: registered.project.root,
     projectId: assertGroveProjectId(projectId),
-    groveId: registered.grove.id,
+    grove: registered.grove,
     machineId: input.machineId ?? fallback.machineId,
     sessionId: input.sessionId ?? fallback.sessionId,
     manifest,
@@ -811,6 +851,7 @@ function resolveRegisteredRequestContext(
   fallback: MycoRequestContext,
   source: RequestContextSource,
   tenancySource: TenancySource,
+  enforceGroveOwnership: boolean,
 ): MycoRequestContext {
   const inputProjectRoot = input.projectRoot ? path.resolve(input.projectRoot) : null;
   const manifestFromInputRoot = inputProjectRoot
@@ -860,9 +901,10 @@ function resolveRegisteredRequestContext(
     fallback,
     source,
     tenancySource,
+    enforceGroveOwnership,
     projectRoot: registeredRoot,
     projectId: assertGroveProjectId(projectId),
-    groveId: grove.id,
+    grove,
     machineId: input.machineId ?? fallback.machineId,
     sessionId: input.sessionId ?? fallback.sessionId,
     manifest,
@@ -887,13 +929,22 @@ function buildRegisteredRequestContext(input: {
   fallback: MycoRequestContext;
   source: RequestContextSource;
   tenancySource: TenancySource;
+  /**
+   * Daemon-side ownership gate (see RequestContextAuthOptions). Every
+   * registered-context branch funnels through here, so one check covers
+   * the grove-id header path, both manifest paths, and URL tenancy.
+   */
+  enforceGroveOwnership: boolean;
   projectRoot: string;
   projectId: GroveProjectId;
-  groveId: string;
+  grove: GroveRecord;
   machineId: string;
   sessionId: string | null;
   manifest: ProjectManifest | null;
 }): MycoRequestContext {
+  if (input.enforceGroveOwnership && !groveServedByThisDaemon(input.grove)) {
+    throw new ForeignGroveError(input.grove.id, input.grove.served_by);
+  }
   const projectRoot = path.resolve(input.projectRoot);
   const projectVaultDir = resolveProjectVaultDir(projectRoot);
   if (input.manifest && input.manifest.project.id !== input.projectId) {
@@ -903,11 +954,11 @@ function buildRegisteredRequestContext(input: {
     ...input.fallback,
     projectRoot,
     projectId: input.projectId,
-    groveId: input.groveId,
+    groveId: input.grove.id,
     machineId: input.machineId,
     sessionId: input.sessionId,
     projectVaultDir,
-    databasePath: resolveGroveDbPath(input.groveId),
+    databasePath: resolveGroveDbPath(input.grove.id),
     source: input.source,
     tenancySource: input.tenancySource,
   };

--- a/packages/myco/src/mcp/http.ts
+++ b/packages/myco/src/mcp/http.ts
@@ -4,6 +4,7 @@ import type { Database } from '../db/client.js';
 import { DaemonClient } from '../hooks/client.js';
 import { createMycoTools } from '../tools/index.js';
 import {
+  ForeignGroveError,
   isCallerTenancy,
   requestContextFromHttpHeaders,
   tryResolveRequestContextForVault,
@@ -78,6 +79,9 @@ function resolveRequestContextOrLegacy(
     // the same context-switch gate the daemon's main HTTP server uses.
     requestContext = requestContextFromHttpHeaders(req.headers, vaultDir, {
       expectedAuthToken: process.env.MYCO_DAEMON_AUTH ?? null,
+      // Inbound daemon resolution: a tool call must never resolve to (and
+      // then open) a Grove served by the other daemon variant.
+      enforceGroveOwnership: true,
     });
   } catch (err) {
     // Preserve the auth-gate contract: a context-switch without the
@@ -85,6 +89,9 @@ function resolveRequestContextOrLegacy(
     // legacy-vault soft-fail. Re-throw so the caller's existing handling
     // applies.
     if (err instanceof UnauthorizedRequestContextError) throw err;
+    // Same for ownership: a Grove served by the other daemon variant is a
+    // 403 foreign_grove refusal, never the misleading legacy_vault 503.
+    if (err instanceof ForeignGroveError) throw err;
     // Pre-Grove vault: the resolver threw because there's no Grove project
     // id to bind to. Surface the soft-fail reason rather than a 500.
     const result = tryResolveRequestContextForVault(vaultDir);
@@ -130,6 +137,20 @@ export function createStreamableMcpHttpHandler(
         res.statusCode = 401;
         res.setHeader('Content-Type', 'application/json');
         res.end(JSON.stringify({ error: 'unauthorized_context_switch', message: err.message }));
+        return;
+      }
+      // Grove served by the other daemon variant: surface the same 403
+      // `foreign_grove` contract the main HTTP path returns so MCP callers
+      // see the claim hint instead of a generic -32603/500.
+      if (err instanceof ForeignGroveError) {
+        res.statusCode = 403;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({
+          error: 'foreign_grove',
+          message: err.message,
+          grove_id: err.groveId,
+          served_by: err.servedBy,
+        }));
         return;
       }
       throw err;

--- a/packages/myco/src/tools/call-context.ts
+++ b/packages/myco/src/tools/call-context.ts
@@ -38,6 +38,8 @@ import {
 } from '@myco/grove/ids.js';
 import {
   findRegisteredProject,
+  ForeignGroveError,
+  groveServedByThisDaemon,
   loadGroveRecord,
 } from '@myco/grove/registry.js';
 import {
@@ -112,6 +114,18 @@ export function resolveCallContext(
   const grove = loadGroveRecord(groveId!, mycoHome);
   if (!grove) {
     throw new ToolError('invalid_input', `Unknown Grove: ${groveId}`);
+  }
+  // Ownership gate: a pivot into a Grove served by the other daemon
+  // variant must be refused BEFORE the dispatcher opens (and
+  // schema-migrates) that Grove's database — a dev daemon pivoting into
+  // a prod-served Grove would otherwise create or roll its schema. The
+  // ToolError envelope carries the typed MCP code; the message is the
+  // canonical ForeignGroveError prose.
+  if (!groveServedByThisDaemon(grove)) {
+    throw new ToolError(
+      'foreign_grove',
+      new ForeignGroveError(grove.id, grove.served_by).message,
+    );
   }
 
   let resolvedProjectId: GroveProjectId;

--- a/packages/myco/src/tools/error.ts
+++ b/packages/myco/src/tools/error.ts
@@ -31,6 +31,14 @@ export type ToolErrorCode =
    * message prose.
    */
   | 'legacy_vault'
+  /**
+   * A `grove_id` pivot targeted a Grove whose `grove.toml served_by`
+   * names the other daemon variant. Rejected before the target Grove's
+   * database is opened (or schema-migrated). Distinct code so clients
+   * can surface the claim path (`myco grove claim`) instead of a
+   * generic failure.
+   */
+  | 'foreign_grove'
   | 'tool_call_failed';
 
 /**

--- a/packages/myco/src/tools/index.ts
+++ b/packages/myco/src/tools/index.ts
@@ -218,6 +218,11 @@ export function createMycoTools(vaultDir: string, client: DaemonClient, options:
     }
     let db: Database;
     try {
+      // Residual front-door hazard: outside the daemon (CLI `myco tool
+      // call`), the BASE context's database opens in-process with no
+      // served_by ownership check — only cross-Grove `grove_id` pivots are
+      // gated (resolveCallContext throws `foreign_grove`). Gating the base
+      // context is tracked in the RC-5 remediation plan.
       db = openDatabase(context.databasePath);
       // Real machine id (not the 'local' default) so the v52 conversion runs.
       createSchema(db, getMachineId());

--- a/tests/backup/handlers.test.ts
+++ b/tests/backup/handlers.test.ts
@@ -3,9 +3,15 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { createGrove, clearGroveRegistryCaches, type GroveRecord } from '@myco/grove/registry.js';
+import {
+  clearGroveRegistryCaches,
+  createGrove,
+  ForeignGroveError,
+  UnknownGroveError,
+  type GroveRecord,
+} from '@myco/grove/registry.js';
 import { ensureGroveDatabase } from '@myco/grove/database.js';
-import { resolveGroveDbPath } from '@myco/grove/paths.js';
+import { resolveGroveDbPath, resolveGroveDir } from '@myco/grove/paths.js';
 import { openDatabase } from '@myco/db/client.js';
 import { createSchema } from '@myco/db/schema.js';
 import { GroveRuntimeCache } from '@myco/daemon/grove-runtime-cache.js';
@@ -29,6 +35,10 @@ function setup(): Env {
   fs.mkdirSync(mycoHome, { recursive: true });
   const prev = process.env.MYCO_HOME;
   process.env.MYCO_HOME = mycoHome;
+  // served_by gates compare against currentDaemonVariant(); pin the
+  // default 'service' variant regardless of the ambient shell.
+  const prevVariant = process.env.MYCO_SERVICE_VARIANT;
+  delete process.env.MYCO_SERVICE_VARIANT;
   clearGroveRegistryCaches();
   const grove = createGrove('Solo', mycoHome);
   ensureGroveDatabase(grove.id, mycoHome);
@@ -45,6 +55,8 @@ function setup(): Env {
       cache.closeAll();
       if (prev === undefined) delete process.env.MYCO_HOME;
       else process.env.MYCO_HOME = prev;
+      if (prevVariant === undefined) delete process.env.MYCO_SERVICE_VARIANT;
+      else process.env.MYCO_SERVICE_VARIANT = prevVariant;
       clearGroveRegistryCaches();
       fs.rmSync(workDir, { recursive: true, force: true });
     },
@@ -152,5 +164,50 @@ describe('backup handlers — explicit Grove, fail-loud', () => {
     expect(noGrove.status).toBe(400);
     const unknown = await handlers.handleRestoreStatus(req({ requestContext: ctx(env.grove.id), query: { job_id: 'nope' } }));
     expect(unknown.status).toBe(404);
+  });
+
+  it('create backup succeeds for a Grove served by this daemon variant', async () => {
+    const handlers = createBackupHandlers({ cache: env.cache, machineId: MACHINE, mycoHome: env.mycoHome });
+    const res = await handlers.handleCreateBackup(req({
+      body: { scope: { kind: 'grove', grove_id: env.grove.id } },
+    }));
+    expect(res.status ?? 200).toBe(200);
+    const body = res.body as { summary: { ok: number; failed: number }; file_path?: string };
+    expect(body.summary).toEqual({ ok: 1, failed: 0 });
+    expect(body.file_path).toBeTruthy();
+  });
+
+  it('create backup refuses a foreign-served Grove before opening its DB (RC-5)', async () => {
+    const foreign = createGrove('Dogfood', env.mycoHome, { servedBy: 'service-dev' });
+    const handlers = createBackupHandlers({ cache: env.cache, machineId: MACHINE, mycoHome: env.mycoHome });
+
+    let caught: unknown;
+    try {
+      await handlers.handleCreateBackup(req({
+        body: { scope: { kind: 'grove', grove_id: foreign.id } },
+      }));
+    } catch (err) {
+      caught = err;
+    }
+    // Thrown so the daemon transport maps it to 403 foreign_grove; the
+    // foreign Grove's DB was never opened or created.
+    expect(caught).toBeInstanceOf(ForeignGroveError);
+    expect(fs.existsSync(resolveGroveDbPath(foreign.id, env.mycoHome))).toBe(false);
+  });
+
+  it('create backup refuses an unknown Grove id without creating groves/<id>/ (RC-5)', async () => {
+    const unknownId = 'grove_' + 'f'.repeat(32);
+    const handlers = createBackupHandlers({ cache: env.cache, machineId: MACHINE, mycoHome: env.mycoHome });
+
+    let caught: unknown;
+    try {
+      await handlers.handleCreateBackup(req({
+        body: { scope: { kind: 'grove', grove_id: unknownId } },
+      }));
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(UnknownGroveError);
+    expect(fs.existsSync(resolveGroveDir(unknownId, env.mycoHome))).toBe(false);
   });
 });

--- a/tests/daemon/api/database-scope.test.ts
+++ b/tests/daemon/api/database-scope.test.ts
@@ -17,7 +17,8 @@ import { GroveRuntimeCache } from '@myco/daemon/grove-runtime-cache';
 import { createDatabaseMaintenanceHandlers } from '@myco/daemon/api/database';
 import { DatabaseMaintenanceManager } from '@myco/daemon/database/manager';
 import { ensureGroveDatabase } from '@myco/grove/database';
-import { createGrove } from '@myco/grove/registry';
+import { createGrove, ForeignGroveError, UnknownGroveError } from '@myco/grove/registry';
+import { resolveGroveDbPath, resolveGroveDir } from '@myco/grove/paths';
 import { assertGroveProjectId } from '@myco/grove/ids';
 import type { RouteRequest } from '@myco/daemon/router';
 
@@ -41,6 +42,7 @@ describe('database scope-aware actions', () => {
   let mycoHome: string;
   let previousMycoHome: string | undefined;
   let previousAuthToken: string | undefined;
+  let previousVariant: string | undefined;
   let logger: DaemonLogger;
 
   beforeEach(() => {
@@ -51,6 +53,10 @@ describe('database scope-aware actions', () => {
     process.env.MYCO_HOME = mycoHome;
     previousAuthToken = process.env.MYCO_DAEMON_AUTH;
     process.env.MYCO_DAEMON_AUTH = ALL_GROVES_TOKEN;
+    // served_by gates compare against currentDaemonVariant(); pin the
+    // default 'service' variant regardless of the ambient shell.
+    previousVariant = process.env.MYCO_SERVICE_VARIANT;
+    delete process.env.MYCO_SERVICE_VARIANT;
     logger = makeLogger(workDir);
   });
 
@@ -59,6 +65,8 @@ describe('database scope-aware actions', () => {
     else process.env.MYCO_DAEMON_AUTH = previousAuthToken;
     if (previousMycoHome === undefined) delete process.env.MYCO_HOME;
     else process.env.MYCO_HOME = previousMycoHome;
+    if (previousVariant === undefined) delete process.env.MYCO_SERVICE_VARIANT;
+    else process.env.MYCO_SERVICE_VARIANT = previousVariant;
     fs.rmSync(workDir, { recursive: true, force: true });
   });
 
@@ -185,6 +193,50 @@ describe('database scope-aware actions', () => {
     const res = await handlers.handleOptimize(emptyRequest({ scope: { kind: 'grove', grove_id: grove.id } }));
     // Status undefined or 200 — either way, NOT 403.
     expect(res.status === 403).toBe(false);
+  });
+
+  it('refuses kind=grove for a foreign-served Grove before creating its DB (RC-5)', async () => {
+    const grove = createGrove('dogfood', mycoHome, { servedBy: 'service-dev' });
+    const handlers = makeHandlers();
+
+    let caught: unknown;
+    try {
+      await handlers.handleOptimize(emptyRequest({ scope: { kind: 'grove', grove_id: grove.id } }));
+    } catch (err) {
+      caught = err;
+    }
+    // Thrown (not soft-failed into a result row) so the daemon transport
+    // can map it to 403 foreign_grove; and the DB open never happened.
+    expect(caught).toBeInstanceOf(ForeignGroveError);
+    expect(fs.existsSync(resolveGroveDbPath(grove.id, mycoHome))).toBe(false);
+  });
+
+  it('refuses kind=grove vacuum for a foreign-served Grove (single-Grove vacuum arm)', async () => {
+    const grove = createGrove('dogfood', mycoHome, { servedBy: 'service-dev' });
+    const handlers = makeHandlers();
+
+    let caught: unknown;
+    try {
+      await handlers.handleVacuum(emptyRequest({ scope: { kind: 'grove', grove_id: grove.id } }));
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ForeignGroveError);
+    expect(fs.existsSync(resolveGroveDbPath(grove.id, mycoHome))).toBe(false);
+  });
+
+  it('refuses kind=grove for an unknown Grove id without creating groves/<id>/ (RC-5)', async () => {
+    const unknownId = 'grove_' + 'f'.repeat(32);
+    const handlers = makeHandlers();
+
+    let caught: unknown;
+    try {
+      await handlers.handleOptimize(emptyRequest({ scope: { kind: 'grove', grove_id: unknownId } }));
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(UnknownGroveError);
+    expect(fs.existsSync(resolveGroveDir(unknownId, mycoHome))).toBe(false);
   });
 
   it('coalesces concurrent identical all-groves dispatches', async () => {

--- a/tests/daemon/api/embedding-scope.test.ts
+++ b/tests/daemon/api/embedding-scope.test.ts
@@ -1,0 +1,131 @@
+/**
+ * RC-5 served_by gate on the embedding action endpoints' single-Grove arm.
+ *
+ * The body-scope `grove_id` arrives outside the request-context funnel, so
+ * the handlers themselves must refuse foreign-served and unknown Groves
+ * BEFORE the runtime cache opens the Grove DB and builds an embedding
+ * runtime on it. Throws propagate to the daemon transport (403
+ * foreign_grove / 404 grove_not_found).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DaemonLogger } from '@myco/daemon/logger.js';
+import { GroveRuntimeCache } from '@myco/daemon/grove-runtime-cache.js';
+import { createEmbeddingActionHandlers } from '@myco/daemon/api/embedding.js';
+import type { EmbeddingManager } from '@myco/daemon/embedding/index.js';
+import { ensureGroveDatabase } from '@myco/grove/database.js';
+import { createGrove, ForeignGroveError, UnknownGroveError } from '@myco/grove/registry.js';
+import { resolveGroveDbPath, resolveGroveDir } from '@myco/grove/paths.js';
+import type { RouteRequest } from '@myco/daemon/router.js';
+
+function emptyRequest(body: unknown = undefined): RouteRequest {
+  return { body, query: {}, params: {}, pathname: '/api/embeddings/clean-orphans' };
+}
+
+// Stub runtime: the gate must fire before the factory is ever invoked for
+// foreign/unknown Groves; the owned-Grove path only needs an object shape.
+function stubEmbeddingFactory() {
+  return {
+    vectorStore: undefined as never,
+    embeddingManager: {
+      cleanOrphans: () => ({ orphans_removed: 0 }),
+    } as unknown as EmbeddingManager,
+  };
+}
+
+describe('embedding scope-aware actions — served_by ownership gate', () => {
+  let workDir: string;
+  let mycoHome: string;
+  let previousMycoHome: string | undefined;
+  let previousVariant: string | undefined;
+  let logger: DaemonLogger;
+  let cache: GroveRuntimeCache;
+
+  beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'embed-scope-'));
+    mycoHome = path.join(workDir, 'home');
+    fs.mkdirSync(mycoHome, { recursive: true });
+    previousMycoHome = process.env.MYCO_HOME;
+    process.env.MYCO_HOME = mycoHome;
+    // served_by gates compare against currentDaemonVariant(); pin the
+    // default 'service' variant regardless of the ambient shell.
+    previousVariant = process.env.MYCO_SERVICE_VARIANT;
+    delete process.env.MYCO_SERVICE_VARIANT;
+    logger = new DaemonLogger(path.join(workDir, 'logs'), { level: 'error' });
+    cache = new GroveRuntimeCache();
+  });
+
+  afterEach(() => {
+    cache.closeAll();
+    if (previousMycoHome === undefined) delete process.env.MYCO_HOME;
+    else process.env.MYCO_HOME = previousMycoHome;
+    if (previousVariant === undefined) delete process.env.MYCO_SERVICE_VARIANT;
+    else process.env.MYCO_SERVICE_VARIANT = previousVariant;
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  function makeHandlers() {
+    return createEmbeddingActionHandlers({
+      cache,
+      embeddingRuntimeFactory: stubEmbeddingFactory,
+      logger,
+      resolveRequestRuntime: () => {
+        throw new Error('kind=grove dispatch must not touch the request runtime');
+      },
+      daemonStateDir: path.join(mycoHome, 'service'),
+      mycoHome,
+    });
+  }
+
+  it('runs against a Grove served by this daemon variant', async () => {
+    const grove = createGrove('alpha', mycoHome);
+    ensureGroveDatabase(grove.id, mycoHome);
+    const handlers = makeHandlers();
+
+    const res = await handlers.handleCleanOrphans(
+      emptyRequest({ scope: { kind: 'grove', grove_id: grove.id } }),
+    );
+
+    const body = res.body as { results: Array<{ grove_id: string; ok: boolean }>; summary: { ok: number } };
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]!.grove_id).toBe(grove.id);
+    expect(body.summary.ok).toBe(1);
+  });
+
+  it('refuses a foreign-served Grove before creating its DB or embedding runtime (RC-5)', async () => {
+    const grove = createGrove('dogfood', mycoHome, { servedBy: 'service-dev' });
+    const handlers = makeHandlers();
+
+    let caught: unknown;
+    try {
+      await handlers.handleCleanOrphans(
+        emptyRequest({ scope: { kind: 'grove', grove_id: grove.id } }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    // Thrown BEFORE wrapPerGroveResult, so the refusal is not swallowed
+    // into an ok:false result row; the foreign DB was never opened.
+    expect(caught).toBeInstanceOf(ForeignGroveError);
+    expect(fs.existsSync(resolveGroveDbPath(grove.id, mycoHome))).toBe(false);
+  });
+
+  it('refuses an unknown Grove id without creating groves/<id>/ (RC-5)', async () => {
+    const unknownId = 'grove_' + 'f'.repeat(32);
+    const handlers = makeHandlers();
+
+    let caught: unknown;
+    try {
+      await handlers.handleCleanOrphans(
+        emptyRequest({ scope: { kind: 'grove', grove_id: unknownId } }),
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(UnknownGroveError);
+    expect(fs.existsSync(resolveGroveDir(unknownId, mycoHome))).toBe(false);
+  });
+});

--- a/tests/daemon/api/maintenance.test.ts
+++ b/tests/daemon/api/maintenance.test.ts
@@ -10,7 +10,9 @@ import { resolveGroveDir } from '@myco/grove/paths.js';
 import { resolveGroveDbPath } from '@myco/grove/paths.js';
 import {
   createGrove,
+  ForeignGroveError,
   registerProjectInGrove,
+  UnknownGroveError,
   type GroveRecord,
 } from '@myco/grove/registry.js';
 import { MycoConfigSchema, type MycoConfig } from '@myco/config/schema.js';
@@ -46,6 +48,7 @@ describe('maintenance API', () => {
   let workDir: string;
   let mycoHome: string;
   let previousMycoHome: string | undefined;
+  let previousVariant: string | undefined;
   let logger: DaemonLogger;
 
   beforeEach(() => {
@@ -54,6 +57,10 @@ describe('maintenance API', () => {
     fs.mkdirSync(mycoHome, { recursive: true });
     previousMycoHome = process.env.MYCO_HOME;
     process.env.MYCO_HOME = mycoHome;
+    // served_by gates compare against currentDaemonVariant(); pin the
+    // default 'service' variant regardless of the ambient shell.
+    previousVariant = process.env.MYCO_SERVICE_VARIANT;
+    delete process.env.MYCO_SERVICE_VARIANT;
     logger = makeLogger(workDir);
   });
 
@@ -63,6 +70,8 @@ describe('maintenance API', () => {
     } else {
       process.env.MYCO_HOME = previousMycoHome;
     }
+    if (previousVariant === undefined) delete process.env.MYCO_SERVICE_VARIANT;
+    else process.env.MYCO_SERVICE_VARIANT = previousVariant;
     fs.rmSync(workDir, { recursive: true, force: true });
   });
 
@@ -324,10 +333,34 @@ describe('maintenance API', () => {
   // ---------------------------------------------------------------------
 
   describe('handleGroveMaintenance', () => {
-    it('returns 404 for an unknown Grove id', async () => {
+    it('throws UnknownGroveError for an unknown Grove id without creating groves/<id>/ (transport maps it to 404)', async () => {
       const { cache, handlers } = makeHandlers();
-      const response = await handlers.handleGroveMaintenance(emptyRequest({ id: 'grv_does_not_exist' }));
-      expect(response.status).toBe(404);
+      const unknownId = 'grove_' + 'f'.repeat(32);
+      for (const id of [unknownId, 'grv_does_not_exist']) {
+        let caught: unknown;
+        try {
+          await handlers.handleGroveMaintenance(emptyRequest({ id }));
+        } catch (err) {
+          caught = err;
+        }
+        expect(caught).toBeInstanceOf(UnknownGroveError);
+      }
+      // The well-formed unknown id must not have materialized a Grove dir.
+      expect(fs.existsSync(resolveGroveDir(unknownId, mycoHome))).toBe(false);
+      cache.closeAll();
+    });
+
+    it('throws ForeignGroveError for a Grove served by the other daemon variant, without opening its DB', async () => {
+      const grove = createGrove('Dogfood', mycoHome, { servedBy: 'service-dev' });
+      const { cache, handlers } = makeHandlers();
+      let caught: unknown;
+      try {
+        await handlers.handleGroveMaintenance(emptyRequest({ id: grove.id }));
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(ForeignGroveError);
+      expect(fs.existsSync(resolveGroveDbPath(grove.id, mycoHome))).toBe(false);
       cache.closeAll();
     });
 

--- a/tests/daemon/grove-ownership-boundary.test.ts
+++ b/tests/daemon/grove-ownership-boundary.test.ts
@@ -1,10 +1,17 @@
-import { describe, it, expect, beforeEach } from 'bun:test';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs, { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { forEachGrove } from '@myco/daemon/scope-iteration.js';
 import { GroveRuntimeCache } from '@myco/daemon/grove-runtime-cache.js';
+import { DaemonServer } from '@myco/daemon/server.js';
+import { createDatabaseMaintenanceHandlers } from '@myco/daemon/api/database.js';
+import { DaemonLogger } from '@myco/daemon/logger.js';
 import type { Logger } from '@myco/daemon/logger.js';
+import { createGrove, registerProjectInGrove, type GroveRecord } from '@myco/grove/registry.js';
+import { resolveGroveDbPath } from '@myco/grove/paths.js';
+import { saveProjectManifest } from '@myco/config/project-manifest.js';
+import { sandboxMycoHome } from '../helpers/myco-home-sandbox.js';
 
 const noopLogger = { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} } as unknown as Logger;
 
@@ -52,5 +59,153 @@ describe('forEachGrove ownership boundary', () => {
       { mycoHome, daemonStateDir: path.join(mycoHome, 'service') },
     );
     expect(visited).toEqual(['default']);
+  });
+});
+
+/**
+ * RC-5 request seam: the daemon's inbound header resolution must refuse a
+ * Grove served by the other variant with a 403 `foreign_grove` BEFORE any
+ * handler runs or the Grove's database is opened — every grove-resolving
+ * header branch funnels through the same gate.
+ */
+describe('DaemonServer served_by ownership gate on inbound requests', () => {
+  let sandbox: ReturnType<typeof sandboxMycoHome>;
+  let previousVariant: string | undefined;
+  let tmp: string;
+  let logger: DaemonLogger;
+  let server: DaemonServer;
+  let foreignGrove: GroveRecord;
+  let ownedGrove: GroveRecord;
+  let foreignRoot: string;
+  let ownedRoot: string;
+
+  beforeEach(async () => {
+    sandbox = sandboxMycoHome('myco-served-by-daemon-');
+    previousVariant = process.env.MYCO_SERVICE_VARIANT;
+    // This test server runs as the production 'service' variant.
+    delete process.env.MYCO_SERVICE_VARIANT;
+    tmp = mkdtempSync(path.join(tmpdir(), 'myco-served-by-seam-'));
+
+    // Foreign Grove (dev-served) with a registered project — both header
+    // shapes below must be refused.
+    foreignGrove = createGrove('Dogfood', sandbox.mycoHome, { servedBy: 'service-dev' });
+    foreignRoot = path.join(tmp, 'foreign-project');
+    const foreignVault = path.join(foreignRoot, '.myco');
+    mkdirSync(foreignVault, { recursive: true });
+    saveProjectManifest(foreignVault, {
+      project: { id: 'proj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', name: 'Foreign' },
+      grove: { binding_id: 'gbind-foreign', slug: foreignGrove.slug, mode: 'local' },
+    });
+    registerProjectInGrove(foreignGrove.id, {
+      projectId: 'proj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      projectName: 'Foreign',
+      projectRoot: foreignRoot,
+      bindingId: 'gbind-foreign',
+    }, sandbox.mycoHome);
+
+    // Owned Grove (service-served) control.
+    ownedGrove = createGrove('Work', sandbox.mycoHome, { servedBy: 'service' });
+    ownedRoot = path.join(tmp, 'owned-project');
+    mkdirSync(path.join(ownedRoot, '.myco'), { recursive: true });
+    registerProjectInGrove(ownedGrove.id, {
+      projectId: 'proj_cccccccccccccccccccccccccccccccc',
+      projectName: 'Owned',
+      projectRoot: ownedRoot,
+    }, sandbox.mycoHome);
+
+    const anchorVault = path.join(tmp, 'anchor', '.myco');
+    mkdirSync(path.join(anchorVault, 'logs'), { recursive: true });
+    logger = new DaemonLogger(path.join(anchorVault, 'logs'));
+    server = new DaemonServer({ vaultDir: anchorVault, logger });
+    server.registerRoute('GET', '/test/ctx', async (req) => ({
+      body: { grove_id: req.requestContext?.groveId ?? null },
+    }));
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    logger.close();
+    if (previousVariant === undefined) delete process.env.MYCO_SERVICE_VARIANT;
+    else process.env.MYCO_SERVICE_VARIANT = previousVariant;
+    fs.rmSync(tmp, { recursive: true, force: true });
+    sandbox.restore();
+  });
+
+  async function request(headers: Record<string, string>) {
+    return fetch(`http://127.0.0.1:${server.port}/test/ctx`, {
+      headers: { 'x-myco-auth': server.getAuthToken(), ...headers },
+    });
+  }
+
+  it('returns 403 foreign_grove for a foreign Grove named by x-myco-grove-id, without creating its DB', async () => {
+    const res = await request({
+      'x-myco-grove-id': foreignGrove.id,
+      'x-myco-project-id': 'proj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json() as { error: string; grove_id: string; served_by: string };
+    expect(body.error).toBe('foreign_grove');
+    expect(body.grove_id).toBe(foreignGrove.id);
+    expect(body.served_by).toBe('service-dev');
+    // The refusal happened before the runtime cache opened the Grove DB.
+    expect(fs.existsSync(resolveGroveDbPath(foreignGrove.id, sandbox.mycoHome))).toBe(false);
+  });
+
+  it('returns 403 foreign_grove when only x-myco-project-root names the foreign project (manifest funnel)', async () => {
+    const res = await request({ 'x-myco-project-root': foreignRoot });
+    expect(res.status).toBe(403);
+    const body = await res.json() as { error: string; grove_id: string };
+    expect(body.error).toBe('foreign_grove');
+    expect(body.grove_id).toBe(foreignGrove.id);
+    expect(fs.existsSync(resolveGroveDbPath(foreignGrove.id, sandbox.mycoHome))).toBe(false);
+  });
+
+  it('serves a Grove owned by this daemon variant', async () => {
+    const res = await request({
+      'x-myco-grove-id': ownedGrove.id,
+      'x-myco-project-id': 'proj_cccccccccccccccccccccccccccccccc',
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { grove_id: string };
+    expect(body.grove_id).toBe(ownedGrove.id);
+  });
+
+  it('translates handler-thrown gate errors on the body-scope channel: 403 foreign_grove / 404 grove_not_found', async () => {
+    // Body-scope `grove_id` bypasses the header funnel; the handler's
+    // assertOwnedGrove throws and the server catch does the translation.
+    const dbHandlers = createDatabaseMaintenanceHandlers({
+      createManager: () => {
+        throw new Error('details endpoint not used in this test');
+      },
+      cache: new GroveRuntimeCache(),
+      logger,
+      vaultDir: path.join(tmp, 'anchor', '.myco'),
+      daemonStateDir: path.join(sandbox.mycoHome, 'service'),
+      mycoHome: sandbox.mycoHome,
+    });
+    server.registerRoute('POST', '/test/database/optimize', dbHandlers.handleOptimize);
+
+    async function optimize(groveId: string) {
+      return fetch(`http://127.0.0.1:${server.port}/test/database/optimize`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scope: { kind: 'grove', grove_id: groveId } }),
+      });
+    }
+
+    const foreignRes = await optimize(foreignGrove.id);
+    expect(foreignRes.status).toBe(403);
+    const foreignBody = await foreignRes.json() as { error: string; served_by: string };
+    expect(foreignBody.error).toBe('foreign_grove');
+    expect(foreignBody.served_by).toBe('service-dev');
+    expect(fs.existsSync(resolveGroveDbPath(foreignGrove.id, sandbox.mycoHome))).toBe(false);
+
+    const unknownId = 'grove_' + 'f'.repeat(32);
+    const unknownRes = await optimize(unknownId);
+    expect(unknownRes.status).toBe(404);
+    const unknownBody = await unknownRes.json() as { error: string };
+    expect(unknownBody.error).toBe('grove_not_found');
+    expect(fs.existsSync(path.join(sandbox.mycoHome, 'groves', unknownId))).toBe(false);
   });
 });

--- a/tests/mcp/http.test.ts
+++ b/tests/mcp/http.test.ts
@@ -221,4 +221,65 @@ describe('streamable HTTP MCP', () => {
       'x-myco-session-id': 'sess-a',
     });
   });
+
+  it('rejects a foreign-served Grove with 403 foreign_grove, not the legacy_vault 503', async () => {
+    const previousHome = process.env.MYCO_HOME;
+    const previousVariant = process.env.MYCO_SERVICE_VARIANT;
+    // Env mutation and fixture setup live inside the try so a setup
+    // throw can't leak MYCO_HOME / MYCO_SERVICE_VARIANT into later tests.
+    try {
+      delete process.env.MYCO_SERVICE_VARIANT;
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-http-mcp-foreign-'));
+      tmpDirs.push(tmp);
+      const home = path.join(tmp, 'home');
+      process.env.MYCO_HOME = home;
+      const projectRoot = path.join(tmp, 'proj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+      const vaultDir = path.join(projectRoot, '.myco');
+      fs.mkdirSync(vaultDir, { recursive: true });
+      // The Grove is served by the dev daemon; this handler runs as the
+      // 'service' variant, so resolution must refuse it up front.
+      const grove = createGrove('Dogfood', home, { servedBy: 'service-dev' });
+      saveProjectManifest(vaultDir, {
+        project: { id: 'proj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', name: 'Project B' },
+        grove: { binding_id: 'gbind-b', slug: grove.slug, mode: 'local' },
+      });
+      registerProjectInGrove(grove.id, {
+        projectId: 'proj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        projectName: 'Project B',
+        projectRoot,
+        bindingId: 'gbind-b',
+      }, home);
+      const handler = createStreamableMcpHttpHandler(vaultDir, { client: mockClient() });
+      const url = await listen((req, res) => {
+        void handler(req, res);
+      });
+
+      const body = JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'myco_cortex', arguments: { op: 'digest', tier: 5000 } },
+      });
+      const response = await fetch(url.toString(), {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          accept: 'application/json, text/event-stream',
+          'x-myco-grove-id': grove.id,
+          'x-myco-project-id': 'proj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        },
+        body,
+      });
+      expect(response.status).toBe(403);
+      const payload = await response.json() as { error?: string; grove_id?: string; served_by?: string };
+      expect(payload.error).toBe('foreign_grove');
+      expect(payload.grove_id).toBe(grove.id);
+      expect(payload.served_by).toBe('service-dev');
+    } finally {
+      if (previousHome === undefined) delete process.env.MYCO_HOME;
+      else process.env.MYCO_HOME = previousHome;
+      if (previousVariant === undefined) delete process.env.MYCO_SERVICE_VARIANT;
+      else process.env.MYCO_SERVICE_VARIANT = previousVariant;
+    }
+  });
 });

--- a/tests/tools/call-context-served-by.test.ts
+++ b/tests/tools/call-context-served-by.test.ts
@@ -1,0 +1,258 @@
+/**
+ * RC-5: `grove.toml served_by` ownership gate at the on-demand seams.
+ *
+ * A `grove_id` tool-call pivot (and the daemon's header resolution —
+ * covered in tests/daemon + tests/mcp) must refuse a Grove served by the
+ * other daemon variant BEFORE the dispatcher opens that Grove's database,
+ * otherwise a dev daemon/CLI can create or schema-migrate a prod-served
+ * Grove's DB. The client-side resolvers (hooks, stdio bridge, CLI env)
+ * must stay non-throwing — a throw there is silently swallowed and drops
+ * capture headers.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { openDatabase, type Database } from '@myco/db/client.js';
+import { createSchema } from '@myco/db/schema.js';
+import type { DaemonClient } from '@myco/hooks/client.js';
+import { createMycoTools } from '@myco/tools/index.js';
+import { isToolError } from '@myco/tools/error.js';
+import {
+  ForeignGroveError,
+  requestContextFromEnvironment,
+  requestContextFromHttpHeaders,
+  resolveLegacyRequestContext,
+  type MycoRequestContext,
+} from '@myco/grove/request-context.js';
+import { assertGroveProjectId, createProjectId } from '@myco/grove/ids.js';
+import {
+  createGrove,
+  registerProjectInGrove,
+  setGroveServedBy,
+  type GroveRecord,
+} from '@myco/grove/registry.js';
+import { resolveGroveDbPath } from '@myco/grove/paths.js';
+import { ensureProjectManifest } from '@myco/config/project-manifest.js';
+import { sandboxMycoHome } from '../helpers/myco-home-sandbox.js';
+import { vi } from '../helpers/vi-shim.js';
+
+const BASE_PROJECT_ID = assertGroveProjectId(createProjectId());
+
+function mockClient(): DaemonClient {
+  return {
+    get: vi.fn().mockResolvedValue({ ok: true, data: {} }),
+    post: vi.fn().mockResolvedValue({ ok: true, data: {} }),
+    put: vi.fn().mockResolvedValue({ ok: true, data: {} }),
+    delete: vi.fn().mockResolvedValue({ ok: true, data: {} }),
+  } as unknown as DaemonClient;
+}
+
+/** Base vault + caller context the tool runtime launches under. */
+function createFixture(): {
+  vaultDir: string;
+  requestContext: MycoRequestContext;
+  cleanup: () => void;
+} {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-served-by-gate-'));
+  const vaultDir = path.join(root, '.myco');
+  fs.mkdirSync(vaultDir, { recursive: true });
+  const db: Database = openDatabase(path.join(vaultDir, 'myco.db'));
+  createSchema(db);
+  db.close();
+  const requestContext = resolveLegacyRequestContext(vaultDir, {
+    projectRoot: root,
+    projectId: BASE_PROJECT_ID,
+    groveId: 'grove-base',
+    machineId: 'machine-a',
+    source: 'explicit',
+    tenancySource: 'caller',
+  });
+  return {
+    vaultDir,
+    requestContext,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+async function callToolError(
+  tools: ReturnType<typeof createMycoTools>,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  try {
+    await tools.callTool(name, args);
+    return null;
+  } catch (err) {
+    return err;
+  }
+}
+
+describe('grove_id pivot served_by ownership gate', () => {
+  let sandbox: ReturnType<typeof sandboxMycoHome>;
+  let previousVariant: string | undefined;
+
+  beforeEach(() => {
+    sandbox = sandboxMycoHome('myco-served-by-');
+    previousVariant = process.env.MYCO_SERVICE_VARIANT;
+    delete process.env.MYCO_SERVICE_VARIANT;
+  });
+
+  afterEach(() => {
+    if (previousVariant === undefined) delete process.env.MYCO_SERVICE_VARIANT;
+    else process.env.MYCO_SERVICE_VARIANT = previousVariant;
+    sandbox.restore();
+  });
+
+  it('rejects a pivot into a foreign-served Grove before its database is created, and allows same-variant pivots', async () => {
+    const fixture = createFixture();
+    try {
+      const foreign = createGrove('Dogfood', sandbox.mycoHome, { servedBy: 'service-dev' });
+      const owned = createGrove('Work', sandbox.mycoHome, { servedBy: 'service' });
+      const tools = createMycoTools(fixture.vaultDir, mockClient(), { requestContext: fixture.requestContext });
+
+      // Driven through callTool so the gate is proven to fire before
+      // runWithRequestDatabase opens (and createSchema-migrates) the
+      // target Grove's DB.
+      const caught = await callToolError(tools, 'myco_plans', { grove_id: foreign.id });
+      expect(isToolError(caught)).toBe(true);
+      expect((caught as { code: string }).code).toBe('foreign_grove');
+      expect((caught as Error).message).toContain('myco grove claim');
+      expect(fs.existsSync(resolveGroveDbPath(foreign.id, sandbox.mycoHome))).toBe(false);
+
+      // Same-variant pivot resolves and opens the owned Grove's DB.
+      const plans = await tools.callTool('myco_plans', { grove_id: owned.id });
+      expect(Array.isArray(plans)).toBe(true);
+      expect(fs.existsSync(resolveGroveDbPath(owned.id, sandbox.mycoHome))).toBe(true);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('matches the gate to the current daemon variant (service vs service-dev)', async () => {
+    const fixture = createFixture();
+    try {
+      const devGrove = createGrove('Dogfood', sandbox.mycoHome, { servedBy: 'service-dev' });
+      const prodGrove = createGrove('Prod', sandbox.mycoHome, { servedBy: 'service' });
+      const tools = createMycoTools(fixture.vaultDir, mockClient(), { requestContext: fixture.requestContext });
+
+      process.env.MYCO_SERVICE_VARIANT = 'dev';
+      expect(Array.isArray(await tools.callTool('myco_plans', { grove_id: devGrove.id }))).toBe(true);
+      const devCaught = await callToolError(tools, 'myco_plans', { grove_id: prodGrove.id });
+      expect((devCaught as { code: string }).code).toBe('foreign_grove');
+      expect((devCaught as Error).message).toContain('service');
+
+      process.env.MYCO_SERVICE_VARIANT = 'service';
+      expect(Array.isArray(await tools.callTool('myco_plans', { grove_id: prodGrove.id }))).toBe(true);
+      const prodCaught = await callToolError(tools, 'myco_plans', { grove_id: devGrove.id });
+      expect((prodCaught as { code: string }).code).toBe('foreign_grove');
+      expect((prodCaught as Error).message).toContain('service-dev');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('treats a legacy grove.toml without served_by as service-owned', async () => {
+    const fixture = createFixture();
+    const legacyId = 'grove_cccccccccccccccccccccccccccccccc';
+    try {
+      const groveDir = path.join(sandbox.mycoHome, 'groves', legacyId);
+      fs.mkdirSync(groveDir, { recursive: true });
+      fs.writeFileSync(path.join(groveDir, 'grove.toml'),
+        `[grove]\nid = "${legacyId}"\nname = "Legacy"\nslug = "legacy"\nmode = "local"\ncreated_at = "2026-01-01T00:00:00Z"\n`);
+      const tools = createMycoTools(fixture.vaultDir, mockClient(), { requestContext: fixture.requestContext });
+
+      // Normalized to 'service' on read: the production variant passes…
+      expect(Array.isArray(await tools.callTool('myco_plans', { grove_id: legacyId }))).toBe(true);
+
+      // …and the dev variant is refused.
+      process.env.MYCO_SERVICE_VARIANT = 'dev';
+      const caught = await callToolError(tools, 'myco_plans', { grove_id: legacyId });
+      expect((caught as { code: string }).code).toBe('foreign_grove');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('admits a pivot after a claim flips served_by to this variant', async () => {
+    const fixture = createFixture();
+    try {
+      process.env.MYCO_SERVICE_VARIANT = 'dev';
+      const grove = createGrove('Claimable', sandbox.mycoHome, { servedBy: 'service' });
+      const tools = createMycoTools(fixture.vaultDir, mockClient(), { requestContext: fixture.requestContext });
+
+      const caught = await callToolError(tools, 'myco_plans', { grove_id: grove.id });
+      expect((caught as { code: string }).code).toBe('foreign_grove');
+
+      setGroveServedBy(grove.id, 'service-dev', sandbox.mycoHome);
+      expect(Array.isArray(await tools.callTool('myco_plans', { grove_id: grove.id }))).toBe(true);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+
+describe('client-side resolvers stay non-throwing for foreign-served Groves', () => {
+  let sandbox: ReturnType<typeof sandboxMycoHome>;
+  let previousVariant: string | undefined;
+  let projectRoot: string;
+  let vaultDir: string;
+  let foreign: GroveRecord;
+  let projectId: string;
+
+  beforeEach(() => {
+    sandbox = sandboxMycoHome('myco-served-by-client-');
+    previousVariant = process.env.MYCO_SERVICE_VARIANT;
+    delete process.env.MYCO_SERVICE_VARIANT;
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-served-by-proj-'));
+    vaultDir = path.join(projectRoot, '.myco');
+    const manifest = ensureProjectManifest(vaultDir, { projectName: 'served-by-client' });
+    foreign = createGrove('Dogfood', sandbox.mycoHome, { servedBy: 'service-dev' });
+    // Registered id must match the manifest's minted project id — the
+    // resolver cross-checks the registered root's project.toml.
+    projectId = manifest.project.id;
+    registerProjectInGrove(foreign.id, {
+      projectId,
+      projectName: 'Foreign project',
+      projectRoot,
+    }, sandbox.mycoHome);
+  });
+
+  afterEach(() => {
+    if (previousVariant === undefined) delete process.env.MYCO_SERVICE_VARIANT;
+    else process.env.MYCO_SERVICE_VARIANT = previousVariant;
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+    sandbox.restore();
+  });
+
+  it('requestContextFromEnvironment resolves a foreign-served Grove without throwing (hooks/CLI contract)', () => {
+    const context = requestContextFromEnvironment({
+      MYCO_GROVE_ID: foreign.id,
+      MYCO_PROJECT_ID: projectId,
+    }, vaultDir);
+    expect(context.groveId).toBe(foreign.id);
+    expect(context.tenancySource).toBe('caller');
+  });
+
+  it('requestContextFromHttpHeaders only enforces ownership when the daemon opts in', () => {
+    const headers = {
+      'x-myco-grove-id': foreign.id,
+      'x-myco-project-id': projectId,
+    };
+
+    // Default (client-side / shared) behavior: resolves, no throw.
+    const context = requestContextFromHttpHeaders(headers, vaultDir);
+    expect(context.groveId).toBe(foreign.id);
+
+    // Daemon-side opt-in: the same headers are refused.
+    let caught: unknown;
+    try {
+      requestContextFromHttpHeaders(headers, vaultDir, { enforceGroveOwnership: true });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ForeignGroveError);
+    expect((caught as ForeignGroveError).groveId).toBe(foreign.id);
+    expect((caught as ForeignGroveError).servedBy).toBe('service-dev');
+  });
+});


### PR DESCRIPTION
## What

Fixes the tenancy gap from the 2026-06-10 bug hunt (RC-5, P1, reproduced): Grove ownership (`grove.toml served_by`; the claim/release invariant) was enforced on every background daemon path but **not at the on-demand seams**. A tool call pivoting via body `grove_id`, an HTTP request resolving a grove via headers or manifest, or four body-scope/URL admin channels could resolve a Grove served by the *other* daemon variant — and `GroveRuntimeCache.getDatabase` unconditionally runs `createSchema`, so a dev daemon (or dev CLI `myco tool call`) answering such a request **creates or schema-migrates a prod-served Grove's DB on demand** (the documented cross-version bootstrap-anchor incident class, made triggerable at will). One channel even created grove directories for arbitrary junk ids.

## How

Single-seam pattern, mirroring `requireCallerTenancy`/`projectScopeFromRequestContext`:
- **Primitives** (`grove/registry.ts`): `groveServedByThisDaemon` (plain equality — `served_by` is always normalized `'service'|'service-dev'` at load), `ForeignGroveError`, `UnknownGroveError`, `assertOwnedGrove` (existence → ownership; junk ids never materialize directories).
- **Body pivot**: `resolveCallContext` rejects foreign groves with new closed-set `ToolError('foreign_grove')` before any DB path resolves.
- **Header/manifest funnel**: opt-in `enforceGroveOwnership` at `buildRegisteredRequestContext`, covering all three grove-resolving branches (omitting the grove header is not a bypass). Enabled **only** where the daemon resolves inbound requests; `requestContextFromEnvironment` hard-passes false — hooks/stdio-bridge/CLI header building can never throw here (a throw inside the hook client's fallback catch would silently drop capture headers — the capture-loss class).
- **Four bypass channels** found by the adversarial diff review and closed in the same PR: database maintenance ops, embedding single-grove ops (gated before the result wrapper that swallows throws), backup create, and the grove maintenance summary route — each via `assertOwnedGrove` before any `getDatabase`.
- **Surfacing**: 403 `{ error: 'foreign_grove', grove_id, served_by }` on both transports + a warn log (hooks swallow 403s; the log is the diagnosable trace during a claim window); mcp/http no longer mislabels refusals as `legacy_vault`; unknown ids → 404 `grove_not_found`.

## ⚠️ Deliberate behavior change

Projects in a **dev-claimed grove** whose hooks/MCP still route to the prod daemon (not yet dev-linked) now get a **loud 403** instead of silently cross-writing the dev-owned grove. This is the ownership invariant working as intended ("don't soften the boundary"); hooks degrade through their existing buffer/fallback handling. Worth watching during the next dogfood claim window — the new warn log is the trace.

## Documented residual (follow-up, not this PR)

The CLI's **non-pivot** manifest base context can still open a foreign-variant grove DB in-process (`tools/index.ts` front door; comment added, tracked in the remediation plan). Pivots are gated; the base-context case needs its own design since the CLI is the serving engine there.

## Tests

`tests/tools/call-context-served-by.test.ts` (pivot gate via `tools.callTool` with DB-not-created ordering proofs, variant matrix under `MYCO_SERVICE_VARIANT`, legacy served_by normalization, claim round-trip, client-side non-throwing contract) + per-channel foreign/unknown/owned coverage (database-scope, embedding-scope, backup handlers, maintenance) + end-to-end transport assertions (real DaemonServer 403/404; mcp/http `foreign_grove` not `legacy_vault`). One pre-existing test updated (maintenance unknown-id 404 moved to the shared gate + server translation, pinned end-to-end).

Full suite green: all 86 phase JUnit artifacts `failures="0"`, every phase exit 0; tsc clean. No schema or `SYNC_PROTOCOL_VERSION` impact.

Pipeline: independently reviewed plan (caught the client-side throw hazard + funnel coverage + transport mislabeling before implementation) → implementation → adversarial diff review (caught the four body-scope bypass channels) → all fixed and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)