### PR TITLE
feat(agent): map reasoningLevel onto provider thinking budgets and effort settings

### DIFF
--- a/packages/myco/src/agent/config-resolver.ts
+++ b/packages/myco/src/agent/config-resolver.ts
@@ -148,6 +148,8 @@ function toProviderConfig(p: {
   base_url?: string;
   model?: string;
   reasoning_map?: Partial<Record<'low' | 'default' | 'high', string>>;
+  thinking_budget_map?: Partial<Record<'low' | 'default' | 'high', { budgetTokens: number } | { adaptive: true }>>;
+  effort_map?: Partial<Record<'low' | 'default' | 'high', { effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'; verbosity?: 'low' | 'medium' | 'high' }>>;
   context_length?: number;
 }): ProviderConfig {
   return {
@@ -156,6 +158,8 @@ function toProviderConfig(p: {
     baseUrl: p.base_url,
     model: p.model,
     reasoningMap: p.reasoning_map,
+    thinkingBudgetMap: p.thinking_budget_map,
+    effortMap: p.effort_map,
     contextLength: p.context_length,
   };
 }

--- a/packages/myco/src/agent/harness/claude.ts
+++ b/packages/myco/src/agent/harness/claude.ts
@@ -20,6 +20,7 @@ import {
   createVaultToolServer,
 } from '@myco/agent/tools.js';
 import { buildPhaseEnv, isLocalProvider } from '@myco/agent/provider.js';
+import { resolveThinkingConfig } from '@myco/agent/reasoning-levels.js';
 import { errorMessage } from '@myco/utils/error-message.js';
 import { resolveClaudeCodeExecutable } from './claude-code-executable.js';
 
@@ -72,13 +73,6 @@ function getIsolatedPluginCacheDir(): string {
   }
   isolatedPluginCacheDir = dir;
   return dir;
-}
-
-/** Disable thinking on local providers whose endpoints don't accept the SDK's reasoning enum. */
-function suppressEffortLeakForLocalProvider(
-  provider?: HarnessExecuteInput['provider'],
-): { thinking?: { type: 'disabled' } } {
-  return isLocalProvider(provider) ? { thinking: { type: 'disabled' as const } } : {};
 }
 
 /**
@@ -304,6 +298,7 @@ function pickClaudeSetup(input: HarnessExecuteInput): HarnessScopeSetup {
     provider: input.provider,
     toolSurface: input.toolSurface,
     logger: input.logger,
+    reasoningLevel: input.reasoningLevel,
   };
 }
 
@@ -399,7 +394,7 @@ async function runClaudeQuery(
       allowDangerouslySkipPermissions: true,
       persistSession: options.persistSession,
       env: prepared.env,
-      ...suppressEffortLeakForLocalProvider(setup.provider),
+      thinking: resolveThinkingConfig(setup.reasoningLevel, setup.provider),
       ...(prepared.claudeCodeExecutable ? { pathToClaudeCodeExecutable: prepared.claudeCodeExecutable } : {}),
       ...(options.sessionRef ? { sessionId: options.sessionRef } : {}),
       ...(options.abortController ? { abortController: options.abortController } : {}),

--- a/packages/myco/src/agent/harness/openai.ts
+++ b/packages/myco/src/agent/harness/openai.ts
@@ -4,6 +4,7 @@ import {
   Agent,
   Runner,
   OpenAIProvider,
+  gpt5ReasoningSettingsRequired,
   type AgentInputItem,
   type JsonSchemaDefinition,
   type ModelProvider,
@@ -35,6 +36,7 @@ import {
   type LocalOpenAIBackendKind,
 } from '@myco/intelligence/local-openai-backends.js';
 import { DEFAULT_OPENAI_URL, DEFAULT_OPENROUTER_URL } from '@myco/agent/provider.js';
+import { resolveModelSettings } from '@myco/agent/reasoning-levels.js';
 import { errorMessage } from '@myco/utils/error-message.js';
 import { createInstrumentedFetch } from '@myco/utils/instrumented-fetch.js';
 
@@ -445,6 +447,7 @@ export class OpenAIAgentsHarness implements AgentHarness {
       provider: input.provider,
       toolSurface: input.toolSurface,
       logger: input.logger,
+      reasoningLevel: input.reasoningLevel,
     };
     const prepared = await prepareOpenAIRun(setup, this.testOverrides, input.outputSchema);
     try {
@@ -550,11 +553,25 @@ async function prepareOpenAIRun(
   const preparedExecution = await prepareLocalProviderExecution(setup.provider, setup.model);
   const mcpServer = createLocalVaultMcpServer(setup.toolSurface);
   await mcpServer.connect();
+  // Only attach `modelSettings` for models the SDK itself recognizes as
+  // GPT-5-family reasoning models (`gpt5ReasoningSettingsRequired`, exported
+  // by @openai/agents-core's defaultModel.js and re-exported from
+  // '@openai/agents'). The Agent constructor (agents-core/dist/agent.js
+  // ~96-116) already resets `modelSettings` to `{}` for a non-GPT-5 model
+  // UNLESS the caller explicitly passed `modelSettings` — so explicitly
+  // attaching `reasoning.effort`/`text.verbosity` here for e.g. gpt-4.1* or
+  // an arbitrary openrouter route would bypass that guard and send fields
+  // the model's API rejects with a 400. Omitting the key entirely for a
+  // non-reasoning-capable model preserves the SDK's own pre-branch default.
+  const modelSettings = gpt5ReasoningSettingsRequired(preparedExecution.model)
+    ? resolveModelSettings(setup.reasoningLevel, setup.provider)
+    : undefined;
   const agent = new Agent({
     name: 'myco-agent',
     instructions: setup.systemPrompt ?? 'You are the Myco agent harness.',
     model: preparedExecution.model,
     mcpServers: [mcpServer],
+    ...(modelSettings ? { modelSettings } : {}),
     ...(outputSchema ? {
       outputType: {
         type: 'json_schema',

--- a/packages/myco/src/agent/harness/types.ts
+++ b/packages/myco/src/agent/harness/types.ts
@@ -1,6 +1,6 @@
 import type { MycoToolDefinition } from '@myco/agent/tools/types.js';
 import type { AgentEmbeddingPort } from '@myco/agent/runtime/ports.js';
-import type { ProviderConfig, RunLogger, HarnessId, RuntimeUsage } from '@myco/agent/types.js';
+import type { ProviderConfig, RunLogger, HarnessId, RuntimeUsage, ReasoningLevel } from '@myco/agent/types.js';
 import type { MycoRequestContext } from '@myco/grove/request-context.js';
 
 export type HarnessCapability =
@@ -68,6 +68,21 @@ export interface HarnessExecuteInput {
     name: string;
     schema: Record<string, unknown>;
   };
+  /**
+   * The reasoning tier resolved for this call. Harness adapters translate
+   * this into their own provider-native thinking/reasoning-effort control
+   * (Claude: `ThinkingConfig`; OpenAI: `ModelSettings.reasoning`/`text`).
+   * Optional — an omitted value still resolves through each harness's
+   * `default`-tier mapping for non-local providers (Claude: adaptive
+   * thinking; OpenAI: the `default` tier's effort/verbosity), it does NOT
+   * mean "no override sent." Only LOCAL providers (ollama/lmstudio/
+   * openai-compatible) get no thinking/reasoning fields at all regardless
+   * of tier, and — for OpenAI specifically — only a resolved model name the
+   * SDK recognizes as GPT-5-family gets `reasoning`/`text` attached; a
+   * non-reasoning-capable model name (e.g. gpt-4.1-mini, a non-GPT-5
+   * openrouter route) also gets no override sent, same as a local provider.
+   */
+  reasoningLevel?: ReasoningLevel;
 }
 
 export interface HarnessExecuteResult {
@@ -113,6 +128,8 @@ export interface HarnessScopeSetup {
   provider?: ProviderConfig;
   toolSurface: HarnessToolSurface;
   logger?: RunLogger;
+  /** See `HarnessExecuteInput.reasoningLevel`. */
+  reasoningLevel?: ReasoningLevel;
 }
 
 /** A long-lived harness scope that runs N items against shared SDK machinery. */

--- a/packages/myco/src/agent/map-phase.ts
+++ b/packages/myco/src/agent/map-phase.ts
@@ -25,7 +25,7 @@ import {
   type HarnessExecuteResult,
   type HarnessScope,
 } from './harness/types.js';
-import type { MapPhaseResult, PhaseDefinition, ProviderConfig, RunLogger, RuntimeUsage } from './types.js';
+import type { MapPhaseResult, PhaseDefinition, ProviderConfig, ReasoningLevel, RunLogger, RuntimeUsage } from './types.js';
 import type { MycoToolDefinition } from '@myco/agent/tools/types.js';
 
 export interface ExecuteMapPhaseInput {
@@ -38,6 +38,8 @@ export interface ExecuteMapPhaseInput {
   agentId: string;
   /** Resolved phase model (from outer phase resolution). Required for the harness adapter to pick the right model. Optional for stub-harness tests. */
   phaseModel?: string;
+  /** Reasoning tier resolved for this phase by `resolvePhaseExecution`, sibling of `phaseModel`. Forwarded to the harness so it can set a provider-native thinking/reasoning-effort control. */
+  reasoningLevel?: ReasoningLevel;
   /** Resolved provider config (task/phase override aware). Required for the harness adapter to pick the right backend. */
   provider?: ProviderConfig;
   /** Vault dir threaded into per-item toolSurface so freshly-built tools resolve project_id correctly. */
@@ -62,7 +64,7 @@ export interface ExecuteMapPhaseInput {
 export async function executeMapPhase(input: ExecuteMapPhaseInput): Promise<MapPhaseResult> {
   const {
     phase, allTools, harness, params, systemPrompt, runId, agentId,
-    phaseModel, provider, vaultDir, projectRoot, embeddingManager, logger,
+    phaseModel, reasoningLevel, provider, vaultDir, projectRoot, embeddingManager, logger,
     runAbortController,
   } = input;
   if (phase.mode !== 'map' || !phase.source || !phase.item || !phase.sink) {
@@ -154,6 +156,7 @@ export async function executeMapPhase(input: ExecuteMapPhaseInput): Promise<MapP
     scope = await harness.openScope({
       systemPrompt,
       model: phaseModel ?? '',
+      reasoningLevel,
       provider,
       toolSurface: sharedToolSurface,
       logger,
@@ -195,6 +198,7 @@ export async function executeMapPhase(input: ExecuteMapPhaseInput): Promise<MapP
             prompt: itemPrompt,
             systemPrompt,
             model: phaseModel ?? '',
+            reasoningLevel,
             maxTurns: phase.perItemMaxTurns ?? 1,
             provider,
             toolSurface: sharedToolSurface,

--- a/packages/myco/src/agent/phase-loop-reasoning.test.ts
+++ b/packages/myco/src/agent/phase-loop-reasoning.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test';
+import { resolvePhaseExecution } from './phase-resolver.js';
+import type { EffectiveConfig, PhaseDefinition } from './types.js';
+
+/**
+ * Regression guard for the reasoningLevel plumbing gap this plan closes:
+ * `resolvePhaseExecution` already returned `reasoningLevel` before this
+ * change, but every caller in phase-loop.ts discarded it after computing
+ * `model`. This test locks that `resolvePhaseExecution` itself still
+ * returns the resolved level (the phase-loop.ts wiring that now forwards
+ * it is exercised via the harness tests in Task 2/3, since phase-loop.ts
+ * has no isolated unit-test seam for its internal wave loop).
+ */
+describe('resolvePhaseExecution reasoningLevel passthrough', () => {
+  const basePhase: PhaseDefinition = {
+    name: 'extract',
+    prompt: 'test',
+    tools: [],
+    maxTurns: 10,
+    required: true,
+  };
+
+  const baseConfig: EffectiveConfig = {
+    agentId: 'agent-1',
+    harness: 'claude-sdk',
+    model: 'claude-sonnet-4-6',
+    maxTurns: 10,
+    timeoutSeconds: 60,
+    systemPromptPath: 'prompt.md',
+    tools: [],
+    taskName: 'test-task',
+    taskDisplayName: 'Test Task',
+    taskPrompt: 'test',
+  };
+
+  test('phase-level reasoningLevel is returned unchanged for the harness to consume', () => {
+    const phase: PhaseDefinition = { ...basePhase, reasoningLevel: 'high' };
+    const resolved = resolvePhaseExecution(phase, undefined, baseConfig, undefined);
+    expect(resolved.reasoningLevel).toBe('high');
+  });
+
+  test('run override reasoningLevel wins over phase YAML', () => {
+    const phase: PhaseDefinition = { ...basePhase, reasoningLevel: 'low' };
+    const resolved = resolvePhaseExecution(
+      phase,
+      { executionOverrides: { phases: { extract: { reasoningLevel: 'high' } } } },
+      baseConfig,
+      undefined,
+    );
+    expect(resolved.reasoningLevel).toBe('high');
+  });
+
+  test('falls back to config.reasoningLevel when nothing else is set', () => {
+    const resolved = resolvePhaseExecution(
+      basePhase,
+      undefined,
+      { ...baseConfig, reasoningLevel: 'low' },
+      undefined,
+    );
+    expect(resolved.reasoningLevel).toBe('low');
+  });
+});

--- a/packages/myco/src/agent/phase-loop.ts
+++ b/packages/myco/src/agent/phase-loop.ts
@@ -48,6 +48,7 @@ import type {
   PhaseDefinition,
   PhaseResult,
   ProviderConfig,
+  ReasoningLevel,
   RuntimeUsage,
 } from './types.js';
 import { aggregateUsage } from './executor-state.js';
@@ -151,6 +152,8 @@ export interface ExecutePhaseInput {
   ctx: PhaseLoopContext;
   phasePrompt: string;
   phaseModel: string;
+  /** Reasoning tier resolved for this phase by `resolvePhaseExecution`. Forwarded to the harness so it can set a provider-native thinking/reasoning-effort control. */
+  reasoningLevel?: ReasoningLevel;
   phase: PhaseDefinition;
   toolSurface: HarnessToolSurface;
   provider?: ProviderConfig;
@@ -169,7 +172,7 @@ export interface ExecutePhaseInput {
 export async function executePhase(
   input: ExecutePhaseInput,
 ): Promise<PhaseResult & { sessionData?: unknown }> {
-  const { ctx, phasePrompt, phaseModel, phase, toolSurface, provider, sessionId, sessionData, priorPhaseResults } = input;
+  const { ctx, phasePrompt, phaseModel, reasoningLevel, phase, toolSurface, provider, sessionId, sessionData, priorPhaseResults } = input;
 
   if (phase.mode === 'map') {
     return runMapPhaseAdapter(input);
@@ -271,6 +274,7 @@ export async function executePhase(
       result = await harness.execute({
         prompt: phasePrompt,
         model: phaseModel,
+        reasoningLevel,
         maxTurns: phase.maxTurns,
         systemPrompt: ctx.systemPrompt,
         provider,
@@ -297,6 +301,7 @@ export async function executePhase(
       result = await harness.execute({
         prompt: phasePrompt,
         model: phaseModel,
+        reasoningLevel,
         maxTurns: phase.maxTurns,
         systemPrompt: ctx.systemPrompt,
         provider,
@@ -398,7 +403,7 @@ function snapshotMetadata(toolSurface: HarnessToolSurface): Record<string, unkno
 // ---------------------------------------------------------------------------
 
 async function runMapPhaseAdapter(input: ExecutePhaseInput): Promise<PhaseResult & { sessionData?: unknown }> {
-  const { ctx, phase, phaseModel, provider } = input;
+  const { ctx, phase, phaseModel, reasoningLevel, provider } = input;
   const logger = ctx.options?.logger;
   const harness = getAgentHarness(ctx.config.harness);
   const allTools = createVaultTools(ctx.agentId, ctx.runId, {
@@ -423,6 +428,7 @@ async function runMapPhaseAdapter(input: ExecutePhaseInput): Promise<PhaseResult
       runId: ctx.runId,
       agentId: ctx.agentId,
       phaseModel,
+      reasoningLevel,
       provider,
       vaultDir: ctx.vaultDir,
       projectRoot: ctx.projectRoot,
@@ -505,8 +511,9 @@ export async function executeSingleQuery(
   sessionData?: unknown;
 }> {
   const harness = getAgentHarness(ctx.config.harness);
+  const effectiveReasoningLevel = ctx.config.execution?.reasoningLevel ?? ctx.config.reasoningLevel;
   const effectiveModel = resolveReasoningModel(
-    ctx.config.execution?.reasoningLevel ?? ctx.config.reasoningLevel,
+    effectiveReasoningLevel,
     provider,
     ctx.config.model,
   );
@@ -522,6 +529,7 @@ export async function executeSingleQuery(
   const baseInput = {
     prompt: taskPrompt,
     model: effectiveModel,
+    reasoningLevel: effectiveReasoningLevel,
     maxTurns: ctx.config.maxTurns,
     systemPrompt: ctx.systemPrompt,
     provider,
@@ -632,8 +640,9 @@ export async function executePhasedQuery(
       : [];
 
     const orchestratorPrompt = composeOrchestratorPrompt(vaultContext, phases, contextResults);
+    const orchestratorReasoningLevel = config.orchestrator.reasoningLevel ?? config.execution?.reasoningLevel ?? config.reasoningLevel;
     const orchestratorModel = config.orchestrator.model ?? resolveReasoningModel(
-      config.orchestrator.reasoningLevel ?? config.execution?.reasoningLevel ?? config.reasoningLevel,
+      orchestratorReasoningLevel,
       ctx.taskProviderOverride ?? config.execution?.provider,
       config.model,
     );
@@ -643,6 +652,7 @@ export async function executePhasedQuery(
     const orchestratorExecuteInput = {
       prompt: orchestratorPrompt,
       model: orchestratorModel,
+      reasoningLevel: orchestratorReasoningLevel,
       maxTurns: orchestratorMaxTurns,
       systemPrompt,
       provider: ctx.taskProviderOverride ?? config.execution?.provider,
@@ -751,6 +761,7 @@ export async function executePhasedQuery(
       const phaseProvider = resolved.provider;
       const effectiveMaxTurns = resolved.maxTurns;
       const phaseModel = resolved.model;
+      const phaseReasoningLevel = resolved.reasoningLevel;
 
       const basePhasePrompt = composePhasePrompt({
         vaultContext,
@@ -817,6 +828,7 @@ export async function executePhasedQuery(
         phase,
         phasePrompt,
         phaseModel,
+        reasoningLevel: phaseReasoningLevel,
         phaseProvider,
         effectivePhase,
         sessionId,
@@ -847,6 +859,7 @@ export async function executePhasedQuery(
           ctx,
           phasePrompt: waveInput.phasePrompt,
           phaseModel: waveInput.phaseModel,
+          reasoningLevel: waveInput.reasoningLevel,
           phase: waveInput.effectivePhase,
           toolSurface: waveInput.toolSurface,
           provider: waveInput.phaseProvider,

--- a/packages/myco/src/agent/reasoning-levels.test.ts
+++ b/packages/myco/src/agent/reasoning-levels.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  DEFAULT_REASONING_LEVEL,
+  resolveReasoningModel,
+  resolveThinkingConfig,
+  resolveModelSettings,
+} from './reasoning-levels.js';
+import type { ProviderConfig } from './types.js';
+
+describe('resolveThinkingConfig', () => {
+  test('maps low to a fixed small budget by default', () => {
+    expect(resolveThinkingConfig('low', undefined)).toEqual({
+      type: 'enabled',
+      budgetTokens: 1024,
+    });
+  });
+
+  test('maps default to adaptive thinking by default', () => {
+    expect(resolveThinkingConfig('default', undefined)).toEqual({ type: 'adaptive' });
+  });
+
+  test('maps high to a large fixed budget by default', () => {
+    expect(resolveThinkingConfig('high', undefined)).toEqual({
+      type: 'enabled',
+      budgetTokens: 32000,
+    });
+  });
+
+  test('undefined reasoningLevel falls back to the default tier mapping', () => {
+    expect(resolveThinkingConfig(undefined, undefined)).toEqual({ type: 'adaptive' });
+  });
+
+  test('forces disabled for local providers regardless of tier', () => {
+    const ollama: ProviderConfig = { type: 'ollama' };
+    expect(resolveThinkingConfig('high', ollama)).toEqual({ type: 'disabled' });
+    expect(resolveThinkingConfig('low', ollama)).toEqual({ type: 'disabled' });
+  });
+
+  test('provider thinkingBudgetMap overrides the default for a specific tier', () => {
+    const anthropic: ProviderConfig = {
+      type: 'anthropic',
+      thinkingBudgetMap: { low: { budgetTokens: 2048 } },
+    };
+    expect(resolveThinkingConfig('low', anthropic)).toEqual({
+      type: 'enabled',
+      budgetTokens: 2048,
+    });
+    // Unset tier still falls back to the built-in default.
+    expect(resolveThinkingConfig('high', anthropic)).toEqual({
+      type: 'enabled',
+      budgetTokens: 32000,
+    });
+  });
+
+  test('provider thinkingBudgetMap can override a tier to adaptive', () => {
+    const anthropic: ProviderConfig = {
+      type: 'anthropic',
+      thinkingBudgetMap: { low: { adaptive: true } },
+    };
+    expect(resolveThinkingConfig('low', anthropic)).toEqual({ type: 'adaptive' });
+  });
+});
+
+describe('resolveModelSettings', () => {
+  test('maps each tier to effort + verbosity by default', () => {
+    expect(resolveModelSettings('low', undefined)).toEqual({
+      reasoning: { effort: 'low' },
+      text: { verbosity: 'low' },
+    });
+    expect(resolveModelSettings('default', undefined)).toEqual({
+      reasoning: { effort: 'medium' },
+      text: { verbosity: 'medium' },
+    });
+    expect(resolveModelSettings('high', undefined)).toEqual({
+      reasoning: { effort: 'high' },
+      text: { verbosity: 'high' },
+    });
+  });
+
+  test('undefined reasoningLevel falls back to the default tier mapping', () => {
+    expect(resolveModelSettings(undefined, undefined)).toEqual({
+      reasoning: { effort: 'medium' },
+      text: { verbosity: 'medium' },
+    });
+  });
+
+  test('returns undefined for local providers', () => {
+    const lmstudio: ProviderConfig = { type: 'lmstudio' };
+    expect(resolveModelSettings('high', lmstudio)).toBeUndefined();
+    const ollama: ProviderConfig = { type: 'ollama' };
+    expect(resolveModelSettings('low', ollama)).toBeUndefined();
+    const openaiCompatible: ProviderConfig = { type: 'openai-compatible' };
+    expect(resolveModelSettings('default', openaiCompatible)).toBeUndefined();
+  });
+
+  test('provider effortMap overrides the default for a specific tier', () => {
+    const openai: ProviderConfig = {
+      type: 'openai',
+      effortMap: { high: { effort: 'xhigh', verbosity: 'high' } },
+    };
+    expect(resolveModelSettings('high', openai)).toEqual({
+      reasoning: { effort: 'xhigh' },
+      text: { verbosity: 'high' },
+    });
+    // Unset tier still falls back to the built-in default.
+    expect(resolveModelSettings('low', openai)).toEqual({
+      reasoning: { effort: 'low' },
+      text: { verbosity: 'low' },
+    });
+  });
+});
+
+describe('resolveReasoningModel (unchanged, regression guard)', () => {
+  test('still resolves to a model string via reasoningMap', () => {
+    const provider: ProviderConfig = {
+      type: 'anthropic',
+      reasoningMap: { low: 'claude-haiku-4-6' },
+    };
+    expect(resolveReasoningModel('low', provider, 'claude-sonnet-4-6')).toBe('claude-haiku-4-6');
+  });
+
+  test('DEFAULT_REASONING_LEVEL is still default', () => {
+    expect(DEFAULT_REASONING_LEVEL).toBe('default');
+  });
+});

--- a/packages/myco/src/agent/reasoning-levels.ts
+++ b/packages/myco/src/agent/reasoning-levels.ts
@@ -1,3 +1,4 @@
+import { isLocalProvider } from './provider.js';
 import type { ProviderConfig, ReasoningLevel } from './types.js';
 
 export const DEFAULT_REASONING_LEVEL: ReasoningLevel = 'default';
@@ -13,3 +14,115 @@ export function resolveReasoningModel(
     ?? fallbackModel;
 }
 
+// ---------------------------------------------------------------------------
+// Claude thinking-budget resolution
+// ---------------------------------------------------------------------------
+
+/** Mirrors the Claude Agent SDK's `ThinkingConfig` union (sdk.d.ts, v0.3.195). */
+export type ThinkingConfigResolution =
+  | { type: 'enabled'; budgetTokens: number }
+  | { type: 'adaptive' }
+  | { type: 'disabled' };
+
+/**
+ * Default reasoningLevel -> Claude ThinkingConfig mapping.
+ *
+ * `low` uses a small fixed budget (fast, cheap, still genuinely extended
+ * thinking). `default` uses adaptive thinking — Claude decides depth per
+ * turn, which fits Myco's phases better than a single fixed number since
+ * per-turn complexity varies widely even within one tier. `high` uses a
+ * large fixed budget reserved for the few phases that need opus-grade
+ * depth (tune-agent-task-cost Pattern 6: use `high` sparingly).
+ *
+ * Deep-frozen (map + each row) because these row objects are handed to the
+ * Claude SDK by reference (`resolveThinkingConfig` returns them directly,
+ * and `runClaudeQuery` passes the result straight into `query()`'s
+ * `thinking:` option). Freezing makes any future SDK-side mutation of a
+ * returned row throw immediately in strict mode instead of silently
+ * corrupting every subsequent call that resolves the same tier.
+ */
+const DEFAULT_THINKING_MAP: Record<ReasoningLevel, ThinkingConfigResolution> = Object.freeze({
+  low: Object.freeze({ type: 'enabled', budgetTokens: 1024 }),
+  default: Object.freeze({ type: 'adaptive' }),
+  high: Object.freeze({ type: 'enabled', budgetTokens: 32000 }),
+});
+
+/**
+ * Resolve a `reasoningLevel` + provider into a Claude SDK `ThinkingConfig`.
+ *
+ * Local providers (ollama/lmstudio/openai-compatible) always resolve to
+ * `{ type: 'disabled' }` regardless of tier or `thinkingBudgetMap` — their
+ * endpoints don't accept the SDK's thinking/reasoning fields. This is the
+ * sole source of the `{ type: 'disabled' }` thinking config the Claude
+ * harness's `runClaudeQuery` passes to `query()` for local providers.
+ */
+export function resolveThinkingConfig(
+  reasoningLevel: ReasoningLevel | undefined,
+  provider: ProviderConfig | undefined,
+): ThinkingConfigResolution {
+  if (isLocalProvider(provider)) return { type: 'disabled' };
+  const level = reasoningLevel ?? DEFAULT_REASONING_LEVEL;
+  const override = provider?.thinkingBudgetMap?.[level];
+  if (override) {
+    return 'adaptive' in override ? { type: 'adaptive' } : { type: 'enabled', budgetTokens: override.budgetTokens };
+  }
+  return DEFAULT_THINKING_MAP[level];
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI reasoning-effort / verbosity resolution
+// ---------------------------------------------------------------------------
+
+export type OpenAIReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+export type OpenAIVerbosity = 'low' | 'medium' | 'high';
+
+export interface ModelSettingsResolution {
+  reasoning: { effort: OpenAIReasoningEffort };
+  text: { verbosity: OpenAIVerbosity };
+}
+
+/**
+ * Default reasoningLevel -> OpenAI ModelSettings mapping (GPT-5-family
+ * `reasoning.effort` / `text.verbosity`, per @openai/agents-core
+ * `ModelSettings`, v0.12.0). `low`/`default`/`high` map onto the SDK's own
+ * `low`/`medium`/`high` effort levels — deliberately not `'none'` for
+ * `low`, since Myco's low tier still wants genuine (just cheap) reasoning,
+ * not a reasoning-suppressed response.
+ *
+ * Deep-frozen (map + each row) for the same reason as `DEFAULT_THINKING_MAP`
+ * above — these rows are handed to the OpenAI Agents SDK by reference via
+ * `resolveModelSettings` -> `prepareOpenAIRun`'s `modelSettings`, which the
+ * SDK's `Agent` stores directly. Freezing turns a future SDK mutation into
+ * a loud failure instead of corrupting every subsequent run that resolves
+ * the same tier.
+ */
+const DEFAULT_EFFORT_MAP: Record<ReasoningLevel, ModelSettingsResolution> = Object.freeze({
+  low: Object.freeze({ reasoning: Object.freeze({ effort: 'low' }), text: Object.freeze({ verbosity: 'low' }) }),
+  default: Object.freeze({ reasoning: Object.freeze({ effort: 'medium' }), text: Object.freeze({ verbosity: 'medium' }) }),
+  high: Object.freeze({ reasoning: Object.freeze({ effort: 'high' }), text: Object.freeze({ verbosity: 'high' }) }),
+});
+
+/**
+ * Resolve a `reasoningLevel` + provider into OpenAI `ModelSettings.reasoning`
+ * / `ModelSettings.text` fields.
+ *
+ * Returns `undefined` for local providers (ollama/lmstudio/openai-compatible)
+ * — most local backends don't parse GPT-5-style reasoning/verbosity params,
+ * so the field is omitted entirely rather than sent with a value the backend
+ * might reject or silently ignore.
+ */
+export function resolveModelSettings(
+  reasoningLevel: ReasoningLevel | undefined,
+  provider: ProviderConfig | undefined,
+): ModelSettingsResolution | undefined {
+  if (isLocalProvider(provider)) return undefined;
+  const level = reasoningLevel ?? DEFAULT_REASONING_LEVEL;
+  const override = provider?.effortMap?.[level];
+  if (override) {
+    return {
+      reasoning: { effort: override.effort ?? DEFAULT_EFFORT_MAP[level].reasoning.effort },
+      text: { verbosity: override.verbosity ?? DEFAULT_EFFORT_MAP[level].text.verbosity },
+    };
+  }
+  return DEFAULT_EFFORT_MAP[level];
+}

--- a/packages/myco/src/agent/reasoning-tier-schemas.ts
+++ b/packages/myco/src/agent/reasoning-tier-schemas.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared per-tier VALUE schemas for reasoning-level provider overrides.
+ *
+ * `config/schema.ts` (snake_case `ProviderOverrideSchema`, classic `zod`
+ * entry point) and `agent/schemas.ts` (camelCase `ProviderConfigSchema`,
+ * `zod/v4` entry point) both define a `{low, default, high}`-keyed map whose
+ * VALUES are one of these two shapes:
+ *   - thinking-budget: `{ budgetTokens: number }` or `{ adaptive: true }`
+ *   - effort: `{ effort?, verbosity? }`
+ *
+ * Only the tier VALUE shape lives here — the field-name casing
+ * (`thinking_budget_map` vs `thinkingBudgetMap`) and the per-tier key
+ * structure stay local to each file, since that's exactly where the two
+ * schemas diverge.
+ *
+ * Built with `zod/v4` (same as `agent/schemas.ts`); `config/schema.ts`'s
+ * classic `zod` import and this module's `zod/v4` import resolve to the
+ * same underlying zod-core in this zod version (v4.4.3), so schemas built
+ * with either entry point compose freely — verified by
+ * `packages/myco/src/config/schema.test.ts`.
+ *
+ * Lives under `agent/` (not `config/`) because `config/schema.ts` already
+ * imports from `agent/schemas.ts` (for `ReasoningLevelSchema` /
+ * `HarnessIdSchema`); `agent/schemas.ts` never imports from `config/schema.ts`,
+ * so this keeps the existing one-way dependency direction intact.
+ */
+
+import { z } from 'zod/v4';
+
+/**
+ * Anthropic's API rejects a thinking budget below 1024 tokens — this is the
+ * documented minimum, not an arbitrary floor. The 128000 ceiling guards
+ * against config typos (e.g. an extra zero) that would silently burn spend
+ * on every phase run using that tier.
+ */
+export const ThinkingBudgetValueSchema = z.union([
+  z.object({ budgetTokens: z.number().int().min(1024).max(128000) }),
+  z.object({ adaptive: z.literal(true) }),
+]);
+
+export const EffortValueSchema = z.object({
+  effort: z.enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh']).optional(),
+  verbosity: z.enum(['low', 'medium', 'high']).optional(),
+});

--- a/packages/myco/src/agent/schemas.ts
+++ b/packages/myco/src/agent/schemas.ts
@@ -7,6 +7,7 @@
 
 import { z } from 'zod/v4';
 import { SCHEDULABLE_POWER_STATES } from '@myco/constants.js';
+import { ThinkingBudgetValueSchema, EffortValueSchema } from './reasoning-tier-schemas.js';
 
 // ---------------------------------------------------------------------------
 // Schema version
@@ -29,10 +30,28 @@ export const ProviderConfigSchema = z.object({
   baseUrl: z.string().optional(),
   apiKey: z.string().optional(),
   model: z.string().optional(),
+  /**
+   * Per-tier model-name override, independently keyed from
+   * `thinkingBudgetMap`/`effortMap`. If an operator pins `reasoningMap.<tier>`
+   * to a swapped model, they must verify that model supports the same
+   * tier's `thinkingBudgetMap`/`effortMap` setting — the maps are resolved
+   * independently, so a mismatch isn't caught here; the API rejects the run
+   * with a 400 at call time instead.
+   */
   reasoningMap: z.object({
     low: z.string().optional(),
     default: z.string().optional(),
     high: z.string().optional(),
+  }).optional(),
+  thinkingBudgetMap: z.object({
+    low: ThinkingBudgetValueSchema.optional(),
+    default: ThinkingBudgetValueSchema.optional(),
+    high: ThinkingBudgetValueSchema.optional(),
+  }).optional(),
+  effortMap: z.object({
+    low: EffortValueSchema.optional(),
+    default: EffortValueSchema.optional(),
+    high: EffortValueSchema.optional(),
   }).optional(),
   contextLength: z.number().optional(),
 });

--- a/packages/myco/src/agent/types.ts
+++ b/packages/myco/src/agent/types.ts
@@ -300,6 +300,25 @@ export interface ProviderConfig {
   apiKey?: string;
   model?: string;
   reasoningMap?: Partial<Record<ReasoningLevel, string>>;
+  /**
+   * Claude-only per-tier override of the default thinking-budget map
+   * (`DEFAULT_THINKING_MAP` in `reasoning-levels.ts`). Unset tiers fall
+   * back to the default. Ignored entirely for local providers — the
+   * harness always forces `{ type: 'disabled' }` there regardless of
+   * this map (see `resolveThinkingConfig`).
+   */
+  thinkingBudgetMap?: Partial<Record<ReasoningLevel, { budgetTokens: number } | { adaptive: true }>>;
+  /**
+   * OpenAI-only per-tier override of the default reasoning-effort /
+   * verbosity map (`DEFAULT_EFFORT_MAP` in `reasoning-levels.ts`). Unset
+   * tiers fall back to the default. Ignored entirely for local providers
+   * — `resolveModelSettings` returns `undefined` there so no
+   * `reasoning`/`text` fields are ever sent to a local backend.
+   */
+  effortMap?: Partial<Record<ReasoningLevel, {
+    effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+    verbosity?: 'low' | 'medium' | 'high';
+  }>>;
   /** Context window size for local models (Ollama num_ctx, LM Studio context_length). */
   contextLength?: number;
 }

--- a/packages/myco/src/config/schema.test.ts
+++ b/packages/myco/src/config/schema.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test';
+import { MycoConfigSchema } from './schema.js';
+
+describe('ProviderOverrideSchema (via MycoConfigSchema.agent.provider)', () => {
+  test('keeps thinking_budget_map and effort_map (Zod v4 default-strips unknown keys otherwise)', () => {
+    const parsed = MycoConfigSchema.parse({
+      version: 3,
+      agent: {
+        provider: {
+          type: 'anthropic',
+          thinking_budget_map: { low: { budgetTokens: 2048 } },
+          effort_map: { high: { effort: 'xhigh', verbosity: 'high' } },
+        },
+      },
+    });
+    expect(parsed.agent.provider?.thinking_budget_map).toEqual({ low: { budgetTokens: 2048 } });
+    expect(parsed.agent.provider?.effort_map).toEqual({ high: { effort: 'xhigh', verbosity: 'high' } });
+  });
+
+  test('omitting thinking_budget_map/effort_map is not an error and leaves them undefined', () => {
+    const parsed = MycoConfigSchema.parse({
+      version: 3,
+      agent: {
+        provider: {
+          type: 'anthropic',
+          reasoning_map: { low: 'claude-haiku-4-6' },
+        },
+      },
+    });
+    expect(parsed.agent.provider?.reasoning_map).toEqual({ low: 'claude-haiku-4-6' });
+    expect(parsed.agent.provider?.thinking_budget_map).toBeUndefined();
+    expect(parsed.agent.provider?.effort_map).toBeUndefined();
+  });
+
+  test('budgetTokens must be positive integer (rejects negative values)', () => {
+    const result = MycoConfigSchema.safeParse({
+      version: 3,
+      agent: {
+        provider: {
+          type: 'anthropic',
+          thinking_budget_map: { low: { budgetTokens: -50 } },
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('budgetTokens must be positive integer (rejects floating-point values)', () => {
+    const result = MycoConfigSchema.safeParse({
+      version: 3,
+      agent: {
+        provider: {
+          type: 'anthropic',
+          thinking_budget_map: { default: { budgetTokens: 1.5 } },
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('budgetTokens below the Anthropic API minimum (1024) is rejected', () => {
+    const result = MycoConfigSchema.safeParse({
+      version: 3,
+      agent: {
+        provider: {
+          type: 'anthropic',
+          thinking_budget_map: { low: { budgetTokens: 512 } },
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('budgetTokens at the Anthropic API minimum (1024) is accepted', () => {
+    const result = MycoConfigSchema.safeParse({
+      version: 3,
+      agent: {
+        provider: {
+          type: 'anthropic',
+          thinking_budget_map: { low: { budgetTokens: 1024 } },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { SCHEDULABLE_POWER_STATES } from '@myco/constants.js';
 import { AcceleratorConfigSchema, ReasoningLevelSchema, HarnessIdSchema } from '@myco/agent/schemas.js';
+import { ThinkingBudgetValueSchema, EffortValueSchema } from '@myco/agent/reasoning-tier-schemas.js';
 
 function rejectLegacyRuntimeKey<T extends z.ZodTypeAny>(schema: T) {
   return z.unknown().superRefine((value, ctx) => {
@@ -119,10 +120,30 @@ const ProviderOverrideSchema = rejectLegacyRuntimeKey(z.object({
   local_backend: z.enum(['ollama', 'lmstudio']).optional(),
   base_url: z.string().optional(),
   model: z.string().optional(),
+  /**
+   * Per-tier model-name override, independently keyed from
+   * `thinking_budget_map`/`effort_map`. If an operator pins
+   * `reasoning_map.<tier>` to a swapped model, they must verify that model
+   * supports the same tier's `thinking_budget_map`/`effort_map` setting —
+   * the maps are resolved independently, so a mismatch isn't caught here;
+   * the API rejects the run with a 400 at call time instead.
+   */
   reasoning_map: z.object({
     low: z.string().optional(),
     default: z.string().optional(),
     high: z.string().optional(),
+  }).optional(),
+  /** Claude-only per-tier ThinkingConfig override; unset tiers fall back to DEFAULT_THINKING_MAP. */
+  thinking_budget_map: z.object({
+    low: ThinkingBudgetValueSchema.optional(),
+    default: ThinkingBudgetValueSchema.optional(),
+    high: ThinkingBudgetValueSchema.optional(),
+  }).optional(),
+  /** OpenAI-only per-tier reasoning effort + verbosity override; unset tiers fall back to DEFAULT_EFFORT_MAP. */
+  effort_map: z.object({
+    low: EffortValueSchema.optional(),
+    default: EffortValueSchema.optional(),
+    high: EffortValueSchema.optional(),
   }).optional(),
   /** Context window size for local models (Ollama num_ctx, LM Studio context_length). */
   context_length: z.number().int().positive().optional(),

--- a/tests/agent/harness/openai-model-settings.test.ts
+++ b/tests/agent/harness/openai-model-settings.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Tests for OpenAIAgentsHarness modelSettings wiring:
+ *   - execute() resolves reasoningLevel + provider into ModelSettings via
+ *     resolveModelSettings() and attaches it to the constructed Agent, but
+ *     ONLY when the resolved model name is GPT-5-family
+ *     (`gpt5ReasoningSettingsRequired`, from @openai/agents-core's
+ *     defaultModel.js, re-exported via '@openai/agents').
+ *   - openScope() gets the same treatment — setup.reasoningLevel flows
+ *     through prepareOpenAIRun exactly like setup.model/provider already do
+ *     (mirrors the Claude harness, where thinking-config resolution applies
+ *     to both execute() and openScope(), not just execute()).
+ *   - Local providers (ollama/lmstudio/openai-compatible) never get a
+ *     `modelSettings` key passed to the Agent constructor at all — the SDK's
+ *     own default (`{}` for non-GPT-5 model names) is what the Agent ends up
+ *     with, identical to today's behavior before this wiring existed.
+ *   - Non-local providers with a non-GPT-5 model name (gpt-4.1-mini, an
+ *     arbitrary openrouter route) ALSO get no `modelSettings` key — passing
+ *     it explicitly would bypass agents-core's own guard (agent.js ~96-116)
+ *     that resets settings to `{}` for those models, and the API 400s on
+ *     `reasoning.effort`/`text.verbosity` for a model that doesn't support it.
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+import { Agent, Runner } from '@openai/agents';
+import { OpenAIAgentsHarness } from '@myco/agent/harness/openai.js';
+
+// LM Studio's real backend makes a network call (`ensureLoaded`) to load
+// the model before the harness can construct the Agent. Stub it so the
+// lmstudio local-provider case can be asserted at the harness level
+// without depending on a live LM Studio server — mirrors how
+// runtime-claude.test.ts stubs SDK-adjacent modules rather than hitting
+// the real thing.
+mock.module('@myco/intelligence/lm-studio.js', () => ({
+  LmStudioBackend: class {
+    async ensureLoaded() { /* no-op stub — no live server required */ }
+    getLoadedInstanceId() { return 'stub-lmstudio-model'; }
+  },
+}));
+
+function stubModelProvider() {
+  return {
+    async getModel() {
+      return {
+        async getResponse() {
+          return {
+            output: [{ type: 'output_text', text: 'plain text response' }],
+            usage: { requests: 1, inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+          };
+        },
+      };
+    },
+  } as any;
+}
+
+async function captureConstructedAgent(run: () => Promise<unknown>): Promise<Agent | undefined> {
+  let capturedAgent: Agent | undefined;
+  const originalRun = Runner.prototype.run;
+  Runner.prototype.run = async function (agent: Agent, ...rest: unknown[]) {
+    capturedAgent = agent;
+    return originalRun.apply(this, [agent, ...rest] as never);
+  } as typeof originalRun;
+  try {
+    await run();
+  } catch {
+    // Tolerate stub-model shape mismatches; only Agent construction matters here.
+  } finally {
+    Runner.prototype.run = originalRun;
+  }
+  return capturedAgent;
+}
+
+describe('OpenAIAgentsHarness.execute — modelSettings wiring', () => {
+  it('attaches modelSettings resolved from reasoningLevel + provider for a non-local provider', async () => {
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider() });
+    const capturedAgent = await captureConstructedAgent(() => harness.execute({
+      prompt: 'do something',
+      model: 'gpt-5.4-mini',
+      provider: { type: 'openai' },
+      reasoningLevel: 'high',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    }));
+
+    expect(capturedAgent?.modelSettings).toEqual({
+      reasoning: { effort: 'high' },
+      text: { verbosity: 'high' },
+    });
+  });
+
+  it('defaults to the medium tier when reasoningLevel is omitted for a non-local provider', async () => {
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider() });
+    const capturedAgent = await captureConstructedAgent(() => harness.execute({
+      prompt: 'do something',
+      model: 'gpt-5.4-mini',
+      provider: { type: 'openai' },
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    }));
+
+    expect(capturedAgent?.modelSettings).toEqual({
+      reasoning: { effort: 'medium' },
+      text: { verbosity: 'medium' },
+    });
+  });
+
+  it('defaults to the medium tier when no provider is supplied at all', async () => {
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider() });
+    const capturedAgent = await captureConstructedAgent(() => harness.execute({
+      prompt: 'do something',
+      model: 'gpt-5.4-mini',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    }));
+
+    expect(capturedAgent?.modelSettings).toEqual({
+      reasoning: { effort: 'medium' },
+      text: { verbosity: 'medium' },
+    });
+  });
+
+  it('honors a provider effortMap override for a non-local provider', async () => {
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider() });
+    const capturedAgent = await captureConstructedAgent(() => harness.execute({
+      prompt: 'do something',
+      model: 'gpt-5.4-mini',
+      provider: {
+        type: 'openai',
+        effortMap: { low: { effort: 'minimal', verbosity: 'low' } },
+      },
+      reasoningLevel: 'low',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    }));
+
+    expect(capturedAgent?.modelSettings).toEqual({
+      reasoning: { effort: 'minimal' },
+      text: { verbosity: 'low' },
+    });
+  });
+
+  it('resolves the same way for an openrouter provider routing to a GPT-5-family model', async () => {
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider() });
+    const capturedAgent = await captureConstructedAgent(() => harness.execute({
+      prompt: 'do something',
+      model: 'gpt-5.4-mini',
+      provider: { type: 'openrouter' },
+      reasoningLevel: 'low',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    }));
+
+    expect(capturedAgent?.modelSettings).toEqual({
+      reasoning: { effort: 'low' },
+      text: { verbosity: 'low' },
+    });
+  });
+
+  it('sends no modelSettings key for a non-GPT-5 model name even on a non-local provider (gpt-4.1-mini)', async () => {
+    // Structural regression guard: explicitly passing `modelSettings` to
+    // `new Agent(...)` bypasses agents-core's own guard (agent.js ~96-116)
+    // that resets settings to `{}` for non-GPT-5 model names. A configured
+    // effortMap + a non-default reasoningLevel must NOT be enough to force
+    // reasoning/text fields onto a model the SDK doesn't recognize as
+    // GPT-5-family — the OpenAI API 400s on `reasoning.effort` for models
+    // like gpt-4.1-mini that don't support it.
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider() });
+    const capturedAgent = await captureConstructedAgent(() => harness.execute({
+      prompt: 'do something',
+      model: 'gpt-4.1-mini',
+      provider: {
+        type: 'openai',
+        effortMap: { high: { effort: 'xhigh', verbosity: 'high' } },
+      },
+      reasoningLevel: 'high',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    }));
+
+    expect(capturedAgent?.modelSettings).toEqual({});
+  });
+
+  it('sends no modelSettings key for an arbitrary (non-GPT-5) openrouter route', async () => {
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider() });
+    const capturedAgent = await captureConstructedAgent(() => harness.execute({
+      prompt: 'do something',
+      model: 'openrouter/auto',
+      provider: { type: 'openrouter' },
+      reasoningLevel: 'low',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    }));
+
+    expect(capturedAgent?.modelSettings).toEqual({});
+  });
+
+  // OpenRouter catalogs GPT-5-family models under vendor-prefixed slugs
+  // ('openai/gpt-5.4-mini'), which the SDK's gpt5ReasoningSettingsRequired
+  // classifies as non-reasoning (startsWith('gpt-5') fails on the prefix).
+  // The gate therefore sends no modelSettings for them — identical to the
+  // SDK's own pre-gate constructor behavior for these names. Attaching
+  // settings for prefixed slugs would require model-name normalization plus
+  // a live openrouter smoke; until then this test pins the parity behavior.
+  it('openrouter vendor-prefixed GPT-5 slugs currently get no modelSettings (SDK gpt5ReasoningSettingsRequired parity — known gap)', async () => {
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider() });
+    const capturedAgent = await captureConstructedAgent(() => harness.execute({
+      prompt: 'do something',
+      model: 'openai/gpt-5.4-mini',
+      provider: {
+        type: 'openrouter',
+        effortMap: { high: { effort: 'xhigh', verbosity: 'high' } },
+      },
+      reasoningLevel: 'high',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    }));
+
+    expect(capturedAgent?.modelSettings).toEqual({});
+  });
+
+  it('sends no modelSettings key to the Agent constructor for an ollama provider', async () => {
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider() });
+    const capturedAgent = await captureConstructedAgent(() => harness.execute({
+      prompt: 'do something',
+      model: 'gemma4:26b',
+      provider: { type: 'ollama' },
+      reasoningLevel: 'low',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    }));
+
+    // The SDK's own default for a non-GPT-5 model name is `{}` — proof that
+    // no `modelSettings` key was passed to `new Agent({...})` at all, byte-
+    // for-byte identical to pre-wiring behavior.
+    expect(capturedAgent?.modelSettings).toEqual({});
+  });
+
+  it('sends no modelSettings key to the Agent constructor for a lmstudio provider', async () => {
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider() });
+    const capturedAgent = await captureConstructedAgent(() => harness.execute({
+      prompt: 'do something',
+      model: 'local-model',
+      provider: { type: 'lmstudio' },
+      reasoningLevel: 'default',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    }));
+
+    expect(capturedAgent?.modelSettings).toEqual({});
+  });
+
+  it('sends no modelSettings key to the Agent constructor for an openai-compatible provider', async () => {
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider() });
+    const capturedAgent = await captureConstructedAgent(() => harness.execute({
+      prompt: 'do something',
+      model: 'google/gemma-4-26b-a4b',
+      provider: { type: 'openai-compatible' },
+      reasoningLevel: 'high',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    }));
+
+    expect(capturedAgent?.modelSettings).toEqual({});
+  });
+
+  it('ADVERSARIAL: an aggressively configured local provider (effortMap high + reasoningLevel high) still sends nothing', async () => {
+    // Regression guard for the plan's global constraint: local providers
+    // (ollama/lmstudio/openai-compatible) must see ZERO reasoning/text
+    // fields sent, no matter how the operator has configured effortMap or
+    // reasoningLevel. resolveModelSettings() already enforces this via
+    // isLocalProvider() — this test locks the harness call site so a
+    // future refactor of prepareOpenAIRun can't silently start spreading
+    // in a value for local providers.
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider() });
+    const capturedAgent = await captureConstructedAgent(() => harness.execute({
+      prompt: 'do something',
+      model: 'gemma4:26b',
+      provider: {
+        type: 'ollama',
+        effortMap: { high: { effort: 'xhigh', verbosity: 'high' } },
+      },
+      reasoningLevel: 'high',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    }));
+
+    expect(capturedAgent?.modelSettings).toEqual({});
+  });
+});
+
+describe('OpenAIAgentsHarness.openScope — modelSettings wiring', () => {
+  it('attaches modelSettings resolved from setup.reasoningLevel + setup.provider', async () => {
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider() });
+    const scope = await harness.openScope({
+      model: 'gpt-5.4-mini',
+      provider: { type: 'openai' },
+      reasoningLevel: 'high',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    });
+    const capturedAgent = await captureConstructedAgent(() => scope.run({ prompt: 'item 1' }));
+    await scope.close();
+
+    expect(capturedAgent?.modelSettings).toEqual({
+      reasoning: { effort: 'high' },
+      text: { verbosity: 'high' },
+    });
+  });
+
+  it('sends no modelSettings key to the Agent constructor for a local provider scope', async () => {
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider() });
+    const scope = await harness.openScope({
+      model: 'gemma4:26b',
+      provider: { type: 'ollama' },
+      reasoningLevel: 'high',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    });
+    const capturedAgent = await captureConstructedAgent(() => scope.run({ prompt: 'item 1' }));
+    await scope.close();
+
+    expect(capturedAgent?.modelSettings).toEqual({});
+  });
+});

--- a/tests/agent/map-phase.test.ts
+++ b/tests/agent/map-phase.test.ts
@@ -74,6 +74,7 @@ describe('executeMapPhase — happy path', () => {
       systemPrompt: 'sys',
       runId: 'r1',
       agentId: 'a',
+      reasoningLevel: 'high',
     });
 
     expect(result.itemCount).toBe(3);
@@ -84,6 +85,12 @@ describe('executeMapPhase — happy path', () => {
     expect(calls).toHaveLength(3);
     // The harness pins `path` from argMap; the model only supplies `description`.
     expect(calls[0]).toMatchObject({ path: 'a.ts', description: 'summary of a.ts' });
+    // Regression for the reasoningLevel plumbing gap: the no-openScope
+    // execute-fallback path (this stub has no `openScope`) must forward
+    // reasoningLevel on every per-item harness.execute() call.
+    for (const call of (stubRuntime.execute as any).mock.calls) {
+      expect(call[0].reasoningLevel).toBe('high');
+    }
   });
 });
 
@@ -369,6 +376,7 @@ describe('executeMapPhase — scoped fast path', () => {
       systemPrompt: 'sys',
       runId: 'r',
       agentId: 'a',
+      reasoningLevel: 'high',
     });
     expect(scopeOpens).toBe(1);
     expect(scopeRuns).toBe(3);
@@ -381,6 +389,11 @@ describe('executeMapPhase — scoped fast path', () => {
     // pinned `path` from argMap each time.
     expect(calls).toHaveLength(3);
     expect(calls[0]).toMatchObject({ path: 'a.ts', description: 'summary of a.ts' });
+    // Regression for the reasoningLevel plumbing gap: executeMapPhase's
+    // openScope call must forward the phase's resolved reasoningLevel on
+    // the setup object, not just phaseModel/provider.
+    const openScopeSetup = (stubRuntime.openScope as any).mock.calls[0][0];
+    expect(openScopeSetup.reasoningLevel).toBe('high');
   });
 
   it('closes scope even when an item throws under onItemError: abort', async () => {

--- a/tests/agent/phase-loop.test.ts
+++ b/tests/agent/phase-loop.test.ts
@@ -529,6 +529,31 @@ describe('executeSingleQuery', () => {
     expect(capturedExecuteInputs).toHaveLength(1);
   });
 
+  it('forwards the resolved reasoningLevel from config into the harness execute() input', async () => {
+    // Regression for the reasoningLevel plumbing gap: executeSingleQuery
+    // resolves `effectiveReasoningLevel` from config.execution.reasoningLevel
+    // ?? config.reasoningLevel and must forward it on baseInput, not just
+    // use it to pick a model.
+    const ctx = baseContext({
+      config: { ...baseConfig(), reasoningLevel: 'high' },
+    });
+    await executeSingleQuery(ctx, 'PROMPT');
+    expect(capturedExecuteInputs).toHaveLength(1);
+    expect(capturedExecuteInputs[0].reasoningLevel).toBe('high');
+  });
+
+  it('prefers config.execution.reasoningLevel over the top-level config.reasoningLevel', async () => {
+    const ctx = baseContext({
+      config: {
+        ...baseConfig(),
+        reasoningLevel: 'low',
+        execution: { reasoningLevel: 'high' },
+      },
+    });
+    await executeSingleQuery(ctx, 'PROMPT');
+    expect(capturedExecuteInputs[0].reasoningLevel).toBe('high');
+  });
+
   it('forwards sessionRef/sessionData into the runtime call', async () => {
     const ctx = baseContext();
     await executeSingleQuery(ctx, 'PROMPT', undefined, 'prev-session', { key: 1 });
@@ -673,6 +698,27 @@ describe('executePhasedQuery', () => {
     expect(checkpointState.phases.b.status).toBe('skipped');
     expect(checkpointState.phases.b.summary).toContain('did not match');
     expect(checkpointState.phases.b.summary).toContain('missing');
+  });
+
+  it('forwards each phase\'s resolved reasoningLevel into the harness execute() input on the wave-loop path', async () => {
+    // Regression for the reasoningLevel plumbing gap: resolvePhaseExecution
+    // has always resolved reasoningLevel per-phase, but the wave loop's
+    // executePhase call must actually forward waveInput.reasoningLevel —
+    // proven droppable by mutation before this assertion existed.
+    const phases = [
+      phase('a', { reasoningLevel: 'high' }),
+      phase('b', { reasoningLevel: 'low' }),
+    ];
+    const ctx = baseContext({ config: baseConfig(phases) });
+    await executePhasedQuery(ctx);
+
+    const byPhase = new Map<string, string | undefined>();
+    for (const input of capturedExecuteInputs) {
+      const match = input.prompt.match(/## Current Phase: (\S+)/);
+      if (match) byPhase.set(match[1], input.reasoningLevel);
+    }
+    expect(byPhase.get('a')).toBe('high');
+    expect(byPhase.get('b')).toBe('low');
   });
 
   it('invokes persistCheckpoints between waves', async () => {
@@ -842,6 +888,47 @@ describe('executePhasedQuery turnOffset allocation', () => {
 // ---------------------------------------------------------------------------
 
 describe('executePhasedQuery orchestrator structured output', () => {
+  it('forwards the orchestrator-resolved reasoningLevel into the orchestrator\'s execute() input', async () => {
+    // Regression for the reasoningLevel plumbing gap on the orchestrator
+    // block: orchestratorReasoningLevel is resolved as
+    // config.orchestrator.reasoningLevel ?? config.execution?.reasoningLevel
+    // ?? config.reasoningLevel, and that resolved value must reach the
+    // orchestrator's own harness.execute() call (identified here by its
+    // empty toolNames, which only the orchestrator call sets).
+    runtimeBehaviors = [
+      { kind: 'success', result: { finalText: '{"phases":[],"reasoning":"unused"}' } },
+    ];
+    const phases = [phase('extract')];
+    const ctx = baseContext({
+      config: {
+        ...baseConfig(phases),
+        reasoningLevel: 'low',
+        orchestrator: { enabled: true, reasoningLevel: 'high' },
+      } as EffectiveConfig,
+    });
+    await executePhasedQuery(ctx);
+    const orchestratorCall = capturedExecuteInputs.find((input) => input.toolSurface.toolNames?.length === 0);
+    expect(orchestratorCall?.reasoningLevel).toBe('high');
+  });
+
+  it('falls back through config.execution.reasoningLevel then config.reasoningLevel when orchestrator.reasoningLevel is unset', async () => {
+    runtimeBehaviors = [
+      { kind: 'success', result: { finalText: '{"phases":[],"reasoning":"unused"}' } },
+    ];
+    const phases = [phase('extract')];
+    const ctx = baseContext({
+      config: {
+        ...baseConfig(phases),
+        reasoningLevel: 'low',
+        execution: { reasoningLevel: 'high' },
+        orchestrator: { enabled: true },
+      },
+    });
+    await executePhasedQuery(ctx);
+    const orchestratorCall = capturedExecuteInputs.find((input) => input.toolSurface.toolNames?.length === 0);
+    expect(orchestratorCall?.reasoningLevel).toBe('high');
+  });
+
   it('requests outputSchema on the orchestrator call when the harness supports structuredOutput', async () => {
     runtimeSupportsStructuredOutput = true;
     runtimeBehaviors = [

--- a/tests/agent/runtime-claude.test.ts
+++ b/tests/agent/runtime-claude.test.ts
@@ -340,3 +340,103 @@ describe('ClaudeSdkHarness.supports', () => {
     expect(runtime.supports('structuredOutput')).toBe(true);
   });
 });
+
+describe('ClaudeSdkHarness.execute — thinking-config wiring', () => {
+  beforeEach(() => {
+    queryCalls.length = 0;
+    scopedServerCalls.length = 0;
+    fullServerCalls.length = 0;
+    structuredOutputOverride = undefined;
+  });
+
+  it('resolves reasoningLevel "high" to an enabled thinking budget for an anthropic provider', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    await runtime.execute(makeInput({
+      reasoningLevel: 'high',
+      provider: { type: 'anthropic' },
+    }));
+
+    expect(queryCalls[0].options.thinking).toEqual({ type: 'enabled', budgetTokens: 32000 });
+  });
+
+  it('defaults to adaptive thinking when reasoningLevel is omitted for a non-local provider', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    await runtime.execute(makeInput({ provider: { type: 'anthropic' } }));
+
+    expect(queryCalls[0].options.thinking).toEqual({ type: 'adaptive' });
+  });
+
+  it('defaults to adaptive thinking when no provider is supplied at all', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    await runtime.execute(makeInput());
+
+    expect(queryCalls[0].options.thinking).toEqual({ type: 'adaptive' });
+  });
+
+  it('honors a provider thinkingBudgetMap override for a non-local provider', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    await runtime.execute(makeInput({
+      reasoningLevel: 'low',
+      provider: {
+        type: 'anthropic',
+        thinkingBudgetMap: { low: { budgetTokens: 2048 } },
+      },
+    }));
+
+    expect(queryCalls[0].options.thinking).toEqual({ type: 'enabled', budgetTokens: 2048 });
+  });
+
+  it('forces disabled thinking for a local (ollama) provider even with a thinkingBudgetMap configured and reasoningLevel "high"', async () => {
+    // Regression: suppressEffortLeakForLocalProvider used to force
+    // `{ type: 'disabled' }` unconditionally for local providers, before
+    // any tier-based thinking logic ran. resolveThinkingConfig must
+    // preserve that ordering — a local provider's thinkingBudgetMap
+    // override (if one is even configured) must never leak a non-disabled
+    // thinking config to an endpoint that can't parse the SDK's reasoning
+    // fields.
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    await runtime.execute(makeInput({
+      reasoningLevel: 'high',
+      provider: {
+        type: 'ollama',
+        thinkingBudgetMap: { high: { budgetTokens: 32000 } },
+      },
+    }));
+
+    expect(queryCalls[0].options.thinking).toEqual({ type: 'disabled' });
+  });
+
+  it('forces disabled thinking for a local (lmstudio) provider regardless of reasoningLevel', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    await runtime.execute(makeInput({
+      reasoningLevel: 'low',
+      provider: { type: 'lmstudio' },
+    }));
+
+    expect(queryCalls[0].options.thinking).toEqual({ type: 'disabled' });
+  });
+
+  it('forces disabled thinking for a local (openai-compatible) provider regardless of reasoningLevel', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    await runtime.execute(makeInput({
+      reasoningLevel: 'default',
+      provider: { type: 'openai-compatible' },
+    }));
+
+    expect(queryCalls[0].options.thinking).toEqual({ type: 'disabled' });
+  });
+});


### PR DESCRIPTION
## Summary

Plan #3 of the Agent Harness SDK Alignment sequence. The existing three-tier `reasoningLevel` (`low`/`default`/`high`) now maps onto real provider reasoning controls, end-to-end from the phase resolver into both harness adapters.

- **Resolvers** (`reasoning-levels.ts`): `resolveThinkingConfig` (Claude `ThinkingConfig`) and `resolveModelSettings` (OpenAI `reasoning.effort`/`text.verbosity`), driven by frozen static default tables with optional per-tier provider overrides (`thinking_budget_map` / `effort_map` in myco.yaml's provider block; shared tier-value schemas bounded `.int().min(1024).max(128000)`).
- **Claude harness**: attaches `thinking:` at `query()`. The old `suppressEffortLeakForLocalProvider` is deleted — its invariant now lives in the resolver's first line, so **local providers (ollama/lmstudio/openai-compatible) still get `thinking: disabled` unconditionally**, adversarially regression-tested (configured budget map + high level → still disabled).
- **OpenAI harness**: attaches `modelSettings` at `Agent` construction, **gated on the SDK's own `gpt5ReasoningSettingsRequired`** so non-reasoning models (gpt-4.1*, arbitrary OpenRouter routes) keep the SDK's reset-to-default guard instead of receiving params they'd 400 on. Local providers get no fields at all.
- **Threading**: per-phase resolved `reasoningLevel` forwarded at all nine harness call sites (wave loop, session retries, single-query, orchestrator ×3 incl. the structured-output retry, map-phase openScope + fallback), with **mutation-verified** integration tests — the final review proved by mutation that the original test coverage couldn't catch a dropped forward; the added assertions now bite at every site.

## Cloud-path behavior delta (intentional, per plan — sanity-check me)

| Level | Claude (anthropic) | OpenAI (gpt-5-family) |
|---|---|---|
| low (16 YAML usages) | `{enabled, budgetTokens: 1024}` vs previous adaptive-by-default — cheaper, capped | `effort low` vs SDK default `none` — enables reasoning, cost UP |
| default / unset (most tasks) | explicit `{adaptive}` — intended no-op vs SDK default | `effort/verbosity medium` vs `none`/`low` — material cost increase |
| high (no YAML usage today) | `{enabled, budgetTokens: 32000}` | `effort/verbosity high` |

Known gap (SDK-parity, pinned by test): OpenRouter vendor-prefixed GPT-5 slugs (`openai/gpt-5.4-mini`) are classified non-reasoning by the SDK's own check, so they get no settings — identical to pre-branch behavior; fixing it needs name normalization + a live openrouter smoke.

## ⚠️ Pre-tag live smoke required (not run in this PR)

Structural + unit verification only — no live API call has exercised the new request shapes. Gate cases from the final review: (a) Claude cloud at each level against the default `sonnet` model; (b) Claude `low` against any `reasoningMap`-pinned model in the dogfood grove; (c) OpenAI harness with a gpt-5-family model; (d) any non-GPT-5 openai/openrouter config (expects the gate to protect it).

## Test plan

- [x] TDD per task (5 tasks), per-task spec+quality reviews; one Critical test-coverage gap caught by reviewer mutation-testing and fixed with bite-proven assertions
- [x] Final whole-branch review (most capable model) + dimensions review — all fix-before-merge findings applied and independently re-verified
- [x] `npm test -- tests/agent` — 525+ pass / 1 pre-existing skip / 0 fail; full `npm test` green
- [x] `make build` green
- [ ] Live-API smoke (see above — deliberately deferred to human pre-tag verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)