### PR TITLE
daemon: eviction acts on the service identity, not the vault; version-disciplined sibling check (RC-13)

### DIFF
--- a/packages/myco/src/daemon/eviction.ts
+++ b/packages/myco/src/daemon/eviction.ts
@@ -1,33 +1,36 @@
 /**
  * Unified daemon-eviction helpers.
  *
- * One source of truth for "find every myco daemon running for this vault and
- * make them go away so we can take the canonical port." Callers:
- *   - `server.evictExistingDaemon` (daemon startup)
- *   - `cli/restart.ts` (user-triggered restart)
+ * One source of truth for "find every myco daemon competing for this
+ * daemon's identity and make them go away so we can take the canonical
+ * port." Sole caller: `server.evictExistingDaemon` (daemon startup).
  *
- * The prior eviction logic looked only at the PID recorded in `daemon.json`.
- * That missed two real failure modes:
- *   - An orphan daemon holding the canonical port whose JSON registration got
- *     lost (racing update-apply, unclean shutdown, stale-JSON SIGTERM that
- *     the target process ignored).
- *   - A "current" daemon that fell back to `canonical+1` because an orphan was
- *     squatting the canonical port; subsequent restarts keep using the wrong
- *     port forever because daemon.json points at the fallback.
+ * Identity is an explicit {@link EvictionScope} — the service state dir
+ * (where daemon.json actually lives) plus the canonical port the daemon
+ * will bind. The prior shape derived BOTH from `vaultDir`, which is the
+ * legacy per-vault protocol: the global daemon keeps its state under the
+ * service dir (`~/.myco/service` or `service-dev`) and derives its port
+ * from that dir, so a
+ * vault-derived sweep scanned a port nobody uses, read a daemon.json that
+ * doesn't exist there, and the cwd-based identity probe could not even
+ * recognize a launchd-spawned daemon (cwd never resolves to the bootstrap
+ * vault). The orphan sweep was a structural no-op in every current config.
  *
- * This module scans a small port range around the canonical port (which was
- * the fallback-retry range before we dropped silent fallback) to catch any
- * historical fallback-bound myco daemons, identifies them via `ps` argv
- * matching, and evicts them all.
+ * Port squatters are identified as myco daemons via, in order:
+ *   1. the pid recorded in the scope's daemon.json (healthy case),
+ *   2. a `/health` probe on the squatted port answering `{myco: true}` —
+ *      a listener that speaks the myco heartbeat IS a myco daemon,
+ *      regardless of how it was spawned or what its cwd looks like,
+ *   3. the legacy cwd→vault check, kept for per-vault daemons.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { derivePort } from './port.js';
 import {
   DAEMON_EVICT_POLL_MS,
   DAEMON_EVICT_TIMEOUT_MS,
+  DAEMON_HEALTH_CHECK_TIMEOUT_MS,
 } from '../constants.js';
 import {
   cleanStaleDaemonJson,
@@ -73,6 +76,39 @@ export interface EvictionTarget {
   source: PidSource;
 }
 
+/**
+ * The identity this eviction acts for. `stateDir` is where the daemon's
+ * `daemon.json` lives (the SERVICE dir for global daemons — e.g.
+ * `~/.myco/service/` — not the project vault); `canonicalPort` is the port
+ * the caller is about to bind. `vaultDir` enables the legacy cwd→vault
+ * identity check for per-vault daemons and is optional.
+ */
+export interface EvictionScope {
+  stateDir: string;
+  canonicalPort: number;
+  vaultDir?: string;
+}
+
+/**
+ * Probe `/health` on a local port. Returns the parsed heartbeat for a myco
+ * daemon, null for anything else (non-myco listener, timeout, no listener).
+ */
+export async function probeMycoDaemon(
+  port: number,
+  timeoutMs = DAEMON_HEALTH_CHECK_TIMEOUT_MS,
+): Promise<{ myco: boolean; version?: string; pid?: number } | null> {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/health`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) return null;
+    const data = await res.json() as { myco?: boolean; version?: string; pid?: number };
+    return data.myco === true ? { myco: true, version: data.version, pid: data.pid } : null;
+  } catch {
+    return null;
+  }
+}
+
 const LOG_KIND = 'daemon.eviction';
 
 // ---------------------------------------------------------------------------
@@ -80,30 +116,29 @@ const LOG_KIND = 'daemon.eviction';
 // ---------------------------------------------------------------------------
 
 /**
- * Evict every myco daemon running for `vaultDir`.
+ * Evict every myco daemon competing for the scope's identity.
  *
- * Looks at both the PID in `daemon.json` and any myco daemon holding a port
- * in the canonical range derived from `vaultDir`. SIGTERMs with a grace
- * period, escalates to SIGKILL, then waits for the process to exit.
+ * Looks at both the PID recorded in the scope's `daemon.json` and any myco
+ * daemon holding a port in the scope's canonical range. SIGTERMs with a
+ * grace period, escalates to SIGKILL, then waits for the process to exit.
  *
  * Safe to call before the caller has bound its own port (the current process
  * is excluded from the kill list).
  */
-export async function evictDaemonsForVault(
-  vaultDir: string,
+export async function evictDaemons(
+  scope: EvictionScope,
   opts: EvictOptions = {},
 ): Promise<EvictionTarget[]> {
   const logger = opts.logger;
   const graceMs = opts.graceMs ?? DAEMON_EVICT_TIMEOUT_MS;
   const pollMs = opts.pollMs ?? DAEMON_EVICT_POLL_MS;
-  const canonicalPort = derivePort(vaultDir);
 
-  const targets = findDaemonTargetsForVault(vaultDir, canonicalPort);
+  const targets = await findDaemonTargets(scope);
   if (targets.length === 0) return [];
 
-  logger?.info(LOG_KIND, 'Evicting daemons for vault', {
-    vault: vaultDir,
-    canonical_port: canonicalPort,
+  logger?.info(LOG_KIND, 'Evicting daemons for scope', {
+    state_dir: scope.stateDir,
+    canonical_port: scope.canonicalPort,
     targets: targets.map((t) => ({ pid: t.pid, source: t.source })),
   });
 
@@ -114,36 +149,38 @@ export async function evictDaemonsForVault(
   // Best-effort: unlink daemon.json if it still points at one of the evicted
   // PIDs. Leaving it can cause subsequent startups to "step aside" from a
   // process we just killed.
-  cleanStaleDaemonJson(vaultDir, targets.map((t) => t.pid));
+  cleanStaleDaemonJson(scope.stateDir, targets.map((t) => t.pid));
   return targets;
 }
 
 /**
- * Return the union of (daemon.json PID, canonical-port squatters) for a vault.
+ * Return the union of (daemon.json PID, canonical-port squatters) for the
+ * scope.
  *
  * Filtered to myco daemons only, deduplicated, and excluding the current
- * process. Port squatters that are NOT myco daemons for this vault are
- * ignored — we don't want to kill an unrelated service just because it
- * grabbed our preferred port.
+ * process. Port squatters that are NOT myco daemons are ignored — we don't
+ * want to kill an unrelated service just because it grabbed our preferred
+ * port. Async because squatter identity may require a `/health` probe.
  */
-export function findDaemonTargetsForVault(
-  vaultDir: string,
-  canonicalPort: number,
-): EvictionTarget[] {
+export async function findDaemonTargets(scope: EvictionScope): Promise<EvictionTarget[]> {
   const seen = new Map<number, EvictionTarget>();
 
-  const jsonPid = readDaemonJsonPid(vaultDir);
+  const jsonPid = readDaemonJsonPid(scope.stateDir);
   if (jsonPid !== undefined && jsonPid !== process.pid && isProcessAlive(jsonPid)) {
     seen.set(jsonPid, { pid: jsonPid, source: 'daemon.json' });
   }
 
-  const portsToScan = rangeInclusive(canonicalPort, canonicalPort + EVICT_PORT_SCAN_RANGE - 1)
+  const portsToScan = rangeInclusive(scope.canonicalPort, scope.canonicalPort + EVICT_PORT_SCAN_RANGE - 1)
     .filter((p) => p <= 65535);
   const squatters = findPidsListeningOn(portsToScan);
   for (const { port, pid } of squatters) {
     if (pid === process.pid) continue;
     if (seen.has(pid)) continue;
-    if (!isMycoDaemonForVault(pid, vaultDir)) continue;
+    if (pid === jsonPid) { seen.set(pid, { pid, source: `port:${port}` }); continue; }
+    const isMyco =
+      (await probeMycoDaemon(port)) !== null ||
+      (scope.vaultDir !== undefined && isMycoDaemonForVault(pid, scope.vaultDir));
+    if (!isMyco) continue;
     seen.set(pid, { pid, source: `port:${port}` });
   }
 
@@ -154,9 +191,9 @@ export function findDaemonTargetsForVault(
 // Discovery
 // ---------------------------------------------------------------------------
 
-function readDaemonJsonPid(vaultDir: string): number | undefined {
+function readDaemonJsonPid(stateDir: string): number | undefined {
   try {
-    const jsonPath = path.join(vaultDir, 'daemon.json');
+    const jsonPath = path.join(stateDir, 'daemon.json');
     const raw = fs.readFileSync(jsonPath, 'utf-8');
     const info = JSON.parse(raw) as { pid?: unknown };
     return typeof info.pid === 'number' ? info.pid : undefined;

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -213,6 +213,8 @@ import { LOG_KINDS } from '../constants/log-kinds.js';
 import { MS_PER_DAY } from '../constants.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import {
+  DAEMON_EVICT_POLL_MS,
+  DAEMON_EVICT_TIMEOUT_MS,
   DAEMON_HEALTH_CHECK_TIMEOUT_MS,
   DAEMON_STALE_GRACE_PERIOD_MS,
   RECONCILE_POLL_MS,
@@ -221,6 +223,7 @@ import {
 } from '../constants.js';
 import { isProcessAlive, waitForProcessExit, readProcessCommandLine } from '@goondocks/myco-shared';
 import { getPluginVersion } from '../version.js';
+import { probeMycoDaemon, findPidsListeningOn, terminateProcess } from './eviction.js';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -233,18 +236,15 @@ import path from 'node:path';
  * True when `127.0.0.1:<port>/health` responds with a myco daemon heartbeat.
  * Used during startup to distinguish a concurrent sibling (step-aside
  * candidate) from an unrelated port squatter.
+ *
+ * Version discipline lives at the call site: only a SAME-version sibling is
+ * a step-aside candidate. A myco daemon on a different version is a stale
+ * orphan (e.g. an old binary image that survived a package replacement) —
+ * stepping aside from it would leave the old version serving forever while
+ * every new boot exits 0.
  */
 export async function isHealthyMycoSibling(port: number): Promise<boolean> {
-  try {
-    const res = await fetch(`http://127.0.0.1:${port}/health`, {
-      signal: AbortSignal.timeout(DAEMON_HEALTH_CHECK_TIMEOUT_MS),
-    });
-    if (!res.ok) return false;
-    const data = await res.json() as { myco?: boolean };
-    return data.myco === true;
-  } catch {
-    return false;
-  }
+  return (await probeMycoDaemon(port)) !== null;
 }
 
 // ---------------------------------------------------------------------------
@@ -2112,28 +2112,54 @@ export async function main(): Promise<void> {
   await server.evictExistingDaemon();
   const canonicalPort = daemonService.canonicalPort;
 
-  try {
-    await server.start(canonicalPort);
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException)?.code;
-    if (code !== 'EADDRINUSE') throw err;
+  // One evict-and-retry round for the stale-orphan case below; anything
+  // still holding the port after that fails loudly.
+  let bindAttemptsLeft = 2;
+  while (true) {
+    try {
+      await server.start(canonicalPort);
+      break;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code !== 'EADDRINUSE') throw err;
+      bindAttemptsLeft--;
 
-    if (await isHealthyMycoSibling(canonicalPort)) {
-      logger.info(LOG_KINDS.DAEMON_START, 'Sibling claimed canonical port during startup — stepping aside', {
+      const sibling = await probeMycoDaemon(canonicalPort);
+      if (sibling !== null && sibling.version === getPluginVersion()) {
+        // A same-version sibling won a concurrent-startup race — its serving
+        // is indistinguishable from ours. Step aside.
+        logger.info(LOG_KINDS.DAEMON_START, 'Sibling claimed canonical port during startup — stepping aside', {
+          port: canonicalPort,
+          sibling_version: sibling.version ?? null,
+        });
+        process.exit(0);
+      }
+
+      if (sibling !== null && bindAttemptsLeft > 0) {
+        // A myco daemon on a DIFFERENT version is a stale orphan — e.g. an
+        // old binary image that survived a package replacement. Stepping
+        // aside would leave the old version serving forever while every new
+        // boot exits 0. Evict it and retry the bind once.
+        logger.warn(LOG_KINDS.DAEMON_PORT, 'Stale myco daemon (version mismatch) holds the canonical port — evicting', {
+          port: canonicalPort,
+          orphan_version: sibling.version ?? null,
+          our_version: getPluginVersion(),
+        });
+        const squatters = findPidsListeningOn([canonicalPort]).filter((s) => s.pid !== process.pid);
+        await Promise.all(squatters.map((s) => terminateProcess(s.pid, { graceMs: DAEMON_EVICT_TIMEOUT_MS, pollMs: DAEMON_EVICT_POLL_MS, logger })));
+        continue;
+      }
+
+      logger.error(LOG_KINDS.DAEMON_PORT, 'Canonical port is held by another process — cannot start', {
         port: canonicalPort,
+        hint: `Run \`lsof -iTCP:${canonicalPort}\` to identify the owner and stop it.`,
       });
-      process.exit(0);
+      process.stderr.write(
+        `Myco daemon cannot bind port ${canonicalPort} (held by another process). ` +
+          `Run \`lsof -iTCP:${canonicalPort}\` to investigate.\n`,
+      );
+      process.exit(1);
     }
-
-    logger.error(LOG_KINDS.DAEMON_PORT, 'Canonical port is held by another process — cannot start', {
-      port: canonicalPort,
-      hint: `Run \`lsof -iTCP:${canonicalPort}\` to identify the owner and stop it.`,
-    });
-    process.stderr.write(
-      `Myco daemon cannot bind port ${canonicalPort} (held by another process). ` +
-        `Run \`lsof -iTCP:${canonicalPort}\` to investigate.\n`,
-    );
-    process.exit(1);
   }
   daemonLifecycleLock?.update({
     port: server.port,

--- a/packages/myco/src/daemon/server.ts
+++ b/packages/myco/src/daemon/server.ts
@@ -7,7 +7,7 @@ import type { DaemonLogger } from './logger.js';
 import { getPluginVersion } from '../version.js';
 import { Router, type RouteHandler } from './router.js';
 import { resolveStaticFile } from './static.js';
-import { evictDaemonsForVault } from './eviction.js';
+import { evictDaemons } from './eviction.js';
 import { LOG_KINDS } from '../constants/log-kinds.js';
 import {
   ForeignGroveError,
@@ -649,16 +649,27 @@ export class DaemonServer {
   }
 
   /**
-   * Kill any existing daemon for this vault before taking over.
-   * Prevents orphaned daemons when spawned from worktrees or plugin upgrades.
-   * Must be called BEFORE `server.start()` so the old daemon releases the
-   * canonical port.
+   * Kill any existing daemon competing for this daemon's identity before
+   * taking over. Prevents orphaned daemons when spawned from worktrees or
+   * plugin upgrades. Must be called BEFORE `server.start()` so the old
+   * daemon releases the canonical port.
    *
-   * Delegates to `evictDaemonsForVault`, which also handles orphans that
-   * hold the canonical port but aren't recorded in daemon.json.
+   * The eviction scope comes from the SERVICE state (where daemon.json
+   * actually lives and where the canonical port derives from), not the
+   * bootstrap vault — global daemons keep no state under the vault, so a
+   * vault-derived sweep finds nothing. The vault is passed along only for
+   * the legacy per-vault identity check.
    */
   async evictExistingDaemon(): Promise<void> {
-    await evictDaemonsForVault(this.vaultDir, { logger: this.logger });
+    const service = resolveDaemonServiceState(this.vaultDir, { env: process.env });
+    await evictDaemons(
+      {
+        stateDir: service.stateDir,
+        canonicalPort: service.canonicalPort,
+        vaultDir: this.vaultDir,
+      },
+      { logger: this.logger },
+    );
   }
 
   private writeDaemonJson(): void {

--- a/tests/daemon/reconcile-existing-daemon.test.ts
+++ b/tests/daemon/reconcile-existing-daemon.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import http from 'node:http';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { reconcileExistingDaemon, isHealthyMycoSibling } from '@myco/daemon/main';
+import { probeMycoDaemon } from '@myco/daemon/eviction.js';
 import { DaemonLogger } from '@myco/daemon/logger';
 import { getPluginVersion } from '@myco/version';
 import type { DaemonServiceState } from '@myco/daemon/service-state';
@@ -378,5 +379,34 @@ describe('isHealthyMycoSibling', () => {
   it('returns false when the port is not listening', async () => {
     // Port 1 refuses connections under normal userspace permissions.
     expect(await isHealthyMycoSibling(1)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// probeMycoDaemon — version-aware sibling probe (RC-13)
+// ---------------------------------------------------------------------------
+
+describe('probeMycoDaemon', () => {
+  it('returns the heartbeat (version included) for a myco daemon', async () => {
+    await withHealthServer(
+      { status: 200, body: { myco: true, version: '9.9.9', pid: 4242 } },
+      async (port) => {
+        const probe = await probeMycoDaemon(port);
+        expect(probe).toEqual({ myco: true, version: '9.9.9', pid: 4242 });
+      },
+    );
+  });
+
+  it('returns null for a non-myco listener', async () => {
+    await withHealthServer(
+      { status: 200, body: { some: 'other service' } },
+      async (port) => {
+        expect(await probeMycoDaemon(port)).toBe(null);
+      },
+    );
+  });
+
+  it('returns null when nothing is listening', async () => {
+    expect(await probeMycoDaemon(1)).toBe(null);
   });
 });


### PR DESCRIPTION
## Problem (bug-hunt RC-13, Wave 4)

The startup orphan sweep (`evictDaemonsForVault`) spoke the legacy per-vault protocol — port derived from `vaultDir`, `daemon.json` read from the vault, daemon identity established by resolving a pid's cwd to its enclosing `.myco/`. The global daemon keeps state under the **service dir**, derives its port from there, and launchd-spawned processes have a cwd that never resolves to the bootstrap vault. Net: the sweep scanned a port nobody uses, read a file that doesn't exist, and couldn't recognize the daemon it exists to find — **a structural no-op in every current config**.

Downstream, the EADDRINUSE fallback accepted *any* `{myco:true}` health response as a step-aside sibling with no version check — so a stale orphan (e.g. the old binary image that survived this week's npm package replacement) would keep serving forever while every new boot exits 0.

## Fix

- **`EvictionScope`**: eviction takes the explicit service identity (stateDir + canonicalPort, optional vaultDir for the legacy per-vault cwd check). Squatter identity gains a `/health` probe — a listener that speaks the myco heartbeat IS a myco daemon regardless of spawn context.
- **Version-disciplined sibling check** at EADDRINUSE: same-version sibling → step aside (unchanged); different-version myco daemon → recognized as a stale orphan, **evicted, bind retried once**; non-myco squatter → loud failure (unchanged). `probeMycoDaemon` is the shared version-aware probe; `isHealthyMycoSibling` delegates to it.

## Testing

- New `probeMycoDaemon` tests (in-process health server: heartbeat + version passthrough, non-myco listener, dead port) following the repo's no-process-spawn eviction-test policy.
- Existing reconcile/eviction/sibling suites green; full suite green (node + jsdom), JUnit artifacts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)