### PR TITLE
agent: run lifecycle owns inputs and retry state — resume caps, honest map phases, persisted context (RC-9, schema v60)

### DIFF
--- a/packages/myco/src/agent/definitions/tasks/canopy-describe.yaml
+++ b/packages/myco/src/agent/definitions/tasks/canopy-describe.yaml
@@ -99,6 +99,7 @@ phases:
       args:
         canopy_entry_path: "{{ params.canopy_entry_path | default(null) }}"
         limit: "{{ params.batch_size | default(10) }}"
+        max_attempts: "{{ params.max_attempts | default(2) }}"
       itemsPath: entries
 
     item:

--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -58,6 +58,7 @@ import {
   serializeCheckpointState,
 } from './executor-state.js';
 import { getAgentHarness } from './harness/index.js';
+import { HarnessExecutionError } from './harness/types.js';
 import {
   analyzeRuntimeTokenBudget,
   buildRunAccountingUpdate,
@@ -92,6 +93,14 @@ const STATUS_SKIPPED = 'skipped';
 
 /** Reason string when skipping due to concurrency guard. */
 const SKIP_REASON_ALREADY_RUNNING = 'already_running';
+
+/**
+ * Grace added to the task timeout when judging whether a 'running' row is
+ * stale. A run loop enforces its own timeout abort, so a 'running' row older
+ * than timeout + margin has no live driver (e.g. the process died between
+ * boot-recovery sweeps) and must not block scheduling forever.
+ */
+const STALE_RUNNING_RUN_MARGIN_SECONDS = 300;
 
 /** Report action emitted by the Cortex instructions task. */
 const CORTEX_INSTRUCTIONS_REPORT_ACTION = 'cortex_instructions';
@@ -153,22 +162,25 @@ export async function runAgent(
     };
   }
 
-  // Block duplicate runs of the SAME task — different tasks may run concurrently.
-  const requestedTask = options?.task ?? resumedRun?.task ?? undefined;
-  {
-    const effectiveTask = requestedTask
-      ?? getDefaultTask(agentId)?.id;
-    if (effectiveTask) {
-      const runningId = getRunningRunForTask(agentId, effectiveTask, scope);
-      if (runningId) {
-        return {
-          runId: runningId,
-          status: STATUS_SKIPPED,
-          reason: SKIP_REASON_ALREADY_RUNNING,
-        };
-      }
-    }
+  if (resumedRun) {
+    // Restore any input the caller omitted from the resumed row so every
+    // resume path (scheduler and manual endpoint) executes with the original
+    // dispatch's inputs. dry_run is the load-bearing one: a resumed dry-run
+    // must never perform real writes. Caller-supplied values still win.
+    options = {
+      ...options,
+      instruction: options?.instruction ?? resumedRun.instruction ?? undefined,
+      runContext: options?.runContext ?? parseStoredRunContext(resumedRun.run_context),
+      dryRun: options?.dryRun ?? resumedRun.dry_run,
+      executionOverrides: options?.executionOverrides
+        ?? (resumedRun.execution_overrides as RunOptions['executionOverrides'])
+        ?? (resumedRun.reasoning_level
+          ? { reasoningLevel: resumedRun.reasoning_level }
+          : undefined),
+    };
   }
+
+  const requestedTask = options?.task ?? resumedRun?.task ?? undefined;
 
   const {
     config: resolvedConfig,
@@ -177,6 +189,36 @@ export async function runAgent(
     phaseProviderOverrides: resolvedPhaseOverrides,
     taskParams: resolvedTaskParams,
   } = resolveRunConfig(agentId, requestedTask, vaultDir, options?.requestContext?.groveId ?? null);
+
+  // Block duplicate runs of the SAME task — different tasks may run
+  // concurrently. A 'running' row older than the task timeout (+ margin)
+  // is treated as not-running: log it and proceed (boot recovery owns
+  // mutating the orphaned row).
+  {
+    const effectiveTask = requestedTask
+      ?? getDefaultTask(agentId)?.id;
+    if (effectiveTask) {
+      const running = getRunningRunForTask(
+        agentId,
+        effectiveTask,
+        scope,
+        resolvedConfig.timeoutSeconds + STALE_RUNNING_RUN_MARGIN_SECONDS,
+      );
+      if (running?.stale) {
+        options?.logger?.warn('agent.run.stale-running-row', `Ignoring stale running row for task ${effectiveTask}`, {
+          taskName: effectiveTask,
+          staleRunId: running.id,
+          startedAt: running.started_at,
+        });
+      } else if (running) {
+        return {
+          runId: running.id,
+          status: STATUS_SKIPPED,
+          reason: SKIP_REASON_ALREADY_RUNNING,
+        };
+      }
+    }
+  }
 
   // Build an effective config for this run by layering per-run overrides
   // on top of the resolved config WITHOUT mutating the resolveRunConfig
@@ -240,7 +282,6 @@ export async function runAgent(
     ?? taskProviderOverride
     ?? config.execution?.provider;
   const runId = options?.resumeRunId ?? crypto.randomUUID();
-  const now = epochSeconds();
   let harnessId = runHarness;
   let effectiveModel = resolveReasoningModel(
     config.execution?.reasoningLevel ?? config.reasoningLevel,
@@ -278,50 +319,6 @@ export async function runAgent(
     checkpointState.provider = checkpointState.provider ?? effectiveProvider?.type;
     checkpointState.providerConfig = checkpointState.providerConfig ?? effectiveProvider;
     checkpointState.model = checkpointState.model ?? effectiveModel;
-  }
-
-  const runStart = {
-    status: STATUS_RUNNING,
-    harness: harnessId,
-    model: effectiveModel,
-    checkpoints: serializeCheckpointState(checkpointState),
-    started_at: now,
-  } as const;
-  if (!resumedRun) {
-    insertRun({
-      id: runId,
-      project_id: projectId,
-      agent_id: agentId,
-      task: config.taskName,
-      instruction: options?.instruction ?? null,
-      ...runStart,
-      provider: effectiveProvider?.type ?? null,
-      usage_data: buildUsageData({}),
-      dryRun: options?.dryRun ?? false,
-      reasoningLevel:
-        options?.executionOverrides?.reasoningLevel
-        ?? config.reasoningLevel
-        ?? config.execution?.reasoningLevel
-        ?? null,
-      executionOverrides: options?.executionOverrides ?? null,
-    });
-  } else {
-    applyRunUpdate(runId, {
-      ...runStart,
-      provider: effectiveProvider?.type ?? resumedRun.provider ?? null,
-      completed_at: null,
-      resumable: 0,
-      resume_status: null,
-      resume_mode: options?.resumeMode ?? resumedRun.resume_mode ?? null,
-      resumed_at: now,
-      usage_data: resumedRun.usage_data,
-      cost_usd: resumedRun.cost_usd,
-      actual_cost_usd: resumedRun.actual_cost_usd,
-      estimated_cost_usd: resumedRun.estimated_cost_usd,
-      cost_source: resumedRun.cost_source,
-      cost_data: resumedRun.cost_data,
-      error: null,
-    }, scope);
   }
 
   const systemPrompt = loadSystemPrompt(definitionsDir, config.systemPromptPath);
@@ -389,6 +386,77 @@ export async function runAgent(
     taskAbortController.abort(new Error(`Agent run timed out after ${config.timeoutSeconds} seconds`));
   }, timeoutMs);
   timeoutId.unref?.();
+
+  // Re-check the duplicate-run guard synchronously, immediately before row
+  // creation. The early guard alone is not single-flight anymore: the
+  // resolver awaits above let two same-tick dispatches both pass it before
+  // either inserts. This check and the insert below run with no await
+  // between them, so the second dispatch always sees the first one's row.
+  {
+    const running = getRunningRunForTask(
+      agentId,
+      config.taskName,
+      scope,
+      config.timeoutSeconds + STALE_RUNNING_RUN_MARGIN_SECONDS,
+    );
+    if (running && !running.stale) {
+      clearTimeout(timeoutId);
+      return {
+        runId: running.id,
+        status: STATUS_SKIPPED,
+        reason: SKIP_REASON_ALREADY_RUNNING,
+      };
+    }
+  }
+
+  // Run-row creation sits immediately before the try so nothing throwable
+  // (prompt loading, vault context, provider resolution above) can leave an
+  // orphaned 'running' row that the catch below never marks failed.
+  const now = epochSeconds();
+  const runStart = {
+    status: STATUS_RUNNING,
+    harness: harnessId,
+    model: effectiveModel,
+    checkpoints: serializeCheckpointState(checkpointState),
+    started_at: now,
+  } as const;
+  if (!resumedRun) {
+    insertRun({
+      id: runId,
+      project_id: projectId,
+      agent_id: agentId,
+      task: config.taskName,
+      instruction: options?.instruction ?? null,
+      ...runStart,
+      provider: effectiveProvider?.type ?? null,
+      usage_data: buildUsageData({}),
+      run_context: options?.runContext ? JSON.stringify(options.runContext) : null,
+      dryRun: options?.dryRun ?? false,
+      reasoningLevel:
+        options?.executionOverrides?.reasoningLevel
+        ?? config.reasoningLevel
+        ?? config.execution?.reasoningLevel
+        ?? null,
+      executionOverrides: options?.executionOverrides ?? null,
+    });
+  } else {
+    applyRunUpdate(runId, {
+      ...runStart,
+      provider: effectiveProvider?.type ?? resumedRun.provider ?? null,
+      completed_at: null,
+      resumable: 0,
+      resume_status: null,
+      resume_mode: options?.resumeMode ?? resumedRun.resume_mode ?? null,
+      resumed_at: now,
+      usage_data: resumedRun.usage_data,
+      cost_usd: resumedRun.cost_usd,
+      actual_cost_usd: resumedRun.actual_cost_usd,
+      estimated_cost_usd: resumedRun.estimated_cost_usd,
+      cost_source: resumedRun.cost_source,
+      cost_data: resumedRun.cost_data,
+      error: null,
+    }, scope);
+  }
 
   let phaseResults: PhaseResult[] | undefined;
   try {
@@ -565,7 +633,13 @@ export async function runAgent(
     });
 
     try {
-      const usage = aggregateUsage(phaseResults?.map((phase) => phase.usage) ?? []);
+      // Non-phased failures carry their usage on HarnessExecutionError
+      // telemetry — without it a failed single-query records zero
+      // tokens/cost even though the requests were billed.
+      const failureTelemetry = err instanceof HarnessExecutionError ? err.telemetry : undefined;
+      const usage = phaseResults
+        ? aggregateUsage(phaseResults.map((phase) => phase.usage))
+        : failureTelemetry?.usage ?? aggregateUsage([]);
       logTokenBudgetPressure(config.taskName, usage, effectiveProvider, options?.logger);
       const costData = phaseResults ? summarizePhaseCosts(phaseResults) : await resolveCost({
         harness: harnessId,
@@ -823,4 +897,23 @@ function fallbackInstructionHash(instruction: string | undefined): string {
     .createHash(CONTENT_HASH_ALGORITHM)
     .update(instruction ?? '')
     .digest('hex');
+}
+
+/**
+ * Parse a persisted `agent_runs.run_context` JSON column back into
+ * RunOptions.runContext. Null, non-object, and unparseable payloads all
+ * degrade to undefined (corruption tolerance — a resume must not fail on a
+ * bad column).
+ */
+function parseStoredRunContext(raw: string | null): RunOptions['runContext'] {
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as RunOptions['runContext'];
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/myco/src/agent/phase-loop.ts
+++ b/packages/myco/src/agent/phase-loop.ts
@@ -425,9 +425,14 @@ async function runMapPhaseAdapter(input: ExecutePhaseInput): Promise<PhaseResult
     const writeAfterThrowPart = mapResult.writeAfterThrow > 0
       ? ` writeAfterThrow=${mapResult.writeAfterThrow}`
       : '';
+    // An all-poisoned batch (items fetched, nothing written) is a failure,
+    // not a quiet completion — every item either threw, was rejected by the
+    // sink, or never reached a terminal tool call. Surfacing it as 'failed'
+    // lets required map phases fail the run and fire the failure notify.
+    const allPoisoned = mapResult.itemCount > 0 && mapResult.written === 0;
     return buildPhaseResult({
       name: phase.name,
-      status: 'completed',
+      status: allPoisoned ? 'failed' : 'completed',
       summary: `map: written=${mapResult.written} skipped=${mapResult.skipped} failed=${mapResult.failed}${writeAfterThrowPart}`,
       usage: mapResult.usage,
       costData,
@@ -582,7 +587,12 @@ export async function executePhasedQuery(
   const phases = config.phases!;
   const state = ctx.checkpointState;
   const phaseResults: PhaseResult[] = checkpointResultsForResume(config, state);
-  let runningTurnCount = phaseResults.reduce((sum, phase) => sum + phase.turnsUsed, 0);
+  // Allocation-based audit offsets: the running base advances by each wave's
+  // total ALLOCATED turns (sum of resolved maxTurns), never by actual turns
+  // used, so every phase owns the same disjoint [offset, offset + maxTurns)
+  // turn-index range across fresh runs and resumes — audit indices can
+  // never collide.
+  let runningTurnCount = 0;
   const completedPhaseNames = new Set(phaseResults.map((phase) => phase.name));
 
   // -------------------------------------------------------------------------
@@ -645,18 +655,18 @@ export async function executePhasedQuery(
   const waves = computeWaves(effectivePhases);
 
   for (const wave of waves) {
-    const runnableWave = wave.filter((phase) => !completedPhaseNames.has(phase.name));
-    if (runnableWave.length === 0) {
-      continue;
-    }
-
-    const waveInputs = runnableWave.map((phase, indexInWave) => {
-      // Resolve execution config FIRST so the prompt can be templated
-      // with the resolved `maxTurns` (and future per-phase harness
-      // knobs). Single canonical precedence resolution — covers run
-      // overrides, phase YAML, myco.yaml per-phase overrides, top-level
-      // run override, and the task default. See `resolvePhaseExecution`
-      // JSDoc for the full precedence table.
+    // Resolve execution config for EVERY phase in the wave (not just the
+    // runnable ones) so each phase's offset is the prefix sum of its
+    // preceding siblings' resolved maxTurns — stable across resume, where
+    // completed phases are filtered out but still occupy their allocated
+    // turn-index range. Single canonical precedence resolution — covers run
+    // overrides, phase YAML, myco.yaml per-phase overrides, top-level run
+    // override, and the task default. See `resolvePhaseExecution` JSDoc for
+    // the full precedence table.
+    const resolvedByName = new Map<string, ReturnType<typeof resolvePhaseExecution>>();
+    const offsetByName = new Map<string, number>();
+    let waveAllocatedTurns = 0;
+    for (const phase of wave) {
       const resolved = resolvePhaseExecution(
         phase,
         ctx.options,
@@ -665,6 +675,19 @@ export async function executePhasedQuery(
         ctx.phaseProviderOverrides,
         ctx.options?.logger,
       );
+      resolvedByName.set(phase.name, resolved);
+      offsetByName.set(phase.name, runningTurnCount + waveAllocatedTurns);
+      waveAllocatedTurns += resolved.maxTurns;
+    }
+
+    const runnableWave = wave.filter((phase) => !completedPhaseNames.has(phase.name));
+    if (runnableWave.length === 0) {
+      runningTurnCount += waveAllocatedTurns;
+      continue;
+    }
+
+    const waveInputs = runnableWave.map((phase) => {
+      const resolved = resolvedByName.get(phase.name)!;
       const phaseProvider = resolved.provider;
       const effectiveMaxTurns = resolved.maxTurns;
       const phaseModel = resolved.model;
@@ -728,7 +751,7 @@ export async function executePhasedQuery(
           agentId,
           runId,
           toolNames: phase.tools,
-          turnOffset: runningTurnCount + (indexInWave * effectiveMaxTurns),
+          turnOffset: offsetByName.get(phase.name)!,
           projectRoot: ctx.projectRoot,
           vaultDir: ctx.vaultDir,
           requestContext: ctx.requestContext,
@@ -826,8 +849,8 @@ export async function executePhasedQuery(
         completedPhaseNames.add(result.name);
       }
       phaseResults.push(result);
-      runningTurnCount += result.turnsUsed;
     }
+    runningTurnCount += waveAllocatedTurns;
 
     if (ctx.persistCheckpoints) {
       await ctx.persistCheckpoints(state, phaseResults);

--- a/packages/myco/src/agent/tools/canopy-tools.ts
+++ b/packages/myco/src/agent/tools/canopy-tools.ts
@@ -21,7 +21,12 @@ import type { CanopyEntry } from '@myco/db/schema.js';
 import { resolveRequestContextForVault } from '@myco/grove/request-context.js';
 import { postProcess } from '@myco/canopy/describe/post-process.js';
 import { isCanopySensitivePath } from '@myco/canopy/sensitive-paths.js';
-import { describedCanopyEntriesPredicate, CANOPY_ENTRIES_ORDER_BY } from '@myco/db/queries/canopy.js';
+import {
+  describedCanopyEntriesPredicate,
+  CANOPY_ENTRIES_ORDER_BY,
+  PENDING_CANOPY_DESCRIBE_PREDICATE,
+  DEFAULT_CANOPY_DESCRIBE_MAX_ATTEMPTS,
+} from '@myco/db/queries/canopy.js';
 import { parseJsonStringArray } from '@myco/utils/parse-json-array.js';
 import { textResult, type VaultToolDeps } from './types.js';
 
@@ -58,12 +63,21 @@ const SELECT_PENDING_SQL = `
   SELECT *
   FROM canopy_entries
   WHERE project_id = ?
-    AND (
-      llm_updated_at IS NULL
-      OR llm_updated_at < mechanical_updated_at
-    )
+    AND ${PENDING_CANOPY_DESCRIBE_PREDICATE}
   ORDER BY (llm_updated_at IS NULL) DESC, mechanical_updated_at ASC
   LIMIT ?
+`;
+
+// Increment-at-fetch: every row a pending fetch hands to the harness counts
+// one attempt, whether the model later fails, the sink rejects the write, or
+// the row is filtered as sensitive. Rows at the cap fall out of
+// SELECT_PENDING_SQL until the mechanical scanner touches them again
+// (canopy/scanner/upsert.ts resets describe_attempts to 0).
+const INCREMENT_ATTEMPTS_SQL = `
+  UPDATE canopy_entries
+  SET describe_attempts = describe_attempts + 1
+  WHERE project_id = ?
+    AND path IN (SELECT value FROM json_each(?))
 `;
 
 const SELECT_BY_PATH_SQL = `
@@ -123,6 +137,7 @@ export function createCanopyTools(deps: VaultToolDeps) {
     {
       limit: z.number().int().positive().optional().describe(`Max rows to return (default ${DEFAULT_BATCH_LIMIT}, ceiling ${MAX_BATCH_LIMIT}).`),
       canopy_entry_path: z.string().optional().describe('When set, fetch this one row by path bypassing the pending predicate (single-row mode).'),
+      max_attempts: z.number().int().positive().optional().describe(`Per-row describe retry budget; rows fetched this many times without a description are excluded from pending mode (default ${DEFAULT_CANOPY_DESCRIBE_MAX_ATTEMPTS}). Sourced from the task's params.max_attempts.`),
     },
     async (args) => {
       if (describeNextIssued) {
@@ -153,7 +168,21 @@ export function createCanopyTools(deps: VaultToolDeps) {
       } else {
         const requested = args.limit ?? DEFAULT_BATCH_LIMIT;
         const limit = Math.min(Math.max(1, requested), MAX_BATCH_LIMIT);
-        rows = getDatabase().prepare(SELECT_PENDING_SQL).all(projectId, limit) as CanopyEntry[];
+        const maxAttempts = args.max_attempts ?? DEFAULT_CANOPY_DESCRIBE_MAX_ATTEMPTS;
+        // Fetch + attempt-increment in one transaction so a crash between
+        // the two can't hand out a batch that never accrued an attempt.
+        const db = getDatabase();
+        const fetchBatch = db.transaction(() => {
+          const batch = db.prepare(SELECT_PENDING_SQL).all(projectId, maxAttempts, limit) as CanopyEntry[];
+          if (batch.length > 0) {
+            db.prepare(INCREMENT_ATTEMPTS_SQL).run(
+              projectId,
+              JSON.stringify(batch.map((row) => row.path)),
+            );
+          }
+          return batch;
+        });
+        rows = fetchBatch();
       }
       const safeRows = rows.filter((row) => !isCanopySensitivePath(row.path));
 

--- a/packages/myco/src/canopy/scanner/upsert.ts
+++ b/packages/myco/src/canopy/scanner/upsert.ts
@@ -26,6 +26,11 @@ const COL_LIST = COLUMNS.join(', ');
  * `llm_description` and `llm_updated_at` are deliberately untouched here so
  * a Tier 2 description survives subsequent mechanical rescans; the
  * `canopy-describe` task is the only writer of those columns.
+ *
+ * `describe_attempts` resets to 0 on conflict: callers only upsert when
+ * content actually changed (scanners skip unchanged hashes), and changed
+ * content makes the row describable again even if the previous content
+ * exhausted its retry budget.
  */
 export function upsertCanopyEntry(db: Database, entry: CanopyEntry): void {
   db.prepare(
@@ -41,7 +46,8 @@ export function upsertCanopyEntry(db: Database, entry: CanopyEntry): void {
        exports_json          = EXCLUDED.exports_json,
        imports_json          = EXCLUDED.imports_json,
        top_comment           = EXCLUDED.top_comment,
-       mechanical_updated_at = EXCLUDED.mechanical_updated_at`,
+       mechanical_updated_at = EXCLUDED.mechanical_updated_at,
+       describe_attempts     = 0`,
   ).run(
     entry.project_id,
     entry.machine_id,

--- a/packages/myco/src/daemon/task-scheduling.ts
+++ b/packages/myco/src/daemon/task-scheduling.ts
@@ -17,11 +17,18 @@ import {
 } from '@myco/agent/instruction-builders.js';
 import { countSkillRecords } from '@myco/db/queries/skill-records.js';
 import { countCandidates } from '@myco/db/queries/skill-candidates.js';
-import { countPendingCanopyDescribe } from '@myco/db/queries/canopy.js';
+import { countPendingCanopyDescribe, DEFAULT_CANOPY_DESCRIBE_MAX_ATTEMPTS } from '@myco/db/queries/canopy.js';
 import { countUnprocessedSettledBatches, INTELLIGENCE_DEFAULT_ORIGINS } from '@myco/db/queries/batches.js';
 import { countTaskRunsSince, getLastCompletedRunsForProject } from '@myco/db/queries/project-activity.js';
 import { withDatabase } from '@myco/db/client.js';
-import { getLatestResumableRunForTask } from '@myco/db/queries/runs.js';
+import {
+  applyRunUpdate,
+  getLatestResumableRunForTask,
+  incrementRunResumeAttempts,
+  refundRunResumeAttempt,
+  RESUME_STATUS_EXHAUSTED,
+  type RunRow,
+} from '@myco/db/queries/runs.js';
 import { countToolCallsByRun } from '@myco/db/queries/turns.js';
 import { dispatchAgentRun } from '@myco/agent/runner-host.js';
 import { loadAllTasks } from '@myco/agent/registry.js';
@@ -62,6 +69,18 @@ export interface CanopyPendingProbeDeps {
   daemonStateDir: string;
 }
 
+// Per-row describe retry budget from the task's params, falling back to the
+// canopy-describe.yaml default. Threaded into every pending count so the
+// scheduler precondition/accelerator/probe agree with the fetch predicate
+// even when a project overrides params.max_attempts.
+function canopyDescribeMaxAttempts(config: MycoConfig | null): number {
+  const raw = config?.agent.tasks?.['canopy-describe']?.params?.max_attempts;
+  const parsed = typeof raw === 'number' ? raw : Number(raw);
+  return Number.isFinite(parsed) && parsed >= 1
+    ? Math.floor(parsed)
+    : DEFAULT_CANOPY_DESCRIBE_MAX_ATTEMPTS;
+}
+
 // Holds the daemon awake only when canopy-describe will actually drain the
 // pending rows. canopy-describe defaults to `schedule.enabled: false` while
 // canopy-background-scan ALWAYS populates pending rows — so an ungated hold
@@ -84,7 +103,12 @@ export function makeTotalCanopyPendingProbe(deps: CanopyPendingProbeDeps): () =>
           mycoHome,
         });
         if (!effectiveTaskScheduleEnabled(config, 'canopy-describe', false)) continue;
-        grovePending += countPendingCanopyDescribe(null, project.project_id, CANOPY_PROBE_COUNT_CAP);
+        grovePending += countPendingCanopyDescribe(
+          null,
+          project.project_id,
+          CANOPY_PROBE_COUNT_CAP,
+          canopyDescribeMaxAttempts(config),
+        );
         if (grovePending > 0) break;
       }
       return grovePending;
@@ -134,6 +158,61 @@ export function decideColdProjectGate(input: ColdProjectGateInput): ColdProjectG
 // a failed run would collapse history onto a single agent_runs row and
 // erase the failure signal we use to tune turn budgets. Always start fresh.
 const NON_RESUMABLE_SCHEDULED_TASKS = new Set<string>(['canopy-describe', 'canopy-map']);
+
+/**
+ * Scheduled resume retry budget per run. A run that fails this many resumes
+ * is terminal-marked (`resumable=0`, `resume_status='exhausted'`) and the
+ * scheduler starts a fresh run in the same tick instead of re-attaching to
+ * the failing checkpoint forever. Manual resumes (the API endpoint) do not
+ * consume the budget — only scheduler-driven retries count.
+ */
+export const RESUME_MAX_ATTEMPTS = 3;
+
+export interface ScheduledResumeGateInput {
+  run: RunRow;
+  taskName: string;
+  scope: ProjectScope;
+  projectVaultDir: string;
+  projectId: GroveProjectId;
+  config: MycoConfig;
+  logger: DaemonLogger;
+}
+
+/**
+ * Decide whether a resumable run may consume another scheduled resume.
+ *
+ * - Under the cap: increments `resume_attempts` (before dispatch, so a
+ *   crash mid-resume still counts) and returns 'resume'.
+ * - At the cap: terminal-marks the run (`resumable=0` +
+ *   `resume_status='exhausted'`), emits the agent.task.failure
+ *   notification, and returns 'exhausted' — the caller falls through to a
+ *   fresh dispatch in the same tick.
+ */
+export function gateScheduledResume(input: ScheduledResumeGateInput): 'resume' | 'exhausted' {
+  const { run, taskName, scope, projectVaultDir, projectId, config, logger } = input;
+  if (run.resume_attempts < RESUME_MAX_ATTEMPTS) {
+    incrementRunResumeAttempts(run.id, scope);
+    return 'resume';
+  }
+  applyRunUpdate(run.id, {
+    resumable: 0,
+    resume_status: RESUME_STATUS_EXHAUSTED,
+  }, scope);
+  logger.warn(LOG_KINDS.AGENT_ERROR, `Scheduled task ${taskName} resume retries exhausted — starting fresh`, {
+    project_id: projectId,
+    runId: run.id,
+    attempts: run.resume_attempts,
+  });
+  notify(projectVaultDir, {
+    domain: 'agents',
+    type: 'agent.task.failure',
+    title: `Task failed: ${taskName}`,
+    message: `Resume retries exhausted after ${run.resume_attempts} attempts; starting a fresh run`,
+    link: `/agent?run=${run.id}`,
+    metadata: { taskName, runId: run.id },
+  }, config, { projectId });
+  return 'exhausted';
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -305,21 +384,42 @@ export async function registerScheduledTasks(
       : getLatestResumableRunForTask(DEFAULT_AGENT_ID, taskName, readScope);
 
     if (resumableRun) {
-      const resumed = await dispatchAgentRun(projectVaultDir, {
-        agentId: DEFAULT_AGENT_ID,
-        task: taskName,
-        resumeRunId: resumableRun.id,
-        resumeMode: 'scheduled',
-        embeddingManager,
-        requestContext,
+      const gate = gateScheduledResume({
+        run: resumableRun,
+        taskName,
+        scope: readScope,
+        projectVaultDir,
+        projectId,
+        config,
         logger,
       });
-      logger.info(LOG_KINDS.AGENT_RUN, `Scheduled task ${taskName} resumed`, {
-        project_id: projectId,
-        status: resumed.status,
-        runId: resumed.runId,
-      });
-      return;
+      if (gate === 'resume') {
+        const resumed = await dispatchAgentRun(projectVaultDir, {
+          agentId: DEFAULT_AGENT_ID,
+          task: taskName,
+          resumeRunId: resumableRun.id,
+          resumeMode: 'scheduled',
+          embeddingManager,
+          requestContext,
+          logger,
+        });
+        if (resumed.status === 'skipped') {
+          // The executor never started the resume (another run of the task
+          // is active — e.g. a long manual run; the runningTasks set only
+          // covers scheduler dispatches). Only dispatches that actually
+          // start a resume consume budget, so hand the attempt back —
+          // otherwise ticks during that run would exhaust the budget with
+          // zero resumes executed.
+          refundRunResumeAttempt(resumableRun.id, readScope);
+        }
+        logger.info(LOG_KINDS.AGENT_RUN, `Scheduled task ${taskName} resumed`, {
+          project_id: projectId,
+          status: resumed.status,
+          runId: resumed.runId,
+        });
+        return;
+      }
+      // 'exhausted' — fall through to a fresh run in the same tick.
     }
 
     const taskConfig = config.agent.tasks?.[taskName];
@@ -514,7 +614,12 @@ export async function registerScheduledTasks(
           origins: INTELLIGENCE_DEFAULT_ORIGINS,
         }) > 0,
       'has-pending-canopy-rows': (scope) =>
-        countPendingCanopyDescribe(null, scope.projectId) > 0,
+        countPendingCanopyDescribe(
+          null,
+          scope.projectId,
+          undefined,
+          canopyDescribeMaxAttempts(resolveProjectConfig(scope)),
+        ) > 0,
       'has-active-skills': (scope) =>
         countSkillRecords({ status: 'active', scope: toProjectScope(scope.projectId) }) > 0,
       'has-approved-candidates': (scope) =>
@@ -527,7 +632,12 @@ export async function registerScheduledTasks(
     },
     accelerators: {
       'canopy-pending-describe': (scope, limit) =>
-        countPendingCanopyDescribe(null, scope.projectId, limit),
+        countPendingCanopyDescribe(
+          null,
+          scope.projectId,
+          limit,
+          canopyDescribeMaxAttempts(resolveProjectConfig(scope)),
+        ),
       'unprocessed-settled-batches': (scope, limit) =>
         countUnprocessedSettledBatches(toProjectScope(scope.projectId), {
           limit,

--- a/packages/myco/src/db/migrations.ts
+++ b/packages/myco/src/db/migrations.ts
@@ -118,6 +118,7 @@ export const MIGRATIONS: Migration[] = [
   { version: 57, migrate: (db) => migrateV56ToV57(db) },
   { version: 58, migrate: (db) => migrateV57ToV58(db) },
   { version: 59, migrate: (db) => migrateV58ToV59(db) },
+  { version: 60, migrate: (db) => migrateV59ToV60(db) },
 ];
 
 // ---------------------------------------------------------------------------
@@ -3727,6 +3728,58 @@ function migrateV58ToV59(db: Database): void {
     db.prepare(
       `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`,
     ).run(59, epochSeconds());
+    db.prepare('COMMIT').run();
+  } catch (err) {
+    db.prepare('ROLLBACK').run();
+    throw err;
+  }
+}
+
+/**
+ * Frozen at the v60 revision: run-lifecycle bookkeeping columns. Per the
+ * frozen-DDL rules above, these must never reference the live
+ * AGENT_RUNS_TABLE / CANOPY_ENTRIES_TABLE constants — later edits to the
+ * live DDL would silently change this migration's semantics.
+ */
+const V60_AGENT_RUNS_RESUME_ATTEMPTS =
+  'ALTER TABLE agent_runs ADD COLUMN resume_attempts INTEGER NOT NULL DEFAULT 0';
+
+const V60_AGENT_RUNS_RUN_CONTEXT =
+  'ALTER TABLE agent_runs ADD COLUMN run_context TEXT';
+
+const V60_CANOPY_ENTRIES_DESCRIBE_ATTEMPTS =
+  'ALTER TABLE canopy_entries ADD COLUMN describe_attempts INTEGER NOT NULL DEFAULT 0';
+
+/**
+ * v59 -> v60: run-lifecycle bookkeeping.
+ *
+ * - `agent_runs.resume_attempts` counts scheduled resume retries so the
+ *   scheduler can stop re-enqueueing a run that keeps failing (cap +
+ *   `resume_status = 'exhausted'`).
+ * - `agent_runs.run_context` persists RunOptions.runContext as JSON so a
+ *   resume restores the structured metadata the original dispatch carried.
+ * - `canopy_entries.describe_attempts` counts canopy-describe fetches per
+ *   row so a poisoned tail (rows the model can never describe) ages out of
+ *   the pending predicate instead of re-running forever.
+ */
+function migrateV59ToV60(db: Database): void {
+  db.prepare('BEGIN').run();
+  try {
+    const runCols = getTableColumnSet(db, 'agent_runs');
+    if (!runCols.has('resume_attempts')) {
+      db.prepare(V60_AGENT_RUNS_RESUME_ATTEMPTS).run();
+    }
+    if (!runCols.has('run_context')) {
+      db.prepare(V60_AGENT_RUNS_RUN_CONTEXT).run();
+    }
+    const canopyCols = getTableColumnSet(db, 'canopy_entries');
+    if (!canopyCols.has('describe_attempts')) {
+      db.prepare(V60_CANOPY_ENTRIES_DESCRIBE_ATTEMPTS).run();
+    }
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`,
+    ).run(60, epochSeconds());
     db.prepare('COMMIT').run();
   } catch (err) {
     db.prepare('ROLLBACK').run();

--- a/packages/myco/src/db/queries/canopy.ts
+++ b/packages/myco/src/db/queries/canopy.ts
@@ -377,18 +377,43 @@ export function describedCanopyEntriesPredicate(
 }
 
 /**
+ * Default canopy-describe retry budget per row. Mirrors the
+ * `params.max_attempts` default in canopy-describe.yaml; a per-project
+ * override of that param must be threaded through to every consumer of
+ * `PENDING_CANOPY_DESCRIBE_PREDICATE` so fetch and count agree.
+ */
+export const DEFAULT_CANOPY_DESCRIBE_MAX_ATTEMPTS = 2;
+
+/**
+ * Canonical "needs an llm_description" predicate for canopy_entries:
+ * description NULL or stale relative to mechanical_updated_at, AND the row
+ * has not exhausted its describe retry budget (one `?` placeholder for
+ * maxAttempts). Shared verbatim by the fetch (SELECT_PENDING_SQL in
+ * agent/tools/canopy-tools.ts) and the scheduler count below so the two
+ * can never disagree about what is pending. Attempts reset to 0 whenever
+ * the mechanical scanner updates the row (canopy/scanner/upsert.ts).
+ */
+export const PENDING_CANOPY_DESCRIBE_PREDICATE = `(
+      llm_updated_at IS NULL
+      OR llm_updated_at < mechanical_updated_at
+    )
+    AND describe_attempts < ?`;
+
+/**
  * Count canopy_entries rows that need an llm_description (NULL or stale
- * relative to mechanical_updated_at). Owned by the canopy domain — the
- * predicate must stay in lock-step with SELECT_PENDING_SQL in
- * agent/tools/canopy-tools.ts and the boolean has-pending-canopy-rows
- * precondition in daemon/task-scheduling.ts. Co-located with the rest of
- * the canopy queries so the scheduler doesn't have to import schema
- * knowledge it doesn't own.
+ * relative to mechanical_updated_at, with describe_attempts under the
+ * retry budget). Owned by the canopy domain — the predicate is literally
+ * shared with SELECT_PENDING_SQL in agent/tools/canopy-tools.ts and the
+ * boolean has-pending-canopy-rows precondition in
+ * daemon/task-scheduling.ts. Co-located with the rest of the canopy
+ * queries so the scheduler doesn't have to import schema knowledge it
+ * doesn't own.
  */
 export function countPendingCanopyDescribe(
   db: Database | null,
   projectId: string,
   limit?: number,
+  maxAttempts: number = DEFAULT_CANOPY_DESCRIBE_MAX_ATTEMPTS,
 ): number {
   const conn = db ?? getDatabase();
   if (limit !== undefined) {
@@ -397,23 +422,17 @@ export function countPendingCanopyDescribe(
       `SELECT COUNT(*) AS n FROM (
         SELECT 1 FROM canopy_entries
         WHERE project_id = ?
-          AND (
-            llm_updated_at IS NULL
-            OR llm_updated_at < mechanical_updated_at
-          )
+          AND ${PENDING_CANOPY_DESCRIBE_PREDICATE}
         LIMIT ?
       )`,
-    ).get(projectId, boundedLimit) as { n: number } | undefined;
+    ).get(projectId, maxAttempts, boundedLimit) as { n: number } | undefined;
     return row?.n ?? 0;
   }
   const row = conn.prepare(
     `SELECT COUNT(*) AS n FROM canopy_entries
       WHERE project_id = ?
-        AND (
-          llm_updated_at IS NULL
-          OR llm_updated_at < mechanical_updated_at
-        )`,
-  ).get(projectId) as { n: number } | undefined;
+        AND ${PENDING_CANOPY_DESCRIBE_PREDICATE}`,
+  ).get(projectId, maxAttempts) as { n: number } | undefined;
   return row?.n ?? 0;
 }
 
@@ -430,18 +449,29 @@ export interface CanopyDescribeBacklogOptions {
    * (which no scribe run will ever service) don't inflate the backlog.
    */
   projectIds?: readonly string[];
+  /**
+   * Per-row describe retry budget (the task's `params.max_attempts`).
+   * Callers without a resolved config take the yaml default so the backlog
+   * applies the same serviceability bar as the fetch/count predicate.
+   */
+  maxAttempts?: number;
 }
 
 /**
  * Count the upstream Canopy scribe backlog. This is deliberately separate
  * from embedding queue depth: changed files keep their old vector until the
  * describe task refreshes llm_description and re-queues embedding.
+ *
+ * Every bucket shares the fetch predicate's describe_attempts cap — rows a
+ * poisoned tail has exhausted are work no scribe run will ever service, so
+ * they must not inflate the backlog (`pending` stays `undescribed + stale`).
  */
 export function getCanopyDescribeBacklog(
   db: Database,
   scope: ProjectScope,
   options: CanopyDescribeBacklogOptions = {},
 ): CanopyDescribeBacklog {
+  const maxAttempts = options.maxAttempts ?? DEFAULT_CANOPY_DESCRIBE_MAX_ATTEMPTS;
   const { sql: projectSql, params } = projectScopeClause(scope);
   let restrictSql = '';
   if (options.projectIds) {
@@ -450,12 +480,12 @@ export function getCanopyDescribeBacklog(
   }
   const row = db.prepare(
     `SELECT
-       SUM(CASE WHEN llm_updated_at IS NULL OR llm_updated_at < mechanical_updated_at THEN 1 ELSE 0 END) AS pending,
-       SUM(CASE WHEN llm_updated_at IS NULL THEN 1 ELSE 0 END) AS undescribed,
-       SUM(CASE WHEN llm_updated_at IS NOT NULL AND llm_updated_at < mechanical_updated_at THEN 1 ELSE 0 END) AS stale
+       SUM(CASE WHEN ${PENDING_CANOPY_DESCRIBE_PREDICATE} THEN 1 ELSE 0 END) AS pending,
+       SUM(CASE WHEN llm_updated_at IS NULL AND describe_attempts < ? THEN 1 ELSE 0 END) AS undescribed,
+       SUM(CASE WHEN llm_updated_at IS NOT NULL AND llm_updated_at < mechanical_updated_at AND describe_attempts < ? THEN 1 ELSE 0 END) AS stale
        FROM canopy_entries
       WHERE 1 = 1${projectSql}${restrictSql}`,
-  ).get(...params) as { pending: number | null; undescribed: number | null; stale: number | null } | undefined;
+  ).get(maxAttempts, maxAttempts, maxAttempts, ...params) as { pending: number | null; undescribed: number | null; stale: number | null } | undefined;
   return {
     pending: Number(row?.pending ?? 0),
     undescribed: Number(row?.undescribed ?? 0),

--- a/packages/myco/src/db/queries/runs.ts
+++ b/packages/myco/src/db/queries/runs.ts
@@ -6,6 +6,7 @@
  */
 
 import { getDatabase } from '@myco/db/client.js';
+import { epochSeconds } from '@myco/constants.js';
 import { appendProjectCondition, type ProjectScope } from '@myco/db/queries/project-scope.js';
 import type { ProviderType, ReasoningLevel, HarnessId } from '@myco/agent/types.js';
 import type { CostSource } from '@myco/agent/cost/types.js';
@@ -42,6 +43,15 @@ export const RESUME_STATUS_READY = 'ready';
  */
 export const RESUME_STATUS_SESSION_EXPIRED = 'session_expired';
 
+/**
+ * Resume status used when a run has burned through the scheduler's resume
+ * retry budget (`resume_attempts` >= cap). Terminal like `session_expired`:
+ * `resumable=0` is what actually stops the scheduler loop —
+ * `getLatestResumableRunForTask` filters on `resumable = 1` and never reads
+ * `resume_status` — but the status tells operators why the run is final.
+ */
+export const RESUME_STATUS_EXHAUSTED = 'exhausted';
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -61,6 +71,8 @@ export interface RunInsert {
   resume_status?: string | null;
   resume_mode?: string | null;
   resumed_at?: number | null;
+  /** Scheduled resume retries consumed so far. Defaults to 0. */
+  resume_attempts?: number | null;
   checkpoints?: string | null;
   usage_data?: string | null;
   started_at?: number | null;
@@ -73,6 +85,8 @@ export interface RunInsert {
   cost_data?: string | null;
   actions_taken?: string | null;
   error?: string | null;
+  /** RunOptions.runContext serialized as JSON. Null when the run had none. */
+  run_context?: string | null;
   /** Whether this run was executed in dry-run mode (intercepted writes). */
   dryRun?: boolean;
   /**
@@ -103,6 +117,8 @@ export interface RunRow {
   resume_status: string | null;
   resume_mode: string | null;
   resumed_at: number | null;
+  /** Scheduled resume retries consumed so far. */
+  resume_attempts: number;
   checkpoints: string | null;
   usage_data: string | null;
   started_at: number | null;
@@ -115,6 +131,8 @@ export interface RunRow {
   cost_data: string | null;
   actions_taken: string | null;
   error: string | null;
+  /** RunOptions.runContext serialized as JSON. Null when the run had none. */
+  run_context: string | null;
   /** True when the run was executed in dry-run mode. */
   dry_run: boolean;
   /** Reasoning level applied to this run, or null if unset. */
@@ -139,6 +157,7 @@ export interface RunUpdate {
   resume_status?: string | null;
   resume_mode?: string | null;
   resumed_at?: number | null;
+  resume_attempts?: number;
   checkpoints?: string | null;
   usage_data?: string | null;
   completed_at?: number | null;
@@ -150,6 +169,7 @@ export interface RunUpdate {
   cost_data?: string | null;
   actions_taken?: string | null;
   error?: string | null;
+  run_context?: string | null;
   dryRun?: boolean;
   reasoningLevel?: ReasoningLevel | null;
   executionOverrides?: Record<string, unknown> | null;
@@ -184,6 +204,7 @@ const RUN_COLUMNS = [
   'resume_status',
   'resume_mode',
   'resumed_at',
+  'resume_attempts',
   'checkpoints',
   'usage_data',
   'started_at',
@@ -196,6 +217,7 @@ const RUN_COLUMNS = [
   'cost_data',
   'actions_taken',
   'error',
+  'run_context',
   'dry_run',
   'reasoning_level',
   'execution_overrides',
@@ -274,6 +296,7 @@ function toRunRow(row: Record<string, unknown>): RunRow {
     resume_status: (row.resume_status as string) ?? null,
     resume_mode: (row.resume_mode as string) ?? null,
     resumed_at: (row.resumed_at as number) ?? null,
+    resume_attempts: Number(row.resume_attempts ?? 0),
     checkpoints: (row.checkpoints as string) ?? null,
     usage_data: (row.usage_data as string) ?? null,
     started_at: (row.started_at as number) ?? null,
@@ -286,6 +309,7 @@ function toRunRow(row: Record<string, unknown>): RunRow {
     cost_data: (row.cost_data as string) ?? null,
     actions_taken: (row.actions_taken as string) ?? null,
     error: (row.error as string) ?? null,
+    run_context: (row.run_context as string) ?? null,
     dry_run: Boolean(Number(row.dry_run ?? 0)),
     reasoning_level: toReasoningLevelOrNull(row.reasoning_level),
     execution_overrides: parseJsonObjectColumn(row.execution_overrides),
@@ -342,6 +366,7 @@ const UPDATE_COLUMNS: readonly (keyof RunUpdate)[] = [
   'resume_status',
   'resume_mode',
   'resumed_at',
+  'resume_attempts',
   'checkpoints',
   'usage_data',
   'completed_at',
@@ -353,6 +378,7 @@ const UPDATE_COLUMNS: readonly (keyof RunUpdate)[] = [
   'cost_data',
   'actions_taken',
   'error',
+  'run_context',
 ];
 
 function buildUpdateClauses(update: RunUpdate): { setClauses: string[]; params: unknown[] } {
@@ -390,18 +416,18 @@ export function insertRun(data: RunInsert): RunRow {
     `INSERT INTO agent_runs (
        id, project_id, agent_id, task, instruction, status,
        harness, provider, model, session_ref, resumable,
-       resume_status, resume_mode, resumed_at, checkpoints, usage_data,
+       resume_status, resume_mode, resumed_at, resume_attempts, checkpoints, usage_data,
        started_at, completed_at, tokens_used, cost_usd,
        actual_cost_usd, estimated_cost_usd, cost_source, cost_data,
-       actions_taken, error, dry_run,
+       actions_taken, error, run_context, dry_run,
        reasoning_level, execution_overrides
      ) VALUES (
        ?, ?, ?, ?, ?, ?,
        ?, ?, ?, ?, ?,
-       ?, ?, ?, ?, ?,
+       ?, ?, ?, ?, ?, ?,
        ?, ?, ?, ?,
        ?, ?, ?, ?,
-       ?, ?, ?,
+       ?, ?, ?, ?,
        ?, ?
      )`,
   ).run(
@@ -419,6 +445,7 @@ export function insertRun(data: RunInsert): RunRow {
     data.resume_status ?? null,
     data.resume_mode ?? null,
     data.resumed_at ?? null,
+    data.resume_attempts ?? 0,
     data.checkpoints ?? null,
     data.usage_data ?? null,
     data.started_at ?? null,
@@ -431,6 +458,7 @@ export function insertRun(data: RunInsert): RunRow {
     data.cost_data ?? null,
     data.actions_taken ?? null,
     data.error ?? null,
+    data.run_context ?? null,
     data.dryRun ? 1 : 0,
     data.reasoningLevel ?? null,
     serializeExecutionOverrides(data.executionOverrides),
@@ -530,21 +558,78 @@ export function getRunningRun(agentId: string, scope: ProjectScope): RunRow | nu
   return row ? toRunRow(row) : null;
 }
 
+export interface RunningRunRef {
+  id: string;
+  started_at: number | null;
+  /**
+   * True when `maxAgeSeconds` was given and the row's `started_at` exceeds
+   * the cutoff — a 'running' row no run loop is still driving (e.g. an
+   * update killed the process between boot-recovery sweeps). Callers treat
+   * a stale ref as not-running and log it; the row itself is NOT mutated
+   * here (boot recovery's `markRunningRunsInterrupted` owns that).
+   */
+  stale: boolean;
+}
+
 export function getRunningRunForTask(
   agentId: string,
   taskName: string,
   scope: ProjectScope,
-): string | null {
+  maxAgeSeconds?: number,
+): RunningRunRef | null {
   const db = getDatabase();
   const conditions = ['agent_id = ?', 'task = ?', 'status = ?'];
   const params: unknown[] = [agentId, taskName, STATUS_RUNNING];
   appendProjectCondition(conditions, params, scope);
   const row = db.prepare(
-    `SELECT id FROM agent_runs
+    `SELECT id, started_at FROM agent_runs
      WHERE ${conditions.join(' AND ')}
+     ORDER BY started_at DESC NULLS LAST
      LIMIT 1`,
-  ).get(...params) as { id: string } | undefined;
-  return row?.id ?? null;
+  ).get(...params) as { id: string; started_at: number | null } | undefined;
+  if (!row) return null;
+  const stale = maxAgeSeconds !== undefined
+    && row.started_at !== null
+    && epochSeconds() - row.started_at > maxAgeSeconds;
+  return { id: row.id, started_at: row.started_at ?? null, stale };
+}
+
+/**
+ * Atomically bump `resume_attempts` for a run. Used by the scheduler before
+ * each resume dispatch so the retry budget survives daemon restarts.
+ * Returns the number of changed rows.
+ */
+export function incrementRunResumeAttempts(id: string, scope: ProjectScope): number {
+  const db = getDatabase();
+  const conditions = ['id = ?'];
+  const params: unknown[] = [id];
+  appendProjectCondition(conditions, params, scope);
+  const info = db.prepare(
+    `UPDATE agent_runs
+     SET resume_attempts = resume_attempts + 1
+     WHERE ${conditions.join(' AND ')}`,
+  ).run(...params);
+  return info.changes;
+}
+
+/**
+ * Refund one resume attempt, flooring at 0. Only dispatches that actually
+ * START a resume consume budget — a dispatch the executor skips
+ * (already_running, e.g. a long manual run of the same task) must hand its
+ * attempt back, or ticks during that run would exhaust the budget with
+ * zero resumes executed. Returns the number of changed rows.
+ */
+export function refundRunResumeAttempt(id: string, scope: ProjectScope): number {
+  const db = getDatabase();
+  const conditions = ['id = ?'];
+  const params: unknown[] = [id];
+  appendProjectCondition(conditions, params, scope);
+  const info = db.prepare(
+    `UPDATE agent_runs
+     SET resume_attempts = MAX(resume_attempts - 1, 0)
+     WHERE ${conditions.join(' AND ')}`,
+  ).run(...params);
+  return info.changes;
 }
 
 export function getLatestRunId(

--- a/packages/myco/src/db/schema-ddl.ts
+++ b/packages/myco/src/db/schema-ddl.ts
@@ -406,7 +406,9 @@ const AGENT_RUNS_TABLE = `
     error          TEXT,
     dry_run        INTEGER NOT NULL DEFAULT 0,
     reasoning_level      TEXT,
-    execution_overrides  TEXT
+    execution_overrides  TEXT,
+    resume_attempts INTEGER NOT NULL DEFAULT 0,
+    run_context    TEXT
   )`;
 
 const AGENT_REPORTS_TABLE = `
@@ -734,6 +736,7 @@ export const CANOPY_ENTRIES_TABLE = `
     llm_description        TEXT,
     llm_updated_at         INTEGER,
     embedded               INTEGER DEFAULT 0,
+    describe_attempts      INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (project_id, path)
   ) WITHOUT ROWID`;
 

--- a/packages/myco/src/db/schema.ts
+++ b/packages/myco/src/db/schema.ts
@@ -20,7 +20,7 @@ import { TABLE_DDLS, FTS_TABLES, SECONDARY_INDEXES, TEAM_DELETE_TRIGGERS } from 
 import { MIGRATIONS } from './migrations.js';
 
 /** Current schema version -- fresh start for the SQLite era. */
-export const SCHEMA_VERSION = 59;
+export const SCHEMA_VERSION = 60;
 
 // Re-export for backwards compat (other modules import from schema.ts)
 export { DEFAULT_MACHINE_ID };
@@ -51,6 +51,12 @@ export interface CanopyEntry {
   llm_description: string | null;
   llm_updated_at: number | null;
   embedded: number;
+  /**
+   * canopy-describe fetch attempts since the last mechanical update.
+   * Optional because scanner-constructed entries omit it (the column
+   * defaults to 0 and the mechanical upsert resets it).
+   */
+  describe_attempts?: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/agent/canopy-describe-map.integration.test.ts
+++ b/tests/agent/canopy-describe-map.integration.test.ts
@@ -38,6 +38,7 @@ const CREATE_CANOPY_ENTRIES = `
     llm_updated_at INTEGER,
     mechanical_updated_at INTEGER NOT NULL,
     embedded INTEGER DEFAULT 0,
+    describe_attempts INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (project_id, path)
   )
 `;

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -6,6 +6,8 @@ import * as __orig__myco_db_queries_reports_js_3__ns from '@myco/db/queries/repo
 const __orig__myco_db_queries_reports_js_3 = { ...__orig__myco_db_queries_reports_js_3__ns };
 import * as __orig__myco_db_client_js_4__ns from '@myco/db/client.js';
 const __orig__myco_db_client_js_4 = { ...__orig__myco_db_client_js_4__ns };
+import * as __orig__myco_agent_lmstudio_context_js_5__ns from '@myco/agent/lmstudio-context.js';
+const __orig__myco_agent_lmstudio_context_js_5 = { ...__orig__myco_agent_lmstudio_context_js_5__ns };
 /**
  * Tests for the agent executor.
  *
@@ -50,14 +52,16 @@ let allQueryCalls: Array<{ prompt: string; options?: Record<string, unknown> }> 
 /** Captured arguments from the last query() call (backward compat). */
 let capturedQueryArgs: { prompt: string; options?: Record<string, unknown> } | null = null;
 
+type MockQueryBehavior = 'success' | 'error' | 'error-after-usage' | 'empty' | 'abort';
+
 /**
  * Per-call behaviors. Each query() call shifts the next behavior.
  * Falls back to mockQueryBehavior when exhausted.
  */
-let mockQueryBehaviors: Array<'success' | 'error' | 'empty' | 'abort'> = [];
+let mockQueryBehaviors: MockQueryBehavior[] = [];
 
 /** Default behavior when mockQueryBehaviors is empty. */
-let mockQueryBehavior: 'success' | 'error' | 'empty' | 'abort' = 'success';
+let mockQueryBehavior: MockQueryBehavior = 'success';
 
 /** Custom error message for the 'error' behavior. */
 let mockErrorMessage = 'SDK exploded';
@@ -94,6 +98,32 @@ mock.module('@anthropic-ai/claude-agent-sdk', () => {
       return {
         [Symbol.asyncIterator]: async function* () {
           if (behavior === 'error') {
+            throw new Error(mockErrorMessage);
+          }
+
+          if (behavior === 'error-after-usage') {
+            // Usage lands on a result message before the stream blows up —
+            // the adapter wraps the throw in HarnessExecutionError telemetry.
+            yield {
+              type: 'result' as const,
+              subtype: 'error_during_execution' as const,
+              total_cost_usd: 0.0042,
+              usage: {
+                input_tokens: 1500,
+                output_tokens: 350,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+              },
+              num_turns: 3,
+              duration_ms: 5000,
+              duration_api_ms: 4500,
+              is_error: true,
+              stop_reason: 'end_turn',
+              modelUsage: {},
+              permission_denials: [],
+              uuid: '00000000-0000-0000-0000-000000000001',
+              session_id: 'test-session',
+            };
             throw new Error(mockErrorMessage);
           }
 
@@ -189,6 +219,9 @@ let mockOrchestratorConfig: OrchestratorConfig | undefined;
 /** Top-level task reasoning level from the registry mock. Set per-test. */
 let mockTaskReasoningLevel: 'low' | 'default' | 'high' | undefined;
 
+/** When set, loadSystemPrompt throws this error. Set per-test. */
+let mockLoadSystemPromptError: Error | null = null;
+
 mock.module('@myco/agent/loader.js', () => {
   const original = __orig__myco_agent_loader_js_1;
   return {
@@ -226,7 +259,10 @@ mock.module('@myco/agent/loader.js', () => {
         isDefault: true,
       }];
     },
-    loadSystemPrompt: () => TEST_SYSTEM_PROMPT,
+    loadSystemPrompt: () => {
+      if (mockLoadSystemPromptError) throw mockLoadSystemPromptError;
+      return TEST_SYSTEM_PROMPT;
+    },
     // Keep resolveEffectiveConfig from the original module
   };
 });
@@ -304,6 +340,28 @@ mock.module('@myco/db/queries/reports.js', () => {
   return {
     ...original,
     listReports: () => mockRunReports,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock: lmstudio context resolver — passthrough by default; a test can park
+// dispatches inside this await by setting the gate, forcing the same-tick
+// concurrency window between the early duplicate-run guard and row creation.
+// ---------------------------------------------------------------------------
+
+/** When set, resolveLmStudioContextLoads awaits this before resolving. */
+let mockLmStudioResolverGate: Promise<void> | null = null;
+
+mock.module('@myco/agent/lmstudio-context.js', () => {
+  const original = __orig__myco_agent_lmstudio_context_js_5;
+  return {
+    ...original,
+    resolveLmStudioContextLoads: async (
+      ...args: Parameters<typeof original.resolveLmStudioContextLoads>
+    ) => {
+      if (mockLmStudioResolverGate) await mockLmStudioResolverGate;
+      return original.resolveLmStudioContextLoads(...args);
+    },
   };
 });
 
@@ -392,6 +450,8 @@ function resetMockState(): void {
   mockExecution = undefined;
   mockOrchestratorConfig = undefined;
   mockTaskReasoningLevel = undefined;
+  mockLoadSystemPromptError = null;
+  mockLmStudioResolverGate = null;
   mockAssistantCount = 0;
   mockToolCallCounts = {};
   mockRunReports = [];
@@ -1942,5 +2002,250 @@ describe('computeWaves', () => {
     const waves = computeWaves([]);
 
     expect(waves).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: runAgent — run lifecycle (RC-9): resume input restoration, insert
+// window, stale running rows, failed-run telemetry.
+// ---------------------------------------------------------------------------
+
+describe('runAgent — run lifecycle', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(async () => {
+    resetMockState();
+    cleanTestDb();
+    await createTestAgent(TEST_AGENT_ID);
+    await createTestTask();
+  });
+
+  function insertResumableRun(overrides: Partial<Parameters<typeof insertRun>[0]> = {}): string {
+    const id = crypto.randomUUID();
+    insertRun({
+      id,
+      agent_id: TEST_AGENT_ID,
+      task: TEST_TASK_NAME,
+      status: 'failed',
+      resumable: 1,
+      resume_status: 'ready',
+      checkpoints: JSON.stringify({ harness: 'claude-sdk', phases: {} }),
+      started_at: epochSeconds() - 120,
+      completed_at: epochSeconds() - 60,
+      error: 'boom',
+      ...overrides,
+    });
+    return id;
+  }
+
+  it('restores instruction and run_context from the resumed row when the caller omits them', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+    const { getState } = await import('@myco/db/queries/agent-state.js');
+    const { SKILL_SURVEY_WATERMARK_KEY } = await import('@myco/agent/instruction-builders.js');
+
+    await createTask('skill-survey');
+    const runId = insertResumableRun({
+      task: 'skill-survey',
+      instruction: 'Original survey instruction',
+      run_context: JSON.stringify({ skill_survey_watermark: 777 }),
+    });
+
+    const result = await runAgent(TEST_VAULT_DIR, {
+      requestContext: TEST_REQUEST_CONTEXT,
+      resumeRunId: runId,
+      resumeMode: 'scheduled',
+    });
+
+    expect(result.status).toBe('completed');
+    expect(capturedQueryArgs!.prompt).toContain('Original survey instruction');
+    // runContext restoration is observable through the skill-survey success
+    // hook, which persists the watermark carried on runContext.
+    const state = getState(TEST_AGENT_ID, TEST_REQUEST_CONTEXT.projectId!, SKILL_SURVEY_WATERMARK_KEY);
+    expect(state?.value).toBe('777');
+  });
+
+  it('restores dry_run from the resumed row — a resumed dry-run skips success hooks', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+    const { getState } = await import('@myco/db/queries/agent-state.js');
+    const { SKILL_SURVEY_WATERMARK_KEY } = await import('@myco/agent/instruction-builders.js');
+
+    await createTask('skill-survey');
+    const runId = insertResumableRun({
+      task: 'skill-survey',
+      instruction: 'Original survey instruction',
+      run_context: JSON.stringify({ skill_survey_watermark: 888 }),
+      dryRun: true,
+    });
+
+    const result = await runAgent(TEST_VAULT_DIR, {
+      requestContext: TEST_REQUEST_CONTEXT,
+      resumeRunId: runId,
+      resumeMode: 'scheduled',
+    });
+
+    expect(result.status).toBe('completed');
+    // dry-run restored from the row → finalizeOnTaskSuccess early-returns,
+    // so the watermark must NOT be written.
+    expect(getState(TEST_AGENT_ID, TEST_REQUEST_CONTEXT.projectId!, SKILL_SURVEY_WATERMARK_KEY)).toBeNull();
+    expect(getRun(runId, ALL_PROJECTS_SCOPE)!.dry_run).toBe(true);
+  });
+
+  it('prefers caller-supplied values over the resumed row', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    const runId = insertResumableRun({ instruction: 'Row instruction A' });
+
+    const result = await runAgent(TEST_VAULT_DIR, {
+      requestContext: TEST_REQUEST_CONTEXT,
+      resumeRunId: runId,
+      instruction: 'Caller instruction B',
+    });
+
+    expect(result.status).toBe('completed');
+    expect(capturedQueryArgs!.prompt).toContain('Caller instruction B');
+    expect(capturedQueryArgs!.prompt).not.toContain('Row instruction A');
+  });
+
+  it('restores executionOverrides (reasoning tier) from the resumed row', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    mockExecution = {
+      provider: {
+        type: 'anthropic',
+        reasoningMap: { high: 'claude-high-tier', low: 'claude-low-tier' },
+      },
+    } as ExecutionConfig;
+    const runId = insertResumableRun({
+      reasoningLevel: 'high',
+      executionOverrides: { reasoningLevel: 'high' },
+    });
+
+    const result = await runAgent(TEST_VAULT_DIR, {
+      requestContext: TEST_REQUEST_CONTEXT,
+      resumeRunId: runId,
+    });
+
+    expect(result.status).toBe('completed');
+    expect((capturedQueryArgs!.options as Record<string, unknown>).model).toBe('claude-high-tier');
+  });
+
+  it('tolerates unparseable run_context on resume', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    const runId = insertResumableRun({ run_context: 'not-json{' });
+
+    const result = await runAgent(TEST_VAULT_DIR, {
+      requestContext: TEST_REQUEST_CONTEXT,
+      resumeRunId: runId,
+    });
+    expect(result.status).toBe('completed');
+  });
+
+  it('persists runContext to the run_context column on insert', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    const result = await runAgent(TEST_VAULT_DIR, {
+      requestContext: TEST_REQUEST_CONTEXT,
+      runContext: { skill_survey_watermark: 5 },
+    });
+
+    expect(result.status).toBe('completed');
+    const run = getRun(result.runId, ALL_PROJECTS_SCOPE)!;
+    expect(JSON.parse(run.run_context!)).toEqual({ skill_survey_watermark: 5 });
+  });
+
+  it('does not create a run row when pre-run setup throws', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    mockLoadSystemPromptError = new Error('definitions dir unreadable');
+
+    await expect(runAgent(TEST_VAULT_DIR, { requestContext: TEST_REQUEST_CONTEXT }))
+      .rejects.toThrow('definitions dir unreadable');
+
+    // No orphaned 'running' row: the row is created immediately before the
+    // try whose catch marks it failed, so a setup throw leaves nothing.
+    const count = getDatabase().prepare('SELECT COUNT(*) AS n FROM agent_runs').get() as { n: number };
+    expect(count.n).toBe(0);
+  });
+
+  it('does not let a stale running row block a new dispatch', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    const staleId = crypto.randomUUID();
+    insertRun({
+      id: staleId,
+      agent_id: TEST_AGENT_ID,
+      task: TEST_TASK_NAME,
+      status: 'running',
+      started_at: epochSeconds() - 7200,
+    });
+
+    const result = await runAgent(TEST_VAULT_DIR, { requestContext: TEST_REQUEST_CONTEXT, task: TEST_TASK_NAME });
+
+    expect(result.status).toBe('completed');
+    expect(result.runId).not.toBe(staleId);
+    // The guard is read-only: boot recovery owns marking the orphan.
+    expect(getRun(staleId, ALL_PROJECTS_SCOPE)!.status).toBe('running');
+  });
+
+  it('still skips when a fresh running row exists for the task', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    const freshId = crypto.randomUUID();
+    insertRun({
+      id: freshId,
+      agent_id: TEST_AGENT_ID,
+      task: TEST_TASK_NAME,
+      status: 'running',
+      started_at: epochSeconds() - 10,
+    });
+
+    const result = await runAgent(TEST_VAULT_DIR, { requestContext: TEST_REQUEST_CONTEXT, task: TEST_TASK_NAME });
+
+    expect(result.status).toBe('skipped');
+    expect(result.runId).toBe(freshId);
+  });
+
+  it('single-flights two same-tick concurrent dispatches of the same task', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    // Park both dispatches inside the resolver await — past the early
+    // duplicate-run guard, before row creation — then release them
+    // together. This is the window where the early guard alone admits both.
+    let release!: () => void;
+    mockLmStudioResolverGate = new Promise<void>((resolve) => { release = resolve; });
+
+    const first = runAgent(TEST_VAULT_DIR, { requestContext: TEST_REQUEST_CONTEXT, task: TEST_TASK_NAME });
+    const second = runAgent(TEST_VAULT_DIR, { requestContext: TEST_REQUEST_CONTEXT, task: TEST_TASK_NAME });
+    release();
+    const [r1, r2] = await Promise.all([first, second]);
+
+    const statuses = [r1.status, r2.status].sort();
+    expect(statuses).toEqual(['completed', 'skipped']);
+    const completed = r1.status === 'completed' ? r1 : r2;
+    const skipped = r1.status === 'skipped' ? r1 : r2;
+    expect(skipped.reason).toBe('already_running');
+    expect(skipped.runId).toBe(completed.runId);
+
+    // Exactly one agent_runs row — the loser never inserted.
+    const count = getDatabase().prepare('SELECT COUNT(*) AS n FROM agent_runs').get() as { n: number };
+    expect(count.n).toBe(1);
+    expect(getRun(completed.runId, ALL_PROJECTS_SCOPE)!.status).toBe('completed');
+  });
+
+  it('records telemetry usage and cost on a failed single-query', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    mockQueryBehavior = 'error-after-usage';
+    mockErrorMessage = 'stream exploded mid-run';
+
+    const result = await runAgent(TEST_VAULT_DIR, { requestContext: TEST_REQUEST_CONTEXT });
+
+    expect(result.status).toBe('failed');
+    const run = getRun(result.runId, ALL_PROJECTS_SCOPE)!;
+    expect(run.status).toBe('failed');
+    expect(run.tokens_used).toBe(1850);
+    expect(run.cost_usd).toBe(0.0042);
+    expect(run.cost_source).toBe('actual');
   });
 });

--- a/tests/agent/phase-loop.test.ts
+++ b/tests/agent/phase-loop.test.ts
@@ -7,6 +7,8 @@
  * a programmable fake instead of a real SDK.
  */
 
+import * as __orig__myco_agent_map_phase_js__ns from '@myco/agent/map-phase.js';
+const __orig__myco_agent_map_phase_js = { ...__orig__myco_agent_map_phase_js__ns };
 import { describe, it, expect, beforeAll, beforeEach, afterAll, mock } from 'bun:test';
 import { vi } from '../helpers/vi-shim.js';
 import fs from 'node:fs';
@@ -15,6 +17,7 @@ import path from 'node:path';
 import { ensureProjectManifest } from '@myco/config/project-manifest.js';
 import type {
   EffectiveConfig,
+  MapPhaseResult,
   PhaseDefinition,
   RuntimeUsage,
   HarnessId,
@@ -104,6 +107,20 @@ const fakeRuntime: AgentHarness = {
 
 mock.module('@myco/agent/harness/index.js', () => ({
   getAgentHarness: () => fakeRuntime,
+}));
+
+// Map-phase executor — passthrough by default, programmable per test so the
+// adapter's status mapping (all-poisoned batch → failed) can be exercised
+// without wiring real source/sink tools.
+let mapPhaseResultOverride: MapPhaseResult | null = null;
+mock.module('@myco/agent/map-phase.js', () => ({
+  ...__orig__myco_agent_map_phase_js,
+  executeMapPhase: async (
+    input: Parameters<typeof __orig__myco_agent_map_phase_js.executeMapPhase>[0],
+  ) => {
+    if (mapPhaseResultOverride) return mapPhaseResultOverride;
+    return __orig__myco_agent_map_phase_js.executeMapPhase(input);
+  },
 }));
 
 // Per-phase preCondition resolver — programmable per test.
@@ -215,6 +232,7 @@ beforeEach(() => {
   capturedExecuteInputs = [];
   runtimeSupportsSessionResume = false;
   phasePreConditionResult = { passed: true, reason: 'default-pass' };
+  mapPhaseResultOverride = null;
 });
 
 // ---------------------------------------------------------------------------
@@ -258,6 +276,68 @@ describe('executePhase', () => {
 
     expect(result.status).toBe('failed');
     expect(result.summary).toMatch(/source tool|nonexistent/i);
+  });
+
+  describe('map-phase batch status', () => {
+    const mapPhase: PhaseDefinition = {
+      name: 'describe', prompt: '', tools: [], maxTurns: 1, required: true,
+      mode: 'map',
+      perItemMaxTurns: 1,
+      source: { tool: 'stub_source', args: {}, itemsPath: 'entries' },
+      item: { prompt: 'x' },
+      sink: { tool: 'stub_sink', argMap: {} },
+    };
+
+    function mapResult(overrides: Partial<MapPhaseResult>): MapPhaseResult {
+      return {
+        itemCount: 0,
+        written: 0,
+        skipped: 0,
+        failed: 0,
+        abandoned: 0,
+        skipReasons: {},
+        writeAfterThrow: 0,
+        usage: {},
+        ...overrides,
+      };
+    }
+
+    async function runMapPhase() {
+      return executePhase({
+        ctx: baseContext(),
+        phasePrompt: 'p',
+        phaseModel: 'm',
+        phase: mapPhase,
+        toolSurface: { agentId: 'a', runId: 'r' },
+      });
+    }
+
+    it('fails the phase when items were fetched but nothing was written (all-poisoned batch)', async () => {
+      mapPhaseResultOverride = mapResult({ itemCount: 3, skipped: 3, skipReasons: { boilerplate: 3 } });
+      const result = await runMapPhase();
+      expect(result.status).toBe('failed');
+      expect(result.summary).toContain('written=0 skipped=3');
+    });
+
+    it('fails the phase when every item failed in the harness', async () => {
+      mapPhaseResultOverride = mapResult({ itemCount: 2, failed: 2 });
+      const result = await runMapPhase();
+      expect(result.status).toBe('failed');
+      expect(result.summary).toContain('failed=2');
+    });
+
+    it('completes when at least one item was written, even with mixed failures', async () => {
+      mapPhaseResultOverride = mapResult({ itemCount: 3, written: 1, skipped: 1, failed: 1 });
+      const result = await runMapPhase();
+      expect(result.status).toBe('completed');
+      expect(result.summary).toContain('written=1');
+    });
+
+    it('completes an empty batch (nothing fetched, nothing to write)', async () => {
+      mapPhaseResultOverride = mapResult({});
+      const result = await runMapPhase();
+      expect(result.status).toBe('completed');
+    });
   });
 
   it('returns a completed PhaseResult on runtime success', async () => {
@@ -653,5 +733,92 @@ describe('executePhasedQuery', () => {
     const ctx = baseContext({ config: baseConfig(phases), checkpointState });
     await executePhasedQuery(ctx);
     expect(capturedExecuteInputs[0].sessionRef).toBe('recoverable-session');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executePhasedQuery — allocation-based turnOffset
+// ---------------------------------------------------------------------------
+
+describe('executePhasedQuery turnOffset allocation', () => {
+  function offsetsByPrompt(): Map<string, number | undefined> {
+    const out = new Map<string, number | undefined>();
+    for (const input of capturedExecuteInputs) {
+      const match = input.prompt.match(/## Current Phase: (\S+)/);
+      if (match) out.set(match[1], input.toolSurface?.turnOffset);
+    }
+    return out;
+  }
+
+  it('within a wave, each phase offset is the prefix sum of preceding siblings maxTurns', async () => {
+    const phases = [
+      phase('a', { maxTurns: 3 }),
+      phase('b', { maxTurns: 10 }),
+    ];
+    const ctx = baseContext({ config: baseConfig(phases) });
+    await executePhasedQuery(ctx);
+
+    const offsets = offsetsByPrompt();
+    expect(offsets.get('a')).toBe(0);
+    expect(offsets.get('b')).toBe(3);
+  });
+
+  it('advances the cross-wave base by the wave\'s total ALLOCATED turns, not turns used', async () => {
+    // Each phase actually uses 1 turn (DEFAULT_USAGE.requests = 1); the
+    // second wave must still start at 3 + 10 = 13.
+    const phases = [
+      phase('a', { maxTurns: 3 }),
+      phase('b', { maxTurns: 10 }),
+      phase('c', { maxTurns: 4, dependsOn: ['a', 'b'] }),
+    ];
+    const ctx = baseContext({ config: baseConfig(phases) });
+    await executePhasedQuery(ctx);
+
+    const offsets = offsetsByPrompt();
+    expect(offsets.get('a')).toBe(0);
+    expect(offsets.get('b')).toBe(3);
+    expect(offsets.get('c')).toBe(13);
+  });
+
+  it('keeps the same offsets on resume — completed phases still occupy their allocated range', async () => {
+    const phases = [
+      phase('a', { maxTurns: 3 }),
+      phase('b', { maxTurns: 10 }),
+      phase('c', { maxTurns: 4, dependsOn: ['a', 'b'] }),
+    ];
+    const checkpointState: RunCheckpointState = {
+      harness: 'claude-sdk',
+      phases: {
+        a: { name: 'a', status: 'completed', summary: 'done', turnsUsed: 1, updatedAt: 0 },
+      },
+    };
+    const ctx = baseContext({ config: baseConfig(phases), checkpointState });
+    await executePhasedQuery(ctx);
+
+    const offsets = offsetsByPrompt();
+    expect(offsets.has('a')).toBe(false);
+    expect(offsets.get('b')).toBe(3);
+    expect(offsets.get('c')).toBe(13);
+  });
+
+  it('starts a later wave at the full allocation even when the entire first wave was restored', async () => {
+    const phases = [
+      phase('a', { maxTurns: 3 }),
+      phase('b', { maxTurns: 10 }),
+      phase('c', { maxTurns: 4, dependsOn: ['a', 'b'] }),
+    ];
+    const checkpointState: RunCheckpointState = {
+      harness: 'claude-sdk',
+      phases: {
+        a: { name: 'a', status: 'completed', summary: 'done', turnsUsed: 1, updatedAt: 0 },
+        b: { name: 'b', status: 'completed', summary: 'done', turnsUsed: 2, updatedAt: 0 },
+      },
+    };
+    const ctx = baseContext({ config: baseConfig(phases), checkpointState });
+    await executePhasedQuery(ctx);
+
+    const offsets = offsetsByPrompt();
+    expect(capturedExecuteInputs).toHaveLength(1);
+    expect(offsets.get('c')).toBe(13);
   });
 });

--- a/tests/agent/tools/canopy-tools.test.ts
+++ b/tests/agent/tools/canopy-tools.test.ts
@@ -22,6 +22,7 @@ function seedSchema(db: Database) {
       llm_updated_at INTEGER,
       mechanical_updated_at INTEGER NOT NULL,
       embedded INTEGER DEFAULT 0,
+      describe_attempts INTEGER NOT NULL DEFAULT 0,
       PRIMARY KEY (project_id, path)
     );
   `;

--- a/tests/canopy/describe-backlog.test.ts
+++ b/tests/canopy/describe-backlog.test.ts
@@ -13,6 +13,7 @@ import {
   registerProjectInGrove,
 } from '@myco/grove/registry';
 import { createCanopyDescribeBacklogReader } from '@myco/canopy/describe-backlog';
+import { getCanopyDescribeBacklog } from '@myco/db/queries/canopy';
 
 let home: string;
 let db: Database;
@@ -88,5 +89,46 @@ describe('canopy describe backlog reader', () => {
     );
 
     expect(backlog.undescribed).toBe(1);
+  });
+});
+
+describe('getCanopyDescribeBacklog — describe_attempts budget', () => {
+  function insertStaleEntry(projectId: string, filePath: string): void {
+    db.prepare(
+      `INSERT INTO canopy_entries (
+        project_id, path, content_hash, size_bytes, token_estimate,
+        line_count, mechanical_updated_at, llm_description, llm_updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(projectId, filePath, `hash-${filePath}`, 10, 5, 1, 200, 'old description', 100);
+  }
+
+  it('excludes capped rows from every bucket — no phantom backlog from a poisoned tail', () => {
+    insertUndescribedEntry('proj_a', 'fresh.ts');
+    insertUndescribedEntry('proj_a', 'poisoned.ts');
+    insertStaleEntry('proj_a', 'stale-poisoned.ts');
+    db.prepare(
+      `UPDATE canopy_entries SET describe_attempts = 2 WHERE path IN ('poisoned.ts', 'stale-poisoned.ts')`,
+    ).run();
+
+    const backlog = getCanopyDescribeBacklog(db, projectScope('proj_a'));
+    expect(backlog).toEqual({ pending: 1, undescribed: 1, stale: 0 });
+  });
+
+  it('reports zero against a fully-poisoned tail, matching the scheduler count', () => {
+    insertUndescribedEntry('proj_a', 'a.ts');
+    insertStaleEntry('proj_a', 'b.ts');
+    db.prepare('UPDATE canopy_entries SET describe_attempts = 2').run();
+
+    expect(getCanopyDescribeBacklog(db, projectScope('proj_a')))
+      .toEqual({ pending: 0, undescribed: 0, stale: 0 });
+  });
+
+  it('honors a larger per-project maxAttempts', () => {
+    insertUndescribedEntry('proj_a', 'a.ts');
+    insertStaleEntry('proj_a', 'b.ts');
+    db.prepare('UPDATE canopy_entries SET describe_attempts = 2').run();
+
+    expect(getCanopyDescribeBacklog(db, projectScope('proj_a'), { maxAttempts: 4 }))
+      .toEqual({ pending: 2, undescribed: 1, stale: 1 });
   });
 });

--- a/tests/canopy/describe/tools.test.ts
+++ b/tests/canopy/describe/tools.test.ts
@@ -7,6 +7,7 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { getDatabase } from '@myco/db/client.js';
+import { countPendingCanopyDescribe } from '@myco/db/queries/canopy.js';
 import { upsertCanopyEntry } from '@myco/canopy/scanner/upsert';
 import { createVaultTools } from '@myco/agent/tools.js';
 import type { CanopyEntry } from '@myco/db/schema';
@@ -153,6 +154,115 @@ describe('canopy_describe_next', () => {
     const tool = findTool(createTools(), 'canopy_describe_next');
     const out = parseResult(await tool.handler({}, {} as any));
     expect(out.entries).toEqual([]);
+  });
+});
+
+describe('canopy_describe_next — describe_attempts budget', () => {
+  function getAttempts(entryPath: string): number {
+    const row = getDatabase()
+      .prepare('SELECT describe_attempts FROM canopy_entries WHERE path = ?')
+      .get(entryPath) as { describe_attempts: number };
+    return row.describe_attempts;
+  }
+
+  it('increments describe_attempts for every row a pending fetch returns', async () => {
+    upsertCanopyEntry(getDatabase(), makeEntry({ path: 'src/foo.ts' }));
+    upsertCanopyEntry(getDatabase(), makeEntry({ path: 'src/bar.ts' }));
+
+    const tool = findTool(createTools(), 'canopy_describe_next');
+    const out = parseResult(await tool.handler({ limit: 5 }, {} as any));
+    expect(out.entries).toHaveLength(2);
+
+    expect(getAttempts('src/foo.ts')).toBe(1);
+    expect(getAttempts('src/bar.ts')).toBe(1);
+  });
+
+  it('excludes rows at the attempts cap from pending fetches', async () => {
+    upsertCanopyEntry(getDatabase(), makeEntry({ path: 'src/poisoned.ts' }));
+    upsertCanopyEntry(getDatabase(), makeEntry({ path: 'src/foo.ts' }));
+    getDatabase()
+      .prepare('UPDATE canopy_entries SET describe_attempts = 2 WHERE path = ?')
+      .run('src/poisoned.ts');
+
+    const tool = findTool(createTools(), 'canopy_describe_next');
+    const out = parseResult(await tool.handler({ limit: 5, max_attempts: 2 }, {} as any));
+    const paths = out.entries.map((e: { path: string }) => e.path);
+    expect(paths).toEqual(['src/foo.ts']);
+    // The excluded row never accrues further attempts.
+    expect(getAttempts('src/poisoned.ts')).toBe(2);
+  });
+
+  it('drains a poisoned row out of the pending pool across fetches', async () => {
+    upsertCanopyEntry(getDatabase(), makeEntry({ path: 'src/foo.ts' }));
+
+    // Each fetch needs a fresh tool instance (one-call-per-run gate).
+    const first = parseResult(await findTool(createTools(), 'canopy_describe_next').handler({}, {} as any));
+    expect(first.entries).toHaveLength(1);
+    const second = parseResult(await findTool(createTools(), 'canopy_describe_next').handler({}, {} as any));
+    expect(second.entries).toHaveLength(1);
+    expect(getAttempts('src/foo.ts')).toBe(2);
+
+    const third = parseResult(await findTool(createTools(), 'canopy_describe_next').handler({}, {} as any));
+    expect(third.entries).toEqual([]);
+    expect(getAttempts('src/foo.ts')).toBe(2);
+  });
+
+  it('honors a larger max_attempts from task params', async () => {
+    upsertCanopyEntry(getDatabase(), makeEntry({ path: 'src/foo.ts' }));
+    getDatabase()
+      .prepare('UPDATE canopy_entries SET describe_attempts = 2 WHERE path = ?')
+      .run('src/foo.ts');
+
+    const out = parseResult(
+      await findTool(createTools(), 'canopy_describe_next').handler({ max_attempts: 4 }, {} as any),
+    );
+    expect(out.entries).toHaveLength(1);
+    expect(getAttempts('src/foo.ts')).toBe(3);
+  });
+
+  it('a mechanical update resets describe_attempts so the row is describable again', async () => {
+    upsertCanopyEntry(getDatabase(), makeEntry({ path: 'src/foo.ts' }));
+    getDatabase()
+      .prepare('UPDATE canopy_entries SET describe_attempts = 2 WHERE path = ?')
+      .run('src/foo.ts');
+
+    // Content changed → the scanner upserts with new mechanical fields.
+    upsertCanopyEntry(getDatabase(), makeEntry({
+      path: 'src/foo.ts',
+      content_hash: 'b'.repeat(64),
+      mechanical_updated_at: 1_700_000_999,
+    }));
+    expect(getAttempts('src/foo.ts')).toBe(0);
+
+    const out = parseResult(
+      await findTool(createTools(), 'canopy_describe_next').handler({}, {} as any),
+    );
+    expect(out.entries.map((e: { path: string }) => e.path)).toEqual(['src/foo.ts']);
+  });
+});
+
+describe('countPendingCanopyDescribe — describe_attempts budget', () => {
+  it('excludes rows at the attempts cap, matching the fetch predicate', () => {
+    upsertCanopyEntry(getDatabase(), makeEntry({ path: 'src/foo.ts' }));
+    upsertCanopyEntry(getDatabase(), makeEntry({ path: 'src/poisoned.ts' }));
+    getDatabase()
+      .prepare('UPDATE canopy_entries SET describe_attempts = 2 WHERE path = ?')
+      .run('src/poisoned.ts');
+
+    expect(countPendingCanopyDescribe(getDatabase(), projectId)).toBe(1);
+    // The capped (limit) variant applies the same exclusion.
+    expect(countPendingCanopyDescribe(getDatabase(), projectId, 50)).toBe(1);
+    // A larger per-project budget brings the row back into the count.
+    expect(countPendingCanopyDescribe(getDatabase(), projectId, undefined, 4)).toBe(2);
+  });
+
+  it('returns 0 against a fully-poisoned tail so the scheduler stops dispatching no-op runs', () => {
+    upsertCanopyEntry(getDatabase(), makeEntry({ path: 'src/a.ts' }));
+    upsertCanopyEntry(getDatabase(), makeEntry({ path: 'src/b.ts' }));
+    getDatabase().prepare('UPDATE canopy_entries SET describe_attempts = 2').run();
+
+    expect(countPendingCanopyDescribe(getDatabase(), projectId)).toBe(0);
+    expect(countPendingCanopyDescribe(getDatabase(), projectId, 50)).toBe(0);
   });
 });
 

--- a/tests/daemon/scheduled-resume-gate.test.ts
+++ b/tests/daemon/scheduled-resume-gate.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for the scheduler's resume retry budget (gateScheduledResume).
+ *
+ * Under the cap a resumable run consumes one attempt and resumes; at the cap
+ * it is terminal-marked (`resumable=0`, `resume_status='exhausted'`), the
+ * failure notification fires, and the caller falls through to a fresh
+ * dispatch — observable here as getLatestResumableRunForTask no longer
+ * returning the run.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll, mock } from 'bun:test';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import {
+  insertRun,
+  getRun,
+  getLatestResumableRunForTask,
+  refundRunResumeAttempt,
+  RESUME_STATUS_EXHAUSTED,
+  RESUME_STATUS_READY,
+  type RunRow,
+} from '@myco/db/queries/runs.js';
+import { ALL_PROJECTS_SCOPE, assertGroveProjectId } from '@myco/grove/ids.js';
+import type { MycoConfig } from '@myco/config/schema.js';
+import type { DaemonLogger } from '@myco/daemon/logger.js';
+
+/** Captured notify() calls. */
+let notifyCalls: Array<{ vaultDir: string | undefined; payload: Record<string, unknown> }> = [];
+
+mock.module('@myco/notifications/notify.js', () => ({
+  notify: (vaultDir: string | undefined, payload: Record<string, unknown>) => {
+    notifyCalls.push({ vaultDir, payload });
+    return 'notif-1';
+  },
+}));
+
+import { gateScheduledResume, RESUME_MAX_ATTEMPTS } from '@myco/daemon/task-scheduling.js';
+
+const TEST_AGENT_ID = 'gate-test-agent';
+const TEST_TASK = 'vault-evolve';
+const TEST_PROJECT_ID = assertGroveProjectId('proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+
+const stubLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as unknown as DaemonLogger;
+
+const stubConfig = {} as MycoConfig;
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+function insertResumableRun(id: string, resumeAttempts: number): RunRow {
+  return insertRun({
+    id,
+    agent_id: TEST_AGENT_ID,
+    task: TEST_TASK,
+    status: 'failed',
+    resumable: 1,
+    resume_status: RESUME_STATUS_READY,
+    resume_attempts: resumeAttempts,
+    started_at: epochNow() - 120,
+    completed_at: epochNow() - 60,
+    error: 'boom',
+  });
+}
+
+function gate(run: RunRow): 'resume' | 'exhausted' {
+  return gateScheduledResume({
+    run,
+    taskName: TEST_TASK,
+    scope: ALL_PROJECTS_SCOPE,
+    projectVaultDir: '/tmp/gate-test/.myco',
+    projectId: TEST_PROJECT_ID,
+    config: stubConfig,
+    logger: stubLogger,
+  });
+}
+
+describe('gateScheduledResume', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    notifyCalls = [];
+    registerAgent({ id: TEST_AGENT_ID, name: 'Gate Test Agent', created_at: epochNow() });
+  });
+
+  it('increments resume_attempts and allows the resume while under the cap', () => {
+    const run = insertResumableRun('run-under-cap', 0);
+
+    expect(gate(run)).toBe('resume');
+
+    const after = getRun('run-under-cap', ALL_PROJECTS_SCOPE)!;
+    expect(after.resume_attempts).toBe(1);
+    expect(after.resumable).toBe(1);
+    expect(after.resume_status).toBe(RESUME_STATUS_READY);
+    expect(notifyCalls).toHaveLength(0);
+  });
+
+  it('allows exactly RESUME_MAX_ATTEMPTS resumes before exhausting', () => {
+    let run = insertResumableRun('run-budget', 0);
+
+    for (let attempt = 1; attempt <= RESUME_MAX_ATTEMPTS; attempt += 1) {
+      expect(gate(run)).toBe('resume');
+      run = getRun('run-budget', ALL_PROJECTS_SCOPE)!;
+      expect(run.resume_attempts).toBe(attempt);
+    }
+
+    expect(gate(run)).toBe('exhausted');
+  });
+
+  it('terminal-marks an at-cap run, notifies, and unblocks a fresh dispatch', () => {
+    const run = insertResumableRun('run-at-cap', RESUME_MAX_ATTEMPTS);
+    expect(getLatestResumableRunForTask(TEST_AGENT_ID, TEST_TASK, ALL_PROJECTS_SCOPE)?.id)
+      .toBe('run-at-cap');
+
+    expect(gate(run)).toBe('exhausted');
+
+    const after = getRun('run-at-cap', ALL_PROJECTS_SCOPE)!;
+    expect(after.resumable).toBe(0);
+    expect(after.resume_status).toBe(RESUME_STATUS_EXHAUSTED);
+    // resume_attempts is not consumed further by the exhaustion path.
+    expect(after.resume_attempts).toBe(RESUME_MAX_ATTEMPTS);
+
+    // The next scheduler tick (and the fall-through in this one) sees no
+    // resumable run, so the task dispatches fresh.
+    expect(getLatestResumableRunForTask(TEST_AGENT_ID, TEST_TASK, ALL_PROJECTS_SCOPE)).toBeNull();
+
+    expect(notifyCalls).toHaveLength(1);
+    expect(notifyCalls[0].payload).toMatchObject({
+      domain: 'agents',
+      type: 'agent.task.failure',
+      title: `Task failed: ${TEST_TASK}`,
+      link: '/agent?run=run-at-cap',
+    });
+    expect(String(notifyCalls[0].payload.message)).toContain(`${RESUME_MAX_ATTEMPTS} attempts`);
+  });
+
+  it('refunds the attempt when the resume dispatch is skipped — budget unchanged, run still resumable', () => {
+    // Mirrors the scheduler's resume branch when the executor returns
+    // status 'skipped' (another run of the task active — e.g. a long
+    // manual run): the gate pre-increments, the skipped dispatch refunds.
+    let run = insertResumableRun('run-skip-refund', 0);
+
+    expect(gate(run)).toBe('resume');
+    expect(getRun('run-skip-refund', ALL_PROJECTS_SCOPE)!.resume_attempts).toBe(1);
+
+    // dispatchAgentRun returned 'skipped' → refund.
+    expect(refundRunResumeAttempt('run-skip-refund', ALL_PROJECTS_SCOPE)).toBe(1);
+
+    run = getRun('run-skip-refund', ALL_PROJECTS_SCOPE)!;
+    expect(run.resume_attempts).toBe(0);
+    expect(run.resumable).toBe(1);
+    expect(run.resume_status).toBe(RESUME_STATUS_READY);
+
+    // The next tick still gets a real resume.
+    expect(gate(run)).toBe('resume');
+  });
+
+  it('skipped ticks during a long manual run can never exhaust the budget', () => {
+    let run = insertResumableRun('run-manual-window', 0);
+
+    // RESUME_MAX_ATTEMPTS + 2 ticks that all skip (a manual run of the
+    // same task stays active the whole time).
+    for (let tick = 0; tick < RESUME_MAX_ATTEMPTS + 2; tick += 1) {
+      expect(gate(run)).toBe('resume');
+      refundRunResumeAttempt(run.id, ALL_PROJECTS_SCOPE);
+      run = getRun('run-manual-window', ALL_PROJECTS_SCOPE)!;
+    }
+
+    expect(run.resume_attempts).toBe(0);
+    expect(run.resumable).toBe(1);
+    expect(notifyCalls).toHaveLength(0);
+  });
+
+  it('does not select session-expired runs in the first place', () => {
+    // A session-expired run is already terminal (resumable=0): the scheduler
+    // never hands it to the gate, so the cap leaves it untouched.
+    insertRun({
+      id: 'run-expired',
+      agent_id: TEST_AGENT_ID,
+      task: TEST_TASK,
+      status: 'failed',
+      resumable: 0,
+      resume_status: 'session_expired',
+      started_at: epochNow() - 120,
+      completed_at: epochNow() - 60,
+    });
+
+    expect(getLatestResumableRunForTask(TEST_AGENT_ID, TEST_TASK, ALL_PROJECTS_SCOPE)).toBeNull();
+    const row = getRun('run-expired', ALL_PROJECTS_SCOPE)!;
+    expect(row.resume_status).toBe('session_expired');
+    expect(row.resume_attempts).toBe(0);
+  });
+});

--- a/tests/db/migrate-v59-to-v60.test.ts
+++ b/tests/db/migrate-v59-to-v60.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for the v59 -> v60 migration: run-lifecycle bookkeeping columns.
+ *
+ * Builds a v59-shaped vault (drop the new columns, rewind schema_version to
+ * 59), re-runs createSchema to apply migrateV59ToV60, and asserts the three
+ * columns materialize with the correct defaults. The migration-matrix suite
+ * covers fresh=migrated parity structurally; this test documents the v60
+ * delta in isolation.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { createSchema, SCHEMA_VERSION } from '@myco/db/schema.js';
+
+interface ColumnInfo {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+}
+
+function columnInfo(db: Database, table: string, column: string): ColumnInfo | undefined {
+  const cols = db.prepare(`PRAGMA table_info(${table})`).all() as ColumnInfo[];
+  return cols.find((c) => c.name === column);
+}
+
+/** Build a v59-shaped DB: full schema with the v60 delta removed. */
+function seedV59Db(): Database {
+  const db = new Database(':memory:');
+  createSchema(db);
+  db.exec('ALTER TABLE agent_runs DROP COLUMN resume_attempts');
+  db.exec('ALTER TABLE agent_runs DROP COLUMN run_context');
+  db.exec('ALTER TABLE canopy_entries DROP COLUMN describe_attempts');
+  db.prepare(`DELETE FROM schema_version WHERE version > 59`).run();
+  return db;
+}
+
+describe('migrateV59ToV60 — run-lifecycle bookkeeping columns', () => {
+  it('adds the three columns with correct defaults, stamping v60', () => {
+    const db = seedV59Db();
+    expect(columnInfo(db, 'agent_runs', 'resume_attempts')).toBeUndefined();
+
+    createSchema(db);
+
+    const resumeAttempts = columnInfo(db, 'agent_runs', 'resume_attempts');
+    expect(resumeAttempts).toMatchObject({ type: 'INTEGER', notnull: 1, dflt_value: '0' });
+    const runContext = columnInfo(db, 'agent_runs', 'run_context');
+    expect(runContext).toMatchObject({ type: 'TEXT', notnull: 0, dflt_value: null });
+    const describeAttempts = columnInfo(db, 'canopy_entries', 'describe_attempts');
+    expect(describeAttempts).toMatchObject({ type: 'INTEGER', notnull: 1, dflt_value: '0' });
+
+    const stamped = (db.prepare(`SELECT MAX(version) AS v FROM schema_version`).get() as { v: number }).v;
+    expect(stamped).toBe(SCHEMA_VERSION);
+    db.close();
+  });
+
+  it('backfills existing rows with the column defaults', () => {
+    const db = seedV59Db();
+    db.prepare(`INSERT INTO agents (id, name, created_at) VALUES ('a', 'A', 1)`).run();
+    db.prepare(
+      `INSERT INTO agent_runs (id, agent_id, status) VALUES ('run-1', 'a', 'failed')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO canopy_entries
+         (project_id, path, content_hash, size_bytes, token_estimate, line_count, mechanical_updated_at)
+       VALUES ('p', 'src/a.ts', 'h', 1, 1, 1, 100)`,
+    ).run();
+
+    createSchema(db);
+
+    const run = db.prepare(
+      `SELECT resume_attempts, run_context FROM agent_runs WHERE id = 'run-1'`,
+    ).get() as { resume_attempts: number; run_context: string | null };
+    expect(run.resume_attempts).toBe(0);
+    expect(run.run_context).toBeNull();
+
+    const entry = db.prepare(
+      `SELECT describe_attempts FROM canopy_entries WHERE path = 'src/a.ts'`,
+    ).get() as { describe_attempts: number };
+    expect(entry.describe_attempts).toBe(0);
+    db.close();
+  });
+
+  it('is idempotent — re-running createSchema on a migrated vault is a no-op', () => {
+    const db = seedV59Db();
+    createSchema(db);
+    createSchema(db);
+    expect(columnInfo(db, 'agent_runs', 'resume_attempts')).toBeDefined();
+    const stamped = (db.prepare(`SELECT MAX(version) AS v FROM schema_version`).get() as { v: number }).v;
+    expect(stamped).toBe(SCHEMA_VERSION);
+    db.close();
+  });
+});

--- a/tests/db/queries/runs.test.ts
+++ b/tests/db/queries/runs.test.ts
@@ -16,6 +16,9 @@ import {
   updateRun,
   updateRunStatus,
   getRunningRun,
+  getRunningRunForTask,
+  incrementRunResumeAttempts,
+  refundRunResumeAttempt,
 } from '@myco/db/queries/runs.js';
 import type { RunInsert } from '@myco/db/queries/runs.js';
 import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
@@ -481,6 +484,96 @@ describe('run query helpers', () => {
       insertRun(makeRun({ id: 'run-dry-default' }));
       const row = getRun('run-dry-default', ALL_PROJECTS_SCOPE);
       expect(row!.dry_run).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // resume_attempts + run_context (v60)
+  // ---------------------------------------------------------------------------
+
+  describe('resume_attempts + run_context columns', () => {
+    it('defaults resume_attempts to 0 and run_context to null when omitted', () => {
+      const row = insertRun(makeRun({ id: 'run-v60-default' }));
+      expect(row.resume_attempts).toBe(0);
+      expect(row.run_context).toBeNull();
+    });
+
+    it('round-trips run_context JSON', () => {
+      const context = JSON.stringify({ candidate_id: 'cand-1', skill_survey_watermark: 42 });
+      const row = insertRun(makeRun({ id: 'run-ctx', run_context: context }));
+      expect(row.run_context).toBe(context);
+
+      const fetched = getRun('run-ctx', ALL_PROJECTS_SCOPE)!;
+      expect(fetched.run_context).toBe(context);
+    });
+
+    it('incrementRunResumeAttempts bumps the counter atomically', () => {
+      insertRun(makeRun({ id: 'run-attempts' }));
+
+      expect(incrementRunResumeAttempts('run-attempts', ALL_PROJECTS_SCOPE)).toBe(1);
+      expect(incrementRunResumeAttempts('run-attempts', ALL_PROJECTS_SCOPE)).toBe(1);
+      expect(getRun('run-attempts', ALL_PROJECTS_SCOPE)!.resume_attempts).toBe(2);
+    });
+
+    it('incrementRunResumeAttempts returns 0 for a missing run', () => {
+      expect(incrementRunResumeAttempts('does-not-exist', ALL_PROJECTS_SCOPE)).toBe(0);
+    });
+
+    it('refundRunResumeAttempt decrements and floors at 0', () => {
+      insertRun(makeRun({ id: 'run-refund' }));
+      incrementRunResumeAttempts('run-refund', ALL_PROJECTS_SCOPE);
+      incrementRunResumeAttempts('run-refund', ALL_PROJECTS_SCOPE);
+
+      expect(refundRunResumeAttempt('run-refund', ALL_PROJECTS_SCOPE)).toBe(1);
+      expect(getRun('run-refund', ALL_PROJECTS_SCOPE)!.resume_attempts).toBe(1);
+
+      refundRunResumeAttempt('run-refund', ALL_PROJECTS_SCOPE);
+      refundRunResumeAttempt('run-refund', ALL_PROJECTS_SCOPE);
+      expect(getRun('run-refund', ALL_PROJECTS_SCOPE)!.resume_attempts).toBe(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getRunningRunForTask staleness
+  // ---------------------------------------------------------------------------
+
+  describe('getRunningRunForTask', () => {
+    it('returns the newest running run for the task with stale=false when no cutoff given', () => {
+      const now = epochNow();
+      insertRun(makeRun({ id: 'run-old', task: 'digest', status: 'running', started_at: now - 100 }));
+      insertRun(makeRun({ id: 'run-new', task: 'digest', status: 'running', started_at: now }));
+
+      const running = getRunningRunForTask(TEST_AGENT_ID, 'digest', ALL_PROJECTS_SCOPE);
+      expect(running).not.toBeNull();
+      expect(running!.id).toBe('run-new');
+      expect(running!.stale).toBe(false);
+    });
+
+    it('returns null when no run is running for the task', () => {
+      insertRun(makeRun({ id: 'run-done', task: 'digest', status: 'completed', started_at: epochNow() }));
+      expect(getRunningRunForTask(TEST_AGENT_ID, 'digest', ALL_PROJECTS_SCOPE)).toBeNull();
+    });
+
+    it('flags a running row older than maxAgeSeconds as stale without mutating it', () => {
+      const now = epochNow();
+      insertRun(makeRun({ id: 'run-stale', task: 'digest', status: 'running', started_at: now - 10_000 }));
+
+      const running = getRunningRunForTask(TEST_AGENT_ID, 'digest', ALL_PROJECTS_SCOPE, 600);
+      expect(running).not.toBeNull();
+      expect(running!.id).toBe('run-stale');
+      expect(running!.stale).toBe(true);
+
+      // Boot recovery owns marking orphans — the read must not mutate.
+      const row = getRun('run-stale', ALL_PROJECTS_SCOPE)!;
+      expect(row.status).toBe('running');
+    });
+
+    it('keeps a recent running row fresh under the same cutoff', () => {
+      const now = epochNow();
+      insertRun(makeRun({ id: 'run-fresh', task: 'digest', status: 'running', started_at: now - 30 }));
+
+      const running = getRunningRunForTask(TEST_AGENT_ID, 'digest', ALL_PROJECTS_SCOPE, 600);
+      expect(running!.stale).toBe(false);
     });
   });
 });

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -48,7 +48,7 @@ describe('Database schema', () => {
 
   describe('constants', () => {
     it('exports SCHEMA_VERSION as a positive integer', () => {
-      expect(SCHEMA_VERSION).toBe(59);
+      expect(SCHEMA_VERSION).toBe(60);
       expect(Number.isInteger(SCHEMA_VERSION)).toBe(true);
     });
 

--- a/tests/smoke/review-fixes.test.ts
+++ b/tests/smoke/review-fixes.test.ts
@@ -57,14 +57,14 @@ describe('P1 #2: Concurrency guard query helpers', () => {
   afterAll(() => { teardownTestDb(); });
   beforeEach(() => { cleanTestDb(); seedAgent(); });
 
-  it('getRunningRunForTask returns running task ID', () => {
+  it('getRunningRunForTask returns the running run ref', () => {
     insertRun({
       id: 'run-1', agent_id: AGENT_ID, task: 'vault-evolve',
       status: STATUS_RUNNING, started_at: now, created_at: now,
     });
 
     const result = getRunningRunForTask(AGENT_ID, 'vault-evolve', ALL_PROJECTS_SCOPE);
-    expect(result).toBe('run-1');
+    expect(result).toMatchObject({ id: 'run-1', stale: false });
   });
 
   it('getRunningRunForTask returns null for different task', () => {


### PR DESCRIPTION
## Problem (bug-hunt RC-9, Wave 3 — final item)

Four verified failure modes in the harness run lifecycle:

1. **No resume cap** — every non-session-expired failure marked `resumable=1`; the scheduler always preferred the resumable run and returned before any notification. Deterministic failures retried forever, re-burning turns with zero signal.
2. **Map phases lied** — `status:'completed'` at 100% item failure; `canopy-describe.yaml`'s `max_attempts: 2` had **no consumer**; the pending predicate's NULL-first sort kept perpetually-failing rows at the head-of-line, blocking all describe progress behind a poisoned tail.
3. **Resume dropped its inputs** — `instruction` was persisted but never read back; `runContext` had no column (skill-survey watermarks silently never advanced on resumed runs; canopy-map threw); **a failed dry-run resumed as a REAL run with real writes**.
4. **Unprotected insert window** — run-row creation sat ~100 lines before its try with `loadSystemPrompt`/assertion throwers between → orphaned `running` rows wedged the task until restart; `getRunningRunForTask` had no staleness cutoff.

Plus: failed single-query runs recorded 0 tokens/$0 (telemetry discarded), and turn-audit offsets collided in mixed-`maxTurns` waves.

## Fix

- **Migration v60** (frozen DDL, column-guarded, transactional; matrix-covered): `agent_runs` += `resume_attempts`, `run_context`; `canopy_entries` += `describe_attempts`. Neither table is team-synced — no D1/`SYNC_PROTOCOL_VERSION` impact (assessed per standing practice).
- **Resume budget**: 3 attempts, pre-incremented (crash-safe), **refunded on skipped dispatch** (a long manual run can't burn the budget); at cap → `resumable=0` + `resume_status='exhausted'` + the same `agent.task.failure` notification the fresh path uses + fresh dispatch same tick. The macro-cycle (3 resumes → exhaust → fresh) is bounded to one dispatch per tick — same burn rate as before, now with signal.
- **Input restoration in the executor** (single path for scheduler + manual endpoint): instruction / run_context / **dry_run** / execution overrides fall back to the resumed row; caller wins.
- **Honest map phases**: `failed` when `itemCount>0 && written==0` — the all-skipped poison class, not just harness throws. `describe_attempts` increments at fetch, the **shared predicate** excludes capped rows from fetch + scheduler count + **UI backlog** (no phantom backlog — the PR #463 contract), and the scanner resets attempts on real content change.
- **Atomic duplicate-run guard**: row creation adjacent to the try with a synchronous re-check at the insert. The probe round **proved the first reorder opened a TOCTOU** through the resolver awaits (two concurrent dispatches both inserted); the regression test forces that exact interleave and was verified to fail with the re-check neutralized.
- Stale-running cutoff (timeout + margin, warn, row untouched — boot recovery owns mutation); real telemetry on failed single-query runs; allocation-based turn offsets in both halves (within-wave prefix sums + cross-wave full allocation, resume-stable).

## Process

Independent plan review (caught: `resumable=0` is the load-bearing exclusion, the dry-run-resumed-as-real hazard, the all-skipped-not-failed counting, the backlog-count spam interaction, the cross-wave offset half) → delegated implementation → adversarial probe (caught the TOCTOU blocker + backlog predicate drift + attempt-burn-on-skip) → fix round → all gates.

## Testing

46 new/extended tests across migration matrix, resume gate, executor restoration, map-phase semantics, describe-attempts lifecycle, duplicate-dispatch interleave, staleness, telemetry, and turn offsets. Full suite green ×3 (2322 JUnit testsuites, `failures="0"` verified by artifact scan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)