### PR TITLE
symbionts: capture-fidelity fixes from live smoke evidence

### DIFF
--- a/packages/myco/src/hooks/capture-rules.ts
+++ b/packages/myco/src/hooks/capture-rules.ts
@@ -313,6 +313,25 @@ function applyAction(rule: CaptureRule, ctx: UserPromptRuleContext): UserPromptD
     // pointless to omit.
     return { action: 'pass', prompt: ctx.prompt, origin: rule.set_origin };
   }
+  // rewrite_prompt + strip_envelope — remove a single enclosing tag pair
+  // (e.g. Cursor's `<user_query>…</user_query>` wrapper, new app payload
+  // behavior observed 2026-06-11). Strips ONLY when both tags are present;
+  // the inner text is kept verbatim apart from the whitespace adjacent to
+  // the tags, which belongs to the envelope. Idempotent: a stripped prompt
+  // no longer starts with the open tag, so re-evaluation passes through.
+  //
+  // Convergence note: prompts stored BEFORE this rule shipped carry the
+  // wrapper, while new buffers strip it — so a session spanning the upgrade
+  // can replay-mismatch on the first-256-chars dedupe key. The prefix
+  // second-chance match won't bridge it either, since the wrapper changes
+  // the head of the text. Accepted: the window is one session generation.
+  if (rule.strip_envelope) {
+    const stripped = stripEnvelope(ctx.prompt, rule.strip_envelope.open, rule.strip_envelope.close);
+    if (stripped === null) {
+      return { action: 'pass', prompt: ctx.prompt, origin: rule.set_origin };
+    }
+    return { action: 'rewrite', prompt: stripped, reason: rule.reason, origin: rule.set_origin };
+  }
   // rewrite_prompt — keep only the substring after the extract_after marker.
   // If the marker isn't in the prompt, fall through to `pass` so we don't
   // accidentally blank out a prompt that turned out not to match after all.
@@ -324,4 +343,19 @@ function applyAction(rule: CaptureRule, ctx: UserPromptRuleContext): UserPromptD
   const next = rule.trim ? after.trim() : after;
   if (!next) return { action: 'pass', prompt: ctx.prompt, origin: rule.set_origin };
   return { action: 'rewrite', prompt: next, reason: rule.reason, origin: rule.set_origin };
+}
+
+/**
+ * Strip a single `open`…`close` envelope from a prompt. Returns the inner
+ * text, or null when the envelope isn't fully present (only one tag, tags
+ * out of order, or an empty interior — never blank out a prompt).
+ */
+function stripEnvelope(prompt: string, open: string, close: string): string | null {
+  if (!prompt.startsWith(open) || !prompt.endsWith(close)) return null;
+  if (prompt.length < open.length + close.length) return null;
+  const inner = prompt
+    .slice(open.length, prompt.length - close.length)
+    .replace(/^\s+/, '')
+    .replace(/\s+$/, '');
+  return inner.length > 0 ? inner : null;
 }

--- a/packages/myco/src/hooks/hook-config.generated.ts
+++ b/packages/myco/src/hooks/hook-config.generated.ts
@@ -356,7 +356,23 @@ export const HOOK_CONFIG: Readonly<Record<string, HookConfigEntry>> = {
         "followupMessage": "followup_message",
         "systemMessage": "system_message"
       }
-    }
+    },
+    "captureRules": [
+      {
+        "event": "user_prompt",
+        "scope": "this_agent",
+        "when": {
+          "prompt_starts_with": "<user_query>"
+        },
+        "action": "rewrite_prompt",
+        "reason": "strip Cursor user_query envelope",
+        "strip_envelope": {
+          "open": "<user_query>",
+          "close": "</user_query>"
+        },
+        "trim": true
+      }
+    ]
   },
   "opencode": {},
   "pi": {},

--- a/packages/myco/src/symbionts/canopy-read-tools.ts
+++ b/packages/myco/src/symbionts/canopy-read-tools.ts
@@ -95,6 +95,12 @@ function resolveFromEntries(
       continue;
     }
 
+    if ('extract' in entry && entry.extract === 'patch') {
+      const resolved = resolvePatchFile(entry, input);
+      if (resolved) return resolved;
+      continue;
+    }
+
     const value = input[entry.pathField];
     if (typeof value === 'string' && value.length > 0) {
       return { filePath: value };
@@ -102,6 +108,37 @@ function resolveFromEntries(
   }
 
   return null;
+}
+
+/**
+ * File headers inside an apply_patch envelope. The grammar (shared by
+ * Codex and opencode) wraps hunks in `*** Begin Patch` … `*** End Patch`
+ * with one header per touched file:
+ *
+ *     *** Add File: <path>
+ *     *** Update File: <path>      (optionally followed by `*** Move to:`)
+ *     *** Delete File: <path>
+ */
+const PATCH_FILE_HEADER = /^\*\*\* (?:Add|Update|Delete) File: (.+)$/m;
+
+/**
+ * Extract the file path from an apply_patch envelope string. A single
+ * envelope can touch multiple files; the FIRST header wins — one tool
+ * call only registers one activity row regardless (mirrors the
+ * last-positional compromise in `resolveShellArg`). `*** Move to:`
+ * destinations are deliberately not considered — the source header
+ * already identifies the file the patch is about.
+ */
+function resolvePatchFile(
+  entry: Extract<SymbiontCanopyReadTool, { extract: 'patch' }>,
+  input: Record<string, unknown>,
+): ResolvedRead | null {
+  const raw = input[entry.pathField];
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+  const match = PATCH_FILE_HEADER.exec(raw);
+  if (!match) return null;
+  const filePath = match[1].trim();
+  return filePath.length > 0 ? { filePath } : null;
 }
 
 function resolveShellArg(

--- a/packages/myco/src/symbionts/manifest-schema.ts
+++ b/packages/myco/src/symbionts/manifest-schema.ts
@@ -23,6 +23,18 @@ const CaptureRuleSchema = z.object({
   reason: z.string().optional(),
   /** For rewrite_prompt: keep the substring after this marker. */
   extract_after: z.string().optional(),
+  /**
+   * For rewrite_prompt: strip a single enclosing tag envelope. Fires only
+   * when the prompt starts with `open` AND ends with `close`; the inner
+   * text is kept verbatim (boundary whitespace adjacent to the tags is
+   * consumed as part of the envelope). When only one side is present the
+   * rule falls through to `pass` unchanged — same fail-safe stance as
+   * `extract_after`. Evaluated before `extract_after` when both are set.
+   */
+  strip_envelope: z.object({
+    open: z.string().min(1),
+    close: z.string().min(1),
+  }).optional(),
   /** For rewrite_prompt: trim whitespace from the extracted substring. */
   trim: z.boolean().default(true),
   /**
@@ -288,6 +300,11 @@ const RegistrationSchema = z.object({
  *    extracted via shlex; the entry's `readCommands` allowlist names the
  *    commands whose first non-flag argument is a path (e.g. Codex's `Bash`
  *    with `cat`, `head`, `tail`).
+ *  - patch: the path is embedded in an apply_patch envelope string
+ *    (`*** Begin Patch` … `*** End Patch`); the resolver scans the file
+ *    headers (`*** Add File:` / `*** Update File:` / `*** Delete File:`)
+ *    and returns the first one. Codex carries the envelope on `command`,
+ *    opencode on `patchText`.
  *
  * `pathKind` is reserved for future image/URL support and defaults to `'file'`.
  */
@@ -304,9 +321,16 @@ const CanopyReadToolShellArg = z.strictObject({
   readCommands: z.array(z.string().min(1)).min(1),
 });
 
+const CanopyReadToolPatch = z.strictObject({
+  tool: z.string().min(1),
+  pathField: z.string().min(1),
+  extract: z.literal('patch'),
+});
+
 const CanopyReadToolSchema = z.union([
   // More-specific first — z.union picks the first matching variant.
   CanopyReadToolShellArg,
+  CanopyReadToolPatch,
   CanopyReadToolStructured,
 ]);
 

--- a/packages/myco/src/symbionts/manifests.generated.ts
+++ b/packages/myco/src/symbionts/manifests.generated.ts
@@ -59,7 +59,49 @@ export const BUNDLED_MANIFESTS: readonly SymbiontManifest[] = [
       "subagentStartInjection": false,
       "toolTransport": "cli",
       "canopyReadTools": [],
-      "pathBearingTools": []
+      "pathBearingTools": [
+        {
+          "tool": "view_file",
+          "pathField": "AbsolutePath",
+          "pathKind": "file"
+        },
+        {
+          "tool": "write_to_file",
+          "pathField": "TargetFile",
+          "pathKind": "file"
+        },
+        {
+          "tool": "read_file",
+          "pathField": "file_path",
+          "pathKind": "file"
+        },
+        {
+          "tool": "replace",
+          "pathField": "file_path",
+          "pathKind": "file"
+        },
+        {
+          "tool": "run_shell_command",
+          "pathField": "command",
+          "extract": "shell-arg",
+          "readCommands": [
+            "cat",
+            "head",
+            "tail",
+            "less",
+            "more",
+            "bat",
+            "wc",
+            "file",
+            "nl",
+            "sed",
+            "awk",
+            "grep",
+            "rg",
+            "perl"
+          ]
+        }
+      ]
     },
     "hooks": {}
   },
@@ -560,6 +602,11 @@ export const BUNDLED_MANIFESTS: readonly SymbiontManifest[] = [
             "rg",
             "perl"
           ]
+        },
+        {
+          "tool": "apply_patch",
+          "pathField": "command",
+          "extract": "patch"
         }
       ]
     },
@@ -844,7 +891,22 @@ export const BUNDLED_MANIFESTS: readonly SymbiontManifest[] = [
         ".cursor/plans/"
       ],
       "planTags": [],
-      "rules": []
+      "rules": [
+        {
+          "event": "user_prompt",
+          "scope": "this_agent",
+          "when": {
+            "prompt_starts_with": "<user_query>"
+          },
+          "action": "rewrite_prompt",
+          "reason": "strip Cursor user_query envelope",
+          "strip_envelope": {
+            "open": "<user_query>",
+            "close": "</user_query>"
+          },
+          "trim": true
+        }
+      ]
     },
     "registration": {
       "hooksTarget": ".cursor/hooks.json",
@@ -882,7 +944,59 @@ export const BUNDLED_MANIFESTS: readonly SymbiontManifest[] = [
       "subagentStartInjection": false,
       "toolTransport": "cli",
       "canopyReadTools": [],
-      "pathBearingTools": []
+      "pathBearingTools": [
+        {
+          "tool": "Read",
+          "pathField": "file_path",
+          "pathKind": "file"
+        },
+        {
+          "tool": "Write",
+          "pathField": "file_path",
+          "pathKind": "file"
+        },
+        {
+          "tool": "Edit",
+          "pathField": "file_path",
+          "pathKind": "file"
+        },
+        {
+          "tool": "MultiEdit",
+          "pathField": "file_path",
+          "pathKind": "file"
+        },
+        {
+          "tool": "Delete",
+          "pathField": "file_path",
+          "pathKind": "file"
+        },
+        {
+          "tool": "Grep",
+          "pathField": "file_path",
+          "pathKind": "file"
+        },
+        {
+          "tool": "Shell",
+          "pathField": "command",
+          "extract": "shell-arg",
+          "readCommands": [
+            "cat",
+            "head",
+            "tail",
+            "less",
+            "more",
+            "bat",
+            "wc",
+            "file",
+            "nl",
+            "sed",
+            "awk",
+            "grep",
+            "rg",
+            "perl"
+          ]
+        }
+      ]
     },
     "hooks": {}
   },
@@ -949,6 +1063,32 @@ export const BUNDLED_MANIFESTS: readonly SymbiontManifest[] = [
           "tool": "edit",
           "pathField": "filePath",
           "pathKind": "file"
+        },
+        {
+          "tool": "apply_patch",
+          "pathField": "patchText",
+          "extract": "patch"
+        },
+        {
+          "tool": "bash",
+          "pathField": "command",
+          "extract": "shell-arg",
+          "readCommands": [
+            "cat",
+            "head",
+            "tail",
+            "less",
+            "more",
+            "bat",
+            "wc",
+            "file",
+            "nl",
+            "sed",
+            "awk",
+            "grep",
+            "rg",
+            "perl"
+          ]
         }
       ]
     },
@@ -995,7 +1135,44 @@ export const BUNDLED_MANIFESTS: readonly SymbiontManifest[] = [
       "subagentStartInjection": false,
       "toolTransport": "mcp",
       "canopyReadTools": [],
-      "pathBearingTools": []
+      "pathBearingTools": [
+        {
+          "tool": "read",
+          "pathField": "path",
+          "pathKind": "file"
+        },
+        {
+          "tool": "write",
+          "pathField": "path",
+          "pathKind": "file"
+        },
+        {
+          "tool": "edit",
+          "pathField": "path",
+          "pathKind": "file"
+        },
+        {
+          "tool": "bash",
+          "pathField": "command",
+          "extract": "shell-arg",
+          "readCommands": [
+            "cat",
+            "head",
+            "tail",
+            "less",
+            "more",
+            "bat",
+            "wc",
+            "file",
+            "nl",
+            "sed",
+            "awk",
+            "grep",
+            "rg",
+            "perl"
+          ]
+        }
+      ]
     },
     "hooks": {}
   },
@@ -1045,7 +1222,34 @@ export const BUNDLED_MANIFESTS: readonly SymbiontManifest[] = [
       "subagentStartInjection": false,
       "toolTransport": "cli",
       "canopyReadTools": [],
-      "pathBearingTools": []
+      "pathBearingTools": [
+        {
+          "tool": "post_write_code",
+          "pathField": "file_path",
+          "pathKind": "file"
+        },
+        {
+          "tool": "post_run_command",
+          "pathField": "command",
+          "extract": "shell-arg",
+          "readCommands": [
+            "cat",
+            "head",
+            "tail",
+            "less",
+            "more",
+            "bat",
+            "wc",
+            "file",
+            "nl",
+            "sed",
+            "awk",
+            "grep",
+            "rg",
+            "perl"
+          ]
+        }
+      ]
     },
     "hooks": {
       "post_cascade_response": {

--- a/packages/myco/src/symbionts/manifests/antigravity.yaml
+++ b/packages/myco/src/symbionts/manifests/antigravity.yaml
@@ -114,3 +114,26 @@ capabilities:
   sessionStartInjection: true
   subagentStartInjection: false
   preToolUseInjection: false
+  # Tools whose toolCall.args carry a file path. Antigravity's current app
+  # uses PascalCase argument names — confirmed from the live buffer of smoke
+  # session b49c825e… (2026-06-11): `view_file` with `{ AbsolutePath,
+  # StartLine, EndLine, … }` and `write_to_file` with `{ TargetFile,
+  # CodeContent, Overwrite, … }`. The snake_case entries below cover the
+  # Gemini-era tool surface (`read_file`/`replace` with `file_path`,
+  # `run_shell_command` with `command`) still present in older installs —
+  # the dogfood vault has extracted rows for both generations.
+  pathBearingTools:
+    # Current Antigravity app (PascalCase args)
+    - tool: view_file
+      pathField: AbsolutePath
+    - tool: write_to_file
+      pathField: TargetFile
+    # Gemini-era surface (snake_case args)
+    - tool: read_file
+      pathField: file_path
+    - tool: replace
+      pathField: file_path
+    - tool: run_shell_command
+      pathField: command
+      extract: shell-arg
+      readCommands: [cat, head, tail, less, more, bat, wc, file, nl, sed, awk, grep, rg, perl]

--- a/packages/myco/src/symbionts/manifests/codex.yaml
+++ b/packages/myco/src/symbionts/manifests/codex.yaml
@@ -257,10 +257,13 @@ capabilities:
         - grep
         - rg
         - perl
-  # Codex's write surface flows through the same Bash tool (editor commands,
-  # apply_patch-style scripts) — no separate path-bearing tool name exists
-  # beyond the read entry above. Mirror canopyReadTools so capture stays
-  # symmetric with the read surface.
+  # Codex's read surface flows through the Bash tool; its write surface is
+  # the dedicated `apply_patch` tool, which carries the whole patch envelope
+  # on `command` ("*** Begin Patch\n*** Update File: docs/x.md\n…") — the
+  # path lives in the `*** Add/Update/Delete File:` header, so the `patch`
+  # extractor pulls the first one (multi-file patches still register a
+  # single activity row). Shape confirmed from the dogfood vault's activity
+  # history (2,780 apply_patch rows, previously all file_path=NULL).
   pathBearingTools:
     - tool: Bash
       pathField: command
@@ -280,6 +283,9 @@ capabilities:
         - grep
         - rg
         - perl
+    - tool: apply_patch
+      pathField: command
+      extract: patch
 
 hooks:
   # Single-event turn-end: `Stop` carries both the inline response and the

--- a/packages/myco/src/symbionts/manifests/cursor.yaml
+++ b/packages/myco/src/symbionts/manifests/cursor.yaml
@@ -15,6 +15,23 @@ capture:
     # Watch both: home for agent-written plans, project-local for any committed plans.
     - ~/.cursor/plans/
     - .cursor/plans/
+  rules:
+    # New Cursor app payloads (observed live 2026-06-11, smoke session
+    # 64465029-53bf-43c2-bb6a-aea6627f56f4) wrap the user's text in a
+    # `<user_query>\n…\n</user_query>` envelope. Strip it so the stored
+    # prompt is the user's verbatim text. The strip only fires when BOTH
+    # tags are present (partial tags pass through untouched) and is
+    # idempotent — see stripEnvelope in hooks/capture-rules.ts, which also
+    # documents the replay-convergence window for sessions whose earlier
+    # batches were stored wrapped.
+    - event: user_prompt
+      when:
+        prompt_starts_with: "<user_query>"
+      action: rewrite_prompt
+      strip_envelope:
+        open: "<user_query>"
+        close: "</user_query>"
+      reason: strip Cursor user_query envelope
 registration:
   hooksTarget: .cursor/hooks.json
   globalHooksTarget: ~/.cursor/hooks.json
@@ -48,3 +65,31 @@ capabilities:
   # Cursor currently exposes subagentStart for lifecycle allow/deny, not
   # proven child model-context injection.
   subagentStartInjection: false
+  # Tools whose tool_input carries a file path. Cursor's composer exposes a
+  # Claude-Code-style tool surface (snake_case `file_path`), confirmed from
+  # live hook payloads (smoke session 64465029…, 2026-06-11: Read failure
+  # event with `tool_input.file_path`) and the dogfood vault's activity
+  # history (Read/Write/Edit/Delete/Grep/Shell input shapes). Without these
+  # entries, events attributed `agent: cursor` stored file_path=NULL — only
+  # events that Cursor's embedded Claude Code runtime mislabeled as
+  # `claude-code` happened to extract via that manifest.
+  pathBearingTools:
+    - tool: Read
+      pathField: file_path
+    - tool: Write
+      pathField: file_path
+    - tool: Edit
+      pathField: file_path
+    - tool: MultiEdit
+      pathField: file_path
+    - tool: Delete
+      pathField: file_path
+    # Grep carries `file_path` only when scoped to a single file; pattern-only
+    # searches have no path to extract and resolve to null.
+    - tool: Grep
+      pathField: file_path
+    # Shell input is `{ command, cwd, timeout }` — extract cat-style reads.
+    - tool: Shell
+      pathField: command
+      extract: shell-arg
+      readCommands: [cat, head, tail, less, more, bat, wc, file, nl, sed, awk, grep, rg, perl]

--- a/packages/myco/src/symbionts/manifests/opencode.yaml
+++ b/packages/myco/src/symbionts/manifests/opencode.yaml
@@ -46,3 +46,18 @@ capabilities:
       pathField: filePath
     - tool: edit
       pathField: filePath
+    # apply_patch carries the whole patch envelope on `patchText`
+    # ("*** Begin Patch\n*** Add File: /tmp/x\n+…\n*** End Patch") — the
+    # path lives in the `*** Add/Update/Delete File:` header, not a field.
+    # Confirmed from the live buffer of smoke session ses_147807fe…
+    # (2026-06-11). The `patch` extractor returns the FIRST file header;
+    # multi-file patches only register one activity row anyway. Hunk-level
+    # content beyond the headers is not extractable.
+    - tool: apply_patch
+      pathField: patchText
+      extract: patch
+    # bash input is `{ command, … }` — extract cat-style reads.
+    - tool: bash
+      pathField: command
+      extract: shell-arg
+      readCommands: [cat, head, tail, less, more, bat, wc, file, nl, sed, awk, grep, rg, perl]

--- a/packages/myco/src/symbionts/manifests/pi.yaml
+++ b/packages/myco/src/symbionts/manifests/pi.yaml
@@ -38,3 +38,20 @@ capabilities:
   # Pi can inject at before_agent_start, but spawned-subagent lifecycle needs
   # runtime proof before enabling direct child injection.
   subagentStartInjection: false
+  # Tools whose tool_input carries a file path. Pi's lowercase tools put it
+  # at `path` (relative or absolute) — confirmed from the live buffer of
+  # smoke session 2026-06-11T21-06-03…: `read`/`write` with
+  # `{ path, offset?, limit? }` / `{ path, content }`; the dogfood vault's
+  # activity history shows `edit` uses `{ path, edits: [...] }` and `bash`
+  # uses `{ command, timeout }`.
+  pathBearingTools:
+    - tool: read
+      pathField: path
+    - tool: write
+      pathField: path
+    - tool: edit
+      pathField: path
+    - tool: bash
+      pathField: command
+      extract: shell-arg
+      readCommands: [cat, head, tail, less, more, bat, wc, file, nl, sed, awk, grep, rg, perl]

--- a/packages/myco/src/symbionts/manifests/windsurf.yaml
+++ b/packages/myco/src/symbionts/manifests/windsurf.yaml
@@ -56,6 +56,28 @@ capabilities:
   # `myco_cortex` and to the AGENTS.md managed-guidance bullet.
   sessionStartInjection: false
   subagentStartInjection: false
+  # Tools whose tool_input carries a file path. Windsurf's hook payload puts
+  # event data in `tool_info` (mapped via hookFields.toolInput above), and
+  # `post_write_code` carries the path at the top level of that bag:
+  # `{ edits: [...], file_path: "..." }` — confirmed from the live buffer of
+  # smoke session 028329ac… (2026-06-11).
+  #
+  # READ-HOOK ABSENCE (app-side limitation): Cascade file views fire NO hook
+  # at all. The same smoke session read README.md (the assistant response
+  # even says "*Viewed file:…README.md*") yet the buffer contains only
+  # pre_user_prompt, post_write_code, and the cascade-response events.
+  # Windsurf's hook surface has no read/view event, so read activities
+  # cannot be captured — nothing to declare here until the app ships one.
+  # `post_run_command` IS registered in our hook template and documented
+  # (docs.windsurf.com/windsurf/cascade/hooks) to carry `tool_info.command`,
+  # so cat-style shell reads are the one read signal we can extract.
+  pathBearingTools:
+    - tool: post_write_code
+      pathField: file_path
+    - tool: post_run_command
+      pathField: command
+      extract: shell-arg
+      readCommands: [cat, head, tail, less, more, bat, wc, file, nl, sed, awk, grep, rg, perl]
 hooks:
   # Windsurf splits turn-end across two events. `post_cascade_response`
   # fires immediately with `tool_info.response` (inline text). The

--- a/tests/hooks/capture-rules.test.ts
+++ b/tests/hooks/capture-rules.test.ts
@@ -551,3 +551,75 @@ describe('transcript_meta_field_equals condition', () => {
     });
   });
 });
+
+describe('rewrite_prompt with strip_envelope', () => {
+  const envelopeRule = manifestWithRules('cursor', [
+    {
+      event: 'user_prompt',
+      scope: 'this_agent',
+      when: { prompt_starts_with: '<user_query>' },
+      action: 'rewrite_prompt',
+      strip_envelope: { open: '<user_query>', close: '</user_query>' },
+      reason: 'strip Cursor user_query envelope',
+      trim: true,
+    },
+  ]);
+
+  // The exact wrapped shape stored by the 2026-06-11 Cursor smoke session
+  // (64465029…): open tag, newline, verbatim text, newline, close tag.
+  const inner = 'This repo is myco’s capture pipeline project. Read the file README.md and tell me its first heading, then write a new file /tmp/smoke-v2-cursor.txt containing exactly: smoke-v2 cursor verified';
+  const wrapped = `<user_query>\n${inner}\n</user_query>`;
+
+  it('strips the envelope and keeps the inner text verbatim', () => {
+    const result = evaluateUserPromptRules([envelopeRule], 'cursor', ctx({ prompt: wrapped }));
+    expect(result).toEqual({
+      action: 'rewrite',
+      prompt: inner,
+      reason: 'strip Cursor user_query envelope',
+    });
+  });
+
+  it('is idempotent — re-evaluating the stripped prompt passes it through unchanged', () => {
+    const first = evaluateUserPromptRules([envelopeRule], 'cursor', ctx({ prompt: wrapped }));
+    expect(first.action).toBe('rewrite');
+    const again = evaluateUserPromptRules([envelopeRule], 'cursor', ctx({
+      prompt: (first as { prompt: string }).prompt,
+    }));
+    expect(again).toEqual({ action: 'pass', prompt: inner });
+  });
+
+  it('leaves an unwrapped prompt unchanged', () => {
+    const result = evaluateUserPromptRules([envelopeRule], 'cursor', ctx({ prompt: inner }));
+    expect(result).toEqual({ action: 'pass', prompt: inner });
+  });
+
+  it('leaves a prompt with only the open tag unchanged (partial envelope)', () => {
+    const openOnly = `<user_query>\n${inner}`;
+    const result = evaluateUserPromptRules([envelopeRule], 'cursor', ctx({ prompt: openOnly }));
+    expect(result).toEqual({ action: 'pass', prompt: openOnly });
+  });
+
+  it('leaves a prompt with only the close tag unchanged (partial envelope)', () => {
+    const closeOnly = `${inner}\n</user_query>`;
+    const result = evaluateUserPromptRules([envelopeRule], 'cursor', ctx({ prompt: closeOnly }));
+    expect(result).toEqual({ action: 'pass', prompt: closeOnly });
+  });
+
+  it('does not blank out an empty envelope', () => {
+    const empty = '<user_query>\n</user_query>';
+    const result = evaluateUserPromptRules([envelopeRule], 'cursor', ctx({ prompt: empty }));
+    expect(result).toEqual({ action: 'pass', prompt: empty });
+  });
+
+  it('keeps interior whitespace and tag-like content verbatim', () => {
+    const tricky = 'line one\n\n  indented <code>block</code>\nline three';
+    const result = evaluateUserPromptRules([envelopeRule], 'cursor', ctx({
+      prompt: `<user_query>${tricky}</user_query>`,
+    }));
+    expect(result).toEqual({
+      action: 'rewrite',
+      prompt: tricky,
+      reason: 'strip Cursor user_query envelope',
+    });
+  });
+});

--- a/tests/symbionts/canopy-read-tools.test.ts
+++ b/tests/symbionts/canopy-read-tools.test.ts
@@ -265,6 +265,52 @@ describe('extractAnyPath — shell-arg variant', () => {
   });
 });
 
+describe('extractAnyPath — patch variant', () => {
+  const patchManifest = {
+    capabilities: {
+      pathBearingTools: [
+        { tool: 'apply_patch', pathField: 'patchText', extract: 'patch' },
+      ],
+    },
+  } as unknown as SymbiontManifest;
+
+  it('extracts the path from an Add File header', () => {
+    expect(extractAnyPath(patchManifest, 'apply_patch', {
+      patchText: '*** Begin Patch\n*** Add File: /tmp/new.txt\n+hello\n*** End Patch',
+    })).toEqual({ filePath: '/tmp/new.txt' });
+  });
+  it('extracts the path from an Update File header', () => {
+    expect(extractAnyPath(patchManifest, 'apply_patch', {
+      patchText: '*** Begin Patch\n*** Update File: docs/groves.md\n@@\n-a\n+b\n*** End Patch',
+    })).toEqual({ filePath: 'docs/groves.md' });
+  });
+  it('extracts the path from a Delete File header', () => {
+    expect(extractAnyPath(patchManifest, 'apply_patch', {
+      patchText: '*** Begin Patch\n*** Delete File: src/old.ts\n*** End Patch',
+    })).toEqual({ filePath: 'src/old.ts' });
+  });
+  it('returns the FIRST header for multi-file patches', () => {
+    expect(extractAnyPath(patchManifest, 'apply_patch', {
+      patchText: '*** Begin Patch\n*** Update File: a.ts\n@@\n-x\n+y\n*** Add File: b.ts\n+z\n*** End Patch',
+    })).toEqual({ filePath: 'a.ts' });
+  });
+  it('returns null when the envelope has no file header', () => {
+    expect(extractAnyPath(patchManifest, 'apply_patch', {
+      patchText: '*** Begin Patch\n*** End Patch',
+    })).toBeNull();
+  });
+  it('returns null when the field is missing, empty, or not a string', () => {
+    expect(extractAnyPath(patchManifest, 'apply_patch', {})).toBeNull();
+    expect(extractAnyPath(patchManifest, 'apply_patch', { patchText: '' })).toBeNull();
+    expect(extractAnyPath(patchManifest, 'apply_patch', { patchText: 42 })).toBeNull();
+  });
+  it('does not match a header that is not at the start of a line', () => {
+    expect(extractAnyPath(patchManifest, 'apply_patch', {
+      patchText: 'prefix *** Add File: /tmp/x.txt',
+    })).toBeNull();
+  });
+});
+
 describe('allPathBearingToolNames', () => {
   it('returns Claude Read/Write/Edit/MultiEdit and Codex Bash', () => {
     const names = allPathBearingToolNames();

--- a/tests/symbionts/cursor-capture-rules.test.ts
+++ b/tests/symbionts/cursor-capture-rules.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'bun:test';
+import { loadManifests } from '@myco/symbionts/detect.js';
+import { evaluateUserPromptRules } from '@myco/hooks/capture-rules.js';
+
+/**
+ * Integration test that exercises the REAL cursor.yaml manifest through the
+ * Zod schema and the user-prompt rule evaluator — the `<user_query>`
+ * envelope strip end to end.
+ *
+ * New Cursor app payloads (observed live 2026-06-11, smoke session
+ * 64465029-53bf-43c2-bb6a-aea6627f56f4) wrap the user's text in
+ * `<user_query>\n…\n</user_query>`. The manifest rule strips the envelope
+ * so the stored prompt is the user's verbatim text. Guards against a YAML
+ * edit silently breaking the rule.
+ */
+describe('cursor.yaml capture rules', () => {
+  const cursor = () => loadManifests().find((m) => m.name === 'cursor')!;
+
+  it('parses cleanly through the Zod schema and declares the envelope rule', () => {
+    const rules = cursor().capture?.rules ?? [];
+    const envelope = rules.find((r) => r.action === 'rewrite_prompt' && r.strip_envelope);
+    expect(envelope).toBeDefined();
+    expect(envelope!.strip_envelope).toEqual({ open: '<user_query>', close: '</user_query>' });
+    expect(envelope!.when.prompt_starts_with).toBe('<user_query>');
+  });
+
+  it('strips the envelope from the exact smoke-run payload shape', () => {
+    const inner = "This repo is myco's capture pipeline project. Read the file README.md and tell me its first heading, then write a new file /tmp/smoke-v2-cursor.txt containing exactly: smoke-v2 cursor verified";
+    const result = evaluateUserPromptRules(loadManifests(), 'cursor', {
+      prompt: `<user_query>\n${inner}\n</user_query>`,
+    });
+    expect(result.action).toBe('rewrite');
+    expect((result as { prompt: string }).prompt).toBe(inner);
+  });
+
+  it('does not fire for other agents (this_agent scope)', () => {
+    // transcriptPath provided so codex's unrelated any_agent phantom-drop
+    // rule (transcript_path_missing) stays out of the way — this test is
+    // about the cursor envelope rule not crossing the agent boundary.
+    const wrapped = '<user_query>\nhello\n</user_query>';
+    const result = evaluateUserPromptRules(loadManifests(), 'claude-code', {
+      prompt: wrapped,
+      transcriptPath: '/Users/x/.claude/projects/p/session.jsonl',
+    });
+    expect(result).toEqual({ action: 'pass', prompt: wrapped });
+  });
+
+  it('leaves unwrapped cursor prompts unchanged', () => {
+    const result = evaluateUserPromptRules(loadManifests(), 'cursor', {
+      prompt: 'plain prompt with no envelope',
+    });
+    expect(result).toEqual({ action: 'pass', prompt: 'plain prompt with no envelope' });
+  });
+});

--- a/tests/symbionts/manifest-schema.test.ts
+++ b/tests/symbionts/manifest-schema.test.ts
@@ -475,16 +475,20 @@ describe('codex manifest enables Canopy PreToolUse for Bash reads', () => {
       .toEqual(expect.arrayContaining(['cat', 'head', 'tail']));
   });
 
-  it('declares pathBearingTools mirroring the Bash shell-arg entry', () => {
+  it('declares pathBearingTools covering Bash shell-arg reads and apply_patch writes', () => {
     const yamlPath = path.join(MANIFESTS_DIR, 'codex.yaml');
     const raw = YAML.parse(fs.readFileSync(yamlPath, 'utf8'));
     const m = SymbiontManifestSchema.parse(raw);
-    expect(m.capabilities?.pathBearingTools).toHaveLength(1);
-    const entry = m.capabilities!.pathBearingTools![0];
-    expect(entry).toMatchObject({
+    expect(m.capabilities?.pathBearingTools).toHaveLength(2);
+    expect(m.capabilities!.pathBearingTools![0]).toMatchObject({
       tool: 'Bash',
       pathField: 'command',
       extract: 'shell-arg',
+    });
+    expect(m.capabilities!.pathBearingTools![1]).toMatchObject({
+      tool: 'apply_patch',
+      pathField: 'command',
+      extract: 'patch',
     });
   });
 });

--- a/tests/symbionts/path-bearing-tools-manifests.test.ts
+++ b/tests/symbionts/path-bearing-tools-manifests.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'bun:test';
+import { loadManifests } from '@myco/symbionts/detect.js';
+import { extractAnyPath } from '@myco/symbionts/canopy-read-tools.js';
+import type { SymbiontManifest } from '@myco/symbionts/manifest-schema.js';
+
+/**
+ * Per-manifest extraction drift tests for `capabilities.pathBearingTools`.
+ *
+ * Every payload below is the REAL tool_input shape mined from live hook
+ * buffers / the dogfood vault during the 2026-06-11 capture-fidelity smoke
+ * runs (one session per symbiont). These tests exercise the actual YAML →
+ * Zod → resolver chain, so editing a manifest in a way that breaks a
+ * symbiont's path extraction fails here — not silently in production as
+ * `activities.file_path = NULL`.
+ */
+
+function manifest(name: string): SymbiontManifest {
+  const m = loadManifests().find((x) => x.name === name);
+  expect(m).toBeDefined();
+  return m!;
+}
+
+describe('claude-code pathBearingTools (reference behavior)', () => {
+  it('extracts Read file_path', () => {
+    expect(extractAnyPath(manifest('claude-code'), 'Read', {
+      file_path: '/Users/chris/Repos/myco/README.md', limit: 15,
+    })).toEqual({ filePath: '/Users/chris/Repos/myco/README.md' });
+  });
+  it('extracts Write file_path', () => {
+    expect(extractAnyPath(manifest('claude-code'), 'Write', {
+      file_path: '/tmp/smoke-v2-claude-code.txt', content: 'smoke-v2 claude-code verified',
+    })).toEqual({ filePath: '/tmp/smoke-v2-claude-code.txt' });
+  });
+});
+
+describe('cursor pathBearingTools', () => {
+  // Smoke session 64465029…: the Read failure event arrived with
+  // `agent: cursor` and `tool_input.file_path`, but cursor.yaml had no
+  // pathBearingTools — so file_path stored NULL while the Write event
+  // (mislabeled `agent: claude-code` by Cursor's embedded runtime)
+  // extracted via the claude-code manifest.
+  it('extracts Read file_path (the smoke-run failure case)', () => {
+    expect(extractAnyPath(manifest('cursor'), 'Read', {
+      file_path: '/tmp/smoke-v2-cursor.txt',
+    })).toEqual({ filePath: '/tmp/smoke-v2-cursor.txt' });
+  });
+  it('extracts Write file_path', () => {
+    expect(extractAnyPath(manifest('cursor'), 'Write', {
+      file_path: '/tmp/smoke-v2-cursor.txt', content: 'smoke-v2 cursor verified',
+    })).toEqual({ filePath: '/tmp/smoke-v2-cursor.txt' });
+  });
+  it('extracts Edit and Delete file_path', () => {
+    expect(extractAnyPath(manifest('cursor'), 'Edit', { file_path: 'src/x.ts' }))
+      .toEqual({ filePath: 'src/x.ts' });
+    expect(extractAnyPath(manifest('cursor'), 'Delete', {
+      file_path: '/Users/chris/Repos/myco/packages/myco/src/daemon/jobs/canopy-delta-scan.ts',
+    })).toEqual({ filePath: '/Users/chris/Repos/myco/packages/myco/src/daemon/jobs/canopy-delta-scan.ts' });
+  });
+  it('extracts Grep file_path when scoped to one file, null for pattern-only', () => {
+    expect(extractAnyPath(manifest('cursor'), 'Grep', {
+      pattern: 'codex/settings.json',
+      file_path: '/Users/chris/Repos/myco/packages/myco/src/symbionts/templates.generated.ts',
+      output_mode: 'content',
+    })).toEqual({ filePath: '/Users/chris/Repos/myco/packages/myco/src/symbionts/templates.generated.ts' });
+    expect(extractAnyPath(manifest('cursor'), 'Grep', {
+      pattern: 'upsertTomlSection', output_mode: 'files_with_matches',
+    })).toBeNull();
+  });
+  it('extracts Shell cat-style reads, null for non-read commands', () => {
+    expect(extractAnyPath(manifest('cursor'), 'Shell', {
+      command: 'cat README.md', cwd: '', timeout: 30000,
+    })).toEqual({ filePath: 'README.md' });
+    expect(extractAnyPath(manifest('cursor'), 'Shell', {
+      command: 'git log -1 --stat', cwd: '', timeout: 30000,
+    })).toBeNull();
+  });
+});
+
+describe('windsurf pathBearingTools', () => {
+  it('extracts post_write_code file_path from the tool_info bag', () => {
+    // Smoke session 028329ac…: tool_input is the `tool_info` bag with
+    // `file_path` at top level alongside the edits array.
+    expect(extractAnyPath(manifest('windsurf'), 'post_write_code', {
+      edits: [{ old_string: '', new_string: 'smoke-v2 cascade verified' }],
+      file_path: '/tmp/smoke-v2-cascade.txt',
+    })).toEqual({ filePath: '/tmp/smoke-v2-cascade.txt' });
+  });
+  it('extracts post_run_command cat-style reads', () => {
+    expect(extractAnyPath(manifest('windsurf'), 'post_run_command', {
+      command: 'cat README.md',
+    })).toEqual({ filePath: 'README.md' });
+  });
+  // Windsurf fires NO hook for file views (app-side limitation, documented
+  // in windsurf.yaml) — there is deliberately no read-tool entry to test.
+});
+
+describe('pi pathBearingTools', () => {
+  it('extracts read path', () => {
+    expect(extractAnyPath(manifest('pi'), 'read', {
+      path: 'README.md', offset: 1, limit: 40,
+    })).toEqual({ filePath: 'README.md' });
+  });
+  it('extracts write path', () => {
+    expect(extractAnyPath(manifest('pi'), 'write', {
+      path: '/tmp/smoke-v2-pi.txt', content: 'smoke-v2 pi verified',
+    })).toEqual({ filePath: '/tmp/smoke-v2-pi.txt' });
+  });
+  it('extracts edit path', () => {
+    expect(extractAnyPath(manifest('pi'), 'edit', {
+      path: 'scripts/one-shots/README.md', edits: [{ oldText: 'a', newText: 'b' }],
+    })).toEqual({ filePath: 'scripts/one-shots/README.md' });
+  });
+  it('extracts bash cat-style reads, null otherwise', () => {
+    expect(extractAnyPath(manifest('pi'), 'bash', { command: 'cat README.md', timeout: 20 }))
+      .toEqual({ filePath: 'README.md' });
+    expect(extractAnyPath(manifest('pi'), 'bash', { command: 'git status --short', timeout: 20 }))
+      .toBeNull();
+  });
+});
+
+describe('antigravity pathBearingTools', () => {
+  it('extracts view_file AbsolutePath (current app, PascalCase args)', () => {
+    expect(extractAnyPath(manifest('antigravity'), 'view_file', {
+      AbsolutePath: '/Users/chris/repos/myco/README.md',
+      EndLine: 20, StartLine: 1,
+      toolAction: 'Viewing README.md first lines',
+      toolSummary: 'Read README.md first lines',
+    })).toEqual({ filePath: '/Users/chris/repos/myco/README.md' });
+  });
+  it('extracts write_to_file TargetFile (current app, PascalCase args)', () => {
+    expect(extractAnyPath(manifest('antigravity'), 'write_to_file', {
+      CodeContent: 'smoke-v2 antigravity verified\n',
+      Description: 'Write verification smoke test file',
+      Overwrite: true,
+      TargetFile: '/tmp/smoke-v2-antigravity.txt',
+      toolAction: 'Writing smoke test file',
+      toolSummary: 'Create smoke-v2-antigravity.txt',
+    })).toEqual({ filePath: '/tmp/smoke-v2-antigravity.txt' });
+  });
+  it('extracts Gemini-era read_file/replace file_path', () => {
+    expect(extractAnyPath(manifest('antigravity'), 'read_file', {
+      file_path: 'packages/myco/src/db/queries/sessions.ts',
+    })).toEqual({ filePath: 'packages/myco/src/db/queries/sessions.ts' });
+    expect(extractAnyPath(manifest('antigravity'), 'replace', {
+      file_path: 'packages/myco/ui/src/components/mycelium/GraphCanvas.tsx',
+      old_string: 'a', new_string: 'b',
+    })).toEqual({ filePath: 'packages/myco/ui/src/components/mycelium/GraphCanvas.tsx' });
+  });
+  it('extracts run_shell_command cat-style reads', () => {
+    expect(extractAnyPath(manifest('antigravity'), 'run_shell_command', {
+      command: 'cat package.json', description: 'Inspect package',
+    })).toEqual({ filePath: 'package.json' });
+  });
+});
+
+describe('opencode pathBearingTools', () => {
+  it('extracts read filePath (camelCase)', () => {
+    // Smoke session ses_147807fe…: read carries BOTH filePath and file_path;
+    // the manifest declares the camelCase field.
+    expect(extractAnyPath(manifest('opencode'), 'read', {
+      filePath: '/Users/chris/Repos/myco/README.md', offset: 1, limit: 40,
+      file_path: '/Users/chris/Repos/myco/README.md',
+    })).toEqual({ filePath: '/Users/chris/Repos/myco/README.md' });
+  });
+  it('extracts apply_patch path from the patchText envelope', () => {
+    expect(extractAnyPath(manifest('opencode'), 'apply_patch', {
+      patchText: '*** Begin Patch\n*** Add File: /tmp/smoke-v2-opencode.txt\n+smoke-v2 opencode verified\n*** End Patch',
+    })).toEqual({ filePath: '/tmp/smoke-v2-opencode.txt' });
+  });
+  it('extracts bash cat-style reads', () => {
+    expect(extractAnyPath(manifest('opencode'), 'bash', {
+      command: 'cat packages/myco/package.json',
+    })).toEqual({ filePath: 'packages/myco/package.json' });
+  });
+});
+
+describe('codex pathBearingTools', () => {
+  it('still extracts Bash shell-arg reads (no regression)', () => {
+    expect(extractAnyPath(manifest('codex'), 'Bash', { command: "sed -n '1,5p' src/x.ts" }))
+      .toEqual({ filePath: 'src/x.ts' });
+  });
+  it('extracts apply_patch path from the command envelope', () => {
+    expect(extractAnyPath(manifest('codex'), 'apply_patch', {
+      command: '*** Begin Patch\n*** Update File: docs/groves.md\n@@\n-old\n+new\n*** End Patch',
+    })).toEqual({ filePath: 'docs/groves.md' });
+  });
+});
+
+describe('pathBearingTools coverage drift', () => {
+  it('every symbiont with observed path-bearing tool events declares the section', () => {
+    // copilot already declared its section before this change; the
+    // remaining manifests gained theirs from the 2026-06-11 smoke findings.
+    const covered = ['claude-code', 'codex', 'copilot', 'cursor', 'windsurf', 'pi', 'antigravity', 'opencode'];
+    for (const name of covered) {
+      const tools = manifest(name).capabilities?.pathBearingTools ?? [];
+      expect(tools.length).toBeGreaterThan(0);
+    }
+  });
+  it('canopyReadTools entries are always mirrored in pathBearingTools (schema invariant)', () => {
+    for (const m of loadManifests()) {
+      const reads = m.capabilities?.canopyReadTools ?? [];
+      const paths = m.capabilities?.pathBearingTools ?? [];
+      if (reads.length > 0) expect(paths.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## What

The release smoke's symbiont matrix (all eight agents driven with real tool tasks against the dev daemon) surfaced capture-fidelity gaps. Every fix here is grounded in the **live hook payloads** from those sessions, mined read-only from the dogfood grove's buffer files.

- **`pathBearingTools` for six manifests** (cursor, windsurf, pi, antigravity incl. both app generations, opencode, codex) with field paths taken from real payloads — pi and antigravity had no section at all; tool activities captured but file paths didn't, degrading plan capture and Canopy.
- **New `extract: patch` variant** for apply_patch grammars (line-anchored header parse — hunk content can't false-match). Recovers extraction for a 2,780-row historical NULL class on codex going forward.
- **New `strip_envelope` capture-rule action** for the new Cursor app behavior of wrapping prompts in `<user_query>` tags (Chris's live find): both-tags-required, inner verbatim, idempotent, cursor-scoped, applied identically on live/replay/miner paths via the single rule evaluator.
- **Windsurf/Cascade fires no hook for file views** — verified from the buffer (response says "Viewed file" yet no event exists); documented as an app-side limitation, with `post_run_command` shell-arg extraction as partial mitigation.

## The discovery worth knowing (deliberately out of scope)

Cursor's embedded Claude Code runtime fires the `~/.claude` hooks, so most cursor tool events arrive attributed to **claude-code** — historical cursor extraction (2552/2553 reads) "worked" through the wrong manifest, and the correctly-attributed events were the ones failing. Attribution is its own follow-up (smoke findings ledger F6).

## Review

Focused review verdict **SHIP**: patch grammar verified against all 2,955 real apply_patch rows in the vault; strip_envelope scoping/idempotence/replay-symmetry proven (including byte-level verification of the stored wrapped prompt's tail); every manifest field path spot-checked against the actual buffers; codegen idempotent. Full suite green; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)