### PR TITLE
symbionts: codex multipart prompts extract real text — shared walker/parser routine (RC-C)

### DIFF
--- a/packages/myco/src/capture/prompt-kind.ts
+++ b/packages/myco/src/capture/prompt-kind.ts
@@ -6,6 +6,7 @@
 import { getAtPath } from '../utils/dot-path.js';
 import { evaluateUserPromptRules, type PromptOrigin, type UserPromptDecision } from '../hooks/capture-rules.js';
 import { HOOK_CONFIG } from '../hooks/hook-config.generated.js';
+import { extractCodexPromptText } from '../symbionts/parsers/codex-jsonl.js';
 import type {
   CapturePrompts,
   MatchExpression,
@@ -165,7 +166,7 @@ function walkTranscript(
       seenDedupe.add(key);
     }
 
-    const rawText = extractText(event, shape.textAt);
+    const rawText = extractText(event, shape);
     if (!rawText) continue;
 
     // Apply manifest capture.rules identically to the live hook path. A
@@ -208,7 +209,7 @@ function findMatchingShape(
     // that share every top-level field with a teammate-message) are excluded
     // by inspecting the resolved text. Falls through to the next shape so the
     // generic user_prompt shape still claims those entries.
-    if (shape.textStartsWith && !extractText(event, shape.textAt).startsWith(shape.textStartsWith)) {
+    if (shape.textStartsWith && !extractText(event, shape).startsWith(shape.textStartsWith)) {
       continue;
     }
     return shape;
@@ -256,13 +257,20 @@ function matchExpression(match: MatchExpression, event: Record<string, unknown>)
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve `path` against `event` and coerce to text. Handles plain strings
- * and Claude's typed-block arrays by returning the first `{type:"text"}` block.
+ * Resolve the shape's `textAt` path against `event` and coerce to text.
+ * Plain strings pass through. Arrays follow the shape's `textExtraction`
+ * mode: `joined_text_parts` delegates to the canonical Codex routine shared
+ * with the transcript parser (wrapper-tag strip + join — walker and parser
+ * must derive identical text for response prefix-matching); the default
+ * `first_text` returns the first `{type:"text"}` block (Claude Code shape).
  */
-function extractText(event: Record<string, unknown>, path: string): string {
-  const value = getAtPath(event, path);
+function extractText(event: Record<string, unknown>, shape: PromptShape): string {
+  const value = getAtPath(event, shape.textAt);
   if (typeof value === 'string') return value;
   if (Array.isArray(value)) {
+    if (shape.textExtraction === 'joined_text_parts') {
+      return extractCodexPromptText(value);
+    }
     const textBlock = value.find(
       (b) => b && typeof b === 'object' && (b as Record<string, unknown>).type === 'text',
     ) as { text?: unknown } | undefined;

--- a/packages/myco/src/hooks/hook-config.generated.ts
+++ b/packages/myco/src/hooks/hook-config.generated.ts
@@ -208,7 +208,8 @@ export const HOOK_CONFIG: Readonly<Record<string, HookConfigEntry>> = {
               "payload.role": "user"
             }
           },
-          "textAt": "payload.content[0].text"
+          "textAt": "payload.content",
+          "textExtraction": "joined_text_parts"
         }
       ],
       "resetBoundaries": [

--- a/packages/myco/src/symbionts/manifest-schema.ts
+++ b/packages/myco/src/symbionts/manifest-schema.ts
@@ -88,6 +88,20 @@ const PromptShapeSchema = z.object({
    */
   textAt: z.string(),
   /**
+   * How text is derived when the `textAt` value resolves to an ARRAY of
+   * content blocks (strings always pass through unchanged):
+   *
+   *   first_text        — (default) the first `{type:"text"}` block's `text`
+   *                       field. Matches the Claude Code typed-block shape.
+   *   joined_text_parts — all text-bearing parts cleaned and joined via the
+   *                       canonical Codex routine (`extractCodexPromptText`),
+   *                       which strips `<image …>` wrapper tags. Required for
+   *                       Codex multipart image prompts, where the user's
+   *                       real text is the LAST part, not the first. `textAt`
+   *                       must point at the content ARRAY itself.
+   */
+  textExtraction: z.enum(['first_text', 'joined_text_parts']).optional(),
+  /**
    * Optional content-prefix guard. When set, the shape only matches when the
    * resolved `textAt` value starts with this literal. Use to disambiguate
    * entries that are STRUCTURALLY identical but semantically distinct — e.g.

--- a/packages/myco/src/symbionts/manifests.generated.ts
+++ b/packages/myco/src/symbionts/manifests.generated.ts
@@ -521,7 +521,8 @@ export const BUNDLED_MANIFESTS: readonly SymbiontManifest[] = [
                 "payload.role": "user"
               }
             },
-            "textAt": "payload.content[0].text"
+            "textAt": "payload.content",
+            "textExtraction": "joined_text_parts"
           }
         ],
         "resetBoundaries": [

--- a/packages/myco/src/symbionts/manifests/codex.yaml
+++ b/packages/myco/src/symbionts/manifests/codex.yaml
@@ -184,13 +184,20 @@ capture:
     # preamble diverges, add a separate rule keyed on its specific marker.
   prompts:
     shapes:
+      # Image prompts are multipart: `<image …>` wrapper input_text tags and
+      # input_image blocks come FIRST, the user's real text is the LAST
+      # input_text part. joined_text_parts routes extraction through the
+      # canonical Codex routine (shared with the transcript parser): wrapper
+      # tags stripped, all remaining text parts joined. textAt points at the
+      # content ARRAY, not [0].text.
       - name: user_message
         match:
           type: response_item
           fieldEquals:
             payload.type: message
             payload.role: user
-        textAt: payload.content[0].text
+        textAt: payload.content
+        textExtraction: joined_text_parts
     resetBoundaries:
       # Codex emits `turn_context` events whenever the agent enters a new
       # turn. Reset only fires when `payload.turn_id` changes from the

--- a/packages/myco/src/symbionts/parsers/codex-jsonl.ts
+++ b/packages/myco/src/symbionts/parsers/codex-jsonl.ts
@@ -62,6 +62,29 @@ function cleanCodexPromptText(text: string): string {
 }
 
 /**
+ * Canonical Codex `content[]` → prompt-text routine. Image prompts arrive as
+ * multipart content — `<image …>` wrapper `input_text` tags and `input_image`
+ * blocks interleaved with the user's real text (which sits LAST, not first).
+ * Strips the wrapper tags and joins every remaining text-bearing part.
+ *
+ * Shared by the transcript parser ({@link CodexJsonlParser.parseTurns}) and
+ * the manifest walker (`capture/prompt-kind.ts` via the codex manifest's
+ * `textExtraction: joined_text_parts` shape) so both derive IDENTICAL text
+ * from the same turn — `populateBatchResponses` prefix-matches walker-stored
+ * prompts against parser turns, so any divergence breaks response attribution.
+ */
+export function extractCodexPromptText(content: unknown): string {
+  if (!Array.isArray(content)) return '';
+  const parts = (content as Array<{ type?: unknown; text?: unknown }>)
+    .filter((b): b is { type: string; text: string } =>
+      !!b && typeof b === 'object' && b.type === 'input_text'
+      && typeof b.text === 'string' && b.text.trim().length > 0)
+    .map((b) => cleanCodexPromptText(b.text))
+    .filter((t) => t.trim());
+  return parts.join('\n').trim();
+}
+
+/**
  * Parses Codex's nested-payload JSONL transcript format.
  *
  * Codex JSONL entries have the structure:
@@ -127,16 +150,12 @@ export class CodexJsonlParser implements TranscriptParser {
         : [];
 
       if (role === 'user') {
-        const textParts = blocks
-          .filter((b) => b.type === 'input_text' && b.text?.trim())
-          .map((b) => cleanCodexPromptText(b.text!))
-          .filter((t) => t.trim());
-
-        if (textParts.length === 0) continue;
+        const fullPrompt = extractCodexPromptText(blocks);
+        if (!fullPrompt) continue;
 
         if (current) turns.push(current);
 
-        const promptText = textParts.join('\n').trim().slice(0, PROMPT_PREVIEW_CHARS);
+        const promptText = fullPrompt.slice(0, PROMPT_PREVIEW_CHARS);
 
         // Extract images from input_image blocks (data URL format: data:<mime>;base64,<data>)
         const images: TranscriptImage[] = [];

--- a/tests/capture/prompt-kind.test.ts
+++ b/tests/capture/prompt-kind.test.ts
@@ -5,6 +5,7 @@ import {
   extractUserPromptKinds,
   extractUserPromptRecords,
 } from '@myco/capture/prompt-kind.js';
+import { CodexJsonlParser } from '@myco/symbionts/parsers/codex-jsonl.js';
 
 // Regression: Claude Code writes real user prompts with `message.content` as a
 // plain string, and tool_result entries with content as an array. The walker
@@ -652,6 +653,103 @@ describe('walker tags origin per capture rule (K3 classify action)', () => {
       },
     ];
     expect(extractUserPromptRecords('claude-code', events)).toHaveLength(0);
+  });
+});
+
+describe('walker Codex multipart image-prompt extraction (textExtraction: joined_text_parts)', () => {
+  // Codex image prompts arrive as multipart content: `<image name=…>` wrapper
+  // input_text tags and input_image blocks come FIRST, the user's real text is
+  // the LAST input_text part. A shape reading `payload.content[0].text` would
+  // extract the wrapper tag as the user prompt (tag-only batches live, real
+  // prompt text lost on re-mining). The codex manifest's user_message shape
+  // points `textAt` at the content ARRAY with `textExtraction:
+  // joined_text_parts`, routing extraction through the parser's canonical
+  // routine: wrapper tags stripped, remaining text parts joined.
+  const wrapperTriplet = (n: number) => [
+    { type: 'input_text', text: `<image name=[Image #${n}] path="/var/folders/x/codex-clipboard-abc${n}.png">` },
+    { type: 'input_image', image_url: 'data:image/png;base64,AAAA' },
+    { type: 'input_text', text: '</image>' },
+  ];
+
+  const REAL_PROMPT = 'Everything is enabled under Privacy and Security';
+
+  const imagePromptEvent = {
+    type: 'response_item',
+    payload: {
+      type: 'message',
+      role: 'user',
+      content: [
+        ...wrapperTriplet(1),
+        ...wrapperTriplet(2),
+        ...wrapperTriplet(3),
+        { type: 'input_text', text: REAL_PROMPT },
+      ],
+    },
+  };
+
+  it('extracts the real prompt text, not the image wrapper tag', () => {
+    const records = extractUserPromptRecords('codex', [imagePromptEvent], '/tmp/codex-rollout.jsonl');
+    expect(records).toHaveLength(1);
+    expect(records[0]?.text).toBe(REAL_PROMPT);
+    expect(records[0]?.kind).toBe('initial');
+    expect(records[0]?.origin).toBe('human');
+  });
+
+  // THE contract: walker-extracted text and parser-turn prompt must be
+  // identical for the same transcript line — populateBatchResponses
+  // prefix-matches one against the other, and any divergence NULLs the
+  // batch's response_summary.
+  it('derives the same text as the transcript parser for the same line', () => {
+    const walkerText = extractUserPromptRecords(
+      'codex',
+      [imagePromptEvent],
+      '/tmp/codex-rollout.jsonl',
+    )[0]?.text;
+    const turns = new CodexJsonlParser().parseTurns(`${JSON.stringify(imagePromptEvent)}\n`);
+    expect(turns).toHaveLength(1);
+    expect(walkerText).toBe(turns[0]!.prompt);
+  });
+
+  it('leaves a single-input_text codex prompt unchanged (no images)', () => {
+    const event = {
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'what has changed in this branch?' }],
+      },
+    };
+    const records = extractUserPromptRecords('codex', [event], '/tmp/codex-rollout.jsonl');
+    expect(records).toHaveLength(1);
+    expect(records[0]?.text).toBe('what has changed in this branch?');
+    expect(records[0]?.kind).toBe('initial');
+  });
+
+  it('emits no record for a wrapper-tags-only event carrying no real text', () => {
+    const event = {
+      type: 'response_item',
+      payload: { type: 'message', role: 'user', content: wrapperTriplet(1) },
+    };
+    expect(extractUserPromptRecords('codex', [event], '/tmp/codex-rollout.jsonl')).toHaveLength(0);
+  });
+
+  it('keeps first-text behavior for shapes without textExtraction (Claude Code typed blocks)', () => {
+    const events = [
+      {
+        type: 'user',
+        promptId: 'p1',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'first block' },
+            { type: 'text', text: 'second block' },
+          ],
+        },
+      },
+    ];
+    const records = extractUserPromptRecords('claude-code', events);
+    expect(records).toHaveLength(1);
+    expect(records[0]?.text).toBe('first block');
   });
 });
 


### PR DESCRIPTION
## What

Forensics RC-C (`codex-capture-forensics-2026-06-12`): the codex manifest walker extracted `payload.content[0].text` — the `<image>` wrapper tag — as the user prompt for any image-bearing message. This corrupted codex sessions **live** (tag-only duplicate batches at every Stop, duplicated attachment BLOBs via renumbering) and on re-mining (real prompt text lost; walker/parser text mismatch broke response prefix-matching → NULL summaries).

## Pattern fix

`extractCodexPromptText()` is the single canonical content→text routine (strip image wrappers, join all `input_text` parts), exported from the codex parser and used by **both** the parser and the walker — they structurally cannot disagree, and the equality is pinned by test against the exact production content shape. The manifest gains opt-in `textExtraction: joined_text_parts`; default `first_text` behavior is unchanged for every other shape (pinned). Wrapper-tags-only events now emit no prompt record, killing the live tag-only-batch class.

## Live smoke (per standing rule)

Dev daemon on this branch **mined the actual production rollout** (`rollout-…019ebc34….jsonl` — the file whose mining produced the corruption): all three image prompts extracted with their real user text, **zero** tag-only batches, six subagent notifications correctly `agent_dispatch`. Same input that corrupted production → correct capture.

- 2,529 isolated tests green (daemon/capture/symbionts); lint clean
- New tests: forensics-shaped fixture → real text; walker===parser equality; no-image regression; tags-only → no record; first-text default pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)