### PR TITLE
docs: native-binary install/update/requirements sweep (v1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to Myco are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.0] - 2026-06-23
+
+### Headline
+
+**Node-free native installer.** Myco now ships as a self-contained native binary — no Node runtime is required to run it. `curl -fsSL https://myco.sh/install.sh | sh` (macOS/Linux) and `irm https://myco.sh/install.ps1 | iex` (Windows x64) download the binary to `~/.myco/bin` (`%LOCALAPPDATA%\Myco\bin` on Windows), register a managed per-user service, and connect supported agents. `npm install -g @goondocks/myco` still works as a thin bootstrap that converges to the same native binary.
+
+### Added
+
+- **Single-binary self-update.** The local service keeps itself up to date from its release channel in the background while idle. Upgrades can also be triggered from the **Upgrade** section of the dashboard's Settings page or with the new `myco upgrade` CLI (`--channel stable|beta`). `npm update` is no longer part of the main upgrade path.
+- **Daemon coexistence.** A development Myco service can run alongside the released production service on the same machine — variant-aware Grove binding keeps their Groves, services, and upgrades isolated.
+- **Cross-platform service lifecycle.** Managed per-user service install and supervision across launchd (macOS), systemd (Linux), and Task Scheduler (Windows), validated on macOS, Linux, and Windows x64.
+
+### Changed
+
+- **Install no longer requires Node.** The installer downloads a native binary instead of installing the npm package. Node 22+ is now needed only for the optional npm install path and the operator CLIs (`@goondocks/myco-team`, `@goondocks/myco-collective`).
+- Platform support: macOS is the primary supported platform; Linux and Windows are in beta. Windows is x64 only — Windows on ARM is not supported.
+
 ## [Unreleased]
 
 ### Headline
@@ -131,4 +148,5 @@ The license changed from MIT to Apache 2.0 on 2026-04-29. No code action require
 
 ---
 
-[Unreleased]: https://github.com/goondocks-co/myco/compare/v0.25.0...HEAD
+[Unreleased]: https://github.com/goondocks-co/myco/compare/myco/v1.2.0...HEAD
+[1.2.0]: https://github.com/goondocks-co/myco/releases/tag/myco/v1.2.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.npmjs.com/package/@goondocks/myco"><img src="https://img.shields.io/npm/v/@goondocks/myco?label=npm&color=22c55e" alt="npm"></a>
   <a href="https://github.com/goondocks-co/myco/blob/main/LICENSE"><img src="https://img.shields.io/github/license/goondocks-co/myco?color=22c55e" alt="License"></a>
   <a href="https://github.com/sponsors/goondocks-co"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-22c55e" alt="Sponsor Myco"></a>
-  <img src="https://img.shields.io/badge/node-%3E%3D22-22c55e" alt="Node 22+">
+  <img src="https://img.shields.io/badge/runs%20on-macOS%20%7C%20Linux%20%7C%20Windows-22c55e" alt="Runs on macOS, Linux, Windows">
   <img src="https://img.shields.io/badge/agents-Claude%20Code%20%7C%20Cursor%20%7C%20Codex%20%7C%20Cline%20%7C%20VS%20Code%20%7C%20Antigravity%20%7C%20Devin%20Desktop%20%7C%20OpenCode%20%7C%20Pi-22c55e" alt="Claude Code | Cursor | Codex | Cline | VS Code | Antigravity | Devin Desktop | OpenCode | Pi">
 </p>
 
@@ -49,9 +49,17 @@ curl -fsSL https://myco.sh/install.sh | sh
 myco open
 ```
 
-That installs the npm package, starts the local service, connects supported coding agents, and opens the local dashboard. Open any git project in a supported coding agent and Myco auto-registers it into your default Grove when the agent starts working there.
+On Windows x64 (PowerShell):
+
+```powershell
+irm https://myco.sh/install.ps1 | iex
+```
+
+Myco is a self-contained native binary — **no Node runtime required**. The installer downloads the binary to `~/.myco/bin` (`%LOCALAPPDATA%\Myco\bin` on Windows), starts the managed local service, and connects supported coding agents. Then `myco open` launches the dashboard. Open any git project in a supported coding agent and Myco auto-registers it into your default Grove when the agent starts working there.
 
 You can also open the dashboard directly at [http://localhost:20915/](http://localhost:20915/). If your local install reports a different service URL, `myco open` will open the right one.
+
+Already have Node? `npm install -g @goondocks/myco` also works — it's a thin bootstrap that converges to the same native binary.
 
 Provider configuration is optional at install time. Capture and full-text search work immediately; spores, digests, semantic search, Canopy summaries, and skill lifecycle features become active after you configure intelligence and embedding providers in the dashboard.
 
@@ -59,15 +67,11 @@ See [Quickstart](docs/quickstart.md) for setup details and platform notes.
 
 ## Upgrade
 
-Existing users upgrade the main product with npm or from the dashboard Operations page:
+Myco keeps itself up to date **automatically** — the local service self-updates from the release channel in the background while it's idle. You can also trigger an upgrade from the **Upgrade** section of the dashboard's **Settings** page.
 
-```bash
-npm update -g @goondocks/myco
-```
+No `npm update` is needed. (A `myco upgrade` CLI exists for advanced or scripted use, with `--channel stable|beta`, but the automatic and dashboard paths are the normal way to stay current.) Upgrading from an older per-project install archives legacy Myco-owned files the next time Myco starts. See [Upgrading Myco](docs/upgrade.md).
 
-The main package includes the local CLI, service, agent connections, MCP server, dashboard, and built-in intelligence pipeline. Upgrading from an older per-project install archives legacy Myco-owned files the next time Myco starts. See [Upgrading Myco](docs/upgrade.md).
-
-Optional operator packages are only needed for infrastructure administration:
+Optional operator packages are only needed for infrastructure administration (these remain npm/Node tools and require Node 22+):
 
 - `@goondocks/myco-team` — provision and manage a team's sync Worker (operators only; teammates join from the dashboard)
 - `@goondocks/myco-collective` — deploy and manage a Myco Collective
@@ -172,7 +176,7 @@ Skills evolve as your code does. When a pattern is abandoned, a new gotcha is di
 
 ### Backup & restore
 
-Backups and restores are Grove-scoped. Local backups run automatically during idle periods, and destructive project deletion creates a fresh Grove backup first when backups are enabled. Configure a custom backup directory from the Operations page. Restore preserves existing records and avoids importing duplicates.
+Backups and restores are Grove-scoped. Local backups run automatically during idle periods, and destructive project deletion creates a fresh Grove backup first when backups are enabled. Configure a custom backup directory in the **Backup & Restore** section of the Settings page. Restore preserves existing records and avoids importing duplicates.
 
 ## Health check
 

--- a/docs/canopy.md
+++ b/docs/canopy.md
@@ -66,7 +66,7 @@ The map refreshes itself when the underlying file descriptions drift — and sho
 
 Once LLM descriptions are on, every described file is also embedded for semantic search. Agents call `myco_search` with `type=canopy` to find files by what they *do*: "where does session capture happen?" returns the right file even if the words "session capture" appear nowhere in it.
 
-The same results show up in the Cortex Operations page and as a **Canopy** facet in the dashboard's universal search — the agent's view and your view are the same view.
+The same results show up in the **Cortex** page and as a **Canopy** facet in the dashboard's universal search — the agent's view and your view are the same view.
 
 ## Configuration
 

--- a/docs/collective.md
+++ b/docs/collective.md
@@ -72,13 +72,7 @@ Once connected:
 
 ### Existing Myco users
 
-If you already use Myco locally, your normal upgrade path does not change:
-
-```bash
-npm update -g @goondocks/myco
-```
-
-That updates the main Myco CLI, service, agent connections, and dashboard. Users who are only *connecting* to an existing team don't need anything else.
+If you already use Myco locally, your normal upgrade path does not change: Myco keeps the main product up to date automatically (or you can update from the dashboard's **Operations** page). That covers the main Myco CLI, service, agent connections, and dashboard. Users who are only *connecting* to an existing team don't need anything else.
 
 ### Team operators
 
@@ -119,7 +113,7 @@ npm update -g @goondocks/myco-team
 myco-team update --team-id <id>
 ```
 
-Project-local Myco installs still update through `@goondocks/myco`. Once the standalone Team or Collective CLI is installed on a machine, the main Myco Operations page also detects and applies those package updates for you.
+The main Myco product keeps itself up to date automatically (or from the **Upgrade** section of the dashboard's **Settings** page). Once the standalone Team or Collective CLI is installed on a machine, that same Upgrade section also detects and applies those package updates for you.
 
 ## Daily use
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -51,11 +51,11 @@
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://myco.sh/",
-      "downloadUrl": "https://www.npmjs.com/package/@goondocks/myco",
+      "downloadUrl": "https://myco.sh/install.sh",
       "installUrl": "https://myco.sh/install.sh",
       "license": "https://www.apache.org/licenses/LICENSE-2.0",
       "description": "Myco gives coding agents shared project knowledge, codebase awareness, and learned workflows that evolve with the project.",
-      "softwareRequirements": "Node.js 22+",
+      "softwareRequirements": "macOS, Linux (x64/arm64), or Windows (x64). Self-contained native binary — no Node runtime required.",
       "sameAs": [
         "https://github.com/goondocks-co/myco",
         "https://www.npmjs.com/package/@goondocks/myco"
@@ -243,7 +243,7 @@
 
       <div class="install-next">
         <span class="n">Requires</span>
-        <span class="txt">Node <code>22+</code> (the installer uses npm), macOS for the supported path, and at least one supported coding agent.</span>
+        <span class="txt">A supported OS — macOS for the supported path; Linux and Windows (x64) in beta — and at least one supported coding agent. Myco ships as a self-contained native binary, so <strong>no Node runtime is required</strong> (the optional npm install path needs Node <code>22+</code>).</span>
         <span style="margin-left:auto;"><a class="arrow-link" href="/quickstart">Quickstart</a></span>
       </div>
     </div>

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -4,7 +4,7 @@ Myco runs a local background service that captures session activity, processes i
 
 ## Install and bootstrap
 
-The service is installed for the current user the first time the npm package lands on a machine. The supported path is macOS, with Linux and Windows in beta. On Windows, only x64 is supported — Windows on ARM (which runs the x64 build under emulation) is not supported.
+The service is installed for the current user the first time the Myco native binary lands on a machine — the installer downloads it to `~/.myco/bin` (`%LOCALAPPDATA%\Myco\bin` on Windows) and registers a managed per-user service (launchd on macOS, systemd on Linux, Task Scheduler on Windows). No Node runtime is required. The supported path is macOS, with Linux and Windows in beta. On Windows, only x64 is supported — Windows on ARM (which runs the x64 build under emulation) is not supported.
 
 When the service starts:
 
@@ -113,16 +113,17 @@ myco remove --purge # Additionally remove ~/.myco/ itself
 
 ## Updates
 
-Myco installs a single global npm package and runs one local service serving every Grove on the machine. To upgrade:
+Myco runs as a single native binary and one local service serving every Grove on the machine. It keeps itself up to date:
 
 ### How to update
 
-- **From the Operations page** — when a new version is available, an **Update & Restart** button appears. Click it to install the new package and restart Myco.
-- **From the command line** — `npm install -g @goondocks/myco@latest` installs the new version. Run `myco restart` to make it take effect immediately, otherwise it picks up on the next restart.
+- **Automatically** — the service self-updates from your release channel in the background while it's idle. Nothing to run.
+- **From the Settings page** — the **Upgrade** section shows the running version and, when a new version is available, an **Upgrade & Restart** button. Click it to apply the update and restart Myco immediately.
+- **From the command line (advanced)** — `myco upgrade` (with `--channel stable|beta`) applies an update for scripted use. The dashboard is the primary interface; the CLI is for bootstrap and advanced use.
 
-Both paths end at the same state: the globally installed Myco package is at the new version, and the next restart updates your local service and connected agents.
+All three paths end at the same state: the installed Myco binary is at the new version, and the next restart updates your local service and connected agents.
 
-If you also installed one of the optional standalone operator CLIs, the Operations page detects and applies those package updates alongside `@goondocks/myco`. Manual npm updates are still available, but they are no longer the normal path once those packages are installed:
+If you also installed one of the optional standalone operator CLIs, the Settings page's Upgrade section detects and applies those package updates too. They remain npm/Node tools and can also be updated directly:
 
 - `npm update -g @goondocks/myco-team`
 - `npm update -g @goondocks/myco-collective`
@@ -131,13 +132,11 @@ See [Upgrading Myco](upgrade.md) for the full upgrade walkthrough.
 
 ### Stable and Beta channels
 
-The Operations page has a **Stable**/**Beta** toggle that controls which release line this project follows. Channel selection is per-project — switching one project to Beta does not affect your other projects or your machine-global `myco` install.
+The Upgrade section of the Settings page has a **Stable**/**Beta** toggle that controls which release line this machine follows. This machine runs one managed Myco binary at `~/.myco/bin/myco`, and switching channels swaps that same binary in place — Beta installs the latest prerelease, Stable steps back to the latest stable release.
 
-**Switching to Beta.** Click **Beta**. Myco installs the latest beta release for that project and uses it for the dashboard, agent connections, and intelligence pipeline. Your other projects continue running whatever version they're on.
+**Switching to Beta.** Click **Beta**. Myco installs the latest beta release and uses it for the dashboard, agent connections, and intelligence pipeline across every Grove on the machine.
 
-**Reverting to Stable.** Click **Revert to Stable & Restart**. Myco removes the project's Beta install, ensures the machine-global install is at the latest stable version, and restarts the service. The project returns to the same Stable version a fresh `npm install -g @goondocks/myco` would give you.
-
-**Machine-wide Beta preferences.** Any existing machine-wide Beta preference applies to each project by default. Click **Stable** on any project's Operations page to opt that project out.
+**Reverting to Stable.** Click **Revert to Stable & Restart**. Myco steps the binary back to the latest stable release and restarts the service. You return to the same Stable version a fresh install would give you.
 
 ## Configuration
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,9 +6,9 @@ Myco does not replace an agent's reasoning, native memory, tools, or workflow. I
 
 ## Requirements
 
-- **Node.js 22+**
+- **A supported OS** — macOS (arm64/x64), Linux (x64/arm64), or Windows (x64). Myco ships as a self-contained native binary, so **no Node runtime is required to run it**. macOS is the supported path, with **Linux and Windows in beta**. On Windows, only **x64** is supported — Windows on ARM (which runs the x64 build under emulation) is not supported.
 - **At least one supported coding agent** — Claude Code, Cursor, Codex, Cline, Copilot, Google Antigravity, Devin Desktop, OpenCode, or Pi
-- **macOS** for the supported path, with **Linux and Windows in beta**. On Windows, only **x64** is supported — Windows on ARM (which runs the x64 build under emulation) is not supported.
+- **Node 22+** is only needed for the optional npm install path and the operator CLIs (`@goondocks/myco-team`, `@goondocks/myco-collective`).
 
 Provider configuration is **optional** at install time. Myco captures sessions and provides full-text search immediately. To enable spores, digests, semantic search, Canopy summaries, and skill lifecycle features, configure intelligence and embedding providers in the dashboard after install.
 
@@ -34,20 +34,18 @@ On Windows x64 (PowerShell, beta):
 irm https://myco.sh/install.ps1 | iex
 ```
 
-Or install manually with npm:
+The installer downloads the native binary to `~/.myco/bin` (`%LOCALAPPDATA%\Myco\bin` on Windows), starts the managed local service, and connects supported coding agents — no Node runtime required.
+
+If you already have Node, you can install with npm instead. This is a thin bootstrap that converges to the same native binary:
 ```bash
 npm install -g @goondocks/myco
 ```
 
 ## Upgrade Existing Installs
 
-Existing users upgrade the main product the same way:
+Myco keeps itself up to date **automatically** — the local service self-updates from the release channel in the background while it's idle. You can also trigger an upgrade from the **Upgrade** section of the dashboard's **Settings** page. There is nothing to run by hand and no `npm update` step.
 
-```bash
-npm update -g @goondocks/myco
-```
-
-That updates the local CLI, service, dashboard, agent connections, and built-in intelligence pipeline. If you later install one of the standalone operator CLIs, the Operations page will detect and apply updates for those installed Myco packages too. You do not need to install extra packages unless you want one of the standalone operator CLIs:
+For advanced or scripted use, the `myco upgrade` CLI (with `--channel stable|beta`) is available, but the automatic and dashboard paths are the normal way to stay current. If you later install one of the standalone operator CLIs, the Settings page's Upgrade section will also detect and apply updates for those installed Myco packages. You do not need to install extra packages unless you want one of the standalone operator CLIs:
 
 - `@goondocks/myco-team` for direct team-worker administration commands
 - `@goondocks/myco-collective` for cross-project Collective administration

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -97,7 +97,7 @@ agent:
 
 The generate and evolve tasks only run when there's work to do (approved candidates waiting, or active skills that might have drifted). They don't wake the daemon if there's nothing to process.
 
-You can also trigger any skill task manually from the dashboard's Operations page.
+You can also trigger any skill task manually from the **Agent** page's **Run Task** dialog.
 
 ## Configuration
 

--- a/docs/team-sync.md
+++ b/docs/team-sync.md
@@ -99,7 +99,7 @@ Store your Cloudflare API token in `secrets.env`.
 
 ## Backup & restore
 
-Independent of Team Sync, Myco creates local backups for resilience. Configure the backup directory on the **Operations** page, or click **Backup Now** for an on-demand backup. Restore supports a dry-run preview, and cross-machine restore preserves attribution, so you can pull a teammate's backup without losing who said what.
+Independent of Team Sync, Myco creates local backups for resilience. Configure the backup directory in the **Backup & Restore** section of the **Settings** page, or click **Backup Now** for an on-demand backup. Restore supports a dry-run preview, and cross-machine restore preserves attribution, so you can pull a teammate's backup without losing who said what.
 
 Backups include all knowledge but exclude logs, tool-call activity, and vector embeddings (rebuilt automatically after restore).
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,24 +1,23 @@
 # Upgrading Myco
 
-Myco upgrades are a single command. The npm package carries the CLI, local service, dashboard, agent connections, and built-in intelligence features. Update the package, then restart Myco when you want the new version to take over.
+Myco keeps itself up to date. It's a self-contained native binary, and the local service self-updates from your release channel in the background while it's idle — no command to run, no Node required. The binary carries the CLI, local service, dashboard, agent connections, and built-in intelligence features.
 
 ## TL;DR
 
-```bash
-npm install -g @goondocks/myco@latest
-```
+Nothing to do — Myco upgrades itself automatically. When you want to take an update now rather than wait for the idle self-update, open the **Upgrade** section of the dashboard's **Settings** page and click **Upgrade & Restart**.
 
-That's it. The next time Myco restarts, it updates your local service, preserves your existing agent settings, and brings registered projects forward. No per-project command is required.
-
-To force the new version to take effect immediately:
+For advanced or scripted use, a CLI is available:
 
 ```bash
-myco restart
+myco upgrade                  # upgrade on the current channel
+myco upgrade --channel beta   # switch to and upgrade on the beta channel
 ```
 
-## What the package upgrade does
+The dashboard is Myco's primary interface; the CLI is for bootstrap and advanced use.
 
-After `npm install -g @goondocks/myco@latest` and the next Myco restart:
+## What the upgrade does
+
+When Myco self-updates (automatically, from the Settings page's Upgrade section, or via `myco upgrade`):
 
 1. **Updates Myco's local service and dashboard** to the new version.
 2. **Refreshes supported agent connections** while preserving settings you already had in those agents.
@@ -33,7 +32,7 @@ Myco v1.0 makes agent and embedding configuration **Grove-scoped** — one setti
 
 **Breaking change.** On the first restart after upgrading to v1.0, Myco removes agent and embedding settings from every project's `myco.yaml` and resets those projects to the Grove's configuration. The fields reset are the agent provider, harness, model, per-task overrides, the scheduling toggles, and the embedding provider, model, and base URL.
 
-Most projects carried these values only because older Myco wrote them per-project, so the Grove already holds the same configuration and the reset changes nothing you can observe. If a project ran a genuinely different agent or embedding setup, reconfigure it at the **Grove** scope from the dashboard's Settings and Operations pages after the upgrade.
+Most projects carried these values only because older Myco wrote them per-project, so the Grove already holds the same configuration and the reset changes nothing you can observe. If a project ran a genuinely different agent or embedding setup, reconfigure it at the **Grove** scope from the dashboard's **Settings** page after the upgrade.
 
 Need a per-project value for a specific field? Use the scope pill on that field in the dashboard to opt it back to project scope. Layering is opt-in per field — nothing is project-scoped by default.
 
@@ -43,10 +42,9 @@ The previous values are not lost: the pre-upgrade `myco.yaml` is in your git his
 
 If you previously had per-project `.agents/` installs:
 
-1. `npm install -g @goondocks/myco@latest`.
-2. Let Myco restart (or run `myco restart`).
-3. Myco archives older Myco-owned per-project files in place.
-4. Per-project overrides now live in the dashboard's **Symbionts** page. You can disable a symbiont in a specific project from there.
+1. Let Myco self-update, or trigger **Upgrade & Restart** from the Settings page's Upgrade section.
+2. Myco archives older Myco-owned per-project files in place.
+3. Per-project overrides now live in the dashboard's **Symbionts** page. You can disable a symbiont in a specific project from there.
 
 After the upgrade, verify with `myco doctor`. It reports anything Myco could not update automatically.
 
@@ -56,7 +54,7 @@ The license changed from MIT to Apache 2.0 on 2026-04-29 (commit `57a9571a`). No
 
 ## Optional operator packages
 
-If you also installed one of the standalone operator CLIs, they upgrade independently. The Operations page in the dashboard detects updates for them too and offers a one-click apply.
+If you also installed one of the standalone operator CLIs, they upgrade independently. The Upgrade section of the dashboard's Settings page detects updates for them too and offers a one-click apply.
 
 ```bash
 npm update -g @goondocks/myco-team       # team-sync operator CLI
@@ -85,12 +83,7 @@ See [Lifecycle](lifecycle.md) for the contributor workflow.
 
 ## Rollback
 
-Myco archives older Myco-owned per-project files rather than deleting them. To return to a previous version, reinstall that version and restart:
-
-```bash
-npm install -g @goondocks/myco@<previous-version>
-myco restart
-```
+Myco archives older Myco-owned per-project files rather than deleting them. The self-updater also keeps the previously installed binary, so if an update misbehaves Myco can fall back to the prior version. To pin a specific release line, use the **Stable** / **Beta** channel toggle in the Settings page's Upgrade section — see [Lifecycle](lifecycle.md) for how channels work.
 
 If you want to remove Myco entirely:
 
@@ -103,9 +96,9 @@ Removal preserves user-pre-existing keys in shared agent config files.
 
 ## Common failure modes
 
-### Myco didn't pick up the new code
+### Myco didn't pick up the new version
 
-Myco does not auto-restart on `npm install`. Run `myco restart` explicitly.
+The self-updater applies an update and restarts the service on the next idle window. To take it immediately, click **Upgrade & Restart** in the Settings page's Upgrade section, or run `myco restart` after `myco upgrade`.
 
 ### Dashboard shows "Connecting to Myco..."
 

--- a/packages/myco/README.md
+++ b/packages/myco/README.md
@@ -4,8 +4,17 @@
 
 Install it once to run the local dashboard and service, connect supported coding agents, capture project knowledge, and use the built-in intelligence pipeline.
 
+Myco is a self-contained native binary — **no Node runtime is required to run it**. The recommended install downloads the binary directly:
+
 ```bash
-curl -fsSL https://myco.sh/install.sh | sh
+curl -fsSL https://myco.sh/install.sh | sh        # macOS / Linux
+irm https://myco.sh/install.ps1 | iex             # Windows x64 (PowerShell)
+```
+
+This npm package is a thin bootstrap that converges to the same native binary, for people who prefer installing through npm (this path needs Node 22+):
+
+```bash
+npm install -g @goondocks/myco
 ```
 
 Open a git project in any supported agent and Myco registers it automatically when the agent starts working there.
@@ -23,11 +32,7 @@ macOS is the primary supported platform. Linux and Windows are in beta. On Windo
 
 ## Upgrade
 
-```bash
-npm update -g @goondocks/myco
-```
-
-The Operations page can also detect and apply updates for installed Myco packages on the same machine.
+Myco keeps itself up to date automatically — the local service self-updates from your release channel in the background while it's idle. You can also trigger an upgrade from the **Upgrade** section of the dashboard's **Settings** page, or run `myco upgrade` (with `--channel stable|beta`) for advanced or scripted use. No `npm update` is required.
 
 ## Learn more
 


### PR DESCRIPTION
Documentation sweep for the v1.2.0 node-free native binary — install, update, and requirements all changed.

### Install
- Native binary via `curl … | sh` / `irm … | iex` — **no Node runtime required**; npm demoted to a secondary bootstrap. Corrected the "installs the npm package" line → it installs the binary (to `~/.myco/bin` / `%LOCALAPPDATA%\Myco\bin`).
- README badge `Node ≥22` → `runs on macOS | Linux | Windows`; index.html JSON-LD `downloadUrl`/`softwareRequirements` + "Requires" line reframed to OS support (Node only for the optional npm path + operator CLIs).

### Update
- **Automatic self-update** + the **Settings page → Upgrade section** (button **"Upgrade & Restart"**). Removed the never-correct `npm update -g @goondocks/myco` instruction. `myco upgrade --channel` noted for advanced/scripted use only.

### Stale UI language fixed (verified against `packages/myco/ui/src`)
- "Operations page" → **Settings** for upgrade (Upgrade section) and backup-directory (Backup & Restore section). The Operations page is now database/maintenance only.
- "Cortex Operations page" → **Cortex page**; "trigger skill task … Operations page" → **Agent page** Run Task dialog.
- Channel **Stable/Beta toggle** documented as **machine-scoped** (one managed binary at `~/.myco/bin/myco`), dropping the stale per-project-channel language.

### Files
README, packages/myco/README, CHANGELOG (1.2.0 entry), docs/index.html, quickstart, upgrade, lifecycle, collective, canopy, skills, team-sync.

### Known follow-up (out of scope)
CHANGELOG.md's pre-existing `[Unreleased]` block still holds older global-install content (incl. an old `npm install -g …@latest` step) that was never cut to a versioned heading. Left untouched — that's a changelog-history restructure, separate from this install/update sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
