### PR TITLE
fix(team): count team-scoped sync drift across all owning groves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     # waiting hours on a wedged runner.
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,4 +43,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version: '22'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build docs site
         run: npm run build
         working-directory: docs
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_site
 

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -21,7 +21,7 @@ jobs:
       issues: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,7 +113,7 @@ jobs:
           - target: windows-x64
             os: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install cross toolchain (linux-arm64)
         if: matrix.target == 'linux-arm64'
@@ -152,7 +152,7 @@ jobs:
       matrix:
         target: [darwin-arm64, darwin-x64, linux-x64, linux-arm64, windows-x64]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:
@@ -244,7 +244,7 @@ jobs:
       needs.validate-tag.result == 'success' &&
       (needs.cross-compile.result == 'success' || needs.cross-compile.result == 'skipped')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -506,7 +506,7 @@ jobs:
       needs.build.result == 'success' &&
       needs.validate-tag.outputs.tag_prefix != 'myco-shared'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/packages/myco/src/daemon/api/team-connect.ts
+++ b/packages/myco/src/daemon/api/team-connect.ts
@@ -35,7 +35,7 @@ import { getPluginVersion } from '@myco/version.js';
 import { SCHEMA_VERSION } from '@myco/db/schema.js';
 import { loadGroveRecord } from '@myco/grove/registry.js';
 import { teamRegistry, withProjectRemoved } from '@myco/team/registry.js';
-import { aggregateTeamSyncRows } from '../team-sync-counts.js';
+import { aggregateTeamSyncRows, aggregateTeamPending } from '../team-sync-counts.js';
 import { GroveRuntimeCache } from '../grove-runtime-cache.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 import type { DaemonLogger } from '../logger.js';
@@ -588,9 +588,10 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
     let pendingCount = 0;
     try {
       // Machine-wide: a team's pending rows live in each owning grove's outbox,
-      // so aggregate across groves rather than the ambient grove DB.
+      // so aggregate across groves rather than the ambient grove DB. Status only
+      // surfaces pending, so use the pending-only fan-out (no per-table counts).
       pendingCount = resolvedTeam
-        ? (await aggregateTeamSyncRows(runtimeCache, logger, machineId, resolvedTeam.projects)).pending
+        ? await aggregateTeamPending(runtimeCache, logger, resolvedTeam.projects)
         : countPending();
     } catch (err) {
       // Log rather than swallow: a thrown count must not be reported as "0 pending"

--- a/packages/myco/src/daemon/api/team-connect.ts
+++ b/packages/myco/src/daemon/api/team-connect.ts
@@ -13,7 +13,6 @@ import { resolveProjectRoot } from '@myco/vault/resolve.js';
 import { resolveGroveDir } from '@myco/grove/paths.js';
 import {
   countPending,
-  countPendingForProjects,
   dropPendingForProjects,
   countTeamSyncRows,
   backfillAll,
@@ -36,6 +35,8 @@ import { getPluginVersion } from '@myco/version.js';
 import { SCHEMA_VERSION } from '@myco/db/schema.js';
 import { loadGroveRecord } from '@myco/grove/registry.js';
 import { teamRegistry, withProjectRemoved } from '@myco/team/registry.js';
+import { aggregateTeamSyncRows } from '../team-sync-counts.js';
+import { GroveRuntimeCache } from '../grove-runtime-cache.js';
 import type { RouteRequest, RouteResponse } from '../router.js';
 import type { DaemonLogger } from '../logger.js';
 import { isGroveScoped, type MycoRequestContext } from '@myco/grove/request-context.js';
@@ -324,6 +325,18 @@ export interface TeamHandlerDeps {
   vaultDir: string;
   machineId: string;
   logger: DaemonLogger;
+  /**
+   * Grove DB cache used to fan out team-scoped local counts across every grove
+   * that owns one of the selected team's projects. Team membership is
+   * machine-wide but each grove keeps its own DB, so a single grove-scoped
+   * handle would undercount projects in other groves.
+   *
+   * Optional: the daemon injects its shared cache so grove DB handles are
+   * reused; when omitted (tests) the factory constructs a private one. The
+   * aggregation is identical either way — sharing is only a handle-reuse
+   * optimization, not a behavior switch.
+   */
+  runtimeCache?: GroveRuntimeCache;
   getTeamClient: (requestContext?: MycoRequestContext) => TeamSyncClient | null;
   /**
    * npm global prefix — used to locate the installed `@goondocks/myco-team`
@@ -371,6 +384,9 @@ const DEPRECATED_STATUS_FIELDS: Record<string, { since: string; reason: string; 
 
 export function createTeamHandlers(deps: TeamHandlerDeps) {
   const { vaultDir, machineId, logger } = deps;
+  // Shared cache when the daemon injects one (handle reuse); a private cache
+  // otherwise. Either way the cross-grove aggregation reads the same rows.
+  const runtimeCache = deps.runtimeCache ?? new GroveRuntimeCache();
 
   const makeJoinClient = deps.makeJoinClient ?? ((opts: { workerUrl: string; apiKey: string }) =>
     new TeamSyncClient({
@@ -571,8 +587,10 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
 
     let pendingCount = 0;
     try {
+      // Machine-wide: a team's pending rows live in each owning grove's outbox,
+      // so aggregate across groves rather than the ambient grove DB.
       pendingCount = resolvedTeam
-        ? countPendingForProjects(resolvedTeam.projects.map((p) => p.project_id))
+        ? (await aggregateTeamSyncRows(runtimeCache, logger, machineId, resolvedTeam.projects)).pending
         : countPending();
     } catch (err) {
       // Log rather than swallow: a thrown count must not be reported as "0 pending"
@@ -727,22 +745,19 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
     if (!guard.ok) return guard.response;
 
     const resolvedTeam = guard.teamId ? teamRegistry.get(guard.teamId) : null;
-    const requestGroveId = req.requestContext?.groveId ?? null;
-    const servedProjectIds = resolvedTeam
-      ? resolvedTeam.projects
-          .filter((p) => requestGroveId == null || p.grove_id === requestGroveId)
-          .map((p) => p.project_id)
-      : undefined;
-    const homeServesTeam = resolvedTeam ? (servedProjectIds?.length ?? 0) > 0 : true;
-    const localTables = resolvedTeam
-      ? countTeamSyncRows(machineId, servedProjectIds ?? [])
-      : countTeamSyncRows(machineId);
+    // A team is machine-wide: count across every grove that owns one of its
+    // projects, not the ambient request grove. The request may still carry a
+    // grove header, but it must not scope a team-scoped read — otherwise a team
+    // spanning two groves reads a phantom delta for the grove not being viewed.
+    const teamAggregate = resolvedTeam
+      ? await aggregateTeamSyncRows(runtimeCache, logger, machineId, resolvedTeam.projects)
+      : null;
+    const homeServesTeam = resolvedTeam ? (teamAggregate?.grovesServed ?? 0) > 0 : true;
+    const localTables = teamAggregate ? teamAggregate.tables : countTeamSyncRows(machineId);
     const localTotal = Object.values(localTables).reduce((sum, count) => sum + count, 0);
     let pendingCount = 0;
     try {
-      pendingCount = resolvedTeam
-        ? countPendingForProjects(servedProjectIds ?? [])
-        : countPending();
+      pendingCount = teamAggregate ? teamAggregate.pending : countPending();
     } catch {
       pendingCount = 0;
     }

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -1978,6 +1978,7 @@ export async function main(): Promise<void> {
     vaultDir: bootstrapVaultDir,
     machineId,
     logger,
+    runtimeCache,
     getTeamClient: (requestContext) => teamSync.getTeamClient(requestContext),
     getTeamClientForId: (teamId) => teamSync.getTeamClientById(teamId),
     globalPrefix,

--- a/packages/myco/src/daemon/team-sync-counts.ts
+++ b/packages/myco/src/daemon/team-sync-counts.ts
@@ -1,0 +1,95 @@
+/**
+ * Cross-grove aggregation of a team's local sync counts.
+ *
+ * Team membership is machine-wide — a single team can own projects that live
+ * in different groves — but each grove keeps its own SQLite DB. A team-scoped
+ * read (Sync/Status) therefore cannot be answered from one grove-scoped
+ * `getDatabase()` handle: projects in other groves would silently count zero.
+ *
+ * `forEachGrove` pins each grove's DB (and asserts this daemon owns it) for the
+ * duration of the body, so the `getDatabase()`-based count helpers read the
+ * correct file. Groves absent from this daemon's home are never visited, which
+ * is also the served-by boundary: a team project served by a different daemon
+ * contributes nothing here.
+ */
+
+import {
+  countPendingForProjects,
+  countTeamSyncRows,
+  TEAM_SYNC_OBSERVED_TABLES,
+  type TeamSyncObservedTable,
+} from '@myco/db/queries/team-outbox.js';
+import { forEachGrove } from './scope-iteration.js';
+import type { GroveRuntimeCache } from './grove-runtime-cache.js';
+import type { Logger } from './logger.js';
+
+/** A team's project as recorded in the machine-wide team registry. */
+export interface TeamProjectRef {
+  grove_id: string;
+  project_id: string;
+}
+
+export interface TeamSyncRowAggregate {
+  /** Per-table local row counts summed across every served grove. */
+  tables: Record<TeamSyncObservedTable, number>;
+  /** Pending outbox rows summed across every served grove. */
+  pending: number;
+  /**
+   * How many of the team's groves are served by this daemon (present in its
+   * home and successfully visited). Zero means this machine serves none of the
+   * team — the caller renders the "home does not serve this team" state.
+   */
+  grovesServed: number;
+}
+
+function emptyCounts(): Record<TeamSyncObservedTable, number> {
+  const counts = {} as Record<TeamSyncObservedTable, number>;
+  for (const table of TEAM_SYNC_OBSERVED_TABLES) counts[table] = 0;
+  return counts;
+}
+
+/**
+ * Sum a team's local row + pending counts across every grove on this machine
+ * that owns one of the team's projects. The ambient request grove is
+ * irrelevant — the team is the scope.
+ */
+export async function aggregateTeamSyncRows(
+  cache: GroveRuntimeCache,
+  logger: Logger,
+  machineId: string,
+  projects: readonly TeamProjectRef[],
+): Promise<TeamSyncRowAggregate> {
+  const projectsByGrove = new Map<string, string[]>();
+  for (const project of projects) {
+    const list = projectsByGrove.get(project.grove_id) ?? [];
+    list.push(project.project_id);
+    projectsByGrove.set(project.grove_id, list);
+  }
+
+  const tables = emptyCounts();
+  let pending = 0;
+  let grovesServed = 0;
+
+  // Sequential (no `parallel`) so the shared accumulators never interleave.
+  // Teams span a handful of groves; the extra wall-clock is negligible.
+  await forEachGrove(
+    cache,
+    logger,
+    ({ grove }) => {
+      const projectIds = projectsByGrove.get(grove.id);
+      if (!projectIds || projectIds.length === 0) return;
+      grovesServed += 1;
+      // forEachGrove has already pinned this grove's DB via withDatabase, so
+      // the getDatabase()-based helpers below read this grove's file.
+      const groveCounts = countTeamSyncRows(machineId, projectIds);
+      for (const table of TEAM_SYNC_OBSERVED_TABLES) tables[table] += groveCounts[table];
+      pending += countPendingForProjects(projectIds);
+    },
+    {
+      jobName: 'team-sync-summary-counts',
+      shouldVisitGrove: (grove) => projectsByGrove.has(grove.id),
+    },
+  );
+
+  return { tables, pending, grovesServed };
+}

--- a/packages/myco/src/daemon/team-sync-counts.ts
+++ b/packages/myco/src/daemon/team-sync-counts.ts
@@ -49,16 +49,20 @@ function emptyCounts(): Record<TeamSyncObservedTable, number> {
 }
 
 /**
- * Sum a team's local row + pending counts across every grove on this machine
- * that owns one of the team's projects. The ambient request grove is
+ * Visit every grove on this machine that owns one of the team's projects,
+ * running `body` with that grove's project ids inside the grove's pinned DB.
+ * Returns how many such groves were served. The ambient request grove is
  * irrelevant — the team is the scope.
+ *
+ * Sequential (no `parallel`) so a caller's shared accumulators never interleave;
+ * teams span a handful of groves, so the extra wall-clock is negligible.
  */
-export async function aggregateTeamSyncRows(
+async function forEachServedTeamGrove(
   cache: GroveRuntimeCache,
   logger: Logger,
-  machineId: string,
   projects: readonly TeamProjectRef[],
-): Promise<TeamSyncRowAggregate> {
+  body: (groveProjectIds: string[]) => void,
+): Promise<number> {
   const projectsByGrove = new Map<string, string[]>();
   for (const project of projects) {
     const list = projectsByGrove.get(project.grove_id) ?? [];
@@ -66,12 +70,7 @@ export async function aggregateTeamSyncRows(
     projectsByGrove.set(project.grove_id, list);
   }
 
-  const tables = emptyCounts();
-  let pending = 0;
   let grovesServed = 0;
-
-  // Sequential (no `parallel`) so the shared accumulators never interleave.
-  // Teams span a handful of groves; the extra wall-clock is negligible.
   await forEachGrove(
     cache,
     logger,
@@ -80,16 +79,51 @@ export async function aggregateTeamSyncRows(
       if (!projectIds || projectIds.length === 0) return;
       grovesServed += 1;
       // forEachGrove has already pinned this grove's DB via withDatabase, so
-      // the getDatabase()-based helpers below read this grove's file.
-      const groveCounts = countTeamSyncRows(machineId, projectIds);
-      for (const table of TEAM_SYNC_OBSERVED_TABLES) tables[table] += groveCounts[table];
-      pending += countPendingForProjects(projectIds);
+      // the getDatabase()-based helpers in `body` read this grove's file.
+      body(projectIds);
     },
     {
       jobName: 'team-sync-summary-counts',
       shouldVisitGrove: (grove) => projectsByGrove.has(grove.id),
     },
   );
+  return grovesServed;
+}
 
+/**
+ * Sum a team's local row + pending counts across every grove on this machine
+ * that owns one of the team's projects. Used by the Sync tab, which needs the
+ * full per-table breakdown to diff against the cloud.
+ */
+export async function aggregateTeamSyncRows(
+  cache: GroveRuntimeCache,
+  logger: Logger,
+  machineId: string,
+  projects: readonly TeamProjectRef[],
+): Promise<TeamSyncRowAggregate> {
+  const tables = emptyCounts();
+  let pending = 0;
+  const grovesServed = await forEachServedTeamGrove(cache, logger, projects, (projectIds) => {
+    const groveCounts = countTeamSyncRows(machineId, projectIds);
+    for (const table of TEAM_SYNC_OBSERVED_TABLES) tables[table] += groveCounts[table];
+    pending += countPendingForProjects(projectIds);
+  });
   return { tables, pending, grovesServed };
+}
+
+/**
+ * Sum a team's pending outbox rows across every owning grove. Used by the
+ * Status tab, which surfaces only the pending count — this avoids the
+ * per-table COUNT fan-out `aggregateTeamSyncRows` runs for the Sync diff.
+ */
+export async function aggregateTeamPending(
+  cache: GroveRuntimeCache,
+  logger: Logger,
+  projects: readonly TeamProjectRef[],
+): Promise<number> {
+  let pending = 0;
+  await forEachServedTeamGrove(cache, logger, projects, (projectIds) => {
+    pending += countPendingForProjects(projectIds);
+  });
+  return pending;
 }

--- a/tests/daemon/team-sync-counts.test.ts
+++ b/tests/daemon/team-sync-counts.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DaemonLogger } from '@myco/daemon/logger.js';
+import { GroveRuntimeCache } from '@myco/daemon/grove-runtime-cache.js';
+import { aggregateTeamSyncRows } from '@myco/daemon/team-sync-counts.js';
+import { openDatabase } from '@myco/db/client.js';
+import { ensureGroveDatabase } from '@myco/grove/database.js';
+import { resolveGroveDbPath } from '@myco/grove/paths.js';
+import { createGrove, type GroveRecord } from '@myco/grove/registry.js';
+
+const MACHINE_ID = 'machine-test';
+
+/**
+ * Regression coverage for the cross-grove team-count bug: a team is
+ * machine-wide, so its projects can live in different groves — each with its
+ * own SQLite DB. Counting from a single grove-scoped handle undercounts the
+ * others and reads a phantom cloud delta. `aggregateTeamSyncRows` must sum
+ * across exactly the groves that own a team project, honoring project and
+ * machine scoping and skipping non-team groves.
+ */
+describe('aggregateTeamSyncRows', () => {
+  let workDir: string;
+  let mycoHome: string;
+  let previousMycoHome: string | undefined;
+  let logger: DaemonLogger;
+
+  beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'team-sync-counts-'));
+    mycoHome = path.join(workDir, 'home');
+    fs.mkdirSync(mycoHome, { recursive: true });
+    previousMycoHome = process.env.MYCO_HOME;
+    process.env.MYCO_HOME = mycoHome;
+    logger = new DaemonLogger(path.join(workDir, 'logs'), { level: 'error' });
+  });
+
+  afterEach(() => {
+    if (previousMycoHome === undefined) delete process.env.MYCO_HOME;
+    else process.env.MYCO_HOME = previousMycoHome;
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  function createGroveWithDb(name: string): GroveRecord {
+    const grove = createGrove(name, mycoHome);
+    ensureGroveDatabase(grove.id, mycoHome);
+    return grove;
+  }
+
+  /** Seed `count` observed rows into a grove's own DB for (project, machine). */
+  function seedRows(groveId: string, projectId: string, machineId: string, count: number): void {
+    const db = openDatabase(resolveGroveDbPath(groveId, mycoHome));
+    try {
+      const insert = db.prepare(
+        `INSERT INTO knowledge_release_state
+           (project_id, machine_id, identity_key, namespace, record_id, state, confidence, checked_at, created_at)
+         VALUES (?, ?, ?, ?, ?, 'present', 'high', 0, 0)`,
+      );
+      for (let i = 0; i < count; i += 1) {
+        // identity_key is UNIQUE; namespace it by grove/project/machine/index.
+        insert.run(projectId, machineId, `${groveId}:${projectId}:${machineId}:${i}`, 'test', `rec-${i}`);
+      }
+    } finally {
+      db.close();
+    }
+  }
+
+  it('sums a team\'s rows across every owning grove, ignoring other groves/projects/machines', async () => {
+    const groveA = createGroveWithDb('Default');
+    const groveB = createGroveWithDb('OSS');
+    const groveC = createGroveWithDb('Unrelated');
+
+    // Team spans groveA + groveB. groveC is not part of the team.
+    seedRows(groveA.id, 'proj-a', MACHINE_ID, 3);
+    seedRows(groveB.id, 'proj-b', MACHINE_ID, 2);
+    // Decoys that must NOT be counted:
+    seedRows(groveB.id, 'proj-other', MACHINE_ID, 5); // non-team project in a team grove
+    seedRows(groveB.id, 'proj-b', 'other-machine', 4); // team project but different machine
+    seedRows(groveC.id, 'proj-c', MACHINE_ID, 7); // project in a non-team grove
+
+    const cache = new GroveRuntimeCache();
+    try {
+      const result = await aggregateTeamSyncRows(cache, logger, MACHINE_ID, [
+        { grove_id: groveA.id, project_id: 'proj-a' },
+        { grove_id: groveB.id, project_id: 'proj-b' },
+      ]);
+
+      // 3 (groveA/proj-a) + 2 (groveB/proj-b) — decoys excluded.
+      expect(result.tables.knowledge_release_state).toBe(5);
+      expect(result.grovesServed).toBe(2);
+      expect(result.pending).toBe(0);
+    } finally {
+      cache.closeAll();
+    }
+  });
+
+  it('reports grovesServed=0 when this home serves none of the team\'s groves', async () => {
+    createGroveWithDb('Local');
+    const cache = new GroveRuntimeCache();
+    try {
+      const result = await aggregateTeamSyncRows(cache, logger, MACHINE_ID, [
+        { grove_id: 'grove_ffffffffffffffffffffffffffffffff', project_id: 'proj-x' },
+      ]);
+      expect(result.grovesServed).toBe(0);
+      expect(result.tables.knowledge_release_state).toBe(0);
+      expect(result.pending).toBe(0);
+    } finally {
+      cache.closeAll();
+    }
+  });
+});

--- a/tests/daemon/team-sync-counts.test.ts
+++ b/tests/daemon/team-sync-counts.test.ts
@@ -4,7 +4,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { DaemonLogger } from '@myco/daemon/logger.js';
 import { GroveRuntimeCache } from '@myco/daemon/grove-runtime-cache.js';
-import { aggregateTeamSyncRows } from '@myco/daemon/team-sync-counts.js';
+import { aggregateTeamSyncRows, aggregateTeamPending } from '@myco/daemon/team-sync-counts.js';
+import { computeProjectScopedDrift } from '@myco/daemon/api/team-connect.js';
 import { openDatabase } from '@myco/db/client.js';
 import { ensureGroveDatabase } from '@myco/grove/database.js';
 import { resolveGroveDbPath } from '@myco/grove/paths.js';
@@ -65,6 +66,20 @@ describe('aggregateTeamSyncRows', () => {
     }
   }
 
+  /** Seed `count` unsent outbox rows into a grove's DB for a project. */
+  function seedOutbox(groveId: string, projectId: string, count: number): void {
+    const db = openDatabase(resolveGroveDbPath(groveId, mycoHome));
+    try {
+      const insert = db.prepare(
+        `INSERT INTO team_outbox (table_name, row_id, payload, machine_id, project_id, created_at)
+         VALUES ('spores', ?, '{}', ?, ?, 0)`,
+      );
+      for (let i = 0; i < count; i += 1) insert.run(`${groveId}:${projectId}:${i}`, MACHINE_ID, projectId);
+    } finally {
+      db.close();
+    }
+  }
+
   it('sums a team\'s rows across every owning grove, ignoring other groves/projects/machines', async () => {
     const groveA = createGroveWithDb('Default');
     const groveB = createGroveWithDb('OSS');
@@ -104,6 +119,69 @@ describe('aggregateTeamSyncRows', () => {
       expect(result.grovesServed).toBe(0);
       expect(result.tables.knowledge_release_state).toBe(0);
       expect(result.pending).toBe(0);
+    } finally {
+      cache.closeAll();
+    }
+  });
+
+  it('counts only served groves when a team project lives in a grove absent from this home', async () => {
+    const groveA = createGroveWithDb('Default');
+    seedRows(groveA.id, 'proj-a', MACHINE_ID, 5);
+    const cache = new GroveRuntimeCache();
+    try {
+      const result = await aggregateTeamSyncRows(cache, logger, MACHINE_ID, [
+        { grove_id: groveA.id, project_id: 'proj-a' },
+        { grove_id: 'grove_ffffffffffffffffffffffffffffffff', project_id: 'proj-absent' },
+      ]);
+      expect(result.grovesServed).toBe(1);
+      expect(result.tables.knowledge_release_state).toBe(5);
+    } finally {
+      cache.closeAll();
+    }
+  });
+
+  it('yields zero drift for a two-grove team whose cloud received all its rows', async () => {
+    // The regression this fix guards: with grove-scoped local counting, a team
+    // spanning two groves read a phantom positive delta from any single grove.
+    const groveA = createGroveWithDb('Default');
+    const groveB = createGroveWithDb('OSS');
+    seedRows(groveA.id, 'proj-a', MACHINE_ID, 4);
+    seedRows(groveB.id, 'proj-b', MACHINE_ID, 3);
+
+    const cache = new GroveRuntimeCache();
+    try {
+      const local = await aggregateTeamSyncRows(cache, logger, MACHINE_ID, [
+        { grove_id: groveA.id, project_id: 'proj-a' },
+        { grove_id: groveB.id, project_id: 'proj-b' },
+      ]);
+      expect(local.grovesServed).toBe(2);
+      expect(local.tables.knowledge_release_state).toBe(7);
+
+      // Cloud (machine_tables) holds exactly this machine's rows across both
+      // groves. The cross-grove local total must match it → zero drift.
+      const cloud = { ...local.tables };
+      const drift = computeProjectScopedDrift(local.tables, cloud);
+      const totalDelta = drift.reduce((sum, d) => sum + Math.abs(d.delta), 0);
+      expect(totalDelta).toBe(0);
+    } finally {
+      cache.closeAll();
+    }
+  });
+
+  it('sums pending outbox rows across owning groves (pending-only fan-out)', async () => {
+    const groveA = createGroveWithDb('Default');
+    const groveB = createGroveWithDb('OSS');
+    seedOutbox(groveA.id, 'proj-a', 2);
+    seedOutbox(groveB.id, 'proj-b', 3);
+    seedOutbox(groveB.id, 'proj-other', 9); // non-team project — excluded
+
+    const cache = new GroveRuntimeCache();
+    try {
+      const pending = await aggregateTeamPending(cache, logger, [
+        { grove_id: groveA.id, project_id: 'proj-a' },
+        { grove_id: groveB.id, project_id: 'proj-b' },
+      ]);
+      expect(pending).toBe(5);
     } finally {
       cache.closeAll();
     }


### PR DESCRIPTION
## Symptom

A team whose projects span more than one grove showed a phantom positive "cloud delta" on the Sync tab — cloud records appeared higher than local even though sync was healthy and one-way (local → cloud). Concretely, on the `sirkirby-oss` team (2 Default-grove projects + `ten-second-tom` in the OSS grove), the Sync tab under `/g/default` read **+178** — exactly `ten-second-tom`'s row count.

## Root cause

The Team tabs (Sync/Status) are **team-scoped and machine-wide**, but the local counts were scoped to the **ambient request grove**:

- **Local** (`countTeamSyncRows`) was filtered to `project_id IN (team projects where grove_id === requestContext.groveId)`.
- **Cloud** (worker `machine_tables`) is **machine-scoped, grove-agnostic**.

So a team viewed from one grove counted only that grove's projects locally, while the cloud held all of them → the other grove's rows read as cloud-ahead drift. Membership is already machine-wide (a project can be assigned from any grove), so this summary read was the last residual leak of the retired project/grove-as-proxy-for-team model.

Widening the project filter alone is **not** enough: each grove keeps its own SQLite DB, so a project's rows are invisible to an ambient-grove `getDatabase()` handle.

## Fix

New `aggregateTeamSyncRows` / `aggregateTeamPending` (`packages/myco/src/daemon/team-sync-counts.ts`) fan a team's counts out across every grove that owns one of its projects via `forEachGrove` — which pins each grove's DB and **asserts daemon ownership**, so cross-home / cross-daemon leakage is impossible (a grove absent from this daemon's `MYCO_HOME` is simply never visited). `handleSyncSummary` and `handleStatus` now use these instead of the ambient-grove count. `homeServesTeam` becomes "the team has ≥1 project on a grove this daemon serves" (this also fixes an old case where it read true for a team with zero locally-served groves, which could misfire the destructive Rebuild).

`handleStatus` surfaces only the pending count, so it uses a pending-only fan-out rather than the full per-table `COUNT` sweep on every polled refresh.

## Verification

- **Live, against a snapshot of the real production grove DBs:** the new aggregator returns Default-grove **6,533** + OSS-grove **178** = **6,711**, matching the cloud exactly — every per-table count now equals the cloud column, so drift is **0**.
- **Unit + regression tests** (`tests/daemon/team-sync-counts.test.ts`): cross-grove summation with project/machine/grove decoys; a two-grove team whose cloud holds all rows yields **zero drift**; served-vs-absent grove accounting; pending-only aggregation.
- **Full `make build` gate green** (tsc + skills/workers lint + fast unit suite).
- Multi-lens review pass (correctness / completeness / maintainability): no correctness or scoping gaps; maintainability finding (Status over-fetch) folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Folded-in dependency updates

Bundles the three open Dependabot GitHub Actions bumps (CI-only, no code impact); they auto-close once this squash-merges:
- #604 `actions/upload-pages-artifact` 4 → 5
- #603 `actions/checkout` 4 → 7
- #602 `actions/deploy-pages` 4 → 5
