### PR TITLE
fix(symbionts): idempotent MCP config writes + operator-driven subsystem-claim ownership

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -49,7 +49,7 @@
       "@id": "https://myco.sh/#software",
       "name": "Myco",
       "applicationCategory": "DeveloperApplication",
-      "operatingSystem": "macOS",
+      "operatingSystem": "macOS, Linux, Windows",
       "url": "https://myco.sh/",
       "downloadUrl": "https://www.npmjs.com/package/@goondocks/myco",
       "installUrl": "https://myco.sh/install.sh",
@@ -130,7 +130,7 @@
       <a class="btn btn-outline btn-lg" href="https://github.com/goondocks-co/myco" target="_blank" rel="noopener">View on GitHub</a>
     </div>
     <div class="hero-meta">
-      <span><span class="k">Augments</span> Claude Code · Cursor · Codex · Copilot · Antigravity · Windsurf · OpenCode · Pi</span>
+      <span><span class="k">Augments</span> Claude Code · Cursor · Codex · Copilot · Antigravity · Devin Desktop · OpenCode · Pi</span>
     </div>
   </div>
 
@@ -175,15 +175,13 @@
               <span class="line"><span class="prompt">$</span><span class="cmd">curl</span> <span class="flag">-fsSL</span> <span class="str">https://myco.sh/install.sh</span> | <span class="cmd">sh</span></span>
               <span class="blank"></span>
               <span class="line"><span class="out-ok">✓</span> <span class="out">installed @goondocks/myco</span></span>
-              <span class="line"><span class="out-ok">✓</span> <span class="out">local service started</span></span>
               <span class="blank"></span>
-              <span class="line"><span class="out">agents connected:</span></span>
-              <span class="indent"><span class="out-ok">✓</span> <span class="out">claude-code</span> <span class="comment">(context, tools, skills)</span></span>
-              <span class="indent"><span class="out-ok">✓</span> <span class="out">cursor</span>      <span class="comment">(context, skills)</span></span>
-              <span class="indent"><span class="out-warn">·</span> <span class="out">codex</span>       <span class="comment">(detected)</span></span>
+              <span class="line"><span class="out">The local service is starting, and your coding agents</span></span>
+              <span class="line"><span class="out">are being connected to Myco.</span></span>
+              <span class="line"><span class="comment"># git projects register automatically as agents work</span></span>
               <span class="blank"></span>
-              <span class="line"><span class="out-ok">✓</span> <span class="out">dashboard ready —</span> <span class="cmd">http://localhost:20915/</span><span class="caret"></span></span>
-              <span class="line"><span class="comment"># projects register automatically as agents work</span></span>
+              <span class="line"><span class="prompt">$</span><span class="cmd">myco</span> open<span class="caret"></span></span>
+              <span class="line"><span class="out">http://localhost:20915/</span></span>
             </div>
           </div>
         </div>
@@ -245,8 +243,8 @@
 
       <div class="install-next">
         <span class="n">Requires</span>
-        <span class="txt">Node <code>22+</code>, macOS for the supported path, and at least one supported coding agent.</span>
-        <span style="margin-left:auto;"><a class="arrow-link" href="#docs">Quickstart</a></span>
+        <span class="txt">Node <code>22+</code> (the installer uses npm), macOS for the supported path, and at least one supported coding agent.</span>
+        <span style="margin-left:auto;"><a class="arrow-link" href="/quickstart">Quickstart</a></span>
       </div>
     </div>
   </div>
@@ -298,7 +296,7 @@
           <span class="feature-kicker">03 · Connect</span>
         </div>
         <h3>A shared nervous system across the team.</h3>
-        <p>Each teammate's Grove knowledge synchronizes through a Cloudflare-backed worker. Secure Cloud MCP exposes that synced knowledge to managed agents beyond your laptop.</p>
+        <p>Each teammate's project knowledge synchronizes through a Cloudflare-backed worker. Secure Cloud MCP exposes that synced knowledge to managed agents beyond your laptop.</p>
         <div class="feature-meta">
           <span class="tag">team sync</span>
           <span class="tag">cloud mcp</span>
@@ -315,8 +313,8 @@
     <div class="showcase">
       <div class="showcase-copy">
         <span class="eyebrow">Local dashboard</span>
-        <h2 class="sec-title" style="margin-top: 16px;">A quiet command deck for your <em>Grove</em>.</h2>
-        <p class="sec-lede">Myco ships a local web dashboard. Configure providers, manage Groves and projects, approve skill candidates, review sessions, and watch Myco work — all on <code style="font-family:var(--font-data); color: var(--sage);">localhost</code>, all yours.</p>
+        <h2 class="sec-title" style="margin-top: 16px;">The local home for <em>everything Myco knows</em>.</h2>
+        <p class="sec-lede">The dashboard is how you work with Myco day to day. Configure providers and per-task models, manage projects and Groves, approve skill candidates, browse sessions and the project map, and watch the intelligence pipeline run — all on <code style="font-family:var(--font-data); color: var(--sage);">localhost</code>, all yours, no account required.</p>
 
         <ul class="showcase-bullets">
           <li>
@@ -373,7 +371,7 @@
           <div class="life-label"><span>Step 01</span><span class="actor">Agent</span></div>
           <h3>Survey</h3>
         <p>The agent harness scans spores, sessions, and plans for procedural patterns with cross-session evidence. One-off observations don't qualify.</p>
-          <div class="life-tag"><code>myco:survey</code><span class="n">≥ 0.7 conf</span></div>
+          <div class="life-tag"><code>myco:survey</code><span class="n">≥ 0.7 quality</span></div>
         </article>
 
         <article class="life-step ochre">
@@ -434,14 +432,14 @@
     <div class="canopy-grid">
       <div class="canopy-copy">
         <span class="eyebrow">Cortex</span>
-        <h2 class="sec-title" style="margin-top: 16px;">Project context, instructions, and a map of your code.</h2>
-        <p class="sec-lede">Cortex is Myco's synthesis layer: the place where accumulated Grove knowledge becomes project context your agent can use — an operating brief, relevant memory, and a living map of the codebase your agent can navigate before opening a single file.</p>
+        <h2 class="sec-title" style="margin-top: 16px;">A briefing, a digest, and a <em>living map of your code</em>.</h2>
+        <p class="sec-lede">Cortex is Myco's synthesis layer — where accumulated project knowledge becomes context your agent can use. At session start it hands the agent a short project briefing; on demand it serves a deeper project digest; and Canopy keeps a living map of your codebase the agent can navigate before opening a single file.</p>
 
         <ul class="canopy-bullets">
-          <li><span class="mark">✓</span><span><strong>Project briefing, written for this project</strong> — generated from your spores, sessions, and plans. Surfaced at session start so agents arrive oriented, refreshed as the project evolves.</span></li>
-          <li><span class="mark">✓</span><span><strong>File anatomy before agents read</strong> — Canopy surfaces exports, imports, and the top comment before a file opens, helping agents choose the right file faster.</span></li>
-          <li><span class="mark">✓</span><span><strong>Project map + behavior search</strong> — agents can ask for the directory shape, golden paths, or files by what they <em>do</em>, not just what they're named.</span></li>
-          <li><span class="mark">✓</span><span><strong>Cortex command deck</strong> — the dashboard tab where you read the brief, browse the index, regenerate the map, and watch token savings tick up.</span></li>
+          <li><span class="mark">✓</span><span><strong>Session-start briefing</strong> — every session opens with a short brief on the stack, conventions, active work, and recent decisions — written from your spores, sessions, and plans, refreshed as the project evolves — so agents arrive oriented.</span></li>
+          <li><span class="mark">✓</span><span><strong>A project digest for deep work</strong> — a fuller, multi-tier digest the agent pulls (or has injected) before a big refactor or unfamiliar change: the high-fidelity story of how the project got here. Myco's own intelligence pipeline draws on it too.</span></li>
+          <li><span class="mark">✓</span><span><strong>Canopy — code intelligence</strong> — Canopy indexes every file's anatomy (exports, imports, the top comment) before a read, synthesizes a navigable project map, and lets agents search by what code <em>does</em>, not just what it's named — so they read fewer files and spend fewer tokens.</span></li>
+          <li><span class="mark">✓</span><span><strong>The Cortex dashboard</strong> — read the briefing, browse the digest tiers, explore the Canopy index and map, regenerate any of them, and watch the tokens Canopy saves add up.</span></li>
         </ul>
 
         <div style="margin-top: 28px; display:flex; gap: 14px;">
@@ -452,13 +450,13 @@
 
       <div class="canopy-frame">
         <span class="diag-label">Cortex</span>
-        <span class="diag-meta">brief · canopy · search</span>
+        <span class="diag-meta">briefing · digest · canopy</span>
 
         <div class="canopy-card sage">
           <div class="canopy-card-head">
             <span class="canopy-mark">01</span>
             <div>
-              <div class="canopy-card-name">Operating brief</div>
+              <div class="canopy-card-name">Session briefing</div>
               <div class="canopy-card-sub">Session start · auto-written</div>
             </div>
           </div>
@@ -475,7 +473,7 @@
           <div class="canopy-card-head">
             <span class="canopy-mark">02</span>
             <div>
-              <div class="canopy-card-name">File anatomy</div>
+              <div class="canopy-card-name">Canopy · file anatomy</div>
               <div class="canopy-card-sub">before agent reads</div>
             </div>
           </div>
@@ -491,7 +489,7 @@
             <span class="canopy-mark">03</span>
             <div>
               <div class="canopy-card-name">Ask the project</div>
-              <div class="canopy-card-sub">search by behavior</div>
+              <div class="canopy-card-sub">Canopy · search by behavior</div>
             </div>
           </div>
           <div class="canopy-snippet">
@@ -511,14 +509,14 @@
     <div class="team-grid">
       <div class="team-copy">
         <span class="eyebrow">Team sync</span>
-        <h2 class="sec-title" style="margin-top: 16px;">A shared Grove, <em>without making cloud the source of truth.</em></h2>
-        <p class="sec-lede">Every teammate's agents benefit from the same project intelligence. Runs on Cloudflare's free tier for small teams. Local Grove databases remain the source of truth — the cloud store mirrors connected teammates' Grove data.</p>
+        <h2 class="sec-title" style="margin-top: 16px;">Shared team knowledge, <em>without making the cloud the source of truth.</em></h2>
+        <p class="sec-lede">Every teammate's agents benefit from the same project intelligence. Runs on Cloudflare's free tier for small teams. Your local databases stay the source of truth — the cloud store only mirrors connected teammates' synced knowledge.</p>
 
         <ul class="team-bullets">
           <li><span class="mark">✓</span><span><strong>Automatic backfill</strong> — existing knowledge syncs when you assign a project to a team, then new knowledge follows in the background.</span></li>
           <li><span class="mark">✓</span><span><strong>Team-aware search</strong> — results include your local knowledge and synced teammate knowledge, merged by relevance.</span></li>
           <li><span class="mark">✓</span><span><strong>Machine-identity attribution</strong> — results are tagged with who said what, so nothing is anonymised.</span></li>
-          <li><span class="mark">✓</span><span><strong>Cloud MCP endpoint</strong> — securely expose synced Grove knowledge to managed agents and N8N automations.</span></li>
+          <li><span class="mark">✓</span><span><strong>Cloud MCP endpoint</strong> — securely expose synced team knowledge to managed agents and N8N automations.</span></li>
         </ul>
 
         <div style="margin-top: 28px; display:flex; gap: 14px;">
@@ -569,7 +567,7 @@
 
         <div class="team-core">
           <span class="label">team mirror</span>
-          <div class="title">synced Grove knowledge</div>
+          <div class="title">synced team knowledge</div>
           <div class="meta">local stays source of truth</div>
         </div>
       </div>
@@ -583,7 +581,7 @@
     <div class="sec-head">
       <span class="eyebrow">Works with your agent</span>
       <h2 class="sec-title">Augment the agent you already use.</h2>
-      <p class="sec-lede">No wrappers, no forked CLIs, no ecosystem lock-in. Your agent keeps its reasoning, memory, tools, and native workflow; Myco adds shared project context around it. Because Myco lives with the project, every connected agent can benefit as that knowledge evolves.</p>
+      <p class="sec-lede">No wrappers, no forked CLIs, no ecosystem lock-in. Myco runs once on your machine and works alongside whatever agent you already use — adding shared project knowledge, codebase awareness, and learned workflows. Open any project with a supported agent and Myco connects to it automatically.</p>
     </div>
 
     <div class="agents-grid">
@@ -639,9 +637,9 @@
       </div>
       <div class="agent-card ochre">
         <div class="top">
-          <span class="agent-mark">ws</span>
+          <span class="agent-mark">dd</span>
           <div>
-            <div class="agent-name">Windsurf</div>
+            <div class="agent-name">Devin Desktop</div>
             <div class="agent-sub">context · skills</div>
           </div>
         </div>
@@ -715,6 +713,12 @@
         <span class="kind">Skills</span>
         <h4>Skill auto-curation</h4>
         <p>The four stages — survey, approve, generate, evolve — and the SKILL.md format Myco uses.</p>
+        <span class="go">Read guide</span>
+      </a>
+      <a class="doc-card" href="/canopy">
+        <span class="kind">Cortex</span>
+        <h4>Canopy</h4>
+        <p>Code intelligence for your agents — file anatomy before a read, a navigable project map, and search by what code <em>does</em>. How Myco cuts speculative reads.</p>
         <span class="go">Read guide</span>
       </a>
       <a class="doc-card" href="/team-sync">

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -151,7 +151,6 @@ embedding:
   model: bge-m3
 
 daemon:
-  port: null                    # null = auto-assign
   log_level: info               # debug | info | warn | error
 
 capture:

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -2,9 +2,9 @@
 
 > Myco is the nervous system for AI-assisted software teams. It works alongside coding agents, subagents, and agent teams to provide shared project knowledge, semantic codebase awareness, and learned workflows that evolve with the project.
 
-Myco is not a replacement coding agent or hosted harness. It lives with the project, captures development sessions into a local Grove, and routes useful context back to the agents a team already uses. Local Grove data remains the source of truth. Optional Team Sync mirrors connected teammates' Grove knowledge through Cloudflare and exposes synced knowledge to cloud agents through secure MCP.
+Myco is not a replacement coding agent or hosted harness. It runs on your machine and works with every git project automatically when you use a supported agent, capturing development sessions into a local Grove and routing useful context back to the agents a team already uses. Local Grove data remains the source of truth. Optional Team Sync mirrors connected teammates' synced knowledge through Cloudflare and exposes it to cloud agents through secure MCP.
 
-The supported path for the current release is macOS. Linux and Windows packages are published for early testing and are experimental.
+macOS is the supported path. Linux and Windows are in beta (Windows x64 only).
 
 ## Start here
 
@@ -23,16 +23,16 @@ The supported path for the current release is macOS. Linux and Windows packages 
 
 ## Team features
 
-- [Team Sync](https://myco.sh/team-sync.md): Share Grove knowledge across machines and teammates while keeping local data as the source of truth.
-- [Cloud MCP](https://myco.sh/cloud-mcp.md): Read-only access to synced Grove knowledge for cloud agents and automations.
+- [Team Sync](https://myco.sh/team-sync.md): Share team knowledge across machines and teammates while keeping local data as the source of truth.
+- [Cloud MCP](https://myco.sh/cloud-mcp.md): Read-only access to synced team knowledge for cloud agents and automations.
 - [Collective](https://myco.sh/collective.md): Cross-project search and shared settings for multiple Team Sync deployments.
 
 ## Operations
 
 - [Local service lifecycle](https://myco.sh/lifecycle.md): What gets captured, how the local service behaves, and what to do when something needs attention.
 - [Upgrade guide](https://myco.sh/upgrade.md): Upgrade Myco, preserve existing agent settings, and verify the install.
-- [Install script for macOS and Linux](https://myco.sh/install.sh): Shell installer. Linux support is experimental.
-- [Install script for Windows](https://myco.sh/install.ps1): PowerShell installer. Windows support is experimental.
+- [Install script for macOS and Linux](https://myco.sh/install.sh): Shell installer. Linux support is in beta.
+- [Install script for Windows](https://myco.sh/install.ps1): PowerShell installer. Windows support is in beta (x64 only).
 
 ## Optional
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,7 @@ Myco does not replace an agent's reasoning, native memory, tools, or workflow. I
 ## Requirements
 
 - **Node.js 22+**
-- **At least one supported coding agent** — Claude Code, Cursor, Codex, Copilot, Google Antigravity, Windsurf, OpenCode, or Pi
+- **At least one supported coding agent** — Claude Code, Cursor, Codex, Copilot, Google Antigravity, Devin Desktop, OpenCode, or Pi
 - **macOS** for the supported path, with **Linux and Windows in beta**. On Windows, only **x64** is supported — Windows on ARM (which runs the x64 build under emulation) is not supported.
 
 Provider configuration is **optional** at install time. Myco captures sessions and provides full-text search immediately. To enable spores, digests, semantic search, Canopy summaries, and skill lifecycle features, configure intelligence and embedding providers in the dashboard after install.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -17,7 +17,7 @@ survey → approve → generate → evolve
 
 **Approve** — Candidates appear in the Skills dashboard. You approve what becomes canon and dismiss the rest. Only approved candidates proceed to generation.
 
-**Generate** — Myco writes a SKILL.md file from the approved candidate's source material. The skill is staged, validated against quality criteria (is it procedural? does it have concrete file paths? is it under 500 lines? does it conflict with existing skills?), and promoted to Myco's canonical skill store only when it passes — at which point every installed agent picks it up via its global skills symlink.
+**Generate** — Myco writes a SKILL.md file from the approved candidate's source material. The skill is staged, validated against quality criteria (is it procedural? does it have concrete file paths? is it under 800 lines? does it conflict with existing skills?), and promoted to Myco's canonical skill store only when it passes — at which point every installed agent picks it up via its global skills symlink.
 
 **Evolve** — Over time, Myco monitors active skills for drift. When new knowledge appears that should be incorporated, a skill's underlying spores get superseded, or a skill grows oversized and should be split, the evolve task rewrites it. Each rewrite bumps a generation number and records what changed.
 

--- a/docs/symbionts.md
+++ b/docs/symbionts.md
@@ -94,7 +94,7 @@ Antigravity supports prompt capture, context routing, and session reconciliation
 
 Antigravity reuses the `~/.gemini/` user-home directory it inherited from Gemini IDE. On first detection, Myco performs a **one-time data remap** that migrates any legacy `~/.gemini/` Myco artifacts and cleans stale `trusted_hooks.json` entries.
 
-### Windsurf
+### Devin Desktop
 
 | Component | Global location |
 |-----------|-----------------|
@@ -103,7 +103,7 @@ Antigravity reuses the `~/.gemini/` user-home directory it inherited from Gemini
 | Skills | `~/.codeium/windsurf/skills/` → Myco's skill store |
 | Plans | `~/.windsurf/plans/` |
 
-Windsurf supports hook capture and skill discovery through Cascade's current agent surfaces.
+Devin Desktop — the editor formerly known as Windsurf — supports hook capture and skill discovery through Cascade's current agent surfaces. Its config still lives under the legacy `~/.codeium/windsurf/` and `~/.windsurf/` paths shown above.
 
 ### OpenCode
 

--- a/docs/team-sync.md
+++ b/docs/team-sync.md
@@ -1,6 +1,6 @@
 # Team Sync
 
-Share captured knowledge across your team through a Cloudflare-backed sync layer. Each teammate keeps their local Grove, and Team Sync mirrors your team's knowledge into a shared, queryable store — so everyone's agents draw on the same spores, sessions, plans, and graph without anyone having to think about it.
+Share captured knowledge across your team through a Cloudflare-backed sync layer. Each teammate keeps their knowledge local, and Team Sync mirrors your team's knowledge into a shared, queryable store — so everyone's agents draw on the same spores, sessions, plans, and graph without anyone having to think about it.
 
 Team Sync also exposes a secure [Cloud MCP Server](cloud-mcp.md) so cloud agents (Anthropic Managed Agents, n8n, and the like) can read your team's knowledge. See [Cloud MCP](cloud-mcp.md) for that side.
 
@@ -13,7 +13,7 @@ Team Sync also exposes a secure [Cloud MCP Server](cloud-mcp.md) so cloud agents
 - A team roster shows who's connected.
 - Runs on the Cloudflare free tier for small teams.
 
-Your local Grove stays the source of truth — the team store is a queryable mirror, and nothing is pulled back down to overwrite local data. Every record is attributed to the machine that created it.
+Your local data stays the source of truth — the team store is a queryable mirror, and nothing is pulled back down to overwrite it. Every record is attributed to the machine that created it.
 
 ## Set up a team
 
@@ -68,7 +68,7 @@ A **team selector** in the top-right scopes what you're viewing to one of your t
 
 ### Leaving a team
 
-To stop syncing to a team, open the **Teams** tab and choose **Leave team**. That removes the team from this machine and clears its pending queue — it does not touch the team's cloud Worker or your local Grove, and other members are unaffected. (To tear the cloud infrastructure down entirely, the operator runs `myco-team destroy --team-id <id>`.)
+To stop syncing to a team, open the **Teams** tab and choose **Leave team**. That removes the team from this machine and clears its pending queue — it does not touch the team's cloud Worker or your local data, and other members are unaffected. (To tear the cloud infrastructure down entirely, the operator runs `myco-team destroy --team-id <id>`.)
 
 ## Machine identity
 
@@ -99,7 +99,7 @@ Store your Cloudflare API token in `secrets.env`.
 
 ## Backup & restore
 
-Independent of Team Sync, Myco creates Grove-scoped backups for resilience. Configure the backup directory on the **Operations** page, or click **Backup Now** for an on-demand backup. Restore supports a dry-run preview, and cross-machine restore preserves attribution, so you can pull a teammate's backup without losing who said what.
+Independent of Team Sync, Myco creates local backups for resilience. Configure the backup directory on the **Operations** page, or click **Backup Now** for an on-demand backup. Restore supports a dry-run preview, and cross-machine restore preserves attribution, so you can pull a teammate's backup without losing who said what.
 
 Backups include all knowledge but exclude logs, tool-call activity, and vector embeddings (rebuilt automatically after restore).
 
@@ -117,7 +117,7 @@ The other operator commands take the same `--team-id`: `status`, `rotate-tokens`
 npm update -g @goondocks/myco-team
 ```
 
-The Worker keeps the cloud side lightweight: your local Grove stays the source of truth, the Worker holds a synced mirror for team search and Cloud MCP, and syncing is queued and retryable, so a transient network or Cloudflare hiccup never blocks local work.
+The Worker keeps the cloud side lightweight: your local data stays the source of truth, the Worker holds a synced mirror for team search and Cloud MCP, and syncing is queued and retryable, so a transient network or Cloudflare hiccup never blocks local work.
 
 ### Cost
 

--- a/packages/myco/src/cli.ts
+++ b/packages/myco/src/cli.ts
@@ -13,6 +13,7 @@ const USAGE = `Usage: myco <command> [args]
 
 Commands:
   grove <subcommand>       Manage local Groves
+  subsystem <subcommand>   Claim/release machine-global subsystem ownership (claim|release|list)
   update                   Update vault files and agent registration
   remove [--purge] [--yes]   Remove Myco's machine-wide install (prompts unless --yes;
                              captured data preserved unless --purge)
@@ -99,6 +100,11 @@ async function main(): Promise<void> {
     process.exit(1);
   }
   if (cmd === 'grove') return (await import('./cli/grove.js')).run(args);
+  // Declare which daemon variant owns a machine-global subsystem (e.g.
+  // symbiont-config) so a coexisting peer daemon defers — operator-driven,
+  // durable, contributor-only. Belongs above the myco.yaml gate like `grove`
+  // since it manages machine state, not a project vault.
+  if (cmd === 'subsystem') return (await import('./cli/subsystem.js')).run(args);
   // Internal: spawned by the daemon to run a heavy restore out-of-process
   // (see backup/restore-runner.ts). Intentionally absent from the help text.
   if (cmd === '__restore-backup') return (await import('./cli/restore-backup.js')).run(args);

--- a/packages/myco/src/cli/subsystem.ts
+++ b/packages/myco/src/cli/subsystem.ts
@@ -1,0 +1,96 @@
+import {
+  claimSubsystem,
+  releaseSubsystemClaim,
+  listSubsystemClaims,
+  readClaim,
+  KNOWN_SUBSYSTEMS,
+} from '../daemon/subsystem-claim.js';
+import { resolveMycoHome, currentDaemonVariant } from '@myco/grove/paths.js';
+
+const USAGE = `Usage: myco subsystem <command>
+
+Declare which daemon variant owns a machine-global subsystem so a peer daemon
+defers. Operator-driven and durable — the claim stands until released, mirroring
+\`myco grove claim\`. Run claim/release under the build whose daemon should own
+the subsystem (the dogfood build → owner 'service-dev').
+
+Commands:
+  claim <subsystem> [--force]   Take ownership for this build's daemon variant
+  release <subsystem>           Relinquish a claim this variant owns
+  list                          Show active claims on this machine
+
+Subsystems: ${KNOWN_SUBSYSTEMS.join(', ')}`;
+
+function assertKnown(subsystem: string): void {
+  if (!KNOWN_SUBSYSTEMS.includes(subsystem)) {
+    throw new Error(
+      `Unknown subsystem: ${subsystem}. Known subsystems: ${KNOWN_SUBSYSTEMS.join(', ')}`,
+    );
+  }
+}
+
+export async function run(args: string[]): Promise<void> {
+  const [cmd, ...rest] = args;
+  const mycoHome = resolveMycoHome();
+
+  if (!cmd || cmd === '--help' || cmd === '-h') {
+    process.stdout.write(USAGE + '\n');
+    return;
+  }
+
+  if (cmd === 'list') {
+    const claims = listSubsystemClaims({ mycoHome });
+    if (claims.length === 0) {
+      console.log('No subsystem claims.');
+      return;
+    }
+    for (const claim of claims) {
+      console.log(
+        `${claim.subsystem} → ${claim.owner} (pid ${claim.pid}, claimed ${new Date(claim.claimed_at).toISOString()})`,
+      );
+    }
+    return;
+  }
+
+  if (cmd === 'claim') {
+    const subsystem = rest[0];
+    if (!subsystem) throw new Error('Subsystem name is required');
+    assertKnown(subsystem);
+    const self = currentDaemonVariant();
+    const existing = readClaim(subsystem, mycoHome);
+    if (existing && existing.owner !== self && !rest.includes('--force')) {
+      throw new Error(
+        `${subsystem} is already claimed by ${existing.owner}. Release it from that `
+        + `build (\`myco subsystem release ${subsystem}\`), or pass --force to take it over.`,
+      );
+    }
+    claimSubsystem(subsystem, self, { mycoHome });
+    console.log(`Claimed ${subsystem} for ${self}.`);
+    console.log(`A peer daemon variant now defers ${subsystem} work to this build's daemon.`);
+    console.log(`Run \`myco subsystem release ${subsystem}\` (under this build) when you're done.`);
+    return;
+  }
+
+  if (cmd === 'release') {
+    const subsystem = rest[0];
+    if (!subsystem) throw new Error('Subsystem name is required');
+    assertKnown(subsystem);
+    const self = currentDaemonVariant();
+    const existing = readClaim(subsystem, mycoHome);
+    if (!existing) {
+      console.log(`${subsystem} is not claimed.`);
+      return;
+    }
+    if (existing.owner !== self) {
+      throw new Error(
+        `${subsystem} is claimed by ${existing.owner}, not ${self}. Release it from the `
+        + `owning build.`,
+      );
+    }
+    releaseSubsystemClaim(subsystem, self, { mycoHome });
+    console.log(`Released ${subsystem} (was owned by ${self}).`);
+    return;
+  }
+
+  throw new Error(`Unknown subsystem command: ${cmd}\n\n${USAGE}`);
+}

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -21,7 +21,8 @@ import { resolveVaultDir, resolveProjectRoot } from '../vault/resolve.js';
 import { EventBuffer } from '../capture/buffer.js';
 import { listAllProjectBufferDirs } from '../capture/buffer-location.js';
 import { runGlobalBootstrap, shouldRunGlobalBootstrap } from '../cli/bootstrap.js';
-import { resolveMycoHome, resolveGroveDbPath } from '../grove/paths.js';
+import { resolveMycoHome, resolveGroveDbPath, currentDaemonVariant } from '../grove/paths.js';
+import { claimSubsystem, releaseSubsystemClaim, SYMBIONT_CONFIG_SUBSYSTEM } from './subsystem-claim.js';
 import { loadManifests } from '../symbionts/detect.js';
 import type { PlanWatchConfig } from './plan-capture.js';
 import {
@@ -2473,6 +2474,16 @@ export async function main(): Promise<void> {
   powerManager.start();
   eventLoopLagProbe.start();
 
+  // Subsystem ownership: a dogfood (service-dev) daemon claims symbiont-config
+  // management so the production daemon defers and the two never fight over the
+  // machine's global agent configs. Released on graceful shutdown below; a
+  // crash leaves a stale claim that production reclaims via the pid-liveness
+  // check. No-op for the production daemon (it never claims — it's the default
+  // owner and simply defers while a peer holds the claim).
+  if (currentDaemonVariant() === 'service-dev') {
+    claimSubsystem(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev');
+  }
+
   // --- Shutdown ---
 
   // Guard against SIGTERM + SIGINT (or repeated signals) running the
@@ -2496,6 +2507,11 @@ export async function main(): Promise<void> {
     selfReconcileLoop.stop();
     powerManager.stop();
     eventLoopLagProbe.stop();
+    // Release our subsystem claim promptly so the production daemon can resume
+    // ownership without waiting on the pid-liveness fallback. No-op for prod.
+    if (currentDaemonVariant() === 'service-dev') {
+      releaseSubsystemClaim(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev');
+    }
     if (phantomRebindWatcher) {
       clearInterval(phantomRebindWatcher);
       phantomRebindWatcher = null;

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -21,8 +21,7 @@ import { resolveVaultDir, resolveProjectRoot } from '../vault/resolve.js';
 import { EventBuffer } from '../capture/buffer.js';
 import { listAllProjectBufferDirs } from '../capture/buffer-location.js';
 import { runGlobalBootstrap, shouldRunGlobalBootstrap } from '../cli/bootstrap.js';
-import { resolveMycoHome, resolveGroveDbPath, currentDaemonVariant } from '../grove/paths.js';
-import { claimSubsystem, releaseSubsystemClaim, SYMBIONT_CONFIG_SUBSYSTEM } from './subsystem-claim.js';
+import { resolveMycoHome, resolveGroveDbPath } from '../grove/paths.js';
 import { loadManifests } from '../symbionts/detect.js';
 import type { PlanWatchConfig } from './plan-capture.js';
 import {
@@ -2474,16 +2473,6 @@ export async function main(): Promise<void> {
   powerManager.start();
   eventLoopLagProbe.start();
 
-  // Subsystem ownership: a dogfood (service-dev) daemon claims symbiont-config
-  // management so the production daemon defers and the two never fight over the
-  // machine's global agent configs. Released on graceful shutdown below; a
-  // crash leaves a stale claim that production reclaims via the pid-liveness
-  // check. No-op for the production daemon (it never claims — it's the default
-  // owner and simply defers while a peer holds the claim).
-  if (currentDaemonVariant() === 'service-dev') {
-    claimSubsystem(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev');
-  }
-
   // --- Shutdown ---
 
   // Guard against SIGTERM + SIGINT (or repeated signals) running the
@@ -2507,11 +2496,6 @@ export async function main(): Promise<void> {
     selfReconcileLoop.stop();
     powerManager.stop();
     eventLoopLagProbe.stop();
-    // Release our subsystem claim promptly so the production daemon can resume
-    // ownership without waiting on the pid-liveness fallback. No-op for prod.
-    if (currentDaemonVariant() === 'service-dev') {
-      releaseSubsystemClaim(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev');
-    }
     if (phantomRebindWatcher) {
       clearInterval(phantomRebindWatcher);
       phantomRebindWatcher = null;

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -39,7 +39,9 @@ import {
 import {
   resolveMycoHome,
   resolveProjectVaultDir,
+  currentDaemonVariant,
 } from '@myco/grove/paths.js';
+import { isClaimedByPeer, SYMBIONT_CONFIG_SUBSYSTEM } from './subsystem-claim.js';
 import {
   pauseAwareShouldVisit,
   listRegisteredProjects,
@@ -547,6 +549,11 @@ export function registerPowerJobs(runner: JobRunner, deps: PowerJobDeps): PowerJ
       const now = Date.now();
       if (now - lastSymbiontDetectionAt < SYMBIONT_DETECTION_INTERVAL_MS) return;
       lastSymbiontDetectionAt = now;
+      // Defer while a peer daemon holds the symbiont-config claim. On a
+      // contributor machine a dogfood (service-dev) daemon claims ownership so
+      // the production daemon stops rewriting global agent configs out from
+      // under the local build. No-op for normal single-daemon installs.
+      if (isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, currentDaemonVariant())) return;
       try {
         const { runSymbiontDetection } = await import('../cli/bootstrap.js');
         const symbionts = runSymbiontDetection();

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -549,10 +549,12 @@ export function registerPowerJobs(runner: JobRunner, deps: PowerJobDeps): PowerJ
       const now = Date.now();
       if (now - lastSymbiontDetectionAt < SYMBIONT_DETECTION_INTERVAL_MS) return;
       lastSymbiontDetectionAt = now;
-      // Defer while a peer daemon holds the symbiont-config claim. On a
-      // contributor machine a dogfood (service-dev) daemon claims ownership so
-      // the production daemon stops rewriting global agent configs out from
-      // under the local build. No-op for normal single-daemon installs.
+      // Defer while a peer daemon variant holds the symbiont-config claim. On a
+      // contributor machine the operator runs `myco subsystem claim
+      // symbiont-config` under the dogfood build so the production daemon stops
+      // rewriting global agent configs out from under the local build. We never
+      // claim here — only read and opt out. No-op for normal single-daemon
+      // installs, where no claim exists.
       if (isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, currentDaemonVariant())) return;
       try {
         const { runSymbiontDetection } = await import('../cli/bootstrap.js');

--- a/packages/myco/src/daemon/subsystem-claim.ts
+++ b/packages/myco/src/daemon/subsystem-claim.ts
@@ -1,19 +1,27 @@
 /**
- * Subsystem ownership claims — a small, general "this daemon owns <subsystem>
- * on this machine" marker written into the shared `~/.myco/claims/` area.
+ * Subsystem ownership claims — a small, general "this daemon variant owns
+ * <subsystem> on this machine" marker written into the shared `~/.myco/claims/`
+ * area.
  *
  * Two daemons can run on one machine (the production `service` daemon and a
  * contributor's dogfood `service-dev` daemon). For machine-global work that
  * both would otherwise perform — today: rewriting global agent/symbiont
  * configs — they'd fight, each clobbering the other's binary path on its next
- * tick. A claim lets one daemon assert ownership so the peer defers.
+ * tick. A claim lets the operator declare which variant owns the subsystem so
+ * the peer defers.
  *
- * The claim is just a file: present + the owner's pid still alive = held;
- * absent or owner-dead = free. There is no heartbeat — liveness is the owner
- * pid, so a crashed owner's claim is stale and the peer reclaims automatically
- * (no permanent lockout). Releasing is explicit (graceful shutdown) or implicit
- * (the owner dies). Inert for normal single-daemon installs: no peer ever
- * claims, so nothing is ever deferred.
+ * Deliberately operator-driven, not automatic (mirrors `myco grove claim`): a
+ * claim is taken with `myco subsystem claim <name>` and dropped with
+ * `myco subsystem release <name>`. The claim is durable — it persists across
+ * daemon restarts and until explicitly released, so the owner is a stated
+ * intent rather than a function of which process happens to be alive. The peer
+ * daemon never writes a claim; it only reads one and opts out of the work.
+ *
+ * The claim is just a file: present and owned by another variant = the peer
+ * defers; absent = free. A stale claim (owner daemon long gone, never released)
+ * is cleared the same way it was taken — `myco subsystem release` — and is
+ * visible via `myco subsystem list`. Inert for normal single-daemon installs:
+ * no operator ever claims, so nothing is ever deferred.
  *
  * General by design — any future machine-global subsystem two daemons might
  * contend over can take a claim with a new subsystem name.
@@ -22,15 +30,22 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { resolveMycoHome } from '../grove/paths.js';
-import { isProcessAlive } from '../cli/shared.js';
 import type { DaemonVariant } from '../grove/registry.js';
 
 /** The symbiont-config (hooks/MCP) management subsystem — the first claim user. */
 export const SYMBIONT_CONFIG_SUBSYSTEM = 'symbiont-config';
 
-interface SubsystemClaim {
+/**
+ * Subsystems that may be claimed. The CLI validates against this so a typo
+ * can't write a claim file no daemon ever reads (a silently-dead claim). Add a
+ * name here when wiring a new subsystem's deferral guard.
+ */
+export const KNOWN_SUBSYSTEMS: readonly string[] = [SYMBIONT_CONFIG_SUBSYSTEM];
+
+export interface SubsystemClaim {
   subsystem: string;
   owner: DaemonVariant;
+  /** The pid that took the claim — informational only (for `subsystem list`). */
   pid: number;
   claimed_at: number;
 }
@@ -40,8 +55,6 @@ export interface ClaimDeps {
   mycoHome?: string;
   /** Owner pid to record (default: this process). */
   pid?: number;
-  /** Liveness probe for a recorded pid (default: the real OS check). */
-  isAlive?: (pid: number) => boolean;
   /** Clock (default: Date.now). */
   now?: () => number;
 }
@@ -54,7 +67,7 @@ function claimPath(subsystem: string, mycoHome: string): string {
   return path.join(claimsDir(mycoHome), `${subsystem}.json`);
 }
 
-function readClaim(subsystem: string, mycoHome: string): SubsystemClaim | null {
+export function readClaim(subsystem: string, mycoHome = resolveMycoHome()): SubsystemClaim | null {
   try {
     const parsed = JSON.parse(fs.readFileSync(claimPath(subsystem, mycoHome), 'utf-8')) as Partial<SubsystemClaim>;
     if (typeof parsed.owner === 'string' && typeof parsed.pid === 'number' && typeof parsed.subsystem === 'string') {
@@ -64,6 +77,21 @@ function readClaim(subsystem: string, mycoHome: string): SubsystemClaim | null {
   } catch {
     return null;
   }
+}
+
+/** Every active claim on this machine, for `myco subsystem list`. */
+export function listSubsystemClaims(deps: ClaimDeps = {}): SubsystemClaim[] {
+  const mycoHome = deps.mycoHome ?? resolveMycoHome();
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(claimsDir(mycoHome));
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((name) => name.endsWith('.json'))
+    .map((name) => readClaim(name.slice(0, -'.json'.length), mycoHome))
+    .filter((claim): claim is SubsystemClaim => claim !== null);
 }
 
 /** Assert ownership of `subsystem` for `owner`. Idempotent (overwrites). Best-effort. */
@@ -81,7 +109,7 @@ export function claimSubsystem(subsystem: string, owner: DaemonVariant, deps: Cl
   } catch { /* best-effort — a missing claim just means the peer doesn't defer */ }
 }
 
-/** Release a claim we hold. Only the recorded owner variant may release it. */
+/** Release a claim. Only the recorded owner variant may release it. */
 export function releaseSubsystemClaim(subsystem: string, owner: DaemonVariant, deps: ClaimDeps = {}): void {
   const mycoHome = deps.mycoHome ?? resolveMycoHome();
   const claim = readClaim(subsystem, mycoHome);
@@ -91,13 +119,13 @@ export function releaseSubsystemClaim(subsystem: string, owner: DaemonVariant, d
 }
 
 /**
- * True when a DIFFERENT daemon variant holds a LIVE claim on `subsystem`. The
- * caller (`self`) should defer the subsystem's work. A claim by `self`, a stale
- * claim (owner pid dead), or no claim at all all return false.
+ * True when a DIFFERENT daemon variant holds a claim on `subsystem`. The caller
+ * (`self`) should defer the subsystem's work. A claim by `self`, or no claim at
+ * all, returns false. Durable: the claim stands until explicitly released, so
+ * this is a pure function of the on-disk marker — no process-liveness check.
  */
 export function isClaimedByPeer(subsystem: string, self: DaemonVariant, deps: ClaimDeps = {}): boolean {
   const mycoHome = deps.mycoHome ?? resolveMycoHome();
   const claim = readClaim(subsystem, mycoHome);
-  if (!claim || claim.owner === self) return false;
-  return (deps.isAlive ?? isProcessAlive)(claim.pid);
+  return claim !== null && claim.owner !== self;
 }

--- a/packages/myco/src/daemon/subsystem-claim.ts
+++ b/packages/myco/src/daemon/subsystem-claim.ts
@@ -1,0 +1,103 @@
+/**
+ * Subsystem ownership claims — a small, general "this daemon owns <subsystem>
+ * on this machine" marker written into the shared `~/.myco/claims/` area.
+ *
+ * Two daemons can run on one machine (the production `service` daemon and a
+ * contributor's dogfood `service-dev` daemon). For machine-global work that
+ * both would otherwise perform — today: rewriting global agent/symbiont
+ * configs — they'd fight, each clobbering the other's binary path on its next
+ * tick. A claim lets one daemon assert ownership so the peer defers.
+ *
+ * The claim is just a file: present + the owner's pid still alive = held;
+ * absent or owner-dead = free. There is no heartbeat — liveness is the owner
+ * pid, so a crashed owner's claim is stale and the peer reclaims automatically
+ * (no permanent lockout). Releasing is explicit (graceful shutdown) or implicit
+ * (the owner dies). Inert for normal single-daemon installs: no peer ever
+ * claims, so nothing is ever deferred.
+ *
+ * General by design — any future machine-global subsystem two daemons might
+ * contend over can take a claim with a new subsystem name.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
+import { resolveMycoHome } from '../grove/paths.js';
+import { isProcessAlive } from '../cli/shared.js';
+import type { DaemonVariant } from '../grove/registry.js';
+
+/** The symbiont-config (hooks/MCP) management subsystem — the first claim user. */
+export const SYMBIONT_CONFIG_SUBSYSTEM = 'symbiont-config';
+
+interface SubsystemClaim {
+  subsystem: string;
+  owner: DaemonVariant;
+  pid: number;
+  claimed_at: number;
+}
+
+/** Injectable seams so the claim store is unit-testable without a real daemon. */
+export interface ClaimDeps {
+  mycoHome?: string;
+  /** Owner pid to record (default: this process). */
+  pid?: number;
+  /** Liveness probe for a recorded pid (default: the real OS check). */
+  isAlive?: (pid: number) => boolean;
+  /** Clock (default: Date.now). */
+  now?: () => number;
+}
+
+function claimsDir(mycoHome: string): string {
+  return path.join(mycoHome, 'claims');
+}
+
+function claimPath(subsystem: string, mycoHome: string): string {
+  return path.join(claimsDir(mycoHome), `${subsystem}.json`);
+}
+
+function readClaim(subsystem: string, mycoHome: string): SubsystemClaim | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(claimPath(subsystem, mycoHome), 'utf-8')) as Partial<SubsystemClaim>;
+    if (typeof parsed.owner === 'string' && typeof parsed.pid === 'number' && typeof parsed.subsystem === 'string') {
+      return parsed as SubsystemClaim;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Assert ownership of `subsystem` for `owner`. Idempotent (overwrites). Best-effort. */
+export function claimSubsystem(subsystem: string, owner: DaemonVariant, deps: ClaimDeps = {}): void {
+  const mycoHome = deps.mycoHome ?? resolveMycoHome();
+  const claim: SubsystemClaim = {
+    subsystem,
+    owner,
+    pid: deps.pid ?? process.pid,
+    claimed_at: (deps.now ?? Date.now)(),
+  };
+  try {
+    fs.mkdirSync(claimsDir(mycoHome), { recursive: true });
+    atomicWriteFileSync(claimPath(subsystem, mycoHome), JSON.stringify(claim, null, 2) + '\n');
+  } catch { /* best-effort — a missing claim just means the peer doesn't defer */ }
+}
+
+/** Release a claim we hold. Only the recorded owner variant may release it. */
+export function releaseSubsystemClaim(subsystem: string, owner: DaemonVariant, deps: ClaimDeps = {}): void {
+  const mycoHome = deps.mycoHome ?? resolveMycoHome();
+  const claim = readClaim(subsystem, mycoHome);
+  if (claim && claim.owner === owner) {
+    try { fs.unlinkSync(claimPath(subsystem, mycoHome)); } catch { /* already gone */ }
+  }
+}
+
+/**
+ * True when a DIFFERENT daemon variant holds a LIVE claim on `subsystem`. The
+ * caller (`self`) should defer the subsystem's work. A claim by `self`, a stale
+ * claim (owner pid dead), or no claim at all all return false.
+ */
+export function isClaimedByPeer(subsystem: string, self: DaemonVariant, deps: ClaimDeps = {}): boolean {
+  const mycoHome = deps.mycoHome ?? resolveMycoHome();
+  const claim = readClaim(subsystem, mycoHome);
+  if (!claim || claim.owner === self) return false;
+  return (deps.isAlive ?? isProcessAlive)(claim.pid);
+}

--- a/packages/myco/src/symbionts/installer.ts
+++ b/packages/myco/src/symbionts/installer.ts
@@ -930,7 +930,14 @@ export class SymbiontInstaller {
    */
   private installBatchedJson(reg: NonNullable<typeof this.manifest.registration>): InstallResult {
     const targetPath = this.resolveAbsoluteTarget("hooks")!;
-    let data = readJsonFile(targetPath);
+    // Capture the on-disk structure up front so we can skip the write entirely
+    // when our transforms produce no change — otherwise the hourly detection
+    // tick would reformat a config the agent actively owns (claude-code's
+    // ~/.claude/settings.json, where hooks + MCP + settings colocate) on every
+    // pass just because its JSON style differs from ours. Same idempotency the
+    // standalone installMcpJson/installPluginHookFile paths already have.
+    const original = readJsonFile(targetPath);
+    let data = structuredClone(original);
     let hooks = false, mcp = false, settings = false;
 
     // Apply hooks transform
@@ -1009,7 +1016,7 @@ export class SymbiontInstaller {
       settings = true;
     }
 
-    writeJsonFile(targetPath, data);
+    if (!isDeepStrictEqual(data, original)) writeJsonFile(targetPath, data);
 
     return {
       hooks,

--- a/packages/myco/src/symbionts/installer.ts
+++ b/packages/myco/src/symbionts/installer.ts
@@ -2,6 +2,7 @@ import type { SymbiontManifest } from './manifest-schema.js';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
 import { expandHome, resolveMycoHome } from '../grove/paths.js';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { findTomlSectionEnd, buildTomlMcpSection, upsertTomlSection, upsertTomlSectionKeys, removeTomlSectionKeys, readTomlSectionKey } from './toml-helpers.js';
@@ -140,8 +141,10 @@ const MYCO_LAUNCHER_PLACEHOLDER = '{{mycoLauncher}}';
  * on PATH can still spawn the bridge — the gap the `myco-run` node shim left.
  *
  * Unlike the hook placeholder, no `--myco-managed` marker is appended: MCP
- * ownership is keyed by the `myco` server name (see `installMcpJson`'s sweep),
- * not the command string, so the command value can change freely across builds.
+ * ownership is keyed by the `myco` server name (see `installMcpJson`'s sweep).
+ * The command updates on a genuine binary change but the write is idempotent —
+ * `installMcpJson`/`installMcpToml` skip the file entirely when the entry already
+ * matches, so the hourly detection tick never churns a config the agent owns.
  */
 const MYCO_BINARY_PLACEHOLDER = '{{mycoBinary}}';
 
@@ -1789,6 +1792,14 @@ export class SymbiontInstaller {
   private installMcpJson(targetPath: string, template: Record<string, unknown>, serversKey: string): boolean {
     const config = readJsonFile(targetPath);
 
+    // Idempotency: only touch the file when myco's own entry actually needs to
+    // change (missing, drifted, or duplicated under a stale key). Otherwise the
+    // hourly detection tick would round-trip read → re-serialize → write and
+    // reformat a config the agent actively owns (e.g. ~/.claude/settings.json),
+    // churning it on every pass purely because our JSON style differs. `changed`
+    // gates the write; a structurally-identical entry is a no-op.
+    let changed = false;
+
     for (const candidateKey of KNOWN_MCP_SERVERS_KEYS) {
       if (candidateKey === serversKey) continue;
       const candidate = config[candidateKey];
@@ -1797,24 +1808,35 @@ export class SymbiontInstaller {
       if (!(MYCO_MCP_SERVER_NAME in bag)) continue;
       delete bag[MYCO_MCP_SERVER_NAME];
       if (Object.keys(bag).length === 0) delete config[candidateKey];
+      changed = true;
     }
 
     const servers = (config[serversKey] ?? {}) as Record<string, unknown>;
     for (const [name, def] of Object.entries(template)) {
+      if (isDeepStrictEqual(servers[name], def)) continue;
       servers[name] = def;
+      changed = true;
     }
     config[serversKey] = servers;
+
+    if (!changed) return false;
     return writeJsonFile(targetPath, config);
   }
 
   /** Write MCP servers to a TOML config file. */
   private installMcpToml(targetPath: string, template: Record<string, unknown>): boolean {
-    let raw = '';
-    try { raw = fs.readFileSync(targetPath, 'utf-8'); } catch { /* doesn't exist */ }
+    let original = '';
+    try { original = fs.readFileSync(targetPath, 'utf-8'); } catch { /* doesn't exist */ }
 
+    let raw = original;
     for (const [name, def] of Object.entries(template)) {
       raw = buildTomlMcpSection(raw, name, def as Record<string, unknown>);
     }
+
+    // Idempotency (mirrors installMcpJson): skip the write when the upsert
+    // produced no change, so the detection tick doesn't churn a config.toml the
+    // agent owns on every pass.
+    if (raw === original) return false;
 
     fs.mkdirSync(path.dirname(targetPath), { recursive: true });
     atomicWriteFileSync(targetPath, raw);

--- a/tests/cli/subsystem.test.ts
+++ b/tests/cli/subsystem.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { run } from '@myco/cli/subsystem';
+import { readClaim, SYMBIONT_CONFIG_SUBSYSTEM } from '@myco/daemon/subsystem-claim.js';
+
+// `myco subsystem <claim|release|list>` — operator-driven, durable ownership.
+// The owner recorded is this build's daemon variant (MYCO_SERVICE_VARIANT), so
+// the test drives it via env to stand in for the dogfood vs production build.
+
+describe('myco subsystem', () => {
+  let mycoHome: string;
+  let logged: string[];
+  let originalLog: typeof console.log;
+  const envKeys = ['MYCO_HOME', 'MYCO_SERVICE_VARIANT'] as const;
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    mycoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-subsystem-cli-'));
+    savedEnv = Object.fromEntries(envKeys.map((k) => [k, process.env[k]]));
+    process.env.MYCO_HOME = mycoHome;
+    logged = [];
+    originalLog = console.log;
+    console.log = (...args: unknown[]) => { logged.push(args.join(' ')); };
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+    for (const k of envKeys) {
+      if (savedEnv[k] === undefined) delete process.env[k]; else process.env[k] = savedEnv[k];
+    }
+    fs.rmSync(mycoHome, { recursive: true, force: true });
+  });
+
+  it('claim under the dev build records service-dev ownership', async () => {
+    process.env.MYCO_SERVICE_VARIANT = 'dev';
+    await run(['claim', SYMBIONT_CONFIG_SUBSYSTEM]);
+    expect(readClaim(SYMBIONT_CONFIG_SUBSYSTEM, mycoHome)?.owner).toBe('service-dev');
+    expect(logged.join('\n')).toContain('Claimed symbiont-config for service-dev');
+  });
+
+  it('list shows an active claim', async () => {
+    process.env.MYCO_SERVICE_VARIANT = 'dev';
+    await run(['claim', SYMBIONT_CONFIG_SUBSYSTEM]);
+    logged = [];
+    await run(['list']);
+    expect(logged.join('\n')).toContain('symbiont-config → service-dev');
+  });
+
+  it('list reports nothing when no claims exist', async () => {
+    await run(['list']);
+    expect(logged.join('\n')).toContain('No subsystem claims.');
+  });
+
+  it('release frees a claim the same variant owns', async () => {
+    process.env.MYCO_SERVICE_VARIANT = 'dev';
+    await run(['claim', SYMBIONT_CONFIG_SUBSYSTEM]);
+    await run(['release', SYMBIONT_CONFIG_SUBSYSTEM]);
+    expect(readClaim(SYMBIONT_CONFIG_SUBSYSTEM, mycoHome)).toBeNull();
+  });
+
+  it('release from a different variant is refused (claim stands)', async () => {
+    process.env.MYCO_SERVICE_VARIANT = 'dev';
+    await run(['claim', SYMBIONT_CONFIG_SUBSYSTEM]);
+    process.env.MYCO_SERVICE_VARIANT = 'prod';
+    await expect(run(['release', SYMBIONT_CONFIG_SUBSYSTEM])).rejects.toThrow(/claimed by service-dev/);
+    expect(readClaim(SYMBIONT_CONFIG_SUBSYSTEM, mycoHome)?.owner).toBe('service-dev');
+  });
+
+  it('claiming a subsystem a peer already owns is refused without --force', async () => {
+    process.env.MYCO_SERVICE_VARIANT = 'dev';
+    await run(['claim', SYMBIONT_CONFIG_SUBSYSTEM]);
+    process.env.MYCO_SERVICE_VARIANT = 'prod';
+    await expect(run(['claim', SYMBIONT_CONFIG_SUBSYSTEM])).rejects.toThrow(/already claimed by service-dev/);
+    // --force takes it over.
+    await run(['claim', SYMBIONT_CONFIG_SUBSYSTEM, '--force']);
+    expect(readClaim(SYMBIONT_CONFIG_SUBSYSTEM, mycoHome)?.owner).toBe('service');
+  });
+
+  it('an unknown subsystem name is rejected', async () => {
+    process.env.MYCO_SERVICE_VARIANT = 'dev';
+    await expect(run(['claim', 'not-a-subsystem'])).rejects.toThrow(/Unknown subsystem/);
+  });
+});

--- a/tests/daemon/subsystem-claim.test.ts
+++ b/tests/daemon/subsystem-claim.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  claimSubsystem,
+  releaseSubsystemClaim,
+  isClaimedByPeer,
+  SYMBIONT_CONFIG_SUBSYSTEM,
+} from '@myco/daemon/subsystem-claim.js';
+
+// The general subsystem-claim primitive: a daemon writes a claim into the
+// shared ~/.myco area; a peer defers while a LIVE claim by another variant
+// exists; a dead owner's claim is stale (no lockout); inert with no claim.
+
+describe('subsystem-claim', () => {
+  let mycoHome: string;
+  beforeEach(() => { mycoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-claim-')); });
+  afterEach(() => { fs.rmSync(mycoHome, { recursive: true, force: true }); });
+
+  const alive = () => true;
+  const dead = () => false;
+
+  it('no claim → peer is not deferred (inert)', () => {
+    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service', { mycoHome, isAlive: alive })).toBe(false);
+  });
+
+  it('a LIVE claim by a different variant defers the peer', () => {
+    claimSubsystem(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev', { mycoHome, pid: 4242 });
+    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service', { mycoHome, isAlive: alive })).toBe(true);
+  });
+
+  it("the owner's own claim never defers the owner", () => {
+    claimSubsystem(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev', { mycoHome, pid: 4242 });
+    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev', { mycoHome, isAlive: alive })).toBe(false);
+  });
+
+  it('a claim whose owner pid is DEAD is stale → no deferral, no lockout', () => {
+    claimSubsystem(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev', { mycoHome, pid: 4242 });
+    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service', { mycoHome, isAlive: dead })).toBe(false);
+  });
+
+  it('only the owner variant can release a claim', () => {
+    claimSubsystem(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev', { mycoHome, pid: 4242 });
+
+    // A peer cannot release the dev daemon's claim.
+    releaseSubsystemClaim(SYMBIONT_CONFIG_SUBSYSTEM, 'service', { mycoHome });
+    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service', { mycoHome, isAlive: alive })).toBe(true);
+
+    // The owner releases it → free.
+    releaseSubsystemClaim(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev', { mycoHome });
+    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service', { mycoHome, isAlive: alive })).toBe(false);
+  });
+
+  it('claim is idempotent — re-claiming just refreshes the marker', () => {
+    claimSubsystem(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev', { mycoHome, pid: 4242, now: () => 1000 });
+    claimSubsystem(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev', { mycoHome, pid: 4242, now: () => 2000 });
+    const raw = JSON.parse(fs.readFileSync(path.join(mycoHome, 'claims', SYMBIONT_CONFIG_SUBSYSTEM + '.json'), 'utf-8'));
+    expect(raw.claimed_at).toBe(2000);
+    expect(raw.owner).toBe('service-dev');
+  });
+});

--- a/tests/daemon/subsystem-claim.test.ts
+++ b/tests/daemon/subsystem-claim.test.ts
@@ -6,38 +6,40 @@ import {
   claimSubsystem,
   releaseSubsystemClaim,
   isClaimedByPeer,
+  listSubsystemClaims,
+  readClaim,
   SYMBIONT_CONFIG_SUBSYSTEM,
 } from '@myco/daemon/subsystem-claim.js';
 
-// The general subsystem-claim primitive: a daemon writes a claim into the
-// shared ~/.myco area; a peer defers while a LIVE claim by another variant
-// exists; a dead owner's claim is stale (no lockout); inert with no claim.
+// The subsystem-claim primitive: an operator writes a durable claim into the
+// shared ~/.myco area; a peer defers while another variant owns the subsystem;
+// the claim stands until explicitly released (no process-liveness expiry);
+// inert with no claim.
 
 describe('subsystem-claim', () => {
   let mycoHome: string;
   beforeEach(() => { mycoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-claim-')); });
   afterEach(() => { fs.rmSync(mycoHome, { recursive: true, force: true }); });
 
-  const alive = () => true;
-  const dead = () => false;
-
   it('no claim → peer is not deferred (inert)', () => {
-    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service', { mycoHome, isAlive: alive })).toBe(false);
+    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service', { mycoHome })).toBe(false);
   });
 
-  it('a LIVE claim by a different variant defers the peer', () => {
+  it('a claim by a different variant defers the peer', () => {
     claimSubsystem(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev', { mycoHome, pid: 4242 });
-    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service', { mycoHome, isAlive: alive })).toBe(true);
+    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service', { mycoHome })).toBe(true);
   });
 
   it("the owner's own claim never defers the owner", () => {
     claimSubsystem(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev', { mycoHome, pid: 4242 });
-    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev', { mycoHome, isAlive: alive })).toBe(false);
+    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev', { mycoHome })).toBe(false);
   });
 
-  it('a claim whose owner pid is DEAD is stale → no deferral, no lockout', () => {
+  it('the claim is durable — it stands until released, regardless of the claiming pid', () => {
+    // pid is informational only; the claim does NOT expire when that process
+    // exits. Only an explicit release frees it.
     claimSubsystem(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev', { mycoHome, pid: 4242 });
-    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service', { mycoHome, isAlive: dead })).toBe(false);
+    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service', { mycoHome })).toBe(true);
   });
 
   it('only the owner variant can release a claim', () => {
@@ -45,18 +47,35 @@ describe('subsystem-claim', () => {
 
     // A peer cannot release the dev daemon's claim.
     releaseSubsystemClaim(SYMBIONT_CONFIG_SUBSYSTEM, 'service', { mycoHome });
-    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service', { mycoHome, isAlive: alive })).toBe(true);
+    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service', { mycoHome })).toBe(true);
 
     // The owner releases it → free.
     releaseSubsystemClaim(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev', { mycoHome });
-    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service', { mycoHome, isAlive: alive })).toBe(false);
+    expect(isClaimedByPeer(SYMBIONT_CONFIG_SUBSYSTEM, 'service', { mycoHome })).toBe(false);
   });
 
   it('claim is idempotent — re-claiming just refreshes the marker', () => {
     claimSubsystem(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev', { mycoHome, pid: 4242, now: () => 1000 });
     claimSubsystem(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev', { mycoHome, pid: 4242, now: () => 2000 });
-    const raw = JSON.parse(fs.readFileSync(path.join(mycoHome, 'claims', SYMBIONT_CONFIG_SUBSYSTEM + '.json'), 'utf-8'));
-    expect(raw.claimed_at).toBe(2000);
-    expect(raw.owner).toBe('service-dev');
+    const raw = readClaim(SYMBIONT_CONFIG_SUBSYSTEM, mycoHome);
+    expect(raw?.claimed_at).toBe(2000);
+    expect(raw?.owner).toBe('service-dev');
+  });
+
+  it('readClaim returns null when no claim exists', () => {
+    expect(readClaim(SYMBIONT_CONFIG_SUBSYSTEM, mycoHome)).toBeNull();
+  });
+
+  it('listSubsystemClaims enumerates active claims', () => {
+    expect(listSubsystemClaims({ mycoHome })).toEqual([]);
+    claimSubsystem(SYMBIONT_CONFIG_SUBSYSTEM, 'service-dev', { mycoHome, pid: 4242, now: () => 1000 });
+    const claims = listSubsystemClaims({ mycoHome });
+    expect(claims).toHaveLength(1);
+    expect(claims[0]).toMatchObject({
+      subsystem: SYMBIONT_CONFIG_SUBSYSTEM,
+      owner: 'service-dev',
+      pid: 4242,
+      claimed_at: 1000,
+    });
   });
 });

--- a/tests/symbionts/installer.test.ts
+++ b/tests/symbionts/installer.test.ts
@@ -778,6 +778,22 @@ describe('installMcp', () => {
     expect(servers.myco).toBeDefined();
   });
 
+  it('is idempotent — re-install with myco already correct writes nothing and preserves the agent config verbatim', () => {
+    const installer = new SymbiontInstaller(CLAUDE_MANIFEST, projectRoot, packageRoot);
+    expect(installer.installMcp()).toBe(true); // first install writes
+
+    const mcpPath = path.join(projectRoot, '.mcp.json');
+    // The agent later rewrites the file in ITS own style (4-space indent),
+    // leaving myco's server entry structurally intact. The hourly detection
+    // tick must NOT reformat the whole file just because the JSON style differs
+    // — that is needless churn over a config the agent actively owns.
+    const agentStyled = JSON.stringify(readJson(mcpPath), null, 4) + '\n';
+    fs.writeFileSync(mcpPath, agentStyled);
+
+    expect(installer.installMcp()).toBe(false); // myco unchanged → no-op
+    expect(fs.readFileSync(mcpPath, 'utf-8')).toBe(agentStyled); // verbatim
+  });
+
   it('skips the MCP server for a cli-transport symbiont (cursor) and writes nothing', () => {
     const installer = new SymbiontInstaller(CURSOR_CLI_MANIFEST, projectRoot, packageRoot);
     const result = installer.installMcp();
@@ -1358,6 +1374,16 @@ describe('installMcp (TOML)', () => {
     expect(content).not.toContain('myco-run');
     expect(content).not.toContain('cwd = "."');
     expect(content).not.toContain('[mcp_servers.myco.env]');
+  });
+
+  it('is idempotent — re-install with myco already correct writes nothing (TOML)', () => {
+    fs.mkdirSync(path.join(projectRoot, '.codex'), { recursive: true });
+    const installer = new SymbiontInstaller(CODEX_MANIFEST, projectRoot, packageRoot);
+    expect(installer.installMcp()).toBe(true); // first install writes
+    const tomlPath = path.join(projectRoot, '.codex/config.toml');
+    const first = fs.readFileSync(tomlPath, 'utf-8');
+    expect(installer.installMcp()).toBe(false); // unchanged → no-op
+    expect(fs.readFileSync(tomlPath, 'utf-8')).toBe(first);
   });
 
   it('preserves existing TOML content', () => {

--- a/tests/symbionts/installer.test.ts
+++ b/tests/symbionts/installer.test.ts
@@ -116,6 +116,27 @@ const CLI_BATCHED_MANIFEST: SymbiontManifest = {
   },
 };
 
+// Like cli-batched but MCP-transport: hooks + MCP server + settings all land in
+// ONE JSON file, so install goes through `installBatchedJson` AND writes the MCP
+// server — the shape of claude-code's global ~/.claude/settings.json. Used to
+// pin batched-path idempotency.
+const MCP_BATCHED_MANIFEST: SymbiontManifest = {
+  name: 'mcp-batched',
+  displayName: 'MCP Batched',
+  binary: 'mcpbatched',
+  configDir: '.mcpbatched',
+  pluginRootEnvVar: 'MCPBATCHED_PLUGIN_ROOT',
+  settingsPath: '.mcpbatched/config.json',
+  hookFields: { transcriptPath: 'transcript_path', lastResponse: 'last_assistant_message', sessionId: 'session_id' },
+  registration: {
+    hooksTarget: '.mcpbatched/config.json',
+    mcpTarget: '.mcpbatched/config.json',
+    mcpFormat: 'json',
+    settingsTarget: '.mcpbatched/config.json',
+    skillsTarget: '.agents/skills',
+  },
+};
+
 const GEMINI_MANIFEST: SymbiontManifest = {
   name: 'gemini',
   displayName: 'Gemini CLI',
@@ -776,6 +797,32 @@ describe('installMcp', () => {
     const servers = config.mcpServers as Record<string, unknown>;
     expect(servers['other-tool']).toBeDefined();
     expect(servers.myco).toBeDefined();
+  });
+
+  it('batched JSON (hooks + MCP + settings colocated) is idempotent — re-install preserves the agent config verbatim', () => {
+    // The claude-code shape: hooks + MCP server + settings share one file
+    // (~/.claude/settings.json), so install goes through installBatchedJson.
+    const tdir = path.join(packageRoot, 'src/symbionts/templates/mcp-batched');
+    fs.mkdirSync(tdir, { recursive: true });
+    writeJson(path.join(tdir, 'hooks.json'), {
+      Stop: [{ hooks: [{ type: 'command', command: '{{mycoLauncher}} hook stop --symbiont mcp-batched', timeout: 30 }] }],
+    });
+    writeJson(path.join(tdir, 'mcp.json'), MCP_TEMPLATE);
+    writeJson(path.join(tdir, 'settings.json'), { features: { capture: true } });
+
+    const installer = new SymbiontInstaller(MCP_BATCHED_MANIFEST, projectRoot, packageRoot);
+    const sharedFile = path.join(projectRoot, '.mcpbatched/config.json');
+    installer.install(); // first install writes hooks + MCP + settings into one file
+    expect((readJson(sharedFile).mcpServers as Record<string, unknown>).myco).toBeDefined();
+
+    // The agent rewrites the file in ITS own 4-space style, myco entry intact.
+    const agentStyled = JSON.stringify(readJson(sharedFile), null, 4) + '\n';
+    fs.writeFileSync(sharedFile, agentStyled);
+
+    // Re-install (the hourly detection tick): myco's contributions are
+    // unchanged, so the batched write must be a no-op — format preserved.
+    installer.install();
+    expect(fs.readFileSync(sharedFile, 'utf-8')).toBe(agentStyled);
   });
 
   it('is idempotent — re-install with myco already correct writes nothing and preserves the agent config verbatim', () => {


### PR DESCRIPTION
## Summary
Two related fixes for MCP-registration churn. The root cause is the hourly symbiont-detection tick rewriting global agent configs every pass — needless churn on its own, and the surface that let a second daemon's binary path drift in.

### 1. Idempotent config writes (all three paths)
The install paths did an unconditional read-modify-write — re-setting myco's server entry and re-serializing the whole config every pass — so the tick reformatted a config the agent actively owns whenever the agent's style differed from ours. Hooks were already idempotent (skip when already-owned); **MCP and the batched path now match** — one consistent pattern.

- `installMcpJson` / `installMcpToml` — the standalone `.mcp.json` (JSON) and `config.toml` (TOML) shapes. Write gated on a genuine change: deep-compare the desired entry (`isDeepStrictEqual`) for JSON / `raw === original` for TOML, plus the existing stale-key sweep.
- `installBatchedJson` — the **claude-code shape**, where hooks + MCP server + settings colocate in `~/.claude/settings.json`. This path was missed by the first pass and still churned the file every tick. Now captures the on-disk structure up front (`structuredClone` + `isDeepStrictEqual`) and skips the write when our transforms produce no change.

A structurally-identical entry is a **no-op that leaves the agent's file byte-for-byte verbatim**.

### 2. Subsystem-claim ownership — operator-driven, durable (mirrors `grove claim`)
On a contributor machine two daemons run side by side — the production `service` daemon and a dogfood `service-dev` daemon built from the most current code. Both run the detection tick and both rewrite global configs, so they fight, each clobbering the other's binary path. Production must never contradict the local build being dogfooded.

A general primitive (`daemon/subsystem-claim.ts`) plus a real CLI (`cli/subsystem.ts`). Claiming is a **deliberate operator action**, not automatic daemon behavior — the primitive only earns its place as a reusable pattern if it's observable and operator-controlled, the way `myco grove claim` is:

- `myco subsystem claim <name>` — take ownership for the build you run it under (the dogfood build resolves to `service-dev`). Refuses to silently steal a peer's claim (`--force` overrides); rejects unknown subsystem names.
- `myco subsystem release <name>` — relinquish a claim your variant owns.
- `myco subsystem list` — show active claims.

The claim is **durable** — it stands until released, mirroring `grove claim`, rather than expiring with a process pid (an operator writing it from an ephemeral CLI process can't bind liveness to that pid; ownership is a stated intent). The **daemon never writes a claim** — `power-jobs.ts` SYMBIONT_DETECTION only reads it (`isClaimedByPeer`) and opts out.

**Inert for normal single-daemon installs** — no operator ever claims, so nothing is ever deferred; no dev-specific machinery on the production hot path; nothing that resolves the production binary. The contributor flow is: run `myco subsystem claim symbiont-config` once under the dogfood build, and prod stops rewriting global configs out from under it. General by design — any future machine-global subsystem takes a claim under a new `KNOWN_SUBSYSTEMS` name + a one-line guard.

## Test Plan
- [x] Idempotency tests: re-install is a no-op preserving the agent's exact formatting, for `.mcp.json` (JSON), `config.toml` (TOML), **and the batched claude-code shape**.
- [x] Subsystem-claim primitive tests (8): inert with no claim, peer defers, owner's own claim doesn't defer self, durable (no pid expiry), only-owner releases, claim idempotent, readClaim/listSubsystemClaims.
- [x] `myco subsystem` CLI tests (7): claim records the build's variant, list, release (own / refused cross-variant), steal refused without --force, unknown subsystem rejected.
- [x] Full suite green (JUnit tally: 0 failures across all 130 reports); tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)