### PR TITLE
fix(agent): harness hygiene sweep — tool annotations + alwaysLoad on vault MCP servers

### DIFF
--- a/packages/myco/src/agent/tools.ts
+++ b/packages/myco/src/agent/tools.ts
@@ -231,9 +231,12 @@ const REPEATED_READ_FAILURE_THRESHOLD = 4;
 
 /**
  * Total number of vault tools defined. Derived from the union of the
- * four tool-group sets above so this constant can never drift from the
+ * seven tool-group sets above so this constant can never drift from the
  * actual factory output — adding a tool to a group bumps the count
  * automatically. Each set is disjoint so the straight sum is correct.
+ * Do not hardcode this number in specs/docs — read VAULT_TOOL_COUNT or
+ * re-derive it; the source of truth drifts every time a tool file gains
+ * an entry.
  */
 export const VAULT_TOOL_COUNT =
   READ_TOOL_NAMES.size +
@@ -673,6 +676,10 @@ export function createVaultToolServer(
     name: 'myco-vault',
     version: getPluginVersion(),
     tools: toSdkMcpToolDefinitions(tools),
+    // Every phase needs its vault tools present starting at turn 1 (phase
+    // prompts reference tool names directly) — don't let the SDK defer
+    // tool schemas behind its tool-search default.
+    alwaysLoad: true,
   });
 }
 
@@ -706,6 +713,7 @@ export function createScopedVaultToolServer(
     name: 'myco-vault',
     version: getPluginVersion(),
     tools: toSdkMcpToolDefinitions(scopedTools),
+    alwaysLoad: true,
   });
 }
 
@@ -724,5 +732,6 @@ export function createMaterializedVaultToolServer(tools: MycoToolDefinition<any>
     name: 'myco-vault',
     version: getPluginVersion(),
     tools: toSdkMcpToolDefinitions(tools),
+    alwaysLoad: true,
   });
 }

--- a/packages/myco/src/agent/tools/canopy-tools.ts
+++ b/packages/myco/src/agent/tools/canopy-tools.ts
@@ -192,7 +192,7 @@ export function createCanopyTools(deps: VaultToolDeps) {
 
       return textResult({ ok: true, description: cleaned });
     },
-    { annotations: {} },
+    { annotations: { idempotentHint: true } },
   );
 
   const canopyListTool = tool(
@@ -245,7 +245,7 @@ export function createCanopyTools(deps: VaultToolDeps) {
       );
       return textResult({ charged });
     },
-    { annotations: {} },
+    { annotations: { idempotentHint: false } },
   );
 
   return [canopyDescribeNext, canopyDescribeWrite, canopyListTool, canopyDescribeCharge];

--- a/packages/myco/src/agent/tools/skill-tools.ts
+++ b/packages/myco/src/agent/tools/skill-tools.ts
@@ -1522,7 +1522,7 @@ export function createSkillTools(deps: VaultToolDeps) {
           return textResult({ error: `Unknown action: ${args.action}` });
       }
     },
-    { annotations: {} },
+    { annotations: { destructiveHint: true, idempotentHint: false } },
   );
 
   const vaultSkillRecords = tool(
@@ -1650,7 +1650,7 @@ export function createSkillTools(deps: VaultToolDeps) {
           return textResult({ error: `Unknown action: ${args.action}` });
       }
     },
-    { annotations: {} },
+    { annotations: { destructiveHint: true, idempotentHint: false } },
   );
 
   const vaultScanSkillContamination = tool(

--- a/tests/agent/harness-properties.test.ts
+++ b/tests/agent/harness-properties.test.ts
@@ -56,6 +56,23 @@ describe('harness properties', () => {
       }
     });
 
+    it('every tool sets at least one annotation hint', () => {
+      // {} annotations are indistinguishable from "never audited". Every
+      // tool must declare at least one hint: read-only tools set
+      // readOnlyHint, write tools set destructive/idempotent/openWorld.
+      for (const t of tools) {
+        const a = t.annotations ?? {};
+        const hasSignal = a.readOnlyHint !== undefined
+          || a.destructiveHint !== undefined
+          || a.idempotentHint !== undefined
+          || a.openWorldHint !== undefined;
+        expect(
+          hasSignal,
+          `Tool "${t.name}" has an empty annotations object — set at least one hint`,
+        ).toBe(true);
+      }
+    });
+
     it('read tools are annotated readOnlyHint: true', () => {
       const readToolNames = [
         'vault_unprocessed', 'vault_batches', 'vault_session_summary_material', 'vault_spores', 'vault_sessions',
@@ -73,7 +90,10 @@ describe('harness properties', () => {
     });
 
     it('destructive tools are annotated destructiveHint: true', () => {
-      const destructiveToolNames = ['vault_resolve_spore', 'vault_mark_processed'];
+      const destructiveToolNames = [
+        'vault_resolve_spore', 'vault_mark_processed',
+        'vault_skill_candidates', 'vault_skill_records',
+      ];
       for (const name of destructiveToolNames) {
         const t = tools.find(tool => tool.name === name);
         expect(t, `Destructive tool "${name}" not found`).toBeDefined();
@@ -101,6 +121,42 @@ describe('harness properties', () => {
           t!.annotations?.idempotentHint,
           `Skill-survey write tool "${name}" must have idempotentHint: false — repeat calls mutate state`,
         ).toBe(false);
+      }
+    });
+
+    it('write tools never carry a fully empty annotations object', () => {
+      // A write tool with {} annotations gives MCP clients zero signal —
+      // it's indistinguishable from an unannotated tool that was simply
+      // never audited. Every write tool must set at least one of
+      // destructiveHint/idempotentHint/openWorldHint. (Myco's runtime
+      // itself currently branches only on readOnlyHint.)
+      const writeToolNames = [
+        'canopy_describe_write', 'canopy_describe_charge',
+        'vault_skill_candidates', 'vault_skill_records',
+      ];
+      for (const name of writeToolNames) {
+        const t = tools.find(tool => tool.name === name);
+        expect(t, `Write tool "${name}" not found`).toBeDefined();
+        const a = t!.annotations ?? {};
+        const hasSignal = a.destructiveHint !== undefined
+          || a.idempotentHint !== undefined
+          || a.openWorldHint !== undefined;
+        expect(
+          hasSignal,
+          `Write tool "${name}" has an empty annotations object — set destructiveHint/idempotentHint/openWorldHint`,
+        ).toBe(true);
+      }
+    });
+
+    it('multi-action tools with a delete action are annotated destructiveHint: true', () => {
+      const deleteCapableToolNames = ['vault_skill_candidates', 'vault_skill_records'];
+      for (const name of deleteCapableToolNames) {
+        const t = tools.find(tool => tool.name === name);
+        expect(t, `Tool "${name}" not found`).toBeDefined();
+        expect(
+          t!.annotations?.destructiveHint,
+          `Tool "${name}" supports a delete action and must have destructiveHint: true`,
+        ).toBe(true);
       }
     });
   });
@@ -269,6 +325,43 @@ describe('harness properties', () => {
         }
       }
       expect(readOnlyCount, 'No readOnly phases found — was the flag removed?').toBeGreaterThan(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Area 5: Vault MCP Server Config
+  // ---------------------------------------------------------------------------
+
+  describe('vault MCP server config', () => {
+    it('every createSdkMcpServer(...) call site sets alwaysLoad: true', () => {
+      // The Claude SDK now connects MCP servers in the background by
+      // default and defers tool schemas behind tool search unless a
+      // server opts out via alwaysLoad. Myco's vault tools must be
+      // present on turn 1 of every phase (phase prompts reference tool
+      // names directly), so every construction site must opt in.
+      const source = readFileSync(
+        resolve(import.meta.dirname, '../../packages/myco/src/agent/tools.ts'),
+        'utf-8',
+      );
+      const callSites = [...source.matchAll(/createSdkMcpServer\s*\(\s*\{[^}]*\}\s*\)/g)];
+      // Cross-check against the raw opening count so a call site whose
+      // options object the regex can't fully parse (e.g. a nested brace)
+      // fails the test instead of silently escaping the alwaysLoad check.
+      // Requiring `(` immediately followed by `{` (whitespace-tolerant)
+      // excludes prose mentions of createSdkMcpServer() in doc comments,
+      // which use empty parens.
+      const callSiteOpenings = (source.match(/createSdkMcpServer\s*\(\s*\{/g) ?? []).length;
+      expect(callSites.length).toBeGreaterThan(0);
+      expect(
+        callSites.length,
+        'a createSdkMcpServer({...}) call site did not fully match the static-shape regex (nested braces in the options object?) — fix the regex so every call site is verified',
+      ).toBe(callSiteOpenings);
+      for (const [callSite] of callSites) {
+        expect(
+          callSite,
+          `createSdkMcpServer(...) call site missing alwaysLoad: true:\n${callSite}`,
+        ).toMatch(/alwaysLoad:\s*true/);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Plan #1 of the Agent Harness SDK Alignment sequence (6 plans). Hygiene/audit sweep of the agent-harness tool surface — closes the "Now-2" (tool-annotation audit) and "§6.1" (alwaysLoad / MCP-config) items from the 2026-07-01 SDK alignment spec.

- **Annotate the 4 vault tools still carrying empty `{}` MCP annotations**: `canopy_describe_write` (`idempotentHint: true` — converging update), `canopy_describe_charge` (`idempotentHint: false` — each call burns retry budget), and the delete-capable multi-action `vault_skill_candidates` / `vault_skill_records` (`destructiveHint: true, idempotentHint: false` — worst-case action annotation). Pure metadata today: verified the runtime branches only on `readOnlyHint`, so zero behavior change.
- **`alwaysLoad: true` on all three `createSdkMcpServer` call sites** so vault tool schemas are never deferred behind the SDK's tool-search default (`defer_loading: false` equivalent). Phase prompts reference tool names directly, so schemas must be present at turn 1; the real-world effect concentrates in the 5 non-phased tasks that use the full unscoped tool surface.
- **Property-test hardening** in `tests/agent/harness-properties.test.ts`: a generalized every-tool-sets-at-least-one-hint assertion (the empty-`{}` class can never silently recur), destructive-allowlist coverage for the two skill tools, and a fail-loud static-shape check that every current and future `createSdkMcpServer` call site opts into `alwaysLoad` (with a call-site-count cross-check so a regex-unparseable site fails instead of silently escaping).

Scope-drift notes (vs the written plan): `vault_report` was left untouched (already annotated `readOnlyHint: true` upstream in 144a7a1d with its own codifying test), and no task-YAML edit was needed (the planned `inventory`-phase tool removal also landed in 144a7a1d). Two spec checks came back clean with no code change: no retired model-ID strings outside inert test fixtures, and `openai@^6.45.0` satisfies the real `^6.42.0` JS floor.

Advisory (deliberately not changed): to spec-conformant external MCP clients, `canopy_describe_write`'s unset `destructiveHint` defaults to *true*; that is conservative-safe for an overwriting update and no Myco consumer reads it.

## Test plan

- [x] `npm test -- tests/agent/harness-properties.test.ts` — 63 pass / 0 fail (new assertions verified to fail before each fix)
- [x] Full `npm test` — green across all groups
- [x] `make build` — lint + fast tests + binary + UI bundle green
- [x] Multi-agent review: per-task spec+quality reviews, whole-branch final review, and a dimensions pass (security/perf/quality-debt) — all findings fixed on-branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)