### PR TITLE
daemon: session deletion safety — no silent resurrection, guarded deletes, phantom-cleanup can't destroy data (RC-A + RC-G)

### DIFF
--- a/packages/myco/src/daemon/api/sessions.ts
+++ b/packages/myco/src/daemon/api/sessions.ts
@@ -1,5 +1,5 @@
 import { getSession, listSessions, countSessions, deleteSessionCascade, getSessionImpact, closeSession } from '@myco/db/queries/sessions.js';
-import { listBatchesBySession, countBatchesBySession, countBatchesBySessions, getBatchById, PROMPT_BATCH_ORIGIN, type PromptBatchOrigin } from '@myco/db/queries/batches.js';
+import { listBatchesBySession, countBatchesBySession, countBatchesBySessions, getBatchById, hasHumanBatch, PROMPT_BATCH_ORIGIN, type PromptBatchOrigin } from '@myco/db/queries/batches.js';
 import { listActivitiesByBatch, countActivities, countActivitiesBySessions } from '@myco/db/queries/activities.js';
 import { listAttachmentsBySession } from '@myco/db/queries/attachments.js';
 import { deletePlan, getPlan, listPlansBySession } from '@myco/db/queries/plans.js';
@@ -189,8 +189,16 @@ export interface SessionMutationDeps {
    *  this, a stale registry entry from the deleted session causes the
    *  dispatcher to skip reconcile entirely, the defensive
    *  `ensureSessionRowExists` materializes an empty row, and the
-   *  buffered prompts are orphaned forever. */
-  registry: { unregister(sessionId: string): void };
+   *  buffered prompts are orphaned forever.
+   *
+   *  `getSession` powers the live-session delete refusal: a registry hit
+   *  means an agent connection is actively feeding this session, so an
+   *  un-forced DELETE gets a 409 instead of silently racing the live
+   *  event stream. */
+  registry: {
+    unregister(sessionId: string): void;
+    getSession(sessionId: string): unknown;
+  };
 }
 
 export function createSessionMutationHandlers(deps: SessionMutationDeps) {
@@ -201,6 +209,56 @@ export function createSessionMutationHandlers(deps: SessionMutationDeps) {
     const sessionId = req.params.id;
     const scope = projectScopeFromRequestContext(req.requestContext);
     if (!getSession(sessionId, scope)) return { status: 404, body: { error: 'Session not found' } };
+
+    const body = (req.body ?? {}) as { force?: boolean; expect_empty?: boolean };
+    // Caller provenance on every delete-path log line. The RC-G hunt was
+    // slowed by six anonymous deletes in the prod log — flags + request
+    // context make the caller identifiable from the log alone.
+    const callerFields = {
+      expect_empty: body.expect_empty === true,
+      force: body.force === true,
+      machine_id: req.requestContext?.machineId ?? null,
+      project_id: req.requestContext?.projectId ?? null,
+    };
+
+    // Phantom-delete contract (evaluated FIRST). A hook cleaning up a
+    // session a drop rule just rejected sends {expect_empty: true}: the
+    // delete proceeds only when the session holds ZERO human-origin
+    // batches. If it has real content, the caller mis-identified the
+    // session (the codex parent-id/child-transcript confusion) — refuse
+    // regardless of force; the phantom-cleanup caller must never force.
+    //
+    // Interplay with the live-session guard below: a just-registered
+    // phantom IS registry-live, so expect_empty deletes bypass the
+    // session_live 409 — emptiness is the stronger, correct guard for
+    // this caller.
+    if (body.expect_empty === true) {
+      if (hasHumanBatch(sessionId)) {
+        logger.info(LOG_KINDS.API_SESSION_DELETE, 'Session delete refused — expect_empty but session has human content', {
+          session_id: sessionId,
+          ...callerFields,
+        });
+        return { status: 409, body: {
+          error: 'session_not_empty',
+          message: 'expect_empty delete refused: this session has captured human prompts. The caller likely mis-identified a phantom session.',
+        } };
+      }
+    } else if (registry.getSession(sessionId) && body.force !== true) {
+      // Refusal-with-override, not a persistence gate: the in-memory registry
+      // stays a cache (the session-lifecycle.ts invariant is untouched) — here
+      // a cache hit only signals "an agent connection is live right now", so
+      // we refuse the destructive delete unless the caller re-sends with
+      // `{force: true}` (the handleDeletePlan force_remote precedent).
+      logger.info(LOG_KINDS.API_SESSION_DELETE, 'Session delete refused — live agent connection (re-send with force)', {
+        session_id: sessionId,
+        ...callerFields,
+      });
+      return { status: 409, body: {
+        error: 'session_live',
+        message: 'This session has a live agent connection. Deleting now permanently discards the rest of the session as it happens. Re-send with force to delete anyway.',
+      } };
+    }
+
     const result = deleteSessionCascade(sessionId, SESSION_TOMBSTONE_SOURCE.API_DELETE);
     if (!result.deleted) return { status: 404, body: { error: 'Session not found' } };
 
@@ -253,6 +311,7 @@ export function createSessionMutationHandlers(deps: SessionMutationDeps) {
     logger.info(LOG_KINDS.API_SESSION_DELETE, 'Session cascade deleted', {
       session_id: sessionId,
       counts: result.counts,
+      ...callerFields,
     });
     return { body: { ok: true, counts: result.counts } };
   }

--- a/packages/myco/src/daemon/event-dispatch.ts
+++ b/packages/myco/src/daemon/event-dispatch.ts
@@ -45,6 +45,7 @@ import { resolveProjectRoot } from '@myco/vault/resolve.js';
 import { getDatabase } from '@myco/db/client.js';
 import { getLatestBatch, toPromptBatchOrigin, type PromptBatchOrigin } from '@myco/db/queries/batches.js';
 import { getSession, updateSession, reactivateSessionIfCompleted } from '@myco/db/queries/sessions.js';
+import { hasSessionTombstone } from '@myco/db/queries/session-tombstones.js';
 import { ensureSession, ensureSessionRowExists, ENSURE_SESSION_SOURCE } from './session-lifecycle.js';
 import { captureBatchImages, type CapturedImage } from './capture-images.js';
 import { DEFAULT_SYMBIONT_NAME, epochSeconds, LOG_PROMPT_PREVIEW_CHARS } from '@myco/constants.js';
@@ -309,6 +310,19 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
         if (shouldReevaluate) {
           droppedSessions.delete(event.session_id);
         }
+        if (hasSessionTombstone(event.session_id)) {
+          // Deletion is final against passive event-driven recreation (an
+          // explicit /sessions/register deliberately supersedes — same-id
+          // reload is a supported flow). hadTranscriptMeta: true makes the
+          // cached drop permanent: a later transcript_path must not reopen
+          // resurrection for a deliberately deleted session.
+          rememberDropped(event.session_id, 'session_tombstoned', true);
+          logger.info(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Ignored event for deleted (tombstoned) session', {
+            session_id: event.session_id,
+            type: event.type,
+          });
+          return { body: { ok: true, ignored: 'session_tombstoned', persisted: false } };
+        }
         const { decision, hadTranscriptMeta } = evaluateAutoRegistration(event);
         if (decision.action === 'drop') {
           rememberDropped(event.session_id, decision.reason, hadTranscriptMeta);
@@ -334,7 +348,7 @@ export function createEventDispatcher(deps: EventDispatchDeps): RouteHandler {
           logger,
           source: event.type === 'user_prompt' ? ENSURE_SESSION_SOURCE.USER_PROMPT : ENSURE_SESSION_SOURCE.TOOL_USE,
         });
-        logger.debug(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Auto-registered session from event', { session_id: event.session_id });
+        logger.info(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Auto-registered session from event', { session_id: event.session_id });
         const autoRegisterScope = projectScopeFromRequestContext(req.requestContext);
         deferGitProvenance(
           {

--- a/packages/myco/src/daemon/session-lifecycle.ts
+++ b/packages/myco/src/daemon/session-lifecycle.ts
@@ -71,6 +71,7 @@ import type { Logger } from './logger.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { epochSeconds, DEFAULT_SYMBIONT_NAME } from '@myco/constants.js';
 import { upsertSession, getSession } from '@myco/db/queries/sessions.js';
+import { hasSessionTombstone } from '@myco/db/queries/session-tombstones.js';
 import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
 import type { SessionRegistry } from './lifecycle.js';
 
@@ -209,6 +210,18 @@ export function ensureSessionRowExists(params: EnsureSessionRowExistsParams): bo
   // PK lookup — cheap, returns null if the row is missing.
   const existing = getSession(params.sessionId, ALL_PROJECTS_SCOPE);
   if (existing) return false;
+
+  // A missing row with a deletion tombstone is deleted-on-purpose, not an
+  // upstream gap — the defensive insert must not passively resurrect it.
+  // Explicit lifecycle paths (ensureSession via /sessions/register, the
+  // reconciler) own their own gating and deliberately supersede.
+  if (hasSessionTombstone(params.sessionId)) {
+    params.logger.debug(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'ensureSessionRowExists skipped — session tombstoned', {
+      session_id: params.sessionId,
+      source: params.source,
+    });
+    return false;
+  }
 
   // The row is missing. Upstream auto-register didn't run (or threw). Log
   // loudly so the gap doesn't repeat silently, then persist a minimal

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -33,7 +33,7 @@ import {
   type PromptBatchOrigin,
 } from '@myco/db/queries/batches.js';
 import { deleteSessionCascade, getSession, updateSession } from '@myco/db/queries/sessions.js';
-import { SESSION_TOMBSTONE_SOURCE } from '@myco/db/queries/session-tombstones.js';
+import { SESSION_TOMBSTONE_SOURCE, hasSessionTombstone } from '@myco/db/queries/session-tombstones.js';
 import { resolveBufferDirForProjectId } from '@myco/capture/buffer-location.js';
 import { listSessionFileActivities } from '@myco/db/queries/activities.js';
 import { detectSkillUsage, SKILL_USAGE_DETECTION_ENABLED } from './skill-usage.js';
@@ -754,6 +754,15 @@ export function createStopProcessor(deps: StopProcessorDeps): {
           session_id: sessionId,
         });
       } else {
+        // Deletion is final against passive Stop-driven recreation: a
+        // deleted live session's next per-turn Stop must not re-register
+        // the row (an explicit /sessions/register deliberately supersedes).
+        if (hasSessionTombstone(sessionId)) {
+          logger.info(LOG_KINDS.HOOKS_STOP, 'Ignored Stop for deleted (tombstoned) session', {
+            session_id: sessionId,
+          });
+          return { body: { ok: true, ignored: 'session_tombstoned' } };
+        }
         // First-sight session — Stop is its registration event. Persist
         // the row before adding to the registry so future prompt/tool
         // events find an existing sessions.id when they reference it via
@@ -770,7 +779,7 @@ export function createStopProcessor(deps: StopProcessorDeps): {
           logger,
           source: ENSURE_SESSION_SOURCE.STOP,
         });
-        logger.debug(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Auto-registered session from stop event', {
+        logger.info(LOG_KINDS.LIFECYCLE_AUTO_REGISTER, 'Auto-registered session from stop event', {
           session_id: sessionId,
         });
       }

--- a/packages/myco/src/db/queries/batches.ts
+++ b/packages/myco/src/db/queries/batches.ts
@@ -1071,6 +1071,22 @@ export function hasAnyBatch(sessionId: string): boolean {
 }
 
 /**
+ * True if the session has at least one human-origin batch.
+ *
+ * Emptiness check behind the API's `expect_empty` phantom-delete contract:
+ * a hook cleaning up a phantom registration must only delete sessions that
+ * captured no real user content. Non-human batches (system envelopes,
+ * agent_dispatch returns) don't count — they carry no user intent.
+ */
+export function hasHumanBatch(sessionId: string): boolean {
+  const db = getDatabase();
+  const row = db.prepare(
+    `SELECT 1 AS hit FROM prompt_batches WHERE session_id = ? AND origin = ? LIMIT 1`,
+  ).get(sessionId, PROMPT_BATCH_ORIGIN.HUMAN) as { hit: number } | undefined;
+  return !!row;
+}
+
+/**
  * Count prompt batches for a session — authoritative prompt count.
  *
  * Pass `origins` to restrict the count (e.g. `['human']` to match the

--- a/packages/myco/src/hooks/user-prompt-submit.ts
+++ b/packages/myco/src/hooks/user-prompt-submit.ts
@@ -31,10 +31,22 @@ export async function main() {
     await client.ensureRunning();
 
     if (decision.action === 'drop') {
-      // Drop rule fired — cascade-delete the session row SessionStart registered.
-      // Session-maintenance sweep catches any stragglers if this request fails.
+      // Drop rule fired — cascade-delete the session row SessionStart
+      // registered, under the phantom-delete contract: {expect_empty: true}
+      // makes the daemon refuse unless the session captured zero human
+      // prompts. Guards against the codex subagent-spawn confusion where
+      // the hook receives the PARENT session_id with the CHILD's transcript
+      // — the drop rule fires correctly but sessionId names a real session.
+      // Session-maintenance sweep catches any stragglers if this request
+      // fails or is refused.
       process.stderr.write(`[myco] user-prompt-submit: dropped (${decision.reason ?? 'rule'})\n`);
-      await client.delete(`/api/sessions/${sessionId}`);
+      const deleteResult = await client.delete(`/api/sessions/${sessionId}`, { expect_empty: true });
+      if (!deleteResult.ok) {
+        const refusedNotEmpty = (deleteResult.data as { error?: string } | undefined)?.error === 'session_not_empty';
+        process.stderr.write(refusedNotEmpty
+          ? '[myco] user-prompt-submit: drop-delete refused (session has captured content) — leaving cleanup to the maintenance sweep\n'
+          : '[myco] user-prompt-submit: drop-delete did not complete (transport or lookup failure) — leaving cleanup to the maintenance sweep\n');
+      }
       writeHookResponse(symbiont, 'user-prompt-submit');
       return;
     }

--- a/packages/myco/ui/src/components/sessions/SessionDetail.tsx
+++ b/packages/myco/ui/src/components/sessions/SessionDetail.tsx
@@ -17,6 +17,7 @@ import { CanopyEfficiencyTile } from './CanopyEfficiencyTile';
 import { ReleaseStateBadge } from '../release-state/ReleaseStateBadge';
 import { StatusBadge } from './status-helpers';
 import { formatTimeAgo, formatDuration as formatDurationSec, shortSession } from '../../lib/format';
+import { ApiError } from '../../lib/api';
 import { cn } from '../../lib/cn';
 
 /* ---------- Helpers ---------- */
@@ -109,6 +110,9 @@ export function SessionDetail({ id }: SessionDetailProps) {
   const completeSession = useCompleteSession();
   const [summaryStatus, setSummaryStatus] = useState<'idle' | 'running' | 'done' | 'error'>('idle');
   const [deleteOpen, setDeleteOpen] = useState(false);
+  // Second-stage confirm: set when the daemon refused the delete with 409
+  // session_live; the next confirm retries with force.
+  const [liveConfirm, setLiveConfirm] = useState(false);
 
   // Read initial tab and plan from URL query params (e.g., ?tab=plans&plan=123)
   const [activeTab, setActiveTab] = useState<TabValue>(() => {
@@ -320,9 +324,11 @@ export function SessionDetail({ id }: SessionDetailProps) {
 
       <ConfirmDialog
         open={deleteOpen}
-        onOpenChange={setDeleteOpen}
+        onOpenChange={(open) => { setDeleteOpen(open); if (!open) setLiveConfirm(false); }}
         title="Delete Session"
-        description="This will permanently remove this session and all related data. This action cannot be undone."
+        description={liveConfirm
+          ? 'Session appears live — the agent is still running. Deleting now permanently discards the rest of the session as it happens. Delete anyway?'
+          : 'This will permanently remove this session and all related data. This action cannot be undone.'}
         icon={<Trash2 className="h-4 w-4 text-tertiary" />}
         meta={session ? [
           { label: 'ID', value: shortSession(session.id) },
@@ -334,13 +340,23 @@ export function SessionDetail({ id }: SessionDetailProps) {
           { label: 'Attachments', value: impact.attachmentCount },
           { label: 'Graph Edges', value: impact.graphEdgeCount },
         ] : []}
-        confirmLabel="Delete Session"
+        confirmLabel={liveConfirm ? 'Delete Anyway' : 'Delete Session'}
         variant="destructive"
         onConfirm={() => {
-          deleteSession.mutate(session!.id, {
+          deleteSession.mutate({ id: session!.id, force: liveConfirm }, {
             onSuccess: () => {
               setDeleteOpen(false);
+              setLiveConfirm(false);
               navigate('/sessions');
+            },
+            onError: (err) => {
+              if (
+                err instanceof ApiError &&
+                err.status === 409 &&
+                (err.body as { error?: string } | null)?.error === 'session_live'
+              ) {
+                setLiveConfirm(true);
+              }
             },
           });
         }}

--- a/packages/myco/ui/src/components/sessions/SessionList.tsx
+++ b/packages/myco/ui/src/components/sessions/SessionList.tsx
@@ -7,6 +7,7 @@ import { Pagination } from '../ui/pagination';
 import { StatusDot, type StatusTone } from '../ui/status-dot';
 import { ActivitySparkline } from '../ui/sparkline';
 import { useSessions, useDeleteSession, useSessionImpact, type SessionSummary } from '../../hooks/use-sessions';
+import { ApiError } from '../../lib/api';
 import { useSymbionts } from '../../hooks/use-symbionts';
 import { DEFAULT_PAGE_SIZE } from '../../lib/constants';
 import { shortSession, formatEpochAgo } from '../../lib/format';
@@ -170,6 +171,9 @@ export function SessionList({
   const navigate = useNavigate();
   const location = useLocation();
   const [deleteTarget, setDeleteTarget] = useState<SessionSummary | null>(null);
+  // Second-stage confirm: set when the daemon refused the delete with 409
+  // session_live; the next confirm retries with force.
+  const [liveConfirm, setLiveConfirm] = useState(false);
   const deleteSession = useDeleteSession();
   const { data: impact } = useSessionImpact(deleteTarget?.id ?? null);
   const { data: symbiontsData } = useSymbionts();
@@ -199,8 +203,20 @@ export function SessionList({
 
   function handleDeleteConfirm() {
     if (!deleteTarget) return;
-    deleteSession.mutate(deleteTarget.id, {
-      onSuccess: () => setDeleteTarget(null),
+    deleteSession.mutate({ id: deleteTarget.id, force: liveConfirm }, {
+      onSuccess: () => {
+        setDeleteTarget(null);
+        setLiveConfirm(false);
+      },
+      onError: (err) => {
+        if (
+          err instanceof ApiError &&
+          err.status === 409 &&
+          (err.body as { error?: string } | null)?.error === 'session_live'
+        ) {
+          setLiveConfirm(true);
+        }
+      },
     });
   }
 
@@ -363,9 +379,11 @@ export function SessionList({
 
       <ConfirmDialog
         open={deleteTarget !== null}
-        onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}
+        onOpenChange={(open) => { if (!open) { setDeleteTarget(null); setLiveConfirm(false); } }}
         title="Delete Session"
-        description="This will permanently remove this session and all related data. This action cannot be undone."
+        description={liveConfirm
+          ? 'Session appears live — the agent is still running. Deleting now permanently discards the rest of the session as it happens. Delete anyway?'
+          : 'This will permanently remove this session and all related data. This action cannot be undone.'}
         icon={<Trash2 className="h-4 w-4 text-terracotta" />}
         meta={deleteTarget ? [
           { label: 'ID', value: shortSession(deleteTarget.id) },
@@ -377,7 +395,7 @@ export function SessionList({
           { label: 'Attachments', value: impact.attachmentCount },
           { label: 'Graph Edges', value: impact.graphEdgeCount },
         ] : []}
-        confirmLabel="Delete Session"
+        confirmLabel={liveConfirm ? 'Delete Anyway' : 'Delete Session'}
         variant="destructive"
         onConfirm={handleDeleteConfirm}
         isPending={deleteSession.isPending}

--- a/packages/myco/ui/src/hooks/use-sessions.ts
+++ b/packages/myco/ui/src/hooks/use-sessions.ts
@@ -258,8 +258,13 @@ export function useSessionAttachments(sessionId: string | undefined) {
 export function useDeleteSession() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (sessionId: string) =>
-      deleteJson<{ ok: boolean; counts: Record<string, number> }>(`/sessions/${sessionId}`),
+    // `force: true` overrides the daemon's live-session refusal (409
+    // `session_live`) — callers re-send it from a second-stage confirm.
+    mutationFn: ({ id, force }: { id: string; force?: boolean }) =>
+      deleteJson<{ ok: boolean; counts: Record<string, number> }>(
+        `/sessions/${id}`,
+        force ? { force: true } : undefined,
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['sessions'] });
     },

--- a/tests/daemon/api/sessions.test.ts
+++ b/tests/daemon/api/sessions.test.ts
@@ -6,6 +6,7 @@ import os from 'node:os';
 import { initDatabase, closeDatabase } from '@myco/db/client';
 import { createSchema } from '@myco/db/schema';
 import { upsertSession, getSession } from '@myco/db/queries/sessions';
+import { insertBatch, PROMPT_BATCH_ORIGIN } from '@myco/db/queries/batches';
 import { getSessionTombstone } from '@myco/db/queries/session-tombstones.js';
 import { upsertPlan, getPlan } from '@myco/db/queries/plans';
 import { createSessionMutationHandlers, createGetSessionHandler, handleListSessions } from '@myco/daemon/api/sessions';
@@ -151,7 +152,7 @@ describe('handleCompleteSession', () => {
       logger: makeLogger() as never,
       liveConfig: liveConfig as never,
       reconciler: { clearSession: vi.fn() },
-      registry: { unregister: vi.fn() },
+      registry: { unregister: vi.fn(), getSession: vi.fn(() => undefined) },
     });
   }
 
@@ -239,7 +240,7 @@ describe('handleCompleteSession', () => {
       },
     };
     const reconcilerStub = { clearSession: vi.fn() };
-    const registryStub = { unregister: vi.fn() };
+    const registryStub = { unregister: vi.fn(), getSession: vi.fn(() => undefined) };
     const handlers = createSessionMutationHandlers({
       embeddingManager: makeEmbeddingManagerStub() as never,
       resolveEmbeddingManager: () => makeEmbeddingManagerStub() as never,
@@ -287,10 +288,221 @@ describe('handleCompleteSession', () => {
       logger: makeLogger() as never,
       liveConfig: { current: { agent: { event_tasks_enabled: false } } } as never,
       reconciler: { clearSession: vi.fn() },
-      registry: { unregister: vi.fn() },
+      registry: { unregister: vi.fn(), getSession: vi.fn(() => undefined) },
     });
     await handlers.handleDeleteSession(makeRequest({ params: { id: 'sess-cleanup-scope' } }));
     expect(seen).toBe(TEST_REQUEST_CONTEXT);
+  });
+});
+
+describe('handleDeleteSession — live-session guard', () => {
+  // RC-A: deleting a session with a live agent connection silently raced
+  // the event stream (the next event resurrected the id). The handler now
+  // refuses with 409 session_live unless the caller re-sends {force: true}
+  // — the handleDeletePlan force_remote precedent.
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-sessions-live-'));
+    const dbPath = path.join(tmpDir, 'myco.db');
+    const db = initDatabase(dbPath);
+    createSchema(db);
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeHandlers(registryStub: { unregister: ReturnType<typeof vi.fn>; getSession: ReturnType<typeof vi.fn> }) {
+    return createSessionMutationHandlers({
+      embeddingManager: makeEmbeddingManagerStub() as never,
+      resolveEmbeddingManager: () => makeEmbeddingManagerStub() as never,
+      vaultDir: tmpDir,
+      logger: makeLogger() as never,
+      liveConfig: { current: { agent: { summary_batch_interval: 5, event_tasks_enabled: false } } } as never,
+      reconciler: { clearSession: vi.fn() },
+      registry: registryStub,
+    });
+  }
+
+  it('refuses to delete a registered (live) session with 409 session_live and leaves the row intact', async () => {
+    const now = epochNow();
+    upsertSession({ id: 'sess-live-guard', agent: 'test-agent', started_at: now, created_at: now, status: 'active' });
+    const registryStub = {
+      unregister: vi.fn(),
+      getSession: vi.fn(() => ({ startedAt: new Date().toISOString() })),
+    };
+
+    const { handleDeleteSession } = makeHandlers(registryStub);
+    const res = await handleDeleteSession(makeRequest({ params: { id: 'sess-live-guard' } }));
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ error: 'session_live' });
+    expect(getSession('sess-live-guard', ALL_PROJECTS_SCOPE)).not.toBeNull();
+    expect(getSessionTombstone('sess-live-guard')).toBeNull();
+    expect(registryStub.unregister).not.toHaveBeenCalled();
+  });
+
+  it('deletes a live session when the caller re-sends {force: true} — tombstone written, registry cleared', async () => {
+    const now = epochNow();
+    upsertSession({ id: 'sess-live-forced', agent: 'test-agent', started_at: now, created_at: now, status: 'active' });
+    const registryStub = {
+      unregister: vi.fn(),
+      getSession: vi.fn(() => ({ startedAt: new Date().toISOString() })),
+    };
+
+    const { handleDeleteSession } = makeHandlers(registryStub);
+    const res = await handleDeleteSession(makeRequest({
+      params: { id: 'sess-live-forced' },
+      body: { force: true },
+    }));
+
+    expect(res.status).toBeUndefined();
+    expect(res.body).toMatchObject({ ok: true });
+    expect(getSession('sess-live-forced', ALL_PROJECTS_SCOPE)).toBeNull();
+    expect(getSessionTombstone('sess-live-forced')?.source).toBe('api_delete');
+    expect(registryStub.unregister).toHaveBeenCalledWith('sess-live-forced');
+  });
+
+  it('deletes a non-registered session without force (unchanged behavior)', async () => {
+    const now = epochNow();
+    upsertSession({ id: 'sess-not-live', agent: 'test-agent', started_at: now, created_at: now, status: 'completed' });
+    const registryStub = { unregister: vi.fn(), getSession: vi.fn(() => undefined) };
+
+    const { handleDeleteSession } = makeHandlers(registryStub);
+    const res = await handleDeleteSession(makeRequest({ params: { id: 'sess-not-live' } }));
+
+    expect(res.status).toBeUndefined();
+    expect(res.body).toMatchObject({ ok: true });
+    expect(getSession('sess-not-live', ALL_PROJECTS_SCOPE)).toBeNull();
+    expect(getSessionTombstone('sess-not-live')?.source).toBe('api_delete');
+  });
+
+  // -- RC-G: expect_empty phantom-delete contract -----------------------------
+  // The hook's drop-path cleanup sends {expect_empty: true}. Emptiness (zero
+  // human-origin batches) is the gate: an empty just-registered phantom
+  // deletes even though it is registry-live; a session with real content
+  // refuses regardless of force — the phantom-cleanup caller must never
+  // destroy captured work (the codex parent-id/child-transcript confusion).
+
+  function seedHumanBatch(sessionId: string): void {
+    const now = epochNow();
+    insertBatch({
+      session_id: sessionId,
+      origin: PROMPT_BATCH_ORIGIN.HUMAN,
+      prompt_number: 1,
+      user_prompt: 'a real captured user prompt',
+      started_at: now,
+      created_at: now,
+    });
+  }
+
+  it('expect_empty deletes an empty just-registered session even though it is registry-live', async () => {
+    const now = epochNow();
+    upsertSession({ id: 'sess-phantom-empty', agent: 'codex', started_at: now, created_at: now, status: 'active' });
+    const registryStub = {
+      unregister: vi.fn(),
+      getSession: vi.fn(() => ({ startedAt: new Date().toISOString() })),
+    };
+
+    const { handleDeleteSession } = makeHandlers(registryStub);
+    const res = await handleDeleteSession(makeRequest({
+      params: { id: 'sess-phantom-empty' },
+      body: { expect_empty: true },
+    }));
+
+    expect(res.status).toBeUndefined();
+    expect(res.body).toMatchObject({ ok: true });
+    expect(getSession('sess-phantom-empty', ALL_PROJECTS_SCOPE)).toBeNull();
+    expect(getSessionTombstone('sess-phantom-empty')?.source).toBe('api_delete');
+  });
+
+  it('expect_empty deletes a session whose only batch is SYSTEM-origin — non-human batches carry no user intent', async () => {
+    const now = epochNow();
+    upsertSession({ id: 'sess-phantom-system', agent: 'codex', started_at: now, created_at: now, status: 'active' });
+    insertBatch({
+      session_id: 'sess-phantom-system',
+      origin: PROMPT_BATCH_ORIGIN.SYSTEM,
+      prompt_number: 1,
+      user_prompt: '<skill> envelope injected by the agent',
+      started_at: now,
+      created_at: now,
+    });
+    const registryStub = {
+      unregister: vi.fn(),
+      getSession: vi.fn(() => ({ startedAt: new Date().toISOString() })),
+    };
+
+    const { handleDeleteSession } = makeHandlers(registryStub);
+    const res = await handleDeleteSession(makeRequest({
+      params: { id: 'sess-phantom-system' },
+      body: { expect_empty: true },
+    }));
+
+    expect(res.status).toBeUndefined();
+    expect(res.body).toMatchObject({ ok: true });
+    expect(getSession('sess-phantom-system', ALL_PROJECTS_SCOPE)).toBeNull();
+    expect(getSessionTombstone('sess-phantom-system')?.source).toBe('api_delete');
+  });
+
+  it('expect_empty refuses a session WITH human batches — 409 session_not_empty, row intact, no tombstone', async () => {
+    const now = epochNow();
+    upsertSession({ id: 'sess-phantom-mistaken', agent: 'codex', started_at: now, created_at: now, status: 'active' });
+    seedHumanBatch('sess-phantom-mistaken');
+    const registryStub = { unregister: vi.fn(), getSession: vi.fn(() => undefined) };
+
+    const { handleDeleteSession } = makeHandlers(registryStub);
+    const res = await handleDeleteSession(makeRequest({
+      params: { id: 'sess-phantom-mistaken' },
+      body: { expect_empty: true },
+    }));
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ error: 'session_not_empty' });
+    expect(getSession('sess-phantom-mistaken', ALL_PROJECTS_SCOPE)).not.toBeNull();
+    expect(getSessionTombstone('sess-phantom-mistaken')).toBeNull();
+    expect(registryStub.unregister).not.toHaveBeenCalled();
+  });
+
+  it('expect_empty + force still refuses when non-empty — force does not override emptiness', async () => {
+    const now = epochNow();
+    upsertSession({ id: 'sess-phantom-forced', agent: 'codex', started_at: now, created_at: now, status: 'active' });
+    seedHumanBatch('sess-phantom-forced');
+    const registryStub = { unregister: vi.fn(), getSession: vi.fn(() => undefined) };
+
+    const { handleDeleteSession } = makeHandlers(registryStub);
+    const res = await handleDeleteSession(makeRequest({
+      params: { id: 'sess-phantom-forced' },
+      body: { expect_empty: true, force: true },
+    }));
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ error: 'session_not_empty' });
+    expect(getSession('sess-phantom-forced', ALL_PROJECTS_SCOPE)).not.toBeNull();
+    expect(getSessionTombstone('sess-phantom-forced')).toBeNull();
+  });
+
+  it('plain force delete on a non-empty live session still works (operator path)', async () => {
+    const now = epochNow();
+    upsertSession({ id: 'sess-operator-force', agent: 'test-agent', started_at: now, created_at: now, status: 'active' });
+    seedHumanBatch('sess-operator-force');
+    const registryStub = {
+      unregister: vi.fn(),
+      getSession: vi.fn(() => ({ startedAt: new Date().toISOString() })),
+    };
+
+    const { handleDeleteSession } = makeHandlers(registryStub);
+    const res = await handleDeleteSession(makeRequest({
+      params: { id: 'sess-operator-force' },
+      body: { force: true },
+    }));
+
+    expect(res.status).toBeUndefined();
+    expect(res.body).toMatchObject({ ok: true });
+    expect(getSession('sess-operator-force', ALL_PROJECTS_SCOPE)).toBeNull();
+    expect(getSessionTombstone('sess-operator-force')?.source).toBe('api_delete');
+    expect(registryStub.unregister).toHaveBeenCalledWith('sess-operator-force');
   });
 });
 
@@ -319,7 +531,7 @@ describe('handleDeletePlan', () => {
       logger: makeLogger() as never,
       liveConfig: { current: { agent: { event_tasks_enabled: false } } } as never,
       reconciler: { clearSession: vi.fn() },
-      registry: { unregister: vi.fn() },
+      registry: { unregister: vi.fn(), getSession: vi.fn(() => undefined) },
     });
   }
 
@@ -415,7 +627,7 @@ describe('handleDeletePlan — machine_id ownership', () => {
       logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
       liveConfig: { current: { agent: { event_tasks_enabled: false } } } as never,
       reconciler: { clearSession: vi.fn() },
-      registry: { unregister: vi.fn() },
+      registry: { unregister: vi.fn(), getSession: vi.fn(() => undefined) },
     });
   }
 

--- a/tests/daemon/event-dispatch.test.ts
+++ b/tests/daemon/event-dispatch.test.ts
@@ -15,6 +15,7 @@ import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
 import { listGitProvenance } from '@myco/db/queries/release-provenance.js';
 import { getDatabase } from '@myco/db/client.js';
 import { EventBuffer } from '@myco/capture/buffer.js';
+import { insertSessionTombstone, SESSION_TOMBSTONE_SOURCE } from '@myco/db/queries/session-tombstones.js';
 
 import { TEST_REQUEST_CONTEXT } from '../helpers/request-context';
 function makeHandler(opts: {
@@ -673,6 +674,150 @@ describe('createEventDispatcher', () => {
       logger.close();
       fs.rmSync(vaultDir, { recursive: true, force: true });
       fs.rmSync(transcriptDir, { recursive: true, force: true });
+    });
+  });
+
+  describe('tombstone gate — deleted sessions are not passively resurrected', () => {
+    // RC-A: DELETE /api/sessions/:id on a live session used to be silently
+    // resurrected by the very next agent event (the unknown-session branch
+    // auto-registered a fresh row). A deletion tombstone makes the drop
+    // final against PASSIVE event-driven recreation; an explicit
+    // /sessions/register (same-id reload) deliberately supersedes.
+
+    function tombstone(sessionId: string): void {
+      insertSessionTombstone(getDatabase(), {
+        sessionId,
+        projectId: null,
+        source: SESSION_TOMBSTONE_SOURCE.API_DELETE,
+      });
+    }
+
+    it('ignores an event for a tombstoned unknown session and creates no row', async () => {
+      const { handler, registry, sessionBuffers, logger, vaultDir } = makeHandler();
+      const sessionId = 'tombstoned-event-001';
+      tombstone(sessionId);
+      const transcriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-tomb-'));
+      const transcriptPath = path.join(transcriptDir, `${sessionId}.jsonl`);
+      fs.writeFileSync(transcriptPath, '');
+
+      const res = await handler({
+        requestContext: TEST_REQUEST_CONTEXT,
+        body: {
+          type: 'user_prompt',
+          session_id: sessionId,
+          agent: 'claude-code',
+          transcript_path: transcriptPath,
+          prompt: 'a prompt arriving after the session was deleted',
+        },
+        query: {}, params: {}, pathname: '/events',
+      });
+
+      expect(res.body).toEqual({ ok: true, ignored: 'session_tombstoned', persisted: false });
+      expect(registry.getSession(sessionId)).toBeUndefined();
+      expect(getSession(sessionId, ALL_PROJECTS_SCOPE)).toBeNull();
+      expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(0);
+      expect(sessionBuffers.has(sessionId)).toBe(false);
+
+      logger.close();
+      fs.rmSync(vaultDir, { recursive: true, force: true });
+      fs.rmSync(transcriptDir, { recursive: true, force: true });
+    });
+
+    it('serves subsequent events from the drop cache with the same tombstone reason', async () => {
+      const { handler, logger, vaultDir } = makeHandler();
+      const sessionId = 'tombstoned-event-cached-002';
+      tombstone(sessionId);
+
+      const first = await handler({
+        requestContext: TEST_REQUEST_CONTEXT,
+        body: { type: 'user_prompt', session_id: sessionId, agent: 'claude-code', prompt: 'first event after delete' },
+        query: {}, params: {}, pathname: '/events',
+      });
+      // Different type + content so the dedup cache can't be the reason.
+      const second = await handler({
+        requestContext: TEST_REQUEST_CONTEXT,
+        body: { type: 'tool_use', session_id: sessionId, agent: 'claude-code', tool_name: 'Bash', tool_input: { command: 'pwd' } },
+        query: {}, params: {}, pathname: '/events',
+      });
+
+      expect(first.body).toEqual({ ok: true, ignored: 'session_tombstoned', persisted: false });
+      expect(second.body).toEqual({ ok: true, ignored: 'session_tombstoned', persisted: false });
+      expect(getSession(sessionId, ALL_PROJECTS_SCOPE)).toBeNull();
+
+      logger.close();
+      fs.rmSync(vaultDir, { recursive: true, force: true });
+    });
+
+    it('keeps the drop permanent when a later event newly supplies a transcript_path (no re-evaluation bypass)', async () => {
+      const { handler, logger, vaultDir } = makeHandler();
+      const sessionId = 'tombstoned-event-transcript-003';
+      tombstone(sessionId);
+      const transcriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-tomb-tx-'));
+      const transcriptPath = path.join(transcriptDir, `${sessionId}.jsonl`);
+      fs.writeFileSync(transcriptPath, '');
+
+      // First sight WITHOUT transcript meta — caches the drop.
+      await handler({
+        requestContext: TEST_REQUEST_CONTEXT,
+        body: { type: 'user_prompt', session_id: sessionId, agent: 'claude-code', prompt: 'no transcript yet' },
+        query: {}, params: {}, pathname: '/events',
+      });
+      // A transcript_path showing up later re-opens capture-rule drops, but
+      // must NOT re-open a deliberate deletion (hadTranscriptMeta: true).
+      const withTranscript = await handler({
+        requestContext: TEST_REQUEST_CONTEXT,
+        body: {
+          type: 'user_prompt',
+          session_id: sessionId,
+          agent: 'claude-code',
+          transcript_path: transcriptPath,
+          prompt: 'now I have a transcript, let me back in',
+        },
+        query: {}, params: {}, pathname: '/events',
+      });
+
+      expect(withTranscript.body).toEqual({ ok: true, ignored: 'session_tombstoned', persisted: false });
+      expect(getSession(sessionId, ALL_PROJECTS_SCOPE)).toBeNull();
+      expect(listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE })).toHaveLength(0);
+
+      logger.close();
+      fs.rmSync(vaultDir, { recursive: true, force: true });
+      fs.rmSync(transcriptDir, { recursive: true, force: true });
+    });
+
+    it('flows events again after an explicit register recreates the row (rehydrate branch — gate not consulted)', async () => {
+      const { handler, registry, logger, vaultDir } = makeHandler();
+      const sessionId = 'tombstoned-then-registered-004';
+      tombstone(sessionId);
+
+      const ignored = await handler({
+        requestContext: TEST_REQUEST_CONTEXT,
+        body: { type: 'user_prompt', session_id: sessionId, agent: 'claude-code', prompt: 'blocked while deleted' },
+        query: {}, params: {}, pathname: '/events',
+      });
+      expect(ignored.body).toEqual({ ok: true, ignored: 'session_tombstoned', persisted: false });
+
+      // Explicit POST /sessions/register recreates the row — the supported
+      // same-id-reload flow. Simulated here by the row upsert it performs.
+      const { upsertSession } = await import('@myco/db/queries/sessions.js');
+      const now = Math.floor(Date.now() / 1000);
+      upsertSession({ id: sessionId, agent: 'claude-code', status: 'active', started_at: now, created_at: now, machine_id: 'local' });
+
+      const res = await handler({
+        requestContext: TEST_REQUEST_CONTEXT,
+        body: { type: 'user_prompt', session_id: sessionId, agent: 'claude-code', prompt: 'second life after explicit register' },
+        query: {}, params: {}, pathname: '/events',
+      });
+
+      expect(res.body).toMatchObject({ ok: true, persisted: true });
+      expect(res.body).toHaveProperty('batchId');
+      expect(registry.getSession(sessionId)).toBeDefined();
+      const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+      expect(batches).toHaveLength(1);
+      expect(batches[0].user_prompt).toBe('second life after explicit register');
+
+      logger.close();
+      fs.rmSync(vaultDir, { recursive: true, force: true });
     });
   });
 

--- a/tests/daemon/session-lifecycle.test.ts
+++ b/tests/daemon/session-lifecycle.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { vi } from '../helpers/vi-shim.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
+import { ensureSessionRowExists, ENSURE_SESSION_SOURCE } from '@myco/daemon/session-lifecycle.js';
+import { insertSessionTombstone, SESSION_TOMBSTONE_SOURCE } from '@myco/db/queries/session-tombstones.js';
+import { getDatabase } from '@myco/db/client.js';
+import { getSession, upsertSession } from '@myco/db/queries/sessions.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+
+const nowSec = () => Math.floor(Date.now() / 1000);
+
+function makeLogger() {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function tombstone(sessionId: string): void {
+  insertSessionTombstone(getDatabase(), {
+    sessionId,
+    projectId: null,
+    source: SESSION_TOMBSTONE_SOURCE.API_DELETE,
+  });
+}
+
+describe('ensureSessionRowExists — tombstone gate', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => { cleanTestDb(); });
+
+  // RC-A: the defensive insert is for upstream gaps, not for deliberately
+  // deleted sessions. A tombstoned id must not be passively materialized
+  // by /context or any future defensive caller — that was a resurrection
+  // path as a class.
+  it('skips the defensive insert for a tombstoned id without throwing', () => {
+    const sessionId = 'tombstoned-defensive-001';
+    tombstone(sessionId);
+    const logger = makeLogger();
+
+    let created: boolean | undefined;
+    expect(() => {
+      created = ensureSessionRowExists({
+        sessionId,
+        machineId: 'local',
+        logger: logger as never,
+        source: ENSURE_SESSION_SOURCE.CONTEXT,
+      });
+    }).not.toThrow();
+
+    expect(created).toBe(false);
+    expect(getSession(sessionId, ALL_PROJECTS_SCOPE)).toBeNull();
+    // The skip is expected behavior, not an upstream gap — no WARN noise.
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('still recovers a genuinely missing (non-tombstoned) row', () => {
+    const sessionId = 'missing-row-recovery-001';
+    const logger = makeLogger();
+
+    const created = ensureSessionRowExists({
+      sessionId,
+      agent: 'claude-code',
+      machineId: 'local',
+      logger: logger as never,
+      source: ENSURE_SESSION_SOURCE.USER_PROMPT,
+    });
+
+    expect(created).toBe(true);
+    expect(getSession(sessionId, ALL_PROJECTS_SCOPE)).not.toBeNull();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('no-ops on an existing row even when a stale tombstone lingers (explicit re-register supersedes)', () => {
+    const sessionId = 'reregistered-after-delete-001';
+    tombstone(sessionId);
+    // The supported same-id reload: /sessions/register recreated the row.
+    upsertSession({ id: sessionId, agent: 'claude-code', status: 'active', started_at: nowSec(), created_at: nowSec(), machine_id: 'local' });
+    const logger = makeLogger();
+
+    const created = ensureSessionRowExists({
+      sessionId,
+      machineId: 'local',
+      logger: logger as never,
+      source: ENSURE_SESSION_SOURCE.TOOL_USE,
+    });
+
+    expect(created).toBe(false);
+    expect(getSession(sessionId, ALL_PROJECTS_SCOPE)).not.toBeNull();
+  });
+});

--- a/tests/daemon/stop-processing.test.ts
+++ b/tests/daemon/stop-processing.test.ts
@@ -7,6 +7,8 @@ import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
 import { createStopProcessor } from '@myco/daemon/stop-processing.js';
 import { SessionRegistry } from '@myco/daemon/lifecycle.js';
 import { getSession, upsertSession } from '@myco/db/queries/sessions.js';
+import { insertSessionTombstone, SESSION_TOMBSTONE_SOURCE } from '@myco/db/queries/session-tombstones.js';
+import { getDatabase } from '@myco/db/client.js';
 import { insertBatch, listBatchesBySession } from '@myco/db/queries/batches.js';
 import { insertActivity } from '@myco/db/queries/activities.js';
 import { listPlansBySession } from '@myco/db/queries/plans.js';
@@ -240,6 +242,43 @@ describe('createStopProcessor session capture rules', () => {
         created_at: epochNow(),
       });
     }).not.toThrow();
+  });
+
+  // RC-A: a deleted live session's next per-turn Stop used to re-register
+  // the row through the first-sight branch — the silent resurrection path.
+  // A deletion tombstone must make the Stop a no-op; only an explicit
+  // /sessions/register (same-id reload) deliberately supersedes.
+  it('ignores a first-sight Stop for a tombstoned session and creates no row', async () => {
+    const sessionId = 'tombstoned-stop-first-sight-001';
+    insertSessionTombstone(getDatabase(), {
+      sessionId,
+      projectId: null,
+      source: SESSION_TOMBSTONE_SOURCE.API_DELETE,
+    });
+    // Real transcript so the ephemeral-sub-invocation guard isn't the
+    // reason the event drops — the tombstone gate must be.
+    const transcriptPath = (() => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-tomb-stop-'));
+      const file = path.join(dir, `rollout-${sessionId}.jsonl`);
+      fs.writeFileSync(
+        file,
+        `${JSON.stringify({ type: 'session_meta', payload: { id: sessionId } })}\n`,
+      );
+      return file;
+    })();
+
+    const stopProcessor = makeStopProcessor(vaultDir);
+    const res = await stopProcessor.handleStopRoute({
+      body: {
+        session_id: sessionId,
+        agent: 'codex',
+        transcript_path: transcriptPath,
+        last_assistant_message: 'ok',
+      },
+    } as never);
+
+    expect(res.body).toEqual({ ok: true, ignored: 'session_tombstoned' });
+    expect(getSession(sessionId, ALL_PROJECTS_SCOPE)).toBeFalsy();
   });
 
   // Regression: Cursor's stop payload doesn't carry `last_assistant_message`

--- a/tests/hooks/user-prompt-submit-drop.test.ts
+++ b/tests/hooks/user-prompt-submit-drop.test.ts
@@ -1,0 +1,163 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { createGrove, registerProjectInGrove } from '@myco/grove/registry.js';
+import { resolveServiceDaemonStatePath } from '@myco/grove/paths.js';
+import { getPluginVersion } from '@myco/version.js';
+import { listenEphemeral, closeServer } from '../helpers/net.js';
+
+const TEST_PROJECT_ID = 'proj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+interface RecordedRequest {
+  method: string;
+  url: string;
+  body: unknown;
+}
+
+/**
+ * RC-G guard for the user-prompt-submit drop branch.
+ *
+ * The drop-path cleanup destroyed six real production sessions when the
+ * hook received a PARENT session_id alongside a CHILD transcript (codex
+ * subagent spawns). The structural fix is server-side ({expect_empty:
+ * true} → 409 session_not_empty unless the session holds zero human
+ * batches); this test pins the CLIENT half of the contract against the
+ * real hook binary:
+ *
+ *   - a drop-rule fire issues DELETE /api/sessions/:id with body
+ *     {expect_empty: true} — never a bare delete;
+ *   - a 409 refusal is logged to stderr and the hook still exits 0
+ *     (never crash the agent).
+ *
+ * Same daemon-stub harness as buffer-event-policy-drift.test.ts — the
+ * hook is spawned as a child process, so the stub must be recorded over
+ * HTTP rather than by mocking the client.
+ */
+describe('user-prompt-submit drop branch — phantom-delete contract', () => {
+  let mycoHome: string;
+  let projectRoot: string;
+  let transcriptPath: string;
+  let server: http.Server;
+  const requests: RecordedRequest[] = [];
+
+  beforeAll(async () => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-upsd-drop-'));
+    const vaultDir = path.join(projectRoot, '.myco');
+    mycoHome = path.join(projectRoot, 'home');
+    transcriptPath = path.join(projectRoot, 'transcript.jsonl');
+    fs.mkdirSync(vaultDir, { recursive: true });
+    fs.mkdirSync(mycoHome, { recursive: true });
+    fs.writeFileSync(
+      path.join(vaultDir, 'project.toml'),
+      `[project]\nid = "${TEST_PROJECT_ID}"\nname = "upsd-drop"\n`,
+      'utf-8',
+    );
+    fs.writeFileSync(path.join(vaultDir, 'myco.yaml'), 'version: 3\nconfig_version: 0\n', 'utf-8');
+    fs.writeFileSync(transcriptPath, '{}\n', 'utf-8');
+    const grove = createGrove('test', mycoHome);
+    registerProjectInGrove(grove.id, {
+      projectId: TEST_PROJECT_ID,
+      projectName: 'upsd-drop',
+      projectRoot,
+    }, mycoHome);
+
+    // Daemon stub: healthy /health; DELETE /api/sessions/* is recorded with
+    // its parsed body and answered 200 — except session ids containing
+    // "refused", which get the daemon's 409 session_not_empty refusal.
+    const listening = await listenEphemeral((req, res) => {
+      if (req.method === 'GET' && req.url === '/health') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ myco: true, pid: process.pid, version: getPluginVersion() }));
+        return;
+      }
+      let raw = '';
+      req.on('data', (chunk) => { raw += chunk; });
+      req.on('end', () => {
+        let body: unknown;
+        try { body = raw ? JSON.parse(raw) : undefined; } catch { body = raw; }
+        requests.push({ method: req.method ?? '', url: req.url ?? '', body });
+        if (req.method === 'DELETE' && req.url?.includes('refused')) {
+          res.writeHead(409, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            error: 'session_not_empty',
+            message: 'expect_empty delete refused: this session has captured human prompts.',
+          }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, counts: {} }));
+      });
+    });
+    server = listening.server;
+    const statePath = resolveServiceDaemonStatePath(mycoHome);
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, JSON.stringify({ pid: process.pid, port: listening.port }));
+  });
+
+  afterAll(async () => {
+    await closeServer(server);
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  // Async spawn, NOT spawnSync: the daemon stub lives in this test process,
+  // and spawnSync would block the event loop the stub needs to answer the
+  // child's requests — a guaranteed deadlock-until-timeout.
+  function runHook(payload: Record<string, unknown>): Promise<{ status: number | null; stderr: string }> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(
+        process.execPath,
+        [path.resolve('packages/myco/src/cli.ts'), 'hook', 'user-prompt-submit', '--symbiont', 'claude-code'],
+        {
+          cwd: projectRoot,
+          env: { ...process.env, MYCO_NO_AUTO_SPAWN: '1', MYCO_HOME: mycoHome },
+          stdio: ['pipe', 'ignore', 'pipe'],
+        },
+      );
+      let stderr = '';
+      child.stderr.on('data', (chunk) => { stderr += chunk; });
+      child.on('error', reject);
+      child.on('close', (status) => resolve({ status, stderr }));
+      child.stdin.write(JSON.stringify(payload));
+      child.stdin.end();
+    });
+  }
+
+  it('a drop-rule fire posts DELETE with {expect_empty: true} — never a bare delete', async () => {
+    const sessionId = 'upsd-drop-accepted-001';
+    const result = await runHook({
+      // claude-code manifest drop rule: prompt_starts_with "<command-message>".
+      prompt: '<command-message>compact</command-message>',
+      session_id: sessionId,
+      transcript_path: transcriptPath,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('user-prompt-submit: dropped');
+
+    const deletes = requests.filter((r) => r.method === 'DELETE' && r.url === `/api/sessions/${sessionId}`);
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0].body).toEqual({ expect_empty: true });
+    // Accepted cleanup — no refusal message.
+    expect(result.stderr).not.toContain('drop-delete refused');
+  }, 20_000);
+
+  it('a 409 session_not_empty refusal is stderr-logged and the hook still exits 0', async () => {
+    const sessionId = 'upsd-drop-refused-001';
+    const result = await runHook({
+      prompt: '<command-message>compact</command-message>',
+      session_id: sessionId,
+      transcript_path: transcriptPath,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('user-prompt-submit: dropped');
+    expect(result.stderr).toContain('drop-delete refused (session has captured content) — leaving cleanup to the maintenance sweep');
+
+    const deletes = requests.filter((r) => r.method === 'DELETE' && r.url === `/api/sessions/${sessionId}`);
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0].body).toEqual({ expect_empty: true });
+  }, 20_000);
+});

--- a/tests/ui/use-delete-session.test.tsx
+++ b/tests/ui/use-delete-session.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { vi } from '../helpers/vi-shim.js';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+const deleteJsonMock = vi.fn();
+
+mock.module('../../packages/myco/ui/src/lib/api', () => ({
+  fetchJson: async () => ({}),
+  postJson: async () => ({}),
+  putJson: async () => ({}),
+  patchJson: async () => ({}),
+  deleteJson: (path: string, body?: unknown) => deleteJsonMock(path, body),
+  ApiError: class extends Error {},
+}));
+
+import { useDeleteSession } from '../../packages/myco/ui/src/hooks/use-sessions';
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useDeleteSession', () => {
+  beforeEach(() => {
+    deleteJsonMock.mockReset();
+    deleteJsonMock.mockResolvedValue({ ok: true, counts: {} });
+  });
+
+  it('sends no body for a plain delete', async () => {
+    const { result } = renderHook(() => useDeleteSession(), { wrapper });
+
+    result.current.mutate({ id: 'sess-1' });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(deleteJsonMock).toHaveBeenCalledWith('/sessions/sess-1', undefined);
+  });
+
+  it('sends {force: true} when retrying past the 409 session_live refusal', async () => {
+    const { result } = renderHook(() => useDeleteSession(), { wrapper });
+
+    result.current.mutate({ id: 'sess-2', force: true });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(deleteJsonMock).toHaveBeenCalledWith('/sessions/sess-2', { force: true });
+  });
+});


### PR DESCRIPTION
## Production incident this fixes

Codex session `019ebc34` was destroyed and re-corrupted **six times** today. The deleter was myco's own user-prompt-submit hook: codex subagent spawns deliver the **parent** session_id with the **child** transcript; the subagent drop rule fired correctly, but the hook's phantom-cleanup cascade-deleted the parent's real session — once per reviewer subagent (6/6 timestamp correlation, 300-700ms offsets). Each delete was then silently resurrected by the next event (tombstones unconsulted, debug-only logging), rebuilding the session from transcript mining — strictly lossier. Full forensics: Myco plan `codex-capture-forensics-2026-06-12`.

## The deletion-safety contract

- **RC-G (server-enforced):** the hook's cleanup delete now carries `{expect_empty: true}`; the daemon refuses (`409 session_not_empty`) whenever the session holds any human-origin batch, **regardless of force**. Client misidentification can never destroy captured work — for any symbiont, current or future. Refused cleanup degrades to the maintenance sweep (the hook comment's own named backstop).
- **RC-A:** all three passive resurrection paths (event auto-register, Stop first-sight, defensive `ensureSessionRowExists`) now honor tombstones — info log once, cached drop after, no transcript_path bypass. Explicit `POST /sessions/register` still supersedes deliberately (same-id reload is a supported, test-pinned flow).
- **Operator guard:** `DELETE /api/sessions/:id` on a registry-live session → `409 session_live` unless `{force:true}`; dashboard gets a two-stage "session appears live — delete anyway?" confirm.
- **Attribution:** every delete-path log line now carries `expect_empty`/`force`/machine/project — the six production deletes were anonymous, which is what made this hunt slow.

## Verification

- Independent design review pre-implementation (closed two resurrection paths the original design missed; kept register ungated per pinned same-id-reload semantics) + two adversarial probe rounds (zero must-fixes; cross-tenant emptiness shape proven structurally impossible; full incident loop demonstrated against real handlers).
- `npm test` canonical full suite: 90/90 phases, **0 failures across all JUnit artifacts** (15,873 tests); lint + vite build clean.
- **LIVE SMOKE on the dev daemon running this branch** (per the new capture-change standing rule), real HTTP against the real daemon:
  - un-forced delete of live session → `409 session_live` ✓
  - `expect_empty` on session with human content → `409 session_not_empty` ✓ (the exact codex incident shape, now refused)
  - forced delete → ok; next event → `ignored: session_tombstoned`, **INFO** `Ignored event for deleted (tombstoned) session` ✓
  - explicit re-register → second-life prompt persists ✓
  - empty phantom + `expect_empty` while registry-live → deletes ✓ (legitimate cleanup preserved)
  - all refusals/deletes logged with caller provenance ✓; a real claude-code session captured continuously across the daemon restart ✓

Known behavior notes: tombstone gates are source-blind (a maintenance-swept session that wakes drops events until its next explicit register — bounded by sweep eligibility + tombstone retention); a crash-stale registry entry can cause a false `session_live` 409, absorbed by the force confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)