### PR TITLE
feat(agent): semantic-check enablement — phase purpose contracts, classifier observability, grove-tier flag promotion

### DIFF
--- a/packages/myco/src/agent/definitions.generated.ts
+++ b/packages/myco/src/agent/definitions.generated.ts
@@ -228,6 +228,7 @@ export const BUNDLED_AGENT_TASKS: readonly AgentTask[] = [
         ],
         "maxTurns": 18,
         "required": true,
+        "purpose": "Read-only prompt assembly; no vault_skill_records writes intended in this phase. Skill records are consulted only to surface repeatable project procedures for the built prompt.",
         "onItemError": "skip"
       }
     ]
@@ -347,6 +348,7 @@ export const BUNDLED_AGENT_TASKS: readonly AgentTask[] = [
         "dependsOn": [
           "inventory"
         ],
+        "purpose": "Writes STALE/MERGE/NARROW classification updates to vault_skill_records properties (last_assessed_at, knowledge_watermark, last_classification, last_assessed_generation, file_fingerprints) for assessed skills. vault_skill_candidates is read-only triage input in this phase — it is consulted for merge/narrow signals but never created, updated, or deleted here.",
         "postCondition": "skill-evolve-assess",
         "onItemError": "skip"
       },
@@ -372,6 +374,7 @@ export const BUNDLED_AGENT_TASKS: readonly AgentTask[] = [
         "dependsOn": [
           "assess"
         ],
+        "purpose": "Applies classified merges, narrowing, and content updates by writing to vault_skill_records — status transitions to retired/deleted for DEPRECATED and merged-away skills, and lineage-bearing content changes via vault_edit_skill/vault_write_skill, which carry no destructiveHint of their own.",
         "onItemError": "skip"
       }
     ],
@@ -428,6 +431,7 @@ export const BUNDLED_AGENT_TASKS: readonly AgentTask[] = [
         "dependsOn": [
           "draft"
         ],
+        "purpose": "Finalizes the staged skill via vault_finalize_skill, which atomically inserts the vault_skill_records row plus lineage and transitions the source candidate to 'generated' — no separate vault_skill_candidates write call is made in this phase.",
         "onItemError": "skip"
       }
     ],
@@ -499,6 +503,7 @@ export const BUNDLED_AGENT_TASKS: readonly AgentTask[] = [
         "dependsOn": [
           "explore"
         ],
+        "purpose": "No destructive writes via vault_skill_candidates/vault_skill_records (list/get only); all durable output flows through vault_skill_survey_bundle_decisions, the non-destructive tool that persists CREATE/UPDATE/DEFER/DISMISS/SKIP decisions for the next phase.",
         "onItemError": "skip"
       },
       {
@@ -517,6 +522,7 @@ export const BUNDLED_AGENT_TASKS: readonly AgentTask[] = [
         "dependsOn": [
           "review-bundles"
         ],
+        "purpose": "Writes reconciliation plan state via vault_skill_survey_reconciliation_plan for persist-decisions to apply. vault_skill_candidates and vault_skill_records are used for list/get lookups only — never create, update, or delete in this phase.",
         "onItemError": "skip"
       },
       {
@@ -534,6 +540,7 @@ export const BUNDLED_AGENT_TASKS: readonly AgentTask[] = [
         "dependsOn": [
           "reconcile-queue"
         ],
+        "purpose": "Applies the stored reconciliation plan's Create/Update/Defer/Dismiss decisions via vault_skill_survey_apply_reconciliation — the sole write path for this phase.",
         "onItemError": "skip"
       }
     ],
@@ -634,6 +641,7 @@ export const BUNDLED_AGENT_TASKS: readonly AgentTask[] = [
         "dependsOn": [
           "read-state"
         ],
+        "purpose": "Resolves spore lifecycle via vault_resolve_spore action \"supersede\" when a new spore replaces an existing one with meaningful new detail, and marks source prompt batches processed via vault_mark_processed as extraction consumes them.",
         "onItemError": "skip"
       },
       {
@@ -690,6 +698,7 @@ export const BUNDLED_AGENT_TASKS: readonly AgentTask[] = [
         "dependsOn": [
           "consolidate-shortlist"
         ],
+        "purpose": "Resolves source spores via vault_resolve_spore — action \"consolidate\" for spores folded into a new wisdom spore, action \"supersede\" for spores replaced by a richer one — superseding or consolidating them out of active search and context injection.",
         "preCondition": "has-recent-consolidatable-spores",
         "onItemError": "skip"
       },

--- a/packages/myco/src/agent/definitions/tasks/cortex-prompt-builder.yaml
+++ b/packages/myco/src/agent/definitions/tasks/cortex-prompt-builder.yaml
@@ -55,6 +55,10 @@ phases:
 
       Before finishing, call `vault_report` with action `cortex_prompt_builder`
       and put the final prompt in `details.prompt`.
+    purpose: >-
+      Read-only prompt assembly; no vault_skill_records writes intended in
+      this phase. Skill records are consulted only to surface repeatable
+      project procedures for the built prompt.
     tools:
       - vault_read_digest
       - vault_sessions

--- a/packages/myco/src/agent/definitions/tasks/skill-evolve.yaml
+++ b/packages/myco/src/agent/definitions/tasks/skill-evolve.yaml
@@ -298,6 +298,13 @@ phases:
       2. One `vault_report` call with aggregate counts and any deferred/watch
          notes.
       3. Final assistant text <= 4 lines, no narrative walkthrough.
+    purpose: >-
+      Writes STALE/MERGE/NARROW classification updates to vault_skill_records
+      properties (last_assessed_at, knowledge_watermark, last_classification,
+      last_assessed_generation, file_fingerprints) for assessed skills.
+      vault_skill_candidates is read-only triage input in this phase — it is
+      consulted for merge/narrow signals but never created, updated, or
+      deleted here.
     tools:
       - vault_spores
       - vault_search_fts
@@ -455,6 +462,12 @@ phases:
       Required output shape:
       - One `vault_report` with executed/deferred counts.
       - Final assistant text <= 3 lines.
+    purpose: >-
+      Applies classified merges, narrowing, and content updates by writing
+      to vault_skill_records — status transitions to retired/deleted for
+      DEPRECATED and merged-away skills, and lineage-bearing content changes
+      via vault_edit_skill/vault_write_skill, which carry no destructiveHint
+      of their own.
     tools:
       - vault_edit_skill
       - vault_write_skill

--- a/packages/myco/src/agent/definitions/tasks/skill-generate.yaml
+++ b/packages/myco/src/agent/definitions/tasks/skill-generate.yaml
@@ -258,6 +258,11 @@ phases:
       - Whether finalize was called
       - Each criterion: pass/fail with brief note
       - Any re-stages performed
+    purpose: >-
+      Finalizes the staged skill via vault_finalize_skill, which atomically
+      inserts the vault_skill_records row plus lineage and transitions the
+      source candidate to 'generated' — no separate vault_skill_candidates
+      write call is made in this phase.
     tools:
       - vault_stage_skill
       - vault_finalize_skill

--- a/packages/myco/src/agent/definitions/tasks/skill-survey.yaml
+++ b/packages/myco/src/agent/definitions/tasks/skill-survey.yaml
@@ -309,6 +309,12 @@ phases:
         lines: counts of CREATE/UPDATE/DEFER/DISMISS/SKIP plus any
         unreviewed bundle IDs. All durable detail goes through
         `vault_skill_survey_bundle_decisions`, not the narrative.
+    purpose: >-
+      No destructive writes via vault_skill_candidates/vault_skill_records
+      (list/get only); all durable output flows through
+      vault_skill_survey_bundle_decisions, the non-destructive tool that
+      persists CREATE/UPDATE/DEFER/DISMISS/SKIP decisions for the next
+      phase.
     tools:
       - vault_skill_survey_prepare
       - vault_skill_candidates
@@ -484,6 +490,11 @@ phases:
       restating their content. The assistant message outside tool calls
       MUST be ≤ 6 lines (counts per action). Durable detail goes through
       `vault_skill_survey_reconciliation_plan`, not the narrative.
+    purpose: >-
+      Writes reconciliation plan state via vault_skill_survey_reconciliation_plan
+      for persist-decisions to apply. vault_skill_candidates and
+      vault_skill_records are used for list/get lookups only — never create,
+      update, or delete in this phase.
     tools:
       - vault_skill_survey_prepare
       - vault_state
@@ -519,6 +530,10 @@ phases:
       under `remaining_cleanup_target_ids`.
 
       Report a summary via vault_report.
+    purpose: >-
+      Applies the stored reconciliation plan's Create/Update/Defer/Dismiss
+      decisions via vault_skill_survey_apply_reconciliation — the sole write
+      path for this phase.
     tools:
       - vault_skill_survey_prepare
       - vault_state

--- a/packages/myco/src/agent/definitions/tasks/vault-evolve.yaml
+++ b/packages/myco/src/agent/definitions/tasks/vault-evolve.yaml
@@ -156,6 +156,11 @@ phases:
 
       Final summary MUST be ≤ 6 lines: batches processed, spores created (by
       type), and supersedes applied. No per-spore retelling.
+    purpose: >-
+      Resolves spore lifecycle via vault_resolve_spore action "supersede" when
+      a new spore replaces an existing one with meaningful new detail, and
+      marks source prompt batches processed via vault_mark_processed as
+      extraction consumes them.
     tools:
       - vault_unprocessed
       - vault_spores
@@ -343,6 +348,11 @@ phases:
 
       Final summary MUST be ≤ 5 lines: how many wisdom spores created, how
       many supersedes applied, anything skipped. No retelling of the shortlist.
+    purpose: >-
+      Resolves source spores via vault_resolve_spore — action "consolidate"
+      for spores folded into a new wisdom spore, action "supersede" for
+      spores replaced by a richer one — superseding or consolidating them
+      out of active search and context injection.
     tools:
       - vault_spores
       - vault_release_state

--- a/packages/myco/src/agent/harness/claude.ts
+++ b/packages/myco/src/agent/harness/claude.ts
@@ -200,6 +200,7 @@ function buildToolServer(input: { toolSurface: HarnessExecuteInput['toolSurface'
         hooks: toolSurface.hooks,
         hookContext: toolSurface.hookContext,
         deferredNames: toolSurface.deferredNames ? new Set(toolSurface.deferredNames) : undefined,
+        logger: toolSurface.logger,
       },
     );
   }
@@ -220,6 +221,7 @@ function buildToolServer(input: { toolSurface: HarnessExecuteInput['toolSurface'
     flaggedWritesAccumulator: toolSurface.flaggedWritesAccumulator,
     hooks: toolSurface.hooks,
     hookContext: toolSurface.hookContext,
+    logger: toolSurface.logger,
   });
 }
 

--- a/packages/myco/src/agent/harness/openai-local-mcp.ts
+++ b/packages/myco/src/agent/harness/openai-local-mcp.ts
@@ -60,6 +60,7 @@ class LocalVaultMcpServer implements MCPServer {
       hooks: toolSurface.hooks,
       hookContext: toolSurface.hookContext,
       deferredNames: toolSurface.deferredNames ? new Set(toolSurface.deferredNames) : undefined,
+      logger: toolSurface.logger,
     }).filter((tool) => !toolSurface.readOnly || tool.annotations?.readOnlyHint === true);
     // vault_search_tools is synthesized by createVaultTools when any tool
     // in scope is deferrable and is never itself in `toolNames` — let it

--- a/packages/myco/src/agent/harness/types.ts
+++ b/packages/myco/src/agent/harness/types.ts
@@ -94,6 +94,16 @@ export interface HarnessToolSurface {
    * write on its own. See VaultToolOptions.flaggedWritesAccumulator.
    */
   flaggedWritesAccumulator?: FlaggedWriteAccumulator;
+  /**
+   * Run logger for tool-level diagnostics, threaded through from
+   * `HarnessExecuteInput.logger`. `buildToolServer` (claude.ts) and
+   * `createLocalVaultMcpServer` (openai-local-mcp.ts) only ever see the
+   * `toolSurface`, not the sibling top-level `logger` field on
+   * `HarnessExecuteInput` — this field is what lets `createVaultTools`
+   * (via `wrapToolWithSemanticCheck`) emit `agent.write.classified` log
+   * lines. Optional everywhere — absence must not throw.
+   */
+  logger?: RunLogger;
 }
 
 /** One recorded semantic-check block, appended to a FlaggedWriteAccumulator. */

--- a/packages/myco/src/agent/phase-loop.ts
+++ b/packages/myco/src/agent/phase-loop.ts
@@ -679,9 +679,12 @@ async function runMapPhaseAdapter(input: ExecutePhaseInput): Promise<PhaseResult
     // comment history / cumulative-review report). phasePurpose is derived
     // from the map phase's own name/prompt the same way executePhase does
     // for the regular path.
+    // An authored purpose is used verbatim as the classifier's promptExcerpt;
+    // the truncated prompt excerpt is only a fallback when no purpose is set.
     phasePurpose: {
       name: phase.name,
-      promptExcerpt: phase.prompt.length > 500 ? `${phase.prompt.slice(0, 500)}…` : phase.prompt,
+      promptExcerpt:
+        phase.purpose ?? (phase.prompt.length > 500 ? `${phase.prompt.slice(0, 500)}…` : phase.prompt),
     },
     semanticCheckEnabled: ctx.config.semanticWriteCheckEnabled ?? false,
     harnessId: ctx.config.harness,
@@ -689,6 +692,7 @@ async function runMapPhaseAdapter(input: ExecutePhaseInput): Promise<PhaseResult
     classifierReasoningLevel: ctx.config.classifierReasoningLevel,
     provider,
     flaggedWritesAccumulator,
+    logger,
   });
 
   logger?.debug('agent.map.start', `Map phase "${phase.name}" starting`, {
@@ -1240,9 +1244,12 @@ export async function executePhasedQuery(
           hookContext: ctx.hooks
             ? { runId, agentId, harnessId: config.harness, phaseName: phase.name }
             : undefined,
+          // An authored purpose is used verbatim as the classifier's promptExcerpt;
+          // the truncated prompt excerpt is only a fallback when no purpose is set.
           phasePurpose: {
             name: phase.name,
-            promptExcerpt: phase.prompt.length > 500 ? `${phase.prompt.slice(0, 500)}…` : phase.prompt,
+            promptExcerpt:
+              phase.purpose ?? (phase.prompt.length > 500 ? `${phase.prompt.slice(0, 500)}…` : phase.prompt),
           },
           semanticCheckEnabled: config.semanticWriteCheckEnabled ?? false,
           harnessId: config.harness,
@@ -1250,6 +1257,7 @@ export async function executePhasedQuery(
           classifierReasoningLevel: config.classifierReasoningLevel,
           provider: phaseProvider,
           flaggedWritesAccumulator,
+          logger: ctx.options?.logger,
         },
       };
     });

--- a/packages/myco/src/agent/schemas.test.ts
+++ b/packages/myco/src/agent/schemas.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test';
+import { AgentTaskSchema, PhaseDefinitionSchema } from './schemas.js';
+
+/**
+ * Coverage for the authored `purpose` field on PhaseDefinitionSchema. The
+ * field feeds the semantic-check classifier's phasePurpose.promptExcerpt
+ * (see write-classifier.ts) as an alternative to the first-500-chars-of-
+ * prompt fallback — it must stay optional and bounded so a pasted whole
+ * prompt fails validation instead of silently becoming the "purpose".
+ */
+describe('PhaseDefinitionSchema purpose field', () => {
+  const basePhase = {
+    name: 'extract',
+    prompt: 'Extract structured data from the source document.',
+    tools: [],
+    maxTurns: 10,
+    required: true,
+  };
+
+  test('accepts a phase without purpose (field is optional)', () => {
+    const result = PhaseDefinitionSchema.safeParse(basePhase);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.purpose).toBeUndefined();
+    }
+  });
+
+  test('accepts and round-trips a valid purpose string', () => {
+    const purpose = 'Writes the finalized report to vault_reports. Never touches vault_sessions.';
+    const result = PhaseDefinitionSchema.safeParse({ ...basePhase, purpose });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.purpose).toBe(purpose);
+    }
+  });
+
+  test('rejects an empty string purpose', () => {
+    const result = PhaseDefinitionSchema.safeParse({ ...basePhase, purpose: '' });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a purpose longer than 2000 characters', () => {
+    const result = PhaseDefinitionSchema.safeParse({ ...basePhase, purpose: 'x'.repeat(2001) });
+    expect(result.success).toBe(false);
+  });
+
+  test('accepts a purpose exactly at the 2000 character bound', () => {
+    const result = PhaseDefinitionSchema.safeParse({ ...basePhase, purpose: 'x'.repeat(2000) });
+    expect(result.success).toBe(true);
+  });
+
+  test('task-YAML load path (AgentTaskSchema) is unaffected by the new field', () => {
+    const task = {
+      name: 'sample-task',
+      displayName: 'Sample Task',
+      description: 'A sample task for schema testing.',
+      agent: 'claude-code',
+      prompt: 'Do the thing.',
+      isDefault: false,
+      phases: [basePhase, { ...basePhase, name: 'write', purpose: 'Writes results to vault_notes only.' }],
+    };
+    const result = AgentTaskSchema.safeParse(task);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.phases?.[0]?.purpose).toBeUndefined();
+      expect(result.data.phases?.[1]?.purpose).toBe('Writes results to vault_notes only.');
+    }
+  });
+});

--- a/packages/myco/src/agent/schemas.ts
+++ b/packages/myco/src/agent/schemas.ts
@@ -221,6 +221,7 @@ export const PhaseDefinitionSchema = z.object({
   provider: ProviderConfigSchema.optional(),
   skipPriorContext: z.boolean().optional(),
   readOnly: z.boolean().optional(),
+  purpose: z.string().min(1).max(2000).optional(),
   preCondition: PhasePreConditionSchema.optional(),
   postCondition: PhasePostConditionSchema.optional(),
   gateOnPriorMetadata: z.object({

--- a/packages/myco/src/agent/tools.ts
+++ b/packages/myco/src/agent/tools.ts
@@ -49,7 +49,7 @@ import type { MycoToolDefinition, VaultToolDeps } from './tools/types.js';
 import type { AgentEmbeddingPort, AgentTeamSearchPort } from '@myco/agent/runtime/ports.js';
 import { rowProjectIdFromRequestContext, type MycoRequestContext } from '@myco/grove/request-context.js';
 import type { HarnessHooks, HarnessHookContext } from './harness/hooks.js';
-import type { HarnessId, ProviderConfig, ReasoningLevel } from '@myco/agent/types.js';
+import type { HarnessId, ProviderConfig, ReasoningLevel, RunLogger } from '@myco/agent/types.js';
 import type { FlaggedWriteAccumulator } from './harness/types.js';
 
 // Re-exports for backward compatibility
@@ -160,6 +160,15 @@ export interface VaultToolOptions {
    * alone (without `hookContext`) never fires.
    */
   hookContext?: HarnessHookContext;
+  /**
+   * Run logger for tool-level diagnostics. Threaded through so
+   * `wrapToolWithSemanticCheck` can emit one `agent.write.classified`
+   * line per rendered verdict (see HarnessToolSurface.logger for the
+   * full threading path from `HarnessExecuteInput.logger`). Optional —
+   * absent for any caller that doesn't pass one; every call site uses
+   * `logger?.info(...)` so absence never throws.
+   */
+  logger?: RunLogger;
 }
 
 /**
@@ -455,6 +464,7 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
     deferredNames,
     hooks,
     hookContext,
+    logger,
   } = options ?? {};
   const projectId = rowProjectIdFromRequestContext(requestContext);
 
@@ -930,6 +940,7 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
           recordFlagAndThrow(toolDef.name, reason, undefined, phasePurpose.name, cacheKey);
         }
 
+        const classifyStartedAt = Date.now();
         const verdict = await classifyWriteIntent({
           harnessId,
           model,
@@ -938,6 +949,17 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
           phasePurpose,
           toolName: toolDef.name,
           toolArgs: args,
+        });
+        const latencyMs = Date.now() - classifyStartedAt;
+
+        logger?.info('agent.write.classified', `Semantic check verdict for ${toolDef.name}`, {
+          runId,
+          phase: phasePurpose.name,
+          toolName: toolDef.name,
+          verdict: verdict.verdict,
+          outcome: verdict.outcome,
+          latencyMs,
+          classifierTokens: verdict.usage?.totalTokens,
         });
 
         if (verdict.verdict === 'ok') {
@@ -1161,7 +1183,7 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
 export function createVaultToolServer(
   agentId: string,
   runId: string,
-  options?: Pick<VaultToolOptions, 'embeddingManager' | 'projectRoot' | 'vaultDir' | 'requestContext' | 'dryRun' | 'metadataAccumulator' | 'phasePurpose' | 'semanticCheckEnabled' | 'harnessId' | 'model' | 'classifierReasoningLevel' | 'provider' | 'flaggedWritesAccumulator' | 'hooks' | 'hookContext'>,
+  options?: Pick<VaultToolOptions, 'embeddingManager' | 'projectRoot' | 'vaultDir' | 'requestContext' | 'dryRun' | 'metadataAccumulator' | 'phasePurpose' | 'semanticCheckEnabled' | 'harnessId' | 'model' | 'classifierReasoningLevel' | 'provider' | 'flaggedWritesAccumulator' | 'hooks' | 'hookContext' | 'logger'>,
 ) {
   const tools = createVaultTools(agentId, runId, options);
 
@@ -1191,7 +1213,7 @@ export function createScopedVaultToolServer(
   agentId: string,
   runId: string,
   toolNames: string[],
-  options?: Pick<VaultToolOptions, 'turnOffset' | 'embeddingManager' | 'projectRoot' | 'vaultDir' | 'requestContext' | 'dryRun' | 'metadataAccumulator' | 'phasePurpose' | 'semanticCheckEnabled' | 'harnessId' | 'model' | 'classifierReasoningLevel' | 'provider' | 'flaggedWritesAccumulator' | 'hooks' | 'hookContext' | 'deferredNames'> & { readOnly?: boolean },
+  options?: Pick<VaultToolOptions, 'turnOffset' | 'embeddingManager' | 'projectRoot' | 'vaultDir' | 'requestContext' | 'dryRun' | 'metadataAccumulator' | 'phasePurpose' | 'semanticCheckEnabled' | 'harnessId' | 'model' | 'classifierReasoningLevel' | 'provider' | 'flaggedWritesAccumulator' | 'hooks' | 'hookContext' | 'deferredNames' | 'logger'> & { readOnly?: boolean },
 ) {
   const nameSet = new Set(toolNames);
   const allTools = createVaultTools(agentId, runId, { ...options, onlyNames: nameSet });

--- a/packages/myco/src/agent/types.ts
+++ b/packages/myco/src/agent/types.ts
@@ -83,6 +83,16 @@ export interface PhaseDefinition {
   /** If true, the scoped tool server only includes read-only tools (readOnlyHint === true). */
   readOnly?: boolean;
   /**
+   * Authored statement of this phase's intended writes. Used verbatim as
+   * the semantic-check classifier's `phasePurpose.promptExcerpt` — must
+   * describe the phase's INTENDED WRITES, not general phase behavior.
+   * When absent, the classifier falls back to the first 500 characters of
+   * `prompt`. Note: an authored purpose means the classifier no longer
+   * sees orchestrator `contextNotes` spliced into the prompt — intended,
+   * since purpose is the static write contract, not the dynamic prompt.
+   */
+  purpose?: string;
+  /**
    * Optional mechanical precondition. When set, the phase loop runs the
    * registered SQL check before composing the prompt; on false the phase
    * is recorded as `skipped` and the harness is not invoked. Use to

--- a/packages/myco/src/agent/write-classifier.ts
+++ b/packages/myco/src/agent/write-classifier.ts
@@ -105,6 +105,22 @@ export interface ClassifyWriteIntentResult {
    * per-phase flagged-writes accumulator.
    */
   usage?: RuntimeUsage;
+  /**
+   * Distinguishes WHY verdict is 'ok' — 'ok' alone conflates a genuine
+   * classification with a classifier that never rendered a verdict at
+   * all. Telemetry only: does not change verdict semantics, does not
+   * gate flag handling, caps, cache, or write-intent rows.
+   *   - 'ok': the classifier ran and genuinely judged the call consistent
+   *     with the phase's purpose.
+   *   - 'flag': the classifier ran and judged the call inconsistent.
+   *   - 'unparseable': the classifier ran but its response text didn't
+   *     match the "ok" / "flag: <reason>" contract — degrades to
+   *     verdict 'ok' (see parseVerdict).
+   *   - 'fail-open': the classifier never rendered a verdict at all —
+   *     the harness call threw, or the wall-clock deadline expired —
+   *     degrades to verdict 'ok' (see the catch block below).
+   */
+  outcome: 'ok' | 'flag' | 'fail-open' | 'unparseable';
 }
 
 const PATTERN_CATEGORIES = `
@@ -169,7 +185,7 @@ function parseVerdict(finalText: string, usage?: RuntimeUsage): ClassifyWriteInt
   const usageField = usage ? { usage } : {};
 
   if (lower === 'ok' || lower.startsWith('ok\n') || lower.startsWith('ok.')) {
-    return { verdict: 'ok', reason: null, ...usageField };
+    return { verdict: 'ok', reason: null, outcome: 'ok', ...usageField };
   }
 
   if (lower.startsWith('flag:')) {
@@ -177,12 +193,13 @@ function parseVerdict(finalText: string, usage?: RuntimeUsage): ClassifyWriteInt
     return {
       verdict: 'flag',
       reason: reason.length > 0 ? reason : 'Classifier flagged this write with no reason given.',
+      outcome: 'flag',
       ...usageField,
     };
   }
 
   // Ambiguous / unparseable — fail open at the classification level.
-  return { verdict: 'ok', reason: null, ...usageField };
+  return { verdict: 'ok', reason: null, outcome: 'unparseable', ...usageField };
 }
 
 export async function classifyWriteIntent(
@@ -225,7 +242,7 @@ export async function classifyWriteIntent(
     // A classifier that cannot run — including one that blew its
     // wall-clock deadline above — must never be the reason a write is
     // blocked — see the design spec's fail-open-at-uncertainty rationale.
-    return { verdict: 'ok', reason: null };
+    return { verdict: 'ok', reason: null, outcome: 'fail-open' };
   } finally {
     clearTimeout(timer);
   }

--- a/packages/myco/src/config/focus.ts
+++ b/packages/myco/src/config/focus.ts
@@ -152,6 +152,12 @@ const SECTION_RULES: PrefixRule[] = [
     sectionLabel: 'Scheduled tasks',
   },
   {
+    prefix: 'agent.semantic_write_check_enabled',
+    page: '/settings',
+    sectionId: CONFIG_SECTION_IDS.settingsAgent,
+    sectionLabel: 'Myco Agent',
+  },
+  {
     prefix: 'agent.summary_batch_interval',
     page: '/agent',
     sectionId: CONFIG_SECTION_IDS.agentOperations,

--- a/packages/myco/src/config/paths.ts
+++ b/packages/myco/src/config/paths.ts
@@ -52,6 +52,7 @@ export const AGENT_PATHS = {
   eventTasksEnabled: 'agent.event_tasks_enabled',
   summaryBatchInterval: 'agent.summary_batch_interval',
   runRetentionDays: 'agent.run_retention_days',
+  semanticWriteCheckEnabled: 'agent.semantic_write_check_enabled',
 } as const;
 
 export const NOTIFICATIONS_PATHS = {

--- a/packages/myco/src/config/schema.ts
+++ b/packages/myco/src/config/schema.ts
@@ -619,6 +619,16 @@ const GroveAgentSchema = rejectLegacyRuntimeKey(z.object({
   scheduled_tasks_enabled: z.boolean().default(true),
   event_tasks_enabled: z.boolean().default(true),
   cold_project_threshold_days: z.number().int().min(0).max(365).default(14),
+  /**
+   * Grove-tier override for the semantic write-check gate. DELIBERATELY
+   * `.optional()` with NO `.default()` — `saveGroveConfig` writes
+   * `YAML.stringify(GroveConfigSchema.parse(config))`, so a `.default(false)`
+   * would materialize an explicit `false` into every grove config.yaml on
+   * any grove save, shadowing future default flips. AgentBaseSchema's
+   * `default(false)` (schema.ts:217) remains the resolver floor when this
+   * field is absent here.
+   */
+  semantic_write_check_enabled: z.boolean().optional(),
   provider: ProviderOverrideSchema.optional(),
   harness: HarnessIdSchema.optional(),
   reasoningLevel: ReasoningLevelSchema.optional(),
@@ -706,6 +716,7 @@ export const GROVE_PROMOTED_FIELDS: ReadonlyArray<readonly string[]> = [
   ['agent', 'scheduled_tasks_enabled'],
   ['agent', 'event_tasks_enabled'],
   ['agent', 'cold_project_threshold_days'],
+  ['agent', 'semantic_write_check_enabled'],
 ];
 
 /**

--- a/packages/myco/src/config/scope.ts
+++ b/packages/myco/src/config/scope.ts
@@ -61,6 +61,12 @@ export const SCOPE_REGISTRY: Record<string, ScopeEntry> = {
   'agent.scheduled_tasks_enabled': { home: 'grove', overridableBy: [] },
   'agent.event_tasks_enabled': { home: 'grove', overridableBy: [] },
   'agent.run_retention_days': { home: 'grove', overridableBy: [] },
+  // Deliberately NOT grove-locked like the toggles above: `.myco/local.yaml`
+  // is the per-machine staging path the Phase 0 gate and dogfooding rely on
+  // for this rollout. This leaf resolves identically to the `agent` block
+  // row above via longest-prefix — it's self-documentation, not a behavior
+  // change, kept for parity with the other explicit agent.* leaf rows.
+  'agent.semantic_write_check_enabled': { home: 'grove', overridableBy: ['local'] },
   'skills': { home: 'grove', overridableBy: ['local'], gate: 'skills' },
   // Vault-Evolution capability master gate. Grove-tier home, per-project
   // Personal override so a project can be promoted/demoted on this machine.

--- a/packages/myco/ui/src/hooks/use-config.ts
+++ b/packages/myco/ui/src/hooks/use-config.ts
@@ -53,6 +53,7 @@ export interface MycoConfig {
     summary_batch_interval: number;
     scheduled_tasks_enabled?: boolean;
     event_tasks_enabled?: boolean;
+    semantic_write_check_enabled?: boolean;
     harness?: 'claude-sdk' | 'openai-agents';
     provider?: {
       harness?: 'claude-sdk' | 'openai-agents';

--- a/packages/myco/ui/src/settings/manifest.ts
+++ b/packages/myco/ui/src/settings/manifest.ts
@@ -203,6 +203,15 @@ export const SETTINGS_GROUPS: readonly SettingGroup[] = [
         suffix: 'days',
         note: 'Deletes completed, skipped, and non-resumable failed agent runs older than this window.',
       },
+      {
+        key: 'agent.semantic_write_check_enabled',
+        label: 'Semantic write check',
+        scope: 'grove',
+        kind: 'toggle',
+        category: 'Agent',
+        icon: 'Bot',
+        note: 'Runs a lightweight semantic classifier against destructive vault writes before they execute, blocking any write that doesn\'t match the calling phase\'s stated purpose. Off by default; verdict quality depends on the classifier model, and the check fails open on classifier error or timeout.',
+      },
     ],
   },
   {

--- a/tests/agent/phase-loop-semantic-check.test.ts
+++ b/tests/agent/phase-loop-semantic-check.test.ts
@@ -42,7 +42,28 @@ mock.module('@myco/agent/harness/index.js', () => ({
   getAgentHarness: () => getAgentHarnessOverride ?? fakeRuntime,
 }));
 
-import { executePhasedQuery, type PhaseLoopContext } from '@myco/agent/phase-loop.js';
+// Captures the options object runMapPhaseAdapter passes to createVaultTools
+// (mirrors map-phase-hooks.test.ts's mocking pattern) so the map-phase
+// phasePurpose construction site (phase-loop.ts's runMapPhaseAdapter) can be
+// asserted without needing full map-item harness scaffolding.
+const createVaultToolsCalls: unknown[] = [];
+mock.module('@myco/agent/tools.js', () => ({
+  createVaultTools: (...args: unknown[]) => {
+    createVaultToolsCalls.push(args);
+    return [];
+  },
+}));
+
+let executeMapPhaseResult: unknown = {
+  itemCount: 0, written: 0, skipped: 0, failed: 0, abandoned: 0,
+  skipReasons: {}, writeAfterThrow: 0, providerUnavailable: false, unavailable: 0,
+  usage: { requests: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0, reasoningTokens: 0, cachedTokens: 0, durationMs: 0 },
+};
+mock.module('@myco/agent/map-phase.js', () => ({
+  executeMapPhase: async () => executeMapPhaseResult,
+}));
+
+import { executePhasedQuery, executePhase, type PhaseLoopContext } from '@myco/agent/phase-loop.js';
 
 function baseConfig(phases?: PhaseDefinition[], extra: Partial<EffectiveConfig> = {}): EffectiveConfig {
   return {
@@ -94,6 +115,12 @@ function phase(name: string, extra: Partial<PhaseDefinition> = {}): PhaseDefinit
 beforeEach(() => {
   capturedExecuteInputs = [];
   getAgentHarnessOverride = undefined;
+  createVaultToolsCalls.length = 0;
+  executeMapPhaseResult = {
+    itemCount: 0, written: 0, skipped: 0, failed: 0, abandoned: 0,
+    skipReasons: {}, writeAfterThrow: 0, providerUnavailable: false, unavailable: 0,
+    usage: { requests: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0, reasoningTokens: 0, cachedTokens: 0, durationMs: 0 },
+  };
 });
 
 describe('phase-loop semantic-check config threading', () => {
@@ -303,5 +330,131 @@ describe('phase-loop semantic-check config threading', () => {
     expect(capturedExecuteInputs).toHaveLength(1);
     expect(capturedExecuteInputs[0].sessionRef).toBeDefined();
     expect(capturedExecuteInputs[0].sessionRef).not.toBe('blocked-session');
+  });
+
+  it('uses an authored phase.purpose verbatim as toolSurface.phasePurpose.promptExcerpt, not the prompt excerpt', async () => {
+    const longPrompt = 'x'.repeat(600); // longer than the 500-char excerpt cap, to prove it is bypassed entirely
+    const authoredPurpose = 'Mark stale prompt batches as processed. Never touch batches outside this run.';
+    const ctx = baseContext({
+      config: baseConfig([phase('only-phase', { prompt: longPrompt, purpose: authoredPurpose })], {
+        semanticWriteCheckEnabled: true,
+      }),
+    });
+
+    await executePhasedQuery(ctx);
+
+    expect(capturedExecuteInputs.length).toBeGreaterThan(0);
+    const surface = capturedExecuteInputs[0].toolSurface as {
+      phasePurpose?: { name?: string; promptExcerpt?: string };
+    };
+    expect(surface.phasePurpose?.promptExcerpt).toBe(authoredPurpose);
+    expect(surface.phasePurpose?.promptExcerpt).not.toContain('x'.repeat(500));
+  });
+
+  it('falls back to the truncated prompt excerpt on toolSurface.phasePurpose when phase.purpose is absent', async () => {
+    const longPrompt = 'y'.repeat(600);
+    const ctx = baseContext({
+      config: baseConfig([phase('only-phase', { prompt: longPrompt })], {
+        semanticWriteCheckEnabled: true,
+      }),
+    });
+
+    await executePhasedQuery(ctx);
+
+    expect(capturedExecuteInputs.length).toBeGreaterThan(0);
+    const surface = capturedExecuteInputs[0].toolSurface as {
+      phasePurpose?: { name?: string; promptExcerpt?: string };
+    };
+    expect(surface.phasePurpose?.promptExcerpt).toBe(`${'y'.repeat(500)}…`);
+  });
+});
+
+describe('phase-loop semantic-check phasePurpose threading — map-phase path', () => {
+  it('uses an authored phase.purpose verbatim as the phasePurpose passed to createVaultTools for a map phase', async () => {
+    // Mirrors map-phase-hooks.test.ts's Fix 5 regression test: the map path
+    // builds phasePurpose independently of the regular (wave-input) path,
+    // inside runMapPhaseAdapter's own createVaultTools call.
+    const authoredPurpose = 'Describe each source file in one sentence. Never write outside canopy_entries.';
+    const longPrompt = 'z'.repeat(600);
+
+    const ctx: PhaseLoopContext = {
+      config: {
+        harness: 'claude-sdk' as HarnessId,
+        taskName: 'test-task',
+        semanticWriteCheckEnabled: true,
+      } as EffectiveConfig,
+      systemPrompt: 'system',
+      vaultContext: 'vault context',
+      agentId: 'agent-1',
+      runId: 'run-1',
+      checkpointState: { schemaVersion: 2, harness: 'claude-sdk' as HarnessId, phases: {} },
+    } as PhaseLoopContext;
+
+    const mapPhase: PhaseDefinition = {
+      name: 'map-describe',
+      prompt: longPrompt,
+      purpose: authoredPurpose,
+      tools: [],
+      maxTurns: 5,
+      required: true,
+      mode: 'map',
+      source: { tool: 'source_tool', args: {}, itemsPath: 'items' },
+      item: { prompt: 'do {{item.path}}' },
+      sink: { tool: 'sink_tool', argMap: {} },
+    } as PhaseDefinition;
+
+    await executePhase({
+      ctx, phasePrompt: '', phaseModel: 'claude-sonnet-4-6', phase: mapPhase,
+      toolSurface: { agentId: 'agent-1', runId: 'run-1' },
+    });
+
+    expect(createVaultToolsCalls).toHaveLength(1);
+    const [, , options] = createVaultToolsCalls[0] as [string, string, {
+      phasePurpose?: { name?: string; promptExcerpt?: string };
+    }];
+    expect(options.phasePurpose?.name).toBe('map-describe');
+    expect(options.phasePurpose?.promptExcerpt).toBe(authoredPurpose);
+    expect(options.phasePurpose?.promptExcerpt).not.toContain('z'.repeat(500));
+  });
+
+  it('falls back to the truncated prompt excerpt for a map phase when phase.purpose is absent', async () => {
+    const longPrompt = 'w'.repeat(600);
+
+    const ctx: PhaseLoopContext = {
+      config: {
+        harness: 'claude-sdk' as HarnessId,
+        taskName: 'test-task',
+        semanticWriteCheckEnabled: true,
+      } as EffectiveConfig,
+      systemPrompt: 'system',
+      vaultContext: 'vault context',
+      agentId: 'agent-1',
+      runId: 'run-1',
+      checkpointState: { schemaVersion: 2, harness: 'claude-sdk' as HarnessId, phases: {} },
+    } as PhaseLoopContext;
+
+    const mapPhase: PhaseDefinition = {
+      name: 'map-describe',
+      prompt: longPrompt,
+      tools: [],
+      maxTurns: 5,
+      required: true,
+      mode: 'map',
+      source: { tool: 'source_tool', args: {}, itemsPath: 'items' },
+      item: { prompt: 'do {{item.path}}' },
+      sink: { tool: 'sink_tool', argMap: {} },
+    } as PhaseDefinition;
+
+    await executePhase({
+      ctx, phasePrompt: '', phaseModel: 'claude-sonnet-4-6', phase: mapPhase,
+      toolSurface: { agentId: 'agent-1', runId: 'run-1' },
+    });
+
+    expect(createVaultToolsCalls).toHaveLength(1);
+    const [, , options] = createVaultToolsCalls[0] as [string, string, {
+      phasePurpose?: { name?: string; promptExcerpt?: string };
+    }];
+    expect(options.phasePurpose?.name).toBe('map-describe');
+    expect(options.phasePurpose?.promptExcerpt).toBe(`${'w'.repeat(500)}…`);
   });
 });

--- a/tests/agent/tools-semantic-check.test.ts
+++ b/tests/agent/tools-semantic-check.test.ts
@@ -736,4 +736,191 @@ describe('semantic write check', () => {
     expect(errorEvent).toBeDefined();
     expect(errorEvent!.errorMessage).toMatch(/blocked by a semantic safety check/i);
   });
+
+  describe('agent.write.classified observability line', () => {
+    // Verifies the ok-verdict observability line: one structured log line
+    // per RENDERED verdict (ok and flag), none on a cache-hit retry.
+
+    type LoggedCall = { kind: string; message: string; data?: Record<string, unknown> };
+
+    function createMockLogger() {
+      const calls: LoggedCall[] = [];
+      return {
+        calls,
+        logger: {
+          debug: (kind: string, message: string, data?: Record<string, unknown>) => { calls.push({ kind, message, data }); },
+          info: (kind: string, message: string, data?: Record<string, unknown>) => { calls.push({ kind, message, data }); },
+          warn: (kind: string, message: string, data?: Record<string, unknown>) => { calls.push({ kind, message, data }); },
+          error: (kind: string, message: string, data?: Record<string, unknown>) => { calls.push({ kind, message, data }); },
+        },
+      };
+    }
+
+    it('emits exactly one agent.write.classified line with outcome "ok" on a genuine ok verdict', async () => {
+      mockClassify.mockImplementation(async () => ({
+        verdict: 'ok' as const,
+        reason: null,
+        outcome: 'ok' as const,
+        usage: { requests: 1, inputTokens: 100, outputTokens: 3, totalTokens: 103 },
+      }));
+
+      const batch = seedBatch();
+      const { calls, logger } = createMockLogger();
+      const tools = createVaultTools(TEST_AGENT_ID, TEST_RUN_ID, {
+        requestContext: TEST_REQUEST_CONTEXT,
+        projectRoot: tmpDir,
+        vaultDir,
+        semanticCheckEnabled: true,
+        harnessId: 'claude-sdk',
+        model: 'claude-haiku-4-5-20251001',
+        classifierReasoningLevel: 'low',
+        phasePurpose: { name: 'cleanup', promptExcerpt: 'Mark stale prompt batches as processed.' },
+        logger,
+      });
+
+      const markProcessed = findTool(tools, 'vault_mark_processed');
+      await markProcessed.handler({ batch_id: batch.id }, undefined);
+
+      const classifiedCalls = calls.filter((c) => c.kind === 'agent.write.classified');
+      expect(classifiedCalls).toHaveLength(1);
+      expect(classifiedCalls[0].data).toMatchObject({
+        runId: TEST_RUN_ID,
+        phase: 'cleanup',
+        toolName: 'vault_mark_processed',
+        verdict: 'ok',
+        outcome: 'ok',
+        classifierTokens: 103,
+      });
+      expect(typeof classifiedCalls[0].data?.latencyMs).toBe('number');
+      expect(classifiedCalls[0].data?.latencyMs as number).toBeGreaterThanOrEqual(0);
+    });
+
+    it('emits exactly one agent.write.classified line with outcome "flag" on a flag verdict', async () => {
+      mockClassify.mockImplementation(async () => ({
+        verdict: 'flag' as const,
+        reason: 'batch_id does not appear in this phase\'s declared scope',
+        outcome: 'flag' as const,
+        usage: { requests: 1, inputTokens: 120, outputTokens: 15, totalTokens: 135 },
+      }));
+
+      const batch = seedBatch();
+      const { calls, logger } = createMockLogger();
+      const tools = createVaultTools(TEST_AGENT_ID, TEST_RUN_ID, {
+        requestContext: TEST_REQUEST_CONTEXT,
+        projectRoot: tmpDir,
+        vaultDir,
+        semanticCheckEnabled: true,
+        harnessId: 'claude-sdk',
+        model: 'claude-haiku-4-5-20251001',
+        classifierReasoningLevel: 'low',
+        phasePurpose: { name: 'cleanup', promptExcerpt: 'Mark stale prompt batches as processed.' },
+        logger,
+      });
+
+      const markProcessed = findTool(tools, 'vault_mark_processed');
+      await expect(markProcessed.handler({ batch_id: batch.id }, undefined)).rejects.toThrow(/blocked by a semantic safety check/i);
+
+      const classifiedCalls = calls.filter((c) => c.kind === 'agent.write.classified');
+      expect(classifiedCalls).toHaveLength(1);
+      expect(classifiedCalls[0].data).toMatchObject({
+        runId: TEST_RUN_ID,
+        phase: 'cleanup',
+        toolName: 'vault_mark_processed',
+        verdict: 'flag',
+        outcome: 'flag',
+        classifierTokens: 135,
+      });
+    });
+
+    it('emits outcome "fail-open" when the classifier throws or times out', async () => {
+      // The wrapper itself never sees the throw — classifyWriteIntent
+      // fails open internally and returns a resolved 'ok' verdict with
+      // outcome 'fail-open'. This test mocks that already-degraded
+      // return shape (the throw/timeout path is write-classifier.ts's
+      // own concern, covered in write-classifier.test.ts).
+      mockClassify.mockImplementation(async () => ({
+        verdict: 'ok' as const,
+        reason: null,
+        outcome: 'fail-open' as const,
+      }));
+
+      const batch = seedBatch();
+      const { calls, logger } = createMockLogger();
+      const tools = createVaultTools(TEST_AGENT_ID, TEST_RUN_ID, {
+        requestContext: TEST_REQUEST_CONTEXT,
+        projectRoot: tmpDir,
+        vaultDir,
+        semanticCheckEnabled: true,
+        harnessId: 'claude-sdk',
+        model: 'claude-haiku-4-5-20251001',
+        classifierReasoningLevel: 'low',
+        phasePurpose: { name: 'cleanup', promptExcerpt: 'Mark stale prompt batches as processed.' },
+        logger,
+      });
+
+      const markProcessed = findTool(tools, 'vault_mark_processed');
+      await markProcessed.handler({ batch_id: batch.id }, undefined);
+
+      const classifiedCalls = calls.filter((c) => c.kind === 'agent.write.classified');
+      expect(classifiedCalls).toHaveLength(1);
+      expect(classifiedCalls[0].data).toMatchObject({
+        toolName: 'vault_mark_processed',
+        verdict: 'ok',
+        outcome: 'fail-open',
+      });
+      // No usage on the fail-open path — classifierTokens must be undefined.
+      expect(classifiedCalls[0].data?.classifierTokens).toBeUndefined();
+    });
+
+    it('does not log a second line on a cache-hit retry of an identical call', async () => {
+      mockClassify.mockImplementation(async () => ({
+        verdict: 'ok' as const,
+        reason: null,
+        outcome: 'ok' as const,
+        usage: { requests: 1, totalTokens: 100 },
+      }));
+
+      const batch = seedBatch();
+      const { calls, logger } = createMockLogger();
+      const tools = createVaultTools(TEST_AGENT_ID, TEST_RUN_ID, {
+        requestContext: TEST_REQUEST_CONTEXT,
+        projectRoot: tmpDir,
+        vaultDir,
+        semanticCheckEnabled: true,
+        harnessId: 'claude-sdk',
+        model: 'claude-haiku-4-5-20251001',
+        classifierReasoningLevel: 'low',
+        phasePurpose: { name: 'cleanup', promptExcerpt: 'Mark stale prompt batches as processed.' },
+        logger,
+      });
+
+      const markProcessed = findTool(tools, 'vault_mark_processed');
+      await markProcessed.handler({ batch_id: batch.id }, undefined);
+      await markProcessed.handler({ batch_id: batch.id }, undefined);
+
+      expect(mockClassify).toHaveBeenCalledTimes(1);
+      const classifiedCalls = calls.filter((c) => c.kind === 'agent.write.classified');
+      expect(classifiedCalls).toHaveLength(1);
+    });
+
+    it('does not throw when no logger is supplied', async () => {
+      mockClassify.mockImplementation(async () => ({ verdict: 'ok' as const, reason: null, outcome: 'ok' as const }));
+
+      const batch = seedBatch();
+      const tools = createVaultTools(TEST_AGENT_ID, TEST_RUN_ID, {
+        requestContext: TEST_REQUEST_CONTEXT,
+        projectRoot: tmpDir,
+        vaultDir,
+        semanticCheckEnabled: true,
+        harnessId: 'claude-sdk',
+        model: 'claude-haiku-4-5-20251001',
+        classifierReasoningLevel: 'low',
+        phasePurpose: { name: 'cleanup', promptExcerpt: 'Mark stale prompt batches as processed.' },
+        // logger intentionally omitted
+      });
+
+      const markProcessed = findTool(tools, 'vault_mark_processed');
+      await expect(markProcessed.handler({ batch_id: batch.id }, undefined)).resolves.toBeDefined();
+    });
+  });
 });

--- a/tests/agent/write-classifier.test.ts
+++ b/tests/agent/write-classifier.test.ts
@@ -51,6 +51,9 @@ describe('classifyWriteIntent', () => {
 
     expect(result.verdict).toBe('ok');
     expect(result.reason).toBeNull();
+    // Genuine ok: the classifier actually rendered this verdict, not a
+    // fail-open or unparseable degrade.
+    expect(result.outcome).toBe('ok');
     expect(mockExecute).toHaveBeenCalledTimes(1);
     const callArgs = mockExecute.mock.calls[0][0] as { toolSurface: { toolNames?: string[] }; maxTurns?: number };
     // The classifier must never be given any tools to call.
@@ -107,6 +110,7 @@ describe('classifyWriteIntent', () => {
 
     expect(result.verdict).toBe('flag');
     expect(result.reason).toBe('batch_id 42 does not appear anywhere in this phase\'s stated purpose');
+    expect(result.outcome).toBe('flag');
   });
 
   it('defaults to ok on any unparseable or ambiguous response (fail-open at the classification-uncertainty level)', async () => {
@@ -128,6 +132,10 @@ describe('classifyWriteIntent', () => {
     });
 
     expect(result.verdict).toBe('ok');
+    // Distinguishes an unparseable classifier response from a genuine ok
+    // — both currently degrade to verdict 'ok', but observability needs
+    // to tell them apart.
+    expect(result.outcome).toBe('unparseable');
   });
 
   it('defaults to ok when the harness call itself throws (classifier failure must never block a write on its own)', async () => {
@@ -146,6 +154,7 @@ describe('classifyWriteIntent', () => {
 
     expect(result.verdict).toBe('ok');
     expect(result.reason).toBeNull();
+    expect(result.outcome).toBe('fail-open');
   });
 
   it('defaults to ok when the harness call rejects with a non-Error value (thrown string/object)', async () => {
@@ -164,6 +173,7 @@ describe('classifyWriteIntent', () => {
 
     expect(result.verdict).toBe('ok');
     expect(result.reason).toBeNull();
+    expect(result.outcome).toBe('fail-open');
   });
 
   it('degrades to ok when the harness call never resolves within the deadline (wall-clock timeout, not just maxTurns)', async () => {
@@ -187,6 +197,7 @@ describe('classifyWriteIntent', () => {
 
     expect(result.verdict).toBe('ok');
     expect(result.reason).toBeNull();
+    expect(result.outcome).toBe('fail-open');
     // Should resolve close to the injected deadline, not hang indefinitely.
     expect(elapsedMs).toBeLessThan(2_000);
 

--- a/tests/config/grove-schema.test.ts
+++ b/tests/config/grove-schema.test.ts
@@ -4,6 +4,7 @@ import {
   ProjectConfigSchema,
   MachineConfigSchema,
   PROJECT_TIER_LEGACY_FIELDS,
+  GROVE_PROMOTED_FIELDS,
 } from '@myco/config/schema';
 
 describe('GroveAgentSchema', () => {
@@ -54,6 +55,24 @@ describe('GroveAgentSchema', () => {
       },
     });
     expect(result.success).toBe(false);
+  });
+
+  test('accepts an explicit semantic_write_check_enabled override', () => {
+    const parsed = GroveConfigSchema.parse({
+      agent: { semantic_write_check_enabled: true },
+    });
+    expect(parsed.agent.semantic_write_check_enabled).toBe(true);
+  });
+
+  test('semantic_write_check_enabled is undefined (no default) when absent — deliberate deviation from the other agent booleans', () => {
+    // Unlike scheduled_tasks_enabled/event_tasks_enabled, this field must NOT
+    // materialize a default on parse: saveGroveConfig round-trips through
+    // GroveConfigSchema.parse before writing YAML, so a `.default(false)`
+    // would stamp an explicit `false` into every grove config.yaml on save,
+    // shadowing any future flip of the AgentBaseSchema floor default.
+    const parsed = GroveConfigSchema.parse({});
+    expect(parsed.agent.semantic_write_check_enabled).toBeUndefined();
+    expect('semantic_write_check_enabled' in parsed.agent).toBe(false);
   });
 });
 
@@ -180,22 +199,35 @@ describe('ProjectConfigSchema', () => {
 });
 
 describe('PROJECT_TIER_LEGACY_FIELDS', () => {
-  test('includes the 11 Grove-promoted paths — loader strips them when Grove-bound', () => {
+  test('includes every Grove-promoted path — loader strips them when Grove-bound', () => {
     // These paths are Grove-tier. The loader strips them from project myco.yaml
     // when the project is Grove-bound (gated by hasGrove), so stale project-tier
     // values never shadow Grove config.
+    //
+    // Asserted against GROVE_PROMOTED_FIELDS itself (rather than a hardcoded
+    // list/count) so a new promoted field can't silently go unasserted here —
+    // adding one to schema.ts without adding the matching toContain below
+    // fails this test immediately instead of drifting unnoticed.
     const stringified = PROJECT_TIER_LEGACY_FIELDS.map((p) => p.join('.'));
-    expect(stringified).toContain('embedding.provider');
-    expect(stringified).toContain('embedding.model');
-    expect(stringified).toContain('embedding.base_url');
-    expect(stringified).toContain('agent.provider');
-    expect(stringified).toContain('agent.harness');
-    expect(stringified).toContain('agent.model');
-    expect(stringified).toContain('agent.tasks');
-    expect(stringified).toContain('agent.summary_batch_interval');
-    expect(stringified).toContain('agent.scheduled_tasks_enabled');
-    expect(stringified).toContain('agent.event_tasks_enabled');
-    expect(stringified).toContain('agent.cold_project_threshold_days');
+    const promoted = GROVE_PROMOTED_FIELDS.map((p) => p.join('.'));
+    expect(promoted).toEqual([
+      'embedding.provider',
+      'embedding.model',
+      'embedding.base_url',
+      'agent.provider',
+      'agent.harness',
+      'agent.reasoningLevel',
+      'agent.model',
+      'agent.tasks',
+      'agent.summary_batch_interval',
+      'agent.scheduled_tasks_enabled',
+      'agent.event_tasks_enabled',
+      'agent.cold_project_threshold_days',
+      'agent.semantic_write_check_enabled',
+    ]);
+    for (const path of promoted) {
+      expect(stringified).toContain(path);
+    }
   });
 
   test('still includes the pre-existing legacy entries', () => {

--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -384,6 +384,25 @@ describe('Grove-tier promotion — merge verification', () => {
     expect(rawOnDisk.agent).toBeUndefined();
   });
 
+  it('legacy project semantic_write_check_enabled is lifted to Grove config and stripped from myco.yaml', () => {
+    // Task 5.3 residue-lift: GROVE_PROMOTED_FIELDS now includes
+    // agent.semantic_write_check_enabled, so migrateLegacyProjectFields (run
+    // by loadMergedConfig with migrateTiers: true on every cache-miss load)
+    // lifts an explicit project-tier value into grove config.yaml the first
+    // time this project loads post-upgrade, exactly like the other promoted
+    // agent.* fields above.
+    const mycoYamlPath = path.join(tmpDir, 'myco.yaml');
+    writeProject(tmpDir, 'version: 3\nagent:\n  semantic_write_check_enabled: true\n');
+
+    const config = loadMergedConfig(tmpDir, { groveId, mycoHome: mycoHomeDir });
+
+    expect(config.agent.semantic_write_check_enabled).toBe(true);
+    const groveRaw = YAML.parse(fs.readFileSync(path.join(mycoHomeDir, 'groves', groveId, 'grove.yaml'), 'utf-8')) as Record<string, unknown>;
+    expect((groveRaw.agent as Record<string, unknown>).semantic_write_check_enabled).toBe(true);
+    const projectRaw = YAML.parse(fs.readFileSync(mycoYamlPath, 'utf-8')) as Record<string, unknown>;
+    expect(projectRaw.agent).toBeUndefined();
+  });
+
   it('a grove-scoped field placed in the project tier is not honored in merged config (pruned)', () => {
     // Every myco-enabled project is Grove-bound; agent/skills are grove-scoped
     // and stripped from project myco.yaml. The old "no-Grove deferral" (keep a

--- a/tests/config/scope-merge.test.ts
+++ b/tests/config/scope-merge.test.ts
@@ -35,4 +35,30 @@ describe('scope-aware merge', () => {
     expect(cfg.capture.plan_dirs).toEqual(['machine-dir/']); // grove stray pruned
     expect(cfg.agent.reasoningLevel).toBe('high');           // legit grove value kept
   });
+
+  it('grove.yaml no longer prunes agent.semantic_write_check_enabled (regression: dogfood gotcha)', () => {
+    // Prior to Task 5, this field lived only in AgentBaseSchema with no
+    // SCOPE_REGISTRY entry, so the scope-aware merge silently dropped any
+    // value set in grove.yaml before it ever reached the resolved config.
+    fs.writeFileSync(
+      path.join(home.path, 'groves', GROVE, 'grove.yaml'),
+      'agent:\n  semantic_write_check_enabled: true\n',
+      'utf-8',
+    );
+    invalidateMergedConfigCache();
+    const cfg = loadMergedConfig(vault, { groveId: GROVE });
+    expect(cfg.agent.semantic_write_check_enabled).toBe(true);
+  });
+
+  it('local.yaml overrides the grove value for agent.semantic_write_check_enabled (staging path)', () => {
+    fs.writeFileSync(
+      path.join(home.path, 'groves', GROVE, 'grove.yaml'),
+      'agent:\n  semantic_write_check_enabled: false\n',
+      'utf-8',
+    );
+    fs.writeFileSync(path.join(vault, 'local.yaml'), 'agent:\n  semantic_write_check_enabled: true\n', 'utf-8');
+    invalidateMergedConfigCache();
+    const cfg = loadMergedConfig(vault, { groveId: GROVE });
+    expect(cfg.agent.semantic_write_check_enabled).toBe(true);
+  });
 });

--- a/tests/config/scope.test.ts
+++ b/tests/config/scope.test.ts
@@ -28,4 +28,30 @@ describe('scope registry', () => {
     const projectRaw = { capture: { plan_dirs: ['x'] }, cortex: { digest_tier: 3 } };
     expect(pruneToTier(projectRaw, 'project')).toEqual({ cortex: { digest_tier: 3 } });
   });
+  it('agent.semantic_write_check_enabled is grove home + local override — NOT scheduled_tasks_enabled\'s grove-lock', () => {
+    // Deliberate deviation (Task 5): .myco/local.yaml is the per-machine
+    // staging path the Phase 0 gate and dogfooding rely on, so this leaf is
+    // NOT locked the way agent.scheduled_tasks_enabled/event_tasks_enabled are.
+    expect(scopePolicyForPath('agent.semantic_write_check_enabled'))
+      .toEqual({ home: 'grove', overridableBy: ['local'] });
+    expect(tierAllowsPath('grove', 'agent.semantic_write_check_enabled')).toBe(true);
+    expect(tierAllowsPath('local', 'agent.semantic_write_check_enabled')).toBe(true);
+    expect(tierAllowsPath('machine', 'agent.semantic_write_check_enabled')).toBe(false);
+    expect(tierAllowsPath('project', 'agent.semantic_write_check_enabled')).toBe(false);
+  });
+  it('pruneToTier retains agent.semantic_write_check_enabled at the grove tier (regression: dogfood gotcha)', () => {
+    // Before Task 5, grove.yaml silently pruned this field on every merge
+    // because SCOPE_REGISTRY had no leaf/block entry recognizing it as
+    // grove-owned (it lived only in AgentBaseSchema). Guard the fix.
+    const groveRaw = { agent: { semantic_write_check_enabled: true } };
+    expect(pruneToTier(groveRaw, 'grove')).toEqual({ agent: { semantic_write_check_enabled: true } });
+  });
+  it('pruneToTier retains agent.semantic_write_check_enabled at the local tier (staging override)', () => {
+    const localRaw = { agent: { semantic_write_check_enabled: false } };
+    expect(pruneToTier(localRaw, 'local')).toEqual({ agent: { semantic_write_check_enabled: false } });
+  });
+  it('pruneToTier still drops agent.semantic_write_check_enabled at the machine tier (unknown-field behavior unchanged)', () => {
+    const machineRaw = { agent: { semantic_write_check_enabled: true }, capture: { plan_dirs: ['x'] } };
+    expect(pruneToTier(machineRaw, 'machine')).toEqual({ capture: { plan_dirs: ['x'] } });
+  });
 });

--- a/tests/ui/settings-manifest-sync.test.ts
+++ b/tests/ui/settings-manifest-sync.test.ts
@@ -24,12 +24,6 @@ const ALLOWLIST: readonly string[] = [
   'agent.tasks',
   'agent.summary_batch_interval',
   'agent.cold_project_threshold_days',
-  // semantic_write_check_enabled lives in AgentBaseSchema only (merged
-  // config; yaml-settable under agent:). Promoting it to a per-Grove
-  // setting needs a GroveAgentSchema field + SCOPE_REGISTRY leaf row +
-  // manifest entry, mirroring scheduled_tasks_enabled — until then this
-  // allowlist entry is a forward guard, not a UI-surfacing decision.
-  'agent.semantic_write_check_enabled',
   'agent.provider.local_backend',
   'agent.provider.reasoning_map',
   // Per-tier reasoning-budget maps (PR #609) are yaml-only advanced config,


### PR DESCRIPTION
## What

Adoption Phases 0+1 of the SDK-alignment follow-up (master plan `4b7d54ba716418ce`, impl plan `b31adfd84bb32778`): the semantic-check enablement arc.

- **`purpose` field on PhaseDefinition** — optional 1–2000 char authored write contract per phase (schema + hand-maintained interface, dual-declaration).
- **Verbatim threading** — both `phasePurpose` construction sites in phase-loop.ts (wave-input builder and map-phase path) now use `phase.purpose ?? <500-char excerpt fallback>`. The classifier's untrusted-data delimiter handling is untouched; purpose rides the existing `promptExcerpt` channel.
- **Nine authored purpose contracts** across vault-evolve, skill-evolve, skill-generate, skill-survey, and cortex-prompt-builder — every destructiveHint-bearing phase (annotation inventory re-verified at implementation time). This closes the 2026-07-02 dogfood incident where the classifier false-flagged skill-evolve assess's legitimate `vault_skill_records action:update` because the write intent sat past the excerpt window (spore `discovery-b0c778c1`).
- **Classifier observability** — `outcome: 'ok' | 'flag' | 'fail-open' | 'unparseable'` marker on `ClassifyWriteIntentResult` (type-enforced on every return path) and an `agent.write.classified` log line on every rendered verdict with runId/phase/toolName/verdict/outcome/latencyMs/classifierTokens. Cache-hit and cap short-circuits emit nothing. Telemetry only — flag/cap/cache/intent-row semantics unchanged. Run logger threaded (optional, absence-safe) through VaultToolOptions → HarnessToolSurface → both claude.ts mapping blocks → openai-local-mcp.ts → both phase-loop toolSurface sites.
- **Config promotion** — `agent.semantic_write_check_enabled` promoted to the walked grove tier: the full `scheduled_tasks_enabled` mirror (GroveAgentSchema, SCOPE_REGISTRY leaf, GROVE_PROMOTED_FIELDS, focus/paths rows, UI settings manifest, use-config type, drift-guard allowlist entry removed) with two deliberate, commented deviations: the schema field is optional with **no** `.default()` (a default would be materialized into every grove config.yaml by `saveGroveConfig`, shadowing future default flips), and the scope leaf is `{ home: 'grove', overridableBy: ['local'] }` (`.myco/local.yaml` is the per-machine staging path for the enablement bake — deliberately not the grove-lock).

## Deploy note (residue lift)

Adding the field to `GROVE_PROMOTED_FIELDS` makes `migrateLegacyProjectFields` lift any explicit `agent.semantic_write_check_enabled` from a project `myco.yaml` into grove config on the next cache-miss load — i.e. stray project-file residue becomes grove-wide enablement. A hermetic loader test pins this mechanism. Before deploying: sweep project `myco.yaml` files on dogfood machines (`grep -rn semantic_write_check_enabled`, dev AND prod MYCO_HOMEs). Swept clean on this machine (both `~/.myco` and `~/.myco-dev`) at implementation time; re-run at deploy.

## Out of scope (deliberate)

- Collective distribution of the flag (`COLLECTIVE_SETTING_DEFINITIONS`) — add only after classifier bake data exists.
- Semantic-check coverage for non-phased single-query tasks (extract-only, review-session, supersession-sweep carry destructive tools but set no `phasePurpose` → applicability fail-open) — master-list follow-up.
- Enablement itself: the flag stays default-false. The staged rollout (local.yaml → per-project → grove) with a ≥3-day bake is plan Task 6, post-merge ops.

## Verification

- Plan independently code-grounded-reviewed twice (authoring + pickup); pickup review's Critical (the residue lift above) folded before execution.
- Five per-task reviews (spec + quality) + final whole-branch review: Ready to merge, 0 Critical / 0 Important code findings; all three cross-task seams traced end-to-end (purpose→classifier verbatim delivery; log/classify coincidence; yaml→`wrapToolWithSemanticCheck` config trace).
- `make build` green in the worktree; full `npm test` green after every task commit (8226→8235+ tests, 0 fail).
- New tests: schema round-trip/bounds; wave + map threading (purpose verbatim, excerpt fallback); classified-line emission per outcome incl. cache-hit negative; classifier outcome marker on all four return paths; grove retention / local override / prune regression; hermetic residue-lift round trip; promoted-paths drift guard now derived from `GROVE_PROMOTED_FIELDS` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
