### PR TITLE
fix(agent): thread pre-generated runId through dispatch instead of racy read-back

### DIFF
--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -324,7 +324,7 @@ export async function runAgent(
     overrideProvider
     ?? taskProviderOverride
     ?? config.execution?.provider;
-  const runId = options?.resumeRunId ?? crypto.randomUUID();
+  const runId = options?.resumeRunId ?? options?.runId ?? crypto.randomUUID();
   const runHooks = mergeHooks(buildAuditEventHooks(runId, projectId ?? null), options?.hooks);
   let harnessId = runHarness;
   let effectiveModel = resolveReasoningModel(

--- a/packages/myco/src/agent/types.ts
+++ b/packages/myco/src/agent/types.ts
@@ -543,6 +543,15 @@ export interface RunOptions {
   instruction?: string;
   /** Per-run task params layered over YAML/myco.yaml task params. */
   taskParams?: Record<string, string | number | boolean>;
+  /**
+   * Caller-supplied ID for the run row this dispatch will create. The API
+   * handler generates it so the HTTP response can name the run
+   * deterministically — the executor's row insert happens after awaits
+   * (e.g. the Ollama variant resolver), so reading the latest row back
+   * after dispatch races concurrent dispatches and returns a stale run.
+   * Ignored when `resumeRunId` is set (a resume reuses the existing row).
+   */
+  runId?: string;
   /** Resume a previous run by its ID (re-uses existing session state). */
   resumeRunId?: string;
   /** Embedding runtime for immediate vector operations during agent tool calls. */

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -7,7 +7,7 @@
 
 import { z } from 'zod';
 import { resolveProjectRoot } from '@myco/vault/resolve.js';
-import { listRuns, countRuns, getRun, getLatestRunId } from '@myco/db/queries/runs.js';
+import { listRuns, countRuns, getRun } from '@myco/db/queries/runs.js';
 import { getRunActivityBuckets, getRunBranches } from '@myco/db/queries/activity-buckets.js';
 import { listReports } from '@myco/db/queries/reports.js';
 import { listTurnsByRun } from '@myco/db/queries/turns.js';
@@ -173,7 +173,6 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
       force,
       executionOverrides: rawExecutionOverrides,
     } = parsedBody.data;
-    const scope = projectScopeFromRequestContext(req.requestContext);
     const effectiveAgentId = agentId ?? DEFAULT_AGENT_ID;
     const runVaultDir = vaultDirForRequest(req);
 
@@ -261,11 +260,21 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
       }
     }
 
+    // Pre-generate the run ID and hand it to the executor rather than
+    // reading the latest row back after dispatch. The executor's row
+    // insert happens after awaits (Ollama variant resolution, resume
+    // restore), so a read-back races concurrent dispatches and returns a
+    // stale run — the UI then watches the wrong run. If the executor
+    // skips this dispatch (same task already running), no row with this
+    // ID is ever created; GET /api/agent/runs/:id returns 404, which is
+    // the caller's signal that the dispatch did not start a new run.
+    const runId = crypto.randomUUID();
     const { dispatchAgentRun } = await import('@myco/agent/runner-host.js');
     const resultPromise = dispatchAgentRun(runVaultDir, {
       task,
       instruction,
       agentId: effectiveAgentId,
+      runId,
       embeddingManager,
       requestContext: req.requestContext,
       runContext,
@@ -273,11 +282,6 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
       executionOverrides,
       logger,
     });
-
-    // runAgent inserts the run row synchronously before the first await.
-    // Query for the most recently created run matching this task to get
-    // the correct ID — not getRunningRun which may return a different task.
-    const runId = getLatestRunId(effectiveAgentId, task, scope);
 
     resultPromise
       .then((result) => {

--- a/packages/myco/src/daemon/cortex.ts
+++ b/packages/myco/src/daemon/cortex.ts
@@ -32,7 +32,7 @@ import {
 } from '@myco/context/cortex-brief.js';
 import { getCortexInstructions } from '@myco/db/queries/cortex-instructions.js';
 import { listReports, type ReportRow } from '@myco/db/queries/reports.js';
-import { getLatestRunId, getRun } from '@myco/db/queries/runs.js';
+import { getRun } from '@myco/db/queries/runs.js';
 import { tryParseJson } from '@myco/utils/json.js';
 import { requireProjectId, type MycoRequestContext } from '@myco/grove/request-context.js';
 import { listSymbiontInfos, type SymbiontInfo } from './api/symbionts.js';
@@ -274,15 +274,19 @@ export async function buildCortexPrompt(
       : '## Current Cortex session-start instructions\nOmit them from the prompt because this symbiont receives session-start injection.\n',
   ].join('\n');
 
+  // Pre-generated and passed through RunOptions — reading the latest row
+  // back after dispatch races the executor's insert (which happens after
+  // awaits) and can name a stale run. Same pattern as handleRun.
+  const runId = crypto.randomUUID();
   const resultPromise = dispatchAgentRun(vaultDir, {
     task: CORTEX_PROMPT_BUILDER_TASK,
     agentId: DEFAULT_AGENT_ID,
     instruction: builderInstruction,
+    runId,
     embeddingManager: deps.resolveEmbeddingManager?.(requestContext),
     logger: deps.logger,
     requestContext,
   });
-  const runId = getLatestRunId(DEFAULT_AGENT_ID, CORTEX_PROMPT_BUILDER_TASK, scope);
   const tracked = resultPromise.catch((err) => {
     deps.logger.warn(LOG_KINDS.AGENT_ERROR, 'cortex-prompt-builder task failed', {
       run_id: runId ?? undefined,
@@ -373,15 +377,19 @@ export async function triggerCortexInstructions(
 
   try {
     const built = await buildCortexInstructionsInput(config, vaultDir, getTeamClient, requestContext);
+    // Pre-generated and passed through RunOptions — reading the latest row
+    // back after dispatch races the executor's insert. Same pattern as
+    // handleRun.
+    const runId = crypto.randomUUID();
     const resultPromise = dispatchFn(vaultDir, {
       task: CORTEX_INSTRUCTIONS_TASK,
       agentId: DEFAULT_AGENT_ID,
       instruction: built.instruction,
+      runId,
       runContext: { cortex_instruction_input_hash: built.inputHash },
       embeddingManager,
       requestContext,
     });
-    const runId = getLatestRunId(DEFAULT_AGENT_ID, CORTEX_INSTRUCTIONS_TASK, { kind: 'project', id: requireProjectId(requestContext, 'cortex instructions') });
 
     const tracked = resultPromise.catch((err) => {
       logger.warn(LOG_KINDS.AGENT_ERROR, 'Cortex instructions task failed', {

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -1689,11 +1689,11 @@ export async function main(): Promise<void> {
     resolveMachineId: (req) => req.requestContext?.machineId ?? getMachineId(),
     runCanopyMapTask: async ({ task, params }) => {
       // Mirror the dispatch shape used by /api/agent/run (see
-      // createAgentRunHandlers.handleRun): build the instruction, fire
-      // runAgent, then look up the run id that runAgent inserted
-      // synchronously before its first await. This matches how the
-      // scheduler enqueues canopy-map and keeps a single source of truth
-      // for instruction assembly.
+      // createAgentRunHandlers.handleRun): build the instruction,
+      // pre-generate the run id, and fire runAgent with it via
+      // RunOptions.runId. This matches how the scheduler enqueues
+      // canopy-map and keeps a single source of truth for instruction
+      // assembly.
       //
       // Use the *detailed* builder so we keep the skip reason: the
       // /api/agent/run dispatcher path collapses skips to undefined and
@@ -1704,7 +1704,6 @@ export async function main(): Promise<void> {
       // runContext.canopy_map_inputs_hash is unset.
       const { buildCanopyMapInstructionDetailed } = await import('../agent/instruction-builders.js');
       const { dispatchAgentRun } = await import('../agent/runner-host.js');
-      const { getLatestRunId } = await import('../db/queries/runs.js');
       const { DEFAULT_AGENT_ID } = await import('../constants.js');
 
       const mycoConfig = liveConfig.current;
@@ -1720,20 +1719,21 @@ export async function main(): Promise<void> {
         return { skipped: true, reason: built.reason };
       }
 
+      // Pre-generated and passed through RunOptions — reading the latest
+      // row back after dispatch races the executor's insert (it happens
+      // after awaits). Same pattern as handleRun.
+      const runId = crypto.randomUUID();
       const resultPromise = dispatchAgentRun(bootstrapVaultDir, {
         task,
         instruction: built.instruction,
         runContext: built.context,
         taskParams: params,
         agentId: DEFAULT_AGENT_ID,
+        runId,
         embeddingManager,
         requestContext,
         logger,
       });
-
-      // runAgent inserts the agent_runs row synchronously before its first
-      // await. Capture the id before letting the promise run unsupervised.
-      const runId = getLatestRunId(DEFAULT_AGENT_ID, task, { kind: 'project', id: projectId });
 
       // Fire-and-forget — caller already has the run id; we don't block
       // the HTTP response on the LLM round-trip. Errors are logged so
@@ -1744,7 +1744,7 @@ export async function main(): Promise<void> {
         });
       });
 
-      return { run_id: runId ?? '' };
+      return { run_id: runId };
     },
     runCanopyDescribeTask: async ({ task, params }) => {
       // Single-row canopy-describe dispatch — same shape as
@@ -1752,7 +1752,6 @@ export async function main(): Promise<void> {
       // params.canopy_entry_path to filter to that one entry.
       const { buildTaskInstruction } = await import('../agent/instruction-builders.js');
       const { dispatchAgentRun } = await import('../agent/runner-host.js');
-      const { getLatestRunId } = await import('../db/queries/runs.js');
       const { DEFAULT_AGENT_ID } = await import('../constants.js');
 
       const mycoConfig = liveConfig.current;
@@ -1773,18 +1772,21 @@ export async function main(): Promise<void> {
         requestContext,
       );
 
+      // Pre-generated and passed through RunOptions — reading the latest
+      // row back after dispatch races the executor's insert (it happens
+      // after awaits). Same pattern as handleRun.
+      const runId = crypto.randomUUID();
       const resultPromise = dispatchAgentRun(bootstrapVaultDir, {
         task,
         instruction: built?.instruction,
         runContext: built?.context,
         taskParams: params,
         agentId: DEFAULT_AGENT_ID,
+        runId,
         embeddingManager,
         requestContext,
         logger,
       });
-
-      const runId = getLatestRunId(DEFAULT_AGENT_ID, task, { kind: 'project', id: projectId });
 
       resultPromise.catch((err) => {
         logger.error(LOG_KINDS.AGENT_ERROR, 'canopy-describe redescribe threw', {
@@ -1792,7 +1794,7 @@ export async function main(): Promise<void> {
         });
       });
 
-      return { run_id: runId ?? '' };
+      return { run_id: runId };
     },
     // Drain bypass for /describe/retry-stuck. Captures the `scheduledTaskKicker`
     // let-binding by reference (reassigned in syncScheduledTasks before any

--- a/packages/myco/src/db/queries/runs.ts
+++ b/packages/myco/src/db/queries/runs.ts
@@ -641,29 +641,6 @@ export function refundRunResumeAttempt(id: string, scope: ProjectScope): number 
   return info.changes;
 }
 
-export function getLatestRunId(
-  agentId: string,
-  taskName: string | undefined,
-  scope: ProjectScope,
-): string | null {
-  const db = getDatabase();
-  const conditions = ['agent_id = ?'];
-  const params: unknown[] = [agentId];
-  if (taskName) {
-    conditions.push('task = ?');
-    params.push(taskName);
-  }
-  appendProjectCondition(conditions, params, scope);
-
-  const row = db.prepare(
-    `SELECT id FROM agent_runs
-     WHERE ${conditions.join(' AND ')}
-     ORDER BY started_at DESC
-     LIMIT 1`,
-  ).get(...params) as { id: string } | undefined;
-  return row?.id ?? null;
-}
-
 export function getLatestResumableRunForTask(
   agentId: string,
   taskName: string,

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -956,6 +956,57 @@ describe('runAgent', () => {
     expect(run!.completed_at).toBeGreaterThan(0);
   });
 
+  it('uses the caller-supplied runId for the run row', async () => {
+    // Dispatchers (API handler, cortex triggers, canopy regenerate)
+    // pre-generate the run id so their responses can name the run without
+    // reading the latest row back — that read-back raced the executor's
+    // insert (which happens after awaits) and returned stale runs.
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    const callerRunId = crypto.randomUUID();
+    const result = await runAgent(TEST_VAULT_DIR, {
+      requestContext: TEST_REQUEST_CONTEXT,
+      runId: callerRunId,
+    });
+
+    expect(result.status).toBe('completed');
+    expect(result.runId).toBe(callerRunId);
+    const run = getRun(callerRunId, ALL_PROJECTS_SCOPE);
+    expect(run).not.toBeNull();
+    expect(run!.status).toBe('completed');
+  });
+
+  it('resumeRunId wins over a caller-supplied runId', async () => {
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    const existingRunId = crypto.randomUUID();
+    insertRun({
+      id: existingRunId,
+      agent_id: TEST_AGENT_ID,
+      task: TEST_TASK_NAME,
+      status: 'failed',
+      harness: 'claude-sdk',
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      resumable: 1,
+      resume_status: 'ready',
+      started_at: epochSeconds() - 600,
+      completed_at: epochSeconds() - 300,
+      error: 'transient failure',
+    });
+
+    const strayRunId = crypto.randomUUID();
+    const result = await runAgent(TEST_VAULT_DIR, {
+      requestContext: TEST_REQUEST_CONTEXT,
+      task: TEST_TASK_NAME,
+      resumeRunId: existingRunId,
+      runId: strayRunId,
+    });
+
+    expect(result.runId).toBe(existingRunId);
+    expect(getRun(strayRunId, ALL_PROJECTS_SCOPE)).toBeNull();
+  });
+
   it('passes system prompt and composed task prompt to the SDK', async () => {
     const { runAgent } = await import('@myco/agent/executor.js');
 

--- a/tests/daemon/api/agent-runs-overrides-security.test.ts
+++ b/tests/daemon/api/agent-runs-overrides-security.test.ts
@@ -298,4 +298,21 @@ describe('POST /api/agent/run — executionOverrides security', () => {
     expect(opts.agentId).toBe(DEFAULT_AGENT_ID);
     expect(opts.instruction).toContain('ignore_watermark: true');
   });
+
+  it('responds with the same runId it hands to the executor', async () => {
+    // The handler pre-generates the run id and threads it through
+    // RunOptions — reading the latest row back after dispatch raced the
+    // executor's insert (it happens after awaits, e.g. Ollama variant
+    // resolution) and returned a stale run's id to the UI.
+    const { handleRun } = makeHandlers();
+    const response = await handleRun(makeRequest({
+      body: { task: 'title-summary', instruction: 'do the thing' },
+    }));
+
+    expect(response.body).toMatchObject({ ok: true, message: 'Agent started' });
+    expect(runAgentSpy).toHaveBeenCalledTimes(1);
+    const [, opts] = runAgentSpy.mock.calls[0] as [string, { runId?: string }];
+    expect(typeof opts.runId).toBe('string');
+    expect((response.body as { runId?: string }).runId).toBe(opts.runId);
+  });
 });

--- a/tests/smoke/review-fixes.test.ts
+++ b/tests/smoke/review-fixes.test.ts
@@ -16,7 +16,7 @@ mock.module('@myco/machine-id.js', () => ({
 }));
 import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
 import { registerAgent } from '@myco/db/queries/agents.js';
-import { insertRun, getRunningRunForTask, getLatestRunId, STATUS_RUNNING, STATUS_COMPLETED } from '@myco/db/queries/runs.js';
+import { insertRun, getRunningRunForTask, STATUS_RUNNING } from '@myco/db/queries/runs.js';
 import { insertCandidate, deleteCandidate, getCandidate, updateCandidate } from '@myco/db/queries/skill-candidates.js';
 import { insertSkillRecord, deleteSkillRecordCascade, getSkillRecord } from '@myco/db/queries/skill-records.js';
 import { insertLineage, listLineageForSkill } from '@myco/db/queries/skill-lineage.js';
@@ -76,19 +76,6 @@ describe('P1 #2: Concurrency guard query helpers', () => {
     expect(getRunningRunForTask(AGENT_ID, 'skill-generate', ALL_PROJECTS_SCOPE)).toBeNull();
   });
 
-  it('getLatestRunId returns most recent run', () => {
-    insertRun({
-      id: 'run-old', agent_id: AGENT_ID, task: 'skill-generate',
-      status: STATUS_COMPLETED, started_at: now - 100, created_at: now - 100,
-    });
-    insertRun({
-      id: 'run-new', agent_id: AGENT_ID, task: 'skill-generate',
-      status: STATUS_RUNNING, started_at: now, created_at: now,
-    });
-
-    expect(getLatestRunId(AGENT_ID, 'skill-generate', ALL_PROJECTS_SCOPE)).toBe('run-new');
-    expect(getLatestRunId(AGENT_ID, undefined, ALL_PROJECTS_SCOPE)).toBe('run-new');
-  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`POST /api/agent/run` (and the cortex/canopy dispatch sites) read the run id back with `getLatestRunId()` immediately after a fire-and-forget `dispatchAgentRun()`, relying on the assumption that `runAgent` inserts its run row synchronously before its first await. That assumption is false — the executor awaits before `insertRun` (Ollama variant resolution, resume restore, and on the openai-agents path) — so callers received a **stale run's id**. Reproduced live during the pre-tag smoke on 3 of 4 provider-override dispatches: the UI navigated to and watched the wrong run (in one case a scheduler run that had completed minutes earlier). This masqueraded as "provider override silently dropped" and cost a full bug hunt.

## Fix (pattern, applied at every dispatch site)

- New `RunOptions.runId`: dispatchers pre-generate `crypto.randomUUID()` and thread it through; the executor uses `resumeRunId ?? runId ?? randomUUID()` (resume still wins).
- Converted all four read-back sites: `handleRun` (agent-runs.ts), `requestCortexPromptBuild` + `triggerCortexInstructions` (cortex.ts), `runCanopyMapTask` + `runCanopyDescribeTask` (main.ts).
- Deleted `getLatestRunId` — the racy pattern is now structurally impossible.

## Accepted trade-off

If the executor skips a dispatch (same task already running), the returned id names a row that never materializes; `GET /api/agent/runs/:id` 404s — a detectable signal, replacing today's silently-wrong id. Documented at the handler.

## Tests

- executor honors caller-supplied `runId`; `resumeRunId` precedence over `runId`.
- route test: response `runId` === the id handed to the executor.
- removed the `getLatestRunId` smoke test with the function.
- `make build` green; independent code review pass (2 minor findings, both fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)