### PR TITLE
hygiene: post-hunt bundle — F11 lock reaping, F14 clear residue, F3 skip-path logging, F7 pi single-injection, team-sync rejection loop

### DIFF
--- a/packages/myco/src/capture/buffer.ts
+++ b/packages/myco/src/capture/buffer.ts
@@ -61,11 +61,31 @@ export class EventBuffer {
     if (fs.existsSync(this.filePath)) {
       fs.unlinkSync(this.filePath);
     }
+    removeBufferLockCompanion(this.bufferDir, this.sessionId);
   }
 
   getFilePath(): string {
     return this.filePath;
   }
+}
+
+/**
+ * Best-effort removal of the `.{sessionId}.lock` companion that
+ * `EventBuffer.append`'s flock leaves beside the buffer file. Every site
+ * that unlinks or quarantines a buffer must also call this — the lock is
+ * meaningless without its buffer and otherwise accumulates forever.
+ *
+ * Unlinking a lock another process currently flocks lets a subsequent
+ * appender create a fresh inode at the same path and acquire instantly
+ * (flock binds to the inode, not the path). Accepted: every caller is
+ * removing a buffer that is condemned (stale, tombstoned, quarantined,
+ * or cascade-deleted), and the reconciler tolerates a torn trailing
+ * line by excluding it with a WARN.
+ */
+export function removeBufferLockCompanion(bufferDir: string, sessionId: string): void {
+  try {
+    fs.unlinkSync(path.join(bufferDir, `.${sessionId}.lock`));
+  } catch { /* already gone or never created */ }
 }
 
 /**
@@ -137,6 +157,9 @@ export function quarantineBufferFile(bufferDir: string, file: string): string {
     target = path.join(quarantineDir, `${base}.${n}${ext}`);
   }
   fs.renameSync(path.join(bufferDir, file), target);
+  // The lock companion stays in the buffer dir on purpose (quarantined
+  // files are never appended to again) — drop it with the move.
+  removeBufferLockCompanion(bufferDir, base);
   return target;
 }
 
@@ -211,11 +234,34 @@ export function cleanStaleBuffers(
       }
       if (decision === 'age-gated' && identity.mtimeMs >= cutoff) continue;
       fs.unlinkSync(filePath);
+      removeBufferLockCompanion(bufferDir, sessionId);
       removed++;
       onRemoved?.(sessionId);
     }
+    reapOrphanedBufferLocks(bufferDir, cutoff);
   } catch { /* buffer dir may not exist */ }
   return removed;
+}
+
+/**
+ * Remove `.{sessionId}.lock` files whose buffer no longer exists. Covers
+ * locks stranded by historical deletion sites (before lock cleanup was
+ * paired with buffer removal) and by crashes between unlink and lock
+ * cleanup. Age-gated by the same cutoff as buffer deletion: a freshly
+ * created lock can precede its buffer's first append, so a young orphan
+ * is left for the next pass.
+ */
+function reapOrphanedBufferLocks(bufferDir: string, cutoff: number): void {
+  for (const file of fs.readdirSync(bufferDir)) {
+    if (!file.startsWith('.') || !file.endsWith('.lock')) continue;
+    const sessionId = file.slice(1, -'.lock'.length);
+    if (!sessionId) continue;
+    if (fs.existsSync(path.join(bufferDir, `${sessionId}.jsonl`))) continue;
+    try {
+      if (fs.statSync(path.join(bufferDir, file)).mtimeMs >= cutoff) continue;
+      fs.unlinkSync(path.join(bufferDir, file));
+    } catch { /* concurrent removal — skip */ }
+  }
 }
 
 /**

--- a/packages/myco/src/daemon/api/config.ts
+++ b/packages/myco/src/daemon/api/config.ts
@@ -191,7 +191,7 @@ export async function handlePutScopedConfig(vaultDir: string, body: unknown): Pr
       const project = loadConfig(vaultDir);
       const updated = updateLocalConfig(vaultDir, (local) => {
         const working = structuredClone(local) as Record<string, unknown>;
-        for (const key of clearList) unsetAtPath(working, key);
+        for (const key of clearList) unsetAtPath(working, key, { pruneEmptyParents: true });
         const withPatch = deepMergeConfig(
           working,
           patch as Record<string, unknown>,
@@ -227,7 +227,7 @@ export async function handlePutScopedConfig(vaultDir: string, body: unknown): Pr
     // shape raises a ZodError that we convert to a 400 below.
     const updated = updateConfig(vaultDir, (current) => {
       const working = structuredClone(current) as Record<string, unknown>;
-      for (const key of clearList) unsetAtPath(working, key);
+      for (const key of clearList) unsetAtPath(working, key, { pruneEmptyParents: true });
       const withPatch = deepMergeConfig(working, patch as Record<string, unknown>) as Record<string, unknown>;
       applyListDeltas(withPatch, addOpsOrError, removeOpsOrError);
       return withPatch as MycoConfig;
@@ -466,7 +466,7 @@ async function handlePutTierConfig<TConfig>(
     const validated = updateTierConfigRaw(options.target, (rawDoc) => {
       // Clears apply first (same order as the scoped handler) so a clear of
       // a stale subtree can't erase the values the patch introduces.
-      for (const key of clearList) unsetAtPath(rawDoc, key);
+      for (const key of clearList) unsetAtPath(rawDoc, key, { pruneEmptyParents: true });
       const next = deepMergeConfig(rawDoc, patch);
       for (const opPath of listTouched) {
         setAtPath(next, opPath, getAtPath(working, opPath));

--- a/packages/myco/src/daemon/api/context.ts
+++ b/packages/myco/src/daemon/api/context.ts
@@ -130,7 +130,7 @@ export function createSessionContextHandler(deps: ContextDeps) {
           cortexContent = snapshot.content;
           sourceRunId = snapshot.sourceRunId;
         } else {
-          logger.debug(LOG_KINDS.CONTEXT_SESSION, 'No stored Cortex instructions available for session start', {
+          logger.info(LOG_KINDS.CONTEXT_SESSION, 'Session context: no stored Cortex instructions available', {
             session_id,
           });
         }
@@ -144,13 +144,18 @@ export function createSessionContextHandler(deps: ContextDeps) {
       );
 
       if (digestEnabled && !composed.parts.some((p) => p.kind === 'digest')) {
-        logger.debug(LOG_KINDS.CONTEXT_SESSION, 'No preferred digest extract available for session start', {
+        logger.info(LOG_KINDS.CONTEXT_SESSION, 'Session context: no preferred digest extract available', {
           session_id,
           preferred_tier: config.cortex.digest.tier,
         });
       }
 
       if (textParts.length === 0) {
+        logger.info(LOG_KINDS.CONTEXT_SESSION, 'Session context skipped — no content parts to inject', {
+          session_id,
+          cortex_enabled: capabilityEnabled(config, 'cortex'),
+          digest_enabled: digestEnabled,
+        });
         return { body: { text: '' } };
       }
 
@@ -162,18 +167,6 @@ export function createSessionContextHandler(deps: ContextDeps) {
       const source = sourceParts.join('+');
       const contextText = textParts.join('\n\n');
       const estimatedTokens = estimateTokens(contextText);
-      logger.info(
-        LOG_KINDS.CONTEXT_SESSION,
-        `Session context: ${estimatedTokens} est. tokens, source=${source}`,
-        {
-          session_id,
-          source,
-          branch,
-          source_run_id: sourceRunId,
-          text_length: contextText.length,
-          estimated_tokens: estimatedTokens,
-        },
-      );
 
       // Per-(session) dedup gate. UNIQUE on
       // `myco:inject:cortex:<sessionId>` blocks re-entry within the same
@@ -206,8 +199,29 @@ export function createSessionContextHandler(deps: ContextDeps) {
           trigger: { metadata: { source, branch } },
           fetchContent: async () => ({ text: contextText, metadata: { source } }),
         });
-        if (suppress) return { body: { text: '' } };
+        if (suppress) {
+          logger.debug(LOG_KINDS.CONTEXT_SESSION, 'Session context suppressed — already injected this session', {
+            session_id,
+            source,
+          });
+          return { body: { text: '' } };
+        }
       }
+
+      // Served-log AFTER the dedup gate: a suppressed duplicate call must
+      // not log as if context was delivered.
+      logger.info(
+        LOG_KINDS.CONTEXT_SESSION,
+        `Session context: ${estimatedTokens} est. tokens, source=${source}`,
+        {
+          session_id,
+          source,
+          branch,
+          source_run_id: sourceRunId,
+          text_length: contextText.length,
+          estimated_tokens: estimatedTokens,
+        },
+      );
 
       return {
         body: {
@@ -243,9 +257,16 @@ export function createSubagentContextHandler(deps: ContextDeps) {
     });
 
     try {
-      if (!session_id) return { body: { text: '' } };
+      if (!session_id) {
+        logger.info(LOG_KINDS.CONTEXT_SESSION, 'Subagent context skipped — request carried no session_id', {
+          agent,
+          agent_id,
+          agent_type,
+        });
+        return { body: { text: '' } };
+      }
       if (!capabilityEnabled(config, 'cortex') || !config.cortex.instructions.inject_on_subagent_start) {
-        logger.debug(LOG_KINDS.CONTEXT_SESSION, 'Subagent context disabled', { session_id, agent });
+        logger.info(LOG_KINDS.CONTEXT_SESSION, 'Subagent context disabled by config', { session_id, agent });
         return { body: { text: '' } };
       }
       if (!symbiontHasCapability(agent, 'subagentStartInjection')) {
@@ -265,7 +286,7 @@ export function createSubagentContextHandler(deps: ContextDeps) {
         cliToolTransport: symbiontToolTransport(agent) === 'cli',
       });
       if (!composed) {
-        logger.debug(LOG_KINDS.CONTEXT_SESSION, 'No stored Cortex instructions available for subagent start', {
+        logger.info(LOG_KINDS.CONTEXT_SESSION, 'Subagent context skipped — no stored Cortex instructions', {
           session_id,
           agent,
         });
@@ -308,7 +329,14 @@ export function createSubagentContextHandler(deps: ContextDeps) {
           },
         }),
       });
-      if (suppress) return { body: { text: '' } };
+      if (suppress) {
+        logger.debug(LOG_KINDS.CONTEXT_SESSION, 'Subagent context suppressed — already injected for this subagent', {
+          session_id,
+          agent,
+          discriminator,
+        });
+        return { body: { text: '' } };
+      }
 
       logger.info(LOG_KINDS.CONTEXT_SESSION, 'Subagent context injected', {
         session_id,
@@ -384,7 +412,10 @@ export function createResumeContextHandler(deps: ContextDeps) {
       }
 
       if (parts.length === 0) {
-        logger.debug(LOG_KINDS.CONTEXT_SESSION, 'No resume context available', { session_id, parent_session_id });
+        logger.info(LOG_KINDS.CONTEXT_SESSION, 'Resume context skipped — parent session has no title or summary', {
+          session_id,
+          parent_session_id,
+        });
         return { body: { text: '' } };
       }
 
@@ -555,7 +586,13 @@ export function createPromptContextHandler(deps: ContextDeps) {
     const hydrated = hydrateSearchResults(selectedResults, { scope });
     const spores = hydrated.filter((r) => r.type === 'spore');
 
-    if (spores.length === 0) return respond('');
+    if (spores.length === 0) {
+      logger.debug(LOG_KINDS.CONTEXT_FILTER, 'Hydration yielded no spores for selected results', {
+        session_id,
+        selected: selectedResults.length,
+      });
+      return respond('');
+    }
 
     const text = formatSporeContext(spores);
 
@@ -591,7 +628,13 @@ export function createPromptContextHandler(deps: ContextDeps) {
         },
         fetchContent: async () => ({ text, metadata: { spore_count: spores.length } }),
       });
-      if (suppress) return respond('');
+      if (suppress) {
+        logger.debug(LOG_KINDS.CONTEXT_PROMPT, 'Prompt spore injection suppressed — already injected for this prompt', {
+          session_id,
+          spore_count: spores.length,
+        });
+        return respond('');
+      }
     }
 
     return respond(text);

--- a/packages/myco/src/daemon/jobs/session-cleanup.ts
+++ b/packages/myco/src/daemon/jobs/session-cleanup.ts
@@ -7,6 +7,7 @@
  */
 
 import { unlink, glob } from 'node:fs/promises';
+import { removeBufferLockCompanion } from '@myco/capture/buffer.js';
 import type { DeleteCascadeResult } from '../../db/queries/sessions.js';
 import type { EmbeddingManager } from '../embedding/manager.js';
 
@@ -63,5 +64,6 @@ export async function cleanupAfterSessionCascade(
   // the real dir or passes null (skip, tombstone keeps it inert).
   if (bufferDir) {
     try { await unlink(`${bufferDir}/${sessionId}.jsonl`); } catch { /* best-effort */ }
+    removeBufferLockCompanion(bufferDir, sessionId);
   }
 }

--- a/packages/myco/src/daemon/jobs/session-maintenance.ts
+++ b/packages/myco/src/daemon/jobs/session-maintenance.ts
@@ -13,6 +13,7 @@ import path from 'node:path';
 import { getDatabase } from '@myco/db/client.js';
 import { closeSession, deleteSessionCascade } from '@myco/db/queries/sessions.js';
 import { SESSION_TOMBSTONE_SOURCE, pruneSessionTombstones } from '@myco/db/queries/session-tombstones.js';
+import { removeBufferLockCompanion } from '@myco/capture/buffer.js';
 import { resolveBufferDirForProjectId } from '@myco/capture/buffer-location.js';
 import {
   epochSeconds,
@@ -225,6 +226,7 @@ export async function runSessionMaintenance(deps: SessionMaintenanceDeps): Promi
       try { embeddingManager.onRemoved('sessions', sessionId); } catch { /* best-effort */ }
       if (bufferDir) {
         try { fs.unlinkSync(path.join(bufferDir, `${sessionId}.jsonl`)); } catch { /* best-effort */ }
+        removeBufferLockCompanion(bufferDir, sessionId);
       }
     }
 

--- a/packages/myco/src/daemon/reconciliation.ts
+++ b/packages/myco/src/daemon/reconciliation.ts
@@ -12,6 +12,7 @@ import {
   listBufferSessionIds,
   cleanStaleBuffers,
   pruneQuarantinedBuffers,
+  removeBufferLockCompanion,
   type BufferCleanupDecision,
 } from '@myco/capture/buffer.js';
 import { bufferDirCurrentRegistration, bufferDirIdentity } from '@myco/capture/buffer-location.js';
@@ -568,6 +569,7 @@ export function createReconciler({ bufferDirs, logger, projectRoot, onSessionRec
       });
       return;
     }
+    removeBufferLockCompanion(path.dirname(bufferPath), sessionId);
     reconciledSessions.delete(sessionId);
     logger.info(LOG_KINDS.LIFECYCLE_RECONCILE, 'Reconciliation: buffer discarded without replay', {
       session_id: sessionId,

--- a/packages/myco/src/daemon/team-sync-init.ts
+++ b/packages/myco/src/daemon/team-sync-init.ts
@@ -522,10 +522,12 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
 
           const rejectedKeys = new Set(enqueueResult.rejected.map((e) => rejectionKey(e.table, e.id)));
           const rejectedOutboxIds: number[] = [];
+          const rejectedRows: OutboxRow[] = [];
           const handedOff: OutboxRow[] = [];
           for (const row of rows) {
             if (rejectedKeys.has(rejectionKey(row.table_name, row.row_id))) {
               rejectedOutboxIds.push(row.id);
+              rejectedRows.push(row);
             } else {
               handedOff.push(row);
             }
@@ -537,6 +539,14 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
               rejected: enqueueResult.rejected.slice(0, 5),
             });
             discardRows(rejectedOutboxIds);
+            // A rejection is the worker's permanent verdict on this payload.
+            // The outbox row is discarded above; the SOURCE row must be
+            // stamped too, or backfillUnsynced re-enqueues it on every
+            // reconcile and the reject/discard cycle repeats forever.
+            // synced_at means "sync fate resolved" (the hand-off semantics
+            // documented on markSourceRowsSynced); the rejection itself
+            // stays visible in the warn log above.
+            markSourceRowsSynced(rejectedRows, now);
             result.rejected += rejectedOutboxIds.length;
             clearedThisTick += rejectedOutboxIds.length;
           }

--- a/packages/myco/src/symbionts/templates/pi/plugin.ts
+++ b/packages/myco/src/symbionts/templates/pi/plugin.ts
@@ -890,20 +890,27 @@ export default function (pi: ExtensionAPI) {
     // Register with the daemon
     await mycoRegisterSession(currentCwd, sessionId);
 
-    // Fetch and inject context as a persistent custom message.
-    // Pi's before_agent_start hook augments the system prompt each turn,
-    // but this initial injection ensures context is visible in the session
-    // history and survives compaction.
-    let contextText: string | null = null;
+    // Fetch and inject context as a persistent custom message — the one
+    // session-context injection for this session id (the daemon's
+    // per-session dedup gate suppresses any repeat /context call).
+    // Persisting it in session history means it survives compaction.
+    // Resumed and forked sessions are NEW session ids to the daemon —
+    // /context/resume records no cortex injection and a fork inherits
+    // only the parent's (possibly stale, possibly compacted-away)
+    // context message — so every entry path fetches the full session
+    // context here; the resume recap rides in front of it.
+    const contextParts: string[] = [];
 
     if (isResume && event.previousSessionFile) {
       const previousSessionId = deriveSessionId(event.previousSessionFile);
       if (previousSessionId) {
-        contextText = await fetchMycoResumeContext(currentCwd, sessionId, previousSessionId);
+        const recap = await fetchMycoResumeContext(currentCwd, sessionId, previousSessionId);
+        if (recap) contextParts.push(recap);
       }
-    } else if (!isFork) {
-      contextText = await fetchMycoSessionContext(currentCwd, sessionId);
     }
+    const sessionContext = await fetchMycoSessionContext(currentCwd, sessionId);
+    if (sessionContext) contextParts.push(sessionContext);
+    const contextText = contextParts.length > 0 ? contextParts.join("\n\n") : null;
 
     if (contextText) {
       pi.sendMessage({
@@ -958,10 +965,14 @@ export default function (pi: ExtensionAPI) {
       }
     }
 
-    const contextText = await fetchMycoSessionContext(currentCwd, currentSessionId);
-    if (contextText) {
-      return { systemPrompt: event.systemPrompt + "\n\n" + contextText };
-    }
+    // Session context is injected once, by the session_start hook above
+    // (every entry path — fresh, resume, fork — fetches there). The
+    // daemon's per-session dedup gate suppresses any repeat /context
+    // call, so re-fetching here delivers nothing and only produced a
+    // duplicate context.session serve. Known trade: if session_start's
+    // fetch failed transiently, there is no per-turn retry. Per-prompt
+    // spore/cortex context (POST /context/prompt) is the future occupant
+    // of this slot.
     return undefined;
   });
 

--- a/tests/capture/buffer.test.ts
+++ b/tests/capture/buffer.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { EventBuffer, resolveSessionFromBuffer } from '@myco/capture/buffer';
+import {
+  EventBuffer,
+  resolveSessionFromBuffer,
+  cleanStaleBuffers,
+  quarantineBufferFile,
+  BUFFER_QUARANTINE_DIRNAME,
+} from '@myco/capture/buffer';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -46,6 +52,76 @@ describe('EventBuffer', () => {
     expect(buffer.exists()).toBe(true);
     buffer.delete();
     expect(buffer.exists()).toBe(false);
+  });
+
+  it('delete() removes the .lock companion alongside the buffer', () => {
+    const buffer = new EventBuffer(bufferDir, 'session-abc');
+    buffer.append({ type: 'tool_use', tool: 'Read' });
+    const lockPath = path.join(bufferDir, '.session-abc.lock');
+    expect(fs.existsSync(lockPath)).toBe(true);
+    buffer.delete();
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+});
+
+describe('buffer lock companion cleanup', () => {
+  let tmpDir: string;
+  let bufferDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-lock-'));
+    bufferDir = path.join(tmpDir, 'buffer');
+    fs.mkdirSync(bufferDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeBufferWithLock(sessionId: string, ageMs: number): void {
+    const old = new Date(Date.now() - ageMs);
+    const jsonlPath = path.join(bufferDir, `${sessionId}.jsonl`);
+    const lockPath = path.join(bufferDir, `.${sessionId}.lock`);
+    fs.writeFileSync(jsonlPath, '{"type":"tool_use"}\n');
+    fs.writeFileSync(lockPath, '');
+    fs.utimesSync(jsonlPath, old, old);
+    fs.utimesSync(lockPath, old, old);
+  }
+
+  it('cleanStaleBuffers removes the lock companion with each stale buffer', () => {
+    makeBufferWithLock('stale-1', 60_000);
+    const removed = cleanStaleBuffers(bufferDir, { maxAgeMs: 1_000 });
+    expect(removed).toBe(1);
+    expect(fs.existsSync(path.join(bufferDir, '.stale-1.lock'))).toBe(false);
+  });
+
+  it('cleanStaleBuffers reaps old orphaned locks but spares young ones and live pairs', () => {
+    // Orphan past the age gate — reaped.
+    const oldOrphan = path.join(bufferDir, '.gone-session.lock');
+    fs.writeFileSync(oldOrphan, '');
+    const old = new Date(Date.now() - 60_000);
+    fs.utimesSync(oldOrphan, old, old);
+    // Fresh orphan — a lock can precede its buffer's first append; spared.
+    const youngOrphan = path.join(bufferDir, '.brand-new.lock');
+    fs.writeFileSync(youngOrphan, '');
+    // Live pair, fresh — both spared.
+    const live = new EventBuffer(bufferDir, 'live-session');
+    live.append({ type: 'tool_use' });
+
+    cleanStaleBuffers(bufferDir, { maxAgeMs: 1_000 });
+
+    expect(fs.existsSync(oldOrphan)).toBe(false);
+    expect(fs.existsSync(youngOrphan)).toBe(true);
+    expect(fs.existsSync(path.join(bufferDir, '.live-session.lock'))).toBe(true);
+    expect(fs.existsSync(path.join(bufferDir, 'live-session.jsonl'))).toBe(true);
+  });
+
+  it('quarantineBufferFile drops the lock companion when moving the buffer', () => {
+    makeBufferWithLock('diverging', 60_000);
+    const target = quarantineBufferFile(bufferDir, 'diverging.jsonl');
+    expect(target).toContain(BUFFER_QUARANTINE_DIRNAME);
+    expect(fs.existsSync(target)).toBe(true);
+    expect(fs.existsSync(path.join(bufferDir, '.diverging.lock'))).toBe(false);
   });
 });
 

--- a/tests/daemon/api/config-scope.test.ts
+++ b/tests/daemon/api/config-scope.test.ts
@@ -139,6 +139,21 @@ describe('scoped config HTTP handlers', () => {
     expect(groveYaml).toContain('moss');
   });
 
+  it('PUT /grove-config clearing the last leaf prunes the empty parent map', async () => {
+    await handlePutGroveConfig(groveId, { patch: { backup: { dir: '/tmp/backups' } } });
+    await handlePutGroveConfig(groveId, { clear: ['backup.dir'] });
+    const groveYaml = fs.readFileSync(path.join(mycoHome, 'groves', groveId, 'grove.yaml'), 'utf-8');
+    // Without pruneEmptyParents the clear leaves `backup: {}` residue.
+    expect(groveYaml).not.toContain('backup');
+  });
+
+  it('PUT /scoped scope=local clearing the last leaf prunes the empty parent map', async () => {
+    await handlePutScopedConfig(tmpDir, { scope: 'local', patch: { notifications: { enabled: false } } });
+    await handlePutScopedConfig(tmpDir, { scope: 'local', clear: ['notifications.enabled'] });
+    const localYaml = fs.readFileSync(path.join(tmpDir, 'local.yaml'), 'utf-8');
+    expect(localYaml).not.toContain('notifications');
+  });
+
   it('PUT /grove-config rejects 400 when patch and clear overlap', async () => {
     const res = await handlePutGroveConfig(groveId, {
       patch: { backup: { dir: '/tmp/backups' } },

--- a/tests/daemon/team-sync-init.test.ts
+++ b/tests/daemon/team-sync-init.test.ts
@@ -354,6 +354,11 @@ describe('initTeamSync.reconcileClient', () => {
     expect(discardRowsMock).toHaveBeenCalledWith([1]);
     expect(markSentMock).toHaveBeenCalledWith([2], expect.any(Number));
     expect(markSourceRowsSyncedMock).toHaveBeenCalledWith([pending[1]], expect.any(Number));
+    // The rejected row's SOURCE is stamped too — a rejection is the
+    // worker's permanent verdict, and an unstamped source row would be
+    // re-enqueued by backfillUnsynced on every reconcile, repeating the
+    // reject/discard cycle forever.
+    expect(markSourceRowsSyncedMock).toHaveBeenCalledWith([pending[0]], expect.any(Number));
   });
 
   it('registry membership exposes a read client even when legacy config is disabled', async () => {


### PR DESCRIPTION
## What

Five hygiene fixes from the post-hunt backlog (plan `d9eeb0a186e720d8`, section B), each fixed as a pattern so the bug class can't recur.

| Fix | Class fix |
|---|---|
| **F11** lock companions never reaped (28 stranded) | `removeBufferLockCompanion()` paired with **every** buffer unlink/quarantine site + age-gated orphan reaping in `cleanStaleBuffers` — existing strays self-heal |
| **F14** `skills: {}` residue after scoped clear | `{ pruneEmptyParents: true }` on all three config-API clear loops |
| **F3** injection skips invisible | Session-scoped skips → info with reason; per-prompt stays debug; served-log moved **after** the dedup gate (suppressed ≠ delivered) |
| **F7** pi `context.session` ×2 | Per-turn `/context` call removed; `session_start` now fetches on **every** entry path (fresh/resume/fork) |
| **team-sync** eternal reject/discard loop | Rejected rows' **source** rows stamped via `markSourceRowsSynced` alongside the outbox discard |

## Root causes worth reading

- **team-sync loop (evidence-corrected):** the 5 perpetually-rejected records are pre-Grove debris in `_unbound-bootstrap-dev/myco.db` (`project_id NULL`). `backfillUnsynced` re-enqueued them on every reconcile because rejection discarded the outbox row but never resolved the source row's sync fate. Stamping completes the existing permanence decision — the live loop self-heals on the dev daemon's next reconcile. (Whether bootstrap DBs should team-sync at all is logged under backlog section E.)
- **F7:** the daemon's per-session cortex dedup made pi's per-turn fetch deliver nothing for fresh sessions — but an adversarial probe caught that **resume/fork sessions relied on it** (resume records no cortex injection; fork skipped the fetch). `session_start` now owns first-turn delivery for all paths instead.

## Probe findings accepted as bounded risk

- Unlinking a lock mid-flock lets a new appender acquire a fresh inode instantly (probe-proven). Accepted and documented on the helper: every caller is removing a condemned buffer, and the reconciler tolerates a torn trailing line.
- Fan-out: a row rejected by team A was already (pre-existing) discarded before team B's confirmation; stamping narrows one accidental redelivery path that rode on the bug being fixed.

## Verification

- New tests: lock-companion removal at delete/clean/quarantine, orphan reaping age-gating, empty-parent pruning (grove + local), rejected-source stamping
- 712 tests green across symbionts/capture suites; targeted suites (config API, team-sync-init, context) green; `tsc --noEmit` clean
- Adversarial probe agent over the diff; its one must-fix (F7 resume/fork regression) is fixed in this PR
- Dogfood plan post-merge: dev daemon's `team-sync.rejected` warnings stop; 28 stale locks disappear on the next stale-buffer pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)