### PR TITLE
fix(daemon): preserve original dispatch time across resumes; sweep on original-dispatch recency

### DIFF
--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -459,12 +459,14 @@ export async function runAgent(
   // (prompt loading, vault context, provider resolution above) can leave an
   // orphaned 'running' row that the catch below never marks failed.
   const now = epochSeconds();
+  // Fields common to both a fresh dispatch and a resume attempt. `started_at`
+  // is deliberately NOT here — see the two branches below: a fresh dispatch
+  // stamps it once (original dispatch time), a resume must never touch it.
   const runStart = {
     status: STATUS_RUNNING,
     harness: harnessId,
     model: effectiveModel,
     checkpoints: serializeCheckpointState(checkpointState),
-    started_at: now,
   } as const;
   if (!resumedRun) {
     // Resolved once here, same as the reasoningLevel column below. Folding it
@@ -491,6 +493,7 @@ export async function runAgent(
       task: config.taskName,
       instruction: options?.instruction ?? null,
       ...runStart,
+      started_at: now,
       provider: effectiveProvider?.type ?? null,
       usage_data: buildUsageData({}),
       run_context: options?.runContext ? JSON.stringify(options.runContext) : null,
@@ -504,15 +507,17 @@ export async function runAgent(
       },
     });
   } else {
-    // Diagnostic gotcha: this OVERWRITES the run row's story on every
-    // resume — started_at (via ...runStart), resumed_at, error, and (if
-    // this attempt itself fails) the checkpoint's postConditionFailed flag
-    // on any phase that succeeds this time. The row reflects only the
-    // LATEST attempt; per-attempt truth for prior attempts lives in the
-    // daemon log + agent_run_events, not in this row. This is exactly why
-    // Part 1's supersede sweep and the Part 1 belt never compare against
-    // started_at (resume-overwritten) and instead use
-    // COALESCE(completed_at, started_at) or completion-time triggers.
+    // `started_at` is preserved as the run's ORIGINAL dispatch time across
+    // every resume attempt — it is never re-stamped here. `resumed_at` is
+    // the per-attempt recency field: it advances on every resume and is the
+    // signal any "how long has the CURRENT attempt been alive" or "when did
+    // this row last move" consumer should read (COALESCE(resumed_at,
+    // started_at)). error and the checkpoint's postConditionFailed flag (on
+    // any phase that succeeds this time) still reflect only the LATEST
+    // attempt — per-attempt truth for prior attempts lives in the daemon log
+    // + agent_run_events, not in this row. The supersede sweep and belt
+    // compare completions against `started_at` directly (see runs.ts) now
+    // that it is stable dispatch-order evidence.
     applyRunUpdate(runId, {
       ...runStart,
       provider: effectiveProvider?.type ?? resumedRun.provider ?? null,

--- a/packages/myco/src/agent/run-accounting.ts
+++ b/packages/myco/src/agent/run-accounting.ts
@@ -13,17 +13,28 @@ const TOKEN_BUDGET_WARNING_PERCENT = 75;
 const TOKEN_BUDGET_CRITICAL_PERCENT = 90;
 
 /**
- * Compute the elapsed duration of a run in milliseconds. Returns `null`
- * unless both timestamps are populated. Started/completed timestamps on
- * `agent_runs` are stored in seconds; this helper converts to ms for UI
- * consumers that expect millisecond precision.
+ * Compute the elapsed duration of the run's CURRENT attempt in
+ * milliseconds. Returns `null` unless both timestamps are populated.
+ * Started/completed/resumed timestamps on `agent_runs` are stored in
+ * seconds; this helper converts to ms for UI consumers that expect
+ * millisecond precision.
+ *
+ * Anchors on `COALESCE(resumed_at, started_at)`, not `started_at` alone:
+ * `started_at` is preserved as the run's ORIGINAL dispatch time across
+ * resumes (see executor.ts), so a naive `completed_at - started_at` would
+ * report the wall-clock span since the FIRST attempt — including however
+ * long the run sat failed and unresumed — as if it were work time.
+ * `resumed_at` is the per-attempt clock; it is null until the first resume,
+ * so a never-resumed run still measures from its one and only `started_at`.
  */
 export function runDurationMs(run: {
   started_at: number | null;
   completed_at: number | null;
+  resumed_at?: number | null;
 }): number | null {
-  if (run.started_at === null || run.completed_at === null) return null;
-  return (run.completed_at - run.started_at) * 1000;
+  const attemptStart = run.resumed_at ?? run.started_at;
+  if (attemptStart === null || attemptStart === undefined || run.completed_at === null) return null;
+  return (run.completed_at - attemptStart) * 1000;
 }
 
 function toRequestTokenNumber(

--- a/packages/myco/src/daemon/task-scheduling.ts
+++ b/packages/myco/src/daemon/task-scheduling.ts
@@ -182,7 +182,7 @@ export interface ScheduledResumeGateInput {
  *
  * - Superseded belt (Part 1 secondary): if a completed equivalent run
  *   (same agent/task/project scope/dry_run/instruction) finished AFTER this
- *   run's own `COALESCE(completed_at, started_at)`, terminal-marks
+ *   run's own ORIGINAL dispatch (`started_at`), terminal-marks
  *   (`resumable=0`, `resume_status='superseded'`) and returns 'superseded'
  *   — the caller falls through to a fresh dispatch. Defends legacy rows
  *   written before the completion-time sweep existed, and any race the

--- a/packages/myco/src/db/queries/feed.ts
+++ b/packages/myco/src/db/queries/feed.ts
@@ -62,7 +62,8 @@ export function getActivityFeed(
     SELECT * FROM (
       SELECT 'agent_run' as type, id, task || ' — ' || status as summary,
               COALESCE(completed_at, started_at) as timestamp
-       FROM agent_runs WHERE 1 = 1${clause.sql} ORDER BY started_at DESC LIMIT ?
+       FROM agent_runs WHERE 1 = 1${clause.sql}
+       ORDER BY COALESCE(resumed_at, started_at) DESC LIMIT ?
     )
 
     UNION ALL

--- a/packages/myco/src/db/queries/runs.ts
+++ b/packages/myco/src/db/queries/runs.ts
@@ -379,6 +379,14 @@ function buildRunsWhere(
  * (`dryRun`, `reasoningLevel`, `executionOverrides`) are handled
  * separately below because their column names differ, `dryRun` needs
  * boolean->integer coercion, and `executionOverrides` serializes to JSON.
+ *
+ * `started_at` is deliberately absent: it is a run's ORIGINAL dispatch
+ * time and must never be re-stamped by an update (see executor.ts's
+ * resume branch and the recency-sort comments on listRuns/getRunningRun*
+ * below). Excluding it here makes that guarantee structural — even a
+ * caller that accidentally includes `started_at` in a RunUpdate cannot
+ * move the column, because `buildUpdateClauses` only emits SET clauses
+ * for keys present in this list.
  */
 const UPDATE_COLUMNS: readonly (keyof RunUpdate)[] = [
   'status',
@@ -388,7 +396,6 @@ const UPDATE_COLUMNS: readonly (keyof RunUpdate)[] = [
   'provider',
   'model',
   'session_ref',
-  'started_at',
   'resumable',
   'resume_status',
   'resume_mode',
@@ -517,11 +524,18 @@ export function listRuns(options: ListRunsOptions): RunRow[] {
   const limit = options.limit ?? DEFAULT_LIST_LIMIT;
   const offset = options.offset ?? 0;
 
+  // Orders by the CURRENT-attempt clock (`COALESCE(resumed_at,
+  // started_at)`), not `started_at` alone — `started_at` is preserved as
+  // each run's ORIGINAL dispatch time (see executor.ts), so a run resumed
+  // long after its first dispatch still surfaces near the top of the list
+  // it was just active in, matching the rail's ACTIVE/TODAY/YESTERDAY
+  // section bucketing (RunList.tsx's `sectionRows` call uses the same
+  // attempt-start value client-side).
   const rows = db.prepare(
     `SELECT ${SELECT_COLUMNS}
      FROM agent_runs
      ${where}
-     ORDER BY started_at DESC NULLS LAST
+     ORDER BY COALESCE(resumed_at, started_at) DESC NULLS LAST
      LIMIT ?
      OFFSET ?`,
   ).all(...params, limit, offset) as Record<string, unknown>[];
@@ -576,6 +590,10 @@ export function updateRunStatus(
   return updateRun(id, { status, ...completion }, scope);
 }
 
+// Orders by the CURRENT-attempt clock (`COALESCE(resumed_at, started_at)`),
+// matching getRunningRunForTask below — `started_at` alone would surface a
+// stale never-resumed running row over one whose resume attempt is actually
+// the most recent activity for this agent.
 export function getRunningRun(agentId: string, scope: ProjectScope): RunRow | null {
   const db = getDatabase();
   const conditions = ['agent_id = ?', 'status = ?'];
@@ -585,7 +603,7 @@ export function getRunningRun(agentId: string, scope: ProjectScope): RunRow | nu
     `SELECT ${SELECT_COLUMNS}
      FROM agent_runs
      WHERE ${conditions.join(' AND ')}
-     ORDER BY started_at DESC NULLS LAST
+     ORDER BY COALESCE(resumed_at, started_at) DESC NULLS LAST
      LIMIT 1`,
   ).get(...params) as Record<string, unknown> | undefined;
   return row ? toRunRow(row) : null;
@@ -595,11 +613,16 @@ export interface RunningRunRef {
   id: string;
   started_at: number | null;
   /**
-   * True when `maxAgeSeconds` was given and the row's `started_at` exceeds
-   * the cutoff — a 'running' row no run loop is still driving (e.g. an
-   * update killed the process between boot-recovery sweeps). Callers treat
-   * a stale ref as not-running and log it; the row itself is NOT mutated
-   * here (boot recovery's `markRunningRunsInterrupted` owns that).
+   * True when `maxAgeSeconds` was given and the row's CURRENT-attempt clock
+   * — `COALESCE(resumed_at, started_at)` — exceeds the cutoff: a 'running'
+   * row no run loop is still driving (e.g. an update killed the process
+   * between boot-recovery sweeps). Deliberately NOT `started_at` alone: a
+   * resumed run preserves its original dispatch time (see executor.ts), so
+   * gauging staleness off `started_at` would immediately flag a
+   * just-resumed long-dormant run as stale even though its current attempt
+   * is seconds old. Callers treat a stale ref as not-running and log it; the
+   * row itself is NOT mutated here (boot recovery's
+   * `markRunningRunsInterrupted` owns that).
    */
   stale: boolean;
 }
@@ -615,15 +638,16 @@ export function getRunningRunForTask(
   const params: unknown[] = [agentId, taskName, STATUS_RUNNING];
   appendProjectCondition(conditions, params, scope);
   const row = db.prepare(
-    `SELECT id, started_at FROM agent_runs
+    `SELECT id, started_at, resumed_at FROM agent_runs
      WHERE ${conditions.join(' AND ')}
-     ORDER BY started_at DESC NULLS LAST
+     ORDER BY COALESCE(resumed_at, started_at) DESC NULLS LAST
      LIMIT 1`,
-  ).get(...params) as { id: string; started_at: number | null } | undefined;
+  ).get(...params) as { id: string; started_at: number | null; resumed_at: number | null } | undefined;
   if (!row) return null;
+  const attemptClock = row.resumed_at ?? row.started_at;
   const stale = maxAgeSeconds !== undefined
-    && row.started_at !== null
-    && epochSeconds() - row.started_at > maxAgeSeconds;
+    && attemptClock !== null
+    && epochSeconds() - attemptClock > maxAgeSeconds;
   return { id: row.id, started_at: row.started_at ?? null, stale };
 }
 
@@ -725,13 +749,11 @@ function appendSupersedeEquivalenceCondition(
  * run's own (agentId, taskName, scope, dryRun, instruction) as the
  * equivalence key. Terminal-marks (`resumable=0`,
  * `resume_status='superseded'`) every OTHER currently-resumable failed run
- * matching the key — structural, no timestamp comparison: anything still
- * resumable when an equivalent run completes is stale BY DEFINITION,
+ * matching the key — structural, no timestamp comparison needed: anything
+ * still resumable when an equivalent run completes is stale BY DEFINITION,
  * because the just-completed run's dispatch necessarily started no earlier
- * than the failed run's most recent attempt. Sidesteps the started_at
- * overwrite trap entirely (a resume re-stamps started_at:now — comparing
- * against it would be comparing the wrong clock). Swept runs hit the
- * existing resumable-guard 400 at the manual resume endpoint automatically
+ * than the failed run's most recent attempt. Swept runs hit the existing
+ * resumable-guard 400 at the manual resume endpoint automatically
  * (agent-runs.ts).
  *
  * `excludeRunId` is the completing run's own id — never supersede itself.
@@ -758,12 +780,13 @@ export function supersedeEquivalentResumableRuns(
  * before the completion-time sweep existed, and any race the sweep's
  * single-completion trigger can't see. Returns the newest COMPLETED
  * equivalent run whose `completed_at` is newer than the failed run's own
- * `COALESCE(completed_at, started_at)` — the failed side must use COALESCE
- * because an interrupted run (`markRunningRunsInterrupted`) sets
- * status='failed' + resume_status='ready' WITHOUT a completed_at. Never
- * compare against the failed run's `started_at` alone: a resume overwrites
- * `started_at` on every attempt, so it is not stable dispatch-order evidence.
- * Returns null when no such run exists. Callers that only need the
+ * ORIGINAL dispatch (`started_at`) — a resume attempt never re-stamps
+ * `started_at` (see executor.ts), so it is stable dispatch-order evidence:
+ * a completion newer than the failed run's first dispatch necessarily
+ * postdates whatever work the failed run represents, resumed or not. The
+ * `COALESCE(F.started_at, 0)` guard only covers a pathological NULL
+ * `started_at`, never a resume — resumed rows keep their real dispatch
+ * time. Returns null when no such run exists. Callers that only need the
  * yes/no answer (`gateScheduledResume`) test the return for non-null;
  * callers that need to NAME the superseding run (the manual resume
  * endpoint's 409) read `.id` off the row.
@@ -777,7 +800,7 @@ export function findNewerCompletedEquivalentRun(
   const params: unknown[] = [failedRun.id, STATUS_COMPLETED];
   appendSupersedeEquivalenceCondition(conditions, params, match);
   conditions.push('completed_at > ?');
-  params.push(failedRun.completed_at ?? failedRun.started_at ?? 0);
+  params.push(failedRun.started_at ?? 0);
   const row = db.prepare(
     `SELECT ${SELECT_COLUMNS} FROM agent_runs
      WHERE ${conditions.join(' AND ')}
@@ -805,11 +828,15 @@ export function hasNewerCompletedEquivalentRun(
  * a daemon crash before the completing run's success path ran). Terminal-
  * marks every resumable failed run F for which ANY completed run C shares
  * F's equivalence key (agent_id, task, project scope, dry_run, instruction
- * equal or both NULL) and has `completed_at` newer than F's
- * `COALESCE(completed_at, started_at)` — same predicate as the gate-time
- * belt (`hasNewerCompletedEquivalentRun`), expressed as a single
- * correlated-EXISTS UPDATE so the whole scope sweeps in one SQL pass. Safe
- * to run on every boot: a fully-swept vault matches zero rows.
+ * equal or both NULL) and has `completed_at` newer than F's ORIGINAL
+ * dispatch (`started_at`) — same predicate as the gate-time belt
+ * (`hasNewerCompletedEquivalentRun`), expressed as a single
+ * correlated-EXISTS UPDATE so the whole scope sweeps in one SQL pass. A
+ * completed equivalent newer than the failed run's original dispatch
+ * supersedes it, resumed or not — `started_at` is stable dispatch-order
+ * evidence because a resume never re-stamps it (see executor.ts).
+ * `COALESCE(F.started_at, 0)` only guards a pathological NULL. Safe to run
+ * on every boot: a fully-swept vault matches zero rows.
  */
 export function sweepStaleSupersededRuns(scope: ProjectScope): number {
   const db = getDatabase();
@@ -835,7 +862,7 @@ export function sweepStaleSupersededRuns(scope: ProjectScope): number {
            AND COALESCE(C.project_id, '') = COALESCE(F.project_id, '')
            AND C.dry_run = F.dry_run
            AND (C.instruction = F.instruction OR (C.instruction IS NULL AND F.instruction IS NULL))
-           AND C.completed_at > COALESCE(F.completed_at, F.started_at, 0)
+           AND C.completed_at > COALESCE(F.started_at, 0)
        )`,
   ).run(RESUME_STATUS_SUPERSEDED, STATUS_FAILED, STATUS_COMPLETED, ...outerParams);
   return info.changes;

--- a/packages/myco/src/services/stats.ts
+++ b/packages/myco/src/services/stats.ts
@@ -155,10 +155,19 @@ export function gatherStats(vaultDir: string, options: GatherStatsOptions): V2St
     ).get(...scope.params) as { cnt: number };
     const unprocessed_batches = Number(unprocessedRow.cnt ?? 0);
 
+    // Sorts and reports on `COALESCE(resumed_at, started_at)` — the
+    // CURRENT-attempt clock, not `started_at` alone. `started_at` is
+    // preserved as a run's ORIGINAL dispatch time across resumes (see
+    // executor.ts), so a run resumed long after its first dispatch would
+    // otherwise report stale recency and could lose the ORDER BY to a
+    // fresher but never-resumed run. Matches the RunList rail's recency
+    // sort (runs.ts's listRuns) and the badge treatment on this branch.
     const lastRun = db.prepare(
-      `SELECT started_at, status FROM agent_runs WHERE 1 = 1${scope.sql} ORDER BY started_at DESC LIMIT 1`,
-    ).get(...scope.params) as { started_at: number; status: string } | undefined;
-    const last_run_at = lastRun ? lastRun.started_at : null;
+      `SELECT COALESCE(resumed_at, started_at) AS last_run_at, status FROM agent_runs
+        WHERE 1 = 1${scope.sql}
+        ORDER BY COALESCE(resumed_at, started_at) DESC LIMIT 1`,
+    ).get(...scope.params) as { last_run_at: number; status: string } | undefined;
+    const last_run_at = lastRun ? lastRun.last_run_at : null;
     const last_run_status = lastRun ? lastRun.status : null;
 
     const agentTotalRow = db.prepare(

--- a/packages/myco/ui/src/components/agent/RunDetail.tsx
+++ b/packages/myco/ui/src/components/agent/RunDetail.tsx
@@ -22,7 +22,7 @@ import {
 import { RunTaskDialog } from './RunTaskDialog';
 import { AuditTrail } from './AuditTrail';
 import { EventsPanel } from './EventsPanel';
-import { formatEpochRelative, capitalize } from '../../lib/format';
+import { formatEpochRelative, capitalize, runAttemptStart } from '../../lib/format';
 import { formatCost, formatTokens, formatDuration, resolveTaskName, statusBadgeVariant } from './helpers';
 import { PhaseTimeline, type PhaseResult } from './PhaseTimeline';
 import type { CostResolution } from '@myco/agent/cost/types';
@@ -499,7 +499,7 @@ export function RunDetail({ runId, onBack }: RunDetailProps) {
         />
         <MetricCard label="Task" value={resolveTaskName(run.task, tasksList)} mono />
         <MetricCard label="Started" value={formatEpochRelative(run.started_at)} mono />
-        <MetricCard label="Duration" value={formatDuration(run.started_at, run.completed_at)} mono />
+        <MetricCard label="Duration" value={formatDuration(runAttemptStart(run), run.completed_at)} mono />
         <MetricCard label="Tokens" value={formatTokens(run.tokens_used)} tone="ochre" mono />
         <MetricCard label={costCardLabel} value={formatCost(run.cost_usd, run.cost_source)} tone="ochre" mono />
       </div>

--- a/packages/myco/ui/src/components/agent/RunList.tsx
+++ b/packages/myco/ui/src/components/agent/RunList.tsx
@@ -10,7 +10,7 @@ import { RunTaskDialog } from './RunTaskDialog';
 import { useListKeyboardNav } from '../../hooks/use-list-keyboard-nav';
 import { DEFAULT_PAGE_SIZE } from '../../lib/constants';
 import { cn } from '../../lib/cn';
-import { formatEpochAgo, capitalize } from '../../lib/format';
+import { formatEpochAgo, capitalize, runAttemptStart } from '../../lib/format';
 import { sectionRows } from '../../lib/section-rows';
 import { statusBadgeVariant, formatDuration, UNKNOWN_TASK_LABEL } from './helpers';
 
@@ -147,11 +147,12 @@ const RunRailRow = memo(forwardRef<HTMLDivElement, RunRailRowProps>(function Run
 
   // Meta segments built conditionally so missing fields drop out entirely
   // rather than rendering em-dash placeholders that read as broken state.
-  // started_at already appears in the top-right; the meta line carries
-  // duration, tokens, and cost only.
+  // started_at (attempt-adjusted) already appears in the top-right; the
+  // meta line carries duration, tokens, and cost only.
+  const attemptStart = runAttemptStart(run);
   const metaSegments: string[] = [];
-  if (run.started_at !== null && run.completed_at !== null) {
-    metaSegments.push(formatDuration(run.started_at, run.completed_at));
+  if (attemptStart !== null && run.completed_at !== null) {
+    metaSegments.push(formatDuration(attemptStart, run.completed_at));
   }
   if (run.tokens_used !== null && run.tokens_used > 0) {
     metaSegments.push(`${run.tokens_used.toLocaleString()} tok`);
@@ -227,9 +228,9 @@ const RunRailRow = memo(forwardRef<HTMLDivElement, RunRailRowProps>(function Run
           )}
         </div>
         <div className="flex items-center gap-2 shrink-0">
-          {run.started_at !== null && (
+          {attemptStart !== null && (
             <span className="font-mono text-[10px] text-on-surface-variant whitespace-nowrap">
-              {formatEpochAgo(run.started_at)}
+              {formatEpochAgo(attemptStart)}
             </span>
           )}
           <div onClick={(e) => e.stopPropagation()}>
@@ -471,7 +472,7 @@ export function RunList({
           {(() => {
             const sections = sectionRows(runs, {
               isActive: (r) => r.status === 'running',
-              startedAtEpochSec: (r) => r.started_at,
+              startedAtEpochSec: (r) => runAttemptStart(r),
             });
             // Keyboard nav was wired with items=runs (flat array). The
             // setRowRef/cursorIndex indices must match positions in that

--- a/packages/myco/ui/src/hooks/use-agent.ts
+++ b/packages/myco/ui/src/hooks/use-agent.ts
@@ -347,9 +347,10 @@ export interface RunCompareSummary {
   /** Per-run write-intent summary. Populated for every run (dry or not). */
   write_intents: WriteIntentsSummary;
   /**
-   * Wall-clock duration in milliseconds, computed as
-   * `(completed_at - started_at) * 1000`. Null when either timestamp is
-   * missing (run in-flight or never started).
+   * Wall-clock duration of the run's current attempt in milliseconds,
+   * computed server-side as `(completed_at - COALESCE(resumed_at,
+   * started_at)) * 1000`. Null when either timestamp is missing (run
+   * in-flight or never started).
    */
   duration_ms: number | null;
 }

--- a/packages/myco/ui/src/lib/format.ts
+++ b/packages/myco/ui/src/lib/format.ts
@@ -64,6 +64,19 @@ export function capitalize(str: string): string {
 }
 
 /**
+ * Resolve an agent run's CURRENT-attempt start time: `resumed_at` when the
+ * run has been resumed at least once, else `started_at`. `started_at` is
+ * preserved as the run's ORIGINAL dispatch time across every resume (see
+ * executor.ts) — per-attempt displays (duration, "started" recency,
+ * rail-list section bucketing) must anchor on this instead, or a run
+ * resumed long after its first dispatch reads as having a multi-day
+ * duration / stale recency it never actually had.
+ */
+export function runAttemptStart(run: { started_at: number | null; resumed_at?: number | null }): number | null {
+  return run.resumed_at ?? run.started_at;
+}
+
+/**
  * Format the duration between two epoch-second timestamps as a human-readable string.
  * Returns an em dash if either timestamp is null.
  */

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -1149,7 +1149,11 @@ describe('runAgent', () => {
     expect(run!.resume_status).toBe('ready');
   });
 
-  it('resets started_at to the resume attempt time when resuming a failed run', async () => {
+  it('preserves the original started_at and advances resumed_at when resuming a failed run', async () => {
+    // started_at must survive every resume attempt unchanged — it is the
+    // run's ORIGINAL dispatch time and the supersede sweep/belt (runs.ts)
+    // depend on it being stable dispatch-order evidence. resumed_at is the
+    // per-attempt clock: it advances on every resume.
     const { runAgent } = await import('@myco/agent/executor.js');
 
     const existingRunId = crypto.randomUUID();
@@ -1182,9 +1186,66 @@ describe('runAgent', () => {
     expect(result.status).toBe('completed');
     const run = getRun(existingRunId, ALL_PROJECTS_SCOPE);
     expect(run).not.toBeNull();
-    expect(run!.started_at).toBeGreaterThan(originalStartedAt);
-    expect(run!.started_at).toBeGreaterThanOrEqual(run!.resumed_at ?? 0);
-    expect(run!.completed_at).toBeGreaterThanOrEqual(run!.started_at ?? 0);
+    expect(run!.started_at).toBe(originalStartedAt);
+    expect(run!.resumed_at).not.toBeNull();
+    expect(run!.resumed_at!).toBeGreaterThan(originalCompletedAt);
+    expect(run!.completed_at).toBeGreaterThanOrEqual(run!.resumed_at ?? 0);
+  });
+
+  it('preserves started_at and sets a fresh resumed_at across TWO resume attempts', async () => {
+    // Pins the field across two attempts: the second resume must not
+    // re-stamp started_at either, and resumed_at must advance each time
+    // (not freeze at the first resume's value).
+    const { runAgent } = await import('@myco/agent/executor.js');
+
+    const existingRunId = crypto.randomUUID();
+    const originalStartedAt = epochSeconds() - 500;
+    insertRun({
+      id: existingRunId,
+      agent_id: TEST_AGENT_ID,
+      task: TEST_TASK_NAME,
+      status: 'failed',
+      instruction: 'Retry this run twice',
+      harness: 'claude-sdk',
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      resumable: 1,
+      resume_status: 'ready',
+      checkpoints: JSON.stringify({ harness: 'claude-sdk', phases: {} }),
+      started_at: originalStartedAt,
+      completed_at: originalStartedAt + 60,
+      error: 'boom',
+    });
+
+    // First resume attempt fails.
+    mockQueryBehavior = 'error';
+    mockErrorMessage = 'Transient provider failure';
+    const firstResult = await runAgent(TEST_VAULT_DIR, { requestContext: TEST_REQUEST_CONTEXT,
+      task: TEST_TASK_NAME,
+      instruction: 'Retry this run twice',
+      resumeRunId: existingRunId,
+      resumeMode: 'manual',
+    });
+    expect(firstResult.status).toBe('failed');
+    const afterFirst = getRun(existingRunId, ALL_PROJECTS_SCOPE)!;
+    expect(afterFirst.started_at).toBe(originalStartedAt);
+    const firstResumedAt = afterFirst.resumed_at;
+    expect(firstResumedAt).not.toBeNull();
+
+    // Second resume attempt succeeds.
+    mockQueryBehavior = 'success';
+    const secondResult = await runAgent(TEST_VAULT_DIR, { requestContext: TEST_REQUEST_CONTEXT,
+      task: TEST_TASK_NAME,
+      instruction: 'Retry this run twice',
+      resumeRunId: existingRunId,
+      resumeMode: 'manual',
+    });
+    expect(secondResult.status).toBe('completed');
+    const afterSecond = getRun(existingRunId, ALL_PROJECTS_SCOPE)!;
+    expect(afterSecond.started_at).toBe(originalStartedAt);
+    expect(afterSecond.resumed_at).not.toBeNull();
+    expect(afterSecond.resumed_at!).toBeGreaterThanOrEqual(firstResumedAt!);
+    expect(afterSecond.completed_at).toBeGreaterThanOrEqual(afterSecond.resumed_at ?? 0);
   });
 
   it('stores user instruction in run record and prompt', async () => {

--- a/tests/agent/run-accounting.test.ts
+++ b/tests/agent/run-accounting.test.ts
@@ -1,7 +1,35 @@
 import { describe, expect, it } from 'bun:test';
-import { analyzeRuntimeTokenBudget, buildRunAccountingUpdate, summarizePhaseCosts } from '@myco/agent/run-accounting.js';
+import { analyzeRuntimeTokenBudget, buildRunAccountingUpdate, runDurationMs, summarizePhaseCosts } from '@myco/agent/run-accounting.js';
 import type { CostResolution } from '@myco/agent/cost/types.js';
 import type { PhaseResult } from '@myco/agent/types.js';
+
+describe('runDurationMs', () => {
+  it('measures from started_at when the run was never resumed', () => {
+    const ms = runDurationMs({ started_at: 1000, completed_at: 1010, resumed_at: null });
+    expect(ms).toBe(10_000);
+  });
+
+  it('measures from resumed_at, not the original started_at, once the run has been resumed', () => {
+    // started_at is preserved as the run's ORIGINAL dispatch time across
+    // resumes (executor.ts) — duration must reflect the CURRENT attempt's
+    // wall-clock span, not the time since the very first dispatch.
+    const ms = runDurationMs({ started_at: 1000, completed_at: 1010, resumed_at: 1008 });
+    expect(ms).toBe(2_000);
+  });
+
+  it('tolerates a missing resumed_at field (RunRow shape without the optional key)', () => {
+    const ms = runDurationMs({ started_at: 1000, completed_at: 1010 });
+    expect(ms).toBe(10_000);
+  });
+
+  it('returns null when completed_at is missing', () => {
+    expect(runDurationMs({ started_at: 1000, completed_at: null, resumed_at: null })).toBeNull();
+  });
+
+  it('returns null when started_at is missing, even with a resumed_at present', () => {
+    expect(runDurationMs({ started_at: null, completed_at: 1010, resumed_at: null })).toBeNull();
+  });
+});
 
 describe('analyzeRuntimeTokenBudget', () => {
   it('computes utilization and headroom when context length is known', () => {

--- a/tests/daemon/scheduled-resume-gate.test.ts
+++ b/tests/daemon/scheduled-resume-gate.test.ts
@@ -329,5 +329,67 @@ describe('gateScheduledResume', () => {
       expect(after.resumable).toBe(0);
       expect(after.resume_status).toBe(RESUME_STATUS_SUPERSEDED);
     });
+
+    // -----------------------------------------------------------------
+    // Regression: resume-overwrites-started_at zombie (discovery-936c7370
+    // live incident). Compares against runs-supersede.test.ts's boot-sweep
+    // pair for the same shape via the OTHER enforcement point (the
+    // gate-time belt, reached through gateScheduledResume).
+    // -----------------------------------------------------------------
+
+    it('supersedes a run whose own zombie resume inflated completed_at/resumed_at past the superseding completion, using ORIGINAL dispatch time', () => {
+      const t0 = epochNow() - 10_000;
+      const run = insertRun({
+        id: 'run-zombie-belt',
+        agent_id: TEST_AGENT_ID,
+        task: TEST_TASK,
+        status: 'failed',
+        resumable: 1,
+        resume_status: RESUME_STATUS_READY,
+        started_at: t0,
+        resumed_at: t0 + 5_000,
+        completed_at: t0 + 5_010,
+      });
+      insertRun({
+        id: 'run-superseding-belt',
+        agent_id: TEST_AGENT_ID,
+        task: TEST_TASK,
+        status: 'completed',
+        started_at: t0 + 100,
+        completed_at: t0 + 2_300,
+      });
+
+      expect(gate(run)).toBe('superseded');
+      const after = getRun('run-zombie-belt', ALL_PROJECTS_SCOPE)!;
+      expect(after.resumable).toBe(0);
+      expect(after.resume_status).toBe(RESUME_STATUS_SUPERSEDED);
+    });
+
+    it('does NOT supersede a run whose ORIGINAL dispatch postdates the last equivalent completion — genuinely newer work resumes normally', () => {
+      const t0 = epochNow() - 10_000;
+      insertRun({
+        id: 'run-older-equivalent-belt',
+        agent_id: TEST_AGENT_ID,
+        task: TEST_TASK,
+        status: 'completed',
+        started_at: t0,
+        completed_at: t0 + 50,
+      });
+      const run = insertRun({
+        id: 'run-genuinely-newer-belt',
+        agent_id: TEST_AGENT_ID,
+        task: TEST_TASK,
+        status: 'failed',
+        resumable: 1,
+        resume_status: RESUME_STATUS_READY,
+        started_at: t0 + 5_000,
+        completed_at: t0 + 5_010,
+      });
+
+      expect(gate(run)).toBe('resume');
+      const after = getRun('run-genuinely-newer-belt', ALL_PROJECTS_SCOPE)!;
+      expect(after.resumable).toBe(1);
+      expect(after.resume_status).toBe(RESUME_STATUS_READY);
+    });
   });
 });

--- a/tests/db/queries/feed.test.ts
+++ b/tests/db/queries/feed.test.ts
@@ -234,6 +234,42 @@ describe('getActivityFeed', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Agent run inner window selects by CURRENT-attempt recency
+  // ---------------------------------------------------------------------------
+
+  it('selects a resumed run into the inner agent_runs window by resumed_at, not started_at, when the window is smaller than the candidate set', async () => {
+    const now = epochNow();
+
+    // run-resumed was dispatched long ago (T0, started_at) but its resume
+    // attempt (T2, resumed_at) is the most recent activity of the three still-
+    // running rows below. If the inner per-branch window (`ORDER BY
+    // started_at DESC LIMIT ?`) sorted on started_at alone, this row would
+    // fall outside a window of 1 and never reach the outer sort at all —
+    // even though it is the most recently active agent_run in the feed.
+    insertRun({
+      id: 'run-resumed',
+      agent_id: TEST_AGENT_ID,
+      task: 'digest',
+      status: 'running',
+      started_at: now - 10_000,
+      resumed_at: now - 100,
+    });
+    insertRun({
+      id: 'run-fresh',
+      agent_id: TEST_AGENT_ID,
+      task: 'digest',
+      status: 'running',
+      started_at: now - 5_000,
+    });
+
+    // Inner window of 1 forces the branch to pick a single candidate before
+    // the outer ORDER BY timestamp DESC LIMIT ? ever sees the rest.
+    const feed = getActivityFeed(ALL_PROJECTS_SCOPE, 1);
+    expect(feed).toHaveLength(1);
+    expect(feed[0].id).toBe('run-resumed');
+  });
+
+  // ---------------------------------------------------------------------------
   // Only data from requested sources returned
   // ---------------------------------------------------------------------------
 

--- a/tests/db/queries/runs-supersede.test.ts
+++ b/tests/db/queries/runs-supersede.test.ts
@@ -242,4 +242,76 @@ describe('sweepStaleSupersededRuns (boot-time backfill)', () => {
     expect(sweepStaleSupersededRuns(ALL_PROJECTS_SCOPE)).toBe(0);
     expect(getRun(untouched.id, ALL_PROJECTS_SCOPE)!.resumable).toBe(1);
   });
+
+  // ---------------------------------------------------------------------
+  // Regression: the resume-overwrites-started_at zombie (discovery-936c7370
+  // live incident, PR #622 follow-up). A resumed-but-still-failed run must
+  // stay sweepable by its ORIGINAL dispatch time even after its own zombie
+  // resume attempt inflates completed_at/resumed_at past the superseding
+  // run's completion — started_at is what makes this comparison exact now
+  // that resumes no longer re-stamp it.
+  // ---------------------------------------------------------------------
+
+  it('sweeps a run whose LAST-ATTEMPT timestamps are newer than the superseding completion, using its ORIGINAL dispatch time', () => {
+    const t0 = epochNow() - 10_000;
+    // Original dispatch far in the past — the zombie's own later resume
+    // attempt (resumed_at/completed_at below) does NOT touch started_at.
+    const zombie = insertRun({
+      id: 'run-zombie-resumed-past-supersede',
+      agent_id: TEST_AGENT_ID,
+      task: TEST_TASK,
+      status: 'failed',
+      resumable: 1,
+      resume_status: RESUME_STATUS_READY,
+      started_at: t0,
+      // A stale resume attempt fired AFTER the superseding run below
+      // completed — completed_at/resumed_at land later in wall-clock time
+      // than the equivalent's completion, mirroring the live zombie shape.
+      resumed_at: t0 + 5_000,
+      completed_at: t0 + 5_010,
+    });
+    // The superseding equivalent completed BEFORE the zombie's own last
+    // attempt, but AFTER the zombie's ORIGINAL dispatch.
+    insertRun(makeRun({
+      id: 'run-superseding-equivalent',
+      status: 'completed',
+      started_at: t0 + 100,
+      completed_at: t0 + 2_300,
+    }));
+
+    const swept = sweepStaleSupersededRuns(ALL_PROJECTS_SCOPE);
+
+    expect(swept).toBe(1);
+    const after = getRun(zombie.id, ALL_PROJECTS_SCOPE)!;
+    expect(after.resumable).toBe(0);
+    expect(after.resume_status).toBe(RESUME_STATUS_SUPERSEDED);
+  });
+
+  it('does NOT sweep a run whose ORIGINAL dispatch postdates the last equivalent completion — genuinely newer work is preserved', () => {
+    const t0 = epochNow() - 10_000;
+    // The only completed equivalent finished well before this failed run
+    // was ever dispatched — this failed run represents newer work and must
+    // survive the sweep even though it is still resumable.
+    insertRun(makeRun({
+      id: 'run-older-equivalent',
+      status: 'completed',
+      started_at: t0,
+      completed_at: t0 + 50,
+    }));
+    const newerDispatch = insertRun({
+      id: 'run-genuinely-newer-dispatch',
+      agent_id: TEST_AGENT_ID,
+      task: TEST_TASK,
+      status: 'failed',
+      resumable: 1,
+      resume_status: RESUME_STATUS_READY,
+      started_at: t0 + 5_000,
+      completed_at: t0 + 5_010,
+    });
+
+    expect(sweepStaleSupersededRuns(ALL_PROJECTS_SCOPE)).toBe(0);
+    const after = getRun(newerDispatch.id, ALL_PROJECTS_SCOPE)!;
+    expect(after.resumable).toBe(1);
+    expect(after.resume_status).toBe(RESUME_STATUS_READY);
+  });
 });

--- a/tests/db/queries/runs.test.ts
+++ b/tests/db/queries/runs.test.ts
@@ -131,6 +131,28 @@ describe('run query helpers', () => {
       expect(rows[2].id).toBe('run-old');
     });
 
+    it('orders a resumed run by its CURRENT attempt (resumed_at), not its original dispatch', () => {
+      // started_at is preserved as the ORIGINAL dispatch time across resumes
+      // (executor.ts) — a run dispatched long ago but resumed moments ago
+      // must still surface near the top of the list, matching the rail's
+      // recency section bucketing (RunList.tsx).
+      const now = epochNow();
+      insertRun(makeRun({ id: 'run-recent-fresh', started_at: now - 50 }));
+      insertRun(makeRun({
+        id: 'run-old-dispatch-just-resumed',
+        started_at: now - 10_000,
+        resumed_at: now,
+      }));
+      insertRun(makeRun({ id: 'run-oldest', started_at: now - 200 }));
+
+      const rows = listRuns({ scope: ALL_PROJECTS_SCOPE });
+      expect(rows.map((r) => r.id)).toEqual([
+        'run-old-dispatch-just-resumed',
+        'run-recent-fresh',
+        'run-oldest',
+      ]);
+    });
+
     it('filters by agent_id', async () => {
       // Create a second agent
       registerAgent({
@@ -340,6 +362,30 @@ describe('run query helpers', () => {
       const updated = updateRunStatus('does-not-exist', 'running', undefined, ALL_PROJECTS_SCOPE);
       expect(updated).toBeNull();
     });
+
+    it('ignores started_at on an update — the column is structurally immutable once inserted', async () => {
+      // started_at is a run's ORIGINAL dispatch time (executor.ts) and must
+      // never move after insertRun. UPDATE_COLUMNS deliberately omits it, so
+      // buildUpdateClauses silently drops the key rather than emitting a SET
+      // clause for it — this pins that dropped-key behavior structurally,
+      // not just by caller discipline.
+      const now = epochNow();
+      const original = now - 10_000;
+      const data = makeRun({ started_at: original });
+      insertRun(data);
+
+      // Cast through RunUpdate's index signature is unnecessary — started_at
+      // is a legitimate (if inert) RunUpdate field — but the update also
+      // carries a real field so we can confirm the update otherwise applies.
+      const updated = updateRun(data.id, { started_at: now, status: 'completed' }, ALL_PROJECTS_SCOPE);
+
+      expect(updated).not.toBeNull();
+      expect(updated!.status).toBe('completed');
+      expect(updated!.started_at).toBe(original);
+
+      const reread = getRun(data.id, ALL_PROJECTS_SCOPE)!;
+      expect(reread.started_at).toBe(original);
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -372,6 +418,20 @@ describe('run query helpers', () => {
       const running = getRunningRun(TEST_AGENT_ID, ALL_PROJECTS_SCOPE);
       expect(running).not.toBeNull();
       expect(running!.id).toBe('run-new');
+    });
+
+    it('picks a resumed run by its CURRENT attempt (resumed_at), not its original dispatch', async () => {
+      const now = epochNow();
+      // run-resumed was dispatched long ago (T0) but its resume attempt (T2)
+      // is the most recent activity; run-fresh was dispatched at T1, strictly
+      // between T0 and T2, and never resumed. A started_at-only ORDER BY
+      // would incorrectly pick run-fresh.
+      insertRun(makeRun({ id: 'run-resumed', status: 'running', started_at: now - 10_000, resumed_at: now - 100 }));
+      insertRun(makeRun({ id: 'run-fresh', status: 'running', started_at: now - 5_000 }));
+
+      const running = getRunningRun(TEST_AGENT_ID, ALL_PROJECTS_SCOPE);
+      expect(running).not.toBeNull();
+      expect(running!.id).toBe('run-resumed');
     });
   });
 
@@ -574,6 +634,40 @@ describe('run query helpers', () => {
 
       const running = getRunningRunForTask(TEST_AGENT_ID, 'digest', ALL_PROJECTS_SCOPE, 600);
       expect(running!.stale).toBe(false);
+    });
+
+    it('treats a long-dormant run as fresh once resumed — stale is judged off the CURRENT attempt, not the original dispatch', () => {
+      // started_at is preserved as the run's ORIGINAL dispatch time across
+      // resumes (executor.ts) — a resume dispatched long after that time
+      // must not immediately read as a stale zombie row just because its
+      // first attempt was old.
+      const now = epochNow();
+      insertRun(makeRun({
+        id: 'run-resumed-fresh',
+        task: 'digest',
+        status: 'running',
+        started_at: now - 10_000,
+        resumed_at: now - 5,
+      }));
+
+      const running = getRunningRunForTask(TEST_AGENT_ID, 'digest', ALL_PROJECTS_SCOPE, 600);
+      expect(running).not.toBeNull();
+      expect(running!.id).toBe('run-resumed-fresh');
+      expect(running!.stale).toBe(false);
+    });
+
+    it('still flags a resumed run as stale once its CURRENT attempt (resumed_at) exceeds the cutoff', () => {
+      const now = epochNow();
+      insertRun(makeRun({
+        id: 'run-resumed-stale',
+        task: 'digest',
+        status: 'running',
+        started_at: now - 20_000,
+        resumed_at: now - 10_000,
+      }));
+
+      const running = getRunningRunForTask(TEST_AGENT_ID, 'digest', ALL_PROJECTS_SCOPE, 600);
+      expect(running!.stale).toBe(true);
     });
   });
 });

--- a/tests/services/phase-audit.test.ts
+++ b/tests/services/phase-audit.test.ts
@@ -230,6 +230,31 @@ describe('buildPhaseAudit', () => {
     expect(only.writeIntents).toBeNull();
   });
 
+  it('computes the synthetic phase duration from the CURRENT attempt (resumed_at), not the original dispatch', () => {
+    // started_at is preserved as the run's ORIGINAL dispatch time across
+    // resumes (executor.ts) — the synthetic single-phase duration must
+    // reflect the resumed attempt's actual wall-clock span, matching
+    // runDurationMs's COALESCE(resumed_at, started_at) semantics.
+    const originalDispatch = epochNow() - 10_000;
+    const resumedAt = epochNow() - 8;
+    const completedAt = epochNow();
+    insertRun({
+      id: 'run-flat-resumed',
+      agent_id: AGENT_ID,
+      task: 'extract-only',
+      status: 'completed',
+      started_at: originalDispatch,
+      resumed_at: resumedAt,
+      completed_at: completedAt,
+      tokens_used: 100,
+    });
+    insertTurn({ run_id: 'run-flat-resumed', agent_id: AGENT_ID, turn_number: 1, tool_name: 'vault_recall' });
+
+    const audit = buildPhaseAudit('run-flat-resumed', ALL_PROJECTS_SCOPE)!;
+    const [only] = audit.phases;
+    expect(only.durationMs).toBe((completedAt - resumedAt) * 1000);
+  });
+
   it('returns empty phases array for an empty run with no turns', () => {
     insertRun({ id: 'run-empty', agent_id: AGENT_ID, task: null });
     const audit = buildPhaseAudit('run-empty', ALL_PROJECTS_SCOPE)!;

--- a/tests/services/stats.test.ts
+++ b/tests/services/stats.test.ts
@@ -158,6 +158,46 @@ describe('gatherStats', () => {
     expect(stats.daemon.active_sessions).toEqual(['sess-1', 'sess-2']);
   });
 
+  it('reports last_run_at from a resumed run\'s CURRENT-attempt clock, not its original dispatch time', () => {
+    const now = epochNow();
+    const originalDispatch = now - 10_000; // T0: resumed run's original dispatch, long ago
+    const resumeTime = now - 100; // T2: resumed run's most recent attempt — the true recency signal
+    const freshDispatch = now - 5_000; // T1: a fresh (never-resumed) run dispatched after T0 but before T2
+
+    registerAgent({ id: AGENT_ID, name: 'Stats Agent', created_at: now });
+
+    // Resumed old run: started_at preserves ORIGINAL dispatch (T0); resumed_at
+    // is the per-attempt recency clock (T2) and must win the ORDER BY.
+    insertRun({
+      id: 'run-resumed',
+      agent_id: AGENT_ID,
+      task: 'digest',
+      status: 'completed',
+      started_at: originalDispatch,
+      resumed_at: resumeTime,
+      completed_at: resumeTime + 5,
+    });
+
+    // Fresh run: dispatched at T1, strictly between T0 and T2, never resumed.
+    // A started_at-only sort would incorrectly pick this row over run-resumed.
+    insertRun({
+      id: 'run-fresh',
+      agent_id: AGENT_ID,
+      task: 'digest',
+      status: 'failed',
+      started_at: freshDispatch,
+      completed_at: freshDispatch + 5,
+    });
+
+    const stats = gatherStats(vaultDir, { active_sessions: [], scope: ALL_PROJECTS_SCOPE });
+
+    // last_run_at must reflect the resumed run's CURRENT-attempt clock (T2),
+    // not its original dispatch (T0), and the resumed run — not the fresher
+    // never-resumed dispatch (T1) — must be the row selected.
+    expect(stats.agent.last_run_at).toBe(resumeTime);
+    expect(stats.agent.last_run_status).toBe('completed');
+  });
+
   it('reads Grove-scoped counts from an explicit database path instead of the singleton', () => {
     const now = epochNow();
     const targetVaultDir = path.join(tempDir, 'target', '.myco');


### PR DESCRIPTION
## What

Completes the resume-admission gate (#622) by fixing the root defect its live verification exposed: **the executor's resume path overwrote `started_at` on every attempt**, destroying the run's original dispatch time. Consequences observed live: run-history diagnostics told the latest attempt's story (misleading two analyses this week), and the founding zombie (`0688614b`) escaped the boot sweep because its own zombie resume inflated its timestamps past the run that superseded it — the exact trap the sweep's design avoided at completion time re-entered through the retroactive predicate.

## The fix

- **`started_at` is immutable** — original dispatch time, forever. Removed from `UPDATE_COLUMNS`, so re-stamping is *structurally impossible*, not caller discipline. `resumed_at` carries attempt recency.
- **Seventeen-reader consumer audit** (verified by an independent re-derivation in review): recency-class consumers — durations (`runDurationMs`, RunDetail/RunList), list ordering/staleness, `last_run_at` in stats ("Last run: X ago"), the activity-feed window, `getRunningRun` — move to `COALESCE(resumed_at, started_at)`; original-dispatch consumers (vault_run_health windows, project-activity ceilings) deliberately keep `started_at`.
- **Sweep + belt predicates** now compare completed equivalents against the failed run's **original dispatch time**: a genuinely newer dispatch is preserved (the correct non-sweep we observed), and a self-inflated zombie is not (the incorrect survival we observed).

## Verification

- Review verdict "with fixes": the independent audit caught one fix-introduced regression (stats `last_run_at` recency) — fixed along with two alignment/structural minors in-branch; re-verified.
- Tests pin: `started_at` immutable across two attempts with `resumed_at` advancing; the exact live zombie shape sweeps; a genuinely-newer-dispatch shape does not; an update carrying `started_at` cannot change the stored value; the changed recency consumers.
- Full `npm test` green; `make build` green; `tsc --noEmit` clean.
- Post-merge live gate: dev daemon restart must sweep `0688614b` to `superseded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
