### PR TITLE
fix(agent): emit per-request usage entries for the Claude harness

### DIFF
--- a/packages/myco/src/agent/executor-state.test.ts
+++ b/packages/myco/src/agent/executor-state.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'bun:test';
+import { aggregateUsage } from './executor-state.js';
+import { analyzeRuntimeTokenBudget } from './run-accounting.js';
+import type { RuntimeUsage } from './types.js';
+
+describe('aggregateUsage requestUsageEntries merging', () => {
+  test('concatenates entries across phases rather than dropping or overwriting them', () => {
+    const phase1: RuntimeUsage = {
+      requests: 2,
+      inputTokens: 300,
+      outputTokens: 100,
+      totalTokens: 400,
+      requestUsageEntries: [
+        { inputTokens: 200, outputTokens: 60, cachedTokens: 0, totalTokens: 260 },
+        { inputTokens: 100, outputTokens: 40, cachedTokens: 0, totalTokens: 140 },
+      ],
+    };
+    const phase2: RuntimeUsage = {
+      requests: 1,
+      inputTokens: 5000,
+      outputTokens: 200,
+      totalTokens: 5200,
+      requestUsageEntries: [
+        { inputTokens: 5000, outputTokens: 200, cachedTokens: 4500, totalTokens: 5200 },
+      ],
+    };
+
+    const aggregate = aggregateUsage([phase1, phase2]);
+
+    expect(aggregate.requestUsageEntries).toHaveLength(3);
+    expect(aggregate.requestUsageEntries).toEqual([
+      ...phase1.requestUsageEntries!,
+      ...phase2.requestUsageEntries!,
+    ]);
+    // Run totals still sum normally — unaffected by entry merging.
+    expect(aggregate.inputTokens).toBe(5300);
+    expect(aggregate.outputTokens).toBe(300);
+  });
+
+  test('phases with no entries are skipped without producing empty/undefined slots', () => {
+    const withEntries: RuntimeUsage = {
+      requestUsageEntries: [{ inputTokens: 10, outputTokens: 5, cachedTokens: 0, totalTokens: 15 }],
+    };
+    const withoutEntries: RuntimeUsage = { inputTokens: 50, outputTokens: 10 };
+
+    const aggregate = aggregateUsage([withEntries, withoutEntries]);
+    expect(aggregate.requestUsageEntries).toHaveLength(1);
+  });
+
+  test('no phase has entries: aggregate.requestUsageEntries stays undefined (falls back to run-total single-entry path)', () => {
+    const aggregate = aggregateUsage([{ inputTokens: 10, outputTokens: 5, totalTokens: 15 }]);
+    expect(aggregate.requestUsageEntries).toBeUndefined();
+  });
+
+  test('multi-phase peak-over-entries reflects the true cross-phase peak, not the summed run total', () => {
+    // Phase A: 3 small requests. Phase B: 1 large request. The run total is
+    // the sum of everything, but the peak must be phase B's single entry —
+    // not the run-level cumulative total, which is what a phase-dropping
+    // aggregation used to leave `analyzeRuntimeTokenBudget` to fall back to.
+    const phaseA: RuntimeUsage = {
+      inputTokens: 300,
+      outputTokens: 90,
+      totalTokens: 390,
+      requestUsageEntries: [
+        { inputTokens: 100, outputTokens: 30, cachedTokens: 0, totalTokens: 130 },
+        { inputTokens: 100, outputTokens: 30, cachedTokens: 0, totalTokens: 130 },
+        { inputTokens: 100, outputTokens: 30, cachedTokens: 0, totalTokens: 130 },
+      ],
+    };
+    const phaseB: RuntimeUsage = {
+      inputTokens: 8000,
+      outputTokens: 500,
+      totalTokens: 8500,
+      requestUsageEntries: [
+        { inputTokens: 8000, outputTokens: 500, cachedTokens: 0, totalTokens: 8500 },
+      ],
+    };
+
+    const runUsage = aggregateUsage([phaseA, phaseB]);
+    const budget = analyzeRuntimeTokenBudget(runUsage, { type: 'anthropic', contextLength: 200_000 });
+
+    expect(budget.peakRequestTotalTokens).toBe(8500);
+    expect(runUsage.totalTokens).toBe(390 + 8500);
+    expect(budget.peakRequestTotalTokens).toBeLessThan(runUsage.totalTokens!);
+  });
+});

--- a/packages/myco/src/agent/executor-state.ts
+++ b/packages/myco/src/agent/executor-state.ts
@@ -206,6 +206,12 @@ export function aggregateUsage(usages: Array<RuntimeUsage | undefined>): Runtime
     durationMs: 0,
   };
   let sawCost = false;
+  // Concatenated (not summed) across phases/items — each entry is still a
+  // single request's own usage, so `analyzeRuntimeTokenBudget`'s
+  // peak-over-entries can find the true per-request peak across the whole
+  // run instead of only the last phase's entries (which is what a naive
+  // overwrite would leave behind).
+  const requestUsageEntries: Array<Record<string, unknown>> = [];
 
   for (const usage of usages) {
     if (!usage) continue;
@@ -220,10 +226,16 @@ export function aggregateUsage(usages: Array<RuntimeUsage | undefined>): Runtime
       aggregate.costUsd = (aggregate.costUsd ?? 0) + usage.costUsd;
       sawCost = true;
     }
+    if (usage.requestUsageEntries && usage.requestUsageEntries.length > 0) {
+      requestUsageEntries.push(...usage.requestUsageEntries);
+    }
   }
 
   if (!sawCost) {
     delete aggregate.costUsd;
+  }
+  if (requestUsageEntries.length > 0) {
+    aggregate.requestUsageEntries = requestUsageEntries;
   }
 
   return aggregate;

--- a/packages/myco/src/agent/harness/claude.test.ts
+++ b/packages/myco/src/agent/harness/claude.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, test } from 'bun:test';
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import { consumeClaudeMessageStream } from './claude.js';
+import { analyzeRuntimeTokenBudget } from '@myco/agent/run-accounting.js';
+
+/**
+ * Builds a synthetic `assistant` SDK message carrying a per-request
+ * `BetaUsage` snapshot on `message.usage` — the shape the real SDK emits
+ * once per API turn (see `BetaMessage.usage` in
+ * `@anthropic-ai/sdk/resources/beta/messages/messages.d.mts`).
+ */
+function assistantMessage(usage: {
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}): SDKMessage {
+  return {
+    type: 'assistant',
+    message: { usage },
+    parent_tool_use_id: null,
+    uuid: 'uuid-assistant',
+    session_id: 'session-1',
+  } as unknown as SDKMessage;
+}
+
+/** Builds a synthetic terminal `result` message with run-cumulative usage. */
+function resultMessage(input: {
+  numTurns: number;
+  totalCostUsd: number;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+  resultText?: string;
+}): SDKMessage {
+  return {
+    type: 'result',
+    subtype: 'success',
+    duration_ms: 1000,
+    duration_api_ms: 900,
+    is_error: false,
+    num_turns: input.numTurns,
+    result: input.resultText ?? 'done',
+    stop_reason: null,
+    total_cost_usd: input.totalCostUsd,
+    usage: input.usage,
+    modelUsage: {},
+    permission_denials: [],
+    uuid: 'uuid-result',
+    session_id: 'session-1',
+  } as unknown as SDKMessage;
+}
+
+async function* streamOf(messages: SDKMessage[]): AsyncIterable<SDKMessage> {
+  for (const message of messages) {
+    yield message;
+  }
+}
+
+describe('consumeClaudeMessageStream request usage entries', () => {
+  test('multi-turn: emits one entry per assistant message with correct composition and totals match sum', async () => {
+    const messages: SDKMessage[] = [
+      assistantMessage({ input_tokens: 100, output_tokens: 50, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 }),
+      assistantMessage({ input_tokens: 20, output_tokens: 80, cache_creation_input_tokens: 0, cache_read_input_tokens: 900 }),
+      assistantMessage({ input_tokens: 30, output_tokens: 120, cache_creation_input_tokens: 0, cache_read_input_tokens: 950 }),
+      resultMessage({
+        numTurns: 3,
+        totalCostUsd: 0.05,
+        // Run-cumulative totals as the real SDK reports them on the terminal
+        // result message: running sums across the whole conversation
+        // (input 150 = 100+20+30, output 250 = 50+80+120, reads 1850 = 900+950).
+        usage: { input_tokens: 150, output_tokens: 250, cache_creation_input_tokens: 0, cache_read_input_tokens: 1850 },
+      }),
+    ];
+
+    const { usage } = await consumeClaudeMessageStream(streamOf(messages), { localProvider: false });
+
+    expect(usage.requestUsageEntries).toHaveLength(3);
+
+    const entries = usage.requestUsageEntries as Array<{
+      inputTokens: number;
+      outputTokens: number;
+      cachedTokens: number;
+      totalTokens: number;
+    }>;
+
+    // Entry 1: no cache activity.
+    expect(entries[0]).toEqual({ inputTokens: 100, outputTokens: 50, cachedTokens: 0, totalTokens: 150 });
+    // Entry 2: 900 cached-read tokens fold into inputTokens, cachedTokens = 900.
+    expect(entries[1]).toEqual({ inputTokens: 920, outputTokens: 80, cachedTokens: 900, totalTokens: 1000 });
+    // Entry 3: 950 cached-read tokens fold into inputTokens, cachedTokens = 950.
+    expect(entries[2]).toEqual({ inputTokens: 980, outputTokens: 120, cachedTokens: 950, totalTokens: 1100 });
+
+    // Run totals are sourced from the terminal `result` message only —
+    // untouched by per-message entry collection.
+    expect(usage.inputTokens).toBe(150 + 0 + 1850); // input_tokens + cache_creation + cache_read
+    expect(usage.outputTokens).toBe(250);
+    expect(usage.cachedTokens).toBe(1850);
+    expect(usage.totalTokens).toBe(usage.inputTokens! + usage.outputTokens!);
+    expect(usage.costUsd).toBe(0.05);
+    expect(usage.requests).toBe(3);
+
+    // Each per-message entry's own composition sums correctly internally.
+    for (const entry of entries) {
+      expect(entry.totalTokens).toBe(entry.inputTokens + entry.outputTokens);
+    }
+
+    // The peak single-request entry is far smaller than the run-cumulative
+    // total — the whole point of the fix.
+    const peakEntryTotal = Math.max(...entries.map((e) => e.totalTokens));
+    expect(peakEntryTotal).toBeLessThan(usage.totalTokens!);
+  });
+
+  test('single-turn: behavior identical to today (one entry, matches run totals)', async () => {
+    const messages: SDKMessage[] = [
+      assistantMessage({ input_tokens: 200, output_tokens: 75, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 }),
+      resultMessage({
+        numTurns: 1,
+        totalCostUsd: 0.01,
+        usage: { input_tokens: 200, output_tokens: 75, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+      }),
+    ];
+
+    const { usage } = await consumeClaudeMessageStream(streamOf(messages), { localProvider: false });
+
+    expect(usage.requestUsageEntries).toHaveLength(1);
+    expect(usage.requestUsageEntries![0]).toEqual({
+      inputTokens: 200,
+      outputTokens: 75,
+      cachedTokens: 0,
+      totalTokens: 275,
+    });
+    expect(usage.inputTokens).toBe(200);
+    expect(usage.outputTokens).toBe(75);
+    expect(usage.totalTokens).toBe(275);
+    expect(usage.costUsd).toBe(0.01);
+  });
+
+  test('degrades to a single cumulative entry when no assistant message carries usage', async () => {
+    // Defensive path: a stream that produces a result with turns/tokens but
+    // whose assistant messages (for whatever SDK-shape reason) don't expose
+    // `message.usage`. Must not crash, and must still produce a usable
+    // (if cumulative) entry so budget analysis has something to peak over.
+    const messages: SDKMessage[] = [
+      { type: 'assistant', message: {}, parent_tool_use_id: null, uuid: 'u1', session_id: 's1' } as unknown as SDKMessage,
+      resultMessage({
+        numTurns: 1,
+        totalCostUsd: 0.02,
+        usage: { input_tokens: 300, output_tokens: 60, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+      }),
+    ];
+
+    const { usage } = await consumeClaudeMessageStream(streamOf(messages), { localProvider: false });
+
+    expect(usage.requestUsageEntries).toHaveLength(1);
+    expect(usage.requestUsageEntries![0]).toEqual({
+      inputTokens: 300,
+      outputTokens: 60,
+      cachedTokens: 0,
+      totalTokens: 360,
+    });
+  });
+
+  test('local provider: costUsd forced to 0 regardless of total_cost_usd', async () => {
+    const messages: SDKMessage[] = [
+      assistantMessage({ input_tokens: 50, output_tokens: 20 }),
+      resultMessage({
+        numTurns: 1,
+        totalCostUsd: 0.99,
+        usage: { input_tokens: 50, output_tokens: 20, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+      }),
+    ];
+
+    const { usage } = await consumeClaudeMessageStream(streamOf(messages), { localProvider: true });
+    expect(usage.costUsd).toBe(0);
+  });
+});
+
+describe('analyzeRuntimeTokenBudget on real per-request entries', () => {
+  const contextWindowProvider = { type: 'anthropic' as const, contextLength: 200_000 };
+
+  test('healthy multi-turn run: cumulative total alone would exceed 100%, true peak does not', async () => {
+    // 40 turns, each re-reading a ~15k-token cached prompt (cachedTokens
+    // folds into inputTokens) plus a small per-turn delta and output. This
+    // is the shape that previously triggered false-positive
+    // agent.token-budget-pressure warnings: the OLD single synthetic entry
+    // carried the run-cumulative total (40 * ~15.4k ≈ 616k tokens), which
+    // alone is > 100% of a 200k context window even though no single
+    // request ever approached the window.
+    const messages: SDKMessage[] = [];
+    let cumulativeInput = 0;
+    let cumulativeOutput = 0;
+    const perTurnCacheRead = 15_000;
+    const perTurnFreshInput = 400;
+    const perTurnOutput = 300;
+    const turns = 40;
+    for (let i = 0; i < turns; i++) {
+      messages.push(assistantMessage({
+        input_tokens: perTurnFreshInput,
+        output_tokens: perTurnOutput,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: perTurnCacheRead,
+      }));
+      cumulativeInput += perTurnFreshInput + perTurnCacheRead;
+      cumulativeOutput += perTurnOutput;
+    }
+    messages.push(resultMessage({
+      numTurns: turns,
+      totalCostUsd: 1.23,
+      usage: {
+        input_tokens: cumulativeInput,
+        output_tokens: cumulativeOutput,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    }));
+
+    const { usage } = await consumeClaudeMessageStream(streamOf(messages), { localProvider: false });
+
+    // Pin the exact cumulative total: this is what the OLD single-entry
+    // implementation would have used as the (bogus) "peak request" size.
+    expect(usage.totalTokens).toBe(cumulativeInput + cumulativeOutput);
+    expect(usage.totalTokens).toBeGreaterThan(200_000); // old behavior: >100% util
+
+    const oldStyleBudget = analyzeRuntimeTokenBudget(
+      { ...usage, requestUsageEntries: [] }, // simulate pre-fix: no per-request entries
+      contextWindowProvider,
+    );
+    expect(oldStyleBudget.utilizationPercent).toBeGreaterThan(100);
+    expect(oldStyleBudget.status).toBe('post_run_pressure');
+
+    const fixedBudget = analyzeRuntimeTokenBudget(usage, contextWindowProvider);
+    // True per-request peak: perTurnFreshInput + perTurnCacheRead + perTurnOutput.
+    const expectedPeak = perTurnFreshInput + perTurnCacheRead + perTurnOutput;
+    expect(fixedBudget.peakRequestTotalTokens).toBe(expectedPeak);
+    expect(fixedBudget.utilizationPercent).toBe(Math.round((expectedPeak / 200_000) * 100));
+    expect(fixedBudget.utilizationPercent).toBeLessThan(100);
+    expect(fixedBudget.status).toBe('ok');
+  });
+
+  test('peak-over-entries equals the max entry, not the sum, for a 3-message fixture', async () => {
+    const messages: SDKMessage[] = [
+      assistantMessage({ input_tokens: 1000, output_tokens: 200 }), // total 1200
+      assistantMessage({ input_tokens: 500, output_tokens: 100, cache_read_input_tokens: 4000 }), // total 4600
+      assistantMessage({ input_tokens: 300, output_tokens: 50, cache_read_input_tokens: 9000 }), // total 9350
+      resultMessage({
+        numTurns: 3,
+        totalCostUsd: 0.1,
+        usage: { input_tokens: 1800, output_tokens: 350, cache_creation_input_tokens: 0, cache_read_input_tokens: 13000 },
+      }),
+    ];
+
+    const { usage } = await consumeClaudeMessageStream(streamOf(messages), { localProvider: false });
+    const budget = analyzeRuntimeTokenBudget(usage, { type: 'anthropic', contextLength: 200_000 });
+
+    expect(budget.peakRequestTotalTokens).toBe(9350);
+    expect(budget.peakRequestTotalTokens).toBeLessThan(usage.totalTokens!);
+  });
+});

--- a/packages/myco/src/agent/harness/claude.ts
+++ b/packages/myco/src/agent/harness/claude.ts
@@ -89,7 +89,51 @@ function getIsolatedPluginCacheDir(): string {
  * the two had already drifted (e.g., `assistantMessages` rescue was added
  * to one and not the other).
  */
-async function consumeClaudeMessageStream(
+/** Raw usage shape shared by both the per-message `BetaUsage` and the run-level result usage. */
+interface RawAnthropicUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
+/**
+ * Fold a raw Anthropic usage snapshot into the composition the rest of
+ * Myco's cost/budget pipeline expects.
+ *
+ * The Anthropic SDK's `input_tokens` counts only tokens billed at the full
+ * uncached rate — cache writes and cache reads are reported separately and
+ * excluded from it. Fold both into `inputTokens` so it represents the true
+ * total prompt size (what cost/breakdown.ts's `uncachedInputTokens =
+ * inputTokens - cachedTokens` subtraction expects), and surface
+ * `cachedTokens` as just the cache-read count — the portion that did NOT
+ * pay the uncached rate. Cache-creation tokens stay folded into
+ * `inputTokens` only, since they bill at their own (higher, but still not
+ * "uncached") rate rather than the cached-read rate.
+ *
+ * Read defensively: the declared SDK type is non-null, but a future SDK
+ * revision or an error-subtype result could omit these fields.
+ */
+function foldUsageComposition(rawUsage: RawAnthropicUsage | undefined): {
+  inputTokens: number;
+  outputTokens: number;
+  cachedTokens: number;
+  totalTokens: number;
+} {
+  const cacheCreationTokens = rawUsage?.cache_creation_input_tokens ?? 0;
+  const cacheReadTokens = rawUsage?.cache_read_input_tokens ?? 0;
+  const inputTokens = (rawUsage?.input_tokens ?? 0) + cacheCreationTokens + cacheReadTokens;
+  const outputTokens = rawUsage?.output_tokens ?? 0;
+  return {
+    inputTokens,
+    outputTokens,
+    cachedTokens: cacheReadTokens,
+    totalTokens: inputTokens + outputTokens,
+  };
+}
+
+/** Exported for unit testing usage-entry composition against synthetic SDK message streams. */
+export async function consumeClaudeMessageStream(
   messageStream: AsyncIterable<SDKMessage>,
   options: { localProvider: boolean; sessionRef?: string },
 ): Promise<{ finalText: string; turnsUsed: number; usage: HarnessExecuteResult['usage']; structuredOutput?: unknown }> {
@@ -101,6 +145,14 @@ async function consumeClaudeMessageStream(
   let costUsd = 0;
   let assistantMessages = 0;
   let structuredOutput: unknown;
+  // Per-request usage entries, one per `assistant` message — each carries
+  // the SDK's own `BetaMessage.usage`, a genuine per-request snapshot (not
+  // a running total). Populated as messages arrive; only falls back to a
+  // single run-cumulative entry (see `buildUsage` below) if the stream
+  // produced turns/tokens but no assistant message exposed usage — a
+  // defensive path for SDK message shapes that don't carry per-message
+  // usage, so budget analysis still has something to peak over.
+  const requestUsageEntries: Array<{ inputTokens: number; outputTokens: number; cachedTokens: number; totalTokens: number }> = [];
 
   const buildUsage = () => ({
     requests: turnsUsed,
@@ -109,15 +161,29 @@ async function consumeClaudeMessageStream(
     cachedTokens,
     totalTokens: inputTokens + outputTokens,
     costUsd,
-    requestUsageEntries: turnsUsed > 0
-      ? [{ inputTokens, outputTokens, cachedTokens, totalTokens: inputTokens + outputTokens }]
-      : [],
+    requestUsageEntries: requestUsageEntries.length > 0
+      ? requestUsageEntries
+      : turnsUsed > 0
+        ? [{ inputTokens, outputTokens, cachedTokens, totalTokens: inputTokens + outputTokens }]
+        : [],
   });
 
   try {
     for await (const message of messageStream) {
       if (message.type === 'assistant') {
         assistantMessages += 1;
+        // `message.message` is the raw Anthropic `BetaMessage` for this
+        // turn — its `usage` is a per-request snapshot (input/output/cache
+        // tokens for THIS API call only), unlike the terminal `result`
+        // message's `usage`, which is the run-cumulative total. Compose it
+        // the same way the run totals are composed below so
+        // SUM(requestUsageEntries) tracks the run total and peak-over-
+        // entries reflects a real single-request peak instead of the
+        // cumulative sum every turn re-reads via prompt caching.
+        const rawMessageUsage = (message.message as { usage?: RawAnthropicUsage } | undefined)?.usage;
+        if (rawMessageUsage) {
+          requestUsageEntries.push(foldUsageComposition(rawMessageUsage));
+        }
         // Yield to libuv so the daemon's HTTP listener and lag probe
         // don't starve during high-message-count runs.
         await new Promise<void>((resolve) => setImmediate(resolve));
@@ -125,32 +191,16 @@ async function consumeClaudeMessageStream(
       }
       if (message.type === 'result') {
         // Capture usage on any subtype — error variants still burn tokens.
-        // finalText only exists on a successful result.
+        // finalText only exists on a successful result. This is the
+        // run-cumulative total across every turn — the source of truth for
+        // run totals/cost, left unchanged; per-request granularity comes
+        // from `requestUsageEntries` above instead.
         turnsUsed = message.num_turns ?? assistantMessages;
-        // The Anthropic SDK's `input_tokens` counts only tokens billed at
-        // the full uncached rate — cache writes and cache reads are
-        // reported separately and excluded from it. Fold both into
-        // `inputTokens` so it represents the true total prompt size (what
-        // cost/breakdown.ts's `uncachedInputTokens = inputTokens -
-        // cachedTokens` subtraction expects), and surface `cachedTokens` as
-        // just the cache-read count — the portion that did NOT pay the
-        // uncached rate. Cache-creation tokens stay folded into
-        // `inputTokens` only, since they bill at their own (higher, but
-        // still not "uncached") rate rather than the cached-read rate.
-        // Read defensively: the declared SDK type is non-null, but a
-        // future SDK revision or an error-subtype result could omit these
-        // fields.
-        const rawUsage = message.usage as {
-          input_tokens?: number;
-          output_tokens?: number;
-          cache_creation_input_tokens?: number;
-          cache_read_input_tokens?: number;
-        } | undefined;
-        const cacheCreationTokens = rawUsage?.cache_creation_input_tokens ?? 0;
-        const cacheReadTokens = rawUsage?.cache_read_input_tokens ?? 0;
-        inputTokens = (rawUsage?.input_tokens ?? 0) + cacheCreationTokens + cacheReadTokens;
-        outputTokens = rawUsage?.output_tokens ?? 0;
-        cachedTokens = cacheReadTokens;
+        const rawUsage = message.usage as RawAnthropicUsage | undefined;
+        const composed = foldUsageComposition(rawUsage);
+        inputTokens = composed.inputTokens;
+        outputTokens = composed.outputTokens;
+        cachedTokens = composed.cachedTokens;
         costUsd = options.localProvider ? 0 : (message.total_cost_usd ?? 0);
         if (message.subtype === 'success') {
           finalText = message.result;

--- a/tests/agent/runtime-claude.test.ts
+++ b/tests/agent/runtime-claude.test.ts
@@ -17,24 +17,41 @@ import { vi } from '../helpers/vi-shim.js';
 const queryCalls: Array<{ prompt: string; options: Record<string, unknown> }> = [];
 let structuredOutputOverride: unknown = undefined;
 let usageOverride: Record<string, number> | undefined = undefined;
+// Override for multi-turn fixtures: an array of raw per-message usage
+// snapshots (BetaUsage shape). When set, the mock emits one `assistant`
+// message per entry, each carrying `message.usage` — the real SDK's
+// per-request usage field — instead of the default single content-only
+// assistant message with no usage.
+let assistantUsageSequenceOverride: Array<Record<string, number>> | undefined = undefined;
 
 mock.module('@anthropic-ai/claude-agent-sdk', () => ({
   query: (args: { prompt: string; options: Record<string, unknown> }) => {
     queryCalls.push(args);
     return {
       [Symbol.asyncIterator]: async function* () {
-        yield {
-          type: 'assistant' as const,
-          message: { role: 'assistant', content: 'thinking' },
-          uuid: 'a-1',
-          session_id: 'test-session',
-        };
+        if (assistantUsageSequenceOverride) {
+          for (const [i, usage] of assistantUsageSequenceOverride.entries()) {
+            yield {
+              type: 'assistant' as const,
+              message: { role: 'assistant', content: 'thinking', usage },
+              uuid: `a-${i + 1}`,
+              session_id: 'test-session',
+            };
+          }
+        } else {
+          yield {
+            type: 'assistant' as const,
+            message: { role: 'assistant', content: 'thinking' },
+            uuid: 'a-1',
+            session_id: 'test-session',
+          };
+        }
         yield {
           type: 'result' as const,
           subtype: 'success' as const,
           total_cost_usd: 0.0123,
           usage: usageOverride ?? { input_tokens: 42, output_tokens: 7 },
-          num_turns: 1,
+          num_turns: assistantUsageSequenceOverride?.length ?? 1,
           duration_ms: 100,
           duration_api_ms: 80,
           is_error: false,
@@ -130,6 +147,7 @@ describe('ClaudeSdkHarness.execute', () => {
     fullServerCalls.length = 0;
     structuredOutputOverride = undefined;
     usageOverride = undefined;
+    assistantUsageSequenceOverride = undefined;
   });
 
   it('forwards sessionRef as sessionId to the SDK when provided', async () => {
@@ -601,6 +619,79 @@ describe('ClaudeSdkHarness.execute', () => {
     expect(breakdown.cachedInputTokens).toBe(0);
     expect(breakdown.uncachedInputTokens).toBe(42);
     expect(breakdown.uncachedInputTokens).toBeGreaterThanOrEqual(0);
+  });
+
+  it('emits one requestUsageEntries entry per assistant message on a multi-turn run, summing to the run totals', async () => {
+    // Each SDK assistant message carries its own BetaUsage snapshot — a
+    // genuine per-request peak, not the run-cumulative total the terminal
+    // `result` message reports. Three turns, each re-reading a cached
+    // prompt (mirrors real multi-turn agent conversations under prompt
+    // caching): entries.length must equal turn count, each entry's own
+    // composition must be correct, and the entries must sum to the run
+    // totals — run totals are untouched by this fix.
+    assistantUsageSequenceOverride = [
+      { input_tokens: 50, output_tokens: 20, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+      { input_tokens: 10, output_tokens: 30, cache_creation_input_tokens: 0, cache_read_input_tokens: 400 },
+      { input_tokens: 15, output_tokens: 45, cache_creation_input_tokens: 0, cache_read_input_tokens: 420 },
+    ];
+    usageOverride = {
+      input_tokens: 75,
+      output_tokens: 95,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 820,
+    };
+
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+    const result = await runtime.execute(makeInput());
+
+    expect(result.turnsUsed).toBe(3);
+    const entries = result.usage.requestUsageEntries as Array<{
+      inputTokens: number;
+      outputTokens: number;
+      cachedTokens: number;
+      totalTokens: number;
+    }>;
+    expect(entries).toHaveLength(3);
+    expect(entries[0]).toEqual({ inputTokens: 50, outputTokens: 20, cachedTokens: 0, totalTokens: 70 });
+    expect(entries[1]).toEqual({ inputTokens: 410, outputTokens: 30, cachedTokens: 400, totalTokens: 440 });
+    expect(entries[2]).toEqual({ inputTokens: 435, outputTokens: 45, cachedTokens: 420, totalTokens: 480 });
+
+    const sumInput = entries.reduce((sum, e) => sum + e.inputTokens, 0);
+    const sumOutput = entries.reduce((sum, e) => sum + e.outputTokens, 0);
+    expect(sumInput).toBe(result.usage.inputTokens);
+    expect(sumOutput).toBe(result.usage.outputTokens);
+
+    // Run totals unchanged: still sourced from the terminal result message.
+    expect(result.usage.inputTokens).toBe(75 + 0 + 820);
+    expect(result.usage.outputTokens).toBe(95);
+    expect(result.usage.cachedTokens).toBe(820);
+    expect(result.usage.costUsd).toBeCloseTo(0.0123);
+
+    // Peak-over-entries is far below the cumulative run total — the bug
+    // this fix closes.
+    const peak = Math.max(...entries.map((e) => e.totalTokens));
+    expect(peak).toBeLessThan(result.usage.totalTokens!);
+  });
+
+  it('single-turn multi-message-mock fixture stays a single entry equal to run totals (unchanged behavior)', async () => {
+    assistantUsageSequenceOverride = [
+      { input_tokens: 42, output_tokens: 7, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+    ];
+
+    const Runtime = await loadRuntime();
+    const runtime = new Runtime();
+    const result = await runtime.execute(makeInput());
+
+    expect(result.usage.requestUsageEntries).toHaveLength(1);
+    expect(result.usage.requestUsageEntries![0]).toEqual({
+      inputTokens: 42,
+      outputTokens: 7,
+      cachedTokens: 0,
+      totalTokens: 49,
+    });
+    expect(result.usage.inputTokens).toBe(42);
+    expect(result.usage.outputTokens).toBe(7);
   });
 
   it('attaches outputFormat to the SDK call when outputSchema is provided', async () => {


### PR DESCRIPTION
## Summary
- The Claude harness emitted a single cumulative `requestUsageEntries` entry per phase; budget-pressure analysis and the RunDetail Budget tile treat entries as per-request data points, so request count and per-request token distribution were conflated (pre-existing, surfaced during the SDK-alignment live smokes).
- `consumeClaudeMessageStream` now emits one entry per SDK assistant message using that message's own `usage`; run totals still come from the terminal result message only, so aggregates are unchanged.
- `aggregateUsage` concatenates entries across phases (undefined-safe) instead of dropping them.

## Verification
- 10 new unit tests across `claude.test.ts` / `executor-state.test.ts` (per-entry values, multi-message streams, peak-over-entries max-not-sum), plus 2 new cases in the canonical cache-rider suite `tests/agent/runtime-claude.test.ts`; 38 pre-existing cache-rider tests unmodified and green.
- Cache-accounting invariant (`cachedTokens ⊆ inputTokens`) holds per entry and in aggregate via the shared fold.
- Full `npm test`, `tsc --noEmit`, `make build` all clean.
- Independent code review: spec pass on all items, no Critical/Important findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)