### PR TITLE
[codex] Fix Copilot response summaries across sourced messages

### DIFF
--- a/packages/myco/src/symbionts/copilot.ts
+++ b/packages/myco/src/symbionts/copilot.ts
@@ -36,7 +36,7 @@ export const copilotAdapter: SymbiontAdapter = {
   displayName: 'GitHub Copilot',
   pluginRootEnvVar: 'COPILOT_PLUGIN_ROOT',
   hookFields: {
-    sessionId: 'sessionId',
+    sessionId: 'session_id',
     transcriptPath: 'transcript_path',
     lastResponse: 'last_assistant_message',
     prompt: 'prompt',
@@ -51,6 +51,14 @@ export const copilotAdapter: SymbiontAdapter = {
 
   parseTurns: (content) => parseCopilotEventLog(content),
 };
+
+const COPILOT_EVENT_TYPES = {
+  USER_MESSAGE: 'user.message',
+  ASSISTANT_MESSAGE: 'assistant.message',
+  TOOL_EXECUTION_START: 'tool.execution_start',
+} as const;
+
+const COPILOT_USER_MESSAGE_SOURCE_FIELD = 'source';
 
 /**
  * Parse Copilot's chronological event-log JSONL transcript and emit
@@ -85,7 +93,8 @@ function parseCopilotEventLog(content: string): TranscriptTurn[] {
     }
     const data = event.data ?? {};
     switch (event.type) {
-      case 'user.message': {
+      case COPILOT_EVENT_TYPES.USER_MESSAGE: {
+        if (isSourcedUserMessage(data)) break;
         flush();
         const promptText = typeof data.content === 'string' ? data.content : '';
         current = {
@@ -96,7 +105,7 @@ function parseCopilotEventLog(content: string): TranscriptTurn[] {
         };
         break;
       }
-      case 'assistant.message': {
+      case COPILOT_EVENT_TYPES.ASSISTANT_MESSAGE: {
         if (!current) break;
         const text = typeof data.content === 'string' ? data.content.trim() : '';
         if (text) {
@@ -105,7 +114,7 @@ function parseCopilotEventLog(content: string): TranscriptTurn[] {
         }
         break;
       }
-      case 'tool.execution_start': {
+      case COPILOT_EVENT_TYPES.TOOL_EXECUTION_START: {
         if (current) current.toolCount += 1;
         break;
       }
@@ -119,6 +128,10 @@ function parseCopilotEventLog(content: string): TranscriptTurn[] {
   return turns;
 }
 
+function isSourcedUserMessage(data: CopilotEventData): boolean {
+  return data[COPILOT_USER_MESSAGE_SOURCE_FIELD] !== undefined;
+}
+
 // --- Types ---
 
 interface CopilotEvent {
@@ -126,5 +139,10 @@ interface CopilotEvent {
   parentId?: string;
   timestamp?: string;
   type: string;
-  data?: { content?: unknown; [key: string]: unknown };
+  data?: CopilotEventData;
+}
+
+interface CopilotEventData {
+  content?: unknown;
+  [key: string]: unknown;
 }

--- a/tests/capture/transcript-miner-reconcile.test.ts
+++ b/tests/capture/transcript-miner-reconcile.test.ts
@@ -9,6 +9,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+import {
+  buildCopilotSourcedUserMessageTranscript,
+  COPILOT_SOURCED_USER_MESSAGE_PROMPT,
+  COPILOT_SOURCED_USER_MESSAGE_RESPONSE,
+} from '../helpers/copilot-transcript.js';
 
 describe('TranscriptMiner.reconcileBatchKinds', () => {
   let tmpDir: string;
@@ -167,6 +172,19 @@ describe('TranscriptMiner.reconcileBatchKinds', () => {
     expect(after[2].kind).toBe('initial');
     expect(after[2].parent_prompt_batch_id).toBeNull();
     expect(after[3].kind).toBe('initial');
+  });
+
+  it('attributes Copilot responses across sourced user.message records', () => {
+    const sessionId = 's-copilot-sourced-user-message';
+    seedSession({ id: sessionId, agent: 'copilot' });
+    handleUserPrompt(sessionId, COPILOT_SOURCED_USER_MESSAGE_PROMPT, { kind: 'initial' });
+    fs.writeFileSync(transcriptPath, `${buildCopilotSourcedUserMessageTranscript(sessionId)}\n`);
+
+    const miner = new TranscriptMiner();
+    miner.reconcileAndAttributeResponses(sessionId, { agent: 'copilot', transcriptPath });
+
+    const [batch] = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batch.response_summary).toBe(COPILOT_SOURCED_USER_MESSAGE_RESPONSE);
   });
 
   // Reconciliation runs at every Stop, so it must be idempotent. Earlier

--- a/tests/daemon/stop-processing.test.ts
+++ b/tests/daemon/stop-processing.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
 import { createStopProcessor } from '@myco/daemon/stop-processing.js';
 import { SessionRegistry } from '@myco/daemon/lifecycle.js';
+import { TranscriptMiner } from '@myco/capture/transcript-miner.js';
 import { getSession, upsertSession } from '@myco/db/queries/sessions.js';
 import { insertSessionTombstone, SESSION_TOMBSTONE_SOURCE } from '@myco/db/queries/session-tombstones.js';
 import { getDatabase } from '@myco/db/client.js';
@@ -13,6 +14,11 @@ import { insertBatch, listBatchesBySession, PROMPT_BATCH_ORIGIN } from '@myco/db
 import { insertActivity } from '@myco/db/queries/activities.js';
 import { listPlansBySession } from '@myco/db/queries/plans.js';
 import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+import {
+  buildCopilotSourcedUserMessageTranscript,
+  COPILOT_SOURCED_USER_MESSAGE_PROMPT,
+  COPILOT_SOURCED_USER_MESSAGE_RESPONSE,
+} from '../helpers/copilot-transcript.js';
 
 const epochNow = () => Math.floor(Date.now() / 1000);
 
@@ -92,6 +98,14 @@ function writeCodexExecTranscript(sessionId: string): string {
     }),
   ];
   fs.writeFileSync(transcriptPath, `${lines.join('\n')}\n`);
+  return transcriptPath;
+}
+
+function writeCopilotSourcedUserMessageTranscript(rootDir: string, sessionId: string): string {
+  const dir = path.join(rootDir, 'copilot-transcripts');
+  fs.mkdirSync(dir, { recursive: true });
+  const transcriptPath = path.join(dir, 'events.jsonl');
+  fs.writeFileSync(transcriptPath, `${buildCopilotSourcedUserMessageTranscript(sessionId)}\n`);
   return transcriptPath;
 }
 
@@ -446,6 +460,50 @@ describe('createStopProcessor session capture rules', () => {
     expect(b1.response_summary).toBe('Hello.');
     expect(b2.response_summary).toBe('Concise branch summary.');
     expect(b3.response_summary).toBe('Here is a practical slicing.');
+  });
+
+  it('captures Copilot final response when sourced user.message events appear mid-turn', async () => {
+    const sessionId = 'copilot-sourced-user-message-stop-001';
+    const now = epochNow();
+    const transcriptPath = writeCopilotSourcedUserMessageTranscript(vaultDir, sessionId);
+    upsertSession({
+      id: sessionId,
+      agent: 'copilot',
+      status: 'active',
+      started_at: now,
+      created_at: now,
+    });
+    insertBatch({
+      session_id: sessionId,
+      prompt_number: 1,
+      user_prompt: COPILOT_SOURCED_USER_MESSAGE_PROMPT,
+      started_at: now,
+      created_at: now,
+    });
+
+    const stopProcessor = createStopProcessor({
+      registry: new SessionRegistry({ gracePeriod: 1, onEmpty: () => {} }),
+      sessionBuffers: new Map(),
+      transcriptMiner: new TranscriptMiner(),
+      embeddingManager: { onRemoved: vi.fn() } as never,
+      resolveEmbeddingManager: () => ({ onRemoved: vi.fn() } as never),
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+      liveConfig: { current: { agent: { event_tasks_enabled: false } } } as never,
+      vaultDir,
+      planTags: [],
+      planWatchConfig: { watchDirs: [], projectRoot: vaultDir },
+    });
+
+    await stopProcessor.handleStopRoute({
+      body: {
+        session_id: sessionId,
+        agent: 'copilot',
+        transcript_path: transcriptPath,
+      },
+    } as never);
+
+    const [batch] = listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE });
+    expect(batch.response_summary).toBe(COPILOT_SOURCED_USER_MESSAGE_RESPONSE);
   });
 
   it('ignores a sub-agent transcript before any session row exists', async () => {

--- a/tests/helpers/copilot-transcript.ts
+++ b/tests/helpers/copilot-transcript.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2026 Goondocks Co.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const COPILOT_SOURCED_USER_MESSAGE_PROMPT = 'Summarize the repo';
+export const COPILOT_SOURCED_USER_MESSAGE_RESPONSE = 'This repository is a Myco development checkout.';
+
+const COPILOT_TOOL_CONTEXT_SOURCE = 'skill-myco';
+const COPILOT_TRANSCRIPT_EVENTS = {
+  SESSION_START: 'session.start',
+  USER_MESSAGE: 'user.message',
+  ASSISTANT_MESSAGE: 'assistant.message',
+  TOOL_EXECUTION_START: 'tool.execution_start',
+} as const;
+
+export function buildCopilotSourcedUserMessageTranscript(sessionId: string): string {
+  return [
+    JSON.stringify({
+      type: COPILOT_TRANSCRIPT_EVENTS.SESSION_START,
+      timestamp: '2026-06-11T21:00:00.000Z',
+      data: { sessionId, version: 1, producer: 'copilot-agent' },
+    }),
+    JSON.stringify({
+      type: COPILOT_TRANSCRIPT_EVENTS.USER_MESSAGE,
+      timestamp: '2026-06-11T21:00:01.000Z',
+      data: {
+        content: COPILOT_SOURCED_USER_MESSAGE_PROMPT,
+        transformedContent: COPILOT_SOURCED_USER_MESSAGE_PROMPT,
+        attachments: [],
+      },
+    }),
+    JSON.stringify({
+      type: COPILOT_TRANSCRIPT_EVENTS.ASSISTANT_MESSAGE,
+      timestamp: '2026-06-11T21:00:02.000Z',
+      data: {
+        content: '',
+        reasoningText: 'I need to inspect the README first.',
+        toolRequests: [{ id: 'tool-1' }],
+      },
+    }),
+    JSON.stringify({
+      type: COPILOT_TRANSCRIPT_EVENTS.TOOL_EXECUTION_START,
+      timestamp: '2026-06-11T21:00:03.000Z',
+      data: {
+        toolCallId: 'tool-1',
+        toolName: 'view',
+        arguments: { path: 'README.md' },
+      },
+    }),
+    JSON.stringify({
+      type: COPILOT_TRANSCRIPT_EVENTS.USER_MESSAGE,
+      timestamp: '2026-06-11T21:00:04.000Z',
+      data: {
+        source: COPILOT_TOOL_CONTEXT_SOURCE,
+        content: 'tool result text',
+      },
+    }),
+    JSON.stringify({
+      type: COPILOT_TRANSCRIPT_EVENTS.ASSISTANT_MESSAGE,
+      timestamp: '2026-06-11T21:00:05.000Z',
+      data: {
+        content: COPILOT_SOURCED_USER_MESSAGE_RESPONSE,
+        toolRequests: [],
+      },
+    }),
+  ].join('\n');
+}

--- a/tests/hooks/normalize.test.ts
+++ b/tests/hooks/normalize.test.ts
@@ -213,7 +213,7 @@ describe('normalizeHookInput', () => {
       expect(result.sessionId).toBe('input-sid');
     });
 
-    it('maps Copilot camelCase sessionId', () => {
+    it('maps Copilot snake_case session_id', () => {
       const copilotManifest = {
         name: 'copilot',
         displayName: 'GitHub Copilot',
@@ -221,7 +221,7 @@ describe('normalizeHookInput', () => {
         configDir: '.vscode',
         pluginRootEnvVar: 'COPILOT_PLUGIN_ROOT',
         hookFields: {
-          sessionId: 'sessionId',
+          sessionId: 'session_id',
           transcriptPath: 'transcript_path',
           lastResponse: 'last_assistant_message',
           prompt: 'prompt',
@@ -232,7 +232,7 @@ describe('normalizeHookInput', () => {
       };
       mockLoadManifests.mockReturnValue([copilotManifest]);
       process.env.COPILOT_PLUGIN_ROOT = '/some/path';
-      const result = normalizeHookInput({ sessionId: 'copilot-session-1' });
+      const result = normalizeHookInput({ session_id: 'copilot-session-1' });
       expect(result.sessionId).toBe('copilot-session-1');
     });
   });

--- a/tests/symbionts/copilot.test.ts
+++ b/tests/symbionts/copilot.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'bun:test';
 import { copilotAdapter } from '@myco/symbionts/copilot.js';
+import {
+  buildCopilotSourcedUserMessageTranscript,
+  COPILOT_SOURCED_USER_MESSAGE_PROMPT,
+  COPILOT_SOURCED_USER_MESSAGE_RESPONSE,
+} from '../helpers/copilot-transcript.js';
 
 /**
  * Build a Copilot event-log JSONL transcript string.
@@ -87,7 +92,7 @@ describe('copilotAdapter', () => {
     expect(copilotAdapter.name).toBe('copilot');
     expect(copilotAdapter.displayName).toBe('GitHub Copilot');
     expect(copilotAdapter.pluginRootEnvVar).toBe('COPILOT_PLUGIN_ROOT');
-    expect(copilotAdapter.hookFields.sessionId).toBe('sessionId');
+    expect(copilotAdapter.hookFields.sessionId).toBe('session_id');
   });
 
   it('findTranscript always returns null', () => {
@@ -157,6 +162,16 @@ describe('copilotAdapter', () => {
       expect(turns[0].aiResponse).toBe('First answer.');
       expect(turns[1].prompt).toBe('Second question');
       expect(turns[1].toolCount).toBe(1);
+    });
+
+    it('keeps sourced user.message records inside the active human turn', () => {
+      const content = buildCopilotSourcedUserMessageTranscript('test-session');
+
+      const turns = copilotAdapter.parseTurns(content);
+      expect(turns).toHaveLength(1);
+      expect(turns[0].prompt).toBe(COPILOT_SOURCED_USER_MESSAGE_PROMPT);
+      expect(turns[0].toolCount).toBe(1);
+      expect(turns[0].aiResponse).toBe(COPILOT_SOURCED_USER_MESSAGE_RESPONSE);
     });
 
     it('attributes tool calls to the in-flight user turn', () => {


### PR DESCRIPTION
## Summary
- Keep Copilot sourced `user.message` records inside the active human turn instead of treating them as new prompts.
- Align Copilot adapter hook metadata with the manifest-backed `session_id` field.
- Add shared Copilot event-log fixtures plus parser, transcript-miner, stop-processing, and normalization regressions.

## Root Cause
Copilot emits sourced `user.message` records for tool/system context during a turn. The parser treated every `user.message` as a human turn boundary, so transcript mining flushed the real prompt before the final assistant response and failed to populate `response_summary`.

## Verification
- `npm test -- tests/symbionts/copilot.test.ts tests/capture/transcript-miner-reconcile.test.ts tests/daemon/stop-processing.test.ts tests/hooks/normalize.test.ts`
- `bun test tests/integration/capture-pipeline-e2e.test.ts tests/hooks/user-prompt-submit-drop.test.ts tests/hooks/vault-gate-readmit.test.ts tests/hooks/vault-gate.test.ts`
- `make dev-link-worktree`
- sandbox compiled hook/daemon smoke with temp Grove: Copilot prompt persisted `response_summary = "This repository is a Myco development checkout."`
- `make build`

## Runtime Note
The earlier full-suite run wedged once in the unrelated `node env isolated 33` group shown in review. The exact four-file group passes directly in ~1s, focused changed tests pass in <1s, and a fresh full `make build` completed after the cleanup.