### PR TITLE
test(ui): allowlist per-tier reasoning-budget maps in manifest sync guard

### DIFF
--- a/tests/ui/settings-manifest-sync.test.ts
+++ b/tests/ui/settings-manifest-sync.test.ts
@@ -26,6 +26,10 @@ const ALLOWLIST: readonly string[] = [
   'agent.cold_project_threshold_days',
   'agent.provider.local_backend',
   'agent.provider.reasoning_map',
+  // Per-tier reasoning-budget maps (PR #609) are yaml-only advanced config,
+  // same as reasoning_map; a Settings editor is an explicit fast-follow.
+  'agent.provider.thinking_budget_map',
+  'agent.provider.effort_map',
   'notifications.domains',
   // release_provenance.reconcile_interval_minutes appears in BOTH the project
   // tier (ReleaseProvenanceSchema) and the grove tier (GroveReleaseProvenanceSchema).


### PR DESCRIPTION
PR #609 added `agent.provider.thinking_budget_map`/`effort_map` as yaml-only advanced provider config (a Settings editor is the documented fast-follow), which tripped the settings-manifest drift guard on main. Allowlists both prefixes beside the existing `reasoning_map` precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)