### PR TITLE
feat(agent): task-level deferredTools plumbing + Claude cache-token accounting

### DIFF
--- a/packages/myco/src/agent/config-resolver.ts
+++ b/packages/myco/src/agent/config-resolver.ts
@@ -202,6 +202,7 @@ function taskOverridesFromSources(
     ...(yamlTask?.execution ? { execution: yamlTask.execution } : {}),
     ...(yamlTask?.contextQueries ? { contextQueries: yamlTask.contextQueries } : {}),
     ...(yamlTask?.orchestrator ? { orchestrator: yamlTask.orchestrator } : {}),
+    ...(yamlTask?.deferredTools ? { deferredTools: yamlTask.deferredTools } : {}),
   };
 }
 

--- a/packages/myco/src/agent/harness/claude.ts
+++ b/packages/myco/src/agent/harness/claude.ts
@@ -97,6 +97,7 @@ async function consumeClaudeMessageStream(
   let turnsUsed = 0;
   let inputTokens = 0;
   let outputTokens = 0;
+  let cachedTokens = 0;
   let costUsd = 0;
   let assistantMessages = 0;
   let structuredOutput: unknown;
@@ -105,10 +106,11 @@ async function consumeClaudeMessageStream(
     requests: turnsUsed,
     inputTokens,
     outputTokens,
+    cachedTokens,
     totalTokens: inputTokens + outputTokens,
     costUsd,
     requestUsageEntries: turnsUsed > 0
-      ? [{ inputTokens, outputTokens, totalTokens: inputTokens + outputTokens }]
+      ? [{ inputTokens, outputTokens, cachedTokens, totalTokens: inputTokens + outputTokens }]
       : [],
   });
 
@@ -125,8 +127,30 @@ async function consumeClaudeMessageStream(
         // Capture usage on any subtype — error variants still burn tokens.
         // finalText only exists on a successful result.
         turnsUsed = message.num_turns ?? assistantMessages;
-        inputTokens = message.usage?.input_tokens ?? 0;
-        outputTokens = message.usage?.output_tokens ?? 0;
+        // The Anthropic SDK's `input_tokens` counts only tokens billed at
+        // the full uncached rate — cache writes and cache reads are
+        // reported separately and excluded from it. Fold both into
+        // `inputTokens` so it represents the true total prompt size (what
+        // cost/breakdown.ts's `uncachedInputTokens = inputTokens -
+        // cachedTokens` subtraction expects), and surface `cachedTokens` as
+        // just the cache-read count — the portion that did NOT pay the
+        // uncached rate. Cache-creation tokens stay folded into
+        // `inputTokens` only, since they bill at their own (higher, but
+        // still not "uncached") rate rather than the cached-read rate.
+        // Read defensively: the declared SDK type is non-null, but a
+        // future SDK revision or an error-subtype result could omit these
+        // fields.
+        const rawUsage = message.usage as {
+          input_tokens?: number;
+          output_tokens?: number;
+          cache_creation_input_tokens?: number;
+          cache_read_input_tokens?: number;
+        } | undefined;
+        const cacheCreationTokens = rawUsage?.cache_creation_input_tokens ?? 0;
+        const cacheReadTokens = rawUsage?.cache_read_input_tokens ?? 0;
+        inputTokens = (rawUsage?.input_tokens ?? 0) + cacheCreationTokens + cacheReadTokens;
+        outputTokens = rawUsage?.output_tokens ?? 0;
+        cachedTokens = cacheReadTokens;
         costUsd = options.localProvider ? 0 : (message.total_cost_usd ?? 0);
         if (message.subtype === 'success') {
           finalText = message.result;
@@ -221,6 +245,7 @@ function buildToolServer(input: { toolSurface: HarnessExecuteInput['toolSurface'
     flaggedWritesAccumulator: toolSurface.flaggedWritesAccumulator,
     hooks: toolSurface.hooks,
     hookContext: toolSurface.hookContext,
+    deferredNames: toolSurface.deferredNames ? new Set(toolSurface.deferredNames) : undefined,
     logger: toolSurface.logger,
   });
 }

--- a/packages/myco/src/agent/loader.ts
+++ b/packages/myco/src/agent/loader.ts
@@ -163,6 +163,7 @@ export function taskFromParsed(parsed: AgentTask): AgentTask {
     ...(parsed.schemaVersion ? { schemaVersion: parsed.schemaVersion } : {}),
     ...(parsed.schedule ? { schedule: parsed.schedule } : {}),
     ...(parsed.params ? { params: parsed.params } : {}),
+    ...(parsed.deferredTools ? { deferredTools: parsed.deferredTools } : {}),
   };
 }
 
@@ -273,6 +274,7 @@ export function resolveEffectiveConfig(
     ...(taskOverrides?.orchestrator ? { orchestrator: taskOverrides.orchestrator } : {}),
     ...(taskOverrides?.contextQueries ? { contextQueries: taskOverrides.contextQueries } : {}),
     ...(taskOverrides?.execution ? { execution: taskOverrides.execution } : {}),
+    ...(taskOverrides?.deferredTools ? { deferredTools: taskOverrides.deferredTools } : {}),
   };
 }
 

--- a/packages/myco/src/agent/phase-loop.ts
+++ b/packages/myco/src/agent/phase-loop.ts
@@ -892,6 +892,7 @@ export async function executeSingleQuery(
     dryRun: ctx.config.dryRun ?? false,
     hooks: ctx.hooks,
     hookContext: ctx.hooks ? { runId: ctx.runId, agentId: ctx.agentId, harnessId: ctx.config.harness } : undefined,
+    deferredNames: ctx.config.deferredTools,
   };
   const baseInput = {
     prompt: taskPrompt,

--- a/packages/myco/src/agent/schemas.ts
+++ b/packages/myco/src/agent/schemas.ts
@@ -8,6 +8,7 @@
 import { z } from 'zod/v4';
 import { SCHEDULABLE_POWER_STATES } from '@myco/constants.js';
 import { ThinkingBudgetValueSchema, EffortValueSchema } from './reasoning-tier-schemas.js';
+import { ALL_VAULT_TOOL_NAMES } from './tool-names.js';
 
 // ---------------------------------------------------------------------------
 // Schema version
@@ -284,4 +285,27 @@ export const AgentTaskSchema = z.object({
   schedule: TaskScheduleSchema.optional(),
   /** Task-specific params with defaults. */
   params: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
-});
+  /**
+   * Tool names to defer on a single-query (non-phased) task — the
+   * executeSingleQuery analog of PhaseDefinition.deferredTools. Validated
+   * against the full vault tool registry (ALL_VAULT_TOOL_NAMES), NOT
+   * against `toolOverrides` — toolOverrides is a phantom surface nothing
+   * reads at runtime for a single-query task's actual tool list resolution
+   * (see resolveEffectiveConfig in loader.ts), so a name outside it but
+   * inside the real registry must still be accepted. Only a typo'd/unknown
+   * name is a load-time error.
+   */
+  deferredTools: z.array(z.string()).optional(),
+}).refine(
+  (t) => !t.deferredTools || t.deferredTools.every((name) => ALL_VAULT_TOOL_NAMES.has(name)),
+  { message: 'deferredTools must only contain names from the vault tool registry' },
+).refine(
+  // A phased task's per-phase deferral (PhaseDefinition.deferredTools) is
+  // the only mechanism executePhase reads — executeSingleQuery is never
+  // invoked once `phases` is present (see phase-loop.ts), so a task-level
+  // deferredTools alongside phases would silently no-op instead of
+  // deferring anything. Reject at load time instead of shipping a field
+  // that quietly does nothing.
+  (t) => !t.deferredTools || !t.phases || t.phases.length === 0,
+  { message: 'deferredTools is not supported on tasks with phases (phased tasks use PhaseDefinition.deferredTools per phase)' },
+);

--- a/packages/myco/src/agent/tool-names.ts
+++ b/packages/myco/src/agent/tool-names.ts
@@ -1,0 +1,74 @@
+/**
+ * Single source of truth for the vault tool-group name sets.
+ *
+ * This module has zero runtime dependencies on purpose — schemas.ts needs
+ * `ALL_VAULT_TOOL_NAMES` for a Zod refine that validates task YAML at load
+ * time (including codegen, which loads schemas.ts in plain Node via tsx),
+ * and any transitive import of `bun:sqlite` (which tools.ts pulls in via
+ * its tool-factory dependencies) breaks codegen. Keeping the name sets in
+ * a leaf module lets both schemas.ts (validation) and tools.ts (the actual
+ * factory) import them without dragging in the DB layer.
+ *
+ * tools.ts imports these sets directly — it must never redeclare its own
+ * copies. Adding a tool means adding its name to the appropriate set here;
+ * `VAULT_TOOL_COUNT` and `ALL_VAULT_TOOL_NAMES` (both derived, in tools.ts
+ * and here respectively) pick up the change automatically.
+ */
+
+export const READ_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'vault_unprocessed', 'vault_batches', 'vault_session_summary_material', 'vault_spores',
+  'vault_sessions', 'vault_search_fts', 'vault_search_semantic', 'vault_search_canopy',
+  'vault_release_state', 'vault_state', 'vault_edges',
+]);
+
+export const WRITE_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'vault_create_spore', 'vault_resolve_spore', 'vault_update_session', 'vault_set_state',
+  'vault_read_digest', 'vault_write_digest', 'vault_mark_processed',
+]);
+
+export const OBSERVABILITY_TOOL_NAMES: ReadonlySet<string> = new Set(['vault_report']);
+
+export const SKILL_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'vault_skill_survey_prepare', 'vault_skill_survey_bundle_decisions',
+  'vault_skill_survey_reconciliation_plan',
+  'vault_skill_survey_apply_reconciliation',
+  'vault_skill_candidates', 'vault_skill_records', 'vault_scan_skill_contamination',
+  'vault_write_skill', 'vault_stage_skill', 'vault_finalize_skill',
+  'vault_edit_skill',
+]);
+
+export const EXPLORATION_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'fs_read', 'fs_list', 'fs_tree', 'code_grep',
+]);
+
+export const CANOPY_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'canopy_describe_next', 'canopy_describe_write', 'canopy_list',
+  'canopy_describe_charge',
+]);
+
+/**
+ * Duplicated literal, not a re-export, of `PHASE_METADATA_TOOL_NAMES` from
+ * `tools/phase-metadata-tools.ts` — that module imports
+ * `@anthropic-ai/claude-agent-sdk` to build the actual tool, so importing
+ * it here would break this module's zero-dep contract. Keep this literal
+ * in sync by hand if `phase-metadata-tools.ts` ever registers a second
+ * tool; `tools.ts` itself still sources the real tuple from that module
+ * for the tool factory and for `VAULT_TOOL_COUNT`.
+ */
+const PHASE_METADATA_TOOL_NAME = 'phase_emit_metadata';
+
+/**
+ * Union of every vault tool name across all groups, including the phase-
+ * metadata tool. Sized to match `VAULT_TOOL_COUNT` (tools.ts) exactly — a
+ * bidirectional-drift test in tests/agent/tools.test.ts asserts this union
+ * carries every name the real tool registry produces, and vice versa.
+ */
+export const ALL_VAULT_TOOL_NAMES: ReadonlySet<string> = new Set([
+  ...READ_TOOL_NAMES,
+  ...WRITE_TOOL_NAMES,
+  ...OBSERVABILITY_TOOL_NAMES,
+  ...SKILL_TOOL_NAMES,
+  ...EXPLORATION_TOOL_NAMES,
+  ...CANOPY_TOOL_NAMES,
+  PHASE_METADATA_TOOL_NAME,
+]);

--- a/packages/myco/src/agent/tools.ts
+++ b/packages/myco/src/agent/tools.ts
@@ -44,6 +44,14 @@ import { createExplorationTools } from './tools/exploration-tools.js';
 import { createCanopyTools } from './tools/canopy-tools.js';
 import { applyDeferredStubs, buildSearchToolsTool } from './tools/deferred-tools.js';
 import { textResult, toSdkMcpToolDefinitions } from './tools/types.js';
+import {
+  READ_TOOL_NAMES,
+  WRITE_TOOL_NAMES,
+  OBSERVABILITY_TOOL_NAMES,
+  SKILL_TOOL_NAMES,
+  EXPLORATION_TOOL_NAMES,
+  CANOPY_TOOL_NAMES,
+} from './tool-names.js';
 import { errorMessage } from '@myco/utils/error-message.js';
 import type { MycoToolDefinition, VaultToolDeps } from './tools/types.js';
 import type { AgentEmbeddingPort, AgentTeamSearchPort } from '@myco/agent/runtime/ports.js';
@@ -264,39 +272,15 @@ const DRY_RUN_STUB_TOOLS = new Map<string, StubToolSpec>([
 // ---------------------------------------------------------------------------
 // Tool group membership — used to skip factory calls for unneeded groups
 // ---------------------------------------------------------------------------
-
-const READ_TOOL_NAMES = new Set([
-  'vault_unprocessed', 'vault_batches', 'vault_session_summary_material', 'vault_spores',
-  'vault_sessions', 'vault_search_fts', 'vault_search_semantic', 'vault_search_canopy',
-  'vault_release_state', 'vault_state', 'vault_edges',
-]);
-
-const WRITE_TOOL_NAMES = new Set([
-  'vault_create_spore', 'vault_resolve_spore', 'vault_update_session', 'vault_set_state',
-  'vault_read_digest', 'vault_write_digest', 'vault_mark_processed',
-]);
-
-const OBSERVABILITY_TOOL_NAMES = new Set(['vault_report']);
+//
+// The name-set literals live in tool-names.ts (zero-dep leaf module — see
+// its header comment) so schemas.ts can validate task-level `deferredTools`
+// against the full registry without pulling tools.ts's bun:sqlite-adjacent
+// dependency chain into codegen. This file is the only place they're
+// composed into factory-skipping Sets; import from tool-names.ts rather
+// than redeclaring a set literal here.
 
 const PHASE_METADATA_TOOL_NAMES_SET = new Set<string>(PHASE_METADATA_TOOL_NAMES);
-
-const SKILL_TOOL_NAMES = new Set([
-  'vault_skill_survey_prepare', 'vault_skill_survey_bundle_decisions',
-  'vault_skill_survey_reconciliation_plan',
-  'vault_skill_survey_apply_reconciliation',
-  'vault_skill_candidates', 'vault_skill_records', 'vault_scan_skill_contamination',
-  'vault_write_skill', 'vault_stage_skill', 'vault_finalize_skill',
-  'vault_edit_skill',
-]);
-
-const EXPLORATION_TOOL_NAMES = new Set([
-  'fs_read', 'fs_list', 'fs_tree', 'code_grep',
-]);
-
-const CANOPY_TOOL_NAMES = new Set([
-  'canopy_describe_next', 'canopy_describe_write', 'canopy_list',
-  'canopy_describe_charge',
-]);
 
 /** Max chars stored from a tool response in the run audit trail. */
 const TOOL_OUTPUT_SUMMARY_LIMIT = 240;
@@ -344,7 +328,7 @@ export const VAULT_TOOL_COUNT =
   CANOPY_TOOL_NAMES.size +
   PHASE_METADATA_TOOL_NAMES_SET.size;
 
-function setsOverlap(a: Set<string>, b: Set<string>): boolean {
+function setsOverlap(a: Set<string>, b: ReadonlySet<string>): boolean {
   for (const item of a) { if (b.has(item)) return true; }
   return false;
 }
@@ -1183,7 +1167,7 @@ export function createVaultTools(agentId: string, runId: string, options?: Vault
 export function createVaultToolServer(
   agentId: string,
   runId: string,
-  options?: Pick<VaultToolOptions, 'embeddingManager' | 'projectRoot' | 'vaultDir' | 'requestContext' | 'dryRun' | 'metadataAccumulator' | 'phasePurpose' | 'semanticCheckEnabled' | 'harnessId' | 'model' | 'classifierReasoningLevel' | 'provider' | 'flaggedWritesAccumulator' | 'hooks' | 'hookContext' | 'logger'>,
+  options?: Pick<VaultToolOptions, 'embeddingManager' | 'projectRoot' | 'vaultDir' | 'requestContext' | 'dryRun' | 'metadataAccumulator' | 'phasePurpose' | 'semanticCheckEnabled' | 'harnessId' | 'model' | 'classifierReasoningLevel' | 'provider' | 'flaggedWritesAccumulator' | 'hooks' | 'hookContext' | 'deferredNames' | 'logger'>,
 ) {
   const tools = createVaultTools(agentId, runId, options);
 

--- a/packages/myco/src/agent/types.ts
+++ b/packages/myco/src/agent/types.ts
@@ -500,6 +500,14 @@ export interface AgentTask {
   orchestrator?: OrchestratorConfig; // orchestrator configuration for phased tasks
   schedule?: TaskSchedule; // schedule configuration for automatic execution
   params?: Record<string, string | number | boolean>; // task-specific params with defaults
+  /**
+   * Tool names to defer on a single-query (non-phased) task. Must be a
+   * subset of the vault tool registry (enforced at YAML-load time by
+   * AgentTaskSchema's refine, schemas.ts) and must not co-occur with
+   * `phases` — a phased task defers per-phase via
+   * `PhaseDefinition.deferredTools` instead.
+   */
+  deferredTools?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -530,6 +538,14 @@ export interface EffectiveConfig {
   execution?: ExecutionConfig;
   /** Resolved task params — YAML defaults merged with myco.yaml overrides. */
   taskParams?: Record<string, string | number | boolean>;
+  /**
+   * Tool names to defer on the single-query (non-phased) execution path.
+   * Carried from AgentTask.deferredTools through resolveEffectiveConfig
+   * unchanged; executeSingleQuery (phase-loop.ts) reads it into the tool
+   * surface's `deferredNames`. Always undefined when `phases` is set —
+   * AgentTaskSchema's refine rejects the co-occurrence at load time.
+   */
+  deferredTools?: string[];
   /**
    * Propagated from RunOptions.dryRun by the executor when building the
    * effective config for this run. Passed through to the tool surface.

--- a/tests/agent/runtime-claude.test.ts
+++ b/tests/agent/runtime-claude.test.ts
@@ -16,6 +16,7 @@ import { vi } from '../helpers/vi-shim.js';
 
 const queryCalls: Array<{ prompt: string; options: Record<string, unknown> }> = [];
 let structuredOutputOverride: unknown = undefined;
+let usageOverride: Record<string, number> | undefined = undefined;
 
 mock.module('@anthropic-ai/claude-agent-sdk', () => ({
   query: (args: { prompt: string; options: Record<string, unknown> }) => {
@@ -32,7 +33,7 @@ mock.module('@anthropic-ai/claude-agent-sdk', () => ({
           type: 'result' as const,
           subtype: 'success' as const,
           total_cost_usd: 0.0123,
-          usage: { input_tokens: 42, output_tokens: 7 },
+          usage: usageOverride ?? { input_tokens: 42, output_tokens: 7 },
           num_turns: 1,
           duration_ms: 100,
           duration_api_ms: 80,
@@ -128,6 +129,7 @@ describe('ClaudeSdkHarness.execute', () => {
     scopedServerCalls.length = 0;
     fullServerCalls.length = 0;
     structuredOutputOverride = undefined;
+    usageOverride = undefined;
   });
 
   it('forwards sessionRef as sessionId to the SDK when provided', async () => {
@@ -409,6 +411,68 @@ describe('ClaudeSdkHarness.execute', () => {
     expect(fullServerCalls[0].options.flaggedWritesAccumulator).toBe(flaggedWritesAccumulator);
   });
 
+  it('threads deferredNames through to createScopedVaultToolServer when toolNames is provided', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    await runtime.execute(makeInput({
+      toolSurface: {
+        agentId: 'a1',
+        runId: 'r1',
+        toolNames: ['vault_report'],
+        deferredNames: ['vault_report'],
+      },
+    }));
+
+    expect(scopedServerCalls).toHaveLength(1);
+    expect(scopedServerCalls[0].options.deferredNames).toEqual(new Set(['vault_report']));
+  });
+
+  it('threads deferredNames through to createVaultToolServer when toolNames is omitted (P3-T1 fix — FULL-SURFACE path)', async () => {
+    // Prior to this fix, buildToolServer's FULL-SURFACE branch (the one
+    // executeSingleQuery hits for the five single-query tasks — no
+    // toolNames means the whole 39-tool registry ships every run) never
+    // read toolSurface.deferredNames at all: it built the
+    // createVaultToolServer options object without a deferredNames key.
+    // A task-level `deferredTools` (P3-T1's new AgentTaskSchema field)
+    // would therefore reach the phase-loop's toolSurface correctly and
+    // then silently no-op the moment it hit the harness adapter — no
+    // stub, no vault_search_tools, full undeferred payload every time.
+    // This test would have failed before the claude.ts fix; it must pass
+    // now that createVaultToolServer's options Pick (tools.ts) includes
+    // 'deferredNames' and the full-surface branch threads it.
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    await runtime.execute(makeInput({
+      toolSurface: {
+        agentId: 'a1',
+        runId: 'r1',
+        deferredNames: ['vault_report'],
+      },
+    }));
+
+    expect(fullServerCalls).toHaveLength(1);
+    expect(fullServerCalls[0].options.deferredNames).toEqual(new Set(['vault_report']));
+  });
+
+  it('leaves deferredNames undefined on both server paths when absent from toolSurface', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    await runtime.execute(makeInput({
+      toolSurface: { agentId: 'a1', runId: 'r1', toolNames: ['vault_report'] },
+    }));
+    expect(scopedServerCalls).toHaveLength(1);
+    expect(scopedServerCalls[0].options.deferredNames).toBeUndefined();
+
+    await runtime.execute(makeInput({
+      toolSurface: { agentId: 'a1', runId: 'r1' },
+    }));
+    expect(fullServerCalls).toHaveLength(1);
+    expect(fullServerCalls[0].options.deferredNames).toBeUndefined();
+  });
+
   it('isolates the agent from user settings via settingSources: []', async () => {
     // Regression: the SDK's plugin-sync path reads `enabledPlugins` from
     // ~/.claude/settings.json / project .claude/settings.json when
@@ -477,6 +541,66 @@ describe('ClaudeSdkHarness.execute', () => {
     expect(result.usage.totalTokens).toBe(49);
     expect(result.usage.costUsd).toBeCloseTo(0.0123);
     expect(result.usage.requestUsageEntries).toHaveLength(1);
+  });
+
+  it('leaves cachedTokens at 0 and inputTokens unchanged when the SDK usage carries no cache fields (backward compat)', async () => {
+    // The fixture above (`makeInput()`'s default query mock) only sets
+    // input_tokens/output_tokens — no cache_creation_input_tokens or
+    // cache_read_input_tokens. Pre-existing runs (and any SDK response
+    // that genuinely has no cache activity) must produce identical
+    // inputTokens/totalTokens to before this fix, with cachedTokens
+    // reported as 0 rather than left undefined.
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    const result = await runtime.execute(makeInput());
+    expect(result.usage.inputTokens).toBe(42);
+    expect(result.usage.outputTokens).toBe(7);
+    expect(result.usage.cachedTokens).toBe(0);
+    expect(result.usage.totalTokens).toBe(49);
+  });
+
+  it('folds cache_creation_input_tokens and cache_read_input_tokens into inputTokens and reports cache_read as cachedTokens', async () => {
+    // SDK usage shape carrying cache fields (BetaUsage on
+    // SDKResultMessage.usage): input_tokens excludes both cache_creation
+    // and cache_read — this fixture models a request where the large
+    // tool-schema payload was served from cache. inputTokens must be the
+    // full prompt size (sdk.input_tokens + cache_creation + cache_read) so
+    // cost/breakdown.ts's uncachedInputTokens = inputTokens - cachedTokens
+    // subtraction stays meaningful; cachedTokens is the cache_read portion
+    // only.
+    usageOverride = {
+      input_tokens: 100,
+      output_tokens: 20,
+      cache_creation_input_tokens: 5000,
+      cache_read_input_tokens: 3000,
+    };
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    const result = await runtime.execute(makeInput());
+    expect(result.usage.inputTokens).toBe(100 + 5000 + 3000);
+    expect(result.usage.cachedTokens).toBe(3000);
+    expect(result.usage.outputTokens).toBe(20);
+    expect(result.usage.totalTokens).toBe(100 + 5000 + 3000 + 20);
+
+    const { buildTokenBreakdown } = await import('@myco/agent/cost/breakdown.js');
+    const breakdown = buildTokenBreakdown(result.usage);
+    expect(breakdown.cachedInputTokens).toBe(3000);
+    expect(breakdown.uncachedInputTokens).toBe(100 + 5000 + 3000 - 3000);
+    expect(breakdown.uncachedInputTokens).toBeGreaterThanOrEqual(0);
+  });
+
+  it('keeps breakdown.uncachedInputTokens non-negative for the no-cache-fields fixture', async () => {
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+
+    const result = await runtime.execute(makeInput());
+    const { buildTokenBreakdown } = await import('@myco/agent/cost/breakdown.js');
+    const breakdown = buildTokenBreakdown(result.usage);
+    expect(breakdown.cachedInputTokens).toBe(0);
+    expect(breakdown.uncachedInputTokens).toBe(42);
+    expect(breakdown.uncachedInputTokens).toBeGreaterThanOrEqual(0);
   });
 
   it('attaches outputFormat to the SDK call when outputSchema is provided', async () => {

--- a/tests/agent/schemas.test.ts
+++ b/tests/agent/schemas.test.ts
@@ -680,6 +680,114 @@ describe('AgentTaskSchema — backward compatibility', () => {
 });
 
 // ---------------------------------------------------------------------------
+// AgentTaskSchema — deferredTools (task-level, single-query path)
+// ---------------------------------------------------------------------------
+
+describe('AgentTaskSchema — deferredTools', () => {
+  const minimalTask = {
+    name: 'extract-only',
+    displayName: 'Extract Only',
+    description: 'Extract spores only.',
+    agent: 'myco-agent',
+    prompt: 'Extract spores from unprocessed batches.',
+    isDefault: false,
+  };
+
+  it('accepts a task without deferredTools (field is optional)', () => {
+    const result = AgentTaskSchema.safeParse(minimalTask);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.deferredTools).toBeUndefined();
+    }
+  });
+
+  it('accepts a registry name that is NOT in toolOverrides — validation is registry-relative, not toolOverrides-relative', () => {
+    // C1 case: toolOverrides narrows the task's own tool list, but
+    // deferredTools is validated against the FULL vault tool registry
+    // (ALL_VAULT_TOOL_NAMES). A name absent from toolOverrides must still
+    // be accepted here — toolOverrides is a phantom surface nothing reads
+    // at runtime for this purpose (see loader.ts's taskFromParsed comment
+    // on the refine in schemas.ts).
+    const task = {
+      ...minimalTask,
+      toolOverrides: ['vault_write_digest'],
+      deferredTools: ['vault_report'],
+    };
+    const result = AgentTaskSchema.safeParse(task);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.deferredTools).toEqual(['vault_report']);
+    }
+  });
+
+  it('rejects a typo/unknown tool name in deferredTools', () => {
+    const task = { ...minimalTask, deferredTools: ['vault_reprot'] };
+    const result = AgentTaskSchema.safeParse(task);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects deferredTools on a task that also has phases', () => {
+    const task = {
+      ...minimalTask,
+      deferredTools: ['vault_report'],
+      phases: [{
+        name: 'extract',
+        prompt: 'Extract structured data.',
+        tools: ['vault_report'],
+        maxTurns: 10,
+        required: true,
+      }],
+    };
+    const result = AgentTaskSchema.safeParse(task);
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts deferredTools on a task with an empty phases array', () => {
+    // Guards the refine's exact condition — `!t.phases || t.phases.length
+    // === 0` mirrors PhaseDefinitionSchema's own empty-array carve-out for
+    // mode: map, so an explicitly-empty phases list is not mistaken for
+    // "this is a phased task."
+    const task = { ...minimalTask, deferredTools: ['vault_report'], phases: [] };
+    const result = AgentTaskSchema.safeParse(task);
+    expect(result.success).toBe(true);
+  });
+
+  it('user-task strip-mode shape (registry/daemon-API load path) validates with deferredTools', () => {
+    // writeUserTask (registry.ts) strips isBuiltin/source before calling
+    // AgentTaskSchema.parse — this is that exact shape, proving the field
+    // survives the user-task write path, not just the built-in YAML path.
+    const userTaskShape = {
+      name: 'extract-only-custom',
+      displayName: 'Extract Only (custom)',
+      description: 'User override of extract-only.',
+      agent: 'myco-agent',
+      prompt: 'Extract spores from unprocessed batches.',
+      isDefault: false,
+      deferredTools: ['vault_report'],
+    };
+    const result = AgentTaskSchema.safeParse(userTaskShape);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.deferredTools).toEqual(['vault_report']);
+    }
+  });
+
+  it('user-task strip-mode shape rejects an invalid name loudly', () => {
+    const userTaskShape = {
+      name: 'extract-only-custom',
+      displayName: 'Extract Only (custom)',
+      description: 'User override of extract-only.',
+      agent: 'myco-agent',
+      prompt: 'Extract spores from unprocessed batches.',
+      isDefault: false,
+      deferredTools: ['not_a_real_tool'],
+    };
+    const result = AgentTaskSchema.safeParse(userTaskShape);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // AgentDefinitionSchema — basic coverage
 // ---------------------------------------------------------------------------
 

--- a/tests/agent/tools.test.ts
+++ b/tests/agent/tools.test.ts
@@ -34,6 +34,7 @@ import { insertGraphEdge } from '@myco/db/queries/graph-edges.js';
 import { insertResolutionEvent } from '@myco/db/queries/resolution-events.js';
 import { createVaultTools, VAULT_TOOL_COUNT } from '@myco/agent/tools.js';
 import { DEFERRED_STUB_DESCRIPTION } from '@myco/agent/tools/deferred-tools.js';
+import { ALL_VAULT_TOOL_NAMES } from '@myco/agent/tool-names.js';
 import { resolveLegacyRequestContext } from '@myco/grove/request-context.js';
 import type { SdkMcpToolDefinition } from '@anthropic-ai/claude-agent-sdk';
 
@@ -169,6 +170,35 @@ describe('vault tools', () => {
   });
 
   // -------------------------------------------------------------------------
+  // ALL_VAULT_TOOL_NAMES drift guard
+  //
+  // tool-names.ts (imported by both tools.ts and schemas.ts) must stay in
+  // lockstep with the REAL tool registry this file builds via
+  // createVaultTools — the registry is imported here in the TEST, not in
+  // tool-names.ts itself, since tool-names.ts must stay zero-dep (no
+  // bun:sqlite-adjacent imports) for codegen to load schemas.ts safely.
+  // -------------------------------------------------------------------------
+
+  describe('ALL_VAULT_TOOL_NAMES drift guard', () => {
+    it('union size matches VAULT_TOOL_COUNT', () => {
+      expect(ALL_VAULT_TOOL_NAMES.size).toBe(VAULT_TOOL_COUNT);
+    });
+
+    it('every tool the real registry produces is in ALL_VAULT_TOOL_NAMES', () => {
+      for (const t of tools) {
+        expect(ALL_VAULT_TOOL_NAMES.has(t.name)).toBe(true);
+      }
+    });
+
+    it('every name in ALL_VAULT_TOOL_NAMES is produced by the real registry', () => {
+      const registryNames = new Set(tools.map((t) => t.name));
+      for (const name of ALL_VAULT_TOOL_NAMES) {
+        expect(registryNames.has(name)).toBe(true);
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Deferred tool loading
   // -------------------------------------------------------------------------
 
@@ -210,6 +240,44 @@ describe('vault tools', () => {
       // Non-deferred tools in the same scoped surface are untouched.
       const sporesTool = scopedTools.find((t) => t.name === 'vault_spores')!;
       expect(sporesTool.description).not.toContain('deferred');
+    });
+
+    it('createVaultToolServer (the FULL-SURFACE / unscoped MCP server factory) threads deferredNames through to real stubs and vault_search_tools', async () => {
+      // P3-T1: single-query tasks (executeSingleQuery, phase-loop.ts) have
+      // no `phases:` block, so they hit createVaultToolServer directly —
+      // the FULL-SURFACE path — never createScopedVaultToolServer. Before
+      // this task, createVaultToolServer's options Pick (tools.ts) excluded
+      // 'deferredNames' entirely, so a task-level deferredTools field would
+      // have reached this call and been silently dropped. Assert against
+      // the real MCP server's registered-tools surface (not a mock) to
+      // prove the stub/meta-tool synthesis actually happens on this path.
+      const { createVaultToolServer: freshCreateVaultToolServer } = await import('@myco/agent/tools.js');
+      const server = freshCreateVaultToolServer(TEST_AGENT_ID, TEST_RUN_ID, {
+        requestContext: TEST_REQUEST_CONTEXT,
+        deferredNames: new Set(['vault_report']),
+      });
+      const registeredTools = (server as unknown as { instance: { _registeredTools: Record<string, { description?: string }> } })
+        .instance._registeredTools;
+      const names = Object.keys(registeredTools);
+
+      expect(names).toContain('vault_search_tools');
+      expect(names).toContain('vault_report');
+      expect(registeredTools.vault_report.description).toBe(DEFERRED_STUB_DESCRIPTION);
+
+      // A non-deferred tool on the same full surface is untouched.
+      expect(registeredTools.vault_spores.description).not.toBe(DEFERRED_STUB_DESCRIPTION);
+
+      // Deferral never changes callability — the stub only replaces
+      // description/schema; the real handler still runs end-to-end and
+      // writes through to the vault exactly as an undeferred call would.
+      const result = await registeredTools.vault_report.handler(
+        { action: 'extract', summary: 'Deferred-stub call still reaches the real handler.' },
+        undefined,
+      );
+      const report = JSON.parse(result.content[0].text) as { run_id: string; agent_id: string; action: string };
+      expect(report.run_id).toBe(TEST_RUN_ID);
+      expect(report.agent_id).toBe(TEST_AGENT_ID);
+      expect(report.action).toBe('extract');
     });
   });
 


### PR DESCRIPTION
## What

Adoption Phase 3 of the SDK-alignment follow-up (master plan `4b7d54ba716418ce`, impl plan `0027ff351a6d2fc5`): the deferral-sweep **plumbing**. The data-driven YAML diffs follow in a separate PR after a ≥1-week usage-analysis window — this PR is inert until a YAML sets the new field.

### Task-level `deferredTools` for single-query tasks

The five single-query tasks (title-summary, extract-only, review-session, supersession-sweep, digest-only) carry the full 39-tool registry surface every run and had no deferral analog to #612's per-phase field. Now:

- **Zero-dep tool-names module** (`tool-names.ts`) extracted from the tools.ts name-set literals — one source of truth (`VAULT_TOOL_COUNT` still self-derives), `ReadonlySet` exports, bidirectional drift guard (test imports the real registry; the module stays codegen-safe).
- **`AgentTaskSchema.deferredTools`** with two refines: names ⊆ `ALL_VAULT_TOOL_NAMES` (the pickup review's Critical: validating against `toolOverrides` — a phantom surface consumed nowhere at runtime — would have left title-summary with ZERO legal candidates and rejected precisely the ~30 out-of-override schemas the sweep exists to shed), and rejected on phased tasks (phases own per-phase deferral; empty `phases: []` correctly routes single-query and is allowed — mirrors the executor's routing condition exactly).
- **The silent-no-op fix:** the Claude adapter's full-surface branch (the path every single-query task runs) now threads `deferredNames`, and `createVaultToolServer`'s options Pick includes it. Guarded by a test asserting stub description + `vault_search_tools` synthesis against the real MCP server's registered tools via that exact path.
- Threading through loader/config-resolver/phase-loop; user-task strip-mode behavior change (errant field now validates loudly) tested and documented.

### Claude harness cache-token accounting (bake-measurability rider)

`buildUsage` now maps the SDK's `cache_creation_input_tokens`/`cache_read_input_tokens`: `inputTokens = input + creation + read`, `cachedTokens = read` — matching the OpenAI harness invariant (`cachedTokens ⊆ inputTokens`) so `breakdown.uncachedInputTokens` is meaningful on the harness all five tasks run. Previously the breakdown was structurally blind to the tool-schema payload (it lives in cache fields the SDK excludes from `input_tokens`). **Telemetry only** — `total_cost_usd` stays authoritative; verified no budget/cap/throttle consumer changes behavior.

**Operator note (from the whole-branch review):** post-rider, `agent.token-budget-pressure` and the RunDetail "Budget Used" tile can exceed 100% on multi-turn Claude runs without a real problem — a pre-existing cumulative-as-peak conflation is now visible. Recorded in the plan's Task 4 runbook; per-turn usage entries are a master-list follow-up.

## Verification

- Pickup review (vs post-#618/#619 main) caught 1 Critical (the phantom-surface refine), 1 Major (blind token gate → this rider + cost-based gate), both folded before execution.
- Two per-task reviews + whole-branch review: **Ready to merge, 0 Critical**; inertness proven hop-by-hop (schema default → loader spread → toolSurface undefined → adapters → no stubs); the two commits share only disjoint regions of claude.ts.
- `make build` green; full `npm test` green after every commit (14,262 tests); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
