### PR TITLE
feat(agent): harness-neutral lifecycle hooks with near-real-time run events

### DIFF
--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -59,6 +59,8 @@ import {
 } from './executor-state.js';
 import { getAgentHarness } from './harness/index.js';
 import { HarnessExecutionError } from './harness/types.js';
+import { buildAuditEventHooks } from './harness/audit-hooks.js';
+import type { HarnessHooks } from './harness/hooks.js';
 import {
   analyzeRuntimeTokenBudget,
   buildRunAccountingUpdate,
@@ -125,6 +127,31 @@ function logTokenBudgetPressure(
     contextWindowTokens: budget.contextWindowTokens,
     peakRequestTotalTokens: budget.peakRequestTotalTokens,
   });
+}
+
+/**
+ * Merge the default audit-event hooks (always on) with any caller-supplied
+ * hooks (RunOptions.hooks). Both fire for every event — the caller's hooks
+ * are additive, not a replacement for the audit recorder. Each merged
+ * callback is best-effort: a failure in either side must not stop the
+ * other from running or bubble into the tool/phase call it's observing.
+ */
+function mergeHooks(defaultHooks: HarnessHooks, callerHooks: HarnessHooks | undefined): HarnessHooks {
+  if (!callerHooks) return defaultHooks;
+  return {
+    preToolUse: async (event) => {
+      await Promise.allSettled([defaultHooks.preToolUse?.(event), callerHooks.preToolUse?.(event)]);
+    },
+    postToolUse: async (event) => {
+      await Promise.allSettled([defaultHooks.postToolUse?.(event), callerHooks.postToolUse?.(event)]);
+    },
+    phaseStart: async (event) => {
+      await Promise.allSettled([defaultHooks.phaseStart?.(event), callerHooks.phaseStart?.(event)]);
+    },
+    phaseEnd: async (event) => {
+      await Promise.allSettled([defaultHooks.phaseEnd?.(event), callerHooks.phaseEnd?.(event)]);
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -282,6 +309,7 @@ export async function runAgent(
     ?? taskProviderOverride
     ?? config.execution?.provider;
   const runId = options?.resumeRunId ?? crypto.randomUUID();
+  const runHooks = mergeHooks(buildAuditEventHooks(runId, projectId ?? null), options?.hooks);
   let harnessId = runHarness;
   let effectiveModel = resolveReasoningModel(
     config.execution?.reasoningLevel ?? config.reasoningLevel,
@@ -505,6 +533,7 @@ export async function runAgent(
       options,
       checkpointState,
       persistCheckpoints: persistHarnessState,
+      hooks: runHooks,
     };
 
     if (config.phases && config.phases.length > 0) {

--- a/packages/myco/src/agent/harness/audit-hooks.ts
+++ b/packages/myco/src/agent/harness/audit-hooks.ts
@@ -1,0 +1,91 @@
+/**
+ * Default HarnessHooks implementation: persists every lifecycle event to
+ * agent_run_events. executor.ts wires this in as the default hooks object
+ * for every run — event recording is on by default, no per-call opt-in,
+ * matching how recordTurn/insertWriteIntent are unconditional today.
+ *
+ * Best-effort: a broken event-log insert must never fail the tool call or
+ * the phase it's observing — same convention as recordTurn (tools.ts) and
+ * insertWriteIntent (write-intents.ts).
+ */
+
+import { insertRunEvent } from '@myco/db/queries/agent-run-events.js';
+import type { GroveProjectId } from '@myco/grove/ids.js';
+import type {
+  HarnessHooks,
+  PreToolUseEvent,
+  PostToolUseEvent,
+  PhaseStartEvent,
+  PhaseEndEvent,
+} from './hooks.js';
+
+export function buildAuditEventHooks(runId: string, projectId: GroveProjectId | null): HarnessHooks {
+  return {
+    async preToolUse(event: PreToolUseEvent) {
+      try {
+        insertRunEvent({
+          runId,
+          projectId,
+          phaseName: event.phaseName ?? null,
+          eventType: 'pre_tool_use',
+          toolName: event.toolName,
+          payload: JSON.stringify({ toolInput: event.toolInput }),
+        });
+      } catch {
+        /* audit trail is best-effort, same as recordTurn */
+      }
+    },
+    async postToolUse(event: PostToolUseEvent) {
+      try {
+        insertRunEvent({
+          runId,
+          projectId,
+          phaseName: event.phaseName ?? null,
+          eventType: 'post_tool_use',
+          toolName: event.toolName,
+          outcome: event.outcome,
+          durationMs: event.durationMs,
+          payload: JSON.stringify({
+            toolInput: event.toolInput,
+            ...(event.errorMessage ? { errorMessage: event.errorMessage } : {}),
+          }),
+        });
+      } catch {
+        /* audit trail is best-effort */
+      }
+    },
+    async phaseStart(event: PhaseStartEvent) {
+      try {
+        insertRunEvent({
+          runId,
+          projectId,
+          phaseName: event.phaseName,
+          eventType: 'phase_start',
+          payload: JSON.stringify({ model: event.model, maxTurns: event.maxTurns, required: event.required }),
+        });
+      } catch {
+        /* audit trail is best-effort */
+      }
+    },
+    async phaseEnd(event: PhaseEndEvent) {
+      try {
+        insertRunEvent({
+          runId,
+          projectId,
+          phaseName: event.phaseName,
+          eventType: 'phase_end',
+          outcome: event.status === 'completed' ? 'success' : event.status === 'failed' ? 'error' : null,
+          durationMs: event.durationMs,
+          payload: JSON.stringify({
+            status: event.status,
+            turnsUsed: event.turnsUsed,
+            tokensUsed: event.tokensUsed,
+            costUsd: event.costUsd,
+          }),
+        });
+      } catch {
+        /* audit trail is best-effort */
+      }
+    },
+  };
+}

--- a/packages/myco/src/agent/harness/claude.ts
+++ b/packages/myco/src/agent/harness/claude.ts
@@ -190,6 +190,8 @@ function buildToolServer(input: { toolSurface: HarnessExecuteInput['toolSurface'
         readOnly: toolSurface.readOnly,
         dryRun: toolSurface.dryRun,
         metadataAccumulator: toolSurface.metadataAccumulator,
+        hooks: toolSurface.hooks,
+        hookContext: toolSurface.hookContext,
       },
     );
   }
@@ -201,6 +203,8 @@ function buildToolServer(input: { toolSurface: HarnessExecuteInput['toolSurface'
     requestContext: toolSurface.requestContext,
     dryRun: toolSurface.dryRun,
     metadataAccumulator: toolSurface.metadataAccumulator,
+    hooks: toolSurface.hooks,
+    hookContext: toolSurface.hookContext,
   });
 }
 

--- a/packages/myco/src/agent/harness/hooks.ts
+++ b/packages/myco/src/agent/harness/hooks.ts
@@ -1,0 +1,76 @@
+/**
+ * Harness-neutral lifecycle hooks.
+ *
+ * Closes Gap 4 from the April 2026 harness maturity audit
+ * (spore_11b6645a205e0a455f247a122cddbb0d): observability was entirely
+ * post-hoc via agent_turns/agent_reports DB queries. These four hook
+ * points let a caller (or the default audit-event recorder in
+ * audit-hooks.ts) observe tool calls and phase boundaries as they happen,
+ * regardless of which harness (claude-sdk, openai-agents) is executing.
+ *
+ * See docs/superpowers/specs/2026-07-01-harness-hook-system-design.md
+ * for the full design rationale, including why these are void-returning
+ * observability hooks and NOT a permission-decision mechanism (that stays
+ * on the existing readOnlyHint/dry-run structural gates — see design
+ * spec §6).
+ */
+
+import type { HarnessId } from '@myco/agent/types.js';
+
+/** Identifies which harness-level construct a tool call or phase belongs to. */
+export interface HarnessHookContext {
+  runId: string;
+  agentId: string;
+  harnessId: HarnessId;
+  /** Present for phase-scoped calls; absent for orchestrator/single-query calls. */
+  phaseName?: string;
+}
+
+export interface PreToolUseEvent extends HarnessHookContext {
+  toolName: string;
+  toolInput: unknown;
+}
+
+export interface PostToolUseEvent extends HarnessHookContext {
+  toolName: string;
+  toolInput: unknown;
+  outcome: 'success' | 'error';
+  /** Present only when outcome === 'error'. */
+  errorMessage?: string;
+  durationMs: number;
+}
+
+export interface PhaseStartEvent extends HarnessHookContext {
+  phaseName: string;
+  model: string;
+  maxTurns?: number;
+  required: boolean;
+}
+
+export interface PhaseEndEvent extends HarnessHookContext {
+  phaseName: string;
+  status: 'completed' | 'failed' | 'skipped';
+  turnsUsed: number;
+  tokensUsed: number;
+  costUsd: number | null;
+  durationMs: number;
+}
+
+/**
+ * Harness-neutral lifecycle hooks. All fields optional — a caller registers
+ * only the events it cares about. Each callback is awaited in-line by the
+ * emission site, around the tool call (preToolUse/postToolUse) or phase
+ * boundary (phaseStart/phaseEnd) it observes — a slow implementation
+ * delays the tool result or phase transition, so implementations must be
+ * fast and non-blocking internally. Failures (sync throws or rejected
+ * promises) are caught and swallowed at the emission site: they never
+ * propagate to the caller and never fail the tool call. The void return
+ * type reflects that these are observability hooks, not a permission
+ * decision mechanism.
+ */
+export interface HarnessHooks {
+  preToolUse?(event: PreToolUseEvent): void | Promise<void>;
+  postToolUse?(event: PostToolUseEvent): void | Promise<void>;
+  phaseStart?(event: PhaseStartEvent): void | Promise<void>;
+  phaseEnd?(event: PhaseEndEvent): void | Promise<void>;
+}

--- a/packages/myco/src/agent/harness/openai-local-mcp.ts
+++ b/packages/myco/src/agent/harness/openai-local-mcp.ts
@@ -39,6 +39,8 @@ class LocalVaultMcpServer implements MCPServer {
       embeddingManager: toolSurface.embeddingManager,
       dryRun: toolSurface.dryRun,
       metadataAccumulator: toolSurface.metadataAccumulator,
+      hooks: toolSurface.hooks,
+      hookContext: toolSurface.hookContext,
     }).filter((tool) => !toolSurface.readOnly || tool.annotations?.readOnlyHint === true);
     this.tools = (nameSet
       ? allTools.filter((tool) => nameSet.has(tool.name))

--- a/packages/myco/src/agent/harness/types.ts
+++ b/packages/myco/src/agent/harness/types.ts
@@ -2,6 +2,7 @@ import type { MycoToolDefinition } from '@myco/agent/tools/types.js';
 import type { AgentEmbeddingPort } from '@myco/agent/runtime/ports.js';
 import type { ProviderConfig, RunLogger, HarnessId, RuntimeUsage, ReasoningLevel } from '@myco/agent/types.js';
 import type { MycoRequestContext } from '@myco/grove/request-context.js';
+import type { HarnessHooks, HarnessHookContext } from './hooks.js';
 
 export type HarnessCapability =
   | 'supportsSessionResume'
@@ -39,6 +40,19 @@ export interface HarnessToolSurface {
    * outcome-capture wrapper) that would be lost if the adapter rebuilt.
    */
   tools?: MycoToolDefinition<any>[];
+  /**
+   * Harness-neutral lifecycle hooks (preToolUse/postToolUse). Optional —
+   * absent for any caller that hasn't opted into hook emission. See
+   * agent/harness/hooks.ts.
+   */
+  hooks?: HarnessHooks;
+  /**
+   * Run/phase identity bound into every hook event emitted for this tool
+   * surface. Required alongside `hooks` for hook emission to actually
+   * fire — `tools.ts`'s wrapToolWithAudit needs both to construct a
+   * PreToolUseEvent/PostToolUseEvent.
+   */
+  hookContext?: HarnessHookContext;
 }
 
 export interface HarnessExecuteInput {
@@ -53,6 +67,14 @@ export interface HarnessExecuteInput {
   abortController?: AbortController;
   /** Optional logger for harness-level debug diagnostics. */
   logger?: RunLogger;
+  /**
+   * Harness-neutral lifecycle hooks for this run. Not read by claude.ts
+   * or openai.ts directly (see agent/harness/hooks.ts and the design
+   * spec §4.4) — phase-loop.ts passes this through so the type carries
+   * it, but hook emission itself happens inside tools.ts and phase-loop.ts,
+   * not inside the harness adapters.
+   */
+  hooks?: HarnessHooks;
   /**
    * Optional structured-output request. When present AND the resolved
    * harness's supports('structuredOutput') is true, the harness must
@@ -128,6 +150,8 @@ export interface HarnessScopeSetup {
   provider?: ProviderConfig;
   toolSurface: HarnessToolSurface;
   logger?: RunLogger;
+  /** Harness-neutral lifecycle hooks — see HarnessExecuteInput.hooks doc. */
+  hooks?: HarnessHooks;
   /** See `HarnessExecuteInput.reasoningLevel`. */
   reasoningLevel?: ReasoningLevel;
 }

--- a/packages/myco/src/agent/phase-loop.ts
+++ b/packages/myco/src/agent/phase-loop.ts
@@ -36,6 +36,7 @@ import {
 } from './executor-state.js';
 import { getAgentHarness } from './harness/index.js';
 import { HarnessExecutionError, type HarnessToolSurface } from './harness/types.js';
+import type { HarnessHooks, HarnessHookContext } from './harness/hooks.js';
 import { composePhasePrompt } from './prompt-composition.js';
 import { buildPhaseRecoveryContext } from './phase-recovery.js';
 import { resolvePhaseExecution, type MycoYamlPhaseOverrides } from './phase-resolver.js';
@@ -125,6 +126,8 @@ export interface PhaseLoopContext {
   readonly requestContext?: RunOptions['requestContext'];
   /** Raw RunOptions — exposed to honor executionOverrides.phases per-phase. */
   readonly options?: RunOptions;
+  /** Harness-neutral lifecycle hooks for this run — see agent/harness/hooks.ts. */
+  readonly hooks?: HarnessHooks;
 
   // --- mutable, passed by reference ----------------------------------------
 
@@ -268,6 +271,22 @@ export async function executePhase(
     toolNames: toolSurface.toolNames ?? null,
     sessionRef: sessionId ?? null,
   });
+  const phaseHookStartedAt = Date.now();
+  if (ctx.hooks?.phaseStart) {
+    try {
+      await ctx.hooks.phaseStart({
+        runId: ctx.runId,
+        agentId: ctx.agentId,
+        harnessId: ctx.config.harness,
+        phaseName: phase.name,
+        model: phaseModel,
+        maxTurns: phase.maxTurns,
+        required: phase.required ?? false,
+      });
+    } catch {
+      /* hook callbacks are best-effort observability, never fail the phase */
+    }
+  }
   try {
     let result;
     try {
@@ -335,6 +354,24 @@ export async function executePhase(
       usage: result.usage,
     });
 
+    if (ctx.hooks?.phaseEnd) {
+      try {
+        await ctx.hooks.phaseEnd({
+          runId: ctx.runId,
+          agentId: ctx.agentId,
+          harnessId: ctx.config.harness,
+          phaseName: phase.name,
+          status: 'completed',
+          turnsUsed: result.turnsUsed,
+          tokensUsed: result.usage.totalTokens ?? 0,
+          costUsd: costData.costUsd,
+          durationMs: Date.now() - phaseHookStartedAt,
+        });
+      } catch {
+        /* hook callbacks are best-effort observability */
+      }
+    }
+
     return buildPhaseResult({
       name: phase.name,
       status: 'completed',
@@ -369,6 +406,25 @@ export async function executePhase(
       allowedMaxTurns: phase.maxTurns ?? null,
       error: abortReason ?? errorText,
     });
+
+    if (ctx.hooks?.phaseEnd) {
+      try {
+        await ctx.hooks.phaseEnd({
+          runId: ctx.runId,
+          agentId: ctx.agentId,
+          harnessId: ctx.config.harness,
+          phaseName: phase.name,
+          status: 'failed',
+          turnsUsed: telemetry?.usage.requests ?? 0,
+          tokensUsed: telemetry?.usage.totalTokens ?? 0,
+          costUsd: costData?.costUsd ?? null,
+          durationMs: Date.now() - phaseHookStartedAt,
+        });
+      } catch {
+        /* hook callbacks are best-effort observability */
+      }
+    }
+
     return buildPhaseResult({
       name: phase.name,
       status: 'failed',
@@ -412,11 +468,31 @@ async function runMapPhaseAdapter(input: ExecutePhaseInput): Promise<PhaseResult
     vaultDir: ctx.vaultDir,
     requestContext: ctx.requestContext,
     dryRun: ctx.options?.dryRun ?? false,
+    hooks: ctx.hooks,
+    hookContext: ctx.hooks
+      ? { runId: ctx.runId, agentId: ctx.agentId, harnessId: ctx.config.harness, phaseName: phase.name }
+      : undefined,
   });
 
   logger?.debug('agent.map.start', `Map phase "${phase.name}" starting`, {
     runId: ctx.runId, phase: phase.name, model: phaseModel, providerType: provider?.type ?? null,
   });
+  const mapHookStartedAt = Date.now();
+  if (ctx.hooks?.phaseStart) {
+    try {
+      await ctx.hooks.phaseStart({
+        runId: ctx.runId,
+        agentId: ctx.agentId,
+        harnessId: ctx.config.harness,
+        phaseName: phase.name,
+        model: phaseModel ?? '',
+        maxTurns: phase.maxTurns,
+        required: phase.required ?? false,
+      });
+    } catch {
+      /* hook callbacks are best-effort observability */
+    }
+  }
 
   try {
     const mapResult = await executeMapPhase({
@@ -455,6 +531,25 @@ async function runMapPhaseAdapter(input: ExecutePhaseInput): Promise<PhaseResult
       ? ` writeAfterThrow=${mapResult.writeAfterThrow}`
       : '';
     const phaseStatus = mapResultToPhaseStatus(mapResult);
+
+    if (ctx.hooks?.phaseEnd) {
+      try {
+        await ctx.hooks.phaseEnd({
+          runId: ctx.runId,
+          agentId: ctx.agentId,
+          harnessId: ctx.config.harness,
+          phaseName: phase.name,
+          status: phaseStatus,
+          turnsUsed: mapResult.usage.requests ?? 0,
+          tokensUsed: mapResult.usage.totalTokens ?? 0,
+          costUsd: costData.costUsd,
+          durationMs: Date.now() - mapHookStartedAt,
+        });
+      } catch {
+        /* hook callbacks are best-effort observability */
+      }
+    }
+
     return buildPhaseResult({
       name: phase.name,
       status: phaseStatus,
@@ -476,6 +571,25 @@ async function runMapPhaseAdapter(input: ExecutePhaseInput): Promise<PhaseResult
       runId: ctx.runId, phase: phase.name, error: reason, capHit,
       allowedMaxTurns: phase.maxTurns ?? null,
     });
+
+    if (ctx.hooks?.phaseEnd) {
+      try {
+        await ctx.hooks.phaseEnd({
+          runId: ctx.runId,
+          agentId: ctx.agentId,
+          harnessId: ctx.config.harness,
+          phaseName: phase.name,
+          status: 'failed',
+          turnsUsed: telemetry?.usage.requests ?? 0,
+          tokensUsed: telemetry?.usage.totalTokens ?? 0,
+          costUsd: null,
+          durationMs: Date.now() - mapHookStartedAt,
+        });
+      } catch {
+        /* hook callbacks are best-effort observability */
+      }
+    }
+
     return buildPhaseResult({
       name: phase.name,
       status: 'failed',
@@ -525,6 +639,8 @@ export async function executeSingleQuery(
     requestContext: ctx.requestContext,
     embeddingManager: ctx.embeddingManager,
     dryRun: ctx.config.dryRun ?? false,
+    hooks: ctx.hooks,
+    hookContext: ctx.hooks ? { runId: ctx.runId, agentId: ctx.agentId, harnessId: ctx.config.harness } : undefined,
   };
   const baseInput = {
     prompt: taskPrompt,
@@ -536,6 +652,7 @@ export async function executeSingleQuery(
     abortController: ctx.abortController,
     toolSurface,
     logger: ctx.options?.logger,
+    hooks: ctx.hooks,
   };
   let result;
   try {
@@ -845,6 +962,10 @@ export async function executePhasedQuery(
           embeddingManager: ctx.embeddingManager,
           dryRun: config.dryRun ?? false,
           metadataAccumulator,
+          hooks: ctx.hooks,
+          hookContext: ctx.hooks
+            ? { runId, agentId, harnessId: config.harness, phaseName: phase.name }
+            : undefined,
         },
       };
     });

--- a/packages/myco/src/agent/tools.ts
+++ b/packages/myco/src/agent/tools.ts
@@ -42,6 +42,7 @@ import { errorMessage } from '@myco/utils/error-message.js';
 import type { MycoToolDefinition, VaultToolDeps } from './tools/types.js';
 import type { AgentEmbeddingPort, AgentTeamSearchPort } from '@myco/agent/runtime/ports.js';
 import { rowProjectIdFromRequestContext, type MycoRequestContext } from '@myco/grove/request-context.js';
+import type { HarnessHooks, HarnessHookContext } from './harness/hooks.js';
 
 // Re-exports for backward compatibility
 export { validateSkillContent, MAX_SKILL_LINES, REQUIRED_FRONTMATTER_FIELDS } from './tools/skill-validator.js';
@@ -84,6 +85,20 @@ export interface VaultToolOptions {
    * phase loop — the tool then no-ops gracefully.
    */
   metadataAccumulator?: Map<string, unknown>;
+  /**
+   * Harness-neutral lifecycle hooks. When both `hooks` and `hookContext`
+   * are supplied, `wrapToolWithAudit` emits `preToolUse` before every tool
+   * handler call and `postToolUse` (with outcome) after. Absent by
+   * default — existing callers that don't pass these get byte-identical
+   * behavior to before hook support was added.
+   */
+  hooks?: HarnessHooks;
+  /**
+   * Static per-run/per-phase identity attached to every emitted hook
+   * event. Hook emission is a no-op unless this is present — `hooks`
+   * alone (without `hookContext`) never fires.
+   */
+  hookContext?: HarnessHookContext;
 }
 
 /**
@@ -337,6 +352,8 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
     dryRun,
     metadataAccumulator,
     onlyNames,
+    hooks,
+    hookContext,
   } = options ?? {};
   const projectId = rowProjectIdFromRequestContext(requestContext);
 
@@ -430,7 +447,7 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
       && typed.annotations?.readOnlyHint !== true
       && !DRY_RUN_EXEMPT_TOOLS.has(typed.name);
     const inner = shouldIntercept ? wrapToolWithDryRun(typed) : typed;
-    return wrapToolWithAudit(inner);
+    return wrapToolWithAudit(inner, hooks, hookContext);
   }) as typeof tools;
 
   /**
@@ -539,7 +556,11 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
     };
   }
 
-  function wrapToolWithAudit(toolDef: MycoToolDefinition<any>): MycoToolDefinition<any> {
+  function wrapToolWithAudit(
+    toolDef: MycoToolDefinition<any>,
+    hooks?: HarnessHooks,
+    hookContext?: HarnessHookContext,
+  ): MycoToolDefinition<any> {
     const originalHandler = toolDef.handler;
     // Reject args keys not in the tool's declared schema. Without this,
     // Zod silently strips unknown keys, which lets a prompt reference a
@@ -562,6 +583,14 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
           ? (repeatedReadCounts.get(repeatedReadKey) ?? 0)
           : 0;
         const turnId = recordTurn(toolDef.name, args);
+        const hookStartedAt = Date.now();
+        if (hookContext) {
+          try {
+            await hooks?.preToolUse?.({ ...hookContext, toolName: toolDef.name, toolInput: args });
+          } catch {
+            /* hook callbacks are best-effort observability, never fail the tool call */
+          }
+        }
         try {
           // Unknown-key guard: fail loud if the caller passed a parameter
           // the tool doesn't declare. This catches prompt-tool contract
@@ -632,6 +661,16 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
               /* audit trail is best-effort */
             }
           }
+          if (hookContext) {
+            try {
+              await hooks?.postToolUse?.({
+                ...hookContext, toolName: toolDef.name, toolInput: args,
+                outcome: 'success', durationMs: Date.now() - hookStartedAt,
+              });
+            } catch {
+              /* hook callbacks are best-effort observability */
+            }
+          }
           return result;
         } catch (error) {
           if (turnId !== null) {
@@ -642,6 +681,16 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
               });
             } catch {
               /* audit trail is best-effort */
+            }
+          }
+          if (hookContext) {
+            try {
+              await hooks?.postToolUse?.({
+                ...hookContext, toolName: toolDef.name, toolInput: args,
+                outcome: 'error', errorMessage: errorMessage(error), durationMs: Date.now() - hookStartedAt,
+              });
+            } catch {
+              /* hook callbacks are best-effort observability */
             }
           }
           throw error;
@@ -668,7 +717,7 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
 export function createVaultToolServer(
   agentId: string,
   runId: string,
-  options?: Pick<VaultToolOptions, 'embeddingManager' | 'projectRoot' | 'vaultDir' | 'requestContext' | 'dryRun' | 'metadataAccumulator'>,
+  options?: Pick<VaultToolOptions, 'embeddingManager' | 'projectRoot' | 'vaultDir' | 'requestContext' | 'dryRun' | 'metadataAccumulator' | 'hooks' | 'hookContext'>,
 ) {
   const tools = createVaultTools(agentId, runId, options);
 
@@ -698,7 +747,7 @@ export function createScopedVaultToolServer(
   agentId: string,
   runId: string,
   toolNames: string[],
-  options?: Pick<VaultToolOptions, 'turnOffset' | 'embeddingManager' | 'projectRoot' | 'vaultDir' | 'requestContext' | 'dryRun' | 'metadataAccumulator'> & { readOnly?: boolean },
+  options?: Pick<VaultToolOptions, 'turnOffset' | 'embeddingManager' | 'projectRoot' | 'vaultDir' | 'requestContext' | 'dryRun' | 'metadataAccumulator' | 'hooks' | 'hookContext'> & { readOnly?: boolean },
 ) {
   const nameSet = new Set(toolNames);
   const allTools = createVaultTools(agentId, runId, { ...options, onlyNames: nameSet });

--- a/packages/myco/src/agent/types.ts
+++ b/packages/myco/src/agent/types.ts
@@ -8,6 +8,7 @@
 
 import type { CostResolution, CostSource } from '@myco/agent/cost/types.js';
 import type { MycoRequestContext } from '@myco/grove/request-context.js';
+import type { HarnessHooks } from './harness/hooks.js';
 
 // ---------------------------------------------------------------------------
 // YAML-sourced definitions (read from src/agent/definitions/)
@@ -518,6 +519,12 @@ export interface RunOptions {
    * `daemon.log_level` is set to `debug`, otherwise filtered out.
    */
   logger?: RunLogger;
+  /**
+   * Caller-supplied lifecycle hooks. Merged additively with the default
+   * audit-event hooks runAgent() always constructs — both fire, this
+   * does not replace the default recorder. See agent/harness/audit-hooks.ts.
+   */
+  hooks?: HarnessHooks;
   /**
    * Structured metadata about the run. Populated by the dispatcher (e.g.
    * instruction-builders.ts) alongside the free-form `instruction` string

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -12,6 +12,7 @@ import { getRunActivityBuckets, getRunBranches } from '@myco/db/queries/activity
 import { listReports } from '@myco/db/queries/reports.js';
 import { listTurnsByRun } from '@myco/db/queries/turns.js';
 import { listWriteIntents, countWriteIntents, countWriteIntentsByTool } from '@myco/db/queries/write-intents.js';
+import { listRunEvents } from '@myco/db/queries/agent-run-events.js';
 import { runDurationMs } from '@myco/agent/run-accounting.js';
 import { buildTaskInstruction, isInstructionRequiredTask, SKILL_SURVEY_TASK } from '@myco/agent/instruction-builders.js';
 import { hasConfiguredProvider, resolveTaskDefinitionExecution } from '@myco/agent/config-resolver.js';
@@ -36,6 +37,16 @@ import { DEFAULT_AGENT_ID } from '@myco/constants.js';
 
 /** Default limit for listing agent runs in the API. */
 export const AGENT_RUNS_DEFAULT_LIMIT = 50;
+
+/**
+ * Max rows returned by GET /api/agent/runs/:id/events per request. A
+ * pathological run (a tight tool-call loop, or a long-running map phase
+ * over hundreds of items) can emit thousands of lifecycle events; without
+ * a cap a single poll could pull the whole table into one response.
+ * Clients page forward with `?since=<id>` — a truncated response just
+ * means the next poll picks up where this one left off.
+ */
+export const AGENT_RUN_EVENTS_LIMIT = 1000;
 
 // ---------------------------------------------------------------------------
 // Schemas
@@ -487,6 +498,22 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
     return { body: { audit } };
   }
 
+  /**
+   * GET /api/agent/runs/:id/events?since=<id> — list harness hook events
+   * (preToolUse/postToolUse/phaseStart/phaseEnd) for a run, incrementally.
+   * Cursor-based: pass the highest `id` seen so far as `since` to get only
+   * new rows. Closes Gap 4 from the April 2026 harness maturity audit —
+   * see docs/superpowers/specs/2026-07-01-harness-hook-system-design.md.
+   */
+  async function handleGetRunEvents(req: RouteRequest): Promise<RouteResponse> {
+    const scope = projectScopeFromRequestContext(req.requestContext);
+    if (!getRun(req.params.id, scope)) return { status: 404, body: { error: 'Run not found' } };
+    const rawSinceId = req.query.since ? Number(req.query.since) : undefined;
+    const sinceId = Number.isFinite(rawSinceId) ? rawSinceId : undefined;
+    const events = listRunEvents(req.params.id, { sinceId, scope, limit: AGENT_RUN_EVENTS_LIMIT });
+    return { body: { events, count: events.length } };
+  }
+
   return {
     handleRun,
     handleListRuns,
@@ -496,5 +523,6 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
     handleGetRunTurns,
     handleGetRunWriteIntents,
     handleGetRunAudit,
+    handleGetRunEvents,
   };
 }

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -1849,6 +1849,7 @@ export async function main(): Promise<void> {
   server.registerRoute('GET', '/api/agent/runs/:id/turns', agentRunHandlers.handleGetRunTurns);
   server.registerRoute('GET', '/api/agent/runs/:id/write-intents', agentRunHandlers.handleGetRunWriteIntents);
   server.registerRoute('GET', '/api/agent/runs/:id/audit', agentRunHandlers.handleGetRunAudit);
+  server.registerRoute('GET', '/api/agent/runs/:id/events', agentRunHandlers.handleGetRunEvents);
 
   const digestRevisionHandlers = createDigestRevisionHandlers({ vaultDir: bootstrapVaultDir, logger });
   server.registerRoute('GET', '/api/digest/revisions', digestRevisionHandlers.handleList);

--- a/packages/myco/src/db/migrations.ts
+++ b/packages/myco/src/db/migrations.ts
@@ -26,6 +26,7 @@ import {
   SESSION_MYCO_TOOL_CALLS_TABLE,
   NOTIFICATIONS_TABLE,
   AGENT_RUN_WRITE_INTENTS_TABLE,
+  AGENT_RUN_EVENTS_TABLE,
   DIGEST_EXTRACT_REVISIONS_TABLE,
   CORTEX_INSTRUCTIONS_TABLE,
   MIGRATION_TASKS_TABLE,
@@ -124,6 +125,7 @@ export const MIGRATIONS: Migration[] = [
   { version: 62, migrate: (db) => migrateV61ToV62(db) },
   { version: 63, migrate: (db) => migrateV62ToV63(db) },
   { version: 64, migrate: (db) => migrateV63ToV64(db) },
+  { version: 65, migrate: (db) => migrateV64ToV65(db) },
 ];
 
 // ---------------------------------------------------------------------------
@@ -4030,6 +4032,27 @@ function migrateV63ToV64(db: Database): void {
     db.prepare(
       `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`,
     ).run(64, epochSeconds());
+    db.prepare('COMMIT').run();
+  } catch (err) {
+    db.prepare('ROLLBACK').run();
+    throw err;
+  }
+}
+
+/**
+ * v64 -> v65: add agent_run_events, the append-only lifecycle-event log
+ * for the harness-neutral hook system (preToolUse/postToolUse/phaseStart/
+ * phaseEnd). See docs/superpowers/specs/2026-07-01-harness-hook-system-design.md.
+ */
+function migrateV64ToV65(db: Database): void {
+  db.prepare('BEGIN').run();
+  try {
+    db.exec(AGENT_RUN_EVENTS_TABLE);
+    db.exec('CREATE INDEX IF NOT EXISTS idx_agent_run_events_run_id ON agent_run_events (run_id, id)');
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`,
+    ).run(65, epochSeconds());
     db.prepare('COMMIT').run();
   } catch (err) {
     db.prepare('ROLLBACK').run();

--- a/packages/myco/src/db/queries/agent-run-events.ts
+++ b/packages/myco/src/db/queries/agent-run-events.ts
@@ -1,0 +1,118 @@
+/**
+ * Query helpers for agent_run_events — the append-only lifecycle-event
+ * log populated by the harness hook system (preToolUse/postToolUse/
+ * phaseStart/phaseEnd). See docs/superpowers/specs/
+ * 2026-07-01-harness-hook-system-design.md.
+ *
+ * Same append-only convention as write-intents.ts: no UPDATE/DELETE
+ * helper is exposed, insert-order (= id order) is the natural cursor for
+ * incremental polling.
+ */
+
+import { getDatabase } from '@myco/db/client.js';
+import { appendProjectCondition, type ProjectScope } from '@myco/db/queries/project-scope.js';
+import type { GroveProjectId } from '@myco/grove/ids.js';
+import { epochSeconds } from '@myco/constants.js';
+import { tryParseJson } from '@myco/utils/json.js';
+
+export interface RunEventInsert {
+  runId: string;
+  projectId?: GroveProjectId | null;
+  phaseName?: string | null;
+  eventType: 'pre_tool_use' | 'post_tool_use' | 'phase_start' | 'phase_end';
+  toolName?: string | null;
+  outcome?: 'success' | 'error' | null;
+  durationMs?: number | null;
+  /** JSON-stringified full event payload, for forward-compat fields not promoted to a column. */
+  payload?: string | null;
+  recordedAt?: number;
+}
+
+export interface RunEventRow {
+  id: number;
+  project_id: string | null;
+  run_id: string;
+  phase_name: string | null;
+  event_type: string;
+  tool_name: string | null;
+  outcome: string | null;
+  duration_ms: number | null;
+  payload: unknown;
+  recorded_at: number;
+}
+
+const EVENT_COLUMNS = [
+  'id', 'project_id', 'run_id', 'phase_name', 'event_type',
+  'tool_name', 'outcome', 'duration_ms', 'payload', 'recorded_at',
+] as const;
+
+const SELECT_COLUMNS = EVENT_COLUMNS.join(', ');
+
+function toRunEventRow(row: Record<string, unknown>): RunEventRow {
+  return {
+    id: row.id as number,
+    project_id: (row.project_id as string) ?? null,
+    run_id: row.run_id as string,
+    phase_name: (row.phase_name as string) ?? null,
+    event_type: row.event_type as string,
+    tool_name: (row.tool_name as string) ?? null,
+    outcome: (row.outcome as string) ?? null,
+    duration_ms: (row.duration_ms as number) ?? null,
+    payload: tryParseJson(row.payload),
+    recorded_at: row.recorded_at as number,
+  };
+}
+
+/** Insert a new lifecycle event. Returns the autoincrement id. */
+export function insertRunEvent(data: RunEventInsert): number {
+  const db = getDatabase();
+  const recordedAt = data.recordedAt ?? epochSeconds();
+  const info = db.prepare(
+    `INSERT INTO agent_run_events
+       (project_id, run_id, phase_name, event_type, tool_name, outcome, duration_ms, payload, recorded_at)
+     VALUES (COALESCE(?, (SELECT project_id FROM agent_runs WHERE id = ?)), ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    data.projectId ?? null,
+    data.runId,
+    data.runId,
+    data.phaseName ?? null,
+    data.eventType,
+    data.toolName ?? null,
+    data.outcome ?? null,
+    data.durationMs ?? null,
+    data.payload ?? null,
+    recordedAt,
+  );
+  return Number(info.lastInsertRowid);
+}
+
+export interface ListRunEventsOptions {
+  /** Only return rows with id > sinceId — cursor-based incremental polling. */
+  sinceId?: number;
+  limit?: number;
+  scope: ProjectScope;
+}
+
+/** List lifecycle events for a run, ordered by id (= insert order). */
+export function listRunEvents(runId: string, options: ListRunEventsOptions): RunEventRow[] {
+  const db = getDatabase();
+  const conditions = ['run_id = ?'];
+  const params: unknown[] = [runId];
+  if (options.sinceId !== undefined) {
+    conditions.push('id > ?');
+    params.push(options.sinceId);
+  }
+  appendProjectCondition(conditions, params, options.scope);
+  let tail = 'ORDER BY id ASC';
+  if (options.limit !== undefined) {
+    tail += ' LIMIT ?';
+    params.push(options.limit);
+  }
+  const rows = db.prepare(
+    `SELECT ${SELECT_COLUMNS}
+     FROM agent_run_events
+     WHERE ${conditions.join(' AND ')}
+     ${tail}`,
+  ).all(...params) as Record<string, unknown>[];
+  return rows.map(toRunEventRow);
+}

--- a/packages/myco/src/db/schema-ddl.ts
+++ b/packages/myco/src/db/schema-ddl.ts
@@ -654,6 +654,33 @@ export const AGENT_RUN_WRITE_INTENTS_TABLE = `
   )`;
 
 /**
+ * Append-only lifecycle-event log for agent runs. Populated by
+ * HarnessHooks (preToolUse/postToolUse/phaseStart/phaseEnd) via
+ * buildAuditEventHooks() in agent/harness/audit-hooks.ts — this is the
+ * durable event trail the daemon UI polls via GET
+ * /api/agent/runs/:id/events for near-real-time activity feedback.
+ * Closes Gap 4 from the April 2026 harness maturity audit
+ * (spore_11b6645a205e0a455f247a122cddbb0d).
+ *
+ * No UPDATE/DELETE query helper is exposed at the query layer — same
+ * append-only convention as agent_run_write_intents. ON DELETE CASCADE
+ * on run_id lets a future agent_runs retention purge cascade.
+ */
+export const AGENT_RUN_EVENTS_TABLE = `
+  CREATE TABLE IF NOT EXISTS agent_run_events (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id    TEXT,
+    run_id        TEXT NOT NULL REFERENCES agent_runs(id) ON DELETE CASCADE,
+    phase_name    TEXT,
+    event_type    TEXT NOT NULL,
+    tool_name     TEXT,
+    outcome       TEXT,
+    duration_ms   INTEGER,
+    payload       TEXT,
+    recorded_at   INTEGER NOT NULL
+  )`;
+
+/**
  * Append-only history of digest_extracts rows. A new revision is inserted
  * every time a real (non-dry) run overwrites an existing digest. Rollback
  * restores an old revision and records a fresh revision to preserve the
@@ -818,6 +845,7 @@ export const GROVE_PROJECT_SCOPED_TABLES = [
   'agent_reports',
   'agent_turns',
   'agent_run_write_intents',
+  'agent_run_events',
   'digest_extract_revisions',
   'skill_candidates',
   'skill_records',
@@ -1172,6 +1200,7 @@ export const SECONDARY_INDEXES = [
   // Eval harness
   'CREATE INDEX IF NOT EXISTS idx_write_intents_run_id ON agent_run_write_intents (run_id)',
   'CREATE INDEX IF NOT EXISTS idx_write_intents_run_id_tool ON agent_run_write_intents (run_id, tool_name)',
+  'CREATE INDEX IF NOT EXISTS idx_agent_run_events_run_id ON agent_run_events (run_id, id)',
   'CREATE INDEX IF NOT EXISTS idx_digest_revisions_agent_tier ON digest_extract_revisions (agent_id, tier, created_at DESC)',
 
   // Grove migration import journal
@@ -1232,6 +1261,7 @@ export const TABLE_DDLS = [
   NOTIFICATIONS_TABLE,
   // Eval harness layer
   AGENT_RUN_WRITE_INTENTS_TABLE,
+  AGENT_RUN_EVENTS_TABLE,
   DIGEST_EXTRACT_REVISIONS_TABLE,
   MIGRATION_IMPORT_JOURNAL_TABLE,
   MIGRATION_LOG_TABLE,

--- a/packages/myco/src/db/schema.ts
+++ b/packages/myco/src/db/schema.ts
@@ -20,7 +20,7 @@ import { TABLE_DDLS, FTS_TABLES, SECONDARY_INDEXES, TEAM_DELETE_TRIGGERS } from 
 import { MIGRATIONS } from './migrations.js';
 
 /** Current schema version -- fresh start for the SQLite era. */
-export const SCHEMA_VERSION = 64;
+export const SCHEMA_VERSION = 65;
 
 // Re-export for backwards compat (other modules import from schema.ts)
 export { DEFAULT_MACHINE_ID };

--- a/packages/myco/src/grove/move-copy.ts
+++ b/packages/myco/src/grove/move-copy.ts
@@ -40,6 +40,7 @@ export const MOVE_REKEYED_TABLES = [
   'agent_reports',
   'agent_turns',
   'agent_run_write_intents',
+  'agent_run_events',
   'digest_extract_revisions',
   'log_entries',
 ] as const;

--- a/tests/agent/executor-hooks.test.ts
+++ b/tests/agent/executor-hooks.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests that runAgent() wires a default HarnessHooks (audit-event
+ * recorder) into every run by default, and that caller-supplied hooks
+ * (via RunOptions.hooks) run ADDITIONALLY, not instead of, the default.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, mock } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+mock.module('@myco/intelligence/embed-query.js', () => ({ tryEmbed: async () => null }));
+
+import { ensureProjectManifest } from '@myco/config/project-manifest.js';
+import { setupTestDb, teardownTestDb } from '../helpers/db';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { epochSeconds, DEFAULT_AGENT_ID } from '@myco/constants.js';
+import { makeTestRequestContext } from '../helpers/request-context';
+import type { AgentHarness, HarnessExecuteInput, HarnessExecuteResult } from '@myco/agent/harness/types.js';
+import type { HarnessId } from '@myco/agent/types.js';
+
+let capturedInputs: HarnessExecuteInput[] = [];
+
+const fakeHarness: AgentHarness = {
+  id: 'claude-sdk' as HarnessId,
+  async execute(input: HarnessExecuteInput): Promise<HarnessExecuteResult> {
+    capturedInputs.push(input);
+    return {
+      finalText: 'ok',
+      turnsUsed: 1,
+      usage: { requests: 1, inputTokens: 10, outputTokens: 10, totalTokens: 20, reasoningTokens: 0, cachedTokens: 0, durationMs: 5 },
+      sessionRef: 'session-1',
+    };
+  },
+  supports: () => false,
+  classifyError: () => 'unknown',
+};
+
+mock.module('@myco/agent/harness/index.js', () => ({
+  getAgentHarness: () => fakeHarness,
+}));
+
+describe('runAgent hook wiring', () => {
+  let tmpDir: string;
+
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+
+  beforeEach(() => {
+    capturedInputs = [];
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-executor-hooks-'));
+    ensureProjectManifest(tmpDir, { projectName: 'executor-hooks-test' });
+    const now = epochSeconds();
+    registerAgent({
+      id: DEFAULT_AGENT_ID,
+      name: `agent-${DEFAULT_AGENT_ID}`,
+      created_at: now,
+      updated_at: now,
+    });
+  });
+
+  it('constructs a default audit-event hooks object and passes it through to harness.execute()', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+    const vaultDir = path.join(tmpDir, '.myco');
+    fs.mkdirSync(vaultDir, { recursive: true });
+
+    const result = await runAgent(vaultDir, {
+      task: 'title-summary',
+      instruction: 'test instruction',
+      // dryRun bypasses the title-summary postcondition (which otherwise
+      // requires a vault_report/vault_update_session call) — this test only
+      // exercises hook wiring, not task-completion semantics.
+      dryRun: true,
+      requestContext: makeTestRequestContext({
+        vaultDir,
+        projectId: 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        groveId: null,
+      }),
+    });
+
+    expect(result.status).toBe('completed');
+    expect(capturedInputs.length).toBeGreaterThan(0);
+    expect(capturedInputs[0].hooks).toBeDefined();
+    expect(typeof capturedInputs[0].hooks?.preToolUse).toBe('function');
+
+    // Assert that toolSurface.hooks and hookContext reach the harness input
+    const input = capturedInputs[0];
+    expect(input.toolSurface).toBeDefined();
+    expect(input.toolSurface.hooks).toBeDefined();
+    expect(typeof input.toolSurface.hooks?.preToolUse).toBe('function');
+
+    expect(input.toolSurface.hookContext).toBeDefined();
+    expect(input.toolSurface.hookContext?.runId).toBe(result.runId);
+    expect(input.toolSurface.hookContext?.agentId).toBe(DEFAULT_AGENT_ID);
+  });
+});

--- a/tests/agent/harness/audit-hooks.test.ts
+++ b/tests/agent/harness/audit-hooks.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for buildAuditEventHooks — the default HarnessHooks implementation
+ * that persists every lifecycle event to agent_run_events. Mirrors the
+ * "best-effort, never throws" convention already used by recordTurn/
+ * insertWriteIntent in tools.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { setupTestDb, teardownTestDb } from '../../helpers/db';
+import { getDatabase } from '@myco/db/client.js';
+import { insertRun } from '@myco/db/queries/runs.js';
+import { listRunEvents } from '@myco/db/queries/agent-run-events.js';
+import { buildAuditEventHooks } from '@myco/agent/harness/audit-hooks.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+function createAgent(id: string): void {
+  const db = getDatabase();
+  db.prepare(`INSERT INTO agents (id, name, created_at) VALUES (?, ?, ?)`).run(id, `agent-${id}`, epochNow());
+}
+
+describe('buildAuditEventHooks', () => {
+  beforeEach(() => {
+    setupTestDb();
+    createAgent('agent-1');
+    insertRun({ id: 'run-1', agent_id: 'agent-1', status: 'running', started_at: epochNow() });
+  });
+
+  afterEach(() => {
+    teardownTestDb();
+  });
+
+  it('records a phaseStart event', async () => {
+    const hooks = buildAuditEventHooks('run-1', null);
+    await hooks.phaseStart?.({
+      runId: 'run-1', agentId: 'agent-1', harnessId: 'claude-sdk', phaseName: 'gather',
+      model: 'claude-sonnet-4-6', maxTurns: 8, required: true,
+    });
+    const events = listRunEvents('run-1', { scope: ALL_PROJECTS_SCOPE });
+    expect(events).toHaveLength(1);
+    expect(events[0].event_type).toBe('phase_start');
+    expect(events[0].phase_name).toBe('gather');
+  });
+
+  it('records a preToolUse event with tool_name set', async () => {
+    const hooks = buildAuditEventHooks('run-1', null);
+    await hooks.preToolUse?.({
+      runId: 'run-1', agentId: 'agent-1', harnessId: 'claude-sdk', phaseName: 'gather',
+      toolName: 'vault_spores', toolInput: { limit: 5 },
+    });
+    const events = listRunEvents('run-1', { scope: ALL_PROJECTS_SCOPE });
+    expect(events[0].event_type).toBe('pre_tool_use');
+    expect(events[0].tool_name).toBe('vault_spores');
+  });
+
+  it('records a postToolUse error event with outcome and errorMessage in payload', async () => {
+    const hooks = buildAuditEventHooks('run-1', null);
+    await hooks.postToolUse?.({
+      runId: 'run-1', agentId: 'agent-1', harnessId: 'openai-agents', phaseName: 'gather',
+      toolName: 'vault_create_spore', toolInput: {}, outcome: 'error',
+      errorMessage: 'insert failed', durationMs: 42,
+    });
+    const events = listRunEvents('run-1', { scope: ALL_PROJECTS_SCOPE });
+    expect(events[0].outcome).toBe('error');
+    expect(events[0].duration_ms).toBe(42);
+    expect(events[0].payload).toMatchObject({ errorMessage: 'insert failed' });
+  });
+
+  it('records a phaseEnd event with status and cost fields', async () => {
+    const hooks = buildAuditEventHooks('run-1', null);
+    await hooks.phaseEnd?.({
+      runId: 'run-1', agentId: 'agent-1', harnessId: 'claude-sdk', phaseName: 'gather',
+      status: 'completed', turnsUsed: 3, tokensUsed: 500, costUsd: 0.02, durationMs: 900,
+    });
+    const events = listRunEvents('run-1', { scope: ALL_PROJECTS_SCOPE });
+    expect(events[0].event_type).toBe('phase_end');
+    expect(events[0].payload).toMatchObject({ status: 'completed', turnsUsed: 3, tokensUsed: 500, costUsd: 0.02 });
+  });
+
+  it('never throws when insertRunEvent fails — best-effort like recordTurn/insertWriteIntent', async () => {
+    // Force a DB error by referencing a run_id that violates the FK constraint
+    // (agent_run_events.run_id REFERENCES agent_runs(id)), for all four
+    // hooks — each calls insertRunEvent independently, so each needs its
+    // own best-effort guard verified, not just phaseStart's.
+    const hooks = buildAuditEventHooks('nonexistent-run', null);
+    const baseEvent = {
+      runId: 'nonexistent-run', agentId: 'agent-1', harnessId: 'claude-sdk' as const, phaseName: 'gather',
+    };
+
+    await expect(
+      hooks.phaseStart?.({
+        ...baseEvent, model: 'claude-sonnet-4-6', required: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      hooks.preToolUse?.({
+        ...baseEvent, toolName: 'vault_spores', toolInput: { limit: 5 },
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      hooks.postToolUse?.({
+        ...baseEvent, toolName: 'vault_create_spore', toolInput: {}, outcome: 'error',
+        errorMessage: 'insert failed', durationMs: 42,
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      hooks.phaseEnd?.({
+        ...baseEvent, status: 'completed', turnsUsed: 3, tokensUsed: 500, costUsd: 0.02, durationMs: 900,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(listRunEvents('nonexistent-run', { scope: ALL_PROJECTS_SCOPE })).toHaveLength(0);
+  });
+});

--- a/tests/agent/harness/hooks.test.ts
+++ b/tests/agent/harness/hooks.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Structural tests for the HarnessHooks type — verifies the shape compiles
+ * and that a partial implementation (only some hooks registered) is valid,
+ * since HarnessHooks fields are all optional.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import type {
+  HarnessHookContext,
+  PreToolUseEvent,
+  PostToolUseEvent,
+  PhaseStartEvent,
+  PhaseEndEvent,
+  HarnessHooks,
+} from '@myco/agent/harness/hooks.js';
+
+describe('HarnessHooks', () => {
+  it('accepts a fully-populated hooks object and invokes each callback with the right event shape', async () => {
+    const calls: string[] = [];
+    const ctx: HarnessHookContext = {
+      runId: 'run-1',
+      agentId: 'agent-1',
+      harnessId: 'claude-sdk',
+      phaseName: 'gather',
+    };
+
+    const hooks: HarnessHooks = {
+      preToolUse: (event: PreToolUseEvent) => {
+        expect(event.toolName).toBe('vault_spores');
+        expect(event.runId).toBe('run-1');
+        calls.push('preToolUse');
+      },
+      postToolUse: (event: PostToolUseEvent) => {
+        expect(event.outcome).toBe('success');
+        expect(event.durationMs).toBeGreaterThanOrEqual(0);
+        calls.push('postToolUse');
+      },
+      phaseStart: (event: PhaseStartEvent) => {
+        expect(event.phaseName).toBe('gather');
+        expect(event.required).toBe(true);
+        calls.push('phaseStart');
+      },
+      phaseEnd: (event: PhaseEndEvent) => {
+        expect(event.status).toBe('completed');
+        calls.push('phaseEnd');
+      },
+    };
+
+    await hooks.phaseStart?.({ ...ctx, phaseName: 'gather', model: 'claude-sonnet-4-6', maxTurns: 8, required: true });
+    await hooks.preToolUse?.({ ...ctx, toolName: 'vault_spores', toolInput: { limit: 10 } });
+    await hooks.postToolUse?.({ ...ctx, toolName: 'vault_spores', toolInput: { limit: 10 }, outcome: 'success', durationMs: 12 });
+    await hooks.phaseEnd?.({ ...ctx, phaseName: 'gather', status: 'completed', turnsUsed: 3, tokensUsed: 500, costUsd: 0.01, durationMs: 900 });
+
+    expect(calls).toEqual(['phaseStart', 'preToolUse', 'postToolUse', 'phaseEnd']);
+  });
+
+  it('allows an empty hooks object — every field is optional', () => {
+    const hooks: HarnessHooks = {};
+    expect(hooks.preToolUse).toBeUndefined();
+    expect(hooks.postToolUse).toBeUndefined();
+    expect(hooks.phaseStart).toBeUndefined();
+    expect(hooks.phaseEnd).toBeUndefined();
+  });
+
+  it('PostToolUseEvent carries errorMessage only conceptually on the error path (type-level check)', () => {
+    const errorEvent: PostToolUseEvent = {
+      runId: 'run-1', agentId: 'agent-1', harnessId: 'openai-agents',
+      toolName: 'vault_create_spore', toolInput: {}, outcome: 'error',
+      errorMessage: 'insert failed', durationMs: 5,
+    };
+    expect(errorEvent.outcome).toBe('error');
+    expect(errorEvent.errorMessage).toBe('insert failed');
+  });
+});

--- a/tests/agent/harness/tool-surface-hooks.test.ts
+++ b/tests/agent/harness/tool-surface-hooks.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Type-level + structural test confirming HarnessToolSurface accepts
+ * optional hooks/hookContext fields without breaking any existing
+ * required field.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import type { HarnessToolSurface, HarnessExecuteInput, HarnessScopeSetup } from '@myco/agent/harness/types.js';
+import type { HarnessHooks, HarnessHookContext } from '@myco/agent/harness/hooks.js';
+
+describe('HarnessToolSurface hooks fields', () => {
+  it('HarnessToolSurface compiles with hooks and hookContext set', () => {
+    const hookContext: HarnessHookContext = { runId: 'run-1', agentId: 'agent-1', harnessId: 'claude-sdk' };
+    const hooks: HarnessHooks = { preToolUse: () => {} };
+    const surface: HarnessToolSurface = {
+      agentId: 'agent-1',
+      runId: 'run-1',
+      hooks,
+      hookContext,
+    };
+    expect(surface.hooks).toBe(hooks);
+    expect(surface.hookContext).toBe(hookContext);
+  });
+
+  it('HarnessToolSurface still compiles with NO hooks fields set (backward compat)', () => {
+    const surface: HarnessToolSurface = { agentId: 'agent-1', runId: 'run-1' };
+    expect(surface.hooks).toBeUndefined();
+    expect(surface.hookContext).toBeUndefined();
+  });
+
+  it('HarnessExecuteInput and HarnessScopeSetup compile with an optional hooks field', () => {
+    const hooks: HarnessHooks = { phaseStart: () => {} };
+    const executeInput: HarnessExecuteInput = {
+      prompt: 'do the thing',
+      model: 'claude-sonnet-4-6',
+      toolSurface: { agentId: 'agent-1', runId: 'run-1' },
+      hooks,
+    };
+    expect(executeInput.hooks).toBe(hooks);
+
+    const scopeSetup: HarnessScopeSetup = {
+      model: 'claude-sonnet-4-6',
+      toolSurface: { agentId: 'agent-1', runId: 'run-1' },
+      hooks,
+    };
+    expect(scopeSetup.hooks).toBe(hooks);
+  });
+});

--- a/tests/agent/hooks-integration.test.ts
+++ b/tests/agent/hooks-integration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * End-to-end integration test: runAgent() with a phased task, using a
+ * stubbed harness that actually invokes a vault tool through the same
+ * tool surface the phase loop builds (so tools.ts's hook emission fires
+ * for real, via wrapToolWithAudit), and asserts agent_run_events contains
+ * the full expected event sequence: phase_start -> pre_tool_use ->
+ * post_tool_use -> phase_end, in that order, for a single-phase task.
+ *
+ * ADAPTATION FROM THE BRIEF'S SKETCH (see task-11-report.md for the
+ * evidence trail):
+ *  - The brief's fakeHarness only *constructed* a tool server
+ *    (`createVaultToolServer(...)`) and never invoked a tool handler.
+ *    Constructing the server wraps each tool's handler with
+ *    wrapToolWithAudit, but wrapping alone never calls the wrapped
+ *    function — no preToolUse/postToolUse would ever fire, which would
+ *    make this "integration" test assert nothing about real tool-hook
+ *    emission. This version calls `createVaultTools(...)` directly (the
+ *    same factory `createVaultToolServer` wraps) and invokes the
+ *    `vault_report` tool's `.handler()` — the same call shape
+ *    tests/agent/tools-hooks.test.ts uses to prove hook emission at the
+ *    unit level. That is what makes preToolUse/postToolUse fire for real
+ *    here.
+ *  - `title-summary` (the brief's suggested task) has no `phases` array —
+ *    it is a single-query task, so it never reaches `executePhase` and
+ *    therefore never emits phase_start/phase_end (Task 8's contract).
+ *    Its postcondition validator also requires a real vault_update_session
+ *    call or an explicit skip report to reach `status: 'completed'`.
+ *    `cortex-prompt-builder` is used instead: it has exactly one phase
+ *    ("build"), no task-specific postcondition validator, and its phase's
+ *    `tools:` list includes `vault_report`, which is FK-safe to call (only
+ *    needs an existing agent_runs row, which runAgent creates) and exempt
+ *    from dry-run interception.
+ *  - `ensureProjectManifest` requires an `options.projectName` (not
+ *    optional as the brief's snippet showed) — supplied here, matching
+ *    tests/agent/executor-hooks.test.ts's convention.
+ *  - Request context is built via `makeTestRequestContext` (Task 7's
+ *    fixture), not a hand-rolled partial-shape object, so `runAgent`'s
+ *    scope resolution and DB path resolution get a real, complete
+ *    `MycoRequestContext`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, mock } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+mock.module('@myco/intelligence/embed-query.js', () => ({ tryEmbed: async () => null }));
+
+import { ensureProjectManifest } from '@myco/config/project-manifest.js';
+import { setupTestDb, teardownTestDb } from '../helpers/db';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { epochSeconds, DEFAULT_AGENT_ID } from '@myco/constants.js';
+import { makeTestRequestContext } from '../helpers/request-context';
+import { listRunEvents } from '@myco/db/queries/agent-run-events.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+import type { AgentHarness, HarnessExecuteInput, HarnessExecuteResult } from '@myco/agent/harness/types.js';
+import type { HarnessId } from '@myco/agent/types.js';
+
+// A stub harness that, when the phase loop calls execute(), actually
+// invokes the `vault_report` tool through the real vault tool factory —
+// simulating what a real SDK would do when the model decides to call a
+// tool. This exercises tools.ts's hook emission (wrapToolWithAudit)
+// without needing a real Claude/OpenAI SDK call.
+const fakeHarness: AgentHarness = {
+  id: 'claude-sdk' as HarnessId,
+  async execute(input: HarnessExecuteInput): Promise<HarnessExecuteResult> {
+    const { createVaultTools } = await import('@myco/agent/tools.js');
+    // Rebuild the same tool surface the phase loop passed in, so the
+    // returned tool definitions are wrapped with wrapToolWithAudit
+    // (preToolUse/postToolUse) using the run's real hooks/hookContext.
+    const tools = createVaultTools(input.toolSurface.agentId, input.toolSurface.runId, {
+      requestContext: input.toolSurface.requestContext,
+      hooks: input.toolSurface.hooks,
+      hookContext: input.toolSurface.hookContext,
+    } as any);
+
+    const vaultReport = tools.find((t) => t.name === 'vault_report');
+    if (!vaultReport) {
+      throw new Error('vault_report tool not found on toolSurface — cortex-prompt-builder phase tools may have drifted');
+    }
+    // Actually call the handler — this is what makes wrapToolWithAudit's
+    // preToolUse/postToolUse fire for real, not just wrap-and-discard.
+    await (vaultReport as any).handler(
+      { action: 'cortex_prompt_builder', summary: 'test-generated prompt', details: { prompt: 'final prompt text' } },
+      {},
+    );
+
+    return {
+      finalText: 'phase complete',
+      turnsUsed: 1,
+      usage: { requests: 1, inputTokens: 10, outputTokens: 10, totalTokens: 20, reasoningTokens: 0, cachedTokens: 0, durationMs: 5 },
+      sessionRef: 'session-1',
+    };
+  },
+  supports: () => false,
+  classifyError: () => 'unknown',
+};
+
+mock.module('@myco/agent/harness/index.js', () => ({
+  getAgentHarness: () => fakeHarness,
+}));
+
+describe('harness hooks — end-to-end integration', () => {
+  let tmpDir: string;
+
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-hooks-e2e-'));
+    ensureProjectManifest(tmpDir, { projectName: 'hooks-integration-test' });
+    const now = epochSeconds();
+    registerAgent({
+      id: DEFAULT_AGENT_ID,
+      name: `agent-${DEFAULT_AGENT_ID}`,
+      created_at: now,
+      updated_at: now,
+    });
+  });
+
+  it('records phase_start -> pre_tool_use -> post_tool_use -> phase_end in order for a real runAgent() call', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+    const vaultDir = path.join(tmpDir, '.myco');
+    fs.mkdirSync(vaultDir, { recursive: true });
+
+    const requestContext = makeTestRequestContext({
+      vaultDir,
+      groveId: null,
+    });
+
+    const result = await runAgent(vaultDir, {
+      task: 'cortex-prompt-builder',
+      instruction: 'test instruction',
+      requestContext,
+    });
+
+    expect(result.status).toBe('completed');
+
+    const events = listRunEvents(result.runId, { scope: ALL_PROJECTS_SCOPE });
+    const eventTypes = events.map((e) => e.event_type);
+
+    // Full expected sequence for a single-phase task whose phase invokes
+    // exactly one tool: phase_start, pre_tool_use, post_tool_use, phase_end.
+    expect(eventTypes).toEqual(['phase_start', 'pre_tool_use', 'post_tool_use', 'phase_end']);
+
+    for (const event of events) {
+      expect(event.run_id).toBe(result.runId);
+      expect(event.recorded_at).toBeGreaterThan(0);
+    }
+
+    const [phaseStart, preToolUse, postToolUse, phaseEnd] = events;
+
+    expect(phaseStart.phase_name).toBe('build');
+    expect(preToolUse.phase_name).toBe('build');
+    expect(preToolUse.tool_name).toBe('vault_report');
+    expect(postToolUse.phase_name).toBe('build');
+    expect(postToolUse.tool_name).toBe('vault_report');
+    expect(postToolUse.outcome).toBe('success');
+    expect(phaseEnd.phase_name).toBe('build');
+  });
+});

--- a/tests/agent/map-phase-hooks.test.ts
+++ b/tests/agent/map-phase-hooks.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests that runMapPhaseAdapter emits one phaseStart/phaseEnd pair around
+ * the whole map-phase batch (not per-item), and that it threads hooks/
+ * hookContext into the createVaultTools call so per-item tool calls get
+ * preToolUse/postToolUse too.
+ */
+
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { vi } from '../helpers/vi-shim.js';
+import type { EffectiveConfig, PhaseDefinition, HarnessId, MapPhaseResult } from '@myco/agent/types.js';
+import type { AgentHarness } from '@myco/agent/harness/types.js';
+import type { PhaseStartEvent, PhaseEndEvent } from '@myco/agent/harness/hooks.js';
+import type { PhaseLoopContext } from '@myco/agent/phase-loop.js';
+
+const fakeMapResult: MapPhaseResult = {
+  itemCount: 3, written: 3, skipped: 0, failed: 0, abandoned: 0,
+  skipReasons: {}, writeAfterThrow: 0, providerUnavailable: false, unavailable: 0,
+  usage: { requests: 3, inputTokens: 30, outputTokens: 30, totalTokens: 60, reasoningTokens: 0, cachedTokens: 0, durationMs: 30 },
+};
+
+let executeMapPhaseBehavior: 'success' | 'error' = 'success';
+
+mock.module('@myco/agent/map-phase.js', () => ({
+  executeMapPhase: async () => {
+    if (executeMapPhaseBehavior === 'error') {
+      throw new Error('map phase failed');
+    }
+    return fakeMapResult;
+  },
+}));
+
+const fakeHarness: AgentHarness = {
+  id: 'claude-sdk' as HarnessId,
+  execute: async () => { throw new Error('not used in this test'); },
+  supports: () => false,
+  classifyError: () => 'unknown',
+};
+
+mock.module('@myco/agent/harness/index.js', () => ({
+  getAgentHarness: () => fakeHarness,
+}));
+
+const createVaultToolsCalls: unknown[] = [];
+mock.module('@myco/agent/tools.js', () => ({
+  createVaultTools: (...args: unknown[]) => {
+    createVaultToolsCalls.push(args);
+    return [];
+  },
+}));
+
+describe('runMapPhaseAdapter hook emission', () => {
+  beforeEach(() => {
+    executeMapPhaseBehavior = 'success';
+    createVaultToolsCalls.length = 0;
+  });
+
+  it('emits exactly one phaseStart/phaseEnd pair for the whole batch, not per item', async () => {
+    const { executePhase } = await import('@myco/agent/phase-loop.js');
+    const starts: PhaseStartEvent[] = [];
+    const ends: PhaseEndEvent[] = [];
+
+    const ctx: PhaseLoopContext = {
+      config: { harness: 'claude-sdk' as HarnessId, taskName: 'test-task' } as EffectiveConfig,
+      systemPrompt: 'system',
+      vaultContext: 'vault context',
+      agentId: 'agent-1',
+      runId: 'run-1',
+      checkpointState: { schemaVersion: 2, harness: 'claude-sdk' as HarnessId, phases: {} },
+      hooks: {
+        phaseStart: (e) => { starts.push(e); },
+        phaseEnd: (e) => { ends.push(e); },
+      },
+    } as PhaseLoopContext;
+
+    const phase: PhaseDefinition = {
+      name: 'map-gather', prompt: '', tools: [], maxTurns: 5, required: true, mode: 'map',
+      source: { tool: 'source_tool', args: {}, itemsPath: 'items' },
+      item: { prompt: 'do {{item.path}}' },
+      sink: { tool: 'sink_tool', argMap: {} },
+    };
+
+    await executePhase({
+      ctx, phasePrompt: '', phaseModel: 'claude-sonnet-4-6', phase,
+      toolSurface: { agentId: 'agent-1', runId: 'run-1' },
+    });
+
+    expect(starts).toHaveLength(1);
+    expect(starts[0].phaseName).toBe('map-gather');
+    expect(ends).toHaveLength(1);
+    expect(ends[0].phaseName).toBe('map-gather');
+    expect(ends[0].status).toBe('completed');
+    expect(ends[0].turnsUsed).toBe(3);
+
+    expect(createVaultToolsCalls).toHaveLength(1);
+    const [, , options] = createVaultToolsCalls[0] as [string, string, { hooks?: unknown; hookContext?: { phaseName?: string } }];
+    expect(options.hooks).toBe(ctx.hooks);
+    expect(options.hookContext?.phaseName).toBe('map-gather');
+  });
+
+  it('emits phaseEnd with status failed when executeMapPhase throws', async () => {
+    executeMapPhaseBehavior = 'error';
+    const { executePhase } = await import('@myco/agent/phase-loop.js');
+    const starts: PhaseStartEvent[] = [];
+    const ends: PhaseEndEvent[] = [];
+
+    const ctx: PhaseLoopContext = {
+      config: { harness: 'claude-sdk' as HarnessId, taskName: 'test-task' } as EffectiveConfig,
+      systemPrompt: 'system',
+      vaultContext: 'vault context',
+      agentId: 'agent-1',
+      runId: 'run-1',
+      checkpointState: { schemaVersion: 2, harness: 'claude-sdk' as HarnessId, phases: {} },
+      hooks: {
+        phaseStart: (e) => { starts.push(e); },
+        phaseEnd: (e) => { ends.push(e); },
+      },
+    } as PhaseLoopContext;
+
+    const phase: PhaseDefinition = {
+      name: 'map-gather', prompt: '', tools: [], maxTurns: 5, required: true, mode: 'map',
+      source: { tool: 'source_tool', args: {}, itemsPath: 'items' },
+      item: { prompt: 'do {{item.path}}' },
+      sink: { tool: 'sink_tool', argMap: {} },
+    };
+
+    const result = await executePhase({
+      ctx, phasePrompt: '', phaseModel: 'claude-sonnet-4-6', phase,
+      toolSurface: { agentId: 'agent-1', runId: 'run-1' },
+    });
+
+    expect(starts).toHaveLength(1);
+    expect(starts[0].phaseName).toBe('map-gather');
+    expect(ends).toHaveLength(1);
+    expect(ends[0].phaseName).toBe('map-gather');
+    expect(ends[0].status).toBe('failed');
+    expect(result.status).toBe('failed');
+  });
+
+  it('does not throw when ctx.hooks is undefined (backward compat)', async () => {
+    const { executePhase } = await import('@myco/agent/phase-loop.js');
+
+    const ctx: PhaseLoopContext = {
+      config: { harness: 'claude-sdk' as HarnessId, taskName: 'test-task' } as EffectiveConfig,
+      systemPrompt: 'system',
+      vaultContext: 'vault context',
+      agentId: 'agent-1',
+      runId: 'run-1',
+      checkpointState: { schemaVersion: 2, harness: 'claude-sdk' as HarnessId, phases: {} },
+      hooks: undefined,
+    } as PhaseLoopContext;
+
+    const phase: PhaseDefinition = {
+      name: 'map-gather', prompt: '', tools: [], maxTurns: 5, required: true, mode: 'map',
+      source: { tool: 'source_tool', args: {}, itemsPath: 'items' },
+      item: { prompt: 'do {{item.path}}' },
+      sink: { tool: 'sink_tool', argMap: {} },
+    };
+
+    const result = await executePhase({
+      ctx, phasePrompt: '', phaseModel: 'claude-sonnet-4-6', phase,
+      toolSurface: { agentId: 'agent-1', runId: 'run-1' },
+    });
+
+    expect(result.status).toBe('completed');
+  });
+});

--- a/tests/agent/openai-local-mcp.test.ts
+++ b/tests/agent/openai-local-mcp.test.ts
@@ -1,6 +1,19 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import { createLocalVaultMcpServer } from '@myco/agent/harness/openai-local-mcp.js';
 import { TEST_REQUEST_CONTEXT } from '../helpers/request-context';
+import { setupTestDb, teardownTestDb } from '../helpers/db';
+import { getDatabase } from '@myco/db/client.js';
+import { insertRun } from '@myco/db/queries/runs.js';
+import { listRunEvents } from '@myco/db/queries/agent-run-events.js';
+import { buildAuditEventHooks } from '@myco/agent/harness/audit-hooks.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+function createAgent(id: string): void {
+  const db = getDatabase();
+  db.prepare(`INSERT INTO agents (id, name, created_at) VALUES (?, ?, ?)`).run(id, `agent-${id}`, epochNow());
+}
 
 describe('createLocalVaultMcpServer', () => {
   it('exports JSON Schema for Anthropic SDK tools', async () => {
@@ -33,5 +46,49 @@ describe('createLocalVaultMcpServer', () => {
     expect((createSpore?.inputSchema?.properties as Record<string, unknown>)?.optional).toBeUndefined();
 
     await server.close();
+  });
+
+  describe('hook threading', () => {
+    // Regression: LocalVaultMcpServer's createVaultTools() call used to omit
+    // toolSurface.hooks/hookContext, so wrapToolWithAudit inside tools.ts
+    // always received undefined for OpenAI-harness runs — no
+    // pre_tool_use/post_tool_use events were ever recorded in production
+    // even when a run had real hooks configured. This exercises the real
+    // (unmocked) createVaultTools/wrapToolWithAudit path end to end: invoke
+    // a tool through the constructed server and assert the DB row lands.
+    beforeEach(() => {
+      setupTestDb();
+      createAgent('agent-1');
+      insertRun({ id: 'run-1', agent_id: 'agent-1', status: 'running', started_at: epochNow() });
+    });
+
+    afterEach(() => {
+      teardownTestDb();
+    });
+
+    it('threads hooks/hookContext through to wrapToolWithAudit, recording pre/post tool-use events', async () => {
+      const server = createLocalVaultMcpServer({
+        agentId: 'agent-1',
+        runId: 'run-1',
+        toolNames: ['vault_report'],
+        requestContext: TEST_REQUEST_CONTEXT,
+        hooks: buildAuditEventHooks('run-1', null),
+        hookContext: { runId: 'run-1', agentId: 'agent-1', harnessId: 'openai-agents', phaseName: 'gather' },
+      });
+
+      await server.callTool('vault_report', {
+        action: 'test_action',
+        summary: 'test summary',
+      });
+
+      const events = listRunEvents('run-1', { scope: ALL_PROJECTS_SCOPE });
+      const eventTypes = events.map((e) => e.event_type);
+      expect(eventTypes).toEqual(['pre_tool_use', 'post_tool_use']);
+      expect(events[0].tool_name).toBe('vault_report');
+      expect(events[0].phase_name).toBe('gather');
+      expect(events[1].outcome).toBe('success');
+
+      await server.close();
+    });
   });
 });

--- a/tests/agent/phase-loop-hooks.test.ts
+++ b/tests/agent/phase-loop-hooks.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests that executePhase emits phaseStart before dispatch and phaseEnd
+ * at both the success and failure return points, using ctx.hooks.
+ */
+
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import { vi } from '../helpers/vi-shim.js';
+import type {
+  EffectiveConfig,
+  PhaseDefinition,
+  RuntimeUsage,
+  HarnessId,
+} from '@myco/agent/types.js';
+import type { AgentHarness, HarnessExecuteInput, HarnessExecuteResult } from '@myco/agent/harness/types.js';
+import { HarnessExecutionError } from '@myco/agent/harness/types.js';
+import type { PhaseStartEvent, PhaseEndEvent } from '@myco/agent/harness/hooks.js';
+import type { PhaseLoopContext } from '@myco/agent/phase-loop.js';
+
+let executeBehavior: 'success' | 'error' = 'success';
+
+const DEFAULT_USAGE: RuntimeUsage = {
+  requests: 1, inputTokens: 10, outputTokens: 10, totalTokens: 20,
+  reasoningTokens: 0, cachedTokens: 0, durationMs: 5,
+};
+
+const fakeHarness: AgentHarness = {
+  id: 'claude-sdk' as HarnessId,
+  async execute(_input: HarnessExecuteInput): Promise<HarnessExecuteResult> {
+    if (executeBehavior === 'error') {
+      throw new HarnessExecutionError('boom', { usage: DEFAULT_USAGE, kind: 'other' });
+    }
+    return { finalText: 'ok', turnsUsed: 1, usage: DEFAULT_USAGE, sessionRef: 'session-1' };
+  },
+  supports: () => false,
+  classifyError: () => 'unknown',
+};
+
+mock.module('@myco/agent/harness/index.js', () => ({
+  getAgentHarness: () => fakeHarness,
+}));
+
+describe('executePhase hook emission', () => {
+  beforeEach(() => {
+    executeBehavior = 'success';
+  });
+
+  function buildCtx(hooksOverrides: Partial<NonNullable<PhaseLoopContext['hooks']>>): PhaseLoopContext {
+    return {
+      config: { harness: 'claude-sdk' as HarnessId, taskName: 'test-task' } as EffectiveConfig,
+      systemPrompt: 'system',
+      vaultContext: 'vault context',
+      agentId: 'agent-1',
+      runId: 'run-1',
+      checkpointState: { schemaVersion: 2, harness: 'claude-sdk' as HarnessId, phases: {} },
+      hooks: hooksOverrides as any,
+    } as PhaseLoopContext;
+  }
+
+  it('emits phaseStart before dispatch and phaseEnd with status completed on success', async () => {
+    const { executePhase } = await import('@myco/agent/phase-loop.js');
+    const starts: PhaseStartEvent[] = [];
+    const ends: PhaseEndEvent[] = [];
+    const ctx = buildCtx({
+      phaseStart: (e) => { starts.push(e); },
+      phaseEnd: (e) => { ends.push(e); },
+    });
+    const phase: PhaseDefinition = { name: 'gather', prompt: '', tools: [], maxTurns: 5, required: true };
+
+    await executePhase({
+      ctx, phasePrompt: 'do the thing', phaseModel: 'claude-sonnet-4-6', phase,
+      toolSurface: { agentId: 'agent-1', runId: 'run-1' },
+    });
+
+    expect(starts).toHaveLength(1);
+    expect(starts[0].phaseName).toBe('gather');
+    expect(starts[0].required).toBe(true);
+    expect(ends).toHaveLength(1);
+    expect(ends[0].status).toBe('completed');
+    expect(ends[0].turnsUsed).toBe(1);
+  });
+
+  it('emits phaseEnd with status failed when the harness throws', async () => {
+    executeBehavior = 'error';
+    const ends: PhaseEndEvent[] = [];
+    const { executePhase } = await import('@myco/agent/phase-loop.js');
+    const ctx = buildCtx({ phaseEnd: (e) => { ends.push(e); } });
+    const phase: PhaseDefinition = { name: 'gather', prompt: '', tools: [], maxTurns: 5, required: false };
+
+    await executePhase({
+      ctx, phasePrompt: 'do the thing', phaseModel: 'claude-sonnet-4-6', phase,
+      toolSurface: { agentId: 'agent-1', runId: 'run-1' },
+    });
+
+    expect(ends).toHaveLength(1);
+    expect(ends[0].status).toBe('failed');
+  });
+
+  it('does not throw when ctx.hooks is undefined (backward compat)', async () => {
+    const { executePhase } = await import('@myco/agent/phase-loop.js');
+    const ctx = { ...buildCtx({}), hooks: undefined } as PhaseLoopContext;
+    const phase: PhaseDefinition = { name: 'gather', prompt: '', tools: [], maxTurns: 5, required: false };
+
+    const result = await executePhase({
+      ctx, phasePrompt: 'do the thing', phaseModel: 'claude-sonnet-4-6', phase,
+      toolSurface: { agentId: 'agent-1', runId: 'run-1' },
+    });
+    expect(result.status).toBe('completed');
+  });
+});

--- a/tests/agent/runtime-claude.test.ts
+++ b/tests/agent/runtime-claude.test.ts
@@ -210,6 +210,49 @@ describe('ClaudeSdkHarness.execute', () => {
     expect(scopedServerCalls).toHaveLength(0);
   });
 
+  it('threads hooks/hookContext through to createScopedVaultToolServer when toolNames is provided', async () => {
+    // Regression: buildToolServer used to omit hooks/hookContext on the
+    // createScopedVaultToolServer call, so wrapToolWithAudit inside
+    // tools.ts always received undefined for agent-mode phases — no
+    // pre_tool_use/post_tool_use events were ever recorded in production
+    // even when a run had real hooks configured.
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+    const hooks = { preToolUse: async () => {} };
+    const hookContext = { runId: 'r1', agentId: 'a1', harnessId: 'claude-sdk' as const, phaseName: 'gather' };
+
+    await runtime.execute(makeInput({
+      toolSurface: {
+        agentId: 'a1',
+        runId: 'r1',
+        toolNames: ['vault_report'],
+        hooks,
+        hookContext,
+      },
+    }));
+
+    expect(scopedServerCalls).toHaveLength(1);
+    expect(scopedServerCalls[0].options.hooks).toBe(hooks);
+    expect(scopedServerCalls[0].options.hookContext).toEqual(hookContext);
+  });
+
+  it('threads hooks/hookContext through to createVaultToolServer when toolNames is omitted', async () => {
+    // Same regression as above, for the single-query / orchestrator path
+    // that hits the full (unscoped) vault tool server.
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+    const hooks = { phaseStart: async () => {} };
+    const hookContext = { runId: 'r1', agentId: 'a1', harnessId: 'claude-sdk' as const };
+
+    await runtime.execute(makeInput({
+      toolSurface: { agentId: 'a1', runId: 'r1', hooks, hookContext },
+    }));
+
+    expect(fullServerCalls).toHaveLength(1);
+    expect(fullServerCalls[0].options.hooks).toBe(hooks);
+    expect(fullServerCalls[0].options.hookContext).toEqual(hookContext);
+  });
+
   it('isolates the agent from user settings via settingSources: []', async () => {
     // Regression: the SDK's plugin-sync path reads `enabledPlugins` from
     // ~/.claude/settings.json / project .claude/settings.json when

--- a/tests/agent/tools-hooks.test.ts
+++ b/tests/agent/tools-hooks.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests that createVaultTools emits preToolUse/postToolUse hook events
+ * around every tool call, for both success and error outcomes, when
+ * hooks + hookContext are supplied via VaultToolOptions.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll, mock } from 'bun:test';
+import { vi } from '../helpers/vi-shim.js';
+
+mock.module('@myco/intelligence/embed-query.js', () => ({ tryEmbed: async () => null }));
+
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
+import { getDatabase } from '@myco/db/client.js';
+import { insertRun } from '@myco/db/queries/runs.js';
+import { createVaultTools } from '@myco/agent/tools.js';
+import type { PreToolUseEvent, PostToolUseEvent } from '@myco/agent/harness/hooks.js';
+import { TEST_REQUEST_CONTEXT } from '../helpers/request-context';
+
+const TEST_AGENT_ID = 'test-agent-hooks';
+const TEST_RUN_ID = 'run-hooks-001';
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+function createAgent(id: string): void {
+  const db = getDatabase();
+  db.prepare(`INSERT INTO agents (id, name, created_at) VALUES (?, ?, ?)`).run(id, `agent-${id}`, epochNow());
+}
+
+function findTool(tools: ReturnType<typeof createVaultTools>, name: string) {
+  const t = tools.find((tool) => tool.name === name);
+  if (!t) throw new Error(`Tool not found: ${name}`);
+  return t;
+}
+
+describe('createVaultTools hook emission', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    createAgent(TEST_AGENT_ID);
+    insertRun({ id: TEST_RUN_ID, agent_id: TEST_AGENT_ID, status: 'running', started_at: epochNow() });
+  });
+
+  it('emits preToolUse then postToolUse (success) around a read tool call', async () => {
+    const preEvents: PreToolUseEvent[] = [];
+    const postEvents: PostToolUseEvent[] = [];
+
+    const tools = createVaultTools(TEST_AGENT_ID, TEST_RUN_ID, {
+      requestContext: TEST_REQUEST_CONTEXT,
+      hooks: {
+        preToolUse: (e) => { preEvents.push(e); },
+        postToolUse: (e) => { postEvents.push(e); },
+      },
+      hookContext: { runId: TEST_RUN_ID, agentId: TEST_AGENT_ID, harnessId: 'claude-sdk', phaseName: 'gather' },
+    } as any);
+
+    const tool = findTool(tools, 'vault_spores');
+    await (tool as any).handler({ limit: 5 }, {});
+
+    expect(preEvents).toHaveLength(1);
+    expect(preEvents[0].toolName).toBe('vault_spores');
+    expect(preEvents[0].phaseName).toBe('gather');
+    expect(postEvents).toHaveLength(1);
+    expect(postEvents[0].toolName).toBe('vault_spores');
+    expect(postEvents[0].outcome).toBe('success');
+    expect(postEvents[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('emits postToolUse with outcome "error" when the handler throws', async () => {
+    const postEvents: PostToolUseEvent[] = [];
+
+    const tools = createVaultTools(TEST_AGENT_ID, TEST_RUN_ID, {
+      requestContext: TEST_REQUEST_CONTEXT,
+      hooks: { postToolUse: (e) => { postEvents.push(e); } },
+      hookContext: { runId: TEST_RUN_ID, agentId: TEST_AGENT_ID, harnessId: 'claude-sdk' },
+    } as any);
+
+    // vault_resolve_spore with a spore_id that doesn't exist errors inside
+    // the handler in a way that surfaces as a normal error result, not a
+    // thrown exception in most tool handlers — use the unknown-arg-key
+    // rejection path instead, which is guaranteed to throw a caught error
+    // inside wrapToolWithAudit's try/catch via a genuine exception path.
+    // Simplest reliable throw: call a tool with a required arg omitted so
+    // the underlying handler throws.
+    const tool = findTool(tools, 'vault_create_spore');
+    await expect((tool as any).handler({}, {})).rejects.toBeDefined();
+
+    expect(postEvents.length).toBeGreaterThanOrEqual(1);
+    expect(postEvents[0].outcome).toBe('error');
+    expect(postEvents[0].errorMessage).toBeDefined();
+  });
+
+  it('does not throw or emit hooks when hooks/hookContext are both absent (backward compat)', async () => {
+    const tools = createVaultTools(TEST_AGENT_ID, TEST_RUN_ID, { requestContext: TEST_REQUEST_CONTEXT });
+    const tool = findTool(tools, 'vault_spores');
+    const result = await (tool as any).handler({ limit: 5 }, {});
+    expect(result).toBeDefined();
+  });
+
+  it('awaits preToolUse and postToolUse in order around the handler (blocking, not fire-and-forget)', async () => {
+    const order: string[] = [];
+    const db = getDatabase();
+    const projectId = TEST_REQUEST_CONTEXT.projectId;
+    const stateKey = 'hook-order-probe';
+    const rowExists = () => db.prepare(
+      `SELECT 1 FROM agent_state WHERE agent_id = ? AND project_id = ? AND key = ?`,
+    ).get(TEST_AGENT_ID, projectId, stateKey) != null;
+
+    const tools = createVaultTools(TEST_AGENT_ID, TEST_RUN_ID, {
+      requestContext: TEST_REQUEST_CONTEXT,
+      hooks: {
+        preToolUse: async () => {
+          await new Promise((r) => setTimeout(r, 20));
+          // The write hasn't happened yet: preToolUse must complete
+          // strictly BEFORE the handler runs.
+          expect(rowExists()).toBe(false);
+          order.push('pre');
+        },
+        postToolUse: async () => {
+          await new Promise((r) => setTimeout(r, 20));
+          // By the time postToolUse fires, the handler's write is
+          // already committed — proving the handler ran strictly
+          // between preToolUse and postToolUse.
+          expect(rowExists()).toBe(true);
+          order.push('post');
+        },
+      },
+      hookContext: { runId: TEST_RUN_ID, agentId: TEST_AGENT_ID, harnessId: 'claude-sdk' },
+    } as any);
+
+    // vault_set_state's handler performs a synchronous DB write with no
+    // delay of its own, so any row-existence check made from inside a
+    // hook callback pins that hook's timing relative to the real handler
+    // execution — no mocking of internals required.
+    const tool = findTool(tools, 'vault_set_state');
+    const startedAt = Date.now();
+    await (tool as any).handler({ key: stateKey, value: 'x' }, {});
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(order).toEqual(['pre', 'post']);
+    expect(rowExists()).toBe(true);
+    // Both hook delays (20ms each) must have been awaited serially around
+    // the handler — if hooks were fire-and-forget, this call would return
+    // in a few ms instead of at least ~40ms.
+    expect(elapsedMs).toBeGreaterThanOrEqual(35);
+  });
+
+  it('isolates emission-site failures: sync throw and rejected-promise hooks never fail the tool call, and the audit path still runs', async () => {
+    const db = getDatabase();
+
+    // Variant A: hooks throw synchronously.
+    const toolsSyncThrow = createVaultTools(TEST_AGENT_ID, TEST_RUN_ID, {
+      requestContext: TEST_REQUEST_CONTEXT,
+      hooks: {
+        preToolUse: () => { throw new Error('pre boom (sync)'); },
+        postToolUse: () => { throw new Error('post boom (sync)'); },
+      },
+      hookContext: { runId: TEST_RUN_ID, agentId: TEST_AGENT_ID, harnessId: 'claude-sdk' },
+    } as any);
+
+    const toolSyncThrow = findTool(toolsSyncThrow, 'vault_spores');
+    const resultSyncThrow = await (toolSyncThrow as any).handler({ limit: 5 }, {});
+    expect(resultSyncThrow).toBeDefined();
+
+    // Variant B: hooks return rejected promises.
+    const toolsRejected = createVaultTools(TEST_AGENT_ID, TEST_RUN_ID, {
+      requestContext: TEST_REQUEST_CONTEXT,
+      hooks: {
+        preToolUse: () => Promise.reject(new Error('pre boom (rejected)')),
+        postToolUse: () => Promise.reject(new Error('post boom (rejected)')),
+      },
+      hookContext: { runId: TEST_RUN_ID, agentId: TEST_AGENT_ID, harnessId: 'claude-sdk' },
+    } as any);
+
+    const toolRejected = findTool(toolsRejected, 'vault_spores');
+    const resultRejected = await (toolRejected as any).handler({ limit: 5 }, {});
+    expect(resultRejected).toBeDefined();
+
+    // Audit path (agent_turns) still ran for both calls despite hook failures.
+    const turns = db.prepare(
+      `SELECT tool_output_summary, completed_at FROM agent_turns WHERE run_id = ? ORDER BY id ASC`,
+    ).all(TEST_RUN_ID) as Array<{ tool_output_summary: string | null; completed_at: number | null }>;
+
+    expect(turns.length).toBeGreaterThanOrEqual(2);
+    for (const turn of turns) {
+      expect(turn.completed_at).not.toBeNull();
+      expect(turn.tool_output_summary).not.toBeNull();
+    }
+  });
+});

--- a/tests/daemon/api/agent-run-events-endpoint.test.ts
+++ b/tests/daemon/api/agent-run-events-endpoint.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for GET /api/agent/runs/:id/events — the polling endpoint the
+ * daemon UI uses to read harness hook events incrementally (via ?since=).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { vi } from '../../helpers/vi-shim.js';
+
+mock.module('@myco/intelligence/embed-query.js', () => ({ tryEmbed: async () => null }));
+
+// Capture the original module so the mock below can delegate to real
+// behavior while also recording the options `listRunEvents` was called
+// with — the seam needed to assert the endpoint passes a cap without
+// inserting thousands of rows (too slow / not meaningful for a unit test).
+import * as __orig_agent_run_events from '@myco/db/queries/agent-run-events.js';
+const __real_agent_run_events = { ...__orig_agent_run_events };
+const listRunEventsCalls: Array<{ runId: string; options: Record<string, unknown> }> = [];
+
+mock.module('@myco/db/queries/agent-run-events.js', () => ({
+  ...__real_agent_run_events,
+  listRunEvents: (runId: string, options: Record<string, unknown>) => {
+    listRunEventsCalls.push({ runId, options });
+    return __real_agent_run_events.listRunEvents(runId, options as any);
+  },
+}));
+
+import { setupTestDb, teardownTestDb } from '../../helpers/db';
+import { getDatabase } from '@myco/db/client.js';
+import { insertRun } from '@myco/db/queries/runs.js';
+import { insertRunEvent } from '@myco/db/queries/agent-run-events.js';
+import { createAgentRunHandlers, AGENT_RUN_EVENTS_LIMIT } from '@myco/daemon/api/agent-runs.js';
+import type { DaemonLogger } from '@myco/daemon/logger.js';
+import { TEST_REQUEST_CONTEXT, makeTestRequestContext } from '../../helpers/request-context';
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+function createAgent(id: string): void {
+  const db = getDatabase();
+  db.prepare(`INSERT INTO agents (id, name, created_at) VALUES (?, ?, ?)`).run(id, `agent-${id}`, epochNow());
+}
+
+const noopLogger: DaemonLogger = {
+  debug: () => {}, info: () => {}, warn: () => {}, error: () => {},
+} as unknown as DaemonLogger;
+
+describe('GET /api/agent/runs/:id/events', () => {
+  beforeEach(() => {
+    listRunEventsCalls.length = 0;
+    setupTestDb();
+    createAgent('agent-1');
+    insertRun({ id: 'run-1', agent_id: 'agent-1', status: 'running', started_at: epochNow() });
+  });
+
+  afterEach(() => {
+    teardownTestDb();
+  });
+
+  it('returns 404 for an unknown run id', async () => {
+    const handlers = createAgentRunHandlers({
+      vaultDir: '/tmp/nonexistent',
+      resolveEmbeddingManager: () => ({} as any),
+      logger: noopLogger,
+    });
+    const response = await handlers.handleGetRunEvents({
+      params: { id: 'no-such-run' }, query: {}, body: undefined, pathname: '', headers: {},
+      requestContext: TEST_REQUEST_CONTEXT,
+    } as any);
+    expect(response.status).toBe(404);
+  });
+
+  it('returns all events for a run when no since param is given', async () => {
+    insertRunEvent({ runId: 'run-1', eventType: 'phase_start', phaseName: 'gather' });
+    insertRunEvent({ runId: 'run-1', eventType: 'phase_end', phaseName: 'gather', outcome: 'success' });
+
+    const handlers = createAgentRunHandlers({
+      vaultDir: '/tmp/nonexistent',
+      resolveEmbeddingManager: () => ({} as any),
+      logger: noopLogger,
+    });
+    const response = await handlers.handleGetRunEvents({
+      params: { id: 'run-1' }, query: {}, body: undefined, pathname: '', headers: {},
+      requestContext: TEST_REQUEST_CONTEXT,
+    } as any);
+
+    expect(response.status).toBeUndefined(); // default 200
+    const body = response.body as { events: unknown[]; count: number };
+    expect(body.count).toBe(2);
+    expect(body.events).toHaveLength(2);
+  });
+
+  it('returns only events after ?since=<id>', async () => {
+    const firstId = insertRunEvent({ runId: 'run-1', eventType: 'phase_start', phaseName: 'gather' });
+    insertRunEvent({ runId: 'run-1', eventType: 'phase_end', phaseName: 'gather', outcome: 'success' });
+
+    const handlers = createAgentRunHandlers({
+      vaultDir: '/tmp/nonexistent',
+      resolveEmbeddingManager: () => ({} as any),
+      logger: noopLogger,
+    });
+    const response = await handlers.handleGetRunEvents({
+      params: { id: 'run-1' }, query: { since: String(firstId) }, body: undefined, pathname: '', headers: {},
+      requestContext: TEST_REQUEST_CONTEXT,
+    } as any);
+
+    const body = response.body as { events: Array<{ event_type: string }>; count: number };
+    expect(body.count).toBe(1);
+    expect(body.events[0].event_type).toBe('phase_end');
+  });
+
+  it('passes the AGENT_RUN_EVENTS_LIMIT cap to listRunEvents without truncating a small result set', async () => {
+    // Inserting AGENT_RUN_EVENTS_LIMIT + 1 rows to prove truncation would be
+    // slow and not meaningfully more informative than asserting the handler
+    // passes the cap through — the cap constant is exported specifically so
+    // this seam is testable without a slow fixture. Assert both: (1) the
+    // real listRunEvents call received the cap, and (2) a small, realistic
+    // result set (well under the cap) is returned unaffected.
+    insertRunEvent({ runId: 'run-1', eventType: 'phase_start', phaseName: 'gather' });
+    insertRunEvent({ runId: 'run-1', eventType: 'pre_tool_use', phaseName: 'gather', toolName: 'vault_report' });
+    insertRunEvent({ runId: 'run-1', eventType: 'post_tool_use', phaseName: 'gather', toolName: 'vault_report', outcome: 'success' });
+
+    const handlers = createAgentRunHandlers({
+      vaultDir: '/tmp/nonexistent',
+      resolveEmbeddingManager: () => ({} as any),
+      logger: noopLogger,
+    });
+    const response = await handlers.handleGetRunEvents({
+      params: { id: 'run-1' }, query: {}, body: undefined, pathname: '', headers: {},
+      requestContext: TEST_REQUEST_CONTEXT,
+    } as any);
+
+    expect(listRunEventsCalls).toHaveLength(1);
+    expect(listRunEventsCalls[0].options.limit).toBe(AGENT_RUN_EVENTS_LIMIT);
+
+    const body = response.body as { events: unknown[]; count: number };
+    expect(body.count).toBe(3);
+    expect(body.events).toHaveLength(3);
+  });
+
+  it('returns 404 for a run belonging to a different project scope', async () => {
+    // Run belongs to proj_b, but request context is proj_a
+    const db = getDatabase();
+    db.prepare(`UPDATE agent_runs SET project_id = ? WHERE id = ?`).run('proj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 'run-1');
+
+    const handlers = createAgentRunHandlers({
+      vaultDir: '/tmp/nonexistent',
+      resolveEmbeddingManager: () => ({} as any),
+      logger: noopLogger,
+    });
+    // Caller asserts they're from proj_a with Grove binding
+    const projAContext = makeTestRequestContext({
+      projectId: 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      groveId: 'grove-test',
+      tenancySource: 'caller',
+    });
+    const response = await handlers.handleGetRunEvents({
+      params: { id: 'run-1' }, query: {}, body: undefined, pathname: '', headers: {},
+      requestContext: projAContext,
+    } as any);
+    expect(response.status).toBe(404);
+  });
+});

--- a/tests/db/agent-run-events-schema.test.ts
+++ b/tests/db/agent-run-events-schema.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Schema test for the agent_run_events table — verifies the table and its
+ * index exist after createSchema() runs, and that the column set matches
+ * what queries/agent-run-events.ts (Task 3) will rely on.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { createSchema, SCHEMA_VERSION } from '@myco/db/schema.js';
+
+describe('agent_run_events schema', () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('creates agent_run_events with the expected columns on a fresh install', () => {
+    createSchema(db, 'local');
+    const columns = db.prepare(`PRAGMA table_info(agent_run_events)`).all() as Array<{ name: string }>;
+    const columnNames = new Set(columns.map((c) => c.name));
+    expect(columnNames).toEqual(new Set([
+      'id', 'project_id', 'run_id', 'phase_name', 'event_type',
+      'tool_name', 'outcome', 'duration_ms', 'payload', 'recorded_at',
+    ]));
+  });
+
+  it('creates an index on (run_id, id) for cursor-based polling', () => {
+    createSchema(db, 'local');
+    const indexes = db.prepare(`PRAGMA index_list(agent_run_events)`).all() as Array<{ name: string }>;
+    expect(indexes.some((idx) => idx.name === 'idx_agent_run_events_run_id')).toBe(true);
+  });
+
+  it('migrates an existing vault at SCHEMA_VERSION - 1 up to SCHEMA_VERSION and creates the table', () => {
+    // Simulate a vault that predates this migration: create schema at the
+    // prior version by stamping schema_version down after a fresh install,
+    // dropping the new table to mimic "never had this migration run".
+    createSchema(db, 'local');
+    db.exec(`DROP TABLE IF EXISTS agent_run_events`);
+    db.exec(`DELETE FROM schema_version WHERE version = ${SCHEMA_VERSION}`);
+    db.prepare(`INSERT INTO schema_version (version, applied_at) VALUES (?, ?)`).run(SCHEMA_VERSION - 1, 0);
+
+    createSchema(db, 'local');
+
+    const versionRow = db.prepare(`SELECT MAX(version) AS v FROM schema_version`).get() as { v: number };
+    expect(versionRow.v).toBe(SCHEMA_VERSION);
+    const columns = db.prepare(`PRAGMA table_info(agent_run_events)`).all() as Array<{ name: string }>;
+    expect(columns.length).toBe(10);
+  });
+
+  it('agent_run_events.run_id cascades on agent_runs delete', () => {
+    db.exec('PRAGMA foreign_keys = ON');
+    createSchema(db, 'local');
+    db.prepare(`INSERT INTO agents (id, name, created_at) VALUES ('a1', 'agent', 0)`).run();
+    db.prepare(`INSERT INTO agent_runs (id, agent_id, status, started_at) VALUES ('run-1', 'a1', 'running', 0)`).run();
+    db.prepare(
+      `INSERT INTO agent_run_events (run_id, event_type, recorded_at) VALUES ('run-1', 'phase_start', 0)`,
+    ).run();
+    db.prepare(`DELETE FROM agent_runs WHERE id = 'run-1'`).run();
+    const remaining = db.prepare(`SELECT COUNT(*) AS n FROM agent_run_events WHERE run_id = 'run-1'`).get() as { n: number };
+    expect(remaining.n).toBe(0);
+  });
+});

--- a/tests/db/agent-run-events.test.ts
+++ b/tests/db/agent-run-events.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { setupTestDb, teardownTestDb } from '../helpers/db';
+import { getDatabase } from '@myco/db/client.js';
+import { insertRun } from '@myco/db/queries/runs.js';
+import { insertRunEvent, listRunEvents } from '@myco/db/queries/agent-run-events.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+function createAgent(id: string): void {
+  const db = getDatabase();
+  db.prepare(`INSERT INTO agents (id, name, created_at) VALUES (?, ?, ?)`).run(id, `agent-${id}`, epochNow());
+}
+
+describe('agent-run-events queries', () => {
+  beforeEach(() => {
+    setupTestDb();
+    createAgent('agent-1');
+    insertRun({ id: 'run-1', agent_id: 'agent-1', status: 'running', started_at: epochNow() });
+  });
+
+  afterEach(() => {
+    teardownTestDb();
+  });
+
+  it('inserts a row and returns the autoincrement id', () => {
+    const id = insertRunEvent({
+      runId: 'run-1',
+      eventType: 'phase_start',
+      phaseName: 'gather',
+      payload: JSON.stringify({ model: 'claude-sonnet-4-6' }),
+    });
+    expect(typeof id).toBe('number');
+    expect(id).toBeGreaterThan(0);
+  });
+
+  it('lists events for a run ordered by id ascending', () => {
+    insertRunEvent({ runId: 'run-1', eventType: 'phase_start', phaseName: 'gather' });
+    insertRunEvent({ runId: 'run-1', eventType: 'pre_tool_use', phaseName: 'gather', toolName: 'vault_spores' });
+    insertRunEvent({ runId: 'run-1', eventType: 'post_tool_use', phaseName: 'gather', toolName: 'vault_spores', outcome: 'success', durationMs: 12 });
+
+    const events = listRunEvents('run-1', { scope: ALL_PROJECTS_SCOPE });
+    expect(events).toHaveLength(3);
+    expect(events.map((e) => e.event_type)).toEqual(['phase_start', 'pre_tool_use', 'post_tool_use']);
+    expect(events[2].tool_name).toBe('vault_spores');
+    expect(events[2].outcome).toBe('success');
+    expect(events[2].duration_ms).toBe(12);
+  });
+
+  it('supports sinceId cursor-based polling — only returns rows with id > sinceId', () => {
+    const firstId = insertRunEvent({ runId: 'run-1', eventType: 'phase_start', phaseName: 'gather' });
+    insertRunEvent({ runId: 'run-1', eventType: 'pre_tool_use', phaseName: 'gather', toolName: 'vault_spores' });
+
+    const events = listRunEvents('run-1', { sinceId: firstId, scope: ALL_PROJECTS_SCOPE });
+    expect(events).toHaveLength(1);
+    expect(events[0].event_type).toBe('pre_tool_use');
+  });
+
+  it('parses the JSON payload column back into an object, degrading to null on parse failure', () => {
+    insertRunEvent({ runId: 'run-1', eventType: 'phase_end', phaseName: 'gather', payload: JSON.stringify({ turnsUsed: 3 }) });
+    const events = listRunEvents('run-1', { scope: ALL_PROJECTS_SCOPE });
+    expect(events[0].payload).toEqual({ turnsUsed: 3 });
+  });
+
+  it('returns an empty array for a run with no events', () => {
+    insertRun({ id: 'run-2', agent_id: 'agent-1', status: 'running', started_at: epochNow() });
+    const events = listRunEvents('run-2', { scope: ALL_PROJECTS_SCOPE });
+    expect(events).toEqual([]);
+  });
+});

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -48,7 +48,7 @@ describe('Database schema', () => {
 
   describe('constants', () => {
     it('exports SCHEMA_VERSION as a positive integer', () => {
-      expect(SCHEMA_VERSION).toBe(64);
+      expect(SCHEMA_VERSION).toBe(65);
       expect(Number.isInteger(SCHEMA_VERSION)).toBe(true);
     });
 


### PR DESCRIPTION
## Summary

Plan #4 of the Agent Harness SDK Alignment sequence — the largest of the six. Closes Gap 4 from the April 2026 harness maturity audit (post-hoc-only observability): tool calls and phase boundaries now emit structured, queryable events in near-real-time, identically under both harnesses.

- **`HarnessHooks`** (`preToolUse`/`postToolUse`/`phaseStart`/`phaseEnd`) — optional, awaited, failure-isolated at every emission site (a throwing hook or failed insert can never affect a tool call or run outcome; contracts locked by ordering + throw-isolation tests).
- **`agent_run_events`** — append-only table (migration v65), grove/project-scoped (registered in purge/backup/move-copy — including `MOVE_REKEYED_TABLES` for its AUTOINCREMENT id), team-sync excluded by design, pruned via the existing run-retention FK cascade.
- **Emission** — tool events from `wrapToolWithAudit` (harness-neutral; both adapters thread `hooks`/`hookContext` through their tool-surface rebuilds); phase events from `executePhase` (every exit path, retry-safe) and `runMapPhaseAdapter` (map batches emit their own start/end).
- **Wiring** — executor builds `buildAuditEventHooks` per run, unconditionally; `GET /api/agent/runs/:id/events?since=<id>` polls the stream (tenancy-scoped via the sibling endpoints' request-context pattern, 1000-row cap, id-cursor pagination).
- **e2e test** drives the real executor → phase-loop → tool pipeline and asserts the exact `phase_start → pre_tool_use → post_tool_use → phase_end` sequence with per-field checks.

Two Criticals caught by the final whole-branch review and fixed on-branch: (1) both harness adapters originally dropped `hooks`/`hookContext` when rebuilding tool surfaces — tool events would have been silently inert in production for all non-map-phase runs (the e2e test's fake harness had masked it; real-seam adapter tests now pin the threading, including a zero-mock test asserting actual DB rows); (2) the new table was missing from `MOVE_REKEYED_TABLES` (PK collisions on grove move; drift guard was red).

Follow-ups deliberately not in this PR (recorded in the master coordination plan): orchestrator planning calls are invisible to the event stream; session-retry tool events carry no attempt marker; payload size caps + pre/post `toolInput` dedupe; a `safeEmit` helper for the repeated swallow blocks; rate-limited error counter for the silent-catch convention; skipped-phase visibility.

## ⚠️ Pre-tag live smoke (with plan #3's)

One dogfood run, then `curl /api/agent/runs/:id/events` and eyeball the event sequence on the real adapter path — a new observability channel that can silently record nothing must be smoke-verified once against the real pipeline.

## Test plan

- [x] TDD per task (12 tasks), per-task spec+quality reviews with fixes applied on-branch (incl. mutation-verified threading tests and a strengthened cross-project tenancy test)
- [x] Migration convergence matrix green (fresh == migrated); grove move/copy drift guards green
- [x] Final whole-branch review (most capable model) + dimensions review; all fix-before-merge findings applied and independently re-verified
- [x] Full `npm test` green; `make build` green
- [ ] Live event-stream smoke on the dogfood daemon (pre-tag, see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)