### PR TITLE
fix(daemon): resume-admission gate — supersede sweep, checkpoint re-validation, unresumable terminal marks

### DIFF
--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -26,8 +26,10 @@ import {
   applyRunUpdate,
   getRun,
   getRunningRunForTask,
+  supersedeEquivalentResumableRuns,
   RESUME_STATUS_READY,
   RESUME_STATUS_SESSION_EXPIRED,
+  RESUME_STATUS_POSTCONDITION_UNSATISFIABLE,
   STATUS_RUNNING,
   STATUS_COMPLETED,
   STATUS_FAILED,
@@ -39,7 +41,7 @@ import { inferHarnessFromProviderType } from './provider-harness.js';
 import { resolveOllamaContextVariants } from './ollama-context.js';
 import { resolveLmStudioContextLoads } from './lmstudio-context.js';
 import { resolveReasoningModel } from './reasoning-levels.js';
-import { validateTaskPostconditions } from './task-postconditions.js';
+import { validateTaskPostconditions, PostconditionUnsatisfiableError } from './task-postconditions.js';
 import {
   CORTEX_INSTRUCTIONS_TASK,
   SKILL_GENERATE_TASK,
@@ -502,6 +504,15 @@ export async function runAgent(
       },
     });
   } else {
+    // Diagnostic gotcha: this OVERWRITES the run row's story on every
+    // resume — started_at (via ...runStart), resumed_at, error, and (if
+    // this attempt itself fails) the checkpoint's postConditionFailed flag
+    // on any phase that succeeds this time. The row reflects only the
+    // LATEST attempt; per-attempt truth for prior attempts lives in the
+    // daemon log + agent_run_events, not in this row. This is exactly why
+    // Part 1's supersede sweep and the Part 1 belt never compare against
+    // started_at (resume-overwritten) and instead use
+    // COALESCE(completed_at, started_at) or completion-time triggers.
     applyRunUpdate(runId, {
       ...runStart,
       provider: effectiveProvider?.type ?? resumedRun.provider ?? null,
@@ -594,6 +605,15 @@ export async function runAgent(
         dryRun: options?.dryRun ?? false,
       });
       if (postconditionError) {
+        // Part 3 of the resume-admission gate: a resume that executed ZERO
+        // fresh phases (every phase this attempt was trusted from the
+        // checkpoint) can never satisfy a missing contract by retrying —
+        // retrying re-runs nothing. Throw the typed error so the catch
+        // block below terminal-marks in one attempt instead of burning the
+        // scheduler's resume budget.
+        if (options?.resumeRunId && result.executedPhaseCount === 0) {
+          throw new PostconditionUnsatisfiableError(postconditionError);
+        }
         throw new Error(postconditionError);
       }
     } else {
@@ -668,6 +688,22 @@ export async function runAgent(
       }),
     }, scope);
 
+    // Part 1 (supersede) primary enforcement: this run just completed, so
+    // any OTHER resumable failed run for the same (agent, task, project
+    // scope, dry_run, instruction) is stale by definition — its checkpoints,
+    // gate verdicts, and watermarks are superseded by this completion.
+    // Terminal-mark it now rather than let the scheduler re-admit it. The
+    // instruction/dry_run pinning in the equivalence key is load-bearing:
+    // without it, this completion would wrongly sweep an unrelated
+    // instruction-scoped failed run (see supersedeEquivalentResumableRuns).
+    supersedeEquivalentResumableRuns(runId, {
+      agentId,
+      taskName: config.taskName,
+      scope,
+      dryRun: options?.dryRun ?? false,
+      instruction: options?.instruction ?? null,
+    });
+
     return {
       runId,
       status: STATUS_COMPLETED,
@@ -734,6 +770,15 @@ export async function runAgent(
         && !recordedAnyTurns
         && (harness.classifyError?.(err, { attemptedResume: true }) === 'session-expired');
 
+      // Part 3 of the resume-admission gate: the typed error thrown at the
+      // run-end seam above means this resume executed ZERO fresh phases and
+      // still failed its postcondition — deterministically unresumable, not
+      // a transient failure worth 3 scheduler retries. Unlike sessionExpired,
+      // checkpoints are PRESERVED (not nulled) — they're not a poisoned
+      // session id, and keeping them lets an operator inspect what the
+      // restored phases actually produced.
+      const postconditionUnsatisfiable = err instanceof PostconditionUnsatisfiableError;
+
       const accountingUpdate = buildRunAccountingUpdate({
         harness: harnessId,
         provider: effectiveProvider,
@@ -747,9 +792,16 @@ export async function runAgent(
         accountingUpdate.checkpoints = null;
       }
 
+      const resumable = sessionExpired || postconditionUnsatisfiable ? 0 : 1;
+      const resumeStatus = sessionExpired
+        ? RESUME_STATUS_SESSION_EXPIRED
+        : postconditionUnsatisfiable
+          ? RESUME_STATUS_POSTCONDITION_UNSATISFIABLE
+          : RESUME_STATUS_READY;
+
       updateRunStatus(runId, STATUS_FAILED, {
-        resumable: sessionExpired ? 0 : 1,
-        resume_status: sessionExpired ? RESUME_STATUS_SESSION_EXPIRED : RESUME_STATUS_READY,
+        resumable,
+        resume_status: resumeStatus,
         completed_at: failedAt,
         tokens_used: usage.totalTokens ?? phaseResults?.reduce((sum, phase) => sum + phase.tokensUsed, 0) ?? undefined,
         error: errorMessage,

--- a/packages/myco/src/agent/phase-loop.ts
+++ b/packages/myco/src/agent/phase-loop.ts
@@ -980,11 +980,97 @@ export async function executePhasedQuery(
   costData: CostResolution;
   usage: RuntimeUsage;
   phases: PhaseResult[];
+  /**
+   * Count of phases actually dispatched through the harness THIS attempt
+   * (fresh work) — phases restored unchanged from checkpoints are excluded.
+   * Zero means every phase in this attempt's plan was trusted from the
+   * checkpoint with none re-executed; the run-end seam in executor.ts uses
+   * this to distinguish a genuinely-stuck resume from a resume that made
+   * progress but still failed its postcondition.
+   */
+  executedPhaseCount: number;
 }> {
   const { config, systemPrompt, vaultContext, agentId, runId } = ctx;
+  const logger = ctx.options?.logger;
   const phases = config.phases!;
   const state = ctx.checkpointState;
-  const phaseResults: PhaseResult[] = checkpointResultsForResume(config, state);
+  let phaseResults: PhaseResult[] = checkpointResultsForResume(config, state);
+
+  // Part 2 of the resume-admission gate: re-validate every RESTORED
+  // `completed` phase that declares a postCondition against the CURRENT
+  // contract before trusting it. checkpointResultsForResume is pure (no
+  // requestContext) — this runs at the production call site instead, where
+  // ctx.requestContext is available. `skipped` phases are never
+  // re-validated: they are a decision the resumed run must honor unchanged
+  // (see checkpointResultsForResume's doc comment on the skip-preservation
+  // invariant), and a gate that never ran the first time has no contract to
+  // have gone stale.
+  //
+  // On failure the demotion does BOTH:
+  //   (a) mutate the checkpoint state entry to status 'failed' +
+  //       postConditionFailed:true, so the reuseSession exclusion below
+  //       forces a fresh session for this phase (same marker the live
+  //       postCondition gate sets — see PhaseCheckpoint.postConditionFailed);
+  //   (b) omit the phase from the returned/local phaseResults, so the
+  //       runnableWave filter re-includes it in the next wave it appears in
+  //       and restoredPhaseNames (below) reflects only what's still trusted.
+  //
+  // Follows the two existing precedents from the live phase-boundary gate:
+  // no requestContext ⇒ loud bypass (contract unverified until run end, same
+  // as agent.phase.postcondition-no-context); a thrown check ⇒ fail OPEN
+  // (a transient SQL error must not demote an otherwise-valid checkpoint).
+  //
+  // Accepted invariant (not fixed here): demoting upstream phase A while a
+  // downstream restored phase B — which consumed A's now-invalid artifact —
+  // stays completed is accepted by the existing restore invariant
+  // (executor-state.ts). The run-end validator remains the backstop.
+  for (const phase of phases) {
+    if (!phase.postCondition) continue;
+    const restored = state.phases[phase.name];
+    if (!restored || restored.status !== 'completed') continue;
+
+    let postCheck: PhasePostConditionResult | null = null;
+    if (!ctx.requestContext) {
+      logger?.warn(
+        'agent.phase.postcondition-no-context',
+        `Restored phase ${phase.name} declares postCondition "${phase.postCondition}" but no requestContext is available — re-validation bypassed; contract unverified until run end.`,
+        { runId: ctx.runId, phase: phase.name, postCondition: phase.postCondition },
+      );
+      continue;
+    }
+    try {
+      postCheck = checkPhasePostCondition(phase.postCondition, {
+        runId: ctx.runId,
+        agentId: ctx.agentId,
+        projectId: rowProjectIdFromRequestContext(ctx.requestContext),
+        dryRun: ctx.config.dryRun === true,
+      });
+    } catch (err) {
+      logger?.warn('agent.phase.postcondition-error', `Restored phase ${phase.name} postCondition re-validation threw — keeping restored result`, {
+        runId: ctx.runId,
+        phase: phase.name,
+        postCondition: phase.postCondition,
+        error: toErrorMessage(err),
+      });
+      continue;
+    }
+    if (postCheck.passed) continue;
+
+    logger?.warn('agent.phase.postcondition-failed', `Restored phase ${phase.name} postcondition "${phase.postCondition}" no longer satisfied: ${postCheck.reason} — demoting for re-execution`, {
+      runId: ctx.runId,
+      phase: phase.name,
+      postCondition: phase.postCondition,
+    });
+
+    state.phases[phase.name] = {
+      ...restored,
+      status: 'failed',
+      postConditionFailed: true,
+      updatedAt: epochSeconds(),
+    };
+    phaseResults = phaseResults.filter((result) => result.name !== phase.name);
+  }
+
   const restoredPhaseNames = new Set(phaseResults.map((phase) => phase.name));
   // Allocation-based audit offsets: the running base advances by each wave's
   // total ALLOCATED turns (sum of resolved maxTurns), never by actual turns
@@ -993,6 +1079,15 @@ export async function executePhasedQuery(
   // never collide.
   let runningTurnCount = 0;
   const completedPhaseNames = new Set(phaseResults.map((phase) => phase.name));
+
+  // Part 3 of the resume-admission gate: phases actually dispatched through
+  // executePhase/executeMapPhase THIS attempt (fresh work, including any
+  // phase Part 2 demoted above) — distinct from phases trusted as restored.
+  // `recordedAnyTurns` in the executor's catch block can't make this
+  // distinction (a restored checkpoint carries its ORIGINAL turnsUsed/usage,
+  // so it looks identical to fresh work by that measure); this counter is
+  // the actual executed/restored signal the run-end seam needs.
+  const executedPhaseNames = new Set<string>();
 
   // -------------------------------------------------------------------------
   // Orchestrator planning (opt-in via config.orchestrator.enabled)
@@ -1120,6 +1215,7 @@ export async function executePhasedQuery(
     }
 
     const runnableWave = wave.filter((phase) => !completedPhaseNames.has(phase.name));
+    for (const phase of runnableWave) executedPhaseNames.add(phase.name);
     if (runnableWave.length === 0) {
       runningTurnCount += waveAllocatedTurns;
       continue;
@@ -1396,5 +1492,6 @@ export async function executePhasedQuery(
     costData,
     usage,
     phases: phaseResults,
+    executedPhaseCount: executedPhaseNames.size,
   };
 }

--- a/packages/myco/src/agent/task-postconditions.ts
+++ b/packages/myco/src/agent/task-postconditions.ts
@@ -13,6 +13,27 @@ interface PostconditionInput {
 
 type PostconditionValidator = (input: PostconditionInput) => string | null;
 
+/**
+ * Part 3 of the resume-admission gate. Thrown at the run-end validator
+ * throw site (executor.ts) instead of a generic Error when BOTH are true:
+ * the run was a resume (`options.resumeRunId` set) AND
+ * `executePhasedQuery`'s `executedPhaseCount === 0` — every phase in this
+ * attempt's plan was trusted from the checkpoint with none re-executed.
+ *
+ * Distinguishes a deterministically-unresumable run from an ordinary
+ * postcondition failure: retrying an all-restored resume can never satisfy
+ * the missing contract, because retrying re-runs nothing. The executor's
+ * catch block terminal-marks via `instanceof` — `resumable=0`,
+ * `resume_status='postcondition_unsatisfiable'` — in ONE attempt instead of
+ * burning the scheduler's full resume budget on a run that cannot recover.
+ */
+export class PostconditionUnsatisfiableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PostconditionUnsatisfiableError';
+  }
+}
+
 /** True when `updated` is a number or numeric string equal to zero (NaN/empty-string/other types excluded). */
 function isZeroUpdateValue(updated: unknown): boolean {
   if (typeof updated !== 'number' && typeof updated !== 'string') return false;

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -7,7 +7,14 @@
 
 import { z } from 'zod';
 import { resolveProjectRoot } from '@myco/vault/resolve.js';
-import { listRuns, countRuns, getRun } from '@myco/db/queries/runs.js';
+import {
+  listRuns,
+  countRuns,
+  getRun,
+  findNewerCompletedEquivalentRun,
+  applyRunUpdate,
+  RESUME_STATUS_SUPERSEDED,
+} from '@myco/db/queries/runs.js';
 import { getRunActivityBuckets, getRunBranches } from '@myco/db/queries/activity-buckets.js';
 import { listReports } from '@myco/db/queries/reports.js';
 import { listTurnsByRun } from '@myco/db/queries/turns.js';
@@ -422,6 +429,35 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
     }
     if (run.resumable !== 1 || run.status !== 'failed') {
       return { status: 400, body: { error: 'Run is not resumable' } };
+    }
+
+    // Belt for the manual endpoint (Part 1 secondary): a newer completed
+    // equivalent run (same agent/task/project scope/dry_run/instruction)
+    // makes this run's checkpoints stale even though nothing has swept it
+    // yet (race with the completion-time sweep, or a legacy row from
+    // before the sweep existed). Terminal-mark here — same write this
+    // endpoint already owns via the 400 above — and refuse with 409,
+    // naming the superseding run and pointing at "Rerun with same
+    // settings" as the intent-preserving path (RunDetail.tsx).
+    const superseding = findNewerCompletedEquivalentRun(run, {
+      agentId: run.agent_id,
+      taskName: run.task ?? '',
+      scope,
+      dryRun: run.dry_run,
+      instruction: run.instruction,
+    });
+    if (superseding) {
+      applyRunUpdate(run.id, {
+        resumable: 0,
+        resume_status: RESUME_STATUS_SUPERSEDED,
+      }, scope);
+      return {
+        status: 409,
+        body: {
+          error: `Run superseded by a newer completed run (${superseding.id}) — use "Rerun with same settings" instead`,
+          supersededBy: superseding.id,
+        },
+      };
     }
 
     const { mode } = ResumeRunBody.parse(req.body ?? {});

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -161,7 +161,7 @@ import { createDigestRevisionHandlers } from './api/digest-revisions.js';
 import { createAttachmentHandler } from './api/attachments.js';
 import { reconcileLogBuffer } from './log-reconcile.js';
 import { logEntryToInsert } from './log-entry-insert.js';
-import { markRunningRunsInterrupted } from '../db/queries/runs.js';
+import { markRunningRunsInterrupted, sweepStaleSupersededRuns } from '../db/queries/runs.js';
 import {
   POWER_IDLE_THRESHOLD_MS,
   POWER_SLEEP_THRESHOLD_MS,
@@ -898,6 +898,18 @@ export async function main(): Promise<void> {
   if (interruptedRuns > 0) {
     logger.warn(LOG_KINDS.AGENT_RUN, 'Marked stale running runs as resumable after daemon restart', {
       count: interruptedRuns,
+      grove_id: dataPaths.requestContext.groveId,
+    });
+  }
+  // One-time backfill (Part 1 of the resume-admission gate): the
+  // completion-time sweep only fires on FUTURE completions, so a vault
+  // upgrading onto this release can still hold stale resumable rows a
+  // completed equivalent run already superseded. Safe on every boot — a
+  // fully-swept vault matches zero rows.
+  const supersededRuns = sweepStaleSupersededRuns({ kind: 'all' });
+  if (supersededRuns > 0) {
+    logger.warn(LOG_KINDS.AGENT_RUN, 'Marked stale resumable runs as superseded on boot', {
+      count: supersededRuns,
       grove_id: dataPaths.requestContext.groveId,
     });
   }
@@ -2528,7 +2540,7 @@ export async function main(): Promise<void> {
   // Boot-DB sweep already ran above; this catches the rest.
   void (async () => {
     try {
-      const { markRunningRunsInterrupted: markStale } = await import('../db/queries/runs.js');
+      const { markRunningRunsInterrupted: markStale, sweepStaleSupersededRuns: sweepStale } = await import('../db/queries/runs.js');
       await forEachGrove(
         runtimeCache,
         logger,
@@ -2538,6 +2550,13 @@ export async function main(): Promise<void> {
           if (count > 0) {
             logger.warn(LOG_KINDS.AGENT_RUN, 'Marked stale running runs as resumable after daemon restart', {
               count,
+              grove_id: grove.id,
+            });
+          }
+          const supersededCount = sweepStale({ kind: 'all' });
+          if (supersededCount > 0) {
+            logger.warn(LOG_KINDS.AGENT_RUN, 'Marked stale resumable runs as superseded on boot', {
+              count: supersededCount,
               grove_id: grove.id,
             });
           }

--- a/packages/myco/src/daemon/task-scheduling.ts
+++ b/packages/myco/src/daemon/task-scheduling.ts
@@ -24,9 +24,11 @@ import { withDatabase } from '@myco/db/client.js';
 import {
   applyRunUpdate,
   getLatestResumableRunForTask,
+  hasNewerCompletedEquivalentRun,
   incrementRunResumeAttempts,
   refundRunResumeAttempt,
   RESUME_STATUS_EXHAUSTED,
+  RESUME_STATUS_SUPERSEDED,
   type RunRow,
 } from '@myco/db/queries/runs.js';
 import { countToolCallsByRun } from '@myco/db/queries/turns.js';
@@ -178,6 +180,16 @@ export interface ScheduledResumeGateInput {
 /**
  * Decide whether a resumable run may consume another scheduled resume.
  *
+ * - Superseded belt (Part 1 secondary): if a completed equivalent run
+ *   (same agent/task/project scope/dry_run/instruction) finished AFTER this
+ *   run's own `COALESCE(completed_at, started_at)`, terminal-marks
+ *   (`resumable=0`, `resume_status='superseded'`) and returns 'superseded'
+ *   — the caller falls through to a fresh dispatch. Defends legacy rows
+ *   written before the completion-time sweep existed, and any race the
+ *   sweep's single-completion trigger can't see. No side effects live in
+ *   the db/queries read helper (`hasNewerCompletedEquivalentRun`) —
+ *   `gateScheduledResume` already owns terminal-marking for this run, so
+ *   the write happens here.
  * - Under the cap: increments `resume_attempts` (before dispatch, so a
  *   crash mid-resume still counts) and returns 'resume'.
  * - At the cap: terminal-marks the run (`resumable=0` +
@@ -185,8 +197,27 @@ export interface ScheduledResumeGateInput {
  *   notification, and returns 'exhausted' — the caller falls through to a
  *   fresh dispatch in the same tick.
  */
-export function gateScheduledResume(input: ScheduledResumeGateInput): 'resume' | 'exhausted' {
+export function gateScheduledResume(input: ScheduledResumeGateInput): 'resume' | 'exhausted' | 'superseded' {
   const { run, taskName, scope, projectVaultDir, projectId, config, logger } = input;
+
+  if (hasNewerCompletedEquivalentRun(run, {
+    agentId: run.agent_id,
+    taskName,
+    scope,
+    dryRun: run.dry_run,
+    instruction: run.instruction,
+  })) {
+    applyRunUpdate(run.id, {
+      resumable: 0,
+      resume_status: RESUME_STATUS_SUPERSEDED,
+    }, scope);
+    logger.warn(LOG_KINDS.AGENT_ERROR, `Scheduled task ${taskName} resume superseded by a newer completed run — starting fresh`, {
+      project_id: projectId,
+      runId: run.id,
+    });
+    return 'superseded';
+  }
+
   if (run.resume_attempts < RESUME_MAX_ATTEMPTS) {
     incrementRunResumeAttempts(run.id, scope);
     return 'resume';
@@ -489,7 +520,11 @@ export async function registerScheduledTasks(
         });
         return;
       }
-      // 'exhausted' — fall through to a fresh run in the same tick.
+      // 'exhausted' or 'superseded' — fall through to a fresh run in the
+      // same tick (Part 4: the interval-clock stamp above is deliberately
+      // pre-dispatch, so this fall-through keeps the tick from being a
+      // no-op even though gateScheduledResume already terminal-marked the
+      // old run).
     }
 
     const taskConfig = config.agent.tasks?.[taskName];

--- a/packages/myco/src/db/queries/runs.ts
+++ b/packages/myco/src/db/queries/runs.ts
@@ -55,6 +55,30 @@ export const RESUME_STATUS_SESSION_EXPIRED = 'session_expired';
  */
 export const RESUME_STATUS_EXHAUSTED = 'exhausted';
 
+/**
+ * Resume status used when a newer, equivalent run (same agent/task/project
+ * scope/dry_run/instruction) has since completed. A resumable failed run
+ * left behind by an OLDER dispatch is stale by definition once an
+ * equivalent run finishes — resuming it would re-execute work against
+ * checkpoints, gates, and watermarks superseded by the completion. See
+ * `supersedeEquivalentResumableRuns` (completion-time sweep) and the
+ * `gateScheduledResume` belt (task-scheduling.ts) for the two enforcement
+ * points.
+ */
+export const RESUME_STATUS_SUPERSEDED = 'superseded';
+
+/**
+ * Resume status used when the run-end postcondition validator fails on a
+ * resume attempt that executed ZERO fresh phases (every phase was restored
+ * from checkpoints — see executor.ts's `executedPhaseCount === 0` check).
+ * Distinct from a normal postcondition failure on a run that did execute
+ * work: an all-restored resume can never satisfy the missing contract by
+ * retrying, because retrying re-runs nothing. Terminal-marking here (instead
+ * of `ready`) stops the scheduler from burning 3 resume attempts on a run
+ * that is deterministically unresumable.
+ */
+export const RESUME_STATUS_POSTCONDITION_UNSATISFIABLE = 'postcondition_unsatisfiable';
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -663,6 +687,158 @@ export function getLatestResumableRunForTask(
      LIMIT 1`,
   ).get(...params) as Record<string, unknown> | undefined;
   return row ? toRunRow(row) : null;
+}
+
+/**
+ * Append the supersede equivalence-key predicate to an in-progress
+ * WHERE-clause builder: same `agent_id` + `task` + project scope (via
+ * `appendProjectCondition`) + `dry_run`, and `instruction` equal OR both
+ * NULL. Shared by the completion-time sweep and the gate-time belt so the
+ * two enforcement points can never drift apart on what counts as
+ * "equivalent" — the instruction/dry_run pinning is load-bearing:
+ * `getLatestResumableRunForTask` doesn't filter on either, and the executor
+ * restores `instruction`/`dryRun` on resume, so without this key a
+ * completed run for a DIFFERENT candidate/instruction would wrongly
+ * supersede or block an unrelated instruction-scoped failed run.
+ */
+function appendSupersedeEquivalenceCondition(
+  conditions: string[],
+  params: unknown[],
+  match: { agentId: string; taskName: string; scope: ProjectScope; dryRun: boolean; instruction: string | null },
+): void {
+  conditions.push('agent_id = ?', 'task = ?');
+  params.push(match.agentId, match.taskName);
+  appendProjectCondition(conditions, params, match.scope);
+  conditions.push('dry_run = ?');
+  params.push(match.dryRun ? 1 : 0);
+  if (match.instruction === null) {
+    conditions.push('instruction IS NULL');
+  } else {
+    conditions.push('instruction = ?');
+    params.push(match.instruction);
+  }
+}
+
+/**
+ * Completion-time supersede sweep (Part 1 primary). Called from the
+ * executor's success path immediately after a run completes, with that
+ * run's own (agentId, taskName, scope, dryRun, instruction) as the
+ * equivalence key. Terminal-marks (`resumable=0`,
+ * `resume_status='superseded'`) every OTHER currently-resumable failed run
+ * matching the key — structural, no timestamp comparison: anything still
+ * resumable when an equivalent run completes is stale BY DEFINITION,
+ * because the just-completed run's dispatch necessarily started no earlier
+ * than the failed run's most recent attempt. Sidesteps the started_at
+ * overwrite trap entirely (a resume re-stamps started_at:now — comparing
+ * against it would be comparing the wrong clock). Swept runs hit the
+ * existing resumable-guard 400 at the manual resume endpoint automatically
+ * (agent-runs.ts).
+ *
+ * `excludeRunId` is the completing run's own id — never supersede itself.
+ */
+export function supersedeEquivalentResumableRuns(
+  excludeRunId: string,
+  match: { agentId: string; taskName: string; scope: ProjectScope; dryRun: boolean; instruction: string | null },
+): number {
+  const db = getDatabase();
+  const conditions = ['id != ?', 'resumable = 1', 'status = ?'];
+  const params: unknown[] = [excludeRunId, STATUS_FAILED];
+  appendSupersedeEquivalenceCondition(conditions, params, match);
+  const info = db.prepare(
+    `UPDATE agent_runs
+     SET resumable = 0,
+         resume_status = ?
+     WHERE ${conditions.join(' AND ')}`,
+  ).run(RESUME_STATUS_SUPERSEDED, ...params);
+  return info.changes;
+}
+
+/**
+ * Gate-time supersede belt (Part 1 secondary). Defends legacy rows written
+ * before the completion-time sweep existed, and any race the sweep's
+ * single-completion trigger can't see. Returns the newest COMPLETED
+ * equivalent run whose `completed_at` is newer than the failed run's own
+ * `COALESCE(completed_at, started_at)` — the failed side must use COALESCE
+ * because an interrupted run (`markRunningRunsInterrupted`) sets
+ * status='failed' + resume_status='ready' WITHOUT a completed_at. Never
+ * compare against the failed run's `started_at` alone: a resume overwrites
+ * `started_at` on every attempt, so it is not stable dispatch-order evidence.
+ * Returns null when no such run exists. Callers that only need the
+ * yes/no answer (`gateScheduledResume`) test the return for non-null;
+ * callers that need to NAME the superseding run (the manual resume
+ * endpoint's 409) read `.id` off the row.
+ */
+export function findNewerCompletedEquivalentRun(
+  failedRun: Pick<RunRow, 'id' | 'started_at' | 'completed_at'>,
+  match: { agentId: string; taskName: string; scope: ProjectScope; dryRun: boolean; instruction: string | null },
+): RunRow | null {
+  const db = getDatabase();
+  const conditions = ['id != ?', 'status = ?', 'completed_at IS NOT NULL'];
+  const params: unknown[] = [failedRun.id, STATUS_COMPLETED];
+  appendSupersedeEquivalenceCondition(conditions, params, match);
+  conditions.push('completed_at > ?');
+  params.push(failedRun.completed_at ?? failedRun.started_at ?? 0);
+  const row = db.prepare(
+    `SELECT ${SELECT_COLUMNS} FROM agent_runs
+     WHERE ${conditions.join(' AND ')}
+     ORDER BY completed_at DESC
+     LIMIT 1`,
+  ).get(...params) as Record<string, unknown> | undefined;
+  return row ? toRunRow(row) : null;
+}
+
+/**
+ * Boolean convenience wrapper over `findNewerCompletedEquivalentRun` for
+ * callers that only need the yes/no answer.
+ */
+export function hasNewerCompletedEquivalentRun(
+  failedRun: Pick<RunRow, 'id' | 'started_at' | 'completed_at'>,
+  match: { agentId: string; taskName: string; scope: ProjectScope; dryRun: boolean; instruction: string | null },
+): boolean {
+  return findNewerCompletedEquivalentRun(failedRun, match) !== null;
+}
+
+/**
+ * Boot-time supersede sweep (Part 1 one-time backfill). The completion-time
+ * sweep above only fires on FUTURE completions — this catches stale
+ * resumable rows that predate the sweep's existence (or were left behind by
+ * a daemon crash before the completing run's success path ran). Terminal-
+ * marks every resumable failed run F for which ANY completed run C shares
+ * F's equivalence key (agent_id, task, project scope, dry_run, instruction
+ * equal or both NULL) and has `completed_at` newer than F's
+ * `COALESCE(completed_at, started_at)` — same predicate as the gate-time
+ * belt (`hasNewerCompletedEquivalentRun`), expressed as a single
+ * correlated-EXISTS UPDATE so the whole scope sweeps in one SQL pass. Safe
+ * to run on every boot: a fully-swept vault matches zero rows.
+ */
+export function sweepStaleSupersededRuns(scope: ProjectScope): number {
+  const db = getDatabase();
+  const outerConditions: string[] = [];
+  const outerParams: unknown[] = [];
+  appendProjectCondition(outerConditions, outerParams, scope, 'F');
+  const outerScopeClause = outerConditions.length > 0 ? `AND ${outerConditions.join(' AND ')}` : '';
+
+  const info = db.prepare(
+    `UPDATE agent_runs AS F
+     SET resumable = 0,
+         resume_status = ?
+     WHERE F.resumable = 1
+       AND F.status = ?
+       ${outerScopeClause}
+       AND EXISTS (
+         SELECT 1 FROM agent_runs AS C
+         WHERE C.id != F.id
+           AND C.status = ?
+           AND C.completed_at IS NOT NULL
+           AND C.agent_id = F.agent_id
+           AND C.task = F.task
+           AND COALESCE(C.project_id, '') = COALESCE(F.project_id, '')
+           AND C.dry_run = F.dry_run
+           AND (C.instruction = F.instruction OR (C.instruction IS NULL AND F.instruction IS NULL))
+           AND C.completed_at > COALESCE(F.completed_at, F.started_at, 0)
+       )`,
+  ).run(RESUME_STATUS_SUPERSEDED, STATUS_FAILED, STATUS_COMPLETED, ...outerParams);
+  return info.changes;
 }
 
 export function markRunningRunsInterrupted(message: string, scope: ProjectScope): number {

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -2469,4 +2469,128 @@ describe('runAgent — run lifecycle', () => {
     expect(run.cost_usd).toBe(0.0042);
     expect(run.cost_source).toBe('actual');
   });
+
+  // ---------------------------------------------------------------------
+  // Regression test 3: all-restored resume + failing run-end validator ⇒
+  // ONE attempt terminal-marks 'postcondition_unsatisfiable' (typed error
+  // path), checkpoints preserved; does not burn 3 attempts.
+  // ---------------------------------------------------------------------
+
+  describe('Part 3 — PostconditionUnsatisfiableError on an all-restored resume', () => {
+    it('terminal-marks postcondition_unsatisfiable in ONE attempt when every phase was restored and the contract is still unmet', async () => {
+      mockTaskName = 'skill-evolve';
+      mockYamlPhases = [
+        {
+          name: 'inventory',
+          prompt: 'Write inventory.',
+          tools: ['vault_report'],
+          maxTurns: 2,
+          required: true,
+        },
+        {
+          name: 'assess',
+          prompt: 'Write assessment.',
+          tools: ['vault_report'],
+          maxTurns: 2,
+          required: true,
+          dependsOn: ['inventory'],
+        },
+      ];
+      await createTask('skill-evolve', 'Run skill evolution.');
+
+      // Checkpoint has BOTH phases already marked completed — a resume
+      // restores them without re-invoking the harness. No matching
+      // agent_reports/agent_state rows exist in the DB (this test never
+      // ran the phases for real), so the run-end postcondition validator
+      // fails exactly as it would for a genuinely stuck run.
+      const runId = insertResumableRun({
+        task: 'skill-evolve',
+        checkpoints: JSON.stringify({
+          harness: 'claude-sdk',
+          phases: {
+            inventory: { name: 'inventory', status: 'completed', summary: 'done', turnsUsed: 2, tokensUsed: 100, updatedAt: 0 },
+            assess: { name: 'assess', status: 'completed', summary: 'done', turnsUsed: 2, tokensUsed: 100, updatedAt: 0 },
+          },
+        }),
+      });
+
+      const { runAgent } = await import('@myco/agent/executor.js');
+      const result = await runAgent(TEST_VAULT_DIR, {
+        requestContext: TEST_REQUEST_CONTEXT,
+        resumeRunId: runId,
+        resumeMode: 'scheduled',
+      });
+
+      // Zero fresh harness calls — every phase was trusted from the checkpoint.
+      expect(allQueryCalls.length).toBe(0);
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('skill-evolve completed without a skill-evolve-inventory report');
+
+      const run = getRun(runId, ALL_PROJECTS_SCOPE)!;
+      expect(run.status).toBe('failed');
+      // Terminal-marked in ONE attempt — resumable=0 stops the scheduler
+      // from re-admitting a run that can never satisfy its contract by
+      // retrying (retrying re-runs nothing).
+      expect(run.resumable).toBe(0);
+      expect(run.resume_status).toBe('postcondition_unsatisfiable');
+      expect(run.resume_attempts).toBe(0);
+      // Unlike session-expired, checkpoints are PRESERVED for debugging —
+      // never nulled.
+      expect(run.checkpoints).not.toBeNull();
+      const checkpoints = JSON.parse(run.checkpoints!);
+      expect(checkpoints.phases.inventory.status).toBe('completed');
+      expect(checkpoints.phases.assess.status).toBe('completed');
+    });
+
+    it('does NOT terminal-mark postcondition_unsatisfiable when at least one phase executed fresh this attempt', async () => {
+      mockTaskName = 'skill-evolve';
+      mockYamlPhases = [
+        {
+          name: 'inventory',
+          prompt: 'Write inventory.',
+          tools: ['vault_report'],
+          maxTurns: 2,
+          required: true,
+        },
+        {
+          name: 'assess',
+          prompt: 'Write assessment.',
+          tools: ['vault_report'],
+          maxTurns: 2,
+          required: true,
+          dependsOn: ['inventory'],
+        },
+      ];
+      await createTask('skill-evolve', 'Run skill evolution.');
+
+      // Only 'inventory' is restored; 'assess' has no checkpoint entry, so
+      // it re-executes fresh this attempt (executedPhaseCount === 1).
+      const runId = insertResumableRun({
+        task: 'skill-evolve',
+        checkpoints: JSON.stringify({
+          harness: 'claude-sdk',
+          phases: {
+            inventory: { name: 'inventory', status: 'completed', summary: 'done', turnsUsed: 2, tokensUsed: 100, updatedAt: 0 },
+          },
+        }),
+      });
+
+      const { runAgent } = await import('@myco/agent/executor.js');
+      const result = await runAgent(TEST_VAULT_DIR, {
+        requestContext: TEST_REQUEST_CONTEXT,
+        resumeRunId: runId,
+        resumeMode: 'scheduled',
+      });
+
+      expect(allQueryCalls.length).toBe(1);
+      expect(result.status).toBe('failed');
+
+      const run = getRun(runId, ALL_PROJECTS_SCOPE)!;
+      // The generic Error path (RESUME_STATUS_READY), not the typed
+      // PostconditionUnsatisfiableError path — this run made progress and
+      // is worth retrying under the normal resume budget.
+      expect(run.resumable).toBe(1);
+      expect(run.resume_status).toBe('ready');
+    });
+  });
 });

--- a/tests/agent/phase-loop-resume-admission.test.ts
+++ b/tests/agent/phase-loop-resume-admission.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Regression tests 2, 3, and 5 for the resume-admission gate.
+ *
+ * Mirrors phase-loop.test.ts's mock harness (checkPhasePostCondition mocked
+ * at module level, executePhasedQuery called directly against a
+ * hand-constructed PhaseLoopContext) so these can assert on the checkpoint
+ * re-validation seam without a full runAgent DB round trip.
+ */
+
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import type {
+  EffectiveConfig,
+  PhaseDefinition,
+  RuntimeUsage,
+  HarnessId,
+} from '@myco/agent/types.js';
+import type { AgentHarness, HarnessExecuteInput, HarnessExecuteResult } from '@myco/agent/harness/types.js';
+import type { RunCheckpointState, PhaseCheckpoint } from '@myco/agent/executor-state.js';
+
+// ---------------------------------------------------------------------------
+// Harness mock — records every execute() call so tests can assert on WHICH
+// phases actually re-ran (vs. stayed restored).
+// ---------------------------------------------------------------------------
+
+let capturedExecuteInputs: HarnessExecuteInput[] = [];
+let executeResultOverride: Partial<HarnessExecuteResult> | null = null;
+
+const DEFAULT_USAGE: RuntimeUsage = {
+  requests: 1,
+  inputTokens: 100,
+  outputTokens: 200,
+  totalTokens: 300,
+  reasoningTokens: 0,
+  cachedTokens: 0,
+  durationMs: 10,
+};
+
+const fakeRuntime: AgentHarness = {
+  id: 'claude-sdk' as HarnessId,
+  async execute(input: HarnessExecuteInput): Promise<HarnessExecuteResult> {
+    capturedExecuteInputs.push(input);
+    return {
+      finalText: 'ok',
+      turnsUsed: 1,
+      usage: DEFAULT_USAGE,
+      sessionRef: 'fresh-session-' + capturedExecuteInputs.length,
+      ...executeResultOverride,
+    };
+  },
+  supports: () => false,
+  classifyError: () => 'unknown',
+};
+
+mock.module('@myco/agent/harness/index.js', () => ({
+  getAgentHarness: () => fakeRuntime,
+}));
+
+mock.module('@myco/agent/phase-preconditions.js', () => ({
+  checkPhasePreCondition: () => ({ passed: true, reason: 'default-pass' }),
+}));
+
+// Programmable per test — the seam under test. Each call is recorded so
+// tests can assert re-validation actually ran (and with what projectId/
+// dryRun) without duplicating the live phase-postconditions.ts logic.
+// `checkPostConditionImpl` is reassigned per test (never mock.module again)
+// so behavior swaps never leak across tests the way re-calling mock.module
+// mid-test would.
+type PostConditionResult = { passed: boolean; reason: string };
+let postConditionResultsByKind: Record<string, PostConditionResult> = {};
+let postConditionCalls: Array<{ kind: string; input: Record<string, unknown> }> = [];
+let checkPostConditionImpl = (kind: string, _input: Record<string, unknown>): PostConditionResult =>
+  postConditionResultsByKind[kind] ?? { passed: true, reason: 'ok' };
+
+mock.module('@myco/agent/phase-postconditions.js', () => ({
+  checkPhasePostCondition: (kind: string, input: Record<string, unknown>) => {
+    postConditionCalls.push({ kind, input });
+    return checkPostConditionImpl(kind, input);
+  },
+}));
+
+mock.module('@myco/grove/request-context.js', () => ({
+  projectScopeFromRequestContext: () => ({ kind: 'all' as const }),
+  rowProjectIdFromRequestContext: () => 'proj_test',
+}));
+
+mock.module('@myco/agent/cost/index.js', () => ({
+  resolveCost: async () => ({
+    source: 'actual' as const,
+    costUsd: 0.01,
+    actualCostUsd: 0.01,
+    estimatedCostUsd: 0,
+    breakdown: {
+      inputTokens: 100,
+      cachedInputTokens: 0,
+      uncachedInputTokens: 100,
+      outputTokens: 200,
+      reasoningTokens: 0,
+      requestCount: 1,
+      totalCostUsd: 0.01,
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports AFTER mock.module() so the mocks apply.
+// ---------------------------------------------------------------------------
+
+import { executePhasedQuery, type PhaseLoopContext } from '@myco/agent/phase-loop.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function baseConfig(phases: PhaseDefinition[]): EffectiveConfig {
+  return {
+    taskName: 'test-task',
+    taskDisplayName: 'Test Task',
+    taskPrompt: 'Do the thing.',
+    systemPromptPath: 'prompts/system.md',
+    harness: 'claude-sdk',
+    model: 'claude-sonnet-4',
+    maxTurns: 5,
+    timeoutSeconds: 60,
+    tools: [],
+    phases,
+  } as EffectiveConfig;
+}
+
+function phase(name: string, extra: Partial<PhaseDefinition> = {}): PhaseDefinition {
+  return {
+    name,
+    prompt: `prompt for ${name}`,
+    tools: [],
+    maxTurns: 3,
+    required: false,
+    ...extra,
+  } as PhaseDefinition;
+}
+
+function restoredCheckpoint(name: string, extra: Partial<PhaseCheckpoint> = {}): PhaseCheckpoint {
+  return {
+    name,
+    status: 'completed',
+    summary: `${name} summary from prior attempt`,
+    turnsUsed: 2,
+    tokensUsed: 150,
+    sessionRef: `restored-session-${name}`,
+    updatedAt: 0,
+    ...extra,
+  };
+}
+
+function baseContext(overrides: Partial<PhaseLoopContext> = {}): PhaseLoopContext {
+  return {
+    config: baseConfig([]),
+    systemPrompt: 'SYSTEM',
+    vaultContext: 'VAULT CONTEXT',
+    agentId: 'myco-agent',
+    runId: 'run-resume-admission',
+    instruction: undefined,
+    abortController: new AbortController(),
+    projectRoot: '/tmp/resume-admission-test',
+    vaultDir: '/tmp/resume-admission-test/.myco',
+    options: undefined,
+    checkpointState: { harness: 'claude-sdk', phases: {} } as RunCheckpointState,
+    requestContext: { projectId: 'proj_test' } as unknown as PhaseLoopContext['requestContext'],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  capturedExecuteInputs = [];
+  executeResultOverride = null;
+  postConditionResultsByKind = {};
+  postConditionCalls = [];
+  checkPostConditionImpl = (kind) => postConditionResultsByKind[kind] ?? { passed: true, reason: 'ok' };
+});
+
+// ---------------------------------------------------------------------------
+// Regression test 2: restored completed phase with an unsatisfied
+// postCondition must be BOTH demoted in the checkpoint AND omitted from
+// restored results, then re-executed with a FRESH session.
+// ---------------------------------------------------------------------------
+
+describe('checkpoint re-validation at the phase-loop restore seam (Part 2)', () => {
+  it('(a) mutates the checkpoint state entry to failed + postConditionFailed as soon as re-validation fails', async () => {
+    const checkpointState: RunCheckpointState = {
+      harness: 'claude-sdk',
+      phases: {
+        inventory: restoredCheckpoint('inventory', { sessionRef: 'poisoned-restored-session' }),
+      },
+    };
+    // Fail BOTH the re-validation call and the fresh execution's own
+    // phase-boundary gate — isolates assertion (a) (the state mutation)
+    // from re-execution's own bookkeeping, since the final checkpoint
+    // write always reflects the LATEST attempt's outcome.
+    postConditionResultsByKind['skill-evolve-inventory'] = { passed: false, reason: 'inventory report missing' };
+
+    const phases = [phase('inventory', { postCondition: 'skill-evolve-inventory' })];
+    const ctx = baseContext({ config: baseConfig(phases), checkpointState });
+
+    await executePhasedQuery(ctx);
+
+    // The checkpoint's FINAL state (after demotion AND re-execution, which
+    // also failed its own gate) is 'failed' + postConditionFailed:true —
+    // proving the demotion write took effect and re-execution actually ran
+    // (a phase that stayed trusted/restored would never re-invoke the gate
+    // a second time here).
+    expect(checkpointState.phases.inventory.status).toBe('failed');
+    expect(checkpointState.phases.inventory.postConditionFailed).toBe(true);
+    expect(capturedExecuteInputs).toHaveLength(1);
+  });
+
+  it('(b) omits the demoted phase from restored results and re-executes it with a FRESH session (never the poisoned restored one)', async () => {
+    const checkpointState: RunCheckpointState = {
+      harness: 'claude-sdk',
+      phases: {
+        inventory: restoredCheckpoint('inventory', { sessionRef: 'poisoned-restored-session' }),
+      },
+    };
+    // Fails the RE-VALIDATION check (first call, against the restored
+    // checkpoint) but passes the live phase-boundary gate's check after
+    // the phase re-executes (second call) — models "the artifact the
+    // restored checkpoint pointed at is gone, but the fresh execution
+    // produces a new one that satisfies the contract."
+    let postConditionCallCount = 0;
+    checkPostConditionImpl = () => {
+      postConditionCallCount += 1;
+      return postConditionCallCount === 1
+        ? { passed: false, reason: 'inventory report missing on re-check' }
+        : { passed: true, reason: 'ok' };
+    };
+
+    const phases = [phase('inventory', { postCondition: 'skill-evolve-inventory' })];
+    const ctx = baseContext({ config: baseConfig(phases), checkpointState });
+
+    const result = await executePhasedQuery(ctx);
+
+    // The phase was RE-EXECUTED this attempt (not left restored) — proven
+    // by an actual harness call, and by the final result showing a
+    // completed status with a FRESH sessionRef (never the poisoned restored one).
+    // This is only possible because (b) omitted it from phaseResults, so
+    // the runnableWave filter re-included it instead of skipping it as
+    // already-completed.
+    expect(capturedExecuteInputs).toHaveLength(1);
+    expect(result.executedPhaseCount).toBe(1);
+    const finalPhase = result.phases.find((p) => p.name === 'inventory')!;
+    expect(finalPhase.status).toBe('completed');
+    expect(finalPhase.sessionRef).not.toBe('poisoned-restored-session');
+    expect(finalPhase.sessionRef).toMatch(/^fresh-session-/);
+  });
+
+  it('never re-validates a restored SKIPPED phase, even when it declares a postCondition', async () => {
+    const checkpointState: RunCheckpointState = {
+      harness: 'claude-sdk',
+      phases: {
+        inventory: restoredCheckpoint('inventory', { status: 'skipped' }),
+      },
+    };
+    // If re-validation ran against a skipped phase, this would fail it —
+    // proving the loop must never call checkPhasePostCondition for 'skipped'.
+    postConditionResultsByKind['skill-evolve-inventory'] = { passed: false, reason: 'would fail if checked' };
+
+    const phases = [phase('inventory', { postCondition: 'skill-evolve-inventory' })];
+    const ctx = baseContext({ config: baseConfig(phases), checkpointState });
+
+    const result = await executePhasedQuery(ctx);
+
+    expect(postConditionCalls).toHaveLength(0);
+    expect(checkpointState.phases.inventory.status).toBe('skipped');
+    expect(capturedExecuteInputs).toHaveLength(0);
+    expect(result.phases.find((p) => p.name === 'inventory')?.status).toBe('skipped');
+  });
+
+  it('keeps a restored completed phase trusted when its postCondition still passes on re-check', async () => {
+    const checkpointState: RunCheckpointState = {
+      harness: 'claude-sdk',
+      phases: {
+        inventory: restoredCheckpoint('inventory'),
+      },
+    };
+    postConditionResultsByKind['skill-evolve-inventory'] = { passed: true, reason: 'ok' };
+
+    const phases = [phase('inventory', { postCondition: 'skill-evolve-inventory' })];
+    const ctx = baseContext({ config: baseConfig(phases), checkpointState });
+
+    const result = await executePhasedQuery(ctx);
+
+    expect(postConditionCalls).toHaveLength(1);
+    expect(capturedExecuteInputs).toHaveLength(0);
+    expect(result.executedPhaseCount).toBe(0);
+    expect(checkpointState.phases.inventory.status).toBe('completed');
+    expect(result.phases.find((p) => p.name === 'inventory')?.status).toBe('completed');
+  });
+
+  it('fails open (keeps the restored result) when the re-validation check throws', async () => {
+    const checkpointState: RunCheckpointState = {
+      harness: 'claude-sdk',
+      phases: {
+        inventory: restoredCheckpoint('inventory'),
+      },
+    };
+    checkPostConditionImpl = () => {
+      throw new Error('transient SQL error');
+    };
+
+    const phases = [phase('inventory', { postCondition: 'skill-evolve-inventory' })];
+    const ctx = baseContext({ config: baseConfig(phases), checkpointState });
+
+    const result = await executePhasedQuery(ctx);
+
+    expect(capturedExecuteInputs).toHaveLength(0);
+    expect(checkpointState.phases.inventory.status).toBe('completed');
+    expect(checkpointState.phases.inventory.postConditionFailed).toBeUndefined();
+    expect(result.phases.find((p) => p.name === 'inventory')?.status).toBe('completed');
+  });
+
+  it('bypasses re-validation loudly when no requestContext is available (contract unverified until run end)', async () => {
+    const checkpointState: RunCheckpointState = {
+      harness: 'claude-sdk',
+      phases: {
+        inventory: restoredCheckpoint('inventory'),
+      },
+    };
+    postConditionResultsByKind['skill-evolve-inventory'] = { passed: false, reason: 'would fail if checked' };
+
+    const phases = [phase('inventory', { postCondition: 'skill-evolve-inventory' })];
+    const ctx = baseContext({ config: baseConfig(phases), checkpointState, requestContext: undefined });
+
+    const result = await executePhasedQuery(ctx);
+
+    expect(postConditionCalls).toHaveLength(0);
+    expect(capturedExecuteInputs).toHaveLength(0);
+    expect(checkpointState.phases.inventory.status).toBe('completed');
+    expect(result.phases.find((p) => p.name === 'inventory')?.status).toBe('completed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression test 3: an all-restored resume whose run-end validator still
+// fails must be distinguishable via executedPhaseCount === 0. Tested at the
+// phase-loop level here (the typed-error / terminal-mark half lives in
+// executor-postcondition-unsatisfiable.test.ts, which exercises the full
+// runAgent path).
+// ---------------------------------------------------------------------------
+
+describe('executedPhaseCount signal (Part 3 foundation)', () => {
+  it('is zero when every phase in the plan was restored (none re-executed)', async () => {
+    const checkpointState: RunCheckpointState = {
+      harness: 'claude-sdk',
+      phases: {
+        a: restoredCheckpoint('a'),
+        b: restoredCheckpoint('b'),
+      },
+    };
+    const phases = [phase('a'), phase('b')];
+    const ctx = baseContext({ config: baseConfig(phases), checkpointState });
+
+    const result = await executePhasedQuery(ctx);
+
+    expect(result.executedPhaseCount).toBe(0);
+    expect(capturedExecuteInputs).toHaveLength(0);
+  });
+
+  it('is greater than zero when at least one phase actually re-executes', async () => {
+    const checkpointState: RunCheckpointState = {
+      harness: 'claude-sdk',
+      phases: {
+        a: restoredCheckpoint('a'),
+      },
+    };
+    // 'b' has no checkpoint entry — it's fresh work this attempt.
+    const phases = [phase('a'), phase('b')];
+    const ctx = baseContext({ config: baseConfig(phases), checkpointState });
+
+    const result = await executePhasedQuery(ctx);
+
+    expect(result.executedPhaseCount).toBe(1);
+    expect(capturedExecuteInputs).toHaveLength(1);
+  });
+
+  it('counts a Part-2-demoted phase as executed', async () => {
+    const checkpointState: RunCheckpointState = {
+      harness: 'claude-sdk',
+      phases: {
+        inventory: restoredCheckpoint('inventory'),
+      },
+    };
+    postConditionResultsByKind['skill-evolve-inventory'] = { passed: false, reason: 'stale' };
+    const phases = [phase('inventory', { postCondition: 'skill-evolve-inventory' })];
+    const ctx = baseContext({ config: baseConfig(phases), checkpointState });
+
+    const result = await executePhasedQuery(ctx);
+
+    expect(result.executedPhaseCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression test 5: contract pin on the restore path — re-validation
+// failure produces the SAME postConditionFailed flag + fresh-session
+// exclusion the live (fresh-path) gate already produces. Proven here by
+// checking the demoted phase reuses the reuseSession exclusion (fresh
+// sessionRef, never the restored one) exactly like phase-loop.test.ts's
+// existing fresh-path assertions for semanticCheckBlocked/postConditionFailed.
+// ---------------------------------------------------------------------------
+
+describe('contract pin: restore-path demotion matches fresh-path postConditionFailed shape (Part 5)', () => {
+  it('sets postConditionFailed on the checkpoint and forces a fresh session — identical shape to the live gate', async () => {
+    const checkpointState: RunCheckpointState = {
+      harness: 'claude-sdk',
+      phases: {
+        assess: restoredCheckpoint('assess', { sessionRef: 'stale-session-to-exclude', turnsUsed: 5 }),
+      },
+    };
+    postConditionResultsByKind['skill-evolve-assess'] = { passed: false, reason: 'classification payload stale' };
+    const phases = [phase('assess', { postCondition: 'skill-evolve-assess' })];
+    const ctx = baseContext({ config: baseConfig(phases), checkpointState });
+
+    await executePhasedQuery(ctx);
+
+    // Same marker name/shape the live phase-boundary gate sets on a fresh
+    // failure (phase-loop.ts's postCondition block) — a resumed run must
+    // read this identically regardless of which seam set it.
+    expect(checkpointState.phases.assess.postConditionFailed).toBe(true);
+    expect(checkpointState.phases.assess.status).toBe('failed');
+
+    // reuseSession exclusion: postConditionFailed !== true is required to
+    // reuse a session — since it IS true here, a fresh session must have
+    // been minted, never the stale restored one.
+    expect(capturedExecuteInputs).toHaveLength(1);
+    expect(capturedExecuteInputs[0].sessionRef).not.toBe('stale-session-to-exclude');
+  });
+});

--- a/tests/daemon/scheduled-resume-gate.test.ts
+++ b/tests/daemon/scheduled-resume-gate.test.ts
@@ -16,8 +16,10 @@ import {
   getRun,
   getLatestResumableRunForTask,
   refundRunResumeAttempt,
+  applyRunUpdate,
   RESUME_STATUS_EXHAUSTED,
   RESUME_STATUS_READY,
+  RESUME_STATUS_SUPERSEDED,
   type RunRow,
 } from '@myco/db/queries/runs.js';
 import { ALL_PROJECTS_SCOPE, assertGroveProjectId } from '@myco/grove/ids.js';
@@ -193,5 +195,139 @@ describe('gateScheduledResume', () => {
     const row = getRun('run-expired', ALL_PROJECTS_SCOPE)!;
     expect(row.resume_status).toBe('session_expired');
     expect(row.resume_attempts).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------
+  // Regression test 1 (belt half) + Regression test 4 (exhaustion-shape
+  // fall-through). See runs-supersede.test.ts for the completion-time
+  // sweep (primary) half of test 1.
+  // ---------------------------------------------------------------------
+
+  describe('supersede belt', () => {
+    it('terminal-marks a resumable run as superseded when a newer equivalent run completed, without consuming resume_attempts', () => {
+      const run = insertResumableRun('run-stale-legacy', 0);
+      // A newer COMPLETED equivalent run — same agent/task/scope/dry_run/
+      // instruction (both null here), completed after the failed run's
+      // own completed_at. Simulates a legacy row written before the
+      // completion-time sweep existed.
+      insertRun({
+        id: 'run-newer-completed',
+        agent_id: TEST_AGENT_ID,
+        task: TEST_TASK,
+        status: 'completed',
+        started_at: run.completed_at! + 10,
+        completed_at: run.completed_at! + 20,
+      });
+
+      expect(gate(run)).toBe('superseded');
+
+      const after = getRun('run-stale-legacy', ALL_PROJECTS_SCOPE)!;
+      expect(after.resumable).toBe(0);
+      expect(after.resume_status).toBe(RESUME_STATUS_SUPERSEDED);
+      // The belt fires BEFORE the resume_attempts cap logic — the budget
+      // counter is untouched, distinguishing this from the exhaustion path.
+      expect(after.resume_attempts).toBe(0);
+      expect(notifyCalls).toHaveLength(0);
+
+      // Regression test 4 (exhaustion-shape fall-through): the next lookup
+      // in the SAME tick sees no resumable run, exactly like the
+      // 'exhausted' path — dispatchScheduledTask's generic
+      // `if (gate === 'resume') {...return} // fall through` structure
+      // treats 'superseded' identically to 'exhausted', so the tick is not
+      // a no-op even though gateScheduledResume already terminal-marked
+      // the old run.
+      expect(getLatestResumableRunForTask(TEST_AGENT_ID, TEST_TASK, ALL_PROJECTS_SCOPE)).toBeNull();
+    });
+
+    it('does NOT supersede when the newer completed run has a DIFFERENT instruction', () => {
+      const run = insertResumableRun('run-instr-scoped', 0);
+      applyRunUpdate(run.id, { instruction: 'candidate X' }, ALL_PROJECTS_SCOPE);
+      const refreshed = getRun(run.id, ALL_PROJECTS_SCOPE)!;
+
+      insertRun({
+        id: 'run-newer-different-instruction',
+        agent_id: TEST_AGENT_ID,
+        task: TEST_TASK,
+        instruction: 'candidate Y',
+        status: 'completed',
+        started_at: refreshed.completed_at! + 10,
+        completed_at: refreshed.completed_at! + 20,
+      });
+
+      expect(gate(refreshed)).toBe('resume');
+      const after = getRun('run-instr-scoped', ALL_PROJECTS_SCOPE)!;
+      expect(after.resumable).toBe(1);
+      expect(after.resume_status).toBe(RESUME_STATUS_READY);
+    });
+
+    it('does NOT supersede a live run using a completed DRY run as the equivalent', () => {
+      const run = insertResumableRun('run-live-scoped', 0);
+
+      insertRun({
+        id: 'run-newer-dry-completed',
+        agent_id: TEST_AGENT_ID,
+        task: TEST_TASK,
+        dryRun: true,
+        status: 'completed',
+        started_at: run.completed_at! + 10,
+        completed_at: run.completed_at! + 20,
+      });
+
+      expect(gate(run)).toBe('resume');
+      const after = getRun('run-live-scoped', ALL_PROJECTS_SCOPE)!;
+      expect(after.resumable).toBe(1);
+      expect(after.resume_status).toBe(RESUME_STATUS_READY);
+    });
+
+    it('does not supersede when the completed equivalent run finished BEFORE the failed run\'s own completion', () => {
+      // An older completion must never supersede a NEWER failed attempt —
+      // only a completion that postdates COALESCE(completed_at, started_at)
+      // counts.
+      insertRun({
+        id: 'run-older-completed',
+        agent_id: TEST_AGENT_ID,
+        task: TEST_TASK,
+        status: 'completed',
+        started_at: epochNow() - 500,
+        completed_at: epochNow() - 400,
+      });
+      const run = insertResumableRun('run-newer-failed', 0);
+
+      expect(gate(run)).toBe('resume');
+      const after = getRun('run-newer-failed', ALL_PROJECTS_SCOPE)!;
+      expect(after.resumable).toBe(1);
+    });
+
+    it('uses COALESCE(completed_at, started_at) on the failed side — an interrupted run with NULL completed_at is still supersedable', () => {
+      // markRunningRunsInterrupted leaves completed_at NULL on the failed
+      // row. The belt must fall back to started_at for that side of the
+      // comparison rather than treating NULL as "never" or as "now".
+      const interruptedId = 'run-interrupted-null-completed';
+      insertRun({
+        id: interruptedId,
+        agent_id: TEST_AGENT_ID,
+        task: TEST_TASK,
+        status: 'failed',
+        resumable: 1,
+        resume_status: RESUME_STATUS_READY,
+        started_at: epochNow() - 300,
+        completed_at: null,
+      });
+      const interrupted = getRun(interruptedId, ALL_PROJECTS_SCOPE)!;
+
+      insertRun({
+        id: 'run-newer-completed-2',
+        agent_id: TEST_AGENT_ID,
+        task: TEST_TASK,
+        status: 'completed',
+        started_at: epochNow() - 100,
+        completed_at: epochNow() - 50,
+      });
+
+      expect(gate(interrupted)).toBe('superseded');
+      const after = getRun(interruptedId, ALL_PROJECTS_SCOPE)!;
+      expect(after.resumable).toBe(0);
+      expect(after.resume_status).toBe(RESUME_STATUS_SUPERSEDED);
+    });
   });
 });

--- a/tests/db/queries/runs-supersede.test.ts
+++ b/tests/db/queries/runs-supersede.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Regression test 1 (primary half) for the resume-admission gate:
+ * completion-time supersede sweep + boot-time backfill sweep.
+ *
+ * `supersedeEquivalentResumableRuns` is called from the executor's success
+ * path (executor.ts) immediately after a run completes — these tests
+ * exercise the query helper directly, matching the pattern in
+ * `runs.test.ts`. The gate-time belt (`hasNewerCompletedEquivalentRun` /
+ * `findNewerCompletedEquivalentRun`) is covered in
+ * `tests/daemon/scheduled-resume-gate.test.ts`.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'bun:test';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import {
+  insertRun,
+  getRun,
+  supersedeEquivalentResumableRuns,
+  sweepStaleSupersededRuns,
+  RESUME_STATUS_SUPERSEDED,
+  RESUME_STATUS_READY,
+  type RunInsert,
+} from '@myco/db/queries/runs.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+const TEST_AGENT_ID = 'supersede-test-agent';
+const TEST_TASK = 'skill-evolve';
+
+function makeRun(overrides: Partial<RunInsert> = {}): RunInsert {
+  return {
+    id: `run-${Math.random().toString(36).slice(2, 10)}`,
+    agent_id: TEST_AGENT_ID,
+    task: TEST_TASK,
+    ...overrides,
+  };
+}
+
+function makeResumableFailed(overrides: Partial<RunInsert> = {}): RunInsert {
+  return makeRun({
+    status: 'failed',
+    resumable: 1,
+    resume_status: RESUME_STATUS_READY,
+    started_at: epochNow() - 200,
+    completed_at: epochNow() - 100,
+    ...overrides,
+  });
+}
+
+describe('supersedeEquivalentResumableRuns (completion-time sweep)', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    registerAgent({ id: TEST_AGENT_ID, name: 'Supersede Test Agent', created_at: epochNow() });
+  });
+
+  it('terminal-marks an older resumable failed run for the same task/scope', () => {
+    const stale = insertRun(makeResumableFailed({ id: 'run-old' }));
+    const completing = insertRun(makeRun({ id: 'run-completing', status: 'completed' }));
+
+    const swept = supersedeEquivalentResumableRuns(completing.id, {
+      agentId: TEST_AGENT_ID,
+      taskName: TEST_TASK,
+      scope: ALL_PROJECTS_SCOPE,
+      dryRun: false,
+      instruction: null,
+    });
+
+    expect(swept).toBe(1);
+    const after = getRun(stale.id, ALL_PROJECTS_SCOPE)!;
+    expect(after.resumable).toBe(0);
+    expect(after.resume_status).toBe(RESUME_STATUS_SUPERSEDED);
+  });
+
+  it('never supersedes the completing run itself', () => {
+    // A run that completes AFTER a resume (resumable was reset to 0 by the
+    // executor's resume-restore block before this ran) must not somehow
+    // match its own id via the equivalence key.
+    const completing = insertRun(makeRun({ id: 'run-self', status: 'completed' }));
+
+    const swept = supersedeEquivalentResumableRuns(completing.id, {
+      agentId: TEST_AGENT_ID,
+      taskName: TEST_TASK,
+      scope: ALL_PROJECTS_SCOPE,
+      dryRun: false,
+      instruction: null,
+    });
+
+    expect(swept).toBe(0);
+  });
+
+  it('does NOT supersede a resumable run for a DIFFERENT instruction (candidate-scoped work stays isolated)', () => {
+    const stale = insertRun(makeResumableFailed({ id: 'run-candidate-x', instruction: 'candidate X' }));
+    const completing = insertRun(makeRun({ id: 'run-candidate-y', status: 'completed', instruction: 'candidate Y' }));
+
+    const swept = supersedeEquivalentResumableRuns(completing.id, {
+      agentId: TEST_AGENT_ID,
+      taskName: TEST_TASK,
+      scope: ALL_PROJECTS_SCOPE,
+      dryRun: false,
+      instruction: 'candidate Y',
+    });
+
+    expect(swept).toBe(0);
+    const after = getRun(stale.id, ALL_PROJECTS_SCOPE)!;
+    expect(after.resumable).toBe(1);
+    expect(after.resume_status).toBe(RESUME_STATUS_READY);
+  });
+
+  it('supersedes when both the stale run and the completing run have NULL instruction', () => {
+    const stale = insertRun(makeResumableFailed({ id: 'run-null-instr' }));
+    const completing = insertRun(makeRun({ id: 'run-null-instr-complete', status: 'completed' }));
+
+    const swept = supersedeEquivalentResumableRuns(completing.id, {
+      agentId: TEST_AGENT_ID,
+      taskName: TEST_TASK,
+      scope: ALL_PROJECTS_SCOPE,
+      dryRun: false,
+      instruction: null,
+    });
+
+    expect(swept).toBe(1);
+    expect(getRun(stale.id, ALL_PROJECTS_SCOPE)!.resumable).toBe(0);
+  });
+
+  it('does NOT supersede a LIVE resumable run when the completing run is a DRY run', () => {
+    const liveStale = insertRun(makeResumableFailed({ id: 'run-live-stale', dryRun: false }));
+    const completingDry = insertRun(makeRun({ id: 'run-completing-dry', status: 'completed', dryRun: true }));
+
+    const swept = supersedeEquivalentResumableRuns(completingDry.id, {
+      agentId: TEST_AGENT_ID,
+      taskName: TEST_TASK,
+      scope: ALL_PROJECTS_SCOPE,
+      dryRun: true,
+      instruction: null,
+    });
+
+    expect(swept).toBe(0);
+    const after = getRun(liveStale.id, ALL_PROJECTS_SCOPE)!;
+    expect(after.resumable).toBe(1);
+  });
+
+  it('does not touch a resumable run for a different task', () => {
+    const otherTaskRun = insertRun(makeResumableFailed({ id: 'run-other-task', task: 'vault-evolve' }));
+    const completing = insertRun(makeRun({ id: 'run-completing-2', status: 'completed' }));
+
+    supersedeEquivalentResumableRuns(completing.id, {
+      agentId: TEST_AGENT_ID,
+      taskName: TEST_TASK,
+      scope: ALL_PROJECTS_SCOPE,
+      dryRun: false,
+      instruction: null,
+    });
+
+    expect(getRun(otherTaskRun.id, ALL_PROJECTS_SCOPE)!.resumable).toBe(1);
+  });
+
+  it('sweeps multiple stale resumable runs at once', () => {
+    insertRun(makeResumableFailed({ id: 'run-old-1' }));
+    insertRun(makeResumableFailed({ id: 'run-old-2' }));
+    const completing = insertRun(makeRun({ id: 'run-completing-3', status: 'completed' }));
+
+    const swept = supersedeEquivalentResumableRuns(completing.id, {
+      agentId: TEST_AGENT_ID,
+      taskName: TEST_TASK,
+      scope: ALL_PROJECTS_SCOPE,
+      dryRun: false,
+      instruction: null,
+    });
+
+    expect(swept).toBe(2);
+  });
+});
+
+describe('sweepStaleSupersededRuns (boot-time backfill)', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    registerAgent({ id: TEST_AGENT_ID, name: 'Supersede Test Agent', created_at: epochNow() });
+  });
+
+  it('sweeps a pre-existing stale resumable row on boot using the same equivalence key', () => {
+    const stale = insertRun(makeResumableFailed({ id: 'run-boot-stale', completed_at: epochNow() - 100 }));
+    insertRun(makeRun({ id: 'run-boot-completed', status: 'completed', completed_at: epochNow() - 50 }));
+
+    const swept = sweepStaleSupersededRuns(ALL_PROJECTS_SCOPE);
+
+    expect(swept).toBe(1);
+    const after = getRun(stale.id, ALL_PROJECTS_SCOPE)!;
+    expect(after.resumable).toBe(0);
+    expect(after.resume_status).toBe(RESUME_STATUS_SUPERSEDED);
+  });
+
+  it('is idempotent — a second boot pass matches zero rows', () => {
+    insertRun(makeResumableFailed({ id: 'run-boot-stale-2', completed_at: epochNow() - 100 }));
+    insertRun(makeRun({ id: 'run-boot-completed-2', status: 'completed', completed_at: epochNow() - 50 }));
+
+    expect(sweepStaleSupersededRuns(ALL_PROJECTS_SCOPE)).toBe(1);
+    expect(sweepStaleSupersededRuns(ALL_PROJECTS_SCOPE)).toBe(0);
+  });
+
+  it('does not sweep a resumable run whose instruction differs from the completed run', () => {
+    const stale = insertRun(makeResumableFailed({
+      id: 'run-boot-instr-x',
+      instruction: 'candidate X',
+      completed_at: epochNow() - 100,
+    }));
+    insertRun(makeRun({
+      id: 'run-boot-instr-y',
+      status: 'completed',
+      instruction: 'candidate Y',
+      completed_at: epochNow() - 50,
+    }));
+
+    expect(sweepStaleSupersededRuns(ALL_PROJECTS_SCOPE)).toBe(0);
+    expect(getRun(stale.id, ALL_PROJECTS_SCOPE)!.resumable).toBe(1);
+  });
+
+  it('handles an interrupted run (NULL completed_at) via COALESCE fallback to started_at', () => {
+    const interrupted = insertRun({
+      id: 'run-boot-interrupted',
+      agent_id: TEST_AGENT_ID,
+      task: TEST_TASK,
+      status: 'failed',
+      resumable: 1,
+      resume_status: RESUME_STATUS_READY,
+      started_at: epochNow() - 300,
+      completed_at: null,
+    });
+    insertRun(makeRun({ id: 'run-boot-completed-3', status: 'completed', completed_at: epochNow() - 100 }));
+
+    expect(sweepStaleSupersededRuns(ALL_PROJECTS_SCOPE)).toBe(1);
+    expect(getRun(interrupted.id, ALL_PROJECTS_SCOPE)!.resumable).toBe(0);
+  });
+
+  it('does not sweep a resumable run with no completed equivalent at all', () => {
+    const untouched = insertRun(makeResumableFailed({ id: 'run-no-completion' }));
+
+    expect(sweepStaleSupersededRuns(ALL_PROJECTS_SCOPE)).toBe(0);
+    expect(getRun(untouched.id, ALL_PROJECTS_SCOPE)!.resumable).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

The pattern fix for the resume-bypass root cause (plan `65ea1b540bf846d2` v2; root-cause trace in spore `discovery-936c7370`). Systemic statement: gate verdicts are computed only at phase-execution time, and resume re-admitted runs by trusting persisted snapshots — checkpoints (never re-validated against contracts that shipped later), instruction (re-run against watermarks newer runs had advanced), and the resumability flag (re-marked `ready` even when deterministically unresumable). Both fresh dispatch paths enforce identical gate stacks; resume — both endpoints — was the bypass.

Observed costs before the fix: three no-op zombie resumes of one pre-gate run delayed real skill-evolve work ~25h by consuming schedule slots; a stale resumed skill-survey tried to force a superseded reconciliation through with `ignore_watermark` (the semantic check was the last line of defense).

## The gate (one admission gate, four parts)

1. **Completion-time supersede sweep (primary, structural):** when a run completes, every still-resumable failed run matching its equivalence key — `(agent, task, project scope, dry_run, instruction)`, NULL-safe on instruction and scope — is terminal-marked `resume_status='superseded'`. No timestamp comparison anywhere, so the resume-overwrites-`started_at` trap can't bite. A shared `appendSupersedeEquivalenceCondition` helper keeps the sweep, the belt, and the boot sweep structurally incapable of drifting on what "equivalent" means.
2. **Checkpoint re-validation at the restore seam:** restored `completed` checkpoints that declare a `postCondition` are re-checked (cheap deterministic DB reads); failures are demoted (checkpoint → failed + `postConditionFailed`, phase omitted from restored results) so the phase re-runs with a fresh session. Resumes now self-heal when gates ship after checkpoints were written. `skipped` phases are never re-validated; the loud-bypass and fail-open precedents of the live gate are mirrored.
3. **Anything-left-to-run check:** an all-restored resume that still fails the run-end validator throws a typed `PostconditionUnsatisfiableError` (detected via a new `executedPhaseCount` return — restored checkpoints carry original turn telemetry, so no catch-side signal existed) and terminal-marks `postcondition_unsatisfiable`, checkpoints preserved for debugging.
4. **Slot fairness:** a gate-refused resume falls through to a fresh dispatch in the same scheduler tick (the exhaustion-path shape); the deliberate pre-dispatch `lastRun` stamp is untouched.

Plus: a one-time boot sweep retires pre-existing zombies (runs post-`createSchema` at both interrupted-run sites); manual resume of a superseded run returns 409 naming the superseding run (swept runs keep the existing 400 and lose their Resume button automatically; "Rerun with same settings" is the intent-preserving path). `NON_RESUMABLE_SCHEDULED_TASKS` and `RESUME_MAX_ATTEMPTS` are deliberately not subsumed.

## Accepted behaviors (review notes, all fail-safe)

- NULL-task runs bypass the manual 409 belt (no false 409; the sweep is likewise keyed) — commented.
- The boot sweep's outer scan is a table scan (boot-only, bounded).
- `executedPhaseCount` counts precondition-skipped fresh phases, so a pathological resume can take one extra bounded attempt before terminal-marking — conservative direction.
- A superseded at-cap run emits no failure notification (equivalent work succeeded; nothing operator-actionable).

## Verification

- Plan pickup-reviewed before execution (4 Majors folded — including a detection signal that didn't exist at the originally cited seam and an interval-clock requirement that contradicted deliberate design).
- Implementation review: **Ready to merge, 0 Critical/Important**; all 7 named checks passed against source, including equivalence-key correctness when a *resumed* run completes (options backfill carries the original key) and the demote-AND-omit duality.
- Five regression tests pin each part (incl. the negatives: different instruction does not sweep; dry does not sweep live). Full `npm test` green; `make build` green; `tsc --noEmit` clean.
- Post-merge live gate: dev daemon restart must boot-sweep the real zombie (run `0688614b`, still resumable with completed equivalent `db4a6a06` beside it) to `superseded` with no hand-editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
