### PR TITLE
fix(version): source builds report real git version; add make dev-deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-all build-fast build-only build-rebuild rebuild check check-fast check-all test test-fast test-integration test-all lint clean watch install dev-build dev-link dev-link-worktree dev-unlink dev-unlink-worktree ui-dev collective-ui-dev daemon-dev dev ui ui-myco ui-collective
+.PHONY: build build-all build-packages build-fast build-only build-rebuild rebuild check check-fast check-all test test-fast test-integration test-all lint clean watch install dev-build dev-link dev-deploy dev-link-worktree dev-unlink dev-unlink-worktree dev-build-windows dev-link-windows ui-dev collective-ui-dev daemon-dev dev ui ui-myco ui-collective
 
 # `make build` runs the fast unit-test profile + build. Integration / smoke
 # tests are deliberately excluded from the inner dev loop — they pair real
@@ -23,6 +23,9 @@ build-packages:
 # Alias retained for backward compatibility with existing automation.
 build-fast: build
 
+# Builds the repo artifacts only (including packages/myco-<target>/bin/myco). It
+# does NOT update the running dev daemon — that runs a standalone COPY in
+# ~/.myco-dev/bin. To rebuild AND refresh the dogfood daemon, use `make dev-deploy`.
 build-only:
 	npm run build
 
@@ -84,7 +87,7 @@ install:
 
 ui-dev:
 	@port=$${MYCO_DAEMON_PORT:-$$(node -e ' \
-		var fs=require("fs"),p=require("path"),v=p.join(require("os").homedir(),".myco/vaults/myco"); \
+		var fs=require("fs"),p=require("path"),v=p.join(require("os").homedir(),".myco/service"); \
 		try{console.log(JSON.parse(fs.readFileSync(p.join(v,"daemon.json"),"utf-8")).port);process.exit(0)}catch{} \
 		try{var y=fs.readFileSync(p.join(v,"myco.yaml"),"utf-8"),m=y.match(/^\\s*port:\\s*(\\d+)/m);if(m){console.log(m[1]);process.exit(0)}}catch{} \
 		console.log(19200)')}; \
@@ -175,8 +178,8 @@ dev-link: dev-build
 	@chmod +x $(HOME)/.myco-dev/bin/myco
 	@# myco-dev wraps the standalone binary: sets MYCO_HOME=~/.myco-dev and
 	@# MYCO_CLAIMS_HOME=~/.myco, then execs it.
-	@# rm -f first: if myco-dev is a symlink to a binary, `printf >` follows it
-	@# and overwrites the target. Write a fresh regular file.
+	@# rm -f first, then write a fresh wrapper script — never append to or follow
+	@# an existing file here (an older install may have left a symlink at this path).
 	@rm -f $(HOME)/.local/bin/myco-dev
 	@printf '#!/bin/sh\nexport MYCO_HOME="$$HOME/.myco-dev"\nexport MYCO_CLAIMS_HOME="$$HOME/.myco"\nexec "$$HOME/.myco-dev/bin/myco" "$$@"\n' > $(HOME)/.local/bin/myco-dev
 	@chmod +x $(HOME)/.local/bin/myco-dev
@@ -208,8 +211,8 @@ dev-link: dev-build
 	@chmod 0644 $(PWD)/.myco/runtime.home
 	@echo "✓ $(HOME)/.myco-dev/config.yaml written (update_channel: manual)"
 	@echo "✓ $(PWD)/.myco/runtime.home set to $(HOME)/.myco-dev"
-	@# Sweep any pre-0.25.2 machine-scope pin written by older `make dev-link`
-	@# runs — it would shadow the new project pin from outside the repo.
+	@# Sweep any machine-scope pin: dev mode uses a PROJECT-scope pin (above), so a
+	@# leftover ~/.myco/runtime.command would shadow it from outside the repo.
 	@if [ -f $(HOME)/.myco/runtime.command ]; then \
 		rm -f $(HOME)/.myco/runtime.command; \
 		echo "✓ removed legacy machine-scope ~/.myco/runtime.command (migrated to project pin)"; \
@@ -228,6 +231,21 @@ dev-link: dev-build
 		myco-dev update --all-projects || echo "⚠ 'myco-dev update --all-projects' failed — symbiont configs may not reflect runtime.command=myco-dev"; \
 	else \
 		echo "⚠ myco-dev not on PATH — skipping symbiont config refresh"; \
+	fi
+
+# Build, deploy, AND restart the dogfood daemon in one step. `dev-link` only
+# COPIES the fresh binary into ~/.myco-dev/bin; a daemon already running keeps
+# the OLD binary until it restarts. Run this (not `build-only`) after changing
+# daemon code so the running dev daemon actually reflects it.
+dev-deploy: dev-link
+	@# Restart only AFTER the deploy. The success line is gated on the restart
+	@# actually confirming healthy — never claim "restarted" when it didn't.
+	@if "$(HOME)/.local/bin/myco-dev" restart; then \
+		echo "✓ rebuilt → deployed to $(HOME)/.myco-dev/bin/myco → dev daemon restarted"; \
+	else \
+		echo "⚠ rebuilt + deployed to $(HOME)/.myco-dev/bin/myco, but 'myco-dev restart' did not confirm healthy."; \
+		echo "  launchd may still be respawning the daemon — verify with: myco-dev service status (or the dashboard)."; \
+		echo "  If it stays down, re-run: myco-dev restart"; \
 	fi
 
 # Windows dogfood — the same shape as `dev-build` / `dev-link`, for a remote
@@ -268,10 +286,10 @@ dev-unlink:
 	@# Remove the relocated standalone dev binary (a build-artifact copy; the dev
 	@# home's grove data under ~/.myco-dev is preserved).
 	@rm -f $(HOME)/.myco-dev/bin/myco
-	@# Also sweep the legacy machine-scope pin in case the user ran the
-	@# pre-0.25.2 `make dev-link` and never re-linked.
+	@# Also sweep any machine-scope pin an older dev-link may have written, so an
+	@# uninstall fully clears dev routing.
 	@rm -f $(HOME)/.myco/runtime.command
-	@echo "✓ myco-dev symlink removed"
+	@echo "✓ myco-dev wrapper + ~/.myco-dev/bin/myco removed"
 	@echo "✓ myco-team-dev symlink removed"
 	@echo "✓ myco-collective-dev symlink removed"
 	@echo "✓ myco-run symlink removed"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@goondocks/myco-monorepo",
   "private": true,
-  "version": "0.25.0",
+  "version": "0.0.0-dev",
   "description": "Myco monorepo workspace root",
   "type": "module",
   "workspaces": [

--- a/packages/myco-darwin-arm64/package.json
+++ b/packages/myco-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goondocks/myco-darwin-arm64",
-  "version": "0.25.0",
+  "version": "0.0.0-dev",
   "description": "macOS arm64 binary for @goondocks/myco. Installed automatically as an optional dependency.",
   "type": "module",
   "files": [

--- a/packages/myco-darwin-x64/package.json
+++ b/packages/myco-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goondocks/myco-darwin-x64",
-  "version": "0.25.0",
+  "version": "0.0.0-dev",
   "description": "macOS x64 binary for @goondocks/myco. Installed automatically as an optional dependency.",
   "type": "module",
   "files": [

--- a/packages/myco-linux-arm64/package.json
+++ b/packages/myco-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goondocks/myco-linux-arm64",
-  "version": "0.25.0",
+  "version": "0.0.0-dev",
   "description": "Linux arm64 binary for @goondocks/myco. Installed automatically as an optional dependency.",
   "type": "module",
   "files": [

--- a/packages/myco-linux-x64/package.json
+++ b/packages/myco-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goondocks/myco-linux-x64",
-  "version": "0.25.0",
+  "version": "0.0.0-dev",
   "description": "Linux x64 binary for @goondocks/myco. Installed automatically as an optional dependency.",
   "type": "module",
   "files": [

--- a/packages/myco-windows-x64/package.json
+++ b/packages/myco-windows-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goondocks/myco-windows-x64",
-  "version": "0.25.0",
+  "version": "0.0.0-dev",
   "description": "Windows x64 binary for @goondocks/myco. Installed automatically as an optional dependency.",
   "type": "module",
   "files": [

--- a/packages/myco/package.json
+++ b/packages/myco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goondocks/myco",
-  "version": "0.25.0",
+  "version": "0.0.0-dev",
   "description": "Collective agent intelligence — Claude Code plugin",
   "type": "module",
   "bin": {
@@ -72,11 +72,11 @@
     "zod": "^4.4.3"
   },
   "optionalDependencies": {
-    "@goondocks/myco-darwin-arm64": "0.25.0",
-    "@goondocks/myco-darwin-x64": "0.25.0",
-    "@goondocks/myco-linux-arm64": "0.25.0",
-    "@goondocks/myco-linux-x64": "0.25.0",
-    "@goondocks/myco-windows-x64": "0.25.0"
+    "@goondocks/myco-darwin-arm64": "0.0.0-dev",
+    "@goondocks/myco-darwin-x64": "0.0.0-dev",
+    "@goondocks/myco-linux-arm64": "0.0.0-dev",
+    "@goondocks/myco-linux-x64": "0.0.0-dev",
+    "@goondocks/myco-windows-x64": "0.0.0-dev"
   },
   "devDependencies": {
     "@goondocks/myco-shared": "*",

--- a/packages/myco/scripts/build-single-target.mjs
+++ b/packages/myco/scripts/build-single-target.mjs
@@ -34,8 +34,35 @@ if (!fs.existsSync(entry)) {
   process.exit(1);
 }
 
-const pkgJson = JSON.parse(fs.readFileSync(path.join(pkgRoot, 'package.json'), 'utf-8'));
-const mycoVersion = pkgJson.version;
+const pkgPath = path.join(pkgRoot, 'package.json');
+const pkgRaw = fs.readFileSync(pkgPath, 'utf-8');
+const pkgJson = JSON.parse(pkgRaw);
+
+// The per-target entry embeds `pkg.version` at compile time via
+// `setPluginVersion(pkg.version)`, so the binary's reported version is whatever
+// package.json says when bun compiles it. Releases get a concrete version
+// written here by scripts/sync-package-versions.mjs before the build; dev builds
+// carry the `0.0.0-dev` placeholder. For dev, stamp the git description so a
+// locally-built / dogfood binary reports the ACTUAL checkout (e.g.
+// `0.0.0-dev+1.2.0-1-g430a7e7b`) instead of the bare placeholder. Temporarily
+// rewrite package.json for the compile, then restore the exact original bytes in
+// `finally`. Keep the format identical to the runtime fallback in src/version.ts.
+const DEV_VERSION_PLACEHOLDER = '0.0.0-dev';
+let stampedPkg = false;
+if (pkgJson.version === DEV_VERSION_PLACEHOLDER) {
+  const described = spawnSync(
+    'git',
+    ['describe', '--tags', '--always', '--dirty', '--match', 'myco/v*'],
+    { cwd: pkgRoot, encoding: 'utf-8' },
+  );
+  const raw = described.status === 0 ? (described.stdout ?? '').trim() : '';
+  if (raw) {
+    const describe = raw.replace(/^myco\/v/, '').replace(/[^0-9A-Za-z.-]/g, '');
+    fs.writeFileSync(pkgPath, `${JSON.stringify({ ...pkgJson, version: `${DEV_VERSION_PLACEHOLDER}+${describe}` }, null, 2)}\n`);
+    stampedPkg = true;
+  }
+}
+const mycoVersion = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
 
 // Compile the binary directly into its per-platform npm package
 // (`packages/myco-<target>/bin/`). The core package's postinstall then uses
@@ -53,9 +80,17 @@ const outfile = path.join(outputDir, binaryName);
 const bunTarget = process.env.BASELINE === '1' ? `bun-${target}-baseline` : `bun-${target}`;
 
 process.stdout.write(`[build:binary] ${target} (${bunTarget}) -> ${outfile} (version ${mycoVersion})\n`);
-const result = spawnSync(
-  'bun',
-  ['build', '--compile', '--minify', `--target=${bunTarget}`, entry, '--outfile', outfile],
-  { stdio: 'inherit', cwd: pkgRoot, env: process.env },
-);
-process.exit(result.status ?? 1);
+let status = 1;
+try {
+  const result = spawnSync(
+    'bun',
+    ['build', '--compile', '--minify', `--target=${bunTarget}`, entry, '--outfile', outfile],
+    { stdio: 'inherit', cwd: pkgRoot, env: process.env },
+  );
+  status = result.status ?? 1;
+} finally {
+  // Restore the exact original package.json bytes so the working tree (and any
+  // release-stamped version) is never left mutated by a dev build.
+  if (stampedPkg) fs.writeFileSync(pkgPath, pkgRaw);
+}
+process.exit(status);

--- a/packages/myco/ui/package.json
+++ b/packages/myco/ui/package.json
@@ -32,5 +32,5 @@
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1"
   },
-  "version": "0.25.0"
+  "version": "0.0.0-dev"
 }


### PR DESCRIPTION
## What & why

Dev/dogfood builds reported a static `0.25.0` placeholder that never tracked the running code — repeatedly causing confusion about what the dev daemon was actually running (it surfaced directly during dogfood-session debugging). This makes the compiled dev/dogfood binary report the real checkout, and adds the missing `make dev-deploy` so a rebuild actually reaches the running dev daemon.

## Changes

**Version reporting**
- `build-single-target.mjs`: for dev binary builds (placeholder version only), stamp `0.0.0-dev+<git-describe>` into the embedded version at compile time, restoring `package.json` afterward. The compiled dogfood daemon reports the real checkout (e.g. `0.0.0-dev+1.2.0-1-g430a7e7b`).
- `package.json` placeholders `0.25.0` → `0.0.0-dev` across the myco family.
- `version.ts` is **unchanged on purpose**: runtime `getPluginVersion()` stays deterministic (reads `package.json` when unbundled). An earlier attempt to derive the version from git at runtime made it non-deterministic (`+<sha>-dirty`) and broke a team-status test that asserts the handler reports the package version. Git stamping belongs at build time, not on every call.

**Makefile**
- New `make dev-deploy` = build + `cp` to `~/.myco-dev/bin` + restart — the build+ship+restart one-shot that was missing. `build-only`/`dev-build` only build artifacts and do **not** refresh the running dev daemon (a standalone copy), which let stale binaries keep running after a plain rebuild + restart.
- Accuracy fixes: false "symlink" message/comment (the dev binary is a copy and `myco-dev` is a wrapper script), `.PHONY` completeness, dead `~/.myco/vaults/myco` path in `ui-dev`, and stale `pre-0.25.2` pin-sweep comments.

## Release safety

Releases are unaffected. `publish.yml` runs `sync-package-versions` (which sets the real tag in `package.json`) **before** the binary compile, so `build-single-target.mjs` sees a concrete version and skips the dev git-stamp branch entirely — published binaries embed the tag exactly as before. The placeholder only ever surfaces in dev/source builds.

## Verification

- Dogfood daemon reports `0.0.0-dev+<git-describe>` end-to-end (binary `--version`, `daemon.json`, `/health`).
- Core package `tsc --noEmit` clean; the previously-failing `team-connect-status` test passes after keeping runtime resolution deterministic.
- `make dev-deploy` exercised: build stamps correctly, `package.json` restored to the placeholder, daemon redeployed + restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G56WdS4ns51uaD8Pm3Jfzz
