### PR TITLE
feat(team,collective): Cloudflare account selection + create --observability

### DIFF
--- a/packages/myco-collective/src/cli.ts
+++ b/packages/myco-collective/src/cli.ts
@@ -15,6 +15,7 @@ import {
   parseKvNamespaceId,
   parseWorkerUrl,
   readJsonConfig,
+  resolveCloudflareAccount,
   resolveHomeDir,
   resolveNamedHomeConfigPath,
   resolveHomeConfigPath,
@@ -423,6 +424,16 @@ export async function collectiveInstall(name = 'myco-collective'): Promise<void>
   if (migrateLegacyConfig(name)) {
     throw new Error(`Collective "${name}" already exists. Use \`myco-collective upgrade ${name}\`.`);
   }
+
+  // Verify auth and resolve the Cloudflare account up front — before any
+  // resource is created — so a multi-account login doesn't fail mid-provision.
+  let whoamiOutput: string;
+  try {
+    whoamiOutput = wrangler(['whoami']);
+  } catch {
+    throw new Error('Not authenticated with Cloudflare. Run: wrangler login');
+  }
+  await resolveCloudflareAccount({ whoamiOutput, isTTY: Boolean(process.stdin.isTTY) });
 
   const d1Id = ensureD1Database(name);
   const kvId = ensureKvNamespace(name);

--- a/packages/myco-collective/src/main.ts
+++ b/packages/myco-collective/src/main.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { collectiveAddProject, collectiveDestroy, collectiveInstall, collectiveRotateTokens, collectiveStatus, collectiveUpgrade } from './cli.js';
+import { applyCloudflareAccountId, extractAccountIdFlag, isValidCloudflareAccountId } from '@myco-deploy/index.js';
 
-const [command, ...args] = process.argv.slice(2);
+const [command, ...rawArgs] = process.argv.slice(2);
 type CommandHandler = (args: string[]) => Promise<void>;
 
 function showHelp(): void {
@@ -14,6 +15,11 @@ Commands:
   rotate-tokens [admin|mcp|all] [name]
   add-project <name> <worker_url> <api_key> [collective_name]
   destroy [name]
+
+--account-id <id> (any command) selects which Cloudflare account to operate on
+when your wrangler login has access to more than one. Without it, install
+prompts you to pick interactively on a terminal, or errors listing the
+available accounts when non-interactive. Equivalent to CLOUDFLARE_ACCOUNT_ID.
 `);
 }
 
@@ -51,4 +57,20 @@ if (!handler) {
   process.exit(1);
 }
 
-await handler(args);
+// A global flag, valid on every command — set CLOUDFLARE_ACCOUNT_ID before any
+// wrangler call so a multi-account login resolves deterministically.
+const { accountId, rest: commandArgs } = extractAccountIdFlag(rawArgs);
+if (accountId !== undefined) {
+  if (!isValidCloudflareAccountId(accountId)) {
+    console.error(`Invalid --account-id "${accountId}": expected a 32-character hex Cloudflare account ID.`);
+    process.exit(2);
+  }
+  applyCloudflareAccountId(accountId);
+}
+
+try {
+  await handler(commandArgs);
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}

--- a/packages/myco-deploy/src/cloudflare.ts
+++ b/packages/myco-deploy/src/cloudflare.ts
@@ -102,6 +102,157 @@ export function extractJsonArray(output: string): unknown[] {
   return JSON.parse(output.slice(start, end + 1)) as unknown[];
 }
 
+/** The env var wrangler reads to pick a Cloudflare account in non-interactive mode. */
+export const CLOUDFLARE_ACCOUNT_ID_ENV = 'CLOUDFLARE_ACCOUNT_ID';
+
+/** Cloudflare account IDs are 32-character hex strings. */
+const ACCOUNT_ID_REGEX = /^[0-9a-f]{32}$/i;
+
+const MAX_ACCOUNT_PROMPT_ATTEMPTS = 3;
+
+export interface WranglerAccount {
+  name: string;
+  id: string;
+}
+
+export function isValidCloudflareAccountId(id: string): boolean {
+  return ACCOUNT_ID_REGEX.test(id.trim());
+}
+
+/**
+ * Point every subsequent wrangler invocation at one account by setting
+ * CLOUDFLARE_ACCOUNT_ID. `buildCommandEnv()` forwards process.env to each
+ * wrangler child, so this single mutation propagates without threading an
+ * account argument through every call site.
+ */
+export function applyCloudflareAccountId(id: string): void {
+  process.env[CLOUDFLARE_ACCOUNT_ID_ENV] = id.trim();
+}
+
+/**
+ * Extract a global `--account-id <id>` (or `--account-id=<id>`) flag from an
+ * argv slice, returning the value and the remaining args. Pure: validation and
+ * env application are the caller's responsibility.
+ */
+export function extractAccountIdFlag(args: string[]): { accountId?: string; rest: string[] } {
+  const rest: string[] = [];
+  let accountId: string | undefined;
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--account-id') {
+      accountId = args[i + 1] ?? '';
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--account-id=')) {
+      accountId = arg.slice('--account-id='.length);
+      continue;
+    }
+    rest.push(arg);
+  }
+  return { accountId, rest };
+}
+
+/**
+ * Parse the account table that `wrangler whoami` renders for an authenticated
+ * user. Rows are delimited by the box-drawing bar; a real account row's last
+ * cell is a 32-hex account ID, which skips the header and (bar-less) border
+ * rows. Border bars produce a leading and trailing empty cell that we drop,
+ * keeping the interior cells — so an account with a blank Name still parses
+ * (we don't filter empty cells, which would collapse such a row and undercount).
+ *
+ * Returns [] for any non-table output (older wrangler, a single-line "logged
+ * in" stub). The guard this feeds therefore assumes a modern wrangler whose
+ * whoami prints this table even for a single account; on that wrangler an
+ * authenticated user always yields >=1 row. A future wrangler that changed the
+ * format would degrade this to wrangler's own account handling — caught by the
+ * live smoke that any wrangler-version bump warrants.
+ */
+export function parseWranglerAccounts(whoamiOutput: string): WranglerAccount[] {
+  const accounts: WranglerAccount[] = [];
+  for (const line of whoamiOutput.split('\n')) {
+    if (!line.includes('│')) continue;
+    const cells = line.split('│').slice(1, -1).map((cell) => cell.trim());
+    if (cells.length < 2) continue;
+    const id = cells[cells.length - 1];
+    if (!ACCOUNT_ID_REGEX.test(id)) continue;
+    accounts.push({ name: cells[0], id });
+  }
+  return accounts;
+}
+
+async function defaultPrompt(question: string): Promise<string> {
+  const readline = await import('node:readline');
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return await new Promise<string>((resolve) => rl.question(question, resolve));
+  } finally {
+    rl.close();
+  }
+}
+
+async function selectAccount(
+  accounts: WranglerAccount[],
+  prompt: (question: string) => Promise<string>,
+  log: (message: string) => void,
+): Promise<WranglerAccount> {
+  for (let attempt = 1; attempt <= MAX_ACCOUNT_PROMPT_ATTEMPTS; attempt += 1) {
+    const answer = (await prompt(`Account [1-${accounts.length}]: `)).trim();
+    const choice = Number.parseInt(answer, 10);
+    if (Number.isInteger(choice) && choice >= 1 && choice <= accounts.length) {
+      return accounts[choice - 1];
+    }
+    log(`Invalid selection "${answer}" — enter a number between 1 and ${accounts.length}.`);
+  }
+  throw new Error('No valid Cloudflare account selected.');
+}
+
+export interface ResolveAccountOptions {
+  /** Captured `wrangler whoami` stdout. */
+  whoamiOutput: string;
+  /** Whether stdin is interactive; when false a multi-account state is a hard error. */
+  isTTY: boolean;
+  /** Prompt function (injectable for tests); defaults to a readline prompt. */
+  prompt?: (question: string) => Promise<string>;
+  /** Progress sink (injectable for tests); defaults to console.log. */
+  log?: (message: string) => void;
+}
+
+/**
+ * Ensure exactly one Cloudflare account is selected before provisioning, so a
+ * multi-account wrangler login doesn't fail mid-flow (after some resources are
+ * already created in an arbitrary account). Precedence:
+ *   1. CLOUDFLARE_ACCOUNT_ID already set (the --account-id flag or a manual
+ *      export) — respected, no prompt.
+ *   2. 0 or 1 parsed accounts — no-op; wrangler selects the sole account itself.
+ *   3. >=2 accounts on a TTY — interactive picker, then set the env.
+ *   4. >=2 accounts without a TTY — throw, listing accounts and the flag to use.
+ */
+export async function resolveCloudflareAccount(options: ResolveAccountOptions): Promise<void> {
+  if (process.env[CLOUDFLARE_ACCOUNT_ID_ENV]?.trim()) return;
+
+  const accounts = parseWranglerAccounts(options.whoamiOutput);
+  if (accounts.length <= 1) return;
+
+  if (!options.isTTY) {
+    const list = accounts.map((account) => `  ${account.name}: ${account.id}`).join('\n');
+    throw new Error(
+      'More than one Cloudflare account is available and none was selected.\n' +
+        `Pass --account-id <id> (or set ${CLOUDFLARE_ACCOUNT_ID_ENV}). Available accounts:\n${list}`,
+    );
+  }
+
+  const log = options.log ?? console.log;
+  const prompt = options.prompt ?? defaultPrompt;
+  log('\nMultiple Cloudflare accounts available. Select one:\n');
+  accounts.forEach((account, index) => log(`  ${index + 1}) ${account.name}  (${account.id})`));
+  log('');
+  const selected = await selectAccount(accounts, prompt, log);
+  applyCloudflareAccountId(selected.id);
+  log(`\nUsing Cloudflare account: ${selected.name} (${selected.id})`);
+  log(`Tip: pass --account-id ${selected.id} next time to skip this prompt.\n`);
+}
+
 export function stageDeploymentDir(options: StageDeploymentDirOptions): string {
   if (options.reset) {
     fs.rmSync(options.deployDir, { recursive: true, force: true });

--- a/packages/myco-team/src/cli.ts
+++ b/packages/myco-team/src/cli.ts
@@ -25,6 +25,7 @@ import {
   parseD1Id,
   parseKvNamespaceId,
   parseWorkerUrl,
+  resolveCloudflareAccount,
   runWrangler,
   stageDeploymentDir,
 } from '@myco-deploy/index.js';
@@ -441,7 +442,7 @@ export function withCustomDomainRoute(toml: string, slug: string, domain: string
  * Copy worker source to the vault deployment directory and patch wrangler.toml
  * with actual D1 database ID and resource names.
  */
-function prepareDeployDir(scope: TeamResourceNameInput, teamId: string, d1Id: string, kvId: string, domain?: string | null): string {
+function prepareDeployDir(scope: TeamResourceNameInput, teamId: string, d1Id: string, kvId: string, domain?: string | null, observability = false): string {
   const srcDir = locateWorkerSource();
   const deployDir = resolveTeamDeployDir(teamId);
   const name = resourceName(scope);
@@ -455,6 +456,13 @@ function prepareDeployDir(scope: TeamResourceNameInput, teamId: string, d1Id: st
     (toml) => toml.replace(TOML_SYNC_DLQ_PLACEHOLDER_REGEX, syncDlqName(name)),
     (toml) => toml.replace(TOML_TEAM_PACKAGE_VERSION_REGEX, `MYCO_TEAM_PACKAGE_VERSION = "${getTeamPackageVersion()}"`),
     (toml) => toml.replace(TOML_MYCO_SCHEMA_VERSION_REGEX, `MYCO_SCHEMA_VERSION = "${getMycoSchemaVersion()}"`),
+    // Render the observability block up front so a freshly created worker can
+    // opt in at deploy time (matches the upgrade path), instead of always
+    // deploying with logs off until a follow-up `upgrade --observability`.
+    (toml) => resetObservabilityBlock(toml).replace(
+      TOML_OBSERVABILITY_PLACEHOLDER_REGEX,
+      renderObservabilitySection(observability),
+    ),
   ];
   if (domain) {
     transforms.push((toml) => withCustomDomainRoute(toml, scope.resourceSlug, domain));
@@ -592,7 +600,7 @@ async function rotateMcpTokenForWorker(workerUrl: string, apiKey: string): Promi
 // Commands
 // ---------------------------------------------------------------------------
 
-export async function teamCreate(options: { name?: string; domain?: string } = {}): Promise<void> {
+export async function teamCreate(options: { name?: string; domain?: string; observability?: boolean } = {}): Promise<void> {
   let teamName = options.name?.trim();
   const domain = options.domain?.trim() || null;
   if (!teamName) {
@@ -629,12 +637,23 @@ export async function teamCreate(options: { name?: string; domain?: string } = {
   }
 
   // 2. Check auth
+  let whoamiOutput: string;
   try {
-    wrangler(['whoami']);
+    whoamiOutput = wrangler(['whoami']);
     console.log('Cloudflare auth: OK\n');
   } catch {
     console.error('Error: Not authenticated with Cloudflare. Run: wrangler login');
     process.exit(1);
+  }
+
+  // 2b. Resolve the Cloudflare account up front — before any resource is
+  // created — so a multi-account login doesn't fail mid-provision (leaking a
+  // D1 db / Vectorize index / KV namespace into an arbitrary account).
+  try {
+    await resolveCloudflareAccount({ whoamiOutput, isTTY: Boolean(process.stdin.isTTY) });
+  } catch (err) {
+    console.error((err as Error).message);
+    process.exit(2);
   }
 
   const name = resourceName(scope);
@@ -708,7 +727,10 @@ export async function teamCreate(options: { name?: string; domain?: string } = {
 
   // 8. Prepare deployment directory
   console.log('Preparing worker deployment...');
-  const deployDir = prepareDeployDir(scope, teamId, d1Id, kvId, domain);
+  if (options.observability) {
+    console.log('Observability: enabled (Cloudflare logs persist for this deploy)');
+  }
+  const deployDir = prepareDeployDir(scope, teamId, d1Id, kvId, domain, options.observability ?? false);
 
   // 7. Set team key secret via wrangler
   console.log('Setting Team key secret...');

--- a/packages/myco-team/src/main.ts
+++ b/packages/myco-team/src/main.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { teamAdopt, teamCreate, teamDestroy, teamExport, teamImport, teamReindexVectors, teamRotateTokens, teamStatus, teamUpgrade, upgradeWorker, reindexWorkerVectors } from './cli.js';
 import { migrateTeamsHomeIfNeeded } from '@myco/team/migrate-home.js';
+import { applyCloudflareAccountId, extractAccountIdFlag, isValidCloudflareAccountId } from '@myco-deploy/index.js';
 
 const [command, ...rawArgs] = process.argv.slice(2);
 type CommandHandler = (args: string[]) => Promise<void>;
@@ -9,7 +10,7 @@ function showHelp(): void {
   console.log(`Usage: myco-team <command>
 
 Commands:
-  create [--name "<team name>"] [--domain <zone>]
+  create [--name "<team name>"] [--domain <zone>] [--observability]
   upgrade|update --team-id <team_id> [--reindex-vectors] [--observability] [--json]
   status --team-id <team_id>
   rotate-tokens [api|mcp|all] --team-id <team_id>
@@ -18,6 +19,11 @@ Commands:
   export --team-id <team_id> [--out <dir-or-file>]
   import <bundle-file>
   adopt --worker-url <url> [--api-key <key>] [--worker-name <name>]
+
+--account-id <id> (any command) selects which Cloudflare account to operate on
+when your wrangler login has access to more than one. Without it, create prompts
+you to pick interactively on a terminal, or errors listing the available
+accounts when non-interactive. Equivalent to exporting CLOUDFLARE_ACCOUNT_ID.
 
 export writes a portable backup bundle (the team's local config + secrets)
 that import restores on another machine — no Cloudflare calls. adopt instead
@@ -88,15 +94,17 @@ function parseTeamSelector(commandArgs: string[]): { teamId?: string; rest: stri
   return { teamId, rest };
 }
 
-function parseCreateArgs(commandArgs: string[]): { name?: string; domain?: string } {
+function parseCreateArgs(commandArgs: string[]): { name?: string; domain?: string; observability?: boolean } {
   let name: string | undefined;
   let domain: string | undefined;
+  let observability = false;
   for (let i = 0; i < commandArgs.length; i += 1) {
     const arg = commandArgs[i];
     if (arg === '--name') { name = requireFlagValue(commandArgs, i, arg); i += 1; continue; }
     if (arg === '--domain') { domain = requireFlagValue(commandArgs, i, arg); i += 1; continue; }
+    if (arg === '--observability') { observability = true; continue; }
   }
-  return { name, domain };
+  return { name, domain, observability };
 }
 
 function parseExportArgs(commandArgs: string[]): { teamId?: string; out?: string } {
@@ -161,8 +169,8 @@ async function runUpgradeJson(
 
 const COMMAND_HANDLERS: Record<string, CommandHandler> = {
   create: async (commandArgs) => {
-    const { name, domain } = parseCreateArgs(commandArgs);
-    return teamCreate({ name, domain });
+    const { name, domain, observability } = parseCreateArgs(commandArgs);
+    return teamCreate({ name, domain, observability });
   },
   upgrade: async (commandArgs) => {
     const parsed = parseUpgradeArgs(commandArgs);
@@ -219,8 +227,19 @@ if (!handler) {
   process.exit(1);
 }
 
+// A global flag, valid on every command — set CLOUDFLARE_ACCOUNT_ID before any
+// wrangler call so a multi-account login resolves deterministically.
+const { accountId, rest: commandArgs } = extractAccountIdFlag(normalizeFlags(rawArgs));
+if (accountId !== undefined) {
+  if (!isValidCloudflareAccountId(accountId)) {
+    console.error(`Invalid --account-id "${accountId}": expected a 32-character hex Cloudflare account ID.`);
+    process.exit(2);
+  }
+  applyCloudflareAccountId(accountId);
+}
+
 try {
-  await handler(normalizeFlags(rawArgs));
+  await handler(commandArgs);
 } catch (err) {
   console.error(err instanceof Error ? err.message : String(err));
   process.exit(1);

--- a/tests/cli/team-create.test.ts
+++ b/tests/cli/team-create.test.ts
@@ -67,6 +67,16 @@ function createFakeWorkerSource(sourceDir: string): void {
   fs.writeFileSync(path.join(sourceDir, 'src', 'index.ts'), '// worker\n', 'utf-8');
 }
 
+const TWO_ACCOUNT_WHOAMI = [
+  '┌──────────────────┬──────────────────────────────────┐',
+  '│ Account Name     │ Account ID                       │',
+  '├──────────────────┼──────────────────────────────────┤',
+  '│ Personal Account │ 0123456789abcdef0123456789abcdef │',
+  '├──────────────────┼──────────────────────────────────┤',
+  '│ Team Account     │ fedcba9876543210fedcba9876543210 │',
+  '└──────────────────┴──────────────────────────────────┘',
+].join('\n') + '\n';
+
 describe('teamCreate', () => {
   let tmpDir: string;
   let homeDir: string;
@@ -75,6 +85,7 @@ describe('teamCreate', () => {
   let previousMycoHome: string | undefined;
   let previousTeamHome: string | undefined;
   let previousPackageRoot: string | undefined;
+  let previousAccountId: string | undefined;
   let previousExit: typeof process.exit;
   let previousConsoleError: typeof console.error;
 
@@ -91,12 +102,14 @@ describe('teamCreate', () => {
     previousMycoHome = process.env.MYCO_HOME;
     previousTeamHome = process.env.MYCO_TEAM_HOME;
     previousPackageRoot = process.env.MYCO_TEAM_PACKAGE_ROOT;
+    previousAccountId = process.env.CLOUDFLARE_ACCOUNT_ID;
     previousExit = process.exit;
     previousConsoleError = console.error;
     process.env.HOME = tmpDir;
     process.env.MYCO_HOME = homeDir;
     process.env.MYCO_TEAM_HOME = homeDir;
     process.env.MYCO_TEAM_PACKAGE_ROOT = path.join(tmpDir, 'package-root');
+    delete process.env.CLOUDFLARE_ACCOUNT_ID;
 
     vi.stubGlobal('fetch', vi.fn(async (url: string | URL) => {
       const target = String(url);
@@ -126,6 +139,8 @@ describe('teamCreate', () => {
     else process.env.MYCO_TEAM_HOME = previousTeamHome;
     if (previousPackageRoot === undefined) delete process.env.MYCO_TEAM_PACKAGE_ROOT;
     else process.env.MYCO_TEAM_PACKAGE_ROOT = previousPackageRoot;
+    if (previousAccountId === undefined) delete process.env.CLOUDFLARE_ACCOUNT_ID;
+    else process.env.CLOUDFLARE_ACCOUNT_ID = previousAccountId;
     process.exit = previousExit;
     console.error = previousConsoleError;
   });
@@ -202,6 +217,9 @@ describe('teamCreate', () => {
     expect(patchedToml).toContain(`SYNC_DLQ_NAME = "${resourceName}-sync-dlq"`);
     expect(patchedToml).toContain(`queue = "${resourceName}-sync"`);
     expect(patchedToml).toContain(`dead_letter_queue = "${resourceName}-sync-dlq"`);
+    // Observability stays off unless --observability is passed.
+    expect(patchedToml).not.toContain('[observability.logs]');
+    expect(patchedToml).toContain('# Observability disabled');
 
     const deployment = JSON.parse(
       fs.readFileSync(path.join(resolveTeamDir(teamId), 'deployment.json'), 'utf-8'),
@@ -225,5 +243,95 @@ describe('teamCreate', () => {
     await expect(teamCreate({})).rejects.toThrow('process.exit(2)');
     expect(errors.join('\n')).toContain('myco-team create requires a team name');
     expect(execCalls).toHaveLength(0);
+  });
+
+  it('refuses to provision when multiple Cloudflare accounts and none is selected (non-interactive)', async () => {
+    process.exit = ((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as typeof process.exit;
+    const errors: string[] = [];
+    console.error = ((...args: unknown[]) => {
+      errors.push(args.map(String).join(' '));
+    }) as typeof console.error;
+
+    execHandlers.push(
+      () => 'wrangler 4.105.0\n',  // 1 --version
+      () => TWO_ACCOUNT_WHOAMI,    // 2 whoami -> two accounts, no selection
+    );
+
+    const { teamCreate } = await import('../../packages/myco-team/src/cli.js');
+    await expect(teamCreate({ name: 'Acme OSS' })).rejects.toThrow('process.exit(2)');
+
+    expect(errors.join('\n')).toContain('More than one Cloudflare account');
+    expect(errors.join('\n')).toContain('fedcba9876543210fedcba9876543210');
+    // Resolution happens BEFORE any resource is created — only --version and
+    // whoami ran, so nothing leaked into an arbitrary account.
+    expect(execCalls.map((call) => call.args.slice(0, 2).join(' '))).toEqual(['--version', 'whoami']);
+  });
+
+  it('skips the account picker when CLOUDFLARE_ACCOUNT_ID is set (the --account-id flag path), even with multiple accounts', async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = '0123456789abcdef0123456789abcdef';
+    const deployHandler = (): string => {
+      const created = execCalls.find((call) => call.args[0] === 'd1' && call.args[1] === 'create');
+      const name = created?.args[2] ?? 'myco-team-unknown';
+      return `https://${name}.test.workers.dev\n`;
+    };
+    execHandlers.push(
+      () => 'wrangler 4.105.0\n',                                          // 1 --version
+      () => TWO_ACCOUNT_WHOAMI,                                            // 2 whoami -> two accounts
+      () => '{ "database_id": "11111111-1111-1111-1111-111111111111" }\n', // 3 d1 create
+      () => '',                                                           // 4 vectorize create
+      () => '{ "kv_namespaces": [ { "id": "abcdef1234567890" } ] }\n',    // 5 kv namespace create
+      () => '',                                                           // 6 queues create sync
+      () => '',                                                           // 7 queues create sync-dlq
+      () => '',                                                           // 8 npm install
+      () => '',                                                           // 9 secret put
+      deployHandler,                                                      // 10 deploy
+      () => '',                                                           // 11 dlq consumer remove
+      () => '',                                                           // 12 dlq consumer http add
+    );
+
+    const { teamCreate } = await import('../../packages/myco-team/src/cli.js');
+    await teamCreate({ name: 'Acme OSS' });
+
+    // Provisioned end-to-end despite two accounts — the pre-set env short-circuits the picker.
+    const d1Create = execCalls.find((call) => call.args[0] === 'd1' && call.args[1] === 'create');
+    expect(d1Create).toBeDefined();
+    expect(teamRegistry.list()).toHaveLength(1);
+  });
+
+  it('renders the observability block into the worker toml when --observability is passed', async () => {
+    const deployHandler = (): string => {
+      const created = execCalls.find((call) => call.args[0] === 'd1' && call.args[1] === 'create');
+      const name = created?.args[2] ?? 'myco-team-unknown';
+      return `https://${name}.test.workers.dev\n`;
+    };
+    execHandlers.push(
+      () => 'wrangler 4.105.0\n',                                          // 1 --version
+      () => 'logged in\n',                                                 // 2 whoami (single account)
+      () => '{ "database_id": "11111111-1111-1111-1111-111111111111" }\n', // 3 d1 create
+      () => '',                                                           // 4 vectorize create
+      () => '{ "kv_namespaces": [ { "id": "abcdef1234567890" } ] }\n',    // 5 kv namespace create
+      () => '',                                                           // 6 queues create sync
+      () => '',                                                           // 7 queues create sync-dlq
+      () => '',                                                           // 8 npm install
+      () => '',                                                           // 9 secret put
+      deployHandler,                                                      // 10 deploy
+      () => '',                                                           // 11 dlq consumer remove
+      () => '',                                                           // 12 dlq consumer http add
+    );
+
+    const { teamCreate } = await import('../../packages/myco-team/src/cli.js');
+    await teamCreate({ name: 'Acme OSS', observability: true });
+
+    const teamId = teamRegistry.list()[0].team_id;
+    const toml = fs.readFileSync(
+      path.join(resolveTeamDir(teamId), 'worker', 'wrangler.toml'),
+      'utf-8',
+    );
+    expect(toml).toContain('[observability]');
+    expect(toml).toContain('[observability.logs]');
+    expect(toml).toContain('enabled = true');
+    expect(toml).not.toContain('# Observability disabled');
   });
 });

--- a/tests/deploy/shared.test.ts
+++ b/tests/deploy/shared.test.ts
@@ -5,12 +5,16 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   createHexToken,
+  extractAccountIdFlag,
   extractJsonArray,
+  isValidCloudflareAccountId,
   maskSecret,
   parseD1Id,
   parseKvNamespaceId,
   parseWorkerUrl,
+  parseWranglerAccounts,
   readJsonConfig,
+  resolveCloudflareAccount,
   resolveHomeConfigPath,
   resolveVaultConfigPath,
   runWrangler,
@@ -141,5 +145,138 @@ describe('cloudflare deployment helpers', () => {
     expect(parseKvNamespaceId('{ "kv_namespaces": [ { "id": "7cc069cb32b4438b29079cca4714056" } ] }')).toBe('7cc069cb32b4438b29079cca4714056');
     expect(parseWorkerUrl('Deployed to https://myco-team.example.workers.dev')).toBe('https://myco-team.example.workers.dev');
     expect(extractJsonArray('banner\n[{"id":"one"}]\n')).toEqual([{ id: 'one' }]);
+  });
+});
+
+const TWO_ACCOUNT_WHOAMI = [
+  ' ⛅️ wrangler 4.105.0 (update available 4.106.0)',
+  '───────────────────────────────────────────────',
+  'Getting User settings...',
+  '👋 You are logged in with an OAuth Token, associated with the email cf@example.net.',
+  '┌──────────────────┬──────────────────────────────────┐',
+  '│ Account Name     │ Account ID                       │',
+  '├──────────────────┼──────────────────────────────────┤',
+  '│ Personal Account │ 0123456789abcdef0123456789abcdef │',
+  '├──────────────────┼──────────────────────────────────┤',
+  '│ Team Account     │ fedcba9876543210fedcba9876543210 │',
+  '└──────────────────┴──────────────────────────────────┘',
+].join('\n') + '\n';
+
+const ONE_ACCOUNT_WHOAMI = [
+  '┌──────────────────┬──────────────────────────────────┐',
+  '│ Account Name     │ Account ID                       │',
+  '├──────────────────┼──────────────────────────────────┤',
+  '│ Personal Account │ 0123456789abcdef0123456789abcdef │',
+  '└──────────────────┴──────────────────────────────────┘',
+].join('\n') + '\n';
+
+describe('cloudflare account selection', () => {
+  let previousAccountId: string | undefined;
+
+  beforeEach(() => {
+    previousAccountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+    delete process.env.CLOUDFLARE_ACCOUNT_ID;
+  });
+
+  afterEach(() => {
+    if (previousAccountId === undefined) delete process.env.CLOUDFLARE_ACCOUNT_ID;
+    else process.env.CLOUDFLARE_ACCOUNT_ID = previousAccountId;
+  });
+
+  it('parses the wrangler whoami account table', () => {
+    expect(parseWranglerAccounts(TWO_ACCOUNT_WHOAMI)).toEqual([
+      { name: 'Personal Account', id: '0123456789abcdef0123456789abcdef' },
+      { name: 'Team Account', id: 'fedcba9876543210fedcba9876543210' },
+    ]);
+    expect(parseWranglerAccounts(ONE_ACCOUNT_WHOAMI)).toHaveLength(1);
+  });
+
+  it('returns [] for non-table whoami output (older wrangler / stubs)', () => {
+    expect(parseWranglerAccounts('logged in\n')).toEqual([]);
+    expect(parseWranglerAccounts('')).toEqual([]);
+  });
+
+  it('still counts an account whose Name cell is blank (no undercount)', () => {
+    const blankName = [
+      '┌──┬──────────────────────────────────┐',
+      '│  │ 0123456789abcdef0123456789abcdef │',
+      '├──┼──────────────────────────────────┤',
+      '│  │ fedcba9876543210fedcba9876543210 │',
+      '└──┴──────────────────────────────────┘',
+    ].join('\n') + '\n';
+    expect(parseWranglerAccounts(blankName)).toEqual([
+      { name: '', id: '0123456789abcdef0123456789abcdef' },
+      { name: '', id: 'fedcba9876543210fedcba9876543210' },
+    ]);
+  });
+
+  it('extracts a --account-id flag in both spaced and = forms', () => {
+    expect(extractAccountIdFlag(['create', '--account-id', 'abc', '--name', 'x'])).toEqual({
+      accountId: 'abc',
+      rest: ['create', '--name', 'x'],
+    });
+    expect(extractAccountIdFlag(['create', '--account-id=abc'])).toEqual({
+      accountId: 'abc',
+      rest: ['create'],
+    });
+    expect(extractAccountIdFlag(['create', '--name', 'x'])).toEqual({
+      accountId: undefined,
+      rest: ['create', '--name', 'x'],
+    });
+  });
+
+  it('validates the 32-hex account id shape', () => {
+    expect(isValidCloudflareAccountId('0123456789abcdef0123456789abcdef')).toBe(true);
+    expect(isValidCloudflareAccountId('0123456789ABCDEF0123456789ABCDEF')).toBe(true);
+    expect(isValidCloudflareAccountId('too-short')).toBe(false);
+    expect(isValidCloudflareAccountId('z123456789abcdef0123456789abcdef')).toBe(false);
+  });
+
+  it('respects an already-set CLOUDFLARE_ACCOUNT_ID without prompting', async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = '0123456789abcdef0123456789abcdef';
+    const prompt = vi.fn(async () => '1');
+    await resolveCloudflareAccount({ whoamiOutput: TWO_ACCOUNT_WHOAMI, isTTY: true, prompt, log: () => {} });
+    expect(prompt).not.toHaveBeenCalled();
+    expect(process.env.CLOUDFLARE_ACCOUNT_ID).toBe('0123456789abcdef0123456789abcdef');
+  });
+
+  it('is a no-op with a single account', async () => {
+    const prompt = vi.fn(async () => '1');
+    await resolveCloudflareAccount({ whoamiOutput: ONE_ACCOUNT_WHOAMI, isTTY: true, prompt, log: () => {} });
+    expect(prompt).not.toHaveBeenCalled();
+    expect(process.env.CLOUDFLARE_ACCOUNT_ID).toBeUndefined();
+  });
+
+  it('throws with the account list when multiple accounts and non-interactive', async () => {
+    await expect(
+      resolveCloudflareAccount({ whoamiOutput: TWO_ACCOUNT_WHOAMI, isTTY: false, log: () => {} }),
+    ).rejects.toThrow(/more than one cloudflare account/i);
+    await expect(
+      resolveCloudflareAccount({ whoamiOutput: TWO_ACCOUNT_WHOAMI, isTTY: false, log: () => {} }),
+    ).rejects.toThrow(/fedcba9876543210fedcba9876543210/);
+    expect(process.env.CLOUDFLARE_ACCOUNT_ID).toBeUndefined();
+  });
+
+  it('prompts and applies the chosen account on a TTY', async () => {
+    const prompt = vi.fn(async () => '2');
+    await resolveCloudflareAccount({ whoamiOutput: TWO_ACCOUNT_WHOAMI, isTTY: true, prompt, log: () => {} });
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(process.env.CLOUDFLARE_ACCOUNT_ID).toBe('fedcba9876543210fedcba9876543210');
+  });
+
+  it('re-prompts on invalid input, then applies a valid choice', async () => {
+    const answers = ['9', 'nope', '1'];
+    const prompt = vi.fn(async () => answers.shift() ?? '');
+    await resolveCloudflareAccount({ whoamiOutput: TWO_ACCOUNT_WHOAMI, isTTY: true, prompt, log: () => {} });
+    expect(prompt).toHaveBeenCalledTimes(3);
+    expect(process.env.CLOUDFLARE_ACCOUNT_ID).toBe('0123456789abcdef0123456789abcdef');
+  });
+
+  it('throws after exhausting prompt attempts without a valid choice', async () => {
+    const prompt = vi.fn(async () => 'x');
+    await expect(
+      resolveCloudflareAccount({ whoamiOutput: TWO_ACCOUNT_WHOAMI, isTTY: true, prompt, log: () => {} }),
+    ).rejects.toThrow(/no valid cloudflare account/i);
+    expect(process.env.CLOUDFLARE_ACCOUNT_ID).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Problem

A wrangler login with access to **more than one Cloudflare account** broke `myco-team create` (and the identical `myco-collective install`). Wrangler refuses to pick an account in non-interactive mode, so `create` failed at `secret put` — but only *after* `d1 create`, `vectorize create`, `kv namespace create`, and the queue creates had **already silently provisioned resources into an arbitrary account**. The only workaround was `export CLOUDFLARE_ACCOUNT_ID=… ` before every invocation.

Separately, `--observability` was only available on `upgrade`, so a freshly created worker always deployed with Cloudflare's persistent logs off — requiring a follow-up `upgrade --observability`.

## What changed

### Account selection
Routed through a shared helper in `@myco-deploy` (`resolveCloudflareAccount` / `parseWranglerAccounts` / `extractAccountIdFlag`) that sets `CLOUDFLARE_ACCOUNT_ID`. `buildCommandEnv()` already forwards `process.env` to every wrangler child, so no account argument has to thread through the call sites.

- **`--account-id <id>`** — a global flag valid on every command in both CLIs (validated as 32-hex), documented in `--help`. For scripted/CI use; equivalent to exporting `CLOUDFLARE_ACCOUNT_ID`.
- **Interactive picker** on `create`/`install` — when `wrangler whoami` reports ≥2 accounts on a TTY, it lists them and prompts for a choice; when non-interactive, it fails with a clear error **listing the accounts** instead of wrangler's opaque mid-flow failure.

The account is resolved **up front, before any resource is created**, so a multi-account login can no longer leak D1/Vectorize/KV/queue resources into an unintended account. `myco-collective` also gains a top-level error handler (it previously surfaced all errors as raw unhandled rejections).

**Precedence:** `--account-id` / a pre-set `CLOUDFLARE_ACCOUNT_ID` wins (no prompt) → a single account is a no-op (wrangler selects it) → ≥2 on a TTY prompts → ≥2 non-interactive errors with the account list.

### `create --observability`
`myco-team create` now accepts `--observability` (parity with `upgrade`). It renders the `[observability]` block into the worker's `wrangler.toml` at deploy time via the same `renderObservabilitySection` path `upgrade` uses, and prints an "Observability: enabled" line. Default remains off.

## Testing

- New unit tests in `tests/deploy/shared.test.ts` (parser incl. blank-name rows, flag extraction, validation, full resolution precedence incl. retry/exhaustion) and `tests/cli/team-create.test.ts` (multi-account non-interactive error; `--account-id` skips the picker; `--observability` renders the block; default leaves it off).
- Live CLI smokes: `--help` documents both flags; invalid IDs reject before any network call; the real multi-account non-interactive path errors **before provisioning anything**; collective errors print cleanly.
- `make build` green end-to-end on the account-selection baseline; the observability increment is whole-project tsc-clean with all team CLI + deploy tests passing and the `myco-team` package building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)