### PR TITLE
feat(agent): harness-health sentinel — run-health tool, three-seam notifications, events panel

### DIFF
--- a/packages/myco/src/agent/definitions.generated.ts
+++ b/packages/myco/src/agent/definitions.generated.ts
@@ -282,6 +282,42 @@ export const BUNDLED_AGENT_TASKS: readonly AgentTask[] = [
     "timeoutSeconds": 300
   },
   {
+    "name": "harness-health",
+    "displayName": "Harness Health",
+    "description": "Scheduled sentinel that reads aggregate agent-run telemetry (unpaired events, turn-budget hits, postcondition failures, cost spikes, blocked writes, zero-usage runs, and silent scheduled tasks) and files a single harness-health report summarizing findings.",
+    "agent": "myco-agent",
+    "prompt": "Read aggregate harness-health signals via vault_run_health and file one vault_report under action \"harness-health\" summarizing what the buckets show, including an all-clear run when nothing is anomalous.",
+    "isDefault": false,
+    "reasoningLevel": "low",
+    "maxTurns": 20,
+    "timeoutSeconds": 300,
+    "phases": [
+      {
+        "name": "assess",
+        "prompt": "Call `vault_run_health` with no arguments (the default lookback\nwindow is sufficient — do not narrow it unless a bucket result\ntells you to look closer with a `task` filter).\n\nThe result has the following buckets under `buckets`: `unpaired_events`,\n`cap_hits`, `postcondition_failures`, `cost_spikes`,\n`flag_clusters`, `zero_usage`, `silent_streams`. Each bucket\nalready carries a `description` explaining what it means and a\npre-computed `entries` array — every anomaly is deterministic SQL\ncomputed for you. Do not re-derive counts or re-judge whether an\nentry belongs; your job is to interpret and narrate what the tool\nalready found, not to re-analyze raw rows.\n\n`silent_streams` is info-tier only: a schedule-enabled task with no\nruns in the window may be entirely expected (nothing to do, or a\nmyco.yaml override disabled it). Note it in the report without\ntreating it as an alarm on its own.\n\n## Report — mandatory, exactly once, every run\n\nThis phase is not done until you call `vault_report` with action\n`harness-health`. This applies whether you found anomalies or the\nrun is completely clean — there is no other way to end this phase,\nand an all-clear run must still report so a stale or missing report\nis never confused with \"nothing wrong\". Call it exactly once.\n\nPass `details` as an object whose top-level keys are exactly every\nbucket name listed above, each value shaped as:\n{\n  \"description\": \"<one-line human summary of this bucket for this run>\",\n  \"entries\": [ ... ]\n}\n- `description` — required on every bucket, even when `entries` is\n  empty. Summarize what you found (or \"no anomalies in this\n  window\" when clean) in your own words; do not just copy the\n  tool's bucket description verbatim.\n- `entries` — required on every bucket, MANDATORY even when there\n  is nothing to report: use an empty array `[]` for a clean\n  bucket, never omit the key. The notification consumer treats\n  `entries.length` as the sole signal for whether a bucket has\n  findings — a bucket with a description but no `entries` key\n  would be misread as non-empty and fire a false-positive\n  notification.\n- Populate `entries` from `vault_run_health`'s own attribution rows\n  for that bucket (run ids, task names, counts) — do not invent\n  entries or drop the tool's attribution detail.\n\nCanonical shape for `details` (fill in real values; keep every key,\nincluding empty `entries` arrays, exactly as shown):\n{\n  \"unpaired_events\": { \"description\": \"...\", \"entries\": [] },\n  \"cap_hits\": { \"description\": \"...\", \"entries\": [] },\n  \"postcondition_failures\": { \"description\": \"...\", \"entries\": [] },\n  \"cost_spikes\": { \"description\": \"...\", \"entries\": [] },\n  \"flag_clusters\": { \"description\": \"...\", \"entries\": [] },\n  \"zero_usage\": { \"description\": \"...\", \"entries\": [] },\n  \"silent_streams\": { \"description\": \"...\", \"entries\": [] }\n}\n\nSet `summary` to a one-sentence overview (e.g. \"all clear\" or\n\"2 anomaly buckets: cap_hits, cost_spikes\").\n",
+        "tools": [
+          "vault_run_health",
+          "vault_report"
+        ],
+        "maxTurns": 20,
+        "reasoningLevel": "low",
+        "required": true,
+        "readOnly": true,
+        "purpose": "Read-only interpretation of vault_run_health's pre-computed buckets, followed by exactly one vault_report call. Neither tool carries destructiveHint — vault_run_health is a pure read and vault_report only appends an observability row — so this phase makes no destructive or state-mutating writes; the purpose is documented per the Phase 0+1 convention rather than enforced by a classifier signal.",
+        "postCondition": "harness-health-report",
+        "onItemError": "skip"
+      }
+    ],
+    "schedule": {
+      "enabled": true,
+      "intervalSeconds": 86400,
+      "runIn": [
+        "idle",
+        "sleep"
+      ]
+    }
+  },
+  {
     "name": "review-session",
     "displayName": "Review Session",
     "description": "Process a single session end-to-end. Extracts spores from all prompt batches in the session, runs supersession checks, and generates the session title and summary.\n",

--- a/packages/myco/src/agent/definitions/tasks/harness-health.yaml
+++ b/packages/myco/src/agent/definitions/tasks/harness-health.yaml
@@ -1,0 +1,119 @@
+# =============================================================================
+# Built-in Task: Harness Health (Tier 3)
+# =============================================================================
+# Scheduled sentinel that interprets vault_run_health's aggregate
+# anomaly buckets and files a single vault_report under action
+# "harness-health". The report is the sole hand-off surface to the daemon:
+# the notification consumer (notifications/harness-health-consumer.ts)
+# reverse-scans for the latest report with this action and fires
+# agent.harness-health.findings when any bucket's `entries` array is
+# non-empty. An all-clear run (every bucket empty) still reports — silence
+# is indistinguishable from "never ran" without one.
+#
+# Single phase, read-only: vault_run_health and vault_report both carry
+# readOnlyHint: true and no destructiveHint, so this task makes no writes
+# beyond the observability report itself.
+# =============================================================================
+
+name: harness-health
+displayName: Harness Health
+description: >-
+  Scheduled sentinel that reads aggregate agent-run telemetry (unpaired
+  events, turn-budget hits, postcondition failures, cost spikes, blocked
+  writes, zero-usage runs, and silent scheduled tasks) and files a single
+  harness-health report summarizing findings.
+agent: myco-agent
+isDefault: false
+reasoningLevel: low
+maxTurns: 20
+timeoutSeconds: 300
+schedule:
+  enabled: true
+  intervalSeconds: 86400
+  runIn:
+    - idle
+    - sleep
+prompt: >-
+  Read aggregate harness-health signals via vault_run_health and file one
+  vault_report under action "harness-health" summarizing what the buckets
+  show, including an all-clear run when nothing is anomalous.
+phases:
+  - name: assess
+    reasoningLevel: low
+    readOnly: true
+    required: true
+    tools:
+      - vault_run_health
+      - vault_report
+    maxTurns: 20
+    prompt: |
+      Call `vault_run_health` with no arguments (the default lookback
+      window is sufficient — do not narrow it unless a bucket result
+      tells you to look closer with a `task` filter).
+
+      The result has the following buckets under `buckets`: `unpaired_events`,
+      `cap_hits`, `postcondition_failures`, `cost_spikes`,
+      `flag_clusters`, `zero_usage`, `silent_streams`. Each bucket
+      already carries a `description` explaining what it means and a
+      pre-computed `entries` array — every anomaly is deterministic SQL
+      computed for you. Do not re-derive counts or re-judge whether an
+      entry belongs; your job is to interpret and narrate what the tool
+      already found, not to re-analyze raw rows.
+
+      `silent_streams` is info-tier only: a schedule-enabled task with no
+      runs in the window may be entirely expected (nothing to do, or a
+      myco.yaml override disabled it). Note it in the report without
+      treating it as an alarm on its own.
+
+      ## Report — mandatory, exactly once, every run
+
+      This phase is not done until you call `vault_report` with action
+      `harness-health`. This applies whether you found anomalies or the
+      run is completely clean — there is no other way to end this phase,
+      and an all-clear run must still report so a stale or missing report
+      is never confused with "nothing wrong". Call it exactly once.
+
+      Pass `details` as an object whose top-level keys are exactly every
+      bucket name listed above, each value shaped as:
+      {
+        "description": "<one-line human summary of this bucket for this run>",
+        "entries": [ ... ]
+      }
+      - `description` — required on every bucket, even when `entries` is
+        empty. Summarize what you found (or "no anomalies in this
+        window" when clean) in your own words; do not just copy the
+        tool's bucket description verbatim.
+      - `entries` — required on every bucket, MANDATORY even when there
+        is nothing to report: use an empty array `[]` for a clean
+        bucket, never omit the key. The notification consumer treats
+        `entries.length` as the sole signal for whether a bucket has
+        findings — a bucket with a description but no `entries` key
+        would be misread as non-empty and fire a false-positive
+        notification.
+      - Populate `entries` from `vault_run_health`'s own attribution rows
+        for that bucket (run ids, task names, counts) — do not invent
+        entries or drop the tool's attribution detail.
+
+      Canonical shape for `details` (fill in real values; keep every key,
+      including empty `entries` arrays, exactly as shown):
+      {
+        "unpaired_events": { "description": "...", "entries": [] },
+        "cap_hits": { "description": "...", "entries": [] },
+        "postcondition_failures": { "description": "...", "entries": [] },
+        "cost_spikes": { "description": "...", "entries": [] },
+        "flag_clusters": { "description": "...", "entries": [] },
+        "zero_usage": { "description": "...", "entries": [] },
+        "silent_streams": { "description": "...", "entries": [] }
+      }
+
+      Set `summary` to a one-sentence overview (e.g. "all clear" or
+      "2 anomaly buckets: cap_hits, cost_spikes").
+    purpose: >-
+      Read-only interpretation of vault_run_health's pre-computed
+      buckets, followed by exactly one vault_report call. Neither tool
+      carries destructiveHint — vault_run_health is a pure read and
+      vault_report only appends an observability row — so this phase
+      makes no destructive or state-mutating writes; the purpose is
+      documented per the Phase 0+1 convention rather than enforced by a
+      classifier signal.
+    postCondition: harness-health-report

--- a/packages/myco/src/agent/phase-postcondition-kinds.ts
+++ b/packages/myco/src/agent/phase-postcondition-kinds.ts
@@ -22,6 +22,7 @@ export const PHASE_POSTCONDITION_KINDS = [
   'skill-generate-validate',
   'skill-survey-reconcile-queue',
   'skill-survey-persist-decisions',
+  'harness-health-report',
 ] as const;
 
 export type PhasePostConditionKind = (typeof PHASE_POSTCONDITION_KINDS)[number];

--- a/packages/myco/src/agent/phase-postconditions.ts
+++ b/packages/myco/src/agent/phase-postconditions.ts
@@ -16,8 +16,9 @@
  * output contract: the run-end validator in task-postconditions.ts
  * delegates to the same functions (belt and suspenders — a later phase can
  * still clobber state the gate already validated, and resumes re-validate).
- * The other kinds (cortex-prompt-builder, skill-generate, skill-survey) are
- * phase-boundary-only — no run-end validator delegates to them today.
+ * The other kinds (cortex-prompt-builder, skill-generate, skill-survey,
+ * harness-health) are phase-boundary-only — no run-end validator delegates
+ * to them today.
  *
  * Failure `reason` strings are load-bearing: the skill-evolve run-end
  * validator surfaces them verbatim as the run error, and tests assert them
@@ -337,6 +338,57 @@ function checkSkillSurveyPersistDecisions(input: PhasePostConditionInput): Phase
   return PASSED;
 }
 
+/**
+ * harness-health (phase `assess`, kind `harness-health-report`): gate = a
+ * `harness-health` report exists with parseable `details`. Mirrors
+ * `checkCortexPromptBuilderBuild`'s last-match scan (the notification
+ * consumer in harness-health-consumer.ts does the same reverse scan for the
+ * same report action) and its no-run_id rationale: the report shape has no
+ * `run_id` key for `stampRunIdInPayload` to rewrite, and
+ * `listReports(runId, ...)` is already run-scoped, so there is no cross-run
+ * state row this report could be confused with.
+ *
+ * Does NOT require bucket contents (findings) — an all-clear report (every
+ * bucket's `entries` empty) is a designed success; the gate exists to catch
+ * a prose-only phase that never called `vault_report` at all, not to demand
+ * findings. It DOES enforce bucket *shape*: structural enforcement over a
+ * prompt contract (repo doctrine — gates belong in tool code, not in the
+ * model's self-discipline). Every `details` value that is a plain object
+ * must carry an `entries` array; a model that narrates a bucket as prose
+ * and drops its `entries` array produces a report the consumer silently
+ * mis-reads (a missing key reads as "no findings") instead of failing the
+ * phase boundary where the mistake actually happened. Array- or
+ * scalar-valued top-level details keys are unaffected — only plain-object
+ * values are required to carry `entries`.
+ */
+function checkHarnessHealthReport(input: PhasePostConditionInput): PhasePostConditionResult {
+  const reports = listReports(input.runId, { scope: ALL_PROJECTS_SCOPE });
+  let healthReport: (typeof reports)[number] | undefined;
+  for (let index = reports.length - 1; index >= 0; index -= 1) {
+    if (reports[index]?.action === 'harness-health') {
+      healthReport = reports[index];
+      break;
+    }
+  }
+  if (!healthReport) {
+    return failed('harness-health completed without a harness-health report');
+  }
+
+  const details = asPlainRecord(healthReport.details);
+  if (!details || Object.keys(details).length === 0) {
+    return failed('harness-health completed without parseable harness-health report details');
+  }
+
+  for (const [key, value] of Object.entries(details)) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) continue;
+    const bucket = value as Record<string, unknown>;
+    if (!Array.isArray(bucket.entries)) {
+      return failed(`harness-health report bucket "${key}" is missing its entries array`);
+    }
+  }
+  return PASSED;
+}
+
 const PHASE_POSTCONDITIONS: Record<PhasePostConditionKind, PhasePostConditionFn> = {
   'skill-evolve-inventory': checkSkillEvolveInventory,
   'skill-evolve-assess': checkSkillEvolveAssess,
@@ -344,6 +396,7 @@ const PHASE_POSTCONDITIONS: Record<PhasePostConditionKind, PhasePostConditionFn>
   'skill-generate-validate': checkSkillGenerateValidate,
   'skill-survey-reconcile-queue': checkSkillSurveyReconcileQueue,
   'skill-survey-persist-decisions': checkSkillSurveyPersistDecisions,
+  'harness-health-report': checkHarnessHealthReport,
 };
 
 export function checkPhasePostCondition(

--- a/packages/myco/src/agent/tool-names.ts
+++ b/packages/myco/src/agent/tool-names.ts
@@ -26,7 +26,7 @@ export const WRITE_TOOL_NAMES: ReadonlySet<string> = new Set([
   'vault_read_digest', 'vault_write_digest', 'vault_mark_processed',
 ]);
 
-export const OBSERVABILITY_TOOL_NAMES: ReadonlySet<string> = new Set(['vault_report']);
+export const OBSERVABILITY_TOOL_NAMES: ReadonlySet<string> = new Set(['vault_report', 'vault_run_health']);
 
 export const SKILL_TOOL_NAMES: ReadonlySet<string> = new Set([
   'vault_skill_survey_prepare', 'vault_skill_survey_bundle_decisions',

--- a/packages/myco/src/agent/tools/observability-tools.ts
+++ b/packages/myco/src/agent/tools/observability-tools.ts
@@ -1,15 +1,35 @@
 /**
  * Observability vault tools.
  *
- * 1 tool: vault_report
+ * 2 tools: vault_report, vault_run_health
  */
 
 import { z } from 'zod/v4';
 import { tool } from '@anthropic-ai/claude-agent-sdk';
 import { epochSeconds } from '@myco/constants.js';
 import { insertReport } from '@myco/db/queries/reports.js';
-import { textResult, stampRunIdInPayload, type VaultToolDeps } from './types.js';
+import {
+  findCapHits,
+  findCostSpikes,
+  findFlagClusters,
+  findPostConditionFailures,
+  findSilentStreams,
+  findUnpairedEvents,
+  findZeroUsageRuns,
+  resolveRunHealthWindow,
+} from '@myco/db/queries/run-health.js';
+import { textResult, stampRunIdInPayload, projectScopeFromVaultToolDeps, type VaultToolDeps } from './types.js';
 import { rowProjectIdFromRequestContext } from '@myco/grove/request-context.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default lookback window for vault_run_health, in hours. */
+const DEFAULT_RUN_HEALTH_WINDOW_HOURS = 24;
+
+/** Default ratio threshold for cost-spike detection (window mean / trailing mean). */
+const DEFAULT_COST_SPIKE_RATIO = 2;
 
 // ---------------------------------------------------------------------------
 // Factory
@@ -18,6 +38,7 @@ import { rowProjectIdFromRequestContext } from '@myco/grove/request-context.js';
 export function createObservabilityTools(deps: VaultToolDeps) {
   const { runId, agentId } = deps;
   const projectId = rowProjectIdFromRequestContext(deps.requestContext);
+  const scope = projectScopeFromVaultToolDeps(deps);
 
   const vaultReport = {
     ...tool(
@@ -55,5 +76,72 @@ export function createObservabilityTools(deps: VaultToolDeps) {
     },
   };
 
-  return [vaultReport];
+  const vaultRunHealth = tool(
+    'vault_run_health',
+    'Read aggregate harness-health signals over agent_runs, agent_run_events, and agent_run_write_intents for a lookback window. Use this to interpret harness health for a scheduled sentinel report — it never re-derives anomalies from raw rows; every bucket is pre-computed deterministic SQL, so treat the counts and attributions as ground truth and focus on narrating what they mean. The buckets: unpaired_events (pre/post tool-use count mismatches — a process death or swallowed insert, not necessarily a tool error), cap_hits (phases that hit their turn budget), postcondition_failures (phases whose postCondition gate rejected an otherwise-complete result), cost_spikes (task/provider pairs whose mean cost jumped vs the trailing window), flag_clusters (writes the semantic classifier blocked), zero_usage (completed or failed runs with no recorded token/cost telemetry), and silent_streams (info-tier only: schedule-enabled tasks with no preCondition gate that produced zero runs — may be entirely expected).',
+    {
+      window_hours: z.number().optional().describe(`Lookback window in hours (default ${DEFAULT_RUN_HEALTH_WINDOW_HOURS}).`),
+      task: z.string().optional().describe('Restrict cost_spikes and zero_usage attribution to a single task name. Other buckets are unaffected — they are run/event-level, not task-filtered.'),
+      cost_spike_ratio: z.number().optional().describe(`Minimum (window mean cost / trailing-window mean cost) ratio to report a cost spike (default ${DEFAULT_COST_SPIKE_RATIO}).`),
+    },
+    async (args) => {
+      const windowHours = args.window_hours ?? DEFAULT_RUN_HEALTH_WINDOW_HOURS;
+      const spikeRatio = args.cost_spike_ratio ?? DEFAULT_COST_SPIKE_RATIO;
+      const window = resolveRunHealthWindow(windowHours);
+
+      const unpairedEvents = findUnpairedEvents(window, scope, runId);
+      const capHits = findCapHits(window, scope);
+      const postConditionFailures = findPostConditionFailures(window, scope);
+      let costSpikes = findCostSpikes(window, scope, spikeRatio);
+      let zeroUsage = findZeroUsageRuns(window, scope);
+      const flagClusters = findFlagClusters(window, scope);
+      const silentStreams = findSilentStreams(window, scope);
+
+      if (args.task) {
+        costSpikes = costSpikes.filter((row) => row.task === args.task);
+        zeroUsage = zeroUsage.filter((row) => row.task === args.task);
+      }
+
+      return textResult({
+        window: {
+          window_hours: windowHours,
+          started_after: window.startedAfter,
+          ended_before: window.endedBefore,
+        },
+        buckets: {
+          unpaired_events: {
+            description: 'agent_run_events groups whose pre_tool_use and post_tool_use counts differ within the window. post_tool_use fires even on tool errors (outcome \'error\'), so a count diff signals a process death mid-tool or a swallowed best-effort insert, not necessarily a tool failure. Excludes the calling run itself; an in-flight OTHER run\'s current tool call can still appear transiently until its post_tool_use event lands.',
+            entries: unpairedEvents,
+          },
+          cap_hits: {
+            description: 'Phases (from actions_taken.phases[].capHit) that failed because the harness exhausted the phase turn budget, on either the success or failure path.',
+            entries: capHits,
+          },
+          postcondition_failures: {
+            description: 'Phases (from actions_taken.phases[].postConditionFailed) whose declared postCondition rejected an otherwise-complete result. Detected via the JSON flag, not error-string matching — the executor\'s wrapped error text does not reliably survive to a matchable column.',
+            entries: postConditionFailures,
+          },
+          cost_spikes: {
+            description: `(task, provider) pairs whose mean cost_usd in the window is at least ${spikeRatio}x the mean cost_usd in the equal-length trailing window. Zero-cost rows are excluded from both means (local providers hard-zero costUsd, which would otherwise mask a real spike). A pair with no nonzero-cost trailing baseline is never reported.`,
+            entries: costSpikes,
+          },
+          flag_clusters: {
+            description: 'agent_run_write_intents rows whose classifier_verdict is the literal string \'flag\' — writes the semantic-check classifier blocked. Excludes ordinary dry-run-intercepted writes, which record classifier_verdict = NULL and would otherwise dominate an unfiltered count.',
+            entries: flagClusters,
+          },
+          zero_usage: {
+            description: 'Completed runs with tokens_used = 0, plus failed runs whose usage telemetry is entirely zero or absent. Info-tier visibility, not an alarm: this flags runs whose failure telemetry was unrecoverable, not a claim that every failed local run qualifies.',
+            entries: zeroUsage,
+          },
+          silent_streams: {
+            description: 'Info-tier only, never alarmed: bundled-YAML-default-enabled tasks with no task-level preCondition gate that produced zero runs in the window. Read from the static bundled task definitions, not the effective per-project myco.yaml schedule (that resolution is internal to the scheduler and unreachable from this tool) — a task may be legitimately silent because a project override disabled it.',
+            entries: silentStreams,
+          },
+        },
+      });
+    },
+    { annotations: { readOnlyHint: true } },
+  );
+
+  return [vaultReport, vaultRunHealth];
 }

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -20,6 +20,7 @@ import { loadMergedConfig } from '@myco/config/loader.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { notify } from '@myco/notifications/notify.js';
 import { agentRunNotificationLink } from '@myco/notifications/links.js';
+import { HARNESS_HEALTH_TASK_NAME, notifyHarnessHealthFindings } from '@myco/notifications/harness-health-consumer.js';
 import { buildPhaseAudit } from '@myco/services/phase-audit.js';
 import { ExecutionOverrideBody } from './schemas/execution-overrides.js';
 import { transformProviderOverrides } from './schemas/execution-overrides-traversal.js';
@@ -316,6 +317,16 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
             status: result.status,
             phases: result.phases?.map(p => `${p.name}:${p.status}`) ?? [],
           });
+
+          if (result.status === 'completed' && task === HARNESS_HEALTH_TASK_NAME) {
+            notifyHarnessHealthFindings({
+              runId: result.runId,
+              projectVaultDir: runVaultDir,
+              config: mycoConfig,
+              projectId: req.requestContext?.projectId ?? undefined,
+              logger,
+            });
+          }
         }
       })
       .catch((err) => {
@@ -438,6 +449,15 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
           provider: result.provider,
           model: result.model,
         });
+
+        if (result.status === 'completed' && run.task === HARNESS_HEALTH_TASK_NAME) {
+          notifyHarnessHealthFindings({
+            runId: result.runId,
+            projectVaultDir: runVaultDir,
+            projectId: req.requestContext?.projectId ?? undefined,
+            logger,
+          });
+        }
       })
       .catch((err) => {
         logger.error(LOG_KINDS.AGENT_ERROR, 'Agent run resume threw unhandled error', {

--- a/packages/myco/src/daemon/task-scheduling.ts
+++ b/packages/myco/src/daemon/task-scheduling.ts
@@ -32,8 +32,10 @@ import {
 import { countToolCallsByRun } from '@myco/db/queries/turns.js';
 import { dispatchAgentRun } from '@myco/agent/runner-host.js';
 import { loadAllTasks } from '@myco/agent/registry.js';
+import type { AgentRunResult } from '@myco/agent/types.js';
 import { notify } from '@myco/notifications/notify.js';
 import { agentRunNotificationLink } from '@myco/notifications/links.js';
+import { HARNESS_HEALTH_TASK_NAME, notifyHarnessHealthFindings } from '@myco/notifications/harness-health-consumer.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { DEFAULT_AGENT_ID, MS_PER_DAY } from '@myco/constants.js';
 import { errorMessage } from '@myco/utils/error-message.js';
@@ -143,10 +145,16 @@ export function decideColdProjectGate(input: ColdProjectGateInput): ColdProjectG
   return active ? { should_run: true, state: 'warm' } : { should_run: false, state: 'cold' };
 }
 
-// These tasks derive their work queue from durable state, so resuming
-// a failed run would collapse history onto a single agent_runs row and
-// erase the failure signal we use to tune turn budgets. Always start fresh.
-const NON_RESUMABLE_SCHEDULED_TASKS = new Set<string>(['canopy-describe', 'canopy-map']);
+// canopy-describe / canopy-map derive their work queue from durable state,
+// so resuming a failed run would collapse history onto a single agent_runs
+// row and erase the failure signal we use to tune turn budgets. Always
+// start fresh. harness-health is non-resumable for a different reason: the
+// scheduled resume branch (dispatchScheduledTask's resumableRun path) emits
+// no completion notifications on its own, so a resumed run would silently
+// skip the harness-health-consumer notification seam — and a stale health
+// report from an old window isn't worth resuming toward anyway. A fresh
+// run always starts a new window.
+const NON_RESUMABLE_SCHEDULED_TASKS = new Set<string>(['canopy-describe', 'canopy-map', 'harness-health']);
 
 /**
  * Scheduled resume retry budget per run. A run that fails this many resumes
@@ -201,6 +209,79 @@ export function gateScheduledResume(input: ScheduledResumeGateInput): 'resume' |
     metadata: { taskName, runId: run.id },
   }, config, { projectId });
   return 'exhausted';
+}
+
+export interface ScheduledRunOutcomeInput {
+  result: Pick<AgentRunResult, 'runId' | 'status' | 'error'>;
+  taskName: string;
+  projectVaultDir: string;
+  projectId: GroveProjectId;
+  config: MycoConfig;
+  logger: DaemonLogger;
+}
+
+/**
+ * Emit the post-dispatch notifications for a scheduled run: task
+ * failure/success, spore/digest activity (from the run's tool calls), and —
+ * for a completed harness-health sentinel — the findings notification
+ * derived from the run's `harness-health` report. Skipped dispatches
+ * (`status: 'skipped'`) emit nothing.
+ */
+export async function notifyScheduledRunOutcome(input: ScheduledRunOutcomeInput): Promise<void> {
+  const { result, taskName, projectVaultDir, projectId, config, logger } = input;
+
+  if (result.status === 'failed') {
+    notify(projectVaultDir, {
+      domain: 'agents',
+      type: 'agent.task.failure',
+      title: `Task failed: ${taskName}`,
+      message: result.error ?? 'Unknown error',
+      link: agentRunNotificationLink(result.runId),
+      metadata: { taskName, runId: result.runId },
+    }, config, { projectId });
+  } else if (result.status === 'completed') {
+    notify(projectVaultDir, {
+      domain: 'agents',
+      type: 'agent.task.success',
+      title: `Task completed: ${taskName}`,
+      link: agentRunNotificationLink(result.runId),
+      metadata: { taskName, runId: result.runId },
+    }, config, { projectId });
+
+    const counts = countToolCallsByRun(result.runId, ['vault_create_spore', 'vault_write_digest']);
+    const sporeCount = counts['vault_create_spore'] ?? 0;
+    const digestCount = counts['vault_write_digest'] ?? 0;
+
+    if (sporeCount > 0) {
+      notify(projectVaultDir, {
+        domain: 'mycelium',
+        type: 'mycelium.spore.created',
+        title: sporeCount === 1 ? 'Extracted 1 observation' : `Extracted ${sporeCount} observations`,
+        message: `From ${taskName} run`,
+        link: '/mycelium?tab=spores',
+        metadata: { count: sporeCount, taskName, runId: result.runId },
+      }, config, { projectId });
+    }
+    if (digestCount > 0) {
+      notify(projectVaultDir, {
+        domain: 'mycelium',
+        type: 'mycelium.digest.completed',
+        title: `Digest updated (${digestCount} ${digestCount === 1 ? 'tier' : 'tiers'})`,
+        link: '/mycelium?tab=digest',
+        metadata: { tierCount: digestCount, taskName, runId: result.runId },
+      }, config, { projectId });
+    }
+
+    if (taskName === HARNESS_HEALTH_TASK_NAME) {
+      await notifyHarnessHealthFindings({
+        runId: result.runId,
+        projectVaultDir,
+        config,
+        projectId,
+        logger,
+      });
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -448,48 +529,14 @@ export async function registerScheduledTasks(
       runId: result.runId,
     });
 
-    if (result.status === 'failed') {
-      notify(projectVaultDir, {
-        domain: 'agents',
-        type: 'agent.task.failure',
-        title: `Task failed: ${taskName}`,
-        message: result.error ?? 'Unknown error',
-        link: agentRunNotificationLink(result.runId),
-        metadata: { taskName, runId: result.runId },
-      }, config, { projectId });
-    } else if (result.status === 'completed') {
-      notify(projectVaultDir, {
-        domain: 'agents',
-        type: 'agent.task.success',
-        title: `Task completed: ${taskName}`,
-        link: agentRunNotificationLink(result.runId),
-        metadata: { taskName, runId: result.runId },
-      }, config, { projectId });
-
-      const counts = countToolCallsByRun(result.runId, ['vault_create_spore', 'vault_write_digest']);
-      const sporeCount = counts['vault_create_spore'] ?? 0;
-      const digestCount = counts['vault_write_digest'] ?? 0;
-
-      if (sporeCount > 0) {
-        notify(projectVaultDir, {
-          domain: 'mycelium',
-          type: 'mycelium.spore.created',
-          title: sporeCount === 1 ? 'Extracted 1 observation' : `Extracted ${sporeCount} observations`,
-          message: `From ${taskName} run`,
-          link: '/mycelium?tab=spores',
-          metadata: { count: sporeCount, taskName, runId: result.runId },
-        }, config, { projectId });
-      }
-      if (digestCount > 0) {
-        notify(projectVaultDir, {
-          domain: 'mycelium',
-          type: 'mycelium.digest.completed',
-          title: `Digest updated (${digestCount} ${digestCount === 1 ? 'tier' : 'tiers'})`,
-          link: '/mycelium?tab=digest',
-          metadata: { tierCount: digestCount, taskName, runId: result.runId },
-        }, config, { projectId });
-      }
-    }
+    await notifyScheduledRunOutcome({
+      result,
+      taskName,
+      projectVaultDir,
+      projectId,
+      config,
+      logger,
+    });
   }
 
   const coldStateKey = (groveId: string, projectId: GroveProjectId) => `${groveId}:${projectId}`;

--- a/packages/myco/src/db/queries/run-health.ts
+++ b/packages/myco/src/db/queries/run-health.ts
@@ -1,0 +1,418 @@
+/**
+ * Aggregate health queries over the three observability tables no
+ * agent-facing tool reads today: agent_run_events, agent_run_write_intents,
+ * agent_runs. Backs `vault_run_health` (agent/tools/observability-tools.ts).
+ *
+ * Aggregate-first by design (repo doctrine: tool gates over self-checks):
+ * every bucket here is deterministic SQL. The agent tool returns these
+ * rows verbatim — a model interprets them, it never re-derives the
+ * anomaly detection itself.
+ *
+ * All functions obtain the SQLite instance internally via `getDatabase()`.
+ * Queries use positional `?` placeholders throughout (better-sqlite3).
+ */
+
+import { getDatabase } from '@myco/db/client.js';
+import { appendProjectCondition, type ProjectScope } from '@myco/db/queries/project-scope.js';
+import { epochSeconds } from '@myco/constants.js';
+import { BUNDLED_AGENT_TASKS } from '@myco/agent/definitions.generated.js';
+
+// ---------------------------------------------------------------------------
+// Shared window helper
+// ---------------------------------------------------------------------------
+
+export interface RunHealthWindow {
+  /** Inclusive lower bound, epoch seconds. */
+  startedAfter: number;
+  /** Upper bound, epoch seconds — always "now" at query time. */
+  endedBefore: number;
+  windowHours: number;
+}
+
+export function resolveRunHealthWindow(windowHours: number, now = epochSeconds()): RunHealthWindow {
+  return {
+    startedAfter: now - Math.max(0, windowHours) * 3600,
+    endedBefore: now,
+    windowHours,
+  };
+}
+
+/** Cap on attribution rows (run ids, task names, etc.) returned per bucket. */
+const DEFAULT_ATTRIBUTION_LIMIT = 25;
+
+// ---------------------------------------------------------------------------
+// 1. unpaired_events — pre/post tool-use count mismatch
+// ---------------------------------------------------------------------------
+
+export interface UnpairedEventGroup {
+  run_id: string;
+  phase_name: string | null;
+  tool_name: string | null;
+  pre_count: number;
+  post_count: number;
+}
+
+/**
+ * Groups of (run_id, phase_name, tool_name) within the window whose
+ * pre_tool_use count differs from its post_tool_use count. `agent_run_events`
+ * has no row-level pairing key, so a count mismatch is the only
+ * deterministic signal available — it does not distinguish "process died
+ * mid-tool" from "a best-effort post insert was swallowed". A count diff
+ * is NOT itself an error signal: post fires even when a tool call ends in
+ * outcome 'error', so a balanced pre/post count with error outcomes is
+ * normal and excluded here by construction (only the count imbalance is
+ * flagged, never individual error rows). Excludes the calling run itself
+ * (`excludeRunId`): the audit wrapper inserts `pre_tool_use` synchronously
+ * before the handler runs (tools.ts) and the matching `post_tool_use` lands
+ * only after the handler returns, so the current `vault_run_health` call's
+ * own in-flight pre row is otherwise a guaranteed false positive on every
+ * invocation. Not filtered by terminal status — a process-death run stays
+ * status='running' forever and is this bucket's primary target.
+ */
+export function findUnpairedEvents(
+  window: RunHealthWindow,
+  scope: ProjectScope,
+  excludeRunId: string,
+  limit = DEFAULT_ATTRIBUTION_LIMIT,
+): UnpairedEventGroup[] {
+  const db = getDatabase();
+  const conditions = [
+    'event_type IN (\'pre_tool_use\', \'post_tool_use\')',
+    'recorded_at >= ?',
+    'recorded_at <= ?',
+    'run_id != ?',
+  ];
+  const params: unknown[] = [window.startedAfter, window.endedBefore, excludeRunId];
+  appendProjectCondition(conditions, params, scope);
+  const rows = db.prepare(
+    `SELECT
+       run_id,
+       phase_name,
+       tool_name,
+       SUM(CASE WHEN event_type = 'pre_tool_use' THEN 1 ELSE 0 END) AS pre_count,
+       SUM(CASE WHEN event_type = 'post_tool_use' THEN 1 ELSE 0 END) AS post_count
+     FROM agent_run_events
+     WHERE ${conditions.join(' AND ')}
+     GROUP BY run_id, phase_name, tool_name
+     HAVING pre_count != post_count
+     ORDER BY run_id ASC
+     LIMIT ?`,
+  ).all(...params, limit) as Array<Record<string, unknown>>;
+  return rows.map((row) => ({
+    run_id: row.run_id as string,
+    phase_name: (row.phase_name as string) ?? null,
+    tool_name: (row.tool_name as string) ?? null,
+    pre_count: Number(row.pre_count),
+    post_count: Number(row.post_count),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// 2. cap_hits + postcondition_failures — actions_taken JSON flags
+// ---------------------------------------------------------------------------
+
+export interface PhaseFlagHit {
+  run_id: string;
+  task: string | null;
+  phase_name: string | null;
+}
+
+/**
+ * Runs in the window whose `actions_taken.phases[]` carries a phase entry
+ * with the given boolean flag set to true. Detects via the JSON payload
+ * (`buildPhaseResult` in executor-state.ts writes `capHit`/
+ * `postConditionFailed` only when `=== true`, on both success and failure
+ * paths) — NOT via error-string matching. The executor's postcondition
+ * error text (`Phase "…" postcondition "…" not satisfied: …`) is an
+ * internal message that does not reliably survive to a matchable column;
+ * matching it returns zero rows. The JSON flag is the only deterministic
+ * signal.
+ */
+function findPhaseFlagHits(
+  flagKey: 'capHit' | 'postConditionFailed',
+  window: RunHealthWindow,
+  scope: ProjectScope,
+  limit: number,
+): PhaseFlagHit[] {
+  const db = getDatabase();
+  const conditions = [
+    'r.actions_taken IS NOT NULL',
+    'r.started_at >= ?',
+    'r.started_at <= ?',
+  ];
+  const params: unknown[] = [window.startedAfter, window.endedBefore];
+  appendProjectCondition(conditions, params, scope, 'r');
+  const rows = db.prepare(
+    `SELECT DISTINCT r.id AS run_id, r.task AS task, json_extract(phase.value, '$.name') AS phase_name
+     FROM agent_runs r, json_each(json_extract(r.actions_taken, '$.phases')) AS phase
+     WHERE ${conditions.join(' AND ')}
+       AND json_extract(phase.value, '$.${flagKey}') = 1
+     ORDER BY r.id ASC
+     LIMIT ?`,
+  ).all(...params, limit) as Array<Record<string, unknown>>;
+  return rows.map((row) => ({
+    run_id: row.run_id as string,
+    task: (row.task as string) ?? null,
+    phase_name: (row.phase_name as string) ?? null,
+  }));
+}
+
+export function findCapHits(
+  window: RunHealthWindow,
+  scope: ProjectScope,
+  limit = DEFAULT_ATTRIBUTION_LIMIT,
+): PhaseFlagHit[] {
+  return findPhaseFlagHits('capHit', window, scope, limit);
+}
+
+export function findPostConditionFailures(
+  window: RunHealthWindow,
+  scope: ProjectScope,
+  limit = DEFAULT_ATTRIBUTION_LIMIT,
+): PhaseFlagHit[] {
+  return findPhaseFlagHits('postConditionFailed', window, scope, limit);
+}
+
+// ---------------------------------------------------------------------------
+// 3. cost_spikes — per (task, provider) mean cost vs trailing window
+// ---------------------------------------------------------------------------
+
+export interface CostSpike {
+  task: string | null;
+  provider: string | null;
+  window_mean_cost_usd: number;
+  window_run_count: number;
+  trailing_mean_cost_usd: number;
+  trailing_run_count: number;
+  ratio: number;
+}
+
+interface CostAggRow {
+  task: string | null;
+  provider: string | null;
+  mean_cost: number;
+  run_count: number;
+}
+
+function aggregateCostByTaskProvider(
+  startedAfter: number,
+  endedBefore: number,
+  scope: ProjectScope,
+): CostAggRow[] {
+  const db = getDatabase();
+  const conditions = [
+    'started_at >= ?',
+    'started_at <= ?',
+    // Local providers hard-zero costUsd — a mixed mean of real and
+    // hard-zeroed costs masks genuine spikes, so zero-cost rows are
+    // excluded from the mean rather than segmented by provider alone.
+    'cost_usd IS NOT NULL',
+    'cost_usd != 0',
+  ];
+  const params: unknown[] = [startedAfter, endedBefore];
+  appendProjectCondition(conditions, params, scope);
+  const rows = db.prepare(
+    `SELECT task, provider, AVG(cost_usd) AS mean_cost, COUNT(*) AS run_count
+     FROM agent_runs
+     WHERE ${conditions.join(' AND ')}
+     GROUP BY task, provider`,
+  ).all(...params) as Array<Record<string, unknown>>;
+  return rows.map((row) => ({
+    task: (row.task as string) ?? null,
+    provider: (row.provider as string) ?? null,
+    mean_cost: Number(row.mean_cost ?? 0),
+    run_count: Number(row.run_count ?? 0),
+  }));
+}
+
+/**
+ * (task, provider) pairs whose mean cost_usd in the window exceeds the
+ * mean cost_usd in the trailing window (the window immediately before it,
+ * same length) by at least `spikeRatio`. Zero-cost rows (local providers
+ * hard-zero costUsd) are excluded from both means so a mixed population
+ * never masks a real spike. Requires at least one run with nonzero cost
+ * in both windows to compute a ratio — a (task, provider) with no
+ * trailing baseline is not reported (nothing to compare against).
+ */
+export function findCostSpikes(
+  window: RunHealthWindow,
+  scope: ProjectScope,
+  spikeRatio: number,
+): CostSpike[] {
+  const spanSeconds = window.endedBefore - window.startedAfter;
+  const trailingStart = window.startedAfter - spanSeconds;
+  const trailingEnd = window.startedAfter;
+
+  const current = aggregateCostByTaskProvider(window.startedAfter, window.endedBefore, scope);
+  const trailing = aggregateCostByTaskProvider(trailingStart, trailingEnd, scope);
+  const trailingByKey = new Map(trailing.map((row) => [`${row.task ?? ''} ${row.provider ?? ''}`, row]));
+
+  const spikes: CostSpike[] = [];
+  for (const row of current) {
+    const key = `${row.task ?? ''} ${row.provider ?? ''}`;
+    const base = trailingByKey.get(key);
+    if (!base || base.mean_cost <= 0) continue;
+    const ratio = row.mean_cost / base.mean_cost;
+    if (ratio >= spikeRatio) {
+      spikes.push({
+        task: row.task,
+        provider: row.provider,
+        window_mean_cost_usd: row.mean_cost,
+        window_run_count: row.run_count,
+        trailing_mean_cost_usd: base.mean_cost,
+        trailing_run_count: base.run_count,
+        ratio,
+      });
+    }
+  }
+  return spikes.sort((a, b) => b.ratio - a.ratio);
+}
+
+// ---------------------------------------------------------------------------
+// 4. flag_clusters — semantic-check 'flag' write intents
+// ---------------------------------------------------------------------------
+
+export interface FlagClusterEntry {
+  run_id: string;
+  task: string | null;
+  tool_name: string;
+  classifier_reason: string | null;
+  recorded_at: number;
+}
+
+/**
+ * Write intents in the window whose classifier_verdict is the literal
+ * string 'flag' — the semantic check ran and blocked the write. This is
+ * NOT the same population as "every write_intents row": dry-run
+ * interception (wrapToolWithDryRun in agent/tools.ts) inserts a row for
+ * every intercepted write with classifier_verdict left NULL, so an
+ * unfiltered count over agent_run_write_intents is dominated by ordinary
+ * dry-run traffic, not flagged writes.
+ */
+export function findFlagClusters(
+  window: RunHealthWindow,
+  scope: ProjectScope,
+  limit = DEFAULT_ATTRIBUTION_LIMIT,
+): FlagClusterEntry[] {
+  const db = getDatabase();
+  const conditions = [
+    'wi.classifier_verdict = \'flag\'',
+    'wi.recorded_at >= ?',
+    'wi.recorded_at <= ?',
+  ];
+  const params: unknown[] = [window.startedAfter, window.endedBefore];
+  appendProjectCondition(conditions, params, scope, 'wi');
+  const rows = db.prepare(
+    `SELECT wi.run_id AS run_id, r.task AS task, wi.tool_name AS tool_name,
+            wi.classifier_reason AS classifier_reason, wi.recorded_at AS recorded_at
+     FROM agent_run_write_intents wi
+     LEFT JOIN agent_runs r ON r.id = wi.run_id
+     WHERE ${conditions.join(' AND ')}
+     ORDER BY wi.recorded_at DESC
+     LIMIT ?`,
+  ).all(...params, limit) as Array<Record<string, unknown>>;
+  return rows.map((row) => ({
+    run_id: row.run_id as string,
+    task: (row.task as string) ?? null,
+    tool_name: row.tool_name as string,
+    classifier_reason: (row.classifier_reason as string) ?? null,
+    recorded_at: Number(row.recorded_at),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// 5. zero_usage — completed/failed runs with zero telemetry
+// ---------------------------------------------------------------------------
+
+export interface ZeroUsageRun {
+  run_id: string;
+  task: string | null;
+  status: string;
+}
+
+/**
+ * Completed runs with tokens_used = 0, plus failed runs whose usage
+ * telemetry is entirely zero/absent (tokens_used = 0 AND cost_usd is
+ * NULL or 0). The failed-run half is an honest info-tier signal, not an
+ * alarm: it flags runs whose failure telemetry was unrecoverable, not a
+ * claim that every failed local run qualifies (a failed run with partial
+ * usage recorded before the failure is excluded).
+ */
+export function findZeroUsageRuns(
+  window: RunHealthWindow,
+  scope: ProjectScope,
+  limit = DEFAULT_ATTRIBUTION_LIMIT,
+): ZeroUsageRun[] {
+  const db = getDatabase();
+  const conditions = [
+    'started_at >= ?',
+    'started_at <= ?',
+    `(
+       (status = 'completed' AND COALESCE(tokens_used, 0) = 0)
+       OR (status = 'failed' AND COALESCE(tokens_used, 0) = 0 AND COALESCE(cost_usd, 0) = 0)
+     )`,
+  ];
+  const params: unknown[] = [window.startedAfter, window.endedBefore];
+  appendProjectCondition(conditions, params, scope);
+  const rows = db.prepare(
+    `SELECT id AS run_id, task, status
+     FROM agent_runs
+     WHERE ${conditions.join(' AND ')}
+     ORDER BY started_at DESC
+     LIMIT ?`,
+  ).all(...params, limit) as Array<Record<string, unknown>>;
+  return rows.map((row) => ({
+    run_id: row.run_id as string,
+    task: (row.task as string) ?? null,
+    status: row.status as string,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// 6. silent_streams — YAML-default-enabled tasks with zero runs
+// ---------------------------------------------------------------------------
+
+export interface SilentStream {
+  task: string;
+  interval_seconds: number;
+}
+
+/**
+ * Tasks that are enabled-by-default in the bundled YAML schedule (no
+ * per-project myco.yaml override applied — `resolveSchedule` in
+ * task-scheduler.ts is module-private and not reachable from a query
+ * module, so this reads BUNDLED_AGENT_TASKS directly) with no task-level
+ * `preCondition` gate, that produced zero runs in the window. Info-tier
+ * only: a task can be legitimately quiet (nothing to do, or a myco.yaml
+ * override disabled it) — this bucket's description exists to point an
+ * operator at "check whether this is expected", never to alarm on its
+ * own. The bundled-YAML default is an honest approximation of the
+ * effective schedule, not the effective schedule itself.
+ */
+export function findSilentStreams(
+  window: RunHealthWindow,
+  scope: ProjectScope,
+): SilentStream[] {
+  const candidates = BUNDLED_AGENT_TASKS.filter(
+    (task) => task.schedule?.enabled === true && !task.schedule?.preCondition,
+  );
+  if (candidates.length === 0) return [];
+
+  const db = getDatabase();
+  const conditions = ['task = ?', 'started_at >= ?', 'started_at <= ?'];
+  const baseParams: unknown[] = [window.startedAfter, window.endedBefore];
+
+  const silent: SilentStream[] = [];
+  for (const task of candidates) {
+    const params = [task.name, ...baseParams];
+    const conds = [...conditions];
+    appendProjectCondition(conds, params, scope);
+    const row = db.prepare(
+      `SELECT COUNT(*) AS count FROM agent_runs WHERE ${conds.join(' AND ')}`,
+    ).get(...params) as { count: number };
+    if (Number(row.count) === 0) {
+      silent.push({ task: task.name, interval_seconds: task.schedule!.intervalSeconds });
+    }
+  }
+  return silent;
+}

--- a/packages/myco/src/notifications/domains.ts
+++ b/packages/myco/src/notifications/domains.ts
@@ -16,6 +16,7 @@ export function registerBuiltinDomains(): void {
       { id: 'agent.task.success', label: 'Task completed', defaultMode: 'summary', defaultLevel: 'success' },
       { id: 'agent.task.failure', label: 'Task failed', defaultMode: 'summary', defaultLevel: 'error' },
       { id: 'agent.write.flagged', label: 'Destructive write flagged', defaultMode: 'banner', defaultLevel: 'error' },
+      { id: 'agent.harness-health.findings', label: 'Harness health findings', defaultMode: 'summary', defaultLevel: 'warning' },
     ],
   });
 

--- a/packages/myco/src/notifications/harness-health-consumer.ts
+++ b/packages/myco/src/notifications/harness-health-consumer.ts
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Consumer that turns a completed `harness-health` sentinel run into a
+ * notification. Agent tools cannot emit notifications themselves — this is
+ * the daemon-side seam that notices the run's `vault_report` (action
+ * `harness-health`) and surfaces its findings.
+ *
+ * Called from three completion seams: the scheduler's own dispatch
+ * (`dispatchScheduledTask`), the manual-run API handler (`handleRun`), and
+ * the manual-resume API handler (`handleResumeRun`). Read-only and
+ * best-effort — never mutates a run or report, and never throws into the
+ * caller's completion handling.
+ */
+
+import { listReports } from '@myco/db/queries/reports.js';
+import { asPlainRecord } from '@myco/agent/phase-postconditions.js';
+import { notify } from './notify.js';
+import { agentRunNotificationLink } from './links.js';
+import type { MycoConfig } from '@myco/config/schema.js';
+import type { GroveProjectId } from '@myco/grove/ids.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+import { LOG_KINDS } from '@myco/constants/log-kinds.js';
+import { errorMessage } from '@myco/utils/error-message.js';
+
+export const HARNESS_HEALTH_TASK_NAME = 'harness-health';
+const HARNESS_HEALTH_REPORT_ACTION = 'harness-health';
+
+/** Minimal logger surface the consumer needs — matches DaemonLogger. */
+export interface HarnessHealthConsumerLogger {
+  warn: (kind: string, message: string, metadata?: Record<string, unknown>) => void;
+}
+
+export interface NotifyHarnessHealthFindingsInput {
+  runId: string;
+  projectVaultDir: string;
+  config?: MycoConfig;
+  projectId?: GroveProjectId;
+  logger: HarnessHealthConsumerLogger;
+}
+
+const MAX_LISTED_BUCKETS = 5;
+const MAX_LISTED_RUN_IDS = 3;
+const MAX_LISTED_TASKS = 5;
+const MAX_METADATA_ATTRIBUTIONS = 10;
+
+/**
+ * A bucket's findings as an entry list. Tolerates both report shapes: a
+ * plain array of findings, or the `vault_run_health` tool's
+ * `{ description, entries: [...] }` object — where `description` is always
+ * present, so key count alone would misreport an empty bucket as non-empty.
+ */
+function bucketEntries(value: unknown): unknown[] | null {
+  if (Array.isArray(value)) return value;
+  if (value !== null && typeof value === 'object') {
+    const entries = (value as Record<string, unknown>).entries;
+    if (Array.isArray(entries)) return entries;
+  }
+  return null;
+}
+
+/** True when a bucket's value carries at least one finding. */
+function bucketHasFindings(value: unknown): boolean {
+  const entries = bucketEntries(value);
+  if (entries) return entries.length > 0;
+  if (value !== null && typeof value === 'object') return Object.keys(value).length > 0;
+  if (value === null || value === undefined) return false;
+  return Boolean(value);
+}
+
+/** Number of findings in a bucket, for the notification summary. */
+function bucketCount(value: unknown): number {
+  const entries = bucketEntries(value);
+  if (entries) return entries.length;
+  if (value !== null && typeof value === 'object') return Object.keys(value).length;
+  return 1;
+}
+
+/**
+ * Distinct task names and run ids attributed across all bucket entries.
+ * Entries mirror `vault_run_health` attribution rows (`task`, `run_id`),
+ * but the report is agent-authored — extraction is lenient (also accepts
+ * `runId`, skips non-object entries) and purely additive.
+ */
+function collectAttributions(nonEmpty: Array<[string, unknown]>): { tasks: string[]; runIds: string[] } {
+  const tasks = new Set<string>();
+  const runIds = new Set<string>();
+  for (const [, value] of nonEmpty) {
+    for (const entry of bucketEntries(value) ?? []) {
+      if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) continue;
+      const record = entry as Record<string, unknown>;
+      if (typeof record.task === 'string' && record.task.length > 0) tasks.add(record.task);
+      const runId = record.run_id ?? record.runId;
+      if (typeof runId === 'string' && runId.length > 0) runIds.add(runId);
+    }
+  }
+  return { tasks: [...tasks], runIds: [...runIds] };
+}
+
+function capped(values: string[], max: number): string {
+  const shown = values.slice(0, max);
+  const remainder = values.length - shown.length;
+  return remainder > 0 ? `${shown.join(', ')} and ${remainder} more` : shown.join(', ');
+}
+
+function summarizeBuckets(nonEmpty: Array<[string, unknown]>): {
+  title: string;
+  message: string;
+  tasks: string[];
+  runIds: string[];
+} {
+  const bucketNames = nonEmpty.map(([name]) => name);
+  const title = nonEmpty.length === 1
+    ? `Harness health: ${bucketNames[0]}`
+    : `Harness health: ${nonEmpty.length} anomaly buckets`;
+
+  const parts = nonEmpty.map(([name, value]) => `${name} (${bucketCount(value)})`);
+  const shown = parts.slice(0, MAX_LISTED_BUCKETS);
+  const remainder = parts.length - shown.length;
+  let message = remainder > 0
+    ? `${shown.join(', ')}, and ${remainder} more`
+    : shown.join(', ');
+
+  const { tasks, runIds } = collectAttributions(nonEmpty);
+  if (tasks.length > 0) message += ` — tasks: ${capped(tasks, MAX_LISTED_TASKS)}`;
+  if (runIds.length > 0) message += `${tasks.length > 0 ? ';' : ' —'} runs: ${capped(runIds, MAX_LISTED_RUN_IDS)}`;
+
+  return { title, message, tasks, runIds };
+}
+
+/**
+ * Read the latest `harness-health` report for a completed run and, if it
+ * contains any non-empty anomaly buckets, emit a single `agents` domain
+ * notification summarizing them. No-ops (without throwing) when there is
+ * no report, the report's `details` isn't a plain object, or every bucket
+ * is empty.
+ */
+async function notifyHarnessHealthFindingsInner(input: NotifyHarnessHealthFindingsInput): Promise<void> {
+  const { runId, projectVaultDir, config, projectId } = input;
+
+  const reports = listReports(runId, { scope: ALL_PROJECTS_SCOPE });
+  let latest: (typeof reports)[number] | undefined;
+  for (let index = reports.length - 1; index >= 0; index -= 1) {
+    if (reports[index]?.action === HARNESS_HEALTH_REPORT_ACTION) {
+      latest = reports[index];
+      break;
+    }
+  }
+  if (!latest) return;
+
+  const details = asPlainRecord(latest.details);
+  if (!details) return;
+
+  const nonEmpty = Object.entries(details).filter(([, value]) => bucketHasFindings(value));
+  if (nonEmpty.length === 0) return;
+
+  const { title, message, tasks, runIds } = summarizeBuckets(nonEmpty);
+
+  notify(projectVaultDir, {
+    domain: 'agents',
+    type: 'agent.harness-health.findings',
+    title,
+    message,
+    link: agentRunNotificationLink(runId),
+    metadata: {
+      runId,
+      buckets: nonEmpty.map(([name, value]) => ({ name, count: bucketCount(value) })),
+      affectedTasks: tasks.slice(0, MAX_METADATA_ATTRIBUTIONS),
+      affectedRunIds: runIds.slice(0, MAX_METADATA_ATTRIBUTIONS),
+    },
+  }, config, projectId ? { projectId } : undefined);
+}
+
+/**
+ * Best-effort wrapper — logs and swallows any error instead of propagating
+ * into the caller's run-completion flow.
+ */
+export async function notifyHarnessHealthFindings(input: NotifyHarnessHealthFindingsInput): Promise<void> {
+  try {
+    await notifyHarnessHealthFindingsInner(input);
+  } catch (err) {
+    input.logger.warn(LOG_KINDS.AGENT_ERROR, 'Failed to emit harness-health findings notification', {
+      runId: input.runId,
+      error: errorMessage(err),
+    });
+  }
+}

--- a/packages/myco/ui/src/components/agent/EventsPanel.tsx
+++ b/packages/myco/ui/src/components/agent/EventsPanel.tsx
@@ -1,0 +1,172 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, Loader2 } from 'lucide-react';
+import { useRunEvents } from '../../hooks/use-agent';
+import { Badge } from '../ui/badge';
+import { Surface } from '../ui/surface';
+import { cn } from '../../lib/cn';
+import { formatEpochRelative } from '../../lib/format';
+import type { RunEventRow } from '../../hooks/use-agent';
+
+/* ---------- Props ---------- */
+
+export interface EventsPanelProps {
+  runId: string;
+  runStatus?: string;
+  className?: string;
+}
+
+/* ---------- Helpers ---------- */
+
+/** Payload is truncated at render time so a pathological tool result never lands whole in the DOM. */
+const PAYLOAD_PREVIEW_CHARS = 2_048;
+
+function eventTypeBadgeVariant(eventType: string): 'default' | 'warning' | 'destructive' | 'secondary' | 'outline' {
+  switch (eventType) {
+    case 'phase_start':
+    case 'phase_end':
+      return 'secondary';
+    case 'pre_tool_use':
+    case 'post_tool_use':
+      return 'default';
+    default:
+      // Unrecognized event_type values (the column is open TEXT) still render — just with a neutral variant.
+      return 'outline';
+  }
+}
+
+function outcomeBadgeVariant(outcome: string | null): 'default' | 'warning' | 'destructive' | 'secondary' {
+  if (outcome === 'error') return 'destructive';
+  if (outcome === 'success') return 'default';
+  return 'secondary';
+}
+
+/** Pretty-print the payload for display, truncated so a large tool result never lands whole in the DOM. */
+function formatPayloadPreview(payload: unknown): string {
+  const text = typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2);
+  if (text.length <= PAYLOAD_PREVIEW_CHARS) return text;
+  return `${text.slice(0, PAYLOAD_PREVIEW_CHARS)}\n… (truncated)`;
+}
+
+/* ---------- Event row ---------- */
+
+function EventItem({ event }: { event: RunEventRow }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasPayload = event.payload !== null && event.payload !== undefined;
+
+  return (
+    <div
+      role={hasPayload ? 'button' : undefined}
+      tabIndex={hasPayload ? 0 : undefined}
+      className={cn(
+        'px-4 py-2.5 border-b border-outline-variant/10 last:border-b-0 transition-colors',
+        hasPayload && 'hover:bg-surface-container-high/30 cursor-pointer',
+      )}
+      onClick={hasPayload ? () => setExpanded(!expanded) : undefined}
+      onKeyDown={hasPayload ? (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          setExpanded(!expanded);
+        }
+      } : undefined}
+      aria-expanded={hasPayload ? expanded : undefined}
+    >
+      <div className="flex items-start gap-3">
+        <span className="font-mono text-xs text-on-surface-variant shrink-0 pt-0.5 min-w-[100px]">
+          {formatEpochRelative(event.recorded_at)}
+        </span>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            {hasPayload && (
+              expanded
+                ? <ChevronDown className="h-3 w-3 shrink-0 text-on-surface-variant" />
+                : <ChevronRight className="h-3 w-3 shrink-0 text-on-surface-variant" />
+            )}
+            <Badge variant={eventTypeBadgeVariant(event.event_type)} className="font-mono">
+              {event.event_type}
+            </Badge>
+            {event.phase_name && (
+              <span className="font-sans text-xs text-on-surface-variant">{event.phase_name}</span>
+            )}
+            {event.tool_name && (
+              <span className="font-mono text-xs font-medium text-on-surface">{event.tool_name}</span>
+            )}
+            {event.outcome && (
+              <Badge variant={outcomeBadgeVariant(event.outcome)}>{event.outcome}</Badge>
+            )}
+            {event.duration_ms !== null && (
+              <span className="font-mono text-xs text-on-surface-variant">{event.duration_ms}ms</span>
+            )}
+          </div>
+
+          {expanded && hasPayload && (
+            <pre className="mt-1.5 rounded-md bg-surface-container-lowest p-2.5 font-mono text-xs whitespace-pre-wrap overflow-x-auto max-h-48 text-on-surface-variant">
+              {formatPayloadPreview(event.payload)}
+            </pre>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ---------- EventsPanel ---------- */
+
+/**
+ * Harness lifecycle event stream for a run — pre/post tool-use and
+ * phase-start/phase-end rows in recorded order. Pre/post pairing is purely
+ * visual: rows render in insertion order, with no attempt to nest or
+ * correlate matching pairs. Runs captured before the event stream shipped
+ * (pre-#611) have no rows here; that renders as a quiet empty state rather
+ * than an error.
+ */
+export function EventsPanel({ runId, runStatus, className }: EventsPanelProps) {
+  const { events, isPending, isError } = useRunEvents(runId, runStatus);
+
+  if (isPending) {
+    return (
+      <div className={cn('flex items-center gap-2 text-on-surface-variant py-4', className)}>
+        <Loader2 className="h-4 w-4 animate-spin" />
+        <span className="font-sans text-sm">Loading events...</span>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Surface level="low" className={cn('flex h-20 items-center justify-center', className)}>
+        <span className="font-sans text-sm text-tertiary">Failed to load events</span>
+      </Surface>
+    );
+  }
+
+  if (events.length === 0) {
+    return (
+      <div className={cn('space-y-3', className)}>
+        <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">
+          Events
+        </p>
+        <Surface level="low" className="flex h-20 items-center justify-center">
+          <span className="font-sans text-sm text-on-surface-variant italic">
+            No lifecycle events recorded for this run.
+          </span>
+        </Surface>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('space-y-3', className)}>
+      <p className="font-sans text-[11px] uppercase tracking-wide text-on-surface-variant">
+        Events
+        <span className="ml-2 text-on-surface normal-case font-normal">
+          {events.length} {events.length === 1 ? 'event' : 'events'}
+        </span>
+      </p>
+      <Surface level="low" className="overflow-hidden">
+        {events.map((event) => (
+          <EventItem key={event.id} event={event} />
+        ))}
+      </Surface>
+    </div>
+  );
+}

--- a/packages/myco/ui/src/components/agent/RunDetail.tsx
+++ b/packages/myco/ui/src/components/agent/RunDetail.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../hooks/use-agent';
 import { RunTaskDialog } from './RunTaskDialog';
 import { AuditTrail } from './AuditTrail';
+import { EventsPanel } from './EventsPanel';
 import { formatEpochRelative, capitalize } from '../../lib/format';
 import { formatCost, formatTokens, formatDuration, resolveTaskName, statusBadgeVariant } from './helpers';
 import { PhaseTimeline, type PhaseResult } from './PhaseTimeline';
@@ -651,6 +652,9 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
 
       {/* Phase audit — always available */}
       <AuditTrail runId={run.id} runStatus={run.status} />
+
+      {/* Harness lifecycle events — always available (empty for pre-events runs) */}
+      <EventsPanel runId={run.id} runStatus={run.status} />
 
       {/* Decisions / Reports */}
       <div className="space-y-3">

--- a/packages/myco/ui/src/hooks/use-agent.ts
+++ b/packages/myco/ui/src/hooks/use-agent.ts
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
 import { usePowerQuery } from './use-power-query';
 import { fetchJson, postJson, putJson, deleteJson } from '../lib/api';
@@ -30,6 +31,16 @@ const TERMINAL_STATUSES = new Set(['completed', 'failed', 'skipped']);
 
 /** Poll interval for audit trail turns. */
 const TURNS_POLL_INTERVAL = POLL_INTERVALS.STATS;
+
+/** Poll interval for the run events stream (matches other live run-detail surfaces). */
+const RUN_EVENTS_POLL_INTERVAL = POLL_INTERVALS.RUN_DETAIL;
+
+/**
+ * Server-side page size for `GET /agent/runs/:id/events` (mirrors
+ * `AGENT_RUN_EVENTS_LIMIT` in `daemon/api/agent-runs.ts`). A response at
+ * exactly this count means more rows may be waiting past the cursor.
+ */
+const RUN_EVENTS_PAGE_LIMIT = 1000;
 
 /** Cache TTL for available task definitions (60 seconds — rarely changes). */
 const TASKS_STALE_TIME = 60_000;
@@ -178,6 +189,24 @@ export interface TurnRow {
   tool_output_summary: string | null;
   started_at: number | null;
   completed_at: number | null;
+}
+
+/**
+ * Harness lifecycle event row (`GET /agent/runs/:id/events`). `event_type`
+ * is an open TEXT column on the backend — new event kinds can appear
+ * without a UI release, so consumers must render unrecognized values
+ * gracefully rather than switching exhaustively over a closed set.
+ */
+export interface RunEventRow {
+  id: number;
+  run_id: string;
+  phase_name: string | null;
+  event_type: string;
+  tool_name: string | null;
+  outcome: string | null;
+  duration_ms: number | null;
+  payload: unknown;
+  recorded_at: number;
 }
 
 /**
@@ -332,6 +361,12 @@ export interface WriteIntentsResponse {
   count: number;
 }
 
+/** Response shape for `GET /agent/runs/:id/events` — no cursor field; the id of the last row IS the cursor. */
+export interface RunEventsResponse {
+  events: RunEventRow[];
+  count: number;
+}
+
 export interface AuditResponse {
   audit: PhaseAudit;
 }
@@ -464,6 +499,85 @@ export function useAgentTurns(runId: string | undefined, runStatus?: string) {
     pollCategory: 'standard',
     refetchInterval: isTerminal ? false : TURNS_POLL_INTERVAL,
   });
+}
+
+/**
+ * Tail the harness lifecycle event stream for a run.
+ *
+ * Unlike the other run-detail hooks, this endpoint has no cursor field in
+ * its response — the highest `id` among the events already fetched IS the
+ * cursor. Each poll requests `?since=<cursor>` and the new rows are
+ * appended to accumulated state; nothing is ever dropped or replaced client
+ * side. Polling runs at `POLL_INTERVALS.RUN_DETAIL` while `runStatus` is
+ * non-terminal (see `TERMINAL_STATUSES`); a terminal run fetches once and
+ * stops. A response that comes back at the server page limit
+ * (`RUN_EVENTS_PAGE_LIMIT`) means more rows are waiting past the cursor, so
+ * an immediate manual `refetch()` is triggered rather than waiting out the
+ * rest of the poll interval. Accumulated state resets whenever `runId`
+ * changes.
+ *
+ * The query key caches only the LAST incremental (`?since=`) page, not the
+ * full event history — so a warm react-query cache is unsafe to read on
+ * remount: within `gcTime` the cache still holds that stale tail page, and
+ * the effect below would append it to freshly-reset (empty) local `events`
+ * state, producing a cursor jumped past unseen events or duplicated rows.
+ * `gcTime: 0` / `staleTime: 0` force every remount to start cold instead of
+ * replaying that cached tail page. Event ids are also deduped on append as a
+ * second, independent guard.
+ */
+export function useRunEvents(runId: string | undefined, runStatus?: string) {
+  const isTerminal = runStatus ? TERMINAL_STATUSES.has(runStatus) : false;
+
+  const [events, setEvents] = useState<RunEventRow[]>([]);
+  const cursorRef = useRef<number | undefined>(undefined);
+  const runIdRef = useRef<string | undefined>(runId);
+  const seenIdsRef = useRef<Set<number>>(new Set());
+
+  // Reset accumulated state and cursor whenever the run being viewed changes.
+  if (runIdRef.current !== runId) {
+    runIdRef.current = runId;
+    cursorRef.current = undefined;
+    seenIdsRef.current = new Set();
+    if (events.length > 0) setEvents([]);
+  }
+
+  const query = usePowerQuery<RunEventsResponse>({
+    queryKey: ['agent-run-events', runId],
+    queryFn: ({ signal }) => {
+      const qs = cursorRef.current !== undefined ? `?since=${cursorRef.current}` : '';
+      return fetchJson<RunEventsResponse>(`/agent/runs/${runId}/events${qs}`, { signal });
+    },
+    enabled: runId !== undefined,
+    pollCategory: 'standard',
+    refetchInterval: isTerminal ? false : RUN_EVENTS_POLL_INTERVAL,
+    // Never serve a cached incremental page to a fresh mount — see the
+    // doc comment above.
+    gcTime: 0,
+    staleTime: 0,
+  });
+
+  const { data, refetch } = query;
+
+  useEffect(() => {
+    if (!data || runIdRef.current !== runId) return;
+    if (data.events.length > 0) {
+      const fresh = data.events.filter((e) => !seenIdsRef.current.has(e.id));
+      if (fresh.length > 0) {
+        for (const e of fresh) seenIdsRef.current.add(e.id);
+        const maxId = fresh.reduce((max, e) => (e.id > max ? e.id : max), cursorRef.current ?? 0);
+        cursorRef.current = maxId;
+        setEvents((prev) => [...prev, ...fresh]);
+      }
+    }
+    // A full page means more rows are waiting past the new cursor — catch up
+    // immediately instead of waiting for the next scheduled poll tick.
+    if (data.count === RUN_EVENTS_PAGE_LIMIT) {
+      void refetch();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, runId]);
+
+  return { ...query, events };
 }
 
 export function useAgentTasks() {

--- a/tests/agent/harness-properties.test.ts
+++ b/tests/agent/harness-properties.test.ts
@@ -253,6 +253,11 @@ describe('harness properties', () => {
       // unconditionally; the gather phase absorbs the no-op cases before
       // any LLM cost.
       'canopy-map',
+      // A sentinel task is deliberately unconditional — it must run every
+      // interval regardless of vault state to detect silence itself
+      // (the silent_streams bucket depends on the schedule firing even
+      // when there is nothing anomalous to report).
+      'harness-health',
     ];
 
     for (const file of yamlFiles) {

--- a/tests/agent/loader.test.ts
+++ b/tests/agent/loader.test.ts
@@ -30,7 +30,7 @@ import type { AgentDefinition, AgentTask } from '@myco/agent/types.js';
 // ---------------------------------------------------------------------------
 
 /** Number of built-in task YAML files. */
-const EXPECTED_TASK_COUNT = 14;
+const EXPECTED_TASK_COUNT = 15;
 
 /** Built-in agent name from agent.yaml. */
 const BUILT_IN_AGENT_NAME = 'myco-agent';

--- a/tests/agent/phase-postconditions.test.ts
+++ b/tests/agent/phase-postconditions.test.ts
@@ -6,6 +6,7 @@
  *   - skill-generate-validate
  *   - skill-survey-reconcile-queue
  *   - skill-survey-persist-decisions
+ *   - harness-health-report
  *
  * Each validator is deterministic DB reads only; these tests seed
  * agent_reports / agent_state / agent_run_write_intents rows directly and
@@ -412,6 +413,200 @@ describe('phase postconditions — new kinds', () => {
     it('fails a dry run with zero tool calls, same as live', () => {
       const result = checkPhasePostCondition('skill-survey-persist-decisions', baseInput({ dryRun: true, projectId: null }));
       expect(result.passed).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // harness-health-report
+  // ---------------------------------------------------------------------
+
+  describe('harness-health-report', () => {
+    it('fails when the phase completes with zero tool calls (no report at all)', () => {
+      const result = checkPhasePostCondition('harness-health-report', baseInput());
+      expect(result.passed).toBe(false);
+      expect(result.reason).toBe('harness-health completed without a harness-health report');
+    });
+
+    it('passes when a harness-health report has parseable details', () => {
+      insertReport({
+        run_id: TEST_RUN_ID,
+        agent_id: DEFAULT_AGENT_ID,
+        action: 'harness-health',
+        summary: '2 anomaly buckets: cap_hits, cost_spikes',
+        details: JSON.stringify({
+          unpaired_events: { description: 'no anomalies', entries: [] },
+          cap_hits: { description: '1 phase hit its budget', entries: [{ run_id: 'run-x', task: 'skill-evolve' }] },
+        }),
+        created_at: epochSeconds(),
+      });
+
+      const result = checkPhasePostCondition('harness-health-report', baseInput());
+      expect(result.passed).toBe(true);
+    });
+
+    it('fails when details are unparseable (not a plain object)', () => {
+      insertReport({
+        run_id: TEST_RUN_ID,
+        agent_id: DEFAULT_AGENT_ID,
+        action: 'harness-health',
+        summary: 'malformed',
+        details: JSON.stringify(['not', 'an', 'object']),
+        created_at: epochSeconds(),
+      });
+
+      const result = checkPhasePostCondition('harness-health-report', baseInput());
+      expect(result.passed).toBe(false);
+      expect(result.reason).toBe('harness-health completed without parseable harness-health report details');
+    });
+
+    it('fails when details is an empty object', () => {
+      insertReport({
+        run_id: TEST_RUN_ID,
+        agent_id: DEFAULT_AGENT_ID,
+        action: 'harness-health',
+        summary: 'empty',
+        details: JSON.stringify({}),
+        created_at: epochSeconds(),
+      });
+
+      const result = checkPhasePostCondition('harness-health-report', baseInput());
+      expect(result.passed).toBe(false);
+      expect(result.reason).toBe('harness-health completed without parseable harness-health report details');
+    });
+
+    it('PASSES on an all-clear report — every bucket present with empty entries is a designed success', () => {
+      insertReport({
+        run_id: TEST_RUN_ID,
+        agent_id: DEFAULT_AGENT_ID,
+        action: 'harness-health',
+        summary: 'all clear',
+        details: JSON.stringify({
+          unpaired_events: { description: 'no anomalies in this window', entries: [] },
+          cap_hits: { description: 'no anomalies in this window', entries: [] },
+          postcondition_failures: { description: 'no anomalies in this window', entries: [] },
+          cost_spikes: { description: 'no anomalies in this window', entries: [] },
+          flag_clusters: { description: 'no anomalies in this window', entries: [] },
+          zero_usage: { description: 'no anomalies in this window', entries: [] },
+          silent_streams: { description: 'no anomalies in this window', entries: [] },
+        }),
+        created_at: epochSeconds(),
+      });
+
+      const result = checkPhasePostCondition('harness-health-report', baseInput());
+      expect(result.passed).toBe(true);
+    });
+
+    it('does not require run_id anywhere in the gate', () => {
+      // The report shape has no run_id key at all — this test documents
+      // that a report without run_id still satisfies the gate.
+      insertReport({
+        run_id: TEST_RUN_ID,
+        agent_id: DEFAULT_AGENT_ID,
+        action: 'harness-health',
+        summary: 'all clear',
+        details: JSON.stringify({ zero_usage: { description: 'no anomalies', entries: [] } }),
+        created_at: epochSeconds(),
+      });
+
+      const result = checkPhasePostCondition('harness-health-report', baseInput());
+      expect(result.passed).toBe(true);
+    });
+
+    it('takes the LAST matching report — first parseable, last empty FAILS', () => {
+      insertReport({
+        run_id: TEST_RUN_ID,
+        agent_id: DEFAULT_AGENT_ID,
+        action: 'harness-health',
+        summary: 'first attempt',
+        details: JSON.stringify({ cap_hits: { description: 'ok', entries: [] } }),
+        created_at: epochSeconds(),
+      });
+      insertReport({
+        run_id: TEST_RUN_ID,
+        agent_id: DEFAULT_AGENT_ID,
+        action: 'harness-health',
+        summary: 'second attempt (malformed)',
+        details: JSON.stringify({}),
+        created_at: epochSeconds() + 1,
+      });
+
+      const result = checkPhasePostCondition('harness-health-report', baseInput());
+      expect(result.passed).toBe(false);
+    });
+
+    it('is identical on dry runs (vault_report is dry-run exempt)', () => {
+      insertReport({
+        run_id: TEST_RUN_ID,
+        agent_id: DEFAULT_AGENT_ID,
+        action: 'harness-health',
+        summary: 'all clear',
+        details: JSON.stringify({ zero_usage: { description: 'no anomalies', entries: [] } }),
+        created_at: epochSeconds(),
+      });
+
+      const result = checkPhasePostCondition('harness-health-report', baseInput({ dryRun: true, projectId: null }));
+      expect(result.passed).toBe(true);
+    });
+
+    it('fails a dry run with zero tool calls, same as live', () => {
+      const result = checkPhasePostCondition('harness-health-report', baseInput({ dryRun: true, projectId: null }));
+      expect(result.passed).toBe(false);
+      expect(result.reason).toBe('harness-health completed without a harness-health report');
+    });
+
+    // Structural enforcement (repo doctrine): a bucket that is a plain
+    // object MUST carry an `entries` array, or the gate fails the phase
+    // boundary instead of letting the consumer silently misread a dropped
+    // entries array as "no findings".
+    it('FAILS when a bucket is a described-but-entries-less object', () => {
+      insertReport({
+        run_id: TEST_RUN_ID,
+        agent_id: DEFAULT_AGENT_ID,
+        action: 'harness-health',
+        summary: 'model narrated the bucket as prose and dropped entries',
+        details: JSON.stringify({
+          unpaired_events: { description: 'no anomalies in this window' },
+        }),
+        created_at: epochSeconds(),
+      });
+
+      const result = checkPhasePostCondition('harness-health-report', baseInput());
+      expect(result.passed).toBe(false);
+      expect(result.reason).toBe('harness-health report bucket "unpaired_events" is missing its entries array');
+    });
+
+    it('PASSES a well-formed { description, entries: [] } bucket', () => {
+      insertReport({
+        run_id: TEST_RUN_ID,
+        agent_id: DEFAULT_AGENT_ID,
+        action: 'harness-health',
+        summary: 'well-formed bucket',
+        details: JSON.stringify({
+          unpaired_events: { description: 'no anomalies in this window', entries: [] },
+        }),
+        created_at: epochSeconds(),
+      });
+
+      const result = checkPhasePostCondition('harness-health-report', baseInput());
+      expect(result.passed).toBe(true);
+    });
+
+    it('does not require array/scalar top-level details keys to carry entries', () => {
+      insertReport({
+        run_id: TEST_RUN_ID,
+        agent_id: DEFAULT_AGENT_ID,
+        action: 'harness-health',
+        summary: 'mixed shapes',
+        details: JSON.stringify({
+          zero_usage: { description: 'no anomalies', entries: [] },
+          note: 'a scalar top-level key',
+          tags: ['info-tier'],
+        }),
+        created_at: epochSeconds(),
+      });
+
+      const result = checkPhasePostCondition('harness-health-report', baseInput());
+      expect(result.passed).toBe(true);
     });
   });
 });

--- a/tests/agent/schemas.test.ts
+++ b/tests/agent/schemas.test.ts
@@ -206,6 +206,7 @@ describe('PhaseDefinitionSchema', () => {
     'skill-generate-validate',
     'skill-survey-reconcile-queue',
     'skill-survey-persist-decisions',
+    'harness-health-report',
   ])('accepts registered postCondition kind %s', (kind) => {
     const result = PhaseDefinitionSchema.parse({
       name: 'phase',

--- a/tests/agent/tools.test.ts
+++ b/tests/agent/tools.test.ts
@@ -32,6 +32,8 @@ import { insertEntity } from '@myco/db/queries/entities.js';
 import { setState } from '@myco/db/queries/agent-state.js';
 import { insertGraphEdge } from '@myco/db/queries/graph-edges.js';
 import { insertResolutionEvent } from '@myco/db/queries/resolution-events.js';
+import { insertRunEvent } from '@myco/db/queries/agent-run-events.js';
+import { insertWriteIntent } from '@myco/db/queries/write-intents.js';
 import { createVaultTools, VAULT_TOOL_COUNT } from '@myco/agent/tools.js';
 import { DEFERRED_STUB_DESCRIPTION } from '@myco/agent/tools/deferred-tools.js';
 import { ALL_VAULT_TOOL_NAMES } from '@myco/agent/tool-names.js';
@@ -1621,6 +1623,119 @@ describe('vault tools', () => {
         `SELECT * FROM agent_reports WHERE run_id = ?`,
       ).all(TEST_RUN_ID);
       expect(rows.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('vault_run_health', () => {
+    it('returns window bounds and every bucket, empty on clean data', async () => {
+      const t = findTool(tools, 'vault_run_health');
+      const result = await t.handler({}, undefined);
+      const health = parseResult(result) as {
+        window: { window_hours: number; started_after: number; ended_before: number };
+        buckets: Record<string, { description: string; entries: unknown[] }>;
+      };
+
+      expect(health.window.window_hours).toBe(24);
+      expect(health.window.started_after).toBeLessThan(health.window.ended_before);
+
+      const bucketNames = [
+        'unpaired_events', 'cap_hits', 'postcondition_failures',
+        'cost_spikes', 'flag_clusters', 'zero_usage', 'silent_streams',
+      ];
+      for (const name of bucketNames) {
+        expect(health.buckets[name]).toBeDefined();
+        expect(typeof health.buckets[name].description).toBe('string');
+      }
+      // TEST_RUN_ID has no events/intents/actions_taken seeded by beforeEach.
+      expect(health.buckets.unpaired_events.entries).toHaveLength(0);
+      expect(health.buckets.cap_hits.entries).toHaveLength(0);
+      expect(health.buckets.postcondition_failures.entries).toHaveLength(0);
+      expect(health.buckets.flag_clusters.entries).toHaveLength(0);
+    });
+
+    it('respects a custom window_hours', async () => {
+      const t = findTool(tools, 'vault_run_health');
+      const result = await t.handler({ window_hours: 6 }, undefined);
+      const health = parseResult(result) as { window: { window_hours: number } };
+      expect(health.window.window_hours).toBe(6);
+    });
+
+    // Sentinel self-observation false positive: the audit wrapper inserts
+    // pre_tool_use synchronously before a tool handler runs (tools.ts), so
+    // vault_run_health's OWN in-flight call always has a pre_tool_use row
+    // with no matching post_tool_use yet at query time. Without excluding
+    // the calling run, this call would always find itself unpaired.
+    it('excludes an unpaired pre/post tool-use group under the CALLING run id (self-observation)', async () => {
+      insertRunEvent({ runId: TEST_RUN_ID, eventType: 'pre_tool_use', phaseName: 'gather', toolName: 'vault_spores' });
+
+      const t = findTool(tools, 'vault_run_health');
+      const result = await t.handler({}, undefined);
+      const health = parseResult(result) as { buckets: Record<string, { entries: Array<{ run_id: string; tool_name: string }> }> };
+      expect(health.buckets.unpaired_events.entries).toHaveLength(0);
+    });
+
+    it('still detects an unpaired pre/post tool-use group under a DIFFERENT run id', async () => {
+      createRun('run-other-caller', TEST_AGENT_ID);
+      insertRunEvent({ runId: 'run-other-caller', eventType: 'pre_tool_use', phaseName: 'gather', toolName: 'vault_spores' });
+
+      const t = findTool(tools, 'vault_run_health');
+      const result = await t.handler({}, undefined);
+      const health = parseResult(result) as { buckets: Record<string, { entries: Array<{ run_id: string; tool_name: string }> }> };
+      expect(health.buckets.unpaired_events.entries).toHaveLength(1);
+      expect(health.buckets.unpaired_events.entries[0]).toMatchObject({ run_id: 'run-other-caller', tool_name: 'vault_spores' });
+    });
+
+    it('detects a cap_hit flag from actions_taken JSON', async () => {
+      getDatabase().prepare(`UPDATE agent_runs SET actions_taken = ? WHERE id = ?`).run(
+        JSON.stringify({
+          harness: 'claude-sdk',
+          model: 'sonnet',
+          provider: 'anthropic',
+          phases: [{ name: 'gather', status: 'failed', turnsUsed: 20, tokensUsed: 500, costUsd: 0, capHit: true, summary: 'ran out of turns' }],
+        }),
+        TEST_RUN_ID,
+      );
+
+      const t = findTool(tools, 'vault_run_health');
+      const result = await t.handler({}, undefined);
+      const health = parseResult(result) as { buckets: Record<string, { entries: Array<{ run_id: string; phase_name: string }> }> };
+      expect(health.buckets.cap_hits.entries).toHaveLength(1);
+      expect(health.buckets.cap_hits.entries[0]).toMatchObject({ run_id: TEST_RUN_ID, phase_name: 'gather' });
+      expect(health.buckets.postcondition_failures.entries).toHaveLength(0);
+    });
+
+    it('detects a flag_clusters entry and excludes a null-verdict dry-run intent', async () => {
+      insertWriteIntent({
+        runId: TEST_RUN_ID,
+        toolName: 'vault_create_spore',
+        toolInput: '{}',
+        syntheticOutput: '{}',
+        classifierVerdict: 'flag',
+        classifierReason: 'looked destructive',
+      });
+      insertWriteIntent({
+        runId: TEST_RUN_ID,
+        toolName: 'vault_mark_processed',
+        toolInput: '{}',
+        syntheticOutput: '{}',
+      });
+
+      const t = findTool(tools, 'vault_run_health');
+      const result = await t.handler({}, undefined);
+      const health = parseResult(result) as { buckets: Record<string, { entries: Array<{ run_id: string; tool_name: string }> }> };
+      expect(health.buckets.flag_clusters.entries).toHaveLength(1);
+      expect(health.buckets.flag_clusters.entries[0]).toMatchObject({ run_id: TEST_RUN_ID, tool_name: 'vault_create_spore' });
+    });
+
+    it('lists silent_streams by default and clears an entry once that task has a run', async () => {
+      const t = findTool(tools, 'vault_run_health');
+      const before = parseResult(await t.handler({}, undefined)) as { buckets: Record<string, { entries: Array<{ task: string }> }> };
+      expect(before.buckets.silent_streams.entries.some((e) => e.task === 'canopy-map')).toBe(true);
+
+      insertRun({ id: 'run-canopy-map-health', agent_id: TEST_AGENT_ID, task: 'canopy-map', started_at: epochNow() });
+
+      const after = parseResult(await t.handler({}, undefined)) as { buckets: Record<string, { entries: Array<{ task: string }> }> };
+      expect(after.buckets.silent_streams.entries.some((e) => e.task === 'canopy-map')).toBe(false);
     });
   });
 });

--- a/tests/daemon/api/agent-runs-harness-health-notify.test.ts
+++ b/tests/daemon/api/agent-runs-harness-health-notify.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Seam tests for the harness-health findings consumer wired into the two
+ * agent-run API completion paths:
+ *   - POST /api/agent/run          (handleRun's resultPromise.then)
+ *   - POST /api/agent/runs/:id/resume (handleResumeRun's resultPromise.then)
+ *
+ * Both seams call `notifyHarnessHealthFindings` when a harness-health task
+ * completes. Seam 3 (resume) previously only logged on completion — no
+ * notification path existed at all — so a manually-resumed harness-health
+ * run's `vault_report` produced no notification. These tests assert both
+ * seams now emit the finding notification.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll, mock } from 'bun:test';
+import { vi } from '../../helpers/vi-shim.js';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
+import { getDatabase } from '@myco/db/client.js';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { insertRun } from '@myco/db/queries/runs.js';
+import { insertReport } from '@myco/db/queries/reports.js';
+import { createAgentRunHandlers } from '@myco/daemon/api/agent-runs';
+import type { RouteRequest } from '@myco/daemon/router';
+import { makeTestRequestContext } from '../../helpers/request-context';
+import { DEFAULT_AGENT_ID, epochSeconds } from '@myco/constants.js';
+import { _clearNotifyDedupForTests } from '@myco/notifications/notify.js';
+
+const PROJECT_ID = 'proj_33333333333333333333333333333333';
+const GROVE_ID = 'grove_33333333333333333333333333333333';
+
+// Seeded so the (unmocked) loadMergedConfig has a myco.yaml to read — a
+// top-level mock of @myco/config/loader.js would poison other test files
+// sharing the bundled bun process (see agent-runs-overrides-security.test.ts).
+const VAULT_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-agent-runs-harness-health-'));
+fs.writeFileSync(
+  path.join(VAULT_DIR, 'myco.yaml'),
+  'version: 3\nembedding:\n  provider: ollama\n  model: bge-m3\nnotifications:\n  enabled: true\n',
+  'utf-8',
+);
+
+const runAgentSpy = vi.fn(async () => ({ runId: 'stub', status: 'completed' as const }));
+mock.module('@myco/agent/executor.js', () => ({
+  runAgent: (...args: unknown[]) => runAgentSpy(...args),
+}));
+mock.module('@myco/agent/config-resolver.js', () => ({
+  hasConfiguredProvider: () => true,
+  resolveTaskDefinitionExecution: () => ({}),
+}));
+
+function makeRequest(overrides: Partial<RouteRequest> = {}): RouteRequest {
+  return {
+    params: {},
+    query: {},
+    body: undefined,
+    pathname: '/',
+    requestContext: makeTestRequestContext({ vaultDir: VAULT_DIR, projectId: PROJECT_ID, groveId: GROVE_ID }),
+    ...overrides,
+  } as RouteRequest;
+}
+
+function makeHandlers() {
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return createAgentRunHandlers({
+    vaultDir: VAULT_DIR,
+    resolveEmbeddingManager: () => ({} as never),
+    logger: logger as never,
+  });
+}
+
+function findingsNotificationRow(): { type: string; title: string; project_id: string } | undefined {
+  return getDatabase().prepare(
+    `SELECT type, title, project_id FROM notifications WHERE type = ?`,
+  ).get('agent.harness-health.findings') as { type: string; title: string; project_id: string } | undefined;
+}
+
+describe('harness-health findings notification — agent-run API seams', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    _clearNotifyDedupForTests();
+    runAgentSpy.mockClear();
+    registerAgent({ id: DEFAULT_AGENT_ID, name: 'Test', created_at: epochSeconds() });
+  });
+
+  describe('handleRun (Seam 2)', () => {
+    // handleRun pre-generates the run id and hands it to the executor —
+    // the id isn't known until the (mocked) executor is invoked, so the
+    // agent_runs row (required by agent_reports' FK) and the report are
+    // both seeded from inside the mock implementation, keyed off the real
+    // generated id.
+    it('emits a harness-health findings notification when the completed run is a harness-health task', async () => {
+      runAgentSpy.mockImplementationOnce(async (vaultDir: string, opts: { runId?: string }) => {
+        const runId = opts.runId!;
+        insertRun({
+          id: runId,
+          project_id: PROJECT_ID,
+          agent_id: DEFAULT_AGENT_ID,
+          task: 'harness-health',
+          status: 'completed',
+          started_at: epochSeconds(),
+          completed_at: epochSeconds(),
+        });
+        insertReport({
+          run_id: runId,
+          project_id: PROJECT_ID,
+          agent_id: DEFAULT_AGENT_ID,
+          action: 'harness-health',
+          summary: 'scan',
+          details: JSON.stringify({ stalledRuns: ['run-x'] }),
+          created_at: epochSeconds(),
+        });
+        return { runId, status: 'completed' as const };
+      });
+
+      const { handleRun } = makeHandlers();
+      await handleRun(makeRequest({
+        body: { task: 'harness-health', instruction: 'scan', agentId: DEFAULT_AGENT_ID },
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const row = findingsNotificationRow();
+      expect(row).toBeTruthy();
+      expect(row?.project_id).toBe(PROJECT_ID);
+      expect(row?.title).toContain('stalledRuns');
+    });
+
+    // Symmetry with the resume seam's "does not complete" case below: a
+    // harness-health run that finishes with a non-'completed', non-'failed'
+    // status (e.g. 'skipped') must not fire the consumer either. Before this
+    // fix, handleRun only branched on `result.status === 'failed'` and fired
+    // the consumer for every other status, including 'skipped'.
+    it('does not emit a findings notification when the harness-health run is skipped, not completed', async () => {
+      runAgentSpy.mockImplementationOnce(async (vaultDir: string, opts: { runId?: string }) => {
+        const runId = opts.runId!;
+        insertRun({
+          id: runId,
+          project_id: PROJECT_ID,
+          agent_id: DEFAULT_AGENT_ID,
+          task: 'harness-health',
+          status: 'skipped',
+          started_at: epochSeconds(),
+          completed_at: epochSeconds(),
+        });
+        insertReport({
+          run_id: runId,
+          project_id: PROJECT_ID,
+          agent_id: DEFAULT_AGENT_ID,
+          action: 'harness-health',
+          summary: 'scan',
+          details: JSON.stringify({ stalledRuns: ['run-x'] }),
+          created_at: epochSeconds(),
+        });
+        return { runId, status: 'skipped' as const };
+      });
+
+      const { handleRun } = makeHandlers();
+      await handleRun(makeRequest({
+        body: { task: 'harness-health', instruction: 'scan', agentId: DEFAULT_AGENT_ID },
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(findingsNotificationRow()).toBeFalsy();
+    });
+
+    it('does not emit a findings notification for a completed run of a different task', async () => {
+      runAgentSpy.mockImplementationOnce(async (vaultDir: string, opts: { runId?: string }) => {
+        const runId = opts.runId!;
+        insertRun({
+          id: runId,
+          project_id: PROJECT_ID,
+          agent_id: DEFAULT_AGENT_ID,
+          task: 'vault-evolve',
+          status: 'completed',
+          started_at: epochSeconds(),
+          completed_at: epochSeconds(),
+        });
+        insertReport({
+          run_id: runId,
+          project_id: PROJECT_ID,
+          agent_id: DEFAULT_AGENT_ID,
+          action: 'harness-health',
+          summary: 'scan',
+          details: JSON.stringify({ stalledRuns: ['run-x'] }),
+          created_at: epochSeconds(),
+        });
+        return { runId, status: 'completed' as const };
+      });
+
+      const { handleRun } = makeHandlers();
+      await handleRun(makeRequest({
+        body: { task: 'vault-evolve', instruction: 'go', agentId: DEFAULT_AGENT_ID },
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(findingsNotificationRow()).toBeFalsy();
+    });
+  });
+
+  describe('handleResumeRun (Seam 3 — the gap this task closes)', () => {
+    it('emits a harness-health findings notification when a resumed harness-health run completes', async () => {
+      runAgentSpy.mockImplementationOnce(async () => ({ runId: 'hh-run-resumed', status: 'completed' as const }));
+
+      insertRun({
+        id: 'hh-run-resumed',
+        project_id: PROJECT_ID,
+        agent_id: DEFAULT_AGENT_ID,
+        task: 'harness-health',
+        instruction: 'scan',
+        status: 'failed',
+        resumable: 1,
+        started_at: epochSeconds(),
+      });
+      insertReport({
+        run_id: 'hh-run-resumed',
+        project_id: PROJECT_ID,
+        agent_id: DEFAULT_AGENT_ID,
+        action: 'harness-health',
+        summary: 'scan',
+        details: JSON.stringify({ budgetExhaustion: ['task-a', 'task-b'] }),
+        created_at: epochSeconds(),
+      });
+
+      const { handleResumeRun } = makeHandlers();
+      const response = await handleResumeRun(makeRequest({
+        params: { id: 'hh-run-resumed' },
+        body: { mode: 'manual' },
+      }));
+      expect(response.body).toMatchObject({ ok: true });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const row = findingsNotificationRow();
+      expect(row).toBeTruthy();
+      expect(row?.project_id).toBe(PROJECT_ID);
+      expect(row?.title).toContain('budgetExhaustion');
+    });
+
+    it('does not emit a findings notification when the resumed run is not a harness-health task', async () => {
+      runAgentSpy.mockImplementationOnce(async () => ({ runId: 'other-run-resumed', status: 'completed' as const }));
+
+      insertRun({
+        id: 'other-run-resumed',
+        project_id: PROJECT_ID,
+        agent_id: DEFAULT_AGENT_ID,
+        task: 'vault-evolve',
+        instruction: 'go',
+        status: 'failed',
+        resumable: 1,
+        started_at: epochSeconds(),
+      });
+      insertReport({
+        run_id: 'other-run-resumed',
+        project_id: PROJECT_ID,
+        agent_id: DEFAULT_AGENT_ID,
+        action: 'harness-health',
+        summary: 'scan',
+        details: JSON.stringify({ stalledRuns: ['run-x'] }),
+        created_at: epochSeconds(),
+      });
+
+      const { handleResumeRun } = makeHandlers();
+      await handleResumeRun(makeRequest({
+        params: { id: 'other-run-resumed' },
+        body: { mode: 'manual' },
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(findingsNotificationRow()).toBeFalsy();
+    });
+
+    it('does not emit a findings notification when the resumed harness-health run does not complete', async () => {
+      runAgentSpy.mockImplementationOnce(async () => ({ runId: 'hh-run-still-failed', status: 'failed' as const, error: 'boom' }));
+
+      insertRun({
+        id: 'hh-run-still-failed',
+        project_id: PROJECT_ID,
+        agent_id: DEFAULT_AGENT_ID,
+        task: 'harness-health',
+        instruction: 'scan',
+        status: 'failed',
+        resumable: 1,
+        started_at: epochSeconds(),
+      });
+      insertReport({
+        run_id: 'hh-run-still-failed',
+        project_id: PROJECT_ID,
+        agent_id: DEFAULT_AGENT_ID,
+        action: 'harness-health',
+        summary: 'scan',
+        details: JSON.stringify({ stalledRuns: ['run-x'] }),
+        created_at: epochSeconds(),
+      });
+
+      const { handleResumeRun } = makeHandlers();
+      await handleResumeRun(makeRequest({
+        params: { id: 'hh-run-still-failed' },
+        body: { mode: 'manual' },
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(findingsNotificationRow()).toBeFalsy();
+    });
+  });
+});

--- a/tests/daemon/scheduled-run-outcome.test.ts
+++ b/tests/daemon/scheduled-run-outcome.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Seam tests for the scheduler's post-dispatch notification path
+ * (`notifyScheduledRunOutcome`, called by `dispatchScheduledTask` after
+ * every dispatch). Covers the harness-health findings consumer at the
+ * scheduled seam: a completed harness-health run with an anomalous
+ * `harness-health` report emits the findings notification alongside the
+ * regular task-success notification; other tasks and failed runs do not.
+ *
+ * Exported-function seam (the gateScheduledResume precedent):
+ * `dispatchScheduledTask` is a closure inside `registerScheduledTasks`, and
+ * driving a full scheduler tick would need top-level module mocks that
+ * poison other test files in the same bundled bun process.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
+import { getDatabase } from '@myco/db/client.js';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { insertRun } from '@myco/db/queries/runs.js';
+import { insertReport } from '@myco/db/queries/reports.js';
+import { loadMergedConfig } from '@myco/config/loader.js';
+import { _clearNotifyDedupForTests } from '@myco/notifications/notify.js';
+import { notifyScheduledRunOutcome } from '@myco/daemon/task-scheduling.js';
+import { DEFAULT_AGENT_ID, epochSeconds } from '@myco/constants.js';
+import { assertGroveProjectId } from '@myco/grove/ids.js';
+import type { DaemonLogger } from '@myco/daemon/logger.js';
+
+const TEST_PROJECT_ID = 'proj_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const TEST_PROJECT_SCOPE_ID = assertGroveProjectId(TEST_PROJECT_ID);
+
+const stubLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as unknown as DaemonLogger;
+
+let VAULT_DIR: string;
+
+function seedCompletedRun(runId: string, task: string) {
+  insertRun({
+    id: runId,
+    project_id: TEST_PROJECT_ID,
+    agent_id: DEFAULT_AGENT_ID,
+    task,
+    status: 'completed',
+    started_at: epochSeconds(),
+    completed_at: epochSeconds(),
+  });
+}
+
+function seedAnomalousReport(runId: string) {
+  insertReport({
+    run_id: runId,
+    project_id: TEST_PROJECT_ID,
+    agent_id: DEFAULT_AGENT_ID,
+    action: 'harness-health',
+    summary: 'harness health scan',
+    details: JSON.stringify({
+      cap_hits: [{ run_id: 'run-victim', task: 'skill-evolve', phase_name: 'assess' }],
+    }),
+    created_at: epochSeconds(),
+  });
+}
+
+function notificationTypes(): string[] {
+  const rows = getDatabase().prepare('SELECT type FROM notifications').all() as Array<{ type: string }>;
+  return rows.map((r) => r.type);
+}
+
+function findingsRow(): { title: string; message: string | null } | undefined {
+  return getDatabase().prepare(
+    'SELECT title, message FROM notifications WHERE type = ?',
+  ).get('agent.harness-health.findings') as { title: string; message: string | null } | undefined;
+}
+
+describe('notifyScheduledRunOutcome — scheduled dispatch seam', () => {
+  beforeAll(() => {
+    setupTestDb();
+    VAULT_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-sched-outcome-'));
+    fs.writeFileSync(path.join(VAULT_DIR, 'myco.yaml'), 'version: 3\n');
+  });
+  afterAll(() => {
+    teardownTestDb();
+    fs.rmSync(VAULT_DIR, { recursive: true, force: true });
+  });
+  beforeEach(() => {
+    cleanTestDb();
+    _clearNotifyDedupForTests();
+    registerAgent({ id: DEFAULT_AGENT_ID, name: 'Myco Agent', created_at: epochSeconds() });
+  });
+
+  it('emits the findings notification for a completed harness-health run with an anomalous report', async () => {
+    seedCompletedRun('hh-sched-run', 'harness-health');
+    seedAnomalousReport('hh-sched-run');
+
+    await notifyScheduledRunOutcome({
+      result: { runId: 'hh-sched-run', status: 'completed' },
+      taskName: 'harness-health',
+      projectVaultDir: VAULT_DIR,
+      projectId: TEST_PROJECT_SCOPE_ID,
+      config: loadMergedConfig(VAULT_DIR),
+      logger: stubLogger,
+    });
+
+    const types = notificationTypes();
+    expect(types).toContain('agent.task.success');
+    expect(types).toContain('agent.harness-health.findings');
+    const row = findingsRow();
+    expect(row?.title).toContain('cap_hits');
+    expect(row?.message).toContain('skill-evolve');
+    expect(row?.message).toContain('run-victim');
+  });
+
+  it('does not emit the findings notification for a completed run of another task', async () => {
+    seedCompletedRun('other-sched-run', 'vault-evolve');
+    seedAnomalousReport('other-sched-run');
+
+    await notifyScheduledRunOutcome({
+      result: { runId: 'other-sched-run', status: 'completed' },
+      taskName: 'vault-evolve',
+      projectVaultDir: VAULT_DIR,
+      projectId: TEST_PROJECT_SCOPE_ID,
+      config: loadMergedConfig(VAULT_DIR),
+      logger: stubLogger,
+    });
+
+    const types = notificationTypes();
+    expect(types).toContain('agent.task.success');
+    expect(types).not.toContain('agent.harness-health.findings');
+  });
+
+  it('does not emit the findings notification for a failed harness-health run', async () => {
+    insertRun({
+      id: 'hh-sched-failed',
+      project_id: TEST_PROJECT_ID,
+      agent_id: DEFAULT_AGENT_ID,
+      task: 'harness-health',
+      status: 'failed',
+      started_at: epochSeconds(),
+      completed_at: epochSeconds(),
+      error: 'boom',
+    });
+    seedAnomalousReport('hh-sched-failed');
+
+    await notifyScheduledRunOutcome({
+      result: { runId: 'hh-sched-failed', status: 'failed', error: 'boom' },
+      taskName: 'harness-health',
+      projectVaultDir: VAULT_DIR,
+      projectId: TEST_PROJECT_SCOPE_ID,
+      config: loadMergedConfig(VAULT_DIR),
+      logger: stubLogger,
+    });
+
+    const types = notificationTypes();
+    expect(types).toContain('agent.task.failure');
+    expect(types).not.toContain('agent.harness-health.findings');
+  });
+
+  it('a consumer failure never propagates into the completion path', async () => {
+    seedCompletedRun('hh-sched-resilient', 'harness-health');
+    // Corrupt report details — the consumer parses leniently and no-ops.
+    insertReport({
+      run_id: 'hh-sched-resilient',
+      project_id: TEST_PROJECT_ID,
+      agent_id: DEFAULT_AGENT_ID,
+      action: 'harness-health',
+      summary: 'scan',
+      details: 'not json',
+      created_at: epochSeconds(),
+    });
+
+    await expect(notifyScheduledRunOutcome({
+      result: { runId: 'hh-sched-resilient', status: 'completed' },
+      taskName: 'harness-health',
+      projectVaultDir: VAULT_DIR,
+      projectId: TEST_PROJECT_SCOPE_ID,
+      config: loadMergedConfig(VAULT_DIR),
+      logger: stubLogger,
+    })).resolves.toBeUndefined();
+
+    const types = notificationTypes();
+    expect(types).toContain('agent.task.success');
+    expect(types).not.toContain('agent.harness-health.findings');
+  });
+});

--- a/tests/db/queries/run-health.test.ts
+++ b/tests/db/queries/run-health.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Tests for the run-health aggregate query helpers backing
+ * `vault_run_health`. Each bucket is exercised against a real in-memory
+ * SQLite database: seed the anomaly shape, assert the detector finds it;
+ * seed clean data, assert the detector stays empty.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'bun:test';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
+import { getDatabase } from '@myco/db/client.js';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { insertRun } from '@myco/db/queries/runs.js';
+import { insertRunEvent } from '@myco/db/queries/agent-run-events.js';
+import { insertWriteIntent } from '@myco/db/queries/write-intents.js';
+import {
+  findCapHits,
+  findCostSpikes,
+  findFlagClusters,
+  findPostConditionFailures,
+  findSilentStreams,
+  findUnpairedEvents,
+  findZeroUsageRuns,
+  resolveRunHealthWindow,
+} from '@myco/db/queries/run-health.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+const TEST_AGENT_ID = 'agent-run-health-test';
+
+function seedRun(id: string, overrides: Parameters<typeof insertRun>[0] = { id, agent_id: TEST_AGENT_ID }) {
+  return insertRun({
+    id,
+    agent_id: TEST_AGENT_ID,
+    started_at: epochNow(),
+    ...overrides,
+  });
+}
+
+describe('run-health query helpers', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    registerAgent({ id: TEST_AGENT_ID, name: 'Test', created_at: epochNow() });
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. unpaired_events
+  // -------------------------------------------------------------------------
+
+  describe('findUnpairedEvents', () => {
+    it('detects a run whose pre/post tool-use counts differ', () => {
+      seedRun('run-unpaired');
+      insertRunEvent({ runId: 'run-unpaired', eventType: 'pre_tool_use', phaseName: 'gather', toolName: 'vault_spores' });
+      // No matching post_tool_use — simulates a process death mid-tool.
+
+      const window = resolveRunHealthWindow(24);
+      const found = findUnpairedEvents(window, ALL_PROJECTS_SCOPE, 'run-caller');
+      expect(found).toHaveLength(1);
+      expect(found[0]).toMatchObject({ run_id: 'run-unpaired', tool_name: 'vault_spores', pre_count: 1, post_count: 0 });
+    });
+
+    it('stays empty when every pre_tool_use has a matching post_tool_use', () => {
+      seedRun('run-paired');
+      insertRunEvent({ runId: 'run-paired', eventType: 'pre_tool_use', phaseName: 'gather', toolName: 'vault_spores' });
+      insertRunEvent({ runId: 'run-paired', eventType: 'post_tool_use', phaseName: 'gather', toolName: 'vault_spores', outcome: 'success' });
+
+      const window = resolveRunHealthWindow(24);
+      expect(findUnpairedEvents(window, ALL_PROJECTS_SCOPE, 'run-caller')).toHaveLength(0);
+    });
+
+    it('counts an error-outcome post_tool_use as paired, not unpaired', () => {
+      seedRun('run-tool-error');
+      insertRunEvent({ runId: 'run-tool-error', eventType: 'pre_tool_use', phaseName: 'gather', toolName: 'vault_spores' });
+      insertRunEvent({ runId: 'run-tool-error', eventType: 'post_tool_use', phaseName: 'gather', toolName: 'vault_spores', outcome: 'error' });
+
+      const window = resolveRunHealthWindow(24);
+      expect(findUnpairedEvents(window, ALL_PROJECTS_SCOPE, 'run-caller')).toHaveLength(0);
+    });
+
+    // Mandatory regression test for the sentinel self-observation false
+    // positive: the audit wrapper inserts pre_tool_use synchronously before
+    // the handler runs, so the CALLING run's own in-flight vault_run_health
+    // call would otherwise always appear as a pre=1/post=0 unpaired group.
+    it('excludes an in-flight pre_tool_use event under the CALLING run id', () => {
+      seedRun('run-self-observing');
+      insertRunEvent({ runId: 'run-self-observing', eventType: 'pre_tool_use', phaseName: 'assess', toolName: 'vault_run_health' });
+      // No matching post_tool_use yet — this IS the in-flight call.
+
+      const window = resolveRunHealthWindow(24);
+      const found = findUnpairedEvents(window, ALL_PROJECTS_SCOPE, 'run-self-observing');
+      expect(found).toHaveLength(0);
+    });
+
+    it('still detects the same unpaired shape under a DIFFERENT run id', () => {
+      seedRun('run-other-in-flight');
+      insertRunEvent({ runId: 'run-other-in-flight', eventType: 'pre_tool_use', phaseName: 'assess', toolName: 'vault_run_health' });
+      // No matching post_tool_use — a genuinely different run's in-flight call.
+
+      const window = resolveRunHealthWindow(24);
+      const found = findUnpairedEvents(window, ALL_PROJECTS_SCOPE, 'run-self-observing');
+      expect(found).toHaveLength(1);
+      expect(found[0]).toMatchObject({ run_id: 'run-other-in-flight', tool_name: 'vault_run_health', pre_count: 1, post_count: 0 });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. cap_hits / postcondition_failures
+  // -------------------------------------------------------------------------
+
+  describe('findCapHits / findPostConditionFailures', () => {
+    it('detects a phase with capHit true in actions_taken JSON', () => {
+      seedRun('run-cap-hit');
+      getDatabase().prepare(`UPDATE agent_runs SET actions_taken = ? WHERE id = ?`).run(
+        JSON.stringify({
+          harness: 'claude-sdk',
+          model: 'sonnet',
+          provider: 'anthropic',
+          phases: [{ name: 'gather', status: 'failed', turnsUsed: 20, tokensUsed: 500, costUsd: 0, capHit: true, summary: 'ran out of turns' }],
+        }),
+        'run-cap-hit',
+      );
+
+      const window = resolveRunHealthWindow(24);
+      const hits = findCapHits(window, ALL_PROJECTS_SCOPE);
+      expect(hits).toHaveLength(1);
+      expect(hits[0]).toMatchObject({ run_id: 'run-cap-hit', phase_name: 'gather' });
+      expect(findPostConditionFailures(window, ALL_PROJECTS_SCOPE)).toHaveLength(0);
+    });
+
+    it('detects a phase with postConditionFailed true, including on a failure-path record', () => {
+      seedRun('run-postcondition');
+      getDatabase().prepare(`UPDATE agent_runs SET actions_taken = ?, status = ? WHERE id = ?`).run(
+        JSON.stringify({
+          harness: 'claude-sdk',
+          model: 'sonnet',
+          provider: 'anthropic',
+          phases: [{ name: 'act', status: 'failed', turnsUsed: 5, tokensUsed: 200, costUsd: 0.01, postConditionFailed: true, summary: 'gate rejected' }],
+        }),
+        'failed',
+        'run-postcondition',
+      );
+
+      const window = resolveRunHealthWindow(24);
+      const failures = findPostConditionFailures(window, ALL_PROJECTS_SCOPE);
+      expect(failures).toHaveLength(1);
+      expect(failures[0]).toMatchObject({ run_id: 'run-postcondition', task: null, phase_name: 'act' });
+      expect(findCapHits(window, ALL_PROJECTS_SCOPE)).toHaveLength(0);
+    });
+
+    it('stays empty when actions_taken has phases with no true flags', () => {
+      seedRun('run-clean-phases');
+      getDatabase().prepare(`UPDATE agent_runs SET actions_taken = ? WHERE id = ?`).run(
+        JSON.stringify({
+          harness: 'claude-sdk',
+          model: 'sonnet',
+          provider: 'anthropic',
+          phases: [{ name: 'gather', status: 'completed', turnsUsed: 3, tokensUsed: 100, costUsd: 0.001, summary: 'ok' }],
+        }),
+        'run-clean-phases',
+      );
+
+      const window = resolveRunHealthWindow(24);
+      expect(findCapHits(window, ALL_PROJECTS_SCOPE)).toHaveLength(0);
+      expect(findPostConditionFailures(window, ALL_PROJECTS_SCOPE)).toHaveLength(0);
+    });
+
+    it('stays empty when actions_taken is NULL', () => {
+      seedRun('run-no-actions');
+      const window = resolveRunHealthWindow(24);
+      expect(findCapHits(window, ALL_PROJECTS_SCOPE)).toHaveLength(0);
+      expect(findPostConditionFailures(window, ALL_PROJECTS_SCOPE)).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. cost_spikes
+  // -------------------------------------------------------------------------
+
+  describe('findCostSpikes', () => {
+    it('detects a (task, provider) pair whose window mean exceeds the trailing mean by the ratio', () => {
+      const now = epochNow();
+      const window = resolveRunHealthWindow(24, now);
+      const trailingMid = window.startedAfter - 12 * 3600;
+
+      // Trailing window baseline: mean cost 0.01
+      seedRun('run-trail-1', { id: 'run-trail-1', agent_id: TEST_AGENT_ID, task: 'vault-evolve', provider: 'anthropic', cost_usd: 0.01, started_at: trailingMid });
+      // Current window: mean cost 0.05 (5x)
+      seedRun('run-spike-1', { id: 'run-spike-1', agent_id: TEST_AGENT_ID, task: 'vault-evolve', provider: 'anthropic', cost_usd: 0.05, started_at: now - 60 });
+
+      const spikes = findCostSpikes(window, ALL_PROJECTS_SCOPE, 2);
+      expect(spikes).toHaveLength(1);
+      expect(spikes[0]).toMatchObject({ task: 'vault-evolve', provider: 'anthropic' });
+      expect(spikes[0].ratio).toBeGreaterThanOrEqual(2);
+    });
+
+    it('excludes zero-cost rows (local providers) from both means', () => {
+      const now = epochNow();
+      const window = resolveRunHealthWindow(24, now);
+      const trailingMid = window.startedAfter - 12 * 3600;
+
+      seedRun('run-trail-zero', { id: 'run-trail-zero', agent_id: TEST_AGENT_ID, task: 'skill-evolve', provider: 'ollama', cost_usd: 0, started_at: trailingMid });
+      seedRun('run-window-zero', { id: 'run-window-zero', agent_id: TEST_AGENT_ID, task: 'skill-evolve', provider: 'ollama', cost_usd: 0, started_at: now - 60 });
+
+      const spikes = findCostSpikes(window, ALL_PROJECTS_SCOPE, 2);
+      expect(spikes).toHaveLength(0);
+    });
+
+    it('stays empty when the ratio does not clear the threshold', () => {
+      const now = epochNow();
+      const window = resolveRunHealthWindow(24, now);
+      const trailingMid = window.startedAfter - 12 * 3600;
+
+      seedRun('run-trail-flat', { id: 'run-trail-flat', agent_id: TEST_AGENT_ID, task: 'cortex-instructions', provider: 'anthropic', cost_usd: 0.02, started_at: trailingMid });
+      seedRun('run-window-flat', { id: 'run-window-flat', agent_id: TEST_AGENT_ID, task: 'cortex-instructions', provider: 'anthropic', cost_usd: 0.022, started_at: now - 60 });
+
+      expect(findCostSpikes(window, ALL_PROJECTS_SCOPE, 2)).toHaveLength(0);
+    });
+
+    it('stays empty when there is no trailing baseline to compare against', () => {
+      const window = resolveRunHealthWindow(24);
+      seedRun('run-no-baseline', { id: 'run-no-baseline', agent_id: TEST_AGENT_ID, task: 'vault-evolve', provider: 'anthropic', cost_usd: 0.05, started_at: epochNow() - 60 });
+      expect(findCostSpikes(window, ALL_PROJECTS_SCOPE, 2)).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. flag_clusters
+  // -------------------------------------------------------------------------
+
+  describe('findFlagClusters', () => {
+    it('finds a write intent with classifier_verdict = flag', () => {
+      seedRun('run-flag', { id: 'run-flag', agent_id: TEST_AGENT_ID, task: 'vault-evolve' });
+      insertWriteIntent({
+        runId: 'run-flag',
+        toolName: 'vault_create_spore',
+        toolInput: '{}',
+        syntheticOutput: '{}',
+        classifierVerdict: 'flag',
+        classifierReason: 'looked destructive',
+      });
+
+      const window = resolveRunHealthWindow(24);
+      const clusters = findFlagClusters(window, ALL_PROJECTS_SCOPE);
+      expect(clusters).toHaveLength(1);
+      expect(clusters[0]).toMatchObject({ run_id: 'run-flag', task: 'vault-evolve', tool_name: 'vault_create_spore', classifier_reason: 'looked destructive' });
+    });
+
+    it('excludes dry-run-intercepted intents with a null verdict', () => {
+      seedRun('run-dry-run', { id: 'run-dry-run', agent_id: TEST_AGENT_ID, task: 'vault-evolve' });
+      insertWriteIntent({
+        runId: 'run-dry-run',
+        toolName: 'vault_mark_processed',
+        toolInput: '{}',
+        syntheticOutput: '{}',
+      });
+
+      const window = resolveRunHealthWindow(24);
+      expect(findFlagClusters(window, ALL_PROJECTS_SCOPE)).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. zero_usage
+  // -------------------------------------------------------------------------
+
+  describe('findZeroUsageRuns', () => {
+    it('detects a completed run with tokens_used = 0', () => {
+      seedRun('run-zero-completed', { id: 'run-zero-completed', agent_id: TEST_AGENT_ID, task: 'title-summary', status: 'completed', tokens_used: 0 });
+
+      const window = resolveRunHealthWindow(24);
+      const found = findZeroUsageRuns(window, ALL_PROJECTS_SCOPE);
+      expect(found).toHaveLength(1);
+      expect(found[0]).toMatchObject({ run_id: 'run-zero-completed', task: 'title-summary', status: 'completed' });
+    });
+
+    it('detects a failed run with all-zero usage telemetry', () => {
+      seedRun('run-zero-failed', { id: 'run-zero-failed', agent_id: TEST_AGENT_ID, task: 'title-summary', status: 'failed', tokens_used: 0, cost_usd: 0 });
+
+      const window = resolveRunHealthWindow(24);
+      const found = findZeroUsageRuns(window, ALL_PROJECTS_SCOPE);
+      expect(found).toHaveLength(1);
+      expect(found[0].status).toBe('failed');
+    });
+
+    it('excludes a failed run that recorded partial usage before failing', () => {
+      seedRun('run-partial-failed', { id: 'run-partial-failed', agent_id: TEST_AGENT_ID, task: 'title-summary', status: 'failed', tokens_used: 150, cost_usd: 0.002 });
+
+      const window = resolveRunHealthWindow(24);
+      expect(findZeroUsageRuns(window, ALL_PROJECTS_SCOPE)).toHaveLength(0);
+    });
+
+    it('excludes a completed run with nonzero token usage', () => {
+      seedRun('run-normal-completed', { id: 'run-normal-completed', agent_id: TEST_AGENT_ID, task: 'title-summary', status: 'completed', tokens_used: 400 });
+
+      const window = resolveRunHealthWindow(24);
+      expect(findZeroUsageRuns(window, ALL_PROJECTS_SCOPE)).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. silent_streams
+  // -------------------------------------------------------------------------
+
+  describe('findSilentStreams', () => {
+    it('flags a schedule-enabled, preCondition-free task with zero runs in the window', () => {
+      // canopy-map is bundled with schedule.enabled=true and no preCondition.
+      const window = resolveRunHealthWindow(24);
+      const silent = findSilentStreams(window, ALL_PROJECTS_SCOPE);
+      expect(silent.some((s) => s.task === 'canopy-map')).toBe(true);
+    });
+
+    it('does not flag that task once it has a run in the window', () => {
+      seedRun('run-canopy-map', { id: 'run-canopy-map', agent_id: TEST_AGENT_ID, task: 'canopy-map' });
+
+      const window = resolveRunHealthWindow(24);
+      const silent = findSilentStreams(window, ALL_PROJECTS_SCOPE);
+      expect(silent.some((s) => s.task === 'canopy-map')).toBe(false);
+    });
+
+    it('never flags a task that has a preCondition gate', () => {
+      // skill-generate ships with schedule.enabled=false; vault-evolve/skill-survey
+      // ship enabled=true but WITH a preCondition — neither should ever appear.
+      const window = resolveRunHealthWindow(24);
+      const silent = findSilentStreams(window, ALL_PROJECTS_SCOPE);
+      expect(silent.some((s) => s.task === 'skill-generate')).toBe(false);
+      expect(silent.some((s) => s.task === 'vault-evolve')).toBe(false);
+      expect(silent.some((s) => s.task === 'skill-survey')).toBe(false);
+    });
+  });
+});

--- a/tests/notifications/harness-health-consumer.test.ts
+++ b/tests/notifications/harness-health-consumer.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Unit tests for `notifyHarnessHealthFindings` — the best-effort consumer
+ * that turns a completed `harness-health` sentinel run's report into an
+ * `agents` domain notification. Agent tools cannot emit notifications
+ * themselves, so this is the read-only daemon-side seam that notices the
+ * run's `vault_report` (action `harness-health`) and surfaces its findings.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { vi } from '../helpers/vi-shim.js';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
+import { getDatabase } from '@myco/db/client.js';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { insertRun } from '@myco/db/queries/runs.js';
+import { insertReport } from '@myco/db/queries/reports.js';
+import { _clearNotifyDedupForTests } from '@myco/notifications/notify.js';
+import { notifyHarnessHealthFindings } from '@myco/notifications/harness-health-consumer.js';
+import { DEFAULT_AGENT_ID, epochSeconds } from '@myco/constants.js';
+import { assertGroveProjectId } from '@myco/grove/ids.js';
+
+const TEST_PROJECT_ID = 'proj_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const TEST_PROJECT_SCOPE_ID = assertGroveProjectId(TEST_PROJECT_ID);
+const TEST_RUN_ID = 'run-harness-health-consumer';
+
+function makeLogger() {
+  return { warn: vi.fn() };
+}
+
+function seedRun(overrides: Partial<Parameters<typeof insertRun>[0]> = {}) {
+  insertRun({
+    id: TEST_RUN_ID,
+    project_id: TEST_PROJECT_ID,
+    agent_id: DEFAULT_AGENT_ID,
+    task: 'harness-health',
+    status: 'completed',
+    started_at: epochSeconds(),
+    completed_at: epochSeconds(),
+    ...overrides,
+  });
+}
+
+function seedReport(details: unknown) {
+  insertReport({
+    run_id: TEST_RUN_ID,
+    project_id: TEST_PROJECT_ID,
+    agent_id: DEFAULT_AGENT_ID,
+    action: 'harness-health',
+    summary: 'harness health scan',
+    details: details === undefined ? null : JSON.stringify(details),
+    created_at: epochSeconds(),
+  });
+}
+
+function countNotificationRows(): number {
+  const row = getDatabase().prepare('SELECT COUNT(*) AS n FROM notifications').get() as { n: number };
+  return row.n;
+}
+
+function getLatestNotification(): { type: string; title: string; message: string | null } | undefined {
+  return getDatabase().prepare(
+    'SELECT type, title, message FROM notifications ORDER BY created_at DESC, rowid DESC LIMIT 1',
+  ).get() as { type: string; title: string; message: string | null } | undefined;
+}
+
+describe('notifyHarnessHealthFindings', () => {
+  let VAULT_DIR: string;
+
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    _clearNotifyDedupForTests();
+    registerAgent({ id: DEFAULT_AGENT_ID, name: 'Myco Agent', created_at: epochSeconds() });
+    VAULT_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-harness-health-consumer-'));
+    fs.writeFileSync(path.join(VAULT_DIR, 'myco.yaml'), 'version: 3\n');
+  });
+  afterEach(() => {
+    fs.rmSync(VAULT_DIR, { recursive: true, force: true });
+  });
+
+  it('emits exactly one notification naming the anomaly bucket for a report with findings', async () => {
+    seedRun();
+    seedReport({ stalledRuns: ['run-a', 'run-b'], budgetExhaustion: [] });
+
+    const logger = makeLogger();
+    await notifyHarnessHealthFindings({
+      runId: TEST_RUN_ID,
+      projectVaultDir: VAULT_DIR,
+      projectId: TEST_PROJECT_SCOPE_ID,
+      logger: logger as never,
+    });
+
+    expect(countNotificationRows()).toBe(1);
+    const row = getLatestNotification();
+    expect(row?.type).toBe('agent.harness-health.findings');
+    expect(row?.title).toContain('stalledRuns');
+    expect(row?.message).toContain('stalledRuns');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('includes affected task names and run ids from bucket entries, capping the run-id list', async () => {
+    seedRun();
+    seedReport({
+      cap_hits: [
+        { run_id: 'run-1', task: 'skill-evolve', phase_name: 'assess' },
+        { run_id: 'run-2', task: 'vault-evolve', phase_name: 'extract' },
+      ],
+      zero_usage: [
+        { run_id: 'run-3', task: 'title-summary' },
+        { run_id: 'run-4', task: 'title-summary' },
+        { run_id: 'run-5', task: 'title-summary' },
+      ],
+    });
+
+    const logger = makeLogger();
+    await notifyHarnessHealthFindings({
+      runId: TEST_RUN_ID,
+      projectVaultDir: VAULT_DIR,
+      projectId: TEST_PROJECT_SCOPE_ID,
+      logger: logger as never,
+    });
+
+    expect(countNotificationRows()).toBe(1);
+    const row = getLatestNotification();
+    expect(row?.message).toContain('cap_hits (2)');
+    expect(row?.message).toContain('zero_usage (3)');
+    expect(row?.message).toContain('skill-evolve');
+    expect(row?.message).toContain('vault-evolve');
+    expect(row?.message).toContain('title-summary');
+    // Five distinct run ids, capped at three shown.
+    expect(row?.message).toContain('run-1, run-2, run-3 and 2 more');
+    expect(row?.message).not.toContain('run-4');
+  });
+
+  it('treats vault_run_health-style { description, entries } buckets by their entries, not key count', async () => {
+    seedRun();
+    seedReport({
+      cap_hits: { description: 'phases that hit their turn budget', entries: [] },
+      flag_clusters: { description: 'classifier-blocked writes', entries: [{ run_id: 'run-f', task: 'vault-evolve' }] },
+    });
+
+    const logger = makeLogger();
+    await notifyHarnessHealthFindings({
+      runId: TEST_RUN_ID,
+      projectVaultDir: VAULT_DIR,
+      projectId: TEST_PROJECT_SCOPE_ID,
+      logger: logger as never,
+    });
+
+    expect(countNotificationRows()).toBe(1);
+    const row = getLatestNotification();
+    // The empty-entries bucket must not be reported despite its description key.
+    expect(row?.title).toBe('Harness health: flag_clusters');
+    expect(row?.message).toContain('flag_clusters (1)');
+    expect(row?.message).not.toContain('cap_hits');
+    expect(row?.message).toContain('run-f');
+  });
+
+  it('emits nothing when every vault_run_health-style bucket has empty entries', async () => {
+    seedRun();
+    seedReport({
+      cap_hits: { description: 'phases that hit their turn budget', entries: [] },
+      zero_usage: { description: 'runs with no usage telemetry', entries: [] },
+    });
+
+    const logger = makeLogger();
+    await notifyHarnessHealthFindings({
+      runId: TEST_RUN_ID,
+      projectVaultDir: VAULT_DIR,
+      projectId: TEST_PROJECT_SCOPE_ID,
+      logger: logger as never,
+    });
+
+    expect(countNotificationRows()).toBe(0);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('emits nothing when every bucket is empty', async () => {
+    seedRun();
+    seedReport({ stalledRuns: [], budgetExhaustion: [], costSpikes: {} });
+
+    const logger = makeLogger();
+    await notifyHarnessHealthFindings({
+      runId: TEST_RUN_ID,
+      projectVaultDir: VAULT_DIR,
+      projectId: TEST_PROJECT_SCOPE_ID,
+      logger: logger as never,
+    });
+
+    expect(countNotificationRows()).toBe(0);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('emits nothing and does not throw when no report was seeded', async () => {
+    seedRun();
+
+    const logger = makeLogger();
+    await expect(notifyHarnessHealthFindings({
+      runId: TEST_RUN_ID,
+      projectVaultDir: VAULT_DIR,
+      projectId: TEST_PROJECT_SCOPE_ID,
+      logger: logger as never,
+    })).resolves.toBeUndefined();
+
+    expect(countNotificationRows()).toBe(0);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('emits nothing and does not throw when details is unparseable / non-object', async () => {
+    seedRun();
+    seedReport(undefined);
+    // Overwrite with a raw non-JSON string to exercise the unparseable path.
+    getDatabase().prepare('UPDATE agent_reports SET details = ? WHERE run_id = ?').run('not json', TEST_RUN_ID);
+
+    const logger = makeLogger();
+    await notifyHarnessHealthFindings({
+      runId: TEST_RUN_ID,
+      projectVaultDir: VAULT_DIR,
+      projectId: TEST_PROJECT_SCOPE_ID,
+      logger: logger as never,
+    });
+
+    expect(countNotificationRows()).toBe(0);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('emits nothing and does not throw when details is a JSON array, not an object', async () => {
+    seedRun();
+    seedReport(['stalledRuns', 'budgetExhaustion']);
+
+    const logger = makeLogger();
+    await notifyHarnessHealthFindings({
+      runId: TEST_RUN_ID,
+      projectVaultDir: VAULT_DIR,
+      projectId: TEST_PROJECT_SCOPE_ID,
+      logger: logger as never,
+    });
+
+    expect(countNotificationRows()).toBe(0);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for a report scoped to a run whose task is not harness-health', async () => {
+    // Contract: callers gate on `task === 'harness-health'` before invoking
+    // the helper. Simulate a caller that (incorrectly) invoked it anyway
+    // for an unrelated run/report pairing — no report exists under this
+    // run id with the harness-health action, so it still no-ops safely.
+    insertRun({
+      id: 'run-other-task',
+      project_id: TEST_PROJECT_ID,
+      agent_id: DEFAULT_AGENT_ID,
+      task: 'vault-evolve',
+      status: 'completed',
+      started_at: epochSeconds(),
+      completed_at: epochSeconds(),
+    });
+
+    const logger = makeLogger();
+    await notifyHarnessHealthFindings({
+      runId: 'run-other-task',
+      projectVaultDir: VAULT_DIR,
+      projectId: TEST_PROJECT_SCOPE_ID,
+      logger: logger as never,
+    });
+
+    expect(countNotificationRows()).toBe(0);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('never throws even if the logger itself is missing a warn method (defensive best-effort contract)', async () => {
+    seedRun();
+    seedReport({ stalledRuns: ['x'] });
+
+    // A logger whose warn throws should still not propagate out of the
+    // outer notify call for a successful path (warn isn't invoked here),
+    // but the wrapper's own try/catch is what's under test more broadly —
+    // covered by the "no report" and "unparseable" cases above returning
+    // cleanly without invoking warn.
+    const logger = { warn: vi.fn() };
+    await expect(notifyHarnessHealthFindings({
+      runId: TEST_RUN_ID,
+      projectVaultDir: VAULT_DIR,
+      projectId: TEST_PROJECT_SCOPE_ID,
+      logger: logger as never,
+    })).resolves.toBeUndefined();
+  });
+});

--- a/tests/ui/events-panel.test.tsx
+++ b/tests/ui/events-panel.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EventsPanel } from '../../packages/myco/ui/src/components/agent/EventsPanel';
+import { PowerProvider } from '../../packages/myco/ui/src/providers/power';
+
+const SAMPLE_EVENTS = {
+  events: [
+    {
+      id: 1,
+      run_id: 'run-1',
+      phase_name: 'describe',
+      event_type: 'phase_start',
+      tool_name: null,
+      outcome: null,
+      duration_ms: null,
+      payload: null,
+      recorded_at: 1_700_000_000,
+    },
+    {
+      id: 2,
+      run_id: 'run-1',
+      phase_name: 'describe',
+      event_type: 'pre_tool_use',
+      tool_name: 'Read',
+      outcome: null,
+      duration_ms: null,
+      payload: { path: 'a.ts' },
+      recorded_at: 1_700_000_005,
+    },
+    {
+      id: 3,
+      run_id: 'run-1',
+      phase_name: 'describe',
+      event_type: 'post_tool_use',
+      tool_name: 'Read',
+      outcome: 'success',
+      duration_ms: 42,
+      payload: { path: 'a.ts', bytes: 128 },
+      recorded_at: 1_700_000_006,
+    },
+    {
+      id: 4,
+      run_id: 'run-1',
+      phase_name: 'describe',
+      event_type: 'model_switch',
+      tool_name: null,
+      outcome: null,
+      duration_ms: null,
+      payload: null,
+      recorded_at: 1_700_000_007,
+    },
+  ],
+  count: 4,
+};
+
+beforeEach(() => {
+  // @ts-expect-error — test scaffold
+  globalThis.fetch = mock(async (url: string) => {
+    if (typeof url === 'string' && url.includes('/events')) {
+      return new Response(JSON.stringify(SAMPLE_EVENTS), { status: 200 });
+    }
+    return new Response('{}', { status: 200 });
+  });
+});
+
+function renderPanel(runStatus?: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <PowerProvider>
+      <QueryClientProvider client={client}>
+        <EventsPanel runId="run-1" runStatus={runStatus ?? 'completed'} />
+      </QueryClientProvider>
+    </PowerProvider>,
+  );
+}
+
+describe('EventsPanel', () => {
+  it('renders one row per event with event_type and tool_name', async () => {
+    renderPanel();
+    const readItems = await screen.findAllByText('Read');
+    expect(readItems.length).toBeGreaterThan(0);
+    expect(screen.getByText('phase_start')).toBeDefined();
+    expect(screen.getByText('pre_tool_use')).toBeDefined();
+    expect(screen.getByText('post_tool_use')).toBeDefined();
+  });
+
+  it('renders an unrecognized event_type value as a plain label', async () => {
+    renderPanel();
+    await screen.findAllByText('Read');
+    expect(screen.getByText('model_switch')).toBeDefined();
+  });
+
+  it('expands a row with a payload to show truncated pretty-printed JSON', async () => {
+    renderPanel();
+    const readItems = await screen.findAllByText('Read');
+    const row = readItems
+      .map((el) => el.closest('[role="button"]'))
+      .find((el) => el !== null);
+    expect(row).toBeDefined();
+    fireEvent.click(row!);
+    const jsonContent = screen.getAllByText(/"path": "a.ts"/);
+    expect(jsonContent.length).toBeGreaterThan(0);
+  });
+
+  it('does not make phase_start (no payload) rows expandable', async () => {
+    renderPanel();
+    const phaseStart = await screen.findByText('phase_start');
+    const row = phaseStart.closest('div[role="button"]');
+    expect(row).toBeNull();
+  });
+
+  it('renders empty state when there are no events', async () => {
+    // @ts-expect-error
+    globalThis.fetch = mock(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/events')) {
+        return new Response(JSON.stringify({ events: [], count: 0 }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    });
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <PowerProvider>
+        <QueryClientProvider client={client}>
+          <EventsPanel runId="run-empty" runStatus="completed" />
+        </QueryClientProvider>
+      </PowerProvider>,
+    );
+    await screen.findByText(/no lifecycle events recorded/i);
+    expect(screen.getByText(/no lifecycle events recorded/i)).toBeDefined();
+  });
+
+  it('truncates a large payload at render rather than dumping it whole into the DOM', async () => {
+    const bigPayload = { data: 'x'.repeat(5_000) };
+    // @ts-expect-error
+    globalThis.fetch = mock(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/events')) {
+        return new Response(JSON.stringify({
+          events: [{
+            id: 1,
+            run_id: 'run-1',
+            phase_name: null,
+            event_type: 'post_tool_use',
+            tool_name: 'Write',
+            outcome: 'success',
+            duration_ms: 10,
+            payload: bigPayload,
+            recorded_at: 1_700_000_000,
+          }],
+          count: 1,
+        }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    });
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <PowerProvider>
+        <QueryClientProvider client={client}>
+          <EventsPanel runId="run-1" runStatus="completed" />
+        </QueryClientProvider>
+      </PowerProvider>,
+    );
+    const writeItems = await screen.findAllByText('Write');
+    const row = writeItems.map((el) => el.closest('[role="button"]')).find((el) => el !== null);
+    fireEvent.click(row!);
+    const pre = document.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre!.textContent!.length).toBeLessThan(5_000);
+    expect(pre!.textContent).toContain('truncated');
+  });
+});

--- a/tests/ui/use-run-events.test.tsx
+++ b/tests/ui/use-run-events.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+/**
+ * useRunEvents accumulates lifecycle events across polls client-side — the
+ * `GET /agent/runs/:id/events` endpoint has no cursor field in its response,
+ * so the hook derives `?since=` from the max `id` it has already seen and
+ * appends new rows rather than replacing state. These tests pin that
+ * contract plus the count===1000 immediate-refetch, terminal-status stop,
+ * and runId-change reset behaviors against a real QueryClient.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi } from '../helpers/vi-shim.js';
+import { PowerProvider } from '../../packages/myco/ui/src/providers/power';
+import { useRunEvents, type RunEventRow } from '../../packages/myco/ui/src/hooks/use-agent';
+
+function makeEvent(id: number, overrides: Partial<RunEventRow> = {}): RunEventRow {
+  return {
+    id,
+    run_id: 'run-1',
+    phase_name: 'describe',
+    event_type: 'pre_tool_use',
+    tool_name: 'Read',
+    outcome: null,
+    duration_ms: null,
+    payload: null,
+    recorded_at: 1_700_000_000 + id,
+    ...overrides,
+  };
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return createElement(PowerProvider, null, createElement(QueryClientProvider, { client: qc }, children));
+}
+
+describe('useRunEvents', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('accumulates events across polls and advances the cursor from the max id seen', async () => {
+    const calls: string[] = [];
+    const fetchMock = vi.fn((url: string) => {
+      calls.push(url);
+      if (calls.length === 1) {
+        return Promise.resolve(Response.json({ events: [makeEvent(1), makeEvent(2)], count: 2 }));
+      }
+      return Promise.resolve(Response.json({ events: [makeEvent(3)], count: 1 }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useRunEvents('run-1', 'running'), { wrapper });
+
+    await waitFor(() => expect(result.current.events.length).toBe(2));
+    expect(result.current.events.map((e) => e.id)).toEqual([1, 2]);
+    expect(calls[0]).toContain('/agent/runs/run-1/events');
+    expect(calls[0]).not.toContain('since=');
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    await waitFor(() => expect(result.current.events.length).toBe(3));
+    expect(result.current.events.map((e) => e.id)).toEqual([1, 2, 3]);
+    // Second request carries the cursor advanced to the max id from the first page.
+    expect(calls[1]).toContain('since=2');
+  });
+
+  it('immediately refetches when a page comes back at the server limit (1000)', async () => {
+    const fullPage = Array.from({ length: 1000 }, (_, i) => makeEvent(i + 1));
+    const calls: string[] = [];
+    const fetchMock = vi.fn((url: string) => {
+      calls.push(url);
+      if (calls.length === 1) {
+        return Promise.resolve(Response.json({ events: fullPage, count: 1000 }));
+      }
+      return Promise.resolve(Response.json({ events: [makeEvent(1001)], count: 1 }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useRunEvents('run-1', 'running'), { wrapper });
+
+    // The count===1000 page triggers an automatic follow-up fetch without
+    // the test driving refetch() itself.
+    await waitFor(() => expect(calls.length).toBe(2), { timeout: 3000 });
+    await waitFor(() => expect(result.current.events.length).toBe(1001));
+    expect(calls[1]).toContain('since=1000');
+  });
+
+  it('stops polling once runStatus is terminal (fetches once)', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(Response.json({ events: [makeEvent(1)], count: 1 })),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useRunEvents('run-1', 'completed'), { wrapper });
+
+    await waitFor(() => expect(result.current.events.length).toBe(1));
+    expect(result.current.isFetching).toBe(false);
+    // No refetchInterval is wired for a terminal run — nothing should
+    // schedule a second call on its own.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets accumulated events and the cursor when runId changes', async () => {
+    const calls: string[] = [];
+    const fetchMock = vi.fn((url: string) => {
+      calls.push(url);
+      if (url.includes('run-1')) {
+        return Promise.resolve(Response.json({ events: [makeEvent(1), makeEvent(2)], count: 2 }));
+      }
+      return Promise.resolve(Response.json({ events: [makeEvent(50)], count: 1 }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result, rerender } = renderHook(
+      ({ runId }: { runId: string }) => useRunEvents(runId, 'completed'),
+      { wrapper, initialProps: { runId: 'run-1' } },
+    );
+
+    await waitFor(() => expect(result.current.events.length).toBe(2));
+
+    rerender({ runId: 'run-2' });
+
+    await waitFor(() => expect(result.current.events.map((e) => e.id)).toEqual([50]));
+    // The fetch for run-2 must not carry a stale since= cursor from run-1.
+    const run2Call = calls.find((c) => c.includes('run-2'));
+    expect(run2Call).toBeDefined();
+    expect(run2Call).not.toContain('since=');
+  });
+
+  // Mandatory regression test for the cache-remount corruption bug: with a
+  // warm react-query cache, the query key caches only the LAST incremental
+  // (`?since=`) page. On remount within gcTime, the old code would replay
+  // that cached tail page against freshly-reset (empty) local state,
+  // producing a cursor jumped past unseen events / duplicate appends.
+  // `gcTime: 0` + `staleTime: 0` force a cold remount; the id-based dedupe
+  // is belt-and-braces. Render the hook twice against a SHARED QueryClient
+  // (unmount -> remount) and assert no duplicates and full coverage.
+  it('starts cold on remount against a shared QueryClient — no duplicates, full coverage', async () => {
+    const calls: string[] = [];
+    const fetchMock = vi.fn((url: string) => {
+      calls.push(url);
+      if (calls.length === 1) {
+        // First mount: page 1, cursor advances to id 2.
+        return Promise.resolve(Response.json({ events: [makeEvent(1), makeEvent(2)], count: 2 }));
+      }
+      // Remount: if the hook incorrectly replayed the cached tail page,
+      // this response (page "2") would never even be requested with a
+      // fresh (cursor-less) query — asserted below via the URL shape.
+      return Promise.resolve(Response.json({ events: [makeEvent(1), makeEvent(2), makeEvent(3)], count: 3 }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const sharedWrapper = ({ children }: { children: ReactNode }) =>
+      createElement(PowerProvider, null, createElement(QueryClientProvider, { client: qc }, children));
+
+    const first = renderHook(() => useRunEvents('run-1', 'completed'), { wrapper: sharedWrapper });
+    await waitFor(() => expect(first.result.current.events.length).toBe(2));
+    expect(first.result.current.events.map((e) => e.id)).toEqual([1, 2]);
+
+    first.unmount();
+
+    // Remount within what would have been gcTime under the old defaults —
+    // same QueryClient instance, same query key.
+    const second = renderHook(() => useRunEvents('run-1', 'completed'), { wrapper: sharedWrapper });
+
+    await waitFor(() => expect(second.result.current.events.length).toBe(3));
+    // No duplicates: exactly one entry per id, full coverage of ids 1-3.
+    const ids = second.result.current.events.map((e) => e.id);
+    expect(ids).toEqual([1, 2, 3]);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    // The remount's request must start cold (no stale since= cursor carried
+    // over from the unmounted instance's cached tail page).
+    const remountCall = calls[calls.length - 1];
+    expect(remountCall).not.toContain('since=');
+  });
+});


### PR DESCRIPTION
## What

Adoption Phase 5 of the SDK-alignment follow-up (master plan `4b7d54ba716418ce`, impl plan `4d3385cf293cf79f`): consumers for the agent events stream — the harness-health sentinel and the run events UI.

### `vault_run_health` (read-only agent tool)

Aggregate-first: deterministic SQL computes seven anomaly buckets in tool code; the model interprets, never re-derives. Buckets: unpaired tool events (count-based — no pairing key exists; **the calling run is excluded so the sentinel never observes its own in-flight call**), cap hits + postcondition failures (via `actions_taken.phases[]` JSON flags, not error-string matching), cost spikes per (task, provider) excluding zero-cost local rows, classifier flag clusters (`classifier_verdict='flag'` literal), unrecoverable-usage runs, and silent scheduled streams (YAML-default approximation, honestly caveated). Two-sided registration per #620's tool-names module; project-scoped; bidirectional drift guard covers it automatically.

### harness-health sentinel task + gate

Single required readOnly phase, daily idle/sleep schedule. Always emits exactly one `harness-health` report whose buckets each carry a **mandatory `entries` array** (empty when clean). The new `harness-health-report` postcondition kind (7th) enforces presence + parseability + per-bucket entries arrays at the phase boundary — so a model dropping the mandated key fails fast instead of false-positive-notifying. All-clear reports pass (designed success). Non-resumable by the scheduler (resume bypasses notification seams; stale health isn't worth resuming).

### Three-seam notification consumer

A shared daemon-side consumer reads a completed harness-health run's latest report and notifies (`agent.harness-health.findings`, agents domain) when any bucket has entries — wired at **all three** completion seams: scheduled dispatch (via `notifyScheduledRunOutcome`, extracted byte-equivalent from the inline block), API dispatch, and **API resume, which previously had no notification path at all**. Consumer failures never propagate into completion handling.

### EventsPanel on RunDetail

Stacked section per the AuditTrail pattern: since-cursor accumulation of `GET /api/agent/runs/:id/events` (client-side cursor — the endpoint has no cursor field), 5s polling while running with immediate re-poll on full 1000-row pages, `gcTime: 0` + id-keyed dedupe (warm-cache remounts can't duplicate or skip), pre-render payload truncation (~2KB, bytes-in-DOM bound, not CSS clipping), graceful unknown event types, empty state for pre-#611 runs. Screenshot review against a live run follows post-merge per UI convention.

## Verification

- Pickup review (vs post-#618/#619/#620 main): 1 Critical (stale tool-registration location — #620 moved the group sets) + 1 Major (the third seam) + 5 Minors, all folded before execution.
- Four per-task reviews (incl. an empirical SQLite JSON-coercion check and a three-way prompt↔gate↔consumer contract trace) + whole-branch review, whose pipeline walk caught the **sentinel self-observation false positive** — invisible to per-task fixtures (no live hooks) — fixed with run-id exclusion + the bidirectional test that would have caught it; fix wave re-reviewed and approved.
- `make build` green; full `npm test` green after every commit; `tsc --noEmit` clean.
- Post-merge live gate (plan Task 5): seeded synthetic anomaly + tripped postcondition → one notification naming both buckets, report row, EventsPanel screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
