### PR TITLE
deps: bump @types/node + @anthropic-ai/sdk in workspace manifests (closes #555, #556)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6197,7 +6197,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.177",
-        "@anthropic-ai/sdk": "^0.104.1",
+        "@anthropic-ai/sdk": "^0.105.0",
         "@inquirer/prompts": "^8.5.2",
         "@modelcontextprotocol/sdk": "^1.28.0",
         "@openai/agents": "^0.11.5",
@@ -6216,7 +6216,7 @@
       "devDependencies": {
         "@goondocks/myco-shared": "*",
         "@types/bun": "^1.3.14",
-        "@types/node": "^25.9.3",
+        "@types/node": "^26.0.0",
         "@types/semver": "^7.7.1",
         "@types/shell-quote": "^1.7.5",
         "@vscode/ripgrep": "^1.15.14",
@@ -6285,26 +6285,9 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@types/node": "^25.9.3",
+        "@types/node": "^26.0.0",
         "typescript": "^6.0.3"
       }
-    },
-    "packages/myco-shared/node_modules/@types/node": {
-      "version": "25.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
-      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
-      }
-    },
-    "packages/myco-shared/node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/myco-team": {
       "name": "@goondocks/myco-team",
@@ -6324,44 +6307,6 @@
       "engines": {
         "node": ">=20"
       }
-    },
-    "packages/myco/node_modules/@anthropic-ai/sdk": {
-      "version": "0.104.2",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.2.tgz",
-      "integrity": "sha512-s1wEVDAtEwkS7Ajgep6PZKJLFqybRkmD3Byz+iVVsSpbDY0gjROXE9aOft6V3PMqynn3NTcycV5whga9tCzmKA==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "packages/myco/node_modules/@types/node": {
-      "version": "25.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
-      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
-      }
-    },
-    "packages/myco/node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
-      "license": "MIT"
     }
   }
 }

--- a/packages/myco-shared/package.json
+++ b/packages/myco-shared/package.json
@@ -39,7 +39,7 @@
     "test": "echo 'myco-shared tests run from repo root'"
   },
   "devDependencies": {
-    "@types/node": "^25.9.3",
+    "@types/node": "^26.0.0",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/myco/package.json
+++ b/packages/myco/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.177",
-    "@anthropic-ai/sdk": "^0.104.1",
+    "@anthropic-ai/sdk": "^0.105.0",
     "@inquirer/prompts": "^8.5.2",
     "@modelcontextprotocol/sdk": "^1.28.0",
     "@openai/agents": "^0.11.5",
@@ -81,7 +81,7 @@
   "devDependencies": {
     "@goondocks/myco-shared": "*",
     "@types/bun": "^1.3.14",
-    "@types/node": "^25.9.3",
+    "@types/node": "^26.0.0",
     "@types/semver": "^7.7.1",
     "@types/shell-quote": "^1.7.5",
     "@vscode/ripgrep": "^1.15.14",


### PR DESCRIPTION
Resolves the two Dependabot PRs left open after the #558 batch (#555 @types/node→26, #556 @anthropic-ai/sdk→0.105).

The batch bumped these in the **root** manifest, but they also live in `packages/myco-shared` and `packages/myco` with ranges too narrow to dedup to the root's new versions (`@types/node ^25.9.3` can't take 26; `@anthropic-ai/sdk ^0.104.1` can't take 0.105). Widening the workspace ranges to `^26.0.0` / `^0.105.0` lets them dedup to the top-level resolutions — closing #555 and #556.

First time `@types/node` 26 actually applies to these workspaces (they were on 25.9.4): **tsc clean** (myco + myco-shared), **full suite 7523 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
