### PR TITLE
capture: content-keyed buffer replay convergence (RC-7 Phase 1)

### DIFF
--- a/packages/myco/src/capture/dedup.ts
+++ b/packages/myco/src/capture/dedup.ts
@@ -27,6 +27,42 @@ export const EVENT_DEDUP_WINDOW_MS = 10_000;
 const PROMPT_FINGERPRINT_CHARS = 256;
 const TOOL_INPUT_FINGERPRINT_CHARS = 256;
 
+/** Assemble the canonical key string from its six fingerprint components. */
+function composeKey(
+  sessionId: string,
+  type: string,
+  prompt: string,
+  toolName: string,
+  toolInput: string,
+  taskId: string,
+  agentId: string,
+): string {
+  return `${sessionId}\0${[type, prompt, toolName, toolInput, taskId, agentId].join('\0')}`;
+}
+
+/** Event-side tool_input component — the exact branch semantics of {@link eventDedupKey}. */
+function toolInputComponent(toolInput: unknown): string {
+  return typeof toolInput === 'object'
+    ? JSON.stringify(toolInput).slice(0, TOOL_INPUT_FINGERPRINT_CHARS)
+    : String(toolInput ?? '').slice(0, TOOL_INPUT_FINGERPRINT_CHARS);
+}
+
+/**
+ * Event-side tool_input components whose source values the storage layer
+ * collapses to a NULL column (`toolInput ? JSON.stringify(...) : null` in
+ * `event-handlers.ts` treats every falsy input as NULL). One stored NULL row
+ * must therefore match a buffer event carrying any of these — undefined→'',
+ * ''→'', null→'null', 0→'0', false→'false', NaN→'NaN'. Convergence keys
+ * canonicalize all of them to '' on BOTH sides. Deliberate small widening:
+ * a tool_use with input `0` converges with one whose input was `false`;
+ * indistinguishable after storage anyway.
+ */
+const FALSY_INPUT_COMPONENTS: ReadonlySet<string> = new Set(['', 'null', '0', 'false', 'NaN']);
+
+function canonicalInputComponent(component: string): string {
+  return FALSY_INPUT_COMPONENTS.has(component) ? '' : component;
+}
+
 /**
  * Compute a content fingerprint key for an inbound capture event.
  *
@@ -44,17 +80,123 @@ const TOOL_INPUT_FINGERPRINT_CHARS = 256;
 export function eventDedupKey(
   event: { type: string; session_id: string } & Record<string, unknown>,
 ): string {
-  const parts: string[] = [
+  return composeKey(
+    event.session_id,
     event.type,
     typeof event.prompt === 'string' ? event.prompt.slice(0, PROMPT_FINGERPRINT_CHARS) : '',
     typeof event.tool_name === 'string' ? event.tool_name : '',
-    typeof event.tool_input === 'object'
-      ? JSON.stringify(event.tool_input).slice(0, TOOL_INPUT_FINGERPRINT_CHARS)
-      : String(event.tool_input ?? '').slice(0, TOOL_INPUT_FINGERPRINT_CHARS),
+    toolInputComponent(event.tool_input),
     typeof event.task_id === 'string' ? event.task_id : '',
     typeof event.agent_id === 'string' ? event.agent_id : '',
-  ];
-  return `${event.session_id}\0${parts.join('\0')}`;
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Convergence projections — DB rows and buffer events into ONE key space
+// ---------------------------------------------------------------------------
+//
+// Buffer reconciliation matches stored rows (prompt_batches / activities)
+// against buffer events by content. The projections below produce keys in a
+// shared "convergence" space: identical to eventDedupKey except that the
+// tool_input component is canonicalized via FALSY_INPUT_COMPONENTS so a
+// stored NULL matches every falsy event-side input.
+
+/**
+ * Convergence key for a buffer event — {@link eventDedupKey} with the
+ * tool_input component canonicalized. Used ONLY for matching events against
+ * stored rows; the live dispatcher's duplicate cache keeps the exact key.
+ */
+export function convergenceEventKey(
+  event: { type: string; session_id: string } & Record<string, unknown>,
+): string {
+  return composeKey(
+    event.session_id,
+    event.type,
+    typeof event.prompt === 'string' ? event.prompt.slice(0, PROMPT_FINGERPRINT_CHARS) : '',
+    typeof event.tool_name === 'string' ? event.tool_name : '',
+    canonicalInputComponent(toolInputComponent(event.tool_input)),
+    typeof event.task_id === 'string' ? event.task_id : '',
+    typeof event.agent_id === 'string' ? event.agent_id : '',
+  );
+}
+
+/**
+ * Project a stored prompt_batches row into the convergence key space — the
+ * key {@link convergenceEventKey} yields for a user_prompt event whose
+ * prompt text is the row's stored prompt. A NULL `user_prompt` mirrors the
+ * event side's missing-prompt component ('').
+ */
+export function dedupKeyFromPromptBatch(
+  row: { session_id: string; user_prompt: string | null },
+): string {
+  return composeKey(
+    row.session_id,
+    'user_prompt',
+    typeof row.user_prompt === 'string' ? row.user_prompt.slice(0, PROMPT_FINGERPRINT_CHARS) : '',
+    '',
+    '',
+    '',
+    '',
+  );
+}
+
+/**
+ * Activity rows written by bookkeeping handlers (`handleSubagentStart` /
+ * `handleSubagentStop`, `handleTaskCompleted`, `handleCompact`,
+ * `handleStopFailure` in `event-handlers.ts`). Their source events are not
+ * replayable and their tool_input is daemon-synthesized, so they must never
+ * consume a tool_use / tool_failure match during buffer convergence.
+ */
+export const BOOKKEEPING_ACTIVITY_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'subagent_start',
+  'subagent_stop',
+  'stop_failure',
+  'task_completed',
+  'pre_compact',
+  'post_compact',
+]);
+
+/** Predicate form of {@link BOOKKEEPING_ACTIVITY_TOOL_NAMES}. */
+export function isBookkeepingActivity(toolName: string): boolean {
+  return BOOKKEEPING_ACTIVITY_TOOL_NAMES.has(toolName);
+}
+
+/**
+ * Project a stored activities row into the convergence key space.
+ *
+ * Type discrimination mirrors the insert paths: `handleToolFailure` writes
+ * `success = 0` (and possibly an error_message); everything else from
+ * `handleToolUse` is a tool_use. Storage serializes tool_input as
+ * `JSON.stringify(input).slice(0, 4000)` while the event side fingerprints
+ * the live value — so the stored text is parsed and re-projected through
+ * the event-side branch semantics (objects re-stringify byte-identically;
+ * a stored `"\"pwd\""` becomes the unquoted `pwd` the event side produces).
+ * When the 4000-char truncation tore the JSON, the raw stored text sliced
+ * to the fingerprint window is exact (256 < 4000), so the key still matches.
+ *
+ * Callers must exclude bookkeeping rows first ({@link isBookkeepingActivity});
+ * this projection assumes a row that originated from a tool event.
+ */
+export function dedupKeyFromActivity(
+  row: {
+    session_id: string;
+    tool_name: string;
+    tool_input: string | null;
+    success: number;
+    error_message: string | null;
+  },
+): string {
+  const type = row.success === 0 || row.error_message !== null ? 'tool_failure' : 'tool_use';
+  let inputComponent = '';
+  if (row.tool_input !== null) {
+    try {
+      inputComponent = toolInputComponent(JSON.parse(row.tool_input));
+    } catch {
+      inputComponent = row.tool_input.slice(0, TOOL_INPUT_FINGERPRINT_CHARS);
+    }
+    inputComponent = canonicalInputComponent(inputComponent);
+  }
+  return composeKey(row.session_id, type, '', row.tool_name, inputComponent, '', '');
 }
 
 /**

--- a/packages/myco/src/constants.ts
+++ b/packages/myco/src/constants.ts
@@ -111,6 +111,18 @@ export function epochSeconds(): number {
 /** Max age for stale buffer files before cleanup (ms). */
 export const STALE_BUFFER_MAX_AGE_MS = 1 * MS_PER_DAY;
 
+// --- Stop replay ---
+/**
+ * How recently a session's latest OPEN batch must have shown activity for a
+ * replayed stop event to treat it as a live turn and skip the summary write.
+ * An open batch older than this is a missed-Stop turn (the Stop is what
+ * closes batches — if it never arrived, the batch stays open forever) and
+ * its buffered summary is recoverable. Conservative: the cost of skipping a
+ * fresh batch is a delayed recovery on the next pass; the cost of writing
+ * onto a live turn is a misattributed summary.
+ */
+export const STOP_REPLAY_OPEN_BATCH_FRESHNESS_MS = 30 * 60 * MS_PER_SECOND;
+
 // --- Retry backoff ---
 /** Retry delays for daemon health check (ms). */
 export const DAEMON_HEALTH_RETRY_DELAYS = [100, 200, 400, 800, 1500];

--- a/packages/myco/src/daemon/event-dedup-cache.ts
+++ b/packages/myco/src/daemon/event-dedup-cache.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared live event-deduplication cache.
+ *
+ * One instance is constructed in daemon/main.ts and handed to BOTH the
+ * /events dispatcher (`event-dispatch.ts`) and the buffer reconciler
+ * (`reconciliation.ts`). The dispatcher consults it to suppress hook-side
+ * retry storms; the reconciler records every event it replays so a late
+ * live POST of the same physical event lands in the duplicate window and
+ * is rejected instead of double-inserting. Both run on the daemon's main
+ * loop — no locking needed.
+ */
+
+import { eventDedupKey, EVENT_DEDUP_WINDOW_MS } from '@myco/capture/dedup.js';
+
+/**
+ * Cap on tracked keys to bound memory. FIFO eviction via Map insertion
+ * order is sufficient — duplicates arrive in sub-window bursts, so the
+ * oldest entries are the least likely to still matter.
+ */
+export const EVENT_DEDUP_CACHE_MAX = 4096;
+
+export class EventDedupCache {
+  private readonly recentEvents = new Map<string, number>();
+
+  constructor(
+    private readonly windowMs: number = EVENT_DEDUP_WINDOW_MS,
+    private readonly maxEntries: number = EVENT_DEDUP_CACHE_MAX,
+  ) {}
+
+  /**
+   * True when an identical event was seen within the dedup window.
+   * On a hit, refreshes the key's LRU position (keeping its ORIGINAL
+   * first-seen timestamp) so a sustained retry stream stays caught.
+   * On a miss, records the event as seen at `nowMs`.
+   */
+  isDuplicate(
+    event: { type: string; session_id: string } & Record<string, unknown>,
+    nowMs: number,
+  ): boolean {
+    const key = eventDedupKey(event);
+    const lastSeenMs = this.recentEvents.get(key);
+    if (lastSeenMs !== undefined && nowMs - lastSeenMs < this.windowMs) {
+      this.recentEvents.delete(key);
+      this.recentEvents.set(key, lastSeenMs);
+      return true;
+    }
+    this.record(key, nowMs);
+    return false;
+  }
+
+  /**
+   * Mark a key as seen at `seenAtMs` without a duplicate check. The buffer
+   * reconciler calls this for every event it replays, stamped with replay
+   * time (not the event's buffered timestamp) so the window covers live
+   * deliveries that race the replay.
+   */
+  record(key: string, seenAtMs: number): void {
+    this.recentEvents.set(key, seenAtMs);
+    if (this.recentEvents.size > this.maxEntries) {
+      // FIFO eviction — Map preserves insertion order
+      const oldest = this.recentEvents.keys().next().value;
+      if (oldest !== undefined) this.recentEvents.delete(oldest);
+    }
+  }
+}

--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -51,7 +51,7 @@ import { DEFAULT_SYMBIONT_NAME, epochSeconds, LOG_PROMPT_PREVIEW_CHARS } from '@
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { loadManifests } from '@myco/symbionts/detect.js';
 import { gateEventByCaptureRules } from './capture-gating.js';
-import { eventDedupKey, EVENT_DEDUP_WINDOW_MS } from '@myco/capture/dedup.js';
+import { EventDedupCache } from './event-dedup-cache.js';
 import { assertGroveProjectId, isGroveEraId } from '@myco/grove/ids.js';
 import type { ProjectPowerStateTracker } from './project-power-state.js';
 import { deferGitProvenance } from '@myco/release-provenance/capture.js';
@@ -98,6 +98,12 @@ export interface EventDispatchDeps {
    * even when it isn't the foreground project in the web UI.
    */
   projectStateTracker?: ProjectPowerStateTracker;
+  /**
+   * Shared duplicate cache — the buffer reconciler records replayed events
+   * into the same instance so a late live POST of an already-replayed event
+   * is rejected here. When absent (tests), a private instance is used.
+   */
+  eventDedupCache?: EventDedupCache;
 }
 
 // ---------------------------------------------------------------------------
@@ -107,17 +113,6 @@ export interface EventDispatchDeps {
 // Cap dropped-session cache to bound memory. Dropped sessions are rarely
 // revisited; FIFO eviction via Map ordering is sufficient.
 const DROP_DECISION_CACHE_MAX = 1024;
-
-// Suppress identical /events POSTs that arrive within `EVENT_DEDUP_WINDOW_MS`.
-// Hook scripts can re-fire the same event when the daemon was previously
-// slow or briefly unavailable (Claude Code retries, multi-symbiont overlap,
-// Codex's user_prompt-submit hook observed firing twice within ~30ms), and
-// the inserts at handleUserPrompt / insertActivityWithBatch have no natural
-// idempotency. A 10-second window catches retry storms without suppressing
-// legitimate same-text turns. The window value and fingerprint live in
-// `@myco/capture/dedup.js` so the buffer reconciler can apply the same key
-// when replaying events the live path already rejected.
-const EVENT_DEDUP_CACHE_MAX = 4096;
 
 export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
   const {
@@ -140,29 +135,19 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
     manifests.map((manifest) => [manifest.name, manifest.capture?.planTags ?? []] as const),
   );
 
-  // FIFO dedup cache for event idempotency. Key includes session_id, type,
-  // and a content fingerprint (see `@myco/capture/dedup.js`) so the cache
-  // can distinguish "same prompt sent twice" from "same hook type for two
-  // different prompts." Shared with the buffer reconciler so duplicates the
-  // live path correctly rejected don't resurrect on replay.
-  const recentEvents = new Map<string, number>();
-  function isDuplicateEvent(event: { type: string; session_id: string } & Record<string, unknown>, nowMs: number): boolean {
-    const key = eventDedupKey(event);
-    const lastSeenMs = recentEvents.get(key);
-    if (lastSeenMs !== undefined && nowMs - lastSeenMs < EVENT_DEDUP_WINDOW_MS) {
-      // Refresh LRU position so a sustained retry stream stays caught
-      recentEvents.delete(key);
-      recentEvents.set(key, lastSeenMs);
-      return true;
-    }
-    recentEvents.set(key, nowMs);
-    if (recentEvents.size > EVENT_DEDUP_CACHE_MAX) {
-      // FIFO eviction — Map preserves insertion order
-      const oldest = recentEvents.keys().next().value;
-      if (oldest !== undefined) recentEvents.delete(oldest);
-    }
-    return false;
-  }
+  // Dedup cache for event idempotency. Suppresses identical /events POSTs
+  // within the dedup window — hook scripts re-fire the same event when the
+  // daemon was previously slow or briefly unavailable (Claude Code retries,
+  // multi-symbiont overlap, Codex's user_prompt-submit hook observed firing
+  // twice within ~30ms), and the inserts at handleUserPrompt /
+  // insertActivityWithBatch have no natural idempotency. The 10-second
+  // window catches retry storms without suppressing legitimate same-text
+  // turns. Key includes session_id, type, and a content fingerprint (see
+  // `@myco/capture/dedup.js`) so the cache can distinguish "same prompt sent
+  // twice" from "same hook type for two different prompts." Shared with the
+  // buffer reconciler so duplicates the live path correctly rejected don't
+  // resurrect on replay — and so replayed events reject late live copies.
+  const eventDedupCache = deps.eventDedupCache ?? new EventDedupCache();
 
   // Cache drop decisions by session_id so a rejected session that keeps firing
   // events doesn't re-open + re-read (up to 128 KB) its transcript every time.
@@ -261,7 +246,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
     // activities. A wedged-then-recovered daemon, or two symbionts watching
     // the same project, can deliver the same physical event multiple times
     // within seconds; the downstream insert paths are not idempotent.
-    if (isDuplicateEvent(event, Date.now())) {
+    if (eventDedupCache.isDuplicate(event, Date.now())) {
       // Promoted from debug to info so `grep hooks.event` in the default
       // daemon log surfaces the volume of in-flight duplicate-fire patterns
       // (Codex's double-fire, Claude retries, multi-symbiont overlap) — a

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -183,6 +183,7 @@ import {
   handleTaskCompleted, handleCompact, syncTranscriptPromptBatches,
 } from './event-handlers.js';
 import { createReconciler } from './reconciliation.js';
+import { EventDedupCache } from './event-dedup-cache.js';
 import { reEnrichSessionFromTranscript } from './session-reenrich.js';
 import { runPendingMigrationTasks } from './migration-tasks.js';
 import { createStopProcessor } from './stop-processing.js';
@@ -1106,11 +1107,17 @@ export async function main(): Promise<void> {
   const bufferDirs = listAllProjectBufferDirs();
   const sessionBuffers = new Map<string, EventBuffer>();
 
+  // One duplicate cache shared between the live /events dispatcher and the
+  // buffer reconciler: live duplicates are suppressed AND replayed events
+  // reject their own late live copies.
+  const eventDedupCache = new EventDedupCache();
+
   const reconciler = createReconciler({
     bufferDirs,
     logger,
     projectRoot,
     onSessionReconciled: (sessionId) => reEnrichSessionFromTranscript(sessionId, { transcriptMiner, logger }),
+    eventDedupCache,
   });
   reconciler.runStartupReconciliation();
 
@@ -1214,6 +1221,7 @@ export async function main(): Promise<void> {
     planWatchConfig,
     triggerTitleSummary: stopProcessor.triggerTitleSummary,
     projectStateTracker,
+    eventDedupCache,
   });
   server.registerRoute('POST', '/events', eventDispatcher);
 

--- a/packages/myco/src/daemon/reconciliation.ts
+++ b/packages/myco/src/daemon/reconciliation.ts
@@ -13,16 +13,33 @@ import {
   listBatchesBySession,
   getLatestBatch,
   setResponseSummary,
+  toPromptBatchOrigin,
+  PROMPT_PREFIX_MATCH_CHARS,
+  type BatchRow,
 } from '@myco/db/queries/batches.js';
+import { listActivities, latestActivityTimestampForBatch } from '@myco/db/queries/activities.js';
 import { getSession } from '@myco/db/queries/sessions.js';
 import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
-import { STALE_BUFFER_MAX_AGE_MS, DEFAULT_SYMBIONT_NAME } from '@myco/constants.js';
+import {
+  STALE_BUFFER_MAX_AGE_MS,
+  STOP_REPLAY_OPEN_BATCH_FRESHNESS_MS,
+  DEFAULT_SYMBIONT_NAME,
+  MS_PER_SECOND,
+} from '@myco/constants.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import type { DaemonLogger } from './logger.js';
+import type { EventDedupCache } from './event-dedup-cache.js';
 import { handleUserPrompt, handleToolUse, handleToolFailure } from './event-handlers.js';
-import { toPromptBatchOrigin, countBatchesBySession, PROMPT_BATCH_ORIGIN, type PromptBatchOrigin } from '@myco/db/queries/batches.js';
 import { classifyNextPromptDecision } from '@myco/capture/prompt-kind.js';
-import { eventDedupKey, eventTimestampMs, EVENT_DEDUP_WINDOW_MS } from '@myco/capture/dedup.js';
+import {
+  eventDedupKey,
+  eventTimestampMs,
+  EVENT_DEDUP_WINDOW_MS,
+  convergenceEventKey,
+  dedupKeyFromPromptBatch,
+  dedupKeyFromActivity,
+  isBookkeepingActivity,
+} from '@myco/capture/dedup.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -39,6 +56,15 @@ const REPLAYABLE_EVENT_TYPES: ReadonlySet<string> = new Set([
   // without re-running full stop processing (which already ran live).
   'stop',
 ]);
+
+/**
+ * Row-fetch bound for the convergence multiset. A session's buffer file holds
+ * at most a few hundred events; this just keeps the query bounded against a
+ * pathological session without ever truncating a realistic one (the default
+ * list limits — 200 batches / 100 activities — WOULD truncate and silently
+ * re-insert the tail as duplicates).
+ */
+const CONVERGENCE_QUERY_LIMIT = 100_000;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -66,6 +92,13 @@ export interface ReconcilerDeps {
    * try/catch by the reconciler — thrown errors are logged and swallowed.
    */
   onSessionReconciled?: (sessionId: string) => void;
+  /**
+   * Shared live duplicate cache (same instance the /events dispatcher
+   * consults). Every replayed event's key is recorded into it at replay
+   * time so a late live POST of the same physical event is rejected as a
+   * duplicate instead of double-inserting.
+   */
+  eventDedupCache?: EventDedupCache;
 }
 
 export interface Reconciler {
@@ -88,30 +121,56 @@ export interface Reconciler {
  * `reconciledSessions` set so that each session is only reconciled once
  * per daemon lifetime.
  */
-export function createReconciler({ bufferDirs, logger, projectRoot, onSessionReconciled }: ReconcilerDeps): Reconciler {
+export function createReconciler({ bufferDirs, logger, projectRoot, onSessionReconciled, eventDedupCache }: ReconcilerDeps): Reconciler {
   // Track sessions already reconciled this daemon lifetime to avoid
   // redundant file reads (startup scan + register + event can all fire).
+  // A session is only added after a pass converges (zero replay errors,
+  // unchanged file identity) — failed or aborted passes stay eligible.
   const reconciledSessions = new Set<string>();
+
+  // Sessions whose idle buffer contained unparseable lines that were
+  // excluded (converge-with-loss). WARN once per session per daemon
+  // lifetime so a persistently-torn file doesn't spam the log.
+  const tornLineWarnedSessions = new Set<string>();
+
+  /** Snapshot of the byte-level identity of a buffer file. */
+  interface BufferIdentity { size: number; mtimeMs: number }
+
+  function statBufferIdentity(filePath: string): BufferIdentity | null {
+    try {
+      const stat = fs.statSync(filePath);
+      return { size: stat.size, mtimeMs: stat.mtimeMs };
+    } catch {
+      return null;
+    }
+  }
 
   /**
    * Locate the buffer file for a session across all known buffer dirs.
-   * Returns `{ dir, path, content }` for the first dir whose buffer file
-   * exists and is non-empty, or `null` when no buffer holds this session.
-   * The PR #346 invariant — "don't mark reconciled if buffer absent" —
-   * lifts cleanly across multiple dirs: a session whose buffer hasn't
-   * surfaced in any of them is genuinely absent, and the caller returns
-   * without marking it.
+   * Returns the first dir whose buffer file exists and is non-empty, or
+   * `null` when no buffer holds this session. The PR #346 invariant —
+   * "don't mark reconciled if buffer absent" — lifts cleanly across
+   * multiple dirs: a session whose buffer hasn't surfaced in any of them
+   * is genuinely absent, and the caller returns without marking it.
+   *
+   * The file is stat'ed BEFORE it is read; the caller re-stats after the
+   * pass and treats any identity change (size or mtime) as "events arrived
+   * mid-pass" — the pass is then not considered converged.
    */
-  function locateBufferContent(sessionId: string): { dir: string; content: string } | null {
+  function locateBufferContent(
+    sessionId: string,
+  ): { dir: string; path: string; content: string; identity: BufferIdentity } | null {
     for (const dir of bufferDirs) {
       const bufferPath = path.join(dir, `${sessionId}.jsonl`);
+      const identity = statBufferIdentity(bufferPath);
+      if (!identity) continue;
       let raw: string;
       try {
         raw = fs.readFileSync(bufferPath, 'utf-8').trim();
       } catch {
         continue;
       }
-      if (raw) return { dir, content: raw };
+      if (raw) return { dir, path: bufferPath, content: raw, identity };
     }
     return null;
   }
@@ -122,9 +181,18 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
    * Shared between reconcileSession (buffer replay) and the live /events
    * route to eliminate dispatch duplication.
    *
+   * `passCreatedBatchIds` collects the batch ids this reconciliation pass
+   * creates (prompt replays) and exempts them from the stop-replay
+   * freshness guard — a batch fabricated from buffered history moments ago
+   * is not a live turn, even though its created_at is "now".
+   *
    * @returns 'prompt' | 'activity' | null indicating what was created.
    */
-  function replayEvent(sessionId: string, event: Record<string, unknown>): 'prompt' | 'activity' | null {
+  function replayEvent(
+    sessionId: string,
+    event: Record<string, unknown>,
+    passCreatedBatchIds?: Set<number>,
+  ): 'prompt' | 'activity' | null {
     if (event.type === 'user_prompt') {
       // Live hooks forward `origin` from the manifest decision; pre-v49 buffer
       // files have no `origin` field. Re-evaluate the manifest rule on the
@@ -136,7 +204,8 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
       if (typeof event.origin === 'string') {
         // Post-rule hooks apply the drop decision BEFORE buffering, so a
         // forwarded origin means the event passed the rules; trust it.
-        handleUserPrompt(sessionId, promptText, { origin: toPromptBatchOrigin(event.origin) });
+        const { batchId } = handleUserPrompt(sessionId, promptText, { origin: toPromptBatchOrigin(event.origin) });
+        passCreatedBatchIds?.add(batchId);
         return 'prompt';
       }
       // Pre-rule buffer (no forwarded origin): re-evaluate the manifest rule
@@ -148,7 +217,8 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
       const decision = classifyNextPromptDecision(agent, promptText);
       if (decision.action === 'drop') return null;
       const replayText = decision.action === 'rewrite' ? decision.prompt : promptText;
-      handleUserPrompt(sessionId, replayText, { origin: toPromptBatchOrigin(decision.origin ?? 'human') });
+      const { batchId } = handleUserPrompt(sessionId, replayText, { origin: toPromptBatchOrigin(decision.origin ?? 'human') });
+      passCreatedBatchIds?.add(batchId);
       return 'prompt';
     }
     if (event.type === 'tool_use') {
@@ -180,26 +250,81 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
         : '';
       if (!summary) return null;
       const latest = getLatestBatch(sessionId);
-      if (latest && !latest.response_summary) {
-        setResponseSummary(latest.id, summary);
-        return 'activity';
+      if (!latest || latest.response_summary) return null;
+      // Staleness-qualified open-batch guard. A FRESH open batch is a turn
+      // that may still be live — a replayed stop landing on it would
+      // attribute a buffered assistant message to a turn it may not belong
+      // to. A STALE open batch is the missed-Stop shape itself: the Stop is
+      // what closes batches, so a turn whose Stop the daemon never received
+      // stays open forever — its buffered summary IS the recovery target.
+      // Batches THIS pass created are exempt: they were fabricated from
+      // buffered history seconds ago (created_at = now, so they'd always
+      // read as fresh) but are by construction not live turns — the
+      // full-turn-missed shape needs its stop to land on exactly such a
+      // batch. Freshness reads the batch's last sign of life: the latest
+      // activity row attached to it, falling back to the batch's own
+      // created_at. created_at alone would misclassify a long-running live
+      // turn (old batch, activities still flowing) as stale; the
+      // MAX(timestamp) is a single indexed query on this rare replay-only
+      // path. Write the summary only — the batch is deliberately NOT
+      // closed here.
+      if (latest.ended_at === null && !passCreatedBatchIds?.has(latest.id)) {
+        const lastActivitySec = latestActivityTimestampForBatch(latest.id) ?? latest.created_at;
+        const lastSignOfLifeSec = Math.max(lastActivitySec, latest.created_at);
+        if (Date.now() - lastSignOfLifeSec * MS_PER_SECOND < STOP_REPLAY_OPEN_BATCH_FRESHNESS_MS) {
+          return null;
+        }
       }
+      setResponseSummary(latest.id, summary);
+      return 'activity';
     }
     return null;
   }
 
   /**
-   * Reconcile buffer events against DB state for a session.
+   * Second-chance prompt match for the miner tail-rewrite shape ONLY: true
+   * when an existing batch's prompt and the buffered text are BOTH at least
+   * PROMPT_PREFIX_MATCH_CHARS long and identical across that full window
+   * (the same window `findBatchByPromptPrefix` uses for attachment
+   * matching). Catches the Stop-time transcript miner rewriting a stored
+   * LONG prompt's tail while the buffer holds the original hook-delivered
+   * text (or vice versa). Texts shorter than the window are deliberately
+   * excluded: they are fully covered by the exact 256-char key, so a
+   * mismatch there means a genuinely different — or genuinely repeated —
+   * prompt ("continue", "y") that must replay, not be absorbed by an
+   * earlier turn's batch. Matches only against the PRE-PASS batch snapshot
+   * so a prompt replayed earlier in this pass can't absorb a later genuine
+   * same-text turn.
+   */
+  function hasPrefixMatchedBatch(batches: ReadonlyArray<BatchRow>, bufferedText: string): boolean {
+    if (bufferedText.length < PROMPT_PREFIX_MATCH_CHARS) return false;
+    const bufferedPrefix = bufferedText.slice(0, PROMPT_PREFIX_MATCH_CHARS);
+    for (const batch of batches) {
+      const rowPrompt = batch.user_prompt;
+      if (!rowPrompt || rowPrompt.length < PROMPT_PREFIX_MATCH_CHARS) continue;
+      if (rowPrompt.startsWith(bufferedPrefix)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Reconcile buffer events against DB state for a session by CONTENT.
    *
    * The buffer is the authoritative event log. The DB (prompt_batches +
    * activities) is a derived view. After a daemon restart, the DB may be
-   * missing events the daemon didn't process while it was down.
+   * missing events the daemon didn't process while it was down — and the
+   * buffer may hold copies of events the daemon DID process (the hook CLI
+   * appends its own copy whenever the daemon's response didn't confirm
+   * processing), so position- or count-based divergence misidentifies the
+   * replay point whenever the two sides drifted asymmetrically.
    *
-   * Activities belong to batches — they're linked via the latest open batch
-   * at insertion time. So we can't reconcile them separately. Instead, we
-   * find where the DB diverges from the buffer (by prompt count) and replay
-   * the FULL event stream from that point: prompts open batches, tool events
-   * attach to the open batch — exactly the normal flow.
+   * Convergence instead keys every stored row and every buffer event with
+   * the shared content fingerprint (`@myco/capture/dedup.js`) and walks the
+   * buffer chronologically: an event whose key still has an unconsumed DB
+   * row converged already; everything else replays through the normal
+   * handler flow (prompts open batches, tool events attach to the open
+   * batch). The session is marked reconciled only when the pass completes
+   * with zero replay errors against an unchanged buffer file.
    */
   function reconcileSession(sessionId: string): void {
     if (reconciledSessions.has(sessionId)) return;
@@ -219,133 +344,208 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
       return;
     }
 
-    // Both preconditions hold; mark reconciled so the startup loop and
-    // a later /events auto-register don't replay it twice.
-    reconciledSessions.add(sessionId);
-
-    const allEvents: Array<Record<string, unknown>> = content.split('\n').map((line) => JSON.parse(line));
-
-    // Stop events can be dropped independently of prompt divergence — the
-    // daemon can accept a prompt live, then go down before that turn's stop
-    // arrives. Apply any buffered stops first; it's cheap and idempotent
-    // (setResponseSummary only writes when the column is still NULL).
-    let summariesRecovered = 0;
-    for (const event of allEvents) {
-      if (event.type !== 'stop') continue;
+    // Tolerant per-line parse with aging. A torn line on a FRESH file (an
+    // append may still be in flight) aborts the pass — the next trigger
+    // retries once the write completes. A torn line on an idle file is
+    // permanent damage: exclude it, warn once per session per daemon
+    // lifetime, and converge what remains.
+    const allEvents: Array<Record<string, unknown>> = [];
+    let tornLines = 0;
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
       try {
-        if (replayEvent(sessionId, event) === 'activity') summariesRecovered++;
-      } catch (err) {
-        logger.warn(LOG_KINDS.LIFECYCLE_RECONCILE, 'Reconciliation: stop replay failed', {
+        allEvents.push(JSON.parse(trimmed));
+      } catch {
+        tornLines++;
+      }
+    }
+    if (tornLines > 0) {
+      if (Date.now() - located.identity.mtimeMs < EVENT_DEDUP_WINDOW_MS) {
+        logger.debug(LOG_KINDS.LIFECYCLE_RECONCILE, 'Reconciliation deferred — unparseable line on a fresh buffer', {
           session_id: sessionId,
-          error: String(err),
+          torn_lines: tornLines,
+        });
+        return;
+      }
+      if (!tornLineWarnedSessions.has(sessionId)) {
+        tornLineWarnedSessions.add(sessionId);
+        logger.warn(LOG_KINDS.LIFECYCLE_RECONCILE, 'Reconciliation: excluding unparseable lines from idle buffer', {
+          session_id: sessionId,
+          torn_lines: tornLines,
+          buffer_path: located.path,
         });
       }
     }
 
-    // Find the divergence point. Both sides count HUMAN-origin batches/events
-    // only. The asymmetric alternative — counting all origins — breaks on
-    // any DB that pre-dates the retirement of SYSTEM_MESSAGE_PREFIXES: those
-    // legacy DBs have no system/agent_dispatch rows (the live path used to
-    // drop them) but their buffer files still contain the underlying events.
-    // Counting all origins on the buffer side against a system-free DB would
-    // pick the wrong replay start and re-insert prior human prompts as
-    // duplicates. Counting only human-origin events stays symmetric across
-    // the upgrade boundary in both directions.
-    const existingBatchCount = countBatchesBySession(sessionId, { origins: [PROMPT_BATCH_ORIGIN.HUMAN] });
+    let replayErrors = 0;
 
-    let promptsSeen = 0;
-    let replayStartIndex = -1;
-
-    for (let i = 0; i < allEvents.length; i++) {
-      const e = allEvents[i];
-      if (e.type !== 'user_prompt') continue;
-      let eventOrigin: PromptBatchOrigin | null;
-      if (typeof e.origin === 'string') {
-        eventOrigin = toPromptBatchOrigin(e.origin);
-      } else {
-        // Mirror replayEvent: a pre-rule buffered prompt the manifest would
-        // DROP must NOT be counted as a human prompt here, or it inflates
-        // promptsSeen and skews the replay-start index (re-inserting prior
-        // human prompts as duplicates).
-        const decision = classifyNextPromptDecision(
-          typeof e.agent === 'string' ? e.agent : undefined,
-          String(e.prompt ?? ''),
-        );
-        eventOrigin = decision.action === 'drop'
-          ? null
-          : toPromptBatchOrigin(decision.origin ?? 'human');
-      }
-      if (eventOrigin !== PROMPT_BATCH_ORIGIN.HUMAN) continue;
-      promptsSeen++;
-      if (promptsSeen === existingBatchCount + 1) {
-        replayStartIndex = i;
-        break;
-      }
+    // DB-side content multiset: every stored prompt and every stored
+    // non-bookkeeping activity, keyed with the convergence projections of
+    // the shared fingerprint. Multiset (key → count) so N genuine
+    // same-text turns consume N matches. Bookkeeping rows (subagent_*,
+    // task_completed, compact, stop_failure) come from non-replayable
+    // events and must never absorb a tool match.
+    const existingBatches = listBatchesBySession(sessionId, {
+      scope: ALL_PROJECTS_SCOPE,
+      limit: CONVERGENCE_QUERY_LIMIT,
+    });
+    const dbKeyCounts = new Map<string, number>();
+    for (const batch of existingBatches) {
+      const key = dedupKeyFromPromptBatch(batch);
+      dbKeyCounts.set(key, (dbKeyCounts.get(key) ?? 0) + 1);
+    }
+    for (const activity of listActivities({
+      session_id: sessionId,
+      scope: ALL_PROJECTS_SCOPE,
+      limit: CONVERGENCE_QUERY_LIMIT,
+    })) {
+      if (isBookkeepingActivity(activity.tool_name)) continue;
+      const key = dedupKeyFromActivity(activity);
+      dbKeyCounts.set(key, (dbKeyCounts.get(key) ?? 0) + 1);
     }
 
-    if (replayStartIndex === -1) {
-      if (summariesRecovered > 0) {
-        logger.info(LOG_KINDS.LIFECYCLE_RECONCILE, 'Buffer reconciliation recovered stop summaries', {
-          session_id: sessionId,
-          summaries_recovered: summariesRecovered,
-        });
-      }
-      tryReEnrich(sessionId);
-      return;
-    }
-
-    // Replay full event stream from the divergence point. Two guards apply
-    // before each event hits replayEvent:
+    // Match-and-consume chronologically. Three guards apply before a
+    // prompt / tool event reaches replayEvent:
     //
-    //   1. Type filter (REPLAYABLE_EVENT_TYPES).
-    //   2. Content+window dedup that mirrors the live dispatcher
-    //      (`event-dispatch.ts`). The hook CLI writes to the buffer file
-    //      whenever the daemon returns `ignored: 'duplicate'` (see
-    //      `hooks/send-event.ts`), so without this guard the replay path
-    //      re-inserts events the live path already rejected. Both paths
-    //      now use the same key from `@myco/capture/dedup.js`.
-    const eventsToReplay = allEvents.slice(replayStartIndex).filter(
-      (e) => REPLAYABLE_EVENT_TYPES.has(String(e.type)),
-    );
-
+    //   1. Intra-buffer collapse — the live dispatcher's content+window
+    //      dedup applied over the whole file, so the daemon-appended copy
+    //      and the hook CLI's duplicate copy (written whenever the daemon
+    //      returns `ignored: 'duplicate'` — see `hooks/send-event.ts`)
+    //      count as ONE logical event.
+    //   2. Exact content match — the event's convergence key consumes one
+    //      unconsumed DB row with the same key. user_prompt events key on
+    //      the candidate replay text (the rewritten form the live hook
+    //      stored and replay would insert), not the raw buffered text.
+    //   3. Second-chance prefix match (user_prompt only) — catches miner
+    //      tail-rewrites of LONG prompts where exact text diverged. Skips
+    //      WITHOUT consuming a multiset count.
+    //
+    // Stop events take none of these: they have no DB-row projection and
+    // their fingerprint carries no content (every stop in a session shares
+    // one key, so collapse would eat a rapid second turn's summary). Each
+    // is replayed at its chronological position — after the prompts that
+    // precede it — so getLatestBatch resolves the batch the turn actually
+    // ended on, including a batch this same pass just recovered. The write
+    // is NULL-only idempotent.
+    //
+    // Replayed activities attach via insertActivityWithBatch's latest-open
+    // fallback — recovered-but-possibly-misattributed-across-turns is
+    // accepted for P1.
     let promptsRecovered = 0;
     let activitiesRecovered = 0;
     let duplicatesSuppressed = 0;
+    let eventsConverged = 0;
+    let summariesRecovered = 0;
     const seenKeys = new Map<string, number>();
+    const passCreatedBatchIds = new Set<number>();
 
-    for (const event of eventsToReplay) {
+    for (const event of allEvents) {
+      const type = String(event.type);
+      if (!REPLAYABLE_EVENT_TYPES.has(type)) continue;
+
+      if (type === 'stop') {
+        try {
+          if (replayEvent(sessionId, event, passCreatedBatchIds) === 'activity') summariesRecovered++;
+        } catch (err) {
+          replayErrors++;
+          logger.warn(LOG_KINDS.LIFECYCLE_RECONCILE, 'Reconciliation: stop replay failed', {
+            session_id: sessionId,
+            error: String(err),
+          });
+        }
+        continue;
+      }
+
       const eventWithSession = {
         ...event,
-        type: String(event.type),
+        type,
         session_id: sessionId,
       } as Record<string, unknown> & { type: string; session_id: string };
-      const key = eventDedupKey(eventWithSession);
+      const exactKey = eventDedupKey(eventWithSession);
       const ts = eventTimestampMs(event) ?? Date.now();
-      const lastSeen = seenKeys.get(key);
+      const lastSeen = seenKeys.get(exactKey);
       if (lastSeen !== undefined && ts - lastSeen < EVENT_DEDUP_WINDOW_MS) {
         duplicatesSuppressed++;
         continue;
       }
-      seenKeys.set(key, ts);
+      seenKeys.set(exactKey, ts);
+
+      // Mirror replayEvent's user_prompt gate so a pre-rule event the
+      // manifest would DROP neither consumes a DB row nor replays, and so
+      // both match layers compare the text replay WOULD insert.
+      let candidateText: string | null = null;
+      if (type === 'user_prompt') {
+        const promptText = String(event.prompt ?? '');
+        if (typeof event.origin === 'string') {
+          candidateText = promptText;
+        } else {
+          const decision = classifyNextPromptDecision(
+            typeof event.agent === 'string' ? event.agent : undefined,
+            promptText,
+          );
+          if (decision.action === 'drop') continue;
+          candidateText = decision.action === 'rewrite' ? decision.prompt : promptText;
+        }
+      }
+
+      const matchKey = type === 'user_prompt'
+        ? convergenceEventKey({ ...eventWithSession, prompt: candidateText ?? '' })
+        : convergenceEventKey(eventWithSession);
+      const remaining = dbKeyCounts.get(matchKey) ?? 0;
+      if (remaining > 0) {
+        dbKeyCounts.set(matchKey, remaining - 1);
+        eventsConverged++;
+        continue;
+      }
+
+      if (type === 'user_prompt' && candidateText && hasPrefixMatchedBatch(existingBatches, candidateText)) {
+        eventsConverged++;
+        continue;
+      }
 
       try {
-        const result = replayEvent(sessionId, event);
+        const result = replayEvent(sessionId, event, passCreatedBatchIds);
         if (result === 'prompt') promptsRecovered++;
         else if (result === 'activity') activitiesRecovered++;
+        // Mirror the replay into the live duplicate cache (replay-time
+        // stamp) so a late live POST of the same physical event is
+        // rejected by the dispatcher instead of double-inserting.
+        if (result !== null) eventDedupCache?.record(exactKey, Date.now());
       } catch (err) {
+        replayErrors++;
         logger.warn(LOG_KINDS.LIFECYCLE_RECONCILE, 'Reconciliation: failed to replay event', {
-          type: String(event.type),
+          type,
           error: String(err),
         });
       }
     }
 
-    if (promptsRecovered > 0 || activitiesRecovered > 0 || duplicatesSuppressed > 0) {
+    // Converged only if no replay failed AND the buffer file is byte-
+    // identical to the pre-read snapshot (no events arrived mid-pass).
+    // Anything else leaves the session eligible for the next trigger.
+    const after = statBufferIdentity(located.path);
+    const identityUnchanged = after !== null
+      && after.size === located.identity.size
+      && after.mtimeMs === located.identity.mtimeMs;
+    if (replayErrors === 0 && identityUnchanged) {
+      reconciledSessions.add(sessionId);
+    } else {
+      logger.debug(LOG_KINDS.LIFECYCLE_RECONCILE, 'Reconciliation pass not converged — session stays eligible', {
+        session_id: sessionId,
+        replay_errors: replayErrors,
+        buffer_changed: !identityUnchanged,
+      });
+    }
+
+    if (promptsRecovered > 0 || activitiesRecovered > 0 || duplicatesSuppressed > 0 || summariesRecovered > 0) {
       logger.info(LOG_KINDS.LIFECYCLE_RECONCILE, 'Buffer reconciliation complete', {
         session_id: sessionId,
         prompts_recovered: promptsRecovered,
         activities_recovered: activitiesRecovered,
         duplicates_suppressed: duplicatesSuppressed,
+        events_converged: eventsConverged,
+        summaries_recovered: summariesRecovered,
       });
     }
     tryReEnrich(sessionId);

--- a/packages/myco/src/db/queries/activities.ts
+++ b/packages/myco/src/db/queries/activities.ts
@@ -393,6 +393,18 @@ export function listActivitiesByBatch(
 }
 
 /**
+ * Latest activity timestamp (epoch seconds) attached to a batch, or null
+ * when the batch has no activities. Single indexed MAX() — the liveness
+ * signal the stop-replay freshness guard reads for open batches.
+ */
+export function latestActivityTimestampForBatch(promptBatchId: number): number | null {
+  const row = getDatabase().prepare(
+    `SELECT MAX(timestamp) AS ts FROM activities WHERE prompt_batch_id = ?`,
+  ).get(promptBatchId) as { ts: number | null };
+  return row.ts ?? null;
+}
+
+/**
  * Count total activities for a given session.
  */
 export function countActivities(sessionId: string): number {

--- a/tests/capture/dedup-projections.test.ts
+++ b/tests/capture/dedup-projections.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  eventDedupKey,
+  convergenceEventKey,
+  dedupKeyFromPromptBatch,
+  dedupKeyFromActivity,
+  isBookkeepingActivity,
+  BOOKKEEPING_ACTIVITY_TOOL_NAMES,
+} from '@myco/capture/dedup.js';
+import { TOOL_INPUT_STORE_LIMIT } from '@myco/daemon/event-handlers.js';
+
+// The convergence projections must place a stored DB row and the buffer
+// event that produced it on the SAME key — across the asymmetric
+// serializations the two sides use (event: live value fingerprinted at 256
+// chars; row: JSON.stringify(...).slice(0, 4000) or NULL for falsy inputs).
+
+const SESSION = 's-proj';
+
+/** Row shape as the live handleToolUse insert path stores it. */
+function storedToolUseRow(toolName: string, toolInput: unknown) {
+  return {
+    session_id: SESSION,
+    tool_name: toolName,
+    tool_input: toolInput ? JSON.stringify(toolInput).slice(0, TOOL_INPUT_STORE_LIMIT) : null,
+    success: 1,
+    error_message: null as string | null,
+  };
+}
+
+describe('dedupKeyFromPromptBatch', () => {
+  it('matches the convergence key of the user_prompt event that stored the row', () => {
+    const event = { type: 'user_prompt', session_id: SESSION, prompt: 'Help me debug this' };
+    const row = { session_id: SESSION, user_prompt: 'Help me debug this' };
+    expect(dedupKeyFromPromptBatch(row)).toBe(convergenceEventKey(event));
+  });
+
+  it('equals the live dispatcher key for an ordinary prompt — the two key spaces align', () => {
+    const event = { type: 'user_prompt', session_id: SESSION, prompt: 'plain prompt' };
+    expect(convergenceEventKey(event)).toBe(eventDedupKey(event));
+  });
+
+  it('a NULL stored prompt matches a prompt-less user_prompt event', () => {
+    const event = { type: 'user_prompt', session_id: SESSION };
+    const row = { session_id: SESSION, user_prompt: null };
+    expect(dedupKeyFromPromptBatch(row)).toBe(convergenceEventKey(event));
+  });
+
+  it('truncates at the 256-char fingerprint window like the event side', () => {
+    const text = 'y'.repeat(300);
+    const row = { session_id: SESSION, user_prompt: text + 'stored-tail' };
+    const event = { type: 'user_prompt', session_id: SESSION, prompt: text + 'event-tail' };
+    expect(dedupKeyFromPromptBatch(row)).toBe(convergenceEventKey(event));
+  });
+
+  it('a rewrite-rule row matches the event keyed on its candidate (rewritten) text, not the raw preamble', () => {
+    // The live hook applies rewrite rules BEFORE buffering/storing, so the
+    // stored row holds the rewritten text. The reconciler therefore keys
+    // user_prompt events on the candidate replay text for the exact match —
+    // the raw preamble form keys differently by construction.
+    const raw = '# Files mentioned by the user:\n## My request for Codex:\nresize it';
+    const rewritten = 'resize it';
+    const row = { session_id: SESSION, user_prompt: rewritten };
+    expect(dedupKeyFromPromptBatch(row))
+      .not.toBe(convergenceEventKey({ type: 'user_prompt', session_id: SESSION, prompt: raw }));
+    expect(dedupKeyFromPromptBatch(row))
+      .toBe(convergenceEventKey({ type: 'user_prompt', session_id: SESSION, prompt: rewritten }));
+  });
+});
+
+describe('dedupKeyFromActivity — input reconstruction', () => {
+  it('round-trips an object tool_input through the stored JSON text', () => {
+    const input = { command: 'ls -la', description: 'list files' };
+    const event = { type: 'tool_use', session_id: SESSION, tool_name: 'Bash', tool_input: input };
+    expect(dedupKeyFromActivity(storedToolUseRow('Bash', input))).toBe(convergenceEventKey(event));
+  });
+
+  it('unquotes a scalar string input (stored as JSON `"pwd"`, fingerprinted as `pwd`)', () => {
+    const event = { type: 'tool_use', session_id: SESSION, tool_name: 'Bash', tool_input: 'pwd' };
+    expect(dedupKeyFromActivity(storedToolUseRow('Bash', 'pwd'))).toBe(convergenceEventKey(event));
+  });
+
+  it('a stored NULL matches every falsy event-side input (undefined, null, "", 0, false)', () => {
+    const nullRowKey = dedupKeyFromActivity(storedToolUseRow('Read', undefined));
+    for (const falsy of [undefined, null, '', 0, false]) {
+      const event = { type: 'tool_use', session_id: SESSION, tool_name: 'Read', tool_input: falsy };
+      expect(convergenceEventKey(event)).toBe(nullRowKey);
+    }
+  });
+
+  it('falsy widening does not swallow truthy scalars', () => {
+    const nullRowKey = dedupKeyFromActivity(storedToolUseRow('Read', undefined));
+    const event = { type: 'tool_use', session_id: SESSION, tool_name: 'Read', tool_input: 'echo 1' };
+    expect(convergenceEventKey(event)).not.toBe(nullRowKey);
+  });
+
+  it('keys a >4000-char torn stored JSON on the raw slice — exact within the fingerprint window', () => {
+    const input = { script: 'z'.repeat(TOOL_INPUT_STORE_LIMIT + 500) };
+    const row = storedToolUseRow('Bash', input);
+    // Sanity: the stored text really is torn (truncated, unparseable).
+    expect(row.tool_input!.length).toBe(TOOL_INPUT_STORE_LIMIT);
+    expect(() => JSON.parse(row.tool_input!)).toThrow();
+    const event = { type: 'tool_use', session_id: SESSION, tool_name: 'Bash', tool_input: input };
+    expect(dedupKeyFromActivity(row)).toBe(convergenceEventKey(event));
+  });
+});
+
+describe('dedupKeyFromActivity — type discrimination', () => {
+  it('success=0 keys as tool_failure', () => {
+    const row = { ...storedToolUseRow('Bash', { command: 'x' }), success: 0 };
+    const failureEvent = { type: 'tool_failure', session_id: SESSION, tool_name: 'Bash', tool_input: { command: 'x' } };
+    expect(dedupKeyFromActivity(row)).toBe(convergenceEventKey(failureEvent));
+  });
+
+  it('error_message present keys as tool_failure even with success=1', () => {
+    const row = { ...storedToolUseRow('Bash', { command: 'x' }), error_message: 'boom' };
+    const failureEvent = { type: 'tool_failure', session_id: SESSION, tool_name: 'Bash', tool_input: { command: 'x' } };
+    expect(dedupKeyFromActivity(row)).toBe(convergenceEventKey(failureEvent));
+  });
+
+  it('a tool_failure row never matches the equivalent tool_use event', () => {
+    const row = { ...storedToolUseRow('Bash', { command: 'x' }), success: 0 };
+    const useEvent = { type: 'tool_use', session_id: SESSION, tool_name: 'Bash', tool_input: { command: 'x' } };
+    expect(dedupKeyFromActivity(row)).not.toBe(convergenceEventKey(useEvent));
+  });
+});
+
+describe('bookkeeping exclusion', () => {
+  it('enumerates exactly the rows written by the bookkeeping handlers', () => {
+    expect([...BOOKKEEPING_ACTIVITY_TOOL_NAMES].sort()).toEqual([
+      'post_compact',
+      'pre_compact',
+      'stop_failure',
+      'subagent_start',
+      'subagent_stop',
+      'task_completed',
+    ]);
+  });
+
+  it('classifies bookkeeping vs tool activities', () => {
+    expect(isBookkeepingActivity('subagent_stop')).toBe(true);
+    expect(isBookkeepingActivity('task_completed')).toBe(true);
+    expect(isBookkeepingActivity('Bash')).toBe(false);
+    expect(isBookkeepingActivity('mcp__myco__myco_search')).toBe(false);
+  });
+});

--- a/tests/daemon/reconciliation-convergence.test.ts
+++ b/tests/daemon/reconciliation-convergence.test.ts
@@ -1,0 +1,608 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'bun:test';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
+import { seedSession, nowSec } from '../helpers/sessions.js';
+import { createReconciler } from '@myco/daemon/reconciliation.js';
+import { EventDedupCache } from '@myco/daemon/event-dedup-cache.js';
+import {
+  handleUserPrompt,
+  handleToolUse,
+  handleToolFailure,
+  handleSubagentStop,
+  handleStopBatches,
+  TOOL_INPUT_STORE_LIMIT,
+} from '@myco/daemon/event-handlers.js';
+import { listBatchesBySession, insertBatchStateless } from '@myco/db/queries/batches.js';
+import { listActivities, countActivities } from '@myco/db/queries/activities.js';
+import { getDatabase } from '@myco/db/client.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// Content-keyed convergence: the reconciler matches buffer events against
+// stored rows by content fingerprint instead of comparing prompt counts.
+// These tests cover the shapes the count-based pass got wrong — duplicate
+// hook copies of already-processed events, torn buffer lines, miner-rewritten
+// prompt text, and missed activities with no prompt divergence at all.
+
+const silentLogger = {
+  debug: () => {}, info: () => {}, warn: () => {}, error: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;
+
+function makeWarnLogger() {
+  const warns: string[] = [];
+  const logger = {
+    debug: () => {}, info: () => {}, error: () => {},
+    warn: (_kind: string, msg: string) => { warns.push(msg); },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+  return { logger, warns };
+}
+
+describe('Buffer reconciliation — content-keyed convergence', () => {
+  let tmpDir: string;
+  let bufferDir: string;
+
+  beforeAll(() => { setupTestDb(); });
+  afterAll(teardownTestDb);
+
+  beforeEach(() => {
+    cleanTestDb();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reconcile-converge-'));
+    bufferDir = path.join(tmpDir, 'buffer');
+    fs.mkdirSync(bufferDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function bufferPathFor(sessionId: string): string {
+    return path.join(bufferDir, `${sessionId}.jsonl`);
+  }
+
+  function writeBuffer(sessionId: string, lines: Array<Record<string, unknown> | string>): void {
+    const content = lines
+      .map((line) => (typeof line === 'string' ? line : JSON.stringify(line)))
+      .join('\n') + '\n';
+    fs.writeFileSync(bufferPathFor(sessionId), content);
+  }
+
+  /** Push a buffer file's mtime into the past so it counts as idle. */
+  function ageBuffer(sessionId: string, ageMs: number): void {
+    const past = new Date(Date.now() - ageMs);
+    fs.utimesSync(bufferPathFor(sessionId), past, past);
+  }
+
+  function makeReconciler(logger = silentLogger, eventDedupCache?: EventDedupCache) {
+    return createReconciler({
+      bufferDirs: [bufferDir],
+      logger,
+      projectRoot: process.cwd(),
+      eventDedupCache,
+    });
+  }
+
+  /**
+   * Backdate a batch so the stop-replay freshness guard sees it as STALE
+   * (missed-Stop shape: open, with its last sign of life in the past).
+   */
+  function backdateBatch(batchId: number, ageSeconds: number): void {
+    const past = nowSec() - ageSeconds;
+    getDatabase().prepare(
+      `UPDATE prompt_batches SET created_at = ?, started_at = ? WHERE id = ?`,
+    ).run(past, past, batchId);
+  }
+
+  // Shape 1: the live path already processed the prompt (row in DB), but the
+  // buffer holds BOTH the daemon-appended copy and the hook CLI's duplicate
+  // copy. The count-based pass saw 1 DB batch vs 2 buffered human prompts
+  // and replayed the "extra" one as a duplicate.
+  it('converges a DB-present prompt against daemon copy + hook duplicate copy — and stays converged on the reload path', () => {
+    const sessionId = 'conv-n-plus-1';
+    seedSession({ id: sessionId });
+    handleUserPrompt(sessionId, 'fix the auth bug', { kind: 'initial' });
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'fix the auth bug', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      { type: 'user_prompt', prompt: 'fix the auth bug', origin: 'human', timestamp: '2026-06-10T10:00:00.007Z' },
+    ]);
+
+    const reconciler = makeReconciler();
+    reconciler.reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(1);
+
+    // Reload path: clearSession (unregister) wipes the once-per-lifetime
+    // mark; a second full pass must converge to the same single batch.
+    reconciler.clearSession(sessionId);
+    reconciler.reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(1);
+  });
+
+  // Shape 2: the hook's 2s response timeout makes it append its own copy a
+  // couple of seconds after the daemon already appended (and processed) the
+  // event. Same convergence outcome at a wider gap inside the dedup window.
+  it('converges the 2s-timeout shape (daemon copy + late hook copy, row in DB)', () => {
+    const sessionId = 'conv-timeout';
+    seedSession({ id: sessionId });
+    handleUserPrompt(sessionId, 'run the migration', { kind: 'initial' });
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'run the migration', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      { type: 'user_prompt', prompt: 'run the migration', origin: 'human', timestamp: '2026-06-10T10:00:02.100Z' },
+    ]);
+
+    makeReconciler().reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(1);
+  });
+
+  // Shape 10: a torn line in the MIDDLE of an idle file is permanent damage
+  // — excluded with one warning, everything else converges, and the session
+  // is marked reconciled (converge-with-loss).
+  it('excludes a torn middle line on an idle file, warns once per lifetime, and converges the rest', () => {
+    const sessionId = 'conv-torn-middle';
+    seedSession({ id: sessionId });
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'first prompt', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      '{"type":"user_prompt","prompt":"torn-in-ha',
+      { type: 'user_prompt', prompt: 'second prompt', origin: 'human', timestamp: '2026-06-10T10:01:00.000Z' },
+    ]);
+    ageBuffer(sessionId, 60_000);
+
+    const { logger, warns } = makeWarnLogger();
+    const reconciler = makeReconciler(logger);
+    reconciler.reconcileSession(sessionId);
+
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches).toHaveLength(2);
+    expect(batches.map((b) => b.user_prompt)).toEqual(['first prompt', 'second prompt']);
+    const tornWarns = () => warns.filter((m) => m.includes('unparseable')).length;
+    expect(tornWarns()).toBe(1);
+
+    // Session was marked reconciled: an immediate re-trigger is a no-op.
+    reconciler.reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(2);
+
+    // The warn is once per session per daemon lifetime — even a forced
+    // second pass (reload path) stays quiet about the same torn line.
+    reconciler.clearSession(sessionId);
+    reconciler.reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(2);
+    expect(tornWarns()).toBe(1);
+  });
+
+  // Shape 11: a torn TAIL on a fresh file is most likely an append still in
+  // flight — the pass aborts without replaying and the session stays
+  // eligible; once the file is idle it converges with the tear excluded.
+  it('aborts on a torn tail while the file is fresh, then converges once idle', () => {
+    const sessionId = 'conv-torn-tail';
+    seedSession({ id: sessionId });
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'complete prompt', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      '{"type":"user_prompt","prompt":"still being writ',
+    ]);
+
+    const reconciler = makeReconciler();
+    // File mtime is "now" → fresh → abort, nothing replayed, not marked.
+    reconciler.reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(0);
+
+    // File goes idle → the tear is permanent; converge what parses.
+    ageBuffer(sessionId, 60_000);
+    reconciler.reconcileSession(sessionId);
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches).toHaveLength(1);
+    expect(batches[0].user_prompt).toBe('complete prompt');
+  });
+
+  // Shape 12: a buffer that accumulated lines across the origin-forwarding
+  // upgrade boundary. Pre-rule lines (no origin) re-gate through the
+  // manifest; agent-less tool lines replay under the default symbiont;
+  // post-rule lines keep their forwarded origin verbatim.
+  it('replays a mixed-shape file: pre-rule re-gating, agent-less defaults, forwarded origins', () => {
+    const sessionId = 'conv-mixed';
+    seedSession({ id: sessionId, agent: 'claude-code' });
+
+    writeBuffer(sessionId, [
+      // Pre-rule human prompt — re-gates to origin=human.
+      { type: 'user_prompt', agent: 'claude-code', prompt: 'do the thing', timestamp: '2026-06-10T10:00:00.000Z' },
+      // Agent-less tool line — replays under DEFAULT_SYMBIONT_NAME.
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'pwd' }, timestamp: '2026-06-10T10:00:01.000Z' },
+      // Pre-rule task-notification — manifest re-gates to origin=system.
+      { type: 'user_prompt', agent: 'claude-code', prompt: '<task-notification>\n<task-id>t1</task-id>\n<status>completed</status>\n</task-notification>', timestamp: '2026-06-10T10:00:20.000Z' },
+      // Pre-rule command dispatch — manifest DROPS it (never a batch).
+      { type: 'user_prompt', agent: 'claude-code', prompt: '<command-name>/compact</command-name>', timestamp: '2026-06-10T10:00:30.000Z' },
+      // Post-rule teammate message — forwarded origin wins, no re-gating.
+      { type: 'user_prompt', prompt: '<teammate-message teammate_id="researcher">found it</teammate-message>', origin: 'agent_dispatch', timestamp: '2026-06-10T10:00:40.000Z' },
+    ]);
+
+    makeReconciler().reconcileSession(sessionId);
+
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches).toHaveLength(3);
+    const byPrompt = new Map(batches.map((b) => [b.user_prompt, b.origin]));
+    expect(byPrompt.get('do the thing')).toBe('human');
+    expect([...byPrompt.entries()].find(([p]) => p?.startsWith('<task-notification>'))?.[1]).toBe('system');
+    expect([...byPrompt.entries()].find(([p]) => p?.startsWith('<teammate-message '))?.[1]).toBe('agent_dispatch');
+    expect(batches.some((b) => b.user_prompt?.startsWith('<command-name>'))).toBe(false);
+    expect(countActivities(sessionId)).toBe(1);
+  });
+
+  // Shape 13: the Stop-time transcript miner stored a different rendering of
+  // a LONG prompt than the hook buffered (tail rewrite). Exact keys diverge;
+  // the second-chance prefix match converges instead of duplicating. The
+  // match requires BOTH texts to span the full 60-char window and agree
+  // across it — anything shorter is covered by the exact key alone.
+  const LONG_BASE = 'Investigate the intermittent capture pipeline regression in the daemon'; // > 60 chars
+
+  it('second-chance prefix match: long buffered text whose stored row gained a rewritten tail converges', () => {
+    const sessionId = 'conv-miner-prefix-a';
+    seedSession({ id: sessionId });
+    const now = nowSec();
+    insertBatchStateless({
+      session_id: sessionId,
+      user_prompt: `${LONG_BASE} and write a postmortem when done`,
+      started_at: now,
+      ended_at: now,
+      created_at: now,
+    });
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: LONG_BASE, origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+    ]);
+
+    makeReconciler().reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(1);
+  });
+
+  it('second-chance prefix match: long buffered text with a rewritten tail converges onto the stored row', () => {
+    const sessionId = 'conv-miner-prefix-b';
+    seedSession({ id: sessionId });
+    const now = nowSec();
+    insertBatchStateless({
+      session_id: sessionId,
+      user_prompt: LONG_BASE,
+      started_at: now,
+      ended_at: now,
+      created_at: now,
+    });
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: `${LONG_BASE} and watch for restart loops`, origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+    ]);
+
+    makeReconciler().reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(1);
+  });
+
+  // Short prompts never take the second chance: a repeated short prompt
+  // ("continue", "y") whose first occurrence is in the DB but whose second
+  // occurrence was missed must REPLAY — the exact key already covers short
+  // texts completely, so a key miss means a genuine new turn.
+  it('a genuine repeated short prompt — one in DB, one only buffered — replays instead of prefix-matching', () => {
+    const sessionId = 'conv-short-repeat';
+    seedSession({ id: sessionId });
+    handleUserPrompt(sessionId, 'continue', { kind: 'initial' });
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'continue', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      // 40 minutes later, outside the dedup window: a genuine second turn
+      // the daemon missed.
+      { type: 'user_prompt', prompt: 'continue', origin: 'human', timestamp: '2026-06-10T10:40:00.000Z' },
+    ]);
+
+    makeReconciler().reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(2);
+  });
+
+  // The convergence lookup keys user_prompt events on the candidate replay
+  // text. A pre-rule buffered event carrying a rewrite-rule preamble (Codex
+  // desktop file-mention wrapper) exact-matches the row the live hook
+  // stored (rewritten), without leaning on the prefix path.
+  it('a rewrite-rule prompt exact-matches the stored rewritten row via its candidate text', () => {
+    const sessionId = 'conv-rewrite-key';
+    seedSession({ id: sessionId, agent: 'codex' });
+    handleUserPrompt(sessionId, 'please resize the screenshot', { kind: 'initial' });
+
+    writeBuffer(sessionId, [
+      {
+        type: 'user_prompt',
+        agent: 'codex',
+        prompt: '# Files mentioned by the user:\n## shot.png: /tmp/shot.png\n## My request for Codex:\nplease resize the screenshot',
+        timestamp: '2026-06-10T10:00:00.000Z',
+      },
+    ]);
+
+    makeReconciler().reconcileSession(sessionId);
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches).toHaveLength(1);
+    expect(batches[0].user_prompt).toBe('please resize the screenshot');
+  });
+
+  // Shape 14 (P1 scope): the staleness-qualified open-batch guard. A FRESH
+  // open batch may be a live turn — the replayed stop skips it. A STALE open
+  // batch is the missed-Stop shape itself (the Stop is what closes batches)
+  // and its buffered summary is recovered, without closing the batch. Closed
+  // batches with a NULL summary always take the summary.
+  it('replayed stop skips a FRESH open batch', () => {
+    const sessionId = 'conv-stop-fresh-open';
+    seedSession({ id: sessionId });
+    handleUserPrompt(sessionId, 'hello', { kind: 'initial' });
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'hello', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      { type: 'stop', last_assistant_message: 'should not land', timestamp: '2026-06-10T10:00:05.000Z' },
+    ]);
+    makeReconciler().reconcileSession(sessionId);
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches).toHaveLength(1);
+    expect(batches[0].ended_at).toBeNull();
+    expect(batches[0].response_summary).toBeNull();
+  });
+
+  it('replayed stop treats an old batch with RECENT activity as fresh — a long live turn is protected', () => {
+    const sessionId = 'conv-stop-long-turn';
+    seedSession({ id: sessionId });
+    const { batchId } = handleUserPrompt(sessionId, 'hello', { kind: 'initial' });
+    // The batch opened hours ago, but an activity just landed on it: the
+    // turn is still alive. Freshness reads the latest attached activity,
+    // not just created_at — created_at alone would misclassify this.
+    handleToolUse(sessionId, 'claude-code', 'Bash', { command: 'bun test' }, undefined, process.cwd());
+    backdateBatch(batchId, 7200);
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'hello', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'bun test' }, timestamp: '2026-06-10T10:00:01.000Z' },
+      { type: 'stop', last_assistant_message: 'should not land', timestamp: '2026-06-10T10:00:05.000Z' },
+    ]);
+    makeReconciler().reconcileSession(sessionId);
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches[0].response_summary).toBeNull();
+  });
+
+  it('replayed stop recovers onto a STALE open batch without closing it', () => {
+    const sessionId = 'conv-stop-stale-open';
+    seedSession({ id: sessionId });
+    const { batchId } = handleUserPrompt(sessionId, 'hello', { kind: 'initial' });
+    backdateBatch(batchId, 7200);
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'hello', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      { type: 'stop', last_assistant_message: 'missed-stop recovery', timestamp: '2026-06-10T10:00:05.000Z' },
+    ]);
+    makeReconciler().reconcileSession(sessionId);
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches).toHaveLength(1);
+    expect(batches[0].response_summary).toBe('missed-stop recovery');
+    expect(batches[0].ended_at).toBeNull();
+  });
+
+  it('replayed stop fills a closed batch with NULL summary', () => {
+    const sessionId = 'conv-stop-closed';
+    seedSession({ id: sessionId });
+    handleUserPrompt(sessionId, 'hello', { kind: 'initial' });
+    handleStopBatches(sessionId);
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'hello', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      { type: 'stop', last_assistant_message: 'recovered summary', timestamp: '2026-06-10T10:00:05.000Z' },
+    ]);
+    makeReconciler().reconcileSession(sessionId);
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches).toHaveLength(1);
+    expect(batches[0].response_summary).toBe('recovered summary');
+  });
+
+  // Full-turn-missed: the daemon was down for the WHOLE turn — prompt, tool
+  // events, and stop all live only in the buffer. The chronological walk
+  // replays the prompt first, and the stop (replayed in position, exempt
+  // from the freshness guard because the batch was created by this pass)
+  // lands its summary on the pass-created batch.
+  it('recovers a fully-missed turn: prompt, activity, and stop summary all land', () => {
+    const sessionId = 'conv-full-turn-missed';
+    seedSession({ id: sessionId });
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'fix the flaky test', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'bun test' }, timestamp: '2026-06-10T10:00:30.000Z' },
+      { type: 'stop', last_assistant_message: 'done, fixed', timestamp: '2026-06-10T10:01:00.000Z' },
+    ]);
+
+    makeReconciler().reconcileSession(sessionId);
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches).toHaveLength(1);
+    expect(batches[0].user_prompt).toBe('fix the flaky test');
+    expect(batches[0].response_summary).toBe('done, fixed');
+    expect(countActivities(sessionId)).toBe(1);
+  });
+
+  // Two fully-missed turns: each stop, replayed at its chronological
+  // position, lands on its OWN turn's batch — the second turn's summary
+  // must not leak onto the first (and vice versa).
+  it('recovers two fully-missed turns with each stop on its own batch', () => {
+    const sessionId = 'conv-two-turns-missed';
+    seedSession({ id: sessionId });
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'first turn prompt', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      { type: 'stop', last_assistant_message: 'first turn answer', timestamp: '2026-06-10T10:01:00.000Z' },
+      { type: 'user_prompt', prompt: 'second turn prompt', origin: 'human', timestamp: '2026-06-10T10:05:00.000Z' },
+      { type: 'stop', last_assistant_message: 'second turn answer', timestamp: '2026-06-10T10:06:00.000Z' },
+    ]);
+
+    makeReconciler().reconcileSession(sessionId);
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches).toHaveLength(2);
+    const byPrompt = new Map(batches.map((b) => [b.user_prompt, b.response_summary]));
+    expect(byPrompt.get('first turn prompt')).toBe('first turn answer');
+    expect(byPrompt.get('second turn prompt')).toBe('second turn answer');
+  });
+
+  // Shape 15: the activity-key edge set.
+  it('a stored NULL tool_input converges with falsy event-side inputs (0 / false / "")', () => {
+    const sessionId = 'conv-falsy';
+    seedSession({ id: sessionId });
+    handleUserPrompt(sessionId, 'start', { kind: 'initial' });
+    handleToolUse(sessionId, 'claude-code', 'ReadA', undefined, undefined, process.cwd());
+    handleToolUse(sessionId, 'claude-code', 'ReadB', undefined, undefined, process.cwd());
+    handleToolUse(sessionId, 'claude-code', 'ReadC', undefined, undefined, process.cwd());
+    expect(countActivities(sessionId)).toBe(3);
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'start', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      { type: 'tool_use', tool_name: 'ReadA', tool_input: 0, timestamp: '2026-06-10T10:00:01.000Z' },
+      { type: 'tool_use', tool_name: 'ReadB', tool_input: false, timestamp: '2026-06-10T10:00:02.000Z' },
+      { type: 'tool_use', tool_name: 'ReadC', tool_input: '', timestamp: '2026-06-10T10:00:03.000Z' },
+    ]);
+
+    makeReconciler().reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(1);
+    expect(countActivities(sessionId)).toBe(3);
+  });
+
+  it('a scalar string tool_input converges across the quoted-vs-unquoted storage gap', () => {
+    const sessionId = 'conv-scalar';
+    seedSession({ id: sessionId });
+    handleUserPrompt(sessionId, 'start', { kind: 'initial' });
+    handleToolUse(sessionId, 'codex', 'shell', 'pwd', undefined, process.cwd());
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'start', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      { type: 'tool_use', tool_name: 'shell', tool_input: 'pwd', timestamp: '2026-06-10T10:00:01.000Z' },
+    ]);
+
+    makeReconciler().reconcileSession(sessionId);
+    expect(countActivities(sessionId)).toBe(1);
+  });
+
+  it('a >4000-char tool_input torn by storage truncation still converges', () => {
+    const sessionId = 'conv-torn-input';
+    seedSession({ id: sessionId });
+    handleUserPrompt(sessionId, 'start', { kind: 'initial' });
+    const bigInput = { script: 'z'.repeat(TOOL_INPUT_STORE_LIMIT + 500) };
+    handleToolUse(sessionId, 'claude-code', 'Bash', bigInput, undefined, process.cwd());
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'start', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: bigInput, timestamp: '2026-06-10T10:00:01.000Z' },
+    ]);
+
+    makeReconciler().reconcileSession(sessionId);
+    expect(countActivities(sessionId)).toBe(1);
+  });
+
+  it('bookkeeping rows do not consume tool_use matches', () => {
+    const sessionId = 'conv-bookkeeping';
+    seedSession({ id: sessionId });
+    handleUserPrompt(sessionId, 'start', { kind: 'initial' });
+    handleSubagentStop(sessionId, 'a1', 'researcher', 'done');
+    expect(countActivities(sessionId)).toBe(1);
+
+    // A tool event whose name/input happens to collide with the bookkeeping
+    // row's stored shape must still replay — the bookkeeping row is excluded
+    // from the convergence multiset.
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'start', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      { type: 'tool_use', tool_name: 'subagent_stop', tool_input: { agent_id: 'a1', agent_type: 'researcher' }, timestamp: '2026-06-10T10:00:01.000Z' },
+    ]);
+
+    makeReconciler().reconcileSession(sessionId);
+    expect(countActivities(sessionId)).toBe(2);
+  });
+
+  it('a tool_failure row does not consume a tool_use event (and vice versa)', () => {
+    const sessionId = 'conv-failure-disc';
+    seedSession({ id: sessionId });
+    handleUserPrompt(sessionId, 'start', { kind: 'initial' });
+    handleToolFailure(sessionId, 'claude-code', 'Bash', { command: 'x' }, 'boom', false);
+    expect(countActivities(sessionId)).toBe(1);
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'start', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'x' }, timestamp: '2026-06-10T10:00:01.000Z' },
+    ]);
+
+    makeReconciler().reconcileSession(sessionId);
+    const activities = listActivities({ session_id: sessionId, scope: ALL_PROJECTS_SCOPE });
+    expect(activities).toHaveLength(2);
+    expect(activities.filter((a) => a.success === 0)).toHaveLength(1);
+    expect(activities.filter((a) => a.success === 1)).toHaveLength(1);
+  });
+
+  // Activity backfill — the count-based pass could NEVER do this: when
+  // prompt counts matched, no replay ran at all, so a missed activity on a
+  // captured turn was lost forever.
+  it('replays a missed activity even when no prompt diverged (activity backfill)', () => {
+    const sessionId = 'conv-backfill';
+    seedSession({ id: sessionId });
+    const { batchId } = handleUserPrompt(sessionId, 'investigate the flake', { kind: 'initial' });
+    expect(countActivities(sessionId)).toBe(0);
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'investigate the flake', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'bun test' }, timestamp: '2026-06-10T10:00:01.000Z' },
+    ]);
+
+    makeReconciler().reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(1);
+    const activities = listActivities({ session_id: sessionId, scope: ALL_PROJECTS_SCOPE });
+    expect(activities).toHaveLength(1);
+    expect(activities[0].prompt_batch_id).toBe(batchId);
+    expect(activities[0].tool_name).toBe('Bash');
+  });
+
+  it('two genuine same-text turns >10s apart, both live-processed → nothing replays', () => {
+    const sessionId = 'conv-same-text-live';
+    seedSession({ id: sessionId });
+    handleUserPrompt(sessionId, 'continue', { kind: 'initial' });
+    handleUserPrompt(sessionId, 'continue', { kind: 'initial' });
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(2);
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'continue', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      { type: 'user_prompt', prompt: 'continue', origin: 'human', timestamp: '2026-06-10T10:00:15.000Z' },
+    ]);
+
+    makeReconciler().reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(2);
+  });
+
+  it('two genuine same-text turns >10s apart, both missed → both replay', () => {
+    const sessionId = 'conv-same-text-missed';
+    seedSession({ id: sessionId });
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'continue', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+      { type: 'user_prompt', prompt: 'continue', origin: 'human', timestamp: '2026-06-10T10:00:15.000Z' },
+    ]);
+
+    makeReconciler().reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(2);
+  });
+
+  // Shared dedup cache: a replayed event's key lands in the SAME cache the
+  // live dispatcher consults, so a late live POST of the replayed event is
+  // rejected as a duplicate instead of double-inserting.
+  it('records replayed events into the shared cache — a late live POST is a duplicate', () => {
+    const sessionId = 'conv-shared-cache';
+    seedSession({ id: sessionId });
+    const cache = new EventDedupCache();
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'replayed prompt', origin: 'human', timestamp: '2026-06-10T10:00:00.000Z' },
+    ]);
+
+    makeReconciler(silentLogger, cache).reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(1);
+
+    // The dispatcher's duplicate check is cache.isDuplicate — a late live
+    // POST of the same physical event arrives within the window.
+    expect(cache.isDuplicate(
+      { type: 'user_prompt', session_id: sessionId, prompt: 'replayed prompt', origin: 'human' },
+      Date.now(),
+    )).toBe(true);
+    expect(cache.isDuplicate(
+      { type: 'user_prompt', session_id: sessionId, prompt: 'a different prompt', origin: 'human' },
+      Date.now(),
+    )).toBe(false);
+  });
+});

--- a/tests/daemon/reconciliation-stop.test.ts
+++ b/tests/daemon/reconciliation-stop.test.ts
@@ -4,6 +4,7 @@ import { nowSec, seedSession } from '../helpers/sessions.js';
 import { createReconciler } from '@myco/daemon/reconciliation.js';
 import { handleUserPrompt } from '@myco/daemon/event-handlers.js';
 import { listBatchesBySession, setResponseSummary } from '@myco/db/queries/batches.js';
+import { getDatabase } from '@myco/db/client.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -13,6 +14,20 @@ const silentLogger = {
   debug: () => {}, info: () => {}, warn: () => {}, error: () => {},
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any;
+
+/**
+ * Backdate a batch so the stop-replay freshness guard sees it as STALE.
+ * A missed-Stop batch stays open with no further activity — its created_at
+ * (and absent activity rows) place its last sign of life in the past.
+ */
+function backdateBatch(batchId: number, ageSeconds: number): void {
+  const past = nowSec() - ageSeconds;
+  getDatabase().prepare(
+    `UPDATE prompt_batches SET created_at = ?, started_at = ? WHERE id = ?`,
+  ).run(past, past, batchId);
+}
+
+const STALE_AGE_SECONDS = 3600; // well past STOP_REPLAY_OPEN_BATCH_FRESHNESS_MS
 
 describe('Buffer reconciliation — stop events (opencode response_summary recovery)', () => {
   let tmpDir: string;
@@ -37,9 +52,11 @@ describe('Buffer reconciliation — stop events (opencode response_summary recov
   // session.idle would silently drop the Stop event. The fallback now writes
   // the stop to the session buffer, and startup reconciliation applies it.
   it('sets response_summary from a buffered stop when the daemon missed it live', () => {
-    // Daemon captured the live prompt and closed the batch without a summary
-    // (as if Stop had been dropped).
+    // Daemon captured the live prompt; the Stop never arrived, so the batch
+    // is still OPEN — and stale, because nothing has touched it since. That
+    // stale-open shape is exactly what the replayed stop must recover.
     const { batchId } = handleUserPrompt('s-stop', 'hello', { kind: 'initial' });
+    backdateBatch(batchId, STALE_AGE_SECONDS);
 
     // Buffer file carries the missing Stop.
     const bufferPath = path.join(bufferDir, 's-stop.jsonl');
@@ -55,10 +72,13 @@ describe('Buffer reconciliation — stop events (opencode response_summary recov
     expect(batches).toHaveLength(1);
     expect(batches[0].id).toBe(batchId);
     expect(batches[0].response_summary).toBe('recovered summary');
+    // Recovery writes the summary only — it must not close the batch.
+    expect(batches[0].ended_at).toBeNull();
   });
 
   it('does not overwrite an existing response_summary', () => {
     const { batchId } = handleUserPrompt('s-stop', 'hello', { kind: 'initial' });
+    backdateBatch(batchId, STALE_AGE_SECONDS);
     setResponseSummary(batchId, 'original summary');
 
     const bufferPath = path.join(bufferDir, 's-stop.jsonl');
@@ -75,7 +95,8 @@ describe('Buffer reconciliation — stop events (opencode response_summary recov
   });
 
   it('skips stop events with empty last_assistant_message', () => {
-    handleUserPrompt('s-stop', 'hello', { kind: 'initial' });
+    const { batchId } = handleUserPrompt('s-stop', 'hello', { kind: 'initial' });
+    backdateBatch(batchId, STALE_AGE_SECONDS);
 
     const bufferPath = path.join(bufferDir, 's-stop.jsonl');
     fs.writeFileSync(bufferPath,
@@ -95,6 +116,7 @@ describe('Buffer reconciliation — stop events (opencode response_summary recov
     // to replay. Before the stop-pass, no replay ran at all; now stops still
     // get applied idempotently.
     const { batchId } = handleUserPrompt('s-stop', 'hello', { kind: 'initial' });
+    backdateBatch(batchId, STALE_AGE_SECONDS);
 
     const bufferPath = path.join(bufferDir, 's-stop.jsonl');
     fs.writeFileSync(bufferPath,
@@ -109,5 +131,45 @@ describe('Buffer reconciliation — stop events (opencode response_summary recov
     expect(batches).toHaveLength(1);
     expect(batches[0].id).toBe(batchId);
     expect(batches[0].response_summary).toBe('late summary');
+  });
+
+  // The freshness qualifier on the open-batch guard: a FRESH open batch may
+  // be a live turn — the replayed stop must not stamp it. A STALE open batch
+  // is the missed-Stop shape and is recoverable.
+  it('skips a FRESH open batch — a possibly-live turn never takes a replayed summary', () => {
+    handleUserPrompt('s-stop', 'hello', { kind: 'initial' });
+    // No backdate: the batch was just created, well inside the freshness window.
+
+    const bufferPath = path.join(bufferDir, 's-stop.jsonl');
+    fs.writeFileSync(bufferPath,
+      JSON.stringify({ type: 'user_prompt', prompt: 'hello', timestamp: new Date().toISOString() }) + '\n' +
+      JSON.stringify({ type: 'stop', last_assistant_message: 'should not land', timestamp: new Date().toISOString() }) + '\n',
+    );
+
+    const reconciler = createReconciler({ bufferDirs: [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
+    reconciler.reconcileSession('s-stop');
+
+    const batches = listBatchesBySession('s-stop', { scope: ALL_PROJECTS_SCOPE });
+    expect(batches).toHaveLength(1);
+    expect(batches[0].ended_at).toBeNull();
+    expect(batches[0].response_summary).toBeNull();
+  });
+
+  it('recovers onto a STALE open batch without closing it', () => {
+    const { batchId } = handleUserPrompt('s-stop', 'hello', { kind: 'initial' });
+    backdateBatch(batchId, STALE_AGE_SECONDS);
+
+    const bufferPath = path.join(bufferDir, 's-stop.jsonl');
+    fs.writeFileSync(bufferPath,
+      JSON.stringify({ type: 'user_prompt', prompt: 'hello', timestamp: new Date().toISOString() }) + '\n' +
+      JSON.stringify({ type: 'stop', last_assistant_message: 'stale-open recovery', timestamp: new Date().toISOString() }) + '\n',
+    );
+
+    const reconciler = createReconciler({ bufferDirs: [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
+    reconciler.reconcileSession('s-stop');
+
+    const batches = listBatchesBySession('s-stop', { scope: ALL_PROJECTS_SCOPE });
+    expect(batches[0].response_summary).toBe('stale-open recovery');
+    expect(batches[0].ended_at).toBeNull();
   });
 });


### PR DESCRIPTION
## What

Phase 1 of the approved RC-7 capture-replay design (4 phases): replaces count-based replay divergence with **content-keyed convergence** in `daemon/reconciliation.ts`. Fixes RC-7b from the bug hunt — duplicate tail batches on restart/reload whenever anything perturbed the buffer line count (hook duplicate copies, 2s-timeout races) — and gains activity backfill, which the positional code could never do.

## How

- **Match-and-consume against a DB-side key multiset** built from two new projections of the existing dedup fingerprint (`dedupKeyFromPromptBatch`, `dedupKeyFromActivity` — exact stored-serialization reconstruction: parse-then-rekey, falsy-NULL canonicalization, truncation-tear fallback, bookkeeping exclusion). Unmatched buffer events replay; matched ones are consumed.
- **Tolerant reads + stat-identity passes**: torn idle lines WARN-once and converge-with-loss; torn fresh tails abort for retry; sessions are marked reconciled only after a zero-error, unchanged-identity pass (previously marked *before parsing* — one torn line permanently excluded a session).
- **Chronological stop replay** with a staleness-qualified open-batch guard (never write a fresh open batch — activity-backed freshness; recover onto stale open ones — the missed-Stop shape; pass-created batches exempt).
- **Second-chance prefix match** for miner-text divergence, restricted to full-60-char-window matches so repeated short steering prompts are never absorbed.
- **Shared `EventDedupCache`** (lifted verbatim from the dispatcher) records replayed keys so wedged live retries dedup normally.

Retained deliberately for later phases: no-row bail (P2 tombstones), cleanup ordering (P2), drain job (P3), hook response contract (P4). **No schema or API changes.**

## Review trail

Approved design (independent design review: 12 must-changes folded) → implementation → adversarial code review **with executable probes**, which caught two real regressions before merge: (1) full-turn-missed recovery lost its stop summary (pre-pass ordering + freshness guard blocking pass-created batches — fixed by chronological in-walk stop replay, which probing showed is strictly *better* than the old pre-pass for multi-turn gaps); (2) the prefix second-chance absorbed genuine repeated short prompts ("continue" twice) — fixed by the full-window restriction. Independent re-verification: 8/8 fresh probes, SHIP.

## Tests

38 new across `tests/capture/dedup-projections.test.ts` and `tests/daemon/reconciliation-convergence.test.ts` (both probe shapes, torn-line aging matrix, activity backfill, stop-guard matrix incl. the activity-backed freshness case, mixed-shape buffers, rewrite keying, shared-cache suppression). `reconciliation-dedup` and `reconciliation-cache-poisoning` pass unchanged; `reconciliation-stop` fixtures restored to their missed-Stop meaning with explicit staleness. Full suite green (88 phase JUnit artifacts `failures="0"`, every phase exit 0); tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)