### PR TITLE
doctor: typed fix registry — advertised fixes exist, fixers are reachable (RC-14b)

### DIFF
--- a/packages/myco/src/cli/doctor-fixes.ts
+++ b/packages/myco/src/cli/doctor-fixes.ts
@@ -1,0 +1,172 @@
+/**
+ * Doctor fix registry — the single dispatch surface for `myco doctor --fix`.
+ *
+ * Each fixable check emitted by `cli/doctor.ts` carries a `fixId` naming
+ * the fixer that repairs it (plus optional structured `fixData`). `fix()`
+ * groups non-ok checks by `fixId` and invokes each present fixer exactly
+ * once with its matched checks. A check without a `fixId` is never
+ * dispatched — string-matching on check details is not a dispatch path.
+ */
+
+import fs from 'node:fs';
+import type { DaemonStateAuthority } from '../daemon/daemon-state-authority.js';
+import type { DoctorCheck } from './doctor.js';
+
+export type DoctorFixerId =
+  | 'daemon-stale'
+  | 'daemon-malformed'
+  | 'smoke-launcher-scrub'
+  | 'migration-retry'
+  | 'service-reinstall'
+  | 'symbiont-global-refresh';
+
+export interface DoctorFixContext {
+  vaultDir: string;
+  authority: DaemonStateAuthority;
+}
+
+export const DOCTOR_FIXERS: Record<DoctorFixerId, (ctx: DoctorFixContext, matched: DoctorCheck[]) => Promise<string[]>> = {
+  // Fix stale daemon.json — re-read under the authority and only unlink
+  // if the recorded pid still matches the pid we observed as dead. If a
+  // concurrent successor wrote into the gap, the unlink is a no-op and
+  // the file is preserved.
+  'daemon-stale': async (ctx, matched) => {
+    const actions: string[] = [];
+    for (const check of matched) {
+      const stalePid = typeof check.fixData?.stalePid === 'number' ? check.fixData.stalePid : NaN;
+      if (!Number.isFinite(stalePid)) continue;
+      const outcome = ctx.authority.deleteIfOwnedBy(stalePid, { reason: 'doctor:stale' });
+      actions.push(
+        outcome === 'deleted'
+          ? `Removed stale daemon state (PID ${stalePid})`
+          : `Daemon state already refreshed by a successor (was PID ${stalePid}) — no action`,
+      );
+    }
+    return actions;
+  },
+
+  // Fix malformed daemon.json — by definition the file was unparseable
+  // when the check ran. The authority re-reads under the same
+  // discipline: if a successor refreshed the file between detection
+  // and fix, leave it alone.
+  'daemon-malformed': async (ctx) => {
+    const outcome = ctx.authority.deleteIfMalformed({ reason: 'doctor:malformed' });
+    return [
+      outcome === 'deleted'
+        ? 'Removed malformed daemon state'
+        : 'Daemon state already refreshed by a successor — no action',
+    ];
+  },
+
+  // Scrub stale escaped smoke-launcher hook groups from global agent
+  // config files via the global-config migration pass.
+  'smoke-launcher-scrub': async () => {
+    const actions: string[] = [];
+    try {
+      const { runGlobalConfigMigration } = await import('../grove/global-config-migration.js');
+      const result = runGlobalConfigMigration();
+      const repaired = result.outcomes.filter((outcome) => outcome.entriesRemoved > 0 && !outcome.error);
+      const failed = result.outcomes.filter((outcome) => outcome.entriesRemoved > 0 && outcome.error);
+      for (const outcome of repaired) {
+        actions.push(`Scrubbed ${outcome.entriesRemoved} stale smoke-launcher hook group(s) from ${outcome.filePath}`);
+      }
+      for (const outcome of failed) {
+        actions.push(`Failed to scrub stale smoke-launcher hooks from ${outcome.filePath}: ${outcome.error}`);
+      }
+      if (repaired.length === 0 && failed.length === 0) {
+        actions.push('No stale smoke-launcher hooks remained to scrub');
+      }
+    } catch (err) {
+      actions.push(`Smoke-launcher scrub failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    return actions;
+  },
+
+  // Migration retry — re-run the project-local → global walker. The
+  // walker is the same code path the daemon's first-start bootstrap
+  // uses; the audit-log writer deduplicates so previously-erroring
+  // projects that now succeed have their error rows dropped, and
+  // projects still failing get their error rows refreshed in place.
+  //
+  // Walks the full set rather than per-project so the audit log stays
+  // consistent — a project that succeeds this pass has its prior error
+  // row removed, not preserved alongside the new outcome.
+  'migration-retry': async (_ctx, matched) => {
+    const actions: string[] = [];
+    try {
+      const { runGlobalInstallMigrationPass } = await import('../grove/global-install-migration.js');
+      const { recordMigrationPass } = await import('../db/queries/migration-log.js');
+      const { getDatabase } = await import('../db/client.js');
+      const beforeRoots = new Set<string>();
+      for (const check of matched) {
+        const root = check.fixData?.projectRoot;
+        if (typeof root === 'string' && root.length > 0) beforeRoots.add(root);
+      }
+      const result = runGlobalInstallMigrationPass();
+      recordMigrationPass(getDatabase(), result);
+      const errorsByRoot = new Map<string, string>();
+      for (const outcome of result.outcomes) {
+        if (outcome.error) errorsByRoot.set(outcome.projectRoot, outcome.error);
+      }
+      for (const root of beforeRoots) {
+        if (errorsByRoot.has(root)) {
+          actions.push(`Retried migration for ${root}: still failing: ${errorsByRoot.get(root)}`);
+        } else {
+          actions.push(`Retried migration for ${root}: succeeded`);
+        }
+      }
+    } catch (err) {
+      actions.push(`Migration retry failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    return actions;
+  },
+
+  // Reinstall the daemon service unit. Covers both Service failure
+  // modes — not installed, and installed-but-executable-missing. Runs
+  // once even when both checks matched.
+  'service-reinstall': async () => {
+    const { detectInstallVariant, resolveServiceExecutable, assertSafeServiceMutation } = await import('./service.js');
+    const { buildServiceSpec } = await import('../service/spec-builder.js');
+    const { getServiceManager } = await import('../service/manager.js');
+    const { serviceLabel } = await import('../service/labels.js');
+
+    const variant = detectInstallVariant();
+    const refusal = assertSafeServiceMutation({ action: 'install', variant }, process.execPath);
+    if (refusal) return [refusal];
+
+    // The 'executable missing' check fires precisely when the recorded
+    // command is gone, and buildServiceSpec throws on a missing path —
+    // fall back to the running binary.
+    let executable = resolveServiceExecutable(variant);
+    if (!fs.existsSync(executable)) executable = process.execPath;
+
+    let spec: import('../service/types.js').ServiceSpec;
+    try {
+      spec = buildServiceSpec({ variant, executable });
+    } catch (err) {
+      return [err instanceof Error ? err.message : String(err)];
+    }
+    const mgr = getServiceManager();
+    const label = serviceLabel(variant);
+    // A throwing manager must surface as a failed action, not escape
+    // fix() — an uncaught throw would discard the other fixers' action
+    // reports and skip the post-fix recheck.
+    try {
+      await mgr.install(spec, { force: true });
+      await mgr.start(label);
+    } catch (err) {
+      return [`Service reinstall failed: ${err instanceof Error ? err.message : String(err)}`];
+    }
+    return [`Reinstalled ${label} service and started it`];
+  },
+
+  // Re-run global symbiont detection, which rewrites every Myco-owned
+  // hook group in every detected agent's global config. Foreign hook
+  // groups are untouched — a partial fix is expected for files mixing
+  // Myco-owned and foreign groups.
+  'symbiont-global-refresh': async () => {
+    const { runSymbiontDetection } = await import('./bootstrap.js');
+    runSymbiontDetection();
+    return ['Re-ran global symbiont config refresh (rewrites Myco-owned hook groups)'];
+  },
+};

--- a/packages/myco/src/cli/doctor.ts
+++ b/packages/myco/src/cli/doctor.ts
@@ -23,6 +23,7 @@ import { isMycoHookGroup } from '../symbionts/install-helpers.js';
 import { manifestToolTransport } from '../symbionts/capabilities.js';
 import { expandHome } from '../grove/paths.js';
 import type { ServiceStatus } from '../service/types.js';
+import { DOCTOR_FIXERS, type DoctorFixContext, type DoctorFixerId } from './doctor-fixes.js';
 
 // --- Named constants (no magic literals) ---
 
@@ -50,6 +51,18 @@ export interface DoctorCheck {
   status: 'ok' | 'fail' | 'warn';
   detail: string;
   fixable: boolean;
+  fixId?: import('./doctor-fixes.js').DoctorFixerId;
+  fixData?: Record<string, unknown>;
+}
+
+/** Build a fixable check bound to its registry fixer. The only way a check
+ *  becomes fixable — `fix()` dispatches on `fixId`, never on detail text. */
+function fixableCheck(
+  base: Omit<DoctorCheck, 'fixable' | 'fixId'>,
+  fixId: DoctorFixerId,
+  fixData?: Record<string, unknown>,
+): DoctorCheck {
+  return { ...base, fixable: true, fixId, ...(fixData ? { fixData } : {}) };
 }
 
 // --- Checks ---
@@ -446,19 +459,18 @@ async function checkDaemon(vaultDir: string): Promise<DoctorCheck> {
     if (!state) {
       // readDaemonState returns null (it never throws) when the file is
       // unreadable, unparseable, or fails shape validation — the
-      // malformed-state case `fix()` repairs via deleteIfMalformed. The
-      // 'parse error' wording is the contract fix() keys on.
-      return { name: 'Daemon', status: 'fail', detail: 'daemon state parse error: daemon.json exists but is unreadable or malformed', fixable: true };
+      // malformed-state case the registry repairs via deleteIfMalformed.
+      return fixableCheck({ name: 'Daemon', status: 'fail', detail: 'daemon state parse error: daemon.json exists but is unreadable or malformed' }, 'daemon-malformed');
     }
     if (!state.pid) {
-      return { name: 'Daemon', status: 'warn', detail: 'daemon state exists but no PID', fixable: true };
+      return { name: 'Daemon', status: 'warn', detail: 'daemon state exists but records no PID — restart the daemon (`myco restart`) to rewrite it', fixable: false };
     }
     if (isProcessAlive(state.pid)) {
       return { name: 'Daemon', status: 'ok', detail: `PID ${state.pid}, port ${state.port ?? 'unknown'}`, fixable: false };
     }
-    return { name: 'Daemon', status: 'warn', detail: `Stale daemon.json (PID ${state.pid} not running)`, fixable: true };
+    return fixableCheck({ name: 'Daemon', status: 'warn', detail: `Stale daemon.json (PID ${state.pid} not running)` }, 'daemon-stale', { stalePid: state.pid });
   } catch (err) {
-    return { name: 'Daemon', status: 'fail', detail: `daemon state parse error: ${(err as Error).message}`, fixable: true };
+    return fixableCheck({ name: 'Daemon', status: 'fail', detail: `daemon state parse error: ${(err as Error).message}` }, 'daemon-malformed');
   }
 }
 
@@ -469,20 +481,18 @@ export function evaluateServiceCheck(
   expectedExecutable: string,
 ): DoctorCheck {
   if (!status.installed) {
-    return {
+    return fixableCheck({
       name: 'Service',
       status: 'warn',
       detail: `${label} not installed — run \`myco service install\` to auto-start at login`,
-      fixable: true,
-    };
+    }, 'service-reinstall');
   }
   if (!fs.existsSync(expectedExecutable)) {
-    return {
+    return fixableCheck({
       name: 'Service',
       status: 'fail',
       detail: `${label} executable not found: ${expectedExecutable} (last exit code ${status.lastExitCode ?? 'unknown'} — EX_CONFIG=78 means stale path) — run \`myco service install\` to repair`,
-      fixable: true,
-    };
+    }, 'service-reinstall');
   }
   if (status.lastExitCode !== null && status.lastExitCode !== 0) {
     return {
@@ -639,8 +649,9 @@ export async function checkSymbiontEdgeCases(): Promise<DoctorCheck[]> {
   const checks: DoctorCheck[] = [];
   const home = process.env.HOME ?? '/';
   let isFirst = true;
-  const emit = (status: DoctorCheck['status'], detail: string, fixable = false): void => {
-    checks.push({ name: isFirst ? 'Edge cases' : '', status, detail, fixable });
+  const emit = (status: DoctorCheck['status'], detail: string, fix?: { id: DoctorFixerId; data?: Record<string, unknown> }): void => {
+    const base = { name: isFirst ? 'Edge cases' : '', status, detail };
+    checks.push(fix ? fixableCheck(base, fix.id, fix.data) : { ...base, fixable: false });
     isFirst = false;
   };
 
@@ -659,7 +670,11 @@ export async function checkSymbiontEdgeCases(): Promise<DoctorCheck[]> {
       }
     }
     if (commands.some((cmd) => /cd\s+"\$\{[A-Z_]+:-\.\}"\s*&&/.test(cmd))) {
-      emit('fail', `Cursor hooks contain a shell-cd prefix at ${cursorHooks} — drops stdin and breaks capture. Run \`myco doctor --fix\` to rewrite.`);
+      // Not fixable: this flags the LEGACY ~/.cursor/settings.json target,
+      // but current installs write ~/.cursor/hooks.json — the global
+      // symbiont refresh leaves settings.json untouched, so advertising
+      // --fix here would report "Fixed:" against a still-failing recheck.
+      emit('fail', `Cursor hooks contain a shell-cd prefix at ${cursorHooks} — drops stdin and breaks capture. Remove the Myco hook groups from ~/.cursor/settings.json by hand (legacy file — current installs use hooks.json), then run \`myco update\`.`);
     }
   } catch { /* file absent or malformed */ }
 
@@ -675,7 +690,7 @@ export async function checkSymbiontEdgeCases(): Promise<DoctorCheck[]> {
       }
     }
     if (missing.length > 0) {
-      emit('fail', `Claude hook groups missing \`matcher\` field (Cursor cross-parser rejects whole file): ${missing.join(', ')}. Run \`myco doctor --fix\` to rewrite.`);
+      emit('fail', `Claude hook groups missing \`matcher\` field (Cursor cross-parser rejects whole file): ${missing.join(', ')}. Run \`myco doctor --fix\` to rewrite. Myco-owned groups are rewritten by --fix; foreign groups need manual edits.`, { id: 'symbiont-global-refresh' });
     }
   } catch { /* missing or malformed — checkAgents covers parse failure */ }
 
@@ -685,7 +700,7 @@ export async function checkSymbiontEdgeCases(): Promise<DoctorCheck[]> {
     for (const target of listEscapedSmokeLauncherTargets(home)) {
       const outcome = scrubEscapedSmokeLaunchers(target, { apply: false });
       if (outcome.error || outcome.entriesRemoved === 0) continue;
-      emit('warn', `Stale escaped smoke-launcher hooks in ${target} (${outcome.entriesRemoved} group(s)). Run \`myco doctor --fix\` to scrub them.`, true);
+      emit('warn', `Stale escaped smoke-launcher hooks in ${target} (${outcome.entriesRemoved} group(s)). Run \`myco doctor --fix\` to scrub them.`, { id: 'smoke-launcher-scrub' });
     }
   } catch { /* best effort */ }
 
@@ -694,7 +709,7 @@ export async function checkSymbiontEdgeCases(): Promise<DoctorCheck[]> {
   try {
     const raw = fs.readFileSync(codexConfig, 'utf-8').trim();
     if (raw.startsWith('{')) {
-      emit('fail', `${codexConfig} starts with JSON, not TOML. Codex silently disables hooks. Run \`myco doctor --fix\` to rewrite.`);
+      emit('fail', `${codexConfig} starts with JSON, not TOML. Codex silently disables hooks. Restore valid TOML by hand (the installer never converts JSON to TOML), then run \`myco update\`.`);
     }
   } catch { /* absent — fine */ }
 
@@ -777,12 +792,11 @@ export async function checkMigrationStatus(vaultDir: string): Promise<DoctorChec
             message = parsed.error;
           }
         } catch { /* malformed row — fall through with default message */ }
-        out.push({
+        out.push(fixableCheck({
           name: isFirst ? 'Migration' : '',
           status: 'warn',
           detail: `Migration failed for project ${root}: ${message}. Retry with \`myco doctor --fix\`.`,
-          fixable: true,
-        });
+        }, 'migration-retry', { projectRoot: root }));
         isFirst = false;
       }
       return out;
@@ -808,115 +822,30 @@ export async function checkMigrationStatus(vaultDir: string): Promise<DoctorChec
   }
 }
 
-/** Auto-repair fixable issues. Returns descriptions of actions taken. */
+/** Auto-repair fixable issues. Returns descriptions of actions taken.
+ *
+ * Dispatch is registry-driven: every non-ok check carrying a `fixId` is
+ * grouped under its fixer, and each present fixer runs exactly once with
+ * its matched checks. Checks without a `fixId` are never dispatched —
+ * there is no detail-text matching here.
+ */
 export async function fix(vaultDir: string, checks: DoctorCheck[]): Promise<string[]> {
-  const actions: string[] = [];
   const service = resolveDaemonServiceState(vaultDir, { env: process.env });
   const authority = createDaemonStateAuthority(service, doctorLogger());
+  const ctx: DoctorFixContext = { vaultDir, authority };
 
+  const byId = new Map<DoctorFixerId, DoctorCheck[]>();
   for (const check of checks) {
-    if (!check.fixable || check.status === 'ok') continue;
-
-    // Fix stale daemon.json — re-read under the authority and only
-    // unlink if the recorded pid still matches the pid we observed as
-    // dead. If a concurrent successor wrote into the gap, the unlink
-    // is a no-op and the file is preserved.
-    if (check.name === 'Daemon' && check.detail.includes('Stale')) {
-      const staleMatch = check.detail.match(/PID (\d+) not running/);
-      const stalePid = staleMatch ? Number(staleMatch[1]) : NaN;
-      if (Number.isFinite(stalePid)) {
-        const outcome = authority.deleteIfOwnedBy(stalePid, { reason: 'doctor:stale' });
-        actions.push(
-          outcome === 'deleted'
-            ? `Removed stale daemon state (PID ${stalePid})`
-            : `Daemon state already refreshed by a successor (was PID ${stalePid}) — no action`,
-        );
-      }
-    }
-
-    // Fix malformed daemon.json — by definition the file was unparseable
-    // when the check ran. The authority re-reads under the same
-    // discipline: if a successor refreshed the file between detection
-    // and fix, leave it alone.
-    if (check.name === 'Daemon' && check.detail.includes('parse error')) {
-      const outcome = authority.deleteIfMalformed({ reason: 'doctor:malformed' });
-      actions.push(
-        outcome === 'deleted'
-          ? 'Removed malformed daemon state'
-          : 'Daemon state already refreshed by a successor — no action',
-      );
-    }
-
-    // Advise on database issues — the daemon initializes the DB on
-    // first start, so restarting it is the canonical recovery path.
-    if (check.name === 'Database' && check.status === 'fail') {
-      actions.push('Start the Myco daemon (`myco service start`) to initialize the database');
-    }
+    if (check.status === 'ok' || !check.fixId) continue;
+    const matched = byId.get(check.fixId);
+    if (matched) matched.push(check);
+    else byId.set(check.fixId, [check]);
   }
 
-  // Migration retry — re-run the project-local → global walker. The
-  // walker is the same code path the daemon's first-start bootstrap
-  // uses; the audit-log writer deduplicates so previously-erroring
-  // projects that now succeed have their error rows dropped, and
-  // projects still failing get their error rows refreshed in place.
-  //
-  // Driven by the presence of any fixable Migration check (surfaced by
-  // checkMigrationStatus). Walks the full set rather than per-project
-  // so the audit log stays consistent — a project that succeeds this
-  // pass has its prior error row removed, not preserved alongside the
-  // new outcome.
-  const staleSmokeChecks = checks.filter(
-    (c) => c.fixable && c.detail.includes('Stale escaped smoke-launcher hooks'),
-  );
-  if (staleSmokeChecks.length > 0) {
-    try {
-      const { runGlobalConfigMigration } = await import('../grove/global-config-migration.js');
-      const result = runGlobalConfigMigration();
-      const repaired = result.outcomes.filter((outcome) => outcome.entriesRemoved > 0 && !outcome.error);
-      const failed = result.outcomes.filter((outcome) => outcome.entriesRemoved > 0 && outcome.error);
-      for (const outcome of repaired) {
-        actions.push(`Scrubbed ${outcome.entriesRemoved} stale smoke-launcher hook group(s) from ${outcome.filePath}`);
-      }
-      for (const outcome of failed) {
-        actions.push(`Failed to scrub stale smoke-launcher hooks from ${outcome.filePath}: ${outcome.error}`);
-      }
-      if (repaired.length === 0 && failed.length === 0) {
-        actions.push('No stale smoke-launcher hooks remained to scrub');
-      }
-    } catch (err) {
-      actions.push(`Smoke-launcher scrub failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
+  const actions: string[] = [];
+  for (const [fixId, matched] of byId) {
+    actions.push(...await DOCTOR_FIXERS[fixId](ctx, matched));
   }
-
-  const migrationChecks = checks.filter((c) => c.name === 'Migration' && c.fixable);
-  if (migrationChecks.length > 0) {
-    try {
-      const { runGlobalInstallMigrationPass } = await import('../grove/global-install-migration.js');
-      const { recordMigrationPass } = await import('../db/queries/migration-log.js');
-      const { getDatabase } = await import('../db/client.js');
-      const beforeRoots = new Set<string>();
-      for (const c of migrationChecks) {
-        const match = c.detail.match(/project ([^:]+):/);
-        if (match) beforeRoots.add(match[1]!);
-      }
-      const result = runGlobalInstallMigrationPass();
-      recordMigrationPass(getDatabase(), result);
-      const errorsByRoot = new Map<string, string>();
-      for (const outcome of result.outcomes) {
-        if (outcome.error) errorsByRoot.set(outcome.projectRoot, outcome.error);
-      }
-      for (const root of beforeRoots) {
-        if (errorsByRoot.has(root)) {
-          actions.push(`Retried migration for ${root}: still failing: ${errorsByRoot.get(root)}`);
-        } else {
-          actions.push(`Retried migration for ${root}: succeeded`);
-        }
-      }
-    } catch (err) {
-      actions.push(`Migration retry failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }
-
   return actions;
 }
 

--- a/tests/cli/doctor-fixes.test.ts
+++ b/tests/cli/doctor-fixes.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { FakeServiceManager } from '../helpers/fake-service-manager.js';
+import { sandboxMycoHome } from '../helpers/myco-home-sandbox.js';
+import type { ServiceVariant } from '@myco/service/types';
+
+// Service-manager calls must NEVER hit real launchctl/systemctl from a
+// test — route everything to the shared fake.
+let fakeServiceManager = new FakeServiceManager();
+mock.module('@myco/service/manager.js', () => ({
+  getServiceManager: () => fakeServiceManager,
+}));
+
+// Drive the cli/service.js seams per-scenario through mutable handles.
+let refusal: string | null = null;
+let resolvedExecutable = '';
+mock.module('@myco/cli/service.js', () => ({
+  detectInstallVariant: (): ServiceVariant => 'prod',
+  resolveServiceExecutable: () => resolvedExecutable,
+  assertSafeServiceMutation: () => refusal,
+}));
+
+// Capture the executable handed to buildServiceSpec — the real builder
+// throws on bun/node basenames (which process.execPath is under the test
+// runner), and the fallback contract is exactly what these tests assert.
+const builtSpecs: Array<{ variant: ServiceVariant; executable: string }> = [];
+mock.module('@myco/service/spec-builder.js', () => ({
+  buildServiceSpec: (opts: { variant: ServiceVariant; executable: string }) => {
+    builtSpecs.push({ variant: opts.variant, executable: opts.executable });
+    return {
+      label: 'co.goondocks.myco',
+      executable: opts.executable,
+      args: ['daemon'],
+      env: {},
+    };
+  },
+}));
+
+describe('DOCTOR_FIXERS service-reinstall', () => {
+  let sandbox: ReturnType<typeof sandboxMycoHome>;
+
+  beforeEach(() => {
+    sandbox = sandboxMycoHome('myco-doctor-fixes-');
+    fakeServiceManager = new FakeServiceManager();
+    refusal = null;
+    resolvedExecutable = '';
+    builtSpecs.length = 0;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  async function runServiceReinstall(): Promise<string[]> {
+    const { DOCTOR_FIXERS } = await import('@myco/cli/doctor-fixes');
+    const { createDaemonStateAuthority } = await import('@myco/daemon/daemon-state-authority.js');
+    const { resolveDaemonServiceState } = await import('@myco/daemon/service-state.js');
+    const vaultDir = '/tmp/unused';
+    const ctx = {
+      vaultDir,
+      authority: createDaemonStateAuthority(
+        resolveDaemonServiceState(vaultDir, { env: process.env }),
+        { info: () => {} },
+      ),
+    };
+    return DOCTOR_FIXERS['service-reinstall'](ctx, [{
+      name: 'Service',
+      status: 'fail',
+      detail: 'co.goondocks.myco executable not found',
+      fixable: true,
+      fixId: 'service-reinstall',
+    }]);
+  }
+
+  it('stops at the safety refusal without touching the service manager', async () => {
+    refusal = 'Refusing to install the *prod* service from a dev-build binary';
+    const actions = await runServiceReinstall();
+
+    expect(actions).toEqual([refusal]);
+    expect(fakeServiceManager.installCalls).toHaveLength(0);
+    expect(fakeServiceManager.startCalls).toHaveLength(0);
+    expect(builtSpecs).toHaveLength(0);
+  });
+
+  it('falls back to process.execPath when the resolved executable is missing, then installs and starts', async () => {
+    resolvedExecutable = path.join(os.tmpdir(), `myco-gone-${Date.now()}`, 'myco');
+    expect(fs.existsSync(resolvedExecutable)).toBe(false);
+
+    const actions = await runServiceReinstall();
+
+    expect(builtSpecs).toHaveLength(1);
+    expect(builtSpecs[0]!.executable).toBe(process.execPath);
+    expect(builtSpecs[0]!.variant).toBe('prod');
+    expect(fakeServiceManager.installCalls).toHaveLength(1);
+    expect(fakeServiceManager.installOptions[0]).toEqual({ force: true });
+    expect(fakeServiceManager.startCalls).toEqual(['co.goondocks.myco']);
+    expect(actions).toEqual(['Reinstalled co.goondocks.myco service and started it']);
+  });
+
+  it('reports a throwing service manager as a failed action instead of escaping fix()', async () => {
+    // A manager whose install throws must surface as an action string —
+    // an escaped throw would discard other fixers' reports and skip the
+    // post-fix recheck.
+    fakeServiceManager.install = async () => {
+      throw new Error('launchctl bootstrap failed: Input/output error');
+    };
+
+    const actions = await runServiceReinstall();
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toContain('Service reinstall failed');
+    expect(actions[0]).toContain('launchctl bootstrap failed: Input/output error');
+    expect(fakeServiceManager.startCalls).toHaveLength(0);
+  });
+
+  it('uses the resolved executable directly when it exists on disk', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-doctor-fixes-bin-'));
+    try {
+      resolvedExecutable = path.join(dir, 'myco');
+      fs.writeFileSync(resolvedExecutable, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+
+      const actions = await runServiceReinstall();
+
+      expect(builtSpecs).toHaveLength(1);
+      expect(builtSpecs[0]!.executable).toBe(resolvedExecutable);
+      expect(fakeServiceManager.installCalls).toHaveLength(1);
+      expect(actions).toEqual(['Reinstalled co.goondocks.myco service and started it']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -148,6 +148,74 @@ describe('doctor exit codes', () => {
   });
 });
 
+describe('doctor fix registry dispatch', () => {
+  let vaultDir: string;
+  let mycoHome: string;
+  let savedMycoHome: string | undefined;
+
+  beforeEach(() => {
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-doctor-registry-'));
+    mycoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-doctor-registry-home-'));
+    savedMycoHome = process.env.MYCO_HOME;
+    process.env.MYCO_HOME = mycoHome;
+  });
+
+  afterEach(() => {
+    fs.rmSync(vaultDir, { recursive: true, force: true });
+    fs.rmSync(mycoHome, { recursive: true, force: true });
+    if (savedMycoHome === undefined) delete process.env.MYCO_HOME;
+    else process.env.MYCO_HOME = savedMycoHome;
+  });
+
+  it('takes no action for a fixable check that carries no fixId — the registry is the only dispatch path', async () => {
+    const actions = await fix(vaultDir, [{
+      name: 'Daemon',
+      status: 'warn',
+      detail: 'Stale daemon.json (PID 424242 not running)',
+      fixable: true,
+    }]);
+    expect(actions).toEqual([]);
+  });
+
+  it('reports a daemon state with no PID as not fixable (restart rewrites it)', async () => {
+    const statePath = resolveDaemonServiceState(vaultDir, { env: process.env }).statePath;
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, JSON.stringify({ pid: 0, port: 12345 }), 'utf-8');
+
+    const checks = await runChecks(vaultDir);
+    const daemon = checks.find((c) => c.name === 'Daemon');
+    expect(daemon).toBeDefined();
+    expect(daemon!.status).toBe('warn');
+    expect(daemon!.fixable).toBe(false);
+    expect(daemon!.fixId).toBeUndefined();
+    expect(daemon!.detail).toContain('records no PID');
+  });
+
+  it('daemon-stale fixer deletes via fixData.stalePid even when the detail omits the PID text', async () => {
+    const statePath = resolveDaemonServiceState(vaultDir, { env: process.env }).statePath;
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, JSON.stringify({ pid: 424242, port: 1 }), 'utf-8');
+
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const actions = await fix(vaultDir, [{
+        name: 'Daemon',
+        status: 'warn',
+        // Deliberately no "PID <n> not running" text — proves the fixer
+        // reads structured fixData, not a detail regex.
+        detail: 'Stale daemon state',
+        fixable: true,
+        fixId: 'daemon-stale',
+        fixData: { stalePid: 424242 },
+      }]);
+      expect(actions).toContain('Removed stale daemon state (PID 424242)');
+    } finally {
+      errorSpy.mockRestore();
+    }
+    expect(fs.existsSync(statePath)).toBe(false);
+  });
+});
+
 describe('Edge-case detector (R4.7)', () => {
   async function withFakeHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-doctor-edge-'));
@@ -213,6 +281,54 @@ describe('Edge-case detector (R4.7)', () => {
       const rows = await checkSymbiontEdgeCases();
       const warnings = rows.filter((c) => c.status === 'warn');
       expect(warnings.some((c) => c.fixable && c.detail.includes('Stale escaped smoke-launcher hooks'))).toBe(true);
+    });
+  });
+
+  it('keeps the cursor shell-cd row non-fixable (legacy settings.json — the global refresh writes hooks.json)', async () => {
+    await withFakeHome(async (home) => {
+      const cursor = path.join(home, '.cursor', 'settings.json');
+      fs.mkdirSync(path.dirname(cursor), { recursive: true });
+      fs.writeFileSync(cursor, JSON.stringify({
+        hooks: { sessionStart: [{ command: 'cd "${CURSOR_PROJECT_DIR:-.}" && node /Users/me/.myco/launcher.cjs hook session-start --symbiont cursor' }] },
+      }), 'utf-8');
+      const rows = await checkSymbiontEdgeCases();
+      const row = rows.find((c) => c.detail.includes('shell-cd prefix'));
+      expect(row).toBeDefined();
+      expect(row!.fixable).toBe(false);
+      expect(row!.fixId).toBeUndefined();
+      expect(row!.detail).not.toContain('--fix');
+      expect(row!.detail).toContain('legacy file — current installs use hooks.json');
+    });
+  });
+
+  it('marks the claude matcher row fixable and notes foreign groups need manual edits', async () => {
+    await withFakeHome(async (home) => {
+      const claude = path.join(home, '.claude', 'settings.json');
+      fs.mkdirSync(path.dirname(claude), { recursive: true });
+      fs.writeFileSync(claude, JSON.stringify({
+        hooks: { SessionStart: [{ hooks: [{ command: 'node x' }] }] }, // missing matcher
+      }), 'utf-8');
+      const rows = await checkSymbiontEdgeCases();
+      const row = rows.find((c) => c.detail.includes('missing `matcher`'));
+      expect(row).toBeDefined();
+      expect(row!.fixable).toBe(true);
+      expect(row!.fixId).toBe('symbiont-global-refresh');
+      expect(row!.detail).toContain('foreign groups need manual edits');
+    });
+  });
+
+  it('keeps the hybrid-TOML codex row non-fixable and no longer suggests doctor --fix', async () => {
+    await withFakeHome(async (home) => {
+      const codex = path.join(home, '.codex', 'config.toml');
+      fs.mkdirSync(path.dirname(codex), { recursive: true });
+      fs.writeFileSync(codex, '{\n  "hooks": {}\n}\n', 'utf-8');
+      const rows = await checkSymbiontEdgeCases();
+      const row = rows.find((c) => c.detail.includes('starts with JSON'));
+      expect(row).toBeDefined();
+      expect(row!.fixable).toBe(false);
+      expect(row!.fixId).toBeUndefined();
+      expect(row!.detail).not.toContain('doctor --fix');
+      expect(row!.detail).toContain('Restore valid TOML by hand');
     });
   });
 
@@ -342,6 +458,7 @@ describe('doctor --fix stale smoke-launcher scrub', () => {
         status: 'warn',
         detail: `Stale escaped smoke-launcher hooks in ${claude} (1 group(s)). Run \`myco doctor --fix\` to scrub them.`,
         fixable: true,
+        fixId: 'smoke-launcher-scrub',
       }]);
 
       expect(actions.some((action) => action.includes('Scrubbed 1 stale smoke-launcher hook group'))).toBe(true);
@@ -430,6 +547,8 @@ describe('doctor --fix migration retry', () => {
         status: 'warn',
         detail: `Migration failed for project ${projectRoot}: EBUSY: resource busy (transient). Retry with \`myco doctor --fix\`.`,
         fixable: true,
+        fixId: 'migration-retry',
+        fixData: { projectRoot },
       };
 
       const actions = await fix(path.join(projectRoot, '.myco'), [stuckCheck]);


### PR DESCRIPTION
## What

Kills the `fixable`/`fix()` drift class in `myco doctor` (backlog `d9eeb0a186e720d8` item RC-14b): a single typed registry (`DOCTOR_FIXERS` keyed by `DoctorFixerId`) replaces inline `fixable: true` literals and name+detail-substring dispatch. A check can only advertise a fix that exists (`fixId` is typed `keyof` the registry — compile error otherwise), fixers receive structured `fixData` instead of regex-parsing human prose, and `fix()` is a pure group-by-fixId dispatch.

## Drift instances resolved

| Site | Before | After |
|---|---|---|
| Daemon stale / malformed | detail-substring dispatch, PID regex-parsed from prose | registry + `fixData.stalePid` |
| Daemon no-PID | advertised fixable, **no fixer existed** | honest demotion — advises `myco restart` |
| Service not-installed / exec-missing | advertised fixable, **no fixer existed** | real `service-reinstall` fixer (guard-first, exec fallback, errors-as-actions) |
| cursor-cd-cwd | message claimed `--fix`, no fixer | honest demotion — flags legacy `settings.json` that current installs (`hooks.json`) never rewrite |
| claude-matcher | message claimed `--fix`, no fixer | real `symbiont-global-refresh` fixer (Myco-owned groups; foreign groups stated as manual) |
| hybrid-TOML codex | message claimed `--fix`, no fixer | honest manual-repair message (`myco update` runs the same code path that can't convert JSON→TOML) |
| Database advice in fix() | doubly dead code (guard skipped non-fixable checks) | deleted |
| Migration retry | project roots regex-parsed (truncated Windows `C:\` paths at the colon) | `fixData.projectRoot` |

## Process

Independent code-grounded design review **before** implementation (caught: `buildServiceSpec` throws on exactly the executable-missing case → fallback required; `myco update` cannot fix hybrid-TOML since it runs the same refresh; two tests constructing checks by hand need `fixId`). Adversarial probe **after** (caught: cursor-cd-cwd fixer wrote `hooks.json` while the check flags legacy `settings.json` — proven byte-identical in a sandbox, would have shipped an infinite "Fixed"-but-failing loop; `mgr.install` throw escaped `fix()` and broke the actions→recheck contract). Both fixed in this PR.

## Verification

- Sandboxed end-to-end: real `doctor --fix` removes stale + malformed daemon.json with correct exit codes
- `bun test --isolate tests/cli/` 275/275; targeted doctor suites 44/44; `tsc --noEmit` clean
- Existing assertions preserved (doctor-service fixable expectations, message leading-substrings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)