### PR TITLE
ui: scoped query keys visible to invalidation; one clear path for every config tier (RC-10/RC-11)

### DIFF
--- a/packages/myco/src/daemon/api/config.ts
+++ b/packages/myco/src/daemon/api/config.ts
@@ -288,6 +288,8 @@ export async function handleGetGroveConfig(
 
 interface TierPutBody {
   patch?: Record<string, unknown>;
+  /** Dot-paths removed from the tier file (same contract as the scoped PUT). */
+  clear?: string[];
   /** Add values to the named array path (deduped, server-side read-modify-write). */
   addToList?: ListDeltaEntry[];
   /** Remove values from the named array path (server-side read-modify-write). */
@@ -381,9 +383,10 @@ interface TierPutOptions<TConfig> {
  *
  * Request body may contain any combination of:
  *   patch          — deep-merged into the current config
+ *   clear          — dot-paths removed from the raw tier file
  *   addToList      — [{ path, values }] set-union additions (deduped)
  *   removeFromList — [{ path, values }] set-difference removals
- * At least one of the three must be non-empty.
+ * At least one of the four must be non-empty.
  */
 async function handlePutTierConfig<TConfig>(
   body: unknown,
@@ -399,6 +402,8 @@ async function handlePutTierConfig<TConfig>(
     };
   }
 
+  const clearListOrError = validateClearList(payload.clear);
+  if (!Array.isArray(clearListOrError)) return { response: clearListOrError, touchedPaths: [] };
   const addOpsRaw = validateListDeltaOps(payload.addToList);
   if (!Array.isArray(addOpsRaw)) return { response: addOpsRaw, touchedPaths: [] };
   const removeOpsRaw = validateListDeltaOps(payload.removeFromList);
@@ -407,8 +412,11 @@ async function handlePutTierConfig<TConfig>(
   const patch = options.sanitizePatch
     ? options.sanitizePatch(incoming as Record<string, unknown>)
     : (incoming as Record<string, unknown>);
-  // Drop list-delta ops targeting protected paths, mirroring how
+  // Drop list-delta ops and clears targeting protected paths, mirroring how
   // `sanitizePatch` strips the same field from `patch`.
+  const clearList = options.isProtectedPath
+    ? clearListOrError.filter((p) => !options.isProtectedPath!(p))
+    : clearListOrError;
   const addOps = options.isProtectedPath
     ? addOpsRaw.filter((op) => !options.isProtectedPath!(op.path))
     : addOpsRaw;
@@ -416,11 +424,20 @@ async function handlePutTierConfig<TConfig>(
     ? removeOpsRaw.filter((op) => !options.isProtectedPath!(op.path))
     : removeOpsRaw;
   const patchLeaves = enumerateLeafPaths(patch);
+  const hasClear = clearList.length > 0;
   const hasListOps = addOps.length > 0 || removeOps.length > 0;
 
-  if (patchLeaves.length === 0 && !hasListOps) {
+  if (patchLeaves.length === 0 && !hasClear && !hasListOps) {
     return {
-      response: { status: 400, body: { error: 'patch, addToList, or removeFromList required' } },
+      response: { status: 400, body: { error: 'patch, clear, addToList, or removeFromList required' } },
+      touchedPaths: [],
+    };
+  }
+
+  const overlap = patchLeaves.filter((leaf) => clearList.some((clearPath) => pathsOverlap(leaf, clearPath)));
+  if (overlap.length > 0) {
+    return {
+      response: { status: 400, body: { error: 'patch_clear_overlap', keys: overlap } },
       touchedPaths: [],
     };
   }
@@ -447,6 +464,9 @@ async function handlePutTierConfig<TConfig>(
     const listTouched = applyListDeltas(working, addOps, removeOps);
 
     const validated = updateTierConfigRaw(options.target, (rawDoc) => {
+      // Clears apply first (same order as the scoped handler) so a clear of
+      // a stale subtree can't erase the values the patch introduces.
+      for (const key of clearList) unsetAtPath(rawDoc, key);
       const next = deepMergeConfig(rawDoc, patch);
       for (const opPath of listTouched) {
         setAtPath(next, opPath, getAtPath(working, opPath));
@@ -454,7 +474,10 @@ async function handlePutTierConfig<TConfig>(
       return next;
     }) as TConfig;
 
-    return { response: { body: validated }, touchedPaths: [...patchLeaves, ...listTouched] };
+    return {
+      response: { body: validated },
+      touchedPaths: [...patchLeaves, ...clearList, ...listTouched],
+    };
   } catch (err) {
     if (err instanceof TierConfigUnreadableError) {
       return {
@@ -481,7 +504,8 @@ async function handlePutTierConfig<TConfig>(
 
 /**
  * PUT /api/grove-config — patch the current Grove's config.
- * Request body: `{ patch: Partial<GroveConfig> }`. 404 when no Grove is bound.
+ * Request body: `{ patch?: Partial<GroveConfig>, clear?: string[] }`.
+ * 404 when no Grove is bound.
  */
 export async function handlePutGroveConfig(
   groveId: string | null | undefined,

--- a/packages/myco/ui/src/components/config/NumberField.tsx
+++ b/packages/myco/ui/src/components/config/NumberField.tsx
@@ -45,6 +45,12 @@ export function NumberField({
   }, [value]);
 
   function commit() {
+    // An emptied input is not a zero: Number('') === 0, which would commit
+    // a value the user never typed. Treat it like NaN and snap back.
+    if (draft.trim() === '') {
+      setDraft(String(value));
+      return;
+    }
     const parsed = Number(draft);
     if (Number.isNaN(parsed)) {
       setDraft(String(value));

--- a/packages/myco/ui/src/components/config/PlanCaptureCard.tsx
+++ b/packages/myco/ui/src/components/config/PlanCaptureCard.tsx
@@ -27,15 +27,17 @@ export function PlanCaptureCard() {
   const [symbiont, setSymbiont] = useState<Record<string, string[]>>({});
   const [newDir, setNewDir] = useState('');
   const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const addToList = useAddToMachineConfigList();
   const removeFromList = useRemoveFromMachineConfigList();
 
   // Symbiont-managed plan dirs come from a separate read-only endpoint
-  // (manifest-derived, not from myco.yaml).
+  // (manifest-derived, not from myco.yaml). A failed fetch must read as an
+  // error, not as "no agent directories configured".
   useEffect(() => {
     fetchJson<PlanDirsAgentResponse>('/config/plan-dirs')
       .then((data) => setSymbiont(data.symbiont))
-      .catch(() => {})
+      .catch((err) => setLoadError(err instanceof Error ? err.message : String(err)))
       .finally(() => setIsLoading(false));
   }, []);
 
@@ -59,7 +61,11 @@ export function PlanCaptureCard() {
             <p className="font-sans text-xs text-on-surface-variant">
               Directories monitored by connected agents. Managed by symbiont manifests.
             </p>
-            {symbiontEntries.length === 0 ? (
+            {loadError ? (
+              <p role="alert" className="font-sans text-xs text-tertiary">
+                Failed to load agent directories: {loadError}
+              </p>
+            ) : symbiontEntries.length === 0 ? (
               <p className="font-sans text-xs text-on-surface-variant italic">No agent directories configured.</p>
             ) : (
               <div className="space-y-3">

--- a/packages/myco/ui/src/components/search/GlobalSearch.tsx
+++ b/packages/myco/ui/src/components/search/GlobalSearch.tsx
@@ -15,6 +15,7 @@ import { SearchResults } from './SearchResults';
 import {
   useSearch,
   useCanopySearch,
+  meetsSearchMinLength,
   type AnySearchResult,
   type CanopySearchResult,
   type SearchResult,
@@ -218,8 +219,8 @@ export function GlobalSearch({ open, onOpenChange }: GlobalSearchProps) {
     [results, highlightedIndex, handleSelect],
   );
 
-  const showEmpty = debouncedQuery.length > 2 && !isLoading && results.length === 0;
-  const showPrompt = debouncedQuery.length <= 2 && !isLoading;
+  const showEmpty = meetsSearchMinLength(debouncedQuery) && !isLoading && results.length === 0;
+  const showPrompt = !meetsSearchMinLength(debouncedQuery) && !isLoading;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -312,7 +313,7 @@ export function GlobalSearch({ open, onOpenChange }: GlobalSearchProps) {
 
         {/* Results area */}
         <div className="max-h-96 overflow-y-auto">
-          {isLoading && debouncedQuery.length > 2 && (
+          {isLoading && meetsSearchMinLength(debouncedQuery) && (
             <div className="px-4 py-8 text-center">
               <div className="flex flex-col items-center gap-2 text-on-surface-variant">
                 <div className="h-4 w-32 rounded bg-muted animate-pulse" />

--- a/packages/myco/ui/src/components/settings/AgentProviderCard.tsx
+++ b/packages/myco/ui/src/components/settings/AgentProviderCard.tsx
@@ -101,6 +101,9 @@ export function AgentProviderCard() {
   // unset value is the built-in `default` tier, so it displays as 'default'.
   const savedReasoningLevel = effective?.agent?.reasoningLevel;
   const [reasoningLevel, setReasoningLevel] = useState<ReasoningLevelUi>(savedReasoningLevel ?? 'default');
+  // Save/clear failures surface inline; a swallowed write looks identical
+  // to a successful no-op from the user's side.
+  const [saveError, setSaveError] = useState<string | null>(null);
   useEffect(() => {
     setReasoningLevel(savedReasoningLevel ?? 'default');
   }, [savedReasoningLevel]);
@@ -142,7 +145,11 @@ export function AgentProviderCard() {
         { path: 'agent.event_tasks_enabled', value: true },
       );
     }
-    void setFields(fields, personal ? 'local' : 'grove');
+    setSaveError(null);
+    void setFields(fields, personal ? 'local' : 'grove').catch((err) => {
+      setSaveError(err instanceof Error ? err.message : String(err));
+      console.error('[agent-card] save provider failed', err);
+    });
   }, [personal, reasoningLevel, reasoningModels, setFields]);
 
   const handleClear = useCallback(() => {
@@ -159,6 +166,7 @@ export function AgentProviderCard() {
   const handleSaveProvider = useCallback(async () => {
     const isClearingProvider = draft.type === '';
     if (isClearingProvider) {
+      setSaveError(null);
       try {
         await setFields(
           [
@@ -169,6 +177,7 @@ export function AgentProviderCard() {
           ['agent.provider', 'agent.harness', 'agent.reasoningLevel'],
         );
       } catch (err) {
+        setSaveError(err instanceof Error ? err.message : String(err));
         console.error('[agent-card] clear provider failed', err);
       }
       return;
@@ -403,6 +412,13 @@ export function AgentProviderCard() {
               </>
             ) : null}
           </div>
+
+          {saveError && (
+            <p role="alert" className="flex items-center gap-1 font-sans text-sm text-tertiary">
+              <XCircle className="h-4 w-4" />
+              {saveError}
+            </p>
+          )}
 
           {draft.type !== '' || savedDraft.type !== '' ? (
             <Button

--- a/packages/myco/ui/src/hooks/use-agent.ts
+++ b/packages/myco/ui/src/hooks/use-agent.ts
@@ -557,11 +557,20 @@ export function useTriggerRun() {
 
 export function useResumeRun() {
   const queryClient = useQueryClient();
+  const selection = useProjectSelection();
 
   return useMutation<ResumeRunResponse, Error, { runId: string; mode?: 'manual' | 'scheduled' }>({
     mutationFn: ({ runId, mode }) =>
       postJson<ResumeRunResponse>(`/agent/runs/${runId}/resume`, mode ? { mode } : {}),
     onSuccess: (_data, variables) => {
+      // Optimistically flip the cached detail to 'running': `useAgentRun`
+      // stops polling at a terminal status, so the resumed run must become
+      // non-terminal in the cache for detail polling to restart immediately
+      // rather than waiting on the invalidation refetch to observe it.
+      const detailKey = projectScopedQueryKey(selection, ['agent-run', variables.runId]);
+      queryClient.setQueryData<RunDetailResponse>(detailKey, (prev) =>
+        prev ? { ...prev, run: { ...prev.run, status: 'running' } } : prev,
+      );
       void queryClient.invalidateQueries({ queryKey: ['agent-runs'] });
       void queryClient.invalidateQueries({ queryKey: ['agent-run', variables.runId] });
     },

--- a/packages/myco/ui/src/hooks/use-grove-config.ts
+++ b/packages/myco/ui/src/hooks/use-grove-config.ts
@@ -30,6 +30,12 @@ export function useGroveConfig() {
   });
 }
 
+export interface GroveConfigWrite {
+  patch?: Partial<GroveConfig>;
+  /** Dot-paths removed from the Grove file (server clears before patching). */
+  clear?: string[];
+}
+
 export function useUpdateGroveConfig() {
   const qc = useQueryClient();
   const selection = useActiveProjectSelection();
@@ -37,8 +43,8 @@ export function useUpdateGroveConfig() {
   const headers = requestContextHeadersForSelection(selection);
 
   return useMutation({
-    mutationFn: (patch: Partial<GroveConfig>) =>
-      putJson<GroveConfig>('/grove-config', { patch }, { headers }),
+    mutationFn: ({ patch, clear }: GroveConfigWrite) =>
+      putJson<GroveConfig>('/grove-config', { patch, clear }, { headers }),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: groveConfigQueryKey(groveId) });
       // The merged-config view depends on Grove tier values, so bust it.

--- a/packages/myco/ui/src/hooks/use-machine-config.ts
+++ b/packages/myco/ui/src/hooks/use-machine-config.ts
@@ -18,6 +18,12 @@ export type MachineConfigPatch = {
   machine_id?: string;
 };
 
+export interface MachineConfigWrite {
+  patch?: MachineConfigPatch;
+  /** Dot-paths removed from the machine file (server clears before patching). */
+  clear?: string[];
+}
+
 const MACHINE_CONFIG_QUERY_KEY = ['machine-config'] as const;
 
 /** GET /api/machine-config — returns the current machine config (always present). */
@@ -43,8 +49,8 @@ export function useMachineConfig() {
  */
 export function useUpdateMachineConfig() {
   const queryClient = useQueryClient();
-  return useMutation<MachineConfig, Error, MachineConfigPatch>({
-    mutationFn: (patch) => putJson<MachineConfig>('/machine-config', { patch }),
+  return useMutation<MachineConfig, Error, MachineConfigWrite>({
+    mutationFn: ({ patch, clear }) => putJson<MachineConfig>('/machine-config', { patch, clear }),
     onSuccess: (config) => {
       queryClient.setQueryData<MachineConfigResponse>(
         [...MACHINE_CONFIG_QUERY_KEY],

--- a/packages/myco/ui/src/hooks/use-project-selection.tsx
+++ b/packages/myco/ui/src/hooks/use-project-selection.tsx
@@ -92,13 +92,20 @@ export function useProjectPathBuilder(): (suffix?: string) => string {
   ), [selection]);
 }
 
+/**
+ * Append the project-selection marker to a query key so per-project caches
+ * stay distinct. The marker goes at the END of the key: TanStack's partial
+ * key matching is positional, so `invalidateQueries({ queryKey: ['ns', id] })`
+ * only matches keys whose leading elements are `'ns', id`. Marker-last keeps
+ * every namespace-shaped invalidation working; marker-at-index-1 silently
+ * no-ops them.
+ */
 export function projectScopedQueryKey(
   selection: ProjectSelection | null,
   queryKey: QueryKey,
 ): QueryKey {
   if (!selection) return queryKey;
-  const [namespace, ...rest] = queryKey;
-  return [namespace, { projectSelection: selectionKey(selection) }, ...rest];
+  return [...queryKey, { projectSelection: selectionKey(selection) }];
 }
 
 export function useProjectScopedQueryKey(queryKey: QueryKey): QueryKey {

--- a/packages/myco/ui/src/hooks/use-scoped-config.ts
+++ b/packages/myco/ui/src/hooks/use-scoped-config.ts
@@ -91,13 +91,30 @@ export function useScopedConfigForSelection(selection: ProjectSelection | null) 
 
   const setField = useCallback(
     async <T,>(path: ConfigPath, value: T, scope: Scope): Promise<void> => {
+      // `undefined` means "clear this field" — every tier PUT accepts a
+      // `clear` list, so empty-string commits route through it instead of
+      // the dead-end conventions (undefined vanishes from JSON → 400
+      // "patch or clear required"; explicit null fails Zod validation).
+      if (value === undefined) {
+        if (scope === 'grove') {
+          await updateGroveConfig.mutateAsync({ clear: [path] });
+          invalidateNotifications();
+        } else if (scope === 'machine') {
+          await updateMachineConfig.mutateAsync({ clear: [path] });
+          invalidateNotifications();
+        } else {
+          await writeScopedConfig(scope, {}, [path], contextHeaders);
+          invalidateForScope(scope);
+        }
+        return;
+      }
       const patch: Record<string, unknown> = {};
       setAtPath(patch, path, value);
       if (scope === 'grove') {
-        await updateGroveConfig.mutateAsync(patch as Parameters<typeof updateGroveConfig.mutateAsync>[0]);
+        await updateGroveConfig.mutateAsync({ patch: patch as Partial<GroveConfig> });
         invalidateNotifications();
       } else if (scope === 'machine') {
-        await updateMachineConfig.mutateAsync(patch as MachineConfigPatch);
+        await updateMachineConfig.mutateAsync({ patch: patch as MachineConfigPatch });
         invalidateNotifications();
       } else {
         await writeScopedConfig(scope, patch, undefined, contextHeaders);
@@ -111,10 +128,9 @@ export function useScopedConfigForSelection(selection: ProjectSelection | null) 
    * Atomic write to the chosen scope. Applies a patch (field -> value pairs)
    * and optionally clears a set of dot-paths — both in a single PUT so
    * coupled transitions can't tear (e.g. Clear Provider unsets the provider
-   * and disables the tied task toggles together).
-   *
-   * For grove scope, `clearPaths` is not supported (Grove config has no
-   * local-override layer to clear); any provided clear paths are ignored.
+   * and disables the tied task toggles together). Fields whose value is
+   * `undefined` are treated as clears (same convention as `setField`).
+   * Every tier PUT (scoped, grove, machine) accepts the clear list.
    */
   const setFields = useCallback(
     async (
@@ -123,19 +139,25 @@ export function useScopedConfigForSelection(selection: ProjectSelection | null) 
       clearPaths?: ConfigPath[],
     ): Promise<void> => {
       const patch: Record<string, unknown> = {};
+      const clears: string[] = [...(clearPaths ?? [])];
       for (const { path, value } of fields) {
-        setAtPath(patch, path, value);
+        if (value === undefined) clears.push(path);
+        else setAtPath(patch, path, value);
       }
       if (scope === 'grove') {
-        await updateGroveConfig.mutateAsync(patch as Parameters<typeof updateGroveConfig.mutateAsync>[0]);
+        await updateGroveConfig.mutateAsync({
+          patch: patch as Partial<GroveConfig>,
+          clear: clears.length > 0 ? clears : undefined,
+        });
         invalidateNotifications();
       } else if (scope === 'machine') {
-        // Machine config has no local-override layer; clearPaths is ignored
-        // (mirrors the grove branch's clearPaths contract).
-        await updateMachineConfig.mutateAsync(patch as MachineConfigPatch);
+        await updateMachineConfig.mutateAsync({
+          patch: patch as MachineConfigPatch,
+          clear: clears.length > 0 ? clears : undefined,
+        });
         invalidateNotifications();
       } else {
-        await writeScopedConfig(scope, patch, clearPaths as string[] | undefined, contextHeaders);
+        await writeScopedConfig(scope, patch, clears.length > 0 ? clears : undefined, contextHeaders);
         invalidateForScope(scope);
       }
     },

--- a/packages/myco/ui/src/hooks/use-search.ts
+++ b/packages/myco/ui/src/hooks/use-search.ts
@@ -5,6 +5,13 @@ import { useProjectScopedQueryKey } from './use-project-selection';
 /** Minimum query length before a search request is issued. */
 const SEARCH_MIN_LENGTH = 2;
 
+/** Single gate for "is this query long enough to search?" — shared by the
+ *  fetch hooks and the search UI's loading/empty states so they can't drift
+ *  (a 2-character query must both fire AND render its states). */
+export function meetsSearchMinLength(query: string): boolean {
+  return query.length >= SEARCH_MIN_LENGTH;
+}
+
 /** How long search results remain fresh in the cache (ms). */
 const SEARCH_STALE_TIME = 30_000;
 
@@ -133,7 +140,7 @@ export function useSearch(
         buildSearchPath(query, mode, filters),
         { signal },
       ),
-    enabled: query.length > SEARCH_MIN_LENGTH,
+    enabled: meetsSearchMinLength(query),
     staleTime: SEARCH_STALE_TIME,
   });
 }
@@ -162,7 +169,7 @@ export function useCanopySearch(
         provider_unavailable: raw.provider_unavailable,
       };
     },
-    enabled: enabled && query.length > SEARCH_MIN_LENGTH,
+    enabled: enabled && meetsSearchMinLength(query),
     staleTime: SEARCH_STALE_TIME,
   });
 }

--- a/packages/myco/ui/src/hooks/use-unified-settings.ts
+++ b/packages/myco/ui/src/hooks/use-unified-settings.ts
@@ -77,6 +77,26 @@ export function useUnifiedSettings(): UnifiedSettings {
 
   const writeField = useCallback(
     async (field: SettingField, value: unknown): Promise<void> => {
+      // `undefined` means "clear this field": each tier PUT accepts a
+      // `clear` list, which is the only convention the API supports —
+      // undefined values vanish from JSON (400 empty patch) and explicit
+      // null fails Zod validation.
+      if (value === undefined) {
+        switch (field.scope) {
+          case 'project': {
+            await project.setField(field.key as ConfigPath, undefined, 'project');
+            return;
+          }
+          case 'grove': {
+            await updateGrove.mutateAsync({ clear: [field.key] });
+            return;
+          }
+          case 'machine': {
+            await updateMachine.mutateAsync({ clear: [field.key] });
+            return;
+          }
+        }
+      }
       switch (field.scope) {
         case 'project': {
           await project.setField(field.key as ConfigPath, value, 'project');
@@ -85,13 +105,13 @@ export function useUnifiedSettings(): UnifiedSettings {
         case 'grove': {
           const patch: Record<string, unknown> = {};
           setAtPath(patch, field.key, value);
-          await updateGrove.mutateAsync(patch as Partial<GroveConfig>);
+          await updateGrove.mutateAsync({ patch: patch as Partial<GroveConfig> });
           return;
         }
         case 'machine': {
           const patch: Record<string, unknown> = {};
           setAtPath(patch, field.key, value);
-          await updateMachine.mutateAsync(patch as MachineConfigPatch);
+          await updateMachine.mutateAsync({ patch: patch as MachineConfigPatch });
           return;
         }
       }

--- a/packages/myco/ui/src/pages/Settings.tsx
+++ b/packages/myco/ui/src/pages/Settings.tsx
@@ -597,9 +597,14 @@ function FieldRow({ field, hasProject, unified }: FieldRowProps) {
   })();
   const disabled = scopeDisabled || dependsOnDisabled;
 
+  const [writeError, setWriteError] = useState<string | null>(null);
   const onChange = useCallback(
     (next: unknown) => {
+      setWriteError(null);
       void unified.writeField(field, next).catch((err) => {
+        // Surface the failure inline — a swallowed write looks identical
+        // to a successful no-op from the user's side.
+        setWriteError(err instanceof Error ? err.message : String(err));
         console.error(`[settings] writeField failed: ${field.key}`, err);
       });
     },
@@ -644,6 +649,9 @@ function FieldRow({ field, hasProject, unified }: FieldRowProps) {
           onAdd={onAdd}
           onRemove={onRemove}
         />
+        {writeError && (
+          <p role="alert" className="mt-1 font-sans text-xs text-tertiary">{writeError}</p>
+        )}
       </div>
     </div>
   );
@@ -715,11 +723,13 @@ function FieldControl({ inputId, field, value, onChange, disabled, onAdd, onRemo
           id={inputId}
           value={typeof value === 'string' ? value : ''}
           onChange={(next) => {
-            // `nullableEmpty: true` lets a field clear its override by writing
-            // `null` for an empty string (pre-merge convention for backup.dir).
+            // `nullableEmpty: true` lets a field clear its value with an
+            // empty string. Committed as `undefined`, which the write layer
+            // routes through the tier PUT's `clear` list — the API's only
+            // supported way to unset a field.
             const trimmed = typeof next === 'string' ? next : '';
             if (field.nullableEmpty && trimmed.length === 0) {
-              onChange(null);
+              onChange(undefined);
             } else {
               onChange(next);
             }

--- a/tests/daemon/api/config-scope.test.ts
+++ b/tests/daemon/api/config-scope.test.ts
@@ -116,6 +116,45 @@ describe('scoped config HTTP handlers', () => {
     expect((merged.body as any).appearance.density).toBe('compact');
   });
 
+  it('PUT /grove-config with clear only removes the field from grove.yaml', async () => {
+    await handlePutGroveConfig(groveId, { patch: { backup: { dir: '/tmp/backups' } } });
+    const res = await handlePutGroveConfig(groveId, { clear: ['backup.dir'] });
+    expect(res.response.status).toBeUndefined();
+    expect(res.touchedPaths).toEqual(['backup.dir']);
+    const groveYaml = fs.readFileSync(path.join(mycoHome, 'groves', groveId, 'grove.yaml'), 'utf-8');
+    expect(groveYaml).not.toContain('/tmp/backups');
+  });
+
+  it('PUT /grove-config applies patch and clear atomically', async () => {
+    await handlePutGroveConfig(groveId, {
+      patch: { backup: { dir: '/tmp/backups' }, appearance: { theme: 'plum' } },
+    });
+    const res = await handlePutGroveConfig(groveId, {
+      patch: { appearance: { theme: 'moss' } },
+      clear: ['backup.dir'],
+    });
+    expect(res.response.status).toBeUndefined();
+    const groveYaml = fs.readFileSync(path.join(mycoHome, 'groves', groveId, 'grove.yaml'), 'utf-8');
+    expect(groveYaml).not.toContain('/tmp/backups');
+    expect(groveYaml).toContain('moss');
+  });
+
+  it('PUT /grove-config rejects 400 when patch and clear overlap', async () => {
+    const res = await handlePutGroveConfig(groveId, {
+      patch: { backup: { dir: '/tmp/backups' } },
+      clear: ['backup.dir'],
+    });
+    expect(res.response.status).toBe(400);
+    expect((res.response.body as any).error).toBe('patch_clear_overlap');
+  });
+
+  it('PUT /grove-config rejects 400 when clear is not an array', async () => {
+    const res = await handlePutGroveConfig(groveId, {
+      clear: 'backup.dir' as unknown as string[],
+    });
+    expect(res.response.status).toBe(400);
+  });
+
   it('GET /local with Grove context lifts legacy local appearance before returning local overrides', async () => {
     fs.writeFileSync(
       path.join(tmpDir, 'local.yaml'),

--- a/tests/ui/api-selection.test.tsx
+++ b/tests/ui/api-selection.test.tsx
@@ -59,11 +59,11 @@ describe('UI API request context', () => {
     expect(headers?.get('x-myco-project-id')).toBeUndefined();
   });
 
-  it('adds selected project identity inside query keys while preserving namespace invalidation', () => {
+  it('appends project identity to query keys so positional prefix invalidation still matches', () => {
     expect(projectScopedQueryKey(selection, ['sessions', { status: 'active' }])).toEqual([
       'sessions',
-      { projectSelection: 'grove-a:project-a' },
       { status: 'active' },
+      { projectSelection: 'grove-a:project-a' },
     ]);
     expect(projectScopedQueryKey(null, ['sessions'])).toEqual(['sessions']);
   });

--- a/tests/ui/config-fields.test.tsx
+++ b/tests/ui/config-fields.test.tsx
@@ -36,6 +36,21 @@ describe('config field controls', () => {
     expect(onChange.mock.calls[0][0]).toBe(10);
   });
 
+  it('NumberField does not commit when the input is emptied (no spurious 0)', () => {
+    const onChange = mock((_next: number) => {});
+    render(
+      <NumberField id="num" value={5} min={0} max={10} onChange={onChange} />,
+    );
+
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+
+    expect(onChange).not.toHaveBeenCalled();
+    // The draft snaps back to the last good value.
+    expect(input.value).toBe('5');
+  });
+
   it('TextField commits a trimmed value on blur', () => {
     const onChange = mock((_next: string) => {});
     render(<TextField id="text" value="" onChange={onChange} />);

--- a/tests/ui/project-scoped-query-key-invalidation.test.tsx
+++ b/tests/ui/project-scoped-query-key-invalidation.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+/**
+ * RC-10 regression — project-scoped query keys must stay visible to
+ * namespace-shaped invalidation.
+ *
+ * TanStack's partial key matching is positional: `invalidateQueries({
+ * queryKey: ['ns', id] })` only matches cached keys whose leading elements
+ * are `'ns', id`. The old scoped-key shape inserted the
+ * `{ projectSelection }` marker at INDEX 1, so every `['ns', id]`-shaped
+ * invalidation in the app silently no-oped (resumed runs stayed "failed",
+ * task-config forms re-seeded stale values, etc). The marker now goes at
+ * the END of the key; these tests pin that contract against a real
+ * QueryClient so the bug class can't come back.
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import { renderHook, act } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi } from '../helpers/vi-shim.js';
+import type { ProjectSelection } from '../../packages/myco/ui/src/lib/selection';
+import { projectScopedQueryKey } from '../../packages/myco/ui/src/hooks/use-project-selection';
+import { useResumeRun } from '../../packages/myco/ui/src/hooks/use-agent';
+
+const selection: ProjectSelection = {
+  grove: {
+    id: 'grove-a',
+    name: 'Work',
+    slug: 'work',
+    mode: 'local',
+    is_default: true,
+    created_at: '2026-01-01T00:00:00.000Z',
+    project_count: 1,
+    projects: [],
+  },
+  project: {
+    project_id: 'project-a',
+    name: 'Project A',
+    slug: 'project-a-123abc',
+    root: '/tmp/project-a',
+    binding_id: 'gbind-a',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    manifest_state: 'present',
+  },
+};
+
+describe('projectScopedQueryKey invalidation visibility (RC-10)', () => {
+  it('keeps the namespace at index 0 so the selection-boundary predicate still works', () => {
+    const key = projectScopedQueryKey(selection, ['agent-run', 'run-1']);
+    expect(key[0]).toBe('agent-run');
+  });
+
+  it("['ns', id]-shaped invalidation marks the scoped query stale", async () => {
+    const qc = new QueryClient();
+    const scopedKey = projectScopedQueryKey(selection, ['agent-run', 'run-1']);
+    qc.setQueryData(scopedKey, { run: { id: 'run-1', status: 'failed' } });
+
+    await qc.invalidateQueries({ queryKey: ['agent-run', 'run-1'] });
+
+    const query = qc.getQueryCache().find({ queryKey: scopedKey, exact: true });
+    expect(query).toBeDefined();
+    expect(query!.state.isInvalidated).toBe(true);
+  });
+
+  it("['ns']-shaped invalidation matches scoped keys with trailing params", async () => {
+    const qc = new QueryClient();
+    const scopedKey = projectScopedQueryKey(selection, [
+      'task-config',
+      'skill-survey',
+    ]);
+    qc.setQueryData(scopedKey, { provider: 'ollama' });
+
+    await qc.invalidateQueries({ queryKey: ['task-config', 'skill-survey'] });
+
+    const query = qc.getQueryCache().find({ queryKey: scopedKey, exact: true });
+    expect(query!.state.isInvalidated).toBe(true);
+  });
+
+  it('different selections keep distinct cache entries for the same logical key', () => {
+    const otherSelection: ProjectSelection = {
+      ...selection,
+      project: { ...selection.project, project_id: 'project-b' },
+    };
+    const keyA = projectScopedQueryKey(selection, ['sessions']);
+    const keyB = projectScopedQueryKey(otherSelection, ['sessions']);
+    expect(JSON.stringify(keyA)).not.toBe(JSON.stringify(keyB));
+  });
+});
+
+describe('useResumeRun optimistic restart (RC-10)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("flips the cached run detail to 'running' so terminal-status polling restarts", async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(Response.json({ ok: true, message: 'resumed' }))));
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    // No ProjectSelectionBoundary in the tree → selection is null → the hook
+    // reads/writes the unscoped key, matching how useAgentRun keys outside a
+    // project route.
+    qc.setQueryData(['agent-run', 'run-1'], { run: { id: 'run-1', status: 'failed' } });
+
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: qc }, children);
+    const { result } = renderHook(() => useResumeRun(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ runId: 'run-1' });
+    });
+
+    const detail = qc.getQueryData<{ run: { status: string } }>(['agent-run', 'run-1']);
+    expect(detail?.run.status).toBe('running');
+  });
+});

--- a/tests/ui/scoped-config-clear.test.tsx
+++ b/tests/ui/scoped-config-clear.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+/**
+ * RC-11 regression — clearing a field from the UI must reach the API as a
+ * `clear` list, the only unset convention the daemon accepts.
+ *
+ * The two dead conventions this replaces:
+ *  - `undefined` leaf → vanishes from JSON → empty patch → 400 "patch or
+ *    clear required"
+ *  - explicit `null` leaf → fails Zod (`z.string().optional()` rejects null)
+ *
+ * These tests drive the real `useScopedConfigForSelection` write layer over
+ * a stubbed fetch and assert the wire payload for all three tiers.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { renderHook, act } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi } from '../helpers/vi-shim.js';
+import { useScopedConfigForSelection } from '../../packages/myco/ui/src/hooks/use-scoped-config';
+
+type FetchCall = [string | URL | Request, (RequestInit | undefined)?];
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function putCallTo(pathFragment: string): { url: string; body: unknown } | undefined {
+  const call = (fetchMock.mock.calls as FetchCall[]).find(([url, init]) => {
+    return String(url).includes(pathFragment) && init?.method === 'PUT';
+  });
+  if (!call) return undefined;
+  return { url: String(call[0]), body: JSON.parse(String(call[1]?.body)) };
+}
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: qc }, children);
+  };
+}
+
+describe('useScopedConfig clear routing (RC-11)', () => {
+  beforeEach(() => {
+    fetchMock = vi.fn((url: string | URL | Request) => {
+      if (String(url).includes('/groves')) {
+        return Promise.resolve(Response.json({ groves: [] }));
+      }
+      return Promise.resolve(Response.json({}));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('setField(path, undefined, grove) PUTs /grove-config with a clear list and no patch', async () => {
+    const { result } = renderHook(() => useScopedConfigForSelection(null), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.setField('backup.dir', undefined, 'grove');
+    });
+
+    const put = putCallTo('/grove-config');
+    expect(put).toBeDefined();
+    expect(put!.body).toEqual({ clear: ['backup.dir'] });
+  });
+
+  it('setField(path, undefined, machine) PUTs /machine-config with a clear list', async () => {
+    const { result } = renderHook(() => useScopedConfigForSelection(null), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.setField('daemon.log_level', undefined, 'machine');
+    });
+
+    const put = putCallTo('/machine-config');
+    expect(put).toBeDefined();
+    expect(put!.body).toEqual({ clear: ['daemon.log_level'] });
+  });
+
+  it('setField(path, undefined, project) PUTs /config/scoped with an empty patch and a clear list', async () => {
+    const { result } = renderHook(() => useScopedConfigForSelection(null), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.setField('release_provenance.enabled', undefined, 'project');
+    });
+
+    const put = putCallTo('/config/scoped');
+    expect(put).toBeDefined();
+    expect(put!.body).toEqual({
+      scope: 'project',
+      patch: {},
+      clear: ['release_provenance.enabled'],
+    });
+  });
+
+  it('setFields treats undefined values as clears and sends patch + clear atomically', async () => {
+    const { result } = renderHook(() => useScopedConfigForSelection(null), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.setFields(
+        [
+          { path: 'agent.scheduled_tasks_enabled', value: false },
+          { path: 'agent.provider', value: undefined },
+        ],
+        'grove',
+        ['agent.harness'],
+      );
+    });
+
+    const put = putCallTo('/grove-config');
+    expect(put).toBeDefined();
+    expect(put!.body).toEqual({
+      patch: { agent: { scheduled_tasks_enabled: false } },
+      clear: ['agent.harness', 'agent.provider'],
+    });
+  });
+});

--- a/tests/ui/scoped-field.test.tsx
+++ b/tests/ui/scoped-field.test.tsx
@@ -204,3 +204,47 @@ describe('ScopedField — registry locks the field (embedding.model: overridable
     expect(pillTrigger).toBeUndefined();
   });
 });
+
+describe('ScopedField — empty-string commit routes through clear (RC-11)', () => {
+  beforeEach(() => {
+    setFieldMock.mockReset().mockResolvedValue(undefined);
+    resetFieldMock.mockReset().mockResolvedValue(undefined);
+    promoteFieldMock.mockReset().mockResolvedValue(undefined);
+    hookState.effective = { embedding: { base_url: 'http://localhost:11434' } };
+    hookState.local = {};
+  });
+
+  it("commits '' as undefined so the write layer issues a clear, not a dead patch", async () => {
+    render(
+      createElement(
+        ScopedField,
+        {
+          path: 'embedding.base_url',
+          label: 'Base URL',
+          commitOn: 'blur',
+          parse: (v: unknown) => (v === '' ? (undefined as unknown as string) : v),
+          children: ({ value, onChange, onBlur }: {
+            value: unknown;
+            onChange: (v: unknown) => void;
+            onBlur: () => void;
+          }) =>
+            createElement('input', {
+              'data-testid': 'clearable-input',
+              value: String(value ?? ''),
+              onChange: (e: { target: { value: string } }) => onChange(e.target.value),
+              onBlur,
+            }),
+        } as unknown as Parameters<typeof ScopedField>[0],
+      ),
+      { wrapper: makeWrapper() },
+    );
+
+    const input = screen.getByTestId('clearable-input');
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(setFieldMock).toHaveBeenCalledWith('embedding.base_url', undefined, 'grove');
+    });
+  });
+});

--- a/tests/ui/search-min-length.test.tsx
+++ b/tests/ui/search-min-length.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+/**
+ * RC-11 satellite — the search min-length gate was `query.length > 2`,
+ * so a 2-character query (which the UI invites) silently fired nothing.
+ * The gate is now `>= SEARCH_MIN_LENGTH` via the shared
+ * `meetsSearchMinLength` predicate; these tests pin both the predicate and
+ * that a 2-character query actually issues a request.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi } from '../helpers/vi-shim.js';
+import { meetsSearchMinLength, useSearch } from '../../packages/myco/ui/src/hooks/use-search';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: qc }, children);
+  };
+}
+
+describe('search min-length gate (RC-11 satellite)', () => {
+  beforeEach(() => {
+    fetchMock = vi.fn(() => Promise.resolve(Response.json({ mode: 'semantic', results: [] })));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('meetsSearchMinLength admits 2-character queries and rejects shorter ones', () => {
+    expect(meetsSearchMinLength('ab')).toBe(true);
+    expect(meetsSearchMinLength('a')).toBe(false);
+    expect(meetsSearchMinLength('')).toBe(false);
+  });
+
+  it('useSearch fires a request for a 2-character query', async () => {
+    renderHook(() => useSearch('ab'), { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      const searchCall = fetchMock.mock.calls.find(([url]: [string | URL | Request]) =>
+        String(url).includes('/search?'),
+      );
+      expect(searchCall).toBeDefined();
+      expect(String(searchCall![0])).toContain('q=ab');
+    });
+  });
+
+  it('useSearch stays idle for a 1-character query', async () => {
+    const { result } = renderHook(() => useSearch('a'), { wrapper: makeWrapper() });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(
+      fetchMock.mock.calls.some(([url]: [string | URL | Request]) => String(url).includes('/search?')),
+    ).toBe(false);
+  });
+});

--- a/tests/ui/settings-page.test.tsx
+++ b/tests/ui/settings-page.test.tsx
@@ -332,9 +332,9 @@ describe('Unified Settings page', () => {
     await waitFor(() => {
       expect(updateGroveMock).toHaveBeenCalled();
     });
-    // Patch shape should be { maintenance: { auto_optimize: <toggled> } }
+    // Write shape should be { patch: { maintenance: { auto_optimize: <toggled> } } }
     expect(updateGroveMock.mock.calls[0][0]).toEqual({
-      maintenance: { auto_optimize: expect.any(Boolean) as unknown as boolean },
+      patch: { maintenance: { auto_optimize: expect.any(Boolean) as unknown as boolean } },
     });
   });
 

--- a/tests/ui/use-unified-settings.test.tsx
+++ b/tests/ui/use-unified-settings.test.tsx
@@ -173,7 +173,7 @@ describe('useUnifiedSettings', () => {
       await result.current.writeField(GROVE_FIELD, 30);
     });
     expect(updateGroveMutateMock).toHaveBeenCalledWith({
-      maintenance: { auto_optimize_interval_hours: 30 },
+      patch: { maintenance: { auto_optimize_interval_hours: 30 } },
     });
   });
 
@@ -183,8 +183,40 @@ describe('useUnifiedSettings', () => {
       await result.current.writeField(MACHINE_FIELD, 'debug');
     });
     expect(updateMachineMutateMock).toHaveBeenCalledWith({
-      daemon: { log_level: 'debug' },
+      patch: { daemon: { log_level: 'debug' } },
     });
+  });
+
+  it('writeField(grove) with undefined routes through the clear list', async () => {
+    const { result } = renderHook(() => useUnifiedSettings());
+    await act(async () => {
+      await result.current.writeField(GROVE_FIELD, undefined);
+    });
+    expect(updateGroveMutateMock).toHaveBeenCalledWith({
+      clear: ['maintenance.auto_optimize_interval_hours'],
+    });
+  });
+
+  it('writeField(machine) with undefined routes through the clear list', async () => {
+    const { result } = renderHook(() => useUnifiedSettings());
+    await act(async () => {
+      await result.current.writeField(MACHINE_FIELD, undefined);
+    });
+    expect(updateMachineMutateMock).toHaveBeenCalledWith({
+      clear: ['daemon.log_level'],
+    });
+  });
+
+  it('writeField(project) with undefined delegates a clear to setField', async () => {
+    const { result } = renderHook(() => useUnifiedSettings());
+    await act(async () => {
+      await result.current.writeField(PROJECT_FIELD, undefined);
+    });
+    expect(setFieldMock).toHaveBeenCalledWith(
+      'release_provenance.enabled',
+      undefined,
+      'project',
+    );
   });
 
   it('isLoading aggregates across scopes', () => {


### PR DESCRIPTION
## Problems (bug-hunt RC-10 + RC-11, Wave 4 — final hunt items)

**RC-10**: `projectScopedQueryKey` put a `{projectSelection}` marker at index 1 of every scoped key; TanStack's partial matching is positional, so **all 90+ multi-element invalidations silently no-oped** (verified against query-core 5.x at hunt time, re-verified now). User-visible: resumed runs stuck at "failed" until refocus, reopened forms re-seeding stale values, canopy re-embed never refreshing.

**RC-11**: clearing a field from the UI was impossible — both conventions ('' → empty patch → 400; explicit null → schema rejection, swallowed) failed, including on the exact fields whose hint text says "leave blank for default". Re-grounding found it worse than the hunt recorded: the grove/machine tier PUTs had **no `clear` support at all**, and `embedding.*`/`backup.*` home at grove tier.

## Fixes

- **Marker-at-end** for scoped keys, chosen over a helper after a full consumer audit (30 consumers position-agnostic, zero `queryKey[1]` reads, zero `exact:true`, existing marker-at-end precedent in `use-scoped-config`). `useResumeRun` optimistically flips the cached run to `running` — polling gates on terminal status, so invalidation alone never restarted it.
- **One clear path**: `handlePutTierConfig` gains the scoped handler's exact `clear` contract (validation, protected-path filtering, `patch_clear_overlap`, clears-before-patch inside `updateTierConfigRaw` — which already carries the F13 corrupt-tier 422 guard); the field layer translates empty commits to clears for all four tiers; the null convention is deleted; write errors render inline.
- Satellites: AgentProviderCard error surfacing + working grove clear, PlanCaptureCard error-vs-empty, numeric inputs never commit 0 on clear, 2-char searches fire (shared `>=` helper incl. GlobalSearch's hardcoded `> 2`).
- Already-fixed-on-main (skipped, verified): the Symbionts PATCH null convention is now a first-class server contract.

## Testing

New: query-key invalidation pin (real QueryClient), wire-payload asserts for all three tier PUT clears + atomic patch+clear, search min-length; extended ScopedField/NumberField/config-scope suites (4 new server-side grove-clear tests). `tsc` clean, `vite build` green, all changed suites green; full local run carried one documented load flake in an untouched file — CI adjudicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)