### PR TITLE
symbionts: support cursor hook field aliases

### DIFF
--- a/packages/myco/src/hooks/normalize.ts
+++ b/packages/myco/src/hooks/normalize.ts
@@ -8,6 +8,7 @@
  */
 
 import { loadManifests } from '../symbionts/detect.js';
+import type { HookFieldPath } from '../symbionts/adapter.js';
 import type { SymbiontManifest } from '../symbionts/manifest-schema.js';
 import { getAtPath } from '../utils/dot-path.js';
 import path from 'node:path';
@@ -177,15 +178,24 @@ function deriveSessionIdFromTranscriptPath(
   return undefined;
 }
 
+function getFirstAtPath(input: Record<string, unknown>, field: HookFieldPath): unknown {
+  const paths = Array.isArray(field) ? field : [field];
+  for (const candidate of paths) {
+    const value = getAtPath(input, candidate);
+    if (value !== undefined) return value;
+  }
+  return undefined;
+}
+
 export function normalizeHookInput(input: Record<string, unknown>): NormalizedHookInput {
   const manifest = detectManifest(input);
   const fields = manifest?.hookFields ?? DEFAULT_HOOK_FIELDS;
-  const transcriptPath = getAtPath(input, fields.transcriptPath) as string | undefined;
+  const transcriptPath = getFirstAtPath(input, fields.transcriptPath) as string | undefined;
 
   // Resolve session ID: try the mapped field, then explicit transcript-path parsing
   // for known symbionts, then env var fallback, then MYCO_SESSION_ID.
   // Do NOT fabricate synthetic session IDs for symbiont hooks with missing payloads.
-  const sessionIdFromInput = getAtPath(input, fields.sessionId) as string | undefined;
+  const sessionIdFromInput = getFirstAtPath(input, fields.sessionId) as string | undefined;
   const sessionIdFromTranscriptPath = deriveSessionIdFromTranscriptPath(manifest, transcriptPath);
   const sessionIdFromEnv = 'sessionIdEnv' in fields && fields.sessionIdEnv
     ? process.env[fields.sessionIdEnv]
@@ -199,11 +209,11 @@ export function normalizeHookInput(input: Record<string, unknown>): NormalizedHo
     agent: manifest?.name ?? DEFAULT_AGENT_NAME,
     sessionId,
     transcriptPath,
-    lastResponse: getAtPath(input, fields.lastResponse) as string | undefined,
-    prompt: getAtPath(input, fields.prompt) as string | undefined,
-    toolName: getAtPath(input, fields.toolName) as string | undefined,
-    toolInput: getAtPath(input, fields.toolInput),
-    toolOutput: getAtPath(input, fields.toolOutput),
+    lastResponse: getFirstAtPath(input, fields.lastResponse) as string | undefined,
+    prompt: getFirstAtPath(input, fields.prompt) as string | undefined,
+    toolName: getFirstAtPath(input, fields.toolName) as string | undefined,
+    toolInput: getFirstAtPath(input, fields.toolInput),
+    toolOutput: getFirstAtPath(input, fields.toolOutput),
     raw: input,
   };
 }

--- a/packages/myco/src/symbionts/adapter.ts
+++ b/packages/myco/src/symbionts/adapter.ts
@@ -32,24 +32,31 @@ export interface TranscriptTurn {
 }
 
 /**
+ * Dot-path for an agent hook payload field. An ordered list means "try each
+ * path in order and use the first one present"; useful for hosts whose outer
+ * integration is stable but whose embedded runtime can emit alternate shapes.
+ */
+export type HookFieldPath = string | readonly string[];
+
+/**
  * Maps agent-specific hook field names to normalized names.
  * Each agent's hook system uses different field names for the same data.
  */
 export interface HookFieldNames {
   /** Field name for the session ID (e.g., 'session_id', 'sessionId', 'trajectory_id') */
-  sessionId: string;
+  sessionId: HookFieldPath;
   /** Field name for the transcript file path (e.g., 'transcript_path') */
-  transcriptPath: string;
+  transcriptPath: HookFieldPath;
   /** Field name for the last AI response text (e.g., 'last_assistant_message') */
-  lastResponse: string;
+  lastResponse: HookFieldPath;
   /** Field name for the user prompt (e.g., 'prompt') */
-  prompt: string;
+  prompt: HookFieldPath;
   /** Field name for the tool name (e.g., 'tool_name') */
-  toolName: string;
+  toolName: HookFieldPath;
   /** Field name for the tool input (e.g., 'tool_input'). Supports dot notation for nested objects. */
-  toolInput: string;
+  toolInput: HookFieldPath;
   /** Field name for the tool output (e.g., 'tool_output'). Supports dot notation for nested objects. */
-  toolOutput: string;
+  toolOutput: HookFieldPath;
   /** Env var fallback for session ID (e.g., 'GEMINI_SESSION_ID'). */
   sessionIdEnv?: string;
 }

--- a/packages/myco/src/symbionts/cursor.ts
+++ b/packages/myco/src/symbionts/cursor.ts
@@ -35,7 +35,7 @@ export const cursorAdapter: SymbiontAdapter = {
   displayName: 'Cursor',
   pluginRootEnvVar: 'CURSOR_PLUGIN_ROOT',
   hookFields: {
-    sessionId: 'conversation_id',
+    sessionId: ['conversation_id', 'session_id'],
     transcriptPath: 'transcript_path',
     lastResponse: 'last_assistant_message',
     prompt: 'prompt',

--- a/packages/myco/src/symbionts/manifest-schema.ts
+++ b/packages/myco/src/symbionts/manifest-schema.ts
@@ -452,6 +452,11 @@ export type StopPhase = z.infer<typeof StopPhaseSchema>;
 export type HookEventDeclaration = z.infer<typeof HookEventDeclarationSchema>;
 export type HooksManifest = z.infer<typeof HooksManifestSchema>;
 
+const HookFieldPathSchema = z.union([
+  z.string().min(1),
+  z.array(z.string().min(1)).min(1),
+]);
+
 export const SymbiontManifestSchema = z.object({
   name: z.string(),
   displayName: z.string(),
@@ -472,20 +477,20 @@ export const SymbiontManifestSchema = z.object({
   pluginRootEnvVar: z.string(),
   settingsPath: z.string().optional(),
   hookFields: z.object({
-    sessionId: z.string(),
-    transcriptPath: z.string(),
+    sessionId: HookFieldPathSchema,
+    transcriptPath: HookFieldPathSchema,
     /** Symbiont's hook payload key for the final assistant response text.
      * Defaults to `last_assistant_message`. Symbionts that deliver the response
      * only through the transcript file (e.g., Antigravity) can keep the default
      * — the payload won't carry that field and the normalized value stays
      * undefined. */
-    lastResponse: z.string().default('last_assistant_message'),
-    prompt: z.string().default('prompt'),
-    toolName: z.string().default('tool_name'),
-    toolInput: z.string().default('tool_input'),
+    lastResponse: HookFieldPathSchema.default('last_assistant_message'),
+    prompt: HookFieldPathSchema.default('prompt'),
+    toolName: HookFieldPathSchema.default('tool_name'),
+    toolInput: HookFieldPathSchema.default('tool_input'),
     /** Symbiont's hook payload key for tool output. Defaults to `tool_output`.
      * Same transcript-only caveat applies as `lastResponse`. */
-    toolOutput: z.string().default('tool_output'),
+    toolOutput: HookFieldPathSchema.default('tool_output'),
     /** Env var fallback for session ID (e.g., GEMINI_SESSION_ID). */
     sessionIdEnv: z.string().optional(),
   }),

--- a/packages/myco/src/symbionts/manifests.generated.ts
+++ b/packages/myco/src/symbionts/manifests.generated.ts
@@ -878,7 +878,10 @@ export const BUNDLED_MANIFESTS: readonly SymbiontManifest[] = [
     "pluginRootEnvVar": "CURSOR_PLUGIN_ROOT",
     "settingsPath": ".cursor/mcp.json",
     "hookFields": {
-      "sessionId": "conversation_id",
+      "sessionId": [
+        "conversation_id",
+        "session_id"
+      ],
       "transcriptPath": "transcript_path",
       "lastResponse": "last_assistant_message",
       "prompt": "prompt",

--- a/packages/myco/src/symbionts/manifests/cursor.yaml
+++ b/packages/myco/src/symbionts/manifests/cursor.yaml
@@ -6,7 +6,7 @@ detectionDir: ~/.cursor
 pluginRootEnvVar: CURSOR_PLUGIN_ROOT
 settingsPath: .cursor/mcp.json
 hookFields:
-  sessionId: conversation_id
+  sessionId: [conversation_id, session_id]
   transcriptPath: transcript_path
   lastResponse: last_assistant_message
 capture:

--- a/tests/hooks/normalize.test.ts
+++ b/tests/hooks/normalize.test.ts
@@ -356,6 +356,22 @@ describe('normalizeHookInput', () => {
         toolOutput: 'tool_output',
       },
     };
+    const cursorManifest = {
+      name: 'cursor',
+      displayName: 'Cursor',
+      binary: 'cursor',
+      configDir: '.cursor',
+      pluginRootEnvVar: 'CURSOR_PLUGIN_ROOT',
+      hookFields: {
+        sessionId: ['conversation_id', 'session_id'],
+        transcriptPath: 'transcript_path',
+        lastResponse: 'last_assistant_message',
+        prompt: 'prompt',
+        toolName: 'tool_name',
+        toolInput: 'tool_input',
+        toolOutput: 'tool_output',
+      },
+    };
 
     afterEach(() => {
       process.argv = originalArgv;
@@ -386,6 +402,32 @@ describe('normalizeHookInput', () => {
         transcript_path: '/Users/me/.claude/projects/foo/abc.jsonl',
       });
       expect(result.agent).toBe('codex');
+    });
+
+    it('uses Cursor argv attribution while accepting embedded Claude-style session_id payloads', () => {
+      mockLoadManifests.mockReturnValue([claudeManifest, cursorManifest]);
+      process.argv = ['node', 'myco-run', 'hook', 'post-tool-use', '--symbiont', 'cursor'];
+      const result = normalizeHookInput({
+        session_id: 'cursor-embedded-runtime-session',
+        transcript_path: '/Users/me/.claude/projects/foo/cursor-embedded-runtime-session.jsonl',
+        tool_name: 'Read',
+        tool_input: { file_path: '/repo/src/file.ts' },
+      });
+      expect(result.agent).toBe('cursor');
+      expect(result.sessionId).toBe('cursor-embedded-runtime-session');
+      expect(result.toolName).toBe('Read');
+      expect(result.toolInput).toEqual({ file_path: '/repo/src/file.ts' });
+    });
+
+    it('prefers the primary field when a manifest declares ordered aliases', () => {
+      mockLoadManifests.mockReturnValue([cursorManifest]);
+      process.argv = ['node', 'myco-run', 'hook', 'post-tool-use', '--symbiont', 'cursor'];
+      const result = normalizeHookInput({
+        conversation_id: 'cursor-native-session',
+        session_id: 'embedded-runtime-session',
+      });
+      expect(result.agent).toBe('cursor');
+      expect(result.sessionId).toBe('cursor-native-session');
     });
 
     it('unknown --symbiont value falls through to heuristic detection', () => {

--- a/tests/symbionts/manifest-schema.test.ts
+++ b/tests/symbionts/manifest-schema.test.ts
@@ -62,6 +62,22 @@ describe('symbiont manifests', () => {
     expect(manifest.registration?.skillsTarget).toBe('.test/skills');
   });
 
+  it('accepts ordered hook field aliases', () => {
+    const manifest = SymbiontManifestSchema.parse({
+      name: 'test-agent',
+      displayName: 'Test Agent',
+      binary: 'test',
+      configDir: '.test',
+      pluginRootEnvVar: 'TEST_PLUGIN_ROOT',
+      hookFields: {
+        sessionId: ['conversation_id', 'session_id'],
+        transcriptPath: 'tp',
+        lastResponse: 'lr',
+      },
+    });
+    expect(manifest.hookFields.sessionId).toEqual(['conversation_id', 'session_id']);
+  });
+
   it('allows manifest without registration block', () => {
     const manifest = SymbiontManifestSchema.parse({
       name: 'test-agent',


### PR DESCRIPTION
## Summary
- add a manifest-level hook field alias pattern so one symbiont can accept alternate embedded-runtime payload shapes without handler-specific branches
- declare Cursor session id aliases as `conversation_id` then `session_id` in the adapter and YAML manifest
- add normalization/schema regression coverage for Cursor argv attribution with Claude-style `session_id` payloads

## Verification
- `npm test -- tests/hooks/normalize.test.ts tests/symbionts/manifest-schema.test.ts tests/symbionts/path-bearing-tools-manifests.test.ts`
- `make build`
- live service-dev dogfood using built worktree binary: `hook post-tool-use --symbiont cursor` with only `session_id`; verified DB row `sessions.agent=cursor` and `activities.file_path=packages/myco/src/hooks/normalize.ts`, then closed via `hook session-end --symbiont cursor`