### PR TITLE
config: refuse tier writes over unparseable files — local/project join the 422 contract (F13)

### DIFF
--- a/packages/myco/src/cli/remove.ts
+++ b/packages/myco/src/cli/remove.ts
@@ -5,7 +5,7 @@ import { confirmDestructive } from './confirm.js';
 import { loadManifests, resolvePackageRoot } from '../symbionts/detect.js';
 import { SymbiontInstaller, removeProjectLaunchers } from '../symbionts/installer.js';
 import { resolveMycoHome } from '../grove/paths.js';
-import { updateConfig } from '../config/loader.js';
+import { updateConfig, TierConfigUnreadableError } from '../config/loader.js';
 import type { SymbiontManifest } from '../symbionts/manifest-schema.js';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -247,12 +247,20 @@ async function runProjectRemove(parsed: ParsedFlags): Promise<void> {
       console.log(`  – ${manifest.displayName}: nothing to remove`);
     }
 
-    updateConfig(vaultDir, (c) => {
-      if (!c.symbionts?.[symbiontName]) return c;
-      const { [symbiontName]: _, ...rest } = c.symbionts;
-      return { ...c, symbionts: Object.keys(rest).length > 0 ? rest : undefined };
-    });
-    console.log(`  ✓ Removed ${symbiontName} from myco.yaml`);
+    try {
+      updateConfig(vaultDir, (c) => {
+        if (!c.symbionts?.[symbiontName]) return c;
+        const { [symbiontName]: _, ...rest } = c.symbionts;
+        return { ...c, symbionts: Object.keys(rest).length > 0 ? rest : undefined };
+      });
+      console.log(`  ✓ Removed ${symbiontName} from myco.yaml`);
+    } catch (err) {
+      if (!(err instanceof TierConfigUnreadableError)) throw err;
+      // Teardown proceeds: an unparseable myco.yaml has no reachable
+      // symbionts block to clean, and remove must not clobber a file the
+      // user may still want to repair.
+      console.log(`  !! Skipped myco.yaml cleanup — file is unparseable (${err.filePath})`);
+    }
     return;
   }
 

--- a/packages/myco/src/config/loader.ts
+++ b/packages/myco/src/config/loader.ts
@@ -332,7 +332,12 @@ function readRawYamlDocStrict(filePath: string): Record<string, unknown> {
   } catch (err) {
     throw new TierConfigUnreadableError(filePath, `invalid YAML — ${(err as Error).message}`);
   }
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+  // A null root (comments-only doc, bare `---`) holds zero YAML values —
+  // there is nothing a write could destroy, so treat it as empty rather
+  // than unwritable. Array/scalar roots still refuse: they're malformed
+  // docs whose content a write WOULD discard.
+  if (parsed === null || parsed === undefined) return {};
+  if (typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new TierConfigUnreadableError(filePath, 'root must be a YAML mapping');
   }
   return parsed as Record<string, unknown>;
@@ -681,7 +686,24 @@ function loadConfigInternal(vaultDir: string, options: LoadConfigOptions = {}): 
   }
 
   const raw = fs.readFileSync(configPath, 'utf-8');
-  const parsed = YAML.parse(raw) as Record<string, unknown>;
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = YAML.parse(raw) as Record<string, unknown>;
+  } catch (err) {
+    // Typed so write-path callers (scoped PUT, agent-tasks, symbionts patch)
+    // surface a 422 instead of a raw YAMLParseError 500. Load-path behavior
+    // is unchanged: corrupt myco.yaml has always thrown out of loadConfig.
+    throw new TierConfigUnreadableError(configPath, `invalid YAML — ${(err as Error).message}`);
+  }
+  // Non-mapping roots (null from a comments-only file, scalar, array) have
+  // always failed this loader — but as untyped TypeErrors from property
+  // access below. Classify them as unreadable so API callers get the same
+  // 422 contract as a parse failure. Unlike local.yaml (an optional overlay
+  // where a null root is treated as empty), myco.yaml is the project's
+  // identity document — a contentless root means it needs repair.
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new TierConfigUnreadableError(configPath, 'root must be a YAML mapping');
+  }
 
   // Detect v1 config and guide migration
   if (parsed.version === 1 || (parsed.intelligence as Record<string, unknown>)?.backend) {
@@ -795,7 +817,12 @@ export function saveConfig(vaultDir: string, config: MycoConfig): void {
   const projectOnly = ProjectConfigSchema.parse(validated) as Record<string, unknown>;
 
   const configPath = path.join(vaultDir, CONFIG_FILENAME);
-  const onDiskRaw = readRawYamlDoc(configPath);
+  // Strict read: refuse to overlay-and-write when the on-disk doc is
+  // unparseable. updateConfig callers never get here (loadConfig already
+  // throws on corrupt myco.yaml); this guards direct saveConfig callers,
+  // which would otherwise replace the user's (recoverable) file with a doc
+  // built from a config object that never saw the on-disk values.
+  const onDiskRaw = readRawYamlDocStrict(configPath);
   const defaults = MycoConfigSchema.parse({ version: 3 });
 
   // Machine-tier fields (capture/notifications/daemon log fields/legacy
@@ -1176,8 +1203,15 @@ export function loadMergedConfig(vaultDir: string, options: LoadMergedConfigOpti
 /**
  * Write local.yaml only when the serialized contents differ from `current`.
  * Skips the write (and mkdirSync) on a no-op to avoid noisy file mtimes.
+ *
+ * Strict-read gate: `current` comes from the lenient `loadLocalConfig`, which
+ * salvages an unparseable file as `{}` — building a write on that salvage
+ * would replace whatever the corrupt file held with just the caller's patch.
+ * Re-read the on-disk doc strictly and throw `TierConfigUnreadableError`
+ * before any write, mirroring the machine/grove raw-writer contract.
  */
 function writeLocalYamlIfChanged<T>(vaultDir: string, current: T, next: T): T {
+  readRawYamlDocStrict(localConfigPath(vaultDir));
   const existingYaml = YAML.stringify(current);
   const nextYaml = YAML.stringify(next);
   if (existingYaml === nextYaml) return next;

--- a/packages/myco/src/daemon/api/agent-tasks.ts
+++ b/packages/myco/src/daemon/api/agent-tasks.ts
@@ -414,6 +414,9 @@ export async function handleUpdateTaskConfig(
       withTaskConfig(config, taskId, body),
     );
   } catch (err) {
+    if (err instanceof TierConfigUnreadableError) {
+      return { status: 422, body: { error: 'tier_config_unreadable', message: err.message, file: err.filePath } };
+    }
     // withTaskConfig throws on unknown keys to prevent silent drops.
     // Surface the message to the UI so a stale form payload fails loudly.
     return { status: HTTP_BAD_REQUEST, body: { error: (err as Error).message } };

--- a/packages/myco/src/daemon/api/config.ts
+++ b/packages/myco/src/daemon/api/config.ts
@@ -211,6 +211,9 @@ export async function handlePutScopedConfig(vaultDir: string, body: unknown): Pr
       });
       return { body: updated };
     } catch (err) {
+      if (err instanceof TierConfigUnreadableError) {
+        return tierConfigUnreadableResponse(err);
+      }
       if (err instanceof z.ZodError) {
         return { status: 400, body: { error: 'validation_failed', issues: err.issues } };
       }
@@ -231,11 +234,31 @@ export async function handlePutScopedConfig(vaultDir: string, body: unknown): Pr
     });
     return { body: updated };
   } catch (err) {
+    if (err instanceof TierConfigUnreadableError) {
+      return tierConfigUnreadableResponse(err);
+    }
     if (err instanceof z.ZodError) {
       return { status: 400, body: { error: 'validation_failed', issues: err.issues } };
     }
     throw err;
   }
+}
+
+/**
+ * 422 envelope for a write refused because the on-disk tier file is
+ * unparseable. Shared by the local/project scoped-PUT branches; the
+ * machine/grove raw-writer path builds the same shape inline (it wraps the
+ * response in a touchedPaths envelope the scoped branches don't use).
+ */
+function tierConfigUnreadableResponse(err: TierConfigUnreadableError): RouteResponse {
+  return {
+    status: 422,
+    body: {
+      error: 'tier_config_unreadable',
+      message: 'The on-disk config file is invalid — fix or remove it before writing.',
+      file: err.filePath,
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/myco/src/daemon/api/symbionts.ts
+++ b/packages/myco/src/daemon/api/symbionts.ts
@@ -1,5 +1,5 @@
 import { loadManifests, resolvePackageRoot } from '@myco/symbionts/detect.js';
-import { loadConfig, loadMergedConfig, getEnabledSymbiontNames } from '../../config/loader.js';
+import { loadConfig, loadMergedConfig, getEnabledSymbiontNames, TierConfigUnreadableError } from '../../config/loader.js';
 import type { RouteHandler, RouteResponse } from '../router.js';
 import { detectSymbiontInjectionSupport } from '@myco/symbionts/injection-support.js';
 import { SymbiontInstaller } from '@myco/symbionts/installer.js';
@@ -375,6 +375,9 @@ export function createProjectSymbiontsPatchHandler(daemonStateDir: string): Rout
         sanitized as Record<string, { enabled: boolean } | null>,
       );
     } catch (err) {
+      if (err instanceof TierConfigUnreadableError) {
+        return { status: 422, body: errorBody('tier_config_unreadable', err.message) };
+      }
       return { status: 500, body: errorBody('patch_failed', (err as Error).message) };
     }
     return { body: { symbionts: updated.symbionts ?? {} } };

--- a/tests/config/rc3-config-tier-write-safety.test.ts
+++ b/tests/config/rc3-config-tier-write-safety.test.ts
@@ -18,10 +18,13 @@ import YAML from 'yaml';
 import {
   loadConfig,
   updateConfig,
+  updateLocalConfig,
+  saveLocalConfig,
   loadMergedConfig,
   invalidateMergedConfigCache,
   loadMachineConfig,
   setTierParseFailureListener,
+  TierConfigUnreadableError,
 } from '@myco/config/loader';
 import { CURRENT_MIGRATION_VERSION } from '@myco/config/migrations';
 import { clearProjectManifestCache } from '@myco/config/project-manifest';
@@ -407,5 +410,128 @@ describe('RC-3: tier-parse-failure listener replay (boot ordering)', () => {
     fs.writeFileSync(machineFile(), ':\nnot yaml: [\n');
     loadMachineConfig(sandbox.mycoHome);
     expect(seen.length).toBe(2);
+  });
+});
+
+describe('F13 — local/project tier write paths refuse unparseable files', () => {
+  let sandbox: ReturnType<typeof sandboxMycoHome>;
+  let vaultDir: string;
+
+  function configPath(): string {
+    return path.join(vaultDir, 'myco.yaml');
+  }
+  function localPath(): string {
+    return path.join(vaultDir, 'local.yaml');
+  }
+
+  beforeEach(() => {
+    sandbox = sandboxMycoHome('myco-f13-home-');
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-f13-vault-'));
+    fs.writeFileSync(configPath(), 'version: 3\n');
+    invalidateMergedConfigCache();
+    clearProjectManifestCache();
+  });
+
+  afterEach(() => {
+    setTierParseFailureListener(null);
+    sandbox.restore();
+    fs.rmSync(vaultDir, { recursive: true, force: true });
+    invalidateMergedConfigCache();
+    clearProjectManifestCache();
+  });
+
+  it('updateLocalConfig throws TierConfigUnreadableError on corrupt local.yaml and leaves the file untouched', () => {
+    const corrupt = 'notifications: [unclosed\n  bad{{{\n';
+    fs.writeFileSync(localPath(), corrupt);
+    expect(() => updateLocalConfig(vaultDir, (local) => ({ ...local, maintenance: { auto_optimize: false } })))
+      .toThrow(TierConfigUnreadableError);
+    expect(fs.readFileSync(localPath(), 'utf-8')).toBe(corrupt);
+  });
+
+  it('saveLocalConfig throws on a non-mapping local.yaml root and leaves the file untouched', () => {
+    const corrupt = '- a\n- list\n';
+    fs.writeFileSync(localPath(), corrupt);
+    expect(() => saveLocalConfig(vaultDir, { maintenance: { auto_optimize: false } }))
+      .toThrow(TierConfigUnreadableError);
+    expect(fs.readFileSync(localPath(), 'utf-8')).toBe(corrupt);
+  });
+
+  it('saveLocalConfig still writes a missing or empty local.yaml (greenfield unaffected)', () => {
+    saveLocalConfig(vaultDir, { maintenance: { auto_optimize: false } });
+    expect(getAtPath(YAML.parse(fs.readFileSync(localPath(), 'utf-8')), 'maintenance.auto_optimize')).toBe(false);
+
+    fs.writeFileSync(localPath(), '');
+    saveLocalConfig(vaultDir, { maintenance: { auto_optimize: true } });
+    expect(getAtPath(YAML.parse(fs.readFileSync(localPath(), 'utf-8')), 'maintenance.auto_optimize')).toBe(true);
+  });
+
+  it('scoped PUT at local scope returns 422 and does not clobber a corrupt local.yaml', async () => {
+    const corrupt = 'notifications: [unclosed\n  bad{{{\n';
+    fs.writeFileSync(localPath(), corrupt);
+
+    const res = await handlePutScopedConfig(vaultDir, {
+      scope: 'local',
+      patch: { notifications: { domains: { skills: { enabled: false } } } },
+    });
+    expect(res.status).toBe(422);
+    expect((res.body as Record<string, unknown>).error).toBe('tier_config_unreadable');
+    expect((res.body as Record<string, unknown>).file).toBe(localPath());
+    expect(fs.readFileSync(localPath(), 'utf-8')).toBe(corrupt);
+  });
+
+  it('updateConfig throws on corrupt myco.yaml before writing (single project write gate)', () => {
+    const corrupt = 'cortex: {unclosed\n';
+    fs.writeFileSync(configPath(), corrupt);
+    expect(() => updateConfig(vaultDir, (c) => c)).toThrow(TierConfigUnreadableError);
+    expect(fs.readFileSync(configPath(), 'utf-8')).toBe(corrupt);
+  });
+
+  it('comments-only local.yaml stays writable (null root holds no values to lose)', () => {
+    fs.writeFileSync(localPath(), '# capture-only overrides\n');
+    saveLocalConfig(vaultDir, { maintenance: { auto_optimize: false } });
+    expect(getAtPath(YAML.parse(fs.readFileSync(localPath(), 'utf-8')), 'maintenance.auto_optimize')).toBe(false);
+  });
+
+  it('non-mapping myco.yaml roots surface as 422 tier_config_unreadable, not raw TypeErrors', async () => {
+    for (const corrupt of ['# just a comment\n', 'scalar-root\n', '- a\n- list\n']) {
+      fs.writeFileSync(configPath(), corrupt);
+      invalidateMergedConfigCache();
+      const res = await handlePutScopedConfig(vaultDir, {
+        scope: 'project',
+        patch: { cortex: { enabled: true } },
+      });
+      expect(res.status).toBe(422);
+      expect((res.body as Record<string, unknown>).error).toBe('tier_config_unreadable');
+      expect(fs.readFileSync(configPath(), 'utf-8')).toBe(corrupt);
+    }
+  });
+
+  it('scoped PUT at project scope returns 422 and does not clobber a corrupt myco.yaml', async () => {
+    const corrupt = 'cortex: {unclosed\n';
+    fs.writeFileSync(configPath(), corrupt);
+    setTierParseFailureListener(() => {});
+
+    const res = await handlePutScopedConfig(vaultDir, {
+      scope: 'project',
+      patch: { cortex: { enabled: true } },
+    });
+    expect(res.status).toBe(422);
+    expect((res.body as Record<string, unknown>).error).toBe('tier_config_unreadable');
+    expect(fs.readFileSync(configPath(), 'utf-8')).toBe(corrupt);
+  });
+
+  it('agent-tasks no-Grove fallback returns 422 on corrupt myco.yaml and leaves it untouched', async () => {
+    const corrupt = 'agent: [unterminated\n';
+    fs.writeFileSync(configPath(), corrupt);
+    setTierParseFailureListener(() => {});
+
+    const req = {
+      params: { id: 'vault-evolve' },
+      query: {},
+      body: { maxTurns: 9 },
+    } as unknown as RouteRequest;
+    const res = await handleUpdateTaskConfig(req, vaultDir, null);
+    expect(res.status).toBe(422);
+    expect(fs.readFileSync(configPath(), 'utf-8')).toBe(corrupt);
   });
 });


### PR DESCRIPTION
## Problem

Release-smoke finding F13: `PUT /api/config/scoped` at `scope: local` against an unparseable `.myco/local.yaml` returned **200 and replaced the file with just the patch** — silent data loss. The local tier's writers were built on the lenient read (`loadLocalConfig` salvages corrupt YAML as `{}`), so the subsequent write clobbered whatever the corrupt file held. Machine and grove tiers already refused via `TierConfigUnreadableError` → 422 (RC-3); local was the uncovered tier.

Investigation also corrected the project-tier picture: `loadConfig` has always **thrown** on corrupt `myco.yaml` (no clobber possible via `updateConfig`), but as a raw `YAMLParseError` → untyped 500s on API paths, and non-mapping roots escaped as `TypeError`s.

## Fix (pattern: every tier write path refuses an unparseable current file)

- `writeLocalYamlIfChanged` strict-reads `local.yaml` before any write — gates `saveLocalConfig`, `updateLocalConfig`, and capability seeding in one chokepoint. Null roots (comments-only docs) are treated as empty (nothing to lose); scalar/array roots refuse.
- `loadConfigInternal` types its parse failure and classifies non-mapping roots as `TierConfigUnreadableError`. Load-path semantics unchanged (it always threw).
- `saveConfig` strict-reads its on-disk overlay (defense for direct callers).
- 422 `tier_config_unreadable` mapping at every config-writing API: scoped PUT (local + project branches), agent-tasks no-Grove fallback, symbionts patch handler.
- `myco remove` warns-and-continues past an unparseable `myco.yaml` rather than aborting teardown.

## Hot-path safety

`reseedCaptureOnly`/`ensureProjectVault({force:true})` throws are swallowed at the vault gate (`hooks/vault-gate.ts:94`) and project unarchive (`grove/project-lifecycle.ts:58`) — a corrupt `local.yaml` cannot crash hooks or block capture on registered projects. Cold-path provision over an externally corrupted `local.yaml` now fails loudly instead of clobbering (intended fail-closed trade).

## Adversarial probe round (caught 2, fixed both)

1. Comments-only `local.yaml` (null YAML root) would have become permanently unwritable → null root now reads as empty.
2. Non-mapping `myco.yaml` roots surfaced as raw `TypeError` 500s → classified 422.

Probe verified clean: all `local.yaml` writers repo-wide are gated (incl. migration write-backs — unreachable on corrupt files), no caller branches on the old exception type, no-op write ordering, TOCTOU not widened.

## Testing

- 9 new regression tests in `tests/config/rc3-config-tier-write-safety.test.ts` (F13 block): direct writer throws + file byte-unchanged, scoped PUT 422s (both scopes), agent-tasks 422, greenfield/empty/comments-only files stay writable, non-mapping project roots across parse/scalar/array shapes.
- Full suite green locally (node + jsdom phases, JUnit artifacts clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)