### PR TITLE
team-sync: backfill dedup matches PENDING outbox entries only (RC-12)

### DIFF
--- a/packages/myco/src/db/queries/team-outbox.ts
+++ b/packages/myco/src/db/queries/team-outbox.ts
@@ -613,8 +613,15 @@ function backfillRows(
     // pending entry is safe: the worker upsert is keyed by the composite PK
     // (id, machine_id) and is idempotent, so the row simply pushes twice.
     //
-    // 'unsynced' mode (routine startup sweep) must still dedup against ALL
-    // existing outbox entries so it never re-queues a row already handed off.
+    // 'unsynced' mode (routine startup sweep) dedups against PENDING outbox
+    // entries only (sent_at IS NULL). A SENT-but-unpruned entry (retained
+    // 24h for diagnostics) must not mask an unsynced row: drop-path resets
+    // and JOIN-second-team both leave rows with synced_at NULL whose only
+    // outbox trace is a sent entry — deduping against those left the row
+    // absent from D1 (while the UI showed 0 pending) until the prune
+    // window expired. Re-enqueuing beside a sent entry is safe for the
+    // same reason 'all' mode tolerates duplicates: the worker upsert is
+    // keyed by composite PK and idempotent.
     const rows = mode === 'all'
       ? db.prepare(`SELECT * FROM ${table}`).all() as Record<string, unknown>[]
       : db.prepare(
@@ -623,6 +630,7 @@ function backfillRows(
            AND NOT EXISTS (
              SELECT 1 FROM team_outbox
              WHERE team_outbox.table_name = ? AND team_outbox.row_id = CAST(${table}.id AS TEXT)
+               AND team_outbox.sent_at IS NULL
            )`,
         ).all(table) as Record<string, unknown>[];
 

--- a/tests/db/queries/team-outbox.test.ts
+++ b/tests/db/queries/team-outbox.test.ts
@@ -357,6 +357,48 @@ describe('team outbox query helpers', () => {
     });
   });
 
+  describe('backfillUnsynced — sent-entry masking (RC-12)', () => {
+    it('re-enqueues an unsynced row whose only outbox trace is sent-but-unpruned', () => {
+      const db = getDatabase();
+      const now = epochNow();
+      // An unsynced local row (synced_at NULL) — e.g. reset by the
+      // JOIN/drop path — whose prior outbox entry was sent and is inside
+      // the 24h retention window.
+      db.prepare(
+        `INSERT INTO sessions (
+          id, agent, started_at, created_at, machine_id, synced_at
+        ) VALUES (?, ?, ?, ?, ?, NULL)`,
+      ).run('session-masked', 'codex', now, now, 'machine-a');
+      const stale = enqueueOutbox(makeOutbox({
+        table_name: 'sessions', row_id: 'session-masked', machine_id: 'machine-a',
+      }));
+      markSent([stale.id], now - 60);
+
+      // Pre-fix: the sent entry masked the row — backfill found nothing and
+      // the row stayed absent from D1 while the UI showed 0 pending.
+      expect(backfillUnsynced('machine-a')).toBe(1);
+      expect(listPending()).toHaveLength(1);
+      expect(listPending()[0].row_id).toBe('session-masked');
+    });
+
+    it('still skips rows that already have a PENDING outbox entry', () => {
+      const db = getDatabase();
+      const now = epochNow();
+      db.prepare(
+        `INSERT INTO sessions (
+          id, agent, started_at, created_at, machine_id, synced_at
+        ) VALUES (?, ?, ?, ?, ?, NULL)`,
+      ).run('session-pending', 'codex', now, now, 'machine-a');
+      enqueueOutbox(makeOutbox({
+        table_name: 'sessions', row_id: 'session-pending', machine_id: 'machine-a',
+      }));
+
+      // Already handed off — the sweep must not double-queue it.
+      expect(backfillUnsynced('machine-a')).toBe(0);
+      expect(listPending()).toHaveLength(1);
+    });
+  });
+
   describe('backfillAll', () => {
     it('re-enqueues previously synced Grove rows', () => {
       const db = getDatabase();


### PR DESCRIPTION
## Problem (bug-hunt RC-12, Wave 3)

The routine unsynced backfill sweep's `NOT EXISTS` matched **any** outbox row for a `(table, row_id)` — including SENT entries retained 24h for diagnostics. A sent-but-unpruned entry masked a genuinely unsynced row:

- the drop path resets `synced_at` but `markSent`s the old entry rather than discarding it (its own comment relies on the backfill this dedup defeated), and
- JOIN-second-team within the retention window leaves the member row **absent from D1 while the Team UI reports 0 pending**, until the prune window expires and an unrelated reconcile recovers it.

## Fix

Dedup requires `sent_at IS NULL`: only a PENDING entry (handed off, not yet drained) suppresses re-enqueue. Re-enqueuing beside a sent entry is safe by the same argument the rebuild path already documents — the worker upsert is keyed by composite `(id, machine_id)` and idempotent; worst case the row pushes twice.

**Sync versioning assessment** (standing practice): no `SYNC_PROTOCOL_VERSION` bump — the wire shape is unchanged; only the local selection of rows to enqueue changes.

## Testing

- Masking-shape regression test (unsynced row + sent-but-unpruned entry → re-enqueued) — **verified to fail against pre-fix source**.
- Still-skips-pending test (row with a pending entry is not double-queued).
- Full suite green (node + jsdom), JUnit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)