### PR TITLE
capture: honest hook contract + capture event policy table (RC-7 Phase 4)

### DIFF
--- a/packages/myco/src/capture/dedup.ts
+++ b/packages/myco/src/capture/dedup.ts
@@ -10,11 +10,15 @@
  *      watching the same project). The dispatcher's in-memory dedup cache
  *      catches these and returns `ignored: 'duplicate'`.
  *
- *   2. **Buffer replay path** (`reconciliation.ts`) — the hook CLI writes
- *      the event to the buffer file whenever the daemon returns
- *      `ignored: 'duplicate'` (so reconcile can replay if the dedup was
- *      wrong). Without this helper, the replay re-inserts the duplicate as
- *      a fresh prompt_batch — the original dedup decision evaporates.
+ *   2. **Buffer replay path** (`reconciliation.ts`) — duplicate copies of an
+ *      already-processed event can land in the buffer file: the hook CLI
+ *      buffers on any transport failure (the daemon may have completed the
+ *      work before the response was lost), and against a LEGACY daemon (no
+ *      `persisted` field in the response) it also buffers on `ignored` per
+ *      the policy table's legacy columns (`capture/event-policy.ts`; a
+ *      contract-aware daemon's `ignored` is never buffered). Without this
+ *      helper, the replay re-inserts such a copy as a fresh prompt_batch —
+ *      the original dedup decision evaporates.
  *
  * Both paths must use the SAME fingerprint, or the buffer replay will
  * resurrect events the live path correctly rejected. This module is the

--- a/packages/myco/src/capture/event-policy.ts
+++ b/packages/myco/src/capture/event-policy.ts
@@ -1,0 +1,165 @@
+/**
+ * Capture event policy table — the single source of truth for how each
+ * hook-emitted event type behaves across the capture pipeline:
+ *
+ *   - whether buffer reconciliation replays it after daemon downtime, and
+ *     in what mode;
+ *   - what the hook CLI's buffer-fallback did under the legacy (pre-honest)
+ *     daemon response contract, preserved for mixed-version rollout where a
+ *     new hook binary talks to an older daemon.
+ *
+ * Both sides import from here: the daemon's reconciler derives its
+ * replayable set from the table, and the hooks' shared capture-critical
+ * helper consults the legacy columns when a daemon response carries no
+ * `persisted` field. Per-hook flags are deliberately gone — encoding the
+ * behavior per event type in one table is what keeps the two processes
+ * from drifting.
+ */
+
+/** How reconciliation replays a buffered event of this type. */
+export type CaptureReplayMode =
+  /** Re-applies the manifest capture/origin rules before inserting
+   *  (`classifyNextPromptDecision`) — a buffered drop-rule event is
+   *  re-filtered on replay rather than blindly re-inserted. */
+  | 'regate'
+  /** Inserted directly through the live handler with no re-filtering. */
+  | 'direct'
+  /** NULL-only write against existing rows (stop: sets response_summary
+   *  only while unset); replaying twice is a no-op. */
+  | 'idempotent';
+
+export interface CaptureEventPolicy {
+  /** Buffer reconciliation replays this type after daemon downtime. */
+  replayable: boolean;
+  /** Replay semantics; null for types reconciliation never replays. */
+  replayMode: CaptureReplayMode | null;
+  /**
+   * LEGACY-daemon column: whether the hook buffers when the daemon answers
+   * 200 with `{ ignored: <reason> }`. Only consulted when the response has
+   * no `persisted` field (an older daemon during mixed-version rollout) —
+   * a new daemon's `ignored` is never buffered (ignored ≠ lost).
+   */
+  legacyBufferOnIgnored: boolean;
+  /**
+   * LEGACY-daemon column: which events the hook offers a buffer-fallback
+   * copy for at all.
+   *
+   *   - 'always'       — every event of this type carries a bufferEvent.
+   *   - 'summary-only' — only events with a non-empty assistant response
+   *                      (`stop`: an empty stop never writes a no-op row).
+   *   - 'never'        — the hook POSTs without a buffer fallback.
+   */
+  legacyBufferEvent: 'always' | 'never' | 'summary-only';
+}
+
+/**
+ * One row per event type a capture hook can emit. The legacy columns
+ * encode the exact per-hook behavior that shipped before the honest
+ * `/events` response contract (see each hook in `src/hooks/`).
+ */
+export const CAPTURE_EVENT_POLICY: Readonly<Record<string, CaptureEventPolicy>> = {
+  user_prompt: {
+    replayable: true,
+    replayMode: 'regate',
+    legacyBufferOnIgnored: true,
+    legacyBufferEvent: 'always',
+  },
+  tool_use: {
+    // Replay inserts the activity directly without re-evaluating capture
+    // rules, so a legacy-daemon `ignored` tool must NOT buffer — it would
+    // resurrect a deliberately-dropped activity on the next start.
+    replayable: true,
+    replayMode: 'direct',
+    legacyBufferOnIgnored: false,
+    legacyBufferEvent: 'always',
+  },
+  tool_failure: {
+    replayable: true,
+    replayMode: 'direct',
+    legacyBufferOnIgnored: true,
+    legacyBufferEvent: 'always',
+  },
+  stop: {
+    // POSTs to /events/stop, whose pipeline is queued — the response never
+    // reports a persist outcome, so the stop hook ALWAYS runs under these
+    // legacy columns regardless of daemon version.
+    replayable: true,
+    replayMode: 'idempotent',
+    legacyBufferOnIgnored: true,
+    legacyBufferEvent: 'summary-only',
+  },
+  subagent_start: {
+    replayable: false,
+    replayMode: null,
+    legacyBufferOnIgnored: true,
+    legacyBufferEvent: 'always',
+  },
+  subagent_stop: {
+    replayable: false,
+    replayMode: null,
+    legacyBufferOnIgnored: true,
+    legacyBufferEvent: 'always',
+  },
+  stop_failure: {
+    replayable: false,
+    replayMode: null,
+    legacyBufferOnIgnored: true,
+    legacyBufferEvent: 'always',
+  },
+  task_completed: {
+    replayable: false,
+    replayMode: null,
+    legacyBufferOnIgnored: true,
+    legacyBufferEvent: 'always',
+  },
+  pre_compact: {
+    replayable: false,
+    replayMode: null,
+    legacyBufferOnIgnored: true,
+    legacyBufferEvent: 'always',
+  },
+  post_compact: {
+    replayable: false,
+    replayMode: null,
+    legacyBufferOnIgnored: true,
+    legacyBufferEvent: 'always',
+  },
+  notification: {
+    replayable: false,
+    replayMode: null,
+    legacyBufferOnIgnored: true,
+    legacyBufferEvent: 'always',
+  },
+  error_occurred: {
+    replayable: false,
+    replayMode: null,
+    legacyBufferOnIgnored: true,
+    legacyBufferEvent: 'always',
+  },
+};
+
+/**
+ * Policy lookup with a fail-safe default for unknown types: not replayable,
+ * legacy behavior matching `sendEvent`'s historical defaults (buffer on
+ * ignored, always offer a buffer copy). A type missing from the table is a
+ * drift bug the policy-table test should catch — the default just keeps the
+ * hook fail-open in the field.
+ */
+export function captureEventPolicy(eventType: string | undefined): CaptureEventPolicy {
+  if (eventType !== undefined) {
+    const policy = CAPTURE_EVENT_POLICY[eventType];
+    if (policy) return policy;
+  }
+  return { replayable: false, replayMode: null, legacyBufferOnIgnored: true, legacyBufferEvent: 'always' };
+}
+
+/**
+ * Event types replayed during buffer reconciliation — derived from the
+ * policy table so the reconciler and the hooks can never disagree about
+ * what survives daemon downtime.
+ */
+export const REPLAYABLE_EVENT_TYPES: ReadonlySet<string> = new Set(
+  Object.entries(CAPTURE_EVENT_POLICY)
+    .filter(([, policy]) => policy.replayable)
+    .map(([type]) => type),
+);

--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -104,6 +104,15 @@ export interface EventDispatchDeps {
    * is rejected here. When absent (tests), a private instance is used.
    */
   eventDedupCache?: EventDedupCache;
+  /**
+   * Clear the session's converged mark (the reconciler's identity map) when
+   * a per-type handler fails after the daemon-side buffer append succeeded.
+   * The appended copy is then unconverged by construction, and the next
+   * quiescent boundary (post-Stop trigger / drain pass / boot) replays it —
+   * the recovery mechanism the honest `persisted:false, buffered:true`
+   * response promises hooks, so they don't double-buffer.
+   */
+  clearConvergedMark?: (sessionId: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -233,6 +242,15 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
     } as Record<string, unknown> & { type: string; session_id: string; timestamp: string };
 
     let userPromptBatchId: number | undefined;
+    // Honest response contract: `persisted` reports whether every per-type
+    // handler that ran for this event committed its writes; `buffered`
+    // reports whether the daemon-side buffer append (which runs BEFORE the
+    // handlers) holds a durable copy the reconciler can replay. Types with
+    // no persisting handler (notification, error_occurred, …) report
+    // `persisted: true` — there is nothing to persist, so success is
+    // vacuous and the field still marks this daemon as contract-aware.
+    let handlerFailed = false;
+    let daemonBuffered = false;
     const requestProjectId = rowProjectIdFromRequestContext(req.requestContext);
     const requestProjectRoot = req.requestContext?.projectRoot ?? projectRoot;
     const requestFilesystemRoot = req.requestContext
@@ -254,7 +272,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
       logger.info(LOG_KINDS.HOOKS_EVENT, 'Event suppressed as duplicate within dedup window', {
         type: event.type, session_id: event.session_id,
       });
-      return { body: { ok: true, ignored: 'duplicate' } };
+      return { body: { ok: true, ignored: 'duplicate', persisted: false } };
     }
 
     // Ensure session is registered (idempotent — handles daemon restarts mid-session)
@@ -286,7 +304,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
             type: event.type,
             reason,
           });
-          return { body: { ok: true, ignored: reason } };
+          return { body: { ok: true, ignored: reason, persisted: false } };
         }
         if (shouldReevaluate) {
           droppedSessions.delete(event.session_id);
@@ -299,7 +317,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
             type: event.type,
             reason: decision.reason ?? 'rule',
           });
-          return { body: { ok: true, ignored: decision.reason ?? 'rule' } };
+          return { body: { ok: true, ignored: decision.reason ?? 'rule', persisted: false } };
         }
 
         // Persist + register through the single lifecycle helper. ordering
@@ -361,7 +379,22 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
         sessionBuffers.set(event.session_id, new EventBuffer(bufferDir, event.session_id));
       }
     }
-    sessionBuffers.get(event.session_id)?.append(event);
+    try {
+      const buffer = sessionBuffers.get(event.session_id);
+      if (buffer) {
+        buffer.append(event);
+        daemonBuffered = true;
+      }
+    } catch (err) {
+      // The append failing must not block the live DB path — but the
+      // response below reports `buffered: false` so the hook knows no
+      // daemon-side copy exists and can take the buffer fallback itself.
+      logger.warn(LOG_KINDS.CAPTURE_BUFFER, 'Daemon-side buffer append failed', {
+        session_id: event.session_id,
+        type: event.type,
+        error: String(err),
+      });
+    }
 
     // --- Prompt batch tracking ---
     if (event.type === 'user_prompt') {
@@ -503,6 +536,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
           setTimeout(() => liveReconcile(event.session_id, reconcileAgent, reconcileTranscript), 0);
         }
       } catch (err) {
+        handlerFailed = true;
         logger.warn(LOG_KINDS.CAPTURE_BATCH, 'Failed to open batch', { session_id: event.session_id, error: (err as Error).message });
       }
     }
@@ -573,6 +607,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
           typeof event.transcript_path === 'string' ? event.transcript_path : undefined,
         );
       } catch (err) {
+        handlerFailed = true;
         logger.warn(LOG_KINDS.CAPTURE_ACTIVITY, 'Failed to record activity', { session_id: event.session_id, error: (err as Error).message });
       }
       // Live capture: surface queued prompts + in-flight responses mid-turn.
@@ -634,6 +669,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
           !!event.is_interrupt,
         );
       } catch (err) {
+        handlerFailed = true;
         logger.warn(LOG_KINDS.CAPTURE_ACTIVITY, 'Failed to record tool failure', { session_id: event.session_id, error: (err as Error).message });
       }
     }
@@ -650,6 +686,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
       try {
         handleSubagentStart(event.session_id, agentId, agentType);
       } catch (err) {
+        handlerFailed = true;
         logger.warn(LOG_KINDS.CAPTURE_ACTIVITY, 'Failed to record subagent start', { session_id: event.session_id, error: (err as Error).message });
       }
     }
@@ -665,7 +702,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
           session_id: event.session_id,
           agent_id: agentId,
         });
-        return { body: { ok: true, ignored: 'synthetic-subagent-stop' } };
+        return { body: { ok: true, ignored: 'synthetic-subagent-stop', persisted: false } };
       }
       logger.info(LOG_KINDS.HOOKS_SUBAGENT, 'Subagent stop event', {
         session_id: event.session_id,
@@ -680,6 +717,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
           typeof event.last_assistant_message === 'string' ? event.last_assistant_message : undefined,
         );
       } catch (err) {
+        handlerFailed = true;
         logger.warn(LOG_KINDS.CAPTURE_ACTIVITY, 'Failed to record subagent stop', { session_id: event.session_id, error: (err as Error).message });
       }
     }
@@ -696,6 +734,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
           typeof event.error_details === 'string' ? event.error_details : undefined,
         );
       } catch (err) {
+        handlerFailed = true;
         logger.warn(LOG_KINDS.CAPTURE_ACTIVITY, 'Failed to record stop failure', { session_id: event.session_id, error: (err as Error).message });
       }
     }
@@ -714,6 +753,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
           typeof event.task_description === 'string' ? event.task_description : undefined,
         );
       } catch (err) {
+        handlerFailed = true;
         logger.warn(LOG_KINDS.CAPTURE_ACTIVITY, 'Failed to record task completion', { session_id: event.session_id, error: (err as Error).message });
       }
     }
@@ -728,6 +768,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
           undefined,
         );
       } catch (err) {
+        handlerFailed = true;
         logger.warn(LOG_KINDS.CAPTURE_ACTIVITY, 'Failed to record pre-compact', { session_id: event.session_id, error: (err as Error).message });
       }
     }
@@ -742,10 +783,26 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
           typeof event.compact_summary === 'string' ? event.compact_summary : undefined,
         );
       } catch (err) {
+        handlerFailed = true;
         logger.warn(LOG_KINDS.CAPTURE_ACTIVITY, 'Failed to record post-compact', { session_id: event.session_id, error: (err as Error).message });
       }
     }
 
-    return { body: { ok: true, ...(userPromptBatchId != null ? { batchId: userPromptBatchId } : {}) } };
+    // Honest outcome assembly. A failed handler answers `persisted: false`
+    // plus whether the daemon-side append holds a durable copy:
+    //
+    //   buffered: true  — recovery is daemon-owned. Clear the converged
+    //                     mark so the appended copy replays at the next
+    //                     quiescent boundary; the hook must NOT re-buffer
+    //                     (the double-buffer trap).
+    //   buffered: false — no daemon-side copy exists (the missing-grove/
+    //                     project-context path, or the append itself
+    //                     failed). The hook's buffer fallback is the only
+    //                     durable copy; it should buffer.
+    if (handlerFailed) {
+      deps.clearConvergedMark?.(event.session_id);
+      return { body: { ok: true, persisted: false, buffered: daemonBuffered } };
+    }
+    return { body: { ok: true, persisted: true, ...(userPromptBatchId != null ? { batchId: userPromptBatchId } : {}) } };
   };
 }

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -1236,6 +1236,11 @@ export async function main(): Promise<void> {
     liveConfig,
     vaultDir: bootstrapVaultDir,
     reconcileSession: reconciler.reconcileSession,
+    // Handler-failure recovery: the dispatcher answers `persisted:false,
+    // buffered:true` and clears the converged mark so the daemon-appended
+    // buffer copy replays at the next quiescent boundary (post-Stop
+    // trigger / drain pass / boot) instead of relying on hook re-buffering.
+    clearConvergedMark: reconciler.clearSession,
     liveReconcile,
     planWatchConfig,
     triggerTitleSummary: stopProcessor.triggerTitleSummary,

--- a/packages/myco/src/daemon/reconciliation.ts
+++ b/packages/myco/src/daemon/reconciliation.ts
@@ -61,22 +61,18 @@ import {
   dedupKeyFromActivity,
   isBookkeepingActivity,
 } from '@myco/capture/dedup.js';
+import { REPLAYABLE_EVENT_TYPES } from '@myco/capture/event-policy.js';
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-/** Event types replayed during buffer reconciliation. */
-const REPLAYABLE_EVENT_TYPES: ReadonlySet<string> = new Set([
-  'user_prompt',
-  'tool_use',
-  'tool_failure',
-  // `stop` events carry the last assistant message and need to survive daemon
-  // downtime so response_summary isn't lost when the TUI fires idle during a
-  // restart window. Replay sets the summary on the session's latest batch
-  // without re-running full stop processing (which already ran live).
-  'stop',
-]);
+// Replayed event types come from the shared capture policy table —
+// user_prompt / tool_use / tool_failure replay through the live handlers,
+// and `stop` events carry the last assistant message (replay sets the
+// summary on the session's latest batch without re-running full stop
+// processing, which already ran live). Deriving the set keeps the
+// reconciler and the hook CLI's buffer-fallback policy in lockstep.
 
 /**
  * Row-fetch bound for the convergence multiset. A session's buffer file holds

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -835,7 +835,14 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     });
     activeStopProcessing = chain;
 
-    return { body: { ok: true } };
+    // The stop pipeline is queued — this response returns before
+    // processStopEvent runs, so the route cannot honestly claim
+    // `persisted`. `queued: true` states exactly what is known. The hook
+    // CLI's buffer fallback therefore runs under the policy table's legacy
+    // columns for `stop` (summary-only buffering), by design: replay is
+    // NULL-only idempotent, so a buffered copy of a turn the queue later
+    // persists converges as a no-op.
+    return { body: { ok: true, queued: true } };
   };
 
   return {

--- a/packages/myco/src/hooks/post-tool-use.ts
+++ b/packages/myco/src/hooks/post-tool-use.ts
@@ -30,9 +30,10 @@ export async function main() {
       ? input.toolOutput.slice(0, TOOL_OUTPUT_PREVIEW_CHARS)
       : undefined;
 
-    // bufferOnIgnored: false — tool_use replay (reconciliation.ts) inserts the
-    // activity directly without re-evaluating capture rules, so buffering a
-    // daemon-dropped (`ignored`) tool would resurrect it on the next start.
+    // Buffer-fallback policy lives in the shared capture policy table
+    // (capture/event-policy.ts): tool_use replays directly without
+    // re-evaluating capture rules, so its legacy column never buffers a
+    // daemon-ignored tool — that would resurrect it on the next start.
     // A transport failure (`!ok`) still buffers so reconcile can replay it.
     await captureCriticalEvent({
       vaultDir: VAULT_DIR,
@@ -55,7 +56,6 @@ export async function main() {
         output_preview: outputPreview,
         transcript_path: input.transcriptPath,
       },
-      bufferOnIgnored: false,
     });
   } catch (error) {
     process.stderr.write(`[myco] post-tool-use error: ${(error as Error).message}\n`);

--- a/packages/myco/src/hooks/send-event.ts
+++ b/packages/myco/src/hooks/send-event.ts
@@ -5,23 +5,74 @@ import { type NormalizedHookInput } from './normalize.js';
 import { readHookInput } from './input.js';
 import { EventBuffer } from '../capture/buffer.js';
 import { resolveProjectBufferDirFromRoot } from '../capture/buffer-location.js';
+import { captureEventPolicy } from '../capture/event-policy.js';
 import { resolveProjectRoot } from '../vault/resolve.js';
 import { resolveProvisionedVaultDir } from './vault-gate.js';
 import { writeHookResponse } from './response.js';
 
 type ClientResult = Awaited<ReturnType<DaemonClient['capturePost']>>;
 
+function responseField(data: unknown, field: string): unknown {
+  if (typeof data !== 'object' || data === null) return undefined;
+  return (data as Record<string, unknown>)[field];
+}
+
+/**
+ * The hook-side buffer-fallback decision over the daemon's honest response
+ * contract. One row per response shape:
+ *
+ *   - `!ok` (transport failure, timeout, non-2xx)        → BUFFER. The
+ *     daemon may have completed the work before the failure; content-keyed
+ *     convergence collapses that duplicate on replay.
+ *   - `ok` + `persisted: true`                           → nothing.
+ *   - `ok` + `persisted: false` + `buffered: true`       → nothing. The
+ *     daemon-side append is the durable copy and the daemon cleared the
+ *     session's converged mark; hook re-buffering is the double-buffer trap.
+ *   - `ok` + `persisted: false` + `buffered: false`      → BUFFER. The one
+ *     honest-fallback case: the daemon could not persist AND holds no
+ *     buffered copy (missing grove/project request context, append failure).
+ *   - `ok` + `ignored` + `persisted` present             → never buffer. A
+ *     contract-aware daemon's ignore is deliberate (capture rule, dedup,
+ *     tombstone) — ignored ≠ lost, and buffering it re-creates the noise
+ *     the gated-resurrection path exists to refuse.
+ *   - `ok` with NO `persisted` field (LEGACY daemon during mixed-version
+ *     rollout, and every /events/stop response — the stop pipeline is
+ *     queued and never reports a persist outcome) → the policy table's
+ *     legacy columns: buffer on `ignored` only when the event type's
+ *     `legacyBufferOnIgnored` says so.
+ */
+export function shouldBufferFallback(
+  result: { ok: boolean; data?: unknown },
+  eventType: string | undefined,
+): boolean {
+  if (!result.ok) return true;
+  const persisted = responseField(result.data, 'persisted');
+  if (typeof persisted === 'boolean') {
+    if (isIgnoredEventResponse(result.data)) return false;
+    if (persisted) return false;
+    return responseField(result.data, 'buffered') !== true;
+  }
+  if (isIgnoredEventResponse(result.data)) {
+    return captureEventPolicy(eventType).legacyBufferOnIgnored;
+  }
+  return false;
+}
+
 /**
  * Classify why a hook is falling back to a buffer write. Surfaces in stderr
  * so a "session not captured" investigation can answer "did the hook reach
  * the daemon at all?" without inspecting buffer-file byte counts. Matches
- * the failure modes in `DaemonClient.capturePost`.
+ * the failure modes in `DaemonClient.capturePost` plus the honest-contract
+ * `persisted:false, buffered:false` outcome.
  */
 export function classifyBufferFallback(result: { ok: boolean; data?: unknown }): string {
   if (result.ok) {
     if (isIgnoredEventResponse(result.data)) {
       const ignored = (result.data as { ignored?: unknown } | undefined)?.ignored;
       return `daemon-ignored:${typeof ignored === 'string' ? ignored : 'unknown'}`;
+    }
+    if (responseField(result.data, 'persisted') === false) {
+      return 'daemon-unpersisted';
     }
     return 'unknown';
   }
@@ -34,23 +85,28 @@ export function classifyBufferFallback(result: { ok: boolean; data?: unknown }):
 }
 
 /**
- * POST a capture-critical event and, on failure, fall back to the on-disk
- * EventBuffer so `reconcileBufferBatches` can replay it on the next daemon
- * start. This is the one durability boundary every capture hook shares.
+ * POST a capture-critical event and, when the response says no durable copy
+ * exists daemon-side, fall back to the on-disk EventBuffer so
+ * `reconcileBufferBatches` can replay it. This is the one durability
+ * boundary every capture hook shares; the fallback decision lives entirely
+ * in {@link shouldBufferFallback}, driven by the shared capture policy
+ * table — hooks carry no per-hook buffering flags.
  *
  * The buffer write MUST live in the hook process: it only happens when the
- * daemon is unreachable, so there is nothing to delegate it to. Hooks stay
+ * daemon holds no copy, so there is nothing to delegate it to. Hooks stay
  * thin (AGENTS.md: "hooks must stay thin and delegate to the daemon") by
  * routing through this single helper instead of re-implementing the fallback.
  *
- * `bufferOnIgnored` (default true) also buffers when the daemon answers 200
- * with `{ ignored }`. Hooks whose replay path RE-APPLIES capture rules
- * (`user_prompt` — see reconciliation.ts) want this. `post-tool-use` passes
- * FALSE: `tool_use` replay inserts directly without re-filtering, so buffering
- * a rule-dropped tool would resurrect it on the next start.
+ * The buffered copy is enriched with `agent` (and `origin`, when the POST
+ * carried one the bufferEvent lacks) from the POST body, so satellite
+ * consumers of the buffer — resurrection's capture gate, replay's manifest
+ * re-evaluation — see the same identity the live daemon path saw.
  *
  * `bufferEvent: null` POSTs without ever buffering — e.g. a stop with no
  * assistant response to recover.
+ *
+ * Fail-open: a throwing buffer write is traced to stderr and swallowed —
+ * no path here may propagate into the agent's hook execution.
  *
  * Pass `client` to reuse an already-warmed client (e.g. after `ensureRunning`).
  */
@@ -61,33 +117,46 @@ export async function captureCriticalEvent(opts: {
   endpoint: string;
   postBody: Record<string, unknown>;
   bufferEvent: Record<string, unknown> | null;
-  bufferOnIgnored?: boolean;
   client?: DaemonClient;
 }): Promise<ClientResult> {
   const { vaultDir, sessionId, hookName, endpoint, postBody, bufferEvent } = opts;
-  const bufferOnIgnored = opts.bufferOnIgnored ?? true;
   const client = opts.client ?? createHookDaemonClient(vaultDir, { sessionId });
 
   const result = await client.capturePost(endpoint, postBody);
 
-  const shouldFallback = !result.ok || (bufferOnIgnored && isIgnoredEventResponse(result.data));
-  if (bufferEvent && shouldFallback) {
-    // Project must be registered globally to receive a buffered write.
-    // No fallback location: Grove migration taught us that "if not in
-    // global, fall back to project-local" silently produces divergent
-    // state. A daemon-unreachable hit on a pre-register project drops
-    // with a visible stderr trace rather than a guessed location.
-    const location = resolveProjectBufferDirFromRoot(resolveProjectRoot(vaultDir));
-    if (location) {
-      new EventBuffer(location.bufferDir, sessionId).append(bufferEvent);
-      // Stderr trace so "session not captured" investigations can see the
-      // buffer-fallback path firing without a daemon round-trip.
+  const eventType = typeof postBody.type === 'string'
+    ? postBody.type
+    : typeof bufferEvent?.type === 'string' ? bufferEvent.type : undefined;
+  if (bufferEvent && shouldBufferFallback(result, eventType)) {
+    try {
+      // Project must be registered globally to receive a buffered write.
+      // No fallback location: Grove migration taught us that "if not in
+      // global, fall back to project-local" silently produces divergent
+      // state. A daemon-unreachable hit on a pre-register project drops
+      // with a visible stderr trace rather than a guessed location.
+      const location = resolveProjectBufferDirFromRoot(resolveProjectRoot(vaultDir));
+      if (location) {
+        const enriched: Record<string, unknown> = { ...bufferEvent };
+        if (postBody.agent !== undefined || bufferEvent.agent !== undefined) {
+          enriched.agent = postBody.agent ?? bufferEvent.agent;
+        }
+        if (postBody.origin !== undefined && bufferEvent.origin === undefined) {
+          enriched.origin = postBody.origin;
+        }
+        new EventBuffer(location.bufferDir, sessionId).append(enriched);
+        // Stderr trace so "session not captured" investigations can see the
+        // buffer-fallback path firing without a daemon round-trip.
+        process.stderr.write(
+          `[myco] ${hookName} buffered (${classifyBufferFallback(result)}) session=${sessionId}\n`,
+        );
+      } else {
+        process.stderr.write(
+          `[myco] ${hookName} dropped (project-not-registered) session=${sessionId}\n`,
+        );
+      }
+    } catch (error) {
       process.stderr.write(
-        `[myco] ${hookName} buffered (${classifyBufferFallback(result)}) session=${sessionId}\n`,
-      );
-    } else {
-      process.stderr.write(
-        `[myco] ${hookName} dropped (project-not-registered) session=${sessionId}\n`,
+        `[myco] ${hookName} buffer write failed: ${(error as Error).message} session=${sessionId}\n`,
       );
     }
   }
@@ -119,9 +188,9 @@ export async function sendEvent(
 
 /**
  * Generic `/events` capture for simple hooks: POST `{ ...event, session_id,
- * agent, transcript_path }` and buffer the same payload on failure/ignored.
- * Thin wrapper over {@link captureCriticalEvent} so every capture path shares
- * one durability implementation.
+ * agent, transcript_path }` and buffer the same payload when the response
+ * warrants it. Thin wrapper over {@link captureCriticalEvent} so every
+ * capture path shares one durability implementation.
  */
 export async function captureHookEvent(
   vaultDir: string,

--- a/packages/myco/src/hooks/user-prompt-submit.ts
+++ b/packages/myco/src/hooks/user-prompt-submit.ts
@@ -49,9 +49,10 @@ export async function main() {
     const originField = decision.origin ? { origin: decision.origin } : undefined;
 
     // Kind classification happens on the daemon; Stop-time reconciler repairs it.
-    // bufferOnIgnored defaults true: user_prompt replay re-applies the capture
-    // rule (classifyNextPromptDecision), so a buffered ignored prompt is re-
-    // filtered on replay rather than blindly re-inserted. Reuse the warmed client.
+    // Buffer-fallback policy (capture/event-policy.ts): user_prompt replay
+    // re-applies the capture rule (classifyNextPromptDecision), so a legacy-
+    // daemon ignored prompt that buffers is re-filtered on replay rather than
+    // blindly re-inserted. Reuse the warmed client.
     await captureCriticalEvent({
       vaultDir: VAULT_DIR,
       sessionId,

--- a/tests/capture/event-policy.test.ts
+++ b/tests/capture/event-policy.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  CAPTURE_EVENT_POLICY,
+  REPLAYABLE_EVENT_TYPES,
+  captureEventPolicy,
+} from '@myco/capture/event-policy.js';
+
+/**
+ * Drift guards for the capture event policy table — the single source of
+ * truth the daemon reconciler (replayable set) and the hook CLI
+ * (legacy buffer-fallback columns) both derive from.
+ */
+describe('capture event policy table', () => {
+  it('derives REPLAYABLE_EVENT_TYPES exactly from the replayable column', () => {
+    const fromTable = Object.entries(CAPTURE_EVENT_POLICY)
+      .filter(([, policy]) => policy.replayable)
+      .map(([type]) => type)
+      .sort();
+    expect([...REPLAYABLE_EVENT_TYPES].sort()).toEqual(fromTable);
+  });
+
+  it('pins the replayable set the reconciler replays after downtime', () => {
+    expect([...REPLAYABLE_EVENT_TYPES].sort()).toEqual([
+      'stop',
+      'tool_failure',
+      'tool_use',
+      'user_prompt',
+    ]);
+  });
+
+  it('gives every replayable type a replay mode and no mode to the rest', () => {
+    for (const policy of Object.values(CAPTURE_EVENT_POLICY)) {
+      if (policy.replayable) {
+        expect(policy.replayMode).not.toBeNull();
+      } else {
+        expect(policy.replayMode).toBeNull();
+      }
+    }
+  });
+
+  it('pins the legacy per-hook columns the mixed-version fallback reproduces', () => {
+    expect(CAPTURE_EVENT_POLICY.user_prompt).toMatchObject({
+      replayMode: 'regate', legacyBufferOnIgnored: true, legacyBufferEvent: 'always',
+    });
+    expect(CAPTURE_EVENT_POLICY.tool_use).toMatchObject({
+      replayMode: 'direct', legacyBufferOnIgnored: false, legacyBufferEvent: 'always',
+    });
+    expect(CAPTURE_EVENT_POLICY.tool_failure).toMatchObject({
+      replayMode: 'direct', legacyBufferOnIgnored: true, legacyBufferEvent: 'always',
+    });
+    expect(CAPTURE_EVENT_POLICY.stop).toMatchObject({
+      replayMode: 'idempotent', legacyBufferOnIgnored: true, legacyBufferEvent: 'summary-only',
+    });
+  });
+
+  it('falls back fail-open for unknown types (legacy sendEvent defaults)', () => {
+    expect(captureEventPolicy('some_future_type')).toEqual({
+      replayable: false,
+      replayMode: null,
+      legacyBufferOnIgnored: true,
+      legacyBufferEvent: 'always',
+    });
+    expect(captureEventPolicy(undefined).legacyBufferOnIgnored).toBe(true);
+  });
+
+  it('covers every event type the capture hooks emit (and carries no orphan rows)', () => {
+    // The dispatcher's daemon-side buffer append is type-agnostic — every
+    // event a hook POSTs gets appended. The set of bufferable types is
+    // therefore the set of `type: '<event>'` literals in the hook sources;
+    // scan them so adding a hook event without a policy row fails here.
+    const hooksDir = path.resolve('packages/myco/src/hooks');
+    const emitted = new Set<string>();
+    for (const file of fs.readdirSync(hooksDir).filter((f) => f.endsWith('.ts'))) {
+      const source = fs.readFileSync(path.join(hooksDir, file), 'utf-8');
+      for (const match of source.matchAll(/\btype: '([a-z_]+)'/g)) {
+        emitted.add(match[1]);
+      }
+    }
+    expect(emitted.size).toBeGreaterThan(0);
+
+    const tableTypes = new Set(Object.keys(CAPTURE_EVENT_POLICY));
+    const missingFromTable = [...emitted].filter((type) => !tableTypes.has(type));
+    expect(missingFromTable).toEqual([]);
+
+    const orphanRows = [...tableTypes].filter((type) => !emitted.has(type));
+    expect(orphanRows).toEqual([]);
+  });
+});

--- a/tests/daemon/event-contract-recovery.test.ts
+++ b/tests/daemon/event-contract-recovery.test.ts
@@ -1,0 +1,152 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
+import { createEventDispatcher } from '@myco/daemon/event-dispatch.js';
+import { createReconciler } from '@myco/daemon/reconciliation.js';
+import { SessionRegistry } from '@myco/daemon/lifecycle.js';
+import { PowerManager } from '@myco/daemon/power.js';
+import { DaemonLogger } from '@myco/daemon/logger.js';
+import { EventBuffer } from '@myco/capture/buffer.js';
+import { getDatabase } from '@myco/db/client.js';
+import { countActivities, listActivities } from '@myco/db/queries/activities.js';
+import { listBatchesBySession } from '@myco/db/queries/batches.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+import { shouldBufferFallback } from '@myco/hooks/send-event.js';
+import { TEST_REQUEST_CONTEXT } from '../helpers/request-context';
+
+/**
+ * The full RC-7c recovery loop, no restart:
+ *
+ *   1. a per-type handler fails AFTER the daemon-side buffer append;
+ *   2. the /events response honestly reports `persisted:false,
+ *      buffered:true` and the dispatcher clears the session's converged
+ *      mark;
+ *   3. the hook-side decision table reads that response and does NOT
+ *      write its own buffer copy (the daemon copy is the durable one);
+ *   4. the post-Stop convergence trigger (reconciler.reconcileSession —
+ *      the same call `onStopProcessed` wires) replays the daemon-appended
+ *      copy and the row appears.
+ */
+describe('honest /events contract — end-to-end recovery loop', () => {
+  let tmpDir: string;
+  let bufferDir: string;
+  let logger: DaemonLogger;
+
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+
+  beforeEach(() => {
+    cleanTestDb();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-contract-recovery-'));
+    bufferDir = path.join(tmpDir, 'buffer');
+    fs.mkdirSync(bufferDir, { recursive: true });
+    logger = new DaemonLogger(path.join(tmpDir, 'logs'), { level: 'debug' });
+  });
+
+  afterEach(() => {
+    logger.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('handler failure → honest response → no hook buffer → post-Stop trigger converges the daemon copy', async () => {
+    const sessionId = 'contract-recovery-e2e-001';
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    fs.writeFileSync(transcriptPath, '');
+
+    const registry = new SessionRegistry({ gracePeriod: 1, onEmpty: () => {} });
+    const powerManager = new PowerManager({
+      idleThresholdMs: 60_000,
+      sleepThresholdMs: 120_000,
+      deepSleepThresholdMs: 180_000,
+      activeIntervalMs: 60_000,
+      sleepIntervalMs: 60_000,
+      logger,
+      onTick: () => {},
+      deepSleepHolder: () => null,
+    });
+    const reconciler = createReconciler({
+      bufferDirs: () => [bufferDir],
+      logger,
+      projectRoot: tmpDir,
+    });
+    // Pre-seeded buffer stands in for the Grove-bound dispatch path (the
+    // test request context is not Grove-bound); the reconciler scans the
+    // same dir, exactly like production where dispatcher and reconciler
+    // share the project's buffer location.
+    const sessionBuffers = new Map<string, EventBuffer>();
+    sessionBuffers.set(sessionId, new EventBuffer(bufferDir, sessionId));
+
+    const handler = createEventDispatcher({
+      registry,
+      sessionBuffers,
+      powerManager,
+      logger,
+      machineId: 'local',
+      liveConfig: { current: {
+        agent: { summary_batch_interval: 20 },
+        canopy: { exclude: { patterns: [] } },
+      } as never },
+      vaultDir: tmpDir,
+      reconcileSession: reconciler.reconcileSession,
+      // The production wiring under test: handler failure clears the
+      // converged mark so the post-Stop trigger can re-converge.
+      clearConvergedMark: reconciler.clearSession,
+      planWatchConfig: { watchDirs: [], projectRoot: tmpDir },
+      triggerTitleSummary: async () => {},
+    });
+
+    const post = (body: Record<string, unknown>) => handler({
+      requestContext: TEST_REQUEST_CONTEXT,
+      body, query: {}, params: {}, pathname: '/events',
+    });
+
+    // Turn opens normally — the live path persists the prompt.
+    const promptRes = await post({
+      type: 'user_prompt',
+      session_id: sessionId,
+      agent: 'claude-code',
+      transcript_path: transcriptPath,
+      prompt: 'implement the honest hook contract',
+    });
+    expect(promptRes.body).toMatchObject({ ok: true, persisted: true });
+
+    // Mid-turn, the activity insert fails (table offline) AFTER the
+    // daemon-side buffer append succeeded.
+    const db = getDatabase();
+    db.exec('ALTER TABLE activities RENAME TO activities_offline');
+    let toolRes;
+    try {
+      toolRes = await post({
+        type: 'tool_use',
+        session_id: sessionId,
+        agent: 'claude-code',
+        transcript_path: transcriptPath,
+        tool_name: 'Bash',
+        tool_input: { command: 'bun test' },
+      });
+    } finally {
+      db.exec('ALTER TABLE activities_offline RENAME TO activities');
+    }
+    expect(toolRes.body).toEqual({ ok: true, persisted: false, buffered: true });
+
+    // The hook-side decision table reads that response and refuses to
+    // re-buffer — the daemon-appended copy is the durable one.
+    expect(shouldBufferFallback({ ok: true, data: toolRes.body }, 'tool_use')).toBe(false);
+    const bufferLines = fs.readFileSync(path.join(bufferDir, `${sessionId}.jsonl`), 'utf-8')
+      .trim().split('\n');
+    expect(bufferLines).toHaveLength(2); // prompt + tool_use, daemon copies only
+    expect(countActivities(sessionId, ALL_PROJECTS_SCOPE)).toBe(0); // genuinely lost from the DB so far
+
+    // Post-Stop convergence trigger (what stop-processing's onStopProcessed
+    // invokes at the turn boundary): the prompt converges against its
+    // stored batch; the tool_use is unmatched and replays.
+    reconciler.reconcileSession(sessionId);
+
+    expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(1);
+    const activities = listActivities({ session_id: sessionId, scope: ALL_PROJECTS_SCOPE });
+    expect(activities).toHaveLength(1);
+    expect(activities[0].tool_name).toBe('Bash');
+  });
+});

--- a/tests/daemon/event-dispatch.test.ts
+++ b/tests/daemon/event-dispatch.test.ts
@@ -13,11 +13,14 @@ import { listBatchesBySession } from '@myco/db/queries/batches.js';
 import { listPlansBySession } from '@myco/db/queries/plans.js';
 import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
 import { listGitProvenance } from '@myco/db/queries/release-provenance.js';
+import { getDatabase } from '@myco/db/client.js';
+import { EventBuffer } from '@myco/capture/buffer.js';
 
 import { TEST_REQUEST_CONTEXT } from '../helpers/request-context';
 function makeHandler(opts: {
   liveReconcile?: (sessionId: string, agent: string, transcriptPath: string) => void;
   planWatchConfig?: { watchDirs: string[]; projectRoot: string; extensions?: string[] };
+  clearConvergedMark?: (sessionId: string) => void;
 } = {}) {
   const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-event-dispatch-'));
   const logger = new DaemonLogger(logDir, { level: 'debug' });
@@ -50,6 +53,7 @@ function makeHandler(opts: {
     planWatchConfig: opts.planWatchConfig ?? { watchDirs: [], projectRoot: vaultDir },
     triggerTitleSummary: async () => {},
     liveReconcile: opts.liveReconcile,
+    clearConvergedMark: opts.clearConvergedMark,
   });
 
   return { handler, registry, sessionBuffers, logger, vaultDir };
@@ -78,7 +82,7 @@ describe('createEventDispatcher', () => {
       pathname: '/events',
     });
 
-    expect(res.body).toEqual({ ok: true, ignored: 'ephemeral-sub-invocation' });
+    expect(res.body).toEqual({ ok: true, ignored: 'ephemeral-sub-invocation', persisted: false });
     expect(registry.getSession(sessionId, ALL_PROJECTS_SCOPE)).toBeUndefined();
     expect(getSession(sessionId, ALL_PROJECTS_SCOPE)).toBeNull();
     expect(countActivities(sessionId, ALL_PROJECTS_SCOPE)).toBe(0);
@@ -115,7 +119,7 @@ describe('createEventDispatcher', () => {
       pathname: '/events',
     });
 
-    expect(res.body).toEqual({ ok: true });
+    expect(res.body).toEqual({ ok: true, persisted: true });
     expect(registry.getSession(sessionId, ALL_PROJECTS_SCOPE)).toBeDefined();
     expect(getSession(sessionId, ALL_PROJECTS_SCOPE)?.agent).toBe('codex');
     expect(countActivities(sessionId, ALL_PROJECTS_SCOPE)).toBe(1);
@@ -400,7 +404,7 @@ describe('createEventDispatcher', () => {
         pathname: '/events',
       });
 
-      expect(res.body).toEqual({ ok: true, ignored: 'ephemeral-sub-invocation' });
+      expect(res.body).toEqual({ ok: true, ignored: 'ephemeral-sub-invocation', persisted: false });
       expect(getSession(sessionId, ALL_PROJECTS_SCOPE)).toBeNull();
       expect(sessionBuffers.has(sessionId)).toBe(false);
 
@@ -481,8 +485,8 @@ describe('createEventDispatcher', () => {
 
       expect(first.body).toMatchObject({ ok: true });
       expect(first.body).not.toMatchObject({ ignored: 'duplicate' });
-      expect(second.body).toEqual({ ok: true, ignored: 'duplicate' });
-      expect(third.body).toEqual({ ok: true, ignored: 'duplicate' });
+      expect(second.body).toEqual({ ok: true, ignored: 'duplicate', persisted: false });
+      expect(third.body).toEqual({ ok: true, ignored: 'duplicate', persisted: false });
 
       // Without the guard, three identical user_prompt POSTs would create
       // three batches (the bug we're fixing). With it, exactly one batch.
@@ -540,8 +544,8 @@ describe('createEventDispatcher', () => {
 
       expect(r1.body).toMatchObject({ ok: true });
       expect(r1.body).not.toMatchObject({ ignored: 'duplicate' });
-      expect(r2.body).toEqual({ ok: true, ignored: 'duplicate' });
-      expect(r3.body).toEqual({ ok: true, ignored: 'duplicate' });
+      expect(r2.body).toEqual({ ok: true, ignored: 'duplicate', persisted: false });
+      expect(r3.body).toEqual({ ok: true, ignored: 'duplicate', persisted: false });
 
       // Dedup verified via response status + a single landed activity. The
       // buffer-side assertion that used to live here required a Grove-
@@ -665,6 +669,155 @@ describe('createEventDispatcher', () => {
       // what happens if the contract widens later.
       expect(res.body).toMatchObject({ ok: true });
       expect(countActivities(sessionId, ALL_PROJECTS_SCOPE)).toBe(1);
+
+      logger.close();
+      fs.rmSync(vaultDir, { recursive: true, force: true });
+      fs.rmSync(transcriptDir, { recursive: true, force: true });
+    });
+  });
+
+  describe('honest response contract (persisted / buffered)', () => {
+    // The /events response must report what actually happened: handlers
+    // committed (`persisted: true`), handler failed but the daemon-side
+    // buffer append holds a durable copy (`persisted: false, buffered:
+    // true` + converged mark cleared so the copy replays at the next
+    // quiescent boundary), or handler failed with no daemon-side copy
+    // (`buffered: false` — the hook's one honest buffer-fallback case).
+
+    function makeRealSession(sessionId: string) {
+      const transcriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-honest-'));
+      const transcriptPath = path.join(transcriptDir, `${sessionId}.jsonl`);
+      fs.writeFileSync(transcriptPath, '');
+      return { transcriptDir, transcriptPath };
+    }
+
+    /** Make `handleToolUse`'s insert fail deterministically. */
+    function withBrokenActivitiesTable<T>(fn: () => Promise<T>): Promise<T> {
+      const db = getDatabase();
+      db.exec('ALTER TABLE activities RENAME TO activities_offline');
+      return fn().finally(() => {
+        db.exec('ALTER TABLE activities_offline RENAME TO activities');
+      });
+    }
+
+    it('reports persisted:false buffered:true and clears the converged mark when a handler fails after the daemon-side append', async () => {
+      const cleared: string[] = [];
+      const { handler, sessionBuffers, logger, vaultDir } = makeHandler({
+        clearConvergedMark: (sessionId) => cleared.push(sessionId),
+      });
+      const sessionId = 'honest-handler-fail-buffered-001';
+      const { transcriptDir, transcriptPath } = makeRealSession(sessionId);
+      // Pre-seeded buffer stands in for the Grove-bound dispatch path —
+      // TEST_REQUEST_CONTEXT carries no groveId, so dispatch would
+      // otherwise skip the daemon-side append entirely.
+      const bufferDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-honest-buf-'));
+      sessionBuffers.set(sessionId, new EventBuffer(bufferDir, sessionId));
+
+      const res = await withBrokenActivitiesTable(() => handler({
+        requestContext: TEST_REQUEST_CONTEXT,
+        body: {
+          type: 'tool_use',
+          session_id: sessionId,
+          agent: 'claude-code',
+          transcript_path: transcriptPath,
+          tool_name: 'Bash',
+          tool_input: { command: 'echo honest contract' },
+        },
+        query: {}, params: {}, pathname: '/events',
+      }));
+
+      expect(res.body).toEqual({ ok: true, persisted: false, buffered: true });
+      // The recovery promise: the converged mark was cleared so the
+      // daemon-appended copy replays at the next quiescent boundary.
+      expect(cleared).toEqual([sessionId]);
+      // The daemon-side copy really exists (it is the durable copy the
+      // response promises).
+      const bufferPath = path.join(bufferDir, `${sessionId}.jsonl`);
+      const lines = fs.readFileSync(bufferPath, 'utf-8').trim().split('\n');
+      expect(lines).toHaveLength(1);
+      expect(JSON.parse(lines[0])).toMatchObject({ type: 'tool_use', tool_name: 'Bash' });
+
+      logger.close();
+      fs.rmSync(vaultDir, { recursive: true, force: true });
+      fs.rmSync(transcriptDir, { recursive: true, force: true });
+      fs.rmSync(bufferDir, { recursive: true, force: true });
+    });
+
+    it('reports persisted:false buffered:false when the handler fails and the daemon-side append was skipped (missing grove/project context)', async () => {
+      const cleared: string[] = [];
+      const { handler, logger, vaultDir } = makeHandler({
+        clearConvergedMark: (sessionId) => cleared.push(sessionId),
+      });
+      const sessionId = 'honest-handler-fail-unbuffered-001';
+      const { transcriptDir, transcriptPath } = makeRealSession(sessionId);
+
+      // TEST_REQUEST_CONTEXT has groveId: null — the no-fallback buffer
+      // rule skips the daemon-side append, so no durable copy exists.
+      const res = await withBrokenActivitiesTable(() => handler({
+        requestContext: TEST_REQUEST_CONTEXT,
+        body: {
+          type: 'tool_use',
+          session_id: sessionId,
+          agent: 'claude-code',
+          transcript_path: transcriptPath,
+          tool_name: 'Bash',
+          tool_input: { command: 'echo no daemon copy' },
+        },
+        query: {}, params: {}, pathname: '/events',
+      }));
+
+      expect(res.body).toEqual({ ok: true, persisted: false, buffered: false });
+      expect(cleared).toEqual([sessionId]);
+
+      logger.close();
+      fs.rmSync(vaultDir, { recursive: true, force: true });
+      fs.rmSync(transcriptDir, { recursive: true, force: true });
+    });
+
+    it('pins the non-persisting-type shape: a type with no handler reports persisted:true (vacuous success)', async () => {
+      const { handler, logger, vaultDir } = makeHandler();
+      const sessionId = 'honest-non-persisting-001';
+      const { transcriptDir, transcriptPath } = makeRealSession(sessionId);
+
+      const res = await handler({
+        requestContext: TEST_REQUEST_CONTEXT,
+        body: {
+          type: 'notification',
+          session_id: sessionId,
+          agent: 'copilot',
+          transcript_path: transcriptPath,
+          payload: { message: 'agent paused' },
+        },
+        query: {}, params: {}, pathname: '/events',
+      });
+
+      expect(res.body).toEqual({ ok: true, persisted: true });
+
+      logger.close();
+      fs.rmSync(vaultDir, { recursive: true, force: true });
+      fs.rmSync(transcriptDir, { recursive: true, force: true });
+    });
+
+    it('keeps success responses honest: a persisting handler that commits reports persisted:true with its extras', async () => {
+      const { handler, logger, vaultDir } = makeHandler();
+      const sessionId = 'honest-success-001';
+      const { transcriptDir, transcriptPath } = makeRealSession(sessionId);
+
+      const res = await handler({
+        requestContext: TEST_REQUEST_CONTEXT,
+        body: {
+          type: 'user_prompt',
+          session_id: sessionId,
+          agent: 'claude-code',
+          transcript_path: transcriptPath,
+          prompt: 'a prompt that persists end to end',
+        },
+        query: {}, params: {}, pathname: '/events',
+      });
+
+      const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+      expect(batches).toHaveLength(1);
+      expect(res.body).toEqual({ ok: true, persisted: true, batchId: batches[0].id });
 
       logger.close();
       fs.rmSync(vaultDir, { recursive: true, force: true });

--- a/tests/daemon/stop-processing.test.ts
+++ b/tests/daemon/stop-processing.test.ts
@@ -548,7 +548,7 @@ describe('createStopProcessor session capture rules', () => {
       },
     } as never);
 
-    expect(res.body).toEqual({ ok: true });
+    expect(res.body).toEqual({ ok: true, queued: true });
     await stopProcessor.getActiveProcessing();
 
     const plans = listPlansBySession(sessionId, ALL_PROJECTS_SCOPE);
@@ -614,7 +614,7 @@ describe('createStopProcessor session capture rules', () => {
       },
     } as never);
 
-    expect(res.body).toEqual({ ok: true });
+    expect(res.body).toEqual({ ok: true, queued: true });
     await stopProcessor.getActiveProcessing();
 
     const plans = listPlansBySession(sessionId, ALL_PROJECTS_SCOPE);
@@ -689,7 +689,7 @@ describe('createStopProcessor session capture rules', () => {
       },
     } as never);
 
-    expect(res.body).toEqual({ ok: true });
+    expect(res.body).toEqual({ ok: true, queued: true });
     await stopProcessor.getActiveProcessing();
 
     const plans = listPlansBySession(sessionId, ALL_PROJECTS_SCOPE);
@@ -751,7 +751,7 @@ describe('createStopProcessor session capture rules', () => {
       },
     } as never);
 
-    expect(res.body).toEqual({ ok: true });
+    expect(res.body).toEqual({ ok: true, queued: true });
     await stopProcessor.getActiveProcessing();
 
     expect(listPlansBySession(sessionId, ALL_PROJECTS_SCOPE)).toHaveLength(0);
@@ -813,7 +813,7 @@ describe('createStopProcessor session capture rules', () => {
           last_assistant_message: 'done',
         },
       } as never);
-      expect(res.body).toEqual({ ok: true });
+      expect(res.body).toEqual({ ok: true, queued: true });
       await stopProcessor.getActiveProcessing();
     }
 

--- a/tests/hooks/buffer-event-policy-drift.test.ts
+++ b/tests/hooks/buffer-event-policy-drift.test.ts
@@ -1,0 +1,216 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { CAPTURE_EVENT_POLICY } from '@myco/capture/event-policy.js';
+import { createGrove, registerProjectInGrove } from '@myco/grove/registry.js';
+import { resolveProjectBufferDir, resolveServiceDaemonStatePath } from '@myco/grove/paths.js';
+import { getPluginVersion } from '@myco/version.js';
+import { listenEphemeral, closeServer } from '../helpers/net.js';
+
+const TEST_PROJECT_ID = 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+/**
+ * Drift guard for the policy table's `legacyBufferEvent` column. The column
+ * is documentation-by-table for behavior that lives in each hook's
+ * bufferEvent construction (a `stop` with no summary passes `bufferEvent:
+ * null`; everything else always offers a copy) — nothing consults it at
+ * runtime, so nothing would fail if a hook and its row diverged. This test
+ * closes that gap: it runs every hook the table covers against a daemon
+ * stub whose `/events` POSTs fail (a non-2xx — the unconditional-buffer
+ * row of the fallback decision table), then asserts the buffer file's
+ * presence matches the row:
+ *
+ *   - 'always'       → the event is buffered;
+ *   - 'summary-only' → buffered with an assistant response, absent without;
+ *   - 'never'        → never buffered.
+ *
+ * A policy row with no hook mapping here fails loudly, so the table cannot
+ * grow without this guard growing with it.
+ */
+describe('legacyBufferEvent column ↔ hook bufferEvent behavior (drift guard)', () => {
+  let mycoHome: string;
+  let projectRoot: string;
+  let transcriptPath: string;
+  let bufferDir: string;
+  let server: http.Server;
+
+  beforeAll(async () => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-buffer-policy-drift-'));
+    const vaultDir = path.join(projectRoot, '.myco');
+    mycoHome = path.join(projectRoot, 'home');
+    transcriptPath = path.join(projectRoot, 'transcript.jsonl');
+    fs.mkdirSync(vaultDir, { recursive: true });
+    fs.mkdirSync(mycoHome, { recursive: true });
+    fs.writeFileSync(
+      path.join(vaultDir, 'project.toml'),
+      `[project]\nid = "${TEST_PROJECT_ID}"\nname = "buffer-policy-drift"\n`,
+      'utf-8',
+    );
+    fs.writeFileSync(path.join(vaultDir, 'myco.yaml'), 'version: 3\nconfig_version: 0\n', 'utf-8');
+    fs.writeFileSync(transcriptPath, '{}\n', 'utf-8');
+    const grove = createGrove('test', mycoHome);
+    registerProjectInGrove(grove.id, {
+      projectId: TEST_PROJECT_ID,
+      projectName: 'buffer-policy-drift',
+      projectRoot,
+    }, mycoHome);
+    bufferDir = resolveProjectBufferDir(grove.id, TEST_PROJECT_ID, mycoHome);
+
+    // Daemon stub: healthy (so user-prompt-submit's ensureRunning returns
+    // fast) but every other request — /events, /events/stop, /context/* —
+    // answers 500. A non-2xx makes capturePost return `{ok:false}`
+    // immediately with no recovery loop, putting every hook on the
+    // unconditional-buffer row, where buffering happens iff the hook
+    // offered a bufferEvent at all.
+    const listening = await listenEphemeral((req, res) => {
+      if (req.method === 'GET' && req.url === '/health') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ myco: true, pid: process.pid, version: getPluginVersion() }));
+        return;
+      }
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'stub failure' }));
+    });
+    server = listening.server;
+    const statePath = resolveServiceDaemonStatePath(mycoHome);
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, JSON.stringify({ pid: process.pid, port: listening.port }));
+  });
+
+  afterAll(async () => {
+    await closeServer(server);
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  // Async spawn, NOT spawnSync: the daemon stub lives in this test process,
+  // and spawnSync would block the event loop the stub needs to answer the
+  // child's requests — a guaranteed deadlock-until-timeout.
+  function runHook(hook: string, payload: Record<string, unknown>): Promise<{ status: number | null }> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(
+        process.execPath,
+        [path.resolve('packages/myco/src/cli.ts'), 'hook', hook, '--symbiont', 'claude-code'],
+        {
+          cwd: projectRoot,
+          env: { ...process.env, MYCO_NO_AUTO_SPAWN: '1', MYCO_HOME: mycoHome },
+          stdio: ['pipe', 'ignore', 'ignore'],
+        },
+      );
+      child.on('error', reject);
+      child.on('close', (status) => resolve({ status }));
+      child.stdin.write(JSON.stringify(payload));
+      child.stdin.end();
+    });
+  }
+
+  function bufferedTypes(sessionId: string): string[] {
+    const bufferPath = path.join(bufferDir, `${sessionId}.jsonl`);
+    if (!fs.existsSync(bufferPath)) return [];
+    const raw = fs.readFileSync(bufferPath, 'utf-8').trim();
+    if (!raw) return [];
+    return raw.split('\n').map((line) => String(JSON.parse(line).type));
+  }
+
+  /**
+   * One hook invocation per policy row. `payload` carries the row's
+   * "content present" shape; `payloadWithoutSummary` (summary-only rows)
+   * carries the same event with nothing to recover.
+   */
+  const HOOK_FOR_TYPE: Record<string, {
+    hook: string;
+    payload: Record<string, unknown>;
+    payloadWithoutSummary?: Record<string, unknown>;
+  }> = {
+    user_prompt: {
+      hook: 'user-prompt-submit',
+      payload: { prompt: 'a real user prompt for the drift guard' },
+    },
+    tool_use: {
+      hook: 'post-tool-use',
+      payload: { tool_name: 'Bash', tool_input: { command: 'pwd' }, tool_output: 'ok' },
+    },
+    tool_failure: {
+      hook: 'post-tool-use-failure',
+      payload: { tool_name: 'Bash', tool_input: { command: 'pwd' }, error: 'exit 1' },
+    },
+    stop: {
+      hook: 'stop',
+      payload: { last_assistant_message: 'The final answer for this turn.' },
+      payloadWithoutSummary: {},
+    },
+    subagent_start: {
+      hook: 'subagent-start',
+      payload: { agent_id: 'sub-001', agent_type: 'Explore' },
+    },
+    subagent_stop: {
+      hook: 'subagent-stop',
+      payload: { agent_id: 'sub-001', agent_type: 'Explore', last_assistant_message: 'done' },
+    },
+    stop_failure: {
+      hook: 'stop-failure',
+      payload: { error: 'stop pipeline failed' },
+    },
+    task_completed: {
+      hook: 'task-completed',
+      payload: { task_id: 'task-1', task_subject: 'subject' },
+    },
+    pre_compact: {
+      hook: 'pre-compact',
+      payload: { trigger: 'auto' },
+    },
+    post_compact: {
+      hook: 'post-compact',
+      payload: { trigger: 'auto', compact_summary: 'compacted' },
+    },
+    notification: {
+      hook: 'notification',
+      payload: { message: 'agent paused' },
+    },
+    error_occurred: {
+      hook: 'error-occurred',
+      payload: { message: 'network fault', code: 'ECONN' },
+    },
+  };
+
+  it('covers every policy row with a hook mapping', () => {
+    expect(Object.keys(HOOK_FOR_TYPE).sort()).toEqual(Object.keys(CAPTURE_EVENT_POLICY).sort());
+  });
+
+  for (const [type, policy] of Object.entries(CAPTURE_EVENT_POLICY)) {
+    it(`${type}: hook bufferEvent behavior matches legacyBufferEvent '${policy.legacyBufferEvent}'`, async () => {
+      const mapping = HOOK_FOR_TYPE[type];
+      expect(mapping).toBeDefined();
+
+      const sessionId = `buffer-policy-${type.replace(/_/g, '-')}-001`;
+      const result = await runHook(mapping.hook, {
+        ...mapping.payload,
+        session_id: sessionId,
+        transcript_path: transcriptPath,
+      });
+      expect(result.status).toBe(0);
+
+      if (policy.legacyBufferEvent === 'never') {
+        expect(bufferedTypes(sessionId)).toEqual([]);
+        return;
+      }
+
+      // 'always' and the content-present half of 'summary-only' both buffer.
+      expect(bufferedTypes(sessionId)).toEqual([type]);
+
+      if (policy.legacyBufferEvent === 'summary-only') {
+        expect(mapping.payloadWithoutSummary).toBeDefined();
+        const emptySessionId = `buffer-policy-${type.replace(/_/g, '-')}-empty-001`;
+        const emptyResult = await runHook(mapping.hook, {
+          ...mapping.payloadWithoutSummary,
+          session_id: emptySessionId,
+          transcript_path: transcriptPath,
+        });
+        expect(emptyResult.status).toBe(0);
+        expect(bufferedTypes(emptySessionId)).toEqual([]);
+      }
+    }, 20_000);
+  }
+});

--- a/tests/hooks/capture-critical-event.test.ts
+++ b/tests/hooks/capture-critical-event.test.ts
@@ -1,0 +1,310 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { captureCriticalEvent, shouldBufferFallback } from '@myco/hooks/send-event.js';
+import type { DaemonClient } from '@myco/hooks/client.js';
+import { createGrove, registerProjectInGrove } from '@myco/grove/registry.js';
+import { resolveProjectBufferDir } from '@myco/grove/paths.js';
+import { sandboxMycoHome } from '../helpers/myco-home-sandbox.js';
+
+const TEST_PROJECT_ID = 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+/**
+ * The hook-side buffer-fallback decision table over the daemon's honest
+ * response contract (capture/event-policy.ts + send-event.ts). Every row:
+ *
+ *   !ok                                   → buffer
+ *   ok + persisted:true                   → nothing
+ *   ok + persisted:false + buffered:true  → nothing (daemon copy durable)
+ *   ok + persisted:false + buffered:false → buffer (the honest fallback)
+ *   ok + ignored + persisted present      → never buffer (ignored ≠ lost)
+ *   ok with NO persisted field (legacy daemon / every /events/stop reply)
+ *                                         → policy table's legacy columns
+ *
+ * Plus the central agent/origin enrichment of the buffered copy and the
+ * fail-open guarantee (a throwing buffer write never propagates).
+ */
+describe('captureCriticalEvent — policy-driven buffer fallback', () => {
+  let sandbox: ReturnType<typeof sandboxMycoHome>;
+  let projectRoot: string;
+  let vaultDir: string;
+  let bufferDir: string;
+
+  beforeAll(() => {
+    sandbox = sandboxMycoHome('myco-capture-critical-');
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-capture-critical-proj-'));
+    vaultDir = path.join(projectRoot, '.myco');
+    fs.mkdirSync(vaultDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(vaultDir, 'project.toml'),
+      `[project]\nid = "${TEST_PROJECT_ID}"\nname = "capture-critical"\n`,
+      'utf-8',
+    );
+    fs.writeFileSync(path.join(vaultDir, 'myco.yaml'), 'version: 3\nconfig_version: 0\n', 'utf-8');
+    const grove = createGrove('test', sandbox.mycoHome);
+    registerProjectInGrove(grove.id, {
+      projectId: TEST_PROJECT_ID,
+      projectName: 'capture-critical',
+      projectRoot,
+    }, sandbox.mycoHome);
+    bufferDir = resolveProjectBufferDir(grove.id, TEST_PROJECT_ID, sandbox.mycoHome);
+  });
+
+  afterAll(() => {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+    sandbox.restore();
+  });
+
+  function fakeClient(result: { ok: boolean; data?: unknown }): DaemonClient {
+    return { capturePost: async () => result } as unknown as DaemonClient;
+  }
+
+  function bufferedLines(sessionId: string): Array<Record<string, unknown>> {
+    const bufferPath = path.join(bufferDir, `${sessionId}.jsonl`);
+    if (!fs.existsSync(bufferPath)) return [];
+    const raw = fs.readFileSync(bufferPath, 'utf-8').trim();
+    if (!raw) return [];
+    return raw.split('\n').map((line) => JSON.parse(line));
+  }
+
+  async function run(opts: {
+    sessionId: string;
+    result: { ok: boolean; data?: unknown };
+    postBody: Record<string, unknown>;
+    bufferEvent: Record<string, unknown> | null;
+  }) {
+    return captureCriticalEvent({
+      vaultDir,
+      sessionId: opts.sessionId,
+      hookName: 'test-hook',
+      endpoint: '/events',
+      postBody: opts.postBody,
+      bufferEvent: opts.bufferEvent,
+      client: fakeClient(opts.result),
+    });
+  }
+
+  describe('decision-table unit rows (shouldBufferFallback)', () => {
+    it('covers every row of the §3 decision table', () => {
+      // Transport / timeout / non-2xx — always buffer.
+      expect(shouldBufferFallback({ ok: false }, 'user_prompt')).toBe(true);
+      expect(shouldBufferFallback({ ok: false, data: { error: 'x' } }, 'tool_use')).toBe(true);
+
+      // Honest contract.
+      expect(shouldBufferFallback({ ok: true, data: { ok: true, persisted: true } }, 'user_prompt')).toBe(false);
+      expect(shouldBufferFallback({ ok: true, data: { ok: true, persisted: false, buffered: true } }, 'user_prompt')).toBe(false);
+      expect(shouldBufferFallback({ ok: true, data: { ok: true, persisted: false, buffered: false } }, 'user_prompt')).toBe(true);
+
+      // Contract-aware daemon's ignored — never buffer, even for types whose
+      // LEGACY column buffers on ignored.
+      expect(shouldBufferFallback({ ok: true, data: { ok: true, ignored: 'rule', persisted: false } }, 'user_prompt')).toBe(false);
+      expect(shouldBufferFallback({ ok: true, data: { ok: true, ignored: 'duplicate', persisted: false } }, 'tool_failure')).toBe(false);
+
+      // LEGACY daemon (no persisted field): exact per-type legacy behavior.
+      expect(shouldBufferFallback({ ok: true, data: { ok: true, ignored: 'rule' } }, 'user_prompt')).toBe(true);
+      expect(shouldBufferFallback({ ok: true, data: { ok: true, ignored: 'rule' } }, 'tool_use')).toBe(false);
+      expect(shouldBufferFallback({ ok: true, data: { ok: true, ignored: 'rule' } }, 'tool_failure')).toBe(true);
+      expect(shouldBufferFallback({ ok: true, data: { ok: true, ignored: 'invalid-session' } }, 'stop')).toBe(true);
+      expect(shouldBufferFallback({ ok: true, data: { ok: true } }, 'user_prompt')).toBe(false);
+      expect(shouldBufferFallback({ ok: true, data: { ok: true, batchId: 7 } }, 'user_prompt')).toBe(false);
+
+      // /events/stop success: queued, no persisted field — never a fallback.
+      expect(shouldBufferFallback({ ok: true, data: { ok: true, queued: true } }, 'stop')).toBe(false);
+    });
+  });
+
+  it('buffers on transport failure (legacy behavior preserved)', async () => {
+    const sessionId = 'ccev-transport-001';
+    await run({
+      sessionId,
+      result: { ok: false },
+      postBody: { type: 'tool_use', session_id: sessionId, agent: 'codex', tool_name: 'Bash' },
+      bufferEvent: { type: 'tool_use', tool_name: 'Bash' },
+    });
+    expect(bufferedLines(sessionId)).toHaveLength(1);
+  });
+
+  it('does not buffer when the daemon persisted', async () => {
+    const sessionId = 'ccev-persisted-001';
+    await run({
+      sessionId,
+      result: { ok: true, data: { ok: true, persisted: true, batchId: 12 } },
+      postBody: { type: 'user_prompt', session_id: sessionId, agent: 'claude-code', prompt: 'p' },
+      bufferEvent: { type: 'user_prompt', prompt: 'p' },
+    });
+    expect(bufferedLines(sessionId)).toHaveLength(0);
+  });
+
+  it('does not double-buffer when the daemon failed to persist but holds a buffered copy', async () => {
+    const sessionId = 'ccev-daemon-buffered-001';
+    await run({
+      sessionId,
+      result: { ok: true, data: { ok: true, persisted: false, buffered: true } },
+      postBody: { type: 'tool_use', session_id: sessionId, agent: 'claude-code', tool_name: 'Bash' },
+      bufferEvent: { type: 'tool_use', tool_name: 'Bash' },
+    });
+    expect(bufferedLines(sessionId)).toHaveLength(0);
+  });
+
+  it('buffers the one honest-fallback case: persisted:false with no daemon-side copy', async () => {
+    const sessionId = 'ccev-honest-fallback-001';
+    await run({
+      sessionId,
+      result: { ok: true, data: { ok: true, persisted: false, buffered: false } },
+      postBody: { type: 'tool_use', session_id: sessionId, agent: 'claude-code', tool_name: 'Bash' },
+      bufferEvent: { type: 'tool_use', tool_name: 'Bash' },
+    });
+    expect(bufferedLines(sessionId)).toHaveLength(1);
+  });
+
+  it('never buffers a contract-aware daemon ignore, even for user_prompt', async () => {
+    const sessionId = 'ccev-new-ignored-001';
+    await run({
+      sessionId,
+      result: { ok: true, data: { ok: true, ignored: 'rule', persisted: false } },
+      postBody: { type: 'user_prompt', session_id: sessionId, agent: 'claude-code', prompt: 'p' },
+      bufferEvent: { type: 'user_prompt', prompt: 'p' },
+    });
+    expect(bufferedLines(sessionId)).toHaveLength(0);
+  });
+
+  describe('LEGACY daemon (no persisted field) reproduces today\'s exact per-hook behavior', () => {
+    it('user_prompt buffers on ignored', async () => {
+      const sessionId = 'ccev-legacy-prompt-001';
+      await run({
+        sessionId,
+        result: { ok: true, data: { ok: true, ignored: 'rule' } },
+        postBody: { type: 'user_prompt', session_id: sessionId, agent: 'claude-code', prompt: 'p' },
+        bufferEvent: { type: 'user_prompt', prompt: 'p' },
+      });
+      expect(bufferedLines(sessionId)).toHaveLength(1);
+    });
+
+    it('tool_use does NOT buffer on ignored (direct replay would resurrect a dropped tool)', async () => {
+      const sessionId = 'ccev-legacy-tool-001';
+      await run({
+        sessionId,
+        result: { ok: true, data: { ok: true, ignored: 'rule' } },
+        postBody: { type: 'tool_use', session_id: sessionId, agent: 'claude-code', tool_name: 'Bash' },
+        bufferEvent: { type: 'tool_use', tool_name: 'Bash' },
+      });
+      expect(bufferedLines(sessionId)).toHaveLength(0);
+    });
+
+    it('stop buffers on ignored only when there is a summary (bufferEvent present)', async () => {
+      const sessionId = 'ccev-legacy-stop-001';
+      // /events/stop posts carry no `type`; the event type comes from the
+      // bufferEvent — exactly the live stop hook's shape.
+      await run({
+        sessionId,
+        result: { ok: true, data: { ok: true, ignored: 'invalid-session' } },
+        postBody: { session_id: sessionId, agent: 'codex', last_assistant_message: 'answer' },
+        bufferEvent: { type: 'stop', last_assistant_message: 'answer', agent: 'codex' },
+      });
+      expect(bufferedLines(sessionId)).toHaveLength(1);
+    });
+
+    it('stop without a summary never buffers (bufferEvent null), even on transport failure', async () => {
+      const sessionId = 'ccev-legacy-stop-empty-001';
+      await run({
+        sessionId,
+        result: { ok: false },
+        postBody: { session_id: sessionId, agent: 'codex' },
+        bufferEvent: null,
+      });
+      expect(bufferedLines(sessionId)).toHaveLength(0);
+    });
+
+    it('plain legacy ok (no persisted field, not ignored) does not buffer', async () => {
+      const sessionId = 'ccev-legacy-ok-001';
+      await run({
+        sessionId,
+        result: { ok: true, data: { ok: true, batchId: 3 } },
+        postBody: { type: 'user_prompt', session_id: sessionId, agent: 'claude-code', prompt: 'p' },
+        bufferEvent: { type: 'user_prompt', prompt: 'p' },
+      });
+      expect(bufferedLines(sessionId)).toHaveLength(0);
+    });
+  });
+
+  describe('central agent/origin enrichment of the buffered copy', () => {
+    it('stamps the POST body\'s agent onto a bufferEvent that lacks one', async () => {
+      const sessionId = 'ccev-agent-merge-001';
+      await run({
+        sessionId,
+        result: { ok: false },
+        postBody: { type: 'tool_use', session_id: sessionId, agent: 'windsurf', tool_name: 'Bash' },
+        bufferEvent: { type: 'tool_use', tool_name: 'Bash' },
+      });
+      const [event] = bufferedLines(sessionId);
+      expect(event.agent).toBe('windsurf');
+    });
+
+    it('forwards origin from the POST body when the bufferEvent lacks it', async () => {
+      const sessionId = 'ccev-origin-merge-001';
+      await run({
+        sessionId,
+        result: { ok: false },
+        postBody: { type: 'user_prompt', session_id: sessionId, agent: 'claude-code', prompt: 'p', origin: 'system' },
+        bufferEvent: { type: 'user_prompt', prompt: 'p' },
+      });
+      const [event] = bufferedLines(sessionId);
+      expect(event.origin).toBe('system');
+    });
+
+    it('keeps the bufferEvent\'s own origin when present (no clobber)', async () => {
+      const sessionId = 'ccev-origin-keep-001';
+      await run({
+        sessionId,
+        result: { ok: false },
+        postBody: { type: 'user_prompt', session_id: sessionId, agent: 'claude-code', prompt: 'p', origin: 'human' },
+        bufferEvent: { type: 'user_prompt', prompt: 'p', origin: 'agent_dispatch' },
+      });
+      const [event] = bufferedLines(sessionId);
+      expect(event.origin).toBe('agent_dispatch');
+    });
+  });
+
+  describe('fail-open', () => {
+    it('a throwing buffer write never propagates out of captureCriticalEvent', async () => {
+      // Force EventBuffer's mkdir to throw by planting a regular FILE where
+      // a project's buffer dir should be — a registration whose buffer path
+      // is unusable. The helper must trace to stderr and resolve normally.
+      const brokenRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-capture-critical-broken-'));
+      const brokenVault = path.join(brokenRoot, '.myco');
+      fs.mkdirSync(brokenVault, { recursive: true });
+      const brokenProjectId = 'proj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+      fs.writeFileSync(
+        path.join(brokenVault, 'project.toml'),
+        `[project]\nid = "${brokenProjectId}"\nname = "broken-buffer"\n`,
+        'utf-8',
+      );
+      fs.writeFileSync(path.join(brokenVault, 'myco.yaml'), 'version: 3\nconfig_version: 0\n', 'utf-8');
+      const grove = createGrove('broken', sandbox.mycoHome);
+      registerProjectInGrove(grove.id, {
+        projectId: brokenProjectId,
+        projectName: 'broken-buffer',
+        projectRoot: brokenRoot,
+      }, sandbox.mycoHome);
+      const brokenBufferDir = resolveProjectBufferDir(grove.id, brokenProjectId, sandbox.mycoHome);
+      fs.mkdirSync(path.dirname(brokenBufferDir), { recursive: true });
+      fs.writeFileSync(brokenBufferDir, 'not a directory', 'utf-8');
+
+      try {
+        const result = await captureCriticalEvent({
+          vaultDir: brokenVault,
+          sessionId: 'ccev-fail-open-001',
+          hookName: 'test-hook',
+          endpoint: '/events',
+          postBody: { type: 'tool_use', session_id: 'ccev-fail-open-001', agent: 'codex', tool_name: 'Bash' },
+          bufferEvent: { type: 'tool_use', tool_name: 'Bash' },
+          client: fakeClient({ ok: false }),
+        });
+        expect(result.ok).toBe(false);
+      } finally {
+        fs.rmSync(brokenRoot, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What

Final phase of the approved RC-7 design: the hook↔daemon contract stops lying. Fixes RC-7c from the bug hunt — handler failures answered `{ok:true}` so the hook's durability fallback never fired and failed tool activities were unrecoverable — and removes the per-hook `bufferOnIgnored` noise that fed RC-7b and the gate-rejected-resurrection class.

## How

- **Honest `/events` outcomes**: `persisted:true` on commit; `persisted:false, buffered:true` when the daemon-side append holds the event (the daemon also clears the converged mark so Phase 3's post-Stop trigger/drain converges the copy — this contract was deliberately sequenced *after* its recovery machinery); `persisted:false, buffered:false` when the daemon holds nothing (hook buffers — the one honest-fallback case). `/events/stop` → `{ok:true, queued:true}` (never fakes persistence for queued work).
- **`CAPTURE_EVENT_POLICY`** (new `capture/event-policy.ts`): single source for per-type replay + fallback behavior; `REPLAYABLE_EVENT_TYPES` derived; legacy columns encode each hook's pre-contract behavior **exactly** (including stop's real summary-only-buffers-on-ignored, which the design spec had guessed wrong — code is the truth). Two drift guards: a source-scan (new hook event type without a table row fails the suite) and a behavioral one (spawns every real hook against a stub daemon, asserts buffer presence per row).
- **One decision point in hooks** (`shouldBufferFallback`): buffer on transport failure; nothing on persisted/durably-buffered; never buffer a contract-aware daemon's `ignored`; exact legacy behavior against old daemons. Unknown shapes fail toward durability. Central agent/origin merge into buffered events (replays attribute correctly).
- **Ratified deviation**: ignored responses carry `persisted:false` — without a contract marker the new-daemon/legacy-daemon branches are byte-identical and the decision table is unimplementable.

## ⚠️ Deliberate trade (chosen, not discovered)

Against contract-aware daemons, capture-rule drops no longer leave a buffered copy — the historic rule-bug recovery channel is gone (rejected ≠ lost). **OpenCode/Pi plugin templates still use legacy buffering and are ported to the contract in the immediate follow-up PR** (they're no worse than today, just not yet contract-aware).

## Review trail

Adversarial review verdict: **SHIP with zero must-fixes** — first phase to clear clean. 16 response-shape probes (malformed bodies, non-boolean fields, priority of `ignored` over `persisted`), full version-skew matrix (old/new hook × old/new daemon per type), `buffered`-flag accuracy traced through every append failure mode, dedup-key neutrality of the agent merge confirmed, no strict `{ok:true}` consumers anywhere.

## Tests

Policy drift guards (source-scan + behavioral 13-spawn), decision-table matrix incl. legacy branch, dispatch honesty matrix with converged-mark-clear assertions, end-to-end recovery loop (handler failure → honest response → no hook copy → post-Stop convergence lands the row, no restart). Full suite green twice; tsc clean. No schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)