### PR TITLE
fix: post-v1.0.17 review hardening (test double-run, hook alias, selection)

### DIFF
--- a/packages/myco/src/hooks/normalize.ts
+++ b/packages/myco/src/hooks/normalize.ts
@@ -182,7 +182,10 @@ function getFirstAtPath(input: Record<string, unknown>, field: HookFieldPath): u
   const paths = Array.isArray(field) ? field : [field];
   for (const candidate of paths) {
     const value = getAtPath(input, candidate);
-    if (value !== undefined) return value;
+    // Treat blank/nullish as absent so a present-but-empty primary field (e.g. a
+    // host that emits `conversation_id: ''`) doesn't shadow a populated alias
+    // later in the list. Non-string payloads (tool_input objects) pass through.
+    if (value !== undefined && value !== null && value !== '') return value;
   }
   return undefined;
 }

--- a/packages/myco/ui/src/App.tsx
+++ b/packages/myco/ui/src/App.tsx
@@ -117,10 +117,15 @@ export default function App() {
 function RootRedirect() {
   const { data, isLoading, error } = useGroves();
   const { data: activity, isLoading: activityLoading } = useProjectsActivity();
-  if (isLoading || activityLoading) return <RouteLoading text="Loading projects..." />;
+  if (isLoading) return <RouteLoading text="Loading projects..." />;
   if (error) return <RouteLoading text={error.message} />;
   const groves = data?.groves ?? [];
-  const selection = selectionFromLast(groves) ?? mostRecentSelection(groves, activity?.projects);
+  // Only the most-recent fallback needs activity data; a stored selection
+  // resolves immediately, so returning users never wait on the (per-project)
+  // activity query just to land on the project they already had selected.
+  const remembered = selectionFromLast(groves);
+  if (!remembered && activityLoading) return <RouteLoading text="Loading projects..." />;
+  const selection = remembered ?? mostRecentSelection(groves, activity?.projects);
   return selection
     ? <Navigate to={projectPath(selection)} replace />
     : <Navigate to="/onboarding" replace />;

--- a/packages/myco/ui/src/lib/selection.ts
+++ b/packages/myco/ui/src/lib/selection.ts
@@ -82,7 +82,10 @@ export function defaultSelection(groves: GroveSummary[]): ProjectSelection | nul
 function activityMsByProject(activity: ProjectActivityRow[] | undefined): Map<string, number> {
   const map = new Map<string, number>();
   for (const row of activity ?? []) {
-    map.set(row.project_id, row.last_activity_at ? Date.parse(row.last_activity_at) : 0);
+    // Normalize a missing or unparseable timestamp to 0 so NaN never reaches a
+    // comparator (NaN makes Array.sort order undefined and `>` always false).
+    const parsed = row.last_activity_at ? Date.parse(row.last_activity_at) : 0;
+    map.set(row.project_id, Number.isNaN(parsed) ? 0 : parsed);
   }
   return map;
 }
@@ -96,10 +99,15 @@ export function mostRecentSelection(
   groves: GroveSummary[],
   activity: ProjectActivityRow[] | undefined,
 ): ProjectSelection | null {
-  if (!activity || activity.length === 0) return defaultSelection(groves);
+  const fallback = defaultSelection(groves);
+  if (!activity || activity.length === 0) return fallback;
   const ms = activityMsByProject(activity);
-  let best: ProjectSelection | null = null;
-  let bestMs = -1;
+  // Seed with the default selection so a project only displaces it when it has
+  // STRICTLY greater activity. This keeps the is_default grove preference on
+  // ties (e.g. right after install when every project's activity is 0), instead
+  // of silently landing on whichever grove happens to be first in the array.
+  let best = fallback;
+  let bestMs = fallback ? (ms.get(fallback.project.project_id) ?? 0) : -1;
   for (const grove of groves) {
     for (const project of grove.projects) {
       const value = ms.get(project.project_id) ?? 0;
@@ -109,7 +117,7 @@ export function mostRecentSelection(
       }
     }
   }
-  return best ?? defaultSelection(groves);
+  return best;
 }
 
 /** Most-recently-active project within a single grove (first project if no activity). */

--- a/scripts/run-bun-tests.mjs
+++ b/scripts/run-bun-tests.mjs
@@ -371,7 +371,6 @@ const NO_ISOLATE_NODE_GROUPS = [
   {
     label: 'tests-daemon-capture-backup',
     targets: [
-      'tests/daemon/event-dispatch.test.ts',
       'tests/daemon/backup-canopy-roundtrip.test.ts',
       'tests/daemon/capture.test.ts',
       'tests/daemon/backup.test.ts',
@@ -622,10 +621,10 @@ function noIsolateArgsForTarget(target, options) {
   ];
 }
 
-function noIsolateArgsForGroup(group, options) {
+function noIsolateArgsForFiles(files, options) {
   return [
     ...options,
-    ...group.targets,
+    ...files,
     "--path-ignore-patterns=**/*.test.tsx",
     ...(profile === 'fast' ? fastIgnoreArgs() : []),
   ];
@@ -639,10 +638,15 @@ function noIsolatePhaseForTarget(target, options) {
   };
 }
 
-function noIsolatePhaseForGroup(group, options) {
+// Emit the files the group actually covers within `sharedFiles` rather than the
+// literal target list. `group.targets` is a *selector*; `sharedFiles` has
+// already excluded solo / process-sensitive files, so a file listed in both a
+// group and SOLO_NODE_FILES can never leak back into a shared (no-isolate)
+// process. Keeps the emitted set identical to the partition accounting.
+function noIsolatePhaseForGroup(group, sharedFiles, options) {
   return {
     label: `node env shared ${group.label}`,
-    args: noIsolateArgsForGroup(group, options),
+    args: noIsolateArgsForFiles(sharedGroupFiles(group, sharedFiles), options),
     isolate: false,
   };
 }
@@ -682,10 +686,10 @@ function findSharedGroups(files) {
   return NO_ISOLATE_NODE_GROUPS.filter((group) => groupHasFiles(group, files));
 }
 
-function buildNoIsolatePhases(targets, groups, options) {
+function buildNoIsolatePhases(targets, groups, sharedFiles, options) {
   return [
     ...targets.map((target) => noIsolatePhaseForTarget(target, options)),
-    ...groups.map((group) => noIsolatePhaseForGroup(group, options)),
+    ...groups.map((group) => noIsolatePhaseForGroup(group, sharedFiles, options)),
   ];
 }
 
@@ -816,7 +820,7 @@ function buildArgs() {
 
     return {
       nonDomPhases: [
-        ...buildNoIsolatePhases(sharedTargets, sharedGroups, options),
+        ...buildNoIsolatePhases(sharedTargets, sharedGroups, sharedFiles, options),
         ...soloFiles.map((file) => soloNodePhaseForFile(file, options)),
         ...buildIsolatedNodePhases(isolatedTargets, options),
       ],
@@ -1287,6 +1291,34 @@ function stripDuplicateReact() {
 }
 
 const { nonDomPhases, dom } = buildArgs();
+
+// Audit the computed phase plan without executing. Lets a reviewer (or a CI
+// guard) confirm every test file lands in exactly one phase — catching a file
+// listed in both SOLO_NODE_FILES and a NO_ISOLATE group, which would otherwise
+// run twice (once solo, once in the shared no-isolate process it was moved out
+// of).
+if (process.env.MYCO_RUNNER_DRY_RUN === '1') {
+  const seen = new Map();
+  for (const phase of [...nonDomPhases, ...(dom ? [{ label: 'jsdom', args: dom, isolate: true }] : [])]) {
+    const files = phase.args.filter(
+      (arg) => !arg.startsWith('-') && (arg.endsWith('.test.ts') || arg.endsWith('.test.tsx')),
+    );
+    console.log(`[dry-run] ${phase.isolate ? 'isolate' : 'shared '} ${phase.label}: ${files.length} file(s)`);
+    for (const file of files) {
+      console.log(`           ${file}`);
+      seen.set(file, (seen.get(file) ?? 0) + 1);
+    }
+  }
+  const duplicated = [...seen.entries()].filter(([, count]) => count > 1);
+  if (duplicated.length > 0) {
+    console.error(`[dry-run] FAIL — files scheduled in more than one phase:`);
+    for (const [file, count] of duplicated) console.error(`  ${count}× ${file}`);
+    process.exit(1);
+  }
+  console.log('[dry-run] OK — no file scheduled in more than one phase');
+  process.exit(0);
+}
+
 const phaseReports = [];
 resetReportDir();
 

--- a/tests/hooks/normalize.test.ts
+++ b/tests/hooks/normalize.test.ts
@@ -430,6 +430,17 @@ describe('normalizeHookInput', () => {
       expect(result.sessionId).toBe('cursor-native-session');
     });
 
+    it('falls through an empty primary alias to a populated secondary alias', () => {
+      mockLoadManifests.mockReturnValue([cursorManifest]);
+      process.argv = ['node', 'myco-run', 'hook', 'post-tool-use', '--symbiont', 'cursor'];
+      const result = normalizeHookInput({
+        conversation_id: '',
+        session_id: 'embedded-runtime-session',
+      });
+      expect(result.agent).toBe('cursor');
+      expect(result.sessionId).toBe('embedded-runtime-session');
+    });
+
     it('unknown --symbiont value falls through to heuristic detection', () => {
       mockLoadManifests.mockReturnValue([claudeManifest, codexManifest]);
       process.argv = ['node', 'myco-run', 'hook', 'session-start', '--symbiont', 'bogus'];

--- a/tests/ui/selection-defaults.test.ts
+++ b/tests/ui/selection-defaults.test.ts
@@ -47,6 +47,27 @@ describe('mostRecentSelection', () => {
     ]));
     expect(sel?.project.project_id).toBe('p-first');
   });
+  it('prefers the is_default grove on an all-equal-activity tie, not the array-first grove', () => {
+    const nonDefaultFirst: GroveSummary = {
+      ...groveA, id: 'grove-z', name: 'Other', slug: 'other', is_default: false,
+      projects: [project('z-first', 'z-first-1')],
+    };
+    // Both projects share the same (null) activity → a tie. The default grove
+    // (second in the array) must still win.
+    const sel = mostRecentSelection([nonDefaultFirst, groveA], activity([
+      ['z-first', null],
+      ['p-first', null],
+    ]));
+    expect(sel?.grove.id).toBe('grove-a');
+    expect(sel?.project.project_id).toBe('p-first');
+  });
+  it('ignores a malformed timestamp rather than letting NaN poison the comparison', () => {
+    const sel = mostRecentSelection([groveA], activity([
+      ['p-first', 'not-a-date'],
+      ['p-second', '2026-06-10T00:00:00.000Z'],
+    ]));
+    expect(sel?.project.project_id).toBe('p-second');
+  });
 });
 
 describe('mostRecentProjectInGrove', () => {


### PR DESCRIPTION
Follow-ups from a review of all changes since `myco/v1.0.17`. Emphasis on patterns over patches.

## Confirmed fixes

### 1. Test double-run + shared-process poisoning (`scripts/run-bun-tests.mjs`)
`tests/daemon/event-dispatch.test.ts` was in **both** `SOLO_NODE_FILES` and the `tests-daemon-capture-backup` `NO_ISOLATE` group. Because group phases emitted the literal `group.targets`, the file ran **twice** — once as its intended solo single-file process, and again in the shared no-`--isolate` process it was explicitly moved out of (the exact DB/dispatcher contention the solo move targeted).

Fixed as a pattern, not a patch:
- Group phases now emit `sharedGroupFiles(group, sharedFiles)` (resolved shared files), not the literal target list. `sharedFiles` already excludes solo/process-sensitive files, so a file listed in both places **can never leak into a shared phase**. The bug class is structurally impossible.
- Removed the contradictory `event-dispatch.test.ts` group entry.
- Added `MYCO_RUNNER_DRY_RUN=1` — prints the phase plan and **fails if any file is double-scheduled** (reusable guard).

### 2. Empty-alias shadowing (`hooks/normalize.ts`)
`getFirstAtPath` only advanced on `undefined`, so a present-but-empty primary hook field (e.g. a host emitting `conversation_id: ''`) shadowed a populated alias (`session_id`). Now treats `''`/`null`/`undefined` as absent; non-string payloads (tool_input objects) still pass through. + regression test.

### 3. RootRedirect over-blocking (`ui/App.tsx`)
The landing route blocked first paint on the per-project `/projects/activity` query even when a stored selection would resolve immediately. Now only waits on activity when there's no stored selection, so returning users don't pay activity latency.

### 4. Selection tie-break + NaN (`ui/lib/selection.ts`)
`mostRecentSelection` ignored `is_default` on all-equal-activity ties (common right after install, when every project's activity is 0), landing on whichever grove was first in the array. Now seeds with `defaultSelection` so the default grove wins ties. `activityMsByProject` normalizes `NaN→0` so a malformed timestamp can't poison the comparator/sort. + 2 regression tests.

## Investigated, no change needed
- **`pi/plugin.ts` / `install-helpers.ts` hardcoded launcher names** — refuted: `pi/plugin.ts` is a deliberately standalone template (cannot import package internals), and `install-helpers.ts` is its own documented single-source-of-truth for ownership detection (intentionally decoupled from the path constant). The launcher-constant extraction was complete for its scope.
- **`context.ts:278` subagent-start log** — pre-existing `info` log, semantically distinct from the prompt-skip the PR targeted; out of scope.
- **Stop-cleanup refusal lingering state** — working as intended (data-preservation contract); self-heals on next valid Stop.

## Verification
- `tsc --noEmit` (root): 0 errors
- `vite build` (UI): success
- `normalize.test.ts` 37 pass · `selection-defaults.test.ts` 9 pass · pinned-scope/persist UI tests pass
- runner dry-run: no double-scheduled files

🤖 Generated with [Claude Code](https://claude.com/claude-code)