### PR TITLE
cli: strict argv parsing, destructive-op guards, honest exit codes (RC-6)

### DIFF
--- a/.agents/skills/grove-multi-tenant-architecture/SKILL.md
+++ b/.agents/skills/grove-multi-tenant-architecture/SKILL.md
@@ -294,7 +294,7 @@ When implementing project migration, bulk deletion, or Grove-wide operations, be
 
 ### myco remove --purge Blast Radius
 
-The `myco remove --purge` command performs a registered-project walk that affects ALL projects in the Grove registry unless explicitly scoped. Always use `--scope grove-id` or `--scope project-id` to limit purge operations.
+The `myco remove --purge` command performs a registered-project walk that affects ALL projects served by the current daemon variant, then deletes `~/.myco/` itself — it is the machine-wide teardown and prompts for confirmation (`--yes` to skip). There is no partial scope flag: to limit removal to one project, use `myco remove --project <root>` (add `--remove-vault` to also delete that project's `.myco/`).
 
 ## Procedure G: Security and Authorization Patterns
 

--- a/.agents/skills/install-and-initialize-myco/SKILL.md
+++ b/.agents/skills/install-and-initialize-myco/SKILL.md
@@ -137,16 +137,24 @@ Updates the CLI binary and refreshes hook files, MCP entries, and skill symlinks
 
 This migration preserves configuration values that previously would have been lost during updates. The migrated settings become available to all projects within the Grove while maintaining their configured behavior.
 
-### 6. Removing Myco from a Project
+### 6. Removing Myco
 
 ```bash
 myco remove
 ```
 
-Stops the daemon, removes hooks, removes MCP entries, removes skill symlinks, and cleans gitignore blocks. The vault (`.myco/` with all session history and spores) is **preserved by default**. To also delete the vault:
+Bare `myco remove` is the **machine-wide uninstall**: it unregisters the OS service, strips Myco's blocks from every detected agent's global config, deletes the global launchers, and cleans project-local artifacts in registered projects. Captured data under `~/.myco/` is preserved unless you pass `--purge`. The command prompts for confirmation; pass `--yes` in non-interactive shells.
+
+To remove Myco from a single project instead, pass `--project` (and optionally a path):
 
 ```bash
-myco remove --remove-vault
+myco remove --project /path/to/project
+```
+
+Stops the project daemon and removes hooks, MCP entries, and skill symlinks for that project. The project vault (`.myco/` with all session history and spores) is **preserved by default**. To also delete the vault:
+
+```bash
+myco remove --project /path/to/project --remove-vault
 ```
 
 ## Development Environment Setup

--- a/packages/myco/src/cli.ts
+++ b/packages/myco/src/cli.ts
@@ -13,8 +13,11 @@ const USAGE = `Usage: myco <command> [args]
 Commands:
   grove <subcommand>       Manage local Groves
   update                   Update vault files and agent registration
-  remove [--remove-vault]    Remove Myco from this project (vault preserved by default)
-  remove --symbiont <name>   Unregister a single agent and remove from config
+  remove [--purge] [--yes]   Remove Myco's machine-wide install (prompts unless --yes;
+                             captured data preserved unless --purge)
+  remove --project [<path>] | --symbiont <name> | --remove-vault
+                             Project-scoped removal (any of these flags switches scope;
+                             vault preserved unless --remove-vault)
   config <get|set> [args]  Get or set vault config values
   detect-providers         Detect available LLM/embedding providers (JSON)
   verify                   Test LLM and embedding connectivity

--- a/packages/myco/src/cli/args.ts
+++ b/packages/myco/src/cli/args.ts
@@ -1,0 +1,90 @@
+/**
+ * Strict argv parsing for CLI subcommands with destructive surfaces.
+ *
+ * Each subcommand declares its complete flag vocabulary. Anything outside
+ * that vocabulary — an unknown flag, a stray positional, or a value-taking
+ * flag with no value — is a usage error (exit code 2) rather than a
+ * silently-ignored token. A silently-dropped `--project` on `myco remove`
+ * is how a project-scoped removal becomes a machine-wide teardown, and a
+ * silently-dropped value on `myco update --project` is how a one-project
+ * update fans out to every registered project.
+ *
+ * Benign read-only commands keep the permissive `parseStringFlag` helper;
+ * this module is for commands whose misparse mutates state.
+ */
+
+export interface FlagSpec {
+  /** Canonical flag name, including leading dashes (e.g. '--project'). */
+  name: string;
+  /** Alternate spellings that map to the canonical name (e.g. '-h'). */
+  aliases?: string[];
+  /**
+   * Whether the flag consumes the following token as its value.
+   *  - 'none' (default): boolean flag.
+   *  - 'required': missing value (end of args, or next token is a flag)
+   *    is a usage error.
+   *  - 'optional': value is taken when the next token is not a flag,
+   *    otherwise the flag is treated as bare presence.
+   */
+  value?: 'none' | 'required' | 'optional';
+}
+
+export interface ParsedFlags {
+  /** Whether the flag (by canonical name) was present in argv. */
+  has(name: string): boolean;
+  /** Value for a value-taking flag; undefined when absent or bare. */
+  value(name: string): string | undefined;
+}
+
+/**
+ * Parse argv against a strict flag vocabulary. On any usage error, prints
+ * the offending token plus the command's usage text to stderr and exits
+ * with code 2.
+ */
+export function parseStrictFlags(
+  command: string,
+  args: string[],
+  specs: FlagSpec[],
+  usage: string,
+): ParsedFlags {
+  const byToken = new Map<string, FlagSpec>();
+  for (const spec of specs) {
+    byToken.set(spec.name, spec);
+    for (const alias of spec.aliases ?? []) byToken.set(alias, spec);
+  }
+
+  const present = new Set<string>();
+  const values = new Map<string, string>();
+
+  const fail = (message: string): never => {
+    process.stderr.write(`${command}: ${message}\n\n${usage}`);
+    return process.exit(2);
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const token = args[i]!;
+    if (!token.startsWith('-')) {
+      fail(`unexpected argument '${token}'`);
+    }
+    const spec = byToken.get(token);
+    if (!spec) {
+      fail(`unknown flag '${token}'`);
+      continue;
+    }
+    present.add(spec.name);
+    const mode = spec.value ?? 'none';
+    if (mode === 'none') continue;
+    const next = args[i + 1];
+    if (next !== undefined && !next.startsWith('-')) {
+      values.set(spec.name, next);
+      i++;
+    } else if (mode === 'required') {
+      fail(`${token} requires a value`);
+    }
+  }
+
+  return {
+    has: (name) => present.has(name),
+    value: (name) => values.get(name),
+  };
+}

--- a/packages/myco/src/cli/confirm.ts
+++ b/packages/myco/src/cli/confirm.ts
@@ -1,0 +1,34 @@
+/**
+ * Interactive confirmation gate for destructive CLI operations.
+ *
+ * Callers that accept `--yes` skip this entirely; everyone else routes
+ * destructive work through `confirmDestructive` so a bare invocation can
+ * never tear state down without an explicit human "y".
+ */
+
+/**
+ * Print `summary` and ask for y/N confirmation on the controlling TTY.
+ *
+ * Returns true only on an explicit yes. When stdin is not a TTY the
+ * question cannot be asked, so the summary is printed with a
+ * "re-run with --yes" hint and the result is false — the caller is
+ * expected to abort with a non-zero exit code.
+ */
+export async function confirmDestructive(summary: string): Promise<boolean> {
+  process.stderr.write(`${summary}\n`);
+
+  if (!process.stdin.isTTY) {
+    process.stderr.write(
+      'Confirmation required but stdin is not a TTY. Re-run with --yes to proceed.\n',
+    );
+    return false;
+  }
+
+  const readline = await import('node:readline');
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await new Promise<string>((resolve) => {
+    rl.question('Proceed? [y/N] ', (reply) => resolve(reply));
+  });
+  rl.close();
+  return /^y(es)?$/i.test(answer.trim());
+}

--- a/packages/myco/src/cli/doctor.ts
+++ b/packages/myco/src/cli/doctor.ts
@@ -17,6 +17,7 @@ import {
 import { resolveProjectRoot } from '../vault/resolve.js';
 import { loadProjectManifest } from '../config/project-manifest.js';
 import { isProcessAlive } from './shared.js';
+import { parseStrictFlags } from './args.js';
 import { MYCO_MCP_SERVER_NAME } from '../symbionts/installer.js';
 import { isMycoHookGroup } from '../symbionts/install-helpers.js';
 import { manifestToolTransport } from '../symbionts/capabilities.js';
@@ -57,7 +58,10 @@ export interface DoctorCheck {
 async function checkVault(vaultDir: string): Promise<{ check: DoctorCheck; config: import('../config/schema.js').MycoConfig | null }> {
   const configPath = path.join(vaultDir, CONFIG_FILENAME);
   if (!fs.existsSync(configPath)) {
-    return { check: { name: 'Vault', status: 'fail', detail: `${CONFIG_FILENAME} not found in ${vaultDir}`, fixable: false }, config: null };
+    // Not a failure: `myco doctor` from a non-project directory (e.g.
+    // $HOME right after install) is a documented flow and must exit 0
+    // on a healthy machine. Only an unparseable config is a hard fail.
+    return { check: { name: 'Vault', status: 'warn', detail: `No ${CONFIG_FILENAME} in ${vaultDir} — run from a project directory for project checks`, fixable: false }, config: null };
   }
   try {
     const { loadMergedConfig } = await import('../config/loader.js');
@@ -440,7 +444,11 @@ async function checkDaemon(vaultDir: string): Promise<DoctorCheck> {
   try {
     const state = readDaemonState(daemonFile);
     if (!state) {
-      return { name: 'Daemon', status: 'warn', detail: 'daemon state exists but no PID', fixable: true };
+      // readDaemonState returns null (it never throws) when the file is
+      // unreadable, unparseable, or fails shape validation — the
+      // malformed-state case `fix()` repairs via deleteIfMalformed. The
+      // 'parse error' wording is the contract fix() keys on.
+      return { name: 'Daemon', status: 'fail', detail: 'daemon state parse error: daemon.json exists but is unreadable or malformed', fixable: true };
     }
     if (!state.pid) {
       return { name: 'Daemon', status: 'warn', detail: 'daemon state exists but no PID', fixable: true };
@@ -522,11 +530,18 @@ export async function runChecks(vaultDir: string): Promise<DoctorCheck[]> {
   const checks: DoctorCheck[] = [vaultCheck];
 
   if (!config) {
+    // Vault-dependent checks can't run. These rows are warn, not fail:
+    // an unreadable config already failed the Vault row above, and a
+    // simply-absent config (doctor run outside a project) is a healthy
+    // state that must not flip the exit code.
+    const detail = vaultCheck.status === 'fail'
+      ? 'Skipped (vault check failed)'
+      : 'Skipped — run from a project directory for project checks';
     checks.push(
-      { name: 'Database', status: 'fail', detail: 'Skipped (vault check failed)', fixable: false },
-      { name: 'Intelligence', status: 'fail', detail: 'Skipped (vault check failed)', fixable: false },
-      { name: 'Embeddings', status: 'fail', detail: 'Skipped (vault check failed)', fixable: false },
-      { name: 'Agents', status: 'fail', detail: 'Skipped (vault check failed)', fixable: false },
+      { name: 'Database', status: 'warn', detail, fixable: false },
+      { name: 'Intelligence', status: 'warn', detail, fixable: false },
+      { name: 'Embeddings', status: 'warn', detail, fixable: false },
+      { name: 'Agents', status: 'warn', detail, fixable: false },
       await checkDaemon(vaultDir),
     );
     return checks;
@@ -938,8 +953,26 @@ function formatCheck(check: DoctorCheck): string {
 
 // --- CLI entry point ---
 
+const USAGE = `Usage: myco doctor [--fix]
+
+Check vault and machine install health.
+
+Options:
+  --fix          Attempt to repair fixable issues
+  -h, --help     Show this help
+`;
+
 export async function run(args: string[], vaultDir: string): Promise<void> {
-  const shouldFix = args.includes('--fix');
+  if (args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(USAGE);
+    return;
+  }
+
+  const parsed = parseStrictFlags('myco doctor', args, [
+    { name: '--fix' },
+    { name: '--help', aliases: ['-h'] },
+  ], USAGE);
+  const shouldFix = parsed.has('--fix');
 
   console.log('\nmyco doctor\n');
 
@@ -961,6 +994,10 @@ export async function run(args: string[], vaultDir: string): Promise<void> {
 
   console.log(`  ${issues.length} issue(s) found.`);
 
+  // The exit code reflects the FINAL state: when --fix repairs something,
+  // re-run the checks so `myco doctor --fix && ...` chains succeed after
+  // a successful repair instead of reporting the pre-fix failures.
+  let finalChecks = checks;
   if (shouldFix) {
     const actions = await fix(vaultDir, checks);
     if (actions.length > 0) {
@@ -969,6 +1006,7 @@ export async function run(args: string[], vaultDir: string): Promise<void> {
         console.log(`  Fixed: ${action}`);
       }
       console.log('');
+      finalChecks = await runChecks(vaultDir);
     } else {
       console.log('  No auto-fixable issues.\n');
     }
@@ -976,5 +1014,12 @@ export async function run(args: string[], vaultDir: string): Promise<void> {
     console.log(`  Run \`myco doctor --fix\` to repair ${fixable.length} fixable issue(s).\n`);
   } else {
     console.log('');
+  }
+
+  // Failed checks must be visible to scripts and CI, not just humans
+  // reading the table. Warnings stay exit-0 — a healthy machine install
+  // run outside a project produces only warn rows.
+  if (finalChecks.some((check) => check.status === 'fail')) {
+    process.exitCode = 1;
   }
 }

--- a/packages/myco/src/cli/remove.ts
+++ b/packages/myco/src/cli/remove.ts
@@ -1,5 +1,7 @@
-import { resolveVaultDir, resolveProjectRoot } from '../vault/resolve.js';
-import { isProcessAlive, parseStringFlag } from './shared.js';
+import { resolveVaultDir, resolveProjectRoot, assertSafeProjectRoot, UnsafeProjectRootError } from '../vault/resolve.js';
+import { isProcessAlive } from './shared.js';
+import { parseStrictFlags, type ParsedFlags } from './args.js';
+import { confirmDestructive } from './confirm.js';
 import { loadManifests, resolvePackageRoot } from '../symbionts/detect.js';
 import { SymbiontInstaller, removeProjectLaunchers } from '../symbionts/installer.js';
 import { resolveMycoHome } from '../grove/paths.js';
@@ -25,12 +27,17 @@ With no flags, removes Myco's global install: unregisters the OS service,
 deletes the global launchers, strips Myco's blocks from each detected
 agent's user-global config, and unlinks the Myco-shipped skill symlinks.
 Captured data under ~/.myco/ is preserved unless --purge is passed.
+Prompts for confirmation; pass --yes for non-interactive use.
+
+Passing --project, --symbiont, or --remove-vault switches to project scope.
 
 Options:
-  --project [<path>]     Remove Myco's project-local install (legacy path)
+  --project [<path>]     Remove Myco's project-local install (defaults to cwd)
   --symbiont <name>      Remove just one symbiont's project-local install
-  --purge                Also delete ~/.myco/ (Grove DB + captured data)
-  --remove-vault         Project-scope only: delete the project's .myco/ dir
+  --purge                Global scope: also delete ~/.myco/ (Grove DB + captured data)
+                         Project scope: alias for --remove-vault
+  --remove-vault         Project scope: delete the project's .myco/ dir
+  --yes                  Skip the confirmation prompt
   -h, --help             Show this help
 `;
 
@@ -40,15 +47,65 @@ export async function run(args: string[]): Promise<void> {
     return;
   }
 
-  if (args.includes('--symbiont') || args.includes('--project')) {
-    return await runProjectRemove(args);
+  const parsed = parseStrictFlags('myco remove', args, [
+    { name: '--project', value: 'optional' },
+    { name: '--symbiont', value: 'required' },
+    { name: '--purge' },
+    { name: '--remove-vault' },
+    { name: '--yes' },
+    { name: '--help', aliases: ['-h'] },
+  ], USAGE);
+
+  // --symbiont removes one agent's registration; the vault-deletion flags
+  // don't apply to it. Reject the combination outright — silently
+  // dropping a destructive flag is the bug class this command just shed.
+  if (parsed.has('--symbiont') && (parsed.has('--remove-vault') || parsed.has('--purge'))) {
+    process.stderr.write(`myco remove: --remove-vault/--purge cannot be combined with --symbiont\n\n${USAGE}`);
+    process.exit(2);
   }
 
-  return await runGlobalRemove(args.includes('--purge'));
+  // --remove-vault is a project-scope operation: without this routing it
+  // would fall through to the machine-wide teardown below (and then be
+  // ignored there) — the exact opposite of what the caller asked for.
+  if (parsed.has('--symbiont') || parsed.has('--project') || parsed.has('--remove-vault')) {
+    return await runProjectRemove(parsed);
+  }
+
+  return await runGlobalRemove({
+    purge: parsed.has('--purge'),
+    assumeYes: parsed.has('--yes'),
+  });
 }
 
-async function runGlobalRemove(purge: boolean): Promise<void> {
+async function runGlobalRemove(opts: { purge: boolean; assumeYes: boolean }): Promise<void> {
+  const { purge, assumeYes } = opts;
   const mycoHome = resolveMycoHome();
+
+  if (!assumeYes) {
+    let projectCount = 0;
+    try {
+      const { currentDaemonVariant } = await import('../grove/paths.js');
+      const { listGroves, listRegisteredProjects } = await import('../grove/registry.js');
+      for (const grove of listGroves(mycoHome, { servedBy: currentDaemonVariant() })) {
+        projectCount += listRegisteredProjects(grove.id, mycoHome).length;
+      }
+    } catch { /* registry unreadable — the summary still describes the rest */ }
+    const summary = [
+      'myco remove will tear down the machine-wide Myco install:',
+      '  - unregister the Myco OS service',
+      "  - strip Myco's blocks from every detected agent's global config",
+      `  - clean project-local artifacts in ${projectCount} registered project${projectCount === 1 ? '' : 's'}`,
+      purge
+        ? `  - DELETE ${mycoHome} (Grove DB + all captured data)`
+        : `  - preserve captured data at ${mycoHome} (pass --purge to delete it)`,
+    ].join('\n');
+    if (!await confirmDestructive(summary)) {
+      console.error('Aborted — nothing was removed.');
+      process.exitCode = 1;
+      return;
+    }
+  }
+
   console.log(`Removing Myco global install (${mycoHome})\n`);
 
   // --- Unregister the OS service (do this first so launchd/systemd
@@ -142,16 +199,37 @@ async function cleanProjectLocalArtifacts(projectRoot: string, pkgRoot: string):
   removeProjectLaunchers(projectRoot, { legacy: true, active: true, runtimeCommand: true });
 }
 
-async function runProjectRemove(args: string[]): Promise<void> {
-  const vaultDir = resolveVaultDir();
-  if (!fs.existsSync(path.join(vaultDir, 'myco.yaml'))) {
-    console.error(`No myco.yaml found in ${vaultDir}. Nothing to remove.`);
-    process.exit(1);
+async function runProjectRemove(parsed: ParsedFlags): Promise<void> {
+  const projectArg = parsed.value('--project');
+  const explicitRoot = projectArg ? path.resolve(projectArg) : null;
+  const vaultDir = explicitRoot ? path.join(explicitRoot, '.myco') : resolveVaultDir();
+  const projectRoot = explicitRoot ?? resolveProjectRoot(vaultDir);
+  const hasConfig = fs.existsSync(path.join(vaultDir, 'myco.yaml'));
+  const symbiontName = parsed.value('--symbiont');
+  const assumeYes = parsed.has('--yes');
+  const removeVault = parsed.has('--remove-vault') || parsed.has('--purge');
+
+  // Safety gate BEFORE any cleanup. Project-scope uninstall resolves
+  // config dirs relative to the root, so `--project ~` would strip the
+  // user's GLOBAL agent configs (~/.claude, ~/.cursor, …) and
+  // `--remove-vault` would rmSync ~/.myco itself. Same guard class as
+  // the hook hot path: reject /, $HOME, and home-shaped directories.
+  try {
+    assertSafeProjectRoot(projectRoot);
+  } catch (err) {
+    if (err instanceof UnsafeProjectRootError) {
+      console.error(`Refusing project-scope removal at ${err.projectRoot}: ${err.reason}.`);
+      console.error('Pass the project repository root via --project <path>.');
+      process.exit(1);
+    }
+    throw err;
   }
 
-  const symbiontName = parseStringFlag(args, '--symbiont');
-
   if (symbiontName) {
+    if (!hasConfig) {
+      console.error(`No myco.yaml found in ${vaultDir}. Nothing to remove.`);
+      process.exit(1);
+    }
     const allManifests = loadManifests();
     const manifest = allManifests.find((m) => m.name === symbiontName);
     if (!manifest) {
@@ -159,7 +237,6 @@ async function runProjectRemove(args: string[]): Promise<void> {
       process.exit(1);
     }
 
-    const projectRoot = resolveProjectRoot(vaultDir);
     const pkgRoot = resolvePackageRoot();
     const installer = new SymbiontInstaller(manifest, projectRoot, pkgRoot);
     const removed = uninstallLabels(installer.uninstall());
@@ -179,10 +256,37 @@ async function runProjectRemove(args: string[]): Promise<void> {
     return;
   }
 
-  const projectRoot = resolveProjectRoot(vaultDir);
   const allManifests = loadManifests();
   const pkgRoot = resolvePackageRoot();
-  const removeVault = args.includes('--remove-vault') || args.includes('--purge');
+
+  // Confirm the vault deletion UP FRONT — before any teardown — so a
+  // decline leaves the project fully intact instead of half-removed
+  // (hooks stripped, daemon stopped, vault still present).
+  if (removeVault && !assumeYes && fs.existsSync(vaultDir)) {
+    const confirmed = await confirmDestructive(
+      `This removes Myco's project-local install from ${projectRoot} and permanently deletes the vault at ${vaultDir} (captured sessions, spores, and project config).`,
+    );
+    if (!confirmed) {
+      console.error('Aborted — nothing was removed. Re-run with --yes to skip confirmation.');
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  // Orphan remedy: launcher artifacts without a myco.yaml — the state
+  // `myco doctor` reports as "orphan project-local launcher stubs" and
+  // routes here. There is no config or daemon to act on, but the
+  // launcher/per-symbiont artifact cleanup still applies.
+  if (!hasConfig) {
+    console.log(`No myco.yaml in ${vaultDir} — cleaning orphan launcher artifacts in ${projectRoot}\n`);
+    await cleanProjectLocalArtifacts(projectRoot, pkgRoot);
+    if (removeVault && fs.existsSync(vaultDir)) {
+      fs.rmSync(vaultDir, { recursive: true, force: true });
+      console.log(`  ✓ Removed vault at ${vaultDir}`);
+    }
+    console.log('\nOrphan project-local artifacts cleaned.');
+    return;
+  }
 
   console.log(`Removing Myco project-local install from ${projectRoot}\n`);
 
@@ -226,7 +330,7 @@ async function runProjectRemove(args: string[]): Promise<void> {
     fs.rmSync(vaultDir, { recursive: true, force: true });
     console.log(`  ✓ Removed vault at ${vaultDir}`);
   } else {
-    console.log(`  – Vault preserved at ${vaultDir} (use --purge to delete)`);
+    console.log(`  – Vault preserved at ${vaultDir} (use --remove-vault to delete)`);
   }
 
   console.log('\nMyco project-local install removed.');

--- a/packages/myco/src/cli/update.ts
+++ b/packages/myco/src/cli/update.ts
@@ -1,4 +1,5 @@
 import { resolveVaultDir, resolveProjectRoot } from '../vault/resolve.js';
+import { parseStrictFlags } from './args.js';
 import { ProjectVault } from '@myco/vault/project-vault.js';
 import { resolveProjectDashboardUrl } from './dashboard-url.js';
 import { loadManifests } from '../symbionts/detect.js';
@@ -48,32 +49,40 @@ export async function run(args: string[]): Promise<void> {
     return;
   }
 
+  const parsed = parseStrictFlags('myco update', args, [
+    { name: '--project', value: 'required' },
+    { name: '--all-projects' },
+    { name: '--target-version', value: 'required' },
+    { name: '--cancel-update' },
+    { name: '--help', aliases: ['-h'] },
+  ], USAGE);
+
   // `--target-version <v>` writes a binary-update intent for the daemon's
   // reconciler to pick up. Distinct from the project-config-sync path
   // (the rest of this command). Doesn't touch project files.
-  const targetVersionIdx = args.indexOf('--target-version');
-  if (targetVersionIdx !== -1) {
-    const target = args[targetVersionIdx + 1];
-    if (!target) {
-      console.error('--target-version requires a version argument');
-      process.exit(1);
-    }
-    await runUpdateIntent(target);
+  if (parsed.has('--target-version')) {
+    await runUpdateIntent(parsed.value('--target-version')!);
     return;
   }
 
-  if (args.includes('--cancel-update')) {
+  if (parsed.has('--cancel-update')) {
     await runCancelUpdate();
     return;
   }
 
-  // Explicit single-project targeting — update only this project.
-  const projectIdx = args.indexOf('--project');
-  if (projectIdx !== -1 && args[projectIdx + 1]) {
+  // Explicit single-project targeting — update only this project. The
+  // strict parser guarantees a value: a bare `--project` is a usage
+  // error, not a silent fan-out to every registered project.
+  if (parsed.has('--project')) {
+    let machineWideErrors: string[] = [];
     try {
-      await runForProject(args[projectIdx + 1]);
+      machineWideErrors = await runForProject(parsed.value('--project')!);
     } catch (error) {
       console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+    if (machineWideErrors.length > 0) {
+      reportMachineWideErrors(machineWideErrors);
       process.exit(1);
     }
     return;
@@ -83,6 +92,13 @@ export async function run(args: string[]): Promise<void> {
   // Grove/project, so `myco update` updates them all. `--all-projects`
   // is a deprecated, tolerated alias for this default.
   await runAllProjects();
+}
+
+function reportMachineWideErrors(errors: string[]): void {
+  console.error(`⚠ ${errors.length} machine-wide update step${errors.length === 1 ? '' : 's'} failed:`);
+  for (const error of errors) {
+    console.error(`  - ${error}`);
+  }
 }
 
 /**
@@ -96,8 +112,13 @@ export async function run(args: string[]): Promise<void> {
  * `myco update --all-projects` with N registered projects doesn't
  * re-run these N times. /code-review finding C7.
  */
-async function runMachineWideUpdate(allManifests: SymbiontManifest[], currentVersion: string, stampPath: string): Promise<number> {
+async function runMachineWideUpdate(
+  allManifests: SymbiontManifest[],
+  currentVersion: string,
+  stampPath: string,
+): Promise<{ updatedCount: number; errors: string[] }> {
   let updatedCount = 0;
+  const errors: string[] = [];
 
   // --- Refresh GLOBAL symbiont configs ---
   //
@@ -123,6 +144,7 @@ async function runMachineWideUpdate(allManifests: SymbiontManifest[], currentVer
       console.log(`  ✓ Updated ${label}: ${installed.join(', ')}`);
     } else if (d.status === 'error') {
       console.log(`  ✗ Failed to update ${d.symbiont}: ${d.error ?? 'unknown error'}`);
+      errors.push(`${d.symbiont}: ${d.error ?? 'unknown error'}`);
     }
   }
   updatedCount += installedCount;
@@ -205,7 +227,7 @@ async function runMachineWideUpdate(allManifests: SymbiontManifest[], currentVer
     // Non-fatal — stamp write failure shouldn't break the update
   }
 
-  return updatedCount;
+  return { updatedCount, errors };
 }
 
 interface RunForProjectOptions {
@@ -218,7 +240,12 @@ interface RunForProjectOptions {
   skipMachineWide?: boolean;
 }
 
-async function runForProject(projectRoot: string | undefined, options: RunForProjectOptions = {}): Promise<void> {
+/**
+ * Sync one project's managed files. Returns the machine-wide step errors
+ * (per-symbiont global-install failures) so the CLI entry point can fold
+ * them into its exit-code rollup; empty when `skipMachineWide` is set.
+ */
+async function runForProject(projectRoot: string | undefined, options: RunForProjectOptions = {}): Promise<string[]> {
   const vaultDir = projectRoot
     ? path.join(projectRoot, '.myco')
     : resolveVaultDir();
@@ -272,8 +299,11 @@ async function runForProject(projectRoot: string | undefined, options: RunForPro
   // Machine-wide refresh (global symbiont install, config scrub,
   // per-project migration pass, version stamp). Skipped by --all-projects
   // which hoists this work out of its per-project loop. /code-review C7.
+  let machineWideErrors: string[] = [];
   if (!options.skipMachineWide) {
-    updatedCount += await runMachineWideUpdate(allManifests, currentVersion, stampPath);
+    const machineWide = await runMachineWideUpdate(allManifests, currentVersion, stampPath);
+    updatedCount += machineWide.updatedCount;
+    machineWideErrors = machineWide.errors;
   }
 
   // HTTP MCP entries depend on the local daemon being reachable at the
@@ -319,6 +349,8 @@ async function runForProject(projectRoot: string | undefined, options: RunForPro
     console.log(`Dashboard: ${dashboardUrl}`);
   }
   console.log('Run `myco doctor` to verify setup health.');
+
+  return machineWideErrors;
 }
 
 /**
@@ -435,10 +467,13 @@ async function runAllProjects(): Promise<void> {
   const allManifests = loadManifests();
   const currentVersion = getPluginVersion();
   const stampPath = resolveLastUpdateVersionPath();
+  const machineWideErrors: string[] = [];
   try {
-    await runMachineWideUpdate(allManifests, currentVersion, stampPath);
+    machineWideErrors.push(...(await runMachineWideUpdate(allManifests, currentVersion, stampPath)).errors);
   } catch (error) {
-    console.error(`  ✗ Machine-wide refresh failed: ${error instanceof Error ? error.message : String(error)}`);
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`  ✗ Machine-wide refresh failed: ${message}`);
+    machineWideErrors.push(`machine-wide refresh: ${message}`);
   }
 
   const failures: { target: typeof targets[number]; error: unknown }[] = [];
@@ -453,14 +488,19 @@ async function runAllProjects(): Promise<void> {
   }
 
   console.log('');
-  if (failures.length === 0) {
+  if (failures.length === 0 && machineWideErrors.length === 0) {
     console.log(`✓ Updated all ${targets.length} project${targets.length === 1 ? '' : 's'}.`);
     return;
   }
 
-  console.error(`⚠ ${failures.length} of ${targets.length} project${targets.length === 1 ? '' : 's'} failed:`);
-  for (const { target, error } of failures) {
-    console.error(`  - ${target.groveSlug}/${target.projectName}: ${error instanceof Error ? error.message : String(error)}`);
+  if (machineWideErrors.length > 0) {
+    reportMachineWideErrors(machineWideErrors);
+  }
+  if (failures.length > 0) {
+    console.error(`⚠ ${failures.length} of ${targets.length} project${targets.length === 1 ? '' : 's'} failed:`);
+    for (const { target, error } of failures) {
+      console.error(`  - ${target.groveSlug}/${target.projectName}: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
   process.exit(1);
 }

--- a/tests/cli/args.test.ts
+++ b/tests/cli/args.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { vi } from '../helpers/vi-shim.js';
+import { parseStrictFlags } from '@myco/cli/args.js';
+
+const USAGE = 'Usage: myco fake [options]\n';
+
+function expectUsageExit(fn: () => void): { stderr: string; code: number | undefined } {
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    throw new Error(`process.exit(${code ?? 0})`);
+  }) as never);
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  try {
+    expect(fn).toThrow(/process\.exit\(2\)/);
+    return {
+      stderr: stderrSpy.mock.calls.flat().join(''),
+      code: exitSpy.mock.calls[0]?.[0] as number | undefined,
+    };
+  } finally {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+  }
+}
+
+describe('parseStrictFlags', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('parses boolean, required-value, and optional-value flags', () => {
+    const parsed = parseStrictFlags('myco fake', ['--force', '--name', 'alpha', '--project', '/tmp/x'], [
+      { name: '--force' },
+      { name: '--name', value: 'required' },
+      { name: '--project', value: 'optional' },
+    ], USAGE);
+
+    expect(parsed.has('--force')).toBe(true);
+    expect(parsed.value('--name')).toBe('alpha');
+    expect(parsed.value('--project')).toBe('/tmp/x');
+    expect(parsed.has('--absent')).toBe(false);
+    expect(parsed.value('--absent')).toBeUndefined();
+  });
+
+  it('maps aliases to the canonical flag name', () => {
+    const parsed = parseStrictFlags('myco fake', ['-h'], [
+      { name: '--help', aliases: ['-h'] },
+    ], USAGE);
+    expect(parsed.has('--help')).toBe(true);
+  });
+
+  it('treats a bare optional-value flag as presence without a value', () => {
+    const parsed = parseStrictFlags('myco fake', ['--project', '--force'], [
+      { name: '--project', value: 'optional' },
+      { name: '--force' },
+    ], USAGE);
+    expect(parsed.has('--project')).toBe(true);
+    expect(parsed.value('--project')).toBeUndefined();
+    expect(parsed.has('--force')).toBe(true);
+  });
+
+  it('rejects an unknown flag with exit code 2 and prints usage', () => {
+    const { stderr } = expectUsageExit(() =>
+      parseStrictFlags('myco fake', ['--frobnicate'], [{ name: '--force' }], USAGE),
+    );
+    expect(stderr).toContain("unknown flag '--frobnicate'");
+    expect(stderr).toContain(USAGE);
+  });
+
+  it('rejects a required-value flag at end of args with exit code 2', () => {
+    const { stderr } = expectUsageExit(() =>
+      parseStrictFlags('myco fake', ['--name'], [{ name: '--name', value: 'required' }], USAGE),
+    );
+    expect(stderr).toContain('--name requires a value');
+  });
+
+  it('rejects a required-value flag followed by another flag with exit code 2', () => {
+    const { stderr } = expectUsageExit(() =>
+      parseStrictFlags('myco fake', ['--name', '--force'], [
+        { name: '--name', value: 'required' },
+        { name: '--force' },
+      ], USAGE),
+    );
+    expect(stderr).toContain('--name requires a value');
+  });
+
+  it('rejects a stray positional argument with exit code 2', () => {
+    const { stderr } = expectUsageExit(() =>
+      parseStrictFlags('myco fake', ['oops'], [{ name: '--force' }], USAGE),
+    );
+    expect(stderr).toContain("unexpected argument 'oops'");
+  });
+});

--- a/tests/cli/confirm.test.ts
+++ b/tests/cli/confirm.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { vi } from '../helpers/vi-shim.js';
+import { confirmDestructive } from '@myco/cli/confirm.js';
+
+describe('confirmDestructive', () => {
+  const originalIsTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+
+  afterEach(() => {
+    if (originalIsTTY) {
+      Object.defineProperty(process.stdin, 'isTTY', originalIsTTY);
+    } else {
+      delete (process.stdin as { isTTY?: boolean }).isTTY;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('refuses without prompting when stdin is not a TTY, printing the summary and a --yes hint', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const result = await confirmDestructive('This will delete EVERYTHING.');
+
+    expect(result).toBe(false);
+    const output = stderrSpy.mock.calls.flat().join('');
+    expect(output).toContain('This will delete EVERYTHING.');
+    expect(output).toContain('--yes');
+  });
+});

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -1,8 +1,8 @@
-import { afterEach, beforeEach, describe, it, expect } from 'bun:test';
+import { afterEach, beforeEach, describe, it, expect, spyOn } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { type DoctorCheck, checkCaptureFlow, checkMigrationStatus, checkSymbiontEdgeCases, fix, isSymbiontRegistered, isSymbiontRegisteredGlobally, runChecks } from '@myco/cli/doctor';
+import { type DoctorCheck, checkCaptureFlow, checkMigrationStatus, checkSymbiontEdgeCases, fix, isSymbiontRegistered, isSymbiontRegisteredGlobally, run, runChecks } from '@myco/cli/doctor';
 import { loadManifests } from '@myco/symbionts/detect';
 import { manifestToolTransport } from '@myco/symbionts/capabilities';
 import { expandHome } from '@myco/grove/paths';
@@ -10,6 +10,7 @@ import { openDatabase, withDatabase, initDatabase, closeDatabase } from '@myco/d
 import { createSchema } from '@myco/db/schema.js';
 import { upsertSession } from '@myco/db/queries/sessions.js';
 import { resolveDaemonDataPaths } from '@myco/daemon/data-paths.js';
+import { resolveDaemonServiceState } from '@myco/daemon/service-state.js';
 import { recordMigrationPass, listMigrationErrors } from '@myco/db/queries/migration-log.js';
 import { clearGroveRegistryCaches, createGrove, registerProjectInGrove } from '@myco/grove/registry.js';
 import { ensureProjectManifest } from '@myco/config/project-manifest.js';
@@ -21,11 +22,27 @@ function findManifest(name: string) {
 }
 
 describe('runChecks', () => {
-  it('returns vault check failure when myco.yaml missing', async () => {
+  it('reports a missing myco.yaml as warn (not fail) so doctor outside a project exits 0', async () => {
+    // RC-6: a missing vault config is the documented "run doctor from
+    // $HOME after install" flow, not a failure. Only an unparseable
+    // config fails the Vault row.
     const checks = await runChecks('/tmp/nonexistent-vault-' + Date.now());
     const vaultCheck = checks.find((c) => c.name === 'Vault');
     expect(vaultCheck).toBeDefined();
-    expect(vaultCheck!.status).toBe('fail');
+    expect(vaultCheck!.status).toBe('warn');
+    expect(checks.every((c) => c.status !== 'fail' || c.name === 'Daemon')).toBe(true);
+  });
+
+  it('reports an unparseable myco.yaml as a Vault failure', async () => {
+    const vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-doctor-badyaml-'));
+    try {
+      fs.writeFileSync(path.join(vaultDir, 'myco.yaml'), 'version: [unclosed\n', 'utf-8');
+      const checks = await runChecks(vaultDir);
+      const vaultCheck = checks.find((c) => c.name === 'Vault');
+      expect(vaultCheck!.status).toBe('fail');
+    } finally {
+      fs.rmSync(vaultDir, { recursive: true, force: true });
+    }
   });
 
   it('returns all expected check names', async () => {
@@ -36,6 +53,98 @@ describe('runChecks', () => {
     expect(names).toContain('Embeddings');
     expect(names).toContain('Agents');
     expect(names).toContain('Daemon');
+  });
+});
+
+describe('doctor exit codes', () => {
+  let vaultDir: string;
+  let savedMycoHome: string | undefined;
+  let mycoHome: string;
+
+  beforeEach(() => {
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-doctor-exit-'));
+    mycoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-doctor-exit-home-'));
+    savedMycoHome = process.env.MYCO_HOME;
+    process.env.MYCO_HOME = mycoHome;
+  });
+
+  afterEach(() => {
+    fs.rmSync(vaultDir, { recursive: true, force: true });
+    fs.rmSync(mycoHome, { recursive: true, force: true });
+    if (savedMycoHome === undefined) delete process.env.MYCO_HOME;
+    else process.env.MYCO_HOME = savedMycoHome;
+    process.exitCode = 0;
+  });
+
+  async function runDoctorQuietly(args: string[]): Promise<void> {
+    const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await run(args, vaultDir);
+    } finally {
+      logSpy.mockRestore();
+    }
+  }
+
+  it('exits 0 from a non-project directory (healthy machine, warn rows only)', async () => {
+    await runDoctorQuietly([]);
+    expect(process.exitCode ?? 0).toBe(0);
+  });
+
+  it('sets exit code 1 when a check fails', async () => {
+    // Unparseable config → Vault check fails.
+    fs.writeFileSync(path.join(vaultDir, 'myco.yaml'), 'version: [unclosed\n', 'utf-8');
+    await runDoctorQuietly([]);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('reports a malformed daemon.json as a fixable failure', async () => {
+    const statePath = resolveDaemonServiceState(vaultDir, { env: process.env }).statePath;
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, '{not json', 'utf-8');
+
+    const checks = await runChecks(vaultDir);
+    const daemon = checks.find((c) => c.name === 'Daemon');
+    expect(daemon!.status).toBe('fail');
+    expect(daemon!.fixable).toBe(true);
+    expect(daemon!.detail).toContain('parse error');
+  });
+
+  it('exits 0 when --fix repairs the only failing check (exit code reflects post-fix state)', async () => {
+    // Malformed daemon.json → Daemon fail (fixable). fix() deletes it via
+    // deleteIfMalformed; the recheck then sees a clean machine.
+    const statePath = resolveDaemonServiceState(vaultDir, { env: process.env }).statePath;
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, '{not json', 'utf-8');
+
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await runDoctorQuietly(['--fix']);
+    } finally {
+      errorSpy.mockRestore();
+    }
+
+    expect(fs.existsSync(statePath)).toBe(false);
+    expect(process.exitCode ?? 0).toBe(0);
+  });
+
+  it('keeps exit code 1 when --fix cannot repair the failure', async () => {
+    // Unparseable myco.yaml is not auto-fixable.
+    fs.writeFileSync(path.join(vaultDir, 'myco.yaml'), 'version: [unclosed\n', 'utf-8');
+    await runDoctorQuietly(['--fix']);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('rejects an unknown flag with exit code 2', async () => {
+    const exitSpy = spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+    const stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await expect(run(['--fxi'], vaultDir)).rejects.toThrow(/process\.exit\(2\)/);
+    expect(stderrSpy.mock.calls.flat().join('')).toContain("unknown flag '--fxi'");
+
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
   });
 });
 

--- a/tests/cli/remove.test.ts
+++ b/tests/cli/remove.test.ts
@@ -19,13 +19,30 @@ mock.module('@myco/symbionts/detect.js', () => ({
 
 mock.module('@myco/symbionts/installer.js', () => {
   const SymbiontInstaller = vi.fn(function () {
-    return { uninstall: vi.fn().mockReturnValue({ hooks: true, mcp: true, skills: true, settings: false, instructions: false }) };
+    return {
+      uninstall: vi.fn().mockReturnValue({ hooks: true, mcp: true, skills: true, settings: false, instructions: false }),
+      isAvailableForScope: vi.fn().mockReturnValue(true),
+    };
   });
   // The CLI's `cleanProjectLocalArtifacts` now imports
   // `removeProjectLaunchers` directly — the mock must expose it.
-  const removeProjectLaunchers = vi.fn().mockReturnValue(false);
+  const removeProjectLaunchers = vi.fn().mockReturnValue([]);
   return { SymbiontInstaller, MYCO_MCP_SERVER_NAME: 'myco', removeProjectLaunchers };
 });
+
+// Confirmation gate: tests drive the answer per-scenario. Real prompting
+// (TTY readline) is covered by confirm.test.ts.
+const confirmMock = vi.fn();
+mock.module('@myco/cli/confirm.js', () => ({ confirmDestructive: confirmMock }));
+
+// Global remove unregisters the OS service — that must NEVER hit the real
+// launchctl/systemctl from a test. Route it to the shared fake.
+import { FakeServiceManager } from '../helpers/fake-service-manager.js';
+import { sandboxMycoHome } from '../helpers/myco-home-sandbox.js';
+let fakeServiceManager = new FakeServiceManager();
+mock.module('@myco/service/manager.js', () => ({
+  getServiceManager: () => fakeServiceManager,
+}));
 
 let testVaultDir = '';
 class UnsafeProjectRootError extends Error {
@@ -36,10 +53,16 @@ class UnsafeProjectRootError extends Error {
 mock.module('@myco/vault/resolve.js', () => ({
   resolveVaultDir: vi.fn(() => testVaultDir),
   resolveProjectRoot: vi.fn((vaultDir: string) => path.dirname(vaultDir)),
-  // Tests run with synthetic /tmp project roots that are always safe — the
-  // real guard would let them through too. Stub as a no-op so cli paths
-  // that import this module don't fail at import time.
-  assertSafeProjectRoot: vi.fn(),
+  // Faithful-shaped guard: synthetic /tmp roots pass (as they would with
+  // the real predicate), while $HOME and the filesystem root throw —
+  // letting the safe-root refusal tests exercise the CLI's guard without
+  // unmocking the rest of the module.
+  assertSafeProjectRoot: vi.fn((projectRoot: string) => {
+    const resolved = path.resolve(projectRoot);
+    if (resolved === os.homedir() || resolved === path.parse(resolved).root) {
+      throw new UnsafeProjectRootError(resolved, 'unsafe root (test guard)');
+    }
+  }),
   isSafeProjectRoot: vi.fn(() => true),
   UnsafeProjectRootError,
 }));
@@ -93,5 +116,312 @@ describe('myco remove --symbiont', () => {
     expect(errorSpy.mock.calls.flat().join(' ')).toContain('Unknown symbiont');
     exitSpy.mockRestore();
     errorSpy.mockRestore();
+  });
+});
+
+describe('myco remove strict argv', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-remove-argv-'));
+    testVaultDir = path.join(testDir, '.myco');
+    fs.mkdirSync(testVaultDir, { recursive: true });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('rejects an unknown flag with exit code 2 before touching anything', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const { run } = await import('@myco/cli/remove.js');
+    await expect(run(['--frobnicate'])).rejects.toThrow(/process\.exit\(2\)/);
+
+    expect(stderrSpy.mock.calls.flat().join('')).toContain("unknown flag '--frobnicate'");
+    expect(fakeServiceManager.uninstallCalls).toHaveLength(0);
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('rejects --symbiont with a missing value with exit code 2', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const { run } = await import('@myco/cli/remove.js');
+    await expect(run(['--symbiont'])).rejects.toThrow(/process\.exit\(2\)/);
+
+    expect(stderrSpy.mock.calls.flat().join('')).toContain('--symbiont requires a value');
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('rejects --symbiont combined with --remove-vault with exit code 2 instead of dropping the flag', async () => {
+    fs.writeFileSync(path.join(testVaultDir, 'myco.yaml'), YAML.stringify({ version: 3, config_version: 0, symbionts: { cursor: { enabled: true } } }));
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const { run } = await import('@myco/cli/remove.js');
+    await expect(run(['--symbiont', 'cursor', '--remove-vault'])).rejects.toThrow(/process\.exit\(2\)/);
+
+    expect(stderrSpy.mock.calls.flat().join('')).toContain('--remove-vault/--purge cannot be combined with --symbiont');
+    expect(fs.existsSync(testVaultDir)).toBe(true);
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('rejects --symbiont combined with --purge with exit code 2', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const { run } = await import('@myco/cli/remove.js');
+    await expect(run(['--symbiont', 'cursor', '--purge'])).rejects.toThrow(/process\.exit\(2\)/);
+
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+});
+
+describe('myco remove --project safe-root guard', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-remove-guard-'));
+    testVaultDir = path.join(testDir, '.myco');
+    fs.mkdirSync(testVaultDir, { recursive: true });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+    process.exitCode = 0;
+    vi.restoreAllMocks();
+  });
+
+  async function expectRefused(args: string[]): Promise<void> {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const rmSpy = vi.spyOn(fs, 'rmSync').mockImplementation(() => {});
+
+    const { SymbiontInstaller, removeProjectLaunchers } = await import('@myco/symbionts/installer.js');
+    const { run } = await import('@myco/cli/remove.js');
+    await expect(run(args)).rejects.toThrow(/process\.exit\(1\)/);
+
+    expect(errorSpy.mock.calls.flat().join(' ')).toContain('Refusing project-scope removal');
+    // The guard fired before ANY cleanup: no uninstalls, no launcher
+    // removal, no vault rm, no confirmation prompt.
+    expect(SymbiontInstaller).not.toHaveBeenCalled();
+    expect(vi.mocked(removeProjectLaunchers)).not.toHaveBeenCalled();
+    expect(rmSpy).not.toHaveBeenCalled();
+    expect(confirmMock).not.toHaveBeenCalled();
+
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+    rmSpy.mockRestore();
+  }
+
+  it('refuses --project $HOME (would strip the global agent configs)', async () => {
+    await expectRefused(['--project', os.homedir()]);
+  });
+
+  it('refuses --project / (filesystem root)', async () => {
+    await expectRefused(['--project', '/']);
+  });
+
+  it('refuses --project $HOME --remove-vault --yes before any rm (would delete ~/.myco)', async () => {
+    await expectRefused(['--project', os.homedir(), '--remove-vault', '--yes']);
+  });
+});
+
+describe('myco remove --remove-vault routing (project scope)', () => {
+  let testDir: string;
+  let sandbox: ReturnType<typeof sandboxMycoHome>;
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-remove-vault-'));
+    testVaultDir = path.join(testDir, '.myco');
+    fs.mkdirSync(testVaultDir, { recursive: true });
+    fs.writeFileSync(path.join(testVaultDir, 'myco.yaml'), YAML.stringify({ version: 3, config_version: 0 }));
+    sandbox = sandboxMycoHome('myco-remove-vault-home-');
+    // Sentinel: if --remove-vault ever falls through to the global
+    // teardown again, this launcher gets deleted.
+    fs.writeFileSync(path.join(sandbox.mycoHome, 'launcher.cjs'), 'launcher', 'utf-8');
+    fakeServiceManager = new FakeServiceManager();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+    sandbox.restore();
+    process.exitCode = 0;
+    vi.restoreAllMocks();
+  });
+
+  it('routes to project scope and deletes the vault with --yes, leaving the global install intact', async () => {
+    const { run } = await import('@myco/cli/remove.js');
+    await run(['--remove-vault', '--yes']);
+
+    expect(fs.existsSync(testVaultDir)).toBe(false);
+    // No machine-wide teardown happened.
+    expect(fakeServiceManager.uninstallCalls).toHaveLength(0);
+    expect(fs.existsSync(path.join(sandbox.mycoHome, 'launcher.cjs'))).toBe(true);
+    // --yes skips the prompt entirely.
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+
+  it('aborts the whole project remove when confirmation is declined — nothing mutated, exit 1', async () => {
+    confirmMock.mockResolvedValue(false);
+    // Teardown surfaces that must remain untouched on decline: a
+    // configured symbiont dir and the project daemon state.
+    fs.mkdirSync(path.join(testDir, '.cursor'), { recursive: true });
+    fs.writeFileSync(path.join(testVaultDir, 'daemon.json'), JSON.stringify({ pid: 999_999 }), 'utf-8');
+
+    const { SymbiontInstaller } = await import('@myco/symbionts/installer.js');
+    const { run } = await import('@myco/cli/remove.js');
+    await run(['--remove-vault']);
+
+    expect(fs.existsSync(testVaultDir)).toBe(true);
+    expect(process.exitCode).toBe(1);
+    expect(confirmMock.mock.calls[0]![0]).toContain(testVaultDir);
+    // The confirmation came BEFORE any teardown: hooks intact, daemon
+    // state intact — not the half-removed state of the prior shape.
+    expect(SymbiontInstaller).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(testVaultDir, 'daemon.json'))).toBe(true);
+  });
+
+  it('deletes the vault when confirmation is accepted', async () => {
+    confirmMock.mockResolvedValue(true);
+
+    const { run } = await import('@myco/cli/remove.js');
+    await run(['--remove-vault']);
+
+    expect(fs.existsSync(testVaultDir)).toBe(false);
+    expect(process.exitCode ?? 0).toBe(0);
+  });
+});
+
+describe('myco remove --project <path>', () => {
+  let cwdDir: string;
+  let targetDir: string;
+
+  beforeEach(() => {
+    cwdDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-remove-cwd-'));
+    targetDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-remove-target-'));
+    // resolveVaultDir (the cwd fallback) points at a DIFFERENT project —
+    // if the --project value is dropped, these tests fail loudly.
+    testVaultDir = path.join(cwdDir, '.myco');
+    fs.mkdirSync(testVaultDir, { recursive: true });
+    fs.writeFileSync(path.join(testVaultDir, 'myco.yaml'), YAML.stringify({ version: 3, config_version: 0 }));
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    fs.rmSync(cwdDir, { recursive: true, force: true });
+    fs.rmSync(targetDir, { recursive: true, force: true });
+    process.exitCode = 0;
+    vi.restoreAllMocks();
+  });
+
+  it('honors the --project value instead of defaulting to the cwd project', async () => {
+    const targetVault = path.join(targetDir, '.myco');
+    fs.mkdirSync(targetVault, { recursive: true });
+    fs.writeFileSync(path.join(targetVault, 'myco.yaml'), YAML.stringify({ version: 3, config_version: 0 }));
+    fs.mkdirSync(path.join(targetDir, '.cursor'), { recursive: true });
+
+    const { SymbiontInstaller } = await import('@myco/symbionts/installer.js');
+    const { run } = await import('@myco/cli/remove.js');
+    await run(['--project', targetDir]);
+
+    // Installers operated on the targeted project root, not the cwd one.
+    const roots = vi.mocked(SymbiontInstaller).mock.calls.map((c) => c[1]);
+    expect(roots).toContain(targetDir);
+    expect(roots).not.toContain(cwdDir);
+    // The cwd project's vault was untouched.
+    expect(fs.existsSync(path.join(testVaultDir, 'myco.yaml'))).toBe(true);
+  });
+
+  it('cleans launcher artifacts and exits 0 for an orphan root without myco.yaml', async () => {
+    // The doctor orphan shape: a launcher stub with no .myco/myco.yaml.
+    fs.mkdirSync(path.join(targetDir, '.agents'), { recursive: true });
+    fs.writeFileSync(path.join(targetDir, '.agents', 'myco-run.cjs'), 'stub', 'utf-8');
+
+    const { removeProjectLaunchers } = await import('@myco/symbionts/installer.js');
+    const { run } = await import('@myco/cli/remove.js');
+    await run(['--project', targetDir]);
+
+    expect(vi.mocked(removeProjectLaunchers)).toHaveBeenCalledWith(
+      targetDir,
+      { legacy: true, active: true, runtimeCommand: true },
+    );
+    expect(process.exitCode ?? 0).toBe(0);
+  });
+});
+
+describe('myco remove (global) confirmation gate', () => {
+  let sandbox: ReturnType<typeof sandboxMycoHome>;
+
+  beforeEach(() => {
+    sandbox = sandboxMycoHome('myco-remove-global-home-');
+    fs.writeFileSync(path.join(sandbox.mycoHome, 'launcher.cjs'), 'launcher', 'utf-8');
+    fs.writeFileSync(path.join(sandbox.mycoHome, 'mcp-launcher.cjs'), 'mcp launcher', 'utf-8');
+    fakeServiceManager = new FakeServiceManager();
+    fakeServiceManager.installed.add('co.goondocks.myco');
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    process.exitCode = 0;
+    vi.restoreAllMocks();
+  });
+
+  it('aborts with exit code 1 and tears nothing down when confirmation is declined (non-TTY shape)', async () => {
+    confirmMock.mockResolvedValue(false);
+
+    const { run } = await import('@myco/cli/remove.js');
+    await run([]);
+
+    expect(process.exitCode).toBe(1);
+    expect(fakeServiceManager.uninstallCalls).toHaveLength(0);
+    expect(fs.existsSync(path.join(sandbox.mycoHome, 'launcher.cjs'))).toBe(true);
+    expect(fs.existsSync(path.join(sandbox.mycoHome, 'mcp-launcher.cjs'))).toBe(true);
+    // The summary names the machine-wide blast radius.
+    expect(confirmMock.mock.calls[0]![0]).toContain('machine-wide');
+  });
+
+  it('proceeds without prompting when --yes is passed', async () => {
+    const { run } = await import('@myco/cli/remove.js');
+    await run(['--yes']);
+
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(fakeServiceManager.uninstallCalls.length).toBeGreaterThan(0);
+    expect(fs.existsSync(path.join(sandbox.mycoHome, 'launcher.cjs'))).toBe(false);
+    expect(fs.existsSync(path.join(sandbox.mycoHome, 'mcp-launcher.cjs'))).toBe(false);
+    // No --purge: captured data home is preserved.
+    expect(fs.existsSync(sandbox.mycoHome)).toBe(true);
+  });
+
+  it('mentions ~/.myco deletion in the summary and purges it on --purge --yes', async () => {
+    confirmMock.mockResolvedValue(true);
+
+    const { run } = await import('@myco/cli/remove.js');
+    await run(['--purge']);
+
+    expect(confirmMock.mock.calls[0]![0]).toContain('DELETE');
+    expect(confirmMock.mock.calls[0]![0]).toContain(sandbox.mycoHome);
+    expect(fs.existsSync(sandbox.mycoHome)).toBe(false);
   });
 });

--- a/tests/cli/update-exit-codes.test.ts
+++ b/tests/cli/update-exit-codes.test.ts
@@ -1,0 +1,167 @@
+// Exit-code rollups for `myco update`: per-symbiont global-install errors
+// and a machine-wide refresh failure must surface as exit 1 instead of the
+// historical silent exit 0 (RC-6 bug 4).
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { vi } from '../helpers/vi-shim.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import YAML from 'yaml';
+
+mock.module('@myco/symbionts/detect.js', () => ({
+  loadManifests: vi.fn().mockReturnValue([
+    {
+      name: 'claude-code', displayName: 'Claude Code', binary: 'claude',
+      configDir: '.claude', pluginRootEnvVar: 'CLAUDE_PLUGIN_ROOT',
+      registration: { skillsTarget: '.claude/skills' },
+      hookFields: { sessionId: 'session_id', transcriptPath: 'transcript_path', lastResponse: 'last_response', prompt: 'prompt', toolName: 'tool_name', toolInput: 'tool_input', toolOutput: 'tool_output' },
+    },
+  ]),
+  resolvePackageRoot: vi.fn().mockReturnValue('/tmp'),
+}));
+
+mock.module('@myco/symbionts/installer.js', () => ({
+  SymbiontInstaller: vi.fn(function MockSymbiontInstaller() {
+    return {
+      isAvailableForScope: vi.fn().mockReturnValue(false),
+      isConfigured: vi.fn().mockReturnValue(false),
+      install: vi.fn().mockReturnValue({ hooks: false, mcp: false, skills: false, settings: false, instructions: false }),
+      uninstall: vi.fn().mockReturnValue({ hooks: false, mcp: false, skills: false, settings: false, instructions: false }),
+    };
+  }),
+  MYCO_MCP_SERVER_NAME: 'myco',
+  removeProjectLaunchers: vi.fn().mockReturnValue([]),
+}));
+
+// The machine-wide refresh's first step — drive its outcome per test.
+const runSymbiontDetectionMock = vi.fn();
+const bootstrapActual = await import('@myco/cli/bootstrap.js');
+mock.module('@myco/cli/bootstrap.js', () => ({
+  ...bootstrapActual,
+  runSymbiontDetection: runSymbiontDetectionMock,
+}));
+
+const ensureRunningMock = vi.fn();
+mock.module('@myco/hooks/client.js', () => ({
+  DaemonClient: vi.fn(function MockDaemonClient() {
+    return {
+      ensureRunning: ensureRunningMock,
+      restart: vi.fn().mockResolvedValue(true),
+    };
+  }),
+}));
+
+const listGrovesMock = vi.fn();
+const listRegisteredProjectsMock = vi.fn();
+const registryActual = await import('@myco/grove/registry.js');
+mock.module('@myco/grove/registry.js', () => ({
+  ...registryActual,
+  listGroves: listGrovesMock,
+  listRegisteredProjects: listRegisteredProjectsMock,
+}));
+
+function writeProjectVault(root: string): void {
+  const vaultDir = path.join(root, '.myco');
+  fs.mkdirSync(vaultDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(vaultDir, 'myco.yaml'),
+    YAML.stringify({ version: 3, config_version: 0, symbionts: { 'claude-code': { enabled: true } } }),
+  );
+}
+
+describe('myco update exit-code rollups', () => {
+  let testDir: string;
+  let mycoHome: string;
+  let fakeHome: string;
+  let previousMycoHome: string | undefined;
+  let previousHome: string | undefined;
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-update-exit-proj-'));
+    mycoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-update-exit-home-'));
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-update-exit-user-'));
+    previousMycoHome = process.env.MYCO_HOME;
+    previousHome = process.env.HOME;
+    process.env.MYCO_HOME = mycoHome;
+    process.env.HOME = fakeHome;
+    writeProjectVault(testDir);
+    vi.clearAllMocks();
+    ensureRunningMock.mockResolvedValue(true);
+    listGrovesMock.mockReturnValue([]);
+    listRegisteredProjectsMock.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true });
+    fs.rmSync(mycoHome, { recursive: true, force: true });
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+    if (previousMycoHome === undefined) delete process.env.MYCO_HOME;
+    else process.env.MYCO_HOME = previousMycoHome;
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    vi.restoreAllMocks();
+  });
+
+  it('exits 1 when a symbiont errors during the machine-wide refresh of a --project update', async () => {
+    runSymbiontDetectionMock.mockReturnValue([
+      { symbiont: 'claude-code', status: 'error', error: 'EACCES: settings.json locked' },
+    ]);
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { run } = await import('@myco/cli/update.js');
+    await expect(run(['--project', testDir])).rejects.toThrow(/process\.exit\(1\)/);
+
+    expect(errorSpy.mock.calls.flat().join(' ')).toContain('EACCES: settings.json locked');
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exits 0 (no exit call) when the machine-wide refresh of a --project update is clean', async () => {
+    runSymbiontDetectionMock.mockReturnValue([
+      { symbiont: 'claude-code', status: 'not-detected' },
+    ]);
+
+    const { run } = await import('@myco/cli/update.js');
+    await run(['--project', testDir]);
+
+    expect(ensureRunningMock).toHaveBeenCalled();
+  });
+
+  it('exits 1 when the machine-wide refresh throws even though every project succeeds', async () => {
+    runSymbiontDetectionMock.mockImplementation(() => {
+      throw new Error('manifest registry corrupted');
+    });
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-update-exit-reg-'));
+    writeProjectVault(projectRoot);
+    listGrovesMock.mockReturnValue([{
+      id: 'grove_00000000000000000000000000000001',
+      name: 'Test', slug: 'test', mode: 'local',
+      created_at: new Date().toISOString(),
+    }]);
+    listRegisteredProjectsMock.mockReturnValue([
+      { project_id: 'proj_00000000000000000000000000000001', name: 'a', root: projectRoot, created_at: '', updated_at: '' },
+    ]);
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const { run } = await import('@myco/cli/update.js');
+      await expect(run([])).rejects.toThrow(/process\.exit\(1\)/);
+
+      const stderr = errorSpy.mock.calls.flat().join(' ');
+      expect(stderr).toContain('Machine-wide refresh failed');
+      expect(stderr).toContain('manifest registry corrupted');
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/tests/cli/update.test.ts
+++ b/tests/cli/update.test.ts
@@ -90,6 +90,66 @@ describe('myco update', () => {
     }
   });
 
+  it('rejects --project with a missing value with exit code 2 instead of fanning out to all projects', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const { run } = await import('@myco/cli/update.js');
+    await expect(run(['--project'])).rejects.toThrow(/process\.exit\(2\)/);
+
+    expect(stderrSpy.mock.calls.flat().join('')).toContain('--project requires a value');
+    // Nothing was updated — the daemon was never consulted.
+    expect(ensureRunningMock).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('rejects --project followed by another flag with exit code 2', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const { run } = await import('@myco/cli/update.js');
+    await expect(run(['--project', '--all-projects'])).rejects.toThrow(/process\.exit\(2\)/);
+
+    expect(ensureRunningMock).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('rejects an unknown flag with exit code 2', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const { run } = await import('@myco/cli/update.js');
+    await expect(run(['--bogus'])).rejects.toThrow(/process\.exit\(2\)/);
+
+    expect(stderrSpy.mock.calls.flat().join('')).toContain("unknown flag '--bogus'");
+    expect(ensureRunningMock).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('still accepts --all-projects (update-installer.sh and the Makefile hardcode it)', async () => {
+    // Strict argv parsing must keep the deprecated alias in the
+    // vocabulary: the daemon's post-install script and `make dev-link`
+    // both invoke `myco update --all-projects`.
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { run } = await import('@myco/cli/update.js');
+    await run(['--all-projects']);
+
+    // Empty sandbox registry: the command reaches the no-targets path
+    // instead of exiting 2 at the parser.
+    expect(logSpy.mock.calls.flat().join(' ')).toContain('No registered projects');
+    logSpy.mockRestore();
+  });
+
   it('prints help without touching project files', async () => {
     const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     const { run } = await import('@myco/cli/update.js');


### PR DESCRIPTION
## What

Fixes the CLI cluster from the 2026-06-10 bug hunt (RC-6, P1 + three P2s). One root cause: ad-hoc per-command flag parsing with destructive fall-through defaults.

- **`myco remove --remove-vault` fell through to the machine-wide global uninstall** (OS service, every agent's global config, every registered project across all served Groves) with zero confirmation — and the flag was then ignored. Now routes to project scope.
- **`myco remove --project <path>` ignored the path** and operated on cwd — while `myco doctor` actively recommended that exact invocation for orphan cleanup.
- **`myco update --project` with a missing value silently updated ALL projects.**
- **Exit codes lied**: doctor always exited 0; update exited 0 on per-symbiont errors and failed machine-wide refreshes.

## ⚠️ Framing correction vs the bug-hunt report

The independent plan review established that **bare `myco remove` = global uninstall is the released, documented contract** (README, quickstart, lifecycle, upgrade, symbionts docs + CHANGELOG all instruct it; `remove.ts` USAGE labels `--project` the legacy path). The hunt report had this inverted — the stale text was the `cli.ts` help line and the install skill, both now corrected. So the fix is *gate and route correctly*, not redefine the default: bare remove stays global, but now shows exactly what will be torn down and requires TTY confirmation or `--yes` (non-TTY without `--yes` refuses, exit 1, touches nothing). `--purge` semantics (delete `~/.myco`) preserved per docs, also gated.

## How

- **`cli/args.ts`** — declarative strict parser (adopted by remove/update/doctor only): unknown flag / stray positional / missing required value → exit 2 + usage. `--all-projects` stays whitelisted (the daemon's detached update scripts and Makefile hardcode it — regression-tested). `--remove-vault`/`--purge` + `--symbiont` is rejected instead of silently ignored.
- **`cli/confirm.ts`** — TTY y/N confirmation helper (myco-team precedent); project-scope vault deletion confirms **once, up front, before any teardown** — declining leaves the project fully intact.
- **Safe-root guard** (caught by the adversarial diff review): honoring `--project` opened a fresh hole where `myco remove --project ~` would take the orphan path against `$HOME` and strip the user's *global* agent configs — and `--project ~ --remove-vault --yes` would delete all of `~/.myco`. Project-scope removal now refuses `/`, `$HOME`, and home-parent roots via the existing `assertSafeProjectRoot` predicate, before any cleanup.
- **Orphan remedy works**: `remove --project <root>` on a launcher-without-myco.yaml root cleans launchers/artifacts and exits 0 (doctor's recommendation is no longer a dead end).
- **Honest exit codes**: doctor → exitCode 1 on genuine fails; non-project cwd emits warn rows instead of synthetic fails (healthy machine install checked from `$HOME` exits 0 — the quickstart flow); `doctor --fix` recomputes post-fix so `--fix && …` succeeds after repair. That last change surfaced dead code: the malformed-daemon.json fixer keyed on a detail the tolerant reader could never produce — malformed state was misreported as a benign warn; reconnected and tested (a down-payment on the RC-14 doctor-registry finding). update aggregates symbiont errors + machine-wide refresh failures into the existing exit-1 rollup.

## Tests

Strict-parser suite, full dispatch-routing matrix, confirmation gates (mocked confirm module, per-file isolation per PR #466), safe-root refusals (`--project ~` / `/` / `~ --remove-vault --yes` each touch nothing), orphan cleanup, `--all-projects` regression, doctor exit-code matrix incl. `--fix` repair, update rollups. Scoped suites green (281 pass / 0 fail, tsc clean). One pre-existing doctor test updated (it pinned the synthetic-fail behavior that broke run-from-anywhere).

Local full-suite runs hit unrelated single-test timeout flakes under machine load (a different untouched test each run; each 3/3 green in isolation) — per project convention, clean-runner CI is the gate.

Pipeline: independently reviewed plan (which caught the framing inversion and the doc-contract break my original plan would have shipped) → implementation → adversarial diff review (which caught the `--project ~` hole) → fixes verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)