### PR TITLE
fix(ui): stop report/phase summaries painting over the Show more row

### DIFF
--- a/packages/myco/ui/src/components/agent/PhaseTimeline.tsx
+++ b/packages/myco/ui/src/components/agent/PhaseTimeline.tsx
@@ -28,11 +28,16 @@ export interface PhaseTimelineProps {
 function PhaseSummary({ text }: { text: string }) {
   const [expanded, setExpanded] = useState(false);
   const isLong = text.length > 200 || text.includes('\n');
+  const collapsed = !expanded && isLong;
 
   return (
     <div className="mt-1">
-      <div className={!expanded && isLong ? 'line-clamp-2' : undefined}>
-        <MarkdownContent content={text} className="text-on-surface-variant [&>*]:text-on-surface-variant" />
+      <div className={collapsed ? 'line-clamp-2' : undefined}>
+        <MarkdownContent
+          content={text}
+          compact={collapsed}
+          className="text-on-surface-variant [&>*]:text-on-surface-variant"
+        />
       </div>
       {isLong && (
         <button

--- a/packages/myco/ui/src/components/agent/RunDetail.tsx
+++ b/packages/myco/ui/src/components/agent/RunDetail.tsx
@@ -124,11 +124,14 @@ function StatTile({ label, value }: { label: string; value: string }) {
 
 /* ---------- Sub-components ---------- */
 
-function ReportCard({ report }: { report: ReportRow }) {
+/* Tailwind purge: line-clamp-3 must appear as a literal string. */
+
+export function ReportCard({ report }: { report: ReportRow }) {
   const [detailsExpanded, setDetailsExpanded] = useState(false);
   const [summaryExpanded, setSummaryExpanded] = useState(false);
   const hasDetails = report.details !== null && report.details.length > 0;
   const isLongSummary = report.summary.length > 200 || report.summary.includes('\n');
+  const collapsed = !summaryExpanded && isLongSummary;
 
   const parsedDetails: unknown = hasDetails
     ? tryParseJson(report.details) ?? report.details
@@ -139,8 +142,8 @@ function ReportCard({ report }: { report: ReportRow }) {
       <div className="flex items-start gap-3">
         <Badge variant={actionBadgeVariant(report.action)}>{report.action}</Badge>
         <div className="flex-1 min-w-0">
-          <div className={!summaryExpanded && isLongSummary ? 'line-clamp-3' : undefined}>
-            <MarkdownContent content={report.summary} />
+          <div className={collapsed ? 'line-clamp-3' : undefined}>
+            <MarkdownContent content={report.summary} compact={collapsed} />
           </div>
           {isLongSummary && (
             <button

--- a/tests/ui/report-card-summary-clamp.test.tsx
+++ b/tests/ui/report-card-summary-clamp.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'bun:test';
+import { render, fireEvent } from '@testing-library/react';
+import { ReportCard } from '../../packages/myco/ui/src/components/agent/RunDetail';
+import { PhaseTimeline } from '../../packages/myco/ui/src/components/agent/PhaseTimeline';
+import type { ReportRow } from '../../packages/myco/ui/src/hooks/use-agent';
+
+function makeReport(summary: string): ReportRow {
+  return {
+    id: 1,
+    run_id: 'run-1',
+    agent_id: 'agent-1',
+    action: 'describe',
+    summary,
+    details: null,
+    created_at: 1_700_000_000,
+  };
+}
+
+// Mirrors the observed harness-health report shape: several distinct
+// "label (n): text" segments joined by newlines — multi-line, well over the
+// 200-char long-summary threshold.
+const MULTI_LINE_SUMMARY = [
+  'unpaired_events (1): a checkpoint fired without a matching completion event, which can indicate a dropped write in the phase pipeline.',
+  'postcondition_failures (1): the verify phase postcondition did not hold after the run completed.',
+  'cost_spikes (1): token cost for this run exceeded the rolling baseline by a wide margin.',
+].join('\n');
+
+const ONE_LINE_SUMMARY = 'short summary text that is nevertheless long enough to pass the two-hundred character long-summary threshold so that the show more expander renders for this single unbroken line of prose content, with no newlines in it at all.';
+
+// Blank-line-separated so each line becomes its own <p> — the worst case for
+// the block-stacking overlap bug (many separately-margined paragraph boxes
+// crammed into a 3-line clamp).
+const TEN_LINE_SUMMARY = Array.from({ length: 10 }, (_, i) => `line ${i + 1}: some report detail text here.`).join('\n\n');
+
+describe('ReportCard summary clamp/expander', () => {
+  it('renders collapsed with compact (inline-flattened) markdown so the clamp box has no block-level children', () => {
+    const { container } = render(<ReportCard report={makeReport(MULTI_LINE_SUMMARY)} />);
+
+    const clampDiv = container.querySelector('.line-clamp-3');
+    expect(clampDiv).not.toBeNull();
+
+    // The compact markdown variant must be active while collapsed: it flattens
+    // headings/paragraphs to `display: inline` (see prose-myco-compact in
+    // index.css) so the clamped box contains a single inline flow instead of
+    // stacked block boxes with their own margins. Stacked block boxes are what
+    // produced the painted-over/overlapping text next to the expander.
+    const markdownRoot = clampDiv!.querySelector('.prose-myco-compact');
+    expect(markdownRoot).not.toBeNull();
+    expect(clampDiv!.querySelector('.prose-myco:not(.prose-myco-compact)')).toBeNull();
+
+    // No paragraph produced by react-markdown should be block-level while
+    // collapsed — that's the geometry that overlapped the "Show more" row.
+    const paragraphs = clampDiv!.querySelectorAll('p');
+    for (const p of Array.from(paragraphs)) {
+      expect(p.className).not.toContain('prose-myco:not');
+    }
+  });
+
+  it('renders the "Show more" control after the clamp container, never nested inside it', () => {
+    const { container, getByText } = render(<ReportCard report={makeReport(MULTI_LINE_SUMMARY)} />);
+
+    const clampDiv = container.querySelector('.line-clamp-3');
+    const expander = getByText(/show more/i).closest('button');
+    expect(expander).not.toBeNull();
+    // The expander must be a sibling of the clamped block, not a descendant —
+    // an absolutely-positioned overlay nested inside the clamp box is exactly
+    // the interaction that painted over clamped text.
+    expect(clampDiv!.contains(expander)).toBe(false);
+    expect(expander!.parentElement).toBe(clampDiv!.parentElement);
+  });
+
+  it('expands to full (non-compact) markdown on click, removing the clamp class', () => {
+    const { container, getByText } = render(<ReportCard report={makeReport(MULTI_LINE_SUMMARY)} />);
+
+    fireEvent.click(getByText(/show more/i));
+
+    expect(container.querySelector('.line-clamp-3')).toBeNull();
+    expect(container.querySelector('.prose-myco-compact')).toBeNull();
+    expect(container.querySelector('.prose-myco')).not.toBeNull();
+    expect(getByText(/show less/i)).toBeDefined();
+  });
+
+  it('does not clamp or show an expander for a short (non-long) summary', () => {
+    const { container, queryByText } = render(<ReportCard report={makeReport('all good, nothing to see here.')} />);
+
+    expect(container.querySelector('.line-clamp-3')).toBeNull();
+    expect(container.querySelector('.prose-myco-compact')).toBeNull();
+    expect(queryByText(/show more/i)).toBeNull();
+  });
+
+  it('clamps a single long line the same way as a multi-line summary', () => {
+    const { container } = render(<ReportCard report={makeReport(ONE_LINE_SUMMARY)} />);
+
+    const clampDiv = container.querySelector('.line-clamp-3');
+    expect(clampDiv).not.toBeNull();
+    expect(clampDiv!.querySelector('.prose-myco-compact')).not.toBeNull();
+  });
+
+  it('clamps a ten-line summary without leaving block-level paragraphs in the collapsed box', () => {
+    const { container } = render(<ReportCard report={makeReport(TEN_LINE_SUMMARY)} />);
+
+    const clampDiv = container.querySelector('.line-clamp-3');
+    expect(clampDiv).not.toBeNull();
+    expect(clampDiv!.querySelector('.prose-myco-compact')).not.toBeNull();
+
+    // react-markdown still produces one <p> per source line; compact CSS makes
+    // them `display: inline`, but structurally they must still all live inside
+    // the single clamp container (not escape it).
+    const paragraphs = clampDiv!.querySelectorAll('p');
+    expect(paragraphs.length).toBe(10);
+  });
+});
+
+describe('PhaseTimeline summary clamp/expander', () => {
+  it('renders phase summaries in compact mode while collapsed', () => {
+    const { container } = render(
+      <PhaseTimeline
+        phases={[
+          {
+            name: 'verify',
+            status: 'completed',
+            turnsUsed: 3,
+            tokensUsed: 500,
+            costUsd: 0.001,
+            summary: MULTI_LINE_SUMMARY,
+          },
+        ]}
+      />,
+    );
+
+    const clampDiv = container.querySelector('.line-clamp-2');
+    expect(clampDiv).not.toBeNull();
+    expect(clampDiv!.querySelector('.prose-myco-compact')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Fixes the RunDetail visual defect where long report summaries painted clamped text over the "Show more" expander (observed live on multi-line harness-health reports). Root cause: `ReportCard`/`PhaseSummary` clamp multi-paragraph markdown with `line-clamp-N` but rendered `MarkdownContent` without its `compact` prop — react-markdown's block-level `<p>` margin boxes stack outside the clamp geometry (`-webkit-line-clamp` needs inline-flowing children). Fix: `compact={collapsed}` at both affected sites (REPORTS panel + the identical latent bug in PHASE EXECUTION), reusing the compact+clamp composition already shipped in SporeList.

## Verification

Review verdict: ready to merge — root cause verified against the actual CSS; all 14 other MarkdownContent call sites checked (none combine clamp + non-compact); 7 new DOM-contract tests (clamp classes, sibling expander, 10-paragraph case, expand path); full `npm test` + `make build` + `tsc` green. Visual confirmation lands in the post-deploy Playwright pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)