### PR TITLE
feat(agent): schema-validated structured output for orchestrator phase directives

### DIFF
--- a/packages/myco/src/agent/harness/claude.ts
+++ b/packages/myco/src/agent/harness/claude.ts
@@ -82,7 +82,10 @@ function suppressEffortLeakForLocalProvider(
 }
 
 /**
- * Drain a Claude SDK message stream into a final text + usage tally.
+ * Drain a Claude SDK message stream into a final text + usage tally,
+ * capturing the provider-validated `structured_output` (when the caller
+ * requested one via `outputFormat` and the terminal `result` message
+ * carries it) alongside the plain-text result.
  *
  * Both `execute` and `openScope.run` produce identical message-stream
  * shapes — only their `query()` options differ (resume + persistSession in
@@ -95,13 +98,14 @@ function suppressEffortLeakForLocalProvider(
 async function consumeClaudeMessageStream(
   messageStream: AsyncIterable<SDKMessage>,
   options: { localProvider: boolean; sessionRef?: string },
-): Promise<{ finalText: string; turnsUsed: number; usage: HarnessExecuteResult['usage'] }> {
+): Promise<{ finalText: string; turnsUsed: number; usage: HarnessExecuteResult['usage']; structuredOutput?: unknown }> {
   let finalText = '';
   let turnsUsed = 0;
   let inputTokens = 0;
   let outputTokens = 0;
   let costUsd = 0;
   let assistantMessages = 0;
+  let structuredOutput: unknown;
 
   const buildUsage = () => ({
     requests: turnsUsed,
@@ -132,6 +136,7 @@ async function consumeClaudeMessageStream(
         costUsd = options.localProvider ? 0 : (message.total_cost_usd ?? 0);
         if (message.subtype === 'success') {
           finalText = message.result;
+          structuredOutput = message.structured_output;
         }
       }
       await new Promise<void>((resolve) => setImmediate(resolve));
@@ -160,7 +165,7 @@ async function consumeClaudeMessageStream(
     throw err;
   }
 
-  return { finalText, turnsUsed, usage: buildUsage() };
+  return { finalText, turnsUsed, usage: buildUsage(), structuredOutput };
 }
 
 function buildToolServer(input: { toolSurface: HarnessExecuteInput['toolSurface'] }) {
@@ -209,7 +214,9 @@ export class ClaudeSdkHarness implements AgentHarness {
   readonly id = HARNESS_CLAUDE_SDK;
 
   supports(capability: HarnessCapability): boolean {
-    return capability === 'supportsSessionResume' || capability === 'supportsMcp';
+    return capability === 'supportsSessionResume'
+      || capability === 'supportsMcp'
+      || capability === 'structuredOutput';
   }
 
   classifyError(error: unknown, context?: { attemptedResume?: boolean }) {
@@ -238,6 +245,7 @@ export class ClaudeSdkHarness implements AgentHarness {
       sessionRef: input.sessionRef,
       persistSession: true,
       abortController: input.abortController,
+      outputSchema: input.outputSchema,
     });
     return { ...drained, sessionRef: input.sessionRef };
   }
@@ -285,6 +293,7 @@ interface ClaudeRunOptions {
   sessionRef?: string;
   persistSession: boolean;
   abortController?: AbortController;
+  outputSchema?: HarnessExecuteInput['outputSchema'];
 }
 
 /** Narrow an ExecuteInput down to the setup-only fields shared with HarnessScopeSetup. */
@@ -394,6 +403,7 @@ async function runClaudeQuery(
       ...(prepared.claudeCodeExecutable ? { pathToClaudeCodeExecutable: prepared.claudeCodeExecutable } : {}),
       ...(options.sessionRef ? { sessionId: options.sessionRef } : {}),
       ...(options.abortController ? { abortController: options.abortController } : {}),
+      ...(options.outputSchema ? { outputFormat: { type: 'json_schema' as const, schema: options.outputSchema.schema } } : {}),
     },
   });
 

--- a/packages/myco/src/agent/harness/openai.ts
+++ b/packages/myco/src/agent/harness/openai.ts
@@ -5,6 +5,7 @@ import {
   Runner,
   OpenAIProvider,
   type AgentInputItem,
+  type JsonSchemaDefinition,
   type ModelProvider,
   type Session,
 } from '@openai/agents';
@@ -302,6 +303,39 @@ function createProvider(provider: ProviderConfig | undefined): OpenAIProvider {
 }
 
 /**
+ * Strip `null`-valued object entries produced by OpenAI strict-mode's
+ * widened-optional-field dialect.
+ *
+ * `toStrictJsonObjectSchema()` widens every optional property's type to
+ * `[type, 'null']` so strict mode's "every key required" rule doesn't
+ * change Myco's own optionality semantics — the model emits `null` for a
+ * field Myco's schema author intended as absent. The `@openai/agents` SDK
+ * does not strip these nulls from `finalOutput` (its own
+ * `stripStrictNullsForJsonSchema` applies only to tool inputs), so without
+ * this helper a caller like `applyDirectives()` in orchestrator.ts sees
+ * `maxTurns: null` instead of `maxTurns: undefined` — and
+ * `directive.maxTurns !== undefined` passes, letting `Math.min(null, ceiling)`
+ * coerce to 0 and zero out the phase's turn budget.
+ *
+ * Recurses into nested objects and arrays; leaves non-object, non-null
+ * values untouched.
+ */
+export function stripStrictNulls(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => stripStrictNulls(item));
+  }
+  if (value !== null && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, entryValue] of Object.entries(value as Record<string, unknown>)) {
+      if (entryValue === null) continue;
+      result[key] = stripStrictNulls(entryValue);
+    }
+    return result;
+  }
+  return value;
+}
+
+/**
  * Drive a single SDK turn-loop with a configured runner+agent. Used by
  * both `OpenAIAgentsHarness.execute` (which feeds in any prior session
  * data + sessionRef) and `scope.run` (always a fresh session). Centralized
@@ -311,13 +345,14 @@ function createProvider(provider: ProviderConfig | undefined): OpenAIProvider {
  */
 async function runOpenAIAgent(
   runner: Runner,
-  agent: Agent,
+  agent: Agent<unknown, any>,
   prompt: string,
   options: {
     maxTurns?: number;
     sessionRef: string;
     sessionData: AgentInputItem[];
     abortController?: AbortController;
+    hasOutputSchema?: boolean;
   },
 ): Promise<HarnessExecuteResult> {
   let persistedItems: AgentInputItem[] = [...options.sessionData];
@@ -325,16 +360,31 @@ async function runOpenAIAgent(
     persistedItems = [...items];
   });
 
-  let result;
+  let usage: RuntimeUsage;
+  let finalText: string;
+  let turnsUsed: number;
+  let lastResponseId: string | undefined;
+  let structuredOutput: unknown;
   try {
-    result = await runner.run(agent, prompt, {
+    const result = await runner.run(agent, prompt, {
       maxTurns: options.maxTurns,
       session,
       ...(options.abortController ? { signal: options.abortController.signal } : {}),
     });
+    // `result.finalOutput` is a getter that re-runs JSON.parse on every
+    // access — capture it once here, inside the try, so a parse failure
+    // (SyntaxError) gets wrapped as a HarnessExecutionError like any other
+    // run failure instead of escaping raw from the return statement below.
+    const finalOutput = result.finalOutput;
+    usage = toOpenAIUsage(result.rawResponses);
+    usage.providerData = { lastResponseId: result.lastResponseId };
+    finalText = typeof finalOutput === 'string' ? finalOutput : JSON.stringify(finalOutput ?? '');
+    turnsUsed = result.rawResponses.length;
+    lastResponseId = result.lastResponseId;
+    structuredOutput = options.hasOutputSchema ? stripStrictNulls(finalOutput) : undefined;
   } catch (err) {
     const partialRaw = extractPartialRawResponses(err);
-    const usage = partialRaw ? toOpenAIUsage(partialRaw) : ({} as RuntimeUsage);
+    const partialUsage = partialRaw ? toOpenAIUsage(partialRaw) : ({} as RuntimeUsage);
     const message = err instanceof Error ? err.message : String(err);
     // The OpenAI Agents SDK throws MaxTurnsExceededError when maxTurns is
     // binding; the constructor name is the most reliable signal. Fall back
@@ -343,23 +393,19 @@ async function runOpenAIAgent(
     const kind = classifyHarnessErrorKind(message, errName);
     throw new HarnessExecutionError(
       message,
-      { usage, sessionRef: options.sessionRef, sessionData: persistedItems, kind },
+      { usage: partialUsage, sessionRef: options.sessionRef, sessionData: persistedItems, kind },
       { cause: err instanceof Error ? err : undefined },
     );
   }
 
-  const usage = toOpenAIUsage(result.rawResponses);
-  usage.providerData = { lastResponseId: result.lastResponseId };
-
   return {
-    finalText: typeof result.finalOutput === 'string'
-      ? result.finalOutput
-      : JSON.stringify(result.finalOutput ?? ''),
-    turnsUsed: result.rawResponses.length,
+    finalText,
+    turnsUsed,
     usage,
     sessionRef: options.sessionRef,
     sessionData: persistedItems,
-    rawRuntimeMetadata: { lastResponseId: result.lastResponseId },
+    rawRuntimeMetadata: { lastResponseId },
+    structuredOutput,
   };
 }
 
@@ -380,7 +426,9 @@ export class OpenAIAgentsHarness implements AgentHarness {
   constructor(private readonly testOverrides: OpenAIAgentsHarnessTestOverrides = {}) {}
 
   supports(capability: HarnessCapability): boolean {
-    return capability === 'supportsSessionResume' || capability === 'supportsMcp';
+    return capability === 'supportsSessionResume'
+      || capability === 'supportsMcp'
+      || capability === 'structuredOutput';
   }
 
   classifyError(error: unknown) {
@@ -398,13 +446,14 @@ export class OpenAIAgentsHarness implements AgentHarness {
       toolSurface: input.toolSurface,
       logger: input.logger,
     };
-    const prepared = await prepareOpenAIRun(setup, this.testOverrides);
+    const prepared = await prepareOpenAIRun(setup, this.testOverrides, input.outputSchema);
     try {
       return await runOpenAIAgent(prepared.runner, prepared.agent, input.prompt, {
         maxTurns: input.maxTurns,
         sessionRef: input.sessionRef ?? crypto.randomUUID(),
         sessionData: Array.isArray(input.sessionData) ? (input.sessionData as AgentInputItem[]) : [],
         abortController: input.abortController,
+        hasOutputSchema: Boolean(input.outputSchema),
       });
     } finally {
       await prepared.mcpServer.close();
@@ -434,6 +483,56 @@ export class OpenAIAgentsHarness implements AgentHarness {
 }
 
 /**
+ * Convert a Myco-authored JSON Schema (optional properties allowed) into
+ * OpenAI's strict JsonObjectSchema dialect: every property listed in
+ * `required`, with previously-optional properties widened to a nullable
+ * union type (`[type, 'null']`) so the strict-mode contract (every key
+ * required) doesn't change the schema's actual optionality semantics —
+ * the model can still emit `null` for a field Myco's own code treats as
+ * optional. `additionalProperties: false` is preserved at every object
+ * level (already present on Myco's own schemas; asserted here rather than
+ * injected, since a schema without it is a bug in the caller).
+ *
+ * Recurses into nested object schemas (e.g., `phases.items`) so multi-
+ * level schemas like ORCHESTRATOR_PLAN_JSON_SCHEMA convert correctly.
+ */
+export function toStrictJsonObjectSchema(schema: Record<string, unknown>): Record<string, unknown> {
+  if (schema['type'] !== 'object' || typeof schema['properties'] !== 'object' || schema['properties'] === null) {
+    return schema;
+  }
+  const properties = schema['properties'] as Record<string, Record<string, unknown>>;
+  const originalRequired = new Set(Array.isArray(schema['required']) ? (schema['required'] as string[]) : []);
+  const strictProperties: Record<string, unknown> = {};
+
+  for (const [key, propSchema] of Object.entries(properties)) {
+    let converted = propSchema;
+    if (propSchema['type'] === 'object') {
+      converted = toStrictJsonObjectSchema(propSchema);
+    } else if (propSchema['type'] === 'array' && typeof propSchema['items'] === 'object' && propSchema['items'] !== null) {
+      converted = { ...propSchema, items: toStrictJsonObjectSchema(propSchema['items'] as Record<string, unknown>) };
+    }
+    if (!originalRequired.has(key)) {
+      const baseType = converted['type'];
+      if (baseType === undefined) {
+        throw new Error(
+          `toStrictJsonObjectSchema: optional property "${key}" has no "type" key — ` +
+            'enum/anyOf/$ref-shaped schemas are not supported for strict-mode widening.',
+        );
+      }
+      converted = { ...converted, type: [baseType, 'null'] };
+    }
+    strictProperties[key] = converted;
+  }
+
+  return {
+    ...schema,
+    properties: strictProperties,
+    required: Object.keys(properties),
+    additionalProperties: false,
+  };
+}
+
+/**
  * Build the per-setup SDK machinery: connect the MCP server, construct
  * the Agent + Runner pair. Both `execute` (single-shot, runs once and
  * closes) and `openScope` (long-lived, scope.run() called N times) share
@@ -442,8 +541,9 @@ export class OpenAIAgentsHarness implements AgentHarness {
 async function prepareOpenAIRun(
   setup: HarnessScopeSetup,
   testOverrides: OpenAIAgentsHarnessTestOverrides = {},
+  outputSchema?: HarnessExecuteInput['outputSchema'],
 ): Promise<{
-  agent: Agent;
+  agent: Agent<unknown, any>;
   runner: Runner;
   mcpServer: ReturnType<typeof createLocalVaultMcpServer>;
 }> {
@@ -455,6 +555,14 @@ async function prepareOpenAIRun(
     instructions: setup.systemPrompt ?? 'You are the Myco agent harness.',
     model: preparedExecution.model,
     mcpServers: [mcpServer],
+    ...(outputSchema ? {
+      outputType: {
+        type: 'json_schema',
+        name: outputSchema.name,
+        strict: true,
+        schema: toStrictJsonObjectSchema(outputSchema.schema),
+      } as JsonSchemaDefinition,
+    } : {}),
   });
   const runner = new Runner({
     modelProvider: testOverrides.modelProvider ?? createProvider(preparedExecution.provider),

--- a/packages/myco/src/agent/harness/types.ts
+++ b/packages/myco/src/agent/harness/types.ts
@@ -5,7 +5,8 @@ import type { MycoRequestContext } from '@myco/grove/request-context.js';
 
 export type HarnessCapability =
   | 'supportsSessionResume'
-  | 'supportsMcp';
+  | 'supportsMcp'
+  | 'structuredOutput';
 
 export interface HarnessToolSurface {
   agentId: string;
@@ -52,6 +53,21 @@ export interface HarnessExecuteInput {
   abortController?: AbortController;
   /** Optional logger for harness-level debug diagnostics. */
   logger?: RunLogger;
+  /**
+   * Optional structured-output request. When present AND the resolved
+   * harness's supports('structuredOutput') is true, the harness must
+   * request schema-validated output from the underlying provider and
+   * return the validated object via HarnessExecuteResult.structuredOutput
+   * instead of (or in addition to) finalText. Callers MUST still handle
+   * a missing structuredOutput on the result (harness didn't support it,
+   * or the provider's schema validation failed after retries) — never
+   * assume presence.
+   */
+  outputSchema?: {
+    /** Stable name for the schema — required by OpenAI's JsonSchemaDefinition; ignored by Claude. */
+    name: string;
+    schema: Record<string, unknown>;
+  };
 }
 
 export interface HarnessExecuteResult {
@@ -61,6 +77,13 @@ export interface HarnessExecuteResult {
   sessionRef?: string;
   sessionData?: unknown;
   rawRuntimeMetadata?: Record<string, unknown>;
+  /**
+   * Present only when the harness both supports 'structuredOutput' and
+   * the caller passed HarnessExecuteInput.outputSchema. Already validated
+   * against the requested schema by the underlying provider — callers on
+   * this path skip extractJson()/parse-and-hope entirely.
+   */
+  structuredOutput?: unknown;
 }
 
 export interface AgentHarness {

--- a/packages/myco/src/agent/orchestrator.ts
+++ b/packages/myco/src/agent/orchestrator.ts
@@ -192,6 +192,109 @@ export function parseOrchestratorPlan(
 }
 
 /**
+ * JSON Schema for OrchestratorPlan, fed to whichever harness supports
+ * native structured output (see HarnessCapability 'structuredOutput' in
+ * harness/types.ts). Mirrors OrchestratorPlan/OrchestratorPhaseDirective
+ * in types.ts exactly — if those interfaces change, this schema must
+ * change with them (see the schema-shape regression test in
+ * tests/agent/orchestrator.test.ts).
+ */
+export const ORCHESTRATOR_PLAN_JSON_SCHEMA = {
+  type: 'object',
+  properties: {
+    phases: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          skip: { type: 'boolean' },
+          skipReason: { type: 'string' },
+          maxTurns: { type: 'integer' },
+          contextNotes: { type: 'string' },
+        },
+        required: ['name', 'skip'],
+        additionalProperties: false,
+      },
+    },
+    reasoning: { type: 'string' },
+  },
+  required: ['phases', 'reasoning'],
+  additionalProperties: false,
+} as const satisfies Record<string, unknown>;
+
+/**
+ * Build an OrchestratorPlan from a harness's already-schema-validated
+ * structured output. Skips extractJson()/parse-and-hope entirely — the
+ * provider already validated the shape against ORCHESTRATOR_PLAN_JSON_SCHEMA.
+ * Still defends against a provider returning a technically-valid-but-
+ * wrong-shape value (defensive, not expected in practice given
+ * additionalProperties: false) by falling back to buildRunAllPlan() via
+ * the same isOrchestratorPlanShape() guard the text path uses.
+ *
+ * Never throws.
+ *
+ * @param structuredOutput - Already-parsed value from HarnessExecuteResult.structuredOutput.
+ * @param phases            - Phase definitions; used to construct the fallback plan.
+ * @param logger             - Optional logger; receives a warning on shape mismatch.
+ * @returns A valid OrchestratorPlan.
+ */
+export function planFromStructuredOutput(
+  structuredOutput: unknown,
+  phases: PhaseDefinition[],
+  logger?: RunLogger,
+): OrchestratorPlan {
+  if (!isOrchestratorPlanShape(structuredOutput)) {
+    logger?.warn(
+      'agent.orchestrator.structured-output-shape-mismatch',
+      'Structured output did not match OrchestratorPlan shape',
+      { received: typeof structuredOutput },
+    );
+    return buildRunAllPlan(phases, FALLBACK_REASONING_MISSING_PHASES);
+  }
+  return dropNullDirectiveFields(structuredOutput);
+}
+
+/**
+ * Defense-in-depth against a harness that forgot to strip OpenAI strict-
+ * mode's widened-optional-field nulls (see `stripStrictNulls` in
+ * harness/openai.ts, the primary fix). This function is the one place in
+ * this dialect-agnostic module allowed to be null-robust — `applyDirectives`
+ * itself stays untouched and keeps its `!== undefined` guard, since a
+ * conforming harness never emits `null` here in the first place.
+ *
+ * Drops a `null` value for `skipReason`/`maxTurns`/`contextNotes` (and,
+ * defensively, `skip` per directive and the plan's own `reasoning`, though
+ * the shape guard already requires those to be present) so a stray `null`
+ * can never reach `applyDirectives`'s `!== undefined` check and coerce a
+ * turn budget to 0. Operates on the raw (possibly null-bearing) value —
+ * the `OrchestratorPlan` type describes the intended shape, not what a
+ * misbehaving harness might actually hand back.
+ */
+function dropNullDirectiveFields(plan: OrchestratorPlan): OrchestratorPlan {
+  const raw = plan as unknown as {
+    phases: Array<Record<string, unknown>>;
+    reasoning: unknown;
+  };
+  const cleanedPhases = raw.phases.map((directive) => {
+    const cleaned: Record<string, unknown> = { ...directive };
+    for (const key of ['skip', 'skipReason', 'maxTurns', 'contextNotes']) {
+      if (cleaned[key] === null) {
+        delete cleaned[key];
+      }
+    }
+    return cleaned as unknown as OrchestratorPhaseDirective;
+  });
+  const cleanedReasoning = raw.reasoning === null ? undefined : raw.reasoning;
+
+  return {
+    ...plan,
+    phases: cleanedPhases,
+    ...(cleanedReasoning !== undefined ? { reasoning: cleanedReasoning as string } : {}),
+  };
+}
+
+/**
  * Apply orchestrator directives to a set of phase definitions.
  *
  * For each phase:

--- a/packages/myco/src/agent/phase-loop.ts
+++ b/packages/myco/src/agent/phase-loop.ts
@@ -19,7 +19,9 @@ import { errorMessage as toErrorMessage } from '@myco/utils/error-message.js';
 import {
   composeOrchestratorPrompt,
   parseOrchestratorPlan,
+  planFromStructuredOutput,
   applyDirectives,
+  ORCHESTRATOR_PLAN_JSON_SCHEMA,
   DEFAULT_ORCHESTRATOR_MAX_TURNS,
 } from './orchestrator.js';
 import { executeContextQueries } from './context-queries.js';
@@ -637,7 +639,8 @@ export async function executePhasedQuery(
     );
     const orchestratorMaxTurns = config.orchestrator.maxTurns ?? DEFAULT_ORCHESTRATOR_MAX_TURNS;
     const harness = getAgentHarness(config.harness);
-    const planResponse = await harness.execute({
+    const supportsStructuredOutput = harness.supports('structuredOutput');
+    const orchestratorExecuteInput = {
       prompt: orchestratorPrompt,
       model: orchestratorModel,
       maxTurns: orchestratorMaxTurns,
@@ -653,9 +656,46 @@ export async function executePhasedQuery(
       },
       abortController: ctx.abortController,
       logger: ctx.options?.logger,
-    });
+    };
 
-    const plan = parseOrchestratorPlan(planResponse.finalText, phases, ctx.options?.logger);
+    let planResponse;
+    if (supportsStructuredOutput) {
+      try {
+        planResponse = await harness.execute({
+          ...orchestratorExecuteInput,
+          outputSchema: { name: 'orchestrator_plan', schema: ORCHESTRATOR_PLAN_JSON_SCHEMA },
+        });
+        if (planResponse.structuredOutput === undefined) {
+          // The call succeeded (no throw) but the provider's structured-output
+          // validation failed after its own internal retries — e.g. Claude's
+          // error_max_structured_output_retries subtype, which yields an empty
+          // finalText and no structured_output on the result message. This is
+          // NOT the same path as the catch below (which never had outputSchema
+          // attached on its retry, so it can't double-warn here) — surface it
+          // so operators can see the schema'd call quietly degraded to the
+          // text-parse fallback.
+          ctx.options?.logger?.warn(
+            'agent.orchestrator.structured-output-missing',
+            'Orchestrator structured-output call succeeded but returned no structuredOutput — falling back to text parsing',
+            { runId },
+          );
+        }
+      } catch (err) {
+        if (ctx.abortController?.signal.aborted) throw err;
+        ctx.options?.logger?.warn(
+          'agent.orchestrator.structured-output-failed',
+          'Orchestrator structured-output request failed — retrying without outputSchema',
+          { runId, error: toErrorMessage(err) },
+        );
+        planResponse = await harness.execute(orchestratorExecuteInput);
+      }
+    } else {
+      planResponse = await harness.execute(orchestratorExecuteInput);
+    }
+
+    const plan = planResponse.structuredOutput !== undefined
+      ? planFromStructuredOutput(planResponse.structuredOutput, phases, ctx.options?.logger)
+      : parseOrchestratorPlan(planResponse.finalText, phases, ctx.options?.logger);
     effectivePhases = applyDirectives(phases, plan.phases, ctx.options?.logger);
     ctx.options?.logger?.debug('agent.orchestrator.plan', 'Orchestrator plan applied', {
       runId,

--- a/tests/agent/harness/openai-structured-output.test.ts
+++ b/tests/agent/harness/openai-structured-output.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for OpenAIAgentsHarness structured-output support:
+ *   - toStrictJsonObjectSchema() converts an optional-fields schema into
+ *     OpenAI's strict JsonObjectSchema shape (every field required,
+ *     nullable types for the previously-optional ones), and rejects
+ *     type-less property schemas it can't safely widen.
+ *   - stripStrictNulls() removes null-valued keys the strict-mode dialect
+ *     forces the model to emit for widened-optional fields.
+ *   - execute() attaches outputType to the constructed Agent when
+ *     outputSchema is passed, and populates structuredOutput on the result
+ *     with strict-mode nulls stripped.
+ *   - openScope() never threads outputSchema (map-phase must be unaffected).
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { Agent, Runner } from '@openai/agents';
+import {
+  OpenAIAgentsHarness,
+  toStrictJsonObjectSchema,
+  stripStrictNulls,
+} from '@myco/agent/harness/openai.js';
+import { ORCHESTRATOR_PLAN_JSON_SCHEMA } from '@myco/agent/orchestrator.js';
+
+describe('toStrictJsonObjectSchema', () => {
+  it('lists every property in required, including previously-optional ones', () => {
+    const strict = toStrictJsonObjectSchema(ORCHESTRATOR_PLAN_JSON_SCHEMA as Record<string, unknown>);
+    expect((strict as any).required.sort()).toEqual(['phases', 'reasoning'].sort());
+    const itemsRequired = (strict as any).properties.phases.items.required;
+    expect(itemsRequired.sort()).toEqual(['contextNotes', 'maxTurns', 'name', 'skip', 'skipReason'].sort());
+  });
+
+  it('makes previously-optional fields nullable', () => {
+    const strict = toStrictJsonObjectSchema(ORCHESTRATOR_PLAN_JSON_SCHEMA as Record<string, unknown>);
+    const props = (strict as any).properties.phases.items.properties;
+    expect(props.skipReason.type).toEqual(['string', 'null']);
+    expect(props.maxTurns.type).toEqual(['integer', 'null']);
+    expect(props.contextNotes.type).toEqual(['string', 'null']);
+    // Fields that were already required stay as-is.
+    expect(props.name.type).toBe('string');
+    expect(props.skip.type).toBe('boolean');
+  });
+
+  it('preserves additionalProperties: false at every object level', () => {
+    const strict = toStrictJsonObjectSchema(ORCHESTRATOR_PLAN_JSON_SCHEMA as Record<string, unknown>);
+    expect((strict as any).additionalProperties).toBe(false);
+    expect((strict as any).properties.phases.items.additionalProperties).toBe(false);
+  });
+
+  it('throws when an optional property has no "type" key (enum/anyOf/$ref shapes)', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        tier: { enum: ['gold', 'silver', 'bronze'] },
+      },
+      required: ['name'],
+      additionalProperties: false,
+    };
+    expect(() => toStrictJsonObjectSchema(schema)).toThrow(/tier/);
+  });
+});
+
+describe('stripStrictNulls', () => {
+  it('drops null-valued object entries but keeps non-null ones', () => {
+    const input = { name: 'extract', skip: false, skipReason: null, maxTurns: null, contextNotes: null };
+    expect(stripStrictNulls(input)).toEqual({ name: 'extract', skip: false });
+  });
+
+  it('recurses into nested objects and arrays', () => {
+    const input = {
+      phases: [
+        { name: 'extract', skip: false, skipReason: null, maxTurns: null, contextNotes: null },
+        { name: 'graph', skip: true, skipReason: 'done', maxTurns: 5, contextNotes: null },
+      ],
+      reasoning: 'ok',
+    };
+    expect(stripStrictNulls(input)).toEqual({
+      phases: [
+        { name: 'extract', skip: false },
+        { name: 'graph', skip: true, skipReason: 'done', maxTurns: 5 },
+      ],
+      reasoning: 'ok',
+    });
+  });
+
+  it('leaves non-object, non-null values untouched', () => {
+    expect(stripStrictNulls('text')).toBe('text');
+    expect(stripStrictNulls(42)).toBe(42);
+    expect(stripStrictNulls(true)).toBe(true);
+    expect(stripStrictNulls(null)).toBe(null);
+  });
+});
+
+describe('OpenAIAgentsHarness.supports', () => {
+  it('reports structuredOutput support', () => {
+    const harness = new OpenAIAgentsHarness();
+    expect(harness.supports('structuredOutput')).toBe(true);
+  });
+});
+
+describe('OpenAIAgentsHarness structured output wiring', () => {
+  it('attaches outputType to the constructed Agent when outputSchema is provided', async () => {
+    let capturedAgent: Agent | undefined;
+    const stubModelProvider = {
+      async getModel() {
+        return {
+          async getResponse() {
+            return {
+              output: [{ type: 'output_text', text: '{"phases":[],"reasoning":"ok"}' }],
+              usage: { requests: 1, inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+            };
+          },
+        };
+      },
+    } as any;
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider });
+    const originalRun = (await import('@openai/agents')).Runner.prototype.run;
+    (await import('@openai/agents')).Runner.prototype.run = async function (agent: Agent, ...rest: unknown[]) {
+      capturedAgent = agent;
+      return originalRun.apply(this, [agent, ...rest] as never);
+    } as typeof originalRun;
+    try {
+      await harness.execute({
+        prompt: 'plan the phases',
+        model: 'gpt-5.4-mini',
+        toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+        outputSchema: { name: 'orchestrator_plan', schema: { type: 'object', properties: {}, required: [], additionalProperties: false } },
+      });
+    } catch {
+      // The stub model's raw output won't satisfy the full Runner
+      // contract in every SDK version — this test only asserts on the
+      // Agent construction, not on a successful run.
+    } finally {
+      (await import('@openai/agents')).Runner.prototype.run = originalRun;
+    }
+    expect(capturedAgent?.outputType).toEqual({
+      type: 'json_schema',
+      name: 'orchestrator_plan',
+      strict: true,
+      schema: { type: 'object', properties: {}, required: [], additionalProperties: false },
+    });
+  });
+
+  it('omits outputType when no outputSchema is provided', async () => {
+    let capturedAgent: Agent | undefined;
+    const stubModelProvider = {
+      async getModel() {
+        return {
+          async getResponse() {
+            return {
+              output: [{ type: 'output_text', text: 'plain text response' }],
+              usage: { requests: 1, inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+            };
+          },
+        };
+      },
+    } as any;
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider });
+    const originalRun = (await import('@openai/agents')).Runner.prototype.run;
+    (await import('@openai/agents')).Runner.prototype.run = async function (agent: Agent, ...rest: unknown[]) {
+      capturedAgent = agent;
+      return originalRun.apply(this, [agent, ...rest] as never);
+    } as typeof originalRun;
+    try {
+      await harness.execute({
+        prompt: 'do something',
+        model: 'gpt-5.4-mini',
+        toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+      });
+    } catch {
+      // Same tolerance as above — only asserting on Agent construction.
+    } finally {
+      (await import('@openai/agents')).Runner.prototype.run = originalRun;
+    }
+    // The installed @openai/agents-core SDK defaults Agent.outputType to the
+    // literal 'text' (see agent.js: `outputType = 'text'`), never `undefined`
+    // — that's the SDK's own sentinel for "no structured output requested."
+    expect(capturedAgent?.outputType).toBe('text');
+  });
+
+  it('openScope() never threads outputSchema onto the constructed Agent', async () => {
+    let capturedAgent: Agent | undefined;
+    const stubModelProvider = {
+      async getModel() {
+        return {
+          async getResponse() {
+            return {
+              output: [{ type: 'output_text', text: 'plain text response' }],
+              usage: { requests: 1, inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+            };
+          },
+        };
+      },
+    } as any;
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider });
+    const scope = await harness.openScope({
+      model: 'gpt-5.4-mini',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    });
+    const originalRun = (await import('@openai/agents')).Runner.prototype.run;
+    (await import('@openai/agents')).Runner.prototype.run = async function (agent: Agent, ...rest: unknown[]) {
+      capturedAgent = agent;
+      return originalRun.apply(this, [agent, ...rest] as never);
+    } as typeof originalRun;
+    try {
+      await scope.run({ prompt: 'item 1' });
+    } catch {
+      // Tolerate stub-model shape mismatches; only Agent construction matters here.
+    } finally {
+      (await import('@openai/agents')).Runner.prototype.run = originalRun;
+      await scope.close();
+    }
+    // Same SDK default as above — 'text', not `undefined`.
+    expect(capturedAgent?.outputType).toBe('text');
+  });
+
+  it('strips strict-mode null keys from structuredOutput on the schema\'d path', async () => {
+    const stubModelProvider = {
+      async getModel() {
+        return { async getResponse() { throw new Error('unused — Runner.run is stubbed directly'); } };
+      },
+    } as any;
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider });
+    const finalOutput = {
+      phases: [{ name: 'extract', skip: false, skipReason: null, maxTurns: null, contextNotes: null }],
+      reasoning: 'x',
+    };
+    const originalRun = Runner.prototype.run;
+    Runner.prototype.run = (async function () {
+      return {
+        finalOutput,
+        rawResponses: [{ usage: { requests: 1, inputTokens: 10, outputTokens: 10, totalTokens: 20 } }],
+        lastResponseId: 'resp-1',
+      };
+    }) as typeof originalRun;
+    let result;
+    try {
+      result = await harness.execute({
+        prompt: 'plan the phases',
+        model: 'gpt-5.4-mini',
+        toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+        outputSchema: { name: 'orchestrator_plan', schema: { type: 'object', properties: {}, required: [], additionalProperties: false } },
+      });
+    } finally {
+      Runner.prototype.run = originalRun;
+    }
+    expect(result.structuredOutput).toBeDefined();
+    const directive = (result.structuredOutput as any).phases[0];
+    expect(directive.name).toBe('extract');
+    expect(directive.skip).toBe(false);
+    expect('skipReason' in directive).toBe(false);
+    expect('maxTurns' in directive).toBe(false);
+    expect('contextNotes' in directive).toBe(false);
+  });
+
+  it('populates structuredOutput on the schema\'d path when no nulls are present', async () => {
+    const stubModelProvider = {
+      async getModel() {
+        return { async getResponse() { throw new Error('unused — Runner.run is stubbed directly'); } };
+      },
+    } as any;
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider });
+    const finalOutput = {
+      phases: [{ name: 'extract', skip: true, skipReason: 'nothing pending', maxTurns: 5, contextNotes: 'note' }],
+      reasoning: 'done',
+    };
+    const originalRun = Runner.prototype.run;
+    Runner.prototype.run = (async function () {
+      return {
+        finalOutput,
+        rawResponses: [{ usage: { requests: 1, inputTokens: 10, outputTokens: 10, totalTokens: 20 } }],
+        lastResponseId: 'resp-2',
+      };
+    }) as typeof originalRun;
+    let result;
+    try {
+      result = await harness.execute({
+        prompt: 'plan the phases',
+        model: 'gpt-5.4-mini',
+        toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+        outputSchema: { name: 'orchestrator_plan', schema: { type: 'object', properties: {}, required: [], additionalProperties: false } },
+      });
+    } finally {
+      Runner.prototype.run = originalRun;
+    }
+    expect(result.structuredOutput).toEqual(finalOutput);
+  });
+});

--- a/tests/agent/orchestrator.test.ts
+++ b/tests/agent/orchestrator.test.ts
@@ -14,6 +14,8 @@ import {
   composeOrchestratorPrompt,
   parseOrchestratorPlan,
   applyDirectives,
+  planFromStructuredOutput,
+  ORCHESTRATOR_PLAN_JSON_SCHEMA,
   resetOrchestratorPromptTemplateCacheForTests,
   resolveOrchestratorPromptTemplate,
 } from '@myco/agent/orchestrator.js';
@@ -229,6 +231,102 @@ describe('parseOrchestratorPlan', () => {
   it('returns empty phases array in run-all plan when no phases defined', () => {
     const plan = parseOrchestratorPlan('bad json', []);
     expect(plan.phases).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// planFromStructuredOutput
+// ---------------------------------------------------------------------------
+
+describe('planFromStructuredOutput', () => {
+  it('returns the plan unchanged when given a well-formed OrchestratorPlan object', () => {
+    const structured = {
+      phases: [{ name: 'extract', skip: false }],
+      reasoning: 'Run all phases.',
+    };
+    const plan = planFromStructuredOutput(structured, []);
+    expect(plan.phases).toHaveLength(1);
+    expect(plan.phases[0].name).toBe('extract');
+    expect(plan.reasoning).toBe('Run all phases.');
+  });
+
+  it('falls back to run-all plan when the object is missing phases', () => {
+    const phases = [makePhase({ name: 'extract' })];
+    const plan = planFromStructuredOutput({ reasoning: 'all good' }, phases);
+    expect(plan.phases).toHaveLength(1);
+    expect(plan.phases[0].name).toBe('extract');
+    expect(plan.phases[0].skip).toBe(false);
+    expect(plan.reasoning).toMatch(/missing phases/i);
+  });
+
+  it('falls back to run-all plan when given a non-object value', () => {
+    const phases = [makePhase({ name: 'digest' })];
+    expect(planFromStructuredOutput(null, phases).phases[0].name).toBe('digest');
+    expect(planFromStructuredOutput('not an object', phases).phases[0].name).toBe('digest');
+    expect(planFromStructuredOutput(['array', 'not', 'object'], phases).phases[0].name).toBe('digest');
+  });
+
+  it('logs a warning on shape mismatch', () => {
+    const warn = vi.fn();
+    const logger = { info: vi.fn(), debug: vi.fn(), warn, error: vi.fn() };
+    planFromStructuredOutput({ notPhases: true }, [], logger);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [kind, , meta] = warn.mock.calls[0];
+    expect(kind).toBe('agent.orchestrator.structured-output-shape-mismatch');
+    expect(meta).toMatchObject({ received: 'object' });
+  });
+
+  it('does not log when the shape is valid', () => {
+    const warn = vi.fn();
+    const logger = { info: vi.fn(), debug: vi.fn(), warn, error: vi.fn() };
+    planFromStructuredOutput({ phases: [], reasoning: 'ok' }, [], logger);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('drops a null maxTurns directive field so applyDirectives never zeroes the matched phase budget', () => {
+    // Regression guard for the CRITICAL #1 finding: a harness that forgot
+    // to strip OpenAI strict-mode nulls (see stripStrictNulls in
+    // harness/openai.ts) would hand planFromStructuredOutput a directive
+    // shaped like { skip: false, maxTurns: null, ... }. applyDirectives'
+    // `directive.maxTurns !== undefined` guard passes on a `null` value,
+    // and `Math.min(null, ceiling)` coerces to 0 — zeroing the phase's
+    // turn budget. planFromStructuredOutput must strip the null before it
+    // ever reaches applyDirectives; applyDirectives itself is untouched.
+    const structured = {
+      phases: [{ name: 'extract', skip: false, maxTurns: null }],
+      reasoning: 'x',
+    };
+    const plan = planFromStructuredOutput(structured, []);
+    const phases = [makePhase({ name: 'extract', maxTurns: 5 })];
+    const result = applyDirectives(phases, plan.phases);
+    expect(result[0].maxTurns).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ORCHESTRATOR_PLAN_JSON_SCHEMA
+// ---------------------------------------------------------------------------
+
+describe('ORCHESTRATOR_PLAN_JSON_SCHEMA', () => {
+  it('declares exactly the OrchestratorPhaseDirective fields', () => {
+    const directiveProps = (ORCHESTRATOR_PLAN_JSON_SCHEMA as any).properties.phases.items.properties;
+    expect(Object.keys(directiveProps).sort()).toEqual(
+      ['contextNotes', 'maxTurns', 'name', 'skip', 'skipReason'].sort(),
+    );
+  });
+
+  it('requires name and skip on each directive, leaves the rest optional', () => {
+    const items = (ORCHESTRATOR_PLAN_JSON_SCHEMA as any).properties.phases.items;
+    expect(items.required).toEqual(['name', 'skip']);
+  });
+
+  it('requires phases and reasoning at the top level', () => {
+    expect((ORCHESTRATOR_PLAN_JSON_SCHEMA as any).required).toEqual(['phases', 'reasoning']);
+  });
+
+  it('disallows additional properties at both levels', () => {
+    expect((ORCHESTRATOR_PLAN_JSON_SCHEMA as any).additionalProperties).toBe(false);
+    expect((ORCHESTRATOR_PLAN_JSON_SCHEMA as any).properties.phases.items.additionalProperties).toBe(false);
   });
 });
 

--- a/tests/agent/phase-loop.test.ts
+++ b/tests/agent/phase-loop.test.ts
@@ -25,6 +25,7 @@ import type {
 import type { AgentHarness, HarnessExecuteInput, HarnessExecuteResult } from '@myco/agent/harness/types.js';
 import { HarnessExecutionError } from '@myco/agent/harness/types.js';
 import type { RunCheckpointState } from '@myco/agent/executor-state.js';
+import { ORCHESTRATOR_PLAN_JSON_SCHEMA } from '@myco/agent/orchestrator.js';
 
 // ---------------------------------------------------------------------------
 // Harness mock — controls execute() behavior per test.
@@ -39,6 +40,7 @@ let runtimeBehaviors: RuntimeBehavior[] = [];
 let defaultRuntimeBehavior: RuntimeBehavior = { kind: 'success' };
 let capturedExecuteInputs: HarnessExecuteInput[] = [];
 let runtimeSupportsSessionResume = false;
+let runtimeSupportsStructuredOutput = false;
 
 const DEFAULT_USAGE: RuntimeUsage = {
   requests: 1,
@@ -95,6 +97,7 @@ const fakeRuntime: AgentHarness = {
   },
   supports(capability) {
     if (capability === 'supportsSessionResume') return runtimeSupportsSessionResume;
+    if (capability === 'structuredOutput') return runtimeSupportsStructuredOutput;
     return false;
   },
 	  classifyError(error) {
@@ -222,6 +225,16 @@ function phase(name: string, extra: Partial<PhaseDefinition> = {}): PhaseDefinit
   } as PhaseDefinition;
 }
 
+function buildPhaseLoopContextWithOrchestratorEnabled(phaseNames: string[] = ['extract']): PhaseLoopContext {
+  const phases = phaseNames.map((name) => phase(name));
+  return baseContext({
+    config: {
+      ...baseConfig(phases),
+      orchestrator: { enabled: true },
+    },
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Reset per test
 // ---------------------------------------------------------------------------
@@ -231,6 +244,7 @@ beforeEach(() => {
   defaultRuntimeBehavior = { kind: 'success' };
   capturedExecuteInputs = [];
   runtimeSupportsSessionResume = false;
+  runtimeSupportsStructuredOutput = false;
   phasePreConditionResult = { passed: true, reason: 'default-pass' };
   mapPhaseResultOverride = null;
 });
@@ -820,5 +834,146 @@ describe('executePhasedQuery turnOffset allocation', () => {
     const offsets = offsetsByPrompt();
     expect(capturedExecuteInputs).toHaveLength(1);
     expect(offsets.get('c')).toBe(13);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executePhasedQuery — orchestrator structured output
+// ---------------------------------------------------------------------------
+
+describe('executePhasedQuery orchestrator structured output', () => {
+  it('requests outputSchema on the orchestrator call when the harness supports structuredOutput', async () => {
+    runtimeSupportsStructuredOutput = true;
+    runtimeBehaviors = [
+      { kind: 'success', result: { finalText: '{"phases":[],"reasoning":"structured path unused for this assertion"}' } },
+    ];
+    await executePhasedQuery(buildPhaseLoopContextWithOrchestratorEnabled());
+    const orchestratorCall = capturedExecuteInputs.find((input) => input.toolSurface.toolNames?.length === 0);
+    expect(orchestratorCall?.outputSchema).toEqual({
+      name: 'orchestrator_plan',
+      schema: ORCHESTRATOR_PLAN_JSON_SCHEMA,
+    });
+  });
+
+  it('does not request outputSchema when the harness does not support structuredOutput', async () => {
+    runtimeSupportsStructuredOutput = false;
+    runtimeBehaviors = [
+      { kind: 'success', result: { finalText: '{"phases":[],"reasoning":"text path"}' } },
+    ];
+    await executePhasedQuery(buildPhaseLoopContextWithOrchestratorEnabled());
+    const orchestratorCall = capturedExecuteInputs.find((input) => input.toolSurface.toolNames?.length === 0);
+    expect(orchestratorCall?.outputSchema).toBeUndefined();
+  });
+
+  it('applies directives from structuredOutput when the harness returns it', async () => {
+    runtimeSupportsStructuredOutput = true;
+    runtimeBehaviors = [
+      {
+        kind: 'success',
+        result: {
+          finalText: '{"phases":[],"reasoning":"should not be used"}',
+          structuredOutput: {
+            phases: [{ name: 'extract', skip: true, skipReason: 'nothing pending' }],
+            reasoning: 'structured plan used directly',
+          },
+        },
+      },
+    ];
+    const ctx = buildPhaseLoopContextWithOrchestratorEnabled(['extract', 'graph']);
+    const result = await executePhasedQuery(ctx);
+    const executedPhaseNames = result.phases.map((p) => p.name);
+    expect(executedPhaseNames).not.toContain('extract');
+    expect(executedPhaseNames).toContain('graph');
+  });
+
+  it('falls back to text parsing when structuredOutput is undefined despite harness support', async () => {
+    runtimeSupportsStructuredOutput = true;
+    runtimeBehaviors = [
+      {
+        kind: 'success',
+        result: {
+          finalText: '{"phases":[{"name":"extract","skip":true,"skipReason":"nothing pending"}],"reasoning":"fallback text plan"}',
+          structuredOutput: undefined,
+        },
+      },
+    ];
+    const ctx = buildPhaseLoopContextWithOrchestratorEnabled(['extract', 'graph']);
+    const result = await executePhasedQuery(ctx);
+    const executedPhaseNames = result.phases.map((p) => p.name);
+    expect(executedPhaseNames).not.toContain('extract');
+    expect(executedPhaseNames).toContain('graph');
+  });
+
+  it('warns "structured-output-missing" once when the schema\'d call succeeds but returns no structuredOutput, then falls back to text parsing', async () => {
+    // Soft-failure path: outputSchema WAS attached, the call did NOT throw,
+    // but the provider's structured-output validation failed after its own
+    // retries (e.g. Claude's error_max_structured_output_retries subtype —
+    // empty finalText, no structured_output on the result message). This is
+    // distinct from the throw-and-retry path above, which never has
+    // outputSchema attached on its retry and therefore never double-warns
+    // here.
+    runtimeSupportsStructuredOutput = true;
+    runtimeBehaviors = [
+      {
+        kind: 'success',
+        result: {
+          finalText: '{"phases":[{"name":"extract","skip":true,"skipReason":"nothing pending"}],"reasoning":"fallback text plan"}',
+          structuredOutput: undefined,
+        },
+      },
+    ];
+    const warn = vi.fn();
+    const logger = { info: vi.fn(), debug: vi.fn(), warn, error: vi.fn() };
+    const ctx = buildPhaseLoopContextWithOrchestratorEnabled(['extract', 'graph']);
+    ctx.options = { logger };
+
+    const result = await executePhasedQuery(ctx);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [kind, , meta] = warn.mock.calls[0];
+    expect(kind).toBe('agent.orchestrator.structured-output-missing');
+    expect(meta).toMatchObject({ runId: 'run-123' });
+
+    const executedPhaseNames = result.phases.map((p) => p.name);
+    expect(executedPhaseNames).not.toContain('extract');
+    expect(executedPhaseNames).toContain('graph');
+  });
+
+  it('retries without outputSchema exactly once when the harness throws on the structured-output call, and uses the retry result', async () => {
+    runtimeSupportsStructuredOutput = true;
+    runtimeBehaviors = [
+      { kind: 'error', message: 'malformed structured output JSON' },
+      {
+        kind: 'success',
+        result: {
+          finalText: '{"phases":[{"name":"extract","skip":true,"skipReason":"nothing pending"}],"reasoning":"retry text plan"}',
+        },
+      },
+    ];
+    const warn = vi.fn();
+    const logger = { info: vi.fn(), debug: vi.fn(), warn, error: vi.fn() };
+    const ctx = buildPhaseLoopContextWithOrchestratorEnabled(['extract', 'graph']);
+    ctx.options = { logger };
+
+    const result = await executePhasedQuery(ctx);
+
+    // The orchestrator planning calls always happen before any phase
+    // executes, so the first two captured inputs are the initial
+    // structured-output attempt and its no-outputSchema retry.
+    const orchestratorCalls = capturedExecuteInputs.slice(0, 2);
+    expect(orchestratorCalls[0].outputSchema).toEqual({
+      name: 'orchestrator_plan',
+      schema: ORCHESTRATOR_PLAN_JSON_SCHEMA,
+    });
+    expect(orchestratorCalls[1].outputSchema).toBeUndefined();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [kind, , meta] = warn.mock.calls[0];
+    expect(kind).toBe('agent.orchestrator.structured-output-failed');
+    expect(meta?.error).toContain('malformed structured output JSON');
+
+    const executedPhaseNames = result.phases.map((p) => p.name);
+    expect(executedPhaseNames).not.toContain('extract');
+    expect(executedPhaseNames).toContain('graph');
   });
 });

--- a/tests/agent/runtime-claude.test.ts
+++ b/tests/agent/runtime-claude.test.ts
@@ -15,6 +15,7 @@ import { vi } from '../helpers/vi-shim.js';
 // ---------------------------------------------------------------------------
 
 const queryCalls: Array<{ prompt: string; options: Record<string, unknown> }> = [];
+let structuredOutputOverride: unknown = undefined;
 
 mock.module('@anthropic-ai/claude-agent-sdk', () => ({
   query: (args: { prompt: string; options: Record<string, unknown> }) => {
@@ -42,6 +43,7 @@ mock.module('@anthropic-ai/claude-agent-sdk', () => ({
           permission_denials: [],
           uuid: 'r-1',
           session_id: 'test-session',
+          ...(structuredOutputOverride !== undefined ? { structured_output: structuredOutputOverride } : {}),
         };
       },
     };
@@ -125,6 +127,7 @@ describe('ClaudeSdkHarness.execute', () => {
     queryCalls.length = 0;
     scopedServerCalls.length = 0;
     fullServerCalls.length = 0;
+    structuredOutputOverride = undefined;
   });
 
   it('forwards sessionRef as sessionId to the SDK when provided', async () => {
@@ -275,5 +278,65 @@ describe('ClaudeSdkHarness.execute', () => {
     expect(result.usage.totalTokens).toBe(49);
     expect(result.usage.costUsd).toBeCloseTo(0.0123);
     expect(result.usage.requestUsageEntries).toHaveLength(1);
+  });
+
+  it('attaches outputFormat to the SDK call when outputSchema is provided', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+    await runtime.execute({
+      prompt: 'plan the phases',
+      model: 'claude-sonnet-4-6',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+      outputSchema: { name: 'orchestrator_plan', schema: { type: 'object', properties: {} } },
+    });
+    const lastCall = queryCalls[queryCalls.length - 1];
+    expect(lastCall.options.outputFormat).toEqual({
+      type: 'json_schema',
+      schema: { type: 'object', properties: {} },
+    });
+  });
+
+  it('omits outputFormat when outputSchema is not provided', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+    await runtime.execute({
+      prompt: 'do something',
+      model: 'claude-sonnet-4-6',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    });
+    const lastCall = queryCalls[queryCalls.length - 1];
+    expect(lastCall.options.outputFormat).toBeUndefined();
+  });
+
+  it('returns structuredOutput from the result message when present', async () => {
+    structuredOutputOverride = { phases: [{ name: 'extract', skip: false }], reasoning: 'ok' };
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+    const result = await runtime.execute({
+      prompt: 'plan the phases',
+      model: 'claude-sonnet-4-6',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+      outputSchema: { name: 'orchestrator_plan', schema: { type: 'object', properties: {} } },
+    });
+    expect(result.structuredOutput).toEqual({ phases: [{ name: 'extract', skip: false }], reasoning: 'ok' });
+  });
+
+  it('leaves structuredOutput undefined when the SDK never emits structured_output', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+    const result = await runtime.execute({
+      prompt: 'do something',
+      model: 'claude-sonnet-4-6',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    });
+    expect(result.structuredOutput).toBeUndefined();
+  });
+});
+
+describe('ClaudeSdkHarness.supports', () => {
+  it('reports structuredOutput support', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+    expect(runtime.supports('structuredOutput')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Plan #2 of the Agent Harness SDK Alignment sequence. The orchestrator's LLM-plan call now requests schema-validated structured output from whichever harness is active, instead of blind-JSON-parsing `finalText` — with the text-parse path kept as an always-available fallback.

- **orchestrator.ts** — canonical `ORCHESTRATOR_PLAN_JSON_SCHEMA` mirroring `OrchestratorPlan` field-for-field, and `planFromStructuredOutput()` (falls back to a run-all plan on shape mismatch; drops null-valued directive fields defensively).
- **Harness contract** — optional `HarnessExecuteInput.outputSchema` / `HarnessExecuteResult.structuredOutput` and a new `'structuredOutput'` capability. All fields optional; every existing `execute()` call site is unaffected (regression-tested, not just inspected).
- **Claude harness** — attaches `outputFormat: { type: 'json_schema', schema }`, captures `structured_output` from the success result. Validation failure yields `structuredOutput: undefined` (caller falls back), never a throw.
- **OpenAI harness** — attaches `Agent.outputType` with a strict-mode schema conversion (`toStrictJsonObjectSchema`: all-required + nullable-widened optionals), and **strips the strict-mode `null`s back out at the harness boundary** — without this, `applyDirectives` would see `maxTurns: null` and `Math.min(null, ceiling)` would silently zero phase turn budgets (caught by the final whole-branch review; production-reachable via vault-evolve on OpenAI/Ollama/LM Studio configs). The converter throws early on schema constructs it can't widen (enum/$ref/oneOf) rather than silently mangling them. `openScope()` (map-phase batch path) never threads `outputSchema`.
- **phase-loop.ts call site** — capability-gated attach; `structuredOutput` takes precedence, `parseOrchestratorPlan(finalText)` otherwise; if the schema'd call *throws* (the OpenAI SDK's runner JSON.parse can), one retry without the schema (abort-gated) so structured output can never make an orchestrator-enabled run less reliable than before; operator warns on both soft-failure modes (`structured-output-missing`, `structured-output-failed`).

Known follow-ups deliberately not in this PR: orchestrator `planResponse.usage` is not folded into the run's cost aggregate (pre-existing gap — the retry makes it marginally worse); no Claude-side distinct handling of the `error_max_structured_output_retries` subtype beyond the generic missing-warn.

## Test plan

- [x] TDD per task: 6 tasks, each red→green with scoped runs; per-task spec+quality reviews
- [x] Final whole-branch review (most capable model) + dimensions review (security/perf/edges) — 1 Critical + 1 Important found, fixed on-branch, fixes independently re-verified
- [x] `npm test -- tests/agent` — 525 pass / 1 skip (pre-existing) / 0 fail
- [x] Full `npm test` — green (node + jsdom groups)
- [x] `make build` — lint + fast tests + binary + UI bundle green

🤖 Generated with [Claude Code](https://claude.com/claude-code)