### PR TITLE
fix(team-sync): enforce project-scoped tenancy on the outbox (stop non-member grove flood)

### DIFF
--- a/.agents/skills/dogfood-worktree/SKILL.md
+++ b/.agents/skills/dogfood-worktree/SKILL.md
@@ -85,12 +85,30 @@ checkout but didn't travel to the worktree. If `dev-build` fails on a missing
 vendor asset, copy/symlink it from the main checkout (or rebuild it in the
 worktree) and re-run `make dev-link-worktree`.
 
-### Daemon version vs. the pin
-The pin routes **hooks, MCP, and CLI** to the worktree binary, but the running
-daemon is whichever build started the global dev service. To exercise the
-worktree's **daemon-side** changes, restart the daemon so it respawns from the
-worktree binary; otherwise capture is still processed by the previously-running
-daemon build.
+### Daemon-side changes: dogfood from the MAIN checkout, never the worktree
+The worktree pin only routes **hooks, MCP, and CLI** to the worktree binary. The
+dev **daemon** always runs the **main dev binary** — its launchd service points at
+the main checkout's `packages/myco-<target>/bin/myco`, so a worktree pin does NOT
+change which code the daemon runs.
+
+To dogfood **daemon-side** changes (schema migrations, reconcile/daemon logic):
+check out the feature branch on the **main checkout** and rebuild + restart there —
+`make dev-build && myco-dev restart`. After a worktree teardown + rebase the
+`~/.local/bin/myco-dev` symlink already points at the main binary, so **no
+`make dev-link` is needed** — only re-link if the symlink was removed or you are
+switching which branch the daemon tracks. After any restart, verify
+`~/.myco/service-dev/daemon.json` is not still pointing at a stale worktree binary.
+
+**Never** `make dev-link` from a worktree, and **never** run the daemon or migrate
+the shared vault from a worktree — a worktree binary running a migration mutates the
+*shared* Grove vault and breaks the main/other builds (the rollup hazard above). The
+only isolated paths are `dogfood-grove-claim` (snapshot a Grove) or exercising the
+merged code against a **temp git repo with its own `MYCO_HOME`** — neither touches
+the shared vault.
+
+> Myco is the most active source of truth: search the vault ("worktree dogfood")
+> before trusting this skill if they disagree. See also the
+> `daemon-process-lifecycle-management` skill for the canonical build/restart commands.
 
 ## Related
 - `dogfood-grove-claim` — snapshot/rollback a Grove for risky (e.g. schema) testing

--- a/packages/myco/src/daemon/api/groves.ts
+++ b/packages/myco/src/daemon/api/groves.ts
@@ -25,6 +25,7 @@ import {
   unarchiveProject,
 } from '@myco/grove/project-lifecycle.js';
 import { projectUrlSlug } from '@myco/grove/ids.js';
+import { ProjectGroveMissingError, resolveProjectTenancy } from '@myco/grove/project-tenancy.js';
 import type { RouteHandler } from '@myco/daemon/router.js';
 import { errorBody } from './error-envelope.js';
 
@@ -61,6 +62,62 @@ export interface GrovesResponse {
   groves: GroveSummary[];
 }
 
+/** Grove tenancy projection exposed via the opt-in `include=grove`. */
+export interface ProjectTenancyGrove {
+  id: string;
+  name: string;
+  slug: string;
+  served_by: DaemonVariant;
+}
+
+/** Tenancy keys added to a project summary when requested via `include`. */
+export interface ProjectTenancyMetadata {
+  grove?: ProjectTenancyGrove;
+  team?: { team_id: string } | null;
+}
+
+type TenancyInclude = 'grove' | 'team';
+
+function parseTenancyInclude(raw: string | undefined): Set<TenancyInclude> {
+  const includes = new Set<TenancyInclude>();
+  if (!raw) return includes;
+  for (const part of raw.split(',')) {
+    const token = part.trim();
+    if (token === 'grove' || token === 'team') includes.add(token);
+  }
+  return includes;
+}
+
+/**
+ * Source the requested tenancy keys for a project from the single tenancy
+ * authority (`resolveProjectTenancy`) rather than re-deriving from the registry.
+ * A grove-less project (the authority throws `ProjectGroveMissingError`) yields
+ * no tenancy keys for that row instead of failing the whole list response.
+ */
+function tenancyMetadata(
+  projectId: string,
+  includes: Set<TenancyInclude>,
+): ProjectTenancyMetadata {
+  if (includes.size === 0) return {};
+  try {
+    const tenancy = resolveProjectTenancy(projectId);
+    const metadata: ProjectTenancyMetadata = {};
+    if (includes.has('grove')) {
+      metadata.grove = {
+        id: tenancy.grove.id,
+        name: tenancy.grove.name,
+        slug: tenancy.grove.slug,
+        served_by: tenancy.grove.served_by,
+      };
+    }
+    if (includes.has('team')) metadata.team = tenancy.team;
+    return metadata;
+  } catch (err) {
+    if (err instanceof ProjectGroveMissingError) return {};
+    throw err;
+  }
+}
+
 export interface ServedGroveScope {
   /**
    * Grove ids this daemon should advertise. `null` means "every Grove
@@ -87,7 +144,13 @@ export function createListGroveProjectsHandler(scope: ServedGroveScope, daemonSt
     const summaries = listGroveSummaries(scope, daemonVariant(daemonStateDir));
     const grove = summaries.groves.find((row) => row.id === groveId || row.slug === groveId);
     if (!grove) return { status: 404, body: { error: 'grove_not_found' } };
-    return { body: { projects: grove.projects } };
+    const includes = parseTenancyInclude(req.query.include);
+    if (includes.size === 0) return { body: { projects: grove.projects } };
+    const projects = grove.projects.map((project) => ({
+      ...project,
+      ...tenancyMetadata(project.project_id, includes),
+    }));
+    return { body: { projects } };
   };
 }
 

--- a/packages/myco/src/daemon/api/team-selection.ts
+++ b/packages/myco/src/daemon/api/team-selection.ts
@@ -15,6 +15,7 @@
 
 import { teamRegistry, withProjectAdded, withProjectRemoved } from '@myco/team/registry.js';
 import { listGroves } from '@myco/grove/registry.js';
+import { assertAssignableProject, ProjectGroveMissingError } from '@myco/grove/project-tenancy.js';
 import { listGroveSummaries } from './groves.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 
@@ -92,6 +93,13 @@ export function createTeamSelectionHandlers() {
    * Enforces one-team-per-project on `add`: if the project already belongs
    * to a different team, the request is rejected with 409 rather than
    * silently re-homing it.
+   *
+   * On `add` the project is validated through the tenancy authority
+   * (`assertAssignableProject`): a team is a global construct, so it may only
+   * reference a project that resolves to a grove, and the caller's claimed
+   * `grove_id` must match that resolved grove. `remove` skips the check — a
+   * project being removed may already be grove-less (its grove was
+   * deregistered), and we must still let it leave the team.
    */
   function handleSetProjectMembership(req: RouteRequest): RouteResponse {
     const body = (req.body ?? {}) as SetProjectMembershipBody;
@@ -110,6 +118,19 @@ export function createTeamSelectionHandlers() {
     }
 
     if (action === 'add') {
+      let tenancy;
+      try {
+        tenancy = assertAssignableProject(projectId);
+      } catch (err) {
+        if (err instanceof ProjectGroveMissingError) {
+          return { status: 400, body: { error: 'project_not_assignable' } };
+        }
+        throw err;
+      }
+      if (tenancy.grove.id !== groveId) {
+        return { status: 400, body: { error: 'grove_mismatch', grove_id: tenancy.grove.id } };
+      }
+
       const existing = teamRegistry.membershipByProject().get(projectId);
       if (existing && existing !== teamId) {
         return { status: 409, body: { error: 'project_in_other_team', team_id: existing } };

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -1900,7 +1900,22 @@ export async function main(): Promise<void> {
   const teamSelectionHandlers = createTeamSelectionHandlers();
   server.registerRoute('GET', '/api/team/registry', async (req) => teamSelectionHandlers.handleListTeams(req));
   server.registerRoute('GET', '/api/team/projects', async (req) => teamSelectionHandlers.handleListProjects(req));
-  server.registerRoute('POST', '/api/team/project-membership', async (req) => teamSelectionHandlers.handleSetProjectMembership(req));
+  server.registerRoute('POST', '/api/team/project-membership', async (req) => {
+    const result = teamSelectionHandlers.handleSetProjectMembership(req);
+    if (!result.status || result.status < 400) {
+      // Reconcile the Grove that actually owns the (re)assigned project, not the
+      // ambient request Grove — membership is machine-wide on the Team page, so a
+      // project can be assigned/removed from any Grove. reconcileGrove targets
+      // that Grove (a no-op when served by another daemon variant) and runs the
+      // full backfill + flush so an assigned project starts syncing immediately
+      // and a removed project's rows are purged immediately.
+      const groveId = (req.body as { grove_id?: string } | undefined)?.grove_id ?? null;
+      if (groveId) {
+        await teamSync.reconcileGrove(runtimeCache, groveId);
+      }
+    }
+    return result;
+  });
   server.registerRoute('POST', '/api/team/connect', async (req) => {
     const result = await teamHandlers.handleConnect(req);
     if (!result.status || result.status < 400) {

--- a/packages/myco/src/daemon/team-sync-init.ts
+++ b/packages/myco/src/daemon/team-sync-init.ts
@@ -101,6 +101,13 @@ export interface TeamSyncResult {
    */
   flushAllGroves: (cache: GroveRuntimeCache) => Promise<TeamFlushAggregate>;
   /**
+   * Immediately reconcile a single Grove's team-sync membership (assign/remove
+   * reaction). Targets the Grove that owns the (re)assigned project — which may
+   * differ from the request-context Grove — and is a no-op for a Grove served by
+   * another daemon variant.
+   */
+  reconcileGrove: (cache: GroveRuntimeCache, groveId: string) => Promise<void>;
+  /**
    * Reconcile team_sync_state.enabled for every registered Grove at boot.
    * At boot only the boot Grove's flag is set (via reconcileClient()). Non-boot
    * Groves' flags stay at their persisted default until their first flush tick —
@@ -795,6 +802,35 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
   }
 
   /**
+   * Immediately reconcile a single named Grove — the affected-Grove reaction to
+   * a project being assigned to / removed from a team. A project can be (re)homed
+   * from ANY Grove machine-wide via the Team page, so the Grove that owns the
+   * (re)assigned project is `body.grove_id`, not the request-context Grove; this
+   * targets THAT Grove. Reuses the same forEachGrove fan-out as flushAllGroves
+   * (filtered to one Grove via `shouldVisitGrove`) so DB pinning + the served-by
+   * boundary are handled identically: a Grove served by another daemon variant
+   * is not in this daemon's `listGroves(servedBy)` set, so this is a no-op for it
+   * and the owning daemon's flush-tick backstop covers it (no cross-service write).
+   * Runs the full per-Grove `reconcileClient` (membership + non-member purge +
+   * self-row + backfill + flush) so an assigned project starts syncing — and a
+   * removed project's rows are purged — without waiting for the next flush tick.
+   */
+  async function reconcileGrove(cache: GroveRuntimeCache, groveId: string): Promise<void> {
+    await forEachGrove(
+      cache,
+      logger,
+      async ({ grove, databasePath, db, groveHome }) => {
+        await withDatabase(db, () => reconcileClient(groveSyncContext(grove.id, databasePath, groveHome)));
+      },
+      {
+        daemonStateDir,
+        jobName: 'team-sync-membership-reconcile',
+        shouldVisitGrove: (grove) => grove.id === groveId,
+      },
+    );
+  }
+
+  /**
    * Reconcile team_sync_state.enabled for every registered Grove without pushing.
    * Mirrors flushAllGroves's forEachGrove fan-out exactly (same groveSyncContext,
    * withDatabase, daemonStateDir, jobName pattern) but only writes the flag so
@@ -848,6 +884,7 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
     flushPending,
     rebuildFromLocal,
     flushAllGroves,
+    reconcileGrove,
     reconcileAllGroveFlags,
     registerFlushJob: (runner, cache) => {
       // Registered unconditionally; registry participation is checked at run

--- a/packages/myco/src/daemon/team-sync-init.ts
+++ b/packages/myco/src/daemon/team-sync-init.ts
@@ -44,11 +44,12 @@ import {
   backfillAllForRebuild,
   discardRows,
   countPending,
-  countPendingByTable,
   purgePendingOutbox,
+  purgeNonMemberOutbox,
 } from '@myco/db/queries/team-outbox.js';
 import { upsertSelfMember } from '@myco/db/queries/team-members.js';
-import { setTeamSyncEnabled } from '@myco/db/queries/team-sync-state.js';
+import { setTeamSyncEnabled, setProjectSyncMembership } from '@myco/db/queries/team-sync-state.js';
+import { memberProjectIdsForGrove, machineHasAnyTeam } from '@myco/grove/project-tenancy.js';
 import {
   SYNC_PROTOCOL_VERSION,
   TEAM_API_KEY_SECRET,
@@ -163,16 +164,9 @@ export function planConfigSeed(
 export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
   const { machineId, logger, daemonStateDir, requestContext: defaultRequestContext } = deps;
 
-  /**
-   * The team registry — not the legacy grove-config `enabled` flag — is the
-   * push-side participation gate: a Grove syncs iff ≥1 of its projects is a
-   * member of some team. Used by the write-path gate (setTeamSyncEnabled), the
-   * stale-outbox purge, and the deep-sleep predicate so they all agree with the
-   * registry-driven drain (flushPending). The grove-config flag is now only the
-   * read/rebuild client's concern.
-   */
+  /** Boolean convenience over `memberProjectIdsForGrove`, used by the deep-sleep `pending` probe. */
   function groveParticipates(groveId: string | null): boolean {
-    return participatingTeamIds(groveId).length > 0;
+    return memberProjectIdsForGrove(groveId).length > 0;
   }
 
   function participatingTeamIds(groveId: string | null): string[] {
@@ -398,13 +392,16 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
 
     const groveId = requestContext?.groveId ?? null;
     const teams = teamRegistry.list();
-    const participates = groveParticipates(groveId);
+    const memberProjectIds = memberProjectIdsForGrove(groveId);
     // The registry is now the write-path gate: keep delete triggers + syncRow
     // in lockstep with whether this Grove feeds any team via project membership,
-    // every tick. (Machine-scoped self rows reach the outbox through
-    // backfillUnsynced, which bypasses this flag, so a joined-no-project Grove
-    // still queues its self row.)
-    setTeamSyncEnabled(participates);
+    // every tick. The per-project member set + non-member purge self-correct on
+    // every served Grove regardless of which entry point last reconciled them.
+    // (Machine-scoped self rows reach the outbox through backfillUnsynced, which
+    // bypasses this flag, so a joined-no-project Grove still queues its self row.)
+    setTeamSyncEnabled(memberProjectIds.length > 0);
+    setProjectSyncMembership(memberProjectIds);
+    purgeNonMemberOutbox(memberProjectIds);
     // Short-circuit only when this machine has joined no team at all — there is
     // nowhere to route any row. With ≥1 registered team we must still drain
     // machine-scoped rows even if no project participates.
@@ -668,49 +665,57 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
   }
 
   async function reconcileClient(requestContext = defaultRequestContext): Promise<void> {
-    const participates = groveParticipates(requestContext?.groveId ?? null);
+    const groveId = requestContext?.groveId ?? null;
+    const memberProjectIds = memberProjectIdsForGrove(groveId);
+    const participates = memberProjectIds.length > 0;
+
+    // (1) Reconcile the per-Grove gate state read by syncRow / backfillRows /
+    //     delete triggers: the enablement flag AND the per-project member set.
     setTeamSyncEnabled(participates);
+    setProjectSyncMembership(memberProjectIds);
 
-    // The participation gate (delete triggers / live syncRow) tracks project
-    // membership, but the self-member re-push and drain are gated on the
-    // machine having joined ANY team: a joined-no-project Grove must still
-    // enqueue and drain its machine-scoped self row so the teammate appears in
-    // the roster before assigning a project. Only when this machine has joined
-    // no team at all do we treat the Grove as fully non-participating.
-    const joinedAnyTeam = teamRegistry.list().length > 0;
+    // (2) Drop outbox rows for non-member projects (sent or pending). Always
+    //     runs — self-heals historical bloat and prevents the re-enqueue loop.
+    try {
+      const purged = purgeNonMemberOutbox(memberProjectIds);
+      if (purged > 0) {
+        logger.info(LOG_KINDS.TEAM_SYNC_START, 'Purged outbox rows for non-member projects', {
+          grove_id: groveId,
+          purged,
+        });
+      }
+    } catch (err) {
+      logger.warn(LOG_KINDS.TEAM_SYNC_ERROR, 'Non-member outbox purge failed', {
+        grove_id: groveId,
+        error: (err as Error).message,
+      });
+    }
 
-    if (!joinedAnyTeam) {
-      // If this machine is in no registry Team but the outbox still
-      // carries pending rows (from a previous sync-enabled period that was
-      // later turned off), drop them. Without this sweep, `countPending()`
-      // keeps reporting stale rows that will never drain — which the Team
-      // page UI then surfaces as "N pending failures" against a Grove that
-      // is not in a Team. Source records are untouched; selecting a Team
-      // re-enqueues from current state via `handleBackfill`.
+    // (3) Machine in NO team: also clear leftover machine-scoped (self-row)
+    //     pending rows that the project-scoped purge above leaves behind, then
+    //     stop — there is nowhere to route. Without this the Team page would
+    //     keep surfacing "N pending failures" against a Grove in no Team.
+    if (!machineHasAnyTeam()) {
       try {
-        // One scan, not two: derive the total from the per-table breakdown
-        // so we don't COUNT(*) the same predicate twice.
-        const byTable = countPendingByTable();
-        const total = Object.values(byTable).reduce((sum, n) => sum + n, 0);
-        if (total > 0) {
-          const purged = purgePendingOutbox();
-          logger.info(LOG_KINDS.TEAM_SYNC_START, 'Purged stale outbox rows for non-participating Grove', {
-            grove_id: requestContext?.groveId ?? null,
-            purged,
-            by_table: byTable,
-          });
-        }
+        purgePendingOutbox();
       } catch (err) {
-        logger.warn(LOG_KINDS.TEAM_SYNC_ERROR, 'Stale outbox sweep failed', {
-          grove_id: requestContext?.groveId ?? null,
+        logger.warn(LOG_KINDS.TEAM_SYNC_ERROR, 'Self-row sweep failed', {
+          grove_id: groveId,
           error: (err as Error).message,
         });
       }
       return;
     }
 
+    // (4) Roster: publish this machine's self-row even for a joined-no-project
+    //     Grove, so a just-joined teammate appears before assigning a project.
     reconcileSelfMember();
 
+    // (5) Backfill runs whenever the machine joined a team: the machine-scoped
+    //     self-row reaches the outbox ONLY via backfillUnsynced, so gating it on
+    //     `participates` would drop a joined-no-project Grove off the roster.
+    //     backfillRows filters project-scoped rows to members internally, so a
+    //     no-member Grove enqueues only the self-row.
     try {
       const backfilled = backfillUnsynced(machineId);
       if (backfilled > 0) {
@@ -808,7 +813,10 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
       logger,
       async ({ grove, databasePath, db, groveHome }) => {
         await withDatabase(db, async () => {
-          setTeamSyncEnabled(groveParticipates(grove.id));
+          const memberProjectIds = memberProjectIdsForGrove(grove.id);
+          setTeamSyncEnabled(memberProjectIds.length > 0);
+          setProjectSyncMembership(memberProjectIds);
+          purgeNonMemberOutbox(memberProjectIds);
         });
       },
       { daemonStateDir, jobName: 'team-sync-flag-reconcile', parallel: true },

--- a/packages/myco/src/db/migrations.ts
+++ b/packages/myco/src/db/migrations.ts
@@ -121,6 +121,7 @@ export const MIGRATIONS: Migration[] = [
   { version: 59, migrate: (db) => migrateV58ToV59(db) },
   { version: 60, migrate: (db) => migrateV59ToV60(db) },
   { version: 61, migrate: (db) => migrateV60ToV61(db) },
+  { version: 62, migrate: (db) => migrateV61ToV62(db) },
 ];
 
 // ---------------------------------------------------------------------------
@@ -3826,6 +3827,75 @@ function migrateV60ToV61(db: Database): void {
     db.prepare(
       `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`,
     ).run(61, epochSeconds());
+    db.prepare('COMMIT').run();
+  } catch (err) {
+    db.prepare('ROLLBACK').run();
+    throw err;
+  }
+}
+
+/**
+ * Frozen at the v62 revision: the per-grove team-sync membership projection
+ * and the membership-gated delete triggers. Per the frozen-DDL rules above,
+ * these never reference the live TEAM_SYNC_MEMBERSHIP_TABLE /
+ * TEAM_DELETE_TRIGGERS constants — later edits to the live DDL would silently
+ * change this migration's semantics. The trigger snapshot must stay
+ * byte-equivalent (after whitespace normalization) to the live
+ * TEAM_DELETE_TRIGGERS so fresh and migrated vaults converge
+ * (tests/db/migration-matrix.test.ts).
+ *
+ * Later additions to the live TEAM_DELETE_TRIGGER_TABLES must NOT appear here:
+ * a CREATE TRIGGER on a table that does not exist yet at this point in the
+ * chain throws and bricks the upgrade (the v41 failure class).
+ */
+const V62_TEAM_SYNC_MEMBERSHIP_TABLE =
+  'CREATE TABLE IF NOT EXISTS team_sync_membership (project_id TEXT PRIMARY KEY)';
+
+const V62_TEAM_DELETE_TRIGGER_TABLES = [
+  'sessions', 'prompt_batches', 'spores', 'entities', 'graph_edges',
+  'resolution_events', 'plans', 'artifacts', 'digest_extracts',
+  'skill_candidates', 'skill_records', 'skill_usage', 'knowledge_release_state',
+] as const;
+
+const V62_TEAM_DELETE_TRIGGERS: readonly string[] = V62_TEAM_DELETE_TRIGGER_TABLES.map(
+  (table) => `
+  CREATE TRIGGER IF NOT EXISTS ${table}_team_ad
+  AFTER DELETE ON ${table}
+  WHEN (SELECT enabled FROM team_sync_state) = 1
+    AND OLD.project_id IN (SELECT project_id FROM team_sync_membership)
+  BEGIN
+    INSERT INTO team_outbox (table_name, row_id, operation, payload, machine_id, project_id, created_at)
+    VALUES ('${table}', CAST(OLD.id AS TEXT), 'delete',
+            json_object('id', OLD.id, 'machine_id', OLD.machine_id),
+            OLD.machine_id, OLD.project_id, CAST(strftime('%s','now') AS INTEGER));
+  END`,
+);
+
+/**
+ * v61 -> v62: per-project team-sync membership.
+ *
+ * Adds the `team_sync_membership` projection (one row per project a grove syncs
+ * to a team) and re-gates the per-table delete triggers on it. The triggers
+ * previously fired on the grove-level `team_sync_state.enabled` flag alone, so
+ * a mixed grove journaled deletes for non-member projects too. ALTER does not
+ * refresh trigger bodies, so DROP + recreate is required. The membership table
+ * is created before the triggers so the new WHEN subquery resolves.
+ */
+function migrateV61ToV62(db: Database): void {
+  db.prepare('BEGIN').run();
+  try {
+    db.prepare(V62_TEAM_SYNC_MEMBERSHIP_TABLE).run();
+
+    for (const table of V62_TEAM_DELETE_TRIGGER_TABLES) {
+      db.exec(`DROP TRIGGER IF EXISTS ${table}_team_ad`);
+    }
+    for (const trg of V62_TEAM_DELETE_TRIGGERS) {
+      db.exec(trg);
+    }
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`,
+    ).run(62, epochSeconds());
     db.prepare('COMMIT').run();
   } catch (err) {
     db.prepare('ROLLBACK').run();

--- a/packages/myco/src/db/queries/team-outbox.ts
+++ b/packages/myco/src/db/queries/team-outbox.ts
@@ -12,7 +12,7 @@
 
 import { getDatabase } from '@myco/db/client.js';
 import { TEAM_SYNC_OBSERVED_TABLES, type TeamSyncObservedTable } from '@myco/db/schema-ddl.js';
-import { getTeamSyncEnabled } from '@myco/db/queries/team-sync-state.js';
+import { isProjectSyncable } from '@myco/db/queries/team-sync-state.js';
 import { getTeamMachineId } from '@myco/team/context.js';
 import { epochSeconds } from '@myco/constants.js';
 
@@ -214,11 +214,13 @@ export function syncRow(
   tableName: string,
   row: object & { id: string | number; created_at?: number },
 ): void {
-  if (!getTeamSyncEnabled()) return;
-  // Project-scoped rows carry `project_id`; machine-scoped rows (e.g.
-  // team_members) don't, so this resolves to null — which is correct for
-  // later per-team routing.
   const projectId = (row as { project_id?: string }).project_id ?? null;
+  // Project-scoped tenancy gate: a row syncs iff its project is an explicit
+  // team member. (Machine-scoped self-rows never flow through syncRow — they are
+  // enqueued by the daemon's reconcileSelfMember / backfill paths.) Membership
+  // is only populated when the grove participates, so this subsumes the prior
+  // grove-level getTeamSyncEnabled check.
+  if (!isProjectSyncable(projectId)) return;
   enqueueOutbox({
     table_name: tableName,
     row_id: String(row.id),
@@ -375,6 +377,23 @@ export function dropPendingForProjects(projectIds: string[]): number {
     `DELETE FROM team_outbox WHERE sent_at IS NULL AND project_id IN (${placeholders})`,
   ).run(...projectIds);
   return result.changes;
+}
+
+/**
+ * Delete outbox rows (sent OR pending) for project-scoped rows whose project is
+ * not in the given member set. Self-rows (project_id IS NULL) are never touched.
+ * This both stops the re-enqueue loop and self-heals historical bloat for groves
+ * that were incorrectly enqueued before the membership gate existed.
+ */
+export function purgeNonMemberOutbox(memberProjectIds: string[]): number {
+  const db = getDatabase();
+  if (memberProjectIds.length === 0) {
+    return db.prepare('DELETE FROM team_outbox WHERE project_id IS NOT NULL').run().changes;
+  }
+  const placeholders = memberProjectIds.map(() => '?').join(', ');
+  return db.prepare(
+    `DELETE FROM team_outbox WHERE project_id IS NOT NULL AND project_id NOT IN (${placeholders})`,
+  ).run(...memberProjectIds).changes;
 }
 
 /**
@@ -622,11 +641,18 @@ function backfillRows(
     // window expired. Re-enqueuing beside a sent entry is safe for the
     // same reason 'all' mode tolerates duplicates: the worker upsert is
     // keyed by composite PK and idempotent.
+    // Project-scoped tenancy gate: exclude rows whose project is not a team
+    // member. The machine-scoped team_members self-row table has no project_id
+    // and is exempt — it must always backfill so the roster reaches the outbox.
+    const isMachineScoped = table === 'team_members';
+    const memberFilter = isMachineScoped
+      ? ''
+      : ' AND project_id IN (SELECT project_id FROM team_sync_membership)';
     const rows = mode === 'all'
-      ? db.prepare(`SELECT * FROM ${table}`).all() as Record<string, unknown>[]
+      ? db.prepare(`SELECT * FROM ${table} WHERE 1=1${memberFilter}`).all() as Record<string, unknown>[]
       : db.prepare(
           `SELECT * FROM ${table}
-           WHERE synced_at IS NULL
+           WHERE synced_at IS NULL${memberFilter}
            AND NOT EXISTS (
              SELECT 1 FROM team_outbox
              WHERE team_outbox.table_name = ? AND team_outbox.row_id = CAST(${table}.id AS TEXT)

--- a/packages/myco/src/db/queries/team-sync-state.ts
+++ b/packages/myco/src/db/queries/team-sync-state.ts
@@ -22,3 +22,42 @@ export function setTeamSyncEnabled(enabled: boolean, db: Database = getDatabase(
      ON CONFLICT (rowid_guard) DO UPDATE SET enabled = excluded.enabled`,
   ).run(enabled ? 1 : 0);
 }
+
+/**
+ * Replace this Grove's syncable-project set. Reconciled from the team registry
+ * (projects in this Grove that belong to any team). The live `syncRow` gate and
+ * `backfillRows` read this so a non-member project's rows are never enqueued.
+ */
+export function setProjectSyncMembership(
+  projectIds: string[],
+  db: Database = getDatabase(),
+): void {
+  const tx = db.transaction((ids: string[]) => {
+    db.prepare('DELETE FROM team_sync_membership').run();
+    const insert = db.prepare(
+      'INSERT OR IGNORE INTO team_sync_membership (project_id) VALUES (?)',
+    );
+    for (const id of ids) insert.run(id);
+  });
+  tx(projectIds);
+}
+
+export function getSyncableProjectIds(db: Database = getDatabase()): string[] {
+  return (
+    db
+      .prepare('SELECT project_id FROM team_sync_membership ORDER BY project_id')
+      .all() as Array<{ project_id: string }>
+  ).map((r) => r.project_id);
+}
+
+export function isProjectSyncable(
+  projectId: string | null,
+  db: Database = getDatabase(),
+): boolean {
+  if (projectId == null) return false;
+  return (
+    db
+      .prepare('SELECT 1 FROM team_sync_membership WHERE project_id = ? LIMIT 1')
+      .get(projectId) != null
+  );
+}

--- a/packages/myco/src/db/schema-ddl.ts
+++ b/packages/myco/src/db/schema-ddl.ts
@@ -484,6 +484,17 @@ export const TEAM_SYNC_STATE_TABLE = `
     enabled     INTEGER NOT NULL DEFAULT 0
   )`;
 
+/**
+ * Per-grove reconciled projection of which projects belong to a team. One row
+ * per syncable project. The live `syncRow` / `backfillRows` gates and the
+ * membership-aware delete triggers read this so a non-member project's rows are
+ * never enqueued. Local-only — never synced.
+ */
+export const TEAM_SYNC_MEMBERSHIP_TABLE = `
+  CREATE TABLE IF NOT EXISTS team_sync_membership (
+    project_id TEXT PRIMARY KEY
+  )`;
+
 // -- Logging Layer ----------------------------------------------------------
 
 export const LOG_ENTRIES_TABLE = `
@@ -989,6 +1000,7 @@ export const TEAM_DELETE_TRIGGERS: readonly string[] = TEAM_DELETE_TRIGGER_TABLE
   CREATE TRIGGER IF NOT EXISTS ${table}_team_ad
   AFTER DELETE ON ${table}
   WHEN (SELECT enabled FROM team_sync_state) = 1
+    AND OLD.project_id IN (SELECT project_id FROM team_sync_membership)
   BEGIN
     INSERT INTO team_outbox (table_name, row_id, operation, payload, machine_id, project_id, created_at)
     VALUES ('${table}', CAST(OLD.id AS TEXT), 'delete',
@@ -1202,6 +1214,7 @@ export const TABLE_DDLS = [
   // Sync layer
   TEAM_OUTBOX_TABLE,
   TEAM_SYNC_STATE_TABLE,
+  TEAM_SYNC_MEMBERSHIP_TABLE,
   // Logging layer
   LOG_ENTRIES_TABLE,
   // Notifications layer

--- a/packages/myco/src/db/schema.ts
+++ b/packages/myco/src/db/schema.ts
@@ -20,7 +20,7 @@ import { TABLE_DDLS, FTS_TABLES, SECONDARY_INDEXES, TEAM_DELETE_TRIGGERS } from 
 import { MIGRATIONS } from './migrations.js';
 
 /** Current schema version -- fresh start for the SQLite era. */
-export const SCHEMA_VERSION = 61;
+export const SCHEMA_VERSION = 62;
 
 // Re-export for backwards compat (other modules import from schema.ts)
 export { DEFAULT_MACHINE_ID };

--- a/packages/myco/src/grove/project-lifecycle.ts
+++ b/packages/myco/src/grove/project-lifecycle.ts
@@ -4,7 +4,8 @@ import { openDatabase } from '@myco/db/client.js';
 import { createGroveBackup } from '@myco/backup/service.js';
 import { getMachineId } from '@myco/machine-id.js';
 import { loadGroveConfig } from '@myco/config/loader.js';
-import { setTeamSyncEnabled } from '@myco/db/queries/team-sync-state.js';
+import { setTeamSyncEnabled, setProjectSyncMembership } from '@myco/db/queries/team-sync-state.js';
+import { memberProjectIdsForGrove } from './project-tenancy.js';
 import fs from 'node:fs';
 import { ensureGroveDatabase } from './database.js';
 import {
@@ -96,6 +97,11 @@ export function deleteProjectPermanently(
     // triggers would silently skip journaling. Reconciling here guarantees the
     // trigger gate reflects the Grove's intent regardless of tick timing.
     setTeamSyncEnabled(groveConfig.team.enabled, db);
+    // The delete triggers are also membership-gated (a delete journals only when
+    // OLD.project_id is a member), so the per-project member set must be present
+    // on this freshly-opened handle too — otherwise a member project's delete
+    // would silently skip journaling.
+    setProjectSyncMembership(memberProjectIdsForGrove(groveId), db);
     // Each `DELETE FROM <table> WHERE project_id = ?` in deleteProjectRows
     // fires that table's `_team_ad` trigger, which journals the delete to
     // team_outbox when this Grove's team_sync_state.enabled = 1. No manual

--- a/packages/myco/src/grove/project-tenancy.ts
+++ b/packages/myco/src/grove/project-tenancy.ts
@@ -1,0 +1,62 @@
+import { findRegisteredProject, type GroveRecord, type RegisteredProject } from './registry.js';
+import { teamRegistry } from '@myco/team/registry.js';
+
+/**
+ * A project's resolved tenancy. grove is ALWAYS present (every project belongs to
+ * exactly one grove); team is the zero-or-one global construct it syncs to.
+ */
+export interface ProjectTenancy {
+  project: RegisteredProject;
+  grove: GroveRecord;
+  team: { team_id: string } | null;
+}
+
+/**
+ * Thrown when a project has no resolvable grove. A grove-less project is a loud
+ * failure, never a silent "global".
+ */
+export class ProjectGroveMissingError extends Error {
+  constructor(public readonly projectId: string) {
+    super(`Project ${projectId} has no resolvable grove (every project must belong to a grove)`);
+    this.name = 'ProjectGroveMissingError';
+  }
+}
+
+/** THE authority. The only sanctioned way to answer "what grove/team owns this project". */
+export function resolveProjectTenancy(projectId: string): ProjectTenancy {
+  const resolved = findRegisteredProject({ projectId });
+  if (!resolved) throw new ProjectGroveMissingError(projectId);
+  const teamId = teamRegistry.membershipByProject().get(projectId) ?? null;
+  return {
+    project: resolved.project,
+    grove: resolved.grove,
+    team: teamId ? { team_id: teamId } : null,
+  };
+}
+
+/**
+ * Member projects (assigned to any team) that live in this grove. The authority
+ * computation that `reconcileClient` projects into `team_sync_membership`.
+ */
+export function memberProjectIdsForGrove(groveId: string | null): string[] {
+  if (!groveId) return [];
+  return [
+    ...new Set(
+      teamRegistry.list()
+        .flatMap((t) => t.projects)
+        .filter((p) => p.grove_id === groveId)
+        .map((p) => p.project_id),
+    ),
+  ];
+}
+
+/** True when this machine has joined at least one team. */
+export const machineHasAnyTeam = (): boolean => teamRegistry.list().length > 0;
+
+/**
+ * The "check" at assignment boundaries: a project may only be referenced by a
+ * global construct (team) if it exists and resolves to a grove.
+ */
+export function assertAssignableProject(projectId: string): ProjectTenancy {
+  return resolveProjectTenancy(projectId);
+}

--- a/packages/myco/ui/src/lib/selection.ts
+++ b/packages/myco/ui/src/lib/selection.ts
@@ -147,8 +147,18 @@ export function projectRouteSuffix(pathname: string): string {
 
 export type NavScope = 'project' | 'grove' | 'machine';
 
+/**
+ * Pages whose true scope differs from what their URL implies. The Team surface
+ * is machine-wide (teams are global; you assign any project from any grove) even
+ * though it is bound to a grove route for request-context headers.
+ */
+const PAGE_SCOPE_OVERRIDES: Array<{ test: RegExp; scope: NavScope }> = [
+  { test: /^\/g\/[^/]+\/team(\/|$|\?)/, scope: 'machine' },
+];
+
 /** Page scope inferred from the URL: project (/g/<g>/p/<p>/…), grove (/g/<g>/…), else machine. */
 export function scopeForPath(pathname: string): NavScope {
+  for (const o of PAGE_SCOPE_OVERRIDES) if (o.test.test(pathname)) return o.scope;
   if (/^\/g\/[^/]+\/p\/[^/]+/.test(pathname)) return 'project';
   if (/^\/g\/[^/]+/.test(pathname)) return 'grove';
   return 'machine';

--- a/packages/myco/ui/src/pages/Team/SelectTeamView.tsx
+++ b/packages/myco/ui/src/pages/Team/SelectTeamView.tsx
@@ -1,0 +1,26 @@
+import { Network } from 'lucide-react';
+import { Panel } from '../../components/ui/panel';
+import { IconEyebrow } from '../../components/ui/icon-eyebrow';
+
+/**
+ * Shown on the team-scoped tabs (Status/Sync/Members) when no team is selected.
+ * The Team page no longer auto-picks the first registered team, so an explicit
+ * selection is required before any local-vs-cloud comparison is made.
+ */
+export function SelectTeamView({ hasTeams }: { hasTeams: boolean }) {
+  return (
+    <div className="flex flex-col gap-4">
+      <Panel
+        tone="sage"
+        eyebrow={<IconEyebrow Icon={Network}>No team selected</IconEyebrow>}
+        title="Select a team to view sync status"
+      >
+        <p className="text-sm text-on-surface-variant m-0">
+          {hasTeams
+            ? 'Choose a team from the selector in the header to view its status, sync state, and members.'
+            : 'No teams are registered on this machine yet. Provision or join a team on the Teams tab, then return here.'}
+        </p>
+      </Panel>
+    </div>
+  );
+}

--- a/packages/myco/ui/src/pages/Team/index.tsx
+++ b/packages/myco/ui/src/pages/Team/index.tsx
@@ -11,6 +11,8 @@ import { StatusTab } from './StatusTab';
 import { SyncTab } from './SyncTab';
 import { MembersTab } from './MembersTab';
 import { NotConnectedView } from './NotConnectedView';
+import { SelectTeamView } from './SelectTeamView';
+import { resolveDefaultSelectedTeamId } from './select-default';
 
 type TabId = 'teams' | 'status' | 'sync' | 'members';
 
@@ -60,7 +62,7 @@ export function TeamPage() {
   const [params, setParams] = useSearchParams();
   const { data: registry, isLoading: registryLoading } = useTeamRegistry();
   const teams = registry?.teams ?? [];
-  const selectedTeamId = params.get('team') ?? teams[0]?.team_id ?? undefined;
+  const selectedTeamId = resolveDefaultSelectedTeamId(params.get('team'), teams);
   const { data: status, isLoading: statusLoading } = useTeamStatus(
     registryLoading ? undefined : selectedTeamId,
   );
@@ -83,6 +85,10 @@ export function TeamPage() {
     // The Teams selection tab is always available — it manages registry
     // membership independent of the legacy per-Grove connection.
     if (tab === 'teams') return <TeamSelection />;
+    // The team-scoped tabs must NOT render against an arbitrary team: without an
+    // explicit selection the Sync tab would compare the ambient context's cloud
+    // and surface a phantom delta. Require an explicit pick first.
+    if (!selectedTeamId) return <SelectTeamView hasTeams={teams.length > 0} />;
     if (!isConnected) return <NotConnectedView scopeName={scopeName} />;
     if (tab === 'sync') return <SyncTab status={status!} teamId={selectedTeamId} />;
     if (tab === 'members') return <MembersTab teamId={selectedTeamId} />;
@@ -109,6 +115,7 @@ export function TeamPage() {
           }, { replace: true })
         }
       >
+        {!selectedTeamId && <option value="" disabled>Select a team…</option>}
         {teams.map((t) => (
           <option key={t.team_id} value={t.team_id}>{t.name}</option>
         ))}

--- a/packages/myco/ui/src/pages/Team/index.tsx
+++ b/packages/myco/ui/src/pages/Team/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Activity, RefreshCw, Users, Network, AlertTriangle } from 'lucide-react';
 import { useTeamStatus, useTeamRegistry, type TeamStatusResponse } from '../../hooks/use-team';
@@ -58,11 +59,24 @@ function VersionBlockBanner({ status }: { status: TeamStatusResponse }) {
   );
 }
 
+const TEAM_SELECTION_KEY = 'myco.team.selectedTeamId';
+
 export function TeamPage() {
   const [params, setParams] = useSearchParams();
   const { data: registry, isLoading: registryLoading } = useTeamRegistry();
   const teams = registry?.teams ?? [];
-  const selectedTeamId = resolveDefaultSelectedTeamId(params.get('team'), teams);
+  const storedTeamId = typeof window !== 'undefined'
+    ? window.localStorage.getItem(TEAM_SELECTION_KEY)
+    : null;
+  const selectedTeamId = resolveDefaultSelectedTeamId(params.get('team'), teams, storedTeamId);
+
+  // Persist the resolved selection (including the auto-selected first team) so it
+  // survives tab navigation and revisits within the Team section.
+  useEffect(() => {
+    if (selectedTeamId && selectedTeamId !== storedTeamId) {
+      window.localStorage.setItem(TEAM_SELECTION_KEY, selectedTeamId);
+    }
+  }, [selectedTeamId, storedTeamId]);
   const { data: status, isLoading: statusLoading } = useTeamStatus(
     registryLoading ? undefined : selectedTeamId,
   );
@@ -85,9 +99,8 @@ export function TeamPage() {
     // The Teams selection tab is always available — it manages registry
     // membership independent of the legacy per-Grove connection.
     if (tab === 'teams') return <TeamSelection />;
-    // The team-scoped tabs must NOT render against an arbitrary team: without an
-    // explicit selection the Sync tab would compare the ambient context's cloud
-    // and surface a phantom delta. Require an explicit pick first.
+    // A team is auto-selected when any exist; this only renders when no teams are
+    // registered yet — point the user to the Teams tab to join one.
     if (!selectedTeamId) return <SelectTeamView hasTeams={teams.length > 0} />;
     if (!isConnected) return <NotConnectedView scopeName={scopeName} />;
     if (tab === 'sync') return <SyncTab status={status!} teamId={selectedTeamId} />;
@@ -107,13 +120,14 @@ export function TeamPage() {
         aria-label="Selected team"
         className="rounded-md border border-[var(--ghost-border)] bg-surface-container px-3 py-1.5 text-xs text-on-surface"
         value={selectedTeamId ?? ''}
-        onChange={(e) =>
+        onChange={(e) => {
+          window.localStorage.setItem(TEAM_SELECTION_KEY, e.target.value);
           setParams((prev) => {
             const next = new URLSearchParams(prev);
             next.set('team', e.target.value);
             return next;
-          }, { replace: true })
-        }
+          }, { replace: true });
+        }}
       >
         {!selectedTeamId && <option value="" disabled>Select a team…</option>}
         {teams.map((t) => (

--- a/packages/myco/ui/src/pages/Team/select-default.ts
+++ b/packages/myco/ui/src/pages/Team/select-default.ts
@@ -1,0 +1,13 @@
+/**
+ * The Team page must NOT silently default to the first registered team:
+ * comparing an arbitrary team's cloud against the current context produced a
+ * phantom delta (and exposed a destructive "Rebuild from local" against a store
+ * the user never chose). Only honor an explicit URL selection; otherwise show
+ * an empty state prompting the user to pick a team.
+ */
+export function resolveDefaultSelectedTeamId(
+  urlTeamParam: string | null,
+  _teams: Array<{ team_id: string }>,
+): string | undefined {
+  return urlTeamParam ?? undefined;
+}

--- a/packages/myco/ui/src/pages/Team/select-default.ts
+++ b/packages/myco/ui/src/pages/Team/select-default.ts
@@ -1,13 +1,17 @@
 /**
- * The Team page must NOT silently default to the first registered team:
- * comparing an arbitrary team's cloud against the current context produced a
- * phantom delta (and exposed a destructive "Rebuild from local" against a store
- * the user never chose). Only honor an explicit URL selection; otherwise show
- * an empty state prompting the user to pick a team.
+ * Resolve which team the Team page shows. Priority: an explicit URL `?team=`,
+ * then the persisted prior selection, then the first registered team. Auto-
+ * selecting the first team (rather than an empty state) keeps the page populated;
+ * persisting the choice keeps it stable across tab navigation within the section.
+ * Stale ids (a team since removed) fall through to the next valid candidate.
  */
 export function resolveDefaultSelectedTeamId(
   urlTeamParam: string | null,
-  _teams: Array<{ team_id: string }>,
+  teams: Array<{ team_id: string }>,
+  storedTeamId?: string | null,
 ): string | undefined {
-  return urlTeamParam ?? undefined;
+  const ids = new Set(teams.map((t) => t.team_id));
+  if (urlTeamParam && ids.has(urlTeamParam)) return urlTeamParam;
+  if (storedTeamId && ids.has(storedTeamId)) return storedTeamId;
+  return teams[0]?.team_id;
 }

--- a/tests/daemon/api/groves-crud.test.ts
+++ b/tests/daemon/api/groves-crud.test.ts
@@ -17,7 +17,8 @@ import {
   listGroveSummaries,
 } from '@myco/daemon/api/groves.js';
 import { initTeamContext, resetTeamContext } from '@myco/team/context.js';
-import { createProjectId } from '@myco/grove/ids.js';
+import { teamRegistry } from '@myco/team/registry.js';
+import { createProjectId, createTeamId } from '@myco/grove/ids.js';
 import { resolveGroveDbPath, resolveGroveDir, resolveProjectVaultDir } from '@myco/grove/paths.js';
 import {
   clearGroveRegistryCaches,
@@ -336,6 +337,25 @@ describe('Grove CRUD API', () => {
       // team_sync_state from this config on its own DB handle, so the AFTER
       // DELETE triggers journal regardless of daemon tick timing.
       updateGroveConfig(grove.id, (c) => ({ ...c, team: { ...c.team, enabled: true } }));
+      // Assign both projects to a team so the authority resolves them as members.
+      // deleteProjectPermanently projects this registry membership into
+      // team_sync_membership on its own DB handle, arming the membership-gated
+      // delete triggers for both projects' rows.
+      teamRegistry.save(
+        {
+          team_id: createTeamId(),
+          name: 'Work Team',
+          worker_url: 'https://team.example.workers.dev',
+          domain: null,
+          mcp_endpoint: null,
+          created_at: new Date().toISOString(),
+          projects: [
+            { grove_id: grove.id, project_id: projectId },
+            { grove_id: grove.id, project_id: siblingProjectId },
+          ],
+        },
+        mycoHome,
+      );
       const dbPath = ensureGroveDb(grove.id);
       const db = openDatabase(dbPath);
       try {
@@ -347,11 +367,6 @@ describe('Grove CRUD API', () => {
           `INSERT INTO sessions (id, agent, project_root, project_id, started_at, created_at, machine_id)
            VALUES ('sess-sibling', 'codex', ?, ?, 1, 1, 'machine_test')`,
         ).run(siblingRoot, siblingProjectId);
-        // Both projects are team members, so the membership-gated delete trigger
-        // journals tombstones for their rows.
-        const member = db.prepare('INSERT OR IGNORE INTO team_sync_membership (project_id) VALUES (?)');
-        member.run(projectId);
-        member.run(siblingProjectId);
       } finally {
         db.close();
       }

--- a/tests/daemon/api/groves-crud.test.ts
+++ b/tests/daemon/api/groves-crud.test.ts
@@ -347,6 +347,11 @@ describe('Grove CRUD API', () => {
           `INSERT INTO sessions (id, agent, project_root, project_id, started_at, created_at, machine_id)
            VALUES ('sess-sibling', 'codex', ?, ?, 1, 1, 'machine_test')`,
         ).run(siblingRoot, siblingProjectId);
+        // Both projects are team members, so the membership-gated delete trigger
+        // journals tombstones for their rows.
+        const member = db.prepare('INSERT OR IGNORE INTO team_sync_membership (project_id) VALUES (?)');
+        member.run(projectId);
+        member.run(siblingProjectId);
       } finally {
         db.close();
       }

--- a/tests/daemon/api/groves.test.ts
+++ b/tests/daemon/api/groves.test.ts
@@ -8,6 +8,8 @@ import { createListGroveProjectsHandler, createListGrovesHandler, servedGroveSco
 import type { GroveProjectSummary } from '@myco/daemon/api/groves.js';
 import { resolveProjectVaultDir } from '@myco/grove/paths.js';
 import { createGrove, registerProjectInGrove } from '@myco/grove/registry.js';
+import { createTeamId } from '@myco/grove/ids.js';
+import { teamRegistry } from '@myco/team/registry.js';
 
 describe('Grove discovery API', () => {
   let testDir: string;
@@ -119,6 +121,120 @@ describe('Grove discovery API', () => {
     const body = response.body as { projects: Array<{ project_id: string }> };
 
     expect(body.projects.map((project) => project.project_id)).toEqual(['proj_a']);
+  });
+
+  it('omits tenancy metadata by default (legacy shape unchanged)', async () => {
+    const grove = createGrove('Work');
+    registerProjectInGrove(grove.id, {
+      projectId: 'proj_a',
+      projectName: 'Project A',
+      projectRoot: path.join(testDir, 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+    });
+
+    const response = await createListGroveProjectsHandler({ groveIds: null }, serviceDir)({
+      body: undefined,
+      query: {},
+      params: { id: grove.id },
+      pathname: `/api/groves/${grove.id}/projects`,
+    });
+    const body = response.body as { projects: Array<Record<string, unknown>> };
+
+    expect(body.projects).toHaveLength(1);
+    expect(body.projects[0]).not.toHaveProperty('grove');
+    expect(body.projects[0]).not.toHaveProperty('team');
+  });
+
+  it('includes resolved grove + team membership when include=grove,team', async () => {
+    const grove = createGrove('Work');
+    registerProjectInGrove(grove.id, {
+      projectId: 'proj_a',
+      projectName: 'Project A',
+      projectRoot: path.join(testDir, 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+    });
+    const teamId = createTeamId();
+    teamRegistry.save({
+      team_id: teamId,
+      name: 'Goondocks OSS',
+      worker_url: 'https://team.example.workers.dev',
+      domain: null,
+      mcp_endpoint: null,
+      created_at: new Date().toISOString(),
+      projects: [{ grove_id: grove.id, project_id: 'proj_a' }],
+    });
+
+    const response = await createListGroveProjectsHandler({ groveIds: null }, serviceDir)({
+      body: undefined,
+      query: { include: 'grove,team' },
+      params: { id: grove.id },
+      pathname: `/api/groves/${grove.id}/projects`,
+    });
+    const body = response.body as {
+      projects: Array<{
+        project_id: string;
+        grove: { id: string; name: string; slug: string; served_by: string };
+        team: { team_id: string } | null;
+      }>;
+    };
+
+    expect(body.projects).toHaveLength(1);
+    expect(body.projects[0].grove).toEqual({
+      id: grove.id,
+      name: grove.name,
+      slug: grove.slug,
+      served_by: grove.served_by,
+    });
+    expect(body.projects[0].team).toEqual({ team_id: teamId });
+  });
+
+  it('returns team=null for a project that is in no team', async () => {
+    const grove = createGrove('Work');
+    registerProjectInGrove(grove.id, {
+      projectId: 'proj_a',
+      projectName: 'Project A',
+      projectRoot: path.join(testDir, 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+    });
+
+    const response = await createListGroveProjectsHandler({ groveIds: null }, serviceDir)({
+      body: undefined,
+      query: { include: 'grove,team' },
+      params: { id: grove.id },
+      pathname: `/api/groves/${grove.id}/projects`,
+    });
+    const body = response.body as {
+      projects: Array<{ grove: { id: string }; team: { team_id: string } | null }>;
+    };
+
+    expect(body.projects[0].grove.id).toBe(grove.id);
+    expect(body.projects[0].team).toBeNull();
+  });
+
+  it('honors include=grove alone (team key omitted) and include=team alone (grove key omitted)', async () => {
+    const grove = createGrove('Work');
+    registerProjectInGrove(grove.id, {
+      projectId: 'proj_a',
+      projectName: 'Project A',
+      projectRoot: path.join(testDir, 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+    });
+
+    const groveOnly = await createListGroveProjectsHandler({ groveIds: null }, serviceDir)({
+      body: undefined,
+      query: { include: 'grove' },
+      params: { id: grove.id },
+      pathname: `/api/groves/${grove.id}/projects`,
+    });
+    const groveBody = groveOnly.body as { projects: Array<Record<string, unknown>> };
+    expect(groveBody.projects[0]).toHaveProperty('grove');
+    expect(groveBody.projects[0]).not.toHaveProperty('team');
+
+    const teamOnly = await createListGroveProjectsHandler({ groveIds: null }, serviceDir)({
+      body: undefined,
+      query: { include: 'team' },
+      params: { id: grove.id },
+      pathname: `/api/groves/${grove.id}/projects`,
+    });
+    const teamBody = teamOnly.body as { projects: Array<Record<string, unknown>> };
+    expect(teamBody.projects[0]).toHaveProperty('team');
+    expect(teamBody.projects[0]).not.toHaveProperty('grove');
   });
 
   it('returns capability gates per project; cortex=false when local.yaml disables it', async () => {

--- a/tests/daemon/api/skills-delete.test.ts
+++ b/tests/daemon/api/skills-delete.test.ts
@@ -99,8 +99,12 @@ describe('skill record API deletion', () => {
     });
     initTeamContext('machine-a');
     // The delete tombstone is now journaled by the skill_records_team_ad
-    // trigger, which gates on this Grove's per-Grove team_sync_state flag.
+    // trigger, which gates on this Grove's per-Grove team_sync_state flag and
+    // the project's membership in team_sync_membership.
     setTeamSyncEnabled(true);
+    getDatabase().prepare(
+      'INSERT OR IGNORE INTO team_sync_membership (project_id) VALUES (?)',
+    ).run(PROJECT_ID);
 
     const response = await handleDeleteSkillRecord(
       { params: { id: 'skill-scoped' }, requestContext: REQUEST_CONTEXT } as never,

--- a/tests/daemon/api/team-selection.test.ts
+++ b/tests/daemon/api/team-selection.test.ts
@@ -4,9 +4,14 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { createTeamId } from '@myco/grove/ids.js';
+import { createTeamId, createProjectId } from '@myco/grove/ids.js';
 import { teamRegistry, type TeamRecord } from '@myco/team/registry.js';
-import { clearGroveRegistryCaches } from '@myco/grove/registry.js';
+import {
+  clearGroveRegistryCaches,
+  createGrove,
+  registerProjectInGrove,
+  type GroveRecord,
+} from '@myco/grove/registry.js';
 import { createTeamSelectionHandlers } from '@myco/daemon/api/team-selection.js';
 import type { RouteRequest, RouteResponse } from '@myco/daemon/router.js';
 
@@ -38,6 +43,20 @@ describe('createTeamSelectionHandlers', () => {
   let originalMycoHome: string | undefined;
   let handlers: ReturnType<typeof createTeamSelectionHandlers>;
 
+  /**
+   * Register a real grove with a real project so the assignment-boundary
+   * check (`assertAssignableProject`) resolves it to a grove. Returns the
+   * grove + project id for use in membership bodies.
+   */
+  function seedGroveProject(name: string): { grove: GroveRecord; projectId: string } {
+    const grove = createGrove(name);
+    const projectId = createProjectId();
+    const projectRoot = path.join(tempDir, 'projects', projectId);
+    fs.mkdirSync(projectRoot, { recursive: true });
+    registerProjectInGrove(grove.id, { projectId, projectName: name, projectRoot });
+    return { grove, projectId };
+  }
+
   beforeEach(() => {
     originalMycoHome = process.env.MYCO_HOME;
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-team-selection-'));
@@ -57,33 +76,29 @@ describe('createTeamSelectionHandlers', () => {
 
   it('adds a project to a team and reflects it via get()', () => {
     const team = seedTeam('Alpha');
+    const { grove, projectId } = seedGroveProject('alpha-project');
 
     const response = handlers.handleSetProjectMembership(
-      membershipBody(team.team_id, 'grove_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'add'),
+      membershipBody(team.team_id, grove.id, projectId, 'add'),
     );
 
     const body = response.body as { team: TeamRecord };
     expect(response.status).toBeUndefined();
-    expect(body.team.projects).toContainEqual({
-      grove_id: 'grove_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-      project_id: 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-    });
+    expect(body.team.projects).toContainEqual({ grove_id: grove.id, project_id: projectId });
 
     const persisted = teamRegistry.get(team.team_id);
-    expect(persisted?.projects.some((p) => p.project_id === 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toBe(true);
+    expect(persisted?.projects.some((p) => p.project_id === projectId)).toBe(true);
   });
 
   it('rejects adding a project already owned by another team with 409', () => {
     const teamA = seedTeam('Alpha');
     const teamB = seedTeam('Beta');
-    const projectId = 'proj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const { grove, projectId } = seedGroveProject('beta-project');
 
-    handlers.handleSetProjectMembership(
-      membershipBody(teamA.team_id, 'grove_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', projectId, 'add'),
-    );
+    handlers.handleSetProjectMembership(membershipBody(teamA.team_id, grove.id, projectId, 'add'));
 
     const response = handlers.handleSetProjectMembership(
-      membershipBody(teamB.team_id, 'grove_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', projectId, 'add'),
+      membershipBody(teamB.team_id, grove.id, projectId, 'add'),
     );
 
     expect(response.status).toBe(409);
@@ -97,17 +112,62 @@ describe('createTeamSelectionHandlers', () => {
 
   it('removes a project from a team', () => {
     const team = seedTeam('Alpha');
-    const groveId = 'grove_cccccccccccccccccccccccccccccccc';
-    const projectId = 'proj_cccccccccccccccccccccccccccccccc';
+    const { grove, projectId } = seedGroveProject('gamma-project');
 
-    handlers.handleSetProjectMembership(membershipBody(team.team_id, groveId, projectId, 'add'));
+    handlers.handleSetProjectMembership(membershipBody(team.team_id, grove.id, projectId, 'add'));
     expect(teamRegistry.get(team.team_id)?.projects).toHaveLength(1);
 
-    const response = handlers.handleSetProjectMembership(membershipBody(team.team_id, groveId, projectId, 'remove'));
+    const response = handlers.handleSetProjectMembership(membershipBody(team.team_id, grove.id, projectId, 'remove'));
     const body = response.body as { team: TeamRecord };
 
     expect(response.status).toBeUndefined();
     expect(body.team.projects.some((p) => p.project_id === projectId)).toBe(false);
+    expect(teamRegistry.get(team.team_id)?.projects).toHaveLength(0);
+  });
+
+  it('rejects assigning a project that resolves to no grove with 400', () => {
+    const team = seedTeam('Alpha');
+    const ghost = createProjectId();
+
+    const response = handlers.handleSetProjectMembership(
+      membershipBody(team.team_id, 'grove_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', ghost, 'add'),
+    );
+
+    expect(response.status).toBe(400);
+    expect((response.body as { error: string }).error).toBe('project_not_assignable');
+    // The grove-less project never reached the registry.
+    expect(teamRegistry.get(team.team_id)?.projects).toHaveLength(0);
+  });
+
+  it('rejects an add whose grove_id does not match the project\'s resolved grove with 400', () => {
+    const team = seedTeam('Alpha');
+    const { grove, projectId } = seedGroveProject('delta-project');
+    const otherGrove = createGrove('decoy');
+
+    const response = handlers.handleSetProjectMembership(
+      membershipBody(team.team_id, otherGrove.id, projectId, 'add'),
+    );
+
+    expect(response.status).toBe(400);
+    const body = response.body as { error: string; grove_id: string };
+    expect(body.error).toBe('grove_mismatch');
+    // The UI self-corrects using the project's ACTUAL resolved grove id.
+    expect(body.grove_id).toBe(grove.id);
+    expect(teamRegistry.get(team.team_id)?.projects).toHaveLength(0);
+  });
+
+  it('does NOT run the assignment check on remove (a removed project may already be grove-less)', () => {
+    const team = seedTeam('Alpha');
+    const { grove, projectId } = seedGroveProject('epsilon-project');
+    handlers.handleSetProjectMembership(membershipBody(team.team_id, grove.id, projectId, 'add'));
+
+    // Simulate the project's grove going away (deregistered) before removal.
+    clearGroveRegistryCaches();
+    fs.rmSync(path.join(process.env.MYCO_HOME!, 'groves'), { recursive: true, force: true });
+    clearGroveRegistryCaches();
+
+    const response = handlers.handleSetProjectMembership(membershipBody(team.team_id, grove.id, projectId, 'remove'));
+    expect(response.status).toBeUndefined();
     expect(teamRegistry.get(team.team_id)?.projects).toHaveLength(0);
   });
 
@@ -121,8 +181,9 @@ describe('createTeamSelectionHandlers', () => {
   });
 
   it('returns unknown_team (404) for an unregistered team id', () => {
+    const { grove, projectId } = seedGroveProject('zeta-project');
     const response = handlers.handleSetProjectMembership(
-      membershipBody(createTeamId(), 'grove_dddddddddddddddddddddddddddddddd', 'proj_dddddddddddddddddddddddddddddddd', 'add'),
+      membershipBody(createTeamId(), grove.id, projectId, 'add'),
     );
     expect(response.status).toBe(404);
     expect((response.body as { error: string }).error).toBe('unknown_team');

--- a/tests/daemon/team-sync-fanout.test.ts
+++ b/tests/daemon/team-sync-fanout.test.ts
@@ -60,6 +60,7 @@ import { ensureGroveDatabase } from '@myco/grove/database.js';
 import { createGrove, type GroveRecord } from '@myco/grove/registry.js';
 import { resolveGroveDir } from '@myco/grove/paths.js';
 import { enqueueOutbox, listPending } from '@myco/db/queries/team-outbox.js';
+import { getSyncableProjectIds } from '@myco/db/queries/team-sync-state.js';
 import { teamRegistry } from '@myco/team/registry.js';
 import { createTeamId, createProjectId } from '@myco/grove/ids.js';
 
@@ -160,6 +161,28 @@ describe('team-sync flush fan-out across Groves', () => {
     const dbPath = path.join(mycoHome, 'groves', grove.id, 'myco.db');
     const db = cache.getDatabase(dbPath);
     return withDatabase(db, () => listPending().length);
+  }
+
+  /** Seed an UNSYNCED source spore (synced_at NULL) so reconcile's backfill picks it up. */
+  function seedUnsyncedSpore(grove: GroveRecord, cache: GroveRuntimeCache, id: string): void {
+    const dbPath = path.join(mycoHome, 'groves', grove.id, 'myco.db');
+    const db = cache.getDatabase(dbPath);
+    const projectId = projectByGrove.get(grove.id)!;
+    withDatabase(db, () => {
+      db.prepare(
+        `INSERT OR IGNORE INTO agents (id, name, source, enabled, created_at) VALUES ('user','user','built-in',1,1)`,
+      ).run();
+      db.prepare(
+        `INSERT INTO spores (id, project_id, agent_id, observation_type, content, created_at, machine_id)
+         VALUES (?, ?, 'user', 'decision', 'x', 1, 'machine-1')`,
+      ).run(id, projectId);
+    });
+  }
+
+  function syncableProjects(grove: GroveRecord, cache: GroveRuntimeCache): string[] {
+    const dbPath = path.join(mycoHome, 'groves', grove.id, 'myco.db');
+    const db = cache.getDatabase(dbPath);
+    return withDatabase(db, () => getSyncableProjectIds());
   }
 
   function buildGroveCtx(grove: GroveRecord) {
@@ -324,6 +347,110 @@ describe('team-sync flush fan-out across Groves', () => {
       batches: 0,
       errors: 0,
     });
+
+    cache.closeAll();
+  });
+
+  // --- reconcileGrove: the affected-grove immediate reconcile (Task 4b) ---
+
+  it('reconcileGrove reconciles + backfills + flushes ONLY the affected grove', async () => {
+    const affected = createGroveWithTeamConfig('Affected');
+    const sibling = createGroveWithTeamConfig('Sibling');
+    const cache = new GroveRuntimeCache();
+
+    const teamSync = initTeamSync({
+      liveConfig: {
+        current: { team: { enabled: false, worker_url: undefined } },
+      } as never,
+      machineId: 'machine-1',
+      logger: logger as never,
+      vaultDir: bootVaultDir,
+      serverVersion: '1.2.3',
+      daemonStateDir: path.join(mycoHome, 'service'),
+    });
+
+    // Both groves own a member project (assigned by createGroveWithTeamConfig),
+    // and each has an unsynced source spore. Reconciling only the affected grove
+    // must backfill + flush its row to its worker while leaving the sibling's
+    // row pending (untouched until its own reconcile / next flush tick).
+    seedUnsyncedSpore(affected, cache, 'sp-affected');
+    seedUnsyncedSpore(sibling, cache, 'sp-sibling');
+
+    await teamSync.reconcileGrove(cache, affected.id);
+
+    // Affected grove: membership table populated, its spore backfilled + flushed.
+    expect(syncableProjects(affected, cache)).toEqual([projectByGrove.get(affected.id)!]);
+    expect(pendingCount(affected, cache)).toBe(0);
+    expect(enqueueBatchByGrove.get(affected.id)?.[0]?.count).toBe(1);
+
+    // Sibling grove untouched by this reconcile — its row never reached a worker.
+    expect(enqueueBatchByGrove.has(sibling.id)).toBe(false);
+    expect(pendingCount(sibling, cache)).toBe(0);
+
+    cache.closeAll();
+  });
+
+  it('reconcileGrove on a grove with no member projects clears membership and purges its outbox', async () => {
+    // A grove whose only project is NOT a team member (a removed/never-assigned
+    // project). reconcileGrove must set empty membership and purge the
+    // project-scoped outbox rows, while the machine HAS joined a team elsewhere.
+    const elsewhere = createGroveWithTeamConfig('Elsewhere');   // owns a member project
+    const orphan = createGroveWithTeamConfig('Orphan');
+    // Strip Orphan's project from its team so the grove owns no member project.
+    const orphanTeam = teamRegistry
+      .list(mycoHome)
+      .find((t) => t.projects.some((p) => p.grove_id === orphan.id))!;
+    teamRegistry.save(
+      { ...orphanTeam, projects: orphanTeam.projects.filter((p) => p.grove_id !== orphan.id) },
+      mycoHome,
+    );
+
+    const cache = new GroveRuntimeCache();
+    const teamSync = initTeamSync({
+      liveConfig: {
+        current: { team: { enabled: false, worker_url: undefined } },
+      } as never,
+      machineId: 'machine-1',
+      logger: logger as never,
+      vaultDir: bootVaultDir,
+      serverVersion: '1.2.3',
+      daemonStateDir: path.join(mycoHome, 'service'),
+    });
+
+    // Pre-seed an orphan outbox row for the now-non-member project.
+    seedOutbox(orphan, cache, ['stale-1']);
+    expect(pendingCount(orphan, cache)).toBe(1);
+
+    await teamSync.reconcileGrove(cache, orphan.id);
+
+    expect(syncableProjects(orphan, cache)).toEqual([]);
+    // The project-scoped stale row is purged by purgeNonMemberOutbox.
+    expect(pendingCount(orphan, cache)).toBe(0);
+    // The elsewhere grove (a different served grove) is NOT touched by a
+    // single-grove reconcile.
+    expect(enqueueBatchByGrove.has(elsewhere.id)).toBe(false);
+
+    cache.closeAll();
+  });
+
+  it('reconcileGrove for an unknown grove id is a no-op (served-by / not-found scoping)', async () => {
+    createGroveWithTeamConfig('Present');
+    const cache = new GroveRuntimeCache();
+    const teamSync = initTeamSync({
+      liveConfig: {
+        current: { team: { enabled: false, worker_url: undefined } },
+      } as never,
+      machineId: 'machine-1',
+      logger: logger as never,
+      vaultDir: bootVaultDir,
+      serverVersion: '1.2.3',
+      daemonStateDir: path.join(mycoHome, 'service'),
+    });
+
+    // No throw, no enqueue — a grove not served here is silently skipped and
+    // the owning daemon's flush-tick backstop covers it.
+    await teamSync.reconcileGrove(cache, 'grove_ffffffffffffffffffffffffffffffff');
+    expect(enqueueBatchByGrove.size).toBe(0);
 
     cache.closeAll();
   });

--- a/tests/daemon/team-sync-grove-scope.test.ts
+++ b/tests/daemon/team-sync-grove-scope.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
 import { setupTestDb, teardownTestDb, cleanTestDb } from '../helpers/db.js';
 import { getDatabase } from '@myco/db/client.js';
-import { setTeamSyncEnabled } from '@myco/db/queries/team-sync-state.js';
+import { setTeamSyncEnabled, setProjectSyncMembership } from '@myco/db/queries/team-sync-state.js';
 import { backfillAll, backfillAllForRebuild, countPending } from '@myco/db/queries/team-outbox.js';
 
 describe('rebuildFromLocal local half: backfillAll re-enqueues the Grove', () => {
@@ -12,6 +12,7 @@ describe('rebuildFromLocal local half: backfillAll re-enqueues the Grove', () =>
   it('backfillAll enqueues a sync-eligible row even when already marked synced', () => {
     const db = getDatabase();
     setTeamSyncEnabled(true, db);
+    setProjectSyncMembership(['proj_x'], db);
     // agents row required by spores.agent_id FK
     db.prepare(
       `INSERT OR IGNORE INTO agents (id, name, source, enabled, created_at) VALUES ('user','user','built-in',1,1)`,
@@ -50,14 +51,15 @@ describe('backfillAllForRebuild: includes skill_usage; backfillAll does not', ()
        VALUES ('sr_su', 'user', 'local', 'test-skill', 'Test Skill', 'desc', 'active', '/tmp/test.md', 1, 1)`,
     ).run();
     db.prepare(
-      `INSERT INTO skill_usage (id, skill_id, session_id, machine_id, detected_at)
-       VALUES ('su_1', 'sr_su', 'sess_su', 'local', 1)`,
+      `INSERT INTO skill_usage (id, project_id, skill_id, session_id, machine_id, detected_at)
+       VALUES ('su_1', 'proj_su', 'sr_su', 'sess_su', 'local', 1)`,
     ).run();
   }
 
   it('backfillAllForRebuild enqueues skill_usage rows', () => {
     const db = getDatabase();
     setTeamSyncEnabled(true, db);
+    setProjectSyncMembership(['proj_su'], db);
     seedSkillUsage(db);
 
     const enqueued = backfillAllForRebuild('local');
@@ -73,6 +75,7 @@ describe('backfillAllForRebuild: includes skill_usage; backfillAll does not', ()
   it('backfillAll does NOT enqueue skill_usage rows', () => {
     const db = getDatabase();
     setTeamSyncEnabled(true, db);
+    setProjectSyncMembership(['proj_su'], db);
     seedSkillUsage(db);
 
     backfillAll('local');

--- a/tests/daemon/team-sync-init.test.ts
+++ b/tests/daemon/team-sync-init.test.ts
@@ -21,6 +21,9 @@ const {
   enqueueOutboxMock,
   upsertSelfMemberMock,
   setTeamSyncEnabledMock,
+  setProjectSyncMembershipMock,
+  purgeNonMemberOutboxMock,
+  purgePendingOutboxMock,
 } = vi.hoisted(() => ({
   connectMock: vi.fn(),
   rebuildMock: vi.fn(),
@@ -36,6 +39,9 @@ const {
   enqueueOutboxMock: vi.fn(),
   upsertSelfMemberMock: vi.fn(),
   setTeamSyncEnabledMock: vi.fn(),
+  setProjectSyncMembershipMock: vi.fn(),
+  purgeNonMemberOutboxMock: vi.fn(() => 0),
+  purgePendingOutboxMock: vi.fn(() => 0),
 }));
 
 mock.module('@myco/db/queries/team-outbox.js', () => ({
@@ -48,6 +54,9 @@ mock.module('@myco/db/queries/team-outbox.js', () => ({
   backfillAllForRebuild: backfillAllForRebuildMock,
   discardRows: discardRowsMock,
   countPending: vi.fn(() => 0),
+  countPendingByTable: vi.fn(() => ({})),
+  purgePendingOutbox: purgePendingOutboxMock,
+  purgeNonMemberOutbox: purgeNonMemberOutboxMock,
   enqueueOutbox: enqueueOutboxMock,
 }));
 
@@ -61,6 +70,7 @@ mock.module('@myco/db/queries/team-members.js', () => ({
 // not the per-Grove flag — that is covered by team-sync-state.test.ts).
 mock.module('@myco/db/queries/team-sync-state.js', () => ({
   setTeamSyncEnabled: setTeamSyncEnabledMock,
+  setProjectSyncMembership: setProjectSyncMembershipMock,
 }));
 
 // reconcileSelfMember wraps upsertSelfMember + enqueueOutbox in a
@@ -437,6 +447,97 @@ describe('initTeamSync.reconcileClient', () => {
 
     expect(teamSync.getTeamClient(groveContext)).toBeNull();
     expect(connectMock).not.toHaveBeenCalled();
+  });
+
+  it('a grove with no member projects does NOT project-backfill, but purges and still pushes the self-row', async () => {
+    // The machine joined a team via ANOTHER grove, so it has joined a team but
+    // THIS grove owns no member project.
+    const { createGrove } = await import('../../packages/myco/src/grove/registry.js');
+    const { createTeamId, createProjectId } = await import('../../packages/myco/src/grove/ids.js');
+    const { teamRegistry } = await import('../../packages/myco/src/team/registry.js');
+    const mycoHome = process.env.MYCO_HOME!;
+    const otherGrove = createGrove('elsewhere', mycoHome);
+    const hereGrove = createGrove('here', mycoHome);
+    const teamId = createTeamId();
+    teamRegistry.save(
+      {
+        team_id: teamId,
+        name: 'Elsewhere Team',
+        worker_url: 'https://team.example.workers.dev',
+        domain: null,
+        mcp_endpoint: null,
+        created_at: new Date().toISOString(),
+        projects: [{ grove_id: otherGrove.id, project_id: createProjectId() }],
+      },
+      mycoHome,
+    );
+    teamRegistry.writeSecret(teamId, 'MYCO_TEAM_API_KEY', 'routing-secret', mycoHome);
+
+    const teamSync = initTeamSync({
+      liveConfig: {
+        current: {
+          team: { enabled: true, worker_url: 'https://team.example.workers.dev' },
+        },
+      } as never,
+      machineId: 'machine-1',
+      logger: logger as never,
+      vaultDir,
+      serverVersion: '1.2.3',
+    });
+
+    await teamSync.reconcileClient(requestContext(hereGrove.id, 'proj-here'));
+
+    expect(setTeamSyncEnabledMock).toHaveBeenCalledWith(false);
+    expect(setProjectSyncMembershipMock).toHaveBeenCalledWith([]);
+    expect(purgeNonMemberOutboxMock).toHaveBeenCalledWith([]);
+    // Roster self-row is still published, and backfill still runs (it carries
+    // the machine-scoped self-row; backfillRows filters project rows internally).
+    expect(upsertSelfMemberMock).toHaveBeenCalled();
+    expect(backfillUnsyncedMock).toHaveBeenCalled();
+    // The no-team early-return self-row sweep must NOT fire — the machine HAS
+    // joined a team, so leftover self-rows are wanted, not purged.
+    expect(purgePendingOutboxMock).not.toHaveBeenCalled();
+  });
+
+  it('a grove that owns a member project reconciles that project and backfills', async () => {
+    const { createGrove } = await import('../../packages/myco/src/grove/registry.js');
+    const { createTeamId } = await import('../../packages/myco/src/grove/ids.js');
+    const { teamRegistry } = await import('../../packages/myco/src/team/registry.js');
+    const mycoHome = process.env.MYCO_HOME!;
+    const grove = createGrove('owns', mycoHome);
+    const teamId = createTeamId();
+    teamRegistry.save(
+      {
+        team_id: teamId,
+        name: 'Owns Team',
+        worker_url: 'https://team.example.workers.dev',
+        domain: null,
+        mcp_endpoint: null,
+        created_at: new Date().toISOString(),
+        projects: [{ grove_id: grove.id, project_id: 'p-mine' }],
+      },
+      mycoHome,
+    );
+    teamRegistry.writeSecret(teamId, 'MYCO_TEAM_API_KEY', 'routing-secret', mycoHome);
+
+    const teamSync = initTeamSync({
+      liveConfig: {
+        current: {
+          team: { enabled: true, worker_url: 'https://team.example.workers.dev' },
+        },
+      } as never,
+      machineId: 'machine-1',
+      logger: logger as never,
+      vaultDir,
+      serverVersion: '1.2.3',
+    });
+
+    await teamSync.reconcileClient(requestContext(grove.id, 'p-mine'));
+
+    expect(setTeamSyncEnabledMock).toHaveBeenCalledWith(true);
+    expect(setProjectSyncMembershipMock).toHaveBeenCalledWith(['p-mine']);
+    expect(purgeNonMemberOutboxMock).toHaveBeenCalledWith(['p-mine']);
+    expect(backfillUnsyncedMock).toHaveBeenCalled();
   });
 
   function writeTeamConfig(enabled: boolean): void {

--- a/tests/db/migrate-v55-to-v56-plan-authorship.test.ts
+++ b/tests/db/migrate-v55-to-v56-plan-authorship.test.ts
@@ -160,11 +160,15 @@ describe('migration v55 -> v56: authorship-gated plan cleanup', () => {
 
   it('enqueues a team-sync tombstone for each deleted plan row when team sync is enabled', () => {
     const db = seedV55Db();
-    // plans carries an AFTER DELETE team-sync trigger gated on team_sync_state.
+    // plans carries an AFTER DELETE team-sync trigger gated on team_sync_state
+    // and the project's membership in team_sync_membership.
     db.prepare(
       `INSERT INTO team_sync_state (rowid_guard, enabled) VALUES (1, 1)
          ON CONFLICT (rowid_guard) DO UPDATE SET enabled = 1`,
     ).run();
+    db.prepare(
+      `INSERT OR IGNORE INTO team_sync_membership (project_id) VALUES (?)`,
+    ).run(PROJECT);
 
     createSchema(db, LOCAL);
 

--- a/tests/db/queries/plans.test.ts
+++ b/tests/db/queries/plans.test.ts
@@ -225,8 +225,12 @@ describe('plan query helpers', () => {
       upsertPlan(data);
       initTeamContext('machine-a');
       // The delete tombstone is journaled by the plans_team_ad trigger, which
-      // gates on this Grove's per-Grove team_sync_state flag.
+      // gates on this Grove's per-Grove team_sync_state flag and the project's
+      // membership in team_sync_membership.
       setTeamSyncEnabled(true);
+      getDatabase().prepare(
+        'INSERT OR IGNORE INTO team_sync_membership (project_id) VALUES (?)',
+      ).run(projectId);
 
       deletePlan(data.id, projectScope(projectId as GroveProjectId));
 

--- a/tests/db/queries/team-outbox.test.ts
+++ b/tests/db/queries/team-outbox.test.ts
@@ -21,6 +21,7 @@ import {
   countTeamSyncRows,
 } from '@myco/db/queries/team-outbox.js';
 import { getDatabase } from '@myco/db/client.js';
+import { setProjectSyncMembership } from '@myco/db/queries/team-sync-state.js';
 import type { OutboxInsert } from '@myco/db/queries/team-outbox.js';
 
 /** Epoch seconds helper. */
@@ -361,14 +362,15 @@ describe('team outbox query helpers', () => {
     it('re-enqueues an unsynced row whose only outbox trace is sent-but-unpruned', () => {
       const db = getDatabase();
       const now = epochNow();
+      setProjectSyncMembership(['proj-a']);
       // An unsynced local row (synced_at NULL) — e.g. reset by the
       // JOIN/drop path — whose prior outbox entry was sent and is inside
       // the 24h retention window.
       db.prepare(
         `INSERT INTO sessions (
-          id, agent, started_at, created_at, machine_id, synced_at
-        ) VALUES (?, ?, ?, ?, ?, NULL)`,
-      ).run('session-masked', 'codex', now, now, 'machine-a');
+          id, agent, project_id, started_at, created_at, machine_id, synced_at
+        ) VALUES (?, ?, ?, ?, ?, ?, NULL)`,
+      ).run('session-masked', 'codex', 'proj-a', now, now, 'machine-a');
       const stale = enqueueOutbox(makeOutbox({
         table_name: 'sessions', row_id: 'session-masked', machine_id: 'machine-a',
       }));
@@ -384,11 +386,12 @@ describe('team outbox query helpers', () => {
     it('still skips rows that already have a PENDING outbox entry', () => {
       const db = getDatabase();
       const now = epochNow();
+      setProjectSyncMembership(['proj-a']);
       db.prepare(
         `INSERT INTO sessions (
-          id, agent, started_at, created_at, machine_id, synced_at
-        ) VALUES (?, ?, ?, ?, ?, NULL)`,
-      ).run('session-pending', 'codex', now, now, 'machine-a');
+          id, agent, project_id, started_at, created_at, machine_id, synced_at
+        ) VALUES (?, ?, ?, ?, ?, ?, NULL)`,
+      ).run('session-pending', 'codex', 'proj-a', now, now, 'machine-a');
       enqueueOutbox(makeOutbox({
         table_name: 'sessions', row_id: 'session-pending', machine_id: 'machine-a',
       }));
@@ -403,11 +406,12 @@ describe('team outbox query helpers', () => {
     it('re-enqueues previously synced Grove rows', () => {
       const db = getDatabase();
       const now = epochNow();
+      setProjectSyncMembership(['proj-a']);
       db.prepare(
         `INSERT INTO sessions (
-          id, agent, started_at, created_at, machine_id, synced_at
-        ) VALUES (?, ?, ?, ?, ?, ?)`,
-      ).run('session-synced', 'codex', now, now, 'machine-a', now - 10);
+          id, agent, project_id, started_at, created_at, machine_id, synced_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ).run('session-synced', 'codex', 'proj-a', now, now, 'machine-a', now - 10);
 
       // Already-synced rows are invisible to the routine unsynced sweep.
       expect(backfillUnsynced('machine-a')).toBe(0);
@@ -443,6 +447,7 @@ describe('team outbox query helpers', () => {
 
     it('backfillAllForRebuild re-enqueues a row that already has a PENDING outbox entry (no skip)', () => {
       const db = getDatabase();
+      setProjectSyncMembership(['proj']);
       seedSyncedSpore(db, 'spore-pending', 'machine-a');
 
       // Pre-existing PENDING (sent_at IS NULL) outbox entry for that same row —
@@ -466,6 +471,7 @@ describe('team outbox query helpers', () => {
     it("'unsynced' mode STILL skips a row that already has an outbox entry (unchanged)", () => {
       const db = getDatabase();
       const now = epochNow();
+      setProjectSyncMembership(['proj']);
       // Source row is UNSYNCED so the only thing that can suppress it is the
       // existing outbox-entry dedup.
       db.prepare(

--- a/tests/db/queries/team-sync-state.test.ts
+++ b/tests/db/queries/team-sync-state.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'bun:test';
 import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db.js';
 import { getDatabase } from '@myco/db/client.js';
-import { getTeamSyncEnabled, setTeamSyncEnabled } from '@myco/db/queries/team-sync-state.js';
+import { getTeamSyncEnabled, setTeamSyncEnabled, setProjectSyncMembership } from '@myco/db/queries/team-sync-state.js';
 import { syncRow } from '@myco/db/queries/team-outbox.js';
 
 describe('team_sync_state', () => {
@@ -24,20 +24,20 @@ describe('team_sync_state', () => {
   });
 });
 
-describe('syncRow gate reads team_sync_state (Grove-correct)', () => {
+describe('syncRow gate reads team_sync_membership (project-scoped)', () => {
   beforeAll(() => { setupTestDb(); });
   afterAll(() => { teardownTestDb(); });
   beforeEach(() => { cleanTestDb(); });
 
-  it('does not enqueue when the Grove flag is disabled', () => {
-    setTeamSyncEnabled(false);
+  it('does not enqueue when the project is not a sync member', () => {
+    // No setProjectSyncMembership -> the project is absent from team_sync_membership.
     syncRow('spores', { id: 'sp_gate1', project_id: 'proj_x', created_at: 1 } as never);
     const n = getDatabase().prepare(`SELECT COUNT(*) AS n FROM team_outbox WHERE row_id='sp_gate1'`).get() as { n: number };
     expect(n.n).toBe(0);
   });
 
-  it('enqueues an upsert when the Grove flag is enabled', () => {
-    setTeamSyncEnabled(true);
+  it('enqueues an upsert when the project is a sync member', () => {
+    setProjectSyncMembership(['proj_x']);
     syncRow('spores', { id: 'sp_gate2', project_id: 'proj_x', created_at: 1 } as never);
     const rows = getDatabase().prepare(`SELECT operation, row_id FROM team_outbox WHERE row_id='sp_gate2'`).all() as Array<Record<string, unknown>>;
     expect(rows.length).toBe(1);

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -48,7 +48,7 @@ describe('Database schema', () => {
 
   describe('constants', () => {
     it('exports SCHEMA_VERSION as a positive integer', () => {
-      expect(SCHEMA_VERSION).toBe(61);
+      expect(SCHEMA_VERSION).toBe(62);
       expect(Number.isInteger(SCHEMA_VERSION)).toBe(true);
     });
 
@@ -168,9 +168,9 @@ describe('Database schema', () => {
           `SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`,
         ).all() as Array<{ name: string }>;
 
-        // Infra/sync tables that carry project_id for routing — not Grove
-        // capture scoping — are deliberately excluded from the registry.
-        const PROJECT_ID_INFRA_TABLES = new Set<string>(['team_outbox']);
+        // Infra/sync tables that carry project_id for routing/membership — not
+        // Grove capture scoping — are deliberately excluded from the registry.
+        const PROJECT_ID_INFRA_TABLES = new Set<string>(['team_outbox', 'team_sync_membership']);
 
         const projectScoped = tables
           .map((t) => t.name)

--- a/tests/db/team-delete-triggers.test.ts
+++ b/tests/db/team-delete-triggers.test.ts
@@ -28,10 +28,17 @@ function newDb(): Database {
   return db;
 }
 
+// The delete triggers fire only for projects in team_sync_membership. Seed the
+// projection so a member project's deletes still journal.
+function markProjectMember(db: Database, projectId: string): void {
+  db.prepare('INSERT OR IGNORE INTO team_sync_membership (project_id) VALUES (?)').run(projectId);
+}
+
 describe('team delete triggers', () => {
   it('a spore delete with sync enabled journals exactly one delete outbox row', () => {
     const db = newDb();
     setTeamSyncEnabled(true, db);
+    markProjectMember(db, 'proj_x');
     db.prepare(
       `INSERT INTO spores (id, project_id, agent_id, observation_type, status, content, created_at, machine_id)
        VALUES ('sp1', 'proj_x', 'user', 'decision', 'active', 'c', 1, 'local')`,
@@ -51,6 +58,7 @@ describe('team delete triggers', () => {
   it('an INTEGER-PK delete journals row_id as the decimal string of the id', () => {
     const db = newDb();
     setTeamSyncEnabled(true, db);
+    markProjectMember(db, 'proj_x');
     db.prepare(
       `INSERT INTO prompt_batches (id, session_id, project_id, created_at, machine_id)
        VALUES (101, 's1', 'proj_x', 1, 'local')`,
@@ -94,9 +102,10 @@ describe('session cascade journals child deletes via triggers', () => {
   it('deleting a session enqueues delete rows for the session and its synced children', () => {
     const db = getDatabase();
     setTeamSyncEnabled(true, db);
+    markProjectMember(db, 'proj_x');
     db.prepare(
-      `INSERT INTO sessions (id, agent, started_at, created_at, machine_id)
-       VALUES ('s1', 'claude-code', 1, 1, 'local')`,
+      `INSERT INTO sessions (id, agent, project_id, started_at, created_at, machine_id)
+       VALUES ('s1', 'claude-code', 'proj_x', 1, 1, 'local')`,
     ).run();
     db.prepare(
       `INSERT INTO prompt_batches (id, session_id, project_id, created_at, machine_id)
@@ -104,8 +113,8 @@ describe('session cascade journals child deletes via triggers', () => {
     ).run();
     db.prepare(`INSERT INTO agents (id, name, created_at) VALUES ('a1', 'agent-1', 1)`).run();
     db.prepare(
-      `INSERT INTO spores (id, agent_id, session_id, observation_type, content, created_at, machine_id)
-       VALUES ('sp_c1', 'a1', 's1', 'decision', 'c', 1, 'local')`,
+      `INSERT INTO spores (id, agent_id, project_id, session_id, observation_type, content, created_at, machine_id)
+       VALUES ('sp_c1', 'a1', 'proj_x', 's1', 'decision', 'c', 1, 'local')`,
     ).run();
     deleteSessionCascade('s1', SESSION_TOMBSTONE_SOURCE.API_DELETE);
     const deletes = db.prepare(
@@ -120,9 +129,10 @@ describe('session cascade journals child deletes via triggers', () => {
   it('no duplicate outbox rows — each child table appears exactly once', () => {
     const db = getDatabase();
     setTeamSyncEnabled(true, db);
+    markProjectMember(db, 'proj_x');
     db.prepare(
-      `INSERT INTO sessions (id, agent, started_at, created_at, machine_id)
-       VALUES ('s2', 'claude-code', 1, 1, 'local')`,
+      `INSERT INTO sessions (id, agent, project_id, started_at, created_at, machine_id)
+       VALUES ('s2', 'claude-code', 'proj_x', 1, 1, 'local')`,
     ).run();
     db.prepare(
       `INSERT INTO prompt_batches (id, session_id, project_id, created_at, machine_id)
@@ -130,8 +140,8 @@ describe('session cascade journals child deletes via triggers', () => {
     ).run();
     db.prepare(`INSERT INTO agents (id, name, created_at) VALUES ('a2', 'agent-2', 1)`).run();
     db.prepare(
-      `INSERT INTO spores (id, agent_id, session_id, observation_type, content, created_at, machine_id)
-       VALUES ('sp_c2', 'a2', 's2', 'decision', 'c', 1, 'local')`,
+      `INSERT INTO spores (id, agent_id, project_id, session_id, observation_type, content, created_at, machine_id)
+       VALUES ('sp_c2', 'a2', 'proj_x', 's2', 'decision', 'c', 1, 'local')`,
     ).run();
     deleteSessionCascade('s2', SESSION_TOMBSTONE_SOURCE.API_DELETE);
     const sessRows = db.prepare(
@@ -177,6 +187,8 @@ describe('write gate is per-Grove (no singleton bleed)', () => {
     const b = newDb();
     setTeamSyncEnabled(true, a);
     setTeamSyncEnabled(false, b);
+    markProjectMember(a, 'proj_x');
+    markProjectMember(b, 'proj_x');
 
     for (const [db, id] of [[a, 'spA'], [b, 'spB']] as const) {
       db.prepare(

--- a/tests/db/team-outbox-membership-gate.test.ts
+++ b/tests/db/team-outbox-membership-gate.test.ts
@@ -101,4 +101,23 @@ describe('outbox membership gate', () => {
       expect(left).toEqual([1, 4]); // member row + self-row survive
     });
   });
+
+  it('does not re-enqueue non-member rows across repeated backfills (the flood)', () => {
+    withDatabase(db(), () => {
+      setTeamSyncEnabled(true);
+      setProjectSyncMembership([]); // grove owns no member project
+      const conn = getDatabase();
+      for (let i = 0; i < 50; i++) seedSpore(conn, `x${i}`, 'outsider');
+      // Reproduce the original flood loop: backfill, mark every pending row sent
+      // (no route exists, so synced_at on the source row is never set), backfill
+      // again. Without the membership filter each round would re-enqueue all 50
+      // rows (the dedup only checks pending rows), leaving 5 × 50 = 250 rows. The
+      // gate keeps the non-member rows out entirely, so nothing ever enqueues.
+      for (let round = 0; round < 5; round++) {
+        backfillUnsynced('m');
+        conn.prepare('UPDATE team_outbox SET sent_at = 9 WHERE sent_at IS NULL').run();
+      }
+      expect((conn.prepare('SELECT COUNT(*) c FROM team_outbox').get() as { c: number }).c).toBe(0);
+    });
+  });
 });

--- a/tests/db/team-outbox-membership-gate.test.ts
+++ b/tests/db/team-outbox-membership-gate.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Outbox project-membership gate.
+ *
+ * A team-sync outbox row is eligible iff its project_id is an explicit team
+ * member (a row in team_sync_membership). This exercises all three enqueue
+ * paths gated on membership:
+ *   1. syncRow (live write path) skips non-member rows.
+ *   2. backfillRows (startup/unsynced sweep) excludes non-member project rows
+ *      while still carrying machine-scoped (team_members) self-rows.
+ *   3. the AFTER DELETE triggers (gated in Task 1) journal a delete op only for
+ *      member projects.
+ * And purgeNonMemberOutbox self-heals historical bloat without ever touching
+ * machine-scoped self-rows (project_id IS NULL).
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { createSchema } from '@myco/db/schema.js';
+import { withDatabase, getDatabase } from '@myco/db/client.js';
+import { setTeamSyncEnabled, setProjectSyncMembership } from '@myco/db/queries/team-sync-state.js';
+import { syncRow, backfillUnsynced, purgeNonMemberOutbox, countPending } from '@myco/db/queries/team-outbox.js';
+
+function db(): Database {
+  const d = new Database(':memory:');
+  createSchema(d);
+  return d;
+}
+
+function spore(id: string, projectId: string) {
+  // In-memory row object for syncRow (NOT a DB insert) — no NOT-NULL cols needed.
+  return { id, project_id: projectId, content: 'x', created_at: 1 };
+}
+
+// seedSpore(conn, id, projectId): real DB insert — see "Test fixtures & conventions".
+function seedSpore(conn: Database, id: string, projectId: string) {
+  conn.prepare(
+    `INSERT OR IGNORE INTO agents (id, name, source, enabled, created_at) VALUES ('user','user','built-in',1,1)`,
+  ).run();
+  conn.prepare(
+    `INSERT INTO spores (id, project_id, agent_id, observation_type, content, created_at, machine_id)
+     VALUES (?, ?, 'user', 'decision', 'x', 1, 'local')`,
+  ).run(id, projectId);
+}
+
+describe('outbox membership gate', () => {
+  it('syncRow enqueues a member project row and skips a non-member one', () => {
+    withDatabase(db(), () => {
+      setTeamSyncEnabled(true);
+      setProjectSyncMembership(['member']);
+      syncRow('spores', spore('s1', 'member'));
+      syncRow('spores', spore('s2', 'outsider'));
+      expect(countPending()).toBe(1);
+    });
+  });
+
+  it('backfillUnsynced only enqueues rows whose project is a member', () => {
+    withDatabase(db(), () => {
+      setTeamSyncEnabled(true);
+      setProjectSyncMembership(['member']);
+      const conn = getDatabase();
+      seedSpore(conn, 'm1', 'member'); // synced_at NULL
+      seedSpore(conn, 'o1', 'outsider');
+      const n = backfillUnsynced('machine-1');
+      expect(n).toBe(1); // only the member row
+      expect(countPending()).toBe(1);
+    });
+  });
+
+  it('a delete of a non-member project row does NOT enqueue a delete op (trigger gate)', () => {
+    withDatabase(db(), () => {
+      setTeamSyncEnabled(true); // grove participates (mixed)
+      setProjectSyncMembership(['member']);
+      const conn = getDatabase();
+      seedSpore(conn, 'm1', 'member');
+      seedSpore(conn, 'o1', 'outsider');
+      conn.prepare('DELETE FROM team_outbox').run(); // clear inserts
+      conn.prepare(`DELETE FROM spores WHERE id = 'o1'`).run(); // non-member delete
+      expect(countPending()).toBe(0); // trigger suppressed
+      conn.prepare(`DELETE FROM spores WHERE id = 'm1'`).run(); // member delete
+      expect(countPending()).toBe(1); // trigger fired
+    });
+  });
+
+  it('purgeNonMemberOutbox removes sent + pending rows for non-member projects, keeps members and self-rows', () => {
+    withDatabase(db(), () => {
+      const conn = getDatabase();
+      // team_outbox.id is INTEGER PRIMARY KEY AUTOINCREMENT — use integer ids.
+      const ins = conn.prepare(
+        `INSERT INTO team_outbox (id, table_name, row_id, operation, payload, machine_id, project_id, created_at, sent_at)
+         VALUES (?,?,?,?,?,?,?,?,?)`,
+      );
+      ins.run(1, 'spores', '1', 'upsert', '{}', 'm', 'member', 1, null); // member pending
+      ins.run(2, 'spores', '2', 'upsert', '{}', 'm', 'outsider', 1, 5); // non-member SENT
+      ins.run(3, 'spores', '3', 'upsert', '{}', 'm', 'outsider', 1, null); // non-member pending
+      ins.run(4, 'team_members', 'm', 'upsert', '{}', 'm', null, 1, 5); // self-row (project_id NULL)
+      const removed = purgeNonMemberOutbox(['member']);
+      expect(removed).toBe(2);
+      const left = (conn.prepare('SELECT id FROM team_outbox ORDER BY id').all() as Array<{ id: number }>).map(
+        (r) => r.id,
+      );
+      expect(left).toEqual([1, 4]); // member row + self-row survive
+    });
+  });
+});

--- a/tests/db/team-outbox-project-id.test.ts
+++ b/tests/db/team-outbox-project-id.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'bun:test'
 import { Database } from 'bun:sqlite';
 import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
 import { syncRow, listPending, backfillAll } from '@myco/db/queries/team-outbox.js';
-import { setTeamSyncEnabled } from '@myco/db/queries/team-sync-state.js';
+import { setTeamSyncEnabled, setProjectSyncMembership } from '@myco/db/queries/team-sync-state.js';
 import { createSchema, SCHEMA_VERSION } from '@myco/db/schema.js';
 import { getDatabase } from '@myco/db/client.js';
 
@@ -25,6 +25,7 @@ describe('team_outbox.project_id — syncRow plumbing', () => {
 
   it('carries project_id from a project-scoped row into the outbox', () => {
     setTeamSyncEnabled(true);
+    setProjectSyncMembership(['proj_y']);
 
     syncRow('spores', { id: 'spore_x', project_id: 'proj_y', created_at: 1 });
 
@@ -34,16 +35,15 @@ describe('team_outbox.project_id — syncRow plumbing', () => {
     expect(pending[0].project_id).toBe('proj_y');
   });
 
-  it('leaves project_id null for a machine-scoped row (no project_id)', () => {
+  it('does not enqueue a machine-scoped row through syncRow (no project_id)', () => {
     setTeamSyncEnabled(true);
 
-    // team_members is machine-scoped — it has no project_id column.
+    // team_members is machine-scoped — it has no project_id, so the membership
+    // gate (project_id IS NULL → not syncable) skips it. Machine-scoped self-rows
+    // reach the outbox via reconcileSelfMember / backfill, not syncRow.
     syncRow('team_members', { id: 'tm', created_at: 1 });
 
-    const pending = listPending();
-    expect(pending).toHaveLength(1);
-    expect(pending[0].row_id).toBe('tm');
-    expect(pending[0].project_id).toBeNull();
+    expect(listPending()).toHaveLength(0);
   });
 
   it('backfill carries project_id from the source row into the outbox', () => {
@@ -53,6 +53,7 @@ describe('team_outbox.project_id — syncRow plumbing', () => {
     // instead of routing to its owning team.
     const db = getDatabase();
     setTeamSyncEnabled(true, db);
+    setProjectSyncMembership(['proj_bf'], db);
     db.prepare(
       `INSERT OR IGNORE INTO agents (id, name, source, enabled, created_at) VALUES ('user','user','built-in',1,1)`,
     ).run();

--- a/tests/db/team-outbox-project-id.test.ts
+++ b/tests/db/team-outbox-project-id.test.ts
@@ -89,6 +89,7 @@ describe('team_outbox.project_id — v53 schema + delete trigger', () => {
     db.exec('PRAGMA foreign_keys = OFF'); // FK-free fixture insert
     createSchema(db);
     setTeamSyncEnabled(true, db);
+    db.prepare(`INSERT OR IGNORE INTO team_sync_membership (project_id) VALUES ('proj_del')`).run();
 
     // Insert a project-scoped spore, then delete it. The recreated team-sync
     // delete trigger must journal a 'delete' row into team_outbox carrying the
@@ -167,6 +168,7 @@ describe('team_outbox.project_id — v53 schema + delete trigger', () => {
 
     // (b) the trigger now captures project_id through a real delete.
     setTeamSyncEnabled(true, db);
+    db.prepare(`INSERT OR IGNORE INTO team_sync_membership (project_id) VALUES ('proj_mig')`).run();
     db.prepare(`
       INSERT INTO spores (id, project_id, agent_id, observation_type, content, created_at, machine_id)
       VALUES ('sp_mig', 'proj_mig', 'agent-x', 'note', 'gone', 1000, 'local')

--- a/tests/db/team-sync-membership.test.ts
+++ b/tests/db/team-sync-membership.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { createSchema, SCHEMA_VERSION } from '@myco/db/schema.js';
+
+function freshDb(): Database {
+  const db = new Database(':memory:');
+  createSchema(db);
+  return db;
+}
+
+describe('team_sync_membership schema', () => {
+  it('SCHEMA_VERSION is at least 62', () => {
+    expect(SCHEMA_VERSION).toBeGreaterThanOrEqual(62);
+  });
+
+  it('fresh install creates team_sync_membership with a project_id PK', () => {
+    const db = freshDb();
+    const cols = db.prepare(`PRAGMA table_info(team_sync_membership)`).all() as Array<{
+      name: string;
+      pk: number;
+    }>;
+    const names = cols.map((c) => c.name);
+    expect(names).toContain('project_id');
+    expect(cols.find((c) => c.name === 'project_id')?.pk).toBe(1);
+  });
+
+  it('fresh install gates delete triggers on membership', () => {
+    const db = freshDb();
+    const trigger = db
+      .prepare(`SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'spores_team_ad'`)
+      .get() as { sql: string } | undefined;
+    expect(trigger).toBeDefined();
+    expect(trigger?.sql).toContain('OLD.project_id IN (SELECT project_id FROM team_sync_membership)');
+  });
+
+  it('upgrade from a pre-61 DB adds the table without data loss', () => {
+    const db = new Database(':memory:');
+    createSchema(db);
+    db.exec('DROP TABLE team_sync_membership');
+    db.exec('DELETE FROM schema_version');
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (60, 0)').run();
+    db.prepare(
+      `INSERT OR IGNORE INTO agents (id, name, source, enabled, created_at) VALUES ('user','user','built-in',1,1)`,
+    ).run();
+    db.prepare(
+      `INSERT INTO spores (id, project_id, agent_id, observation_type, content, created_at, machine_id) VALUES ('s1','p1','user','decision','x',1,'local')`,
+    ).run();
+    createSchema(db);
+    expect(db.prepare(`SELECT COUNT(*) c FROM team_sync_membership`).get()).toEqual({ c: 0 });
+    expect((db.prepare(`SELECT COUNT(*) c FROM spores`).get() as { c: number }).c).toBe(1);
+  });
+
+  it('upgrade recreates delete triggers with the membership-aware WHEN clause', () => {
+    const db = new Database(':memory:');
+    createSchema(db);
+    db.exec('DROP TABLE team_sync_membership');
+    db.exec('DELETE FROM schema_version');
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (60, 0)').run();
+    db.exec('DROP TRIGGER IF EXISTS spores_team_ad');
+    db.exec(`
+      CREATE TRIGGER spores_team_ad
+      AFTER DELETE ON spores
+      WHEN (SELECT enabled FROM team_sync_state) = 1
+      BEGIN
+        INSERT INTO team_outbox (table_name, row_id, operation, payload, machine_id, project_id, created_at)
+        VALUES ('spores', CAST(OLD.id AS TEXT), 'delete',
+                json_object('id', OLD.id, 'machine_id', OLD.machine_id),
+                OLD.machine_id, OLD.project_id, CAST(strftime('%s','now') AS INTEGER));
+      END`);
+    createSchema(db);
+    const trigger = db
+      .prepare(`SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'spores_team_ad'`)
+      .get() as { sql: string } | undefined;
+    expect(trigger?.sql).toContain('OLD.project_id IN (SELECT project_id FROM team_sync_membership)');
+  });
+});

--- a/tests/db/team-sync-membership.test.ts
+++ b/tests/db/team-sync-membership.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { createSchema, SCHEMA_VERSION } from '@myco/db/schema.js';
+import { withDatabase } from '@myco/db/client.js';
+import {
+  setProjectSyncMembership,
+  getSyncableProjectIds,
+  isProjectSyncable,
+} from '@myco/db/queries/team-sync-state.js';
 
 function freshDb(): Database {
   const db = new Database(':memory:');
@@ -72,5 +78,25 @@ describe('team_sync_membership schema', () => {
       .prepare(`SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'spores_team_ad'`)
       .get() as { sql: string } | undefined;
     expect(trigger?.sql).toContain('OLD.project_id IN (SELECT project_id FROM team_sync_membership)');
+  });
+});
+
+describe('team_sync_membership accessors', () => {
+  it('replaces the membership set and answers membership queries', () => {
+    const db = freshDb();
+    withDatabase(db, () => {
+      setProjectSyncMembership(['p1', 'p2']);
+      expect(new Set(getSyncableProjectIds())).toEqual(new Set(['p1', 'p2']));
+      expect(isProjectSyncable('p1')).toBe(true);
+      expect(isProjectSyncable('p3')).toBe(false);
+      expect(isProjectSyncable(null)).toBe(false);
+
+      setProjectSyncMembership(['p2']);
+      expect(getSyncableProjectIds()).toEqual(['p2']);
+      expect(isProjectSyncable('p1')).toBe(false);
+
+      setProjectSyncMembership([]);
+      expect(getSyncableProjectIds()).toEqual([]);
+    });
   });
 });

--- a/tests/grove/project-tenancy.test.ts
+++ b/tests/grove/project-tenancy.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  assertAssignableProject,
+  machineHasAnyTeam,
+  memberProjectIdsForGrove,
+  ProjectGroveMissingError,
+  resolveProjectTenancy,
+} from '@myco/grove/project-tenancy.js';
+import {
+  clearGroveRegistryCaches,
+  createGrove,
+  registerProjectInGrove,
+} from '@myco/grove/registry.js';
+import { createTeamId } from '@myco/grove/ids.js';
+import { teamRegistry, type TeamRecord } from '@myco/team/registry.js';
+
+let home: string;
+let prevHome: string | undefined;
+const projectRoots: string[] = [];
+
+function makeProjectRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-tenancy-proj-'));
+  projectRoots.push(root);
+  return root;
+}
+
+function saveTeam(projects: Array<{ grove_id: string; project_id: string }>): string {
+  const teamId = createTeamId();
+  const record: TeamRecord = {
+    team_id: teamId,
+    name: teamId,
+    worker_url: 'https://example.invalid',
+    domain: null,
+    mcp_endpoint: null,
+    created_at: new Date(0).toISOString(),
+    projects,
+  };
+  teamRegistry.save(record, home);
+  return teamId;
+}
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-tenancy-home-'));
+  prevHome = process.env.MYCO_HOME;
+  process.env.MYCO_HOME = home;
+  clearGroveRegistryCaches();
+});
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.MYCO_HOME;
+  else process.env.MYCO_HOME = prevHome;
+  fs.rmSync(home, { recursive: true, force: true });
+  for (const root of projectRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  clearGroveRegistryCaches();
+});
+
+describe('project tenancy authority', () => {
+  it('resolves a project to its (non-optional) grove and team membership', () => {
+    const grove = createGrove('G', home);
+    const projectRoot = makeProjectRoot();
+    registerProjectInGrove(
+      grove.id,
+      { projectId: 'P', projectName: 'P', projectRoot },
+      home,
+    );
+    const teamId = saveTeam([{ grove_id: grove.id, project_id: 'P' }]);
+
+    const t = resolveProjectTenancy('P');
+    expect(t.grove.id).toBe(grove.id);
+    expect(t.project.project_id).toBe('P');
+    expect(t.team?.team_id).toBe(teamId);
+  });
+
+  it('returns team=null for a project in no team', () => {
+    const grove = createGrove('G', home);
+    const projectRoot = makeProjectRoot();
+    registerProjectInGrove(
+      grove.id,
+      { projectId: 'P-unassigned', projectName: 'P-unassigned', projectRoot },
+      home,
+    );
+
+    const t = resolveProjectTenancy('P-unassigned');
+    expect(t.team).toBeNull();
+    expect(t.grove).toBeDefined();
+    expect(t.grove.id).toBe(grove.id);
+  });
+
+  it('throws ProjectGroveMissingError for a project with no resolvable grove', () => {
+    createGrove('G', home);
+    expect(() => resolveProjectTenancy('ghost')).toThrow(ProjectGroveMissingError);
+  });
+
+  it("memberProjectIdsForGrove returns only this grove's team-member projects", () => {
+    const grove = createGrove('G', home);
+    const projectRoot = makeProjectRoot();
+    registerProjectInGrove(
+      grove.id,
+      { projectId: 'P', projectName: 'P', projectRoot },
+      home,
+    );
+    const otherGrove = createGrove('Other', home);
+    const otherRoot = makeProjectRoot();
+    registerProjectInGrove(
+      otherGrove.id,
+      { projectId: 'P-other', projectName: 'P-other', projectRoot: otherRoot },
+      home,
+    );
+    // P (in grove G) and P-other (in otherGrove) both belong to one team.
+    saveTeam([
+      { grove_id: grove.id, project_id: 'P' },
+      { grove_id: otherGrove.id, project_id: 'P-other' },
+    ]);
+
+    expect(new Set(memberProjectIdsForGrove(grove.id))).toEqual(new Set(['P']));
+    // A grove with no team-member projects returns [].
+    const emptyGrove = createGrove('Empty', home);
+    expect(memberProjectIdsForGrove(emptyGrove.id)).toEqual([]);
+    expect(memberProjectIdsForGrove(null)).toEqual([]);
+  });
+
+  it('machineHasAnyTeam reflects whether any team is registered', () => {
+    expect(machineHasAnyTeam()).toBe(false);
+    saveTeam([]);
+    expect(machineHasAnyTeam()).toBe(true);
+  });
+
+  it('assertAssignableProject accepts a grove-bound project and rejects a grove-less one', () => {
+    const grove = createGrove('G', home);
+    const projectRoot = makeProjectRoot();
+    registerProjectInGrove(
+      grove.id,
+      { projectId: 'P', projectName: 'P', projectRoot },
+      home,
+    );
+
+    expect(() => assertAssignableProject('P')).not.toThrow();
+    expect(() => assertAssignableProject('ghost')).toThrow(ProjectGroveMissingError);
+  });
+});

--- a/tests/grove/tenancy-no-ad-hoc-derivation.test.ts
+++ b/tests/grove/tenancy-no-ad-hoc-derivation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Modules routed through `grove/project-tenancy.ts`. They must NOT re-derive
+ * tenancy ad-hoc; project-tenancy.ts is the authority and is intentionally
+ * excluded from this guard (it owns the raw `teamRegistry` reads).
+ */
+const GUARDED = [
+  'packages/myco/src/db/queries/team-outbox.ts',
+  'packages/myco/src/daemon/team-sync-init.ts',
+];
+
+const FORBIDDEN = [
+  /teamRegistry\.list\(\)\s*\.\s*flatMap/,
+  /joinedAnyTeam\s*=\s*teamRegistry\.list\(\)\.length/,
+];
+
+function findRepoRoot(start: string): string {
+  let dir = start;
+  for (let i = 0; i < 20; i += 1) {
+    if (fs.existsSync(path.join(dir, 'package.json'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(`Could not locate repo root (no package.json) walking up from ${start}`);
+}
+
+const REPO_ROOT = findRepoRoot(import.meta.dir);
+
+describe('tenancy: guarded modules route through the authority', () => {
+  for (const file of GUARDED) {
+    it(`${file} exists, is non-empty, and has no ad-hoc tenancy derivation`, () => {
+      const abs = path.join(REPO_ROOT, file);
+      expect(fs.existsSync(abs)).toBe(true);
+      const src = fs.readFileSync(abs, 'utf8');
+      expect(src.length).toBeGreaterThan(0);
+      for (const re of FORBIDDEN) {
+        expect(re.test(src)).toBe(false);
+      }
+    });
+  }
+});

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -44,6 +44,7 @@ const DELETE_TABLES = [
   'team_members',
   'team_outbox',
   'team_sync_state',
+  'team_sync_membership',
   'notifications',
   'session_tombstones',
   'sessions',

--- a/tests/ui/scope-for-path.test.ts
+++ b/tests/ui/scope-for-path.test.ts
@@ -9,12 +9,19 @@ describe('scopeForPath', () => {
   it('classifies grove-scoped routes', () => {
     expect(scopeForPath('/g/default/operations')).toBe('grove');
     expect(scopeForPath('/g/default/dashboard')).toBe('grove');
-    expect(scopeForPath('/g/default/team')).toBe('grove');
   });
   it('classifies machine-scoped routes', () => {
     expect(scopeForPath('/settings')).toBe('machine');
     expect(scopeForPath('/logs')).toBe('machine');
     expect(scopeForPath('/groves')).toBe('machine');
     expect(scopeForPath('/')).toBe('machine');
+  });
+  it('classifies the Team page as machine-wide despite its grove-bound route', () => {
+    expect(scopeForPath('/g/default/team')).toBe('machine');
+    expect(scopeForPath('/g/default/team?tab=sync')).toBe('machine');
+  });
+  it('still classifies a normal grove page as grove and a project page as project', () => {
+    expect(scopeForPath('/g/default')).toBe('grove');
+    expect(scopeForPath('/g/default/p/myco/sessions')).toBe('project');
   });
 });

--- a/tests/ui/team-page-default-team.test.tsx
+++ b/tests/ui/team-page-default-team.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'bun:test';
+import { resolveDefaultSelectedTeamId } from '../../packages/myco/ui/src/pages/Team/select-default';
+
+describe('Team page default team selection', () => {
+  it('returns the URL team param when present', () => {
+    expect(resolveDefaultSelectedTeamId('t-url', [{ team_id: 't1' }, { team_id: 't2' }])).toBe('t-url');
+  });
+  it('returns undefined (no auto-pick) when no URL param, instead of teams[0]', () => {
+    expect(resolveDefaultSelectedTeamId(null, [{ team_id: 't1' }, { team_id: 't2' }])).toBeUndefined();
+  });
+  it('returns undefined when no URL param and no teams', () => {
+    expect(resolveDefaultSelectedTeamId(null, [])).toBeUndefined();
+  });
+});

--- a/tests/ui/team-page-default-team.test.tsx
+++ b/tests/ui/team-page-default-team.test.tsx
@@ -1,14 +1,26 @@
 import { describe, expect, it } from 'bun:test';
 import { resolveDefaultSelectedTeamId } from '../../packages/myco/ui/src/pages/Team/select-default';
 
+const TEAMS = [{ team_id: 't1' }, { team_id: 't2' }];
+
 describe('Team page default team selection', () => {
-  it('returns the URL team param when present', () => {
-    expect(resolveDefaultSelectedTeamId('t-url', [{ team_id: 't1' }, { team_id: 't2' }])).toBe('t-url');
+  it('honors the URL team param when it is a registered team', () => {
+    expect(resolveDefaultSelectedTeamId('t2', TEAMS)).toBe('t2');
   });
-  it('returns undefined (no auto-pick) when no URL param, instead of teams[0]', () => {
-    expect(resolveDefaultSelectedTeamId(null, [{ team_id: 't1' }, { team_id: 't2' }])).toBeUndefined();
+  it('auto-selects the first team when there is no URL param or stored selection', () => {
+    expect(resolveDefaultSelectedTeamId(null, TEAMS)).toBe('t1');
   });
-  it('returns undefined when no URL param and no teams', () => {
+  it('honors a persisted selection over the first team', () => {
+    expect(resolveDefaultSelectedTeamId(null, TEAMS, 't2')).toBe('t2');
+  });
+  it('URL param takes priority over the persisted selection', () => {
+    expect(resolveDefaultSelectedTeamId('t1', TEAMS, 't2')).toBe('t1');
+  });
+  it('falls through a stale URL/stored id to the first team', () => {
+    expect(resolveDefaultSelectedTeamId('gone', TEAMS, 'also-gone')).toBe('t1');
+  });
+  it('returns undefined only when there are no teams', () => {
     expect(resolveDefaultSelectedTeamId(null, [])).toBeUndefined();
+    expect(resolveDefaultSelectedTeamId('x', [], 'y')).toBeUndefined();
   });
 });

--- a/tests/ui/team-tabs.test.tsx
+++ b/tests/ui/team-tabs.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { describe, it, expect, mock } from 'bun:test';
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Navigate, Route, Routes, useParams } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -145,6 +145,10 @@ function wrapWithRoutes(initial: string) {
 }
 
 describe('TeamPage tabs', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    lastStatusTeamId = undefined;
+  });
   it('renders the Teams selection tab by default', async () => {
     render(wrap('/g/foo/team'));
     await waitFor(() => expect(screen.getByText('Registered teams')).toBeInTheDocument());
@@ -171,33 +175,38 @@ describe('TeamPage tabs', () => {
     const lastReceived = screen.queryAllByText(/last received/);
     expect(lastReceived).toHaveLength(1);
   });
-  it('shows the select-a-team empty state on a team-scoped tab when no team is chosen', async () => {
+  it('auto-selects the first team on a team-scoped tab when none is chosen', async () => {
     render(wrap('/g/foo/team?tab=sync'));
-    await waitFor(() => expect(screen.getByText(/Select a team to view sync status/i)).toBeInTheDocument());
-    // The team-scoped content must NOT render against an arbitrary team.
-    expect(screen.queryByText(/Remote store/i)).not.toBeInTheDocument();
+    // No ?team= → the first team is auto-selected and its status is fetched;
+    // the empty state is NOT shown.
+    await waitFor(() => expect(lastStatusTeamId).toBe('team_a'));
+    expect(screen.queryByText(/Select a team to view sync status/i)).not.toBeInTheDocument();
   });
-  it('does not fetch a per-team status when no team is selected', async () => {
-    lastStatusTeamId = 'sentinel';
-    render(wrap('/g/foo/team?tab=sync'));
-    await waitFor(() => expect(screen.getByText(/Select a team to view sync status/i)).toBeInTheDocument());
-    // useTeamStatus is called with undefined (ambient context), never an
-    // auto-picked teams[0] — the regression that produced the phantom delta.
-    expect(lastStatusTeamId).toBeUndefined();
+  it('fetches status for the auto-selected first team', async () => {
+    render(wrap('/g/foo/team?tab=status'));
+    await waitFor(() => expect(lastStatusTeamId).toBe('team_a'));
   });
-  it('redirects /team/maintenance → /team?tab=sync (empty state, no auto-selected team)', async () => {
+  it('redirects /team/maintenance → /team?tab=sync with the first team auto-selected', async () => {
     render(wrapWithRoutes('/g/foo/team/maintenance'));
-    // The redirect lands on the Sync tab with no team selected, so the
-    // select-a-team empty state is shown rather than an arbitrary team's delta.
-    await waitFor(() => expect(screen.getByText(/Select a team to view sync status/i)).toBeInTheDocument());
+    // The redirect lands on the Sync tab; the first team is auto-selected.
+    await waitFor(() => expect(lastStatusTeamId).toBe('team_a'));
   });
-  it('does not auto-select a team; honors an explicit selection', async () => {
+  it('auto-selects the first team and honors an explicit change', async () => {
     render(wrap('/g/foo/team?tab=status'));
     const selector = await screen.findByLabelText('Selected team');
-    // No ?team= → nothing auto-picked (the bug was defaulting to teams[0]).
-    expect((selector as HTMLSelectElement).value).toBe('');
-    expect(lastStatusTeamId).toBeUndefined();
+    // No ?team= → first team auto-selected (populated, not an empty state).
+    expect((selector as HTMLSelectElement).value).toBe('team_a');
+    await waitFor(() => expect(lastStatusTeamId).toBe('team_a'));
     fireEvent.change(selector, { target: { value: 'team_b' } });
+    await waitFor(() => expect(lastStatusTeamId).toBe('team_b'));
+    // The explicit choice persists for the next visit within the section.
+    expect(window.localStorage.getItem('myco.team.selectedTeamId')).toBe('team_b');
+  });
+  it('restores the persisted selection over the first team', async () => {
+    window.localStorage.setItem('myco.team.selectedTeamId', 'team_b');
+    render(wrap('/g/foo/team?tab=status'));
+    const selector = await screen.findByLabelText('Selected team');
+    expect((selector as HTMLSelectElement).value).toBe('team_b');
     await waitFor(() => expect(lastStatusTeamId).toBe('team_b'));
   });
 });

--- a/tests/ui/team-tabs.test.tsx
+++ b/tests/ui/team-tabs.test.tsx
@@ -150,38 +150,53 @@ describe('TeamPage tabs', () => {
     await waitFor(() => expect(screen.getByText('Registered teams')).toBeInTheDocument());
     expect(screen.getByText('Team A')).toBeInTheDocument();
   });
-  it('renders Status tab when ?tab=status', async () => {
-    render(wrap('/g/foo/team?tab=status'));
+  it('renders Status tab when a team is selected (?tab=status&team=)', async () => {
+    render(wrap('/g/foo/team?tab=status&team=team_a'));
     await waitFor(() => expect(screen.getByText(/Team Credentials/i)).toBeInTheDocument());
   });
-  it('renders Sync tab when ?tab=sync', async () => {
-    render(wrap('/g/foo/team?tab=sync'));
+  it('renders Sync tab when a team is selected (?tab=sync&team=)', async () => {
+    render(wrap('/g/foo/team?tab=sync&team=team_a'));
     await waitFor(() => expect(screen.getByText(/Remote store/i)).toBeInTheDocument());
   });
-  it('renders Members roster when ?tab=members', async () => {
-    render(wrap('/g/foo/team?tab=members'));
+  it('renders Members roster when a team is selected (?tab=members&team=)', async () => {
+    render(wrap('/g/foo/team?tab=members&team=team_a'));
     await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
     expect(screen.getByText('owner')).toBeInTheDocument();
     expect(screen.getByText('machine-1')).toBeInTheDocument();
   });
   it('flags the local machine and hides the inbound-sync chip for self', async () => {
-    render(wrap('/g/foo/team?tab=members'));
+    render(wrap('/g/foo/team?tab=members&team=team_a'));
     await waitFor(() => expect(screen.getByText('this machine')).toBeInTheDocument());
     // Peer row still shows "last received <ago>"; self row must not.
     const lastReceived = screen.queryAllByText(/last received/);
     expect(lastReceived).toHaveLength(1);
   });
-  it('redirects /team/maintenance → /team?tab=sync', async () => {
-    render(wrapWithRoutes('/g/foo/team/maintenance'));
-    // After the redirect resolves, the Sync tab body is mounted —
-    // assert on its "Remote store" section header.
-    await waitFor(() => expect(screen.getByText(/Remote store/i)).toBeInTheDocument());
+  it('shows the select-a-team empty state on a team-scoped tab when no team is chosen', async () => {
+    render(wrap('/g/foo/team?tab=sync'));
+    await waitFor(() => expect(screen.getByText(/Select a team to view sync status/i)).toBeInTheDocument());
+    // The team-scoped content must NOT render against an arbitrary team.
+    expect(screen.queryByText(/Remote store/i)).not.toBeInTheDocument();
   });
-  it('renders a team selector that scopes status to the selected team', async () => {
+  it('does not fetch a per-team status when no team is selected', async () => {
+    lastStatusTeamId = 'sentinel';
+    render(wrap('/g/foo/team?tab=sync'));
+    await waitFor(() => expect(screen.getByText(/Select a team to view sync status/i)).toBeInTheDocument());
+    // useTeamStatus is called with undefined (ambient context), never an
+    // auto-picked teams[0] — the regression that produced the phantom delta.
+    expect(lastStatusTeamId).toBeUndefined();
+  });
+  it('redirects /team/maintenance → /team?tab=sync (empty state, no auto-selected team)', async () => {
+    render(wrapWithRoutes('/g/foo/team/maintenance'));
+    // The redirect lands on the Sync tab with no team selected, so the
+    // select-a-team empty state is shown rather than an arbitrary team's delta.
+    await waitFor(() => expect(screen.getByText(/Select a team to view sync status/i)).toBeInTheDocument());
+  });
+  it('does not auto-select a team; honors an explicit selection', async () => {
     render(wrap('/g/foo/team?tab=status'));
     const selector = await screen.findByLabelText('Selected team');
-    expect((selector as HTMLSelectElement).value).toBe('team_a');
-    expect(lastStatusTeamId).toBe('team_a');
+    // No ?team= → nothing auto-picked (the bug was defaulting to teams[0]).
+    expect((selector as HTMLSelectElement).value).toBe('');
+    expect(lastStatusTeamId).toBeUndefined();
     fireEvent.change(selector, { target: { value: 'team_b' } });
     await waitFor(() => expect(lastStatusTeamId).toBe('team_b'));
   });


### PR DESCRIPTION
## Problem

A tenancy leak flooded a **non-member** grove's `team_outbox` with 1.45M+ rows. `reconcileClient` gated backfill on machine-level `joinedAnyTeam` instead of **per-project membership**, so a grove with zero team-member projects backfilled its unsynced rows, couldn't route them (no team owns those projects), marked them sent, and re-backfilled — a 158× re-enqueue loop (`Backfilled 9158 unsynced records`). On the prod **Default** grove this reached **1,712,424** rows despite `team_sync_state.enabled=0` and no project assigned to any team. It also surfaced a phantom Team-page delta from comparing an unrelated team's cloud against the ambient grove.

## Fix — tenancy as a single authority, enforced at the write path

- **`grove/project-tenancy.ts`** (new authority): `resolveProjectTenancy(projectId)` (grove non-optional), `memberProjectIdsForGrove`, `machineHasAnyTeam`, `assertAssignableProject`. Tenancy is resolved once, not re-derived ad hoc. Every line this PR touches routes through it; a follow-up sweeps the rest of the package.
- **`team_sync_membership`** (schema **v62**): reconciled per-grove projection of the authority's membership — the hot-path gate.
- **`isProjectSyncable`** gate on `syncRow`, `backfillRows` (project-scoped tables), **and** the team delete-triggers — non-member project rows never enter the outbox. (`team_members` self-rows are machine-scoped and exempt.)
- **`purgeNonMemberOutbox`**: clears sent **and** pending non-member rows, self-healing historical bloat. Runs in `reconcileClient`, the per-tick `flushPending`, `reconcileAllGroveFlags` (boot critical path), and the immediate assign/remove route reconcile — so every served grove self-corrects regardless of entry point.
- **UI**: Team page declares `machine` scope (pill reads **MACHINE-WIDE**, not GROVE-WIDE); auto-selects + persists the first team instead of an empty state / phantom cross-store delta.

## Live validation — `dogfood-grove-claim` against the real prod grove

Claimed the production **Default** grove (2.9GB, **1,712,424** outbox rows, schema 60, non-member) under the dev daemon:

- Migration **60 → 62** ran cleanly on production-scale data.
- `team_sync_membership` created and correctly **empty** (non-member grove).
- Purge cleared the flood: **1,712,424 → 0**.
- A steady-state `team-sync-flush` cycle ran `backfillUnsynced` over the grove with **no re-flood** (stayed 0); zero `Backfilled N` lines — the 158× loop is dead.
- Legitimate team sync intact (dogfood grove: 1 member, flush `count=5 accepted=5`).
- Released → prod restored byte-for-byte (schema 60, 1.71M rows, `served_by=service`).

## Tests

- Regression test reproduces the exact 158× re-enqueue loop and proves the gate kills it.
- Structural guard against ad-hoc tenancy derivation (asserts `syncRow`/`backfillRows` route through the gate).
- Full suite green: **16,241 tests, 0 failures** across node + jsdom phases (JUnit-verified).

## Follow-ups (separate plans)

- Tenancy-authority full package sweep — route all remaining sites through `resolveProjectTenancy`.
- Task 8: served-by labels + team-scoped Sync-tab local computation (display correctness; not required to stop the flood).

## Notes

- Commit `13177a1f`'s subject says "schema v61"; the code is correctly **v62** (renumbered after rebasing over main's own v61). Cosmetic.
- Includes a small `dogfood-worktree` skill-doc correction (`a0b400ad`) that came out of this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
