### PR TITLE
Prune retained agent runs

### DIFF
--- a/packages/myco/src/config/focus.ts
+++ b/packages/myco/src/config/focus.ts
@@ -213,6 +213,7 @@ const EXACT_FIELD_LABELS: Record<string, string> = {
   [AGENT_PATHS.scheduledTasksEnabled]: 'Scheduled Tasks',
   [AGENT_PATHS.eventTasksEnabled]: 'Event-Driven Tasks',
   [AGENT_PATHS.summaryBatchInterval]: 'Title & Summary Batch Interval',
+  [AGENT_PATHS.runRetentionDays]: 'Agent Run Retention (days)',
   'maintenance.auto_optimize': 'Auto-optimize',
   'maintenance.auto_optimize_interval_hours': 'Auto-optimize Interval',
   'backup.dir': 'Backup Directory',

--- a/packages/myco/src/config/paths.ts
+++ b/packages/myco/src/config/paths.ts
@@ -51,6 +51,7 @@ export const AGENT_PATHS = {
   scheduledTasksEnabled: 'agent.scheduled_tasks_enabled',
   eventTasksEnabled: 'agent.event_tasks_enabled',
   summaryBatchInterval: 'agent.summary_batch_interval',
+  runRetentionDays: 'agent.run_retention_days',
 } as const;
 
 export const NOTIFICATIONS_PATHS = {

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -195,6 +195,12 @@ const AgentBaseSchema = z.object({
    * (Storage tier: Grove. See GroveConfigSchema.)
    */
   scheduled_tasks_active_window_days: z.number().int().min(0).max(365).default(14),
+  /**
+   * Retention window for completed, skipped, and non-resumable failed agent
+   * runs. The PowerManager retention job prunes matching runs from each Grove
+   * database and preserves active/resumable runs.
+   */
+  run_retention_days: z.number().int().min(1).max(365).default(30),
   /** Global default provider — applies to all tasks unless overridden per-task. */
   provider: ProviderOverrideSchema.optional(),
   /** Global default harness — applies to all tasks unless overridden per-task. */
@@ -571,6 +577,7 @@ const GroveAgentSchema = rejectLegacyRuntimeKey(z.object({
    * cold-project gating.
    */
   scheduled_tasks_active_window_days: z.number().int().min(0).max(365).default(14),
+  run_retention_days: z.number().int().min(1).max(365).default(30),
   summary_batch_interval: z.number().int().min(0).default(5),
   scheduled_tasks_enabled: z.boolean().default(true),
   event_tasks_enabled: z.boolean().default(true),
@@ -678,6 +685,7 @@ export const GROVE_TIER_FIELDS: ReadonlyArray<readonly string[]> = [
   ['maintenance'],
   ['embedding', 'run_in_deep_sleep'],
   ['agent', 'scheduled_tasks_active_window_days'],
+  ['agent', 'run_retention_days'],
   ['appearance'],
   ['team'],
   ...GROVE_PROMOTED_FIELDS,
@@ -698,6 +706,7 @@ export const PROJECT_TIER_LEGACY_FIELDS: ReadonlyArray<readonly string[]> = [
   ['team'],
   ['embedding', 'run_in_deep_sleep'],
   ['agent', 'scheduled_tasks_active_window_days'],
+  ['agent', 'run_retention_days'],
   ['appearance'],
   ...GROVE_PROMOTED_FIELDS,
   // 2026-06 settings-scope correction.

--- a/packages/myco/src/config/scope.ts
+++ b/packages/myco/src/config/scope.ts
@@ -57,6 +57,7 @@ export const SCOPE_REGISTRY: Record<string, ScopeEntry> = {
   // over the `agent` block.
   'agent.scheduled_tasks_enabled': { home: 'grove', overridableBy: [] },
   'agent.event_tasks_enabled': { home: 'grove', overridableBy: [] },
+  'agent.run_retention_days': { home: 'grove', overridableBy: [] },
   'skills': { home: 'grove', overridableBy: ['local'], gate: 'skills' },
   // Vault-Evolution capability master gate. Grove-tier home, per-project
   // Personal override so a project can be promoted/demoted on this machine.

--- a/packages/myco/src/constants/log-kinds.ts
+++ b/packages/myco/src/constants/log-kinds.ts
@@ -119,6 +119,7 @@ export const LOG_KINDS = {
 
   // Log retention
   LOG_RETENTION: 'log.retention',
+  AGENT_RUN_RETENTION: 'agent_run.retention',
   NOTIFICATION_RETENTION: 'notification.retention',
 
   // Backup

--- a/packages/myco/src/constants/power-jobs.ts
+++ b/packages/myco/src/constants/power-jobs.ts
@@ -7,6 +7,7 @@ export const POWER_JOB_NAMES = {
   EMBEDDING_RECONCILE: 'embedding-reconcile',
   SESSION_MAINTENANCE: 'session-maintenance',
   LOG_RETENTION: 'log-retention',
+  AGENT_RUN_RETENTION: 'agent-run-retention',
   NOTIFICATION_RETENTION: 'notification-retention',
   AUTO_BACKUP: 'auto-backup',
   DATABASE_OPTIMIZE: 'database-optimize',

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -3,7 +3,7 @@ import type { JobRunner } from './job-runner.js';
 import type { EmbeddingManager } from './embedding/manager.js';
 import type { SessionRegistry } from './lifecycle.js';
 import type { MycoConfig } from '@myco/config/schema.js';
-import { loadMachineConfig, loadMergedConfig } from '@myco/config/loader.js';
+import { loadGroveConfig, loadMachineConfig, loadMergedConfig } from '@myco/config/loader.js';
 import { DatabaseMaintenanceManager } from './database/manager.js';
 import { runSessionMaintenance } from './jobs/session-maintenance.js';
 import {
@@ -14,6 +14,7 @@ import {
 import { isAutoBackupDue, createGroveBackup } from '@myco/backup/service.js';
 import { deleteOldLogs } from '@myco/db/queries/logs.js';
 import { pruneOldNotifications } from '@myco/db/queries/notifications.js';
+import { pruneOldAgentRuns } from '@myco/db/queries/runs.js';
 import { getLastDatabaseLogTimestamps } from '@myco/db/queries/database.js';
 import { notify } from '@myco/notifications/notify.js';
 import { errorMessage } from '@myco/utils/error-message.js';
@@ -380,6 +381,28 @@ export function registerPowerJobs(runner: JobRunner, deps: PowerJobDeps): PowerJ
         logger.info(
           LOG_KINDS.LOG_RETENTION,
           `Deleted ${deleted} log entries older than ${retentionDays} days`,
+          {
+            deleted,
+            retention_days: retentionDays,
+            grove_id: scope.grove.id,
+            grove_slug: scope.grove.slug,
+          },
+        );
+      }
+    }),
+  });
+
+  runner.register({
+    name: POWER_JOB_NAMES.AGENT_RUN_RETENTION,
+    runIn: ['idle', 'sleep'],
+    kind: 'housekeeping',
+    fn: fanOutGroves(POWER_JOB_NAMES.AGENT_RUN_RETENTION, async (scope) => {
+      const retentionDays = loadGroveConfig(scope.grove.id, mycoHome).agent.run_retention_days;
+      const deleted = pruneOldAgentRuns(retentionDays * MS_PER_DAY / 1000, ALL_PROJECTS_SCOPE);
+      if (deleted > 0) {
+        logger.info(
+          LOG_KINDS.AGENT_RUN_RETENTION,
+          `Deleted ${deleted} terminal agent runs older than ${retentionDays} days`,
           {
             deleted,
             retention_days: retentionDays,

--- a/packages/myco/src/db/queries/runs.ts
+++ b/packages/myco/src/db/queries/runs.ts
@@ -30,6 +30,9 @@ export const STATUS_COMPLETED = 'completed';
 /** Run status for a run that encountered an error. */
 export const STATUS_FAILED = 'failed';
 
+/** Run status for a run skipped by gating or preconditions. */
+export const STATUS_SKIPPED = 'skipped';
+
 /** Resume status used when a failed/interrupted run can be resumed. */
 export const RESUME_STATUS_READY = 'ready';
 
@@ -405,6 +408,12 @@ function buildUpdateClauses(update: RunUpdate): { setClauses: string[]; params: 
   return { setClauses, params };
 }
 
+function forEachChunk<T>(items: T[], size: number, fn: (chunk: T[]) => void): void {
+  for (let i = 0; i < items.length; i += size) {
+    fn(items.slice(i, i + size));
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -693,4 +702,63 @@ export function markRunningRunsInterrupted(message: string, scope: ProjectScope)
      WHERE ${conditions.join(' AND ')}`,
   ).run(STATUS_FAILED, RESUME_STATUS_READY, message, ...params);
   return info.changes;
+}
+
+/**
+ * Prune old terminal agent runs. Active, pending, and resumable failed runs are
+ * preserved; derived durable artifacts keep their content with run references
+ * nulled where those references are soft links.
+ */
+export function pruneOldAgentRuns(
+  retentionSeconds: number,
+  scope: ProjectScope,
+  nowSeconds = epochSeconds(),
+): number {
+  const db = getDatabase();
+  const cutoff = nowSeconds - Math.max(0, retentionSeconds);
+  const conditions = [
+    'status IN (?, ?, ?)',
+    'COALESCE(resumable, 0) = 0',
+    'COALESCE(completed_at, started_at) IS NOT NULL',
+    'COALESCE(completed_at, started_at) < ?',
+  ];
+  const params: unknown[] = [STATUS_COMPLETED, STATUS_FAILED, STATUS_SKIPPED, cutoff];
+  appendProjectCondition(conditions, params, scope);
+
+  const ids = db.prepare(
+    `SELECT id FROM agent_runs WHERE ${conditions.join(' AND ')}`,
+  ).all(...params).map((row) => (row as { id: string }).id);
+  if (ids.length === 0) return 0;
+
+  let deleted = 0;
+  db.exec('BEGIN');
+  try {
+    forEachChunk(ids, 500, (chunk) => {
+      const placeholders = chunk.map(() => '?').join(', ');
+      db.prepare(
+        `UPDATE digest_extract_revisions SET run_id = NULL WHERE run_id IN (${placeholders})`,
+      ).run(...chunk);
+      db.prepare(
+        `UPDATE cortex_instructions SET source_run_id = NULL WHERE source_run_id IN (${placeholders})`,
+      ).run(...chunk);
+      db.prepare(
+        `UPDATE canopy_maps SET generated_by_run_id = NULL WHERE generated_by_run_id IN (${placeholders})`,
+      ).run(...chunk);
+      db.prepare(
+        `DELETE FROM agent_reports WHERE run_id IN (${placeholders})`,
+      ).run(...chunk);
+      db.prepare(
+        `DELETE FROM agent_turns WHERE run_id IN (${placeholders})`,
+      ).run(...chunk);
+      db.prepare(
+        `DELETE FROM agent_runs WHERE id IN (${placeholders})`,
+      ).run(...chunk);
+      deleted += chunk.length;
+    });
+    db.exec('COMMIT');
+  } catch (err) {
+    db.exec('ROLLBACK');
+    throw err;
+  }
+  return deleted;
 }

--- a/packages/myco/ui/src/pages/Settings.tsx
+++ b/packages/myco/ui/src/pages/Settings.tsx
@@ -184,7 +184,16 @@ interface CustomGroupCtx {
 }
 
 const CUSTOM_GROUP_RENDERERS: Record<string, (ctx: CustomGroupCtx) => JSX.Element> = {
-  agent: () => <AgentProviderCard />,
+  // Agent is hybrid: AgentProviderCard owns provider/model/runtime controls,
+  // and manifest rows below it own additional agent-domain settings.
+  agent: ({ fields, hasProject, unified }) => (
+    <div className="space-y-4">
+      <AgentProviderCard />
+      {fields.length > 0 && (
+        <FieldGroupBody fields={fields} hasProject={hasProject} unified={unified} />
+      )}
+    </div>
+  ),
   embedding: () => <EmbeddingCard />,
   // Capture is hybrid: PlanCaptureCard owns plan_dirs +
   // ignore_plan_dirs_in_git with rich glob-pattern help, and the manifest

--- a/packages/myco/ui/src/settings/manifest.ts
+++ b/packages/myco/ui/src/settings/manifest.ts
@@ -191,6 +191,18 @@ export const SETTINGS_GROUPS: readonly SettingGroup[] = [
         note: 'Runtime id (e.g. claude-sdk, openai-agents). Picked from the installed runtime registry.',
         customRender: 'card-owns',
       },
+      {
+        key: 'agent.run_retention_days',
+        label: 'Agent run retention',
+        scope: 'grove',
+        kind: 'number',
+        category: 'Agent',
+        icon: 'Bot',
+        min: 1,
+        max: 365,
+        suffix: 'days',
+        note: 'Deletes completed, skipped, and non-resumable failed agent runs older than this window.',
+      },
     ],
   },
   {

--- a/tests/daemon/power-jobs.test.ts
+++ b/tests/daemon/power-jobs.test.ts
@@ -7,6 +7,8 @@ import os from 'node:os';
 import { initDatabase, closeDatabase, getDatabase, withDatabase } from '@myco/db/client';
 import { createSchema } from '@myco/db/schema';
 import { insertLogEntry } from '@myco/db/queries/logs';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { insertRun } from '@myco/db/queries/runs.js';
 import { DaemonLogger } from '@myco/daemon/logger.js';
 import { registerPowerJobs, type PowerJobDeps } from '@myco/daemon/power-jobs.js';
 import { writeStagedSkill, stagingRoot } from '@myco/agent/tools/skill-staging.js';
@@ -636,6 +638,108 @@ describe('notification-retention power job', () => {
     expect(notificationCount('old-dismissed')).toBe(0);
     expect(notificationCount('old-unread')).toBe(1);
     expect(notificationCount('new-read')).toBe(1);
+  });
+});
+
+describe('agent-run-retention power job', () => {
+  let fx: GroveFixture;
+  let pm: FakeJobRunner;
+
+  beforeEach(() => {
+    fx = setupGrove();
+    pm = new FakeJobRunner();
+  });
+
+  afterEach(() => fx.cleanup());
+
+  function ensureAgent(): void {
+    withDatabase(fx.cache.getDatabase(fx.databasePath), () => {
+      registerAgent({
+        id: 'agent-retention-test',
+        name: 'Agent Retention Test',
+        created_at: Math.floor(Date.now() / 1000),
+      });
+    });
+  }
+
+  function seedRun(id: string, status: string, daysAgo: number, resumable = 0): void {
+    const completedAt = Math.floor((Date.now() - daysAgo * 24 * 60 * 60 * 1000) / 1000);
+    withDatabase(fx.cache.getDatabase(fx.databasePath), () => {
+      insertRun({
+        id,
+        agent_id: 'agent-retention-test',
+        task: 'retention-test',
+        status,
+        resumable,
+        started_at: completedAt - 5,
+        completed_at: status === 'running' || status === 'pending' ? null : completedAt,
+      });
+    });
+  }
+
+  function runCount(id: string): number {
+    return withDatabase(fx.cache.getDatabase(fx.databasePath), () =>
+      (getDatabase().prepare(
+        `SELECT COUNT(*) AS n FROM agent_runs WHERE id = ?`,
+      ).get(id) as { n: number }).n,
+    );
+  }
+
+  function saveRunRetention(days: number): void {
+    const config = loadGroveConfig(fx.grove.id, fx.mycoHome);
+    saveGroveConfig(fx.grove.id, {
+      ...config,
+      agent: {
+        ...config.agent,
+        run_retention_days: days,
+      },
+    }, fx.mycoHome);
+  }
+
+  it('registers as idle/sleep housekeeping', () => {
+    registerPowerJobs(pm as never, buildDeps(fx));
+    const job = pm.find('agent-run-retention');
+    expect(job.runIn).toEqual(['idle', 'sleep']);
+    expect(job.kind).toBe('housekeeping');
+  });
+
+  it('reads agent.run_retention_days from Grove config on each run', async () => {
+    ensureAgent();
+    registerPowerJobs(pm as never, buildDeps(fx));
+
+    seedRun('fourteen-days-old', 'completed', 14);
+
+    await pm.find('agent-run-retention').fn();
+
+    expect(runCount('fourteen-days-old')).toBe(1);
+
+    saveRunRetention(7);
+
+    await pm.find('agent-run-retention').fn();
+
+    expect(runCount('fourteen-days-old')).toBe(0);
+  });
+
+  it('deletes old terminal non-resumable runs and preserves active or resumable rows', async () => {
+    ensureAgent();
+    saveRunRetention(7);
+    registerPowerJobs(pm as never, buildDeps(fx));
+
+    seedRun('old-completed', 'completed', 14);
+    seedRun('old-failed', 'failed', 14);
+    seedRun('old-skipped', 'skipped', 14);
+    seedRun('old-resumable', 'failed', 14, 1);
+    seedRun('old-running', 'running', 14);
+    seedRun('new-completed', 'completed', 1);
+
+    await pm.find('agent-run-retention').fn();
+
+    expect(runCount('old-completed')).toBe(0);
+    expect(runCount('old-failed')).toBe(0);
+    expect(runCount('old-skipped')).toBe(0);
+    expect(runCount('old-resumable')).toBe(1);
+    expect(runCount('old-running')).toBe(1);
+    expect(runCount('new-completed')).toBe(1);
   });
 });
 

--- a/tests/db/queries/runs-retention.test.ts
+++ b/tests/db/queries/runs-retention.test.ts
@@ -1,0 +1,118 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
+import { getDatabase } from '@myco/db/client.js';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { insertRun, pruneOldAgentRuns } from '@myco/db/queries/runs.js';
+import { ALL_PROJECTS_SCOPE, projectScope, type GroveProjectId } from '@myco/grove/ids.js';
+
+const PROJECT_A = 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as GroveProjectId;
+const PROJECT_B = 'proj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as GroveProjectId;
+const AGENT_ID = 'agent-run-retention-test';
+const NOW = 1_800_000_000;
+
+function count(table: string, where: string, ...params: unknown[]): number {
+  return (getDatabase().prepare(
+    `SELECT COUNT(*) AS n FROM ${table} WHERE ${where}`,
+  ).get(...params) as { n: number }).n;
+}
+
+function seedRun(
+  id: string,
+  projectId: GroveProjectId,
+  status: string,
+  ageSeconds: number,
+  resumable = 0,
+): void {
+  const completedAt = NOW - ageSeconds;
+  insertRun({
+    id,
+    project_id: projectId,
+    agent_id: AGENT_ID,
+    task: 'retention-test',
+    status,
+    resumable,
+    started_at: completedAt - 5,
+    completed_at: status === 'running' || status === 'pending' ? null : completedAt,
+  });
+}
+
+describe('agent run retention queries', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    registerAgent({
+      id: AGENT_ID,
+      name: 'Agent Run Retention Test',
+      created_at: NOW,
+    });
+  });
+
+  it('prunes old terminal non-resumable runs within scope and preserves active or resumable rows', () => {
+    seedRun('old-completed-a', PROJECT_A, 'completed', 90_000);
+    seedRun('old-failed-a', PROJECT_A, 'failed', 90_000);
+    seedRun('old-skipped-a', PROJECT_A, 'skipped', 90_000);
+    seedRun('new-completed-a', PROJECT_A, 'completed', 60);
+    seedRun('old-resumable-a', PROJECT_A, 'failed', 90_000, 1);
+    seedRun('old-running-a', PROJECT_A, 'running', 90_000);
+    seedRun('old-pending-a', PROJECT_A, 'pending', 90_000);
+    seedRun('old-completed-b', PROJECT_B, 'completed', 90_000);
+
+    expect(pruneOldAgentRuns(86_400, projectScope(PROJECT_A), NOW)).toBe(3);
+
+    expect(count('agent_runs', 'id = ?', 'old-completed-a')).toBe(0);
+    expect(count('agent_runs', 'id = ?', 'old-failed-a')).toBe(0);
+    expect(count('agent_runs', 'id = ?', 'old-skipped-a')).toBe(0);
+    expect(count('agent_runs', 'id = ?', 'new-completed-a')).toBe(1);
+    expect(count('agent_runs', 'id = ?', 'old-resumable-a')).toBe(1);
+    expect(count('agent_runs', 'id = ?', 'old-running-a')).toBe(1);
+    expect(count('agent_runs', 'id = ?', 'old-pending-a')).toBe(1);
+    expect(count('agent_runs', 'id = ?', 'old-completed-b')).toBe(1);
+
+    expect(pruneOldAgentRuns(86_400, ALL_PROJECTS_SCOPE, NOW)).toBe(1);
+    expect(count('agent_runs', 'id = ?', 'old-completed-b')).toBe(0);
+  });
+
+  it('removes run audit children and nulls soft durable run references', () => {
+    seedRun('old-run', PROJECT_A, 'completed', 90_000);
+
+    getDatabase().prepare(
+      `INSERT INTO agent_reports (project_id, run_id, agent_id, action, summary, details, created_at)
+       VALUES (?, ?, ?, 'test', 'summary', NULL, ?)`,
+    ).run(PROJECT_A, 'old-run', AGENT_ID, NOW);
+    getDatabase().prepare(
+      `INSERT INTO agent_turns (project_id, run_id, agent_id, turn_number, tool_name, started_at, completed_at)
+       VALUES (?, ?, ?, 1, 'read', ?, ?)`,
+    ).run(PROJECT_A, 'old-run', AGENT_ID, NOW - 10, NOW);
+    getDatabase().prepare(
+      `INSERT INTO agent_run_write_intents
+       (project_id, run_id, phase_id, tool_name, tool_input, synthetic_output, stub_id, recorded_at)
+       VALUES (?, ?, NULL, 'write', '{}', '{}', NULL, ?)`,
+    ).run(PROJECT_A, 'old-run', NOW);
+    getDatabase().prepare(
+      `INSERT INTO digest_extract_revisions
+       (project_id, agent_id, tier, content, metadata, run_id, parent_revision_id, created_at)
+       VALUES (?, ?, 1, 'content', NULL, ?, NULL, ?)`,
+    ).run(PROJECT_A, AGENT_ID, 'old-run', NOW);
+    getDatabase().prepare(
+      `INSERT INTO cortex_instructions
+       (id, project_id, agent_id, content, input_hash, source_run_id, generated_at)
+       VALUES ('ctx', ?, ?, 'content', 'hash', ?, ?)`,
+    ).run(PROJECT_A, AGENT_ID, 'old-run', NOW);
+    getDatabase().prepare(
+      `INSERT INTO canopy_maps
+       (project_id, machine_id, content, inputs_hash, generated_at, generated_by_run_id, token_estimate)
+       VALUES (?, 'local', 'map', 'hash', ?, ?, 10)`,
+    ).run(PROJECT_A, NOW, 'old-run');
+
+    expect(pruneOldAgentRuns(86_400, projectScope(PROJECT_A), NOW)).toBe(1);
+
+    expect(count('agent_runs', 'id = ?', 'old-run')).toBe(0);
+    expect(count('agent_reports', 'run_id = ?', 'old-run')).toBe(0);
+    expect(count('agent_turns', 'run_id = ?', 'old-run')).toBe(0);
+    expect(count('agent_run_write_intents', 'run_id = ?', 'old-run')).toBe(0);
+    expect(count('digest_extract_revisions', 'run_id IS NULL')).toBe(1);
+    expect(count('cortex_instructions', 'source_run_id IS NULL')).toBe(1);
+    expect(count('canopy_maps', 'generated_by_run_id IS NULL')).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add Grove-scoped `agent.run_retention_days` setting with Settings UI wiring
- add an `agent-run-retention` PowerManager housekeeping job that fans out per Grove
- prune old completed, skipped, and non-resumable failed agent runs while preserving active/resumable runs and durable soft references

## Verification
- `npm test -- tests/db/queries/runs-retention.test.ts tests/daemon/power-jobs.test.ts`
- `git diff --check`
- `make build`

## Review notes
- Independent adversarial review found no blocking issues. Follow-up applied: write intents are now removed only by the `agent_runs` cascade, preserving the append-only/cascade ownership invariant.
- During that fix, the prune helper was adjusted to return agent-run count rather than SQLite cascade-inclusive affected-row count.