### PR TITLE
[codex] harden service-dev global artifact ownership

### DIFF
--- a/packages/myco/src/cli/bootstrap.ts
+++ b/packages/myco/src/cli/bootstrap.ts
@@ -3,15 +3,15 @@
  *
  * Two functions, split by *when* migration runs:
  *
- *   - `runGlobalBootstrap()` — write launchers, run a detection pass,
- *     AND walk every registered project for legacy per-project install
- *     artifacts. Migration is fire-once-per-project: it runs at daemon
- *     first-start and on auto-Grove-create when a fresh project
- *     registers. Explicit retry happens via `myco doctor --fix`. This
- *     entry MUST NOT be called on the hourly tick — re-running the
- *     migration walker every hour normalizes failure as ongoing
- *     operational state. Failures land in the bounded migration audit
- *     log and surface as doctor warnings.
+ *   - `runGlobalBootstrap()` — ensure this variant's default Grove,
+ *     write launchers, run a detection pass, AND walk every registered
+ *     project for legacy per-project install artifacts. Migration is
+ *     fire-once-per-project: it runs at daemon first-start and on
+ *     auto-Grove-create when a fresh project registers. Explicit retry
+ *     happens via `myco doctor --fix`. This entry MUST NOT be called on
+ *     the hourly tick — re-running the migration walker every hour
+ *     normalizes failure as ongoing operational state. Failures land in
+ *     the bounded migration audit log and surface as doctor warnings.
  *   - `runSymbiontDetection()` — walk the manifest registry, install
  *     the global Myco config into each agent whose `detectionDir`
  *     exists. Idempotent: a symbiont already installed (settings-merge
@@ -26,16 +26,28 @@
  * is the structural enforcement; this module reports.
  */
 
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { loadManifests, resolvePackageRoot } from '../symbionts/detect.js';
 import { SymbiontInstaller, type InstallResult } from '../symbionts/installer.js';
-import { installGlobalLaunchers, type InstalledLauncherReport } from '../grove/launcher-install.js';
+import {
+  GLOBAL_HOOK_LAUNCHER_FILENAME,
+  installGlobalLaunchers,
+  type InstalledLauncherReport,
+} from '../grove/launcher-install.js';
 import { runGlobalInstallMigrationPass, type MigrationPassResult } from '../grove/global-install-migration.js';
 import {
   runGlobalConfigMigration,
   type GlobalConfigMigrationResult,
 } from '../grove/global-config-migration.js';
-import { ensureDefaultGrove, type GroveRecord } from '../grove/registry.js';
-import { daemonVariantFromEnvValue } from '../grove/paths.js';
+import {
+  ensureDefaultGrove,
+  resolveDefaultGroveForVariant,
+  type DaemonVariant,
+  type GroveRecord,
+} from '../grove/registry.js';
+import { daemonVariantFromEnvValue, resolveMycoHome } from '../grove/paths.js';
 
 export interface DetectionResult {
   /** Manifest name (e.g. 'claude-code'). */
@@ -67,6 +79,36 @@ export interface BootstrapResult {
   migration: MigrationPassResult;
   /** Per-pass global-config scrub outcomes (e.g. legacy ~/.gemini state). */
   globalConfigMigration: GlobalConfigMigrationResult;
+}
+
+export interface GlobalBootstrapStartupDecision {
+  shouldRun: boolean;
+  launchersAbsent: boolean;
+  defaultGroveAbsent: boolean;
+  servedBy: DaemonVariant;
+  mycoHome: string;
+}
+
+/**
+ * Startup bootstrap is needed when either shared launchers are missing
+ * or this daemon variant lacks its default Grove. The second condition is
+ * load-bearing for dogfood: production may already have created
+ * `launcher.cjs`, while service-dev still needs to create `default-dev`
+ * before hooks can auto-register projects into the dev Grove.
+ */
+export function shouldRunGlobalBootstrap(
+  mycoHome: string = resolveMycoHome(),
+  servedBy: DaemonVariant = daemonVariantFromEnvValue(process.env.MYCO_SERVICE_VARIANT),
+): GlobalBootstrapStartupDecision {
+  const launchersAbsent = !fs.existsSync(path.join(mycoHome, GLOBAL_HOOK_LAUNCHER_FILENAME));
+  const defaultGroveAbsent = resolveDefaultGroveForVariant(mycoHome, { servedBy }) === null;
+  return {
+    shouldRun: launchersAbsent || defaultGroveAbsent,
+    launchersAbsent,
+    defaultGroveAbsent,
+    servedBy,
+    mycoHome,
+  };
 }
 
 /**

--- a/packages/myco/src/cli/doctor.ts
+++ b/packages/myco/src/cli/doctor.ts
@@ -576,21 +576,29 @@ export async function runChecks(vaultDir: string): Promise<DoctorCheck[]> {
 /**
  * Global launcher health: `~/.myco/launcher.cjs` and
  * `~/.myco/mcp-launcher.cjs` exist and are non-empty. Their absence is
- * the signal that drives the daemon's first-start auto-bootstrap; once
- * the daemon has come up at least once they must be present, so a
+ * the signal that drives daemon bootstrap for the shared launcher path;
+ * once the daemon has come up at least once they must be present, so a
  * missing launcher here is a real failure mode (recover by restarting
- * the daemon, which re-runs the first-start bootstrap and rewrites the
- * launchers).
+ * the daemon, which re-runs bootstrap and rewrites them).
  */
 async function checkGlobalLaunchers(): Promise<DoctorCheck> {
   const { resolveMycoHome } = await import('../grove/paths.js');
+  const {
+    GLOBAL_HOOK_LAUNCHER_FILENAME,
+    GLOBAL_MCP_LAUNCHER_FILENAME,
+  } = await import('../grove/launcher-install.js');
   const mycoHome = resolveMycoHome();
-  const launcherPath = path.join(mycoHome, 'launcher.cjs');
-  const mcpLauncherPath = path.join(mycoHome, 'mcp-launcher.cjs');
+  const launcherPath = path.join(mycoHome, GLOBAL_HOOK_LAUNCHER_FILENAME);
+  const mcpLauncherPath = path.join(mycoHome, GLOBAL_MCP_LAUNCHER_FILENAME);
   const launcherOk = fs.existsSync(launcherPath) && fs.statSync(launcherPath).size > 0;
   const mcpOk = fs.existsSync(mcpLauncherPath) && fs.statSync(mcpLauncherPath).size > 0;
   if (launcherOk && mcpOk) {
-    return { name: 'Launchers', status: 'ok', detail: `${mycoHome}/launcher.cjs + mcp-launcher.cjs`, fixable: false };
+    return {
+      name: 'Launchers',
+      status: 'ok',
+      detail: `${launcherPath} + ${mcpLauncherPath}`,
+      fixable: false,
+    };
   }
   return {
     name: 'Launchers',

--- a/packages/myco/src/cli/remove.ts
+++ b/packages/myco/src/cli/remove.ts
@@ -4,6 +4,7 @@ import { parseStrictFlags, type ParsedFlags } from './args.js';
 import { confirmDestructive } from './confirm.js';
 import { loadManifests, resolvePackageRoot } from '../symbionts/detect.js';
 import { SymbiontInstaller, removeProjectLaunchers } from '../symbionts/installer.js';
+import { GLOBAL_HOOK_LAUNCHER_FILENAME, GLOBAL_MCP_LAUNCHER_FILENAME } from '../grove/launcher-install.js';
 import { resolveMycoHome } from '../grove/paths.js';
 import { updateConfig, TierConfigUnreadableError } from '../config/loader.js';
 import type { SymbiontManifest } from '../symbionts/manifest-schema.js';
@@ -143,7 +144,7 @@ async function runGlobalRemove(opts: { purge: boolean; assumeYes: boolean }): Pr
 
   // --- Delete the global launchers. lstat + unlink so we never follow a
   //     symlink and accidentally clobber an unrelated target. ---
-  for (const filename of ['launcher.cjs', 'mcp-launcher.cjs']) {
+  for (const filename of [GLOBAL_HOOK_LAUNCHER_FILENAME, GLOBAL_MCP_LAUNCHER_FILENAME]) {
     const target = path.join(mycoHome, filename);
     try {
       fs.lstatSync(target);

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -20,7 +20,7 @@ import * as updateInProgress from './update-in-progress.js';
 import { resolveVaultDir, resolveProjectRoot } from '../vault/resolve.js';
 import { EventBuffer } from '../capture/buffer.js';
 import { listAllProjectBufferDirs } from '../capture/buffer-location.js';
-import { runGlobalBootstrap } from '../cli/bootstrap.js';
+import { runGlobalBootstrap, shouldRunGlobalBootstrap } from '../cli/bootstrap.js';
 import { resolveMycoHome, resolveGroveDbPath } from '../grove/paths.js';
 import { loadManifests } from '../symbionts/detect.js';
 import type { PlanWatchConfig } from './plan-capture.js';
@@ -1158,18 +1158,20 @@ export async function main(): Promise<void> {
   // vault regardless of how many times the daemon starts.
   await runPendingMigrationTasks({ db: getDatabase(), embeddingManager, logger });
 
-  // First-start auto-bootstrap. Signal: the global launcher is absent
-  // from `~/.myco/`. When fired, write the launchers and run a symbiont
-  // detection pass so every installed agent on the machine gets Myco
-  // wired into its user-global config without the user touching the
-  // CLI. Idempotent — subsequent daemon starts skip immediately.
-  // PowerManager tick (Step 7) handles re-detection thereafter.
+  // First-start auto-bootstrap. Runs when shared launchers are missing
+  // or this daemon variant lacks its default Grove. The second condition
+  // matters for service-dev: production may already have created
+  // `launcher.cjs`, while dogfood still needs `default-dev` before hooks
+  // can auto-register projects into the dev Grove. PowerManager tick
+  // handles re-detection thereafter.
   try {
-    const mycoHome = resolveMycoHome();
-    const launcherPath = path.join(mycoHome, 'launcher.cjs');
-    if (!fs.existsSync(launcherPath)) {
-      logger.info(LOG_KINDS.DAEMON_START, 'First-start global bootstrap — launchers absent', {
-        myco_home: mycoHome,
+    const decision = shouldRunGlobalBootstrap(resolveMycoHome());
+    if (decision.shouldRun) {
+      logger.info(LOG_KINDS.DAEMON_START, 'First-start global bootstrap required', {
+        myco_home: decision.mycoHome,
+        served_by: decision.servedBy,
+        launchers_absent: decision.launchersAbsent,
+        default_grove_absent: decision.defaultGroveAbsent,
       });
       const result = runGlobalBootstrap();
       const installed = result.symbionts.filter((r) => r.status === 'installed');

--- a/packages/myco/src/grove/launcher-install.ts
+++ b/packages/myco/src/grove/launcher-install.ts
@@ -39,7 +39,12 @@ import type { DaemonServiceState } from '../daemon/service-state.js';
 const LAUNCHER_TEMPLATE_KEY = '_shared/global-launcher.cjs';
 
 /** Filenames the launcher is installed under (mode is encoded in the basename). */
-const LAUNCHER_FILENAMES = ['launcher.cjs', 'mcp-launcher.cjs'] as const;
+export const GLOBAL_HOOK_LAUNCHER_FILENAME = 'launcher.cjs';
+export const GLOBAL_MCP_LAUNCHER_FILENAME = 'mcp-launcher.cjs';
+const LAUNCHER_FILENAMES = [
+  GLOBAL_HOOK_LAUNCHER_FILENAME,
+  GLOBAL_MCP_LAUNCHER_FILENAME,
+] as const;
 
 /**
  * When the daemon is the active process, all launcher refreshes flow
@@ -62,7 +67,7 @@ export function unbindDaemonForLauncherRefresh(): void {
 }
 
 export interface InstalledLauncherReport {
-  /** Absolute paths actually written this call (skipped paths are absent). */
+  /** Absolute paths actually written this call. */
   written: string[];
   /** Absolute paths whose content matched the template already (no write). */
   unchanged: string[];
@@ -84,6 +89,7 @@ export function installGlobalLaunchers(
   mycoHome = resolveMycoHome(),
   options: { skipIntent?: boolean } = {},
 ): InstalledLauncherReport {
+  const targets = LAUNCHER_FILENAMES.map((filename) => path.join(mycoHome, filename));
   const template = BUNDLED_TEMPLATES[LAUNCHER_TEMPLATE_KEY];
   if (!template) {
     throw new Error(`Global launcher template missing from bundled assets: ${LAUNCHER_TEMPLATE_KEY}`);
@@ -94,8 +100,7 @@ export function installGlobalLaunchers(
   fs.mkdirSync(mycoHome, { recursive: true });
   const report: InstalledLauncherReport = { written: [], unchanged: [] };
   const needsWrite: string[] = [];
-  for (const filename of LAUNCHER_FILENAMES) {
-    const target = path.join(mycoHome, filename);
+  for (const target of targets) {
     if (readFileQuiet(target) === template) {
       report.unchanged.push(target);
       continue;

--- a/packages/myco/src/symbionts/installer.ts
+++ b/packages/myco/src/symbionts/installer.ts
@@ -2,7 +2,10 @@ import type { SymbiontManifest } from './manifest-schema.js';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { installGlobalLaunchers } from '../grove/launcher-install.js';
+import {
+  GLOBAL_HOOK_LAUNCHER_FILENAME,
+  installGlobalLaunchers,
+} from '../grove/launcher-install.js';
 import { expandHome, resolveMycoHome } from '../grove/paths.js';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { findTomlSectionEnd, buildTomlMcpSection, upsertTomlSection, upsertTomlSectionKeys, removeTomlSectionKeys, readTomlSectionKey } from './toml-helpers.js';
@@ -157,7 +160,7 @@ const PROJECT_LAUNCHER_CMD = 'node .agents/myco-run.cjs';
  */
 function resolveLauncherCmd(scope: InstallScope, mycoHome: string): string {
   if (scope === 'project') return PROJECT_LAUNCHER_CMD;
-  const launcherPath = path.join(mycoHome, 'launcher.cjs');
+  const launcherPath = path.join(mycoHome, GLOBAL_HOOK_LAUNCHER_FILENAME);
   assertSafeHomeForUnquotedPath(launcherPath);
   return `node ${launcherPath}`;
 }
@@ -212,6 +215,18 @@ export interface InstallResult {
    * runtime dependency declaration.
    */
   pluginManifest: boolean;
+}
+
+function emptyInstallResult(): InstallResult {
+  return {
+    hooks: false,
+    mcp: false,
+    skills: false,
+    settings: false,
+    instructions: false,
+    pluginPackage: false,
+    pluginManifest: false,
+  };
 }
 
 export interface ManagedProjectFilesResult {
@@ -593,10 +608,7 @@ export class SymbiontInstaller {
     if (this.capabilities.detectionGate && !this.isAvailableForScope()) {
       // Agent isn't installed on this machine — skip silently, never
       // create the agent's config dir on its behalf.
-      return {
-        hooks: false, mcp: false, skills: false, settings: false,
-        instructions: false, pluginPackage: false, pluginManifest: false,
-      };
+      return emptyInstallResult();
     }
     // Project-content surfaces (AGENTS.md, .gitignore, instruction stubs)
     // are intentionally project-scope-only — they live in the repo tree.

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -212,24 +212,17 @@ const SOLO_NODE_FILES = [
   'tests/daemon/api/providers-ssrf.test.ts',
   'tests/daemon/api/restart.test.ts',
   'tests/daemon/api/stats.test.ts',
+  // These dispatcher fixtures share the ambient test DB and dispatcher
+  // lifecycle heavily enough that they stay cheaper and less flaky as
+  // explicit single-file processes than as hidden source-pattern matches.
+  'tests/daemon/event-contract-recovery.test.ts',
+  'tests/daemon/event-dispatch.test.ts',
   'tests/daemon/team-sync.test.ts',
   'tests/deploy/shared.test.ts',
 ];
 
 const SOLO_NODE_REASON_LISTED_FILE = 'listed-solo-node-file';
 const SOLO_NODE_REASON_MODULE_MOCK = 'mock.module';
-const SOLO_NODE_REASON_DISPATCHER_SHARED_TEST_DB = 'dispatcher-with-shared-test-db';
-
-const PROCESS_DIRTY_FIXTURE_RULES = [
-  {
-    reason: SOLO_NODE_REASON_DISPATCHER_SHARED_TEST_DB,
-    patterns: [
-      /\bcreateEventDispatcher\(/,
-      /\bsetupTestDb\(/,
-      /\bteardownTestDb\(/,
-    ],
-  },
-];
 
 const NO_ISOLATE_NODE_GROUPS = [
   {
@@ -563,24 +556,9 @@ function fileHasModuleMock(file) {
   return moduleMockCache.get(file);
 }
 
-const processDirtyFixtureCache = new Map();
-function processDirtyFixtureReason(file) {
-  if (!processDirtyFixtureCache.has(file)) {
-    let matchingReason = null;
-    try {
-      const source = fs.readFileSync(path.resolve(REPO, file), 'utf-8');
-      matchingReason = PROCESS_DIRTY_FIXTURE_RULES.find((rule) => (
-        rule.patterns.every((pattern) => pattern.test(source))
-      ))?.reason ?? null;
-    } catch { /* unreadable file — let bun surface it */ }
-    processDirtyFixtureCache.set(file, matchingReason);
-  }
-  return processDirtyFixtureCache.get(file);
-}
-
 function soloNodeProcessReason(file) {
   if (fileHasModuleMock(file)) return SOLO_NODE_REASON_MODULE_MOCK;
-  return processDirtyFixtureReason(file);
+  return null;
 }
 
 function fileRequiresSoloNodeProcess(file) {

--- a/tests/cli/bootstrap.test.ts
+++ b/tests/cli/bootstrap.test.ts
@@ -13,8 +13,16 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { runGlobalBootstrap, runSymbiontDetection } from '@myco/cli/bootstrap.js';
+import {
+  runGlobalBootstrap,
+  runSymbiontDetection,
+  shouldRunGlobalBootstrap,
+} from '@myco/cli/bootstrap.js';
 import { loadProjectManifest } from '@myco/config/project-manifest.js';
+import {
+  GLOBAL_HOOK_LAUNCHER_FILENAME,
+  GLOBAL_MCP_LAUNCHER_FILENAME,
+} from '@myco/grove/launcher-install.js';
 import {
   createGrove,
   registerProjectInGrove,
@@ -230,6 +238,48 @@ describe('runGlobalBootstrap — default-Grove ensure (greenfield)', () => {
 
     expect(result.defaultGrove.served_by).toBe('service-dev');
     expect(result.defaultGrove.slug).toBe('default-dev');
+  });
+
+  it('startup bootstrap still runs for service-dev when prod launchers exist but default-dev is missing', () => {
+    const mycoHome = path.join(tmpHome, '.myco');
+    fs.mkdirSync(mycoHome, { recursive: true });
+    fs.writeFileSync(path.join(mycoHome, GLOBAL_HOOK_LAUNCHER_FILENAME), '// prod-owned launcher\n', 'utf-8');
+    createGrove('default', mycoHome, { servedBy: 'service' });
+    clearGroveRegistryCaches();
+
+    const decision = shouldRunGlobalBootstrap(mycoHome, 'service-dev');
+
+    expect(decision.shouldRun).toBe(true);
+    expect(decision.launchersAbsent).toBe(false);
+    expect(decision.defaultGroveAbsent).toBe(true);
+    expect(decision.servedBy).toBe('service-dev');
+  });
+
+  it('startup bootstrap skips when the shared launcher and this variant default Grove already exist', () => {
+    const mycoHome = path.join(tmpHome, '.myco');
+    fs.mkdirSync(mycoHome, { recursive: true });
+    fs.writeFileSync(path.join(mycoHome, GLOBAL_HOOK_LAUNCHER_FILENAME), '// prod-owned launcher\n', 'utf-8');
+    createGrove('default', mycoHome, { servedBy: 'service' });
+    createGrove('default-dev', mycoHome, { servedBy: 'service-dev' });
+    clearGroveRegistryCaches();
+
+    const decision = shouldRunGlobalBootstrap(mycoHome, 'service-dev');
+
+    expect(decision.shouldRun).toBe(false);
+    expect(decision.launchersAbsent).toBe(false);
+    expect(decision.defaultGroveAbsent).toBe(false);
+  });
+
+  it('startup bootstrap runs when the shared launcher is missing even if the default Grove exists', () => {
+    const mycoHome = path.join(tmpHome, '.myco');
+    createGrove('default', mycoHome, { servedBy: 'service' });
+    clearGroveRegistryCaches();
+
+    const decision = shouldRunGlobalBootstrap(mycoHome, 'service');
+
+    expect(decision.shouldRun).toBe(true);
+    expect(decision.launchersAbsent).toBe(true);
+    expect(decision.defaultGroveAbsent).toBe(false);
   });
 
   it('is idempotent — second bootstrap returns the same default Grove without creating a duplicate', () => {

--- a/tests/grove/launcher-install.test.ts
+++ b/tests/grove/launcher-install.test.ts
@@ -5,6 +5,8 @@ import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
 import {
+  GLOBAL_HOOK_LAUNCHER_FILENAME,
+  GLOBAL_MCP_LAUNCHER_FILENAME,
   installGlobalLaunchers,
   bindDaemonForLauncherRefresh,
   unbindDaemonForLauncherRefresh,
@@ -23,8 +25,8 @@ describe('installGlobalLaunchers', () => {
 
   it('writes both launcher files on a fresh home', () => {
     const report = installGlobalLaunchers(mycoHome);
-    const launcherPath = path.join(mycoHome, 'launcher.cjs');
-    const mcpLauncherPath = path.join(mycoHome, 'mcp-launcher.cjs');
+    const launcherPath = path.join(mycoHome, GLOBAL_HOOK_LAUNCHER_FILENAME);
+    const mcpLauncherPath = path.join(mycoHome, GLOBAL_MCP_LAUNCHER_FILENAME);
 
     expect(report.written).toEqual([launcherPath, mcpLauncherPath]);
     expect(report.unchanged).toEqual([]);
@@ -47,7 +49,7 @@ describe('installGlobalLaunchers', () => {
   });
 
   it('rewrites a stale launcher whose content has drifted', () => {
-    const launcherPath = path.join(mycoHome, 'launcher.cjs');
+    const launcherPath = path.join(mycoHome, GLOBAL_HOOK_LAUNCHER_FILENAME);
     fs.writeFileSync(launcherPath, '#!/usr/bin/env node\n// stale\n', { mode: 0o755 });
 
     const report = installGlobalLaunchers(mycoHome);
@@ -57,12 +59,13 @@ describe('installGlobalLaunchers', () => {
 
   it('installs both files with executable bits set', () => {
     installGlobalLaunchers(mycoHome);
-    const launcherStat = fs.statSync(path.join(mycoHome, 'launcher.cjs'));
-    const mcpStat = fs.statSync(path.join(mycoHome, 'mcp-launcher.cjs'));
+    const launcherStat = fs.statSync(path.join(mycoHome, GLOBAL_HOOK_LAUNCHER_FILENAME));
+    const mcpStat = fs.statSync(path.join(mycoHome, GLOBAL_MCP_LAUNCHER_FILENAME));
     // User-exec bit set on both.
     expect(launcherStat.mode & 0o100).toBe(0o100);
     expect(mcpStat.mode & 0o100).toBe(0o100);
   });
+
 });
 
 describe('global launcher — runtime resolution', () => {
@@ -79,7 +82,10 @@ describe('global launcher — runtime resolution', () => {
     fs.rmSync(projectRoot, { recursive: true, force: true });
   });
 
-  function spawnLauncher(launcher: 'launcher.cjs' | 'mcp-launcher.cjs', args: string[]) {
+  function spawnLauncher(
+    launcher: typeof GLOBAL_HOOK_LAUNCHER_FILENAME | typeof GLOBAL_MCP_LAUNCHER_FILENAME,
+    args: string[],
+  ) {
     return spawnSync(
       process.execPath,
       [path.join(mycoHome, launcher), ...args],
@@ -111,7 +117,7 @@ describe('global launcher — runtime resolution', () => {
     );
     fs.chmodSync(fakeBin, 0o755);
 
-    const result = spawnLauncher('launcher.cjs', ['hook', 'stop']);
+    const result = spawnLauncher(GLOBAL_HOOK_LAUNCHER_FILENAME, ['hook', 'stop']);
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe('pin:hook,stop');
   });
@@ -165,8 +171,8 @@ describe('installGlobalLaunchers — daemon-bound intent bypass', () => {
   it('skipIntent: true writes launchers directly even with daemonIntentContext bound', () => {
     const report = installGlobalLaunchers(mycoHome, { skipIntent: true });
 
-    const launcherPath = path.join(mycoHome, 'launcher.cjs');
-    const mcpLauncherPath = path.join(mycoHome, 'mcp-launcher.cjs');
+    const launcherPath = path.join(mycoHome, GLOBAL_HOOK_LAUNCHER_FILENAME);
+    const mcpLauncherPath = path.join(mycoHome, GLOBAL_MCP_LAUNCHER_FILENAME);
     expect(report.written).toEqual([launcherPath, mcpLauncherPath]);
     expect(report.unchanged).toEqual([]);
 
@@ -188,8 +194,8 @@ describe('installGlobalLaunchers — daemon-bound intent bypass', () => {
   it('default (no skipIntent) raises the refresh-launchers intent and does NOT write the launchers', () => {
     const report = installGlobalLaunchers(mycoHome);
 
-    const launcherPath = path.join(mycoHome, 'launcher.cjs');
-    const mcpLauncherPath = path.join(mycoHome, 'mcp-launcher.cjs');
+    const launcherPath = path.join(mycoHome, GLOBAL_HOOK_LAUNCHER_FILENAME);
+    const mcpLauncherPath = path.join(mycoHome, GLOBAL_MCP_LAUNCHER_FILENAME);
 
     // Both launchers reported as `unchanged` (pending the reconciler's
     // bypass-write pass — the contract documented in launcher-install.ts).


### PR DESCRIPTION
## Summary
- make daemon startup bootstrap variant-aware: skip only when the shared launcher exists and this daemon variant already has its default Grove
- add shared global launcher filename constants and use them on touched launcher lifecycle paths
- dial back the #499 Bun runner hardening by removing source-pattern solo classification; dispatcher fixtures are now explicit solo files, while `mock.module` detection remains semantic

## Validation
- `npm test -- tests/cli/remove.test.ts tests/grove/launcher-install.test.ts tests/cli/bootstrap.test.ts tests/symbionts/installer.test.ts tests/daemon/event-contract-recovery.test.ts tests/daemon/event-dispatch.test.ts`
- `npx tsc --noEmit`
- `make build`
- dogfood sandbox: prod daemon created shared launchers/default Grove, then service-dev daemon still ran bootstrap with `launchers_absent:false` and `default_grove_absent:true`, creating `default-dev` without skipped global-artifact behavior
