### PR TITLE
grove: move copies via id-rekeying, not id-preserving restore — non-empty targets are safe (RC-2)

### DIFF
--- a/packages/myco/src/backup/engine.ts
+++ b/packages/myco/src/backup/engine.ts
@@ -13,9 +13,11 @@ import { GROVE_PROJECT_SCOPED_TABLES } from '@myco/db/schema-ddl.js';
 import {
   ALL_PROJECTS_SCOPE,
   assertGroveProjectId,
+  isGroveEraId,
   projectScope,
   type ProjectScope,
 } from '@myco/grove/ids.js';
+import { groveIdFromDbPath } from '@myco/grove/paths.js';
 
 export { ALL_PROJECTS_SCOPE, projectScope, type ProjectScope };
 
@@ -187,6 +189,12 @@ export function createBackup(
   lines.push(`${BACKUP_HEADER_TEMPLATE}: machine_id=${machineId}, created_at=${timestamp}`);
   lines.push(`-- Protocol version: ${SYNC_PROTOCOL_VERSION}`);
   lines.push(`-- scope: ${scopeLabel}`);
+  // Grove lineage, when the source DB lives at a Grove path. Restore
+  // refuses to merge a Grove's dump into a DIFFERENT Grove's DB — the
+  // dump's literal AUTOINCREMENT ids only mean anything in their home
+  // Grove. Non-Grove DBs (tests, ad-hoc paths) emit no lineage line.
+  const sourceGroveId = groveIdFromDbPath(db.filename);
+  if (sourceGroveId) lines.push(`-- grove_id: ${sourceGroveId}`);
   lines.push('');
 
   for (const table of BACKUP_TABLES) {
@@ -423,6 +431,11 @@ export interface SnapshotHeader {
   created_at: number | null;
   protocol_version: number | null;
   scope: ProjectScope | null;
+  /**
+   * Grove the dump was taken from. `null` for legacy archives that
+   * predate lineage recording and for dumps of non-Grove DBs.
+   */
+  grove_id: string | null;
 }
 
 const HEADER_SCAN_LIMIT = 16;
@@ -447,6 +460,7 @@ export function readSnapshotHeader(snapshotPath: string): SnapshotHeader {
     created_at: null,
     protocol_version: null,
     scope: null,
+    grove_id: null,
   };
 
   const lines = raw.split('\n').slice(0, HEADER_SCAN_LIMIT);
@@ -466,6 +480,14 @@ export function readSnapshotHeader(snapshotPath: string): SnapshotHeader {
     const protocolMatch = /^Protocol version:\s*(\d+)/.exec(meta);
     if (protocolMatch) {
       header.protocol_version = Number(protocolMatch[1]);
+      continue;
+    }
+
+    const groveMatch = /^grove_id:\s*(\S+)$/.exec(meta);
+    if (groveMatch) {
+      // A malformed grove id is treated as absent lineage (kept `null`)
+      // rather than throwing — same posture as a malformed scope line.
+      header.grove_id = isGroveEraId(groveMatch[1], 'grove') ? groveMatch[1] : null;
       continue;
     }
 
@@ -621,6 +643,27 @@ function countTableInserts(content: string, table: string): number {
 // ---------------------------------------------------------------------------
 
 /**
+ * Refusal raised when an archive carries Grove lineage that disagrees
+ * with the restore target. A dump's literal AUTOINCREMENT ids are only
+ * meaningful in the Grove they came from — merging them into another
+ * Grove's DB silently drops colliding rows and attaches children to the
+ * wrong project's parents.
+ */
+export class BackupGroveMismatchError extends Error {
+  constructor(
+    readonly backupGroveId: string,
+    readonly targetGroveId: string,
+  ) {
+    super(
+      `Backup was taken from Grove ${backupGroveId} but the restore target is `
+      + `Grove ${targetGroveId}; cross-Grove restore is refused. Use the move `
+      + `orchestrator to relocate a project between Groves.`,
+    );
+    this.name = 'BackupGroveMismatchError';
+  }
+}
+
+/**
  * Restore a backup by feeding the entire dump to SQLite's own parser as
  * one multi-statement script. SQLite's parser understands string literals
  * with embedded newlines, so multi-line text values round-trip byte-exact.
@@ -631,11 +674,29 @@ function countTableInserts(content: string, table: string): number {
  *
  * Uses `INSERT OR IGNORE` — existing records are skipped, new records
  * are inserted.
+ *
+ * Grove lineage gate: an archive whose header records a `grove_id`
+ * different from the target DB's Grove is refused (see
+ * BackupGroveMismatchError). Same-Grove restores — including the
+ * cross-machine merge restore of a teammate's dump of the same Grove —
+ * pass. Legacy archives without lineage restore with a warning.
  */
 export function restoreBackup(
   db: Database,
   backupPath: string,
 ): RestoreResult {
+  const header = readSnapshotHeader(backupPath);
+  const targetGroveId = groveIdFromDbPath(db.filename);
+  if (header.grove_id && targetGroveId && header.grove_id !== targetGroveId) {
+    throw new BackupGroveMismatchError(header.grove_id, targetGroveId);
+  }
+  if (!header.grove_id && targetGroveId) {
+    console.warn(
+      `[backup] archive ${path.basename(backupPath)} carries no grove_id lineage; `
+      + `cross-Grove guard skipped for restore into Grove ${targetGroveId}`,
+    );
+  }
+
   const content = fs.readFileSync(backupPath, 'utf-8');
   const tableNames = extractTableNames(content);
   const before = new Map<string, number>();

--- a/packages/myco/src/daemon/server.ts
+++ b/packages/myco/src/daemon/server.ts
@@ -353,11 +353,17 @@ export class DaemonServer {
         // Long-running ops (move, vacuum) take a per-project pause in
         // `projects.toml`; while set, every writer for that project must
         // be refused. Reads stay open so the UI can still surface "this
-        // project is paused (reason)".
+        // project is paused (reason)". One owner-op-scoped exception: the
+        // move endpoint itself passes a 'grove-move' pause, because the
+        // retry that resumes a crash-orphaned move (releasing or re-taking
+        // its own pause) arrives through this very gate.
         if (isWriteMethod(req.method) && requestContext.groveId && requestContext.projectId) {
           const projectId = requestContext.projectId;
           const paused = isProjectPaused(projectId);
-          if (paused.paused) {
+          if (
+            paused.paused
+            && !isMoveRetryRequest(req.method, match.pathname, match.params, paused.reason, projectId)
+          ) {
             const response = pausedErrorResponse(projectId, paused);
             res.writeHead(response.status, { 'Content-Type': 'application/json', ...versionHeader });
             res.end(JSON.stringify(response.body));
@@ -701,6 +707,31 @@ function isWriteMethod(method: string | undefined): boolean {
   if (!method) return false;
   const upper = method.toUpperCase();
   return upper === 'POST' || upper === 'PUT' || upper === 'PATCH' || upper === 'DELETE';
+}
+
+/**
+ * True when a write hitting the pause gate is the move POST for the very
+ * project a 'grove-move' pause is guarding. A move that crashed mid-op
+ * leaves its pause held; the only HTTP path that resumes (or fresh-starts)
+ * that move is POST /api/groves/:id/projects/:projectId, and
+ * `moveProjectBetweenGroves` arbitrates the pause itself — it re-takes
+ * the same owner_op idempotently and surfaces a real owner conflict.
+ * Matched on the pause's reason plus the exact route shape for the same
+ * project, never a blanket exemption: every other write for the paused
+ * project (including the /archive and /unarchive siblings, which carry a
+ * trailing segment) stays refused.
+ */
+function isMoveRetryRequest(
+  method: string | undefined,
+  pathname: string,
+  params: Record<string, string>,
+  pauseReason: string,
+  projectId: string,
+): boolean {
+  if (method?.toUpperCase() !== 'POST') return false;
+  if (pauseReason !== 'grove-move') return false;
+  if (!params.id || params.projectId !== projectId) return false;
+  return pathname === `/api/groves/${params.id}/projects/${params.projectId}`;
 }
 
 /**

--- a/packages/myco/src/grove/importer.ts
+++ b/packages/myco/src/grove/importer.ts
@@ -66,6 +66,7 @@ import {
   type SourceSporeRow,
   type SourceSessionRow,
 } from './importer/source-rows.js';
+import { sortRowsByParentChain } from './importer/parent-chain-sort.js';
 
 export interface ImportProjectCoreInput {
   migrationId: string;
@@ -2239,61 +2240,21 @@ function requireMapping(
 }
 
 function sortPromptBatchesForImport(rows: readonly SourcePromptBatchRow[]): SourcePromptBatchRow[] {
-  const byId = new Map(rows.map((row) => [row.id, row]));
-  const visited = new Set<number>();
-  const visiting = new Set<number>();
-  const ordered: SourcePromptBatchRow[] = [];
-
-  function visit(row: SourcePromptBatchRow): void {
-    if (visited.has(row.id)) return;
-    if (visiting.has(row.id)) {
-      throw new Error(`Cycle in prompt_batches parent chain at ${row.id}`);
-    }
-
-    visiting.add(row.id);
-    if (row.parent_prompt_batch_id != null) {
-      const parent = byId.get(row.parent_prompt_batch_id);
-      if (!parent) {
-        throw new Error(`Missing source prompt_batches parent ${row.parent_prompt_batch_id} for ${row.id}`);
-      }
-      visit(parent);
-    }
-    visiting.delete(row.id);
-    visited.add(row.id);
-    ordered.push(row);
-  }
-
-  for (const row of rows) visit(row);
-  return ordered;
+  return sortRowsByParentChain(
+    rows,
+    'prompt_batches',
+    (row) => row.id,
+    (row) => row.parent_prompt_batch_id,
+  );
 }
 
 function sortDigestExtractRevisionsForImport(rows: readonly SourceDigestExtractRevisionRow[]): SourceDigestExtractRevisionRow[] {
-  const byId = new Map(rows.map((row) => [row.id, row]));
-  const visited = new Set<number>();
-  const visiting = new Set<number>();
-  const ordered: SourceDigestExtractRevisionRow[] = [];
-
-  function visit(row: SourceDigestExtractRevisionRow): void {
-    if (visited.has(row.id)) return;
-    if (visiting.has(row.id)) {
-      throw new Error(`Cycle in digest_extract_revisions parent chain at ${row.id}`);
-    }
-
-    visiting.add(row.id);
-    if (row.parent_revision_id != null) {
-      const parent = byId.get(row.parent_revision_id);
-      if (!parent) {
-        throw new Error(`Missing source digest_extract_revisions parent ${row.parent_revision_id} for ${row.id}`);
-      }
-      visit(parent);
-    }
-    visiting.delete(row.id);
-    visited.add(row.id);
-    ordered.push(row);
-  }
-
-  for (const row of rows) visit(row);
-  return ordered;
+  return sortRowsByParentChain(
+    rows,
+    'digest_extract_revisions',
+    (row) => row.id,
+    (row) => row.parent_revision_id,
+  );
 }
 
 function markImported(ctx: ImportContext, sourceTable: TargetTable, sourceId: string | number): void {

--- a/packages/myco/src/grove/importer/parent-chain-sort.ts
+++ b/packages/myco/src/grove/importer/parent-chain-sort.ts
@@ -1,0 +1,43 @@
+/**
+ * Topological sort for tables with a self-referential parent column
+ * (prompt_batches.parent_prompt_batch_id, digest_extract_revisions.
+ * parent_revision_id). Parents are emitted before children so an insert
+ * pass can resolve each row's remapped parent id from rows already
+ * written. Shared by the Grove importer and the move rekey copy.
+ */
+
+export function sortRowsByParentChain<T>(
+  rows: readonly T[],
+  table: string,
+  idOf: (row: T) => number,
+  parentIdOf: (row: T) => number | null,
+): T[] {
+  const byId = new Map(rows.map((row) => [idOf(row), row]));
+  const visited = new Set<number>();
+  const visiting = new Set<number>();
+  const ordered: T[] = [];
+
+  function visit(row: T): void {
+    const id = idOf(row);
+    if (visited.has(id)) return;
+    if (visiting.has(id)) {
+      throw new Error(`Cycle in ${table} parent chain at ${id}`);
+    }
+
+    visiting.add(id);
+    const parentId = parentIdOf(row);
+    if (parentId != null) {
+      const parent = byId.get(parentId);
+      if (!parent) {
+        throw new Error(`Missing source ${table} parent ${parentId} for ${id}`);
+      }
+      visit(parent);
+    }
+    visiting.delete(id);
+    visited.add(id);
+    ordered.push(row);
+  }
+
+  for (const row of rows) visit(row);
+  return ordered;
+}

--- a/packages/myco/src/grove/move-copy.ts
+++ b/packages/myco/src/grove/move-copy.ts
@@ -1,0 +1,311 @@
+/**
+ * Move rekey copy — project-scoped row transfer between two Grove DBs.
+ *
+ * The backup engine's dump/restore pair cannot serve a move into a
+ * non-empty target: dumps serialize literal AUTOINCREMENT integer ids
+ * and restore with `INSERT OR IGNORE`, so colliding ids are silently
+ * dropped and child rows attach to the wrong project's parents. This
+ * copy reads the source rows directly and re-inserts them into the
+ * target in one transaction, reallocating every integer primary key
+ * and remapping the foreign-key columns that point at them.
+ *
+ * Text primary keys (sessions, spores, plans, ...) are globally unique
+ * and copied as-is. FTS shadow tables are maintained by the INSERT
+ * triggers on their base tables, so plain prepared INSERTs keep them
+ * in sync — `*_fts` tables are never written directly.
+ */
+
+import type { Database } from 'bun:sqlite';
+import { GROVE_PROJECT_SCOPED_TABLES } from '@myco/db/schema-ddl.js';
+import { sortRowsByParentChain } from './importer/parent-chain-sort.js';
+
+/**
+ * Tables the move copies, verifies, and cleans. The full project-scoped
+ * registry — including `entity_mentions`, which the dump format excludes
+ * (no `id` column) but a direct row copy carries fine.
+ */
+export const MOVE_COPY_TABLES: readonly string[] = GROVE_PROJECT_SCOPED_TABLES;
+
+/**
+ * Tables whose `INTEGER PRIMARY KEY AUTOINCREMENT` ids are reallocated
+ * in the target. Guarded against schema drift by
+ * tests/grove/move-copy.test.ts, which re-derives this set from the DDL.
+ */
+export const MOVE_REKEYED_TABLES = [
+  'prompt_batches',
+  'knowledge_git_provenance',
+  'knowledge_release_state',
+  'activities',
+  'digest_extracts',
+  'agent_reports',
+  'agent_turns',
+  'agent_run_write_intents',
+  'digest_extract_revisions',
+  'log_entries',
+] as const;
+
+const MOVE_REKEYED_TABLE_SET = new Set<string>(MOVE_REKEYED_TABLES);
+
+export interface MoveFkRemap {
+  /** Table carrying the foreign-key column. */
+  table: string;
+  /** Column holding an integer id into a rekeyed table. */
+  column: string;
+  /** Rekeyed table the column references. */
+  via: string;
+}
+
+/**
+ * Every foreign-key column that references a rekeyed table's integer id.
+ * Drift-guarded against the DDL by tests/grove/move-copy.test.ts.
+ */
+export const MOVE_FK_REMAPS: readonly MoveFkRemap[] = [
+  { table: 'prompt_batches', column: 'parent_prompt_batch_id', via: 'prompt_batches' },
+  { table: 'knowledge_git_provenance', column: 'prompt_batch_id', via: 'prompt_batches' },
+  { table: 'knowledge_release_state', column: 'source_prompt_batch_id', via: 'prompt_batches' },
+  { table: 'activities', column: 'prompt_batch_id', via: 'prompt_batches' },
+  { table: 'plans', column: 'prompt_batch_id', via: 'prompt_batches' },
+  { table: 'attachments', column: 'prompt_batch_id', via: 'prompt_batches' },
+  { table: 'spores', column: 'prompt_batch_id', via: 'prompt_batches' },
+  { table: 'digest_extract_revisions', column: 'parent_revision_id', via: 'digest_extract_revisions' },
+];
+
+/** Self-referential parent columns requiring parents-before-children insert order. */
+const SELF_FK_PARENT_COLUMNS: Record<string, string> = {
+  prompt_batches: 'parent_prompt_batch_id',
+  digest_extract_revisions: 'parent_revision_id',
+};
+
+type SqlValue = string | number | bigint | Uint8Array | null;
+
+/**
+ * True for SQLite's "no such table" — the ONLY skippable per-table error
+ * (a missing table holds no rows for the project). Every other error must
+ * surface: the same error swallowed symmetrically on both sides of the
+ * move would let a skipped table pass count-verify as 0 == 0, after which
+ * cleanup deletes the only copy of the rows.
+ */
+export function isMissingTableError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /no such table/i.test(message);
+}
+
+/**
+ * Copy every row of the moved project from `sourceDb` into `targetDb`.
+ *
+ * Runs as ONE target transaction that first wipes any target rows for
+ * `projectId` across the copy's table set, then inserts the source rows.
+ * Target registration only happens at the move's commit phase, so the
+ * project cannot legitimately have target rows yet — the wipe makes the
+ * copy re-entrant after a crash between transaction commit and marker
+ * write. Foreign keys are deferred for the duration (rows may reference
+ * out-of-scope tables such as `agents`, copied separately).
+ */
+export function copyProjectBetweenGroveDbs(
+  sourceDb: Database,
+  targetDb: Database,
+  projectId: string,
+): void {
+  targetDb.run('PRAGMA foreign_keys = OFF');
+  try {
+    const tx = targetDb.transaction(() => {
+      wipeProjectRows(targetDb, projectId);
+      const idMaps = new Map<string, Map<number, number>>();
+      for (const table of MOVE_COPY_TABLES) {
+        copyTable(sourceDb, targetDb, table, projectId, idMaps);
+      }
+    });
+    tx();
+  } finally {
+    targetDb.run('PRAGMA foreign_keys = ON');
+  }
+}
+
+/**
+ * Delete every row for `projectId` across the move's table set, in its
+ * own transaction with foreign keys deferred. Used for the move's
+ * source-cleanup phase and for rolling the target back after a failed
+ * move. Per-table errors are collected and thrown together — a failed
+ * delete must surface, not silently leave rows behind. The transaction
+ * makes the deletion all-or-nothing.
+ */
+export function deleteProjectRowsForMove(db: Database, projectId: string): void {
+  db.run('PRAGMA foreign_keys = OFF');
+  try {
+    const tx = db.transaction(() => wipeProjectRows(db, projectId));
+    tx();
+  } finally {
+    db.run('PRAGMA foreign_keys = ON');
+  }
+}
+
+/**
+ * Post-copy integrity check: rows whose remapped foreign key does not
+ * resolve to a parent row of the same project. Structurally impossible
+ * after a correct rekey copy — any hit means the copy is broken and the
+ * move must not commit.
+ */
+export function findOrphanRemappedRows(db: Database, projectId: string): string[] {
+  const problems: string[] = [];
+  for (const { table, column, via } of MOVE_FK_REMAPS) {
+    let row: { n: number } | undefined;
+    try {
+      row = db.prepare(
+        `SELECT COUNT(*) AS n FROM ${table} child
+         WHERE child.project_id = ?
+           AND child.${column} IS NOT NULL
+           AND NOT EXISTS (
+             SELECT 1 FROM ${via} parent
+             WHERE parent.id = child.${column} AND parent.project_id = ?
+           )`,
+      ).get(projectId, projectId) as { n: number } | undefined;
+    } catch (err) {
+      // A missing table has nothing to check; any other error blinds the
+      // orphan check and must fail the verify it serves.
+      if (isMissingTableError(err)) continue;
+      throw new Error(
+        `orphan check failed reading ${table}.${column}: `
+        + (err instanceof Error ? err.message : String(err)),
+      );
+    }
+    const count = row?.n ?? 0;
+    if (count > 0) {
+      problems.push(`${table}.${column}: ${count} row(s) reference a missing ${via} parent`);
+    }
+  }
+  return problems;
+}
+
+function wipeProjectRows(db: Database, projectId: string): void {
+  const failures: string[] = [];
+  for (const table of MOVE_COPY_TABLES) {
+    try {
+      db.prepare(`DELETE FROM ${table} WHERE project_id = ?`).run(projectId);
+    } catch (err) {
+      // A missing table holds no rows for the project — nothing to delete.
+      if (isMissingTableError(err)) continue;
+      failures.push(`${table}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  if (failures.length > 0) {
+    throw new Error(
+      `failed to delete rows for project ${projectId}: ${failures.join('; ')}`,
+    );
+  }
+}
+
+function copyTable(
+  sourceDb: Database,
+  targetDb: Database,
+  table: string,
+  projectId: string,
+  idMaps: Map<string, Map<number, number>>,
+): void {
+  let rows: Record<string, unknown>[];
+  try {
+    rows = sourceDb.prepare(
+      `SELECT * FROM ${table} WHERE project_id = ?`,
+    ).all(projectId) as Record<string, unknown>[];
+  } catch (err) {
+    // A table absent from an older source schema has nothing to copy.
+    // Any other read error (corrupt table, missing column) must abort
+    // the move — see isMissingTableError.
+    if (isMissingTableError(err)) return;
+    throw new Error(
+      `failed to read ${table} rows for project ${projectId}: `
+      + (err instanceof Error ? err.message : String(err)),
+    );
+  }
+  if (rows.length === 0) return;
+
+  const selfFkColumn = SELF_FK_PARENT_COLUMNS[table];
+  if (selfFkColumn) {
+    rows = sortRowsByParentChain(
+      rows,
+      table,
+      (row) => row.id as number,
+      (row) => row[selfFkColumn] as number | null,
+    );
+  }
+
+  const targetColumns = tableColumns(targetDb, table);
+  const rekey = MOVE_REKEYED_TABLE_SET.has(table);
+  const remaps = MOVE_FK_REMAPS.filter((r) => r.table === table && targetColumns.has(r.column));
+  // Columns the source rows carry AND the target schema knows; the
+  // reallocated integer id is omitted so the target assigns a fresh one.
+  const columns = Object.keys(rows[0]).filter(
+    (c) => targetColumns.has(c) && !(rekey && c === 'id'),
+  );
+  const insert = targetDb.prepare(
+    `INSERT INTO ${table} (${columns.map((c) => `"${c}"`).join(', ')})
+     VALUES (${columns.map(() => '?').join(', ')})`,
+  );
+  const map = rekey ? mapFor(idMaps, table) : null;
+
+  for (const row of rows) {
+    const out: Record<string, unknown> = { ...row };
+    for (const remap of remaps) {
+      out[remap.column] = remapFkValue(sourceDb, idMaps, remap, out[remap.column], row.id);
+    }
+    const result = insert.run(...columns.map((c) => out[c] as SqlValue));
+    if (map) map.set(row.id as number, Number(result.lastInsertRowid));
+  }
+}
+
+function mapFor(idMaps: Map<string, Map<number, number>>, table: string): Map<number, number> {
+  let map = idMaps.get(table);
+  if (!map) {
+    map = new Map<number, number>();
+    idMaps.set(table, map);
+  }
+  return map;
+}
+
+function remapFkValue(
+  sourceDb: Database,
+  idMaps: Map<string, Map<number, number>>,
+  remap: MoveFkRemap,
+  value: unknown,
+  childRowId: unknown,
+): number | null {
+  if (value === null || value === undefined) return null;
+  const sourceId = Number(value);
+  const mapped = idMaps.get(remap.via)?.get(sourceId);
+  if (mapped === undefined) {
+    // The referenced parent is not part of the moved project's row set.
+    // Copying the literal id would attach the row to an arbitrary target
+    // parent — refuse and let the move's failure path roll back. The
+    // message names the polluted row and its foreign parent so manual
+    // triage (repair or delete the row in the source Grove) is possible
+    // without re-deriving the lineage.
+    throw new Error(
+      `${remap.table}.${remap.column} references ${remap.via} id ${sourceId}, `
+      + `which is not part of the moved project's rows `
+      + `(${remap.table} row id ${String(childRowId)}; ${describeForeignParent(sourceDb, remap.via, sourceId)}). `
+      + `Repair or delete that ${remap.table} row in the source Grove, then retry the move.`,
+    );
+  }
+  return mapped;
+}
+
+/** Triage detail for an out-of-scope FK parent: who owns it, if anyone. */
+function describeForeignParent(sourceDb: Database, table: string, id: number): string {
+  let row: { project_id: string | null } | undefined;
+  try {
+    row = sourceDb.prepare(
+      `SELECT project_id FROM ${table} WHERE id = ?`,
+    ).get(id) as { project_id: string | null } | undefined;
+  } catch {
+    return `the ${table} parent could not be inspected`;
+  }
+  if (!row) return `no ${table} row with that id exists in the source`;
+  if (row.project_id === null || row.project_id === '') {
+    return `the ${table} parent carries no project_id`;
+  }
+  return `the ${table} parent belongs to project ${row.project_id}`;
+}
+
+function tableColumns(db: Database, table: string): Set<string> {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return new Set(rows.map((r) => r.name));
+}

--- a/packages/myco/src/grove/move.ts
+++ b/packages/myco/src/grove/move.ts
@@ -11,21 +11,25 @@
  *
  * The marker is the source of truth for resumability. A marker for the
  * same (project, from, to) tuple is resumed; any other open marker
- * refuses to proceed.
+ * refuses to proceed. A failure before the commit phase rolls the
+ * target back, records the marker as 'failed' (terminal — the next
+ * call starts a fresh move op), and releases the source pause.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import type { Database } from 'bun:sqlite';
-import { GROVE_PROJECT_SCOPED_TABLES } from '@myco/db/schema-ddl.js';
 import { openDatabase } from '@myco/db/client.js';
 import { EMBEDDABLE_TABLES } from '@myco/db/queries/embeddings.js';
 import { ProjectVault } from '@myco/vault/project-vault.js';
+import { createBackup } from '@myco/backup/engine.js';
 import {
-  BACKUP_TABLES,
-  createBackup,
-  restoreBackup,
-} from '@myco/backup/engine.js';
+  MOVE_COPY_TABLES,
+  copyProjectBetweenGroveDbs,
+  deleteProjectRowsForMove,
+  findOrphanRemappedRows,
+  isMissingTableError,
+} from './move-copy.js';
 import { getMachineId } from '@myco/machine-id.js';
 import {
   assertGroveProjectId,
@@ -57,7 +61,8 @@ type MovePhase =
   | 'verified'
   | 'committed'
   | 'cleaned'
-  | 'completed';
+  | 'completed'
+  | 'failed';
 
 interface MoveMarker {
   move_op_id: string;
@@ -71,6 +76,7 @@ interface MoveMarker {
   snapshot_path?: string;
   table_counts?: Record<string, number>;
   new_binding_id?: string;
+  error?: string;
 }
 
 export interface MoveResult {
@@ -80,16 +86,6 @@ export interface MoveResult {
   snapshot_path: string;
   table_counts: Record<string, number>;
 }
-
-const PROJECT_SCOPED_TABLE_SET = new Set<string>(GROVE_PROJECT_SCOPED_TABLES);
-
-/**
- * Tables iterated for the verify/clean phases. Drawn from BACKUP_TABLES
- * intersected with the project-scoped set so `team_members` (grove-
- * scoped, not project-scoped) is not deleted from the source — moves
- * only relocate project data.
- */
-const MOVE_SCOPED_TABLES = BACKUP_TABLES.filter((t) => PROJECT_SCOPED_TABLE_SET.has(t));
 
 export interface MoveProjectOptions {
   /**
@@ -219,140 +215,256 @@ export function moveProjectBetweenGroves(
     pauseProject(sourceGroveId, projectId, 'grove-move', moveOpId, mycoHome);
   }
 
-  if (!fs.existsSync(markerPath)) writeMarker(markerPath, marker);
-
   const sourceDbPath = resolveGroveDbPath(sourceGroveId, mycoHome);
   const targetDbPath = resolveGroveDbPath(targetGroveId, mycoHome);
 
-  const machineId = getMachineId();
-  const snapshotsRoot = resolveBackupsRoot(options.snapshotsRoot);
-  const snapshotDir = path.join(snapshotsRoot, projectSlug, moveOpId);
-  fs.mkdirSync(snapshotDir, { recursive: true });
+  // The pause is held from here on. Every exit path below either
+  // completes the move (the pause dies with the deregistered source
+  // entry) or flows through the catch, which rolls back and releases
+  // the pause — a failed move must never leave the source refusing
+  // writes.
+  try {
+    if (!fs.existsSync(markerPath)) writeMarker(markerPath, marker);
 
-  if (orderOf(marker.phase) <= orderOf('snapshot')) {
-    const snapshotPath = withDb(sourceDbPath, (sourceDb) => {
-      return createBackup(
-        sourceDb,
-        snapshotDir,
-        machineId,
-        projectScope(brandedProjectId),
-        projectSlug,
+    const machineId = getMachineId();
+    const snapshotsRoot = resolveBackupsRoot(options.snapshotsRoot);
+    const snapshotDir = path.join(snapshotsRoot, projectSlug, moveOpId);
+    fs.mkdirSync(snapshotDir, { recursive: true });
+
+    if (orderOf(marker.phase) <= orderOf('snapshot')) {
+      const snapshotPath = withDb(sourceDbPath, (sourceDb) => {
+        return createBackup(
+          sourceDb,
+          snapshotDir,
+          machineId,
+          projectScope(brandedProjectId),
+          projectSlug,
+        );
+      });
+      marker = { ...marker, phase: 'snapshot_complete', snapshot_path: snapshotPath };
+      writeMarker(markerPath, marker);
+    }
+
+    const snapshotPath = marker.snapshot_path;
+    if (!snapshotPath) {
+      throw new Error('move marker advanced past snapshot but recorded no snapshot_path');
+    }
+
+    if (orderOf(marker.phase) <= orderOf('snapshot_complete')) {
+      // Target DB may be uninitialized (Grove registered but never
+      // activated). `openDatabase` only creates an empty file; the copy
+      // needs the schema present before its INSERT statements run.
+      ensureGroveDatabase(targetGroveId, mycoHome);
+      // Rekey copy straight from the live source DB — the snapshot taken
+      // above is a recovery artifact, not the transfer medium. Integer
+      // ids are reallocated in the target so a non-empty target Grove
+      // cannot collide with (and silently swallow) the moved rows.
+      withDbs(sourceDbPath, targetDbPath, (sourceDb, targetDb) => {
+        copyAgents(sourceDb, targetDb);
+        copyProjectBetweenGroveDbs(sourceDb, targetDb, projectId);
+        resetTargetEmbeddingFlags(targetDb, projectId);
+      });
+      marker = { ...marker, phase: 'restored' };
+      writeMarker(markerPath, marker);
+    }
+
+    let tableCounts: Record<string, number> = marker.table_counts ?? {};
+
+    if (orderOf(marker.phase) <= orderOf('restored')) {
+      const sourceCounts = withDb(sourceDbPath, (sourceDb) =>
+        countProjectRows(sourceDb, projectId),
       );
-    });
-    marker = { ...marker, phase: 'snapshot_complete', snapshot_path: snapshotPath };
-    writeMarker(markerPath, marker);
-  }
+      const targetCounts = withDb(targetDbPath, (targetDb) =>
+        countProjectRows(targetDb, projectId),
+      );
 
-  const snapshotPath = marker.snapshot_path;
-  if (!snapshotPath) {
-    throw new Error('move marker advanced past snapshot but recorded no snapshot_path');
-  }
-
-  if (orderOf(marker.phase) <= orderOf('snapshot_complete')) {
-    // Target DB may be uninitialized (Grove registered but never activated).
-    // `openDatabase` only creates an empty file; restoreBackup needs the
-    // schema present before its INSERT OR IGNORE statements run.
-    ensureGroveDatabase(targetGroveId, mycoHome);
-    withDbs(sourceDbPath, targetDbPath, (sourceDb, targetDb) => {
-      copyAgents(sourceDb, targetDb);
-      restoreBackup(targetDb, snapshotPath);
-      resetTargetEmbeddingFlags(targetDb, projectId);
-    });
-    marker = { ...marker, phase: 'restored' };
-    writeMarker(markerPath, marker);
-  }
-
-  let tableCounts: Record<string, number> = marker.table_counts ?? {};
-
-  if (orderOf(marker.phase) <= orderOf('restored')) {
-    const sourceCounts = withDb(sourceDbPath, (sourceDb) =>
-      countProjectRows(sourceDb, projectId),
-    );
-    const targetCounts = withDb(targetDbPath, (targetDb) =>
-      countProjectRows(targetDb, projectId),
-    );
-
-    const mismatches: string[] = [];
-    for (const table of MOVE_SCOPED_TABLES) {
-      const src = sourceCounts[table] ?? 0;
-      const tgt = targetCounts[table] ?? 0;
-      if (src !== tgt) {
-        mismatches.push(`${table}: source=${src}, target=${tgt}`);
+      const mismatches: string[] = [];
+      for (const table of MOVE_COPY_TABLES) {
+        const src = sourceCounts[table] ?? 0;
+        const tgt = targetCounts[table] ?? 0;
+        if (src !== tgt) {
+          mismatches.push(`${table}: source=${src}, target=${tgt}`);
+        }
       }
-    }
-    if (mismatches.length > 0) {
-      throw new Error(
-        `move verification failed for project ${projectId}: ${mismatches.join('; ')}`,
+      if (mismatches.length > 0) {
+        throw new Error(
+          `move verification failed for project ${projectId}: ${mismatches.join('; ')}`,
+        );
+      }
+
+      // Remapped foreign keys must resolve to parents of the moved
+      // project. Structurally guaranteed by the rekey copy; checked
+      // anyway because a violation here means cross-project corruption.
+      const orphans = withDb(targetDbPath, (targetDb) =>
+        findOrphanRemappedRows(targetDb, projectId),
       );
+      if (orphans.length > 0) {
+        throw new Error(
+          `move verification failed for project ${projectId}: orphaned rows after rekey: `
+          + orphans.join('; '),
+        );
+      }
+
+      // TEXT foreign keys are copied verbatim (only integer ids are
+      // rekeyed), so a source row pointing at another project's parent —
+      // e.g. spores.session_id at a sibling project's session — arrives
+      // dangling, and count-compare cannot see it. The copy runs with
+      // foreign keys deferred; this is where they are enforced. Any
+      // violation fails the move before commit, including pre-existing
+      // ones in other projects' rows — a target with broken references
+      // must surface, not absorb more data.
+      const fkViolations = withDb(targetDbPath, (targetDb) =>
+        targetDb.prepare('PRAGMA foreign_key_check').all() as Array<{
+          table: string;
+          rowid: number | bigint | null;
+          parent: string;
+          fkid: number;
+        }>,
+      );
+      if (fkViolations.length > 0) {
+        const listed = fkViolations.slice(0, 20)
+          .map((v) => `${v.table}(rowid=${v.rowid}) -> ${v.parent}`)
+          .join('; ');
+        throw new Error(
+          `move verification failed for project ${projectId}: ${fkViolations.length} foreign key `
+          + `violation(s) in target after copy: ${listed}`,
+        );
+      }
+
+      tableCounts = {};
+      for (const [table, count] of Object.entries(sourceCounts)) {
+        if (count > 0) tableCounts[table] = count;
+      }
+
+      marker = { ...marker, phase: 'verified', table_counts: tableCounts };
+      writeMarker(markerPath, marker);
     }
 
-    tableCounts = {};
-    for (const [table, count] of Object.entries(sourceCounts)) {
-      if (count > 0) tableCounts[table] = count;
-    }
-
-    marker = { ...marker, phase: 'verified', table_counts: tableCounts };
-    writeMarker(markerPath, marker);
-  }
-
-  if (orderOf(marker.phase) <= orderOf('verified')) {
-    const newBindingId = marker.new_binding_id ?? createGroveBindingId();
-    // registerProjectInGrove merges with any existing entry (preserves
-    // created_at, refreshes updated_at), so a resume after a partial
-    // commit is idempotent on the target side.
-    registerProjectInGrove(targetGroveId, {
-      projectId,
-      projectName,
-      projectRoot,
-      bindingId: newBindingId,
-    }, mycoHome);
-    // force: idempotent on resume after a partial commit
-    deregisterProjectInGrove(sourceGroveId, projectId, mycoHome, { force: true });
-    // Move commit: atomic write of both manifests + gitignore refresh
-    // via ProjectVault. The new Grove identity carries the freshly
-    // minted binding_id (newBindingId) generated for this move.
-    new ProjectVault(projectRoot).writeIdentity({
-      manifest: {
-        project: { id: projectId, name: projectName },
-        grove: {
-          id: targetGroveId,
-          slug: targetGrove.slug,
-          name: targetGrove.name,
-          mode: 'local',
+    if (orderOf(marker.phase) <= orderOf('verified')) {
+      const newBindingId = marker.new_binding_id ?? createGroveBindingId();
+      // registerProjectInGrove merges with any existing entry (preserves
+      // created_at, refreshes updated_at), so a resume after a partial
+      // commit is idempotent on the target side.
+      registerProjectInGrove(targetGroveId, {
+        projectId,
+        projectName,
+        projectRoot,
+        bindingId: newBindingId,
+      }, mycoHome);
+      // force: idempotent on resume after a partial commit
+      deregisterProjectInGrove(sourceGroveId, projectId, mycoHome, { force: true });
+      // Move commit: atomic write of both manifests + gitignore refresh
+      // via ProjectVault. The new Grove identity carries the freshly
+      // minted binding_id (newBindingId) generated for this move.
+      new ProjectVault(projectRoot).writeIdentity({
+        manifest: {
+          project: { id: projectId, name: projectName },
+          grove: {
+            id: targetGroveId,
+            slug: targetGrove.slug,
+            name: targetGrove.name,
+            mode: 'local',
+          },
         },
-      },
-      localManifest: {
-        grove_binding: { binding_id: newBindingId, mode: 'local' },
-      },
+        localManifest: {
+          grove_binding: { binding_id: newBindingId, mode: 'local' },
+        },
+      });
+      marker = { ...marker, phase: 'committed', new_binding_id: newBindingId };
+      writeMarker(markerPath, marker);
+    }
+
+    if (orderOf(marker.phase) <= orderOf('committed')) {
+      // Source cleanup deletes the MOVED project id only. Rows under
+      // sibling legacy project ids sharing the same project_root were
+      // never copied to the target, so deleting them here would be
+      // unrecoverable data loss — they stay in the source Grove.
+      withDb(sourceDbPath, (sourceDb) => {
+        deleteProjectRowsForMove(sourceDb, projectId);
+      });
+      marker = { ...marker, phase: 'cleaned' };
+      writeMarker(markerPath, marker);
+    }
+
+    if (orderOf(marker.phase) <= orderOf('cleaned')) {
+      // Pause was on source's projects.toml entry; deregister already
+      // dropped the entry. resumeProject on target is a no-op-on-unpaused
+      // path, included for symmetry so future ops see a clean slate.
+      resumeProject(targetGroveId, projectId, moveOpId, mycoHome);
+      marker = { ...marker, phase: 'completed' };
+      writeMarker(markerPath, marker);
+    }
+
+    return {
+      from_grove_id: sourceGroveId,
+      to_grove_id: targetGroveId,
+      project_id: projectId,
+      snapshot_path: snapshotPath,
+      table_counts: marker.table_counts ?? tableCounts,
+    };
+  } catch (err) {
+    handleMoveFailure({
+      marker,
+      markerPath,
+      targetDbPath,
+      sourceGroveId,
+      projectId,
+      moveOpId,
+      mycoHome,
+      cause: err,
     });
-    marker = { ...marker, phase: 'committed', new_binding_id: newBindingId };
-    writeMarker(markerPath, marker);
+    throw err;
   }
+}
 
-  if (orderOf(marker.phase) <= orderOf('committed')) {
-    withDb(sourceDbPath, (sourceDb) => {
-      deleteProjectRows(sourceDb, projectIdsForCleanup(sourceDb, projectId, projectRoot));
-    });
-    marker = { ...marker, phase: 'cleaned' };
-    writeMarker(markerPath, marker);
+interface MoveFailureContext {
+  marker: MoveMarker;
+  markerPath: string;
+  targetDbPath: string;
+  sourceGroveId: string;
+  projectId: string;
+  moveOpId: string;
+  mycoHome: string;
+  cause: unknown;
+}
+
+/**
+ * Failure path for a move that threw mid-flight.
+ *
+ * Before the commit phase the target is not yet authoritative: wipe the
+ * moved project's rows from it and record the marker as 'failed' so the
+ * next call starts a fresh move op. From 'committed' onward the target
+ * owns the data — the marker is left resumable and nothing is wiped.
+ * The source pause is released on every failure; rollback steps are
+ * best-effort so the original error always propagates.
+ */
+function handleMoveFailure(ctx: MoveFailureContext): void {
+  if (orderOf(ctx.marker.phase) < orderOf('committed')) {
+    try {
+      withDb(ctx.targetDbPath, (targetDb) =>
+        deleteProjectRowsForMove(targetDb, ctx.projectId),
+      );
+    } catch {
+      // Target wipe is best-effort: the wipe-before-copy at the start of
+      // the next move's transfer clears any rows left behind here.
+    }
+    try {
+      writeMarker(ctx.markerPath, {
+        ...ctx.marker,
+        phase: 'failed',
+        error: ctx.cause instanceof Error ? ctx.cause.message : String(ctx.cause),
+      });
+    } catch {
+      // A stuck non-failed marker resumes at its recorded phase, which
+      // re-runs the (re-entrant) copy rather than corrupting anything.
+    }
   }
-
-  if (orderOf(marker.phase) <= orderOf('cleaned')) {
-    // Pause was on source's projects.toml entry; deregister already
-    // dropped the entry. resumeProject on target is a no-op-on-unpaused
-    // path, included for symmetry so future ops see a clean slate.
-    resumeProject(targetGroveId, projectId, moveOpId, mycoHome);
-    marker = { ...marker, phase: 'completed' };
-    writeMarker(markerPath, marker);
+  try {
+    resumeProject(ctx.sourceGroveId, ctx.projectId, ctx.moveOpId, ctx.mycoHome);
+  } catch {
+    // No-op when the source entry is already deregistered; an owner
+    // conflict cannot mask the original failure.
   }
-
-  return {
-    from_grove_id: sourceGroveId,
-    to_grove_id: targetGroveId,
-    project_id: projectId,
-    snapshot_path: snapshotPath,
-    table_counts: marker.table_counts ?? tableCounts,
-  };
 }
 
 const PHASE_ORDER: MovePhase[] = [
@@ -364,6 +476,14 @@ const PHASE_ORDER: MovePhase[] = [
   'cleaned',
   'completed',
 ];
+
+/**
+ * Phases a marker may legitimately record. 'failed' is terminal and
+ * deliberately outside PHASE_ORDER — it never participates in resume
+ * ordering; both terminal phases mean "this op is over".
+ */
+const TERMINAL_PHASES = new Set<MovePhase>(['completed', 'failed']);
+const VALID_MARKER_PHASES = new Set<MovePhase>([...PHASE_ORDER, 'failed']);
 
 function orderOf(phase: MovePhase): number {
   return PHASE_ORDER.indexOf(phase);
@@ -383,7 +503,7 @@ function validateMarker(raw: unknown): MoveMarker | null {
     || typeof parsed.project_id !== 'string'
     || typeof parsed.started_at !== 'string'
     || typeof parsed.phase !== 'string'
-    || !PHASE_ORDER.includes(parsed.phase as MovePhase)
+    || !VALID_MARKER_PHASES.has(parsed.phase as MovePhase)
   ) {
     return null;
   }
@@ -399,6 +519,7 @@ function validateMarker(raw: unknown): MoveMarker | null {
     ...(typeof parsed.snapshot_path === 'string' ? { snapshot_path: parsed.snapshot_path } : {}),
     ...(parsed.table_counts ? { table_counts: parsed.table_counts as Record<string, number> } : {}),
     ...(typeof parsed.new_binding_id === 'string' ? { new_binding_id: parsed.new_binding_id } : {}),
+    ...(typeof parsed.error === 'string' ? { error: parsed.error } : {}),
   };
 }
 
@@ -406,10 +527,16 @@ function readMarker(markerPath: string): MoveMarker | null {
   return readMarkerJson<MoveMarker>(markerPath, validateMarker);
 }
 
+/**
+ * Find a resumable (non-terminal) marker for the project. A 'failed'
+ * marker is terminal: the failed op already rolled the target back and
+ * released the pause, so the next call must start a fresh move op
+ * rather than resume at the failed op's recorded phase.
+ */
 function findExistingMarkerForProject(migrationDir: string, projectId: string): MoveMarker | null {
   for (const full of findMarkerFiles(migrationDir, () => true)) {
     const parsed = readMarker(full);
-    if (parsed && parsed.project_id === projectId && parsed.phase !== 'completed') {
+    if (parsed && parsed.project_id === projectId && !TERMINAL_PHASES.has(parsed.phase)) {
       return parsed;
     }
   }
@@ -434,7 +561,7 @@ function findCompletedMarkerForProject(migrationDir: string, projectId: string):
 function findMarkerForOtherProject(migrationDir: string, projectId: string): MoveMarker | null {
   for (const full of findMarkerFiles(migrationDir, () => true)) {
     const parsed = readMarker(full);
-    if (parsed && parsed.project_id !== projectId && parsed.phase !== 'completed') {
+    if (parsed && parsed.project_id !== projectId && !TERMINAL_PHASES.has(parsed.phase)) {
       return parsed;
     }
   }
@@ -519,13 +646,22 @@ function copyAgents(sourceDb: Database, targetDb: Database): void {
 
 function countProjectRows(db: Database, projectId: string): Record<string, number> {
   const counts: Record<string, number> = {};
-  for (const table of MOVE_SCOPED_TABLES) {
+  for (const table of MOVE_COPY_TABLES) {
     try {
       const row = db.prepare(
         `SELECT COUNT(*) AS n FROM ${table} WHERE project_id = ?`,
       ).get(projectId) as { n: number } | undefined;
       counts[table] = row?.n ?? 0;
-    } catch {
+    } catch (err) {
+      // A missing table counts as zero rows. Any other error must fail
+      // the move — the same error swallowed on BOTH sides would let a
+      // skipped table verify as 0 == 0 and cleanup delete the only copy.
+      if (!isMissingTableError(err)) {
+        throw new Error(
+          `failed to count ${table} rows for project ${projectId}: `
+          + (err instanceof Error ? err.message : String(err)),
+        );
+      }
       counts[table] = 0;
     }
   }
@@ -545,60 +681,3 @@ function resetTargetEmbeddingFlags(db: Database, projectId: string): void {
   tx();
 }
 
-function projectIdsForCleanup(
-  db: Database,
-  projectId: string,
-  projectRoot: string,
-): string[] {
-  const ids = new Set<string>([projectId]);
-  try {
-    const rows = db.prepare(
-      `SELECT DISTINCT project_id
-       FROM sessions
-       WHERE project_root = ?
-         AND project_id IS NOT NULL
-         AND project_id <> ''`,
-    ).all(projectRoot) as Array<{ project_id: string }>;
-    for (const row of rows) {
-      if (typeof row.project_id === 'string') ids.add(row.project_id);
-    }
-  } catch {
-    // Older schemas may not have project_root/project_id; fall back to the
-    // project id from the active registry entry.
-  }
-  return [...ids];
-}
-
-function deleteProjectRows(db: Database, projectIds: string[]): void {
-  const uniqueProjectIds = [...new Set(projectIds)].filter((id) => id.length > 0);
-  if (uniqueProjectIds.length === 0) return;
-
-  db.run('PRAGMA foreign_keys = OFF');
-  try {
-    const tx = db.transaction(() => {
-      for (const table of MOVE_SCOPED_TABLES) {
-        try {
-          const stmt = db.prepare(`DELETE FROM ${table} WHERE project_id = ?`);
-          for (const id of uniqueProjectIds) stmt.run(id);
-        } catch {
-          // Table may not exist on a brand-new target Grove DB; skip.
-        }
-      }
-      // `entity_mentions` is project-scoped but excluded from BACKUP_TABLES
-      // (no `id` column makes it incompatible with the INSERT OR IGNORE
-      // round-trip; see gotcha_entity_mentions_not_synced.md). Its rows
-      // are not snapshotted and not restored on the target, so we delete
-      // them from source explicitly here — the moved project must leave
-      // no orphans behind.
-      try {
-        const stmt = db.prepare(`DELETE FROM entity_mentions WHERE project_id = ?`);
-        for (const id of uniqueProjectIds) stmt.run(id);
-      } catch {
-        // Table may not exist on older schemas; skip.
-      }
-    });
-    tx();
-  } finally {
-    db.run('PRAGMA foreign_keys = ON');
-  }
-}

--- a/packages/myco/src/grove/paths.ts
+++ b/packages/myco/src/grove/paths.ts
@@ -7,7 +7,7 @@ import {
   MACHINE_RUNTIME_DIRNAME,
   MACHINE_RUNTIME_TMP_DIRNAME,
 } from '../constants/update.js';
-import { assertGroveEraId } from './ids.js';
+import { assertGroveEraId, isGroveEraId } from './ids.js';
 import type { DaemonVariant } from './registry.js';
 
 /**
@@ -230,6 +230,20 @@ export function resolveGroveConfigPath(groveId: string, mycoHome = resolveMycoHo
 
 export function resolveGroveDbPath(groveId: string, mycoHome = resolveMycoHome()): string {
   return path.join(resolveGroveDir(groveId, mycoHome), GROVE_DB_FILENAME);
+}
+
+/**
+ * Inverse of `resolveGroveDbPath`: the Grove id a DB file belongs to,
+ * read off its path (`.../groves/<groveId>/myco.db`). Same derivation
+ * the daemon's cross-Grove ownership gate uses (db/client.ts
+ * `assertOwnsDatabase`). Returns null for non-Grove DBs (in-memory,
+ * test fixtures, arbitrary paths) so callers can treat Grove identity
+ * as unknown rather than wrong.
+ */
+export function groveIdFromDbPath(dbPath: string): string | null {
+  if (path.basename(dbPath) !== GROVE_DB_FILENAME) return null;
+  const candidate = path.basename(path.dirname(dbPath));
+  return isGroveEraId(candidate, 'grove') ? candidate : null;
 }
 
 export function resolveGroveVectorsPath(groveId: string, mycoHome = resolveMycoHome()): string {

--- a/tests/backup/restore-grove-guard.test.ts
+++ b/tests/backup/restore-grove-guard.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { openDatabase, type Database } from '@myco/db/client.js';
+import { createSchema } from '@myco/db/schema.js';
+import { createGroveId } from '@myco/grove/ids.js';
+import { groveIdFromDbPath } from '@myco/grove/paths.js';
+import {
+  BackupGroveMismatchError,
+  createBackup,
+  readSnapshotHeader,
+  restoreBackup,
+} from '@myco/backup/engine.js';
+
+const MACHINE = 'test-machine';
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-restore-guard-'));
+});
+
+afterEach(() => {
+  fs.rmSync(workDir, { recursive: true, force: true });
+});
+
+/** Create a schema-initialized DB at a Grove-shaped path. */
+function createGroveShapedDb(groveId: string, home = 'home'): string {
+  const dbPath = path.join(workDir, home, 'groves', groveId, 'myco.db');
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = openDatabase(dbPath);
+  try {
+    createSchema(db);
+  } finally {
+    db.close();
+  }
+  return dbPath;
+}
+
+function withDb<T>(dbPath: string, fn: (db: Database) => T): T {
+  const db = openDatabase(dbPath);
+  try {
+    return fn(db);
+  } finally {
+    db.close();
+  }
+}
+
+function seedSession(dbPath: string, id: string): void {
+  withDb(dbPath, (db) => {
+    db.prepare(
+      `INSERT INTO sessions (id, agent, started_at, created_at, machine_id)
+       VALUES (?, 'claude-code', 100, 100, ?)`,
+    ).run(id, MACHINE);
+  });
+}
+
+function sessionCount(dbPath: string): number {
+  return withDb(dbPath, (db) =>
+    (db.prepare('SELECT COUNT(*) AS n FROM sessions').get() as { n: number }).n,
+  );
+}
+
+describe('restoreBackup Grove lineage guard', () => {
+  it('records the source grove_id in the dump header', () => {
+    const groveId = createGroveId();
+    const dbPath = createGroveShapedDb(groveId);
+    seedSession(dbPath, 'sess-1');
+
+    const backupPath = withDb(dbPath, (db) =>
+      createBackup(db, path.join(workDir, 'backups'), MACHINE),
+    );
+
+    expect(groveIdFromDbPath(dbPath)).toBe(groveId);
+    expect(readSnapshotHeader(backupPath).grove_id).toBe(groveId);
+  });
+
+  it('refuses to restore another Grove\'s archive and leaves the target untouched', () => {
+    const sourceGroveId = createGroveId();
+    const targetGroveId = createGroveId();
+    const sourceDbPath = createGroveShapedDb(sourceGroveId);
+    const targetDbPath = createGroveShapedDb(targetGroveId);
+    seedSession(sourceDbPath, 'sess-1');
+
+    const backupPath = withDb(sourceDbPath, (db) =>
+      createBackup(db, path.join(workDir, 'backups'), MACHINE),
+    );
+
+    withDb(targetDbPath, (db) => {
+      let caught: unknown;
+      try {
+        restoreBackup(db, backupPath);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(BackupGroveMismatchError);
+      expect((caught as BackupGroveMismatchError).backupGroveId).toBe(sourceGroveId);
+      expect((caught as BackupGroveMismatchError).targetGroveId).toBe(targetGroveId);
+    });
+    expect(sessionCount(targetDbPath)).toBe(0);
+  });
+
+  it('restores a legacy archive without grove_id lineage', () => {
+    const sourceGroveId = createGroveId();
+    const targetGroveId = createGroveId();
+    const sourceDbPath = createGroveShapedDb(sourceGroveId);
+    const targetDbPath = createGroveShapedDb(targetGroveId);
+    seedSession(sourceDbPath, 'sess-legacy');
+
+    const backupPath = withDb(sourceDbPath, (db) =>
+      createBackup(db, path.join(workDir, 'backups'), MACHINE),
+    );
+    // Strip the lineage line, emulating an archive from before grove_id
+    // was recorded.
+    const stripped = fs.readFileSync(backupPath, 'utf-8')
+      .split('\n')
+      .filter((line) => !line.startsWith('-- grove_id:'))
+      .join('\n');
+    fs.writeFileSync(backupPath, stripped, 'utf-8');
+    expect(readSnapshotHeader(backupPath).grove_id).toBeNull();
+
+    const result = withDb(targetDbPath, (db) => restoreBackup(db, backupPath));
+    expect(result.total_restored).toBeGreaterThan(0);
+    expect(sessionCount(targetDbPath)).toBe(1);
+  });
+
+  it('restores a same-Grove archive into another machine\'s copy of that Grove', () => {
+    const groveId = createGroveId();
+    const machineADbPath = createGroveShapedDb(groveId, 'machine-a');
+    const machineBDbPath = createGroveShapedDb(groveId, 'machine-b');
+    seedSession(machineADbPath, 'sess-from-a');
+
+    const backupPath = withDb(machineADbPath, (db) =>
+      createBackup(db, path.join(workDir, 'backups'), MACHINE),
+    );
+
+    const result = withDb(machineBDbPath, (db) => restoreBackup(db, backupPath));
+    expect(result.total_restored).toBeGreaterThan(0);
+    expect(sessionCount(machineBDbPath)).toBe(1);
+  });
+
+  it('keeps restoring archives of non-Grove DBs (no lineage recorded)', () => {
+    const looseDbPath = path.join(workDir, 'loose.db');
+    withDb(looseDbPath, (db) => createSchema(db));
+    seedSession(looseDbPath, 'sess-loose');
+
+    const backupPath = withDb(looseDbPath, (db) =>
+      createBackup(db, path.join(workDir, 'backups'), MACHINE),
+    );
+    expect(readSnapshotHeader(backupPath).grove_id).toBeNull();
+
+    const targetGroveId = createGroveId();
+    const targetDbPath = createGroveShapedDb(targetGroveId);
+    const result = withDb(targetDbPath, (db) => restoreBackup(db, backupPath));
+    expect(result.total_restored).toBeGreaterThan(0);
+  });
+});

--- a/tests/daemon/api/pause-enforcement.test.ts
+++ b/tests/daemon/api/pause-enforcement.test.ts
@@ -62,6 +62,15 @@ describe('pause enforcement at write paths', () => {
     server = new DaemonServer({ vaultDir: bootstrapVault, logger });
     server.registerRoute('POST', '/api/test-write', async () => ({ body: { ok: true } }));
     server.registerRoute('GET', '/api/test-read', async () => ({ body: { ok: true } }));
+    // Stand-ins for the move route and its archive sibling, matching the
+    // real registrations in daemon/main.ts — the pause gate's move-retry
+    // exemption keys on this exact route shape.
+    server.registerRoute('POST', '/api/groves/:id/projects/:projectId', async () => ({
+      body: { ok: true, move: true },
+    }));
+    server.registerRoute('POST', '/api/groves/:id/projects/:projectId/archive', async () => ({
+      body: { ok: true },
+    }));
     await server.start();
   });
 
@@ -140,5 +149,51 @@ describe('pause enforcement at write paths', () => {
       headers: buildHeaders(),
     });
     expect(res.status).toBe(200);
+  });
+
+  it('lets the move POST through a grove-move pause for the SAME project (crash-orphaned move retry)', async () => {
+    pauseProject(groveId, projectId, 'grove-move', `grove-move-${projectId}-123`);
+
+    const res = await fetch(
+      `http://127.0.0.1:${server.port}/api/groves/${groveId}/projects/${projectId}`,
+      { method: 'POST', headers: buildHeaders(), body: JSON.stringify({}) },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean; move: boolean };
+    expect(body.move).toBe(true);
+  });
+
+  it('still 409s the move POST when the URL names a DIFFERENT project than the paused one', async () => {
+    pauseProject(groveId, projectId, 'grove-move', `grove-move-${projectId}-123`);
+
+    // Context headers carry the paused project; the URL names another.
+    const otherProjectId = 'proj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const res = await fetch(
+      `http://127.0.0.1:${server.port}/api/groves/${groveId}/projects/${otherProjectId}`,
+      { method: 'POST', headers: buildHeaders(), body: JSON.stringify({}) },
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json() as { error: { code: string } };
+    expect(body.error.code).toBe('project_paused');
+  });
+
+  it('still 409s the archive sibling route during a grove-move pause', async () => {
+    pauseProject(groveId, projectId, 'grove-move', `grove-move-${projectId}-123`);
+
+    const res = await fetch(
+      `http://127.0.0.1:${server.port}/api/groves/${groveId}/projects/${projectId}/archive`,
+      { method: 'POST', headers: buildHeaders(), body: JSON.stringify({}) },
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it('still 409s the move POST when the pause belongs to a different owner-op class', async () => {
+    pauseProject(groveId, projectId, 'vacuum', 'vacuum-op-1');
+
+    const res = await fetch(
+      `http://127.0.0.1:${server.port}/api/groves/${groveId}/projects/${projectId}`,
+      { method: 'POST', headers: buildHeaders(), body: JSON.stringify({}) },
+    );
+    expect(res.status).toBe(409);
   });
 });

--- a/tests/grove/move-copy.test.ts
+++ b/tests/grove/move-copy.test.ts
@@ -1,0 +1,525 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { openDatabase, type Database } from '@myco/db/client.js';
+import { createSchema } from '@myco/db/schema.js';
+import { GROVE_PROJECT_SCOPED_TABLES, TABLE_DDLS } from '@myco/db/schema-ddl.js';
+import {
+  MOVE_COPY_TABLES,
+  MOVE_FK_REMAPS,
+  MOVE_REKEYED_TABLES,
+  copyProjectBetweenGroveDbs,
+  deleteProjectRowsForMove,
+  findOrphanRemappedRows,
+} from '@myco/grove/move-copy.js';
+import {
+  clearGroveRegistryCaches,
+  createGrove,
+  registerProjectInGrove,
+} from '@myco/grove/registry.js';
+import { createProjectId } from '@myco/grove/ids.js';
+import { resolveGroveDbPath, resolveProjectVaultDir } from '@myco/grove/paths.js';
+import { moveProjectBetweenGroves } from '@myco/grove/move.js';
+
+let tmpDir: string;
+let mycoHome: string;
+let projectRoot: string;
+let snapshotsRoot: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-move-copy-'));
+  mycoHome = path.join(tmpDir, 'home');
+  projectRoot = path.join(tmpDir, 'project');
+  snapshotsRoot = path.join(tmpDir, 'snapshots');
+  fs.mkdirSync(mycoHome, { recursive: true });
+  fs.mkdirSync(projectRoot, { recursive: true });
+  const vaultDir = resolveProjectVaultDir(projectRoot);
+  fs.mkdirSync(vaultDir, { recursive: true });
+  fs.writeFileSync(path.join(vaultDir, 'machine_id'), 'test-user_deadbeef', 'utf-8');
+  clearGroveRegistryCaches();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  clearGroveRegistryCaches();
+});
+
+function withGroveDb<T>(groveId: string, fn: (db: Database) => T): T {
+  const dbPath = resolveGroveDbPath(groveId, mycoHome);
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = openDatabase(dbPath);
+  try {
+    return fn(db);
+  } finally {
+    db.close();
+  }
+}
+
+function ensureGroveDb(groveId: string): void {
+  withGroveDb(groveId, (db) => createSchema(db));
+}
+
+function seedAgent(db: Database): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO agents (id, name, source, enabled, created_at)
+     VALUES ('claude-code', 'Claude Code', 'built-in', 1, 100)`,
+  ).run();
+}
+
+/** Tables seeded by `seedRichProject`, in a stable snapshot order. */
+const RICH_TABLES = [
+  'sessions',
+  'prompt_batches',
+  'knowledge_git_provenance',
+  'knowledge_release_state',
+  'activities',
+  'plans',
+  'attachments',
+  'spores',
+  'entities',
+  'entity_mentions',
+  'digest_extracts',
+  'agent_runs',
+  'agent_reports',
+  'agent_turns',
+  'agent_run_write_intents',
+  'digest_extract_revisions',
+  'log_entries',
+];
+
+/**
+ * Seed a project across every rekeyed table plus the FK-carrying text
+ * tables, using EXPLICIT integer ids from `base` so two projects seeded
+ * with the same base collide on every AUTOINCREMENT primary key.
+ *
+ * Layout: prompt batch `base` is the parent of batch `base+1`;
+ * plans/spores/kgp/krs reference batch `base`; activities/attachments
+ * reference batch `base+1`; digest_extract_revision `base` is the
+ * parent of revision `base+1`.
+ */
+function seedRichProject(db: Database, projectId: string, sfx: string, base: number): void {
+  seedAgent(db);
+  db.prepare(
+    `INSERT INTO sessions (id, agent, project_root, project_id, started_at, created_at, machine_id)
+     VALUES (?, 'claude-code', ?, ?, 100, 100, 'test-machine')`,
+  ).run(`sess-${sfx}`, projectRoot, projectId);
+  db.prepare(
+    `INSERT INTO prompt_batches (id, project_id, session_id, user_prompt, created_at)
+     VALUES (?, ?, ?, ?, 110)`,
+  ).run(base, projectId, `sess-${sfx}`, `parent-batch-${sfx}`);
+  db.prepare(
+    `INSERT INTO prompt_batches (id, project_id, session_id, parent_prompt_batch_id, user_prompt, created_at)
+     VALUES (?, ?, ?, ?, ?, 111)`,
+  ).run(base + 1, projectId, `sess-${sfx}`, base, `child-batch-${sfx}`);
+  db.prepare(
+    `INSERT INTO knowledge_git_provenance (id, project_id, identity_key, session_id, prompt_batch_id, capture_point, captured_at, status_hash, created_at)
+     VALUES (?, ?, ?, ?, ?, 'prompt', 120, 'hash', 120)`,
+  ).run(base, projectId, `kgp-${sfx}`, `sess-${sfx}`, base);
+  db.prepare(
+    `INSERT INTO knowledge_release_state (id, project_id, identity_key, namespace, record_id, source_prompt_batch_id, state, confidence, checked_at, created_at)
+     VALUES (?, ?, ?, 'spores', ?, ?, 'released', 'high', 130, 130)`,
+  ).run(base, projectId, `krs-${sfx}`, `rec-${sfx}`, base);
+  db.prepare(
+    `INSERT INTO activities (id, project_id, session_id, prompt_batch_id, tool_name, timestamp, created_at)
+     VALUES (?, ?, ?, ?, ?, 140, 140)`,
+  ).run(base, projectId, `sess-${sfx}`, base + 1, `tool-${sfx}`);
+  db.prepare(
+    `INSERT INTO plans (id, project_id, logical_key, title, prompt_batch_id, created_at)
+     VALUES (?, ?, ?, ?, ?, 150)`,
+  ).run(`plan-${sfx}`, projectId, `plan:${sfx}`, `Plan ${sfx}`, base);
+  db.prepare(
+    `INSERT INTO attachments (id, project_id, session_id, prompt_batch_id, file_path, data, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, 160)`,
+  ).run(`att-${sfx}`, projectId, `sess-${sfx}`, base + 1, `/tmp/${sfx}.png`, Buffer.from([1, 2, 3, base]));
+  db.prepare(
+    `INSERT INTO spores (id, project_id, agent_id, session_id, prompt_batch_id, observation_type, content, created_at)
+     VALUES (?, ?, 'claude-code', ?, ?, 'gotcha', ?, 170)`,
+  ).run(`spore-${sfx}`, projectId, `sess-${sfx}`, base, `spore content ${sfx}`);
+  db.prepare(
+    `INSERT INTO entities (id, project_id, agent_id, type, name, first_seen, last_seen)
+     VALUES (?, ?, 'claude-code', 'thing', ?, 180, 180)`,
+  ).run(`ent-${sfx}`, projectId, `name-${sfx}`);
+  db.prepare(
+    `INSERT INTO entity_mentions (project_id, entity_id, note_id, note_type, agent_id)
+     VALUES (?, ?, ?, 'session', 'claude-code')`,
+  ).run(projectId, `ent-${sfx}`, `note-${sfx}`);
+  db.prepare(
+    `INSERT INTO digest_extracts (id, project_id, agent_id, tier, content, generated_at)
+     VALUES (?, ?, 'claude-code', 1, ?, 190)`,
+  ).run(base, projectId, `digest ${sfx}`);
+  db.prepare(
+    `INSERT INTO agent_runs (id, project_id, agent_id, task, status)
+     VALUES (?, ?, 'claude-code', 'digest', 'completed')`,
+  ).run(`run-${sfx}`, projectId);
+  db.prepare(
+    `INSERT INTO agent_reports (id, project_id, run_id, agent_id, action, summary, created_at)
+     VALUES (?, ?, ?, 'claude-code', 'observe', ?, 200)`,
+  ).run(base, projectId, `run-${sfx}`, `summary ${sfx}`);
+  db.prepare(
+    `INSERT INTO agent_turns (id, project_id, run_id, agent_id, turn_number, tool_name)
+     VALUES (?, ?, ?, 'claude-code', 1, ?)`,
+  ).run(base, projectId, `run-${sfx}`, `turn-tool-${sfx}`);
+  db.prepare(
+    `INSERT INTO agent_run_write_intents (id, project_id, run_id, tool_name, tool_input, synthetic_output, recorded_at)
+     VALUES (?, ?, ?, ?, '{}', '{}', 210)`,
+  ).run(base, projectId, `run-${sfx}`, `intent-tool-${sfx}`);
+  db.prepare(
+    `INSERT INTO digest_extract_revisions (id, project_id, agent_id, tier, content, run_id, created_at)
+     VALUES (?, ?, 'claude-code', 1, ?, ?, 220)`,
+  ).run(base, projectId, `parent-rev-${sfx}`, `run-${sfx}`);
+  db.prepare(
+    `INSERT INTO digest_extract_revisions (id, project_id, agent_id, tier, content, run_id, parent_revision_id, created_at)
+     VALUES (?, ?, 'claude-code', 1, ?, ?, ?, 221)`,
+  ).run(base + 1, projectId, `child-rev-${sfx}`, `run-${sfx}`, base);
+  db.prepare(
+    `INSERT INTO log_entries (id, project_id, timestamp, level, component, kind, message, session_id)
+     VALUES (?, ?, '2026-06-10T00:00:00Z', 'info', 'test', 'event', ?, ?)`,
+  ).run(base, projectId, `log message ${sfx}`, `sess-${sfx}`);
+}
+
+function snapshotProjectRows(db: Database, projectId: string): Record<string, unknown[]> {
+  const snapshot: Record<string, unknown[]> = {};
+  for (const table of RICH_TABLES) {
+    snapshot[table] = db.prepare(
+      `SELECT * FROM ${table} WHERE project_id = ? ORDER BY rowid`,
+    ).all(projectId);
+  }
+  return snapshot;
+}
+
+describe('move-copy DDL drift guards', () => {
+  const createTableName = /CREATE TABLE IF NOT EXISTS (\w+)/;
+  const intFkPattern = /(\w+)\s+INTEGER(?:\s+NOT\s+NULL)?\s+REFERENCES\s+(\w+)\s*\(\s*id\s*\)/g;
+
+  it('MOVE_COPY_TABLES is the full project-scoped registry', () => {
+    expect([...MOVE_COPY_TABLES]).toEqual([...GROVE_PROJECT_SCOPED_TABLES]);
+  });
+
+  it('MOVE_REKEYED_TABLES matches the integer-AUTOINCREMENT project-scoped tables in the DDL', () => {
+    const projectScoped = new Set<string>(GROVE_PROJECT_SCOPED_TABLES);
+    const fromDdl: string[] = [];
+    for (const ddl of TABLE_DDLS) {
+      const name = createTableName.exec(ddl)?.[1];
+      if (!name || !projectScoped.has(name)) continue;
+      if (/\bid\s+INTEGER PRIMARY KEY AUTOINCREMENT\b/.test(ddl)) fromDdl.push(name);
+    }
+    expect([...MOVE_REKEYED_TABLES].sort()).toEqual(fromDdl.sort());
+  });
+
+  it('MOVE_FK_REMAPS covers every integer FK into a rekeyed table, exactly', () => {
+    const rekeyed = new Set<string>(MOVE_REKEYED_TABLES);
+    const fromDdl: string[] = [];
+    for (const ddl of TABLE_DDLS) {
+      const name = createTableName.exec(ddl)?.[1];
+      if (!name) continue;
+      for (const match of ddl.matchAll(intFkPattern)) {
+        const [, column, referenced] = match;
+        if (!rekeyed.has(referenced)) continue;
+        fromDdl.push(`${name}.${column}->${referenced}`);
+      }
+    }
+    const declared = MOVE_FK_REMAPS.map((r) => `${r.table}.${r.column}->${r.via}`);
+    expect(declared.sort()).toEqual(fromDdl.sort());
+  });
+});
+
+describe('copyProjectBetweenGroveDbs', () => {
+  it('moves a project into a NON-EMPTY target with colliding integer ids, remapping all FK columns', () => {
+    const source = createGrove('Source', mycoHome);
+    const target = createGrove('Target', mycoHome);
+    ensureGroveDb(source.id);
+    ensureGroveDb(target.id);
+
+    const movedProjectId = createProjectId();
+    const residentProjectId = createProjectId();
+
+    // The target already holds another project's rows whose integer ids
+    // deliberately collide with the moved project's (same base).
+    withGroveDb(target.id, (db) => seedRichProject(db, residentProjectId, 'resident', 1));
+    withGroveDb(source.id, (db) => seedRichProject(db, movedProjectId, 'moved', 1));
+
+    registerProjectInGrove(source.id, {
+      projectId: movedProjectId,
+      projectName: 'Demo',
+      projectRoot,
+    }, mycoHome);
+
+    const residentBefore = withGroveDb(target.id, (db) =>
+      snapshotProjectRows(db, residentProjectId),
+    );
+
+    moveProjectBetweenGroves(source.id, target.id, movedProjectId, mycoHome, { snapshotsRoot });
+
+    withGroveDb(target.id, (db) => {
+      // The resident project's rows are byte-identical to before the move.
+      expect(snapshotProjectRows(db, residentProjectId)).toEqual(residentBefore);
+
+      // Every moved row arrived.
+      for (const table of RICH_TABLES) {
+        const want = table === 'prompt_batches' || table === 'digest_extract_revisions' ? 2 : 1;
+        const got = (db.prepare(
+          `SELECT COUNT(*) AS n FROM ${table} WHERE project_id = ?`,
+        ).get(movedProjectId) as { n: number }).n;
+        expect(`${table}:${got}`).toBe(`${table}:${want}`);
+      }
+
+      // Rekeyed parent/child chain: fresh ids, child points at parent.
+      const parentBatch = db.prepare(
+        `SELECT id, parent_prompt_batch_id FROM prompt_batches WHERE user_prompt = 'parent-batch-moved'`,
+      ).get() as { id: number; parent_prompt_batch_id: number | null };
+      const childBatch = db.prepare(
+        `SELECT id, parent_prompt_batch_id FROM prompt_batches WHERE user_prompt = 'child-batch-moved'`,
+      ).get() as { id: number; parent_prompt_batch_id: number | null };
+      expect(parentBatch.id).not.toBe(1);
+      expect(childBatch.id).not.toBe(2);
+      expect(parentBatch.parent_prompt_batch_id).toBeNull();
+      expect(childBatch.parent_prompt_batch_id).toBe(parentBatch.id);
+
+      // The seven prompt-batch FK columns point at the REMAPPED parents.
+      const kgp = db.prepare(
+        `SELECT prompt_batch_id FROM knowledge_git_provenance WHERE identity_key = 'kgp-moved'`,
+      ).get() as { prompt_batch_id: number };
+      expect(kgp.prompt_batch_id).toBe(parentBatch.id);
+      const krs = db.prepare(
+        `SELECT source_prompt_batch_id FROM knowledge_release_state WHERE identity_key = 'krs-moved'`,
+      ).get() as { source_prompt_batch_id: number };
+      expect(krs.source_prompt_batch_id).toBe(parentBatch.id);
+      const activity = db.prepare(
+        `SELECT prompt_batch_id FROM activities WHERE tool_name = 'tool-moved'`,
+      ).get() as { prompt_batch_id: number };
+      expect(activity.prompt_batch_id).toBe(childBatch.id);
+      const plan = db.prepare(
+        `SELECT prompt_batch_id FROM plans WHERE id = 'plan-moved'`,
+      ).get() as { prompt_batch_id: number };
+      expect(plan.prompt_batch_id).toBe(parentBatch.id);
+      const attachment = db.prepare(
+        `SELECT prompt_batch_id, data FROM attachments WHERE id = 'att-moved'`,
+      ).get() as { prompt_batch_id: number; data: Uint8Array };
+      expect(attachment.prompt_batch_id).toBe(childBatch.id);
+      expect(Buffer.from(attachment.data)).toEqual(Buffer.from([1, 2, 3, 1]));
+      const spore = db.prepare(
+        `SELECT prompt_batch_id FROM spores WHERE id = 'spore-moved'`,
+      ).get() as { prompt_batch_id: number };
+      expect(spore.prompt_batch_id).toBe(parentBatch.id);
+
+      // Self-FK revision chain remapped the same way.
+      const parentRev = db.prepare(
+        `SELECT id FROM digest_extract_revisions WHERE content = 'parent-rev-moved'`,
+      ).get() as { id: number };
+      const childRev = db.prepare(
+        `SELECT id, parent_revision_id FROM digest_extract_revisions WHERE content = 'child-rev-moved'`,
+      ).get() as { id: number; parent_revision_id: number };
+      expect(parentRev.id).not.toBe(1);
+      expect(childRev.parent_revision_id).toBe(parentRev.id);
+
+      // entity_mentions rode along (the dump format excluded it; the copy doesn't).
+      const mentions = db.prepare(
+        `SELECT note_id FROM entity_mentions WHERE project_id = ?`,
+      ).all(movedProjectId) as Array<{ note_id: string }>;
+      expect(mentions).toEqual([{ note_id: 'note-moved' }]);
+
+      expect(db.prepare('PRAGMA foreign_key_check').all()).toEqual([]);
+    });
+
+    // Source cleaned of the moved project's rows.
+    withGroveDb(source.id, (db) => {
+      for (const table of RICH_TABLES) {
+        const got = (db.prepare(
+          `SELECT COUNT(*) AS n FROM ${table} WHERE project_id = ?`,
+        ).get(movedProjectId) as { n: number }).n;
+        expect(`${table}:${got}`).toBe(`${table}:0`);
+      }
+    });
+  });
+
+  it('is re-entrant: running the copy twice leaves a single copy of every row', () => {
+    const source = createGrove('Source', mycoHome);
+    const target = createGrove('Target', mycoHome);
+    ensureGroveDb(source.id);
+    ensureGroveDb(target.id);
+
+    const projectId = createProjectId();
+    withGroveDb(source.id, (db) => seedRichProject(db, projectId, 'twice', 1));
+    withGroveDb(target.id, (db) => seedAgent(db));
+
+    const sourceDb = openDatabase(resolveGroveDbPath(source.id, mycoHome));
+    const targetDb = openDatabase(resolveGroveDbPath(target.id, mycoHome));
+    try {
+      // Crash between copy-transaction commit and marker write replays
+      // the whole copy phase; the wipe at the head of the transaction
+      // must absorb the first pass.
+      copyProjectBetweenGroveDbs(sourceDb, targetDb, projectId);
+      copyProjectBetweenGroveDbs(sourceDb, targetDb, projectId);
+
+      for (const table of RICH_TABLES) {
+        const want = table === 'prompt_batches' || table === 'digest_extract_revisions' ? 2 : 1;
+        const got = (targetDb.prepare(
+          `SELECT COUNT(*) AS n FROM ${table} WHERE project_id = ?`,
+        ).get(projectId) as { n: number }).n;
+        expect(`${table}:${got}`).toBe(`${table}:${want}`);
+      }
+      expect(findOrphanRemappedRows(targetDb, projectId)).toEqual([]);
+    } finally {
+      targetDb.close();
+      sourceDb.close();
+    }
+  });
+
+  it('refuses to copy a row whose FK references a parent outside the moved project', () => {
+    const source = createGrove('Source', mycoHome);
+    const target = createGrove('Target', mycoHome);
+    ensureGroveDb(source.id);
+    ensureGroveDb(target.id);
+
+    const projectId = createProjectId();
+    const otherProjectId = createProjectId();
+    withGroveDb(source.id, (db) => {
+      seedRichProject(db, projectId, 'main', 1);
+      seedRichProject(db, otherProjectId, 'other', 10);
+      // Cross-project FK: a spore of the moved project pointing at the
+      // OTHER project's prompt batch. Copying the literal id would attach
+      // it to an arbitrary target parent.
+      db.prepare(
+        `UPDATE spores SET prompt_batch_id = 10 WHERE id = 'spore-main'`,
+      ).run();
+    });
+
+    const sourceDb = openDatabase(resolveGroveDbPath(source.id, mycoHome));
+    const targetDb = openDatabase(resolveGroveDbPath(target.id, mycoHome));
+    try {
+      let caught: Error | undefined;
+      try {
+        copyProjectBetweenGroveDbs(sourceDb, targetDb, projectId);
+      } catch (err) {
+        caught = err as Error;
+      }
+      expect(caught?.message).toMatch(/spores\.prompt_batch_id references prompt_batches id 10/);
+      // Triage detail: the polluted row, the foreign parent's owner, and
+      // the manual remedy — every retry hits the same row, so the error
+      // must be actionable without re-deriving the lineage.
+      expect(caught?.message).toContain('spores row id spore-main');
+      expect(caught?.message).toContain(`belongs to project ${otherProjectId}`);
+      expect(caught?.message).toContain('Repair or delete');
+      // The transaction rolled back: nothing landed in the target.
+      const n = (targetDb.prepare(
+        `SELECT COUNT(*) AS n FROM sessions WHERE project_id = ?`,
+      ).get(projectId) as { n: number }).n;
+      expect(n).toBe(0);
+    } finally {
+      targetDb.close();
+      sourceDb.close();
+    }
+  });
+
+  it('surfaces non-missing-table read errors instead of silently skipping the table', () => {
+    const source = createGrove('Source', mycoHome);
+    const target = createGrove('Target', mycoHome);
+    ensureGroveDb(source.id);
+    ensureGroveDb(target.id);
+
+    const projectId = createProjectId();
+    withGroveDb(source.id, (db) => {
+      seedRichProject(db, projectId, 'main', 1);
+      // A readable-but-broken table: project_id gone, so the project-
+      // scoped SELECT fails with "no such column" — NOT a missing table.
+      db.run('DROP INDEX idx_log_entries_project_id');
+      db.run('ALTER TABLE log_entries DROP COLUMN project_id');
+    });
+
+    const sourceDb = openDatabase(resolveGroveDbPath(source.id, mycoHome));
+    const targetDb = openDatabase(resolveGroveDbPath(target.id, mycoHome));
+    try {
+      expect(() => copyProjectBetweenGroveDbs(sourceDb, targetDb, projectId))
+        .toThrow(/failed to read log_entries rows/);
+      // The transaction rolled back: a half-copied project never lands.
+      const n = (targetDb.prepare(
+        `SELECT COUNT(*) AS n FROM sessions WHERE project_id = ?`,
+      ).get(projectId) as { n: number }).n;
+      expect(n).toBe(0);
+    } finally {
+      targetDb.close();
+      sourceDb.close();
+    }
+  });
+});
+
+describe('findOrphanRemappedRows', () => {
+  it('reports children whose parent is missing or belongs to another project', () => {
+    const grove = createGrove('Solo', mycoHome);
+    ensureGroveDb(grove.id);
+    const projectId = createProjectId();
+    const otherProjectId = createProjectId();
+
+    withGroveDb(grove.id, (db) => {
+      seedRichProject(db, projectId, 'main', 1);
+      seedRichProject(db, otherProjectId, 'other', 10);
+      expect(findOrphanRemappedRows(db, projectId)).toEqual([]);
+
+      db.run('PRAGMA foreign_keys = OFF');
+      // Parent gone entirely.
+      db.prepare(`UPDATE activities SET prompt_batch_id = 999 WHERE tool_name = 'tool-main'`).run();
+      // Parent exists but under the other project.
+      db.prepare(`UPDATE spores SET prompt_batch_id = 10 WHERE id = 'spore-main'`).run();
+      db.run('PRAGMA foreign_keys = ON');
+
+      const problems = findOrphanRemappedRows(db, projectId);
+      expect(problems).toHaveLength(2);
+      expect(problems.join('; ')).toContain('activities.prompt_batch_id');
+      expect(problems.join('; ')).toContain('spores.prompt_batch_id');
+    });
+  });
+
+  it('throws on non-missing-table errors instead of silently skipping the check', () => {
+    const grove = createGrove('Solo', mycoHome);
+    ensureGroveDb(grove.id);
+    const projectId = createProjectId();
+
+    withGroveDb(grove.id, (db) => {
+      seedRichProject(db, projectId, 'main', 1);
+      // Break one checked table without removing it: the orphan query's
+      // project_id filter now fails with "no such column" — a swallowed
+      // error here would blind the verify phase the check serves.
+      db.run('DROP INDEX idx_knowledge_git_provenance_project_captured');
+      db.run('DROP INDEX idx_knowledge_git_provenance_project_id');
+      db.run('ALTER TABLE knowledge_git_provenance DROP COLUMN project_id');
+
+      expect(() => findOrphanRemappedRows(db, projectId))
+        .toThrow(/orphan check failed reading knowledge_git_provenance\.prompt_batch_id/);
+    });
+  });
+});
+
+describe('deleteProjectRowsForMove', () => {
+  it('deletes only the given project id and surfaces injected delete failures', () => {
+    const grove = createGrove('Solo', mycoHome);
+    ensureGroveDb(grove.id);
+    const projectId = createProjectId();
+    const siblingProjectId = createProjectId();
+
+    withGroveDb(grove.id, (db) => {
+      seedRichProject(db, projectId, 'main', 1);
+      seedRichProject(db, siblingProjectId, 'sibling', 10);
+
+      deleteProjectRowsForMove(db, projectId);
+      expect((db.prepare(
+        `SELECT COUNT(*) AS n FROM sessions WHERE project_id = ?`,
+      ).get(projectId) as { n: number }).n).toBe(0);
+      expect((db.prepare(
+        `SELECT COUNT(*) AS n FROM sessions WHERE project_id = ?`,
+      ).get(siblingProjectId) as { n: number }).n).toBe(1);
+
+      // An injected delete failure must surface AND roll the whole
+      // deletion back — no partial cleanup.
+      db.run(
+        `CREATE TRIGGER block_spore_delete BEFORE DELETE ON spores
+         BEGIN SELECT RAISE(ABORT, 'injected delete failure'); END`,
+      );
+      expect(() => deleteProjectRowsForMove(db, siblingProjectId))
+        .toThrow(/spores: .*injected delete failure/);
+      expect((db.prepare(
+        `SELECT COUNT(*) AS n FROM sessions WHERE project_id = ?`,
+      ).get(siblingProjectId) as { n: number }).n).toBe(1);
+    });
+  });
+});

--- a/tests/grove/move-rollback.test.ts
+++ b/tests/grove/move-rollback.test.ts
@@ -1,0 +1,364 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { openDatabase, type Database } from '@myco/db/client.js';
+import { createSchema } from '@myco/db/schema.js';
+import {
+  clearGroveRegistryCaches,
+  createGrove,
+  isProjectPaused,
+  listRegisteredProjects,
+  pauseProject,
+  registerProjectInGrove,
+} from '@myco/grove/registry.js';
+import { createProjectId } from '@myco/grove/ids.js';
+import { resolveGroveDbPath, resolveProjectVaultDir } from '@myco/grove/paths.js';
+import { moveProjectBetweenGroves } from '@myco/grove/move.js';
+
+let tmpDir: string;
+let mycoHome: string;
+let projectRoot: string;
+let vaultDir: string;
+let snapshotsRoot: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-move-rollback-'));
+  mycoHome = path.join(tmpDir, 'home');
+  projectRoot = path.join(tmpDir, 'project');
+  snapshotsRoot = path.join(tmpDir, 'snapshots');
+  fs.mkdirSync(mycoHome, { recursive: true });
+  fs.mkdirSync(projectRoot, { recursive: true });
+  vaultDir = resolveProjectVaultDir(projectRoot);
+  fs.mkdirSync(vaultDir, { recursive: true });
+  fs.writeFileSync(path.join(vaultDir, 'machine_id'), 'test-user_deadbeef', 'utf-8');
+  clearGroveRegistryCaches();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  clearGroveRegistryCaches();
+});
+
+function withGroveDb<T>(groveId: string, fn: (db: Database) => T): T {
+  const dbPath = resolveGroveDbPath(groveId, mycoHome);
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = openDatabase(dbPath);
+  try {
+    return fn(db);
+  } finally {
+    db.close();
+  }
+}
+
+function ensureGroveDb(groveId: string): void {
+  withGroveDb(groveId, (db) => createSchema(db));
+}
+
+function seedAgent(groveId: string): void {
+  withGroveDb(groveId, (db) => {
+    db.prepare(
+      `INSERT OR IGNORE INTO agents (id, name, source, enabled, created_at)
+       VALUES ('claude-code', 'Claude Code', 'built-in', 1, 100)`,
+    ).run();
+  });
+}
+
+function seedProjectRows(groveId: string, projectId: string): void {
+  withGroveDb(groveId, (db) => {
+    db.prepare(
+      `INSERT INTO sessions (id, agent, project_root, project_id, started_at, created_at, machine_id)
+       VALUES (?, 'claude-code', ?, ?, 200, 200, 'test-machine')`,
+    ).run(`sess-${projectId}-1`, projectRoot, projectId);
+    db.prepare(
+      `INSERT INTO spores (id, project_id, agent_id, session_id, observation_type, content, created_at)
+       VALUES (?, ?, 'claude-code', ?, 'gotcha', 'spore body', 220)`,
+    ).run(`spore-${projectId}-1`, projectId, `sess-${projectId}-1`);
+  });
+}
+
+function countRows(groveId: string, table: string, projectId: string): number {
+  return withGroveDb(groveId, (db) => {
+    const row = db.prepare(
+      `SELECT COUNT(*) AS n FROM ${table} WHERE project_id = ?`,
+    ).get(projectId) as { n: number };
+    return row.n;
+  });
+}
+
+function readMarkers(): Array<Record<string, unknown>> {
+  const migrationDir = path.join(vaultDir, 'migration');
+  if (!fs.existsSync(migrationDir)) return [];
+  return fs.readdirSync(migrationDir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => JSON.parse(fs.readFileSync(path.join(migrationDir, f), 'utf-8')));
+}
+
+describe('move failure rollback and pause release', () => {
+  it('verify failure: wipes the target, marks the move failed, releases the pause, and a retry starts fresh', () => {
+    const source = createGrove('Source', mycoHome);
+    const target = createGrove('Target', mycoHome);
+    ensureGroveDb(source.id);
+    ensureGroveDb(target.id);
+    seedAgent(source.id);
+    seedAgent(target.id);
+
+    const projectId = createProjectId();
+    registerProjectInGrove(source.id, {
+      projectId,
+      projectName: 'Demo',
+      projectRoot,
+    }, mycoHome);
+    seedProjectRows(source.id, projectId);
+
+    // Inject a count mismatch: a marker claiming the restore already ran
+    // while the target holds nothing. Verify must fail and roll back.
+    const moveOpId = `grove-move-${projectId}-injected`;
+    const migrationDir = path.join(vaultDir, 'migration');
+    fs.mkdirSync(migrationDir, { recursive: true });
+    const snapshotPath = path.join(migrationDir, 'fake-snapshot.sql');
+    fs.writeFileSync(snapshotPath, '-- Myco backup: machine_id=test, created_at=1\n', 'utf-8');
+    pauseProject(source.id, projectId, 'grove-move', moveOpId, mycoHome);
+    fs.writeFileSync(
+      path.join(migrationDir, `${moveOpId}.json`),
+      JSON.stringify({
+        move_op_id: moveOpId,
+        from_grove_id: source.id,
+        to_grove_id: target.id,
+        project_id: projectId,
+        project_name: 'Demo',
+        project_root: projectRoot,
+        started_at: new Date().toISOString(),
+        phase: 'restored',
+        snapshot_path: snapshotPath,
+      }),
+    );
+
+    expect(() =>
+      moveProjectBetweenGroves(source.id, target.id, projectId, mycoHome, { snapshotsRoot }),
+    ).toThrow(/move verification failed/);
+
+    // Target holds nothing for the project; marker recorded the failure.
+    expect(countRows(target.id, 'sessions', projectId)).toBe(0);
+    const failedMarker = readMarkers().find((m) => m.move_op_id === moveOpId);
+    expect(failedMarker?.phase).toBe('failed');
+    expect(String(failedMarker?.error)).toContain('move verification failed');
+
+    // The pause was released — source writes are no longer refused.
+    expect(isProjectPaused(projectId, mycoHome).paused).toBe(false);
+
+    // Source data untouched by the failed attempt.
+    expect(countRows(source.id, 'sessions', projectId)).toBe(1);
+    expect(countRows(source.id, 'spores', projectId)).toBe(1);
+
+    // A retry does NOT resume the failed op: it starts a fresh move op
+    // and completes.
+    const result = moveProjectBetweenGroves(source.id, target.id, projectId, mycoHome, {
+      snapshotsRoot,
+    });
+    expect(result.table_counts.sessions).toBe(1);
+    expect(countRows(target.id, 'sessions', projectId)).toBe(1);
+    expect(countRows(source.id, 'sessions', projectId)).toBe(0);
+
+    const markers = readMarkers();
+    const completed = markers.find((m) => m.phase === 'completed');
+    expect(completed).toBeDefined();
+    expect(completed?.move_op_id).not.toBe(moveOpId);
+  });
+
+  it('releases the pause when the move throws before the snapshot completes', () => {
+    const source = createGrove('Source', mycoHome);
+    const target = createGrove('Target', mycoHome);
+    ensureGroveDb(source.id);
+    ensureGroveDb(target.id);
+    seedAgent(source.id);
+    seedAgent(target.id);
+
+    const projectId = createProjectId();
+    registerProjectInGrove(source.id, {
+      projectId,
+      projectName: 'Demo',
+      projectRoot,
+    }, mycoHome);
+    seedProjectRows(source.id, projectId);
+
+    // Snapshot failure injection: the snapshots root is a FILE, so
+    // creating the snapshot directory under it throws.
+    const blockedRoot = path.join(tmpDir, 'blocked-snapshots');
+    fs.writeFileSync(blockedRoot, 'not a directory', 'utf-8');
+
+    expect(() =>
+      moveProjectBetweenGroves(source.id, target.id, projectId, mycoHome, {
+        snapshotsRoot: blockedRoot,
+      }),
+    ).toThrow();
+
+    // The failure left no pause behind and recorded a failed marker.
+    expect(isProjectPaused(projectId, mycoHome).paused).toBe(false);
+    expect(readMarkers().map((m) => m.phase)).toEqual(['failed']);
+
+    // With the obstruction removed, the next call succeeds end-to-end.
+    const result = moveProjectBetweenGroves(source.id, target.id, projectId, mycoHome, {
+      snapshotsRoot,
+    });
+    expect(result.table_counts.sessions).toBe(1);
+    expect(countRows(target.id, 'sessions', projectId)).toBe(1);
+  });
+
+  it('TEXT-FK pollution fails verify: dangling copied references cannot commit', () => {
+    const source = createGrove('Source', mycoHome);
+    const target = createGrove('Target', mycoHome);
+    ensureGroveDb(source.id);
+    ensureGroveDb(target.id);
+    seedAgent(source.id);
+    seedAgent(target.id);
+
+    const projectId = createProjectId();
+    const otherProjectId = createProjectId();
+    registerProjectInGrove(source.id, {
+      projectId,
+      projectName: 'Demo',
+      projectRoot,
+    }, mycoHome);
+    seedProjectRows(source.id, projectId);
+    seedProjectRows(source.id, otherProjectId);
+
+    // Pollute a TEXT foreign key: the moved project's spore points at the
+    // OTHER project's session. Valid in the source (the session exists),
+    // but the copy only carries the moved project's rows — in the target
+    // the reference dangles. Counts match and the integer-FK orphan check
+    // passes; only the verify-phase foreign_key_check can see it.
+    withGroveDb(source.id, (db) => {
+      db.prepare(`UPDATE spores SET session_id = ? WHERE id = ?`)
+        .run(`sess-${otherProjectId}-1`, `spore-${projectId}-1`);
+    });
+
+    expect(() =>
+      moveProjectBetweenGroves(source.id, target.id, projectId, mycoHome, { snapshotsRoot }),
+    ).toThrow(/foreign key violation/);
+
+    // Failure rollback: target wiped, marker failed, pause released,
+    // source untouched.
+    expect(countRows(target.id, 'spores', projectId)).toBe(0);
+    expect(countRows(target.id, 'sessions', projectId)).toBe(0);
+    expect(readMarkers().map((m) => m.phase)).toEqual(['failed']);
+    expect(isProjectPaused(projectId, mycoHome).paused).toBe(false);
+    expect(countRows(source.id, 'spores', projectId)).toBe(1);
+
+    // Repair the polluted row, retry: fresh move op succeeds.
+    withGroveDb(source.id, (db) => {
+      db.prepare(`UPDATE spores SET session_id = ? WHERE id = ?`)
+        .run(`sess-${projectId}-1`, `spore-${projectId}-1`);
+    });
+    moveProjectBetweenGroves(source.id, target.id, projectId, mycoHome, { snapshotsRoot });
+    expect(countRows(target.id, 'spores', projectId)).toBe(1);
+    expect(countRows(source.id, 'spores', projectId)).toBe(0);
+  });
+
+  it('count errors other than a missing table fail the move and release the pause', () => {
+    const source = createGrove('Source', mycoHome);
+    const target = createGrove('Target', mycoHome);
+    ensureGroveDb(source.id);
+    ensureGroveDb(target.id);
+    seedAgent(source.id);
+    seedAgent(target.id);
+
+    const projectId = createProjectId();
+    registerProjectInGrove(source.id, {
+      projectId,
+      projectName: 'Demo',
+      projectRoot,
+    }, mycoHome);
+    seedProjectRows(source.id, projectId);
+
+    // Break log_entries on BOTH sides the same way: project_id gone, so
+    // the per-table count fails with "no such column". The old swallow-
+    // to-zero behavior would verify this as 0 == 0; it must throw.
+    for (const groveId of [source.id, target.id]) {
+      withGroveDb(groveId, (db) => {
+        db.run('DROP INDEX idx_log_entries_project_id');
+        db.run('ALTER TABLE log_entries DROP COLUMN project_id');
+      });
+    }
+
+    // Enter at the verify phase so the failure is countProjectRows', not
+    // the copy's (the copy guards the same error class separately).
+    const moveOpId = `grove-move-${projectId}-count-injected`;
+    const migrationDir = path.join(vaultDir, 'migration');
+    fs.mkdirSync(migrationDir, { recursive: true });
+    const snapshotPath = path.join(migrationDir, 'fake-snapshot.sql');
+    fs.writeFileSync(snapshotPath, '-- Myco backup: machine_id=test, created_at=1\n', 'utf-8');
+    pauseProject(source.id, projectId, 'grove-move', moveOpId, mycoHome);
+    fs.writeFileSync(
+      path.join(migrationDir, `${moveOpId}.json`),
+      JSON.stringify({
+        move_op_id: moveOpId,
+        from_grove_id: source.id,
+        to_grove_id: target.id,
+        project_id: projectId,
+        project_name: 'Demo',
+        project_root: projectRoot,
+        started_at: new Date().toISOString(),
+        phase: 'restored',
+        snapshot_path: snapshotPath,
+      }),
+    );
+
+    expect(() =>
+      moveProjectBetweenGroves(source.id, target.id, projectId, mycoHome, { snapshotsRoot }),
+    ).toThrow(/failed to count log_entries rows/);
+
+    expect(readMarkers().map((m) => m.phase)).toEqual(['failed']);
+    expect(isProjectPaused(projectId, mycoHome).paused).toBe(false);
+    expect(countRows(source.id, 'sessions', projectId)).toBe(1);
+  });
+
+  it('cleanup failure surfaces loudly, deletes nothing, and the move resumes once unblocked', () => {
+    const source = createGrove('Source', mycoHome);
+    const target = createGrove('Target', mycoHome);
+    ensureGroveDb(source.id);
+    ensureGroveDb(target.id);
+    seedAgent(source.id);
+    seedAgent(target.id);
+
+    const projectId = createProjectId();
+    registerProjectInGrove(source.id, {
+      projectId,
+      projectName: 'Demo',
+      projectRoot,
+    }, mycoHome);
+    seedProjectRows(source.id, projectId);
+
+    // Injected source-delete failure: cleanup must throw, not swallow.
+    withGroveDb(source.id, (db) => {
+      db.run(
+        `CREATE TRIGGER block_spore_delete BEFORE DELETE ON spores
+         BEGIN SELECT RAISE(ABORT, 'injected cleanup failure'); END`,
+      );
+    });
+
+    expect(() =>
+      moveProjectBetweenGroves(source.id, target.id, projectId, mycoHome, { snapshotsRoot }),
+    ).toThrow(/injected cleanup failure/);
+
+    // Past the commit phase the target owns the data: the marker stays
+    // resumable (NOT failed), the target keeps its rows, and the
+    // source-delete transaction rolled back whole.
+    expect(readMarkers().map((m) => m.phase)).toEqual(['committed']);
+    expect(countRows(target.id, 'sessions', projectId)).toBe(1);
+    expect(countRows(source.id, 'sessions', projectId)).toBe(1);
+    expect(countRows(source.id, 'spores', projectId)).toBe(1);
+    expect(isProjectPaused(projectId, mycoHome).paused).toBe(false);
+
+    // Unblock and resume: cleanup completes the same move op.
+    withGroveDb(source.id, (db) => db.run('DROP TRIGGER block_spore_delete'));
+    moveProjectBetweenGroves(source.id, target.id, projectId, mycoHome, { snapshotsRoot });
+
+    expect(readMarkers().map((m) => m.phase)).toEqual(['completed']);
+    expect(countRows(source.id, 'sessions', projectId)).toBe(0);
+    expect(countRows(source.id, 'spores', projectId)).toBe(0);
+    expect(countRows(target.id, 'sessions', projectId)).toBe(1);
+    expect(listRegisteredProjects(target.id, mycoHome).map((p) => p.project_id))
+      .toContain(projectId);
+  });
+});

--- a/tests/grove/move.test.ts
+++ b/tests/grove/move.test.ts
@@ -280,7 +280,7 @@ describe('moveProjectBetweenGroves', () => {
     expect(embeddedValue(target.id, 'spores', `spore-${projectId}-1`)).toBe(0);
   });
 
-  it('cleans stale source rows for the same project root after a successful move', () => {
+  it('cleans only the moved project id from the source; sibling legacy ids on the same root stay', () => {
     const source = createGrove('Source', mycoHome);
     const target = createGrove('Target', mycoHome);
     ensureGroveDb(source.id);
@@ -289,7 +289,7 @@ describe('moveProjectBetweenGroves', () => {
     seedAgent(target.id);
 
     const currentProjectId = createProjectId();
-    const staleProjectId = createProjectId();
+    const siblingProjectId = createProjectId();
     const unrelatedProjectId = createProjectId();
     registerProjectInGrove(source.id, {
       projectId: currentProjectId,
@@ -297,7 +297,7 @@ describe('moveProjectBetweenGroves', () => {
       projectRoot,
     }, mycoHome);
     seedProjectRows(source.id, currentProjectId);
-    seedProjectRows(source.id, staleProjectId);
+    seedProjectRows(source.id, siblingProjectId);
     seedProjectRows(source.id, unrelatedProjectId, path.join(tmpDir, 'other-project'));
 
     moveProjectBetweenGroves(source.id, target.id, currentProjectId, mycoHome, { snapshotsRoot });
@@ -305,8 +305,11 @@ describe('moveProjectBetweenGroves', () => {
     expect(countRows(target.id, 'sessions', currentProjectId)).toBe(1);
     expect(countRows(source.id, 'sessions', currentProjectId)).toBe(0);
     expect(countRows(source.id, 'spores', currentProjectId)).toBe(0);
-    expect(countRows(source.id, 'sessions', staleProjectId)).toBe(0);
-    expect(countRows(source.id, 'spores', staleProjectId)).toBe(0);
+    // Rows under a sibling legacy project id sharing project_root were
+    // never copied to the target — deleting them would be data loss, so
+    // cleanup must leave them in place.
+    expect(countRows(source.id, 'sessions', siblingProjectId)).toBe(1);
+    expect(countRows(source.id, 'spores', siblingProjectId)).toBe(1);
     expect(countRows(source.id, 'sessions', unrelatedProjectId)).toBe(1);
     expect(countRows(source.id, 'spores', unrelatedProjectId)).toBe(1);
   });
@@ -607,7 +610,7 @@ describe('moveProjectBetweenGroves', () => {
     expect(finalMarker.snapshot_path).toBe(initial.snapshot_path);
   });
 
-  it('clean phase deletes entity_mentions from source for the moved project only', () => {
+  it('moves entity_mentions to the target and deletes them from source for the moved project only', () => {
     const source = createGrove('Source', mycoHome);
     const target = createGrove('Target', mycoHome);
     ensureGroveDb(source.id);
@@ -626,8 +629,9 @@ describe('moveProjectBetweenGroves', () => {
 
     // Seed entity_mentions for both the moving project and an unrelated
     // project. entity_mentions is project-scoped but excluded from
-    // BACKUP_TABLES (no `id` column), so the orchestrator's clean phase
-    // must DELETE the moving project's rows without touching the rest.
+    // BACKUP_TABLES (no `id` column); the rekey copy carries it anyway,
+    // and the clean phase must DELETE the moving project's rows from the
+    // source without touching the rest.
     withGroveDb(source.id, (db) => {
       // entity_mentions schema: (project_id, entity_id, note_id, note_type,
       // agent_id, machine_id, synced_at) with FKs on entity_id → entities
@@ -675,14 +679,14 @@ describe('moveProjectBetweenGroves', () => {
     expect(sourceAfter.moving).toBe(0);
     expect(sourceAfter.other).toBe(1);
 
-    // Target: entity_mentions intentionally not transported (excluded
-    // from BACKUP_TABLES), so the moving project's rows are not present.
+    // Target: the rekey copy transports entity_mentions (the dump format
+    // never could — no `id` column), so the moving project's rows arrive.
     const targetMoving = withGroveDb(target.id, (db) =>
       (db.prepare(
         `SELECT COUNT(*) AS n FROM entity_mentions WHERE project_id = ?`,
       ).get(movingProjectId) as { n: number }).n,
     );
-    expect(targetMoving).toBe(0);
+    expect(targetMoving).toBe(2);
   });
 
   it('moves a multi-line spore body through snapshot+restore without truncation', () => {
@@ -753,7 +757,7 @@ describe('moveProjectBetweenGroves', () => {
     expect(restored.crlf.content).toBe(crlfBody);
   });
 
-  it('verify phase counts source and target from live DBs (catches truncated snapshots)', () => {
+  it('restore phase copies from the live source DB; a truncated snapshot cannot corrupt the move', () => {
     const source = createGrove('Source', mycoHome);
     const target = createGrove('Target', mycoHome);
     ensureGroveDb(source.id);
@@ -790,7 +794,9 @@ describe('moveProjectBetweenGroves', () => {
     });
 
     // Take a snapshot ourselves and corrupt it (drop one spore INSERT)
-    // before letting moveProjectBetweenGroves resume from it.
+    // before letting moveProjectBetweenGroves resume past it. The
+    // snapshot is a recovery artifact only — the transfer reads the
+    // live source DB, so the tampering must not affect the move.
     const moveOpId = `grove-move-${projectId}-fault-${Date.now()}`;
     const projectSlug = projectUrlSlug('Demo', projectId);
     const snapshotDir = path.join(snapshotsRoot, projectSlug, moveOpId);
@@ -805,8 +811,7 @@ describe('moveProjectBetweenGroves', () => {
       ),
     );
     // Remove every INSERT line for the second spore — simulates a
-    // truncated/broken dump where the source/target row counts must
-    // diverge.
+    // truncated/broken dump.
     const dump = fs.readFileSync(snapshotPath, 'utf-8');
     const tampered = dump
       .split('\n')
@@ -834,12 +839,15 @@ describe('moveProjectBetweenGroves', () => {
       }),
     );
 
-    expect(() =>
-      moveProjectBetweenGroves(source.id, target.id, projectId, mycoHome, { snapshotsRoot }),
-    ).toThrow(/move verification failed/);
+    const result = moveProjectBetweenGroves(source.id, target.id, projectId, mycoHome, {
+      snapshotsRoot,
+    });
 
-    // Source data was never modified (verify aborted before commit).
-    expect(countRows(source.id, 'spores', projectId)).toBe(2);
+    // Both spores arrived — the copy read the live source rows, not the
+    // tampered dump.
+    expect(result.table_counts.spores).toBe(2);
+    expect(countRows(target.id, 'spores', projectId)).toBe(2);
+    expect(countRows(source.id, 'spores', projectId)).toBe(0);
   });
 
   it('pauses the source project after entry, before snapshot completes', () => {


### PR DESCRIPTION
## Problem (bug-hunt RC-2, Wave 4 — reproduced in the hunt)

Grove move copied project rows between grove DBs via an id-preserving backup restore (`INSERT OR IGNORE`). Into a **non-empty target**: colliding AUTOINCREMENT ids silently dropped, children with non-colliding ids attached to the *wrong project's* parents (cross-project pollution invisible to count-verify), the move left permanently stuck with no rollback — and, companion bug, the per-project pause taken at move start was **never released on failure**, refusing the source project's writes forever.

## Fix (independently plan-reviewed; adversarially probed; both rounds found real defects that are fixed here)

- **`move-copy.ts`**: single-transaction rekey copy — TEXT PKs preserved, ten integer-PK tables reallocated through an in-memory map, eight FK columns remapped with topologically-ordered self-FK chains (sorter extracted from the importer, which the review proved was NOT directly reusable: unfiltered source reads, TEXT-id reminting, four missing tables). Wipe-before-copy gives crash re-entrancy. `entity_mentions` now rides the move (previously deleted from source without ever being snapshotted). Out-of-scope FK values fail loud **with the polluted row id, the foreign parent's owning project, and the remedy** — victims of the original bug get an actionable exit.
- **Verify**: count-compare + integer-orphan check + full `PRAGMA foreign_key_check` — the probe round proved TEXT-FK pollution previously copied silently and passed verify. Copy/count/orphan readers rethrow everything except `no such table`, closing the 0==0 blind spot where a failed table copy could survive verify and cleanup would delete the only copy.
- **Failure handling**: pre-commit → wipe target + terminal `failed` marker (retry starts fresh) + pause released on *every* path; post-commit → resumable `committed` marker kept (target is authoritative; wiping it would be data loss), pause still released. The write gate owner-op-matches the move POST through its own crash-orphaned pause (probe finding: UI retry was 409-blocked for up to an hour).
- **Cleanup**: deletes only the moved project_id (the old root-sweep deleted sibling legacy ids' rows that were never snapshotted — active data loss); per-table delete errors surface loudly.
- **Lineage guard** (defense-in-depth): backups record `grove_id`; cross-grove id-preserving restore refused (typed), legacy archives warn, documented same-grove cross-machine merge unaffected.

## Testing

26 new/updated tests: non-empty-target collision matrix across all ten integer-PK tables (pre-existing target project byte-identical), self-FK chains, re-entrancy, verify-failure rollback + pause release + fresh retry, TEXT-FK pollution caught at verify, error-swallowing blind spot, cleanup scoping + loud failures + RAISE-trigger case, pause-gate owner-op matching (+3 negative cases), restore guard (5 cases), DDL drift guards that re-derive the rekey/FK sets from `TABLE_DDLS`. RC-2 suites 256 pass / 0 fail isolated; full local runs carry only the documented disjoint load flakes — clean-runner CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)