### PR TITLE
[codex] Make capability-off prompt skips visible

### DIFF
--- a/packages/myco/src/daemon/api/context.ts
+++ b/packages/myco/src/daemon/api/context.ts
@@ -30,6 +30,7 @@ import { symbiontHasCapability, symbiontToolTransport } from '@myco/symbionts/ca
 import { getCortexInstructionsSnapshot } from '../cortex.js';
 import { resolveTenantConfig } from '../request-config.js';
 import { recordInjectionAndShouldSuppress, getSessionInjectedSporeIds } from '../injection-records.js';
+import { createBoundedFirstOccurrenceTracker, sessionLogScopeKey } from '../first-occurrence-tracker.js';
 import { resolvePlanIntentNudge } from './plan-intent.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 import type { EmbeddingManager } from '../embedding/manager.js';
@@ -80,6 +81,14 @@ const PromptContextBody = z.object({
   prompt: z.string(),
   session_id: z.string().optional(),
 });
+
+const PROMPT_CONTEXT_SKIP_REASONS = {
+  CORTEX_CAPABILITY_OFF: 'cortex_capability_off',
+} as const;
+
+const PROMPT_CONTEXT_LOG_MESSAGES = {
+  CORTEX_CAPABILITY_OFF: 'Prompt context disabled (cortex capability off)',
+} as const;
 
 const SubagentContextBody = z.object({
   session_id: z.string().optional(),
@@ -460,6 +469,8 @@ export function createResumeContextHandler(deps: ContextDeps) {
  * Create a handler that searches spore embeddings for prompt-relevant observations.
  */
 export function createPromptContextHandler(deps: ContextDeps) {
+  const capabilityOffSkipLogTracker = createBoundedFirstOccurrenceTracker();
+
   return async function handlePromptContext(req: RouteRequest): Promise<RouteResponse> {
     const { prompt, session_id } = PromptContextBody.parse(req.body);
     const { logger, liveConfig } = deps;
@@ -472,7 +483,12 @@ export function createPromptContextHandler(deps: ContextDeps) {
     // Coarse master gate at the handler boundary. Suppresses spore search and
     // plan-intent nudge when the cortex capability is off.
     if (!capabilityEnabled(config, 'cortex')) {
-      logger.debug(LOG_KINDS.CONTEXT_PROMPT, 'Prompt context disabled (cortex capability off)', { session_id });
+      const logPayload = { session_id, reason: PROMPT_CONTEXT_SKIP_REASONS.CORTEX_CAPABILITY_OFF };
+      if (capabilityOffSkipLogTracker.mark(sessionLogScopeKey(session_id)) === 'repeat') {
+        logger.debug(LOG_KINDS.CONTEXT_PROMPT, PROMPT_CONTEXT_LOG_MESSAGES.CORTEX_CAPABILITY_OFF, logPayload);
+      } else {
+        logger.info(LOG_KINDS.CONTEXT_PROMPT, PROMPT_CONTEXT_LOG_MESSAGES.CORTEX_CAPABILITY_OFF, logPayload);
+      }
       return { body: { text: '' } };
     }
 

--- a/packages/myco/src/daemon/first-occurrence-tracker.ts
+++ b/packages/myco/src/daemon/first-occurrence-tracker.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Goondocks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+export const DEFAULT_FIRST_OCCURRENCE_TRACKER_MAX_KEYS = 1024;
+export const MISSING_SESSION_LOG_SCOPE_KEY = 'session_id:missing';
+const SESSION_LOG_SCOPE_VALUE_PREFIX = 'session_id:value:';
+
+export type OccurrenceDecision = 'first' | 'repeat';
+
+export interface FirstOccurrenceTracker {
+  mark(key: string): OccurrenceDecision;
+  clear(): void;
+  readonly size: number;
+}
+
+export function sessionLogScopeKey(sessionId: string | undefined): string {
+  return sessionId === undefined
+    ? MISSING_SESSION_LOG_SCOPE_KEY
+    : `${SESSION_LOG_SCOPE_VALUE_PREFIX}${sessionId}`;
+}
+
+export function createBoundedFirstOccurrenceTracker(options: {
+  maxKeys?: number;
+} = {}): FirstOccurrenceTracker {
+  const maxKeys = options.maxKeys ?? DEFAULT_FIRST_OCCURRENCE_TRACKER_MAX_KEYS;
+  if (!Number.isInteger(maxKeys) || maxKeys < 1) {
+    throw new Error('FirstOccurrenceTracker maxKeys must be a positive integer');
+  }
+
+  const seen = new Set<string>();
+
+  return {
+    mark(key: string): OccurrenceDecision {
+      if (seen.has(key)) return 'repeat';
+      if (seen.size >= maxKeys) seen.clear();
+      seen.add(key);
+      return 'first';
+    },
+    clear(): void {
+      seen.clear();
+    },
+    get size(): number {
+      return seen.size;
+    },
+  };
+}

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -93,11 +93,10 @@ const forwardedArgs = process.argv.slice(2);
 // Isolated files are bundled into chunks to amortize bun's `--isolate`
 // startup cost. Capped at 4 (was 8): the bun 1.3.14 `--isolate` runtime spin
 // emerges from the multi-file isolate/SQLite-teardown churn, and an 8-file
-// chunk of SQLite-heavy tests triggers it reliably under load (≤3-file groups
-// verified clean). 4 keeps the per-chunk startup amortization while staying
-// below the spin threshold; the phase-kill + wedge-retry above remain the
-// safety net for any chunk that still spins. Env-tunable for CI.
-const ISOLATED_NODE_CHUNK_SIZE = Number(process.env.MYCO_RUNNER_ISOLATED_CHUNK_SIZE ?? 4);
+// chunk of SQLite-heavy tests triggers it reliably under load. Three-file
+// groups are the verified-clean default; the phase-kill + wedge-retry above
+// remain the safety net for any chunk that still spins. Env-tunable for CI.
+const ISOLATED_NODE_CHUNK_SIZE = Number(process.env.MYCO_RUNNER_ISOLATED_CHUNK_SIZE ?? 3);
 
 // Bun's `--isolate` mode pays a large per-file startup cost. These groups
 // have been validated to run correctly when imported through one generated

--- a/tests/daemon/api/context.test.ts
+++ b/tests/daemon/api/context.test.ts
@@ -19,6 +19,7 @@ import type { RouteRequest } from '@myco/daemon/router';
 import type { EmbeddingManager } from '@myco/daemon/embedding/manager';
 import type { DaemonLogger } from '@myco/daemon/logger';
 import { DEFAULT_AGENT_ID } from '@myco/constants';
+import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { listActivities } from '@myco/db/queries/activities';
 import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids';
 
@@ -483,6 +484,30 @@ describe('createPromptContextHandler', () => {
     const result = await handler(makeReq({ prompt: 'please plan the migration', session_id: 'sess-cortex-master-off-prompt' }));
 
     expect((result.body as { text: string }).text).toBe('');
+  });
+
+  it('logs the first capability-off prompt skip per session at info, then repeats at debug', async () => {
+    const cfg = MycoConfigSchema.parse({ version: 3 });
+    cfg.cortex.enabled = false;
+    const logger = mockLogger();
+    const handler = createPromptContextHandler(makeDeps({ config: cfg, logger }));
+
+    await handler(makeReq({ prompt: 'please plan the migration', session_id: 'sess-cortex-master-off-visible' }));
+    await handler(makeReq({ prompt: 'please plan the migration again', session_id: 'sess-cortex-master-off-visible' }));
+    await handler(makeReq({ prompt: 'please plan this other migration', session_id: 'sess-cortex-master-off-visible-2' }));
+
+    expect(logger.info).toHaveBeenCalledTimes(2);
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      LOG_KINDS.CONTEXT_PROMPT,
+      'Prompt context disabled (cortex capability off)',
+      { session_id: 'sess-cortex-master-off-visible', reason: 'cortex_capability_off' },
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      LOG_KINDS.CONTEXT_PROMPT,
+      'Prompt context disabled (cortex capability off)',
+      { session_id: 'sess-cortex-master-off-visible', reason: 'cortex_capability_off' },
+    );
   });
 
   it('injects the nudge at most once per session', async () => {

--- a/tests/daemon/first-occurrence-tracker.test.ts
+++ b/tests/daemon/first-occurrence-tracker.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Goondocks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  createBoundedFirstOccurrenceTracker,
+  MISSING_SESSION_LOG_SCOPE_KEY,
+  sessionLogScopeKey,
+} from '@myco/daemon/first-occurrence-tracker.js';
+
+describe('createBoundedFirstOccurrenceTracker', () => {
+  it('returns first once for a key, then repeat', () => {
+    const tracker = createBoundedFirstOccurrenceTracker();
+
+    expect(tracker.mark('session_id:value:sess-1')).toBe('first');
+    expect(tracker.mark('session_id:value:sess-1')).toBe('repeat');
+    expect(tracker.mark('session_id:value:sess-2')).toBe('first');
+  });
+
+  it('clears old keys before admitting a new key beyond the configured bound', () => {
+    const tracker = createBoundedFirstOccurrenceTracker({ maxKeys: 2 });
+
+    expect(tracker.mark('one')).toBe('first');
+    expect(tracker.mark('two')).toBe('first');
+    expect(tracker.size).toBe(2);
+
+    expect(tracker.mark('three')).toBe('first');
+    expect(tracker.size).toBe(1);
+    expect(tracker.mark('one')).toBe('first');
+  });
+
+  it('rejects invalid bounds instead of silently disabling the latch', () => {
+    expect(() => createBoundedFirstOccurrenceTracker({ maxKeys: 0 })).toThrow(
+      'FirstOccurrenceTracker maxKeys must be a positive integer',
+    );
+    expect(() => createBoundedFirstOccurrenceTracker({ maxKeys: 1.5 })).toThrow(
+      'FirstOccurrenceTracker maxKeys must be a positive integer',
+    );
+  });
+});
+
+describe('sessionLogScopeKey', () => {
+  it('uses a named missing-session scope instead of an inline sentinel', () => {
+    expect(sessionLogScopeKey(undefined)).toBe(MISSING_SESSION_LOG_SCOPE_KEY);
+  });
+
+  it('namespaces real session ids away from the missing-session scope', () => {
+    expect(sessionLogScopeKey('missing')).toBe('session_id:value:missing');
+    expect(sessionLogScopeKey('missing')).not.toBe(MISSING_SESSION_LOG_SCOPE_KEY);
+  });
+});


### PR DESCRIPTION
## Summary

- add a bounded first-occurrence tracker for daemon log latches
- log the first `/context/prompt` skip per session at `info` when `cortex.enabled=false`, then repeat skips at `debug`
- name the capability-off skip reason/message and cover the tracker plus prompt-context behavior with tests
- harden the Bun test runner default to three-file isolated chunks, matching the runner's verified-clean size after CI wedged a four-file hook/integration chunk

## Why

When Cortex was disabled at a config tier, prompt context injection returned an empty response and only logged at debug. In normal service-dev logging this made accidental capability-off states look like silent injection failure. The new behavior makes the first skip visible per session without spamming every prompt.

The first CI run also exposed a runner issue rather than a product-code slowdown: a four-file Bun `--isolate` phase wedged repeatedly and only passed after the retry safety net. The default isolated chunk size now uses the runner's documented clean size so CI does not rely on wedge retries for that workload.

## Verification

- `npm test -- tests/daemon/first-occurrence-tracker.test.ts tests/daemon/api/context.test.ts`
- `npm test -- tests/integration/capture-pipeline-e2e.test.ts tests/hooks/user-prompt-submit-drop.test.ts tests/hooks/vault-gate-readmit.test.ts tests/hooks/vault-gate.test.ts`
- runner dry-run check: isolated hook/capture phase now contains three files, not four
- `make build`
- `myco-dev restart`
- live service-dev smoke with config snapshot/restore:
  - set local `cortex.enabled=false` through `PUT /api/config/scoped`
  - posted `/context/prompt` twice for one session and once for a second session
  - verified daemon log emitted one `info` line per unique session and no second visible info for the repeated prompt
  - cleared the override and confirmed `.myco/local.yaml` was restored and merged config reported `cortex.enabled: true`