### PR TITLE
feat(team-sync): heal & prevent D1 mirror drift (membership-gated capture + automatic reconcile)

### DIFF
--- a/packages/myco-team/worker/src/index.ts
+++ b/packages/myco-team/worker/src/index.ts
@@ -15,6 +15,7 @@ import { toCloudSearchResult } from './mcp/result-shape';
 import { searchKnowledge, embedText, MAX_EMBEDDING_TEXT_CHARS, type TeamVectorMetadata } from './search-helpers';
 import { fetchRecord, isAllowedRecordType } from './records';
 import { SYNCED_TABLES, requiresGroveProjectId, stampSyncedAtAtIngestion, type SyncedTable } from './synced-tables';
+import { parseManifestParams, queryManifest } from './manifest';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1728,6 +1729,22 @@ async function handleSyncSummary(request: Request, env: Env): Promise<Response> 
 }
 
 /**
+ * `GET /manifest` — content-addressed drift summary for symmetric reconcile.
+ *
+ * Returns a cheap aggregate (summary=1) or cursor-paged item list for a
+ * (machine_id, table[, project_id]) partition. Purely read-only — no writes
+ * to D1. All reconcile decisions live daemon-side.
+ */
+async function handleManifest(request: Request, env: Env): Promise<Response> {
+  const params = parseManifestParams(new URL(request.url));
+  if ('error' in params) {
+    return errorResponse(params.error, params.status);
+  }
+  const result = await queryManifest(env.MYCO_TEAM_DB, params);
+  return jsonResponse(result);
+}
+
+/**
  * `GET /members` — the team's member roster, synced from every node's
  * local `team_members` rows. Returns the union across all machines so the
  * daemon can render the Members tab for the selected team rather than the
@@ -2124,6 +2141,9 @@ export default {
       }
       if (method === 'GET' && path === '/sync-summary') {
         return await handleSyncSummary(request, env);
+      }
+      if (method === 'GET' && path === '/manifest') {
+        return await handleManifest(request, env);
       }
       if (method === 'GET' && path === '/members') {
         return await handleListMembers(env);

--- a/packages/myco-team/worker/src/manifest.ts
+++ b/packages/myco-team/worker/src/manifest.ts
@@ -5,8 +5,8 @@
  * (machine_id, project_id, table) partition without pulling every row.
  * Two modes:
  *
- *   summary=1  → { count, cheap_agg } — fast aggregate for a coarse
- *                 drift check before deciding whether to page.
+ *   summary=1  → { count } — fast aggregate for a coarse drift check
+ *                 before deciding whether to page.
  *   (default)  → { items, next_cursor? } — cursor-paged { id,
  *                 project_id, content_hash? } for the daemon to diff
  *                 against local state.
@@ -74,7 +74,6 @@ export interface ManifestSummaryResponse {
   machine_id: string;
   project_id?: string;
   count: number;
-  cheap_agg: number;
 }
 
 export interface ManifestItem {
@@ -88,7 +87,6 @@ export interface ManifestPageResponse {
   machine_id: string;
   project_id?: string;
   count: number;
-  cheap_agg: number;
   items: ManifestItem[];
   next_cursor?: string;
 }
@@ -142,20 +140,19 @@ export async function queryManifest(
 
   if (summary) {
     const sql = projectId
-      ? `SELECT COUNT(*) AS count, MAX(rowid) AS cheap_agg FROM ${table} WHERE machine_id = ? AND project_id = ?`
-      : `SELECT COUNT(*) AS count, MAX(rowid) AS cheap_agg FROM ${table} WHERE machine_id = ?`;
+      ? `SELECT COUNT(*) AS count FROM ${table} WHERE machine_id = ? AND project_id = ?`
+      : `SELECT COUNT(*) AS count FROM ${table} WHERE machine_id = ?`;
 
     const row = await (projectId
       ? db.prepare(sql).bind(machineId, projectId)
       : db.prepare(sql).bind(machineId)
-    ).first<{ count: number; cheap_agg: number | null }>();
+    ).first<{ count: number }>();
 
     return {
       table,
       machine_id: machineId,
       ...(projectId != null ? { project_id: projectId } : {}),
       count: Number(row?.count ?? 0),
-      cheap_agg: Number(row?.cheap_agg ?? 0),
     };
   }
 
@@ -179,22 +176,21 @@ export async function queryManifest(
   const items = hasMore ? allItems.slice(0, limit) : allItems;
   const nextCursor = hasMore ? String(items[items.length - 1].id) : undefined;
 
-  // Also fetch count + cheap_agg for the summary fields.
+  // Also fetch count for the summary field on paged responses.
   const aggSql = projectId
-    ? `SELECT COUNT(*) AS count, MAX(rowid) AS cheap_agg FROM ${table} WHERE machine_id = ? AND project_id = ?`
-    : `SELECT COUNT(*) AS count, MAX(rowid) AS cheap_agg FROM ${table} WHERE machine_id = ?`;
+    ? `SELECT COUNT(*) AS count FROM ${table} WHERE machine_id = ? AND project_id = ?`
+    : `SELECT COUNT(*) AS count FROM ${table} WHERE machine_id = ?`;
 
   const aggRow = await (projectId
     ? db.prepare(aggSql).bind(machineId, projectId)
     : db.prepare(aggSql).bind(machineId)
-  ).first<{ count: number; cheap_agg: number | null }>();
+  ).first<{ count: number }>();
 
   return {
     table,
     machine_id: machineId,
     ...(projectId != null ? { project_id: projectId } : {}),
     count: Number(aggRow?.count ?? 0),
-    cheap_agg: Number(aggRow?.cheap_agg ?? 0),
     items,
     ...(nextCursor !== undefined ? { next_cursor: nextCursor } : {}),
   };

--- a/packages/myco-team/worker/src/manifest.ts
+++ b/packages/myco-team/worker/src/manifest.ts
@@ -160,21 +160,45 @@ export async function queryManifest(
   const hasContentHash = WORKER_CONTENT_HASH_TABLES.has(table);
   const projection = hasContentHash ? 'id, project_id, content_hash' : 'id, project_id';
 
-  const cursorId = cursor ?? '';
+  // The `AND id > ?` cursor filter is applied ONLY when a real cursor is
+  // present. The FIRST page (no/empty cursor) omits it entirely.
+  //
+  // Why: SQLite/D1 sorts NULL < INTEGER/REAL < TEXT, and `id > ?` applies the
+  // id column's affinity to the bound param. An empty-string cursor ('') is not
+  // a valid number, so it stays TEXT — making `id > ''` FALSE for EVERY
+  // integer id (integer < text). Tables with an INTEGER id (prompt_batches,
+  // knowledge_release_state, ...) would then return zero items on the first
+  // page while still reporting the correct count. On later pages the cursor is
+  // a concrete id whose affinity-converted value compares correctly for both
+  // integer and text ids, so the clause is safe there. Do NOT "simplify" this
+  // back to an always-on `id > ?` with an empty-string default.
+  const hasCursor = cursor != null && cursor !== '';
 
-  const sql = projectId
-    ? `SELECT ${projection} FROM ${table} WHERE machine_id = ? AND project_id = ? AND id > ? ORDER BY id LIMIT ?`
-    : `SELECT ${projection} FROM ${table} WHERE machine_id = ? AND id > ? ORDER BY id LIMIT ?`;
+  const whereParts = ['machine_id = ?'];
+  const bindValues: unknown[] = [machineId];
+  if (projectId) {
+    whereParts.push('project_id = ?');
+    bindValues.push(projectId);
+  }
+  if (hasCursor) {
+    whereParts.push('id > ?');
+    bindValues.push(cursor);
+  }
+  bindValues.push(limit + 1);
 
-  const rows = await (projectId
-    ? db.prepare(sql).bind(machineId, projectId, cursorId, limit + 1)
-    : db.prepare(sql).bind(machineId, cursorId, limit + 1)
-  ).all<ManifestItem>();
+  const sql = `SELECT ${projection} FROM ${table} WHERE ${whereParts.join(' AND ')} ORDER BY id LIMIT ?`;
+
+  const rows = await db.prepare(sql).bind(...bindValues).all<ManifestItem>();
 
   const allItems = rows.results ?? [];
   const hasMore = allItems.length > limit;
-  const items = hasMore ? allItems.slice(0, limit) : allItems;
-  const nextCursor = hasMore ? String(items[items.length - 1].id) : undefined;
+  const page = hasMore ? allItems.slice(0, limit) : allItems;
+  // D1 returns INTEGER id columns as JS numbers. Coerce every id to a string so
+  // the wire shape is type-stable and the daemon diff compares like-typed ids
+  // against its (already-stringified) local partition. String(uuid) === uuid,
+  // so text-id tables are unaffected.
+  const items = page.map((row) => ({ ...row, id: String(row.id) }));
+  const nextCursor = hasMore ? items[items.length - 1].id : undefined;
 
   // Also fetch count for the summary field on paged responses.
   const aggSql = projectId

--- a/packages/myco-team/worker/src/manifest.ts
+++ b/packages/myco-team/worker/src/manifest.ts
@@ -1,0 +1,201 @@
+/**
+ * GET /manifest — content-addressed drift summary for symmetric reconcile.
+ *
+ * Allows the daemon to cheaply diff local vs cloud state per
+ * (machine_id, project_id, table) partition without pulling every row.
+ * Two modes:
+ *
+ *   summary=1  → { count, cheap_agg } — fast aggregate for a coarse
+ *                 drift check before deciding whether to page.
+ *   (default)  → { items, next_cursor? } — cursor-paged { id,
+ *                 project_id, content_hash? } for the daemon to diff
+ *                 against local state.
+ *
+ * This endpoint is purely READ-ONLY. All reconcile decisions live
+ * daemon-side in later tasks.
+ */
+
+import { SYNCED_TABLES } from './synced-tables';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Tables that carry a `content_hash` column. Verified against schema.ts:
+ * sessions, prompt_batches, spores, and plans each have `content_hash TEXT`
+ * in their CREATE TABLE statement. All other synced tables do not.
+ *
+ * The parity assertion in manifest.test.ts keeps this constant honest:
+ * it checks each member against the schema DDL so adding/removing
+ * content_hash from a table is caught immediately.
+ */
+export const WORKER_CONTENT_HASH_TABLES = new Set<string>([
+  'sessions',
+  'prompt_batches',
+  'spores',
+  'plans',
+]);
+
+/**
+ * Tables eligible for manifest reconcile: synced tables that have a
+ * single `id` column (primary key). `entity_mentions` is excluded
+ * because its primary key is composite (entity_id, note_id, note_type,
+ * agent_id) — there is no single `id` to cursor-page on.
+ */
+export const MANIFEST_ELIGIBLE_TABLES = new Set<string>(
+  SYNCED_TABLES.filter((t) => t !== 'entity_mentions'),
+);
+
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 1000;
+
+// ---------------------------------------------------------------------------
+// Public interface (D1Database subset — avoids importing the Workers runtime)
+// ---------------------------------------------------------------------------
+
+/** Minimal D1Database surface the manifest handler needs. */
+export interface ManifestDb {
+  prepare(sql: string): ManifestStmt;
+}
+
+interface ManifestStmt {
+  bind(...values: unknown[]): ManifestStmt;
+  first<T = unknown>(): Promise<T | null>;
+  all<T = unknown>(): Promise<{ results: T[] }>;
+}
+
+// ---------------------------------------------------------------------------
+// Response shapes
+// ---------------------------------------------------------------------------
+
+export interface ManifestSummaryResponse {
+  table: string;
+  machine_id: string;
+  project_id?: string;
+  count: number;
+  cheap_agg: number;
+}
+
+export interface ManifestItem {
+  id: string;
+  project_id: string | null;
+  content_hash?: string | null;
+}
+
+export interface ManifestPageResponse {
+  table: string;
+  machine_id: string;
+  project_id?: string;
+  count: number;
+  cheap_agg: number;
+  items: ManifestItem[];
+  next_cursor?: string;
+}
+
+export type ManifestResponse = ManifestSummaryResponse | ManifestPageResponse;
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export interface ManifestParams {
+  machineId: string;
+  table: string;
+  projectId: string | null;
+  cursor: string | null;
+  limit: number;
+  summary: boolean;
+}
+
+export function parseManifestParams(url: URL): ManifestParams | { error: string; status: number } {
+  const sp = url.searchParams;
+  const machineId = sp.get('machine_id')?.trim() ?? '';
+  if (!machineId) {
+    return { error: 'machine_id is required', status: 400 };
+  }
+
+  const table = sp.get('table')?.trim() ?? '';
+  if (!table) {
+    return { error: 'table is required', status: 400 };
+  }
+  if (!MANIFEST_ELIGIBLE_TABLES.has(table)) {
+    return { error: `Unknown or ineligible table: ${table}`, status: 400 };
+  }
+
+  const projectId = sp.get('project_id')?.trim() || null;
+  const cursor = sp.get('cursor')?.trim() || null;
+  const rawLimit = parseInt(sp.get('limit') ?? '', 10);
+  const limit = Number.isFinite(rawLimit) && rawLimit > 0
+    ? Math.min(rawLimit, MAX_LIMIT)
+    : DEFAULT_LIMIT;
+  const summary = sp.get('summary') === '1';
+
+  return { machineId, table, projectId, cursor, limit, summary };
+}
+
+export async function queryManifest(
+  db: ManifestDb,
+  params: ManifestParams,
+): Promise<ManifestResponse> {
+  const { machineId, table, projectId, cursor, limit, summary } = params;
+
+  if (summary) {
+    const sql = projectId
+      ? `SELECT COUNT(*) AS count, MAX(rowid) AS cheap_agg FROM ${table} WHERE machine_id = ? AND project_id = ?`
+      : `SELECT COUNT(*) AS count, MAX(rowid) AS cheap_agg FROM ${table} WHERE machine_id = ?`;
+
+    const row = await (projectId
+      ? db.prepare(sql).bind(machineId, projectId)
+      : db.prepare(sql).bind(machineId)
+    ).first<{ count: number; cheap_agg: number | null }>();
+
+    return {
+      table,
+      machine_id: machineId,
+      ...(projectId != null ? { project_id: projectId } : {}),
+      count: Number(row?.count ?? 0),
+      cheap_agg: Number(row?.cheap_agg ?? 0),
+    };
+  }
+
+  // Paged query: select id, project_id, and optionally content_hash.
+  const hasContentHash = WORKER_CONTENT_HASH_TABLES.has(table);
+  const projection = hasContentHash ? 'id, project_id, content_hash' : 'id, project_id';
+
+  const cursorId = cursor ?? '';
+
+  const sql = projectId
+    ? `SELECT ${projection} FROM ${table} WHERE machine_id = ? AND project_id = ? AND id > ? ORDER BY id LIMIT ?`
+    : `SELECT ${projection} FROM ${table} WHERE machine_id = ? AND id > ? ORDER BY id LIMIT ?`;
+
+  const rows = await (projectId
+    ? db.prepare(sql).bind(machineId, projectId, cursorId, limit + 1)
+    : db.prepare(sql).bind(machineId, cursorId, limit + 1)
+  ).all<ManifestItem>();
+
+  const allItems = rows.results ?? [];
+  const hasMore = allItems.length > limit;
+  const items = hasMore ? allItems.slice(0, limit) : allItems;
+  const nextCursor = hasMore ? String(items[items.length - 1].id) : undefined;
+
+  // Also fetch count + cheap_agg for the summary fields.
+  const aggSql = projectId
+    ? `SELECT COUNT(*) AS count, MAX(rowid) AS cheap_agg FROM ${table} WHERE machine_id = ? AND project_id = ?`
+    : `SELECT COUNT(*) AS count, MAX(rowid) AS cheap_agg FROM ${table} WHERE machine_id = ?`;
+
+  const aggRow = await (projectId
+    ? db.prepare(aggSql).bind(machineId, projectId)
+    : db.prepare(aggSql).bind(machineId)
+  ).first<{ count: number; cheap_agg: number | null }>();
+
+  return {
+    table,
+    machine_id: machineId,
+    ...(projectId != null ? { project_id: projectId } : {}),
+    count: Number(aggRow?.count ?? 0),
+    cheap_agg: Number(aggRow?.cheap_agg ?? 0),
+    items,
+    ...(nextCursor !== undefined ? { next_cursor: nextCursor } : {}),
+  };
+}

--- a/packages/myco-team/worker/wrangler.toml
+++ b/packages/myco-team/worker/wrangler.toml
@@ -8,8 +8,11 @@ compatibility_flags = [ "nodejs_compat", "global_fetch_strictly_public" ]
 
 [vars]
 # See packages/myco/src/constants.ts SYNC_PROTOCOL_VERSION /
-# MIN_COMPAT_CLIENT_VERSION — these MUST stay in lockstep. Worker
-# code reads these as strings and parseInt's them at request time.
+# MIN_COMPAT_CLIENT_VERSION. The worker's advertised version may lead
+# the daemon's claimed version (worker=3, daemon claims 2). Clients
+# are accepted when MIN_COMPAT_CLIENT_VERSION <= client_version <=
+# SYNC_PROTOCOL_VERSION. Worker code reads these as strings and
+# parseInt's them at request time.
 SYNC_PROTOCOL_VERSION = "3"
 MIN_COMPAT_CLIENT_VERSION = "1"
 MYCO_TEAM_PACKAGE_VERSION = "<MYCO_TEAM_PACKAGE_VERSION>"

--- a/packages/myco-team/worker/wrangler.toml
+++ b/packages/myco-team/worker/wrangler.toml
@@ -10,7 +10,7 @@ compatibility_flags = [ "nodejs_compat", "global_fetch_strictly_public" ]
 # See packages/myco/src/constants.ts SYNC_PROTOCOL_VERSION /
 # MIN_COMPAT_CLIENT_VERSION — these MUST stay in lockstep. Worker
 # code reads these as strings and parseInt's them at request time.
-SYNC_PROTOCOL_VERSION = "2"
+SYNC_PROTOCOL_VERSION = "3"
 MIN_COMPAT_CLIENT_VERSION = "1"
 MYCO_TEAM_PACKAGE_VERSION = "<MYCO_TEAM_PACKAGE_VERSION>"
 MYCO_SCHEMA_VERSION = "<MYCO_SCHEMA_VERSION>"

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -2099,20 +2099,19 @@ export async function main(): Promise<void> {
     const result = await teamSync.rebuildFromLocal(req.requestContext);
     return { status: result.error ? 502 : 200, body: { ok: !result.error, ...result } };
   });
-  // POST /api/team/reconcile — operator-confirmed symmetric reconcile. Runs the
-  // count-first reconcile across every owned (grove, project) partition with
-  // operatorConfirmed=true: the settledness guards (empty local set, unseeded
-  // membership) still block, but the magnitude caps (per-partition floor,
-  // fraction, aggregate) are bypassed so an operator can heal large genuine
-  // drift the automatic path leaves for a human. The automatic path runs
-  // continuously via reconcileClient triggers + the team-sync-reconcile backstop.
+  // POST /api/team/reconcile — on-demand symmetric reconcile. An immediacy
+  // trigger only: it runs the SAME fully-automatic full-diff reconcile across
+  // every owned (grove, project) partition that the periodic backstop runs, just
+  // now instead of on the next tick. There is no operator power — deletes are
+  // bounded by settledness + cross-pass drift stability inside reconcilePartition
+  // (an orphan must persist across two passes before it is deleted), so a single
+  // on-demand pass heals only drift already observed on a prior pass.
   server.registerRoute('POST', '/api/team/reconcile', async (req) => {
-    // Operator pass once, over every owned grove. We do NOT also call
-    // reconcileTeamRoute(req) here — that would run a redundant automatic pass
-    // over the request grove on top of the operator fan-out below. Targeting a
-    // single grove instead of the all-groves fan-out is future UI work.
-    const result = await teamSync.reconcileAllGroves(runtimeCache, true);
-    return { status: 200, body: { ok: true, deletes: result.deletes } };
+    // One pass over every owned grove. We do NOT also call reconcileTeamRoute(req)
+    // here — that would run a redundant pass over the request grove on top of the
+    // all-groves fan-out below. Targeting a single grove is future UI work.
+    await teamSync.reconcileAllGroves(runtimeCache);
+    return { status: 200, body: { ok: true } };
   });
 
   const collectiveHandlers = createCollectiveHandlers({

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -2107,7 +2107,10 @@ export async function main(): Promise<void> {
   // drift the automatic path leaves for a human. The automatic path runs
   // continuously via reconcileClient triggers + the team-sync-reconcile backstop.
   server.registerRoute('POST', '/api/team/reconcile', async (req) => {
-    await reconcileTeamRoute(req);
+    // Operator pass once, over every owned grove. We do NOT also call
+    // reconcileTeamRoute(req) here — that would run a redundant automatic pass
+    // over the request grove on top of the operator fan-out below. Targeting a
+    // single grove instead of the all-groves fan-out is future UI work.
     const result = await teamSync.reconcileAllGroves(runtimeCache, true);
     return { status: 200, body: { ok: true, deletes: result.deletes } };
   });

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -2099,6 +2099,18 @@ export async function main(): Promise<void> {
     const result = await teamSync.rebuildFromLocal(req.requestContext);
     return { status: result.error ? 502 : 200, body: { ok: !result.error, ...result } };
   });
+  // POST /api/team/reconcile — operator-confirmed symmetric reconcile. Runs the
+  // count-first reconcile across every owned (grove, project) partition with
+  // operatorConfirmed=true: the settledness guards (empty local set, unseeded
+  // membership) still block, but the magnitude caps (per-partition floor,
+  // fraction, aggregate) are bypassed so an operator can heal large genuine
+  // drift the automatic path leaves for a human. The automatic path runs
+  // continuously via reconcileClient triggers + the team-sync-reconcile backstop.
+  server.registerRoute('POST', '/api/team/reconcile', async (req) => {
+    await reconcileTeamRoute(req);
+    const result = await teamSync.reconcileAllGroves(runtimeCache, true);
+    return { status: 200, body: { ok: true, deletes: result.deletes } };
+  });
 
   const collectiveHandlers = createCollectiveHandlers({
     getTeamClient: () => teamSync.getTeamClient(),

--- a/packages/myco/src/daemon/team-reconcile.ts
+++ b/packages/myco/src/daemon/team-reconcile.ts
@@ -109,3 +109,133 @@ export function diffPartition(
 
   return { upsertIds, deleteIds, staleIds };
 }
+
+// ---------------------------------------------------------------------------
+// Delete-safety gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Maximum per-partition deletes the AUTOMATIC reconcile path may apply in one
+ * pass. Chosen as 50: large enough to heal genuine bulk-drift (e.g. a restore
+ * that wiped a few dozen rows) without approaching the scale of a full-
+ * partition wipe on any realistic team dataset. `== floor` is allowed;
+ * `> floor` requires operator confirmation.
+ */
+export const MIN_ABSOLUTE_DELETE_FLOOR = 50;
+
+/**
+ * Maximum fraction of the D1 partition the AUTOMATIC path may delete in one
+ * pass. 0.2 (20%) bounds blast radius relative to partition size while still
+ * allowing meaningful drift healing. Values above 0.2 would let a 300-row
+ * partition lose 60+ rows automatically — closer to a wipe than drift repair.
+ */
+export const MAX_DELETE_FRACTION = 0.2;
+
+/**
+ * Per-pass cap across ALL partitions. Set to 4× the per-partition floor so
+ * N partitions each under the floor cannot SUM to an unbounded wipe across
+ * the full reconcile pass. 200 allows roughly 4 fully-drifted partitions to
+ * heal in one pass while still bounding the worst-case aggregate.
+ */
+export const MAX_PASS_AGGREGATE_DELETES = 200;
+
+/** Inputs to the delete-safety gate. */
+export interface DeleteSafetyInput {
+  /** Number of rows in the local (authoritative) partition. */
+  localCount: number;
+  /** Number of rows the D1 manifest reports for this partition. */
+  d1Count: number;
+  /** How many D1 rows the current partition diff wants to delete. */
+  partitionDeleteCount: number;
+  /** Running total of delete ops already approved across all partitions in this pass. */
+  passAggregateDeleteCount: number;
+  /**
+   * Whether the team membership registry has been seeded (i.e. the caller
+   * confirmed that `memberProjectIdsForGrove(grove)` returned a non-empty set).
+   * When false the local id-set may not yet reflect actual membership, so no
+   * deletes may proceed.
+   */
+  membershipSeeded: boolean;
+  /**
+   * When true the operator has explicitly confirmed this reconcile, which
+   * bypasses the magnitude caps (floor, fraction, aggregate). Settledness
+   * guards (localCount==0 and membershipSeeded) are NEVER overridable —
+   * an operator confirming does not make not-yet-loaded data trustworthy.
+   */
+  operatorConfirmed: boolean;
+}
+
+/** Result of the delete-safety gate. */
+export interface DeleteSafetyResult {
+  allow: boolean;
+  /** Machine-readable reason when allow===false. */
+  reason?: string;
+}
+
+/**
+ * Evaluate whether a set of delete ops is safe to proceed.
+ *
+ * Guards are evaluated in strict order. The first two are settledness guards
+ * that block unconditionally — even operator confirmation cannot override them,
+ * because no human decision can make a not-yet-loaded local dataset trustworthy.
+ *
+ * Guard order:
+ *   1. localCount===0 && d1Count>0   → not_settled         (unconditional)
+ *   2. !membershipSeeded             → membership_unseeded  (unconditional)
+ *   3. operatorConfirmed             → allow (magnitude caps bypassed)
+ *   4. partitionDeleteCount > floor  → requires_operator
+ *   5. fraction > MAX_DELETE_FRACTION (when d1Count>0) → exceeds_fraction
+ *   6. passAggregateDeleteCount > aggregate cap → exceeds_aggregate
+ *   7. otherwise                     → allow
+ */
+export function evaluateDeleteSafety(input: DeleteSafetyInput): DeleteSafetyResult {
+  const {
+    localCount,
+    d1Count,
+    partitionDeleteCount,
+    passAggregateDeleteCount,
+    membershipSeeded,
+    operatorConfirmed,
+  } = input;
+
+  // Guard 1: transient-empty trap. A reconcile may never wipe a whole
+  // partition, regardless of operator intent — the local set has simply not
+  // loaded yet and cannot be trusted as authoritative.
+  if (localCount === 0 && d1Count > 0) {
+    return { allow: false, reason: 'not_settled' };
+  }
+
+  // Guard 2: membership not yet seeded. Without a populated membership
+  // registry the daemon cannot determine which rows are genuinely absent
+  // locally vs. temporarily invisible due to an unseeded registry.
+  if (!membershipSeeded) {
+    return { allow: false, reason: 'membership_unseeded' };
+  }
+
+  // Guard 3: operator confirmed — settledness already passed above; bypass
+  // all magnitude caps.
+  if (operatorConfirmed) {
+    return { allow: true };
+  }
+
+  // Guard 4: per-partition absolute floor. Deleting more than this many rows
+  // from a single partition in one automatic pass requires a human decision.
+  if (partitionDeleteCount > MIN_ABSOLUTE_DELETE_FLOOR) {
+    return { allow: false, reason: 'requires_operator' };
+  }
+
+  // Guard 5: fraction cap. Even if the count is under the floor, a high
+  // fraction signals the local set diverged from D1 by an unusual proportion.
+  // Skip when d1Count===0 — there are no D1 rows to bound.
+  if (d1Count > 0 && (partitionDeleteCount / d1Count) > MAX_DELETE_FRACTION) {
+    return { allow: false, reason: 'exceeds_fraction' };
+  }
+
+  // Guard 6: per-pass aggregate cap. Prevents N partitions each under the
+  // per-partition floor from summing to an unbounded total wipe.
+  if (passAggregateDeleteCount > MAX_PASS_AGGREGATE_DELETES) {
+    return { allow: false, reason: 'exceeds_aggregate' };
+  }
+
+  return { allow: true };
+}

--- a/packages/myco/src/daemon/team-reconcile.ts
+++ b/packages/myco/src/daemon/team-reconcile.ts
@@ -25,15 +25,27 @@ import type { OutboxInsert, OutboxRow, PartitionRow } from '@myco/db/queries/tea
 // Types
 // ---------------------------------------------------------------------------
 
-/** A local row as returned by `localPartition`. */
+/**
+ * A local row as returned by `localPartition`.
+ *
+ * `id` is `string | number` because integer-id tables (prompt_batches,
+ * knowledge_release_state) surface ids as JS numbers from bun:sqlite. The
+ * comparison in `diffPartition` coerces both sides to strings before matching.
+ */
 export interface LocalRow {
-  id: string;
+  id: string | number;
   content_hash?: string;
 }
 
-/** One item from the worker's GET /manifest response. */
+/**
+ * One item from the worker's GET /manifest response.
+ *
+ * `id` is `string | number` because D1 returns INTEGER id columns as JS
+ * numbers; `diffPartition` normalizes to strings so a number id can never
+ * mis-compare against a stringified local id.
+ */
 export interface ManifestItemLike {
-  id: string;
+  id: string | number;
   content_hash?: string | null;
 }
 
@@ -73,14 +85,19 @@ export function diffPartition(
   local: ReadonlyArray<LocalRow>,
   manifestItems: ReadonlyArray<ManifestItemLike>,
 ): PartitionDiff {
+  // Key both maps — and every returned id — by String(id). D1 returns INTEGER
+  // id columns as JS numbers while the local side (localPartition) stringifies
+  // ids; without this coercion an integer-id table would compare '101' against
+  // 101, miss on every row, and classify EVERY id as a spurious delete/upsert.
+  // For text-id tables String(uuid) === uuid, so this is a no-op there.
   const localMap = new Map<string, string | undefined>();
   for (const row of local) {
-    localMap.set(row.id, row.content_hash);
+    localMap.set(String(row.id), row.content_hash);
   }
 
   const manifestMap = new Map<string, string | null | undefined>();
   for (const item of manifestItems) {
-    manifestMap.set(item.id, item.content_hash);
+    manifestMap.set(String(item.id), item.content_hash);
   }
 
   const upsertIds: string[] = [];
@@ -470,9 +487,11 @@ export async function reconcilePartition(
   // must never target another home's partition. Only consider manifest items
   // whose project_id === projectId as deletable (defense-in-depth on top of the
   // already-strict project-scoped fetch).
+  // Key by String(id) to match diff.deleteIds (which diffPartition stringifies)
+  // — an integer-id table's manifest items arrive as numbers from D1.
   const deletableProjectById = new Map<string, string>();
   for (const item of manifestItems) {
-    if (item.project_id === projectId) deletableProjectById.set(item.id, item.project_id);
+    if (item.project_id === projectId) deletableProjectById.set(String(item.id), item.project_id);
   }
   const deleteCandidates = diff.deleteIds.filter((id) => deletableProjectById.has(id));
 
@@ -539,7 +558,11 @@ export async function reconcilePartition(
       // project_id MUST come from the manifest item — there is no local row to
       // source it from, and the worker's grove-project_id gate 409-rejects
       // deletes lacking project_id. Payload matches the delete-trigger shape:
-      // json_object('id', id, 'machine_id', machine_id).
+      // json_object('id', id, 'machine_id', machine_id). `id` is a string here
+      // (diffPartition stringifies all ids); a string id in the delete payload
+      // still matches an INTEGER D1 row because the worker's `DELETE ... WHERE
+      // id = ?` applies the id column's INTEGER affinity to the bound value, so
+      // '12345' converts to 12345 and matches.
       const manifestProjectId = deletableProjectById.get(id)!;
       deps.enqueueOutbox({
         table_name: table,

--- a/packages/myco/src/daemon/team-reconcile.ts
+++ b/packages/myco/src/daemon/team-reconcile.ts
@@ -1,0 +1,111 @@
+/**
+ * Pure fingerprint + diff logic for symmetric team-sync reconcile.
+ *
+ * Compares a local partition (rows from the SQLite vault) against the D1
+ * manifest (rows the worker knows about) and classifies each id into one of
+ * three buckets:
+ *
+ *   upsertIds — present locally but absent in D1 → daemon must (re-)push.
+ *   deleteIds — present in D1 but absent locally → daemon must delete from D1.
+ *   staleIds  — present in both but content_hash differs (content-hash tables
+ *               only) → daemon must re-push to refresh the D1 copy.
+ *
+ * This module contains NO I/O, NO DB access, NO network calls. All inputs are
+ * plain in-memory objects, making it trivially unit-testable.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A local row as returned by `localPartition`. */
+export interface LocalRow {
+  id: string;
+  content_hash?: string;
+}
+
+/** One item from the worker's GET /manifest response. */
+export interface ManifestItemLike {
+  id: string;
+  content_hash?: string | null;
+}
+
+/** Result of diffPartition. */
+export interface PartitionDiff {
+  /** Ids present locally but missing from D1. */
+  upsertIds: string[];
+  /** Ids present in D1 but absent locally (D1 has extra rows; delete them). */
+  deleteIds: string[];
+  /**
+   * Ids present in both but whose content_hash differs.
+   * Only populated for content-hash-bearing tables; always empty for others.
+   */
+  staleIds: string[];
+}
+
+// ---------------------------------------------------------------------------
+// diffPartition
+// ---------------------------------------------------------------------------
+
+/**
+ * Diff a local partition against the D1 manifest for the same partition.
+ *
+ * Semantics:
+ *   - id in local ONLY           → upsertIds (D1 is missing it)
+ *   - id in manifest ONLY        → deleteIds (D1 has an extra row)
+ *   - id in both, hashes match   → no action
+ *   - id in both, hashes differ, AND both items carry content_hash
+ *                                → staleIds (re-upsert needed)
+ *   - id in both, no content_hash on either item (presence-only table)
+ *                                → no action (stale detection is not possible)
+ *
+ * `staleIds` is always empty for tables that do not carry content_hash because
+ * there is no hash to compare — presence alone confirms the row is in sync.
+ */
+export function diffPartition(
+  local: ReadonlyArray<LocalRow>,
+  manifestItems: ReadonlyArray<ManifestItemLike>,
+): PartitionDiff {
+  const localMap = new Map<string, string | undefined>();
+  for (const row of local) {
+    localMap.set(row.id, row.content_hash);
+  }
+
+  const manifestMap = new Map<string, string | null | undefined>();
+  for (const item of manifestItems) {
+    manifestMap.set(item.id, item.content_hash);
+  }
+
+  const upsertIds: string[] = [];
+  const deleteIds: string[] = [];
+  const staleIds: string[] = [];
+
+  // Classify each local id.
+  for (const [id, localHash] of localMap) {
+    if (!manifestMap.has(id)) {
+      // Local only → D1 is missing it.
+      upsertIds.push(id);
+    } else {
+      // Present in both. Check for content_hash drift only when both sides
+      // carry a hash (content-hash tables). If either side lacks a hash, the
+      // table is presence-only and no stale detection is possible.
+      const manifestHash = manifestMap.get(id);
+      if (
+        localHash !== undefined && localHash !== null &&
+        manifestHash !== undefined && manifestHash !== null &&
+        localHash !== manifestHash
+      ) {
+        staleIds.push(id);
+      }
+    }
+  }
+
+  // Classify each manifest id not seen locally.
+  for (const id of manifestMap.keys()) {
+    if (!localMap.has(id)) {
+      deleteIds.push(id);
+    }
+  }
+
+  return { upsertIds, deleteIds, staleIds };
+}

--- a/packages/myco/src/daemon/team-reconcile.ts
+++ b/packages/myco/src/daemon/team-reconcile.ts
@@ -10,9 +10,16 @@
  *   staleIds  — present in both but content_hash differs (content-hash tables
  *               only) → daemon must re-push to refresh the D1 copy.
  *
- * This module contains NO I/O, NO DB access, NO network calls. All inputs are
- * plain in-memory objects, making it trivially unit-testable.
+ * The pure diff/safety functions contain NO I/O. `reconcilePartition` is the
+ * orchestrator: it DOES perform I/O (manifest fetch, local reads, outbox
+ * writes) but only through an INJECTED `deps` object, so the MODULE itself
+ * stays import-pure (no DB/network/fs imports — only type-only imports, which
+ * are erased at compile time). The real wiring lives in the team-sync init
+ * path; this module is unit-testable end-to-end with mock deps.
  */
+
+import type { ManifestItem, ManifestResponse } from '@myco/daemon/team-sync.js';
+import type { OutboxInsert, OutboxRow, PartitionRow } from '@myco/db/queries/team-outbox.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -238,4 +245,305 @@ export function evaluateDeleteSafety(input: DeleteSafetyInput): DeleteSafetyResu
   }
 
   return { allow: true };
+}
+
+// ---------------------------------------------------------------------------
+// Reconcile ↔ flush mutex (MF3)
+// ---------------------------------------------------------------------------
+
+/**
+ * In-process async mutex shared by the reconcile-seed path (reconcilePartition)
+ * and the flush-drain path (the team-sync flush job). The two lanes must NEVER
+ * interleave: a reconcile that is part-way through seeding deletes into the
+ * outbox must not have the flush drain a half-seeded batch, and the flush must
+ * not mark rows sent while reconcile is mid-decision.
+ *
+ * `runExclusive` queues callers FIFO; each runs to completion (including async
+ * awaits inside it) before the next acquires the lock. A SINGLE instance must
+ * guard both lanes — create one via `createReconcileFlushMutex()` and hand the
+ * same object to reconcilePartition (via deps) and to the flush job.
+ */
+export interface ReconcileMutex {
+  runExclusive<T>(fn: () => Promise<T> | T): Promise<T>;
+}
+
+/**
+ * Create a fresh reconcile↔flush mutex. The returned object is the share-able
+ * lock instance: pass the SAME object to both the reconcile-seed deps and the
+ * flush-drain job so they serialize against each other.
+ */
+export function createReconcileFlushMutex(): ReconcileMutex {
+  // Tail of the promise chain. Each acquirer awaits the previous tail before
+  // running, then becomes the new tail. Errors are isolated so one caller's
+  // rejection does not poison the chain for the next caller.
+  let tail: Promise<unknown> = Promise.resolve();
+
+  return {
+    runExclusive<T>(fn: () => Promise<T> | T): Promise<T> {
+      const run = tail.then(() => fn());
+      // Advance the tail to a settled (never-rejecting) continuation so a
+      // failure in `fn` does not break serialization for subsequent callers.
+      tail = run.then(
+        () => undefined,
+        () => undefined,
+      );
+      return run;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// reconcilePartition — orchestration (probe → check → diff → safety → dedup → seed)
+// ---------------------------------------------------------------------------
+
+/** Minimal logger surface used for skip/blocked diagnostics. */
+export interface ReconcileLogger {
+  info(message: string): void;
+  warn(message: string): void;
+}
+
+/** The worker-client surface reconcilePartition depends on (a subset of TeamSyncClient). */
+export interface ReconcileClient {
+  getWorkerProtocolVersion(): number | undefined;
+  health(): Promise<unknown>;
+  supportsManifest(): boolean;
+  getManifest(
+    machineId: string,
+    table: string,
+    options: { projectId?: string; cursor?: string; limit?: number; summary?: boolean },
+  ): Promise<ManifestResponse>;
+}
+
+/**
+ * Injected I/O surface for reconcilePartition. Keeping the module import-pure
+ * means every DB/network seam arrives through this object. The real wiring
+ * binds these to TeamSyncClient + the team-outbox query helpers.
+ */
+export interface ReconcilePartitionDeps {
+  client: ReconcileClient;
+  /** Local rows for the (machineId, projectId, table) partition. */
+  localPartition(machineId: string, projectId: string, table: string): PartitionRow[];
+  /** Row ids already pending (sent_at IS NULL) in the outbox for this partition. */
+  pendingRowIdsForPartition(table: string, machineId: string, projectId: string): Set<string>;
+  /** The ONLY outbox write seam — matches the existing push pipeline. */
+  enqueueOutbox(data: OutboxInsert): OutboxRow;
+  /**
+   * Build the upsert payload (full sanitized row JSON) for a local row id,
+   * matching the existing push pipeline's upsert payload shape. Returns null
+   * when the row has vanished between diff and seed (skip that upsert).
+   */
+  buildUpsertPayload(table: string, id: string): string | null;
+  /**
+   * Whether the team membership registry is seeded for this grove (the caller
+   * derives this from memberProjectIdsForGrove(grove) being non-empty). Threaded
+   * into the delete-safety gate.
+   */
+  membershipSeeded: boolean;
+  /** The shared reconcile↔flush mutex (MF3). */
+  mutex: ReconcileMutex;
+  logger: ReconcileLogger;
+  /**
+   * Diff function. Defaults to the pure `diffPartition` in this module; exposed
+   * as a seam only so tests can deterministically exercise the contradiction
+   * guard (an id classified into BOTH the upsert/stale set AND the delete set,
+   * which the real diff never produces but which the seed path defends against).
+   */
+  diff?: typeof diffPartition;
+}
+
+/**
+ * A shared, mutable per-pass delete accumulator. reconcilePartition adds this
+ * partition's APPLIED delete count to it and passes the running cumulative to
+ * evaluateDeleteSafety, so N partitions' deletes can't sum to a wipe.
+ */
+export interface PassAggregate {
+  count: number;
+}
+
+export interface ReconcilePartitionArgs {
+  machineId: string;
+  projectId: string;
+  table: string;
+  operatorConfirmed: boolean;
+  passAggregate: PassAggregate;
+}
+
+/** Page size for paged manifest fetches. */
+const MANIFEST_PAGE_LIMIT = 500;
+
+/**
+ * Reconcile one (machineId, projectId, table) partition against D1 and seed the
+ * resulting upserts/deletes into the outbox.
+ *
+ * Flow (strict (machine_id, project_id) scope throughout):
+ *   1. Probe-before-feature-detect (MF2): probe via health() if the worker
+ *      protocol version is unknown — never silently skip an unprobed client.
+ *   2. Version gate: skip+log if the worker does not support /manifest (v2).
+ *   3. Cheap count check: if D1 count === local count, no-op (no paging/seed).
+ *   4. Full diff: page the manifest, diff against the local partition.
+ *   5. Per-home mismatch guard (N3): only delete manifest items whose
+ *      project_id === projectId (machine_id is machine-global, shared by both
+ *      daemon homes — a delete must never target another home's partition).
+ *   6. Delete safety firewall: evaluateDeleteSafety; on block, skip ONLY the
+ *      deletes (upserts/stale re-pushes are always safe and still proceed).
+ *   7. Resurrection guard / dedup: skip ids already pending in the outbox; skip
+ *      any id that lands in BOTH the upsert/stale set and the delete set.
+ *   8. Seed under the mutex (MF3): enqueue survivors via enqueueOutbox.
+ */
+export async function reconcilePartition(
+  deps: ReconcilePartitionDeps,
+  args: ReconcilePartitionArgs,
+): Promise<void> {
+  const { client, logger } = deps;
+  const { machineId, projectId, table, operatorConfirmed, passAggregate } = args;
+
+  // 1. Probe-before-feature-detect (MF2). An unprobed client reports undefined;
+  // learn the version via health() rather than silently skipping.
+  if (client.getWorkerProtocolVersion() === undefined) {
+    try {
+      await client.health();
+    } catch (err) {
+      logger.warn(
+        `reconcile[${table}/${projectId}]: skipped — worker health probe failed: ${String(err)}`,
+      );
+      return;
+    }
+  }
+
+  // 2. Version gate. A confirmed v2 worker has no /manifest endpoint; skip
+  // gracefully (other sync is unaffected). Not an error.
+  if (!client.supportsManifest()) {
+    logger.info(
+      `reconcile[${table}/${projectId}]: skipped — worker does not support manifest (protocol ${
+        client.getWorkerProtocolVersion() ?? 'unknown'
+      })`,
+    );
+    return;
+  }
+
+  // 3. Cheap count check (fast path). Compare D1 count to local count; equal →
+  // no-op. (cheap_agg is MAX(rowid) on the D1 side and is NOT comparable to any
+  // local rowid sequence — the skip condition is COUNT equality only.)
+  const local = deps.localPartition(machineId, projectId, table);
+  const localCount = local.length;
+  const summary = await client.getManifest(machineId, table, { projectId, summary: true });
+  const d1Count = summary.count;
+  if (d1Count === localCount) {
+    return;
+  }
+
+  // 4. Full diff. Page the manifest (strict project scope) until exhausted.
+  const manifestItems: ManifestItem[] = [];
+  let cursor: string | undefined;
+  do {
+    const resp = await client.getManifest(machineId, table, {
+      projectId,
+      cursor,
+      limit: MANIFEST_PAGE_LIMIT,
+    });
+    if (resp.items) manifestItems.push(...resp.items);
+    cursor = resp.next_cursor;
+  } while (cursor);
+
+  const diff = (deps.diff ?? diffPartition)(local, manifestItems);
+
+  // 5. Per-home mismatch guard (N3). machine_id is machine-GLOBAL, so a delete
+  // must never target another home's partition. Only consider manifest items
+  // whose project_id === projectId as deletable (defense-in-depth on top of the
+  // already-strict project-scoped fetch).
+  const deletableProjectById = new Map<string, string>();
+  for (const item of manifestItems) {
+    if (item.project_id === projectId) deletableProjectById.set(item.id, item.project_id);
+  }
+  const deleteCandidates = diff.deleteIds.filter((id) => deletableProjectById.has(id));
+
+  // 6. Delete safety firewall. The running cumulative INCLUDES this partition's
+  // candidates so an aggregate wipe across partitions is bounded.
+  const partitionDeleteCount = deleteCandidates.length;
+  const safety = evaluateDeleteSafety({
+    localCount,
+    d1Count,
+    partitionDeleteCount,
+    passAggregateDeleteCount: passAggregate.count + partitionDeleteCount,
+    membershipSeeded: deps.membershipSeeded,
+    operatorConfirmed,
+  });
+  let allowedDeletes = deleteCandidates;
+  if (!safety.allow) {
+    logger.warn(
+      `reconcile[${table}/${projectId}]: ${partitionDeleteCount} delete(s) blocked (${
+        safety.reason ?? 'unknown'
+      }); applying upserts only`,
+    );
+    allowedDeletes = [];
+  }
+
+  // 7. Resurrection guard / dedup. Build the upsert/stale id set, the delete id
+  // set, then: (a) drop any id present in BOTH (a contradictory op would
+  // resurrect or thrash the row), (b) drop any id already pending in the outbox.
+  const upsertSet = new Set<string>([...diff.upsertIds, ...diff.staleIds]);
+  const deleteSet = new Set<string>(allowedDeletes);
+  for (const id of upsertSet) {
+    if (deleteSet.has(id)) {
+      upsertSet.delete(id);
+      deleteSet.delete(id);
+    }
+  }
+  const pending = deps.pendingRowIdsForPartition(table, machineId, projectId);
+
+  const upsertIds = [...upsertSet].filter((id) => !pending.has(id));
+  const deleteIds = [...deleteSet].filter((id) => !pending.has(id));
+
+  if (upsertIds.length === 0 && deleteIds.length === 0) return;
+
+  // 8. Seed under the mutex (MF3). The reconcile-seed and the flush-drain share
+  // this lock instance and must not interleave.
+  await deps.mutex.runExclusive(() => {
+    const now = nowSeconds();
+
+    for (const id of upsertIds) {
+      const payload = deps.buildUpsertPayload(table, id);
+      if (payload === null) continue; // row vanished between diff and seed
+      deps.enqueueOutbox({
+        table_name: table,
+        row_id: id,
+        operation: 'upsert',
+        payload,
+        machine_id: machineId,
+        project_id: projectId,
+        created_at: now,
+      });
+    }
+
+    let appliedDeletes = 0;
+    for (const id of deleteIds) {
+      // project_id MUST come from the manifest item — there is no local row to
+      // source it from, and the worker's grove-project_id gate 409-rejects
+      // deletes lacking project_id. Payload matches the delete-trigger shape:
+      // json_object('id', id, 'machine_id', machine_id).
+      const manifestProjectId = deletableProjectById.get(id)!;
+      deps.enqueueOutbox({
+        table_name: table,
+        row_id: id,
+        operation: 'delete',
+        payload: JSON.stringify({ id, machine_id: machineId }),
+        machine_id: machineId,
+        project_id: manifestProjectId,
+        created_at: now,
+      });
+      appliedDeletes += 1;
+    }
+
+    // Accumulate APPLIED deletes into the shared per-pass aggregate.
+    passAggregate.count += appliedDeletes;
+  });
+}
+
+/**
+ * Current wall-clock time in whole seconds. Kept local (not imported from
+ * @myco/constants) so the module has zero runtime imports and stays trivially
+ * unit-testable without pulling the constants graph.
+ */
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
 }

--- a/packages/myco/src/daemon/team-reconcile.ts
+++ b/packages/myco/src/daemon/team-reconcile.ts
@@ -336,7 +336,11 @@ const MANIFEST_PAGE_LIMIT = 500;
  */
 const priorDeleteCandidates = new Map<string, Set<string>>();
 
-/** Stable partition key for the cross-pass drift map. */
+/**
+ * Stable partition key for the cross-pass drift map. NUL-separated to match
+ * the sibling `rejectionKey` convention and eliminate any collision risk from
+ * ids that contain spaces.
+ */
 function partitionKey(machineId: string, projectId: string, table: string): string {
   return `${machineId} ${projectId} ${table}`;
 }
@@ -404,7 +408,7 @@ export async function reconcilePartition(
 
   // 3. Local partition. When forceFullDiff is false (the frequent poll path),
   // a cheap summary fetch gates paging: equal counts → no-op. When
-  // forceFullDiff is true (the 6h backstop and operator-confirmed paths), skip
+  // forceFullDiff is true (the 6h backstop and on-demand trigger paths), skip
   // the count check so equal-count / different-set drift is always caught.
   const local = deps.localPartition(machineId, projectId, table);
   const localCount = local.length;
@@ -416,6 +420,13 @@ export async function reconcilePartition(
     if (d1Count === localCount) {
       // No drift this pass — drop any candidate carried from a prior pass so a
       // since-resolved orphan can never linger as a stale second-pass match.
+      //
+      // NOTE: clearing here on a count-equal (not just zero-diff) pass can reset
+      // the cross-pass accumulator even for an equal-count / different-set partition
+      // (one local add + one local delete that nets the same count). That only DELAYS
+      // healing by one pass, not permanently blocks it: the accompanying upsert for the
+      // new local row lands in this same pass, D1 counts diverge on the next summary
+      // fetch, and the full diff then deletes the orphan as a first-sighting candidate.
       priorDeleteCandidates.delete(key);
       return;
     }

--- a/packages/myco/src/daemon/team-reconcile.ts
+++ b/packages/myco/src/daemon/team-reconcile.ts
@@ -366,6 +366,14 @@ export interface ReconcilePartitionArgs {
   table: string;
   operatorConfirmed: boolean;
   passAggregate: PassAggregate;
+  /**
+   * When true, skip the count-equality fast path and always run the full ID diff.
+   * Used by the 6h periodic backstop and the operator on-demand reconcile to
+   * catch equal-count / different-set drift (e.g. one local delete + one local
+   * add that nets the same count). The frequent poll path keeps forceFullDiff
+   * false so per-partition summary fetches stay cheap.
+   */
+  forceFullDiff?: boolean;
 }
 
 /** Page size for paged manifest fetches. */
@@ -395,7 +403,7 @@ export async function reconcilePartition(
   args: ReconcilePartitionArgs,
 ): Promise<void> {
   const { client, logger } = deps;
-  const { machineId, projectId, table, operatorConfirmed, passAggregate } = args;
+  const { machineId, projectId, table, operatorConfirmed, passAggregate, forceFullDiff = false } = args;
 
   // 1. Probe-before-feature-detect (MF2). An unprobed client reports undefined;
   // learn the version via health() rather than silently skipping.
@@ -421,15 +429,20 @@ export async function reconcilePartition(
     return;
   }
 
-  // 3. Cheap count check (fast path). Compare D1 count to local count; equal →
-  // no-op. (cheap_agg is MAX(rowid) on the D1 side and is NOT comparable to any
-  // local rowid sequence — the skip condition is COUNT equality only.)
+  // 3. Local partition. When forceFullDiff is false (the frequent poll path),
+  // a cheap summary fetch gates paging: equal counts → no-op. When
+  // forceFullDiff is true (the 6h backstop and operator-confirmed paths), skip
+  // the count check so equal-count / different-set drift is always caught.
   const local = deps.localPartition(machineId, projectId, table);
   const localCount = local.length;
-  const summary = await client.getManifest(machineId, table, { projectId, summary: true });
-  const d1Count = summary.count;
-  if (d1Count === localCount) {
-    return;
+
+  let d1Count = 0;
+  if (!forceFullDiff) {
+    const summary = await client.getManifest(machineId, table, { projectId, summary: true });
+    d1Count = summary.count;
+    if (d1Count === localCount) {
+      return;
+    }
   }
 
   // 4. Full diff. Page the manifest (strict project scope) until exhausted.
@@ -444,6 +457,12 @@ export async function reconcilePartition(
     if (resp.items) manifestItems.push(...resp.items);
     cursor = resp.next_cursor;
   } while (cursor);
+
+  if (forceFullDiff) {
+    // No summary was fetched; derive d1Count from the full paged result
+    // (total paged items = D1 partition count) so the safety gate is accurate.
+    d1Count = manifestItems.length;
+  }
 
   const diff = (deps.diff ?? diffPartition)(local, manifestItems);
 

--- a/packages/myco/src/daemon/team-reconcile.ts
+++ b/packages/myco/src/daemon/team-reconcile.ts
@@ -135,33 +135,8 @@ export function diffPartition(
 }
 
 // ---------------------------------------------------------------------------
-// Delete-safety gate
+// Delete-safety gate (settledness)
 // ---------------------------------------------------------------------------
-
-/**
- * Maximum per-partition deletes the AUTOMATIC reconcile path may apply in one
- * pass. Chosen as 50: large enough to heal genuine bulk-drift (e.g. a restore
- * that wiped a few dozen rows) without approaching the scale of a full-
- * partition wipe on any realistic team dataset. `== floor` is allowed;
- * `> floor` requires operator confirmation.
- */
-export const MIN_ABSOLUTE_DELETE_FLOOR = 50;
-
-/**
- * Maximum fraction of the D1 partition the AUTOMATIC path may delete in one
- * pass. 0.2 (20%) bounds blast radius relative to partition size while still
- * allowing meaningful drift healing. Values above 0.2 would let a 300-row
- * partition lose 60+ rows automatically — closer to a wipe than drift repair.
- */
-export const MAX_DELETE_FRACTION = 0.2;
-
-/**
- * Per-pass cap across ALL partitions. Set to 4× the per-partition floor so
- * N partitions each under the floor cannot SUM to an unbounded wipe across
- * the full reconcile pass. 200 allows roughly 4 fully-drifted partitions to
- * heal in one pass while still bounding the worst-case aggregate.
- */
-export const MAX_PASS_AGGREGATE_DELETES = 200;
 
 /** Inputs to the delete-safety gate. */
 export interface DeleteSafetyInput {
@@ -169,10 +144,6 @@ export interface DeleteSafetyInput {
   localCount: number;
   /** Number of rows the D1 manifest reports for this partition. */
   d1Count: number;
-  /** How many D1 rows the current partition diff wants to delete. */
-  partitionDeleteCount: number;
-  /** Running total of delete ops already approved across all partitions in this pass. */
-  passAggregateDeleteCount: number;
   /**
    * Whether the team membership registry has been seeded (i.e. the caller
    * confirmed that `memberProjectIdsForGrove(grove)` returned a non-empty set).
@@ -180,13 +151,6 @@ export interface DeleteSafetyInput {
    * deletes may proceed.
    */
   membershipSeeded: boolean;
-  /**
-   * When true the operator has explicitly confirmed this reconcile, which
-   * bypasses the magnitude caps (floor, fraction, aggregate). Settledness
-   * guards (localCount==0 and membershipSeeded) are NEVER overridable —
-   * an operator confirming does not make not-yet-loaded data trustworthy.
-   */
-  operatorConfirmed: boolean;
 }
 
 /** Result of the delete-safety gate. */
@@ -197,68 +161,42 @@ export interface DeleteSafetyResult {
 }
 
 /**
- * Evaluate whether a set of delete ops is safe to proceed.
+ * Evaluate whether deletes for a partition are safe to proceed.
  *
- * Guards are evaluated in strict order. The first two are settledness guards
- * that block unconditionally — even operator confirmation cannot override them,
- * because no human decision can make a not-yet-loaded local dataset trustworthy.
+ * The reconcile path is a FULLY AUTOMATIC backstop: its actor is any member
+ * daemon that just syncs (possibly headless), so this gate is machine-decidable
+ * with zero human judgment. Magnitude is NOT gated here — delete blast radius is
+ * bounded instead by cross-pass drift stability in `reconcilePartition` (an
+ * orphan must be observed across two consecutive passes before it is deleted, so
+ * a transient/partial-load orphan never reaches a delete). What remains are the
+ * two settledness guards, which block unconditionally because no amount of drift
+ * confirmation can make a not-yet-loaded local dataset trustworthy:
  *
- * Guard order:
- *   1. localCount===0 && d1Count>0   → not_settled         (unconditional)
- *   2. !membershipSeeded             → membership_unseeded  (unconditional)
- *   3. operatorConfirmed             → allow (magnitude caps bypassed)
- *   4. partitionDeleteCount > floor  → requires_operator
- *   5. fraction > MAX_DELETE_FRACTION (when d1Count>0) → exceeds_fraction
- *   6. passAggregateDeleteCount > aggregate cap → exceeds_aggregate
- *   7. otherwise                     → allow
+ *   1. localCount===0 && d1Count>0 → not_settled
+ *      The local set has simply not loaded yet; treating an empty local as
+ *      authoritative would wipe the whole partition.
+ *   2. !membershipSeeded → membership_unseeded
+ *      Without a populated membership registry the daemon cannot tell a
+ *      genuinely-absent row from one temporarily invisible behind an unseeded
+ *      registry.
+ *
+ * Otherwise → allow.
  */
 export function evaluateDeleteSafety(input: DeleteSafetyInput): DeleteSafetyResult {
-  const {
-    localCount,
-    d1Count,
-    partitionDeleteCount,
-    passAggregateDeleteCount,
-    membershipSeeded,
-    operatorConfirmed,
-  } = input;
+  const { localCount, d1Count, membershipSeeded } = input;
 
-  // Guard 1: transient-empty trap. A reconcile may never wipe a whole
-  // partition, regardless of operator intent — the local set has simply not
-  // loaded yet and cannot be trusted as authoritative.
+  // Guard 1: transient-empty trap. A reconcile may never wipe a whole partition
+  // — an empty local set has simply not loaded yet and cannot be trusted as
+  // authoritative.
   if (localCount === 0 && d1Count > 0) {
     return { allow: false, reason: 'not_settled' };
   }
 
-  // Guard 2: membership not yet seeded. Without a populated membership
-  // registry the daemon cannot determine which rows are genuinely absent
-  // locally vs. temporarily invisible due to an unseeded registry.
+  // Guard 2: membership not yet seeded. Without a populated membership registry
+  // the daemon cannot determine which rows are genuinely absent locally vs.
+  // temporarily invisible due to an unseeded registry.
   if (!membershipSeeded) {
     return { allow: false, reason: 'membership_unseeded' };
-  }
-
-  // Guard 3: operator confirmed — settledness already passed above; bypass
-  // all magnitude caps.
-  if (operatorConfirmed) {
-    return { allow: true };
-  }
-
-  // Guard 4: per-partition absolute floor. Deleting more than this many rows
-  // from a single partition in one automatic pass requires a human decision.
-  if (partitionDeleteCount > MIN_ABSOLUTE_DELETE_FLOOR) {
-    return { allow: false, reason: 'requires_operator' };
-  }
-
-  // Guard 5: fraction cap. Even if the count is under the floor, a high
-  // fraction signals the local set diverged from D1 by an unusual proportion.
-  // Skip when d1Count===0 — there are no D1 rows to bound.
-  if (d1Count > 0 && (partitionDeleteCount / d1Count) > MAX_DELETE_FRACTION) {
-    return { allow: false, reason: 'exceeds_fraction' };
-  }
-
-  // Guard 6: per-pass aggregate cap. Prevents N partitions each under the
-  // per-partition floor from summing to an unbounded total wipe.
-  if (passAggregateDeleteCount > MAX_PASS_AGGREGATE_DELETES) {
-    return { allow: false, reason: 'exceeds_aggregate' };
   }
 
   return { allow: true };
@@ -368,33 +306,48 @@ export interface ReconcilePartitionDeps {
   diff?: typeof diffPartition;
 }
 
-/**
- * A shared, mutable per-pass delete accumulator. reconcilePartition adds this
- * partition's APPLIED delete count to it and passes the running cumulative to
- * evaluateDeleteSafety, so N partitions' deletes can't sum to a wipe.
- */
-export interface PassAggregate {
-  count: number;
-}
-
 export interface ReconcilePartitionArgs {
   machineId: string;
   projectId: string;
   table: string;
-  operatorConfirmed: boolean;
-  passAggregate: PassAggregate;
   /**
    * When true, skip the count-equality fast path and always run the full ID diff.
-   * Used by the 6h periodic backstop and the operator on-demand reconcile to
-   * catch equal-count / different-set drift (e.g. one local delete + one local
-   * add that nets the same count). The frequent poll path keeps forceFullDiff
-   * false so per-partition summary fetches stay cheap.
+   * Used by the 6h periodic backstop and the on-demand reconcile to catch
+   * equal-count / different-set drift (e.g. one local delete + one local add
+   * that nets the same count). The frequent poll path keeps forceFullDiff false
+   * so per-partition summary fetches stay cheap.
    */
   forceFullDiff?: boolean;
 }
 
 /** Page size for paged manifest fetches. */
 const MANIFEST_PAGE_LIMIT = 500;
+
+/**
+ * Cross-pass drift tracking. Maps a partition key (machineId, projectId, table)
+ * to the set of orphan-candidate ids — D1 rows absent locally — observed on the
+ * PREVIOUS full-diff pass. An orphan is deleted only when it appears in TWO
+ * consecutive passes: the first pass records it here, the second pass intersects
+ * the current candidates with this set and seeds the survivors. A transient or
+ * partial-load orphan that has vanished by the next pass is never deleted;
+ * genuine drift persists and heals on the second pass. This is process memory,
+ * not I/O, so the module stays import-pure. State is best-effort: a daemon
+ * restart simply costs one extra pass before the first delete.
+ */
+const priorDeleteCandidates = new Map<string, Set<string>>();
+
+/** Stable partition key for the cross-pass drift map. */
+function partitionKey(machineId: string, projectId: string, table: string): string {
+  return `${machineId} ${projectId} ${table}`;
+}
+
+/**
+ * Clear all in-memory cross-pass drift tracking. Test seam only — production
+ * never resets this; the map lives for the daemon process's lifetime.
+ */
+export function resetReconcileDriftTracking(): void {
+  priorDeleteCandidates.clear();
+}
 
 /**
  * Reconcile one (machineId, projectId, table) partition against D1 and seed the
@@ -409,8 +362,10 @@ const MANIFEST_PAGE_LIMIT = 500;
  *   5. Per-home mismatch guard (N3): only delete manifest items whose
  *      project_id === projectId (machine_id is machine-global, shared by both
  *      daemon homes — a delete must never target another home's partition).
- *   6. Delete safety firewall: evaluateDeleteSafety; on block, skip ONLY the
- *      deletes (upserts/stale re-pushes are always safe and still proceed).
+ *   6. Settledness firewall + cross-pass drift stability: evaluateDeleteSafety
+ *      blocks deletes for an unsettled partition; otherwise only orphans also
+ *      seen on the PREVIOUS pass are deleted now (current candidates are
+ *      recorded for the next pass). Upserts/stale re-pushes always proceed.
  *   7. Resurrection guard / dedup: skip ids already pending in the outbox; skip
  *      any id that lands in BOTH the upsert/stale set and the delete set.
  *   8. Seed under the mutex (MF3): enqueue survivors via enqueueOutbox.
@@ -420,7 +375,8 @@ export async function reconcilePartition(
   args: ReconcilePartitionArgs,
 ): Promise<void> {
   const { client, logger } = deps;
-  const { machineId, projectId, table, operatorConfirmed, passAggregate, forceFullDiff = false } = args;
+  const { machineId, projectId, table, forceFullDiff = false } = args;
+  const key = partitionKey(machineId, projectId, table);
 
   // 1. Probe-before-feature-detect (MF2). An unprobed client reports undefined;
   // learn the version via health() rather than silently skipping.
@@ -458,6 +414,9 @@ export async function reconcilePartition(
     const summary = await client.getManifest(machineId, table, { projectId, summary: true });
     d1Count = summary.count;
     if (d1Count === localCount) {
+      // No drift this pass — drop any candidate carried from a prior pass so a
+      // since-resolved orphan can never linger as a stale second-pass match.
+      priorDeleteCandidates.delete(key);
       return;
     }
   }
@@ -495,25 +454,32 @@ export async function reconcilePartition(
   }
   const deleteCandidates = diff.deleteIds.filter((id) => deletableProjectById.has(id));
 
-  // 6. Delete safety firewall. The running cumulative INCLUDES this partition's
-  // candidates so an aggregate wipe across partitions is bounded.
-  const partitionDeleteCount = deleteCandidates.length;
+  // 6. Settledness firewall + cross-pass drift stability. Settledness gates
+  // FIRST: an unsettled partition seeds zero deletes regardless of candidates,
+  // and — being an untrustworthy observation — breaks the consecutive-pass chain
+  // (drop any carried candidates). When settled, only orphans also seen on the
+  // PREVIOUS pass are deleted now; the current candidate set is recorded for the
+  // next pass so a transient/partial-load orphan (gone by then) is never deleted
+  // while genuine drift heals on its second consecutive sighting.
   const safety = evaluateDeleteSafety({
     localCount,
     d1Count,
-    partitionDeleteCount,
-    passAggregateDeleteCount: passAggregate.count + partitionDeleteCount,
     membershipSeeded: deps.membershipSeeded,
-    operatorConfirmed,
   });
-  let allowedDeletes = deleteCandidates;
+  let allowedDeletes: string[];
   if (!safety.allow) {
     logger.warn(
-      `reconcile[${table}/${projectId}]: ${partitionDeleteCount} delete(s) blocked (${
+      `reconcile[${table}/${projectId}]: ${deleteCandidates.length} delete(s) blocked (${
         safety.reason ?? 'unknown'
       }); applying upserts only`,
     );
     allowedDeletes = [];
+    priorDeleteCandidates.delete(key);
+  } else {
+    const prior = priorDeleteCandidates.get(key);
+    allowedDeletes = prior ? deleteCandidates.filter((id) => prior.has(id)) : [];
+    if (deleteCandidates.length === 0) priorDeleteCandidates.delete(key);
+    else priorDeleteCandidates.set(key, new Set(deleteCandidates));
   }
 
   // 7. Resurrection guard / dedup. Build the upsert/stale id set, the delete id
@@ -553,7 +519,6 @@ export async function reconcilePartition(
       });
     }
 
-    let appliedDeletes = 0;
     for (const id of deleteIds) {
       // project_id MUST come from the manifest item — there is no local row to
       // source it from, and the worker's grove-project_id gate 409-rejects
@@ -573,11 +538,7 @@ export async function reconcilePartition(
         project_id: manifestProjectId,
         created_at: now,
       });
-      appliedDeletes += 1;
     }
-
-    // Accumulate APPLIED deletes into the shared per-pass aggregate.
-    passAggregate.count += appliedDeletes;
   });
 }
 

--- a/packages/myco/src/daemon/team-sync-init.ts
+++ b/packages/myco/src/daemon/team-sync-init.ts
@@ -47,7 +47,19 @@ import {
   countPending,
   purgePendingOutbox,
   purgeNonMemberOutbox,
+  enqueueOutbox,
+  localPartition,
+  pendingRowIdsForPartition,
+  sanitizeSyncPayload,
+  RECONCILE_ELIGIBLE_TABLES,
 } from '@myco/db/queries/team-outbox.js';
+import {
+  reconcilePartition as reconcilePartitionImplDefault,
+  createReconcileFlushMutex,
+  type PassAggregate,
+  type ReconcileLogger,
+  type ReconcilePartitionDeps,
+} from './team-reconcile.js';
 import { upsertSelfMember } from '@myco/db/queries/team-members.js';
 import { setTeamSyncEnabled, setProjectSyncMembership } from '@myco/db/queries/team-sync-state.js';
 import { memberProjectIdsForGrove, machineHasAnyTeam } from '@myco/grove/project-tenancy.js';
@@ -81,6 +93,13 @@ export interface TeamSyncDeps {
   /** The current daemon's service dir; passed through to `forEachGrove` to enforce the served-by boundary. */
   daemonStateDir: string;
   requestContext?: MycoRequestContext;
+  /**
+   * Test-only seam for the per-partition reconcile orchestrator. Defaults to
+   * the real `reconcilePartition`; tests inject a spy to assert the trigger
+   * wiring (which partitions get reconciled, with which operatorConfirmed +
+   * shared passAggregate) without doing real manifest/outbox I/O.
+   */
+  reconcilePartitionImpl?: typeof reconcilePartitionImplDefault;
 }
 
 export interface TeamSyncResult {
@@ -116,6 +135,16 @@ export interface TeamSyncResult {
    * flag write (no push, no client) so all Groves start the session in lockstep.
    */
   reconcileAllGroveFlags: (cache: GroveRuntimeCache) => Promise<void>;
+  /**
+   * Run a symmetric reconcile pass across every owned (grove, project)
+   * partition. `operatorConfirmed=false` is the automatic path (count-first
+   * no-op in the steady state, magnitude-capped deletes); `operatorConfirmed=true`
+   * is the operator-confirmed on-demand path (settledness guards still apply,
+   * magnitude caps bypassed). One shared per-pass delete aggregate spans every
+   * partition so cross-partition deletes can't sum past the aggregate cap.
+   * Returns the applied-delete count for the whole pass.
+   */
+  reconcileAllGroves: (cache: GroveRuntimeCache, operatorConfirmed: boolean) => Promise<{ deletes: number }>;
   registerFlushJob: (runner: JobRunner, cache: GroveRuntimeCache) => void;
 }
 
@@ -133,6 +162,14 @@ export interface TeamFlushAggregate {
   batches: number;
   errors: number;
 }
+
+/**
+ * Low cadence for the periodic reconcile backstop job. The trigger paths handle
+ * the common cases (boot, team reactions, membership changes); the backstop only
+ * needs to catch drift no trigger noticed, so a 6-hour floor keeps the manifest
+ * traffic negligible while still self-healing within a day.
+ */
+const TEAM_SYNC_RECONCILE_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Config-seed planner
@@ -177,6 +214,43 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
   }
 
   const { machineId, logger, daemonStateDir, requestContext: defaultRequestContext } = deps;
+
+  // The per-partition reconcile orchestrator (test-injectable; defaults to the
+  // real implementation). Bound once so every reconcile call site uses the
+  // same impl.
+  const reconcilePartition = deps.reconcilePartitionImpl ?? reconcilePartitionImplDefault;
+
+  // ONE reconcile↔flush mutex for this team-sync instance (MF3). The same
+  // object guards both the reconcile-seed path (threaded into reconcilePartition
+  // deps) AND the flush-drain path (flushPending wraps its body in it), so a
+  // reconcile that is mid-seed and a flush that is mid-drain never interleave.
+  const reconcileFlushMutex = createReconcileFlushMutex();
+
+  // Adapt the daemon logger (info(kind, msg, fields)) to the reconcile module's
+  // minimal info/warn(message) surface, tagging team-sync log kinds.
+  const reconcilePartitionLogger: ReconcileLogger = {
+    info: (message) => logger.info(LOG_KINDS.TEAM_SYNC_START, message),
+    warn: (message) => logger.warn(LOG_KINDS.TEAM_SYNC_ERROR, message),
+  };
+
+  /**
+   * Build the sanitized upsert payload for a local row by id, matching the push
+   * pipeline's shape (`sanitizeSyncPayload(table, row)` — the same call syncRow
+   * and backfill use). Returns null when the row vanished between diff and seed.
+   *
+   * Runs INSIDE the reconcile↔flush mutex, so it MUST stay cheap + synchronous:
+   * better-sqlite3 reads are synchronous — never hold the lock across async I/O.
+   * `table` is only ever an allow-listed RECONCILE_ELIGIBLE_TABLES name (the
+   * reconcile pass is the sole caller), the SQL-injection safety boundary.
+   */
+  function buildUpsertPayload(table: string, id: string): string | null {
+    const db = getDatabase();
+    const row = db
+      .prepare(`SELECT * FROM ${table} WHERE id = ?`)
+      .get(id) as Record<string, unknown> | undefined;
+    if (!row) return null;
+    return JSON.stringify(sanitizeSyncPayload(table, row));
+  }
 
   /** Boolean convenience over `memberProjectIdsForGrove`, used by the deep-sleep `pending` probe. */
   function groveParticipates(groveId: string | null): boolean {
@@ -401,7 +475,17 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
    * machine-scoped self row to that team's worker, so a just-joined teammate
    * appears in the Members roster before assigning any project.
    */
+  /**
+   * Drain entry point. Serializes the whole drain against the reconcile-seed
+   * path via the shared mutex (MF3): a reconcile that is part-way through seeding
+   * deletes/upserts into the outbox must not have the flush drain a half-seeded
+   * batch, and the flush must not mark rows sent while reconcile is mid-decision.
+   */
   async function flushPending(requestContext = defaultRequestContext): Promise<TeamFlushResult> {
+    return reconcileFlushMutex.runExclusive(() => flushPendingInner(requestContext));
+  }
+
+  async function flushPendingInner(requestContext = defaultRequestContext): Promise<TeamFlushResult> {
     const result: TeamFlushResult = { handedOff: 0, rejected: 0, batches: 0 };
 
     const groveId = requestContext?.groveId ?? null;
@@ -678,6 +762,86 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
     }
   }
 
+  /**
+   * Reconcile every owned (this grove, member project) × reconcile-eligible
+   * table partition for the CURRENTLY-SCOPED grove DB. Runs only when the grove
+   * has ≥1 member project — that single signal is both `participates` and
+   * `membershipSeeded` (the member-project set IS the seeded membership), so a
+   * non-member grove is a no-op and deletes are gated until membership is known.
+   *
+   * The shared `passAggregate` is threaded into every partition so deletes
+   * across all partitions in the pass can't sum past the aggregate cap. Each
+   * partition is reconciled against its owning team's worker; a project whose
+   * team client can't be built this tick is skipped (left for a later pass),
+   * never deleted. Non-throwing: any error is logged so a reconcile failure
+   * never aborts the caller (boot, flush job, or request handler).
+   */
+  async function runReconcilePass(
+    groveId: string | null,
+    operatorConfirmed: boolean,
+    passAggregate: PassAggregate,
+  ): Promise<void> {
+    try {
+      const memberProjectIds = memberProjectIdsForGrove(groveId);
+      // participates && membershipSeeded both reduce to a non-empty member set.
+      if (memberProjectIds.length === 0) return;
+
+      const membershipByProject = teamRegistry.membershipByProject();
+      const baseDeps: Omit<ReconcilePartitionDeps, 'client'> = {
+        localPartition,
+        pendingRowIdsForPartition,
+        enqueueOutbox,
+        buildUpsertPayload,
+        membershipSeeded: true,
+        mutex: reconcileFlushMutex,
+        logger: reconcilePartitionLogger,
+      };
+
+      for (const projectId of memberProjectIds) {
+        const teamId = membershipByProject.get(projectId);
+        const client = teamId ? getOrBuildTeamClient(teamId) : null;
+        // No reachable/configured team worker for this project this pass — skip
+        // (its rows stay as-is for a later pass), never delete on a missing peer.
+        if (!client) continue;
+        for (const table of RECONCILE_ELIGIBLE_TABLES) {
+          await reconcilePartition(
+            { ...baseDeps, client },
+            { machineId, projectId, table, operatorConfirmed, passAggregate },
+          );
+        }
+      }
+    } catch (err) {
+      logger.error(LOG_KINDS.TEAM_SYNC_ERROR, 'Team-sync reconcile pass failed', {
+        grove_id: groveId,
+        operator_confirmed: operatorConfirmed,
+        error: (err as Error).message,
+      });
+    }
+  }
+
+  /**
+   * Fan a symmetric reconcile pass across every registered Grove. Mirrors
+   * flushAllGroves's forEachGrove fan-out (per-Grove DB pinned + scoped via
+   * withDatabase, per-Grove failures isolated). ONE passAggregate spans the
+   * whole pass — across every Grove, project, and table — so the per-pass
+   * aggregate delete cap bounds the worst case for the entire run.
+   */
+  async function reconcileAllGroves(
+    cache: GroveRuntimeCache,
+    operatorConfirmed: boolean,
+  ): Promise<{ deletes: number }> {
+    const passAggregate: PassAggregate = { count: 0 };
+    await forEachGrove(
+      cache,
+      logger,
+      async ({ grove, db }) => {
+        await withDatabase(db, () => runReconcilePass(grove.id, operatorConfirmed, passAggregate));
+      },
+      { daemonStateDir, jobName: 'team-sync-reconcile' },
+    );
+    return { deletes: passAggregate.count };
+  }
+
   async function reconcileClient(requestContext = defaultRequestContext): Promise<void> {
     const groveId = requestContext?.groveId ?? null;
     const memberProjectIds = memberProjectIdsForGrove(groveId);
@@ -734,6 +898,16 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
       const backfilled = backfillUnsynced(machineId);
       if (backfilled > 0) {
         logger.info(LOG_KINDS.TEAM_SYNC_START, `Backfilled ${backfilled} unsynced records into outbox`);
+      }
+      // (6) Re-enable the symmetric reconcile delete/upsert seed after backfill
+      //     whenever this grove participates (≥1 member project ⇒ participates &&
+      //     membershipSeeded). Automatic path (operatorConfirmed=false): the
+      //     count-first no-op keeps a steady-state partition cheap, so this runs
+      //     unconditionally on every reconcile without a synthetic transition
+      //     flag. A fresh per-call aggregate bounds this reconcile's deletes;
+      //     runReconcilePass is itself non-throwing so it can't abort the flush.
+      if (participates) {
+        await runReconcilePass(groveId, false, { count: 0 });
       }
       await flushPending(requestContext);
     } catch (err) {
@@ -893,6 +1067,7 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
     flushAllGroves,
     reconcileGrove,
     reconcileAllGroveFlags,
+    reconcileAllGroves,
     registerFlushJob: (runner, cache) => {
       // Registered unconditionally; registry participation is checked at run
       // time so Team selection changes take effect without a daemon restart.
@@ -912,6 +1087,28 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
         },
         fn: async () => {
           await flushAllGroves(cache);
+        },
+      });
+
+      // Periodic symmetric-reconcile BACKSTOP. The trigger paths (reconcileClient
+      // on boot / team reactions / membership changes) cover the common cases;
+      // this housekeeping job re-runs the count-first automatic reconcile across
+      // every Grove on a low cadence so drift that no trigger noticed (a restore,
+      // a missed delete) self-heals. Same registration shape as the flush job;
+      // 'housekeeping' kind keeps it in the background lane so a long pass can't
+      // starve foreground drain/scheduler work, and the JobRunner runs the fn
+      // fire-and-forget so the dispatch tick is never blocked. idle/sleep only —
+      // active-time reconcile is covered by the request-driven trigger path.
+      let lastReconcileAt = 0;
+      runner.register({
+        name: 'team-sync-reconcile',
+        runIn: ['idle', 'sleep'],
+        kind: 'housekeeping',
+        fn: async () => {
+          const now = Date.now();
+          if (now - lastReconcileAt < TEAM_SYNC_RECONCILE_INTERVAL_MS) return;
+          lastReconcileAt = now;
+          await reconcileAllGroves(cache, false);
         },
       });
     },

--- a/packages/myco/src/daemon/team-sync-init.ts
+++ b/packages/myco/src/daemon/team-sync-init.ts
@@ -139,7 +139,7 @@ export interface TeamSyncResult {
    * (grove, project) partition (always full-diff). Used by the periodic backstop
    * and the on-demand immediacy trigger; both run the same fully-automatic
    * reconcile. Deletes are bounded by settledness + cross-pass drift stability
-   * inside `reconcilePartition`, so there is no operator/magnitude knob here.
+   * inside `reconcilePartition`, so there is no per-call magnitude knob here.
    */
   reconcileAllGroves: (cache: GroveRuntimeCache) => Promise<void>;
   registerFlushJob: (runner: JobRunner, cache: GroveRuntimeCache) => void;
@@ -184,7 +184,7 @@ const TEAM_SYNC_RECONCILE_INTERVAL_MS = 6 * 60 * 60 * 1000;
  * pure rate limit (an in-memory last-run timestamp), NOT a synthetic transition
  * flag, so it does not reintroduce SF2. The FIRST call after connect has no
  * prior timestamp and always runs, preserving connect-time auto-heal; the
- * operator path and the periodic backstop bypass it entirely.
+ * The on-demand trigger path and the periodic backstop bypass it entirely.
  */
 const TEAM_SYNC_RECONCILE_TRIGGER_THROTTLE_MS = 2 * 60 * 1000;
 

--- a/packages/myco/src/daemon/team-sync-init.ts
+++ b/packages/myco/src/daemon/team-sync-init.ts
@@ -836,10 +836,19 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
         // (its rows stay as-is for a later pass), never delete on a missing peer.
         if (!client) continue;
         for (const table of RECONCILE_ELIGIBLE_TABLES) {
-          await reconcilePartition(
-            { ...baseDeps, client },
-            { machineId, projectId, table, operatorConfirmed, passAggregate },
-          );
+          try {
+            await reconcilePartition(
+              { ...baseDeps, client },
+              { machineId, projectId, table, operatorConfirmed, passAggregate },
+            );
+          } catch (partitionErr) {
+            logger.error(LOG_KINDS.TEAM_SYNC_ERROR, 'Reconcile partition failed (skipping)', {
+              grove_id: groveId,
+              project_id: projectId,
+              table,
+              error: (partitionErr as Error).message,
+            });
+          }
         }
       }
     } catch (err) {

--- a/packages/myco/src/daemon/team-sync-init.ts
+++ b/packages/myco/src/daemon/team-sync-init.ts
@@ -812,6 +812,7 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
     groveId: string | null,
     operatorConfirmed: boolean,
     passAggregate: PassAggregate,
+    forceFullDiff: boolean,
   ): Promise<void> {
     try {
       const memberProjectIds = memberProjectIdsForGrove(groveId);
@@ -839,7 +840,7 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
           try {
             await reconcilePartition(
               { ...baseDeps, client },
-              { machineId, projectId, table, operatorConfirmed, passAggregate },
+              { machineId, projectId, table, operatorConfirmed, passAggregate, forceFullDiff },
             );
           } catch (partitionErr) {
             logger.error(LOG_KINDS.TEAM_SYNC_ERROR, 'Reconcile partition failed (skipping)', {
@@ -887,7 +888,7 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
     if (reconcileTriggerInFlight.has(key)) return; // a pass is already running for this grove
     reconcileTriggerLastRunAt.set(key, now);
     reconcileTriggerInFlight.add(key);
-    void runReconcilePass(groveId, false, { count: 0 }).finally(() => {
+    void runReconcilePass(groveId, false, { count: 0 }, false).finally(() => {
       reconcileTriggerInFlight.delete(key);
     });
   }
@@ -908,7 +909,9 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
       cache,
       logger,
       async ({ grove, db }) => {
-        await withDatabase(db, () => runReconcilePass(grove.id, operatorConfirmed, passAggregate));
+        // Always forceFullDiff=true: the backstop and on-demand operator paths
+        // must catch equal-count / different-set drift that the poll path misses.
+        await withDatabase(db, () => runReconcilePass(grove.id, operatorConfirmed, passAggregate, true));
       },
       { daemonStateDir, jobName: 'team-sync-reconcile' },
     );

--- a/packages/myco/src/daemon/team-sync-init.ts
+++ b/packages/myco/src/daemon/team-sync-init.ts
@@ -56,7 +56,6 @@ import {
 import {
   reconcilePartition as reconcilePartitionImplDefault,
   createReconcileFlushMutex,
-  type PassAggregate,
   type ReconcileLogger,
   type ReconcilePartitionDeps,
 } from './team-reconcile.js';
@@ -96,8 +95,8 @@ export interface TeamSyncDeps {
   /**
    * Test-only seam for the per-partition reconcile orchestrator. Defaults to
    * the real `reconcilePartition`; tests inject a spy to assert the trigger
-   * wiring (which partitions get reconciled, with which operatorConfirmed +
-   * shared passAggregate) without doing real manifest/outbox I/O.
+   * wiring (which partitions get reconciled, with which forceFullDiff) without
+   * doing real manifest/outbox I/O.
    */
   reconcilePartitionImpl?: typeof reconcilePartitionImplDefault;
 }
@@ -136,15 +135,13 @@ export interface TeamSyncResult {
    */
   reconcileAllGroveFlags: (cache: GroveRuntimeCache) => Promise<void>;
   /**
-   * Run a symmetric reconcile pass across every owned (grove, project)
-   * partition. `operatorConfirmed=false` is the automatic path (count-first
-   * no-op in the steady state, magnitude-capped deletes); `operatorConfirmed=true`
-   * is the operator-confirmed on-demand path (settledness guards still apply,
-   * magnitude caps bypassed). One shared per-pass delete aggregate spans every
-   * partition so cross-partition deletes can't sum past the aggregate cap.
-   * Returns the applied-delete count for the whole pass.
+   * Run the automatic symmetric reconcile pass across every owned
+   * (grove, project) partition (always full-diff). Used by the periodic backstop
+   * and the on-demand immediacy trigger; both run the same fully-automatic
+   * reconcile. Deletes are bounded by settledness + cross-pass drift stability
+   * inside `reconcilePartition`, so there is no operator/magnitude knob here.
    */
-  reconcileAllGroves: (cache: GroveRuntimeCache, operatorConfirmed: boolean) => Promise<{ deletes: number }>;
+  reconcileAllGroves: (cache: GroveRuntimeCache) => Promise<void>;
   registerFlushJob: (runner: JobRunner, cache: GroveRuntimeCache) => void;
 }
 
@@ -253,8 +250,8 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
   //   - last-run timestamp → throttle window (see the constant above).
   //   - in-flight set → single-flight, so overlapping polls don't pile up
   //     concurrent passes for the same grove.
-  // The operator path (reconcileAllGroves operatorConfirmed=true) and the
-  // periodic backstop call runReconcilePass directly and bypass both guards.
+  // The on-demand path (reconcileAllGroves) and the periodic backstop call
+  // runReconcilePass directly and bypass both guards.
   const reconcileTriggerLastRunAt = new Map<string, number>();
   const reconcileTriggerInFlight = new Set<string>();
 
@@ -808,17 +805,15 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
    * `membershipSeeded` (the member-project set IS the seeded membership), so a
    * non-member grove is a no-op and deletes are gated until membership is known.
    *
-   * The shared `passAggregate` is threaded into every partition so deletes
-   * across all partitions in the pass can't sum past the aggregate cap. Each
-   * partition is reconciled against its owning team's worker; a project whose
-   * team client can't be built this tick is skipped (left for a later pass),
-   * never deleted. Non-throwing: any error is logged so a reconcile failure
-   * never aborts the caller (boot, flush job, or request handler).
+   * Each partition is reconciled against its owning team's worker; a project
+   * whose team client can't be built this tick is skipped (left for a later
+   * pass), never deleted. Delete blast radius is bounded inside reconcilePartition
+   * by settledness + cross-pass drift stability — no per-pass accumulator is
+   * threaded here. Non-throwing: any error is logged so a reconcile failure never
+   * aborts the caller (boot, flush job, or request handler).
    */
   async function runReconcilePass(
     groveId: string | null,
-    operatorConfirmed: boolean,
-    passAggregate: PassAggregate,
     forceFullDiff: boolean,
   ): Promise<void> {
     try {
@@ -850,7 +845,7 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
           try {
             await reconcilePartition(
               { ...baseDeps, client },
-              { machineId, projectId, table, operatorConfirmed, passAggregate, forceFullDiff },
+              { machineId, projectId, table, forceFullDiff },
             );
           } catch (partitionErr) {
             logger.error(LOG_KINDS.TEAM_SYNC_ERROR, 'Reconcile partition failed (skipping)', {
@@ -865,7 +860,6 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
     } catch (err) {
       logger.error(LOG_KINDS.TEAM_SYNC_ERROR, 'Team-sync reconcile pass failed', {
         grove_id: groveId,
-        operator_confirmed: operatorConfirmed,
         error: (err as Error).message,
       });
     }
@@ -886,9 +880,9 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
    * grove's DB. runReconcilePass is non-throwing, so the detached promise always
    * resolves (no unhandled rejection); the .finally only clears the in-flight key.
    *
-   * Only the automatic path routes through here. The operator path and the
-   * periodic backstop call runReconcilePass / reconcileAllGroves directly, so
-   * they are never throttled.
+   * The poll path keeps forceFullDiff false (cheap count-first). The on-demand
+   * path and the periodic backstop call runReconcilePass / reconcileAllGroves
+   * directly, so they are never throttled.
    */
   function triggerReconcilePass(groveId: string | null): void {
     const key = groveId ?? '';
@@ -898,34 +892,27 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
     if (reconcileTriggerInFlight.has(key)) return; // a pass is already running for this grove
     reconcileTriggerLastRunAt.set(key, now);
     reconcileTriggerInFlight.add(key);
-    void runReconcilePass(groveId, false, { count: 0 }, false).finally(() => {
+    void runReconcilePass(groveId, false).finally(() => {
       reconcileTriggerInFlight.delete(key);
     });
   }
 
   /**
-   * Fan a symmetric reconcile pass across every registered Grove. Mirrors
-   * flushAllGroves's forEachGrove fan-out (per-Grove DB pinned + scoped via
-   * withDatabase, per-Grove failures isolated). ONE passAggregate spans the
-   * whole pass — across every Grove, project, and table — so the per-pass
-   * aggregate delete cap bounds the worst case for the entire run.
+   * Fan the automatic symmetric reconcile pass across every registered Grove.
+   * Mirrors flushAllGroves's forEachGrove fan-out (per-Grove DB pinned + scoped
+   * via withDatabase, per-Grove failures isolated). Always full-diff so equal-
+   * count / different-set drift the poll path misses is caught; delete blast
+   * radius is bounded per-partition by settledness + cross-pass drift stability.
    */
-  async function reconcileAllGroves(
-    cache: GroveRuntimeCache,
-    operatorConfirmed: boolean,
-  ): Promise<{ deletes: number }> {
-    const passAggregate: PassAggregate = { count: 0 };
+  async function reconcileAllGroves(cache: GroveRuntimeCache): Promise<void> {
     await forEachGrove(
       cache,
       logger,
       async ({ grove, db }) => {
-        // Always forceFullDiff=true: the backstop and on-demand operator paths
-        // must catch equal-count / different-set drift that the poll path misses.
-        await withDatabase(db, () => runReconcilePass(grove.id, operatorConfirmed, passAggregate, true));
+        await withDatabase(db, () => runReconcilePass(grove.id, true));
       },
       { daemonStateDir, jobName: 'team-sync-reconcile' },
     );
-    return { deletes: passAggregate.count };
   }
 
   async function reconcileClient(requestContext = defaultRequestContext): Promise<void> {
@@ -1003,13 +990,14 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
       }
       // (6) Re-enable the symmetric reconcile delete/upsert seed after backfill
       //     whenever this grove participates (≥1 member project ⇒ participates &&
-      //     membershipSeeded). Automatic path (operatorConfirmed=false). This is
-      //     dispatched throttled + fire-and-forget (triggerReconcilePass): the
-      //     Team-page read poll path calls reconcileClient on every poll, so the
-      //     per-partition summary fetches must not run on every poll nor block the
-      //     handler response. A fresh per-call aggregate bounds the pass's deletes;
-      //     the seed and this flush serialize via the shared mutex (MF3) so the
-      //     reconcile-seeded rows drain on this or the next flush tick.
+      //     membershipSeeded). This is dispatched throttled + fire-and-forget
+      //     (triggerReconcilePass): the Team-page read poll path calls
+      //     reconcileClient on every poll, so the per-partition summary fetches
+      //     must not run on every poll nor block the handler response. Delete
+      //     blast radius is bounded per-partition by settledness + cross-pass
+      //     drift stability; the seed and this flush serialize via the shared
+      //     mutex (MF3) so the reconcile-seeded rows drain on this or the next
+      //     flush tick.
       if (participates) {
         triggerReconcilePass(groveId);
       }
@@ -1202,7 +1190,7 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
 
       // Periodic symmetric-reconcile BACKSTOP. The trigger paths (reconcileClient
       // on boot / team reactions / membership changes) cover the common cases;
-      // this housekeeping job re-runs the count-first automatic reconcile across
+      // this housekeeping job re-runs the full-diff automatic reconcile across
       // every Grove on a low cadence so drift that no trigger noticed (a restore,
       // a missed delete) self-heals. Same registration shape as the flush job;
       // 'housekeeping' kind keeps it in the background lane so a long pass can't
@@ -1218,7 +1206,7 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
           const now = Date.now();
           if (now - lastReconcileAt < TEAM_SYNC_RECONCILE_INTERVAL_MS) return;
           lastReconcileAt = now;
-          await reconcileAllGroves(cache, false);
+          await reconcileAllGroves(cache);
         },
       });
     },

--- a/packages/myco/src/daemon/team-sync-init.ts
+++ b/packages/myco/src/daemon/team-sync-init.ts
@@ -171,6 +171,26 @@ export interface TeamFlushAggregate {
  */
 const TEAM_SYNC_RECONCILE_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
+/**
+ * Per-grove rate limit for the reconcileClient-triggered reconcile pass.
+ *
+ * A reconcile pass does roughly one summary manifest fetch per
+ * (project × eligible-table) partition, and reconcileClient is invoked on every
+ * Team-page read poll (status/members/queue-stats/sync-summary/dlq) which fires
+ * every 5-10s while a Team page is open. Without a rate limit an open Team page
+ * sustains a continuous stream of full reconcile passes (worker load + latency).
+ *
+ * 2 minutes is ~12-24x the poll interval, so it collapses the burst of polls an
+ * open Team page produces into at most one pass per grove per 2 minutes — over a
+ * 90% cut in poll-path manifest traffic — while keeping drift-healing on an
+ * actively-watched page far tighter than the 6h periodic backstop. This is a
+ * pure rate limit (an in-memory last-run timestamp), NOT a synthetic transition
+ * flag, so it does not reintroduce SF2. The FIRST call after connect has no
+ * prior timestamp and always runs, preserving connect-time auto-heal; the
+ * operator path and the periodic backstop bypass it entirely.
+ */
+const TEAM_SYNC_RECONCILE_TRIGGER_THROTTLE_MS = 2 * 60 * 1000;
+
 // ---------------------------------------------------------------------------
 // Config-seed planner
 // ---------------------------------------------------------------------------
@@ -225,6 +245,18 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
   // deps) AND the flush-drain path (flushPending wraps its body in it), so a
   // reconcile that is mid-seed and a flush that is mid-drain never interleave.
   const reconcileFlushMutex = createReconcileFlushMutex();
+
+  // Rate-limit + single-flight state for the reconcileClient-triggered reconcile
+  // pass, keyed per grove (empty string for the null/boot grove). The automatic
+  // poll path (reconcileTeamRoute → reconcileClient) hits this on every Team-page
+  // poll, so it must NOT each launch a full per-partition summary-fetch pass.
+  //   - last-run timestamp → throttle window (see the constant above).
+  //   - in-flight set → single-flight, so overlapping polls don't pile up
+  //     concurrent passes for the same grove.
+  // The operator path (reconcileAllGroves operatorConfirmed=true) and the
+  // periodic backstop call runReconcilePass directly and bypass both guards.
+  const reconcileTriggerLastRunAt = new Map<string, number>();
+  const reconcileTriggerInFlight = new Set<string>();
 
   // Adapt the daemon logger (info(kind, msg, fields)) to the reconcile module's
   // minimal info/warn(message) surface, tagging team-sync log kinds.
@@ -820,6 +852,38 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
   }
 
   /**
+   * Trigger the AUTOMATIC reconcile pass from the reconcileClient path without
+   * adding latency to the (frequently-polled) Team-page read handlers.
+   *
+   * Two guards keep the poll path cheap (see the rate-limit constant): a per-grove
+   * throttle window and a per-grove single-flight set. When neither guard skips,
+   * the pass is dispatched FIRE-AND-FORGET — the read handler never awaits it, so
+   * the per-partition summary fetches never sit on the response path. This mirrors
+   * the JobRunner's single-flight + non-blocking dispatch discipline; the pass is
+   * async I/O so it yields at every await and can't starve the loop. The
+   * AsyncLocalStorage database scope active at the call site is captured by the
+   * promise, so getDatabase() inside the background pass still resolves to this
+   * grove's DB. runReconcilePass is non-throwing, so the detached promise always
+   * resolves (no unhandled rejection); the .finally only clears the in-flight key.
+   *
+   * Only the automatic path routes through here. The operator path and the
+   * periodic backstop call runReconcilePass / reconcileAllGroves directly, so
+   * they are never throttled.
+   */
+  function triggerReconcilePass(groveId: string | null): void {
+    const key = groveId ?? '';
+    const now = Date.now();
+    const last = reconcileTriggerLastRunAt.get(key) ?? 0;
+    if (now - last < TEAM_SYNC_RECONCILE_TRIGGER_THROTTLE_MS) return; // throttled
+    if (reconcileTriggerInFlight.has(key)) return; // a pass is already running for this grove
+    reconcileTriggerLastRunAt.set(key, now);
+    reconcileTriggerInFlight.add(key);
+    void runReconcilePass(groveId, false, { count: 0 }).finally(() => {
+      reconcileTriggerInFlight.delete(key);
+    });
+  }
+
+  /**
    * Fan a symmetric reconcile pass across every registered Grove. Mirrors
    * flushAllGroves's forEachGrove fan-out (per-Grove DB pinned + scoped via
    * withDatabase, per-Grove failures isolated). ONE passAggregate spans the
@@ -901,13 +965,15 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
       }
       // (6) Re-enable the symmetric reconcile delete/upsert seed after backfill
       //     whenever this grove participates (≥1 member project ⇒ participates &&
-      //     membershipSeeded). Automatic path (operatorConfirmed=false): the
-      //     count-first no-op keeps a steady-state partition cheap, so this runs
-      //     unconditionally on every reconcile without a synthetic transition
-      //     flag. A fresh per-call aggregate bounds this reconcile's deletes;
-      //     runReconcilePass is itself non-throwing so it can't abort the flush.
+      //     membershipSeeded). Automatic path (operatorConfirmed=false). This is
+      //     dispatched throttled + fire-and-forget (triggerReconcilePass): the
+      //     Team-page read poll path calls reconcileClient on every poll, so the
+      //     per-partition summary fetches must not run on every poll nor block the
+      //     handler response. A fresh per-call aggregate bounds the pass's deletes;
+      //     the seed and this flush serialize via the shared mutex (MF3) so the
+      //     reconcile-seeded rows drain on this or the next flush tick.
       if (participates) {
-        await runReconcilePass(groveId, false, { count: 0 });
+        triggerReconcilePass(groveId);
       }
       await flushPending(requestContext);
     } catch (err) {

--- a/packages/myco/src/daemon/team-sync-init.ts
+++ b/packages/myco/src/daemon/team-sync-init.ts
@@ -62,7 +62,7 @@ import {
 } from './team-reconcile.js';
 import { upsertSelfMember } from '@myco/db/queries/team-members.js';
 import { setTeamSyncEnabled, setProjectSyncMembership } from '@myco/db/queries/team-sync-state.js';
-import { memberProjectIdsForGrove, machineHasAnyTeam } from '@myco/grove/project-tenancy.js';
+import { memberProjectIdsForGrove, machineHasAnyTeamResolved } from '@myco/grove/project-tenancy.js';
 import {
   SYNC_PROTOCOL_VERSION,
   TEAM_API_KEY_SECRET,
@@ -968,7 +968,14 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
     //     pending rows that the project-scoped purge above leaves behind, then
     //     stop — there is nowhere to route. Without this the Team page would
     //     keep surfacing "N pending failures" against a Grove in no Team.
-    if (!machineHasAnyTeam()) {
+    //     Only purge on a confirmed read — an indeterminate result (e.g.
+    //     registry mid-migration/unreadable) must not delete rows that may
+    //     belong to a team we couldn't observe.
+    const machineTeamRes = machineHasAnyTeamResolved();
+    if (!machineTeamRes.resolved) {
+      return; // indeterminate — leave all state, including pending rows, untouched
+    }
+    if (!machineTeamRes.hasTeam) {
       try {
         purgePendingOutbox();
       } catch (err) {

--- a/packages/myco/src/daemon/team-sync-init.ts
+++ b/packages/myco/src/daemon/team-sync-init.ts
@@ -286,7 +286,8 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
 
   /** Boolean convenience over `memberProjectIdsForGrove`, used by the deep-sleep `pending` probe. */
   function groveParticipates(groveId: string | null): boolean {
-    return memberProjectIdsForGrove(groveId).length > 0;
+    const resolution = memberProjectIdsForGrove(groveId);
+    return resolution.resolved && resolution.projectIds.length > 0;
   }
 
   function participatingTeamIds(groveId: string | null): string[] {
@@ -522,16 +523,22 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
 
     const groveId = requestContext?.groveId ?? null;
     const teams = teamRegistry.list();
-    const memberProjectIds = memberProjectIdsForGrove(groveId);
+    const memberResolution = memberProjectIdsForGrove(groveId);
+    const memberProjectIds = memberResolution.resolved ? memberResolution.projectIds : [];
     // The registry is now the write-path gate: keep delete triggers + syncRow
     // in lockstep with whether this Grove feeds any team via project membership,
     // every tick. The per-project member set + non-member purge self-correct on
     // every served Grove regardless of which entry point last reconciled them.
     // (Machine-scoped self rows reach the outbox through backfillUnsynced, which
     // bypasses this flag, so a joined-no-project Grove still queues its self row.)
-    setTeamSyncEnabled(memberProjectIds.length > 0);
-    setProjectSyncMembership(memberProjectIds);
-    purgeNonMemberOutbox(memberProjectIds);
+    // Only act when the registry was successfully read: a failed/indeterminate
+    // read must not flip enabled off or purge rows for projects that may still
+    // be members.
+    if (memberResolution.resolved) {
+      setTeamSyncEnabled(memberProjectIds.length > 0);
+      setProjectSyncMembership(memberProjectIds);
+      purgeNonMemberOutbox(memberProjectIds);
+    }
     // Short-circuit only when this machine has joined no team at all — there is
     // nowhere to route any row. With ≥1 registered team we must still drain
     // machine-scoped rows even if no project participates.
@@ -815,9 +822,12 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
     forceFullDiff: boolean,
   ): Promise<void> {
     try {
-      const memberProjectIds = memberProjectIdsForGrove(groveId);
+      const memberResolution = memberProjectIdsForGrove(groveId);
       // participates && membershipSeeded both reduce to a non-empty member set.
-      if (memberProjectIds.length === 0) return;
+      // An unresolved (indeterminate) registry read also short-circuits: we
+      // cannot reconcile without knowing which projects are members.
+      if (!memberResolution.resolved || memberResolution.projectIds.length === 0) return;
+      const memberProjectIds = memberResolution.projectIds;
 
       const membershipByProject = teamRegistry.membershipByProject();
       const baseDeps: Omit<ReconcilePartitionDeps, 'client'> = {
@@ -920,29 +930,38 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
 
   async function reconcileClient(requestContext = defaultRequestContext): Promise<void> {
     const groveId = requestContext?.groveId ?? null;
-    const memberProjectIds = memberProjectIdsForGrove(groveId);
-    const participates = memberProjectIds.length > 0;
+    const memberResolution = memberProjectIdsForGrove(groveId);
+    const memberProjectIds = memberResolution.resolved ? memberResolution.projectIds : [];
+    const participates = memberResolution.resolved && memberProjectIds.length > 0;
 
     // (1) Reconcile the per-Grove gate state read by syncRow / backfillRows /
     //     delete triggers: the enablement flag AND the per-project member set.
-    setTeamSyncEnabled(participates);
-    setProjectSyncMembership(memberProjectIds);
+    //     Only when the registry was successfully read — a failed/indeterminate
+    //     read must not flip enabled off (D1 orphan risk) or clear membership.
+    if (memberResolution.resolved) {
+      setTeamSyncEnabled(participates);
+      setProjectSyncMembership(memberProjectIds);
+    }
 
-    // (2) Drop outbox rows for non-member projects (sent or pending). Always
-    //     runs — self-heals historical bloat and prevents the re-enqueue loop.
-    try {
-      const purged = purgeNonMemberOutbox(memberProjectIds);
-      if (purged > 0) {
-        logger.info(LOG_KINDS.TEAM_SYNC_START, 'Purged outbox rows for non-member projects', {
+    // (2) Drop outbox rows for non-member projects (sent or pending). Only
+    //     when membership is confirmed: purging with an empty list when the
+    //     registry was unreadable would discard rows for projects that may
+    //     still be members.
+    if (memberResolution.resolved) {
+      try {
+        const purged = purgeNonMemberOutbox(memberProjectIds);
+        if (purged > 0) {
+          logger.info(LOG_KINDS.TEAM_SYNC_START, 'Purged outbox rows for non-member projects', {
+            grove_id: groveId,
+            purged,
+          });
+        }
+      } catch (err) {
+        logger.warn(LOG_KINDS.TEAM_SYNC_ERROR, 'Non-member outbox purge failed', {
           grove_id: groveId,
-          purged,
+          error: (err as Error).message,
         });
       }
-    } catch (err) {
-      logger.warn(LOG_KINDS.TEAM_SYNC_ERROR, 'Non-member outbox purge failed', {
-        grove_id: groveId,
-        error: (err as Error).message,
-      });
     }
 
     // (3) Machine in NO team: also clear leftover machine-scoped (self-row)
@@ -1108,10 +1127,16 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
       logger,
       async ({ grove, databasePath, db, groveHome }) => {
         await withDatabase(db, async () => {
-          const memberProjectIds = memberProjectIdsForGrove(grove.id);
-          setTeamSyncEnabled(memberProjectIds.length > 0);
-          setProjectSyncMembership(memberProjectIds);
-          purgeNonMemberOutbox(memberProjectIds);
+          const memberResolution = memberProjectIdsForGrove(grove.id);
+          // Only write state when the registry was successfully read. A
+          // failed/indeterminate read (e.g. mid-migration directory unavailable)
+          // must not flip enabled off and silence delete-trigger journaling.
+          if (memberResolution.resolved) {
+            const memberProjectIds = memberResolution.projectIds;
+            setTeamSyncEnabled(memberProjectIds.length > 0);
+            setProjectSyncMembership(memberProjectIds);
+            purgeNonMemberOutbox(memberProjectIds);
+          }
         });
       },
       { daemonStateDir, jobName: 'team-sync-flag-reconcile', parallel: true },

--- a/packages/myco/src/daemon/team-sync.ts
+++ b/packages/myco/src/daemon/team-sync.ts
@@ -271,6 +271,46 @@ export interface TeamMembersListResponse {
   members: TeamMemberWire[];
 }
 
+/**
+ * One item in a paged /manifest response.
+ * `content_hash` is present only for content-hashed tables
+ * (sessions, prompt_batches, spores, plans); absent for others.
+ */
+export interface ManifestItem {
+  id: string;
+  project_id?: string;
+  content_hash?: string;
+}
+
+/**
+ * Response from the worker's GET /manifest endpoint.
+ *
+ * Summary mode (`summary=1`): `items` and `next_cursor` are absent.
+ * Paged mode (default): `items` is present; `next_cursor` is present
+ * only when more pages remain.
+ *
+ * `cheap_agg` is MAX(rowid), 0 when the partition is empty.
+ * `project_id` echoes the request's project_id; absent when the request
+ * omitted it.
+ */
+export interface ManifestResponse {
+  table: string;
+  machine_id: string;
+  project_id?: string;
+  count: number;
+  cheap_agg: number;
+  items?: ManifestItem[];
+  next_cursor?: string;
+}
+
+/** Options accepted by `getManifest`. */
+export interface GetManifestOptions {
+  projectId?: string;
+  cursor?: string;
+  limit?: number;
+  summary?: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Client
 // ---------------------------------------------------------------------------
@@ -503,6 +543,40 @@ export class TeamSyncClient {
       ? `/sync-summary?machine_id=${encodeURIComponent(machineId)}`
       : '/sync-summary';
     return await this.request('GET', path) as TeamRemoteSyncSummaryResponse;
+  }
+
+  /**
+   * Fetch a per-partition manifest from the worker's GET /manifest endpoint.
+   *
+   * Summary mode (`summary: true`): returns count + cheap_agg only — no items.
+   * Paged mode (default): returns a page of {id, project_id?, content_hash?}
+   * items. Pagination continues while `next_cursor` is present in the response.
+   */
+  async getManifest(
+    machineId: string,
+    table: string,
+    options: GetManifestOptions,
+  ): Promise<ManifestResponse> {
+    const params = new URLSearchParams();
+    params.set('machine_id', machineId);
+    params.set('table', table);
+    if (options.projectId != null) params.set('project_id', options.projectId);
+    if (options.cursor != null) params.set('cursor', options.cursor);
+    if (options.limit != null) params.set('limit', String(options.limit));
+    if (options.summary) params.set('summary', '1');
+    return await this.request('GET', `/manifest?${params.toString()}`, undefined, {
+      timeoutMs: TEAM_REQUEST_TIMEOUT_MS,
+    }) as ManifestResponse;
+  }
+
+  /**
+   * Returns true when the worker has advertised sync protocol version >= 3,
+   * indicating that the GET /manifest endpoint is available.
+   * Returns false if the version has not been probed yet (undefined) or is < 3.
+   */
+  supportsManifest(): boolean {
+    const version = this.getWorkerProtocolVersion();
+    return version !== undefined && version >= 3;
   }
 
   /**

--- a/packages/myco/src/daemon/team-sync.ts
+++ b/packages/myco/src/daemon/team-sync.ts
@@ -289,7 +289,6 @@ export interface ManifestItem {
  * Paged mode (default): `items` is present; `next_cursor` is present
  * only when more pages remain.
  *
- * `cheap_agg` is MAX(rowid), 0 when the partition is empty.
  * `project_id` echoes the request's project_id; absent when the request
  * omitted it.
  */
@@ -298,7 +297,6 @@ export interface ManifestResponse {
   machine_id: string;
   project_id?: string;
   count: number;
-  cheap_agg: number;
   items?: ManifestItem[];
   next_cursor?: string;
 }
@@ -548,7 +546,7 @@ export class TeamSyncClient {
   /**
    * Fetch a per-partition manifest from the worker's GET /manifest endpoint.
    *
-   * Summary mode (`summary: true`): returns count + cheap_agg only — no items.
+   * Summary mode (`summary: true`): returns count only — no items.
    * Paged mode (default): returns a page of {id, project_id?, content_hash?}
    * items. Pagination continues while `next_cursor` is present in the response.
    */

--- a/packages/myco/src/db/migrations.ts
+++ b/packages/myco/src/db/migrations.ts
@@ -122,6 +122,7 @@ export const MIGRATIONS: Migration[] = [
   { version: 60, migrate: (db) => migrateV59ToV60(db) },
   { version: 61, migrate: (db) => migrateV60ToV61(db) },
   { version: 62, migrate: (db) => migrateV61ToV62(db) },
+  { version: 63, migrate: (db) => migrateV62ToV63(db) },
 ];
 
 // ---------------------------------------------------------------------------
@@ -3896,6 +3897,71 @@ function migrateV61ToV62(db: Database): void {
     db.prepare(
       `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`,
     ).run(62, epochSeconds());
+    db.prepare('COMMIT').run();
+  } catch (err) {
+    db.prepare('ROLLBACK').run();
+    throw err;
+  }
+}
+
+/**
+ * Frozen at the v63 revision: the membership-only delete triggers. Per the
+ * frozen-DDL rules above, this never references the live TEAM_DELETE_TRIGGERS
+ * constant — later edits to the live DDL would silently change this migration's
+ * semantics. The trigger snapshot must stay byte-equivalent (after whitespace
+ * normalization) to the live TEAM_DELETE_TRIGGERS so fresh and migrated vaults
+ * converge (tests/db/migration-matrix.test.ts).
+ *
+ * Later additions to the live TEAM_DELETE_TRIGGER_TABLES must NOT appear here:
+ * a CREATE TRIGGER on a table that does not exist yet at this point in the
+ * chain throws and bricks the upgrade (the v41 failure class).
+ */
+const V63_TEAM_DELETE_TRIGGER_TABLES = [
+  'sessions', 'prompt_batches', 'spores', 'entities', 'graph_edges',
+  'resolution_events', 'plans', 'artifacts', 'digest_extracts',
+  'skill_candidates', 'skill_records', 'skill_usage', 'knowledge_release_state',
+] as const;
+
+const V63_TEAM_DELETE_TRIGGERS: readonly string[] = V63_TEAM_DELETE_TRIGGER_TABLES.map(
+  (table) => `
+  CREATE TRIGGER IF NOT EXISTS ${table}_team_ad
+  AFTER DELETE ON ${table}
+  WHEN OLD.project_id IN (SELECT project_id FROM team_sync_membership)
+  BEGIN
+    INSERT INTO team_outbox (table_name, row_id, operation, payload, machine_id, project_id, created_at)
+    VALUES ('${table}', CAST(OLD.id AS TEXT), 'delete',
+            json_object('id', OLD.id, 'machine_id', OLD.machine_id),
+            OLD.machine_id, OLD.project_id, CAST(strftime('%s','now') AS INTEGER));
+  END`,
+);
+
+/**
+ * v62 -> v63: drop the `enabled` gate from the per-table delete triggers.
+ *
+ * The triggers previously fired only WHEN team_sync_state.enabled = 1. That
+ * flag is auto-derived and transiently flips to 0 (e.g. the ~/.myco-team
+ * home-move window when membership momentarily resolves empty). A delete during
+ * that window was silently dropped, and — unlike an upsert, whose source row
+ * persists and re-backfills — a deleted row leaves no local trace, so it became
+ * a permanent D1 orphan. Re-gate on the stable `team_sync_membership`
+ * projection alone (kept from being wiped on a transient registry read) so a
+ * member project's delete is always tombstoned regardless of the volatile flag;
+ * membership gating for what actually ships stays on the push/flush path.
+ * ALTER does not refresh trigger bodies, so DROP + recreate is required.
+ */
+function migrateV62ToV63(db: Database): void {
+  db.prepare('BEGIN').run();
+  try {
+    for (const table of V63_TEAM_DELETE_TRIGGER_TABLES) {
+      db.exec(`DROP TRIGGER IF EXISTS ${table}_team_ad`);
+    }
+    for (const trg of V63_TEAM_DELETE_TRIGGERS) {
+      db.exec(trg);
+    }
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`,
+    ).run(63, epochSeconds());
     db.prepare('COMMIT').run();
   } catch (err) {
     db.prepare('ROLLBACK').run();

--- a/packages/myco/src/db/queries/team-outbox.ts
+++ b/packages/myco/src/db/queries/team-outbox.ts
@@ -515,6 +515,25 @@ export const TEAM_SYNC_BACKFILL_TABLES = [
  */
 export const REBUILD_TABLES = [...TEAM_SYNC_BACKFILL_TABLES, 'skill_usage'] as const;
 
+/**
+ * Tables eligible for symmetric reconcile (the daemon's project-partition diff
+ * against the worker's GET /manifest). Mirrors the worker-side
+ * MANIFEST_ELIGIBLE_TABLES (`src/worker/src/manifest.ts`) — the synced set minus
+ * the id-less `entity_mentions` — further restricted to PROJECT-scoped tables.
+ *
+ * Reconcile runs strictly per (machine_id, project_id) partition, so the
+ * machine-scoped `team_members` table (no `project_id` column; maintained via
+ * reconcileSelfMember + backfill) is excluded — interpolating it into the
+ * project-scoped partition query would reference a non-existent column.
+ *
+ * Only these names may be interpolated into the reconcile path's table-name SQL
+ * (`localPartition`, `buildUpsertPayload`); the allow-list is the SQL-injection
+ * safety boundary — never pass an arbitrary table name into that path.
+ */
+export const RECONCILE_ELIGIBLE_TABLES: readonly string[] = REBUILD_TABLES.filter(
+  (t) => t !== 'team_members',
+);
+
 // Canonical synced/observed set now lives in the dependency-free schema-ddl
 // module (so the migration chain can import it without pulling db/client →
 // bun:sqlite into the worker-CLI bundle). Imported above for internal use and

--- a/packages/myco/src/db/queries/team-outbox.ts
+++ b/packages/myco/src/db/queries/team-outbox.ts
@@ -608,6 +608,90 @@ export function backfillAllForRebuild(machineId: string): number {
   return backfillRows(machineId, 'all', REBUILD_TABLES);
 }
 
+// ---------------------------------------------------------------------------
+// Reconcile helpers (symmetric reconcile)
+// ---------------------------------------------------------------------------
+
+/**
+ * A minimal row shape for partition comparisons.
+ * `content_hash` is present only for tables that carry the column
+ * (sessions, prompt_batches, spores, plans).
+ */
+export interface PartitionRow {
+  id: string;
+  content_hash?: string;
+}
+
+/**
+ * Return all local rows for a (machineId, projectId, table) partition in the
+ * minimal `{ id, content_hash? }` shape needed by diffPartition.
+ *
+ * Always uses `1=1` as the row predicate (the reconcile path needs the full
+ * local id-set, not just unsynced rows). Tables that lack a `synced_at`
+ * column — specifically skill_usage — are safe here because no
+ * `synced_at IS NULL` predicate is applied.
+ *
+ * `content_hash` is included in the SELECT only when the table's schema
+ * carries that column (detected via PRAGMA table_info). For presence-only
+ * tables the returned rows have no `content_hash` property so diffPartition
+ * skips stale detection automatically.
+ */
+export function localPartition(
+  machineId: string,
+  projectId: string,
+  table: string,
+): PartitionRow[] {
+  const db = getDatabase();
+
+  // Detect available columns for this table via the schema.
+  const cols = new Set(
+    (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>)
+      .map((r) => r.name),
+  );
+
+  const selectCols = cols.has('content_hash') ? 'id, content_hash' : 'id';
+
+  const rows = db.prepare(
+    `SELECT ${selectCols}
+     FROM ${table}
+     WHERE machine_id = ? AND project_id = ?`,
+  ).all(machineId, projectId) as Array<{ id: string; content_hash?: string }>;
+
+  return rows.map((r) => {
+    const row: PartitionRow = { id: String(r.id) };
+    if (cols.has('content_hash') && r.content_hash != null) {
+      row.content_hash = r.content_hash;
+    }
+    return row;
+  });
+}
+
+/**
+ * Return the set of row_ids in team_outbox that are still pending
+ * (`sent_at IS NULL`) for the exact (table, machine_id, project_id) partition.
+ *
+ * Used by the reconcile orchestrator to skip rows already in-flight so the
+ * outbox is not double-enqueued before the pending entries drain.
+ */
+export function pendingRowIdsForPartition(
+  table: string,
+  machineId: string,
+  projectId: string,
+): Set<string> {
+  const db = getDatabase();
+
+  const rows = db.prepare(
+    `SELECT row_id
+     FROM team_outbox
+     WHERE table_name = ?
+       AND machine_id = ?
+       AND project_id = ?
+       AND sent_at IS NULL`,
+  ).all(table, machineId, projectId) as Array<{ row_id: string }>;
+
+  return new Set(rows.map((r) => r.row_id));
+}
+
 function backfillRows(
   machineId: string,
   mode: 'unsynced' | 'all',

--- a/packages/myco/src/db/schema-ddl.ts
+++ b/packages/myco/src/db/schema-ddl.ts
@@ -980,10 +980,17 @@ export type TeamSyncObservedTable = (typeof TEAM_SYNC_OBSERVED_TABLES)[number];
  * Team-sync delete triggers — one per synced table.
  *
  * Auto-journal every local delete into `team_outbox` so the one-way push
- * to D1 mirrors deletions. Gated on the Grove's own `team_sync_state.enabled`
- * (NULL/absent row => disabled). Widens the FTS auto-sync-trigger pattern
- * above. `entity_mentions` is intentionally absent — no single `id` column,
- * never reaches D1.
+ * to D1 mirrors deletions. Gated solely on stable team membership: the row's
+ * project must be in `team_sync_membership`. The volatile
+ * `team_sync_state.enabled` flag is deliberately NOT consulted — it is
+ * auto-derived and transiently flips to 0 (e.g. the ~/.myco-team home-move
+ * window), and a delete dropped during that window leaves no local trace, so
+ * it would become a permanent D1 orphan. Membership is the stable signal
+ * (kept from being wiped on a transient registry read), so a paused/transition
+ * window delays a push but never loses a member's delete; push-side membership
+ * gating still bounds what actually ships. Widens the FTS auto-sync-trigger
+ * pattern above. `entity_mentions` is intentionally absent — no single `id`
+ * column, never reaches D1.
  */
 export const TEAM_DELETE_TRIGGER_TABLES = [
   'sessions', 'prompt_batches', 'spores', 'entities', 'graph_edges',
@@ -999,8 +1006,7 @@ export const TEAM_DELETE_TRIGGERS: readonly string[] = TEAM_DELETE_TRIGGER_TABLE
   (table) => `
   CREATE TRIGGER IF NOT EXISTS ${table}_team_ad
   AFTER DELETE ON ${table}
-  WHEN (SELECT enabled FROM team_sync_state) = 1
-    AND OLD.project_id IN (SELECT project_id FROM team_sync_membership)
+  WHEN OLD.project_id IN (SELECT project_id FROM team_sync_membership)
   BEGIN
     INSERT INTO team_outbox (table_name, row_id, operation, payload, machine_id, project_id, created_at)
     VALUES ('${table}', CAST(OLD.id AS TEXT), 'delete',

--- a/packages/myco/src/db/schema.ts
+++ b/packages/myco/src/db/schema.ts
@@ -20,7 +20,7 @@ import { TABLE_DDLS, FTS_TABLES, SECONDARY_INDEXES, TEAM_DELETE_TRIGGERS } from 
 import { MIGRATIONS } from './migrations.js';
 
 /** Current schema version -- fresh start for the SQLite era. */
-export const SCHEMA_VERSION = 62;
+export const SCHEMA_VERSION = 63;
 
 // Re-export for backwards compat (other modules import from schema.ts)
 export { DEFAULT_MACHINE_ID };

--- a/packages/myco/src/grove/project-lifecycle.ts
+++ b/packages/myco/src/grove/project-lifecycle.ts
@@ -102,7 +102,13 @@ export function deleteProjectPermanently(
     // on this freshly-opened handle too — otherwise a member project's delete
     // would silently skip journaling.
     const memberResolution = memberProjectIdsForGrove(groveId);
-    setProjectSyncMembership(memberResolution.resolved ? memberResolution.projectIds : [], db);
+    // Only write membership when the registry was successfully read. An
+    // indeterminate read leaves the prior membership in place — that is the
+    // best available outcome, since replacing it with a known-wrong empty
+    // list would cause member-project deletes to silently skip D1 journaling.
+    if (memberResolution.resolved) {
+      setProjectSyncMembership(memberResolution.projectIds, db);
+    }
     // Each `DELETE FROM <table> WHERE project_id = ?` in deleteProjectRows
     // fires that table's `_team_ad` trigger, which journals the delete to
     // team_outbox when this Grove's team_sync_state.enabled = 1. No manual

--- a/packages/myco/src/grove/project-lifecycle.ts
+++ b/packages/myco/src/grove/project-lifecycle.ts
@@ -101,7 +101,8 @@ export function deleteProjectPermanently(
     // OLD.project_id is a member), so the per-project member set must be present
     // on this freshly-opened handle too — otherwise a member project's delete
     // would silently skip journaling.
-    setProjectSyncMembership(memberProjectIdsForGrove(groveId), db);
+    const memberResolution = memberProjectIdsForGrove(groveId);
+    setProjectSyncMembership(memberResolution.resolved ? memberResolution.projectIds : [], db);
     // Each `DELETE FROM <table> WHERE project_id = ?` in deleteProjectRows
     // fires that table's `_team_ad` trigger, which journals the delete to
     // team_outbox when this Grove's team_sync_state.enabled = 1. No manual

--- a/packages/myco/src/grove/project-tenancy.ts
+++ b/packages/myco/src/grove/project-tenancy.ts
@@ -35,19 +35,40 @@ export function resolveProjectTenancy(projectId: string): ProjectTenancy {
 }
 
 /**
+ * Discriminated result from `memberProjectIdsForGrove`. `resolved: true` means
+ * the team registry was successfully read (even if the project list is empty —
+ * that is a confirmed non-member state). `resolved: false` means the registry
+ * directory exists but could not be read (indeterminate — callers must NOT
+ * treat this as confirmed-empty and must leave any enabled/membership state
+ * unchanged).
+ */
+export type MemberProjectResolution =
+  | { resolved: true; projectIds: string[] }
+  | { resolved: false };
+
+/**
  * Member projects (assigned to any team) that live in this grove. The authority
  * computation that `reconcileClient` projects into `team_sync_membership`.
+ *
+ * Returns a discriminated result so callers can distinguish a confirmed
+ * non-member state (`resolved: true, projectIds: []`) from an indeterminate
+ * read failure (`resolved: false`). Only the former should disable team sync.
  */
-export function memberProjectIdsForGrove(groveId: string | null): string[] {
-  if (!groveId) return [];
-  return [
-    ...new Set(
-      teamRegistry.list()
-        .flatMap((t) => t.projects)
-        .filter((p) => p.grove_id === groveId)
-        .map((p) => p.project_id),
-    ),
-  ];
+export function memberProjectIdsForGrove(groveId: string | null): MemberProjectResolution {
+  if (!groveId) return { resolved: true, projectIds: [] };
+  const result = teamRegistry.listResolved();
+  if (!result.resolved) return { resolved: false };
+  return {
+    resolved: true,
+    projectIds: [
+      ...new Set(
+        result.teams
+          .flatMap((t) => t.projects)
+          .filter((p) => p.grove_id === groveId)
+          .map((p) => p.project_id),
+      ),
+    ],
+  };
 }
 
 /** True when this machine has joined at least one team. */

--- a/packages/myco/src/grove/project-tenancy.ts
+++ b/packages/myco/src/grove/project-tenancy.ts
@@ -75,6 +75,23 @@ export function memberProjectIdsForGrove(groveId: string | null): MemberProjectR
 export const machineHasAnyTeam = (): boolean => teamRegistry.list().length > 0;
 
 /**
+ * Discriminated variant of `machineHasAnyTeam`. Returns `{ resolved: false }`
+ * when the team directory exists but cannot be read (e.g. ENOTDIR during a
+ * migration window). Callers that must not act on an unconfirmed "no teams"
+ * state — such as paths that would delete pending outbox rows — should use
+ * this instead of `machineHasAnyTeam()`.
+ */
+export type MachineTeamResolution =
+  | { resolved: true; hasTeam: boolean }
+  | { resolved: false };
+
+export function machineHasAnyTeamResolved(): MachineTeamResolution {
+  const result = teamRegistry.listResolved();
+  if (!result.resolved) return { resolved: false };
+  return { resolved: true, hasTeam: result.teams.length > 0 };
+}
+
+/**
  * The "check" at assignment boundaries: a project may only be referenced by a
  * global construct (team) if it exists and resolves to a grove.
  */

--- a/packages/myco/src/team/registry.ts
+++ b/packages/myco/src/team/registry.ts
@@ -55,6 +55,36 @@ function list(): TeamRecord[] {
   return results;
 }
 
+/**
+ * Discriminated variant of `list()`. Returns `{ resolved: false }` when the
+ * teams directory exists but cannot be read (e.g. ENOTDIR during a migration
+ * window). Callers that must distinguish "confirmed no teams" from "couldn't
+ * determine" should use this instead of `list()`.
+ *
+ * `resolved: true` is returned for both "directory does not exist" (confirmed
+ * no teams — the directory is created on first join) and "directory readable"
+ * (zero or more teams). `resolved: false` means the directory exists but the
+ * read failed; the result is indeterminate and callers must not treat it as
+ * an empty team set.
+ */
+export type TeamListResult = { resolved: true; teams: TeamRecord[] } | { resolved: false };
+
+function listResolved(): TeamListResult {
+  const teamsDir = resolveTeamsDir();
+  if (!fs.existsSync(teamsDir)) return { resolved: true, teams: [] };
+  const results: TeamRecord[] = [];
+  let entries: fs.Dirent[];
+  try { entries = fs.readdirSync(teamsDir, { withFileTypes: true }); }
+  catch { return { resolved: false }; }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const configPath = path.join(teamsDir, entry.name, 'team.json');
+    try { results.push(JSON.parse(fs.readFileSync(configPath, 'utf-8')) as TeamRecord); }
+    catch { /* missing/unparseable — skip */ }
+  }
+  return { resolved: true, teams: results };
+}
+
 function get(teamId: string): TeamRecord | null {
   try { return JSON.parse(fs.readFileSync(resolveTeamConfigPath(teamId), 'utf-8')) as TeamRecord; }
   catch { return null; }
@@ -115,6 +145,6 @@ export function withProjectRemoved(record: TeamRecord, projectId: string): TeamR
 }
 
 export const teamRegistry = {
-  list, get, save, remove, membershipByProject, projectsForTeam,
+  list, listResolved, get, save, remove, membershipByProject, projectsForTeam,
   readSecrets, writeSecret, readDeployment, saveDeployment, removeDeployment,
 };

--- a/tests/daemon/team-reconcile-diff.test.ts
+++ b/tests/daemon/team-reconcile-diff.test.ts
@@ -118,4 +118,50 @@ describe('diffPartition', () => {
     expect(result.deleteIds).toEqual([]);
     expect(result.staleIds).toEqual([]);
   });
+
+  // -------------------------------------------------------------------------
+  // INTEGER-id tables: D1 returns INTEGER id columns as JS numbers and
+  // bun:sqlite does too. diffPartition must coerce ids on BOTH sides so an
+  // integer-id table never mis-compares '101' (one side) against 101 (other),
+  // which would classify every row as a spurious delete/upsert.
+  // -------------------------------------------------------------------------
+
+  it('integer-typed ids (numbers) classify correctly and return string ids', () => {
+    const result = diffPartition(
+      [{ id: 101 }, { id: 102 }, { id: 103 }], // local as numbers
+      [{ id: 102 }, { id: 103 }, { id: 104 }], // manifest as numbers
+    );
+    expect(result.upsertIds).toEqual(['101']); // local-only
+    expect(result.deleteIds).toEqual(['104']); // D1-only
+    expect(result.staleIds).toEqual([]);
+
+    // Every returned id is a string, so it matches the TEXT outbox row_id and
+    // the Set<string> resurrection-guard dedup downstream.
+    for (const id of [...result.upsertIds, ...result.deleteIds, ...result.staleIds]) {
+      expect(typeof id).toBe('string');
+    }
+  });
+
+  it('mixed number/string ids for the same row are treated as equal (no spurious diff)', () => {
+    // Models the live shape: localPartition stringifies ids while the raw D1
+    // manifest hands back numbers. Without coercion this produces a catastrophic
+    // all-upsert + all-delete; with coercion the rows are recognized as in-sync.
+    const result = diffPartition(
+      [{ id: '101' }, { id: '102' }], // local stringified
+      [{ id: 101 }, { id: 102 }],     // manifest numeric
+    );
+    expect(result.upsertIds).toEqual([]);
+    expect(result.deleteIds).toEqual([]);
+    expect(result.staleIds).toEqual([]);
+  });
+
+  it('integer-id stale detection: same id, differing content_hash → staleIds (string)', () => {
+    const result = diffPartition(
+      [{ id: 101, content_hash: 'h-old' }],
+      [{ id: 101, content_hash: 'h-new' }],
+    );
+    expect(result.upsertIds).toEqual([]);
+    expect(result.deleteIds).toEqual([]);
+    expect(result.staleIds).toEqual(['101']);
+  });
 });

--- a/tests/daemon/team-reconcile-diff.test.ts
+++ b/tests/daemon/team-reconcile-diff.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure unit tests for diffPartition — no DB, no I/O.
+ *
+ * Covers the five canonical cases from the symmetric-reconcile spec:
+ *   1. local-only id   → upsertIds
+ *   2. D1-only id      → deleteIds
+ *   3. both, same hash → no action (none bucket)
+ *   4. both, hash differs, content-hash table → staleIds
+ *   5. both ids match, table has no content_hash → presence-only, no stale
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { diffPartition, type LocalRow, type ManifestItemLike } from '@myco/daemon/team-reconcile.js';
+
+// Convenience constructors.
+function local(id: string, hash?: string): LocalRow {
+  return hash !== undefined ? { id, content_hash: hash } : { id };
+}
+
+function manifest(id: string, hash?: string): ManifestItemLike {
+  return hash !== undefined ? { id, content_hash: hash } : { id };
+}
+
+describe('diffPartition', () => {
+  it('case 1: local-only id → upsertIds', () => {
+    const result = diffPartition(
+      [local('a')],
+      [],
+    );
+    expect(result.upsertIds).toEqual(['a']);
+    expect(result.deleteIds).toEqual([]);
+    expect(result.staleIds).toEqual([]);
+  });
+
+  it('case 2: D1-only id → deleteIds', () => {
+    const result = diffPartition(
+      [],
+      [manifest('b')],
+    );
+    expect(result.upsertIds).toEqual([]);
+    expect(result.deleteIds).toEqual(['b']);
+    expect(result.staleIds).toEqual([]);
+  });
+
+  it('case 3: id in both, same content_hash → no action', () => {
+    const result = diffPartition(
+      [local('c', 'hash-abc')],
+      [manifest('c', 'hash-abc')],
+    );
+    expect(result.upsertIds).toEqual([]);
+    expect(result.deleteIds).toEqual([]);
+    expect(result.staleIds).toEqual([]);
+  });
+
+  it('case 4: id in both, hashes differ (content-hash table) → staleIds', () => {
+    const result = diffPartition(
+      [local('d', 'hash-old')],
+      [manifest('d', 'hash-new')],
+    );
+    expect(result.upsertIds).toEqual([]);
+    expect(result.deleteIds).toEqual([]);
+    expect(result.staleIds).toEqual(['d']);
+  });
+
+  it('case 5: id in both, no content_hash (presence-only table) → no stale, no action', () => {
+    // Tables like skill_usage, entities, graph_edges have no content_hash.
+    // Presence alone confirms the row is in sync.
+    const result = diffPartition(
+      [local('e')],           // no content_hash
+      [manifest('e')],        // no content_hash
+    );
+    expect(result.upsertIds).toEqual([]);
+    expect(result.deleteIds).toEqual([]);
+    expect(result.staleIds).toEqual([]);
+  });
+
+  it('mixed partition: multiple ids in all three buckets', () => {
+    const result = diffPartition(
+      [
+        local('local-only'),
+        local('both-same', 'same-hash'),
+        local('both-stale', 'local-hash'),
+        local('presence-both'),      // presence-only (no hash)
+      ],
+      [
+        manifest('d1-only'),
+        manifest('both-same', 'same-hash'),
+        manifest('both-stale', 'd1-hash'),
+        manifest('presence-both'),   // presence-only (no hash)
+      ],
+    );
+
+    expect(result.upsertIds).toEqual(['local-only']);
+    expect(result.deleteIds).toEqual(['d1-only']);
+    expect(result.staleIds).toEqual(['both-stale']);
+    // 'both-same' and 'presence-both' land in none of the three buckets.
+  });
+
+  it('no stale when only one side carries content_hash (asymmetric schema)', () => {
+    // If local has a hash but manifest does not (or vice versa), we cannot
+    // conclude staleness — treat as presence-only for that row.
+    const localHashOnly = diffPartition(
+      [local('x', 'some-hash')],
+      [manifest('x')],               // D1 item has no hash
+    );
+    expect(localHashOnly.staleIds).toEqual([]);
+
+    const manifestHashOnly = diffPartition(
+      [local('y')],                  // local row has no hash
+      [manifest('y', 'some-hash')],
+    );
+    expect(manifestHashOnly.staleIds).toEqual([]);
+  });
+
+  it('empty inputs produce empty diff', () => {
+    const result = diffPartition([], []);
+    expect(result.upsertIds).toEqual([]);
+    expect(result.deleteIds).toEqual([]);
+    expect(result.staleIds).toEqual([]);
+  });
+});

--- a/tests/daemon/team-reconcile-partition.test.ts
+++ b/tests/daemon/team-reconcile-partition.test.ts
@@ -53,7 +53,6 @@ function makeHarness(opts: {
   local: PartitionRow[];
   pages: ManifestResponse[];
   summaryCount: number;
-  summaryAgg?: number;
   pending?: Set<string>;
   membershipSeeded?: boolean;
   upsertPayload?: (table: string, id: string) => string | null;
@@ -87,14 +86,13 @@ function makeHarness(opts: {
           table: _table,
           machine_id: _machineId,
           count: opts.summaryCount,
-          cheap_agg: opts.summaryAgg ?? 0,
         };
       }
       const idx = harness.pageCalls;
       harness.pageCalls += 1;
       const page = opts.pages[idx];
       if (!page) {
-        return { table: _table, machine_id: _machineId, count: 0, cheap_agg: 0, items: [] };
+        return { table: _table, machine_id: _machineId, count: 0, items: [] };
       }
       return page;
     },
@@ -137,7 +135,7 @@ function manifest(id: string, projectId?: string, hash?: string): ManifestItem {
 }
 
 function page(items: ManifestItem[], count: number, nextCursor?: string): ManifestResponse {
-  const r: ManifestResponse = { table: 'spores', machine_id: 'm1', count, cheap_agg: 0, items };
+  const r: ManifestResponse = { table: 'spores', machine_id: 'm1', count, items };
   if (nextCursor) r.next_cursor = nextCursor;
   return r;
 }
@@ -427,6 +425,49 @@ describe('reconcilePartition — pagination', () => {
     expect(h.pageCalls).toBe(3);
     // 'd' is local-only → one upsert.
     expect(h.enqueued.filter((e) => e.row_id === 'd').length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forceFullDiff: equal-count, different-set gap closure
+// ---------------------------------------------------------------------------
+
+describe('reconcilePartition — forceFullDiff gap closure', () => {
+  // 5 shared rows so a 1-delete doesn't hit the 20% fraction cap (1/6 ≈ 16.7%).
+  const baseShared = settled(5); // {s0..s4}
+
+  it('forceFullDiff:false + equal counts → count-match fast path, no diff, no enqueue', async () => {
+    const h = makeHarness({
+      protocolVersion: 3,
+      local: [...baseShared.local, { id: 'B' }],           // 6 local
+      pages: [page([...baseShared.manifest, manifest('A', 'p1')], 6)], // 6 D1
+      summaryCount: 6,  // D1 count == local count → fast-path skip
+    });
+    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 }, forceFullDiff: false });
+    // Count-equality fast path: summary fetched, no paging, no enqueue.
+    expect(h.summaryCalls).toBe(1);
+    expect(h.pageCalls).toBe(0);
+    expect(h.enqueued.length).toBe(0);
+  });
+
+  it('forceFullDiff:true + equal counts → full diff runs, seeds delete for D1-orphan and upsert for local-only', async () => {
+    const h = makeHarness({
+      protocolVersion: 3,
+      local: [...baseShared.local, { id: 'B' }],           // 6 local: s0-s4 + B
+      pages: [page([...baseShared.manifest, manifest('A', 'p1')], 6)], // 6 D1: s0-s4 + A
+      summaryCount: 6,  // same count — would skip without forceFullDiff
+    });
+    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 }, forceFullDiff: true });
+    // Summary skipped; paging ran.
+    expect(h.summaryCalls).toBe(0);
+    expect(h.pageCalls).toBe(1);
+    // A is D1-orphan → delete; B is local-only → upsert.
+    const deletes = h.enqueued.filter((e) => e.operation === 'delete');
+    const upserts = h.enqueued.filter((e) => (e.operation ?? 'upsert') === 'upsert');
+    expect(deletes.length).toBe(1);
+    expect(deletes[0].row_id).toBe('A');
+    expect(upserts.length).toBe(1);
+    expect(upserts[0].row_id).toBe('B');
   });
 });
 

--- a/tests/daemon/team-reconcile-partition.test.ts
+++ b/tests/daemon/team-reconcile-partition.test.ts
@@ -1,0 +1,485 @@
+/**
+ * Unit tests for reconcilePartition — the orchestration that probes the worker,
+ * diffs the local partition against the D1 manifest, runs the delete-safety
+ * firewall, dedups against in-flight outbox rows, and seeds survivors into the
+ * outbox under the reconcile↔flush mutex.
+ *
+ * All deps are injected mocks; this test touches NO real DB, network, or fs.
+ * It is the contract test for the code path that actually SEEDS DELETES.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  reconcilePartition,
+  createReconcileFlushMutex,
+  type ReconcilePartitionDeps,
+  type ReconcileMutex,
+} from '@myco/daemon/team-reconcile.js';
+import type { ManifestItem, ManifestResponse } from '@myco/daemon/team-sync.js';
+import type { OutboxInsert, OutboxRow, PartitionRow } from '@myco/db/queries/team-outbox.js';
+
+// ---------------------------------------------------------------------------
+// Mock builders
+// ---------------------------------------------------------------------------
+
+interface ClientStub {
+  getWorkerProtocolVersion(): number | undefined;
+  health(): Promise<unknown>;
+  supportsManifest(): boolean;
+  getManifest(
+    machineId: string,
+    table: string,
+    options: { projectId?: string; cursor?: string; limit?: number; summary?: boolean },
+  ): Promise<ManifestResponse>;
+}
+
+interface Harness {
+  deps: ReconcilePartitionDeps;
+  enqueued: OutboxInsert[];
+  healthCalls: number;
+  summaryCalls: number;
+  pageCalls: number;
+  logs: string[];
+}
+
+/**
+ * Build a reconcilePartition deps harness. `pages` is the ordered list of
+ * paged-manifest responses (each may carry next_cursor); `summary` is the
+ * cheap-count response. `local` is the local partition; `pending` is the set
+ * of already-in-flight outbox row_ids.
+ */
+function makeHarness(opts: {
+  protocolVersion?: number | undefined;
+  local: PartitionRow[];
+  pages: ManifestResponse[];
+  summaryCount: number;
+  summaryAgg?: number;
+  pending?: Set<string>;
+  membershipSeeded?: boolean;
+  upsertPayload?: (table: string, id: string) => string | null;
+  mutex?: ReconcileMutex;
+}): Harness {
+  let version = opts.protocolVersion;
+  const enqueued: OutboxInsert[] = [];
+  const logs: string[] = [];
+  const harness: Harness = {
+    deps: undefined as unknown as ReconcilePartitionDeps,
+    enqueued,
+    healthCalls: 0,
+    summaryCalls: 0,
+    pageCalls: 0,
+    logs,
+  };
+
+  const client: ClientStub = {
+    getWorkerProtocolVersion: () => version,
+    health: async () => {
+      harness.healthCalls += 1;
+      // Probing learns the version (mirrors the real client populating it).
+      if (version === undefined) version = opts.protocolVersion === undefined ? 3 : opts.protocolVersion;
+      return {};
+    },
+    supportsManifest: () => version !== undefined && version >= 3,
+    getManifest: async (_machineId, _table, options) => {
+      if (options.summary) {
+        harness.summaryCalls += 1;
+        return {
+          table: _table,
+          machine_id: _machineId,
+          count: opts.summaryCount,
+          cheap_agg: opts.summaryAgg ?? 0,
+        };
+      }
+      const idx = harness.pageCalls;
+      harness.pageCalls += 1;
+      const page = opts.pages[idx];
+      if (!page) {
+        return { table: _table, machine_id: _machineId, count: 0, cheap_agg: 0, items: [] };
+      }
+      return page;
+    },
+  };
+
+  harness.deps = {
+    client,
+    localPartition: () => opts.local,
+    pendingRowIdsForPartition: () => opts.pending ?? new Set<string>(),
+    enqueueOutbox: (data: OutboxInsert) => {
+      enqueued.push(data);
+      // Return a minimal OutboxRow; reconcilePartition does not use the result.
+      return {
+        id: enqueued.length,
+        table_name: data.table_name,
+        row_id: data.row_id,
+        operation: data.operation ?? 'upsert',
+        payload: {},
+        machine_id: data.machine_id,
+        project_id: data.project_id ?? null,
+        created_at: data.created_at,
+        sent_at: null,
+      } as OutboxRow;
+    },
+    buildUpsertPayload:
+      opts.upsertPayload ?? ((_table, id) => JSON.stringify({ id, machine_id: 'm1' })),
+    membershipSeeded: opts.membershipSeeded ?? true,
+    mutex: opts.mutex ?? createReconcileFlushMutex(),
+    logger: { info: (m: string) => logs.push(m), warn: (m: string) => logs.push(m) },
+  };
+
+  return harness;
+}
+
+function manifest(id: string, projectId?: string, hash?: string): ManifestItem {
+  const item: ManifestItem = { id };
+  if (projectId !== undefined) item.project_id = projectId;
+  if (hash !== undefined) item.content_hash = hash;
+  return item;
+}
+
+function page(items: ManifestItem[], count: number, nextCursor?: string): ManifestResponse {
+  const r: ManifestResponse = { table: 'spores', machine_id: 'm1', count, cheap_agg: 0, items };
+  if (nextCursor) r.next_cursor = nextCursor;
+  return r;
+}
+
+const BASE = { machineId: 'm1', projectId: 'p1', table: 'spores', operatorConfirmed: false };
+
+/**
+ * A pool of `n` shared ids present in BOTH local and D1, used to give a
+ * partition enough headroom that a single delete stays under the 20% fraction
+ * cap (e.g. with n=20, deleting 1 of 21 D1 rows is ~4.8%). Returns the local
+ * rows, the matching manifest items, and the shared count.
+ */
+function settled(n: number, projectId = 'p1'): {
+  local: PartitionRow[];
+  manifest: ManifestItem[];
+  count: number;
+} {
+  const local: PartitionRow[] = [];
+  const items: ManifestItem[] = [];
+  for (let i = 0; i < n; i++) {
+    local.push({ id: `s${i}` });
+    items.push(manifest(`s${i}`, projectId));
+  }
+  return { local, manifest: items, count: n };
+}
+
+// ---------------------------------------------------------------------------
+// Count-match fast path
+// ---------------------------------------------------------------------------
+
+describe('reconcilePartition — count-match fast path', () => {
+  it('count equal → no paging, no enqueue', async () => {
+    const h = makeHarness({
+      protocolVersion: 3,
+      local: [{ id: 'a' }, { id: 'b' }],
+      pages: [],
+      summaryCount: 2,
+    });
+    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    expect(h.summaryCalls).toBe(1);
+    expect(h.pageCalls).toBe(0);
+    expect(h.enqueued.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MF2: probe-before-feature-detect
+// ---------------------------------------------------------------------------
+
+describe('reconcilePartition — MF2 probe before feature detect', () => {
+  it('unprobed client (version undefined) → calls health() then proceeds', async () => {
+    const h = makeHarness({
+      protocolVersion: undefined, // health() will populate it to 3
+      local: [{ id: 'a' }],
+      pages: [page([], 0)],
+      summaryCount: 0,
+    });
+    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    expect(h.healthCalls).toBe(1);
+    // version became 3 → supportsManifest → proceeds. Local has 1, D1 has 0:
+    // count mismatch, so it pages and enqueues an upsert.
+    expect(h.enqueued.length).toBe(1);
+    expect(h.enqueued[0].operation ?? 'upsert').toBe('upsert');
+  });
+
+  it('confirmed v2 worker → skip + log, no paging, no enqueue', async () => {
+    const h = makeHarness({
+      protocolVersion: 2, // already probed, manifest unsupported
+      local: [{ id: 'a' }],
+      pages: [page([], 5)],
+      summaryCount: 5,
+    });
+    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    expect(h.healthCalls).toBe(0); // already probed, no re-probe needed
+    expect(h.summaryCalls).toBe(0);
+    expect(h.pageCalls).toBe(0);
+    expect(h.enqueued.length).toBe(0);
+    expect(h.logs.some((l) => /manifest|protocol|skip/i.test(l))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Delete seeding
+// ---------------------------------------------------------------------------
+
+describe('reconcilePartition — delete seeding', () => {
+  it('D1 has an extra id (settled, small) → enqueues a delete', async () => {
+    // 20 shared rows + 1 D1-only extra → 1/21 ≈ 4.8% delete, under the 20% cap.
+    const s = settled(20);
+    const h = makeHarness({
+      protocolVersion: 3,
+      local: s.local,
+      pages: [page([...s.manifest, manifest('extra', 'p1')], s.count + 1)],
+      summaryCount: s.count + 1, // D1 count 21 vs local 20 → mismatch
+    });
+    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    const deletes = h.enqueued.filter((e) => e.operation === 'delete');
+    expect(deletes.length).toBe(1);
+    expect(deletes[0].row_id).toBe('extra');
+    expect(deletes[0].project_id).toBe('p1'); // FROM the manifest item
+    const payload = JSON.parse(deletes[0].payload) as Record<string, unknown>;
+    expect(payload).toEqual({ id: 'extra', machine_id: 'm1' });
+  });
+
+  it('delete count is accumulated into passAggregate', async () => {
+    const s = settled(20);
+    const h = makeHarness({
+      protocolVersion: 3,
+      local: s.local,
+      pages: [page([...s.manifest, manifest('extra', 'p1')], s.count + 1)],
+      summaryCount: s.count + 1,
+    });
+    const passAggregate = { count: 3 };
+    await reconcilePartition(h.deps, { ...BASE, passAggregate });
+    expect(passAggregate.count).toBe(4); // 3 + 1 applied delete
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Upsert seeding
+// ---------------------------------------------------------------------------
+
+describe('reconcilePartition — upsert seeding', () => {
+  it('local-missing id → enqueues an upsert with the built payload', async () => {
+    const h = makeHarness({
+      protocolVersion: 3,
+      local: [{ id: 'a' }, { id: 'b' }],
+      // D1 only has 'a' → 'b' is local-only → upsert. count 1 vs local 2.
+      pages: [page([manifest('a', 'p1')], 1)],
+      summaryCount: 1,
+      upsertPayload: (table, id) => JSON.stringify({ id, machine_id: 'm1', table }),
+    });
+    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    const upserts = h.enqueued.filter((e) => (e.operation ?? 'upsert') === 'upsert');
+    expect(upserts.length).toBe(1);
+    expect(upserts[0].row_id).toBe('b');
+    expect(upserts[0].project_id).toBe('p1'); // the partition being reconciled
+    const payload = JSON.parse(upserts[0].payload) as Record<string, unknown>;
+    expect(payload.id).toBe('b');
+  });
+
+  it('upsert whose payload build returns null (row vanished) is skipped', async () => {
+    const h = makeHarness({
+      protocolVersion: 3,
+      local: [{ id: 'a' }, { id: 'gone' }],
+      pages: [page([manifest('a', 'p1')], 1)],
+      summaryCount: 1,
+      upsertPayload: (_table, id) => (id === 'gone' ? null : JSON.stringify({ id })),
+    });
+    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    expect(h.enqueued.filter((e) => e.row_id === 'gone').length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resurrection guard / dedup
+// ---------------------------------------------------------------------------
+
+describe('reconcilePartition — resurrection guard', () => {
+  it('id already pending in the outbox is skipped', async () => {
+    const h = makeHarness({
+      protocolVersion: 3,
+      local: [{ id: 'a' }, { id: 'b' }],
+      pages: [page([manifest('a', 'p1')], 1)],
+      summaryCount: 1,
+      pending: new Set(['b']), // 'b' already in flight
+    });
+    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    expect(h.enqueued.filter((e) => e.row_id === 'b').length).toBe(0);
+  });
+
+  it('id in BOTH upsert and delete sets is skipped from both', async () => {
+    // The real diffPartition can never put one id in both sets, so the
+    // contradiction guard is defense-in-depth. Exercise it deterministically by
+    // injecting a diff that classifies 'dup' as BOTH a delete and an upsert.
+    // 'dup' is present in the manifest under p1 (so it passes the N3 deletable
+    // filter); the guard must then drop it from BOTH the upsert and delete sets.
+    const s = settled(20);
+    const h = makeHarness({
+      protocolVersion: 3,
+      local: [...s.local, { id: 'dup' }],
+      pages: [page([...s.manifest, manifest('dup', 'p1')], s.count + 1)],
+      summaryCount: s.count + 1, // mismatch → diff path
+    });
+    h.deps.diff = () => ({ upsertIds: ['dup'], deleteIds: ['dup'], staleIds: [] });
+    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    // 'dup' is contradictory → skipped from both; nothing enqueued for it.
+    expect(h.enqueued.filter((e) => e.row_id === 'dup').length).toBe(0);
+  });
+
+  it('stale id (in both, hash differs) re-pushes as a single upsert, never a delete', async () => {
+    // A stale row does not change the partition count, so add a local-only id to
+    // break count-equality and force the diff path. The stale id must then
+    // produce exactly one upsert and no delete.
+    const s = settled(20);
+    const h = makeHarness({
+      protocolVersion: 3,
+      local: [...s.local, { id: 'dup', content_hash: 'h1' }, { id: 'localonly' }], // count 22
+      pages: [page([...s.manifest, manifest('dup', 'p1', 'h2')], s.count + 1)],
+      summaryCount: s.count + 1, // D1 count 21 ≠ local 22 → diff path
+    });
+    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    expect(h.enqueued.filter((e) => e.row_id === 'dup' && e.operation === 'delete').length).toBe(0);
+    expect(h.enqueued.filter((e) => e.row_id === 'dup').length).toBe(1);
+    // 'localonly' also upserts (local-only).
+    expect(h.enqueued.filter((e) => e.row_id === 'localonly').length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Delete safety firewall
+// ---------------------------------------------------------------------------
+
+describe('reconcilePartition — delete safety', () => {
+  it('transient localCount=0 (d1Count>0) → NO delete, but does not throw', async () => {
+    const h = makeHarness({
+      protocolVersion: 3,
+      local: [], // empty local → not_settled blocks deletes
+      pages: [page([manifest('a', 'p1'), manifest('b', 'p1')], 2)],
+      summaryCount: 2,
+    });
+    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    expect(h.enqueued.filter((e) => e.operation === 'delete').length).toBe(0);
+    // No upserts either — local is empty.
+    expect(h.enqueued.length).toBe(0);
+    expect(h.logs.some((l) => /not_settled|blocked|safety/i.test(l))).toBe(true);
+  });
+
+  it('blocked deletes still allow upserts/stale re-pushes to proceed', async () => {
+    // membershipSeeded=false blocks deletes; a local-only id still upserts.
+    // Use a count mismatch (D1 has two extras, local has one extra) so the diff
+    // path runs rather than the count-equal fast path.
+    const s = settled(20);
+    const h = makeHarness({
+      protocolVersion: 3,
+      local: [...s.local, { id: 'localonly' }], // count 21
+      pages: [page([...s.manifest, manifest('d1extra1', 'p1'), manifest('d1extra2', 'p1')], s.count + 2)],
+      summaryCount: s.count + 2, // D1 count 22 ≠ local 21
+      membershipSeeded: false, // blocks deletes (membership_unseeded)
+    });
+    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    expect(h.enqueued.filter((e) => e.operation === 'delete').length).toBe(0);
+    const upserts = h.enqueued.filter((e) => (e.operation ?? 'upsert') === 'upsert');
+    expect(upserts.map((u) => u.row_id)).toEqual(['localonly']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// N3: per-home mismatch guard
+// ---------------------------------------------------------------------------
+
+describe('reconcilePartition — N3 per-home mismatch guard', () => {
+  it('manifest item from a DIFFERENT project is NOT deleted', async () => {
+    const h = makeHarness({
+      protocolVersion: 3,
+      local: [{ id: 'a' }],
+      // 'other' belongs to project p2 (another home's grove) — must not delete.
+      // count mismatch (D1 reports 2 for partition) to force the diff path.
+      pages: [page([manifest('a', 'p1'), manifest('other', 'p2')], 2)],
+      summaryCount: 2,
+    });
+    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    expect(h.enqueued.filter((e) => e.row_id === 'other').length).toBe(0);
+    expect(h.enqueued.filter((e) => e.operation === 'delete').length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pagination
+// ---------------------------------------------------------------------------
+
+describe('reconcilePartition — pagination', () => {
+  it('follows next_cursor until exhausted', async () => {
+    const h = makeHarness({
+      protocolVersion: 3,
+      local: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+      pages: [
+        page([manifest('a', 'p1')], 3, 'cursor-2'),
+        page([manifest('b', 'p1')], 3, 'cursor-3'),
+        page([manifest('c', 'p1')], 3), // no next_cursor → stop
+      ],
+      summaryCount: 3, // count differs? equal to local (3) → fast path!
+    });
+    // Make count differ from local to force paging.
+    h.deps.localPartition = () => [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }];
+    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    expect(h.pageCalls).toBe(3);
+    // 'd' is local-only → one upsert.
+    expect(h.enqueued.filter((e) => e.row_id === 'd').length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MF3 mutex serialization
+// ---------------------------------------------------------------------------
+
+describe('reconcilePartition — MF3 mutex', () => {
+  it('reconcile-seed and a concurrent flush-drain serialize via the shared mutex', async () => {
+    const mutex = createReconcileFlushMutex();
+    const order: string[] = [];
+
+    // Instrument the seed to record entry/exit ordering. We slow the reconcile's
+    // critical section by making enqueueOutbox await a microtask-deferred marker.
+    const h = makeHarness({
+      protocolVersion: 3,
+      local: [{ id: 'a' }, { id: 'b' }],
+      pages: [page([manifest('a', 'p1')], 1)],
+      summaryCount: 1,
+      mutex,
+    });
+    const realEnqueue = h.deps.enqueueOutbox;
+    h.deps.enqueueOutbox = (data) => {
+      order.push('seed:enqueue');
+      return realEnqueue(data);
+    };
+
+    // A competing "flush-drain" that grabs the SAME mutex.
+    const flush = async () => {
+      await mutex.runExclusive(async () => {
+        order.push('flush:start');
+        await Promise.resolve();
+        order.push('flush:end');
+      });
+    };
+
+    // Start the reconcile, then immediately start the flush. Because the seed
+    // section holds the mutex, the flush must run entirely before or entirely
+    // after the seed — never interleaved with seed:enqueue.
+    const recon = reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    const fl = flush();
+    await Promise.all([recon, fl]);
+
+    // Assert no interleave: flush:start..flush:end must be contiguous, and the
+    // seed:enqueue events must not appear between them.
+    const flushStart = order.indexOf('flush:start');
+    const flushEnd = order.indexOf('flush:end');
+    expect(flushStart).toBeGreaterThanOrEqual(0);
+    expect(flushEnd).toBe(flushStart + 1); // contiguous, nothing between
+  });
+
+  it('createReconcileFlushMutex returns a shareable lock with runExclusive', () => {
+    const m = createReconcileFlushMutex();
+    expect(typeof m.runExclusive).toBe('function');
+  });
+});

--- a/tests/daemon/team-reconcile-partition.test.ts
+++ b/tests/daemon/team-reconcile-partition.test.ts
@@ -472,6 +472,44 @@ describe('reconcilePartition — forceFullDiff gap closure', () => {
 });
 
 // ---------------------------------------------------------------------------
+// INTEGER-id partition: end-to-end type normalization
+// ---------------------------------------------------------------------------
+
+describe('reconcilePartition — INTEGER id partition (type normalization)', () => {
+  it('number/string id mismatch does not cause spurious mass delete/upsert', async () => {
+    // localPartition stringifies ids; the raw D1 manifest hands back numbers.
+    // The 20 shared rows must be recognized as in-sync (no upsert, no delete);
+    // only the genuine integer D1-orphan (999) is deleted, with a STRING row_id.
+    // 1/21 deletes ≈ 4.8% keeps us under the 20% fraction cap.
+    const local: PartitionRow[] = [];
+    const items: ManifestItem[] = [];
+    for (let i = 1; i <= 20; i++) {
+      local.push({ id: String(100 + i) });                                       // '101'..'120'
+      items.push({ id: 100 + i, project_id: 'p1' } as unknown as ManifestItem);  // numbers
+    }
+    items.push({ id: 999, project_id: 'p1' } as unknown as ManifestItem);        // D1 orphan
+
+    const h = makeHarness({
+      protocolVersion: 3,
+      local,
+      pages: [page(items, 21)],
+      summaryCount: 21, // D1 21 vs local 20 → diff path
+    });
+    await reconcilePartition(h.deps, { ...BASE, table: 'prompt_batches', passAggregate: { count: 0 } });
+
+    const deletes = h.enqueued.filter((e) => e.operation === 'delete');
+    const upserts = h.enqueued.filter((e) => (e.operation ?? 'upsert') === 'upsert');
+
+    expect(upserts.length).toBe(0); // no spurious all-upsert from a type mismatch
+    expect(deletes.length).toBe(1); // only the genuine orphan
+    expect(deletes[0].row_id).toBe('999');
+    expect(typeof deletes[0].row_id).toBe('string');
+    const payload = JSON.parse(deletes[0].payload) as Record<string, unknown>;
+    expect(payload).toEqual({ id: '999', machine_id: 'm1' });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // MF3 mutex serialization
 // ---------------------------------------------------------------------------
 

--- a/tests/daemon/team-reconcile-partition.test.ts
+++ b/tests/daemon/team-reconcile-partition.test.ts
@@ -1,16 +1,22 @@
 /**
  * Unit tests for reconcilePartition — the orchestration that probes the worker,
- * diffs the local partition against the D1 manifest, runs the delete-safety
- * firewall, dedups against in-flight outbox rows, and seeds survivors into the
- * outbox under the reconcile↔flush mutex.
+ * diffs the local partition against the D1 manifest, runs the settledness
+ * firewall + cross-pass drift stability gate, dedups against in-flight outbox
+ * rows, and seeds survivors into the outbox under the reconcile↔flush mutex.
  *
  * All deps are injected mocks; this test touches NO real DB, network, or fs.
  * It is the contract test for the code path that actually SEEDS DELETES.
+ *
+ * Cross-pass model: a D1-only orphan is deleted only after it is observed on TWO
+ * consecutive full-diff passes. The first sighting is recorded in the module's
+ * in-memory drift map; the second sighting intersects with it and seeds the
+ * delete. `resetReconcileDriftTracking()` clears that map between tests.
  */
 
-import { describe, expect, it } from 'bun:test';
+import { beforeEach, describe, expect, it } from 'bun:test';
 import {
   reconcilePartition,
+  resetReconcileDriftTracking,
   createReconcileFlushMutex,
   type ReconcilePartitionDeps,
   type ReconcileMutex,
@@ -42,13 +48,7 @@ interface Harness {
   logs: string[];
 }
 
-/**
- * Build a reconcilePartition deps harness. `pages` is the ordered list of
- * paged-manifest responses (each may carry next_cursor); `summary` is the
- * cheap-count response. `local` is the local partition; `pending` is the set
- * of already-in-flight outbox row_ids.
- */
-function makeHarness(opts: {
+interface HarnessOpts {
   protocolVersion?: number | undefined;
   local: PartitionRow[];
   pages: ManifestResponse[];
@@ -57,7 +57,15 @@ function makeHarness(opts: {
   membershipSeeded?: boolean;
   upsertPayload?: (table: string, id: string) => string | null;
   mutex?: ReconcileMutex;
-}): Harness {
+}
+
+/**
+ * Build a reconcilePartition deps harness. `pages` is the ordered list of
+ * paged-manifest responses (each may carry next_cursor); `summary` is the
+ * cheap-count response. `local` is the local partition; `pending` is the set
+ * of already-in-flight outbox row_ids.
+ */
+function makeHarness(opts: HarnessOpts): Harness {
   let version = opts.protocolVersion;
   const enqueued: OutboxInsert[] = [];
   const logs: string[] = [];
@@ -140,13 +148,12 @@ function page(items: ManifestItem[], count: number, nextCursor?: string): Manife
   return r;
 }
 
-const BASE = { machineId: 'm1', projectId: 'p1', table: 'spores', operatorConfirmed: false };
+const BASE = { machineId: 'm1', projectId: 'p1', table: 'spores' };
 
 /**
  * A pool of `n` shared ids present in BOTH local and D1, used to give a
- * partition enough headroom that a single delete stays under the 20% fraction
- * cap (e.g. with n=20, deleting 1 of 21 D1 rows is ~4.8%). Returns the local
- * rows, the matching manifest items, and the shared count.
+ * partition a non-empty (settled) local set. Returns the local rows, the
+ * matching manifest items, and the shared count.
  */
 function settled(n: number, projectId = 'p1'): {
   local: PartitionRow[];
@@ -162,6 +169,31 @@ function settled(n: number, projectId = 'p1'): {
   return { local, manifest: items, count: n };
 }
 
+/**
+ * Run `passes` consecutive reconcile passes against the SAME partition (a fresh
+ * harness each pass so enqueued/page counters reset, but the module-level drift
+ * map carries across). Returns the LAST harness so callers assert on the pass
+ * whose outcome they care about.
+ */
+async function runPasses(
+  opts: HarnessOpts,
+  passes: number,
+  argOverrides: { table?: string; forceFullDiff?: boolean } = {},
+): Promise<Harness> {
+  let last!: Harness;
+  for (let i = 0; i < passes; i++) {
+    last = makeHarness(opts);
+    await reconcilePartition(last.deps, { ...BASE, ...argOverrides });
+  }
+  return last;
+}
+
+beforeEach(() => {
+  // The cross-pass drift map is module state; clear it so each test starts with
+  // no carried orphan candidates (and one test's candidates never leak forward).
+  resetReconcileDriftTracking();
+});
+
 // ---------------------------------------------------------------------------
 // Count-match fast path
 // ---------------------------------------------------------------------------
@@ -174,7 +206,7 @@ describe('reconcilePartition — count-match fast path', () => {
       pages: [],
       summaryCount: 2,
     });
-    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    await reconcilePartition(h.deps, { ...BASE });
     expect(h.summaryCalls).toBe(1);
     expect(h.pageCalls).toBe(0);
     expect(h.enqueued.length).toBe(0);
@@ -193,7 +225,7 @@ describe('reconcilePartition — MF2 probe before feature detect', () => {
       pages: [page([], 0)],
       summaryCount: 0,
     });
-    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    await reconcilePartition(h.deps, { ...BASE });
     expect(h.healthCalls).toBe(1);
     // version became 3 → supportsManifest → proceeds. Local has 1, D1 has 0:
     // count mismatch, so it pages and enqueues an upsert.
@@ -208,7 +240,7 @@ describe('reconcilePartition — MF2 probe before feature detect', () => {
       pages: [page([], 5)],
       summaryCount: 5,
     });
-    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    await reconcilePartition(h.deps, { ...BASE });
     expect(h.healthCalls).toBe(0); // already probed, no re-probe needed
     expect(h.summaryCalls).toBe(0);
     expect(h.pageCalls).toBe(0);
@@ -218,20 +250,28 @@ describe('reconcilePartition — MF2 probe before feature detect', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Delete seeding
+// Cross-pass drift stability (the delete-seeding contract)
 // ---------------------------------------------------------------------------
 
-describe('reconcilePartition — delete seeding', () => {
-  it('D1 has an extra id (settled, small) → enqueues a delete', async () => {
-    // 20 shared rows + 1 D1-only extra → 1/21 ≈ 4.8% delete, under the 20% cap.
-    const s = settled(20);
-    const h = makeHarness({
+describe('reconcilePartition — cross-pass drift stability', () => {
+  /** A settled partition with one D1-only orphan ('extra'). */
+  function orphanOpts(): HarnessOpts {
+    const s = settled(2);
+    return {
       protocolVersion: 3,
       local: s.local,
       pages: [page([...s.manifest, manifest('extra', 'p1')], s.count + 1)],
-      summaryCount: s.count + 1, // D1 count 21 vs local 20 → mismatch
-    });
-    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+      summaryCount: s.count + 1, // D1 count 3 vs local 2 → mismatch → diff path
+    };
+  }
+
+  it('an orphan observed in ONE pass is recorded but NOT deleted', async () => {
+    const h = await runPasses(orphanOpts(), 1);
+    expect(h.enqueued.filter((e) => e.operation === 'delete').length).toBe(0);
+  });
+
+  it('the SAME orphan observed in TWO consecutive passes is deleted on the second', async () => {
+    const h = await runPasses(orphanOpts(), 2);
     const deletes = h.enqueued.filter((e) => e.operation === 'delete');
     expect(deletes.length).toBe(1);
     expect(deletes[0].row_id).toBe('extra');
@@ -240,22 +280,97 @@ describe('reconcilePartition — delete seeding', () => {
     expect(payload).toEqual({ id: 'extra', machine_id: 'm1' });
   });
 
-  it('delete count is accumulated into passAggregate', async () => {
-    const s = settled(20);
-    const h = makeHarness({
+  it('an orphan that is resolved by the next pass is never deleted', async () => {
+    const s = settled(2);
+    // Pass 1: 'extra' is a D1 orphan → recorded as a candidate.
+    const h1 = makeHarness(orphanOpts());
+    await reconcilePartition(h1.deps, { ...BASE });
+    expect(h1.enqueued.filter((e) => e.operation === 'delete').length).toBe(0);
+    // Pass 2: drift resolved (D1 no longer has 'extra'; count now matches local).
+    const h2 = makeHarness({
+      protocolVersion: 3,
+      local: s.local,
+      pages: [page([...s.manifest], s.count)],
+      summaryCount: s.count, // count match → fast path clears the candidate
+    });
+    await reconcilePartition(h2.deps, { ...BASE });
+    expect(h2.enqueued.filter((e) => e.operation === 'delete').length).toBe(0);
+  });
+
+  it('a DIFFERENT orphan each pass is never deleted (no consecutive sighting)', async () => {
+    const s = settled(2);
+    // Pass 1: orphan 'X'.
+    const h1 = makeHarness({
+      protocolVersion: 3,
+      local: s.local,
+      pages: [page([...s.manifest, manifest('X', 'p1')], s.count + 1)],
+      summaryCount: s.count + 1,
+    });
+    await reconcilePartition(h1.deps, { ...BASE });
+    // Pass 2: a different orphan 'Y' (full diff runs; 'X' is gone from D1).
+    const h2 = makeHarness({
+      protocolVersion: 3,
+      local: s.local,
+      pages: [page([...s.manifest, manifest('Y', 'p1')], s.count + 1)],
+      summaryCount: s.count + 1,
+    });
+    await reconcilePartition(h2.deps, { ...BASE });
+    // Neither orphan was seen twice in a row → nothing deleted.
+    expect(h1.enqueued.filter((e) => e.operation === 'delete').length).toBe(0);
+    expect(h2.enqueued.filter((e) => e.operation === 'delete').length).toBe(0);
+  });
+
+  it('a large settled persistent drift heals fully across two passes (no magnitude cap)', async () => {
+    const ORPHANS = 5000;
+    const local: PartitionRow[] = [{ id: 'keep' }];
+    const items: ManifestItem[] = [manifest('keep', 'p1')];
+    for (let i = 0; i < ORPHANS; i++) items.push(manifest(`orphan${i}`, 'p1'));
+    const opts: HarnessOpts = {
+      protocolVersion: 3,
+      local, // localCount 1 > 0 → settled
+      pages: [page(items, ORPHANS + 1)],
+      summaryCount: ORPHANS + 1, // D1 5001 vs local 1 → diff path
+    };
+
+    // Pass 1: records 5000 candidates, deletes nothing (not blocked, just first
+    // sighting). Pass 2: every orphan was seen on both passes → all 5000 delete.
+    const h1 = await runPasses(opts, 1);
+    expect(h1.enqueued.filter((e) => e.operation === 'delete').length).toBe(0);
+
+    const h2 = await runPasses(opts, 2);
+    const deletes = h2.enqueued.filter((e) => e.operation === 'delete');
+    expect(deletes.length).toBe(ORPHANS);
+    // No safety block was logged — a large settled drift is NOT operator-gated.
+    expect(h2.logs.some((l) => /blocked/i.test(l))).toBe(false);
+  });
+
+  it('settledness gates BEFORE cross-pass: a recorded orphan in a not_settled pass seeds zero deletes', async () => {
+    const s = settled(2);
+    // Pass 1 (settled): 'extra' recorded as a candidate.
+    const h1 = makeHarness({
       protocolVersion: 3,
       local: s.local,
       pages: [page([...s.manifest, manifest('extra', 'p1')], s.count + 1)],
       summaryCount: s.count + 1,
     });
-    const passAggregate = { count: 3 };
-    await reconcilePartition(h.deps, { ...BASE, passAggregate });
-    expect(passAggregate.count).toBe(4); // 3 + 1 applied delete
+    await reconcilePartition(h1.deps, { ...BASE });
+    // Pass 2 (not settled): local has not loaded (empty) while D1 still reports
+    // rows — including the recorded 'extra'. Settledness must block regardless of
+    // the carried candidate.
+    const h2 = makeHarness({
+      protocolVersion: 3,
+      local: [], // localCount 0, d1Count > 0 → not_settled
+      pages: [page([...s.manifest, manifest('extra', 'p1')], s.count + 1)],
+      summaryCount: s.count + 1,
+    });
+    await reconcilePartition(h2.deps, { ...BASE });
+    expect(h2.enqueued.filter((e) => e.operation === 'delete').length).toBe(0);
+    expect(h2.logs.some((l) => /not_settled|blocked/i.test(l))).toBe(true);
   });
 });
 
 // ---------------------------------------------------------------------------
-// Upsert seeding
+// Upsert seeding (independent of cross-pass; always proceeds)
 // ---------------------------------------------------------------------------
 
 describe('reconcilePartition — upsert seeding', () => {
@@ -268,7 +383,7 @@ describe('reconcilePartition — upsert seeding', () => {
       summaryCount: 1,
       upsertPayload: (table, id) => JSON.stringify({ id, machine_id: 'm1', table }),
     });
-    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    await reconcilePartition(h.deps, { ...BASE });
     const upserts = h.enqueued.filter((e) => (e.operation ?? 'upsert') === 'upsert');
     expect(upserts.length).toBe(1);
     expect(upserts[0].row_id).toBe('b');
@@ -285,7 +400,7 @@ describe('reconcilePartition — upsert seeding', () => {
       summaryCount: 1,
       upsertPayload: (_table, id) => (id === 'gone' ? null : JSON.stringify({ id })),
     });
-    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    await reconcilePartition(h.deps, { ...BASE });
     expect(h.enqueued.filter((e) => e.row_id === 'gone').length).toBe(0);
   });
 });
@@ -303,41 +418,51 @@ describe('reconcilePartition — resurrection guard', () => {
       summaryCount: 1,
       pending: new Set(['b']), // 'b' already in flight
     });
-    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    await reconcilePartition(h.deps, { ...BASE });
     expect(h.enqueued.filter((e) => e.row_id === 'b').length).toBe(0);
   });
 
-  it('id in BOTH upsert and delete sets is skipped from both', async () => {
+  it('id in BOTH upsert and delete sets is skipped from both (on the delete-active pass)', async () => {
     // The real diffPartition can never put one id in both sets, so the
     // contradiction guard is defense-in-depth. Exercise it deterministically by
     // injecting a diff that classifies 'dup' as BOTH a delete and an upsert.
     // 'dup' is present in the manifest under p1 (so it passes the N3 deletable
-    // filter); the guard must then drop it from BOTH the upsert and delete sets.
-    const s = settled(20);
-    const h = makeHarness({
+    // filter). The delete only becomes active on the SECOND consecutive pass
+    // (cross-pass), so run two passes; the guard must then drop 'dup' from BOTH.
+    const s = settled(2);
+    const opts: HarnessOpts = {
       protocolVersion: 3,
       local: [...s.local, { id: 'dup' }],
       pages: [page([...s.manifest, manifest('dup', 'p1')], s.count + 1)],
       summaryCount: s.count + 1, // mismatch → diff path
-    });
-    h.deps.diff = () => ({ upsertIds: ['dup'], deleteIds: ['dup'], staleIds: [] });
-    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
-    // 'dup' is contradictory → skipped from both; nothing enqueued for it.
-    expect(h.enqueued.filter((e) => e.row_id === 'dup').length).toBe(0);
+    };
+    const inject = () => ({ upsertIds: ['dup'], deleteIds: ['dup'], staleIds: [] });
+
+    const h1 = makeHarness(opts);
+    h1.deps.diff = inject;
+    await reconcilePartition(h1.deps, { ...BASE });
+
+    const h2 = makeHarness(opts);
+    h2.deps.diff = inject;
+    await reconcilePartition(h2.deps, { ...BASE });
+
+    // On pass 2 'dup' is a confirmed delete AND an upsert → contradiction →
+    // dropped from both; nothing enqueued for it.
+    expect(h2.enqueued.filter((e) => e.row_id === 'dup').length).toBe(0);
   });
 
   it('stale id (in both, hash differs) re-pushes as a single upsert, never a delete', async () => {
     // A stale row does not change the partition count, so add a local-only id to
     // break count-equality and force the diff path. The stale id must then
     // produce exactly one upsert and no delete.
-    const s = settled(20);
+    const s = settled(2);
     const h = makeHarness({
       protocolVersion: 3,
-      local: [...s.local, { id: 'dup', content_hash: 'h1' }, { id: 'localonly' }], // count 22
+      local: [...s.local, { id: 'dup', content_hash: 'h1' }, { id: 'localonly' }], // count 4
       pages: [page([...s.manifest, manifest('dup', 'p1', 'h2')], s.count + 1)],
-      summaryCount: s.count + 1, // D1 count 21 ≠ local 22 → diff path
+      summaryCount: s.count + 1, // D1 count 3 ≠ local 4 → diff path
     });
-    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    await reconcilePartition(h.deps, { ...BASE });
     expect(h.enqueued.filter((e) => e.row_id === 'dup' && e.operation === 'delete').length).toBe(0);
     expect(h.enqueued.filter((e) => e.row_id === 'dup').length).toBe(1);
     // 'localonly' also upserts (local-only).
@@ -346,18 +471,19 @@ describe('reconcilePartition — resurrection guard', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Delete safety firewall
+// Delete safety firewall (settledness)
 // ---------------------------------------------------------------------------
 
 describe('reconcilePartition — delete safety', () => {
   it('transient localCount=0 (d1Count>0) → NO delete, but does not throw', async () => {
-    const h = makeHarness({
+    // Even across two passes, a not_settled partition seeds no deletes.
+    const opts: HarnessOpts = {
       protocolVersion: 3,
       local: [], // empty local → not_settled blocks deletes
       pages: [page([manifest('a', 'p1'), manifest('b', 'p1')], 2)],
       summaryCount: 2,
-    });
-    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    };
+    const h = await runPasses(opts, 2);
     expect(h.enqueued.filter((e) => e.operation === 'delete').length).toBe(0);
     // No upserts either — local is empty.
     expect(h.enqueued.length).toBe(0);
@@ -367,16 +493,17 @@ describe('reconcilePartition — delete safety', () => {
   it('blocked deletes still allow upserts/stale re-pushes to proceed', async () => {
     // membershipSeeded=false blocks deletes; a local-only id still upserts.
     // Use a count mismatch (D1 has two extras, local has one extra) so the diff
-    // path runs rather than the count-equal fast path.
-    const s = settled(20);
-    const h = makeHarness({
+    // path runs rather than the count-equal fast path. Two passes prove the block
+    // holds even once an orphan would otherwise be cross-pass confirmed.
+    const s = settled(2);
+    const opts: HarnessOpts = {
       protocolVersion: 3,
-      local: [...s.local, { id: 'localonly' }], // count 21
+      local: [...s.local, { id: 'localonly' }], // count 3
       pages: [page([...s.manifest, manifest('d1extra1', 'p1'), manifest('d1extra2', 'p1')], s.count + 2)],
-      summaryCount: s.count + 2, // D1 count 22 ≠ local 21
+      summaryCount: s.count + 2, // D1 count 4 ≠ local 3
       membershipSeeded: false, // blocks deletes (membership_unseeded)
-    });
-    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    };
+    const h = await runPasses(opts, 2);
     expect(h.enqueued.filter((e) => e.operation === 'delete').length).toBe(0);
     const upserts = h.enqueued.filter((e) => (e.operation ?? 'upsert') === 'upsert');
     expect(upserts.map((u) => u.row_id)).toEqual(['localonly']);
@@ -388,16 +515,16 @@ describe('reconcilePartition — delete safety', () => {
 // ---------------------------------------------------------------------------
 
 describe('reconcilePartition — N3 per-home mismatch guard', () => {
-  it('manifest item from a DIFFERENT project is NOT deleted', async () => {
-    const h = makeHarness({
+  it('manifest item from a DIFFERENT project is NOT deleted (even across passes)', async () => {
+    const opts: HarnessOpts = {
       protocolVersion: 3,
       local: [{ id: 'a' }],
       // 'other' belongs to project p2 (another home's grove) — must not delete.
       // count mismatch (D1 reports 2 for partition) to force the diff path.
       pages: [page([manifest('a', 'p1'), manifest('other', 'p2')], 2)],
       summaryCount: 2,
-    });
-    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    };
+    const h = await runPasses(opts, 2);
     expect(h.enqueued.filter((e) => e.row_id === 'other').length).toBe(0);
     expect(h.enqueued.filter((e) => e.operation === 'delete').length).toBe(0);
   });
@@ -411,17 +538,15 @@ describe('reconcilePartition — pagination', () => {
   it('follows next_cursor until exhausted', async () => {
     const h = makeHarness({
       protocolVersion: 3,
-      local: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+      local: [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }],
       pages: [
         page([manifest('a', 'p1')], 3, 'cursor-2'),
         page([manifest('b', 'p1')], 3, 'cursor-3'),
         page([manifest('c', 'p1')], 3), // no next_cursor → stop
       ],
-      summaryCount: 3, // count differs? equal to local (3) → fast path!
+      summaryCount: 3, // D1 count 3 ≠ local 4 → diff path forces paging
     });
-    // Make count differ from local to force paging.
-    h.deps.localPartition = () => [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }];
-    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    await reconcilePartition(h.deps, { ...BASE });
     expect(h.pageCalls).toBe(3);
     // 'd' is local-only → one upsert.
     expect(h.enqueued.filter((e) => e.row_id === 'd').length).toBe(1);
@@ -433,7 +558,6 @@ describe('reconcilePartition — pagination', () => {
 // ---------------------------------------------------------------------------
 
 describe('reconcilePartition — forceFullDiff gap closure', () => {
-  // 5 shared rows so a 1-delete doesn't hit the 20% fraction cap (1/6 ≈ 16.7%).
   const baseShared = settled(5); // {s0..s4}
 
   it('forceFullDiff:false + equal counts → count-match fast path, no diff, no enqueue', async () => {
@@ -443,27 +567,35 @@ describe('reconcilePartition — forceFullDiff gap closure', () => {
       pages: [page([...baseShared.manifest, manifest('A', 'p1')], 6)], // 6 D1
       summaryCount: 6,  // D1 count == local count → fast-path skip
     });
-    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 }, forceFullDiff: false });
+    await reconcilePartition(h.deps, { ...BASE, forceFullDiff: false });
     // Count-equality fast path: summary fetched, no paging, no enqueue.
     expect(h.summaryCalls).toBe(1);
     expect(h.pageCalls).toBe(0);
     expect(h.enqueued.length).toBe(0);
   });
 
-  it('forceFullDiff:true + equal counts → full diff runs, seeds delete for D1-orphan and upsert for local-only', async () => {
-    const h = makeHarness({
+  it('forceFullDiff:true + equal counts → full diff runs, upserts local-only immediately; D1-orphan deletes on the 2nd pass', async () => {
+    const opts: HarnessOpts = {
       protocolVersion: 3,
       local: [...baseShared.local, { id: 'B' }],           // 6 local: s0-s4 + B
       pages: [page([...baseShared.manifest, manifest('A', 'p1')], 6)], // 6 D1: s0-s4 + A
       summaryCount: 6,  // same count — would skip without forceFullDiff
-    });
-    await reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 }, forceFullDiff: true });
-    // Summary skipped; paging ran.
-    expect(h.summaryCalls).toBe(0);
-    expect(h.pageCalls).toBe(1);
-    // A is D1-orphan → delete; B is local-only → upsert.
-    const deletes = h.enqueued.filter((e) => e.operation === 'delete');
-    const upserts = h.enqueued.filter((e) => (e.operation ?? 'upsert') === 'upsert');
+    };
+
+    // Pass 1: summary skipped, paging ran; B (local-only) upserts now, A
+    // (D1-orphan) is only recorded (first sighting), not yet deleted.
+    const h1 = makeHarness(opts);
+    await reconcilePartition(h1.deps, { ...BASE, forceFullDiff: true });
+    expect(h1.summaryCalls).toBe(0);
+    expect(h1.pageCalls).toBe(1);
+    expect(h1.enqueued.filter((e) => e.operation === 'delete').length).toBe(0);
+    expect(h1.enqueued.filter((e) => (e.operation ?? 'upsert') === 'upsert' && e.row_id === 'B').length).toBe(1);
+
+    // Pass 2: A seen again → delete; B still upserts.
+    const h2 = makeHarness(opts);
+    await reconcilePartition(h2.deps, { ...BASE, forceFullDiff: true });
+    const deletes = h2.enqueued.filter((e) => e.operation === 'delete');
+    const upserts = h2.enqueued.filter((e) => (e.operation ?? 'upsert') === 'upsert');
     expect(deletes.length).toBe(1);
     expect(deletes[0].row_id).toBe('A');
     expect(upserts.length).toBe(1);
@@ -479,8 +611,8 @@ describe('reconcilePartition — INTEGER id partition (type normalization)', () 
   it('number/string id mismatch does not cause spurious mass delete/upsert', async () => {
     // localPartition stringifies ids; the raw D1 manifest hands back numbers.
     // The 20 shared rows must be recognized as in-sync (no upsert, no delete);
-    // only the genuine integer D1-orphan (999) is deleted, with a STRING row_id.
-    // 1/21 deletes ≈ 4.8% keeps us under the 20% fraction cap.
+    // only the genuine integer D1-orphan (999) is deleted, with a STRING row_id —
+    // and only after it is observed on two consecutive passes.
     const local: PartitionRow[] = [];
     const items: ManifestItem[] = [];
     for (let i = 1; i <= 20; i++) {
@@ -489,13 +621,13 @@ describe('reconcilePartition — INTEGER id partition (type normalization)', () 
     }
     items.push({ id: 999, project_id: 'p1' } as unknown as ManifestItem);        // D1 orphan
 
-    const h = makeHarness({
+    const opts: HarnessOpts = {
       protocolVersion: 3,
       local,
       pages: [page(items, 21)],
       summaryCount: 21, // D1 21 vs local 20 → diff path
-    });
-    await reconcilePartition(h.deps, { ...BASE, table: 'prompt_batches', passAggregate: { count: 0 } });
+    };
+    const h = await runPasses(opts, 2, { table: 'prompt_batches' });
 
     const deletes = h.enqueued.filter((e) => e.operation === 'delete');
     const upserts = h.enqueued.filter((e) => (e.operation ?? 'upsert') === 'upsert');
@@ -545,7 +677,7 @@ describe('reconcilePartition — MF3 mutex', () => {
     // Start the reconcile, then immediately start the flush. Because the seed
     // section holds the mutex, the flush must run entirely before or entirely
     // after the seed — never interleaved with seed:enqueue.
-    const recon = reconcilePartition(h.deps, { ...BASE, passAggregate: { count: 0 } });
+    const recon = reconcilePartition(h.deps, { ...BASE });
     const fl = flush();
     await Promise.all([recon, fl]);
 

--- a/tests/daemon/team-reconcile-partition.test.ts
+++ b/tests/daemon/team-reconcile-partition.test.ts
@@ -340,7 +340,7 @@ describe('reconcilePartition — cross-pass drift stability', () => {
     const h2 = await runPasses(opts, 2);
     const deletes = h2.enqueued.filter((e) => e.operation === 'delete');
     expect(deletes.length).toBe(ORPHANS);
-    // No safety block was logged — a large settled drift is NOT operator-gated.
+    // No safety block was logged — a large settled drift is NOT magnitude-gated.
     expect(h2.logs.some((l) => /blocked/i.test(l))).toBe(false);
   });
 

--- a/tests/daemon/team-reconcile-safety.test.ts
+++ b/tests/daemon/team-reconcile-safety.test.ts
@@ -1,40 +1,31 @@
 /**
- * Exhaustive unit tests for evaluateDeleteSafety — the data-loss firewall for
- * symmetric team-sync reconcile.
+ * Unit tests for evaluateDeleteSafety — the settledness firewall for symmetric
+ * team-sync reconcile.
  *
- * This function is the SOLE daemon-side guard bounding how many D1 rows an
- * automatic reconcile may delete. Tests cover every guard, every boundary, and
- * every operator-override interaction. All inputs are plain objects; no I/O.
+ * The reconcile path is a FULLY AUTOMATIC backstop, so this gate is purely
+ * machine-decidable: there is NO operator override and NO magnitude cap. Delete
+ * blast radius is bounded elsewhere by cross-pass drift stability (see
+ * team-reconcile-partition.test.ts). What remains here are the two settledness
+ * guards, which block unconditionally. All inputs are plain objects; no I/O.
  */
 
 import { describe, expect, it } from 'bun:test';
-import {
-  evaluateDeleteSafety,
-  MIN_ABSOLUTE_DELETE_FLOOR,
-  MAX_DELETE_FRACTION,
-  MAX_PASS_AGGREGATE_DELETES,
-} from '@myco/daemon/team-reconcile.js';
+import { evaluateDeleteSafety } from '@myco/daemon/team-reconcile.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Build a baseline input where everything is settled, small, and automatic. */
+/** Build a baseline input where everything is settled. */
 function safe(overrides: {
   localCount?: number;
   d1Count?: number;
-  partitionDeleteCount?: number;
-  passAggregateDeleteCount?: number;
   membershipSeeded?: boolean;
-  operatorConfirmed?: boolean;
 } = {}) {
   return {
     localCount: 100,
     d1Count: 100,
-    partitionDeleteCount: 1,
-    passAggregateDeleteCount: 1,
     membershipSeeded: true,
-    operatorConfirmed: false,
     ...overrides,
   };
 }
@@ -44,36 +35,25 @@ function safe(overrides: {
 // ---------------------------------------------------------------------------
 
 describe('evaluateDeleteSafety — guard 1: transient-empty local', () => {
-  it('blocks when localCount===0 and d1Count>0 (automatic)', () => {
-    const result = evaluateDeleteSafety(safe({ localCount: 0, d1Count: 50, membershipSeeded: true }));
+  it('blocks when localCount===0 and d1Count>0', () => {
+    const result = evaluateDeleteSafety(safe({ localCount: 0, d1Count: 50 }));
     expect(result.allow).toBe(false);
     expect(result.reason).toBe('not_settled');
   });
 
-  it('blocks even when operatorConfirmed (operator cannot override settledness)', () => {
-    const result = evaluateDeleteSafety(safe({
-      localCount: 0,
-      d1Count: 50,
-      membershipSeeded: true,
-      operatorConfirmed: true,
-    }));
+  it('blocks regardless of how large d1Count is (no magnitude escape hatch)', () => {
+    const result = evaluateDeleteSafety(safe({ localCount: 0, d1Count: 100_000 }));
     expect(result.allow).toBe(false);
     expect(result.reason).toBe('not_settled');
   });
 
   it('does NOT block when localCount===0 and d1Count===0 (nothing to delete)', () => {
-    const result = evaluateDeleteSafety(safe({
-      localCount: 0,
-      d1Count: 0,
-      partitionDeleteCount: 0,
-      membershipSeeded: true,
-    }));
+    const result = evaluateDeleteSafety(safe({ localCount: 0, d1Count: 0 }));
     expect(result.allow).toBe(true);
   });
 
   it('does NOT block when localCount>0 even if d1Count>0', () => {
     const result = evaluateDeleteSafety(safe({ localCount: 5, d1Count: 100 }));
-    // Falls through to magnitude caps; with partitionDeleteCount=1 it passes.
     expect(result.allow).toBe(true);
   });
 });
@@ -83,14 +63,18 @@ describe('evaluateDeleteSafety — guard 1: transient-empty local', () => {
 // ---------------------------------------------------------------------------
 
 describe('evaluateDeleteSafety — guard 2: membership unseeded', () => {
-  it('blocks when membershipSeeded===false (automatic)', () => {
+  it('blocks when membershipSeeded===false', () => {
     const result = evaluateDeleteSafety(safe({ membershipSeeded: false }));
     expect(result.allow).toBe(false);
     expect(result.reason).toBe('membership_unseeded');
   });
 
-  it('blocks when membershipSeeded===false even with operatorConfirmed', () => {
-    const result = evaluateDeleteSafety(safe({ membershipSeeded: false, operatorConfirmed: true }));
+  it('blocks even when local and d1 counts are large and equal', () => {
+    const result = evaluateDeleteSafety(safe({
+      localCount: 10_000,
+      d1Count: 10_000,
+      membershipSeeded: false,
+    }));
     expect(result.allow).toBe(false);
     expect(result.reason).toBe('membership_unseeded');
   });
@@ -102,188 +86,44 @@ describe('evaluateDeleteSafety — guard 2: membership unseeded', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Guard 3: operatorConfirmed bypasses magnitude caps
+// No magnitude caps / no operator gate: any settled drift is allowed
 // ---------------------------------------------------------------------------
 
-describe('evaluateDeleteSafety — guard 3: operatorConfirmed bypasses magnitude caps', () => {
-  it('allows when operatorConfirmed and partitionDeleteCount exceeds floor', () => {
-    const result = evaluateDeleteSafety(safe({
-      partitionDeleteCount: MIN_ABSOLUTE_DELETE_FLOOR + 1,
-      d1Count: 1000,
-      operatorConfirmed: true,
-    }));
-    expect(result.allow).toBe(true);
-  });
-
-  it('allows when operatorConfirmed and fraction exceeds MAX_DELETE_FRACTION', () => {
-    // 90% delete rate — way over fraction cap but operator confirmed.
-    const result = evaluateDeleteSafety(safe({
-      d1Count: 100,
-      partitionDeleteCount: 90,
-      operatorConfirmed: true,
-    }));
-    expect(result.allow).toBe(true);
-  });
-
-  it('allows when operatorConfirmed and passAggregateDeleteCount exceeds aggregate cap', () => {
-    const result = evaluateDeleteSafety(safe({
-      passAggregateDeleteCount: MAX_PASS_AGGREGATE_DELETES + 1,
-      operatorConfirmed: true,
-    }));
-    expect(result.allow).toBe(true);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Guard 4: per-partition absolute floor
-// ---------------------------------------------------------------------------
-
-describe('evaluateDeleteSafety — guard 4: per-partition absolute floor', () => {
-  it('blocks when partitionDeleteCount > MIN_ABSOLUTE_DELETE_FLOOR (automatic)', () => {
-    const result = evaluateDeleteSafety(safe({
-      d1Count: 10000, // large so fraction cap is not the binding guard
-      partitionDeleteCount: MIN_ABSOLUTE_DELETE_FLOOR + 1,
-    }));
-    expect(result.allow).toBe(false);
-    expect(result.reason).toBe('requires_operator');
-  });
-
-  it('allows when partitionDeleteCount === MIN_ABSOLUTE_DELETE_FLOOR (at boundary, automatic)', () => {
-    const result = evaluateDeleteSafety(safe({
-      d1Count: 10000,
-      partitionDeleteCount: MIN_ABSOLUTE_DELETE_FLOOR,
-    }));
-    expect(result.allow).toBe(true);
-  });
-
-  it('blocks at floor+1 but allows with operatorConfirmed', () => {
-    const input = safe({
-      d1Count: 10000,
-      partitionDeleteCount: MIN_ABSOLUTE_DELETE_FLOOR + 1,
-      operatorConfirmed: true,
-    });
-    expect(evaluateDeleteSafety(input).allow).toBe(true);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Guard 5: fraction cap
-// ---------------------------------------------------------------------------
-
-describe('evaluateDeleteSafety — guard 5: fraction cap', () => {
-  it('blocks when partitionDeleteCount/d1Count > MAX_DELETE_FRACTION (automatic)', () => {
-    // Use a small d1Count so the fraction guard triggers while the delete count
-    // stays well under the absolute floor. With d1Count=20 and fraction 0.2:
-    //   floor threshold  = MIN_ABSOLUTE_DELETE_FLOOR (50)
-    //   fraction-blocked = Math.ceil(20 * (0.2 + epsilon)) = 5 deletes (25% > 20%)
-    // 5 is safely under 50, so guard 4 does NOT fire first.
-    const d1Count = 20;
-    const partitionDeleteCount = 5; // 5/20 = 0.25 > MAX_DELETE_FRACTION (0.2)
-    expect(partitionDeleteCount).toBeLessThan(MIN_ABSOLUTE_DELETE_FLOOR);
-    expect(partitionDeleteCount / d1Count).toBeGreaterThan(MAX_DELETE_FRACTION);
-
-    const result = evaluateDeleteSafety(safe({ d1Count, partitionDeleteCount }));
-    expect(result.allow).toBe(false);
-    // reason is implementation-defined for this guard; check it's not the others.
-    expect(result.reason).not.toBe('not_settled');
-    expect(result.reason).not.toBe('membership_unseeded');
-    expect(result.reason).not.toBe('requires_operator');
-  });
-
-  it('allows when fraction is exactly MAX_DELETE_FRACTION (not strictly greater)', () => {
-    // partitionDeleteCount / d1Count === MAX_DELETE_FRACTION → NOT blocked.
-    const d1Count = 100;
-    const partitionDeleteCount = Math.floor(d1Count * MAX_DELETE_FRACTION);
-    // Ensure still under the floor.
-    const result = evaluateDeleteSafety(safe({ d1Count, partitionDeleteCount }));
-    expect(result.allow).toBe(true);
-  });
-
-  it('skips fraction check when d1Count===0 (no divide-by-zero)', () => {
-    const result = evaluateDeleteSafety(safe({
-      d1Count: 0,
-      partitionDeleteCount: 0,
-      passAggregateDeleteCount: 0,
-    }));
-    expect(result.allow).toBe(true);
-  });
-
-  it('blocks on fraction but allows with operatorConfirmed', () => {
-    const d1Count = 20;
-    const partitionDeleteCount = 5; // 5/20 = 0.25 > MAX_DELETE_FRACTION
-    const result = evaluateDeleteSafety(safe({ d1Count, partitionDeleteCount, operatorConfirmed: true }));
-    expect(result.allow).toBe(true);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Guard 6: per-pass aggregate cap
-// ---------------------------------------------------------------------------
-
-describe('evaluateDeleteSafety — guard 6: per-pass aggregate cap', () => {
-  it('blocks when passAggregateDeleteCount > MAX_PASS_AGGREGATE_DELETES (automatic)', () => {
-    const result = evaluateDeleteSafety(safe({
-      passAggregateDeleteCount: MAX_PASS_AGGREGATE_DELETES + 1,
-    }));
-    expect(result.allow).toBe(false);
-    expect(result.reason).not.toBe('not_settled');
-    expect(result.reason).not.toBe('membership_unseeded');
-    expect(result.reason).not.toBe('requires_operator');
-  });
-
-  it('allows when passAggregateDeleteCount === MAX_PASS_AGGREGATE_DELETES (at boundary)', () => {
-    const result = evaluateDeleteSafety(safe({
-      passAggregateDeleteCount: MAX_PASS_AGGREGATE_DELETES,
-    }));
-    expect(result.allow).toBe(true);
-  });
-
-  it('blocks on aggregate but allows with operatorConfirmed', () => {
-    const result = evaluateDeleteSafety(safe({
-      passAggregateDeleteCount: MAX_PASS_AGGREGATE_DELETES + 1,
-      operatorConfirmed: true,
-    }));
-    expect(result.allow).toBe(true);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Guard 7: settled, under all caps → allow
-// ---------------------------------------------------------------------------
-
-describe('evaluateDeleteSafety — guard 7: settled and small → allow', () => {
-  it('allows when all guards pass (typical small drift case)', () => {
-    const result = evaluateDeleteSafety(safe());
+describe('evaluateDeleteSafety — no magnitude/operator gate', () => {
+  it('allows a settled partition with a huge D1 surplus (no fraction cap)', () => {
+    // local 1, D1 100_000 — a 99.999% would-be delete rate is NOT blocked here;
+    // cross-pass drift stability (not this gate) bounds blast radius.
+    const result = evaluateDeleteSafety(safe({ localCount: 1, d1Count: 100_000 }));
     expect(result.allow).toBe(true);
     expect(result.reason).toBeUndefined();
   });
 
-  it('allows a zero-delete reconcile pass', () => {
-    const result = evaluateDeleteSafety(safe({
-      partitionDeleteCount: 0,
-      passAggregateDeleteCount: 0,
-    }));
+  it('allows a settled partition with thousands of would-be deletes (no floor)', () => {
+    const result = evaluateDeleteSafety(safe({ localCount: 50, d1Count: 5_050 }));
     expect(result.allow).toBe(true);
+  });
+
+  it('exposes no operator/magnitude reason — only settledness reasons exist', () => {
+    // A blocked result is only ever one of the two settledness reasons.
+    const blocked = [
+      evaluateDeleteSafety(safe({ localCount: 0, d1Count: 1 })),
+      evaluateDeleteSafety(safe({ membershipSeeded: false })),
+    ];
+    for (const r of blocked) {
+      expect(r.allow).toBe(false);
+      expect(['not_settled', 'membership_unseeded']).toContain(r.reason);
+    }
   });
 });
 
 // ---------------------------------------------------------------------------
-// Constant sanity checks — ensure named exports exist and are in valid ranges
+// Settled → allow
 // ---------------------------------------------------------------------------
 
-describe('evaluateDeleteSafety — exported constants', () => {
-  it('MIN_ABSOLUTE_DELETE_FLOOR is a positive integer in a safe range', () => {
-    expect(MIN_ABSOLUTE_DELETE_FLOOR).toBeGreaterThan(0);
-    expect(Number.isInteger(MIN_ABSOLUTE_DELETE_FLOOR)).toBe(true);
-  });
-
-  it('MAX_DELETE_FRACTION is between 0.1 and 0.2 inclusive', () => {
-    expect(MAX_DELETE_FRACTION).toBeGreaterThanOrEqual(0.1);
-    expect(MAX_DELETE_FRACTION).toBeLessThanOrEqual(0.2);
-  });
-
-  it('MAX_PASS_AGGREGATE_DELETES is a positive integer larger than MIN_ABSOLUTE_DELETE_FLOOR', () => {
-    expect(MAX_PASS_AGGREGATE_DELETES).toBeGreaterThan(MIN_ABSOLUTE_DELETE_FLOOR);
-    expect(Number.isInteger(MAX_PASS_AGGREGATE_DELETES)).toBe(true);
+describe('evaluateDeleteSafety — settled → allow', () => {
+  it('allows a settled, seeded partition', () => {
+    const result = evaluateDeleteSafety(safe());
+    expect(result.allow).toBe(true);
+    expect(result.reason).toBeUndefined();
   });
 });

--- a/tests/daemon/team-reconcile-safety.test.ts
+++ b/tests/daemon/team-reconcile-safety.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Exhaustive unit tests for evaluateDeleteSafety — the data-loss firewall for
+ * symmetric team-sync reconcile.
+ *
+ * This function is the SOLE daemon-side guard bounding how many D1 rows an
+ * automatic reconcile may delete. Tests cover every guard, every boundary, and
+ * every operator-override interaction. All inputs are plain objects; no I/O.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  evaluateDeleteSafety,
+  MIN_ABSOLUTE_DELETE_FLOOR,
+  MAX_DELETE_FRACTION,
+  MAX_PASS_AGGREGATE_DELETES,
+} from '@myco/daemon/team-reconcile.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a baseline input where everything is settled, small, and automatic. */
+function safe(overrides: {
+  localCount?: number;
+  d1Count?: number;
+  partitionDeleteCount?: number;
+  passAggregateDeleteCount?: number;
+  membershipSeeded?: boolean;
+  operatorConfirmed?: boolean;
+} = {}) {
+  return {
+    localCount: 100,
+    d1Count: 100,
+    partitionDeleteCount: 1,
+    passAggregateDeleteCount: 1,
+    membershipSeeded: true,
+    operatorConfirmed: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Guard 1: transient-empty trap (localCount === 0 && d1Count > 0)
+// ---------------------------------------------------------------------------
+
+describe('evaluateDeleteSafety — guard 1: transient-empty local', () => {
+  it('blocks when localCount===0 and d1Count>0 (automatic)', () => {
+    const result = evaluateDeleteSafety(safe({ localCount: 0, d1Count: 50, membershipSeeded: true }));
+    expect(result.allow).toBe(false);
+    expect(result.reason).toBe('not_settled');
+  });
+
+  it('blocks even when operatorConfirmed (operator cannot override settledness)', () => {
+    const result = evaluateDeleteSafety(safe({
+      localCount: 0,
+      d1Count: 50,
+      membershipSeeded: true,
+      operatorConfirmed: true,
+    }));
+    expect(result.allow).toBe(false);
+    expect(result.reason).toBe('not_settled');
+  });
+
+  it('does NOT block when localCount===0 and d1Count===0 (nothing to delete)', () => {
+    const result = evaluateDeleteSafety(safe({
+      localCount: 0,
+      d1Count: 0,
+      partitionDeleteCount: 0,
+      membershipSeeded: true,
+    }));
+    expect(result.allow).toBe(true);
+  });
+
+  it('does NOT block when localCount>0 even if d1Count>0', () => {
+    const result = evaluateDeleteSafety(safe({ localCount: 5, d1Count: 100 }));
+    // Falls through to magnitude caps; with partitionDeleteCount=1 it passes.
+    expect(result.allow).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard 2: membership unseeded
+// ---------------------------------------------------------------------------
+
+describe('evaluateDeleteSafety — guard 2: membership unseeded', () => {
+  it('blocks when membershipSeeded===false (automatic)', () => {
+    const result = evaluateDeleteSafety(safe({ membershipSeeded: false }));
+    expect(result.allow).toBe(false);
+    expect(result.reason).toBe('membership_unseeded');
+  });
+
+  it('blocks when membershipSeeded===false even with operatorConfirmed', () => {
+    const result = evaluateDeleteSafety(safe({ membershipSeeded: false, operatorConfirmed: true }));
+    expect(result.allow).toBe(false);
+    expect(result.reason).toBe('membership_unseeded');
+  });
+
+  it('does NOT block when membershipSeeded===true', () => {
+    const result = evaluateDeleteSafety(safe({ membershipSeeded: true }));
+    expect(result.allow).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard 3: operatorConfirmed bypasses magnitude caps
+// ---------------------------------------------------------------------------
+
+describe('evaluateDeleteSafety — guard 3: operatorConfirmed bypasses magnitude caps', () => {
+  it('allows when operatorConfirmed and partitionDeleteCount exceeds floor', () => {
+    const result = evaluateDeleteSafety(safe({
+      partitionDeleteCount: MIN_ABSOLUTE_DELETE_FLOOR + 1,
+      d1Count: 1000,
+      operatorConfirmed: true,
+    }));
+    expect(result.allow).toBe(true);
+  });
+
+  it('allows when operatorConfirmed and fraction exceeds MAX_DELETE_FRACTION', () => {
+    // 90% delete rate — way over fraction cap but operator confirmed.
+    const result = evaluateDeleteSafety(safe({
+      d1Count: 100,
+      partitionDeleteCount: 90,
+      operatorConfirmed: true,
+    }));
+    expect(result.allow).toBe(true);
+  });
+
+  it('allows when operatorConfirmed and passAggregateDeleteCount exceeds aggregate cap', () => {
+    const result = evaluateDeleteSafety(safe({
+      passAggregateDeleteCount: MAX_PASS_AGGREGATE_DELETES + 1,
+      operatorConfirmed: true,
+    }));
+    expect(result.allow).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard 4: per-partition absolute floor
+// ---------------------------------------------------------------------------
+
+describe('evaluateDeleteSafety — guard 4: per-partition absolute floor', () => {
+  it('blocks when partitionDeleteCount > MIN_ABSOLUTE_DELETE_FLOOR (automatic)', () => {
+    const result = evaluateDeleteSafety(safe({
+      d1Count: 10000, // large so fraction cap is not the binding guard
+      partitionDeleteCount: MIN_ABSOLUTE_DELETE_FLOOR + 1,
+    }));
+    expect(result.allow).toBe(false);
+    expect(result.reason).toBe('requires_operator');
+  });
+
+  it('allows when partitionDeleteCount === MIN_ABSOLUTE_DELETE_FLOOR (at boundary, automatic)', () => {
+    const result = evaluateDeleteSafety(safe({
+      d1Count: 10000,
+      partitionDeleteCount: MIN_ABSOLUTE_DELETE_FLOOR,
+    }));
+    expect(result.allow).toBe(true);
+  });
+
+  it('blocks at floor+1 but allows with operatorConfirmed', () => {
+    const input = safe({
+      d1Count: 10000,
+      partitionDeleteCount: MIN_ABSOLUTE_DELETE_FLOOR + 1,
+      operatorConfirmed: true,
+    });
+    expect(evaluateDeleteSafety(input).allow).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard 5: fraction cap
+// ---------------------------------------------------------------------------
+
+describe('evaluateDeleteSafety — guard 5: fraction cap', () => {
+  it('blocks when partitionDeleteCount/d1Count > MAX_DELETE_FRACTION (automatic)', () => {
+    // Use a small d1Count so the fraction guard triggers while the delete count
+    // stays well under the absolute floor. With d1Count=20 and fraction 0.2:
+    //   floor threshold  = MIN_ABSOLUTE_DELETE_FLOOR (50)
+    //   fraction-blocked = Math.ceil(20 * (0.2 + epsilon)) = 5 deletes (25% > 20%)
+    // 5 is safely under 50, so guard 4 does NOT fire first.
+    const d1Count = 20;
+    const partitionDeleteCount = 5; // 5/20 = 0.25 > MAX_DELETE_FRACTION (0.2)
+    expect(partitionDeleteCount).toBeLessThan(MIN_ABSOLUTE_DELETE_FLOOR);
+    expect(partitionDeleteCount / d1Count).toBeGreaterThan(MAX_DELETE_FRACTION);
+
+    const result = evaluateDeleteSafety(safe({ d1Count, partitionDeleteCount }));
+    expect(result.allow).toBe(false);
+    // reason is implementation-defined for this guard; check it's not the others.
+    expect(result.reason).not.toBe('not_settled');
+    expect(result.reason).not.toBe('membership_unseeded');
+    expect(result.reason).not.toBe('requires_operator');
+  });
+
+  it('allows when fraction is exactly MAX_DELETE_FRACTION (not strictly greater)', () => {
+    // partitionDeleteCount / d1Count === MAX_DELETE_FRACTION → NOT blocked.
+    const d1Count = 100;
+    const partitionDeleteCount = Math.floor(d1Count * MAX_DELETE_FRACTION);
+    // Ensure still under the floor.
+    const result = evaluateDeleteSafety(safe({ d1Count, partitionDeleteCount }));
+    expect(result.allow).toBe(true);
+  });
+
+  it('skips fraction check when d1Count===0 (no divide-by-zero)', () => {
+    const result = evaluateDeleteSafety(safe({
+      d1Count: 0,
+      partitionDeleteCount: 0,
+      passAggregateDeleteCount: 0,
+    }));
+    expect(result.allow).toBe(true);
+  });
+
+  it('blocks on fraction but allows with operatorConfirmed', () => {
+    const d1Count = 20;
+    const partitionDeleteCount = 5; // 5/20 = 0.25 > MAX_DELETE_FRACTION
+    const result = evaluateDeleteSafety(safe({ d1Count, partitionDeleteCount, operatorConfirmed: true }));
+    expect(result.allow).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard 6: per-pass aggregate cap
+// ---------------------------------------------------------------------------
+
+describe('evaluateDeleteSafety — guard 6: per-pass aggregate cap', () => {
+  it('blocks when passAggregateDeleteCount > MAX_PASS_AGGREGATE_DELETES (automatic)', () => {
+    const result = evaluateDeleteSafety(safe({
+      passAggregateDeleteCount: MAX_PASS_AGGREGATE_DELETES + 1,
+    }));
+    expect(result.allow).toBe(false);
+    expect(result.reason).not.toBe('not_settled');
+    expect(result.reason).not.toBe('membership_unseeded');
+    expect(result.reason).not.toBe('requires_operator');
+  });
+
+  it('allows when passAggregateDeleteCount === MAX_PASS_AGGREGATE_DELETES (at boundary)', () => {
+    const result = evaluateDeleteSafety(safe({
+      passAggregateDeleteCount: MAX_PASS_AGGREGATE_DELETES,
+    }));
+    expect(result.allow).toBe(true);
+  });
+
+  it('blocks on aggregate but allows with operatorConfirmed', () => {
+    const result = evaluateDeleteSafety(safe({
+      passAggregateDeleteCount: MAX_PASS_AGGREGATE_DELETES + 1,
+      operatorConfirmed: true,
+    }));
+    expect(result.allow).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard 7: settled, under all caps → allow
+// ---------------------------------------------------------------------------
+
+describe('evaluateDeleteSafety — guard 7: settled and small → allow', () => {
+  it('allows when all guards pass (typical small drift case)', () => {
+    const result = evaluateDeleteSafety(safe());
+    expect(result.allow).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('allows a zero-delete reconcile pass', () => {
+    const result = evaluateDeleteSafety(safe({
+      partitionDeleteCount: 0,
+      passAggregateDeleteCount: 0,
+    }));
+    expect(result.allow).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Constant sanity checks — ensure named exports exist and are in valid ranges
+// ---------------------------------------------------------------------------
+
+describe('evaluateDeleteSafety — exported constants', () => {
+  it('MIN_ABSOLUTE_DELETE_FLOOR is a positive integer in a safe range', () => {
+    expect(MIN_ABSOLUTE_DELETE_FLOOR).toBeGreaterThan(0);
+    expect(Number.isInteger(MIN_ABSOLUTE_DELETE_FLOOR)).toBe(true);
+  });
+
+  it('MAX_DELETE_FRACTION is between 0.1 and 0.2 inclusive', () => {
+    expect(MAX_DELETE_FRACTION).toBeGreaterThanOrEqual(0.1);
+    expect(MAX_DELETE_FRACTION).toBeLessThanOrEqual(0.2);
+  });
+
+  it('MAX_PASS_AGGREGATE_DELETES is a positive integer larger than MIN_ABSOLUTE_DELETE_FLOOR', () => {
+    expect(MAX_PASS_AGGREGATE_DELETES).toBeGreaterThan(MIN_ABSOLUTE_DELETE_FLOOR);
+    expect(Number.isInteger(MAX_PASS_AGGREGATE_DELETES)).toBe(true);
+  });
+});

--- a/tests/daemon/team-reconcile-triggers.test.ts
+++ b/tests/daemon/team-reconcile-triggers.test.ts
@@ -348,7 +348,7 @@ describe('team-sync reconcile triggers', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // forceFullDiff threading: backstop/operator → true, poll path → false
+  // forceFullDiff threading: backstop/on-demand → true, poll path → false
   // ---------------------------------------------------------------------------
 
   it('reconcileAllGroves (backstop/on-demand) reaches reconcilePartition with forceFullDiff:true', async () => {

--- a/tests/daemon/team-reconcile-triggers.test.ts
+++ b/tests/daemon/team-reconcile-triggers.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { vi } from '../helpers/vi-shim.js';
+import { initTeamSync } from '@myco/daemon/team-sync-init.js';
+
+// Reconcile-eligible table allow-list the trigger pass iterates. Mocked to a
+// small set so call counts stay legible (real list is 13 project-scoped tables).
+const MOCK_RECONCILE_TABLES = ['sessions', 'spores'];
+
+const {
+  enqueueBatchMock,
+  listPendingMock,
+  backfillUnsyncedMock,
+  upsertSelfMemberMock,
+  setTeamSyncEnabledMock,
+  setProjectSyncMembershipMock,
+  purgeNonMemberOutboxMock,
+  purgePendingOutboxMock,
+  localPartitionMock,
+  pendingRowIdsForPartitionMock,
+  enqueueOutboxMock,
+  forEachGroveMock,
+} = vi.hoisted(() => ({
+  enqueueBatchMock: vi.fn(),
+  listPendingMock: vi.fn(() => []),
+  backfillUnsyncedMock: vi.fn(() => 0),
+  upsertSelfMemberMock: vi.fn(),
+  setTeamSyncEnabledMock: vi.fn(),
+  setProjectSyncMembershipMock: vi.fn(),
+  purgeNonMemberOutboxMock: vi.fn(() => 0),
+  purgePendingOutboxMock: vi.fn(() => 0),
+  localPartitionMock: vi.fn(() => []),
+  pendingRowIdsForPartitionMock: vi.fn(() => new Set<string>()),
+  enqueueOutboxMock: vi.fn(),
+  forEachGroveMock: vi.fn(),
+}));
+
+mock.module('@myco/db/queries/team-outbox.js', () => ({
+  listPending: listPendingMock,
+  markSent: vi.fn(),
+  markSourceRowsSynced: vi.fn(),
+  pruneOld: vi.fn(),
+  backfillUnsynced: backfillUnsyncedMock,
+  backfillAll: vi.fn(),
+  backfillAllForRebuild: vi.fn(),
+  discardRows: vi.fn(),
+  countPending: vi.fn(() => 0),
+  countPendingByTable: vi.fn(() => ({})),
+  purgePendingOutbox: purgePendingOutboxMock,
+  purgeNonMemberOutbox: purgeNonMemberOutboxMock,
+  enqueueOutbox: enqueueOutboxMock,
+  localPartition: localPartitionMock,
+  pendingRowIdsForPartition: pendingRowIdsForPartitionMock,
+  sanitizeSyncPayload: (_table: string, row: object) => row,
+  RECONCILE_ELIGIBLE_TABLES: MOCK_RECONCILE_TABLES,
+}));
+
+mock.module('@myco/db/queries/team-members.js', () => ({
+  upsertSelfMember: upsertSelfMemberMock,
+}));
+
+mock.module('@myco/db/queries/team-sync-state.js', () => ({
+  setTeamSyncEnabled: setTeamSyncEnabledMock,
+  setProjectSyncMembership: setProjectSyncMembershipMock,
+}));
+
+mock.module('@myco/db/client.js', () => ({
+  getDatabase: () => ({
+    transaction: (fn: () => void) => () => fn(),
+  }),
+  withDatabase: <T>(_db: unknown, fn: () => T) => fn(),
+}));
+
+mock.module('@myco/daemon/team-sync.js', () => ({
+  TeamSyncClient: class {
+    rebuild = vi.fn();
+    enqueueBatch = enqueueBatchMock;
+    health = vi.fn();
+    getVersionCompat = vi.fn(() => 'unknown');
+    getWorkerProtocolVersion = vi.fn(() => 3);
+    supportsManifest = vi.fn(() => true);
+    getManifest = vi.fn();
+  },
+}));
+
+// forEachGrove is mocked so the multi-grove fan-out (periodic + on-demand)
+// drives a test-controlled set of grove scopes without opening real SQLite DBs.
+// The body is invoked once per scope, exactly as the real iterator would.
+let groveScopesForMock: Array<{ id: string }> = [];
+mock.module('@myco/daemon/scope-iteration.js', () => ({
+  forEachGrove: forEachGroveMock,
+}));
+
+describe('team-sync reconcile triggers', () => {
+  let tmpDir: string;
+  let vaultDir: string;
+  let previousMycoHome: string | undefined;
+  let prevLegacyHomes: string | undefined;
+
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+
+  // Per-test spy injected as the per-partition reconcile orchestrator.
+  const reconcilePartitionSpy = vi.fn(async () => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    groveScopesForMock = [];
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-reconcile-triggers-'));
+    vaultDir = path.join(tmpDir, '.myco');
+    previousMycoHome = process.env.MYCO_HOME;
+    prevLegacyHomes = process.env.MYCO_TEAM_LEGACY_HOMES;
+    process.env.MYCO_HOME = path.join(tmpDir, 'home');
+    process.env.MYCO_TEAM_HOME = path.join(tmpDir, 'team-home');
+    process.env.MYCO_TEAM_LEGACY_HOMES = '';
+    fs.mkdirSync(vaultDir, { recursive: true });
+    enqueueBatchMock.mockResolvedValue({ accepted: 0, rejected: [] });
+    listPendingMock.mockReturnValue([]);
+    backfillUnsyncedMock.mockReturnValue(0);
+    upsertSelfMemberMock.mockReturnValue({ inserted: false, row: {} });
+    // Default fan-out: replay whatever scopes the test registered.
+    forEachGroveMock.mockImplementation(
+      async (
+        _cache: unknown,
+        _logger: unknown,
+        body: (scope: { grove: { id: string; slug: string }; groveHome: string; databasePath: string; db: object }) => Promise<void>,
+      ) => {
+        for (const g of groveScopesForMock) {
+          await body({ grove: { id: g.id, slug: 'slug' }, groveHome: '', databasePath: '', db: {} });
+        }
+        return { attempted: groveScopesForMock.length, ok: groveScopesForMock.length, failed: 0 };
+      },
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (previousMycoHome === undefined) delete process.env.MYCO_HOME;
+    else process.env.MYCO_HOME = previousMycoHome;
+    delete process.env.MYCO_TEAM_HOME;
+    if (prevLegacyHomes === undefined) delete process.env.MYCO_TEAM_LEGACY_HOMES;
+    else process.env.MYCO_TEAM_LEGACY_HOMES = prevLegacyHomes;
+  });
+
+  /** Register a team owning `projectIds` in a fresh grove; returns the grove + ids. */
+  async function registerGroveWithProjects(name: string, projectIds: string[]) {
+    const { createGrove } = await import('../../packages/myco/src/grove/registry.js');
+    const { createTeamId } = await import('../../packages/myco/src/grove/ids.js');
+    const { teamRegistry } = await import('../../packages/myco/src/team/registry.js');
+    const mycoHome = process.env.MYCO_HOME!;
+    const grove = createGrove(name, mycoHome);
+    const teamId = createTeamId();
+    teamRegistry.save({
+      team_id: teamId,
+      name,
+      worker_url: 'https://team.example.workers.dev',
+      domain: null,
+      mcp_endpoint: null,
+      created_at: new Date().toISOString(),
+      projects: projectIds.map((project_id) => ({ grove_id: grove.id, project_id })),
+    });
+    teamRegistry.writeSecret(teamId, 'MYCO_TEAM_API_KEY', 'routing-secret');
+    return { grove, teamId };
+  }
+
+  function makeTeamSync() {
+    return initTeamSync({
+      liveConfig: {
+        current: { team: { enabled: true, worker_url: 'https://team.example.workers.dev' } },
+      } as never,
+      machineId: 'machine-1',
+      logger: logger as never,
+      vaultDir,
+      serverVersion: '1.2.3',
+      daemonStateDir: path.join(tmpDir, 'service'),
+      reconcilePartitionImpl: reconcilePartitionSpy as never,
+    });
+  }
+
+  function requestContext(groveId: string, projectId: string) {
+    return {
+      projectRoot: tmpDir,
+      projectVaultDir: vaultDir,
+      projectId,
+      groveId,
+      machineId: 'machine-1',
+      sessionId: null,
+      databasePath: path.join(tmpDir, groveId, 'myco.db'),
+      source: 'headers',
+    } as const;
+  }
+
+  /** Distinct args[1] objects passed to the reconcile spy. */
+  function reconcileArgs(): Array<{
+    projectId: string;
+    table: string;
+    operatorConfirmed: boolean;
+    passAggregate: { count: number };
+  }> {
+    return reconcilePartitionSpy.mock.calls.map((c) => (c as unknown[])[1] as never);
+  }
+
+  it('reconcileClient reconciles every owned (grove, project) × eligible table after backfill', async () => {
+    const { grove } = await registerGroveWithProjects('owns-two', ['p-a', 'p-b']);
+    const teamSync = makeTeamSync();
+
+    await teamSync.reconcileClient(requestContext(grove.id, 'p-a'));
+
+    // 2 projects × 2 eligible tables = 4 partition reconciles.
+    expect(reconcilePartitionSpy).toHaveBeenCalledTimes(4);
+    const args = reconcileArgs();
+    expect(new Set(args.map((a) => a.projectId))).toEqual(new Set(['p-a', 'p-b']));
+    expect(new Set(args.map((a) => a.table))).toEqual(new Set(MOCK_RECONCILE_TABLES));
+    // Automatic (re-enable-after-backfill) path is never operator-confirmed.
+    expect(args.every((a) => a.operatorConfirmed === false)).toBe(true);
+    // ONE shared per-pass aggregate threads through every partition.
+    const aggregates = new Set(args.map((a) => a.passAggregate));
+    expect(aggregates.size).toBe(1);
+    // Reconcile runs only after the backfill it follows.
+    expect(backfillUnsyncedMock).toHaveBeenCalled();
+  });
+
+  it('the periodic team-sync-reconcile job runs automatic, threading one shared passAggregate across all partitions', async () => {
+    const a = await registerGroveWithProjects('grove-a', ['p-a']);
+    const b = await registerGroveWithProjects('grove-b', ['p-b']);
+    groveScopesForMock = [{ id: a.grove.id }, { id: b.grove.id }];
+    const teamSync = makeTeamSync();
+
+    const jobs: Array<{ name: string; kind: string; runIn: string[]; fn: (ctx: unknown) => Promise<unknown> }> = [];
+    const runner = { register: (j: (typeof jobs)[number]) => jobs.push(j) } as never;
+    teamSync.registerFlushJob(runner, {} as never);
+
+    const reconcileJob = jobs.find((j) => j.name === 'team-sync-reconcile');
+    expect(reconcileJob).toBeDefined();
+    expect(reconcileJob!.kind).toBe('housekeeping');
+
+    await reconcileJob!.fn({ sliceBudget: { maxItems: 0, softDeadlineMs: 0 } });
+
+    // 2 groves × 1 project × 2 tables = 4 partition reconciles.
+    expect(reconcilePartitionSpy).toHaveBeenCalledTimes(4);
+    const args = reconcileArgs();
+    expect(args.every((a2) => a2.operatorConfirmed === false)).toBe(true);
+    expect(new Set(args.map((a2) => a2.projectId))).toEqual(new Set(['p-a', 'p-b']));
+    // A single accumulator object reaches every partition across BOTH groves so
+    // cross-partition deletes can't sum past the aggregate cap.
+    expect(new Set(args.map((a2) => a2.passAggregate)).size).toBe(1);
+  });
+
+  it('the on-demand entrypoint reconciles operator-confirmed across all groves', async () => {
+    const a = await registerGroveWithProjects('grove-a', ['p-a']);
+    groveScopesForMock = [{ id: a.grove.id }];
+    const teamSync = makeTeamSync();
+
+    await teamSync.reconcileAllGroves({} as never, true);
+
+    expect(reconcilePartitionSpy).toHaveBeenCalledTimes(MOCK_RECONCILE_TABLES.length);
+    const args = reconcileArgs();
+    expect(args.every((a2) => a2.operatorConfirmed === true)).toBe(true);
+    expect(new Set(args.map((a2) => a2.passAggregate)).size).toBe(1);
+  });
+
+  it('does not reconcile a grove with no member projects (not participates / not membershipSeeded)', async () => {
+    // The machine joined a team via ANOTHER grove, so machineHasAnyTeam() is
+    // true, but THIS grove owns no member project — both `participates` and
+    // `membershipSeeded` reduce to an empty member set, so reconcile is skipped.
+    await registerGroveWithProjects('elsewhere', ['p-elsewhere']);
+    const { createGrove } = await import('../../packages/myco/src/grove/registry.js');
+    const hereGrove = createGrove('here', process.env.MYCO_HOME!);
+    const teamSync = makeTeamSync();
+
+    await teamSync.reconcileClient(requestContext(hereGrove.id, 'p-here'));
+
+    expect(reconcilePartitionSpy).not.toHaveBeenCalled();
+    // Backfill still runs (it carries the machine-scoped self-row); reconcile
+    // is the only thing gated off here.
+    expect(backfillUnsyncedMock).toHaveBeenCalled();
+  });
+
+  it('the periodic job skips a grove with no member projects', async () => {
+    const { createGrove } = await import('../../packages/myco/src/grove/registry.js');
+    const empty = createGrove('empty', process.env.MYCO_HOME!);
+    groveScopesForMock = [{ id: empty.id }];
+    const teamSync = makeTeamSync();
+
+    await teamSync.reconcileAllGroves({} as never, false);
+
+    expect(reconcilePartitionSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/daemon/team-reconcile-triggers.test.ts
+++ b/tests/daemon/team-reconcile-triggers.test.ts
@@ -215,6 +215,7 @@ describe('team-sync reconcile triggers', () => {
     table: string;
     operatorConfirmed: boolean;
     passAggregate: { count: number };
+    forceFullDiff: boolean | undefined;
   }> {
     return reconcilePartitionSpy.mock.calls.map((c) => (c as unknown[])[1] as never);
   }
@@ -351,5 +352,33 @@ describe('team-sync reconcile triggers', () => {
     // The flush still ran despite the reconcile failure — listPending is touched
     // only by the flush drain, so its invocation proves flushPending executed.
     expect(listPendingMock).toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // forceFullDiff threading: backstop/operator → true, poll path → false
+  // ---------------------------------------------------------------------------
+
+  it('reconcileAllGroves (backstop/operator) reaches reconcilePartition with forceFullDiff:true', async () => {
+    const a = await registerGroveWithProjects('force-diff-grove', ['p-fd']);
+    groveScopesForMock = [{ id: a.grove.id }];
+    const teamSync = makeTeamSync();
+
+    await teamSync.reconcileAllGroves({} as never, false);
+
+    const args = reconcileArgs();
+    expect(args.length).toBeGreaterThan(0);
+    expect(args.every((a2) => a2.forceFullDiff === true)).toBe(true);
+  });
+
+  it('reconcileClient poll path reaches reconcilePartition with forceFullDiff:false', async () => {
+    const { grove } = await registerGroveWithProjects('poll-path-grove', ['p-pp']);
+    const teamSync = makeTeamSync();
+
+    await teamSync.reconcileClient(requestContext(grove.id, 'p-pp'));
+    await flushAsync();
+
+    const args = reconcileArgs();
+    expect(args.length).toBeGreaterThan(0);
+    expect(args.every((a2) => a2.forceFullDiff === false)).toBe(true);
   });
 });

--- a/tests/daemon/team-reconcile-triggers.test.ts
+++ b/tests/daemon/team-reconcile-triggers.test.ts
@@ -9,6 +9,16 @@ import { initTeamSync } from '@myco/daemon/team-sync-init.js';
 // small set so call counts stay legible (real list is 13 project-scoped tables).
 const MOCK_RECONCILE_TABLES = ['sessions', 'spores'];
 
+/**
+ * Drain the microtask + timer queues so a FIRE-AND-FORGET reconcile pass
+ * (dispatched by reconcileClient via triggerReconcilePass, not awaited) settles
+ * before we assert on its spy. Each partition is one awaited spy call; a couple
+ * of macrotask turns flush them all.
+ */
+async function flushAsync(times = 3): Promise<void> {
+  for (let i = 0; i < times; i++) await new Promise<void>((r) => setTimeout(r, 0));
+}
+
 const {
   enqueueBatchMock,
   listPendingMock,
@@ -124,6 +134,9 @@ describe('team-sync reconcile triggers', () => {
     listPendingMock.mockReturnValue([]);
     backfillUnsyncedMock.mockReturnValue(0);
     upsertSelfMemberMock.mockReturnValue({ inserted: false, row: {} });
+    // clearAllMocks resets call history but NOT implementations, so restore the
+    // default no-op pass here (the throwing-reconcile test overrides it).
+    reconcilePartitionSpy.mockImplementation(async () => {});
     // Default fan-out: replay whatever scopes the test registered.
     forEachGroveMock.mockImplementation(
       async (
@@ -211,6 +224,9 @@ describe('team-sync reconcile triggers', () => {
     const teamSync = makeTeamSync();
 
     await teamSync.reconcileClient(requestContext(grove.id, 'p-a'));
+    // The reconcile pass is dispatched fire-and-forget off the poll path; let it
+    // settle before counting partition reconciles.
+    await flushAsync();
 
     // 2 projects × 2 eligible tables = 4 partition reconciles.
     expect(reconcilePartitionSpy).toHaveBeenCalledTimes(4);
@@ -291,5 +307,49 @@ describe('team-sync reconcile triggers', () => {
     await teamSync.reconcileAllGroves({} as never, false);
 
     expect(reconcilePartitionSpy).not.toHaveBeenCalled();
+  });
+
+  it('throttles repeated reconcileClient passes for one grove but never throttles the operator path', async () => {
+    const { grove } = await registerGroveWithProjects('owns-two', ['p-a', 'p-b']);
+    groveScopesForMock = [{ id: grove.id }];
+    const teamSync = makeTeamSync();
+
+    // Two back-to-back Team-page polls of the same grove, well inside the throttle
+    // window: the first dispatches a reconcile pass, the second is rate-limited.
+    await teamSync.reconcileClient(requestContext(grove.id, 'p-a'));
+    await teamSync.reconcileClient(requestContext(grove.id, 'p-a'));
+    await flushAsync();
+
+    // Exactly ONE automatic pass ran (2 projects × 2 tables = 4), not two.
+    const automatic = reconcileArgs().filter((a) => a.operatorConfirmed === false);
+    expect(automatic.length).toBe(4);
+
+    // The operator path bypasses the throttle entirely: it runs immediately even
+    // though an automatic pass just executed for the same grove.
+    await teamSync.reconcileAllGroves({} as never, true);
+    const operator = reconcileArgs().filter((a) => a.operatorConfirmed === true);
+    expect(operator.length).toBe(4);
+  });
+
+  it('a throwing reconcile pass does not propagate out of reconcileClient and does not break the flush', async () => {
+    reconcilePartitionSpy.mockImplementation(() => {
+      throw new Error('reconcile boom');
+    });
+    const { grove } = await registerGroveWithProjects('owns-one', ['p-a']);
+    const teamSync = makeTeamSync();
+
+    // reconcileClient must RESOLVE (not reject) even though the injected reconcile
+    // partition throws on the fire-and-forget pass.
+    await expect(
+      teamSync.reconcileClient(requestContext(grove.id, 'p-a')),
+    ).resolves.toBeUndefined();
+    await flushAsync();
+
+    // The pass was attempted; its throw was caught + logged, never propagated.
+    expect(reconcilePartitionSpy).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+    // The flush still ran despite the reconcile failure — listPending is touched
+    // only by the flush drain, so its invocation proves flushPending executed.
+    expect(listPendingMock).toHaveBeenCalled();
   });
 });

--- a/tests/daemon/team-reconcile-triggers.test.ts
+++ b/tests/daemon/team-reconcile-triggers.test.ts
@@ -213,8 +213,6 @@ describe('team-sync reconcile triggers', () => {
   function reconcileArgs(): Array<{
     projectId: string;
     table: string;
-    operatorConfirmed: boolean;
-    passAggregate: { count: number };
     forceFullDiff: boolean | undefined;
   }> {
     return reconcilePartitionSpy.mock.calls.map((c) => (c as unknown[])[1] as never);
@@ -234,16 +232,13 @@ describe('team-sync reconcile triggers', () => {
     const args = reconcileArgs();
     expect(new Set(args.map((a) => a.projectId))).toEqual(new Set(['p-a', 'p-b']));
     expect(new Set(args.map((a) => a.table))).toEqual(new Set(MOCK_RECONCILE_TABLES));
-    // Automatic (re-enable-after-backfill) path is never operator-confirmed.
-    expect(args.every((a) => a.operatorConfirmed === false)).toBe(true);
-    // ONE shared per-pass aggregate threads through every partition.
-    const aggregates = new Set(args.map((a) => a.passAggregate));
-    expect(aggregates.size).toBe(1);
+    // Poll path is count-first (cheap), never a forced full diff.
+    expect(args.every((a) => a.forceFullDiff === false)).toBe(true);
     // Reconcile runs only after the backfill it follows.
     expect(backfillUnsyncedMock).toHaveBeenCalled();
   });
 
-  it('the periodic team-sync-reconcile job runs automatic, threading one shared passAggregate across all partitions', async () => {
+  it('the periodic team-sync-reconcile job runs the automatic full-diff reconcile across all groves', async () => {
     const a = await registerGroveWithProjects('grove-a', ['p-a']);
     const b = await registerGroveWithProjects('grove-b', ['p-b']);
     groveScopesForMock = [{ id: a.grove.id }, { id: b.grove.id }];
@@ -262,24 +257,22 @@ describe('team-sync reconcile triggers', () => {
     // 2 groves × 1 project × 2 tables = 4 partition reconciles.
     expect(reconcilePartitionSpy).toHaveBeenCalledTimes(4);
     const args = reconcileArgs();
-    expect(args.every((a2) => a2.operatorConfirmed === false)).toBe(true);
     expect(new Set(args.map((a2) => a2.projectId))).toEqual(new Set(['p-a', 'p-b']));
-    // A single accumulator object reaches every partition across BOTH groves so
-    // cross-partition deletes can't sum past the aggregate cap.
-    expect(new Set(args.map((a2) => a2.passAggregate)).size).toBe(1);
+    // The backstop always forces a full diff to catch equal-count / different-set
+    // drift the poll path misses.
+    expect(args.every((a2) => a2.forceFullDiff === true)).toBe(true);
   });
 
-  it('the on-demand entrypoint reconciles operator-confirmed across all groves', async () => {
+  it('the on-demand entrypoint reconciles automatically across all groves', async () => {
     const a = await registerGroveWithProjects('grove-a', ['p-a']);
     groveScopesForMock = [{ id: a.grove.id }];
     const teamSync = makeTeamSync();
 
-    await teamSync.reconcileAllGroves({} as never, true);
+    await teamSync.reconcileAllGroves({} as never);
 
     expect(reconcilePartitionSpy).toHaveBeenCalledTimes(MOCK_RECONCILE_TABLES.length);
     const args = reconcileArgs();
-    expect(args.every((a2) => a2.operatorConfirmed === true)).toBe(true);
-    expect(new Set(args.map((a2) => a2.passAggregate)).size).toBe(1);
+    expect(args.every((a2) => a2.forceFullDiff === true)).toBe(true);
   });
 
   it('does not reconcile a grove with no member projects (not participates / not membershipSeeded)', async () => {
@@ -305,12 +298,12 @@ describe('team-sync reconcile triggers', () => {
     groveScopesForMock = [{ id: empty.id }];
     const teamSync = makeTeamSync();
 
-    await teamSync.reconcileAllGroves({} as never, false);
+    await teamSync.reconcileAllGroves({} as never);
 
     expect(reconcilePartitionSpy).not.toHaveBeenCalled();
   });
 
-  it('throttles repeated reconcileClient passes for one grove but never throttles the operator path', async () => {
+  it('throttles repeated reconcileClient passes for one grove but never throttles the on-demand path', async () => {
     const { grove } = await registerGroveWithProjects('owns-two', ['p-a', 'p-b']);
     groveScopesForMock = [{ id: grove.id }];
     const teamSync = makeTeamSync();
@@ -321,15 +314,15 @@ describe('team-sync reconcile triggers', () => {
     await teamSync.reconcileClient(requestContext(grove.id, 'p-a'));
     await flushAsync();
 
-    // Exactly ONE automatic pass ran (2 projects × 2 tables = 4), not two.
-    const automatic = reconcileArgs().filter((a) => a.operatorConfirmed === false);
-    expect(automatic.length).toBe(4);
+    // Exactly ONE poll-path pass ran (count-first; 2 projects × 2 tables = 4), not two.
+    const pollPath = reconcileArgs().filter((a) => a.forceFullDiff === false);
+    expect(pollPath.length).toBe(4);
 
-    // The operator path bypasses the throttle entirely: it runs immediately even
-    // though an automatic pass just executed for the same grove.
-    await teamSync.reconcileAllGroves({} as never, true);
-    const operator = reconcileArgs().filter((a) => a.operatorConfirmed === true);
-    expect(operator.length).toBe(4);
+    // The on-demand path bypasses the throttle entirely: it runs immediately even
+    // though a poll-path pass just executed for the same grove. It full-diffs.
+    await teamSync.reconcileAllGroves({} as never);
+    const onDemand = reconcileArgs().filter((a) => a.forceFullDiff === true);
+    expect(onDemand.length).toBe(4);
   });
 
   it('a throwing reconcile pass does not propagate out of reconcileClient and does not break the flush', async () => {
@@ -358,12 +351,12 @@ describe('team-sync reconcile triggers', () => {
   // forceFullDiff threading: backstop/operator → true, poll path → false
   // ---------------------------------------------------------------------------
 
-  it('reconcileAllGroves (backstop/operator) reaches reconcilePartition with forceFullDiff:true', async () => {
+  it('reconcileAllGroves (backstop/on-demand) reaches reconcilePartition with forceFullDiff:true', async () => {
     const a = await registerGroveWithProjects('force-diff-grove', ['p-fd']);
     groveScopesForMock = [{ id: a.grove.id }];
     const teamSync = makeTeamSync();
 
-    await teamSync.reconcileAllGroves({} as never, false);
+    await teamSync.reconcileAllGroves({} as never);
 
     const args = reconcileArgs();
     expect(args.length).toBeGreaterThan(0);

--- a/tests/daemon/team-sync-init.test.ts
+++ b/tests/daemon/team-sync-init.test.ts
@@ -566,6 +566,9 @@ describe('initTeamSync.reconcileClient', () => {
     // Registry read failed — enabled must be left unchanged (NOT set to false).
     expect(setTeamSyncEnabledMock).not.toHaveBeenCalledWith(false);
     expect(setTeamSyncEnabledMock).not.toHaveBeenCalledWith(true);
+    // Pending self-rows (machine-scoped outbox entries) must NOT be purged —
+    // the machine may belong to a team that we couldn't observe.
+    expect(purgePendingOutboxMock).not.toHaveBeenCalled();
   });
 
   it('sets enabled=false when the registry is readable but has no members for this grove (confirmed empty)', async () => {
@@ -587,6 +590,8 @@ describe('initTeamSync.reconcileClient', () => {
 
     // Registry readable + genuinely empty → confirmed non-member → disabled.
     expect(setTeamSyncEnabledMock).toHaveBeenCalledWith(false);
+    // Confirmed-empty read IS a valid reason to purge pending self-rows.
+    expect(purgePendingOutboxMock).toHaveBeenCalled();
   });
 
   function writeTeamConfig(enabled: boolean): void {

--- a/tests/daemon/team-sync-init.test.ts
+++ b/tests/daemon/team-sync-init.test.ts
@@ -543,6 +543,52 @@ describe('initTeamSync.reconcileClient', () => {
     expect(backfillUnsyncedMock).toHaveBeenCalled();
   });
 
+  it('does not set enabled=false when the team registry dir is unreadable (readdirSync throws)', async () => {
+    // Plant a regular file at the teams/ path so readdirSync throws ENOTDIR.
+    // This simulates a transient/mid-migration state where the directory
+    // cannot be read — the result is indeterminate, not confirmed-empty.
+    const teamsDir = path.join(process.env.MYCO_TEAM_HOME!, 'teams');
+    fs.mkdirSync(path.dirname(teamsDir), { recursive: true });
+    fs.writeFileSync(teamsDir, 'not-a-dir');
+
+    const { createGrove } = await import('../../packages/myco/src/grove/registry.js');
+    const grove = createGrove('resilience-unreadable', process.env.MYCO_HOME!);
+    const teamSync = initTeamSync({
+      liveConfig: { current: { team: { enabled: false, worker_url: undefined } } } as never,
+      machineId: 'machine-1',
+      logger: logger as never,
+      vaultDir,
+      serverVersion: '1.2.3',
+    });
+
+    await teamSync.reconcileClient(requestContext(grove.id, 'proj-unreadable'));
+
+    // Registry read failed — enabled must be left unchanged (NOT set to false).
+    expect(setTeamSyncEnabledMock).not.toHaveBeenCalledWith(false);
+    expect(setTeamSyncEnabledMock).not.toHaveBeenCalledWith(true);
+  });
+
+  it('sets enabled=false when the registry is readable but has no members for this grove (confirmed empty)', async () => {
+    // Empty teams/ dir — successfully read but genuinely no members.
+    const teamsDir = path.join(process.env.MYCO_TEAM_HOME!, 'teams');
+    fs.mkdirSync(teamsDir, { recursive: true });
+
+    const { createGrove } = await import('../../packages/myco/src/grove/registry.js');
+    const grove = createGrove('confirmed-empty', process.env.MYCO_HOME!);
+    const teamSync = initTeamSync({
+      liveConfig: { current: { team: { enabled: false, worker_url: undefined } } } as never,
+      machineId: 'machine-1',
+      logger: logger as never,
+      vaultDir,
+      serverVersion: '1.2.3',
+    });
+
+    await teamSync.reconcileClient(requestContext(grove.id, 'proj-no-team'));
+
+    // Registry readable + genuinely empty → confirmed non-member → disabled.
+    expect(setTeamSyncEnabledMock).toHaveBeenCalledWith(false);
+  });
+
   function writeTeamConfig(enabled: boolean): void {
     fs.writeFileSync(path.join(vaultDir, 'myco.yaml'), [
       'version: 3',

--- a/tests/daemon/team-sync-manifest-client.test.ts
+++ b/tests/daemon/team-sync-manifest-client.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Tests for TeamSyncClient.getManifest() and supportsManifest().
+ */
+
+import { describe, it, expect, mock } from 'bun:test';
+import { vi } from '../helpers/vi-shim.js';
+import { TeamSyncClient } from '@myco/daemon/team-sync.js';
+
+// ---------------------------------------------------------------------------
+// Mock getMachineId so tests are environment-independent.
+// ---------------------------------------------------------------------------
+
+mock.module('@myco/machine-id.js', () => ({
+  getMachineId: () => 'test_machine_abc',
+}));
+
+// ---------------------------------------------------------------------------
+// Mock fetch helper
+// ---------------------------------------------------------------------------
+
+function createMockFetch(responses: Record<string, { status: number; body: unknown }>) {
+  return vi.fn(async (url: string | URL | Request, _init?: RequestInit) => {
+    const urlStr = typeof url === 'string' ? url : url.toString();
+    const path = new URL(urlStr).pathname;
+
+    const response = responses[path];
+    if (!response) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    return new Response(JSON.stringify(response.body), {
+      status: response.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as unknown as typeof globalThis.fetch;
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const baseOptions = {
+  workerUrl: 'https://myco-team.example.workers.dev',
+  apiKey: 'test-api-key-123',
+  machineId: 'test_abc123',
+  syncProtocolVersion: 2,
+};
+
+const SUMMARY_BODY = {
+  table: 'spores',
+  machine_id: 'test_abc123',
+  count: 5,
+  cheap_agg: 42,
+};
+
+const PAGED_BODY = {
+  table: 'sessions',
+  machine_id: 'test_abc123',
+  count: 3,
+  cheap_agg: 100,
+  items: [
+    { id: 'sess-001', project_id: 'proj_aaa', content_hash: 'abc123' },
+    { id: 'sess-002', project_id: 'proj_aaa', content_hash: 'def456' },
+    { id: 'sess-003', project_id: 'proj_bbb' },
+  ],
+  next_cursor: 'cursor-xyz',
+};
+
+// ---------------------------------------------------------------------------
+// getManifest — path and query-string construction
+// ---------------------------------------------------------------------------
+
+describe('TeamSyncClient.getManifest', () => {
+  describe('summary mode (summary=1)', () => {
+    it('builds /manifest with machine_id, table, and summary=1', async () => {
+      const mockFetch = createMockFetch({
+        '/manifest': { status: 200, body: SUMMARY_BODY },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      const result = await client.getManifest('test_abc123', 'spores', { summary: true });
+
+      expect(result.table).toBe('spores');
+      expect(result.machine_id).toBe('test_abc123');
+      expect(result.count).toBe(5);
+      expect(result.cheap_agg).toBe(42);
+      expect('items' in result).toBe(false);
+
+      const calledUrl = (mockFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('/manifest');
+      expect(calledUrl).toContain('machine_id=test_abc123');
+      expect(calledUrl).toContain('table=spores');
+      expect(calledUrl).toContain('summary=1');
+    });
+
+    it('includes projectId in the query string when provided', async () => {
+      const mockFetch = createMockFetch({
+        '/manifest': { status: 200, body: { ...SUMMARY_BODY, project_id: 'proj_aaa' } },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      await client.getManifest('test_abc123', 'spores', {
+        summary: true,
+        projectId: 'proj_aaa',
+      });
+
+      const calledUrl = (mockFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('project_id=proj_aaa');
+      expect(calledUrl).toContain('summary=1');
+    });
+
+    it('omits projectId from the query string when not provided', async () => {
+      const mockFetch = createMockFetch({
+        '/manifest': { status: 200, body: SUMMARY_BODY },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      await client.getManifest('test_abc123', 'spores', { summary: true });
+
+      const calledUrl = (mockFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).not.toContain('project_id=');
+    });
+  });
+
+  describe('paged mode (default)', () => {
+    it('builds /manifest with machine_id and table only (no summary param)', async () => {
+      const mockFetch = createMockFetch({
+        '/manifest': { status: 200, body: PAGED_BODY },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      const result = await client.getManifest('test_abc123', 'sessions', {});
+
+      expect(result.table).toBe('sessions');
+      expect(result.machine_id).toBe('test_abc123');
+      expect(result.count).toBe(3);
+      expect(result.cheap_agg).toBe(100);
+      expect(result.items).toHaveLength(3);
+      expect(result.next_cursor).toBe('cursor-xyz');
+
+      const calledUrl = (mockFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('machine_id=test_abc123');
+      expect(calledUrl).toContain('table=sessions');
+      expect(calledUrl).not.toContain('summary=');
+    });
+
+    it('includes cursor and limit when provided', async () => {
+      const mockFetch = createMockFetch({
+        '/manifest': {
+          status: 200,
+          body: { ...PAGED_BODY, items: [], next_cursor: undefined },
+        },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      await client.getManifest('test_abc123', 'sessions', {
+        cursor: 'cursor-xyz',
+        limit: 50,
+      });
+
+      const calledUrl = (mockFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('cursor=cursor-xyz');
+      expect(calledUrl).toContain('limit=50');
+    });
+
+    it('omits cursor and limit from the query string when not provided', async () => {
+      const mockFetch = createMockFetch({
+        '/manifest': { status: 200, body: PAGED_BODY },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      await client.getManifest('test_abc123', 'sessions', {});
+
+      const calledUrl = (mockFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).not.toContain('cursor=');
+      expect(calledUrl).not.toContain('limit=');
+    });
+
+    it('includes all optional params together', async () => {
+      const mockFetch = createMockFetch({
+        '/manifest': { status: 200, body: PAGED_BODY },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      await client.getManifest('test_abc123', 'sessions', {
+        projectId: 'proj_aaa',
+        cursor: 'cursor-abc',
+        limit: 100,
+      });
+
+      const calledUrl = (mockFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('project_id=proj_aaa');
+      expect(calledUrl).toContain('cursor=cursor-abc');
+      expect(calledUrl).toContain('limit=100');
+      expect(calledUrl).not.toContain('summary=');
+    });
+
+    it('returns parsed items with optional content_hash', async () => {
+      const mockFetch = createMockFetch({
+        '/manifest': { status: 200, body: PAGED_BODY },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      const result = await client.getManifest('test_abc123', 'sessions', {});
+
+      // items[0] and [1] have content_hash; items[2] does not
+      expect(result.items?.[0]?.content_hash).toBe('abc123');
+      expect(result.items?.[1]?.content_hash).toBe('def456');
+      expect(result.items?.[2]?.content_hash).toBeUndefined();
+    });
+  });
+
+  describe('HTTP method', () => {
+    it('issues a GET request', async () => {
+      const mockFetch = createMockFetch({
+        '/manifest': { status: 200, body: SUMMARY_BODY },
+      });
+
+      const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+      await client.getManifest('test_abc123', 'spores', { summary: true });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ method: 'GET' }),
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// supportsManifest — feature detect
+// ---------------------------------------------------------------------------
+
+describe('TeamSyncClient.supportsManifest', () => {
+  it('returns false when worker protocol version has not been probed (undefined)', () => {
+    const client = new TeamSyncClient({ ...baseOptions });
+    expect(client.getWorkerProtocolVersion()).toBeUndefined();
+    expect(client.supportsManifest()).toBe(false);
+  });
+
+  it('returns false when worker protocol version is below 3', async () => {
+    const mockFetch = createMockFetch({
+      '/health': {
+        status: 200,
+        body: { status: 'ok', node_count: 1, sync_protocol_version: 2 },
+      },
+    });
+
+    const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+    await client.health();
+
+    expect(client.getWorkerProtocolVersion()).toBe(2);
+    expect(client.supportsManifest()).toBe(false);
+  });
+
+  it('returns false when worker protocol version is 1', async () => {
+    const mockFetch = createMockFetch({
+      '/health': {
+        status: 200,
+        body: { status: 'ok', node_count: 1, sync_protocol_version: 1 },
+      },
+    });
+
+    const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+    await client.health();
+
+    expect(client.supportsManifest()).toBe(false);
+  });
+
+  it('returns true when worker protocol version is exactly 3', async () => {
+    const mockFetch = createMockFetch({
+      '/health': {
+        status: 200,
+        body: { status: 'ok', node_count: 1, sync_protocol_version: 3 },
+      },
+    });
+
+    const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+    await client.health();
+
+    expect(client.getWorkerProtocolVersion()).toBe(3);
+    expect(client.supportsManifest()).toBe(true);
+  });
+
+  it('returns true when worker protocol version is above 3', async () => {
+    const mockFetch = createMockFetch({
+      '/health': {
+        status: 200,
+        body: { status: 'ok', node_count: 1, sync_protocol_version: 4 },
+      },
+    });
+
+    const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+    await client.health();
+
+    expect(client.supportsManifest()).toBe(true);
+  });
+
+  it('returns true when version is populated via connect (not health)', async () => {
+    const mockFetch = createMockFetch({
+      '/connect': {
+        status: 200,
+        body: { config: {}, sync_protocol_version: 3 },
+      },
+    });
+
+    const client = new TeamSyncClient({ ...baseOptions, fetch: mockFetch });
+    await client.connect({ machine_id: 'test_abc123' });
+
+    expect(client.supportsManifest()).toBe(true);
+  });
+});

--- a/tests/daemon/team-sync-manifest-client.test.ts
+++ b/tests/daemon/team-sync-manifest-client.test.ts
@@ -50,14 +50,12 @@ const SUMMARY_BODY = {
   table: 'spores',
   machine_id: 'test_abc123',
   count: 5,
-  cheap_agg: 42,
 };
 
 const PAGED_BODY = {
   table: 'sessions',
   machine_id: 'test_abc123',
   count: 3,
-  cheap_agg: 100,
   items: [
     { id: 'sess-001', project_id: 'proj_aaa', content_hash: 'abc123' },
     { id: 'sess-002', project_id: 'proj_aaa', content_hash: 'def456' },
@@ -83,7 +81,6 @@ describe('TeamSyncClient.getManifest', () => {
       expect(result.table).toBe('spores');
       expect(result.machine_id).toBe('test_abc123');
       expect(result.count).toBe(5);
-      expect(result.cheap_agg).toBe(42);
       expect('items' in result).toBe(false);
 
       const calledUrl = (mockFetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
@@ -134,7 +131,6 @@ describe('TeamSyncClient.getManifest', () => {
       expect(result.table).toBe('sessions');
       expect(result.machine_id).toBe('test_abc123');
       expect(result.count).toBe(3);
-      expect(result.cheap_agg).toBe(100);
       expect(result.items).toHaveLength(3);
       expect(result.next_cursor).toBe('cursor-xyz');
 

--- a/tests/db/migrate-v63-delete-trigger.test.ts
+++ b/tests/db/migrate-v63-delete-trigger.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { createSchema, SCHEMA_VERSION } from '@myco/db/schema.js';
+import { TEAM_DELETE_TRIGGER_TABLES } from '@myco/db/schema-ddl.js';
+
+/**
+ * v62 -> v63 drops the volatile `team_sync_state.enabled` gate from the
+ * per-table delete triggers, re-gating them on the stable `team_sync_membership`
+ * projection alone so a paused/transition window can never silently lose a
+ * member project's delete tombstone (decision-893ef22a).
+ */
+
+function triggerSql(db: Database, name: string): string {
+  const row = db
+    .prepare(`SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = ?`)
+    .get(name) as { sql: string } | undefined;
+  return row?.sql ?? '';
+}
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim();
+}
+
+/** Rebuild the pre-v63 (v62) trigger shape: enabled AND membership gated. */
+function installV62Trigger(db: Database, table: string): void {
+  db.exec(`DROP TRIGGER IF EXISTS ${table}_team_ad`);
+  db.exec(`
+    CREATE TRIGGER ${table}_team_ad
+    AFTER DELETE ON ${table}
+    WHEN (SELECT enabled FROM team_sync_state) = 1
+      AND OLD.project_id IN (SELECT project_id FROM team_sync_membership)
+    BEGIN
+      INSERT INTO team_outbox (table_name, row_id, operation, payload, machine_id, project_id, created_at)
+      VALUES ('${table}', CAST(OLD.id AS TEXT), 'delete',
+              json_object('id', OLD.id, 'machine_id', OLD.machine_id),
+              OLD.machine_id, OLD.project_id, CAST(strftime('%s','now') AS INTEGER));
+    END`);
+}
+
+describe('migrate v62 -> v63: drop the enabled gate from delete triggers', () => {
+  it('SCHEMA_VERSION includes this migration', () => {
+    expect(SCHEMA_VERSION).toBeGreaterThanOrEqual(63);
+  });
+
+  it('a fresh vault installs membership-only triggers (no enabled gate)', () => {
+    const db = new Database(':memory:');
+    createSchema(db, 'local');
+    for (const table of TEAM_DELETE_TRIGGER_TABLES) {
+      const sql = triggerSql(db, `${table}_team_ad`);
+      expect(sql).toContain('OLD.project_id IN (SELECT project_id FROM team_sync_membership)');
+      expect(sql).not.toContain('team_sync_state');
+    }
+  });
+
+  it('an existing v62 vault is migrated: triggers lose the enabled gate and converge on the fresh shape', () => {
+    const fresh = new Database(':memory:');
+    createSchema(fresh, 'local');
+
+    const db = new Database(':memory:');
+    createSchema(db, 'local');
+    // Roll the vault back to the v62 shape: old-gate triggers + stamp 62.
+    for (const table of TEAM_DELETE_TRIGGER_TABLES) installV62Trigger(db, table);
+    db.exec('DELETE FROM schema_version');
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (62, 0)').run();
+
+    createSchema(db, 'local');
+
+    const stamped = (db.prepare('SELECT MAX(version) AS v FROM schema_version').get() as { v: number }).v;
+    expect(stamped).toBe(SCHEMA_VERSION);
+
+    for (const table of TEAM_DELETE_TRIGGER_TABLES) {
+      const migrated = triggerSql(db, `${table}_team_ad`);
+      expect(migrated).not.toContain('team_sync_state'); // enabled gate gone
+      expect(migrated).toContain('OLD.project_id IN (SELECT project_id FROM team_sync_membership)');
+      // Fresh-install DDL and the migrated trigger must be identical.
+      expect(normalize(migrated)).toBe(normalize(triggerSql(fresh, `${table}_team_ad`)));
+    }
+  });
+
+  it('a member delete journals with enabled = 0 after migration', () => {
+    const db = new Database(':memory:');
+    db.exec('PRAGMA foreign_keys = OFF');
+    createSchema(db, 'local');
+    for (const table of TEAM_DELETE_TRIGGER_TABLES) installV62Trigger(db, table);
+    db.exec('DELETE FROM schema_version');
+    db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (62, 0)').run();
+    createSchema(db, 'local');
+
+    // enabled stays 0; only membership marks the project as a participant.
+    db.prepare(
+      `INSERT INTO team_sync_state (rowid_guard, enabled) VALUES (1, 0)
+       ON CONFLICT (rowid_guard) DO UPDATE SET enabled = 0`,
+    ).run();
+    db.prepare(`INSERT OR IGNORE INTO team_sync_membership (project_id) VALUES ('proj_x')`).run();
+    db.prepare(
+      `INSERT INTO spores (id, project_id, agent_id, observation_type, status, content, created_at, machine_id)
+       VALUES ('sp_mig', 'proj_x', 'user', 'decision', 'active', 'c', 1, 'local')`,
+    ).run();
+    db.prepare(`DELETE FROM spores WHERE id = 'sp_mig'`).run();
+
+    const n = (db.prepare(
+      `SELECT COUNT(*) AS n FROM team_outbox WHERE table_name='spores' AND operation='delete'`,
+    ).get() as { n: number }).n;
+    expect(n).toBe(1);
+  });
+
+  it('is idempotent: re-running createSchema leaves the trigger unchanged', () => {
+    const db = new Database(':memory:');
+    createSchema(db, 'local');
+    const before = TEAM_DELETE_TRIGGER_TABLES.map((t) => triggerSql(db, `${t}_team_ad`));
+    createSchema(db, 'local');
+    createSchema(db, 'local');
+    const after = TEAM_DELETE_TRIGGER_TABLES.map((t) => triggerSql(db, `${t}_team_ad`));
+    expect(after).toEqual(before);
+    const stamped = (db.prepare('SELECT MAX(version) AS v FROM schema_version').get() as { v: number }).v;
+    expect(stamped).toBe(SCHEMA_VERSION);
+  });
+});

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -48,7 +48,7 @@ describe('Database schema', () => {
 
   describe('constants', () => {
     it('exports SCHEMA_VERSION as a positive integer', () => {
-      expect(SCHEMA_VERSION).toBe(62);
+      expect(SCHEMA_VERSION).toBe(63);
       expect(Number.isInteger(SCHEMA_VERSION)).toBe(true);
     });
 

--- a/tests/db/team-delete-triggers.test.ts
+++ b/tests/db/team-delete-triggers.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { createSchema } from '@myco/db/schema.js';
-import { setTeamSyncEnabled } from '@myco/db/queries/team-sync-state.js';
+import { setTeamSyncEnabled, setProjectSyncMembership } from '@myco/db/queries/team-sync-state.js';
+import { listPending, purgeNonMemberOutbox } from '@myco/db/queries/team-outbox.js';
 import { setupTestDb, teardownTestDb, cleanTestDb } from '../helpers/db.js';
-import { getDatabase } from '@myco/db/client.js';
+import { getDatabase, withDatabase } from '@myco/db/client.js';
 import { deleteSessionCascade } from '@myco/db/queries/sessions.js';
 import { SESSION_TOMBSTONE_SOURCE } from '@myco/db/queries/session-tombstones.js';
 import { TEAM_SYNC_OBSERVED_TABLES } from '@myco/db/queries/team-outbox.js';
@@ -55,6 +56,26 @@ describe('team delete triggers', () => {
     expect(JSON.parse(rows[0].payload as string)).toEqual({ id: 'sp1', machine_id: 'local' });
   });
 
+  it('journals a member-project delete even when team_sync_state.enabled = 0 (transient-pause regression)', () => {
+    // Membership is the stable participation signal; `enabled` is the volatile
+    // auto-derived flag that transiently flips to 0 (e.g. the ~/.myco-team
+    // home-move window). A delete during that window must still tombstone, or
+    // it leaves no local trace and becomes a permanent D1 orphan.
+    const db = newDb();
+    setTeamSyncEnabled(false, db);
+    markProjectMember(db, 'proj_x');
+    db.prepare(
+      `INSERT INTO spores (id, project_id, agent_id, observation_type, status, content, created_at, machine_id)
+       VALUES ('sp_paused', 'proj_x', 'user', 'decision', 'active', 'c', 1, 'local')`,
+    ).run();
+    db.prepare(`DELETE FROM spores WHERE id = 'sp_paused'`).run();
+    const rows = db.prepare(
+      `SELECT row_id FROM team_outbox WHERE table_name = 'spores' AND operation = 'delete'`,
+    ).all() as Array<{ row_id: string }>;
+    expect(rows.length).toBe(1);
+    expect(rows[0].row_id).toBe('sp_paused');
+  });
+
   it('an INTEGER-PK delete journals row_id as the decimal string of the id', () => {
     const db = newDb();
     setTeamSyncEnabled(true, db);
@@ -71,8 +92,11 @@ describe('team delete triggers', () => {
     expect(JSON.parse(row.payload).id).toBe(101);
   });
 
-  it('deletes do NOT journal when sync is disabled (default)', () => {
+  it('deletes do NOT journal for a non-member project (even with sync enabled)', () => {
     const db = newDb();
+    setTeamSyncEnabled(true, db);
+    // proj_x is NOT a member — the membership gate must suppress the tombstone
+    // so never-team data cannot accumulate unbounded in the outbox.
     db.prepare(
       `INSERT INTO spores (id, project_id, agent_id, observation_type, status, content, created_at, machine_id)
        VALUES ('sp2', 'proj_x', 'user', 'decision', 'active', 'c', 1, 'local')`,
@@ -181,14 +205,17 @@ describe('structural guard: every synced table has a delete trigger', () => {
   });
 });
 
-describe('write gate is per-Grove (no singleton bleed)', () => {
-  it('enabled in Grove A, disabled in Grove B → deletes journal only in A', () => {
+describe('membership gate is per-Grove and independent of the enabled flag', () => {
+  it('member in Grove A (enabled off) journals; non-member in Grove B (enabled on) does not', () => {
     const a = newDb();
     const b = newDb();
-    setTeamSyncEnabled(true, a);
-    setTeamSyncEnabled(false, b);
+    // enabled is set OPPOSITE to each Grove's membership to prove the trigger
+    // follows stable membership, not the volatile flag (no singleton bleed:
+    // membership lives in each Grove's own DB).
+    setTeamSyncEnabled(false, a); // member, but flag transiently off
+    setTeamSyncEnabled(true, b);  // non-member, but flag on
     markProjectMember(a, 'proj_x');
-    markProjectMember(b, 'proj_x');
+    // Grove B intentionally has no membership row.
 
     for (const [db, id] of [[a, 'spA'], [b, 'spB']] as const) {
       db.prepare(
@@ -200,7 +227,61 @@ describe('write gate is per-Grove (no singleton bleed)', () => {
 
     const aDeletes = a.prepare(`SELECT COUNT(*) AS n FROM team_outbox WHERE operation='delete'`).get() as { n: number };
     const bDeletes = b.prepare(`SELECT COUNT(*) AS n FROM team_outbox WHERE operation='delete'`).get() as { n: number };
-    expect(aDeletes.n).toBe(1);
-    expect(bDeletes.n).toBe(0);
+    expect(aDeletes.n).toBe(1); // member journals despite enabled = 0
+    expect(bDeletes.n).toBe(0); // non-member suppressed despite enabled = 1
+  });
+});
+
+describe('captured member tombstones are push-eligible; non-member rows never accumulate', () => {
+  it('a member delete captured while enabled = 0 is pending and project-routed (the flush will push it)', () => {
+    withDatabase(newDb(), () => {
+      const db = getDatabase();
+      setTeamSyncEnabled(false, db);
+      setProjectSyncMembership(['proj_x'], db);
+      db.prepare(
+        `INSERT INTO spores (id, project_id, agent_id, observation_type, status, content, created_at, machine_id)
+         VALUES ('sp_push', 'proj_x', 'user', 'decision', 'active', 'c', 1, 'local')`,
+      ).run();
+      db.prepare(`DELETE FROM spores WHERE id = 'sp_push'`).run();
+
+      // The drain (initTeamSync) selects pending rows via listPending and routes
+      // them by project_id; a tombstone that is pending with the member's
+      // project_id is exactly what the flush pushes.
+      const pending = listPending().filter((r) => r.operation === 'delete' && r.table_name === 'spores');
+      expect(pending.length).toBe(1);
+      expect(pending[0].row_id).toBe('sp_push');
+      expect(pending[0].project_id).toBe('proj_x');
+      expect(pending[0].sent_at).toBeNull();
+    });
+  });
+
+  it('a non-member delete is never captured, and historical non-member tombstones are swept', () => {
+    withDatabase(newDb(), () => {
+      const db = getDatabase();
+      setTeamSyncEnabled(true, db);
+      setProjectSyncMembership(['proj_member'], db);
+
+      // Live non-member delete → trigger suppressed, nothing to push or prune.
+      db.prepare(
+        `INSERT INTO spores (id, project_id, agent_id, observation_type, status, content, created_at, machine_id)
+         VALUES ('sp_out', 'proj_outsider', 'user', 'decision', 'active', 'c', 1, 'local')`,
+      ).run();
+      db.prepare(`DELETE FROM spores WHERE id = 'sp_out'`).run();
+      expect(
+        (db.prepare(`SELECT COUNT(*) AS n FROM team_outbox WHERE operation='delete'`).get() as { n: number }).n,
+      ).toBe(0);
+
+      // A historical non-member tombstone (enqueued before the gate existed) is
+      // pruned by the sweep so it cannot accumulate unbounded.
+      db.prepare(
+        `INSERT INTO team_outbox (table_name, row_id, operation, payload, machine_id, project_id, created_at)
+         VALUES ('spores', 'legacy_out', 'delete', '{"id":"legacy_out"}', 'local', 'proj_outsider', 1)`,
+      ).run();
+      const removed = purgeNonMemberOutbox(['proj_member']);
+      expect(removed).toBe(1);
+      expect(
+        (db.prepare(`SELECT COUNT(*) AS n FROM team_outbox`).get() as { n: number }).n,
+      ).toBe(0);
+    });
   });
 });

--- a/tests/db/team-outbox-pending-partition.test.ts
+++ b/tests/db/team-outbox-pending-partition.test.ts
@@ -1,0 +1,264 @@
+/**
+ * DB-backed tests for localPartition and pendingRowIdsForPartition.
+ *
+ * Covers:
+ *   - pendingRowIdsForPartition returns only sent_at IS NULL row_ids for the
+ *     exact (table, machine_id, project_id) partition.
+ *   - pendingRowIdsForPartition excludes rows from other partitions and sent rows.
+ *   - localPartition returns the partition's rows with id (and content_hash for
+ *     content-hash tables, absent for presence-only tables).
+ *   - SF4: localPartition for skill_usage does NOT reference synced_at
+ *     (verified both by SQL inspection and by a live fixture that would throw
+ *     if the column were queried on the columnless table).
+ */
+
+import { describe, expect, it, beforeAll, beforeEach, afterAll } from 'bun:test';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db.js';
+import { getDatabase } from '@myco/db/client.js';
+import {
+  localPartition,
+  pendingRowIdsForPartition,
+} from '@myco/db/queries/team-outbox.js';
+
+beforeAll(() => { setupTestDb(); });
+afterAll(() => { teardownTestDb(); });
+beforeEach(() => { cleanTestDb(); });
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Insert a minimal agent row needed by FK-constrained tables. */
+function seedAgent(db: ReturnType<typeof getDatabase>, id = 'agent-1'): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO agents (id, name, source, enabled, created_at)
+     VALUES (?, 'test-agent', 'built-in', 1, 1)`,
+  ).run(id);
+}
+
+/** Insert a minimal session row (needed by skill_usage FK). */
+function seedSession(
+  db: ReturnType<typeof getDatabase>,
+  id: string,
+  machineId: string,
+  projectId: string,
+): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO sessions (id, agent, project_id, machine_id, created_at, started_at, status)
+     VALUES (?, 'claude', ?, ?, 1, 1, 'closed')`,
+  ).run(id, projectId, machineId);
+}
+
+/** Insert a minimal skill_record row (needed by skill_usage FK). */
+function seedSkillRecord(
+  db: ReturnType<typeof getDatabase>,
+  id: string,
+  machineId: string,
+  projectId: string,
+): void {
+  seedAgent(db);
+  db.prepare(
+    `INSERT OR IGNORE INTO skill_records
+       (id, project_id, agent_id, machine_id, name, display_name, description, path, created_at, updated_at)
+     VALUES (?, ?, 'agent-1', ?, 'test-skill', 'Test Skill', 'desc', '/fake', 1, 1)`,
+  ).run(id, projectId, machineId);
+}
+
+/** Insert a skill_usage row (has id+machine_id+project_id but no synced_at). */
+function seedSkillUsage(
+  db: ReturnType<typeof getDatabase>,
+  opts: { id: string; machineId: string; projectId: string; skillId: string; sessionId: string },
+): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO skill_usage (id, project_id, skill_id, session_id, machine_id, detected_at)
+     VALUES (?, ?, ?, ?, ?, 1)`,
+  ).run(opts.id, opts.projectId, opts.skillId, opts.sessionId, opts.machineId);
+}
+
+/** Insert a spore row (has content_hash + synced_at). */
+function seedSpore(
+  db: ReturnType<typeof getDatabase>,
+  opts: { id: string; machineId: string; projectId: string; contentHash?: string },
+): void {
+  seedAgent(db);
+  db.prepare(
+    `INSERT OR IGNORE INTO spores
+       (id, project_id, agent_id, observation_type, content, created_at, machine_id, content_hash)
+     VALUES (?, ?, 'agent-1', 'decision', 'x', 1, ?, ?)`,
+  ).run(opts.id, opts.projectId, opts.machineId, opts.contentHash ?? null);
+}
+
+/** Insert a raw team_outbox row. */
+function seedOutboxRow(
+  db: ReturnType<typeof getDatabase>,
+  opts: {
+    tableName: string;
+    rowId: string;
+    machineId: string;
+    projectId: string;
+    sentAt?: number | null;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO team_outbox (table_name, row_id, operation, payload, machine_id, project_id, created_at, sent_at)
+     VALUES (?, ?, 'upsert', '{}', ?, ?, 1, ?)`,
+  ).run(opts.tableName, opts.rowId, opts.machineId, opts.projectId, opts.sentAt ?? null);
+}
+
+// ---------------------------------------------------------------------------
+// pendingRowIdsForPartition
+// ---------------------------------------------------------------------------
+
+describe('pendingRowIdsForPartition', () => {
+  it('returns only sent_at IS NULL row_ids for the exact (table, machine_id, project_id)', () => {
+    const db = getDatabase();
+
+    // Pending rows for the target partition.
+    seedOutboxRow(db, { tableName: 'spores', rowId: 'row-1', machineId: 'mA', projectId: 'pA' });
+    seedOutboxRow(db, { tableName: 'spores', rowId: 'row-2', machineId: 'mA', projectId: 'pA' });
+    // Sent row for the same partition — must be excluded.
+    seedOutboxRow(db, { tableName: 'spores', rowId: 'row-sent', machineId: 'mA', projectId: 'pA', sentAt: 99 });
+
+    const result = pendingRowIdsForPartition('spores', 'mA', 'pA');
+
+    expect(result).toBeInstanceOf(Set);
+    expect(result.size).toBe(2);
+    expect(result.has('row-1')).toBe(true);
+    expect(result.has('row-2')).toBe(true);
+    expect(result.has('row-sent')).toBe(false);
+  });
+
+  it('excludes rows from a different machine_id', () => {
+    const db = getDatabase();
+
+    seedOutboxRow(db, { tableName: 'spores', rowId: 'row-A', machineId: 'mA', projectId: 'pA' });
+    seedOutboxRow(db, { tableName: 'spores', rowId: 'row-B', machineId: 'mB', projectId: 'pA' });
+
+    const result = pendingRowIdsForPartition('spores', 'mA', 'pA');
+    expect(result.has('row-A')).toBe(true);
+    expect(result.has('row-B')).toBe(false);
+  });
+
+  it('excludes rows from a different project_id', () => {
+    const db = getDatabase();
+
+    seedOutboxRow(db, { tableName: 'spores', rowId: 'row-pA', machineId: 'mA', projectId: 'pA' });
+    seedOutboxRow(db, { tableName: 'spores', rowId: 'row-pB', machineId: 'mA', projectId: 'pB' });
+
+    const result = pendingRowIdsForPartition('spores', 'mA', 'pA');
+    expect(result.has('row-pA')).toBe(true);
+    expect(result.has('row-pB')).toBe(false);
+  });
+
+  it('excludes rows for a different table_name', () => {
+    const db = getDatabase();
+
+    seedOutboxRow(db, { tableName: 'spores', rowId: 'row-spore', machineId: 'mA', projectId: 'pA' });
+    seedOutboxRow(db, { tableName: 'plans', rowId: 'row-plan', machineId: 'mA', projectId: 'pA' });
+
+    const result = pendingRowIdsForPartition('spores', 'mA', 'pA');
+    expect(result.has('row-spore')).toBe(true);
+    expect(result.has('row-plan')).toBe(false);
+  });
+
+  it('returns an empty Set when the partition has no pending rows', () => {
+    const result = pendingRowIdsForPartition('spores', 'mA', 'pA');
+    expect(result.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// localPartition — content-hash table (spores)
+// ---------------------------------------------------------------------------
+
+describe('localPartition — spores (content_hash table)', () => {
+  it('returns rows for the exact (machineId, projectId) partition', () => {
+    const db = getDatabase();
+
+    seedSpore(db, { id: 'sp-1', machineId: 'mA', projectId: 'pA', contentHash: 'hash-1' });
+    seedSpore(db, { id: 'sp-2', machineId: 'mA', projectId: 'pA', contentHash: 'hash-2' });
+    // Different partition — must not appear.
+    seedSpore(db, { id: 'sp-other', machineId: 'mB', projectId: 'pA' });
+
+    const rows = localPartition('mA', 'pA', 'spores');
+
+    expect(rows.length).toBe(2);
+    const ids = rows.map((r) => r.id).sort();
+    expect(ids).toEqual(['sp-1', 'sp-2']);
+  });
+
+  it('includes content_hash when present on the row', () => {
+    const db = getDatabase();
+    seedSpore(db, { id: 'sp-hash', machineId: 'mA', projectId: 'pA', contentHash: 'abc123' });
+
+    const rows = localPartition('mA', 'pA', 'spores');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content_hash).toBe('abc123');
+  });
+
+  it('omits content_hash property when the row has no hash (NULL)', () => {
+    const db = getDatabase();
+    // Insert spore without a content_hash (NULL stored).
+    seedSpore(db, { id: 'sp-no-hash', machineId: 'mA', projectId: 'pA' });
+
+    const rows = localPartition('mA', 'pA', 'spores');
+    expect(rows).toHaveLength(1);
+    // content_hash should be absent (undefined) on the returned object.
+    expect(rows[0].content_hash).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// localPartition — presence-only table (skill_usage) — SF4
+// ---------------------------------------------------------------------------
+
+describe('localPartition — skill_usage (no synced_at, presence-only) — SF4', () => {
+  it('returns rows without content_hash for skill_usage', () => {
+    const db = getDatabase();
+    seedSession(db, 'sess-1', 'mA', 'pA');
+    seedSkillRecord(db, 'skill-1', 'mA', 'pA');
+    seedSkillUsage(db, { id: 'su-1', machineId: 'mA', projectId: 'pA', skillId: 'skill-1', sessionId: 'sess-1' });
+
+    const rows = localPartition('mA', 'pA', 'skill_usage');
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe('su-1');
+    // skill_usage has no content_hash column → property must be absent.
+    expect(rows[0].content_hash).toBeUndefined();
+  });
+
+  it('SF4: localPartition for skill_usage does not reference synced_at', () => {
+    // skill_usage has no synced_at column. If localPartition generated SQL
+    // that referenced synced_at, SQLite would throw "no such column".
+    // Seeding a real row and calling localPartition is the live assertion.
+    const db = getDatabase();
+    seedSession(db, 'sess-sf4', 'mA', 'pA');
+    seedSkillRecord(db, 'skill-sf4', 'mA', 'pA');
+    seedSkillUsage(db, {
+      id: 'su-sf4',
+      machineId: 'mA',
+      projectId: 'pA',
+      skillId: 'skill-sf4',
+      sessionId: 'sess-sf4',
+    });
+
+    // This call must not throw.
+    expect(() => localPartition('mA', 'pA', 'skill_usage')).not.toThrow();
+    const rows = localPartition('mA', 'pA', 'skill_usage');
+    expect(rows).toHaveLength(1);
+  });
+
+  it('excludes skill_usage rows from other partitions', () => {
+    const db = getDatabase();
+    seedSession(db, 'sess-2', 'mA', 'pA');
+    seedSession(db, 'sess-3', 'mB', 'pB');
+    seedSkillRecord(db, 'skill-2', 'mA', 'pA');
+    seedSkillRecord(db, 'skill-3', 'mB', 'pB');
+    seedSkillUsage(db, { id: 'su-pA', machineId: 'mA', projectId: 'pA', skillId: 'skill-2', sessionId: 'sess-2' });
+    seedSkillUsage(db, { id: 'su-pB', machineId: 'mB', projectId: 'pB', skillId: 'skill-3', sessionId: 'sess-3' });
+
+    const rows = localPartition('mA', 'pA', 'skill_usage');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe('su-pA');
+  });
+});

--- a/tests/grove/project-tenancy.test.ts
+++ b/tests/grove/project-tenancy.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import {
   assertAssignableProject,
   machineHasAnyTeam,
+  machineHasAnyTeamResolved,
   memberProjectIdsForGrove,
   ProjectGroveMissingError,
   resolveProjectTenancy,
@@ -133,6 +134,32 @@ describe('project tenancy authority', () => {
     expect(machineHasAnyTeam()).toBe(false);
     saveTeam([]);
     expect(machineHasAnyTeam()).toBe(true);
+  });
+
+  it('memberProjectIdsForGrove returns resolved:false when the teams dir is unreadable', () => {
+    // Plant a regular file at the teams/ path so readdirSync throws ENOTDIR.
+    const teamsDir = path.join(process.env.MYCO_TEAM_HOME!, 'teams');
+    fs.mkdirSync(path.dirname(teamsDir), { recursive: true });
+    fs.writeFileSync(teamsDir, 'not-a-dir');
+    const grove = createGrove('G-unreadable', home);
+    expect(memberProjectIdsForGrove(grove.id)).toEqual({ resolved: false });
+  });
+
+  it('machineHasAnyTeamResolved returns resolved:false when the teams dir is unreadable', () => {
+    const teamsDir = path.join(process.env.MYCO_TEAM_HOME!, 'teams');
+    fs.mkdirSync(path.dirname(teamsDir), { recursive: true });
+    fs.writeFileSync(teamsDir, 'not-a-dir');
+    expect(machineHasAnyTeamResolved()).toEqual({ resolved: false });
+  });
+
+  it('machineHasAnyTeamResolved returns resolved:true with hasTeam false when no teams exist', () => {
+    // teams/ dir absent — confirmed no teams
+    expect(machineHasAnyTeamResolved()).toEqual({ resolved: true, hasTeam: false });
+  });
+
+  it('machineHasAnyTeamResolved returns resolved:true with hasTeam true when a team is registered', () => {
+    saveTeam([]);
+    expect(machineHasAnyTeamResolved()).toEqual({ resolved: true, hasTeam: true });
   });
 
   it('assertAssignableProject accepts a grove-bound project and rejects a grove-less one', () => {

--- a/tests/grove/project-tenancy.test.ts
+++ b/tests/grove/project-tenancy.test.ts
@@ -120,11 +120,13 @@ describe('project tenancy authority', () => {
       { grove_id: otherGrove.id, project_id: 'P-other' },
     ]);
 
-    expect(new Set(memberProjectIdsForGrove(grove.id))).toEqual(new Set(['P']));
-    // A grove with no team-member projects returns [].
+    const res = memberProjectIdsForGrove(grove.id);
+    expect(res.resolved).toBe(true);
+    expect(new Set((res as { resolved: true; projectIds: string[] }).projectIds)).toEqual(new Set(['P']));
+    // A grove with no team-member projects returns confirmed-empty.
     const emptyGrove = createGrove('Empty', home);
-    expect(memberProjectIdsForGrove(emptyGrove.id)).toEqual([]);
-    expect(memberProjectIdsForGrove(null)).toEqual([]);
+    expect(memberProjectIdsForGrove(emptyGrove.id)).toEqual({ resolved: true, projectIds: [] });
+    expect(memberProjectIdsForGrove(null)).toEqual({ resolved: true, projectIds: [] });
   });
 
   it('machineHasAnyTeam reflects whether any team is registered', () => {

--- a/tests/worker/manifest.test.ts
+++ b/tests/worker/manifest.test.ts
@@ -1,0 +1,602 @@
+/**
+ * Tests for GET /manifest — content-addressed drift reconcile endpoint.
+ *
+ * Verifies:
+ *   - summary=1 returns { count, cheap_agg } scoped to (machine_id, [project_id])
+ *   - paged results are ordered by id with correct next_cursor
+ *   - content_hash present only on the 4 content-hash tables
+ *   - WORKER_CONTENT_HASH_TABLES parity: every member has content_hash in schema DDL
+ *   - scoping excludes the other machine AND (when project_id given) the other project
+ *   - invalid / ineligible tables are rejected 400
+ *   - a v2 client still passes /connect against a v3 worker (200, not 409)
+ *
+ * Uses the same bun:test + fake-D1 pattern as tests/worker/schema.test.ts.
+ * The manifest handler lives in its own dependency-free module so it can be
+ * imported here without pulling in cloudflare:email via index.ts.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  WORKER_CONTENT_HASH_TABLES,
+  MANIFEST_ELIGIBLE_TABLES,
+  parseManifestParams,
+  queryManifest,
+  type ManifestDb,
+  type ManifestItem,
+} from '@myco-team-worker/manifest';
+import { SYNCED_TABLES } from '@myco-team-worker/synced-tables';
+
+// ---------------------------------------------------------------------------
+// Schema DDL source — read to verify WORKER_CONTENT_HASH_TABLES parity
+// ---------------------------------------------------------------------------
+// We import the raw schema DDL strings directly so the parity assertion
+// checks the REAL schema rather than a prose description.
+
+// Inline the column patterns we expect. The parity assertion below
+// reads the actual SCHEMA_MODULE source file to verify each member of
+// WORKER_CONTENT_HASH_TABLES has `content_hash` in its DDL, and that
+// no other synced table has one.
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCHEMA_PATH = path.resolve(__dirname, '../../packages/myco-team/worker/src/schema.ts');
+const schemaSrc = fs.readFileSync(SCHEMA_PATH, 'utf8');
+
+// ---------------------------------------------------------------------------
+// Fixture data: 2 machines × 2 projects × a few rows per table
+// ---------------------------------------------------------------------------
+
+const MACHINE_A = 'machine-aaa';
+const MACHINE_B = 'machine-bbb';
+const PROJECT_1 = 'proj_0000000000000000000000000000001a';
+const PROJECT_2 = 'proj_0000000000000000000000000000002b';
+
+interface FakeRow {
+  id: string;
+  machine_id: string;
+  project_id: string | null;
+  content_hash?: string | null;
+  rowid?: number;
+}
+
+// Seed rows for the 'sessions' table (has content_hash).
+const SESSIONS_ROWS: FakeRow[] = [
+  { id: 'sess-a1', machine_id: MACHINE_A, project_id: PROJECT_1, content_hash: 'hash-a1', rowid: 1 },
+  { id: 'sess-a2', machine_id: MACHINE_A, project_id: PROJECT_1, content_hash: 'hash-a2', rowid: 2 },
+  { id: 'sess-a3', machine_id: MACHINE_A, project_id: PROJECT_2, content_hash: 'hash-a3', rowid: 3 },
+  { id: 'sess-b1', machine_id: MACHINE_B, project_id: PROJECT_1, content_hash: 'hash-b1', rowid: 4 },
+];
+
+// Seed rows for the 'entities' table (no content_hash).
+const ENTITIES_ROWS: FakeRow[] = [
+  { id: 'ent-a1', machine_id: MACHINE_A, project_id: PROJECT_1, rowid: 1 },
+  { id: 'ent-a2', machine_id: MACHINE_A, project_id: PROJECT_2, rowid: 2 },
+  { id: 'ent-b1', machine_id: MACHINE_B, project_id: PROJECT_1, rowid: 3 },
+];
+
+// ---------------------------------------------------------------------------
+// Fake D1 implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal fake D1 that parses the SQL the manifest handler issues and
+ * answers from in-memory fixture rows. Supports the two query shapes:
+ *
+ *   SELECT COUNT(*) AS count, MAX(rowid) AS cheap_agg FROM <table>
+ *     WHERE machine_id = ? [AND project_id = ?]
+ *
+ *   SELECT id, project_id[, content_hash] FROM <table>
+ *     WHERE machine_id = ? [AND project_id = ?] AND id > ? ORDER BY id LIMIT ?
+ */
+function createFakeD1(tableData: Record<string, FakeRow[]>): ManifestDb {
+  return {
+    prepare(sql: string) {
+      let boundValues: unknown[] = [];
+      return {
+        bind(...values: unknown[]) {
+          boundValues = [...values];
+          return this;
+        },
+        async first<T>(): Promise<T | null> {
+          const tableMatch = sql.match(/FROM\s+(\w+)/i);
+          const table = tableMatch?.[1] ?? '';
+          const rows = tableData[table] ?? [];
+
+          // Parse WHERE clause bindings.
+          // Summary: SELECT COUNT(*), MAX(rowid) FROM t WHERE machine_id=? [AND project_id=?]
+          const [machineId, maybeProjectId] = boundValues as string[];
+          const filtered = rows.filter((r) => {
+            if (r.machine_id !== machineId) return false;
+            if (maybeProjectId !== undefined && r.project_id !== maybeProjectId) return false;
+            return true;
+          });
+
+          const count = filtered.length;
+          const maxRowid = filtered.length > 0
+            ? Math.max(...filtered.map((r) => r.rowid ?? 0))
+            : 0;
+
+          return { count, cheap_agg: maxRowid } as T;
+        },
+        async all<T>(): Promise<{ results: T[] }> {
+          const tableMatch = sql.match(/FROM\s+(\w+)/i);
+          const table = tableMatch?.[1] ?? '';
+          const rows = tableData[table] ?? [];
+
+          const hasProjectIdFilter = /AND project_id = \?/.test(sql);
+          const hasContentHash = sql.includes('content_hash');
+
+          // Binding order for paged query:
+          //   With project_id:    machine_id, project_id, cursor_id, limit
+          //   Without project_id: machine_id, cursor_id, limit
+          let machineId: string;
+          let projectId: string | null = null;
+          let cursorId: string;
+          let limit: number;
+
+          if (hasProjectIdFilter) {
+            [machineId, projectId, cursorId, limit] = boundValues as [string, string, string, number];
+          } else {
+            [machineId, cursorId, limit] = boundValues as [string, string, number];
+          }
+
+          const filtered = rows
+            .filter((r) => {
+              if (r.machine_id !== machineId) return false;
+              if (projectId !== null && r.project_id !== projectId) return false;
+              if (String(r.id) <= String(cursorId)) return false;
+              return true;
+            })
+            .sort((a, b) => String(a.id).localeCompare(String(b.id)));
+
+          const paged = filtered.slice(0, limit);
+
+          const items = paged.map((r): ManifestItem => {
+            const item: ManifestItem = {
+              id: r.id,
+              project_id: r.project_id,
+              ...(hasContentHash ? { content_hash: r.content_hash ?? null } : {}),
+            };
+            return item;
+          });
+
+          return { results: items as T[] };
+        },
+      };
+    },
+  };
+}
+
+const fakeDb = createFakeD1({
+  sessions: SESSIONS_ROWS,
+  entities: ENTITIES_ROWS,
+});
+
+// ---------------------------------------------------------------------------
+// Parity assertion: WORKER_CONTENT_HASH_TABLES vs schema.ts
+// ---------------------------------------------------------------------------
+
+describe('WORKER_CONTENT_HASH_TABLES parity with schema.ts', () => {
+  it('every member of WORKER_CONTENT_HASH_TABLES has content_hash in its schema DDL', () => {
+    // Each table in WORKER_CONTENT_HASH_TABLES should appear as a const block
+    // in schema.ts that includes "content_hash TEXT".
+    for (const table of WORKER_CONTENT_HASH_TABLES) {
+      // Find the CREATE TABLE block for this table in the schema source.
+      // Blocks are delimited by "CREATE TABLE IF NOT EXISTS <table>" and end
+      // before the next "CREATE TABLE IF NOT EXISTS" or end of string.
+      const blockPattern = new RegExp(
+        `CREATE TABLE IF NOT EXISTS ${table}[\\s\\S]*?(?=CREATE TABLE IF NOT EXISTS|$)`,
+        'i',
+      );
+      const match = schemaSrc.match(blockPattern);
+      expect(
+        match,
+        `Schema source must contain a CREATE TABLE block for ${table}`,
+      ).not.toBeNull();
+
+      expect(
+        match![0].includes('content_hash'),
+        `${table} must have content_hash in its DDL (WORKER_CONTENT_HASH_TABLES member)`,
+      ).toBe(true);
+    }
+  });
+
+  it('no synced table outside WORKER_CONTENT_HASH_TABLES has content_hash in its schema DDL', () => {
+    for (const table of SYNCED_TABLES) {
+      if (WORKER_CONTENT_HASH_TABLES.has(table)) continue;
+
+      const blockPattern = new RegExp(
+        `CREATE TABLE IF NOT EXISTS ${table}[\\s\\S]*?(?=CREATE TABLE IF NOT EXISTS|$)`,
+        'i',
+      );
+      const match = schemaSrc.match(blockPattern);
+      if (!match) continue; // table may not have its own CREATE TABLE block
+
+      expect(
+        match[0].includes('content_hash'),
+        `${table} must NOT have content_hash in its DDL (not in WORKER_CONTENT_HASH_TABLES)`,
+      ).toBe(false);
+    }
+  });
+
+  it('WORKER_CONTENT_HASH_TABLES is a subset of MANIFEST_ELIGIBLE_TABLES', () => {
+    for (const table of WORKER_CONTENT_HASH_TABLES) {
+      expect(
+        MANIFEST_ELIGIBLE_TABLES.has(table),
+        `${table} is in WORKER_CONTENT_HASH_TABLES but not in MANIFEST_ELIGIBLE_TABLES`,
+      ).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MANIFEST_ELIGIBLE_TABLES
+// ---------------------------------------------------------------------------
+
+describe('MANIFEST_ELIGIBLE_TABLES', () => {
+  it('excludes entity_mentions (no single id column)', () => {
+    expect(MANIFEST_ELIGIBLE_TABLES.has('entity_mentions')).toBe(false);
+  });
+
+  it('includes all other synced tables', () => {
+    const expected = new Set(SYNCED_TABLES.filter((t) => t !== 'entity_mentions'));
+    expect(MANIFEST_ELIGIBLE_TABLES).toEqual(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseManifestParams
+// ---------------------------------------------------------------------------
+
+describe('parseManifestParams', () => {
+  it('rejects missing machine_id', () => {
+    const result = parseManifestParams(new URL('https://example.com/manifest?table=sessions'));
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.status).toBe(400);
+      expect(result.error).toMatch(/machine_id/);
+    }
+  });
+
+  it('rejects missing table', () => {
+    const result = parseManifestParams(new URL('https://example.com/manifest?machine_id=m1'));
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.status).toBe(400);
+      expect(result.error).toMatch(/table/);
+    }
+  });
+
+  it('rejects ineligible table (entity_mentions)', () => {
+    const result = parseManifestParams(
+      new URL('https://example.com/manifest?machine_id=m1&table=entity_mentions'),
+    );
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.status).toBe(400);
+    }
+  });
+
+  it('rejects unknown table', () => {
+    const result = parseManifestParams(
+      new URL('https://example.com/manifest?machine_id=m1&table=nonexistent'),
+    );
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.status).toBe(400);
+    }
+  });
+
+  it('parses summary=1 correctly', () => {
+    const result = parseManifestParams(
+      new URL('https://example.com/manifest?machine_id=m1&table=sessions&summary=1'),
+    );
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.summary).toBe(true);
+    }
+  });
+
+  it('defaults summary to false when absent', () => {
+    const result = parseManifestParams(
+      new URL('https://example.com/manifest?machine_id=m1&table=sessions'),
+    );
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.summary).toBe(false);
+    }
+  });
+
+  it('caps limit at MAX_LIMIT=1000', () => {
+    const result = parseManifestParams(
+      new URL('https://example.com/manifest?machine_id=m1&table=sessions&limit=9999'),
+    );
+    expect('error' in result).toBe(false);
+    if (!('error' in result)) {
+      expect(result.limit).toBe(1000);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// summary=1 scoping
+// ---------------------------------------------------------------------------
+
+describe('GET /manifest?summary=1 — scoping', () => {
+  it('returns count and cheap_agg scoped to machine_id only (no project_id)', async () => {
+    const params = {
+      machineId: MACHINE_A,
+      table: 'sessions',
+      projectId: null,
+      cursor: null,
+      limit: 200,
+      summary: true,
+    };
+    const result = await queryManifest(fakeDb, params);
+
+    // MACHINE_A has 3 sessions total (sess-a1, sess-a2, sess-a3)
+    expect(result.count).toBe(3);
+    expect(result.machine_id).toBe(MACHINE_A);
+    expect('project_id' in result).toBe(false);
+    // cheap_agg is MAX(rowid) for MACHINE_A rows: max rowid = 3
+    expect(result.cheap_agg).toBe(3);
+  });
+
+  it('excludes the other machine from the count', async () => {
+    const paramsA = {
+      machineId: MACHINE_A, table: 'sessions',
+      projectId: null, cursor: null, limit: 200, summary: true,
+    };
+    const paramsB = {
+      machineId: MACHINE_B, table: 'sessions',
+      projectId: null, cursor: null, limit: 200, summary: true,
+    };
+
+    const resultA = await queryManifest(fakeDb, paramsA);
+    const resultB = await queryManifest(fakeDb, paramsB);
+
+    expect(resultA.count).toBe(3); // MACHINE_A: 3 sessions
+    expect(resultB.count).toBe(1); // MACHINE_B: 1 session
+    expect(resultA.count + resultB.count).toBe(SESSIONS_ROWS.length);
+  });
+
+  it('scopes to (machine_id, project_id) when project_id is given', async () => {
+    const params = {
+      machineId: MACHINE_A,
+      table: 'sessions',
+      projectId: PROJECT_1,
+      cursor: null,
+      limit: 200,
+      summary: true,
+    };
+    const result = await queryManifest(fakeDb, params);
+
+    // MACHINE_A + PROJECT_1: sess-a1, sess-a2
+    expect(result.count).toBe(2);
+    expect(result.project_id).toBe(PROJECT_1);
+    // cheap_agg = MAX(rowid) for sess-a1 (rowid=1) and sess-a2 (rowid=2) = 2
+    expect(result.cheap_agg).toBe(2);
+  });
+
+  it('excludes the other project when project_id is given', async () => {
+    const p1 = {
+      machineId: MACHINE_A, table: 'sessions', projectId: PROJECT_1,
+      cursor: null, limit: 200, summary: true,
+    };
+    const p2 = {
+      machineId: MACHINE_A, table: 'sessions', projectId: PROJECT_2,
+      cursor: null, limit: 200, summary: true,
+    };
+
+    const r1 = await queryManifest(fakeDb, p1);
+    const r2 = await queryManifest(fakeDb, p2);
+
+    expect(r1.count).toBe(2); // sess-a1, sess-a2
+    expect(r2.count).toBe(1); // sess-a3
+  });
+
+  it('returns cheap_agg=0 when no rows match', async () => {
+    const params = {
+      machineId: 'machine-unknown', table: 'sessions',
+      projectId: null, cursor: null, limit: 200, summary: true,
+    };
+    const result = await queryManifest(fakeDb, params);
+    expect(result.count).toBe(0);
+    expect(result.cheap_agg).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Paged results — ordering and next_cursor
+// ---------------------------------------------------------------------------
+
+describe('GET /manifest paged — ordering and next_cursor', () => {
+  it('returns items ordered by id for machine_id-only scope', async () => {
+    const params = {
+      machineId: MACHINE_A, table: 'sessions',
+      projectId: null, cursor: null, limit: 200, summary: false,
+    };
+    const result = await queryManifest(fakeDb, params);
+
+    expect('items' in result).toBe(true);
+    if (!('items' in result)) return;
+
+    const ids = result.items.map((r) => r.id);
+    expect(ids).toEqual([...ids].sort());
+  });
+
+  it('paginates correctly: next_cursor present when more rows exist', async () => {
+    // MACHINE_A has 3 sessions. Limit=2 should return 2 and a next_cursor.
+    const params = {
+      machineId: MACHINE_A, table: 'sessions',
+      projectId: null, cursor: null, limit: 2, summary: false,
+    };
+    const result = await queryManifest(fakeDb, params);
+
+    expect('items' in result).toBe(true);
+    if (!('items' in result)) return;
+
+    expect(result.items.length).toBe(2);
+    expect(result.next_cursor).toBeDefined();
+    // The cursor is the last item's id.
+    expect(result.next_cursor).toBe(result.items[result.items.length - 1].id);
+  });
+
+  it('fetches the next page using the cursor', async () => {
+    const page1 = await queryManifest(fakeDb, {
+      machineId: MACHINE_A, table: 'sessions',
+      projectId: null, cursor: null, limit: 2, summary: false,
+    });
+    expect('next_cursor' in page1).toBe(true);
+    if (!('next_cursor' in page1) || !page1.next_cursor) return;
+
+    const page2 = await queryManifest(fakeDb, {
+      machineId: MACHINE_A, table: 'sessions',
+      projectId: null, cursor: page1.next_cursor, limit: 2, summary: false,
+    });
+    expect('items' in page2).toBe(true);
+    if (!('items' in page2)) return;
+
+    // The combined ids from both pages should equal all MACHINE_A session ids.
+    const p1ids = (page1 as { items: ManifestItem[] }).items.map((r) => r.id);
+    const p2ids = page2.items.map((r) => r.id);
+    const allIds = [...p1ids, ...p2ids].sort();
+    const expectedIds = SESSIONS_ROWS
+      .filter((r) => r.machine_id === MACHINE_A)
+      .map((r) => r.id)
+      .sort();
+    expect(allIds).toEqual(expectedIds);
+    // Last page has no cursor.
+    expect(page2.next_cursor).toBeUndefined();
+  });
+
+  it('no next_cursor when all rows fit in one page', async () => {
+    const params = {
+      machineId: MACHINE_A, table: 'sessions',
+      projectId: null, cursor: null, limit: 200, summary: false,
+    };
+    const result = await queryManifest(fakeDb, params);
+    expect('next_cursor' in result && result.next_cursor).toBeFalsy();
+  });
+
+  it('scopes paged results to (machine_id, project_id) when project_id is given', async () => {
+    const params = {
+      machineId: MACHINE_A, table: 'sessions',
+      projectId: PROJECT_1, cursor: null, limit: 200, summary: false,
+    };
+    const result = await queryManifest(fakeDb, params);
+
+    expect('items' in result).toBe(true);
+    if (!('items' in result)) return;
+
+    // Only sess-a1 and sess-a2 belong to MACHINE_A + PROJECT_1.
+    expect(result.items.length).toBe(2);
+    expect(result.items.every((r) => r.project_id === PROJECT_1)).toBe(true);
+    // sess-a3 (PROJECT_2) must not appear.
+    expect(result.items.find((r) => r.id === 'sess-a3')).toBeUndefined();
+  });
+
+  it('excludes the other machine from paged results', async () => {
+    const params = {
+      machineId: MACHINE_A, table: 'sessions',
+      projectId: null, cursor: null, limit: 200, summary: false,
+    };
+    const result = await queryManifest(fakeDb, params);
+
+    expect('items' in result).toBe(true);
+    if (!('items' in result)) return;
+
+    expect(result.items.every((r) => {
+      // We verify by checking that the id matches known MACHINE_A rows.
+      return SESSIONS_ROWS.some((sr) => sr.id === r.id && sr.machine_id === MACHINE_A);
+    })).toBe(true);
+    // sess-b1 (MACHINE_B) must not appear.
+    expect(result.items.find((r) => r.id === 'sess-b1')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// content_hash presence
+// ---------------------------------------------------------------------------
+
+describe('content_hash field on paged results', () => {
+  it('includes content_hash for sessions (a content-hash table)', async () => {
+    const params = {
+      machineId: MACHINE_A, table: 'sessions',
+      projectId: null, cursor: null, limit: 200, summary: false,
+    };
+    const result = await queryManifest(fakeDb, params);
+
+    expect('items' in result).toBe(true);
+    if (!('items' in result)) return;
+
+    expect(result.items.length).toBeGreaterThan(0);
+    for (const item of result.items) {
+      expect('content_hash' in item).toBe(true);
+    }
+  });
+
+  it('omits content_hash for entities (not a content-hash table)', async () => {
+    const params = {
+      machineId: MACHINE_A, table: 'entities',
+      projectId: null, cursor: null, limit: 200, summary: false,
+    };
+    const result = await queryManifest(fakeDb, params);
+
+    expect('items' in result).toBe(true);
+    if (!('items' in result)) return;
+
+    expect(result.items.length).toBeGreaterThan(0);
+    for (const item of result.items) {
+      expect('content_hash' in item).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// v2 client still passes /connect against the v3 worker
+// ---------------------------------------------------------------------------
+// This assertion verifies the protocol compat window [minClientVersion=1,
+// serverVersion=3]. A v2 client is inside [1, 3] and must get 200.
+// We test parseManifestParams and the protocol logic directly since we
+// can't import index.ts (cloudflare:email). The actual protocol-version
+// window logic lives in resolveProtocolBounds which reads env vars; we
+// test the invariant by checking the wrangler.toml values instead.
+
+describe('protocol version: v2 client still accepted by v3 worker', () => {
+  it('SYNC_PROTOCOL_VERSION in wrangler.toml is "3"', () => {
+    const wranglerPath = path.resolve(
+      __dirname,
+      '../../packages/myco-team/worker/wrangler.toml',
+    );
+    const wranglerSrc = fs.readFileSync(wranglerPath, 'utf8');
+    const match = wranglerSrc.match(/SYNC_PROTOCOL_VERSION\s*=\s*"(\d+)"/);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe('3');
+  });
+
+  it('MIN_COMPAT_CLIENT_VERSION in wrangler.toml is "1"', () => {
+    const wranglerPath = path.resolve(
+      __dirname,
+      '../../packages/myco-team/worker/wrangler.toml',
+    );
+    const wranglerSrc = fs.readFileSync(wranglerPath, 'utf8');
+    const match = wranglerSrc.match(/MIN_COMPAT_CLIENT_VERSION\s*=\s*"(\d+)"/);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe('1');
+  });
+
+  it('a v2 client is inside the window [MIN_COMPAT=1, SERVER=3]', () => {
+    // The connect handler accepts clients in [minClientVersion, serverVersion].
+    // With MIN_COMPAT_CLIENT_VERSION="1" and SYNC_PROTOCOL_VERSION="3",
+    // a v2 client satisfies: 2 >= 1 AND 2 <= 3 → accepted (200).
+    const minClient = 1;
+    const serverVersion = 3;
+    const clientVersion = 2; // v2 client
+
+    const accepted = clientVersion >= minClient && clientVersion <= serverVersion;
+    expect(accepted).toBe(true);
+  });
+});

--- a/tests/worker/manifest.test.ts
+++ b/tests/worker/manifest.test.ts
@@ -55,7 +55,11 @@ const PROJECT_1 = 'proj_0000000000000000000000000000001a';
 const PROJECT_2 = 'proj_0000000000000000000000000000002b';
 
 interface FakeRow {
-  id: string;
+  // `id` is `string | number` so the fake can model BOTH text-id tables
+  // (sessions: TEXT id) and integer-id tables (prompt_batches: INTEGER id).
+  // D1 returns INTEGER id columns as JS numbers, so integer-id fixtures store
+  // numbers here — the regression the integer-id tests below pin down.
+  id: string | number;
   machine_id: string;
   project_id: string | null;
   content_hash?: string | null;
@@ -77,6 +81,60 @@ const ENTITIES_ROWS: FakeRow[] = [
   { id: 'ent-b1', machine_id: MACHINE_B, project_id: PROJECT_1, rowid: 3 },
 ];
 
+// Seed rows for the 'prompt_batches' table — INTEGER id, has content_hash.
+// MACHINE_A + PROJECT_1: ids 101, 102, 103 (3 rows) for multi-page coverage.
+const PROMPT_BATCHES_ROWS: FakeRow[] = [
+  { id: 101, machine_id: MACHINE_A, project_id: PROJECT_1, content_hash: 'pb-101', rowid: 1 },
+  { id: 102, machine_id: MACHINE_A, project_id: PROJECT_1, content_hash: 'pb-102', rowid: 2 },
+  { id: 103, machine_id: MACHINE_A, project_id: PROJECT_1, content_hash: 'pb-103', rowid: 3 },
+  { id: 104, machine_id: MACHINE_A, project_id: PROJECT_2, content_hash: 'pb-104', rowid: 4 },
+  { id: 201, machine_id: MACHINE_B, project_id: PROJECT_1, content_hash: 'pb-201', rowid: 5 },
+];
+
+// ---------------------------------------------------------------------------
+// SQLite storage-class semantics (faithful to D1)
+// ---------------------------------------------------------------------------
+// The previous fake compared ids as strings, which silently masked the
+// integer-affinity bug. These helpers model SQLite's real cross-type ordering
+// and affinity application so the integer-id tests below actually exercise the
+// `id > ''` first-page failure.
+
+/** Storage-class rank for ordering: NULL < INTEGER/REAL < TEXT. */
+function sqliteRank(v: unknown): number {
+  if (v === null || v === undefined) return 0;
+  if (typeof v === 'number') return 1;
+  return 2;
+}
+
+/** Compare two values per SQLite's cross-storage-class ordering. */
+function sqliteCompare(a: unknown, b: unknown): number {
+  const ra = sqliteRank(a);
+  const rb = sqliteRank(b);
+  if (ra !== rb) return ra - rb;
+  if (ra === 1) return (a as number) - (b as number);
+  const sa = String(a);
+  const sb = String(b);
+  return sa < sb ? -1 : sa > sb ? 1 : 0;
+}
+
+/**
+ * Apply a column's type affinity to a bound param, as SQLite does inside an
+ * `id > ?` comparison. INTEGER affinity converts a well-formed integer string
+ * to a number; '' and non-numeric strings stay TEXT — which is exactly why
+ * `id > ''` excludes every INTEGER-id row (integer < text), the bug under test.
+ */
+function applyAffinity(value: unknown, affinity: 'integer' | 'text'): unknown {
+  if (
+    affinity === 'integer' &&
+    typeof value === 'string' &&
+    value !== '' &&
+    /^-?\d+$/.test(value)
+  ) {
+    return Number(value);
+  }
+  return value;
+}
+
 // ---------------------------------------------------------------------------
 // Fake D1 implementation
 // ---------------------------------------------------------------------------
@@ -89,9 +147,18 @@ const ENTITIES_ROWS: FakeRow[] = [
  *     WHERE machine_id = ? [AND project_id = ?]
  *
  *   SELECT id, project_id[, content_hash] FROM <table>
- *     WHERE machine_id = ? [AND project_id = ?] AND id > ? ORDER BY id LIMIT ?
+ *     WHERE machine_id = ? [AND project_id = ?] [AND id > ?] ORDER BY id LIMIT ?
+ *
+ * The `AND id > ?` cursor clause is OPTIONAL (the first page omits it). The
+ * fake detects each clause from the SQL and parses bindings positionally so it
+ * works against both the buggy (always-on cursor) and fixed (first-page-omits)
+ * worker code. `idAffinity` maps a table to its id column affinity so the fake
+ * reproduces SQLite's integer-vs-empty-string comparison faithfully.
  */
-function createFakeD1(tableData: Record<string, FakeRow[]>): ManifestDb {
+function createFakeD1(
+  tableData: Record<string, FakeRow[]>,
+  idAffinity: Record<string, 'integer' | 'text'> = {},
+): ManifestDb {
   return {
     prepare(sql: string) {
       let boundValues: unknown[] = [];
@@ -106,7 +173,7 @@ function createFakeD1(tableData: Record<string, FakeRow[]>): ManifestDb {
           const rows = tableData[table] ?? [];
 
           // Parse WHERE clause bindings.
-          // Summary: SELECT COUNT(*), MAX(rowid) FROM t WHERE machine_id=? [AND project_id=?]
+          // Summary: SELECT COUNT(*) FROM t WHERE machine_id=? [AND project_id=?]
           const [machineId, maybeProjectId] = boundValues as string[];
           const filtered = rows.filter((r) => {
             if (r.machine_id !== machineId) return false;
@@ -122,37 +189,42 @@ function createFakeD1(tableData: Record<string, FakeRow[]>): ManifestDb {
           const tableMatch = sql.match(/FROM\s+(\w+)/i);
           const table = tableMatch?.[1] ?? '';
           const rows = tableData[table] ?? [];
+          const affinity = idAffinity[table] ?? 'text';
 
           const hasProjectIdFilter = /AND project_id = \?/.test(sql);
+          const hasCursorFilter = /id > \?/.test(sql);
           const hasContentHash = sql.includes('content_hash');
 
-          // Binding order for paged query:
-          //   With project_id:    machine_id, project_id, cursor_id, limit
-          //   Without project_id: machine_id, cursor_id, limit
-          let machineId: string;
-          let projectId: string | null = null;
-          let cursorId: string;
-          let limit: number;
+          // Binding order for the paged query (clauses optional):
+          //   machine_id, [project_id], [cursor], limit
+          let bi = 0;
+          const machineId = boundValues[bi++] as string;
+          const projectId = hasProjectIdFilter ? (boundValues[bi++] as string) : null;
+          const cursorRaw = hasCursorFilter ? boundValues[bi++] : undefined;
+          // limit not read directly: queryManifest binds limit+1 and slices via
+          // hasMore. The fake returns all matches; queryManifest paginates.
 
-          if (hasProjectIdFilter) {
-            [machineId, projectId, cursorId, limit] = boundValues as [string, string, string, number];
-          } else {
-            [machineId, cursorId, limit] = boundValues as [string, string, number];
-          }
+          // SQLite applies the id column's affinity to the bound cursor before
+          // comparing. This is what makes `id > ''` FALSE for integer ids.
+          const cursorBound = hasCursorFilter ? applyAffinity(cursorRaw, affinity) : undefined;
 
           const filtered = rows
             .filter((r) => {
               if (r.machine_id !== machineId) return false;
               if (projectId !== null && r.project_id !== projectId) return false;
-              if (String(r.id) <= String(cursorId)) return false;
+              if (hasCursorFilter && sqliteCompare(r.id, cursorBound) <= 0) return false;
               return true;
             })
-            .sort((a, b) => String(a.id).localeCompare(String(b.id)));
+            .sort((a, b) => sqliteCompare(a.id, b.id));
 
+          const limit = boundValues[bi] as number;
           const paged = filtered.slice(0, limit);
 
-          const items = paged.map((r): ManifestItem => {
-            const item: ManifestItem = {
+          // Return ids in their stored runtime type (number for integer-id
+          // tables) — queryManifest is responsible for coercing them to strings
+          // on the wire, mirroring how D1 hands back raw INTEGER columns.
+          const items = paged.map((r) => {
+            const item: Record<string, unknown> = {
               id: r.id,
               project_id: r.project_id,
               ...(hasContentHash ? { content_hash: r.content_hash ?? null } : {}),
@@ -167,10 +239,14 @@ function createFakeD1(tableData: Record<string, FakeRow[]>): ManifestDb {
   };
 }
 
-const fakeDb = createFakeD1({
-  sessions: SESSIONS_ROWS,
-  entities: ENTITIES_ROWS,
-});
+const fakeDb = createFakeD1(
+  {
+    sessions: SESSIONS_ROWS,
+    entities: ENTITIES_ROWS,
+    prompt_batches: PROMPT_BATCHES_ROWS,
+  },
+  { prompt_batches: 'integer' },
+);
 
 // ---------------------------------------------------------------------------
 // Parity assertion: WORKER_CONTENT_HASH_TABLES vs schema.ts
@@ -555,6 +631,86 @@ describe('content_hash field on paged results', () => {
     expect(result.items.length).toBeGreaterThan(0);
     for (const item of result.items) {
       expect('content_hash' in item).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// INTEGER-id tables — regression for the first-page `id > ''` paging bug
+// ---------------------------------------------------------------------------
+// Tables whose `id` column is INTEGER (prompt_batches, knowledge_release_state)
+// returned the correct count but `items: []` on the FIRST page, because
+// `id > ''` is FALSE for every integer id (SQLite orders INTEGER < TEXT). Every
+// existing test used string ids, so the suite never caught it. These tests pin:
+//   - first page returns items (not empty)
+//   - pagination works ACROSS pages for integer ids (multi-page with limit)
+//   - ids come back as strings on the wire
+
+describe('GET /manifest paged — INTEGER id tables (regression)', () => {
+  it('first page returns items for an integer-id table (not empty)', async () => {
+    const result = await queryManifest(fakeDb, {
+      machineId: MACHINE_A, table: 'prompt_batches',
+      projectId: PROJECT_1, cursor: null, limit: 200, summary: false,
+    });
+
+    expect('items' in result).toBe(true);
+    if (!('items' in result)) return;
+
+    // The bug returned []. MACHINE_A + PROJECT_1 has 3 prompt_batches.
+    expect(result.items.length).toBe(3);
+    expect(result.count).toBe(3);
+  });
+
+  it('returns integer ids coerced to strings on the wire', async () => {
+    const result = await queryManifest(fakeDb, {
+      machineId: MACHINE_A, table: 'prompt_batches',
+      projectId: PROJECT_1, cursor: null, limit: 200, summary: false,
+    });
+    expect('items' in result).toBe(true);
+    if (!('items' in result)) return;
+
+    for (const item of result.items) {
+      expect(typeof item.id).toBe('string');
+    }
+    expect(result.items.map((r) => r.id)).toEqual(['101', '102', '103']);
+  });
+
+  it('paginates across pages for integer ids (multi-page with limit)', async () => {
+    const page1 = await queryManifest(fakeDb, {
+      machineId: MACHINE_A, table: 'prompt_batches',
+      projectId: PROJECT_1, cursor: null, limit: 2, summary: false,
+    });
+    expect('items' in page1).toBe(true);
+    if (!('items' in page1)) return;
+
+    expect(page1.items.map((r) => r.id)).toEqual(['101', '102']);
+    expect(page1.next_cursor).toBe('102');
+
+    const page2 = await queryManifest(fakeDb, {
+      machineId: MACHINE_A, table: 'prompt_batches',
+      projectId: PROJECT_1, cursor: page1.next_cursor!, limit: 2, summary: false,
+    });
+    expect('items' in page2).toBe(true);
+    if (!('items' in page2)) return;
+
+    expect(page2.items.map((r) => r.id)).toEqual(['103']);
+    expect(page2.next_cursor).toBeUndefined();
+
+    const allIds = [...page1.items, ...page2.items].map((r) => r.id);
+    expect(allIds).toEqual(['101', '102', '103']);
+  });
+
+  it('includes content_hash for the integer-id content-hash table', async () => {
+    const result = await queryManifest(fakeDb, {
+      machineId: MACHINE_A, table: 'prompt_batches',
+      projectId: PROJECT_1, cursor: null, limit: 200, summary: false,
+    });
+    expect('items' in result).toBe(true);
+    if (!('items' in result)) return;
+
+    expect(result.items.length).toBeGreaterThan(0);
+    for (const item of result.items) {
+      expect('content_hash' in item).toBe(true);
     }
   });
 });

--- a/tests/worker/manifest.test.ts
+++ b/tests/worker/manifest.test.ts
@@ -25,6 +25,7 @@ import {
   type ManifestItem,
 } from '@myco-team-worker/manifest';
 import { SYNCED_TABLES } from '@myco-team-worker/synced-tables';
+import { RECONCILE_ELIGIBLE_TABLES } from '@myco/db/queries/team-outbox.js';
 
 // ---------------------------------------------------------------------------
 // Schema DDL source — read to verify WORKER_CONTENT_HASH_TABLES parity
@@ -226,6 +227,17 @@ describe('WORKER_CONTENT_HASH_TABLES parity with schema.ts', () => {
       expect(
         MANIFEST_ELIGIBLE_TABLES.has(table),
         `${table} is in WORKER_CONTENT_HASH_TABLES but not in MANIFEST_ELIGIBLE_TABLES`,
+      ).toBe(true);
+    }
+  });
+
+  it('RECONCILE_ELIGIBLE_TABLES is a subset of MANIFEST_ELIGIBLE_TABLES', () => {
+    // Guards against a daemon-only addition to the reconcile set that the worker's
+    // /manifest doesn't serve — such a table would 400 at runtime on every reconcile pass.
+    for (const table of RECONCILE_ELIGIBLE_TABLES) {
+      expect(
+        MANIFEST_ELIGIBLE_TABLES.has(table),
+        `${table} is in RECONCILE_ELIGIBLE_TABLES but not in MANIFEST_ELIGIBLE_TABLES`,
       ).toBe(true);
     }
   });

--- a/tests/worker/manifest.test.ts
+++ b/tests/worker/manifest.test.ts
@@ -2,7 +2,7 @@
  * Tests for GET /manifest — content-addressed drift reconcile endpoint.
  *
  * Verifies:
- *   - summary=1 returns { count, cheap_agg } scoped to (machine_id, [project_id])
+ *   - summary=1 returns { count } scoped to (machine_id, [project_id])
  *   - paged results are ordered by id with correct next_cursor
  *   - content_hash present only on the 4 content-hash tables
  *   - WORKER_CONTENT_HASH_TABLES parity: every member has content_hash in schema DDL
@@ -85,7 +85,7 @@ const ENTITIES_ROWS: FakeRow[] = [
  * Minimal fake D1 that parses the SQL the manifest handler issues and
  * answers from in-memory fixture rows. Supports the two query shapes:
  *
- *   SELECT COUNT(*) AS count, MAX(rowid) AS cheap_agg FROM <table>
+ *   SELECT COUNT(*) AS count FROM <table>
  *     WHERE machine_id = ? [AND project_id = ?]
  *
  *   SELECT id, project_id[, content_hash] FROM <table>
@@ -115,11 +115,8 @@ function createFakeD1(tableData: Record<string, FakeRow[]>): ManifestDb {
           });
 
           const count = filtered.length;
-          const maxRowid = filtered.length > 0
-            ? Math.max(...filtered.map((r) => r.rowid ?? 0))
-            : 0;
 
-          return { count, cheap_agg: maxRowid } as T;
+          return { count } as T;
         },
         async all<T>(): Promise<{ results: T[] }> {
           const tableMatch = sql.match(/FROM\s+(\w+)/i);
@@ -337,7 +334,7 @@ describe('parseManifestParams', () => {
 // ---------------------------------------------------------------------------
 
 describe('GET /manifest?summary=1 — scoping', () => {
-  it('returns count and cheap_agg scoped to machine_id only (no project_id)', async () => {
+  it('returns count scoped to machine_id only (no project_id)', async () => {
     const params = {
       machineId: MACHINE_A,
       table: 'sessions',
@@ -352,8 +349,6 @@ describe('GET /manifest?summary=1 — scoping', () => {
     expect(result.count).toBe(3);
     expect(result.machine_id).toBe(MACHINE_A);
     expect('project_id' in result).toBe(false);
-    // cheap_agg is MAX(rowid) for MACHINE_A rows: max rowid = 3
-    expect(result.cheap_agg).toBe(3);
   });
 
   it('excludes the other machine from the count', async () => {
@@ -388,8 +383,6 @@ describe('GET /manifest?summary=1 — scoping', () => {
     // MACHINE_A + PROJECT_1: sess-a1, sess-a2
     expect(result.count).toBe(2);
     expect(result.project_id).toBe(PROJECT_1);
-    // cheap_agg = MAX(rowid) for sess-a1 (rowid=1) and sess-a2 (rowid=2) = 2
-    expect(result.cheap_agg).toBe(2);
   });
 
   it('excludes the other project when project_id is given', async () => {
@@ -409,14 +402,13 @@ describe('GET /manifest?summary=1 — scoping', () => {
     expect(r2.count).toBe(1); // sess-a3
   });
 
-  it('returns cheap_agg=0 when no rows match', async () => {
+  it('returns count=0 when no rows match', async () => {
     const params = {
       machineId: 'machine-unknown', table: 'sessions',
       projectId: null, cursor: null, limit: 200, summary: true,
     };
     const result = await queryManifest(fakeDb, params);
     expect(result.count).toBe(0);
-    expect(result.cheap_agg).toBe(0);
   });
 });
 

--- a/tests/worker/team-worker-schedule.test.ts
+++ b/tests/worker/team-worker-schedule.test.ts
@@ -13,19 +13,37 @@ describe('team worker deployment config', () => {
     expect(wranglerToml).toMatch(/\[triggers\][\s\S]*crons = \["\*\/5 \* \* \* \*"\]/);
   });
 
-  it('declares SYNC_PROTOCOL_VERSION + MIN_COMPAT_CLIENT_VERSION matching the daemon constants', () => {
+  it('declares MIN_COMPAT_CLIENT_VERSION matching the daemon constant and a SYNC_PROTOCOL_VERSION that accepts the current daemon client', () => {
     // Worker [vars] are read at request time via parseInt(env.VAR, 10).
-    // The wrangler.toml string literal MUST match the daemon-side
-    // SYNC_PROTOCOL_VERSION / MIN_COMPAT_CLIENT_VERSION exactly — out
-    // of lockstep, the worker's compat window is wrong on every
-    // request and the gates in handleEnqueue/initD1Schema misbehave.
+    // Two invariants must hold:
+    //   1. wrangler.toml MIN_COMPAT_CLIENT_VERSION matches the daemon constant
+    //      exactly — it is the oldest client the worker will accept.
+    //   2. wrangler.toml SYNC_PROTOCOL_VERSION >= daemon SYNC_PROTOCOL_VERSION
+    //      — the worker's server version must be at least as high as the
+    //      current client version, so the daemon is inside the window
+    //      [minClient, workerServer]. A worker server version BELOW the
+    //      daemon client version would cause every /connect to 409.
+    // When the worker leads by one (e.g. worker=3, daemon=2), the daemon
+    // client still passes: 2 >= MIN_COMPAT (1) AND 2 <= workerServer (3).
     const wranglerToml = fs.readFileSync(
       path.join(process.cwd(), 'packages', 'myco-team', 'worker', 'wrangler.toml'),
       'utf-8',
     );
     const protocolMatch = wranglerToml.match(/^SYNC_PROTOCOL_VERSION\s*=\s*"(\d+)"$/m);
     const minCompatMatch = wranglerToml.match(/^MIN_COMPAT_CLIENT_VERSION\s*=\s*"(\d+)"$/m);
-    expect(protocolMatch?.[1]).toBe(String(SYNC_PROTOCOL_VERSION));
+    const workerServerVersion = parseInt(protocolMatch?.[1] ?? '', 10);
+    const workerMinCompat = parseInt(minCompatMatch?.[1] ?? '', 10);
+
+    // MIN_COMPAT stays in lockstep with the daemon constant.
     expect(minCompatMatch?.[1]).toBe(String(MIN_COMPAT_CLIENT_VERSION));
+
+    // Worker server version must be >= current daemon client version so
+    // the daemon is accepted by /connect. Worker-leads-by-N is fine.
+    expect(Number.isFinite(workerServerVersion)).toBe(true);
+    expect(workerServerVersion).toBeGreaterThanOrEqual(SYNC_PROTOCOL_VERSION);
+
+    // Daemon client must be within the worker's compat window.
+    expect(SYNC_PROTOCOL_VERSION).toBeGreaterThanOrEqual(workerMinCompat);
+    expect(SYNC_PROTOCOL_VERSION).toBeLessThanOrEqual(workerServerVersion);
   });
 });


### PR DESCRIPTION
## Problem

The team→D1 sync is a one-way mirror (local authoritative, D1 a dumb mirror), but it accumulated **positive drift** — rows deleted locally that lingered in D1 forever. On the Goondocks OSS partition this was 4,723 orphaned `prompt_batches` (D1 12,242 vs local 7,519) plus 7 `knowledge_release_state`.

**Root cause:** the delete-tombstone trigger `${table}_team_ad` was gated on `team_sync_state.enabled`. That flag is *auto-derived* from membership resolution (`setTeamSyncEnabled(memberProjectIds.length > 0)`), so any transient that resolves membership empty — e.g. the `~/.myco-team` machine-scoped home move (old registry retired, new not yet readable) — silently flips it to 0. Deletes in that window were never tombstoned, and unlike a missed insert (the row persists → backfill re-pushes it), a missed delete leaves no trace to replay → permanent orphans.

## Fix

Resilience belongs in a complete, durable change-log — not in after-the-fact bulk reconciliation. Four parts:

1. **Resilient `enabled` derivation** — `teamRegistry.listResolved()` returns a discriminated result; `enabled`/membership/outbox writes only act on a *confirmed* registry read, never an indeterminate/unreadable one. A transient can no longer flip capture off or wipe membership.
2. **Membership-gated delete capture (schema v63)** — the delete trigger now gates on the *stable* `team_sync_membership` (`WHEN OLD.project_id IN (SELECT project_id FROM team_sync_membership)`) instead of the transient `enabled` flag, so a member's delete is captured even mid-transition. Idempotent, convergent migration; D1 has no triggers so it's local-only.
3. **Automatic reconcile backstop** — a read-only worker `GET /manifest` lets the daemon diff local vs D1 and heal residual/anomalous orphans by seeding the existing outbox. Safety is fully machine-decidable (no operator judgment — a joining teammate just syncs): unconditional settledness guards (`localCount==0` / membership-unseeded → never delete) + cross-pass drift stability (delete only orphans observed across ≥2 passes, so a transient/partial read resolves before anything is removed).
4. **Integer-id manifest paging fix** — the paged query's empty-string first-page cursor (`id > ''`) excluded every INTEGER-id row in SQLite (NULL < INT < TEXT); ids are now normalized to strings end-to-end. (Caught by the live smoke; CI was green because all fixtures used string ids.)

## Live validation (real Goondocks OSS partition)

- **Healing:** reconcile converged D1 → local exactly — `prompt_batches` 12,242→7,519, `knowledge_release_state` 3,674→3,667 — removing only the 4,730 orphans, zero collateral on in-sync tables.
- **Prevention:** with `enabled=0` and membership seeded, a member delete is now tombstoned (verified non-destructively via a rolled-back transaction).

## Notes

- No `SYNC_PROTOCOL_VERSION` bump — the tombstone wire payload is unchanged. The worker advertises protocol 3 for the additive `/manifest` route; a v2 daemon still connects and simply doesn't reconcile.
- Trade-off: removing the old magnitude/operator gate means cross-pass stability defends transient bad reads; a *persistent* non-empty partial local read is bounded only by the settledness guards (intentional — fully automatic, one-way mirror, origin data intact).
- Follow-ups: the periodic backstop runs in the idle/sleep lane only; a single full-chain e2e test (enabled=0 delete → flush → worker); the leave-the-team unflushed-tombstone edge.

Full suite green (17,690 tests, 0 failures); `make build` green.
