### PR TITLE
fix(upgrade): single source of truth for managed paths + release channel (fixes doubled-path adopt loop)

### DIFF
--- a/packages/myco/scripts/managed-paths.d.mts
+++ b/packages/myco/scripts/managed-paths.d.mts
@@ -1,0 +1,34 @@
+// Types for the shared managed-path layout module (managed-paths.mjs).
+// See that file for the convention: callers pass the resolved myco-home.
+
+export function managedBinDir(
+  mycoHome: string,
+  platform: NodeJS.Platform | string,
+  localAppData?: string,
+): string;
+
+export function managedBinaryPath(
+  mycoHome: string,
+  platform: NodeJS.Platform | string,
+  localAppData?: string,
+): string;
+
+export function versionsDir(
+  mycoHome: string,
+  platform: NodeJS.Platform | string,
+  localAppData?: string,
+): string;
+
+export function versionDir(
+  mycoHome: string,
+  platform: NodeJS.Platform | string,
+  version: string,
+  localAppData?: string,
+): string;
+
+export function versionBinaryPath(
+  mycoHome: string,
+  platform: NodeJS.Platform | string,
+  version: string,
+  localAppData?: string,
+): string;

--- a/packages/myco/scripts/managed-paths.mjs
+++ b/packages/myco/scripts/managed-paths.mjs
@@ -1,0 +1,58 @@
+// SINGLE SOURCE OF TRUTH for the managed-binary path layout.
+//
+// Imported by BOTH:
+//   - the npm postinstall (`select-binary.mjs`) at install time, straight from
+//     the published tarball (plain ESM, no build step), and
+//   - `src/install/managed-binary.ts`, which re-exports these and is compiled
+//     into the bun binary.
+//
+// Keeping the layout in ONE plain-ESM module is what makes the JS (postinstall)
+// and TS (binary) copies structurally unable to drift — the doubled-path bug
+// (`~/.myco/.myco/bin`) shipped precisely because the logic was duplicated and
+// the two copies disagreed on what `home` meant.
+//
+// CONVENTION: callers pass the resolved MYCO-HOME — `resolveMycoHome()` in TS
+// (`~/.myco` or `$MYCO_HOME`). On POSIX the bin dir is `<mycoHome>/bin`. On
+// win32 the managed bin lives at `%LOCALAPPDATA%\Myco\bin`, which is NOT under
+// the myco-home: the `mycoHome` argument is unused there. When `localAppData`
+// is absent (rare — real callers pass `process.env.LOCALAPPDATA`), the fallback
+// derives the OS home via `os.homedir()` independently, so a custom `$MYCO_HOME`
+// can never relocate the Windows bin and no doubling can occur on any platform.
+
+import os from 'node:os';
+import path from 'node:path';
+
+/** Managed binary directory: `<mycoHome>/bin` (POSIX) / `%LOCALAPPDATA%\Myco\bin` (win32). */
+export function managedBinDir(mycoHome, platform, localAppData) {
+  if (platform === 'win32') {
+    const appDataLocal = localAppData ?? path.win32.join(os.homedir(), 'AppData', 'Local');
+    return path.win32.join(appDataLocal, 'Myco', 'bin');
+  }
+  return path.posix.join(mycoHome, 'bin');
+}
+
+/** Full path to the managed binary: `<binDir>/myco[.exe]`. */
+export function managedBinaryPath(mycoHome, platform, localAppData) {
+  const p = platform === 'win32' ? path.win32 : path.posix;
+  const binaryName = platform === 'win32' ? 'myco.exe' : 'myco';
+  return p.join(managedBinDir(mycoHome, platform, localAppData), binaryName);
+}
+
+/** Versions directory: `<binDir>/versions`. */
+export function versionsDir(mycoHome, platform, localAppData) {
+  const p = platform === 'win32' ? path.win32 : path.posix;
+  return p.join(managedBinDir(mycoHome, platform, localAppData), 'versions');
+}
+
+/** Directory for a specific version: `<binDir>/versions/<version>`. */
+export function versionDir(mycoHome, platform, version, localAppData) {
+  const p = platform === 'win32' ? path.win32 : path.posix;
+  return p.join(versionsDir(mycoHome, platform, localAppData), version);
+}
+
+/** Full path to a versioned binary: `<versionDir>/myco[.exe]`. */
+export function versionBinaryPath(mycoHome, platform, version, localAppData) {
+  const p = platform === 'win32' ? path.win32 : path.posix;
+  const binaryName = platform === 'win32' ? 'myco.exe' : 'myco';
+  return p.join(versionDir(mycoHome, platform, version, localAppData), binaryName);
+}

--- a/packages/myco/scripts/select-binary.mjs
+++ b/packages/myco/scripts/select-binary.mjs
@@ -14,10 +14,11 @@
 // would require `dist/src/` modules that are never emitted in the published
 // tarball (the build only produces a bun binary + `dist/ui/`).
 //
-// Path layout helpers are inlined here (not imported from `dist/src/`) for
-// the same reason: this script is the only .mjs in the published package and
-// must be self-contained. The layout it produces MUST match what
-// `src/install/managed-binary.ts` computes (verified by the pack smoke test).
+// The path-layout helpers come from `./managed-paths.mjs` — a shared plain-ESM
+// module imported BOTH here and (re-exported) by `src/install/managed-binary.ts`,
+// so the postinstall and the compiled binary cannot disagree on the layout.
+// (We still cannot import `dist/src/` — it is never emitted in the published
+// tarball — which is why the shared module is plain ESM under `scripts/`.)
 //
 // This module exports `convergeNpmInstall` so the convergence mechanics are
 // unit-testable in isolation. The postinstall side effects run only when the
@@ -30,29 +31,26 @@ import os from 'node:os';
 import { createRequire } from 'node:module';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+// The PATH layout is imported from the shared `./managed-paths.mjs` module —
+// the SINGLE source of truth that both this postinstall and the compiled binary
+// (`src/install/managed-binary.ts` re-exports it) use, so they cannot drift.
+import { managedBinaryPath, versionBinaryPath } from './managed-paths.mjs';
+
 // ---------------------------------------------------------------------------
-// Inlined path helpers — must match src/install/managed-binary.ts exactly.
-// We cannot import dist/src/ because it is never emitted in the published
-// tarball (the build only produces a bun binary + dist/ui/).
+// Myco-home resolution. Mirrors `src/grove/paths.ts` resolveMycoHome() for the
+// postinstall (which cannot import TS): honors `$MYCO_HOME`, else `~/.myco`.
 // ---------------------------------------------------------------------------
 
-function managedBinDir(home, platform, localAppData) {
-  if (platform === 'win32') {
-    const appDataLocal = localAppData ?? path.win32.join(home, 'AppData', 'Local');
-    return path.win32.join(appDataLocal, 'Myco', 'bin');
+function resolveMycoHome() {
+  const configured = process.env.MYCO_HOME?.trim();
+  if (configured) {
+    if (configured === '~') return os.homedir();
+    if (configured.startsWith('~/') || configured.startsWith(`~${path.sep}`)) {
+      return path.join(os.homedir(), configured.slice(2));
+    }
+    return path.resolve(configured);
   }
-  return path.posix.join(home, '.myco', 'bin');
-}
-
-function managedBinaryPath(home, platform, localAppData) {
-  const binaryName = platform === 'win32' ? 'myco.exe' : 'myco';
-  return (platform === 'win32' ? path.win32 : path.posix).join(managedBinDir(home, platform, localAppData), binaryName);
-}
-
-function versionBinaryPath(home, platform, version, localAppData) {
-  const binaryName = platform === 'win32' ? 'myco.exe' : 'myco';
-  const p = platform === 'win32' ? path.win32 : path.posix;
-  return p.join(managedBinDir(home, platform, localAppData), 'versions', version, binaryName);
+  return path.join(os.homedir(), '.myco');
 }
 
 function detectTarget() {
@@ -82,11 +80,10 @@ function detectTarget() {
  *
  * Returns `{ dest, copied, pinAction }` for callers/tests to assert.
  *
- * @param {{ home: string, platform: string, resolvedBinary: string, dest: string, channel: string, version?: string, versionedDest?: string, writeMarker?: Function }} args
+ * @param {{ mycoHome: string, platform: string, resolvedBinary: string, dest: string, channel: string, version?: string, versionedDest?: string, writeMarker?: Function }} args
  */
-export function convergeNpmInstall({ home, platform, resolvedBinary, dest, channel, version, versionedDest, writeMarker }) {
+export function convergeNpmInstall({ mycoHome, platform, resolvedBinary, dest, channel, version, versionedDest, writeMarker }) {
   const log = (msg) => process.stderr.write(`[myco] ${msg}\n`);
-  const mycoHome = path.join(home, '.myco');
   let copied = false;
   let pinAction = 'skipped';
 
@@ -290,7 +287,7 @@ async function main() {
   // the published tarball.
   if (!isSourceCheckout) {
     try {
-      const home = os.homedir();
+      const mycoHome = resolveMycoHome();
       const platform = process.platform;
       // `pkg.version` is the bare semver (e.g. "1.2.3") — npm packages never
       // carry the "myco/v" tag prefix that curl installers use. This is the
@@ -300,13 +297,13 @@ async function main() {
         pkg = JSON.parse(fs.readFileSync(path.join(pkgRoot, 'package.json'), 'utf8'));
       } catch { /* version stays null; versionedDest skipped */ }
       const version = pkg.version ?? null;
-      const dest = managedBinaryPath(home, platform, process.env.LOCALAPPDATA);
+      const dest = managedBinaryPath(mycoHome, platform, process.env.LOCALAPPDATA);
       const versionedDest = version
-        ? versionBinaryPath(home, platform, version, process.env.LOCALAPPDATA)
+        ? versionBinaryPath(mycoHome, platform, version, process.env.LOCALAPPDATA)
         : null;
       const channel = deriveChannel(pkgRoot);
       convergeNpmInstall({
-        home,
+        mycoHome,
         platform,
         resolvedBinary: binaryPath,
         dest,

--- a/packages/myco/src/cli/doctor.ts
+++ b/packages/myco/src/cli/doctor.ts
@@ -564,7 +564,7 @@ async function checkService(): Promise<DoctorCheck> {
   const label = serviceLabel(variant);
   const status = await mgr.status(label);
   const serviceExec = resolveServiceExecutable(variant);
-  const managedBinary = managedBinaryPath(os.homedir(), process.platform, process.env.LOCALAPPDATA);
+  const managedBinary = managedBinaryPath(resolveMycoHome(), process.platform, process.env.LOCALAPPDATA);
   return evaluateServiceCheck(label, status, serviceExec, { variant, managedBinary });
 }
 

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -505,6 +505,12 @@ const MachineDaemonSchema = z.object({
   log_retention_days: z.number().int().min(1).max(365).default(30),
   /** Update channel — `stable` (default) or `beta` for dogfood/preview builds. */
   update_channel: z.enum(['stable', 'beta']).default('stable'),
+  /**
+   * How often the daemon checks the release channel for a newer version, in
+   * hours. Positive (fractional allowed for dogfood/testing). Default 6. This
+   * is the canonical home — the legacy `~/.myco/update.yaml` is retired.
+   */
+  check_interval_hours: z.number().positive().max(8760).default(6),
 });
 
 // NOTE: the registry block (`grove.default_grove_id`) used to live

--- a/packages/myco/src/config/scope.ts
+++ b/packages/myco/src/config/scope.ts
@@ -36,6 +36,7 @@ export const SCOPE_REGISTRY: Record<string, ScopeEntry> = {
   'daemon.log_level': { home: 'machine', overridableBy: [] },
   'daemon.log_retention_days': { home: 'machine', overridableBy: [] },
   'daemon.update_channel': { home: 'machine', overridableBy: [] },
+  'daemon.check_interval_hours': { home: 'machine', overridableBy: [] },
   // Legacy `update.channel` leaf. Runtime reads/writes machine
   // `daemon.update_channel` exclusively, and the loader lifts any legacy
   // `update.channel` from myco.yaml or local.yaml to machine once, then strips

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -2285,6 +2285,19 @@ export async function main(): Promise<void> {
         target_version: sentinel.targetVersion,
         initiator: sentinel.initiator,
       });
+    } else if (sentinel) {
+      // An adopt was attempted but the daemon came back on a DIFFERENT version —
+      // the adopt failed (crash / restore). Mark the target version failed so the
+      // idle adopt job never re-adopts a known-bad release (otherwise it loops
+      // every ~10-min sentinel stale-window), then clear the sentinel now.
+      const { markAdoptFailed } = await import('../upgrade/auto-check.js');
+      markAdoptFailed(mycoHome, process.platform, sentinel.targetVersion, process.env.LOCALAPPDATA);
+      updateInProgress.clear(daemonService.stateDir);
+      logger.warn(LOG_KINDS.DAEMON_START, 'Adopt did not reach target version — marked failed, sentinel cleared', {
+        target_version: sentinel.targetVersion,
+        running_version: server.version,
+        initiator: sentinel.initiator,
+      });
     }
   }
 

--- a/packages/myco/src/daemon/update-checker.ts
+++ b/packages/myco/src/daemon/update-checker.ts
@@ -19,7 +19,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
-import YAML from 'yaml';
 import semver from 'semver';
 import { loadMachineConfig, updateTierConfigRaw } from '../config/loader.js';
 import { setAtPath } from '../utils/dot-path.js';
@@ -28,8 +27,6 @@ import {
   NPM_PACKAGE_NAME,
   MYCO_GLOBAL_DIR,
   UPDATE_CHECK_CACHE_PATH,
-  UPDATE_CONFIG_PATH,
-  UPDATE_CHECK_INTERVAL_HOURS,
   MS_PER_HOUR,
   DEV_BUILD_CACHE_PATH,
   DEFAULT_RELEASE_CHANNEL,
@@ -47,7 +44,7 @@ import { getPluginVersion } from '../version.js';
 // Public types
 // ---------------------------------------------------------------------------
 
-/** Persisted update configuration stored in ~/.myco/update.yaml */
+/** Daemon update config (channel + check cadence), read from the canonical machine config `daemon.*`. */
 export interface UpdateConfig {
   channel: ReleaseChannel;
   check_interval_hours: number;
@@ -488,44 +485,19 @@ export function detectDevBuild(
 // Config helpers
 // ---------------------------------------------------------------------------
 
-/** Default config returned when no update.yaml exists. */
-function defaultUpdateConfig(): UpdateConfig {
-  return {
-    channel: DEFAULT_RELEASE_CHANNEL,
-    check_interval_hours: UPDATE_CHECK_INTERVAL_HOURS,
-  };
-}
-
 /**
- * Reads ~/.myco/update.yaml. Returns defaults when the file is missing or
- * unparseable.
+ * Reads the daemon's update config from the CANONICAL machine config
+ * (`~/.myco/config.yaml` `daemon.*`) — the SAME source the UI/CLI write via
+ * `writeProjectReleaseChannel`. This is deliberately NOT a separate file: the
+ * old `~/.myco/update.yaml` diverged from `daemon.update_channel` (nothing ever
+ * wrote it), so the background auto-adopt silently ignored channel switches.
+ * Reading the daemon config makes the channel + cadence a single source of truth.
  */
 export function readUpdateConfig(): UpdateConfig {
-  try {
-    const raw = fs.readFileSync(UPDATE_CONFIG_PATH, 'utf-8');
-    const parsed = YAML.parse(raw) as Partial<UpdateConfig>;
-
-    const channel = RELEASE_CHANNELS.includes(parsed?.channel as ReleaseChannel)
-      ? (parsed.channel as ReleaseChannel)
-      : DEFAULT_RELEASE_CHANNEL;
-
-    const check_interval_hours =
-      typeof parsed?.check_interval_hours === 'number' && parsed.check_interval_hours > 0
-        ? parsed.check_interval_hours
-        : UPDATE_CHECK_INTERVAL_HOURS;
-
-    return { channel, check_interval_hours };
-  } catch {
-    return defaultUpdateConfig();
-  }
-}
-
-/**
- * Writes UpdateConfig to ~/.myco/update.yaml. Creates ~/.myco/ if needed.
- */
-export function writeUpdateConfig(config: UpdateConfig): void {
-  fs.mkdirSync(MYCO_GLOBAL_DIR, { recursive: true });
-  fs.writeFileSync(UPDATE_CONFIG_PATH, YAML.stringify(config), 'utf-8');
+  return {
+    channel: readProjectReleaseChannel(),
+    check_interval_hours: loadMachineConfig().daemon.check_interval_hours,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/myco/src/install/managed-binary.ts
+++ b/packages/myco/src/install/managed-binary.ts
@@ -1,9 +1,13 @@
 /**
- * Canonical managed-binary path + install-marker helpers.
+ * Install-marker helpers, plus a re-export of the canonical managed-binary path
+ * layout.
  *
- * This module is the single owner of the path computation for the managed
- * binary (`~/.myco/bin/myco` / `%LOCALAPPDATA%\Myco\bin\myco.exe`) and the
- * `~/.myco/install.json` marker that records how the binary was installed.
+ * The PATH layout itself lives in ONE plain-ESM module — `scripts/managed-paths.mjs`
+ * — which is imported BOTH here (compiled into the bun binary) AND by the npm
+ * postinstall (`scripts/select-binary.mjs`). Sharing one module is what keeps
+ * the JS and TS copies from drifting; the historical duplication is what let
+ * the doubled-path (`~/.myco/.myco/bin`) bug ship. See that module for the
+ * `home` → `mycoHome` convention (callers pass the resolved myco-home).
  *
  * Note: the *running* binary is resolved elsewhere via the existing
  * `resolveManagedBinaryPath()` in `symbionts/installer.ts`; this module only
@@ -14,94 +18,19 @@ import type { ReleaseChannel } from '@myco/constants/update';
 import fs from 'node:fs';
 import path from 'node:path';
 
+export {
+  managedBinDir,
+  managedBinaryPath,
+  versionsDir,
+  versionDir,
+  versionBinaryPath,
+} from '../../scripts/managed-paths.mjs';
+
 /** Shape of the install marker written to `<myco-home>/install.json`. */
 export interface InstallMarker {
   channel: ReleaseChannel;
   source: 'curl' | 'npm';
   bin: string;
-}
-
-/**
- * Returns the managed binary directory for the given home directory and
- * platform.
- *
- * On win32, pass the real `%LOCALAPPDATA%` value as `localAppData` to avoid
- * divergence under Known-Folder redirection or roaming profiles. When omitted,
- * falls back to `<home>/AppData/Local` (the historical default). On non-win32
- * platforms `localAppData` is ignored.
- *
- * This module remains pure — it does NOT read `process.env`. Callers that
- * need the real env value pass `process.env.LOCALAPPDATA` at the call site.
- */
-export function managedBinDir(
-  home: string,
-  platform: NodeJS.Platform | string,
-  localAppData?: string,
-): string {
-  const p = platform === 'win32' ? path.win32 : path.posix;
-  if (platform === 'win32') {
-    // Prefer the injected %LOCALAPPDATA% (real env value, honors KF redirection
-    // and roaming profiles). Fall back to the computed default when absent.
-    const appDataLocal = localAppData ?? p.join(home, 'AppData', 'Local');
-    return p.join(appDataLocal, 'Myco', 'bin');
-  }
-  return p.join(home, '.myco', 'bin');
-}
-
-/** Returns the full path to the managed binary for the given home and platform.
- *
- * Pass `localAppData` on win32 to honor the real `%LOCALAPPDATA%` env var
- * (see `managedBinDir`). Ignored on non-win32 platforms.
- */
-export function managedBinaryPath(
-  home: string,
-  platform: NodeJS.Platform | string,
-  localAppData?: string,
-): string {
-  const binaryName = platform === 'win32' ? 'myco.exe' : 'myco';
-  return (platform === 'win32' ? path.win32 : path.posix).join(managedBinDir(home, platform, localAppData), binaryName);
-}
-
-/**
- * Returns the versions directory (`<bindir>/versions`) for the managed binary.
- *
- * Pass `localAppData` on win32 — see `managedBinDir` for details.
- */
-export function versionsDir(
-  home: string,
-  platform: NodeJS.Platform | string,
-  localAppData?: string,
-): string {
-  return (platform === 'win32' ? path.win32 : path.posix).join(managedBinDir(home, platform, localAppData), 'versions');
-}
-
-/**
- * Returns the directory for a specific version (`<bindir>/versions/<version>`).
- *
- * Pass `localAppData` on win32 — see `managedBinDir` for details.
- */
-export function versionDir(
-  home: string,
-  platform: NodeJS.Platform | string,
-  version: string,
-  localAppData?: string,
-): string {
-  return (platform === 'win32' ? path.win32 : path.posix).join(versionsDir(home, platform, localAppData), version);
-}
-
-/**
- * Returns the full path to the versioned binary (`<versionDir>/myco[.exe]`).
- *
- * Pass `localAppData` on win32 — see `managedBinDir` for details.
- */
-export function versionBinaryPath(
-  home: string,
-  platform: NodeJS.Platform | string,
-  version: string,
-  localAppData?: string,
-): string {
-  const binaryName = platform === 'win32' ? 'myco.exe' : 'myco';
-  return (platform === 'win32' ? path.win32 : path.posix).join(versionDir(home, platform, version, localAppData), binaryName);
 }
 
 /**

--- a/packages/myco/src/service/self-install.ts
+++ b/packages/myco/src/service/self-install.ts
@@ -1,9 +1,8 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import { getServiceManager } from './manager.js';
 import { buildServiceSpec } from './spec-builder.js';
 import { serviceLabel } from './labels.js';
-import { isDevServiceMode } from '../grove/paths.js';
+import { isDevServiceMode, resolveMycoHome } from '../grove/paths.js';
 import { managedBinaryPath } from '../install/managed-binary.js';
 import type { ServiceManager, ServiceVariant } from './types.js';
 
@@ -36,15 +35,15 @@ export interface SelfInstallOptions {
  * silently run released code as the `service-dev` unit, violating strict
  * variant isolation (AGENTS.md).
  *
- * `home` and `platform` are injectable for deterministic testing.
+ * `mycoHome` and `platform` are injectable for deterministic testing.
  */
 export function defaultServiceExecutable(
   variant: ServiceVariant,
-  home: string = os.homedir(),
+  mycoHome: string = resolveMycoHome(),
   platform: NodeJS.Platform = process.platform,
 ): string {
   if (variant === 'prod') {
-    const managed = managedBinaryPath(home, platform, process.env.LOCALAPPDATA);
+    const managed = managedBinaryPath(mycoHome, platform, process.env.LOCALAPPDATA);
     if (fs.existsSync(managed)) return managed;
   }
   return process.execPath;

--- a/packages/myco/src/symbionts/installer.ts
+++ b/packages/myco/src/symbionts/installer.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
-import { expandHome, resolveHomeDir, resolveMycoHome } from '../grove/paths.js';
+import { expandHome, resolveMycoHome } from '../grove/paths.js';
 import { atomicWriteFileSync } from '../utils/atomic-write.js';
 import { findTomlSectionEnd, buildTomlMcpSection, upsertTomlSection, upsertTomlSectionKeys, removeTomlSectionKeys, readTomlSectionKey } from './toml-helpers.js';
 import {
@@ -199,12 +199,12 @@ function resolveLauncherCmd(_scope: InstallScope, binaryPath: string): string {
  * `runtime.command` pin's job; this path must remain daemon-agnostic.
  */
 export function resolveManagedBinaryPath(
-  home: string = resolveHomeDir(),
+  mycoHome: string = resolveMycoHome(),
   platform: NodeJS.Platform = process.platform,
 ): string {
   const pin = resolveRuntimeCommand();
   if (pin) return pin.replaceAll('\\', '/');
-  const managed = managedBinaryPath(home, platform, process.env.LOCALAPPDATA);
+  const managed = managedBinaryPath(mycoHome, platform, process.env.LOCALAPPDATA);
   if (fs.existsSync(managed)) return managed.replaceAll('\\', '/');
   return process.execPath.replaceAll('\\', '/');
 }

--- a/packages/myco/src/upgrade/auto-check.ts
+++ b/packages/myco/src/upgrade/auto-check.ts
@@ -24,6 +24,7 @@
  */
 
 import fs from 'node:fs';
+import path from 'node:path';
 import semver from 'semver';
 
 import {
@@ -35,6 +36,7 @@ import type { InitiateAdoptOpts } from './adopt.js';
 import { inFlight as inProgressInFlight, write as writeInProgress, sentinelPath as inProgressSentinelPathFn } from './in-progress.js';
 import {
   versionsDir,
+  versionDir,
   versionBinaryPath,
 } from '../install/managed-binary.js';
 import { isUpdateExempt } from '../daemon/update-checker.js';
@@ -206,6 +208,39 @@ export async function checkAndStage(
 }
 
 // ---------------------------------------------------------------------------
+// Failed-adopt marker
+// ---------------------------------------------------------------------------
+
+/**
+ * Marker file written into a versioned slot when an adopt of that version
+ * FAILED (the daemon came back on a different version). `resolveNewestStagedVersion`
+ * skips marked versions so a known-bad release is not re-adopted on every idle
+ * tick — without it the loop is only bounded by the ~10-min sentinel stale sweep.
+ */
+const ADOPT_FAILED_MARKER = '.adopt-failed';
+
+/**
+ * Record that adopting `version` failed by writing the marker into its versioned
+ * slot. Best-effort and never throws — a missing marker only costs one extra
+ * (bounded) retry. Called from the daemon startup path when the running version
+ * does not match the sentinel's target (see daemon/main.ts).
+ */
+export function markAdoptFailed(
+  home: string,
+  platform: NodeJS.Platform,
+  version: string,
+  localAppData?: string,
+): void {
+  try {
+    const dir = versionDir(home, platform, version, localAppData);
+    if (!fs.existsSync(dir)) return;
+    fs.writeFileSync(path.join(dir, ADOPT_FAILED_MARKER), `${new Date().toISOString()}\n`);
+  } catch {
+    /* best effort */
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Helper: resolve the newest staged version strictly greater than current
 // ---------------------------------------------------------------------------
 
@@ -236,6 +271,11 @@ export function resolveNewestStagedVersion(
   const candidates = entries
     .filter((entry) => semver.valid(entry) !== null)
     .filter((entry) => semver.gt(entry, currentVersion))
+    // Skip versions whose adopt already failed (marker in the slot) — otherwise a
+    // known-bad release is re-adopted on every idle tick / stale-window.
+    .filter(
+      (entry) => !existsSyncFn(path.join(versionDir(home, platform, entry, localAppData), ADOPT_FAILED_MARKER)),
+    )
     // Sort newest-first.
     .sort((a, b) => semver.compare(semver.valid(b)!, semver.valid(a)!));
 

--- a/tests/cli/select-binary.test.ts
+++ b/tests/cli/select-binary.test.ts
@@ -13,6 +13,10 @@ interface Fixture {
   target: string;
   binaryName: string;
   binaryPath: string;
+  /** Hermetic env for the spawned postinstall — HOME + MYCO_HOME redirected into the temp tree. */
+  scriptEnv: NodeJS.ProcessEnv;
+  /** The sandbox myco-home (`<sandboxHome>/.myco`) the convergence writes into. */
+  mycoHome: string;
 }
 
 function hostTarget(): string | null {
@@ -41,6 +45,13 @@ function makeFixture(options?: { sourceCheckout?: boolean; includeBinary?: boole
 
   const scriptPath = path.join(scriptsDir, 'select-binary.mjs');
   fs.copyFileSync(SCRIPT_SOURCE, scriptPath);
+  // select-binary.mjs imports the shared `./managed-paths.mjs` path module — it
+  // ships alongside the script in `scripts/` and must travel with it into the
+  // scaffolded package, or the postinstall subprocess crashes at module load.
+  fs.copyFileSync(
+    path.resolve('packages/myco/scripts/managed-paths.mjs'),
+    path.join(scriptsDir, 'managed-paths.mjs'),
+  );
 
   if (options?.sourceCheckout) {
     fs.mkdirSync(path.join(pkgRoot, 'src'), { recursive: true });
@@ -64,7 +75,17 @@ function makeFixture(options?: { sourceCheckout?: boolean; includeBinary?: boole
     fs.writeFileSync(binaryPath, 'binary');
   }
 
-  return { tmpDir, pkgRoot, scriptPath, target, binaryName, binaryPath };
+  // HERMETIC SANDBOX (critical): the postinstall CONVERGES into MYCO_HOME,
+  // which DEFAULTS to ~/.myco. Every spawn MUST redirect HOME + MYCO_HOME into
+  // the temp tree — otherwise a test with a real platform binary present writes
+  // the fixture's fake binary over the developer's REAL ~/.myco/bin/myco, which
+  // breaks every hook on the machine (the runtime.command pin execs that path).
+  const sandboxHome = path.join(tmpDir, 'sandbox-home');
+  const mycoHome = path.join(sandboxHome, '.myco');
+  fs.mkdirSync(sandboxHome, { recursive: true });
+  const scriptEnv = { ...process.env, HOME: sandboxHome, MYCO_HOME: mycoHome };
+
+  return { tmpDir, pkgRoot, scriptPath, target, binaryName, binaryPath, scriptEnv, mycoHome };
 }
 
 describe('select-binary postinstall', () => {
@@ -84,6 +105,7 @@ describe('select-binary postinstall', () => {
     const result = spawnSync(process.execPath, [fixture.scriptPath], {
       cwd: fixture.pkgRoot,
       encoding: 'utf8',
+      env: fixture.scriptEnv,
     });
 
     expect(result.status).toBe(0);
@@ -97,6 +119,7 @@ describe('select-binary postinstall', () => {
     const result = spawnSync(process.execPath, [fixture.scriptPath], {
       cwd: fixture.pkgRoot,
       encoding: 'utf8',
+      env: fixture.scriptEnv,
     });
 
     expect(result.status).toBe(1);
@@ -111,6 +134,7 @@ describe('select-binary postinstall', () => {
     const result = spawnSync(process.execPath, [fixture.scriptPath], {
       cwd: fixture.pkgRoot,
       encoding: 'utf8',
+      env: fixture.scriptEnv,
     });
 
     expect(result.status).toBe(0);
@@ -142,14 +166,10 @@ describe('select-binary postinstall', () => {
     expect(fs.existsSync(path.join(fixture.pkgRoot, 'dist', 'src'))).toBe(false);
     expect(fs.existsSync(path.join(fixture.pkgRoot, 'src'))).toBe(false);
 
-    // Run with a custom HOME so convergence writes to a temp dir, not the real ~/.myco.
-    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-conv-smoke-'));
-    fixtures.push({ ...fixture, tmpDir: fakeHome }); // ensure cleanup
-
     const result = spawnSync(process.execPath, [fixture.scriptPath], {
       cwd: fixture.pkgRoot,
       encoding: 'utf8',
-      env: { ...process.env, HOME: fakeHome, MYCO_HOME: path.join(fakeHome, '.myco') },
+      env: fixture.scriptEnv,
     });
 
     expect(result.status).toBe(0);
@@ -157,17 +177,18 @@ describe('select-binary postinstall', () => {
     expect(result.stderr).not.toContain('managed-binary module not found in dist/');
     expect(result.stderr).not.toContain('Convergence skipped');
 
-    // Stable managed binary must be laid down.
+    // Convergence wrote into the sandbox myco-home, never the real ~/.myco.
+    // Stable managed binary at <mycoHome>/bin/myco[.exe].
     const binaryName = process.platform === 'win32' ? 'myco.exe' : 'myco';
-    const managedBin = path.join(fakeHome, '.myco', 'bin', binaryName);
+    const managedBin = path.join(fixture.mycoHome, 'bin', binaryName);
     expect(fs.existsSync(managedBin)).toBe(true);
 
-    // Versioned slot must exist at <bindir>/versions/1.2.3/myco[.exe].
-    const versionedBin = path.join(fakeHome, '.myco', 'bin', 'versions', '1.2.3', binaryName);
+    // Versioned slot at <mycoHome>/bin/versions/1.2.3/myco[.exe].
+    const versionedBin = path.join(fixture.mycoHome, 'bin', 'versions', '1.2.3', binaryName);
     expect(fs.existsSync(versionedBin)).toBe(true);
 
-    // install.json marker must be present.
-    const markerPath = path.join(fakeHome, '.myco', 'install.json');
+    // install.json marker at <mycoHome>/install.json.
+    const markerPath = path.join(fixture.mycoHome, 'install.json');
     expect(fs.existsSync(markerPath)).toBe(true);
     const marker = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
     expect(marker.source).toBe('npm');

--- a/tests/cli/upgrade.test.ts
+++ b/tests/cli/upgrade.test.ts
@@ -123,6 +123,21 @@ function makeDeps(overrides: Partial<UpgradeDeps> = {}): UpgradeDeps {
     })),
     initiateAdopt: vi.fn(async (_opts) => {}),
     writeChannel: vi.fn((_vaultDir, _channel) => {}),
+    // checkFn stubbed so `--check` NEVER hits the real GitHub releases API —
+    // resolveMycoPackageCheck defaults to `globalThis.fetch`, which hangs on CI.
+    // Returns a deterministic up-to-date result (report-only path; no stage/adopt).
+    checkFn: vi.fn(async (_current, _channel, _installed) => ({
+      id: 'myco' as const,
+      display_name: 'Myco',
+      package_name: '@goondocks/myco',
+      installed: true,
+      installed_version: '1.0.0',
+      latest_version: '1.0.0',
+      latest_stable: '1.0.0',
+      latest_beta: null,
+      update_available: false,
+      revert_available: false,
+    })),
     ...overrides,
   };
 }

--- a/tests/daemon/api/upgrade.test.ts
+++ b/tests/daemon/api/upgrade.test.ts
@@ -724,11 +724,12 @@ describe('handleUpgradeApply', () => {
     (resolveNewestStagedVersion as AnyMock).mockReturnValue(null);
     (resolveRuntimeCommand as AnyMock).mockReturnValue(null);
 
-    // Point home at a tmpdir and pre-create the versioned binary so the
-    // already-staged guard short-circuits the stage step. The managed layout is
-    // `<home>/.myco/bin/versions/<v>/myco` on POSIX (see managed-binary.ts).
+    // Point the myco-home at a tmpdir and pre-create the versioned binary so the
+    // already-staged guard short-circuits the stage step. The deps `home` IS the
+    // resolved myco-home (`resolveMycoHome()`), so the managed layout is
+    // `<mycoHome>/bin/versions/<v>/myco` on POSIX (see managed-paths.mjs).
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-revert-home-'));
-    const vBinDir = path.join(home, '.myco', 'bin', 'versions', '1.0.0');
+    const vBinDir = path.join(home, 'bin', 'versions', '1.0.0');
     fs.mkdirSync(vBinDir, { recursive: true });
     fs.writeFileSync(path.join(vBinDir, 'myco'), '#!/bin/sh\n');
 

--- a/tests/daemon/update-checker.test.ts
+++ b/tests/daemon/update-checker.test.ts
@@ -4,7 +4,7 @@
  * Covers:
  * - isUpdateExempt / setDevBuildCliEntry — dev-mode exemption via
  *   module-level state (replaces the old MYCO_CMD env-var dispatch)
- * - readUpdateConfig — defaults when missing, reads YAML when present
+ * - readUpdateConfig — reads channel + cadence from the canonical daemon config
  * - isCacheStale — null cache, fresh cache, expired cache
  * - detectDevBuild — realpath comparison against npm global prefix
  * - resolveMycoBinary — dev CLI entry vs literal `myco` fallback
@@ -105,7 +105,6 @@ import {
   type CachedCheck,
   type UpdateConfig,
 } from '@myco/daemon/update-checker.js';
-import { UPDATE_CONFIG_PATH } from '@myco/constants/update.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -521,40 +520,28 @@ describe('release channel helpers (machine-scoped, decision-46130740)', () => {
 // readUpdateConfig
 // ---------------------------------------------------------------------------
 
-describe('readUpdateConfig()', () => {
-  it('returns defaults when the config file is missing', () => {
+describe('readUpdateConfig() — reads the canonical daemon config', () => {
+  // readUpdateConfig now delegates to the machine config `daemon.*` (the SAME
+  // source the UI/CLI write), NOT a separate ~/.myco/update.yaml. Invalid
+  // channel/interval values are rejected at the schema layer (covered by config
+  // tests), so they are no longer this function's concern.
+  const MACHINE_CONFIG_PATH = '/mock-home/.myco/config.yaml';
+
+  it('returns schema defaults when the machine config is missing', () => {
     mockNoFiles();
-    const config = readUpdateConfig();
+    const config: UpdateConfig = readUpdateConfig();
     expect(config.channel).toBe('stable');
-    expect(config.check_interval_hours).toBeGreaterThan(0);
+    expect(config.check_interval_hours).toBe(6);
   });
 
-  it('reads channel from yaml when file exists', () => {
+  it('reads channel + cadence from daemon.* in machine config', () => {
     mockFileContent(
-      UPDATE_CONFIG_PATH,
-      'channel: beta\ncheck_interval_hours: 12\n',
+      MACHINE_CONFIG_PATH,
+      'daemon:\n  update_channel: beta\n  check_interval_hours: 12\n',
     );
     const config = readUpdateConfig();
     expect(config.channel).toBe('beta');
     expect(config.check_interval_hours).toBe(12);
-  });
-
-  it('falls back to stable channel for unknown channel values', () => {
-    mockFileContent(
-      UPDATE_CONFIG_PATH,
-      'channel: nightly\ncheck_interval_hours: 6\n',
-    );
-    const config = readUpdateConfig();
-    expect(config.channel).toBe('stable');
-  });
-
-  it('falls back to default interval for invalid interval value', () => {
-    mockFileContent(
-      UPDATE_CONFIG_PATH,
-      'channel: stable\ncheck_interval_hours: -5\n',
-    );
-    const config: UpdateConfig = readUpdateConfig();
-    expect(config.check_interval_hours).toBeGreaterThan(0);
   });
 });
 

--- a/tests/install/managed-binary.test.ts
+++ b/tests/install/managed-binary.test.ts
@@ -1,117 +1,46 @@
 import { describe, it, expect } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import {
-  managedBinDir,
   managedBinaryPath,
-  versionsDir,
-  versionDir,
-  versionBinaryPath,
   writeInstallMarker,
   readInstallMarker,
 } from '@myco/install/managed-binary';
 
-describe('managed-binary', () => {
-  it('resolves per-OS managed paths', () => {
-    expect(managedBinaryPath('/home/u', 'linux')).toBe('/home/u/.myco/bin/myco');
-    expect(managedBinaryPath('C:/Users/u', 'win32')).toMatch(/Myco[\\/]+bin[\\/]+myco\.exe$/);
+// The path-layout helpers now live in the shared `scripts/managed-paths.mjs`
+// module and are exhaustively covered (myco-home convention, win32 localAppData
+// rooting, no doubled `.myco/.myco`) in tests/install/managed-paths.test.ts.
+// This file covers what `managed-binary.ts` still OWNS — the install marker —
+// plus a smoke that the path helpers are re-exported on the new convention.
+
+describe('managed-binary: re-exports path helpers on the myco-home convention', () => {
+  it('roots the managed binary at <mycoHome>/bin (no extra .myco)', () => {
+    expect(managedBinaryPath('/home/u/.myco', 'linux')).toBe('/home/u/.myco/bin/myco');
+    expect(managedBinaryPath('/home/u/.myco', 'linux')).not.toContain('.myco/.myco');
   });
+});
 
-  describe('win32 with localAppData override', () => {
-    it('uses the injected localAppData when provided', () => {
-      // Real %LOCALAPPDATA% differs from <home>/AppData/Local under KF redirection.
-      const result = managedBinaryPath('C:/Users/u', 'win32', 'D:/CustomAppData');
-      expect(result).toMatch(/D:[/\\]CustomAppData[/\\]Myco[/\\]bin[/\\]myco\.exe/);
-    });
-
-    it('falls back to <home>/AppData/Local when localAppData is absent', () => {
-      const result = managedBinaryPath('C:/Users/u', 'win32');
-      expect(result).toMatch(/C:[/\\]Users[/\\]u[/\\]AppData[/\\]Local[/\\]Myco[/\\]bin[/\\]myco\.exe/);
-    });
-
-    it('ignores localAppData on posix', () => {
-      const result = managedBinaryPath('/home/u', 'linux', 'D:/ShouldBeIgnored');
-      expect(result).toBe('/home/u/.myco/bin/myco');
-    });
-  });
-
-  describe('managedBinDir with localAppData', () => {
-    it('uses the injected localAppData on win32', () => {
-      const result = managedBinDir('C:/Users/u', 'win32', 'C:/Users/u/AppDataRedirected/Local');
-      expect(result).toMatch(/AppDataRedirected[/\\]Local[/\\]Myco[/\\]bin/);
-    });
-
-    it('ignores localAppData on posix', () => {
-      const result = managedBinDir('/home/u', 'darwin', 'D:/ShouldBeIgnored');
-      expect(result).toBe('/home/u/.myco/bin');
-    });
-  });
-
-  describe('versionsDir', () => {
-    it('returns <bindir>/versions on linux', () => {
-      expect(versionsDir('/home/u', 'linux')).toBe('/home/u/.myco/bin/versions');
-    });
-
-    it('returns <bindir>/versions on win32 (default appdata)', () => {
-      const result = versionsDir('C:/Users/u', 'win32');
-      expect(result).toMatch(/C:[/\\]Users[/\\]u[/\\]AppData[/\\]Local[/\\]Myco[/\\]bin[/\\]versions/);
-    });
-
-    it('honors localAppData override on win32', () => {
-      const result = versionsDir('C:/Users/u', 'win32', 'D:/CustomAppData');
-      expect(result).toMatch(/D:[/\\]CustomAppData[/\\]Myco[/\\]bin[/\\]versions/);
-    });
-
-    it('ignores localAppData on posix', () => {
-      expect(versionsDir('/home/u', 'linux', 'D:/Ignored')).toBe('/home/u/.myco/bin/versions');
-    });
-  });
-
-  describe('versionDir', () => {
-    it('returns <bindir>/versions/<version> on linux', () => {
-      expect(versionDir('/home/u', 'linux', '1.2.3')).toBe('/home/u/.myco/bin/versions/1.2.3');
-    });
-
-    it('returns correct path on win32', () => {
-      const result = versionDir('C:/Users/u', 'win32', '1.2.3');
-      expect(result).toMatch(/C:[/\\]Users[/\\]u[/\\]AppData[/\\]Local[/\\]Myco[/\\]bin[/\\]versions[/\\]1\.2\.3/);
-    });
-
-    it('honors localAppData override on win32', () => {
-      const result = versionDir('C:/Users/u', 'win32', '1.2.3', 'D:/CustomAppData');
-      expect(result).toMatch(/D:[/\\]CustomAppData[/\\]Myco[/\\]bin[/\\]versions[/\\]1\.2\.3/);
-    });
-  });
-
-  describe('versionBinaryPath', () => {
-    it('returns <bindir>/versions/<version>/myco on linux', () => {
-      expect(versionBinaryPath('/home/u', 'linux', '1.2.3')).toBe(
-        '/home/u/.myco/bin/versions/1.2.3/myco',
-      );
-    });
-
-    it('returns <bindir>/versions/<version>/myco.exe on win32', () => {
-      const result = versionBinaryPath('C:/Users/u', 'win32', '1.2.3');
-      expect(result).toMatch(
-        /C:[/\\]Users[/\\]u[/\\]AppData[/\\]Local[/\\]Myco[/\\]bin[/\\]versions[/\\]1\.2\.3[/\\]myco\.exe/,
-      );
-    });
-
-    it('honors localAppData override on win32', () => {
-      const result = versionBinaryPath('C:/Users/u', 'win32', '1.2.3', 'D:/CustomAppData');
-      expect(result).toMatch(
-        /D:[/\\]CustomAppData[/\\]Myco[/\\]bin[/\\]versions[/\\]1\.2\.3[/\\]myco\.exe/,
-      );
-    });
-
-    it('ignores localAppData on posix', () => {
-      expect(versionBinaryPath('/home/u', 'linux', '1.2.3', 'D:/Ignored')).toBe(
-        '/home/u/.myco/bin/versions/1.2.3/myco',
-      );
-    });
-  });
-
+describe('managed-binary: install marker', () => {
   it('round-trips the marker', () => {
-    const dir = `/tmp/mb-${process.pid}`;
-    writeInstallMarker(dir, { channel: 'stable', source: 'npm', bin: `${dir}/bin/myco` });
-    expect(readInstallMarker(dir)?.source).toBe('npm');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mb-marker-'));
+    try {
+      writeInstallMarker(dir, { channel: 'stable', source: 'npm', bin: `${dir}/bin/myco` });
+      const marker = readInstallMarker(dir);
+      expect(marker?.source).toBe('npm');
+      expect(marker?.channel).toBe('stable');
+      expect(marker?.bin).toBe(`${dir}/bin/myco`);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null when the marker is absent', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mb-marker-'));
+    try {
+      expect(readInstallMarker(dir)).toBeNull();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/install/managed-paths.test.ts
+++ b/tests/install/managed-paths.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Path-layout regression tests for the shared managed-paths module.
+ *
+ * The doubled-path bug (`~/.myco/.myco/bin`) that broke the daemon auto-adopt
+ * AND manual `myco upgrade` shipped because these helpers had ZERO coverage and
+ * an ambiguous `home` param: install/service/doctor callers passed the os-home
+ * (and the helper appended `.myco/bin`), while the upgrade domain passed the
+ * myco-home (`~/.myco`) — which then doubled. The single shared module now
+ * takes the resolved MYCO-HOME and appends `bin` on POSIX; these tests lock
+ * that in and assert the doubled `.myco/.myco` segment can never reappear for
+ * any caller's home value, default or custom `$MYCO_HOME`. (Imported via the TS
+ * re-export so we also cover the binary-facing surface.)
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  managedBinDir,
+  managedBinaryPath,
+  versionsDir,
+  versionDir,
+  versionBinaryPath,
+} from '@myco/install/managed-binary.js';
+
+describe('managed-paths: POSIX roots at the myco-home + bin (never .myco/bin)', () => {
+  const mycoHome = '/Users/alice/.myco';
+
+  test('managedBinDir', () => {
+    expect(managedBinDir(mycoHome, 'darwin')).toBe('/Users/alice/.myco/bin');
+  });
+
+  test('managedBinaryPath (darwin + linux)', () => {
+    expect(managedBinaryPath(mycoHome, 'darwin')).toBe('/Users/alice/.myco/bin/myco');
+    expect(managedBinaryPath(mycoHome, 'linux')).toBe('/Users/alice/.myco/bin/myco');
+  });
+
+  test('versionsDir / versionDir / versionBinaryPath', () => {
+    expect(versionsDir(mycoHome, 'linux')).toBe('/Users/alice/.myco/bin/versions');
+    expect(versionDir(mycoHome, 'linux', '1.2.0-beta.3')).toBe('/Users/alice/.myco/bin/versions/1.2.0-beta.3');
+    expect(versionBinaryPath(mycoHome, 'linux', '1.2.0-beta.3')).toBe(
+      '/Users/alice/.myco/bin/versions/1.2.0-beta.3/myco',
+    );
+  });
+
+  test('NO doubled .myco/.myco for any helper (the shipped bug)', () => {
+    const paths = [
+      managedBinDir(mycoHome, 'darwin'),
+      managedBinaryPath(mycoHome, 'linux'),
+      versionsDir(mycoHome, 'linux'),
+      versionDir(mycoHome, 'darwin', '9.9.9'),
+      versionBinaryPath(mycoHome, 'darwin', '9.9.9'),
+    ];
+    for (const p of paths) expect(p).not.toContain('.myco/.myco');
+  });
+});
+
+describe('managed-paths: honors a custom $MYCO_HOME (the os-home convention silently ignored it)', () => {
+  const customHome = '/opt/myco-home';
+
+  test('rooted at the custom home; no extra .myco appended', () => {
+    expect(managedBinaryPath(customHome, 'linux')).toBe('/opt/myco-home/bin/myco');
+    expect(versionBinaryPath(customHome, 'linux', '1.2.0')).toBe('/opt/myco-home/bin/versions/1.2.0/myco');
+    expect(managedBinaryPath(customHome, 'linux')).not.toContain('.myco');
+  });
+});
+
+describe('managed-paths: win32 roots at %LOCALAPPDATA%, NOT the myco-home', () => {
+  const localAppData = 'C:\\Users\\Alice\\AppData\\Local';
+
+  test('uses localAppData; the myco-home arg is ignored', () => {
+    expect(managedBinaryPath('C:\\Users\\Alice\\.myco', 'win32', localAppData)).toBe(
+      'C:\\Users\\Alice\\AppData\\Local\\Myco\\bin\\myco.exe',
+    );
+    // A custom $MYCO_HOME must NOT relocate the win32 bin dir.
+    expect(managedBinaryPath('D:\\custom\\myco', 'win32', localAppData)).toBe(
+      'C:\\Users\\Alice\\AppData\\Local\\Myco\\bin\\myco.exe',
+    );
+  });
+
+  test('versioned path under localAppData', () => {
+    expect(versionBinaryPath('C:\\Users\\Alice\\.myco', 'win32', '1.2.0', localAppData)).toBe(
+      'C:\\Users\\Alice\\AppData\\Local\\Myco\\bin\\versions\\1.2.0\\myco.exe',
+    );
+  });
+});

--- a/tests/install/select-binary-converge.test.ts
+++ b/tests/install/select-binary-converge.test.ts
@@ -13,36 +13,41 @@ const PLATFORM = process.platform === 'win32' ? 'win32' : process.platform;
 const TEST_VERSION = '1.2.3';
 
 interface Fixture {
-  home: string;
+  // The temp dir IS the resolved myco-home (what the daemon passes as the
+  // `mycoHome` arg — `resolveMycoHome()` = `~/.myco` / `$MYCO_HOME`). The managed
+  // layout (`bin/`, `bin/versions/`, `runtime.command`, `install.json`) lives
+  // directly under it.
+  mycoHome: string;
   resolvedBinary: string;
 }
 
 function makeFixture(): Fixture {
-  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-converge-home-'));
+  const mycoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-converge-home-'));
   // A fake "source" platform binary that convergence copies into the managed
-  // bin dir. Distinct content so we can assert byte-for-byte placement.
-  const srcDir = path.join(home, 'fake-platform-pkg', 'bin');
+  // bin dir. Distinct content so we can assert byte-for-byte placement. Kept in
+  // a sibling dir so it doesn't collide with the managed `bin/` layout.
+  const srcDir = path.join(mycoHome, 'fake-platform-pkg', 'bin');
   fs.mkdirSync(srcDir, { recursive: true });
   const resolvedBinary = path.join(srcDir, 'myco');
   fs.writeFileSync(resolvedBinary, 'FAKE-MYCO-BINARY-CONTENT');
-  return { home, resolvedBinary };
+  return { mycoHome, resolvedBinary };
 }
 
-function writePin(home: string, value: string): void {
-  const pinPath = path.join(home, '.myco', 'runtime.command');
+function writePin(mycoHome: string, value: string): void {
+  const pinPath = path.join(mycoHome, 'runtime.command');
   fs.mkdirSync(path.dirname(pinPath), { recursive: true });
   fs.writeFileSync(pinPath, `${value}\n`, { mode: 0o644 });
 }
 
-function readPin(home: string): string {
-  return fs.readFileSync(path.join(home, '.myco', 'runtime.command'), 'utf8').trim();
+function readPin(mycoHome: string): string {
+  return fs.readFileSync(path.join(mycoHome, 'runtime.command'), 'utf8').trim();
 }
 
 describe('select-binary convergeNpmInstall', () => {
   let fixtures: Fixture[] = [];
 
   afterEach(() => {
-    for (const f of fixtures) fs.rmSync(f.home, { recursive: true, force: true });
+    for (const f of fixtures) fs.rmSync(f.mycoHome, { recursive: true, force: true });
     fixtures = [];
   });
 
@@ -57,12 +62,12 @@ describe('select-binary convergeNpmInstall', () => {
   it('places the binary in the versioned slot then copies to stable dest (a, a2, b)', () => {
     const fixture = makeFixture();
     fixtures.push(fixture);
-    const { home, resolvedBinary } = fixture;
-    const versionedPath = versionBinaryPath(home, PLATFORM, TEST_VERSION);
-    const dest = managedBinaryPath(home, PLATFORM);
+    const { mycoHome, resolvedBinary } = fixture;
+    const versionedPath = versionBinaryPath(mycoHome, PLATFORM, TEST_VERSION);
+    const dest = managedBinaryPath(mycoHome, PLATFORM);
 
     const result = convergeNpmInstall({
-      home,
+      mycoHome,
       platform: PLATFORM,
       resolvedBinary,
       dest,
@@ -77,12 +82,14 @@ describe('select-binary convergeNpmInstall', () => {
 
     // (a2) stable dest is the canonical managed path and holds the source bytes.
     expect(result.dest).toBe(dest);
-    expect(dest).toBe(managedBinaryPath(home, PLATFORM));
+    expect(dest).toBe(managedBinaryPath(mycoHome, PLATFORM));
     expect(fs.existsSync(dest)).toBe(true);
     expect(fs.readFileSync(dest, 'utf8')).toBe('FAKE-MYCO-BINARY-CONTENT');
+    // The single-.myco invariant: the managed path is rooted at the myco-home,
+    // never doubled.
+    expect(dest).not.toContain('.myco/.myco');
 
-    // (b) no leftover temp files from the atomic placement — in either the
-    // stable bin dir or the versioned slot dir (both use temp+rename).
+    // (b) no leftover temp files from the atomic placement.
     const binDir = path.dirname(dest);
     const stableLeftovers = fs.readdirSync(binDir).filter((n) => n.includes('.tmp-'));
     expect(stableLeftovers).toEqual([]);
@@ -95,12 +102,12 @@ describe('select-binary convergeNpmInstall', () => {
   it('versioned slot path matches versions/<version>/myco layout (a3)', () => {
     const fixture = makeFixture();
     fixtures.push(fixture);
-    const { home, resolvedBinary } = fixture;
-    const versionedPath = versionBinaryPath(home, PLATFORM, TEST_VERSION);
-    const dest = managedBinaryPath(home, PLATFORM);
+    const { mycoHome, resolvedBinary } = fixture;
+    const versionedPath = versionBinaryPath(mycoHome, PLATFORM, TEST_VERSION);
+    const dest = managedBinaryPath(mycoHome, PLATFORM);
 
     convergeNpmInstall({
-      home,
+      mycoHome,
       platform: PLATFORM,
       resolvedBinary,
       dest,
@@ -109,7 +116,6 @@ describe('select-binary convergeNpmInstall', () => {
       versionedDest: versionedPath,
     });
 
-    // Path structure: <bindir>/versions/<bare-semver>/myco[.exe]
     const binaryName = PLATFORM === 'win32' ? 'myco.exe' : 'myco';
     expect(versionedPath).toContain(`versions/${TEST_VERSION}/${binaryName}`);
     expect(fs.existsSync(versionedPath)).toBe(true);
@@ -118,12 +124,12 @@ describe('select-binary convergeNpmInstall', () => {
   it('writes the runtime.command pin to dest, never group/other-writable (c)', () => {
     const fixture = makeFixture();
     fixtures.push(fixture);
-    const { home, resolvedBinary } = fixture;
-    const versionedPath = versionBinaryPath(home, PLATFORM, TEST_VERSION);
-    const dest = managedBinaryPath(home, PLATFORM);
+    const { mycoHome, resolvedBinary } = fixture;
+    const versionedPath = versionBinaryPath(mycoHome, PLATFORM, TEST_VERSION);
+    const dest = managedBinaryPath(mycoHome, PLATFORM);
 
     convergeNpmInstall({
-      home,
+      mycoHome,
       platform: PLATFORM,
       resolvedBinary,
       dest,
@@ -132,9 +138,9 @@ describe('select-binary convergeNpmInstall', () => {
       versionedDest: versionedPath,
     });
 
-    expect(readPin(home)).toBe(dest);
+    expect(readPin(mycoHome)).toBe(dest);
     if (process.platform !== 'win32') {
-      const mode = fs.statSync(path.join(home, '.myco', 'runtime.command')).mode & 0o777;
+      const mode = fs.statSync(path.join(mycoHome, 'runtime.command')).mode & 0o777;
       expect(mode & 0o022).toBe(0);
     }
   });
@@ -142,12 +148,12 @@ describe('select-binary convergeNpmInstall', () => {
   it('writes the install marker with source=npm, bin=dest, and channel (d)', () => {
     const fixture = makeFixture();
     fixtures.push(fixture);
-    const { home, resolvedBinary } = fixture;
-    const versionedPath = versionBinaryPath(home, PLATFORM, TEST_VERSION);
-    const dest = managedBinaryPath(home, PLATFORM);
+    const { mycoHome, resolvedBinary } = fixture;
+    const versionedPath = versionBinaryPath(mycoHome, PLATFORM, TEST_VERSION);
+    const dest = managedBinaryPath(mycoHome, PLATFORM);
 
     convergeNpmInstall({
-      home,
+      mycoHome,
       platform: PLATFORM,
       resolvedBinary,
       dest,
@@ -156,7 +162,7 @@ describe('select-binary convergeNpmInstall', () => {
       versionedDest: versionedPath,
     });
 
-    const marker = JSON.parse(fs.readFileSync(path.join(home, '.myco', 'install.json'), 'utf8'));
+    const marker = JSON.parse(fs.readFileSync(path.join(mycoHome, 'install.json'), 'utf8'));
     expect(marker.source).toBe('npm');
     expect(marker.bin).toBe(dest);
     expect(marker.channel).toBe('beta');
@@ -165,15 +171,15 @@ describe('select-binary convergeNpmInstall', () => {
   it('preserves a pre-existing managed-runtime pin (e)', () => {
     const fixture = makeFixture();
     fixtures.push(fixture);
-    const { home, resolvedBinary } = fixture;
-    const versionedPath = versionBinaryPath(home, PLATFORM, TEST_VERSION);
-    const dest = managedBinaryPath(home, PLATFORM);
-    // An ACTIVE beta managed runtime pin: <home>/.myco/runtime/node_modules/...
-    const managedRuntimePin = path.join(home, '.myco', 'runtime', 'node_modules', '.bin', 'myco');
-    writePin(home, managedRuntimePin);
+    const { mycoHome, resolvedBinary } = fixture;
+    const versionedPath = versionBinaryPath(mycoHome, PLATFORM, TEST_VERSION);
+    const dest = managedBinaryPath(mycoHome, PLATFORM);
+    // An ACTIVE beta managed runtime pin: <mycoHome>/runtime/node_modules/...
+    const managedRuntimePin = path.join(mycoHome, 'runtime', 'node_modules', '.bin', 'myco');
+    writePin(mycoHome, managedRuntimePin);
 
     const result = convergeNpmInstall({
-      home,
+      mycoHome,
       platform: PLATFORM,
       resolvedBinary,
       dest,
@@ -184,7 +190,7 @@ describe('select-binary convergeNpmInstall', () => {
 
     // Pin is untouched — the binary still converges, but we do NOT clobber an
     // active managed runtime.
-    expect(readPin(home)).toBe(managedRuntimePin);
+    expect(readPin(mycoHome)).toBe(managedRuntimePin);
     expect(result.pinAction).not.toBe('wrote');
     expect(fs.existsSync(dest)).toBe(true);
   });
@@ -192,15 +198,15 @@ describe('select-binary convergeNpmInstall', () => {
   it('re-points a legacy node_modules pin onto the managed binary (f)', () => {
     const fixture = makeFixture();
     fixtures.push(fixture);
-    const { home, resolvedBinary } = fixture;
-    const versionedPath = versionBinaryPath(home, PLATFORM, TEST_VERSION);
-    const dest = managedBinaryPath(home, PLATFORM);
+    const { mycoHome, resolvedBinary } = fixture;
+    const versionedPath = versionBinaryPath(mycoHome, PLATFORM, TEST_VERSION);
+    const dest = managedBinaryPath(mycoHome, PLATFORM);
     // A legacy npm install pin: inside node_modules but NOT the managed runtime.
     const legacyPin = '/somewhere/node_modules/@goondocks/myco-darwin-arm64/bin/myco';
-    writePin(home, legacyPin);
+    writePin(mycoHome, legacyPin);
 
     const result = convergeNpmInstall({
-      home,
+      mycoHome,
       platform: PLATFORM,
       resolvedBinary,
       dest,
@@ -209,26 +215,24 @@ describe('select-binary convergeNpmInstall', () => {
       versionedDest: versionedPath,
     });
 
-    expect(readPin(home)).toBe(dest);
+    expect(readPin(mycoHome)).toBe(dest);
     expect(result.pinAction).toBe('wrote');
   });
 
   it('preserves a deliberate external/dev pin (not node_modules, not managed-runtime) (g)', () => {
     const fixture = makeFixture();
     fixtures.push(fixture);
-    const { home, resolvedBinary } = fixture;
-    const versionedPath = versionBinaryPath(home, PLATFORM, TEST_VERSION);
-    const dest = managedBinaryPath(home, PLATFORM);
+    const { mycoHome, resolvedBinary } = fixture;
+    const versionedPath = versionBinaryPath(mycoHome, PLATFORM, TEST_VERSION);
+    const dest = managedBinaryPath(mycoHome, PLATFORM);
     // A deliberate external/dev pin: no /node_modules/ segment, not under
-    // <home>/.myco/runtime/. Convergence must NEVER clobber this.
-    const externalPin = path.join(home, '.local', 'bin', 'myco-dev');
-    writePin(home, externalPin);
-    // Record exact bytes written (writePin appends \n, trim() strips it for
-    // readPin; compare at the trim level to match the assertion style of case e).
-    const pinBefore = readPin(home);
+    // <mycoHome>/runtime/. Convergence must NEVER clobber this.
+    const externalPin = path.join(mycoHome, '.local', 'bin', 'myco-dev');
+    writePin(mycoHome, externalPin);
+    const pinBefore = readPin(mycoHome);
 
     const result = convergeNpmInstall({
-      home,
+      mycoHome,
       platform: PLATFORM,
       resolvedBinary,
       dest,
@@ -238,11 +242,9 @@ describe('select-binary convergeNpmInstall', () => {
     });
 
     // Pin is byte-identical to what was written — not overwritten with dest.
-    expect(readPin(home)).toBe(pinBefore);
-    expect(readPin(home)).toBe(externalPin);
-    // Implementation must land on the preserve-external branch, not 'wrote'.
+    expect(readPin(mycoHome)).toBe(pinBefore);
+    expect(readPin(mycoHome)).toBe(externalPin);
     expect(result.pinAction).toBe('preserved-external');
-    // Binary convergence still happens — the managed dest is placed.
     expect(fs.existsSync(dest)).toBe(true);
   });
 });

--- a/tests/service/self-install-executable.test.ts
+++ b/tests/service/self-install-executable.test.ts
@@ -5,7 +5,7 @@
  * dev variant always uses `process.execPath` (dogfood guard).
  */
 
-import { afterEach, describe, expect, spyOn, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -16,14 +16,20 @@ import { FakeServiceManager } from '../helpers/fake-service-manager';
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Create a temp dir with the managed binary present and return its home root. */
-function makeTempHomeWithManagedBinary(): { home: string; binPath: string } {
+/**
+ * Create a temp OS-home with the managed binary present at `<home>/.myco/bin/myco`,
+ * and return both the OS-home and the MYCO-HOME (`<home>/.myco`). Callers of
+ * `defaultServiceExecutable` pass the myco-home (the resolved `resolveMycoHome()`
+ * value the daemon supplies), not the OS-home.
+ */
+function makeTempHomeWithManagedBinary(): { home: string; mycoHome: string; binPath: string } {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-home-managed-'));
-  const binDir = path.join(home, '.myco', 'bin');
+  const mycoHome = path.join(home, '.myco');
+  const binDir = path.join(mycoHome, 'bin');
   fs.mkdirSync(binDir, { recursive: true });
   const binPath = path.join(binDir, 'myco');
   fs.writeFileSync(binPath, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
-  return { home, binPath };
+  return { home, mycoHome, binPath };
 }
 
 /** Create a temp home dir WITHOUT any managed binary. */
@@ -54,8 +60,8 @@ class CapturingLogger {
 
 describe('defaultServiceExecutable', () => {
   test('prod + managed binary present → returns the managed binary path', () => {
-    const { home, binPath } = makeTempHomeWithManagedBinary();
-    const result = defaultServiceExecutable('prod', home, 'darwin');
+    const { mycoHome, binPath } = makeTempHomeWithManagedBinary();
+    const result = defaultServiceExecutable('prod', mycoHome, 'darwin');
     expect(result).toBe(binPath);
   });
 
@@ -78,9 +84,9 @@ describe('defaultServiceExecutable', () => {
     expect(result).toBe(process.execPath);
   });
 
-  test('works on linux platform (uses .myco/bin path)', () => {
-    const { home, binPath } = makeTempHomeWithManagedBinary();
-    const result = defaultServiceExecutable('prod', home, 'linux');
+  test('works on linux platform (uses <mycoHome>/bin path)', () => {
+    const { mycoHome, binPath } = makeTempHomeWithManagedBinary();
+    const result = defaultServiceExecutable('prod', mycoHome, 'linux');
     expect(result).toBe(binPath);
   });
 });
@@ -139,15 +145,16 @@ describe('ensureSelfInstalledAsService executable threading', () => {
     }
   });
 
-  test('prod without explicit override picks up the managed binary via os.homedir() (default wiring)', async () => {
-    const { home, binPath } = makeTempHomeWithManagedBinary();
+  test('prod without explicit override resolves the managed binary via resolveMycoHome (default wiring)', async () => {
+    const { mycoHome, binPath } = makeTempHomeWithManagedBinary();
     const logger = new CapturingLogger();
     const mgr = new FakeServiceManager();
 
     const origHome = process.env.MYCO_HOME;
-    process.env.MYCO_HOME = path.join(home, '.myco');
+    // The default wiring uses resolveMycoHome(), which honors $MYCO_HOME — no
+    // os.homedir() mock needed (the old default read os.homedir() directly).
+    process.env.MYCO_HOME = mycoHome;
 
-    const homedirSpy = spyOn(os, 'homedir').mockReturnValue(home);
     try {
       // No `executable` override — the default wiring must resolve it.
       await ensureSelfInstalledAsService(logger, {
@@ -159,7 +166,6 @@ describe('ensureSelfInstalledAsService executable threading', () => {
       expect(mgr.installCalls[0].executable).toBe(binPath);
       expect(logger.warns).toHaveLength(0);
     } finally {
-      homedirSpy.mockRestore();
       if (origHome === undefined) delete process.env.MYCO_HOME;
       else process.env.MYCO_HOME = origHome;
     }

--- a/tests/symbionts/managed-binary-path.test.ts
+++ b/tests/symbionts/managed-binary-path.test.ts
@@ -39,14 +39,17 @@ import { resolveManagedBinaryPath } from '@myco/symbionts/installer.js';
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Create a temp home directory with a managed binary on disk. */
-function makeTempHomeWithManagedBinary(): { home: string; managedPath: string } {
+/** Create a temp home with a managed binary on disk at `<mycoHome>/bin/myco`. */
+function makeTempHomeWithManagedBinary(): { home: string; mycoHome: string; managedPath: string } {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-mbp-test-'));
-  const binDir = path.join(home, '.myco', 'bin');
+  // The temp dir is the OS-home; the myco-home is `<home>/.myco` (what the
+  // daemon passes as `resolveMycoHome()`). The managed binary lives under it.
+  const mycoHome = path.join(home, '.myco');
+  const binDir = path.join(mycoHome, 'bin');
   fs.mkdirSync(binDir, { recursive: true });
   const managedPath = path.join(binDir, 'myco');
   fs.writeFileSync(managedPath, '#!/bin/sh\nexec myco "$@"', 'utf8');
-  return { home, managedPath };
+  return { home, mycoHome, managedPath };
 }
 
 /** Create a temp home directory WITHOUT a managed binary on disk. */
@@ -93,11 +96,11 @@ describe('resolveManagedBinaryPath', () => {
 
   describe('managed binary preferred over execPath (coexistence fix)', () => {
     it('returns the managed binary when no pin AND managed binary exists on disk', () => {
-      const { home, managedPath } = makeTempHomeWithManagedBinary();
+      const { home, mycoHome, managedPath } = makeTempHomeWithManagedBinary();
       mockResolveRuntimeCommand = () => null;
 
       try {
-        const result = resolveManagedBinaryPath(home, 'linux');
+        const result = resolveManagedBinaryPath(mycoHome, 'linux');
         // KEY ASSERTION: the managed path wins over process.execPath
         expect(result).toBe(managedPath.replaceAll('\\', '/'));
         expect(result).not.toBe(process.execPath.replaceAll('\\', '/'));
@@ -111,14 +114,14 @@ describe('resolveManagedBinaryPath', () => {
       // owns the symbiont-config claim and writes global hook config. With a
       // converged ~/.myco/bin/myco on disk, the hook MUST embed that managed path,
       // not the writing daemon's own execPath.
-      const { home, managedPath } = makeTempHomeWithManagedBinary();
+      const { home, mycoHome, managedPath } = makeTempHomeWithManagedBinary();
       mockResolveRuntimeCommand = () => null;
 
       // The dev daemon's execPath is something like
       // packages/myco-darwin-arm64/bin/myco — but we only need to verify
       // that the result is the managed path, not process.execPath.
       try {
-        const result = resolveManagedBinaryPath(home, 'linux');
+        const result = resolveManagedBinaryPath(mycoHome, 'linux');
         expect(result).toBe(managedPath.replaceAll('\\', '/'));
         // This is the incident fix: the writer's own binary must not appear
         expect(result).not.toContain(process.execPath.replaceAll('\\', '/'));
@@ -194,11 +197,11 @@ describe('resolveManagedBinaryPath', () => {
     });
 
     it('managed binary beats execPath when managed exists but no pin', () => {
-      const { home, managedPath } = makeTempHomeWithManagedBinary();
+      const { home, mycoHome, managedPath } = makeTempHomeWithManagedBinary();
       mockResolveRuntimeCommand = () => null;
 
       try {
-        const result = resolveManagedBinaryPath(home, 'linux');
+        const result = resolveManagedBinaryPath(mycoHome, 'linux');
         expect(result).toBe(managedPath.replaceAll('\\', '/'));
         // execPath must not appear unless it happens to equal the managed path
         if (process.execPath.replaceAll('\\', '/') !== managedPath.replaceAll('\\', '/')) {

--- a/tests/ui/settings-manifest-sync.test.ts
+++ b/tests/ui/settings-manifest-sync.test.ts
@@ -40,6 +40,9 @@ const ALLOWLIST: readonly string[] = [
   // Admission ignore list — managed via the Groves "Ignore" action and the
   // machine settings page, not a per-field settings card.
   'capture.ignore.',
+  // Auto-update check cadence — an internal daemon setting. The Upgrade card
+  // surfaces only the channel (daemon.update_channel), not the poll interval.
+  'daemon.check_interval_hours',
 ];
 
 function isAllowlisted(key: string): boolean {

--- a/tests/upgrade/auto-check.test.ts
+++ b/tests/upgrade/auto-check.test.ts
@@ -19,6 +19,7 @@ import path from 'node:path';
 import {
   checkAndStage,
   resolveNewestStagedVersion,
+  markAdoptFailed,
   type CheckAndStageDeps,
 } from '@myco/upgrade/auto-check.js';
 import * as updateChecker from '@myco/daemon/update-checker.js';
@@ -325,5 +326,52 @@ describe('resolveNewestStagedVersion', () => {
       () => { throw new Error('EACCES'); },
     );
     expect(result).toBeNull();
+  });
+
+  it('skips a version whose adopt already failed (marker present), returning the next-newest', () => {
+    const vDir = versionsDir(tmpHome, PLATFORM);
+    const failedMarker = path.join(vDir, '1.3.0', '.adopt-failed');
+    const result = resolveNewestStagedVersion(
+      tmpHome,
+      PLATFORM,
+      CURRENT_VERSION,
+      undefined,
+      // versions dir exists; 1.3.0 carries the failed marker, 1.2.0 does not.
+      (p: string) => p === vDir || p === failedMarker,
+      () => ['1.2.0', '1.3.0'],
+    );
+    expect(result).toBe('1.2.0');
+  });
+
+  it('returns null when the ONLY newer staged version is marked failed', () => {
+    const vDir = versionsDir(tmpHome, PLATFORM);
+    const failedMarker = path.join(vDir, '1.3.0', '.adopt-failed');
+    const result = resolveNewestStagedVersion(
+      tmpHome,
+      PLATFORM,
+      CURRENT_VERSION,
+      undefined,
+      (p: string) => p === vDir || p === failedMarker,
+      () => ['1.3.0'],
+    );
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// markAdoptFailed
+// ---------------------------------------------------------------------------
+
+describe('markAdoptFailed', () => {
+  it('writes the .adopt-failed marker into an existing version slot', () => {
+    const dir = path.join(versionsDir(tmpHome, PLATFORM), '1.3.0');
+    fs.mkdirSync(dir, { recursive: true });
+    markAdoptFailed(tmpHome, PLATFORM, '1.3.0');
+    expect(fs.existsSync(path.join(dir, '.adopt-failed'))).toBe(true);
+  });
+
+  it('no-ops (no throw) when the version slot does not exist', () => {
+    expect(() => markAdoptFailed(tmpHome, PLATFORM, '9.9.9')).not.toThrow();
+    expect(fs.existsSync(path.join(versionsDir(tmpHome, PLATFORM), '9.9.9'))).toBe(false);
   });
 });


### PR DESCRIPTION
## Why

Live validation of `v1.2.0-beta.2` on a real machine surfaced two bugs in the daemon self-upgrade ("auto-adopt") — both the same flaw, **divergent sources of truth**:

1. **Doubled-path adopt loop.** Auto-adopt staged binaries to `~/.myco/.myco/bin/...` and restart-looped (also broke manual `myco upgrade`). Root cause: the managed-path helpers took an ambiguous `home` and appended `.myco/bin` (expecting `os.homedir()`), but the upgrade domain passed `resolveMycoHome()` (`~/.myco`). Two divergent implementations (TS helpers + an inlined copy in `select-binary.mjs`) compounded it.
2. **Channel divergence.** The background auto-adopt resolved the channel from `~/.myco/update.yaml`, which nothing writes — the UI/CLI write `daemon.update_channel`. So switching to beta via the UI was silently ignored by the hands-off upgrade.

Caught because beta.2's self-upgrade looped on a dogfood machine and disrupted capture — found via **live validation, not CI**.

## What

Three commits, each collapsing a divergent source to one:

- **single managed-paths module + myco-home convention** — new `scripts/managed-paths.mjs` (+ `.d.mts`) is the SOLE path-layout definition, imported by both the postinstall and the TS (re-exported into the binary) so JS/TS can't drift. All callers pass `resolveMycoHome()`; POSIX roots at `<mycoHome>/bin`, win32 stays `%LOCALAPPDATA%`-rooted; now honors `$MYCO_HOME`. Also closes a test-hygiene landmine: the convergence test was converging into the REAL `~/.myco` and clobbering the dev binary — now hermetic.
- **one channel + cadence source** — `readUpdateConfig()` reads the canonical `daemon.*` machine config (same source the UI writes); `update.yaml` + `writeUpdateConfig` retired; new `daemon.check_interval_hours`.
- **per-version adopt bound** — a failed adopt (daemon returns on a different version) marks that slot `.adopt-failed` so the idle job never re-adopts a known-bad release.

## Process

Plan reviewed by 3 independent code-grounded reviewers (feasibility / scope / coherence); all must-fixes folded (win32 exception, full caller inventory, dropped the over-built `__converge` subcommand + startup self-heal + launchd reload-semantics change as non-bugs). The fix makes the doubled-path bug class **unrepresentable**, not patched.

## Testing

Every affected suite green in isolation (managed-paths, managed-binary, select-binary ×2, self-install ×2, managed-binary-path, api/upgrade, update-checker, scope, tier-dispatch, auto-check, idle-adopt, sentinel, apply-binary, hooks). `tsc` clean. The full *local* suite is blocked by an intermittent bun-`--isolate` phase wedge (infra, not these changes — that phase passes 31/0 in isolation); **CI is the authoritative gate.**

## Remaining (post-merge)

Dogfood: cut the fixed beta → validate the real `1.1.2 → 1.2.0` upgrade (1.1.2 npm auto-update → convergence → version_sync restart, no doubled path, capabilities survive) + the forward auto-adopt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGeJyXYBcUzQZQndVhzBvJ