### PR TITLE
capture: quiescence-gated buffer drain + post-Stop convergence (RC-7 Phase 3)

### DIFF
--- a/packages/myco/src/capture/buffer.ts
+++ b/packages/myco/src/capture/buffer.ts
@@ -2,33 +2,28 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { withFileLockSync } from '../utils/lifecycle-lock.js';
 
-interface BufferOptions {
-  maxEvents?: number;
-}
+/**
+ * Subdirectory of a buffer dir holding quarantined (hard-retention-capped
+ * diverging) buffer files. Excluded from every buffer enumeration — the
+ * listing/locating helpers below only look at `*.jsonl` entries directly
+ * inside the buffer dir and never descend.
+ */
+export const BUFFER_QUARANTINE_DIRNAME = 'quarantine';
 
 export class EventBuffer {
   private filePath: string;
   private lockPath: string;
-  private maxEvents: number;
-  private eventCount = 0;
 
   constructor(
     private bufferDir: string,
     private sessionId: string,
-    options: BufferOptions = {},
   ) {
     this.filePath = path.join(bufferDir, `${sessionId}.jsonl`);
     this.lockPath = path.join(bufferDir, `.${sessionId}.lock`);
-    this.maxEvents = options.maxEvents ?? 500;
 
     // Ensure the buffer dir exists once at construction so the per-append
     // hot path doesn't repeat mkdirSync for every event.
     fs.mkdirSync(this.bufferDir, { recursive: true });
-
-    if (fs.existsSync(this.filePath)) {
-      const content = fs.readFileSync(this.filePath, 'utf-8').trim();
-      this.eventCount = content ? content.split('\n').length : 0;
-    }
   }
 
   /**
@@ -49,7 +44,6 @@ export class EventBuffer {
     withFileLockSync(this.lockPath, () => {
       fs.appendFileSync(this.filePath, line + '\n');
     });
-    this.eventCount++;
   }
 
   readAll(): Array<Record<string, unknown>> {
@@ -57,10 +51,6 @@ export class EventBuffer {
     const content = fs.readFileSync(this.filePath, 'utf-8').trim();
     if (!content) return [];
     return content.split('\n').map((line) => JSON.parse(line));
-  }
-
-  count(): number {
-    return this.eventCount;
   }
 
   exists(): boolean {
@@ -71,11 +61,6 @@ export class EventBuffer {
     if (fs.existsSync(this.filePath)) {
       fs.unlinkSync(this.filePath);
     }
-    this.eventCount = 0;
-  }
-
-  isOverflow(): boolean {
-    return this.eventCount > this.maxEvents;
   }
 
   getFilePath(): string {
@@ -104,10 +89,81 @@ export function listBufferSessionIds(bufferDir: string): string[] {
  *                   sessions: the DB row was deliberately deleted).
  *   - 'age-gated' — remove only when older than `maxAgeMs` (sessions whose
  *                   buffer is fully converged into a closed DB row).
- *   - 'retain'    — never remove (diverging buffers; convergence has not
- *                   absorbed every event yet).
+ *   - 'retain'    — keep (diverging buffers; convergence has not absorbed
+ *                   every event yet). Subject ONLY to the hard retention
+ *                   cap, which quarantines rather than deletes.
  */
 export type BufferCleanupDecision = 'delete' | 'age-gated' | 'retain';
+
+export interface CleanStaleBuffersOptions {
+  /** Age gate (ms) for 'age-gated' files. */
+  maxAgeMs: number;
+  /** Skip this session (e.g., the currently active one). */
+  excludeSessionId?: string;
+  /**
+   * Per-session retention decision; absent → every file is age-gated.
+   * Receives the file's CURRENT (size, mtimeMs) identity so the caller
+   * can require its converged mark to match — a file that changed since
+   * the converged pass holds unreplayed events and must classify as
+   * diverging ('retain'), never 'age-gated'.
+   */
+  classify?: (sessionId: string, identity: { size: number; mtimeMs: number }) => BufferCleanupDecision;
+  /**
+   * Hard retention cap for 'retain' files: a retained (diverging) buffer
+   * idle past `maxAgeMs` is MOVED into the dir's `quarantine/` subdir —
+   * never deleted, it may be the only durable copy of unreplayed events.
+   */
+  quarantine?: {
+    maxAgeMs: number;
+    /** Fires after a successful move with the file's new path. */
+    onQuarantined?: (sessionId: string, quarantinedPath: string) => void;
+  };
+  /** Fires after each successful delete (cache eviction hook). */
+  onRemoved?: (sessionId: string) => void;
+}
+
+/**
+ * Move one buffer file into the dir's quarantine subdirectory, preserving
+ * the filename (a name collision gains a `.N` suffix before the extension).
+ * Returns the quarantined path.
+ */
+export function quarantineBufferFile(bufferDir: string, file: string): string {
+  const quarantineDir = path.join(bufferDir, BUFFER_QUARANTINE_DIRNAME);
+  fs.mkdirSync(quarantineDir, { recursive: true });
+  const ext = path.extname(file);
+  const base = path.basename(file, ext);
+  let target = path.join(quarantineDir, file);
+  for (let n = 1; fs.existsSync(target); n++) {
+    target = path.join(quarantineDir, `${base}.${n}${ext}`);
+  }
+  fs.renameSync(path.join(bufferDir, file), target);
+  return target;
+}
+
+/**
+ * Delete quarantined buffer files idle past `maxAgeMs`. Callers pass
+ * TOMBSTONE_RETENTION_MS so a quarantined copy never outlives the
+ * tombstone window that prevents its session's resurrection.
+ *
+ * @returns count of files pruned
+ */
+export function pruneQuarantinedBuffers(bufferDir: string, maxAgeMs: number): number {
+  const quarantineDir = path.join(bufferDir, BUFFER_QUARANTINE_DIRNAME);
+  let pruned = 0;
+  try {
+    const cutoff = Date.now() - maxAgeMs;
+    for (const file of fs.readdirSync(quarantineDir)) {
+      if (!file.endsWith('.jsonl')) continue;
+      const filePath = path.join(quarantineDir, file);
+      try {
+        if (fs.statSync(filePath).mtimeMs >= cutoff) continue;
+        fs.unlinkSync(filePath);
+        pruned++;
+      } catch { /* concurrent removal — skip */ }
+    }
+  } catch { /* quarantine dir may not exist */ }
+  return pruned;
+}
 
 /**
  * Remove buffer files per the retention policy.
@@ -115,32 +171,48 @@ export type BufferCleanupDecision = 'delete' | 'age-gated' | 'retain';
  * Without `classify`, every file is age-gated (the original mtime-only
  * behavior). Daemon callers pass the reconciler's convergence-aware
  * classifier so a diverging buffer — the only durable copy of unreplayed
- * events — is never deleted on age alone.
+ * events — is never deleted on age alone; the `quarantine` option completes
+ * retention for those files by moving (not deleting) them once they pass
+ * the hard cap.
  *
- * @param excludeSessionId - skip this session (e.g., the currently active one)
- * @returns count of files removed
+ * @returns count of files removed (deletes only; quarantine moves are
+ *   reported through `onQuarantined`, not the return value)
  */
 export function cleanStaleBuffers(
   bufferDir: string,
-  maxAgeMs: number,
-  excludeSessionId?: string,
-  classify?: (sessionId: string) => BufferCleanupDecision,
+  options: CleanStaleBuffersOptions,
 ): number {
+  const { maxAgeMs, excludeSessionId, classify, quarantine, onRemoved } = options;
   let removed = 0;
   try {
-    const cutoff = Date.now() - maxAgeMs;
+    const now = Date.now();
+    const cutoff = now - maxAgeMs;
     for (const file of fs.readdirSync(bufferDir)) {
       if (!file.endsWith('.jsonl')) continue;
       if (excludeSessionId && file === `${excludeSessionId}.jsonl`) continue;
+      const sessionId = file.replace('.jsonl', '');
       const filePath = path.join(bufferDir, file);
-      const decision = classify ? classify(file.replace('.jsonl', '')) : 'age-gated';
-      if (decision === 'retain') continue;
-      if (decision === 'age-gated') {
-        const stat = fs.statSync(filePath);
-        if (stat.mtimeMs >= cutoff) continue;
+      let stat: fs.Stats;
+      try {
+        stat = fs.statSync(filePath);
+      } catch {
+        continue; // concurrent removal
       }
+      const identity = { size: stat.size, mtimeMs: stat.mtimeMs };
+      const decision = classify ? classify(sessionId, identity) : 'age-gated';
+      if (decision === 'retain') {
+        if (!quarantine) continue;
+        if (identity.mtimeMs >= now - quarantine.maxAgeMs) continue;
+        try {
+          const target = quarantineBufferFile(bufferDir, file);
+          quarantine.onQuarantined?.(sessionId, target);
+        } catch { /* move failed — retry next pass */ }
+        continue;
+      }
+      if (decision === 'age-gated' && identity.mtimeMs >= cutoff) continue;
       fs.unlinkSync(filePath);
       removed++;
+      onRemoved?.(sessionId);
     }
   } catch { /* buffer dir may not exist */ }
   return removed;

--- a/packages/myco/src/constants.ts
+++ b/packages/myco/src/constants.ts
@@ -114,11 +114,52 @@ export const STALE_BUFFER_MAX_AGE_MS = 1 * MS_PER_DAY;
 /**
  * How long a session deletion tombstone survives before
  * `pruneSessionTombstones` reclaims it. Must stay strictly longer than
- * every buffer-retention window (STALE_BUFFER_MAX_AGE_MS today; the
- * buffer hard-retention cap planned for RC-7 Phase 3) — a buffer file
- * must never outlive the tombstone that prevents its resurrection.
+ * every buffer-retention window (STALE_BUFFER_MAX_AGE_MS and
+ * BUFFER_HARD_RETENTION_MS) — a buffer file must never outlive the
+ * tombstone that prevents its resurrection. Quarantined buffer files are
+ * also pruned at this age, so quarantine never outlives the tombstone
+ * window either.
  */
 export const TOMBSTONE_RETENTION_MS = 14 * MS_PER_DAY;
+
+/**
+ * Hard retention cap for DIVERGING buffer files — buffers convergence has
+ * not absorbed (stale-dir orphans, gate-undecidable content, persistent
+ * replay failures). At this age the file moves to the buffer dir's
+ * `quarantine/` subdirectory instead of being deleted: a diverging buffer
+ * is the only durable copy of unreplayed events, so retention removes it
+ * from enumeration without destroying it. Strictly shorter than
+ * TOMBSTONE_RETENTION_MS (14d), which prunes the quarantined copy.
+ */
+export const BUFFER_HARD_RETENTION_MS = 7 * MS_PER_DAY;
+
+// --- Capture buffer drain (RC-7 Phase 3) ---
+/** Cadence of the periodic quiescence-gated buffer drain job. */
+export const CAPTURE_BUFFER_DRAIN_INTERVAL_MS = 15 * 60 * 1000;
+
+/**
+ * How long a session's buffer file must sit unmodified before the drain
+ * job treats an open-row session as quiescent. Deliberately much wider
+ * than the 10s live dedup window (EVENT_DEDUP_WINDOW_MS): the gate is
+ * "no turn in flight", not "no duplicate in flight".
+ */
+export const BUFFER_QUIESCENCE_IDLE_MS = 5 * 60 * 1000;
+
+/**
+ * Maximum sessions one drain pass converges, mirroring the drain.slice
+ * bound on EMBEDDING_RECONCILE — a backlog spread across many sessions
+ * drains across passes instead of monopolizing one tick. Hitting the cap
+ * is logged; the remainder is picked up next pass.
+ */
+export const CAPTURE_BUFFER_DRAIN_SESSION_CAP = 50;
+
+/**
+ * Cap on how many drain passes a failing session sits out under
+ * exponential backoff (2^attempts passes, capped here) — a poisoned
+ * buffer retries at most every ~2h on the 15-minute cadence instead of
+ * hot-looping every pass.
+ */
+export const CAPTURE_BUFFER_DRAIN_BACKOFF_CAP_PASSES = 8;
 
 // --- Stop replay ---
 /**

--- a/packages/myco/src/constants/power-jobs.ts
+++ b/packages/myco/src/constants/power-jobs.ts
@@ -21,6 +21,13 @@ export const POWER_JOB_NAMES = {
    * config into any newly-detected agent. Idempotent.
    */
   SYMBIONT_DETECTION: 'symbiont-detection',
+  /**
+   * Periodic quiescence-gated convergence of capture buffer files into
+   * the DB, plus convergence-aware retention (cleanup + quarantine).
+   * Catches sessions whose buffers diverged without a restart or
+   * register/event trigger to converge them.
+   */
+  CAPTURE_BUFFER_DRAIN: 'capture-buffer-drain',
 } as const;
 
 export type PowerJobName = (typeof POWER_JOB_NAMES)[keyof typeof POWER_JOB_NAMES];

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -1101,10 +1101,6 @@ export async function main(): Promise<void> {
     ),
   });
 
-  // Every registered project's buffer dir under the global Grove tree.
-  // No legacy bootstrap path — there is exactly one canonical home for a
-  // project's buffer, and the reconciler scans those and only those.
-  const bufferDirs = listAllProjectBufferDirs();
   const sessionBuffers = new Map<string, EventBuffer>();
 
   // One duplicate cache shared between the live /events dispatcher and the
@@ -1113,7 +1109,12 @@ export async function main(): Promise<void> {
   const eventDedupCache = new EventDedupCache();
 
   const reconciler = createReconciler({
-    bufferDirs,
+    // Every registered project's buffer dir under the global Grove tree,
+    // re-resolved per pass so a project registered after boot is visible
+    // without a restart. No legacy bootstrap path — there is exactly one
+    // canonical home for a project's buffer, and the reconciler scans
+    // those and only those.
+    bufferDirs: () => listAllProjectBufferDirs(),
     logger,
     projectRoot,
     onSessionReconciled: (sessionId) => reEnrichSessionFromTranscript(sessionId, { transcriptMiner, logger }),
@@ -1196,6 +1197,12 @@ export async function main(): Promise<void> {
     machineId,
     planTags: symbiontPlanTags,
     planWatchConfig,
+    // Post-Stop convergence trigger: re-converge THIS session's buffer at
+    // the turn boundary when its converged mark is stale (identity-aware
+    // skip inside reconcileSession makes the matching case a no-op).
+    // Recovers wedge-buffered events that arrived mid-turn without
+    // waiting for a restart or the 15-minute drain cadence.
+    onStopProcessed: (sessionId) => reconciler.reconcileSession(sessionId),
   });
 
   // --- Session routes ---

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -20,7 +20,12 @@ import {
   listStaleStagingDirs,
   cleanupStagedSkill,
 } from '@myco/agent/tools/skill-staging.js';
-import { EMBEDDING_BATCH_SIZE, MS_PER_DAY, MS_PER_HOUR } from '@myco/constants.js';
+import {
+  EMBEDDING_BATCH_SIZE,
+  MS_PER_DAY,
+  MS_PER_HOUR,
+  CAPTURE_BUFFER_DRAIN_INTERVAL_MS,
+} from '@myco/constants.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { POWER_JOB_NAMES, type PowerJobName } from '@myco/constants/power-jobs.js';
 import {
@@ -74,11 +79,16 @@ export interface PowerJobDeps {
   daemonStateDir: string;
   onCanopyMassAdd?: (groveId: string, projectId: GroveProjectId) => void;
   /**
-   * The buffer reconciler's convergence probe. The dead-session sweep
-   * defers zero-batch sessions whose buffer hasn't converged this daemon
-   * lifetime — their prompts may still be sitting unreplayed on disk.
+   * The buffer reconciler. The dead-session sweep consults
+   * `hasUnconvergedBuffer` to defer zero-batch sessions whose buffer
+   * hasn't converged — their prompts may still be sitting unreplayed on
+   * disk. `runDrainPass` is the quiescence-gated drain job's per-Grove
+   * body (convergence + retention/quarantine).
    */
-  reconciler?: { hasUnconvergedBuffer(sessionId: string): boolean };
+  reconciler?: {
+    hasUnconvergedBuffer(sessionId: string): boolean;
+    runDrainPass(options?: { groveId?: string }): unknown;
+  };
 }
 
 export interface PowerJobsResult {
@@ -330,6 +340,32 @@ export function registerPowerJobs(runner: JobRunner, deps: PowerJobDeps): PowerJ
       });
     }),
   });
+
+  // Quiescence-gated capture-buffer drain: converge diverging buffers
+  // (sessions whose buffer changed without a restart / register / event /
+  // post-Stop trigger to converge them), then run convergence-aware
+  // retention (cleanup + quarantine) over each Grove's buffer dirs. The
+  // reconciler re-resolves buffer dirs per pass, applies the quiescence
+  // gate per session, and bounds each pass with the session cap +
+  // per-session failure backoff. Same power states as SESSION_MAINTENANCE;
+  // cadence is the job-level 15-minute throttle (ticks fire more often).
+  let lastBufferDrainAt = 0;
+  if (deps.reconciler) {
+    const drainReconciler = deps.reconciler;
+    runner.register({
+      name: POWER_JOB_NAMES.CAPTURE_BUFFER_DRAIN,
+      runIn: ['active', 'idle', 'sleep'],
+      kind: 'housekeeping',
+      fn: async () => {
+        const now = Date.now();
+        if (now - lastBufferDrainAt < CAPTURE_BUFFER_DRAIN_INTERVAL_MS) return;
+        lastBufferDrainAt = now;
+        await fanOutGroves(POWER_JOB_NAMES.CAPTURE_BUFFER_DRAIN, async (scope) => {
+          drainReconciler.runDrainPass({ groveId: scope.grove.id });
+        })();
+      },
+    });
+  }
 
   runner.register({
     name: POWER_JOB_NAMES.LOG_RETENTION,

--- a/packages/myco/src/daemon/reconciliation.ts
+++ b/packages/myco/src/daemon/reconciliation.ts
@@ -8,7 +8,12 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { listBufferSessionIds, cleanStaleBuffers, type BufferCleanupDecision } from '@myco/capture/buffer.js';
+import {
+  listBufferSessionIds,
+  cleanStaleBuffers,
+  pruneQuarantinedBuffers,
+  type BufferCleanupDecision,
+} from '@myco/capture/buffer.js';
 import { bufferDirCurrentRegistration, bufferDirIdentity } from '@myco/capture/buffer-location.js';
 import { openDatabase, withDatabase, type Database } from '@myco/db/client.js';
 import { resolveGroveDbPath } from '@myco/grove/paths.js';
@@ -16,6 +21,7 @@ import {
   listBatchesBySession,
   getLatestBatch,
   setResponseSummary,
+  resolveResponseSummaryTarget,
   toPromptBatchOrigin,
   PROMPT_PREFIX_MATCH_CHARS,
   type BatchRow,
@@ -29,6 +35,11 @@ import {
   STALE_BUFFER_MAX_AGE_MS,
   STALE_SESSION_THRESHOLD_MS,
   STOP_REPLAY_OPEN_BATCH_FRESHNESS_MS,
+  BUFFER_HARD_RETENTION_MS,
+  BUFFER_QUIESCENCE_IDLE_MS,
+  CAPTURE_BUFFER_DRAIN_SESSION_CAP,
+  CAPTURE_BUFFER_DRAIN_BACKOFF_CAP_PASSES,
+  TOMBSTONE_RETENTION_MS,
   DEFAULT_SYMBIONT_NAME,
   MS_PER_SECOND,
   epochSeconds,
@@ -82,18 +93,21 @@ const CONVERGENCE_QUERY_LIMIT = 100_000;
 
 export interface ReconcilerDeps {
   /**
-   * Every buffer directory the reconciler should scan. One per registered
-   * project under the global install at
+   * Every buffer directory the reconciler should scan, re-resolved on
+   * EACH use — a thunk, not a snapshot, so a project registered after
+   * reconciler construction is visible to the next pass without a daemon
+   * restart. One dir per registered project under the global install at
    * `~/.myco/groves/<groveId>/projects/<projectId>/buffer/`. There is NO
    * legacy fallback — `capture/buffer-location.ts` enforces the
    * no-divergent-location invariant structurally, and the reconciler
-   * trusts that contract. Derived from `listAllProjectBufferDirs()`.
+   * trusts that contract. Wraps `listAllProjectBufferDirs()`, which also
+   * excludes archived projects (the registry's default listing filter).
    *
    * Order matters only for log determinism; per-session lookup tries each
    * directory in order and uses the first match (a session's events live
    * in exactly one dir).
    */
-  bufferDirs: string[];
+  bufferDirs: () => string[];
   logger: DaemonLogger;
   /** Canonical project root — derived from vaultDir, never cwd. */
   projectRoot: string;
@@ -137,6 +151,29 @@ export interface ReconcilerDeps {
   resolveGroveDb?: (groveId: string) => Database | null;
 }
 
+/** Outcome counts for one drain pass (log + test observability). */
+export interface DrainPassSummary {
+  /**
+   * Real convergence attempts — sessions that passed the quiescence gate
+   * and ran a pass (drained + failed + benign-deferred). Only these
+   * consume per-pass cap slots.
+   */
+  attempted: number;
+  /** Attempts that converged (mark written or buffer terminally discarded). */
+  drained: number;
+  /**
+   * Sessions skipped this pass by the quiescence gate. Gate checks are
+   * cheap reads and consume NO cap slot.
+   */
+  skippedQuiescent: number;
+  /** Sessions sitting out under per-session failure backoff. */
+  skippedBackoff: number;
+  /** Sessions deferred because the per-pass cap was reached. */
+  deferredByCap: number;
+  /** Drain attempts that errored or did not converge (backoff recorded). */
+  failed: number;
+}
+
 export interface Reconciler {
   reconcileSession(sessionId: string): void;
   replayEvent(sessionId: string, event: Record<string, unknown>): 'prompt' | 'activity' | null;
@@ -146,16 +183,25 @@ export interface Reconciler {
   /**
    * Convergence-aware buffer cleanup across every known buffer dir.
    * Deletes tombstoned sessions' buffers immediately; deletes converged
-   * buffers of closed sessions past STALE_BUFFER_MAX_AGE_MS; NEVER
-   * deletes a diverging buffer (P3 adds the hard retention cap).
+   * buffers of closed sessions past STALE_BUFFER_MAX_AGE_MS; quarantines
+   * (never deletes) a diverging buffer past BUFFER_HARD_RETENTION_MS;
+   * prunes quarantined files past TOMBSTONE_RETENTION_MS.
    */
   cleanStaleBuffers(excludeSessionId?: string): number;
   /**
-   * True when the session has a non-empty buffer file that this daemon
-   * lifetime has not converged. The dead-session sweep consults this to
-   * defer deleting a zero-batch session whose buffer may still replay.
+   * True when the session has a non-empty buffer file whose current
+   * identity has not been converged (no mark, or the file changed since
+   * the converged pass). The dead-session sweep consults this to defer
+   * deleting a zero-batch session whose buffer may still replay.
    */
   hasUnconvergedBuffer(sessionId: string): boolean;
+  /**
+   * One quiescence-gated drain pass: converge every drain-eligible
+   * diverging buffer (capped per pass), then run convergence-aware
+   * cleanup + quarantine over the visited dirs. `groveId` scopes the
+   * pass to one Grove's dirs (the power-job fan-out shape).
+   */
+  runDrainPass(options?: { groveId?: string }): DrainPassSummary;
 }
 
 // ---------------------------------------------------------------------------
@@ -171,10 +217,16 @@ export interface Reconciler {
  * per daemon lifetime.
  */
 export function createReconciler({ bufferDirs, logger, projectRoot, onSessionReconciled, eventDedupCache, registry, machineId, resolveGroveDb }: ReconcilerDeps): Reconciler {
-  // Track sessions already reconciled this daemon lifetime to avoid
-  // redundant file reads (startup scan + register + event can all fire).
-  // A session is only added after a pass converges (zero replay errors,
-  // unchanged file identity) — failed or aborted passes stay eligible.
+  // Converged map: session id → the buffer file identity (size, mtimeMs)
+  // the last converged pass observed. A session whose CURRENT file
+  // matches its entry is skipped (startup scan + register + event +
+  // post-Stop trigger + drain pass can all fire); an entry whose identity
+  // no longer matches is STALE — events arrived since the converged pass
+  // and the session is eligible to re-converge. An entry is only written
+  // after a pass converges (zero replay errors, unchanged file identity)
+  // — failed or aborted passes stay eligible. Entries are evicted on
+  // buffer delete/quarantine and clearSession, so the map stays bounded
+  // by the live buffer-file population.
   //
   // Keys are bare session ids, deliberately NOT grove-qualified: a session
   // resolves to exactly ONE buffer dir (locateBufferContent takes the
@@ -183,7 +235,20 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
   // IN ITS GROVE DB". Cross-Grove same-id collision would require two
   // UUID session ids to coincide AND would still collapse to the first
   // dir, the reconciler's pre-existing resolution rule.
-  const reconciledSessions = new Set<string>();
+  const reconciledSessions = new Map<string, BufferIdentity>();
+
+  // Per-session drain failure backoff: a session whose drain attempt
+  // errored (or completed without converging) sits out 2^failures passes
+  // (capped) before retrying, so a poisoned event can't hot-loop the
+  // drain job. Reset on a successful (converged) attempt.
+  const drainBackoff = new Map<string, { failures: number; skipPasses: number }>();
+
+  // Drain scan rotation, per pass scope (grove id, or '*' for an
+  // unscoped pass): the candidate key of the last session that consumed
+  // a cap slot. The next pass starts scanning AFTER it so a cap-sized
+  // block of undrainable diverging buffers can't permanently starve the
+  // candidates behind it.
+  const drainScanCursors = new Map<string, string>();
 
   // Default Grove-DB resolver: open the Grove's SQLite file directly when
   // it exists (one cached handle per Grove per reconciler lifetime). The
@@ -238,6 +303,34 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
     }
   }
 
+  function identityEquals(a: BufferIdentity, b: BufferIdentity): boolean {
+    return a.size === b.size && a.mtimeMs === b.mtimeMs;
+  }
+
+  /** Converged-map check against a CURRENT file identity. */
+  function isConverged(sessionId: string, identity: BufferIdentity): boolean {
+    const mark = reconciledSessions.get(sessionId);
+    return mark !== undefined && identityEquals(mark, identity);
+  }
+
+  /**
+   * Stat-only location of a session's buffer file across all known dirs —
+   * the cheap precursor to `locateBufferContent` for skip decisions that
+   * don't need the file's content. First dir with a non-empty file wins,
+   * mirroring the content locator's resolution rule.
+   */
+  function statBufferAcrossDirs(
+    sessionId: string,
+  ): { dir: string; path: string; identity: BufferIdentity } | null {
+    for (const dir of bufferDirs()) {
+      const bufferPath = path.join(dir, `${sessionId}.jsonl`);
+      const identity = statBufferIdentity(bufferPath);
+      if (!identity || identity.size === 0) continue;
+      return { dir, path: bufferPath, identity };
+    }
+    return null;
+  }
+
   /**
    * Locate the buffer file for a session across all known buffer dirs.
    * Returns the first dir whose buffer file exists and is non-empty, or
@@ -253,7 +346,7 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
   function locateBufferContent(
     sessionId: string,
   ): { dir: string; path: string; content: string; identity: BufferIdentity } | null {
-    for (const dir of bufferDirs) {
+    for (const dir of bufferDirs()) {
       const bufferPath = path.join(dir, `${sessionId}.jsonl`);
       const identity = statBufferIdentity(bufferPath);
       if (!identity) continue;
@@ -343,7 +436,7 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
         : '';
       if (!summary) return null;
       const latest = getLatestBatch(sessionId);
-      if (!latest || latest.response_summary) return null;
+      if (!latest) return null;
       // Staleness-qualified open-batch guard. A FRESH open batch is a turn
       // that may still be live — a replayed stop landing on it would
       // attribute a buffered assistant message to a turn it may not belong
@@ -368,7 +461,23 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
           return null;
         }
       }
-      setResponseSummary(latest.id, summary);
+      // Same human-anchor resolution the live Stop pipeline uses: latest
+      // HUMAN-origin batch, steering child redirected to its owning
+      // parent, summary-bearing target → no write. A trailing system
+      // batch (a <task-notification> after the human prompt) must not
+      // absorb the turn's summary on replay any more than it does live.
+      //
+      // Accepted limitation (pre-existing P1 class): stop events carry no
+      // turn key, so when ONE session misses TWO stops, both replay
+      // against "the latest summary-less target" in chronological order —
+      // if the first turn's prompt was also missed and recovered in this
+      // same pass, turn 1's stop can land on turn 2's batch first-wins
+      // and strand turn 2's summary on turn 1's. Recovered-with-possible-
+      // cross-turn-misattribution is the deliberate trade over dropping
+      // the summaries; turn-keyed stop events are a possible future fix.
+      const target = resolveResponseSummaryTarget(sessionId, latest);
+      if (!target) return null;
+      setResponseSummary(target.id, summary);
       return 'activity';
     }
     return null;
@@ -443,12 +552,13 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
   }
 
   /**
-   * Discard a session's buffer file and mark the session converged. The
-   * skip-not-resurrect terminal state for tombstoned and gate-rejected
-   * sessions: no DB row exists, none will be created, and the buffer must
-   * not linger as a resurrection candidate. The mark is only applied when
-   * the unlink succeeds — a failed delete leaves the session eligible so
-   * the next trigger retries.
+   * Discard a session's buffer file — the skip-not-resurrect terminal
+   * state for tombstoned and gate-rejected sessions: no DB row exists,
+   * none will be created, and the buffer must not linger as a
+   * resurrection candidate. The converged-map entry is evicted (file
+   * gone → no identity to match; every trigger no-ops on the absent
+   * file). A failed delete leaves state untouched so the next trigger
+   * retries.
    */
   function discardBuffer(sessionId: string, bufferPath: string, reason: string): void {
     try {
@@ -462,7 +572,7 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
       });
       return;
     }
-    reconciledSessions.add(sessionId);
+    reconciledSessions.delete(sessionId);
     logger.info(LOG_KINDS.LIFECYCLE_RECONCILE, 'Reconciliation: buffer discarded without replay', {
       session_id: sessionId,
       buffer_path: bufferPath,
@@ -614,88 +724,50 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
    * batch). The session is marked reconciled only when the pass completes
    * with zero replay errors against an unchanged buffer file.
    */
-  function reconcileSession(sessionId: string): void {
-    if (reconciledSessions.has(sessionId)) return;
+  /** Per-event verdict from {@link createConvergenceMatcher}. */
+  type ConvergenceVerdict =
+    | { kind: 'duplicate' }   // intra-buffer copy within the dedup window
+    | { kind: 'dropped' }     // pre-rule prompt the manifest would DROP
+    | { kind: 'converged' }   // consumed a stored row (or prefix-matched)
+    | { kind: 'unmatched'; exactKey: string }; // no stored counterpart
 
-    // Locate the session's buffer across every known dir. Buffer file
-    // absent in every dir → return WITHOUT marking reconciled so a later
-    // call (after the buffer appears) can replay it.
-    const located = locateBufferContent(sessionId);
-    if (!located) return;
-
-    // Bind the whole pass to the Grove DB that OWNS the located buffer
-    // dir. At boot the ambient DB is the bootstrap/anchor vault — running
-    // unbound there made every Grove session's tombstone invisible and
-    // replayed its events into the anchor. On the live path the HTTP layer
-    // already bound the request's Grove DB; rebinding resolves the same
-    // shared handle (cache hit), so nesting is a no-op.
-    const scope = groveScopeForDir(located.dir);
-    if (scope.kind === 'unavailable') {
-      logger.warn(LOG_KINDS.LIFECYCLE_RECONCILE, 'Skipping reconciliation — Grove DB for buffer dir unavailable', {
-        session_id: sessionId,
-        buffer_dir: located.dir,
-        grove_id: scope.groveId,
-      });
-      return;
-    }
-    if (scope.kind === 'scoped') {
-      withDatabase(scope.db, () => reconcileLocatedSession(sessionId, located));
-    } else {
-      reconcileLocatedSession(sessionId, located);
-    }
-  }
-
-  /** The per-session pass body; runs inside the owning Grove's DB scope. */
-  function reconcileLocatedSession(
+  /**
+   * Build the per-pass content matcher: a DB-side multiset snapshot plus
+   * the chronological match-and-consume walk, shared between the replay
+   * pass and the quarantine diagnostics (unmatched-event count).
+   *
+   * The multiset holds every stored prompt and every stored
+   * non-bookkeeping activity, keyed with the convergence projections of
+   * the shared fingerprint (`@myco/capture/dedup.js`). Multiset
+   * (key → count) so N genuine same-text turns consume N matches.
+   * Bookkeeping rows (subagent_*, task_completed, compact, stop_failure)
+   * come from non-replayable events and must never absorb a tool match.
+   *
+   * Three guards apply per prompt / tool event:
+   *
+   *   1. Intra-buffer collapse — the live dispatcher's content+window
+   *      dedup applied over the whole file, so the daemon-appended copy
+   *      and the hook CLI's duplicate copy (written whenever the daemon
+   *      returns `ignored: 'duplicate'` — see `hooks/send-event.ts`)
+   *      count as ONE logical event.
+   *   2. Exact content match — the event's convergence key consumes one
+   *      unconsumed DB row with the same key. user_prompt events key on
+   *      the candidate replay text (the rewritten form the live hook
+   *      stored and replay would insert), not the raw buffered text.
+   *   3. Second-chance prefix match (user_prompt only) — catches miner
+   *      tail-rewrites of LONG prompts where exact text diverged. Skips
+   *      WITHOUT consuming a multiset count. Matches only against the
+   *      PRE-PASS batch snapshot so a prompt replayed earlier in this
+   *      pass can't absorb a later genuine same-text turn.
+   *
+   * Stateful per pass (the multiset is consumed, the dedup-window memory
+   * accumulates) — create one matcher per pass and feed it the buffer's
+   * events in chronological order. Must run inside the owning Grove's DB
+   * scope. Stop events must not be passed in (no DB-row projection).
+   */
+  function createConvergenceMatcher(
     sessionId: string,
-    located: NonNullable<ReturnType<typeof locateBufferContent>>,
-  ): void {
-    // Four-way discrimination on the session row. Row present → normal
-    // convergence. Row absent → tombstone / resurrection / retention.
-    let resurrected = false;
-    let staleResurrection = false;
-    let allEvents: Array<Record<string, unknown>> | null = null;
-    if (!getSession(sessionId, ALL_PROJECTS_SCOPE)) {
-      // (2) Tombstoned: the row was deliberately deleted through
-      // deleteSessionCascade. Skip-not-resurrect — discard the lingering
-      // buffer so nothing can replay it, and mark converged.
-      if (hasSessionTombstone(sessionId)) {
-        discardBuffer(sessionId, located.path, 'session tombstoned');
-        return;
-      }
-      allEvents = parseBufferEvents(sessionId, located);
-      if (!allEvents) return;
-      // (4) No replayable content: nothing to resurrect. Leave the file
-      // for retention (P3 adds the hard cap) without marking reconciled —
-      // a row appearing later must stay free to converge.
-      if (!allEvents.some((event) => REPLAYABLE_EVENT_TYPES.has(String(event.type)))) {
-        logger.debug(LOG_KINDS.LIFECYCLE_RECONCILE, 'Skipping reconciliation — session row absent, no replayable events', {
-          session_id: sessionId,
-        });
-        return;
-      }
-      // (3) Gate-checked resurrection. A resurrection whose newest event
-      // already predates the stale threshold is historical recovery — it
-      // will be closed right after convergence and must NOT enter the
-      // in-memory registry (nothing will ever unregister it, and registry
-      // membership shields sessions from the dead sweep).
-      const newestMs = newestReplayableTimestampMs(allEvents);
-      staleResurrection = newestMs !== undefined && Date.now() - newestMs > STALE_SESSION_THRESHOLD_MS;
-      if (!resurrectSession(sessionId, located, allEvents, { registerInRegistry: !staleResurrection })) return;
-      resurrected = true;
-    }
-
-    allEvents ??= parseBufferEvents(sessionId, located);
-    if (!allEvents) return;
-
-    let replayErrors = 0;
-
-    // DB-side content multiset: every stored prompt and every stored
-    // non-bookkeeping activity, keyed with the convergence projections of
-    // the shared fingerprint. Multiset (key → count) so N genuine
-    // same-text turns consume N matches. Bookkeeping rows (subagent_*,
-    // task_completed, compact, stop_failure) come from non-replayable
-    // events and must never absorb a tool match.
+  ): (event: Record<string, unknown>) => ConvergenceVerdict {
     const existingBatches = listBatchesBySession(sessionId, {
       scope: ALL_PROJECTS_SCOPE,
       limit: CONVERGENCE_QUERY_LIMIT,
@@ -714,24 +786,158 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
       const key = dedupKeyFromActivity(activity);
       dbKeyCounts.set(key, (dbKeyCounts.get(key) ?? 0) + 1);
     }
+    const seenKeys = new Map<string, number>();
 
-    // Match-and-consume chronologically. Three guards apply before a
-    // prompt / tool event reaches replayEvent:
-    //
-    //   1. Intra-buffer collapse — the live dispatcher's content+window
-    //      dedup applied over the whole file, so the daemon-appended copy
-    //      and the hook CLI's duplicate copy (written whenever the daemon
-    //      returns `ignored: 'duplicate'` — see `hooks/send-event.ts`)
-    //      count as ONE logical event.
-    //   2. Exact content match — the event's convergence key consumes one
-    //      unconsumed DB row with the same key. user_prompt events key on
-    //      the candidate replay text (the rewritten form the live hook
-    //      stored and replay would insert), not the raw buffered text.
-    //   3. Second-chance prefix match (user_prompt only) — catches miner
-    //      tail-rewrites of LONG prompts where exact text diverged. Skips
-    //      WITHOUT consuming a multiset count.
-    //
-    // Stop events take none of these: they have no DB-row projection and
+    return (event) => {
+      const type = String(event.type);
+      const eventWithSession = {
+        ...event,
+        type,
+        session_id: sessionId,
+      } as Record<string, unknown> & { type: string; session_id: string };
+      const exactKey = eventDedupKey(eventWithSession);
+      const ts = eventTimestampMs(event) ?? Date.now();
+      const lastSeen = seenKeys.get(exactKey);
+      if (lastSeen !== undefined && ts - lastSeen < EVENT_DEDUP_WINDOW_MS) {
+        return { kind: 'duplicate' };
+      }
+      seenKeys.set(exactKey, ts);
+
+      // Mirror replayEvent's user_prompt gate so a pre-rule event the
+      // manifest would DROP neither consumes a DB row nor replays, and so
+      // both match layers compare the text replay WOULD insert.
+      let candidateText: string | null = null;
+      if (type === 'user_prompt') {
+        const promptText = String(event.prompt ?? '');
+        if (typeof event.origin === 'string') {
+          candidateText = promptText;
+        } else {
+          const decision = classifyNextPromptDecision(
+            typeof event.agent === 'string' ? event.agent : undefined,
+            promptText,
+          );
+          if (decision.action === 'drop') return { kind: 'dropped' };
+          candidateText = decision.action === 'rewrite' ? decision.prompt : promptText;
+        }
+      }
+
+      const matchKey = type === 'user_prompt'
+        ? convergenceEventKey({ ...eventWithSession, prompt: candidateText ?? '' })
+        : convergenceEventKey(eventWithSession);
+      const remaining = dbKeyCounts.get(matchKey) ?? 0;
+      if (remaining > 0) {
+        dbKeyCounts.set(matchKey, remaining - 1);
+        return { kind: 'converged' };
+      }
+
+      if (type === 'user_prompt' && candidateText && hasPrefixMatchedBatch(existingBatches, candidateText)) {
+        return { kind: 'converged' };
+      }
+
+      return { kind: 'unmatched', exactKey };
+    };
+  }
+
+  /**
+   * What a convergence pass made of a session:
+   *
+   *   - 'converged'     — mark written (or the buffer terminally
+   *                       discarded); nothing left to replay.
+   *   - 'deferred'      — benign non-completion (fresh torn tail, events
+   *                       arrived mid-pass, retention-bound content,
+   *                       stale-dir skip): retry on the next trigger,
+   *                       no failure recorded.
+   *   - 'replay-errors' — one or more events failed to replay; the drain
+   *                       job records a failure and backs the session off.
+   */
+  type PassResult = 'converged' | 'deferred' | 'replay-errors';
+
+  function reconcileSession(sessionId: string): PassResult {
+    // Stat-only converged-map skip: identical (size, mtimeMs) to the last
+    // converged pass means no events arrived since — nothing to do, and
+    // the file is not even read. A stale mark (identity changed) falls
+    // through and re-converges; that staleness check is what lets the
+    // post-Stop trigger and the drain job pick up wedge-buffered events
+    // without any explicit mark-clearing.
+    const pre = statBufferAcrossDirs(sessionId);
+    if (!pre) return 'converged';
+    if (isConverged(sessionId, pre.identity)) return 'converged';
+
+    // Locate the session's buffer across every known dir. Buffer file
+    // absent in every dir → return WITHOUT marking reconciled so a later
+    // call (after the buffer appears) can replay it.
+    const located = locateBufferContent(sessionId);
+    if (!located) return 'deferred';
+
+    // Bind the whole pass to the Grove DB that OWNS the located buffer
+    // dir. At boot the ambient DB is the bootstrap/anchor vault — running
+    // unbound there made every Grove session's tombstone invisible and
+    // replayed its events into the anchor. On the live path the HTTP layer
+    // already bound the request's Grove DB; rebinding resolves the same
+    // shared handle (cache hit), so nesting is a no-op.
+    const scope = groveScopeForDir(located.dir);
+    if (scope.kind === 'unavailable') {
+      logger.warn(LOG_KINDS.LIFECYCLE_RECONCILE, 'Skipping reconciliation — Grove DB for buffer dir unavailable', {
+        session_id: sessionId,
+        buffer_dir: located.dir,
+        grove_id: scope.groveId,
+      });
+      return 'deferred';
+    }
+    return scope.kind === 'scoped'
+      ? withDatabase(scope.db, () => reconcileLocatedSession(sessionId, located))
+      : reconcileLocatedSession(sessionId, located);
+  }
+
+  /** The per-session pass body; runs inside the owning Grove's DB scope. */
+  function reconcileLocatedSession(
+    sessionId: string,
+    located: NonNullable<ReturnType<typeof locateBufferContent>>,
+  ): PassResult {
+    // Four-way discrimination on the session row. Row present → normal
+    // convergence. Row absent → tombstone / resurrection / retention.
+    let resurrected = false;
+    let staleResurrection = false;
+    let allEvents: Array<Record<string, unknown>> | null = null;
+    if (!getSession(sessionId, ALL_PROJECTS_SCOPE)) {
+      // (2) Tombstoned: the row was deliberately deleted through
+      // deleteSessionCascade. Skip-not-resurrect — discard the lingering
+      // buffer so nothing can replay it, and mark converged.
+      if (hasSessionTombstone(sessionId)) {
+        discardBuffer(sessionId, located.path, 'session tombstoned');
+        return 'converged';
+      }
+      allEvents = parseBufferEvents(sessionId, located);
+      if (!allEvents) return 'deferred';
+      // (4) No replayable content: nothing to resurrect. Leave the file
+      // for retention (the hard cap quarantines it eventually) without
+      // marking reconciled — a row appearing later must stay free to
+      // converge.
+      if (!allEvents.some((event) => REPLAYABLE_EVENT_TYPES.has(String(event.type)))) {
+        logger.debug(LOG_KINDS.LIFECYCLE_RECONCILE, 'Skipping reconciliation — session row absent, no replayable events', {
+          session_id: sessionId,
+        });
+        return 'deferred';
+      }
+      // (3) Gate-checked resurrection. A resurrection whose newest event
+      // already predates the stale threshold is historical recovery — it
+      // will be closed right after convergence and must NOT enter the
+      // in-memory registry (nothing will ever unregister it, and registry
+      // membership shields sessions from the dead sweep).
+      const newestMs = newestReplayableTimestampMs(allEvents);
+      staleResurrection = newestMs !== undefined && Date.now() - newestMs > STALE_SESSION_THRESHOLD_MS;
+      if (!resurrectSession(sessionId, located, allEvents, { registerInRegistry: !staleResurrection })) return 'deferred';
+      resurrected = true;
+    }
+
+    allEvents ??= parseBufferEvents(sessionId, located);
+    if (!allEvents) return 'deferred';
+
+    let replayErrors = 0;
+
+    // Match-and-consume chronologically via the shared matcher (see
+    // `createConvergenceMatcher` for the three pre-replay guards). Stop
+    // events bypass the matcher: they have no DB-row projection and
     // their fingerprint carries no content (every stop in a session shares
     // one key, so collapse would eat a rapid second turn's summary). Each
     // is replayed at its chronological position — after the prompts that
@@ -747,8 +953,8 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
     let duplicatesSuppressed = 0;
     let eventsConverged = 0;
     let summariesRecovered = 0;
-    const seenKeys = new Map<string, number>();
     const passCreatedBatchIds = new Set<number>();
+    const matchEvent = createConvergenceMatcher(sessionId);
 
     for (const event of allEvents) {
       const type = String(event.type);
@@ -767,52 +973,10 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
         continue;
       }
 
-      const eventWithSession = {
-        ...event,
-        type,
-        session_id: sessionId,
-      } as Record<string, unknown> & { type: string; session_id: string };
-      const exactKey = eventDedupKey(eventWithSession);
-      const ts = eventTimestampMs(event) ?? Date.now();
-      const lastSeen = seenKeys.get(exactKey);
-      if (lastSeen !== undefined && ts - lastSeen < EVENT_DEDUP_WINDOW_MS) {
-        duplicatesSuppressed++;
-        continue;
-      }
-      seenKeys.set(exactKey, ts);
-
-      // Mirror replayEvent's user_prompt gate so a pre-rule event the
-      // manifest would DROP neither consumes a DB row nor replays, and so
-      // both match layers compare the text replay WOULD insert.
-      let candidateText: string | null = null;
-      if (type === 'user_prompt') {
-        const promptText = String(event.prompt ?? '');
-        if (typeof event.origin === 'string') {
-          candidateText = promptText;
-        } else {
-          const decision = classifyNextPromptDecision(
-            typeof event.agent === 'string' ? event.agent : undefined,
-            promptText,
-          );
-          if (decision.action === 'drop') continue;
-          candidateText = decision.action === 'rewrite' ? decision.prompt : promptText;
-        }
-      }
-
-      const matchKey = type === 'user_prompt'
-        ? convergenceEventKey({ ...eventWithSession, prompt: candidateText ?? '' })
-        : convergenceEventKey(eventWithSession);
-      const remaining = dbKeyCounts.get(matchKey) ?? 0;
-      if (remaining > 0) {
-        dbKeyCounts.set(matchKey, remaining - 1);
-        eventsConverged++;
-        continue;
-      }
-
-      if (type === 'user_prompt' && candidateText && hasPrefixMatchedBatch(existingBatches, candidateText)) {
-        eventsConverged++;
-        continue;
-      }
+      const verdict = matchEvent(event);
+      if (verdict.kind === 'duplicate') { duplicatesSuppressed++; continue; }
+      if (verdict.kind === 'dropped') continue;
+      if (verdict.kind === 'converged') { eventsConverged++; continue; }
 
       try {
         const result = replayEvent(sessionId, event, passCreatedBatchIds);
@@ -821,7 +985,7 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
         // Mirror the replay into the live duplicate cache (replay-time
         // stamp) so a late live POST of the same physical event is
         // rejected by the dispatcher instead of double-inserting.
-        if (result !== null) eventDedupCache?.record(exactKey, Date.now());
+        if (result !== null) eventDedupCache?.record(verdict.exactKey, Date.now());
       } catch (err) {
         replayErrors++;
         logger.warn(LOG_KINDS.LIFECYCLE_RECONCILE, 'Reconciliation: failed to replay event', {
@@ -835,11 +999,12 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
     // identical to the pre-read snapshot (no events arrived mid-pass).
     // Anything else leaves the session eligible for the next trigger.
     const after = statBufferIdentity(located.path);
-    const identityUnchanged = after !== null
-      && after.size === located.identity.size
-      && after.mtimeMs === located.identity.mtimeMs;
-    if (replayErrors === 0 && identityUnchanged) {
-      reconciledSessions.add(sessionId);
+    const identityUnchanged = after !== null && identityEquals(after, located.identity);
+    const passResult: PassResult = replayErrors > 0
+      ? 'replay-errors'
+      : identityUnchanged ? 'converged' : 'deferred';
+    if (passResult === 'converged' && after !== null) {
+      reconciledSessions.set(sessionId, after);
     } else {
       logger.debug(LOG_KINDS.LIFECYCLE_RECONCILE, 'Reconciliation pass not converged — session stays eligible', {
         session_id: sessionId,
@@ -871,6 +1036,7 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
       });
     }
     tryReEnrich(sessionId);
+    return passResult;
   }
 
   /** Invoke `onSessionReconciled` if provided, swallowing + logging any error. */
@@ -894,42 +1060,284 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
    *   - anything else (diverging, live,
    *     row-absent-no-tombstone)        → 'retain'
    *
-   * A diverging buffer is the only durable copy of unreplayed events and
-   * is NEVER deleted here — P3 adds the 7d hard cap + quarantine; for P2
-   * such buffers are simply retained.
+   * "Converged" requires mark CURRENCY: the converged-map entry must
+   * match the file's CURRENT (size, mtimeMs) identity. Mark presence
+   * alone is not enough — a closed session converged at identity I1
+   * whose buffer later gained a wedge-buffered event (I2) holds the only
+   * durable copy of that unreplayed event; an 'age-gated' classification
+   * would let the 24h gate destroy it whenever the drain couldn't
+   * re-converge first (persistent replay errors under backoff, or any
+   * append between drain cadences). A stale-mark file is DIVERGING
+   * ('retain') and is never deleted here — past BUFFER_HARD_RETENTION_MS
+   * it is QUARANTINED (moved, preserved) by `cleanStaleBuffers`'
+   * hard-cap option.
    */
-  function classifyBufferForCleanup(sessionId: string): BufferCleanupDecision {
+  function classifyBufferForCleanup(sessionId: string, identity: BufferIdentity): BufferCleanupDecision {
     if (hasSessionTombstone(sessionId)) return 'delete';
     const row = getSession(sessionId, ALL_PROJECTS_SCOPE);
-    if (row && row.status !== 'active' && reconciledSessions.has(sessionId)) return 'age-gated';
+    if (row && row.status !== 'active' && isConverged(sessionId, identity)) return 'age-gated';
     return 'retain';
   }
 
   /**
-   * Convergence-aware buffer cleanup across every known dir. Each dir's
+   * Unmatched-event diagnostic for a quarantined buffer: how many of its
+   * replayable prompt/tool events have no stored DB counterpart. Runs the
+   * shared matcher in count-only mode (no replay, no side effects beyond
+   * the matcher's own per-call state). Stop events are excluded — they
+   * have no DB-row projection. Must run inside the owning Grove's scope.
+   */
+  function countUnmatchedEvents(sessionId: string, filePath: string): number {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(filePath, 'utf-8');
+    } catch {
+      return 0;
+    }
+    const matchEvent = createConvergenceMatcher(sessionId);
+    let unmatched = 0;
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let event: Record<string, unknown>;
+      try {
+        event = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      const type = String(event.type);
+      if (!REPLAYABLE_EVENT_TYPES.has(type) || type === 'stop') continue;
+      if (matchEvent(event).kind === 'unmatched') unmatched++;
+    }
+    return unmatched;
+  }
+
+  /**
+   * Convergence-aware buffer cleanup over the given dirs. Each dir's
    * classification runs bound to ITS Grove's DB — the classifier reads
    * tombstones and session status, and an ambient binding (the anchor at
    * boot, the requester's Grove on the unregister path) would classify
    * every other Grove's sessions as never-seen → retain. Dirs whose Grove
    * DB is unavailable are skipped (retain everything — fail-safe).
+   *
+   * Retention completion runs here too: a diverging ('retain') buffer
+   * past BUFFER_HARD_RETENTION_MS moves into the dir's quarantine/
+   * subdir (WARN with its unmatched-event count), and quarantined files
+   * past TOMBSTONE_RETENTION_MS are pruned — the same pass that prunes
+   * the tombstones whose window they must not outlive. Deletes and
+   * quarantine moves both evict the converged-map entry. The quarantine
+   * prune is pure filesystem work and runs even for unavailable-Grove
+   * dirs — a Grove whose DB vanished must still age out its quarantine.
    */
-  function cleanBuffers(excludeSessionId?: string): number {
+  function cleanBufferDirs(dirs: readonly string[], excludeSessionId?: string): number {
     let totalCleaned = 0;
-    for (const dir of bufferDirs) {
+    let totalPruned = 0;
+    for (const dir of dirs) {
+      totalPruned += pruneQuarantinedBuffers(dir, TOMBSTONE_RETENTION_MS);
       const scope = groveScopeForDir(dir);
       if (scope.kind === 'unavailable') continue;
-      const run = () => cleanStaleBuffers(dir, STALE_BUFFER_MAX_AGE_MS, excludeSessionId, classifyBufferForCleanup);
+      const run = () => cleanStaleBuffers(dir, {
+        maxAgeMs: STALE_BUFFER_MAX_AGE_MS,
+        ...(excludeSessionId !== undefined ? { excludeSessionId } : {}),
+        classify: classifyBufferForCleanup,
+        onRemoved: (sessionId) => reconciledSessions.delete(sessionId),
+        quarantine: {
+          maxAgeMs: BUFFER_HARD_RETENTION_MS,
+          onQuarantined: (sessionId, quarantinedPath) => {
+            reconciledSessions.delete(sessionId);
+            drainBackoff.delete(sessionId);
+            logger.warn(LOG_KINDS.CAPTURE_BUFFER, 'Diverging buffer quarantined at hard retention cap', {
+              session_id: sessionId,
+              quarantined_path: quarantinedPath,
+              unmatched_events: countUnmatchedEvents(sessionId, quarantinedPath),
+            });
+          },
+        },
+      });
       totalCleaned += scope.kind === 'scoped' ? withDatabase(scope.db, run) : run();
     }
-    if (totalCleaned > 0) {
-      logger.info(LOG_KINDS.CAPTURE_BUFFER, 'Buffer cleanup complete', { stale_removed: totalCleaned });
+    if (totalCleaned > 0 || totalPruned > 0) {
+      logger.info(LOG_KINDS.CAPTURE_BUFFER, 'Buffer cleanup complete', {
+        stale_removed: totalCleaned,
+        quarantine_pruned: totalPruned,
+      });
     }
     return totalCleaned;
   }
 
+  /** Cleanup across every known dir (public surface + startup path). */
+  function cleanBuffers(excludeSessionId?: string): number {
+    return cleanBufferDirs(bufferDirs(), excludeSessionId);
+  }
+
   function hasUnconvergedBuffer(sessionId: string): boolean {
-    if (reconciledSessions.has(sessionId)) return false;
-    return locateBufferContent(sessionId) !== null;
+    const located = statBufferAcrossDirs(sessionId);
+    if (!located) return false;
+    return !isConverged(sessionId, located.identity);
+  }
+
+  /**
+   * Quiescence gate: may a drain pass converge this session's buffer NOW
+   * without racing a live turn? Eligible when:
+   *
+   *   (a) the session row is ABSENT — the resurrection path; no live turn
+   *       can exist for a row-less session by construction (P2's
+   *       tombstone/identity/capture gates still apply inside the pass);
+   *   (b) the session is CLOSED (status flipped through the completion
+   *       chokepoint, `closeSession`); or
+   *   (c) the session has NO open batch (latest batch ended_at set, or no
+   *       batches at all) AND the buffer file has been idle for at least
+   *       BUFFER_QUIESCENCE_IDLE_MS — an active session between turns.
+   *
+   * Must run inside the owning Grove's DB scope.
+   */
+  function isDrainQuiescent(sessionId: string, identity: BufferIdentity): boolean {
+    const row = getSession(sessionId, ALL_PROJECTS_SCOPE);
+    if (!row) return true;
+    if (row.status !== 'active') return true;
+    const latest = getLatestBatch(sessionId);
+    if (latest && latest.ended_at === null) return false;
+    return Date.now() - identity.mtimeMs >= BUFFER_QUIESCENCE_IDLE_MS;
+  }
+
+  function runDrainPass(options: { groveId?: string } = {}): DrainPassSummary {
+    const dirs = bufferDirs().filter((dir) =>
+      options.groveId === undefined || bufferDirIdentity(dir)?.groveId === options.groveId,
+    );
+    const summary: DrainPassSummary = {
+      attempted: 0,
+      drained: 0,
+      skippedQuiescent: 0,
+      skippedBackoff: 0,
+      deferredByCap: 0,
+      failed: 0,
+    };
+
+    // Flat candidate list (stable dir order, per-dir readdir order),
+    // rotated to start AFTER the previous pass's last cap-consuming
+    // session. Without rotation, ≥cap undrainable diverging buffers at
+    // the front of the scan would starve everything behind them until
+    // quarantine; with it, every candidate is reached within two passes.
+    interface DrainCandidate { dir: string; sessionId: string; key: string; scope: DirScope }
+    const candidates: DrainCandidate[] = [];
+    for (const dir of dirs) {
+      const scope = groveScopeForDir(dir);
+      if (scope.kind === 'unavailable') {
+        logger.warn(LOG_KINDS.CAPTURE_BUFFER, 'Drain pass skipping dir — Grove DB unavailable', {
+          buffer_dir: dir,
+          grove_id: scope.groveId,
+        });
+        continue;
+      }
+      for (const sessionId of listBufferSessionIds(dir)) {
+        candidates.push({ dir, sessionId, key: `${dir}\0${sessionId}`, scope });
+      }
+    }
+    const cursorKey = options.groveId ?? '*';
+    const cursor = drainScanCursors.get(cursorKey);
+    let start = 0;
+    if (cursor !== undefined && candidates.length > 0) {
+      const idx = candidates.findIndex((c) => c.key === cursor);
+      if (idx >= 0) start = (idx + 1) % candidates.length;
+    }
+
+    let capConsumed = 0;
+    for (let i = 0; i < candidates.length; i++) {
+      const { dir, sessionId, key, scope } = candidates[(start + i) % candidates.length];
+      const identity = statBufferIdentity(path.join(dir, `${sessionId}.jsonl`));
+      if (!identity || identity.size === 0) continue;
+      if (isConverged(sessionId, identity)) continue;
+
+      // Failure backoff: an erroring session sits out 2^failures passes
+      // (capped) so a poisoned buffer can't hot-loop the job.
+      const backoff = drainBackoff.get(sessionId);
+      if (backoff && backoff.skipPasses > 0) {
+        backoff.skipPasses--;
+        summary.skippedBackoff++;
+        continue;
+      }
+
+      // Per-pass cap on real convergence attempts: the remainder is
+      // counted (and logged below), never silently truncated; rotation
+      // hands it the head of the next pass.
+      if (capConsumed >= CAPTURE_BUFFER_DRAIN_SESSION_CAP) {
+        summary.deferredByCap++;
+        continue;
+      }
+
+      let outcome: 'quiescence-skip' | 'thrown' | PassResult;
+      let thrownError = '';
+      try {
+        const drainOne = (): 'quiescence-skip' | PassResult => {
+          if (!isDrainQuiescent(sessionId, identity)) return 'quiescence-skip';
+          return reconcileSession(sessionId);
+        };
+        outcome = scope.kind === 'scoped' ? withDatabase(scope.db, drainOne) : drainOne();
+      } catch (err) {
+        outcome = 'thrown';
+        thrownError = String(err);
+      }
+
+      // Quiescence-skips are cheap gate reads — they consume no cap slot,
+      // so ≥cap not-yet-quiescent sessions can't starve drainable ones.
+      if (outcome === 'quiescence-skip') {
+        summary.skippedQuiescent++;
+        continue;
+      }
+
+      summary.attempted++;
+      capConsumed++;
+      drainScanCursors.set(cursorKey, key);
+      if (outcome === 'thrown') {
+        recordDrainFailure(sessionId, summary, thrownError);
+      } else if (outcome === 'converged') {
+        summary.drained++;
+        drainBackoff.delete(sessionId);
+      } else if (outcome === 'replay-errors') {
+        recordDrainFailure(sessionId, summary, 'replay errors during pass');
+      }
+      // 'deferred' is benign (fresh torn tail, mid-pass append,
+      // retention-bound content): retried next pass, no backoff.
+    }
+
+    if (summary.deferredByCap > 0) {
+      logger.info(LOG_KINDS.CAPTURE_BUFFER, 'Drain pass hit the per-pass session cap — remainder deferred to next pass', {
+        cap: CAPTURE_BUFFER_DRAIN_SESSION_CAP,
+        deferred: summary.deferredByCap,
+      });
+    }
+
+    // Retention runs on the same cadence, scoped to the visited dirs.
+    cleanBufferDirs(dirs);
+
+    // Converged-map / backoff hygiene: deletes that happen OUTSIDE the
+    // reconciler (maintenance-sweep cascade cleanup, manual removal)
+    // can't evict through the cleanup callbacks above. Drop entries
+    // whose buffer file no longer exists in any dir so both maps stay
+    // bounded by the live buffer-file population.
+    for (const sessionId of [...reconciledSessions.keys()]) {
+      if (!statBufferAcrossDirs(sessionId)) reconciledSessions.delete(sessionId);
+    }
+    for (const sessionId of [...drainBackoff.keys()]) {
+      if (!statBufferAcrossDirs(sessionId)) drainBackoff.delete(sessionId);
+    }
+
+    if (summary.drained > 0 || summary.failed > 0) {
+      logger.info(LOG_KINDS.CAPTURE_BUFFER, 'Buffer drain pass complete', { ...summary });
+    }
+    return summary;
+  }
+
+  function recordDrainFailure(sessionId: string, summary: DrainPassSummary, error: string): void {
+    summary.failed++;
+    const failures = (drainBackoff.get(sessionId)?.failures ?? 0) + 1;
+    const skipPasses = Math.min(2 ** failures, CAPTURE_BUFFER_DRAIN_BACKOFF_CAP_PASSES);
+    drainBackoff.set(sessionId, { failures, skipPasses });
+    logger.warn(LOG_KINDS.CAPTURE_BUFFER, 'Drain attempt failed — session backing off', {
+      session_id: sessionId,
+      failures,
+      skip_passes: skipPasses,
+      error,
+    });
   }
 
   /**
@@ -944,9 +1352,9 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
     // Reconcile every buffer file across all known dirs. A session shows
     // up at most once even if its buffer lives in only one dir —
     // `reconcileSession` is idempotent across multiple invocations via
-    // the `reconciledSessions` set.
+    // the converged map.
     const seen = new Set<string>();
-    for (const dir of bufferDirs) {
+    for (const dir of bufferDirs()) {
       for (const sessionId of listBufferSessionIds(dir)) {
         if (seen.has(sessionId)) continue;
         seen.add(sessionId);
@@ -963,6 +1371,7 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
 
   function clearSession(sessionId: string): void {
     reconciledSessions.delete(sessionId);
+    drainBackoff.delete(sessionId);
   }
 
   return {
@@ -972,5 +1381,6 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
     clearSession,
     cleanStaleBuffers: cleanBuffers,
     hasUnconvergedBuffer,
+    runDrainPass,
   };
 }

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -23,15 +23,13 @@ import {
 } from './plan-capture.js';
 import {
   getLatestBatch,
-  getBatchById,
   setResponseSummary,
+  resolveResponseSummaryTarget,
   populateBatchResponses,
   rehomeSystemActivitiesToHumanAnchor,
   closeOpenBatches,
   listBatchesBySession,
   findBatchByPromptPrefix,
-  PROMPT_BATCH_ORIGIN,
-  type BatchRow,
   type PromptBatchOrigin,
 } from '@myco/db/queries/batches.js';
 import { deleteSessionCascade, getSession, updateSession } from '@myco/db/queries/sessions.js';
@@ -87,6 +85,15 @@ export interface StopProcessorDeps {
   /** Plan tag names to extract from transcript responses. Merged from all symbiont manifests. */
   planTags: string[];
   planWatchConfig: PlanWatchConfig;
+  /**
+   * Fires after the queued stop-processing task for a session settles —
+   * the daemon-owned turn boundary, quiescent by construction. The
+   * reconciler hangs its deferred per-session convergence here so
+   * wedge-buffered events that arrived mid-turn replay without waiting
+   * for a restart or drain pass. Deferred off the queue's tick and
+   * fire-safe: errors are logged, never thrown into the stop chain.
+   */
+  onStopProcessed?: (sessionId: string) => void;
 }
 
 
@@ -227,22 +234,6 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     return true;
   }
 
-  /**
-   * Walk parent pointers up to the first non-steering batch so the response
-   * summary lands on the turn's owning prompt card. Steering children never
-   * themselves become parents (see handleUserPrompt), so a single hop is the
-   * expected depth; the loop survives an unexpected multi-hop chain anyway.
-   */
-  function findOwningParent(child: BatchRow): BatchRow | null {
-    let current: BatchRow | null = child;
-    while (current?.parent_prompt_batch_id != null) {
-      const parent = getBatchById(current.parent_prompt_batch_id, ALL_PROJECTS_SCOPE);
-      if (!parent || parent.id === current.id) break;
-      current = parent;
-    }
-    return current;
-  }
-
   async function processStopEvent(
     sessionId: string,
     user: string | undefined,
@@ -366,25 +357,21 @@ export function createStopProcessor(deps: StopProcessorDeps): {
       // model, where the file is rewritten each turn and only contains the
       // current one — we always want that single turn's response on the latest
       // batch, regardless of prompt_number alignment.
-      // Anchor the response to the latest HUMAN turn, never a point-in-time
-      // system batch (a <system-reminder> / <task-notification> born-closed
-      // after the human prompt carries a higher prompt_number and would be
-      // `latestBatch`, stranding the turn's answer on a dashboard-hidden row
-      // that populateBatchResponses never clears — it only clears system
-      // batches whose prompt matched a transcript turn, which an envelope is
-      // not). populateBatchResponses handles the matched case; this is the
-      // per-turn-transcript fallback (Cursor), so target the human anchor.
-      const responseTarget = latestBatch && latestBatch.origin !== PROMPT_BATCH_ORIGIN.HUMAN
-        ? getLatestBatch(sessionId, { origin: PROMPT_BATCH_ORIGIN.HUMAN })
-        : latestBatch;
-      if (resolvedResponse && responseTarget && !responseTarget.response_summary) {
-        const summaryTarget = responseTarget.parent_prompt_batch_id
-          ? findOwningParent(responseTarget)
-          : responseTarget;
-        if (summaryTarget && !summaryTarget.response_summary) {
-          try { setResponseSummary(summaryTarget.id, resolvedResponse); }
-          catch (err) { logger.warn(LOG_KINDS.PROCESSOR_BATCH, 'Failed to set response_summary on latest batch', { error: String(err) }); }
-        }
+      // Anchor the response via the shared human-anchor resolution
+      // (`resolveResponseSummaryTarget`) — latest HUMAN turn, steering
+      // child redirected to its owning parent, never a point-in-time
+      // system batch (a <system-reminder> / <task-notification> born-
+      // closed after the human prompt carries a higher prompt_number and
+      // would be `latestBatch`, stranding the turn's answer on a
+      // dashboard-hidden row that populateBatchResponses never clears —
+      // it only clears system batches whose prompt matched a transcript
+      // turn, which an envelope is not). populateBatchResponses handles
+      // the matched case; this is the per-turn-transcript fallback
+      // (Cursor), so target the human anchor.
+      const summaryTarget = resolveResponseSummaryTarget(sessionId, latestBatch);
+      if (resolvedResponse && summaryTarget) {
+        try { setResponseSummary(summaryTarget.id, resolvedResponse); }
+        catch (err) { logger.warn(LOG_KINDS.PROCESSOR_BATCH, 'Failed to set response_summary on latest batch', { error: String(err) }); }
       }
 
       // Close open batches but do NOT close the session — the Stop hook fires
@@ -809,6 +796,26 @@ export function createStopProcessor(deps: StopProcessorDeps): {
       logger.error(LOG_KINDS.PROCESSOR_SESSION, 'Stop processing failed', { session_id: sessionId, error: (err as Error).message });
     });
 
+    // Post-Stop convergence trigger. Runs after the queued task body has
+    // settled — the daemon-owned turn boundary — and is deferred off the
+    // queue's tick (the deferGitProvenance precedent: setImmediate keeps
+    // the cost out of the serialized chain). Fire-safe by construction:
+    // the setImmediate body catches and logs, so a throwing trigger can
+    // never poison the stop chain or the request path.
+    const fireStopProcessed = () => {
+      if (!deps.onStopProcessed) return;
+      setImmediate(() => {
+        try {
+          deps.onStopProcessed?.(sessionId);
+        } catch (err) {
+          logger.warn(LOG_KINDS.PROCESSOR_SESSION, 'Post-stop convergence trigger failed', {
+            session_id: sessionId,
+            error: (err as Error).message,
+          });
+        }
+      });
+    };
+
     const prev = activeStopProcessing ?? Promise.resolve();
     // Chain the new run after prev, then null out activeStopProcessing
     // only if THIS chain is still the registered head — without this
@@ -821,7 +828,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     //       running. getActiveProcessing() consumers (shutdown drain,
     //       tests) then proceed on what looks like an idle queue and
     //       can interrupt chainB mid-write. /code-review finding C5.
-    const chain: Promise<void> = prev.then(run).finally(() => {
+    const chain: Promise<void> = prev.then(run).then(fireStopProcessed).finally(() => {
       if (activeStopProcessing === chain) {
         activeStopProcessing = null;
       }

--- a/packages/myco/src/db/queries/batches.ts
+++ b/packages/myco/src/db/queries/batches.ts
@@ -9,6 +9,7 @@ import { getDatabase } from '@myco/db/client.js';
 import { getTeamMachineId } from '@myco/team/context.js';
 import { syncRow } from '@myco/db/queries/team-outbox.js';
 import { appendProjectCondition, type ProjectScope } from '@myco/db/queries/project-scope.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -891,6 +892,56 @@ export function getLatestBatch(
 
   if (!row) return null;
   return toBatchRow(row);
+}
+
+/**
+ * Walk parent pointers up to the first non-steering batch so the response
+ * summary lands on the turn's owning prompt card. Steering children never
+ * themselves become parents (see handleUserPrompt), so a single hop is the
+ * expected depth; the loop survives an unexpected multi-hop chain anyway.
+ */
+export function findOwningParent(child: BatchRow): BatchRow | null {
+  let current: BatchRow | null = child;
+  while (current?.parent_prompt_batch_id != null) {
+    const parent = getBatchById(current.parent_prompt_batch_id, ALL_PROJECTS_SCOPE);
+    if (!parent || parent.id === current.id) break;
+    current = parent;
+  }
+  return current;
+}
+
+/**
+ * Resolve the batch a turn's response summary belongs on, or `null` when
+ * no summary write should happen.
+ *
+ * Anchors the response to the latest HUMAN turn, never a point-in-time
+ * system batch (a <system-reminder> / <task-notification> born-closed
+ * after the human prompt carries a higher prompt_number and would be the
+ * latest batch, stranding the turn's answer on a dashboard-hidden row).
+ * A steering child redirects to its owning parent — there's only one
+ * combined assistant response per turn, and it belongs on the parent so
+ * the UI's parent card renders it. A target that already carries a
+ * summary yields `null` (the write is first-wins idempotent).
+ *
+ * Shared between the live Stop pipeline and buffer stop replay so both
+ * paths land the summary on the same row.
+ *
+ * @param latest the session's latest batch, when the caller already
+ *   fetched it; pass `null` only when the session has no batches.
+ */
+export function resolveResponseSummaryTarget(
+  sessionId: string,
+  latest: BatchRow | null,
+): BatchRow | null {
+  const responseTarget = latest && latest.origin !== PROMPT_BATCH_ORIGIN.HUMAN
+    ? getLatestBatch(sessionId, { origin: PROMPT_BATCH_ORIGIN.HUMAN })
+    : latest;
+  if (!responseTarget || responseTarget.response_summary) return null;
+  const summaryTarget = responseTarget.parent_prompt_batch_id
+    ? findOwningParent(responseTarget)
+    : responseTarget;
+  if (!summaryTarget || summaryTarget.response_summary) return null;
+  return summaryTarget;
 }
 
 /**

--- a/tests/capture/buffer.test.ts
+++ b/tests/capture/buffer.test.ts
@@ -40,28 +40,12 @@ describe('EventBuffer', () => {
     expect(buffer.readAll()).toEqual([]);
   });
 
-  it('reports event count', () => {
-    const buffer = new EventBuffer(bufferDir, 'session-abc');
-    expect(buffer.count()).toBe(0);
-    buffer.append({ type: 'tool_use', tool: 'Read' });
-    buffer.append({ type: 'tool_use', tool: 'Write' });
-    expect(buffer.count()).toBe(2);
-  });
-
   it('deletes buffer file', () => {
     const buffer = new EventBuffer(bufferDir, 'session-abc');
     buffer.append({ type: 'tool_use', tool: 'Read' });
     expect(buffer.exists()).toBe(true);
     buffer.delete();
     expect(buffer.exists()).toBe(false);
-  });
-
-  it('respects max events limit', () => {
-    const buffer = new EventBuffer(bufferDir, 'session-abc', { maxEvents: 3 });
-    for (let i = 0; i < 5; i++) {
-      buffer.append({ type: 'tool_use', tool: `tool-${i}` });
-    }
-    expect(buffer.isOverflow()).toBe(true);
   });
 });
 

--- a/tests/daemon/buffer-drain-job.test.ts
+++ b/tests/daemon/buffer-drain-job.test.ts
@@ -1,0 +1,725 @@
+/**
+ * RC-7 Phase 3: quiescence-gated drain pass + retention completion
+ * (hard cap → quarantine) + post-Stop deferred convergence trigger.
+ *
+ * Grove-scoped shapes reuse the two-database topology from
+ * reconciliation-resurrection.test.ts: the suite's singleton DB plays the
+ * daemon's bootstrap/ANCHOR vault, the Grove owns a REAL on-disk DB at
+ * resolveGroveDbPath, and every per-dir drain body must bind to the
+ * Grove DB.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
+import { sandboxMycoHome } from '../helpers/myco-home-sandbox.js';
+import { nowSec, seedSession } from '../helpers/sessions.js';
+import { createReconciler, type Reconciler, type ReconcilerDeps } from '@myco/daemon/reconciliation.js';
+import { createStopProcessor } from '@myco/daemon/stop-processing.js';
+import { SessionRegistry } from '@myco/daemon/lifecycle.js';
+import { EventDedupCache } from '@myco/daemon/event-dedup-cache.js';
+import { handleUserPrompt } from '@myco/daemon/event-handlers.js';
+import { openDatabase, withDatabase, type Database } from '@myco/db/client.js';
+import { createSchema } from '@myco/db/schema.js';
+import { upsertSession, getSession } from '@myco/db/queries/sessions.js';
+import { listBatchesBySession, closeOpenBatches } from '@myco/db/queries/batches.js';
+import { listActivities } from '@myco/db/queries/activities.js';
+import { listBufferSessionIds, BUFFER_QUARANTINE_DIRNAME } from '@myco/capture/buffer.js';
+import { listAllProjectBufferDirs } from '@myco/capture/buffer-location.js';
+import {
+  clearGroveRegistryCaches,
+  ensureDefaultGrove,
+  registerProjectInGrove,
+  type GroveRecord,
+} from '@myco/grove/registry.js';
+import { createGroveId, createProjectId, ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+import { resolveProjectBufferDir, resolveGroveDbPath } from '@myco/grove/paths.js';
+import {
+  BUFFER_QUIESCENCE_IDLE_MS,
+  BUFFER_HARD_RETENTION_MS,
+  TOMBSTONE_RETENTION_MS,
+  CAPTURE_BUFFER_DRAIN_SESSION_CAP,
+} from '@myco/constants.js';
+
+const silentLogger = {
+  debug: () => {}, info: () => {}, warn: () => {}, error: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;
+
+interface CapturedLog { kind: string; message: string; data?: Record<string, unknown> }
+
+function makeCapturingLogger() {
+  const infos: CapturedLog[] = [];
+  const warns: CapturedLog[] = [];
+  const logger = {
+    debug: () => {},
+    error: () => {},
+    info: (kind: string, message: string, data?: Record<string, unknown>) => { infos.push({ kind, message, ...(data ? { data } : {}) }); },
+    warn: (kind: string, message: string, data?: Record<string, unknown>) => { warns.push({ kind, message, ...(data ? { data } : {}) }); },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+  return { logger, infos, warns };
+}
+
+// Satisfies the any_agent transcript_path_missing drop rule's negation
+// (the file itself need not exist).
+const TRANSCRIPT = '/tmp/myco-test-transcripts/session.jsonl';
+
+function iso(msAgo: number): string {
+  return new Date(Date.now() - msAgo).toISOString();
+}
+
+describe('Capture buffer drain — quiescence gate, backoff, cap, retention (Grove-scoped)', () => {
+  let sandbox: ReturnType<typeof sandboxMycoHome>;
+  let grove: GroveRecord;
+  let groveDb: Database;
+  let projectId: string;
+  let projectRoot: string;
+  let bufferDir: string;
+
+  beforeAll(() => { setupTestDb(); });
+  afterAll(teardownTestDb);
+
+  beforeEach(() => {
+    cleanTestDb();
+    sandbox = sandboxMycoHome('myco-drain-');
+    clearGroveRegistryCaches();
+    grove = ensureDefaultGrove(sandbox.mycoHome);
+    projectId = createProjectId();
+    projectRoot = path.join(sandbox.mycoHome, 'workspace', 'drain-project');
+    fs.mkdirSync(projectRoot, { recursive: true });
+    registerProjectInGrove(grove.id, {
+      projectId,
+      projectName: 'drain-project',
+      projectRoot,
+    }, sandbox.mycoHome);
+    bufferDir = resolveProjectBufferDir(grove.id, projectId, sandbox.mycoHome);
+    fs.mkdirSync(bufferDir, { recursive: true });
+    groveDb = openDatabase(resolveGroveDbPath(grove.id, sandbox.mycoHome));
+    createSchema(groveDb);
+  });
+
+  afterEach(() => {
+    groveDb.close();
+    clearGroveRegistryCaches();
+    sandbox.restore();
+  });
+
+  function inGrove<T>(fn: () => T): T {
+    return withDatabase(groveDb, fn);
+  }
+
+  function bufferPathFor(sessionId: string, dir = bufferDir): string {
+    return path.join(dir, `${sessionId}.jsonl`);
+  }
+
+  function writeBuffer(sessionId: string, events: Array<Record<string, unknown>>, dir = bufferDir): void {
+    fs.writeFileSync(
+      bufferPathFor(sessionId, dir),
+      events.map((e) => JSON.stringify(e)).join('\n') + '\n',
+    );
+  }
+
+  /** Push a file's mtime into the past without touching content. */
+  function ageFile(filePath: string, ageMs: number): void {
+    const past = new Date(Date.now() - ageMs);
+    fs.utimesSync(filePath, past, past);
+  }
+
+  function makeReconciler(
+    overrides: Partial<ReconcilerDeps> = {},
+  ): Reconciler {
+    return createReconciler({
+      bufferDirs: () => [bufferDir],
+      logger: silentLogger,
+      projectRoot,
+      machineId: 'test-machine',
+      ...overrides,
+    });
+  }
+
+  function seedGroveSession(sessionId: string, status: 'active' | 'completed' = 'active'): void {
+    inGrove(() => upsertSession({
+      id: sessionId, agent: 'claude-code', status,
+      started_at: nowSec(), created_at: nowSec(), project_id: projectId,
+    }));
+  }
+
+  // -- Shape 8: the quiescence gate -----------------------------------------
+
+  it('skips a session with an OPEN batch; skips again until 5min idle after the batch closes; then drains', () => {
+    const sessionId = 'quiesce-open-001';
+    seedGroveSession(sessionId);
+    inGrove(() => handleUserPrompt(sessionId, 'live turn', { kind: 'initial' }));
+
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'live turn', origin: 'human', agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(30_000) },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'make wedge' }, agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(20_000) },
+    ]);
+
+    const reconciler = makeReconciler();
+
+    // Open batch → ineligible, regardless of buffer idle time.
+    let summary = reconciler.runDrainPass();
+    expect(summary.skippedQuiescent).toBe(1);
+    expect(summary.drained).toBe(0);
+    expect(inGrove(() => listActivities({ session_id: sessionId, scope: ALL_PROJECTS_SCOPE }))).toHaveLength(0);
+
+    // Batch closed but the buffer is still fresh → still ineligible.
+    inGrove(() => closeOpenBatches(sessionId, nowSec()));
+    summary = reconciler.runDrainPass();
+    expect(summary.skippedQuiescent).toBe(1);
+    expect(summary.drained).toBe(0);
+
+    // Idle past the quiescence window → drains; the wedge event replays.
+    ageFile(bufferPathFor(sessionId), BUFFER_QUIESCENCE_IDLE_MS + 60_000);
+    summary = reconciler.runDrainPass();
+    expect(summary.drained).toBe(1);
+    const activities = inGrove(() => listActivities({ session_id: sessionId, scope: ALL_PROJECTS_SCOPE }));
+    expect(activities.filter((a) => a.tool_name === 'Bash')).toHaveLength(1);
+    // Prompt converged against the stored batch — no duplicate.
+    expect(inGrove(() => listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE }))).toHaveLength(1);
+
+    // Converged-map skip: the next pass doesn't touch the session.
+    summary = reconciler.runDrainPass();
+    expect(summary.attempted).toBe(0);
+  });
+
+  it('drains a CLOSED session immediately — no idle requirement', () => {
+    const sessionId = 'quiesce-closed-002';
+    seedGroveSession(sessionId, 'completed');
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'finished work', origin: 'human', agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(30_000) },
+    ]);
+    // Buffer mtime is NOW — only the closed status makes it eligible.
+
+    const summary = makeReconciler().runDrainPass();
+    expect(summary.drained).toBe(1);
+    const batches = inGrove(() => listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE }));
+    expect(batches).toHaveLength(1);
+    expect(batches[0].user_prompt).toBe('finished work');
+  });
+
+  it('drains a row-absent buffer immediately (resurrection path — no live turn by construction)', () => {
+    const sessionId = 'quiesce-absent-003';
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'offline session', origin: 'human', agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(30_000) },
+    ]);
+
+    const summary = makeReconciler().runDrainPass();
+    expect(summary.drained).toBe(1);
+    const session = inGrove(() => getSession(sessionId, ALL_PROJECTS_SCOPE))!;
+    expect(session).not.toBeNull();
+    expect(session.project_id).toBe(projectId);
+  });
+
+  // -- Shape 9: shared dedup cache across drain replay + late live retry ----
+
+  it('a delayed live retry of a drain-replayed event is suppressed by the shared dedup cache', () => {
+    const sessionId = 'drain-dedup-009';
+    seedGroveSession(sessionId, 'completed');
+    const toolEvent = {
+      type: 'tool_use',
+      tool_name: 'Bash',
+      tool_input: { command: 'npm test' },
+      agent: 'claude-code',
+      transcript_path: TRANSCRIPT,
+      timestamp: iso(30_000),
+    };
+    writeBuffer(sessionId, [toolEvent]);
+
+    const eventDedupCache = new EventDedupCache();
+    const summary = makeReconciler({ eventDedupCache }).runDrainPass();
+    expect(summary.drained).toBe(1);
+    expect(
+      inGrove(() => listActivities({ session_id: sessionId, scope: ALL_PROJECTS_SCOPE }))
+        .filter((a) => a.tool_name === 'Bash'),
+    ).toHaveLength(1);
+
+    // The hook's delayed live retry of the same physical event hits the
+    // shared cache (replay-time stamp) and is rejected as a duplicate.
+    expect(eventDedupCache.isDuplicate(
+      { ...toolEvent, session_id: sessionId } as { type: string; session_id: string } & Record<string, unknown>,
+      Date.now(),
+    )).toBe(true);
+  });
+
+  // -- Shape 11: fresh torn tail defers without backoff ----------------------
+
+  it('a fresh torn tail defers the pass (no failure recorded); the next pass drains once the file is idle', () => {
+    const sessionId = 'torn-tail-011';
+    seedGroveSession(sessionId, 'completed');
+    fs.writeFileSync(bufferPathFor(sessionId),
+      JSON.stringify({ type: 'user_prompt', prompt: 'before the tear', origin: 'human', agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(30_000) }) + '\n'
+      + '{"type":"user_prompt","pro', // torn mid-append
+    );
+
+    const reconciler = makeReconciler();
+
+    // Fresh file (mtime = now) → torn line may still be an in-flight
+    // append → pass defers. NOT a drain failure: no backoff.
+    let summary = reconciler.runDrainPass();
+    expect(summary.attempted).toBe(1);
+    expect(summary.drained).toBe(0);
+    expect(summary.failed).toBe(0);
+    expect(inGrove(() => listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE }))).toHaveLength(0);
+
+    // Idle file → the torn line is permanent damage: excluded, the rest
+    // replays on the very NEXT pass (no backoff window to wait out).
+    ageFile(bufferPathFor(sessionId), 30_000);
+    summary = reconciler.runDrainPass();
+    expect(summary.drained).toBe(1);
+    const batches = inGrove(() => listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE }));
+    expect(batches).toHaveLength(1);
+    expect(batches[0].user_prompt).toBe('before the tear');
+  });
+
+  // -- Shape 19: lazy bufferDirs --------------------------------------------
+
+  it('sees a project registered AFTER reconciler construction without a restart (lazy dirs)', () => {
+    const reconciler = createReconciler({
+      bufferDirs: () => listAllProjectBufferDirs(sandbox.mycoHome),
+      logger: silentLogger,
+      projectRoot,
+      machineId: 'test-machine',
+    });
+
+    // Nothing anywhere yet.
+    expect(reconciler.runDrainPass().attempted).toBe(0);
+
+    // A new project registers mid-lifetime; its buffer appears.
+    const lateProjectId = createProjectId();
+    const lateRoot = path.join(sandbox.mycoHome, 'workspace', 'late-project');
+    fs.mkdirSync(lateRoot, { recursive: true });
+    registerProjectInGrove(grove.id, {
+      projectId: lateProjectId,
+      projectName: 'late-project',
+      projectRoot: lateRoot,
+    }, sandbox.mycoHome);
+    const lateBufferDir = resolveProjectBufferDir(grove.id, lateProjectId, sandbox.mycoHome);
+    fs.mkdirSync(lateBufferDir, { recursive: true });
+    const sessionId = 'late-project-019';
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'first prompt in the new project', origin: 'human', agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(30_000) },
+    ], lateBufferDir);
+
+    const summary = reconciler.runDrainPass();
+    expect(summary.drained).toBe(1);
+    expect(inGrove(() => getSession(sessionId, ALL_PROJECTS_SCOPE))).not.toBeNull();
+  });
+
+  // -- Per-session failure backoff -------------------------------------------
+
+  it('an erroring session sits out 2^failures passes and recovers after a successful attempt', () => {
+    const sessionId = 'backoff-005';
+    // Row-absent FRESH buffer → resurrection registers in the registry;
+    // a throwing register is the injected failure.
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'poisoned for a while', origin: 'human', agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(10_000) },
+    ]);
+
+    let allowRegister = false;
+    const registry = {
+      register: () => {
+        if (!allowRegister) throw new Error('injected registry failure');
+      },
+    };
+    const reconciler = makeReconciler({ registry: registry as never });
+
+    // Pass 1: the attempt throws → failure recorded, 2^1 = 2 passes of backoff.
+    let summary = reconciler.runDrainPass();
+    expect(summary.failed).toBe(1);
+    expect(summary.drained).toBe(0);
+
+    // Passes 2 and 3: skipped under backoff — no attempt, no further failures.
+    summary = reconciler.runDrainPass();
+    expect(summary.skippedBackoff).toBe(1);
+    expect(summary.attempted).toBe(0);
+    summary = reconciler.runDrainPass();
+    expect(summary.skippedBackoff).toBe(1);
+
+    // Pass 4: backoff elapsed and the dep recovered → drains.
+    allowRegister = true;
+    ageFile(bufferPathFor(sessionId), BUFFER_QUIESCENCE_IDLE_MS + 60_000);
+    summary = reconciler.runDrainPass();
+    expect(summary.drained).toBe(1);
+    expect(summary.failed).toBe(0);
+    expect(inGrove(() => listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE }))).toHaveLength(1);
+
+    // Backoff state cleared: next pass is a clean converged-map skip.
+    summary = reconciler.runDrainPass();
+    expect(summary.attempted).toBe(0);
+    expect(summary.skippedBackoff).toBe(0);
+  });
+
+  // -- Per-pass session cap ----------------------------------------------------
+
+  it('caps a pass at the session cap, logs the deferral, and drains the remainder next pass', () => {
+    const total = CAPTURE_BUFFER_DRAIN_SESSION_CAP + 5;
+    for (let i = 0; i < total; i++) {
+      const sessionId = `cap-${String(i).padStart(3, '0')}`;
+      seedGroveSession(sessionId, 'completed');
+      writeBuffer(sessionId, [
+        { type: 'user_prompt', prompt: `prompt ${i}`, origin: 'human', agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(30_000) },
+      ]);
+    }
+
+    const { logger, infos } = makeCapturingLogger();
+    const reconciler = makeReconciler({ logger });
+
+    let summary = reconciler.runDrainPass();
+    expect(summary.attempted).toBe(CAPTURE_BUFFER_DRAIN_SESSION_CAP);
+    expect(summary.drained).toBe(CAPTURE_BUFFER_DRAIN_SESSION_CAP);
+    expect(summary.deferredByCap).toBe(5);
+    expect(infos.some((l) => l.message.includes('per-pass session cap') && l.data?.deferred === 5)).toBe(true);
+
+    // Remainder drains on the next pass; converged sessions skip.
+    summary = reconciler.runDrainPass();
+    expect(summary.drained).toBe(5);
+    expect(summary.deferredByCap).toBe(0);
+  });
+
+  // -- Retention completion: hard cap → quarantine → prune ---------------------
+
+  it('quarantines a diverging buffer past the hard cap (WARN with unmatched count), excludes it from enumeration, and prunes it past tombstone retention', () => {
+    // A stale-dir orphan: grove-shaped dir whose project id is NOT a
+    // current registration. Resurrection refuses it, so it stays
+    // diverging forever — the exact shape the hard cap exists for.
+    const staleDir = resolveProjectBufferDir(grove.id, createProjectId(), sandbox.mycoHome);
+    fs.mkdirSync(staleDir, { recursive: true });
+    const sessionId = 'quarantine-016';
+    const age = BUFFER_HARD_RETENTION_MS + 60 * 60_000;
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'orphaned work', origin: 'human', agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(age) },
+      { type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'ls' }, agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(age) },
+    ], staleDir);
+    ageFile(bufferPathFor(sessionId, staleDir), age);
+
+    const { logger, warns } = makeCapturingLogger();
+    const reconciler = createReconciler({
+      bufferDirs: () => [bufferDir, staleDir],
+      logger,
+      projectRoot,
+      machineId: 'test-machine',
+    });
+
+    reconciler.runDrainPass();
+
+    // Moved, not deleted — preserving the only copy of unreplayed events.
+    const quarantinedPath = path.join(staleDir, BUFFER_QUARANTINE_DIRNAME, `${sessionId}.jsonl`);
+    expect(fs.existsSync(bufferPathFor(sessionId, staleDir))).toBe(false);
+    expect(fs.existsSync(quarantinedPath)).toBe(true);
+    const warn = warns.find((w) => w.message.includes('quarantined'));
+    expect(warn).toBeDefined();
+    expect(warn!.data?.session_id).toBe(sessionId);
+    // Both replayable events have no stored counterpart in the Grove DB.
+    expect(warn!.data?.unmatched_events).toBe(2);
+
+    // Quarantine is excluded from buffer enumeration: not listed, and a
+    // fresh drain pass finds nothing to do (no resurrection from quarantine).
+    expect(listBufferSessionIds(staleDir)).toEqual([]);
+    const after = reconciler.runDrainPass();
+    expect(after.attempted).toBe(0);
+    expect(inGrove(() => getSession(sessionId, ALL_PROJECTS_SCOPE))).toBeNull();
+
+    // Quarantined files older than the tombstone window are pruned.
+    ageFile(quarantinedPath, TOMBSTONE_RETENTION_MS + 60 * 60_000);
+    reconciler.cleanStaleBuffers();
+    expect(fs.existsSync(quarantinedPath)).toBe(false);
+  });
+
+  it('evicts the converged-map entry when cleanup deletes a buffer — a recreated identical file re-converges instead of being skipped', () => {
+    const sessionId = 'evict-on-delete-017';
+    seedGroveSession(sessionId, 'completed');
+    const dayPlus = 25 * 60 * 60 * 1000;
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'old converged work', origin: 'human', agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(dayPlus) },
+    ]);
+
+    const reconciled: string[] = [];
+    const reconciler = makeReconciler({
+      onSessionReconciled: (id) => { reconciled.push(id); },
+    });
+
+    // Age FIRST, then converge, so the mark records the file's final
+    // identity (the age gate requires mark CURRENCY). Snapshot the
+    // identity for the recreation below.
+    ageFile(bufferPathFor(sessionId), dayPlus);
+    reconciler.reconcileSession(sessionId);
+    expect(reconciled).toEqual([sessionId]);
+    const stat = fs.statSync(bufferPathFor(sessionId));
+
+    // Cleanup: converged (current mark) + closed past the stale window →
+    // deleted, and the converged-map entry must be evicted with it.
+    expect(reconciler.cleanStaleBuffers()).toBe(1);
+    expect(fs.existsSync(bufferPathFor(sessionId))).toBe(false);
+
+    // Recreate the file byte-identical AND mtime-identical. Without
+    // eviction the stale mark would match and the pass would never run.
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'old converged work', origin: 'human', agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(dayPlus) },
+    ]);
+    fs.utimesSync(bufferPathFor(sessionId), stat.atime, stat.mtime);
+    reconciler.reconcileSession(sessionId);
+    expect(reconciled).toEqual([sessionId, sessionId]);
+    // Content matched the stored batch — re-convergence, not duplication.
+    expect(inGrove(() => listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE }))).toHaveLength(1);
+  });
+
+  // Regression (probe-proven): a STALE mark must never qualify a buffer
+  // for the 24h age gate. Converged at identity I1, a late wedge event
+  // appends (I2); the file is then the only durable copy of that event
+  // and must ride retention to quarantine, not be deleted at 1d.
+  it('retains a closed session whose buffer changed after convergence (stale mark) at 25h, then quarantines it at the 7d cap', () => {
+    const sessionId = 'stale-mark-retention-020';
+    seedGroveSession(sessionId, 'completed');
+    writeBuffer(sessionId, [
+      { type: 'user_prompt', prompt: 'converged turn', origin: 'human', agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(60_000) },
+    ]);
+
+    const reconciler = makeReconciler();
+    reconciler.reconcileSession(sessionId); // mark at identity I1
+    expect(reconciler.hasUnconvergedBuffer(sessionId)).toBe(false);
+
+    // Late wedge event lands in the buffer only → identity I2, mark stale.
+    fs.appendFileSync(bufferPathFor(sessionId),
+      JSON.stringify({ type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'make wedge' }, agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(30_000) }) + '\n',
+    );
+    expect(reconciler.hasUnconvergedBuffer(sessionId)).toBe(true);
+
+    // 25h idle: the closed+marked session would pass a presence-only
+    // check — currency keeps the only copy of the wedge event alive.
+    ageFile(bufferPathFor(sessionId), 25 * 60 * 60 * 1000);
+    expect(reconciler.cleanStaleBuffers()).toBe(0);
+    expect(fs.existsSync(bufferPathFor(sessionId))).toBe(true);
+
+    // Past the hard cap it is QUARANTINED (preserved), never deleted.
+    ageFile(bufferPathFor(sessionId), BUFFER_HARD_RETENTION_MS + 60 * 60_000);
+    reconciler.cleanStaleBuffers();
+    expect(fs.existsSync(bufferPathFor(sessionId))).toBe(false);
+    expect(fs.existsSync(path.join(bufferDir, BUFFER_QUARANTINE_DIRNAME, `${sessionId}.jsonl`))).toBe(true);
+  });
+
+  // -- Cap fairness ------------------------------------------------------------
+
+  it('quiescence-skips consume no cap slots — a drainable session behind cap-many gated sessions drains in the SAME pass', () => {
+    // CAP sessions that are NOT quiescent (active, open batch, fresh buffer).
+    for (let i = 0; i < CAPTURE_BUFFER_DRAIN_SESSION_CAP; i++) {
+      const sessionId = `gated-${String(i).padStart(3, '0')}`;
+      seedGroveSession(sessionId);
+      inGrove(() => handleUserPrompt(sessionId, `open turn ${i}`, { kind: 'initial' }));
+      writeBuffer(sessionId, [
+        { type: 'user_prompt', prompt: `open turn ${i}`, origin: 'human', agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(10_000) },
+      ]);
+    }
+    // One drainable session (closed → quiescent immediately).
+    const drainableId = 'cap-fair-drainable';
+    seedGroveSession(drainableId, 'completed');
+    writeBuffer(drainableId, [
+      { type: 'user_prompt', prompt: 'should not be starved', origin: 'human', agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(30_000) },
+    ]);
+
+    const summary = makeReconciler().runDrainPass();
+    expect(summary.skippedQuiescent).toBe(CAPTURE_BUFFER_DRAIN_SESSION_CAP);
+    expect(summary.deferredByCap).toBe(0);
+    expect(summary.drained).toBe(1);
+    expect(inGrove(() => listBatchesBySession(drainableId, { scope: ALL_PROJECTS_SCOPE }))).toHaveLength(1);
+  });
+
+  it('scan rotation: cap-many undrainable diverging buffers cannot starve a drainable one past the next pass', () => {
+    // CAP benign-deferred buffers: row-absent, no replayable content —
+    // every pass attempts them (consuming cap slots) and defers them for
+    // retention. They never converge and never back off.
+    for (let i = 0; i < CAPTURE_BUFFER_DRAIN_SESSION_CAP; i++) {
+      writeBuffer(`undrainable-${String(i).padStart(3, '0')}`, [
+        { type: 'session_start', agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(30_000) },
+      ]);
+    }
+    const drainableId = 'rotation-drainable';
+    seedGroveSession(drainableId, 'completed');
+    writeBuffer(drainableId, [
+      { type: 'user_prompt', prompt: 'reached by rotation', origin: 'human', agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(30_000) },
+    ]);
+
+    const reconciler = makeReconciler();
+    // CAP+1 cap-consuming candidates → exactly one is cap-deferred in
+    // pass 1, whichever it is. Rotation starts pass 2 right after pass
+    // 1's last consumed slot, so the deferred candidate goes first: the
+    // drainable session converges within two passes, deterministically.
+    const first = reconciler.runDrainPass();
+    expect(first.deferredByCap).toBe(1);
+    const second = reconciler.runDrainPass();
+    expect(first.drained + second.drained).toBe(1);
+    expect(inGrove(() => listBatchesBySession(drainableId, { scope: ALL_PROJECTS_SCOPE }))).toHaveLength(1);
+  });
+
+  // -- Quarantine prune for unavailable Groves ----------------------------------
+
+  it('prunes expired quarantined files in a dir whose Grove DB is unavailable (fs-only path)', () => {
+    // Grove-shaped dir for a grove with NO DB file → scope 'unavailable'.
+    const ghostGroveId = createGroveId();
+    const ghostDir = resolveProjectBufferDir(ghostGroveId, createProjectId(), sandbox.mycoHome);
+    const ghostQuarantine = path.join(ghostDir, BUFFER_QUARANTINE_DIRNAME);
+    fs.mkdirSync(ghostQuarantine, { recursive: true });
+    const quarantinedPath = path.join(ghostQuarantine, 'ghost-session.jsonl');
+    fs.writeFileSync(quarantinedPath, JSON.stringify({ type: 'user_prompt', prompt: 'long gone' }) + '\n');
+    ageFile(quarantinedPath, TOMBSTONE_RETENTION_MS + 60 * 60_000);
+
+    const reconciler = createReconciler({
+      bufferDirs: () => [ghostDir],
+      logger: silentLogger,
+      projectRoot,
+      machineId: 'test-machine',
+    });
+    reconciler.cleanStaleBuffers();
+    expect(fs.existsSync(quarantinedPath)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Post-Stop deferred convergence trigger (ambient single-DB harness — the
+// trigger mechanism is DB-agnostic; Grove binding is covered above).
+// ---------------------------------------------------------------------------
+
+describe('Post-Stop deferred convergence trigger', () => {
+  let tmpDir: string;
+  let bufferDir: string;
+  let vaultDir: string;
+
+  beforeAll(() => { setupTestDb(); });
+  afterAll(teardownTestDb);
+
+  beforeEach(() => {
+    cleanTestDb();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-poststop-'));
+    bufferDir = path.join(tmpDir, 'buffer');
+    vaultDir = path.join(tmpDir, 'vault');
+    fs.mkdirSync(bufferDir, { recursive: true });
+    fs.mkdirSync(vaultDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeStopProcessor(onStopProcessed: (sessionId: string) => void) {
+    return createStopProcessor({
+      registry: new SessionRegistry({ gracePeriod: 1, onEmpty: () => {} }),
+      sessionBuffers: new Map(),
+      transcriptMiner: {
+        getAllTurnsWithSource: () => ({ turns: [], source: 'transcript' }),
+        reconcileBatchKinds: () => {},
+      } as never,
+      embeddingManager: { onRemoved: () => {} } as never,
+      resolveEmbeddingManager: () => ({ onRemoved: () => {} } as never),
+      logger: silentLogger,
+      liveConfig: { current: { agent: { event_tasks_enabled: false } } } as never,
+      vaultDir,
+      projectId: null,
+      planTags: [],
+      planWatchConfig: { watchDirs: [], projectRoot: vaultDir },
+      onStopProcessed,
+    });
+  }
+
+  /** Drain the stop queue AND the deferred (setImmediate) trigger. */
+  async function settle(processor: { getActiveProcessing: () => Promise<void> | null }): Promise<void> {
+    await processor.getActiveProcessing();
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+
+  it('replays a wedge-buffered mid-session event at the Stop boundary without a restart', async () => {
+    const sessionId = 's-poststop-wedge';
+    seedSession({ id: sessionId, agent: 'claude-code' });
+    handleUserPrompt(sessionId, 'hello', { kind: 'initial' });
+
+    const reconciler = createReconciler({
+      bufferDirs: () => [bufferDir],
+      logger: silentLogger,
+      projectRoot: process.cwd(),
+    });
+
+    // Converge once so the mark exists (live-path equivalent state).
+    fs.writeFileSync(path.join(bufferDir, `${sessionId}.jsonl`),
+      JSON.stringify({ type: 'user_prompt', prompt: 'hello', timestamp: iso(30_000) }) + '\n',
+    );
+    reconciler.reconcileSession(sessionId);
+
+    // Mid-turn, the daemon wedges: a tool event lands ONLY in the buffer
+    // (hook fallback). The mark is now stale.
+    fs.appendFileSync(path.join(bufferDir, `${sessionId}.jsonl`),
+      JSON.stringify({ type: 'tool_use', tool_name: 'Bash', tool_input: { command: 'make wedge' }, agent: 'claude-code', timestamp: iso(5_000) }) + '\n',
+    );
+
+    const processor = makeStopProcessor((id) => reconciler.reconcileSession(id));
+    await processor.handleStopRoute({
+      body: { session_id: sessionId, agent: 'claude-code', last_assistant_message: 'turn done' },
+    } as never);
+    await settle(processor);
+
+    // The deferred trigger re-converged THIS session: wedge event recovered.
+    const activities = listActivities({ session_id: sessionId, scope: ALL_PROJECTS_SCOPE });
+    expect(activities.filter((a) => a.tool_name === 'Bash')).toHaveLength(1);
+    // No duplicate batch — the stored prompt converged.
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(1);
+  });
+
+  it('does NOT run a pass when the converged mark still matches the buffer', async () => {
+    const sessionId = 's-poststop-noop';
+    seedSession({ id: sessionId, agent: 'claude-code' });
+    handleUserPrompt(sessionId, 'hello', { kind: 'initial' });
+
+    const reconciled: string[] = [];
+    const reconciler = createReconciler({
+      bufferDirs: () => [bufferDir],
+      logger: silentLogger,
+      projectRoot: process.cwd(),
+      onSessionReconciled: (id) => { reconciled.push(id); },
+    });
+
+    fs.writeFileSync(path.join(bufferDir, `${sessionId}.jsonl`),
+      JSON.stringify({ type: 'user_prompt', prompt: 'hello', timestamp: iso(30_000) }) + '\n',
+    );
+    reconciler.reconcileSession(sessionId);
+    expect(reconciled).toEqual([sessionId]);
+
+    // Stop fires; the buffer is unchanged since the converged pass, so
+    // the trigger's identity check short-circuits — no second pass.
+    const processor = makeStopProcessor((id) => reconciler.reconcileSession(id));
+    await processor.handleStopRoute({
+      body: { session_id: sessionId, agent: 'claude-code', last_assistant_message: 'turn done' },
+    } as never);
+    await settle(processor);
+
+    expect(reconciled).toEqual([sessionId]);
+  });
+
+  it('a throwing trigger is contained — the stop chain settles and a later Stop still processes', async () => {
+    const sessionId = 's-poststop-throw';
+    seedSession({ id: sessionId, agent: 'claude-code' });
+    handleUserPrompt(sessionId, 'hello', { kind: 'initial' });
+
+    let calls = 0;
+    const processor = makeStopProcessor(() => {
+      calls++;
+      throw new Error('injected trigger failure');
+    });
+    await processor.handleStopRoute({
+      body: { session_id: sessionId, agent: 'claude-code', last_assistant_message: 'first' },
+    } as never);
+    await settle(processor);
+    expect(calls).toBe(1);
+
+    // The queue is healthy: a second Stop runs to completion.
+    await processor.handleStopRoute({
+      body: { session_id: sessionId, agent: 'claude-code', last_assistant_message: 'second' },
+    } as never);
+    await settle(processor);
+    expect(calls).toBe(2);
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batches[0].response_summary).toBe('first');
+  });
+});

--- a/tests/daemon/reconciliation-cache-poisoning.test.ts
+++ b/tests/daemon/reconciliation-cache-poisoning.test.ts
@@ -50,7 +50,7 @@ describe('Buffer reconciliation — cache poisoning protection', () => {
       JSON.stringify({ type: 'user_prompt', prompt: promptText, timestamp: '2026-05-18T17:37:20.907Z' }) + '\n',
     );
 
-    const reconciler = createReconciler({ bufferDirs: [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
+    const reconciler = createReconciler({ bufferDirs: () => [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
 
     // First call: session row not present, no tombstone, and the buffer
     // dir is not a current Grove registration — the identity gate refuses
@@ -80,7 +80,7 @@ describe('Buffer reconciliation — cache poisoning protection', () => {
     seedSession({ id: sessionId, agent: 'claude-code' });
     deleteSessionCascade(sessionId, SESSION_TOMBSTONE_SOURCE.API_DELETE);
 
-    const reconciler = createReconciler({ bufferDirs: [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
+    const reconciler = createReconciler({ bufferDirs: () => [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
     reconciler.reconcileSession(sessionId);
 
     // Skip-not-resurrect: no rows created, buffer gone, marked converged
@@ -95,7 +95,7 @@ describe('Buffer reconciliation — cache poisoning protection', () => {
     const sessionId = 'cache-poison-002';
     seedSession({ id: sessionId, agent: 'claude-code' });
 
-    const reconciler = createReconciler({ bufferDirs: [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
+    const reconciler = createReconciler({ bufferDirs: () => [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
 
     // No buffer file on disk yet — reconciler should silently no-op.
     reconciler.reconcileSession(sessionId);
@@ -114,7 +114,7 @@ describe('Buffer reconciliation — cache poisoning protection', () => {
     expect(batches[0].user_prompt).toBe(promptText);
   });
 
-  it('a successful reconcile still marks the session — a second call is a no-op (existing per-lifetime guard preserved)', () => {
+  it('a successful reconcile marks the session by buffer identity — an unchanged buffer is a no-op; a changed one re-converges without duplicating', () => {
     const sessionId = 'cache-poison-003';
     seedSession({ id: sessionId, agent: 'claude-code' });
 
@@ -123,20 +123,31 @@ describe('Buffer reconciliation — cache poisoning protection', () => {
       JSON.stringify({ type: 'user_prompt', prompt: promptText, timestamp: '2026-05-18T17:37:20.907Z' }) + '\n',
     );
 
-    const reconciler = createReconciler({ bufferDirs: [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
+    const reconciler = createReconciler({ bufferDirs: () => [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
 
     reconciler.reconcileSession(sessionId);
     const batchesAfterFirst = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
     expect(batchesAfterFirst).toHaveLength(1);
 
-    // Append a second event to the buffer. The cache is now marked, so a
-    // second reconcileSession must skip without re-replaying — this is
-    // the existing once-per-lifetime guarantee. If it ever re-replayed,
-    // we'd get duplicate batches.
+    // Identical file → converged-map skip; nothing replays twice.
+    reconciler.reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(1);
+
+    // Append a second event. The mark is now STALE (identity changed), so
+    // the next call re-converges: the already-stored first prompt matches
+    // and is NOT re-inserted; only the new event replays. This is the
+    // identity-keyed mark that lets the post-Stop trigger and the drain
+    // job recover wedge-buffered events without a restart.
     fs.appendFileSync(path.join(bufferDir, `${sessionId}.jsonl`),
       JSON.stringify({ type: 'user_prompt', prompt: 'second prompt', timestamp: '2026-05-18T17:42:00.000Z' }) + '\n',
     );
     reconciler.reconcileSession(sessionId);
-    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(1);
+    const batchesAfterAppend = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batchesAfterAppend).toHaveLength(2);
+    expect(batchesAfterAppend.map((b) => b.user_prompt)).toEqual(['first prompt', 'second prompt']);
+
+    // And the refreshed mark makes the next call a no-op again.
+    reconciler.reconcileSession(sessionId);
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(2);
   });
 });

--- a/tests/daemon/reconciliation-convergence.test.ts
+++ b/tests/daemon/reconciliation-convergence.test.ts
@@ -77,7 +77,7 @@ describe('Buffer reconciliation — content-keyed convergence', () => {
 
   function makeReconciler(logger = silentLogger, eventDedupCache?: EventDedupCache) {
     return createReconciler({
-      bufferDirs: [bufferDir],
+      bufferDirs: () => [bufferDir],
       logger,
       projectRoot: process.cwd(),
       eventDedupCache,

--- a/tests/daemon/reconciliation-dedup.test.ts
+++ b/tests/daemon/reconciliation-dedup.test.ts
@@ -51,7 +51,7 @@ describe('Buffer reconciliation — duplicate suppression', () => {
       JSON.stringify({ type: 'user_prompt', prompt: promptText, timestamp: '2026-05-15T15:55:07.597Z' }) + '\n',
     );
 
-    const reconciler = createReconciler({ bufferDirs: [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
+    const reconciler = createReconciler({ bufferDirs: () => [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
     reconciler.reconcileSession(sessionId);
 
     const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
@@ -77,7 +77,7 @@ describe('Buffer reconciliation — duplicate suppression', () => {
       JSON.stringify({ ...toolEvent, timestamp: '2026-05-15T15:55:01.040Z' }) + '\n',
     );
 
-    const reconciler = createReconciler({ bufferDirs: [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
+    const reconciler = createReconciler({ bufferDirs: () => [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
     reconciler.reconcileSession(sessionId);
 
     expect(countActivities(sessionId, ALL_PROJECTS_SCOPE)).toBe(1);
@@ -97,7 +97,7 @@ describe('Buffer reconciliation — duplicate suppression', () => {
       JSON.stringify({ type: 'user_prompt', prompt: 'continue', timestamp: '2026-05-15T15:00:15.000Z' }) + '\n',
     );
 
-    const reconciler = createReconciler({ bufferDirs: [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
+    const reconciler = createReconciler({ bufferDirs: () => [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
     reconciler.reconcileSession(sessionId);
 
     const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });

--- a/tests/daemon/reconciliation-resurrection.test.ts
+++ b/tests/daemon/reconciliation-resurrection.test.ts
@@ -136,7 +136,7 @@ describe('Buffer reconciliation — tombstones + gate-checked resurrection', () 
     extra: { registry?: { register: (id: string, meta: unknown) => void } } = {},
   ): Reconciler {
     return createReconciler({
-      bufferDirs: dirs,
+      bufferDirs: () => dirs,
       logger,
       projectRoot,
       machineId: 'test-machine',
@@ -440,15 +440,18 @@ describe('Buffer reconciliation — tombstones + gate-checked resurrection', () 
 
     const reconciler = makeReconciler();
 
-    // Converged + closed, 25h old → eligible.
+    // Converged + closed, 25h old → eligible. The file is aged BEFORE the
+    // converging pass so the mark records the file's final identity — the
+    // age gate requires mark CURRENCY, not mere presence (in production
+    // an untouched file keeps its converge-time identity as it ages).
     const convergedId = 'retain-converged-016';
     inGrove(() => upsertSession({ id: convergedId, agent: 'claude-code', started_at: nowSec(), created_at: nowSec(), project_id: projectId }));
     writeBuffer(convergedId, [
       { type: 'user_prompt', prompt: 'done work', origin: 'human', agent: 'claude-code', transcript_path: TRANSCRIPT, timestamp: iso(dayPlus) },
     ]);
+    ageBuffer(convergedId, dayPlus);
     reconciler.reconcileSession(convergedId);
     inGrove(() => closeSession(convergedId, nowSec()));
-    ageBuffer(convergedId, dayPlus);
 
     // Converged but still ACTIVE at 25h → retained.
     const activeId = 'retain-active-016';

--- a/tests/daemon/reconciliation-stop.test.ts
+++ b/tests/daemon/reconciliation-stop.test.ts
@@ -65,7 +65,7 @@ describe('Buffer reconciliation — stop events (opencode response_summary recov
       JSON.stringify({ type: 'stop', last_assistant_message: 'recovered summary', timestamp: new Date().toISOString() }) + '\n',
     );
 
-    const reconciler = createReconciler({ bufferDirs: [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
+    const reconciler = createReconciler({ bufferDirs: () => [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
     reconciler.reconcileSession('s-stop');
 
     const batches = listBatchesBySession('s-stop', { scope: ALL_PROJECTS_SCOPE });
@@ -87,7 +87,7 @@ describe('Buffer reconciliation — stop events (opencode response_summary recov
       JSON.stringify({ type: 'stop', last_assistant_message: 'buffered summary', timestamp: new Date().toISOString() }) + '\n',
     );
 
-    const reconciler = createReconciler({ bufferDirs: [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
+    const reconciler = createReconciler({ bufferDirs: () => [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
     reconciler.reconcileSession('s-stop');
 
     const batches = listBatchesBySession('s-stop', { scope: ALL_PROJECTS_SCOPE });
@@ -104,7 +104,7 @@ describe('Buffer reconciliation — stop events (opencode response_summary recov
       JSON.stringify({ type: 'stop', last_assistant_message: '', timestamp: new Date().toISOString() }) + '\n',
     );
 
-    const reconciler = createReconciler({ bufferDirs: [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
+    const reconciler = createReconciler({ bufferDirs: () => [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
     reconciler.reconcileSession('s-stop');
 
     const batches = listBatchesBySession('s-stop', { scope: ALL_PROJECTS_SCOPE });
@@ -124,7 +124,7 @@ describe('Buffer reconciliation — stop events (opencode response_summary recov
       JSON.stringify({ type: 'stop', last_assistant_message: 'late summary', timestamp: new Date().toISOString() }) + '\n',
     );
 
-    const reconciler = createReconciler({ bufferDirs: [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
+    const reconciler = createReconciler({ bufferDirs: () => [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
     reconciler.reconcileSession('s-stop');
 
     const batches = listBatchesBySession('s-stop', { scope: ALL_PROJECTS_SCOPE });
@@ -146,13 +146,39 @@ describe('Buffer reconciliation — stop events (opencode response_summary recov
       JSON.stringify({ type: 'stop', last_assistant_message: 'should not land', timestamp: new Date().toISOString() }) + '\n',
     );
 
-    const reconciler = createReconciler({ bufferDirs: [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
+    const reconciler = createReconciler({ bufferDirs: () => [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
     reconciler.reconcileSession('s-stop');
 
     const batches = listBatchesBySession('s-stop', { scope: ALL_PROJECTS_SCOPE });
     expect(batches).toHaveLength(1);
     expect(batches[0].ended_at).toBeNull();
     expect(batches[0].response_summary).toBeNull();
+  });
+
+  // Shared human-anchor resolution (resolveResponseSummaryTarget): a
+  // trailing SYSTEM batch (a <task-notification> born after the human
+  // prompt) wins getLatestBatch by prompt_number, but the replayed stop's
+  // summary belongs to the human turn — same anchoring as the live path.
+  it('replay stop lands on the latest HUMAN batch when a trailing system batch is the latest', () => {
+    const { batchId: humanBatchId } = handleUserPrompt('s-stop', 'real question', { kind: 'initial' });
+    backdateBatch(humanBatchId, STALE_AGE_SECONDS);
+    const { batchId: systemBatchId } = handleUserPrompt('s-stop', '<task-notification>done</task-notification>', { origin: 'system' });
+    backdateBatch(systemBatchId, STALE_AGE_SECONDS);
+
+    const bufferPath = path.join(bufferDir, 's-stop.jsonl');
+    fs.writeFileSync(bufferPath,
+      JSON.stringify({ type: 'user_prompt', prompt: 'real question', timestamp: new Date().toISOString() }) + '\n' +
+      JSON.stringify({ type: 'stop', last_assistant_message: 'anchored answer', timestamp: new Date().toISOString() }) + '\n',
+    );
+
+    const reconciler = createReconciler({ bufferDirs: () => [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
+    reconciler.reconcileSession('s-stop');
+
+    const batches = listBatchesBySession('s-stop', { scope: ALL_PROJECTS_SCOPE });
+    const human = batches.find((b) => b.id === humanBatchId)!;
+    const system = batches.find((b) => b.id === systemBatchId)!;
+    expect(human.response_summary).toBe('anchored answer');
+    expect(system.response_summary).toBeNull();
   });
 
   it('recovers onto a STALE open batch without closing it', () => {
@@ -165,7 +191,7 @@ describe('Buffer reconciliation — stop events (opencode response_summary recov
       JSON.stringify({ type: 'stop', last_assistant_message: 'stale-open recovery', timestamp: new Date().toISOString() }) + '\n',
     );
 
-    const reconciler = createReconciler({ bufferDirs: [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
+    const reconciler = createReconciler({ bufferDirs: () => [bufferDir], logger: silentLogger, projectRoot: process.cwd() });
     reconciler.reconcileSession('s-stop');
 
     const batches = listBatchesBySession('s-stop', { scope: ALL_PROJECTS_SCOPE });

--- a/tests/integration/capture-pipeline-e2e.test.ts
+++ b/tests/integration/capture-pipeline-e2e.test.ts
@@ -272,7 +272,7 @@ function makeDispatcherWithRealReconciler(opts: { bufferDir: string; vaultDir?: 
   });
   const sessionBuffers = new Map();
   const reconciler = createReconciler({
-    bufferDirs: [opts.bufferDir],
+    bufferDirs: () => [opts.bufferDir],
     logger: logger as never,
     projectRoot: process.cwd(),
     // This harness is single-DB by design: the Grove is registered (so the


### PR DESCRIPTION
## What

Phase 3 of the approved RC-7 design: buffer replay becomes **continuous** instead of restart-gated. A new `CAPTURE_BUFFER_DRAIN` power job (15 min, per-Grove fan-out) converges quiescent sessions, and a post-Stop deferred reconcile recovers wedge-buffered events at the next turn boundary. No schema changes.

## The design's biggest risk, closed

The design review flagged drain-vs-live-turn interleaving as the structural hazard (replay is append-only; a replayed prompt would close the user's open batch). The adversarial review **proved the quiescence gate is structural, not advisory**: the entire gate-to-replay path is synchronous on the daemon's single event loop — zero await points — so no live event can land between the gate check and replay. Eligibility: row absent / session closed / no open batch + 5-min buffer idle.

## How

- **Identity-keyed converged marks** (size+mtime) replace once-per-lifetime semantics: unchanged files skip in O(stat); appended files re-converge idempotently (Phase 1's content-keyed convergence makes re-passes safe by construction).
- **Cleanup requires mark currency, not presence** — the review's probe showed a diverging buffer with a stale mark could be *deleted* at the 24h gate (the one unrecoverable operation); it now retains and quarantines at the 7-day cap (`buffer/quarantine/`, WARN with unmatched count, excluded from enumeration, pruned at 14d — fs-only so it runs even for groves whose DB vanished).
- **Fair capping**: only real convergence attempts consume the per-pass cap (quiescence skips are free), with a rotating scan cursor — independently probed: capped sessions take the head of the next pass.
- **Per-session exponential backoff** on replay errors — a poisoned event can't hot-loop the job.
- **Post-Stop trigger**: fires off the serialized stop chain's tail (`setImmediate`, self-caught, per-session) only when the buffer identity moved past the mark.
- **Shared human-anchor helper** for stop summary targeting, used by the live path (byte-identical — existing stop-processing tests pass untouched) and replay (P1's staleness guard + pass-created exemption verbatim).
- Lazy `bufferDirs` (mid-lifetime project registrations drainable without restart); dead `EventBuffer` API removed.

## Review trail

Implementation → adversarial probe review (gate proven structural; FIX-FIRST on the mark-presence cleanup hole + cap fairness) → fixes → independent re-verification (fresh probes green incl. the rotation-cursor evidence; SHIP). Two pre-existing tests adjusted with justification: they aged files *after* converging via `utimesSync` with no content change — a state unreachable in production, where a converged file's identity only moves on a write.

## Tests

17-test drain suite (quiescence matrix, dedup suppression, torn-tail retry, lazy dirs, backoff, both cap-fairness shapes, quarantine lifecycle incl. the currency regression probe, post-Stop trigger matrix), human-anchor parity, cache-poisoning re-pinned to the identity contract. Full suite green (all phase JUnit artifacts `failures="0"`); tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)