### PR TITLE
fix(service): platform-aware PATH in daemon service spec

### DIFF
--- a/packages/myco/src/service/spec-builder.ts
+++ b/packages/myco/src/service/spec-builder.ts
@@ -11,6 +11,8 @@ export interface BuildSpecOptions {
   executable: string;
   /** Override MYCO_HOME (defaults to the live resolver). */
   mycoHome?: string;
+  /** Platform to build the spec for; defaults to process.platform. Injected mainly for tests. */
+  platform?: NodeJS.Platform;
 }
 
 /**
@@ -46,6 +48,7 @@ export function looksLikeDevBuildExecutable(executable: string): boolean {
 
 export function buildServiceSpec(opts: BuildSpecOptions): ServiceSpec {
   const mycoHome = opts.mycoHome ?? resolveMycoHome();
+  const platform = opts.platform ?? process.platform;
   const executable = path.resolve(opts.executable);
 
   if (!fs.existsSync(executable)) {
@@ -89,7 +92,9 @@ export function buildServiceSpec(opts: BuildSpecOptions): ServiceSpec {
   const env: Record<string, string> = {
     MYCO_HOME: mycoHome,
     MYCO_SERVICE_VARIANT: opts.variant,
-    PATH: '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin',
+    PATH: platform === 'darwin'
+      ? '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
+      : '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin',
   };
   // Propagate the sandbox unit-dir override into the plist so a supervisor-
   // spawned child daemon does NOT fall back to `~/Library/LaunchAgents/` and

--- a/tests/service/spec-builder.test.ts
+++ b/tests/service/spec-builder.test.ts
@@ -56,11 +56,20 @@ describe('buildServiceSpec', () => {
     })).toThrow(/Cellar/);
   });
 
-  test('PATH always includes /opt/homebrew/bin and /usr/local/bin so GUI-launched daemon finds tools', () => {
+  test('darwin service PATH includes Homebrew bin + /usr/local/bin', () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-home-'));
     const bin = makeFakeBinary();
-    const spec = buildServiceSpec({ variant: 'prod', mycoHome: home, executable: bin });
+    const spec = buildServiceSpec({ variant: 'prod', mycoHome: home, executable: bin, platform: 'darwin' });
     expect(spec.env.PATH).toContain('/opt/homebrew/bin');
+    expect(spec.env.PATH).toContain('/usr/local/bin');
+  });
+
+  test('linux service PATH omits Homebrew bin', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-home-'));
+    const bin = makeFakeBinary();
+    const spec = buildServiceSpec({ variant: 'prod', mycoHome: home, executable: bin, platform: 'linux' });
+    expect(spec.env.PATH).not.toContain('/opt/homebrew');
+    expect(spec.env.PATH).toContain('/usr/bin');
     expect(spec.env.PATH).toContain('/usr/local/bin');
   });
 


### PR DESCRIPTION
## Summary

Phase 2 (Linux harden) of the cross-platform foundation effort. `buildServiceSpec` injected a Homebrew-prefixed `PATH` (`/opt/homebrew/bin:/usr/local/bin:...`) into the daemon service env on **every** platform; on Linux the `/opt/homebrew/bin` prefix is noise. This makes the PATH platform-aware.

## What changed

`packages/myco/src/service/spec-builder.ts`:
- Added an optional `platform?: NodeJS.Platform` to `BuildSpecOptions`, defaulting to `process.platform` (mirrors `getServiceManager`'s convention). The three callers are unchanged — the default keeps them correct on the host they run on.
- The injected `PATH` now branches: **darwin** keeps `/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin` (unchanged); **everything else** gets `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`.

## Decision: the Cellar guard stays cross-platform

The plan loosely suggested gating the `/Cellar/` executable-path guard to darwin. Investigation showed that's wrong: **Linuxbrew also uses `Cellar/` paths** that break on upgrade, so the guard is correctly cross-platform. Gating it would both let Linuxbrew Cellar paths through and break the existing Cellar test on Linux CI. So this PR is scoped to the PATH fix only; the guard is untouched.

## Verification

- **Unit tests (TDD):** replaced the old unconditional-PATH test with two platform-explicit tests — darwin includes `/opt/homebrew/bin`, linux excludes it. Full suite green (JUnit-verified, both node + jsdom phases).
- **Linux smoke (linux-arm64, native-arch Docker):** the binary builds (103 MB) and the runtime — daemon + `bun:sqlite` + `/health` + MCP — runs on Linux.
- **macOS dogfood:** dev-build green on this branch (rebased onto current main); the compiled binary's `buildServiceSpec` yields the correct PATH per platform; daemon starts healthy.

## Test plan

- [x] CI green (lint + build + full bun test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)