### PR TITLE
fix(capture): activate prompt_batch content_hash dedup guard (positional ordinal)

### DIFF
--- a/packages/myco/src/capture/transcript-miner.ts
+++ b/packages/myco/src/capture/transcript-miner.ts
@@ -9,6 +9,7 @@ import {
   setBatchPromptNumber,
   populateBatchResponses,
   rehomeSystemActivitiesToHumanAnchor,
+  normalizePromptForHash,
   PROMPT_PREFIX_MATCH_CHARS,
   BATCH_KIND,
   PROMPT_BATCH_ORIGIN,
@@ -308,6 +309,18 @@ export class TranscriptMiner {
     let currentParentId: number | null = null;
     let currentParentOrigin: PromptBatchOrigin | null = null;
 
+    // content_hash ordinal source: the 0-based occurrence index of each
+    // (origin, normalized text) pair in transcript order, advanced for every
+    // record (consumed or inserted) so a later genuine repeat gets the next
+    // index rather than colliding with the earlier turn.
+    const occurrenceByKey = new Map<string, number>();
+    const takeOrdinal = (origin: PromptBatchOrigin, text: string): number => {
+      const key = `${origin} ${normalizePromptForHash(text)}`;
+      const ordinal = occurrenceByKey.get(key) ?? 0;
+      occurrenceByKey.set(key, ordinal + 1);
+      return ordinal;
+    };
+
     // Resolve a record's effective kind + parent against the open turn.
     // A steering/interrupt record normally nests under the open initial
     // batch. Two cases force it to start its own initial turn instead:
@@ -343,6 +356,11 @@ export class TranscriptMiner {
     };
 
     for (const record of records) {
+      // Advance the positional ordinal for this record's slot BEFORE the
+      // consume check so consumed (already-captured) records still occupy
+      // their transcript position — otherwise a later genuine repeat would
+      // collide with an earlier turn's hash.
+      const ordinal = takeOrdinal(record.origin, record.text);
       const existing = buckets.consume(record.text);
 
       if (existing) {
@@ -368,9 +386,10 @@ export class TranscriptMiner {
       }
       const now = epochSeconds();
       const isSystemOrigin = record.origin !== PROMPT_BATCH_ORIGIN.HUMAN;
-      const created = insertBatchStateless({
+      const { row: created, created: didInsert } = insertBatchStateless({
         session_id: sessionId,
         user_prompt: record.text,
+        ordinal,
         started_at: now,
         // System / agent_dispatch batches are born CLOSED point-in-time records,
         // identical to the live handleUserPrompt path. Born OPEN, a miner-created
@@ -384,11 +403,16 @@ export class TranscriptMiner {
         origin: record.origin,
         parent_prompt_batch_id: effectiveKind === BATCH_KIND.INITIAL ? null : parentForNew,
       });
-      inserted++;
-      try {
-        const lineageProjectId = created.project_id ? assertGroveProjectId(created.project_id) : null;
-        createBatchLineage(DEFAULT_AGENT_ID, sessionId, created.id, now, lineageProjectId);
-      } catch { /* lineage best-effort */ }
+      // On a dedup (didInsert === false) the row already exists with its
+      // lineage, so skip the counter and lineage write; the row still serves
+      // as the steering anchor below.
+      if (didInsert) {
+        inserted++;
+        try {
+          const lineageProjectId = created.project_id ? assertGroveProjectId(created.project_id) : null;
+          createBatchLineage(DEFAULT_AGENT_ID, sessionId, created.id, now, lineageProjectId);
+        } catch { /* lineage best-effort */ }
+      }
       // Only a HUMAN initial batch becomes the open anchor (see existing-branch
       // note above) — system batches never claim the steering anchor.
       if (effectiveKind === BATCH_KIND.INITIAL && record.origin === PROMPT_BATCH_ORIGIN.HUMAN) {

--- a/packages/myco/src/daemon/event-handlers.ts
+++ b/packages/myco/src/daemon/event-handlers.ts
@@ -9,7 +9,7 @@ import path from 'node:path';
 import { getDatabase } from '@myco/db/client.js';
 import { epochSeconds, DEFAULT_AGENT_ID } from '@myco/constants.js';
 import { getTeamMachineId } from '@myco/team/context.js';
-import { closeOpenBatches, insertBatchStateless, incrementActivityCount, findOpenParentBatch, hasAnyBatch, countBatchesBySession, listBatchesBySession, getLatestBatch, replaceRecoveredBatchUserPrompt, BATCH_KIND, RECOVERED_BATCH_SENTINEL, PROMPT_BATCH_ORIGIN, type PromptBatchOrigin } from '@myco/db/queries/batches.js';
+import { closeOpenBatches, insertBatchStateless, incrementActivityCount, findOpenParentBatch, hasAnyBatch, countBatchesBySession, listBatchesBySession, getLatestBatch, replaceRecoveredBatchUserPrompt, liveContentOrdinal, normalizePromptForHash, BATCH_KIND, RECOVERED_BATCH_SENTINEL, PROMPT_BATCH_ORIGIN, type PromptBatchOrigin } from '@myco/db/queries/batches.js';
 import { classifyNextPromptOrigin } from '@myco/capture/prompt-kind.js';
 import { AntigravityJsonlParser } from '@myco/symbionts/parsers/antigravity-jsonl.js';
 import fs from 'node:fs';
@@ -288,9 +288,10 @@ export function handleUserPrompt(
     closeOpenBatches(sessionId, now);
   }
 
-  const batch = insertBatchStateless({
+  const { row: batch, created } = insertBatchStateless({
     session_id: sessionId,
     user_prompt: prompt ?? null,
+    ordinal: prompt != null ? liveContentOrdinal(sessionId, incomingOrigin, prompt) : undefined,
     started_at: now,
     // System batches are point-in-time records: born closed so they are never
     // the active turn. Human batches stay open (ended_at left null).
@@ -304,10 +305,14 @@ export function handleUserPrompt(
 
   const promptNumber = batch.prompt_number!;
 
-  try {
-    const lineageProjectId = batch.project_id ? assertGroveProjectId(batch.project_id) : null;
-    createBatchLineage(DEFAULT_AGENT_ID, sessionId, batch.id, now, lineageProjectId);
-  } catch { /* lineage best-effort */ }
+  // Skip lineage when the row was deduped — it was created (with lineage) by
+  // the first insert of this turn.
+  if (created) {
+    try {
+      const lineageProjectId = batch.project_id ? assertGroveProjectId(batch.project_id) : null;
+      createBatchLineage(DEFAULT_AGENT_ID, sessionId, batch.id, now, lineageProjectId);
+    } catch { /* lineage best-effort */ }
+  }
 
   // `sessions.prompt_count` cache bump is folded into
   // `insertBatchStateless` so it's atomic with the row write —
@@ -349,18 +354,32 @@ export function syncTranscriptPromptBatches(
   const machineId = getTeamMachineId();
 
   const insertTail = getDatabase().transaction(() => {
-    for (let i = existingBatchCount; i < prompts.length; i++) {
+    // content_hash ordinal = occurrence index over the FULL prompt list (origin
+    // is always HUMAN here), so each prompt hashes the same on every re-POST of
+    // the growing list and genuine repeats get distinct ordinals.
+    const occurrenceByText = new Map<string, number>();
+    for (let i = 0; i < prompts.length; i++) {
       const prompt = prompts[i];
-      if (typeof prompt !== 'string' || prompt.trim().length === 0) continue;
-      const batch = insertBatchStateless({
+      const insertable = typeof prompt === 'string' && prompt.trim().length > 0;
+      let ordinal = 0;
+      if (insertable) {
+        const key = normalizePromptForHash(prompt);
+        ordinal = occurrenceByText.get(key) ?? 0;
+        occurrenceByText.set(key, ordinal + 1);
+      }
+      // Only the new tail is inserted; earlier indices already have rows.
+      if (i < existingBatchCount || !insertable) continue;
+      const { row: batch, created } = insertBatchStateless({
         session_id: sessionId,
         user_prompt: prompt,
+        ordinal,
         started_at: now,
         created_at: now,
         machine_id: machineId,
         kind: BATCH_KIND.INITIAL,
         parent_prompt_batch_id: null,
       });
+      if (!created) continue;
       try {
         const lineageProjectId = batch.project_id ? assertGroveProjectId(batch.project_id) : null;
         createBatchLineage(DEFAULT_AGENT_ID, sessionId, batch.id, now, lineageProjectId);

--- a/packages/myco/src/daemon/injection-records.ts
+++ b/packages/myco/src/daemon/injection-records.ts
@@ -12,7 +12,7 @@
  *   myco:inject:subagent:<sessionId>:<agentIdOrType>
  */
 
-import { getDatabase } from '@myco/db/client.js';
+import { getDatabase, isUniqueConstraintError } from '@myco/db/client.js';
 import { insertActivity, type ActivityRow } from '@myco/db/queries/activities.js';
 import { getLatestBatch, incrementActivityCount } from '@myco/db/queries/batches.js';
 import { epochSeconds } from '@myco/constants.js';
@@ -228,11 +228,4 @@ export function getSessionInjectedSporeIds(sessionId: string): Set<string> {
     }
   }
   return ids;
-}
-
-function isUniqueConstraintError(err: unknown): boolean {
-  if (!err || typeof err !== 'object') return false;
-  const code = (err as { code?: string }).code ?? '';
-  const message = (err as { message?: string }).message ?? '';
-  return code.startsWith('SQLITE_CONSTRAINT') && message.includes('UNIQUE');
 }

--- a/packages/myco/src/db/client.ts
+++ b/packages/myco/src/db/client.ts
@@ -193,3 +193,15 @@ export function changesSince(db: Database): number {
   const row = db.prepare('SELECT changes() AS c').get() as { c: number };
   return row.c;
 }
+
+/**
+ * True when a thrown error is a SQLite UNIQUE-constraint violation. Matches on
+ * the extended result code (`err.code` starts with `SQLITE_CONSTRAINT`) and the
+ * `UNIQUE` marker in `err.message`; works for better-sqlite3 and bun:sqlite.
+ */
+export function isUniqueConstraintError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const code = (err as { code?: string }).code ?? '';
+  const message = (err as { message?: string }).message ?? '';
+  return code.startsWith('SQLITE_CONSTRAINT') && message.includes('UNIQUE');
+}

--- a/packages/myco/src/db/queries/batches.ts
+++ b/packages/myco/src/db/queries/batches.ts
@@ -5,11 +5,12 @@
  * Queries use positional `?` placeholders throughout (better-sqlite3).
  */
 
-import { getDatabase } from '@myco/db/client.js';
+import { getDatabase, isUniqueConstraintError } from '@myco/db/client.js';
 import { getTeamMachineId } from '@myco/team/context.js';
 import { syncRow } from '@myco/db/queries/team-outbox.js';
 import { appendProjectCondition, type ProjectScope } from '@myco/db/queries/project-scope.js';
 import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+import { sha256Hex } from '@myco/canopy/hash.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -115,6 +116,77 @@ export function toPromptBatchOrigin(value: unknown): PromptBatchOrigin {
     return value as PromptBatchOrigin;
   }
   return PROMPT_BATCH_ORIGIN.HUMAN;
+}
+
+// ---------------------------------------------------------------------------
+// content_hash dedup guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical normalization for the content_hash prompt body: trim of the full
+ * prompt (not a prefix). Used by every content_hash producer and by the
+ * ordinal counts so they key identically.
+ */
+export function normalizePromptForHash(text: string | null | undefined): string {
+  return (text ?? '').trim();
+}
+
+/** Inputs to {@link promptBatchContentHash}. */
+export interface PromptBatchHashInput {
+  sessionId: string;
+  origin: PromptBatchOrigin;
+  /**
+   * 0-based occurrence index of this turn among same-(normalized text, origin)
+   * turns in the session, by capture order. Caller-supplied and stable per
+   * turn: the miner uses its in-pass positional index, the live path uses
+   * {@link liveContentOrdinal}. Distinguishes a genuine repeat (next index,
+   * preserved) from a re-insert of the same turn (same index, deduped).
+   */
+  ordinal: number;
+  userPrompt: string | null | undefined;
+}
+
+/**
+ * Deterministic dedup key for a prompt batch. Backs the partial UNIQUE indexes
+ * on `prompt_batches (content_hash)` / `(project_id, content_hash)`.
+ *
+ * `session_id` scopes the key to one session (the index is project-scoped;
+ * session_id makes same-text turns in different sessions never collide).
+ * `origin` keeps a synthesized `system` batch from colliding with a human
+ * prompt of the same text. `ordinal` distinguishes genuine repeats.
+ */
+export function promptBatchContentHash(input: PromptBatchHashInput): string {
+  const canonical = [
+    input.sessionId,
+    input.origin,
+    String(input.ordinal),
+    normalizePromptForHash(input.userPrompt),
+  ].join(' ');
+  return sha256Hex(canonical);
+}
+
+/**
+ * Content ordinal for an incoming live prompt: the count of batches already
+ * committed in this session whose (origin, normalized text) matches. Reflects
+ * insertion order, which equals the turn's transcript position only when
+ * captured in order — live-path only, not valid for backfill / out-of-order
+ * callers. The miner derives its own positional ordinal independently.
+ */
+export function liveContentOrdinal(
+  sessionId: string,
+  origin: PromptBatchOrigin,
+  userPrompt: string | null | undefined,
+): number {
+  const db = getDatabase();
+  const norm = normalizePromptForHash(userPrompt);
+  const rows = db.prepare(
+    `SELECT user_prompt FROM prompt_batches WHERE session_id = ? AND origin = ?`,
+  ).all(sessionId, origin) as Array<{ user_prompt: string | null }>;
+  let n = 0;
+  for (const row of rows) {
+    if (normalizePromptForHash(row.user_prompt) === norm) n += 1;
+  }
+  return n;
 }
 
 // ---------------------------------------------------------------------------
@@ -714,6 +786,21 @@ export interface StatelessBatchInsert {
   kind?: string;                            // defaults to 'initial'
   origin?: PromptBatchOrigin;               // defaults to 'human'
   parent_prompt_batch_id?: number | null;   // defaults to null
+  /**
+   * Transcript-positional occurrence index for the dedup `content_hash`
+   * (see {@link PromptBatchHashInput}). When supplied alongside a non-null
+   * `user_prompt`, the row gets a `content_hash` and the insert becomes
+   * idempotent on it. Omit to leave `content_hash` NULL (no dedup) — used by
+   * transient rows like the recovered sentinel.
+   */
+  ordinal?: number;
+}
+
+/** Result of {@link insertBatchStateless}: the row plus whether it was newly created. */
+export interface StatelessBatchInsertResult {
+  row: BatchRow;
+  /** False when an existing row with the same content_hash was returned (deduped). */
+  created: boolean;
 }
 
 /**
@@ -741,8 +828,21 @@ export interface StatelessBatchInsert {
  *
  * FTS5 index is kept in sync automatically via database triggers.
  */
-export function insertBatchStateless(data: StatelessBatchInsert): BatchRow {
+export function insertBatchStateless(data: StatelessBatchInsert): StatelessBatchInsertResult {
   const db = getDatabase();
+
+  const origin = data.origin ?? PROMPT_BATCH_ORIGIN.HUMAN;
+  // Dedup key is only meaningful with both a position AND a body. Transient
+  // rows (the recovered sentinel) omit `ordinal` and stay NULL → no dedup.
+  const contentHash =
+    data.ordinal != null && data.user_prompt != null
+      ? promptBatchContentHash({
+          sessionId: data.session_id,
+          origin,
+          ordinal: data.ordinal,
+          userPrompt: data.user_prompt,
+        })
+      : null;
 
   const tx = db.transaction(() => {
     const info = db.prepare(
@@ -756,7 +856,7 @@ export function insertBatchStateless(data: StatelessBatchInsert): BatchRow {
          (SELECT COALESCE(MAX(prompt_number), 0) + 1 FROM prompt_batches WHERE session_id = ?),
          ?, NULL,
          NULL, ?, ?, ?,
-         ?, ?, NULL, ?, ?
+         ?, ?, ?, ?, ?
        )`,
     ).run(
       data.session_id,
@@ -764,7 +864,7 @@ export function insertBatchStateless(data: StatelessBatchInsert): BatchRow {
       data.session_id,
       data.parent_prompt_batch_id ?? null,
       data.kind ?? 'initial',
-      data.origin ?? PROMPT_BATCH_ORIGIN.HUMAN,
+      origin,
       data.session_id,
       data.user_prompt ?? null,
       data.started_at ?? null,
@@ -774,6 +874,7 @@ export function insertBatchStateless(data: StatelessBatchInsert): BatchRow {
       data.status ?? (data.ended_at != null ? STATUS_COMPLETED : DEFAULT_STATUS),
       DEFAULT_ACTIVITY_COUNT,
       DEFAULT_PROCESSED,
+      contentHash,
       data.created_at,
       data.machine_id ?? getTeamMachineId(),
     );
@@ -795,11 +896,30 @@ export function insertBatchStateless(data: StatelessBatchInsert): BatchRow {
     return batchId;
   });
 
-  const batchId = tx();
+  let batchId: number;
+  try {
+    batchId = tx();
+  } catch (err) {
+    // A row with this content_hash already exists (the UNIQUE index fired). The
+    // INSERT rolled back the whole transaction, so prompt_count was not bumped —
+    // return the existing row with created: false.
+    if (contentHash != null && isUniqueConstraintError(err)) {
+      const existing = db.prepare(
+        `SELECT ${SELECT_COLUMNS} FROM prompt_batches WHERE session_id = ? AND content_hash = ?`,
+      ).get(data.session_id, contentHash) as Record<string, unknown> | undefined;
+      if (existing) {
+        return { row: toBatchRow(existing), created: false };
+      }
+    }
+    throw err;
+  }
 
-  return toBatchRow(
-    db.prepare(`SELECT ${SELECT_COLUMNS} FROM prompt_batches WHERE id = ?`).get(batchId) as Record<string, unknown>,
-  );
+  return {
+    row: toBatchRow(
+      db.prepare(`SELECT ${SELECT_COLUMNS} FROM prompt_batches WHERE id = ?`).get(batchId) as Record<string, unknown>,
+    ),
+    created: true,
+  };
 }
 
 /**
@@ -1035,13 +1155,30 @@ export function replaceRecoveredBatchUserPrompt(
 ): boolean {
   if (!realPrompt) return false;
   const db = getDatabase();
-  const info = db.prepare(
+  // The sentinel is the session's first turn (ordinal 0); stamp the matching
+  // content_hash so a later re-mine of this turn dedups against it.
+  const sessionRow = db
+    .prepare(`SELECT session_id FROM prompt_batches WHERE id = ?`)
+    .get(batchId) as { session_id: string } | undefined;
+  const contentHash = sessionRow
+    ? promptBatchContentHash({ sessionId: sessionRow.session_id, origin, ordinal: 0, userPrompt: realPrompt })
+    : null;
+  const runUpdate = (hash: string | null) => db.prepare(
     `UPDATE prompt_batches
-       SET user_prompt = ?, kind = ?, origin = ?
+       SET user_prompt = ?, kind = ?, origin = ?, content_hash = ?
        WHERE id = ?
          AND user_prompt = ?`,
-  ).run(realPrompt, BATCH_KIND.INITIAL, origin, batchId, RECOVERED_BATCH_SENTINEL);
-  return info.changes > 0;
+  ).run(realPrompt, BATCH_KIND.INITIAL, origin, hash, batchId, RECOVERED_BATCH_SENTINEL);
+  try {
+    return runUpdate(contentHash).changes > 0;
+  } catch (err) {
+    // Another row already owns this content_hash (a multi-sentinel session whose
+    // turns share text, or a turn already re-mined). Replacing the prompt is the
+    // primary job and must never throw — fall back to leaving content_hash NULL
+    // (the prefix-bucket path still dedups that turn on re-mine).
+    if (isUniqueConstraintError(err)) return runUpdate(null).changes > 0;
+    throw err;
+  }
 }
 
 /**

--- a/scripts/one-shots/2026-06-23-prompt-batch-dedup/README.md
+++ b/scripts/one-shots/2026-06-23-prompt-batch-dedup/README.md
@@ -1,0 +1,66 @@
+# One-shot: collapse historical prompt_batch duplicates (2026-06-23)
+
+**This is a POINT-IN-TIME CLEANUP SCRIPT, not reusable tooling.**
+
+It collapses byte-identical `prompt_batches` duplicates left behind by re-mine
+overlap. The duplication is prevented going forward by the `content_hash` UNIQUE
+guard in `packages/myco/src/db/queries/batches.ts`; this script only cleans up
+rows written before that guard was active.
+
+It is hardcoded to the original developer machine (`user=chris`) and refuses to
+run anywhere else. Do not modify the guard to "generalize" it.
+
+## What it does
+
+For every Grove DB under `~/.myco/groves/*` and `~/.myco-dev/groves/*` (or a
+single `--db <path>`):
+
+1. Groups batches by `(session_id, origin, normalize(user_prompt))` where
+   `normalize` is JS `.trim()` of the **full** prompt — the SAME normalization
+   the going-forward `content_hash` guard uses. The collapse is keyed on this,
+   **not** on `content_hash`: the positional hash deliberately makes
+   byte-identical bug-dups *distinct*, so it cannot be the collapse key.
+2. Keeps the earliest row in each group (`MIN(id)`) as canonical.
+3. Lifts a `response_summary` that only a duplicate carries onto the canonical.
+4. **Repoints every child reference** (`activities`, `plans`, `attachments`,
+   `spores`, `knowledge_git_provenance`, `knowledge_release_state`, and the
+   self-referential `parent_prompt_batch_id`) from the duplicate to the
+   canonical row — no child row is ever deleted.
+5. Deletes the duplicate batches.
+
+## Safeguards
+
+- **Dry-run by default.** Runs inside a transaction that is `ROLLBACK`'d unless
+  `--apply` is passed. Always run the dry-run first and read the per-DB counts.
+- **Pre/post assertions** (abort + rollback on any mismatch): exactly the
+  duplicate rows are removed; every child table's row count is unchanged
+  (repointed, not lost); no dangling `parent_prompt_batch_id` remains.
+- **`PRAGMA foreign_keys = ON`** so an un-repointed reference aborts the DELETE
+  loudly instead of orphaning a row. The repoint list covers every column with a
+  declared `REFERENCES prompt_batches(id)` FK; this safety net only catches
+  declared FKs, so a child column storing a `prompt_batch_id` without a FK would
+  be missed.
+- **Team-delete trigger suppression.** The per-row `*_team_ad` triggers
+  (`TEAM_DELETE_TRIGGERS` in `schema-ddl.ts`) would enqueue one `team_outbox`
+  `delete` per collapsed row on a sync-enabled member project. The script flips
+  `team_sync_state.enabled` to 0 inside the transaction (the trigger re-reads it
+  per row) and restores it before commit; on crash the whole transaction rolls
+  back, so the flag never sticks at 0. Consequence: D1 is left with the
+  pre-cleanup duplicate topology — it is not reconciled. Survivor `content_hash`
+  is intentionally **not** backfilled (the partial index protects new writes).
+
+## Accepted limitation
+
+On byte-identical historical data this **cannot** distinguish a bug-dup from a
+genuine repeated prompt — exactly as the original manual dogfood drain could
+not. Collapsing a genuine byte-identical repeat is accepted. Going forward,
+genuine repeats are preserved because they get distinct positional ordinals.
+
+## Run
+
+```bash
+bun scripts/one-shots/2026-06-23-prompt-batch-dedup/collapse.mjs          # dry-run, all groves
+bun scripts/one-shots/2026-06-23-prompt-batch-dedup/collapse.mjs --apply  # COMMIT
+```
+
+Kept in-tree as evidence of the cleanup, not as a runtime utility.

--- a/scripts/one-shots/2026-06-23-prompt-batch-dedup/collapse.mjs
+++ b/scripts/one-shots/2026-06-23-prompt-batch-dedup/collapse.mjs
@@ -1,0 +1,199 @@
+// ONE-SHOT — see README.md in this directory. Collapses the historical
+// byte-identical prompt_batch duplicates left by the re-mine overlap bug
+// (the going-forward guard is the content_hash UNIQUE index activated in
+// packages/myco/src/db/queries/batches.ts). Hardcoded to the original
+// developer machine; refuses to run elsewhere. DRY-RUN unless --apply.
+//
+// Usage:
+//   bun scripts/one-shots/2026-06-23-prompt-batch-dedup/collapse.mjs            # dry-run, all groves
+//   bun scripts/one-shots/2026-06-23-prompt-batch-dedup/collapse.mjs --db PATH  # dry-run, one DB
+//   bun scripts/one-shots/2026-06-23-prompt-batch-dedup/collapse.mjs --apply    # COMMIT
+import { Database } from 'bun:sqlite';
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+
+if (os.userInfo().username !== 'chris') {
+  console.error('One-shot hardcoded for the original developer machine (user=chris).');
+  console.error(`Got user=${os.userInfo().username}. See ./README.md — do not "generalize" this; the going-forward fix is the content_hash guard.`);
+  process.exit(1);
+}
+
+const APPLY = process.argv.includes('--apply');
+const dbArgIdx = process.argv.indexOf('--db');
+const HOME = os.homedir();
+
+/** Collapse key MUST match the going-forward normalize (JS .trim() of the full prompt). */
+const norm = (t) => (t ?? '').trim();
+
+/** Every column that references prompt_batches(id) — repoint dup→canonical before delete. */
+const CHILD_REFS = [
+  { table: 'prompt_batches', col: 'parent_prompt_batch_id' },
+  { table: 'activities', col: 'prompt_batch_id' },
+  { table: 'knowledge_git_provenance', col: 'prompt_batch_id' },
+  { table: 'knowledge_release_state', col: 'source_prompt_batch_id' },
+  { table: 'plans', col: 'prompt_batch_id' },
+  { table: 'attachments', col: 'prompt_batch_id' },
+  { table: 'spores', col: 'prompt_batch_id' },
+];
+
+function discoverDbs() {
+  if (dbArgIdx !== -1) return [process.argv[dbArgIdx + 1]];
+  const roots = [path.join(HOME, '.myco', 'groves'), path.join(HOME, '.myco-dev', 'groves')];
+  const dbs = [];
+  for (const root of roots) {
+    if (!fs.existsSync(root)) continue;
+    for (const entry of fs.readdirSync(root)) {
+      const p = path.join(root, entry, 'myco.db');
+      if (fs.existsSync(p)) dbs.push(p);
+    }
+  }
+  return dbs;
+}
+
+function tableExists(db, name) {
+  return !!db.prepare(`SELECT 1 FROM sqlite_master WHERE type='table' AND name=?`).get(name);
+}
+
+function collapseDb(dbPath) {
+  const db = new Database(dbPath);
+  // The live daemon holds these DBs in WAL; wait rather than fail on its
+  // transient write locks during our (rolled-back) dry-run transaction.
+  db.run('PRAGMA busy_timeout = 5000');
+  // FK ON so an un-repointed child reference aborts the DELETE (loud) instead
+  // of silently orphaning a row — the safety net for any child table this
+  // script doesn't know about.
+  db.run('PRAGMA foreign_keys = ON');
+
+  // Build the canonical map in JS so the collapse key matches the going-forward
+  // JS .trim() normalization exactly (SQLite trim() only strips spaces).
+  const rows = db.prepare('SELECT id, session_id, origin, user_prompt FROM prompt_batches').all();
+  const groups = new Map(); // key -> sorted ids
+  for (const r of rows) {
+    // Same field shape as the going-forward content_hash, minus the ordinal.
+    const key = [r.session_id, r.origin, norm(r.user_prompt)].join(" ");
+    const list = groups.get(key) ?? [];
+    list.push(r.id);
+    groups.set(key, list);
+  }
+  const pairs = []; // { dup_id, canonical_id }
+  for (const ids of groups.values()) {
+    if (ids.length < 2) continue;
+    ids.sort((a, b) => a - b);
+    const canonical = ids[0];
+    for (let i = 1; i < ids.length; i++) pairs.push({ dup_id: ids[i], canonical_id: canonical });
+  }
+
+  const before = {
+    batches: rows.length,
+    groups: groups.size,
+    dups: pairs.length,
+  };
+  if (pairs.length === 0) {
+    console.log(`  ${dbPath}\n    no duplicates — skipped`);
+    db.close();
+    return { dups: 0 };
+  }
+
+  // Conscious handling of the per-row team-delete trigger
+  // (TEAM_DELETE_TRIGGERS in schema-ddl.ts): on a sync-enabled, member project
+  // a mass DELETE would enqueue one team_outbox 'delete' per collapsed row —
+  // the tenancy-flood shape. Suppress by flipping team_sync_state.enabled to 0
+  // inside the txn (the trigger re-reads it per row), restored before COMMIT.
+  // The dup rows were never legitimately distinct; D1 keeps its (inert) copies.
+  const syncRow = tableExists(db, 'team_sync_state')
+    ? db.prepare('SELECT enabled FROM team_sync_state LIMIT 1').get()
+    : null;
+  const syncWasEnabled = !!(syncRow && syncRow.enabled === 1);
+
+  const childCountsBefore = {};
+  for (const { table } of CHILD_REFS) {
+    if (table === 'prompt_batches') continue;
+    childCountsBefore[table] = tableExists(db, table)
+      ? db.prepare(`SELECT COUNT(*) AS n FROM ${table}`).get().n
+      : null;
+  }
+
+  db.prepare('BEGIN').run();
+  try {
+    if (syncWasEnabled) db.prepare('UPDATE team_sync_state SET enabled = 0').run();
+
+    db.run('CREATE TEMP TABLE dup_map (dup_id INTEGER PRIMARY KEY, canonical_id INTEGER NOT NULL)');
+    const ins = db.prepare('INSERT INTO dup_map (dup_id, canonical_id) VALUES (?, ?)');
+    for (const p of pairs) ins.run(p.dup_id, p.canonical_id);
+
+    // Preserve a response_summary that only the dup carries.
+    const lifted = db.prepare(`
+      UPDATE prompt_batches SET response_summary = (
+        SELECT d.response_summary FROM prompt_batches d
+        JOIN dup_map m ON m.dup_id = d.id
+        WHERE m.canonical_id = prompt_batches.id AND d.response_summary IS NOT NULL
+        ORDER BY d.id ASC LIMIT 1)
+      WHERE id IN (SELECT canonical_id FROM dup_map)
+        AND response_summary IS NULL
+        AND EXISTS (
+          SELECT 1 FROM prompt_batches d JOIN dup_map m ON m.dup_id = d.id
+          WHERE m.canonical_id = prompt_batches.id AND d.response_summary IS NOT NULL)`).run();
+
+    // Repoint every child reference dup→canonical so the DELETE never orphans.
+    let repointed = 0;
+    for (const { table, col } of CHILD_REFS) {
+      if (!tableExists(db, table)) continue;
+      const r = db.prepare(
+        `UPDATE ${table} SET ${col} = (SELECT canonical_id FROM dup_map WHERE dup_id = ${table}.${col})
+         WHERE ${col} IN (SELECT dup_id FROM dup_map)`,
+      ).run();
+      repointed += r.changes;
+    }
+
+    const deleted = db.prepare('DELETE FROM prompt_batches WHERE id IN (SELECT dup_id FROM dup_map)').run();
+
+    // Restore sync flag BEFORE asserting/commit.
+    if (syncWasEnabled) db.prepare('UPDATE team_sync_state SET enabled = 1').run();
+
+    const after = {
+      batches: db.prepare('SELECT COUNT(*) AS n FROM prompt_batches').get().n,
+    };
+    // Invariants: exactly the dup rows were removed; no child rows were lost
+    // (they were repointed, never deleted); no dangling parent ref remains.
+    if (after.batches !== before.batches - before.dups) {
+      throw new Error(`batch count mismatch: ${after.batches} != ${before.batches} - ${before.dups}`);
+    }
+    for (const { table } of CHILD_REFS) {
+      if (table === 'prompt_batches') continue;
+      if (childCountsBefore[table] === null) continue;
+      const now = db.prepare(`SELECT COUNT(*) AS n FROM ${table}`).get().n;
+      if (now !== childCountsBefore[table]) throw new Error(`${table} row count changed: ${childCountsBefore[table]} -> ${now}`);
+    }
+    const dangling = db.prepare(
+      `SELECT COUNT(*) AS n FROM prompt_batches
+       WHERE parent_prompt_batch_id IS NOT NULL
+         AND parent_prompt_batch_id NOT IN (SELECT id FROM prompt_batches)`).get().n;
+    if (dangling !== 0) throw new Error(`${dangling} dangling parent_prompt_batch_id refs after collapse`);
+
+    console.log(`  ${dbPath}`);
+    console.log(`    batches ${before.batches} -> ${after.batches}  (collapsed ${before.dups} dups across ${before.groups} groups; summaries lifted ${lifted.changes}; child refs repointed ${repointed}; sync trigger ${syncWasEnabled ? 'SUPPRESSED' : 'inactive'})`);
+
+    if (APPLY) { db.prepare('COMMIT').run(); console.log('    COMMITTED'); }
+    else { db.prepare('ROLLBACK').run(); console.log('    rolled back (dry-run)'); }
+    db.close();
+    return { dups: before.dups };
+  } catch (err) {
+    db.prepare('ROLLBACK').run();
+    db.close();
+    console.error(`    rolled back due to error: ${err.message}`);
+    process.exitCode = 1;
+    return { dups: 0, error: true };
+  }
+}
+
+console.log(`mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}`);
+const dbs = discoverDbs();
+if (dbs.length === 0) { console.log('no grove DBs found'); process.exit(0); }
+let totalDups = 0;
+for (const dbPath of dbs) {
+  if (!dbPath || !fs.existsSync(dbPath)) { console.error(`  ${dbPath}: not found`); continue; }
+  const { dups } = collapseDb(dbPath);
+  totalDups += dups ?? 0;
+}
+console.log(`\ntotal duplicate batches ${APPLY ? 'collapsed' : 'collapsible'}: ${totalDups}`);

--- a/tests/agent/context-queries.test.ts
+++ b/tests/agent/context-queries.test.ts
@@ -96,7 +96,7 @@ describe('executeContextQueries', () => {
     // For vault_unprocessed we need a settled (closed, processed_at IS NULL)
     // batch. The dispatcher would normally create this; we go through the
     // stateless insert path and close the batch by hand.
-    const batch = insertBatchStateless({
+    const { row: batch } = insertBatchStateless({
       session_id: 'sess-a',
       project_id: PROJECT_A,
       user_prompt: 'A test prompt',

--- a/tests/capture/transcript-miner-reconcile.test.ts
+++ b/tests/capture/transcript-miner-reconcile.test.ts
@@ -530,3 +530,61 @@ describe('TranscriptMiner.reconcileBatchKinds', () => {
     expect(taskNotif.response_summary).toBeNull();
   });
 });
+
+describe('TranscriptMiner content_hash dedup (positional ordinal)', () => {
+  let tmpDir: string;
+  let transcriptPath: string;
+
+  beforeAll(() => { setupTestDb(); });
+  afterAll(teardownTestDb);
+
+  beforeEach(() => {
+    cleanTestDb();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'miner-dedup-'));
+    transcriptPath = path.join(tmpDir, 'transcript.jsonl');
+    seedSession({ id: 's-dedup', agent: 'claude-code' });
+  });
+
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  // Each text becomes its own ended human turn.
+  const writeTurns = (texts: string[]) => {
+    const events: unknown[] = [];
+    texts.forEach((text, i) => {
+      events.push({ type: 'user', promptId: `p${i}`, message: { role: 'user', content: [{ type: 'text', text }] } });
+      events.push({ type: 'assistant', message: { stop_reason: 'end_turn' } });
+    });
+    fs.writeFileSync(transcriptPath, events.map((e) => JSON.stringify(e)).join('\n') + '\n');
+  };
+  const mine = () => new TranscriptMiner().reconcileBatchKinds('s-dedup', { agent: 'claude-code', transcriptPath });
+  const humanBatches = () =>
+    listBatchesBySession('s-dedup', { scope: ALL_PROJECTS_SCOPE }).filter((b) => b.origin === 'human');
+
+  it('preserves a genuine repeated prompt as two rows with distinct content_hash', () => {
+    writeTurns(['deploy', 'deploy']);
+    mine();
+    const rows = humanBatches();
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.content_hash).not.toBeNull();
+    expect(rows[1]!.content_hash).not.toBeNull();
+    expect(rows[0]!.content_hash).not.toBe(rows[1]!.content_hash);
+  });
+
+  it('re-mining the same transcript adds no rows', () => {
+    writeTurns(['deploy', 'deploy']);
+    mine();
+    expect(humanBatches()).toHaveLength(2);
+    mine(); // fresh miner instance — re-reads + re-snapshots
+    expect(humanBatches()).toHaveLength(2);
+  });
+
+  it('a live-captured turn does not block a genuine repeat on mine', () => {
+    // The ordinal must advance for the consumed (live) turn so the second
+    // occurrence gets ordinal 1 and a distinct hash rather than colliding.
+    handleUserPrompt('s-dedup', 'deploy', { kind: 'initial' });
+    expect(humanBatches()).toHaveLength(1);
+    writeTurns(['deploy', 'deploy']);
+    mine();
+    expect(humanBatches()).toHaveLength(2);
+  });
+});

--- a/tests/daemon/capture.test.ts
+++ b/tests/daemon/capture.test.ts
@@ -380,9 +380,9 @@ describe('stateless DB functions', () => {
 
       upsertSession({ id: sessionId, agent: 'claude-code', started_at: now, created_at: now });
 
-      const b1 = insertBatchStateless({ session_id: sessionId, user_prompt: 'first', created_at: now });
-      const b2 = insertBatchStateless({ session_id: sessionId, user_prompt: 'second', created_at: now });
-      const b3 = insertBatchStateless({ session_id: sessionId, user_prompt: 'third', created_at: now });
+      const { row: b1 } = insertBatchStateless({ session_id: sessionId, user_prompt: 'first', created_at: now });
+      const { row: b2 } = insertBatchStateless({ session_id: sessionId, user_prompt: 'second', created_at: now });
+      const { row: b3 } = insertBatchStateless({ session_id: sessionId, user_prompt: 'third', created_at: now });
 
       expect(b1.prompt_number).toBe(1);
       expect(b2.prompt_number).toBe(2);
@@ -400,7 +400,7 @@ describe('stateless DB functions', () => {
       insertBatch({ session_id: sessionId, prompt_number: 2, user_prompt: 'old-2', started_at: now, ended_at: now, status: 'completed', created_at: now });
 
       // Stateless insert should pick up prompt_number = 3
-      const b3 = insertBatchStateless({ session_id: sessionId, user_prompt: 'new-after-restart', created_at: now });
+      const { row: b3 } = insertBatchStateless({ session_id: sessionId, user_prompt: 'new-after-restart', created_at: now });
       expect(b3.prompt_number).toBe(3);
     });
 
@@ -414,7 +414,7 @@ describe('stateless DB functions', () => {
 
       insertBatchStateless({ session_id: session1, user_prompt: 's1-first', created_at: now });
       insertBatchStateless({ session_id: session1, user_prompt: 's1-second', created_at: now });
-      const s2b1 = insertBatchStateless({ session_id: session2, user_prompt: 's2-first', created_at: now });
+      const { row: s2b1 } = insertBatchStateless({ session_id: session2, user_prompt: 's2-first', created_at: now });
 
       // Session 2 should start at 1, not 3
       expect(s2b1.prompt_number).toBe(1);
@@ -426,7 +426,7 @@ describe('stateless DB functions', () => {
 
       upsertSession({ id: sessionId, agent: 'claude-code', started_at: now, created_at: now });
 
-      const batch = insertBatchStateless({ session_id: sessionId, user_prompt: 'test', created_at: now });
+      const { row: batch } = insertBatchStateless({ session_id: sessionId, user_prompt: 'test', created_at: now });
       expect(batch.status).toBe('active');
       expect(batch.ended_at).toBeNull();
       expect(batch.activity_count).toBe(0);
@@ -443,7 +443,7 @@ describe('stateless DB functions', () => {
       upsertSession({ id: sessionId, agent: 'claude-code', started_at: now, created_at: now });
 
       // Create an open batch
-      const batch = insertBatchStateless({ session_id: sessionId, user_prompt: 'do something', created_at: now });
+      const { row: batch } = insertBatchStateless({ session_id: sessionId, user_prompt: 'do something', created_at: now });
 
       // Insert activity — should auto-link to the open batch
       const activity = insertActivityWithBatch({
@@ -489,7 +489,7 @@ describe('stateless DB functions', () => {
 
       // Create two open batches
       insertBatchStateless({ session_id: sessionId, user_prompt: 'first', created_at: now });
-      const batch2 = insertBatchStateless({ session_id: sessionId, user_prompt: 'second', created_at: now });
+      const { row: batch2 } = insertBatchStateless({ session_id: sessionId, user_prompt: 'second', created_at: now });
 
       // Activity should link to the most recent (highest id) open batch
       const activity = insertActivityWithBatch({
@@ -509,7 +509,7 @@ describe('stateless DB functions', () => {
       upsertSession({ id: sessionId, agent: 'claude-code', started_at: now, created_at: now });
 
       // Create a batch and close it.
-      const batch = insertBatchStateless({ session_id: sessionId, user_prompt: 'closed', created_at: now });
+      const { row: batch } = insertBatchStateless({ session_id: sessionId, user_prompt: 'closed', created_at: now });
       closeOpenBatches(sessionId, now + 1);
 
       // Inline subquery now picks the most-recent batch (open first, then
@@ -602,8 +602,8 @@ describe('daemon-restart resilience', () => {
     upsertSession({ id: sessionId, agent: 'claude-code', started_at: now, created_at: now });
 
     // Pre-restart: 2 batches
-    const b1 = insertBatchStateless({ session_id: sessionId, user_prompt: 'pre-1', created_at: now });
-    const b2 = insertBatchStateless({ session_id: sessionId, user_prompt: 'pre-2', created_at: now });
+    const { row: b1 } = insertBatchStateless({ session_id: sessionId, user_prompt: 'pre-1', created_at: now });
+    const { row: b2 } = insertBatchStateless({ session_id: sessionId, user_prompt: 'pre-2', created_at: now });
     expect(b1.prompt_number).toBe(1);
     expect(b2.prompt_number).toBe(2);
 
@@ -614,8 +614,8 @@ describe('daemon-restart resilience', () => {
     // No in-memory state carried over. The DB is the only source of truth.
 
     // Post-restart: new batches should continue from 3
-    const b3 = insertBatchStateless({ session_id: sessionId, user_prompt: 'post-1', created_at: now + 2 });
-    const b4 = insertBatchStateless({ session_id: sessionId, user_prompt: 'post-2', created_at: now + 3 });
+    const { row: b3 } = insertBatchStateless({ session_id: sessionId, user_prompt: 'post-1', created_at: now + 2 });
+    const { row: b4 } = insertBatchStateless({ session_id: sessionId, user_prompt: 'post-2', created_at: now + 3 });
     expect(b3.prompt_number).toBe(3);
     expect(b4.prompt_number).toBe(4);
 
@@ -632,7 +632,7 @@ describe('daemon-restart resilience', () => {
     upsertSession({ id: sessionId, agent: 'claude-code', started_at: now, created_at: now });
 
     // Pre-restart: open a batch, add an activity
-    const preBatch = insertBatchStateless({ session_id: sessionId, user_prompt: 'pre', created_at: now });
+    const { row: preBatch } = insertBatchStateless({ session_id: sessionId, user_prompt: 'pre', created_at: now });
     const preActivity = insertActivityWithBatch({
       session_id: sessionId,
       tool_name: 'Write',
@@ -646,7 +646,7 @@ describe('daemon-restart resilience', () => {
     closeOpenBatches(sessionId, now + 1);
 
     // Post-restart: new batch, new activity
-    const postBatch = insertBatchStateless({ session_id: sessionId, user_prompt: 'post', created_at: now + 2 });
+    const { row: postBatch } = insertBatchStateless({ session_id: sessionId, user_prompt: 'post', created_at: now + 2 });
     const postActivity = insertActivityWithBatch({
       session_id: sessionId,
       tool_name: 'Bash',
@@ -669,7 +669,7 @@ describe('daemon-restart resilience', () => {
     upsertSession({ id: sessionId, agent: 'claude-code', started_at: now, created_at: now });
 
     // Pre-restart: open batch, close it. Represents the turn that just ended.
-    const preBatch = insertBatchStateless({ session_id: sessionId, user_prompt: 'pre', created_at: now });
+    const { row: preBatch } = insertBatchStateless({ session_id: sessionId, user_prompt: 'pre', created_at: now });
     closeOpenBatches(sessionId, now + 1);
 
     // ---- Late tool_use arrives between turns (or after restart) ----
@@ -687,7 +687,7 @@ describe('daemon-restart resilience', () => {
     expect(activitiesMid[0].prompt_batch_id).toBe(preBatch.id);
 
     // Now open a new real batch — subsequent activities link correctly to it.
-    const postBatch = insertBatchStateless({ session_id: sessionId, user_prompt: 'post', created_at: now + 3 });
+    const { row: postBatch } = insertBatchStateless({ session_id: sessionId, user_prompt: 'post', created_at: now + 3 });
     handleToolUse(sessionId, 'claude-code', 'Write', {}, 'ok', TEST_PROJECT_ROOT);
     const finalActivities = listActivities({ session_id: sessionId, scope: ALL_PROJECTS_SCOPE });
     expect(finalActivities.length).toBe(2);
@@ -721,17 +721,17 @@ describe('daemon-restart resilience', () => {
     upsertSession({ id: sessionId, agent: 'claude-code', started_at: now, created_at: now });
 
     // Restart 1: 2 batches
-    const r1b1 = insertBatchStateless({ session_id: sessionId, user_prompt: 'r1-1', created_at: now });
-    const r1b2 = insertBatchStateless({ session_id: sessionId, user_prompt: 'r1-2', created_at: now + 1 });
+    const { row: r1b1 } = insertBatchStateless({ session_id: sessionId, user_prompt: 'r1-1', created_at: now });
+    const { row: r1b2 } = insertBatchStateless({ session_id: sessionId, user_prompt: 'r1-2', created_at: now + 1 });
     closeOpenBatches(sessionId, now + 2);
 
     // Restart 2: 1 batch
-    const r2b1 = insertBatchStateless({ session_id: sessionId, user_prompt: 'r2-1', created_at: now + 3 });
+    const { row: r2b1 } = insertBatchStateless({ session_id: sessionId, user_prompt: 'r2-1', created_at: now + 3 });
     closeOpenBatches(sessionId, now + 4);
 
     // Restart 3: 2 batches
-    const r3b1 = insertBatchStateless({ session_id: sessionId, user_prompt: 'r3-1', created_at: now + 5 });
-    const r3b2 = insertBatchStateless({ session_id: sessionId, user_prompt: 'r3-2', created_at: now + 6 });
+    const { row: r3b1 } = insertBatchStateless({ session_id: sessionId, user_prompt: 'r3-1', created_at: now + 5 });
+    const { row: r3b2 } = insertBatchStateless({ session_id: sessionId, user_prompt: 'r3-2', created_at: now + 6 });
 
     expect(r1b1.prompt_number).toBe(1);
     expect(r1b2.prompt_number).toBe(2);

--- a/tests/db/batches-dedup.test.ts
+++ b/tests/db/batches-dedup.test.ts
@@ -1,0 +1,176 @@
+/**
+ * prompt_batches content_hash dedup guard.
+ *
+ * A re-inserted turn (same session, origin, ordinal, normalized text) dedups to
+ * one row; a genuine repeat takes the next ordinal and is preserved. These tests
+ * pin that the writer honors the caller-supplied ordinal and the partial UNIQUE
+ * index fires. The miner's in-pass ordinal source and the live↔miner agreement
+ * are covered in tests/capture/transcript-miner-reconcile.test.ts.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'bun:test';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
+import { nowSec, seedSession } from '../helpers/sessions.js';
+import { getSession } from '@myco/db/queries/sessions.js';
+import {
+  insertBatchStateless,
+  promptBatchContentHash,
+  normalizePromptForHash,
+  liveContentOrdinal,
+  replaceRecoveredBatchUserPrompt,
+  listBatchesBySession,
+  PROMPT_BATCH_ORIGIN,
+  RECOVERED_BATCH_SENTINEL,
+} from '@myco/db/queries/batches.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+
+const batchCount = (sessionId: string): number =>
+  listBatchesBySession(sessionId, { scope: ALL_PROJECTS_SCOPE }).length;
+
+describe('promptBatchContentHash — positional, full-prompt, scoped', () => {
+  it('is a pure function of (session, origin, ordinal, normalized prompt)', () => {
+    const a = promptBatchContentHash({ sessionId: 's1', origin: PROMPT_BATCH_ORIGIN.HUMAN, ordinal: 0, userPrompt: 'deploy' });
+    const again = promptBatchContentHash({ sessionId: 's1', origin: PROMPT_BATCH_ORIGIN.HUMAN, ordinal: 0, userPrompt: 'deploy' });
+    expect(a).toBe(again);
+  });
+
+  it('the ordinal differentiates genuine repeats (the positional contract)', () => {
+    const first = promptBatchContentHash({ sessionId: 's1', origin: PROMPT_BATCH_ORIGIN.HUMAN, ordinal: 0, userPrompt: 'deploy' });
+    const second = promptBatchContentHash({ sessionId: 's1', origin: PROMPT_BATCH_ORIGIN.HUMAN, ordinal: 1, userPrompt: 'deploy' });
+    expect(first).not.toBe(second);
+  });
+
+  it('normalizes the FULL prompt via trim — whitespace-only differences collapse', () => {
+    const tight = promptBatchContentHash({ sessionId: 's1', origin: PROMPT_BATCH_ORIGIN.HUMAN, ordinal: 0, userPrompt: 'deploy the app' });
+    const padded = promptBatchContentHash({ sessionId: 's1', origin: PROMPT_BATCH_ORIGIN.HUMAN, ordinal: 0, userPrompt: '  deploy the app\n' });
+    expect(padded).toBe(tight);
+    expect(normalizePromptForHash('  deploy the app\n')).toBe('deploy the app');
+  });
+
+  it('hashes the full prompt, not a prefix — divergence past any prefix window matters', () => {
+    const long1 = `${'x'.repeat(500)}A`;
+    const long2 = `${'x'.repeat(500)}B`;
+    expect(promptBatchContentHash({ sessionId: 's1', origin: PROMPT_BATCH_ORIGIN.HUMAN, ordinal: 0, userPrompt: long1 }))
+      .not.toBe(promptBatchContentHash({ sessionId: 's1', origin: PROMPT_BATCH_ORIGIN.HUMAN, ordinal: 0, userPrompt: long2 }));
+  });
+
+  it('origin and session id are part of the key', () => {
+    const human = promptBatchContentHash({ sessionId: 's1', origin: PROMPT_BATCH_ORIGIN.HUMAN, ordinal: 0, userPrompt: 'x' });
+    const system = promptBatchContentHash({ sessionId: 's1', origin: PROMPT_BATCH_ORIGIN.SYSTEM, ordinal: 0, userPrompt: 'x' });
+    const other = promptBatchContentHash({ sessionId: 's2', origin: PROMPT_BATCH_ORIGIN.HUMAN, ordinal: 0, userPrompt: 'x' });
+    expect(human).not.toBe(system);
+    expect(human).not.toBe(other);
+  });
+});
+
+describe('insertBatchStateless — content_hash dedup guard', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(teardownTestDb);
+  beforeEach(() => {
+    cleanTestDb();
+    seedSession({ id: 's1' });
+  });
+
+  it('two passes of the same positional turn insert ONE row', () => {
+    // Both passes supply ordinal 0 for the same turn → same content_hash → the
+    // unique index dedups the second insert.
+    const first = insertBatchStateless({ session_id: 's1', user_prompt: 'deploy', ordinal: 0, created_at: nowSec() });
+    const second = insertBatchStateless({ session_id: 's1', user_prompt: 'deploy', ordinal: 0, created_at: nowSec() });
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    // The deduped insert returns the EXISTING row, never a stale lastInsertRowid.
+    expect(second.row.id).toBe(first.row.id);
+    expect(batchCount('s1')).toBe(1);
+  });
+
+  it('genuine repeats get distinct ordinals → both rows kept, stable across re-mine', () => {
+    const t0 = insertBatchStateless({ session_id: 's1', user_prompt: 'deploy', ordinal: 0, created_at: nowSec() });
+    const t1 = insertBatchStateless({ session_id: 's1', user_prompt: 'deploy', ordinal: 1, created_at: nowSec() });
+    expect(t0.created).toBe(true);
+    expect(t1.created).toBe(true);
+    expect(batchCount('s1')).toBe(2);
+
+    // Re-mine: a fresh pass replays the SAME positional ordinals (0, 1).
+    const r0 = insertBatchStateless({ session_id: 's1', user_prompt: 'deploy', ordinal: 0, created_at: nowSec() });
+    const r1 = insertBatchStateless({ session_id: 's1', user_prompt: 'deploy', ordinal: 1, created_at: nowSec() });
+    expect(r0.created).toBe(false);
+    expect(r1.created).toBe(false);
+    expect(batchCount('s1')).toBe(2);
+  });
+
+  it('a deduped insert does not bump sessions.prompt_count a second time', () => {
+    insertBatchStateless({ session_id: 's1', user_prompt: 'deploy', ordinal: 0, created_at: nowSec() });
+    const afterFirst = getSession('s1', ALL_PROJECTS_SCOPE)?.prompt_count;
+    insertBatchStateless({ session_id: 's1', user_prompt: 'deploy', ordinal: 0, created_at: nowSec() });
+    const afterDup = getSession('s1', ALL_PROJECTS_SCOPE)?.prompt_count;
+    expect(afterFirst).toBe(1);
+    expect(afterDup).toBe(1);
+  });
+
+  it('an insert without an ordinal leaves content_hash NULL (no dedup, legacy behavior)', () => {
+    const a = insertBatchStateless({ session_id: 's1', user_prompt: 'deploy', created_at: nowSec() });
+    const b = insertBatchStateless({ session_id: 's1', user_prompt: 'deploy', created_at: nowSec() });
+    expect(a.row.content_hash).toBeNull();
+    expect(b.created).toBe(true);
+    expect(batchCount('s1')).toBe(2);
+  });
+});
+
+describe('liveContentOrdinal — the live path position', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(teardownTestDb);
+  beforeEach(() => {
+    cleanTestDb();
+    seedSession({ id: 's1' });
+  });
+
+  it('counts prior committed same-(origin, normalized text) batches in the session', () => {
+    expect(liveContentOrdinal('s1', PROMPT_BATCH_ORIGIN.HUMAN, 'deploy')).toBe(0);
+    insertBatchStateless({ session_id: 's1', user_prompt: '  deploy\n', ordinal: 0, created_at: nowSec() });
+    // Whitespace-normalized match counts as a prior occurrence.
+    expect(liveContentOrdinal('s1', PROMPT_BATCH_ORIGIN.HUMAN, 'deploy')).toBe(1);
+    // A different origin with the same text is a separate sequence.
+    expect(liveContentOrdinal('s1', PROMPT_BATCH_ORIGIN.SYSTEM, 'deploy')).toBe(0);
+  });
+});
+
+describe('replaceRecoveredBatchUserPrompt — content_hash stamping', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(teardownTestDb);
+  beforeEach(() => {
+    cleanTestDb();
+    seedSession({ id: 's1' });
+  });
+
+  it('stamps the ordinal-0 hash so a re-mine of the first turn dedups', () => {
+    const sentinel = insertBatchStateless({
+      session_id: 's1', user_prompt: RECOVERED_BATCH_SENTINEL, kind: 'recovered', created_at: nowSec(),
+    });
+    expect(sentinel.row.content_hash).toBeNull();
+
+    expect(replaceRecoveredBatchUserPrompt(sentinel.row.id, 'first turn', PROMPT_BATCH_ORIGIN.HUMAN)).toBe(true);
+    const stamped = listBatchesBySession('s1', { scope: ALL_PROJECTS_SCOPE })[0]!;
+    expect(stamped.content_hash).toBe(
+      promptBatchContentHash({ sessionId: 's1', origin: PROMPT_BATCH_ORIGIN.HUMAN, ordinal: 0, userPrompt: 'first turn' }),
+    );
+
+    // A subsequent re-mine of that same turn (ordinal 0) dedups against it.
+    const remined = insertBatchStateless({ session_id: 's1', user_prompt: 'first turn', ordinal: 0, created_at: nowSec() });
+    expect(remined.created).toBe(false);
+    expect(batchCount('s1')).toBe(1);
+  });
+
+  it('does not throw when the ordinal-0 hash is already taken — leaves content_hash NULL', () => {
+    // A pre-existing turn already owns the ordinal-0 hash for "dup text".
+    insertBatchStateless({ session_id: 's1', user_prompt: 'dup text', ordinal: 0, created_at: nowSec() });
+    const sentinel = insertBatchStateless({
+      session_id: 's1', user_prompt: RECOVERED_BATCH_SENTINEL, kind: 'recovered', created_at: nowSec(),
+    });
+
+    expect(() => replaceRecoveredBatchUserPrompt(sentinel.row.id, 'dup text', PROMPT_BATCH_ORIGIN.HUMAN)).not.toThrow();
+    const replaced = listBatchesBySession('s1', { scope: ALL_PROJECTS_SCOPE }).find((b) => b.id === sentinel.row.id)!;
+    expect(replaced.user_prompt).toBe('dup text');
+    expect(replaced.content_hash).toBeNull();
+  });
+});

--- a/tests/db/batches-steering.test.ts
+++ b/tests/db/batches-steering.test.ts
@@ -13,14 +13,14 @@ describe('insertBatchStateless with steering fields', () => {
   });
 
   it('defaults kind to "initial" and parent to null', () => {
-    const b = insertBatchStateless({ session_id: 's1', created_at: nowSec() });
+    const { row: b } = insertBatchStateless({ session_id: 's1', created_at: nowSec() });
     expect(b.kind).toBe('initial');
     expect(b.parent_prompt_batch_id).toBeNull();
   });
 
   it('accepts explicit kind and parent_prompt_batch_id', () => {
-    const parent = insertBatchStateless({ session_id: 's1', created_at: nowSec() });
-    const child = insertBatchStateless({
+    const { row: parent } = insertBatchStateless({ session_id: 's1', created_at: nowSec() });
+    const { row: child } = insertBatchStateless({
       session_id: 's1',
       created_at: nowSec(),
       kind: 'steering',

--- a/tests/db/find-open-parent.test.ts
+++ b/tests/db/find-open-parent.test.ts
@@ -18,7 +18,7 @@ describe('findOpenParentBatch', () => {
   });
 
   it('returns the open initial batch', () => {
-    const b = insertBatchStateless({ session_id: 's1', created_at: nowSec(), kind: 'initial' });
+    const { row: b } = insertBatchStateless({ session_id: 's1', created_at: nowSec(), kind: 'initial' });
     const found = findOpenParentBatch('s1');
     expect(found).not.toBeNull();
     expect(found!.id).toBe(b.id);
@@ -26,14 +26,14 @@ describe('findOpenParentBatch', () => {
   });
 
   it('returns null when the batch is closed (ended_at set)', () => {
-    const b = insertBatchStateless({ session_id: 's1', created_at: nowSec(), kind: 'initial' });
+    const { row: b } = insertBatchStateless({ session_id: 's1', created_at: nowSec(), kind: 'initial' });
     const db = getDatabase();
     db.prepare(`UPDATE prompt_batches SET ended_at = ? WHERE id = ?`).run(nowSec(), b.id);
     expect(findOpenParentBatch('s1')).toBeNull();
   });
 
   it('returns the parent, never a steering child', () => {
-    const parent = insertBatchStateless({ session_id: 's1', created_at: nowSec(), kind: 'initial' });
+    const { row: parent } = insertBatchStateless({ session_id: 's1', created_at: nowSec(), kind: 'initial' });
     insertBatchStateless({
       session_id: 's1',
       created_at: nowSec(),

--- a/tests/smoke/review-fixes.test.ts
+++ b/tests/smoke/review-fixes.test.ts
@@ -655,7 +655,7 @@ describe('machine_id fix: insertBatchStateless', () => {
       machine_id: 'correct-machine',
     });
 
-    const batch = insertBatchStateless({
+    const { row: batch } = insertBatchStateless({
       session_id: 'sess-mid',
       user_prompt: 'test prompt',
       created_at: now,
@@ -673,7 +673,7 @@ describe('machine_id fix: insertBatchStateless', () => {
       id: 'sess-mid2', agent: 'test', started_at: now, created_at: now,
     });
 
-    const batch = insertBatchStateless({
+    const { row: batch } = insertBatchStateless({
       session_id: 'sess-mid2',
       user_prompt: 'test prompt',
       created_at: now,


### PR DESCRIPTION
## What

Activates the previously-inert partial UNIQUE index on `prompt_batches(content_hash)`. `insertBatchStateless` hardcoded `content_hash = NULL`, so cross-process re-mine overlap inserted byte-identical duplicate prompt_batches. The index existed but never fired.

## How

`content_hash = sha256(session_id · origin · ordinal · trim(prompt))`, where the **ordinal is transcript-positional**, supplied by the caller, never a re-counted DB aggregate — a DB-count ordinal drifts upward on every re-mine pass (new hash each time → the index never fires), a positional ordinal is stable per turn so a re-inserted turn dedups while a genuine repeat takes the next position and is preserved.

- `insertBatchStateless` populates `content_hash` and is idempotent: on a UNIQUE violation the transaction rolls back (no `prompt_count` bump) and the existing row is returned. Return type is now `{ row, created }` so every caller handles the dedup signal.
- Miner derives an in-pass positional index (advanced for every record, consumed or inserted); the live path uses `liveContentOrdinal`; `syncTranscriptPromptBatches` computes position over the full prompt list; `replaceRecoveredBatchUserPrompt` stamps the ordinal-0 hash for the sentinel→first-turn path and falls back to NULL on conflict (never throws).
- `isUniqueConstraintError` consolidated into `db/client.ts`.

No schema bump (column + indexes already existed). Team-sync unaffected (`content_hash` already in the D1 worker schema; upsert-by-id).

## Tests

New `tests/db/batches-dedup.test.ts` (writer-level: proving gate, genuine-repeat preservation, no double `prompt_count` bump, live ordinal, `replaceRecoveredBatchUserPrompt`) and miner-level cases in `tests/capture/transcript-miner-reconcile.test.ts` (genuine repeat → distinct hashes; re-mine idempotency; advance-for-consumed). Existing callers updated to the `{ row, created }` contract. Full suite + tsc green; verified live via a real Claude Code session (content_hash written and recompute-correct; resume/re-mine did not duplicate).

## Historical cleanup (not auto-run)

`scripts/one-shots/2026-06-23-prompt-batch-dedup/` collapses pre-fix byte-identical duplicates — dry-run default, machine-locked, FK-on, pre/post assertions, team-delete-trigger suppression. Run manually after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
