### PR TITLE
symbionts: symlink stewardship — never destroy real paths; symmetric global uninstall (RC-14a)

### DIFF
--- a/packages/myco/src/symbionts/install-helpers.ts
+++ b/packages/myco/src/symbionts/install-helpers.ts
@@ -127,10 +127,32 @@ export function ensureAgentsMd(projectRoot: string): void {
   );
 }
 
-export function ensureSymlink(linkPath: string, target: string): void {
+/**
+ * Outcome of an {@link ensureSymlink} call. 'kept-real-path' means a real
+ * file or directory (NOT a symlink) occupies the link path — user content
+ * the installer must never destroy; the caller decides how to surface it.
+ */
+export type EnsureSymlinkResult = 'linked' | 'unchanged' | 'kept-real-path';
+
+/**
+ * Point `linkPath` at `target`, replacing only things this installer could
+ * have created: an existing symlink (wherever it points) or nothing at all.
+ * A REAL file or directory at the link path is user content — a
+ * hand-authored skill dir, a vendored copy — and is left untouched. This
+ * runs from hourly detection ticks, so a destructive replace here turns a
+ * naming overlap into silent data loss.
+ */
+export function ensureSymlink(linkPath: string, target: string): EnsureSymlinkResult {
+  let existing: fs.Stats | undefined;
   try {
-    if (fs.readlinkSync(linkPath) === target) return;
-  } catch { /* does not exist or is not a symlink — proceed */ }
-  try { fs.rmSync(linkPath, { recursive: true, force: true }); } catch { /* ignore */ }
+    existing = fs.lstatSync(linkPath);
+  } catch { /* absent — create below */ }
+
+  if (existing !== undefined) {
+    if (!existing.isSymbolicLink()) return 'kept-real-path';
+    if (fs.readlinkSync(linkPath) === target) return 'unchanged';
+    fs.unlinkSync(linkPath);
+  }
   fs.symlinkSync(target, linkPath);
+  return 'linked';
 }

--- a/packages/myco/src/symbionts/installer.ts
+++ b/packages/myco/src/symbionts/installer.ts
@@ -1768,7 +1768,9 @@ export class SymbiontInstaller {
       // directly under the agent's globalSkillsTarget.
       fs.mkdirSync(agentSkillsDir, { recursive: true });
       for (const name of skillNames) {
-        ensureSymlink(path.join(agentSkillsDir, name), path.join(skillsSrc, name));
+        if (ensureSymlink(path.join(agentSkillsDir, name), path.join(skillsSrc, name)) === 'kept-real-path') {
+          process.stderr.write(`[myco] Skipped skill link '${name}' — a real file or directory occupies ${path.join(agentSkillsDir, name)}\n`);
+        }
       }
       return true;
     }
@@ -1782,7 +1784,9 @@ export class SymbiontInstaller {
     for (const name of skillNames) {
       const canonicalLink = path.join(canonicalDir, name);
       const target = path.join(skillsSrc, name);
-      ensureSymlink(canonicalLink, target);
+      if (ensureSymlink(canonicalLink, target) === 'kept-real-path') {
+        process.stderr.write(`[myco] Skipped skill link '${name}' — a real file or directory occupies ${canonicalLink}\n`);
+      }
     }
 
     // Create agent-specific symlinks if skillsTarget differs from canonical
@@ -1793,7 +1797,9 @@ export class SymbiontInstaller {
       for (const name of skillNames) {
         const agentLink = path.join(agentSkillsDir, name);
         const relTarget = path.join(canonicalRel, name);
-        ensureSymlink(agentLink, relTarget);
+        if (ensureSymlink(agentLink, relTarget) === 'kept-real-path') {
+          process.stderr.write(`[myco] Skipped skill link '${name}' — a real file or directory occupies ${agentLink}\n`);
+        }
       }
       ensureLocalSkillsGitignore(agentSkillsDir);
     }
@@ -2230,13 +2236,36 @@ export class SymbiontInstaller {
     return true;
   }
 
-  /** Remove skill symlinks (canonical + agent-specific). */
+  /** Remove skill symlinks (flat-global, canonical, and agent-specific). */
   uninstallSkills(): boolean {
     const reg = this.manifest.registration;
-    if (!reg?.skillsTarget) return false;
 
     const skillNames = this.listSkillDirs();
     if (skillNames.length === 0) return false;
+
+    // Global scope installs flat symlinks under globalSkillsTarget with no
+    // canonical layer (see installSkills). Uninstall must mirror that or
+    // every globally-installed agent keeps orphaned skill links forever.
+    // Only symlinks are removed — a real file or directory under the same
+    // name is user content.
+    if (this.capabilities.flatSkills) {
+      if (!reg?.globalSkillsTarget) return false;
+      const agentSkillsDir = this.resolveAbsoluteTarget("skills")!;
+      let removedFlat = false;
+      for (const name of skillNames) {
+        const link = path.join(agentSkillsDir, name);
+        try {
+          if (fs.lstatSync(link).isSymbolicLink()) {
+            fs.unlinkSync(link);
+            removedFlat = true;
+          }
+        } catch { /* doesn't exist */ }
+      }
+      try { fs.rmdirSync(agentSkillsDir); } catch { /* not empty or missing */ }
+      return removedFlat;
+    }
+
+    if (!reg?.skillsTarget) return false;
 
     let removed = false;
 
@@ -2244,7 +2273,9 @@ export class SymbiontInstaller {
     if (reg.skillsTarget !== CANONICAL_SKILLS_DIR) {
       for (const name of skillNames) {
         const link = path.join(this.resolveAbsoluteTarget("skills")!, name);
-        try { fs.unlinkSync(link); removed = true; } catch { /* doesn't exist */ }
+        try {
+          if (fs.lstatSync(link).isSymbolicLink()) { fs.unlinkSync(link); removed = true; }
+        } catch { /* doesn't exist */ }
       }
       // Remove agent skills dir if now empty (rmdirSync fails atomically if non-empty)
       try { fs.rmdirSync(this.resolveAbsoluteTarget("skills")!); } catch { /* not empty or missing */ }
@@ -2254,7 +2285,9 @@ export class SymbiontInstaller {
     const canonicalDir = path.join(this.projectRoot, CANONICAL_SKILLS_DIR);
     for (const name of skillNames) {
       const link = path.join(canonicalDir, name);
-      try { fs.unlinkSync(link); removed = true; } catch { /* doesn't exist */ }
+      try {
+        if (fs.lstatSync(link).isSymbolicLink()) { fs.unlinkSync(link); removed = true; }
+      } catch { /* doesn't exist */ }
     }
     // Remove empty dirs (rmdirSync fails atomically if non-empty)
     try { fs.rmdirSync(canonicalDir); } catch { /* not empty or missing */ }

--- a/tests/symbionts/installer.test.ts
+++ b/tests/symbionts/installer.test.ts
@@ -2802,3 +2802,90 @@ describe('opencode (plugin-file hooks)', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// RC-14 — symlink stewardship: never destroy user content; symmetric uninstall
+// ---------------------------------------------------------------------------
+
+describe('RC-14 — ensureSymlink never destroys real paths', () => {
+  it('a REAL directory at the canonical link path survives install (other skills still link)', () => {
+    const canonicalDir = path.join(projectRoot, '.agents/skills');
+    fs.mkdirSync(path.join(canonicalDir, 'myco'), { recursive: true });
+    fs.writeFileSync(path.join(canonicalDir, 'myco', 'SKILL.md'), 'hand-authored content\n');
+
+    const installer = new SymbiontInstaller(CLAUDE_MANIFEST, projectRoot, packageRoot);
+    const result = installer.installSkills();
+    expect(result).toBe(true);
+
+    // The user's real directory is untouched.
+    const kept = path.join(canonicalDir, 'myco');
+    expect(fs.lstatSync(kept).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(path.join(kept, 'SKILL.md'), 'utf-8')).toBe('hand-authored content\n');
+  });
+
+  it('a REAL file at the agent link path survives install', () => {
+    const agentSkillsDir = path.join(projectRoot, '.claude/skills');
+    fs.mkdirSync(agentSkillsDir, { recursive: true });
+    fs.writeFileSync(path.join(agentSkillsDir, 'myco'), 'not a symlink\n');
+
+    const installer = new SymbiontInstaller(CLAUDE_MANIFEST, projectRoot, packageRoot);
+    installer.installSkills();
+
+    expect(fs.lstatSync(path.join(agentSkillsDir, 'myco')).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(path.join(agentSkillsDir, 'myco'), 'utf-8')).toBe('not a symlink\n');
+    // The canonical layer still linked normally.
+    expect(fs.lstatSync(path.join(projectRoot, '.agents/skills/myco')).isSymbolicLink()).toBe(true);
+  });
+});
+
+describe('RC-14 — global-scope (flatSkills) uninstall symmetry', () => {
+  it('uninstallSkills removes flat global skill symlinks installed under globalSkillsTarget', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-home-rc14-'));
+    const origHome = process.env.HOME;
+    const origSandbox = process.env.MYCO_SANDBOX_ROOT;
+    process.env.HOME = home;
+    process.env.MYCO_SANDBOX_ROOT = home;
+    try {
+      const globalClaude = {
+        ...CLAUDE_MANIFEST,
+        registration: {
+          ...CLAUDE_MANIFEST.registration,
+          globalSkillsTarget: '~/.claude/skills',
+        },
+      };
+      const installer = new SymbiontInstaller(globalClaude, '/', packageRoot, false, undefined, null, 'global');
+      expect(installer.installSkills()).toBe(true);
+
+      const link = path.join(home, '.claude/skills/myco');
+      expect(fs.lstatSync(link).isSymbolicLink()).toBe(true);
+
+      // A real user skill beside ours must survive the uninstall.
+      const userSkill = path.join(home, '.claude/skills/my-own-skill');
+      fs.mkdirSync(userSkill, { recursive: true });
+
+      expect(installer.uninstallSkills()).toBe(true);
+      expect(fs.existsSync(link)).toBe(false);
+      expect(fs.existsSync(userSkill)).toBe(true);
+    } finally {
+      if (origHome === undefined) delete process.env.HOME; else process.env.HOME = origHome;
+      if (origSandbox === undefined) delete process.env.MYCO_SANDBOX_ROOT; else process.env.MYCO_SANDBOX_ROOT = origSandbox;
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('uninstallSkills leaves a REAL directory named like a skill untouched (project scope)', () => {
+    const installer = new SymbiontInstaller(CLAUDE_MANIFEST, projectRoot, packageRoot);
+    installer.installSkills();
+
+    // Replace the agent link with a real dir (user vendored a copy).
+    const agentLink = path.join(projectRoot, '.claude/skills/myco');
+    fs.unlinkSync(agentLink);
+    fs.mkdirSync(agentLink);
+    fs.writeFileSync(path.join(agentLink, 'SKILL.md'), 'vendored\n');
+
+    installer.uninstallSkills();
+    expect(fs.existsSync(path.join(agentLink, 'SKILL.md'))).toBe(true);
+    // The canonical symlink (ours) is gone.
+    expect(fs.existsSync(path.join(projectRoot, '.agents/skills/myco'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem (bug-hunt RC-14, Wave 4)

1. **`ensureSymlink` destroyed user content**: it `rm -rf`'d whatever occupied the link path before re-linking — including a real, hand-authored directory that merely shared a name with a bundled skill. Reachable from the hourly detection tick (reproduced in the hunt: a user-customized skill dir was destroyed).
2. **Global uninstall orphaned skill symlinks**: global scope installs flat links under `globalSkillsTarget` with no canonical layer, but `uninstallSkills` bailed when `skillsTarget` was absent — exactly the global case. Every globally-installed agent kept orphaned links forever.

## Fix

- `ensureSymlink` replaces only what an installer could have created (an existing symlink, or nothing); a real file/dir returns `'kept-real-path'` and install sites surface the skip. Data-preservation contract: the installer never deletes user content.
- `uninstallSkills` mirrors `installSkills`'s `flatSkills` branch, driven by the same capabilities table; all unlink paths are lstat-gated so a real path named like a skill survives uninstall too.
- The third hunt item (doctor `fixable`/`fix()` registry drift) is split off as RC-14b — hygiene, not data loss.

## Testing

4 regression tests (real-dir survives install at both link layers; flat-global uninstall removes our links and spares user skills; real dir named like a skill survives project uninstall) — the destructive cases **verified to fail against pre-fix code**. Installer suite 148/148; full suite green (node + jsdom), JUnit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)