### PR TITLE
fix(agent): stamp run_id in tool payloads server-side

### DIFF
--- a/packages/myco/src/agent/tools.ts
+++ b/packages/myco/src/agent/tools.ts
@@ -600,7 +600,17 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
     } else if (shouldSemanticCheck) {
       inner = wrapToolWithSemanticCheck(typed);
     }
-    return wrapToolWithAudit(inner, hooks, hookContext);
+    const audited = wrapToolWithAudit(inner, hooks, hookContext);
+    // Argument normalization is the OUTERMOST wrapper so it runs FIRST on
+    // the way in: audit events, dry-run write intents, the semantic-check
+    // classifier, and the real handler all see the same normalized args.
+    // Ordering matters for the dry-run path in particular — the intent row
+    // records the arguments verbatim, and the run-end/phase postconditions
+    // validate against that row, so a normalization applied only inside
+    // the real handler would leave dry runs validating unstamped payloads.
+    return typed.normalizeArgs
+      ? wrapToolWithArgNormalization(audited, typed.normalizeArgs)
+      : audited;
   });
 
   // Deferred-loading pass: built from the FULLY WRAPPED tool list so
@@ -657,6 +667,33 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
   return (searchTool
     ? [...withStubs, wrapToolWithAudit(searchTool, hooks, hookContext)]
     : withStubs) as typeof tools;
+
+  /**
+   * Outermost wrapper for tools that declare `normalizeArgs` (see
+   * MycoToolDefinition.normalizeArgs in tools/types.ts): rewrites the
+   * incoming arguments deterministically before ANY other consumer —
+   * audit events, dry-run write intents, the semantic-check classifier,
+   * and the real handler all receive the normalized shape. Fails open to
+   * the original args if the normalizer throws — normalization is a
+   * correction, never a gate.
+   */
+  function wrapToolWithArgNormalization(
+    toolDef: MycoToolDefinition<any>,
+    normalizeArgs: NonNullable<MycoToolDefinition<any>['normalizeArgs']>,
+  ): MycoToolDefinition<any> {
+    return {
+      ...toolDef,
+      handler: async (args, extra) => {
+        let normalized = args ?? {};
+        try {
+          normalized = normalizeArgs(normalized, { runId });
+        } catch {
+          normalized = args ?? {};
+        }
+        return toolDef.handler(normalized, extra);
+      },
+    };
+  }
 
   /**
    * Outer wrapper applied only when `dryRun === true` and the tool is a

--- a/packages/myco/src/agent/tools/observability-tools.ts
+++ b/packages/myco/src/agent/tools/observability-tools.ts
@@ -8,7 +8,7 @@ import { z } from 'zod/v4';
 import { tool } from '@anthropic-ai/claude-agent-sdk';
 import { epochSeconds } from '@myco/constants.js';
 import { insertReport } from '@myco/db/queries/reports.js';
-import { textResult, type VaultToolDeps } from './types.js';
+import { textResult, stampRunIdInPayload, type VaultToolDeps } from './types.js';
 import { rowProjectIdFromRequestContext } from '@myco/grove/request-context.js';
 
 // ---------------------------------------------------------------------------
@@ -19,31 +19,41 @@ export function createObservabilityTools(deps: VaultToolDeps) {
   const { runId, agentId } = deps;
   const projectId = rowProjectIdFromRequestContext(deps.requestContext);
 
-  const vaultReport = tool(
-    'vault_report',
-    'Record an observability report for the current run. Use action "skip" when skipping expected operations (e.g., not updating a session summary) with reasoning in the summary field.',
-    {
-      action: z.string().describe('Action name (e.g., extract, consolidate, digest, skip)'),
-      summary: z.string().describe('Human-readable summary of what was done'),
-      details: z.record(z.string(), z.unknown()).optional().describe('Structured details as key-value pairs'),
-    },
-    async (args) => {
-      const now = epochSeconds();
+  const vaultReport = {
+    ...tool(
+      'vault_report',
+      'Record an observability report for the current run. Use action "skip" when skipping expected operations (e.g., not updating a session summary) with reasoning in the summary field. When details contains a run_id field, the daemon stamps it to the current run\'s id server-side — you do not need to reproduce the run id exactly.',
+      {
+        action: z.string().describe('Action name (e.g., extract, consolidate, digest, skip)'),
+        summary: z.string().describe('Human-readable summary of what was done'),
+        details: z.record(z.string(), z.unknown()).optional().describe('Structured details as key-value pairs'),
+      },
+      async (args) => {
+        const now = epochSeconds();
 
-      const report = insertReport({
-        run_id: runId,
-        project_id: projectId,
-        agent_id: agentId,
-        action: args.action,
-        summary: args.summary,
-        details: args.details ? JSON.stringify(args.details) : null,
-        created_at: now,
-      });
+        const report = insertReport({
+          run_id: runId,
+          project_id: projectId,
+          agent_id: agentId,
+          action: args.action,
+          summary: args.summary,
+          details: args.details ? JSON.stringify(args.details) : null,
+          created_at: now,
+        });
 
-      return textResult(report);
+        return textResult(report);
+      },
+      { annotations: { readOnlyHint: true } },
+    ),
+    // Same fabricated-run_id class as vault_set_state: skill-evolve's
+    // assess report details carry a run_id the postconditions validate.
+    // `details` is already an object on the wire — stamp in place.
+    normalizeArgs: (args: Record<string, unknown>, ctx: { runId: string }) => {
+      const stamped = stampRunIdInPayload(args.details, ctx.runId);
+      if (stamped === args.details) return args;
+      return { ...args, details: stamped };
     },
-    { annotations: { readOnlyHint: true } },
-  );
+  };
 
   return [vaultReport];
 }

--- a/packages/myco/src/agent/tools/types.ts
+++ b/packages/myco/src/agent/tools/types.ts
@@ -47,6 +47,46 @@ export interface MycoToolDefinition<TInput = any> {
    * checked (existing behavior, unchanged for single-action write tools).
    */
   destructiveActions?: string[];
+  /**
+   * Deterministic argument normalization applied by `createVaultTools()`
+   * as the OUTERMOST wrapper — before audit-event recording, dry-run
+   * write-intent capture, the semantic-check classifier, and the real
+   * handler, so every consumer sees the same normalized arguments.
+   *
+   * Motivating case: payloads whose shape asks the model to transcribe a
+   * load-bearing identifier (e.g. `run_id` in skill-evolve state/report
+   * payloads). Models fabricate placeholders instead of copying UUIDs,
+   * which the task postconditions then reject. Stamping the true value
+   * here makes that failure class structurally impossible.
+   *
+   * Must be pure and total: return the (possibly new) args object, never
+   * throw — `wrapToolWithArgNormalization` fails open to the original
+   * args if it does.
+   */
+  normalizeArgs?: (args: Record<string, unknown>, ctx: { runId: string }) => Record<string, unknown>;
+}
+
+/**
+ * Stamp `run_id` in a plain-object payload to the actual run id. Returns
+ * a new object when the payload carries a `run_id` key with a different
+ * value; returns the input unchanged otherwise (no key added — payloads
+ * without run-attribution semantics are never touched, so cursor-style
+ * state values and strict downstream parsers are unaffected).
+ */
+export function stampRunIdInPayload(
+  payload: unknown,
+  runId: string,
+): unknown {
+  if (
+    payload !== null
+    && typeof payload === 'object'
+    && !Array.isArray(payload)
+    && 'run_id' in payload
+    && (payload as Record<string, unknown>).run_id !== runId
+  ) {
+    return { ...(payload as Record<string, unknown>), run_id: runId };
+  }
+  return payload;
 }
 
 export function toSdkMcpToolDefinition<TInput>(

--- a/packages/myco/src/agent/tools/write-tools.ts
+++ b/packages/myco/src/agent/tools/write-tools.ts
@@ -20,7 +20,7 @@ import { createSporeLineage } from '@myco/db/queries/lineage.js';
 import { assertGroveProjectId } from '@myco/grove/ids.js';
 import { requireProjectId } from '@myco/grove/request-context.js';
 import { upsertDigestExtract, listDigestExtracts } from '@myco/db/queries/digest-extracts.js';
-import { textResult, dryRunResult, projectScopeFromVaultToolDeps, rowProjectIdFromVaultToolDeps, type VaultToolDeps } from './types.js';
+import { textResult, dryRunResult, projectScopeFromVaultToolDeps, rowProjectIdFromVaultToolDeps, stampRunIdInPayload, type VaultToolDeps } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Factory
@@ -167,21 +167,40 @@ export function createWriteTools(deps: VaultToolDeps) {
     { annotations: { idempotentHint: true } },
   );
 
-  const vaultSetState = tool(
-    'vault_set_state',
-    'Set a key-value state pair for the current agent. Used for bookmarks, cursors, and preferences.',
-    {
-      key: z.string().describe('State key (e.g., last_processed_batch_id, cursor)'),
-      value: z.string().describe('State value (stored as text)'),
-    },
-    async (args) => {
-      const now = epochSeconds();
-      const state = setState(agentId, requireProjectId(requestContext!, 'agent state write'), args.key, args.value, now);
+  const vaultSetState = {
+    ...tool(
+      'vault_set_state',
+      'Set a key-value state pair for the current agent. Used for bookmarks, cursors, and preferences. When the value is a JSON object containing a run_id field, the daemon stamps it to the current run\'s id server-side — you do not need to reproduce the run id exactly.',
+      {
+        key: z.string().describe('State key (e.g., last_processed_batch_id, cursor)'),
+        value: z.string().describe('State value (stored as text)'),
+      },
+      async (args) => {
+        const now = epochSeconds();
+        const state = setState(agentId, requireProjectId(requestContext!, 'agent state write'), args.key, args.value, now);
 
-      return textResult(state);
+        return textResult(state);
+      },
+      { annotations: { idempotentHint: true } },
+    ),
+    // Models fabricate run ids instead of transcribing UUIDs, and the
+    // skill-evolve postconditions validate the payload's run_id. The
+    // value is a JSON string on the wire — parse, stamp, re-serialize;
+    // non-JSON values and object payloads without a run_id key pass
+    // through untouched.
+    normalizeArgs: (args: Record<string, unknown>, ctx: { runId: string }) => {
+      if (typeof args.value !== 'string') return args;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(args.value);
+      } catch {
+        return args;
+      }
+      const stamped = stampRunIdInPayload(parsed, ctx.runId);
+      if (stamped === parsed) return args;
+      return { ...args, value: JSON.stringify(stamped) };
     },
-    { annotations: { idempotentHint: true } },
-  );
+  };
 
   const vaultReadDigest = tool(
     'vault_read_digest',

--- a/tests/agent/tools-dry-run.test.ts
+++ b/tests/agent/tools-dry-run.test.ts
@@ -435,6 +435,103 @@ describe('vault tools regression (dryRun: false)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Test suite — run_id stamping (normalizeArgs, live + dry-run)
+// ---------------------------------------------------------------------------
+
+describe('run_id stamping in tool payloads', () => {
+  let tools: ReturnType<typeof createVaultTools>;
+
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+
+  beforeEach(() => {
+    cleanTestDb();
+    createAgent(TEST_AGENT_ID);
+    createRun(TEST_RUN_ID, TEST_AGENT_ID);
+    tools = createVaultTools(TEST_AGENT_ID, TEST_RUN_ID, { requestContext: TEST_REQUEST_CONTEXT });
+  });
+
+  it('vault_set_state stamps a fabricated run_id in a JSON object value', async () => {
+    // The failure class this guards: a model writes a placeholder
+    // instead of transcribing the run UUID, and the skill-evolve
+    // postcondition rejects the run.
+    const t = findTool(tools, 'vault_set_state');
+    await t.handler({
+      key: 'skill-evolve-inventory',
+      value: JSON.stringify({ run_id: 'skill-evolve-2026-07-02', merge_candidates: [], narrow_candidates: [] }),
+    }, undefined);
+
+    const db = getDatabase();
+    const row = db.prepare(`SELECT value FROM agent_state WHERE key = ?`).get('skill-evolve-inventory') as { value: string };
+    const stored = JSON.parse(row.value);
+    expect(stored.run_id).toBe(TEST_RUN_ID);
+    expect(stored.merge_candidates).toEqual([]);
+  });
+
+  it('vault_set_state leaves payloads without a run_id key untouched', async () => {
+    const t = findTool(tools, 'vault_set_state');
+    await t.handler({
+      key: 'cursor',
+      value: JSON.stringify({ last_processed_batch_id: 42 }),
+    }, undefined);
+
+    const db = getDatabase();
+    const row = db.prepare(`SELECT value FROM agent_state WHERE key = ?`).get('cursor') as { value: string };
+    const stored = JSON.parse(row.value);
+    expect(stored).toEqual({ last_processed_batch_id: 42 });
+    expect('run_id' in stored).toBe(false);
+  });
+
+  it('vault_set_state leaves non-JSON values untouched', async () => {
+    const t = findTool(tools, 'vault_set_state');
+    await t.handler({ key: 'plain', value: 'not json at all' }, undefined);
+
+    const db = getDatabase();
+    const row = db.prepare(`SELECT value FROM agent_state WHERE key = ?`).get('plain') as { value: string };
+    expect(row.value).toBe('not json at all');
+  });
+
+  it('vault_report stamps a fabricated run_id in details', async () => {
+    const t = findTool(tools, 'vault_report');
+    await t.handler({
+      action: 'assess',
+      summary: 'classified skills',
+      details: { run_id: 'made-up-id', classifications: [] },
+    }, undefined);
+
+    const db = getDatabase();
+    const row = db.prepare(`SELECT details FROM agent_reports WHERE action = 'assess'`).get() as { details: string };
+    const details = JSON.parse(row.details);
+    expect(details.run_id).toBe(TEST_RUN_ID);
+  });
+
+  it('dry-run: the recorded write intent carries the STAMPED value, not the fabricated one', async () => {
+    // The postconditions validate dry runs against the intent rows —
+    // stamping must be applied OUTSIDE the dry-run interceptor so the
+    // intent records the corrected payload.
+    const dryTools = createVaultTools(TEST_AGENT_ID, TEST_RUN_ID, {
+      requestContext: TEST_REQUEST_CONTEXT,
+      dryRun: true,
+    });
+    const t = findTool(dryTools, 'vault_set_state');
+    await t.handler({
+      key: 'skill-evolve-inventory',
+      value: JSON.stringify({ run_id: 'fabricated', merge_candidates: [], narrow_candidates: [] }),
+    }, undefined);
+
+    const intents = listIntents();
+    expect(intents).toHaveLength(1);
+    const toolInput = JSON.parse(intents[0].tool_input);
+    const value = JSON.parse(toolInput.value);
+    expect(value.run_id).toBe(TEST_RUN_ID);
+    // No live-table write in dry-run.
+    const db = getDatabase();
+    const row = db.prepare(`SELECT value FROM agent_state WHERE key = ?`).get('skill-evolve-inventory');
+    expect(row ?? null).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Test suite — JSON.stringify dedupe in the wrapper hot path
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Recurring prod failure (2× on 2026-07-02, project unifi-mcp): `skill-evolve inventory state run_id does not match the run`. The inventory phase's state payload asks the model to transcribe the run UUID; the model wrote a fabricated placeholder instead:

```json
{"run_id":"skill-evolve-2026-07-02","merge_candidates":[],"narrow_candidates":[]}
```

The task postconditions validate that run_id, so every occurrence fails the run (and with #616, will fail it at the phase boundary). The failure class is *LLM transcription of a load-bearing identifier* — prompt discipline held for weeks, then didn't.

## Fix — remove the transcription requirement

New `MycoToolDefinition.normalizeArgs` hook + shared `stampRunIdInPayload` helper. `createVaultTools` applies it as the **outermost** wrapper, so audit events, dry-run write-intent rows, the semantic-check classifier, and the real handler all see the same stamped args — critical because dry-run postconditions validate the intent rows, so a handler-level stamp would leave dry runs unprotected (pinned by a dedicated test).

- `vault_set_state`: JSON-string value parsed, run_id stamped, re-serialized. Non-JSON values and payloads without a run_id key pass through untouched (cursor-style state never modified).
- `vault_report`: `details.run_id` stamped (the assess-report check validates it — same class).
- Both tool descriptions now tell the model the id is stamped server-side.

## Review

Independent implementation review: no findings ≥80 confidence. Traced clean: wrapper ordering end-to-end, the map-phase materialized-tools path (preserves wrapped handlers), openai-agents adapter leg, semantic-check cache-key interaction, and a sweep for other model-transcribed identifiers (the skill-survey run_ids are already server-computed; the two normalized tools cover all three YAML transcription sites).

## Tests

5 new: live stamp for both tools, non-run_id and non-JSON pass-through, and the ordering-guarding dry-run case (intent row carries the stamped value). `make build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)