### PR TITLE
capture: codex miner fidelity — RC-B/E/F/D (envelope turns, meta-gated mining, clean summaries, content-keyed attachments)

### DIFF
--- a/packages/myco/src/capture/prompt-kind.ts
+++ b/packages/myco/src/capture/prompt-kind.ts
@@ -47,10 +47,11 @@ export function extractUserPromptRecords(
   agent: string,
   events: ReadonlyArray<Record<string, unknown>>,
   transcriptPath?: string,
+  transcriptMeta?: Record<string, unknown>,
 ): UserPromptRecord[] {
   const config = HOOK_CONFIG[agent]?.capturePrompts;
   if (!config) return [];
-  return walkTranscript(config, agent, events, transcriptPath).records;
+  return walkTranscript(config, agent, events, transcriptPath, transcriptMeta).records;
 }
 
 /**
@@ -64,10 +65,11 @@ export function extractUserPromptRecordsWithDrops(
   agent: string,
   events: ReadonlyArray<Record<string, unknown>>,
   transcriptPath?: string,
+  transcriptMeta?: Record<string, unknown>,
 ): { records: UserPromptRecord[]; droppedText: string[] } {
   const config = HOOK_CONFIG[agent]?.capturePrompts;
   if (!config) return { records: [], droppedText: [] };
-  const result = walkTranscript(config, agent, events, transcriptPath);
+  const result = walkTranscript(config, agent, events, transcriptPath, transcriptMeta);
   return { records: result.records, droppedText: result.droppedText };
 }
 
@@ -141,6 +143,7 @@ function walkTranscript(
   agent: string,
   events: ReadonlyArray<Record<string, unknown>>,
   transcriptPath: string | undefined,
+  transcriptMeta?: Record<string, unknown>,
 ): WalkResult {
   const seenDedupe = new Set<string>();
   const records: UserPromptRecord[] = [];
@@ -172,11 +175,19 @@ function walkTranscript(
     // Apply manifest capture.rules identically to the live hook path. A
     // synthetic transcriptPath is used when none was supplied so structural
     // rules keyed on `transcript_path_missing` don't mis-fire during mining.
+    // `transcriptMeta` (the transcript's session_meta payload, when the
+    // caller read it) makes `transcript_meta_*` rules fire at mining time
+    // exactly as they do at hook time — without it every such rule was
+    // structurally inert on this path (capture-rules requires meta present).
     // evaluateUserPromptRules now reads from the generated hook-config by
     // default — no loadManifests() call on the mining path either.
     const decision = evaluateUserPromptRules(
       agent,
-      { prompt: rawText, transcriptPath: transcriptPath ?? '<transcript-walker>' },
+      {
+        prompt: rawText,
+        transcriptPath: transcriptPath ?? '<transcript-walker>',
+        transcriptMeta,
+      },
     );
     if (decision.action === 'drop') {
       droppedText.push(rawText);

--- a/packages/myco/src/capture/transcript-miner.ts
+++ b/packages/myco/src/capture/transcript-miner.ts
@@ -17,9 +17,13 @@ import {
 } from '../db/queries/batches.js';
 import { extractUserPromptRecordsWithDrops, type UserPromptRecord } from './prompt-kind.js';
 import { epochSeconds, DEFAULT_AGENT_ID } from '@myco/constants.js';
+import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { createBatchLineage } from '../db/queries/lineage.js';
-import { assertGroveProjectId } from '@myco/grove/ids.js';
+import { assertGroveProjectId, type GroveProjectId } from '@myco/grove/ids.js';
 import { getTeamMachineId } from '@myco/team/context.js';
+import { readTranscriptMeta } from '../hooks/transcript-meta.js';
+import { evaluateSessionCaptureRules } from '../hooks/capture-rules.js';
+import { stripPlanTagEnvelopes } from '../plans/tag-envelopes.js';
 
 function promptPrefix(text: string | null | undefined): string {
   return (text ?? '').slice(0, PROMPT_PREFIX_MATCH_CHARS);
@@ -54,11 +58,42 @@ function buildPrefixBuckets(batches: ReadonlyArray<BatchRow>): {
 
 // Re-export TranscriptTurn from its canonical home in symbionts/adapter.ts
 export type { TranscriptTurn } from '../symbionts/adapter.js';
-import type { TranscriptTurn } from '../symbionts/adapter.js';
+import type { TranscriptTurn, TranscriptImage } from '../symbionts/adapter.js';
+
+/** Minimal logger surface the miner needs. `DaemonLogger` satisfies it. */
+export interface MinerLogger {
+  info(kind: string, message: string, data?: Record<string, unknown>): void;
+  warn(kind: string, message: string, data?: Record<string, unknown>): void;
+}
+
+/** A matched turn's images, attributed to a batch during mining. */
+export interface MinedImageCapture {
+  sessionId: string;
+  promptBatchId: number;
+  promptNumber: number;
+  images: TranscriptImage[];
+  projectId: GroveProjectId;
+}
 
 interface TranscriptConfig {
   /** Additional symbiont adapters to register (useful for testing or custom symbionts) */
   additionalAdapters?: SymbiontAdapter[];
+  /** Logger for mining observability (skip decisions, image-capture failures). */
+  logger?: MinerLogger;
+  /**
+   * Plan tag names (merged manifest `capture.planTags`). Plan envelopes are
+   * machine-readable payloads the parser synthesizes for plan extraction;
+   * they are stripped from every response the miner persists so they never
+   * leak into user-facing summaries.
+   */
+  planTags?: string[];
+  /**
+   * Sink invoked for each transcript turn whose images were matched to a
+   * batch during `reconcileAndAttributeResponses`. The daemon wires this to
+   * the shared `captureBatchImages` routine; without it the mining path
+   * silently never captured images (Stop was the only entry point).
+   */
+  captureImages?: (input: MinedImageCapture) => void;
 }
 
 export interface ReconcileInput {
@@ -71,6 +106,14 @@ export interface ReconcileResult {
   /** Batches created during reconciliation to recover prompts the hook dropped. */
   inserted: number;
   errors: string[];
+  /**
+   * Set when the entire mining pass was skipped because a transcript-level
+   * drop rule fired on the transcript's session_meta (e.g. a Codex
+   * sub-agent thread whose tool events carry the PARENT session_id with
+   * the CHILD transcript_path — mining it would graft the child rollout
+   * onto the parent session).
+   */
+  skippedReason?: string;
 }
 
 /** Head-bytes sampled to detect in-place overwrite with same inode + size. */
@@ -100,17 +143,82 @@ interface ParseCacheEntry {
   reconciledSize: number;
 }
 
+/**
+ * Bound on the transcript-meta memo. Entries hold the parsed session_meta
+ * payload (Codex meta can embed multi-KB base_instructions), so the cap is
+ * kept small and the map is cleared wholesale on overflow — the memo is a
+ * re-read suppressor, not a correctness mechanism.
+ */
+const META_MEMO_MAX_ENTRIES = 64;
+
+interface TranscriptMetaMemoEntry {
+  agent: string;
+  meta: Record<string, unknown> | undefined;
+  /** Drop reason from transcript-level rules, or null when mining may proceed. */
+  dropReason: string | null;
+}
+
 export class TranscriptMiner {
   private registry: SymbiontRegistry;
+  private logger?: MinerLogger;
+  private planTags: string[];
+  private captureImages?: (input: MinedImageCapture) => void;
   /**
    * Append-read cache keyed by path; avoids re-parsing the whole transcript
    * per Stop. Bounded LRU: insertion order preserved via Map semantics,
    * touch-on-access moves the entry to the end, eviction pops the head.
    */
   private parseCache = new Map<string, ParseCacheEntry>();
+  /**
+   * Per-path memo of the transcript's session_meta + transcript-level drop
+   * decision. A rollout's session_meta is its immutable first line, so the
+   * decision is stable per file; memoizing also keeps the skip log to one
+   * line per transcript instead of one per throttled reconcile tick. Only
+   * populated when the meta line was actually readable — a not-yet-flushed
+   * file must be re-checked on the next pass.
+   */
+  private metaMemo = new Map<string, TranscriptMetaMemoEntry>();
 
   constructor(config?: TranscriptConfig) {
     this.registry = new SymbiontRegistry(config?.additionalAdapters);
+    this.logger = config?.logger;
+    this.planTags = config?.planTags ?? [];
+    this.captureImages = config?.captureImages;
+  }
+
+  /**
+   * Evaluate the manifest's transcript-level drop rules for this transcript
+   * (session_start rules keyed on transcript meta — e.g. Codex's
+   * `source.subagent` thread-spawn filter and `source: exec` filter).
+   * Returns the memoized entry; `dropReason` non-null means the entire
+   * mining pass must be skipped for this file.
+   */
+  private transcriptGate(sessionId: string, input: ReconcileInput): TranscriptMetaMemoEntry {
+    const memo = this.metaMemo.get(input.transcriptPath);
+    if (memo && memo.agent === input.agent) return memo;
+
+    const meta = readTranscriptMeta(input.transcriptPath) ?? undefined;
+    const decision = evaluateSessionCaptureRules(input.agent, {
+      transcriptPath: input.transcriptPath,
+      transcriptMeta: meta,
+    });
+    const dropReason = decision.action === 'drop' ? (decision.reason ?? 'transcript-drop-rule') : null;
+    const entry: TranscriptMetaMemoEntry = { agent: input.agent, meta, dropReason };
+
+    // Only memoize once the meta line is readable — before the agent
+    // flushes the file, a pass decision would be premature and sticky.
+    if (meta !== undefined) {
+      if (this.metaMemo.size >= META_MEMO_MAX_ENTRIES) this.metaMemo.clear();
+      this.metaMemo.set(input.transcriptPath, entry);
+      if (dropReason) {
+        this.logger?.info(LOG_KINDS.PROCESSOR_TRANSCRIPT, 'Mining skipped — transcript belongs to a dropped class (e.g. subagent thread)', {
+          session_id: sessionId,
+          transcript_path: input.transcriptPath,
+          reason: dropReason,
+        });
+      }
+    }
+    return entry;
   }
 
   /**
@@ -144,6 +252,17 @@ export class TranscriptMiner {
    * prompts the hook dropped (e.g., Claude's queued mid-turn prompts).
    */
   public reconcileBatchKinds(sessionId: string, input: ReconcileInput): ReconcileResult {
+    // Transcript-level drop gate — BEFORE any parsing or DB work. Codex
+    // sub-agent tool events carry the parent session_id with the CHILD
+    // rollout's transcript_path; without this gate the child transcript was
+    // mined INTO the parent session (foreign kickoff prompts materialized
+    // as human batches). The gate kills that class wholesale: a transcript
+    // whose session_meta matches a manifest drop rule is never mined.
+    const gate = this.transcriptGate(sessionId, input);
+    if (gate.dropReason) {
+      return { reclassified: 0, inserted: 0, errors: [], skippedReason: gate.dropReason };
+    }
+
     // Short-circuit: if we've already reconciled this transcript at its
     // current size, nothing new to do. The cached `reconciledSize` is only
     // set after a full reconcile pass at that size, so the DB state is
@@ -169,10 +288,13 @@ export class TranscriptMiner {
       // statSync failure falls through to parseAllEvents, which handles it.
     }
 
+    // The walker receives the transcript meta so per-prompt
+    // `transcript_meta_*` rules fire at mining time exactly as at hook time.
     const { records, droppedText } = extractUserPromptRecordsWithDrops(
       input.agent,
       this.parseAllEvents(input.transcriptPath),
       input.transcriptPath,
+      gate.meta,
     );
     const batches = listBatchesBySession(sessionId, { scope: { kind: 'all' } }).sort((a, b) => a.id - b.id);
 
@@ -374,10 +496,21 @@ export class TranscriptMiner {
     input: ReconcileInput,
   ): ReconcileResult {
     const result = this.reconcileBatchKinds(sessionId, input);
+    // A transcript-level drop skips the WHOLE mining pass — attributing
+    // responses or images from a dropped-class transcript would graft its
+    // content onto the session exactly like the reconcile would have.
+    if (result.skippedReason) return result;
+
     const { turns } = this.getAllTurnsWithSource(sessionId, input.transcriptPath);
+    // Plan envelopes have had their extraction chance by the time a summary
+    // is persisted (extraction reads raw parser turns, never persisted
+    // summaries) — strip them here so machine-readable plan payloads never
+    // reach user-facing response_summary values. Envelope-only responses
+    // strip to '' and are filtered, leaving the batch summary untouched.
     const responses = turns
       .filter((t) => t.prompt && t.aiResponse)
-      .map((t) => ({ prompt: t.prompt, response: t.aiResponse! }));
+      .map((t) => ({ prompt: t.prompt, response: stripPlanTagEnvelopes(t.aiResponse!, this.planTags) }))
+      .filter((r) => r.response.trim().length > 0);
     if (responses.length > 0) {
       populateBatchResponses(sessionId, responses);
     }
@@ -386,7 +519,44 @@ export class TranscriptMiner {
     // races). The live path attributes correctly by construction; this keeps
     // re-mined/older sessions consistent so the myco agent sees the tool calls.
     rehomeSystemActivitiesToHumanAnchor(sessionId);
+    this.captureTurnImages(sessionId, turns);
     return result;
+  }
+
+  /**
+   * Mining-path image capture: match each image-bearing turn to its batch by
+   * prompt prefix (the same matching `populateBatchResponses` uses) and hand
+   * the images to the injected sink. Tenancy comes from the matched batch's
+   * own project_id — never from ambient daemon state. Best-effort: a sink
+   * failure is logged and never blocks reconciliation.
+   */
+  private captureTurnImages(sessionId: string, turns: TranscriptTurn[]): void {
+    if (!this.captureImages) return;
+    const imageTurns = turns.filter((t) => t.images?.length && t.prompt);
+    if (imageTurns.length === 0) return;
+
+    const batches = listBatchesBySession(sessionId, { scope: { kind: 'all' } }).sort((a, b) => a.id - b.id);
+    const buckets = buildPrefixBuckets(batches);
+    for (let i = 0; i < imageTurns.length; i++) {
+      const turn = imageTurns[i]!;
+      const match = buckets.consume(turn.prompt);
+      if (!match?.project_id) continue;
+      try {
+        this.captureImages({
+          sessionId,
+          promptBatchId: match.id,
+          promptNumber: match.prompt_number ?? i + 1,
+          images: turn.images!,
+          projectId: assertGroveProjectId(match.project_id),
+        });
+      } catch (err) {
+        this.logger?.warn(LOG_KINDS.PROCESSOR_TRANSCRIPT, 'Mining-path image capture failed', {
+          session_id: sessionId,
+          batch_id: match.id,
+          error: (err as Error).message,
+        });
+      }
+    }
   }
 
   private parseAllEvents(transcriptPath: string): Array<Record<string, unknown>> {

--- a/packages/myco/src/daemon/capture-images.ts
+++ b/packages/myco/src/daemon/capture-images.ts
@@ -1,31 +1,63 @@
 /**
  * Shared image attachment persistence.
  *
- * Called from two paths that both produce the same attachment row shape:
+ * Called from three paths that all produce the same attachment row shape:
  *
- * 1. `stop-processing.ts` — for claude-code / cursor, where images come from
- *    transcript-mined `TranscriptTurn.images`. The transcript miner has
- *    already decoded base64 blocks and produced a canonical `TranscriptImage`
- *    per image per turn.
+ * 1. `stop-processing.ts` — for claude-code / cursor / codex, where images
+ *    come from transcript-mined `TranscriptTurn.images`. The transcript miner
+ *    has already decoded base64 blocks and produced a canonical
+ *    `TranscriptImage` per image per turn.
  *
  * 2. `event-dispatch.ts` — for opencode, where images come from the plugin
  *    in the `user_prompt` event payload. The opencode plugin extracts each
  *    image from a `FilePart.url` data URL and ships it straight to the
  *    daemon, since opencode has no on-disk transcript to mine.
  *
- * Deterministic IDs (`${sessionShort}-b${promptNumber}-${index}`) keep the
- * insert idempotent under replay: `insertAttachment` uses `ON CONFLICT DO NOTHING`.
+ * 3. `capture/transcript-miner.ts` — the mining/resurrection path, via the
+ *    miner's injected `captureImages` sink, for turns whose images only
+ *    surface through transcript re-mining (no Stop fired for them).
+ *
+ * Dedup identity is CONTENT-KEYED: a sha256 over (media type + image bytes),
+ * stored in `attachments.content_hash`, scoped per session. The row id keeps
+ * the legacy `${sessionShort}-b${promptNumber}-${index}` scheme for display/
+ * grouping, but identity no longer depends on prompt_number — walker-batch
+ * renumbering between Stops used to mint a fresh id for identical bytes and
+ * duplicate the BLOB. Legacy rows (NULL content_hash) are lazily stamped per
+ * session before dedup so they participate without a schema migration.
  */
 
-import { insertAttachment } from '@myco/db/queries/attachments.js';
+import { createHash } from 'node:crypto';
+import {
+  insertAttachment,
+  findAttachmentBySessionContentHash,
+  linkAttachmentToBatchIfUnlinked,
+  listAttachmentsMissingContentHash,
+  setAttachmentContentHash,
+} from '@myco/db/queries/attachments.js';
 import { extensionForMimeType } from '@myco/symbionts/adapter.js';
-import { epochSeconds } from '@myco/constants.js';
+import { epochSeconds, CONTENT_HASH_ALGORITHM } from '@myco/constants.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
-import type { DaemonLogger } from './logger.js';
 import type { GroveProjectId } from '@myco/grove/ids.js';
 
 /** Short session-id suffix used in attachment filenames and IDs. */
 const SESSION_SHORT_LEN = 6;
+
+/**
+ * Hex chars of the content hash appended to id/filename when a DISTINCT
+ * image collides with an already-occupied (promptNumber, index) slot —
+ * both images are kept; the suffix disambiguates the second.
+ */
+const HASH_SUFFIX_LEN = 8;
+
+/**
+ * Minimal logger surface required by this module. `DaemonLogger` satisfies
+ * it structurally; the capture-layer caller (transcript miner) injects its
+ * own without importing daemon types.
+ */
+export interface CaptureImagesLogger {
+  debug(kind: string, message: string, data?: Record<string, unknown>): void;
+  warn(kind: string, message: string, data?: Record<string, unknown>): void;
+}
 
 /** Image attachment in canonical base64 form. Matches `TranscriptImage`. */
 export interface CapturedImage {
@@ -40,8 +72,37 @@ export interface CaptureBatchImagesInput {
   promptBatchId: number | null | undefined;
   promptNumber: number;
   images: CapturedImage[];
-  logger: DaemonLogger;
+  logger: CaptureImagesLogger;
   projectId: GroveProjectId;
+}
+
+/** Content identity of an attachment: media type + raw bytes. */
+export function attachmentContentHash(mediaType: string, bytes: Buffer): string {
+  return createHash(CONTENT_HASH_ALGORITHM)
+    .update(mediaType)
+    .update('\n')
+    .update(bytes)
+    .digest('hex');
+}
+
+/**
+ * Stamp content hashes onto a session's pre-content-keying rows so the
+ * dedup lookup sees them. One-time per row: stamped rows never reappear
+ * in the missing-hash query. Best-effort — a failure here only weakens
+ * dedup for legacy rows, never blocks new captures.
+ */
+function backfillSessionContentHashes(sessionId: string, logger: CaptureImagesLogger): void {
+  try {
+    for (const legacy of listAttachmentsMissingContentHash(sessionId)) {
+      if (!legacy.data || !legacy.media_type) continue;
+      setAttachmentContentHash(legacy.id, attachmentContentHash(legacy.media_type, legacy.data));
+    }
+  } catch (err) {
+    logger.warn(LOG_KINDS.CAPTURE_ATTACHMENT, 'Failed to backfill attachment content hashes', {
+      session_id: sessionId,
+      error: String(err),
+    });
+  }
 }
 
 /**
@@ -51,27 +112,56 @@ export function captureBatchImages(input: CaptureBatchImagesInput): void {
   const { sessionId, promptBatchId, promptNumber, images, logger, projectId } = input;
   if (images.length === 0) return;
 
+  backfillSessionContentHashes(sessionId, logger);
+
   const sessionShort = sessionId.slice(-SESSION_SHORT_LEN);
   for (let j = 0; j < images.length; j++) {
     const img = images[j];
     if (!img?.data || !img?.mediaType) continue;
     try {
+      const bytes = Buffer.from(img.data, 'base64');
+      const contentHash = attachmentContentHash(img.mediaType, bytes);
+
+      // Content-keyed dedup: the same image in the same session is ONE
+      // attachment row, regardless of how prompt_numbers shifted between
+      // capture passes (Stop replays, walker renumbering, re-mining). A
+      // dedup hit still upgrades batch linkage when the existing row was
+      // captured before its batch was known.
+      const existing = findAttachmentBySessionContentHash(sessionId, contentHash);
+      if (existing) {
+        if (existing.prompt_batch_id == null && promptBatchId != null) {
+          linkAttachmentToBatchIfUnlinked(existing.id, promptBatchId);
+        }
+        continue;
+      }
+
       const ext = extensionForMimeType(img.mediaType);
-      const filename = `${sessionShort}-t${promptNumber}-${j + 1}.${ext}`;
-      const inserted = insertAttachment({
-        id: `${sessionShort}-b${promptNumber}-${j + 1}`,
+      const slotId = `${sessionShort}-b${promptNumber}-${j + 1}`;
+      const slotFilename = `${sessionShort}-t${promptNumber}-${j + 1}.${ext}`;
+      const buildRow = (id: string, filename: string) => ({
+        id,
         session_id: sessionId,
         prompt_batch_id: promptBatchId ?? undefined,
         file_path: filename,
         media_type: img.mediaType,
-        data: Buffer.from(img.data, 'base64'),
+        data: bytes,
+        content_hash: contentHash,
         created_at: epochSeconds(),
         project_id: projectId,
       });
-      // insertAttachment returns undefined on ON CONFLICT DO NOTHING — only
-      // log when a row was actually inserted, otherwise stop-event replays
-      // (or plugin retries) produce phantom "Image stored in DB" lines for
-      // attachments that were already persisted.
+
+      let filename = slotFilename;
+      let inserted = insertAttachment(buildRow(slotId, slotFilename));
+      if (!inserted) {
+        // The slot id is occupied by DIFFERENT content (identical content
+        // returned above). Keep both images: disambiguate the new one with
+        // a content-hash suffix. The `-t{n}-` filename marker stays intact
+        // so turn-number grouping keeps working.
+        const suffix = contentHash.slice(0, HASH_SUFFIX_LEN);
+        filename = `${sessionShort}-t${promptNumber}-${j + 1}-${suffix}.${ext}`;
+        inserted = insertAttachment(buildRow(`${slotId}-${suffix}`, filename));
+      }
+
       if (inserted) {
         logger.debug(LOG_KINDS.CAPTURE_ATTACHMENT, 'Image stored in DB', {
           filename,

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -188,6 +188,7 @@ import { EventDedupCache } from './event-dedup-cache.js';
 import { reEnrichSessionFromTranscript } from './session-reenrich.js';
 import { runPendingMigrationTasks } from './migration-tasks.js';
 import { createStopProcessor } from './stop-processing.js';
+import { captureBatchImages } from './capture-images.js';
 import { createEventDispatcher } from './event-dispatch.js';
 import { createLiveReconcile } from './live-reconcile.js';
 import { createConfigReactionRegistry, computeTouchedPaths, loadReactionContext } from './config-reactions/index.js';
@@ -1109,6 +1110,14 @@ export async function main(): Promise<void> {
     additionalAdapters: config.capture.transcript_paths.map((p) =>
       createPerProjectAdapter(p, claudeCodeAdapter.parseTurns),
     ),
+    logger,
+    // Manifest plan tags — the miner strips plan envelopes from every
+    // response it persists (plan extraction reads raw turns, so Plan
+    // records survive intact).
+    planTags: symbiontPlanTags,
+    // Mining-path image capture: the same shared routine the Stop and
+    // plugin paths use; tenancy comes from the matched batch's project_id.
+    captureImages: (input) => captureBatchImages({ ...input, logger }),
   });
 
   const sessionBuffers = new Map<string, EventBuffer>();
@@ -1127,7 +1136,7 @@ export async function main(): Promise<void> {
     bufferDirs: () => listAllProjectBufferDirs(),
     logger,
     projectRoot,
-    onSessionReconciled: (sessionId) => reEnrichSessionFromTranscript(sessionId, { transcriptMiner, logger }),
+    onSessionReconciled: (sessionId) => reEnrichSessionFromTranscript(sessionId, { transcriptMiner, logger, planTags: symbiontPlanTags }),
     eventDedupCache,
     registry,
     machineId,

--- a/packages/myco/src/daemon/plan-capture.ts
+++ b/packages/myco/src/daemon/plan-capture.ts
@@ -24,6 +24,7 @@ import {
   normalizePlanSourcePath,
   TRANSCRIPT_SOURCE_PREFIX,
 } from '@myco/plans/identity.js';
+import { planTagEnvelopeRegex } from '@myco/plans/tag-envelopes.js';
 
 // ---------------------------------------------------------------------------
 // Transcript-based plan extraction
@@ -51,7 +52,10 @@ export function extractTaggedPlans(
   if (origin !== PROMPT_BATCH_ORIGIN.HUMAN) return [];
   const results: Array<{ tag: string; content: string }> = [];
   for (const tag of tags) {
-    const regex = new RegExp(`<${tag}>\\n?([\\s\\S]*?)\\n?</${tag}>`, 'g');
+    // Shared envelope shape — `stripPlanTagEnvelopes` removes exactly what
+    // this extracts, so persisted summaries can never retain an envelope
+    // that extraction recognized (or vice versa).
+    const regex = planTagEnvelopeRegex(tag);
     let match;
     while ((match = regex.exec(text)) !== null) {
       const content = match[1].trim();

--- a/packages/myco/src/daemon/session-reenrich.ts
+++ b/packages/myco/src/daemon/session-reenrich.ts
@@ -24,10 +24,13 @@ import { ALL_PROJECTS_SCOPE } from '../grove/ids.js';
 import { LOG_KINDS } from '../constants/log-kinds.js';
 import { TITLE_PREVIEW_CHARS } from './event-handlers.js';
 import { classifyNextPromptOrigin } from '../capture/prompt-kind.js';
+import { stripPlanTagEnvelopes } from '../plans/tag-envelopes.js';
 
 export interface ReEnrichDeps {
   transcriptMiner: TranscriptMiner;
   logger: DaemonLogger;
+  /** Manifest plan tags stripped from any response this path persists. */
+  planTags?: string[];
 }
 
 export interface ReEnrichResult {
@@ -101,7 +104,13 @@ export function reEnrichSessionFromTranscript(
   }
 
   const lastBatch = batches[batches.length - 1];
-  const lastTurnReply = turns[turns.length - 1]?.aiResponse?.trim();
+  // Parser-derived response — strip plan-tag envelopes at the persist point
+  // (same contract as the miner and stop paths; plan extraction never reads
+  // persisted summaries, so nothing is lost).
+  const lastTurnReplyRaw = turns[turns.length - 1]?.aiResponse?.trim();
+  const lastTurnReply = lastTurnReplyRaw
+    ? stripPlanTagEnvelopes(lastTurnReplyRaw, deps.planTags ?? [])
+    : undefined;
   if (lastBatch && lastTurnReply && !lastBatch.response_summary) {
     setResponseSummary(lastBatch.id, lastTurnReply);
     summarySet = true;

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -52,6 +52,7 @@ import type { RouteHandler } from './router.js';
 import type { RegisteredSession } from './lifecycle.js';
 import { cleanupAfterSessionCascade } from './jobs/session-cleanup.js';
 import type { PlanWatchConfig } from './plan-capture.js';
+import { stripPlanTagEnvelopes } from '@myco/plans/tag-envelopes.js';
 import { materializeCanopyAggregates } from '@myco/canopy/aggregate.js';
 import { materializeSessionMycoToolCalls } from '@myco/db/queries/myco-tool-usage.js';
 import { filesystemRootFromRequestContext, rowProjectIdFromRequestContext, type MycoRequestContext } from '@myco/grove/request-context.js';
@@ -383,8 +384,16 @@ export function createStopProcessor(deps: StopProcessorDeps): {
       // the matched case; this is the per-turn-transcript fallback
       // (Cursor), so target the human anchor.
       const summaryTarget = resolveResponseSummaryTarget(sessionId, latestBatch);
-      if (resolvedResponse && summaryTarget) {
-        try { setResponseSummary(summaryTarget.id, resolvedResponse); }
+      // Strip plan-tag envelopes at the persist point: the transcript-turn
+      // fallback above is parser-derived and can carry synthesized
+      // `<update_plan>` payloads (plan extraction below reads the raw turns,
+      // so it loses nothing). An envelope-only response strips to '' and is
+      // not persisted. Idempotent no-op for envelope-free text.
+      const persistableResponse = resolvedResponse
+        ? stripPlanTagEnvelopes(resolvedResponse, deps.planTags)
+        : undefined;
+      if (persistableResponse && summaryTarget) {
+        try { setResponseSummary(summaryTarget.id, persistableResponse); }
         catch (err) { logger.warn(LOG_KINDS.PROCESSOR_BATCH, 'Failed to set response_summary on latest batch', { error: String(err) }); }
       }
 
@@ -483,10 +492,14 @@ export function createStopProcessor(deps: StopProcessorDeps): {
     // turn order doesn't align with batch insertion order (Cursor starts its
     // transcript mid-session, daemon restarts renumber prompts, etc.).
     // Gated on transcript phase — allTurns is empty until Phase 1 runs.
+    // Plan-tag envelopes are stripped at this persist point too — the plan
+    // extraction pass below reads the UNSTRIPPED `allTurns`, so Plan records
+    // still capture every envelope while summaries carry only prose.
     const transcriptResponses = runTranscriptPhase
       ? allTurns
           .filter((t) => t.prompt && t.aiResponse)
-          .map((t) => ({ prompt: t.prompt, response: t.aiResponse! }))
+          .map((t) => ({ prompt: t.prompt, response: stripPlanTagEnvelopes(t.aiResponse!, deps.planTags) }))
+          .filter((r) => r.response.trim().length > 0)
       : [];
     if (transcriptResponses.length > 0) {
       try { populateBatchResponses(sessionId, transcriptResponses); }

--- a/packages/myco/src/db/queries/attachments.ts
+++ b/packages/myco/src/db/queries/attachments.ts
@@ -185,6 +185,62 @@ export function insertAttachment(data: AttachmentInsert): AttachmentRow | undefi
 }
 
 /**
+ * Find an attachment within a session by its content hash — the
+ * content-keyed dedup identity for captured images. Returns metadata only
+ * (no BLOB); callers use this to decide whether the same bytes were
+ * already persisted for the session, regardless of which prompt_number
+ * they were first captured under.
+ */
+export function findAttachmentBySessionContentHash(
+  sessionId: string,
+  contentHash: string,
+): AttachmentListRow | null {
+  const db = getDatabase();
+
+  const row = db.prepare(
+    `SELECT ${SELECT_LIST_COLUMNS} FROM attachments
+      WHERE session_id = ? AND content_hash = ? LIMIT 1`,
+  ).get(sessionId, contentHash) as Record<string, unknown> | undefined;
+
+  return row ? toAttachmentListRow(row) : null;
+}
+
+/**
+ * List a session's attachments that predate content-hash stamping (BLOB
+ * present, `content_hash` NULL). The image-capture path lazily backfills
+ * these so legacy rows participate in content-keyed dedup without a
+ * schema migration: once stamped, a row never reappears here.
+ */
+export function listAttachmentsMissingContentHash(sessionId: string): AttachmentRow[] {
+  const db = getDatabase();
+
+  const rows = db.prepare(
+    `SELECT ${SELECT_COLUMNS} FROM attachments
+      WHERE session_id = ? AND content_hash IS NULL AND data IS NOT NULL`,
+  ).all(sessionId) as Record<string, unknown>[];
+
+  return rows.map(toAttachmentRow);
+}
+
+/** Stamp a computed content hash onto an existing attachment row. */
+export function setAttachmentContentHash(id: string, contentHash: string): void {
+  getDatabase().prepare(
+    `UPDATE attachments SET content_hash = ? WHERE id = ?`,
+  ).run(contentHash, id);
+}
+
+/**
+ * Link an attachment to a prompt batch ONLY when it has no linkage yet.
+ * Used on content-dedup hits: a row first captured before its batch was
+ * known gains the linkage on re-capture instead of staying orphaned.
+ */
+export function linkAttachmentToBatchIfUnlinked(id: string, promptBatchId: number): void {
+  getDatabase().prepare(
+    `UPDATE attachments SET prompt_batch_id = ? WHERE id = ? AND prompt_batch_id IS NULL`,
+  ).run(promptBatchId, id);
+}
+
+/**
  * List all attachments for a given session, ordered by created_at ASC.
  *
  * The `data` BLOB column is intentionally excluded — use getAttachmentByFilePath

--- a/packages/myco/src/plans/tag-envelopes.ts
+++ b/packages/myco/src/plans/tag-envelopes.ts
@@ -1,0 +1,34 @@
+/**
+ * Plan-tag envelope helpers.
+ *
+ * A symbiont's plan output travels inside XML-style envelopes
+ * (`<update_plan>…</update_plan>`, `<proposed_plan>…</proposed_plan>` —
+ * tag names come from each manifest's `capture.planTags`). Extraction
+ * (`extractTaggedPlans` in daemon/plan-capture.ts) persists the envelope
+ * content as Plan records; the response-persist paths must then strip the
+ * envelopes so machine-readable plan payloads never leak into user-facing
+ * `response_summary` values. Both sides share the envelope regex here so
+ * what extraction matches and what stripping removes can never drift.
+ */
+
+/** Canonical regex matching every `<tag>…</tag>` plan envelope in a text. */
+export function planTagEnvelopeRegex(tag: string): RegExp {
+  return new RegExp(`<${tag}>\\n?([\\s\\S]*?)\\n?</${tag}>`, 'g');
+}
+
+/**
+ * Remove every `<tag>…</tag>` envelope for the given plan tags from `text`,
+ * keeping the surrounding prose. Collapses the blank runs left behind and
+ * trims the result; an envelope-only text strips to `''` (callers treat
+ * that as "no response to persist"). Texts without any envelope are
+ * returned unchanged.
+ */
+export function stripPlanTagEnvelopes(text: string, planTags: readonly string[]): string {
+  if (!text || planTags.length === 0) return text;
+  let out = text;
+  for (const tag of planTags) {
+    out = out.replace(planTagEnvelopeRegex(tag), '');
+  }
+  if (out === text) return text;
+  return out.replace(/\n{3,}/g, '\n\n').trim();
+}

--- a/packages/myco/src/symbionts/codex.ts
+++ b/packages/myco/src/symbionts/codex.ts
@@ -1,11 +1,14 @@
 import type { SymbiontAdapter } from './adapter.js';
 import { CodexJsonlParser } from './parsers/codex-jsonl.js';
+import { systemEnvelopePrefixes } from './envelope-prefixes.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 
 const TRANSCRIPT_BASE = path.join(os.homedir(), '.codex');
-const codexParser = new CodexJsonlParser();
+// Envelope prefixes come from the codex manifest's capture rules (via the
+// generated hook config) — the parser must never hardcode prompt strings.
+const codexParser = new CodexJsonlParser({ envelopePrefixes: systemEnvelopePrefixes('codex') });
 
 /**
  * Find a Codex transcript file by session ID.

--- a/packages/myco/src/symbionts/envelope-prefixes.ts
+++ b/packages/myco/src/symbionts/envelope-prefixes.ts
@@ -1,0 +1,32 @@
+/**
+ * Manifest-derived system-envelope prompt prefixes.
+ *
+ * Symbiont runtimes inject synthetic user-role transcript entries — skill
+ * expansions, sub-agent notifications, environment refreshes. Each manifest
+ * already classifies those via `capture.rules` entries of the form
+ * `{ event: user_prompt, when: { prompt_starts_with }, action: classify,
+ * set_origin: <non-human> }`. This helper harvests the prefixes from the
+ * build-time generated hook config so transcript parsers can treat such
+ * entries as mid-turn envelopes rather than turn boundaries — without any
+ * prompt strings hardcoded in parser code.
+ */
+
+import { HOOK_CONFIG } from '../hooks/hook-config.generated.js';
+
+/**
+ * Prompt prefixes whose user-role transcript entries are runtime-synthesized
+ * system envelopes for `agent`, per its manifest capture rules. A user
+ * message starting with one of these is NOT a new conversational turn.
+ */
+export function systemEnvelopePrefixes(agent: string): string[] {
+  const rules = HOOK_CONFIG[agent]?.captureRules ?? [];
+  const prefixes: string[] = [];
+  for (const rule of rules) {
+    if (rule.event !== 'user_prompt') continue;
+    if (rule.action !== 'classify') continue;
+    if (!rule.set_origin || rule.set_origin === 'human') continue;
+    const prefix = rule.when.prompt_starts_with;
+    if (prefix) prefixes.push(prefix);
+  }
+  return prefixes;
+}

--- a/packages/myco/src/symbionts/parsers/codex-jsonl.ts
+++ b/packages/myco/src/symbionts/parsers/codex-jsonl.ts
@@ -61,6 +61,21 @@ function cleanCodexPromptText(text: string): string {
   return text;
 }
 
+/** Construction options for {@link CodexJsonlParser}. */
+export interface CodexJsonlParserOptions {
+  /**
+   * User-message prefixes that mark runtime-synthesized system envelopes
+   * (manifest-derived — see `symbionts/envelope-prefixes.ts`). An envelope
+   * user message folds into the CURRENT turn: it neither replaces the
+   * turn's prompt nor starts a new one, so the assistant output that
+   * follows it stays attached to the prompt that opened the turn. Without
+   * this, a `$skill` expansion (a second user-role response_item) opened a
+   * fresh turn that absorbed the real prompt's response, stranding the
+   * human batch without a summary.
+   */
+  envelopePrefixes?: readonly string[];
+}
+
 /**
  * Canonical Codex `content[]` → prompt-text routine. Image prompts arrive as
  * multipart content — `<image …>` wrapper `input_text` tags and `input_image`
@@ -98,8 +113,15 @@ export function extractCodexPromptText(content: unknown): string {
  * - Images are data URLs in "input_image" blocks (data:<mime>;base64,<data>), not structured source objects
  * - Codex Desktop wraps prompts with file-mention preambles and <image> tags when screenshots are attached — these are stripped
  * - Non-conversation entries (event_msg, session_meta, turn_context, reasoning) are skipped
+ * - System-envelope user messages (manifest-declared prefixes) fold into the current turn
  */
 export class CodexJsonlParser implements TranscriptParser {
+  private readonly envelopePrefixes: readonly string[];
+
+  constructor(options: CodexJsonlParserOptions = {}) {
+    this.envelopePrefixes = options.envelopePrefixes ?? [];
+  }
+
   parseTurns(content: string): TranscriptTurn[] {
     const lines = content.split('\n').filter(Boolean);
     const turns: TranscriptTurn[] = [];
@@ -152,6 +174,15 @@ export class CodexJsonlParser implements TranscriptParser {
       if (role === 'user') {
         const fullPrompt = extractCodexPromptText(blocks);
         if (!fullPrompt) continue;
+
+        // System envelopes are not turn boundaries. Match against the RAW
+        // text of the first text block — the same view the live hook and
+        // the transcript walker evaluate `prompt_starts_with` rules on.
+        // The envelope's text is dropped here (the walker records it as a
+        // system-origin batch separately); the turn stays open so the
+        // assistant output that follows lands on the prompt that opened it.
+        const firstRawText = blocks.find((b) => b.type === 'input_text' && b.text?.trim())?.text ?? '';
+        if (this.envelopePrefixes.some((p) => firstRawText.startsWith(p))) continue;
 
         if (current) turns.push(current);
 

--- a/tests/capture/plan-tag-envelopes.test.ts
+++ b/tests/capture/plan-tag-envelopes.test.ts
@@ -1,0 +1,66 @@
+/**
+ * RC-F — stripPlanTagEnvelopes: plan envelopes never reach persisted
+ * response summaries, while the extraction channel (which reads raw parser
+ * turns) keeps receiving them. The strip and extraction share one regex
+ * (`planTagEnvelopeRegex`) so they can never drift.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { stripPlanTagEnvelopes, planTagEnvelopeRegex } from '@myco/plans/tag-envelopes.js';
+import { extractTaggedPlans } from '@myco/daemon/plan-capture.js';
+
+const PLAN_BODY = '## Plan\n\n- [x] step one\n- [ ] step two';
+const envelope = (body: string = PLAN_BODY) => `<update_plan>\n${body}\n</update_plan>`;
+
+describe('stripPlanTagEnvelopes', () => {
+  it('removes every envelope and keeps the surrounding prose', () => {
+    const text = `Working on it.\n\n${envelope()}\n\nDone with phase one.\n\n${envelope('## Plan\n\n- [x] all done')}\n\nShip it.`;
+
+    const stripped = stripPlanTagEnvelopes(text, ['update_plan']);
+
+    expect(stripped).not.toContain('<update_plan>');
+    expect(stripped).not.toContain('</update_plan>');
+    expect(stripped).toContain('Working on it.');
+    expect(stripped).toContain('Done with phase one.');
+    expect(stripped).toContain('Ship it.');
+    expect(stripped).not.toMatch(/\n{3,}/); // no blank-run residue
+  });
+
+  it('strips an envelope-only response to the empty string', () => {
+    expect(stripPlanTagEnvelopes(envelope(), ['update_plan'])).toBe('');
+  });
+
+  it('handles many envelopes (production: 7× in one summary)', () => {
+    const text = Array.from({ length: 7 }, (_, i) => envelope(`## Plan\n\n- [ ] rev ${i}`)).join('\n\n');
+    expect(stripPlanTagEnvelopes(text, ['update_plan'])).toBe('');
+  });
+
+  it('returns envelope-free text unchanged (identity, no re-trim)', () => {
+    const text = '  prose with leading whitespace preserved\n\nand a <update_plan tag-lookalike';
+    expect(stripPlanTagEnvelopes(text, ['update_plan'])).toBe(text);
+  });
+
+  it('only strips the configured tags', () => {
+    const text = `<proposed_plan>\nkeep me\n</proposed_plan>\n\n${envelope()}`;
+    const stripped = stripPlanTagEnvelopes(text, ['update_plan']);
+    expect(stripped).toContain('<proposed_plan>');
+    expect(stripped).not.toContain('<update_plan>');
+  });
+
+  it('no-ops with an empty tag list', () => {
+    const text = envelope();
+    expect(stripPlanTagEnvelopes(text, [])).toBe(text);
+  });
+
+  it('strip removes exactly what extraction matches (shared regex)', () => {
+    const text = `prose before\n\n${envelope()}\n\nprose after`;
+    const extracted = extractTaggedPlans(text, ['update_plan']);
+    const stripped = stripPlanTagEnvelopes(text, ['update_plan']);
+
+    expect(extracted).toHaveLength(1);
+    expect(extracted[0].content).toBe(PLAN_BODY);
+    // Everything extraction matched is gone; everything else survives.
+    expect(stripped).toBe('prose before\n\nprose after');
+    expect(text.match(planTagEnvelopeRegex('update_plan'))).toHaveLength(1);
+  });
+});

--- a/tests/capture/transcript-miner-codex-fidelity.test.ts
+++ b/tests/capture/transcript-miner-codex-fidelity.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Codex miner fidelity — end-to-end over a production-shaped rollout.
+ *
+ * One transcript exercises three RCs at once:
+ *  - RC-B: a `$skill` expansion (second user-role response_item) folds into
+ *    the human turn, so the assistant's answer lands on the HUMAN batch and
+ *    the envelope system batch keeps a NULL summary.
+ *  - RC-F: the parser-synthesized `<update_plan>` envelope is stripped from
+ *    the persisted response_summary, while plan extraction (raw turns) still
+ *    receives it.
+ *  - RC-D(2): images carried on the turn reach the injected mining-path
+ *    capture sink, attributed to the matched batch with the batch's own
+ *    project tenancy.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'bun:test';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
+import { TranscriptMiner, type MinedImageCapture } from '@myco/capture/transcript-miner.js';
+import { upsertSession } from '@myco/db/queries/sessions.js';
+import { insertBatch, listBatchesBySession } from '@myco/db/queries/batches.js';
+import { extractTaggedPlans } from '@myco/daemon/plan-capture.js';
+import { codexAdapter } from '@myco/symbionts/codex.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+const PROJECT_ID = `proj_${'ab'.repeat(16)}`;
+
+/** 1x1 transparent PNG encoded as base64 — smallest valid PNG. */
+const PNG_1x1 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9ZuUKhUAAAAASUVORK5CYII=';
+
+const HUMAN_PROMPT = 'Run the review skill and plan the fixes';
+const SKILL_ENVELOPE = '<skill>\n# Review skill\nFollow the procedure…\n</skill>';
+const PROSE = 'Review complete. Two findings, both fixed.';
+
+function buildRollout(): string {
+  const entries = [
+    { timestamp: '2026-06-12T10:00:00Z', type: 'session_meta', payload: { id: 'rollout-1', source: 'vscode' } },
+    {
+      timestamp: '2026-06-12T10:00:01Z',
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [
+          { type: 'input_text', text: HUMAN_PROMPT },
+          { type: 'input_image', image_url: `data:image/png;base64,${PNG_1x1}` },
+        ],
+      },
+    },
+    {
+      timestamp: '2026-06-12T10:00:02Z',
+      type: 'response_item',
+      payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: SKILL_ENVELOPE }] },
+    },
+    {
+      timestamp: '2026-06-12T10:00:10Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call',
+        name: 'update_plan',
+        arguments: JSON.stringify({ plan: [
+          { step: 'Fix finding one', status: 'completed' },
+          { step: 'Fix finding two', status: 'in_progress' },
+        ] }),
+      },
+    },
+    {
+      timestamp: '2026-06-12T10:00:30Z',
+      type: 'response_item',
+      payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: PROSE }] },
+    },
+  ];
+  return entries.map((e) => JSON.stringify(e)).join('\n') + '\n';
+}
+
+describe('TranscriptMiner — codex fidelity (RC-B / RC-F / RC-D mining path)', () => {
+  let tmpDir: string;
+  let transcriptPath: string;
+  const sessionId = 's-codex-fidelity';
+
+  beforeAll(() => { setupTestDb(); });
+  afterAll(teardownTestDb);
+  beforeEach(() => {
+    cleanTestDb();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-fidelity-'));
+    transcriptPath = path.join(tmpDir, 'rollout.jsonl');
+    fs.writeFileSync(transcriptPath, buildRollout());
+    const now = epochNow();
+    upsertSession({ id: sessionId, agent: 'codex', project_id: PROJECT_ID, started_at: now, created_at: now });
+  });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  function seedLiveBatches() {
+    const now = epochNow();
+    const human = insertBatch({
+      session_id: sessionId, prompt_number: 1, user_prompt: HUMAN_PROMPT,
+      origin: 'human', started_at: now, created_at: now,
+    });
+    const envelope = insertBatch({
+      session_id: sessionId, prompt_number: 2, user_prompt: SKILL_ENVELOPE,
+      origin: 'system', started_at: now, ended_at: now, created_at: now,
+    });
+    return { human, envelope };
+  }
+
+  it('response lands on the HUMAN batch without plan envelopes; the skill envelope batch stays NULL; images reach the sink', () => {
+    const { human, envelope } = seedLiveBatches();
+    const sinkCalls: MinedImageCapture[] = [];
+    const miner = new TranscriptMiner({
+      planTags: ['update_plan'],
+      captureImages: (input) => sinkCalls.push(input),
+    });
+
+    const result = miner.reconcileAndAttributeResponses(sessionId, {
+      agent: 'codex',
+      transcriptPath,
+    });
+    expect(result.skippedReason).toBeUndefined();
+
+    const batches = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    const humanRow = batches.find((b) => b.id === human.id)!;
+    const envelopeRow = batches.find((b) => b.id === envelope.id)!;
+
+    // RC-B: the human prompt's turn owns the assistant output.
+    expect(humanRow.response_summary).toContain(PROSE);
+    // RC-F: no machine-readable plan payload in the user-facing summary.
+    expect(humanRow.response_summary).not.toContain('<update_plan>');
+    expect(humanRow.response_summary).not.toContain('</update_plan>');
+    // RC-B: an envelope batch matches no transcript turn — NULL is correct.
+    expect(envelopeRow.response_summary).toBeNull();
+
+    // RC-D(2): the turn's image was attributed to the matched human batch,
+    // with tenancy from the batch row itself.
+    expect(sinkCalls).toHaveLength(1);
+    expect(sinkCalls[0].sessionId).toBe(sessionId);
+    expect(sinkCalls[0].promptBatchId).toBe(human.id);
+    expect(sinkCalls[0].promptNumber).toBe(1);
+    expect(sinkCalls[0].projectId).toBe(PROJECT_ID);
+    expect(sinkCalls[0].images).toEqual([{ mediaType: 'image/png', data: PNG_1x1 }]);
+  });
+
+  it('plan extraction still receives the envelopes the persisted summary loses', () => {
+    seedLiveBatches();
+    const miner = new TranscriptMiner({ planTags: ['update_plan'] });
+    miner.reconcileAndAttributeResponses(sessionId, { agent: 'codex', transcriptPath });
+
+    // The extraction channel reads RAW parser turns (the Stop pipeline's
+    // input), not persisted summaries — so the Plan record pipeline keeps
+    // seeing the envelope after mining stripped it from the summary.
+    const turns = codexAdapter.parseTurns(fs.readFileSync(transcriptPath, 'utf-8'));
+    expect(turns).toHaveLength(1); // RC-B: envelope folded, single turn
+    const plans = extractTaggedPlans(turns[0].aiResponse!, ['update_plan']);
+    expect(plans).toHaveLength(1);
+    expect(plans[0].tag).toBe('update_plan');
+    expect(plans[0].content).toContain('- [x] Fix finding one');
+    expect(plans[0].content).toContain('- [~] Fix finding two');
+  });
+
+  it('an envelope-only assistant turn persists no summary at all', () => {
+    // Rollout where the assistant emitted ONLY an update_plan call.
+    const entries = [
+      { timestamp: '2026-06-12T11:00:00Z', type: 'session_meta', payload: { id: 'rollout-2', source: 'vscode' } },
+      {
+        timestamp: '2026-06-12T11:00:01Z',
+        type: 'response_item',
+        payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'plan only please' }] },
+      },
+      {
+        timestamp: '2026-06-12T11:00:10Z',
+        type: 'response_item',
+        payload: {
+          type: 'function_call',
+          name: 'update_plan',
+          arguments: JSON.stringify({ plan: [{ step: 'Only step', status: 'pending' }] }),
+        },
+      },
+    ];
+    fs.writeFileSync(transcriptPath, entries.map((e) => JSON.stringify(e)).join('\n') + '\n');
+    const now = epochNow();
+    const batch = insertBatch({
+      session_id: sessionId, prompt_number: 1, user_prompt: 'plan only please',
+      origin: 'human', started_at: now, created_at: now,
+    });
+
+    const miner = new TranscriptMiner({ planTags: ['update_plan'] });
+    miner.reconcileAndAttributeResponses(sessionId, { agent: 'codex', transcriptPath });
+
+    const row = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE }).find((b) => b.id === batch.id)!;
+    expect(row.response_summary).toBeNull(); // stripped to '' → filtered, not persisted
+  });
+});

--- a/tests/capture/transcript-miner-meta-gate.test.ts
+++ b/tests/capture/transcript-miner-meta-gate.test.ts
@@ -1,0 +1,186 @@
+/**
+ * RC-E — transcript-level drop gate + transcript_meta rule parity.
+ *
+ * 1. A transcript whose session_meta matches a manifest drop rule (e.g.
+ *    Codex sub-agent thread spawns: `source.subagent`) must skip the ENTIRE
+ *    mining pass — no batches created, no responses attributed. This kills
+ *    the child-into-parent class: Codex sub-agent tool events carry the
+ *    PARENT session_id with the CHILD transcript_path, so mining the child
+ *    rollout grafted foreign kickoffs onto the parent session.
+ *
+ * 2. Per-prompt `transcript_meta_*` rules must fire identically in hook
+ *    context (evaluateUserPromptRules with meta) and walker context
+ *    (extractUserPromptRecordsWithDrops with meta) — pre-fix the walker
+ *    never received meta, so every such rule was structurally inert at
+ *    mining time.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'bun:test';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
+import { seedSession } from '../helpers/sessions.js';
+import { TranscriptMiner, type MinerLogger } from '@myco/capture/transcript-miner.js';
+import { extractUserPromptRecordsWithDrops } from '@myco/capture/prompt-kind.js';
+import { evaluateUserPromptRules } from '@myco/hooks/capture-rules.js';
+import { listBatchesBySession } from '@myco/db/queries/batches.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+interface LogCall { level: string; kind: string; message: string; data?: Record<string, unknown> }
+
+function collectingLogger(): { logger: MinerLogger; calls: LogCall[] } {
+  const calls: LogCall[] = [];
+  return {
+    calls,
+    logger: {
+      info: (kind, message, data) => calls.push({ level: 'info', kind, message, data }),
+      warn: (kind, message, data) => calls.push({ level: 'warn', kind, message, data }),
+    },
+  };
+}
+
+function codexUserEntry(text: string, timestamp: string): Record<string, unknown> {
+  return {
+    timestamp,
+    type: 'response_item',
+    payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text }] },
+  };
+}
+
+function codexAssistantEntry(text: string, timestamp: string): Record<string, unknown> {
+  return {
+    timestamp,
+    type: 'response_item',
+    payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text }] },
+  };
+}
+
+function sessionMetaEntry(source: unknown): Record<string, unknown> {
+  return { timestamp: '2026-06-12T10:00:00Z', type: 'session_meta', payload: { id: 'rollout-meta', source } };
+}
+
+function writeTranscript(filePath: string, entries: Record<string, unknown>[]): void {
+  fs.writeFileSync(filePath, entries.map((e) => JSON.stringify(e)).join('\n') + '\n');
+}
+
+const SUBAGENT_META = { subagent: { thread_spawn: { parent: 'whatever' } } };
+
+describe('TranscriptMiner — transcript-level drop gate (RC-E layer 1)', () => {
+  let tmpDir: string;
+  let transcriptPath: string;
+
+  beforeAll(() => { setupTestDb(); });
+  afterAll(teardownTestDb);
+  beforeEach(() => {
+    cleanTestDb();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'meta-gate-test-'));
+    transcriptPath = path.join(tmpDir, 'rollout.jsonl');
+    seedSession({ id: 's-meta-gate', agent: 'codex' });
+  });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  const conversation = [
+    codexUserEntry('Kickoff: review the diff for correctness', '2026-06-12T10:00:01Z'),
+    codexAssistantEntry('Reviewing now.', '2026-06-12T10:00:30Z'),
+  ];
+
+  it('skips the entire mining pass for a subagent-thread transcript, with an info log', () => {
+    writeTranscript(transcriptPath, [sessionMetaEntry(SUBAGENT_META), ...conversation]);
+    const { logger, calls } = collectingLogger();
+    const miner = new TranscriptMiner({ logger });
+
+    const result = miner.reconcileAndAttributeResponses('s-meta-gate', {
+      agent: 'codex',
+      transcriptPath,
+    });
+
+    expect(result.skippedReason).toBe('subagent-thread-spawn');
+    expect(result.inserted).toBe(0);
+    expect(result.reclassified).toBe(0);
+    // No batches were created in the (parent) session.
+    expect(listBatchesBySession('s-meta-gate', { scope: ALL_PROJECTS_SCOPE })).toHaveLength(0);
+    // Info log carries session, path, and reason.
+    const skip = calls.find((c) => c.message.startsWith('Mining skipped'));
+    expect(skip).toBeDefined();
+    expect(skip!.level).toBe('info');
+    expect(skip!.data).toMatchObject({
+      session_id: 's-meta-gate',
+      transcript_path: transcriptPath,
+      reason: 'subagent-thread-spawn',
+    });
+  });
+
+  it('logs the skip once per transcript, not once per reconcile tick', () => {
+    writeTranscript(transcriptPath, [sessionMetaEntry(SUBAGENT_META), ...conversation]);
+    const { logger, calls } = collectingLogger();
+    const miner = new TranscriptMiner({ logger });
+
+    miner.reconcileAndAttributeResponses('s-meta-gate', { agent: 'codex', transcriptPath });
+    miner.reconcileAndAttributeResponses('s-meta-gate', { agent: 'codex', transcriptPath });
+    miner.reconcileAndAttributeResponses('s-meta-gate', { agent: 'codex', transcriptPath });
+
+    expect(calls.filter((c) => c.message.startsWith('Mining skipped'))).toHaveLength(1);
+  });
+
+  it('mines normally when the same transcript lacks the subagent meta', () => {
+    writeTranscript(transcriptPath, [sessionMetaEntry('vscode'), ...conversation]);
+    const miner = new TranscriptMiner();
+
+    const result = miner.reconcileAndAttributeResponses('s-meta-gate', {
+      agent: 'codex',
+      transcriptPath,
+    });
+
+    expect(result.skippedReason).toBeUndefined();
+    expect(result.inserted).toBe(1);
+    const batches = listBatchesBySession('s-meta-gate', { scope: ALL_PROJECTS_SCOPE });
+    expect(batches).toHaveLength(1);
+    expect(batches[0].user_prompt).toBe('Kickoff: review the diff for correctness');
+    expect(batches[0].response_summary).toBe('Reviewing now.');
+  });
+
+  it('drops a `source: exec` transcript via the same gate (noninteractive-exec rule)', () => {
+    writeTranscript(transcriptPath, [sessionMetaEntry('exec'), ...conversation]);
+    const miner = new TranscriptMiner();
+
+    const result = miner.reconcileBatchKinds('s-meta-gate', { agent: 'codex', transcriptPath });
+
+    expect(result.skippedReason).toBe('noninteractive-exec');
+    expect(listBatchesBySession('s-meta-gate', { scope: ALL_PROJECTS_SCOPE })).toHaveLength(0);
+  });
+});
+
+describe('transcript_meta rules — hook/walker parity (RC-E layer 2)', () => {
+  const prompt = 'Kickoff prompt from a subagent thread';
+  const events = [codexUserEntry(prompt, '2026-06-12T10:00:01Z')];
+  const meta = { id: 'rollout-meta', source: SUBAGENT_META };
+
+  it('a per-prompt transcript_meta rule fires identically in hook and walker contexts', () => {
+    // Hook context — codex layer 4: user_prompt + transcript_meta_field_exists
+    // source.subagent → drop.
+    const hookDecision = evaluateUserPromptRules('codex', {
+      prompt,
+      transcriptPath: '/tmp/rollout.jsonl',
+      transcriptMeta: meta,
+    });
+    expect(hookDecision.action).toBe('drop');
+
+    // Walker context — same meta supplied, same outcome.
+    const walked = extractUserPromptRecordsWithDrops('codex', events, '/tmp/rollout.jsonl', meta);
+    expect(walked.records).toHaveLength(0);
+    expect(walked.droppedText).toEqual([prompt]);
+  });
+
+  it('without meta, both contexts pass the prompt through (no false drops)', () => {
+    const hookDecision = evaluateUserPromptRules('codex', {
+      prompt,
+      transcriptPath: '/tmp/rollout.jsonl',
+    });
+    expect(hookDecision.action).toBe('pass');
+
+    const walked = extractUserPromptRecordsWithDrops('codex', events, '/tmp/rollout.jsonl');
+    expect(walked.records.map((r) => r.text)).toEqual([prompt]);
+    expect(walked.droppedText).toHaveLength(0);
+  });
+});

--- a/tests/daemon/capture-images.test.ts
+++ b/tests/daemon/capture-images.test.ts
@@ -226,3 +226,119 @@ describe('captureBatchImages', () => {
     expect(rows[0].prompt_batch_id).toBeNull();
   });
 });
+
+/**
+ * RC-D — content-keyed attachment identity. Dedup keys on a sha256 of
+ * (media type + bytes) per session, NOT on (prompt_number, index): walker
+ * renumbering between Stops used to mint a fresh prompt-number id for
+ * identical bytes and duplicate the BLOB (production: 3 duplicate rows).
+ */
+describe('captureBatchImages — content-keyed identity (RC-D)', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => { cleanTestDb(); });
+
+  /** A second, distinct valid base64 payload (different bytes than PNG_1x1). */
+  const PNG_OTHER = Buffer.from('not-actually-a-png-but-distinct-bytes-1').toString('base64');
+
+  const rowsFor = (sessionId: string) =>
+    getDatabase()
+      .prepare('SELECT id, file_path, prompt_batch_id, content_hash FROM attachments WHERE session_id = ? ORDER BY created_at, id')
+      .all(sessionId) as Array<Record<string, unknown>>;
+
+  it('same content captured under a renumbered prompt → ONE attachment row', () => {
+    const sessionId = 'test-captureimg-renumber';
+    const now = epochNow();
+    upsertSession({ id: sessionId, agent: 'codex', started_at: now, created_at: now });
+    const batch = insertBatch({
+      session_id: sessionId, prompt_number: 2, user_prompt: 'with image',
+      started_at: now, created_at: now,
+    });
+
+    const image = { data: PNG_1x1, mediaType: 'image/png' };
+
+    // Stop 1: captured at prompt_number 2.
+    captureBatchImages({ sessionId, promptBatchId: batch.id, promptNumber: 2, images: [image], logger: stubLogger() });
+    // Walker renumbering between Stops: same image re-captured at 3.
+    captureBatchImages({ sessionId, promptBatchId: batch.id, promptNumber: 3, images: [image], logger: stubLogger() });
+
+    const rows = rowsFor(sessionId);
+    expect(rows).toHaveLength(1);
+    expect(String(rows[0].content_hash)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('different images at the same prompt_number slot → both kept', () => {
+    const sessionId = 'test-captureimg-distinct';
+    const now = epochNow();
+    upsertSession({ id: sessionId, agent: 'codex', started_at: now, created_at: now });
+    const batch = insertBatch({
+      session_id: sessionId, prompt_number: 1, user_prompt: 'two captures',
+      started_at: now, created_at: now,
+    });
+
+    captureBatchImages({
+      sessionId, promptBatchId: batch.id, promptNumber: 1,
+      images: [{ data: PNG_1x1, mediaType: 'image/png' }], logger: stubLogger(),
+    });
+    // Renumbering swapped slots: a DIFFERENT image now claims (1, 1).
+    captureBatchImages({
+      sessionId, promptBatchId: batch.id, promptNumber: 1,
+      images: [{ data: PNG_OTHER, mediaType: 'image/png' }], logger: stubLogger(),
+    });
+
+    const rows = rowsFor(sessionId);
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((r) => String(r.id))).size).toBe(2);
+    expect(new Set(rows.map((r) => String(r.file_path))).size).toBe(2);
+    // The disambiguated row keeps the parseable -t{n}- marker.
+    for (const r of rows) expect(String(r.file_path)).toMatch(/-t1-/);
+  });
+
+  it('legacy rows (NULL content_hash) are lazily stamped and participate in dedup', () => {
+    const sessionId = 'test-captureimg-legacy';
+    const now = epochNow();
+    upsertSession({ id: sessionId, agent: 'codex', started_at: now, created_at: now });
+    const batch = insertBatch({
+      session_id: sessionId, prompt_number: 1, user_prompt: 'legacy',
+      started_at: now, created_at: now,
+    });
+
+    // A pre-content-keying row: prompt-number id, BLOB present, hash NULL.
+    getDatabase().prepare(
+      `INSERT INTO attachments (id, session_id, prompt_batch_id, file_path, media_type, data, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run('legacy-b1-1', sessionId, batch.id, 'legacy-t1-1.png', 'image/png', Buffer.from(PNG_1x1, 'base64'), now);
+
+    // Re-capture of the SAME bytes under a different prompt number (the
+    // duplication class) must dedup against the freshly-stamped legacy row.
+    captureBatchImages({
+      sessionId, promptBatchId: batch.id, promptNumber: 4,
+      images: [{ data: PNG_1x1, mediaType: 'image/png' }], logger: stubLogger(),
+    });
+
+    const rows = rowsFor(sessionId);
+    expect(rows).toHaveLength(1);
+    expect(String(rows[0].id)).toBe('legacy-b1-1');
+    expect(String(rows[0].content_hash)).toMatch(/^[0-9a-f]{64}$/); // stamped
+  });
+
+  it('a dedup hit upgrades missing batch linkage instead of dropping it', () => {
+    const sessionId = 'test-captureimg-linkup';
+    const now = epochNow();
+    upsertSession({ id: sessionId, agent: 'codex', started_at: now, created_at: now });
+    const batch = insertBatch({
+      session_id: sessionId, prompt_number: 1, user_prompt: 'late linkage',
+      started_at: now, created_at: now,
+    });
+
+    const image = { data: PNG_1x1, mediaType: 'image/png' };
+    // First capture before the batch was known.
+    captureBatchImages({ sessionId, promptBatchId: null, promptNumber: 1, images: [image], logger: stubLogger() });
+    // Re-capture once matched to a batch.
+    captureBatchImages({ sessionId, promptBatchId: batch.id, promptNumber: 1, images: [image], logger: stubLogger() });
+
+    const rows = rowsFor(sessionId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].prompt_batch_id).toBe(batch.id);
+  });
+});

--- a/tests/db/queries/batches.test.ts
+++ b/tests/db/queries/batches.test.ts
@@ -591,6 +591,27 @@ describe('prompt batch query helpers', () => {
       expect(summaryOf(human.id)).toBe('human answer\n\nmid-turn system note');
       expect(summaryOf(system.id)).toBeNull(); // cleared — rolled into the anchor
     });
+
+    it('codex skill-expansion shape: the human batch receives the response, the envelope batch stays NULL (RC-B)', () => {
+      // Production shape: the live hook captured a human prompt batch and a
+      // <skill> envelope system batch. The fixed parser folds the envelope
+      // into the human turn, so the transcript yields ONE turn keyed on the
+      // HUMAN prompt. The response must land on the human batch; the
+      // envelope batch matches nothing — NULL is correct for an envelope.
+      const human = insertBatch(makeBatch(sessionId, {
+        user_prompt: 'Run the review skill on this diff', origin: 'human', prompt_number: 1,
+      }));
+      const envelope = insertBatch(makeBatch(sessionId, {
+        user_prompt: '<skill>\n# Review skill\nDo the steps…\n</skill>', origin: 'system', prompt_number: 2,
+      }));
+
+      populateBatchResponses(sessionId, [
+        { prompt: 'Run the review skill on this diff', response: 'Review complete: two findings.' },
+      ]);
+
+      expect(summaryOf(human.id)).toBe('Review complete: two findings.');
+      expect(summaryOf(envelope.id)).toBeNull();
+    });
   });
 
   describe('getLatestBatch — origin filter', () => {

--- a/tests/symbionts/parsers/codex-jsonl.test.ts
+++ b/tests/symbionts/parsers/codex-jsonl.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'bun:test';
 import { CodexJsonlParser } from '@myco/symbionts/parsers/codex-jsonl.js';
+import { systemEnvelopePrefixes } from '@myco/symbionts/envelope-prefixes.js';
 
 /**
  * Build a JSONL string from an array of entry objects.
@@ -389,5 +390,95 @@ describe('CodexJsonlParser', () => {
 
     expect(turns).toHaveLength(1);
     expect(turns[0].toolCount).toBe(0); // function_call before user message is ignored
+  });
+});
+
+describe('CodexJsonlParser — system envelope folding (RC-B)', () => {
+  const envelopeParser = new CodexJsonlParser({
+    envelopePrefixes: systemEnvelopePrefixes('codex'),
+  });
+
+  it('manifest-derived prefixes cover the codex envelope set', () => {
+    const prefixes = systemEnvelopePrefixes('codex');
+    expect(prefixes).toContain('<skill>');
+    expect(prefixes).toContain('<subagent_notification>');
+    expect(prefixes).toContain('<environment_context>');
+  });
+
+  it('folds a skill-expansion user message into the current turn (production shape)', () => {
+    // Production shape from session 019ebc34: real prompt → $skill expansion
+    // (second user-role response_item) → assistant output. Pre-fix the
+    // expansion opened a NEW turn that absorbed the assistant text, closing
+    // the real prompt's turn responseless.
+    const content = toJsonl([
+      messageItem('user', [{ type: 'input_text', text: 'Run the review skill on this diff' }], '2026-06-12T10:00:00Z'),
+      messageItem('user', [{ type: 'input_text', text: '<skill>\n# Review skill\nDo the steps…\n</skill>' }], '2026-06-12T10:00:01Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'Review complete: two findings.' }], '2026-06-12T10:00:30Z'),
+    ]);
+
+    const turns = envelopeParser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].prompt).toBe('Run the review skill on this diff');
+    expect(turns[0].aiResponse).toBe('Review complete: two findings.');
+  });
+
+  it('folds subagent_notification and environment_context envelopes mid-turn', () => {
+    const content = toJsonl([
+      messageItem('user', [{ type: 'input_text', text: 'Parallelize the build' }], '2026-06-12T10:00:00Z'),
+      messageItem('user', [{ type: 'input_text', text: '<environment_context>\ncwd: /repo\n</environment_context>' }], '2026-06-12T10:00:05Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'Spawning workers.' }], '2026-06-12T10:00:10Z'),
+      messageItem('user', [{ type: 'input_text', text: '<subagent_notification>worker 1 done</subagent_notification>' }], '2026-06-12T10:01:00Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'All workers finished.' }], '2026-06-12T10:01:30Z'),
+    ]);
+
+    const turns = envelopeParser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].prompt).toBe('Parallelize the build');
+    expect(turns[0].aiResponse).toBe('Spawning workers.\n\nAll workers finished.');
+  });
+
+  it('non-envelope second user message still starts a new turn (regression)', () => {
+    const content = toJsonl([
+      messageItem('user', [{ type: 'input_text', text: 'First question' }], '2026-06-12T10:00:00Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'First answer' }], '2026-06-12T10:00:30Z'),
+      messageItem('user', [{ type: 'input_text', text: 'Second question' }], '2026-06-12T10:01:00Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'Second answer' }], '2026-06-12T10:01:30Z'),
+    ]);
+
+    const turns = envelopeParser.parseTurns(content);
+
+    expect(turns).toHaveLength(2);
+    expect(turns[0].prompt).toBe('First question');
+    expect(turns[0].aiResponse).toBe('First answer');
+    expect(turns[1].prompt).toBe('Second question');
+    expect(turns[1].aiResponse).toBe('Second answer');
+  });
+
+  it('an envelope before any turn does not open one', () => {
+    const content = toJsonl([
+      messageItem('user', [{ type: 'input_text', text: '<environment_context>\ncwd: /repo\n</environment_context>' }], '2026-06-12T09:59:59Z'),
+      messageItem('user', [{ type: 'input_text', text: 'Real first prompt' }], '2026-06-12T10:00:00Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'Answer' }], '2026-06-12T10:00:30Z'),
+    ]);
+
+    const turns = envelopeParser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].prompt).toBe('Real first prompt');
+    expect(turns[0].aiResponse).toBe('Answer');
+  });
+
+  it('without configured prefixes, envelope folding is off (default construction)', () => {
+    const bare = new CodexJsonlParser();
+    const content = toJsonl([
+      messageItem('user', [{ type: 'input_text', text: 'Real prompt' }], '2026-06-12T10:00:00Z'),
+      messageItem('user', [{ type: 'input_text', text: '<skill>\nexpansion\n</skill>' }], '2026-06-12T10:00:01Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'Answer' }], '2026-06-12T10:00:30Z'),
+    ]);
+
+    const turns = bare.parseTurns(content);
+    expect(turns).toHaveLength(2); // legacy behavior preserved when unconfigured
   });
 });


### PR DESCRIPTION
## What

The final four codex forensics root causes (plan `codex-capture-forensics-2026-06-12`), each as a class fix:

| RC | Fix |
|---|---|
| **B** skill-expansion response stranding | Parser folds manifest-declared system envelopes into the current turn (prefixes harvested from capture rules — zero hardcoded agent strings; opt-in, codex-only construction) |
| **E** child rollouts mined into parent | Transcript-meta gate skips dropped-class transcripts wholesale + walker passes transcriptMeta so `transcript_meta_*` rules fire at mining time |
| **F** `<update_plan>` in summaries | Shared tag-envelope strip after plan extraction, driven by manifest `planTags` |
| **D** image loss on mining + BLOB duplication | Content-hashed attachment identity (renumber-proof) + mining-path image capture through the same Stop sink; lazy hash backfill |

## Verification

- **Adversarial probe ran the real production rollout (parent + child) through the real miner**: skill response lands on the human batch; zero envelopes across 20 summaries while 24 plans still extract; all 3 image prompts real-text + prefix-matched (composes with RC-C); child rollout skipped (`subagent-thread-spawn`); 70 assertions green.
- Non-codex regression pinned: default parser construction preserves legacy behavior; `anchorMatched` Cursor guard untouched and its pinning test green; cross-agent rule bleed structurally impossible (`scopePermits`).
- `npm test` canonical full suite exit 0 (one known bun-isolate wedge retried green); vite build + lint clean; 3,489 isolated targeted tests green post-main-merge.
- Live smoke on the dev daemon follows before merge per the standing rule (re-mining the production rollout through the deployed build).

## Documented trade-offs (probe-flagged, accepted)

- Re-pasting byte-identical images at a later prompt dedups to the first batch's attachment (the inverse of the production triple-BLOB bug; user-visible but correct-by-content).
- Follow-up recorded for the RC-A/G family: a Stop arriving with parent session id + child transcript path reaches `cleanupInvalidCapturedSession` without a captured-work guard (same event-shape class; not observed in production).

🤖 Generated with [Claude Code](https://claude.com/claude-code)