### PR TITLE
fix(canopy): gate Operations describe-backlog on the Canopy capability

### DIFF
--- a/.agents/skills/feature-branch-worktree-squash-merge-delivery/SKILL.md
+++ b/.agents/skills/feature-branch-worktree-squash-merge-delivery/SKILL.md
@@ -3,9 +3,10 @@ name: myco:feature-branch-worktree-squash-merge-delivery
 description: >-
   Use this skill when delivering a non-trivial Myco feature that spans
   multiple files and needs clean PR history. It applies whenever you need
-  git worktrees for isolated implementation, the `/simplify` quality pass,
-  `make build` as the full quality gate, or a single clean squash-merge
-  commit for the final PR.
+  git worktrees for isolated implementation, the `code-review high` quality
+  pass (multi-agent fan-out; `/simplify` is deprecated), `make build` as
+  the full quality gate, or a single clean squash-merge commit for the
+  final PR.
 managed_by: myco
 version: 1
 user-invocable: true
@@ -73,11 +74,11 @@ unset MYCO_HOME
 
 Commit regularly in the worktree. Don't worry about commit message quality — these will be squashed. Keep `.myco/` and `VAULT_GITIGNORE`-tracked files out of commits.
 
-### Step 4: Run the `/simplify` Quality Pass
+### Step 4: Run the `code-review high` Quality Pass
 
-After implementation, run a structured quality review targeting four classes of technical debt that accumulate during fast feature work. This pass must complete **before** the squash — simplification changes belong in the final commit, not a follow-up PR.
+After implementation, run `code-review high` (the current quality pass — `/simplify` is deprecated) to trigger a multi-agent fan-out review targeting four classes of technical debt that accumulate during fast feature work. This pass must complete **before** the squash — review changes belong in the final commit, not a follow-up PR.
 
-**Sequence constraint**: make a simplify commit in the worktree — it will be squashed into the single feature commit at delivery.
+**Sequence constraint**: commit review changes in the worktree — they will be squashed into the single feature commit at delivery.
 
 #### 4a. Identify and Extract Duplication
 
@@ -158,11 +159,11 @@ npm test
 
 Both must be clean before committing.
 
-#### 4f. Commit the simplify pass
+#### 4f. Commit the review pass
 
 ```bash
 git add -A
-git commit -m "refactor: /simplify pass — <feature-name>"
+git commit -m "refactor: code-review pass — <feature-name>"
 ```
 
 This commit will be squashed into the feature commit in Step 6.
@@ -240,10 +241,10 @@ The single squashed commit becomes the PR commit.
 
 - **`npm run build` silently ships broken packages** — only `make build` runs lint + fast unit tests + `tsc` + `tsup` + `vite`; for the full test sweep including integration/smoke, use `make build-all`
 - **Sibling directory, not subdirectory** — always use `../myco-branch-name`; nested worktrees cause CWD detection misattribution
-- **`/simplify` before squash, not after** — simplification belongs in the final squashed commit, not a follow-up cleanup PR
+- **`code-review high` before squash, not after** — review changes belong in the final squashed commit, not a follow-up cleanup PR (`/simplify` is deprecated)
 - **Delete the worktree before pushing** — `git worktree remove` must precede `git push`; lingering worktrees confuse subsequent Claude Code sessions
 - **Design spec on `main` first** — commit the spec in `docs/superpowers/specs/` before switching to the worktree
 - **Run `npm rebuild` after branch switches involving native modules** — if the dependency tree includes native Node addons (e.g., `better-sqlite3`), switching between branches requires `npm rebuild` before running tests or the daemon; failures manifest as cryptic runtime errors, not build errors
-- **Stage untracked files before `/simplify` or code review** — Claude Code's review tools only see git-tracked files; new files that haven't been `git add`-ed are invisible; run `git add -N .` (intent-to-add) before any review pass
+- **Stage untracked files before `code-review high`** — Claude Code's review tools only see git-tracked files; new files that haven't been `git add`-ed are invisible; run `git add -N .` (intent-to-add) before any review pass
 - **Check existing utility modules before extracting helpers** — re-extracting an existing helper creates a naming conflict during the simplify pass
 - **`gh pr merge --squash` exit code is unreliable inside worktrees** — the command can exit non-zero (local checkout fails) even when the remote merge succeeded; do not treat a non-zero exit as a failed merge. Always verify with `gh pr view --json state,mergeCommit` to confirm the actual PR state before retrying or force-pushing.

--- a/packages/myco/src/canopy/describe-backlog.ts
+++ b/packages/myco/src/canopy/describe-backlog.ts
@@ -29,6 +29,7 @@ import {
   loadGroveRecord,
 } from '@myco/grove/registry.js';
 import { loadMergedConfig } from '@myco/config/loader.js';
+import { capabilityEnabled } from '@myco/config/capabilities.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 
 export interface CanopyDescribeBacklogContext {
@@ -50,6 +51,14 @@ export function createCanopyDescribeBacklogReader(
   return {
     read(scope, context) {
       const groveId = context?.groveId ?? null;
+      // Empty backlog for a Canopy-disabled project; unresolvable → don't filter.
+      if (scope.kind === 'project' && groveId) {
+        const home = options.mycoHome ?? resolveMycoHome();
+        const found = findRegisteredProject({ projectId: scope.id, groveId }, home);
+        if (found && !projectCanopyEnabled(found.project.root, groveId, home)) {
+          return { pending: 0, undescribed: 0, stale: 0, stuck: 0 };
+        }
+      }
       const projectIds = scope.kind === 'all'
         ? serviceableProjectIds(groveId, options.mycoHome)
         : null;
@@ -62,12 +71,8 @@ export function createCanopyDescribeBacklogReader(
   };
 }
 
-// Grove-wide backlog counts must reflect work the scribe can actually
-// service: active registered projects only. Rows left behind by deleted
-// projects (pre-cascade orphans) or held by archived projects would
-// otherwise inflate the dashboard with work no scheduled run will drain.
-// When the grove record can't be loaded the registry is unavailable, so
-// fall back to the unrestricted count rather than report a false zero.
+// Registered, active projects with the Canopy capability enabled.
+// Returns null (unrestricted count) when the grove record can't be loaded.
 export function serviceableProjectIds(
   groveId: string | null,
   mycoHome?: string,
@@ -75,7 +80,24 @@ export function serviceableProjectIds(
   if (!groveId) return null;
   const home = mycoHome ?? resolveMycoHome();
   if (!loadGroveRecord(groveId, home)) return null;
-  return listRegisteredProjects(groveId, home).map((project) => project.project_id);
+  return listRegisteredProjects(groveId, home)
+    .filter((project) => projectCanopyEnabled(project.root, groveId, home))
+    .map((project) => project.project_id);
+}
+
+// Canopy capability state from the project's merged config; unloadable → false.
+function projectCanopyEnabled(
+  projectRoot: string,
+  groveId: string,
+  mycoHome: string,
+): boolean {
+  let config: MycoConfig | null = null;
+  try {
+    config = loadMergedConfig(resolveProjectVaultDir(projectRoot), { groveId, mycoHome });
+  } catch {
+    // unloadable config → capabilityEnabled(null) === false
+  }
+  return capabilityEnabled(config, 'canopy');
 }
 
 /**

--- a/tests/canopy/describe-backlog.test.ts
+++ b/tests/canopy/describe-backlog.test.ts
@@ -39,19 +39,38 @@ function insertUndescribedEntry(projectId: string, filePath: string): void {
   ).run(projectId, filePath, `hash-${filePath}`, 10, 5, 1, 200, null, null);
 }
 
+/**
+ * Materialize a project's `.myco` config on disk. A registered project always
+ * has a myco.yaml (loadMergedConfig requires it), so the capability resolver
+ * can read it; the capture-only off-gate lives in local.yaml, mirroring how
+ * the daemon resolves a Canopy-disabled project.
+ */
+function writeProjectConfig(root: string, opts: { canopyEnabled: boolean }): string {
+  const vaultDir = path.join(root, '.myco');
+  fs.mkdirSync(vaultDir, { recursive: true });
+  fs.writeFileSync(path.join(vaultDir, 'myco.yaml'), 'version: 3\n');
+  if (!opts.canopyEnabled) {
+    fs.writeFileSync(
+      path.join(vaultDir, 'local.yaml'),
+      'cortex:\n  enabled: false\n  canopy:\n    enabled: false\n',
+    );
+  }
+  return root;
+}
+
 describe('canopy describe backlog reader', () => {
   it('grove-wide reads count only active registered projects', () => {
     const grove = createGrove('Test Grove', home);
     registerProjectInGrove(grove.id, {
       projectId: 'proj_active',
       projectName: 'active',
-      projectRoot: '/tmp/active',
+      projectRoot: writeProjectConfig(path.join(home, 'active-project'), { canopyEnabled: true }),
       bindingId: 'gbind_active',
     }, home);
     registerProjectInGrove(grove.id, {
       projectId: 'proj_archived',
       projectName: 'archived',
-      projectRoot: '/tmp/archived',
+      projectRoot: path.join(home, 'archived-project'),
       bindingId: 'gbind_archived',
     }, home);
     archiveProjectInGrove(grove.id, 'proj_archived', home);
@@ -67,6 +86,53 @@ describe('canopy describe backlog reader', () => {
     );
 
     expect(backlog).toEqual({ pending: 2, undescribed: 2, stale: 0, stuck: 0 });
+  });
+
+  it('grove-wide reads exclude registered projects with Canopy disabled', () => {
+    const grove = createGrove('Test Grove', home);
+    registerProjectInGrove(grove.id, {
+      projectId: 'proj_enabled',
+      projectName: 'enabled',
+      projectRoot: writeProjectConfig(path.join(home, 'enabled-project'), { canopyEnabled: true }),
+      bindingId: 'gbind_enabled',
+    }, home);
+    registerProjectInGrove(grove.id, {
+      projectId: 'proj_disabled',
+      projectName: 'disabled',
+      projectRoot: writeProjectConfig(path.join(home, 'disabled-project'), { canopyEnabled: false }),
+      bindingId: 'gbind_disabled',
+    }, home);
+
+    insertUndescribedEntry('proj_enabled', 'a.ts');
+    insertUndescribedEntry('proj_disabled', 'b.ts');
+    insertUndescribedEntry('proj_disabled', 'c.ts');
+
+    const reader = createCanopyDescribeBacklogReader({ mycoHome: home });
+    const backlog = withDatabase(db, () =>
+      reader.read(ALL_PROJECTS_SCOPE, { groveId: grove.id }),
+    );
+
+    // proj_disabled's two rows are dropped; only proj_enabled's one counts.
+    expect(backlog).toEqual({ pending: 1, undescribed: 1, stale: 0, stuck: 0 });
+  });
+
+  it('project-scoped reads report an empty backlog when Canopy is disabled', () => {
+    const grove = createGrove('Test Grove', home);
+    registerProjectInGrove(grove.id, {
+      projectId: 'proj_disabled',
+      projectName: 'disabled',
+      projectRoot: writeProjectConfig(path.join(home, 'disabled-project'), { canopyEnabled: false }),
+      bindingId: 'gbind_disabled',
+    }, home);
+
+    insertUndescribedEntry('proj_disabled', 'a.ts');
+
+    const reader = createCanopyDescribeBacklogReader({ mycoHome: home });
+    const backlog = withDatabase(db, () =>
+      reader.read(projectScope('proj_disabled'), { groveId: grove.id }),
+    );
+
+    expect(backlog).toEqual({ pending: 0, undescribed: 0, stale: 0, stuck: 0 });
   });
 
   it('falls back to the unrestricted count when the grove record is unknown', () => {


### PR DESCRIPTION
## Problem

The grove Operations page (`/g/:slug/operations`) showed a fixed **435 pending Canopy** that never drained — new entries would describe and clear, but the number always snapped back to 435. "Clean orphans" found nothing, because the rows aren't orphans.

## Root cause

The Operations describe-backlog reader counted pending `canopy_entries` for **all** active registered projects, skipping the Canopy capability gate that every other Canopy-data path enforces. Capture-only projects (Canopy disabled via `local.yaml`) still accrue mechanically-scanned `canopy_entries`, but `canopy-describe` never runs for them — so their rows counted as pending forever with no scribe to drain them and nothing to clean.

On the prod default grove the 435 was exactly **homelab (249) + career-ops (186)** — two active, registered, but Canopy-disabled projects (all rows `describe_attempts=0`, `llm_updated_at IS NULL`, zero describe runs ever).

This is the same bug family as the earlier deleted/archived-project phantom (counter must mirror the worker's serviceable set); that fix closed the deleted/archived axis and this closes the Canopy-disabled axis.

## Fix

`serviceableProjectIds` now filters registered projects through `capabilityEnabled(loadMergedConfig(root), 'canopy')` — the same gate `daemon/api/groves.ts` `resolveCapabilities` and the PreToolUse inject path (`canopy-inject.ts`) use. The reader's project-scope path is gated too (it previously bypassed the filter entirely). This fixes both consumers of `serviceableProjectIds`: the Operations count and the `retry-stuck` reset. Grove-unloadable / unregistered reads stay fail-open ("truth beats a false zero").

The predicate is **capability-only**, not capability-plus-schedule: a Canopy-enabled project whose `canopy-describe` schedule is paused still surfaces its (legitimately pending) backlog; only fully Canopy-disabled projects are excluded.

Not team-sync related: `canopy_entries` is local-only (in neither `TEAM_SYNC_OBSERVED_TABLES` nor `TEAM_SYNC_BACKFILL_TABLES`).

## Verification

- Two new regression tests (grove-wide exclusion + project-scope empty backlog for Canopy-disabled projects); full canopy suite green.
- `make build` green (lint, workers, all tests, ui-build, codegen, binary).
- Both correctness and regression code-review passes clean.
- **Real prod data:** the new reader run against the live default grove returns `serviceableProjectIds` = exactly the 5 Canopy-enabled registered projects and a grove-wide backlog of `{ pending: 0, undescribed: 0, stale: 0, stuck: 0 }` (was 435).
- Dogfood daemon rebuilt + restarted on this commit; Operations page renders cleanly end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)