### PR TITLE
fix(upgrade): heal launchd respawn loop + make self-update converge (multi-signal health-watch)

### DIFF
--- a/.agents/skills/feature-branch-worktree-squash-merge-delivery/SKILL.md
+++ b/.agents/skills/feature-branch-worktree-squash-merge-delivery/SKILL.md
@@ -52,7 +52,7 @@ cd ../myco-branch-name
 make dev-link-worktree
 ```
 
-This writes a `.myco/runtime.command` file that pins this worktree to the freshly-built local binary (not the shared `~/.local/bin/myco-dev` symlink). All hooks, MCP calls, and CLI invocations in this worktree then dispatch to the worktree build. The file is gitignored, so it's never committed. When you're done (Step 6), run `make dev-unlink-worktree` to remove the pin.
+This writes a `.myco/runtime.command` file that pins this worktree to the freshly-built in-repo binary (not via the shared `~/.local/bin/myco-dev` wrapper script). All hooks, MCP calls, and CLI invocations in this worktree then dispatch to the worktree build. The file is gitignored, so it's never committed. When you're done (Step 6), run `make dev-unlink-worktree` to remove the pin.
 
 Skip this step ONLY when you deliberately want the worktree to fall back to the global binary.
 
@@ -224,7 +224,9 @@ The single squashed commit becomes the PR commit.
 
 - **Build artifact scope collision** — multiple worktrees can overwrite each other's build outputs. Ensure build directories are worktree-scoped or use unique naming.
 
-- **Never run `make dev-link` from a worktree directory** — `make dev-link` sets the machine-wide dev symlink at `~/.local/bin/myco-dev`; running it from inside a worktree routes the global daemon through the worktree binary, breaking isolation for all other sessions. Always run `make dev-link` from the root repo checkout. Use `make dev-link-worktree` (inside the worktree) to pin only that worktree's binary.
+- **Never run `make dev-link` from a worktree directory** — `make dev-link` copies the built binary to `~/.myco-dev/bin/myco` and writes a wrapper script at `~/.local/bin/myco-dev`; running it from inside a worktree routes the global daemon through the worktree binary, breaking isolation for all other sessions. Always run `make dev-link` from the root repo checkout. Use `make dev-link-worktree` (inside the worktree) to pin only that worktree's binary.
+
+- **`make build` alone does NOT update the standalone dev daemon** — since v1.2.0, the dev daemon runs via a copied standalone binary at `~/.myco-dev/bin/myco` (not a symlink to the repo build). Running `make build` only refreshes the in-repo build output. To propagate changes to the main dev daemon, run `make dev-link` + daemon restart. Exception: worktrees using `make dev-link-worktree` point directly to the in-repo build, so `make build` + restart is sufficient there.
 
 ### CLI and Configuration Compatibility
 

--- a/.agents/skills/native-binary-distribution/SKILL.md
+++ b/.agents/skills/native-binary-distribution/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: myco:native-binary-distribution
+description: |
+  Apply this skill when working on native binary installation, upgrade pipelines,
+  daemon binary path management, or dev/prod daemon coexistence for the Myco
+  native installer (1.2.0+). Covers: the steady-state binary path model
+  (~/.myco/bin/myco after plist self-heal), the looksLikeDevBuildExecutable()
+  service-mutation guard, managedBinaryPath() usage, the MYCO_HOME physical
+  boundary model (prod ~/.myco vs dogfood ~/.myco-dev) that replaced the
+  deprecated detectDevBuild() pattern, upgrade-path validation (confirm plist
+  self-heal before testing), beta rollout sequencing for install-path changes,
+  and the self-propagation trap requiring GA-gating any upgrade-path fix. Use
+  this skill whenever code touches binary paths, service install/uninstall,
+  upgrade exemption, plist config, or daemon coexistence.
+managed_by: myco
+user-invocable: true
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+# Native Binary Distribution and Installer Pipeline
+
+Myco's 1.2.0+ native installer places the daemon binary at a managed stable slot
+(`~/.myco/bin/myco`) via plist self-healing, distinct from the npm global prefix
+(`/opt/homebrew/...`). This creates a two-path world that every piece of upgrade,
+coexistence, and service-mutation guard must understand. Getting the boundary wrong
+silently breaks service install, upgrade paths, or coexistence for every real user.
+
+## Prerequisites
+
+Understand the two production binary locations:
+
+1. **npm-package path (transient)** — e.g., `/opt/homebrew/lib/node_modules/myco-darwin-arm64/bin/myco`.
+   Present immediately after `npm install -g`. Falls *under* the npm global prefix.
+2. **Managed stable slot (steady state)** — `~/.myco/bin/myco`. Reached after the launchd
+   plist self-heals post-install. This is where every real user's daemon runs permanently.
+
+Key source files:
+- `packages/myco/src/install/managed-binary.ts` — `managedBinaryPath()` (production slot)
+- `packages/myco/src/service/spec-builder.ts` — `looksLikeDevBuildExecutable()`, `buildServiceSpec()`
+- `packages/myco/src/cli/service.ts` — `assertSafeServiceMutation()`, `resolveServiceExecutable()`
+- `packages/myco/src/daemon/update-checker.ts` — `resolveMycoBinary()`, `releaseChannelIsManual()`
+
+Quick diagnostic — check upgrade status on a running daemon:
+```bash
+curl -s http://localhost:<port>/api/upgrade/status | jq '{update_available, channel, channel_scope, running_version}'
+```
+
+## Procedure A: Understanding the Steady-State Path Model
+
+After a native install, the daemon moves through two phases before reaching steady state.
+
+**Phase 1 — Fresh install (transient).** The daemon runs from the npm-package path, e.g.,
+`/opt/homebrew/.../myco-darwin-arm64/bin/myco`. This falls under the npm global prefix.
+
+**Phase 2 — Steady state (permanent).** The launchd plist self-heals to point at
+`~/.myco/bin/myco` (the `managedBinaryPath()`). Every real user reaches this state after
+first install. Any code that assumes "production = npm prefix only" breaks at steady state.
+
+### The Managed Binary Path API
+
+Always obtain the production binary location via `managedBinaryPath()`:
+
+```ts
+// packages/myco/src/install/managed-binary.ts
+import { managedBinaryPath } from '../install/managed-binary.js';
+const dest = managedBinaryPath(mycoHome, platform, process.env.LOCALAPPDATA);
+// → ~/.myco/bin/myco (macOS/Linux), %APPDATA%\myco\bin\myco.exe (Windows)
+```
+
+`managedBinaryPath()` is the authoritative source for the production binary path.
+Never hardcode `~/.myco/bin/myco` as a literal — use this function.
+
+### The Upgrade API Response Shape
+
+Current `/api/upgrade/status` response fields (note: `update_exempt` was removed in 1.2.0):
+
+```json
+{
+  "update_available": false,
+  "revert_available": false,
+  "running_version": "1.2.0",
+  "latest_version": "1.2.0",
+  "channel": "stable",
+  "channel_scope": "machine",
+  "runtime_scope": "machine",
+  "check_interval_hours": 6,
+  "last_check": "2026-06-01T12:00:00.000Z",
+  "packages": [...]
+}
+```
+
+If `update_available` is unexpectedly `false` when a newer build is published, check:
+1. Is `channel` set to `manual`? Manual channel suppresses auto-check.
+   (`releaseChannelIsManual()` reads `daemon.update_channel` from machine config.)
+2. Is `last_check` stale? The check interval may not have elapsed.
+3. Is the daemon actually running from `~/.myco/bin/myco` (confirm plist self-heal)?
+
+## Procedure B: Dev/Prod Boundary — `looksLikeDevBuildExecutable()` and `MYCO_HOME`
+
+The production/dev distinction is enforced at two levels: the **binary path pattern**
+and the **MYCO_HOME boundary**. These replaced the deprecated `detectDevBuild()` function
+(which existed in 1.2.0-beta.5/6 era and misclassified the managed stable slot as a dev
+build, blocking all upgrade surfaces simultaneously — see architectural note below).
+
+### Current Dev-Build Detection: `looksLikeDevBuildExecutable()`
+
+Located in `packages/myco/src/service/spec-builder.ts`:
+
+```ts
+export function looksLikeDevBuildExecutable(executable: string): boolean {
+  const platformPkgPattern = /\/packages\/myco-(?:darwin-arm64|darwin-x64|linux-x64|linux-arm64|windows-x64)\/bin\//;
+  const legacyVendorPattern = /\/packages\/[^/]+\/vendor\//;
+  return platformPkgPattern.test(executable) || legacyVendorPattern.test(executable);
+}
+```
+
+A dev-build binary has a path containing `/packages/myco-<arch>/bin/` or `/packages/<pkg>/vendor/`.
+The npm global install always has `node_modules/` in the path and never matches these patterns.
+The managed stable slot (`~/.myco/bin/myco`) also never matches — it is correctly treated as production.
+
+**This function guards service mutations only** — it prevents a dev binary from installing
+itself as the prod daemon's launchd plist. It is NOT used for upgrade exemption.
+
+### The Service Mutation Fence: `assertSafeServiceMutation()`
+
+Located in `packages/myco/src/cli/service.ts`:
+
+```ts
+export function assertSafeServiceMutation(
+  parsed: ParsedServiceArgs,
+  execPath: string,
+  mycoHome: string = resolveMycoHome(),
+): string | null {
+  const mutating = new Set(['install', 'uninstall', 'start', 'stop', 'restart', 'reconcile']);
+  if (!isDefaultMycoHome(mycoHome)) return null;           // non-default home = ok
+  if (!mutating.has(parsed.action)) return null;           // status = ok
+  if (!looksLikeDevBuildExecutable(execPath)) return null; // prod binary = ok
+  return `Refusing to ${parsed.action} ...`;               // dev binary + default home = blocked
+}
+```
+
+This is the CLI boundary. `buildServiceSpec()` enforces the same check at the spec level,
+checking both the literal path and its `realpathSync` target to prevent symlink bypass.
+
+### The Primary Boundary: `MYCO_HOME`
+
+Coexistence of prod and dev daemons is achieved via separate home directories:
+- **Prod daemon**: `MYCO_HOME=~/.myco` (the default home every released user has)
+- **Dev/dogfood daemon**: `MYCO_HOME=~/.myco-dev` (a separate home set in the dev plist)
+
+When `MYCO_HOME` is not the default (`isDefaultMycoHome()` returns `false`), the dev daemon
+can freely manage its own service without triggering the mutation fence. All grove data,
+service config, and upgrade state are isolated by `MYCO_HOME`.
+
+### Architectural Note: Why `detectDevBuild()` Was Removed
+
+The deprecated `detectDevBuild()` function classified binaries by checking if `process.execPath`
+fell under the npm global prefix. Once the plist self-heals to `~/.myco/bin/myco`, that path
+is NOT under the npm prefix, so `detectDevBuild()` returned `true` (dev build) for every
+production native install at steady state. This simultaneously blocked all five upgrade
+surfaces (`/api/upgrade/check`, `/api/upgrade/apply`, auto-adopt job, `myco upgrade` CLI,
+and status). The fix replaced path-based runtime classification with the `MYCO_HOME` boundary
+model and moved dev-binary detection to service-install time via `looksLikeDevBuildExecutable()`.
+
+### Checklist: When Adding a New Binary Location
+
+1. Verify `managedBinaryPath()` returns the new path — update it if a new platform is added.
+2. Verify `looksLikeDevBuildExecutable()` does NOT match the new path (update regex if needed).
+3. Verify `buildServiceSpec()` does not reject the new path.
+4. Run a full upgrade cycle from **steady state** (plist self-heal confirmed) — see Procedure C.
+
+## Procedure C: Upgrade-Path Validation Protocol
+
+Before any GA release, validate the upgrade path from **steady state**. Fresh-install
+tests give false confidence because the daemon is still at the npm path.
+
+### Why Fresh-Install Tests Miss Path Bugs
+
+Immediately after `npm install -g`, the daemon runs from
+`/opt/homebrew/.../myco-darwin-arm64/bin/myco`. Only after plist self-heal moves
+it to `~/.myco/bin/myco` does any managed-path-specific bug appear.
+
+> **Rule:** upgrade tests MUST be run after confirming plist self-heal, not immediately
+> after `npm install -g`. This is how the 1.2.0-beta.5 GA blocker was caught.
+
+### Validation Steps
+
+1. Install the target build: `npm install -g myco-darwin-arm64@<version>` + daemon restart.
+2. Confirm plist self-heal: verify the launchd plist `Program` points at `~/.myco/bin/myco`.
+   ```bash
+   cat ~/Library/LaunchAgents/com.myco.daemon.plist | grep Program
+   # Should show: <string>/Users/<user>/.myco/bin/myco</string>
+   ```
+3. Check upgrade status from steady state:
+   ```bash
+   curl -s http://localhost:<port>/api/upgrade/status | jq '{update_available, channel, running_version}'
+   ```
+4. Publish a newer build. Confirm `update_available: true` appears within one check cycle.
+5. Test auto-adopt: wait for the idle job to fire and apply the update.
+6. Test manual upgrade: call `/api/upgrade/apply` or `myco upgrade` from CLI.
+7. Test revert → re-upgrade: downgrade to a prior version, confirm upgrade works again from steady state.
+
+### Zero-Migration Check
+
+For minor version upgrades (e.g., 1.1.2 → 1.2.0), verify that restarting the daemon
+produces zero pending migrations — the install path change should not trigger schema drift.
+
+## Procedure D: Beta Rollout Sequencing for Upgrade-Path Fixes
+
+When the bug being fixed is in the upgrade path itself, auto-adopt cannot deliver the fix.
+The mechanism that would deliver the patch is disabled by the bug being patched.
+
+### The Self-Propagation Trap
+
+A daemon running with a broken upgrade path is effectively frozen — it cannot auto-adopt
+the build containing the fix.
+
+```
+daemon (broken upgrade path) → cannot auto-adopt the fix build
+                             → requires manual installer hop to fixed build
+                             → after manual hop, auto-adopt works again
+```
+
+There is no self-healing path for users already on the broken build.
+
+### Required Build Sequencing
+
+| Build    | Role                                                                          |
+|----------|-------------------------------------------------------------------------------|
+| beta.N   | First native-install test; bug surfaced in plist-self-heal steady state       |
+| beta.N+1 | Adopt target (published, waiting); remains blocked by the upgrade-path bug    |
+| beta.N+2 | Fix build — requires **manual installer hop** to reach from earlier betas    |
+| beta.N+3 | **Actual auto-adopt test target** — must be cut *after* fix build lands      |
+
+Why not reuse beta.N+1 as the adopt target after the fix lands? Because the fix build
+(N+2) has a higher version number than the original adopt target (N+1) — it cannot
+be adopted "down" to N+1. Cut a fresh build after the fix ships.
+
+### GA Gate Requirement
+
+Any fix to the upgrade path or dev-build boundary is a **hard merge blocker** for the
+GA release it targets. If GA ships without the fix:
+- Every native install reaches steady state (plist self-heals to `~/.myco/bin/myco`)
+- Users become permanently unable to auto-adopt any newer build
+- Recovery requires another manual reinstall
+
+> "Good that the dogfood test caught it in beta." — this class of bug is invisible in
+> CI and only surfaces in steady-state native installs.
+
+## Procedure E: Dev/Prod Daemon Coexistence via `MYCO_HOME` and `MYCO_CLAIMS_HOME`
+
+### Why `MYCO_HOME` Is the Correct Coexistence Mechanism
+
+The `MYCO_HOME` boundary makes each daemon instance self-describing via environment,
+not installation path. The dev daemon sets `MYCO_HOME=~/.myco-dev` in its launchd plist.
+All service management, grove binding, and upgrade state derives from this value.
+No binary needs to inspect its own path to determine which kind of daemon it is.
+
+### `MYCO_CLAIMS_HOME` for Subsystem Claims Sharing
+
+When `MYCO_HOME` is not the canonical home, `buildServiceSpec()` automatically injects
+`MYCO_CLAIMS_HOME` pointing at the canonical home into the plist environment
+(`packages/myco/src/service/spec-builder.ts`):
+
+```ts
+// When MYCO_HOME is not the canonical home, point subsystem claims at the
+// canonical home so prod and dogfood share one area.
+if (!isDefaultHome) {
+  env.MYCO_CLAIMS_HOME = resolveMycoHome({ env: {} });
+}
+```
+
+The dev daemon at `~/.myco-dev` reads `MYCO_CLAIMS_HOME` (in
+`packages/myco/src/grove/subsystem-claim.ts`) to redirect its subsystem registrations
+to the canonical home — so prod and dogfood share one global symbiont state area without
+collision. This is set automatically by `buildServiceSpec()`; you do not need to write
+it into the dev plist manually.
+
+### Four Consumers of Daemon Identity
+
+| Consumer               | Current mechanism                                           |
+|------------------------|-------------------------------------------------------------|
+| Service-dir routing    | Derived from `MYCO_HOME` (default → prod, else dev)        |
+| Port assignment        | Derived from `MYCO_HOME` / service-dir                     |
+| Grove binding          | `MYCO_HOME`                                                 |
+| Subsystem claims       | `MYCO_CLAIMS_HOME` (auto-set by `buildServiceSpec()`)      |
+| Service mutation guard | `looksLikeDevBuildExecutable` + `isDefaultMycoHome`        |
+
+Upgrade exemption is NOT a consumer — it is only suppressed by `channel: manual`.
+A dev daemon in `~/.myco-dev` runs its own upgrade pipeline without exemption.
+
+### Migration Steps When Adding a New Daemon Instance Type
+
+1. Add `MYCO_HOME=<new-home>` to the daemon's plist environment.
+2. Verify `isDefaultMycoHome(newHome)` returns `false` — so `assertSafeServiceMutation`
+   does not block the new instance from managing its own home.
+3. `MYCO_CLAIMS_HOME` is set automatically by `buildServiceSpec()` when the home is
+   non-default. Confirm the new instance builds its plist via `buildServiceSpec()`
+   rather than constructing the env manually.
+4. Do NOT add path-based detection to upgrade or exemption logic.
+
+## Cross-Cutting Gotchas
+
+**The upgrade API has no `update_exempt` field.**
+That field existed in 1.2.0-beta.5/6 era and was removed when `detectDevBuild()` was
+eliminated. Stale docs or tests referencing `update_exempt` are incorrect. Current API
+fields: `update_available`, `revert_available`, `channel`, `channel_scope`, `runtime_scope`.
+
+**Manual channel is the only remaining upgrade suppression mechanism.**
+`releaseChannelIsManual()` in `update-checker.ts` checks `daemon.update_channel === 'manual'`.
+This is the only way upgrades are suppressed now (aside from being current). Dev daemons
+in `~/.myco-dev` are not exempt — they upgrade normally.
+
+**Steady-state testing cannot be skipped.**
+A passing upgrade test immediately after `npm install -g` (daemon still at npm path) gives
+false confidence. The plist self-heal must complete and the daemon must be at `~/.myco/bin/myco`
+before upgrade tests are meaningful.
+
+**Every new binary distribution path requires a `looksLikeDevBuildExecutable()` audit.**
+The function uses regex path matching. A new install path that accidentally matches
+`/packages/myco-<arch>/bin/` would be misclassified as a dev build and blocked from
+managing the prod service. Audit the function whenever a new binary path is introduced.
+
+**The channel setting is machine-scoped, not per-project.**
+`writeProjectReleaseChannel` is a misleading function name — it writes `daemon.update_channel`,
+a machine-level setting (`{ home: 'machine', overridableBy: [] }` in config scope). One managed
+binary at `~/.myco/bin/myco` per `MYCO_HOME`. The channel is not per-grove.
+
+**UI: upgrade and channel toggle live on Settings, not Operations.**
+The `<UpgradeCard/>` and the Stable/Beta channel toggle are on the **Settings page**
+(`/settings` → Upgrade section). The Operations page hosts only database/file health
+for the grove's SQLite store. When writing docs, reference "Settings page → Upgrade section."

--- a/.agents/skills/upgrade-path-safety/SKILL.md
+++ b/.agents/skills/upgrade-path-safety/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: myco:upgrade-path-safety
+description: |
+  Apply this skill when validating, testing, or releasing any version-to-version
+  upgrade — even if the user doesn't explicitly ask about upgrade safety. Covers
+  five orthogonal procedures: (1) clean-state revert methodology before upgrade
+  testing to simulate real-world conditions; (2) CI-as-primary-gate discipline
+  when local tests are flaky or environment-contaminated; (3) merge→publish→test
+  release sequencing to avoid blocking on local reliability; (4) detecting and
+  handling the self-propagation trap, where a bug disables the auto-adopt
+  mechanism that would deliver its own fix; (5) dev environment routing via
+  pattern extension (runtime.command + runtime.home + manual channel) instead
+  of bespoke knobs.
+managed_by: myco
+user-invocable: true
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+# Upgrade Path Safety Profile
+
+This skill governs the discipline around validating and releasing version-to-version
+upgrades in the Myco native installer (e.g., v1.1.2 → v1.2.0). The procedures were
+established under real conditions during the `feat/native-installer` branch and apply
+to any upgrade cycle involving binary replacement, installer mechanics, or auto-adopt
+channels.
+
+Use this skill whenever you are: testing an upgrade path, cutting a release beta,
+debugging auto-adopt failures, or designing dev environment routing for dual-daemon
+setups.
+
+## Prerequisites
+
+Before any upgrade-path work:
+
+- Know the **source version** (prior release) users will be upgrading from.
+- Know the **target channel** (`beta`, `stable`, or `manual`) for the upgrade.
+- Have a clean machine state available — or be prepared to revert to one. A
+  development state with partial changes applied is **not** a valid starting point
+  for upgrade testing.
+- CI must be available and healthy. If CI is down, all validation gates collapse.
+
+## Procedure A: Clean-State Revert Before Upgrade Testing
+
+**Why:** Testing an upgrade from a mid-development state doesn't simulate real user
+conditions. Only a clean install of the prior release exercises the actual code path
+users will hit.
+
+**Steps:**
+
+1. **Fully revert** to a clean install of the prior release — uninstall the current
+   binary, clear `MYCO_HOME`, and reinstall as if you were a fresh user:
+   ```bash
+   # Remove current install
+   rm -rf ~/.myco/bin/myco
+   # Reinstall prior release (e.g., 1.1.2) from the release artifact
+   ```
+2. **Set the channel** to match the target in `~/.myco/config.yaml`:
+   ```yaml
+   daemon:
+     update_channel: beta   # or stable
+   ```
+3. **Run the upgrade** from that clean state — do not shortcut by applying dev
+   changes before running the upgrade command.
+
+**Rationale:** "That is our best way to test this as it would be in the wild."
+(session 7bf0bb2d, batch 9620). Testing from an in-dev state introduces artefacts —
+leftover processes, partial file states, contaminated `MYCO_HOME` — that real users
+never have.
+
+**Gotcha — launchd KeepAlive:** After a revert, `launchd` may hold port 20915
+because the old plist has `KeepAlive: true`. This is an environment hygiene issue,
+not a code bug. Check `launchctl list | grep myco` and unload the old plist before
+declaring the revert complete.
+
+## Procedure B: CI as Primary Validation Gate
+
+**Why:** When local tests are flaky during upgrade-path work, CI on a clean machine
+is a better proxy for real-user behavior than your contaminated local environment.
+Local flakiness reflects environment state, not code bugs.
+
+**Steps:**
+
+1. **Diagnose why local tests are unreliable.** Common causes during upgrade work:
+   - Dev daemon over-capturing prompts (test output contaminated by side-effects)
+   - Repeated revert/upgrade cycles leaving stale process state
+   - `launchd` holding ports or keeping the prior binary alive
+2. **Push to CI rather than blocking** — open the PR and let CI run on a clean
+   environment. Do not wait to fix local infrastructure first.
+3. **Treat CI green as the merge gate**, not local green.
+4. **Log the local reliability issue** as a follow-up, not a blocker.
+
+**Rationale:** "The real goal is to get the upgrade from 1.1.2 to 1.2.0 working
+correctly. If the tests can't run locally reliably, that is an issue we have to
+solve, but that is secondary." (session 7bf0bb2d, batch 9674).
+
+**Caveat:** This is about sequencing, not abandonment. Local test reliability still
+needs a follow-up — it signals real environment hygiene issues (e.g., launchd
+KeepAlive holding ports across reverts). The prioritization is: fix the upgrade path
+first, then stabilize the local test harness.
+
+## Procedure C: Release Sequencing — Merge → Publish → Test
+
+**Why:** Blocking a merge on local test reliability inverts the priority. The shipped
+artifact's behavior on a clean machine is what matters, and you can't test that until
+you publish.
+
+**Correct sequence:**
+
+1. **Merge the PR** — CI green is the authoritative gate (see Procedure B).
+2. **Cut and publish the beta** — make the artifact available on the target channel.
+3. **Test locally once it lands** — verify against the published artifact using a
+   clean-state revert (see Procedure A), not against the dev build.
+
+**Anti-pattern — do not do this:**
+- Block the merge waiting for local tests to pass when CI is green
+- Test the upgrade path against your in-dev binary before publishing
+- Conflate "local test green" with "upgrade path correct"
+
+**Example outcome (beta.4, v1.1.2→v1.2.0):** After merge and publish, testing
+against the published artifact confirmed end-to-end: convergence layout correct,
+`.myco/.myco` absent, `MYCO_HOME` honored, `~/.myco/bin/myco` byte-identical
+before/after upgrade.
+
+## Procedure D: Self-Propagation Trap — Manual Bootstrap for Bug Fixes
+
+**Why:** Some bugs disable the very mechanism that would deliver their own fix. When
+a daemon is incorrectly marked as `update_exempt` (e.g., due to a dev-build
+detection bug), that daemon cannot auto-adopt the fix — the channel the fix travels
+through is the one the bug broke.
+
+**Detection checklist — you have a self-propagation trap if:**
+- [ ] The bug affects auto-adopt, auto-check, or `update_channel` evaluation
+- [ ] The fix ships via the same channel the bug disables
+- [ ] Users are already running a version with the bug installed
+
+**Handling steps:**
+
+1. **Identify the affected version range** — e.g., beta.5 and beta.6 users are stuck.
+2. **Publish a fix build** (e.g., beta.7) containing the repair.
+3. **Require a manual installer hop** — affected users must manually run the
+   installer to reach the fix build. There is no self-healing path.
+4. **Cut a new adopt-target beta after the fix** — because the fix build (beta.7) is
+   now the highest-numbered beta, you must publish a new beta (e.g., beta.8) as the
+   auto-adopt target. Users on beta.7 will then auto-adopt beta.8 normally.
+5. **Confirm dev-build detection re-evaluates** — a version bump to the fix build
+   changes the version key used for dev-build detection, so any previously cached
+   stale verdict is invalidated on first run. No manual cache clear is needed in
+   the field.
+
+**Beta rollout sequencing example (dev-build detection fix):**
+```
+beta.5/beta.6  → affected (update_exempt bug present; cannot self-upgrade)
+beta.7         → fix build (requires manual installer hop from beta.5/beta.6)
+beta.8         → new auto-adopt target (cut after beta.7 lands; normal auto-adopt resumes)
+```
+
+**GA gate rule:** Any bug that creates a self-propagation trap **must** be fixed
+before GA. A GA release with this bug means every native install reaches steady state
+(`launchd` plist self-heals → daemon at `~/.myco/bin/myco`) and becomes permanently
+unable to self-upgrade. The only recovery is a full manual reinstall.
+
+> "Good that the dogfood test caught it in beta."
+
+## Procedure E: Dev Environment Routing via Pattern Extension
+
+**Why:** Bespoke machine-specific knobs (e.g., a `MYCO_DEV_HOME` env var that only
+exists on the dogfood machine) cause churn, break dogfooding, and codify something
+that can never ship to users. Instead, extend the two general-purpose mechanisms
+already in place.
+
+### Mechanism 1: Two-file pin — `runtime.command` + `runtime.home`
+
+`make dev-link` writes two companion files in `<repo>/.myco/`:
+
+```
+# <repo>/.myco/runtime.command  (binary path — one line, absolute)
+~/.local/bin/myco-dev
+
+# <repo>/.myco/runtime.home  (MYCO_HOME companion — one line, absolute)
+~/.myco-dev
+```
+
+`myco-run.cjs` (the hook/MCP launcher shim) reads `runtime.command` for the binary
+and `runtime.home` beside it for the MYCO_HOME override. Together they route all
+in-repo launchers to both the dev binary **and** the dev home in a single
+`make dev-link` invocation. The home (`~/.myco-dev`) determines `bin/`, `groves/`,
+`service/`, and the daemon port.
+
+The `myco-dev` wrapper at `~/.local/bin/myco-dev` sets `MYCO_HOME=~/.myco-dev` and
+`MYCO_CLAIMS_HOME=~/.myco` before executing `~/.myco-dev/bin/myco`. This is what
+`runtime.command` points to.
+
+### Mechanism 2: `manual` channel in `~/.myco-dev/config.yaml`
+
+The `daemon.update_channel` enum extends from `stable | beta` to
+`stable | beta | manual`. `manual` means: never auto-check or auto-adopt; explicit
+`myco upgrade` still works.
+
+```yaml
+# ~/.myco-dev/config.yaml
+daemon:
+  update_channel: manual
+```
+
+`make dev-link` writes this value (only if the file doesn't exist, to preserve
+contributor edits) so the dev daemon never self-upgrades and never interferes with
+upgrade-path testing cycles.
+
+**Why `manual` is a real product feature, not a hack:** It's designed as a
+"pin my version" option for users who don't want automatic updates. Shipping it as a
+general feature means it's testable, maintainable, and beneficial to real users —
+not invisible debt on the dogfood machine.
+
+**Anti-pattern:**
+```
+# Don't do this — bespoke knob that can never ship
+if os.Getenv("MYCO_DEV_HOME") != "" {
+    homeDir = os.Getenv("MYCO_DEV_HOME")
+}
+```
+
+This pattern "makes it near impossible to dogfood what should be a straightforward
+thing" because you can't reproduce it on any machine that doesn't have the magic env
+var set.
+
+## Cross-Cutting Gotchas
+
+- **Dev build ≠ published artifact for upgrade testing.** These are different test
+  subjects. The dev binary may have side-effects (over-capture, partial states) the
+  published artifact doesn't. Final upgrade validation must always be against the
+  published artifact (Procedures A + C together).
+
+- **Version ordering is numeric.** Beta version numbers compare numerically, not
+  lexicographically. If the fix lands in beta.7, you cannot re-use beta.6 as the
+  auto-adopt target — you must cut beta.8 (Procedure D, step 4).
+
+- **Use `MYCO_HOME` isolation, not `MYCO_SERVICE_VARIANT`.** The current architecture
+  isolates dev and prod via separate home directories (`~/.myco` for prod,
+  `~/.myco-dev` for dev). `MYCO_SERVICE_VARIANT` was removed — AGENTS.md explicitly
+  states "There is no `MYCO_SERVICE_VARIANT`". Do not add code that branches on
+  that variable; use `MYCO_HOME` scoping instead.
+
+- **Revert completeness check.** A "clean revert" is not complete until: old binary
+  is removed, `MYCO_HOME` is in expected initial state, and the launchd plist for
+  the old version is unloaded. Missing any of these leaves ghost state that
+  contaminates the upgrade test.
+
+- **CI environment is authoritative for upgrade path, not local.** This is a design
+  principle, not a workaround. Upgrade-path correctness is defined by behavior on a
+  clean machine — exactly what CI provides.
+
+- **Beta-tag deletion downgrade trap.** The beta channel resolves to
+  `max(latest_stable, latest_prerelease)` — both the curl installer (`docs/install.sh`)
+  and the daemon's channel resolution use this logic. Deleting pre-release tags
+  BEFORE the GA stable tag exists causes every beta-channel user to downgrade to the
+  previous stable version. Always verify that `myco/v<GA>` is published and resolving
+  correctly on the beta channel before removing any pre-release tags or GitHub releases.

--- a/packages/myco/src/cli/service.ts
+++ b/packages/myco/src/cli/service.ts
@@ -5,17 +5,17 @@ import { buildServiceSpec, looksLikeDevBuildExecutable } from '../service/spec-b
 import { serviceLabel } from '../service/labels.js';
 import { isDefaultMycoHome, resolveMycoHome, resolveServiceDir, DAEMON_STATE_FILENAME } from '../grove/paths.js';
 
-export type ServiceAction = 'install' | 'uninstall' | 'start' | 'stop' | 'restart' | 'status';
+export type ServiceAction = 'install' | 'uninstall' | 'start' | 'stop' | 'restart' | 'status' | 'reconcile';
 
 export interface ParsedServiceArgs {
   action: ServiceAction;
 }
 
-const ACTIONS: ServiceAction[] = ['install', 'uninstall', 'start', 'stop', 'restart', 'status'];
+const ACTIONS: ServiceAction[] = ['install', 'uninstall', 'start', 'stop', 'restart', 'status', 'reconcile'];
 
 export function parseServiceArgs(args: string[]): ParsedServiceArgs {
   if (args.length === 0) {
-    throw new Error('Usage: myco service <install|uninstall|start|stop|restart|status>');
+    throw new Error('Usage: myco service <install|uninstall|start|stop|restart|status|reconcile>');
   }
   const action = args[0] as ServiceAction;
   if (!ACTIONS.includes(action)) {
@@ -76,7 +76,7 @@ export function assertSafeServiceMutation(
   execPath: string,
   mycoHome: string = resolveMycoHome(),
 ): string | null {
-  const mutating: ReadonlySet<ServiceAction> = new Set(['install', 'uninstall', 'start', 'stop', 'restart']);
+  const mutating: ReadonlySet<ServiceAction> = new Set(['install', 'uninstall', 'start', 'stop', 'restart', 'reconcile']);
   if (!isDefaultMycoHome(mycoHome)) return null;
   if (!mutating.has(parsed.action)) return null;
   if (!looksLikeDevBuildExecutable(execPath)) return null;
@@ -135,5 +135,57 @@ export async function run(args: string[]): Promise<void> {
       console.log(JSON.stringify({ label, platform: mgr.platformName, ...st }, null, 2));
       return;
     }
+    case 'reconcile': {
+      await reconcile(mgr, mycoHome, label);
+      return;
+    }
   }
+}
+
+/**
+ * Re-establish exactly ONE supervisor-tracked daemon for this home, healing a
+ * detached/looping state: a daemon that direct-spawned (detached from its
+ * launchd job) keeps the lock and serves while the job hot-loops, respawning
+ * step-aside daemons.
+ *
+ * Safe BECAUSE it runs from the CLI (a separate process), so the cooperative
+ * shutdown + bootout/bootstrap never targets the caller's own process:
+ *   1. Cooperative-shutdown whatever currently holds the port (the detached
+ *      usurper) so it drains and releases the lifecycle lock.
+ *   2. install(force) re-bootstraps the on-disk (corrected) plist — the loaded
+ *      policy becomes current AND a single tracked daemon comes up under it.
+ *   3. start ensures it is running; it claims the now-free lock and serves.
+ *
+ * Exported so the daemon's autonomous detached-state detection and `myco doctor`
+ * can drive the same heal.
+ */
+export async function reconcile(
+  mgr: ReturnType<typeof getServiceManager>,
+  mycoHome: string,
+  label: string,
+): Promise<void> {
+  const { findInstalledServiceLabel } = await import('../daemon/api/restart.js');
+  const found = await findInstalledServiceLabel(mgr, mycoHome);
+  if (!found) {
+    console.log(`No managed service installed for ${label}; nothing to reconcile.`);
+    return;
+  }
+
+  const { resolveGlobalDaemonPort } = await import('../daemon/service-state.js');
+  const { requestCooperativeShutdown } = await import('../service/cooperative-shutdown.js');
+  const port = resolveGlobalDaemonPort(mycoHome);
+  const stopped = await requestCooperativeShutdown(port);
+  if (!stopped) {
+    // The serving daemon did not drain in time. Re-bootstrap still installs the
+    // correct policy + a tracked daemon, but if a wedged daemon keeps the lock
+    // the fresh one will step aside — surface that rather than claim success.
+    console.warn(
+      `Warning: daemon on port ${port} did not confirm shutdown; if it is wedged, kill it manually and re-run.`,
+    );
+  }
+
+  const spec = buildServiceSpec({ mycoHome, executable: resolveServiceExecutable(mycoHome) });
+  await mgr.install(spec, { force: true });
+  await mgr.start(label);
+  console.log(`Reconciled ${label}: one ${mgr.platformName}-tracked daemon.`);
 }

--- a/packages/myco/src/cli/upgrade.ts
+++ b/packages/myco/src/cli/upgrade.ts
@@ -249,10 +249,13 @@ export async function run(args: string[], deps: UpgradeDeps = {}): Promise<void>
   const projectRoot = deps.projectRoot ?? process.cwd();
   const daemonPort = deps.daemonPort ?? resolveGlobalDaemonPort();
 
-  // Resolve service-managed label at adopt time.
+  // Resolve the restart-routing label at adopt time, keyed on the installed
+  // unit (not pid-identity): the CLI never shares the daemon's pid, so a
+  // pid-match would always miss and force an unsupervised direct spawn even on
+  // a service-managed machine.
   const { getServiceManager } = await import('../service/manager.js');
-  const { detectServiceManagedLabel } = await import('../daemon/api/restart.js');
-  const serviceManagedLabel = await detectServiceManagedLabel(getServiceManager());
+  const { resolveRestartServiceLabel } = await import('../daemon/api/restart.js');
+  const serviceManagedLabel = await resolveRestartServiceLabel(getServiceManager());
 
   const adoptOpts: InitiateAdoptOpts = {
     source: 'cli',

--- a/packages/myco/src/constants/log-kinds.ts
+++ b/packages/myco/src/constants/log-kinds.ts
@@ -134,6 +134,13 @@ export const LOG_KINDS = {
   TEAM_SYNC_ERROR: 'team-sync.error',
   TEAM_SYNC_REJECTED: 'team-sync.rejected',
 
+  // Self-update / adopt orchestration. Emitted by the DETACHED orchestrator
+  // process into a side-channel, then replayed into log_entries by the daemon
+  // on its next startup (it cannot write the grove DB itself — it is restarting
+  // the daemon that owns it). One kind keeps the adopt sequence filterable; the
+  // message/metadata distinguish start / restart-attempt / health / outcome.
+  UPGRADE_ADOPT: 'upgrade.adopt',
+
   // Release provenance
   RELEASE_PROVENANCE_RECONCILE: 'release-provenance.reconcile',
 

--- a/packages/myco/src/constants/power-jobs.ts
+++ b/packages/myco/src/constants/power-jobs.ts
@@ -50,6 +50,18 @@ export const POWER_JOB_NAMES = {
    * live session). `deep_sleep` doesn't tick, so it is also excluded.
    */
   UPGRADE_ADOPT: 'upgrade-adopt',
+  /**
+   * Detached-daemon self-heal: when this (lock-holding) daemon detects that a
+   * supervisor unit is installed for its home but the supervisor-tracked PID is
+   * NOT us — the detached-usurper signature behind the launchd respawn loop — it
+   * spawns `myco service reconcile`, which cooperatively stops us and
+   * re-bootstraps exactly one supervisor-tracked daemon.
+   *
+   * Idle/sleep only and two-tick latched so a transient status read can't
+   * trigger it; gated on the MYCO_DAEMON_MANAGED marker so a hand-run
+   * `myco daemon` is never auto-reconciled.
+   */
+  SERVICE_RECONCILE: 'service-reconcile',
 } as const;
 
 export type PowerJobName = (typeof POWER_JOB_NAMES)[keyof typeof POWER_JOB_NAMES];

--- a/packages/myco/src/constants/update.ts
+++ b/packages/myco/src/constants/update.ts
@@ -17,6 +17,15 @@ export const UPDATE_CONFIG_PATH = path.join(MYCO_GLOBAL_DIR, 'update.yaml');
 export const UPDATE_ERROR_PATH = path.join(MYCO_GLOBAL_DIR, 'update-error.json');
 
 /**
+ * Append-only event log the DETACHED adopt orchestrator writes (it is
+ * `stdio:'ignore'` and cannot reach the grove DB it is restarting). The daemon
+ * drains it on the next startup and replays each line through the structured
+ * logger (LOG_KINDS.UPGRADE_ADOPT) into `log_entries`, so the self-upgrade
+ * sequence is visible in the log viewer instead of vanishing into /dev/null.
+ */
+export const UPDATE_EVENTS_PATH = path.join(MYCO_GLOBAL_DIR, 'update-events.jsonl');
+
+/**
  * Filename for the machine-scope runtime command pin (lives in `~/.myco/`).
  *
  * Single source of truth for which `myco` binary the launcher shims exec.

--- a/packages/myco/src/daemon/api/restart.ts
+++ b/packages/myco/src/daemon/api/restart.ts
@@ -70,21 +70,30 @@ export async function findInstalledServiceLabel(
   };
 }
 
-/** Probe whether THIS process is the currently-running service-managed daemon.
- *  Returns the label if so, otherwise null.
+/**
+ * Resolve the service label to ROUTE A RESTART THROUGH for a home, or null when
+ * no supervisor owns this home's daemon (the caller then respawns directly).
  *
- *  Exported so other detached-script paths (update-installer post-install
- *  respawn, sibling-version-sync restart) can share a single detection
- *  implementation. Pass `process.pid` from the caller; defaults to it. */
-export async function detectServiceManagedLabel(
+ * Restart routing keys on supervisor INSTALLATION (the plist/unit exists for
+ * `mycoHome`), NOT on pid-identity. A daemon that has DETACHED from its launchd
+ * job — live pid ≠ the supervisor-tracked pid, e.g. after a prior direct-spawn
+ * restart — must still restart via the supervisor's native primitive
+ * (`launchctl kickstart -k` / `systemctl --user restart`) so the supervisor
+ * RE-ADOPTS it. Pid-identity matching returns null in exactly that detached
+ * state, stranding the daemon on a detached direct-spawn that re-detaches on
+ * every restart; keying on the installed unit heals it. It is also the only
+ * correct answer off the daemon process — the CLI never shares the daemon's
+ * pid — so `myco upgrade` from the CLI routes through the supervisor too.
+ *
+ * Exported so every restart path (this handler, version-sync, upgrade/adopt)
+ * shares one resolver and the routing rule lives in exactly one place.
+ */
+export async function resolveRestartServiceLabel(
   mgr: ServiceManager,
-  myPid: number = process.pid,
+  mycoHome: string = resolveMycoHome(),
 ): Promise<string | null> {
-  // Platform-agnostic: the manager owns the "is this me?" decision
-  // (`isManagedDaemon`) — POSIX pid-matches, Windows reads its env marker.
-  const found = await findInstalledServiceLabel(mgr);
-  if (found && mgr.isManagedDaemon(found.label, found.status, myPid)) return found.label;
-  return null;
+  const found = await findInstalledServiceLabel(mgr, mycoHome);
+  return found?.label ?? null;
 }
 
 export async function handleRestart(
@@ -103,7 +112,7 @@ export async function handleRestart(
   }
 
   const mgr = deps.serviceManager ?? getServiceManager();
-  const serviceManagedLabel = await detectServiceManagedLabel(mgr);
+  const serviceManagedLabel = await resolveRestartServiceLabel(mgr);
 
   // Schedule: respond → wait for flush → SIGTERM self → child starts after parent exits.
   // When service-managed, the child calls `myco service restart`, which uses

--- a/packages/myco/src/daemon/api/upgrade.ts
+++ b/packages/myco/src/daemon/api/upgrade.ts
@@ -55,7 +55,7 @@ import {
 } from '../../constants/update.js';
 import type { ReleaseChannel, UpdatePackageId } from '../../constants/update.js';
 import { resolveLastUpdateVersionPath, isDefaultMycoHome } from '../../grove/paths.js';
-import { detectServiceManagedLabel } from './restart.js';
+import { resolveRestartServiceLabel } from './restart.js';
 import { getServiceManager } from '../../service/manager.js';
 import type { ServiceManager } from '../../service/types.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
@@ -412,7 +412,7 @@ export function createUpgradeHandlers(deps: UpgradeDeps) {
         }
         restartInitiated = true;
         const runLocalUpdate = !isStampMatching(installedVersion);
-        const serviceManagedLabel = await detectServiceManagedLabel(serviceManager);
+        const serviceManagedLabel = await resolveRestartServiceLabel(serviceManager);
         spawnRestartScript({
           projectRoot, vaultDir, runLocalUpdate,
           fromVersion: currentVersion,
@@ -713,7 +713,7 @@ export function createUpgradeHandlers(deps: UpgradeDeps) {
       }
     }
 
-    const serviceManagedLabel = await detectServiceManagedLabel(serviceManager);
+    const serviceManagedLabel = await resolveRestartServiceLabel(serviceManager);
     const reportedVersion = mycoTargetVersion ?? status.latest_version;
 
     // Operator CLIs: spawn update script (npm path).

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -170,6 +170,7 @@ import {
   epochSeconds,
 } from '../constants.js';
 import { RESTART_REASON_FILENAME } from '../constants/update.js';
+import { drainUpdateEvents } from '../upgrade/update-events.js';
 import { buildScopedConfigSaveNotification } from '../config/focus.js';
 import { notify } from '../notifications/notify.js';
 import { agentRunNotificationLink } from '../notifications/links.js';
@@ -959,6 +960,17 @@ export async function main(): Promise<void> {
   logger.setPersistFn((entry) => {
     insertLogEntry(logEntryToInsert(entry, daemonLogProjectId));
   });
+
+  // --- Replay adopt-orchestrator events into log_entries ---
+  // The detached adopt orchestrator (stdio:'ignore') cannot write the grove DB
+  // it is restarting, so it appends its restart / health-watch / rollback events
+  // to a side-channel. Drain them here — AFTER persistFn is wired — so the whole
+  // self-upgrade sequence lands in log_entries (and the log viewer) under
+  // `upgrade.adopt`, instead of vanishing into /dev/null. Mirrors the
+  // restart-reason ingestion above.
+  for (const ev of drainUpdateEvents()) {
+    logger.log(ev.level, LOG_KINDS.UPGRADE_ADOPT, ev.message, { ...ev.data, orchestrator_ts: ev.ts });
+  }
 
   // Reconcile log entries missed while daemon was down
   const lastLogTimestamp = getMaxTimestamp();

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -857,8 +857,8 @@ export function registerPowerJobs(runner: JobRunner, deps: PowerJobDeps): PowerJ
       // runs when we actually have a staged version ready to adopt).
       resolveServiceLabel: async () => {
         const { getServiceManager } = await import('../service/manager.js');
-        const { detectServiceManagedLabel } = await import('./api/restart.js');
-        return detectServiceManagedLabel(getServiceManager());
+        const { resolveRestartServiceLabel } = await import('./api/restart.js');
+        return resolveRestartServiceLabel(getServiceManager());
       },
       mycoBinary: upg.mycoBinary ?? resolveMycoBinary(),
       projectRoot: upg.projectRoot,
@@ -871,6 +871,46 @@ export function registerPowerJobs(runner: JobRunner, deps: PowerJobDeps): PowerJ
       fn: buildAdoptJobFn(adoptDeps),
     });
   }
+
+  // service-reconcile: a daemon that direct-spawned (detached from its launchd
+  // job) keeps the lock and serves while the supervisor job hot-loops respawning
+  // step-aside daemons. This job — which only runs INSIDE the lock-holding
+  // daemon — detects that signature and hands off to the supervisor by spawning
+  // `myco service reconcile` (cooperative stop + re-bootstrap of one tracked
+  // daemon). See POWER_JOB_NAMES.SERVICE_RECONCILE.
+  let serviceReconcileLatched = false;
+  runner.register({
+    name: POWER_JOB_NAMES.SERVICE_RECONCILE,
+    runIn: ['idle', 'sleep'],
+    kind: 'housekeeping',
+    fn: async () => {
+      // Only a daemon that believes it is supervisor-managed (marker set in the
+      // unit env, inherited across an orchestrator direct-spawn) is a candidate;
+      // a hand-run `myco daemon` (no marker) is never auto-reconciled.
+      if (!process.env.MYCO_DAEMON_MANAGED?.trim()) { serviceReconcileLatched = false; return; }
+      const { getServiceManager } = await import('../service/manager.js');
+      const mgr = getServiceManager();
+      if (!mgr.supported) { serviceReconcileLatched = false; return; }
+      const { findInstalledServiceLabel } = await import('./api/restart.js');
+      const found = await findInstalledServiceLabel(mgr, mycoHome);
+      // Detached-usurper signature: a unit is installed and running, but the
+      // supervisor-tracked PID is NOT us (we are the live lock-holder). Any other
+      // shape (no unit, not running, or the supervisor already tracks us) is
+      // healthy. Only the clear "running under a different PID" case acts.
+      const detached = !!found && found.status.running
+        && found.status.pid !== null && found.status.pid !== process.pid;
+      if (!detached) { serviceReconcileLatched = false; return; }
+      // Two-tick latch so a single transient launchctl status read can't trigger
+      // a needless self-restart.
+      if (!serviceReconcileLatched) { serviceReconcileLatched = true; return; }
+      serviceReconcileLatched = false;
+      logger.warn(LOG_KINDS.DAEMON_START, 'Detached from supervisor job — spawning `service reconcile`', {
+        tracked_pid: found!.status.pid, my_pid: process.pid, label: found!.label,
+      });
+      const { spawnDetached } = await import('../upgrade/orchestrator.js');
+      spawnDetached(resolveMycoBinary(), ['service', 'reconcile'], mycoHome);
+    },
+  });
 
   const canopy = registerCanopyJobs(runner, {
     logger,

--- a/packages/myco/src/service/launchd-plist.ts
+++ b/packages/myco/src/service/launchd-plist.ts
@@ -32,8 +32,19 @@ export function renderLaunchdPlist(spec: ServiceSpec): string {
     .map(([k, v]) => `    ${tag('key', escapeXml(k))}\n    ${tag('string', escapeXml(v))}`)
     .join('\n');
 
+  // Respawn ONLY on an unsuccessful exit (non-zero code or a signal), matching
+  // systemd's `Restart=on-failure` and the Windows launcher's `errorlevel equ 0
+  // -> stop`. A bare `<true/>` respawns even a deliberate step-aside `exit(0)`,
+  // which hot-loops the job (~1/10s) when a sibling daemon holds the lock. With
+  // `SuccessfulExit=false`, clean exits (step-aside, `daemon kill`, cooperative
+  // shutdown) stay down while real crashes (non-zero) still restart.
   const keepAlive = spec.keepAlive
-    ? `  <key>KeepAlive</key>\n  <true/>\n  <key>ThrottleInterval</key>\n  ${tag('integer', String(spec.throttleSeconds))}\n`
+    ? `  <key>KeepAlive</key>\n`
+      + `  <dict>\n`
+      + `    <key>SuccessfulExit</key>\n`
+      + `    <false/>\n`
+      + `  </dict>\n`
+      + `  <key>ThrottleInterval</key>\n  ${tag('integer', String(spec.throttleSeconds))}\n`
     : '';
 
   const resourceLimits =

--- a/packages/myco/src/service/launchd.ts
+++ b/packages/myco/src/service/launchd.ts
@@ -75,7 +75,19 @@ export class LaunchdServiceManager implements ServiceManager {
 
     let existing: string | null = null;
     try { existing = fs.readFileSync(plistPath, 'utf-8'); } catch { /* ENOENT */ }
+
     if (existing === rendered) {
+      // File already matches. `force` still re-bootstraps so the LOADED unit
+      // adopts the on-disk policy — the case where a daemon wrote the corrected
+      // (SuccessfulExit=false) plist during self-install but its launchd job is
+      // still looping under the old bare-KeepAlive policy, which a content
+      // compare can't see. Safe only because `force` comes solely from the CLI
+      // (a separate process); a daemon re-bootstrapping its OWN job would
+      // SIGTERM itself mid-bootout.
+      if (opts.force) {
+        await this.rebootstrap(spec.label, plistPath);
+        return { changed: false, supervisorReloaded: true };
+      }
       return { changed: false, supervisorReloaded: false };
     }
 
@@ -85,39 +97,49 @@ export class LaunchdServiceManager implements ServiceManager {
     atomicWriteFileSync(plistPath, rendered);
 
     if (existing === null) {
-      assertRunSucceeded(
-        await this.runner.run(['bootstrap', `gui/${this.uid}`, plistPath]),
-        `launchctl bootstrap gui/${this.uid}`,
-      );
-      assertRunSucceeded(
-        await this.runner.run(['enable', this.domainTarget(spec.label)]),
-        `launchctl enable ${this.domainTarget(spec.label)}`,
-      );
+      await this.bootstrapEnable(spec.label, plistPath);
       return { changed: true, supervisorReloaded: true };
     }
 
-    // bootout terminates the running service; default is to write the
-    // new plist and let the next supervisor-initiated restart pick it
-    // up. `force: true` opts into an immediate swap.
+    // A changed plist: bootout terminates the running service, so the default
+    // is to write the new plist and let the supervisor's next restart pick it
+    // up (reloading now would terminate the calling daemon during self-install).
+    // `force: true` opts into an immediate swap.
     if (!opts.force) {
       return { changed: true, supervisorReloaded: false };
     }
-    await this.runner.run(['bootout', this.domainTarget(spec.label)]);
+    await this.rebootstrap(spec.label, plistPath);
+    return { changed: true, supervisorReloaded: true };
+  }
+
+  /** bootstrap + enable for a freshly-written plist (first install). */
+  private async bootstrapEnable(label: string, plistPath: string): Promise<void> {
     assertRunSucceeded(
       await this.runner.run(['bootstrap', `gui/${this.uid}`, plistPath]),
       `launchctl bootstrap gui/${this.uid}`,
     );
     assertRunSucceeded(
-      await this.runner.run(['enable', this.domainTarget(spec.label)]),
-      `launchctl enable ${this.domainTarget(spec.label)}`,
+      await this.runner.run(['enable', this.domainTarget(label)]),
+      `launchctl enable ${this.domainTarget(label)}`,
     );
-    return { changed: true, supervisorReloaded: true };
+  }
+
+  /** bootout the loaded job (best-effort — it may not be loaded) then
+   *  bootstrap + enable: the immediate swap that makes the supervisor adopt the
+   *  on-disk plist NOW. MUST NOT be called by the daemon whose own job this is —
+   *  the bootout would SIGTERM the caller before bootstrap runs. */
+  private async rebootstrap(label: string, plistPath: string): Promise<void> {
+    await this.runner.run(['bootout', this.domainTarget(label)]);
+    await this.bootstrapEnable(label, plistPath);
   }
 
   async uninstall(label: string): Promise<void> {
     const plistPath = this.plistPath(label);
     await this.runner.run(['bootout', this.domainTarget(label)]);
     if (fs.existsSync(plistPath)) fs.unlinkSync(plistPath);
+    // Sweep any sibling plists whose target binary is gone (old version dirs,
+    // removed dev-build worktrees) so launchd stops churning on dead units.
+    await this.pruneSupersededUnits(label);
   }
 
   async start(label: string): Promise<void> {
@@ -148,10 +170,6 @@ export class LaunchdServiceManager implements ServiceManager {
     return `launchctl kickstart -k ${this.domainTarget(label)}`;
   }
 
-  isManagedDaemon(_label: string, status: ServiceStatus, myPid: number): boolean {
-    return status.running && status.pid === myPid;
-  }
-
   async status(label: string): Promise<ServiceStatus> {
     const plistPath = this.plistPath(label);
     if (!fs.existsSync(plistPath)) {
@@ -169,4 +187,45 @@ export class LaunchdServiceManager implements ServiceManager {
       unitPath: plistPath,
     };
   }
+
+  /**
+   * Bootout + remove `co.goondocks.myco*.plist` units whose target binary no
+   * longer exists on disk — superseded leftovers (an old version dir, a removed
+   * dev-build worktree) that launchd keeps trying to respawn.
+   *
+   * Identity is verified by READING each plist's executable, never by matching
+   * the label pattern: home-hash and sandbox-suffix labels are by design, so a
+   * still-live non-default-home daemon must never be pruned. A unit is removed
+   * ONLY when its executable is parseable AND missing; an unparseable plist or a
+   * present binary is left untouched. `keepLabel` is an extra guard for the unit
+   * the caller is actively managing. Returns the labels pruned.
+   */
+  async pruneSupersededUnits(keepLabel?: string): Promise<string[]> {
+    const pruned: string[] = [];
+    let entries: string[];
+    try { entries = fs.readdirSync(this.agentsDir); } catch { return pruned; }
+    for (const file of entries) {
+      if (!/^co\.goondocks\.myco.*\.plist$/.test(file)) continue;
+      const label = file.slice(0, -'.plist'.length);
+      if (keepLabel && label === keepLabel) continue;
+      const plistPath = path.join(this.agentsDir, file);
+      let content: string;
+      try { content = fs.readFileSync(plistPath, 'utf-8'); } catch { continue; }
+      const exe = parsePlistExecutable(content);
+      // Only prune a unit we can positively identify as dead (executable gone).
+      // Unparseable or still-present → leave it; never delete by label pattern.
+      if (!exe || fs.existsSync(exe)) continue;
+      await this.runner.run(['bootout', this.domainTarget(label)]);
+      try { fs.unlinkSync(plistPath); } catch { /* best-effort */ }
+      pruned.push(label);
+    }
+    return pruned;
+  }
+}
+
+/** First ProgramArguments <string> (the executable) from a launchd plist. */
+function parsePlistExecutable(plist: string): string | null {
+  const arrayBlock = plist.split('<key>ProgramArguments</key>')[1]?.split('</array>')[0];
+  const m = arrayBlock?.match(/<string>([^<]*)<\/string>/);
+  return m ? m[1] : null;
 }

--- a/packages/myco/src/service/self-install.ts
+++ b/packages/myco/src/service/self-install.ts
@@ -82,6 +82,22 @@ export async function ensureSelfInstalledAsService(
     // `force: true` would terminate the calling daemon.
     const result = await mgr.install(spec);
 
+    // Sweep superseded sibling units whose target binary is gone (old version
+    // dirs, removed dev-build worktrees) so the supervisor stops respawning dead
+    // units. Best-effort and never touches our own label (passed as keepLabel).
+    try {
+      const pruned = (await mgr.pruneSupersededUnits?.(label)) ?? [];
+      if (pruned.length > 0) {
+        logger.info('daemon.service_install', `Pruned ${pruned.length} superseded service unit(s)`, {
+          home: mycoHome, platform: mgr.platformName, pruned,
+        });
+      }
+    } catch (err) {
+      logger.debug('daemon.service_install', 'Superseded-unit prune skipped', {
+        error: (err as Error).message,
+      });
+    }
+
     if (!result.changed) {
       logger.debug('daemon.service_install', `Managed service ${label} unchanged`, {
         home: mycoHome, platform: mgr.platformName, executable,

--- a/packages/myco/src/service/systemd.ts
+++ b/packages/myco/src/service/systemd.ts
@@ -109,13 +109,9 @@ export class SystemdUserServiceManager implements ServiceManager {
 
   restartShellCommand(label: string): string {
     // Literal command the detached update / restart script invokes after the
-    // daemon exits. Mirrors restart() above so systemd's Restart=always cannot
-    // race a manually-spawned daemon child for the canonical port.
+    // daemon exits. Mirrors restart() above so systemd's Restart=on-failure
+    // cannot race a manually-spawned daemon child for the canonical port.
     return `systemctl --user restart ${label}.service`;
-  }
-
-  isManagedDaemon(_label: string, status: ServiceStatus, myPid: number): boolean {
-    return status.running && status.pid === myPid;
   }
 
   async status(label: string): Promise<ServiceStatus> {

--- a/packages/myco/src/service/types.ts
+++ b/packages/myco/src/service/types.ts
@@ -87,11 +87,9 @@ export interface ServiceManager {
    *  unsupported platform. */
   restartShellCommand(label: string): string;
   status(label: string): Promise<ServiceStatus>;
-  /** Whether the current process is the daemon THIS manager started for `label`.
-   *  The one genuinely platform-specific bit of restart routing: launchd/systemd
-   *  match the reported `status.pid` to `myPid`; Windows can't (schtasks exposes
-   *  no action PID, so `status.pid` is always null) and instead reads the
-   *  `MYCO_SERVICE_MANAGED` marker the launcher .cmd exports. Lives on the
-   *  interface so `detectServiceManagedLabel` stays platform-agnostic. */
-  isManagedDaemon(label: string, status: ServiceStatus, myPid: number): boolean;
+  /** Optional: bootout + remove superseded units whose target binary is gone
+   *  (old version dirs, removed dev-build worktrees) so the supervisor stops
+   *  respawning dead units. Implemented where stale units accumulate (launchd);
+   *  absent elsewhere. `keepLabel` guards the unit the caller is managing. */
+  pruneSupersededUnits?(keepLabel?: string): Promise<string[]>;
 }

--- a/packages/myco/src/service/unsupported.ts
+++ b/packages/myco/src/service/unsupported.ts
@@ -29,8 +29,4 @@ export class UnsupportedServiceManager implements ServiceManager {
   async status(_label: string): Promise<ServiceStatus> {
     return { installed: false, running: false, pid: null, lastExitCode: null, unitPath: null };
   }
-
-  isManagedDaemon(_label: string, _status: ServiceStatus, _myPid: number): boolean {
-    return false;
-  }
 }

--- a/packages/myco/src/service/windows-task.ts
+++ b/packages/myco/src/service/windows-task.ts
@@ -17,19 +17,11 @@ import type { ServiceSpec } from './types.js';
  * CRLF line endings: `cmd.exe` is whitespace/line-ending sensitive.
  */
 export function renderWindowsServiceScript(spec: ServiceSpec): string {
-  const setLines = [
-    ...Object.entries(spec.env)
-      .filter(([key]) => key !== 'PATH')
-      // `set "K=V"` quoting keeps spaces/special chars literal and is the
-      // canonical cmd.exe form for values that may contain `&`, `(`, etc.
-      .map(([key, value]) => `set "${key}=${value}"`),
-    // Marker so the daemon knows it was started by THIS service. Windows
-    // schtasks exposes no action PID, so detectServiceManagedLabel can't
-    // pid-match (as launchd/systemd do) — it reads this env var instead, which
-    // routes the restart button through `myco service restart` (schtasks
-    // /end + /run) rather than the unsupervised respawn path.
-    `set "MYCO_SERVICE_MANAGED=${spec.label}"`,
-  ];
+  const setLines = Object.entries(spec.env)
+    .filter(([key]) => key !== 'PATH')
+    // `set "K=V"` quoting keeps spaces/special chars literal and is the
+    // canonical cmd.exe form for values that may contain `&`, `(`, etc.
+    .map(([key, value]) => `set "${key}=${value}"`);
 
   const exec = `"${spec.executable}" ${spec.args.join(' ')}`;
   const run = `${exec} >> "${spec.stdoutPath}" 2>> "${spec.stderrPath}"`;

--- a/packages/myco/src/service/windows.ts
+++ b/packages/myco/src/service/windows.ts
@@ -78,7 +78,7 @@ export interface WindowsManagerOptions {
  * `sc start`. A logon-triggered scheduled task runs an ordinary process with
  * no service-protocol contract — the correct fit for a user daemon.
  *
- * Crash auto-restart (the launchd `KeepAlive` / systemd `Restart=always`
+ * Crash auto-restart (the launchd `KeepAlive` / systemd `Restart=on-failure`
  * equivalent) is handled by the existing hook-respawn path — a hook fires,
  * finds no live daemon via the lifecycle lock, and spawns one. A Task
  * Scheduler `RestartOnFailure` policy (XML task definition) would add
@@ -183,13 +183,6 @@ export class WindowsTaskServiceManager implements ServiceManager {
     // daemon exits — re-triggers the task to bring the daemon back. Mirrors
     // the systemd/launchd restart primitives.
     return `schtasks /run /tn "${label}"`;
-  }
-
-  isManagedDaemon(label: string, _status: ServiceStatus, _myPid: number): boolean {
-    // schtasks exposes no action PID (status.pid is always null), so the
-    // launchd/systemd pid-match can't work. The launcher .cmd exports
-    // MYCO_SERVICE_MANAGED=<label> (renderWindowsServiceScript); trust it.
-    return process.env.MYCO_SERVICE_MANAGED === label;
   }
 
   async status(label: string): Promise<ServiceStatus> {

--- a/packages/myco/src/upgrade/auto-check.ts
+++ b/packages/myco/src/upgrade/auto-check.ts
@@ -363,8 +363,8 @@ export function buildAdoptJobFn(
       // knows whether to let the supervisor restart or do a direct spawn.
       const resolveServiceLabel = adoptDeps.resolveServiceLabel ?? (async () => {
         const { getServiceManager } = await import('../service/manager.js');
-        const { detectServiceManagedLabel } = await import('../daemon/api/restart.js');
-        return detectServiceManagedLabel(getServiceManager());
+        const { resolveRestartServiceLabel } = await import('../daemon/api/restart.js');
+        return resolveRestartServiceLabel(getServiceManager());
       });
       const serviceManagedLabel = await resolveServiceLabel();
 

--- a/packages/myco/src/upgrade/orchestrator.ts
+++ b/packages/myco/src/upgrade/orchestrator.ts
@@ -39,10 +39,12 @@ import { spawn } from 'node:child_process';
 
 import {
   UPDATE_ERROR_PATH,
+  UPDATE_EVENTS_PATH,
   UPDATE_SCRIPT_DELAY_SECONDS,
 } from '../constants/update.js';
 import { getServiceManager } from '../service/manager.js';
 import { clearJsonSentinel } from '../utils/json-sentinel.js';
+import { appendUpdateEvent, type UpdateEventLevel } from './update-events.js';
 import type { ServiceManager } from '../service/types.js';
 
 // ---------------------------------------------------------------------------
@@ -111,6 +113,9 @@ export interface ApplyAdoptParams {
   healthIntervalMs: number;
   /** Error side-channel path. Defaults to UPDATE_ERROR_PATH; overridable for tests. */
   errorPath?: string;
+  /** Adopt-event side-channel path. Defaults to UPDATE_EVENTS_PATH; overridable
+   *  for hermetic tests (the default is machine-global, not MYCO_HOME-scoped). */
+  updateEventsPath?: string;
   /**
    * Absolute path to the `update.in-progress` sentinel. Cleared on every
    * abort/restore exit path so a failed adopt never locks out future updates
@@ -445,9 +450,18 @@ async function resolvePruneVersions(
 // Adopt path
 // ---------------------------------------------------------------------------
 
+interface HealthWatchResult {
+  healthy: boolean;
+  /** Last version /health reported (null = never reachable in the window). The
+   *  key adopt-failure discriminator: a window stuck on the OLD version means
+   *  the restart never brought up the target; null means the daemon stayed
+   *  down; the target with healthy=false would mean a version-match bug. */
+  lastSeenVersion: string | null;
+}
+
 /**
- * Poll /health up to `maxHealthAttempts` times for `targetVersion`.
- * Returns true on success.
+ * Poll /health up to `maxHealthAttempts` times for `targetVersion`, reporting
+ * the last version it saw so the caller can log WHY a watch failed.
  */
 async function pollHealthForAdopt(
   deps: ApplyUpdateDeps,
@@ -455,17 +469,21 @@ async function pollHealthForAdopt(
   targetVersion: string,
   maxHealthAttempts: number,
   healthIntervalMs: number,
-): Promise<boolean> {
+): Promise<HealthWatchResult> {
+  let lastSeenVersion: string | null = null;
   for (let i = 0; i < maxHealthAttempts; i += 1) {
     if (i > 0) await deps.sleep(healthIntervalMs);
     try {
       const body = await deps.probeHealth(daemonPort);
-      if (body && body.version === targetVersion) return true;
+      if (body) {
+        lastSeenVersion = body.version ?? lastSeenVersion;
+        if (body.version === targetVersion) return { healthy: true, lastSeenVersion };
+      }
     } catch {
       /* probe failure → not yet healthy */
     }
   }
-  return false;
+  return { healthy: false, lastSeenVersion };
 }
 
 /**
@@ -480,6 +498,17 @@ async function pollHealthForAdopt(
 async function runAdopt(p: ApplyAdoptParams, deps: ApplyUpdateDeps): Promise<void> {
   await deps.sleep(UPDATE_SCRIPT_DELAY_SECONDS * 1000);
 
+  // Observability side-channel — the daemon replays these into log_entries on
+  // its next startup (see update-events.ts). Path is injectable for hermetic tests.
+  const eventsPath = p.updateEventsPath ?? UPDATE_EVENTS_PATH;
+  const event = (level: UpdateEventLevel, message: string, data?: Record<string, unknown>): void =>
+    appendUpdateEvent(eventsPath, level, message, data);
+
+  event('info', 'adopt started', {
+    from: p.prevVersion, to: p.targetVersion, platform: p.platform,
+    daemon_port: p.daemonPort, service_managed_label: p.serviceManagedLabel ?? null,
+  });
+
   const errorPath = p.errorPath ?? UPDATE_ERROR_PATH;
   const writeError = (message: string): void => {
     writeFileSafe(errorPath, JSON.stringify({ error: message }));
@@ -493,6 +522,9 @@ async function runAdopt(p: ApplyAdoptParams, deps: ApplyUpdateDeps): Promise<voi
   // --- Step 1: cooperative stop ---
   const cooperativeShutdown = await resolveRequestCooperativeShutdown(deps);
   const stopConfirmed = await cooperativeShutdown(p.daemonPort);
+  event('info', stopConfirmed ? 'cooperative stop confirmed' : 'cooperative stop NOT confirmed', {
+    daemon_port: p.daemonPort,
+  });
 
   // --- Step 2: cross-platform stop-confirm gate ---
   // win32 invariant: NEVER copy over a live image (Windows locks running .exe
@@ -555,23 +587,29 @@ async function runAdopt(p: ApplyAdoptParams, deps: ApplyUpdateDeps): Promise<voi
     // version exhausts the attempts and falls through to the restore below.
     let healthy = false;
     for (let attempt = 1; attempt <= ADOPT_RESTART_ATTEMPTS; attempt += 1) {
+      event('info', 'restart onto target', {
+        attempt, of: ADOPT_RESTART_ATTEMPTS, target: p.targetVersion,
+        service_managed_label: p.serviceManagedLabel ?? null,
+      });
       await restart(deps, p.serviceManagedLabel, p.mycoBinary, p.projectRoot);
-      healthy = await pollHealthForAdopt(
+      const watch = await pollHealthForAdopt(
         deps,
         p.daemonPort,
         p.targetVersion,
         p.maxHealthAttempts,
         p.healthIntervalMs,
       );
+      healthy = watch.healthy;
+      event(healthy ? 'info' : 'warn', healthy ? 'target healthy' : 'health-watch did not reach target', {
+        attempt, of: ADOPT_RESTART_ATTEMPTS, target: p.targetVersion,
+        last_seen_version: watch.lastSeenVersion, // OLD version = restart never took; null = daemon stayed down
+        health_polls: p.maxHealthAttempts, poll_interval_ms: p.healthIntervalMs,
+      });
       if (healthy || attempt === ADOPT_RESTART_ATTEMPTS) break;
-      try {
-        process.stderr.write(
-          `[myco] adopt: ${p.targetVersion} not healthy after restart attempt ${attempt}/${ADOPT_RESTART_ATTEMPTS} — retrying\n`,
-        );
-      } catch { /* best-effort */ }
     }
 
     if (healthy) {
+      event('info', 'adopt succeeded', { version: p.targetVersion, from: p.prevVersion });
       // Success: prune old versions, clear error, clear sentinel.
       // The daemon-startup clear fires when the new daemon sees targetVersion ==
       // sentinel.targetVersion — but we also clear here so the sentinel is gone
@@ -602,6 +640,9 @@ async function runAdopt(p: ApplyAdoptParams, deps: ApplyUpdateDeps): Promise<voi
       `new binary ${p.targetVersion} failed to become healthy after ${ADOPT_RESTART_ATTEMPTS} restart attempts `
       + `(${p.maxHealthAttempts} health polls each) — rollback to ${p.prevVersion} applied`,
     );
+    event('error', 'rollback applied', {
+      target: p.targetVersion, restored: p.prevVersion, restart_attempts: ADOPT_RESTART_ATTEMPTS,
+    });
     clearSentinel();
     await restart(deps, p.serviceManagedLabel, p.mycoBinary, p.projectRoot);
   } catch (err) {

--- a/packages/myco/src/upgrade/orchestrator.ts
+++ b/packages/myco/src/upgrade/orchestrator.ts
@@ -192,6 +192,16 @@ export interface ApplyUpdateDeps {
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
+ * How many times `runAdopt` restarts onto the new binary and re-watches health
+ * before restoring the previous version. >1 so a single transient failure (a
+ * respawn racing the restart) converges instead of immediately rolling back —
+ * the convergence the manual one-shot apply needs and the idle auto-adopt
+ * previously provided only via its next-tick retry. Kept small so a genuinely
+ * broken binary still rolls back promptly.
+ */
+const ADOPT_RESTART_ATTEMPTS = 2;
+
+/**
  * Spawn `<bin> <args>` cross-platform without letting the shell word-split a
  * spaced binary path.
  *
@@ -530,20 +540,36 @@ async function runAdopt(p: ApplyAdoptParams, deps: ApplyUpdateDeps): Promise<voi
     return;
   }
 
-  // --- Step 4: restart onto the new binary ---
+  // --- Step 4+5: restart onto the new binary, then confirm it reaches the
+  // target version — RETRIED a bounded number of times before restoring.
   // Past this point the daemon MUST come back. Wrap in try/catch so an
   // unexpected throw (e.g. a deps bug) still ends in a final restart attempt.
   try {
-    await restart(deps, p.serviceManagedLabel, p.mycoBinary, p.projectRoot);
-
-    // --- Step 5: health-watch ---
-    const healthy = await pollHealthForAdopt(
-      deps,
-      p.daemonPort,
-      p.targetVersion,
-      p.maxHealthAttempts,
-      p.healthIntervalMs,
-    );
+    // A single restart can fail to "take" transiently (a respawn racing the
+    // restart during the shutdown window, the supervisor not yet re-adopting).
+    // Retrying the restart+health-watch makes BOTH entry points converge through
+    // this one shared path: the manual one-shot apply now lands reliably instead
+    // of relying on the idle auto-adopt's next-tick retry to eventually fix it.
+    // The binary was already copied in Step 3, so each retry only re-restarts —
+    // never re-copies. A genuinely broken binary that never reaches the target
+    // version exhausts the attempts and falls through to the restore below.
+    let healthy = false;
+    for (let attempt = 1; attempt <= ADOPT_RESTART_ATTEMPTS; attempt += 1) {
+      await restart(deps, p.serviceManagedLabel, p.mycoBinary, p.projectRoot);
+      healthy = await pollHealthForAdopt(
+        deps,
+        p.daemonPort,
+        p.targetVersion,
+        p.maxHealthAttempts,
+        p.healthIntervalMs,
+      );
+      if (healthy || attempt === ADOPT_RESTART_ATTEMPTS) break;
+      try {
+        process.stderr.write(
+          `[myco] adopt: ${p.targetVersion} not healthy after restart attempt ${attempt}/${ADOPT_RESTART_ATTEMPTS} — retrying\n`,
+        );
+      } catch { /* best-effort */ }
+    }
 
     if (healthy) {
       // Success: prune old versions, clear error, clear sentinel.
@@ -573,7 +599,8 @@ async function runAdopt(p: ApplyAdoptParams, deps: ApplyUpdateDeps): Promise<voi
       );
     }
     writeError(
-      `new binary ${p.targetVersion} failed to become healthy after ${p.maxHealthAttempts} attempts — rollback to ${p.prevVersion} applied`,
+      `new binary ${p.targetVersion} failed to become healthy after ${ADOPT_RESTART_ATTEMPTS} restart attempts `
+      + `(${p.maxHealthAttempts} health polls each) — rollback to ${p.prevVersion} applied`,
     );
     clearSentinel();
     await restart(deps, p.serviceManagedLabel, p.mycoBinary, p.projectRoot);

--- a/packages/myco/src/upgrade/orchestrator.ts
+++ b/packages/myco/src/upgrade/orchestrator.ts
@@ -44,6 +44,7 @@ import {
 } from '../constants/update.js';
 import { getServiceManager } from '../service/manager.js';
 import { clearJsonSentinel } from '../utils/json-sentinel.js';
+import { resolveServiceDaemonStatePath } from '../grove/paths.js';
 import { appendUpdateEvent, type UpdateEventLevel } from './update-events.js';
 import type { ServiceManager } from '../service/types.js';
 
@@ -148,6 +149,9 @@ export interface ApplyUpdateDeps {
   runFanout: (mycoBinary: string, logPath: string) => Promise<void>;
   /** Probe the daemon /health endpoint; null on any failure. */
   probeHealth: (daemonPort: number) => Promise<{ version?: string } | null>;
+  /** Read the daemon's recorded version from daemon.json, gated on a live pid;
+   *  null when absent/stale. The probe-independent second health signal. */
+  probeDaemonState: (home: string) => { version?: string } | null;
   /** Sleep helper (overridable so tests don't actually wait). */
   sleep: (ms: number) => Promise<void>;
   /**
@@ -273,12 +277,17 @@ function runFanout(mycoBinary: string, logPath: string): Promise<void> {
   });
 }
 
-/** Probe /health with a ~2s timeout; returns the parsed body or null. */
+/** Probe /health; returns the parsed body or null. `Connection: close` forces a
+ *  FRESH connection every probe so a pooled/keep-alive socket left dead by the
+ *  daemon's restart can never poison the whole health-watch. */
 async function probeHealth(daemonPort: number): Promise<{ version?: string } | null> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 2000);
+  const timer = setTimeout(() => controller.abort(), HEALTH_PROBE_TIMEOUT_MS);
   try {
-    const res = await fetch(`http://127.0.0.1:${daemonPort}/health`, { signal: controller.signal });
+    const res = await fetch(`http://127.0.0.1:${daemonPort}/health`, {
+      signal: controller.signal,
+      headers: { connection: 'close' },
+    });
     if (!res.ok) return null;
     return (await res.json()) as { version?: string };
   } catch {
@@ -288,12 +297,35 @@ async function probeHealth(daemonPort: number): Promise<{ version?: string } | n
   }
 }
 
+const HEALTH_PROBE_TIMEOUT_MS = 4000;
+
+/**
+ * Cross-check the daemon's OWN recorded state: the version it wrote to
+ * `<home>/service/daemon.json` on startup, gated on that pid being alive. This
+ * is a file read + process-liveness check — immune to the HTTP-probe flakiness
+ * that would otherwise roll back a demonstrably-healthy adopt. The health-watch
+ * succeeds when EITHER /health OR this agrees the target is live, so a single
+ * fragile signal can no longer fail a good update.
+ */
+function probeDaemonState(home: string): { version?: string } | null {
+  try {
+    const raw = fs.readFileSync(resolveServiceDaemonStatePath(home), 'utf-8');
+    const d = JSON.parse(raw) as { version?: string; pid?: number };
+    if (!d.version || typeof d.pid !== 'number') return null;
+    try { process.kill(d.pid, 0); } catch { return null; } // pid not alive → stale record
+    return { version: d.version };
+  } catch {
+    return null;
+  }
+}
+
 const DEFAULT_DEPS: ApplyUpdateDeps = {
   getServiceManager,
   runNpm,
   spawnDetached,
   runFanout,
   probeHealth,
+  probeDaemonState,
   sleep,
 };
 
@@ -452,16 +484,21 @@ async function resolvePruneVersions(
 
 interface HealthWatchResult {
   healthy: boolean;
-  /** Last version /health reported (null = never reachable in the window). The
-   *  key adopt-failure discriminator: a window stuck on the OLD version means
-   *  the restart never brought up the target; null means the daemon stayed
-   *  down; the target with healthy=false would mean a version-match bug. */
+  /** Last version EITHER signal reported (null = never reachable in the window).
+   *  The adopt-failure discriminator: a window stuck on the OLD version means the
+   *  restart never brought up the target; null means the daemon stayed down. */
   lastSeenVersion: string | null;
+  /** Which signal confirmed the target — for the narration. */
+  via: 'health' | 'daemon-state' | null;
 }
 
 /**
- * Poll /health up to `maxHealthAttempts` times for `targetVersion`, reporting
- * the last version it saw so the caller can log WHY a watch failed.
+ * Watch for `targetVersion` up to `maxHealthAttempts` times using TWO
+ * independent signals each poll: the HTTP /health probe AND the daemon's own
+ * `daemon.json` record (version + live pid). Either confirming the target is
+ * success — so a flaky HTTP probe can no longer roll back a daemon that is
+ * demonstrably running the new version. Reports the last version seen + which
+ * signal won so the caller can narrate WHY a watch failed.
  */
 async function pollHealthForAdopt(
   deps: ApplyUpdateDeps,
@@ -469,21 +506,29 @@ async function pollHealthForAdopt(
   targetVersion: string,
   maxHealthAttempts: number,
   healthIntervalMs: number,
+  home: string,
 ): Promise<HealthWatchResult> {
   let lastSeenVersion: string | null = null;
   for (let i = 0; i < maxHealthAttempts; i += 1) {
     if (i > 0) await deps.sleep(healthIntervalMs);
+    // Signal 1: HTTP /health (fresh connection per probe).
     try {
       const body = await deps.probeHealth(daemonPort);
       if (body) {
         lastSeenVersion = body.version ?? lastSeenVersion;
-        if (body.version === targetVersion) return { healthy: true, lastSeenVersion };
+        if (body.version === targetVersion) return { healthy: true, lastSeenVersion, via: 'health' };
       }
     } catch {
-      /* probe failure → not yet healthy */
+      /* probe failure → fall through to the file signal */
+    }
+    // Signal 2: daemon.json (version + live pid). Probe-independent.
+    const state = deps.probeDaemonState(home);
+    if (state) {
+      lastSeenVersion = state.version ?? lastSeenVersion;
+      if (state.version === targetVersion) return { healthy: true, lastSeenVersion, via: 'daemon-state' };
     }
   }
-  return { healthy: false, lastSeenVersion };
+  return { healthy: false, lastSeenVersion, via: null };
 }
 
 /**
@@ -598,11 +643,13 @@ async function runAdopt(p: ApplyAdoptParams, deps: ApplyUpdateDeps): Promise<voi
         p.targetVersion,
         p.maxHealthAttempts,
         p.healthIntervalMs,
+        p.home,
       );
       healthy = watch.healthy;
       event(healthy ? 'info' : 'warn', healthy ? 'target healthy' : 'health-watch did not reach target', {
         attempt, of: ADOPT_RESTART_ATTEMPTS, target: p.targetVersion,
         last_seen_version: watch.lastSeenVersion, // OLD version = restart never took; null = daemon stayed down
+        via: watch.via, // 'health' = HTTP probe, 'daemon-state' = daemon.json cross-check
         health_polls: p.maxHealthAttempts, poll_interval_ms: p.healthIntervalMs,
       });
       if (healthy || attempt === ADOPT_RESTART_ATTEMPTS) break;

--- a/packages/myco/src/upgrade/spawn.ts
+++ b/packages/myco/src/upgrade/spawn.ts
@@ -44,8 +44,9 @@ export interface InstallParams {
    * preventing the thundering-herd race between a manually-spawned daemon
    * child and the supervisor's KeepAlive/Restart policy.
    *
-   * Null (or absent) means non-service-managed — the orchestrator respawns the
-   * daemon directly. Callers derive this from `detectServiceManagedLabel()`.
+   * Null (or absent) means no supervisor owns this home — the orchestrator
+   * respawns the daemon directly. Callers derive this from
+   * `resolveRestartServiceLabel()` (keyed on the installed unit, not pid).
    */
   serviceManagedLabel?: string | null;
   /**

--- a/packages/myco/src/upgrade/update-events.ts
+++ b/packages/myco/src/upgrade/update-events.ts
@@ -1,0 +1,85 @@
+/**
+ * Observability side-channel for the DETACHED adopt orchestrator.
+ *
+ * The orchestrator (`runAdopt` in orchestrator.ts) runs as a separate
+ * `stdio:'ignore'` process spawned just before the daemon exits, so it has no
+ * structured logger and no handle on the grove DB it is restarting. Its restart
+ * attempts, health-watch results, and rollback decisions otherwise vanish into
+ * /dev/null — which is exactly why adopt failures were undebuggable.
+ *
+ * Instead it APPENDS structured events here, and the daemon DRAINS them on its
+ * next startup (see the restart-reason ingestion in daemon/main.ts), replaying
+ * each through the logger under {@link LOG_KINDS.UPGRADE_ADOPT} so the whole
+ * sequence lands in `log_entries` and the log viewer. Mirrors the existing
+ * restart-reason.json → daemon.version_sync pattern rather than inventing a
+ * bespoke, viewer-invisible log file.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { UPDATE_EVENTS_PATH } from '../constants/update.js';
+
+export type UpdateEventLevel = 'info' | 'warn' | 'error';
+
+export interface UpdateEvent {
+  /** ISO timestamp recorded by the orchestrator at emit time. */
+  ts: string;
+  level: UpdateEventLevel;
+  message: string;
+  /** Structured metadata (versions, attempt counts, the version health saw). */
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Append one adopt event. Best-effort and NEVER throws: observability must not
+ * be able to break the self-upgrade it is observing. `eventsPath` is injectable
+ * so the orchestrator can point it at a hermetic location under test instead of
+ * the machine-global default.
+ */
+export function appendUpdateEvent(
+  eventsPath: string,
+  level: UpdateEventLevel,
+  message: string,
+  data?: Record<string, unknown>,
+): void {
+  try {
+    fs.mkdirSync(path.dirname(eventsPath), { recursive: true });
+    const line = JSON.stringify({ ts: new Date().toISOString(), level, message, data }) + '\n';
+    fs.appendFileSync(eventsPath, line);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Read and DELETE the event log, returning the parsed events in order. Malformed
+ * lines are skipped (never let a corrupt side-channel wedge startup). Returns []
+ * when the file is absent or unreadable.
+ */
+export function drainUpdateEvents(eventsPath: string = UPDATE_EVENTS_PATH): UpdateEvent[] {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(eventsPath, 'utf-8');
+  } catch {
+    return []; // ENOENT (the common case) or unreadable
+  }
+  try { fs.unlinkSync(eventsPath); } catch { /* best-effort */ }
+
+  const events: UpdateEvent[] = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line) as Partial<UpdateEvent>;
+      if (typeof parsed.message !== 'string') continue;
+      events.push({
+        ts: typeof parsed.ts === 'string' ? parsed.ts : new Date().toISOString(),
+        level: parsed.level === 'warn' || parsed.level === 'error' ? parsed.level : 'info',
+        message: parsed.message,
+        data: parsed.data && typeof parsed.data === 'object' ? parsed.data : undefined,
+      });
+    } catch {
+      /* skip a malformed line */
+    }
+  }
+  return events;
+}

--- a/tests/cli/service.test.ts
+++ b/tests/cli/service.test.ts
@@ -23,6 +23,10 @@ describe('parseServiceArgs', () => {
     expect(parseServiceArgs(['restart'])).toEqual({ action: 'restart' });
   });
 
+  test('reconcile', () => {
+    expect(parseServiceArgs(['reconcile'])).toEqual({ action: 'reconcile' });
+  });
+
   test('rejects unknown action', () => {
     expect(() => parseServiceArgs(['frobnicate'])).toThrow(/unknown.*frobnicate/i);
   });
@@ -46,7 +50,7 @@ describe('assertSafeServiceMutation (default-home-from-dev-binary fence)', () =>
   const globalPath = '/opt/homebrew/lib/node_modules/@goondocks/myco-darwin-arm64/bin/myco';
 
   test('refuses every mutating verb against the default home when run from a dev-build binary', () => {
-    for (const action of ['install', 'uninstall', 'start', 'stop', 'restart'] as const) {
+    for (const action of ['install', 'uninstall', 'start', 'stop', 'restart', 'reconcile'] as const) {
       const refusal = assertSafeServiceMutation({ action }, devBuildPath, DEFAULT_HOME);
       expect(refusal).not.toBeNull();
       expect(refusal!).toMatch(/Refusing to .* the default-home \(~\/\.myco\) service from a dev-build binary/);
@@ -54,7 +58,7 @@ describe('assertSafeServiceMutation (default-home-from-dev-binary fence)', () =>
   });
 
   test('refuses every mutating verb against the default home from the legacy vendor/<arch>/ layout', () => {
-    for (const action of ['install', 'uninstall', 'start', 'stop', 'restart'] as const) {
+    for (const action of ['install', 'uninstall', 'start', 'stop', 'restart', 'reconcile'] as const) {
       const refusal = assertSafeServiceMutation({ action }, legacyDevBuildPath, DEFAULT_HOME);
       expect(refusal).not.toBeNull();
       expect(refusal!).toMatch(/Refusing to .* the default-home \(~\/\.myco\) service from a dev-build binary/);
@@ -66,13 +70,13 @@ describe('assertSafeServiceMutation (default-home-from-dev-binary fence)', () =>
   });
 
   test('allows all actions against a non-default (dogfood) home from a dev-build binary', () => {
-    for (const action of ['install', 'uninstall', 'start', 'stop', 'restart', 'status'] as const) {
+    for (const action of ['install', 'uninstall', 'start', 'stop', 'restart', 'status', 'reconcile'] as const) {
       expect(assertSafeServiceMutation({ action }, devBuildPath, DOGFOOD_HOME)).toBeNull();
     }
   });
 
   test('allows all actions against the default home from the globally installed binary', () => {
-    for (const action of ['install', 'uninstall', 'start', 'stop', 'restart', 'status'] as const) {
+    for (const action of ['install', 'uninstall', 'start', 'stop', 'restart', 'status', 'reconcile'] as const) {
       expect(assertSafeServiceMutation({ action }, globalPath, DEFAULT_HOME)).toBeNull();
     }
   });

--- a/tests/cli/upgrade.test.ts
+++ b/tests/cli/upgrade.test.ts
@@ -47,13 +47,13 @@ mock.module('@myco/install/managed-binary.js', () => ({
     platform === 'win32' ? `${home}\\AppData\\Local\\Myco\\bin\\myco.exe` : `${home}/.myco/bin/myco`,
 }));
 
-// Mock service/manager and daemon/api/restart for detectServiceManagedLabel.
+// Mock service/manager and daemon/api/restart for resolveRestartServiceLabel.
 mock.module('@myco/service/manager.js', () => ({
   getServiceManager: () => ({ type: 'none' }),
 }));
 
 mock.module('@myco/daemon/api/restart.js', () => ({
-  detectServiceManagedLabel: async () => null,
+  resolveRestartServiceLabel: async () => null,
 }));
 
 // import AFTER mocks

--- a/tests/daemon/api/restart.test.ts
+++ b/tests/daemon/api/restart.test.ts
@@ -36,7 +36,7 @@ function restoreProcessKill() {
   (process as any).kill = realKill;
 }
 
-import { buildRestartArgv, detectServiceManagedLabel, findInstalledServiceLabel, handleRestart, type RestartHandlerDeps } from '@myco/daemon/api/restart.js';
+import { buildRestartArgv, resolveRestartServiceLabel, findInstalledServiceLabel, handleRestart, type RestartHandlerDeps } from '@myco/daemon/api/restart.js';
 import { ProgressTracker } from '@myco/daemon/api/progress.js';
 import { serviceLabel } from '@myco/service/labels.js';
 import { resolveMycoHome } from '@myco/grove/paths.js';
@@ -75,11 +75,11 @@ describe('buildRestartArgv (shell-free, cross-platform)', () => {
   });
 });
 
-// Process-agnostic sibling of detectServiceManagedLabel — used by client-side
-// surfaces (DaemonClient.spawnDaemon) that need to know "is a supervisor
-// installed for this home" without checking the PID match. There is exactly
-// one managed service per home now (its label IS the home), so the default
-// resolves `serviceLabel(resolveMycoHome())`; the test env's default home is
+// Resolves "is a supervisor installed for this home" without checking the PID
+// match — the basis for restart routing (resolveRestartServiceLabel) and for
+// client-side surfaces (DaemonClient.spawnDaemon). There is exactly one managed
+// service per home now (its label IS the home), so the default resolves
+// `serviceLabel(resolveMycoHome())`; the test env's default home is
 // `~/.myco` → `co.goondocks.myco`.
 describe('findInstalledServiceLabel', () => {
   test('returns null when service manager is unsupported', async () => {
@@ -115,7 +115,7 @@ describe('findInstalledServiceLabel', () => {
     const mgr = new FakeServiceManager();
     mgr.installed.add(HOME_LABEL);
     // PID intentionally different from process.pid — findInstalledServiceLabel
-    // must still return the entry; only detectServiceManagedLabel checks PID.
+    // keys on the installed unit, never on a PID match.
     mgr.statuses.set(HOME_LABEL, { installed: true, running: true, pid: process.pid + 999, lastExitCode: 0, unitPath: '/x.plist' });
     const found = await findInstalledServiceLabel(mgr);
     expect(found?.label).toBe(HOME_LABEL);
@@ -131,11 +131,18 @@ describe('findInstalledServiceLabel', () => {
     expect(found?.label).toBe(label);
   });
 
-  test('detectServiceManagedLabel matches the home service by PID', async () => {
+  test('resolveRestartServiceLabel returns the home label whenever the unit is installed (no PID match)', async () => {
     const mgr = new FakeServiceManager();
     mgr.installed.add(HOME_LABEL);
-    mgr.statuses.set(HOME_LABEL, { installed: true, running: true, pid: process.pid, lastExitCode: 0, unitPath: '/prod.plist' });
-    await expect(detectServiceManagedLabel(mgr, process.pid)).resolves.toBe(HOME_LABEL);
+    // Tracked PID deliberately unequal to ours: a detached daemon must still
+    // resolve the label so the restart re-attaches it via the supervisor.
+    mgr.statuses.set(HOME_LABEL, { installed: true, running: true, pid: process.pid + 999, lastExitCode: 0, unitPath: '/prod.plist' });
+    await expect(resolveRestartServiceLabel(mgr)).resolves.toBe(HOME_LABEL);
+  });
+
+  test('resolveRestartServiceLabel returns null when no unit is installed', async () => {
+    const mgr = new FakeServiceManager();
+    await expect(resolveRestartServiceLabel(mgr)).resolves.toBeNull();
   });
 });
 
@@ -173,7 +180,12 @@ describe('handleRestart', () => {
     expect(shellCmd).not.toContain('--dev');
   });
 
-  test('service installed but a different PID is the running daemon: treats us as non-service-managed', async () => {
+  test('DETACHED daemon (unit installed, different tracked PID): still routes to `service restart` so the supervisor re-adopts it', async () => {
+    // Regression guard for the launchd respawn-loop incident: routing keyed on
+    // pid-identity returned null in the detached state and fell to an
+    // unsupervised direct spawn that re-detached on every restart. Keyed on the
+    // installed unit, a detached daemon restarts via the supervisor's
+    // `kickstart -k`, which re-attaches it — healing the detach.
     const mgr = new FakeServiceManager();
     mgr.installed.add(HOME_LABEL);
     mgr.statuses.set(HOME_LABEL, { installed: true, running: true, pid: process.pid + 999, lastExitCode: 0, unitPath: '/x' });
@@ -181,7 +193,7 @@ describe('handleRestart', () => {
     const res = await handleRestart(deps, {});
     expect(res.body).toMatchObject({ status: 'restarting' });
     const shellCmd = (spawnCalls[0].args ?? []).join(' '); // direct-spawn argv, joined
-    expect(shellCmd).not.toContain('service restart');
+    expect(shellCmd).toContain('service restart');
   });
 
   test('unsupported service manager: takes the non-service path without crashing', async () => {

--- a/tests/daemon/api/upgrade.test.ts
+++ b/tests/daemon/api/upgrade.test.ts
@@ -113,13 +113,15 @@ type AnyMock = ReturnType<typeof vi.fn>;
 
 // The runner sets a hermetic sandbox MYCO_HOME, so the daemon's service label
 // is the home-derived label for that sandbox — resolve it the same way the
-// production code does so detectServiceManagedLabel(mgr) finds the seeded fake.
+// production code does so resolveRestartServiceLabel(mgr) finds the seeded fake.
 const HOME_LABEL = serviceLabel(resolveMycoHome());
 
 function installedServiceManager(shellCmd: string, label: string = HOME_LABEL): FakeServiceManager {
   const mgr = new FakeServiceManager();
   mgr.installed.add(label);
-  mgr.statuses.set(label, { installed: true, running: true, pid: process.pid, lastExitCode: 0, unitPath: '/x' });
+  // Tracked PID deliberately != process.pid: restart routing keys on the
+  // installed unit, never on a pid-match, so the label must still resolve.
+  mgr.statuses.set(label, { installed: true, running: true, pid: process.pid + 999, lastExitCode: 0, unitPath: '/x' });
   mgr.restartShellCommands.set(label, shellCmd);
   return mgr;
 }

--- a/tests/helpers/fake-service-manager.ts
+++ b/tests/helpers/fake-service-manager.ts
@@ -130,13 +130,6 @@ export class FakeServiceManager implements ServiceManager {
     }
     return { installed: false, running: false, pid: null, lastExitCode: null, unitPath: null };
   }
-
-  /** Mirrors the POSIX managers (pid-match) so existing detection tests drive it
-   *  via the `statuses` map. The Windows env-marker variant is covered by
-   *  WindowsTaskServiceManager's own unit test. */
-  isManagedDaemon(_label: string, status: ServiceStatus, myPid: number): boolean {
-    return status.running && status.pid === myPid;
-  }
 }
 
 /**

--- a/tests/service/launchd-plist.test.ts
+++ b/tests/service/launchd-plist.test.ts
@@ -62,6 +62,21 @@ describe('renderLaunchdPlist', () => {
     expect(plist).not.toContain('<key>KeepAlive</key>');
   });
 
+  test('KeepAlive is a SuccessfulExit=false dict, never a bare <true/>', () => {
+    // Restart-on-failure-ONLY parity with systemd (Restart=on-failure) and the
+    // Windows launcher (errorlevel equ 0 -> stop). A bare <true/> respawns a
+    // deliberate step-aside exit(0) and hot-loops the launchd job.
+    const plist = renderLaunchdPlist(baseSpec);
+    const keepAliveBlock = plist
+      .split('<key>KeepAlive</key>')[1]
+      ?.split('<key>ThrottleInterval</key>')[0] ?? '';
+    expect(keepAliveBlock).toContain('<dict>');
+    expect(keepAliveBlock).toContain('<key>SuccessfulExit</key>');
+    expect(keepAliveBlock).toContain('<false/>');
+    // The bare form (KeepAlive immediately followed by <true/>) must be gone.
+    expect(plist).not.toMatch(/<key>KeepAlive<\/key>\s*<true\/>/);
+  });
+
   test('raises NumberOfFiles past the launchd-session default of 256', () => {
     // launchd inherits the user session's `maxfiles` ceiling, which on
     // macOS is typically 256. A burst of concurrent HTTP connections

--- a/tests/service/restart-policy-parity.test.ts
+++ b/tests/service/restart-policy-parity.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+import { renderLaunchdPlist } from '../../packages/myco/src/service/launchd-plist';
+import { renderSystemdUnit } from '../../packages/myco/src/service/systemd-unit';
+import { renderWindowsServiceScript } from '../../packages/myco/src/service/windows-task';
+import type { ServiceSpec } from '../../packages/myco/src/service/types';
+
+/**
+ * Cross-renderer parity: every supervised platform must restart ONLY on an
+ * unsuccessful exit, never on a clean exit(0). A deliberate step-aside (a
+ * sibling daemon already holds the lock) exits 0; if any renderer respawns that,
+ * the launchd job hot-loops (the production incident this guards against).
+ *
+ * This lives in one place so the three renderers can't silently drift apart
+ * again — launchd was the lone outlier (bare KeepAlive=<true/>) while systemd
+ * and Windows already restarted on failure only.
+ */
+function specWith(overrides: Partial<ServiceSpec> = {}): ServiceSpec {
+  return {
+    label: 'co.goondocks.myco',
+    variant: 'prod',
+    executable: '/Users/test/.local/bin/myco',
+    args: ['daemon'],
+    workingDir: '/Users/test/.myco',
+    env: { MYCO_HOME: '/Users/test/.myco' },
+    stdoutPath: '/Users/test/.myco/service/logs/daemon.out.log',
+    stderrPath: '/Users/test/.myco/service/logs/daemon.err.log',
+    runAtLoad: true,
+    keepAlive: true,
+    throttleSeconds: 10,
+    ...overrides,
+  };
+}
+
+describe('restart-policy parity (restart-on-failure only)', () => {
+  test('launchd: KeepAlive is SuccessfulExit=false, not a bare <true/>', () => {
+    const plist = renderLaunchdPlist(specWith());
+    expect(plist).toContain('<key>SuccessfulExit</key>');
+    expect(plist).toContain('<false/>');
+    // The bare form respawns even a clean exit(0) — the loop trigger.
+    expect(plist).not.toMatch(/<key>KeepAlive<\/key>\s*<true\/>/);
+  });
+
+  test('systemd: Restart=on-failure, never always', () => {
+    const unit = renderSystemdUnit(specWith());
+    expect(unit).toContain('Restart=on-failure');
+    expect(unit).not.toContain('Restart=always');
+  });
+
+  test('windows: stops on clean exit(0), restarts on a non-zero code', () => {
+    const script = renderWindowsServiceScript(specWith());
+    expect(script).toContain('if %errorlevel% equ 0 goto myco_done'); // exit 0 → stop
+    expect(script).toContain('goto myco_run');                        // non-zero → retry
+  });
+
+  test('none supervise when keepAlive=false', () => {
+    const off = { keepAlive: false } as const;
+    expect(renderLaunchdPlist(specWith(off))).not.toContain('<key>KeepAlive</key>');
+    expect(renderSystemdUnit(specWith(off))).toContain('Restart=no');
+    expect(renderWindowsServiceScript(specWith(off))).not.toContain(':myco_run');
+  });
+});

--- a/tests/service/windows.test.ts
+++ b/tests/service/windows.test.ts
@@ -60,8 +60,9 @@ describe('renderWindowsServiceScript', () => {
     expect(out.startsWith('@echo off')).toBe(true);
     expect(out).toContain(`set "MYCO_HOME=${spec.env.MYCO_HOME}"`);
     expect(out).toContain('set "MYCO_SERVICE_VARIANT=dev"');
-    // The service-managed marker: restart detection reads this (schtasks gives no PID).
-    expect(out).toContain(`set "MYCO_SERVICE_MANAGED=${spec.label}"`);
+    // Restart routing keys on the installed task (resolveRestartServiceLabel),
+    // so the launcher no longer needs to export a pid-substitute marker.
+    expect(out).not.toContain('MYCO_SERVICE_MANAGED');
     expect(out).not.toContain('set "PATH='); // POSIX PATH is meaningless on Windows — inherit the user's
     expect(out).toContain(`cd /d "${spec.workingDir}"`);
     expect(out).toContain(`"${spec.executable}" daemon >> "${spec.stdoutPath}" 2>> "${spec.stderrPath}"`);
@@ -81,22 +82,6 @@ describe('renderWindowsServiceScript', () => {
     const out = renderWindowsServiceScript(makeSpec({ keepAlive: false }));
     expect(out).not.toContain(':myco_run');
     expect(out).toContain('daemon >>');
-  });
-
-  test('isManagedDaemon reads the MYCO_SERVICE_MANAGED marker, not a PID (schtasks has none)', () => {
-    const mgr = new WindowsTaskServiceManager({ runner: new StubRunner(), scriptDir: tmp('myco-wt-') });
-    const status = { installed: true, running: true, pid: null, lastExitCode: null, unitPath: null };
-    const prev = process.env.MYCO_SERVICE_MANAGED;
-    try {
-      process.env.MYCO_SERVICE_MANAGED = 'co.goondocks.myco-dev';
-      // Matches the marker regardless of the (null) PID; rejects a different label.
-      expect(mgr.isManagedDaemon('co.goondocks.myco-dev', status, 999)).toBe(true);
-      expect(mgr.isManagedDaemon('co.goondocks.myco', status, 999)).toBe(false);
-      delete process.env.MYCO_SERVICE_MANAGED;
-      expect(mgr.isManagedDaemon('co.goondocks.myco-dev', status, 999)).toBe(false);
-    } finally {
-      if (prev === undefined) delete process.env.MYCO_SERVICE_MANAGED; else process.env.MYCO_SERVICE_MANAGED = prev;
-    }
   });
 });
 

--- a/tests/upgrade/orchestrator.test.ts
+++ b/tests/upgrade/orchestrator.test.ts
@@ -58,6 +58,8 @@ interface AdoptRecorder {
 
 interface AdoptRecorderOpts {
   healthSequence?: Array<{ version?: string } | null>;
+  /** Version the daemon.json cross-check reports (null = absent/stale). */
+  daemonState?: { version?: string } | null;
   stopConfirmed?: boolean;
   adoptThrows?: Error;
   platform?: NodeJS.Platform;
@@ -98,6 +100,7 @@ function makeAdoptDeps(opts: AdoptRecorderOpts = {}): AdoptRecorder {
     probeHealth: vi.fn(async () => {
       return healthQueue.length > 0 ? healthQueue.shift()! : null;
     }),
+    probeDaemonState: vi.fn(() => opts.daemonState ?? null),
     sleep: vi.fn(async () => {}),
     adoptStaged: vi.fn(async (params: { version: string }) => {
       rec.adoptCalls.push({ version: params.version });
@@ -304,6 +307,23 @@ describe('runAdopt — crash-loop (health never reaches target → restore + res
     expect(rec.restoreCalls).toEqual([]);
     expect(rec.restartCount).toBe(1);
     expect(rec.pruneCalls.length).toBe(1);
+  });
+
+  it('FLAKY-PROBE RESCUE: /health stays dark but daemon.json shows the target → success, no rollback', async () => {
+    // The actual root cause of the manual-button rollback: a healthy new daemon
+    // whose HTTP /health probe flakes for the entire watch (seen live: /health
+    // served the target for 100+s while the orchestrator's probe got null). The
+    // daemon.json cross-check (recorded version + live pid) must confirm the adopt
+    // instead of rolling back a demonstrably-running new version.
+    const rec = makeAdoptDeps({
+      healthSequence: [null, null, null], // HTTP probe dead the whole window
+      daemonState: { version: '1.2.3' },  // but the daemon recorded the target
+    });
+    await run([writeParamsFile(makeParams())], rec.deps);
+
+    expect(rec.restoreCalls).toEqual([]);  // NO rollback
+    expect(rec.restartCount).toBe(1);       // landed on attempt 1 via daemon-state
+    expect(rec.pruneCalls.length).toBe(1);  // success path
   });
 
   it('CONVERGENCE: first restart never reaches target, a retried restart does → success, no restore', async () => {

--- a/tests/upgrade/orchestrator.test.ts
+++ b/tests/upgrade/orchestrator.test.ts
@@ -239,13 +239,16 @@ describe('runAdopt — crash-loop (health never reaches target → restore + res
     expect(rec.restoreCalls).toEqual([{ version: '1.1.0' }]);
   });
 
-  it('restarts twice: once for the new binary, once after restore', async () => {
+  it('restarts ADOPT_RESTART_ATTEMPTS times before giving up, then once after restore', async () => {
+    // Convergence retry: a single failed restart is retried before rolling back,
+    // so a genuinely-unhealthy binary is restarted twice (2 attempts) and then
+    // once more on the restored prev version = 3 total.
     const rec = makeAdoptDeps({
       healthSequence: [null, null, null],
     });
     await run([writeParamsFile(makeParams())], rec.deps);
 
-    expect(rec.restartCount).toBe(2);
+    expect(rec.restartCount).toBe(3);
   });
 
   it('writes the error side-channel describing the rollback', async () => {
@@ -286,7 +289,8 @@ describe('runAdopt — crash-loop (health never reaches target → restore + res
     await run([writeParamsFile(makeParams())], rec.deps);
 
     expect(rec.restoreCalls).toEqual([{ version: '1.1.0' }]);
-    expect(rec.restartCount).toBe(2);
+    // 2 adopt restart attempts + 1 restore restart.
+    expect(rec.restartCount).toBe(3);
   });
 
   it('reaches target on a later attempt (after some nulls) → success, no restore', async () => {
@@ -298,6 +302,23 @@ describe('runAdopt — crash-loop (health never reaches target → restore + res
     expect(rec.restoreCalls).toEqual([]);
     expect(rec.restartCount).toBe(1);
     expect(rec.pruneCalls.length).toBe(1);
+  });
+
+  it('CONVERGENCE: first restart never reaches target, a retried restart does → success, no restore', async () => {
+    // The manual one-shot apply and the idle auto-adopt both flow through here;
+    // this proves a single transient restart failure (e.g. a respawn racing the
+    // restart) converges via the bounded retry instead of rolling back — so the
+    // manual button lands without waiting for the idle auto-adopt to re-try.
+    // First health-watch (maxHealthAttempts=3) sees only nulls; the SECOND
+    // restart's health-watch reports the target on its first probe.
+    const rec = makeAdoptDeps({
+      healthSequence: [null, null, null, { version: '1.2.3' }],
+    });
+    await run([writeParamsFile(makeParams({ maxHealthAttempts: 3 }))], rec.deps);
+
+    expect(rec.restoreCalls).toEqual([]);       // no rollback
+    expect(rec.restartCount).toBe(2);           // attempt 1 + attempt 2 (which succeeds)
+    expect(rec.pruneCalls.length).toBe(1);      // success path pruned
   });
 });
 
@@ -318,7 +339,7 @@ describe('runAdopt — non-service (serviceManagedLabel:null) CR-1 guarantees', 
     expect(spawnedBin).toBe(params.mycoBinary);
   });
 
-  it('crash-loop: still restarts twice (once for new binary, once after restore) — never strands DOWN', async () => {
+  it('crash-loop: restarts on every attempt then once after restore — never strands DOWN', async () => {
     const sentinelPath = path.join(tmpDir, 'update.in-progress');
     fs.writeFileSync(sentinelPath, JSON.stringify({
       targetVersion: '1.2.3', startedAt: Date.now(), initiator: 'api/update/apply',
@@ -327,8 +348,9 @@ describe('runAdopt — non-service (serviceManagedLabel:null) CR-1 guarantees', 
     const rec = makeAdoptDeps({ healthSequence: [null, null, null] });
     await run([writeParamsFile(makeParams({ serviceManagedLabel: null, inProgressSentinelPath: sentinelPath }))], rec.deps);
 
-    // Must have restarted twice — the daemon NEVER stays down on non-service.
-    expect(rec.restartCount).toBe(2);
+    // ADOPT_RESTART_ATTEMPTS (2) restart attempts + 1 restore restart = 3 — the
+    // daemon NEVER stays down on the non-service path.
+    expect(rec.restartCount).toBe(3);
     expect(rec.restoreCalls).toEqual([{ version: '1.1.0' }]);
     // clearSentinel is unconditional — must fire on the non-service path too (CR-1).
     expect(fs.existsSync(sentinelPath)).toBe(false);

--- a/tests/upgrade/orchestrator.test.ts
+++ b/tests/upgrade/orchestrator.test.ts
@@ -143,6 +143,8 @@ function makeParams(overrides: Partial<ApplyAdoptParams> = {}): ApplyAdoptParams
     projectRoot: '/home/user/project',
     maxHealthAttempts: 3,
     healthIntervalMs: 5,
+    // Keep the adopt-event side-channel hermetic (default is machine-global).
+    updateEventsPath: path.join(tmpDir, 'update-events.jsonl'),
     ...overrides,
   };
 }

--- a/tests/upgrade/update-events.test.ts
+++ b/tests/upgrade/update-events.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { appendUpdateEvent, drainUpdateEvents } from '@myco/upgrade/update-events.js';
+
+let tmpDir: string;
+let eventsPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'update-events-test-'));
+  eventsPath = path.join(tmpDir, 'sub', 'update-events.jsonl'); // sub/ tests mkdir
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('update-events side-channel', () => {
+  it('append → drain returns events in order, then deletes the file', () => {
+    appendUpdateEvent(eventsPath, 'info', 'adopt started', { from: '1.0.0', to: '1.1.0' });
+    appendUpdateEvent(eventsPath, 'warn', 'health-watch did not reach target', { last_seen_version: '1.0.0' });
+    appendUpdateEvent(eventsPath, 'error', 'rollback applied', { restored: '1.0.0' });
+
+    const events = drainUpdateEvents(eventsPath);
+    expect(events.map((e) => [e.level, e.message])).toEqual([
+      ['info', 'adopt started'],
+      ['warn', 'health-watch did not reach target'],
+      ['error', 'rollback applied'],
+    ]);
+    expect(events[1].data).toEqual({ last_seen_version: '1.0.0' });
+    // Drained = deleted, so a second drain is empty.
+    expect(fs.existsSync(eventsPath)).toBe(false);
+    expect(drainUpdateEvents(eventsPath)).toEqual([]);
+  });
+
+  it('drain returns [] when the file is absent', () => {
+    expect(drainUpdateEvents(eventsPath)).toEqual([]);
+  });
+
+  it('skips malformed lines without dropping the valid ones', () => {
+    fs.mkdirSync(path.dirname(eventsPath), { recursive: true });
+    fs.writeFileSync(
+      eventsPath,
+      'not json\n' +
+        JSON.stringify({ ts: '2026-01-01T00:00:00Z', level: 'info', message: 'kept' }) + '\n' +
+        JSON.stringify({ level: 'info' }) + '\n', // no message → skipped
+    );
+    const events = drainUpdateEvents(eventsPath);
+    expect(events.map((e) => e.message)).toEqual(['kept']);
+  });
+
+  it('append never throws even when the path is unwritable', () => {
+    // Point at a path whose parent is a FILE, so mkdir/append fail internally.
+    const blocked = path.join(tmpDir, 'afile');
+    fs.writeFileSync(blocked, 'x');
+    expect(() => appendUpdateEvent(path.join(blocked, 'nope.jsonl'), 'info', 'x')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Heal the launchd respawn loop and make self-update converge

This branch fixes two related classes of daemon-lifecycle failure that surfaced
while validating v1.2.0 upgrades on macOS, and hardens the self-update path so a
healthy upgrade can no longer be rolled back by a transient probe failure. Every
fix was reproduced and then re-validated live on this machine's production
instance, driven through the real UI upgrade button on the beta channel.

### Root causes fixed

**1. launchd respawn loop + adopt-detached daemon** (`ad10bda5`)
- `KeepAlive` was an unconditional `true`, so launchd respawned the daemon on
  *every* exit — including the clean exit an adopt performs to restart onto a new
  binary. The orchestrator's detached child would bring up the new version while
  launchd simultaneously relaunched the old one. Switched to
  `KeepAlive = { SuccessfulExit: false }` (respawn only on *unsuccessful* exit) —
  the macOS parity of systemd `Restart=on-failure` and the Windows
  `errorlevel equ 0 -> stop` guard, now covered by a restart-policy-parity test.
- Restart routing keyed on PID identity, so a detached adopt child wasn't
  recognized as service-managed and restarts went to the wrong path. Re-keyed
  `resolveRestartServiceLabel` / `findInstalledServiceLabel` on plist
  **existence**, not pid-identity.
- `install()` now force re-bootstraps (`bootout`+`bootstrap`) even when the plist
  is byte-identical, so a policy change actually takes effect; `pruneSupersededUnits`
  removes only dead-target units. Added a `service reconcile` CLI action and a
  guarded autonomous `SERVICE_RECONCILE` job, both fenced by
  `assertSafeServiceMutation`.

**2. Manual upgrade button rolled back where auto-adopt didn't** (`de30ee8e`)
- The manual button and auto-adopt share one code path, but the restart could
  land a beat before the new daemon finished claiming the port, and the watch
  gave up after a single attempt. Added an `ADOPT_RESTART_ATTEMPTS = 2`
  convergence loop around restart + health-watch so the button matches auto-adopt.

**3. The ultimate root cause — single-signal health-watch** (`d653c26f`)
- Even after convergence, the adopt occasionally rolled a *healthy* daemon back.
  The health-watch trusted a single signal: an HTTP `/health` probe. Under launchd
  `ThrottleInterval` back-pressure the restarted daemon serves `/health` fine, but
  the orchestrator's own probe can flake for the whole watch window (proven live:
  the probe returned `null` for 120s while `/health` served the target version
  healthily for 108s — then the watch "failed" and restored the old binary).
- Made the watch **multi-signal**: it now also reads `daemon.json` and confirms
  the recorded version with a live `process.kill(pid, 0)` liveness check. Either
  signal confirming = success. Hardened the HTTP probe (`connection: close`,
  4s timeout). The watch now reports *which* signal confirmed (`via`).

**4. Observability — the adopt is now visible in the log viewer** (`4f7f0cc8`)
- The orchestrator runs in a detached process that outlives the daemon, so its
  narration never reached the log store. Added an `upgrade.adopt` log kind and a
  side-channel: the orchestrator appends structured events to
  `update-events.jsonl`; the daemon drains and re-emits them through the normal
  `DaemonLogger` -> `log_entries` path on next startup (the same pattern as
  `restart-reason.json`). Every adopt now narrates start, cooperative-stop
  confirmation, restart onto target, health outcome (with `last_seen_version` +
  `via`), and success/rollback — all queryable in the log viewer.

### Live validation

Reproduced the rollback on the real prod instance (moved to the beta channel),
then validated the fix end-to-end through the **UI upgrade button** under the same
throttle stress that caused the rollback:

```
target healthy   {attempt:1, target:1.2.1-beta.7, last_seen_version:1.2.1-beta.7, via:"daemon-state"}
adopt succeeded  {version:1.2.1-beta.7, from:1.2.1-beta.6}
final: health=1.2.1-beta.7, error=none   (stable 140s+)
```

`via:"daemon-state"` is the proof: the HTTP probe flaked, and the `daemon.json`
cross-check is exactly what rescued the upgrade instead of rolling it back.

### Tests

New: `tests/upgrade/update-events.test.ts`,
`tests/service/restart-policy-parity.test.ts`, plus a `FLAKY-PROBE RESCUE` and a
`CONVERGENCE` case in `tests/upgrade/orchestrator.test.ts`. Updated restart/upgrade
API, windows-service, and CLI tests for the existence-based routing and the
2-attempt convergence. `make build` green.

Also folds in the skills the vault evolved during this work (a new
`upgrade-path-safety` skill, `native-binary-distribution`, and a refreshed
worktree squash-merge delivery skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
