### PR TITLE
gnore transient Codex update_plan progress

### DIFF
--- a/packages/myco/src/daemon/api/symbionts.ts
+++ b/packages/myco/src/daemon/api/symbionts.ts
@@ -117,10 +117,7 @@ export function listSymbiontInfos(vaultDir: string, groveId?: string | null): Sy
       && ((manifest.capabilities?.canopyReadTools?.length ?? 0) > 0);
     const supportsSubagentStartInjection = manifest.capabilities?.subagentStartInjection ?? false;
     // Plans surface counts either mechanism: filesystem watch (`planDirs`)
-    // or transcript tag extraction (`planTags`). Codex emits no on-disk
-    // plans but ships an `update_plan` function-call tool whose JSON args
-    // the Codex parser synthesizes into a `<update_plan>` envelope —
-    // captured via the `planTags` path.
+    // or transcript tag extraction (`planTags`).
     const supportsPlanCapture =
       (manifest.capture?.planDirs?.length ?? 0) > 0
       || (manifest.capture?.planTags?.length ?? 0) > 0;

--- a/packages/myco/src/daemon/stop-processing.ts
+++ b/packages/myco/src/daemon/stop-processing.ts
@@ -385,10 +385,10 @@ export function createStopProcessor(deps: StopProcessorDeps): {
       // (Cursor), so target the human anchor.
       const summaryTarget = resolveResponseSummaryTarget(sessionId, latestBatch);
       // Strip plan-tag envelopes at the persist point: the transcript-turn
-      // fallback above is parser-derived and can carry synthesized
-      // `<update_plan>` payloads (plan extraction below reads the raw turns,
-      // so it loses nothing). An envelope-only response strips to '' and is
-      // not persisted. Idempotent no-op for envelope-free text.
+      // fallback above is parser-derived and can carry machine-readable plan
+      // tags (plan extraction below reads the raw turns, so it loses nothing).
+      // An envelope-only response strips to '' and is not persisted.
+      // Idempotent no-op for envelope-free text.
       const persistableResponse = resolvedResponse
         ? stripPlanTagEnvelopes(resolvedResponse, deps.planTags)
         : undefined;

--- a/packages/myco/src/symbionts/manifests.generated.ts
+++ b/packages/myco/src/symbionts/manifests.generated.ts
@@ -386,7 +386,7 @@ export const BUNDLED_MANIFESTS: readonly SymbiontManifest[] = [
     "capture": {
       "planDirs": [],
       "planTags": [
-        "update_plan"
+        "proposed_plan"
       ],
       "rules": [
         {

--- a/packages/myco/src/symbionts/manifests/codex.yaml
+++ b/packages/myco/src/symbionts/manifests/codex.yaml
@@ -13,15 +13,11 @@ hookFields:
 capture:
   planDirs: []
   planTags:
-    # Codex's plan mode does not write markdown files to disk; instead
-    # it emits structured plan updates via the `update_plan` function-call
-    # tool (response_item / function_call / name=update_plan with a JSON
-    # `plan` array in `arguments`). The Codex transcript parser
-    # (`packages/myco/src/symbionts/parsers/codex-jsonl.ts`) synthesizes
-    # an `<update_plan>...</update_plan>` envelope from the tool call's
-    # JSON args at parse time, appended to the assistant turn's
-    # aiResponse, so this shared tag-extraction path captures it.
-    - update_plan
+    # Codex Plan Mode emits the approved plan as assistant text wrapped in
+    # `<proposed_plan>...</proposed_plan>`. The `update_plan` function-call
+    # tool is only transient checklist/progress state and must not be
+    # persisted as a Myco plan.
+    - proposed_plan
   rules:
     # Ephemeral sub-invocation filter (structural, two-layer defense).
     #

--- a/packages/myco/src/symbionts/parsers/codex-jsonl.ts
+++ b/packages/myco/src/symbionts/parsers/codex-jsonl.ts
@@ -10,35 +10,6 @@ function parseDataUrl(url: string): { mediaType: string; data: string } | null {
 }
 
 /**
- * Render the JSON arguments of Codex's `update_plan` function-call tool as
- * markdown so the existing tag-extraction pipeline can persist it as a
- * Plan record. `arguments` is a JSON string of shape:
- *   { "plan": [ { "step": "...", "status": "pending"|"in_progress"|"completed" }, ... ] }
- *
- * Returns null when the args fail to parse or carry no plan steps —
- * caller skips the wrap so no empty plan envelopes are emitted.
- */
-function synthesizeUpdatePlanMarkdown(rawArgs: unknown): string | null {
-  if (typeof rawArgs !== 'string' || rawArgs.length === 0) return null;
-  let parsed: unknown;
-  try { parsed = JSON.parse(rawArgs); } catch { return null; }
-  if (!parsed || typeof parsed !== 'object') return null;
-  const planRaw = (parsed as { plan?: unknown }).plan;
-  if (!Array.isArray(planRaw) || planRaw.length === 0) return null;
-  const lines: string[] = ['## Plan', ''];
-  for (const item of planRaw) {
-    if (!item || typeof item !== 'object') continue;
-    const step = String((item as { step?: unknown }).step ?? '').trim();
-    if (!step) continue;
-    const status = String((item as { status?: unknown }).status ?? 'pending');
-    const box = status === 'completed' ? '[x]' : status === 'in_progress' ? '[~]' : '[ ]';
-    lines.push(`- ${box} ${step}`);
-  }
-  if (lines.length <= 2) return null;
-  return lines.join('\n');
-}
-
-/**
  * Codex Desktop wraps user prompts with file-mention preambles when screenshots
  * are attached, and injects <image> wrapper tags around image blocks. Strip both
  * so the captured prompt contains only the user's actual text.
@@ -141,24 +112,12 @@ export class CodexJsonlParser implements TranscriptParser {
       const timestamp = (entry.timestamp as string) ?? '';
 
       // Function calls are separate entries — count them as tool use.
-      // The `update_plan` tool is special: it carries Codex's plan-mode
-      // updates as structured JSON, the analog of Claude Code's plan
-      // mode writing markdown to ~/.claude/plans/. Synthesize an
-      // `<update_plan>...</update_plan>` envelope and append it to the
-      // current turn's aiResponse so the shared `extractTaggedPlans`
-      // pass in stop-processing picks it up (planTags entry below).
+      // Codex's `update_plan` function is transient task-progress state,
+      // not Plan Mode. Durable Plan Mode output is emitted as assistant
+      // text in a `<proposed_plan>...</proposed_plan>` envelope.
       if (payloadType === 'function_call') {
         if (current) {
           current.toolCount++;
-          if (payload.name === 'update_plan') {
-            const markdown = synthesizeUpdatePlanMarkdown(payload.arguments);
-            if (markdown) {
-              const wrapped = `<update_plan>\n${markdown}\n</update_plan>`;
-              current.aiResponse = current.aiResponse
-                ? `${current.aiResponse}\n\n${wrapped}`
-                : wrapped;
-            }
-          }
         }
         continue;
       }
@@ -206,8 +165,7 @@ export class CodexJsonlParser implements TranscriptParser {
         if (text) {
           // Append rather than overwrite — multi-message turns (text → tool →
           // text → tool → text → …) emit separate assistant entries and
-          // overwriting collapses the turn to its last fragment. Matches the
-          // `update_plan` envelope path above which already uses this shape.
+          // overwriting collapses the turn to its last fragment.
           current.aiResponse = current.aiResponse
             ? `${current.aiResponse}\n\n${text}`
             : text;

--- a/tests/capture/transcript-miner-codex-fidelity.test.ts
+++ b/tests/capture/transcript-miner-codex-fidelity.test.ts
@@ -5,9 +5,9 @@
  *  - RC-B: a `$skill` expansion (second user-role response_item) folds into
  *    the human turn, so the assistant's answer lands on the HUMAN batch and
  *    the envelope system batch keeps a NULL summary.
- *  - RC-F: the parser-synthesized `<update_plan>` envelope is stripped from
- *    the persisted response_summary, while plan extraction (raw turns) still
- *    receives it.
+ *  - RC-F: Codex `update_plan` calls remain transient task progress. They
+ *    count as tool calls but never become persisted response_summary content
+ *    or captured Plan rows.
  *  - RC-D(2): images carried on the turn reach the injected mining-path
  *    capture sink, attributed to the matched batch with the batch's own
  *    project tenancy.
@@ -112,7 +112,7 @@ describe('TranscriptMiner — codex fidelity (RC-B / RC-F / RC-D mining path)', 
     const { human, envelope } = seedLiveBatches();
     const sinkCalls: MinedImageCapture[] = [];
     const miner = new TranscriptMiner({
-      planTags: ['update_plan'],
+      planTags: ['proposed_plan'],
       captureImages: (input) => sinkCalls.push(input),
     });
 
@@ -128,7 +128,7 @@ describe('TranscriptMiner — codex fidelity (RC-B / RC-F / RC-D mining path)', 
 
     // RC-B: the human prompt's turn owns the assistant output.
     expect(humanRow.response_summary).toContain(PROSE);
-    // RC-F: no machine-readable plan payload in the user-facing summary.
+    // RC-F: no transient task-progress payload in the user-facing summary.
     expect(humanRow.response_summary).not.toContain('<update_plan>');
     expect(humanRow.response_summary).not.toContain('</update_plan>');
     // RC-B: an envelope batch matches no transcript turn — NULL is correct.
@@ -144,21 +144,17 @@ describe('TranscriptMiner — codex fidelity (RC-B / RC-F / RC-D mining path)', 
     expect(sinkCalls[0].images).toEqual([{ mediaType: 'image/png', data: PNG_1x1 }]);
   });
 
-  it('plan extraction still receives the envelopes the persisted summary loses', () => {
+  it('update_plan task progress does not synthesize a durable transcript plan', () => {
     seedLiveBatches();
-    const miner = new TranscriptMiner({ planTags: ['update_plan'] });
+    const miner = new TranscriptMiner({ planTags: ['proposed_plan'] });
     miner.reconcileAndAttributeResponses(sessionId, { agent: 'codex', transcriptPath });
 
-    // The extraction channel reads RAW parser turns (the Stop pipeline's
-    // input), not persisted summaries — so the Plan record pipeline keeps
-    // seeing the envelope after mining stripped it from the summary.
     const turns = codexAdapter.parseTurns(fs.readFileSync(transcriptPath, 'utf-8'));
     expect(turns).toHaveLength(1); // RC-B: envelope folded, single turn
-    const plans = extractTaggedPlans(turns[0].aiResponse!, ['update_plan']);
-    expect(plans).toHaveLength(1);
-    expect(plans[0].tag).toBe('update_plan');
-    expect(plans[0].content).toContain('- [x] Fix finding one');
-    expect(plans[0].content).toContain('- [~] Fix finding two');
+    expect(turns[0].toolCount).toBe(1);
+    expect(turns[0].aiResponse).toBe(PROSE);
+    expect(turns[0].aiResponse).not.toContain('<update_plan>');
+    expect(extractTaggedPlans(turns[0].aiResponse!, ['proposed_plan'])).toEqual([]);
   });
 
   it('an envelope-only assistant turn persists no summary at all', () => {
@@ -187,7 +183,7 @@ describe('TranscriptMiner — codex fidelity (RC-B / RC-F / RC-D mining path)', 
       origin: 'human', started_at: now, created_at: now,
     });
 
-    const miner = new TranscriptMiner({ planTags: ['update_plan'] });
+    const miner = new TranscriptMiner({ planTags: ['proposed_plan'] });
     miner.reconcileAndAttributeResponses(sessionId, { agent: 'codex', transcriptPath });
 
     const row = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE }).find((b) => b.id === batch.id)!;

--- a/tests/symbionts/codex.test.ts
+++ b/tests/symbionts/codex.test.ts
@@ -115,7 +115,7 @@ describe('codexAdapter', () => {
       expect(turns[0].prompt).toBe('Valid line');
     });
 
-    it('synthesizes an <update_plan> envelope from the update_plan function-call tool', () => {
+    it('does not synthesize an <update_plan> envelope from the transient update_plan function-call tool', () => {
       const updatePlanArgs = JSON.stringify({
         plan: [
           { step: 'Investigate the bug', status: 'completed' },
@@ -130,17 +130,12 @@ describe('codexAdapter', () => {
       ]);
       const turns = codexAdapter.parseTurns(content);
       expect(turns).toHaveLength(1);
-      expect(turns[0].aiResponse).toContain('<update_plan>');
-      expect(turns[0].aiResponse).toContain('## Plan');
-      expect(turns[0].aiResponse).toContain('- [x] Investigate the bug');
-      expect(turns[0].aiResponse).toContain('- [~] Write a failing test');
-      expect(turns[0].aiResponse).toContain('- [ ] Land the fix');
-      expect(turns[0].aiResponse).toContain('</update_plan>');
+      expect(turns[0].aiResponse).toBe('Here is the plan.');
       // toolCount still increments — update_plan IS a tool call.
       expect(turns[0].toolCount).toBe(1);
     });
 
-    it('does not synthesize an envelope when update_plan args are empty or malformed', () => {
+    it('ignores update_plan content even when update_plan args are empty or malformed', () => {
       const content = toJsonl([
         messageItem('user', [{ type: 'input_text', text: 'X' }], '2026-05-25T10:00:00Z'),
         messageItem('assistant', [{ type: 'output_text', text: 'AI reply' }]),
@@ -153,7 +148,7 @@ describe('codexAdapter', () => {
       expect(turns[0].aiResponse).not.toContain('<update_plan>');
     });
 
-    it('ignores other function calls (only update_plan synthesizes a plan envelope)', () => {
+    it('ignores function calls as assistant response content', () => {
       const content = toJsonl([
         messageItem('user', [{ type: 'input_text', text: 'X' }], '2026-05-25T10:00:00Z'),
         messageItem('assistant', [{ type: 'output_text', text: 'AI reply' }]),

--- a/tests/symbionts/manifest-schema.test.ts
+++ b/tests/symbionts/manifest-schema.test.ts
@@ -268,10 +268,10 @@ describe('symbiont manifests', () => {
     expect(result.capture?.planTags).toEqual(['proposed_plan']);
   });
 
-  it('codex manifest has planTags with update_plan (synthesized by the parser from the function-call tool)', () => {
+  it('codex manifest captures only proposed_plan Plan Mode artifacts', () => {
     const raw = fs.readFileSync(path.join(MANIFESTS_DIR, 'codex.yaml'), 'utf-8');
     const manifest = SymbiontManifestSchema.parse(YAML.parse(raw));
-    expect(manifest.capture?.planTags).toEqual(['update_plan']);
+    expect(manifest.capture?.planTags).toEqual(['proposed_plan']);
   });
 
   it('claude-code manifest has planTags with ultraplan', () => {

--- a/tests/symbionts/parsers/codex-jsonl.test.ts
+++ b/tests/symbionts/parsers/codex-jsonl.test.ts
@@ -60,6 +60,26 @@ describe('CodexJsonlParser', () => {
     expect(turns[0].aiResponse).toBe('Done.');
   });
 
+  it('treats update_plan function calls as transient task progress, not assistant plan content', () => {
+    const content = toJsonl([
+      messageItem('user', [{ type: 'input_text', text: 'Fix the bug' }], '2026-04-12T10:00:00Z'),
+      functionCallItem('update_plan', JSON.stringify({
+        plan: [
+          { step: 'Inspect failing path', status: 'completed' },
+          { step: 'Patch implementation', status: 'in_progress' },
+        ],
+      }), '2026-04-12T10:00:10Z'),
+      messageItem('assistant', [{ type: 'output_text', text: 'I found the issue.' }], '2026-04-12T10:00:30Z'),
+    ]);
+
+    const turns = parser.parseTurns(content);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].toolCount).toBe(1);
+    expect(turns[0].aiResponse).toBe('I found the issue.');
+    expect(turns[0].aiResponse).not.toContain('<update_plan>');
+  });
+
   it('skips developer messages', () => {
     const content = toJsonl([
       messageItem('developer', [{ type: 'input_text', text: 'System instructions here' }], '2026-04-12T09:59:00Z'),
@@ -133,9 +153,7 @@ describe('CodexJsonlParser', () => {
   // Surfaced 2026-05-28 alongside the StandardJsonlParser fix: a multi-step
   // turn emits a sequence of message items, each carrying part of the
   // assistant text. The pre-fix `current.aiResponse = text` overwrote with
-  // each entry, leaving only the final fragment in response_summary. Matches
-  // the existing `update_plan` envelope path in this parser which already
-  // appends rather than overwrites.
+  // each entry, leaving only the final fragment in response_summary.
   it('concatenates text across multiple assistant message items in one turn', () => {
     const content = toJsonl([
       messageItem('user', [{ type: 'input_text', text: 'Multi-step task' }], '2026-04-12T10:00:00Z'),


### PR DESCRIPTION
## Summary

- Stop synthesizing Codex `update_plan` function calls into `<update_plan>` assistant-plan envelopes.
- Restore Codex transcript plan capture to the durable Plan Mode tag, `<proposed_plan>...</proposed_plan>`.
- Update Codex parser, manifest, generated manifest data, and regression tests so `update_plan` remains tool activity only.

## Why

PR #355 changed Codex plan capture from `proposed_plan` to parser-synthesized `update_plan` after live rollout research found many `update_plan` calls and no `<proposed_plan>` matches. That conflated two Codex surfaces: `update_plan` is ongoing checklist/progress/TODO state, while Codex Plan Mode emits durable plan output as assistant text wrapped in `<proposed_plan>`.

Persisting `update_plan` polluted Myco plans with ephemeral Codex task lists like `Update Plan` rows, including the dogfood and production example sessions we reviewed.

## Impact

Existing real plan capture still uses the manifest-driven `planTags` path, but Codex now declares only `proposed_plan`. `update_plan` calls still increment parser `toolCount`; they just no longer become `aiResponse` content or captured Myco plans.

Existing polluted plan rows are intentionally not deleted in this PR.

## Validation

- `npm test -- tests/symbionts/parsers/codex-jsonl.test.ts tests/symbionts/codex.test.ts tests/capture/transcript-miner-codex-fidelity.test.ts tests/symbionts/manifest-schema.test.ts tests/daemon/codex-plan-capture.test.ts`
- `make build`
- `myco-dev restart`
- Real transcript smoke against sessions `019eaa56-3084-7f31-b1ac-3dbcf2fe3a1b` and `019ebc34-9fdf-73c2-b499-9a83d05bab65`: Codex manifest reports `planTags ["proposed_plan"]`; parsed turns contain zero `<update_plan>` assistant content.